### PR TITLE
Update ALA and GDY editions

### DIFF
--- a/forge-gui/res/editions/Game Day Promos.txt
+++ b/forge-gui/res/editions/Game Day Promos.txt
@@ -6,4 +6,6 @@ Type=Promo
 ScryfallCode=GDY
 
 [cards]
+1 R Power Word Kill @Andreas Zafiratos
+2 R Skyclave Apparition @Mila Pesic
 3 M All-Seeing Arbiter @Nicholas Gregory

--- a/forge-gui/res/editions/Shards of Alara.txt
+++ b/forge-gui/res/editions/Shards of Alara.txt
@@ -6,261 +6,264 @@ Code2=ALA
 MciCode=ala
 Type=Expansion
 BoosterCovers=5
-Booster=10 Common, 3 Uncommon, 1 RareMythic, 1 BasicLand
+Booster=10 Common:fromsheet("ALA cards"), 3 Uncommon:fromSheet("ALA cards"), 1 RareMythic:fromSheet("ALA cards"), 1 BasicLand:fromSheet("ALA cards")
 FatPack=8
 FatPackExtraSlots=40 BasicLands
 ScryfallCode=ALA
 
 [cards]
-63 R Ad Nauseam @Jeremy Jarvis
-153 C Agony Warp @Dave Allsop
-154 M Ajani Vengeant @Wayne Reynolds
 1 C Akrasan Squire @Todd Lockwood
-123 U Algae Gharial @Michael Ryan
 2 U Angel's Herald @Greg Staples
 3 U Angelic Benediction @Michael Komarck
 4 C Angelsong @Sal Villagran
-220 U Arcane Sanctum @Anthony Francisco
+5 U Bant Battlemage @Donato Giancola
+6 R Battlegrace Angel @Matt Stewart
+7 R Cradle of Vitality @Trevor Hairsine
+8 C Dispeller's Capsule @Franz Vohwinkel
+9 M Elspeth, Knight-Errant @Volkan Baǵa
+10 R Ethersworn Canonist @Izzy
+11 C Excommunicate @Matt Stewart
+12 C Guardians of Akrasa @Alan Pollack
+13 C Gustrider Exuberant @Wayne Reynolds
+14 R Invincible Hymn @Matt Stewart
+15 C Knight of the Skyward Eye @Matt Stewart
+16 R Knight of the White Orchid @Mark Zug
+17 R Knight-Captain of Eos @Chris Rahn
+18 C Marble Chalice @Howard Lyon
+19 U Metallurgeon @Warren Mahy
+20 C Oblivion Ring @Franz Vohwinkel
+21 R Ranger of Eos @Volkan Baǵa
+22 C Resounding Silence @Mark Zug
+23 U Rockcaster Platoon @David Palumbo
+24 C Sanctum Gargoyle @Shelly Wan
+25 R Scourglass @Matt Cavotta
+26 C Sighted-Caste Sorcerer @Chris Rahn
+27 U Sigiled Paladin @Greg Staples
+28 C Soul's Grace @Christopher Moeller
+29 U Sunseed Nurturer @Steve Argyle
+30 C Welkin Guide @David Palumbo
+31 C Yoked Plowbeast @Steve Argyle
+32 C Call to Heel @Randy Gallegos
+33 C Cancel @David Palumbo
+34 C Cathartic Adept @Carl Critchlow
+35 C Cloudheath Drake @Izzy
+36 C Coma Veil @Dan Scott
+37 C Courier's Capsule @Andrew Murray
+38 R Covenant of Minds @Dan Seagrave
+39 U Dawnray Archer @Dan Dos Santos
+40 U Esper Battlemage @Matt Cavotta
+41 U Etherium Astrolabe @Michael Bruinsma
+42 C Etherium Sculptor @Steven Belledin
+43 U Fatestitcher @E. M. Gist
+44 U Filigree Sages @Dan Scott
+45 R Gather Specimens @Michael Bruinsma
+46 C Jhessian Lookout @Donato Giancola
+47 C Kathari Screecher @Pete Venters
+48 R Kederekt Leviathan @Mark Hyzer
+49 R Master of Etherium @Matt Cavotta
+50 R Memory Erosion @Howard Lyon
+51 R Mindlock Orb @rk post
+52 C Outrider of Jhess @Alan Pollack
+53 U Protomatter Powder @Francis Tsai
+54 C Resounding Wave @Izzy
+55 R Sharding Sphinx @Michael Bruinsma
+56 R Skill Borrower @Shelly Wan
+57 C Spell Snip @Michael Sutfin
+58 U Sphinx's Herald @Dan Scott
+59 C Steelclad Serpent @Carl Critchlow
+60 M Tezzeret the Seeker @Anthony Francisco
+61 C Tortoise Formation @Mark Zug
+62 C Vectis Silencers @Steven Belledin
+63 R Ad Nauseam @Jeremy Jarvis
 64 R Archdemon of Unx @Dave Allsop
 65 C Banewasp Affliction @Dave Allsop
