### PR TITLE
Blitz Again, check for Keyword

### DIFF
--- a/forge-game/src/main/java/forge/game/CardTraitBase.java
+++ b/forge-game/src/main/java/forge/game/CardTraitBase.java
@@ -20,6 +20,7 @@ import forge.game.card.CardPredicates;
 import forge.game.card.CardState;
 import forge.game.card.CardView;
 import forge.game.card.IHasCardView;
+import forge.game.keyword.KeywordInterface;
 import forge.game.player.Player;
 import forge.game.spellability.SpellAbility;
 import forge.game.zone.ZoneType;
@@ -34,6 +35,7 @@ public abstract class CardTraitBase extends GameObject implements IHasCardView, 
     /** The host card. */
     protected Card hostCard;
     protected CardState cardState = null;
+    protected KeywordInterface keyword = null;
 
     /** The map params. */
     protected Map<String, String> originalMapParams = Maps.newHashMap(),
@@ -138,6 +140,14 @@ public abstract class CardTraitBase extends GameObject implements IHasCardView, 
         this.hostCard = c;
     }
 
+    public KeywordInterface getKeyword() {
+        return this.keyword;
+    }
+    
+    public void setKeyword(final KeywordInterface kw) {
+        this.keyword = kw;
+    }
+    
     /**
      * <p>
      * isSecondary.
@@ -667,6 +677,7 @@ public abstract class CardTraitBase extends GameObject implements IHasCardView, 
         copy.setCardState(cardState);
         // dont use setHostCard to not trigger the not copied parts yet
         copy.hostCard = host;
+        copy.keyword = this.keyword;
     }
 
     abstract public List<Object> getTriggerRemembered();

--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -297,6 +297,14 @@ public class GameAction {
 
                 // copy bestow timestamp
                 copied.setBestowTimestamp(c.getBestowTimestamp());
+
+                if (cause != null && cause.isSpell() && c.equals(cause.getHostCard())) {
+                    copied.setCastSA(cause);
+                    KeywordInterface kw = cause.getKeyword();
+                    if (kw != null) {
+                        copied.addKeywordForStaticAbility(kw);
+                    }
+                }
             } else {
                 // when a card leaves the battlefield, ensure it's in its original state
                 // (we need to do this on the object before copying it, or it won't work correctly e.g.
@@ -505,6 +513,7 @@ public class GameAction {
                             }
                         }
                         if (keepKeyword) {
+                            ki.setHostCard(copied);
                             newKw.add(ki);
                         }
                     }

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -4463,6 +4463,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
         KeywordInterface result;
         if (staticId < 1 || !storedKeywords.contains(staticId, kw)) {
             result = Keyword.getInstance(kw);
+            result.setStaticId(staticId);
             result.createTraits(this, false);
             if (staticId > 0) {
                 storedKeywords.put(staticId, kw, result);
@@ -4471,6 +4472,12 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
             result = storedKeywords.get(staticId, kw);
         }
         return result;
+    }
+    
+    public final void addKeywordForStaticAbility(KeywordInterface kw) {
+        if (kw.getStaticId() > 0) {
+            storedKeywords.put(kw.getStaticId(), kw.getOriginal(), kw);
+        }
     }
 
     public final void addChangedCardKeywordsByText(final List<KeywordInterface> keywords, final long timestamp, final long staticId, final boolean updateView) {

--- a/forge-game/src/main/java/forge/game/card/CardFactory.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactory.java
@@ -29,6 +29,7 @@ import forge.game.Game;
 import forge.game.ability.AbilityFactory;
 import forge.game.ability.AbilityUtils;
 import forge.game.cost.Cost;
+import forge.game.keyword.KeywordInterface;
 import forge.game.player.Player;
 import forge.game.replacement.ReplacementHandler;
 import forge.game.spellability.*;
@@ -203,6 +204,13 @@ public class CardFactory {
         } else {
             copySA = targetSA.copy(c, controller, false);
             c.setCastSA(copySA);
+            // need to copy keyword
+            if (targetSA.getKeyword() != null) {
+                KeywordInterface kw = targetSA.getKeyword().copy(c, false);
+                copySA.setKeyword(kw);
+                // need to add the keyword to so static doesn't make new keyword
+                c.addKeywordForStaticAbility(kw);
+            }
         }
 
         copySA.setCopied(true);

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -3448,9 +3448,21 @@ public class CardFactoryUtil {
             st.setSVar("AffinityX", "Count$Valid " + t + ".YouCtrl");
             inst.addStaticAbility(st);
         } else if (keyword.startsWith("Blitz")) {
-            String effect = "Mode$ Continuous | Affected$ Card.Self+blitzed | AddKeyword$ Haste | AddTrigger$ Dies";
-            String trig = "Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | " +
-                    "Execute$ TrigDraw | TriggerDescription$ When this creature dies, draw a card.";
+            final String[] k = keyword.split(":");
+            final String manacost = k[1];
+            final Cost cost = new Cost(manacost, false);
+
+            StringBuilder sb = new StringBuilder("Blitz");
+            if (!cost.isOnlyManaCost()) {
+                sb.append("—");
+            } else {
+                sb.append(" ");
+            }
+            sb.append(cost.toSimpleString());
+            String effect = "Mode$ Continuous | Affected$ Card.Self+blitzed+castKeyword | AddKeyword$ Haste | AddTrigger$ Dies"
+                    + " | Secondary$ True | Description$ " + sb.toString() + " (" + inst.getReminderText() + ")";
+            String trig = "Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self" +
+                    " | Execute$ TrigDraw | Secondary$ True | TriggerDescription$ When this creature dies, draw a card.";
             String ab = "DB$ Draw | NumCards$ 1";
 
             StaticAbility st = StaticAbility.create(effect, state.getCard(), state, intrinsic);
@@ -3524,7 +3536,7 @@ public class CardFactoryUtil {
 
             inst.addStaticAbility(StaticAbility.create(effect, state.getCard(), state, intrinsic));
         } else if (keyword.startsWith("Dash")) {
-            String effect = "Mode$ Continuous | Affected$ Card.Self+dashed | AddKeyword$ Haste";
+            String effect = "Mode$ Continuous | Affected$ Card.Self+dashed+castKeyword | AddKeyword$ Haste";
             inst.addStaticAbility(StaticAbility.create(effect, state.getCard(), state, intrinsic));
         } else if (keyword.equals("Daybound")) {
             String effect = "Mode$ CantTransform | ValidCard$ Creature.Self | ExceptCause$ SpellAbility.Daybound | Secondary$ True | Description$ This permanent can't be transformed except by its daybound ability.";

--- a/forge-game/src/main/java/forge/game/card/CardProperty.java
+++ b/forge-game/src/main/java/forge/game/card/CardProperty.java
@@ -34,6 +34,7 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 public class CardProperty {
@@ -1796,6 +1797,21 @@ public class CardProperty {
         } else if (property.equals("NoCounters")) {
             if (card.hasCounters()) {
                 return false;
+            }
+        } else if (property.equals("castKeyword")) {
+            SpellAbility castSA = card.getCastSA();
+            if (castSA == null) {
+                return false;
+            }
+            // intrinsic keyword might be a new one when the zone changes
+            if (castSA.isIntrinsic()) {
+                // so just check if the static is intrinsic too
+                if (!spellAbility.isIntrinsic()) {
+                    return false;
+                }
+            } else {
+                // otherwise check for keyword object
+                return Objects.equals(castSA.getKeyword(), spellAbility.getKeyword());
             }
         } else if (property.startsWith("CastSa"))  {
             SpellAbility castSA = card.getCastSA();

--- a/forge-game/src/main/java/forge/game/keyword/KeywordInstance.java
+++ b/forge-game/src/main/java/forge/game/keyword/KeywordInstance.java
@@ -22,6 +22,7 @@ import io.sentry.Sentry;
 public abstract class KeywordInstance<T extends KeywordInstance<?>> implements KeywordInterface {
     private Keyword keyword;
     private String original;
+    private long staticId = 0;
 
     private List<Trigger> triggers = Lists.newArrayList();
     private List<ReplacementEffect> replacements = Lists.newArrayList();
@@ -181,6 +182,7 @@ public abstract class KeywordInstance<T extends KeywordInstance<?>> implements K
      * @see forge.game.keyword.KeywordInterface#addTrigger(forge.game.trigger.Trigger)
      */
     public final void addTrigger(final Trigger trg) {
+        trg.setKeyword(this);
         triggers.add(trg);
     }
 
