### PR TITLE
Alchemy Rebalancing for October 6, 2022

### DIFF
--- a/forge-gui/res/cardsfolder/c/cabaretti_charm.txt
+++ b/forge-gui/res/cardsfolder/c/cabaretti_charm.txt
@@ -2,7 +2,7 @@ Name:Cabaretti Charm
 ManaCost:R G W
 Types:Instant
 A:SP$ Charm | Choices$ DBDealDamage,DBPumpAll,DBToken
-SVar:DBDealDamage:DB$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ X | SpellDescription$ CARDNAME deals damage to target creature or planeswalker equal to the number of creatures you control.
+SVar:DBDealDamage:DB$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ X | SpellDescription$ CARDNAME deals damage equal to the number of creatures you control to target creature or planeswalker.
 SVar:X:Count$Valid Creature.YouCtrl
 SVar:DBPumpAll:DB$ PumpAll | ValidCards$ Creature.YouCtrl | NumAtt$ +1 | NumDef$ +1 | KW$ Trample | SpellDescription$ Creatures you control get +1/+1 and gain trample until end of turn.
 SVar:DBToken:DB$ Token | TokenAmount$ 2 | TokenScript$ gw_1_1_citizen | SpellDescription$ Create two 1/1 green and white Citizen creature tokens.

--- a/forge-gui/res/cardsfolder/rebalanced/a-buy_your_silence.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-buy_your_silence.txt
@@ -1,0 +1,7 @@
+Name:A-Buy Your Silence
+ManaCost:4 W
+Types:Instant
+A:SP$ ChangeZone | Cost$ 4 W | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Permanent.nonLand | TgtPromt$ Select target nonland permanant | SubAbility$ DBTreasure | StackDescription$ SpellDescription | SpellDescription$ Exile target nonland permanent. Its controller creates a Treasure token.
+SVar:DBTreasure:DB$ Token | TokenAmount$ 1 | TokenScript$ c_a_treasure_sac | TokenOwner$ TargetedController
+DeckHas:Ability$Sacrifice|Token & Type$Treasure|Artifact
+Oracle:Exile target nonland permanent. Its controller creates a Treasure token.

--- a/forge-gui/res/cardsfolder/rebalanced/a-cabaretti_charm.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-cabaretti_charm.txt
@@ -1,0 +1,10 @@
+Name:A-Cabaretti Charm
+ManaCost:R G W
+Types:Instant
+A:SP$ Charm | Choices$ DBDealDamage,DBPumpAll,DBToken
+SVar:DBDealDamage:DB$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ X | SpellDescription$ CARDNAME deals damage equal to twice the number of creatures you control to target creature or planeswalker.
+SVar:X:Count$Valid Creature.YouCtrl/Times.2
+SVar:DBPumpAll:DB$ PumpAll | ValidCards$ Creature.YouCtrl | NumAtt$ +1 | NumDef$ +1 | KW$ Trample | SpellDescription$ Creatures you control get +1/+1 and gain trample until end of turn.
+SVar:DBToken:DB$ Token | TokenAmount$ 2 | TokenScript$ gw_1_1_citizen | SpellDescription$ Create two 1/1 green and white Citizen creature tokens.
+DeckHas:Ability$Token & Type$Citizen
+Oracle:Choose one —\n• Cabaretti Charm deals damage equal to twice the number of creatures you control to target creature or planeswalker.\n• Creatures you control get +1/+1 and gain trample until end of turn.\n• Create two 1/1 green and white Citizen creature tokens.

--- a/forge-gui/res/cardsfolder/rebalanced/a-capenna_express.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-capenna_express.txt
@@ -1,0 +1,9 @@
+Name:A-Capenna Express
+ManaCost:3 G
+Types:Artifact Vehicle
+PT:7/7
+A:AB$ Animate | Cost$ Sac<1/Treasure> | Defined$ Self | Types$ Artifact,Creature | SpellDescription$ CARDNAME becomes an artifact creature until end of turn.
+K:Crew:3
+DeckHas:Ability$Sacrifice
+DeckHints:Type$Treasure
+Oracle:Sacrifice a Treasure: Capenna Express becomes an artifact creature until end of turn.\nCrew 3

--- a/forge-gui/res/cardsfolder/rebalanced/a-case_the_joint.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-case_the_joint.txt
@@ -1,0 +1,6 @@
+Name:A-Case the Joint
+ManaCost:4 U
+Types:Sorcery
+A:SP$ Draw | NumCards$ 3 | SubAbility$ DBLook | SpellDescription$ Draw three cards, then look at the top card of each player's library.
+SVar:DBLook:DB$ PeekAndReveal | Defined$ Player | NoReveal$ True
+Oracle:Draw three cards, then look at the top card of each player's library.

--- a/forge-gui/res/cardsfolder/rebalanced/a-celebrity_fencer.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-celebrity_fencer.txt
@@ -1,0 +1,9 @@
+Name:A-Celebrity Fencer
+ManaCost:3 W
+Types:Creature Elf Druid
+PT:3/3
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.Other+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Alliance — Whenever another creature enters the battlefield under your control, put a +1/+1 counter on CARDNAME.
+SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
+SVar:BuffedBy:Creature
+DeckHas:Ability$Counters
+Oracle:Alliance — Whenever another creature enters the battlefield under your control, put a +1/+1 counter on Celebrity Fencer.

--- a/forge-gui/res/cardsfolder/rebalanced/a-celestial_regulator.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-celestial_regulator.txt
@@ -1,0 +1,11 @@
+Name:A-Celestial Regulator
+ManaCost:1 W U
+Types:Creature Angel Advisor
+PT:1/4
+K:Flying
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigTap | TriggerDescription$ When CARDNAME enters the battlefield, choose target creature you don't control and tap it. If you control a creature with a counter on it, the chosen creature doesn't untap during its controller's next untap step.
+SVar:TrigTap:DB$ Tap | ValidTgts$ Creature.YouDontCtrl | TgtPrompt$ Choose target creature you don't control | SubAbility$ DBPump
+SVar:DBPump:DB$ Pump | ConditionPresent$ Creature.YouCtrl+HasCounters | Defined$ Targeted | KW$ HIDDEN This card doesn't untap during your next untap step. | Duration$ Permanent
+SVar:PlayMain1:TRUE
+DeckHints:Ability$Counters
+Oracle:Flying\nWhen Celestial Regulator enters the battlefield, choose target creature you don't control and tap it. If you control a creature with a counter on it, the chosen creature doesn't untap during its controller's next untap step.