-5 U Bant Battlemage @Donato Giancola
-155 U Bant Charm @Randy Gallegos
-221 C Bant Panorama @Donato Giancola
-6 R Battlegrace Angel @Matt Stewart
-124 U Behemoth's Herald @Paolo Parente
-156 C Blightning @Thomas M. Baxa
 66 C Blister Beetle @Anthony S. Waters
-157 U Blood Cultist @Karl Kopinski
+67 C Bone Splinters @Cole Eastburn
+68 U Corpse Connoisseur @Mark Hyzer
+69 R Cunning Lethemancer @Paul Bonner
+70 R Death Baron @Nils Hamm
+71 C Deathgreeter @Dominick Domingo
+72 U Demon's Herald @Karl Kopinski
+73 C Dreg Reaver @Thomas M. Baxa
+74 C Dregscape Zombie @Lars Grant-West
+75 C Executioner's Capsule @Warren Mahy
+76 U Fleshbag Marauder @Pete Venters
+77 C Glaze Fiend @Joshua Hagler
+78 U Grixis Battlemage @Nils Hamm
+79 R Immortal Coil @Dan Scott
+80 U Infest @Karl Kopinski
+81 C Onyx Goblet @rk post
+82 U Puppet Conjurer @Steven Belledin
+83 C Resounding Scream @Thomas M. Baxa
+84 R Salvage Titan @Anthony Francisco
+85 U Scavenger Drake @Trevor Claxton
+86 C Shadowfeed @Dave Kendall
+87 C Shore Snapper @Dave Kendall
+88 C Skeletal Kathari @Carl Critchlow
+89 R Tar Fiend @Anthony S. Waters
+90 C Undead Leotau @Carl Critchlow
+91 R Vein Drinker @Lars Grant-West
+92 C Viscera Dragger @Ralph Horsley
 93 C Bloodpyre Elemental @Trevor Claxton
 94 C Bloodthorn Taunter @Jesper Ejsing
