### PR TITLE
Detect Screen DPI and scale images accordingly

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/GuiDesktop.java
+++ b/forge-gui-desktop/src/main/java/forge/GuiDesktop.java
@@ -2,8 +2,11 @@ package forge;
 
 import java.awt.Desktop;
 import java.awt.Graphics2D;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsEnvironment;
 import java.awt.Toolkit;
 import java.awt.datatransfer.StringSelection;
+import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
@@ -333,5 +336,19 @@ public class GuiDesktop implements IGuiBase {
     @Override
     public void preventSystemSleep(boolean preventSleep) {
         OperatingSystem.preventSystemSleep(preventSleep);
+    }
+
+    private static float initializeScreenScale() {
+        GraphicsConfiguration gc = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDefaultConfiguration();
+        AffineTransform at = gc.getDefaultTransform();
+        double scaleX = at.getScaleX();
+        double scaleY = at.getScaleY();
+        return (float) Math.min(scaleX, scaleY);
+    }
+    static float screenScale = initializeScreenScale();
+
+    @Override
+    public float getScreenScale() {
+        return screenScale;
     }
 }

--- a/forge-gui-desktop/src/main/java/forge/ImageCache.java
+++ b/forge-gui-desktop/src/main/java/forge/ImageCache.java
@@ -45,6 +45,7 @@ import forge.game.card.Card;
 import forge.game.card.CardView;
 import forge.game.player.PlayerView;
 import forge.gui.FThreads;
+import forge.gui.GuiBase;
 import forge.item.IPaperCard;
 import forge.item.InventoryItem;
 import forge.item.PaperCard;
