### PR TITLE
Alchemy Rebalancing for July 7, 2022

### DIFF
--- a/forge-gui/res/cardsfolder/d/dueling_coach.txt
+++ b/forge-gui/res/cardsfolder/d/dueling_coach.txt
@@ -4,6 +4,6 @@ Types:Creature Human Monk
 PT:2/2
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPutCounter | TriggerDescription$ When CARDNAME enters the battlefield, put a +1/+1 counter on target creature you control.
 SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | CounterType$ P1P1 | CounterNum$ 1
-A:AB$ PutCounterAll | Cost$ 4 W T | ValidCards$ Creature.YouCtrl+counters_GE1_P1P1 | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on each creature you control with a +1/+1 counter on it.
+A:AB$ PutCounterAll | Cost$ 4 W T | ValidCards$ Creature.YouCtrl+counters_GE1_P1P1 | CounterType$ P1P1 | CounterNum$ 1 | ValidCardsDesc$ creature you control with a +1/+1 counter on it. | SpellDescription$ Put a +1/+1 counter on each creature you control with a +1/+1 counter on it.
 DeckHas:Ability$Counters
 Oracle:When Dueling Coach enters the battlefield, put a +1/+1 counter on target creature.\n{4}{W}, {T}: Put a +1/+1 counter on each creature you control with a +1/+1 counter on it.

--- a/forge-gui/res/cardsfolder/d/dueling_coach.txt
+++ b/forge-gui/res/cardsfolder/d/dueling_coach.txt
@@ -4,6 +4,6 @@ Types:Creature Human Monk
 PT:2/2
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPutCounter | TriggerDescription$ When CARDNAME enters the battlefield, put a +1/+1 counter on target creature you control.
 SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | CounterType$ P1P1 | CounterNum$ 1
-A:AB$ PutCounterAll | Cost$ 4 W T | ValidCards$ Creature.YouCtrl+counters_GE1_P1P1 | CounterType$ P1P1 | CounterNum$ 1
+A:AB$ PutCounterAll | Cost$ 4 W T | ValidCards$ Creature.YouCtrl+counters_GE1_P1P1 | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on each creature you control with a +1/+1 counter on it.
 DeckHas:Ability$Counters
 Oracle:When Dueling Coach enters the battlefield, put a +1/+1 counter on target creature.\n{4}{W}, {T}: Put a +1/+1 counter on each creature you control with a +1/+1 counter on it.

--- a/forge-gui/res/cardsfolder/p/painful_bond.txt
+++ b/forge-gui/res/cardsfolder/p/painful_bond.txt
@@ -1,11 +1,11 @@
 Name:Painful Bond
 ManaCost:1 B
 Types:Instant
-A:SP$ Draw | Cost$ 1 B | NumCards$ 2 | SubAbility$ DBEffect | SpellDescription$ Draw two cards, then cards in your hand with mana value 3 or greater perpetually gain "When you cast this spell, you lose 1 life."
-SVar:DBEffect:DB$ Effect | RememberObjects$ ValidHand Card.cmcLE3+YouOwn | StaticAbilities$ PerpetualAbility | Duration$ Permanent | Triggers$ Update | Name$ Painful Bond's Perpetual Effect | StackDescription$ Then cards in {p:You}'s hand with mana value 3 or less perpetually gain "When you cast this spell, you lose 1 life."
-SVar:PerpetualAbility:Mode$ Continuous | Affected$ Card.IsRemembered | AddTrigger$ CastSpellLoseLife | EffectZone$ Command | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | Description$ Cards in your hand with mana value 3 or less perpetually gain "When you cast this spell, you lose 1 life."
+A:SP$ Draw | Cost$ 1 B | NumCards$ 2 | SubAbility$ DBEffect | SpellDescription$ Draw two cards, then nonland cards in your hand with mana value 3 or less perpetually gain "When you cast this spell, you lose 1 life."
+SVar:DBEffect:DB$ Effect | RememberObjects$ ValidHand Card.nonLand+cmcLE3+YouOwn | StaticAbilities$ PerpetualAbility | Duration$ Permanent | Triggers$ Update | Name$ Painful Bond's Perpetual Effect | StackDescription$ Then nonland cards in {p:You}'s hand with mana value 3 or less perpetually gain "When you cast this spell, you lose 1 life."
+SVar:PerpetualAbility:Mode$ Continuous | Affected$ Card.IsRemembered | AddTrigger$ CastSpellLoseLife | EffectZone$ Command | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | Description$ Nonland cards in your hand with mana value 3 or less perpetually gain "When you cast this spell, you lose 1 life."
 SVar:CastSpellLoseLife:Mode$ SpellCast | ValidCard$ Card.Self | Execute$ TrigDrain | TriggerDescription$ When you cast this spell, you lose 1 life.
 SVar:TrigDrain:DB$ LoseLife | LifeAmount$ 1
 SVar:Update:Mode$ ChangesZone | Origin$ Any | Destination$ Any | Static$ True | ValidCard$ Card.IsRemembered | Execute$ DBUpdate
 SVar:DBUpdate:DB$ UpdateRemember
-Oracle:Draw two cards, then cards in your hand with mana value 3 or less perpetually gain "When you cast this spell, you lose 1 life."
+Oracle:Draw two cards, then nonland cards in your hand with mana value 3 or less perpetually gain "When you cast this spell, you lose 1 life."

