### PR TITLE
Post the Enchanter

### DIFF
--- a/forge-gui/res/editions/Celebration Cards.txt
+++ b/forge-gui/res/editions/Celebration Cards.txt
@@ -13,3 +13,4 @@ ScryfallCode=PCEL
 5 R Fraternal Exaltation @Susan Garfield
 6 M Robot Chicken @Robot Chicken
 7 M Phoenix Heart @Drew Tucker
+8 R Zur the Enchanter @Chase Stone


### PR DESCRIPTION
Added Post Malone's custom card to PCEL set.
Source: https://scryfall.com/card/pcel/8/zur-the-enchanter

![050e8f17-7b51-40a4-b76c-2f3b1eb4b389](https://user-images.githubusercontent.com/18243520/185712704-6426ee3d-8c78-4939-9683-56db6cf38473.jpg)
