### PR TITLE
DMU: Karn, Living Legacy + Powerstone token, engine support

### DIFF
--- a/forge-game/src/main/java/forge/game/spellability/AbilityManaPart.java
+++ b/forge-game/src/main/java/forge/game/spellability/AbilityManaPart.java
@@ -361,6 +361,10 @@ public class AbilityManaPart implements java.io.Serializable {
                 }
             }
 
+            if (restriction.equals("CantCastNonArtifactSpells")) {
+                return !sa.isSpell() || sa.getHostCard().isArtifact();
+            }
+
             // the payment is for a resolving SA, currently no other restrictions would allow that
             if (getSourceCard().getGame().getStack().getInstanceFromSpellAbility(sa.getRootAbility()) != null) {
                 return false;

--- a/forge-gui/res/cardsfolder/upcoming/karn_living_legacy.txt
+++ b/forge-gui/res/cardsfolder/upcoming/karn_living_legacy.txt
@@ -1,0 +1,14 @@
+Name:Karn, Living Legacy
+ManaCost:4
+Types:Legendary Planeswalker Karn
+Loyalty:4
+A:AB$ Token | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | TokenAmount$ 1 | TokenTapped$ True | TokenScript$ c_a_powerstone | TokenOwner$ You | SpellDescription$ Create a tapped Powerstone token. (It's an artifact with "{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.")
+A:AB$ ChooseNumber | Cost$ SubCounter<1/LOYALTY> | Planeswalker$ True | Defined$ You | ChooseAnyNumber$ True | ListTitle$ Pay Any Mana | SubAbility$ DBDig | SpellDescription$ Pay any amount of mana. Look at that many cards from the top of your library, then put one of those cards into your hand and the rest on the bottom of your library in a random order.
+SVar:DBDig:DB$ Dig | DigNum$ X | ChangeNum$ 1 | RestRandomOrder$ True | UnlessCost$ X | UnlessPayer$ You | UnlessSwitched$ True
+A:AB$ Effect | Cost$ SubCounter<7/LOYALTY> | Planeswalker$ True | Ultimate$ True | AIlogic$ Always | Stackable$ False | Name$ Emblem - Karn, Living Legacy | Image$ emblem_karn_living_legacy | Duration$ Permanent | Abilities$ KarnPing | SpellDescription$ You get an emblem with "Tap an untapped artifact you control: This emblem deals 1 damage to any target."
+SVar:KarnPing:AB$ DealDamage | Cost$ tapXType<1/Artifact> | ActivationZone$ Command | ValidTgts$ Creature,Player,Planeswalker | NumDmg$ 1
+SVar:PlayMain1:TRUE
+DeckHas:Ability$Token & Type|Artifact
+DeckNeeds:Type$Artifact
+SVar:X:Count$ChosenNumber
+Oracle:[+1]: Create a tapped Powerstone token. (It's an artifact with "{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.")\n[−1]: Pay any amount of mana. Look at that many cards from the top of your library, then put one of those cards into your hand and the rest on the bottom of your library in a random order.\n[−7]: You get an emblem with "Tap an untapped artifact you control: This emblem deals 1 damage to any target."

--- a/forge-gui/res/lists/TypeLists.txt
+++ b/forge-gui/res/lists/TypeLists.txt
@@ -313,6 +313,7 @@ Food
 Fortification
 Gold
 Key:Keys
+Powerstone
 Treasure
 Vehicle
 [WalkerTypes]

--- a/forge-gui/res/tokenscripts/c_a_powerstone.txt
+++ b/forge-gui/res/tokenscripts/c_a_powerstone.txt
@@ -1,0 +1,7 @@
+Name:Powerstone token
+ManaCost:no cost
+Types:Artifact
+Colors:colorless
+A:AB$ Mana | Cost$ T | Produced$ C | RestrictValid$ CantCastNonArtifactSpells | SpellDescription$ Add {C}. This mana can't be spent to cast a nonartifact spell.
+Oracle:{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.
+


### PR DESCRIPTION
DMU: Add script for Karn, Living Legacy, his Powerstone token, and engine support for mana restriction "can't be spent to cast nonartifact spells."

- Karn, Living Legacy
- Powerstone token closes #1375
- AbilityManaPart.java small addition