### PR TITLE
NCC: Tenuous Truce

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/tenuous_truce.txt
+++ b/forge-gui/res/cardsfolder/upcoming/tenuous_truce.txt
@@ -4,7 +4,7 @@ Types:Enchantment Aura
 K:Enchant opponent
 A:SP$ Attach | ValidTgts$ Opponent | AILogic$ Curse
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ Opponent.EnchantedBy | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ At the beginning of enchanted opponent's end step, you and that player each draw a card.
-SVar:TrigDraw:DB$ Draw | Defined$ Player.EnchantedBy,You
+SVar:TrigDraw:DB$ Draw | Defined$ TriggeredPlayerAndYou
 T:Mode$ AttackersDeclared | AttackingPlayer$ You | AttackedTarget$ Player.EnchantedBy,Planeswalker.EnchantedPlayerCtrl | Execute$ TrigSac | TriggerZones$ Battlefield | TriggerDescription$ When you attack enchanted opponent or a planeswalker they control or when they attack you or a planeswalker you control, sacrifice CARDNAME.
 T:Mode$ AttackersDeclared | AttackingPlayer$ Player.EnchantedBy | AttackedTarget$ You,Planeswalker.YouCtrl | Execute$ TrigSac | Secondary$ True | TriggerZones$ Battlefield | TriggerDescription$ When you attack enchanted opponent or a planeswalker they control or when they attack you or a planeswalker you control, sacrifice CARDNAME.
 SVar:TrigSac:DB$ Sacrifice

--- a/forge-gui/res/cardsfolder/upcoming/tenuous_truce.txt
+++ b/forge-gui/res/cardsfolder/upcoming/tenuous_truce.txt
@@ -1,0 +1,12 @@
+Name:Tenuous Truce
+ManaCost:1 W
+Types:Enchantment Aura
+K:Enchant opponent
+A:SP$ Attach | ValidTgts$ Opponent | AILogic$ Curse
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ Opponent.EnchantedBy | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ At the beginning of enchanted opponent's end step, you and that player each draw a card.
+SVar:TrigDraw:DB$ Draw | Defined$ Player.EnchantedBy,You
+T:Mode$ AttackersDeclared | AttackingPlayer$ You | AttackedTarget$ Player.EnchantedBy,Planeswalker.EnchantedPlayerCtrl | Execute$ TrigSac | TriggerZones$ Battlefield | TriggerDescription$ When you attack enchanted opponent or a planeswalker they control or when they attack you or a planeswalker you control, sacrifice CARDNAME.
+T:Mode$ AttackersDeclared | AttackingPlayer$ Player.EnchantedBy | AttackedTarget$ You,Planeswalker.YouCtrl | Execute$ TrigSac | Secondary$ True | TriggerZones$ Battlefield | TriggerDescription$ When you attack enchanted opponent or a planeswalker they control or when they attack you or a planeswalker you control, sacrifice CARDNAME.
+SVar:TrigSac:DB$ Sacrifice
+DeckHas:Ability$Sacrifice
+Oracle:Enchant opponent\nAt the beginning of enchanted opponent's end step, you and that player each draw a card.\nWhen you attack enchanted opponent or a planeswalker they control or when they attack you or a planeswalker you control, sacrifice Tenuous Truce.


### PR DESCRIPTION
What do we think about `Defined$ This,That` with the comma for a split?

Seems we could go back and clean up many files using stuff like `TargetedAndYou`
Also things where we use the same effect/params twice but for different Defined$ (if there are any of those... seems there may be)

closes #230 