### PR TITLE
Fix unmorphing being prevented by invalid static

### DIFF
--- a/forge-game/src/main/java/forge/game/spellability/SpellAbilityRestriction.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbilityRestriction.java
@@ -499,6 +499,7 @@ public class SpellAbilityRestriction extends SpellAbilityVariables {
 
             // check static abilities
             game.getTracker().freeze();
+            cp.clearStaticChangedCardKeywords(false);
             CardCollection preList = new CardCollection(cp);
             game.getAction().checkStaticAbilities(false, Sets.newHashSet(cp), preList);
 


### PR DESCRIPTION
You should be allowed to turn _Lumithread Field_ face up with _Humility_ in play.