### PR TITLE
wasAttackedThisCombat restriction for multiplayer

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/DestroyAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DestroyAi.java
@@ -353,12 +353,10 @@ public class DestroyAi extends SpellAbilityAi {
             // Filter AI-specific targets if provided
             preferred = ComputerUtil.filterAITgts(sa, ai, preferred, true);
 
-            for (final Card c : preferred) {
-                list.remove(c);
-            }
+            list.removeAll(preferred);
 
             if (preferred.isEmpty() && !mandatory) {
-            	return false;
+                return false;
             }
 
             while (sa.canAddMoreTarget()) {

--- a/forge-game/src/main/java/forge/game/ability/effects/EffectEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/EffectEffect.java
@@ -271,7 +271,7 @@ public class EffectEffect extends SpellAbilityEffect {
             }
 
             if (sa.hasParam("CopySVar")) {
-                eff.setSVar(sa.getParam("CopySVar"), sa.getHostCard().getSVar(sa.getParam("CopySVar")));
+                eff.setSVar(sa.getParam("CopySVar"), hostCard.getSVar(sa.getParam("CopySVar")));
             }
 
             // Copy text changes

--- a/forge-game/src/main/java/forge/game/combat/CombatUtil.java
+++ b/forge-game/src/main/java/forge/game/combat/CombatUtil.java
@@ -408,7 +408,7 @@ public class CombatUtil {
         c.getDamageHistory().setCreatureAttackedThisCombat(defender);
         c.getDamageHistory().clearNotAttackedSinceLastUpkeepOf();
         c.getController().addCreaturesAttackedThisTurn(CardUtil.getLKICopy(c));
-        if (combat.getDefenderByAttacker(c) instanceof Player) {
+        if (defender instanceof Player) {
             c.getController().addAttackedPlayersMyTurn(combat.getDefenderPlayerByAttacker(c));
         }
     }

--- a/forge-game/src/main/java/forge/game/phase/PhaseHandler.java
+++ b/forge-game/src/main/java/forge/game/phase/PhaseHandler.java
@@ -641,6 +641,7 @@ public class PhaseHandler implements java.io.Serializable {
             game.getTriggerHandler().runTrigger(TriggerType.AttackersDeclared, runParams, false);
         }
 
+        playerTurn.clearAttackedPlayersMyCombat();
         for (final Card c : combat.getAttackers()) {
             CombatUtil.checkDeclaredAttacker(game, c, combat, true);
         }

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -206,6 +206,8 @@ public class Player extends GameEntity implements Comparable<Player> {
     private List<Card> creatureAttackedThisTurn = new ArrayList<>();
     private List<Player> attackedPlayersThisTurn = new ArrayList<>();
     private List <Player> attackedPlayersLastTurn = new ArrayList<>();
+    private List<Player> attackedPlayersThisCombat = new ArrayList<>();
+
     private boolean activateLoyaltyAbilityThisTurn = false;
     private boolean tappedLandForManaThisTurn = false;
     private List<Card> completedDungeons = new ArrayList<>();
@@ -1886,6 +1888,7 @@ public class Player extends GameEntity implements Comparable<Player> {
 
     public final void addAttackedPlayersMyTurn(final Player p) {
         if (!attackedPlayersThisTurn.contains(p)) {
+            attackedPlayersThisCombat.add(p);
             attackedPlayersThisTurn.add(p);
         }
     }
@@ -1901,6 +1904,13 @@ public class Player extends GameEntity implements Comparable<Player> {
     public final void setAttackedPlayersMyLastTurn(List<Player> players) {
         attackedPlayersLastTurn.clear();
         attackedPlayersLastTurn.addAll(players);
+    }
+
+    public final List<Player> getAttackedPlayersMyCombat() {
+        return attackedPlayersThisTurn;
+    }
+    public final void clearAttackedPlayersMyCombat() {
+        attackedPlayersThisCombat.clear();
     }
 
     public final int getVenturedThisTurn() {

--- a/forge-game/src/main/java/forge/game/player/PlayerProperty.java
+++ b/forge-game/src/main/java/forge/game/player/PlayerProperty.java
@@ -395,7 +395,7 @@ public class PlayerProperty {
             if (!player.getAttackedPlayersMyLastTurn().contains(sourceController)) {
                 return false;
             }
-        } else if (property.equals("wasAttackedThisCombat")) {
+        } else if (property.equals("BeenAttackedThisCombat")) {
             for (Player p : game.getRegisteredPlayers()) {
                 if (p.getAttackedPlayersMyCombat().contains(sourceController)) {
                     return true;

--- a/forge-game/src/main/java/forge/game/player/PlayerProperty.java
+++ b/forge-game/src/main/java/forge/game/player/PlayerProperty.java
@@ -395,6 +395,13 @@ public class PlayerProperty {
             if (!player.getAttackedPlayersMyLastTurn().contains(sourceController)) {
                 return false;
             }
+        } else if (property.equals("wasAttackedThisCombat")) {
+            for (Player p : game.getRegisteredPlayers()) {
+                if (p.getAttackedPlayersMyCombat().contains(sourceController)) {
+                    return true;
+                }
+            }
+            return false;
         } else if (property.equals("VenturedThisTurn")) {
             if (player.getVenturedThisTurn() < 1) {
                 return false;

--- a/forge-gui/res/cardsfolder/a/assassins_blade.txt
+++ b/forge-gui/res/cardsfolder/a/assassins_blade.txt
@@ -1,5 +1,6 @@
 Name:Assassin's Blade
 ManaCost:1 B
 Types:Instant
-A:SP$ Destroy | Cost$ 1 B | ValidTgts$ Creature.nonBlack+attacking | TgtPrompt$ Select target nonblack attacking creature | Activator$ You.wasAttackedThisCombat | ActivationPhases$ Declare Attackers | SpellDescription$ Cast CARDNAME only during the declare attackers step and only if you've been attacked this step. Destroy target nonblack attacking creature.
+A:SP$ Destroy | Cost$ 1 B | ValidTgts$ Creature.nonBlack+attacking | TgtPrompt$ Select target nonblack attacking creature | CheckSVar$ X | ActivationPhases$ Declare Attackers | SpellDescription$ Cast CARDNAME only during the declare attackers step and only if you've been attacked this step. Destroy target nonblack attacking creature.
+SVar:X:PlayerCountPropertyYou$HasPropertyBeenAttackedThisCombat
 Oracle:Cast this spell only during the declare attackers step and only if you've been attacked this step.\nDestroy target nonblack attacking creature.

--- a/forge-gui/res/cardsfolder/a/assassins_blade.txt
+++ b/forge-gui/res/cardsfolder/a/assassins_blade.txt
@@ -1,5 +1,5 @@
 Name:Assassin's Blade
 ManaCost:1 B
 Types:Instant
-A:SP$ Destroy | Cost$ 1 B | ValidTgts$ Creature.nonBlack+attacking | TgtPrompt$ Select target nonblack attacking creature | OpponentTurn$ True | ActivationPhases$ Declare Attackers | SpellDescription$ Cast CARDNAME only during the declare attackers step and only if you've been attacked this step. Destroy target nonblack attacking creature.
+A:SP$ Destroy | Cost$ 1 B | ValidTgts$ Creature.nonBlack+attacking | TgtPrompt$ Select target nonblack attacking creature | Activator$ You.wasAttackedThisCombat | ActivationPhases$ Declare Attackers | SpellDescription$ Cast CARDNAME only during the declare attackers step and only if you've been attacked this step. Destroy target nonblack attacking creature.
 Oracle:Cast this spell only during the declare attackers step and only if you've been attacked this step.\nDestroy target nonblack attacking creature.

--- a/forge-gui/res/cardsfolder/b/bearer_of_the_heavens.txt
+++ b/forge-gui/res/cardsfolder/b/bearer_of_the_heavens.txt
@@ -3,6 +3,6 @@ ManaCost:7 R
 Types:Creature Giant
 PT:10/10
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ DelTrigLeaves | TriggerDescription$ When CARDNAME dies, destroy all permanents at the beginning of the next end step.
-SVar:DelTrigLeaves:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ TrigDestroyAll | CopyTriggeringObjects$ True | TriggerDescription$ Destroy all permanents at the beginning of the next end step.
+SVar:DelTrigLeaves:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ TrigDestroyAll | TriggerDescription$ Destroy all permanents at the beginning of the next end step.
 SVar:TrigDestroyAll:DB$ DestroyAll | ValidCards$ Permanent
 Oracle:When Bearer of the Heavens dies, destroy all permanents at the beginning of the next end step.

--- a/forge-gui/res/cardsfolder/c/champions_victory.txt
+++ b/forge-gui/res/cardsfolder/c/champions_victory.txt
@@ -1,5 +1,6 @@
 Name:Champion's Victory
 ManaCost:U
 Types:Instant
-A:SP$ ChangeZone | Cost$ U | ValidTgts$ Creature.attacking | TgtPrompt$ Select target attacking creature | Origin$ Battlefield | Destination$ Hand | OpponentTurn$ True | ActivationPhases$ Declare Attackers | SpellDescription$ Cast CARDNAME only during the declare attackers step and only if you've been attacked this step. Return target attacking creature to its owner's hand.
+A:SP$ ChangeZone | Cost$ U | ValidTgts$ Creature.attacking | TgtPrompt$ Select target attacking creature | Origin$ Battlefield | Destination$ Hand | CheckSVar$ X | ActivationPhases$ Declare Attackers | SpellDescription$ Cast CARDNAME only during the declare attackers step and only if you've been attacked this step. Return target attacking creature to its owner's hand.
+SVar:X:PlayerCountPropertyYou$HasPropertyBeenAttackedThisCombat
 Oracle:Cast this spell only during the declare attackers step and only if you've been attacked this step.\nReturn target attacking creature to its owner's hand.

--- a/forge-gui/res/cardsfolder/c/command_of_unsummoning.txt
+++ b/forge-gui/res/cardsfolder/c/command_of_unsummoning.txt
@@ -1,5 +1,6 @@
 Name:Command of Unsummoning
 ManaCost:2 U
 Types:Instant
-A:SP$ ChangeZone | Cost$ 2 U | TargetMin$ 1 | TargetMax$ 2 | ValidTgts$ Creature.attacking | TgtPrompt$ Select target attacking creature | Origin$ Battlefield | Destination$ Hand | OpponentTurn$ True | ActivationPhases$ Declare Attackers | SpellDescription$ Cast CARDNAME only during the declare attackers step and only if you've been attacked this step. Return one or two target attacking creatures to their owner's hand.
+A:SP$ ChangeZone | Cost$ 2 U | TargetMin$ 1 | TargetMax$ 2 | ValidTgts$ Creature.attacking | TgtPrompt$ Select target attacking creature | Origin$ Battlefield | Destination$ Hand | CheckSVar$ X | ActivationPhases$ Declare Attackers | SpellDescription$ Cast CARDNAME only during the declare attackers step and only if you've been attacked this step. Return one or two target attacking creatures to their owner's hand.
+SVar:X:PlayerCountPropertyYou$HasPropertyBeenAttackedThisCombat
 Oracle:Cast this spell only during the declare attackers step and only if you've been attacked this step.\nReturn one or two target attacking creatures to their owner's hand.

--- a/forge-gui/res/cardsfolder/c/cryptic_gateway.txt
+++ b/forge-gui/res/cardsfolder/c/cryptic_gateway.txt
@@ -1,8 +1,7 @@
 Name:Cryptic Gateway
 ManaCost:5
 Types:Artifact
-A:AB$ ChangeZone | Cost$ tapXType<2/Creature> | RememberCostCards$ True | ChangeType$ Creature.sharesCreatureTypeWith AllRemembered | Origin$ Hand | Destination$ Battlefield | ChangeNum$ 1 | Optional$ True | SpellDescription$ You may put a creature card from your hand that shares a creature type with each creature tapped this way onto the battlefield. | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+A:AB$ ChangeZone | Cost$ tapXType<2/Creature> | ChangeType$ Creature.sharesCreatureTypeWith Tapped | Origin$ Hand | Destination$ Battlefield | ChangeNum$ 1 | Optional$ True | SpellDescription$ You may put a creature card from your hand that shares a creature type with each creature tapped this way onto the battlefield.
 SVar:NonStackingEffect:True
 AI:RemoveDeck:All
 Oracle:Tap two untapped creatures you control: You may put a creature card from your hand that shares a creature type with each creature tapped this way onto the battlefield.

--- a/forge-gui/res/cardsfolder/d/deep_wood.txt
+++ b/forge-gui/res/cardsfolder/d/deep_wood.txt
@@ -1,6 +1,7 @@
 Name:Deep Wood
 ManaCost:1 G
 Types:Instant
-A:SP$ Effect | Cost$ 1 G | Name$ Deep Wood Effect | ReplacementEffects$ RPrevent | AILogic$ Fog | OpponentTurn$ True | ActivationPhases$ Declare Attackers | SpellDescription$ Cast this spell only during the declare attackers step and only if you've been attacked this step. Prevent all damage that would be dealt to you this turn by attacking creatures.
+A:SP$ Effect | Cost$ 1 G | Name$ Deep Wood Effect | ReplacementEffects$ RPrevent | AILogic$ Fog | CheckSVar$ X | ActivationPhases$ Declare Attackers | SpellDescription$ Cast this spell only during the declare attackers step and only if you've been attacked this step. Prevent all damage that would be dealt to you this turn by attacking creatures.
 SVar:RPrevent:Event$ DamageDone | Prevent$ True | ActiveZones$ Command | ValidTarget$ You | ValidSource$ Creature.attacking | Description$ Prevent all damage that would be dealt to you this turn by attacking creatures.
+SVar:X:PlayerCountPropertyYou$HasPropertyBeenAttackedThisCombat
 Oracle:Cast this spell only during the declare attackers step and only if you've been attacked this step.\nPrevent all damage that would be dealt to you this turn by attacking creatures.

--- a/forge-gui/res/cardsfolder/d/defiant_stand.txt
+++ b/forge-gui/res/cardsfolder/d/defiant_stand.txt
@@ -1,7 +1,8 @@
 Name:Defiant Stand
 ManaCost:1 W
 Types:Instant
-A:SP$ Pump | Cost$ 1 W | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +1 | NumDef$ +3 | SubAbility$ DBUntap | OpponentTurn$ True | ActivationPhases$ Declare Attackers | SpellDescription$ Cast this spell only during the declare attackers step and only if you've been attacked this step. Target creature gets +1/+3 until end of turn. Untap that creature.
+A:SP$ Pump | Cost$ 1 W | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +1 | NumDef$ +3 | SubAbility$ DBUntap | CheckSVar$ X | ActivationPhases$ Declare Attackers | SpellDescription$ Cast this spell only during the declare attackers step and only if you've been attacked this step. Target creature gets +1/+3 until end of turn. Untap that creature.
 SVar:DBUntap:DB$ Untap | Defined$ Targeted
+SVar:X:PlayerCountPropertyYou$HasPropertyBeenAttackedThisCombat
 AI:RemoveDeck:All
 Oracle:Cast this spell only during the declare attackers step and only if you've been attacked this step.\nTarget creature gets +1/+3 until end of turn. Untap that creature.

--- a/forge-gui/res/cardsfolder/e/eightfold_maze.txt
+++ b/forge-gui/res/cardsfolder/e/eightfold_maze.txt
@@ -1,5 +1,6 @@
 Name:Eightfold Maze
 ManaCost:2 W
 Types:Instant
-A:SP$ Destroy | Cost$ 2 W | ValidTgts$ Creature.attacking | TgtPrompt$ Select target attacking creature | OpponentTurn$ True | ActivationPhases$ Declare Attackers | SpellDescription$ Cast this spell only during the declare attackers step and only if you've been attacked this step. Destroy target attacking creature.
+A:SP$ Destroy | Cost$ 2 W | ValidTgts$ Creature.attacking | TgtPrompt$ Select target attacking creature | CheckSVar$ X | ActivationPhases$ Declare Attackers | SpellDescription$ Cast this spell only during the declare attackers step and only if you've been attacked this step. Destroy target attacking creature.
+SVar:X:PlayerCountPropertyYou$HasPropertyBeenAttackedThisCombat
 Oracle:Cast this spell only during the declare attackers step and only if you've been attacked this step.\nDestroy target attacking creature.

--- a/forge-gui/res/cardsfolder/h/harsh_justice.txt
+++ b/forge-gui/res/cardsfolder/h/harsh_justice.txt
@@ -1,9 +1,10 @@
 Name:Harsh Justice
 ManaCost:2 W
 Types:Instant
-A:SP$ Effect | Cost$ 2 W | Name$ Harsh Justice Effect | Triggers$ TrigDamage | AILogic$ Fog | OpponentTurn$ True | ActivationPhases$ Declare Attackers | SpellDescription$ Cast this spell only during the declare attackers step and only if you've been attacked this step. This turn, whenever an attacking creature deals combat damage to you, it deals that much damage to its controller.
+A:SP$ Effect | Cost$ 2 W | Name$ Harsh Justice Effect | Triggers$ TrigDamage | AILogic$ Fog | CheckSVar$ Y | ActivationPhases$ Declare Attackers | SpellDescription$ Cast this spell only during the declare attackers step and only if you've been attacked this step. This turn, whenever an attacking creature deals combat damage to you, it deals that much damage to its controller.
 SVar:TrigDamage:Mode$ DamageDone | ValidSource$ Creature.attacking | ValidTarget$ You | Execute$ TrigDealDamage | CombatDamage$ True | TriggerDescription$ This turn, whenever an attacking creature deals combat damage to you, it deals that much damage to its controller.
 SVar:TrigDealDamage:DB$ DealDamage | Defined$ TriggeredSourceController | NumDmg$ X | DamageSource$ TriggeredSource
 SVar:X:TriggerCount$DamageAmount
+SVar:Y:PlayerCountPropertyYou$HasPropertyBeenAttackedThisCombat
 AI:RemoveDeck:All
 Oracle:Cast this spell only during the declare attackers step and only if you've been attacked this step.\nThis turn, whenever an attacking creature deals combat damage to you, it deals that much damage to its controller.

--- a/forge-gui/res/cardsfolder/h/heavy_fog.txt
+++ b/forge-gui/res/cardsfolder/h/heavy_fog.txt
@@ -1,6 +1,7 @@
 Name:Heavy Fog
 ManaCost:1 G
 Types:Instant
-A:SP$ Effect | Cost$ 1 G | Name$ Heavy Fog Effect | ReplacementEffects$ RPrevent | AILogic$ Fog | OpponentTurn$ True | ActivationPhases$ Declare Attackers | SpellDescription$ Cast this spell only during the declare attackers step and only if you've been attacked this step. Prevent all damage that would be dealt to you this turn by attacking creatures.
+A:SP$ Effect | Cost$ 1 G | Name$ Heavy Fog Effect | ReplacementEffects$ RPrevent | AILogic$ Fog | CheckSVar$ X | ActivationPhases$ Declare Attackers | SpellDescription$ Cast this spell only during the declare attackers step and only if you've been attacked this step. Prevent all damage that would be dealt to you this turn by attacking creatures.
 SVar:RPrevent:Event$ DamageDone | Prevent$ True | ActiveZones$ Command | ValidTarget$ You | ValidSource$ Creature.attacking | Description$ Prevent all damage that would be dealt to you this turn by attacking creatures.
+SVar:X:PlayerCountPropertyYou$HasPropertyBeenAttackedThisCombat
 Oracle:Cast this spell only during the declare attackers step and only if you've been attacked this step.\nPrevent all damage that would be dealt to you this turn by attacking creatures.

--- a/forge-gui/res/cardsfolder/h/holistic_wisdom.txt
+++ b/forge-gui/res/cardsfolder/h/holistic_wisdom.txt
@@ -1,8 +1,7 @@
 Name:Holistic Wisdom
 ManaCost:1 G G
 Types:Enchantment
-A:AB$ Pump | Cost$ 2 ExileFromHand<1/Card> | RememberCostCards$ True | SubAbility$ DBChangeZone | ValidTgts$ Card.YouOwn | TgtZone$ Graveyard | StackDescription$ None | SpellDescription$ Return target card from your graveyard to your hand if it shares a card type with the card exiled this way. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and tribal are card types.)
-SVar:DBChangeZone:DB$ ChangeZone | Defined$ ParentTarget | Origin$ Graveyard | Destination$ Hand | ConditionDefined$ ParentTarget | ConditionPresent$ Card.sharesCardTypeWith Remembered | ConditionCompare$ GE1 | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+A:AB$ Pump | Cost$ 2 ExileFromHand<1/Card> | SubAbility$ DBChangeZone | ValidTgts$ Card.YouOwn | TgtZone$ Graveyard | StackDescription$ None | SpellDescription$ Return target card from your graveyard to your hand if it shares a card type with the card exiled this way. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and tribal are card types.)
+SVar:DBChangeZone:DB$ ChangeZone | Defined$ ParentTarget | Origin$ Graveyard | Destination$ Hand | ConditionDefined$ ParentTarget | ConditionPresent$ Card.sharesCardTypeWith Exiled | ConditionCompare$ GE1
 AI:RemoveDeck:All
 Oracle:{2}, Exile a card from your hand: Return target card from your graveyard to your hand if it shares a card type with the card exiled this way. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and tribal are card types.)

--- a/forge-gui/res/cardsfolder/j/just_fate.txt
+++ b/forge-gui/res/cardsfolder/j/just_fate.txt
@@ -1,5 +1,6 @@
 Name:Just Fate
 ManaCost:2 W
 Types:Instant
-A:SP$ Destroy | Cost$ 2 W | ValidTgts$ Creature.attacking | TgtPrompt$ Select target attacking creature | OpponentTurn$ True | ActivationPhases$ Declare Attackers | SpellDescription$ Cast this spell only during the declare attackers step and only if you've been attacked this step. Destroy target attacking creature.
+A:SP$ Destroy | Cost$ 2 W | ValidTgts$ Creature.attacking | TgtPrompt$ Select target attacking creature | CheckSVar$ X | ActivationPhases$ Declare Attackers | SpellDescription$ Cast this spell only during the declare attackers step and only if you've been attacked this step. Destroy target attacking creature.
+SVar:X:PlayerCountPropertyYou$HasPropertyBeenAttackedThisCombat
 Oracle:Cast this spell only during the declare attackers step and only if you've been attacked this step.\nDestroy target attacking creature.

--- a/forge-gui/res/cardsfolder/k/kongmings_contraptions.txt
+++ b/forge-gui/res/cardsfolder/k/kongmings_contraptions.txt
@@ -2,5 +2,6 @@ Name:Kongming's Contraptions
 ManaCost:3 W
 Types:Creature Human Soldier
 PT:2/4
-A:AB$ DealDamage | Cost$ T | ValidTgts$ Creature.attacking | TgtPrompt$ Select target attacking creature | NumDmg$ 2 | OpponentTurn$ True | ActivationPhases$ Declare Attackers | SpellDescription$ CARDNAME deals 2 damage to target attacking creature. Activate only during the declare attackers step and only if you've been attacked this step.
+A:AB$ DealDamage | Cost$ T | ValidTgts$ Creature.attacking | TgtPrompt$ Select target attacking creature | NumDmg$ 2 | CheckSVar$ X | ActivationPhases$ Declare Attackers | SpellDescription$ CARDNAME deals 2 damage to target attacking creature. Activate only during the declare attackers step and only if you've been attacked this step.
+SVar:X:PlayerCountPropertyYou$HasPropertyBeenAttackedThisCombat
 Oracle:{T}: Kongming's Contraptions deals 2 damage to target attacking creature. Activate only during the declare attackers step and only if you've been attacked this step.

--- a/forge-gui/res/cardsfolder/r/rally_the_troops.txt
+++ b/forge-gui/res/cardsfolder/r/rally_the_troops.txt
@@ -1,6 +1,7 @@
 Name:Rally the Troops
 ManaCost:W
 Types:Instant
-A:SP$ UntapAll | Cost$ W | ValidCards$ Creature.YouCtrl | OpponentTurn$ True | ActivationPhases$ Declare Attackers | SpellDescription$ Cast this spell only during the declare attackers step and only if you've been attacked this step. Untap all creatures you control.
+A:SP$ UntapAll | Cost$ W | ValidCards$ Creature.YouCtrl | CheckSVar$ X | ActivationPhases$ Declare Attackers | SpellDescription$ Cast this spell only during the declare attackers step and only if you've been attacked this step. Untap all creatures you control.
+SVar:X:PlayerCountPropertyYou$HasPropertyBeenAttackedThisCombat
 AI:RemoveDeck:All
 Oracle:Cast this spell only during the declare attackers step and only if you've been attacked this step.\nUntap all creatures you control.

--- a/forge-gui/res/cardsfolder/r/remove.txt
+++ b/forge-gui/res/cardsfolder/r/remove.txt
@@ -1,5 +1,6 @@
 Name:Remove
 ManaCost:U
 Types:Instant
-A:SP$ ChangeZone | Cost$ U | ValidTgts$ Creature.attacking | TgtPrompt$ Select target attacking creature | Origin$ Battlefield | Destination$ Hand | OpponentTurn$ True | ActivationPhases$ Declare Attackers | SpellDescription$ Cast this spell only during the declare attackers step and only if you've been attacked this step. Return target attacking creature to its owner's hand.
+A:SP$ ChangeZone | Cost$ U | ValidTgts$ Creature.attacking | TgtPrompt$ Select target attacking creature | Origin$ Battlefield | Destination$ Hand | CheckSVar$ X | ActivationPhases$ Declare Attackers | SpellDescription$ Cast this spell only during the declare attackers step and only if you've been attacked this step. Return target attacking creature to its owner's hand.
+SVar:X:PlayerCountPropertyYou$HasPropertyBeenAttackedThisCombat
 Oracle:Cast this spell only during the declare attackers step and only if you've been attacked this step.\nReturn target attacking creature to its owner's hand.

--- a/forge-gui/res/cardsfolder/s/scorching_winds.txt
+++ b/forge-gui/res/cardsfolder/s/scorching_winds.txt
@@ -2,6 +2,6 @@ Name:Scorching Winds
 ManaCost:R
 Types:Instant
 Text:Cast this spell only during the declare attackers step and only if you've been attacked this step.\r\n
-A:SP$ DamageAll | Cost$ R | NumDmg$ 1 | ValidCards$ Creature.attacking | ValidDescription$ each attacking creature. | OpponentTurn$ True | CheckSVar$ X | SVarCompare$ GE1 | ActivationPhases$ Declare Attackers | SpellDescription$ CARDNAME deals 1 damage to each attacking creature.
-SVar:X:Count$Valid Creature.attackingYou
+A:SP$ DamageAll | Cost$ R | NumDmg$ 1 | ValidCards$ Creature.attacking | ValidDescription$ each attacking creature. | CheckSVar$ X | CheckSVar$ X | SVarCompare$ GE1 | ActivationPhases$ Declare Attackers | SpellDescription$ CARDNAME deals 1 damage to each attacking creature.
+SVar:X:PlayerCountPropertyYou$HasPropertyBeenAttackedThisCombat
 Oracle:Cast this spell only during the declare attackers step and only if you've been attacked this step.\nScorching Winds deals 1 damage to each attacking creature.

--- a/forge-gui/res/cardsfolder/s/sigardian_zealot.txt
+++ b/forge-gui/res/cardsfolder/s/sigardian_zealot.txt
@@ -3,7 +3,7 @@ ManaCost:4 G
 Types:Creature Human Cleric
 PT:3/3
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigChoose | TriggerDescription$ At the beginning of combat on your turn, choose any number of creatures with different powers. Each of them gets +X/+X and gains vigilance until end of turn, where X is CARDNAME's power.
-SVar:TrigChoose:DB$ ChooseCard | MinAmount$ 0 | Amount$ Max | Choices$ Creature | WithDifferentPowers$ True | SubAbility$ DBPump
+SVar:TrigChoose:DB$ ChooseCard | MinAmount$ 0 | Amount$ Max | Choices$ Creature | WithDifferentPowers$ True | AILogic$ OwnCard | SubAbility$ DBPump
 SVar:DBPump:DB$ Pump | Defined$ ChosenCard | NumAtt$ X | NumDef$ X | KW$ Vigilance | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearChosenCard$ True
 SVar:Max:Count$DifferentPower_Creature

--- a/forge-gui/res/cardsfolder/t/treetop_defense.txt
+++ b/forge-gui/res/cardsfolder/t/treetop_defense.txt
@@ -1,7 +1,7 @@
 Name:Treetop Defense
 ManaCost:1 G
 Types:Instant
-A:SP$ PumpAll | Cost$ 1 G | ValidCards$ Creature.YouCtrl | KW$ Reach | CheckSVar$ X | SVarCompare$ GE1 | OpponentTurn$ True | ActivationPhases$ Declare Attackers | SpellDescription$ Cast this spell only during the declare attackers step and only if you've been attacked this step. Creatures you control gain reach until end of turn.
-SVar:X:Count$Valid Creature.attackingYou
+A:SP$ PumpAll | Cost$ 1 G | ValidCards$ Creature.YouCtrl | KW$ Reach | CheckSVar$ X | ActivationPhases$ Declare Attackers | SpellDescription$ Cast this spell only during the declare attackers step and only if you've been attacked this step. Creatures you control gain reach until end of turn.
+SVar:X:PlayerCountPropertyYou$HasPropertyBeenAttackedThisCombat
 AI:RemoveDeck:All
 Oracle:Cast this spell only during the declare attackers step and only if you've been attacked this step.\nCreatures you control gain reach until end of turn. (They can block creatures with flying.)

--- a/forge-gui/res/cardsfolder/v/vigorous_charge.txt
+++ b/forge-gui/res/cardsfolder/v/vigorous_charge.txt
@@ -3,12 +3,10 @@ ManaCost:G
 Types:Instant
 K:Kicker:W
 A:SP$ Pump | Cost$ G | ValidTgts$ Creature | KW$ Trample | SubAbility$ VigorousPumping | SpellDescription$ Target creature gains trample until end of turn. Whenever that creature deals combat damage this turn, if this spell was kicked, you gain life equal to that damage.
-SVar:VigorousPumping:DB$ Effect | TgtPrompt$ Select target creature | Triggers$ TrigDamage,EndTrackingEffect | RememberObjects$ Targeted | Condition$ Kicked | ConditionDescription$ If Vigorous Charge was kicked,
+SVar:VigorousPumping:DB$ Effect | TgtPrompt$ Select target creature | Triggers$ TrigDamage | RememberObjects$ Targeted | ExileOnMoved$ Battlefield | Condition$ Kicked | ConditionDescription$ If Vigorous Charge was kicked,
 SVar:TrigDamage:Mode$ DamageDealtOnce | CombatDamage$ True | ValidSource$ Creature.IsRemembered | Execute$ VigorousLife | TriggerDescription$ Whenever the targeted creature deals combat damage this turn, you gain life equal to that damage.
 SVar:VigorousLife:DB$ GainLife | Defined$ You | LifeAmount$ X
 SVar:X:TriggerCount$DamageAmount
-SVar:EndTrackingEffect:Mode$ ChangesZone | ValidCard$ Card.IsRemembered | Origin$ Battlefield | Destination$ Any | Execute$ ExileEffect | Static$ True
-SVar:ExileEffect:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 AI:RemoveDeck:Random
 DeckHints:Color$White
 Oracle:Kicker {W} (You may pay an additional {W} as you cast this spell.)\nTarget creature gains trample until end of turn. Whenever that creature deals combat damage this turn, if this spell was kicked, you gain life equal to that damage.

--- a/forge-gui/res/cardsfolder/v/viridian_zealot_avatar.txt
+++ b/forge-gui/res/cardsfolder/v/viridian_zealot_avatar.txt
@@ -2,7 +2,6 @@ Name:Viridian Zealot Avatar
 ManaCost:no cost
 Types:Vanguard
 HandLifeModifier:+0/+2
-A:AB$ Destroy | ActivationZone$ Command | Cost$ 2 Sac<1/Creature> | RememberCostCards$ True | ValidTgts$ Artifact,Enchantment | TgtPrompt$ Select target artifact or enchantment | SubAbility$ DBChangeZone | SpellDescription$ Destroy target artifact or enchantment. Search your library for a card with the same name as the sacrificed creature, reveal that card, put it into your hand, then shuffle.
-SVar:DBChangeZone:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Creature.sharesNameWith Remembered | ChangeNum$ 1 | StackDescription$ Search your library for a card with the same name as the sacrificed creature, reveal that card, and put it into your hand. Then shuffle. | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+A:AB$ Destroy | ActivationZone$ Command | Cost$ 2 Sac<1/Creature> | ValidTgts$ Artifact,Enchantment | TgtPrompt$ Select target artifact or enchantment | SubAbility$ DBChangeZone | SpellDescription$ Destroy target artifact or enchantment. Search your library for a card with the same name as the sacrificed creature, reveal that card, put it into your hand, then shuffle.
+SVar:DBChangeZone:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Creature.sharesNameWith Sacrificed | ChangeNum$ 1 | StackDescription$ Search your library for a card with the same name as the sacrificed creature, reveal that card, and put it into your hand. Then shuffle.
 Oracle:Hand +0, life +2\n{2}, Sacrifice a creature: Destroy target artifact or enchantment. Search your library for a card with the same name as the sacrificed creature, reveal that card, put it into your hand, then shuffle.

--- a/forge-gui/res/cardsfolder/w/warriors_stand.txt
+++ b/forge-gui/res/cardsfolder/w/warriors_stand.txt
@@ -1,6 +1,7 @@
 Name:Warrior's Stand
 ManaCost:1 W
 Types:Instant
-A:SP$ PumpAll | Cost$ 1 W | ValidCards$ Creature.YouCtrl | NumAtt$ +2 | NumDef$ +2 | OpponentTurn$ True | ActivationPhases$ Declare Attackers | SpellDescription$ Cast this spell only during the declare attackers step and only if you've been attacked this step. Creatures you control get +2/+2 until end of turn.
+A:SP$ PumpAll | Cost$ 1 W | ValidCards$ Creature.YouCtrl | NumAtt$ +2 | NumDef$ +2 | CheckSVar$ X | ActivationPhases$ Declare Attackers | SpellDescription$ Cast this spell only during the declare attackers step and only if you've been attacked this step. Creatures you control get +2/+2 until end of turn.
+SVar:X:PlayerCountPropertyYou$HasPropertyBeenAttackedThisCombat
 AI:RemoveDeck:All
 Oracle:Cast this spell only during the declare attackers step and only if you've been attacked this step.\nCreatures you control get +2/+2 until end of turn.


### PR DESCRIPTION
- [x] update remaining cards

@Hanmac

Doing it as PlayerProperty felt cleaner instead of ``ActivatorWasAttackedThisCombat$ True``

But I wasn't sure if ``checkActivatorRestrictions`` needs changing because of that [MayPlay part](https://github.com/Card-Forge/forge/blob/875f6c78c092f88631007ad3133ef5eba3ed0986/forge-game/src/main/java/forge/game/spellability/SpellAbilityRestriction.java#L353) (I couldn't find a case where it was even making a difference)