### PR TITLE
Adventure: Fix "Card Reward Bonus" to properly max at 3

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
+++ b/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
@@ -539,7 +539,7 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
         if(blessing != null) {
             if(blessing.cardRewardBonus > 0) result += blessing.cardRewardBonus;
         }
-        return Math.max(result, 3);
+        return Math.min(result, 3);
     }
 
     public DifficultyData getDifficulty() {


### PR DESCRIPTION
This fixes a logic error so that the "Card Reward Bonus" will cap out at 3. See the comment here, which suggests it should be max 3: https://github.com/Card-Forge/forge/blob/0c3536a561a947c84cdf922956ba2a6d3ccbb1eb/forge-gui-mobile/src/forge/adventure/data/EffectData.java#L21

Previous logic returned `Math.max(result, 3)` which has the effect of always returning at least 3. What we need is `Math.min(result, 3)` which ensures only values less than or equal to 3 can be returned.

In-game, this resulted in 3 more deck card rewards than intended whenever you defeat an enemy.