### PR TITLE
Better fix for card list dancing light issue.

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/itemmanager/views/ImageView.java
+++ b/forge-gui-desktop/src/main/java/forge/itemmanager/views/ImageView.java
@@ -1170,12 +1170,12 @@ public class ImageView<T extends InventoryItem> extends ItemView<T> {
             final int drawY = bounds.y + borderSize;
             final int drawWidth = bounds.width - 2 * borderSize;
             final int drawHeight = bounds.height - 2 * borderSize;
-            final int imageWidth = Math.round(drawWidth * screenScale)-1;
-            final int imageHeight = Math.round(drawHeight * screenScale)-1;
+            final int imageWidth = Math.round(drawWidth * screenScale);
+            final int imageHeight = Math.round(drawHeight * screenScale);
             BufferedImage img = ImageCache.getImage(item, imageWidth, imageHeight, itemInfo.alt);
 
             if (img != null) {
-                g.drawImage(img, drawX, drawY, drawX + drawWidth, drawY + drawHeight, 0, 0, imageWidth, imageHeight, null);
+                g.drawImage(img, drawX, drawY, drawWidth, drawHeight, null);
             }
             else {
                 if (deckSelectMode) {


### PR DESCRIPTION
This is the better fix for the card list dancing light issue.

I dropped the image dimension change added by kevlahnota, but call a different image rendering function.  
By Snoops test this seems to also solves the issue.

The code before and after the fix should work equivalently. I can't reproduce this issue in my environment, so I can only guess maybe there are some rendering bug in the Java runtime depends on the version. 