### PR TITLE
Adventure mode - Revert RNG

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/pointofintrest/PointOfInterestChanges.java
+++ b/forge-gui-mobile/src/forge/adventure/pointofintrest/PointOfInterestChanges.java
@@ -11,19 +11,18 @@ import java.util.HashSet;
  * Class to save point of interest changes, like sold cards and dead enemies
  */
 public class PointOfInterestChanges implements SaveFileContent  {
+    private final HashSet<Integer> deletedObjects=new HashSet<>();
+    private final HashMap<Integer, HashSet<Integer>> cardsBought = new HashMap<>();
+    private java.util.Map<String, Byte> mapFlags = new HashMap<>();
 
-    public static class Map extends HashMap<String,PointOfInterestChanges> implements SaveFileContent
-    {
-
+    public static class Map extends HashMap<String,PointOfInterestChanges> implements SaveFileContent {
         @Override
         public void load(SaveFileData data) {
-
             this.clear();
-            if(data==null||!data.containsKey("keys"))
-                return;
+            if(data==null || !data.containsKey("keys")) return;
+
             String[] keys= (String[]) data.readObject("keys");
-            for(int i=0;i<keys.length;i++)
-            {
+            for(int i=0;i<keys.length;i++) {
                 SaveFileData elementData = data.readSubData("value_"+i);
                 PointOfInterestChanges newChanges=new PointOfInterestChanges();
                 newChanges.load(elementData);
@@ -66,35 +65,21 @@ public class PointOfInterestChanges implements SaveFileContent  {
         return data;
     }
 
-    private final HashSet<Integer> deletedObjects=new HashSet<>();
-    private final HashMap<Integer, HashSet<Integer>> cardsBought=new HashMap<>();
-    private java.util.Map<String, Byte> mapFlags = new HashMap<>();
-
-    public boolean isObjectDeleted(int objectID)
-    {
-        return deletedObjects.contains(objectID);
-    }
-    public boolean deleteObject(int objectID)
-    {
-        return deletedObjects.add(objectID);
-    }
+    public boolean isObjectDeleted(int objectID) { return deletedObjects.contains(objectID); }
+    public boolean deleteObject(int objectID)    { return deletedObjects.add(objectID); }
 
     public java.util.Map<String, Byte> getMapFlags() {
         return mapFlags;
     }
 
-    public void buyCard(int objectID, int cardIndex)
-    {
-        if( !cardsBought.containsKey(objectID))
-        {
+    public void buyCard(int objectID, int cardIndex) {
+        if( !cardsBought.containsKey(objectID)) {
             cardsBought.put(objectID,new HashSet<>());
         }
         cardsBought.get(objectID).add(cardIndex);
     }
-    public boolean wasCardBought(int objectID, int cardIndex)
-    {
-        if( !cardsBought.containsKey(objectID))
-        {
+    public boolean wasCardBought(int objectID, int cardIndex) {
+        if( !cardsBought.containsKey(objectID)) {
             return false;
         }
         return cardsBought.get(objectID).contains(cardIndex);

--- a/forge-gui-mobile/src/forge/adventure/scene/RewardScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/RewardScene.java
@@ -269,25 +269,25 @@ public class RewardScene extends UIScene {
             addListener(new ClickListener() {
                 @Override
                 public void clicked(InputEvent event, float x, float y) {
-                    if (Current.player().getGold() >= price) {
-                        if(changes!=null)
-                            changes.buyCard(objectID, index);
-                        Current.player().takeGold(price);
-                        Current.player().addReward(reward.getReward());
+                if (Current.player().getGold() >= price) {
+                    if(changes!=null)
+                        changes.buyCard(objectID, index);
+                    Current.player().takeGold(price);
+                    Current.player().addReward(reward.getReward());
 
-                        Gdx.input.vibrate(5);
-                        SoundSystem.instance.play(SoundEffectType.FlipCoin, false);
+                    Gdx.input.vibrate(5);
+                    SoundSystem.instance.play(SoundEffectType.FlipCoin, false);
 
-                        updateBuyButtons();
-                        goldLabel.setText("Gold: " + String.valueOf(AdventurePlayer.current().getGold()));
-                        if(changes==null)
-                            return;
-                        setDisabled(true);
-                        reward.sold();
-                        getColor().a = 0.5f;
-                        setText("SOLD");
-                        removeListener(this);
-                    }
+                    updateBuyButtons();
+                    goldLabel.setText("Gold: " + String.valueOf(AdventurePlayer.current().getGold()));
+                    if(changes==null)
+                        return;
+                    setDisabled(true);
+                    reward.sold();
+                    getColor().a = 0.5f;
+                    setText("SOLD");
+                    removeListener(this);
+                }
                 }
             });
         }

--- a/forge-gui-mobile/src/forge/adventure/stage/MapStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/MapStage.java
@@ -373,7 +373,7 @@ public class MapStage extends GameStage {
                     case "shop":
                         String shopList = prop.get("shopList").toString();
                         shopList=shopList.replaceAll("\\s","");
-                        List possibleShops = Arrays.asList(shopList.split(","));
+                        List<String> possibleShops = Arrays.asList(shopList.split(","));
                         Array<ShopData> shops;
                         if (possibleShops.size() == 0 || shopList.equals(""))
                             shops = WorldData.getShopList();
@@ -385,8 +385,7 @@ public class MapStage extends GameStage {
                                 }
                             }
                         }
-                        if (shops.size == 0)
-                            continue;
+                        if(shops.size == 0) continue;
 
                         ShopData data = shops.get(WorldSave.getCurrentSave().getWorld().getRandom().nextInt(shops.size));
                         Array<Reward> ret = new Array<>();
@@ -406,6 +405,8 @@ public class MapStage extends GameStage {
                             }
                         }
                         break;
+                    default:
+                        System.err.println("Unexpected value: " + type);
                 }
             }
         }
@@ -494,16 +495,14 @@ public class MapStage extends GameStage {
         }
         currentMob = null;
     }
-    public void removeAllEnemies()
-    {
+    public void removeAllEnemies() {
         List<Integer> idsToRemove=new ArrayList<>();
         for (MapActor actor : new Array.ArrayIterator<>(actors)) {
-                if (actor instanceof EnemySprite) {
-                    idsToRemove.add(actor.getObjectId());
-                }
+            if (actor instanceof EnemySprite) {
+                idsToRemove.add(actor.getObjectId());
+            }
         }
-        for(Integer i:idsToRemove)
-            deleteObject(i);
+        for(Integer i:idsToRemove) deleteObject(i);
     }
 
     @Override

--- a/forge-gui-mobile/src/forge/adventure/world/World.java
+++ b/forge-gui-mobile/src/forge/adventure/world/World.java
@@ -22,7 +22,7 @@ import forge.adventure.util.Config;
 import forge.adventure.util.Paths;
 import forge.adventure.util.SaveFileContent;
 import forge.adventure.util.SaveFileData;
-import forge.util.MyRandom;
+//import forge.util.MyRandom;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.ArrayList;

--- a/forge-gui-mobile/src/forge/adventure/world/World.java
+++ b/forge-gui-mobile/src/forge/adventure/world/World.java
@@ -46,7 +46,7 @@ public class World implements  Disposable, SaveFileContent {
     private PointOfInterestMap mapPoiIds;
     private BiomeTexture[] biomeTexture;
     private long seed;
-    private final Random random = MyRandom.getRandom();
+    private final Random random = new Random();
     private boolean worldDataLoaded=false;
     private Texture globalTexture = null;
 


### PR DESCRIPTION
This will revert shops back to being handled consistently. Temporary solution, most changes are code re-arranging to prepare for more drastic changes.
The current design for shops doesn't allow for easy dynamic changes, it's going to need to be rewritten so PointOfInterestChanges saves the type and current contents of a shop. As it is, a world will always generate a limited amount of cards unless that's done.