### PR TITLE
Fix attack requirement check

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/MustAttackEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/MustAttackEffect.java
@@ -75,7 +75,6 @@ public class MustAttackEffect extends SpellAbilityEffect {
                 } else {
                     p.setMustAttackEntity(entity);
                 }
-
             }
         }
         for (final Card c : getTargetCards(sa)) {

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -1347,7 +1347,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
         if (getController().equals(playerturn)) {
             mustAttackEntity = null;
         }
-        mustAttackEntityThisTurn = null;
+        mustAttackEntityThisTurn = mustAttackEntity;
     }
     public final GameEntity getMustAttackEntityThisTurn() { return mustAttackEntityThisTurn; }
     public final void setMustAttackEntityThisTurn(GameEntity entThisTurn) { mustAttackEntityThisTurn = entThisTurn; }

--- a/forge-game/src/main/java/forge/game/combat/AttackRequirement.java
+++ b/forge-game/src/main/java/forge/game/combat/AttackRequirement.java
@@ -13,6 +13,7 @@ import forge.game.Game;
 import forge.game.GameEntity;
 import forge.game.ability.AbilityUtils;
 import forge.game.card.Card;
+import forge.game.card.CardLists;
 import forge.game.keyword.KeywordInterface;
 import forge.game.player.Player;
 import forge.game.zone.ZoneType;
@@ -101,7 +102,7 @@ public class AttackRequirement {
             }
         }
 
-        // Remove GameEntities that are no longer on the battlefield or are
+        // Remove GameEntities that are no longer on an opposing battlefield or are
         // related to Players who have lost the game
         final MapToAmount<GameEntity> combinedDefMap = new LinkedHashMapToAmount<>();
         combinedDefMap.putAll(defenderSpecific);
@@ -115,8 +116,9 @@ public class AttackRequirement {
                     removeThis = true;
                 }
             } else if (entity instanceof Card) {
-                final Player controller = ((Card) entity).getController();
-                if (controller.hasLost() || !controller.getCardsIn(ZoneType.Battlefield).contains(entity)) {
+                final Card reqPW = (Card) entity;
+                final List<Card> actualPW = CardLists.getValidCards(attacker.getController().getOpponents().getCardsIn(ZoneType.Battlefield), "Card.StrictlySelf", null, reqPW, null);
+                if (reqPW.getController().hasLost() || actualPW.isEmpty()) {
                     removeThis = true;
                 }
             }

--- a/forge-game/src/main/java/forge/game/phase/Untap.java
+++ b/forge-game/src/main/java/forge/game/phase/Untap.java
@@ -231,26 +231,24 @@ public class Untap extends Phase {
     } // end doUntap
 
     private static void optionalUntap(final Card c) {
-        if (c.hasKeyword("You may choose not to untap CARDNAME during your untap step.")) {
-            if (c.isTapped()) {
-                StringBuilder prompt = new StringBuilder("Untap " + c.toString() + "?");
-                boolean defaultChoice = true;
-                if (c.getGainControlTargets().size() > 0) {
-                    final Iterable<Card> targets = c.getGainControlTargets();
-                    prompt.append("\r\n").append(c).append(" is controlling: ");
-                    for (final Card target : targets) {
-                        prompt.append(target);
-                        if (target.isInPlay()) {
-                            defaultChoice = false;
-                        }
+        boolean untap = true;
+
+        if (c.hasKeyword("You may choose not to untap CARDNAME during your untap step.") && c.isTapped()) {
+            StringBuilder prompt = new StringBuilder("Untap " + c.toString() + "?");
+            boolean defaultChoice = true;
+            if (c.getGainControlTargets().size() > 0) {
+                final Iterable<Card> targets = c.getGainControlTargets();
+                prompt.append("\r\n").append(c).append(" is controlling: ");
+                for (final Card target : targets) {
+                    prompt.append(target);
+                    if (target.isInPlay()) {
+                        defaultChoice = false;
                     }
                 }
-                boolean untap = c.getController().getController().chooseBinary(new SpellAbility.EmptySa(c, c.getController()), prompt.toString(), BinaryChoiceType.UntapOrLeaveTapped, defaultChoice);
-                if (untap) {
-                    c.untap(true);
-                }
             }
-        } else {
+            untap = c.getController().getController().chooseBinary(new SpellAbility.EmptySa(c, c.getController()), prompt.toString(), BinaryChoiceType.UntapOrLeaveTapped, defaultChoice);
+        }
+        if (untap) {
             c.untap(true);
         }
     }


### PR DESCRIPTION
Following interactions are fixed for cards like _Gideon, Battle-Forged_:

- his +2 wasn't working at all (fix is bandaid until it can be refactored better)

- when the taunted player confiscates him it would still try to obey the attack requirement = GUI deadlock

- attack requirement would still count if he got blinked