### PR TITLE
NCC: Seize the Spotlight and support

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/ControlGainEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ControlGainEffect.java
@@ -1,9 +1,7 @@
 package forge.game.ability.effects;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 import com.google.common.collect.Lists;
 

--- a/forge-game/src/main/java/forge/game/ability/effects/ControlGainEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ControlGainEffect.java
@@ -16,6 +16,9 @@ import forge.game.spellability.SpellAbility;
 import forge.game.zone.ZoneType;
 import forge.util.Localizer;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class ControlGainEffect extends SpellAbilityEffect {
 
     @Override

--- a/forge-game/src/main/java/forge/game/ability/effects/ControlGainEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ControlGainEffect.java
@@ -1,17 +1,12 @@
 package forge.game.ability.effects;
 
-import java.util.Arrays;
-import java.util.List;
-
 import com.google.common.collect.Lists;
 
-import com.google.common.collect.Maps;
 import forge.GameCommand;
 import forge.game.Game;
 import forge.game.ability.AbilityUtils;
 import forge.game.ability.SpellAbilityEffect;
 import forge.game.card.Card;
-import forge.game.card.CardCollection;
 import forge.game.card.CardCollectionView;
 import forge.game.card.CardLists;
 import forge.game.event.GameEventCardStatsChanged;

--- a/forge-game/src/main/java/forge/game/ability/effects/ControlGainEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ControlGainEffect.java
@@ -1,15 +1,19 @@
 package forge.game.ability.effects;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import com.google.common.collect.Lists;
 
+import com.google.common.collect.Maps;
 import forge.GameCommand;
 import forge.game.Game;
 import forge.game.ability.AbilityUtils;
 import forge.game.ability.SpellAbilityEffect;
 import forge.game.card.Card;
+import forge.game.card.CardCollection;
 import forge.game.card.CardCollectionView;
 import forge.game.card.CardLists;
 import forge.game.event.GameEventCardStatsChanged;
@@ -17,6 +21,7 @@ import forge.game.event.GameEventCombatChanged;
 import forge.game.player.Player;
 import forge.game.spellability.SpellAbility;
 import forge.game.zone.ZoneType;
+import forge.util.Localizer;
 
 public class ControlGainEffect extends SpellAbilityEffect {
 
@@ -102,6 +107,7 @@ public class ControlGainEffect extends SpellAbilityEffect {
     @Override
     public void resolve(SpellAbility sa) {
         Card source = sa.getHostCard();
+        final Player activator = sa.getActivatingPlayer();
 
         final boolean bUntap = sa.hasParam("Untap");
         final boolean bTapOnLose = sa.hasParam("TapOnLose");
@@ -112,13 +118,24 @@ public class ControlGainEffect extends SpellAbilityEffect {
 
         final List<Player> controllers = getDefinedPlayersOrTargeted(sa, "NewController");
 
-        final Player newController = controllers.isEmpty() ? sa.getActivatingPlayer() : controllers.get(0);
+        final Player newController = controllers.isEmpty() ? activator : controllers.get(0);
         final Game game = newController.getGame();
 
-        CardCollectionView tgtCards = getDefinedCards(sa);
-
+        CardCollectionView tgtCards = null;
         if (sa.hasParam("ControlledByTarget")) {
         	tgtCards = CardLists.filterControlledBy(tgtCards, getTargetPlayers(sa));
+        } else if (sa.hasParam("Choices")) {
+            Player chooser = sa.hasParam("Chooser") ? AbilityUtils.getDefinedPlayers(source,
+                    sa.getParam("Chooser"), sa).get(0) : activator;
+            CardCollectionView choices = CardLists.getValidCards(game.getCardsIn(ZoneType.Battlefield),
+                    sa.getParam("Choices"), activator, source, sa);
+            if (!choices.isEmpty()) {
+                String title = sa.hasParam("ChoiceTitle") ? sa.getParam("ChoiceTitle") :
+                        Localizer.getInstance().getMessage("lblChooseaCard") +" ";
+                tgtCards = activator.getController().chooseCardsForEffect(choices, sa, title, 1, 1, false, null);
+            }
+        } else {
+            tgtCards = getDefinedCards(sa);
         }
 
         // in case source was LKI or still resolving

--- a/forge-game/src/main/java/forge/game/card/CounterEnumType.java
+++ b/forge-game/src/main/java/forge/game/card/CounterEnumType.java
@@ -73,6 +73,8 @@ public enum CounterEnumType {
 
     COMPONENT("COMPN", 224, 160, 48),
 
+    CONTESTED("CONTES", 255, 76, 2),
+
     CORPSE("CRPSE", 230, 186, 209),
 
     CORRUPTION("CRPTN", 210, 121, 210),

--- a/forge-gui/res/cardsfolder/upcoming/seize_the_spotlight.txt
+++ b/forge-gui/res/cardsfolder/upcoming/seize_the_spotlight.txt
@@ -1,0 +1,14 @@
+Name:Seize the Spotlight
+ManaCost:2 R
+Types:Sorcery
+A:SP$ RepeatEach | RepeatPlayers$ Opponent | RepeatSubAbility$ DBChoice | SubAbility$ DBFame | ClearRememberedBeforeLoop$ True | SpellDescription$ Each opponent chooses fame or fortune. For each player who chose fame, gain control of a creature that player controls until end of turn. Untap those creatures and they gain haste until end of turn. For each player who chose fortune, you draw a card and create a Treasure token.
+SVar:DBChoice:DB$ GenericChoice | Defined$ Player.IsRemembered | Choices$ Fame,Fortune | ShowChoice$ True
+SVar:Fame:DB$ Pump | Defined$ Player.IsRemembered | NoteCards$ Self | NoteCardsFor$ Fame | SpellDescription$ Fame
+SVar:Fortune:DB$ Pump | Defined$ Player.IsRemembered | NoteCards$ Self | NoteCardsFor$ Fortune | SpellDescription$ Fortune
+SVar:DBFame:DB$ RepeatEach | RepeatPlayers$ Player.NotedForFame | RepeatSubAbility$ GainControl | SubAbility$ DBFortune | ClearRememberedBeforeLoop$ True
+SVar:GainControl:DB$ GainControl | Choices$ Creature.RememberedPlayerCtrl | LoseControl$ EOT | Untap$ True | AddKWs$ Haste
+SVar:DBFortune:DB$ RepeatEach | RepeatPlayers$ Player.NotedForFortune | RepeatSubAbility$ DBDraw | ClearRememberedBeforeLoop$ True
+SVar:DBDraw:DB$ Draw | SubAbility$ DBTreasure
+SVar:DBTreasure:DB$ Token | TokenScript$ c_a_treasure_sac
+DeckHas:Ability$Token|Sacrifice & Types$Artifact|Treasure
+Oracle:Each opponent chooses fame or fortune. For each player who chose fame, gain control of a creature that player controls until end of turn. Untap those creatures and they gain haste until end of turn. For each player who chose fortune, you draw a card and create a Treasure token.

--- a/forge-gui/res/cardsfolder/upcoming/turf_war.txt
+++ b/forge-gui/res/cardsfolder/upcoming/turf_war.txt
@@ -1,0 +1,9 @@
+Name:Turf War
+ManaCost:4 R
+Types:Enchantment
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPutCounter | TriggerDescription$ When CARDNAME enters the battlefield, for each player, put a contested counter on target land that player controls.
+SVar:TrigPutCounter:DB$ PutCounter | CounterType$ CONTESTED | ValidTgts$ Land | TgtPrompt$ For each player, select a target land | TargetMin$ OneEach | TargetMax$ OneEach | TargetsWithDifferentControllers$ True
+SVar:OneEach:PlayerCountPlayers$Amount
+T:Mode$ DamageDone | ValidSource$ Creature | ValidTarget$ Player.controlsLand+counters_GE1_CONTESTED | CombatDamage$ True | TriggerZones$ Battlefield | Execute$ TrigGainControl | TriggerDescription$ Whenever a creature deals combat damage to a player, if that player controls one or more lands with contested counters on them, that creature's controller gains control of one of those lands of their choice and untaps it.
+SVar:TrigGainControl:DB$ GainControl | Choices$ Land.ControlledBy TriggeredTarget+counters_GE1_CONTESTED | Untap$ True | NewController$ TriggeredSourceController
+Oracle:When Turf War enters the battlefield, for each player, put a contested counter on target land that player controls.\nWhenever a creature deals combat damage to a player, if that player controls one or more lands with contested counters on them, that creature's controller gains control of one of those lands of their choice and untaps it.


### PR DESCRIPTION
added non-targeted "Choices" to ControlGainEffect - for now choice is always 1 card, can be expanded later if need be

this might mean the AI needs some tweaking too?

closes #433
closes #449 