### PR TITLE
HBG: Specialize mechanic

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiCostDecision.java
+++ b/forge-ai/src/main/java/forge/ai/AiCostDecision.java
@@ -2,10 +2,12 @@ package forge.ai;
 
 import static forge.ai.ComputerUtilCard.getBestCreatureAI;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import forge.card.MagicColor;
 import forge.game.cost.*;
 import org.apache.commons.lang3.ObjectUtils;
 
@@ -53,6 +55,14 @@ public class AiCostDecision extends CostDecisionMakerBase {
         int c = cost.getAbilityAmount(ability);
 
         return PaymentDecision.number(c);
+    }
+
+    @Override
+    public PaymentDecision visit(CostChooseColor cost) {
+        int c = cost.getAbilityAmount(ability);
+        List<String> choices = player.getController().chooseColors("Color", ability, c, c,
+                new ArrayList<>(MagicColor.Constant.ONLY_COLORS));
+        return PaymentDecision.colors(choices);
     }
 
     @Override

--- a/forge-core/src/main/java/forge/card/CardRules.java
+++ b/forge-core/src/main/java/forge/card/CardRules.java
@@ -414,6 +414,11 @@ public final class CardRules implements ICardCharacteristics {
             CardAiHints cah = new CardAiHints(removedFromAIDecks, removedFromRandomDecks, removedFromNonCommanderDecks, hints, needs, has);
             faces[0].assignMissingFields();
             if (null != faces[1]) faces[1].assignMissingFields();
+            if (null != faces[2]) faces[2].assignMissingFields();
+            if (null != faces[3]) faces[3].assignMissingFields();
+            if (null != faces[4]) faces[4].assignMissingFields();
+            if (null != faces[5]) faces[5].assignMissingFields();
+            if (null != faces[6]) faces[6].assignMissingFields();
             final CardRules result = new CardRules(faces, altMode, cah);
 
             result.setNormalizedName(this.normalizedName);

--- a/forge-core/src/main/java/forge/card/CardRules.java
+++ b/forge-core/src/main/java/forge/card/CardRules.java
@@ -43,6 +43,11 @@ public final class CardRules implements ICardCharacteristics {
     private CardSplitType splitType;
     private ICardFace mainPart;
     private ICardFace otherPart;
+    private ICardFace wSpecialize;
+    private ICardFace uSpecialize;
+    private ICardFace bSpecialize;
+    private ICardFace rSpecialize;
+    private ICardFace gSpecialize;
     private CardAiHints aiHints;
     private ColorSet colorIdentity;
     private ColorSet deckbuildingColors;
@@ -54,6 +59,12 @@ public final class CardRules implements ICardCharacteristics {
         splitType = altMode;
         mainPart = faces[0];
         otherPart = faces[1];
+        wSpecialize = faces[2];
+        uSpecialize = faces[3];
+        bSpecialize = faces[4];
+        rSpecialize = faces[5];
+        gSpecialize = faces[6];
+
         aiHints = cah;
         meldWith = "";
         partnerWith = "";
@@ -74,6 +85,11 @@ public final class CardRules implements ICardCharacteristics {
         splitType = newRules.splitType;
         mainPart = newRules.mainPart;
         otherPart = newRules.otherPart;
+        wSpecialize = newRules.wSpecialize;
+        uSpecialize = newRules.uSpecialize;
+        bSpecialize = newRules.bSpecialize;
+        rSpecialize = newRules.rSpecialize;
+        gSpecialize = newRules.gSpecialize;
         aiHints = newRules.aiHints;
         colorIdentity = newRules.colorIdentity;
         meldWith = newRules.meldWith;
@@ -130,6 +146,22 @@ public final class CardRules implements ICardCharacteristics {
 
     public ICardFace getOtherPart() {
         return otherPart;
+    }
+
+    public ICardFace getWSpecialize() {
+        return wSpecialize;
+    }
+    public ICardFace getUSpecialize() {
+        return uSpecialize;
+    }
+    public ICardFace getBSpecialize() {
+        return bSpecialize;
+    }
+    public ICardFace getRSpecialize() {
+        return rSpecialize;
+    }
+    public ICardFace getGSpecialize() {
+        return gSpecialize;
     }
 
     public String getName() {
@@ -335,7 +367,7 @@ public final class CardRules implements ICardCharacteristics {
     // Reads cardname.txt
     public static class Reader {
         // fields to build
-        private CardFace[] faces = new CardFace[] { null, null };
+        private CardFace[] faces = new CardFace[] { null, null, null, null, null, null, null };
         private int curFace = 0;
         private CardSplitType altMode = CardSplitType.None;
         private String meldWith = "";
@@ -518,6 +550,18 @@ public final class CardRules implements ICardCharacteristics {
                 case 'S':
                     if ("S".equals(key)) {
                         this.faces[this.curFace].addStaticAbility(value);
+                    } else if (key.startsWith("SPECIALIZE")) {
+                        if (value.equals("WHITE")) {
+                            this.curFace = 2;
+                        } else if (value.equals("BLUE")) {
+                            this.curFace = 3;
+                        } else if (value.equals("BLACK")) {
+                            this.curFace = 4;
+                        } else if (value.equals("RED")) {
+                            this.curFace = 5;
+                        } else if (value.equals("GREEN")) {
+                            this.curFace = 6;
+                        }
                     } else if ("SVar".equals(key)) {
                         if (null == value) throw new IllegalArgumentException("SVar has no variable name");
 
@@ -600,7 +644,7 @@ public final class CardRules implements ICardCharacteristics {
 
     public static CardRules getUnsupportedCardNamed(String name) {
         CardAiHints cah = new CardAiHints(true, true, true, null, null, null);
-        CardFace[] faces = { new CardFace(name), null};
+        CardFace[] faces = { new CardFace(name), null, null, null, null, null, null};
         faces[0].setColor(ColorSet.fromMask(0));
         faces[0].setType(CardType.parse("", false));
         faces[0].setOracleText("This card is not supported by Forge. Whenever you start a game with this card, it will be bugged.");

--- a/forge-core/src/main/java/forge/card/CardSplitType.java
+++ b/forge-core/src/main/java/forge/card/CardSplitType.java
@@ -10,7 +10,8 @@ public enum CardSplitType
     Split(FaceSelectionMethod.COMBINE, CardStateName.RightSplit),
     Flip(FaceSelectionMethod.USE_PRIMARY_FACE, CardStateName.Flipped),
     Adventure(FaceSelectionMethod.USE_PRIMARY_FACE, CardStateName.Adventure),
-    Modal(FaceSelectionMethod.USE_ACTIVE_FACE, CardStateName.Modal);
+    Modal(FaceSelectionMethod.USE_ACTIVE_FACE, CardStateName.Modal),
+    Specialize(FaceSelectionMethod.USE_ACTIVE_FACE, null);
 
     CardSplitType(FaceSelectionMethod calcMode, CardStateName stateName) {
         method = calcMode;

--- a/forge-core/src/main/java/forge/card/CardStateName.java
+++ b/forge-core/src/main/java/forge/card/CardStateName.java
@@ -10,7 +10,12 @@ public enum CardStateName {
     LeftSplit,
     RightSplit,
     Adventure,
-    Modal
+    Modal,
+    SpecializeW,
+    SpecializeU,
+    SpecializeB,
+    SpecializeR,
+    SpecializeG
 
     ;
 

--- a/forge-game/src/main/java/forge/game/ForgeScript.java
+++ b/forge-game/src/main/java/forge/game/ForgeScript.java
@@ -80,6 +80,22 @@ public class ForgeScript {
             return source.hasChosenColor()
                     && colors.hasAnyColor(ColorSet.fromNames(source.getChosenColors()).getColor());
 
+        } else if (property.equals("AssociatedWithChosenColor")) {
+            final String color = source.getChosenColor();
+            switch (color) {
+                case "white":
+                    return cardState.getTypeWithChanges().getLandTypes().contains("Plains");
+                case "blue":
+                    return cardState.getTypeWithChanges().getLandTypes().contains("Island");
+                case "black":
+                    return cardState.getTypeWithChanges().getLandTypes().contains("Swamp");
+                case "red":
+                    return cardState.getTypeWithChanges().getLandTypes().contains("Mountain");
+                case "green":
+                    return cardState.getTypeWithChanges().getLandTypes().contains("Forest");
+                default:
+                    return false;
+            }
         } else if (property.startsWith("non")) {
             // ... Other Card types
             return !cardState.getTypeWithChanges().hasStringType(property.substring(3));

--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -608,6 +608,10 @@ public class GameAction {
         if (c.hasIntensity()) {
             copied.setIntensity(c.getIntensity(false));
         }
+        // specialize is perpetual
+        if (c.isSpecialized()) {
+            copied.setState(c.getCurrentStateName(), false);
+        }
 
         // update state for view
         copied.updateStateForView();
@@ -688,7 +692,7 @@ public class GameAction {
         }
 
         if (fromBattlefield) {
-            if (!c.isRealToken()) {
+            if (!c.isRealToken() && !c.isSpecialized()) {
                 copied.setState(CardStateName.Original, true);
             }
             // Soulbond unpairing

--- a/forge-game/src/main/java/forge/game/ability/effects/SetStateEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/SetStateEffect.java
@@ -21,15 +21,22 @@ public class SetStateEffect extends SpellAbilityEffect {
 
     @Override
     protected String getStackDescription(final SpellAbility sa) {
+        final Card host = sa.getHostCard();
         final StringBuilder sb = new StringBuilder();
+        boolean specialize = sa.getParam("Mode").equals("Specialize");
 
         if (sa.hasParam("Flip")) {
             sb.append("Flip ");
+        } else if (specialize) { // verb will come later
         } else {
             sb.append("Transform ");
         }
 
         sb.append(Lang.joinHomogenous(getTargetCards(sa)));
+        if (specialize) {
+            sb.append(" perpetually specializes into ");
+            sb.append(host.hasChosenColor() ? host.getChosenColor() : "the chosen color");
+        }
         sb.append(".");
         return sb.toString();
     }

--- a/forge-game/src/main/java/forge/game/ability/effects/SetStateEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/SetStateEffect.java
@@ -160,6 +160,9 @@ public class SetStateEffect extends SpellAbilityEffect {
                 hasTransformed = gameCard.turnFaceUp(sa);
             } else if (sa.isManifestUp()) {
                 hasTransformed = gameCard.turnFaceUp(true, true, sa);
+            } else if ("Specialize".equals(mode)) {
+                hasTransformed = gameCard.changeCardState(mode, host.getChosenColor(), sa);
+                //remove Chosen Color here? Or just add to kw handling?
             } else {
                 hasTransformed = gameCard.changeCardState(mode, sa.getParam("NewState"), sa);
                 if (gameCard.isFaceDown() && (sa.hasParam("FaceDownPower") || sa.hasParam("FaceDownToughness")

--- a/forge-game/src/main/java/forge/game/ability/effects/SetStateEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/SetStateEffect.java
@@ -4,18 +4,23 @@ import forge.card.CardStateName;
 import forge.game.Game;
 import forge.game.GameEntityCounterTable;
 import forge.game.GameLogEntryType;
+import forge.game.ability.AbilityKey;
 import forge.game.ability.AbilityUtils;
 import forge.game.ability.SpellAbilityEffect;
 import forge.game.card.*;
 import forge.game.event.GameEventCardStatsChanged;
 import forge.game.player.Player;
 import forge.game.player.PlayerActionConfirmMode;
+import forge.game.trigger.TriggerHandler;
+import forge.game.trigger.TriggerType;
 import forge.game.spellability.SpellAbility;
 import forge.game.zone.ZoneType;
 import forge.util.Lang;
 import forge.util.Localizer;
 import forge.util.TextUtil;
 import org.apache.commons.lang3.StringUtils;
+
+import java.util.Map;
 
 public class SetStateEffect extends SpellAbilityEffect {
 
@@ -207,6 +212,12 @@ public class SetStateEffect extends SpellAbilityEffect {
                     transformedCards.add(gameCard);
                 if ("Specialize".equals(mode)) {
                     gameCard.setSpecialized(true);
+                    //run Specializes trigger
+                    final TriggerHandler th = game.getTriggerHandler();
+                    th.clearActiveTriggers(gameCard, null);
+                    th.registerActiveTrigger(gameCard, false);
+                    final Map<AbilityKey, Object> runParams = AbilityKey.mapFromCard(gameCard);
+                    th.runTrigger(TriggerType.Specializes, runParams, false);
                 } else if ("Unspecialize".equals(mode)) {
                     gameCard.setSpecialized(false);
                 }

--- a/forge-game/src/main/java/forge/game/ability/effects/SetStateEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/SetStateEffect.java
@@ -203,6 +203,11 @@ public class SetStateEffect extends SpellAbilityEffect {
                 }
                 if (!gameCard.isDoubleFaced())
                     transformedCards.add(gameCard);
+                if ("Specialize".equals(mode)) {
+                    gameCard.setSpecialized(true);
+                } else if ("Unspecialize".equals(mode)) {
+                    gameCard.setSpecialized(false);
+                }
             }
         }
         table.replaceCounterEffect(game, sa, true);

--- a/forge-game/src/main/java/forge/game/ability/effects/SetStateEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/SetStateEffect.java
@@ -94,7 +94,9 @@ public class SetStateEffect extends SpellAbilityEffect {
 
             // Cards which are not on the battlefield should not be able to transform.
             // TurnFace should be allowed in other zones like Exile too
-            if (!"TurnFace".equals(mode) && !gameCard.isInPlay() && !sa.hasParam("ETB")) {
+            // Unspecialize is allowed in other zones
+            if (!"TurnFace".equals(mode) && !"Unspecialize".equals(mode) && !gameCard.isInPlay()
+                    && !sa.hasParam("ETB")) {
                 continue;
             }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/SetStateEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/SetStateEffect.java
@@ -94,9 +94,9 @@ public class SetStateEffect extends SpellAbilityEffect {
 
             // Cards which are not on the battlefield should not be able to transform.
             // TurnFace should be allowed in other zones like Exile too
-            // Unspecialize is allowed in other zones
-            if (!"TurnFace".equals(mode) && !"Unspecialize".equals(mode) && !gameCard.isInPlay()
-                    && !sa.hasParam("ETB")) {
+            // Specialize and Unspecialize are allowed in other zones
+            if (!"TurnFace".equals(mode) && !"Unspecialize".equals(mode) && !"Specialize".equals(mode)
+                    && !gameCard.isInPlay() && !sa.hasParam("ETB")) {
                 continue;
             }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/SetStateEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/SetStateEffect.java
@@ -169,7 +169,7 @@ public class SetStateEffect extends SpellAbilityEffect {
                 hasTransformed = gameCard.turnFaceUp(true, true, sa);
             } else if ("Specialize".equals(mode)) {
                 hasTransformed = gameCard.changeCardState(mode, host.getChosenColor(), sa);
-                //remove Chosen Color here? Or just add to kw handling?
+                host.setChosenColors(null);
             } else {
                 hasTransformed = gameCard.changeCardState(mode, sa.getParam("NewState"), sa);
                 if (gameCard.isFaceDown() && (sa.hasParam("FaceDownPower") || sa.hasParam("FaceDownToughness")

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -212,6 +212,8 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
     private boolean foretoldThisTurn;
     private boolean foretoldByEffect;
 
+    private boolean specialized;
+
     private int timesCrewedThisTurn = 0;
 
     private int classLevel = 1;

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -2027,7 +2027,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
                 } else if (keyword.startsWith("Morph") || keyword.startsWith("Megamorph")
                         || keyword.startsWith("Escape") || keyword.startsWith("Foretell:")
                         || keyword.startsWith("Disturb") || keyword.startsWith("Madness:")
-                        || keyword.startsWith("Reconfigure") || keyword.startsWith("Specialize")) {
+                        || keyword.startsWith("Reconfigure")) {
                     String[] k = keyword.split(":");
                     sbLong.append(k[0]);
                     if (k.length > 1) {

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -661,6 +661,19 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
             }
         } else if (mode.equals("Meld") && isMeldable()) {
             return changeToState(CardStateName.Meld);
+        } else if (mode.equals("Specialize")) {
+            if (customState.equalsIgnoreCase("white")) {
+                return changeToState(CardStateName.SpecializeW);
+            } else if (customState.equalsIgnoreCase("blue")) {
+                return changeToState(CardStateName.SpecializeU);
+            } else if (customState.equalsIgnoreCase("black")) {
+                return changeToState(CardStateName.SpecializeB);
+            } else if (customState.equalsIgnoreCase("red")) {
+                return changeToState(CardStateName.SpecializeR);
+            } else if (customState.equalsIgnoreCase("green")) {
+                return changeToState(CardStateName.SpecializeG);
+            }
+            //do trigger here?
         }
         return false;
     }

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -663,7 +663,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
             }
         } else if (mode.equals("Meld") && isMeldable()) {
             return changeToState(CardStateName.Meld);
-        } else if (mode.equals("Specialize")) {
+        } else if (mode.equals("Specialize") && canSpecialize()) {
             if (customState.equalsIgnoreCase("white")) {
                 return changeToState(CardStateName.SpecializeW);
             } else if (customState.equalsIgnoreCase("blue")) {

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -676,6 +676,8 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
                 return changeToState(CardStateName.SpecializeG);
             }
             //do trigger here?
+        } else if (mode.equals("Unspecialize") && isSpecialized()) {
+            return changeToState(CardStateName.Original);
         }
         return false;
     }

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -2238,7 +2238,8 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
                         || keyword.startsWith("Transfigure") || keyword.startsWith("Aura swap")
                         || keyword.startsWith("Cycling") || keyword.startsWith("TypeCycling")
                         || keyword.startsWith("Encore") || keyword.startsWith("Mutate") || keyword.startsWith("Dungeon")
-                        || keyword.startsWith("Class") || keyword.startsWith("Blitz")) {
+                        || keyword.startsWith("Class") || keyword.startsWith("Blitz")
+                        || keyword.startsWith("Specialize")) {
                     // keyword parsing takes care of adding a proper description
                 } else if (keyword.equals("Unblockable")) {
                     sbLong.append(getName()).append(" can't be blocked.\r\n");

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -675,7 +675,6 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
             } else if (customState.equalsIgnoreCase("green")) {
                 return changeToState(CardStateName.SpecializeG);
             }
-            //do trigger here?
         } else if (mode.equals("Unspecialize") && isSpecialized()) {
             return changeToState(CardStateName.Original);
         }

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -2010,7 +2010,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
                 } else if (keyword.startsWith("Morph") || keyword.startsWith("Megamorph")
                         || keyword.startsWith("Escape") || keyword.startsWith("Foretell:")
                         || keyword.startsWith("Disturb") || keyword.startsWith("Madness:")
-                        || keyword.startsWith("Reconfigure")) {
+                        || keyword.startsWith("Reconfigure") || keyword.startsWith("Specialize")) {
                     String[] k = keyword.split(":");
                     sbLong.append(k[0]);
                     if (k.length > 1) {

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -5745,6 +5745,16 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
         foretoldThisTurn = false;
     }
 
+    public boolean isSpecialized() {
+        return specialized;
+    }
+    public final void setSpecialized(final boolean bool) {
+        specialized = bool;
+    }
+    public final boolean canSpecialize() {
+        return getRules() != null && getRules().getSplitType() == CardSplitType.Specialize;
+    }
+
     public int getTimesCrewedThisTurn() {
         return timesCrewedThisTurn;
     }

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -3998,6 +3998,8 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
     public final CardStateName getFaceupCardStateName() {
         if (isFlipped() && hasState(CardStateName.Flipped)) {
             return CardStateName.Flipped;
+        } else if (isSpecialized()) {
+            return getCurrentStateName();
         } else if (backside && hasBackSide()) {
             CardStateName stateName = getRules().getSplitType().getChangedStateName();
             if (hasState(stateName)) {

--- a/forge-game/src/main/java/forge/game/card/CardFactory.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactory.java
@@ -97,6 +97,7 @@ public class CardFactory {
         out.setAttachedCards(in.getAttachedCards());
         out.setEntityAttachedTo(in.getEntityAttachedTo());
 
+        out.setSpecialized(in.isSpecialized());
         out.addRemembered(in.getRemembered());
         out.addImprintedCards(in.getImprintedCards());
         out.setCommander(in.isRealCommander());

--- a/forge-game/src/main/java/forge/game/card/CardFactory.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactory.java
@@ -364,7 +364,33 @@ public class CardFactory {
 
         readCardFace(card, rules.getMainPart());
 
-        if (st != CardSplitType.None) {
+        if (st == CardSplitType.Specialize) {
+            card.addAlternateState(CardStateName.SpecializeW, false);
+            card.setState(CardStateName.SpecializeW, false);
+            if (rules.getWSpecialize() != null) {
+                readCardFace(card, rules.getWSpecialize());
+            }
+            card.addAlternateState(CardStateName.SpecializeU, false);
+            card.setState(CardStateName.SpecializeU, false);
+            if (rules.getUSpecialize() != null) {
+                readCardFace(card, rules.getUSpecialize());
+            }
+            card.addAlternateState(CardStateName.SpecializeB, false);
+            card.setState(CardStateName.SpecializeB, false);
+            if (rules.getBSpecialize() != null) {
+                readCardFace(card, rules.getBSpecialize());
+            }
+            card.addAlternateState(CardStateName.SpecializeR, false);
+            card.setState(CardStateName.SpecializeR, false);
+            if (rules.getRSpecialize() != null) {
+                readCardFace(card, rules.getRSpecialize());
+            }
+            card.addAlternateState(CardStateName.SpecializeG, false);
+            card.setState(CardStateName.SpecializeG, false);
+            if (rules.getGSpecialize() != null) {
+                readCardFace(card, rules.getGSpecialize());
+            }
+        } else if (st != CardSplitType.None) {
             card.addAlternateState(st.getChangedStateName(), false);
             card.setState(st.getChangedStateName(), false);
             if (rules.getOtherPart() != null) {

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -3221,15 +3221,11 @@ public class CardFactoryUtil {
             final String[] k = keyword.split(":");
             final String cost = k[1];
 
-            //this needs to just be AB$ SetState with choosecolor and discard costs
-            //don't forget to add SorcerySpeed$ True!!!
-            final String effect = "AB$ ChooseColor | Cost$ " + cost;
-            final String sub = "DB$ SetState | Mode$ Specialize";
+            final String effect = "AB$ SetState | Cost$ " + cost + " ChooseColor<1> Discard<1/Card.ChosenColor;" +
+                    "Card.AssociatedWithChosenColor/card of the chosen color or its associated basic land type> | " +
+                    "Mode$ Specialize | SorcerySpeed$ True";
 
             final SpellAbility sa = AbilityFactory.getAbility(effect, card);
-            final AbilitySub subSa = (AbilitySub) AbilityFactory.getAbility(sub, card);
-            sa.setSubAbility(subSa);
-
             sa.setIntrinsic(intrinsic);
             inst.addSpellAbility(sa);
         } else if (keyword.startsWith("Spectacle")) {

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -3221,13 +3221,14 @@ public class CardFactoryUtil {
             final String[] k = keyword.split(":");
             final String cost = k[1];
             String flavor = k.length > 2 && !k[2].isEmpty() ? k[2] + " – " : "";
-            String extra = k.length > 3 && !k[3].isEmpty() ? k[3] + " | " : "";
+            String condition = k.length > 3 && !k[3].isEmpty() ? ". " + k[3] : "";
+            String extra = k.length > 4 && !k[4].isEmpty() ? k[4] + " | " : "";
 
             final String effect = "AB$ SetState | Cost$ " + cost + " ChooseColor<1> Discard<1/Card.ChosenColor;" +
                     "Card.AssociatedWithChosenColor/card of the chosen color or its associated basic land type> | " +
                     "Mode$ Specialize | SorcerySpeed$ True | " + extra + "PrecostDesc$ " + flavor + "Specialize | " +
-                    "CostDesc$ " + ManaCostParser.parse(cost) + " | SpellDescription$ (" + inst.getReminderText() +
-                    ")";
+                    "CostDesc$ " + ManaCostParser.parse(cost) + condition + " | SpellDescription$ (" +
+                    inst.getReminderText() + ")";
 
             final SpellAbility sa = AbilityFactory.getAbility(effect, card);
             sa.setIntrinsic(intrinsic);

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -3220,10 +3220,14 @@ public class CardFactoryUtil {
         } else if (keyword.startsWith("Specialize")) {
             final String[] k = keyword.split(":");
             final String cost = k[1];
+            String flavor = k.length > 2 && !k[2].isEmpty() ? k[2] + " – " : "";
+            String extra = k.length > 3 && !k[3].isEmpty() ? k[3] + " | " : "";
 
             final String effect = "AB$ SetState | Cost$ " + cost + " ChooseColor<1> Discard<1/Card.ChosenColor;" +
                     "Card.AssociatedWithChosenColor/card of the chosen color or its associated basic land type> | " +
-                    "Mode$ Specialize | SorcerySpeed$ True";
+                    "Mode$ Specialize | SorcerySpeed$ True | " + extra + "PrecostDesc$ " + flavor + "Specialize | " +
+                    "CostDesc$ " + ManaCostParser.parse(cost) + " | SpellDescription$ (" + inst.getReminderText() +
+                    ")";
 
             final SpellAbility sa = AbilityFactory.getAbility(effect, card);
             sa.setIntrinsic(intrinsic);

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -3217,6 +3217,21 @@ public class CardFactoryUtil {
 
             sa.setIntrinsic(intrinsic);
             inst.addSpellAbility(sa);
+        } else if (keyword.startsWith("Specialize")) {
+            final String[] k = keyword.split(":");
+            final String cost = k[1];
+
+            //this needs to just be AB$ SetState with choosecolor and discard costs
+            //don't forget to add SorcerySpeed$ True!!!
+            final String effect = "AB$ ChooseColor | Cost$ " + cost;
+            final String sub = "DB$ SetState | Mode$ Specialize";
+
+            final SpellAbility sa = AbilityFactory.getAbility(effect, card);
+            final AbilitySub subSa = (AbilitySub) AbilityFactory.getAbility(sub, card);
+            sa.setSubAbility(subSa);
+
+            sa.setIntrinsic(intrinsic);
+            inst.addSpellAbility(sa);
         } else if (keyword.startsWith("Spectacle")) {
             final String[] k = keyword.split(":");
             final Cost cost = new Cost(k[1], false);

--- a/forge-game/src/main/java/forge/game/cost/Cost.java
+++ b/forge-game/src/main/java/forge/game/cost/Cost.java
@@ -341,6 +341,13 @@ public class Cost implements Serializable {
             return new CostUnattach(splitStr[0], description);
         }
 
+        if (parse.startsWith("ChooseColor<")) {
+            // ChooseColor<NumToChoose>
+            //TODO expand this to set off different UI for Specialize
+            final String[] splitStr = abCostParse(parse, 1);
+            return new CostChooseColor(splitStr[0]);
+        }
+
         if (parse.startsWith("ChooseCreatureType<")) {
             final String[] splitStr = abCostParse(parse, 1);
             return new CostChooseCreatureType(splitStr[0]);

--- a/forge-game/src/main/java/forge/game/cost/CostChooseColor.java
+++ b/forge-game/src/main/java/forge/game/cost/CostChooseColor.java
@@ -1,0 +1,83 @@
+/*
+ * Forge: Play Magic: the Gathering.
+ * Copyright (C) 2011  Forge Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package forge.game.cost;
+
+import forge.game.player.Player;
+import forge.game.spellability.SpellAbility;
+
+/**
+ * the class CostChooseColor
+ */
+public class CostChooseColor extends CostPart {
+
+    /**
+     * Serializables need a version ID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Instantiates a new cost choose color.
+     *
+     * @param amount
+     *            the amount
+     */
+    public CostChooseColor(final String amount) {
+        this.setAmount(amount);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see
+     * forge.card.cost.CostPart#canPay(forge.card.spellability.SpellAbility,
+     * forge.Card, forge.Player, forge.card.cost.Cost)
+     */
+    @Override
+    public final boolean canPay(final SpellAbility ability, final Player payer, final boolean effect) {
+        return true;
+    }
+
+    @Override
+    public boolean payAsDecided(Player payer, PaymentDecision pd, SpellAbility sa, final boolean effect) {
+        sa.getHostCard().setChosenColors(pd.colors);
+        return true;
+    }
+
+    @Override
+    public int paymentOrder() { return 8; }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see forge.card.cost.CostPart#toString()
+     */
+    @Override
+    public final String toString() {
+        final StringBuilder sb = new StringBuilder();
+        final Integer i = this.convertAmount();
+        sb.append("Choose ");
+        sb.append(Cost.convertAmountTypeToWords(i, this.getAmount(), "color"));
+        return sb.toString();
+    }
+
+    @Override
+    public <T> T accept(ICostVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+
+}

--- a/forge-game/src/main/java/forge/game/cost/CostChooseColor.java
+++ b/forge-game/src/main/java/forge/game/cost/CostChooseColor.java
@@ -17,6 +17,7 @@
  */
 package forge.game.cost;
 
+import forge.game.card.Card;
 import forge.game.player.Player;
 import forge.game.spellability.SpellAbility;
 
@@ -73,6 +74,19 @@ public class CostChooseColor extends CostPart {
         sb.append("Choose ");
         sb.append(Cost.convertAmountTypeToWords(i, this.getAmount(), "color"));
         return sb.toString();
+    }
+
+    @Override
+    public boolean isUndoable() { return true; }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see forge.card.cost.CostPart#refund(forge.Card)
+     */
+    @Override
+    public final void refund(final Card source) {
+        source.setChosenColors(null);
     }
 
     @Override

--- a/forge-game/src/main/java/forge/game/cost/CostDiscard.java
+++ b/forge-game/src/main/java/forge/game/cost/CostDiscard.java
@@ -166,7 +166,9 @@ public class CostDiscard extends CostPartWithList {
                 sameName = true;
                 type = TextUtil.fastReplace(type, "+WithSameName", "");
             }
-            if (!type.equals("Random") && !type.contains("X")) {
+            if (type.contains("ChosenColor") && !source.hasChosenColor()) {
+                //color hasn't been chosen yet, so skip getValidCards
+            } else if (!type.equals("Random") && !type.contains("X")) {
                 // Knollspine Invocation fails to activate without the above conditional
                 handList = CardLists.getValidCards(handList, type.split(";"), payer, source, ability);
             }

--- a/forge-game/src/main/java/forge/game/cost/ICostVisitor.java
+++ b/forge-game/src/main/java/forge/game/cost/ICostVisitor.java
@@ -3,6 +3,7 @@ package forge.game.cost;
 public interface ICostVisitor<T> {
 
     T visit(CostGainControl cost);
+    T visit(CostChooseColor cost);
     T visit(CostChooseCreatureType cost);
     T visit(CostDiscard cost);
     T visit(CostDamage cost);
@@ -37,6 +38,11 @@ public interface ICostVisitor<T> {
 
         @Override
         public T visit(CostGainControl cost) {
+            return null;
+        }
+
+        @Override
+        public T visit(CostChooseColor cost) {
             return null;
         }
 

--- a/forge-game/src/main/java/forge/game/cost/PaymentDecision.java
+++ b/forge-game/src/main/java/forge/game/cost/PaymentDecision.java
@@ -13,6 +13,7 @@ import forge.util.TextUtil;
 public class PaymentDecision {
     public int c = 0;
     public String type;
+    public List<String> colors;
 
     public final CardCollection cards = new CardCollection();
     public final List<Mana> mana;
@@ -46,6 +47,11 @@ public class PaymentDecision {
     public PaymentDecision(String choice) {
         this(null, null, null, null, null);
         type = choice;
+    }
+
+    public PaymentDecision(List<String> choices) {
+        this(null, null, null, null, null);
+        colors = choices;
     }
 
     public static PaymentDecision card(Card chosen) {
@@ -86,6 +92,10 @@ public class PaymentDecision {
 
     public static PaymentDecision type(String choice) {
         return new PaymentDecision(choice);
+    }
+
+    public static PaymentDecision colors(List<String> choices) {
+        return new PaymentDecision(choices);
     }
 
     public static PaymentDecision players(List<Player> players) {

--- a/forge-game/src/main/java/forge/game/keyword/Keyword.java
+++ b/forge-game/src/main/java/forge/game/keyword/Keyword.java
@@ -153,6 +153,7 @@ public enum Keyword {
     SCAVENGE("Scavenge", KeywordWithCost.class, false, "%s, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery."),
     SOULBOND("Soulbond", SimpleKeyword.class, true, "You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them."),
     SOULSHIFT("Soulshift", KeywordWithAmount.class, false, "When this creature dies, you may return target Spirit card with mana value %d or less from your graveyard to your hand."),
+    SPECIALIZE("Specialize", KeywordWithCost.class, false, "%s, Choose a color, discard a card of that color or associated basic land type: This card perpetually specializes into that color. Activate only as a sorcery."),
     SPECTACLE("Spectacle", KeywordWithCost.class, false, "You may cast this spell for its spectacle cost rather than its mana cost if an opponent lost life this turn."),
     SPLICE("Splice", KeywordWithCostAndType.class, false, "As you cast an %2$s spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell."),
     SPLIT_SECOND("Split second", SimpleKeyword.class, true, "As long as this spell is on the stack, players can't cast other spells or activate abilities that aren't mana abilities."),

--- a/forge-game/src/main/java/forge/game/keyword/KeywordWithCost.java
+++ b/forge-game/src/main/java/forge/game/keyword/KeywordWithCost.java
@@ -7,7 +7,8 @@ public class KeywordWithCost extends KeywordInstance<KeywordWithCost> {
 
     @Override
     protected void parse(String details) {
-        cost = new Cost(details.split("\\|", 2)[0].trim(), false);
+        String[] allDetails = details.split(":");
+        cost = new Cost(allDetails[0].split("\\|", 2)[0].trim(), false);
     }
 
     @Override

--- a/forge-game/src/main/java/forge/game/trigger/TriggerSpecializes.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerSpecializes.java
@@ -1,0 +1,73 @@
+/*
+ * Forge: Play Magic: the Gathering.
+ * Copyright (C) 2011  Forge Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package forge.game.trigger;
+
+import forge.game.ability.AbilityKey;
+import forge.game.card.Card;
+import forge.game.spellability.SpellAbility;
+import forge.util.Localizer;
+
+import java.util.Map;
+
+/**
+ * <p>
+ * TriggerSpecializes class.
+ * </p>
+ */
+public class TriggerSpecializes extends Trigger {
+
+    /**
+     * <p>
+     * Constructor for TriggerSpecializes
+     * </p>
+     *
+     * @param params
+     *            a {@link java.util.HashMap} object.
+     * @param host
+     *            a {@link forge.game.card.Card} object.
+     * @param intrinsic
+     *            the intrinsic
+     */
+    public TriggerSpecializes (Map<String, String> params, final Card host, final boolean intrinsic) {
+        super(params, host, intrinsic);
+    }
+
+    /** {@inheritDoc}
+     * @param runParams*/
+    @Override
+    public final boolean performTest(Map<AbilityKey, Object> runParams) {
+        if (!matchesValidParam("ValidCard", runParams.get(AbilityKey.Card))) {
+            return false;
+        }
+        return true;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public final void setTriggeringObjects(final SpellAbility sa, Map<AbilityKey, Object> runParams) {
+        sa.setTriggeringObjectsFrom(runParams, AbilityKey.Card);
+    }
+
+    @Override
+    public String getImportantStackObjects(SpellAbility sa) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(Localizer.getInstance().getMessage("lblSpecialized")).append(": ");
+        sb.append(sa.getTriggeringObject(AbilityKey.Card));
+        return sb.toString();
+    }
+}

--- a/forge-game/src/main/java/forge/game/trigger/TriggerType.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerType.java
@@ -102,6 +102,7 @@ public enum TriggerType {
     SearchedLibrary(TriggerSearchedLibrary.class),
     SetInMotion(TriggerSetInMotion.class),
     Shuffled(TriggerShuffled.class),
+    Specializes(TriggerSpecializes.class),
     SpellAbilityCast(TriggerSpellAbilityCastOrCopy.class),
     SpellAbilityCopy(TriggerSpellAbilityCastOrCopy.class),
     SpellCast(TriggerSpellAbilityCastOrCopy.class),

--- a/forge-gui/res/cardsfolder/a/alora_merry_thief.txt
+++ b/forge-gui/res/cardsfolder/a/alora_merry_thief.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature Halfling Rogue
 PT:3/2
 T:Mode$ AttackersDeclared | AttackingPlayer$ You | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever you attack, up to one target attacking creature can't be blocked this turn. Return that creature to its owner's hand at the beginning of the next end step.
 SVar:TrigPump:DB$ Pump | KW$ HIDDEN Unblockable | TgtPrompt$ Select target attacking creature | ValidTgts$ Creature.attacking | TargetMin$ 0 | TargetMax$ 1 | SubAbility$ DBDelTrig
-SVar:DBDelTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | RememberObjects$ Targeted | Execute$ TrigReturn | SpellDescription$ Return that creature to its owner's hand at the beginning of the next end step.
+SVar:DBDelTrig:DB$ DelayedTrigger | ConditionDefined$ Targeted | ConditionPresent$ Card | Mode$ Phase | Phase$ End of Turn | RememberObjects$ Targeted | Execute$ TrigReturn | SpellDescription$ Return that creature to its owner's hand at the beginning of the next end step.
 SVar:TrigReturn:DB$ ChangeZone | Defined$ DelayTriggerRememberedLKI | Origin$ Battlefield | Destination$ Hand
 K:Choose a Background
 Oracle:Whenever you attack, up to one target attacking creature can't be blocked this turn. Return that creature to its owner's hand at the beginning of the next end step.\nChoose a Background (You can have a Background as a second commander.)

--- a/forge-gui/res/cardsfolder/upcoming/alora_rogue_companion.txt
+++ b/forge-gui/res/cardsfolder/upcoming/alora_rogue_companion.txt
@@ -1,0 +1,86 @@
+Name:Alora, Rogue Companion
+ManaCost:3 U
+Types:Legendary Creature Halfling Rogue
+PT:3/3
+K:Specialize:2
+T:Mode$ AttackersDeclared | AttackingPlayer$ You | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever you attack, up to one target attacking creature can't be blocked this turn. At the beginning of the next end step, return that creature to its owner's hand.
+SVar:TrigPump:DB$ Pump | KW$ HIDDEN Unblockable | TgtPrompt$ Select target attacking creature | ValidTgts$ Creature.attacking | TargetMin$ 0 | TargetMax$ 1 | SubAbility$ DBDelTrig
+SVar:DBDelTrig:DB$ DelayedTrigger | ConditionDefined$ Targeted | ConditionPresent$ Card | Mode$ Phase | Phase$ End of Turn | RememberObjects$ Targeted | Execute$ TrigReturn | TriggerDescription$ At the beginning of the next end step, return that creature to its owner's hand.
+SVar:TrigReturn:DB$ ChangeZone | Defined$ DelayTriggerRememberedLKI | Origin$ Battlefield | Destination$ Hand
+AlternateMode:Specialize
+Oracle:Specialize {2}\nWhenever you attack, up to one target attacking creature can't be blocked this turn. At the beginning of the next end step, return that creature to its owner's hand.
+
+SPECIALIZE:WHITE
+
+Name:Alora, Cheerful Mastermind
+ManaCost:3 W U
+Types:Legendary Creature Halfling Rogue
+PT:4/4
+T:Mode$ AttackersDeclared | AttackingPlayer$ You | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever you attack, up to one target attacking creature can't be blocked this turn. At the beginning of the next end step, return that creature to its owner's hand. If you do, create a 1/1 white Soldier creature token.
+SVar:TrigPump:DB$ Pump | KW$ HIDDEN Unblockable | TgtPrompt$ Select target attacking creature | ValidTgts$ Creature.attacking | TargetMin$ 0 | TargetMax$ 1 | SubAbility$ DBDelTrig
+SVar:DBDelTrig:DB$ DelayedTrigger | ConditionDefined$ Targeted | ConditionPresent$ Card | Mode$ Phase | Phase$ End of Turn | RememberObjects$ Targeted | Execute$ TrigReturn | TriggerDescription$ At the beginning of the next end step, return that creature to its owner's hand. If you do, create a 1/1 white Soldier creature token.
+SVar:TrigReturn:DB$ ChangeZone | Defined$ DelayTriggerRememberedLKI | Origin$ Battlefield | Destination$ Hand | ForgetOtherRemembered$ True | RememberChanged$ True | SubAbility$ DBToken
+SVar:DBToken:DB$ Token | TokenScript$ w_1_1_soldier | ConditionDefined$ Remembered | ConditionPresent$ Card | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+DeckHas:Ability$Token & Type$Soldier
+Oracle:Whenever you attack, up to one target attacking creature can't be blocked this turn. At the beginning of the next end step, return that creature to its owner's hand. If you do, create a 1/1 white Soldier creature token.
+
+SPECIALIZE:BLUE
+
+Name:Alora, Cheerful Thief
+ManaCost:3 U U
+Types:Legendary Creature Halfling Rogue
+PT:4/4
+T:Mode$ AttackersDeclared | AttackingPlayer$ You | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever you attack, up to one target attacking creature can't be blocked this turn. At the beginning of the next end step, return that creature to its owner's hand. If you do, a creature of your choice an opponent controls perpetually gets -1/-0.
+SVar:TrigPump:DB$ Pump | KW$ HIDDEN Unblockable | TgtPrompt$ Select target attacking creature | ValidTgts$ Creature.attacking | TargetMin$ 0 | TargetMax$ 1 | SubAbility$ DBDelTrig
+SVar:DBDelTrig:DB$ DelayedTrigger | ConditionDefined$ Targeted | ConditionPresent$ Card | Mode$ Phase | Phase$ End of Turn | RememberObjects$ Targeted | Execute$ TrigReturn | TriggerDescription$ At the beginning of the next end step, return that creature to its owner's hand. If you do, a creature of your choice an opponent controls perpetually gets -1/-0.
+SVar:TrigReturn:DB$ ChangeZone | Defined$ DelayTriggerRememberedLKI | Origin$ Battlefield | Destination$ Hand | ForgetOtherRemembered$ True | RememberChanged$ True | SubAbility$ DBChooseCard
+SVar:DBChooseCard:DB$ ChooseCard | ConditionDefined$ Remembered | ConditionPresent$ Card | Choices$ Creature.OppCtrl | Mandatory$ True | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | SubAbility$ DBPerpetual
+SVar:DBPerpetual:DB$ Effect | ConditionDefined$ ChosenCard | ConditionPresent$ Card | StaticAbilities$ PerpetualDebuff | Name$ Alora, Cheerful Thief's Perpetual Effect | Duration$ Permanent | SubAbility$ DBClearChosen
+SVar:PerpetualDebuff:Mode$ Continuous | Affected$ Card.ChosenCard | AddPower$ -1 | EffectZone$ Command | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | Description$ The chosen creature perpetually gets -1/-0.
+SVar:DBClearChosen:DB$ Cleanup | ClearChosenCard$ True
+Oracle:Whenever you attack, up to one target attacking creature can't be blocked this turn. At the beginning of the next end step, return that creature to its owner's hand. If you do, a creature of your choice an opponent controls perpetually gets -1/-0.
+
+SPECIALIZE:BLACK
+
+Name:Alora, Cheerful Assassin
+ManaCost:3 U B
+Types:Legendary Creature Halfling Rogue Assassin
+PT:4/4
+T:Mode$ AttackersDeclared | AttackingPlayer$ You | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever you attack, up to one target attacking creature can't be blocked this turn. At the beginning of the next end step, return that creature to its owner's hand. If you do, each opponent loses 2 life.
+SVar:TrigPump:DB$ Pump | KW$ HIDDEN Unblockable | TgtPrompt$ Select target attacking creature | ValidTgts$ Creature.attacking | TargetMin$ 0 | TargetMax$ 1 | SubAbility$ DBDelTrig
+SVar:DBDelTrig:DB$ DelayedTrigger | ConditionDefined$ Targeted | ConditionPresent$ Card | Mode$ Phase | Phase$ End of Turn | RememberObjects$ Targeted | Execute$ TrigReturn | TriggerDescription$ At the beginning of the next end step, return that creature to its owner's hand. If you do, each opponent loses 2 life.
+SVar:TrigReturn:DB$ ChangeZone | Defined$ DelayTriggerRememberedLKI | Origin$ Battlefield | Destination$ Hand | ForgetOtherRemembered$ True | RememberChanged$ True | SubAbility$ DBDrain
+SVar:DBDrain:DB$ LoseLife | Defined$ Opponent | LifeAmount$ 2 | ConditionDefined$ Remembered | ConditionPresent$ Card
+Oracle:Whenever you attack, up to one target attacking creature can't be blocked this turn. At the beginning of the next end step, return that creature to its owner's hand. If you do, each opponent loses 2 life.
+
+SPECIALIZE:RED
+
+Name:Alora, Cheerful Swashbuckler
+ManaCost:3 U R
+Types:Legendary Creature Halfling Rogue
+PT:4/4
+T:Mode$ AttackersDeclared | AttackingPlayer$ You | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever you attack, up to one target attacking creature can't be blocked this turn. At the beginning of the next end step, return that creature to its owner's hand. If you do, create a Treasure token.
+SVar:TrigPump:DB$ Pump | KW$ HIDDEN Unblockable | TgtPrompt$ Select target attacking creature | ValidTgts$ Creature.attacking | TargetMin$ 0 | TargetMax$ 1 | SubAbility$ DBDelTrig
+SVar:DBDelTrig:DB$ DelayedTrigger | ConditionDefined$ Targeted | ConditionPresent$ Card | Mode$ Phase | Phase$ End of Turn | RememberObjects$ Targeted | Execute$ TrigReturn | TriggerDescription$ At the beginning of the next end step, return that creature to its owner's hand. If you do, create a Treasure token.
+SVar:TrigReturn:DB$ ChangeZone | Defined$ DelayTriggerRememberedLKI | Origin$ Battlefield | Destination$ Hand | ForgetOtherRemembered$ True | RememberChanged$ True | SubAbility$ DBTreasure
+SVar:DBTreasure:DB$ Token | TokenScript$ c_a_treasure_sac | ConditionDefined$ Remembered | ConditionPresent$ Card | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+DeckHas:Ability$Token|Sacrifice & Type$Artifact|Treasure
+Oracle:Whenever you attack, up to one target attacking creature can't be blocked this turn. At the beginning of the next end step, return that creature to its owner's hand. If you do, create a Treasure token.
+
+SPECIALIZE:GREEN
+
+Name:Alora, Cheerful Scout
+ManaCost:3 G U
+Types:Legendary Creature Halfling Rogue Scout
+PT:4/4
+T:Mode$ AttackersDeclared | AttackingPlayer$ You | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever you attack, up to one target attacking creature can't be blocked this turn. At the beginning of the next end step, return that creature to its owner's hand. If you do, it perpetually gets +1/+1.
+SVar:TrigPump:DB$ Pump | KW$ HIDDEN Unblockable | TgtPrompt$ Select target attacking creature | ValidTgts$ Creature.attacking | TargetMin$ 0 | TargetMax$ 1 | SubAbility$ DBDelTrig
+SVar:DBDelTrig:DB$ DelayedTrigger | ConditionDefined$ Targeted | ConditionPresent$ Card | Mode$ Phase | Phase$ End of Turn | RememberObjects$ Targeted | Execute$ TrigReturn | TriggerDescription$ At the beginning of the next end step, return that creature to its owner's hand. If you do, it perpetually gets +1/+1.
+SVar:TrigReturn:DB$ ChangeZone | Defined$ DelayTriggerRememberedLKI | Origin$ Battlefield | Destination$ Hand | ForgetOtherRemembered$ True | RememberChanged$ True | SubAbility$ DBPerpetual
+SVar:DBPerpetual:DB$ Effect | ConditionDefined$ Remembered | ConditionPresent$ Card | RememberObjects$ Remembered | StaticAbilities$ PerpetualP1P1 | Name$ Alora, Cheerful Scout's Perpetual Effect | Duration$ Permanent | SubAbility$ DBCleanup
+SVar:PerpetualP1P1:Mode$ Continuous | Affected$ Card.IsRemembered | AddPower$ 1 | AddToughness$ 1 | EffectZone$ Command | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | Description$ That creature perpetually gets +1/+1.
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:Whenever you attack, up to one target attacking creature can't be blocked this turn. At the beginning of the next end step, return that creature to its owner's hand. If you do, it perpetually gets +1/+1.

--- a/forge-gui/res/cardsfolder/upcoming/karlach_raging_tiefling.txt
+++ b/forge-gui/res/cardsfolder/upcoming/karlach_raging_tiefling.txt
@@ -1,0 +1,96 @@
+Name:Karlach, Raging Tiefling
+ManaCost:1 R
+Types:Legendary Creature Tiefling Barbarian
+PT:2/2
+K:First strike
+K:Specialize:6:Rage Beyond Death:You may also activate this ability if CARDNAME is in your graveyard.:AdditionalActivationZone$ Graveyard
+AlternateMode:Specialize
+DeckHas:Ability$Graveyard
+Oracle:First strike\nRage Beyond Death — Specialize {6}. You may also activate this ability if Karlach, Raging Tiefling is in your graveyard.
+
+SPECIALIZE:WHITE
+
+Name:Karlach, Tiefling Zealot
+ManaCost:1 R W
+Types:Legendary Creature Tiefling Barbarian
+PT:4/4
+K:First strike
+K:Haste
+T:Mode$ Specializes | ValidCard$ Card.Self | TriggerZones$ Graveyard | Execute$ TrigReturn | TriggerDescription$ When this card specializes from your graveyard, return it from your graveyard to the battlefield. It perpetually gains "This creature can't block."
+SVar:TrigReturn:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | Defined$ TriggeredCard | SubAbility$ DBEffect
+SVar:DBEffect:DB$ Effect | RememberObjects$ TriggeredCard | StaticAbilities$ PerpetualStatic | Duration$ Permanent
+SVar:PerpetualStatic:Mode$ Continuous | Affected$ Card.IsRemembered | AddKeyword$ CARDNAME can't block. | EffectZone$ Command | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | Description$ It perpetually gains "This creature can't block."
+T:Mode$ Specializes | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When this card specializes from any zone, create a 2/2 white Knight creature token. Creatures you control get +1/+1 and gain haste until end of turn.
+SVar:TrigToken:DB$ Token | TokenScript$ w_2_2_knight | SubAbility$ DBPumpAll
+SVar:DBPumpAll:DB$ PumpAll | ValidCards$ Creature.YouCtrl | NumAtt$ +1 | NumDef$ +1 | KW$ Haste
+DeckHas:Ability$Token & Type$Knight
+Oracle:First strike, haste\nWhen this card specializes from your graveyard, return it from your graveyard to the battlefield. It perpetually gains "This creature can't block."\nWhen this card specializes from any zone, create a 2/2 white Knight creature token. Creatures you control get +1/+1 and gain haste until end of turn.
+
+SPECIALIZE:BLUE
+
+Name:Karlach, Tiefling Spellrager
+ManaCost:1 U R
+Types:Legendary Creature Tiefling Barbarian
+PT:4/4
+K:First strike
+K:Haste
+T:Mode$ Specializes | ValidCard$ Card.Self | TriggerZones$ Graveyard | Execute$ TrigReturn | TriggerDescription$ When this card specializes from your graveyard, return it from your graveyard to the battlefield. It perpetually gains "This creature can't block."
+SVar:TrigReturn:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | Defined$ TriggeredCard | SubAbility$ DBEffect
+SVar:DBEffect:DB$ Effect | RememberObjects$ TriggeredCard | StaticAbilities$ PerpetualStatic | Duration$ Permanent
+SVar:PerpetualStatic:Mode$ Continuous | Affected$ Card.IsRemembered | AddKeyword$ CARDNAME can't block. | EffectZone$ Command | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | Description$ It perpetually gains "This creature can't block."
+T:Mode$ Specializes | ValidCard$ Card.Self | Execute$ TrigSeek | TriggerDescription$ When this card specializes from any zone, seek an instant or sorcery card with mana value 3 or less. Until end of turn, you may cast that card without paying its mana cost.
+SVar:TrigSeek:DB$ ChangeZone | Origin$ Library | Destination$ Hand | AtRandom$ True | NoShuffle$ True | NoLooking$ True | NoReveal$ True | ChangeNum$ 1 | ChangeType$ Instant.cmcLE3,Sorcery.cmcLE3 | RememberChanged$ True
+SVar:DBEffect:DB$ Effect | StaticAbilities$ MayPlay | RememberObjects$ Remembered | ForgetOnMoved$ Hand | SubAbility$ DBCleanup
+SVar:MayPlay:Mode$ Continuous | Affected$ Card.IsRemembered+nonLand | MayPlayWithoutManaCost$ True | EffectZone$ Command | AffectedZone$ Hand
+DeckHints:Type$Instant|Sorcery
+Oracle:First strike, haste\nWhen this card specializes from your graveyard, return it from your graveyard to the battlefield. It perpetually gains "This creature can't block."\nWhen this card specializes from any zone, seek an instant or sorcery card with mana value 3 or less. Until end of turn, you may cast that card without paying its mana cost.
+
+SPECIALIZE:BLACK
+
+Name:Karlach, Tiefling Punisher
+ManaCost:1 B R
+Types:Legendary Creature Tiefling Barbarian
+PT:4/4
+K:First strike
+K:Haste
+T:Mode$ Specializes | ValidCard$ Card.Self | TriggerZones$ Graveyard | Execute$ TrigReturn | TriggerDescription$ When this card specializes from your graveyard, return it from your graveyard to the battlefield. It perpetually gains "This creature can't block."
+SVar:TrigReturn:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | Defined$ TriggeredCard | SubAbility$ DBEffect
+SVar:DBEffect:DB$ Effect | RememberObjects$ TriggeredCard | StaticAbilities$ PerpetualStatic | Duration$ Permanent
+SVar:PerpetualStatic:Mode$ Continuous | Affected$ Card.IsRemembered | AddKeyword$ CARDNAME can't block. | EffectZone$ Command | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | Description$ It perpetually gains "This creature can't block."
+T:Mode$ Specializes | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ When this card specializes from any zone, you may sacrifice a creature. If you do, you draw two cards and each opponent loses 2 life.
+SVar:TrigDraw:AB$ Draw | Cost$ Sac<1/Creature> | NumCards$ 2 | SubAbility$ DBLoseLife
+SVar:DBLoseLife:DB$ LoseLife | Defined$ Opponent | LifeAmount$ 2
+DeckHas:Ability$Sacrifice
+Oracle:First strike, haste\nWhen this card specializes from your graveyard, return it from your graveyard to the battlefield. It perpetually gains "This creature can't block."\nWhen this card specializes from any zone, you may sacrifice a creature. If you do, you draw two cards and each opponent loses 2 life.
+
+SPECIALIZE:RED
+
+Name:Karlach, Tiefling Berserker
+ManaCost:1 R R
+Types:Legendary Creature Tiefling Barbarian
+PT:4/4
+K:First strike
+K:Haste
+T:Mode$ Specializes | ValidCard$ Card.Self | TriggerZones$ Graveyard | Execute$ TrigReturn | TriggerDescription$ When this card specializes from your graveyard, return it from your graveyard to the battlefield. It perpetually gains "This creature can't block."
+SVar:TrigReturn:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | Defined$ TriggeredCard | SubAbility$ DBEffect
+SVar:DBEffect:DB$ Effect | RememberObjects$ TriggeredCard | StaticAbilities$ PerpetualStatic | Duration$ Permanent
+SVar:PerpetualStatic:Mode$ Continuous | Affected$ Card.IsRemembered | AddKeyword$ CARDNAME can't block. | EffectZone$ Command | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | Description$ It perpetually gains "This creature can't block."
+T:Mode$ Specializes | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ When this card specializes from any zone, target creature an opponent controls can't block this turn.
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.OppCtrl | KW$ HIDDEN CARDNAME can't block. | TgtPrompt$ Select target creature an opponent controls | IsCurse$ True
+Oracle:First strike, haste\nWhen this card specializes from your graveyard, return it from your graveyard to the battlefield. It perpetually gains "This creature can't block."\nWhen this card specializes from any zone, target creature an opponent controls can't block this turn.
+
+SPECIALIZE:GREEN
+
+Name:Karlach, Tiefling Guardian
+ManaCost:1 R G
+Types:Legendary Creature Tiefling Barbarian
+PT:4/4
+K:First strike
+K:Haste
+T:Mode$ Specializes | ValidCard$ Card.Self | TriggerZones$ Graveyard | Execute$ TrigReturn | TriggerDescription$ When this card specializes from your graveyard, return it from your graveyard to the battlefield. It perpetually gains "This creature can't block."
+SVar:TrigReturn:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | Defined$ TriggeredCard | SubAbility$ DBEffect
+SVar:DBEffect:DB$ Effect | RememberObjects$ TriggeredCard | StaticAbilities$ PerpetualStatic | Duration$ Permanent
+SVar:PerpetualStatic:Mode$ Continuous | Affected$ Card.IsRemembered | AddKeyword$ CARDNAME can't block. | EffectZone$ Command | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | Description$ It perpetually gains "This creature can't block."
+T:Mode$ Specializes | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ When this card specializes from any zone, another target creature you control gets +4/+4 until end of turn.
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.Other+YouCtrl | TgtPrompt$ Select another target creature you control | NumAtt$ +4 | NumDef$ +4
+Oracle:First strike, haste\nWhen this card specializes from your graveyard, return it from your graveyard to the battlefield. It perpetually gains "This creature can't block."\nWhen this card specializes from any zone, another target creature you control gets +4/+4 until end of turn.

--- a/forge-gui/res/cardsfolder/upcoming/lukamina_moon_druid.txt
+++ b/forge-gui/res/cardsfolder/upcoming/lukamina_moon_druid.txt
@@ -1,0 +1,76 @@
+Name:Lukamina, Moon Druid
+ManaCost:2 G
+Types:Legendary Creature Human Druid
+PT:2/2
+K:Specialize:3:Wild Shape:Activate only if you control six or more lands.:IsPresent$ Land.YouCtrl | PresentCompare$ GE6
+T:Mode$ ChangesZone | ValidCard$ Card.wasCastByYou+Self | Destination$ Battlefield | Execute$ TrigSeek | TriggerDescription$ When CARDNAME enters the battlefield, if you cast it, seek a land card with a basic land type.
+SVar:TrigSeek:DB$ ChangeZone | Origin$ Library | Destination$ Hand | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | NoReveal$ True | ChangeType$ Land.hasABasicLandType | ChangeNum$ 1
+AlternateMode:Specialize
+Oracle:Wild Shape — Specialize {3}. Activate only if you control six or more lands.\nWhen Lukamina, Moon Druid enters the battlefield, if you cast it, seek a land card with a basic land type.
+
+SPECIALIZE:WHITE
+
+Name:Lukamina, Hawk Form
+ManaCost:2 G W
+Types:Legendary Creature Bird Druid
+PT:4/4
+K:Flying
+K:Lifelink
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigUnspecialize | TriggerDescription$ When CARDNAME dies, it unspecializes. If it unspecializes this way, return it to the battlefield tapped.
+SVar:TrigUnspecialize:DB$ SetState | Mode$ Unspecialize | RememberChanged$ True | SubAbility$ DBReturn
+SVar:DBReturn:DB$ ChangeZone | ConditionDefined$ Remembered | ConditionPresent$ Card | Origin$ Graveyard | Destination$ Battlefield | Tapped$ True | Defined$ Remembered
+DeckHas:Ability$LifeGain
+Oracle:Flying, lifelink\nWhen Lukamina, Hawk Form dies, it unspecializes. If it unspecializes this way, return it to the battlefield tapped.
+
+SPECIALIZE:BLUE
+
+Name:Lukamina, Crocodile Form
+ManaCost:2 G U
+Types:Legendary Creature Crocodile Druid
+PT:4/4
+#Needs specialize trigger
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigUnspecialize | TriggerDescription$ When NICKNAME dies, it unspecializes. If it unspecializes this way, return it to the battlefield tapped.
+SVar:TrigUnspecialize:DB$ SetState | Defined$ TriggeredCard | Mode$ Unspecialize | RememberChanged$ True | SubAbility$ DBReturn
+SVar:DBReturn:DB$ ChangeZone | ConditionDefined$ Remembered | ConditionPresent$ Card | Origin$ Graveyard | Destination$ Battlefield | Tapped$ True | Defined$ Remembered
+Oracle:When this creature specializes, tap target nonland permanent an opponent controls. That permanent doesn't untap during its controller's untap step for as long as you control Lukamina, Crocodile Form.\nWhen Lukamina dies, it unspecializes. If it unspecializes this way, return it to the battlefield tapped.
+
+SPECIALIZE:BLACK
+
+Name:Lukamina, Scorpion Form
+ManaCost:2 B G
+Types:Legendary Creature Scorpion Druid
+PT:4/4
+K:Deathtouch
+K:CARDNAME must be blocked if able.
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigUnspecialize | TriggerDescription$ When NICKNAME dies, it unspecializes. If it unspecializes this way, return it to the battlefield tapped.
+SVar:TrigUnspecialize:DB$ SetState | Defined$ TriggeredCard | Mode$ Unspecialize | RememberChanged$ True | SubAbility$ DBReturn
+SVar:DBReturn:DB$ ChangeZone | ConditionDefined$ Remembered | ConditionPresent$ Card | Origin$ Graveyard | Destination$ Battlefield | Tapped$ True | Defined$ Remembered
+Oracle:Deathtouch\nLukamina, Scorpion Form must be blocked if able.\nWhen Lukamina dies, it unspecializes. If it unspecializes this way, return it to the battlefield tapped.
+
+SPECIALIZE:RED
+
+Name:Lukamina, Wolf Form
+ManaCost:2 R G
+Types:Legendary Creature Wolf Druid
+PT:4/4
+K:Menace
+#Needs specialize trigger - then make attacks trigger secondary
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ Whenever this creature specializes or attacks, create a 2/2 green Wolf creature token.
+SVar:TrigToken:DB$ Token | TokenScript$ g_2_2_wolf
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigUnspecialize | TriggerDescription$ When NICKNAME dies, it unspecializes. If it unspecializes this way, return it to the battlefield tapped.
+SVar:TrigUnspecialize:DB$ SetState | Defined$ TriggeredCard | Mode$ Unspecialize | RememberChanged$ True | SubAbility$ DBReturn
+SVar:DBReturn:DB$ ChangeZone | ConditionDefined$ Remembered | ConditionPresent$ Card | Origin$ Graveyard | Destination$ Battlefield | Tapped$ True | Defined$ Remembered
+DeckHas:Ability$Token
+Oracle:Menace\nWhenever this creature specializes or attacks, create a 2/2 green Wolf creature token.\nWhen Lukamina, Wolf Form dies, it unspecializes. If it unspecializes this way, return it to the battlefield tapped.
+
+SPECIALIZE:GREEN
+
+Name:Lukamina, Bear Form
+ManaCost:2 G G
+Types:Legendary Creature Bear Druid
+K:Trample
+S:Mode$ Continuous | Affected$ Creature.YouCtrl+Other | AddPower$ 1 | AddToughness$ 1 | AddKeyword$ Trample | Description$ Other creatures you control get +1/+1 and have trample.
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigUnspecialize | TriggerDescription$ When CARDNAME dies, it unspecializes. If it unspecializes this way, return it to the battlefield tapped.
+SVar:TrigUnspecialize:DB$ SetState | Defined$ TriggeredCard | Mode$ Unspecialize | RememberChanged$ True | SubAbility$ DBReturn
+SVar:DBReturn:DB$ ChangeZone | ConditionDefined$ Remembered | ConditionPresent$ Card | Origin$ Graveyard | Destination$ Battlefield | Tapped$ True | Defined$ Remembered
+Oracle:Trample\nOther creatures you control get +1/+1 and have trample.\nWhen Lukamina, Bear Form dies, it unspecializes. If it unspecializes this way, return it to the battlefield tapped.

--- a/forge-gui/res/cardsfolder/upcoming/lukamina_moon_druid.txt
+++ b/forge-gui/res/cardsfolder/upcoming/lukamina_moon_druid.txt
@@ -28,7 +28,9 @@ Name:Lukamina, Crocodile Form
 ManaCost:2 G U
 Types:Legendary Creature Crocodile Druid
 PT:4/4
-#Needs specialize trigger
+T:Mode$ Specializes | ValidCard$ Card.Self | Execute$ TrigTap | TriggerDescription$ When this creature specializes, tap target nonland permanent an opponent controls. That permanent doesn't untap during its controller's untap step for as long as you control CARDNAME.
+SVar:TrigTap:DB$ Tap | ValidTgts$ Permanent.nonLand+OppCtrl | TgtPrompt$ Select target nonland permanent an opponent controls | SubAbility$ DBPump
+SVar:DBPump:DB$ Pump | Defined$ Targeted | KW$ HIDDEN CARDNAME doesn't untap during your untap step. | Duration$ UntilLoseControlOfHost
 T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigUnspecialize | TriggerDescription$ When NICKNAME dies, it unspecializes. If it unspecializes this way, return it to the battlefield tapped.
 SVar:TrigUnspecialize:DB$ SetState | Defined$ TriggeredCard | Mode$ Unspecialize | RememberChanged$ True | SubAbility$ DBReturn
 SVar:DBReturn:DB$ ChangeZone | ConditionDefined$ Remembered | ConditionPresent$ Card | Origin$ Graveyard | Destination$ Battlefield | Tapped$ True | Defined$ Remembered
@@ -54,8 +56,8 @@ ManaCost:2 R G
 Types:Legendary Creature Wolf Druid
 PT:4/4
 K:Menace
-#Needs specialize trigger - then make attacks trigger secondary
-T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ Whenever this creature specializes or attacks, create a 2/2 green Wolf creature token.
+T:Mode$ Specializes | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When this creature specializes or attacks, create a 2/2 green Wolf creature token.
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigToken | Secondary$ True | TriggerDescription$ Whenever this creature specializes or attacks, create a 2/2 green Wolf creature token.
 SVar:TrigToken:DB$ Token | TokenScript$ g_2_2_wolf
 T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigUnspecialize | TriggerDescription$ When NICKNAME dies, it unspecializes. If it unspecializes this way, return it to the battlefield tapped.
 SVar:TrigUnspecialize:DB$ SetState | Defined$ TriggeredCard | Mode$ Unspecialize | RememberChanged$ True | SubAbility$ DBReturn

--- a/forge-gui/res/languages/de-DE.properties
+++ b/forge-gui/res/languages/de-DE.properties
@@ -1601,6 +1601,8 @@ lblScryer=Hellsicht angewendet
 lblSearcher=hat gesucht
 #TriggerShuffled.java
 lblShuffler=hat gemischt
+#TriggerSpecializes.java
+lblSpecialized=Specialized
 #TriggerSpellAbilityCast.java
 lblActivator=hat aktiviert
 #TriggerSpellAbilityCast.java

--- a/forge-gui/res/languages/en-US.properties
+++ b/forge-gui/res/languages/en-US.properties
@@ -1601,6 +1601,8 @@ lblScryer=Scryer
 lblSearcher=Searcher
 #TriggerShuffled.java
 lblShuffler=Shuffler
+#TriggerSpecializes.java
+lblSpecialized=Specialized
 #TriggerSpellAbilityCast.java
 lblActivator=Activator
 #TriggerSpellAbilityCast.java

--- a/forge-gui/res/languages/es-ES.properties
+++ b/forge-gui/res/languages/es-ES.properties
@@ -1601,6 +1601,8 @@ lblScryer=Escrutador
 lblSearcher=Buscador
 #TriggerShuffled.java
 lblShuffler=Barajeador
+#TriggerSpecializes.java
+lblSpecialized=Specialized
 #TriggerSpellAbilityCast.java
 lblActivator=Activador
 #TriggerSpellAbilityCast.java

--- a/forge-gui/res/languages/it-IT.properties
+++ b/forge-gui/res/languages/it-IT.properties
@@ -1599,6 +1599,8 @@ lblScryer=Giocatore che profetizza
 lblSearcher=Giocatore che passa in rassegna il grimorio
 #TriggerShuffled.java
 lblShuffler=Giocatore che mescola
+#TriggerSpecializes.java
+lblSpecialized=Specialized
 #TriggerSpellAbilityCast.java
 lblActivator=Attivatore
 #TriggerSpellAbilityCast.java

--- a/forge-gui/res/languages/ja-JP.properties
+++ b/forge-gui/res/languages/ja-JP.properties
@@ -1600,6 +1600,8 @@ lblScryer=占術プレイヤー
 lblSearcher=探したプレイヤー
 #TriggerShuffled.java
 lblShuffler=シャッフルしたプレイヤー
+#TriggerSpecializes.java
+lblSpecialized=Specialized
 #TriggerSpellAbilityCast.java
 lblActivator=起動者
 #TriggerSpellAbilityCast.java

--- a/forge-gui/res/languages/pt-BR.properties
+++ b/forge-gui/res/languages/pt-BR.properties
@@ -1635,6 +1635,8 @@ lblScryer=Vidente
 lblSearcher=Buscador
 #TriggerShuffled.java
 lblShuffler=Embaralhador
+#TriggerSpecializes.java
+lblSpecialized=Specialized
 #TriggerSpellAbilityCast.java
 lblActivator=Ativador
 #TriggerSpellAbilityCast.java

--- a/forge-gui/res/languages/zh-CN.properties
+++ b/forge-gui/res/languages/zh-CN.properties
@@ -1602,6 +1602,8 @@ lblScryer=占卜者
 lblSearcher=搜寻者
 #TriggerShuffled.java
 lblShuffler=洗牌者
+#TriggerSpecializes.java
+lblSpecialized=Specialized
 #TriggerSpellAbilityCast.java
 lblActivator=起动自
 #TriggerSpellAbilityCast.java

--- a/forge-gui/src/main/java/forge/player/HumanCostDecision.java
+++ b/forge-gui/src/main/java/forge/player/HumanCostDecision.java
@@ -11,6 +11,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
 import forge.card.CardType;
+import forge.card.MagicColor;
 import forge.game.Game;
 import forge.game.GameEntity;
 import forge.game.GameEntityCounterTable;
@@ -66,6 +67,15 @@ public class HumanCostDecision extends CostDecisionMakerBase {
     @Override
     public PaymentDecision visit(final CostAddMana cost) {
         return PaymentDecision.number(cost.getAbilityAmount(ability));
+    }
+
+    @Override
+    public PaymentDecision visit(CostChooseColor cost) {
+        int c = cost.getAbilityAmount(ability);
+        List<String> choices = player.getController().chooseColors(Localizer.getInstance().
+                        getMessage("lblChooseAColor"), ability, c, c,
+                new ArrayList<>(MagicColor.Constant.ONLY_COLORS));
+        return PaymentDecision.colors(choices);
     }
 
     @Override

--- a/forge-gui/src/main/java/forge/player/HumanCostDecision.java
+++ b/forge-gui/src/main/java/forge/player/HumanCostDecision.java
@@ -174,6 +174,9 @@ public class HumanCostDecision extends CostDecisionMakerBase {
         final String type = discardType;
         final String[] validType = type.split(";");
         hand = CardLists.getValidCards(hand, validType, player, source, ability);
+        if (hand.size() < 1) { // if we somehow have no valids (e.g. picked bad Specialize color), cancel payment
+            return null;
+        }
 
         final InputSelectCardsFromList inp = new InputSelectCardsFromList(controller, c, c, hand, ability);
         inp.setMessage(Localizer.getInstance().getMessage("lblSelectNMoreTargetTypeCardToDiscard", "%d", cost.getDescriptiveType()));


### PR DESCRIPTION
- [x] wire up keyword
- [x] `Cost$ ` + cost + `ChooseColor<1/Specialize> Discard<1/Card.ChosenColor,Land.AssociatedBasicLandTypeOfChosenColor/card of that color or associated basic land type>`
  - [x] create ChooseColor cost (can probably base a lot on ChooseCreatureType cost)
  - [x] make sure ChooseColor cost comes before Discard cost in cost order
  - [x] CardProperty for `AssociatedBasicLandTypeOfChosenColor`
  - [x] issue where you choose a color you can't discard :\
- [x] Once cost is paid, transform to state - how?
- [x] deal with ChosenColor afterward
- [x] fix up stack description for SetState with this mode
- [x] make state change "perpetual" without messing up all ChangesZone triggers etc.
- [x] handle non-specialize cards getting the keyword (even if they have it, they shouldn't be able to specialize)
- [x] specialize trigger (in Card.changeCardState)

For other PRs:
- wire up changing card image for state change
- make specialized state images part of UI when choosing color for Specialize cost 
- secondary color needs to be chosen when Commander deck building