--- a/forge-gui/res/cardsfolder/rebalanced/a-civil_servant.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-civil_servant.txt
@@ -1,0 +1,9 @@
+Name:A-Civil Servant
+ManaCost:G W
+Types:Creature Cat Citizen
+PT:2/3
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, you may tap another untapped Citizen you control. If you do, Civil Servant gets +1/+0 and gains trample until end of turn.
+SVar:TrigPump:AB$ Pump | Cost$ tapXType<1/Creature.Citizen/Citizen> | Defined$ Self | NumAtt$ 1 | KW$ Trample
+SVar:HasAttackEffect:TRUE
+DeckNeeds:Type$Citizen
+Oracle:Whenever Civil Servant attacks, you may tap another untapped Citizen you control. If you do, Civil Servant gets +1/+0 and gains trample until end of turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-deal_gone_bad.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-deal_gone_bad.txt
@@ -1,0 +1,8 @@
+Name:A-Deal Gone Bad
+ManaCost:3 B
+Types:Instant
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ -3 | NumDef$ -3 | SubAbility$ DBMill | IsCurse$ True | SpellDescription$ Target creature gets -3/-3 until end of turn.
+SVar:DBMill:DB$ Mill | NumCards$ 3 | ValidTgts$ Player | TgtPrompt$ Choose a player | SubAbility$ DBGainLife | SpellDescription$ Target player mills three cards.
+SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 3 | SpellDescription$ You gain 3 life.
+DeckHas:Ability$Mill|LifeGain
+Oracle:Target creature gets -3/-3 until end of turn. Target player mills three cards. You gain 3 life.

--- a/forge-gui/res/cardsfolder/rebalanced/a-demons_due.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-demons_due.txt
@@ -1,0 +1,7 @@
+Name:A-Demon's Due
+ManaCost:3 B
+Types:Instant
+A:SP$ Dig | Cost$ 3 B | DigNum$ 4 | ChangeNum$ 2 | DestinationZone2$ Graveyard | SubAbility$ DBLoseLife | SpellDescription$ Look at the top four cards of your library. Put two of them into your hand and the rest into your graveyard. You lose 2 life.
+SVar:DBLoseLife:DB$ LoseLife | Defined$ You | LifeAmount$ 2
+DeckHas:Ability$Graveyard
+Oracle:Look at the top four cards of your library. Put two of them into your hand and the rest into your graveyard. You lose 2 life.

--- a/forge-gui/res/cardsfolder/rebalanced/a-emerald_dragon_dissonant_wave.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-emerald_dragon_dissonant_wave.txt
@@ -5,7 +5,7 @@ PT:4/4
 K:Flying
 K:Ward:2
 AlternateMode:Adventure
-Oracle:Flying, Ward {2}
+Oracle:Flying, ward {2}
 
 ALTERNATE
 

--- a/forge-gui/res/cardsfolder/rebalanced/a-exhibition_magician.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-exhibition_magician.txt
@@ -1,0 +1,10 @@
+Name:A-Exhibition Magician
+ManaCost:2 R
+Types:Creature Human Wizard
+PT:2/2
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigCharm | TriggerDescription$ When CARDNAME enters the battlefield, ABILITY
+SVar:TrigCharm:DB$ Charm | Choices$ DBToken,DBToken2
+SVar:DBToken:DB$ Token | TokenScript$ gw_1_1_citizen | SpellDescription$ Create a 1/1 green and white Citizen creature token.
+SVar:DBToken2:DB$ Token | TokenScript$ c_a_treasure_sac | SpellDescription$ Create a Treasure token.
+DeckHas:Ability$Sacrifice|Token & Type$Treasure|Artifact|Citizen
+Oracle:When Exhibition Magician enters the battlefield, choose one —\n• Create a 1/1 green and white Citizen creature token.\n• Create a Treasure token.

--- a/forge-gui/res/cardsfolder/rebalanced/a-forge_boss.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-forge_boss.txt
@@ -1,0 +1,8 @@
+Name:A-Forge Boss
+ManaCost:2 B R
+Types:Creature Human Warrior
+PT:4/4
+T:Mode$ Sacrificed | ValidCard$ Creature.Other+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigDamage | ActivationLimit$ 1 | TriggerDescription$ Whenever you sacrifice one or more other creatures, CARDNAME deals 2 damage to each opponent. This ability triggers only once each turn.
+SVar:TrigDamage:DB$ DealDamage | Defined$ Opponent | NumDmg$ 2
+DeckNeeds:Ability$Sacrifice
+Oracle:Whenever you sacrifice one or more other creatures, Forge Boss deals 2 damage to each opponent. This ability triggers only once each turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-glamorous_outlaw.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-glamorous_outlaw.txt
@@ -1,0 +1,16 @@
+Name:A-Glamorous Outlaw
+ManaCost:3 U B R
+Types:Creature Vampire Rogue
+PT:4/5
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When CARDNAME enters the battlefield, it deals 2 damage to each opponent and you gain 2 life. Scry 2.
+SVar:TrigDealDamage:DB$ DealDamage | NumDmg$ 2 | Defined$ Opponent | SubAbility$ DBGainLife
+SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 2 | SubAbility$ DBScry
+SVar:DBScry:DB$ Scry | ScryNum$ 2
+A:AB$ Effect | Cost$ 1 ExileFromHand<1/CARDNAME> | ActivationZone$ Hand | ValidTgts$ Land | TgtPrompt$ Select target land | RememberObjects$ Targeted,Self | StaticAbilities$ Land,MayPlay | Triggers$ Cast | ImprintCards$ Self | Duration$ Permanent | ForgetOnMoved$ Exile | SpellDescription$ Target land gains "{T}: Add {U}, {B}, or {R}" until CARDNAME is cast from exile. You may cast CARDNAME for as long as it remains exiled.
+SVar:Land:Mode$ Continuous | EffectZone$ Command | AffectedZone$ Battlefield | Affected$ Card.IsRemembered+IsNotImprinted | AddAbility$ Mana | Description$ Target land gains "{T}: Add {U}, {B}, or {R}" until EFFECTSOURCE is cast from exile. You may cast EFFECTSOURCE for as long as it remains exiled.
+SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo U B R | Amount$ 1 | SpellDescription$ Add {U}, {B}, or {R}
+SVar:MayPlay:Mode$ Continuous | MayPlay$ True | EffectZone$ Command | Affected$ Card.IsImprinted+IsRemembered | AffectedZone$ Exile | Secondary$ True | Description$ You may cast EFFECTSOURCE for as long as it remains exiled.
+SVar:Cast:Mode$ SpellCast | ValidCard$ Card.IsImprinted+IsRemembered+wasCastFromExile | Execute$ ExileSelf | Static$ True
+SVar:ExileSelf:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self
+DeckHas:Ability$LifeGain
+Oracle:When Glamorous Outlaw enters the battlefield, it deals 2 damage to each opponent and you gain 2 life. Scry 2.\n{1}, Exile Glamorous Outlaw from your hand: Target land gains "{T}: Add {U}, {B}, or {R}" until Glamorous Outlaw is cast from exile. You may cast Glamorous Outlaw for as long as it remains exiled.

