### PR TITLE
confirmAction: add Map Params

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -1326,7 +1326,7 @@ public class AiController {
         return discardList;
     }
 
-    public boolean confirmAction(SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         if (mode == PlayerActionConfirmMode.AlternativeDamageAssignment) {
             return true;
         }
@@ -1339,7 +1339,7 @@ public class AiController {
                     mode);
             throw new IllegalArgumentException(exMsg);
         }
-        return SpellApiToAi.Converter.get(api).confirmAction(player, sa, mode, message);
+        return SpellApiToAi.Converter.get(api).confirmAction(player, sa, mode, message, null);
     }
 
     public boolean confirmBidAction(SpellAbility sa, PlayerActionConfirmMode mode, String message, int bid, Player winner) {

--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -1339,7 +1339,7 @@ public class AiController {
                     mode);
             throw new IllegalArgumentException(exMsg);
         }
-        return SpellApiToAi.Converter.get(api).confirmAction(player, sa, mode, message, null);
+        return SpellApiToAi.Converter.get(api).confirmAction(player, sa, mode, message, params);
     }
 
     public boolean confirmBidAction(SpellAbility sa, PlayerActionConfirmMode mode, String message, int bid, Player winner) {

--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -269,8 +269,8 @@ public class PlayerControllerAi extends PlayerController {
     }
 
     @Override
-    public boolean confirmAction(SpellAbility sa, PlayerActionConfirmMode mode, String message) {
-        return getAi().confirmAction(sa, mode, message);
+    public boolean confirmAction(SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
+        return getAi().confirmAction(sa, mode, message, params);
     }
 
     @Override

--- a/forge-ai/src/main/java/forge/ai/SpellAbilityAi.java
+++ b/forge-ai/src/main/java/forge/ai/SpellAbilityAi.java
@@ -305,7 +305,7 @@ public abstract class SpellAbilityAi {
         return SpellApiToAi.Converter.get(ab.getApi()).chkAIDrawback(ab, aiPlayer) && (subAb == null || chkDrawbackWithSubs(aiPlayer, subAb));  
     }
 
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         System.err.println("Warning: default (ie. inherited from base class) implementation of confirmAction is used by " + sa.getHostCard().getName() + " for " + this.getClass().getName() + ". Consider declaring an overloaded method");
         return true;
     }

--- a/forge-ai/src/main/java/forge/ai/ability/AlwaysPlayAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/AlwaysPlayAi.java
@@ -1,6 +1,8 @@
 package forge.ai.ability;
 
 
+import java.util.Map;
+
 import forge.ai.SpellAbilityAi;
 import forge.game.player.Player;
 import forge.game.player.PlayerActionConfirmMode;
@@ -16,7 +18,7 @@ public class AlwaysPlayAi extends SpellAbilityAi {
     }
 
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         return true;
     }
 }

--- a/forge-ai/src/main/java/forge/ai/ability/AmassAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/AmassAi.java
@@ -85,7 +85,7 @@ public class AmassAi extends SpellAbilityAi {
     }
 
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         return true;
     }
 

--- a/forge-ai/src/main/java/forge/ai/ability/AnimateAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/AnimateAi.java
@@ -240,7 +240,7 @@ public class AnimateAi extends SpellAbilityAi {
     }
 
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         return player.getGame().getPhaseHandler().getPhase().isBefore(PhaseType.MAIN2);
     }
     

--- a/forge-ai/src/main/java/forge/ai/ability/AttachAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/AttachAi.java
@@ -1729,7 +1729,7 @@ public class AttachAi extends SpellAbilityAi {
     }
 
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         return true;
     }
 

--- a/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
@@ -1739,7 +1739,7 @@ public class ChangeZoneAi extends SpellAbilityAi {
      * @see forge.card.ability.SpellAbilityAi#confirmAction(forge.game.player.Player, forge.card.spellability.SpellAbility, forge.game.player.PlayerActionConfirmMode, java.lang.String)
      */
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         // AI was never asked
         return true;
     }

--- a/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAllAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAllAi.java
@@ -1,6 +1,7 @@
 package forge.ai.ability;
 
 import java.util.Collections;
