### PR TITLE
DMU 10 Cards + 2 cleanup

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/kobold_warcaller.txt
+++ b/forge-gui/res/cardsfolder/upcoming/kobold_warcaller.txt
@@ -5,4 +5,5 @@ PT:1/1
 A:AB$ ChooseCard | Cost$ T | ChoiceZone$ Hand | Choices$ Creature.YouOwn | ChoiceTitle$ Choose a creature card in your hand | Amount$ 1 | SpellDescription$ Choose a creature card in your hand. It perpetually gains haste. | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | StaticAbilities$ PerpetualHaste | Name$ Kobold WarCaller's Perpetual Effect | Duration$ Permanent
 SVar:PerpetualHaste:Mode$ Continuous | Affected$ Card.ChosenCard | AddKeyword$ Haste | EffectZone$ Command | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | Description$ This creature perpetually gains haste.
+AI:RemoveDeck:Random 
 Oracle:{T}: Choose a creature card in your hand. It perpetually gains haste.

--- a/forge-gui/res/cardsfolder/upcoming/orca_siege_demon.txt
+++ b/forge-gui/res/cardsfolder/upcoming/orca_siege_demon.txt
@@ -1,6 +1,6 @@
 Name:Orca, Siege Demon
 ManaCost:5 B R
-Types:Legendary Creature Human Soldier
+Types:Legendary Creature Demon
 K:Trample
 PT:5/5
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.Other | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Whenever another creature dies, put a +1/+1 counter on CARDNAME.

--- a/forge-gui/res/cardsfolder/upcoming/talas_lookout.txt
+++ b/forge-gui/res/cardsfolder/upcoming/talas_lookout.txt
@@ -3,7 +3,7 @@ ManaCost:2 U U
 Types:Creature Human Pirate
 PT:3/2
 K:Flying
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigDig | TriggerDescription$ When CARDNAME dies, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigDig | TriggerDescription$ When CARDNAME dies, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.
 SVar:TrigDig:DB$ Dig | DigNum$ 2 | ChangeNum$ 1 | DestinationZone2$ Graveyard
 DeckHas:Ability$Graveyard
 Oracle:Flying\nWhen Talas Lookout dies, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.

--- a/forge-gui/res/cardsfolder/upcoming/talas_lookout.txt
+++ b/forge-gui/res/cardsfolder/upcoming/talas_lookout.txt
@@ -1,0 +1,9 @@
+Name:Talas Lookout
+ManaCost:2 U U
+Types:Creature Human Pirate
+PT:3/2
+K:Flying
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigDig | TriggerDescription$ When CARDNAME dies, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.
+SVar:TrigDig:DB$ Dig | DigNum$ 2 | ChangeNum$ 1 | DestinationZone2$ Graveyard
+DeckHas:Ability$Graveyard
+Oracle:Flying\nWhen Talas Lookout dies, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.

--- a/forge-gui/res/cardsfolder/upcoming/tattered_apparition.txt
+++ b/forge-gui/res/cardsfolder/upcoming/tattered_apparition.txt
@@ -1,0 +1,7 @@
+Name:Tattered Apparition
+ManaCost:3 B
+Types:Creature Shade
+PT:2/2
+K:Flying
+A:AB$ Pump | Cost$ 1 B | Defined$ Self | NumAtt$ +1 | NumDef$ +1 | SpellDescription$ CARDNAME gets +1/+1 until end of turn.
+Oracle:Flying\n{1}{B}: Tattered Apparition gets +1/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/upcoming/tatyova_steward_of_tides.txt
+++ b/forge-gui/res/cardsfolder/upcoming/tatyova_steward_of_tides.txt
@@ -3,8 +3,8 @@ ManaCost:G G U
 Types:Legendary Creature Merfolk Druid
 PT:3/3
 S:Mode$ Continuous | Affected$ Creature.Land+YouCtrl | AddKeyword$ Flying | Description$ Land creatures you control have flying.
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | TriggerZones$ Battlefield | ConditionPresent$ Land.YouCtrl | ConditionCompare$ GE7 | Execute$ TrigAnimate | TriggerDescription$ Whenever a land enters the battlefield under your control, if you control seven or more lands, up to one target land you control becomes a 3/3 Elemental creature with haste. It’s still a land.
-SVar:TrigAnimate:DB$ Animate | ValidTgts$ Land.YouCtrl | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target land you control | Power$ 3 | Toughness$ 3 | Types$ Elemental,Creature | Keywords$ Haste
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | TriggerZones$ Battlefield | SubAbility$ TrigAnimate | TriggerDescription$ Whenever a land enters the battlefield under your control, if you control seven or more lands, up to one target land you control becomes a 3/3 Elemental creature with haste. It's still a land.
+SVar:TrigAnimate:DB$ Animate | ValidTgts$ Land.YouCtrl | TargetMin$ 0 | TargetMax$ 1 | ConditionPresent$ Land.YouCtrl | ConditionCompare$ GE7 | TgtPrompt$ Select up to one target land you control | Power$ 3 | Toughness$ 3 | Types$ Elemental,Creature | Keywords$ Haste
 DeckHints:Type$Land
 SVar:BuffedBy:Land