--- a/forge-gui/res/cardsfolder/rebalanced/a-glittermonger.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-glittermonger.txt
@@ -1,0 +1,7 @@
+Name:A-Glittermonger
+ManaCost:3 G
+Types:Creature Elf Rogue
+PT:2/4
+A:AB$ Token | Cost$ T | TokenScript$ c_a_treasure_sac | SpellDescription$ Create a Treasure token.
+DeckHas:Ability$Sacrifice|Token & Type$Treasure|Artifact
+Oracle:{T}: Create a Treasure token.

--- a/forge-gui/res/cardsfolder/rebalanced/a-graveyard_shift.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-graveyard_shift.txt
@@ -1,0 +1,9 @@
+Name:A-Graveyard Shift
+ManaCost:4 B
+Types:Sorcery
+S:Mode$ Continuous | CharacteristicDefining$ True | Affected$ Card.Self | AddKeyword$ Flash | CheckSVar$ X | SVarCompare$ GE5 | Description$ This spell has flash as long as there are five or more mana values among cards in your graveyard.
+SVar:X:Count$ValidGraveyard Card.YouOwn$DifferentCMC
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | ValidTgts$ Creature.YouOwn | TgtPrompt$ Select target creature card in your graveyard | WithCountersType$ P1P1 | SpellDescription$ Return target creature card from your graveyard to the battlefield with an additional +1/+1 counter on it.
+DeckHas:Ability$Graveyard|Counters
+DeckHints:Ability$Discard|Mill
+Oracle:This spell has flash as long as there are five or more mana values among cards in your graveyard.\nReturn target creature card from your graveyard to the battlefield with an additional +1/+1 counter on it.

--- a/forge-gui/res/cardsfolder/rebalanced/a-high-rise_sawjack.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-high-rise_sawjack.txt
@@ -1,0 +1,8 @@
+Name:A-High-Rise Sawjack
+ManaCost:2 G
+Types:Creature Elf Citizen
+PT:1/4
+K:Reach
+T:Mode$ AttackerBlocked | ValidCard$ Creature.withFlying | ValidBlocker$ Card.Self | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME blocks a creature with flying, CARDNAME gets +3/+0 until end of turn.
+SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ 3
+Oracle:Reach\nWhenever High-Rise Sawjack blocks a creature with flying, High-Rise Sawjack gets +3/+0 until end of turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-incriminate.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-incriminate.txt
@@ -1,0 +1,8 @@
+Name:A-Incriminate
+ManaCost:B
+Types:Sorcery
+A:SP$ Pump | Cost$ 1 B | ValidTgts$ Creature | TgtPrompt$ Choose two target creatures controlled by the same player | TargetMin$ 2 | TargetMax$ 2 | TargetUnique$ True | TargetsWithSameController$ True | RememberTargets$ True | IsCurse$ True | SubAbility$ DBChooseSac | StackDescription$ SpellDescription | SpellDescription$ Choose two target creatures controlled by the same player. That player sacrifices one of them.
+SVar:DBChooseSac:DB$ ChooseCard | Choices$ Card.IsRemembered | Defined$ TargetedController | ChoiceTitle$ Choose one to sacrifice | SubAbility$ DBSac | StackDescription$ None | AILogic$ WorstCard
+SVar:DBSac:DB$ Destroy | Defined$ ChosenCard | Sacrifice$ True | SubAbility$ DBCleanup | StackDescription$ None
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:Choose two target creatures controlled by the same player. That player sacrifices one of them.

--- a/forge-gui/res/cardsfolder/rebalanced/a-jackhammer.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-jackhammer.txt
@@ -1,0 +1,6 @@
+Name:A-Jackhammer
+ManaCost:R
+Types:Artifact Equipment
+K:Equip:2
+S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 2 | Description$ Equipped creature gets +2/+0.
+Oracle:Equipped creature gets +2/+0.\nEquip {2}

--- a/forge-gui/res/cardsfolder/rebalanced/a-masked_bandits.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-masked_bandits.txt
@@ -1,0 +1,13 @@
+Name:A-Masked Bandits
+ManaCost:3 B R G
+Types:Creature Raccoon Rogue
+PT:5/6
+K:Vigilance
+K:Menace
+A:AB$ Effect | Cost$ 1 ExileFromHand<1/CARDNAME> | ActivationZone$ Hand | ValidTgts$ Land | TgtPrompt$ Select target land | RememberObjects$ Targeted,Self | StaticAbilities$ Land,MayPlay | Triggers$ Cast | ImprintCards$ Self | Duration$ Permanent | ForgetOnMoved$ Exile | SpellDescription$ Target land gains "{T}: Add {B}, {R}, or {G}" until CARDNAME is cast from exile. You may cast CARDNAME for as long as it remains exiled.
+SVar:Land:Mode$ Continuous | EffectZone$ Command | AffectedZone$ Battlefield | Affected$ Card.IsRemembered+IsNotImprinted | AddAbility$ Mana | Description$ Target land gains "{T}: Add {B}, {R}, or {G}" until EFFECTSOURCE is cast from exile. You may cast EFFECTSOURCE for as long as it remains exiled.
+SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo B R G | Amount$ 1 | SpellDescription$ Add {B}, {R}, or {G}
+SVar:MayPlay:Mode$ Continuous | MayPlay$ True | EffectZone$ Command | Affected$ Card.IsImprinted+IsRemembered | AffectedZone$ Exile | Secondary$ True | Description$ You may cast EFFECTSOURCE for as long as it remains exiled.
+SVar:Cast:Mode$ SpellCast | ValidCard$ Card.IsImprinted+IsRemembered+wasCastFromExile | Execute$ ExileSelf | Static$ True
+SVar:ExileSelf:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self
+Oracle:Vigilance, menace\n{1}, Exile Masked Bandits from your hand: Target land gains "{T}: Add {B}, {R}, or {G}" until Masked Bandits is cast from exile. You may cast Masked Bandits for as long as it remains exiled.

