### PR TITLE
Card: store Keywords created by Static Abilities

### DIFF
--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -139,8 +139,11 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
 
     private final Table<Long, Long, CardChangedName> changedCardNames = TreeBasedTable.create(); // Layer 3
     private final Table<Long, Long, KeywordsChange> changedCardKeywordsByText = TreeBasedTable.create(); // Layer 3 by Text Change
-    protected KeywordsChange changedCardKeywordsByWord = new KeywordsChange(ImmutableList.<String>of(), null, false); // Layer 3 by Word Change
+    protected KeywordsChange changedCardKeywordsByWord = new KeywordsChange(ImmutableList.<KeywordInterface>of(), ImmutableList.<KeywordInterface>of(), false); // Layer 3 by Word Change
     private final Table<Long, Long, KeywordsChange> changedCardKeywords = TreeBasedTable.create(); // Layer 6
+
+    // stores the keywords created by static abilities
+    private final Table<Long, String, KeywordInterface> storedKeywords = TreeBasedTable.create();
 
     // x=timestamp y=StaticAbility id
     private final Table<Long, Long, CardTraitChanges> changedCardTraitsByText = TreeBasedTable.create(); // Layer 3 by Text Change
@@ -179,7 +182,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
 
     private List<Pair<Card, Integer>> receivedDamageFromThisTurn = Lists.newArrayList();
     private Map<Player, Integer> receivedDamageFromPlayerThisTurn = Maps.newHashMap();
-    
+
     private final Map<Card, Integer> assignedDamageMap = Maps.newTreeMap();
 
     private boolean isCommander = false;
@@ -3680,7 +3683,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
     public Iterable<KeywordsChange> getChangedCardKeywordsList() {
         return Iterables.concat(
             changedCardKeywordsByText.values(), // Layer 3
-            ImmutableList.of(new KeywordsChange(ImmutableList.<String>of(), null, this.hasRemoveIntrinsic())), // Layer 4
+            ImmutableList.of(new KeywordsChange(ImmutableList.<KeywordInterface>of(), ImmutableList.<KeywordInterface>of(), this.hasRemoveIntrinsic())), // Layer 4
             changedCardKeywords.values() // Layer 6
         );
     }
@@ -4367,8 +4370,14 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
     }
     public final void addChangedCardKeywords(final List<String> keywords, final List<String> removeKeywords,
             final boolean removeAllKeywords, final long timestamp, final long staticId, final boolean updateView) {
-        final KeywordsChange newCks = new KeywordsChange(keywords, removeKeywords, removeAllKeywords);
-        newCks.addKeywordsToCard(this);
+        List<KeywordInterface> kws = Lists.newArrayList();
+        if (keywords != null) {
+            for(String kw : keywords) {
+                kws.add(getKeywordForStaticAbility(kw, staticId));
+            }
+        }
+
+        final KeywordsChange newCks = new KeywordsChange(kws, removeKeywords, removeAllKeywords);
         changedCardKeywords.put(timestamp, staticId, newCks);
 
         if (updateView) {
@@ -4378,10 +4387,24 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
         }
     }
 
