### PR TITLE
Card script for Call to the Void and changes to ChooseCardEffect to enable card mechanisms.

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/ChooseCardEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChooseCardEffect.java
@@ -83,7 +83,7 @@ public class ChooseCardEffect extends SpellAbilityEffect {
             combined.addAll(choices);
             choices = combined;
         }
-
+        
         final String amountValue = sa.getParamOrDefault("Amount", "1");
         int validAmount;
         if (StringUtils.isNumeric(amountValue)) {
@@ -187,6 +187,18 @@ public class ChooseCardEffect extends SpellAbilityEffect {
                     chosenPool.add(choice);
                 }
                 chosen.addAll(chosenPool);
+            } else if (sa.hasParam("ControlAndNot")) {
+                String title = sa.hasParam("ChoiceTitle") ? sa.getParam("ChoiceTitle") : Localizer.getInstance().getMessage("lblChooseCreature");
+                // Targeted player (p) chooses N creatures that belongs to them
+                CardCollection tgtPlayerCtrl = CardLists.filterControlledBy(choices, p);
+                chosen.addAll(p.getController().chooseCardsForEffect(tgtPlayerCtrl, sa, title + " " + "you control", minAmount, validAmount,
+                    !sa.hasParam("Mandatory"), null));
+                // Targeted player (p) chooses N creatures that don't belong to them
+                CardCollection notTgtPlayerCtrl = new CardCollection(choices);
+                notTgtPlayerCtrl.removeAll(tgtPlayerCtrl);
+                chosen.addAll(p.getController().chooseCardsForEffect(notTgtPlayerCtrl, sa, title + " " + "you don't control", minAmount, validAmount,
+                    !sa.hasParam("Mandatory"), null));
+
             } else if ((tgt == null) || p.canBeTargetedBy(sa)) {
                 if (sa.hasParam("AtRandom") && !choices.isEmpty()) {
                     Aggregates.random(choices, validAmount, chosen);
@@ -217,8 +229,13 @@ public class ChooseCardEffect extends SpellAbilityEffect {
                     }
                 }
             }
-            if (sa.hasParam("Reveal")) {
-                game.getAction().reveal(chosen, p, true, Localizer.getInstance().getMessage("lblChosenCards") + " ");
+            if (sa.hasParam("Reveal") && !sa.hasParam("SecretlyChoose")) {
+                game.getAction().reveal(chosen, p, true, sa.hasParam("RevealTitle") ? sa.getParam("RevealTitle") : Localizer.getInstance().getMessage("lblChosenCards") + " ");
+            }
+        }
+        if(sa.hasParam("Reveal") && sa.hasParam("SecretlyChoose")) {
+            for (final Player p : tgtPlayers) {
+                game.getAction().reveal(chosen, p, true, sa.hasParam("RevealTitle") ? sa.getParam("RevealTitle") : Localizer.getInstance().getMessage("lblChosenCards") + " ");
             }
         }
         host.setChosenCards(chosen);

--- a/forge-game/src/main/java/forge/game/ability/effects/ChooseCardEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChooseCardEffect.java
@@ -83,7 +83,7 @@ public class ChooseCardEffect extends SpellAbilityEffect {
             combined.addAll(choices);
             choices = combined;
         }
