### PR TITLE
Enforce sets in quest

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/screens/home/quest/CSubmenuQuestPrefs.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/quest/CSubmenuQuestPrefs.java
@@ -84,6 +84,10 @@ public enum CSubmenuQuestPrefs implements ICDoc {
         final Localizer localizer = Localizer.getInstance();
         final String s = localizer.getMessage("lblSavefailed") +":" + s0;
         switch(i0.getErrType()) {
+        case GAME_SETTINGS:
+            view.getLblErrGameSettings().setVisible(true);
+            view.getLblErrGameSettings().setText(s);
+            break;
         case BOOSTER:
             view.getLblErrBooster().setVisible(true);
             view.getLblErrBooster().setText(s);
@@ -115,6 +119,7 @@ public enum CSubmenuQuestPrefs implements ICDoc {
     public static void resetErrors() {
         final VSubmenuQuestPrefs view = VSubmenuQuestPrefs.SINGLETON_INSTANCE;
 
+        view.getLblErrGameSettings().setVisible(false);
         view.getLblErrBooster().setVisible(false);
         view.getLblErrDifficulty().setVisible(false);
         view.getLblErrRewards().setVisible(false);

--- a/forge-gui-desktop/src/main/java/forge/screens/home/quest/VSubmenuQuestPrefs.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/quest/VSubmenuQuestPrefs.java
@@ -48,11 +48,13 @@ public enum VSubmenuQuestPrefs implements IVSubmenu<CSubmenuQuestPrefs> {
             .opaque(true).fontSize(16).build();
     private final JPanel pnlContent = new JPanel();
     private final FScrollPane scrContent = new FScrollPane(pnlContent, false);
+    private final JPanel pnlGameSettings = new JPanel();
     private final JPanel pnlRewards = new JPanel();
     private final JPanel pnlDifficulty = new JPanel();
     private final JPanel pnlBooster = new JPanel();
     private final JPanel pnlShop = new JPanel();
     private final JPanel pnlDraftTournaments = new JPanel();
+    private final FLabel lblErrGameSettings = new FLabel.Builder().text(localizer.getMessage("lblQuestGameSettingsError")).fontStyle(Font.BOLD).build();
     private final FLabel lblErrRewards = new FLabel.Builder().text(localizer.getMessage("lblRewardsError")).fontStyle(Font.BOLD).build();
     private final FLabel lblErrDifficulty = new FLabel.Builder().text(localizer.getMessage("lblDifficultyError")).fontStyle(Font.BOLD).build();
     private final FLabel lblErrBooster = new FLabel.Builder().text(localizer.getMessage("lblBoosterError")).fontStyle(Font.BOLD).build();
@@ -62,6 +64,7 @@ public enum VSubmenuQuestPrefs implements IVSubmenu<CSubmenuQuestPrefs> {
     private PrefInput focusTarget;
     /** */
     public enum QuestPreferencesErrType { /** */
+    GAME_SETTINGS, /** */
     REWARDS, /** */
     DIFFICULTY, /** */
     BOOSTER, /** */
@@ -75,11 +78,22 @@ public enum VSubmenuQuestPrefs implements IVSubmenu<CSubmenuQuestPrefs> {
         lblTitle.setBackground(FSkin.getColor(FSkin.Colors.CLR_THEME2));
         pnlContent.setOpaque(false);
         pnlContent.setLayout(new MigLayout("insets 0, gap 0, wrap"));
+        lblErrGameSettings.setForeground(Color.red);
         lblErrRewards.setForeground(Color.red);
         lblErrDifficulty.setForeground(Color.red);
         lblErrBooster.setForeground(Color.red);
         lblErrShop.setForeground(Color.red);
         lblErrDraftTournaments.setForeground(Color.red);
+        // Game settings panel
+        final FPanel pnlTitleGameSettings = new FPanel();
+        pnlTitleGameSettings.setLayout(new MigLayout("insets 0, align center"));
+        pnlTitleGameSettings.setBackground(FSkin.getColor(FSkin.Colors.CLR_THEME2));
+        pnlTitleGameSettings.add(new FLabel.Builder().text(localizer.getMessage("lblQuestGameSettings"))
+                .icon(FSkin.getIcon(FSkinProp.ICO_QUEST_GEAR))
+                .fontSize(16).build(), "h 95%!, gap 0 0 2.5% 0");
+        pnlContent.add(pnlTitleGameSettings, "w 96%!, h 36px!, gap 2% 0 10px 20px");
+        pnlContent.add(pnlGameSettings, "w 96%!, gap 2% 0 10px 20px");
+        populateGameSettings();
         // Rewards panel
         final FPanel pnlTitleRewards = new FPanel();
         pnlTitleRewards.setLayout(new MigLayout("insets 0, align center"));
@@ -166,6 +180,10 @@ public enum VSubmenuQuestPrefs implements IVSubmenu<CSubmenuQuestPrefs> {
         return EDocID.HOME_QUESTPREFS;
     }
     /** @return {@link javax.swing.JLabel} */
+    public JLabel getLblErrGameSettings() {
+        return lblErrGameSettings;
+    }
+    /** @return {@link javax.swing.JLabel} */
     public JLabel getLblErrRewards() {
         return lblErrRewards;
     }
@@ -190,6 +208,19 @@ public enum VSubmenuQuestPrefs implements IVSubmenu<CSubmenuQuestPrefs> {
     }
     private final static String fieldConstraints = "w 60px!, h 26px!";
     private final static String labelConstraints = "w 200px!, h 26px!, gap 0 10px 0 0";
+
+    private void populateGameSettings() {
+        pnlGameSettings.setOpaque(false);
+        pnlGameSettings.setLayout(new MigLayout("insets 0px, gap 0, wrap 2, hidemode 3"));
+        pnlGameSettings.removeAll();
+        pnlGameSettings.add(lblErrGameSettings, "w 100%!, h 30px!, span 2 1");
+        FLabel worldRulesConformance = new FLabel.Builder().text(localizer.getMessage("lblWorldRulesConformance")).fontAlign(SwingConstants.RIGHT).build();
+        worldRulesConformance.setToolTipText(localizer.getMessage("ttWorldRulesConformance"));
+        pnlGameSettings.add(worldRulesConformance, labelConstraints);
+        focusTarget = new PrefInput(QPref.WORLD_RULES_CONFORMANCE, QuestPreferencesErrType.GAME_SETTINGS);
+        pnlGameSettings.add(focusTarget, fieldConstraints);
+    }
+
     private void populateRewards() {
         pnlRewards.setOpaque(false);
         pnlRewards.setLayout(new MigLayout("insets 0px, gap 0, wrap 2, hidemode 3"));

--- a/forge-gui/res/languages/de-DE.properties
+++ b/forge-gui/res/languages/de-DE.properties
@@ -719,11 +719,15 @@ lblInvalidDeck=Unzulässiges Deck
 lblInvalidDeckDesc=Dein Deck %n\nBitte ändern oder anderes Deck wählen.
 #VSubmenuQuestPrefs.java
 lblQuestPreferences=Quest-Einstellungen
+lblQuestGameSettingsError=Game Settings Error
 lblRewardsError=Fehler bei Belohnungen
 lblDifficultyError=Fehler bei Schwierigkeitsgrad
 lblBoosterError=Fehler bei Boostern
 lblShopError=Fehler im Laden
 lblDraftTournamentsError=Fehler im Draft-Turnier
+lblQuestGameSettings=Game Settings
+lblWorldRulesConformance=World Rules Conformance
+ttWorldRulesConformance=Enforce player deck legality in each world (allowed sets, restricted cards etc).
 lblRewards=Belohnungen
 lblBoosterPackRatios=Booster-Pack Verteilung
 lblDifficultyAdjustments=Einstellung des Schwierigkeitsgrades

--- a/forge-gui/res/languages/en-US.properties
+++ b/forge-gui/res/languages/en-US.properties
@@ -720,11 +720,15 @@ lblInvalidDeck=Invalid Deck
 lblInvalidDeckDesc=Your deck %n\nPlease edit or choose a different deck.
 #VSubmenuQuestPrefs.java
 lblQuestPreferences=Quest Preferences
+lblQuestGameSettingsError=Game Settings Error
 lblRewardsError=Rewards Error
 lblDifficultyError=Difficulty Error
 lblBoosterError=Booster Error
 lblShopError=Shop Error
 lblDraftTournamentsError=Draft Tournaments Error
+lblQuestGameSettings=Game Settings
+lblWorldRulesConformance=World Rules Conformance
+ttWorldRulesConformance=Enforce player deck legality in each world (allowed sets, restricted cards etc).
 lblRewards=Rewards
 lblBoosterPackRatios=Booster Pack Ratios
 lblDifficultyAdjustments=Difficulty Adjustments

--- a/forge-gui/res/languages/es-ES.properties
+++ b/forge-gui/res/languages/es-ES.properties
@@ -720,11 +720,15 @@ lblInvalidDeck=Mazo no válido
 lblInvalidDeckDesc=Tu mazo %n\nPor favor, edita o elige un mazo diferente.
 #VSubmenuQuestPrefs.java
 lblQuestPreferences=Preferencias de aventura
+lblQuestGameSettingsError=Game Settings Error
 lblRewardsError=Error de recompensas
 lblDifficultyError=Error de dificultad
 lblBoosterError=Error de sobres
 lblShopError=Error de tienda
 lblDraftTournamentsError=Error de torneos de Draft
+lblQuestGameSettings=Game Settings
+lblWorldRulesConformance=World Rules Conformance
+ttWorldRulesConformance=Enforce player deck legality in each world (allowed sets, restricted cards etc).
 lblRewards=Recompensas
 lblBoosterPackRatios=Proporción de pack de sobres
 lblDifficultyAdjustments=Ajustes de dificultad

--- a/forge-gui/res/languages/fr-FR.properties
+++ b/forge-gui/res/languages/fr-FR.properties
@@ -721,11 +721,15 @@ lblInvalidDeck=Deck invalide
 lblInvalidDeckDesc=Votre deck %n\nVeuillez modifier ou choisir un autre deck.
 #VSubmenuQuestPrefs.java
 lblQuestPreferences=Préférences de quête
+lblQuestGameSettingsError=Game Settings Error
 lblRewardsError=Erreur de récompenses
 lblDifficultyError=Erreur de difficulté
 lblBoosterError=Erreur de booster
 lblShopError=Erreur de la boutique
 lblDraftTournamentsError=Erreur de draft de tournois
+lblQuestGameSettings=Game Settings
+lblWorldRulesConformance=World Rules Conformance
+ttWorldRulesConformance=Enforce player deck legality in each world (allowed sets, restricted cards etc).
 lblRewards=Récompenses
 lblBoosterPackRatios=Ratios des boosters
 lblDifficultyAdjustments=Ajustements de la difficulté

--- a/forge-gui/res/languages/it-IT.properties
+++ b/forge-gui/res/languages/it-IT.properties
@@ -719,11 +719,15 @@ lblInvalidDeck=Mazzo non valido
 lblInvalidDeckDesc=Il tuo mazzo %n \nModifica o scegli un altro mazzo.
 #VSubmenuQuestPrefs.java
 lblQuestPreferences=Preferenze Avventura
+lblQuestGameSettingsError=Game Settings Error
 lblRewardsError=Errore premi
 lblDifficultyError=Errore difficoltà
 lblBoosterError=Errore buste
 lblShopError=Errore negozio
 lblDraftTournamentsError=Errore tornei Draft
+lblQuestGameSettings=Game Settings
+lblWorldRulesConformance=World Rules Conformance
+ttWorldRulesConformance=Enforce player deck legality in each world (allowed sets, restricted cards etc).
 lblRewards=Ricompense
 lblBoosterPackRatios=Rapporti buste
 lblDifficultyAdjustments=Regola la difficoltà

--- a/forge-gui/res/languages/ja-JP.properties
+++ b/forge-gui/res/languages/ja-JP.properties
@@ -720,11 +720,15 @@ lblInvalidDeck=無効なデッキ
 lblInvalidDeckDesc=あなたのデッキ %n\n別のデッキを編集または選択してください。
 #VSubmenuQuestPrefs.java
 lblQuestPreferences=クエスト設定
+lblQuestGameSettingsError=Game Settings Error
 lblRewardsError=報酬エラー
 lblDifficultyError=難易度エラー
 lblBoosterError=ブースターエラー
 lblShopError=ショップエラー
 lblDraftTournamentsError=ドラフトトーナメントエラー
+lblQuestGameSettings=Game Settings
+lblWorldRulesConformance=World Rules Conformance
+ttWorldRulesConformance=Enforce player deck legality in each world (allowed sets, restricted cards etc).
 lblRewards=報酬
 lblBoosterPackRatios=ブースターパック比
 lblDifficultyAdjustments=難易度調整

--- a/forge-gui/res/languages/pt-BR.properties
+++ b/forge-gui/res/languages/pt-BR.properties
@@ -745,11 +745,15 @@ lblInvalidDeckDesc=Seu deck %n\n\
 Por favor edite ou escolha um deck diferente.
 #VSubmenuQuestPrefs.java
 lblQuestPreferences=Preferências de Missões
+lblQuestGameSettingsError=Game Settings Error
 lblRewardsError=Erro de Prêmios
 lblDifficultyError=Erro de Dificuldade
 lblBoosterError=Erro de Booster
 lblShopError=Erro de Loja
 lblDraftTournamentsError=Erro de Torneio Draft
+lblQuestGameSettings=Game Settings
+lblWorldRulesConformance=World Rules Conformance
+ttWorldRulesConformance=Enforce player deck legality in each world (allowed sets, restricted cards etc).
 lblRewards=Prêmios
 lblBoosterPackRatios=Proporção Pacote Booster
 lblDifficultyAdjustments=Ajustes de Dificuldade

--- a/forge-gui/res/languages/zh-CN.properties
+++ b/forge-gui/res/languages/zh-CN.properties
@@ -720,11 +720,15 @@ lblInvalidDeck=错误的套牌
 lblInvalidDeckDesc=你的套牌%n请编辑或者选择其他套牌
 #VSubmenuQuestPrefs.java
 lblQuestPreferences=冒险偏好
+lblQuestGameSettingsError=Game Settings Error
 lblRewardsError=奖励错误
 lblDifficultyError=难度错误
 lblBoosterError=补充包错误
 lblShopError=商店错误
 lblDraftTournamentsError=轮抓锦标赛错误
+lblQuestGameSettings=Game Settings
+lblWorldRulesConformance=World Rules Conformance
+ttWorldRulesConformance=Enforce player deck legality in each world (allowed sets, restricted cards etc).
 lblRewards=奖励
 lblBoosterPackRatios=补充包比例
 lblDifficultyAdjustments=挑战难度

--- a/forge-gui/src/main/java/forge/gamemodes/quest/QuestUtil.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/QuestUtil.java
@@ -32,6 +32,7 @@ import forge.gamemodes.quest.bazaar.QuestPetController;
 import forge.gamemodes.quest.data.DeckConstructionRules;
 import forge.gamemodes.quest.data.QuestAchievements;
 import forge.gamemodes.quest.data.QuestAssets;
+import forge.gamemodes.quest.data.QuestPreferences;
 import forge.gui.FThreads;
 import forge.gui.GuiBase;
 import forge.gui.interfaces.IButton;
@@ -681,8 +682,6 @@ public class QuestUtil {
 
         //Check quest mode's generic deck construction rules: minimum cards in deck, sideboard etc
         String errorMessage = GameType.Quest.getDeckFormat().getDeckConformanceProblem(deck);
-
-        //Check the quest mode's generic deck construction rules: minimum cards in deck, sideboard etc
         if(errorMessage != null) return errorMessage; //return immediately if the deck does not conform to quest requirements
 
         //Check for all applicable deck construction rules per this quests's saved DeckConstructionRules enum
@@ -694,8 +693,10 @@ public class QuestUtil {
         if(errorMessage != null) return errorMessage;
 
         //Check for this quest- and World's deck construction rules: allowed sets, banned/restricted cards etc
-        if(FModel.getQuest().getFormat() != null)
-            errorMessage = FModel.getQuest().getFormat().getDeckConformanceProblem(deck);
+        if (FModel.getQuestPreferences().getPrefInt(QuestPreferences.QPref.WORLD_RULES_CONFORMANCE) == 1) {
+            if(FModel.getQuest().getFormat() != null)
+                errorMessage = FModel.getQuest().getFormat().getDeckConformanceProblem(deck);
+        }
 
         return errorMessage;
     }

--- a/forge-gui/src/main/java/forge/gamemodes/quest/QuestUtil.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/QuestUtil.java
@@ -664,7 +664,7 @@ public class QuestUtil {
         }
 
         if (FModel.getPreferences().getPrefBoolean(FPref.ENFORCE_DECK_LEGALITY)) {
-            final String errorMessage = getDeckConformanceProblems(deck);
+            final String errorMessage = getDeckConformanceProblemsBeforeGame(deck);
             if (null != errorMessage) {
                 SOptionPane.showErrorDialog(localizer.getMessage("lblInvalidDeckDesc").replace("%n",errorMessage), "Invalid Deck");
                 return false;
@@ -674,9 +674,15 @@ public class QuestUtil {
         return true;
     }
 
-    public static String getDeckConformanceProblems(Deck deck){
+    public static String getDeckConformanceProblemsBeforeGame(Deck deck){
+        // Challenges with fixed decks override conformance settings
+        if(event instanceof QuestEventChallenge && ((QuestEventChallenge) event).getHumanDeck() != null)
+            return null;
+
+        //Check quest mode's generic deck construction rules: minimum cards in deck, sideboard etc
         String errorMessage = GameType.Quest.getDeckFormat().getDeckConformanceProblem(deck);
 
+        //Check the quest mode's generic deck construction rules: minimum cards in deck, sideboard etc
         if(errorMessage != null) return errorMessage; //return immediately if the deck does not conform to quest requirements
 
         //Check for all applicable deck construction rules per this quests's saved DeckConstructionRules enum
@@ -685,6 +691,11 @@ public class QuestUtil {
                 errorMessage = GameType.Commander.getDeckFormat().getDeckConformanceProblem(deck);
                 break;
         }
+        if(errorMessage != null) return errorMessage;
+
+        //Check for this quest- and World's deck construction rules: allowed sets, banned/restricted cards etc
+        if(FModel.getQuest().getFormat() != null)
+            errorMessage = FModel.getQuest().getFormat().getDeckConformanceProblem(deck);
 
         return errorMessage;
     }

--- a/forge-gui/src/main/java/forge/gamemodes/quest/data/QuestPreferences.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/data/QuestPreferences.java
@@ -32,6 +32,8 @@ public class QuestPreferences extends PreferencesStore<QuestPreferences.QPref> i
      */
     public enum QPref {
 
+        // if enabled, player must follow world rules in duels (allowed sets only, banned/restricted cards etc.)
+        WORLD_RULES_CONFORMANCE("0"),
         // How many of each rarity comes in a won booster pack
         BOOSTER_COMMONS("11"),
         BOOSTER_UNCOMMONS("3"),
@@ -293,6 +295,7 @@ public class QuestPreferences extends PreferencesStore<QuestPreferences.QPref> i
                     return "Bias value too large (maximum 100).";
                 }
                 break;
+            case WORLD_RULES_CONFORMANCE:
             case DRAFT_ROTATION:
             case SPECIAL_BOOSTERS:
             case FOIL_FILTER_DEFAULT:


### PR DESCRIPTION
This PR includes two changes:

1. Enforcing the current world's rules for player decks. `getDeckConformanceProblemsBeforeGame()` runs the deck through the quest's `GameFormat`'s `getPoolLegalityProblem()`, which applies its `filterRules` and also checks for banned/restricted cards. Challenges with custom human decks, such as Tibalt vs Sorin don't need to pass these checks.
2. Add a new Quest Preferences setting that toggles this behavior on and off. Off by default.

Test by:

- Making a new quest with a starting pool of cards from mixed vintage/standard sets. Create a vintage deck. Travel to Alara or Random Standard. Try to run a duel. Should work. Now go to Quest Preferences and change World Rules Conformance to 1. Try to run another duel. Should fail and tell you which cards are illegal.
- **This test will require some hacking in `QuestController.regenerateChallenges()` to force the correct challenges to spawn**. Create a quest with mixed vintage/standard cards, and run a challenge with a fixed human deck. Should be playable regardless of current world and World Conformance Rules setting. Now give it a "normal" challenge. Playability should behave exactly as a regular duel.