### PR TITLE
Fix Tezzeret, Betrayer of Flesh

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -1773,7 +1773,7 @@ public class AiController {
         }
         return toExile;
     }
-    
+
     public boolean doTrigger(SpellAbility spell, boolean mandatory) {
         if (spell instanceof WrappedAbility)
             return doTrigger(((WrappedAbility)spell).getWrappedAbility(), mandatory);
@@ -1785,7 +1785,7 @@ public class AiController {
         }
         return false;
     }
-    
+
     /**
      * Ai should run.
      *
@@ -1840,12 +1840,11 @@ public class AiController {
         } else if (effect.hasParam("AICheckDredge")) {
             return player.getCardsIn(ZoneType.Library).size() > 8 || player.isCardInPlay("Laboratory Maniac");
         } else return sa != null && doTrigger(sa, false);
-
     }
 
     public List<SpellAbility> chooseSaToActivateFromOpeningHand(List<SpellAbility> usableFromOpeningHand) {
         // AI would play everything. But limits to one copy of (Leyline of Singularity) and (Gemstone Caverns)
-        
+
         List<SpellAbility> result = Lists.newArrayList();
         for (SpellAbility sa : usableFromOpeningHand) {
             // Is there a better way for the AI to decide this?
@@ -1853,7 +1852,7 @@ public class AiController {
                 result.add(sa);
             }
         }
-        
+
         boolean hasLeyline1 = false;
         SpellAbility saGemstones = null;
 
@@ -1879,7 +1878,7 @@ public class AiController {
             result.remove(saGemstones);
             result.add(saGemstones);
         }
-        
+
         return result;
     }
 

--- a/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
@@ -273,8 +273,7 @@ public class ChangeZoneAi extends SpellAbilityAi {
                 }
             }
 
-            //Ninjutsu
-            if (sa.hasParam("Ninjutsu")) {
+            if (sa.isNinjutsu()) {
                 if (!source.ignoreLegendRule() && ai.isCardInPlay(source.getName())) {
                     return false;
                 }

--- a/forge-ai/src/main/java/forge/ai/ability/PermanentAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PermanentAi.java
@@ -54,7 +54,6 @@ public class PermanentAi extends SpellAbilityAi {
         // check on legendary
         if (!card.ignoreLegendRule() && ai.isCardInPlay(card.getName())) {
             // TODO check the risk we'd lose the effect with bad timing
-            // TODO check for keyword
             if (!card.hasSVar("AILegendaryException")) {
                 // AiPlayDecision.WouldDestroyLegend
                 return false;

--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
@@ -144,7 +144,7 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
                 sa.getParam("ChangeNum"), sa) : 1;
         boolean tapped = sa.hasParam("Tapped");
         boolean attacking = sa.hasParam("Attacking");
-        if (sa.hasParam("Ninjutsu")) {
+        if (sa.isNinjutsu()) {
             tapped = true;
             attacking = true;
         }
@@ -455,7 +455,7 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
             return;
         }
 
-        if (sa.isHidden() && !sa.hasParam("Ninjutsu")) {
+        if (sa.isHidden() && !sa.isNinjutsu()) {
             changeHiddenOriginResolve(sa);
         } else {
             //else if (isKnown(origin) || sa.containsKey("Ninjutsu")) {
@@ -599,7 +599,7 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
                 movedCard = game.getAction().moveToLibrary(gameCard, libraryPosition, sa);
             } else {
                 if (destination.equals(ZoneType.Battlefield)) {
-                    if (sa.hasParam("Tapped") || sa.hasParam("Ninjutsu")) {
+                    if (sa.hasParam("Tapped") || sa.isNinjutsu()) {
                         gameCard.setTapped(true);
                     }
                     if (sa.hasParam("Untapped")) {
@@ -713,7 +713,7 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
                     if (addToCombat(movedCard, movedCard.getController(), sa, "Attacking", "Blocking")) {
                         combatChanged = true;
                     }
-                    if (sa.hasParam("Ninjutsu")) {
+                    if (sa.isNinjutsu()) {
                         // Ninjutsu need to get the Defender of the Returned Creature
                         final Card returned = sa.getPaidList("Returned").getFirst();
                         final GameEntity defender = game.getCombat().getDefenderByAttacker(returned);

--- a/forge-game/src/main/java/forge/game/ability/effects/ManaEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ManaEffect.java
@@ -245,8 +245,6 @@ public class ManaEffect extends SpellAbilityEffect {
 
         // Only clear express choice after mana has been produced
         abMana.clearExpressChoice();
-
-        //resolveDrawback(sa);
     }
 
     /**

--- a/forge-game/src/main/java/forge/game/cost/CostAdjustment.java
+++ b/forge-game/src/main/java/forge/game/cost/CostAdjustment.java
@@ -433,8 +433,8 @@ public class CostAdjustment {
         if (!st.matchesValidParam("Activator", activator)) {
             return false;
         }
-        if (st.hasParam("NonActivatorTurn") && ((activator == null)
-                || hostCard.getGame().getPhaseHandler().isPlayerTurn(activator))) {
+        if (st.hasParam("NonActivatorTurn") && (activator == null
+                || game.getPhaseHandler().isPlayerTurn(activator))) {
             return false;
         }
 
@@ -469,6 +469,18 @@ public class CostAdjustment {
                 if (!sa.isActivatedAbility() || sa.isReplacementAbility()) {
                     return false;
                 }
+                if (st.hasParam("OnlyFirstActivation")) {
+                    int times = 0;
+                    for (IndividualCostPaymentInstance i : game.costPaymentStack) {
+                        SpellAbility paymentSa = i.getPayment().getAbility();
+                        if (paymentSa.isActivatedAbility() && st.matchesValidParam("ValidCard", paymentSa.getHostCard())) {
+                            times++;
+                            if (times > 1) {
+                                return false;
+                            }
+                        }
+                    }
+                }
             } else if (type.equals("NonManaAbility")) {
                 if (!sa.isActivatedAbility() || sa.isManaAbility() || sa.isReplacementAbility()) {
                     return false;
@@ -488,7 +500,7 @@ public class CostAdjustment {
         }
         if (st.hasParam("AffectedZone")) {
             List<ZoneType> zones = ZoneType.listValueOf(st.getParam("AffectedZone"));
-            if (sa.isSpell() && sa.getHostCard().wasCast()) {
+            if (sa.isSpell() && card.wasCast()) {
                 if (!zones.contains(card.getCastFrom().getZoneType())) {
                     return false;
                 }
@@ -508,7 +520,7 @@ public class CostAdjustment {
                     continue;
                 }
                 for (GameObject target : curSa.getTargets()) {
-                    if (target.isValid(st.getParam("ValidTarget").split(","), hostCard.getController(), hostCard, curSa)) {
+                    if (target.isValid(st.getParam("ValidTarget").split(","), controller, hostCard, curSa)) {
                         targetValid = true;
                         break outer;
                     }
@@ -533,7 +545,7 @@ public class CostAdjustment {
                 }
                 for (SpellAbility target : curSa.getTargets().getTargetSpells()) {
                     Card targetCard = target.getHostCard();
-                    if (targetCard.isValid(st.getParam("ValidSpellTarget").split(","), hostCard.getController(), hostCard, curSa)) {
+                    if (targetCard.isValid(st.getParam("ValidSpellTarget").split(","), controller, hostCard, curSa)) {
                         targetValid = true;
                         break outer;
                     }

--- a/forge-gui/res/cardsfolder/h/hematite_talisman.txt
+++ b/forge-gui/res/cardsfolder/h/hematite_talisman.txt
@@ -2,6 +2,6 @@ Name:Hematite Talisman
 ManaCost:2
 Types:Artifact
 T:Mode$ SpellCast | ValidCard$ Card.Red | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigUntap | TriggerDescription$ Whenever a player casts a red spell, you may pay {3}. If you do, untap target permanent.
-SVar:TrigUntap:AB$Untap | Cost$ 3 | ValidTgts$ Permanent | TgtPrompt$ Select target permanent
+SVar:TrigUntap:AB$ Untap | Cost$ 3 | ValidTgts$ Permanent | TgtPrompt$ Select target permanent
 AI:RemoveDeck:Random
 Oracle:Whenever a player casts a red spell, you may pay {3}. If you do, untap target permanent.

--- a/forge-gui/res/cardsfolder/s/shreds_of_sanity.txt
+++ b/forge-gui/res/cardsfolder/s/shreds_of_sanity.txt
@@ -1,7 +1,7 @@
 Name:Shreds of Sanity
 ManaCost:2 R
 Types:Sorcery
-A:SP$ ChangeZone | Cost$ 2 R | Origin$ Graveyard | Destination$ Hand | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Choose target instant card in your graveyard | ValidTgts$ Instant.YouCtrl | SpellDescription$ Return up to two target creature cards from your graveyard to your hand, then discard a card. | SubAbility$ DBReturn
+A:SP$ ChangeZone | Cost$ 2 R | Origin$ Graveyard | Destination$ Hand | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Choose target instant card in your graveyard | ValidTgts$ Instant.YouCtrl | SpellDescription$ Return up to one target instant card and up to one target sorcery card from your graveyard to your hand, then discard a card. Exile CARDNAME. | SubAbility$ DBReturn
 SVar:DBReturn:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | TargetMin$ 0 | TargetMax$ 1 | ValidTgts$ Sorcery.YouCtrl | TgtPrompt$ Select target sorcery card in your graveyard | SubAbility$ DBDiscard
 SVar:DBDiscard:DB$ Discard | Defined$ You | NumCards$ 1 | Mode$ TgtChoose | SubAbility$ DBExile
 SVar:DBExile:DB$ ChangeZone | Origin$ Stack | Destination$ Exile

--- a/forge-gui/res/cardsfolder/t/tezzeret_betrayer_of_flesh.txt
+++ b/forge-gui/res/cardsfolder/t/tezzeret_betrayer_of_flesh.txt
@@ -7,7 +7,7 @@ SVar:TrigStore:DB$ Pump | NoteNumber$ 1
 SVar:ArtAct:Count$NotedNumber
 T:Mode$ TurnBegin | Execute$ TrigReset | Static$ True
 SVar:TrigReset:DB$ Pump | NoteNumber$ 0
-S:Mode$ ReduceCost | ValidCard$ Artifact.YouCtrl | Type$ Ability | Amount$ 2 | CheckSVar$ ArtAct | SVarCompare$ NE1 | AffectedZone$ Battlefield | Description$ The first activated ability of an artifact you activate each turn costs {2} less to activate.
+S:Mode$ ReduceCost | ValidCard$ Artifact.YouCtrl | Type$ Ability | Amount$ 2 | CheckSVar$ ArtAct | SVarCompare$ NE1 | OnlyFirstActivation$ True | AffectedZone$ Battlefield | Description$ The first activated ability of an artifact you activate each turn costs {2} less to activate.
 A:AB$ Draw | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | NumCards$ 2 | SpellDescription$ Draw two cards. Then discard two cards unless you discard an artifact card. | SubAbility$ DBDiscard
 SVar:DBDiscard:DB$ Discard | Defined$ You | NumCards$ 2 | Mode$ TgtChoose | UnlessType$ Artifact
 A:AB$ Animate | Cost$ SubCounter<2/LOYALTY> | Planeswalker$ True | ValidTgts$ Artifact | Types$ Creature,Artifact | TgtPrompt$ Select target artifact | SubAbility$ NonVehicle | Duration$ Permanent | SpellDescription$ Target artifact becomes an artifact creature. If it isn't a vehicle, it has base power and toughness 4/4.


### PR DESCRIPTION
This fixes cheating when using multiple mana abilities from artifacts during one payment.

E.g. you could have activated _Doubling Cube_ for {1} and paid that with _Prismite_ for {0} still