### PR TITLE
Fix PLG22 edition

### DIFF
--- a/forge-gui/res/editions/Love Your LGS 2022.txt
+++ b/forge-gui/res/editions/Love Your LGS 2022.txt
@@ -7,7 +7,3 @@ ScryfallCode=PLG22
 
 [cards]
 1 R Sol Ring @Mike Bierek
-P1 M Moraug, Fury of Akoum @Rudy Siswanto
-P2 M Ox of Agonas @Lie Setiawan
-P3 M Angrath, the Flame-Chained @Song Qijin
-P4 R Tahngarth, First Mate @Song Qijin


### PR DESCRIPTION
Removed these cards as the JP versions were put in the edition incorrectly by Scryfall and have since been taken out.