### PR TITLE
Add webp support for cards images

### DIFF
--- a/forge-core/pom.xml
+++ b/forge-core/pom.xml
@@ -23,6 +23,11 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.12.0</version>
         </dependency>
+        <dependency>
+            <groupId>io.github.zumikua</groupId>
+            <artifactId>webploader-common</artifactId>
+            <version>0.1.0</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/forge-core/src/main/java/forge/ImageKeys.java
+++ b/forge-core/src/main/java/forge/ImageKeys.java
@@ -66,7 +66,7 @@ public final class ImageKeys {
 
     // image file extensions for various formats in order of likelihood
     // the last, empty, string is for keys that come in with an extension already in place
-    private static final String[] FILE_EXTENSIONS = { ".jpg", ".png", "" };
+    private static final String[] FILE_EXTENSIONS = { ".jpg", ".png", "webp", "" };
 
     public static String getTokenKey(String tokenName) {
         return ImageKeys.TOKEN_PREFIX + tokenName;
@@ -362,11 +362,11 @@ public final class ImageKeys {
                 HashSet<String> setFolderContent = new HashSet<>();
                 for (String filename : Arrays.asList(f.list())) {
                     // TODO: should this use FILE_EXTENSIONS ?
-                    if (!filename.endsWith(".jpg") && !filename.endsWith(".png"))
+                    if (!filename.endsWith(".jpg") && !filename.endsWith(".png") && !filename.endsWith(".webp"))
                         continue;  // not image - not interested
                     setFolderContent.add(filename.split("\\.")[0]);  // get rid of any full or fullborder
                     //preload cachedCards at startUp
-                    String key = setFolder + "/" + filename.replace(".fullborder", ".full").replace(".jpg", "").replace(".png", "");
+                    String key = setFolder + "/" + filename.replace(".fullborder", ".full").replace(".jpg", "").replace(".png", "").replace(".webp", "");
                     File value = new File(CACHE_CARD_PICS_DIR + setFolder + "/" + filename);
                     cachedCards.put(key, value);
                 }

--- a/forge-gui-android/pom.xml
+++ b/forge-gui-android/pom.xml
@@ -179,6 +179,12 @@
             <version>2.2.3-SNAPSHOT</version>
             <type>aar</type>
         </dependency>
+        <dependency>
+            <groupId>io.github.zumikua</groupId>
+            <artifactId>webploader-android</artifactId>
+            <version>0.1.0</version>
+            <type>aar</type>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/forge-gui-desktop/pom.xml
+++ b/forge-gui-desktop/pom.xml
@@ -273,7 +273,12 @@
         <dependency>
             <groupId>com.twelvemonkeys.imageio</groupId>
             <artifactId>imageio-jpeg</artifactId>
-            <version>3.7.0</version>
+            <version>3.9.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.twelvemonkeys.imageio</groupId>
+            <artifactId>imageio-webp</artifactId>
+            <version>3.9.3</version>
         </dependency>
     </dependencies>
 

--- a/forge-gui-desktop/pom.xml
+++ b/forge-gui-desktop/pom.xml
@@ -272,12 +272,12 @@
         </dependency>
         <dependency>
             <groupId>com.twelvemonkeys.imageio</groupId>
-            <artifactId>imageio-jpeg</artifactId>
+            <artifactId>imageio-webp</artifactId>
             <version>3.9.3</version>
         </dependency>
         <dependency>
             <groupId>com.twelvemonkeys.imageio</groupId>
-            <artifactId>imageio-webp</artifactId>
+            <artifactId>imageio-jpeg</artifactId>
             <version>3.9.3</version>
         </dependency>
     </dependencies>

--- a/forge-gui-desktop/src/main/java/forge/gui/ImportSourceAnalyzer.java
+++ b/forge-gui-desktop/src/main/java/forge/gui/ImportSourceAnalyzer.java
@@ -421,7 +421,8 @@ public class ImportSourceAnalyzer {
                 if (validFilenames.containsKey(filename)) {
                     return validFilenames.get(filename);
                 } else if (StringUtils.endsWithIgnoreCase(filename, ".jpg")
-                        || StringUtils.endsWithIgnoreCase(filename, ".png")) {
+                        || StringUtils.endsWithIgnoreCase(filename, ".png")
+                        || StringUtils.endsWithIgnoreCase(filename, ".webp")) {
                     return filename;
                 }
                 return null;

--- a/forge-gui-mobile/src/forge/assets/WebpLoader.java
+++ b/forge-gui-mobile/src/forge/assets/WebpLoader.java
@@ -1,0 +1,38 @@
+package forge.assets;
+
+import com.badlogic.gdx.assets.AssetManager;
+import com.badlogic.gdx.graphics.Texture;
+import io.github.zumikua.webploader.common.WebPLoaderFactory;
+import io.github.zumikua.webploader.common.WebPLoaderNativeInterface;
+import io.github.zumikua.webploader.common.WebPTextureFactory;
+import io.github.zumikua.webploader.common.WebPTextureLoader;
+
+/**
+ *
+ */
+public class WebpLoader  {
+
+    private final WebPTextureFactory textureFactory;
+
+    /**
+     *
+     * @param nativeInterface
+     */
+    public WebpLoader(WebPLoaderNativeInterface nativeInterface) {
+        WebPLoaderFactory mFactory = new WebPLoaderFactory(nativeInterface);
+        textureFactory = mFactory.getTextureFactory();
+    }
+
+    /**
+     * Load the webp file into Texture file.
+     * @param filename Webp image file
+     * @return Texture file load
+     */
+    public Texture load(String filename) {
+        AssetManager mAssetManager = new AssetManager();
+        mAssetManager.setLoader(Texture.class, ".webp", new WebPTextureLoader(mAssetManager.getFileHandleResolver(), textureFactory));
+        mAssetManager.load(filename, Texture.class);
+        mAssetManager.finishLoading();
+        return mAssetManager.get(filename, Texture.class);
+    }
+}

--- a/forge-gui-mobile/src/forge/card/CardRenderer.java
+++ b/forge-gui-mobile/src/forge/card/CardRenderer.java
@@ -219,7 +219,7 @@ public class CardRenderer {
 
     public static FImageComplex getCardArt(String imageKey, boolean isSplitCard, boolean isHorizontalCard, boolean isAftermathCard, boolean isSaga, boolean isClass, boolean isDungeon, boolean isFlipCard, boolean isPlanesWalker, boolean isModernFrame) {
         FImageComplex cardArt = Forge.getAssets().cardArtCache().get(imageKey);
-        boolean isClassicModule = imageKey != null && imageKey.length() > 2 && classicModuleCardtoCrop.contains(imageKey.substring(ImageKeys.CARD_PREFIX.length()).replace(".jpg", "").replace(".png", ""));
+        boolean isClassicModule = imageKey != null && imageKey.length() > 2 && classicModuleCardtoCrop.contains(imageKey.substring(ImageKeys.CARD_PREFIX.length()).replace(".jpg", "").replace(".png", "").replace(".webp", ""));
         if (cardArt == null) {
             Texture image = new RendererCachedCardImage(imageKey, true).getImage();
             if (image != null) {

--- a/forge-gui/release-files/CONTRIBUTORS.txt
+++ b/forge-gui/release-files/CONTRIBUTORS.txt
@@ -1,3 +1,4 @@
+add-le
 Agetian
 Alumi
 Aoki-Kujo


### PR DESCRIPTION
Add support webp format to the cards images :
Give 25% to 50% smaller image size for same quality as jpg.
Can reduce the cache folder to 25% to 50% its size, for android support can be a good idea.

https://developers.google.com/speed/webp
https://developers.google.com/speed/webp/docs/webp_study

If you find the good settings to convert all superLQ's kevlahnota to webp, without losing much quality, you can achieve near to 30-35% reduce size.

- [ ] Need to check if it's work for token and crop images too

Resolves #643