### PR TITLE
Fix The Fallen ignoring planeswalkers

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/CountersPutAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CountersPutAi.java
@@ -752,14 +752,16 @@ public class CountersPutAi extends CountersAi {
         final int amount = AbilityUtils.calculateAmount(source, amountStr, sa);
         int left = amount;
         final String[] types;
+        String type = "";
         if (sa.hasParam("CounterType")) {
             // TODO some cards let you choose types, should check each
             types = sa.getParam("CounterType").split(",");
-        } else {
+            type = types[0];
+        } else if (sa.hasParam("CounterTypes")) {
             // all types will be added
             types = sa.getParam("CounterTypes").split(",");
+            type = types[0];
         }
-        final String type = types[0];
 
         if (!sa.usesTargeting()) {
             // No target. So must be defined

--- a/forge-game/src/main/java/forge/game/GameEntityCounterTable.java
+++ b/forge-game/src/main/java/forge/game/GameEntityCounterTable.java
@@ -94,7 +94,9 @@ public class GameEntityCounterTable extends ForwardingTable<Optional<Player>, Ga
                 for (Map<CounterType, Integer> cm : gm.getValue().values()) {
                     Integer old = ObjectUtils.firstNonNull(result.get(gm.getKey()), 0);
                     Integer v = ObjectUtils.firstNonNull(cm.get(type), 0);
-                    result.put(gm.getKey(), old + v);
+                    if (old + v > 0) {
+                        result.put(gm.getKey(), old + v);
+                    }
                 }
             }
         }