--- a/forge-gui/res/cardsfolder/rebalanced/a-ardent_dustspeaker.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-ardent_dustspeaker.txt
@@ -1,0 +1,11 @@
+Name:A-Ardent Dustspeaker
+ManaCost:2 R
+Types:Creature Minotaur Shaman
+PT:3/2
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ ABImpulse | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME attacks, you may put an instant or sorcery card from your graveyard on the bottom of your library. If you do, exile the top two cards of your library. You may play those cards this turn.
+SVar:ABImpulse:AB$ Dig | Cost$ PutCardToLibFromGrave<1/-1/Sorcery;Instant> | Defined$ You | DigNum$ 2 | ChangeNum$ All | DestinationZone$ Exile | SubAbility$ DBEffect | RememberChanged$ True | SubAbility$ DBEffect | SpellDescription$ Exile the top two cards of your library. You may play this cards this turn.
+SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ Play | SubAbility$ DBCleanup | ForgetOnMoved$ Exile
+SVar:Play:Mode$ Continuous | MayPlay$ True | EffectZone$ Command | Affected$ Card.IsRemembered | AffectedZone$ Exile | Description$ You may play remembered card.
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:HasAttackEffect:TRUE
+Oracle:Whenever Ardent Dustspeaker attacks, you may put an instant or sorcery card from your graveyard on the bottom of your library. If you do, exile the top two cards of your library. You may play those cards this turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-bretagard_stronghold.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-bretagard_stronghold.txt
@@ -1,0 +1,9 @@
+Name:A-Bretagard Stronghold
+ManaCost:no cost
+Types:Land
+K:CARDNAME enters the battlefield tapped.
+A:AB$ Mana | Cost$ T | Produced$ G | SpellDescription$ Add {G}.
+A:AB$ PutCounter | Cost$ G W W T Sac<1/CARDNAME> | CounterNum$ 2 | CounterType$ P1P1 | TargetMin$ 1 | TargetMax$ 2 | DividedAsYouChoose$ 2 | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select one or two target creatures you control | SorcerySpeed$ True | SubAbility$ DBPump | SpellDescription$ Distribute two +1/+1 counters among one or two target creatures you control. They gain vigilance and lifelink until end of turn. Activate only as a sorcery.
+SVar:DBPump:DB$ Pump | Defined$ Targeted | KW$ Vigilance & Lifelink | StackDescription$ {c:Targeted} gain vigilance and lifelink until end of turn.
+DeckHas:Ability$Sacrifice|Counters|LifeGain
+Oracle:Bretagard Stronghold enters the battlefield tapped.\n{T}: Add {G}.\n{G}{W}{W}, {T}, Sacrifice Bretagard Stronghold: Distribute two +1/+1 counters among one or two target creatures you control. They gain vigilance and lifelink until end of turn. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/rebalanced/a-cauldron_familiar.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-cauldron_familiar.txt
@@ -1,0 +1,15 @@
+Name:A-Cauldron Familiar
+ManaCost:B
+Types:Creature Cat
+PT:1/1
+K:CARDNAME can't block.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDrain | TriggerDescription$ When CARDNAME enters the battlefield, each opponent loses 1 life and you gain 1 life.
+SVar:TrigDrain:DB$ LoseLife | Defined$ Player.Opponent | LifeAmount$ 1 | SubAbility$ DBGainLife
+SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1
+DeckHas:Ability$LifeGain
+A:AB$ ChangeZone | Cost$ Sac<1/Food> | Origin$ Graveyard | Destination$ Battlefield | ActivationZone$ Graveyard | SpellDescription$ Return CARDNAME from your graveyard to the battlefield.
+SVar:DiscardMe:2
+SVar:SacMe:1
+SVar:AIPreference:SacCost$Card.Food
+DeckHints:Ability$Food
+Oracle:Cauldron Familiar can't block.\nWhen Cauldron Familiar enters the battlefield, each opponent loses 1 life and you gain 1 life.\nSacrifice a Food: Return Cauldron Familiar from your graveyard to the battlefield.

--- a/forge-gui/res/cardsfolder/rebalanced/a-dragons_rage_channeler.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-dragons_rage_channeler.txt
@@ -1,0 +1,10 @@
+Name:A-Dragon's Rage Channeler
+ManaCost:R
+Types:Creature Human Shaman
+PT:1/1
+T:Mode$ SpellCast | ValidCard$ Card.nonCreature | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ DBSurveil | TriggerDescription$ Whenever you cast a noncreature spell, surveil 1.
+SVar:DBSurveil:DB$ Surveil | Defined$ You | Amount$ 1
+S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 2 | AddKeyword$ Flying | Condition$ Delirium | Description$ Delirium — As long as there are four or more card types in your graveyard, CARDNAME gets +2/+0, has flying, and attacks each combat if able.
+S:Mode$ MustAttack | ValidCreature$ Card.Self | Condition$ Delirium | Secondary$ True
+DeckHas:Ability$Delirium|Surveil
+Oracle:Whenever you cast a noncreature spell, surveil 1.\nDelirium — As long as there are four or more card types among cards in your graveyard, Dragon's Rage Channeler gets +2/+0, has flying, and attacks each combat if able.

--- a/forge-gui/res/cardsfolder/rebalanced/a-dueling_coach.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-dueling_coach.txt
@@ -1,0 +1,9 @@
+Name:A-Dueling Coach
+ManaCost:3 W
+Types:Creature Human Monk
+PT:2/2
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPutCounter | TriggerDescription$ When CARDNAME enters the battlefield, distribute two +1/+1 counters among one or two target creatures you control.
+SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select one or two target creatures you control | CounterType$ P1P1 | CounterNum$ 2 | TargetMin$ 1 | TargetMax$ 2 | DividedAsYouChoose$ 2
+A:AB$ PutCounterAll | Cost$ W T | ValidCards$ Creature.YouCtrl+counters_GE1_P1P1 | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on each creature you control with a +1/+1 counter on it.
+DeckHas:Ability$Counters
+Oracle:When Dueling Coach enters the battlefield, distribute two +1/+1 counters among one or two target creatures you control.\n{W}, {T}: Put a +1/+1 counter on each creature you control with a +1/+1 counter on it.

--- a/forge-gui/res/cardsfolder/rebalanced/a-dueling_coach.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-dueling_coach.txt
@@ -4,6 +4,6 @@ Types:Creature Human Monk
 PT:2/2
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPutCounter | TriggerDescription$ When CARDNAME enters the battlefield, distribute two +1/+1 counters among one or two target creatures you control.
 SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select one or two target creatures you control | CounterType$ P1P1 | CounterNum$ 2 | TargetMin$ 1 | TargetMax$ 2 | DividedAsYouChoose$ 2
-A:AB$ PutCounterAll | Cost$ W T | ValidCards$ Creature.YouCtrl+counters_GE1_P1P1 | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on each creature you control with a +1/+1 counter on it.
+A:AB$ PutCounterAll | Cost$ W T | ValidCards$ Creature.YouCtrl+counters_GE1_P1P1 | CounterType$ P1P1 | CounterNum$ 1 | ValidCardsDesc$ creature you control with a +1/+1 counter on it. | SpellDescription$ Put a +1/+1 counter on each creature you control with a +1/+1 counter on it.
 DeckHas:Ability$Counters
 Oracle:When Dueling Coach enters the battlefield, distribute two +1/+1 counters among one or two target creatures you control.\n{W}, {T}: Put a +1/+1 counter on each creature you control with a +1/+1 counter on it.

