### PR TITLE
Card: add Shield counter Replacement Effects

### DIFF
--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -1775,9 +1775,8 @@ public class GameAction {
         }
 
         // Replacement effects
-        final Map<AbilityKey, Object> repRunParams = AbilityKey.mapFromCard(c);
+        final Map<AbilityKey, Object> repRunParams = AbilityKey.mapFromAffected(c);
         repRunParams.put(AbilityKey.Source, sa);
-        repRunParams.put(AbilityKey.Affected, c);
         repRunParams.put(AbilityKey.Regeneration, regenerate);
         if (params != null) {
             repRunParams.putAll(params);

--- a/forge-game/src/main/java/forge/game/card/CounterEnumType.java
+++ b/forge-game/src/main/java/forge/game/card/CounterEnumType.java
@@ -18,6 +18,8 @@
 
 package forge.game.card;
 
+import java.util.Locale;
+
 import com.google.common.collect.ImmutableList;
 
 /**
@@ -431,7 +433,7 @@ public enum CounterEnumType {
     }
 
     public static CounterEnumType getType(final String name) {
-        final String replacedName = name.replace("/", "").replaceAll("\\+", "p").replaceAll("\\-", "m").toUpperCase();
+        final String replacedName = name.replace("/", "").replaceAll("\\+", "p").replaceAll("\\-", "m").toUpperCase(Locale.ROOT);
         return Enum.valueOf(CounterEnumType.class, replacedName);
     }
 

--- a/forge-game/src/main/java/forge/game/replacement/ReplaceDestroy.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplaceDestroy.java
@@ -44,16 +44,13 @@ public class ReplaceDestroy extends ReplacementEffect {
      */
     @Override
     public boolean canReplace(Map<AbilityKey, Object> runParams) {
-        if (!matchesValidParam("ValidPlayer", runParams.get(AbilityKey.Affected))) {
-            return false;
-        }
-        if (!matchesValidParam("ValidCard", runParams.get(AbilityKey.Card))) {
+        if (!matchesValidParam("ValidCard", runParams.get(AbilityKey.Affected))) {
             return false;
         }
 
         // extra check for Regeneration
         if (hasParam("Regeneration")) {
-            Card card = (Card) runParams.get(AbilityKey.Card);
+            Card card = (Card) runParams.get(AbilityKey.Affected);
             if (!runParams.containsKey(AbilityKey.Regeneration) || !(Boolean)runParams.get(AbilityKey.Regeneration)) {
                 return false;
             }
@@ -78,7 +75,7 @@ public class ReplaceDestroy extends ReplacementEffect {
      */
     @Override
     public void setReplacingObjects(Map<AbilityKey, Object> runParams, SpellAbility sa) {
-        sa.setReplacingObject(AbilityKey.Card, runParams.get(AbilityKey.Card));
+        sa.setReplacingObject(AbilityKey.Card, runParams.get(AbilityKey.Affected));
     }
 
 }


### PR DESCRIPTION
Closes #142

This adds the Replacement Effects for Shield Counters
they should be unaffected by any card trait changes

for later MR, do `CARDNAME can't be regenerated.` as StaticAbility and undo `If CARDNAME would be destroyed, regenerate it.` Keyword