### PR TITLE
Kytheon Fix

### DIFF
--- a/forge-game/src/main/java/forge/game/card/CardDamageHistory.java
+++ b/forge-game/src/main/java/forge/game/card/CardDamageHistory.java
@@ -20,7 +20,8 @@ import forge.util.collect.FCollection;
  */
 public class CardDamageHistory {
 
-    private boolean creatureAttackedThisCombat = false;
+    // amount only needed for Kytheon
+    private int creatureAttackedThisCombat = 0;
     private boolean creatureBlockedThisCombat = false;
     private boolean creatureGotBlockedThisCombat = false;
 
@@ -53,8 +54,8 @@ public class CardDamageHistory {
      * @param hasAttacked
      *            a boolean.
      */
-    public final void setCreatureAttackedThisCombat(GameEntity defender) {
-        this.creatureAttackedThisCombat = defender != null;
+    public final void setCreatureAttackedThisCombat(GameEntity defender, int numOtherAttackers) {
+        this.creatureAttackedThisCombat = 1 + numOtherAttackers;
 
         if (defender != null) {
             attackedThisTurn.add(defender);
@@ -67,7 +68,7 @@ public class CardDamageHistory {
      * 
      * @return a boolean.
      */
-    public final boolean getCreatureAttackedThisCombat() {
+    public final int getCreatureAttackedThisCombat() {
         return this.creatureAttackedThisCombat;
     }
     /**

--- a/forge-game/src/main/java/forge/game/card/CardProperty.java
+++ b/forge-game/src/main/java/forge/game/card/CardProperty.java
@@ -1439,7 +1439,7 @@ public class CardProperty {
                 rhs = property.substring(11);
                 y = card.getNetToughness();
             } else if (property.startsWith("baseToughness")) {
-                rhs= property.substring(15);
+                rhs = property.substring(15);
                 y = card.getCurrentToughness();
             } else if (property.startsWith("cmc")) {
                 rhs = property.substring(5);
@@ -1544,9 +1544,15 @@ public class CardProperty {
             }
         } else if (property.startsWith("notattacking")) {
             return null == combat || !combat.isAttacking(card);
-        } else if (property.equals("attackedThisCombat")) {
-            if (null == combat || !card.getDamageHistory().getCreatureAttackedThisCombat()) {
+        } else if (property.startsWith("attackedThisCombat")) {
+            if (null == combat || card.getDamageHistory().getCreatureAttackedThisCombat() == 0) {
                 return false;
+            }
+            if (property.length() > 18) {
+                int x = AbilityUtils.calculateAmount(source, property.substring(21), spellAbility);
+                if (!Expressions.compare(card.getDamageHistory().getCreatureAttackedThisCombat(), property, x)) {
+                    return false;
+                }
             }
         } else if (property.equals("blockedThisCombat")) {
             if (null == combat || !card.getDamageHistory().getCreatureBlockedThisCombat()) {

--- a/forge-game/src/main/java/forge/game/combat/CombatUtil.java
+++ b/forge-game/src/main/java/forge/game/combat/CombatUtil.java
@@ -383,13 +383,13 @@ public class CombatUtil {
      *            a {@link forge.game.card.Card} object.
      */
     public static void checkDeclaredAttacker(final Game game, final Card c, final Combat combat, boolean triggers) {
-        GameEntity defender = combat.getDefenderByAttacker(c);
+        final GameEntity defender = combat.getDefenderByAttacker(c);
+        final List<Card> otherAttackers = combat.getAttackers();
 
         // Run triggers
         if (triggers) {
             final Map<AbilityKey, Object> runParams = AbilityKey.newMap();
             runParams.put(AbilityKey.Attacker, c);
-            final List<Card> otherAttackers = combat.getAttackers();
             otherAttackers.remove(c);
             runParams.put(AbilityKey.OtherAttackers, otherAttackers);
             runParams.put(AbilityKey.Attacked, defender);
@@ -405,7 +405,7 @@ public class CombatUtil {
             game.getTriggerHandler().runTrigger(TriggerType.Attacks, runParams, false);
         }
 
-        c.getDamageHistory().setCreatureAttackedThisCombat(defender);
+        c.getDamageHistory().setCreatureAttackedThisCombat(defender, otherAttackers.size());
         c.getDamageHistory().clearNotAttackedSinceLastUpkeepOf();
         c.getController().addCreaturesAttackedThisTurn(CardUtil.getLKICopy(c), defender);
     }

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -2639,13 +2639,12 @@ public class Player extends GameEntity implements Comparable<Player> {
         CardCollectionView list = getCardsIn(ZoneType.Battlefield);
 
         for (Card c : list) {
-            if (c.getDamageHistory().getCreatureAttackedThisCombat()) {
-                c.getDamageHistory().setCreatureAttackedThisCombat(null);
+            if (c.getDamageHistory().getCreatureAttackedThisCombat() > 0) {
+                c.getDamageHistory().setCreatureAttackedThisCombat(null, 0);
             }
             if (c.getDamageHistory().getCreatureBlockedThisCombat()) {
                 c.getDamageHistory().setCreatureBlockedThisCombat(false);
             }
-
             if (c.getDamageHistory().getCreatureGotBlockedThisCombat()) {
                 c.getDamageHistory().setCreatureGotBlockedThisCombat(false);
             }

--- a/forge-gui/res/cardsfolder/b/blazing_effigy.txt
+++ b/forge-gui/res/cardsfolder/b/blazing_effigy.txt
@@ -3,13 +3,6 @@ ManaCost:1 R
 Types:Creature Elemental
 PT:0/3
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ BlazeDmg | TriggerDescription$ When CARDNAME dies, it deals X damage to target creature, where X is 3 plus the amount of damage dealt to CARDNAME this turn by other sources named Blazing Effigy.
-SVar:BlazeDmg:DB$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature to deal damage to | NumDmg$ BlazeSize | SubAbility$ TrigReset
-T:Mode$ DamageDone | ValidSource$ Card.Other+namedBlazing Effigy | ValidTarget$ Card.Self | Execute$ StoreContribution | Static$ True
-SVar:StoreContribution:DB$ StoreSVar | SVar$ Contributions | Type$ CountSVar | Expression$ Contributions/Plus.Blazed
-T:Mode$ Phase | Phase$ Cleanup | Execute$ TrigReset | Static$ True
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Ante,Library,Hand,Exile | ValidCard$ Card.Self | Execute$ TrigReset | Static$ True
-SVar:TrigReset:DB$ StoreSVar | SVar$ Contributions | Type$ Number | Expression$ 0
-SVar:BlazeSize:SVar$Contributions/Plus.3
-SVar:Contributions:Number$0
-SVar:Blazed:TriggerCount$DamageAmount
+SVar:BlazeDmg:DB$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature to deal damage to | NumDmg$ BlazeSize
+SVar:BlazeSize:Count$TotalDamageThisTurn Card.Other+namedBlazing_Effigy/Plus.3
 Oracle:When Blazing Effigy dies, it deals X damage to target creature, where X is 3 plus the amount of damage dealt to Blazing Effigy this turn by other sources named Blazing Effigy.

--- a/forge-gui/res/cardsfolder/c/conquerors_galleon_conquerors_foothold.txt
+++ b/forge-gui/res/cardsfolder/c/conquerors_galleon_conquerors_foothold.txt
@@ -3,14 +3,10 @@ ManaCost:4
 Types:Artifact Vehicle
 PT:2/10
 K:Crew:4
-SVar:TrigExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | RememberChanged$ True | SubAbility$ DBReturn
-SVar:DBReturn:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Battlefield | Transformed$ True | SubAbility$ DBCleanup
-T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ GalleonReset | TriggerDescription$ When CARDNAME attacks, exile it at end of combat, then return it to the battlefield transformed under your control.
-T:Mode$ Phase | Phase$ EndCombat | ValidPlayer$ Player | CheckSVar$ CanFlip | SVarCompare$ GE1 | TriggerZones$ Battlefield | Execute$ TrigExile | Secondary$ True | TriggerDescription$ When CARDNAME attacks, exile it at end of combat, then return it to the battlefield transformed under your control.
-SVar:GalleonReset:DB$ StoreSVar | SVar$ CanFlip | Type$ Number | Expression$ 0 | SubAbility$ GalleonAttacked
-SVar:GalleonAttacked:DB$ StoreSVar | SVar$ CanFlip | Type$ Number | Expression$ 1 | ConditionPresent$ Card.attackedThisCombat+Self
-SVar:CanFlip:Number$0
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ DelayedTransform | TriggerDescription$ When CARDNAME attacks, exile it at end of combat, then return it to the battlefield transformed under your control.
+SVar:DelayedTransform:DB$ DelayedTrigger | Mode$ Phase | Phase$ EndCombat | RememberObjects$ TriggeredAttacker | Execute$ TrigExile | TriggerDescription$ When CARDNAME attacks, exile it at end of combat, then return it to the battlefield transformed under your control.
+SVar:TrigExile:DB$ ChangeZone | Defined$ DelayTriggerRememberedLKI | Origin$ Battlefield | Destination$ Exile | RememberChanged$ True | SubAbility$ DBReturn
+SVar:DBReturn:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Battlefield | Transformed$ True
 AlternateMode:DoubleFaced
 Oracle:When Conqueror's Galleon attacks, exile it at end of combat, then return it to the battlefield transformed under your control.\nCrew 4 (Tap any number of creatures you control with total power 4 or more: This Vehicle becomes an artifact creature until end of turn.)
 

--- a/forge-gui/res/cardsfolder/k/kytheon_hero_of_akros_gideon_battle_forged.txt
+++ b/forge-gui/res/cardsfolder/k/kytheon_hero_of_akros_gideon_battle_forged.txt
@@ -2,13 +2,10 @@ Name:Kytheon, Hero of Akros
 ManaCost:W
 Types:Legendary Creature Human Soldier
 PT:2/1
-T:Mode$ Phase | Mode$ Phase | Phase$ EndCombat | CheckSVar$ X | SVarCompare$ GE3 | Execute$ TrigExile | TriggerDescription$ At end of combat, if CARDNAME and at least two other creatures attacked this combat, exile CARDNAME, then return him to the battlefield transformed under his owner's control.
+T:Mode$ Phase | Mode$ Phase | Phase$ EndCombat | IsPresent$ Card.Self+attackedThisCombat GE3 | Execute$ TrigExile | TriggerDescription$ At end of combat, if CARDNAME and at least two other creatures attacked this combat, exile CARDNAME, then return him to the battlefield transformed under his owner's control.
 SVar:TrigExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | RememberChanged$ True | SubAbility$ DBReturn
 SVar:DBReturn:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Battlefield | Transformed$ True | ForgetOtherRemembered$ True | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-SVar:X:SVar$Y/Plus.Z
-SVar:Y:Count$Valid Card.Self+attackedThisCombat
-SVar:Z:Count$Valid Creature.Other+attackedThisCombat/LimitMax.2
 A:AB$ Pump | Cost$ 2 W | Defined$ Self | KW$ Indestructible | SpellDescription$ CARDNAME gains indestructible until end of turn.
 AlternateMode:DoubleFaced
 Oracle:At end of combat, if Kytheon, Hero of Akros and at least two other creatures attacked this combat, exile Kytheon, then return him to the battlefield transformed under his owner's control.\n{2}{W}: Kytheon gains indestructible until end of turn.


### PR DESCRIPTION
> Kytheon’s first ability will count creatures that attacked but are no longer on the battlefield (perhaps because they didn’t survive combat damage being dealt). It will not count any creatures that were put onto the battlefield attacking, as those creatures were never declared as attackers. 