### PR TITLE
fix LibGDXImageFetcher not deleting .tmp files

### DIFF
--- a/forge-core/src/main/java/forge/ImageKeys.java
+++ b/forge-core/src/main/java/forge/ImageKeys.java
@@ -155,20 +155,8 @@ public final class ImageKeys {
                     cachedCards.put(filename, file);
                     return file;
                 }
-                // if there's a 1st art variant try with it for .fullborder images
-                file = findFile(dir, fullborderFile.replaceAll("[0-9]*.fullborder", "1.fullborder"));
-                if (file != null) {
-                    cachedCards.put(filename, file);
-                    return file;
-                }
                 // if there's an art variant try without it for .full images
                 file = findFile(dir, filename.replaceAll("[0-9].full",".full"));
-                if (file != null) {
-                    cachedCards.put(filename, file);
-                    return file;
-                }
-                // if there's a 1st art variant try with it for .full images
-                file = findFile(dir, filename.replaceAll("[0-9]*.full", "1.full"));
                 if (file != null) {
                     cachedCards.put(filename, file);
                     return file;

--- a/forge-gui-mobile/src/forge/util/LibGDXImageFetcher.java
+++ b/forge-gui-mobile/src/forge/util/LibGDXImageFetcher.java
@@ -3,6 +3,7 @@ package forge.util;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
@@ -42,9 +43,11 @@ public class LibGDXImageFetcher extends ImageFetcher {
             FileHandle destFile = new FileHandle(newdespath + ".tmp");
             System.out.println(newdespath);
             destFile.parent().mkdirs();
-
+            OutputStream out = new FileOutputStream(destFile.file());
             // Conversion to JPEG will be handled differently depending on the platform
-            Forge.getDeviceAdapter().convertToJPEG(is, new FileOutputStream(destFile.file()));
+            Forge.getDeviceAdapter().convertToJPEG(is, out);
+            is.close();
+            out.close(); //close outputstream before destfile.moveto so it can delete the tmp file internally
             destFile.moveTo(new FileHandle(newdespath));
 
             System.out.println("Saved image to " + newdespath);


### PR DESCRIPTION
- removed unnecessary keys for 2nd variants displaying first art.
  should fix displaying duplicated art when using image fetcher