### PR TITLE
Alchemy Rebalancing for August 11, 2022

### DIFF
--- a/forge-gui/res/cardsfolder/rebalanced/a-baleful_beholder.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-baleful_beholder.txt
@@ -1,0 +1,9 @@
+Name:A-Baleful Beholder
+ManaCost:4 B B
+Types:Creature Beholder
+PT:7/5
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigCharm | TriggerDescription$ When CARDNAME enters the battlefield, ABILITY
+SVar:TrigCharm:DB$ Charm | Choices$ DBSacrifice,DBPumpAll
+SVar:DBSacrifice:DB$ Sacrifice | Defined$ Opponent | SacValid$ Enchantment | SpellDescription$ Antimagic Cone — Each opponent sacrifices an enchantment.
+SVar:DBPumpAll:DB$ PumpAll | ValidCards$ Creature.YouCtrl | KW$ Menace | SpellDescription$ Fear Ray — Creatures you control gain menace until end of turn.
+Oracle:When Baleful Beholder enters the battlefield, choose one —\n• Antimagic Cone — Each opponent sacrifices an enchantment.\n• Fear Ray — Creatures you control gain menace until end of turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-blessed_hippogriff_tyrs_blesing.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-blessed_hippogriff_tyrs_blesing.txt
@@ -1,0 +1,18 @@
+Name:A-Blessed Hippogriff
+ManaCost:3 W
+Types:Creature Hippogriff
+PT:2/3
+K:Flying
+T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, target attacking creature without flying gains flying until end of turn.
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.attacking+withoutFlying | TgtPrompt$ Select target attacking creature without flying | KW$ Flying
+AlternateMode:Adventure
+Oracle:Flying\nWhenever Blessed Hippogriff attacks, target attacking creature without flying gains flying until end of turn. 
+
+ALTERNATE
+
+Name:A-Tyr's Blesing
+ManaCost:1 W
+Types:Instant Adventure
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target to make indestructable | KW$ Indestructible | SpellDescription$ Target creature gains indestructible until end of turn.
+SVar:HasAttackEffect:TRUE
+Oracle:Target creature gains indestructible until end of turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-blessed_hippogriff_tyrs_blesing.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-blessed_hippogriff_tyrs_blesing.txt
@@ -13,6 +13,5 @@ ALTERNATE
 Name:A-Tyr's Blesing
 ManaCost:1 W
 Types:Instant Adventure
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target to make indestructable | KW$ Indestructible | SpellDescription$ Target creature gains indestructible until end of turn.
-SVar:HasAttackEffect:TRUE
+A:SP$ Pump | ValidTgts$ Creature | KW$ Indestructible | SpellDescription$ Target creature gains indestructible until end of turn.
 Oracle:Target creature gains indestructible until end of turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-carnelian_orb_of_dragonkind.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-carnelian_orb_of_dragonkind.txt
