### PR TITLE
avoid "Card card" in ChangeZone StackDesc

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
@@ -134,7 +134,7 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
             List<Card> tgts = getDefinedCardsOrTargeted(sa, "Defined");
             type = Lang.joinHomogenous(tgts);
             defined = true;
-        } else if (sa.hasParam("ChangeType")) {
+        } else if (sa.hasParam("ChangeType") && !sa.getParam("ChangeType").equals("Card")) {
             final String ct = sa.getParam("ChangeType");
             type = CardType.CoreType.isValidEnum(ct) ? ct.toLowerCase() : ct;
         }


### PR DESCRIPTION
`ChangeType$ Card` would slip by and result in "Card card" output