### PR TITLE
Spy Kit Fix

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/EncodeEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/EncodeEffect.java
@@ -73,8 +73,6 @@ public class EncodeEffect extends SpellAbilityEffect {
         // store hostcard in encoded array
         choice.addEncodedCard(movedCard);
         movedCard.setEncodingCard(choice);
-
-        return;
     }
 
 }

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -5187,12 +5187,10 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
             } else if (getName().isEmpty()) {
                 // if this does not have a name, then there is no name to share
                 return false;
-            } else {
+            } else if (StaticData.instance().getCommonCards().isNonLegendaryCreatureName(getName())) {
                 // check if this card has a name from a face
                 // in general token creatures does not have this
-                // TODO add check if face is legal in the format of the game
-                // name does need to be a non-legendary creature
-                return StaticData.instance().getCommonCards().isNonLegendaryCreatureName(getName());
+                return true;
             }
         }
         return sharesNameWith(c1.getName());
@@ -5215,8 +5213,6 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
         if (!shares && hasNonLegendaryCreatureNames()) {
             // check if the name is from a face
             // in general token creatures does not have this
-            // TODO add check if face is legal in the format of the game
-            // name does need to be a non-legendary creature
             return StaticData.instance().getCommonCards().isNonLegendaryCreatureName(name);
         }
         return shares;

--- a/forge-gui/res/cardsfolder/s/skeletonize.txt
+++ b/forge-gui/res/cardsfolder/s/skeletonize.txt
@@ -2,7 +2,7 @@ Name:Skeletonize
 ManaCost:4 R
 Types:Instant
 A:SP$ DealDamage | NumDmg$ 3 | ValidTgts$ Creature | TgtPrompt$ Select target creature | RememberDamaged$ True | SubAbility$ DBDelayedTrigger | SpellDescription$ CARDNAME deals 3 damage to target creature. When a creature dealt damage this way dies this turn, create a 1/1 black Skeleton creature token with "{B}: Regenerate this creature."
-SVar:DBDelayedTrigger:DB$ DelayedTrigger | Mode$ ChangesZone | RememberObjects$ Targeted | ValidCard$ Card.IsTriggerRemembered | Origin$ Battlefield | Destination$ Graveyard | ThisTurn$ True | Execute$ TrigToken | TriggerDescription$ When a creature dealt damage this way dies this turn, create a 1/1 black Skeleton creature token with "{B}: Regenerate this creature."
+SVar:DBDelayedTrigger:DB$ DelayedTrigger | Mode$ ChangesZone | RememberObjects$ Remembered | ValidCard$ Card.IsTriggerRemembered | Origin$ Battlefield | Destination$ Graveyard | ThisTurn$ True | Execute$ TrigToken | TriggerDescription$ When a creature dealt damage this way dies this turn, create a 1/1 black Skeleton creature token with "{B}: Regenerate this creature."
 SVar:TrigToken:DB$ Token | TokenScript$ b_1_1_skeleton_regenerate
 DeckHas:Ability$Token
 Oracle:Skeletonize deals 3 damage to target creature. When a creature dealt damage this way dies this turn, create a 1/1 black Skeleton creature token with "{B}: Regenerate this creature."


### PR DESCRIPTION
For reference the previous version only returned if it was true:

```diff
-            final CardType type = face.getType();
-            if (type.isCreature() && !type.isLegendary())
-                return true;
+            return StaticData.instance().getCommonCards().isNonLegendaryCreatureName(name);
```

so I think we can just let the other overloaded one handle it