--- a/forge-gui/res/cardsfolder/rebalanced/a-metropolis_angel.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-metropolis_angel.txt
@@ -1,0 +1,9 @@
+Name:A-Metropolis Angel
+ManaCost:3 W U
+Types:Creature Angel Soldier
+PT:3/3
+K:Flying
+T:Mode$ AttackersDeclared | ValidAttackers$ Creature.YouCtrl+HasCounters | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ Whenever you attack with one or more creatures with counters on them, draw a card.
+SVar:TrigDraw:DB$ Draw
+DeckHints:Ability$Counters
+Oracle:Flying\nWhenever you attack with one or more creatures with counters on them, draw a card.

--- a/forge-gui/res/cardsfolder/rebalanced/a-midnight_assassin.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-midnight_assassin.txt
@@ -1,0 +1,7 @@
+Name:A-Midnight Assassin
+ManaCost:2 B
+Types:Creature Vampire Assassin
+PT:1/3
+K:Flying
+K:Deathtouch
+Oracle:Flying, deathtouch

--- a/forge-gui/res/cardsfolder/rebalanced/a-most_wanted.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-most_wanted.txt
@@ -1,0 +1,11 @@
+Name:A-Most Wanted
+ManaCost:2 G
+Types:Enchantment Aura
+K:Flash
+K:Enchant creature
+A:SP$ Attach | ValidTgts$ Creature | AILogic$ Pump
+S:Mode$ Continuous | Affected$ Card.EnchantedBy | AddPower$ 2 | AddToughness$ 2 | Description$ Enchanted creature gets +2/+2.
+T:Mode$ ChangesZone | ValidCard$ Card.AttachedBy | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigToken | TriggerDescription$ When enchanted creature dies, create two Treasure tokens.
+SVar:TrigToken:DB$ Token | TokenAmount$ 2 | TokenScript$ c_a_treasure_sac
+DeckHas:Ability$Sacrifice|Token & Type$Treasure|Artifact
+Oracle:Flash\nEnchant creature\nEnchanted creature gets +2/+2.\nWhen enchanted creature dies, create two Treasure tokens.

--- a/forge-gui/res/cardsfolder/rebalanced/a-mr_orfeo_the_boulder.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-mr_orfeo_the_boulder.txt
@@ -1,0 +1,9 @@
+Name:A-Mr. Orfeo, the Boulder
+ManaCost:1 B R G
+Types:Legendary Creature Rhino Warrior
+PT:3/4
+T:Mode$ AttackersDeclared | AttackingPlayer$ You | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever you attack, double target creature's power until end of turn.
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | Double$ True
+SVar:X:Targeted$CardPower
+SVar:PlayMain1:TRUE
+Oracle:Whenever you attack, double target creature's power until end of turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-ominous_parcel.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-ominous_parcel.txt
@@ -1,0 +1,6 @@
+Name:A-Ominous Parcel
+ManaCost:1
+Types:Artifact
+A:AB$ ChangeZone | Cost$ 1 T Sac<1/CARDNAME> | Origin$ Library | Destination$ Hand | ChangeType$ Land.Basic | ChangeNum$ 1 | ChangeTypeDesc$ basic land | SpellDescription$ Search your library for a basic land card, reveal it, put it into your hand, then shuffle.
+A:AB$ DealDamage | Cost$ 5 T Sac<1/CARDNAME> | ValidTgts$ Creature | NumDmg$ 4 | SpellDescription$ It deals 4 damage to target creature.
+Oracle:{1}, {T}, Sacrifice Ominous Parcel: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.\n{5}, {T}, Sacrifice Ominous Parcel: It deals 4 damage to target creature.

--- a/forge-gui/res/cardsfolder/rebalanced/a-paragon_of_modernity.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-paragon_of_modernity.txt
@@ -1,0 +1,11 @@
+Name:A-Paragon of Modernity
+ManaCost:4
+Types:Artifact Creature Angel Warrior
+PT:2/3
+K:Flying
+A:AB$ Branch | Cost$ 3 | BranchConditionSVar$ X | BranchConditionSVarCompare$ EQ3 | FalseSubAbility$ DBPump | TrueSubAbility$ DBPutCounter | SpellDescription$ CARDNAME gets +1/+1 until end of turn. If exactly three colors of mana were spent to activate this ability, put a +1/+1 counter on it instead.
+SVar:DBPump:DB$ Pump | Defined$ Self | NumAtt$ 1 | NumDef$ 1
+SVar:DBPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1
+SVar:X:Count$ManaColorsPaid
+DeckHas:Ability$Counters
+Oracle:Flying\n{3}: Paragon of Modernity gets +1/+1 until end of turn. If exactly three colors of mana were spent to activate this ability, put a +1/+1 counter on it instead.

--- a/forge-gui/res/cardsfolder/rebalanced/a-psionic_snoop.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-psionic_snoop.txt
@@ -1,0 +1,9 @@
+Name:A-Psionic Snoop
+ManaCost:2 U
+Types:Creature Human Rogue
+PT:0/4
+K:Flash
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigConnive | TriggerDescription$ When CARDNAME enters the battlefield, it connives.
+SVar:TrigConnive:DB$ Connive
+DeckHas:Ability$Discard|Counters
+Oracle:Flash\nWhen Psionic Snoop enters the battlefield, it connives.

--- a/forge-gui/res/cardsfolder/rebalanced/a-public_enemy.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-public_enemy.txt
@@ -1,0 +1,9 @@
+Name:A-Public Enemy
+ManaCost:2 U
+Types:Enchantment Aura
+K:Enchant creature
+A:SP$ Attach | ValidTgts$ Creature | AILogic$ Curse
+S:Mode$ MustAttack | ValidCreature$ Creature | MustAttack$ EnchantedController | Description$ All creatures attack enchanted creature's controller each combat if able.
+T:Mode$ ChangesZone | ValidCard$ Card.AttachedBy | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigDraw | TriggerDescription$ When enchanted creature dies, draw two cards.
+SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 2
+Oracle:Enchant creature\nAll creatures attack enchanted creature's controller each combat if able.\nWhen enchanted creature dies, draw two cards.

