### PR TITLE
NCC: Rain of Riches and support

### DIFF
--- a/forge-game/src/main/java/forge/game/ForgeScript.java
+++ b/forge-game/src/main/java/forge/game/ForgeScript.java
@@ -10,6 +10,7 @@ import forge.game.ability.ApiType;
 import forge.game.card.Card;
 import forge.game.card.CardState;
 import forge.game.cost.Cost;
+import forge.game.mana.Mana;
 import forge.game.mana.ManaCostBeingPaid;
 import forge.game.player.Player;
 import forge.game.spellability.SpellAbility;
@@ -197,6 +198,19 @@ public class ForgeScript {
             return sa.hasParam("Nightbound");
         } else if (property.equals("paidPhyrexianMana")) {
             return sa.getSpendPhyrexianMana();
+        } else if (property.startsWith("ManaFrom")) {
+            final String fromWhat = property.substring(8);
+            boolean found = false;
+            for (Mana m : sa.getPayingMana()) {
+                final Card manaSource = m.getSourceCard();
+                if (manaSource != null) {
+                    if (manaSource.isValid(fromWhat, sourceController, source, spellAbility)) {
+                        found = true;
+                        break;
+                    }
+                }
+            }
+            return found;
         } else if (property.equals("MayPlaySource")) {
             StaticAbility m = sa.getMayPlay();
             if (m == null) {

--- a/forge-gui/res/cardsfolder/upcoming/rain_of_riches.txt
+++ b/forge-gui/res/cardsfolder/upcoming/rain_of_riches.txt
@@ -3,8 +3,8 @@ ManaCost:3 R R
 Types:Enchantment
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters the battlefield, create two Treasure tokens.
 SVar:TrigToken:DB$ Token | TokenAmount$ 2 | TokenScript$ c_a_treasure_sac
-S:Mode$ Continuous | Affected$ Card.YouCtrl+ManaFromTreasure | AffectedZone$ Stack | CheckSVar$ X | SVarCompare$ EQ0 | AddKeyword$ Cascade | Description$ The first spell you cast each turn that mana from a Treasure was spent to cast has cascade. (When you cast the spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)
-SVar:X:Count$ThisTurnCast_Card.YouCtrl+ManaFromTreasure
+S:Mode$ Continuous | Affected$ Card.YouCtrl+CastSa Spell.ManaFromTreasure | AffectedZone$ Stack | CheckSVar$ X | SVarCompare$ EQ0 | AddKeyword$ Cascade | Description$ The first spell you cast each turn that mana from a Treasure was spent to cast has cascade. (When you cast the spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)
+SVar:X:Count$ThisTurnCast_Card.YouCtrl+CastSa Spell.ManaFromTreasure
 DeckHas:Ability$Token|Sacrifice & Type$Artifact|Treasure
 DeckHints:Type$Treasure
 Oracle:When Rain of Riches enters the battlefield, create two Treasure tokens.\nThe first spell you cast each turn that mana from a Treasure was spent to cast has cascade. (When you cast the spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)

--- a/forge-gui/res/cardsfolder/upcoming/rain_of_riches.txt
+++ b/forge-gui/res/cardsfolder/upcoming/rain_of_riches.txt
@@ -1,0 +1,10 @@
+Name:Rain of Riches
+ManaCost:3 R R
+Types:Enchantment
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters the battlefield, create two Treasure tokens.
+SVar:TrigToken:DB$ Token | TokenAmount$ 2 | TokenScript$ c_a_treasure_sac
+S:Mode$ Continuous | Affected$ Card.YouCtrl+ManaFromTreasure | AffectedZone$ Stack | CheckSVar$ X | SVarCompare$ EQ0 | AddKeyword$ Cascade | Description$ The first spell you cast each turn that mana from a Treasure was spent to cast has cascade. (When you cast the spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)
+SVar:X:Count$ThisTurnCast_Card.YouCtrl+ManaFromTreasure
+DeckHas:Ability$Token|Sacrifice & Type$Artifact|Treasure
+DeckHints:Type$Treasure
+Oracle:When Rain of Riches enters the battlefield, create two Treasure tokens.\nThe first spell you cast each turn that mana from a Treasure was spent to cast has cascade. (When you cast the spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)


### PR DESCRIPTION
Need to track spells cast with mana from treasure each turn

We could expand the Card Property to ManaFrom<Whatever> if need arises later

closes #418 