-Oracle:Land creatures you control have flying.\nWhenever a land enters the battlefield under your control, if you control seven or more lands, up to one target land you control becomes a 3/3 Elemental creature with haste. It’s still a land.
+Oracle:Land creatures you control have flying.\nWhenever a land enters the battlefield under your control, if you control seven or more lands, up to one target land you control becomes a 3/3 Elemental creature with haste. It's still a land.

--- a/forge-gui/res/cardsfolder/upcoming/tatyova_steward_of_tides.txt
+++ b/forge-gui/res/cardsfolder/upcoming/tatyova_steward_of_tides.txt
@@ -3,8 +3,8 @@ ManaCost:G G U
 Types:Legendary Creature Merfolk Druid
 PT:3/3
 S:Mode$ Continuous | Affected$ Creature.Land+YouCtrl | AddKeyword$ Flying | Description$ Land creatures you control have flying.
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | TriggerZones$ Battlefield | SubAbility$ TrigAnimate | TriggerDescription$ Whenever a land enters the battlefield under your control, if you control seven or more lands, up to one target land you control becomes a 3/3 Elemental creature with haste. It's still a land.
-SVar:TrigAnimate:DB$ Animate | ValidTgts$ Land.YouCtrl | TargetMin$ 0 | TargetMax$ 1 | ConditionPresent$ Land.YouCtrl | ConditionCompare$ GE7 | TgtPrompt$ Select up to one target land you control | Power$ 3 | Toughness$ 3 | Types$ Elemental,Creature | Keywords$ Haste
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | IsPresent$ Land.YouCtrl | PresentCompare$ GE7 | TriggerZones$ Battlefield | Execute$ TrigAnimate | TriggerDescription$ Whenever a land enters the battlefield under your control, if you control seven or more lands, up to one target land you control becomes a 3/3 Elemental creature with haste. It's still a land.
+SVar:TrigAnimate:DB$ Animate | ValidTgts$ Land.YouCtrl | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target land you control | Power$ 3 | Toughness$ 3 | Types$ Elemental,Creature | Keywords$ Haste
 DeckHints:Type$Land
 SVar:BuffedBy:Land
 Oracle:Land creatures you control have flying.\nWhenever a land enters the battlefield under your control, if you control seven or more lands, up to one target land you control becomes a 3/3 Elemental creature with haste. It's still a land.

--- a/forge-gui/res/cardsfolder/upcoming/tatyova_steward_of_tides.txt
+++ b/forge-gui/res/cardsfolder/upcoming/tatyova_steward_of_tides.txt
@@ -1,0 +1,10 @@
+Name:Tatyova, Steward of Tides
+ManaCost:G G U
+Types:Legendary Creature Merfolk Druid
+PT:3/3
+S:Mode$ Continuous | Affected$ Creature.Land+YouCtrl | AddKeyword$ Flying | Description$ Land creatures you control have flying.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | TriggerZones$ Battlefield | ConditionPresent$ Land.YouCtrl | ConditionCompare$ GE7 | Execute$ TrigAnimate | TriggerDescription$ Whenever a land enters the battlefield under your control, if you control seven or more lands, up to one target land you control becomes a 3/3 Elemental creature with haste. It’s still a land.
+SVar:TrigAnimate:DB$ Animate | ValidTgts$ Land.YouCtrl | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target land you control | Power$ 3 | Toughness$ 3 | Types$ Elemental,Creature | Keywords$ Haste
+DeckHints:Type$Land
+SVar:BuffedBy:Land
+Oracle:Land creatures you control have flying.\nWhenever a land enters the battlefield under your control, if you control seven or more lands, up to one target land you control becomes a 3/3 Elemental creature with haste. It’s still a land.

