### PR TITLE
LastState: pass through from GameAction into ReplacementHandler & performance fixes

### DIFF
--- a/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
@@ -44,6 +44,7 @@ import forge.game.ability.AbilityUtils;
 import forge.game.ability.ApiType;
 import forge.game.card.Card;
 import forge.game.card.CardCollection;
+import forge.game.card.CardCollectionView;
 import forge.game.card.CardDamageMap;
 import forge.game.card.CardState;
 import forge.game.card.CardTraitChanges;
@@ -351,8 +352,8 @@ public class ReplacementHandler {
                 tailend = tailend.getSubAbility();
             } while(tailend != null);
 
-            effectSA.setLastStateBattlefield(game.getLastStateBattlefield());
-            effectSA.setLastStateGraveyard(game.getLastStateGraveyard());
+            effectSA.setLastStateBattlefield((CardCollectionView) runParams.getOrDefault(AbilityKey.LastStateBattlefield, game.getLastStateBattlefield()));
+            effectSA.setLastStateGraveyard((CardCollectionView) runParams.getOrDefault(AbilityKey.LastStateBattlefield, game.getLastStateGraveyard()));
             if (replacementEffect.isIntrinsic()) {
                 effectSA.setIntrinsic(true);
                 effectSA.changeText();

--- a/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
@@ -176,9 +176,17 @@ public class ReplacementHandler {
                 final Card c = preList.get(crd);
 
                 for (final ReplacementEffect replacementEffect : c.getReplacementEffects()) {
-                    // Use "CheckLKIZone" parameter to test for effects that care abut where the card was last (e.g. Kalitas, Traitor of Ghet
+                    Zone cardZone;
+                    // Use "CheckLKIZone" parameter to test for effects that care about where the card was last (e.g. Kalitas, Traitor of Ghet
                     // getting hit by mass removal should still produce tokens).
-                    Zone cardZone = "True".equals(replacementEffect.getParam("CheckSelfLKIZone")) ? game.getChangeZoneLKIInfo(c).getLastKnownZone() : game.getZoneOf(c);
+                    if ("True".equals(replacementEffect.getParam("CheckSelfLKIZone"))) {
+                        cardZone = game.getChangeZoneLKIInfo(c).getLastKnownZone();
+                        if (cardZone.is(ZoneType.Battlefield) && runParams.containsKey(AbilityKey.LastStateBattlefield) && !((CardCollectionView) runParams.get(AbilityKey.LastStateBattlefield)).contains(crd)) {
+                            continue;
+                        }
+                    } else {
+                        cardZone = game.getZoneOf(c);
+                    }
 
                     // Replacement effects that are tied to keywords (e.g. damage prevention effects - if the keyword is removed, the replacement
                     // effect should be inactive)

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
@@ -111,11 +111,17 @@ public final class StaticAbilityContinuous {
         final List<Player> affectedPlayers = StaticAbilityContinuous.getAffectedPlayers(stAb);
         final Game game = hostCard.getGame();
 
-        final StaticEffect se = game.getStaticEffects().getStaticEffect(stAb);
+        final StaticEffects effects = game.getStaticEffects();
+        final StaticEffect se = effects.getStaticEffect(stAb);
         se.setAffectedCards(affectedCards);
         se.setAffectedPlayers(affectedPlayers);
         se.setParams(params);
         se.setTimestamp(hostCard.getTimestamp());
+
+        // nothing more to do
+        if (stAb.hasParam("Affected") && affectedPlayers.isEmpty() && affectedCards.isEmpty()) {
+            return affectedCards;
+        }
 
         String addP = "";
         int powerBonus = 0;
@@ -161,7 +167,6 @@ public final class StaticAbilityContinuous {
 
         //Global rules changes
         if (layer == StaticAbilityLayer.RULES && params.containsKey("GlobalRule")) {
-            final StaticEffects effects = game.getStaticEffects();
             effects.setGlobalRuleChange(GlobalRuleChange.fromString(params.get("GlobalRule")));
         }
 
@@ -196,8 +201,6 @@ public final class StaticAbilityContinuous {
 
                 // update keywords with Chosen parts
                 final String hostCardUID = Integer.toString(hostCard.getId()); // Protection with "doesn't remove" effect
-
-                final ColorSet colorsYouCtrl = CardUtil.getColorsYouCtrl(controller);
 
                 Iterables.removeIf(addKeywords, new Predicate<String>() {
                     @Override
@@ -246,6 +249,8 @@ public final class StaticAbilityContinuous {
                         }
                         // two variants for Red vs. red in keyword
                         if (input.contains("ColorsYouCtrl") || input.contains("colorsYouCtrl")) {
+                            final ColorSet colorsYouCtrl = CardUtil.getColorsYouCtrl(controller);
+
                             for (byte color : colorsYouCtrl) {
                                 final String colorWord = MagicColor.toLongString(color);
                                 String y = input.replaceAll("ColorsYouCtrl", StringUtils.capitalize(colorWord));
@@ -718,6 +723,7 @@ public final class StaticAbilityContinuous {
             // add P/T bonus
             if (layer == StaticAbilityLayer.MODIFYPT) {
                 if (addP.contains("Affected")) {
+                    // TODO don't calculate these above if this gets used instead
                     powerBonus = AbilityUtils.calculateAmount(affectedCard, addP, stAb, true);
                 }
                 if (addT.contains("Affected")) {


### PR DESCRIPTION
1. Fixes _Giada, Font of Hope_:
if multiple angels ETB together they don't see each other

2. I noticed cases where StaticAbilityContinuous kept checking stuff, even if there was nothing to affect.
E. g. _Heroes' Podium_ if you control no legendary creature it would still call into `AbilityUtils.calculateAmount` and then still deeper into `CardProperty`