### PR TITLE
AiBlockController: check commanders in sortPotentialAttackers

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCombat.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCombat.java
@@ -387,7 +387,7 @@ public class ComputerUtilCombat {
     public static List<Card> getLifeThreateningCommanders(final Player ai, final Combat combat) {
         List<Card> res = Lists.newArrayList();
         for (Card c : combat.getAttackers()) {
-            if (c.isCommander()) {
+            if (c.isCommander() && combat.isAttacking(c, ai)) {
                 int currentCommanderDamage = ai.getCommanderDamage(c);
                 if (damageIfUnblocked(c, ai, combat, false) + currentCommanderDamage >= 21) {
                     res.add(c);

--- a/forge-gui/res/cardsfolder/a/ashling_the_extinguisher.txt
+++ b/forge-gui/res/cardsfolder/a/ashling_the_extinguisher.txt
@@ -3,6 +3,6 @@ ManaCost:2 B B
 Types:Legendary Creature Elemental Shaman
 PT:4/4
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigDestroy | CombatDamage$ True | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, choose target creature that player controls. The player sacrifices that creature.
-SVar:TrigDestroy:DB$ Destroy | ValidTgts$ Creature.ControlledBy TriggeredDefendingPlayer | Sacrifice$ True | TgtPrompt$ Select target creature defending player controls
+SVar:TrigDestroy:DB$ Destroy | ValidTgts$ Creature.ControlledBy TriggeredTarget | Sacrifice$ True | TgtPrompt$ Select target creature that player controls
 SVar:MustBeBlocked:True
 Oracle:Whenever Ashling, the Extinguisher deals combat damage to a player, choose target creature that player controls. The player sacrifices that creature.

--- a/forge-gui/res/cardsfolder/b/balefire_dragon.txt
+++ b/forge-gui/res/cardsfolder/b/balefire_dragon.txt
@@ -4,7 +4,7 @@ Types:Creature Dragon
 PT:6/6
 K:Flying
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigDamage | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, it deals that much damage to each creature that player controls.
-SVar:TrigDamage:DB$ DamageAll | NumDmg$ X | ValidCards$ Creature.ControlledBy TriggeredDefendingPlayer
+SVar:TrigDamage:DB$ DamageAll | NumDmg$ X | ValidCards$ Creature.ControlledBy TriggeredTarget
 SVar:X:TriggerCount$DamageAmount
 SVar:MustBeBlocked:True
 Oracle:Flying\nWhenever Balefire Dragon deals combat damage to a player, it deals that much damage to each creature that player controls.

--- a/forge-gui/res/cardsfolder/c/cephalid_constable.txt
+++ b/forge-gui/res/cardsfolder/c/cephalid_constable.txt
@@ -3,6 +3,6 @@ ManaCost:1 U U
 Types:Creature Cephalid Wizard
 PT:1/1
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigBounce | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, return up to that many target permanents that player controls to their owner's hand.
-SVar:TrigBounce:DB$ ChangeZone | ValidTgts$ Permanent.ControlledBy TriggeredDefendingPlayer | TgtPrompt$ Select target permanent | TargetMin$ 0 | TargetMax$ X | Origin$ Battlefield | Destination$ Hand
+SVar:TrigBounce:DB$ ChangeZone | ValidTgts$ Permanent.ControlledBy TriggeredTarget | TgtPrompt$ Select target permanent | TargetMin$ 0 | TargetMax$ X | Origin$ Battlefield | Destination$ Hand
 SVar:X:TriggeredSource$CardPower
 Oracle:Whenever Cephalid Constable deals combat damage to a player, return up to that many target permanents that player controls to their owner's hand.

--- a/forge-gui/res/cardsfolder/c/commando_raid.txt
+++ b/forge-gui/res/cardsfolder/c/commando_raid.txt
@@ -3,6 +3,6 @@ ManaCost:2 R
 Types:Instant
 A:SP$ Animate | Cost$ 2 R | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | Triggers$ TrigDamage | SpellDescription$ Until end of turn, target creature you control gains "When this creature deals combat damage to a player, you may have it deal damage equal to its power to target creature that player controls."
 SVar:TrigDamage:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ Damage | OptionalDecider$ You | TriggerDescription$ When this creature deals combat damage to a player, you may have it deal damage equal to its power to target creature that player controls.
-SVar:Damage:DB$ DealDamage | ValidTgts$ Creature.ControlledBy TriggeredDefendingPlayer | TgtPrompt$ Select target creature defending player controls | NumDmg$ CommandoRaidX
+SVar:Damage:DB$ DealDamage | ValidTgts$ Creature.ControlledBy TriggeredTarget | TgtPrompt$ Select target creature that player controls | NumDmg$ CommandoRaidX
 SVar:CommandoRaidX:Count$CardPower
 Oracle:Until end of turn, target creature you control gains "When this creature deals combat damage to a player, you may have it deal damage equal to its power to target creature that player controls."

--- a/forge-gui/res/cardsfolder/d/dawning_purist.txt
+++ b/forge-gui/res/cardsfolder/d/dawning_purist.txt
@@ -4,5 +4,5 @@ Types:Creature Human Cleric
 PT:2/2
 K:Morph:1 W
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigDestroy | CombatDamage$ True | OptionalDecider$ You | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, you may destroy target enchantment that player controls.
-SVar:TrigDestroy:DB$ Destroy | ValidTgts$ Enchantment.ControlledBy TriggeredTarget | TgtPrompt$ Select target artifact damaged player controls
+SVar:TrigDestroy:DB$ Destroy | ValidTgts$ Enchantment.ControlledBy TriggeredTarget | TgtPrompt$ Select target enchantment damaged player controls
 Oracle:Whenever Dawning Purist deals combat damage to a player, you may destroy target enchantment that player controls.\nMorph {1}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)

--- a/forge-gui/res/cardsfolder/e/emissary_of_despair.txt
+++ b/forge-gui/res/cardsfolder/e/emissary_of_despair.txt
@@ -5,5 +5,5 @@ PT:2/1
 K:Flying
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigLoseLife | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, that player loses 1 life for each artifact they control.
 SVar:TrigLoseLife:DB$ LoseLife | Defined$ TriggeredTarget | LifeAmount$ X
-SVar:X:Count$Valid Artifact.ControlledBy TriggeredDefendingPlayer
+SVar:X:Count$Valid Artifact.ControlledBy TriggeredTarget
 Oracle:Flying\nWhenever Emissary of Despair deals combat damage to a player, that player loses 1 life for each artifact they control.

--- a/forge-gui/res/cardsfolder/e/emissary_of_hope.txt
+++ b/forge-gui/res/cardsfolder/e/emissary_of_hope.txt
@@ -5,5 +5,5 @@ PT:2/1
 K:Flying
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigLoseLife | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, you gain 1 life for each artifact that player controls.
 SVar:TrigLoseLife:DB$ GainLife | Defined$ You | LifeAmount$ X
-SVar:X:Count$Valid Artifact.ControlledBy TriggeredDefendingPlayer
+SVar:X:Count$Valid Artifact.ControlledBy TriggeredTarget
 Oracle:Flying\nWhenever Emissary of Hope deals combat damage to a player, you gain 1 life for each artifact that player controls.

--- a/forge-gui/res/cardsfolder/e/etrata_the_silencer.txt
+++ b/forge-gui/res/cardsfolder/e/etrata_the_silencer.txt
@@ -4,9 +4,9 @@ Types:Legendary Creature Vampire Assassin
 PT:3/5
 K:Unblockable
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigExile | TriggerDescription$ Whenever NICKNAME deals combat damage to a player, exile target creature that player controls and put a hit counter on that card. That player loses the game if they own three or more exiled cards with hit counters on them. NICKNAME's owner shuffles NICKNAME into their library.
-SVar:TrigExile:DB$ ChangeZone | ValidTgts$ Creature.ControlledBy TriggeredDefendingPlayer | TgtPrompt$ Exile target creature that player controls | Origin$ Battlefield | Destination$ Exile | WithCountersType$ HIT | SubAbility$ DBLose
+SVar:TrigExile:DB$ ChangeZone | ValidTgts$ Creature.ControlledBy TriggeredTarget | TgtPrompt$ Exile target creature that player controls | Origin$ Battlefield | Destination$ Exile | WithCountersType$ HIT | SubAbility$ DBLose
 SVar:DBLose:DB$ LosesGame | Defined$ TriggeredTarget | ConditionCheckSVar$ CheckExile | ConditionSVarCompare$ GE3 | SubAbility$ DBShuffle
-SVar:CheckExile:Count$ValidExile Card.counters_GE1_HIT+ControlledBy TriggeredDefendingPlayer
+SVar:CheckExile:Count$ValidExile Card.counters_GE1_HIT+ControlledBy TriggeredTarget
 SVar:DBShuffle:DB$ ChangeZone | ConditionPresent$ Card.Self | ValidCard$ Card.Self | Origin$ Battlefield | Destination$ Library | Shuffle$ True
 DeckHints:Name$Mari, the Killing Quill|Ravenloft Adventurer
 Oracle:Etrata, the Silencer can't be blocked.\nWhenever Etrata deals combat damage to a player, exile target creature that player controls and put a hit counter on that card. That player loses the game if they own three or more exiled cards with hit counters on them. Etrata's owner shuffles Etrata into their library.

--- a/forge-gui/res/cardsfolder/h/hellkite_tyrant.txt
+++ b/forge-gui/res/cardsfolder/h/hellkite_tyrant.txt
@@ -5,7 +5,7 @@ PT:6/5
 K:Flying
 K:Trample
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigGainControl | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, gain control of all artifacts that player controls.
-SVar:TrigGainControl:DB$ GainControl | AllValid$ Artifact.ControlledBy TriggeredDefendingPlayer | NewController$ You
+SVar:TrigGainControl:DB$ GainControl | AllValid$ Artifact.ControlledBy TriggeredTarget | NewController$ You
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | PresentCompare$ GE20 | IsPresent$ Artifact.YouCtrl | Execute$ WinGame | TriggerDescription$ At the beginning of your upkeep, if you control twenty or more artifacts, you win the game.
 SVar:WinGame:DB$ WinsGame | Defined$ You
 Oracle:Flying, trample\nWhenever Hellkite Tyrant deals combat damage to a player, gain control of all artifacts that player controls.\nAt the beginning of your upkeep, if you control twenty or more artifacts, you win the game.

--- a/forge-gui/res/cardsfolder/h/hoard_hauler.txt
+++ b/forge-gui/res/cardsfolder/h/hoard_hauler.txt
@@ -5,7 +5,7 @@ PT:5/5
 K:Trample
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigTreasure | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, create a Treasure token for each artifact they control.
 SVar:TrigTreasure:DB$ Token | TokenScript$ c_a_treasure_sac | TokenAmount$ X
-SVar:X:Count$Valid Artifact.ControlledBy TriggeredDefendingPlayer
+SVar:X:Count$Valid Artifact.ControlledBy TriggeredTarget
 K:Crew:3
 AI:RemoveDeck:Random
 DeckHas:Ability$Token|Sacrifice & Type$Treasure|Artifact

--- a/forge-gui/res/cardsfolder/k/kappa_tech_wrecker.txt
+++ b/forge-gui/res/cardsfolder/k/kappa_tech_wrecker.txt
@@ -6,5 +6,5 @@ K:Ninjutsu:1 G
 K:etbCounter:Deathtouch:1
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigImmediateTrig | CombatDamage$ True | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, you may remove a deathtouch counter from it. When you do, exile target artifact or enchantment that player controls.
 SVar:TrigImmediateTrig:AB$ ImmediateTrigger | Cost$ SubCounter<1/Deathtouch> | Execute$ TrigExile | CopyTriggeringObjects$ True | TriggerDescription$ When you do, exile target artifact or enchantment that player controls.
-SVar:TrigExile:DB$ ChangeZone | ValidTgts$ Artifact.ControlledBy TriggeredDefendingPlayer,Enchantment.ControlledBy TriggeredDefendingPlayer | TgtPrompt$ Select target artifact or enchantment creature that player controls | Origin$ Battlefield | Destination$ Exile
+SVar:TrigExile:DB$ ChangeZone | ValidTgts$ Artifact.ControlledBy TriggeredTarget,Enchantment.ControlledBy TriggeredTarget | TgtPrompt$ Select target artifact or enchantment creature that player controls | Origin$ Battlefield | Destination$ Exile
 Oracle:Ninjutsu {1}{G}\nKappa Tech-Wrecker enters the battlefield with a deathtouch counter on it.\nWhenever Kappa Tech-Wrecker deals combat damage to a player, you may remove a deathtouch counter from it. When you do, exile target artifact or enchantment that player controls.

--- a/forge-gui/res/cardsfolder/l/lightwielder_paladin.txt
+++ b/forge-gui/res/cardsfolder/l/lightwielder_paladin.txt
@@ -4,5 +4,5 @@ Types:Creature Human Knight
 PT:4/4
 K:First Strike
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigExile | OptionalDecider$ You | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, you may exile target black or red permanent that player controls.
-SVar:TrigExile:DB$ ChangeZone | ValidTgts$ Permanent.Black+ControlledBy TriggeredDefendingPlayer,Permanent.Red+ControlledBy TriggeredDefendingPlayer | TgtPrompt$ Choose target black or red permanent. | Origin$ Battlefield | Destination$ Exile | IsCurse$ True
+SVar:TrigExile:DB$ ChangeZone | ValidTgts$ Permanent.Black+ControlledBy TriggeredTarget,Permanent.Red+ControlledBy TriggeredTarget | TgtPrompt$ Choose target black or red permanent. | Origin$ Battlefield | Destination$ Exile | IsCurse$ True
 Oracle:First strike (This creature deals combat damage before creatures without first strike.)\nWhenever Lightwielder Paladin deals combat damage to a player, you may exile target black or red permanent that player controls.

--- a/forge-gui/res/cardsfolder/m/mairsil_the_pretender.txt
+++ b/forge-gui/res/cardsfolder/m/mairsil_the_pretender.txt
@@ -2,7 +2,7 @@ Name:Mairsil, the Pretender
 ManaCost:1 U B R
 Types:Legendary Creature Human Wizard
 PT:4/4
-S:Mode$ Continuous | Affected$ Card.Self | EffectZone$ Battlefield | GainsAbilitiesOf$ Card.YouOwn+inZoneExile+counters_GE1_CAGE | GainsAbilitiesOfZones$ Exile | GainsAbilitiesLimitPerTurn$ 1 | Description$ CARDNAME has all activated abilities of all cards you own in exile with cage counters on them. You may activate each of those abilities only once each turn.
+S:Mode$ Continuous | Affected$ Card.Self | EffectZone$ Battlefield | GainsAbilitiesOf$ Card.YouOwn+counters_GE1_CAGE | GainsAbilitiesOfZones$ Exile | GainsAbilitiesLimitPerTurn$ 1 | Description$ CARDNAME has all activated abilities of all cards you own in exile with cage counters on them. You may activate each of those abilities only once each turn.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExile | OptionalDecider$ You | TriggerDescription$ When CARDNAME enters the battlefield, you may exile an artifact or creature card from your hand or graveyard and put a cage counter on it.
 SVar:TrigExile:DB$ ChangeZone | Origin$ Hand,Graveyard | Destination$ Exile | ChangeType$ Artifact.YouCtrl,Creature.YouCtrl | SubAbility$ DBCounter | RememberChanged$ True | ChangeNum$ 1 | AILogic$ Mairsil
 SVar:DBCounter:DB$ PutCounter | CounterType$ CAGE | CounterNum$ 1 | Defined$ Remembered | SubAbility$ DBCleanup

--- a/forge-gui/res/cardsfolder/m/mindleech_mass.txt
+++ b/forge-gui/res/cardsfolder/m/mindleech_mass.txt
@@ -5,5 +5,5 @@ PT:6/6
 K:Trample
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigReveal | TriggerZones$ Battlefield | OptionalDecider$ You | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, you may look at that player's hand. If you do, you may cast a spell from among those cards without paying its mana cost.
 SVar:TrigReveal:DB$ RevealHand | Defined$ TriggeredTarget | SubAbility$ TrigPlay | Look$ True
-SVar:TrigPlay:DB$ Play | Valid$ Card.ControlledBy TriggeredDefendingPlayer | ValidZone$ Hand | ValidSA$ Spell | WithoutManaCost$ True | Optional$ True
+SVar:TrigPlay:DB$ Play | Valid$ Card.ControlledBy TriggeredTarget | ValidZone$ Hand | ValidSA$ Spell | WithoutManaCost$ True | Optional$ True
 Oracle:Trample\nWhenever Mindleech Mass deals combat damage to a player, you may look at that player's hand. If you do, you may cast a spell from among those cards without paying its mana cost.

--- a/forge-gui/res/cardsfolder/m/mistblade_shinobi.txt
+++ b/forge-gui/res/cardsfolder/m/mistblade_shinobi.txt
@@ -4,5 +4,5 @@ Types:Creature Human Ninja
 PT:1/1
 K:Ninjutsu:U
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigBounce | OptionalDecider$ You | CombatDamage$ True | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, you may return target creature that player controls to its owner's hand.
-SVar:TrigBounce:DB$ ChangeZone | ValidTgts$ Creature.ControlledBy TriggeredDefendingPlayer | TgtPrompt$ Choose target creature your opponent controls. | Origin$ Battlefield | Destination$ Hand
+SVar:TrigBounce:DB$ ChangeZone | ValidTgts$ Creature.ControlledBy TriggeredTarget | TgtPrompt$ Choose target creature your opponent controls. | Origin$ Battlefield | Destination$ Hand
 Oracle:Ninjutsu {U} ({U}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Mistblade Shinobi deals combat damage to a player, you may return target creature that player controls to its owner's hand.

--- a/forge-gui/res/cardsfolder/m/mordant_dragon.txt
+++ b/forge-gui/res/cardsfolder/m/mordant_dragon.txt
@@ -5,7 +5,7 @@ PT:5/5
 K:Flying
 A:AB$ Pump | Cost$ 1 R | Defined$ Self | NumAtt$ +1 | SpellDescription$ CARDNAME gets +1/+0 until end of turn.
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | OptionalDecider$ You | Execute$ TrigDamage | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, you may have it deal that much damage to target creature that player controls.
-SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Creature.ControlledBy TriggeredDefendingPlayer | NumDmg$ X | TgtPrompt$ Select target creature.
+SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Creature.ControlledBy TriggeredTarget | NumDmg$ X | TgtPrompt$ Select target creature.
 SVar:X:Count$CardPower
 SVar:MustBeBlocked:True
 Oracle:Flying\n{1}{R}: Mordant Dragon gets +1/+0 until end of turn.\nWhenever Mordant Dragon deals combat damage to a player, you may have it deal that much damage to target creature that player controls.

--- a/forge-gui/res/cardsfolder/n/narset_of_the_ancient_way.txt
+++ b/forge-gui/res/cardsfolder/n/narset_of_the_ancient_way.txt
@@ -9,7 +9,7 @@ SVar:DBDiscard:DB$ Discard | Defined$ You | Mode$ TgtChoose | Optional$ True | N
 SVar:DBImmediateTrig:DB$ ImmediateTrigger | ConditionDefined$ Remembered | ConditionPresent$ Card.nonLand | ConditionCompare$ EQ1 | Execute$ TrigDamage | RememberObjects$ Remembered | SubAbility$ DBCleanup | StackDescription$ SpellDescription | SpellDescription$ When you discard a nonland card this way, CARDNAME deals damage equal to that card's mana value to target creature or planeswalker.
 SVar:TrigDamage:DB$ DealDamage | NumDmg$ X | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-SVar:X:Remembered$CardManaCost
+SVar:X:TriggerRemembered$CardManaCost
 A:AB$ Effect | Cost$ SubCounter<6/LOYALTY> | Planeswalker$ True | Ultimate$ True | Name$ Emblem - Narset of the Ancient Way | Image$ emblem_narset_of_the_ancient_way | Triggers$ TrigSpellCast | Duration$ Permanent | Duration$ Permanent | AILogic$ Always | SpellDescription$ You get an emblem with "Whenever you cast a noncreature spell, this emblem deals 2 damage to any target."
 SVar:TrigSpellCast:Mode$ SpellCast | ValidActivatingPlayer$ You | ValidCard$ Card.nonCreature | Execute$ EffSpellCast | TriggerDescription$ Whenever you cast a noncreature spell, this emblem deals 2 damage to any target.
 SVar:EffSpellCast:DB$ DealDamage | ValidTgts$ Creature,Player,Planeswalker | TgtPrompt$ Select any target | NumDmg$ 2

--- a/forge-gui/res/cardsfolder/o/o_kagachi_vengeful_kami.txt
+++ b/forge-gui/res/cardsfolder/o/o_kagachi_vengeful_kami.txt
@@ -5,5 +5,5 @@ PT:6/6
 K:Flying
 K:Trample
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player.attackedYouTheirLastTurn | Execute$ TrigExile | CombatDamage$ True | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, if that player attacked you during their last turn, exile target nonland permanent that player controls.
-SVar:TrigExile:DB$ ChangeZone | ValidTgts$ Permanent.nonLand+ControlledBy TriggeredDefendingPlayer | TgtPrompt$ Select target nonland permanent | Origin$ Battlefield | Destination$ Exile
+SVar:TrigExile:DB$ ChangeZone | ValidTgts$ Permanent.nonLand+ControlledBy TriggeredTarget | TgtPrompt$ Select target nonland permanent | Origin$ Battlefield | Destination$ Exile
 Oracle:Flying, trample\nWhenever O-Kagachi, Vengeful Kami deals combat damage to a player, if that player attacked you during their last turn, exile target nonland permanent that player controls.

--- a/forge-gui/res/cardsfolder/r/riptide_entrancer.txt
+++ b/forge-gui/res/cardsfolder/r/riptide_entrancer.txt
@@ -3,6 +3,6 @@ ManaCost:1 U U
 Types:Creature Human Wizard
 PT:1/1
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigGainControl | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, you may sacrifice it. If you do, gain control of target creature that player controls. (This effect lasts indefinitely.)
-SVar:TrigGainControl:AB$GainControl | Cost$ Sac<1/CARDNAME> | ValidTgts$ Creature.ControlledBy TriggeredDefendingPlayer | TgtPrompt$ Select target creature that player controls
+SVar:TrigGainControl:AB$GainControl | Cost$ Sac<1/CARDNAME> | ValidTgts$ Creature.ControlledBy TriggeredTarget | TgtPrompt$ Select target creature that player controls
 K:Morph:U U
 Oracle:Whenever Riptide Entrancer deals combat damage to a player, you may sacrifice it. If you do, gain control of target creature that player controls. (This effect lasts indefinitely.)\nMorph {U}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)

--- a/forge-gui/res/cardsfolder/s/shield_mare.txt
+++ b/forge-gui/res/cardsfolder/s/shield_mare.txt
@@ -4,6 +4,6 @@ Types:Creature Horse
 PT:2/3
 S:Mode$ CantBlockBy | ValidAttacker$ Creature.Self | ValidBlocker$ Creature.Red | Description$ CARDNAME can't be blocked by red creatures.
 T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ DBGainLife | TriggerDescription$ When CARDNAME enters the battlefield or becomes the target of a spell or ability an opponent controls, you gain 3 life.
-T:Mode$ BecomesTarget | ValidTarget$ Card.Self | ValidSource$ Card.OppCtrl | TriggerZones$ Battlefield | Execute$ DBGainLife | TriggerDescription$ When CARDNAME enters the battlefield or becomes the target of a spell or ability an opponent controls, you gain 3 life.
+T:Mode$ BecomesTarget | ValidTarget$ Card.Self | ValidSource$ Card.OppCtrl | TriggerZones$ Battlefield | Execute$ DBGainLife | Secondary$ True | TriggerDescription$ When CARDNAME enters the battlefield or becomes the target of a spell or ability an opponent controls, you gain 3 life.
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 3
 Oracle:Shield Mare can't be blocked by red creatures.\nWhen Shield Mare enters the battlefield or becomes the target of a spell or ability an opponent controls, you gain 3 life.

--- a/forge-gui/res/cardsfolder/s/shockmaw_dragon.txt
+++ b/forge-gui/res/cardsfolder/s/shockmaw_dragon.txt
@@ -4,5 +4,5 @@ Types:Creature Dragon
 PT:4/4
 K:Flying
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigDamage | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, it deals 1 damage to each creature that player controls.
-SVar:TrigDamage:DB$ DamageAll | NumDmg$ 1 | ValidCards$ Creature.ControlledBy TriggeredDefendingPlayer
+SVar:TrigDamage:DB$ DamageAll | NumDmg$ 1 | ValidCards$ Creature.ControlledBy TriggeredTarget
 Oracle:Flying\nWhenever Shockmaw Dragon deals combat damage to a player, it deals 1 damage to each creature that player controls.

--- a/forge-gui/res/cardsfolder/s/skirk_commando.txt
+++ b/forge-gui/res/cardsfolder/s/skirk_commando.txt
@@ -4,5 +4,5 @@ Types:Creature Goblin
 PT:2/1
 K:Morph:2 R
 T:Mode$ DamageDone | ValidSource$ Card.Self+faceUp | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigDamage | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, you may have it deal 2 damage to target creature that player controls.
-SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Creature.ControlledBy TriggeredDefendingPlayer | TgtPrompt$ Select target creature controlled by opponent | NumDmg$ 2
+SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Creature.ControlledBy TriggeredTarget | TgtPrompt$ Select target creature controlled by that player | NumDmg$ 2
 Oracle:Whenever Skirk Commando deals combat damage to a player, you may have it deal 2 damage to target creature that player controls.\nMorph {2}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)

--- a/forge-gui/res/cardsfolder/s/snapping_thragg.txt
+++ b/forge-gui/res/cardsfolder/s/snapping_thragg.txt
@@ -4,5 +4,5 @@ Types:Creature Beast
 PT:3/3
 K:Morph:4 R R
 T:Mode$ DamageDone | ValidSource$ Card.Self+faceUp | ValidTarget$ Player | Execute$ TrigDamage | TriggerZones$ Battlefield | CombatDamage$ True | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, you may have it deal 3 damage to target creature that player controls.
-SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Creature.ControlledBy TriggeredDefendingPlayer | TgtPrompt$ Select target creature defending player controls | NumDmg$ 3
+SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Creature.ControlledBy TriggeredTarget | TgtPrompt$ Select target creature that player controls | NumDmg$ 3
 Oracle:Whenever Snapping Thragg deals combat damage to a player, you may have it deal 3 damage to target creature that player controls.\nMorph {4}{R}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)

--- a/forge-gui/res/cardsfolder/s/soul_seizer_ghastly_haunting.txt
+++ b/forge-gui/res/cardsfolder/s/soul_seizer_ghastly_haunting.txt
@@ -5,7 +5,7 @@ PT:1/3
 K:Flying
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | OptionalDecider$ You | Execute$ TrigTransform | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, you may transform it. If you do, attach it to target creature that player controls.
 SVar:TrigTransform:DB$ SetState | Defined$ Self | Mode$ Transform | SubAbility$ DBAttach
-SVar:DBAttach:DB$ Attach | ValidTgts$ Creature.ControlledBy TriggeredDefendingPlayer | TgtPrompt$ Select target creature that damaged player controls | AILogic$ GainControl
+SVar:DBAttach:DB$ Attach | ValidTgts$ Creature.ControlledBy TriggeredTarget | TgtPrompt$ Select target creature that damaged player controls | AILogic$ GainControl
 AlternateMode:DoubleFaced
 Oracle:Flying\nWhen Soul Seizer deals combat damage to a player, you may transform it. If you do, attach it to target creature that player controls.
 

--- a/forge-gui/res/cardsfolder/s/spark_mage.txt
+++ b/forge-gui/res/cardsfolder/s/spark_mage.txt
@@ -3,5 +3,5 @@ ManaCost:R
 Types:Creature Dwarf Wizard
 PT:1/1
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigDamage | CombatDamage$ True | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, you may have CARDNAME deal 1 damage to target creature that player controls.
-SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Creature.ControlledBy TriggeredDefendingPlayer | TgtPrompt$ Select target creature | NumDmg$ 1 | OptionalDecider$ You
+SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Creature.ControlledBy TriggeredTarget | TgtPrompt$ Select target creature | NumDmg$ 1 | OptionalDecider$ You
 Oracle:Whenever Spark Mage deals combat damage to a player, you may have Spark Mage deal 1 damage to target creature that player controls.

--- a/forge-gui/res/cardsfolder/s/standstill.txt
+++ b/forge-gui/res/cardsfolder/s/standstill.txt
@@ -3,7 +3,6 @@ ManaCost:1 U
 Types:Enchantment
 T:Mode$ SpellCast | ValidActivatingPlayer$ Player | TriggerZones$ Battlefield | Execute$ TrigSac | TriggerDescription$ When a player casts a spell, sacrifice CARDNAME. If you do, each of that player's opponents draws three cards.
 SVar:TrigSac:AB$ Draw | NumCards$ 3 | Cost$ Mandatory Sac<1/CARDNAME> | Defined$ TriggeredCardOpponent
-SVar:X:Remembered$Amount
 SVar:Y:Count$Valid Creature.YouCtrl
 SVar:Z:Count$Valid Creature.OppCtrl
 SVar:NeedsToPlayVar:Y GTZ

--- a/forge-gui/res/cardsfolder/u/uvilda_dean_of_perfection_nassari_dean_of_expression.txt
+++ b/forge-gui/res/cardsfolder/u/uvilda_dean_of_perfection_nassari_dean_of_expression.txt
@@ -9,7 +9,7 @@ SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:TrigRemoveCounter:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Exile | Execute$ DBRemoveCounter | TriggerDescription$ At the beginning of your upkeep, if this card is exiled, remove a hone counter from it.
 SVar:DBRemoveCounter:DB$ RemoveCounter | Defined$ Self | CounterType$ HONE | CounterNum$ 1
 SVar:TrigCast:Mode$ CounterRemoved | TriggerZones$ Exile | ValidCard$ Card.Self | CounterType$ HONE | NewCounterAmount$ 0 | Execute$ DBCast | TriggerDescription$ When the last hone counter is removed from this card, if it's exiled, you may cast it. It costs {4} less to cast this way.
-SVar:DBCast:DB$ Play | Defined$ Self | PlayReduceCost$ 4 | ValidSA$ Spell
+SVar:DBCast:DB$ Play | Defined$ Self | PlayReduceCost$ 4 | ValidSA$ Spell | Optional$ True
 AlternateMode:Modal
 SVar:BuffedBy:Instant,Sorcery
 DeckHints:Type$Instant|Sorcery

--- a/forge-gui/res/cardsfolder/w/wrathful_red_dragon.txt
+++ b/forge-gui/res/cardsfolder/w/wrathful_red_dragon.txt
@@ -3,7 +3,7 @@ ManaCost:3 R R
 Types:Creature Dragon
 PT:5/5
 K:Flying
-T:Mode$ DamageDone | Execute$ TrigDamage | ValidTarget$ Dragon+YouCtrl | TriggerZones$ Battlefield | TriggerDescription$ Whenever a Dragon you control is dealt damage, it deals that much damage to any target that isn't a Dragon.
+T:Mode$ DamageDone | Execute$ TrigDamage | ValidTarget$ Dragon.YouCtrl | TriggerZones$ Battlefield | TriggerDescription$ Whenever a Dragon you control is dealt damage, it deals that much damage to any target that isn't a Dragon.
 SVar:TrigDamage:DB$ DealDamage | NumDmg$ X | ValidTgts$ Creature.nonDragon,Player,Planeswalker.nonDragon | TgtPrompt$ Select any target that isn't a Dragon
 SVar:X:TriggerCount$DamageAmount
 DeckHints:Type$Dragon


### PR DESCRIPTION
This helps AI make correct block decision to survive in cases where the commander otherwise wouldn't be the strongest attacker.

In this example I've already dealt 14 commander damage (from two combats with the same attacks before):
![image](https://user-images.githubusercontent.com/8506892/191216685-1ccb2ff6-5801-46c1-a09e-0295db8e749e.png)

Of course it could be argued that AI should not have even take those 14 just to prevent 1 more dmg by blocking the Eldrazi before that instead, but that's a bit more situational so I'll leave it at that for now. :)