### PR TITLE
Alchemy Rebalancing for May 5, 2022

### DIFF
--- a/forge-gui/res/cardsfolder/a/artillery_enthusiast.txt
+++ b/forge-gui/res/cardsfolder/a/artillery_enthusiast.txt
@@ -1,7 +1,7 @@
 Name:Artillery Enthusiast
 ManaCost:R
 Types:Creature Goblin Artificer
-PT:1/1
+PT:1/2
 S:Mode$ Continuous | Affected$ Creature.modified+YouCtrl | AddKeyword$ Menace | Description$ Modified creatures you control have menace.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.Self | Execute$ TrigSeek | TriggerDescription$ When CARDNAME enters the battlefield, you may discard a card. If you do, seek a card with mana value equal to that card's mana value.
 SVar:TrigSeek:AB$ ChangeZone | Cost$ Discard<1/Card> | Origin$ Library | Destination$ Hand | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | NoReveal$ True | ChangeType$ Card.cmcEQX | ChangeNum$ 1

--- a/forge-gui/res/cardsfolder/c/captain_eberhart.txt
+++ b/forge-gui/res/cardsfolder/c/captain_eberhart.txt
@@ -1,7 +1,7 @@
 Name:Captain Eberhart
 ManaCost:1 W
 Types:Legendary Creature Human Soldier
-PT:1/1
+PT:1/2
 K:Double Strike
 S:Mode$ ReduceCost | ValidCard$ Card.YouOwn+DrawnThisTurn | Type$ Spell | Amount$ 1 | Description$ Spells cast from among cards you drew this turn cost {1} less to cast.
 S:Mode$ RaiseCost | ValidCard$ Card.OppOwn+DrawnThisTurn | Type$ Spell | Amount$ 1 | Description$ Spells cast from among cards your opponents drew this turn cost {1} more to cast.

--- a/forge-gui/res/cardsfolder/c/citystalker_connoisseur.txt
+++ b/forge-gui/res/cardsfolder/c/citystalker_connoisseur.txt
@@ -3,7 +3,7 @@ ManaCost:3 B
 Types:Creature Vampire
 PT:3/3
 K:Deathtouch
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDiscard | TriggerDescription$ When CARDNAME enters the battlefield, target opponent discards a card with the greatest mana value among cards in their hand. Create a Blood token.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDiscard | TriggerDescription$ When CARDNAME enters the battlefield, target opponent discards a nonland card with the greatest mana value among cards in their hand. Create a Blood token.
 SVar:TrigDiscard:DB$ Discard | ValidTgts$ Opponent | TgtPrompt$ Select an opponent | NumCards$ 1 | DiscardValid$ Card.nonLand+cmcEQX | Mode$ TgtChoose | SubAbility$ DBToken
 SVar:DBToken:DB$ Token | TokenScript$ c_a_blood_draw
 SVar:X:Count$HighestCMC_Card.TargetedPlayerOwn+inZoneHand

--- a/forge-gui/res/cardsfolder/c/citystalker_connoisseur.txt
+++ b/forge-gui/res/cardsfolder/c/citystalker_connoisseur.txt
@@ -4,8 +4,8 @@ Types:Creature Vampire
 PT:3/3
 K:Deathtouch
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDiscard | TriggerDescription$ When CARDNAME enters the battlefield, target opponent discards a card with the greatest mana value among cards in their hand. Create a Blood token.
-SVar:TrigDiscard:DB$ Discard | ValidTgts$ Opponent | TgtPrompt$ Select an opponent | NumCards$ 1 | DiscardValid$ Card.cmcEQX | Mode$ TgtChoose | SubAbility$ DBToken
+SVar:TrigDiscard:DB$ Discard | ValidTgts$ Opponent | TgtPrompt$ Select an opponent | NumCards$ 1 | DiscardValid$ Card.nonLand+cmcEQX | Mode$ TgtChoose | SubAbility$ DBToken
 SVar:DBToken:DB$ Token | TokenScript$ c_a_blood_draw
 SVar:X:Count$HighestCMC_Card.TargetedPlayerOwn+inZoneHand
 DeckHas:Ability$Token|Sacrifice & Type$Blood
-Oracle:Deathtouch\nWhen Citystalker Connoisseur enters the battlefield, target opponent discards a card with the greatest mana value among cards in their hand. Create a Blood token.
+Oracle:Deathtouch\nWhen Citystalker Connoisseur enters the battlefield, target opponent discards a nonland card with the greatest mana value among cards in their hand. Create a Blood token.

