### PR TITLE
CardType: better handling for multiword types

### DIFF
--- a/forge-core/src/main/java/forge/card/CardType.java
+++ b/forge-core/src/main/java/forge/card/CardType.java
@@ -51,6 +51,7 @@ public final class CardType implements Comparable<CardType>, CardTypeView {
     private static final long serialVersionUID = 4629853583167022151L;
 
     public static final CardTypeView EMPTY = new CardType(false);
+    private static final Set<String> multiWordTypes = ImmutableSet.of("Serra's Realm", "Bolas's Meditation Realm", "Dungeon Master");
 
     public enum CoreType {
         Artifact(true, "artifacts"),
@@ -752,12 +753,14 @@ public final class CardType implements Comparable<CardType>, CardTypeView {
         while (hasMoreTypes) {
             final String type = typeText.substring(iTypeStart, iSpace == -1 ? typeText.length() : iSpace);
             hasMoreTypes = iSpace != -1;
-            if (!isMultiwordType(type) || !hasMoreTypes) {
-                iTypeStart = iSpace + 1;
-                if (!"-".equals(type)) {
-                    result.add(type);
-                }
+            final String rest = typeText.substring(iTypeStart);
+            if (isMultiwordType(rest)) {
+                result.add(rest);
+                break;
             }
+
+            iTypeStart = iSpace + 1;
+            result.add(type);
             iSpace = typeText.indexOf(space, iSpace + 1);
         }
         return result;
@@ -775,13 +778,7 @@ public final class CardType implements Comparable<CardType>, CardTypeView {
     }
 
     private static boolean isMultiwordType(final String type) {
-        final String[] multiWordTypes = { "Serra's Realm", "Bolas's Meditation Realm", "Dungeon Master" };
-        for (int i = 0; i < multiWordTypes.length; ++i) {
-            if (multiWordTypes[i].startsWith(type) && !multiWordTypes[i].equals(type)) {
-                return true;
-            }
-        }
-        return false;
+        return multiWordTypes.contains(type);
     }
 
     public static class Constant {

--- a/forge-game/src/main/java/forge/game/ability/effects/VentureEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/VentureEffect.java
@@ -24,6 +24,7 @@ import forge.game.trigger.WrappedAbility;
 import forge.game.zone.ZoneType;
 import forge.item.PaperCard;
 import forge.util.Localizer;
+import forge.util.PredicateString.StringOp;
 
 public class VentureEffect  extends SpellAbilityEffect {
 
@@ -42,18 +43,21 @@ public class VentureEffect  extends SpellAbilityEffect {
             }
         }
 
-        Card dungeon = null;
+        List<PaperCard> dungeonCards = null;
         if (sa.hasParam("Dungeon")) {
-            dungeon = Card.fromPaperCard(StaticData.instance().getVariantCards().getUniqueByName(
-                    sa.getParam("Dungeon")), player);
+            dungeonCards = StaticData.instance().getVariantCards()
+                    .getAllCards(Predicates.compose(
+                            Predicates.and(CardRulesPredicates.Presets.IS_DUNGEON,
+                                    CardRulesPredicates.subType(StringOp.EQUALS, sa.getParam("Dungeon"))),
+                            PaperCard.FN_GET_RULES));
         } else {
             // Create a new dungeon card chosen by player in command zone.
-            List<PaperCard> dungeonCards = StaticData.instance().getVariantCards().getAllCards(
+            dungeonCards = StaticData.instance().getVariantCards().getAllCards(
                 Predicates.compose(CardRulesPredicates.Presets.IS_DUNGEON, PaperCard.FN_GET_RULES));
             dungeonCards.removeIf(c -> !c.getRules().isEnterableDungeon());
-            String message = Localizer.getInstance().getMessage("lblChooseDungeon");
-            dungeon = player.getController().chooseDungeon(player, dungeonCards, message);
         }
+        String message = Localizer.getInstance().getMessage("lblChooseDungeon");
+        Card dungeon = player.getController().chooseDungeon(player, dungeonCards, message);
 
         game.getTriggerHandler().suppressMode(TriggerType.ChangesZone);
         game.getAction().moveTo(ZoneType.Command, dungeon, sa, moveParams);

--- a/forge-gui/res/cardsfolder/upcoming/undercity.txt
+++ b/forge-gui/res/cardsfolder/upcoming/undercity.txt
@@ -1,6 +1,6 @@
 Name:Undercity
 ManaCost:no cost
-Types:Dungeon
+Types:Dungeon Undercity
 K:You can't enter this dungeon unless you "venture into Undercity".
 K:Dungeon:Entrance,Forge,Well,Trap,Arena,Stash,Archives,Catacombs,Throne
 SVar:Entrance:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Land.Basic | RoomName$ Secret Entrance | NextRoom$ Forge,Well | SpellDescription$ Search your library for a basic land card, reveal it, put it into your hand, then shuffle.


### PR DESCRIPTION
Closes #254

* fixes CardType to handle "Dungeon Master" as one Type and "Dungeon Undercity" as two
* VentureEffect better handles `Venture into [quality]` with Quality be a SubType

this would also support other Undercity Dungeons