### PR TITLE
Fix resolving trigger check using wrong controller

### DIFF
--- a/forge-game/src/main/java/forge/game/CardTraitBase.java
+++ b/forge-game/src/main/java/forge/game/CardTraitBase.java
@@ -253,8 +253,16 @@ public abstract class CardTraitBase extends GameObject implements IHasCardView, 
     }
 
     protected boolean meetsCommonRequirements(Map<String, String> params) {
-        final Player hostController = this.getHostCard().getController();
+        Player hostController = this.getHostCard().getController();
         final Game game = hostController.getGame();
+
+        // intervening if check, make sure to use right controller
+        if (game.getStack().isResolving(getHostCard())) {
+            SpellAbility sa = game.getStack().peekAbility();
+            if (sa.isTrigger()) {
+                hostController = sa.getActivatingPlayer();
+            }
+        }
 
         if (params.containsKey("Metalcraft")) {
             if ("True".equalsIgnoreCase(params.get("Metalcraft")) != hostController.hasMetalcraft()) return false;

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
@@ -1954,9 +1954,14 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
         }
 
         Card host = topSA.getHostCard();
-        // if from an effect it's always Delayed Trigger
+        // if from an effect it's usually Delayed Trigger
         if (host.isImmutable() && !host.isEmblem()) {
-            host = host.getEffectSource();
+            if (host.getEffectSource() != null) {
+                host = host.getEffectSource();
+            } else {
+                // or it could be the monarch, in that case it's only targetable if no source restriction
+                return StringUtils.indexOfAny("Card", tgt.getValidTgts()) != -1;
+            }
         }
 
         return host.isValid(tgt.getValidTgts(), getActivatingPlayer(), getHostCard(), this);

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbilityRestriction.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbilityRestriction.java
@@ -465,7 +465,7 @@ public class SpellAbilityRestriction extends SpellAbilityVariables {
                 life = activator.getOpponentsSmallestLifeTotal();
             }
 
-            int right =AbilityUtils.calculateAmount(sa.getHostCard(), this.getLifeAmount().substring(2), sa);
+            int right = AbilityUtils.calculateAmount(sa.getHostCard(), this.getLifeAmount().substring(2), sa);
 
             if (!Expressions.compare(life, this.getLifeAmount(), right)) {
                 return false;


### PR DESCRIPTION
E. g. when _Felidar Sovereign_ triggers and in response opponent gains control of him you usually wouldn't win the game because it would now check his life instead.