-        
+
         final String amountValue = sa.getParamOrDefault("Amount", "1");
         int validAmount;
         if (StringUtils.isNumeric(amountValue)) {

--- a/forge-gui/res/cardsfolder/upcoming/call_to_the_void.txt
+++ b/forge-gui/res/cardsfolder/upcoming/call_to_the_void.txt
@@ -1,9 +1,6 @@
 Name:Call to the Void
 ManaCost:4 B
 Types:Sorcery
-A:SP$ RepeatEach | Cost$ 4 B | RepeatPlayers$ Player | RepeatSubAbility$ DBChooseCreatureYouCtrl | SubAbility$ DBRevealChosenToAll
-SVar:DBChooseCreatureYouCtrl:DB$ ChooseCard | Defined$ Remembered | Amount$ 1 | Choices$ Creature.RememberedPlayerCtrl | ChoiceTitle$ Secretly choose a creature you control | SubAbility$ DBChooseCreatureYouDontCtrl | RememberChosen$ True | Mandatory$ True
-SVar:DBChooseCreatureYouDontCtrl:DB$ ChooseCard | Defined$ Remembered | Amount$ 1 | Choices$ Creature.nonRememberedPlayerCtrl | ChoiceTitle$ Secretly choose a creature you don't control | RememberChosen$ True | Mandatory$ True
-SVar:DBRevealChosenToAll:DB$ Reveal | Defined$ CardOwner | RevealDefined$ RememberedCard | RevealToAll$ True | RevealTitle$ OVERRIDE Creatures chosen. They will be destroyed. | Description$ Test | SubAbility$ DBDestroyChosen
+A:SP$ ChooseCard | Defined$ Player | Choices$ Creature | SecretlyChoose$ True | Amount$ 1 | ControlAndNot$ True | ChoiceTitle$ Secretly choose a creature | Reveal$ True | RevealTitle$ OVERRIDE Chosen creatures. They will be destroyed. | SubAbility$ DBDestroyChosen | RememberChosen$ True | Mandatory$ True
 SVar:DBDestroyChosen:DB$ DestroyAll | ValidCards$ Creature.IsRemembered | SubAbility$ DBCleanUp
-SVar:DBCleanUp:DB$ Cleanup | ClearRemembered$ True 
+SVar:DBCleanUp:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/upcoming/call_to_the_void.txt
+++ b/forge-gui/res/cardsfolder/upcoming/call_to_the_void.txt
@@ -1,6 +1,7 @@
 Name:Call to the Void
 ManaCost:4 B
 Types:Sorcery
-A:SP$ ChooseCard | Defined$ Player | Choices$ Creature | SecretlyChoose$ True | Amount$ 1 | ControlAndNot$ True | ChoiceTitle$ Secretly choose a creature | Reveal$ True | RevealTitle$ OVERRIDE Chosen creatures. They will be destroyed. | SubAbility$ DBDestroyChosen | RememberChosen$ True | Mandatory$ True
-SVar:DBDestroyChosen:DB$ DestroyAll | ValidCards$ Creature.IsRemembered | SubAbility$ DBCleanUp
+A:SP$ ChooseCard | Defined$ Player | Choices$ Creature | SecretlyChoose$ True | Amount$ 1 | ControlAndNot$ True | ChoiceTitle$ Secretly choose a creature | Reveal$ True | RevealTitle$ OVERRIDE Chosen creatures. They will be destroyed. | SubAbility$ DBDestroyChosen | Mandatory$ True
+SVar:DBDestroyChosen:DB$ DestroyAll | ValidCards$ Creature.ChosenCard | SubAbility$ DBCleanUp
 SVar:DBCleanUp:DB$ Cleanup | ClearRemembered$ True
+Oracle:Each player secretly chooses a creature they control and a creature they don't control. Then those choices are revealed. Destroy each creature chosen this way.

--- a/forge-gui/res/cardsfolder/upcoming/call_to_the_void.txt
+++ b/forge-gui/res/cardsfolder/upcoming/call_to_the_void.txt
@@ -1,10 +1,9 @@
 Name:Call to the Void
 ManaCost:4 B
 Types:Sorcery
-A:SP$ RepeatEach | Cost$ 4 B | RepeatPlayers$ Player | RepeatSubAbility$ DBChooseCreatureYouCtrl | SubAbility$ DBRevealChosen
+A:SP$ RepeatEach | Cost$ 4 B | RepeatPlayers$ Player | RepeatSubAbility$ DBChooseCreatureYouCtrl | SubAbility$ DBRevealChosenToAll
 SVar:DBChooseCreatureYouCtrl:DB$ ChooseCard | Defined$ Remembered | Amount$ 1 | Choices$ Creature.RememberedPlayerCtrl | ChoiceTitle$ Secretly choose a creature you control | SubAbility$ DBChooseCreatureYouDontCtrl | RememberChosen$ True | Mandatory$ True
 SVar:DBChooseCreatureYouDontCtrl:DB$ ChooseCard | Defined$ Remembered | Amount$ 1 | Choices$ Creature.nonRememberedPlayerCtrl | ChoiceTitle$ Secretly choose a creature you don't control | RememberChosen$ True | Mandatory$ True
-SVar:DBRevealChosen:DB$ RepeatEach | RepeatPlayers$ Player | RepeatSubAbility$ DBRevealToEachPlayer | SubAbility$ DBDestroyChosen
-SVar:DBRevealToEachPlayer:DB$ Reveal | Defined$ RememberedPlayer | RevealDefined$ ChosenCard
+SVar:DBRevealChosenToAll:DB$ Reveal | Defined$ CardOwner | RevealDefined$ RememberedCard | RevealToAll$ True | RevealTitle$ OVERRIDE Creatures chosen. They will be destroyed. | Description$ Test | SubAbility$ DBDestroyChosen
 SVar:DBDestroyChosen:DB$ DestroyAll | ValidCards$ Creature.IsRemembered | SubAbility$ DBCleanUp
 SVar:DBCleanUp:DB$ Cleanup | ClearRemembered$ True 

--- a/forge-gui/res/cardsfolder/upcoming/call_to_the_void.txt
+++ b/forge-gui/res/cardsfolder/upcoming/call_to_the_void.txt
@@ -2,6 +2,5 @@ Name:Call to the Void
 ManaCost:4 B
 Types:Sorcery
 A:SP$ ChooseCard | Defined$ Player | Choices$ Creature | SecretlyChoose$ True | Amount$ 1 | ControlAndNot$ True | ChoiceTitle$ Secretly choose a creature | Reveal$ True | RevealTitle$ OVERRIDE Chosen creatures. They will be destroyed. | SubAbility$ DBDestroyChosen | Mandatory$ True
-SVar:DBDestroyChosen:DB$ DestroyAll | ValidCards$ Creature.ChosenCard | SubAbility$ DBCleanUp
-SVar:DBCleanUp:DB$ Cleanup | ClearRemembered$ True
+SVar:DBDestroyChosen:DB$ DestroyAll | ValidCards$ Creature.ChosenCard
 Oracle:Each player secretly chooses a creature they control and a creature they don't control. Then those choices are revealed. Destroy each creature chosen this way.

--- a/forge-gui/res/cardsfolder/upcoming/call_to_the_void.txt
+++ b/forge-gui/res/cardsfolder/upcoming/call_to_the_void.txt
@@ -1,0 +1,10 @@
+Name:Call to the Void
+ManaCost:4 B
+Types:Sorcery
+A:SP$ RepeatEach | Cost$ 4 B | RepeatPlayers$ Player | RepeatSubAbility$ DBChooseCreatureYouCtrl | SubAbility$ DBRevealChosen
+SVar:DBChooseCreatureYouCtrl:DB$ ChooseCard | Defined$ Remembered | Amount$ 1 | Choices$ Creature.RememberedPlayerCtrl | ChoiceTitle$ Secretly choose a creature you control | SubAbility$ DBChooseCreatureYouDontCtrl | RememberChosen$ True | Mandatory$ True
+SVar:DBChooseCreatureYouDontCtrl:DB$ ChooseCard | Defined$ Remembered | Amount$ 1 | Choices$ Creature.nonRememberedPlayerCtrl | ChoiceTitle$ Secretly choose a creature you don't control | RememberChosen$ True | Mandatory$ True
+SVar:DBRevealChosen:DB$ RepeatEach | RepeatPlayers$ Player | RepeatSubAbility$ DBRevealToEachPlayer | SubAbility$ DBDestroyChosen
+SVar:DBRevealToEachPlayer:DB$ Reveal | Defined$ RememberedPlayer | RevealDefined$ ChosenCard
+SVar:DBDestroyChosen:DB$ DestroyAll | ValidCards$ Creature.IsRemembered | SubAbility$ DBCleanUp
+SVar:DBCleanUp:DB$ CleanUp | ClearRemembered$ True 

--- a/forge-gui/res/cardsfolder/upcoming/call_to_the_void.txt
+++ b/forge-gui/res/cardsfolder/upcoming/call_to_the_void.txt
@@ -7,4 +7,4 @@ SVar:DBChooseCreatureYouDontCtrl:DB$ ChooseCard | Defined$ Remembered | Amount$ 
 SVar:DBRevealChosen:DB$ RepeatEach | RepeatPlayers$ Player | RepeatSubAbility$ DBRevealToEachPlayer | SubAbility$ DBDestroyChosen
 SVar:DBRevealToEachPlayer:DB$ Reveal | Defined$ RememberedPlayer | RevealDefined$ ChosenCard
 SVar:DBDestroyChosen:DB$ DestroyAll | ValidCards$ Creature.IsRemembered | SubAbility$ DBCleanUp
-SVar:DBCleanUp:DB$ CleanUp | ClearRemembered$ True 
+SVar:DBCleanUp:DB$ Cleanup | ClearRemembered$ True 


### PR DESCRIPTION
- Created CardScript for call to the void.
- Added "ControlAndNot" parameter to ChooseCardEffect as suggested by @northmoc on discord (https://discord.com/channels/267367946135928833/994588726254633090/994610830815539370)
- Added and implemented "SecretlyChoose" in ChooseCardEffect.
- Added RevealTitle to ChooseCardEffect.