### PR TITLE
Dev Mode fix for cards cheated in transformed/modal

### DIFF
--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -2753,9 +2753,11 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
             getGame().getAction().invoke(() -> {
                 if (targetZone == ZoneType.Battlefield) {
                     if (!forgeCard.getName().equals(f.getName())) {
-                        forgeCard.changeToState(CardStateName.Flipped);
-                        forgeCard.changeToState(CardStateName.Transformed);
-                        forgeCard.changeToState(CardStateName.Modal);
+                        forgeCard.changeToState(forgeCard.getRules().getSplitType().getChangedStateName());
+                        if (forgeCard.getCurrentStateName().equals(CardStateName.Transformed) ||
+                                forgeCard.getCurrentStateName().equals(CardStateName.Modal)) {
+                            forgeCard.setBackSide(true);
+                        }
                     }
 
                     if (noTriggers) {


### PR DESCRIPTION
Fixes an issue where cards cheated into play by dev mode on their back side wouldn't be set as back side, breaking "dies" triggers because LKI was always original state. Prior to this patch, this trigger would not happen:
![image](https://user-images.githubusercontent.com/103371817/185412480-63304ef0-24a6-4605-adf4-083710b85f2d.png)