### PR TITLE
Fix Esix replacing too much from other effects

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/CopyPermanentEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CopyPermanentEffect.java
@@ -251,7 +251,7 @@ public class CopyPermanentEffect extends TokenEffectBase {
         }
     } // end resolve
 
-    private Card getProtoType(final SpellAbility sa, final Card original, final Player newOwner) {
+    public static Card getProtoType(final SpellAbility sa, final Card original, final Player newOwner) {
         final Card host = sa.getHostCard();
         int id = newOwner == null ? 0 : newOwner.getGame().nextCardId();
         final Card copy = new Card(id, original.getPaperCard(), host.getGame());

--- a/forge-gui/res/cardsfolder/e/esix_fractal_bloom.txt
+++ b/forge-gui/res/cardsfolder/e/esix_fractal_bloom.txt
@@ -4,8 +4,8 @@ Types:Legendary Creature Fractal
 PT:4/4
 K:Flying
 R:Event$ CreateToken | ActiveZones$ Battlefield | CheckSVar$ X | SVarCompare$ EQ0 | ValidPlayer$ You | PlayerTurn$ True | Optional$ True | ReplaceWith$ DBCopy | Description$ The first time you would create one or more tokens during each of your turns, you may instead choose a creature other than CARDNAME and create that many tokens that are copies of that creature.
-SVar:DBCopy:DB$ CopyPermanent | Choices$ Creature.Other | NumCopies$ Y
+SVar:DBCopy:DB$ ReplaceToken | Type$ ReplaceToken | ValidChoices$ Creature.Other | TokenScript$ Chosen
 SVar:X:PlayerCountPropertyYou$TokensCreatedThisTurn
-SVar:Y:ReplaceCount$TokenNum
 DeckHas:Ability$Token
+AI:RemoveDeck:All
 Oracle:Flying\nThe first time you would create one or more tokens during each of your turns, you may instead choose a creature other than Esix, Fractal Bloom and create that many tokens that are copies of that creature.


### PR DESCRIPTION
Finally if you create token with Encore and use Esix the rest (Haste, MustAttack & Exile trigger) is now still applied to other choice too.