### PR TITLE
Non-mana abilities incorrectly triggering/replaced

### DIFF
--- a/forge-game/src/main/java/forge/game/spellability/AbilityManaPart.java
+++ b/forge-game/src/main/java/forge/game/spellability/AbilityManaPart.java
@@ -126,20 +126,22 @@ public class AbilityManaPart implements java.io.Serializable {
 
         SpellAbility root = sa == null ? null : sa.getRootAbility();
 
-        final Map<AbilityKey, Object> repParams = AbilityKey.mapFromAffected(source);
-        repParams.put(AbilityKey.Mana, afterReplace);
-        repParams.put(AbilityKey.Player, player);
-        repParams.put(AbilityKey.AbilityMana, root);
-        repParams.put(AbilityKey.Activator, root == null ? null : root.getActivatingPlayer());
+        if (root != null && root.isManaAbility()) {
+            final Map<AbilityKey, Object> repParams = AbilityKey.mapFromAffected(source);
+            repParams.put(AbilityKey.Mana, afterReplace);
+            repParams.put(AbilityKey.Player, player);
+            repParams.put(AbilityKey.AbilityMana, root);
+            repParams.put(AbilityKey.Activator, root.getActivatingPlayer());
 
-        switch (player.getGame().getReplacementHandler().run(ReplacementType.ProduceMana, repParams)) {
-        case NotReplaced:
-            break;
-        case Updated:
-            afterReplace = (String) repParams.get(AbilityKey.Mana);
-            break;
-        default:
-            return;
+            switch (player.getGame().getReplacementHandler().run(ReplacementType.ProduceMana, repParams)) {
+            case NotReplaced:
+                break;
+            case Updated:
+                afterReplace = (String) repParams.get(AbilityKey.Mana);
+                break;
+            default:
+                return;
+            }
         }
 
         //clear lastProduced
@@ -172,7 +174,7 @@ public class AbilityManaPart implements java.io.Serializable {
         runParams.put(AbilityKey.Activator, root == null ? null : root.getActivatingPlayer());
 
         player.getGame().getTriggerHandler().runTrigger(TriggerType.TapsForMana, runParams, false);
-        if (source.isLand() && sa.getPayCosts() != null && sa.getPayCosts().hasTapCost()) {
+        if (source.isLand() && root.isManaAbility() && root.getPayCosts() != null && root.getPayCosts().hasTapCost()) {
             player.setTappedLandForManaThisTurn(true);
         }
     } // end produceMana(String)

--- a/forge-game/src/main/java/forge/game/trigger/TriggerTapsForMana.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerTapsForMana.java
@@ -56,11 +56,12 @@ public class TriggerTapsForMana extends Trigger {
     /** {@inheritDoc}
      * @param runParams*/
     @Override
-    public final boolean performTest(final Map<AbilityKey, Object> runParams) {        
-        //Check for tapping
+    public final boolean performTest(final Map<AbilityKey, Object> runParams) {
+        SpellAbility manaAbility = (SpellAbility) runParams.get(AbilityKey.AbilityMana);
+
+        // Caged Sun special case
         if (!hasParam("NoTapCheck")) {
-            final SpellAbility manaAbility = (SpellAbility) runParams.get(AbilityKey.AbilityMana);
-            if (manaAbility == null || !manaAbility.getRootAbility().getPayCosts().hasTapCost()) {
+            if (manaAbility == null || !manaAbility.isManaAbility() || !manaAbility.getPayCosts().hasTapCost()) {
                 return false;
             }
         }

--- a/forge-gui/res/cardsfolder/p/pillar_of_war.txt
+++ b/forge-gui/res/cardsfolder/p/pillar_of_war.txt
@@ -3,7 +3,7 @@ ManaCost:3
 Types:Artifact Creature Golem
 PT:3/3
 K:Defender
-S:Mode$ CanAttackDefender | Affected$ Card.Self+enchanted | Description$ As long as CARDNAME is enchanted, it can attack as though it didn't have defender.
+S:Mode$ CanAttackDefender | ValidCard$ Card.Self+enchanted | Description$ As long as CARDNAME is enchanted, it can attack as though it didn't have defender.
 SVar:EnchantMe:Once
 DeckHints:Type$Enchantment
 Oracle:Defender\nAs long as Pillar of War is enchanted, it can attack as though it didn't have defender.

--- a/forge-gui/res/cardsfolder/p/piston_fist_cyclops.txt
+++ b/forge-gui/res/cardsfolder/p/piston_fist_cyclops.txt
@@ -3,7 +3,7 @@ ManaCost:1 U/R U/R
 Types:Creature Cyclops
 PT:4/3
 K:Defender
-S:Mode$ CanAttackDefender | Affected$ Card.Self | CheckSVar$ X | Description$ As long as you've cast an instant or sorcery spell this turn, CARDNAME can attack as though it didn't have defender.
+S:Mode$ CanAttackDefender | ValidCard$ Card.Self | CheckSVar$ X | Description$ As long as you've cast an instant or sorcery spell this turn, CARDNAME can attack as though it didn't have defender.
 SVar:X:Count$ThisTurnCast_Instant.YouOwn,Sorcery.YouOwn
 SVar:BuffedBy:Instant,Sorcery
 DeckHints:Type$Instant|Sorcery


### PR DESCRIPTION
If you have _Ashaya_ and activate _Deathrite Shaman_ first ability to generate mana _Vorinclex, Voice of Hunger_ or _Naked Singularity_ can both affect it.

> 106.12a. An ability that triggers whenever a permanent "is tapped for mana" or is tapped for mana of a specified type triggers whenever such a mana ability resolves and produces mana or the specified type of mana.
106.12b. A replacement effect that applies if a permanent "is tapped for mana" or tapped for mana of a specific type and/or amount modifies the mana production event while such an ability is resolving and producing mana or the specified type and/or amount of mana.

_Caged Sun_ should continue to work for non-mana abilities.