@@ -189,6 +191,7 @@ public abstract class KeywordInstance<T extends KeywordInstance<?>> implements K
      * @see forge.game.keyword.KeywordInterface#addReplacement(forge.game.replacement.ReplacementEffect)
      */
     public final void addReplacement(final ReplacementEffect trg) {
+        trg.setKeyword(this);
         replacements.add(trg);
     }
 
@@ -197,6 +200,7 @@ public abstract class KeywordInstance<T extends KeywordInstance<?>> implements K
      * @see forge.game.keyword.KeywordInterface#addSpellAbility(forge.game.spellability.SpellAbility)
      */
     public final void addSpellAbility(final SpellAbility s) {
+        s.setKeyword(this);
         abilities.add(s);
     }
 
@@ -205,6 +209,7 @@ public abstract class KeywordInstance<T extends KeywordInstance<?>> implements K
      * @see forge.game.keyword.KeywordInterface#addStaticAbility(forge.game.staticability.StaticAbility)
      */
     public final void addStaticAbility(final StaticAbility st) {
+        st.setKeyword(this);
         staticAbilities.add(st);
     }
 
@@ -247,22 +252,30 @@ public abstract class KeywordInstance<T extends KeywordInstance<?>> implements K
 
             result.abilities = Lists.newArrayList();
             for (SpellAbility sa : this.abilities) {
-                result.abilities.add(sa.copy(host, lki));
+                SpellAbility copy = sa.copy(host, lki);
+                copy.setKeyword(result);
+                result.abilities.add(copy);
             }
 
             result.triggers = Lists.newArrayList();
             for (Trigger tr : this.triggers) {
-                result.triggers.add(tr.copy(host, lki));
+                Trigger copy = tr.copy(host, lki);
+                copy.setKeyword(result);
+                result.triggers.add(copy);
             }
 
             result.replacements = Lists.newArrayList();
             for (ReplacementEffect re : this.replacements) {
-                result.replacements.add(re.copy(host, lki));
+                ReplacementEffect copy = re.copy(host, lki);
+                copy.setKeyword(result);
+                result.replacements.add(copy);
             }
 
             result.staticAbilities = Lists.newArrayList();
             for (StaticAbility sa : this.staticAbilities) {
-                result.staticAbilities.add(sa.copy(host, lki));
+                StaticAbility copy = sa.copy(host, lki);
+                copy.setKeyword(result);
+                result.staticAbilities.add(copy);
             }
 
             return result;