--- a/forge-gui/res/cardsfolder/rebalanced/a-pyre-sledge_arsonist.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-pyre-sledge_arsonist.txt
@@ -1,0 +1,8 @@
+Name:A-Pyre-Sledge Arsonist
+ManaCost:2 R
+Types:Creature Viashino Shaman
+PT:2/3
+A:AB$ DealDamage | Cost$ 1 T | NumDmg$ X | ValidTgts$ Creature,Player,Planeswalker | TgtPrompt$ Select any target | SpellDescription$ CARDNAME deals X damage to any target, where X is the number of permanents you've sacrificed this turn.
+SVar:X:Count$SacrificedThisTurn Permanent
+DeckNeeds:Ability$Sacrifice
+Oracle:{1}, {T}: Pyre-Sledge Arsonist deals X damage to any target, where X is the number of permanents you've sacrificed this turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-queza_augur_of_agonies.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-queza_augur_of_agonies.txt
@@ -1,0 +1,10 @@
+Name:A-Queza, Augur of Agonies
+ManaCost:1 W U B
+Types:Legendary Creature Cephalid Advisor
+PT:3/4
+K:Vigilance
+T:Mode$ Drawn | ValidCard$ Card.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigDrain | TriggerDescription$ Whenever you draw a card, target opponent loses 1 life and you gain 1 life.
+SVar:TrigDrain:DB$ LoseLife | ValidTgts$ Opponent | LifeAmount$ 1 | SubAbility$ DBGainLife
+SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1
+DeckHas:Ability$LifeGain
+Oracle:Vigilance\nWhenever you draw a card, target opponent loses 1 life and you gain 1 life.

--- a/forge-gui/res/cardsfolder/rebalanced/a-rakish_revelers.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-rakish_revelers.txt
@@ -1,0 +1,14 @@
+Name:A-Rakish Revelers
+ManaCost:2 R G W
+Types:Creature Elf Druid Rogue
+PT:5/3
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters the battlefield, create a 1/1 green and white Citizen creature token.
+SVar:TrigToken:DB$ Token | TokenScript$ gw_1_1_citizen
+A:AB$ Effect | Cost$ 1 ExileFromHand<1/CARDNAME> | ActivationZone$ Hand | ValidTgts$ Land | TgtPrompt$ Select target land | RememberObjects$ Targeted,Self | StaticAbilities$ Land,MayPlay | Triggers$ Cast | ImprintCards$ Self | Duration$ Permanent | ForgetOnMoved$ Exile | SpellDescription$ Target land gains "{T}: Add {R}, {G}, or {W}" until CARDNAME is cast from exile. You may cast CARDNAME for as long as it remains exiled.
+SVar:Land:Mode$ Continuous | EffectZone$ Command | AffectedZone$ Battlefield | Affected$ Card.IsRemembered+IsNotImprinted | AddAbility$ Mana | Description$ Target land gains "{T}: Add {R}, {G}, or {W}" until EFFECTSOURCE is cast from exile. You may cast EFFECTSOURCE for as long as it remains exiled.
+SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo R G W | Amount$ 1 | SpellDescription$ Add {R}, {G}, or {W}
+SVar:MayPlay:Mode$ Continuous | MayPlay$ True | EffectZone$ Command | Affected$ Card.IsImprinted+IsRemembered | AffectedZone$ Exile | Secondary$ True | Description$ You may cast EFFECTSOURCE for as long as it remains exiled.
+SVar:Cast:Mode$ SpellCast | ValidCard$ Card.IsImprinted+IsRemembered+wasCastFromExile | Execute$ ExileSelf | Static$ True
+SVar:ExileSelf:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self
+DeckHas:Ability$Token & Type$Citizen
+Oracle:When Rakish Revelers enters the battlefield, create a 1/1 green and white Citizen creature token.\n{1}, Exile Rakish Revelers from your hand: Target land gains "{T}: Add {R}, {G}, or {W}" until Rakish Revelers is cast from exile. You may cast Rakish Revelers for as long as it remains exiled.

--- a/forge-gui/res/cardsfolder/rebalanced/a-ready_to_rumble.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-ready_to_rumble.txt
@@ -1,0 +1,8 @@
+Name:A-Ready to Rumble
+ManaCost:4 R
+Types:Instant
+A:SP$ Charm | Choices$ DBDmg,DBDestroy
+SVar:DBDmg:DB$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ 5 | StaticAbilities$ STCantPrevent | NoPrevention$ True | SpellDescription$ Damage can't be prevented this turn. CARDNAME deals 5 damage to target creature or planeswalker.
+SVar:STCantPrevent:Mode$ CantPreventDamage | EffectZone$ Command | Description$ Damage can't be prevented.
+SVar:DBDestroy:DB$ Destroy | ValidTgts$ Artifact | TgtPrompt$ Select target artifact | SpellDescription$ Destroy target artifact.
+Oracle:Choose one —\n• Damage can't be prevented this turn. Ready to Rumble deals 5 damage to target creature or planeswalker.\n• Destroy target artifact.

--- a/forge-gui/res/cardsfolder/rebalanced/a-revel_ruiner.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-revel_ruiner.txt
@@ -1,0 +1,9 @@
+Name:A-Revel Ruiner
+ManaCost:3 B
+Types:Creature Cephalid Rogue
+PT:3/2
+K:Menace
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigConnive | TriggerDescription$ When CARDNAME enters the battlefield, it connives.
+SVar:TrigConnive:DB$ Connive
+DeckHas:Ability$Discard|Counters
+Oracle:Menace\nWhen Revel Ruiner enters the battlefield, it connives.