--- a/forge-gui/res/cardsfolder/rebalanced/a-fall_of_the_impostor.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-fall_of_the_impostor.txt
@@ -1,0 +1,11 @@
+Name:A-Fall of the Impostor
+ManaCost:G W
+Types:Enchantment Saga
+K:Saga:3:DBPutCounter,DBPutCounter,DBExileGreatest
+SVar:DBPutCounter:DB$ PutCounter | ValidTgts$ Creature | TgtPrompt$ Select target creature | CounterType$ P1P1 | CounterNum$ 1 | TargetMin$ 0 | TargetMax$ 1 | SpellDescription$ Put a +1/+1 counter on up to one target creature.
+SVar:DBExileGreatest:DB$ Pump | ValidTgts$ Player.Opponent | RememberTargets$ True | SubAbility$ DBChooseExiled | IsCurse$ True | SpellDescription$ Exile a creature with the greatest power among creatures target opponent controls.
+SVar:DBChooseExiled:DB$ ChooseCard | Choices$ Creature.greatestPowerControlledByRemembered | MinAmount$ 1 | Amount$ 1 | Mandatory$ True | ChoiceZone$ Battlefield | SubAbility$ DBChangeZone
+SVar:DBChangeZone:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | Defined$ ChosenCard | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+DeckHas:Ability$Counters
+Oracle:(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II — Put a +1/+1 counter on up to one target creature.\nIII — Exile a creature with the greatest power among creatures target opponent controls.

--- a/forge-gui/res/cardsfolder/rebalanced/a-gnarlid_colony.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-gnarlid_colony.txt
@@ -1,0 +1,11 @@
+Name:A-Gnarlid Colony
+ManaCost:1 G
+Types:Creature Beast
+PT:2/2
+K:Kicker:2 G
+K:etbCounter:P1P1:4:CheckSVar$ WasKicked:If CARDNAME was kicked, it enters the battlefield with four +1/+1 counters on it.
+SVar:WasKicked:Count$Kicked.1.0
+S:Mode$ Continuous | Affected$ Creature.YouCtrl+counters_GE1_P1P1 | AddKeyword$ Trample | Description$ Each creature you control with a +1/+1 counter on it has trample.
+DeckHints:Ability$Counters
+DeckHas:Ability$Counters
+Oracle:Kicker {2}{G}\nIf Gnarlid Colony was kicked, it enters the battlefield with four +1/+1 counters on it.\nEach creature you control with a +1/+1 counter on it has trample.

--- a/forge-gui/res/cardsfolder/rebalanced/a-hagra_constrictor.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-hagra_constrictor.txt
@@ -1,0 +1,8 @@
+Name:A-Hagra Constrictor
+ManaCost:1 B
+Types:Creature Snake
+PT:0/0
+K:etbCounter:P1P1:2
+S:Mode$ Continuous | Affected$ Creature.YouCtrl+counters_GE1_P1P1 | AddKeyword$ Menace | Description$ Each creature you control with a +1/+1 counter on it has menace.
+DeckHas:Ability$Counters
+Oracle:Hagra Constrictor enters the battlefield with two +1/+1 counters on it.\nEach creature you control with a +1/+1 counter on it has menace.

--- a/forge-gui/res/cardsfolder/rebalanced/a-iridescent_hornbeetle.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-iridescent_hornbeetle.txt
@@ -1,0 +1,10 @@
+Name:A-Iridescent Hornbeetle
+ManaCost:3 G
+Types:Creature Insect
+PT:3/3
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ At the beginning of your end step, create a 1/1 green Insect creature token for each +1/+1 counter you've put on creatures under your control this turn.
+SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenOwner$ You | TokenScript$ g_1_1_insect
+SVar:X:Count$CountersAddedThisTurn P1P1 You Creature.YouCtrl
+DeckNeeds:Ability$Counters
+DeckHas:Ability$Counters
+Oracle:At the beginning of your end step, create a 1/1 green Insect creature token for each +1/+1 counter you've put on creatures under your control this turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-maelstrom_muse.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-maelstrom_muse.txt
@@ -1,0 +1,14 @@
+Name:A-Maelstrom Muse
+ManaCost:U U/R R
+Types:Creature Djinn Wizard
+PT:2/4
+K:Flying
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ CheckPower | TriggerDescription$ Whenever CARDNAME attacks, the next instant or sorcery spell you cast this turn costs {X} less to cast, where X is CARDNAME's power as this ability resolves.
+SVar:CheckPower:DB$ StoreSVar | SVar$ CurrPower | Type$ CountSVar | Expression$ X | SubAbility$ DBEffect | SpellDescription$ The next instant or sorcery spell you cast this turn costs {X} less to cast, where X is CARDNAME's power as this ability resolves.
+SVar:DBEffect:DB$ Effect | StaticAbilities$ ReduceCost | Triggers$ TrigCastSpell
+SVar:ReduceCost:Mode$ ReduceCost | EffectZone$ Command | Type$ Spell | ValidCard$ Instant,Sorcery | Activator$ You | Amount$ CurrPower | Description$ The next instant or sorcery spell you cast this turn costs {X} less to cast, where X is CARDNAME's power at the time EFFECTSOURCE's ability resolved.
+SVar:TrigCastSpell:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Command | Execute$ RemoveEffect | Static$ True
+SVar:RemoveEffect:DB$ ChangeZone | Origin$ Command | Destination$ Exile
+SVar:CurrPower:Number$0
+SVar:X:TriggeredCard$CardPower
+Oracle:Flying\nWhenever Maelstrom Muse attacks, the next instant or sorcery spell you cast this turn costs {X} less to cast, where X is Maelstrom Muse's power as this ability resolves.

--- a/forge-gui/res/cardsfolder/rebalanced/a-master_of_winds.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-master_of_winds.txt
@@ -1,0 +1,15 @@
+Name:A-Master of Winds
+ManaCost:2 U U
+Types:Creature Sphinx Wizard
+PT:1/5
+K:Flying
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ When CARDNAME enters the battlefield, draw two cards, then discard a card.
+SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 2 | SubAbility$ DBDiscard
+SVar:DBDiscard:DB$ Discard | Defined$ You | NumCards$ 1 | Mode$ TgtChoose
+T:Mode$ SpellCast | ValidCard$ Instant,Sorcery,Wizard | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigChoose | TriggerDescription$ Whenever you cast an instant, sorcery, or Wizard spell, you may have CARDNAME's base power and toughness become 5/1 or 1/5 until end of turn.
+SVar:TrigChoose:DB$ GenericChoice | Defined$ You | Choices$ Animate51,Animate15
+SVar:Animate51:DB$ Animate | Defined$ Self | Power$ 5 | Toughness$ 1 | SpellDescription$ CARDNAME's base power and toughness become 5/1 until end of turn.
+SVar:Animate15:DB$ Animate | Defined$ Self | Power$ 1 | Toughness$ 5 | SpellDescription$ CARDNAME's base power and toughness become 1/5 until end of turn.
+SVar:BuffedBy:Instant,Sorcery,Wizard
+DeckNeeds:Type$Instant|Sorcery|Wizard
+Oracle:Flying\nWhen Master of Winds enters the battlefield, draw two cards, then discard a card.\nWhenever you cast an instant, sorcery, or Wizard spell, you may have Master of Winds's base power and toughness become 5/1 or 1/5 until end of turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-mentors_guidance.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-mentors_guidance.txt
@@ -1,0 +1,9 @@
+Name:A-Mentor's Guidance
+ManaCost:1 U
+Types:Sorcery
+T:Mode$ SpellCast | ValidCard$ Card.Self | Execute$ TrigCopy | TriggerDescription$ When you cast this spell, copy it if you control a planeswalker, Cleric, Druid, Shaman, Warlock, or Wizard.
+SVar:TrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | ConditionPresent$ Planeswalker.YouCtrl,Cleric.YouCtrl,Druid.YouCtrl,Shaman.YouCtrl,Warlock.YouCtrl,Wizard.YouCtrl | ConditionCompare$ GE1
+A:SP$ Scry | ScryNum$ 1 | SubAbility$ DBDraw | SpellDescription$ Scry 1,
+SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1 | SpellDescription$ then draw a card.
+DeckHints:Type$Planeswalker|Cleric|Druid|Shaman|Warlock|Wizard
+Oracle:When you cast this spell, copy it if you control a planeswalker, Cleric, Druid, Shaman, Warlock, or Wizard.\nScry 1, then draw a card.

--- a/forge-gui/res/cardsfolder/rebalanced/a-moss_pit_skeleton.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-moss_pit_skeleton.txt
@@ -1,0 +1,12 @@
+Name:A-Moss-Pit Skeleton
+ManaCost:B G
+Types:Creature Plant Skeleton
+PT:2/2
+K:Kicker:3
+K:etbCounter:P1P1:3:CheckSVar$ WasKicked:If CARDNAME was kicked, it enters the battlefield with three +1/+1 counters on it.
+SVar:WasKicked:Count$Kicked.1.0
+T:Mode$ CounterAddedOnce | ValidCard$ Creature.YouCtrl | CounterType$ P1P1 | TriggerZones$ Graveyard | IsPresent$ Card.StrictlySelf | PresentZone$ Graveyard | Execute$ TrigDelayedTrigger | TriggerDescription$ Whenever one or more +1/+1 counters are put on a creature you control, return CARDNAME from your graveyard to your hand at the beginning of the next end step.
+SVar:TrigDelayedTrigger:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ TrigChange | TriggerDescription$ Return CARDNAME from your graveyard to your hand at the beginning of the next end step.
+SVar:TrigChange:DB$ ChangeZone | Defined$ Self | Origin$ Graveyard | Destination$ Hand
+DeckHints:Ability$Counters|Graveyard
+Oracle:Kicker {3}\nIf Moss-Pit Skeleton was kicked, it enters the battlefield with three +1/+1 counters on it.\nWhenever one or more +1/+1 counters are put on a creature you control, return Moss-Pit Skeleton from your graveyard to your hand at the beginning of the next end step.

--- a/forge-gui/res/cardsfolder/rebalanced/a-ochre_jelly.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-ochre_jelly.txt
@@ -1,0 +1,14 @@
+Name:A-Ochre Jelly
+ManaCost:X G
+Types:Creature Ooze
+PT:0/0
+K:Trample
+K:Ward:2
+K:etbCounter:P1P1:X
+SVar:X:Count$xPaid
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self+counters_GE2_P1P1 | TriggerZones$ Battlefield | Execute$ TrigDelayTrigger | TriggerDescription$ Split — When CARDNAME dies, if it had two or more +1/+1 counters on it, create a token that's a copy of it at the beginning of the next end step. The token enters the battlefield with half that many +1/+1 counters on it, rounded down.
+SVar:TrigDelayTrigger:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | ValidPlayer$ Player | RememberObjects$ TriggeredCardLKICopy | CopyTriggeringObjects$ True | Execute$ TrigCopy | TriggerDescription$ Create a token that's a copy of it at the beginning of the next end step. That token enters the battlefield with half that many +1/+1 counters on it, rounded down.
+SVar:TrigCopy:DB$ CopyPermanent | Defined$ DelayTriggerRememberedLKI | WithCountersType$ P1P1 | WithCountersAmount$ Y
+SVar:Y:TriggeredCard$CardCounters.P1P1/HalfDown
+DeckHas:Ability$Counters|Token
+Oracle:Trample\nWard {2}\nOchre Jelly enters the battlefield with X +1/+1 counters on it.\nSplit — When Ochre Jelly dies, if it had two or more +1/+1 counters on it, create a token that's a copy of it at the beginning of the next end step. The token enters the battlefield with half that many +1/+1 counters on it, rounded down.

--- a/forge-gui/res/cardsfolder/rebalanced/a-oran_rief_ooze.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-oran_rief_ooze.txt
@@ -1,0 +1,11 @@
+Name:A-Oran-Rief Ooze
+ManaCost:2 G
+Types:Creature Ooze
+PT:2/2
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPutCounter | TriggerDescription$ When CARDNAME enters the battlefield, put a +1/+1 counter on target creature you control.
+SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | CounterType$ P1P1 | CounterNum$ 1
+T:Mode$ Attacks | ValidCard$ Creature.Self | Execute$ TrigPutCounterAll | TriggerDescription$ Whenever CARDNAME attacks, put a +1/+1 counter on each creature you control with a +1/+1 counter on it.
+SVar:TrigPutCounterAll:DB$ PutCounterAll | ValidCards$ Creature.YouCtrl+counters_GE1_P1P1 | CounterType$ P1P1 | CounterNum$ 1
+SVar:HasAttackEffect:TRUE
+DeckHas:Ability$Counters
+Oracle:When Oran-Rief Ooze enters the battlefield, put a +1/+1 counter on target creature you control.\nWhenever Oran-Rief Ooze attacks, put a +1/+1 counter on each creature you control with a +1/+1 counter on it.

--- a/forge-gui/res/cardsfolder/rebalanced/a-rockslide_sorcerer.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-rockslide_sorcerer.txt
@@ -1,0 +1,9 @@
+Name:A-Rockslide Sorcerer
+ManaCost:2 R
+Types:Creature Human Wizard
+PT:2/2
+T:Mode$ SpellCast | ValidCard$ Instant,Sorcery,Wizard | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDealDamage | TriggerDescription$ Whenever you cast an instant, sorcery, or Wizard spell, CARDNAME deals 1 damage to any target.
+SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Creature,Player,Planeswalker | TgtPrompt$ Select any target | NumDmg$ 1
+SVar:BuffedBy:Instant,Sorcery,Wizard
+DeckNeeds:Type$Instant|Sorcery|Wizard
+Oracle:Whenever you cast an instant, sorcery, or Wizard spell, Rockslide Sorcerer deals 1 damage to any target.

--- a/forge-gui/res/cardsfolder/rebalanced/a-rowan_scholar_of_sparks_will_scholar_of_frost.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-rowan_scholar_of_sparks_will_scholar_of_frost.txt
@@ -1,0 +1,30 @@
+Name:A-Rowan, Scholar of Sparks
+ManaCost:2 R
+Types:Legendary Planeswalker Rowan
+Loyalty:3
+S:Mode$ ReduceCost | ValidCard$ Instant,Sorcery | Type$ Spell | Activator$ You | Amount$ 1 | Description$ Instant and sorcery spells you cast cost {1} less to cast.
+A:AB$ DealDamage | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | Defined$ Player.Opponent | NumDmg$ X | SpellDescription$ CARDNAME deals 1 damage to each opponent. If you've drawn three or more cards this turn, she deals 3 damage to each opponent instead.
+SVar:X:Count$Compare Y GE3.3.1
+SVar:Y:Count$YouDrewThisTurn
+A:AB$ Effect | Cost$ SubCounter<5/LOYALTY> | Planeswalker$ True | Ultimate$ True | Name$ Emblem - Rowan, Scholar of Sparks | Triggers$ TRCast | Duration$ Permanent | SpellDescription$ You get an emblem with "Whenever you cast an instant or sorcery spell, you may pay {2}. If you do, copy that spell. You may choose new targets for the copy."
+SVar:TRCast:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Command | Execute$ TrigCopy | TriggerDescription$ Whenever you cast an instant or sorcery spell, you may pay {2}. If you do, copy that spell. You may choose new targets for the copy.
+SVar:TrigCopy:AB$ CopySpellAbility | Cost$ 2 | Defined$ TriggeredSpellAbility | AILogic$ AlwaysIfViable | MayChooseTarget$ True
+AlternateMode:Modal
+DeckHints:Type$Instant|Sorcery
+Oracle:Instant and sorcery spells you cast cost {1} less to cast.\n[+1]: Rowan, Scholar of Sparks deals 1 damage to each opponent. If you've drawn three or more cards this turn, she deals 3 damage to each opponent instead.\n[-5]: You get an emblem with "Whenever you cast an instant or sorcery spell, you may pay {2}. If you do, copy that spell. You may choose new targets for the copy."
+
+ALTERNATE
+
+Name:A-Will, Scholar of Frost
+ManaCost:4 U
+Types:Legendary Planeswalker Will
+Loyalty:5
+S:Mode$ ReduceCost | ValidCard$ Instant,Sorcery | Type$ Spell | Activator$ You | Amount$ 1 | Description$ Instant and sorcery spells you cast cost {1} less to cast.
+A:AB$ Animate | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | ValidTgts$ Creature | TgtPrompt$ Select up to one target creature | TargetMin$ 0 | TargetMax$ 1 | Power$ 0 | Toughness$ 2 | Duration$ UntilYourNextTurn | SpellDescription$ Up to one target creature has base power and toughness 0/2 until your next turn.
+A:AB$ Draw | Cost$ SubCounter<3/LOYALTY> | Planeswalker$ True | NumCards$ 2 | SpellDescription$ Draw two cards.
+A:AB$ ChangeZone | Cost$ SubCounter<8/LOYALTY> | Planeswalker$ True | Ultimate$ True | ValidTgts$ Permanent | TgtPrompt$ Select up to five target permanents | TargetMin$ 0 | TargetMax$ 5 | Origin$ Battlefield | Destination$ Exile | RememberLKI$ True | SubAbility$ DBRepeat | SpellDescription$ Exile up to five target permanents. For each permanent exiled this way, its controller creates a 4/4 blue and red Elemental creature token.
+SVar:DBRepeat:DB$ RepeatEach | DefinedCards$ DirectRemembered | UseImprinted$ True | RepeatSubAbility$ DBToken | SubAbility$ DBCleanup | ChangeZoneTables$ True
+SVar:DBToken:DB$ Token | TokenScript$ ur_4_4_elemental | TokenOwner$ ImprintedController
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+DeckHas:Ability$Token
+Oracle:Instant and sorcery spells you cast cost {1} less to cast.\n[+1]: Up to one target creature has base power and toughness 0/2 until your next turn.\n[-3]: Draw two cards.\n[-8]: Exile up to five target permanents. For each permanent exiled this way, its controller creates a 4/4 blue and red Elemental creature token.

--- a/forge-gui/res/cardsfolder/rebalanced/a-sigardian_paladin.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-sigardian_paladin.txt
@@ -1,0 +1,10 @@
+Name:A-Sigardian Paladin
+ManaCost:1 G W
+Types:Creature Human Knight
+PT:4/3
+S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Trample & Lifelink | CheckSVar$ X | Description$ As long as you've put one or more +1/+1 counters on a creature this turn, CARDNAME has trample and lifelink.
+SVar:X:Count$CountersAddedThisTurn P1P1 You Creature
+A:AB$ Pump | Cost$ G W | ValidTgts$ Creature.YouCtrl+counters_GE1_P1P1 | TgtPrompt$ Select target creature with a +1/+1 counter on it | KW$ Trample & Lifelink | SpellDescription$ Target creature you control with a +1/+1 counter on it gains trample and lifelink until end of turn.
+DeckNeeds:Ability$Counters
+DeckHas:Ability$LifeGain
+Oracle:As long as you've put one or more +1/+1 counters on a creature this turn, Sigardian Paladin has trample and lifelink.\n{G}{W}: Target creature you control with a +1/+1 counter on it gains trample and lifelink until end of turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-skyclave_shadowcat.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-skyclave_shadowcat.txt
@@ -1,0 +1,10 @@
+Name:A-Skyclave Shadowcat
+ManaCost:2 B
+Types:Creature Cat Horror
+PT:3/3
+A:AB$ PutCounter | Cost$ B Sac<1/Creature.Other/another creature> | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on CARDNAME.
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.YouCtrl+counters_GE1_P1P1 | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ Whenever a creature you control with a +1/+1 counter on it dies, draw a card.
+SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1
+SVar:PlayMain1:TRUE
+DeckHas:Ability$Sacrifice|Counters
+Oracle:{B}, Sacrifice another creature: Put a +1/+1 counter on Skyclave Shadowcat.\nWhenever a creature you control with a +1/+1 counter on it dies, draw a card.

--- a/forge-gui/res/cardsfolder/rebalanced/a-sorcerer_class.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-sorcerer_class.txt
@@ -1,0 +1,14 @@
+Name:A-Sorcerer Class
+ManaCost:U R
+Types:Enchantment Class
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ When CARDNAME enters the battlefield, draw two cards, then discard two cards.
+SVar:TrigDraw:DB$ Draw | NumCards$ 2 | SubAbility$ DBDiscard
+SVar:DBDiscard:DB$ Discard | Defined$ You | NumCards$ 2 | Mode$ TgtChoose
+K:Class:2:U R:AddStaticAbility$ STapMana
+SVar:STapMana:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Creature.YouCtrl | AddAbility$ AddMana | Secondary$ True | Description$ Creatures you control have "{T}: Add {U} or {R}. Spend this mana only to cast an instant or sorcery spell or to gain a Class level."
+SVar:AddMana:AB$ Mana | Cost$ T | Produced$ Combo U R | Amount$ 1 | RestrictValid$ Spell.Instant,Spell.Sorcery,Activated.ClassLevelUp | SpellDescription$ Add {U} or {R}. Spend this mana only to cast an instant or sorcery spell or to gain a Class level.
+K:Class:3:1 U R:AddTrigger$ TriggerSpellCast
+SVar:TriggerSpellCast:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDealDamage | Secondary$ True | TriggerDescription$ Whenever you cast an instant or sorcery spell, that spell deals damage to each opponent equal to the number of instant and sorcery spells you've cast this turn.
+SVar:TrigDealDamage:DB$ DamageAll | ValidPlayers$ Player.Opponent | NumDmg$ X | DamageSource$ TriggeredCard
+SVar:X:Count$ThisTurnCast_Instant.YouCtrl,Sorcery.YouCtrl
+Oracle:(Gain the next level as a sorcery to add its ability.)\nWhen Sorcerer Class enters the battlefield, draw two cards, then discard two cards.\n{U}{R}: Level 2\nCreatures you control have "{T}: Add {U} or {R}. Spend this mana only to cast an instant or sorcery spell or to gain a Class level."\n{1}{U}{R}: Level 3\nWhenever you cast an instant or sorcery spell, that spell deals damage to each opponent equal to the number of instant and sorcery spells you've cast this turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-tanazir_quandrix.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-tanazir_quandrix.txt
@@ -1,0 +1,15 @@
+Name:A-Tanazir Quandrix
+ManaCost:3 G U
+Types:Legendary Creature Elder Dragon
+PT:5/5
+K:Flying
+K:Trample
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDouble | TriggerDescription$ When CARDNAME enters the battlefield, double the number of +1/+1 counters on target creature you control.
+SVar:TrigDouble:DB$ MultiplyCounter | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | CounterType$ P1P1
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigAnimateAll | OptionalDecider$ You | TriggerDescription$ Whenever CARDNAME attacks, you may have the base power and toughness of other creatures you control become equal to CARDNAME's power and toughness until end of turn.
+SVar:TrigAnimateAll:DB$ AnimateAll | Power$ X | Toughness$ Y | ValidCards$ Creature.YouCtrl+Other
+SVar:X:Count$CardPower
+SVar:Y:Count$CardToughness
+SVar:HasAttackEffect:TRUE
+DeckHas:Ability$Counters
+Oracle:Flying, trample\nWhen Tanazir Quandrix enters the battlefield, double the number of +1/+1 counters on target creature you control.\nWhenever Tanazir Quandrix attacks, you may have the base power and toughness of other creatures you control become equal to Tanazir Quandrix's power and toughness until end of turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-tenured_inkcaster.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-tenured_inkcaster.txt
@@ -1,0 +1,11 @@
+Name:A-Tenured Inkcaster
+ManaCost:3 B
+Types:Creature Vampire Warlock
+PT:3/3
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPutCounter | TriggerDescription$ When CARDNAME enters the battlefield, put a +1/+1 counter on target creature.
+SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Creature | TgtPrompt$ Select target creature you control | CounterType$ P1P1 | CounterNum$ 1
+T:Mode$ Attacks | ValidCard$ Creature.YouCtrl+counters_GE1_P1P1 | TriggerZones$ Battlefield | Execute$ TrigDrain | TriggerDescription$ Whenever a creature you control with a +1/+1 counter on it attacks, each opponent loses 1 life and you gain 1 life.
+SVar:TrigDrain:DB$ LoseLife | Defined$ Player.Opponent | LifeAmount$ 1 | SubAbility$ DBGainLife
+SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1
+DeckHas:Ability$Counters|LifeGain
+Oracle:When Tenured Inkcaster enters the battlefield, put a +1/+1 counter on target creature.\nWhenever a creature you control with a +1/+1 counter on it attacks, each opponent loses 1 life and you gain 1 life.

--- a/forge-gui/res/cardsfolder/rebalanced/a-the_meathook_massacre.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-the_meathook_massacre.txt
@@ -1,0 +1,10 @@
+Name:A-The Meathook Massacre
+ManaCost:X B B
+Types:Legendary Enchantment
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPumpAll | TriggerDescription$ When CARDNAME enters the battlefield, each creature gets -X/-X until end of turn.
+SVar:TrigPumpAll:DB$ PumpAll | ValidCards$ Creature | NumAtt$ -X | NumDef$ -X | IsCurse$ True
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigLoseLife | TriggerDescription$ Whenever a creature you control dies, each opponent loses 1 life.
+SVar:TrigLoseLife:DB$ LoseLife | Defined$ Opponent | LifeAmount$ 1
+SVar:X:Count$xPaid
+DeckHints:Ability$Graveyard|Sacrifice
+Oracle:When The Meathook Massacre enters the battlefield, each creature gets -X/-X until end of turn.\nWhenever a creature you control dies, each opponent loses 1 life.

--- a/forge-gui/res/cardsfolder/rebalanced/a-tome_shredder.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-tome_shredder.txt
@@ -1,0 +1,8 @@
+Name:A-Tome Shredder
+ManaCost:1 R
+Types:Creature Wolf
+PT:2/1
+K:Haste
+A:AB$ PutCounter | Cost$ T ExileFromGrave<1/Instant;Sorcery> | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Exile an instant or sorcery card from your graveyard: Put a +1/+1 counter on CARDNAME.
+DeckHas:Ability$Counters
+Oracle:Haste\n{T}, Exile an instant or sorcery card from your graveyard: Put a +1/+1 counter on Tome Shredder.

--- a/forge-gui/res/cardsfolder/rebalanced/a-umara_mystic.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-umara_mystic.txt
@@ -1,0 +1,11 @@
+Name:A-Umara Mystic
+ManaCost:1 U R
+Types:Creature Merfolk Wizard
+PT:1/3
+K:Flying
+K:Haste
+T:Mode$ SpellCast | ValidCard$ Instant,Sorcery,Wizard | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever you cast a instant, sorcery, or Wizard spell, CARDNAME gets +2/+0 until end of turn.
+SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ 2
+SVar:BuffedBy:Instant,Sorcery,Wizard
+DeckHints:Type$Instant|Sorcery|Wizard
+Oracle:Flying, haste\nWhenever you cast an instant, sorcery, or Wizard spell, Umara Mystic gets +2/+0 until end of turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-unholy_heat.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-unholy_heat.txt
@@ -1,0 +1,7 @@
+Name:A-Unholy Heat
+ManaCost:R
+Types:Instant
+A:SP$ DealDamage | Cost$ R | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ X | SpellDescription$ CARDNAME deals 2 damage to target creature or planeswalker. Delirium — CARDNAME deals 4 damage instead if there are four or more card types among cards in your graveyard.
+SVar:X:Count$Compare Y GE4.4.2
+SVar:Y:Count$CardControllerTypes.Graveyard
+Oracle:Unholy Heat deals 2 damage to target creature or planeswalker.\nDelirium — Unholy Heat deals 4 damage instead if there are four or more card types among cards in your graveyard.

--- a/forge-gui/res/cardsfolder/rebalanced/a-winota_joiner_of_forces.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-winota_joiner_of_forces.txt
@@ -1,0 +1,10 @@
+Name:A-Winota, Joiner of Forces
+ManaCost:2 R W
+Types:Legendary Creature Human Warrior
+PT:4/4
+T:Mode$ AttackersDeclared | ValidAttackers$ Creature.nonHuman+YouCtrl | Execute$ TrigDig | TriggerZones$ Battlefield | TriggerDescription$ Whenever one or more non-Human creatures you control attack, look at the top six cards of your library. You may put a Human creature card from among them onto the battlefield tapped and attacking. It gains indestructible until end of turn. Put the rest of the cards on the bottom of your library in a random order.
+SVar:TrigDig:DB$ Dig | DigNum$ 6 | ChangeNum$ 1 | Optional$ True | Reveal$ False | ChangeValid$ Creature.Human | DestinationZone$ Battlefield | DestinationZone2$ Library | LibraryPosition$ -1 | RestRandomOrder$ True | Tapped$ True | Attacking$ True | RememberChanged$ True | SubAbility$ DBPump
+SVar:DBPump:DB$ Pump | Defined$ Remembered | KW$ Indestructible | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+DeckHints:Type$Human
+Oracle:Whenever one or more non-Human creatures you control attack, look at the top six cards of your library. You may put a Human creature card from among them onto the battlefield tapped and attacking. It gains indestructible until end of turn. Put the rest of the cards on the bottom of your library in a random order.

--- a/forge-gui/res/cardsfolder/s/sigardian_paladin.txt
+++ b/forge-gui/res/cardsfolder/s/sigardian_paladin.txt
@@ -2,7 +2,7 @@ Name:Sigardian Paladin
 ManaCost:2 G W
 Types:Creature Human Knight
 PT:4/4
-S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Trample & Lifelink | CheckSVar$ X | Description$ As long as you've put one or more +1/+1 counters on a creature this turn, Sigardian Paladin has trample and lifelink.
+S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Trample & Lifelink | CheckSVar$ X | Description$ As long as you've put one or more +1/+1 counters on a creature this turn, CARDNAME has trample and lifelink.
 SVar:X:Count$CountersAddedThisTurn P1P1 You Creature
 A:AB$ Pump | Cost$ 1 G W | ValidTgts$ Creature.YouCtrl+counters_GE1_P1P1 | TgtPrompt$ Select target creature with a +1/+1 counter on it | KW$ Trample & Lifelink | SpellDescription$ Target creature you control with a +1/+1 counter on it gains trample and lifelink until end of turn.
 DeckNeeds:Ability$Counters

--- a/forge-gui/res/editions/Dungeons & Dragons Adventures in the Forgotten Realms.txt
+++ b/forge-gui/res/editions/Dungeons & Dragons Adventures in the Forgotten Realms.txt
@@ -440,8 +440,10 @@ A130 C A-Armory Veteran @Caio Monteiro
 A180 U A-Druid Class @Svetlin Velinov
 A181 M A-Ellywick Tumblestrum @Anna Steinbauer
 A183 C A-Find the Path @Lindsey Look
+A196 R A-Ochre Jelly @Daarken
 A219 U A-Bruenor Battlehammer @Wayne Reynolds
 A231 U A-Shessra, Death's Whisper @Marie Magny
+A233 R A-Sorcerer Class @Alexander Mokhov
 A237 R A-Triumphant Adventurer @Alexander Mokhov
 A255 R A-Dungeon Descent @Kasia 'Kafis' Zielińska
 

--- a/forge-gui/res/editions/Ikoria Lair of Behemoths.txt
+++ b/forge-gui/res/editions/Ikoria Lair of Behemoths.txt
@@ -411,6 +411,9 @@ ScryfallCode=IKO
 386 R Dirge Bat @羽山晃平
 387 R Crystalline Giant @Kotakan
 
+[rebalanced]
+A216 M A-Winota, Joiner of Forces @Magali Villeneuve
+
 [Lands]
 10 Bloodfell Caves|IKO
 10 Blossoming Sands|IKO

--- a/forge-gui/res/editions/Innistrad Crimson Vow.txt
+++ b/forge-gui/res/editions/Innistrad Crimson Vow.txt
@@ -437,6 +437,7 @@ Prerelease=6 Boosters, 1 RareMythic+
 A52 U A-Cobbled Lancer @Igor Kieryluk
 A63 R A-Hullbreaker Horror @Svetlin Velinov
 A81 C A-Stitched Assistant @Andrey Kuzinskiy
+A247 U A-Sigardian Paladin @Slawomir Maniak
 A248 U A-Skull Skaab @Nicholas Gregory
 
 [tokens]

--- a/forge-gui/res/editions/Innistrad Midnight Hunt.txt
+++ b/forge-gui/res/editions/Innistrad Midnight Hunt.txt
@@ -417,6 +417,7 @@ Prerelease=6 Boosters, 1 RareMythic+
 A52 C A-Falcon Abomination @Brent Hollowell
 A59 M A-Lier, Disciple of the Drowned @Ekaterina Burmak
 A106 C A-Hobbling Zombie @Josh Hass
+A112 M A-The Meathook Massacre @Chris Seaman
 
 [tokens]
 b_1_1_bat_flying

--- a/forge-gui/res/editions/Jumpstart Historic Horizons.txt
+++ b/forge-gui/res/editions/Jumpstart Historic Horizons.txt
@@ -794,5 +794,9 @@ ScryfallCode=J21
 786 L Mountain
 787 L Forest
 
+[rebalanced]
+A438 U A-Dragon's Rage Channeler @Martina Fackova
+A529 C A-Unholy Heat @Kari Christensen
+
 [tokens]
 u_8_8_kraken

--- a/forge-gui/res/editions/Jumpstart Historic Horizons.txt
+++ b/forge-gui/res/editions/Jumpstart Historic Horizons.txt
@@ -794,9 +794,5 @@ ScryfallCode=J21
 786 L Mountain
 787 L Forest
 
-[rebalanced]
-A438 U A-Dragon's Rage Channeler @Martina Fackova
-A529 C A-Unholy Heat @Kari Christensen
-
 [tokens]
 u_8_8_kraken

--- a/forge-gui/res/editions/Kaldheim.txt
+++ b/forge-gui/res/editions/Kaldheim.txt
@@ -442,11 +442,13 @@ A165 C A-Elderleaf Mentor @Zoltan Boros
 A166 U A-Elven Bow @Dallas Williams
 A169 R A-Esika's Chariot @Raoul Vitale
 A198 M A-Tyvar Kell @Chris Rallis
+A208 U A-Fall of the Impostor @Eric Deschamps
 A224 U A-Narfi, Betrayer King @Daarken
 A212 U A-Harald, King of Skemfar @Grzegorz Rutkowski
 A213 R A-Harald Unites the Elves @Ryan Pancoast
 A233 U A-Vega, the Watcher @Paul Scott Canavan
 A237 R A-Cosmos Elixir @Volkan Baǵa
+A253 U A-Bretagard Stronghold @Jung Park
 A255 R A-Faceless Haven @Titus Lunter
 A268 U A-Skemfar Elderhall @Johannes Voss
 A378 R A-Canopy Tactician @Ekaterina Burmak

--- a/forge-gui/res/editions/Modern Horizons 2.txt
+++ b/forge-gui/res/editions/Modern Horizons 2.txt
@@ -522,6 +522,10 @@ ScryfallCode=MH2
 [bundle]
 492 R Yusri, Fortune's Flame @Evyn Fong
 
+[rebalanced]
+A121 U A-Dragon's Rage Channeler @Martina Fackova
+A145 C A-Unholy Heat @Kari Christensen
+
 [Lands]
 19 Arid Mesa|MH2|1
 1 Arid Mesa|MH2|2

--- a/forge-gui/res/editions/Strixhaven School of Mages.txt
+++ b/forge-gui/res/editions/Strixhaven School of Mages.txt
@@ -409,8 +409,16 @@ ScryfallCode=STX
 382 U Decisive Denial @Lorenzo Mastroianni
 
 [rebalanced]
+A15 U A-Dueling Coach @Caio Monteiro
 A41 U A-Divide by Zero @Liiga Smilshkalne
+A46 U A-Mentor's Guidance @Brian Valeza
 A56 U A-Symmetry Sage @Jehan Choo
+A88 U A-Tenured Inkcaster @Jake Murray
+A92 U A-Ardent Dustspeaker @Mads Ahm
+A117 C A-Tome Shredder @Sam Rowan
+A156 M A-Rowan, Scholar of Sparks @Magali Villeneuve
+A202 U A-Maelstrom Muse @Michele Parisi
+A240 M A-Tanazir Quandrix @Raymond Swanland
 A258 U A-Spell Satchel @YW Tang
 
 [lesson]

--- a/forge-gui/res/editions/Throne of Eldraine.txt
+++ b/forge-gui/res/editions/Throne of Eldraine.txt
@@ -425,6 +425,7 @@ ScryfallCode=ELD
 397 U Inspiring Veteran @Scott Murphy
 
 [rebalanced]
+A81 U A-Cauldron Familiar @Milivoj Ćeran
 A125 R A-Fires of Invention @Stanton Feng
 
 [tokens]

--- a/forge-gui/res/editions/Zendikar Rising.txt
+++ b/forge-gui/res/editions/Zendikar Rising.txt
@@ -419,12 +419,21 @@ ScryfallCode=ZNR
 
 [rebalanced]
 A24 R A-Luminarch Aspirant @Mads Ahm
+A68 R A-Master of Winds @Yigit Koroglu
+A105 C A-Hagra Constrictor @Simon Dominic
+A126 U A-Skyclave Shadowcat @Simon Dominic
 A141 U A-Goma Fada Vanguard @Sean Sevestre
 A145 R A-Kargan Intimidator @Kieran Yanner
+A154 U A-Rockslide Sorcerer @Daarken
+A185 C A-Gnarlid Colony @Izzy
+A187 U A-Iridescent Hornbeetle @Simon Dominic
+A198 R A-Oran-Rief Ooze @Daarken
 A224 U A-Kargan Warleader @Colin Boyer
+A228 U A-Moss-Pit Skeleton @Bryan Sola
 A230 M A-Nahiri, Heir of the Ancients @Anna Steinbauer
 A232 M A-Omnath, Locus of Creation @Chris Rahn
 A234 R A-Phylath, World Sculptor @Victor Adame Minguez
+A238 U A-Umara Mystic @Bryan Sola
 A257 U A-Base Camp @Jokubas Uogintas
 
 [ModalDoubleFaceCards]

--- a/forge-gui/res/formats/Archived/Alchemy/2022-07-07.txt
+++ b/forge-gui/res/formats/Archived/Alchemy/2022-07-07.txt
@@ -1,0 +1,7 @@
+[format]
+Name:Alchemy (2022-07-07)
+Type:Archived
+Subtype:Arena
+Effective:2022-07-07
+Sets:ANA, ANB, ZNR, KHM, STX, AFR, MID, VOW, YMID, NEO, YNEO, SNC, YSNC
+Banned:Grinning Ignus

--- a/forge-gui/res/formats/Archived/Historic/2022-07-07.txt
+++ b/forge-gui/res/formats/Archived/Historic/2022-07-07.txt
@@ -1,8 +1,7 @@
 [format]
-Name:Historic
-Type:Digital
+Name:Historic (2022-07-07)
+Type:Archived
 Subtype:Arena
-Effective:2019-11-21
-Order:142
+Effective:2022-07-07
 Sets:XLN, RIX, DOM, M19, ANA, PANA, GRN, G18, RNA, WAR, M20, ELD, HA1, THB, HA2, IKO, HA3, M21, JMP, AJMP, AKR, ANB, ZNR, KLR, KHM, HA4, STX, STA, HA5, AFR, J21, MID, VOW, YMID, NEO, YNEO, SNC, YSNC
 Banned:Agent of Treachery; Brainstorm; Channel; Counterspell; Dark Ritual; Demonic Tutor; Field of the Dead; Lightning Bolt; Memory Lapse; Natural Order; Nexus of Fate; Oko, Thief of Crowns; Once Upon a Time; Swords to Plowshares; Thassa's Oracle; Tibalt's Trickery; Time Warp; Uro, Titan of Nature's Wrath; Veil of Summer; Wilderness Reclamation


### PR DESCRIPTION
Source: https://magic.wizards.com/en/articles/archive/magic-digital/alchemy-rebalancing-july-7-2022-2022-07-01

Obscura Polymorphist (YSNC - not yet in Forge; will put in another PR)

- [x] Add rebalanced cards to editions
- [x] Alchemy banned: Grinning Ignus
- [x] Historic unbanned: Winota, Joiner of Forces
- [x] A-Cauldron Familiar
- [x] A-Meathook Massacre
- [x] A-Dragon's Rage Channeler
- [x] A-Unholy Heat
- [x] A-Winota, Joiner of Forces
- [x] A-Bretagard Stronghold
- [x] A-Dueling Coach
- [x] A-Fall of the Impostor
- [x] A-Gnarlid Colony
- [x] A-Sigardian Paladin
- [x] A-Hagra Constrictor
- [x] A-Tenured Inkcaster
- [x] A-Iridescent Hornbeetle
- [x] A-Moss-Pit Skeleton
- [x] A-Skyclave Shadowcat
- [x] A-Ochre Jelly
- [x] A-Oran-Rief Ooze
- [x] A-Tanazir Quandrix
- [x] A-Ardent Dustspeaker
- [x] A-Maelstrom Muse
- [x] A-Rockslide Sorcerer
- [x] A-Tome Shredder
- [x] A-Master of Winds
- [x] A-Mentor's Guidance
- [x] A-Rowan, Scholar of Sparks // A-Will, Scholar of Frost
- [x] A-Sorcerer Class
- [x] A-Umara Mystic
- [x] Painful Bond (YNEO)