--- a/forge-game/src/main/java/forge/game/card/CardProperty.java
+++ b/forge-game/src/main/java/forge/game/card/CardProperty.java
@@ -1160,7 +1160,7 @@ public class CardProperty {
         } else if (property.startsWith("dealtCombatDamage") || property.startsWith("notDealtCombatDamage")) {
             final String[] v = property.split(" ")[1].split(",");
             final Iterable<GameEntity> list = property.contains("ThisCombat") ?
-                    card.getDamageHistory().getThisCombatDamaged().keySet() :
+                    Lists.newArrayList(card.getDamageHistory().getThisCombatDamaged()) :
                     card.getDamageHistory().getThisTurnCombatDamaged().keySet();
             boolean found = Iterables.any(list, GameObjectPredicates.restriction(v, sourceController, source, spellAbility));
             if (found == property.startsWith("not")) {
@@ -1180,6 +1180,15 @@ public class CardProperty {
             }
         } else if (property.equals("wasDealtNonCombatDamageThisTurn")) {
             if (!card.getDamageHistory().hasBeenDealtNonCombatDamageThisTurn()) {
+                return false;
+            }
+        } else if (property.startsWith("wasDealtDamageByThisGame")) {
+            int idx = source.getDamageHistory().getThisGameDamaged().indexOf(card);
+            if (idx == -1) {
+                return false;
+            }
+            Card c = (Card) source.getDamageHistory().getThisGameDamaged().get(idx);
+            if (!c.equalsWithTimestamp(game.getCardState(card))) {
                 return false;
             }
         } else if (property.startsWith("dealtDamageThisTurn")) {

--- a/forge-game/src/main/java/forge/game/player/PlayerProperty.java
+++ b/forge-game/src/main/java/forge/game/player/PlayerProperty.java
@@ -94,7 +94,7 @@ public class PlayerProperty {
             final List<Card> cards = AbilityUtils.getDefinedCards(source, v, spellAbility);
             int found = 0;
             for (final Card card : cards) {
-                if (card.getDamageHistory().getThisCombatDamaged().containsKey(player)) {
+                if (card.getDamageHistory().getThisCombatDamaged().contains(player)) {
                     found++;
                 }
             }
@@ -113,7 +113,7 @@ public class PlayerProperty {
             final List<Card> cards = AbilityUtils.getDefinedCards(source, v, spellAbility);
             int found = 0;
             for (final Card card : cards) {
-                if (card.getDamageHistory().getThisGameDamaged().containsKey(player)) {
+                if (card.getDamageHistory().getThisGameDamaged().contains(player)) {
                     found++;
                 }
             }

--- a/forge-gui/res/cardsfolder/a/ancient_brass_dragon.txt
+++ b/forge-gui/res/cardsfolder/a/ancient_brass_dragon.txt
@@ -6,7 +6,7 @@ K:Flying
 T:Mode$ DamageDone | ValidSource$ Card.Self | Execute$ TrigRoll | CombatDamage$ True | ValidTarget$ Player | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, roll a d20. When you do, put any number of target creature cards with total mana value X or less from graveyards onto the battlefield under your control, where X is the result.
 SVar:TrigRoll:DB$ RollDice | ResultSVar$ Result | Sides$ 20 | SubAbility$ DBImmediateTrigger
 SVar:DBImmediateTrigger:DB$ ImmediateTrigger | Execute$ TrigChangeZone | RememberSVarAmount$ Result | TriggerDescription$ When you do, put any number of target creature cards with total mana value X or less from graveyards onto the battlefield under your control, where X is the result.
-SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | TargetMin$ 0 | TargetMax$ Y | ValidTgts$ Creature | TgtPrompt$ Select any number of target creature cards with total mana value X or less from graveyards | WithTotalCMC$ X | GainControl$ True
+SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | TargetMin$ 0 | TargetMax$ Y | ValidTgts$ Creature | TgtPrompt$ Select any number of target creature cards with total mana value X or less from graveyards | MaxTotalTargetCMC$ X | GainControl$ True
 SVar:X:Count$TriggerRememberAmount
 SVar:Y:Count$TypeInAllYards.Creature
 DeckHas:Ability$Graveyard

--- a/forge-gui/res/cardsfolder/b/bess_soul_nourisher.txt
+++ b/forge-gui/res/cardsfolder/b/bess_soul_nourisher.txt
@@ -2,7 +2,7 @@ Name:Bess, Soul Nourisher
 ManaCost:1 G W
 Types:Legendary Creature Human Citizen
 PT:1/1
-T:Mode$ ChangesZoneAll | ValidCards$ Creature.basePowerEQ1+baseToughnessEQ1+Other | Destination$ Battlefield | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Whenever one or more other creatures with base power and toughness 1/1 enter the battlefield under your control, put a +1/+1 counter on CARDNAME.
+T:Mode$ ChangesZoneAll | ValidCards$ Creature.basePowerEQ1+baseToughnessEQ1+Other+YouCtrl | Destination$ Battlefield | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Whenever one or more other creatures with base power and toughness 1/1 enter the battlefield under your control, put a +1/+1 counter on CARDNAME.
 SVar:TrigPutCounter:DB$ PutCounter | CounterType$ P1P1
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPumpAll | TriggerDescription$ Whenever NICKNAME attacks, each other creature you control with base power and toughness 1/1 gets +X/+X until end of turn, where X is the number of +1/+1 counters on NICKNAME.
 SVar:TrigPumpAll:DB$ PumpAll | ValidCards$ Creature.basePowerEQ1+baseToughnessEQ1+Other | NumAtt$ +X | NumDef$ +X

--- a/forge-gui/res/cardsfolder/t/the_fallen.txt
+++ b/forge-gui/res/cardsfolder/t/the_fallen.txt
@@ -3,5 +3,5 @@ ManaCost:1 B B B
 Types:Creature Zombie
 PT:2/3
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ TrigDamage | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, CARDNAME deals 1 damage to each opponent and planeswalker it has dealt damage to this game.
-SVar:TrigDamage:DB$ DealDamage | Defined$ Player.Opponent+wasDealtDamageThisGameBy Self | NumDmg$ 1
+SVar:TrigDamage:DB$ DamageAll | ValidPlayers$ Player.Opponent+wasDealtDamageThisGameBy Self | ValidCards$ Planeswalker.wasDealtDamageByThisGame | NumDmg$ 1
 Oracle:At the beginning of your upkeep, The Fallen deals 1 damage to each opponent and planeswalker it has dealt damage to this game.


### PR DESCRIPTION
Most importantly, added manual cleanup because unfortunately every single card has to track its damage dealt for the whole game for this unique ability.

This helps with earlier Garbage Collection, which can be quite a few Card and related objects like View or State etc.