@@ -1,0 +1,6 @@
+Name:A-Carnelian Orb of Dragonkind
+ManaCost:2 R
+Types:Artifact
+A:AB$ Mana | Cost$ T | Produced$ Any | AddsKeywords$ Haste | AddsKeywordsValid$ Spell.Dragon+Creature | AddsKeywordsUntil$ UntilEOT | SpellDescription$ Add one mana of any color. If that mana is spent on a Dragon creature spell, it gains haste until end of turn.
+DeckHints:Type$Dragon
+Oracle:{T}: Add one mana of any color. If that mana is spent on a Dragon creature spell, it gains haste until end of turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-circle_of_the_land_druid.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-circle_of_the_land_druid.txt
@@ -1,0 +1,10 @@
+Name:A-Circle of the Land Druid
+ManaCost:1 G
+Types:Creature Gnome Druid
+PT:2/1
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigMill | TriggerDescription$ When CARDNAME enters the battlefield, you may mill four cards.
+SVar:TrigMill:DB$ Mill | NumCards$ 4 | Defined$ You | Optional$ True
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigChangeZone | TriggerDescription$ Natural Recovery — When CARDNAME dies, return target land card from your graveyard to your hand.
+SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Land.YouCtrl
+DeckHas:Ability$Mill|Graveyard
+Oracle:When Circle of the Land Druid enters the battlefield, you may mill four cards.\nNatural Recovery — When Circle of the Land Druid dies, return target land card from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/rebalanced/a-circle_of_the_land_druid.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-circle_of_the_land_druid.txt
@@ -5,6 +5,6 @@ PT:2/1
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigMill | TriggerDescription$ When CARDNAME enters the battlefield, you may mill four cards.
 SVar:TrigMill:DB$ Mill | NumCards$ 4 | Defined$ You | Optional$ True
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigChangeZone | TriggerDescription$ Natural Recovery — When CARDNAME dies, return target land card from your graveyard to your hand.
-SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Land.YouCtrl
+SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Land.YouOwn | TgtPrompt$ Select target land card from your graveyard
 DeckHas:Ability$Mill|Graveyard
 Oracle:When Circle of the Land Druid enters the battlefield, you may mill four cards.\nNatural Recovery — When Circle of the Land Druid dies, return target land card from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/rebalanced/a-dragonborn_looter.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-dragonborn_looter.txt
@@ -1,0 +1,8 @@
+Name:A-Dragonborn Looter
+ManaCost:U
+Types:Creature Dragon Rogue
+PT:1/2
+A:AB$ Draw | Cost$ 1 T | SubAbility$ DBDiscard | SpellDescription$ Draw a card, then discard a card.
+SVar:DBDiscard:DB$ Discard | Mode$ TgtChoose
+DeckHas:Ability$Discard
+Oracle:{1}, {T}: Draw a card, then discard a card.

--- a/forge-gui/res/cardsfolder/rebalanced/a-druidic_ritual.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-druidic_ritual.txt
@@ -1,0 +1,7 @@
+Name:A-Druidic Ritual
+ManaCost:2 G
+Types:Sorcery
+A:SP$ Mill | NumCards$ 3 | Optional$ True | SubAbility$ DBReturn | SpellDescription$ You may mill three cards.
+SVar:DBReturn:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | Hidden$ True | TargetMin$ 0 | TargetMax$ 2 | ChangeType$ Creature.YouOwn,Land.YouOwn | ChangeTypeDesc$ up to two creature and/or land cards they own | SpellDescription$ Then return up to two creature and/or land cards from your graveyard to your hand.
+DeckHas:Ability$Mill|Graveyard
+Oracle:You may mill three cards. Then return up to two creature and/or land cards from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/rebalanced/a-emerald_dragon_dissonant_wave.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-emerald_dragon_dissonant_wave.txt
@@ -1,0 +1,16 @@
+Name:A-Emerald Dragon
+ManaCost:4 G G
+Types:Creature Dragon
+PT:4/4
+K:Flying
+K:Ward:2
+AlternateMode:Adventure
+Oracle:Flying, Ward {2}
+
+ALTERNATE
+
+Name:A-Dissonant Wave
+ManaCost:2 G
+Types:Instant Adventure
+A:SP$ Counter | TargetType$ Activated,Triggered | TgtPrompt$ Select target activated or triggered ability from a noncreature source | ValidTgts$ Card.nonCreature,Emblem | SpellDescription$ Counter target activated or triggered ability from a noncreature source.
+Oracle:Counter target activated or triggered ability from a noncreature source.

--- a/forge-gui/res/cardsfolder/rebalanced/a-eyes_of_the_beholder.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-eyes_of_the_beholder.txt
@@ -1,0 +1,5 @@
+Name:A-Eyes of the Beholder
+ManaCost:3 B B
+Types:Instant
+A:SP$ Pump | Cost$ 3 B B | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ -11 | NumDef$ -11 | IsCurse$ True | SpellDescription$ Target creature gets -11/-11 until end of turn.
+Oracle:Target creature gets -11/-11 until end of turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-goggles_of_night.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-goggles_of_night.txt
@@ -1,0 +1,8 @@
+Name:A-Goggles of Night
+ManaCost:1 U
+Types:Artifact Equipment
+T:Mode$ DamageDone | ValidSource$ Creature.EquippedBy | ValidTarget$ Player | CombatDamage$ True | Execute$ DBScry | TriggerZones$ Battlefield | TriggerDescription$ Whenever equipped creature deals combat damage to a player, scry 1, then draw a card.
+SVar:DBScry:DB$ Scry | ScryNum$ 1 | SubAbility$ DBDraw
+SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1
+K:Equip:1
+Oracle:Whenever equipped creature deals combat damage to a player, scry 1, then draw a card.\nEquip {1}

