### PR TITLE
Fix RememberCountered when replaced

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
@@ -2599,12 +2599,11 @@ public class AbilityUtils {
 
         // Count$Chroma.<color name>
         if (sq[0].startsWith("Chroma")) {
-            ZoneType sourceZone = sq[0].contains("ChromaInGrave") ?  ZoneType.Graveyard : ZoneType.Battlefield;
             final CardCollectionView cards;
             if (sq[0].contains("ChromaSource")) { // Runs Chroma for passed in Source card
                 cards = new CardCollection(c);
-            }
-            else {
+            } else {
+                ZoneType sourceZone = sq[0].contains("ChromaInGrave") ?  ZoneType.Graveyard : ZoneType.Battlefield;
                 cards = player.getCardsIn(sourceZone);
             }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/CounterEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CounterEffect.java
@@ -120,7 +120,15 @@ public class CounterEffect extends SpellAbilityEffect {
                 continue;
             }
 
-            removeFromStack(tgtSA, sa, si, table);
+            if (sa.hasParam("RememberSplicedOntoCounteredSpell")) {
+                if (tgtSA.getSplicedCards() != null) {
+                    sa.getHostCard().addRemembered(tgtSA.getSplicedCards());
+                }
+            }
+
+            if (!removeFromStack(tgtSA, sa, si, table)) {
+                continue;
+            }
 
             // Destroy Permanent may be able to be turned into a SubAbility
             if (tgtSA.isAbility() && sa.hasParam("DestroyPermanent")) {
@@ -129,12 +137,6 @@ public class CounterEffect extends SpellAbilityEffect {
 
             if (sa.hasParam("RememberCountered")) {
                 sa.getHostCard().addRemembered(tgtSACard);
-            }
-
-            if (sa.hasParam("RememberSplicedOntoCounteredSpell")) {
-                if (tgtSA.getSplicedCards() != null) {
-                    sa.getHostCard().addRemembered(tgtSA.getSplicedCards());
-                }
             }
         }
         table.triggerChangesZoneAll(game, sa);
@@ -269,7 +271,7 @@ public class CounterEffect extends SpellAbilityEffect {
      *            a {@link forge.game.spellability.SpellAbilityStackInstance}
      *            object.
      */
-    private static void removeFromStack(final SpellAbility tgtSA, final SpellAbility srcSA, final SpellAbilityStackInstance si, CardZoneTable triggerList) {
+    private static boolean removeFromStack(final SpellAbility tgtSA, final SpellAbility srcSA, final SpellAbilityStackInstance si, CardZoneTable triggerList) {
         final Game game = tgtSA.getActivatingPlayer().getGame();
         Card movedCard = null;
         final Card c = tgtSA.getHostCard();
@@ -280,7 +282,7 @@ public class CounterEffect extends SpellAbilityEffect {
         repParams.put(AbilityKey.TgtSA, tgtSA);
         repParams.put(AbilityKey.Cause, srcSA.getHostCard());
         if (game.getReplacementHandler().run(ReplacementType.Counter, repParams) != ReplacementResult.NotReplaced) {
-            return;
+            return false;
         }
         game.getStack().remove(si);
 
@@ -340,6 +342,7 @@ public class CounterEffect extends SpellAbilityEffect {
         if (originZone != null && movedCard != null) {
             triggerList.put(originZone.getZoneType(), movedCard.getZone().getZoneType(), movedCard);
         }
+        return true;
     }
 
 }

--- a/forge-game/src/main/java/forge/game/ability/effects/RepeatEachEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/RepeatEachEffect.java
@@ -65,7 +65,7 @@ public class RepeatEachEffect extends SpellAbilityEffect {
         }
         else if (sa.hasParam(("RepeatSpellAbilities"))) {
             repeatSas = Lists.newArrayList();
-            String[] restrictions = sa.getParam("RepeatSpellAbilities").split((","));
+            String[] restrictions = sa.getParam("RepeatSpellAbilities").split(",");
             for (SpellAbilityStackInstance stackInstance : game.getStack()) {
                 if (stackInstance.getSpellAbility(false).isValid(restrictions, source.getController(), source, sa)) {
                     repeatSas.add(stackInstance.getSpellAbility(false));

--- a/forge-gui/res/cardsfolder/a/absorb_energy.txt
+++ b/forge-gui/res/cardsfolder/a/absorb_energy.txt
@@ -1,7 +1,7 @@
 Name:Absorb Energy
 ManaCost:1 U U
 Types:Instant
-A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | RememberCountered$ True | SubAbility$ DBEffect | SpellDescription$ Counter target spell.
+A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | RememberTargets$ True | SubAbility$ DBEffect | SpellDescription$ Counter target spell.
 SVar:DBEffect:DB$ Effect | ImprintCards$ Remembered | RememberObjects$ ValidHand Card.YouOwn+sharesCardTypeWith RememberedLKI | StaticAbilities$ PerpetualAbility | Duration$ Permanent | Triggers$ Update | Name$ Absorb Energy's Perpetual Effect | SubAbility$ DBCleanup | SpellDescription$ Cards in your hand that share a card type with that spell perpetually gain "This spell costs {1} less to cast."
 SVar:PerpetualAbility:Mode$ Continuous | Affected$ Card.IsRemembered | AddStaticAbility$ PerpetualReduceCost | EffectZone$ Command | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | Description$ Cards in your hand that share a card type with that [imprinted] spell perpetually gain "This spell costs {1} less to cast."
 SVar:PerpetualReduceCost:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 1 | EffectZone$ All | Description$ This spell costs {1} less to cast.

--- a/forge-gui/res/cardsfolder/a/arcane_denial.txt
+++ b/forge-gui/res/cardsfolder/a/arcane_denial.txt
@@ -1,7 +1,7 @@
 Name:Arcane Denial
 ManaCost:1 U
 Types:Instant
-A:SP$ Counter | Cost$ 1 U | TargetType$ Spell | TgtPrompt$ Select target spell | RememberCountered$ True | ValidTgts$ Card | SubAbility$ DelTrigSlowtrip | SpellDescription$ Counter target spell. Its controller may draw up to two cards at the beginning of the next turn's upkeep. You draw a card at the beginning of the next turn's upkeep.
+A:SP$ Counter | Cost$ 1 U | TargetType$ Spell | TgtPrompt$ Select target spell | RememberTargets$ True | ValidTgts$ Card | SubAbility$ DelTrigSlowtrip | SpellDescription$ Counter target spell. Its controller may draw up to two cards at the beginning of the next turn's upkeep. You draw a card at the beginning of the next turn's upkeep.
 SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | SubAbility$ DelTrigDrawTwo | TriggerDescription$ Draw a card.
 SVar:DrawSlowtrip:DB$ Draw | Defined$ You
 SVar:DelTrigDrawTwo:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | RememberObjects$ RememberedController | Execute$ DrawTwo | TriggerDescription$ Draw up to two cards. | SubAbility$ DBCleanup

--- a/forge-gui/res/cardsfolder/b/bottled_cloister.txt
+++ b/forge-gui/res/cardsfolder/b/bottled_cloister.txt
@@ -4,7 +4,7 @@ Types:Artifact
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Opponent | Execute$ TrigExile | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of each opponent's upkeep, exile all cards from your hand face down.
 SVar:TrigExile:DB$ ChangeZoneAll | Origin$ Hand | Destination$ Exile | ExileFaceDown$ True | ChangeType$ Card.YouCtrl | RememberChanged$ True
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ TrigReturn | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, return all cards you own exiled with CARDNAME to your hand, then draw a card.
-SVar:TrigReturn:DB$ ChangeZoneAll | Origin$ Exile | Destination$ Hand | ChangeType$ Card.IsRemembered | SubAbility$ DBDraw
+SVar:TrigReturn:DB$ ChangeZoneAll | Origin$ Exile | Destination$ Hand | ChangeType$ Card.IsRemembered+YouOwn | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:At the beginning of each opponent's upkeep, exile all cards from your hand face down.\nAt the beginning of your upkeep, return all cards you own exiled with Bottled Cloister to your hand, then draw a card.

--- a/forge-gui/res/cardsfolder/h/heroism.txt
+++ b/forge-gui/res/cardsfolder/h/heroism.txt
@@ -1,11 +1,9 @@
 Name:Heroism
 ManaCost:2 W
 Types:Enchantment
-A:AB$ RepeatEach | Cost$ Sac<1/Creature.White/White Creature> | RepeatCards$ Creature.attacking+Red | UseImprinted$ True | RepeatSubAbility$ DBPump | SubAbility$ DBEffect | SpellDescription$ For each attacking red creature, prevent all combat damage that would be dealt by that creature this turn unless its controller pays {2}{R}.
-SVar:DBPump:DB$ Pump | RememberObjects$ Imprinted | UnlessCost$ 2 R | UnlessPayer$ ImprintedController | ShowCurrentCard$ Imprinted
-SVar:DBEffect:DB$ Effect | ReplacementEffects$ RPrevent | RememberObjects$ Remembered | ForgetOnMoved$ Battlefield | SubAbility$ DBCleanup
+A:AB$ RepeatEach | Cost$ Sac<1/Creature.White/White Creature> | RepeatCards$ Creature.attacking+Red | RepeatSubAbility$ DBEffect | SubAbility$ DBEffect | SpellDescription$ For each attacking red creature, prevent all combat damage that would be dealt by that creature this turn unless its controller pays {2}{R}.
+SVar:DBEffect:DB$ Effect | ReplacementEffects$ RPrevent | RememberObjects$ Remembered | ForgetOnMoved$ Battlefield | UnlessCost$ 2 R | UnlessPayer$ RememberedController | ShowCurrentCard$ Remembered
 SVar:RPrevent:Event$ DamageDone | Prevent$ True | IsCombat$ True | ValidSource$ Card.IsRemembered | Description$ Prevent all combat damage that would be dealt by that creature.
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:AIPreference:SacCost$Creature.token
 AI:RemoveDeck:Random
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/k/king_narfis_betrayal.txt
+++ b/forge-gui/res/cardsfolder/k/king_narfis_betrayal.txt
@@ -8,6 +8,6 @@ SVar:DBChooseCard:DB$ ChooseCard | Defined$ You | Choices$ Creature.RememberedPl
 SVar:DBExile:DB$ ChangeZoneAll | Origin$ Graveyard | Destination$ Exile | ChangeType$ Card.IsRemembered
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearChosenCard$ True
 SVar:DBEffect:DB$ Effect | StaticAbilities$ PlayExile | SpellDescription$ Until end of turn, you may cast spells from among cards exiled with CARDNAME, and you may spend mana as though it were mana of any color to cast those spells.
-SVar:PlayExile:Mode$ Continuous | MayPlayIgnoreType$ True | MayPlayIgnoreColor$ True | MayPlay$ True | Affected$ Card.ExiledWithEffectSource | AffectedZone$ Exile | Description$ You may play cards exiled with EFFECTSOURCE, and you may spend mana as though it were mana of any color to cast those spells.
+SVar:PlayExile:Mode$ Continuous | MayPlayIgnoreType$ True | MayPlayIgnoreColor$ True | MayPlay$ True | Affected$ Card.ExiledWithEffectSource+nonLand | AffectedZone$ Exile | Description$ You may play cards exiled with EFFECTSOURCE, and you may spend mana as though it were mana of any color to cast those spells.
 DeckHas:Ability$Mill
 Oracle:(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI — Each player mills four cards. Then you may exile a creature or planeswalker card from each graveyard.\nII, III — Until end of turn, you may cast spells from among cards exiled with King Narfi's Betrayal, and you may spend mana as though it were mana of any color to cast those spells.

--- a/forge-gui/res/cardsfolder/m/moonring_mirror.txt
+++ b/forge-gui/res/cardsfolder/m/moonring_mirror.txt
@@ -5,7 +5,7 @@ T:Mode$ Drawn | ValidCard$ Card.YouCtrl | TriggerZones$ Battlefield | Execute$ T
 SVar:TrigExile:DB$ Dig | DigNum$ 1 | ChangeNum$ All | Defined$ You | DestinationZone$ Exile | ExileFaceDown$ True | RememberChanged$ True
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigChangeHandExile | TriggerDescription$ At the beginning of your upkeep, you may exile all cards from your hand face down. If you do, put all other cards you own exiled with CARDNAME into your hand.
 SVar:TrigChangeHandExile:DB$ ChangeZoneAll | Origin$ Hand | Destination$ Exile | ExileFaceDown$ True | ChangeType$ Card.YouCtrl | RememberChanged$ True | Imprint$ True | SubAbility$ ChangeBack
-SVar:ChangeBack:DB$ ChangeZoneAll | ChangeType$ Card.IsRemembered+IsNotImprinted+ExiledWithSource | Origin$ Exile | Destination$ Hand | ForgetChanged$ True | SubAbility$ DBCleanup
+SVar:ChangeBack:DB$ ChangeZoneAll | ChangeType$ Card.IsRemembered+IsNotImprinted+ExiledWithSource+YouOwn | Origin$ Exile | Destination$ Hand | ForgetChanged$ True | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearImprinted$ True
 T:Mode$ ChangesZone | Origin$ Exile | Destination$ Any | Static$ True | ValidCard$ Card.IsRemembered+ExiledWithSource | Execute$ DBForget
 SVar:DBForget:DB$ Pump | ForgetObjects$ TriggeredCard

--- a/forge-gui/res/cardsfolder/s/serpents_soul_jar.txt
+++ b/forge-gui/res/cardsfolder/s/serpents_soul_jar.txt
@@ -4,6 +4,6 @@ Types:Artifact
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Elf.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigChange | TriggerDescription$ Whenever an Elf you control dies, exile it.
 SVar:TrigChange:DB$ ChangeZone | Defined$ TriggeredCard | Origin$ Graveyard | Destination$ Exile
 A:AB$ Effect | Cost$ T PayLife<2> | StaticAbilities$ MayCast | SpellDescription$ Until end of turn, you may cast a creature spell from among cards exiled with CARDNAME.
-SVar:MayCast:Mode$ Continuous | Affected$ Creature.ExiledWithEffectSource | MayPlay$ True | AffectedZone$ Exile | MayPlayLimit$ 1 | Description$ Until end of turn, you may cast a creature spell from among cards exiled with CARDNAME.
+SVar:MayCast:Mode$ Continuous | Affected$ Creature.ExiledWithEffectSource+nonLand | MayPlay$ True | AffectedZone$ Exile | MayPlayLimit$ 1 | Description$ Until end of turn, you may cast a creature spell from among cards exiled with CARDNAME.
 DeckNeeds:Type$Elf
 Oracle:Whenever an Elf you control dies, exile it.\n{T}, Pay 2 life: Until end of turn, you may cast a creature spell from among cards exiled with Serpent's Soul-Jar.

--- a/forge-gui/res/cardsfolder/t/tasha_the_witch_queen.txt
+++ b/forge-gui/res/cardsfolder/t/tasha_the_witch_queen.txt
@@ -3,7 +3,7 @@ ManaCost:3 U B
 Types:Legendary Planeswalker Tasha
 Loyalty:4
 Text:CARDNAME can be your commander.
-T:Mode$ SpellCast | ValidCard$ Card.OppOwn | ValidActivatingPlayer$ You | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a spell you don't own, create a 3/3 black Demon creature token.
+T:Mode$ SpellCast | ValidCard$ Card.YouDontOwn | ValidActivatingPlayer$ You | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a spell you don't own, create a 3/3 black Demon creature token.
 SVar:TrigToken:DB$ Token | TokenOwner$ You | TokenAmount$ 1 | TokenScript$ b_3_3_demon
 A:AB$ Draw | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | Defined$ You | NumCards$ 1 | SubAbility$ DBExileForEach | SpellDescription$ Draw a card. For each opponent, exile up to one target instant or sorcery card from that player's graveyard and put a page counter on it.
 SVar:DBExileForEach:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | ValidTgts$ Instant.OppCtrl,Sorcery.OppCtrl | TgtPrompt$ Choose up to one target instant or sorcery card in each opponent's graveyard | TargetMin$ 0 | TargetMax$ OneEach | TargetsWithDifferentControllers$ True | WithCountersType$ PAGE

--- a/forge-gui/res/cardsfolder/t/tibalts_trickery.txt
+++ b/forge-gui/res/cardsfolder/t/tibalts_trickery.txt
@@ -1,7 +1,7 @@
 Name:Tibalt's Trickery
 ManaCost:1 R
 Types:Instant
-A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | SubAbility$ DBRandom | Destination$ Graveyard | RememberCountered$ True | StackDescription$ SpellDescription | SpellDescription$ Counter target spell. Choose 1, 2, or 3 at random. Its controller mills that many cards, then exiles cards from the top of their library until they exile a nonland card with a different name than that spell. They may cast that card without paying its mana cost. Then they put the exiled cards on the bottom of their library in a random order.
+A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | SubAbility$ DBRandom | Destination$ Graveyard | RememberTargets$ True | StackDescription$ SpellDescription | SpellDescription$ Counter target spell. Choose 1, 2, or 3 at random. Its controller mills that many cards, then exiles cards from the top of their library until they exile a nonland card with a different name than that spell. They may cast that card without paying its mana cost. Then they put the exiled cards on the bottom of their library in a random order.
 SVar:DBRandom:DB$ ChooseNumber | Min$ 1 | Max$ 3 | Defined$ You | Random$ True | SubAbility$ DBMill | StackDescription$ None
 SVar:DBMill:DB$ Mill | NumCards$ X | Defined$ TargetedController | SubAbility$ DBDig | StackDescription$ None
 SVar:DBDig:DB$ DigUntil | Defined$ TargetedController | Valid$ Card.nonLand+doesNotShareNameWith Remembered | FoundDestination$ Exile | RevealedDestination$ Exile | RememberFound$ True | ForgetOtherRemembered$ True | ImprintRevealed$ True | SubAbility$ DBPlay | StackDescription$ None

--- a/forge-gui/res/cardsfolder/upcoming/titania_natures_force.txt
+++ b/forge-gui/res/cardsfolder/upcoming/titania_natures_force.txt
@@ -5,8 +5,8 @@ PT:6/6
 S:Mode$ Continuous | Affected$ Forest.YouOwn | MayPlay$ True | AffectedZone$ Graveyard | Description$ You may play Forests from your graveyard.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Forest.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever a Forest enters the battlefield under your control, create a 5/3 green Elemental creature token.
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ g_5_3_elemental | TokenOwner$ You
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Elemental.YouCtrl | OptionalDecider$ You | Execute$ TrigMill | TriggerDescription$ Whenever an Elemental you control dies, you may mill three cards.
-SVar:TrigMill:DB$ Mill | NumCards$ 3 | Defined$ You
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Elemental.YouCtrl | Execute$ TrigMill | TriggerDescription$ Whenever an Elemental you control dies, you may mill three cards.
+SVar:TrigMill:DB$ Mill | NumCards$ 3 | Defined$ You | Optional$ True
 SVar:BuffedBy:Forest
 DeckHints:Type$Elemental
 DeckHas:Ability$Graveyard|Mill

--- a/forge-gui/res/cardsfolder/w/witch_hunter.txt
+++ b/forge-gui/res/cardsfolder/w/witch_hunter.txt
@@ -3,6 +3,6 @@ ManaCost:2 W W
 Types:Creature Human Cleric
 PT:1/1
 A:AB$ DealDamage | Cost$ T | NumDmg$ 1 | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | SpellDescription$ CARDNAME deals 1 damage to target player.
-A:AB$ ChangeZone | Cost$ 1 W W T | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return target creature you don't control to its owner's hand.
+A:AB$ ChangeZone | Cost$ 1 W W T | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return target creature an opponent controls to its owner's hand.
 SVar:NonCombatPriority:1
 Oracle:{T}: Witch Hunter deals 1 damage to target player or planeswalker.\n{1}{W}{W}, {T}: Return target creature an opponent controls to its owner's hand.


### PR DESCRIPTION
This is so you don't get to draw cards from _Swift Silence_ if you also control _Guile_.