+    public final KeywordInterface getKeywordForStaticAbility(String kw, final long staticId) {
+        KeywordInterface result;
+        if (staticId < 1 || !storedKeywords.contains(staticId, kw)) {
+            result = Keyword.getInstance(kw);
+            result.createTraits(this, false);
+            if (staticId > 0) {
+                storedKeywords.put(staticId, kw, result);
+            }
+        } else {
+            result = storedKeywords.get(staticId, kw);
+        }
+        return result;
+    }
+
     public final void addChangedCardKeywordsByText(final List<KeywordInterface> keywords, final long timestamp, final long staticId, final boolean updateView) {
         // keywords should already created for Card, so no addKeywordsToCard
         // this one is done for Volrath's Shapeshifter which replaces all the card text
-        changedCardKeywordsByText.put(timestamp, staticId, new KeywordsChange(keywords, null, true));
+        changedCardKeywordsByText.put(timestamp, staticId, new KeywordsChange(keywords, ImmutableList.<KeywordInterface>of(), true));
 
         if (updateView) {
             updateKeywords();
@@ -4394,7 +4417,6 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
         final long timestamp, final long staticId, final boolean updateView) {
 
         final KeywordsChange newCks = new KeywordsChange(keywords, removeKeywords, removeAllKeywords);
-        newCks.addKeywordsToCard(this);
         changedCardKeywords.put(timestamp, staticId, newCks);
 
         if (updateView) {

--- a/forge-game/src/main/java/forge/game/keyword/KeywordsChange.java
+++ b/forge-game/src/main/java/forge/game/keyword/KeywordsChange.java
@@ -23,7 +23,6 @@ import java.util.List;
 import com.google.common.collect.Lists;
 
 import forge.game.card.Card;
-import forge.game.player.Player;
 import forge.game.replacement.ReplacementEffect;
 import forge.game.spellability.SpellAbility;
 import forge.game.staticability.StaticAbility;
@@ -51,11 +50,11 @@ public class KeywordsChange implements Cloneable {
      * @param removeAll whether to remove all keywords.
      */
     public KeywordsChange(
-            final Iterable<String> keywordList,
+            final Iterable<KeywordInterface> keywordList,
             final Collection<String> removeKeywordList,
             final boolean removeAll) {
         if (keywordList != null) {
-            this.keywords.addAll(keywordList);
+            this.keywords.insertAll(keywordList);
         }
 
         if (removeKeywordList != null) {
@@ -64,7 +63,6 @@ public class KeywordsChange implements Cloneable {
 
         this.removeAllKeywords = removeAll;
     }
-
     public KeywordsChange(
             final Collection<KeywordInterface> keywordList,
             final Collection<KeywordInterface> removeKeywordInterfaces,
@@ -120,18 +118,6 @@ public class KeywordsChange implements Cloneable {
         return !this.removeAllKeywords
                 && this.keywords.isEmpty()
                 && this.removeKeywords.isEmpty();
-    }
-
-    public final void addKeywordsToCard(final Card host) {
-        for (KeywordInterface inst : keywords.getValues()) {
-            inst.createTraits(host, false, true);
-        }
-    }
-
-    public final void addKeywordsToPlayer(final Player player) {
-        for (KeywordInterface inst : keywords.getValues()) {
-            inst.createTraits(player, true);
-        }
     }
 
     public void setHostCard(final Card host) {

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
@@ -56,11 +56,9 @@ import forge.game.keyword.Keyword;
 import forge.game.keyword.KeywordInterface;
 import forge.game.player.Player;
 import forge.game.replacement.ReplacementEffect;
-import forge.game.replacement.ReplacementHandler;
 import forge.game.spellability.AbilityStatic;
 import forge.game.spellability.SpellAbility;
 import forge.game.trigger.Trigger;
-import forge.game.trigger.TriggerHandler;
 import forge.game.zone.ZoneType;
 import forge.util.TextUtil;
 
@@ -804,10 +802,7 @@ public final class StaticAbilityContinuous {
                             abilty = TextUtil.fastReplace(abilty, "ConvertedManaCost", costcmc);
                         }
                         if (abilty.startsWith("AB") || abilty.startsWith("ST")) { // grant the ability
-                            final SpellAbility sa = AbilityFactory.getAbility(abilty, affectedCard, stAb);
-                            sa.setIntrinsic(false);
-                            sa.setGrantorStatic(stAb);
-                            addedAbilities.add(sa);
+                            addedAbilities.add(affectedCard.getSpellAbilityForStaticAbility(abilty, stAb));
                         }
                     }
                 }
@@ -853,15 +848,14 @@ public final class StaticAbilityContinuous {
                 // add Replacement effects
                 if (addReplacements != null) {
                     for (String rep : addReplacements) {
-                        final ReplacementEffect actualRep = ReplacementHandler.parseReplacement(rep, affectedCard, false, stAb);
-                        addedReplacementEffects.add(actualRep);
+                        addedReplacementEffects.add(affectedCard.getReplacementEffectForStaticAbility(rep, stAb));
                     }
                 }
 
                 // add triggers
                 if (addTriggers != null) {
                     for (final String trigger : addTriggers) {
-                        final Trigger actualTrigger = TriggerHandler.parseTrigger(trigger, affectedCard, false, stAb);
+                        final Trigger actualTrigger = affectedCard.getTriggerForStaticAbility(trigger, stAb);
                         // if the trigger has Execute param, which most trigger gained by Static Abilties should have
                         // turn them into SpellAbility object before adding to card
                         // with that the TargetedCard does not need the Svars added to them anymore
@@ -886,7 +880,7 @@ public final class StaticAbilityContinuous {
                             s = TextUtil.fastReplace(s, "ConvertedManaCost", costcmc);
                         }
 
-                        addedStaticAbility.add(StaticAbility.create(s, affectedCard, stAb.getCardState(), false));
+                        addedStaticAbility.add(affectedCard.getStaticAbilityForStaticAbility(s, stAb));
                     }
                 }
 

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
@@ -724,8 +724,6 @@ public final class StaticAbilityContinuous {
             }
 
             // add keywords
-            // TODO regular keywords currently don't try to use keyword multiplier
-            // (Although nothing uses it at this time)
             if (addKeywords != null || removeKeywords != null || removeAllAbilities) {
                 List<String> newKeywords = null;
                 if (addKeywords != null) {


### PR DESCRIPTION
This stops Static Abilities from creating the same Keyword again for the same Card (until Card moves zones)

for this MR or later ones, the same can be done for other CardTraits created by StaticAbilities (which would reduce the amount of CardTraits being created)