--- a/forge-gui/res/cardsfolder/rebalanced/a-guildsworn_prowler.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-guildsworn_prowler.txt
@@ -1,0 +1,8 @@
+Name:A-Guildsworn Prowler
+ManaCost:1 B
+Types:Creature Tiefling Rogue Assassin
+PT:1/1
+K:Deathtouch
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self+notblocking | Execute$ TrigDraw | TriggerDescription$ When CARDNAME dies, if it wasn't blocking, draw a card.
+SVar:TrigDraw:DB$ Draw
+Oracle:Deathtouch\nWhen Guildsworn Prowler dies, if it wasn't blocking, draw a card.

--- a/forge-gui/res/cardsfolder/rebalanced/a-jade_orb_of_dragonkind.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-jade_orb_of_dragonkind.txt
@@ -1,0 +1,12 @@
+Name:A-Jade Orb of Dragonkind
+ManaCost:2 G
+Types:Artifact
+A:AB$ Mana | Cost$ T | Produced$ Any | TriggersWhenSpent$ TrigSpent | SpellDescription$ Add one mana of any color. When you spend this mana to cast a Dragon creature spell, it enters the battlefield with an additional +1/+1 counter on it and gains hexproof until your next turn.
+SVar:TrigSpent:Mode$ SpellCast | ValidCard$ Creature.Dragon | ValidActivatingPlayer$ You | Execute$ TrigEffect | TriggerDescription$ When you spend this mana to cast a Dragon creature spell, it enters the battlefield with an additional +1/+1 counter on it and gains hexproof until your next turn.
+SVar:TrigEffect:DB$ Effect | RememberObjects$ TriggeredCard | ForgetOnMoved$ Stack | ReplacementEffects$ ETBCreat
+SVar:ETBCreat:Event$ Moved | ValidCard$ Card.IsRemembered | Destination$ Battlefield | ReplaceWith$ DBPutP1P1 | ReplacementResult$ Updated | Description$ That creature enters the battlefield with an additional +1/+1 counter on it and gains hexproof until your next turn.
+SVar:DBPutP1P1:DB$ PutCounter | Defined$ ReplacedCard | CounterType$ P1P1 | ETB$ True | CounterNum$ 1 | SubAbility$ DBPump
+SVar:DBPump:DB$ Pump | Defined$ ReplacedCard | Duration$ UntilYourNextTurn | KW$ Hexproof | PumpZone$ Stack
+DeckHas:Ability$Counters
+DeckHints:Type$Dragon
+Oracle:{T}: Add one mana of any color. When you spend this mana to cast a Dragon creature spell, it enters the battlefield with an additional +1/+1 counter on it and gains hexproof until your next turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-kenku_artificer.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-kenku_artificer.txt
@@ -1,0 +1,10 @@
+Name:A-Kenku Artificer
+ManaCost:2 U
+Types:Creature Bird Artificer
+PT:1/3
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPutCounter | TriggerDescription$ Homunculus Servant — When CARDNAME enters the battlefield, put three +1/+1 counters on up to one target noncreature artifact. That artifact becomes a 0/0 Homunculus artifact creature with flying.
+SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Artifact.nonCreature+YouCtrl | TgtPrompt$ Select up to one noncreature artifact | CounterType$ P1P1 | CounterNum$ 3 | MinTarget$ 0 | MaxTarget$ 1 | SubAbility$ TrigAnimate
+SVar:TrigAnimate:DB$ Animate | Defined$ Targeted | Keywords$ Flying | Power$ 0 | Toughness$ 0 | Types$ Artifact,Creature,Homunculus | RemoveCreatureTypes$ True | Duration$ Permanent
+DeckHas:Ability$Counters & Type$Homunculus
+DeckNeeds:Type$Artifact
+Oracle:Homunculus Servant — When Kenku Artificer enters the battlefield, put three +1/+1 counters on up to one target noncreature artifact. That artifact becomes a 0/0 Homunculus artifact creature with flying.

