### PR TITLE
prevent startup crash adventure (ExceptionInInitializerError)

### DIFF
--- a/forge-gui-mobile/src/forge/assets/Assets.java
+++ b/forge-gui-mobile/src/forge/assets/Assets.java
@@ -44,14 +44,20 @@ public class Assets implements Disposable {
     private TextureParameter textureParameter;
     private int cGen = 0, cGenVal = 0, cFB = 0, cFBVal = 0, cTM = 0, cTMVal = 0, cSF = 0, cSFVal = 0, cCF = 0, cCFVal = 0, aDF = 0, cDFVal = 0;
     public Assets() {
-        //init titlebg fallback
-        fallback_skins().put(0, new Texture(GuiBase.isAndroid()
-                ? Gdx.files.internal("fallback_skin").child("title_bg_lq.png")
-                : Gdx.files.local("fallback_skin").child("title_bg_lq.png")));
-        //init transition fallback
-        fallback_skins().put(1, new Texture(GuiBase.isAndroid()
-                ? Gdx.files.internal("fallback_skin").child("transition.png")
-                : Gdx.files.local("fallback_skin").child("transition.png")));
+        try {
+            //init titleLQ
+            Texture titleBG_LQ = GuiBase.isAndroid() ?
+                    new Texture(Gdx.files.internal("fallback_skin").child("title_bg_lq.png")) :
+                    new Texture(Gdx.files.classpath("fallback_skin").child("title_bg_lq.png"));
+            fallback_skins().put(0, titleBG_LQ == null ? getDummy() : titleBG_LQ);
+            //init transition
+            Texture transitionLQ = GuiBase.isAndroid() ?
+                    new Texture(Gdx.files.internal("fallback_skin").child("transition.png")) :
+                    new Texture(Gdx.files.classpath("fallback_skin").child("transition.png"));
+            fallback_skins().put(1, transitionLQ == null ? getDummy() : transitionLQ);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
     @Override
     public void dispose() {


### PR DESCRIPTION
- if not using classpath, it will fail to get the fallback_skin hidden inside the jar, to prevent crash use dummy instead;