### PR TITLE
Fix missing check for mana abilities at instant speed

### DIFF
--- a/forge-game/src/main/java/forge/game/spellability/SpellAbilityRestriction.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbilityRestriction.java
@@ -581,6 +581,11 @@ public class SpellAbilityRestriction extends SpellAbilityVariables {
             }
         }
 
+        // Special check for Lion's Eye Diamond
+        if (sa.isManaAbility() && c.getGame().getStack().isFrozen() && isInstantSpeed()) {
+            return false;
+        }
+
         if (!sa.hasSVar("IsCastFromPlayEffect")) {
             if (!checkTimingRestrictions(c, sa)) {
                 return false;
@@ -620,6 +625,6 @@ public class SpellAbilityRestriction extends SpellAbilityVariables {
         }
 
         return true;
-    } // canPlay()
+    }
 
 }


### PR DESCRIPTION
> You can't cast an instant (or activate an ability as an instant) while casting a spell. Therefore, much like Lion's Eye Diamond, you can't activate the ability intending to use the mana to cast a spell from your hand. 

E.g. you could cheat by starting to cast a Sol Ring from your hand and then paying with _Lion's Eye Diamond_.