### PR TITLE
Adventure: Fix Dungeon Effect that adds Creatures to the field

### DIFF
--- a/forge-game/src/main/java/forge/game/player/RegisteredPlayer.java
+++ b/forge-game/src/main/java/forge/game/player/RegisteredPlayer.java
@@ -63,7 +63,10 @@ public class RegisteredPlayer {
     }
 
     public final void addExtraCardsOnBattlefield(Iterable<IPaperCard> extraCardsonTable) {
-        this.extraCardsOnBattlefield = extraCardsonTable;
+        if (this.extraCardsOnBattlefield == null)
+            this.extraCardsOnBattlefield = extraCardsonTable;
+        else
+            this.extraCardsOnBattlefield = Iterables.concat(this.extraCardsOnBattlefield, extraCardsonTable);
     }
 
     public int getStartingHand() {

--- a/forge-gui-mobile/src/forge/adventure/scene/DuelScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/DuelScene.java
@@ -137,7 +137,7 @@ public class DuelScene extends ForgeScene {
             changeStartCards += data.changeStartCards;
             startCards.addAll(data.startBattleWithCards());
         }
-        player.setCardsOnBattlefield(startCards);
+        player.addExtraCardsOnBattlefield(startCards);
         player.setStartingLife(Math.max(1, lifeMod + player.getStartingLife()));
         player.setStartingHand(player.getStartingHand() + changeStartCards);
     }


### PR DESCRIPTION
In my testing, dungeon effects that add cards to the field weren't working (such as in the "Skep" dungeon). I think this broke when [!1319](https://github.com/Card-Forge/forge/pull/1319) was merged, which added an additional call to `RegisteredPlayer.setCardsOnBattlefield()` to cover equipment effects, which happens after the dungeon effects. This function replaces the existing list each time, so we were never getting the cards from the dungeon effect.

I fixed this by changing the function call to `RegisteredPlayer.addExtraCardsOnBattlefield()`, which I thought would be able to add to the list each time. Unfortunately, this had the same behaviour as the "set" call, replacing the list each time. So I changed the behaviour of that call so that it adds to the cards on the battlefield each time it is called. The `RegisteredPlayer.setCardsOnBattlefield()` function remains unchanged, so it can still be used if we need to clear the list again for some reason.