--- a/forge-gui/res/cardsfolder/c/citystalker_connoisseur.txt
+++ b/forge-gui/res/cardsfolder/c/citystalker_connoisseur.txt
@@ -7,5 +7,5 @@ T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.S
 SVar:TrigDiscard:DB$ Discard | ValidTgts$ Opponent | TgtPrompt$ Select an opponent | NumCards$ 1 | DiscardValid$ Card.nonLand+cmcEQX | Mode$ TgtChoose | SubAbility$ DBToken
 SVar:DBToken:DB$ Token | TokenScript$ c_a_blood_draw
 SVar:X:Count$HighestCMC_Card.TargetedPlayerOwn+inZoneHand
-DeckHas:Ability$Token|Sacrifice & Type$Blood
+DeckHas:Ability$Token|Sacrifice & Type$Artifact|Blood
 Oracle:Deathtouch\nWhen Citystalker Connoisseur enters the battlefield, target opponent discards a nonland card with the greatest mana value among cards in their hand. Create a Blood token.

--- a/forge-gui/res/cardsfolder/e/experimental_pilot.txt
+++ b/forge-gui/res/cardsfolder/e/experimental_pilot.txt
@@ -1,7 +1,7 @@
 Name:Experimental Pilot
 ManaCost:U
 Types:Creature Human Pilot
-PT:1/1
+PT:1/2
 K:Ward:2
 A:AB$ NameCard | Cost$ U Discard<2/Card> | Draft$ True | Defined$ You | ChooseFromList$ Cultivator's Caravan,Bomat Bazaar Barge,Raiders' Karve,Demolition Stomper,Futurist Sentinel,Mechtitan Core,Reckoner Bankbuster,High-Speed Hoverbike,Mindlink Mech,Silent Submersible,Mobile Garrison,Untethered Express,Ovalchase Dragster,Daredevil Dragster,Thundering Chariot | SubAbility$ DBMakeCard | SpellDescription$ Draft a card from CARDNAME's spellbook.
 SVar:DBMakeCard:DB$ MakeCard | Name$ ChosenName | Zone$ Hand | SubAbility$ DBCleanup

--- a/forge-gui/res/cardsfolder/g/garruk_wrath_of_the_wilds.txt
+++ b/forge-gui/res/cardsfolder/g/garruk_wrath_of_the_wilds.txt
@@ -1,7 +1,7 @@
 Name:Garruk, Wrath of the Wilds
 ManaCost:2 G G
 Types:Legendary Planeswalker Garruk
-Loyalty:3
+Loyalty:4
 A:AB$ ChooseCard | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | ChoiceZone$ Hand | Choices$ Card.Creature+YouOwn | ChoiceTitle$ Choose up to one creature card in your hand | Amount$ 1 | SubAbility$ DBEffect | StackDescription$ SpellDescription | SpellDescription$ Choose a creature card in your hand. It perpetually gets +1/+1 and perpetually gains "This spell costs {1} less to cast."
 SVar:DBEffect:DB$ Effect | StaticAbilities$ PerpetualAbility,PerpetualP1P1 | Duration$ Permanent | Name$ Garruk, Wrath of the Wilds's Perpetual Effect | SubAbility$ DBCleanup
 SVar:PerpetualAbility:Mode$ Continuous | Affected$ Card.ChosenCard | AddStaticAbility$ ReduceCost | EffectZone$ Command | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | Description$ The chosen card perpetually gets +1/+1 and perpetually gains "This spell costs {1} less to cast."
@@ -10,5 +10,5 @@ SVar:ReduceCost:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 
 A:AB$ NameCard | Cost$ SubCounter<1/LOYALTY> | Planeswalker$ True | Draft$ True | Defined$ You | ChooseFromList$ Mosscoat Goriak,Sylvan Brushstrider,Murasa Rootgrazer,Dire Wolf Prowler,Ferocious Pup,Pestilent Wolf,Garruk's Uprising,Dawntreader Elk,Nessian Hornbeetle,Territorial Scythecat,Trufflesnout,Wary Okapi,Scurrid Colony,Barkhide Troll,Underdark Basilisk | SubAbility$ DBMakeCard | StackDescription$ SpellDescription | SpellDescription$ Draft a card from CARDNAME's spellbook and put it onto the battlefield.
 SVar:DBMakeCard:DB$ MakeCard | Name$ ChosenName | Zone$ Battlefield | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearNamedCard$ True | ClearChosenCard$ True
