### PR TITLE
"Historic" formats Arena Standard fix

### DIFF
--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2017-09-07.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2017-09-07.txt
@@ -1,6 +1,6 @@
 [format]
 Name:Arena Standard (2017-09-07)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2017-09-07
 Sets:XLN

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2018-01-18.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2018-01-18.txt
@@ -1,6 +1,6 @@
 [format]
 Name:Arena Standard (RIX)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2018-01-18
 Sets:XLN, RIX

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2018-03-22.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2018-03-22.txt
@@ -1,6 +1,6 @@
 [format]
 Name:Arena Standard (AKH/HOU)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2018-03-22
 Sets:XLN, RIX, AKH, HOU

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2018-04-26.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2018-04-26.txt
@@ -1,6 +1,6 @@
 [format]
 Name:Arena Standard (DOM)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2018-04-26
 Sets:XLN, RIX, AKH, HOU, DOM

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2018-06-07.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2018-06-07.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (KLD/AER)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2018-06-07
 Sets:XLN, RIX, AKH, HOU, DOM, KLD, AER, W17
 Banned:Aetherworks Marvel; Attune with Aether; Felidar Guardian; Rampaging Ferocidon; Ramunap Ruins; Rogue Refiner; Smuggler's Copter

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2018-07-12.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2018-07-12.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (M19)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2018-07-12
 Sets:XLN, RIX, AKH, HOU, DOM, KLD, AER, W17, M19, ANA, PANA
 Banned:Aetherworks Marvel; Attune with Aether; Felidar Guardian; Rampaging Ferocidon; Ramunap Ruins; Rogue Refiner; Smuggler's Copter

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2018-09-27.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2018-09-27.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (GRN)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2018-09-27
 Sets:XLN, RIX, DOM, M19, ANA, PANA, GRN
 Banned:Rampaging Ferocidon

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2018-11-15.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2018-11-15.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (G18)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2018-11-15
 Sets:XLN, RIX, DOM, M19, ANA, PANA, GRN, G18
 Banned:Rampaging Ferocidon

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2019-01-17.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2019-01-17.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (RNA)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2019-01-17
 Sets:XLN, RIX, DOM, M19, ANA, PANA, GRN, G18, RNA
 Banned:Rampaging Ferocidon

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2019-02-14.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2019-02-14.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (2019-02-14)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2019-02-14
 Sets:XLN, RIX, DOM, M19, ANA, PANA, GRN, G18, RNA
 Banned:Nexus of Fate; Rampaging Ferocidon

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2019-04-25.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2019-04-25.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (WAR)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2019-04-25
 Sets:XLN, RIX, DOM, M19, ANA, PANA, GRN, G18, RNA, WAR
 Banned:Nexus of Fate; Rampaging Ferocidon

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2019-07-02.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2019-07-02.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (M20)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2019-07-02
 Sets:XLN, RIX, DOM, M19, ANA, PANA, GRN, G18, RNA, WAR, M20
 Banned:Nexus of Fate; Rampaging Ferocidon

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2019-09-26.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2019-09-26.txt
@@ -1,6 +1,6 @@
 [format]
 Name:Arena Standard (ELD)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2019-09-26
 Sets:ANA, PANA, GRN, RNA, WAR, M20, ELD

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2019-10-24.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2019-10-24.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (2019-10-24)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2019-10-24
 Sets:ANA, PANA, GRN, RNA, WAR, M20, ELD
 Banned:Field of the Dead

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2019-11-18.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2019-11-18.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (2019-11-18)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2019-11-18
 Sets:ANA, PANA, GRN, RNA, WAR, M20, ELD
 Banned:Field of the Dead; Oko, Thief of Crowns; Once Upon a Time; Veil of Summer

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2020-01-16.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2020-01-16.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (THB)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2020-01-16
 Sets:ANA, PANA, GRN, RNA, WAR, M20, ELD, THB
 Banned:Field of the Dead; Oko, Thief of Crowns; Once Upon a Time; Veil of Summer

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2020-04-16.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2020-04-16.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (IKO)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2020-04-16
 Sets:ANA, PANA, GRN, RNA, WAR, M20, ELD, THB, IKO
 Banned:Field of the Dead; Oko, Thief of Crowns; Once Upon a Time; Veil of Summer

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2020-06-04.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2020-06-04.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (2020-06-04)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2020-06-04
 Sets:ANA, PANA, GRN, RNA, WAR, M20, ELD, THB, IKO
 Banned:Agent of Treachery; Field of the Dead; Fires of Invention; Oko, Thief of Crowns; Once Upon a Time; Veil of Summer

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2020-07-25.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2020-07-25.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (M21)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2020-07-25
 Sets:ANA, PANA, GRN, RNA, WAR, M20, ELD, THB, IKO, M21
 Banned:Agent of Treachery; Field of the Dead; Fires of Invention; Oko, Thief of Crowns; Once Upon a Time; Veil of Summer

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2020-08-03.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2020-08-03.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (2020-08-03)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2020-08-03
 Sets:ANA, PANA, GRN, RNA, WAR, M20, ELD, THB, IKO, M21
 Banned:Agent of Treachery; Cauldron Familiar; Field of the Dead; Fires of Invention; Growth Spiral; Oko, Thief of Crowns; Once Upon a Time; Teferi, Time Raveler; Veil of Summer; Wilderness Reclamation

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2020-08-12.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2020-08-12.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (ANB)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2020-08-12
 Sets:ANA, PANA, GRN, RNA, WAR, M20, ELD, THB, IKO, M21, ANB
 Banned:Agent of Treachery; Cauldron Familiar; Field of the Dead; Fires of Invention; Growth Spiral; Oko, Thief of Crowns; Once Upon a Time; Teferi, Time Raveler; Veil of Summer; Wilderness Reclamation

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2020-09-17.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2020-09-17.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (ZNR)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2020-09-17
 Sets:ANA, PANA, ELD, THB, IKO, M21, ANB, ZNR
 Banned:Cauldron Familiar; Fires of Invention; Oko, Thief of Crowns; Once Upon a Time

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2020-09-28.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2020-09-28.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (2020-09-28)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2020-09-28
 Sets:ANA, PANA, ELD, THB, IKO, M21, ANB, ZNR
 Banned:Cauldron Familiar; Fires of Invention; Oko, Thief of Crowns; Once Upon a Time; Uro, Titan of Nature's Wrath

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2020-10-12.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2020-10-12.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (2020-10-12)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2020-10-12
 Sets:ANA, PANA, ELD, THB, IKO, M21, ANB, ZNR
 Banned:Cauldron Familiar; Escape to the Wilds; Fires of Invention; Lucky Clover; Oko, Thief of Crowns; Omnath, Locus of Creation; Once Upon a Time; Uro, Titan of Nature's Wrath

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2021-01-28.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2021-01-28.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (KHM)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2021-01-28
 Sets:ANA, PANA, ELD, THB, IKO, M21, ANB, ZNR, KHM
 Banned:Cauldron Familiar; Escape to the Wilds; Fires of Invention; Lucky Clover; Oko, Thief of Crowns; Omnath, Locus of Creation; Once Upon a Time; Uro, Titan of Nature's Wrath

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2021-04-15.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2021-04-15.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (STX)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2021-04-15
 Sets:ANA, PANA, ELD, THB, IKO, M21, ANB, ZNR, KHM, STX
 Banned:Cauldron Familiar; Escape to the Wilds; Fires of Invention; Lucky Clover; Oko, Thief of Crowns; Omnath, Locus of Creation; Once Upon a Time; Uro, Titan of Nature's Wrath

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2021-07-08.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2021-07-08.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (AFR)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2021-07-08
 Sets:ANA, PANA, ELD, THB, IKO, M21, ANB, ZNR, KHM, STX, AFR
 Banned:Cauldron Familiar; Escape to the Wilds; Fires of Invention; Lucky Clover; Oko, Thief of Crowns; Omnath, Locus of Creation; Once Upon a Time; Uro, Titan of Nature's Wrath

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2021-09-16.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2021-09-16.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (MID)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2021-09-16
 Sets:ANA, PANA, ANB, ZNR, KHM, STX, AFR, MID
 Banned:Omnath, Locus of Creation

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2021-11-17.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2021-11-17.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (VOW)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2021-11-17
 Sets:ANA, PANA, ANB, ZNR, KHM, STX, AFR, MID, VOW
 Banned:Omnath, Locus of Creation

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2022-01-27.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2022-01-27.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (2022-01-27)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2022-01-27
 Sets:ANA, PANA, ANB, ZNR, KHM, STX, AFR, MID, VOW
 Banned:Alrund's Epiphany; Divide by Zero; Faceless Haven; Omnath, Locus of Creation

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2022-02-10.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2022-02-10.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (NEO)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2022-02-10
 Sets:ANA, PANA, ANB, ZNR, KHM, STX, AFR, MID, VOW, NEO
 Banned:Alrund's Epiphany; Divide by Zero; Faceless Haven; Omnath, Locus of Creation

--- a/forge-gui/res/formats/Historic/DCI/Arena Standard/2022-03-17.txt
+++ b/forge-gui/res/formats/Historic/DCI/Arena Standard/2022-03-17.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (2022-03-17)
 Type:Historic
-Subtype:Standard
+Subtype:Arena
 Effective:2022-03-17
 Sets:ZNR, KHM, STX, AFR, MID, VOW, NEO
 Banned:Alrund's Epiphany; Divide by Zero; Faceless Haven; Omnath, Locus of Creation


### PR DESCRIPTION
For Arena Standard format files I have changed "Subtype:Standard" to "Subtype:Arena" as this was overriding what was shown in the deck list and therefore prioritising Arena Standard over Standard.

Before:
![java_ZZQUXz5Pjh](https://user-images.githubusercontent.com/18243520/162795589-44f31cf3-f892-4b7f-aba3-499e44c0bc06.png)

After:
![java_GQbsFPL5F9](https://user-images.githubusercontent.com/18243520/162795673-88b2b18f-b3f9-4961-aef3-300211a8744c.png)