@@ -326,5 +339,12 @@ public abstract class KeywordInstance<T extends KeywordInstance<?>> implements K
         for (StaticAbility sa : this.staticAbilities) {
             sa.setIntrinsic(value);
         }
+    }
+    
+    public long getStaticId() {
+        return this.staticId;
+    }
+    public void setStaticId(long v) {
+        this.staticId = v;
     }
 }

--- a/forge-game/src/main/java/forge/game/keyword/KeywordInterface.java
+++ b/forge-game/src/main/java/forge/game/keyword/KeywordInterface.java
@@ -18,6 +18,8 @@ public interface KeywordInterface extends Cloneable {
     String getReminderText();
 
     int getAmount();
+    long getStaticId();
+    void setStaticId(long v);
 
     void createTraits(final Card host, final boolean intrinsic);
     void createTraits(final Card host, final boolean intrinsic, final boolean clear);


### PR DESCRIPTION
@Agetian @tool4ever 

This is for Blitz only triggering when the specific cost was paid (for this Reference to Keyword)

But there is a corner case i couldn't get working:

* Toolbox on the Field
* Cast Hill Giant with Blitz
* while on the Stack, copy the Blitz Hill Giant with Double Major
* Currently the token doesn't get Haste and trigger because the condition does fail.

but i can't find it at what place from copying the Spell, the Spell gaining Blitz on the Stack again (for this i copied the KW so the ability should give it the new one?) til the creature entering the battlefield.

somewhere i get the wrong static ability with a different keyword instance

can some one of you debug it?