--- a/forge-gui/res/cardsfolder/rebalanced/a-lantern_of_revealing.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-lantern_of_revealing.txt
@@ -1,0 +1,8 @@
+Name:A-Lantern of Revealing
+ManaCost:3
+Types:Artifact
+A:AB$ Mana | Cost$ T | Produced$ Any | SpellDescription$ Add one mana of any color.
+A:AB$ Dig | Cost$ 3 T | DigNum$ 1 | ChangeNum$ All | ForceRevealToController$ True | Optional$ True | PromptToSkipOptionalAbility$ True | OptionalAbilityPrompt$ Would you like to put the land onto the battlefield tapped? | ChangeValid$ Land | DestinationZone$ Battlefield | Tapped$ True | DestinationZone2$ Library | LibraryPosition2$ 0 | RememberChanged$ True | SubAbility$ DBMoveToBottom | SpellDescription$ Look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped. If you don't put the card onto the battlefield, you may put it on the bottom of your library.
+SVar:DBMoveToBottom:DB$ Dig | DigNum$ 1 | DestinationZone$ Library | Optional$ True | LibraryPosition$ -1 | LibraryPosition2$ 0 | ConditionPresent$ Card | ConditionDefined$ Remembered | ConditionCompare$ EQ0 | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:{T}: Add one mana of any color.\n{3}, {T}: Look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped. If you don't put the card onto the battlefield, you may put it on the bottom of your library.

--- a/forge-gui/res/cardsfolder/rebalanced/a-lapis_orb_of_dragonkind.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-lapis_orb_of_dragonkind.txt
@@ -1,0 +1,8 @@
+Name:A-Lapis Orb of Dragonkind
+ManaCost:2 U
+Types:Artifact
+A:AB$ Mana | Cost$ T | Produced$ Any | TriggersWhenSpent$ TrigSpent | SpellDescription$ Add one mana of any color. When you spend this mana to cast a Dragon creature spell, scry 2.
+SVar:TrigSpent:Mode$ SpellCast | ValidCard$ Creature.Dragon | ValidActivatingPlayer$ You | Execute$ TrigScry | TriggerDescription$ When you spend this mana to cast a Dragon creature spell, scry 2.
+SVar:TrigScry:DB$ Scry | ScryNum$ 2
+DeckHints:Type$Dragon
+Oracle:{T}: Add one mana of any color. When you spend this mana to cast a Dragon creature spell, scry 2.