+import java.util.Map;
 
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
@@ -334,7 +335,7 @@ public class ChangeZoneAllAi extends SpellAbilityAi {
      * @see forge.card.ability.SpellAbilityAi#confirmAction(forge.game.player.Player, forge.card.spellability.SpellAbility, forge.game.player.PlayerActionConfirmMode, java.lang.String)
      */
     @Override
-    public boolean confirmAction(Player ai, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player ai, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         final Card source = sa.getHostCard();
         final String hostName = source.getName();
         final ZoneType origin = ZoneType.listValueOf(sa.getParam("Origin")).get(0);

--- a/forge-ai/src/main/java/forge/ai/ability/CloneAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CloneAi.java
@@ -154,7 +154,7 @@ public class CloneAi extends SpellAbilityAi {
      * @see forge.card.ability.SpellAbilityAi#confirmAction(forge.game.player.Player, forge.card.spellability.SpellAbility, forge.game.player.PlayerActionConfirmMode, java.lang.String)
      */
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         if (sa.hasParam("AILogic") && (!sa.usesTargeting() || sa.isTargetNumberValid())) {
             // Had a special logic for it and managed to target, so confirm if viable
             if ("CloneBestCreature".equals(sa.getParam("AILogic"))) {

--- a/forge-ai/src/main/java/forge/ai/ability/CopyPermanentAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CopyPermanentAi.java
@@ -224,7 +224,7 @@ public class CopyPermanentAi extends SpellAbilityAi {
      * @see forge.card.ability.SpellAbilityAi#confirmAction(forge.game.player.Player, forge.card.spellability.SpellAbility, forge.game.player.PlayerActionConfirmMode, java.lang.String)
      */
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         //TODO: add logic here
         return true;
     }

--- a/forge-ai/src/main/java/forge/ai/ability/CopySpellAbilityAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CopySpellAbilityAi.java
@@ -134,7 +134,7 @@ public class CopySpellAbilityAi extends SpellAbilityAi {
     }
 
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         // Chain of Acid requires special attention here since otherwise the AI will confirm the copy and then
         // run into the necessity of confirming a mandatory Destroy, thus destroying all of its own permanents.
         if ("ChainOfAcid".equals(sa.getParam("AILogic"))) {

--- a/forge-ai/src/main/java/forge/ai/ability/CountersPutAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CountersPutAi.java
@@ -913,7 +913,7 @@ public class CountersPutAi extends CountersAi {
     }
 
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         final Card source = sa.getHostCard();
         if (mode == PlayerActionConfirmMode.Tribute) {
             // add counter if that opponent has a giant creature

--- a/forge-ai/src/main/java/forge/ai/ability/CountersPutAllAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CountersPutAllAi.java
@@ -1,6 +1,7 @@
 package forge.ai.ability;
 
 import java.util.List;
+import java.util.Map;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
@@ -151,7 +152,7 @@ public class CountersPutAllAi extends SpellAbilityAi {
      * @see forge.card.ability.SpellAbilityAi#confirmAction(forge.game.player.Player, forge.card.spellability.SpellAbility, forge.game.player.PlayerActionConfirmMode, java.lang.String)
      */
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         return player.getCreaturesInPlay().size() >= player.getWeakestOpponent().getCreaturesInPlay().size();
     }
 

--- a/forge-ai/src/main/java/forge/ai/ability/DayTimeAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DayTimeAi.java
@@ -1,5 +1,7 @@
 package forge.ai.ability;
 
+import java.util.Map;
+
 import forge.ai.SpellAbilityAi;
 import forge.game.phase.PhaseHandler;
 import forge.game.phase.PhaseType;
@@ -30,7 +32,7 @@ public class DayTimeAi extends SpellAbilityAi {
     }
 
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         return true;
     }
 }

--- a/forge-ai/src/main/java/forge/ai/ability/DigAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DigAi.java
@@ -209,7 +209,7 @@ public class DigAi extends SpellAbilityAi {
      * @see forge.card.ability.SpellAbilityAi#confirmAction(forge.card.spellability.SpellAbility, forge.game.player.PlayerActionConfirmMode, java.lang.String)
      */
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         Card topc = player.getZone(ZoneType.Library).get(0);
 
         // AI actions for individual cards (until this AI can be generalized)

--- a/forge-ai/src/main/java/forge/ai/ability/DigMultipleAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DigMultipleAi.java
@@ -1,5 +1,7 @@
 package forge.ai.ability;
 
+import java.util.Map;
+
 import forge.ai.AiAttackController;
 import forge.ai.ComputerUtil;
 import forge.ai.SpellAbilityAi;
@@ -94,7 +96,7 @@ public class DigMultipleAi extends SpellAbilityAi {
      * @see forge.card.ability.SpellAbilityAi#confirmAction(forge.card.spellability.SpellAbility, forge.game.player.PlayerActionConfirmMode, java.lang.String)
      */
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         return true;
     }
 }

--- a/forge-ai/src/main/java/forge/ai/ability/DigUntilAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DigUntilAi.java
@@ -1,6 +1,7 @@
 package forge.ai.ability;
 
 import java.util.List;
+import java.util.Map;
 
 import forge.ai.AiAttackController;
 import forge.ai.ComputerUtilCost;
@@ -122,7 +123,7 @@ public class DigUntilAi extends SpellAbilityAi {
      * @see forge.card.ability.SpellAbilityAi#confirmAction(forge.card.spellability.SpellAbility, forge.game.player.PlayerActionConfirmMode, java.lang.String)
      */
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         if (sa.hasParam("AILogic")) {
             final String logic = sa.getParam("AILogic");
             if ("OathOfDruids".equals(logic)) {

--- a/forge-ai/src/main/java/forge/ai/ability/DiscardAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DiscardAi.java
@@ -2,6 +2,7 @@ package forge.ai.ability;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import forge.ai.ComputerUtil;
 import forge.ai.ComputerUtilAbility;
@@ -211,11 +212,11 @@ public class DiscardAi extends SpellAbilityAi {
         return true;
     }
 
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         if (mode == PlayerActionConfirmMode.Random) {
             // TODO For now AI will always discard Random used currently with: Balduvian Horde and similar cards
             return true;
         }
-        return super.confirmAction(player, sa, mode, message);
+        return super.confirmAction(player, sa, mode, message, params);
     }
 }

--- a/forge-ai/src/main/java/forge/ai/ability/DrawAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DrawAi.java
@@ -18,6 +18,8 @@
  */
 package forge.ai.ability;
 
+import java.util.Map;
+
 import forge.ai.AiCostDecision;
 import forge.ai.AiProps;
 import forge.ai.ComputerUtil;
@@ -541,7 +543,7 @@ public class DrawAi extends SpellAbilityAi {
      * @see forge.card.ability.SpellAbilityAi#confirmAction(forge.game.player.Player, forge.card.spellability.SpellAbility, forge.game.player.PlayerActionConfirmMode, java.lang.String)
      */
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         int numCards = sa.hasParam("NumCards") ? AbilityUtils.calculateAmount(sa.getHostCard(), sa.getParam("NumCards"), sa) : 1;
         // AI shouldn't mill itself
         if (numCards < player.getZone(ZoneType.Library).size())

--- a/forge-ai/src/main/java/forge/ai/ability/EncodeAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/EncodeAi.java
@@ -70,7 +70,7 @@ public final class EncodeAi extends SpellAbilityAi {
      * forge.game.player.PlayerActionConfirmMode, java.lang.String)
      */
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         // only try to encode if there is a creature it can be used on
         return chooseCard(player, player.getCreaturesInPlay(), true) != null;
     }

--- a/forge-ai/src/main/java/forge/ai/ability/FlipOntoBattlefieldAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/FlipOntoBattlefieldAi.java
@@ -1,5 +1,7 @@
 package forge.ai.ability;
 
+import java.util.Map;
+
 import com.google.common.base.Predicate;
 import forge.ai.SpellAbilityAi;
 import forge.game.card.Card;
@@ -42,7 +44,7 @@ public class FlipOntoBattlefieldAi extends SpellAbilityAi {
     }
 
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         return true;
     }
 }

--- a/forge-ai/src/main/java/forge/ai/ability/InvestigateAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/InvestigateAi.java
@@ -1,6 +1,8 @@
 package forge.ai.ability;
 
 
+import java.util.Map;
+
 import forge.ai.SpellAbilityAi;
 import forge.game.phase.PhaseHandler;
 import forge.game.phase.PhaseType;
@@ -20,7 +22,7 @@ public class InvestigateAi extends SpellAbilityAi {
     }
 
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         return true;
     }
 }

--- a/forge-ai/src/main/java/forge/ai/ability/LearnAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/LearnAi.java
@@ -1,6 +1,8 @@
 package forge.ai.ability;
 
 
+import java.util.Map;
+
 import forge.ai.ComputerUtilCard;
 import forge.ai.PlayerControllerAi;
 import forge.ai.SpellAbilityAi;
@@ -32,7 +34,7 @@ public class LearnAi extends SpellAbilityAi {
     }
 
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         return true;
     }
 

--- a/forge-ai/src/main/java/forge/ai/ability/ManifestAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ManifestAi.java
@@ -43,7 +43,7 @@ public class ManifestAi extends SpellAbilityAi {
      * @see forge.card.ability.SpellAbilityAi#confirmAction(forge.game.player.Player, forge.card.spellability.SpellAbility, forge.game.player.PlayerActionConfirmMode, java.lang.String)
      */
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         return true;
     }
 

--- a/forge-ai/src/main/java/forge/ai/ability/MillAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/MillAi.java
@@ -196,7 +196,7 @@ public class MillAi extends SpellAbilityAi {
      * @see forge.card.ability.SpellAbilityAi#confirmAction(forge.game.player.Player, forge.card.spellability.SpellAbility, forge.game.player.PlayerActionConfirmMode, java.lang.String)
      */
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         if ("TimmerianFiends".equals(sa.getParam("AILogic"))) {
             return SpecialCardAi.TimmerianFiends.consider(player, sa);
         }

--- a/forge-ai/src/main/java/forge/ai/ability/MutateAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/MutateAi.java
@@ -65,7 +65,7 @@ public class MutateAi extends SpellAbilityAi {
     }
 
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         return true;
     }
 }

--- a/forge-ai/src/main/java/forge/ai/ability/PeekAndRevealAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PeekAndRevealAi.java
@@ -1,5 +1,7 @@
 package forge.ai.ability;
 
+import java.util.Map;
+
 import forge.ai.AiAttackController;
 import forge.ai.SpellAbilityAi;
 import forge.ai.SpellApiToAi;
@@ -70,7 +72,7 @@ public class PeekAndRevealAi extends SpellAbilityAi {
      * @see forge.card.ability.SpellAbilityAi#confirmAction(forge.game.player.Player, forge.card.spellability.SpellAbility, forge.game.player.PlayerActionConfirmMode, java.lang.String)
      */
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         AbilitySub subAb = sa.getSubAbility();
         return subAb != null && SpellApiToAi.Converter.get(subAb.getApi()).chkDrawbackWithSubs(player, subAb);
     }