-67 C Bone Splinters @Cole Eastburn
+95 R Caldera Hellion @Raymond Swanland
+96 R Crucible of Fire @Dominick Domingo
+97 C Dragon Fodder @Jaime Jones
+98 U Dragon's Herald @Daarken
+99 U Exuberant Firestoker @Zoltan Boros & Gabor Szikszai
+100 R Flameblast Dragon @Jaime Jones
+101 R Goblin Assault @Jaime Jones
+102 C Goblin Mountaineer @Michael Ryan
+103 R Hell's Thunder @Karl Kopinski
+104 C Hissing Iguanar @Brandon Kitkouski
+105 C Incurable Ogre @Carl Critchlow
+106 U Jund Battlemage @Vance Kovacs
+107 C Lightning Talons @Pete Venters
+108 C Magma Spray @Jarreau Wimberly
+109 R Predator Dragon @Raymond Swanland
+110 C Resounding Thunder @Jon Foster
+111 C Ridge Rannet @Jim Murray
+112 U Rockslide Elemental @Joshua Hagler
+113 U Scourge Devil @Dave Kendall
+114 U Skeletonize @Karl Kopinski
+115 C Soul's Fire @Wayne Reynolds
+116 C Thorn-Thrash Viashino @Jon Foster
+117 U Thunder-Thrash Elder @Brandon Kitkouski
+118 C Viashino Skeleton @Cole Eastburn
+119 R Vicious Shadows @Joshua Hagler
+120 C Vithian Stinger @Dave Kendall
+121 C Volcanic Submersion @Trevor Claxton
+122 R Where Ancients Tread @Zoltan Boros & Gabor Szikszai
+123 U Algae Gharial @Michael Ryan
+124 U Behemoth's Herald @Paolo Parente
+125 C Cavern Thoctar @Jean-Sébastien Rossbach
+126 C Court Archers @Randy Gallegos
+127 C Cylian Elf @Steve Prescott
+128 C Druid of the Anima @Jim Murray
+129 U Drumhunter @Jim Murray
+130 C Elvish Visionary @D. Alexander Gregory
+131 R Feral Hydra @Steve Prescott
+132 C Gift of the Gargantuan @Jean-Sébastien Rossbach
+133 C Godtoucher @Jesper Ejsing
+134 C Jungle Weaver @Trevor Hairsine
+135 R Keeper of Progenitus @Kev Walker
+136 C Lush Growth @Jesper Ejsing
+137 U Mighty Emergence @Steve Prescott
+138 R Manaplasm @Daarken
+139 C Mosstodon @Paolo Parente
+140 R Mycoloth @Raymond Swanland
+141 C Naturalize @Trevor Hairsine
+142 U Naya Battlemage @Steve Argyle
+143 R Ooze Garden @Anthony S. Waters
+144 C Resounding Roar @Steve Prescott
+145 U Rhox Charger @Chris Rahn
+146 R Sacellum Godspeaker @Wayne Reynolds
+147 C Savage Hunger @Trevor Claxton
+148 R Skullmulcher @Michael Ryan
+149 C Soul's Might @Kev Walker
+150 R Spearbreaker Behemoth @Christopher Moeller
+151 U Topan Ascetic @Sal Villagran
+152 C Wild Nacatl @Wayne Reynolds
+153 C Agony Warp @Dave Allsop
+154 M Ajani Vengeant @Wayne Reynolds
+155 U Bant Charm @Randy Gallegos
+156 C Blightning @Thomas M. Baxa
+157 U Blood Cultist @Karl Kopinski
 158 C Branching Bolt @Vance Kovacs
 159 R Brilliant Ultimatum @Anthony Francisco
 160 R Broodmate Dragon @Vance Kovacs
 161 U Bull Cerodon @Jesper Ejsing
-95 R Caldera Hellion @Raymond Swanland
-32 C Call to Heel @Randy Gallegos
-33 C Cancel @David Palumbo
 162 C Carrion Thrash @Jaime Jones
-34 C Cathartic Adept @Carl Critchlow
-125 C Cavern Thoctar @Jean-Sébastien Rossbach
 163 R Clarion Ultimatum @Michael Komarck
-35 C Cloudheath Drake @Izzy
-36 C Coma Veil @Dan Scott
-68 U Corpse Connoisseur @Mark Hyzer
-37 C Courier's Capsule @Andrew Murray
-126 C Court Archers @Randy Gallegos
-38 R Covenant of Minds @Dan Seagrave
-7 R Cradle of Vitality @Trevor Hairsine
-96 R Crucible of Fire @Dominick Domingo
 164 R Cruel Ultimatum @Ralph Horsley
-222 U Crumbling Necropolis @Dave Kendall
-69 R Cunning Lethemancer @Paul Bonner
-127 C Cylian Elf @Steve Prescott
-39 U Dawnray Archer @Dan Dos Santos
-70 R Death Baron @Nils Hamm
-71 C Deathgreeter @Dominick Domingo
 165 C Deft Duelist @David Palumbo
-72 U Demon's Herald @Karl Kopinski
-8 C Dispeller's Capsule @Franz Vohwinkel
-97 C Dragon Fodder @Jaime Jones
-98 U Dragon's Herald @Daarken
-73 C Dreg Reaver @Thomas M. Baxa
-74 C Dregscape Zombie @Lars Grant-West
-128 C Druid of the Anima @Jim Murray
-129 U Drumhunter @Jim Murray
-9 M Elspeth, Knight-Errant @Volkan Baǵa
-130 C Elvish Visionary @D. Alexander Gregory
 166 M Empyrial Archangel @Greg Staples
-40 U Esper Battlemage @Matt Cavotta
 167 U Esper Charm @Michael Bruinsma
-223 C Esper Panorama @Franz Vohwinkel
-41 U Etherium Astrolabe @Michael Bruinsma
-42 C Etherium Sculptor @Steven Belledin
-10 R Ethersworn Canonist @Izzy
-11 C Excommunicate @Matt Stewart
-75 C Executioner's Capsule @Warren Mahy
-99 U Exuberant Firestoker @Zoltan Boros & Gabor Szikszai
-43 U Fatestitcher @E. M. Gist
-131 R Feral Hydra @Steve Prescott
-44 U Filigree Sages @Dan Scott
 168 U Fire-Field Ogre @Mitch Cotie
