### PR TITLE
Always change zone of cards when they move

### DIFF
--- a/forge-game/src/main/java/forge/game/zone/Zone.java
+++ b/forge-game/src/main/java/forge/game/zone/Zone.java
@@ -121,11 +121,11 @@ public class Zone implements java.io.Serializable, Iterable<Card> {
             c.setTapped(false);
         }
 
+        c.setZone(this);
+
         // Do not add Tokens to other zones than the battlefield. (unless it's a copy of a card 707.12)
         // But Effects/Emblems count as Tokens too, so allow Command too.
         if ((zoneType == ZoneType.Battlefield || !c.isToken()) || (zoneType == ZoneType.Stack && c.getCopiedPermanent() != null)) {
-            c.setZone(this);
-
             if (index == null) {
                 cardList.add(c);
             } else {

--- a/forge-game/src/main/java/forge/game/zone/Zone.java
+++ b/forge-game/src/main/java/forge/game/zone/Zone.java
@@ -121,7 +121,7 @@ public class Zone implements java.io.Serializable, Iterable<Card> {
             c.setTapped(false);
         }
         //Emblem/Effects are Immutable..
-        if (!c.isImmutable())
+        if (!c.isToken() || !c.isImmutable())
             c.setZone(this);
 
         if ((zoneType == ZoneType.Battlefield || !c.isToken()) || (zoneType == ZoneType.Stack && c.getCopiedPermanent() != null)) {

--- a/forge-game/src/main/java/forge/game/zone/Zone.java
+++ b/forge-game/src/main/java/forge/game/zone/Zone.java
@@ -120,9 +120,8 @@ public class Zone implements java.io.Serializable, Iterable<Card> {
         if (zoneType != ZoneType.Battlefield) {
             c.setTapped(false);
         }
-        //Emblem/Effects are Immutable..
-        if (!c.isToken() || !c.isImmutable())
-            c.setZone(this);
+
+        c.setZone(this);
 
         if ((zoneType == ZoneType.Battlefield || !c.isToken()) || (zoneType == ZoneType.Stack && c.getCopiedPermanent() != null)) {
             if (index == null) {

--- a/forge-game/src/main/java/forge/game/zone/Zone.java
+++ b/forge-game/src/main/java/forge/game/zone/Zone.java
@@ -120,11 +120,10 @@ public class Zone implements java.io.Serializable, Iterable<Card> {
         if (zoneType != ZoneType.Battlefield) {
             c.setTapped(false);
         }
+        //Emblem/Effects are Immutable..
+        if (!c.isImmutable())
+            c.setZone(this);
 
-        c.setZone(this);
-
-        // Do not add Tokens to other zones than the battlefield. (unless it's a copy of a card 707.12)
-        // But Effects/Emblems count as Tokens too, so allow Command too.
         if ((zoneType == ZoneType.Battlefield || !c.isToken()) || (zoneType == ZoneType.Stack && c.getCopiedPermanent() != null)) {
             if (index == null) {
                 cardList.add(c);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8506892/166069492-981f77af-7ca1-4258-b637-c05d87bff8f2.png)

Because tokens are now also copied the new one kept Battlefield as zone.