--- a/forge-gui/res/cardsfolder/rebalanced/a-riveteers_initiate.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-riveteers_initiate.txt
@@ -1,0 +1,7 @@
+Name:A-Riveteers Initiate
+ManaCost:1 R
+Types:Creature Viashino Citizen
+PT:2/2
+A:AB$ Pump | Cost$ BG | Defined$ Self | KW$ Deathtouch | SpellDescription$ CARDNAME gains deathtouch until end of turn.
+DeckHints:Color$Black|Green
+Oracle:{B/G}: Riveteers Initiate gains deathtouch until end of turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-security_rhox.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-security_rhox.txt
@@ -1,0 +1,7 @@
+Name:A-Security Rhox
+ManaCost:2 R G
+Types:Creature Rhino Warrior
+PT:5/5
+SVar:AltCost:Cost$ Mana<R G\Treasure> | Description$ You may pay {R}{G} rather than pay this spell's mana cost. Spend only mana produced by Treasures to cast it this way.
+DeckHints:Type$Treasure
+Oracle:You may pay {R}{G} rather than pay this spell's mana cost. Spend only mana produced by Treasures to cast it this way.

--- a/forge-gui/res/cardsfolder/rebalanced/a-sewer_crocodile.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-sewer_crocodile.txt
@@ -1,0 +1,9 @@
+Name:A-Sewer Crocodile
+ManaCost:5 U
+Types:Creature Crocodile
+PT:4/7
+A:AB$ Effect | Cost$ 3 U | RememberObjects$ Self | ReduceCost$ X | ExileOnMoved$ Battlefield | StaticAbilities$ Unblockable | StackDescription$ CARDNAME can't be blocked this turn. | SpellDescription$ CARDNAME can't be blocked this turn. This ability costs {3} less to activate if there are five or more mana values among cards in your graveyard.
+SVar:Unblockable:Mode$ CantBlockBy | ValidAttacker$ Card.IsRemembered | Description$ EFFECTSOURCE can't be blocked this turn.
+SVar:X:Count$Compare Y GE5.3.0
+SVar:Y:Count$ValidGraveyard Card.YouOwn$DifferentCMC
+Oracle:{3}{U}: Sewer Crocodile can't be blocked this turn. This ability costs {3} less to activate if there are five or more mana values among cards in your graveyard.

--- a/forge-gui/res/cardsfolder/rebalanced/a-shattered_seraph.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-shattered_seraph.txt
@@ -1,0 +1,15 @@
+Name:A-Shattered Seraph
+ManaCost:4 W U B
+Types:Creature Angel Rogue
+PT:4/5
+K:Flying
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigGainLife | TriggerDescription$ When CARDNAME enters the battlefield, you gain 3 life.
+SVar:TrigGainLife:DB$ GainLife | LifeAmount$ 3
+A:AB$ Effect | Cost$ 1 ExileFromHand<1/CARDNAME> | ActivationZone$ Hand | ValidTgts$ Land | TgtPrompt$ Select target land | RememberObjects$ Targeted,Self | StaticAbilities$ Land,MayPlay | Triggers$ Cast | ImprintCards$ Self | Duration$ Permanent | ForgetOnMoved$ Exile | SpellDescription$ Target land gains "{T}: Add {W}, {U}, or {B}" until CARDNAME is cast from exile. You may cast CARDNAME for as long as it remains exiled.
+SVar:Land:Mode$ Continuous | EffectZone$ Command | AffectedZone$ Battlefield | Affected$ Card.IsRemembered+IsNotImprinted | AddAbility$ Mana | Description$ Target land gains "{T}: Add {W}, {U}, or {B}" until EFFECTSOURCE is cast from exile. You may cast EFFECTSOURCE for as long as it remains exiled.
+SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo W U B | Amount$ 1 | SpellDescription$ Add {W}, {U}, or {B}
+SVar:MayPlay:Mode$ Continuous | MayPlay$ True | EffectZone$ Command | Affected$ Card.IsImprinted+IsRemembered | AffectedZone$ Exile | Secondary$ True | Description$ You may cast EFFECTSOURCE for as long as it remains exiled.
+SVar:Cast:Mode$ SpellCast | ValidCard$ Card.IsImprinted+IsRemembered+wasCastFromExile | Execute$ ExileSelf | Static$ True
+SVar:ExileSelf:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self
+DeckHas:Ability$LifeGain
+Oracle:Flying\nWhen Shattered Seraph enters the battlefield, you gain 3 life.\n{1}, Exile Shattered Seraph from your hand: Target land gains "{T}: Add {W}, {U}, or {B}" until Shattered Seraph is cast from exile. You may cast Shattered Seraph for as long as it remains exiled.

--- a/forge-gui/res/cardsfolder/rebalanced/a-sizzling_soloist.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-sizzling_soloist.txt
@@ -1,0 +1,14 @@
+Name:A-Sizzling Soloist
+ManaCost:3 R
+Types:Creature Human Citizen
+PT:4/2
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.Other+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigCantBlock | TriggerDescription$ Alliance — Whenever another creature enters the battlefield under your control, target creature an opponent controls can't block this turn. If this is the second time this ability has resolved this turn, that creature attacks during its controller's next combat phase if able.
+SVar:TrigCantBlock:DB$ Pump | ValidTgts$ Creature.OppCtrl | KW$ HIDDEN CARDNAME can't block. | TgtPrompt$ Select target creature an opponent controls | IsCurse$ True | SubAbility$ DBEffect
+SVar:DBEffect:DB$ Effect | ConditionCheckSVar$ X | ConditionSVarCompare$ EQ2 | RememberObjects$ Targeted | Triggers$ MustAttackTrig | Duration$ Permanent | ExileOnMoved$ Battlefield
+SVar:MustAttackTrig:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ Player.controlsCreature.IsRemembered_GE1 | Execute$ TrigAttacks | Static$ True | TriggerDescription$ This creature attacks during its controller's next combat phase if able.
+SVar:TrigAttacks:DB$ Animate | Defined$ Remembered | staticAbilities$ MustAttack | Duration$ UntilEndOfCombat | SubAbility$ ExileSelf
+SVar:MustAttack:Mode$ MustAttack | ValidCreature$ Card.Self | Description$ This creature attacks during its controller's next combat phase if able.
+SVar:ExileSelf:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self
+SVar:X:Count$ResolvedThisTurn
+SVar:BuffedBy:Creature
+Oracle:Alliance — Whenever another creature enters the battlefield under your control, target creature an opponent controls can't block this turn. If this is the second time this ability has resolved this turn, that creature attacks during its controller's next combat phase if able.