--- a/forge-gui/res/cardsfolder/rebalanced/a-manticore.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-manticore.txt
@@ -1,0 +1,9 @@
+Name:A-Manticore
+ManaCost:3 B
+Types:Creature Manticore
+PT:3/1
+K:Flash
+K:Flying
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TailSpikes | TriggerDescription$ Tail Spikes — When CARDNAME enters the battlefield, destroy target creature an opponent controls that was dealt damage this turn.
+SVar:TailSpikes:DB$ Destroy | ValidTgts$ Creature.wasDealtDamageThisTurn+OppCtrl | TgtPrompt$ Select target creature an opponent controls that was dealt damage this turn
+Oracle:Flash\nFlying\nTail Spikes — When Manticore enters the battlefield, destroy target creature an opponent controls that was dealt damage this turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-navigation_orb.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-navigation_orb.txt
@@ -1,0 +1,9 @@
+Name:A-Navigation Orb
+ManaCost:3
+Types:Artifact
+A:AB$ ChangeZone | Cost$ 1 T Sac<1/CARDNAME> | Origin$ Library | Destination$ Library | ChangeType$ Land.Basic,Gate | ChangeNum$ 2 | RememberChanged$ True | Reveal$ True | Shuffle$ False | StackDescription$ SpellDescription | SubAbility$ DBChangeZone1 | SpellDescription$ Search your library for up to two basic land cards and/or Gate cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.
+SVar:DBChangeZone1:DB$ ChangeZone | Origin$ Library | Destination$ Battlefield | ChangeType$ Land.IsRemembered,Gate.IsRemembered | ChangeNum$ 1 | Mandatory$ True | ForgetChanged$ True | NoLooking$ True | SelectPrompt$ Select a card for the battlefield | Tapped$ True | Shuffle$ False | SubAbility$ DBChangeZone2 | StackDescription$ None
+SVar:DBChangeZone2:DB$ ChangeZone | Origin$ Library | Destination$ Hand | Defined$ Remembered | ConditionDefined$ Remembered | ConditionPresent$ Card | ForgetChanged$ True | StackDescription$ None | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+DeckHints:Type$Gate
+Oracle:{1}, {T}, Sacrifice Navigation Orb: Search your library for up to two basic land cards and/or Gate cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.

--- a/forge-gui/res/cardsfolder/rebalanced/a-pseudodragon_familiar.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-pseudodragon_familiar.txt
@@ -1,0 +1,7 @@
+Name:A-Pseudodragon Familiar
+ManaCost:2 U
+Types:Creature Dragon
+PT:2/2
+K:Flying
+A:AB$ Pump | Cost$ 2 U | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ Flying | SpellDescription$ Target creature gains flying until end of turn.
+Oracle:Flying\n{2}{U}: Target creature gains flying until end of turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-sigil_of_myrkul.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-sigil_of_myrkul.txt
@@ -1,0 +1,10 @@
+Name:A-Sigil of Myrkul
+ManaCost:1 B
+Types:Enchantment
+T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigMill | TriggerDescription$ At the beginning of combat on your turn, mill a card. When you do, if there are four or more creature cards in your graveyard, put a +1/+1 counter on target creature you control and it gains deathtouch until end of turn.
+SVar:TrigMill:DB$ Mill | SubAbility$ DBImmediateTrigger
+SVar:DBImmediateTrigger:DB$ ImmediateTrigger | ConditionPresent$ Creature.YouOwn | ConditionZone$ Graveyard | ConditionCompare$ GE4 | PresentZone$ Graveyard | Execute$ TrigPutCounter | TriggerDescription$ When you do, if there are four or more creature cards in your graveyard, put a +1/+1 counter on target creature you control and it gains deathtouch until end of turn.
+SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | CounterType$ P1P1 | SubAbility$ DBPump
+SVar:DBPump:DB$ Pump | Defined$ Targeted | KW$ Deathtouch
+DeckHas:Ability$Mill|Counters
+Oracle:At the beginning of combat on your turn, mill a card. When you do, if there are four or more creature cards in your graveyard, put a +1/+1 counter on target creature you control and it gains deathtouch until end of turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-split_the_spoils.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-split_the_spoils.txt
@@ -1,0 +1,9 @@
+Name:A-Split the Spoils
+ManaCost:1 G
+Types:Sorcery
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Exile | ValidTgts$ Permanent.YouOwn | TargetMin$ 0 | TargetMax$ 5 | TgtPrompt$ Select up to five target permanent cards from your graveyard | SubAbility$ DBTwoPiles | SpellDescription$ Exile up to five target permanent cards from your graveyard
+SVar:DBTwoPiles:DB$ TwoPiles | Chooser$ Opponent | DefinedCards$ Targeted | Separator$ You | ChosenPile$ DBHand | UnchosenPile$ DBGrave | AILogic$ Worst | StackDescription$ {p:You} separates them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. | SpellDescription$ and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. (Piles can be empty.)
+SVar:DBHand:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Hand
+SVar:DBGrave:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Graveyard
+DeckHas:Ability$Graveyard
+Oracle:Exile up to five target permanent cards from your graveyard and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. (Piles can be empty.)

