### PR TITLE
[Adventure] Add continue button to main menu

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/data/SettingData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/SettingData.java
@@ -13,4 +13,5 @@ public class SettingData {
     public String plane;
     public boolean fullScreen;
     public String videomode;
+    public String lastActiveSave;
 }

--- a/forge-gui-mobile/src/forge/adventure/scene/StartScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/StartScene.java
@@ -3,8 +3,6 @@ package forge.adventure.scene;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
-import com.sun.org.slf4j.internal.Logger;
-import com.sun.org.slf4j.internal.LoggerFactory;
 import forge.Forge;
 import forge.adventure.stage.GameHUD;
 import forge.adventure.stage.MapStage;
@@ -16,8 +14,6 @@ import forge.screens.TransitionScreen;
  * First scene after the splash screen
  */
 public class StartScene extends UIScene {
-
-    final Logger log = LoggerFactory.getLogger(StartScene.class);
 
     TextButton saveButton, resumeButton, continueButton, newGameButton, newGameButtonPlus, loadButton, settingsButton, exitButton, switchButton;
 

--- a/forge-gui-mobile/src/forge/adventure/scene/StartScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/StartScene.java
@@ -3,16 +3,23 @@ package forge.adventure.scene;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
+import com.sun.org.slf4j.internal.Logger;
+import com.sun.org.slf4j.internal.LoggerFactory;
 import forge.Forge;
 import forge.adventure.stage.GameHUD;
 import forge.adventure.stage.MapStage;
+import forge.adventure.util.Config;
 import forge.adventure.world.WorldSave;
+import forge.screens.TransitionScreen;
 
 /**
  * First scene after the splash screen
  */
 public class StartScene extends UIScene {
-    TextButton saveButton, resumeButton, newGameButton, newGameButtonPlus, loadButton, settingsButton, exitButton, switchButton;
+
+    final Logger log = LoggerFactory.getLogger(StartScene.class);
+
+    TextButton saveButton, resumeButton, continueButton, newGameButton, newGameButtonPlus, loadButton, settingsButton, exitButton, switchButton;
 
     public StartScene() {
         super(Forge.isLandscapeMode()?"ui/start_menu.json":"ui/start_menu_portrait.json");
@@ -45,6 +52,23 @@ public class StartScene extends UIScene {
         return true;
     }
 
+    public boolean Continue() {
+        final String lastActiveSave = Config.instance().getSettingData().lastActiveSave;
+
+        if (WorldSave.isSafeFile(lastActiveSave) && WorldSave.load(WorldSave.filenameToSlot(lastActiveSave))) {
+            Forge.setTransitionScreen(new TransitionScreen(new Runnable() {
+                @Override
+                public void run() {
+                    Forge.switchScene(SceneType.GameScene.instance);
+                }
+            }, null, false, true));
+        } else {
+            Forge.clearTransitionScreen();
+        }
+
+        return true;
+    }
+
     public boolean settings() {
         Forge.switchScene(SceneType.SettingsScene.instance);
         return true;
@@ -61,7 +85,13 @@ public class StartScene extends UIScene {
         if (hasSaveButton)
             hasSaveButton = !((TileMapScene) SceneType.TileMapScene.instance).currentMap().isInMap();
         saveButton.setVisible(hasSaveButton);
-        resumeButton.setVisible(WorldSave.getCurrentSave().getWorld().getData() != null);
+
+        boolean hasResumeButton = WorldSave.getCurrentSave().getWorld().getData() != null;
+        resumeButton.setVisible(hasResumeButton);
+
+        // Continue button mutually exclusive with resume button
+        continueButton.setVisible(Config.instance().getSettingData().lastActiveSave != null && !hasResumeButton);
+
         Gdx.input.setInputProcessor(stage); //Start taking input from the ui
     }
 
@@ -87,6 +117,7 @@ public class StartScene extends UIScene {
             ui.onButtonPress("Load", () -> StartScene.this.Load());
             ui.onButtonPress("Save", () -> StartScene.this.Save());
             ui.onButtonPress("Resume", () -> StartScene.this.Resume());
+            ui.onButtonPress("Continue", () -> StartScene.this.Continue());
             ui.onButtonPress("Settings", () -> StartScene.this.settings());
             ui.onButtonPress("Exit", () -> StartScene.this.Exit());
             ui.onButtonPress("Switch", () -> Forge.switchToClassic());
@@ -101,6 +132,8 @@ public class StartScene extends UIScene {
             saveButton.getLabel().setText(Forge.getLocalizer().getMessage("lblSave"));
             resumeButton = ui.findActor("Resume");
             resumeButton.getLabel().setText(Forge.getLocalizer().getMessage("lblResume"));
+            continueButton = ui.findActor("Continue");
+            continueButton.getLabel().setText(Forge.getLocalizer().getMessage("lblContinue"));
             settingsButton = ui.findActor("Settings");
             settingsButton.getLabel().setText(Forge.getLocalizer().getMessage("lblSettings"));
             exitButton = ui.findActor("Exit");

--- a/forge-gui-mobile/src/forge/adventure/world/WorldSave.java
+++ b/forge-gui-mobile/src/forge/adventure/world/WorldSave.java
@@ -166,6 +166,9 @@ public class WorldSave   {
             e.printStackTrace();
             return false;
         }
+
+        Config.instance().getSettingData().lastActiveSave = WorldSave.filename(currentSlot);
+        Config.instance().saveSettings();
         return true;
     }
 

--- a/forge-gui/res/adventure/Shandalar/ui/start_menu.json
+++ b/forge-gui/res/adventure/Shandalar/ui/start_menu.json
@@ -56,6 +56,15 @@
     },
     {
       "type": "TextButton",
+      "name": "Continue",
+      "text": "Continue",
+      "width": 160,
+      "height": 30,
+      "x": 160,
+      "y": 140
+    },
+    {
+      "type": "TextButton",
       "name": "Settings",
       "text": "Settings",
       "width": 160,

--- a/forge-gui/res/adventure/Shandalar/ui/start_menu_portrait.json
+++ b/forge-gui/res/adventure/Shandalar/ui/start_menu_portrait.json
@@ -56,6 +56,15 @@
     },
     {
       "type": "TextButton",
+      "name": "Continue",
+      "text": "Continue",
+      "width": 238,
+      "height": 48,
+      "x": 16,
+      "yOffset": 8
+    },
+    {
+      "type": "TextButton",
       "name": "Settings",
       "text": "Settings",
       "width": 238,

--- a/forge-gui/res/languages/en-US.properties
+++ b/forge-gui/res/languages/en-US.properties
@@ -2878,6 +2878,7 @@ lblStart=Start
 lblLoad=Load
 lblSaveGame=Save Game
 lblResume=Resume
+lblContinue=Continue
 lblClassic=Classic
 lblClassicMode=Classic Mode
 lblAdventureMode=Adventure Mode


### PR DESCRIPTION
Persist the filename of the last game that was saved in `settings.json` and, if it's not `null` and the user isn't in a game, display a continue button that loads it. 

Notes:
- `settings.json` may not be the right place to persist this, but it seems like the best fit from what I could see
- I have not localised the continue string for locales other than `en-US`
- We load the save directly from `StartScene`, which seems non-idiomatic, but creating a separate scene seems wasteful unless we want to provide other info to the user
- It's possible the desired behaviour is actually to use the most recently *loaded* filename rather than the most recently *saved*