### PR TITLE
CantTarget "as you cast it" is checked on resolve

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -1683,7 +1683,7 @@ public class AiController {
         Iterables.removeIf(saList, new Predicate<SpellAbility>() {
             @Override
             public boolean apply(final SpellAbility spellAbility) { //don't include removedAI cards if somehow the AI can play the ability or gain control of unsupported card
-                return spellAbility instanceof LandAbility || (spellAbility.getHostCard() != null && spellAbility.getHostCard().getRules().getAiHints().getRemAIDecks());
+                return spellAbility instanceof LandAbility || (spellAbility.getHostCard() != null && ComputerUtilCard.isCardRemAIDeck(spellAbility.getHostCard()));
             }
         });
 

--- a/forge-game/src/main/java/forge/game/card/CardUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardUtil.java
@@ -530,27 +530,25 @@ public final class CardUtil {
     // however, due to the changes necessary for SA_Requirements this is much
     // different than the original
     public static List<Card> getValidCardsToTarget(TargetRestrictions tgt, SpellAbility ability) {
-        Card activatingCard = ability.getHostCard();
+        final Card activatingCard = ability.getHostCard();
         final Game game = ability.getActivatingPlayer().getGame();
         final List<ZoneType> zone = tgt.getZone();
 
         final boolean canTgtStack = zone.contains(ZoneType.Stack);
-        List<Card> validCards = CardLists.getValidCards(game.getCardsIn(zone), tgt.getValidTgts(), ability.getActivatingPlayer(), ability.getHostCard(), ability);
+        List<Card> validCards = CardLists.getValidCards(game.getCardsIn(zone), tgt.getValidTgts(), ability.getActivatingPlayer(), activatingCard, ability);
         List<Card> choices = CardLists.getTargetableCards(validCards, ability);
         if (canTgtStack) {
             // Since getTargetableCards doesn't have additional checks if one of the Zones is stack
             // Remove the activating card from targeting itself if its on the Stack
             if (activatingCard.isInZone(ZoneType.Stack)) {
-                choices.remove(ability.getHostCard());
+                choices.remove(activatingCard);
             }
         }
         List<GameObject> targetedObjects = ability.getUniqueTargets();
 
         // Remove cards already targeted
         final List<Card> targeted = Lists.newArrayList(ability.getTargets().getTargetCards());
-        for (final Card c : targeted) {
-            choices.remove(c);
-        }
+        choices.removeAll(targeted);
 
         // Remove cards exceeding total CMC
         if (ability.hasParam("MaxTotalTargetCMC")) {

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityCantTarget.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityCantTarget.java
@@ -99,6 +99,13 @@ public class StaticAbilityCantTarget {
             }
         }
 
+        if ("Stack".equals(stAb.getParam("EffectZone"))) {
+            // Enthralling Hold: only works if it wasn't already cast
+            if (card.getGame().getStack().getSpellMatchingHost(spellAbility.getHostCard()) != null) {
+                return false;
+            }
+        }
+
         if (!stAb.matchesValidParam("ValidCard", card)) {
             return false;
         }

--- a/forge-gui/res/cardsfolder/d/dream_leash.txt
+++ b/forge-gui/res/cardsfolder/d/dream_leash.txt
@@ -3,6 +3,6 @@ ManaCost:3 U U
 Types:Enchantment Aura
 K:Enchant permanent
 S:Mode$ CantTarget | EffectZone$ Stack | ValidSource$ Spell.Self | ValidCard$ Permanent.untapped | Description$ You can't choose an untapped permanent as this spell's target as you cast it.
-A:SP$ Attach | Cost$ 3 U U | ValidTgts$ Permanent | AILogic$ GainControl
+A:SP$ Attach | Cost$ 3 U U | ValidTgts$ Permanent | AILogic$ GainControl | AITgts$ Permanent.tapped
 S:Mode$ Continuous | Affected$ Card.EnchantedBy | GainControl$ You | Description$ You control enchanted permanent.
 Oracle:Enchant permanent\nYou can't choose an untapped permanent as this spell's target as you cast it.\nYou control enchanted permanent.

--- a/forge-gui/res/cardsfolder/e/enthralling_hold.txt
+++ b/forge-gui/res/cardsfolder/e/enthralling_hold.txt
@@ -3,6 +3,6 @@ ManaCost:3 U U
 Types:Enchantment Aura
 K:Enchant creature
 S:Mode$ CantTarget | EffectZone$ Stack | ValidSource$ Spell.Self | ValidCard$ Creature.untapped | Description$ You can't choose an untapped creature as this spell's target as you cast it.
-A:SP$ Attach | Cost$ 3 U U | ValidTgts$ Creature | AILogic$ GainControl
+A:SP$ Attach | Cost$ 3 U U | ValidTgts$ Creature | AILogic$ GainControl | AITgts$ Creature.tapped
 S:Mode$ Continuous | Affected$ Card.EnchantedBy | GainControl$ You | Description$ You control enchanted creature.
 Oracle:Enchant creature\nYou can't choose an untapped creature as this spell's target as you cast it.\nYou control enchanted creature.

--- a/forge-gui/res/cardsfolder/r/roil_elemental.txt
+++ b/forge-gui/res/cardsfolder/r/roil_elemental.txt
@@ -3,7 +3,7 @@ ManaCost:3 U U U
 Types:Creature Elemental
 PT:3/2
 K:Flying
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | Execute$ TrigGainControl | TriggerZones$ Battlefield | TriggerDescription$ Landfall — Whenever a land enters the battlefield under your control, you may gain control of target creature for as long as you control CARDNAME.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | Execute$ TrigGainControl | OptionalDecider$ You | TriggerZones$ Battlefield | TriggerDescription$ Landfall — Whenever a land enters the battlefield under your control, you may gain control of target creature for as long as you control CARDNAME.
 SVar:TrigGainControl:DB$ GainControl | TgtPrompt$ Choose target creature | ValidTgts$ Creature | LoseControl$ LeavesPlay,LoseControl | SpellDescription$ Gain control of target creature for as long as CARDNAME remains on the battlefield.
 SVar:BuffedBy:Land
 Oracle:Flying\nLandfall — Whenever a land enters the battlefield under your control, you may gain control of target creature for as long as you control Roil Elemental.


### PR DESCRIPTION
Currently you can make it fizzle.

> The middle ability of Enthralling Hold affects only the choice of target as the spell is cast. **If the creature becomes untapped before the spell resolves, it still resolves.** If a player is allowed to change the spell's target while it's on the stack, they may choose an untapped creature. If you put Enthralling Hold onto the battlefield without casting it, you may attach it to an untapped creature.