### PR TITLE
GameAction: Add ETB counters before checking statics

### DIFF
--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -577,6 +577,8 @@ public class GameAction {
             }
         }
 
+        table.replaceCounterEffect(game, null, true);
+
         // Need to apply any static effects to produce correct triggers
         checkStaticAbilities();
 
@@ -591,8 +593,6 @@ public class GameAction {
             game.getTriggerHandler().registerActiveLTBTrigger(lki);
         }
         game.getTriggerHandler().registerActiveTrigger(copied, false);
-
-        table.replaceCounterEffect(game, null, true);
 
         // play the change zone sound
         game.fireEvent(new GameEventCardChangeZone(c, zoneFrom, zoneTo));


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/8506892/166205628-dbd4a4d9-14f7-41ce-b10c-b67e08fb7a84.png)

Is this fix safe?

Tested with _Tayam, Luminous Enigma_ and it also still got vigilance counter