### PR TITLE
Fix scripts

### DIFF
--- a/forge-ai/src/main/java/forge/ai/GameState.java
+++ b/forge-ai/src/main/java/forge/ai/GameState.java
@@ -15,7 +15,6 @@ import forge.card.MagicColor;
 import forge.card.mana.ManaAtom;
 import forge.game.Game;
 import forge.game.GameEntity;
-import forge.game.GameObject;
 import forge.game.ability.AbilityFactory;
 import forge.game.ability.effects.DetachedCardEffect;
 import forge.game.card.Card;
@@ -862,9 +861,7 @@ public abstract class GameState {
         }
 
         if (sa.hasParam("RememberTargets")) {
-            for (final GameObject o : sa.getTargets()) {
-                sa.getHostCard().addRemembered(o);
-            }
+            sa.getHostCard().addRemembered(sa.getTargets());
         }
     }
 

--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -1245,6 +1245,8 @@ public class GameAction {
             c.updateAbilityTextForView(); // only update keywords and text for view to avoid flickering
         }
 
+        // TODO filter out old copies from zone change
+
         if (runEvents && !affectedCards.isEmpty()) {
             game.fireEvent(new GameEventCardStatsChanged(affectedCards));
         }

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -503,7 +503,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
             if (game != null) {
                 // update Type, color and keywords again if they have changed
                 if (!changedCardTypes.isEmpty()) {
-                    currentState.getView().updateType(currentState);
+                    updateTypesForView();;
                 }
                 updateColorForView();
 

--- a/forge-gui/res/cardsfolder/m/mogg_assassin.txt
+++ b/forge-gui/res/cardsfolder/m/mogg_assassin.txt
@@ -3,7 +3,7 @@ ManaCost:2 R
 Types:Creature Goblin Assassin
 PT:2/1
 A:AB$ Pump | Cost$ T | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | RememberObjects$ ThisTargetedCard | IsCurse$ True | SubAbility$ DBPump | StackDescription$ You choose {c:ThisTargetedCard} | SpellDescription$ You choose target creature an opponent controls, and that opponent chooses target creature. Flip a coin. If you win the flip, destroy the creature you chose. If you lose the flip, destroy the creature your opponent chose.
-SVar:DBPump:DB$ Pump | ValidTgts$ Creature | TargetingPlayer$ Player.Opponent | IsCurse$ True | ImprintCards$ ThisTargetedCard | SubAbility$ DBFlip | StackDescription$ That player chooses {c:ThisTargetedCard}
+SVar:DBPump:DB$ Pump | ValidTgts$ Creature | TargetingPlayer$ ParentTargetedController | IsCurse$ True | ImprintCards$ ThisTargetedCard | SubAbility$ DBFlip | StackDescription$ That player chooses {c:ThisTargetedCard}
 SVar:DBFlip:DB$ FlipACoin | WinSubAbility$ DestroyRemembered | LoseSubAbility$ DestroyImprinted | SubAbility$ DBCleanup
 SVar:DestroyRemembered:DB$ Destroy | Defined$ Remembered
 SVar:DestroyImprinted:DB$ Destroy | Defined$ Imprinted

--- a/forge-gui/res/cardsfolder/s/searing_blaze.txt
+++ b/forge-gui/res/cardsfolder/s/searing_blaze.txt
@@ -2,7 +2,7 @@ Name:Searing Blaze
 ManaCost:R R
 Types:Instant
 A:SP$ DealDamage | Cost$ R R | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | NumDmg$ SearingX | DamageMap$ True | SubAbility$ SearingDamage | SpellDescription$ CARDNAME deals 1 damage to target player or planeswalker and 1 damage to target creature that player or that planeswalker's controller controls. Landfall — If you had a land enter the battlefield under your control this turn, CARDNAME deals 3 damage to that player or planeswalker and 3 damage to that creature instead.
-SVar:SearingDamage:DB$ DealDamage | ValidTgts$ Creature.ControlledBy TargetedOrController | TgtPrompt$ Select target creature that player or that planeswalker's controller controls | NumDmg$ SearingX | SubAbility$ DBDamageResolve
+SVar:SearingDamage:DB$ DealDamage | ValidTgts$ Creature.ControlledBy ParentTargetedController,Creature.ControlledBy ParentTarget | TgtPrompt$ Select target creature that player or that planeswalker's controller controls | NumDmg$ SearingX | SubAbility$ DBDamageResolve
 SVar:DBDamageResolve:DB$ DamageResolve
 SVar:SearingX:Count$Landfall.3.1
 Oracle:Searing Blaze deals 1 damage to target player or planeswalker and 1 damage to target creature that player or that planeswalker's controller controls.\nLandfall — If you had a land enter the battlefield under your control this turn, Searing Blaze deals 3 damage to that player or planeswalker and 3 damage to that creature instead.

--- a/forge-gui/res/cardsfolder/upcoming/ancient_bronze_dragon.txt
+++ b/forge-gui/res/cardsfolder/upcoming/ancient_bronze_dragon.txt
@@ -6,6 +6,7 @@ K:Flying
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigRoll | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, roll a d20. When you do, put X +1/+1 counters on each of up to two target creatures, where X is the result.
 SVar:TrigRoll:DB$ RollDice | ResultSVar$ Result | Sides$ 20 | SubAbility$ DBImmediateTrigPutCounter
 SVar:DBImmediateTrigPutCounter:DB$ ImmediateTrigger | Execute$ TrigPutCounter | RememberSVarAmount$ Result | TriggerDescription$ When you do, put X +1/+1 counters on each of up to two target creatures, where X is the result.
-SVar:TrigPutCounter:DB$ PutCounter | TargetMin$ 0 | TargetMax$ 2 | ValidTgts$ Creature | TgtPrompt$ Select up to two target creatures | CounterType$ P1P1 | CounterNum$ Result
+SVar:TrigPutCounter:DB$ PutCounter | TargetMin$ 0 | TargetMax$ 2 | ValidTgts$ Creature | TgtPrompt$ Select up to two target creatures | CounterType$ P1P1 | CounterNum$ X
+SVar:X:Count$TriggerRememberAmount
 DeckHas:Ability$Counters
 Oracle:Flying\nWhenever Ancient Bronze Dragon deals combat damage to a player, roll a d20. When you do, put X +1/+1 counters on each of up to two target creatures, where X is the result.

--- a/forge-gui/res/cardsfolder/y/yosei_the_morning_star.txt
+++ b/forge-gui/res/cardsfolder/y/yosei_the_morning_star.txt
@@ -4,6 +4,6 @@ Types:Legendary Creature Dragon Spirit
 PT:5/5
 K:Flying
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigSkipPhase | TriggerDescription$ When CARDNAME dies, target player skips their next untap step. Tap up to five target permanents that player controls.
-SVar:TrigSkipPhase:DB$ SkipPhase | ValidTgts$ Player | Step$ Untap | IsCurse$ True | SubAbility$ TrigTap
-SVar:TrigTap:DB$ Tap | TargetMin$ 0 | TargetMax$ 5 | TargetsWithDefinedController$ ParentTarget | ValidTgts$ Permanent
+SVar:TrigSkipPhase:DB$ SkipPhase | ValidTgts$ Player | Step$ Untap | RememberOriginalTargets$ True | IsCurse$ True | SubAbility$ TrigTap
+SVar:TrigTap:DB$ Tap | TargetMin$ 0 | TargetMax$ 5 | ValidTgts$ Permanent.ControlledBy ParentTarget,Permanent.ControlledBy Remembered
 Oracle:Flying\nWhen Yosei, the Morning Star dies, target player skips their next untap step. Tap up to five target permanents that player controls.


### PR DESCRIPTION
Closes #714

Yosei not tapping if player gains hexproof:
> If the player becomes an illegal target, the target permanents are tapped, but the player doesn’t skip their untap step. 