### PR TITLE
update RewardScene & RewardActor for various screen display

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/scene/RewardScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/RewardScene.java
@@ -216,9 +216,11 @@ public class RewardScene extends UIScene {
         float fW = Forge.isLandscapeMode() ? Forge.getScreenWidth() : Forge.getScreenHeight();
         float fH = Forge.isLandscapeMode() ? Forge.getScreenHeight() : Forge.getScreenWidth();
         float mul = fW/fH < AR ? AR/(fW/fH) : (fW/fH)/AR;
-        if (fW/fH >= 2) {//tall display
+        if (fW/fH >= 2f) {//tall display
             mul = (fW/fH) - ((fW/fH)/AR);
-            if ((fW/fH) > 2.3) //ultrawide 21:9 Galaxy Fold, Huawei X2, Xperia 1
+            if ((fW/fH) >= 2.1f && (fW/fH) < 2.3f)
+                mul *= 0.9f;
+            else if ((fW/fH) > 2.3) //ultrawide 21:9 Galaxy Fold, Huawei X2, Xperia 1
                 mul *= 0.8f;
         }
         cardHeight = bestCardHeight * 0.90f ;

--- a/forge-gui-mobile/src/forge/adventure/scene/RewardScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/RewardScene.java
@@ -212,9 +212,17 @@ public class RewardScene extends UIScene {
                 bestCardHeight = h;
             }
         }
-
+        float AR = 480f/270f;
+        float fW = Forge.isLandscapeMode() ? Forge.getScreenWidth() : Forge.getScreenHeight();
+        float fH = Forge.isLandscapeMode() ? Forge.getScreenHeight() : Forge.getScreenWidth();
+        float mul = fW/fH < AR ? AR/(fW/fH) : (fW/fH)/AR;
+        if (fW/fH >= 2) {//tall display
+            mul = (fW/fH) - ((fW/fH)/AR);
+            if ((fW/fH) > 2.3) //ultrawide 21:9 Galaxy Fold, Huawei X2, Xperia 1
+                mul *= 0.8f;
+        }
         cardHeight = bestCardHeight * 0.90f ;
-        cardWidth = bestCardHeight / CARD_WIDTH_TO_HEIGHT;
+        cardWidth = (cardHeight / CARD_WIDTH_TO_HEIGHT)*mul;
 
         yOff += (targetHeight - (cardHeight * numberOfRows)) / 2f;
         xOff += (targetWidth - (cardWidth * numberOfColumns)) / 2f;

--- a/forge-gui-mobile/src/forge/adventure/util/RewardActor.java
+++ b/forge-gui-mobile/src/forge/adventure/util/RewardActor.java
@@ -335,10 +335,33 @@ public class RewardActor extends Actor implements Disposable, ImageFetcher.Callb
     }
     private TextureRegionDrawable processDrawable(Texture texture) {
         TextureRegionDrawable drawable = new TextureRegionDrawable(ImageCache.croppedBorderImage(texture));
-        if(Forge.isLandscapeMode())
-            drawable.setMinSize((Scene.getIntendedHeight() / RewardScene.CARD_WIDTH_TO_HEIGHT) * 0.95f, Scene.getIntendedHeight() * 0.95f);
+        float origW = texture.getWidth();
+        float origH = texture.getHeight();
+        float boundW = Scene.getIntendedWidth() * 0.95f;
+        float boundH = Scene.getIntendedHeight() * 0.95f;
+        float newW = origW;
+        float newH = origH;
+        if (origW > boundW) {
+            newW = boundW;
+            newH = (newW * origH) / origW;
+        }
+        if (newH > boundH) {
+            newH = boundH;
+            newW = (newH * origW) / origH;
+        }
+        float AR = 480f/270f;
+        float fW = Forge.isLandscapeMode() ? Forge.getScreenWidth() : Forge.getScreenHeight();
+        float fH = Forge.isLandscapeMode() ? Forge.getScreenHeight() : Forge.getScreenWidth();
+        float mul = fW/fH < AR ? AR/(fW/fH) : (fW/fH)/AR;
+        if (fW/fH >= 2) {//tall display
+            mul = (fW/fH) - ((fW/fH)/AR);
+            if ((fW/fH) > 2.3) //ultrawide 21:9 Galaxy Fold, Huawei X2, Xperia 1
+                mul *= 0.8f;
+        }
+        if (Forge.isLandscapeMode())
+            drawable.setMinSize(newW*mul, newH);
         else
-            drawable.setMinSize(Scene.getIntendedWidth()  * 0.95f, Scene.getIntendedWidth()* RewardScene.CARD_WIDTH_TO_HEIGHT * 0.95f);
+            drawable.setMinSize(newW, newH*mul);
         return drawable;
     }
     private void setCardImage(Texture img) {

--- a/forge-gui-mobile/src/forge/adventure/util/RewardActor.java
+++ b/forge-gui-mobile/src/forge/adventure/util/RewardActor.java
@@ -28,7 +28,6 @@ import forge.Forge;
 import forge.Graphics;
 import forge.ImageKeys;
 import forge.adventure.data.ItemData;
-import forge.adventure.scene.RewardScene;
 import forge.adventure.scene.Scene;
 import forge.assets.FSkin;
 import forge.assets.FSkinFont;

--- a/forge-gui-mobile/src/forge/adventure/util/RewardActor.java
+++ b/forge-gui-mobile/src/forge/adventure/util/RewardActor.java
@@ -678,9 +678,9 @@ public class RewardActor extends Actor implements Disposable, ImageFetcher.Callb
                     actor.getStage().addActor(switchButton);
             }
             //Vector2 point = actor.localToStageCoordinates(tmp.set(x, y));