-100 R Flameblast Dragon @Jaime Jones
-76 U Fleshbag Marauder @Pete Venters
-246 L Forest @Aleksi Briclot
-247 L Forest @Zoltan Boros & Gabor Szikszai
-248 L Forest @Zoltan Boros & Gabor Szikszai
-249 L Forest @Michael Komarck
-45 R Gather Specimens @Michael Bruinsma
-132 C Gift of the Gargantuan @Jean-Sébastien Rossbach
-77 C Glaze Fiend @Joshua Hagler
-101 R Goblin Assault @Jaime Jones
 169 C Goblin Deathraiders @Raymond Swanland
-102 C Goblin Mountaineer @Michael Ryan
 170 M Godsire @Jim Murray
-133 C Godtoucher @Jesper Ejsing
-78 U Grixis Battlemage @Nils Hamm
 171 U Grixis Charm @Lars Grant-West
-224 C Grixis Panorama @Nils Hamm
-12 C Guardians of Akrasa @Alan Pollack
-13 C Gustrider Exuberant @Wayne Reynolds
-103 R Hell's Thunder @Karl Kopinski
 172 M Hellkite Overlord @Justin Sweet
 173 C Hindering Light @Chris Rahn
-104 C Hissing Iguanar @Brandon Kitkouski
-79 R Immortal Coil @Dan Scott
-105 C Incurable Ogre @Carl Critchlow
-80 U Infest @Karl Kopinski
-14 R Invincible Hymn @Matt Stewart
-234 L Island @Michael Komarck
-235 L Island @Chippy
-236 L Island @Chippy
-237 L Island @Mark Tedin
 174 U Jhessian Infiltrator @Donato Giancola
-46 C Jhessian Lookout @Donato Giancola
-106 U Jund Battlemage @Vance Kovacs
 175 U Jund Charm @Brandon Kitkouski
-225 C Jund Panorama @Jaime Jones
-226 U Jungle Shrine @Wayne Reynolds
-134 C Jungle Weaver @Trevor Hairsine
-47 C Kathari Screecher @Pete Venters
 176 C Kederekt Creeper @Mark Hyzer
-48 R Kederekt Leviathan @Mark Hyzer
-135 R Keeper of Progenitus @Kev Walker
 177 U Kiss of the Amesha @Todd Lockwood
-15 C Knight of the Skyward Eye @Matt Stewart
-16 R Knight of the White Orchid @Mark Zug
-17 R Knight-Captain of Eos @Chris Rahn
 178 M Kresh the Bloodbraided @Raymond Swanland
-210 M Lich's Mirror @Ash Wood
-107 C Lightning Talons @Pete Venters
-136 C Lush Growth @Jesper Ejsing
-108 C Magma Spray @Jarreau Wimberly
-138 R Manaplasm @Daarken
-18 C Marble Chalice @Howard Lyon
-49 R Master of Etherium @Matt Cavotta
 179 M Mayael the Anima @Jason Chan
-50 R Memory Erosion @Howard Lyon
-19 U Metallurgeon @Warren Mahy
-137 U Mighty Emergence @Steve Prescott
-51 R Mindlock Orb @rk post
-211 R Minion Reflector @Mark Tedin
-139 C Mosstodon @Paolo Parente
-242 L Mountain @Mark Tedin
-243 L Mountain @Aleksi Briclot
-244 L Mountain @Aleksi Briclot
-245 L Mountain @Zoltan Boros & Gabor Szikszai
-140 R Mycoloth @Raymond Swanland
-141 C Naturalize @Trevor Hairsine
-142 U Naya Battlemage @Steve Argyle
 180 U Naya Charm @Jesper Ejsing
-227 C Naya Panorama @Hideaki Takamura
 181 U Necrogenesis @Trevor Claxton
