### PR TITLE
Fix noncreature permanents having P/T

### DIFF
--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -4052,6 +4052,10 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
     }
 
     public final StatBreakdown getUnswitchedPowerBreakdown() {
+        // 208.3 A noncreature permanent has no power or toughness
+        if (isInPlay() && !isCreature()) {
+            return new StatBreakdown();
+        }
         return new StatBreakdown(getCurrentPower(), getTempPowerBoost(), getPowerBonusFromCounters());
     }
     public final int getUnswitchedPower() {
@@ -4111,6 +4115,10 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
     }
 
     public final StatBreakdown getUnswitchedToughnessBreakdown() {
+        // 208.3 A noncreature permanent has no power or toughness
+        if (isInPlay() && !isCreature()) {
+            return new StatBreakdown();
+        }
         return new StatBreakdown(getCurrentToughness(), getTempToughnessBoost(), getToughnessBonusFromCounters());
     }
     public final int getUnswitchedToughness() {


### PR DESCRIPTION
Another thing that could have been exploited with (but not limited to) _Myrkul, Lord of Bones_ by e.g. creating a copy of _Leafkin Avenger_ that could still deal damage with its ability.