### PR TITLE
CountersPutAI: shouldPumpCard is too restrictive for instant speed PutCounter

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtil.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtil.java
@@ -1741,6 +1741,10 @@ public class ComputerUtil {
                         continue;
                     }
 
+                    if (c.getCounters(CounterEnumType.SHIELD) > 0) {
+                        continue;
+                    }
+
                     // already regenerated
                     if (c.getShieldCount() > 0) {
                         continue;
@@ -1852,6 +1856,10 @@ public class ComputerUtil {
                     final Card c = (Card) o;
                     // indestructible
                     if (c.hasKeyword(Keyword.INDESTRUCTIBLE)) {
+                        continue;
+                    }
+
+                    if (c.getCounters(CounterEnumType.SHIELD) > 0) {
                         continue;
                     }
 

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCombat.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCombat.java
@@ -128,7 +128,7 @@ public class ComputerUtilCombat {
         //        || (attacker.hasKeyword(Keyword.FADING) && attacker.getCounters(CounterEnumType.FADE) == 0)
         //        || attacker.hasSVar("EndOfTurnLeavePlay"));
         // The creature won't untap next turn
-        return !attacker.isTapped() || Untap.canUntap(attacker);
+        return !attacker.isTapped() || (attacker.getCounters(CounterEnumType.STUN) == 0 && Untap.canUntap(attacker));
     }
 
     /**
@@ -1628,14 +1628,18 @@ public class ComputerUtilCombat {
      *            a {@link forge.game.card.Card} object.
      * @return a boolean.
      */
-    public static boolean combatantCantBeDestroyed(Player ai, final Card combatant) {
-        // either indestructible or may regenerate
-        if (combatant.hasKeyword(Keyword.INDESTRUCTIBLE) || ComputerUtil.canRegenerate(ai, combatant)) {
+    public static boolean combatantCantBeDestroyed(final Player ai, final Card combatant) {
+        if (combatant.getCounters(CounterEnumType.SHIELD) > 0) {
             return true;
         }
 
         // will regenerate
         if (combatant.getShieldCount() > 0 && combatant.canBeShielded()) {
+            return true;
+        }
+
+        // either indestructible or may regenerate
+        if (combatant.hasKeyword(Keyword.INDESTRUCTIBLE) || ComputerUtil.canRegenerate(ai, combatant)) {
             return true;
         }
 
@@ -2150,7 +2154,7 @@ public class ComputerUtilCombat {
             final boolean noPrevention) {
         final int killDamage = getDamageToKill(c, false);
 
-        if (c.hasKeyword(Keyword.INDESTRUCTIBLE) || c.getShieldCount() > 0) {
+        if (c.hasKeyword(Keyword.INDESTRUCTIBLE) || c.getCounters(CounterEnumType.SHIELD) > 0 || (c.getShieldCount() > 0 && c.canBeShielded())) {
             if (!(source.hasKeyword(Keyword.WITHER) || source.hasKeyword(Keyword.INFECT))) {
                 return maxDamage + 1;
             }

--- a/forge-ai/src/main/java/forge/ai/ability/CharmAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CharmAi.java
@@ -14,6 +14,7 @@ import forge.ai.SpellAbilityAi;
 import forge.game.ability.AbilityUtils;
 import forge.game.ability.effects.CharmEffect;
 import forge.game.card.Card;
+import forge.game.keyword.Keyword;
 import forge.game.player.Player;
 import forge.game.spellability.AbilitySub;
 import forge.game.spellability.SpellAbility;
@@ -26,7 +27,6 @@ public class CharmAi extends SpellAbilityAi {
     protected boolean checkApiLogic(Player ai, SpellAbility sa) {
         final Card source = sa.getHostCard();
         List<AbilitySub> choices = CharmEffect.makePossibleOptions(sa);
-        Collections.shuffle(choices);
 
         final int num;
         final int min;
@@ -35,6 +35,11 @@ public class CharmAi extends SpellAbilityAi {
         } else {
             num = AbilityUtils.calculateAmount(source, sa.getParamOrDefault("CharmNum", "1"), sa);
             min = sa.hasParam("MinCharmNum") ? AbilityUtils.calculateAmount(source, sa.getParam("MinCharmNum"), sa) : num;
+        }
+
+        // only randomize if not all possible together
+        if (num < choices.size() || source.hasKeyword(Keyword.ESCALATE)) {
+            Collections.shuffle(choices);
         }
 
         boolean timingRight = sa.isTrigger(); //is there a reason to play the charm now?

--- a/forge-ai/src/main/java/forge/ai/ability/CountersPutAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CountersPutAi.java
@@ -571,6 +571,9 @@ public class CountersPutAi extends CountersAi {
                                     Lists.newArrayList())) {
                                 choice = c;
                                 break;
+                            } else if (!sa.getRestrictions().isSorcerySpeed() && !ComputerUtilCard.isUselessCreature(ai, c)) {
+                                choice = c;
+                                break;
                             }
                         }
                         if (!source.isSpell()) {    // does not cost a card

--- a/forge-ai/src/main/java/forge/ai/ability/CountersPutAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CountersPutAi.java
@@ -45,6 +45,7 @@ import forge.game.player.Player;
 import forge.game.player.PlayerActionConfirmMode;
 import forge.game.player.PlayerCollection;
 import forge.game.player.PlayerPredicates;
+import forge.game.spellability.AbilitySub;
 import forge.game.spellability.SpellAbility;
 import forge.game.spellability.TargetRestrictions;
 import forge.game.trigger.Trigger;
@@ -456,25 +457,24 @@ public class CountersPutAi extends CountersAi {
             }
         }
 
-        if (!ai.getGame().getStack().isEmpty() && !SpellAbilityAi.isSorcerySpeed(sa, ai)) {
-            // only evaluates case where all tokens are placed on a single target
-            if (sa.usesTargeting() && sa.getMinTargets() < 2) {
-                if (ComputerUtilCard.canPumpAgainstRemoval(ai, sa)) {
-                    Card c = sa.getTargetCard();
-                    if (sa.getTargets().size() > 1) {
-                        sa.resetTargets();
-                        sa.getTargets().add(c);
+        if (sa.usesTargeting()) {
+            if (!ai.getGame().getStack().isEmpty() && !SpellAbilityAi.isSorcerySpeed(sa, ai)) {
+                // only evaluates case where all tokens are placed on a single target
+                if (sa.getMinTargets() < 2) {
+                    if (ComputerUtilCard.canPumpAgainstRemoval(ai, sa)) {
+                        Card c = sa.getTargetCard();
+                        if (sa.getTargets().size() > 1) {
+                            sa.resetTargets();
+                            sa.getTargets().add(c);
+                        }
+                        sa.addDividedAllocation(c, amount);
+                        return true;
+                    } else {
+                        return false;
                     }
-                    sa.addDividedAllocation(c, amount);
-                    return true;
-                } else {
-                    return false;
                 }
             }
-        }
 
-        // Targeting
-        if (sa.usesTargeting()) {
             sa.resetTargets();
 
             final boolean sacSelf = ComputerUtilCost.isSacrificeSelfCost(abCost);
@@ -482,7 +482,7 @@ public class CountersPutAi extends CountersAi {
             if (sa.isCurse()) {
                 list = ai.getOpponents().getCardsIn(ZoneType.Battlefield);
             } else {
-                list = new CardCollection(ai.getCardsIn(ZoneType.Battlefield));
+                list = ComputerUtil.getSafeTargets(ai, sa, ai.getCardsIn(ZoneType.Battlefield));
             }
 
             list = CardLists.filter(list, new Predicate<Card>() {
@@ -530,8 +530,7 @@ public class CountersPutAi extends CountersAi {
                 for (int i = 1; i < amount + 1; i++) {
                     int left = amount;
                     for (Card c : list) {
-                        if (ComputerUtilCard.shouldPumpCard(ai, sa, c, i, i,
-                                Lists.newArrayList())) {
+                        if (ComputerUtilCard.shouldPumpCard(ai, sa, c, i, i, Lists.newArrayList())) {
                             sa.getTargets().add(c);
                             sa.addDividedAllocation(c, i);
                             left -= i;
@@ -553,7 +552,7 @@ public class CountersPutAi extends CountersAi {
             // target loop
             while (sa.canAddMoreTarget()) {
                 if (list.isEmpty()) {
-                    if (!sa.isTargetNumberValid() || (sa.getTargets().size() == 0)) {
+                    if (!sa.isTargetNumberValid() || sa.getTargets().isEmpty()) {
                         sa.resetTargets();
                         return false;
                     } else {
@@ -567,26 +566,34 @@ public class CountersPutAi extends CountersAi {
                 } else {
                     if (type.equals("P1P1") && !SpellAbilityAi.isSorcerySpeed(sa, ai)) {
                         for (Card c : list) {
-                            if (ComputerUtilCard.shouldPumpCard(ai, sa, c, amount, amount,
-                                    Lists.newArrayList())) {
-                                choice = c;
-                                break;
-                            } else if (!sa.getRestrictions().isSorcerySpeed() && !ComputerUtilCard.isUselessCreature(ai, c)) {
+                            if (ComputerUtilCard.shouldPumpCard(ai, sa, c, amount, amount, Lists.newArrayList())) {
                                 choice = c;
                                 break;
                             }
                         }
-                        if (!source.isSpell()) {    // does not cost a card
-                            if (choice == null) {   // find generic target
-                                if (abCost == null
+
+                        if (choice == null) {
+                            // try to use as cheap kill
+                            choice =  ComputerUtil.getKilledByTargeting(sa, CardLists.getTargetableCards(ai.getOpponents().getCreaturesInPlay(), sa));
+                        }
+
+                        if (choice == null) {
+                            // find generic target
+                            boolean increasesCharmOutcome = false;
+                            if (sa.getRootAbility().getApi() == ApiType.Charm && source.getStaticAbilities().isEmpty()) {
+                                List<AbilitySub> choices = Lists.newArrayList(sa.getRootAbility().getAdditionalAbilityList("Choices"));
+                                choices.remove(sa);
+                                // check if other choice will already be played
+                                increasesCharmOutcome = !choices.get(0).getTargets().isEmpty(); 
+                            }
+                            if (!source.isSpell() || increasesCharmOutcome // does not cost a card or can buff charm for no expense
+                                    || ph.getTurn() - source.getTurnInZone() >= source.getGame().getPlayers().size() * 2) {
+                                if (abCost == null || abCost == Cost.Zero
                                         || (ph.is(PhaseType.END_OF_TURN) && ph.getPlayerTurn().isOpponentOf(ai))) {
                                     // only use at opponent EOT unless it is free
                                     choice = chooseBoonTarget(list, type);
                                 }
                             }
-                        }
-                        if (ComputerUtilAbility.getAbilitySourceName(sa).equals("Dromoka's Command")) {
-                            choice = chooseBoonTarget(list, type);
                         }
                     } else {
                         choice = chooseBoonTarget(list, type);
@@ -594,7 +601,7 @@ public class CountersPutAi extends CountersAi {
                 }
 
                 if (choice == null) { // can't find anything left
-                    if (!sa.isTargetNumberValid() || sa.getTargets().size() == 0) {
+                    if (!sa.isTargetNumberValid() || sa.getTargets().isEmpty()) {
                         sa.resetTargets();
                         return false;
                     } else {
@@ -910,7 +917,6 @@ public class CountersPutAi extends CountersAi {
                     // Didn't want to choose anything?
                     list.clear();
                 }
-
             }
         }
         return true;

--- a/forge-ai/src/main/java/forge/ai/ability/DestroyAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DestroyAi.java
@@ -1,6 +1,7 @@
 package forge.ai.ability;
 
 import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 
 import forge.ai.*;
 import forge.game.ability.AbilityUtils;
@@ -174,6 +175,8 @@ public class DestroyAi extends SpellAbilityAi {
                 list = ComputerUtilCard.prioritizeCreaturesWorthRemovingNow(ai, list, false);
             }
             if (!SpellAbilityAi.playReusable(ai, sa)) {
+                list = CardLists.filter(list, Predicates.not(CardPredicates.hasCounter(CounterEnumType.SHIELD, 1)));
+
                 list = CardLists.filter(list, new Predicate<Card>() {
                     @Override
                     public boolean apply(final Card c) {
@@ -196,7 +199,7 @@ public class DestroyAi extends SpellAbilityAi {
                             return false;
                         }
                         //Check for undying
-                        return (!c.hasKeyword(Keyword.UNDYING) || c.getCounters(CounterEnumType.P1P1) > 0);
+                        return !c.hasKeyword(Keyword.UNDYING) || c.getCounters(CounterEnumType.P1P1) > 0;
                     }
                 });
             }
@@ -333,6 +336,7 @@ public class DestroyAi extends SpellAbilityAi {
 
             CardCollection preferred = CardLists.getNotKeyword(list, Keyword.INDESTRUCTIBLE);
             preferred = CardLists.filterControlledBy(preferred, ai.getOpponents());
+            preferred = CardLists.filter(preferred, Predicates.not(CardPredicates.hasCounter(CounterEnumType.SHIELD, 1)));
             if (CardLists.getNotType(preferred, "Creature").isEmpty()) {
                 preferred = ComputerUtilCard.prioritizeCreaturesWorthRemovingNow(ai, preferred, false);
             }

--- a/forge-ai/src/main/java/forge/ai/ability/DestroyAllAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DestroyAllAi.java
@@ -8,6 +8,7 @@ import forge.game.card.Card;
 import forge.game.card.CardCollection;
 import forge.game.card.CardLists;
 import forge.game.card.CardPredicates;
+import forge.game.card.CounterEnumType;
 import forge.game.combat.Combat;
 import forge.game.cost.Cost;
 import forge.game.keyword.Keyword;
@@ -21,7 +22,7 @@ public class DestroyAllAi extends SpellAbilityAi {
     private static final Predicate<Card> predicate = new Predicate<Card>() {
         @Override
         public boolean apply(final Card c) {
-            return !(c.hasKeyword(Keyword.INDESTRUCTIBLE) || c.getSVar("SacMe").length() > 0);
+            return !(c.hasKeyword(Keyword.INDESTRUCTIBLE) || c.getCounters(CounterEnumType.SHIELD) > 0 || c.hasSVar("SacMe"));
         }
     };
 

--- a/forge-game/src/main/java/forge/game/phase/Untap.java
+++ b/forge-game/src/main/java/forge/game/phase/Untap.java
@@ -105,7 +105,7 @@ public class Untap extends Phase {
     public static final Predicate<Card> CANUNTAP = new Predicate<Card>() {
         @Override
         public boolean apply(Card c) {
-            return Untap.canUntap(c);
+            return canUntap(c);
         }
     };
 

--- a/forge-game/src/main/java/forge/game/spellability/AbilityStatic.java
+++ b/forge-game/src/main/java/forge/game/spellability/AbilityStatic.java
@@ -20,7 +20,6 @@ package forge.game.spellability;
 import forge.card.mana.ManaCost;
 import forge.game.card.Card;
 import forge.game.cost.Cost;
-import forge.game.player.Player;
 
 /**
  * <p>
@@ -51,11 +50,6 @@ public abstract class AbilityStatic extends Ability implements Cloneable {
     }
     @Override
     public boolean canPlay() {
-        Player player = getActivatingPlayer();
-        if (player == null) {
-            player = this.getHostCard().getController();
-        }
-
         final Card c = this.getHostCard();
 
         return this.getRestrictions().canPlay(c, this);

--- a/forge-game/src/main/java/forge/game/trigger/TriggerSpellAbilityCastOrCopy.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerSpellAbilityCastOrCopy.java
@@ -126,15 +126,8 @@ public class TriggerSpellAbilityCastOrCopy extends Trigger {
 
             boolean validTgtFound = false;
             while (sa != null && !validTgtFound) {
-                for (final Card tgt : sa.getTargets().getTargetCards()) {
-                    if (matchesValid(tgt, getParam("TargetsValid").split(","))) {
-                        validTgtFound = true;
-                        break;
-                    }
-                }
-
-                for (final Player p : sa.getTargets().getTargetPlayers()) {
-                    if (matchesValid(p, getParam("TargetsValid").split(","))) {
+                for (final GameEntity ge : sa.getTargets().getTargetEntities()) {
+                    if (matchesValid(ge, getParam("TargetsValid").split(","))) {
                         validTgtFound = true;
                         break;
                     }

--- a/forge-gui/res/cardsfolder/s/subtle_strike.txt
+++ b/forge-gui/res/cardsfolder/s/subtle_strike.txt
@@ -3,5 +3,5 @@ ManaCost:1 B
 Types:Instant
 A:SP$ Charm | Cost$ 1 B | MinCharmNum$ 1 | CharmNum$ 2 | Choices$ DBPump,DBPutCounter
 SVar:DBPump:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature (-1/-1) | NumAtt$ -1 | NumDef$ -1 | IsCurse$ True | SpellDescription$ Target creature gets -1/-1 until end of turn.
-SVar:DBPutCounter:DB$ PutCounter | ValidTgts$ Creature | TgtPrompt$ Select target creature (+1/+1 counter) | AILogic$ Good | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on target creature.
+SVar:DBPutCounter:DB$ PutCounter | ValidTgts$ Creature | TgtPrompt$ Select target creature (+1/+1 counter) | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on target creature.
 Oracle:Choose one or both —\n• Target creature gets -1/-1 until end of turn.\n• Put a +1/+1 counter on target creature.


### PR DESCRIPTION
Currently, the AI only goes by shouldPumpCard when deciding whether to put a +1/+1 counter on its own creature or not. This is suboptimal because: (a) shouldPumpCard is truly designed for combat trick pumps that last until the end of turn, while PutCounter is a lasting effect that gives a more permanent bonus to the creature; (b) shouldPumpCard mostly evaluates combat tricks in the AI's own turn during the pre-combat phases or various blocking scenarios in the opponent's turn, thus, the AI would fail to activate the PutCounter ability at other times even when it's clearly beneficial.

Example case: the AI has a creature on board and I have a Raging Goblin in play. The AI casts Subtle Strike. It'll pretty much never choose to put a counter on its own creature because shouldPumpCard fails.

Expected behavior: the AI should pretty much always buff the creature with a counter unless it's useless or unless it can't receive counters (of this type or at all).

Now, currently I wrote it in such a way that shouldPumpCard is still checked, but if it fails, for instant speed stuff the AI goes by less restrictive isUselessCreature to determine playability. This makes Subtle Strike work correctly, but I don't know if it's too lax and if it should be generalized. Thus, the questions are:

(a) Should we completely replace shouldPumpCard with a different check (isUselessCreature + maybe something else)?
(b) If we keep shouldPumpCard, should anything be changed about the instant speed test? Is it too lax, and is there a better option?

I understand that the intention to use shouldPumpCard was to try to teach the AI to use a card like this one as a form of a combat trick, but unfortunately, I don't think the AI really holds on to this particular card for a possible combat trick (due to the presence of the other option in AF Charm), so it sort of loses its meaning... Maybe in that case, the best approach would be to just flag this card (and other possible similar cards) with the AI logic (it's already flagged with AILogic$ Good, but I don't think that's hooked up into PutCounterAi) so that the AI knows not to wait specifically for shouldPumpCard to succeed?