### PR TITLE
AiHints upgrade

### DIFF
--- a/forge-core/src/main/java/forge/card/CardRulesPredicates.java
+++ b/forge-core/src/main/java/forge/card/CardRulesPredicates.java
@@ -209,6 +209,16 @@ public final class CardRulesPredicates {
         };
     }
 
+    public static Predicate<CardRules> deckHasExactly(final DeckHints.Type type, final String has[]) {
+        return new Predicate<CardRules>() {
+            @Override
+            public boolean apply(final CardRules card) {
+                DeckHints deckHas = card.getAiHints().getDeckHas();
+                return deckHas != null && deckHas.isValid() && deckHas.is(type, has);
+            }
+        };
+    }
+
     /**
      * Core type.
      *


### PR DESCRIPTION
1. DeckHas for other Types besides Ability$ finally works

2. DeckHas no longer requires exact matching to have an effect but cards that care about multiple entries for a given type will be judged higher if a card seems to provide even "more" synergy for it.
Example:
_Chishiro_ has two abilities so ``DeckHas:Ability$Token & Ability$Counters`` is used, therefore score for ``DeckNeeds:Ability$Token|Counters`` is increased

4. if for some reason you want a type more than once in DeckHas/DeckNeeds you can do so now
this will provide the intersection of both e.g.
``DeckNeeds:Type$Human & Type$Warrior`` will only find Human Warrior compared to ``DeckNeeds:Type$Human|Warrior`` which will match either like before