@@ -259,7 +260,8 @@ public class ImageCache {
         // as otherwise it's problematic to update if the real image gets fetched.
         if (original == null || useArtCrop) {
             if ((ipc != null || cardView != null) && !originalKey.equals(ImageKeys.getTokenKey(ImageKeys.HIDDEN_CARD))) {
-                int width = 488, height = 680;
+                float screenScale = GuiBase.getInterface().getScreenScale();
+                int width = Math.round(488 * screenScale), height = Math.round(680 * screenScale);
                 BufferedImage art = original;
                 CardView card = ipc != null ? Card.getCardForUi(ipc).getView() : cardView;
                 String legalString = null;

--- a/forge-gui-desktop/src/main/java/forge/itemmanager/filters/StatTypeFilter.java
+++ b/forge-gui-desktop/src/main/java/forge/itemmanager/filters/StatTypeFilter.java
@@ -8,6 +8,7 @@ import javax.swing.JPanel;
 
 import com.google.common.base.Predicates;
 
+import forge.gui.GuiBase;
 import forge.gui.UiCommand;
 import forge.item.InventoryItem;
 import forge.item.ItemPredicate;
@@ -43,7 +44,8 @@ public abstract class StatTypeFilter<T extends InventoryItem> extends ToggleButt
         }
         tooltip.append(")");
 
-        final FLabel button = addToggleButton(widget, FSkin.getImage(st.skinProp, 18, 18), tooltip.toString());
+        int imageSize = Math.round(18 * GuiBase.getInterface().getScreenScale());
+        final FLabel button = addToggleButton(widget, FSkin.getImage(st.skinProp, imageSize, imageSize), tooltip.toString());
         buttonMap.put(st, button);
 
         //hook so right-clicking a button toggles itself on and toggles off all other buttons

--- a/forge-gui-desktop/src/main/java/forge/itemmanager/views/ImageView.java
+++ b/forge-gui-desktop/src/main/java/forge/itemmanager/views/ImageView.java
@@ -7,6 +7,7 @@ import forge.deck.io.DeckPreferences;
 import forge.game.card.Card;
 import forge.game.card.CardView;
 import forge.gamemodes.limited.CardRanker;
+import forge.gui.GuiBase;
 import forge.gui.framework.ILocalRepaint;
 import forge.item.IPaperCard;
 import forge.item.InventoryItem;
@@ -1164,10 +1165,17 @@ public class ImageView<T extends InventoryItem> extends ItemView<T> {
             g.setColor(Color.black);
             g.fillRoundRect(bounds.x, bounds.y, bounds.width, bounds.height, cornerSize, cornerSize);
 
-            BufferedImage img = ImageCache.getImage(item, bounds.width - 2 * borderSize, bounds.height - 2 * borderSize, itemInfo.alt);
+            final float screenScale = GuiBase.getInterface().getScreenScale();
+            final int drawX = bounds.x + borderSize;
+            final int drawY = bounds.y + borderSize;
+            final int drawWidth = bounds.width - 2 * borderSize;
+            final int drawHeight = bounds.height - 2 * borderSize;
+            final int imageWidth = Math.round(drawWidth * screenScale);
+            final int imageHeight = Math.round(drawHeight * screenScale);
+            BufferedImage img = ImageCache.getImage(item, imageWidth, imageHeight, itemInfo.alt);
 
             if (img != null) {
-                g.drawImage(img, null, bounds.x + borderSize, bounds.y + borderSize);
+                g.drawImage(img, drawX, drawY, drawX + drawWidth, drawY + drawHeight, 0, 0, imageWidth, imageHeight, null);
             }
             else {
                 if (deckSelectMode) {

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/AddBasicLandsDialog.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/AddBasicLandsDialog.java
@@ -43,6 +43,7 @@ import forge.deck.CardPool;
 import forge.deck.Deck;
 import forge.deck.DeckProxy;
 import forge.deck.DeckgenUtil;
+import forge.gui.GuiBase;
 import forge.gui.UiCommand;
 import forge.item.PaperCard;
 import forge.localinstance.skin.FSkinProp;
@@ -436,12 +437,15 @@ public class AddBasicLandsDialog {
 
                 final Graphics2D g2d = (Graphics2D) g;
 
-                int width = getWidth();
-                int height = getHeight();
+                final float screenScale = GuiBase.getInterface().getScreenScale();
+                final int drawWidth = getWidth();
+                final int drawHeight = getHeight();
+                final int imageWidth = Math.round(drawWidth * screenScale);
+                final int imageHeight = Math.round(drawHeight * screenScale);
 
-                final BufferedImage img = ImageCache.getImage(card, width, height);
+                final BufferedImage img = ImageCache.getImage(card, imageWidth, imageHeight);
                 if (img != null) {
-                    g2d.drawImage(img, null, (width - img.getWidth()) / 2, (height - img.getHeight()) / 2);
+                    g2d.drawImage(img, 0, 0, drawWidth, drawHeight, 0, 0, imageWidth, imageHeight, null);
                 }
             }
         }

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/ACEditorBase.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/ACEditorBase.java
@@ -37,6 +37,7 @@ import forge.deck.DeckBase;
 import forge.deck.DeckFormat;
 import forge.deck.DeckSection;
 import forge.game.GameType;
+import forge.gui.GuiBase;
 import forge.gui.GuiChoose;
 import forge.gui.GuiUtils;
 import forge.gui.UiCommand;
@@ -126,7 +127,9 @@ public abstract class ACEditorBase<TItem extends InventoryItem, TModel extends D
             .fontSize(14)
             .text(localizer.getMessage("lblAddBasicLands"))
             .tooltip(localizer.getMessage("ttAddBasicLands"))
-            .icon(FSkin.getImage(FSkinProp.IMG_LAND, 18, 18))
+            .icon(FSkin.getImage(FSkinProp.IMG_LAND,
+                Math.round(18 * GuiBase.getInterface().getScreenScale()),
+                Math.round(18 * GuiBase.getInterface().getScreenScale())))
             .iconScaleAuto(false).hoverable().build();
 
     protected ACEditorBase(final FScreen screen0, final CDetailPicture cDetailPicture0, final GameType gameType0) {

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/views/VStatistics.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/views/VStatistics.java
@@ -8,6 +8,7 @@ import forge.gui.framework.DragCell;
 import forge.gui.framework.DragTab;
 import forge.gui.framework.EDocID;
 import forge.gui.framework.IVDoc;
+import forge.gui.GuiBase;
 import forge.itemmanager.SItemManagerUtil.StatTypes;
 import forge.screens.deckeditor.controllers.CStatistics;
 import forge.toolbox.FLabel;
@@ -309,6 +310,7 @@ public enum VStatistics implements IVDoc<CStatistics> {
     }
 
     private static FLabel buildLabel(final StatTypes statType, final boolean zebra) {
-        return buildLabel(FSkin.getImage(statType.skinProp, 18, 18), zebra);
+        int imageSize = Math.round(18 * GuiBase.getInterface().getScreenScale());
+        return buildLabel(FSkin.getImage(statType.skinProp, imageSize, imageSize), zebra);
     }
 }

--- a/forge-gui-desktop/src/main/java/forge/toolbox/CardFaceSymbols.java
+++ b/forge-gui-desktop/src/main/java/forge/toolbox/CardFaceSymbols.java
@@ -10,6 +10,7 @@ import com.esotericsoftware.minlog.Log;
 import forge.card.ColorSet;
 import forge.card.mana.ManaCost;
 import forge.card.mana.ManaCostShard;
+import forge.gui.GuiBase;
 import forge.localinstance.skin.FSkinProp;
 import forge.toolbox.FSkin.SkinImage;
 
@@ -295,13 +296,23 @@ public class CardFaceSymbols {
         FSkin.drawImage(g, MANA_IMAGES.get(imageName), x, y);
     }
     public static void drawManaSymbol(final String imageName, final Graphics g, final int x, final int y) {
-        FSkin.drawImage(g, MANA_IMAGES.get(imageName).resize(manaImageSize, manaImageSize), x, y);
+        drawSymbol(imageName, g, x, y, manaImageSize);
     }
     public static void drawSymbol(final String imageName, final Graphics g, final int x, final int y, final int size) {
-        FSkin.drawImage(g, MANA_IMAGES.get(imageName).resize(size, size), x, y);
+        // Obtain screen DPI scale
+        float screenScale = GuiBase.getInterface().getScreenScale();
+        int imageSize = Math.round(size * screenScale);
+
+        FSkin.drawImage(g, MANA_IMAGES.get(imageName).resize(imageSize, imageSize),
+            x, y, x + size, y + size, 0, 0, imageSize, imageSize);
     }
     public static void drawWatermark(final String imageName, final Graphics g, final int x, final int y, final int size) {
-        FSkin.drawImage(g, WATERMARKS.get(imageName).resize(size, size), x, y);
+        // Obtain screen DPI scale
+        float screenScale = GuiBase.getInterface().getScreenScale();
+        int imageSize = Math.round(size * screenScale);
+
+        FSkin.drawImage(g, WATERMARKS.get(imageName).resize(imageSize, imageSize),
+            x, y, x + size, y + size, 0, 0, imageSize, imageSize);
     }
     public static void drawAbilitySymbol(final String imageName, final Graphics g, final int x, final int y, final int w, final int h) {
         FSkin.drawImage(g, MANA_IMAGES.get(imageName), x, y, w, h);

--- a/forge-gui-desktop/src/main/java/forge/toolbox/FSkin.java
+++ b/forge-gui-desktop/src/main/java/forge/toolbox/FSkin.java
@@ -39,6 +39,7 @@ import java.awt.Window;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.image.BaseMultiResolutionImage;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
@@ -103,6 +104,7 @@ import javax.swing.text.JTextComponent;
 
 import forge.Singletons;
 import forge.gui.FThreads;
+import forge.gui.GuiBase;
 import forge.gui.GuiUtils;
 import forge.gui.framework.ILocalRepaint;
 import forge.localinstance.properties.ForgeConstants;
@@ -688,7 +690,14 @@ public class FSkin {
 
         protected ImageIcon getIcon() {
             if (this.imageIcon == null) {
-                this.imageIcon = new ImageIcon(this.image);
+                float screenScale = GuiBase.getInterface().getScreenScale();
+                int iconWidth = Math.round(image.getWidth(null) / screenScale);
+                int iconHeight = Math.round(image.getHeight(null) / screenScale);
+                Image [] iconImages = new Image[2];
+                iconImages[0] = image.getScaledInstance(iconWidth, iconHeight, Image.SCALE_SMOOTH);
+                iconImages[1] = image;
+                BaseMultiResolutionImage multiImage = new BaseMultiResolutionImage(iconImages);
+                this.imageIcon = new ImageIcon(multiImage);
             }
             return this.imageIcon;
         }

--- a/forge-gui-desktop/src/main/java/forge/toolbox/imaging/FCardImageRenderer.java
+++ b/forge-gui-desktop/src/main/java/forge/toolbox/imaging/FCardImageRenderer.java
@@ -26,6 +26,7 @@ import forge.card.CardRarity;
 import forge.card.mana.ManaCost;
 import forge.game.card.CardView;
 import forge.game.card.CardView.CardStateView;
+import forge.gui.GuiBase;
 import forge.gui.card.CardDetailUtil;
 import forge.gui.card.CardDetailUtil.DetailColors;
 import forge.localinstance.properties.ForgePreferences.FPref;
@@ -82,12 +83,15 @@ public class FCardImageRenderer {
         PT_FONT = NAME_FONT;
         ARTIST_FONT = new Font(Font.SERIF, Font.BOLD, 20);
 
+        float screenScale = GuiBase.getInterface().getScreenScale();
+        int arrayMultiplier = Math.round(2 * screenScale);
+
         cachedFonts = new HashMap<>();
-        cachedFonts.put(NAME_FONT, new Font[NAME_FONT.getSize() * 2]);
-        cachedFonts.put(TYPE_FONT, new Font[TYPE_FONT.getSize() * 2]);
-        cachedFonts.put(TEXT_FONT, new Font[TEXT_FONT.getSize() * 2]);
-        cachedFonts.put(REMINDER_FONT, new Font[REMINDER_FONT.getSize() * 2]);
-        cachedFonts.put(ARTIST_FONT, new Font[ARTIST_FONT.getSize() * 2]);
+        cachedFonts.put(NAME_FONT, new Font[NAME_FONT.getSize() * arrayMultiplier]);
+        cachedFonts.put(TYPE_FONT, new Font[TYPE_FONT.getSize() * arrayMultiplier]);
+        cachedFonts.put(TEXT_FONT, new Font[TEXT_FONT.getSize() * arrayMultiplier]);
+        cachedFonts.put(REMINDER_FONT, new Font[REMINDER_FONT.getSize() * arrayMultiplier]);
+        cachedFonts.put(ARTIST_FONT, new Font[ARTIST_FONT.getSize() * arrayMultiplier]);
 
         isInitialed = true;
     }
@@ -620,10 +624,12 @@ public class FCardImageRenderer {
             float halfWidth = w / 2;
             GradientPaint gradient1 = new GradientPaint(x, y, colors[0], x + halfWidth, y, colors[1]);
             g.setPaint(gradient1);
-            g.fillRoundRect(Math.round(x), Math.round(y), Math.round(halfWidth + arcWidth), Math.round(h), Math.round(arcWidth), Math.round(arcHeight));
+            g.fillRoundRect(Math.round(x), Math.round(y), Math.round(halfWidth), Math.round(h), Math.round(arcWidth), Math.round(arcHeight));
+            g.fillRect(Math.round(x + halfWidth - arcWidth), Math.round(y), Math.round(arcWidth), Math.round(h));
             GradientPaint gradient2 = new GradientPaint(x + halfWidth, y, colors[1], x + w, y, colors[2]);
             g.setPaint(gradient2);
-            g.fillRoundRect(Math.round(x + halfWidth - arcWidth), Math.round(y), Math.round(halfWidth + arcWidth), Math.round(h), Math.round(arcWidth), Math.round(arcHeight));
+            g.fillRoundRect(Math.round(x + halfWidth), Math.round(y), Math.round(halfWidth), Math.round(h), Math.round(arcWidth), Math.round(arcHeight));
+            g.fillRect(Math.round(x + halfWidth), Math.round(y), Math.round(arcWidth), Math.round(h));
             break;
         }
         g.setPaint(oldPaint);

--- a/forge-gui-desktop/src/main/java/forge/toolbox/imaging/FImagePanel.java
+++ b/forge-gui-desktop/src/main/java/forge/toolbox/imaging/FImagePanel.java
@@ -33,6 +33,8 @@ import javax.swing.Timer;
 import com.mortennobel.imagescaling.DimensionConstrain;
 import com.mortennobel.imagescaling.ResampleOp;
 
+import forge.gui.GuiBase;
+
 /**
  * Displays a {@code BufferedImage} at its center.
  * <p>
@@ -295,8 +297,11 @@ public class FImagePanel extends JPanel {
         at.rotate(Math.toRadians(degreesOfRotation));
 
         // 2. scale image.
+        float screenScale = GuiBase.getInterface().getScreenScale();
         if (createScaleTransform) {
-            at.scale(this.imageScale, this.imageScale);
+            at.scale(this.imageScale / screenScale, this.imageScale / screenScale);
+        } else {
+            at.scale(1 / screenScale, 1 / screenScale);
         }
 
         // 1. move the image so that its center is at (0,0).
@@ -334,6 +339,8 @@ public class FImagePanel extends JPanel {
         if (this.sourceImage != null) {
             if (this.autoSizeMode != AutoSizeImageMode.OFF) {
                 Double newScale = FImageUtil.getBestFitScale(getSourceImageSize(), this.getSize());
+                // apply DPI based scale
+                newScale *= GuiBase.getInterface().getScreenScale();
                 if (newScale != this.imageScale) {
                     isResampleEnabled = true;
                     this.imageScale = newScale;

--- a/forge-gui-desktop/src/main/java/forge/view/arcane/CardPanel.java
+++ b/forge-gui-desktop/src/main/java/forge/view/arcane/CardPanel.java
@@ -56,6 +56,7 @@ import forge.game.keyword.Keyword;
 import forge.game.zone.ZoneType;
 import forge.gui.CardContainer;
 import forge.gui.FThreads;
+import forge.gui.GuiBase;
 import forge.item.PaperCard;
 import forge.localinstance.properties.ForgeConstants;
 import forge.localinstance.properties.ForgeConstants.CounterDisplayType;
@@ -215,7 +216,11 @@ public class CardPanel extends SkinnedPanel implements CardContainer, IDisposabl
             return;
         }
 
-        cachedImage = new CachedCardImage(card, matchUI.getLocalPlayers(), imagePanel.getWidth(), imagePanel.getHeight()) {
+        // Obtain screen DPI scale and apply them
+        final float screenScale = GuiBase.getInterface().getScreenScale();
+        int imageWidth = Math.round(imagePanel.getWidth() * screenScale);
+        int imageHeight = Math.round(imagePanel.getHeight() * screenScale);
+        cachedImage = new CachedCardImage(card, matchUI.getLocalPlayers(), imageWidth, imageHeight) {
             @Override
             public void onImageFetched() {
                 if (cachedImage != null) {

--- a/forge-gui-desktop/src/main/java/forge/view/arcane/ScaledImagePanel.java
+++ b/forge-gui-desktop/src/main/java/forge/view/arcane/ScaledImagePanel.java
@@ -23,6 +23,8 @@ import java.awt.image.BufferedImage;
 
 import javax.swing.JPanel;
 
+import forge.gui.GuiBase;
+
 /**
  * <p>
  * ScaledImagePanel class.
@@ -107,24 +109,25 @@ public class ScaledImagePanel extends JPanel {
         //ResampleOp resizer = new ResampleOp(DimensionConstrain.createMaxDimension(this.getWidth(), this.getHeight(), !scaleLarger));
         //resizer.setUnsharpenMask(UnsharpenMask.Soft);
         BufferedImage img = getSrcImage(); //resizer.filter(getSrcImage(), null);
+        float screenScale = GuiBase.getInterface().getScreenScale();
 
-        boolean needsScale = img.getWidth() < sz.width;
-        float scaleFactor = ((float)img.getWidth()) / sz.width;
-        if (needsScale && ( scaleFactor < 0.95 || scaleFactor > 1.05 )) { // This should very low-quality scaling to draw during animation            
-            float maxZoomX = ((float)sz.width) / img.getWidth();
-            float maxZoomY = ((float)sz.height) / img.getHeight();
+        boolean needsScale = Math.round(img.getWidth() / screenScale) < sz.width;
+        float scaleFactor = ((float)img.getWidth() / screenScale) / sz.width;
+        if (needsScale && ( scaleFactor < 0.95 || scaleFactor > 1.05 )) { // This should very low-quality scaling to draw during animation
+            float maxZoomX = ((float)sz.width) / (img.getWidth() / screenScale);
+            float maxZoomY = ((float)sz.height) / (img.getHeight() / screenScale);
             float zoom = Math.min(maxZoomX, maxZoomY);
 
-            int zoomedWidth = (int) (img.getWidth() * zoom);
-            int zoomedHeight = (int) (img.getHeight() * zoom);
+            int zoomedWidth = (int) (img.getWidth() / screenScale * zoom);
+            int zoomedHeight = (int) (img.getHeight() / screenScale * zoom);
             int x = (sz.width - zoomedWidth) / 2;
             int y = (sz.height - zoomedHeight) / 2;
 
-            g.drawImage(img, x, y, zoomedWidth, zoomedHeight, null);
-        } else { 
-            int x = (sz.width / 2) - (img.getWidth() / 2);
-            int y = (sz.height / 2) - (img.getHeight() / 2);
-            g.drawImage(img, x, y, null);
+            g.drawImage(img, x, y, x + zoomedWidth, y + zoomedHeight, 0, 0, img.getWidth(), img.getHeight(), null);
+        } else {
+            int x = Math.round((sz.width / 2) - (img.getWidth() / screenScale / 2));
+            int y = Math.round((sz.height / 2) - (img.getHeight() / screenScale / 2));
+            g.drawImage(img, x, y, x + sz.width, y + sz.height, 0, 0, img.getWidth(), img.getHeight(), null);
         }
     }
 

--- a/forge-gui-mobile/src/forge/GuiMobile.java
+++ b/forge-gui-mobile/src/forge/GuiMobile.java
@@ -322,4 +322,9 @@ public class GuiMobile implements IGuiBase {
     public void preventSystemSleep(boolean preventSleep) {
         Forge.getDeviceAdapter().preventSystemSleep(preventSleep);
     }
+
+    @Override
+    public float getScreenScale() {
+        return 1f;
+    }
 }

--- a/forge-gui/src/main/java/forge/gui/interfaces/IGuiBase.java
+++ b/forge-gui/src/main/java/forge/gui/interfaces/IGuiBase.java
@@ -61,4 +61,5 @@ public interface IGuiBase {
     void runBackgroundTask(String message, Runnable task);
     String encodeSymbols(String str, boolean formatReminderText);
     void preventSystemSleep(boolean preventSleep);
+    float getScreenScale();
 }


### PR DESCRIPTION
The change in Fskin.java is using BaseMultiResolutionImage, which needs Java version >= 9.

Currently this handles all card images rendering and some of icons like those used in the deck editor.
But some icons or icons are still not scaled:
- Icons in the main tab.
- Player/Opponent avatar images in the duel screen
- Card ability icons above card images in the duel screen
- Card details panel <- This is using HTMLText to render texts and symbols, which I am not sure how to fix.

But I think this fix is big enough for now and can be merged first, and I will try to fix the above cases later.

Also I only tested in my environment, so I think other should test this fix and see if it works correctly in other environments too.
