### PR TITLE
Fix mutated cards disappearing when top is token

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/PlayEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PlayEffect.java
@@ -91,8 +91,8 @@ public class PlayEffect extends SpellAbilityEffect {
         final boolean imprint = sa.hasParam("ImprintPlayed");
         final boolean forget = sa.hasParam("ForgetPlayed");
         final boolean hasTotalCMCLimit = sa.hasParam("WithTotalCMC");
-        int amount = 1;
         int totalCMCLimit = Integer.MAX_VALUE;
+        int amount = 1;
         if (sa.hasParam("Amount") && !sa.getParam("Amount").equals("All")) {
             amount = AbilityUtils.calculateAmount(source, sa.getParam("Amount"), sa);
         }

--- a/forge-game/src/main/java/forge/game/card/CardFactory.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactory.java
@@ -77,7 +77,7 @@ public class CardFactory {
      */
     public final static Card copyCard(final Card in, boolean assignNewId) {
         Card out;
-        if (!(in.isToken() || in.getCopiedPermanent() != null)) {
+        if (!(in.isRealToken() || in.getCopiedPermanent() != null)) {
             out = assignNewId ? getCard(in.getPaperCard(), in.getOwner(), in.getGame())
                               : getCard(in.getPaperCard(), in.getOwner(), in.getId(), in.getGame());
         } else { // token

--- a/forge-gui/res/cardsfolder/m/mirrorwing_dragon.txt
+++ b/forge-gui/res/cardsfolder/m/mirrorwing_dragon.txt
@@ -4,5 +4,5 @@ Types:Creature Dragon
 PT:4/5
 K:Flying
 T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | IsSingleTarget$ True | TargetsValid$ Card.Self | Execute$ TrigCopy | TriggerZones$ Battlefield | TriggerDescription$ Whenever a player casts an instant or sorcery spell that targets only CARDNAME, that player copies that spell for each other creature they control that the spell could target. Each copy targets a different one of those creatures.
-SVar:TrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | Controller$ TriggeredActivator | CopyForEachCanTarget$ Creature.YouCtrl
+SVar:TrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | Controller$ TriggeredActivator | CopyForEachCanTarget$ Creature.ControlledBy TriggeredActivator
 Oracle:Flying\nWhenever a player casts an instant or sorcery spell that targets only Mirrorwing Dragon, that player copies that spell for each other creature they control that the spell could target. Each copy targets a different one of those creatures.

--- a/forge-gui/res/cardsfolder/t/tatsumasa_the_dragons_fang.txt
+++ b/forge-gui/res/cardsfolder/t/tatsumasa_the_dragons_fang.txt
@@ -4,6 +4,6 @@ Types:Legendary Artifact Equipment
 K:Equip:3
 S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 5 | AddToughness$ 5 | Description$ Equipped creature gets +5/+5.
 A:AB$ Token | Cost$ 6 Exile<1/CARDNAME> | TokenAmount$ 1 | TokenScript$ u_5_5_dragon_spirit_flying | TokenOwner$ You | RememberTokens$ True | SubAbility$ DelTrig | SpellDescription$ Create a 5/5 blue Dragon Spirit creature token with flying. Return CARDNAME to the battlefield under its owner's control when that token dies.
-SVar:DelTrig:DB$ DelayedTrigger | Mode$ ChangesZone | ValidCard$ Card.IsTriggerRemembered | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigReturn | RememberObjects$ Remembered | TriggerDescription$ Return CARDNAME to the battlefield under its owner's control when that token dies.
-SVar:TrigReturn:DB$ ChangeZone | Origin$ Exile | Destination$ Battlefield | Defined$ Self
+SVar:DelTrig:DB$ DelayedTrigger | Mode$ ChangesZone | ValidCard$ Card.IsTriggerRemembered | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigReturn | RememberObjects$ Remembered,ExiledCards | TriggerDescription$ Return CARDNAME to the battlefield under its owner's control when that token dies.
+SVar:TrigReturn:DB$ ChangeZone | Origin$ Exile | Destination$ Battlefield | Defined$ DelayTriggerRememberedLKI
 Oracle:Equipped creature gets +5/+5.\n{6}, Exile Tatsumasa, the Dragon's Fang: Create a 5/5 blue Dragon Spirit creature token with flying. Return Tatsumasa to the battlefield under its owner's control when that token dies.\nEquip {3}


### PR DESCRIPTION
Happens when you get the spell copied with _Ivy, Gleeful Spellthief_ and then do a zone change.

The problem was because it technically counts as token `copyCard` would be fooled and even transform the real card part into one.