### PR TITLE
Stop unnecessarily directory scanning 1000s of times when downloading images

### DIFF
--- a/forge-core/src/main/java/forge/ImageKeys.java
+++ b/forge-core/src/main/java/forge/ImageKeys.java
@@ -299,20 +299,13 @@ public final class ImageKeys {
     }
     private static File findFile(String dir, String filename) {
         if (dir.equals(CACHE_CARD_PICS_DIR)) {
-            File f = new File(dir+"/"+filename);
-            String initialDirectory = f.getParent();
-            String cardName = f.getName();
-            File parentDir = new File(initialDirectory);
-            String[] cardNames = parentDir.list();
-            if (cardNames != null) {
-                Set<String> cardList = new HashSet<>(Arrays.asList(cardNames));
-                for (String ext : FILE_EXTENSIONS) {
-                    if (ext.equals(""))
-                        continue;
-                    String cardLookup = cardName+ext;
-                    if (cardList.contains(cardLookup)) {
-                        return new File(parentDir+"/"+cardLookup);
-                    }
+            for (String ext : FILE_EXTENSIONS) {
+                if (ext.equals(""))
+                    continue;
+
+                File f = new File(dir, filename + ext);
+                if (f.exists()) {
+                    return f;
                 }
             }
         } else {

--- a/forge-gui/src/main/java/forge/gui/download/GuiDownloadPicturesLQ.java
+++ b/forge-gui/src/main/java/forge/gui/download/GuiDownloadPicturesLQ.java
@@ -18,11 +18,7 @@
 package forge.gui.download;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
+import java.util.*;
 
 import forge.ImageKeys;
 import forge.StaticData;
@@ -34,7 +30,6 @@ import forge.util.ImageUtil;
 public class GuiDownloadPicturesLQ extends GuiDownloadService {
     final Map<String, String> downloads = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     Set<String> existingSets;
-    ArrayList<String> existingImages;
 
     @Override
     public String getTitle() {
@@ -44,7 +39,6 @@ public class GuiDownloadPicturesLQ extends GuiDownloadService {
     @Override
     protected final Map<String, String> getNeededFiles() {
         File f = new File(ForgeConstants.CACHE_CARD_PICS_DIR);
-        existingImages = new ArrayList<>(Arrays.asList(f.list()));
         existingSets = retrieveManifestDirectory();
 
         for (final PaperCard c : FModel.getMagicDb().getCommonCards().getAllCards()) {

--- a/forge-gui/src/main/java/forge/gui/download/GuiDownloadPicturesLQ.java
+++ b/forge-gui/src/main/java/forge/gui/download/GuiDownloadPicturesLQ.java
@@ -17,7 +17,6 @@
  */
 package forge.gui.download;
 
-import java.io.File;
 import java.util.*;
 
 import forge.ImageKeys;
@@ -38,7 +37,6 @@ public class GuiDownloadPicturesLQ extends GuiDownloadService {
 
     @Override
     protected final Map<String, String> getNeededFiles() {
-        File f = new File(ForgeConstants.CACHE_CARD_PICS_DIR);
         existingSets = retrieveManifestDirectory();
 
         for (final PaperCard c : FModel.getMagicDb().getCommonCards().getAllCards()) {


### PR DESCRIPTION
- Replaces a repeated directory scan and HashSet creation (over a directory that probably has thousands of files) with a File.exists() check. This gets called ~10 times _for each card_ on every image set download attempt.  On my (Windows) machine, this change reduced the time it took to determine image files that need to be downloaded from ~30 minutes to ~10 seconds
- Also cleans out some data structures in the LQ image downloader that weren't being used