### PR TITLE
Evolving wilds world

### DIFF
--- a/forge-game/src/main/java/forge/game/GameFormat.java
+++ b/forge-game/src/main/java/forge/game/GameFormat.java
@@ -137,22 +137,22 @@ public class GameFormat implements Comparable<GameFormat> {
         this.filterRules = this.buildFilterRules();
         this.filterPrinted = this.buildFilterPrinted();
     }
-    private Predicate<PaperCard> buildFilter(boolean printed) {
-        Predicate<PaperCard> p = Predicates.not(IPaperCard.Predicates.names(this.bannedCardNames_ro));
-        if (!this.allowedSetCodes_ro.isEmpty()) {
+    protected Predicate<PaperCard> buildFilter(boolean printed) {
+        Predicate<PaperCard> p = Predicates.not(IPaperCard.Predicates.names(this.getBannedCardNames()));
+        if (!this.getAllowedSetCodes().isEmpty()) {
             p = Predicates.and(p, printed ?
-                    IPaperCard.Predicates.printedInSets(this.allowedSetCodes_ro, printed) :
-                    StaticData.instance().getCommonCards().wasPrintedInSets(this.allowedSetCodes_ro));
+                    IPaperCard.Predicates.printedInSets(this.getAllowedSetCodes(), printed) :
+                    StaticData.instance().getCommonCards().wasPrintedInSets(this.getAllowedSetCodes()));
         }
-        if (!this.allowedRarities.isEmpty()) {
+        if (!this.getAllowedRarities().isEmpty()) {
             List<Predicate<? super PaperCard>> crp = Lists.newArrayList();
-            for (CardRarity cr: this.allowedRarities) {
+            for (CardRarity cr: this.getAllowedRarities()) {
                 crp.add(StaticData.instance().getCommonCards().wasPrintedAtRarity(cr));
             }
             p = Predicates.and(p, Predicates.or(crp));
         }
-        if (!this.additionalCardNames_ro.isEmpty()) {
-            p = Predicates.or(p, IPaperCard.Predicates.names(this.additionalCardNames_ro));
+        if (!this.getAdditionalCards().isEmpty()) {
+            p = Predicates.or(p, IPaperCard.Predicates.names(this.getAdditionalCards()));
         }
         return p;
     }
@@ -241,7 +241,7 @@ public class GameFormat implements Comparable<GameFormat> {
     }
 
     public boolean isSetLegal(final String setCode) {
-        return this.allowedSetCodes_ro.isEmpty() || this.allowedSetCodes_ro.contains(setCode);
+        return this.getAllowedSetCodes().isEmpty() || this.getAllowedSetCodes().contains(setCode);
     }
     
     private boolean isPoolLegal(final CardPool allCards) {
@@ -257,7 +257,7 @@ public class GameFormat implements Comparable<GameFormat> {
         {
             final List<PaperCard> erroneousCI = new ArrayList<>();
             for (Entry<PaperCard, Integer> poolEntry : allCards) {
-                if (!filterRules.apply(poolEntry.getKey())) {
+                if (!getFilterRules().apply(poolEntry.getKey())) {
                     erroneousCI.add(poolEntry.getKey());
                 }
             }
@@ -270,12 +270,12 @@ public class GameFormat implements Comparable<GameFormat> {
             }
         }
         // Check number of restricted and legendary-restricted cards
-        if(!restrictedCardNames_ro.isEmpty() || restrictedLegendary ) {
+        if(!getRestrictedCards().isEmpty() || isRestrictedLegendary() ) {
             final List<PaperCard> erroneousRestricted = new ArrayList<>();
             for (Entry<PaperCard, Integer> poolEntry : allCards) {
-                boolean isRestricted = restrictedCardNames_ro.contains(poolEntry.getKey().getName());
+                boolean isRestricted = getRestrictedCards().contains(poolEntry.getKey().getName());
                 boolean isLegendaryNonPlaneswalker = poolEntry.getKey().getRules().getType().isLegendary()
-                        && !poolEntry.getKey().getRules().getType().isPlaneswalker() && restrictedLegendary;
+                        && !poolEntry.getKey().getRules().getType().isPlaneswalker() && isRestrictedLegendary();
                 if( poolEntry.getValue() > 1 && (isRestricted || isLegendaryNonPlaneswalker)) {
                     erroneousRestricted.add(poolEntry.getKey());
                 }

--- a/forge-game/src/main/java/forge/game/GameFormat.java
+++ b/forge-game/src/main/java/forge/game/GameFormat.java
@@ -558,6 +558,10 @@ public class GameFormat implements Comparable<GameFormat> {
             return this.map.get("Modern");
         }
 
+        public GameFormat getVintage() {
+            return this.map.get("Vintage");
+        }
+
         public GameFormat getFormat(String format) {
             return this.map.get(format);
         }

--- a/forge-gui-desktop/src/main/java/forge/screens/home/quest/CSubmenuQuestPrefs.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/quest/CSubmenuQuestPrefs.java
@@ -84,6 +84,10 @@ public enum CSubmenuQuestPrefs implements ICDoc {
         final Localizer localizer = Localizer.getInstance();
         final String s = localizer.getMessage("lblSavefailed") +":" + s0;
         switch(i0.getErrType()) {
+        case GAME_SETTINGS:
+            view.getLblErrGameSettings().setVisible(true);
+            view.getLblErrGameSettings().setText(s);
+            break;
         case BOOSTER:
             view.getLblErrBooster().setVisible(true);
             view.getLblErrBooster().setText(s);
@@ -115,6 +119,7 @@ public enum CSubmenuQuestPrefs implements ICDoc {
     public static void resetErrors() {
         final VSubmenuQuestPrefs view = VSubmenuQuestPrefs.SINGLETON_INSTANCE;
 
+        view.getLblErrGameSettings().setVisible(false);
         view.getLblErrBooster().setVisible(false);
         view.getLblErrDifficulty().setVisible(false);
         view.getLblErrRewards().setVisible(false);

--- a/forge-gui-desktop/src/main/java/forge/screens/home/quest/VSubmenuQuestPrefs.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/quest/VSubmenuQuestPrefs.java
@@ -48,11 +48,13 @@ public enum VSubmenuQuestPrefs implements IVSubmenu<CSubmenuQuestPrefs> {
             .opaque(true).fontSize(16).build();
     private final JPanel pnlContent = new JPanel();
     private final FScrollPane scrContent = new FScrollPane(pnlContent, false);
+    private final JPanel pnlGameSettings = new JPanel();
     private final JPanel pnlRewards = new JPanel();
     private final JPanel pnlDifficulty = new JPanel();
     private final JPanel pnlBooster = new JPanel();
     private final JPanel pnlShop = new JPanel();
     private final JPanel pnlDraftTournaments = new JPanel();
+    private final FLabel lblErrGameSettings = new FLabel.Builder().text(localizer.getMessage("lblQuestGameSettingsError")).fontStyle(Font.BOLD).build();
     private final FLabel lblErrRewards = new FLabel.Builder().text(localizer.getMessage("lblRewardsError")).fontStyle(Font.BOLD).build();
     private final FLabel lblErrDifficulty = new FLabel.Builder().text(localizer.getMessage("lblDifficultyError")).fontStyle(Font.BOLD).build();
     private final FLabel lblErrBooster = new FLabel.Builder().text(localizer.getMessage("lblBoosterError")).fontStyle(Font.BOLD).build();
@@ -62,6 +64,7 @@ public enum VSubmenuQuestPrefs implements IVSubmenu<CSubmenuQuestPrefs> {
     private PrefInput focusTarget;
     /** */
     public enum QuestPreferencesErrType { /** */
+    GAME_SETTINGS, /** */
     REWARDS, /** */
     DIFFICULTY, /** */
     BOOSTER, /** */
@@ -75,11 +78,22 @@ public enum VSubmenuQuestPrefs implements IVSubmenu<CSubmenuQuestPrefs> {
         lblTitle.setBackground(FSkin.getColor(FSkin.Colors.CLR_THEME2));
         pnlContent.setOpaque(false);
         pnlContent.setLayout(new MigLayout("insets 0, gap 0, wrap"));
+        lblErrGameSettings.setForeground(Color.red);
         lblErrRewards.setForeground(Color.red);
         lblErrDifficulty.setForeground(Color.red);
         lblErrBooster.setForeground(Color.red);
         lblErrShop.setForeground(Color.red);
         lblErrDraftTournaments.setForeground(Color.red);
+        // Game settings panel
+        final FPanel pnlTitleGameSettings = new FPanel();
+        pnlTitleGameSettings.setLayout(new MigLayout("insets 0, align center"));
+        pnlTitleGameSettings.setBackground(FSkin.getColor(FSkin.Colors.CLR_THEME2));
+        pnlTitleGameSettings.add(new FLabel.Builder().text(localizer.getMessage("lblQuestGameSettings"))
+                .icon(FSkin.getIcon(FSkinProp.ICO_QUEST_GEAR))
+                .fontSize(16).build(), "h 95%!, gap 0 0 2.5% 0");
+        pnlContent.add(pnlTitleGameSettings, "w 96%!, h 36px!, gap 2% 0 10px 20px");
+        pnlContent.add(pnlGameSettings, "w 96%!, gap 2% 0 10px 20px");
+        populateGameSettings();
         // Rewards panel
         final FPanel pnlTitleRewards = new FPanel();
         pnlTitleRewards.setLayout(new MigLayout("insets 0, align center"));
@@ -166,6 +180,10 @@ public enum VSubmenuQuestPrefs implements IVSubmenu<CSubmenuQuestPrefs> {
         return EDocID.HOME_QUESTPREFS;
     }
     /** @return {@link javax.swing.JLabel} */
+    public JLabel getLblErrGameSettings() {
+        return lblErrGameSettings;
+    }
+    /** @return {@link javax.swing.JLabel} */
     public JLabel getLblErrRewards() {
         return lblErrRewards;
     }
@@ -190,6 +208,19 @@ public enum VSubmenuQuestPrefs implements IVSubmenu<CSubmenuQuestPrefs> {
     }
     private final static String fieldConstraints = "w 60px!, h 26px!";
     private final static String labelConstraints = "w 200px!, h 26px!, gap 0 10px 0 0";
+
+    private void populateGameSettings() {
+        pnlGameSettings.setOpaque(false);
+        pnlGameSettings.setLayout(new MigLayout("insets 0px, gap 0, wrap 2, hidemode 3"));
+        pnlGameSettings.removeAll();
+        pnlGameSettings.add(lblErrGameSettings, "w 100%!, h 30px!, span 2 1");
+        FLabel worldRulesConformance = new FLabel.Builder().text(localizer.getMessage("lblWorldRulesConformance")).fontAlign(SwingConstants.RIGHT).build();
+        worldRulesConformance.setToolTipText(localizer.getMessage("ttWorldRulesConformance"));
+        pnlGameSettings.add(worldRulesConformance, labelConstraints);
+        focusTarget = new PrefInput(QPref.WORLD_RULES_CONFORMANCE, QuestPreferencesErrType.GAME_SETTINGS);
+        pnlGameSettings.add(focusTarget, fieldConstraints);
+    }
+
     private void populateRewards() {
         pnlRewards.setOpaque(false);
         pnlRewards.setLayout(new MigLayout("insets 0px, gap 0, wrap 2, hidemode 3"));

--- a/forge-gui/res/languages/en-US.properties
+++ b/forge-gui/res/languages/en-US.properties
@@ -720,11 +720,15 @@ lblInvalidDeck=Invalid Deck
 lblInvalidDeckDesc=Your deck %n\nPlease edit or choose a different deck.
 #VSubmenuQuestPrefs.java
 lblQuestPreferences=Quest Preferences
+lblQuestGameSettingsError=Game Settings Error
 lblRewardsError=Rewards Error
 lblDifficultyError=Difficulty Error
 lblBoosterError=Booster Error
 lblShopError=Shop Error
 lblDraftTournamentsError=Draft Tournaments Error
+lblQuestGameSettings=Game Settings
+lblWorldRulesConformance=World Rules Conformance
+ttWorldRulesConformance=Enforce player deck legality in each world (allowed sets, restricted cards etc).
 lblRewards=Rewards
 lblBoosterPackRatios=Booster Pack Ratios
 lblDifficultyAdjustments=Difficulty Adjustments

--- a/forge-gui/res/quest/world/worlds.txt
+++ b/forge-gui/res/quest/world/worlds.txt
@@ -3,6 +3,7 @@ Name:Random Standard
 Name:Random Pioneer
 Name:Random Modern
 Name:Random Commander
+Name:Evolving Wilds
 Name:Amonkhet|Dir:Amonkhet|Sets:AKH, HOU, AKR
 Name:Jamuraa|Dir:jamuraa|Sets:5ED, ARN, MIR, VIS, WTH
 Name:Kamigawa|Dir:2004 Kamigawa|Sets:CHK, BOK, SOK

--- a/forge-gui/src/main/java/forge/gamemodes/quest/QuestUtil.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/QuestUtil.java
@@ -32,6 +32,7 @@ import forge.gamemodes.quest.bazaar.QuestPetController;
 import forge.gamemodes.quest.data.DeckConstructionRules;
 import forge.gamemodes.quest.data.QuestAchievements;
 import forge.gamemodes.quest.data.QuestAssets;
+import forge.gamemodes.quest.data.QuestPreferences;
 import forge.gui.FThreads;
 import forge.gui.GuiBase;
 import forge.gui.interfaces.IButton;
@@ -681,8 +682,6 @@ public class QuestUtil {
 
         //Check quest mode's generic deck construction rules: minimum cards in deck, sideboard etc
         String errorMessage = GameType.Quest.getDeckFormat().getDeckConformanceProblem(deck);
-
-        //Check the quest mode's generic deck construction rules: minimum cards in deck, sideboard etc
         if(errorMessage != null) return errorMessage; //return immediately if the deck does not conform to quest requirements
 
         //Check for all applicable deck construction rules per this quests's saved DeckConstructionRules enum
@@ -694,8 +693,10 @@ public class QuestUtil {
         if(errorMessage != null) return errorMessage;
 
         //Check for this quest- and World's deck construction rules: allowed sets, banned/restricted cards etc
-        if(FModel.getQuest().getFormat() != null)
-            errorMessage = FModel.getQuest().getFormat().getDeckConformanceProblem(deck);
+        if (FModel.getQuestPreferences().getPrefInt(QuestPreferences.QPref.WORLD_RULES_CONFORMANCE) == 1) {
+            if(FModel.getQuest().getFormat() != null)
+                errorMessage = FModel.getQuest().getFormat().getDeckConformanceProblem(deck);
+        }
 
         return errorMessage;
     }

--- a/forge-gui/src/main/java/forge/gamemodes/quest/QuestUtil.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/QuestUtil.java
@@ -664,7 +664,7 @@ public class QuestUtil {
         }
 
         if (FModel.getPreferences().getPrefBoolean(FPref.ENFORCE_DECK_LEGALITY)) {
-            final String errorMessage = getDeckConformanceProblems(deck);
+            final String errorMessage = getDeckConformanceProblemsBeforeGame(deck);
             if (null != errorMessage) {
                 SOptionPane.showErrorDialog(localizer.getMessage("lblInvalidDeckDesc").replace("%n",errorMessage), "Invalid Deck");
                 return false;
@@ -674,9 +674,15 @@ public class QuestUtil {
         return true;
     }
 
-    public static String getDeckConformanceProblems(Deck deck){
+    public static String getDeckConformanceProblemsBeforeGame(Deck deck){
+        // Challenges with fixed decks override conformance settings
+        if(event instanceof QuestEventChallenge && ((QuestEventChallenge) event).getHumanDeck() != null)
+            return null;
+
+        //Check quest mode's generic deck construction rules: minimum cards in deck, sideboard etc
         String errorMessage = GameType.Quest.getDeckFormat().getDeckConformanceProblem(deck);
 
+        //Check the quest mode's generic deck construction rules: minimum cards in deck, sideboard etc
         if(errorMessage != null) return errorMessage; //return immediately if the deck does not conform to quest requirements
 
         //Check for all applicable deck construction rules per this quests's saved DeckConstructionRules enum
@@ -685,6 +691,11 @@ public class QuestUtil {
                 errorMessage = GameType.Commander.getDeckFormat().getDeckConformanceProblem(deck);
                 break;
         }
+        if(errorMessage != null) return errorMessage;
+
+        //Check for this quest- and World's deck construction rules: allowed sets, banned/restricted cards etc
+        if(FModel.getQuest().getFormat() != null)
+            errorMessage = FModel.getQuest().getFormat().getDeckConformanceProblem(deck);
 
         return errorMessage;
     }

--- a/forge-gui/src/main/java/forge/gamemodes/quest/QuestUtilCards.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/QuestUtilCards.java
@@ -561,7 +561,7 @@ public final class QuestUtilCards {
      * @return the predicate
      */
     public static Predicate<CardEdition> isLegalInQuestFormat(final GameFormatQuest qFormat) {
-        return GameFormatQuest.Predicates.isLegalInFormatQuest(qFormat);
+        return GameFormatQuest.QPredicates.isLegalInFormatQuest(qFormat);
     }
 
 

--- a/forge-gui/src/main/java/forge/gamemodes/quest/QuestWorld.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/QuestWorld.java
@@ -26,9 +26,12 @@ import java.util.Set;
 
 import com.google.common.base.Function;
 
+import forge.card.CardEdition;
 import forge.deck.Deck;
 import forge.game.GameFormat;
 import forge.gamemodes.quest.data.GameFormatQuest;
+import forge.gamemodes.quest.setrotation.ISetRotation;
+import forge.gamemodes.quest.setrotation.QueueRandomRotation;
 import forge.item.PaperCard;
 import forge.model.FModel;
 import forge.util.storage.StorageReaderFile;
@@ -46,6 +49,7 @@ public class QuestWorld implements Comparable<QuestWorld>{
     public static final String MODERNWORLDNAME = "Random Modern";
     public static final String RANDOMCOMMANDERWORLDNAME = "Random Commander";
     public static final String MAINWORLDNAME = "Main world";
+    public static final String EVOLVINGWILDSWORLDNAME = "Evolving Wilds";
 
     private boolean isCustom;
 
@@ -215,6 +219,20 @@ public class QuestWorld implements Comparable<QuestWorld>{
                 useFormat = new GameFormatQuest(QuestWorld.RANDOMCOMMANDERWORLDNAME,
                         FModel.getFormats().getFormat("Commander").getAllowedSetCodes(),
                         FModel.getFormats().getFormat("Commander").getBannedCardNames(),false);
+            }
+
+            if (useName.equalsIgnoreCase(QuestWorld.EVOLVINGWILDSWORLDNAME)){
+                ISetRotation rot = new QueueRandomRotation(6, 5, 1);
+                List<String> allowedCodes = new ArrayList<>();
+                for (CardEdition edition : FModel.getMagicDb().getEditionsTypeMap().get(CardEdition.Type.CORE)) {
+                    allowedCodes.add(edition.getCode());
+                }
+                for (CardEdition edition : FModel.getMagicDb().getEditionsTypeMap().get(CardEdition.Type.EXPANSION)) {
+                    allowedCodes.add(edition.getCode());
+                }
+                useFormat = new GameFormatQuest(QuestWorld.EVOLVINGWILDSWORLDNAME,
+                        allowedCodes,
+                        FModel.getFormats().getVintage().getBannedCardNames(),false, rot);
             }
 
             // System.out.println("Creating quest world " + useName + " (index " + useIdx + ", dir: " + useDir);

--- a/forge-gui/src/main/java/forge/gamemodes/quest/data/GameFormatQuest.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/data/GameFormatQuest.java
@@ -118,7 +118,7 @@ public final class GameFormatQuest extends GameFormat {
 		return unlocksUsed;
 	}
 
-	public abstract static class Predicates {
+	public abstract static class QPredicates {
 		/**
 		 * Checks if is legal in quest format.
 		 *

--- a/forge-gui/src/main/java/forge/gamemodes/quest/data/GameFormatQuest.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/data/GameFormatQuest.java
@@ -21,9 +21,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.google.common.base.Predicate;
-
 import forge.card.CardEdition;
 import forge.game.GameFormat;
+import forge.gamemodes.quest.setrotation.ISetRotation;
+import forge.item.PaperCard;
 import forge.model.FModel;
 
 
@@ -38,6 +39,31 @@ public final class GameFormatQuest extends GameFormat {
 	private final boolean allowUnlocks;
 	private int unlocksUsed = 0;
 
+	private ISetRotation setRotation;
+
+	@Override
+	public List<String> getAllowedSetCodes() {
+		if(setRotation != null)
+			return setRotation.getCurrentSetCodes(super.getAllowedSetCodes());
+		return super.getAllowedSetCodes();
+	}
+
+	@Override
+	public Predicate<PaperCard> getFilterRules() {
+		// Filter must be continuously rebuilt if the format is mutable
+		if(setRotation != null)
+			return super.buildFilter(false);
+		return super.getFilterRules();
+	}
+
+	@Override
+	public Predicate<PaperCard> getFilterPrinted() {
+		// Filter must be continuously rebuilt if the format is mutable
+		if(setRotation != null)
+			return super.buildFilter(true);
+		return super.getFilterRules();
+	}
+
 	/**
 	 * Instantiates a new game format based on two lists.
 	 *
@@ -48,11 +74,27 @@ public final class GameFormatQuest extends GameFormat {
 	public GameFormatQuest(final String newName, final List<String> setsToAllow, final List<String> cardsToBan) {
 		super(newName, setsToAllow, cardsToBan);
 		allowUnlocks = false;
+		setRotation = null;
 	}
 
 	public GameFormatQuest(final String newName, final List<String> setsToAllow, final List<String> cardsToBan, boolean allowSetUnlocks) {
 		super(newName, setsToAllow, cardsToBan);
 		allowUnlocks = allowSetUnlocks;
+		setRotation = null;
+	}
+
+	/**
+	 * Instantiates a format that uses an ISetRotation to automatically rotate sets in and out
+	 * @param newName
+	 * @param setsToAllow
+	 * @param cardsToBan
+	 * @param allowSetUnlocks
+	 * @param setRotation	  an ISetRotation that determines the currently allowed sets
+	 */
+	public GameFormatQuest(final String newName, final List<String> setsToAllow, final List<String> cardsToBan, boolean allowSetUnlocks, ISetRotation setRotation) {
+		super(newName, setsToAllow, cardsToBan);
+		allowUnlocks = allowSetUnlocks;
+		this.setRotation = setRotation;
 	}
 
 	/**
@@ -60,12 +102,14 @@ public final class GameFormatQuest extends GameFormat {
 	 *
 	 * @param toCopy          an existing format
 	 * @param allowSetUnlocks
+	 * @param setRotation
 	 */
-	public GameFormatQuest(final GameFormat toCopy, boolean allowSetUnlocks) {
+	public GameFormatQuest(final GameFormat toCopy, boolean allowSetUnlocks, ISetRotation setRotation) {
 		super(toCopy.getName(), toCopy.getEffectiveDate(), toCopy.getAllowedSetCodes(), toCopy.getBannedCardNames(), toCopy.getRestrictedCards(),
 				toCopy.isRestrictedLegendary(),toCopy.getAdditionalCards(), toCopy.getAllowedRarities(),
 				toCopy.getIndex(), FormatType.CUSTOM, FormatSubType.CUSTOM);
 		allowUnlocks = allowSetUnlocks;
+		this.setRotation = setRotation;
 	}
 
 	/**

--- a/forge-gui/src/main/java/forge/gamemodes/quest/data/QuestData.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/data/QuestData.java
@@ -100,7 +100,7 @@ public class QuestData {
         this.name = name0;
 
         if (userFormat != null) {
-            this.format = new GameFormatQuest(userFormat, allowSetUnlocks);
+            this.format = new GameFormatQuest(userFormat, allowSetUnlocks, null);
         }
         this.mode = mode0;
         this.achievements = new QuestAchievements(diff);

--- a/forge-gui/src/main/java/forge/gamemodes/quest/data/QuestPreferences.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/data/QuestPreferences.java
@@ -32,6 +32,8 @@ public class QuestPreferences extends PreferencesStore<QuestPreferences.QPref> i
      */
     public enum QPref {
 
+        // if enabled, player must follow world rules in duels (allowed sets only, banned/restricted cards etc.)
+        WORLD_RULES_CONFORMANCE("0"),
         // How many of each rarity comes in a won booster pack
         BOOSTER_COMMONS("11"),
         BOOSTER_UNCOMMONS("3"),
@@ -293,6 +295,7 @@ public class QuestPreferences extends PreferencesStore<QuestPreferences.QPref> i
                     return "Bias value too large (maximum 100).";
                 }
                 break;
+            case WORLD_RULES_CONFORMANCE:
             case DRAFT_ROTATION:
             case SPECIAL_BOOSTERS:
             case FOIL_FILTER_DEFAULT:

--- a/forge-gui/src/main/java/forge/gamemodes/quest/setrotation/ISetRotation.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/setrotation/ISetRotation.java
@@ -1,0 +1,11 @@
+package forge.gamemodes.quest.setrotation;
+
+import java.util.List;
+
+/**
+ * Supplies the current rotation of set codes based on the current quest state.
+ * Used for quest worlds that change their sets automatically over time.
+ */
+public interface ISetRotation {
+    public List<String> getCurrentSetCodes(List<String> allowedSetCodes);
+}

--- a/forge-gui/src/main/java/forge/gamemodes/quest/setrotation/QueueRandomRotation.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/setrotation/QueueRandomRotation.java
@@ -1,0 +1,48 @@
+package forge.gamemodes.quest.setrotation;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import forge.model.FModel;
+
+import static java.lang.Integer.min;
+
+/**
+ * A quest world rotation style where N random concurrent sets are available at any given time.
+ * S of these sets are rotated out after each set of W number of wins.
+ */
+public class QueueRandomRotation implements ISetRotation {
+
+    private int concurrentSets;
+    private int rotateAfterWins;
+    private int setsPerRotation;
+
+    @Override
+    public List<String> getCurrentSetCodes(List<String> allSets) {
+        if(FModel.getQuest() == null)
+            return allSets;
+
+        // Each unique quest (based on name) gets its own unique set order
+        int seed = FModel.getQuest().getName().hashCode();
+        Random rnd = new Random(seed);
+        List<String> shuffledSets = new ArrayList<>(allSets);
+        Collections.shuffle(shuffledSets, rnd);
+
+        List<String> currentCodes = new ArrayList<>();
+        int outRotations = FModel.getQuest().getAchievements().getWin() / rotateAfterWins;
+        int outRotated = outRotations * setsPerRotation;
+        int setsToAdd = min(concurrentSets, shuffledSets.size());
+        for (int i = 0; i < setsToAdd; i++) {
+            int setToAdd = (i + outRotated) % shuffledSets.size();
+            currentCodes.add(shuffledSets.get(setToAdd));
+        }
+        return currentCodes;
+    }
+
+    public QueueRandomRotation(int concurrentSets, int rotateAfterWins, int setsPerRotation){
+        this.concurrentSets = concurrentSets;
+        this.rotateAfterWins = rotateAfterWins;
+        this.setsPerRotation = setsPerRotation;
+    }
+}


### PR DESCRIPTION
Depends on #1794 being merged first.

Adds a new `ISetRotation` interface that can be used by `GameFormatQuest` to change the behavior of its own set legality checks. Adds the new quest world Evolving Wilds that uses such a combo of `GameFormatQuest` and `ISetRotation`. Basically, all core- and expansion sets are potentially legal in Evolving Wilds, but only a few at a time. After a certain number of wins, the oldest set(s) are rotated out and replaced with new ones. Both the starting sets and the rotation order is random and uses the quest name as seed.

Why?

In quest mode, I like the early game where I have to scramble a deck together and quickly upgrade it into something strong. At that point it gets a bit boring though, because it's more efficient to keep upgrading my already good deck than experimenting with new ones. Evolving Wilds "solves" this problem by forcing me to create new decks when my old ones get rotated out. At least in theory; this is quite experimental.

Feel free to give feedback on the idea or execution.