### PR TITLE
YCLB Land Gate cycle

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/gate_of_the_black_dragon.txt
+++ b/forge-gui/res/cardsfolder/upcoming/gate_of_the_black_dragon.txt
@@ -1,0 +1,7 @@
+Name:Gate of the Black Dragon
+ManaCost:no cost
+Types:Land Swamp Gate
+K:CARDNAME enters the battlefield tapped.
+A:AB$ ChangeZone | Cost$ 3 B T | Origin$ Library | Destination$ Hand | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | NoReveal$ True | ChangeNum$ 1 | ChangeType$ Card.nonLand | GameActivationLimit$ 1 | StackDescription$ SpellDescription | SpellDescription$ Seek a nonland card. Activate only once.
+DeckHints:Type$Gate
+Oracle:Gate of the Black Dragon enters the battlefield tapped.\n{3}{B}, {T}: Seek a nonland card. Activate only once.\n{T}: Add {B}.

--- a/forge-gui/res/cardsfolder/upcoming/gate_of_the_black_dragon.txt
+++ b/forge-gui/res/cardsfolder/upcoming/gate_of_the_black_dragon.txt
@@ -3,5 +3,6 @@ ManaCost:no cost
 Types:Land Swamp Gate
 K:CARDNAME enters the battlefield tapped.
 A:AB$ ChangeZone | Cost$ 3 B T | Origin$ Library | Destination$ Hand | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | NoReveal$ True | ChangeNum$ 1 | ChangeType$ Card.nonLand | GameActivationLimit$ 1 | StackDescription$ SpellDescription | SpellDescription$ Seek a nonland card. Activate only once.
+Text:{T}: Add {B}.
 DeckHints:Type$Gate
 Oracle:Gate of the Black Dragon enters the battlefield tapped.\n{3}{B}, {T}: Seek a nonland card. Activate only once.\n{T}: Add {B}.

--- a/forge-gui/res/cardsfolder/upcoming/gate_to_manorborn.txt
+++ b/forge-gui/res/cardsfolder/upcoming/gate_to_manorborn.txt
@@ -1,0 +1,7 @@
+Name:Gate to Manorborn
+ManaCost:no cost
+Types:Land Forest Gate
+K:CARDNAME enters the battlefield tapped.
+A:AB$ ChangeZone | Cost$ 3 G T | Origin$ Library | Destination$ Hand | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | NoReveal$ True | ChangeNum$ 1 | ChangeType$ Card.nonLand | GameActivationLimit$ 1 | StackDescription$ SpellDescription | SpellDescription$ Seek a nonland card. Activate only once.
+DeckHints:Type$Gate
+Oracle:Gate to Manorborn enters the battlefield tapped.\n{3}{G}, {T}: Seek a nonland card. Activate only once.\n{T}: Add {G}.

--- a/forge-gui/res/cardsfolder/upcoming/gate_to_manorborn.txt
+++ b/forge-gui/res/cardsfolder/upcoming/gate_to_manorborn.txt
@@ -3,5 +3,6 @@ ManaCost:no cost
 Types:Land Forest Gate
 K:CARDNAME enters the battlefield tapped.
 A:AB$ ChangeZone | Cost$ 3 G T | Origin$ Library | Destination$ Hand | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | NoReveal$ True | ChangeNum$ 1 | ChangeType$ Card.nonLand | GameActivationLimit$ 1 | StackDescription$ SpellDescription | SpellDescription$ Seek a nonland card. Activate only once.
+Text:{T}: Add {G}.
 DeckHints:Type$Gate
 Oracle:Gate to Manorborn enters the battlefield tapped.\n{3}{G}, {T}: Seek a nonland card. Activate only once.\n{T}: Add {G}.

--- a/forge-gui/res/cardsfolder/upcoming/gate_to_seatower.txt
+++ b/forge-gui/res/cardsfolder/upcoming/gate_to_seatower.txt
@@ -1,0 +1,7 @@
+Name:Gate to Seatower
+ManaCost:no cost
+Types:Land Island Gate
+K:CARDNAME enters the battlefield tapped.
+A:AB$ ChangeZone | Cost$ 3 U T | Origin$ Library | Destination$ Hand | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | NoReveal$ True | ChangeNum$ 1 | ChangeType$ Card.nonLand | GameActivationLimit$ 1 | StackDescription$ SpellDescription | SpellDescription$ Seek a nonland card. Activate only once.
+DeckHints:Type$Gate
+Oracle:Gate to Seatower enters the battlefield tapped.\n{3}{U}, {T}: Seek a nonland card. Activate only once.\n{T}: Add {U}.

