### PR TITLE
Testing workflow: Only install xvfb if not available

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -19,8 +19,8 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
 
-      - name: Install virtual framebuffer to allow running GUI on a headless server
-        run: sudo apt update && sudo apt install -y xvfb
+      - name: Install virtual framebuffer (if not available) to allow running GUI on a headless server
+        run: command -v Xvfb >/dev/null 2>&1 || { sudo apt update && sudo apt install -y xvfb; }
 
       - name: Run tests in virtual framebuffer
         run: |


### PR DESCRIPTION
Very minor improvement:
Only installs the virtual framebuffer if the package is not installed yet. Saves a few seconds, since the apt doesn't have to be updated. 