### PR TITLE
SNC: Maestros Ascendancy and support

### DIFF
--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -3358,8 +3358,8 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
         }
         return result;
     }
-    public final void setMayPlay(final Player player, final boolean withoutManaCost, final Cost altManaCost, final boolean withFlash, final boolean grantZonePermissions, final StaticAbility sta) {
-        this.mayPlay.put(sta, new CardPlayOption(player, sta, withoutManaCost, altManaCost, withFlash, grantZonePermissions));
+    public final void setMayPlay(final Player player, final boolean withoutManaCost, final Cost altManaCost, final boolean altIsAdditional, final boolean withFlash, final boolean grantZonePermissions, final StaticAbility sta) {
+        this.mayPlay.put(sta, new CardPlayOption(player, sta, withoutManaCost, altManaCost, altIsAdditional, withFlash, grantZonePermissions));
         this.updateMayPlay();
     }
     public final void removeMayPlay(final StaticAbility sta) {

--- a/forge-game/src/main/java/forge/game/card/CardPlayOption.java
+++ b/forge-game/src/main/java/forge/game/card/CardPlayOption.java
@@ -20,11 +20,12 @@ public final class CardPlayOption {
     private final boolean withFlash;
     private final boolean grantsZonePermissions;
     private final Cost altManaCost;
+    private final boolean altIsAdditional;
 
-    public CardPlayOption(final Player player, final StaticAbility sta, final boolean withoutManaCost, final Cost altManaCost, final boolean withFlash, final boolean grantZonePermissions) {
-        this(player, sta, withoutManaCost ? PayManaCost.NO : PayManaCost.YES, altManaCost, withFlash, grantZonePermissions);
+    public CardPlayOption(final Player player, final StaticAbility sta, final boolean withoutManaCost, final Cost altManaCost, final boolean altIsAdditional, final boolean withFlash, final boolean grantZonePermissions) {
+        this(player, sta, withoutManaCost ? PayManaCost.NO : PayManaCost.YES, altManaCost, altIsAdditional, withFlash, grantZonePermissions);
     }
-    private CardPlayOption(final Player player, final StaticAbility sta, final PayManaCost payManaCost, final Cost altManaCost, final boolean withFlash,
+    private CardPlayOption(final Player player, final StaticAbility sta, final PayManaCost payManaCost, final Cost altManaCost, final boolean altIsAdditional, final boolean withFlash,
                            final boolean grantZonePermissions) {
         this.player = player;
         this.sta = sta;
@@ -32,6 +33,7 @@ public final class CardPlayOption {
         this.withFlash = withFlash;
         this.grantsZonePermissions = grantZonePermissions;
         this.altManaCost = altManaCost;
+        this.altIsAdditional = altIsAdditional;
     }
 
 
@@ -86,9 +88,14 @@ public final class CardPlayOption {
         switch (getPayManaCost()) {
             case YES:
                 if (altManaCost != null) {
-                    String insteadCost = getFormattedAltManaCost();
-                    insteadCost = insteadCost.replace("Pay ","");
-                    sb.append(" (by paying ").append(insteadCost).append(" instead of paying its mana cost");
+                    if (altIsAdditional) {
+                        String desc = sta.getParam("Description");
+                        sb.append(" (").append(desc, desc.indexOf("by "), desc.indexOf("."));
+                    } else {
+                        String insteadCost = getFormattedAltManaCost();
+                        insteadCost = insteadCost.replace("Pay ","");
+                        sb.append(" (by paying ").append(insteadCost).append(" instead of paying its mana cost");
+                    }
                     if (isWithFlash()) {
                         sb.append(" and as though it has flash");
                     }

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
@@ -937,25 +937,32 @@ public final class StaticAbilityContinuous {
 
             if (controllerMayPlay && (mayPlayLimit == null || stAb.getMayPlayTurn() < mayPlayLimit)) {
                 String mayPlayAltCost = mayPlayAltManaCost;
+                boolean additional = mayPlayAltCost.contains("RegularCost");
 
-                if (mayPlayAltCost != null && mayPlayAltCost.contains("ConvertedManaCost")) {
-                    final String costcmc = Integer.toString(affectedCard.getCMC());
-                    mayPlayAltCost = mayPlayAltCost.replace("ConvertedManaCost", costcmc);
+                if (mayPlayAltCost != null) {
+                    if (mayPlayAltCost.contains("ConvertedManaCost")) {
+                        final String costcmc = Integer.toString(affectedCard.getCMC());
+                        mayPlayAltCost = mayPlayAltCost.replace("ConvertedManaCost", costcmc);
+                    } else if (additional) {
+                        final String regCost = affectedCard.getManaCost().getShortString();
+                        mayPlayAltCost = mayPlayAltManaCost.replace("RegularCost", regCost);
+
+                    }
                 }
 
                 Player mayPlayController = params.containsKey("MayPlayPlayer") ?
                     AbilityUtils.getDefinedPlayers(affectedCard, params.get("MayPlayPlayer"), stAb).get(0) :
                     controller;
                 affectedCard.setMayPlay(mayPlayController, mayPlayWithoutManaCost,
-                        mayPlayAltCost != null ? new Cost(mayPlayAltCost, false) : null,
-                        mayPlayWithFlash, mayPlayGrantZonePermissions, stAb);
+                        mayPlayAltCost != null ? new Cost(mayPlayAltCost, false) : null, additional, mayPlayWithFlash,
+                        mayPlayGrantZonePermissions, stAb);
 
                 // If the MayPlay effect only affected itself, check if it is in graveyard and give other player who cast Shaman's Trance MayPlay
                 if (stAb.hasParam("Affected") && stAb.getParam("Affected").equals("Card.Self") && affectedCard.isInZone(ZoneType.Graveyard)) {
                     for (final Player p : game.getPlayers()) {
                         if (p.hasKeyword("Shaman's Trance") && mayPlayController != p) {
                             affectedCard.setMayPlay(p, mayPlayWithoutManaCost,
-                                    mayPlayAltCost != null ? new Cost(mayPlayAltCost, false) : null,
+                                    mayPlayAltCost != null ? new Cost(mayPlayAltCost, false) : null, additional,
                                     mayPlayWithFlash, mayPlayGrantZonePermissions, stAb);
                         }
                     }

--- a/forge-gui/res/cardsfolder/upcoming/maestros_ascendancy.txt
+++ b/forge-gui/res/cardsfolder/upcoming/maestros_ascendancy.txt
@@ -1,7 +1,7 @@
 Name:Maestros Ascendancy
 ManaCost:U B R
 Types:Enchantment
-S:Mode$ Continuous | Affected$ Instant.YouCtrl,Sorcery.YouCtrl | Condition$ PlayerTurn | MayPlay$ True | MayPlayAdditionalCost$ Sac<1/Creature> | MayPlayLimit$ 1 | EffectZone$ Battlefield | AffectedZone$ Graveyard | Description$ Once during each of your turns, you may cast an instant or sorcery spell from your graveyard by sacrificing a creature in addition to paying its other costs. If a spell cast this way would be put into your graveyard, exile it instead.
+S:Mode$ Continuous | Affected$ Instant.YouCtrl,Sorcery.YouCtrl | Condition$ PlayerTurn | MayPlay$ True | MayPlayAltManaCost$ RegularCost Sac<1/Creature> | MayPlayLimit$ 1 | EffectZone$ Battlefield | AffectedZone$ Graveyard | Description$ Once during each of your turns, you may cast an instant or sorcery spell from your graveyard by sacrificing a creature in addition to paying its other costs. If a spell cast this way would be put into your graveyard, exile it instead.
 R:Event$ Moved | ValidLKI$ Card.CastSa Spell.MayPlaySource | Origin$ Stack | Destination$ Graveyard | ReplaceWith$ MoveExile
 SVar:MoveExile:DB$ ChangeZone | Defined$ ReplacedCard | Origin$ Stack | Destination$ Exile
 Oracle:Once during each of your turns, you may cast an instant or sorcery spell from your graveyard by sacrificing a creature in addition to paying its other costs. If a spell cast this way would be put into your graveyard, exile it instead.

--- a/forge-gui/res/cardsfolder/upcoming/maestros_ascendancy.txt
+++ b/forge-gui/res/cardsfolder/upcoming/maestros_ascendancy.txt
@@ -1,0 +1,7 @@
+Name:Maestros Ascendancy
+ManaCost:U B R
+Types:Enchantment
+S:Mode$ Continuous | Affected$ Instant.YouCtrl,Sorcery.YouCtrl | Condition$ PlayerTurn | MayPlay$ True | MayPlayAdditionalCost$ Sac<1/Creature> | MayPlayLimit$ 1 | EffectZone$ Battlefield | AffectedZone$ Graveyard | Description$ Once during each of your turns, you may cast an instant or sorcery spell from your graveyard by sacrificing a creature in addition to paying its other costs. If a spell cast this way would be put into your graveyard, exile it instead.
+R:Event$ Moved | ValidLKI$ Card.CastSa Spell.MayPlaySource | Origin$ Stack | Destination$ Graveyard | ReplaceWith$ MoveExile
+SVar:MoveExile:DB$ ChangeZone | Defined$ ReplacedCard | Origin$ Stack | Destination$ Exile
+Oracle:Once during each of your turns, you may cast an instant or sorcery spell from your graveyard by sacrificing a creature in addition to paying its other costs. If a spell cast this way would be put into your graveyard, exile it instead.


### PR DESCRIPTION
Works with cards that already have additional costs - regular mana cost, additional cost, and the may play's creature sac cost are all required