### PR TITLE
Banned and Restricted Announcement for September 19, 2022

### DIFF
--- a/forge-gui/res/formats/Casual/Pauper.txt
+++ b/forge-gui/res/formats/Casual/Pauper.txt
@@ -4,4 +4,4 @@ Order:108
 Subtype:Custom
 Type:Casual
 Rarities:L, C
-Banned:Arcum's Astrolabe; Atog; Bonder's Ornament; Chatterstorm; Cloud of Faeries; Cloudpost; Cranial Plating; Daze; Disciple of the Vault; Empty the Warrens; Fall from Favor; Frantic Search; Galvanic Relay; Gitaxian Probe; Grapeshot; Gush; High Tide; Hymn to Tourach; Invigorate; Mystic Sanctuary; Peregrine Drake; Prophetic Prism; Sinkhole; Sojourner's Companion; Temporal Fissure; Treasure Cruise
+Banned:Aarakocra Sneak; Arcum's Astrolabe; Atog; Bonder's Ornament; Chatterstorm; Cloud of Faeries; Cloudpost; Cranial Plating; Daze; Disciple of the Vault; Empty the Warrens; Fall from Favor; Frantic Search; Galvanic Relay; Gitaxian Probe; Grapeshot; Gush; High Tide; Hymn to Tourach; Invigorate; Mystic Sanctuary; Peregrine Drake; Prophetic Prism; Sinkhole; Sojourner's Companion; Stirring Bard; Temporal Fissure; Treasure Cruise; Underdark Explorer; Vicious Battlerager


### PR DESCRIPTION
Pauper:

- Aarakocra Sneak is banned.
- Stirring Bard is banned.
- Underdark Explorer is banned.
- Vicious Battlerager is banned.

Source: https://magic.wizards.com/en/articles/archive/news/september-19-2022-banned-and-restricted-announcement