### PR TITLE
SNC card fixes

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/jetmirs_fixer.txt
+++ b/forge-gui/res/cardsfolder/upcoming/jetmirs_fixer.txt
@@ -2,7 +2,7 @@ Name:Jetmir's Fixer
 ManaCost:R G
 Types:Creature Cat Warrior
 PT:2/2
-A:AB$ Branch | BranchConditionSVar$ TreasureCheck | BranchConditionSVarCompare$ GE1 | FalseSubAbility$ DBPump | TrueSubAbility$ DBPutCounter | SpellDescription$ CARDNAME gets +1/+1 until end of turn. If mana from a Treasure was spent to activate this ability, put a +1/+1 counter on CARDNAME instead.
+A:AB$ Branch | Cost$ R G | BranchConditionSVar$ TreasureCheck | BranchConditionSVarCompare$ GE1 | FalseSubAbility$ DBPump | TrueSubAbility$ DBPutCounter | SpellDescription$ CARDNAME gets +1/+1 until end of turn. If mana from a Treasure was spent to activate this ability, put a +1/+1 counter on CARDNAME instead.
 SVar:DBPump:DB$ Pump | Defined$ Self | NumAtt$ 1 | NumDef$ 1
 SVar:DBPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1
 SVar:TreasureCheck:Count$TotalManaSpent Treasure

--- a/forge-gui/res/cardsfolder/upcoming/psionic_snoop.txt
+++ b/forge-gui/res/cardsfolder/upcoming/psionic_snoop.txt
@@ -2,7 +2,8 @@ Name:Psionic Snoop
 ManaCost:2 U
 Types:Creature Human Rogue
 PT:0/3
+K:Flash
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigConnive | TriggerDescription$ When CARDNAME enters the battlefield, it connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)
 SVar:TrigConnive:DB$ Connive
 DeckHas:Ability$Discard|Counters
-Oracle:When Psionic Snoop enters the battlefield, it connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)
+Oracle:Flash\nWhen Psionic Snoop enters the battlefield, it connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)

--- a/forge-gui/res/cardsfolder/upcoming/sewer_crocodile.txt
+++ b/forge-gui/res/cardsfolder/upcoming/sewer_crocodile.txt
@@ -2,7 +2,7 @@ Name:Sewer Crocodile
 ManaCost:5 U
 Types:Creature Crocodile
 PT:4/6
-A:AB$ Pump | Cost$ 3 U | Defined$ Self | KW$ HIDDEN Unblockable | ReduceCost$ X | SubAbility$ DBEffect | SpellDescription$ CARDNAME can't be blocked this turn.
+A:AB$ Pump | Cost$ 3 U | Defined$ Self | KW$ HIDDEN Unblockable | ReduceCost$ X | SpellDescription$ CARDNAME can't be blocked this turn.
 SVar:X:Count$Compare Y GE5.3.0
 SVar:Y:Count$ValidGraveyard Card.YouOwn$DifferentCMC
 Oracle:{3}{U}: Sewer Crocodile can't be blocked this turn. This ability costs {3} less to activate if there are five or more mana values among cards in your graveyard.

--- a/forge-gui/res/cardsfolder/upcoming/sparas_adjudicators.txt
+++ b/forge-gui/res/cardsfolder/upcoming/sparas_adjudicators.txt
@@ -3,7 +3,7 @@ ManaCost:2 G W U
 Types:Creature Cat Citizen
 PT:4/4
 T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigPump | TriggerDescription$ When CARDNAME enters the battlefield, target creature an opponent controls can't attack or block until your next turn.
-SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.OpponentCtrl | TgtPrompt$ Select target creature an opponent controls | KW$ HIDDEN CARDNAME can't attack or block. | IsCurse$ True | Duration$ UntilYourNextTurn
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | KW$ HIDDEN CARDNAME can't attack or block. | IsCurse$ True | Duration$ UntilYourNextTurn
 A:AB$ Effect | Cost$ 2 ExileFromHand<1/CARDNAME> | ActivationZone$ Hand | ValidTgts$ Land | TgtPrompt$ Select target land | RememberObjects$ Targeted,Self | StaticAbilities$ Land,MayPlay | Triggers$ Cast | ImprintCards$ Self | Duration$ Permanent | ForgetOnMoved$ Exile | SpellDescription$ Target land gains "{T}: Add {G}, {W}, or {U}" until CARDNAME is cast from exile. You may cast CARDNAME for as long as it remains exiled.
 SVar:Land:Mode$ Continuous | EffectZone$ Command | AffectedZone$ Battlefield | Affected$ Card.IsRemembered+IsNotImprinted | AddAbility$ Mana | Description$ Target land gains "{T}: Add {G}, {W}, or {U}" until EFFECTSOURCE is cast from exile. You may cast EFFECTSOURCE for as long as it remains exiled.
 SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo G W U | Amount$ 1 | SpellDescription$ Add {G}, {W}, or {U}


### PR DESCRIPTION
Jetmir's Fixer - causing crash from deck editor because of no cost in A:AB$ Branch
Sewer Crocodile - removed redundant SubAbility$ DBEffect
Psionic Snoop - Added missing Flash keyword
Spara's Adjudicators - EtB wasn't working