-A:AB$ PumpAll | Cost$ SubCounter<5/LOYALTY> | Planeswalker$ True | Ultimate$ True | ValidCards$ Creature.YouCtrl | NumAtt$ +3 | NumDef$ +3 | KW$ Trample | SpellDescription$ Until end of turn, creatures you control get +3/+3 and gain trample.
-Oracle:[+1]: Choose a creature card in your hand. It perpetually gets +1/+1 and perpetually gains "This spell costs {1} less to cast."\n[-1]: Draft a card from Garruk, Wrath of the Wild's spellbook and put it onto the battlefield.\n[-5]: Until end of turn, creatures you control get +3/+3 and gain trample.
+A:AB$ PumpAll | Cost$ SubCounter<6/LOYALTY> | Planeswalker$ True | Ultimate$ True | ValidCards$ Creature.YouCtrl | NumAtt$ +3 | NumDef$ +3 | KW$ Trample | SpellDescription$ Until end of turn, creatures you control get +3/+3 and gain trample.
+Oracle:[+1]: Choose a creature card in your hand. It perpetually gets +1/+1 and perpetually gains "This spell costs {1} less to cast."\n[-1]: Draft a card from Garruk, Wrath of the Wild's spellbook and put it onto the battlefield.\n[-6]: Until end of turn, creatures you control get +3/+3 and gain trample.

--- a/forge-gui/res/cardsfolder/g/geist_of_regret.txt
+++ b/forge-gui/res/cardsfolder/g/geist_of_regret.txt
@@ -1,7 +1,7 @@
 Name:Geist of Regret
 ManaCost:4 U
 Types:Creature Spirit
-PT:4/5
+PT:5/5
 K:Flying
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChangeInstant | TriggerDescription$ When CARDNAME enters the battlefield, put a random instant card from your library into your graveyard. Then put a random sorcery card from your library into your graveyard.
 SVar:TrigChangeInstant:DB$ ChangeZone | Origin$ Library | Destination$ Graveyard | ChangeType$ Instant.YouOwn | ChangeNum$ 1 | Hidden$ True | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | SubAbility$ DBChangeSorcery

--- a/forge-gui/res/cardsfolder/p/painful_bond.txt
+++ b/forge-gui/res/cardsfolder/p/painful_bond.txt
@@ -2,8 +2,8 @@ Name:Painful Bond
 ManaCost:1 B
 Types:Instant
 A:SP$ Draw | Cost$ 1 B | NumCards$ 2 | SubAbility$ DBEffect | SpellDescription$ Draw two cards, then cards in your hand with mana value 3 or greater perpetually gain "When you cast this spell, you lose 1 life."
-SVar:DBEffect:DB$ Effect | RememberObjects$ ValidHand Card.cmcLE3+YouOwn | StaticAbilities$ PerpetualAbility | Duration$ Permanent | Triggers$ Update | Name$ Painful Bond's Perpetual Effect | StackDescription$ Then cards in {p:You}'s hand with mana value 3 or greater perpetually gain "When you cast this spell, you lose 1 life."
-SVar:PerpetualAbility:Mode$ Continuous | Affected$ Card.IsRemembered | AddTrigger$ CastSpellLoseLife | EffectZone$ Command | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | Description$ Cards in your hand with mana value 3 or greater perpetually gain "When you cast this spell, you lose 1 life."
+SVar:DBEffect:DB$ Effect | RememberObjects$ ValidHand Card.cmcLE3+YouOwn | StaticAbilities$ PerpetualAbility | Duration$ Permanent | Triggers$ Update | Name$ Painful Bond's Perpetual Effect | StackDescription$ Then cards in {p:You}'s hand with mana value 3 or less perpetually gain "When you cast this spell, you lose 1 life."
+SVar:PerpetualAbility:Mode$ Continuous | Affected$ Card.IsRemembered | AddTrigger$ CastSpellLoseLife | EffectZone$ Command | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | Description$ Cards in your hand with mana value 3 or less perpetually gain "When you cast this spell, you lose 1 life."
 SVar:CastSpellLoseLife:Mode$ SpellCast | ValidCard$ Card.Self | Execute$ TrigDrain | TriggerDescription$ When you cast this spell, you lose 1 life.
 SVar:TrigDrain:DB$ LoseLife | LifeAmount$ 1
 SVar:Update:Mode$ ChangesZone | Origin$ Any | Destination$ Any | Static$ True | ValidCard$ Card.IsRemembered | Execute$ DBUpdate

