### PR TITLE
Remove duplicate exalted calculation

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCombat.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCombat.java
@@ -1181,11 +1181,6 @@ public class ComputerUtilCombat {
     public static int predictPowerBonusOfAttacker(final Card attacker, final Card blocker, final Combat combat, boolean withoutAbilities, boolean withoutCombatStaticAbilities) {
         int power = 0;
 
-        //check Exalted only for the first attacker
-        if (combat != null && combat.getAttackers().isEmpty()) {
-            power += attacker.getController().countExaltedBonus();
-        }
-
         // Serene Master switches power with attacker
         if (blocker!= null && blocker.getName().equals("Serene Master")) {
             power += blocker.getNetPower() - attacker.getNetPower();
@@ -1376,11 +1371,6 @@ public class ComputerUtilCombat {
     public static int predictToughnessBonusOfAttacker(final Card attacker, final Card blocker, final Combat combat
             , boolean withoutAbilities, boolean withoutCombatStaticAbilities) {
         int toughness = 0;
-
-        //check Exalted only for the first attacker
-        if (combat != null && combat.getAttackers().isEmpty()) {
-            toughness += attacker.getController().countExaltedBonus();
-        }
 
         if (blocker != null && attacker.getName().equals("Shape Stealer")) {
             toughness += blocker.getNetToughness() - attacker.getNetToughness();


### PR DESCRIPTION
These parts haven't been needed since a long time when Exalted got converted to real trigger which the AI is able to predict correctly with the better checks that follow there. So this stops misplays like this example:

![image](https://user-images.githubusercontent.com/8506892/166153231-f76987d0-eeca-40ce-a5cc-3db6e1590a43.png)