--- a/forge-ai/src/main/java/forge/ai/ability/PlayAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PlayAi.java
@@ -131,7 +131,7 @@ public class PlayAi extends SpellAbilityAi {
     }
 
     @Override
-    public boolean confirmAction(Player ai, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player ai, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         return true;
     }
 

--- a/forge-ai/src/main/java/forge/ai/ability/PumpAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PumpAi.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 public class PumpAi extends PumpAiBase {
 
@@ -781,7 +782,7 @@ public class PumpAi extends PumpAiBase {
     }
 
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         //TODO Add logic here if necessary but I think the AI won't cast
         //the spell in the first place if it would curse its own creature
         //and the pump isn't mandatory

--- a/forge-ai/src/main/java/forge/ai/ability/RearrangeTopOfLibraryAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/RearrangeTopOfLibraryAi.java
@@ -1,6 +1,8 @@
 package forge.ai.ability;
 
 
+import java.util.Map;
+
 import forge.ai.AiCardMemory;
 import forge.ai.AiController;
 import forge.ai.AiProps;
@@ -92,7 +94,7 @@ public class RearrangeTopOfLibraryAi extends SpellAbilityAi {
      * @see forge.card.ability.SpellAbilityAi#confirmAction(forge.game.player.Player, forge.card.spellability.SpellAbility, forge.game.player.PlayerActionConfirmMode, java.lang.String)
      */
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         // Confirming this action means shuffling the library if asked.
 
         // First, let's check if we can play the top card of the library

--- a/forge-ai/src/main/java/forge/ai/ability/RepeatAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/RepeatAi.java
@@ -1,6 +1,8 @@
 package forge.ai.ability;
 
 
+import java.util.Map;
+
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import forge.ai.*;
@@ -40,7 +42,7 @@ public class RepeatAi extends SpellAbilityAi {
     }
     
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
       //TODO add logic to have computer make better choice (ArsenalNut)
         return false;
     }

--- a/forge-ai/src/main/java/forge/ai/ability/RollDiceAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/RollDiceAi.java
@@ -1,6 +1,8 @@
 package forge.ai.ability;
 
 
+import java.util.Map;
+
 import forge.ai.SpellAbilityAi;
 import forge.game.Game;
 import forge.game.card.Card;
@@ -43,7 +45,7 @@ public class RollDiceAi extends SpellAbilityAi {
     }
 
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         return true;
     }
 }

--- a/forge-ai/src/main/java/forge/ai/ability/SacrificeAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/SacrificeAi.java
@@ -1,6 +1,7 @@
 package forge.ai.ability;
 
 import java.util.List;
+import java.util.Map;
 
 import forge.ai.ComputerUtilCard;
 import forge.ai.ComputerUtilCost;
@@ -175,7 +176,7 @@ public class SacrificeAi extends SpellAbilityAi {
     }
 
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         return true;
     }
 

--- a/forge-ai/src/main/java/forge/ai/ability/ScryAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ScryAi.java
@@ -1,5 +1,7 @@
 package forge.ai.ability;
 
+import java.util.Map;
+
 import com.google.common.base.Predicates;
 
 import forge.ai.ComputerUtilMana;
@@ -132,7 +134,7 @@ public class ScryAi extends SpellAbilityAi {
     }
 
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         return true;
     }
 }

--- a/forge-ai/src/main/java/forge/ai/ability/SetStateAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/SetStateAi.java
@@ -1,6 +1,7 @@
 package forge.ai.ability;
 
 import java.util.List;
+import java.util.Map;
 
 import com.google.common.base.Predicate;
 
@@ -264,7 +265,7 @@ public class SetStateAi extends SpellAbilityAi {
         return true;
     }
 
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         // TODO: improve the AI for when it may want to transform something that's optional to transform
         return isSafeToTransformIntoLegendary(player, sa.getHostCard());
     }

--- a/forge-ai/src/main/java/forge/ai/ability/ShuffleAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ShuffleAi.java
@@ -1,5 +1,7 @@
 package forge.ai.ability;
 
+import java.util.Map;
+
 import forge.ai.SpellAbilityAi;
 import forge.game.phase.PhaseType;
 import forge.game.player.Player;
@@ -54,7 +56,7 @@ public class ShuffleAi extends SpellAbilityAi {
     }  
 
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         // ai could analyze parameter denoting the player to shuffle
         return true;
     }

--- a/forge-ai/src/main/java/forge/ai/ability/SkipPhaseAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/SkipPhaseAi.java
@@ -1,5 +1,7 @@
 package forge.ai.ability;
 
+import java.util.Map;
+
 import forge.ai.AiAttackController;
 import forge.ai.SpellAbilityAi;
 import forge.game.player.Player;
@@ -18,7 +20,7 @@ public class SkipPhaseAi extends SpellAbilityAi {
     }
 
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         return true;
     }
     

--- a/forge-ai/src/main/java/forge/ai/ability/SurveilAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/SurveilAi.java
@@ -1,5 +1,7 @@
 package forge.ai.ability;
 
+import java.util.Map;
+
 import forge.ai.AiCardMemory;
 import forge.ai.AiProps;
 import forge.ai.ComputerUtilCost;
@@ -119,7 +121,7 @@ public class SurveilAi extends SpellAbilityAi {
     }
 
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         return true;
     }
 }

--- a/forge-ai/src/main/java/forge/ai/ability/TokenAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/TokenAi.java
@@ -311,7 +311,7 @@ public class TokenAi extends SpellAbilityAi {
      * @see forge.card.ability.SpellAbilityAi#confirmAction(forge.game.player.Player, forge.card.spellability.SpellAbility, forge.game.player.PlayerActionConfirmMode, java.lang.String)
      */
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         // TODO: AILogic
         return true;
     }

--- a/forge-ai/src/main/java/forge/ai/ability/VentureAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/VentureAi.java
@@ -36,7 +36,7 @@ public class VentureAi extends SpellAbilityAi {
     }
 
     @Override
-    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         return true;
     }
 

