### PR TITLE
TwoPiles streamline (+ CLB Split the Spoils)

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/TwoPilesEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/TwoPilesEffect.java
@@ -89,8 +89,6 @@ public class TwoPilesEffect extends SpellAbilityEffect {
                     title = Localizer.getInstance().getMessage("lblDivideCardIntoTwoPiles");
                 }
 
-                card.clearRemembered();
-
                 // first, separate the cards into piles
                 final CardCollectionView pile1 = separator.getController().chooseCardsForEffect(pool, sa, title, 0, size, false, null);
                 final CardCollection pile2 = new CardCollection(pool);
@@ -140,8 +138,15 @@ public class TwoPilesEffect extends SpellAbilityEffect {
                 }
 
 
+                if (sa.hasParam("RememberChosen")) {
+                    card.addRemembered(chosenPile);
+                }
+
                 // take action on the chosen pile
                 if (sa.hasParam("ChosenPile")) {
+                    if (card.hasRemembered()) {
+                        card.clearRemembered();
+                    }
                     card.addRemembered(chosenPile);
 
                     SpellAbility sub = sa.getAdditionalAbility("ChosenPile");
@@ -153,6 +158,9 @@ public class TwoPilesEffect extends SpellAbilityEffect {
 
                 // take action on the unchosen pile
                 if (sa.hasParam("UnchosenPile")) {
+                    if (card.hasRemembered()) {
+                        card.clearRemembered();
+                    }
                     card.addRemembered(unchosenPile);
 
                     SpellAbility sub = sa.getAdditionalAbility("UnchosenPile");

--- a/forge-game/src/main/java/forge/game/ability/effects/TwoPilesEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/TwoPilesEffect.java
@@ -148,17 +148,18 @@ public class TwoPilesEffect extends SpellAbilityEffect {
                     if (sub != null) {
                         AbilityUtils.resolve(sub);
                     }
+                    card.clearRemembered();
                 }
 
                 // take action on the unchosen pile
                 if (sa.hasParam("UnchosenPile")) {
-                    card.clearRemembered();
                     card.addRemembered(unchosenPile);
 
                     SpellAbility sub = sa.getAdditionalAbility("UnchosenPile");
                     if (sub != null) {
                         AbilityUtils.resolve(sub);
                     }
+                    card.clearRemembered();
                 }
             }
         }

--- a/forge-gui/res/cardsfolder/a/atris_oracle_of_half_truths.txt
+++ b/forge-gui/res/cardsfolder/a/atris_oracle_of_half_truths.txt
@@ -7,7 +7,6 @@ T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.S
 SVar:DBChoosePlayer:DB$ Pump | ValidTgts$ Opponent | IsCurse$ True | SubAbility$ DBPeekAndReveal
 SVar:DBPeekAndReveal:DB$ PeekAndReveal | Defined$ You | PeekAmount$ 3 | NoPeek$ True | NoReveal$ True | RememberPeeked$ True | SubAbility$ Separate
 SVar:Separate:DB$ TwoPiles | Defined$ You | Separator$ Targeted | Chooser$ You | DefinedCards$ Remembered | ChosenPile$ DBHand | UnchosenPile$ DBGrave | Zone$ Library | FaceDown$ One | StackDescription$ None
-SVar:DBHand:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Hand | SubAbility$ DBCleanup
-SVar:DBGrave:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Graveyard | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBHand:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Hand
+SVar:DBGrave:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Graveyard
 Oracle:Menace\nWhen Atris, Oracle of Half-Truths enters the battlefield, target opponent looks at the top three cards of your library and separates them into a face-down pile and a face-up pile. Put one pile into your hand and the other into your graveyard.

--- a/forge-gui/res/cardsfolder/b/boneyard_parley.txt
+++ b/forge-gui/res/cardsfolder/b/boneyard_parley.txt
@@ -1,9 +1,8 @@
 Name:Boneyard Parley
 ManaCost:5 B B
 Types:Sorcery
-A:SP$ ChangeZone | Cost$ 5 B B | Origin$ Graveyard | Destination$ Exile | TargetMin$ 0 | TargetMax$ 5 | TgtPrompt$ Select up to five target cards in graveyards | ValidTgts$ Card.Creature | RememberTargets$ True | SubAbility$ DBTwoPiles | AITgtOwnCards$ True | AIMinTgts$ 3 | SpellDescription$ Exile up to five target creature cards from graveyards. An opponent separates those cards into two piles. Put all cards from the pile of your choice onto the battlefield under your control and the rest into their owners' graveyards.
-SVar:DBTwoPiles:DB$ TwoPiles | Defined$ You | DefinedCards$ Remembered | Separator$ Opponent | ChosenPile$ DBBattlefield | UnchosenPile$ DBGrave
-SVar:DBBattlefield:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Battlefield | GainControl$ True | SubAbility$ DBCleanup
-SVar:DBGrave:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Graveyard | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Exile | TargetMin$ 0 | TargetMax$ 5 | TgtPrompt$ Select up to five target cards in graveyards | ValidTgts$ Card.Creature | SubAbility$ DBTwoPiles | AITgtOwnCards$ True | AIMinTgts$ 3 | SpellDescription$ Exile up to five target creature cards from graveyards. An opponent separates those cards into two piles. Put all cards from the pile of your choice onto the battlefield under your control and the rest into their owners' graveyards.
+SVar:DBTwoPiles:DB$ TwoPiles | Defined$ You | DefinedCards$ Targeted | Separator$ Opponent | ChosenPile$ DBBattlefield | UnchosenPile$ DBGrave
+SVar:DBBattlefield:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Battlefield | GainControl$ True
+SVar:DBGrave:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Graveyard
 Oracle:Exile up to five target creature cards from graveyards. An opponent separates those cards into two piles. Put all cards from the pile of your choice onto the battlefield under your control and the rest into their owners' graveyards.

--- a/forge-gui/res/cardsfolder/b/brilliant_ultimatum.txt
+++ b/forge-gui/res/cardsfolder/b/brilliant_ultimatum.txt
@@ -1,10 +1,9 @@
 Name:Brilliant Ultimatum
 ManaCost:W W U U U B B
 Types:Sorcery
-A:SP$ Dig | Cost$ W W U U U B B | Defined$ You | DigNum$ 5 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBTwoPiles | SpellDescription$ Exile the top five cards of your library. An opponent separates those cards into two piles. You may play lands and cast spells from one of those piles. If you cast a spell this way, you cast it without paying its mana cost.
-SVar:DBTwoPiles:DB$ TwoPiles | Defined$ You | DefinedCards$ Remembered | Separator$ Opponent | ChosenPile$ DBPlay | SubAbility$ DBCleanup
+A:SP$ Dig | Defined$ You | DigNum$ 5 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBTwoPiles | SpellDescription$ Exile the top five cards of your library. An opponent separates those cards into two piles. You may play lands and cast spells from one of those piles. If you cast a spell this way, you cast it without paying its mana cost.
+SVar:DBTwoPiles:DB$ TwoPiles | Defined$ You | DefinedCards$ Remembered | Separator$ Opponent | ChosenPile$ DBPlay
 SVar:DBPlay:DB$ Play | Defined$ Remembered | WithoutManaCost$ True | Optional$ True | Amount$ All
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:Y:Count$InYourLibrary
 SVar:NeedsToPlayVar:Y GE8
 Oracle:Exile the top five cards of your library. An opponent separates those cards into two piles. You may play lands and cast spells from one of those piles. If you cast a spell this way, you cast it without paying its mana cost.

--- a/forge-gui/res/cardsfolder/c/choose_your_demise.txt
+++ b/forge-gui/res/cardsfolder/c/choose_your_demise.txt
@@ -4,7 +4,6 @@ Types:Scheme
 T:Mode$ SetInMotion | ValidCard$ Card.Self | Execute$ TwoPiles | TriggerZones$ Command | TriggerDescription$ When you set this scheme in motion, look at the top four cards of your library and separate them into a face-down pile and a face-up pile. An opponent chooses one of those piles. Put the cards in that pile into your hand and the rest on the bottom of your library in any order.
 SVar:TwoPiles:DB$ PeekAndReveal | Defined$ You | PeekAmount$ 4 | NoReveal$ True | RememberPeeked$ True | SubAbility$ Separate | SpellDescription$ When you set this scheme in motion, look at the top four cards of your library and separate them into a face-down pile and a face-up pile. An opponent chooses one of those piles. Put the cards in that pile into your hand and the rest on the bottom of your library in any order.
 SVar:Separate:DB$ TwoPiles | Defined$ You | Separator$ You | Chooser$ Opponent | DefinedCards$ Remembered | ChosenPile$ DBHand | UnchosenPile$ DBLibraryBottom | Zone$ Library | FaceDown$ One | StackDescription$ None
-SVar:DBHand:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Hand | SubAbility$ DBCleanup
-SVar:DBLibraryBottom:DB$ ChangeZoneAll | ChangeType$ Card.IsRemembered | Origin$ Library | Destination$ Library | LibraryPosition$ -1 | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBHand:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Hand
+SVar:DBLibraryBottom:DB$ ChangeZoneAll | ChangeType$ Card.IsRemembered | Origin$ Library | Destination$ Library | LibraryPosition$ -1
 Oracle:When you set this scheme in motion, look at the top four cards of your library and separate them into a face-down pile and a face-up pile. An opponent chooses one of those piles. Put the cards in that pile into your hand and the rest on the bottom of your library in any order.

--- a/forge-gui/res/cardsfolder/e/epiphany_at_the_drownyard.txt
+++ b/forge-gui/res/cardsfolder/e/epiphany_at_the_drownyard.txt
@@ -1,11 +1,10 @@
 Name:Epiphany at the Drownyard
 ManaCost:X U
 Types:Instant
-A:SP$ PeekAndReveal | Cost$ X U | PeekAmount$ Y | RememberRevealed$ True | NoPeek$ True | SubAbility$ DBTwoPiles | SpellDescription$ Reveal the top X plus one cards of your library and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard.
+A:SP$ PeekAndReveal | PeekAmount$ Y | RememberRevealed$ True | NoPeek$ True | SubAbility$ DBTwoPiles | SpellDescription$ Reveal the top X plus one cards of your library and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard.
 SVar:DBTwoPiles:DB$ TwoPiles | Chooser$ Opponent | DefinedCards$ Remembered | Separator$ You | ChosenPile$ DBHand | UnchosenPile$ DBGrave | AILogic$ Worst
-SVar:DBHand:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Hand | SubAbility$ DBCleanup
-SVar:DBGrave:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Graveyard | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBHand:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Hand
+SVar:DBGrave:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Graveyard
 SVar:Y:Count$xPaid/Plus.1
 SVar:X:Count$xPaid
 DeckHints:Ability$Delirium

--- a/forge-gui/res/cardsfolder/f/fact_or_fiction.txt
+++ b/forge-gui/res/cardsfolder/f/fact_or_fiction.txt
@@ -3,7 +3,6 @@ ManaCost:3 U
 Types:Instant
 A:SP$ PeekAndReveal | PeekAmount$ 5 | RememberRevealed$ True | NoPeek$ True | SubAbility$ DBTwoPiles | SpellDescription$ Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.
 SVar:DBTwoPiles:DB$ TwoPiles | Defined$ You | DefinedCards$ Remembered | Separator$ Opponent | ChosenPile$ DBHand | UnchosenPile$ DBGrave | StackDescription$ An opponent separates those cards into two piles. {p:You} puts one pile into their hand and the other into their graveyard.
-SVar:DBHand:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Hand | SubAbility$ DBCleanup
-SVar:DBGrave:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Graveyard | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBHand:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Hand
+SVar:DBGrave:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Graveyard
 Oracle:Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.

--- a/forge-gui/res/cardsfolder/f/fight_or_flight.txt
+++ b/forge-gui/res/cardsfolder/f/fight_or_flight.txt
@@ -3,8 +3,7 @@ ManaCost:3 W
 Types:Enchantment
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ Player.Opponent | Execute$ TrigTwoPile | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of combat on each opponent's turn, separate all creatures that player controls into two piles. Only creatures in the pile of their choice can attack this turn.
 SVar:TrigTwoPile:DB$ TwoPiles | Defined$ TriggeredPlayer | Chooser$ TriggeredPlayer | ValidCards$ Creature | Zone$ Battlefield | Separator$ You | ChosenPile$ DBEffect
-SVar:DBEffect:DB$ Effect | RememberObjects$ Remembered | StaticAbilities$ STCantAttack | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBEffect:DB$ Effect | RememberObjects$ Remembered | StaticAbilities$ STCantAttack
 SVar:STCantAttack:Mode$ CantAttack | EffectZone$ Command | ValidCard$ Creature.IsNotRemembered | Description$ Only creatures in the pile of their choice can attack this turn.
 SVar:NonStackingAttachEffect:True
 Oracle:At the beginning of combat on each opponent's turn, separate all creatures that player controls into two piles. Only creatures in the pile of their choice can attack this turn.

--- a/forge-gui/res/cardsfolder/f/fortunes_favor.txt
+++ b/forge-gui/res/cardsfolder/f/fortunes_favor.txt
@@ -1,11 +1,10 @@
 Name:Fortune's Favor
 ManaCost:3 U
 Types:Instant
-A:SP$ PeekAndReveal | Cost$ 3 U | Defined$ You | PeekAmount$ 4 | NoPeek$ True | NoReveal$ True | RememberPeeked$ True | SubAbility$ Separate | SpellDescription$ Target opponent looks at the top four cards of your library and separates them into a face-down pile and a face-up pile. Put one pile into your hand and the other into your graveyard.
+A:SP$ PeekAndReveal | PeekAmount$ 4 | NoPeek$ True | NoReveal$ True | RememberPeeked$ True | SubAbility$ Separate | SpellDescription$ Target opponent looks at the top four cards of your library and separates them into a face-down pile and a face-up pile. Put one pile into your hand and the other into your graveyard.
 SVar:Separate:DB$ TwoPiles | Defined$ You | Separator$ TargetedPlayer | Chooser$ You | ValidTgts$ Opponent | DefinedCards$ Remembered | ChosenPile$ DBHand | UnchosenPile$ DBGrave | Zone$ Library | FaceDown$ One | StackDescription$ None
-SVar:DBHand:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Hand | SubAbility$ DBCleanup
-SVar:DBGrave:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Graveyard | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBHand:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Hand
+SVar:DBGrave:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Graveyard
 DeckHints:Ability$Delirium
 DeckHas:Ability$Graveyard
 Oracle:Target opponent looks at the top four cards of your library and separates them into a face-down pile and a face-up pile. Put one pile into your hand and the other into your graveyard.

--- a/forge-gui/res/cardsfolder/j/jace_architect_of_thought.txt
+++ b/forge-gui/res/cardsfolder/j/jace_architect_of_thought.txt
@@ -8,7 +8,7 @@ SVar:JacePump:DB$ Pump | Defined$ TriggeredAttacker | NumAtt$ -1
 A:AB$ PeekAndReveal | Cost$ SubCounter<2/LOYALTY> | Planeswalker$ True | PeekAmount$ 3 | RememberRevealed$ True | NoPeek$ True | SubAbility$ DBTwoPiles | SpellDescription$ Reveal the top three cards of your library. An opponent separates them into two piles. Put one pile into your hand and the other on the bottom of your library in any order.
 SVar:DBTwoPiles:DB$ TwoPiles | Defined$ You | DefinedCards$ Remembered | Separator$ Opponent | ChosenPile$ DBHand | UnchosenPile$ DBLibraryBottom
 SVar:DBHand:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Hand
-SVar:DBLibraryBottom:DB$ ChangeZoneAll | ChangeType$ Card.IsRemembered | Origin$ Library | Destination$ Library | LibraryPosition$ -1 | SubAbility$ DBCleanup
+SVar:DBLibraryBottom:DB$ ChangeZoneAll | ChangeType$ Card.IsRemembered | Origin$ Library | Destination$ Library | LibraryPosition$ -1
 A:AB$ RepeatEach | Cost$ SubCounter<8/LOYALTY> | Planeswalker$ True | Ultimate$ True | RepeatPlayers$ Player | RepeatSubAbility$ DBJaceExile | SubAbility$ DBPlayIt | SpellDescription$ For each player, search that player's library for a nonland card and exile it, then that player shuffles. You may cast those cards without paying their mana costs.
 SVar:DBJaceExile:DB$ ChangeZone | Origin$ Library | Destination$ Exile | DefinedPlayer$ Remembered | Chooser$ You | ChangeType$ Card.nonLand | ChangeNum$ 1 | Imprint$ True | Shuffle$ True
 SVar:DBPlayIt:DB$ Play | Defined$ Imprinted | Amount$ All | Controller$ You | WithoutManaCost$ True | ValidSA$ Spell | Optional$ True | RememberPlayed$ True | SubAbility$ DBCleanup

--- a/forge-gui/res/cardsfolder/l/liliana_of_the_veil.txt
+++ b/forge-gui/res/cardsfolder/l/liliana_of_the_veil.txt
@@ -5,6 +5,6 @@ Loyalty:3
 A:AB$ Discard | Cost$ AddCounter<1/LOYALTY> | NumCards$ 1 | Mode$ TgtChoose | Defined$ Player | Planeswalker$ True | SpellDescription$ Each player discards a card.
 A:AB$ Sacrifice | Cost$ SubCounter<2/LOYALTY> | ValidTgts$ Player | SacValid$ Creature | SacMessage$ Creature | Planeswalker$ True | SpellDescription$ Target player sacrifices a creature.
 A:AB$ TwoPiles | Cost$ SubCounter<6/LOYALTY> | ValidTgts$ Player | TgtPrompt$ Select target player | Separator$ You | ChosenPile$ DBSacAll | ValidCards$ Permanent | Zone$ Battlefield | Planeswalker$ True | Ultimate$ True | AILogic$ Worst | SpellDescription$ Separate all permanents target player controls into two piles. That player sacrifices all permanents in the pile of their choice.
-SVar:DBSacAll:DB$ SacrificeAll | ValidCards$ Permanent.IsRemembered | SubAbility$ Cleanup
-SVar:Cleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBSacAll:DB$ SacrificeAll | ValidCards$ Permanent.IsRemembered
+DeckHas:Ability$Discard|Sacrifice
 Oracle:[+1]: Each player discards a card.\n[-2]: Target player sacrifices a creature.\n[-6]: Separate all permanents target player controls into two piles. That player sacrifices all permanents in the pile of their choice.

--- a/forge-gui/res/cardsfolder/m/make_an_example.txt
+++ b/forge-gui/res/cardsfolder/m/make_an_example.txt
@@ -5,5 +5,5 @@ A:SP$ RepeatEach | RepeatPlayers$ Opponent | RepeatSubAbility$ DBTwoPiles | SubA
 SVar:DBTwoPiles:DB$ TwoPiles | Defined$ Remembered | Separator$ Remembered | Chooser$ You | ChosenPile$ DBImprint | ValidCards$ Creature.RememberedPlayerCtrl | Zone$ Battlefield
 SVar:DBImprint:DB$ Pump | ImprintCards$ Remembered
 SVar:DBSac:DB$ SacrificeAll | Defined$ Imprinted | SubAbility$ DBCleanup | StackDescription$ Each opponent sacrifices the creatures in their chosen pile. | SpellDescription$ Each opponent sacrifices the creatures in their chosen pile. (Piles can be empty.)
-SVar:DBCleanup:DB$ Cleanup | ClearImprinted$ True | ClearRemembered$ True
+SVar:DBCleanup:DB$ Cleanup | ClearImprinted$ True
 Oracle:Each opponent separates the creatures they control into two piles. For each opponent, you choose one of their piles. Each opponent sacrifices the creatures in their chosen pile. (Piles can be empty.)

--- a/forge-gui/res/cardsfolder/m/make_an_example.txt
+++ b/forge-gui/res/cardsfolder/m/make_an_example.txt
@@ -2,8 +2,7 @@ Name:Make an Example
 ManaCost:3 B
 Types:Sorcery
 A:SP$ RepeatEach | RepeatPlayers$ Opponent | RepeatSubAbility$ DBTwoPiles | SubAbility$ DBSac | SpellDescription$ Each opponent separates the creatures they control into two piles. For each opponent, you choose one of their piles.
-SVar:DBTwoPiles:DB$ TwoPiles | Defined$ Remembered | Separator$ Remembered | Chooser$ You | ChosenPile$ DBImprint | ValidCards$ Creature.RememberedPlayerCtrl | Zone$ Battlefield
-SVar:DBImprint:DB$ Pump | ImprintCards$ Remembered
-SVar:DBSac:DB$ SacrificeAll | Defined$ Imprinted | SubAbility$ DBCleanup | StackDescription$ Each opponent sacrifices the creatures in their chosen pile. | SpellDescription$ Each opponent sacrifices the creatures in their chosen pile. (Piles can be empty.)
-SVar:DBCleanup:DB$ Cleanup | ClearImprinted$ True
+SVar:DBTwoPiles:DB$ TwoPiles | Defined$ Remembered | Separator$ Remembered | Chooser$ You | RememberChosen$ True | ValidCards$ Creature.RememberedPlayerCtrl | Zone$ Battlefield
+SVar:DBSac:DB$ SacrificeAll | Defined$ Remembered | SubAbility$ DBCleanup | StackDescription$ Each opponent sacrifices the creatures in their chosen pile. | SpellDescription$ Each opponent sacrifices the creatures in their chosen pile. (Piles can be empty.)
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Each opponent separates the creatures they control into two piles. For each opponent, you choose one of their piles. Each opponent sacrifices the creatures in their chosen pile. (Piles can be empty.)

--- a/forge-gui/res/cardsfolder/p/phyrexian_portal.txt
+++ b/forge-gui/res/cardsfolder/p/phyrexian_portal.txt
@@ -1,11 +1,10 @@
 Name:Phyrexian Portal
 ManaCost:3
 Types:Artifact
-A:AB$ Dig | Cost$ 3 | ValidTgts$ Opponent | TgtPrompt$ Select target opponent | Defined$ You | DigNum$ 10 | RememberRevealed$ True | NoLooking$ True | NoMove$ True | Choser$ Targeted | ConditionCheckSVar$ X | ConditionSVarCompare$ GE10 | SubAbility$ DBTwoPiles | SpellDescription$ If your library has ten or more cards in it, target opponent looks at the top ten cards of your library and separates them into two face-down piles. Exile one of those piles. Search the other pile for a card, put it into your hand, then shuffle the rest of that pile into your library. | StackDescription$ SpellDescription
-SVar:DBTwoPiles:DB$ TwoPiles | Defined$ You | DefinedCards$ Remembered | Separator$ Targeted | FaceDown$ True | ConditionCheckSVar$ X | ConditionSVarCompare$ GE10 | ChosenPile$ DBHand | UnchosenPile$ DBExile | SubAbility$ DBCleanup
+A:AB$ Dig | Cost$ 3 | ValidTgts$ Opponent | DigNum$ 10 | RememberRevealed$ True | NoLooking$ True | NoMove$ True | Choser$ Targeted | ConditionCheckSVar$ X | ConditionSVarCompare$ GE10 | SubAbility$ DBTwoPiles | SpellDescription$ If your library has ten or more cards in it, target opponent looks at the top ten cards of your library and separates them into two face-down piles. Exile one of those piles. Search the other pile for a card, put it into your hand, then shuffle the rest of that pile into your library. | StackDescription$ SpellDescription
+SVar:DBTwoPiles:DB$ TwoPiles | Defined$ You | DefinedCards$ Remembered | Separator$ Targeted | FaceDown$ True | ConditionCheckSVar$ X | ConditionSVarCompare$ GE10 | ChosenPile$ DBHand | UnchosenPile$ DBExile
 SVar:DBHand:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Hand | ChangeType$ Card | ChangeNum$ 1 | ChooseFromDefined$ True | Mandatory$ True | Shuffle$ True
 SVar:DBExile:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Exile
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 # This variable may be incorrect if the controller changes while the ability is on the stack
 SVar:X:Count$InYourLibrary
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/r/raging_river.txt
+++ b/forge-gui/res/cardsfolder/r/raging_river.txt
@@ -10,11 +10,10 @@ SVar:DBDefLeftRight:DB$ TwoPiles | Defined$ Remembered | Separator$ Remembered |
 SVar:DBDefLeftPile:DB$ Animate | Defined$ ValidCommand Effect.namedRaging River Left+IsImprinted | ImprintCards$ Remembered | Duration$ Permanent | SubAbility$ DBLeftPump
 SVar:DBDefRightPile:DB$ Animate | Defined$ ValidCommand Effect.namedRaging River Right+IsImprinted | ImprintCards$ Remembered | Duration$ Permanent | SubAbility$ DBRightPump
 SVar:DBClearImprinted:DB$ Cleanup | ClearImprinted$ True
-SVar:DBAtkLeftRight:DB$ TwoPiles | Defined$ You | Separator$ You | ValidCards$ Creature.attacking+YouCtrl | Zone$ Battlefield | LeftRightPile$ True | ChosenPile$ DBAtkLeftPile | UnchosenPile$ DBAtkRightPile | AILogic$ Random | SubAbility$ DBCleanup
+SVar:DBAtkLeftRight:DB$ TwoPiles | Defined$ You | Separator$ You | ValidCards$ Creature.attacking+YouCtrl | Zone$ Battlefield | LeftRightPile$ True | ChosenPile$ DBAtkLeftPile | UnchosenPile$ DBAtkRightPile | AILogic$ Random
 SVar:DBAtkLeftPile:DB$ Animate | Defined$ ValidCommand Effect.namedRaging River Left | RememberObjects$ RememberedCard | Duration$ Permanent | SubAbility$ DBLeftPump
 SVar:DBAtkRightPile:DB$ Animate | Defined$ ValidCommand Effect.namedRaging River Right | RememberObjects$ RememberedCard | Duration$ Permanent | SubAbility$ DBRightPump
 SVar:DBLeftPump:DB$ Pump | Defined$ Remembered | KW$ "Left" pile | Duration$ UntilEndOfCombat
 SVar:DBRightPump:DB$ Pump | Defined$ Remembered | KW$ "Right" pile | Duration$ UntilEndOfCombat
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:PlayMain1:TRUE
 Oracle:Whenever one or more creatures you control attack, each defending player divides all creatures without flying they control into a "left" pile and a "right" pile. Then, for each attacking creature you control, choose "left" or "right." That creature can't be blocked this combat except by creatures with flying and creatures in a pile with the chosen label.

--- a/forge-gui/res/cardsfolder/s/sphinx_of_uthuun.txt
+++ b/forge-gui/res/cardsfolder/s/sphinx_of_uthuun.txt
@@ -4,9 +4,8 @@ Types:Creature Sphinx
 PT:5/6
 K:Flying
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChangeZone | TriggerDescription$ When CARDNAME enters the battlefield, reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.
-SVar:TrigChangeZone:DB$ PeekAndReveal | PeekAmount$ 5 | NoPeek$ True | SubAbility$ DBTwoPiles | SpellDescription$ Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.
+SVar:TrigChangeZone:DB$ PeekAndReveal | PeekAmount$ 5 | NoPeek$ True | RememberRevealed$ True | SubAbility$ DBTwoPiles | SpellDescription$ Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.
 SVar:DBTwoPiles:DB$ TwoPiles | Defined$ You | DefinedCards$ Remembered | Separator$ Opponent | ChosenPile$ DBHand | UnchosenPile$ DBGrave
 SVar:DBHand:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Hand
-SVar:DBGrave:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Graveyard | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBGrave:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Graveyard
 Oracle:Flying\nWhen Sphinx of Uthuun enters the battlefield, reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.

--- a/forge-gui/res/cardsfolder/s/stand_or_fall.txt
+++ b/forge-gui/res/cardsfolder/s/stand_or_fall.txt
@@ -3,9 +3,7 @@ ManaCost:3 R
 Types:Enchantment
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | Execute$ RepeatPlayer | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of combat on your turn, for each defending player, separate all creatures that player controls into two piles and that player chooses one. Only creatures in the chosen piles can block this turn.
 SVar:RepeatPlayer:DB$ RepeatEach | RepeatPlayers$ Opponent | RepeatSubAbility$ DBTwoPiles | SubAbility$ DBOnlyBlock
-SVar:DBTwoPiles:DB$ TwoPiles | Defined$ Player.IsRemembered | Chooser$ Player.IsRemembered | Zone$ Battlefield | ValidCards$ Creature.RememberedPlayerCtrl | Separator$ You | ChosenPile$ DBRemember | AILogic$ Best
-SVar:DBRemember:DB$ Pump | ImprintCards$ Remembered
-SVar:DBOnlyBlock:DB$ PumpAll | KW$ HIDDEN CARDNAME can't block. | ValidCards$ Creature.OppCtrl+IsNotImprinted | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearImprinted$ True
+SVar:DBTwoPiles:DB$ TwoPiles | Defined$ Player.IsRemembered | Chooser$ Player.IsRemembered | Zone$ Battlefield | ValidCards$ Creature.RememberedPlayerCtrl | Separator$ You | ChosenPile$ DBOnlyBlock | AILogic$ Best
+SVar:DBOnlyBlock:DB$ PumpAll | KW$ HIDDEN CARDNAME can't block. | ValidCards$ Creature.RememberedPlayerCtrl+IsNotRemembered
 SVar:PlayMain1:TRUE
 Oracle:At the beginning of combat on your turn, for each defending player, separate all creatures that player controls into two piles and that player chooses one. Only creatures in the chosen piles can block this turn.

--- a/forge-gui/res/cardsfolder/s/stand_or_fall.txt
+++ b/forge-gui/res/cardsfolder/s/stand_or_fall.txt
@@ -6,6 +6,6 @@ SVar:RepeatPlayer:DB$ RepeatEach | RepeatPlayers$ Opponent | RepeatSubAbility$ D
 SVar:DBTwoPiles:DB$ TwoPiles | Defined$ Player.IsRemembered | Chooser$ Player.IsRemembered | Zone$ Battlefield | ValidCards$ Creature.RememberedPlayerCtrl | Separator$ You | ChosenPile$ DBRemember | AILogic$ Best
 SVar:DBRemember:DB$ Pump | ImprintCards$ Remembered
 SVar:DBOnlyBlock:DB$ PumpAll | KW$ HIDDEN CARDNAME can't block. | ValidCards$ Creature.OppCtrl+IsNotImprinted | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearImprinted$ True
+SVar:DBCleanup:DB$ Cleanup | ClearImprinted$ True
 SVar:PlayMain1:TRUE
 Oracle:At the beginning of combat on your turn, for each defending player, separate all creatures that player controls into two piles and that player chooses one. Only creatures in the chosen piles can block this turn.

--- a/forge-gui/res/cardsfolder/s/stand_or_fall.txt
+++ b/forge-gui/res/cardsfolder/s/stand_or_fall.txt
@@ -3,7 +3,8 @@ ManaCost:3 R
 Types:Enchantment
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | Execute$ RepeatPlayer | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of combat on your turn, for each defending player, separate all creatures that player controls into two piles and that player chooses one. Only creatures in the chosen piles can block this turn.
 SVar:RepeatPlayer:DB$ RepeatEach | RepeatPlayers$ Opponent | RepeatSubAbility$ DBTwoPiles | SubAbility$ DBOnlyBlock
-SVar:DBTwoPiles:DB$ TwoPiles | Defined$ Player.IsRemembered | Chooser$ Player.IsRemembered | Zone$ Battlefield | ValidCards$ Creature.RememberedPlayerCtrl | Separator$ You | ChosenPile$ DBOnlyBlock | AILogic$ Best
-SVar:DBOnlyBlock:DB$ PumpAll | KW$ HIDDEN CARDNAME can't block. | ValidCards$ Creature.RememberedPlayerCtrl+IsNotRemembered
+SVar:DBTwoPiles:DB$ TwoPiles | Chooser$ Remembered | Zone$ Battlefield | ValidCards$ Creature.RememberedPlayerCtrl | Separator$ You | RememberChosen$ True | AILogic$ Best
+SVar:DBOnlyBlock:DB$ PumpAll | KW$ HIDDEN CARDNAME can't block. | ValidCards$ Creature.OppCtrl+IsNotRemembered | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:PlayMain1:TRUE
 Oracle:At the beginning of combat on your turn, for each defending player, separate all creatures that player controls into two piles and that player chooses one. Only creatures in the chosen piles can block this turn.

--- a/forge-gui/res/cardsfolder/s/steam_augury.txt
+++ b/forge-gui/res/cardsfolder/s/steam_augury.txt
@@ -3,7 +3,6 @@ ManaCost:2 U R
 Types:Instant
 A:SP$ PeekAndReveal | PeekAmount$ 5 | RememberRevealed$ True | NoPeek$ True | SubAbility$ DBTwoPiles | SpellDescription$ Reveal the top five cards of your library and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard.
 SVar:DBTwoPiles:DB$ TwoPiles | Chooser$ Opponent | DefinedCards$ Remembered | Separator$ You | ChosenPile$ DBHand | UnchosenPile$ DBGrave | AILogic$ Worst
-SVar:DBHand:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Hand | SubAbility$ DBCleanup
-SVar:DBGrave:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Graveyard | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBHand:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Hand
+SVar:DBGrave:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Graveyard
 Oracle:Reveal the top five cards of your library and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard.

--- a/forge-gui/res/cardsfolder/u/unesh_criosphinx_sovereign.txt
+++ b/forge-gui/res/cardsfolder/u/unesh_criosphinx_sovereign.txt
@@ -8,7 +8,6 @@ T:Mode$ ChangesZone | ValidCard$ Card.Self,Card.Sphinx+Other+YouCtrl | Origin$ A
 SVar:TrigChangeZone:DB$ PeekAndReveal | PeekAmount$ 4 | NoPeek$ True | RememberRevealed$ True | SubAbility$ DBTwoPiles | SpellDescription$ Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.
 SVar:DBTwoPiles:DB$ TwoPiles | Defined$ You | DefinedCards$ Remembered | Separator$ Opponent | ChosenPile$ DBHand | UnchosenPile$ DBGrave
 SVar:DBHand:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Hand
-SVar:DBGrave:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Graveyard | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBGrave:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Graveyard
 SVar:BuffedBy:Sphinx
 Oracle:Flying\nSphinx spells you cast cost {2} less to cast.\nWhenever Unesh, Criosphinx Sovereign or another Sphinx enters the battlefield under your control, reveal the top four cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.

--- a/forge-gui/res/cardsfolder/u/urza_academy_headmaster.txt
+++ b/forge-gui/res/cardsfolder/u/urza_academy_headmaster.txt
@@ -50,7 +50,7 @@ SVar:Mill8M:DB$ Mill | ValidTgts$ Player | TgtPrompt$ Select target player | Num
 SVar:Dig9M:DB$ PeekAndReveal | PeekAmount$ 5 | NoPeek$ True | RememberRevealed$ True | SubAbility$ DBTwoPiles9M | SpellDescription$ Reveal the top five cards of your library. An opponent separates them into two piles. Put one pile into your hand and the other on the bottom of your library in any order.
 SVar:DBTwoPiles9M:DB$ TwoPiles | Defined$ You | DefinedCards$ Remembered | Separator$ Opponent | ChosenPile$ DBHand9M | UnchosenPile$ DBLibraryBottom9M
 SVar:DBHand9M:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Hand
-SVar:DBLibraryBottom9M:DB$ ChangeZoneAll | ChangeType$ Card.IsRemembered | Origin$ Library | Destination$ Library | LibraryPosition$ -1 | SubAbility$ DBCleanup
+SVar:DBLibraryBottom9M:DB$ ChangeZoneAll | ChangeType$ Card.IsRemembered | Origin$ Library | Destination$ Library | LibraryPosition$ -1
 SVar:Exile10M:DB$ ChangeZone | ValidTgts$ Permanent | TgtPrompt$ Select target permanent | Origin$ Battlefield | Destination$ Exile | SpellDescription$ Exile target permanent.
 SVar:Reveal11M:DB$ PeekAndReveal | PeekAmount$ 5 | NoPeek$ True | RememberRevealed$ True | SubAbility$ DBChangeCreatures11M | SpellDescription$ Reveal the top five cards of your library. You may put all creature cards and/or land cards from among them into your hand. Put the rest into your graveyard.
 SVar:DBChangeCreatures11M:DB$ ChangeZoneAll | ChangeType$ Card.Creature+IsRemembered | Origin$ Library | Destination$ Hand | Optional$ True | OptionQuestion$ Put all creature cards into your hand? | ForgetChanged$ True | SubAbility$ DBChangeLands11M

--- a/forge-gui/res/cardsfolder/upcoming/split_the_spoils.txt
+++ b/forge-gui/res/cardsfolder/upcoming/split_the_spoils.txt
@@ -1,0 +1,9 @@
+Name:Split the Spoils
+ManaCost:2 G
+Types:Sorcery
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Exile | ValidTgts$ Permanent.YouOwn | TargetMin$ 0 | TargetMax$ 5 | TgtPrompt$ Select up to five target permanent cards from your graveyard | SubAbility$ DBTwoPiles | SpellDescription$ Exile up to five target permanent cards from your graveyard
+SVar:DBTwoPiles:DB$ TwoPiles | Defined$ Opponent | DefinedCards$ Targeted | Separator$ You | ChosenPile$ DBHand | UnchosenPile$ DBGrave | AILogic$ Worst | StackDescription$ {p:You} separates them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. | SpellDescription$ and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. (Piles can be empty.)
+SVar:DBBattlefield:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Hand
+SVar:DBGrave:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Graveyard
+DeckHas:Ability$Graveyard
+Oracle:Exile up to five target permanent cards from your graveyard and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. (Piles can be empty.)

--- a/forge-gui/res/cardsfolder/upcoming/split_the_spoils.txt
+++ b/forge-gui/res/cardsfolder/upcoming/split_the_spoils.txt
@@ -3,7 +3,7 @@ ManaCost:2 G
 Types:Sorcery
 A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Exile | ValidTgts$ Permanent.YouOwn | TargetMin$ 0 | TargetMax$ 5 | TgtPrompt$ Select up to five target permanent cards from your graveyard | SubAbility$ DBTwoPiles | SpellDescription$ Exile up to five target permanent cards from your graveyard
 SVar:DBTwoPiles:DB$ TwoPiles | Defined$ Opponent | DefinedCards$ Targeted | Separator$ You | ChosenPile$ DBHand | UnchosenPile$ DBGrave | AILogic$ Worst | StackDescription$ {p:You} separates them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. | SpellDescription$ and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. (Piles can be empty.)
-SVar:DBBattlefield:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Hand
+SVar:DBHand:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Hand
 SVar:DBGrave:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Graveyard
 DeckHas:Ability$Graveyard
 Oracle:Exile up to five target permanent cards from your graveyard and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. (Piles can be empty.)

--- a/forge-gui/res/cardsfolder/upcoming/split_the_spoils.txt
+++ b/forge-gui/res/cardsfolder/upcoming/split_the_spoils.txt
@@ -2,7 +2,7 @@ Name:Split the Spoils
 ManaCost:2 G
 Types:Sorcery
 A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Exile | ValidTgts$ Permanent.YouOwn | TargetMin$ 0 | TargetMax$ 5 | TgtPrompt$ Select up to five target permanent cards from your graveyard | SubAbility$ DBTwoPiles | SpellDescription$ Exile up to five target permanent cards from your graveyard
-SVar:DBTwoPiles:DB$ TwoPiles | Defined$ Opponent | DefinedCards$ Targeted | Separator$ You | ChosenPile$ DBHand | UnchosenPile$ DBGrave | AILogic$ Worst | StackDescription$ {p:You} separates them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. | SpellDescription$ and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. (Piles can be empty.)
+SVar:DBTwoPiles:DB$ TwoPiles | Chooser$ Opponent | DefinedCards$ Targeted | Separator$ You | ChosenPile$ DBHand | UnchosenPile$ DBGrave | AILogic$ Worst | StackDescription$ {p:You} separates them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. | SpellDescription$ and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. (Piles can be empty.)
 SVar:DBHand:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Hand
 SVar:DBGrave:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Graveyard
 DeckHas:Ability$Graveyard


### PR DESCRIPTION
Seems more straightforward to always handle cleaning up remembering after pile subabilities similar to RepeatEach... might be nice to add a further param to avoid the host clear remembered for the few here that are messing with imprinted, but that is for another day.

-closes #944 