### PR TITLE
Add basic AI logic for reducing costs for chosen card type

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtil.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtil.java
@@ -2309,7 +2309,9 @@ public class ComputerUtil {
         return getCardsToDiscardFromOpponent(aiChooser, p, sa, validCards, min, max);
     }
 
-    public static String chooseSomeType(Player ai, String kindOfType, String logic, Collection<String> validTypes, List<String> invalidTypes) {
+    public static String chooseSomeType(Player ai, String kindOfType, SpellAbility sa, Collection<String> validTypes, List<String> invalidTypes) {
+        final String logic = sa.getParam("AILogic");
+
         if (invalidTypes == null) {
             invalidTypes = ImmutableList.of();
         }
@@ -2334,6 +2336,23 @@ public class ComputerUtil {
                             chosen = type;
                         }
                     }
+                }
+            }
+            else {
+                // Are we picking a type to reduce costs for that type?
+                boolean reducingCost = false;
+                for (StaticAbility s : sa.getHostCard().getStaticAbilities()) {
+                    if ("ReduceCost".equals(s.getParam("Mode")) && "Card.ChosenType".equals(s.getParam("ValidCard"))) {
+                        reducingCost = true;
+                        break;
+                    }
+                }
+
+                if (reducingCost) {
+                    List<String> valid = Lists.newArrayList(validTypes);
+                    valid.removeAll(invalidTypes);
+                    valid.remove("Land"); // Lands don't have costs to reduce
+                    chosen = ComputerUtilCard.getMostProminentCardType(ai.getAllCards(), valid);
                 }
             }
             if (StringUtils.isEmpty(chosen)) {

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
@@ -864,6 +864,41 @@ public class ComputerUtilCard {
         return maxType;
     }
 
+    public static String getMostProminentCardType(final CardCollectionView list, final Collection<String> valid) {
+        if (list.size() == 0 || valid.isEmpty()) {
+            return "";
+        }
+
+        final Map<String, Integer> typesInDeck = Maps.newHashMap();
+        for (String type : valid) {
+            typesInDeck.put(type, 0);
+        }
+
+        for (final Card c : list) {
+            Iterable<CardType.CoreType> cardTypes = c.getType().getCoreTypes();
+            for (CardType.CoreType type : cardTypes) {
+                Integer count = typesInDeck.get(type.toString());
+                if (count != null) {
+                    typesInDeck.put(type.toString(), count + 1);
+                }
+            }
+        }
+
+        int max = 0;
+        String maxType = "";
+
+        for (final Entry<String, Integer> entry : typesInDeck.entrySet()) {
+            final String type = entry.getKey();
+
+            if (max < entry.getValue()) {
+                max = entry.getValue();
+                maxType = type;
+            }
+        }
+
+        return maxType;
+    }
+
     /**
      * <p>
      * getMostProminentColor.

--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -577,10 +577,10 @@ public class PlayerControllerAi extends PlayerController {
 
     @Override
     public String chooseSomeType(String kindOfType, SpellAbility sa, Collection<String> validTypes, List<String> invalidTypes, boolean isOptional) {
-        String chosen = ComputerUtil.chooseSomeType(player, kindOfType, sa.getParam("AILogic"), validTypes, invalidTypes);
+        String chosen = ComputerUtil.chooseSomeType(player, kindOfType, sa, validTypes, invalidTypes);
         if (StringUtils.isBlank(chosen) && !validTypes.isEmpty()) {
             chosen = validTypes.iterator().next();
-            System.err.println("AI has no idea how to choose " + kindOfType +", defaulting to arbitrary element: chosen");
+            System.err.println("AI has no idea how to choose " + kindOfType +", defaulting to arbitrary element: " + chosen);
         }
         return chosen;
     }

--- a/forge-gui/res/cardsfolder/c/cloud_key.txt
+++ b/forge-gui/res/cardsfolder/c/cloud_key.txt
@@ -4,5 +4,4 @@ Types:Artifact
 S:Mode$ ReduceCost | ValidCard$ Card.ChosenType | Type$ Spell | Activator$ You | Amount$ 1 | Description$ Spells you cast of the chosen type cost {1} less to cast.
 K:ETBReplacement:Other:ChooseCT
 SVar:ChooseCT:DB$ ChooseType | Defined$ You | Type$ Card | ValidTypes$ Artifact,Creature,Enchantment,Instant,Sorcery | SpellDescription$ As CARDNAME enters the battlefield, choose artifact, creature, enchantment, instant, or sorcery.
-AI:RemoveDeck:All
 Oracle:As Cloud Key enters the battlefield, choose artifact, creature, enchantment, instant, or sorcery.\nSpells you cast of the chosen type cost {1} less to cast.

--- a/forge-gui/res/cardsfolder/s/stenn_paranoid_partisan.txt
+++ b/forge-gui/res/cardsfolder/s/stenn_paranoid_partisan.txt
@@ -9,5 +9,4 @@ A:AB$ ChangeZone | Cost$ 1 W U | Origin$ Battlefield | Destination$ Exile | SubA
 SVar:DelTrig:DB$ DelayedTrigger | Mode$ Phase | RememberObjects$ Remembered | Phase$ End of Turn | Execute$ TrigReturn | TriggerDescription$ Return it to the battlefield under its owner's control at the beginning of the next end step. | SubAbility$ DBCleanup
 SVar:TrigReturn:DB$ ChangeZone | Defined$ DelayTriggerRememberedLKI | Origin$ Exile | Destination$ Battlefield 
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-AI:RemoveDeck:All
 Oracle:As Stenn, Paranoid Partisan enters the battlefield, choose a card type other than creature or land.\nSpells you cast of the chosen type cost {1} less to cast.\n{1}{W}{U}: Exile Stenn. Return it to the battlefield under its owner's control at the beginning of the next end step.

--- a/forge-gui/res/cardsfolder/u/umori_the_collector.txt
+++ b/forge-gui/res/cardsfolder/u/umori_the_collector.txt
@@ -4,6 +4,6 @@ Types:Legendary Creature Ooze
 PT:4/5
 K:Companion:Special:SharesCardType:Each nonland card in your starting deck shares a card type.
 K:ETBReplacement:Other:ChooseCT
-SVar:ChooseCT:DB$ ChooseType | Defined$ You | Type$ Card | AILogic$ MostProminentInComputerDeck | SpellDescription$ As CARDNAME enters the battlefield, choose a card type.
+SVar:ChooseCT:DB$ ChooseType | Defined$ You | Type$ Card | SpellDescription$ As CARDNAME enters the battlefield, choose a card type.
 S:Mode$ ReduceCost | ValidCard$ Card.ChosenType | Type$ Spell | Activator$ You | Amount$ 1 | Description$ Spells you cast of the chosen type cost {1} less to cast.
 Oracle:Companion — Each nonland card in your starting deck shares a card type. (If this card is your chosen companion, you may put it into your hand from outside the game for {3} any time you could cast a sorcery.)\nAs Umori, the Collector enters the battlefield, choose a card type.\nSpells you cast of the chosen type cost {1} less to cast.


### PR DESCRIPTION
This adds basic AI support for cards that reduce costs for spells of a chosen card type. Specifically, it adds logic so that when the AI is asked to choose a card type, it recognizes if that choice is for reducing costs and in that case it picks the most common card type in its deck. It also excludes Lands in that case to avoid picking 'Land' for [Umori, the Collector](https://scryfall.com/card/iko/231/umori-the-collector).

I removed `AILogic$ MostProminentInComputerDeck` from [Umori, the Collector](https://scryfall.com/card/iko/231/umori-the-collector) since that logic wasn't working in the first place, and isn't needed in this implementation. I also marked [Cloud Key](https://scryfall.com/card/tsr/265/cloud-key) and [Stenn, Paranoid Partisan](https://scryfall.com/card/dmu/221/stenn-paranoid-partisan) as playable by AI. I think this logic, while not always "right" in all cases, is good enough to let the AI play them. (At least it won't make a silly choice like "Plane" anymore.)

A detail of this implementation: I'm passing the SpellAbility `sa` to `ComputerUtil.chooseSomeType()` instead of just the AILogic String. This is cleaner for what I wanted to do, and I see other abilities in `ComputerUtil` accepting the SpellAbility as a parameter so I don't think it breaks any established patterns in the code.

I tested this with the AI playing [Umori, the Collector](https://scryfall.com/card/iko/231/umori-the-collector), [Cloud Key](https://scryfall.com/card/tsr/265/cloud-key), and [Stenn, Paranoid Partisan](https://scryfall.com/card/dmu/221/stenn-paranoid-partisan). I tested a few different deck compositions, including a typical creature-focused deck and a "superfriends" deck (where actually Lands are most common). The logic appears to be behaving as expected.

For future work, I thought maybe another heuristic would be to add up all of the generic mana costs of all cards of a certain type, and pick based on the maximum. That might catch cases where you intend to use Cloud Key for very expensive Sorceries (or something) in your deck, even if the Sorcery card type is outnumbered by other types in the deck. For now, I think the current implementation will be good enough.