### PR TITLE
Fix NPE when copying spell with failed targeting

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtil.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtil.java
@@ -2826,7 +2826,7 @@ public class ComputerUtil {
         }
 
         return type.is(CounterEnumType.AWAKENING) || type.is(CounterEnumType.MANIFESTATION) || type.is(CounterEnumType.PETRIFICATION)
-                || type.is(CounterEnumType.TRAINING);
+                || type.is(CounterEnumType.TRAINING) || type.is(CounterEnumType.GHOSTFORM);
     }
 
     public static Player evaluateBoardPosition(final List<Player> listToEvaluate) {

--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -1045,16 +1045,14 @@ public class PlayerControllerAi extends PlayerController {
                         }
                     }
 
-                    /* FIXME: the new implementation (below) requires implementing setupNewTargets in the AI controller, among other possible changes, otherwise breaks AI
                     if (sa.isMayChooseNewTargets()) {
-                        sa.setupNewTargets(player);
-                    }
-                    */
-                    if (sa.isMayChooseNewTargets() && !sa.setupTargets()) {
-                        if (sa.isSpell()) {
-                            getGame().getAction().ceaseToExist(sa.getHostCard(), false);
+                        TargetChoices tc = sa.getTargets();
+                        if (!sa.setupTargets()) {
+                            // if AI can't choose targets need to keep old one even if illegal
+                            sa.setTargets(tc);
                         }
-                        continue;
+                        // FIXME: the new implementation (below) requires implementing setupNewTargets in the AI controller, among other possible changes, otherwise breaks AI
+                        // sa.setupNewTargets(player);
                     }
                 }
                 // need finally add the new spell to the stack

--- a/forge-gui/res/cardsfolder/a/audacious_swap.txt
+++ b/forge-gui/res/cardsfolder/a/audacious_swap.txt
@@ -5,7 +5,7 @@ K:Casualty:2
 A:SP$ ChangeZone | ValidTgts$ Permanent.nonEnchantment | TgtPrompt$ Select target nonenchantment permanent | Origin$ Battlefield | Destination$ Library | Shuffle$ True | SubAbility$ DBExile | SpellDescription$ The owner of target nonenchantment permanent shuffles it into their library,
 SVar:DBExile:DB$ Dig | DigNum$ 1 | ChangeNum$ All | DestinationZone$ Exile | Defined$ TargetedOwner | RememberChanged$ True | SubAbility$ DBPutLand | SpellDescription$ then exiles the top card of their library.
 SVar:DBPutLand:DB$ ChangeZone | ConditionDefined$ Remembered | ConditionPresent$ Land | Defined$ Remembered | DefinedDesc$ it | Origin$ Exile | Destination$ Battlefield | ForgetChanged$ True | SubAbility$ DBCast | SpellDescription$ If it's a land card, they put it onto the battlefield.
-SVar:DBCast:DB$ Play | Defined$ Remembered | DefinedDesc$ it | ValidSA$ Spell | WithoutManaCost$ True | Optional$ True | SubAbility$ DBCleanup | SpellDescription$ Otherwise, they may cast it without paying its mana cost.
+SVar:DBCast:DB$ Play | Defined$ Remembered | DefinedDesc$ it | ValidSA$ Spell | Controller$ RememberedOwner | WithoutManaCost$ True | Optional$ True | SubAbility$ DBCleanup | SpellDescription$ Otherwise, they may cast it without paying its mana cost.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 DeckHas:Ability$Sacrifice
 Oracle:Casualty 2 (As you cast this spell, you may sacrifice a creature with power 2 or greater. When you do, copy this spell and you may choose a new target for the copy.)\nThe owner of target nonenchantment permanent shuffles it into their library, then exiles the top card of their library. If it's a land card, they put it onto the battlefield. Otherwise, they may cast it without paying its mana cost.


### PR DESCRIPTION
Only small improvement until `setupNewTargets` gets wired up there.