### PR TITLE
Fix AI casting suspended spells against Drannith Magistrate

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtil.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtil.java
@@ -250,6 +250,13 @@ public class ComputerUtil {
             return false;
 
         final Card source = sa.getHostCard();
+
+        Zone fromZone = game.getZoneOf(source);
+        int zonePosition = 0;
+        if (fromZone != null) {
+            zonePosition = fromZone.getCards().indexOf(source);
+        }
+
         if (sa.isSpell() && !source.isCopiedSpell()) {
             sa.setHostCard(game.getAction().moveToStack(source, sa));
         }
@@ -257,11 +264,18 @@ public class ComputerUtil {
         sa = GameActionUtil.addExtraKeywordCost(sa);
 
         final Cost cost = sa.getPayCosts();
+        final CostPayment pay = new CostPayment(cost, sa);
+
+        // do this after card got added to stack
+        if (!sa.checkRestrictions(ai)) {
+            GameActionUtil.rollbackAbility(sa, fromZone, zonePosition, pay, source);
+            return false;
+        }
+
         if (cost == null) {
             ComputerUtilMana.payManaCost(ai, sa, false);
             game.getStack().add(sa);
         } else {
-            final CostPayment pay = new CostPayment(cost, sa);
             if (pay.payComputerCosts(new AiCostDecision(ai, sa, false))) {
                 game.getStack().add(sa);
             }
@@ -292,6 +306,13 @@ public class ComputerUtil {
         newSA = GameActionUtil.addExtraKeywordCost(newSA);
 
         final Card source = newSA.getHostCard();
+
+        Zone fromZone = game.getZoneOf(source);
+        int zonePosition = 0;
+        if (fromZone != null) {
+            zonePosition = fromZone.getCards().indexOf(source);
+        }
+
         if (newSA.isSpell() && !source.isCopiedSpell()) {
             newSA.setHostCard(game.getAction().moveToStack(source, newSA));
 
@@ -303,6 +324,13 @@ public class ComputerUtil {
         }
 
         final CostPayment pay = new CostPayment(newSA.getPayCosts(), newSA);
+
+        // do this after card got added to stack
+        if (!sa.checkRestrictions(ai)) {
+            GameActionUtil.rollbackAbility(sa, fromZone, zonePosition, pay, source);
+            return false;
+        }
+        
         pay.payComputerCosts(new AiCostDecision(ai, newSA, false));
 
         game.getStack().add(newSA);

--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -1087,7 +1087,7 @@ public class PlayerControllerAi extends PlayerController {
         if (tgtSA instanceof Spell) { // Isn't it ALWAYS a spell?
             Spell spell = (Spell) tgtSA;
             // TODO if mandatory AI is only forced to use mana when it's already in the pool
-            if (tgtSA.checkRestrictions(brains.getPlayer()) && (brains.canPlayFromEffectAI(spell, !optional, noManaCost) == AiPlayDecision.WillPlay || !optional)) {
+            if (brains.canPlayFromEffectAI(spell, !optional, noManaCost) == AiPlayDecision.WillPlay || !optional) {
                 if (noManaCost) {
                     return ComputerUtil.playSpellAbilityWithoutPayingManaCost(player, tgtSA, getGame());
                 }

--- a/forge-game/src/main/java/forge/game/GameActionUtil.java
+++ b/forge-game/src/main/java/forge/game/GameActionUtil.java
@@ -34,6 +34,7 @@ import forge.game.ability.AbilityUtils;
 import forge.game.ability.ApiType;
 import forge.game.card.CardPlayOption.PayManaCost;
 import forge.game.cost.Cost;
+import forge.game.cost.CostPayment;
 import forge.game.keyword.Keyword;
 import forge.game.keyword.KeywordInterface;
 import forge.game.player.Player;
@@ -840,6 +841,48 @@ public final class GameActionUtil {
         c.updateKeywords();
 
         c.getGame().getTriggerHandler().resetActiveTriggers();
+    }
+
+    public static void rollbackAbility(SpellAbility ability, final Zone fromZone, final int zonePosition, CostPayment payment, Card oldCard) {
+        // cancel ability during target choosing
+        final Game game = ability.getActivatingPlayer().getGame();
+
+        if (fromZone != null) { // and not a copy
+            oldCard.setCastSA(null);
+            oldCard.setCastFrom(null);
+            // add back to where it came from, hopefully old state
+            // skip GameAction
+            oldCard.getZone().remove(oldCard);
+            fromZone.add(oldCard, zonePosition >= 0 ? Integer.valueOf(zonePosition) : null);
+            ability.setHostCard(oldCard);
+            ability.setXManaCostPaid(null);
+            ability.setSpendPhyrexianMana(false);
+            if (ability.hasParam("Announce")) {
+                for (final String aVar : ability.getParam("Announce").split(",")) {
+                    final String varName = aVar.trim();
+                    if (!varName.equals("X")) {
+                        ability.setSVar(varName, "0");
+                    }
+                }
+            }
+            // better safe than sorry approach in case rolled back ability was copy (from addExtraKeywordCost)
+            for (SpellAbility sa : oldCard.getSpells()) {
+                sa.setHostCard(oldCard);
+            }
+            //for Chorus of the Conclave
+            ability.rollback();
+
+            oldCard.setBackSide(false);
+            oldCard.setState(oldCard.getFaceupCardStateName(), true);
+            oldCard.unanimateBestow();
+        }
+
+        ability.clearTargets();
+
+        ability.resetOnceResolved();
+        payment.refundPayment();
+        game.getStack().clearFrozen();
+        game.getTriggerHandler().clearWaitingTriggers();
     }
 
 }

--- a/forge-game/src/main/java/forge/game/ability/effects/CountersPutEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CountersPutEffect.java
@@ -495,7 +495,7 @@ public class CountersPutEffect extends SpellAbilityEffect {
                             // need to unfreeze tracker
                             game.getTracker().unfreeze();
 
-                            // check if it can recive the Tribute
+                            // check if it can receive the Tribute
                             if (abort) {
                                 continue;
                             }

--- a/forge-gui/res/cardsfolder/d/djerus_resolve.txt
+++ b/forge-gui/res/cardsfolder/d/djerus_resolve.txt
@@ -2,6 +2,7 @@ Name:Djeru's Resolve
 ManaCost:W
 Types:Instant
 A:SP$ Untap | Cost$ W | ValidTgts$ Creature | TgtPrompt$ Select target creature | SubAbility$ DBPump | SpellDescription$ Untap target creature. Prevent all damage that would be dealt to it this turn.
-SVar:DBPump:DB$ Pump | Defined$ Targeted | KW$ Prevent all damage that would be dealt to CARDNAME.
+SVar:DBPump:DB$ Effect | ReplacementEffects$ RPrevent | RememberObjects$ Targeted | ExileOnMoved$ Battlefield
+SVar:RPrevent:Event$ DamageDone | Prevent$ True | ValidTarget$ Card.IsRemembered | Description$ Prevent all damage that would be dealt to that creature this turn.
 K:Cycling:2
 Oracle:Untap target creature. Prevent all damage that would be dealt to it this turn.\nCycling {2} ({2}, Discard this card: Draw a card.)

--- a/forge-gui/res/cardsfolder/g/godtoucher.txt
+++ b/forge-gui/res/cardsfolder/g/godtoucher.txt
@@ -2,7 +2,8 @@ Name:Godtoucher
 ManaCost:3 G
 Types:Creature Elf Cleric
 PT:2/2
-A:AB$ Pump | Cost$ 1 W T | KW$ Prevent all damage that would be dealt to CARDNAME. | ValidTgts$ Creature.powerGE5 | TgtPrompt$ Select target creature with power 5 or greater | SpellDescription$ Prevent all damage that would be dealt to target creature with power 5 or greater this turn.
+A:AB$ Effect | Cost$ 1 W T | ValidTgts$ Creature.powerGE5 | TgtPrompt$ Select target creature with power 5 or greater | ReplacementEffects$ RPrevent| RememberObjects$ Targeted | ExileOnMoved$ Battlefield | SpellDescription$ Prevent all damage that would be dealt to target creature with power 5 or greater this turn.
+SVar:RPrevent:Event$ DamageDone | Prevent$ True | ValidTarget$ Card.IsRemembered | Description$ Prevent all damage that would be dealt to that creature this turn.
 AI:RemoveDeck:All
 AI:RemoveDeck:Random
 Oracle:{1}{W}, {T}: Prevent all damage that would be dealt to target creature with power 5 or greater this turn.

--- a/forge-gui/res/cardsfolder/h/harvestguard_alseids.txt
+++ b/forge-gui/res/cardsfolder/h/harvestguard_alseids.txt
@@ -3,7 +3,8 @@ ManaCost:2 W
 Types:Enchantment Creature Nymph
 PT:2/3
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self,Enchantment.Other+YouCtrl | Execute$ TrigPump | TriggerDescription$ Constellation — Whenever CARDNAME or another enchantment enters the battlefield under your control, prevent all damage that would be dealt to target creature this turn.
-SVar:TrigPump:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ Prevent all damage that would be dealt to CARDNAME.
+SVar:TrigPump:DB$ Effect | Cost$ W | ValidTgts$ Creature | ReplacementEffects$ RPrevent | RememberObjects$ Targeted | ExileOnMoved$ Battlefield
+SVar:RPrevent:Event$ DamageDone | Prevent$ True | ValidTarget$ Card.IsRemembered | Description$ Prevent all damage that would be dealt to that creature this turn.
 SVar:PlayMain1:TRUE
 SVar:BuffedBy:Enchantment
 Oracle:Constellation — Whenever Harvestguard Alseids or another enchantment enters the battlefield under your control, prevent all damage that would be dealt to target creature this turn.

--- a/forge-gui/res/cardsfolder/i/indestructible_aura.txt
+++ b/forge-gui/res/cardsfolder/i/indestructible_aura.txt
@@ -1,6 +1,7 @@
 Name:Indestructible Aura
 ManaCost:W
 Types:Instant
-A:SP$ Pump | Cost$ W | KW$ Prevent all damage that would be dealt to CARDNAME. | ValidTgts$ Creature | TgtPrompt$ Select target creature | SpellDescription$ Prevent all damage that would be dealt to target creature this turn.
+A:SP$ Effect | ValidTgts$ Creature | ReplacementEffects$ RPrevent | RememberObjects$ Targeted | ExileOnMoved$ Battlefield | SpellDescription$ Prevent all damage that would be dealt to target creature this turn.
+SVar:RPrevent:Event$ DamageDone | Prevent$ True | ValidTarget$ Card.IsRemembered | Description$ Prevent all damage that would be dealt to that creature this turn.
 AI:RemoveDeck:All
 Oracle:Prevent all damage that would be dealt to target creature this turn.

--- a/forge-gui/res/cardsfolder/p/piston_fist_cyclops.txt
+++ b/forge-gui/res/cardsfolder/p/piston_fist_cyclops.txt
@@ -4,7 +4,7 @@ Types:Creature Cyclops
 PT:4/3
 K:Defender
 S:Mode$ CanAttackDefender | ValidCard$ Card.Self | CheckSVar$ X | Description$ As long as you've cast an instant or sorcery spell this turn, CARDNAME can attack as though it didn't have defender.
-SVar:X:Count$ThisTurnCast_Instant.YouOwn,Sorcery.YouOwn
+SVar:X:Count$ThisTurnCast_Instant.YouCtrl,Sorcery.YouCtrl
 SVar:BuffedBy:Instant,Sorcery
 DeckHints:Type$Instant|Sorcery
 Oracle:Defender\nAs long as you've cast an instant or sorcery spell this turn, Piston-Fist Cyclops can attack as though it didn't have defender.

--- a/forge-gui/res/cardsfolder/s/shielded_passage.txt
+++ b/forge-gui/res/cardsfolder/s/shielded_passage.txt
@@ -1,6 +1,7 @@
 Name:Shielded Passage
 ManaCost:W
 Types:Instant
-A:SP$ Pump | Cost$ W | KW$ Prevent all damage that would be dealt to CARDNAME. | ValidTgts$ Creature | TgtPrompt$ Select target creature | SpellDescription$ Prevent all damage that would be dealt to target creature this turn.
+A:SP$ Effect | ValidTgts$ Creature | ReplacementEffects$ RPrevent | RememberObjects$ Targeted | ExileOnMoved$ Battlefield | SpellDescription$ Prevent all damage that would be dealt to target creature this turn.
+SVar:RPrevent:Event$ DamageDone | Prevent$ True | ValidTarget$ Card.IsRemembered | Description$ Prevent all damage that would be dealt to that creature this turn.
 AI:RemoveDeck:All
 Oracle:Prevent all damage that would be dealt to target creature this turn.

--- a/forge-gui/res/cardsfolder/w/wellgabber_apothecary.txt
+++ b/forge-gui/res/cardsfolder/w/wellgabber_apothecary.txt
@@ -2,5 +2,6 @@ Name:Wellgabber Apothecary
 ManaCost:4 W
 Types:Creature Merfolk Cleric
 PT:2/3
-A:AB$ Pump | Cost$ 1 W | KW$ Prevent all damage that would be dealt to CARDNAME. | ValidTgts$ Creature.Merfolk+tapped,Creature.Kithkin+tapped | TgtPrompt$ Select tapped Merfolk or Kithkin creature | SpellDescription$ Prevent all damage that would be dealt to target tapped Merfolk or Kithkin creature this turn.
+A:SP$ Effect | Cost$ 1 W | ValidTgts$ Creature.Merfolk+tapped,Creature.Kithkin+tapped | TgtPrompt$ Select tapped Merfolk or Kithkin creature | ReplacementEffects$ RPrevent | RememberObjects$ Targeted | ExileOnMoved$ Battlefield | SpellDescription$ Prevent all damage that would be dealt to target tapped Merfolk or Kithkin creature this turn.
+SVar:RPrevent:Event$ DamageDone | Prevent$ True | ValidTarget$ Card.IsRemembered | Description$ Prevent all damage that would be dealt to that creature this turn.
 Oracle:{1}{W}: Prevent all damage that would be dealt to target tapped Merfolk or Kithkin creature this turn.

--- a/forge-gui/src/main/java/forge/player/HumanPlaySpellAbility.java
+++ b/forge-gui/src/main/java/forge/player/HumanPlaySpellAbility.java
@@ -164,7 +164,7 @@ public class HumanPlaySpellAbility {
 
         if (!prerequisitesMet) {
             if (!ability.isTrigger()) {
-                rollbackAbility(fromZone, zonePosition, payment, c);
+                GameActionUtil.rollbackAbility(ability, fromZone, zonePosition, payment, c);
                 if (ability.getHostCard().isMadness()) {
                     // if a player failed to play madness cost, move the card to graveyard
                     Card newCard = game.getAction().moveToGraveyard(c, null);
@@ -207,48 +207,6 @@ public class HumanPlaySpellAbility {
         }
         game.clearTopLibsCast(ability);
         return true;
-    }
-
-    private void rollbackAbility(final Zone fromZone, final int zonePosition, CostPayment payment, Card oldCard) {
-        // cancel ability during target choosing
-        final Game game = ability.getActivatingPlayer().getGame();
-
-        if (fromZone != null) { // and not a copy
-            oldCard.setCastSA(null);
-            oldCard.setCastFrom(null);
-            // add back to where it came from, hopefully old state
-            // skip GameAction
-            oldCard.getZone().remove(oldCard);
-            fromZone.add(oldCard, zonePosition >= 0 ? Integer.valueOf(zonePosition) : null);
-            ability.setHostCard(oldCard);
-            ability.setXManaCostPaid(null);
-            ability.setSpendPhyrexianMana(false);
-            if (ability.hasParam("Announce")) {
-                for (final String aVar : ability.getParam("Announce").split(",")) {
-                    final String varName = aVar.trim();
-                    if (!varName.equals("X")) {
-                        ability.setSVar(varName, "0");
-                    }
-                }
-            }
-            // better safe than sorry approach in case rolled back ability was copy (from addExtraKeywordCost)
-            for (SpellAbility sa : oldCard.getSpells()) {
-                sa.setHostCard(oldCard);
-            }
-            //for Chorus of the Conclave
-            ability.rollback();
-
-            oldCard.setBackSide(false);
-            oldCard.setState(oldCard.getFaceupCardStateName(), true);
-            oldCard.unanimateBestow();
-        }
-
-        ability.clearTargets();
-
-        ability.resetOnceResolved();
-        payment.refundPayment();
-        game.getStack().clearFrozen();
-        game.getTriggerHandler().clearWaitingTriggers();
     }
 
     private boolean announceValuesLikeX() {


### PR DESCRIPTION
The checkRestrictions() was too early before it was on the stack, so the static couldn't prevent it.

I've decided to change it by doing rollback cleanly like HumanController if it fails, which seems to work fine.

Closes #1088

Also cleaned up some more outdated damage KW.