### PR TITLE
catch unloaded card images

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/util/RewardActor.java
+++ b/forge-gui-mobile/src/forge/adventure/util/RewardActor.java
@@ -146,15 +146,20 @@ public class RewardActor extends Actor implements Disposable, ImageFetcher.Callb
                     PaperCard card = ImageUtil.getPaperCardFromImageKey(reward.getCard().getImageKey(false));
                     File frontFace = ImageKeys.getImageFile(card.getCardImageKey());
                     if (frontFace != null) {
-                        if (!Forge.getAssets().manager().contains(frontFace.getPath())) {
-                            Forge.getAssets().manager().load(frontFace.getPath(), Texture.class, Forge.getAssets().getTextureFilter());
-                            Forge.getAssets().manager().finishLoadingAsset(frontFace.getPath());
-                            count+=1;
-                        }
-                        Texture front = Forge.getAssets().manager().get(frontFace.getPath(), Texture.class, false);
-                        if (front != null) {
-                            setCardImage(front);
-                        } else {
+                        try {
+                            if (!Forge.getAssets().manager().contains(frontFace.getPath())) {
+                                Forge.getAssets().manager().load(frontFace.getPath(), Texture.class, Forge.getAssets().getTextureFilter());
+                                Forge.getAssets().manager().finishLoadingAsset(frontFace.getPath());
+                                count+=1;
+                            }
+                            Texture front = Forge.getAssets().manager().get(frontFace.getPath(), Texture.class, false);
+                            if (front != null) {
+                                setCardImage(front);
+                            } else {
+                                loaded = false;
+                            }
+                        } catch (Exception e) {
+                            System.err.println("Failed to load image: "+frontFace.getPath());
                             loaded = false;
                         }
                     } else {
@@ -166,10 +171,14 @@ public class RewardActor extends Actor implements Disposable, ImageFetcher.Callb
                         PaperCard cardBack = ImageUtil.getPaperCardFromImageKey(reward.getCard().getImageKey(true));
                         File backFace = ImageKeys.getImageFile(cardBack.getCardAltImageKey());
                         if (backFace != null) {
-                            if (!Forge.getAssets().manager().contains(backFace.getPath())) {
-                                Forge.getAssets().manager().load(backFace.getPath(), Texture.class, Forge.getAssets().getTextureFilter());
-                                Forge.getAssets().manager().finishLoadingAsset(backFace.getPath());
-                                ImageCache.updateSynqCount(backFace, 1);
+                            try {
+                                if (!Forge.getAssets().manager().contains(backFace.getPath())) {
+                                    Forge.getAssets().manager().load(backFace.getPath(), Texture.class, Forge.getAssets().getTextureFilter());
+                                    Forge.getAssets().manager().finishLoadingAsset(backFace.getPath());
+                                    ImageCache.updateSynqCount(backFace, 1);
+                                }
+                            } catch (Exception e) {
+                                System.err.println("Failed to load image: "+backFace.getPath());
                             }
                         }
                     }
@@ -178,18 +187,23 @@ public class RewardActor extends Actor implements Disposable, ImageFetcher.Callb
                     File lookup = ImageKeys.hasSetLookup(imagePath) ? ImageKeys.setLookUpFile(imagePath, imagePath+"border") : null;
                     int count = 0;
                     if (lookup != null) {
-                        if (!Forge.getAssets().manager().contains(lookup.getPath())) {
-                            Forge.getAssets().manager().load(lookup.getPath(), Texture.class, Forge.getAssets().getTextureFilter());
-                            Forge.getAssets().manager().finishLoadingAsset(lookup.getPath());
-                            count+=1;
-                        }
-                        Texture replacement = Forge.getAssets().manager().get(lookup.getPath(), Texture.class, false);
-                        if (replacement != null) {
-                            setCardImage(replacement);
-                        } else {
+                        try {
+                            if (!Forge.getAssets().manager().contains(lookup.getPath())) {
+                                Forge.getAssets().manager().load(lookup.getPath(), Texture.class, Forge.getAssets().getTextureFilter());
+                                Forge.getAssets().manager().finishLoadingAsset(lookup.getPath());
+                                count += 1;
+                            }
+                            Texture replacement = Forge.getAssets().manager().get(lookup.getPath(), Texture.class, false);
+                            if (replacement != null) {
+                                setCardImage(replacement);
+                            } else {
+                                loaded = false;
+                            }
+                            ImageCache.updateSynqCount(lookup, count);
+                        } catch (Exception e) {
+                            System.err.println("Failed to load image: "+lookup.getPath());
                             loaded = false;
                         }
-                        ImageCache.updateSynqCount(lookup, count);
                     } else if (!ImageCache.imageKeyFileExists(reward.getCard().getImageKey(false))) {
                         //Cannot find an image file, set up a rendered card until (if) a file is downloaded.
                         T = renderPlaceholder(getGraphics(), reward.getCard()); //Now we can render the card.

--- a/forge-gui-mobile/src/forge/assets/ImageCache.java
+++ b/forge-gui-mobile/src/forge/assets/ImageCache.java
@@ -293,10 +293,14 @@ public class ImageCache {
         }
         String fileName = file.getPath();
         //load to assetmanager
-        if (!Forge.getAssets().manager().contains(fileName, Texture.class)) {
-            Forge.getAssets().manager().load(fileName, Texture.class, Forge.getAssets().getTextureFilter());
-            Forge.getAssets().manager().finishLoadingAsset(fileName);
-            counter+=1;
+        try {
+            if (!Forge.getAssets().manager().contains(fileName, Texture.class)) {
+                Forge.getAssets().manager().load(fileName, Texture.class, Forge.getAssets().getTextureFilter());
+                Forge.getAssets().manager().finishLoadingAsset(fileName);
+                counter += 1;
+            }
+        } catch (Exception e) {
+            System.err.println("Failed to load image: "+fileName);
         }
 
         //return loaded assets
@@ -305,7 +309,7 @@ public class ImageCache {
         } else {
             Texture cardTexture = Forge.getAssets().manager().get(fileName, Texture.class, false);
             //if full bordermasking is enabled, update the border color
-            if (Forge.enableUIMask.equals("Full")) {
+            if (cardTexture != null && Forge.enableUIMask.equals("Full")) {
                 boolean borderless = isBorderless(imageKey);
                 updateBorders(cardTexture.toString(), borderless ? Pair.of(Color.valueOf("#171717").toString(), false): isCloserToWhite(getpixelColor(cardTexture)));
                 //if borderless, generate new texture from the asset and store


### PR DESCRIPTION
- either due to being corrupted, invalid header or libgdx failed to load dependency (wrong path, etc..)