+182 M Prince of Thralls @Paul Bonner
+183 R Punish Ignorance @Shelly Wan
+184 U Qasali Ambusher @Kev Walker
+185 M Rafiq of the Many @Michael Komarck
+186 C Rakeclaw Gargantuan @Jesper Ejsing
+187 R Realm Razer @Hideaki Takamura
+188 U Rhox War Monk @Dan Dos Santos
+189 C Rip-Clan Crasher @Justin Sweet
+190 U Sangrite Surge @Jarreau Wimberly
+191 M Sarkhan Vol @Daarken
+192 R Sedraxis Specter @Cole Eastburn
+193 M Sedris, the Traitor King @Paul Bonner
+194 M Sharuum the Hegemon @Izzy
+195 C Sigil Blessing @Matt Stewart
+196 M Sphinx Sovereign @Chippy
+197 U Sprouting Thrinax @Jarreau Wimberly
+198 C Steward of Valeron @Greg Staples
+199 R Stoic Angel @Volkan Baǵa
+200 U Swerve @Karl Kopinski
+201 U Thoughtcutter Agent @Cyril Van Der Haegen
+202 U Tidehollow Sculler @rk post
+203 C Tidehollow Strix @Cyril Van Der Haegen
+204 R Titanic Ultimatum @Steve Prescott
+205 U Tower Gargoyle @Matt Cavotta
+206 R Violent Ultimatum @Raymond Swanland
+207 C Waveskimmer Aven @Mark Zug
+208 C Windwright Mage @Chippy
+209 U Woolly Thoctar @Wayne Reynolds
+210 M Lich's Mirror @Ash Wood
+211 R Minion Reflector @Mark Tedin
 212 C Obelisk of Bant @David Palumbo
 213 C Obelisk of Esper @Francis Tsai
 214 C Obelisk of Grixis @Nils Hamm
 215 C Obelisk of Jund @Brandon Kitkouski
 216 C Obelisk of Naya @Steve Prescott
-20 C Oblivion Ring @Franz Vohwinkel
-81 C Onyx Goblet @rk post
-143 R Ooze Garden @Anthony S. Waters
-52 C Outrider of Jhess @Alan Pollack
+217 R Quietus Spike @Mark Brill
+218 C Relic of Progenitus @Jean-Sébastien Rossbach
+219 R Sigil of Distinction @Alan Pollack
+220 U Arcane Sanctum @Anthony Francisco
+221 C Bant Panorama @Donato Giancola
+222 U Crumbling Necropolis @Dave Kendall
+223 C Esper Panorama @Franz Vohwinkel
+224 C Grixis Panorama @Nils Hamm
+225 C Jund Panorama @Jaime Jones
+226 U Jungle Shrine @Wayne Reynolds
+227 C Naya Panorama @Hideaki Takamura
+228 U Savage Lands @Vance Kovacs
+229 U Seaside Citadel @Volkan Baǵa
 230 L Plains @Zoltan Boros & Gabor Szikszai
 231 L Plains @Michael Komarck
 232 L Plains @Michael Komarck
 233 L Plains @Chippy
