### PR TITLE
Capricopian PW fix

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeCombatantsEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeCombatantsEffect.java
@@ -21,7 +21,7 @@ import forge.game.spellability.SpellAbilityStackInstance;
 import forge.game.spellability.TargetRestrictions;
 import forge.util.CardTranslation;
 import forge.util.Localizer;
-import forge.util.collect.FCollectionView;
+import forge.util.collect.FCollection;
 
 public class ChangeCombatantsEffect extends SpellAbilityEffect {
 
@@ -47,7 +47,8 @@ public class ChangeCombatantsEffect extends SpellAbilityEffect {
             if ((tgt == null) || c.canBeTargetedBy(sa)) {
                 final Combat combat = game.getCombat();
                 final GameEntity originalDefender = combat.getDefenderByAttacker(c);
-                final FCollectionView<GameEntity> defs = combat.getDefenders();
+                final FCollection<GameEntity> defs = new FCollection<>();
+                defs.addAll(sa.hasParam("PlayerOnly") ? combat.getDefendingPlayers() : combat.getDefenders());
 
                 String title = Localizer.getInstance().getMessage("lblChooseDefenderToAttackWithCard", CardTranslation.getTranslatedName(c.getName()));
                 Map<String, Object> params = Maps.newHashMap();

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityCantBeCast.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityCantBeCast.java
@@ -109,7 +109,7 @@ public class StaticAbilityCantBeCast {
             return false;
         }
 
-        if (stAb.hasParam("OnlySorcerySpeed") && (activator != null) && activator.canCastSorcery()) {
+        if (stAb.hasParam("OnlySorcerySpeed") && activator != null && activator.canCastSorcery()) {
             return false;
         }
 
@@ -120,12 +120,12 @@ public class StaticAbilityCantBeCast {
             }
         }
 
-        if (stAb.hasParam("NonCasterTurn") && (activator != null)
+        if (stAb.hasParam("NonCasterTurn") && activator != null
                 && activator.getGame().getPhaseHandler().isPlayerTurn(activator)) {
             return false;
         }
 
-        if (stAb.hasParam("cmcGT") && (activator != null)) {
+        if (stAb.hasParam("cmcGT") && activator != null) {
             if (stAb.getParam("cmcGT").equals("Turns")) {
                 if (card.getCMC() <= activator.getTurn()) {
                     return false;
@@ -176,7 +176,7 @@ public class StaticAbilityCantBeCast {
             return false;
         }
 
-        if (stAb.hasParam("NonActivatorTurn") && (activator != null)
+        if (stAb.hasParam("NonActivatorTurn") && activator != null
                 && activator.getGame().getPhaseHandler().isPlayerTurn(activator)) {
             return false;
         }

--- a/forge-gui/res/cardsfolder/c/capricopian.txt
+++ b/forge-gui/res/cardsfolder/c/capricopian.txt
@@ -4,7 +4,7 @@ Types:Creature Goat Hydra
 PT:0/0
 K:etbCounter:P1P1:X
 SVar:X:Count$xPaid
-A:AB$ PutCounter | Cost$ 2 | Activator$ Player.attackedBySourceThisCombat | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBReselect | ActivationPhases$ Declare Attackers | AILogic$ AlwaysWithNoTgt | SpellDescription$ Put a +1/+1 counter on CARDNAME, then you may reselect which player CARDNAME is attacking. Only the player CARDNAME is attacking may activate this ability and only during the declare attackers step. (It can't attack its controller.)
-SVar:DBReselect:DB$ ChangeCombatants | Defined$ Self | AILogic$ WeakestOppExceptCtrl
+A:AB$ PutCounter | Cost$ 2 | Activator$ Player | IsPresent$ Card.Self+attackingYou | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBReselect | ActivationPhases$ Declare Attackers | AILogic$ AlwaysWithNoTgt | SpellDescription$ Put a +1/+1 counter on CARDNAME, then you may reselect which player CARDNAME is attacking. Only the player CARDNAME is attacking may activate this ability and only during the declare attackers step. (It can't attack its controller.)
+SVar:DBReselect:DB$ ChangeCombatants | Defined$ Self | AILogic$ WeakestOppExceptCtrl | PlayerOnly$ True
 DeckHas:Ability$Counters
 Oracle:Capricopian enters the battlefield with X +1/+1 counters on it.\n{2}: Put a +1/+1 counter on Capricopian, then you may reselect which player Capricopian is attacking. Only the player Capricopian is attacking may activate this ability and only during the declare attackers step. (It can't attack its controller.)

--- a/forge-gui/res/cardsfolder/c/chronozoa.txt
+++ b/forge-gui/res/cardsfolder/c/chronozoa.txt
@@ -4,7 +4,6 @@ Types:Creature Illusion
 PT:3/3
 K:Flying
 K:Vanishing:3
-T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigCopyPermanent | TriggerDescription$ When CARDNAME dies, if it had no time counters on it, create two tokens that are copies of it.
-SVar:TrigCopyPermanent:DB$ CopyPermanent | Defined$ TriggeredCard | NumCopies$ 2 | ConditionCheckSVar$ X | ConditionSVarCompare$ EQ0
-SVar:X:TriggeredCard$CardCounters.TIME
+T:Mode$ ChangesZone | ValidCard$ Card.Self+counters_EQ0_TIME | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigCopyPermanent | TriggerDescription$ When CARDNAME dies, if it had no time counters on it, create two tokens that are copies of it.
+SVar:TrigCopyPermanent:DB$ CopyPermanent | Defined$ TriggeredCard | NumCopies$ 2
 Oracle:Flying\nVanishing 3 (This creature enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Chronozoa dies, if it had no time counters on it, create two tokens that are copies of it.

--- a/forge-gui/res/cardsfolder/e/epic_experiment.txt
+++ b/forge-gui/res/cardsfolder/e/epic_experiment.txt
@@ -2,7 +2,7 @@ Name:Epic Experiment
 ManaCost:X U R
 Types:Sorcery
 A:SP$ Dig | Cost$ X U R | Defined$ You | DigNum$ X | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBPlay | SpellDescription$ Exile the top X cards of your library. You may cast instant and sorcery spells with mana value X or less from among them without paying their mana costs. Then put all cards exiled this way that weren't cast into your graveyard.
-SVar:DBPlay:DB$ Play | Valid$ Instant.cmcLEX+IsRemembered+YouOwn,Sorcery.cmcLEX+IsRemembered+YouOwn | ValidZone$ Exile | ValidSA$ Spell | Controller$ You | WithoutManaCost$ True | Optional$ True | Amount$ All | SubAbility$ DBGrave
+SVar:DBPlay:DB$ Play | Valid$ Card.IsRemembered+YouOwn | ValidZone$ Exile | ValidSA$ Instant.cmcLEX,Sorcery.cmcLEX | Controller$ You | WithoutManaCost$ True | Optional$ True | Amount$ All | SubAbility$ DBGrave
 SVar:DBGrave:DB$ ChangeZoneAll | Origin$ Exile | Destination$ Graveyard | ChangeType$ Card.IsRemembered+YouOwn | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Count$xPaid

--- a/forge-gui/res/cardsfolder/m/martial_impetus.txt
+++ b/forge-gui/res/cardsfolder/m/martial_impetus.txt
@@ -5,5 +5,5 @@ K:Enchant creature
 A:SP$ Attach | Cost$ 2 W | ValidTgts$ Creature | AILogic$ Pump
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | AddToughness$ 1 | Goad$ True | Description$ Enchanted creature gets +1/+1 and is goaded. (It attacks each combat if able and attacks a player other than you if able.)
 T:Mode$ Attacks | ValidCard$ Card.AttachedBy | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever enchanted creature attacks, each other creature that's attacking one of your opponents gets +1/+1 until end of turn.
-SVar:TrigPump:DB$ PumpAll | ValidCards$ Creature.NotEnchantedBy+attackingOpponent | NumAtt$ +1 | NumDef$ +1
+SVar:TrigPump:DB$ PumpAll | ValidCards$ Creature.NotEnchantedBy+attacking Opponent | NumAtt$ +1 | NumDef$ +1
 Oracle:Enchant creature\nEnchanted creature gets +1/+1 and is goaded. (It attacks each combat if able and attacks a player other than you if able.)\nWhenever enchanted creature attacks, each other creature that's attacking one of your opponents gets +1/+1 until end of turn.


### PR DESCRIPTION
> The player Capricopian is attacking can’t reselect it to attack a planeswalker instead. If Capricopian is attacking a planeswalker, no player may activate its last ability. 