--- a/forge-gui/res/cardsfolder/rebalanced/a-steadfast_unicorn.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-steadfast_unicorn.txt
@@ -1,0 +1,6 @@
+Name:A-Steadfast Unicorn
+ManaCost:W
+Types:Creature Unicorn
+PT:1/2
+A:AB$ PumpAll | Cost$ 4 W | ValidCards$ Creature.YouCtrl | NumAtt$ +1 | NumDef$ +1 | KW$ Vigilance | PlayerTurn$ True | SpellDescription$ Creatures you control get +1/+1 and gain vigilance until end of turn. Activate only during your turn.
+Oracle:{4}{W}: Creatures you control get +1/+1 and gain vigilance until end of turn. Activate only during your turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-you_come_to_a_river.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-you_come_to_a_river.txt
@@ -1,0 +1,7 @@
+Name:A-You Come to a River
+ManaCost:2 U
+Types:Sorcery
+A:SP$ Charm | Cost$ 2 U | Choices$ FightTheCurrent,FindACrossing
+SVar:FightTheCurrent:DB$ ChangeZone | ValidTgts$ Permanent.nonLand | TgtPrompt$ Select target nonland permanent | AlternativeDecider$ TargetedController | Origin$ Battlefield | Destination$ Library | LibraryPosition$ 0 | DestinationAlternative$ Library | LibraryPositionAlternative$ -1 | AlternativeDestinationMessage$ Would you like to put the card on the top of your library (and not on the bottom)? | StackDescription$ The owner of {c:Targeted} puts it on the top or bottom of their library. | SpellDescription$ Fight the Current — The owner of target nonland permanent puts it on the top or bottom of their library.
+SVar:FindACrossing:DB$ Pump | Cost$ U | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ 1 | KW$ HIDDEN Unblockable | SpellDescription$ Find a Crossing — Target creature gets +1/+0 until end of turn and can't be blocked this turn.
+Oracle:Choose one —\n• Fight the Current — The owner of target nonland permanent puts it on the top or bottom of their library.\n• Find a Crossing — Target creature gets +1/+0 until end of turn and can't be blocked this turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-you_come_to_a_river.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-you_come_to_a_river.txt
@@ -1,7 +1,7 @@
 Name:A-You Come to a River
 ManaCost:2 U
 Types:Sorcery
-A:SP$ Charm | Cost$ 2 U | Choices$ FightTheCurrent,FindACrossing
+A:SP$ Charm | Choices$ FightTheCurrent,FindACrossing
 SVar:FightTheCurrent:DB$ ChangeZone | ValidTgts$ Permanent.nonLand | TgtPrompt$ Select target nonland permanent | AlternativeDecider$ TargetedController | Origin$ Battlefield | Destination$ Library | LibraryPosition$ 0 | DestinationAlternative$ Library | LibraryPositionAlternative$ -1 | AlternativeDestinationMessage$ Would you like to put the card on the top of your library (and not on the bottom)? | StackDescription$ The owner of {c:Targeted} puts it on the top or bottom of their library. | SpellDescription$ Fight the Current — The owner of target nonland permanent puts it on the top or bottom of their library.
-SVar:FindACrossing:DB$ Pump | Cost$ U | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ 1 | KW$ HIDDEN Unblockable | SpellDescription$ Find a Crossing — Target creature gets +1/+0 until end of turn and can't be blocked this turn.
+SVar:FindACrossing:DB$ Pump | ValidTgts$ Creature | NumAtt$ 1 | KW$ HIDDEN Unblockable | SpellDescription$ Find a Crossing — Target creature gets +1/+0 until end of turn and can't be blocked this turn.
 Oracle:Choose one —\n• Fight the Current — The owner of target nonland permanent puts it on the top or bottom of their library.\n• Find a Crossing — Target creature gets +1/+0 until end of turn and can't be blocked this turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-young_blue_dragon_sand_augury.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-young_blue_dragon_sand_augury.txt