--- a/forge-gui/res/cardsfolder/rebalanced/a-social_climber.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-social_climber.txt
@@ -1,0 +1,9 @@
+Name:A-Social Climber
+ManaCost:2 G
+Types:Creature Human Druid
+PT:4/2
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.Other+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigGainLife | TriggerDescription$ Alliance — Whenever another creature enters the battlefield under your control, you gain 1 life.
+SVar:TrigGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1
+SVar:BuffedBy:Creature
+DeckHas:Ability$LifeGain
+Oracle:Alliance — Whenever another creature enters the battlefield under your control, you gain 1 life.

--- a/forge-gui/res/cardsfolder/rebalanced/a-sparas_adjudicators.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-sparas_adjudicators.txt
@@ -1,0 +1,13 @@
+Name:A-Spara's Adjudicators
+ManaCost:2 G W U
+Types:Creature Cat Citizen
+PT:4/4
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigPump | TriggerDescription$ When CARDNAME enters the battlefield, target creature an opponent controls can't attack or block until your next turn.
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | KW$ HIDDEN CARDNAME can't attack or block. | IsCurse$ True | Duration$ UntilYourNextTurn
+A:AB$ Effect | Cost$ 1 ExileFromHand<1/CARDNAME> | ActivationZone$ Hand | ValidTgts$ Land | TgtPrompt$ Select target land | RememberObjects$ Targeted,Self | StaticAbilities$ Land,MayPlay | Triggers$ Cast | ImprintCards$ Self | Duration$ Permanent | ForgetOnMoved$ Exile | SpellDescription$ Target land gains "{T}: Add {G}, {W}, or {U}" until CARDNAME is cast from exile. You may cast CARDNAME for as long as it remains exiled.
+SVar:Land:Mode$ Continuous | EffectZone$ Command | AffectedZone$ Battlefield | Affected$ Card.IsRemembered+IsNotImprinted | AddAbility$ Mana | Description$ Target land gains "{T}: Add {G}, {W}, or {U}" until EFFECTSOURCE is cast from exile. You may cast EFFECTSOURCE for as long as it remains exiled.
+SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo G W U | Amount$ 1 | SpellDescription$ Add {G}, {W}, or {U}
+SVar:MayPlay:Mode$ Continuous | MayPlay$ True | EffectZone$ Command | Affected$ Card.IsImprinted+IsRemembered | AffectedZone$ Exile | Secondary$ True | Description$ You may cast EFFECTSOURCE for as long as it remains exiled.
+SVar:Cast:Mode$ SpellCast | ValidCard$ Card.IsImprinted+IsRemembered+wasCastFromExile | Execute$ ExileSelf | Static$ True
+SVar:ExileSelf:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self
+Oracle:When Spara's Adjudicators enters the battlefield, target creature an opponent controls can't attack or block until your next turn.\n{1}, Exile Spara's Adjudicators from your hand: Target land gains "{T}: Add {G}, {W}, or {U}" until Spara's Adjudicators is cast from exile. You may cast Spara's Adjudicators for as long as it remains exiled.

--- a/forge-gui/res/cardsfolder/rebalanced/a-speakeasy_server.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-speakeasy_server.txt
@@ -1,0 +1,10 @@
+Name:A-Speakeasy Server
+ManaCost:4 W
+Types:Creature Bird Citizen
+PT:3/3
+K:Flying
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigGainLife | TriggerDescription$ When CARDNAME enters the battlefield, you gain 1 life for each creature you control.
+SVar:TrigGainLife:DB$ GainLife | Defined$ You | LifeAmount$ X
+SVar:X:Count$Valid Creature.YouCtrl
+DeckHas:Ability$LifeGain
+Oracle:Flying\nWhen Speakeasy Server enters the battlefield, you gain 1 life for each creature you control.

--- a/forge-gui/res/cardsfolder/rebalanced/a-stimulus_package.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-stimulus_package.txt
@@ -1,0 +1,9 @@
+Name:A-Stimulus Package
+ManaCost:2 R G
+Types:Enchantment
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ DBToken | TriggerDescription$ When CARDNAME enters the battlefield, create two Treasure tokens.
+SVar:DBToken:DB$ Token | TokenAmount$ 2 | TokenScript$ c_a_treasure_sac
+A:AB$ Token | Cost$ Sac<1/Treasure> | TokenScript$ gw_1_1_citizen | SubAbility$ DBScry | SpellDescription$ Create a 1/1 green and white Citizen creature token. Scry 1.
+SVar:DBScry:DB$ Scry | ScryNum$ 1
+DeckHas:Ability$Sacrifice|Token & Type$Treasure|Artifact|Citizen
+Oracle:When Stimulus Package enters the battlefield, create two Treasure tokens.\nSacrifice a Treasure: Create a 1/1 green and white Citizen creature token. Scry 1.

--- a/forge-gui/res/cardsfolder/rebalanced/a-syndicate_infiltrator.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-syndicate_infiltrator.txt
@@ -1,0 +1,11 @@
+Name:A-Syndicate Infiltrator
+ManaCost:2 U B
+Types:Creature Vampire Wizard
+PT:3/3
+K:Flying
+K:Ward:2
+S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 2 | AddToughness$ 2 | CheckSVar$ X | SVarCompare$ GE5 | Description$ As long as there are five or more mana values among cards in your graveyard, CARDNAME gets +2/+2.
+SVar:X:Count$ValidGraveyard Card.YouOwn$DifferentCMC
+DeckHas:Ability$Graveyard
+DeckHints:Ability$Sacrifice|Discard
+Oracle:Flying, ward {2}\nAs long as there are five or more mana values among cards in your graveyard, Syndicate Infiltrator gets +2/+2.

--- a/forge-gui/res/cardsfolder/rebalanced/a-vampire_scrivener.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-vampire_scrivener.txt
@@ -1,0 +1,11 @@
+Name:A-Vampire Scrivener
+ManaCost:3 B
+Types:Creature Vampire Warlock
+PT:2/2
+K:Flying
+T:Mode$ LifeGained | ValidPlayer$ You | TriggerZones$ Battlefield | PlayerTurn$ True | Execute$ TrigPutCounter | TriggerDescription$ Whenever you gain life during your turn, put a +1/+1 counter on CARDNAME.
+T:Mode$ LifeLost | ValidPlayer$ You | TriggerZones$ Battlefield | PlayerTurn$ True | Execute$ TrigPutCounter | TriggerDescription$ Whenever you lose life during your turn, put a +1/+1 counter on CARDNAME.
+SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
+DeckHints:Ability$LifeGain
+DeckHas:Ability$Counters
+Oracle:Flying\nWhenever you gain life during your turn, put a +1/+1 counter on Vampire Scrivener.\nWhenever you lose life during your turn, put a +1/+1 counter on Vampire Scrivener.

