### PR TITLE
Make Witness the Future AI playable.

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/PumpAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PumpAi.java
@@ -398,7 +398,7 @@ public class PumpAi extends PumpAiBase {
 
         if (!mandatory
                 && !immediately
-                && game.getPhaseHandler().getPhase().isAfter(PhaseType.COMBAT_DECLARE_BLOCKERS)
+                && (game.getPhaseHandler().getPhase().isAfter(PhaseType.COMBAT_DECLARE_BLOCKERS) && !"AnyPhase".equals(sa.getParam("AILogic")))
                 && !(sa.isCurse() && defense < 0)
                 && !containsNonCombatKeyword(keywords)
                 && !"UntilYourNextTurn".equals(sa.getParam("Duration"))

--- a/forge-gui/res/cardsfolder/w/witness_the_future.txt
+++ b/forge-gui/res/cardsfolder/w/witness_the_future.txt
@@ -1,8 +1,7 @@
 Name:Witness the Future
 ManaCost:2 U
 Types:Sorcery
-A:SP$ Pump | ValidTgts$ Player | TgtPrompt$ Select target player | SubAbility$ DBChangeZone | StackDescription$ {p:Targeted} | SpellDescription$ Target player
+A:SP$ Pump | ValidTgts$ Player | TgtPrompt$ Select target player | SubAbility$ DBChangeZone | AILogic$ AnyPhase | StackDescription$ {p:Targeted} | SpellDescription$ Target player
 SVar:DBChangeZone:DB$ ChangeZone | TargetMin$ 0 | TargetMax$ 4 | TargetsWithDefinedController$ ParentTarget | Origin$ Graveyard | Destination$ Library | Shuffle$ True | TgtPrompt$ Select up to four target cards | ValidTgts$ Card | SubAbility$ DBDig | StackDescription$ SpellDescription | SpellDescription$ shuffles up to four target cards from their graveyard into their library.
 SVar:DBDig:DB$ Dig | DigNum$ 4 | ChangeNum$ 1 | RestRandomOrder$ True | StackDescription$ SpellDescription | SpellDescription$ You look at the top four cards of your library, then put one of those cards into your hand and the rest on the bottom of your library in a random order.
-AI:RemoveDeck:All
 Oracle:Target player shuffles up to four target cards from their graveyard into their library. You look at the top four cards of your library, then put one of those cards into your hand and the rest on the bottom of your library in a random order.


### PR DESCRIPTION
A simple tweak to make the card playable - since the Pump here is "fake", the ordinary AI rules for its playability clashed with those of ChangeZone+Dig :)