### PR TITLE
CLB: Vhal, Candlekeep Researcher and support

### DIFF
--- a/forge-game/src/main/java/forge/game/spellability/AbilityManaPart.java
+++ b/forge-game/src/main/java/forge/game/spellability/AbilityManaPart.java
@@ -20,7 +20,6 @@ package forge.game.spellability;
 import java.util.List;
 import java.util.Map;
 
-import forge.game.zone.ZoneType;
 import org.apache.commons.lang3.StringUtils;
 
 import com.google.common.collect.Lists;
@@ -43,6 +42,8 @@ import forge.game.replacement.ReplacementType;
 import forge.game.trigger.Trigger;
 import forge.game.trigger.TriggerHandler;
 import forge.game.trigger.TriggerType;
+import forge.game.zone.ZoneType;
+import forge.game.zone.Zone;
 import forge.util.TextUtil;
 
 /**
@@ -351,8 +352,11 @@ public class AbilityManaPart implements java.io.Serializable {
                     return true;
                 }
                 final ZoneType badZone = ZoneType.smartValueOf(restriction.substring(17));
-                final ZoneType castFrom = sa.getHostCard().getCastFrom().getZoneType();
-                if (!badZone.equals(castFrom)) {
+                final Card host = sa.getHostCard();
+                final Zone castFrom = host.getCastFrom();
+                //ComputerUtilMana looks at this to see if AI can cast things, so need a fallback zone
+                final ZoneType zone = castFrom == null ? host.getZone().getZoneType() : castFrom.getZoneType();
+                if (!badZone.equals(zone)) {
                     return true;
                 }
             }

--- a/forge-game/src/main/java/forge/game/spellability/AbilityManaPart.java
+++ b/forge-game/src/main/java/forge/game/spellability/AbilityManaPart.java
@@ -20,6 +20,7 @@ package forge.game.spellability;
 import java.util.List;
 import java.util.Map;
 
+import forge.game.zone.ZoneType;
 import org.apache.commons.lang3.StringUtils;
 
 import com.google.common.collect.Lists;
@@ -339,8 +340,20 @@ public class AbilityManaPart implements java.io.Serializable {
                 continue;
             }
 
+            //handled in meetsManaShardRestrictions
             if (restriction.equals("CantPayGenericCosts")) {
                 return true;
+            }
+
+            if (restriction.startsWith("CantCastSpellFrom")) {
+                if (sa.isSpell()) {
+                    final ZoneType badZone = ZoneType.smartValueOf(restriction.substring(17));
+                    final ZoneType castFrom = sa.getHostCard().getCastFrom().getZoneType();
+                    if (!badZone.equals(castFrom)) {
+                        return true;
+                    }
+                }
+                continue;
             }
 
             // the payment is for a resolving SA, currently no other restrictions would allow that

--- a/forge-game/src/main/java/forge/game/spellability/AbilityManaPart.java
+++ b/forge-game/src/main/java/forge/game/spellability/AbilityManaPart.java
@@ -345,15 +345,16 @@ public class AbilityManaPart implements java.io.Serializable {
                 return true;
             }
 
+            // "can't" zone restriction – shouldn't be mixed with other restrictions
             if (restriction.startsWith("CantCastSpellFrom")) {
-                if (sa.isSpell()) {
-                    final ZoneType badZone = ZoneType.smartValueOf(restriction.substring(17));
-                    final ZoneType castFrom = sa.getHostCard().getCastFrom().getZoneType();
-                    if (!badZone.equals(castFrom)) {
-                        return true;
-                    }
+                if (!sa.isSpell()) { //
+                    return true;
                 }
-                continue;
+                final ZoneType badZone = ZoneType.smartValueOf(restriction.substring(17));
+                final ZoneType castFrom = sa.getHostCard().getCastFrom().getZoneType();
+                if (!badZone.equals(castFrom)) {
+                    return true;
+                }
             }
 
             // the payment is for a resolving SA, currently no other restrictions would allow that

--- a/forge-gui/res/cardsfolder/upcoming/vhal_candelkeep_researcher.txt
+++ b/forge-gui/res/cardsfolder/upcoming/vhal_candelkeep_researcher.txt
@@ -1,0 +1,10 @@
+Name:Vhal, Candlekeep Researcher
+ManaCost:3 U
+Types:Legendary Creature Human Wizard
+PT:2/3
+K:Vigilance
+A:AB$ Mana | Cost$ T | Produced$ C | Amount$ X | RestrictValid$ CantCastSpellFromHand | SpellDescription$ Add an amount of {C} equal to CARDNAME's toughness. This mana can't be spent to cast spells from your hand.
+SVar:X:Count$CardToughness
+K:Choose a Background
+AI:RemoveDeck:Random
+Oracle:Vigilance\n{T}: Add an amount of {C} equal to Vhal, Candlekeep Researcher's toughness. This mana can't be spent to cast spells from your hand.\nChoose a Background (You can have a Background as a second commander.)


### PR DESCRIPTION
closes #710

The AI seems to be able to use this legally, though it prioritizes tapping down lands first and then using the restricted mana, so kind of an ai-dumb-not-cheating type of thing.

Here it tapped three plains and only used 1 of its Vhal mana to cast Chapel Shieldgeist 3 W - it would have been "smarter" to use all the Vhal mana and only tap one of its plains.
![image](https://user-images.githubusercontent.com/103371817/177061356-a174d162-1a50-4245-87c9-16dad63c5f02.png)

I have it marked as RemoveDeck:Random since not every deck uses cast from other zones mechanics.