### PR TITLE
Fix crash from meld missing backside for new Urza

### DIFF
--- a/forge-ai/src/main/java/forge/ai/GameState.java
+++ b/forge-ai/src/main/java/forge/ai/GameState.java
@@ -1344,6 +1344,7 @@ public abstract class GameState {
                     c.setState(CardStateName.Flipped, true);
                 } else if (info.startsWith("Meld")) {
                     c.setState(CardStateName.Meld, true);
+                    c.setBackSide(true);
                 } else if (info.startsWith("Modal")) {
                     c.setState(CardStateName.Modal, true);
                     c.setBackSide(true);

--- a/forge-game/src/main/java/forge/game/ability/effects/MeldEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/MeldEffect.java
@@ -1,7 +1,5 @@
 package forge.game.ability.effects;
 
-import com.google.common.collect.Lists;
-
 import forge.card.CardStateName;
 import forge.game.Game;
 import forge.game.ability.SpellAbilityEffect;
@@ -26,12 +24,12 @@ public class MeldEffect extends SpellAbilityEffect {
         Game game = hostCard.getGame();
         Player controller = sa.getActivatingPlayer();
 
-        // a creature you control and own named secondary
+        // a permanent you control and own named secondary
         CardCollection field = CardLists.filter(
-                controller.getCreaturesInPlay(),
+                controller.getCardsIn(ZoneType.Battlefield),
                 CardPredicates.isOwner(controller),
                 CardPredicates.nameEquals(secName));
-
+        field = CardLists.getType(field, sa.getParamOrDefault("SecondaryType", "Creature"));
         if (field.isEmpty()) {
             return;
         }
@@ -48,7 +46,7 @@ public class MeldEffect extends SpellAbilityEffect {
             return;
         }
 
-        for (Card c : Lists.newArrayList(primary, secondary)) {
+        for (Card c : exiled) {
             if (c.isToken() || c.getCloneOrigin() != null) {
                 // Neither of these things
                 return;
@@ -58,6 +56,7 @@ public class MeldEffect extends SpellAbilityEffect {
         }
 
         primary.changeToState(CardStateName.Meld);
+        primary.setBackSide(true);
         primary.setMeldedWith(secondary);
         PlayerZoneBattlefield bf = (PlayerZoneBattlefield)controller.getZone(ZoneType.Battlefield);
         game.getAction().changeZone(primary.getZone(), bf, primary, 0, sa);

--- a/forge-game/src/main/java/forge/game/card/CardUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardUtil.java
@@ -232,7 +232,6 @@ public final class CardUtil {
         }
         //*/
 
-        newCopy.setType(new CardType(in.getType()));
         newCopy.setToken(in.isToken());
         newCopy.setCopiedSpell(in.isCopiedSpell());
         newCopy.setImmutable(in.isImmutable());


### PR DESCRIPTION
The problem was this would create LKI with Original State but Planeswalker type

@Hanmac
I also don't think we need the extra `setType` anymore because the `getCurrentState().copyFrom` above will already store it in a new object