### PR TITLE
YSNC: Celestial Vault and support

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/DraftEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DraftEffect.java
@@ -26,12 +26,12 @@ import java.util.*;
          final StringBuilder sb = new StringBuilder();
 
          sb.append(player).append(" drafts a card from ").append(source.getName()).append("'s spellbook");
-         if (zone.equals("Hand")) {
+         if (zone.equals(ZoneType.Hand)) {
              sb.append(".");
-         } else if (zone.equals("Battlefield")) {
+         } else if (zone.equals(ZoneType.Battlefield)) {
              sb.append(" and puts it onto the battlefield.");
-         } else if (zone.equals("Exile")) {
-             sb.append(", then exiles it.");
+         } else if (zone.equals(ZoneType.Exile)) {
+             sb.append(sa.hasParam("ExileFaceDown") ? " and exiles it face down." : ", then exiles it.");
          }
 
          return sb.toString();

--- a/forge-game/src/main/java/forge/game/ability/effects/DraftEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DraftEffect.java
@@ -73,6 +73,14 @@ import java.util.*;
          final CardZoneTable triggerList = new CardZoneTable();
          for (final Card c : drafted) {
              Card made = game.getAction().moveTo(zone, c, sa, moveParams);
+             if (zone.equals(ZoneType.Exile)) {
+                 source.addExiledCard(made);
+                 made.setExiledWith(source);
+                 made.setExiledBy(source.getController());
+                 if (sa.hasParam("ExileFaceDown")) {
+                     made.turnFaceDown(true);
+                 }
+             }
              if (c != null) {
                  triggerList.put(ZoneType.None, made.getZone().getZoneType(), made);
              }

--- a/forge-gui/res/cardsfolder/upcoming/celestial_vault.txt
+++ b/forge-gui/res/cardsfolder/upcoming/celestial_vault.txt
@@ -1,0 +1,10 @@
+Name:Celestial Vault
+ManaCost:1 W
+Types:Artifact
+A:AB$ Draft | Cost$ W T | Spellbook$ Angel of Destiny,Resplendent Angel,Angel of Vitality,Righteous Valkyrie,Angel of Invention,Angel of Sanctions,Valkyrie Harbinger,Emancipation Angel,Youthful Valkyrie,Resplendent Marshal,Enduring Angel,Sigardian Savior,Serra Angel,Stalwart Valkyrie,Segovian Angel | Zone$ Exile | ExileFaceDown$ True | RememberDrafted$ True | SpellDescription$ Draft a card from CARDNAME's spellbook and exile it face down.
+A:AB$ ChangeZoneAll | Cost$ 1 Sac<1/CARDNAME> | Origin$ Exile | Destination$ Hand | ChangeType$ Card.IsRemembered+ExiledWithSource | SpellDescription$ Put each card exiled with CARDNAME into your hand.
+T:Mode$ ChangesZone | Origin$ Exile | Destination$ Any | Static$ True | ValidCard$ Card.IsRemembered+ExiledWithSource | Execute$ DBForget
+SVar:DBForget:DB$ Pump | ForgetObjects$ TriggeredCard
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | Static$ True | ValidCard$ Card.Self | Execute$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:{W}, {T}: Draft a card from Celestial Vault's spellbook and exile it face down.\n{1}, Sacrifice Celestial Vault: Put each card exiled with Celestial Vault into your hand.

--- a/forge-gui/res/cardsfolder/upcoming/celestial_vault.txt
+++ b/forge-gui/res/cardsfolder/upcoming/celestial_vault.txt
@@ -7,4 +7,5 @@ T:Mode$ ChangesZone | Origin$ Exile | Destination$ Any | Static$ True | ValidCar
 SVar:DBForget:DB$ Pump | ForgetObjects$ TriggeredCard
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | Static$ True | ValidCard$ Card.Self | Execute$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+DeckHas:Type$Angel & Ability$LifeGain|Token|Counters
 Oracle:{W}, {T}: Draft a card from Celestial Vault's spellbook and exile it face down.\n{1}, Sacrifice Celestial Vault: Put each card exiled with Celestial Vault into your hand.


### PR DESCRIPTION
- closes #777 

I have wondered if Draft stuff should start in None zone, then go to Hand, THEN go to the zone specified by cards like this

Stinking digital-only no CR support :(