### PR TITLE
Fix AbilityTriggered failing when cause lacks targets

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/AbilityKey.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityKey.java
@@ -131,7 +131,6 @@ public enum AbilityKey {
     TgtSA("TgtSA"),
     Token("Token"),
     TokenNum("TokenNum"),
-    TriggeredParams("TriggeredParams"),
     Vehicle("Vehicle"),
     Won("Won");
 

--- a/forge-game/src/main/java/forge/game/trigger/TriggerAbilityTriggered.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerAbilityTriggered.java
@@ -80,13 +80,11 @@ public class TriggerAbilityTriggered extends Trigger {
             return false;
         }
 
-        if (!matchesValidParam("ValidCause", causes))
-        {
+        if (!matchesValidParam("ValidCause", causes)) {
             return false;
         }
         
-        if (hasParam("TriggeredOwnAbility") && "True".equals(getParam("TriggeredOwnAbility")) && !Iterables.contains(causes, source))
-        {
+        if (hasParam("TriggeredOwnAbility") && "True".equals(getParam("TriggeredOwnAbility")) && !Iterables.contains(causes, source)) {
             return false;
         }
 
@@ -112,7 +110,7 @@ public class TriggerAbilityTriggered extends Trigger {
         return sb.toString();
     }
 
-    public static void addTriggeringObject(Trigger regtrig, SpellAbility sa, Map<AbilityKey, Object> runParams) {
+    public static Map<AbilityKey, Object> getRunParams(Trigger regtrig, SpellAbility sa, Map<AbilityKey, Object> runParams) {
         Map<AbilityKey, Object> newRunParams = AbilityKey.newMap();
         newRunParams.put(AbilityKey.Mode, regtrig.getMode().toString());
         if (regtrig.getMode() == TriggerType.ChangesZone) {
@@ -129,6 +127,9 @@ public class TriggerAbilityTriggered extends Trigger {
             newRunParams.put(AbilityKey.Destination, TextUtil.join(destinations, ","));
             newRunParams.put(AbilityKey.Cause, table.allCards());
         }
-        sa.setTriggeringObject(AbilityKey.TriggeredParams, newRunParams);
+
+        newRunParams.put(AbilityKey.SpellAbility, sa);
+
+        return newRunParams;
     }
 }

--- a/forge-game/src/main/java/forge/game/trigger/TriggerHandler.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerHandler.java
@@ -552,7 +552,6 @@ public class TriggerHandler {
         sa.setTrigger(regtrig);
         sa.setSourceTrigger(regtrig.getId());
         regtrig.setTriggeringObjects(sa, runParams);
-        TriggerAbilityTriggered.addTriggeringObject(regtrig, sa, runParams);
         sa.setTriggerRemembered(regtrig.getTriggerRemembered());
 
         if (regtrig.hasParam("TriggerController")) {
@@ -592,6 +591,8 @@ public class TriggerHandler {
         }
 
         regtrig.triggerRun();
+
+        game.getTriggerHandler().runTrigger(TriggerType.AbilityTriggered, TriggerAbilityTriggered.getRunParams(regtrig, sa, runParams), false);
 
         if (regtrig.hasParam("OneOff")) {
             if (regtrig.getHostCard().isImmutable()) {

--- a/forge-gui/res/cardsfolder/upcoming/historians_boon.txt
+++ b/forge-gui/res/cardsfolder/upcoming/historians_boon.txt
@@ -3,7 +3,7 @@ ManaCost:3 W
 Types:Enchantment
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self,Enchantment.nonToken+Other+YouCtrl | Execute$ TrigSmallToken | TriggerDescription$ Whenever CARDNAME or another nontoken enchantment enters the battlefield under your control, create a 1/1 white Soldier creature token.
 SVar:TrigSmallToken:DB$ Token | TokenAmount$ 1 | TokenScript$ w_1_1_soldier | TokenOwner$ You
-T:Mode$ AbilityTriggered | ValidMode$ CounterAdded | ValidSpellAbility$ Triggered.LastChapter | TriggerZones$ Battlefield | Execute$ TrigBigToken | TriggerDescription$ Whenever the final chapter of a Saga you control triggers, create a 4/4 white Angel creature token with flying and vigilance.
+T:Mode$ AbilityTriggered | ValidMode$ CounterAdded | ValidSource$ Saga.YouCtrl | ValidSpellAbility$ Triggered.LastChapter | TriggerZones$ Battlefield | Execute$ TrigBigToken | TriggerDescription$ Whenever the final chapter of a Saga you control triggers, create a 4/4 white Angel creature token with flying and vigilance.
 SVar:TrigBigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ w_4_4_angel_flying_vigilance | TokenOwner$ You
 DeckHas:Ability$Token
 DeckHints:Type$Enchantment|Saga


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8506892/192162315-b4759640-b123-46ab-aac2-378e1f40f739.png)

Fixing this meant I also had to extend `chooseOrderOfSimultaneousStackEntry` to follow CR more strictly:
> First, each player, in APNAP order, puts each triggered ability they control with a trigger condition that isn’t another ability triggering on the stack in any order they choose. Second, each player, in APNAP order, puts all remaining triggered abilities they control on the stack in any order they choose.