--- a/forge-gui/res/cardsfolder/p/painful_bond.txt
+++ b/forge-gui/res/cardsfolder/p/painful_bond.txt
@@ -2,10 +2,10 @@ Name:Painful Bond
 ManaCost:1 B
 Types:Instant
 A:SP$ Draw | Cost$ 1 B | NumCards$ 2 | SubAbility$ DBEffect | SpellDescription$ Draw two cards, then cards in your hand with mana value 3 or greater perpetually gain "When you cast this spell, you lose 1 life."
-SVar:DBEffect:DB$ Effect | RememberObjects$ ValidHand Card.cmcGE3+YouOwn | StaticAbilities$ PerpetualAbility | Duration$ Permanent | Triggers$ Update | Name$ Painful Bond's Perpetual Effect | StackDescription$ Then cards in {p:You}'s hand with mana value 3 or greater perpetually gain "When you cast this spell, you lose 1 life."
+SVar:DBEffect:DB$ Effect | RememberObjects$ ValidHand Card.cmcLE3+YouOwn | StaticAbilities$ PerpetualAbility | Duration$ Permanent | Triggers$ Update | Name$ Painful Bond's Perpetual Effect | StackDescription$ Then cards in {p:You}'s hand with mana value 3 or greater perpetually gain "When you cast this spell, you lose 1 life."
 SVar:PerpetualAbility:Mode$ Continuous | Affected$ Card.IsRemembered | AddTrigger$ CastSpellLoseLife | EffectZone$ Command | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | Description$ Cards in your hand with mana value 3 or greater perpetually gain "When you cast this spell, you lose 1 life."
 SVar:CastSpellLoseLife:Mode$ SpellCast | ValidCard$ Card.Self | Execute$ TrigDrain | TriggerDescription$ When you cast this spell, you lose 1 life.
 SVar:TrigDrain:DB$ LoseLife | LifeAmount$ 1
 SVar:Update:Mode$ ChangesZone | Origin$ Any | Destination$ Any | Static$ True | ValidCard$ Card.IsRemembered | Execute$ DBUpdate
 SVar:DBUpdate:DB$ UpdateRemember
-Oracle:Draw two cards, then cards in your hand with mana value 3 or greater perpetually gain "When you cast this spell, you lose 1 life."
+Oracle:Draw two cards, then cards in your hand with mana value 3 or less perpetually gain "When you cast this spell, you lose 1 life."

--- a/forge-gui/res/cardsfolder/rebalanced/a-omnath_locus_of_creation.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-omnath_locus_of_creation.txt
@@ -2,12 +2,12 @@ Name:A-Omnath, Locus of Creation
 ManaCost:1 R G W U
 Types:Legendary Creature Elemental
 PT:4/4
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters the battlefield, scry 1.
-SVar:TrigScry:DB$ Scry | ScryNum$ 1
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ When CARDNAME enters the battlefield, draw a card.
+SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | TriggerZones$ Battlefield | Execute$ DBGainLife | TriggerDescription$ Landfall - Whenever a land enters the battlefield under your control, you gain 4 life if this is the first time this ability has resolved this turn. If it's the second time, add {R}{G}{W}{U}. If it's the third time, CARDNAME deals 4 damage to each opponent and each planeswalker you don't control.
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 4 | ConditionCheckSVar$ LandfallAmount | ConditionSVarCompare$ EQ1 | SubAbility$ DBMana
 SVar:DBMana:DB$ Mana | Produced$ R G W U | ConditionCheckSVar$ LandfallAmount | ConditionSVarCompare$ EQ2 | SubAbility$ DBDamageAll
 SVar:DBDamageAll:DB$ DamageAll | ValidPlayers$ Opponent | ValidCards$ Planeswalker.YouDontCtrl | NumDmg$ 4 | ConditionCheckSVar$ LandfallAmount | ConditionSVarCompare$ EQ3
 SVar:LandfallAmount:Count$ResolvedThisTurn
 DeckHas:Ability$LifeGain
-Oracle:When Omnath, Locus of Creation enters the battlefield, scry 1.\nLandfall — Whenever a land enters the battlefield under your control, you gain 4 life if this is the first time this ability has resolved this turn. If it's the second time, add {R}{G}{W}{U}. If it's the third time, Omnath deals 4 damage to each opponent and each planeswalker you don't control.
+Oracle:When Omnath, Locus of Creation enters the battlefield, draw a card.\nLandfall — Whenever a land enters the battlefield under your control, you gain 4 life if this is the first time this ability has resolved this turn. If it's the second time, add {R}{G}{W}{U}. If it's the third time, Omnath deals 4 damage to each opponent and each planeswalker you don't control.