--- a/forge-gui/res/cardsfolder/upcoming/tear_asunder.txt
+++ b/forge-gui/res/cardsfolder/upcoming/tear_asunder.txt
@@ -2,8 +2,9 @@ Name:Tear Asunder
 ManaCost:1 G
 Types:Instant
 K:Kicker:1 B
-A:SP$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Artifact,Enchantment | TgtPrompt$ Select target artifact or enchantment | ConditionCheckSVar$ X | ConditionSVarCompare$ EQ0 | SubAbility$ DBChangeZone | SpellDescription$ Exile target artifact or enchantment. Exile target artifact or enchantment. If this spell was kicked, exile target nonland permanent instead.
-SVar:DBChangeZone:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Permanent.nonLand | Condition$ Kicked
-SVar:X:Count$TimesKicked
+A:SP$ ChangeZone | Origin$ Battlefield | Destination$ Exile | TgtPrompt$ Select target artifact or enchantment | ValidTgts$ Artifact,Enchantment | TargetMin$ X | TargetMax$ X | SubAbility$ DBChangeZone | SpellDescription$ Exile target artifact or enchantment. Exile target artifact or enchantment. If this spell was kicked, exile target nonland permanent instead.
+SVar:DBChangeZone:DB$ ChangeZone | TargetMin$ Y | TargetMax$ Y | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Permanent.nonLand | TgtPrompt$ Select target nonland permanent | Condition$ Kicked
+SVar:X:Count$Kicked.0.1
+SVar:Y:Count$Kicked.1.0
 DeckHints:Color$Black
 Oracle:Kicker {1}{B} (You may pay an additional {1}{B} as you cast this spell.)\nExile target artifact or enchantment. If this spell was kicked, exile target nonland permanent instead.

--- a/forge-gui/res/cardsfolder/upcoming/tear_asunder.txt
+++ b/forge-gui/res/cardsfolder/upcoming/tear_asunder.txt
@@ -2,7 +2,7 @@ Name:Tear Asunder
 ManaCost:1 G
 Types:Instant
 K:Kicker:1 B
-A:SP$ ChangeZone | Origin$ Battlefield | Destination$ Exile | TgtPrompt$ Select target artifact or enchantment | ValidTgts$ Artifact,Enchantment | TargetMin$ X | TargetMax$ X | SubAbility$ DBChangeZone | SpellDescription$ Exile target artifact or enchantment. Exile target artifact or enchantment. If this spell was kicked, exile target nonland permanent instead.
+A:SP$ ChangeZone | Origin$ Battlefield | Destination$ Exile | TgtPrompt$ Select target artifact or enchantment | ValidTgts$ Artifact,Enchantment | TargetMin$ X | TargetMax$ X | SubAbility$ DBChangeZone | SpellDescription$ Exile target artifact or enchantment. If this spell was kicked, exile target nonland permanent instead.
 SVar:DBChangeZone:DB$ ChangeZone | TargetMin$ Y | TargetMax$ Y | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Permanent.nonLand | TgtPrompt$ Select target nonland permanent | Condition$ Kicked
 SVar:X:Count$Kicked.0.1
 SVar:Y:Count$Kicked.1.0

--- a/forge-gui/res/cardsfolder/upcoming/tear_asunder.txt
+++ b/forge-gui/res/cardsfolder/upcoming/tear_asunder.txt
@@ -1,0 +1,9 @@
+Name:Tear Asunder
+ManaCost:1 G
+Types:Instant
+K:Kicker:1 B
+A:SP$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Artifact,Enchantment | TgtPrompt$ Select target artifact or enchantment | ConditionCheckSVar$ X | ConditionSVarCompare$ EQ0 | SubAbility$ DBChangeZone | SpellDescription$ Exile target artifact or enchantment. Exile target artifact or enchantment. If this spell was kicked, exile target nonland permanent instead.
+SVar:DBChangeZone:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Permanent.nonLand | Condition$ Kicked
+SVar:X:Count$TimesKicked
+DeckHints:Color$Black
+Oracle:Kicker {1}{B} (You may pay an additional {1}{B} as you cast this spell.)\nExile target artifact or enchantment. If this spell was kicked, exile target nonland permanent instead.

