### PR TITLE
support showing back face on shops and loot on adventure mode

### DIFF
--- a/forge-gui-mobile/src/forge/assets/ImageCache.java
+++ b/forge-gui-mobile/src/forge/assets/ImageCache.java
@@ -281,7 +281,6 @@ public class ImageCache {
         }
         if (!others && cardsLoaded.size() > maxCardCapacity) {
             unloadCardTextures(Forge.getAssets().manager());
-            return null;
         }
         String fileName = file.getPath();
         //load to assetmanager


### PR DESCRIPTION
- for mobile backport, hover the card and left click to switch the tooltip
- for android, double tap the image before holdtouching to switch tooltip