### PR TITLE
Update some older cards to use LKI correctly

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/PumpAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PumpAi.java
@@ -33,7 +33,7 @@ public class PumpAi extends PumpAiBase {
         }
         return cost.hasSpecificCostType(CostTapType.class);
     }
-    
+
     @Override
     protected boolean checkAiLogic(final Player ai, final SpellAbility sa, final String aiLogic) {
         if ("MoveCounter".equals(aiLogic)) {

--- a/forge-gui/res/cardsfolder/h/howling_mine.txt
+++ b/forge-gui/res/cardsfolder/h/howling_mine.txt
@@ -1,6 +1,6 @@
 Name:Howling Mine
 ManaCost:2
 Types:Artifact
-T:Mode$ Phase | Phase$ Draw | ValidPlayer$ Player | TriggerZones$ Battlefield | IsPresent$ Card.Self+untapped | Execute$ TrigDraw | TriggerDescription$ At the beginning of each player's draw step, if CARDNAME is untapped, that player draws an additional card.
-SVar:TrigDraw:DB$ Draw | NumCards$ 1 | Defined$ TriggeredPlayer
+T:Mode$ Phase | Phase$ Draw | ValidPlayer$ Player | TriggerZones$ Battlefield | IsPresent$ Card.Self+untapped | NoResolvingCheck$ True | Execute$ TrigDraw | TriggerDescription$ At the beginning of each player's draw step, if CARDNAME is untapped, that player draws an additional card.
+SVar:TrigDraw:DB$ Draw | NumCards$ 1 | Defined$ TriggeredPlayer | ConditionDefined$ Self | ConditionPresent$ Card.untapped
 Oracle:At the beginning of each player's draw step, if Howling Mine is untapped, that player draws an additional card.

--- a/forge-gui/res/cardsfolder/m/mana_vault.txt
+++ b/forge-gui/res/cardsfolder/m/mana_vault.txt
@@ -4,9 +4,9 @@ Types:Artifact
 A:AB$ Mana | Cost$ T | Produced$ C | Amount$ 3 | SpellDescription$ Add {C}{C}{C}.
 K:CARDNAME doesn't untap during your untap step.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigUntap | TriggerDescription$ At the beginning of your upkeep, you may pay {4}. If you do, untap CARDNAME.
-T:Mode$ Phase | Phase$ Draw | ValidPlayer$ You | IsPresent$ Card.Self+tapped | Execute$ TrigDamage | TriggerDescription$ At the beginning of your draw step, if CARDNAME is tapped, it deals 1 damage to you.
-SVar:TrigUntap:AB$Untap | Cost$ 4 | Defined$ Self
-SVar:TrigDamage:DB$ DealDamage | Defined$ You | NumDmg$ 1
+T:Mode$ Phase | Phase$ Draw | ValidPlayer$ You | IsPresent$ Card.Self+tapped | NoResolvingCheck$ True | Execute$ TrigDamage | TriggerDescription$ At the beginning of your draw step, if CARDNAME is tapped, it deals 1 damage to you.
+SVar:TrigUntap:AB$ Untap | Cost$ 4 | Defined$ Self
+SVar:TrigDamage:DB$ DealDamage | Defined$ You | NumDmg$ 1 | ConditionDefined$ Self | ConditionPresent$ Card.tapped
 SVar:UntapMe:True
 AI:RemoveDeck:Random
 Oracle:Mana Vault doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {4}. If you do, untap Mana Vault.\nAt the beginning of your draw step, if Mana Vault is tapped, it deals 1 damage to you.\n{T}: Add {C}{C}{C}.

--- a/forge-gui/res/cardsfolder/n/nim_abomination.txt
+++ b/forge-gui/res/cardsfolder/n/nim_abomination.txt
@@ -2,6 +2,6 @@ Name:Nim Abomination
 ManaCost:2 B
 Types:Creature Zombie
 PT:3/4
-T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | IsPresent$ Card.Self+untapped | Execute$ TrigLoseLife | TriggerDescription$ At the beginning of your end step, if CARDNAME is untapped, you lose 3 life.
-SVar:TrigLoseLife:DB$ LoseLife | Defined$ You | LifeAmount$ 3
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | IsPresent$ Card.Self+untapped | NoResolvingCheck$ True | Execute$ TrigLoseLife | TriggerDescription$ At the beginning of your end step, if CARDNAME is untapped, you lose 3 life.
+SVar:TrigLoseLife:DB$ LoseLife | Defined$ You | LifeAmount$ 3 | ConditionDefined$ Self | ConditionPresent$ Card.untapped
 Oracle:At the beginning of your end step, if Nim Abomination is untapped, you lose 3 life.

--- a/forge-gui/res/cardsfolder/s/sphinx_sovereign.txt
+++ b/forge-gui/res/cardsfolder/s/sphinx_sovereign.txt
@@ -4,6 +4,6 @@ Types:Artifact Creature Sphinx
 PT:6/6
 K:Flying
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigLoseLife | TriggerDescription$ At the beginning of your end step, you gain 3 life if CARDNAME is untapped. Otherwise, each opponent loses 3 life.
-SVar:TrigLoseLife:DB$ LoseLife | Defined$ Player.Opponent | LifeAmount$ 3 | ConditionPresent$ Card.Self+tapped | SubAbility$ DBGainLife | ConditionCompare$ EQ1
-SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 3 | ConditionPresent$ Card.Self+untapped | ConditionCompare$ EQ1
+SVar:TrigLoseLife:DB$ LoseLife | Defined$ Player.Opponent | LifeAmount$ 3 | SubAbility$ DBGainLife | ConditionDefined$ Self | ConditionPresent$ Card.tapped
+SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 3 | ConditionDefined$ Self | ConditionPresent$ Card.tapped | ConditionCompare$ EQ0
 Oracle:Flying\nAt the beginning of your end step, you gain 3 life if Sphinx Sovereign is untapped. Otherwise, each opponent loses 3 life.

--- a/forge-gui/res/cardsfolder/upcoming/syndicate_infiltrator.txt
+++ b/forge-gui/res/cardsfolder/upcoming/syndicate_infiltrator.txt
@@ -2,6 +2,7 @@ Name:Syndicate Infiltrator
 ManaCost:2 U B
 Types:Creature Vampire Wizard
 PT:3/3
+K:Flying
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 2 | AddToughness$ 2 | CheckSVar$ X | SVarCompare$ GE5 | Description$ As long as there are five or more mana values among cards in your graveyard, CARDNAME gets +2/+2.
 SVar:X:Count$ValidGraveyard Card.YouOwn$DifferentCMC
 DeckHas:Ability$Graveyard

--- a/forge-gui/res/cardsfolder/v/voodoo_doll.txt
+++ b/forge-gui/res/cardsfolder/v/voodoo_doll.txt
@@ -2,11 +2,11 @@ Name:Voodoo Doll
 ManaCost:6
 Types:Artifact
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ TrigPutCounter | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, put a pin counter on CARDNAME.
-T:Mode$ Phase | Phase$ End of Turn | IsPresent$ Card.Self+untapped | PresentCompare$ EQ1 | ValidPlayer$ You | Execute$ TrigDestroy | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your end step, if CARDNAME is untapped, destroy CARDNAME and it deals damage to you equal to the number of pin counters on it.
+T:Mode$ Phase | Phase$ End of Turn | IsPresent$ Card.Self+untapped | NoResolvingCheck$ True | ValidPlayer$ You | Execute$ TrigDestroy | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your end step, if CARDNAME is untapped, destroy CARDNAME and it deals damage to you equal to the number of pin counters on it.
 A:AB$ DealDamage | Cost$ X X T | ValidTgts$ Creature,Player,Planeswalker | TgtPrompt$ Select any target | NumDmg$ X | SpellDescription$ CARDNAME deals damage equal to the number of pin counters on it to any target. X is the number of pin counters on CARDNAME.
 SVar:TrigPutCounter:DB$ PutCounter | CounterType$ PIN | CounterNum$ 1 | Defined$ Self
-SVar:TrigDestroy:DB$ Destroy | Defined$ Self | SubAbility$ DBDealDamageYou
-SVar:DBDealDamageYou:DB$ DealDamage | Defined$ You | NumDmg$ X
+SVar:TrigDestroy:DB$ Destroy | Defined$ Self | SubAbility$ DBDealDamageYou | ConditionDefined$ Self | ConditionPresent$ Card.untapped
+SVar:DBDealDamageYou:DB$ DealDamage | Defined$ You | NumDmg$ X | ConditionDefined$ Self | ConditionPresent$ Card.untapped
 SVar:X:Count$CardCounters.PIN
 AI:RemoveDeck:All
 Oracle:At the beginning of your upkeep, put a pin counter on Voodoo Doll.\nAt the beginning of your end step, if Voodoo Doll is untapped, destroy Voodoo Doll and it deals damage to you equal to the number of pin counters on it.\n{X}{X}, {T}: Voodoo Doll deals damage equal to the number of pin counters on it to any target. X is the number of pin counters on Voodoo Doll.


### PR DESCRIPTION
> If Sphinx Sovereign is no longer on the battlefield by then, the ability checks whether Sphinx Sovereign was tapped or untapped at the time it left the battlefield. 