--- a/forge-gui/res/cardsfolder/s/semblance_scanner.txt
+++ b/forge-gui/res/cardsfolder/s/semblance_scanner.txt
@@ -1,7 +1,7 @@
 Name:Semblance Scanner
 ManaCost:2 U
 Types:Artifact Creature Equipment Shapeshifter
-PT:3/1
+PT:3/2
 T:Mode$ DamageDone | ValidSource$ Card.Self+nonToken,Creature.EquippedBy+nonToken | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigConjure | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME or equipped creature deals combat damage to a player, if it's not a token, conjure a duplicate of it into your hand.
 SVar:TrigConjure:DB$ MakeCard | DefinedName$ TriggeredSource | Zone$ Hand
 K:Reconfigure:1

--- a/forge-gui/res/cardsfolder/s/settle_the_wilds.txt
+++ b/forge-gui/res/cardsfolder/s/settle_the_wilds.txt
@@ -1,5 +1,5 @@
 Name:Settle the Wilds
-ManaCost:1 G G
+ManaCost:2 G
 Types:Sorcery
 A:SP$ ChangeZone | Origin$ Library | Destination$ Battlefield | Tapped$ True | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | NoReveal$ True | ChangeType$ Land.Basic | ChangeNum$ 1 | SubAbility$ DBSeek | StackDescription$ SpellDescription | SpellDescription$ Seek a basic land card and put it onto the battlefield tapped.
 SVar:DBSeek:DB$ ChangeZone | Origin$ Library | Destination$ Hand | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | NoReveal$ True | ChangeType$ Permanent.cmcEQX | ChangeNum$ 1 | StackDescription$ SpellDescription | SpellDescription$ Then seek a permanent card with mana value equal to the number of lands you control.

--- a/forge-gui/res/cardsfolder/s/swarm_saboteur.txt
+++ b/forge-gui/res/cardsfolder/s/swarm_saboteur.txt
@@ -1,7 +1,7 @@
 Name:Swarm Saboteur
 ManaCost:1 B
 Types:Creature Human Ninja
-PT:2/1
+PT:2/2
 K:Ninjutsu:1 B
 K:Deathtouch
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigConjure | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, conjure a card named Virus Beetle into your hand.

--- a/forge-gui/res/cardsfolder/t/tireless_angler.txt
+++ b/forge-gui/res/cardsfolder/t/tireless_angler.txt
@@ -1,7 +1,7 @@
 Name:Tireless Angler
 ManaCost:2 U
 Types:Creature Human Rogue
-PT:1/4
+PT:2/4
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Island.YouCtrl,Swamp.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigDraft | TriggerDescription$ Whenever an Island or Swamp enters the battlefield under your control, draft a card from CARDNAME's spellbook.
 SVar:TrigDraft:DB$ NameCard | Draft$ True | Defined$ You | ChooseFromList$ Fleet Swallower,Moat Piranhas,Mystic Skyfish,Nadir Kraken,Pouncing Shoreshark,Sea-Dasher Octopus,Spined Megalodon,Stinging Lionfish,Voracious Greatshark,Archipelagore,Serpent of Yawning Depths,Wormhole Serpent,Sigiled Starfish,Riptide Turtle,Ruin Crab | SubAbility$ DBMakeCard
 SVar:DBMakeCard:DB$ MakeCard | Name$ ChosenName | Zone$ Hand | SubAbility$ DBCleanup

--- a/forge-gui/res/cardsfolder/v/veteran_ghoulcaller.txt
+++ b/forge-gui/res/cardsfolder/v/veteran_ghoulcaller.txt
@@ -1,7 +1,7 @@
 Name:Veteran Ghoulcaller
 ManaCost:1 B
 Types:Creature Human Rogue
-PT:2/1
+PT:2/2
 K:Menace
 T:Mode$ ChangesZone | Origin$ Graveyard | Destination$ Hand | ValidCard$ Card.YouOwn | TriggerZones$ Battlefield | Execute$ TrigConjure | TriggerDescription$ Whenever a card in your graveyard is put into your hand, conjure a duplicate of that card into your hand.
 SVar:TrigConjure:DB$ MakeCard | DefinedName$ TriggeredCard | Zone$ Hand


### PR DESCRIPTION
Source: https://magic.wizards.com/en/articles/archive/magic-digital/alchemy-rebalancing-may-5-2022

All cards are Alchemy only so no need for new scripts