### PR TITLE
add DPAD selector for gamepad in ListChooser

### DIFF
--- a/forge-gui-mobile/src/forge/Forge.java
+++ b/forge-gui-mobile/src/forge/Forge.java
@@ -288,6 +288,9 @@ public class Forge implements ApplicationListener {
                         if (controller.getMapping().buttonB == buttonIndex) {
                             container.keyDown(Keys.BUTTON_B);
                         }
+                        if (controller.getMapping().buttonBack == buttonIndex) { //selecting player
+                            container.keyDown(Keys.BUTTON_SELECT);
+                        }
                     } else {//Others
                         /*if (controller.getMapping().buttonL2 == buttonIndex) {//others are axis-4
                             container.keyDown(Keys.ENTER);

--- a/forge-gui-mobile/src/forge/Forge.java
+++ b/forge-gui-mobile/src/forge/Forge.java
@@ -288,7 +288,7 @@ public class Forge implements ApplicationListener {
                         if (controller.getMapping().buttonB == buttonIndex) {
                             container.keyDown(Keys.BUTTON_B);
                         }
-                        if (controller.getMapping().buttonBack == buttonIndex) { //selecting player
+                        if (controller.getMapping().buttonBack == buttonIndex) {
                             container.keyDown(Keys.BUTTON_SELECT);
                         }
                     } else {//Others

--- a/forge-gui-mobile/src/forge/menu/FMenuBar.java
+++ b/forge-gui-mobile/src/forge/menu/FMenuBar.java
@@ -105,7 +105,7 @@ public class FMenuBar extends Header {
 
     @Override
     public boolean keyDown(int keyCode) {
-        if (keyCode == Input.Keys.BUTTON_L1) {
+        if (keyCode == Input.Keys.BUTTON_SELECT) { //show menu tabs
             setNextSelected();
             return true;
         }

--- a/forge-gui-mobile/src/forge/screens/match/MatchScreen.java
+++ b/forge-gui-mobile/src/forge/screens/match/MatchScreen.java
@@ -579,14 +579,16 @@ public class MatchScreen extends FScreen {
                     } catch (Exception e) {}
                 }
                 break;
-            case Keys.PAGE_DOWN:
+            case Keys.BUTTON_L1: //switch selected panels
                 if (Forge.hasGamepad()) {
                     //nullPotentialListener();
                     selectedPlayerPanel().hideSelectedTab();
                     selectedPlayer--;
                     if (selectedPlayer < 0)
                         selectedPlayer=playerPanelsList.size()-1;
-                    selectedPlayerPanel().setNextSelectedTab(true);
+                    selectedPlayerPanel().closeSelectedTab();
+                    selectedPlayerPanel().getSelectedRow().unselectCurrent();
+                    //selectedPlayerPanel().setNextSelectedTab(true);
                 }
                 break;
             case Keys.ENTER:

--- a/forge-gui-mobile/src/forge/screens/match/views/VAvatar.java
+++ b/forge-gui-mobile/src/forge/screens/match/views/VAvatar.java
@@ -1,5 +1,6 @@
 package forge.screens.match.views;
 
+import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.math.Vector2;
@@ -96,12 +97,8 @@ public class VAvatar extends FDisplayObject {
     }
     @Override
     public boolean tap(float x, float y, int count) {
-        ThreadUtil.invokeInGameThread(new Runnable() { //must invoke in game thread in case a dialog needs to be shown
-            @Override
-            public void run() {
-                MatchController.instance.getGameController().selectPlayer(player, null);
-            }
-        });
+        //must invoke in game thread in case a dialog needs to be shown
+        ThreadUtil.invokeInGameThread(() -> MatchController.instance.getGameController().selectPlayer(player, null));
         return true;
     }
 
@@ -170,5 +167,27 @@ public class VAvatar extends FDisplayObject {
         if (MatchController.instance.isHighlighted(player)) {
             g.drawRect(w / 16f, Color.MAGENTA, 0, 0, w, h);
         }
+        //selector
+        if (Forge.hasGamepad()) {
+            if (MatchController.getView().selectedPlayerPanel() != null) {
+                if (MatchController.getView().selectedPlayerPanel().getPlayer() == player) {
+                    g.drawRect(w / 16f, Color.ORANGE, 0, 0, w, h);
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean keyDown(int keyCode) {
+        if (keyCode == Input.Keys.BUTTON_SELECT) {
+            //must invoke in game thread in case a dialog needs to be shown
+            if (MatchController.getView().selectedPlayerPanel() != null) {
+                PlayerView selected = MatchController.getView().selectedPlayerPanel().getPlayer();
+                if (selected != null)
+                    ThreadUtil.invokeInGameThread(() -> MatchController.instance.getGameController().selectPlayer(selected, null));
+            }
+            return true;
+        }
+        return super.keyDown(keyCode);
     }
 }

--- a/forge-gui-mobile/src/forge/screens/match/views/VAvatar.java
+++ b/forge-gui-mobile/src/forge/screens/match/views/VAvatar.java
@@ -179,7 +179,7 @@ public class VAvatar extends FDisplayObject {
 
     @Override
     public boolean keyDown(int keyCode) {
-        if (keyCode == Input.Keys.BUTTON_SELECT) {
+        if (keyCode == Input.Keys.PAGE_DOWN) { // left analog down to select current selected panel
             //must invoke in game thread in case a dialog needs to be shown
             if (MatchController.getView().selectedPlayerPanel() != null) {
                 PlayerView selected = MatchController.getView().selectedPlayerPanel().getPlayer();

--- a/forge-gui/release-files/GAMEPAD_README.txt
+++ b/forge-gui/release-files/GAMEPAD_README.txt
@@ -57,10 +57,11 @@ Right Trigger - Keep/Mulligan/Cancel/End Turn/Alpha Strike (Bottom Right Button)
 (To select cards on the battlefield, close Zone tabs first (Button B), then use DPAD)
 
 DPAD Up/Down/Left/Right - Selector
-Left Shoulder - Tab Selector/Show
+Left Shoulder - Player Panel Selector
 Right Shoulder - Zone Selector/Show
-Left Analog Down - Switch Player for Selector
+Left Analog Down - Select Player (current selected panel)
 
 Button A - Confirm
 Button B - Cancel/Hide
 Button Y - Show Zoom
+Button Back - Show Menu Tabs


### PR DESCRIPTION
Update Controls:
L1/Left Shoulder - Select Player Panel
R1/Right Shoulder - Select Zone tabs/Show Zone Tabs
Back Button - Show Menu Tabs
Left Analog Down - Select Player (for spell/ability that needs to select player, choose player with L1/Left Shoulder first, then Left Analog Down to choose that player)

 ListChooser Dialog:
DPAD Up/Down - List Item Selector
L2/Left Trigger - Ok/Confirm
R2/Right Trigger - Cancel