-            tooltip_actor.setX(actor.getRight());
-            if (tooltip_actor.getX() + tooltip_actor.getWidth() > Scene.getIntendedWidth())
-                tooltip_actor.setX(Math.max(0,actor.getX() - tooltip_actor.getWidth()));
+            tooltip_actor.setX(Scene.getIntendedWidth() / 2 - tooltip_actor.getWidth() / 2);
+            //if (tooltip_actor.getX() + tooltip_actor.getWidth() > Scene.getIntendedWidth())
+                //tooltip_actor.setX(Math.max(0,actor.getX() - tooltip_actor.getWidth()));
             tooltip_actor.setY(Scene.getIntendedHeight() / 2 - tooltip_actor.getHeight() / 2);
             //tooltip_actor.setX(480/2 - tooltip_actor.getWidth()/2); //480 hud width
             //tooltip_actor.setY(270/2-tooltip_actor.getHeight()/2); //270 hud height

--- a/forge-gui-mobile/src/forge/adventure/util/RewardActor.java
+++ b/forge-gui-mobile/src/forge/adventure/util/RewardActor.java
@@ -352,9 +352,11 @@ public class RewardActor extends Actor implements Disposable, ImageFetcher.Callb
         float fW = Forge.isLandscapeMode() ? Forge.getScreenWidth() : Forge.getScreenHeight();
         float fH = Forge.isLandscapeMode() ? Forge.getScreenHeight() : Forge.getScreenWidth();
         float mul = fW/fH < AR ? AR/(fW/fH) : (fW/fH)/AR;
-        if (fW/fH >= 2) {//tall display
+        if (fW/fH >= 2f) {//tall display
             mul = (fW/fH) - ((fW/fH)/AR);
-            if ((fW/fH) > 2.3) //ultrawide 21:9 Galaxy Fold, Huawei X2, Xperia 1
+            if ((fW/fH) >= 2.1f && (fW/fH) < 2.3f)
+                mul *= 0.9f;
+            else if ((fW/fH) > 2.3) //ultrawide 21:9 Galaxy Fold, Huawei X2, Xperia 1
                 mul *= 0.8f;
         }
         if (Forge.isLandscapeMode())


### PR DESCRIPTION
- support for tall phones, ultra wide and unfolded screen (11.2:9)
- tested with simulated display aspect ratio of (4:3, 5:4, 16:9, 16:10, 18:9, 19:9, 21:9)