### PR TITLE
Add AI support for Fiery Justice

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/DamageAiBase.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DamageAiBase.java
@@ -2,6 +2,7 @@ package forge.ai.ability;
 
 import com.google.common.collect.Iterables;
 
+import forge.ai.ComputerUtil;
 import forge.ai.ComputerUtilCombat;
 import forge.ai.SpellAbilityAi;
 import forge.game.Game;
@@ -68,6 +69,11 @@ public abstract class DamageAiBase extends SpellAbilityAi {
             return false;
         }
         if (sa.getTargets() != null && sa.getTargets().contains(enemy)) {
+            return false;
+        }
+
+        // If the opponent will gain life (ex. Fiery Justice), not beneficial unless life gain is harmful or ignored
+        if ("OpponentGainLife".equals(sa.getParam("AILogic")) && ComputerUtil.lifegainPositive(enemy, sa.getHostCard())) {
             return false;
         }
 

--- a/forge-ai/src/main/java/forge/ai/ability/DamageDealAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DamageDealAi.java
@@ -781,6 +781,13 @@ public class DamageDealAi extends DamageAiBase {
             sa.resetTargets();
             return false;
         }
+
+        // if opponent will gain life (ex. Fiery Justice), don't target only enemy player unless life gain is harmful or ignored
+        if ("OpponentGainLife".equals(logic) && tcs.size() == 1 && tcs.contains(enemy) && ComputerUtil.lifegainPositive(enemy, source)){
+            sa.resetTargets();
+            return false;
+        }
+
         return true;
     }
 

--- a/forge-gui/res/cardsfolder/f/fiery_justice.txt
+++ b/forge-gui/res/cardsfolder/f/fiery_justice.txt
@@ -1,7 +1,6 @@
 Name:Fiery Justice
 ManaCost:R G W
 Types:Sorcery
-A:SP$ DealDamage | Cost$ R G W | ValidTgts$ Creature,Player,Planeswalker | TgtPrompt$ Select any target to distribute damage to | NumDmg$ 5 | TargetMin$ 1 | TargetMax$ 5 | DividedAsYouChoose$ 5 | SubAbility$ Justice | SpellDescription$ CARDNAME deals 5 damage divided as you choose among any number of targets. Target opponent gains 5 life.
+A:SP$ DealDamage | Cost$ R G W | ValidTgts$ Creature,Player,Planeswalker | TgtPrompt$ Select any target to distribute damage to | NumDmg$ 5 | TargetMin$ 1 | TargetMax$ 5 | DividedAsYouChoose$ 5 | AILogic$ OpponentGainLife | SubAbility$ Justice | SpellDescription$ CARDNAME deals 5 damage divided as you choose among any number of targets. Target opponent gains 5 life.
 SVar:Justice:DB$ GainLife | ValidTgts$ Opponent | TgtPrompt$ Select target opponent to gain life | LifeAmount$ 5
-AI:RemoveDeck:All
 Oracle:Fiery Justice deals 5 damage divided as you choose among any number of targets. Target opponent gains 5 life.


### PR DESCRIPTION
[Fiery Justice](https://scryfall.com/card/2x2/212/fiery-justice) is a cool and unique card. This adds logic so the AI plays it reasonably well. 

Before this, the AI would cast Fiery Justice with all the damage going to the opponent, which is useless (unless life gain is prevented or reversed). The AI now avoids this behaviour via two new similar but slightly different checks in the damage AI code, based on a new "OpponentGainLife" AILogic string:
1. In `DamageAiBase.shouldTargetP()`, avoid targeting players unless life gain is not beneficial for that player. That makes the AI prioritize targeting creatures in those cases, throwing only leftover damage to the opponent.
2. At the end of `DamageDealAi.damageChoosingTargets()`, check if we're targeting only the opponent, and don't do that if life gain would be beneficial for that player. This additional check is necessary since there is a bit of logic previously that targets players "just because we can".

I tested the following scenarios. In each case, the AI player has an untapped Plains, Mountain and Forest on the battlefield and a Fiery Justice in hand:
- [x] I have no creatures and 20 life. AI does not cast Fiery Justice.
- [x] I have no creatures and 1 life. AI does not cast Fiery Justice.
- [x] I have one 1/1 creature and 20 life. AI targets 1/1 with 1 damage and me with 4 damage.
- [x] I have a 1/1 and a 2/2, and 20 life. AI deals 1, 2, and 2 damage to the creatures then me.
- [x] I have one 1/1 creature and one 2/6 creature, and 20 life. AI kills the 1/1 and targets me with 4 damage.
- [x] I have one 1/1 creature and 1 life. AI targets 1/1 with 1 damage and me with 4 damage.
- [x] I have no creatures, 20 life, AI has [Erebos, God of the Dead](https://scryfall.com/card/ths/85/erebos-god-of-the-dead) (prevents life gain). AI casts Fiery Justice, targeting me with all 5 damage.
- [x] I have one 1/1 creature and 20 life, AI has [Erebos, God of the Dead](https://scryfall.com/card/ths/85/erebos-god-of-the-dead). AI targets 1/1 with 1 damage, me with 4.
- [x] I have one 1/1 creature and 5 life, AI has [Erebos, God of the Dead](https://scryfall.com/card/ths/85/erebos-god-of-the-dead). AI targets me with all 5 damage.
- [x] I have 20 life and no creatures, AI has [Tainted Remedy](https://scryfall.com/card/ori/120/tainted-remedy) (reverses life gain). AI casts Fiery Justice targeting me and I take 5 damage and lose 5 life. Ouch!