### PR TITLE
Fixed quest deck 'Evangelyne (hard)'

### DIFF
--- a/forge-gui/res/quest/duels/Evangelyne 3.dck
+++ b/forge-gui/res/quest/duels/Evangelyne 3.dck
@@ -6,6 +6,7 @@ Difficulty=hard
 Description=Selesnya Stompy ramp deck with Primordial Hydra, Nullhide Ferox, Shalai, Voice of Plenty, and Ghalta, Primal Hunger.
 Deck Type=constructed
 Icon=Evangelyne.jpg
+[main]
 1 Black Lotus|LEA
 3 Conclave Tribunal|GRN
 2 Emmara, Soul of the Accord|GRN


### PR DESCRIPTION
Quest deck 'Evangelyne (hard)' was missing then [main] tag in its .dck file.

As a result, AI's library was empty and the player won turn 0, because AI could not draw a card. The player also got a ton of achievements -- win by turn 0, win without playing any spells, win while having 0 lands, etc -- and a ton of gold (about 1700).

The game log typically looked like this:

> Phase: Jakob's Untap step
> Turn: Turn 1 (Jakob)
> Match result: Jakob: 1 Evangelyne: 0 
> Game outcome: **Evangelyne has lost trying to draw cards from empty library**
> Game outcome: Jakob has won because all opponents have lost
> Game outcome: **Turn 0**
> Player control: Evangelyne is controlled by Evangelyne
> Player control: Jakob is controlled by Jakob
> Mulligan: **Evangelyne has kept a hand of 0 cards**
> Mulligan: Jakob has kept a hand of 7 cards