### PR TITLE
only reset castFaceDown when making a full spell copy

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
@@ -1555,7 +1555,6 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
         Card movedCard = null;
         if (srcSA.hasParam("Destination")) {
             final boolean remember = srcSA.hasParam("RememberChanged");
-            final boolean rememberSpell = srcSA.hasParam("RememberSpell");
             final boolean imprint = srcSA.hasParam("Imprint");
             if (tgtSA.isAbility()) {
                 // Shouldn't be able to target Abilities but leaving this in for now
@@ -1590,9 +1589,6 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
             if (remember) {
                 srcSA.getHostCard().addRemembered(tgtHost);
                 // TODO or remember moved?
-            }
-            if (rememberSpell) {
-                srcSA.getHostCard().addRemembered(tgtSA);
             }
             if (imprint) {
                 srcSA.getHostCard().addImprintedCard(tgtHost);

--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
@@ -1587,9 +1587,13 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
             }
 
             if (srcSA.hasParam("WithCountersType")) {
+                Player placer = srcSA.getActivatingPlayer();
+                if (srcSA.hasParam("WithCountersPlacer")) {
+                    placer = AbilityUtils.getDefinedPlayers(srcSA.getHostCard(), srcSA.getParam("WithCountersPlacer"), srcSA).get(0);
+                }
                 CounterType cType = CounterType.getType(srcSA.getParam("WithCountersType"));
                 int cAmount = AbilityUtils.calculateAmount(srcSA.getHostCard(), srcSA.getParamOrDefault("WithCountersAmount", "1"), srcSA);
-                movedCard.addCounter(cType, cAmount, srcSA.getActivatingPlayer(), counterTable);
+                movedCard.addCounter(cType, cAmount, placer, counterTable);
             }
 
             if (remember) {

--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
@@ -511,7 +511,7 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
                 continue;
             }
 
-            removeFromStack(tgtSA, sa, si, game, triggerList);
+            removeFromStack(tgtSA, sa, si, game, triggerList, counterTable);
         } // End of change from stack
 
         final String remember = sa.getParam("RememberChanged");
@@ -1543,7 +1543,7 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
      *            object.
      * @param game
      */
-    private static void removeFromStack(final SpellAbility tgtSA, final SpellAbility srcSA, final SpellAbilityStackInstance si, final Game game, CardZoneTable triggerList) {
+    private static void removeFromStack(final SpellAbility tgtSA, final SpellAbility srcSA, final SpellAbilityStackInstance si, final Game game, CardZoneTable triggerList, GameEntityCounterTable counterTable) {
         final Card tgtHost = tgtSA.getHostCard();
         final Zone originZone = tgtHost.getZone();
         game.getStack().remove(si);
@@ -1584,6 +1584,12 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
             } else {
                 throw new IllegalArgumentException("AbilityFactory_ChangeZone: Invalid Destination argument for card "
                         + srcSA.getHostCard().getName());
+            }
+
+            if (srcSA.hasParam("WithCountersType")) {
+                CounterType cType = CounterType.getType(srcSA.getParam("WithCountersType"));
+                int cAmount = AbilityUtils.calculateAmount(srcSA.getHostCard(), srcSA.getParamOrDefault("WithCountersAmount", "1"), srcSA);
+                movedCard.addCounter(cType, cAmount, srcSA.getActivatingPlayer(), counterTable);
             }
 
             if (remember) {

--- a/forge-game/src/main/java/forge/game/ability/effects/EffectEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/EffectEffect.java
@@ -88,6 +88,13 @@ public class EffectEffect extends SpellAbilityEffect {
             effectKeywords = sa.getParam("Keywords").split(",");
         }
 
+        if (sa.hasParam("RememberSpell")) {
+            rememberList = new FCollection<>();
+            for (final String rem : sa.getParam("RememberSpell").split(",")) {
+                rememberList.addAll(AbilityUtils.getDefinedSpellAbilities(hostCard, rem, sa));
+            }
+        }
+
         if (sa.hasParam("RememberObjects")) {
             rememberList = new FCollection<>();
             for (final String rem : sa.getParam("RememberObjects").split(",")) {

--- a/forge-game/src/main/java/forge/game/card/CardFactory.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactory.java
@@ -209,6 +209,12 @@ public class CardFactory {
         // 707.10b
         copySA.setOriginalAbility(targetSA);
 
+        // Copied spell is not cast face down
+        if (copySA instanceof Spell) {
+            Spell spell = (Spell) copySA;
+            spell.setCastFaceDown(false);
+        }
+
         if (targetSA.usesTargeting()) {
             // do for SubAbilities too?
             copySA.setTargets(targetSA.getTargets().clone());

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
@@ -1155,14 +1155,6 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
         }
         newSA.setDescription(newSA.getDescription() + " (without paying its mana cost)");
 
-        //Normal copied spell will not copy castFaceDown flag
-        //But copyWithNoManaCost is used to get SA without mana cost
-        //So it need to copy the castFaceDown flag too
-        if (newSA instanceof Spell) {
-            Spell spell = (Spell) newSA;
-            spell.setCastFaceDown(this.isCastFaceDown());
-        }
-
         return newSA;
     }
 

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
@@ -1096,12 +1096,6 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
             // always set this to false, it is only set in CopyEffect
             clone.mayChooseNewTargets = false;
 
-            // Copied spell is not cast face down
-            if (clone instanceof Spell) {
-                Spell spell = (Spell) clone;
-                spell.setCastFaceDown(false);
-            }
-
             clone.triggeringObjects = AbilityKey.newMap(this.triggeringObjects);
 
             clone.setPayCosts(getPayCosts().copy());

--- a/forge-gui/res/cardsfolder/e/ertais_meddling.txt
+++ b/forge-gui/res/cardsfolder/e/ertais_meddling.txt
@@ -2,7 +2,7 @@ Name:Ertai's Meddling
 ManaCost:X U
 Types:Instant
 Text:X can't be 0.\r\n
-A:SP$ ChangeZone | Cost$ XCantBe0 X U | TgtZone$ Stack | TargetType$ Spell | ValidTgts$ Card | Origin$ Stack | Destination$ Exile | Imprint$ True | WithCountersType$ DELAY | WithCountersAmount$ X | SubAbility$ DBPutCounter | SpellDescription$ Target spell's controller exiles it with X delay counters on it.
+A:SP$ ChangeZone | Cost$ XCantBe0 X U | TgtZone$ Stack | TargetType$ Spell | ValidTgts$ Card | Origin$ Stack | Destination$ Exile | Imprint$ True | SubAbility$ DBPutCounter | SpellDescription$ Target spell's controller exiles it with X delay counters on it.
 SVar:X:Count$xPaid
 SVar:DBPutCounter:DB$ PutCounter | Defined$ Imprinted | CounterType$ DELAY | CounterNum$ X | SubAbility$ DBDelayEffect
 SVar:DBDelayEffect:DB$ Effect | EffectOwner$ TargetedController | RememberSpell$ Targeted | ImprintCards$ Imprinted | ConditionDefined$ Imprinted | ConditionPresent$ Card.inZoneExile | Triggers$ TrigDelay,TrigExile | Duration$ Permanent | SubAbility$ DBForget

--- a/forge-gui/res/cardsfolder/e/ertais_meddling.txt
+++ b/forge-gui/res/cardsfolder/e/ertais_meddling.txt
@@ -2,11 +2,11 @@ Name:Ertai's Meddling
 ManaCost:X U
 Types:Instant
 Text:X can't be 0.\r\n
-A:SP$ ChangeZone | Cost$ XCantBe0 X U | TgtZone$ Stack | TargetType$ Spell | ValidTgts$ Card | Origin$ Stack | Destination$ Exile | Imprint$ True | RememberSpell$ True | SubAbility$ DBPutCounter | SpellDescription$ Target spell's controller exiles it with X delay counters on it.
+A:SP$ ChangeZone | Cost$ XCantBe0 X U | TgtZone$ Stack | TargetType$ Spell | ValidTgts$ Card | Origin$ Stack | Destination$ Exile | Imprint$ True | WithCountersType$ DELAY | WithCountersAmount$ X | SubAbility$ DBPutCounter | SpellDescription$ Target spell's controller exiles it with X delay counters on it.
 SVar:X:Count$xPaid
 SVar:DBPutCounter:DB$ PutCounter | Defined$ Imprinted | CounterType$ DELAY | CounterNum$ X | SubAbility$ DBDelayEffect
-SVar:DBDelayEffect:DB$ Effect | EffectOwner$ TargetedController | RememberObjects$ Remembered | ImprintCards$ Imprinted | Triggers$ TrigDelay,TrigExile | Duration$ Permanent | SubAbility$ DBForget
-SVar:DBForget:DB$ Cleanup | ClearRemembered$ True | ClearImprinted$ True
+SVar:DBDelayEffect:DB$ Effect | EffectOwner$ TargetedController | RememberSpell$ Targeted | ImprintCards$ Imprinted | ConditionDefined$ Imprinted | ConditionPresent$ Card.inZoneExile | Triggers$ TrigDelay,TrigExile | Duration$ Permanent | SubAbility$ DBForget
+SVar:DBForget:DB$ Cleanup | ClearImprinted$ True
 # Add a fake trigger to display spell ability text ingame
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Command | Execute$ TrigLoseDelay | TriggerDescription$ At the beginning of each of that player's upkeeps, if that card is exiled, remove a delay counter from it. If the card has no delay counters on it, the player puts it onto the stack as a copy of the original spell.
 SVar:TrigDelay:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Command | Execute$ TrigLoseDelay | TriggerDescription$ At the beginning of each of that player's upkeeps, if that card is exiled, remove a delay counter from it. If the card has no delay counters on it, the player puts it onto the stack as a copy of the original spell.

--- a/forge-gui/res/cardsfolder/e/ertais_meddling.txt
+++ b/forge-gui/res/cardsfolder/e/ertais_meddling.txt
@@ -2,9 +2,8 @@ Name:Ertai's Meddling
 ManaCost:X U
 Types:Instant
 Text:X can't be 0.\r\n
-A:SP$ ChangeZone | Cost$ XCantBe0 X U | TgtZone$ Stack | TargetType$ Spell | ValidTgts$ Card | Origin$ Stack | Destination$ Exile | Imprint$ True | SubAbility$ DBPutCounter | SpellDescription$ Target spell's controller exiles it with X delay counters on it.
+A:SP$ ChangeZone | Cost$ XCantBe0 X U | TgtZone$ Stack | TargetType$ Spell | ValidTgts$ Card | Origin$ Stack | Destination$ Exile | Imprint$ True | WithCountersType$ DELAY | WithCountersAmount$ X | SubAbility$ DBDelayEffect | SpellDescription$ Target spell's controller exiles it with X delay counters on it.
 SVar:X:Count$xPaid
-SVar:DBPutCounter:DB$ PutCounter | Defined$ Imprinted | CounterType$ DELAY | CounterNum$ X | SubAbility$ DBDelayEffect
 SVar:DBDelayEffect:DB$ Effect | EffectOwner$ TargetedController | RememberSpell$ Targeted | ImprintCards$ Imprinted | ConditionDefined$ Imprinted | ConditionPresent$ Card.inZoneExile | Triggers$ TrigDelay,TrigExile | Duration$ Permanent | SubAbility$ DBForget
 SVar:DBForget:DB$ Cleanup | ClearImprinted$ True
 # Add a fake trigger to display spell ability text ingame

--- a/forge-gui/res/cardsfolder/e/ertais_meddling.txt
+++ b/forge-gui/res/cardsfolder/e/ertais_meddling.txt
@@ -2,7 +2,7 @@ Name:Ertai's Meddling
 ManaCost:X U
 Types:Instant
 Text:X can't be 0.\r\n
-A:SP$ ChangeZone | Cost$ XCantBe0 X U | TgtZone$ Stack | TargetType$ Spell | ValidTgts$ Card | Origin$ Stack | Destination$ Exile | Imprint$ True | WithCountersType$ DELAY | WithCountersAmount$ X | SubAbility$ DBDelayEffect | SpellDescription$ Target spell's controller exiles it with X delay counters on it.
+A:SP$ ChangeZone | Cost$ XCantBe0 X U | TgtZone$ Stack | TargetType$ Spell | ValidTgts$ Card | Origin$ Stack | Destination$ Exile | Imprint$ True | WithCountersType$ DELAY | WithCountersAmount$ X | WithCountersPlacer$ TargetedController | SubAbility$ DBDelayEffect | SpellDescription$ Target spell's controller exiles it with X delay counters on it.
 SVar:X:Count$xPaid
 SVar:DBDelayEffect:DB$ Effect | EffectOwner$ TargetedController | RememberSpell$ Targeted | ImprintCards$ Imprinted | ConditionDefined$ Imprinted | ConditionPresent$ Card.inZoneExile | Triggers$ TrigDelay,TrigExile | Duration$ Permanent | SubAbility$ DBForget
 SVar:DBForget:DB$ Cleanup | ClearImprinted$ True

--- a/forge-gui/res/cardsfolder/e/evelyn_the_covetous.txt
+++ b/forge-gui/res/cardsfolder/e/evelyn_the_covetous.txt
@@ -8,3 +8,4 @@ SVar:TrigExile:DB$ Dig | DigNum$ 1 | ChangeNum$ All | Defined$ Player | Destinat
 S:Mode$ Continuous | MayPlayLimit$ 1 | Affected$ Card.ExiledByYou+counters_GE1_COLLECTION | AffectedZone$ Exile | MayPlay$ True | MayPlayIgnoreColor$ True | Description$ Once each turn, you may play a card from exile with a collection counter on it if it was exiled by an ability you controlled, and you may spend mana as though it were any color to cast it.
 DeckHints:Type$Vampire
 Oracle:Flash\nWhenever Evelyn, the Covetous or another Vampire enters the battlefield under your control, exile the top card of each player's library with a collection counter on it.
+\nOnce each turn, you may play a card from exile with a collection counter on it if it was exiled by an ability you controlled, and you may spend mana as though it were mana of any color to cast it.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8506892/175510886-31edd30d-6122-49c5-9b71-4b8ca7233f94.png)

sa.copy does reset it for copied spells