### PR TITLE
DiscardEffect getStackDescription() overhaul

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/DiscardEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DiscardEffect.java
@@ -59,11 +59,14 @@ public class DiscardEffect extends SpellAbilityEffect {
 
             int numCards = sa.hasParam("NumCards") ?
                     AbilityUtils.calculateAmount(sa.getHostCard(), sa.getParam("NumCards"), sa) : 1;
+            final boolean oneCard = numCards == 1 && oneTgtP;
 
-            String valid = "card";
+            String valid = oneCard ? "card" : "cards";
             if (sa.hasParam("DiscardValid")) {
-                valid = sa.hasParam("DiscardValidDesc") ? sa.getParam("DiscardValidDesc")
+                String validD = sa.hasParam("DiscardValidDesc") ? sa.getParam("DiscardValidDesc")
                         : sa.getParam("DiscardValid");
+                valid = validD.contains(" card") ?
+                        (oneCard ? validD : validD.replace(" card", " cards")) : validD + " " + valid;
             }
 
             if (mode.equals("Hand")) {
@@ -82,7 +85,7 @@ public class DiscardEffect extends SpellAbilityEffect {
             if (revealYouChoose) {
                 sb.append(valid.contains(" from ") ? ". " : (oneTgtP ? " from it. " : " from them. ")).append(tgtPs);
                 sb.append(oneTgtP ? " discards " : " discard ");
-                sb.append(numCards > 1 || !oneTgtP ? "those cards" : "that card");
+                sb.append(oneCard ? "that card" : "those cards");
             } else if (revealDiscardAll) {
                 sb.append(" of type: ").append(valid);
             }

--- a/forge-game/src/main/java/forge/game/ability/effects/DiscardEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DiscardEffect.java
@@ -80,7 +80,7 @@ public class DiscardEffect extends SpellAbilityEffect {
             }
 
             if (revealYouChoose) {
-                sb.append(oneTgtP ? " from it. " : " from them. ").append(tgtPs);
+                sb.append(valid.contains(" from ") ? ". " : (oneTgtP ? " from it. " : " from them. ")).append(tgtPs);
                 sb.append(oneTgtP ? " discards " : " discard ");
                 sb.append(numCards > 1 || !oneTgtP ? "those cards" : "that card");
             } else if (revealDiscardAll) {

--- a/forge-gui/res/cardsfolder/i/inquisition_of_kozilek.txt
+++ b/forge-gui/res/cardsfolder/i/inquisition_of_kozilek.txt
@@ -1,5 +1,5 @@
 Name:Inquisition of Kozilek
 ManaCost:B
 Types:Sorcery
-A:SP$ Discard | Cost$ B | ValidTgts$ Player | TgtPrompt$ Select target player | Mode$ RevealYouChoose | DiscardValid$ Card.nonLand+cmcLE3 | NumCards$ 1 | SpellDescription$ Target player reveals their hand. You choose a nonland card from it with mana value 3 or less. That player discards that card.
+A:SP$ Discard | ValidTgts$ Player | TgtPrompt$ Select target player | Mode$ RevealYouChoose | DiscardValid$ Card.nonLand+cmcLE3 | DiscardValidDesc$ nonland card from it with mana value 3 or less | SpellDescription$ Target player reveals their hand. You choose a nonland card from it with mana value 3 or less. That player discards that card.
 Oracle:Target player reveals their hand. You choose a nonland card from it with mana value 3 or less. That player discards that card.


### PR DESCRIPTION
Clean up where important calculations are made and not making the same `sa.getParam` etc. more than once
Improve verb conjugation for one vs. multiple targets
Introduce `DiscardValidDesc$` for garbled `DiscardValid$` values
Improve syntax for `Mode$ RevealYouChoose`

Before (thanks @paulsnoops)
![image](https://user-images.githubusercontent.com/103371817/164053612-06495fdf-37e7-4465-99c2-a66a3a391291.png)

After
![image](https://user-images.githubusercontent.com/103371817/164053641-5a279b61-29da-4058-9d60-23ed1471eeae.png)

New rainy day issue is to batch check cards with `DiscardValid$` to see which would need `DiscardValidDesc$`