@@ -1,0 +1,16 @@
+Name:A-Young Blue Dragon
+ManaCost:4 U
+Types:Creature Dragon
+PT:3/4
+K:Flying
+Oracle:Flying
+AlternateMode:Adventure
+
+ALTERNATE
+
+Name:A-Sand Augury
+ManaCost:1 U
+Types:Sorcery Adventure
+A:SP$ Scry | ScryNum$ 1 | SubAbility$ DBDraw | SpellDescription$ Scry 1,
+SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1 | SpellDescription$ then draw a card
+Oracle:Scry 1, then draw a card.

--- a/forge-gui/res/cardsfolder/rebalanced/a-young_red_dragon_bathe_in_gold.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-young_red_dragon_bathe_in_gold.txt
@@ -1,0 +1,16 @@
+Name:A-Young Red Dragon
+ManaCost:3 R
+Types:Creature Dragon
+PT:3/1
+K:Flying
+Oracle:Flying
+AlternateMode:Adventure
+
+ALTERNATE
+
+Name:A-Bathe in Gold
+ManaCost:1 R
+Types:Instant Adventure
+A:SP$ Token | TokenScript$ c_a_treasure_sac | SpellDescription$ Create a Treasure token.
+DeckHas:Ability$Token|Sacrifice & Type$Artifact|Treasure
+Oracle:Create a Treasure token.

--- a/forge-gui/res/cardsfolder/upcoming/blessed_hippogriff_tyrs_blesing.txt
+++ b/forge-gui/res/cardsfolder/upcoming/blessed_hippogriff_tyrs_blesing.txt
@@ -13,6 +13,5 @@ ALTERNATE
 Name:Tyr's Blesing
 ManaCost:W
 Types:Instant Adventure
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target to make indestructable | KW$ Indestructible | SpellDescription$ Target creature gains indestructible until end of turn.
-SVar:HasAttackEffect:TRUE
+A:SP$ Pump | ValidTgts$ Creature | KW$ Indestructible | SpellDescription$ Target creature gains indestructible until end of turn.
 Oracle:Target creature gains indestructible until end of turn.

--- a/forge-gui/res/cardsfolder/upcoming/circle_of_the_land_druid.txt
+++ b/forge-gui/res/cardsfolder/upcoming/circle_of_the_land_druid.txt
@@ -5,6 +5,6 @@ PT:1/1
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigMill | TriggerDescription$ When CARDNAME enters the battlefield, you may mill four cards. (You may put the top four cards of your library into your graveyard.)
 SVar:TrigMill:DB$ Mill | NumCards$ 4 | Defined$ You | Optional$ True
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigChangeZone | TriggerDescription$ Natural Recovery — When CARDNAME dies, return target land card from your graveyard to your hand.
-SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Land.YouCtrl
+SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Land.YouOwn | TgtPrompt$ Select target land card from your graveyard
 DeckHas:Ability$Mill|Graveyard
 Oracle:When Circle of the Land Druid enters the battlefield, you may mill four cards. (You may put the top four cards of your library into your graveyard.)\nNatural Recovery — When Circle of the Land Druid dies, return target land card from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/y/you_come_to_a_river.txt
+++ b/forge-gui/res/cardsfolder/y/you_come_to_a_river.txt
@@ -1,7 +1,7 @@
 Name:You Come to a River
 ManaCost:1 U
 Types:Instant
-A:SP$ Charm | Cost$ 1 U | Choices$ FightTheCurrent,FindACrossing
+A:SP$ Charm | Choices$ FightTheCurrent,FindACrossing
 SVar:FightTheCurrent:DB$ ChangeZone | ValidTgts$ Permanent.nonLand | TgtPrompt$ Select target nonland permanent | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Fight the Current — Return target nonland permanent to its owner's hand.