--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -1576,7 +1576,7 @@ public class GameAction {
             c.getGame().getTracker().flush();
 
             c.setMoveToCommandZone(false);
-            if (c.getOwner().getController().confirmAction(c.getFirstSpellAbility(), PlayerActionConfirmMode.ChangeZoneToAltDestination, c.getName() + ": If a commander is in a graveyard or in exile and that card was put into that zone since the last time state-based actions were checked, its owner may put it into the command zone.")) {
+            if (c.getOwner().getController().confirmAction(c.getFirstSpellAbility(), PlayerActionConfirmMode.ChangeZoneToAltDestination, c.getName() + ": If a commander is in a graveyard or in exile and that card was put into that zone since the last time state-based actions were checked, its owner may put it into the command zone.", null)) {
                 moveTo(c.getOwner().getZone(ZoneType.Command), c, null);
                 return true;
             }

--- a/forge-game/src/main/java/forge/game/ability/effects/AbandonEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/AbandonEffect.java
@@ -25,7 +25,7 @@ public class AbandonEffect extends SpellAbilityEffect {
         Player controller = source.getController();
 
         boolean isOptional = sa.hasParam("Optional");
-        if (isOptional && !controller.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblWouldYouLikeAbandonSource", CardTranslation.getTranslatedName(source.getName())))) {
+        if (isOptional && !controller.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblWouldYouLikeAbandonSource", CardTranslation.getTranslatedName(source.getName())), null)) {
             return;
         }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/AnimateEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/AnimateEffect.java
@@ -164,7 +164,7 @@ public class AnimateEffect extends AnimateEffectBase {
                     ? TextUtil.fastReplace(sa.getParam("OptionQuestion"), "TARGETS", targets)
                     : getStackDescription(sa);
 
-            if (!sa.getActivatingPlayer().getController().confirmAction(sa, null, message)) {
+            if (!sa.getActivatingPlayer().getController().confirmAction(sa, null, message, null)) {
                 return;
             }
         }

--- a/forge-game/src/main/java/forge/game/ability/effects/AttachEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/AttachEffect.java
@@ -134,7 +134,7 @@ public class AttachEffect extends SpellAbilityEffect {
         // If Cast Targets will be checked on the Stack
         for (final Card attachment : attachments) {
             String message = Localizer.getInstance().getMessage("lblDoYouWantAttachSourceToTarget", CardTranslation.getTranslatedName(attachment.getName()), attachToName);
-            if (sa.hasParam("Optional") && !p.getController().confirmAction(sa, null, message))
+            if (sa.hasParam("Optional") && !p.getController().confirmAction(sa, null, message, null))
             // TODO add params for message
                 continue;
 

--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeTargetsEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeTargetsEffect.java
@@ -50,7 +50,7 @@ public class ChangeTargetsEffect extends SpellAbilityEffect {
             // Redirect rules read 'you MAY choose new targets' ... okay!
             // TODO: Don't even ask to change targets, if the SA and subs don't actually have targets
             boolean isOptional = sa.hasParam("Optional");
-            if (isOptional && !chooser.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantChangeAbilityTargets", tgtSA.getHostCard().toString()))) {
+            if (isOptional && !chooser.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantChangeAbilityTargets", tgtSA.getHostCard().toString()), null)) {
                 continue;
             }
             if (sa.hasParam("ChangeSingleTarget")) {

--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneAllEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneAllEffect.java
@@ -120,7 +120,7 @@ public class ChangeZoneAllEffect extends SpellAbilityEffect {
                 message = Localizer.getInstance().getMessage("lblMoveTargetFromOriginToDestination", targets, Lang.joinHomogenous(origin, ZoneType.Accessors.GET_TRANSLATED_NAME), destination.getTranslatedName());
             }
 
-            if (!sa.getActivatingPlayer().getController().confirmAction(sa, null, message)) {
+            if (!sa.getActivatingPlayer().getController().confirmAction(sa, null, message, null)) {
                 return;
             }
         }

--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
@@ -492,7 +492,7 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
                 PlayerCollection deciders = AbilityUtils.getDefinedPlayers(hostCard, sa.getParam("AlternativeDecider"), sa);
                 alterDecider = deciders.isEmpty() ? null : deciders.get(0);
             }
-            if (alterDecider != null && !alterDecider.getController().confirmAction(sa, PlayerActionConfirmMode.ChangeZoneToAltDestination, sb.toString())) {
+            if (alterDecider != null && !alterDecider.getController().confirmAction(sa, PlayerActionConfirmMode.ChangeZoneToAltDestination, sb.toString(), null)) {
                 destination = ZoneType.smartValueOf(sa.getParam("DestinationAlternative"));
                 altDest = true;
             }
@@ -564,7 +564,7 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
             }
 
             final String prompt = TextUtil.concatWithSpace(Localizer.getInstance().getMessage("lblDoYouWantMoveTargetFromOriToDest", CardTranslation.getTranslatedName(gameCard.getName()), Lang.joinHomogenous(origin, ZoneType.Accessors.GET_TRANSLATED_NAME), destination.getTranslatedName()));
-            if (optional && !chooser.getController().confirmAction(sa, null, prompt) )
+            if (optional && !chooser.getController().confirmAction(sa, null, prompt, null) )
                 continue;
 
             final Zone originZone = game.getZoneOf(gameCard);
@@ -956,7 +956,7 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
                 sb.append(sa.getParam("AlternativeMessage")).append(" ");
                 sb.append(altFetchList.size()).append(" " + Localizer.getInstance().getMessage("lblCardMatchSearchingTypeInAlternateZones"));
 
-                if (!decider.getController().confirmAction(sa, PlayerActionConfirmMode.ChangeZoneFromAltSource, sb.toString())) {
+                if (!decider.getController().confirmAction(sa, PlayerActionConfirmMode.ChangeZoneFromAltSource, sb.toString(), null)) {
                     origin = alt;
                 }
             }
@@ -968,7 +968,7 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
                 final StringBuilder sb = new StringBuilder();
                 sb.append(sa.getParam("AlternativeDestinationMessage"));
 
-                if (!decider.getController().confirmAction(sa, PlayerActionConfirmMode.ChangeZoneToAltDestination, sb.toString())) {
+                if (!decider.getController().confirmAction(sa, PlayerActionConfirmMode.ChangeZoneToAltDestination, sb.toString(), null)) {
                     destination = ZoneType.smartValueOf(sa.getParam("DestinationAlternative"));
                     libraryPos = sa.hasParam("LibraryPositionAlternative") ? Integer.parseInt(sa.getParam("LibraryPositionAlternative")) : 0;
                 }
@@ -985,7 +985,7 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
                     prompt = Localizer.getInstance().getMessage("lblSearchPlayerZoneConfirm", "{player's}", Lang.joinHomogenous(origin, ZoneType.Accessors.GET_TRANSLATED_NAME).toLowerCase());
                 }
                 String message = MessageUtil.formatMessage(prompt , decider, player);
-                if (!decider.getController().confirmAction(sa, PlayerActionConfirmMode.ChangeZoneGeneral, message)) {
+                if (!decider.getController().confirmAction(sa, PlayerActionConfirmMode.ChangeZoneGeneral, message, null)) {
                     return;
                 }
             }
@@ -1071,7 +1071,7 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
                             continue;
                         }
                         SpellAbility tgtSA = decider.getController().getAbilityToPlay(tgtCard, sas);
-                        if (!decider.getController().confirmAction(tgtSA, null, Localizer.getInstance().getMessage("lblDoYouWantPlayCard", CardTranslation.getTranslatedName(tgtCard.getName())))) {
+                        if (!decider.getController().confirmAction(tgtSA, null, Localizer.getInstance().getMessage("lblDoYouWantPlayCard", CardTranslation.getTranslatedName(tgtCard.getName())), null)) {
                             continue;
                         }
                         tgtSA.setSVar("IsCastFromPlayEffect", "True");
@@ -1187,7 +1187,7 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
                         String message = Localizer.getInstance().getMessage("lblCancelSearchUpToSelectNumCards", String.valueOf(num));
 
                         if (fetchList.isEmpty() || sa.hasParam("SkipCancelPrompt") ||
-                                decider.getController().confirmAction(sa, PlayerActionConfirmMode.ChangeZoneGeneral, message)) {
+                                decider.getController().confirmAction(sa, PlayerActionConfirmMode.ChangeZoneGeneral, message, null)) {
                             break;
                         }
                         i--;

--- a/forge-game/src/main/java/forge/game/ability/effects/CharmEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CharmEffect.java
@@ -180,7 +180,7 @@ public class CharmEffect extends SpellAbilityEffect {
         num = Math.min(num, choices.size());
 
         boolean isOptional = sa.hasParam("Optional");
-        if (isOptional && !activator.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblWouldYouLikeCharm", CardTranslation.getTranslatedName(source.getName())))) {
+        if (isOptional && !activator.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblWouldYouLikeCharm", CardTranslation.getTranslatedName(source.getName())), null)) {
             return false;
         }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/ChooseCardEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChooseCardEffect.java
@@ -131,7 +131,7 @@ public class ChooseCardEffect extends SpellAbilityEffect {
                             Localizer.getInstance().getMessage("lblSelectCreatureWithTotalPowerLessOrEqualTo", (totP - chosenP - negativeNum))
                                     + "\r\n(" + Localizer.getInstance().getMessage("lblSelected") + ":" + chosenPool + ")\r\n(" + Localizer.getInstance().getMessage("lblTotalPowerNum", chosenP) + ")", chosenP <= totP, null);
                     if (c == null) {
-                        if (p.getController().confirmAction(sa, PlayerActionConfirmMode.OptionalChoose, Localizer.getInstance().getMessage("lblCancelChooseConfirm"))) {
+                        if (p.getController().confirmAction(sa, PlayerActionConfirmMode.OptionalChoose, Localizer.getInstance().getMessage("lblCancelChooseConfirm"), null)) {
                             break;
                         }
                     } else {

--- a/forge-game/src/main/java/forge/game/ability/effects/CloneEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CloneEffect.java
@@ -108,7 +108,7 @@ public class CloneEffect extends SpellAbilityEffect {
         }
 
         final boolean optional = sa.hasParam("Optional");
-        if (optional && !host.getController().getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantCopy", CardTranslation.getTranslatedName(cardToCopy.getName())))) {
+        if (optional && !host.getController().getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantCopy", CardTranslation.getTranslatedName(cardToCopy.getName())), null)) {
             return;
         }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/ControlExchangeEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ControlExchangeEffect.java
@@ -89,7 +89,7 @@ public class ControlExchangeEffect extends SpellAbilityEffect {
         if (sa.hasParam("Optional") && !sa.getActivatingPlayer().getController().confirmAction(sa, null,
                 Localizer.getInstance().getMessage("lblExchangeControl",
                         CardTranslation.getTranslatedName(object1.getName()),
-                        CardTranslation.getTranslatedName(object2.getName())))) {
+                        CardTranslation.getTranslatedName(object2.getName())), null)) {
             return;
         }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/CopyPermanentEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CopyPermanentEffect.java
@@ -119,7 +119,7 @@ public class CopyPermanentEffect extends TokenEffectBase {
         TokenCreateTable tokenTable = new TokenCreateTable();
 
         if (sa.hasParam("Optional") && !activator.getController().confirmAction(sa, null,
-                Localizer.getInstance().getMessage("lblCopyPermanentConfirm"))) {
+                Localizer.getInstance().getMessage("lblCopyPermanentConfirm"), null)) {
             return;
         }
 
@@ -208,7 +208,7 @@ public class CopyPermanentEffect extends TokenEffectBase {
                             if (choosen != null) {
                                 tgtCards.add(choosen);
                                 choices = CardLists.filter(choices, Predicates.not(CardPredicates.sharesNameWith(choosen)));
-                            } else if (chooser.getController().confirmAction(sa, PlayerActionConfirmMode.OptionalChoose, Localizer.getInstance().getMessage("lblCancelChooseConfirm"))) {
+                            } else if (chooser.getController().confirmAction(sa, PlayerActionConfirmMode.OptionalChoose, Localizer.getInstance().getMessage("lblCancelChooseConfirm"), null)) {
                                 break;
                             }
                         }

--- a/forge-game/src/main/java/forge/game/ability/effects/CopySpellAbilityEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CopySpellAbilityEffect.java
@@ -89,7 +89,7 @@ public class CopySpellAbilityEffect extends SpellAbilityEffect {
             SpellAbility chosenSA = controller.getController().chooseSingleSpellForEffect(tgtSpells, sa,
                     Localizer.getInstance().getMessage("lblSelectASpellCopy"), ImmutableMap.of());
 
-            if (isOptional && !controller.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoyouWantCopyTheSpell", CardTranslation.getTranslatedName(chosenSA.getHostCard().getName())))) {
+            if (isOptional && !controller.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoyouWantCopyTheSpell", CardTranslation.getTranslatedName(chosenSA.getHostCard().getName())), null)) {
                 continue;
             }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/CountersPutEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CountersPutEffect.java
@@ -174,7 +174,7 @@ public class CountersPutEffect extends SpellAbilityEffect {
         boolean putOnDefined = sa.hasParam("PutOnDefined");
 
         if (sa.hasParam("Optional") && !pc.confirmAction
-                (sa, null, Localizer.getInstance().getMessage("lblDoYouWantPutCounter"))) {
+                (sa, null, Localizer.getInstance().getMessage("lblDoYouWantPutCounter"), null)) {
             return;
         }
 
@@ -509,7 +509,7 @@ public class CountersPutEffect extends SpellAbilityEffect {
                             Player chooser = pc.chooseSingleEntityForEffect(activator.getOpponents(), sa,
                                     Localizer.getInstance().getMessage("lblChooseAnOpponent"), params);
 
-                            if (chooser.getController().confirmAction(sa, PlayerActionConfirmMode.Tribute, message)) {
+                            if (chooser.getController().confirmAction(sa, PlayerActionConfirmMode.Tribute, message, null)) {
                                 gameCard.setTributed(true);
                             } else {
                                 continue;

--- a/forge-game/src/main/java/forge/game/ability/effects/CountersPutOrRemoveEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CountersPutOrRemoveEffect.java
@@ -76,7 +76,7 @@ public class CountersPutOrRemoveEffect extends SpellAbilityEffect {
             }
             if (!eachExisting && sa.hasParam("Optional") && !pl.getController().confirmAction(sa, null,
                     Localizer.getInstance().getMessage("lblWouldYouLikePutRemoveCounters", ctype.getName(),
-                            CardTranslation.getTranslatedName(gameCard.getName())))) {
+                            CardTranslation.getTranslatedName(gameCard.getName())), null)) {
                 continue;
             }
             if (!sa.usesTargeting() || gameCard.canBeTargetedBy(sa)) {

--- a/forge-game/src/main/java/forge/game/ability/effects/CountersRemoveEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CountersRemoveEffect.java
@@ -83,7 +83,7 @@ public class CountersRemoveEffect extends SpellAbilityEffect {
 
         if (sa.hasParam("Optional")) {
             String ctrs = cntToRemove > 1 ? Localizer.getInstance().getMessage("lblCounters") : num.equals("All") ? Localizer.getInstance().getMessage("lblAllCounters") : Localizer.getInstance().getMessage("lblACounters");
-            if (!sa.getActivatingPlayer().getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblRemove") + " " + ctrs + "?")) {
+            if (!sa.getActivatingPlayer().getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblRemove") + " " + ctrs + "?", null)) {
                 return;
             }
         }

--- a/forge-game/src/main/java/forge/game/ability/effects/DamageDealEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DamageDealEffect.java
@@ -156,7 +156,7 @@ public class DamageDealEffect extends DamageBaseEffect {
         List<GameObject> tgts = getTargets(sa);
         if (sa.hasParam("OptionalDecider")) {
             Player decider = Iterables.getFirst(AbilityUtils.getDefinedPlayers(hostCard, sa.getParam("OptionalDecider"), sa), null);
-            if (decider != null && !decider.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoyouWantDealTargetDamageToTarget", String.valueOf(dmg), tgts.toString()))) {
+            if (decider != null && !decider.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoyouWantDealTargetDamageToTarget", String.valueOf(dmg), tgts.toString()), null)) {
                 return;
             }
         }

--- a/forge-game/src/main/java/forge/game/ability/effects/DigEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DigEffect.java
@@ -203,7 +203,7 @@ public class DigEffect extends SpellAbilityEffect {
                 else if (sa.hasParam("RevealOptional")) {
                     String question = TextUtil.concatWithSpace(Localizer.getInstance().getMessage("lblReveal") + ":", TextUtil.addSuffix(Lang.joinHomogenous(top),"?"));
 
-                    hasRevealed = p.getController().confirmAction(sa, null, question);
+                    hasRevealed = p.getController().confirmAction(sa, null, question, null);
                     if (hasRevealed) {
                         game.getAction().reveal(top, p);
                     }
@@ -276,7 +276,7 @@ public class DigEffect extends SpellAbilityEffect {
                     // Optional abilities that use a dialog box to prompt the user to skip the ability (e.g. Explorer's Scope, Quest for Ula's Temple)
                     if (optional && mayBeSkipped && !valid.isEmpty()) {
                         String prompt = !optionalAbilityPrompt.isEmpty() ? optionalAbilityPrompt : Localizer.getInstance().getMessage("lblWouldYouLikeProceedWithOptionalAbility") + " " + host + "?\n\n(" + sa.getDescription() + ")";
-                        if (!p.getController().confirmAction(sa, null, TextUtil.fastReplace(prompt, "CARDNAME", CardTranslation.getTranslatedName(host.getName())))) {
+                        if (!p.getController().confirmAction(sa, null, TextUtil.fastReplace(prompt, "CARDNAME", CardTranslation.getTranslatedName(host.getName())), null)) {
                             return;
                         }
                     }

--- a/forge-game/src/main/java/forge/game/ability/effects/DigUntilEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DigUntilEffect.java
@@ -120,7 +120,7 @@ public class DigUntilEffect extends SpellAbilityEffect {
                 continue;
             }
             if (!sa.usesTargeting() || p.canBeTargetedBy(sa)) {
-                if (optional && !p.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantDigYourLibrary"))) {
+                if (optional && !p.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantDigYourLibrary"), null)) {
                     continue;
                 }
                 CardCollection found = new CardCollection();
@@ -171,7 +171,7 @@ public class DigUntilEffect extends SpellAbilityEffect {
                         final Card c = itr.next();
                         final ZoneType origin = c.getZone().getZoneType();
                         if (optionalFound && !p.getController().confirmAction(sa, null,
-                                Localizer.getInstance().getMessage("lblDoYouWantPutCardToZone", foundDest.getTranslatedName()))) {
+                                Localizer.getInstance().getMessage("lblDoYouWantPutCardToZone", foundDest.getTranslatedName()), null)) {
                             continue;
                         }
                         Map<AbilityKey, Object> moveParams = AbilityKey.newMap();

--- a/forge-game/src/main/java/forge/game/ability/effects/DiscardEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DiscardEffect.java
@@ -153,7 +153,7 @@ public class DiscardEffect extends SpellAbilityEffect {
                     }
 
                     boolean runDiscard = !sa.hasParam("Optional")
-                            || p.getController().confirmAction(sa, PlayerActionConfirmMode.Random, sa.getParam("DiscardMessage"));
+                            || p.getController().confirmAction(sa, PlayerActionConfirmMode.Random, sa.getParam("DiscardMessage"), null);
                     if (runDiscard) {
                         toBeDiscarded = AbilityUtils.getDefinedCards(source, sa.getParam("DefinedCards"), sa);
 
@@ -197,7 +197,7 @@ public class DiscardEffect extends SpellAbilityEffect {
                         continue;
                     }
                     String message = Localizer.getInstance().getMessage("lblWouldYouLikeRandomDiscardTargetCard", String.valueOf(numCards));
-                    boolean runDiscard = !sa.hasParam("Optional") || p.getController().confirmAction(sa, PlayerActionConfirmMode.Random, message);
+                    boolean runDiscard = !sa.hasParam("Optional") || p.getController().confirmAction(sa, PlayerActionConfirmMode.Random, message, null);
 
                     if (runDiscard) {
                         final String valid = sa.getParamOrDefault("DiscardValid", "Card");

--- a/forge-game/src/main/java/forge/game/ability/effects/DrawEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DrawEffect.java
@@ -72,7 +72,7 @@ public class DrawEffect extends SpellAbilityEffect {
                 continue;
             }
 
-            if (optional && !p.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantDrawCards", Lang.nounWithAmount(numCards, " card")))) {
+            if (optional && !p.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantDrawCards", Lang.nounWithAmount(numCards, " card")), null)) {
                 continue;
             }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/EncodeEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/EncodeEffect.java
@@ -48,7 +48,7 @@ public class EncodeEffect extends SpellAbilityEffect {
         }
         // Handle choice of whether or not to encoded
 
-        if (!player.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantExileCardAndEncodeOntoYouCreature", CardTranslation.getTranslatedName(host.getName())))) {
+        if (!player.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantExileCardAndEncodeOntoYouCreature", CardTranslation.getTranslatedName(host.getName())), null)) {
             return;
         }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/EndTurnEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/EndTurnEffect.java
@@ -20,7 +20,7 @@ public class EndTurnEffect extends SpellAbilityEffect {
     public void resolve(SpellAbility sa) {
         final List<Player> enders = getDefinedPlayersOrTargeted(sa, "Defined");
         final Player ender = enders.isEmpty() ? sa.getActivatingPlayer() : enders.get(0);
-        if (sa.hasParam("Optional") && !ender.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantEndTurn"))) {
+        if (sa.hasParam("Optional") && !ender.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantEndTurn"), null)) {
             return;
         }
         Game game = ender.getGame();

--- a/forge-game/src/main/java/forge/game/ability/effects/FightEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/FightEffect.java
@@ -59,7 +59,7 @@ public class FightEffect extends DamageBaseEffect {
         Player controller = host.getController();
         boolean isOptional = sa.hasParam("Optional");
 
-        if (isOptional && !controller.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblWouldYouLikeFight", CardTranslation.getTranslatedName(fighters.get(0).getName()), CardTranslation.getTranslatedName(fighters.get(1).getName())))) {
+        if (isOptional && !controller.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblWouldYouLikeFight", CardTranslation.getTranslatedName(fighters.get(0).getName()), CardTranslation.getTranslatedName(fighters.get(1).getName())), null)) {
             return;
         }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/InvestigateEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/InvestigateEffect.java
@@ -40,7 +40,7 @@ public class InvestigateEffect extends TokenEffectBase {
         for (final Player p : getTargetPlayers(sa)) {
             for (int i = 0; i < amount; i++) {
                 if (sa.hasParam("Optional") && !p.getController().confirmAction(sa, null,
-                        Localizer.getInstance().getMessage("lblWouldYouLikeInvestigate"))) {
+                        Localizer.getInstance().getMessage("lblWouldYouLikeInvestigate"), null)) {
                     return;
                 }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/ManaEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ManaEffect.java
@@ -40,7 +40,7 @@ public class ManaEffect extends SpellAbilityEffect {
         final boolean optional = sa.hasParam("Optional");
         final Game game = sa.getActivatingPlayer().getGame();
 
-        if (optional && !sa.getActivatingPlayer().getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantAddMana"))) {
+        if (optional && !sa.getActivatingPlayer().getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantAddMana"), null)) {
             return;
         }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/MillEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/MillEffect.java
@@ -48,7 +48,7 @@ public class MillEffect extends SpellAbilityEffect {
                 if (sa.hasParam("Optional")) {
                     final String prompt = TextUtil.concatWithSpace(Localizer.getInstance().getMessage("lblDoYouWantPutLibraryCardsTo", destination.getTranslatedName()));
                     // CR 701.13b
-                    if (numCards > p.getZone(ZoneType.Library).size() || !p.getController().confirmAction(sa, null, prompt)) {
+                    if (numCards > p.getZone(ZoneType.Library).size() || !p.getController().confirmAction(sa, null, prompt, null)) {
                         continue;
                     }
                 }

--- a/forge-game/src/main/java/forge/game/ability/effects/PeekAndRevealEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PeekAndRevealEffect.java
@@ -87,7 +87,7 @@ public class PeekAndRevealEffect extends SpellAbilityEffect {
             }
             
             if (doReveal && sa.hasParam("RevealOptional"))
-                doReveal = peekingPlayer.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblRevealCardToOtherPlayers"));
+                doReveal = peekingPlayer.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblRevealCardToOtherPlayers"), null);
             
             if (doReveal) {
                 peekingPlayer.getGame().getAction().reveal(revealableCards, ZoneType.Library, libraryToPeek, !noPeek,

--- a/forge-game/src/main/java/forge/game/ability/effects/PlayEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PlayEffect.java
@@ -259,7 +259,7 @@ public class PlayEffect extends SpellAbilityEffect {
             }
             if (singleOption && sa.getTargetCard() == null)
                 sa.setPlayEffectCard(tgtCard);// show card to play rather than showing the source card
-            if (singleOption && !controller.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantPlayCard", CardTranslation.getTranslatedName(tgtCard.getName())))) {
+            if (singleOption && !controller.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantPlayCard", CardTranslation.getTranslatedName(tgtCard.getName())), null)) {
                 if (wasFaceDown) {
                     tgtCard.turnFaceDownNoUpdate();
                     tgtCard.updateStateForView();

--- a/forge-game/src/main/java/forge/game/ability/effects/PumpEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PumpEffect.java
@@ -352,7 +352,7 @@ public class PumpEffect extends SpellAbilityEffect {
                     ? TextUtil.fastReplace(sa.getParam("OptionQuestion"), "TARGETS", targets)
                     : Localizer.getInstance().getMessage("lblApplyPumpToTarget", targets);
 
-            if (!sa.getActivatingPlayer().getController().confirmAction(sa, null, message)) {
+            if (!sa.getActivatingPlayer().getController().confirmAction(sa, null, message, null)) {
                 return;
             }
         }

--- a/forge-game/src/main/java/forge/game/ability/effects/RearrangeTopOfLibraryEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/RearrangeTopOfLibraryEffect.java
@@ -116,7 +116,7 @@ public class RearrangeTopOfLibraryEffect extends SpellAbilityEffect {
             Card next = orderedCards.get(i);
             player.getGame().getAction().moveToLibrary(next, 0, sa);
         }
-        if (mayshuffle && activator.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoyouWantShuffleTheLibrary"))) {
+        if (mayshuffle && activator.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoyouWantShuffleTheLibrary"), null)) {
             player.shuffle(sa);
         }
     }

--- a/forge-game/src/main/java/forge/game/ability/effects/RepeatEachEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/RepeatEachEffect.java
@@ -47,7 +47,7 @@ public class RepeatEachEffect extends SpellAbilityEffect {
         final Player player = sa.getActivatingPlayer();
         final Game game = player.getGame();
         if (sa.hasParam("Optional") && sa.hasParam("OptionPrompt") && //for now, OptionPrompt is needed
-                !player.getController().confirmAction(sa, null, sa.getParam("OptionPrompt"))) {
+                !player.getController().confirmAction(sa, null, sa.getParam("OptionPrompt"), null)) {
             return;
         }
 
@@ -151,7 +151,7 @@ public class RepeatEachEffect extends SpellAbilityEffect {
                 }
             }
             for (final Player p : repeatPlayers) {
-                if (optional && !p.getController().confirmAction(repeat, null, sa.getParam("RepeatOptionalMessage"))) {
+                if (optional && !p.getController().confirmAction(repeat, null, sa.getParam("RepeatOptionalMessage"), null)) {
                     continue;
                 }
                 if (nextTurn) {

--- a/forge-game/src/main/java/forge/game/ability/effects/RepeatEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/RepeatEffect.java
@@ -115,7 +115,7 @@ public class RepeatEffect extends SpellAbilityEffect {
             Player decider = sa.hasParam("RepeatOptionalDecider")
                     ? AbilityUtils.getDefinedPlayers(sa.getHostCard(), sa.getParam("RepeatOptionalDecider"), sa).get(0)
                     : sa.getActivatingPlayer();
-            return decider.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantRepeatProcessAgain"));
+            return decider.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantRepeatProcessAgain"), null);
         }
 
         return true;

--- a/forge-game/src/main/java/forge/game/ability/effects/RevealHandEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/RevealHandEffect.java
@@ -41,7 +41,7 @@ public class RevealHandEffect extends SpellAbilityEffect {
 
         for (final Player p : getTargetPlayers(sa)) {
             if ((tgt == null) || p.canBeTargetedBy(sa)) {
-                if (optional && !p.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantRevealYourHand"))) {
+                if (optional && !p.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantRevealYourHand"), null)) {
                     continue;
                 }
                 CardCollectionView hand = p.getCardsIn(ZoneType.Hand);

--- a/forge-game/src/main/java/forge/game/ability/effects/SacrificeEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/SacrificeEffect.java
@@ -46,7 +46,7 @@ public class SacrificeEffect extends SpellAbilityEffect {
         if (sa.hasParam("Echo")) {
             boolean isPaid;
             if (activator.hasKeyword("You may pay 0 rather than pay the echo cost for permanents you control.")
-                    && activator.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantPayEcho") + " {0}?")) {
+                    && activator.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantPayEcho") + " {0}?", null)) {
                 isPaid = true;
             } else {
                 isPaid = activator.getController().payManaOptional(card, new Cost(sa.getParam("Echo"), true),
@@ -110,7 +110,7 @@ public class SacrificeEffect extends SpellAbilityEffect {
         if (valid.equals("Self") && game.getZoneOf(card) != null) {
             if (game.getZoneOf(card).is(ZoneType.Battlefield)) {
                 if (!optional || activator.getController().confirmAction(sa, null,
-                        Localizer.getInstance().getMessage("lblDoYouWantSacrificeThis", card.getName()))) {
+                        Localizer.getInstance().getMessage("lblDoYouWantSacrificeThis", card.getName()), null)) {
                     if (game.getAction().sacrifice(card, sa, true, table, params) != null) {
                         if (remSacrificed) {
                             card.addRemembered(card);
@@ -153,7 +153,7 @@ public class SacrificeEffect extends SpellAbilityEffect {
 
                     if (sa.hasParam("Random")) {
                         choosenToSacrifice = Aggregates.random(validTargets, Math.min(amount, validTargets.size()), new CardCollection());
-                    } else if (optional && !p.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantSacrifice"))) {
+                    } else if (optional && !p.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantSacrifice"), null)) {
                         choosenToSacrifice = CardCollection.EMPTY;
                     } else {
                         boolean isStrict = sa.hasParam("StrictAmount");

--- a/forge-game/src/main/java/forge/game/ability/effects/ScryEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ScryEffect.java
@@ -44,7 +44,7 @@ public class ScryEffect extends SpellAbilityEffect {
         // Optional here for spells that have optional multi-player scrying
         for (final Player p : getTargetPlayers(sa)) {
             if ( (!sa.usesTargeting() || p.canBeTargetedBy(sa)) &&
-                    (!isOptional || p.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWanttoScry"))) ) {
+                    (!isOptional || p.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWanttoScry"), null)) ) {
                 players.add(p);
             }
         }

--- a/forge-game/src/main/java/forge/game/ability/effects/SetStateEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/SetStateEffect.java
@@ -150,7 +150,7 @@ public class SetStateEffect extends SpellAbilityEffect {
 
             if (optional) {
                 String message = TextUtil.concatWithSpace("Transform", gameCard.getName(), "?");
-                if (!p.getController().confirmAction(sa, PlayerActionConfirmMode.Random, message)) {
+                if (!p.getController().confirmAction(sa, PlayerActionConfirmMode.Random, message, null)) {
                     return;
                 }
             }

--- a/forge-game/src/main/java/forge/game/ability/effects/ShuffleEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ShuffleEffect.java
@@ -21,7 +21,7 @@ public class ShuffleEffect extends SpellAbilityEffect {
 
         for (final Player p : tgtPlayers) {
             if ((tgt == null) || p.canBeTargetedBy(sa)) {
-                boolean mustShuffle = !optional || sa.getActivatingPlayer().getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblHaveTargetShuffle", p.getName())); 
+                boolean mustShuffle = !optional || sa.getActivatingPlayer().getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblHaveTargetShuffle", p.getName()), null); 
                 if (mustShuffle) 
                     p.shuffle(sa);
             }

--- a/forge-game/src/main/java/forge/game/ability/effects/SurveilEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/SurveilEffect.java
@@ -43,7 +43,7 @@ public class SurveilEffect extends SpellAbilityEffect {
 
         for (final Player p : getTargetPlayers(sa)) {
             if (!sa.usesTargeting() || p.canBeTargetedBy(sa)) {
-                if (isOptional && !p.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantSurveil"))) {
+                if (isOptional && !p.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblDoYouWantSurveil"), null)) {
                     continue;
                 }
 

--- a/forge-game/src/main/java/forge/game/combat/Combat.java
+++ b/forge-game/src/main/java/forge/game/combat/Combat.java
@@ -724,7 +724,7 @@ public class Combat {
                                 "defending player and/or any number of creatures they control.")
                         && blocker.getController().getController().confirmAction(null, null,
                         Localizer.getInstance().getMessage("lblAssignCombatDamageAsChoose",
-                                CardTranslation.getTranslatedName(blocker.getName())));
+                                CardTranslation.getTranslatedName(blocker.getName())), null);
                 // choose defending player
                 if (divideCombatDamageAsChoose) {
                     defender = blocker.getController().getController().chooseSingleEntityForEffect(attackingPlayer.getOpponents(), null, Localizer.getInstance().getMessage("lblChoosePlayer"), null);
@@ -803,7 +803,7 @@ public class Combat {
             if (!assignToPlayer && attacker.getGame().getCombat().isBlocked(attacker) && attacker.hasKeyword("You may have CARDNAME assign its combat damage as though it weren't blocked.")) {
                 assignToPlayer = assigningPlayer.getController().confirmAction(emptySA, PlayerActionConfirmMode.AlternativeDamageAssignment,
                         Localizer.getInstance().getMessage("lblAssignCombatDamageWerentBlocked",
-                                CardTranslation.getTranslatedName(attacker.getName())));
+                                CardTranslation.getTranslatedName(attacker.getName())), null);
             }
 
             boolean divideCombatDamageAsChoose = false;
@@ -815,7 +815,7 @@ public class Combat {
                                 "defending player and/or any number of creatures they control.")
                         && assigningPlayer.getController().confirmAction(emptySA, PlayerActionConfirmMode.AlternativeDamageAssignment,
                                 Localizer.getInstance().getMessage("lblAssignCombatDamageAsChoose",
-                                        CardTranslation.getTranslatedName(attacker.getName())));
+                                        CardTranslation.getTranslatedName(attacker.getName())), null);
                 if (defender instanceof Card && divideCombatDamageAsChoose) {
                     defender = getDefenderPlayerByAttacker(attacker);
                 }
@@ -826,7 +826,7 @@ public class Combat {
                                 "a creature defending player controls.") &&
                         assigningPlayer.getController().confirmAction(emptySA, PlayerActionConfirmMode.AlternativeDamageAssignment,
                                 Localizer.getInstance().getMessage("lblAssignCombatDamageToCreature",
-                                        CardTranslation.getTranslatedName(attacker.getName())));
+                                        CardTranslation.getTranslatedName(attacker.getName())), null);
                         if (divideCombatDamageAsChoose) {
                             if (orderedBlockers == null || orderedBlockers.isEmpty()) {
                                 orderedBlockers = getDefendersCreatures();

--- a/forge-game/src/main/java/forge/game/player/PlayerController.java
+++ b/forge-game/src/main/java/forge/game/player/PlayerController.java
@@ -134,7 +134,7 @@ public abstract class PlayerController {
 
     public abstract <T extends GameEntity> List<T> chooseEntitiesForEffect(FCollectionView<T> optionList, int min, int max, DelayedReveal delayedReveal, SpellAbility sa, String title, Player relatedPlayer, Map<String, Object> params);
 
-    public abstract boolean confirmAction(SpellAbility sa, PlayerActionConfirmMode mode, String message);
+    public abstract boolean confirmAction(SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params);
     public abstract boolean confirmBidAction(SpellAbility sa, PlayerActionConfirmMode bidlife, String string, int bid, Player winner);
     public abstract boolean confirmReplacementEffect(ReplacementEffect replacementEffect, SpellAbility effectSA, GameEntity affected, String question);
     public abstract boolean confirmStaticApplication(Card hostCard, GameEntity affected, String logic, String message);

--- a/forge-gui-desktop/src/test/java/forge/gamesimulationtests/util/PlayerControllerForTests.java
+++ b/forge-gui-desktop/src/test/java/forge/gamesimulationtests/util/PlayerControllerForTests.java
@@ -191,7 +191,7 @@ public class PlayerControllerForTests extends PlayerController {
     }
 
     @Override
-    public boolean confirmAction(SpellAbility sa, PlayerActionConfirmMode mode, String message) {
+    public boolean confirmAction(SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> newParam) {
         return true;
     }
 

--- a/forge-gui/src/main/java/forge/player/HumanPlaySpellAbility.java
+++ b/forge-gui/src/main/java/forge/player/HumanPlaySpellAbility.java
@@ -106,7 +106,7 @@ public class HumanPlaySpellAbility {
         }
 
         final boolean playerManaConversion = human.hasManaConversion()
-                && human.getController().confirmAction(ability, null, "Do you want to spend mana as though it were mana of any color to pay the cost?");
+                && human.getController().confirmAction(ability, null, "Do you want to spend mana as though it were mana of any color to pay the cost?", null);
 
         Cost abCost = ability.getPayCosts();
         CostPayment payment = new CostPayment(abCost, ability);

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -733,7 +733,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
      * SpellAbility, java.lang.String, java.lang.String)
      */
     @Override
-    public boolean confirmAction(final SpellAbility sa, final PlayerActionConfirmMode mode, final String message) {
+    public boolean confirmAction(final SpellAbility sa, final PlayerActionConfirmMode mode, final String message, Map<String, Object> params) {
         if (sa != null && sa.getHostCard() != null && sa.hasParam("ShowCardInPrompt")) {
             // The card wants another thing displayed in the prompt on mouse over rather than itself
             Card show = null;


### PR DESCRIPTION
Small AI patch

confirmAction is extended with Map Params so later Effects might tell the AI what it needs to confirm. (i want to use it for Bond Effect later or other stuff)