--- a/forge-gui/res/cardsfolder/upcoming/gate_to_seatower.txt
+++ b/forge-gui/res/cardsfolder/upcoming/gate_to_seatower.txt
@@ -3,5 +3,6 @@ ManaCost:no cost
 Types:Land Island Gate
 K:CARDNAME enters the battlefield tapped.
 A:AB$ ChangeZone | Cost$ 3 U T | Origin$ Library | Destination$ Hand | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | NoReveal$ True | ChangeNum$ 1 | ChangeType$ Card.nonLand | GameActivationLimit$ 1 | StackDescription$ SpellDescription | SpellDescription$ Seek a nonland card. Activate only once.
+Text:{T}: Add {U}.
 DeckHints:Type$Gate
 Oracle:Gate to Seatower enters the battlefield tapped.\n{3}{U}, {T}: Seek a nonland card. Activate only once.\n{T}: Add {U}.

--- a/forge-gui/res/cardsfolder/upcoming/gate_to_the_citadel.txt
+++ b/forge-gui/res/cardsfolder/upcoming/gate_to_the_citadel.txt
@@ -3,5 +3,6 @@ ManaCost:no cost
 Types:Land Plains Gate
 K:CARDNAME enters the battlefield tapped.
 A:AB$ ChangeZone | Cost$ 3 W T | Origin$ Library | Destination$ Hand | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | NoReveal$ True | ChangeNum$ 1 | ChangeType$ Card.nonLand | GameActivationLimit$ 1 | StackDescription$ SpellDescription | SpellDescription$ Seek a nonland card. Activate only once.
+Text:{T}: Add {W}.
 DeckHints:Type$Gate
 Oracle:Gate to the Citadel enters the battlefield tapped.\n{3}{W}, {T}: Seek a nonland card. Activate only once.\n{T}: Add {W}.

--- a/forge-gui/res/cardsfolder/upcoming/gate_to_the_citadel.txt
+++ b/forge-gui/res/cardsfolder/upcoming/gate_to_the_citadel.txt
@@ -1,0 +1,7 @@
+Name:Gate to the Citadel
+ManaCost:no cost
+Types:Land Plains Gate
+K:CARDNAME enters the battlefield tapped.
+A:AB$ ChangeZone | Cost$ 3 W T | Origin$ Library | Destination$ Hand | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | NoReveal$ True | ChangeNum$ 1 | ChangeType$ Card.nonLand | GameActivationLimit$ 1 | StackDescription$ SpellDescription | SpellDescription$ Seek a nonland card. Activate only once.
+DeckHints:Type$Gate
+Oracle:Gate to the Citadel enters the battlefield tapped.\n{3}{W}, {T}: Seek a nonland card. Activate only once.\n{T}: Add {W}.

--- a/forge-gui/res/cardsfolder/upcoming/gate_to_tumbledown.txt
+++ b/forge-gui/res/cardsfolder/upcoming/gate_to_tumbledown.txt
@@ -3,5 +3,6 @@ ManaCost:no cost
 Types:Land Mountain Gate
 K:CARDNAME enters the battlefield tapped.
 A:AB$ ChangeZone | Cost$ 3 R T | Origin$ Library | Destination$ Hand | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | NoReveal$ True | ChangeNum$ 1 | ChangeType$ Card.nonLand | GameActivationLimit$ 1 | StackDescription$ SpellDescription | SpellDescription$ Seek a nonland card. Activate only once.
+Text:{T}: Add {R}.
 DeckHints:Type$Gate
 Oracle:Gate to Tumbledown enters the battlefield tapped.\n{3}{R}, {T}: Seek a nonland card. Activate only once.\n{T}: Add {R}.

--- a/forge-gui/res/cardsfolder/upcoming/gate_to_tumbledown.txt
+++ b/forge-gui/res/cardsfolder/upcoming/gate_to_tumbledown.txt
@@ -1,0 +1,7 @@
+Name:Gate to Tumbledown
+ManaCost:no cost
+Types:Land Mountain Gate
+K:CARDNAME enters the battlefield tapped.
+A:AB$ ChangeZone | Cost$ 3 R T | Origin$ Library | Destination$ Hand | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | NoReveal$ True | ChangeNum$ 1 | ChangeType$ Card.nonLand | GameActivationLimit$ 1 | StackDescription$ SpellDescription | SpellDescription$ Seek a nonland card. Activate only once.
+DeckHints:Type$Gate
+Oracle:Gate to Tumbledown enters the battlefield tapped.\n{3}{R}, {T}: Seek a nonland card. Activate only once.\n{T}: Add {R}.


### PR DESCRIPTION
As these are "Types:Land Colour Gate" they auto have the ability to produce the colour but it doesn't show in card detail so added Text:

-closes #766 and other gates from YCLB