--- a/forge-gui/res/cardsfolder/upcoming/territorial_maro.txt
+++ b/forge-gui/res/cardsfolder/upcoming/territorial_maro.txt
@@ -1,0 +1,9 @@
+Name:Territorial Maro
+ManaCost:4 G
+Types:Creature Elemental
+PT:*/*
+S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ Domain — CARDNAME's power and toughness are each equal to twice the number of basic land types among lands you control.
+SVar:X:Count$Domain/Twice
+AI:RemoveDeck:Random
+SVar:NeedsToPlayVar:X GE1
+Oracle:Domain — Territorial Maro's power and toughness are each equal to twice the number of basic land types among lands you control.

--- a/forge-gui/res/cardsfolder/upcoming/tidepool_turtle.txt
+++ b/forge-gui/res/cardsfolder/upcoming/tidepool_turtle.txt
@@ -1,0 +1,6 @@
+Name:Tidepool Turtle
+ManaCost:3 U
+Types:Creature Turtle
+PT:2/5
+A:AB$ Scry | Cost$ 2 U | ScryNum$ 1 | SpellDescription$ Scry 1.(Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:{2}{U}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)

--- a/forge-gui/res/cardsfolder/upcoming/timely_interference.txt
+++ b/forge-gui/res/cardsfolder/upcoming/timely_interference.txt
@@ -2,7 +2,7 @@ Name:Timely Interference
 ManaCost:U
 Types:Instant
 K:Kicker:1 R
-A:AB$ Pump | NumAtt$ -1 | ValidTgts$ Creature | IsCurse$ True | SpellDescription$ Target creature gets -1/-0 until end of turn. If this spell was kicked, that creature blocks this turn if able.
+A:SP$ Pump | NumAtt$ -1 | ValidTgts$ Creature | IsCurse$ True | SubAbility$ DBPump | SpellDescription$ Target creature gets -1/-0 until end of turn. If this spell was kicked, that creature blocks this turn if able.
 SVar:DBPump:DB$ Pump | Defined$ Targeted | Condition$ Kicked | KW$ HIDDEN CARDNAME blocks each combat if able. | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw | SpellDescription$ Draw a card. 
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/upcoming/timely_interference.txt
+++ b/forge-gui/res/cardsfolder/upcoming/timely_interference.txt
@@ -1,0 +1,10 @@
+Name:Timely Interference
+ManaCost:U
+Types:Instant
+K:Kicker:1 R
+A:AB$ Pump | NumAtt$ -1 | ValidTgts$ Creature | IsCurse$ True | SpellDescription$ Target creature gets -1/-0 until end of turn. If this spell was kicked, that creature blocks this turn if able.
+SVar:DBPump:DB$ Pump | Defined$ Targeted | Condition$ Kicked | KW$ HIDDEN CARDNAME blocks each combat if able. | SubAbility$ DBDraw
+SVar:DBDraw:DB$ Draw | SpellDescription$ Draw a card. 
+AI:RemoveDeck:All
+DeckHints:Color$Red
+Oracle:Kicker {1}{R} (You may pay an additional {1}{R} as you cast this spell.)\nTarget creature gets -1/-0 until end of turn. If this spell was kicked, that creature blocks this turn if able.\nDraw a card.

--- a/forge-gui/res/cardsfolder/upcoming/tolarian_geyser.txt
+++ b/forge-gui/res/cardsfolder/upcoming/tolarian_geyser.txt
@@ -1,0 +1,8 @@
+Name:Tolarian Geyser
+ManaCost:2 U
+Types:Sorcery
+K:Kicker:W
+A:SP$ ChangeZone | Cost$ U | ValidTgts$ Creature | Origin$ Battlefield | Destination$ Hand | SubAbility$ DBGainLife | SpellDescription$ Return target creature to its owner's hand. Draw a card. If this spell was kicked, you gain 3 life. 
+SVar:DBGainLife:DB$ GainLife | LifeAmount$ 3 | Condition$ Kicked
+DeckHas:Ability$LifeGain
+Oracle:Kicker {W} (You may pay an additional {W} as you cast this spell.)\nReturn target creature to its owner's hand. Draw a card. If this spell was kicked, you gain 3 life.

--- a/forge-gui/res/cardsfolder/upcoming/tolarian_geyser.txt
+++ b/forge-gui/res/cardsfolder/upcoming/tolarian_geyser.txt
@@ -2,7 +2,8 @@ Name:Tolarian Geyser
 ManaCost:2 U
 Types:Sorcery
 K:Kicker:W
-A:SP$ ChangeZone | Cost$ U | ValidTgts$ Creature | Origin$ Battlefield | Destination$ Hand | SubAbility$ DBGainLife | SpellDescription$ Return target creature to its owner's hand. Draw a card. If this spell was kicked, you gain 3 life. 
+A:SP$ ChangeZone | ValidTgts$ Creature | Origin$ Battlefield | Destination$ Hand | SubAbility$ DBDraw | SpellDescription$ Return target creature to its owner's hand. Draw a card. If this spell was kicked, you gain 3 life. 
+SVar:DBDraw:DB$ Draw | SubAbility$ DBGainLife
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ 3 | Condition$ Kicked
 DeckHas:Ability$LifeGain
 Oracle:Kicker {W} (You may pay an additional {W} as you cast this spell.)\nReturn target creature to its owner's hand. Draw a card. If this spell was kicked, you gain 3 life.

--- a/forge-gui/res/cardsfolder/upcoming/tolarian_terror.txt
+++ b/forge-gui/res/cardsfolder/upcoming/tolarian_terror.txt
@@ -1,0 +1,9 @@
+Name:Tolarian Terror
+ManaCost:6 U
+Types:Creature Serpent
+PT:5/5
+K:Ward:2
+S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ CARDNAME costs {1} less to cast for each instant and sorcery card in your graveyard.
+SVar:X:Count$ValidGraveyard Instant.YouOwn,Sorcery.YouOwn
+DeckHints:Ability$Graveyard & Type$Instant|Sorcery
+Oracle:This spell costs {1} less to cast for each instant and sorcery card in your graveyard.\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)

--- a/forge-gui/res/cardsfolder/upcoming/tori_davenant_fury_rider.txt
+++ b/forge-gui/res/cardsfolder/upcoming/tori_davenant_fury_rider.txt
@@ -1,0 +1,12 @@
+Name:Tori D'Avenant, Fury Rider
+ManaCost:1 R R W
+Types:Legendary Creature Human Knight
+PT:3/3
+K:Vigilance
+K:Trample
+T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, all other attacking creatures you control get +1/+1 until end of turn. Other red attacking creatures you control gain trample until end of turn Untap each other white attacking creature you control.
+SVar:TrigPump:DB$ PumpAll | ValidCards$ Creature.attacking+Other | NumAtt$ 1 | NumDef$ 1 | SubAbility$ DBPumpRed
+SVar:TrigPumpRed:DB$ PumpAll | ValidCards$ Creature.attacking+Red+Other | KW$ Trample | SubAbility$ DBPumpWhite
+SVar:DBPumpWhite:DB$ UntapAll | ValidCards$ Creature.attacking+White+Other
+SVar:BuffedBy:Creature
+Oracle:Vigilance, trample\nWhenever Tori D'Avenant, Fury Rider attacks, all other attacking creatures you control get +1/+1 until end of turn. Other red attacking creatures you control gain trample until end of turn Untap each other white attacking creature you control.

--- a/forge-gui/res/cardsfolder/upcoming/tori_davenant_fury_rider.txt
+++ b/forge-gui/res/cardsfolder/upcoming/tori_davenant_fury_rider.txt
@@ -5,8 +5,8 @@ PT:3/3
 K:Vigilance
 K:Trample
 T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, all other attacking creatures you control get +1/+1 until end of turn. Other red attacking creatures you control gain trample until end of turn Untap each other white attacking creature you control.
-SVar:TrigPump:DB$ PumpAll | ValidCards$ Creature.attacking+Other | NumAtt$ 1 | NumDef$ 1 | SubAbility$ DBPumpRed
-SVar:TrigPumpRed:DB$ PumpAll | ValidCards$ Creature.attacking+Red+Other | KW$ Trample | SubAbility$ DBPumpWhite
-SVar:DBPumpWhite:DB$ UntapAll | ValidCards$ Creature.attacking+White+Other
+SVar:TrigPump:DB$ PumpAll | ValidCards$ Creature.attacking+Other+YouCtrl | NumAtt$ 1 | NumDef$ 1 | SubAbility$ DBPumpRed
+SVar:DBPumpRed:DB$ PumpAll | ValidCards$ Creature.attacking+Red+Other+YouCtrl | KW$ Trample | SubAbility$ DBPumpWhite
+SVar:DBPumpWhite:DB$ UntapAll | ValidCards$ Creature.attacking+White+Other+YouCtrl
 SVar:BuffedBy:Creature
 Oracle:Vigilance, trample\nWhenever Tori D'Avenant, Fury Rider attacks, all other attacking creatures you control get +1/+1 until end of turn. Other red attacking creatures you control gain trample until end of turn Untap each other white attacking creature you control.


### PR DESCRIPTION
Added AI:RemoveDeck:Random to Kobold Warcaller since the AI keeps activating it's ability even when all the card in the creatures in the AI's hand have haste. I've looked around a bit with AI logic in ChooseCard but coudn't find anything usefull