### PR TITLE
[Adventure] Refactor GameHud

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/stage/GameHUD.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/GameHUD.java
@@ -48,7 +48,7 @@ public class GameHUD extends Stage {
         instance = this;
         this.gameStage = gameStage;
 
-        ui = new UIActor(Config.instance().getFile(Forge.isLandscapeMode()?"ui/hud.json":"ui/hud_portrait.json"));
+        ui = new UIActor(Config.instance().getFile(GuiBase.isAndroid() ? Forge.isLandscapeMode()?"ui/hud_landscape.json" : "ui/hud_portrait.json" : "ui/hud.json"));
 
         blank = ui.findActor("blank");
         miniMap = ui.findActor("map");
@@ -144,12 +144,8 @@ public class GameHUD extends Stage {
 
         float x=(c.x-miniMap.getX())/miniMap.getWidth();
         float y=(c.y-miniMap.getY())/miniMap.getHeight();
-        float mMapX = ui.findActor("map").getX();
-        float mMapY = ui.findActor("map").getY();
-        float mMapT = ui.findActor("map").getTop();
-        float mMapR = ui.findActor("map").getRight();
         //map bounds
-        if (c.x>=mMapX&&c.x<=mMapR&&c.y>=mMapY&&c.y<=mMapT) {
+        if (Controls.actorContainsVector(miniMap,c)) {
             touchpad.setVisible(false);
             if (MapStage.getInstance().isInMap())
                 return true;
@@ -163,10 +159,6 @@ public class GameHUD extends Stage {
     @Override
     public boolean touchDown(int screenX, int screenY, int pointer, int button)
     {
-        return setPosition(screenX, screenY, pointer, button);
-    }
-
-    boolean setPosition(int screenX, int screenY, int pointer, int button) {
         Vector2 c=new Vector2();
         Vector2 touch =new Vector2();
         screenToStageCoordinates(touch.set(screenX, screenY));
@@ -174,48 +166,31 @@ public class GameHUD extends Stage {
 
         float x=(c.x-miniMap.getX())/miniMap.getWidth();
         float y=(c.y-miniMap.getY())/miniMap.getHeight();
-
-
-        float uiX = gamehud.getX();
-        float uiY = gamehud.getY();
-        float uiTop = gamehud.getTop();
-        float uiRight = gamehud.getRight();
-        //gamehud bounds
-        if (c.x>=uiX&&c.x<=uiRight&&c.y>=uiY&&c.y<=uiTop) {
+        if (Controls.actorContainsVector(gamehud,c)) {
             super.touchDown(screenX, screenY, pointer, button);
             return true;
         }
-
-        float mMapX = miniMap.getX();
-        float mMapY = miniMap.getY();
-        float mMapT = miniMap.getTop();
-        float mMapR = miniMap.getRight();
-        //map bounds
-        if (c.x>=mMapX&&c.x<=mMapR&&c.y>=mMapY&&c.y<=mMapT) {
+        if (Controls.actorContainsVector(miniMap,c)) {
             if (MapStage.getInstance().isInMap())
                 return true;
             if(Current.isInDebug())
                 WorldStage.getInstance().GetPlayer().setPosition(x*WorldSave.getCurrentSave().getWorld().getWidthInPixels(),y*WorldSave.getCurrentSave().getWorld().getHeightInPixels());
             return true;
         }
-        //display bounds
-        float displayX = ui.getX();
-        float displayY = ui.getY();
-        float displayT = ui.getTop();
-        float displayR = ui.getRight();
-        //menu Y bounds
-        float menuY = menuActor.getY();
         //auto follow touchpad
         if (GuiBase.isAndroid()) {
-            if (!(touch.x>=mMapX&&touch.x<=mMapR&&touch.y>=mMapY&&touch.y<=mMapT) // not inside map bounds
-                    && !(touch.x>=uiX&&touch.x<=uiRight&&touch.y>=menuY&&touch.y<=uiTop) //not inside gamehud bounds and menu Y bounds
-                    && (touch.x>=displayX&&touch.x<=displayR&&touch.y>=displayY&&touch.y<=displayT) //inside display bounds
+            if (!(Controls.actorContainsVector(miniMap,touch)) // not inside map bounds
+                    && !(Controls.actorContainsVector(gamehud,touch)) //not inside gamehud bounds
+                    && !(Controls.actorContainsVector(menuActor,touch)) //not inside menu button
+                    && !(Controls.actorContainsVector(deckActor,touch)) //not inside deck button
+                    && !(Controls.actorContainsVector(statsActor,touch)) //not inside stats button
+                    && !(Controls.actorContainsVector(inventoryActor,touch)) //not inside inventory button
+                    && (Controls.actorContainsVector(ui,touch)) //inside display bounds
                     && pointer < 1) { //not more than 1 pointer
                 touchpad.setBounds(touch.x-TOUCHPAD_SCALE/2, touch.y-TOUCHPAD_SCALE/2, TOUCHPAD_SCALE, TOUCHPAD_SCALE);
                 touchpad.setVisible(true);
                 touchpad.setResetOnTouchUp(true);
-                if (!Forge.isLandscapeMode())
-                    hideButtons();
+                hideButtons();
                 return super.touchDown(screenX, screenY, pointer, button);
             }
         }
@@ -292,12 +267,10 @@ public class GameHUD extends Stage {
             return true;
         }
         if (keycode == Input.Keys.BACK) {
-            if (!Forge.isLandscapeMode()) {
-                menuActor.setVisible(!menuActor.isVisible());
-                statsActor.setVisible(!statsActor.isVisible());
-                inventoryActor.setVisible(!inventoryActor.isVisible());
-                deckActor.setVisible(!deckActor.isVisible());
-            }
+            menuActor.setVisible(!menuActor.isVisible());
+            statsActor.setVisible(!statsActor.isVisible());
+            inventoryActor.setVisible(!inventoryActor.isVisible());
+            deckActor.setVisible(!deckActor.isVisible());
         }
         return super.keyDown(keycode);
     }

--- a/forge-gui-mobile/src/forge/adventure/util/Controls.java
+++ b/forge-gui-mobile/src/forge/adventure/util/Controls.java
@@ -30,7 +30,8 @@ public class Controls {
         return new Rectangle(actor.getX(),actor.getY(),actor.getWidth(),actor.getHeight());
     }
     static public boolean actorContainsVector (Actor actor, Vector2 point) {
-
+        if (!actor.isVisible())
+            return false;
         return getBoundingRect(actor).contains(point);
     }
 

--- a/forge-gui/res/adventure/Shandalar/ui/hud_landscape.json
+++ b/forge-gui/res/adventure/Shandalar/ui/hud_landscape.json
@@ -1,0 +1,114 @@
+{
+  "width": 480,
+  "height": 270,
+  "yDown": true,
+  "elements": [
+    {
+      "type": "Image",
+      "name": "gamehud",
+      "width": 64,
+      "height": 104,
+      "image": "ui/hud_portrait.png",
+      "x": 416,
+      "y": 0
+    },
+    {
+      "type": "Image",
+      "name": "map",
+      "width": 80,
+      "height": 80,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "type": "Image",
+      "name": "mapborder",
+      "image": "ui/minimap.png",
+      "width": 80,
+      "height": 80,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "type": "Image",
+      "name": "blank",
+      "image": "ui/blank.png",
+      "width": 46,
+      "height": 46,
+      "x": 425,
+      "y": 10
+    },
+    {
+      "type": "Image",
+      "name": "avatar",
+      "width": 46,
+      "height": 46,
+      "x": 425,
+      "y": 10
+    },
+    {
+      "type": "Image",
+      "name": "avatarborder",
+      "image": "ui/avatarhud.png",
+      "width": 46,
+      "height": 46,
+      "x": 425,
+      "y": 10
+    },
+    {
+      "type": "Label",
+      "name": "lifePoints",
+      "font": "default",
+      "width": 64,
+      "height": 16,
+      "x": 442,
+      "y": 64
+    },
+    {
+      "type": "Label",
+      "name": "money",
+      "font": "default",
+      "width": 64,
+      "height": 16,
+      "x": 442,
+      "y": 82
+    },
+    {
+      "type": "TextButton",
+      "name": "deck",
+      "text": "Deck",
+      "width": 40,
+      "height": 36,
+      "x": 428,
+      "y": 106
+    },
+    {
+      "type": "TextButton",
+      "name": "inventory",
+      "text": "Inventory",
+      "width": 40,
+      "height": 36,
+      "x": 428,
+      "y": 146
+    },
+
+    {
+      "type": "TextButton",
+      "name": "statistic",
+      "text": "Status",
+      "width": 40,
+      "height": 36,
+      "x": 428,
+      "y": 186
+    },
+    {
+      "type": "TextButton",
+      "name": "menu",
+      "text": "Menu",
+      "width": 40,
+      "height": 36,
+      "x": 428,
+      "y": 226
+    }
+  ]
+}


### PR DESCRIPTION
Make GameHud controls/layout for Android landscape mode identical to Android portrait mode. Desktop Adventure mode retains previous layout and controls.