### PR TITLE
YSNC: herald_of_vengeance.txt

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/herald_of_vengeance.txt
+++ b/forge-gui/res/cardsfolder/upcoming/herald_of_vengeance.txt
@@ -1,0 +1,14 @@
+Name:Herald of Vengeance
+ManaCost:3 W W
+Types:Creature Angel
+PT:4/3
+K:Flying
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDestroyAll | TriggerDescription$ When CARDNAME enters the battlefield, destroy each permanent you don't control that has the same name as a permanent that dealt damage to you last turn.
+SVar:TrigDestroyAll:DB$ DestroyAll | ValidCards$ Permanent.YouDontCtrl+sharesNameWith Remembered
+T:Mode$ DamageDone | ValidSource$ Permanent | ValidTarget$ You | Static$ True | Execute$ TrigRemember
+SVar:TrigRemember:DB$ Pump | ImprintCards$ TriggeredSource
+T:Mode$ Phase | Phase$ Cleanup | Static$ True | Execute$ TrigForget
+SVar:TrigForget:DB$ Cleanup | ClearRemembered$ True | SubAbility$ DBImprint
+SVar:DBImprint:DB$ Pump | RememberObjects$ Imprinted | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearImprinted$ True
+Oracle:Flying\nWhen Herald of Vengeance enters the battlefield, destroy each permanent you don't control that has the same name as a permanent that dealt damage to you last turn.


### PR DESCRIPTION
This is the one that cares about "the same name as a permanent that dealt damage to you last turn."

Done here with statics... should be fine as long as there isn't a way to make this card with MakeCard?

We may need to make this more official somewhere rather than storing the pertinent data on the card.

- closes #778 