-SVar:FindACrossing:DB$ Pump | Cost$ U | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ 1 | KW$ HIDDEN Unblockable | SpellDescription$ Find a Crossing — Target creature gets +1/+0 until end of turn and can't be blocked this turn.
+SVar:FindACrossing:DB$ Pump | ValidTgts$ Creature | NumAtt$ 1 | KW$ HIDDEN Unblockable | SpellDescription$ Find a Crossing — Target creature gets +1/+0 until end of turn and can't be blocked this turn.
 Oracle:Choose one —\n• Fight the Current — Return target nonland permanent to its owner's hand.\n• Find a Crossing — Target creature gets +1/+0 until end of turn and can't be blocked this turn.

--- a/forge-gui/res/editions/Alchemy Horizons Baldur's Gate.txt
+++ b/forge-gui/res/editions/Alchemy Horizons Baldur's Gate.txt
@@ -398,8 +398,31 @@ ScryfallCode=HBG
 286 L Forest @Julian Kok Joon Wen
 
 [rebalanced]
+A85 C A-Blessed Hippogriff @Leanna Crossan
+A104 C A-Steadfast Unicorn @John Thacker
+A117 C A-Dragonborn Looter @Julio Reyna
+A120 U A-Goggles of Night @Forrest Imel
+A125 U A-Kenku Artificer @Dave Greco
+A127 U A-Lapis Orb of Dragonkind @Olena Richards
+A128 C A-Pseudodragon Familiar @Campbell White
+A136 C A-You Come to a River @Viko Menezes
+A138 C A-Young Blue Dragon @Tuan Duong Chu
+A143 C A-Baleful Beholder @Lars Grant-West
+A154 C A-Eyes of the Beholder @Kari Christensen
+A160 C A-Guildsworn Prowler @Fariba Khamseh
+A163 C A-Manticore @Billy Christian
 A166 C A-Sepulcher Ghoul @Jason A. Engle
+A168 U A-Sigil of Myrkul @David Astruga
+A177 U A-Carnelian Orb of Dragonkind @Olena Richards
+A197 C A-Young Red Dragon @Adam Vehige
+A203 C A-Circle of the Land Druid @Alexandre Honoré
+A208 C A-Druidic Ritual @Vincent Christiaens
 A209 R A-Earthquake Dragon @Johan Grenier
+A210 U A-Emerald Dragon @Diego Gisbert
+A215 U A-Jade Orb of Dragonkind @Olena Richards
 A217 R A-Monster Manual @David Gaillet
+A223 U A-Split the Spoils @Edgar Sánchez Hidalgo
 A232 R A-Baba Lysaga, Night Witch @Slawomir Maniak
 A243 M A-Minsc & Boo, Timeless Heroes @Andreas Zafiratos
+A259 C A-Lantern of Revealing @Eytan Zana
+A262 U A-Navigation Orb @Robin Olausson


### PR DESCRIPTION
Source: https://magic.wizards.com/en/articles/archive/magic-digital/alchemy-rebalancing-august-11-2022-08-10

- [x] Add rebalanced cards to editions
- [x] A-Baleful Beholder
- [x] A-Blessed Hippogriff
- [x] A-Carnelian Orb of Dragonkind
- [x] A-Circle of the Land Druid
- [x] A-Dragonborn Looter
- [x] A-Druidic Ritual
- [x] A-Emerald Dragon
- [x] A-Eyes of the Beholder
- [x] A-Goggles of Night
- [x] A-Guildsworn Prowler
- [x] A-Jade Orb of Dragonkind
- [x] A-Kenku Artificer
- [x] A-Lantern of Revealing
- [x] A-Lapis Orb of Dragonkind
- [x] A-Manticore
- [x] A-Navigation Orb
- [x] A-Pseudodragon Familiar
- [x] A-Sigil of Myrkul
- [x] A-Split the Spoils
- [x] A-Steadfast Unicorn
- [x] A-You Come to a River
- [x] A-Young Blue Dragon
- [x] A-Young Red Dragon

**Not in this PR**:
- Cabaretti Revels (in another PR)
- Racketeer Boss (in another PR)
- Alora, Rogue Companion (Specialize not yet implemented)
- Vhal, Eager Scholar (Specialize not yet implemented)
- Dragonborn Immolator (not yet scripted)
- Water Weird (not yet scripted)