-109 R Predator Dragon @Raymond Swanland
-182 M Prince of Thralls @Paul Bonner
-53 U Protomatter Powder @Francis Tsai
-183 R Punish Ignorance @Shelly Wan
-82 U Puppet Conjurer @Steven Belledin
-184 U Qasali Ambusher @Kev Walker
-217 R Quietus Spike @Mark Brill
-185 M Rafiq of the Many @Michael Komarck
-186 C Rakeclaw Gargantuan @Jesper Ejsing
-21 R Ranger of Eos @Volkan Baǵa
-187 R Realm Razer @Hideaki Takamura
-218 C Relic of Progenitus @Jean-Sébastien Rossbach
-144 C Resounding Roar @Steve Prescott
-83 C Resounding Scream @Thomas M. Baxa
-22 C Resounding Silence @Mark Zug
-110 C Resounding Thunder @Jon Foster
-54 C Resounding Wave @Izzy
-145 U Rhox Charger @Chris Rahn
-188 U Rhox War Monk @Dan Dos Santos
-111 C Ridge Rannet @Jim Murray
-189 C Rip-Clan Crasher @Justin Sweet
-23 U Rockcaster Platoon @David Palumbo
-112 U Rockslide Elemental @Joshua Hagler
-146 R Sacellum Godspeaker @Wayne Reynolds
-84 R Salvage Titan @Anthony Francisco
-24 C Sanctum Gargoyle @Shelly Wan
-190 U Sangrite Surge @Jarreau Wimberly
-191 M Sarkhan Vol @Daarken
-147 C Savage Hunger @Trevor Claxton
-228 U Savage Lands @Vance Kovacs
-85 U Scavenger Drake @Trevor Claxton
-113 U Scourge Devil @Dave Kendall
-25 R Scourglass @Matt Cavotta
-229 U Seaside Citadel @Volkan Baǵa
-192 R Sedraxis Specter @Cole Eastburn
-193 M Sedris, the Traitor King @Paul Bonner
-86 C Shadowfeed @Dave Kendall
-55 R Sharding Sphinx @Michael Bruinsma
-194 M Sharuum the Hegemon @Izzy
-87 C Shore Snapper @Dave Kendall
-26 C Sighted-Caste Sorcerer @Chris Rahn
-195 C Sigil Blessing @Matt Stewart
-219 R Sigil of Distinction @Alan Pollack
-27 U Sigiled Paladin @Greg Staples
-88 C Skeletal Kathari @Carl Critchlow
-114 U Skeletonize @Karl Kopinski
-56 R Skill Borrower @Shelly Wan
-148 R Skullmulcher @Michael Ryan
-115 C Soul's Fire @Wayne Reynolds
-28 C Soul's Grace @Christopher Moeller
-149 C Soul's Might @Kev Walker
-150 R Spearbreaker Behemoth @Christopher Moeller
-57 C Spell Snip @Michael Sutfin
-196 M Sphinx Sovereign @Chippy
-58 U Sphinx's Herald @Dan Scott
-197 U Sprouting Thrinax @Jarreau Wimberly
-59 C Steelclad Serpent @Carl Critchlow
-198 C Steward of Valeron @Greg Staples
-199 R Stoic Angel @Volkan Baǵa
-29 U Sunseed Nurturer @Steve Argyle
+234 L Island @Michael Komarck
+235 L Island @Chippy
+236 L Island @Chippy
+237 L Island @Mark Tedin
 238 L Swamp @Chippy
 239 L Swamp @Mark Tedin
 240 L Swamp @Mark Tedin
 241 L Swamp @Aleksi Briclot
-200 U Swerve @Karl Kopinski
-89 R Tar Fiend @Anthony S. Waters
-60 M Tezzeret the Seeker @Anthony Francisco
-116 C Thorn-Thrash Viashino @Jon Foster
-201 U Thoughtcutter Agent @Cyril Van Der Haegen
-117 U Thunder-Thrash Elder @Brandon Kitkouski
-202 U Tidehollow Sculler @rk post
-203 C Tidehollow Strix @Cyril Van Der Haegen
-204 R Titanic Ultimatum @Steve Prescott
-151 U Topan Ascetic @Sal Villagran
-61 C Tortoise Formation @Mark Zug
-205 U Tower Gargoyle @Matt Cavotta
-90 C Undead Leotau @Carl Critchlow
-62 C Vectis Silencers @Steven Belledin
-91 R Vein Drinker @Lars Grant-West
-118 C Viashino Skeleton @Cole Eastburn
-119 R Vicious Shadows @Joshua Hagler
-206 R Violent Ultimatum @Raymond Swanland
-92 C Viscera Dragger @Ralph Horsley
-120 C Vithian Stinger @Dave Kendall
-121 C Volcanic Submersion @Trevor Claxton
-207 C Waveskimmer Aven @Mark Zug
-30 C Welkin Guide @David Palumbo
-122 R Where Ancients Tread @Zoltan Boros & Gabor Szikszai
-152 C Wild Nacatl @Wayne Reynolds
-208 C Windwright Mage @Chippy
-209 U Woolly Thoctar @Wayne Reynolds
-31 C Yoked Plowbeast @Steve Argyle
+242 L Mountain @Mark Tedin
+243 L Mountain @Aleksi Briclot
+244 L Mountain @Aleksi Briclot
+245 L Mountain @Zoltan Boros & Gabor Szikszai
+246 L Forest @Aleksi Briclot
+247 L Forest @Zoltan Boros & Gabor Szikszai
+248 L Forest @Zoltan Boros & Gabor Szikszai
+249 L Forest @Michael Komarck
+
+[showcase]
+250 M Rafiq of the Many @Meel Tamphanon
 
 [tokens]
 w_1_1_soldier


### PR DESCRIPTION
Updated ALA edition file and booster due to new Rafiq of the Many [showcase] card
Added new GDY promos

Source: https://magic.wizards.com/en/articles/archive/feature/whats-new-list-streets-new-capenna-2022-04-14