--- a/forge-gui/res/cardsfolder/rebalanced/a-warm_welcome.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-warm_welcome.txt
@@ -1,0 +1,7 @@
+Name:A-Warm Welcome
+ManaCost:3 G
+Types:Sorcery
+A:SP$ Dig | DigNum$ 5 | ChangeNum$ 1 | Optional$ True | ForceRevealToController$ True | ChangeValid$ Card.Creature | RestRandomOrder$ True | SubAbility$ DBToken | SpellDescription$ Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. Create two 1/1 green and white Citizen creature tokens.
+SVar:DBToken:DB$ Token | TokenAmount$ 2 | TokenScript$ gw_1_1_citizen
+DeckHas:Ability$Token & Type$Citizen
+Oracle:Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. Create two 1/1 green and white Citizen creature tokens.

--- a/forge-gui/res/editions/Alchemy Dominaria.txt
+++ b/forge-gui/res/editions/Alchemy Dominaria.txt
@@ -34,5 +34,5 @@ ScryfallCode=YDMU
 26 R Slimefoot, Thallid Transplant @Loïc Canavaggia
 27 R Teferi's Contingency @Milivoj Ćeran
 28 R Tiana, Angelic Mechanic @Joseph Weston
-29 R Vodalian Tide Mage @Joseph Weston
+29 R Vodalian Tide Mage @Brian Valeza
 30 R Coalition Construct @Artur Treffner

--- a/forge-gui/res/editions/Streets of New Capenna.txt
+++ b/forge-gui/res/editions/Streets of New Capenna.txt
@@ -492,6 +492,51 @@ ScryfallCode=SNC
 466 C Light 'Em Up @Tony Foti
 467 U Courier's Briefcase @Josu Hernaiz
 
+[rebalanced]
+A6 C A-Buy Your Silence @Tony Foti
+A7 C A-Celebrity Fencer @Inka Schulz
+A32 C A-Speakeasy Server @Scott Murphy
+A37 C A-Case the Joint @Stella Spente
+A53 C A-Psionic Snoop @Marcela Medeiros
+A55 U A-Public Enemy @Dominik Mayer
+A60 C A-Sewer Crocodile @Milivoj Ćeran
+A74 C A-Deal Gone Bad @Mathias Kollros
+A75 C A-Demon's Due @Slawomir Maniak
+A81 U A-Graveyard Shift @Liiga Smilshkalne
+A84 C A-Incriminate @Kieran Yanner
+A87 C A-Midnight Assassin @Christina Davis
+A91 C A-Revel Ruiner @Christina Davis
+A98 U A-Vampire Scrivener @Bastien L. Deharme
+A106 C A-Exhibition Magician @Greg Staples
+A111 C A-Jackhammer @John Severin Brassell
+A118 U A-Pyre-Sledge Arsonist @Kekai Kotaki
+A119 C A-Ready to Rumble @Josu Hernaiz
+A120 C A-Riveteers Initiate @Svetlin Velinov
+A123 U A-Sizzling Soloist @Véronique Meignaud
+A139 C A-Capenna Express @Viko Menezes
+A149 C A-Glittermonger @Evyn Fong
+A150 C A-High-Rise Sawjack @Randy Vargas
+A153 C A-Most Wanted @Rémi Jacquot
+A157 C A-Social Climber @Carly Mazur
+A164 C A-Warm Welcome @Inka Schulz
+A173 U A-Cabaretti Charm @Steve Argyle
+A174 C A-Celestial Regulator @Mathias Kollros
+A176 C A-Civil Servant @Tony Foti
+A189 U A-Forge Boss @Igor Kieryluk
+A190 C A-Glamorous Outlaw @Maria Zolotukhina
+A201 C A-Masked Bandits @Micah Epstein
+A203 U A-Metropolis Angel @Lie Setiawan
+A204 U A-Mr. Orfeo, the Boulder @Daarken
+A212 U A-Queza, Augur of Agonies @Josh Hass
+A214 C A-Rakish Revelers @Alessandra Pisano
+A220 U A-Security Rhox @Lie Setiawan
+A221 C A-Shattered Seraph @Bastien L. Deharme
+A224 C A-Spara's Adjudicators @Aaron J. Riley
+A225 U A-Stimulus Package @Robin Olausson
+A226 U A-Syndicate Infiltrator @Mila Pesic
+A241 C A-Ominous Parcel @Joe Slucher
+A242 C A-Paragon of Modernity @Volkan Baǵa
+
 [lands]
 2 Plains|SNC|1
 2 Plains|SNC|2


### PR DESCRIPTION
- closes #1648 

Source: https://magic.wizards.com/en/articles/archive/magic-digital/alchemy-rebalancing-october-6-2022
_I'm ignoring the "reverted rebalanced" cards for now until we implement a way of specifying which versions are legal/illegal_

- [x] Buy Your Silence
- [x] Cabaretti Charm
- [x] Capenna Express
- [x] Case the Joint
- [x] Celebrity Fencer
- [x] Celestial Regulator
- [x] Civil Servant
- [x] Deal Gone Bad
- [x] Demon's Due
- [x] Exhibition Magician
- [x] Forge Boss
- [x] Glamorous Outlaw
- [x] Glittermonger
- [x] Graveyard Shift
- [x] High-Rise Sawjack
- [x] Incriminate
- [x] Jackhammer
- [x] Masked Bandits
- [x] Metropolis Angel
- [x] Midnight Assassin
- [x] Most Wanted
- [x] Mr. Orfeo, the Boulder
- [x] Ominous Parcel
- [x] Paragon of Modernity
- [x] Psionic Snoop
- [x] Public Enemy
- [x] Pyre-Sledge Arsonist
- [x] Queza, Augur of Agonies
- [x] Rakish Revelers
- [x] Ready to Rumble
- [x] Revel Ruiner
- [x] Riveteers Initiate
- [x] Security Rhox
- [x] Sewer Crocodile
- [x] Shattered Seraph
- [x] Sizzling Soloist
- [x] Social Climber
- [x] Spara's Adjudicators
- [x] Speakeasy Server
- [x] Stimulus Package
- [x] Syndicate Infiltrator
- [x] Vampire Scrivener
- [x] Warm Welcome