### PR TITLE
Adventure: Don't warn about cards the AI can't play well

### DIFF
--- a/forge-game/src/main/java/forge/game/GameRules.java
+++ b/forge-game/src/main/java/forge/game/GameRules.java
@@ -19,6 +19,9 @@ public class GameRules {
     // same for me
     private boolean useGrayText;
 
+    // whether to warn about cards AI can't play well
+    private boolean warnAboutAICards = true;
+
     public GameRules(final GameType type) {
         this.gameType = type;
     }
@@ -108,5 +111,12 @@ public class GameRules {
     }
     public void setUseGrayText(final boolean useGrayText) {
         this.useGrayText = useGrayText;
+    }
+
+    public boolean warnAboutAICards() {
+        return warnAboutAICards;
+    }
+    public void setWarnAboutAICards(final boolean warnAboutAICards) {
+        this.warnAboutAICards = warnAboutAICards;
     }
 }

--- a/forge-game/src/main/java/forge/game/Match.java
+++ b/forge-game/src/main/java/forge/game/Match.java
@@ -334,7 +334,7 @@ public class Match {
         }
 
         final Localizer localizer = Localizer.getInstance();
-        if (!rAICards.isEmpty() && !rules.getGameType().isCardPoolLimited()) {
+        if (!rAICards.isEmpty() && !rules.getGameType().isCardPoolLimited() && rules.warnAboutAICards()) {
             game.getAction().revealUnplayableByAI(localizer.getMessage("lblAICantPlayCards"), rAICards);
         }
 

--- a/forge-gui-mobile/src/forge/adventure/scene/DuelScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/DuelScene.java
@@ -282,6 +282,7 @@ public class DuelScene extends ForgeScene {
         rules.setMatchAnteRarity(true);
         rules.setGamesPerMatch(1);
         rules.setManaBurn(false);
+        rules.setWarnAboutAICards(false);
 
         hostedMatch.setEndGameHook(() -> DuelScene.this.GameEnd());
         hostedMatch.startMatch(rules, appliedVariants, players, guiMap);


### PR DESCRIPTION
In Quest Mode, you don't get warnings about cards the AI can't play well, even if Quest Decks sometimes include them. This makes Adventure Mode do the same thing. The creators of Quest and Adventure decks chose to put those cards in, so it's best just to leave out the warning. (It ruins the surprise, otherwise.)

Digging into the code, I found that currently this works via a check to `isCardPoolLimited()`, which is tied to the `GameType`. The "Quest" game type has this set to true. Doing the same approach won't work for Adventure, since Adventure selects "Constructed" as the game type, rather than "Quest". Notably, I believe Adventure wants the game type to be configurable (maybe someone will make an Oathbreaker world?), so we should not have a new game type called "Adventure".

Instead, I added a new property to the `GameRules` object. I think it fits okay there, but I'm open to suggestions about how to do it differently.

