### PR TITLE
NCC: 9 April

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/parnesse_the_subtle_brush.txt
+++ b/forge-gui/res/cardsfolder/upcoming/parnesse_the_subtle_brush.txt
@@ -1,0 +1,11 @@
+Name:Parnesse, the Subtle Brush
+ManaCost:2 U B R
+Types:Legendary Creature Vampire Wizard
+PT:4/4
+T:Mode$ BecomesTarget | ValidTarget$ You,Permanent.YouCtrl+inZoneBattlefield | ValidSource$ Card.OppCtrl | TriggerZones$ Battlefield | Execute$ TrigCounter | TriggerDescription$ Whenever you or a permanent you control becomes the target of a spell or ability an opponent controls, counter that spell or ability unless that player pays 4 life.
+SVar:TrigCounter:DB$ Counter | Defined$ TriggeredSourceSA | UnlessCost$ PayLife<4> | UnlessPayer$ TriggeredSourceSAController
+T:Mode$ SpellCopy | ValidActivatingPlayer$ You | NoResolvingCheck$ True | TriggerZones$ Battlefield | Execute$ TrigTarget | TriggerDescription$ Whenever you copy a spell, up to one target opponent may also copy that spell. They may choose new targets for that copy.
+SVar:TrigTarget:DB$ Pump | ValidTgts$ Opponent | SubAbility$ DBCopy
+SVar:DBCopy:DB$ CopySpellAbility | TargetMin$ 0 | TargetMax$ 1 | Defined$ TriggeredSpellAbility | AILogic$ Always | Controller$ Targeted | Optional$ True | MayChooseTarget$ True
+AI:RemoveDeck:Random
+Oracle:Whenever you or a permanent you control becomes the target of a spell or ability an opponent controls, counter that spell or ability unless that player pays 4 life.\nWhenever you copy a spell, up to one target opponent may also copy that spell. They may choose new targets for that copy.

--- a/forge-gui/res/cardsfolder/upcoming/syrix_carrier_of_the_flame.txt
+++ b/forge-gui/res/cardsfolder/upcoming/syrix_carrier_of_the_flame.txt
@@ -1,0 +1,22 @@
+Name:Syrix, Carrier of the Flame
+ManaCost:2 B R
+Types:Legendary Creature Phoenix
+PT:3/3
+K:Flying
+K:Haste
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ Player | Execute$ TrigPhoenix | CheckSVar$ X | TriggerDescription$ At the beginning of each end step, if a creature card left your graveyard this turn, target Phoenix you control deals damage equal to its power to any target.
+SVar:TrigPhoenix:DB$ Pump | ValidTgts$ Phoenix.YouCtrl | AILogic$ PowerDmg | TgtPrompt$ Select target Phoenix you control | SubAbility$ DBDamage
+SVar:DBDamage:DB$ DealDamage | ValidTgts$ Creature,Player,Planeswalker | AILogic$ PowerDmg | TgtPrompt$ Select any target | NumDmg$ Y | DamageSource$ ParentTarget
+SVar:Y:ParentTargeted$CardPower
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Phoenix.Other+YouCtrl | TriggerZones$ Graveyard | Execute$ TrigPlay | OptionalDecider$ You | TriggerDescription$ Whenever another Phoenix you control dies, you may cast CARDNAME from your graveyard.
+SVar:TrigPlay:DB$ Play | Optional$ True
+T:Mode$ ChangesZone | Origin$ Graveyard | Destination$ Any | ValidCard$ Card.Creature+YouOwn | Execute$ Tally | CheckSVar$ X | SVarCompare$ EQ0 | Static$ True
+SVar:Tally:DB$ StoreSVar | SVar$ X | Type$ Number | Expression$ 1
+SVar:X:Number$0
+T:Mode$ TurnBegin | Execute$ TrigReset | Static$ True
+SVar:TrigReset:DB$ StoreSVar | SVar$ X | Type$ Number | Expression$ 0
+DeckNeeds:Type$Phoenix
+DeckHints:Ability$Graveyard
+DeckHas:Ability$Graveyard
+#SVar:X:Count$ThisTurnEntered_Any_from_Graveyard_Creature.YouOwn
+Oracle:Flying, haste\nAt the beginning of each end step, if a creature card left your graveyard this turn, target Phoenix you control deals damage equal to its power to any target.\nWhenever another Phoenix you control dies, you may cast Syrix, Carrier of the Flame from your graveyard.

--- a/forge-gui/res/cardsfolder/upcoming/syrix_carrier_of_the_flame.txt
+++ b/forge-gui/res/cardsfolder/upcoming/syrix_carrier_of_the_flame.txt
@@ -18,5 +18,4 @@ SVar:TrigReset:DB$ StoreSVar | SVar$ X | Type$ Number | Expression$ 0
 DeckNeeds:Type$Phoenix
 DeckHints:Ability$Graveyard
 DeckHas:Ability$Graveyard
-#SVar:X:Count$ThisTurnEntered_Any_from_Graveyard_Creature.YouOwn
 Oracle:Flying, haste\nAt the beginning of each end step, if a creature card left your graveyard this turn, target Phoenix you control deals damage equal to its power to any target.\nWhenever another Phoenix you control dies, you may cast Syrix, Carrier of the Flame from your graveyard.


### PR DESCRIPTION
A few pretty fiddly ones... no engine changes, though

We might potentially do Syrix later with:
```
SVar:X:Count$ThisTurnEntered_Any_from_Graveyard_Creature.YouOwn
```
Just need to support `Any` there

closes #303 
closes #304 