### PR TITLE
SNC: Jinnie Fay, Jetmir's Second and support

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/ReplaceTokenEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ReplaceTokenEffect.java
@@ -26,14 +26,18 @@ public class ReplaceTokenEffect extends SpellAbilityEffect {
         final Card card = sa.getHostCard();
         final Player p = sa.getActivatingPlayer();
         final Game game = card.getGame();
+        SpellAbility repSA = sa;
 
+        if (repSA.getReplacingObjects().isEmpty()) {
+            repSA = sa.getRootAbility();
+        }
         // ReplaceToken Effect only applies to one Player
-        Player affected = (Player) sa.getReplacingObject(AbilityKey.Player);
-        TokenCreateTable table = (TokenCreateTable) sa.getReplacingObject(AbilityKey.Token);
+        Player affected = (Player) repSA.getReplacingObject(AbilityKey.Player);
+        TokenCreateTable table = (TokenCreateTable) repSA.getReplacingObject(AbilityKey.Token);
 
         @SuppressWarnings("unchecked")
-        Map<AbilityKey, Object> originalParams = (Map<AbilityKey, Object>) sa
-                .getReplacingObject(AbilityKey.OriginalParams);
+        Map<AbilityKey, Object> originalParams =
+                (Map<AbilityKey, Object>) repSA.getReplacingObject(AbilityKey.OriginalParams);
 
         // currently the only ones that changes the amount does double it
         if ("Amount".equals(sa.getParam("Type"))) {

--- a/forge-gui/res/cardsfolder/upcoming/jinnie_fay_jetmirs_second.txt
+++ b/forge-gui/res/cardsfolder/upcoming/jinnie_fay_jetmirs_second.txt
@@ -1,0 +1,12 @@
+Name:Jinnie Fay, Jetmir's Second
+ManaCost:RG G GW
+Types:Legendary Creature Elf Druid
+PT:3/3
+R:Event$ CreateToken | ActiveZones$ Battlefield | ValidToken$ Card.YouCtrl | ReplaceWith$ GenericChoice | Optional$ True | Description$ If you would create one or more tokens, you may instead create that many 2/2 green Cat creature tokens with haste or that many 3/1 green Dog creature tokens with vigilance.
+SVar:GenericChoice:DB$ GenericChoice | Choices$ Cat,Dog
+SVar:Cat:DB$ ReplaceToken | Type$ ReplaceToken | ValidCard$ Card.YouCtrl | TokenScript$ g_2_2_cat_haste | SpellDescription$ Create that many 2/2 green Cat creature tokens with haste
+SVar:Dog:DB$ ReplaceToken | Type$ ReplaceToken | ValidCard$ Card.YouCtrl | TokenScript$ g_3_1_dog_vigilance | SpellDescription$ Create that many 3/1 green Dog creature tokens with vigilance
+DeckNeeds:Ability$Token
+DeckHas:Type$Cat|Dog
+AI:RemoveDeck:Random
+Oracle:If you would create one or more tokens, you may instead create that many 2/2 green Cat creature tokens with haste or that many 3/1 green Dog creature tokens with vigilance.

--- a/forge-gui/res/tokenscripts/g_2_2_cat_haste.txt
+++ b/forge-gui/res/tokenscripts/g_2_2_cat_haste.txt
@@ -1,0 +1,7 @@
+Name:Cat Token
+ManaCost:no cost
+Colors:green
+Types:Creature Cat
+PT:2/2
+K:Haste
+Oracle:Haste

--- a/forge-gui/res/tokenscripts/g_3_1_dog_vigilance.txt
+++ b/forge-gui/res/tokenscripts/g_3_1_dog_vigilance.txt
@@ -1,0 +1,7 @@
+Name:Dog Token
+ManaCost:no cost
+Colors:green
+Types:Creature Dog
+PT:3/1
+K:Vigilance
+Oracle:Vigilance


### PR DESCRIPTION
Possibly it would be better to skip GenericChoice and do the choice/choice prompt on ReplaceTokenEffect? It would need to be some kind of map <String, String> with <Description, TokenScript>, right? Then we probably wouldn't need the repSA stuff I added at the beginning of the ReplaceTokenEffect yet.

Unsure what is better for AI – initially at least this requires less finagling on ReplaceTokenEffect.

It may also be the case that this is "good enough for now" and we revisit this card and effect if/when more similar cards are printed. 