### PR TITLE
DMU: Defiler cycle and support

### DIFF
--- a/forge-game/src/main/java/forge/game/GameActionUtil.java
+++ b/forge-game/src/main/java/forge/game/GameActionUtil.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import com.google.common.collect.*;
 import forge.game.card.*;
+import forge.game.staticability.StaticAbility;
 import forge.util.Aggregates;
 import org.apache.commons.lang3.StringUtils;
 
@@ -444,6 +445,41 @@ public final class GameActionUtil {
             source.clearStaticChangedCardKeywords(false);
             CardCollection preList = new CardCollection(source);
             game.getAction().checkStaticAbilities(false, Sets.newHashSet(source), preList);
+        }
+
+        for (final Card ca : game.getCardsIn(ZoneType.STATIC_ABILITIES_SOURCE_ZONES)) {
+            for (final StaticAbility stAb : ca.getStaticAbilities()) {
+                if (!stAb.getParam("Mode").equals("OptionalCost") || stAb.isSuppressed() || !stAb.checkConditions()) {
+                    continue;
+                }
+
+                if (!stAb.matchesValidParam("ValidCard", source)) {
+                    continue;
+                }
+                if (!stAb.matchesValidParam("ValidSA", sa)) {
+                    continue;
+                }
+                if (!stAb.matchesValidParam("Activator", sa.getActivatingPlayer())) {
+                    continue;
+                }
+
+                final Cost cost = new Cost(stAb.getParam("Cost"), false);
+                if (stAb.hasParam("ReduceColor")) {
+                    if (stAb.getParam("ReduceColor").equals("W")) {
+                        costs.add(new OptionalCostValue(OptionalCost.ReduceW, cost));
+                    } else if (stAb.getParam("ReduceColor").equals("U")) {
+                        costs.add(new OptionalCostValue(OptionalCost.ReduceU, cost));
+                    } else if (stAb.getParam("ReduceColor").equals("B")) {
+                        costs.add(new OptionalCostValue(OptionalCost.ReduceB, cost));
+                    } else if (stAb.getParam("ReduceColor").equals("R")) {
+                        costs.add(new OptionalCostValue(OptionalCost.ReduceR, cost));
+                    } else if (stAb.getParam("ReduceColor").equals("G")) {
+                        costs.add(new OptionalCostValue(OptionalCost.ReduceG, cost));
+                    }
+                } else {
+                    costs.add(new OptionalCostValue(OptionalCost.AltCost, cost));
+                }
+            }
         }
 
         for (KeywordInterface inst : source.getKeywords()) {

--- a/forge-game/src/main/java/forge/game/GameActionUtil.java
+++ b/forge-game/src/main/java/forge/game/GameActionUtil.java
@@ -936,6 +936,7 @@ public final class GameActionUtil {
             ability.setHostCard(oldCard);
             ability.setXManaCostPaid(null);
             ability.setSpendPhyrexianMana(false);
+            ability.clearPipsToReduce();
             ability.setPaidLife(0);
             if (ability.hasParam("Announce")) {
                 for (final String aVar : ability.getParam("Announce").split(",")) {

--- a/forge-game/src/main/java/forge/game/cost/CostAdjustment.java
+++ b/forge-game/src/main/java/forge/game/cost/CostAdjustment.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import forge.game.spellability.OptionalCost;
 import org.apache.commons.lang3.StringUtils;
 
 import com.google.common.base.Strings;
@@ -207,6 +208,22 @@ public class CostAdjustment {
         }
         // need to reduce generic extra because of 2 hybrid mana
         cost.decreaseGenericMana(sumGeneric);
+
+        if (sa.isSpell() && sa.isOptionalCostPaid(OptionalCost.ReduceW)) {
+            cost.decreaseShard(ManaCostShard.parseNonGeneric("W"), 1);
+        }
+        if (sa.isSpell() && sa.isOptionalCostPaid(OptionalCost.ReduceU)) {
+            cost.decreaseShard(ManaCostShard.parseNonGeneric("U"), 1);
+        }
+        if (sa.isSpell() && sa.isOptionalCostPaid(OptionalCost.ReduceB)) {
+            cost.decreaseShard(ManaCostShard.parseNonGeneric("B"), 1);
+        }
+        if (sa.isSpell() && sa.isOptionalCostPaid(OptionalCost.ReduceR)) {
+            cost.decreaseShard(ManaCostShard.parseNonGeneric("R"), 1);
+        }
+        if (sa.isSpell() && sa.isOptionalCostPaid(OptionalCost.ReduceG)) {
+            cost.decreaseShard(ManaCostShard.parseNonGeneric("G"), 1);
+        }
 
         if (sa.isSpell() && sa.isOffering()) { // cost reduction from offerings
             adjustCostByOffering(cost, sa);

--- a/forge-game/src/main/java/forge/game/cost/CostAdjustment.java
+++ b/forge-game/src/main/java/forge/game/cost/CostAdjustment.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import forge.game.spellability.OptionalCost;
 import org.apache.commons.lang3.StringUtils;
 
 import com.google.common.base.Strings;
@@ -209,20 +208,10 @@ public class CostAdjustment {
         // need to reduce generic extra because of 2 hybrid mana
         cost.decreaseGenericMana(sumGeneric);
 
-        if (sa.isSpell() && sa.isOptionalCostPaid(OptionalCost.ReduceW)) {
-            cost.decreaseShard(ManaCostShard.parseNonGeneric("W"), 1);
-        }
-        if (sa.isSpell() && sa.isOptionalCostPaid(OptionalCost.ReduceU)) {
-            cost.decreaseShard(ManaCostShard.parseNonGeneric("U"), 1);
-        }
-        if (sa.isSpell() && sa.isOptionalCostPaid(OptionalCost.ReduceB)) {
-            cost.decreaseShard(ManaCostShard.parseNonGeneric("B"), 1);
-        }
-        if (sa.isSpell() && sa.isOptionalCostPaid(OptionalCost.ReduceR)) {
-            cost.decreaseShard(ManaCostShard.parseNonGeneric("R"), 1);
-        }
-        if (sa.isSpell() && sa.isOptionalCostPaid(OptionalCost.ReduceG)) {
-            cost.decreaseShard(ManaCostShard.parseNonGeneric("G"), 1);
+        if (sa.isSpell() && !sa.getPipsToReduce().isEmpty()) {
+            for (String pip : sa.getPipsToReduce()) {
+                cost.decreaseShard(ManaCostShard.parseNonGeneric(pip), 1);
+            }
         }
 
         if (sa.isSpell() && sa.isOffering()) { // cost reduction from offerings

--- a/forge-game/src/main/java/forge/game/spellability/OptionalCost.java
+++ b/forge-game/src/main/java/forge/game/spellability/OptionalCost.java
@@ -5,25 +5,27 @@ package forge.game.spellability;
  *
  */
 public enum OptionalCost {
-    Buyback("Buyback"),
-    Entwine("Entwine"),
-    Kicker1("Kicker"),
-    Kicker2("Kicker"),
-    Retrace("Retrace"),
-    Jumpstart("Jump-start"),
-    ReduceW("(to reduce white mana)"),
-    ReduceU("(to reduce blue mana)"),
-    ReduceB("(to reduce black mana)"),
-    ReduceR("(to reduce red mana)"),
-    ReduceG("(to reduce green mana)"),
-    AltCost(""),
-    Flash("Flash"), // used for Pay Extra for Flash
-    Generic("Generic"); // used by "Dragon Presence" and pseudo-kicker cards
+    Buyback("Buyback", ""),
+    Entwine("Entwine", ""),
+    Kicker1("Kicker", ""),
+    Kicker2("Kicker", ""),
+    Retrace("Retrace", ""),
+    Jumpstart("Jump-start", ""),
+    ReduceW("(to reduce white mana)", "W"),
+    ReduceU("(to reduce blue mana)", "U"),
+    ReduceB("(to reduce black mana)", "B"),
+    ReduceR("(to reduce red mana)", "R"),
+    ReduceG("(to reduce green mana)", "G"),
+    AltCost("", ""),
+    Flash("Flash", ""), // used for Pay Extra for Flash
+    Generic("Generic", ""); // used by "Dragon Presence" and pseudo-kicker cards
 
     private String name;
+    private String pip;
     
-    OptionalCost(String name) {
+    OptionalCost(String name, String pip) {
         this.name = name;
+        this.pip = pip;
     }
 
     /**
@@ -31,5 +33,12 @@ public enum OptionalCost {
      */
     public String getName() {
         return name;
+    }
+
+    /**
+     * @return the pip
+     */
+    public String getPip() {
+        return pip;
     }
 }

--- a/forge-game/src/main/java/forge/game/spellability/OptionalCost.java
+++ b/forge-game/src/main/java/forge/game/spellability/OptionalCost.java
@@ -11,6 +11,11 @@ public enum OptionalCost {
     Kicker2("Kicker"),
     Retrace("Retrace"),
     Jumpstart("Jump-start"),
+    ReduceW("(to reduce white mana)"),
+    ReduceU("(to reduce blue mana)"),
+    ReduceB("(to reduce black mana)"),
+    ReduceR("(to reduce red mana)"),
+    ReduceG("(to reduce green mana)"),
     AltCost(""),
     Flash("Flash"), // used for Pay Extra for Flash
     Generic("Generic"); // used by "Dragon Presence" and pseudo-kicker cards

--- a/forge-game/src/main/java/forge/game/spellability/OptionalCostValue.java
+++ b/forge-game/src/main/java/forge/game/spellability/OptionalCostValue.java
@@ -51,11 +51,12 @@ public class OptionalCostValue implements Serializable {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        if (type != OptionalCost.Generic) {
+        if (type != OptionalCost.Generic && !type.getName().startsWith("(to reduce")) {
             sb.append(type.getName());
             sb.append(" ");
         }
         sb.append(cost.toSimpleString());
+        sb.append(type.getName().startsWith("(to reduce") ? " " + type.getName() : "");
         return sb.toString();
     }
 }

--- a/forge-game/src/main/java/forge/game/spellability/OptionalCostValue.java
+++ b/forge-game/src/main/java/forge/game/spellability/OptionalCostValue.java
@@ -51,12 +51,13 @@ public class OptionalCostValue implements Serializable {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        if (type != OptionalCost.Generic && !type.getName().startsWith("(to reduce")) {
+        boolean isTag = type.getName().startsWith("(");
+        if (type != OptionalCost.Generic && !isTag) {
             sb.append(type.getName());
             sb.append(" ");
         }
         sb.append(cost.toSimpleString());
-        sb.append(type.getName().startsWith("(to reduce") ? " " + type.getName() : "");
+        sb.append(isTag ? " " + type.getName() : "");
         return sb.toString();
     }
 }

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
@@ -17,13 +17,7 @@
  */
 package forge.game.spellability;
 
-import java.util.Arrays;
-import java.util.EnumMap;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -158,6 +152,8 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
     private EnumMap<AbilityKey, Object> triggeringObjects = AbilityKey.newMap();
 
     private EnumMap<AbilityKey, Object> replacingObjects = AbilityKey.newMap();
+
+    private final List<String> pipsToReduce = new ArrayList<>();
 
     private List<AbilitySub> chosenList = null;
     private CardCollection tappedForConvoke = new CardCollection();
@@ -716,6 +712,9 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
         // Thus, to protect the original's set from changes, we make a copy right here.
         optionalCosts = EnumSet.copyOf(optionalCosts);
         optionalCosts.add(cost);
+        if (!cost.getPip().equals("")) {
+            pipsToReduce.add(cost.getPip());
+        }
     }
 
     public boolean isBuyBackAbility() {
@@ -1482,6 +1481,13 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
 
     public final boolean isSpectacle() {
         return isAlternativeCost(AlternativeCost.Spectacle);
+    }
+
+    public List<String> getPipsToReduce() {
+        return pipsToReduce;
+    }
+    public final void clearPipsToReduce() {
+        pipsToReduce.clear();
     }
 
     public CardCollection getTappedForConvoke() {

--- a/forge-gui/res/cardsfolder/d/defiler_of_dreams.txt
+++ b/forge-gui/res/cardsfolder/d/defiler_of_dreams.txt
@@ -1,0 +1,10 @@
+Name:Defiler of Dreams
+ManaCost:3 U U
+Types:Creature Phyrexian Sphinx
+PT:4/3
+K:Flying
+S:Mode$ OptionalCost | ValidCard$ Permanent.Blue | ValidSA$ Spell | Activator$ You | Cost$ PayLife<2> | ReduceColor$ U | Description$ As an additional cost to cast blue permanent spells, you may pay 2 life. Those spells cost {U} less to cast if you paid life this way. This effect reduces only the amount of blue mana you pay.
+T:Mode$ SpellCast | ValidCard$ Permanent.Blue | ValidActivatingPlayer$ You | Execute$ TrigDraw | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a blue permanent spell, draw a card.
+SVar:TrigDraw:DB$ Draw
+SVar:BuffedBy:Permanent.Blue
+Oracle:Flying\nAs an additional cost to cast blue permanent spells, you may pay 2 life. Those spells cost {U} less to cast if you paid life this way. This effect reduces only the amount of blue mana you pay.\nWhenever you cast a blue permanent spell, draw a card.

--- a/forge-gui/res/cardsfolder/d/defiler_of_faith.txt
+++ b/forge-gui/res/cardsfolder/d/defiler_of_faith.txt
@@ -1,0 +1,11 @@
+Name:Defiler of Faith
+ManaCost:3 W W
+Types:Creature Phyrexian Human
+PT:5/5
+K:Vigilance
+S:Mode$ OptionalCost | ValidCard$ Permanent.White | ValidSA$ Spell | Activator$ You | Cost$ PayLife<2> | ReduceColor$ W | Description$ As an additional cost to cast white permanent spells, you may pay 2 life. Those spells cost {W} less to cast if you paid life this way. This effect reduces only the amount of white mana you pay.
+T:Mode$ SpellCast | ValidCard$ Permanent.White | ValidActivatingPlayer$ You | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a white permanent spell, create a 1/1 white Soldier creature token.
+SVar:TrigToken:DB$ Token | TokenScript$ w_1_1_soldier
+DeckHas:Ability$Token & Type$Soldier
+SVar:BuffedBy:Permanent.White
+Oracle:Vigilance\nAs an additional cost to cast white permanent spells, you may pay 2 life. Those spells cost {W} less to cast if you paid life this way. This effect reduces only the amount of white mana you pay.\nWhenever you cast a white permanent spell, create a 1/1 white Soldier creature token.

--- a/forge-gui/res/cardsfolder/d/defiler_of_flesh.txt
+++ b/forge-gui/res/cardsfolder/d/defiler_of_flesh.txt
@@ -1,0 +1,10 @@
+Name:Defiler of Flesh
+ManaCost:2 B B
+Types:Creature Phyrexian Horror
+PT:4/4
+K:Menace
+S:Mode$ OptionalCost | ValidCard$ Permanent.Black | ValidSA$ Spell | Activator$ You | Cost$ PayLife<2> | ReduceColor$ B | Description$ As an additional cost to cast black permanent spells, you may pay 2 life. Those spells cost {B} less to cast if you paid life this way. This effect reduces only the amount of black mana you pay.
+T:Mode$ SpellCast | ValidCard$ Permanent.Black | ValidActivatingPlayer$ You | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a black permanent spell, target creature you control gets +1/+1 and gains menace until end of turn.
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | NumAtt$ 1 | NumDef$ 1 | KW$ Menace
+SVar:BuffedBy:Permanent.Black
+Oracle:Menace\nAs an additional cost to cast black permanent spells, you may pay 2 life. Those spells cost {B} less to cast if you paid life this way. This effect reduces only the amount of black mana you pay.\nWhenever you cast a black permanent spell, target creature you control gets +1/+1 and gains menace until end of turn.

--- a/forge-gui/res/cardsfolder/d/defiler_of_instinct.txt
+++ b/forge-gui/res/cardsfolder/d/defiler_of_instinct.txt
@@ -1,0 +1,10 @@
+Name:Defiler of Instinct
+ManaCost:2 R R
+Types:Creature Phyrexian Kavu
+PT:4/4
+K:First Strike
+S:Mode$ OptionalCost | ValidCard$ Permanent.Red | ValidSA$ Spell | Activator$ You | Cost$ PayLife<2> | ReduceColor$ R | Description$ As an additional cost to cast red permanent spells, you may pay 2 life. Those spells cost {R} less to cast if you paid life this way. This effect reduces only the amount of red mana you pay.
+T:Mode$ SpellCast | ValidCard$ Permanent.Red | ValidActivatingPlayer$ You | Execute$ TrigDamage | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a red permanent spell, CARDNAME deals 1 damage to any target.
+SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Creature,Player,Planeswalker | TgtPrompt$ Select any target | NumDmg$ 1
+SVar:BuffedBy:Permanent.Red
+Oracle:First strike\nAs an additional cost to cast red permanent spells, you may pay 2 life. Those spells cost {R} less to cast if you paid life this way. This effect reduces only the amount of red mana you pay.\nWhenever you cast a red permanent spell, Defiler of Instinct deals 1 damage to any target.

--- a/forge-gui/res/cardsfolder/d/defiler_of_vigor.txt
+++ b/forge-gui/res/cardsfolder/d/defiler_of_vigor.txt
@@ -1,0 +1,11 @@
+Name:Defiler of Vigor
+ManaCost:3 G G
+Types:Creature Phyrexian Wurm
+PT:6/6
+K:Trample
+S:Mode$ OptionalCost | ValidCard$ Permanent.Green | ValidSA$ Spell | Activator$ You | Cost$ PayLife<2> | ReduceColor$ G | Description$ As an additional cost to cast green permanent spells, you may pay 2 life. Those spells cost {G} less to cast if you paid life this way. This effect reduces only the amount of green mana you pay.
+T:Mode$ SpellCast | ValidCard$ Permanent.Green | ValidActivatingPlayer$ You | Execute$ TrigCounters | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a green permanent spell, put a +1/+1 counter on each creature you control.
+SVar:TrigCounters:DB$ PutCounterAll | ValidCards$ Creature.YouCtrl | CounterType$ P1P1
+DeckHas:Ability$Counters
+SVar:BuffedBy:Permanent.Green
+Oracle:Trample\nAs an additional cost to cast green permanent spells, you may pay 2 life. Those spells cost {G} less to cast if you paid life this way. This effect reduces only the amount of green mana you pay.\nWhenever you cast a green permanent spell, put a +1/+1 counter on each creature you control.


### PR DESCRIPTION
Some of this feels pretty boilerplate (the five different optional costs for example) and I'm sure can be improved, either now or in future when further card design forces it. But it does seem to be working correctly... and it seems like the AI should be able to handle it reasonably well.

![image](https://user-images.githubusercontent.com/103371817/198854622-1e2c91d8-e133-4278-a68b-540b340702aa.png)
Choosing both leads to:
![image](https://user-images.githubusercontent.com/103371817/198854627-8fb75c97-4a41-430f-abde-17e2cb4b7f9e.png)

If I choose both with Mistmeadow Witch (only one colored hybrid pip) -- seems right:
![image](https://user-images.githubusercontent.com/103371817/198854732-17786358-8912-432b-9564-063a125f482b.png)

Saying you'll pay the 2 life, then cancelling, then casting the spell again but not choosing additional cost results in normal mana cost, so that seems good too.