### PR TITLE
Move MH2 rebalanced to J21

### DIFF
--- a/forge-gui/res/editions/Jumpstart Historic Horizons.txt
+++ b/forge-gui/res/editions/Jumpstart Historic Horizons.txt
@@ -794,5 +794,9 @@ ScryfallCode=J21
 786 L Mountain
 787 L Forest
 
+[rebalanced]
+A438 U A-Dragon's Rage Channeler @Martina Fackova
+A529 C A-Unholy Heat @Kari Christensen
+
 [tokens]
 u_8_8_kraken

--- a/forge-gui/res/editions/Modern Horizons 2.txt
+++ b/forge-gui/res/editions/Modern Horizons 2.txt
@@ -522,10 +522,6 @@ ScryfallCode=MH2
 [bundle]
 492 R Yusri, Fortune's Flame @Evyn Fong
 
-[rebalanced]
-A121 U A-Dragon's Rage Channeler @Martina Fackova
-A145 C A-Unholy Heat @Kari Christensen
-
 [Lands]
 19 Arid Mesa|MH2|1
 1 Arid Mesa|MH2|2


### PR DESCRIPTION
I have moved the two rebalanced cards from MH2 to J21 so that they show up as legal in Historic and not Modern. It makes no sense to have them in MH2 (even though Scryfall lists them there) as the set is not in Arena but J21 is (where these two cards are part of the set)