### PR TITLE
Add additional AI logic for playing blink effects

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
@@ -1000,6 +1000,35 @@ public class ChangeZoneAi extends SpellAbilityAi {
 
                     return true;
                 }
+                // blink logic: get my own permanents back or blink permanents with ETB effects
+                if (blink) {
+                    CardCollection blinkTargets = CardLists.filter(list, new Predicate<Card>() {
+                        @Override
+                        public boolean apply(final Card c) {
+                            return !c.isToken() && c.getOwner().equals(ai) && (c.getController().isOpponentOf(ai) || c.hasETBTrigger(false));
+                        }
+                    });
+                    if (!blinkTargets.isEmpty()) {
+                        CardCollection opponentBlinkTargets = CardLists.filterControlledBy(blinkTargets, ai.getOpponents());
+                        // prefer post-combat unless targeting opponent's stuff or part of another ability
+                        if (immediately || sa.getParent() != null || sa.isTrigger() || !opponentBlinkTargets.isEmpty() || !game.getPhaseHandler().getPhase().isBefore(PhaseType.MAIN2)) {
+                            while (!blinkTargets.isEmpty() && sa.canAddMoreTarget()) {
+                                Card choice = null;
+                                // first prefer targeting opponents stuff
+                                if (!opponentBlinkTargets.isEmpty()) {
+                                    choice = ComputerUtilCard.getBestAI(opponentBlinkTargets);
+                                    opponentBlinkTargets.remove(choice);
+                                }
+                                else {
+                                    choice = ComputerUtilCard.getBestAI(blinkTargets);
+                                }
+                                sa.getTargets().add(choice);
+                                blinkTargets.remove(choice);
+                            }
+                            return true;
+                        }
+                    }
+                }
                 // bounce opponent's stuff
                 list = CardLists.filterControlledBy(list, ai.getOpponents());
                 if (!CardLists.getNotType(list, "Land").isEmpty()) {
@@ -1017,26 +1046,6 @@ public class ChangeZoneAi extends SpellAbilityAi {
                         }
                     });
                 }
-                // TODO: Blink permanents with ETB triggers
-                /*else if (!sa.isTrigger() && SpellAbilityAi.playReusable(ai, sa)) {
-                    aiPermanents = CardLists.filter(aiPermanents, new Predicate<Card>() {
-                        @Override
-                        public boolean apply(final Card c) {
-                            if (c.hasCounters()) {
-                                return false; // don't blink something with
-                            }
-                            // counters TODO check good and
-                            // bad counters
-                            // checks only if there is a dangerous ETB effect
-                            return !c.equals(sa.getHostCard()) && SpellPermanent.checkETBEffects(c, ai);
-                        }
-                    });
-                    if (!aiPermanents.isEmpty()) {
-                        // Choose "best" of the remaining to save
-                        sa.getTargets().add(ComputerUtilCard.getBestAI(aiPermanents));
-                        return true;
-                    }
-                }*/
             }
 
         } else if (origin.contains(ZoneType.Graveyard)) {

--- a/forge-gui/res/cardsfolder/e/eerie_interlude.txt
+++ b/forge-gui/res/cardsfolder/e/eerie_interlude.txt
@@ -6,5 +6,4 @@ SVar:DelTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ Tr
 SVar:TrigReturn:DB$ ChangeZone | Origin$ Exile | Destination$ Battlefield | Defined$ DelayTriggerRememberedLKI
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Count$Valid Creature.YouCtrl
-AI:RemoveDeck:All
 Oracle:Exile any number of target creatures you control. Return those cards to the battlefield under their owner's control at the beginning of the next end step.


### PR DESCRIPTION
This adds additional AI logic for blink effects, focused around two common use cases:
- Get my own stuff back
- Trigger ETB effects

There was some commented-out code that tried to do this before, which I removed in favour of this. I put it above the "bounce opponent's stuff" logic since it needs to happen before that logic tampers with `list`. A few caveats:
- The original commented code was going to avoid flickering ETB creatures if they have a counter on them. I decided not to include that, since often the better move will still be to get the ETB effect again even if you lose a +1/+1 counter or something. It would be a tricky thing for the AI to evaluate in general. I think for decks built around ETB effects, this is the better way to lean.
- The AI will prefer to blink ETB creatures after combat. This is so it can still have an opportunity to attack with those creatures first. This isn't always the right move since sometimes you want ETB effects that will pump creatures or otherwise affect combat. In my testing, this felt more natural in most cases (otherwise, the AI often does this during upkeep).
- The above timing restriction doesn't apply if the blink effect is part of another ability. For example, this fixes [Settle Beyond Reality](https://scryfall.com/card/2x2/30/settle-beyond-reality), which is typically cast in Main Phase 1 (to remove a blocker).
- The AI doesn't actually know if re-triggering the ETB effect will be useful (eg. blinking a [War Priest of Thune](https://scryfall.com/card/ema/35/war-priest-of-thune) when there are no Enchantments to destroy).

I tested this with the following cards: [Eerie Interlude](https://scryfall.com/card/khc/22/eerie-interlude), [Teleportation Circle](https://scryfall.com/card/afr/39/teleportation-circle), [Hallowed Respite](https://scryfall.com/card/mid/227/hallowed-respite), [Soulherder](https://scryfall.com/card/khc/93/soulherder), [Settle Beyond Reality](https://scryfall.com/card/2x2/30/settle-beyond-reality), [Ephemerate](https://scryfall.com/card/mh1/7/ephemerate), and ETB creatures like [Circuit Mender](https://scryfall.com/card/neo/242/circuit-mender). I created a few contrived scenarios to test the edge cases, like donating a Circuit Mender to the opponent and confirming it won't blink it, and stealing a (non-ETB) creature from the AI to confirm it will use blink to take it back. I played a handful of rounds with a deck containing the mentioned cards that I'm working on for an Adventure mode enemy, and the AI plays it pretty well now.

As usual with AI changes, this isn't perfect, but I think it is an improvement over previous behaviour. The AI should be able to play a [Brago, King Eternal](https://scryfall.com/card/khc/82/brago-king-eternal) Commander deck now, which is pretty cool. 

Further improvements could be:
- Extend this logic to cover removing bad counters or bad enchantments from creatures. It would just need a new function to answer "does this creature have a bad counter on it?" or "does this creature have a bad enchantment on it?".
- Evaluate whether the triggered ability from a targeted permanent is actually worth playing. Maybe feed it through "should play?" logic somehow.


