### PR TITLE
fix autosave flip preview

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/world/WorldSaveHeader.java
+++ b/forge-gui-mobile/src/forge/adventure/world/WorldSaveHeader.java
@@ -28,7 +28,7 @@ public class WorldSaveHeader implements java.io.Serializable, Disposable {
         out.writeUTF(name);
         if (preview == null)
             preview = new Pixmap(1, 1, Pixmap.Format.RGBA8888);
-        Serializer.WritePixmap(out, preview, true);
+        Serializer.WritePixmap(out, preview, false);
         out.writeObject(saveDate);
     }
 


### PR DESCRIPTION
- the screenshot is already flipped to render correctly so we don't need to flip it again