### PR TITLE
2022 Commander decks

### DIFF
--- a/forge-gui/res/quest/commanderprecons/Buckle Up [NEC] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Buckle Up [NEC] [2022].dck
@@ -1,0 +1,78 @@
+[metadata]
+Name=Buckle Up [NEC] [2022]
+[Commander]
+1 Kotori, Pilot Prodigy|NEC|1
+[Main]
+1 Access Denied|NEC|1
+1 Aerial Surveyor|NEC|1
+1 Aeronaut Admiral|NEC|1
+1 Arcane Signet|NEC|1
+1 Arcanist's Owl|NEC|1
+1 Armed and Armored|NEC|1
+1 Azorius Signet|NEC|1
+1 Cataclysmic Gearhulk|NEC|1
+1 Colossal Plow|NEC|1
+1 Command Tower|NEC|1
+1 Crush Contraband|NEC|1
+1 Cultivator's Caravan|NEC|1
+1 Cyberdrive Awakener|NEC|1
+1 Dance of the Manse|NEC|1
+1 Dispatch|NEC|1
+1 Drumbellower|NEC|1
+1 Emry, Lurker of the Loch|NEC|1
+1 Etherium Sculptor|NEC|1
+1 Exotic Orchard|NEC|1
+1 Fellwar Stone|NEC|1
+1 Foundry Inspector|NEC|1
+1 Generous Gift|NEC|1
+1 Gold Myr|NEC|1
+1 Hanna, Ship's Navigator|NEC|1
+1 Imperial Recovery Unit|NEO|1
+1 Imposter Mech|NEC|1
+1 Indomitable Archangel|NEC|1
+1 Ironsoul Enforcer|NEC|1
+15 Island|NEO|1
+1 Jace, Architect of Thought|NEC|1
+1 Kappa Cannoneer|NEC|1
+1 Katsumasa, the Animator|NEC|1
+1 Master of Etherium|NEC|1
+1 Mirage Mirror|NEC|1
+1 Mobilizer Mech|NEO|1
+1 Myrsmith|NEC|1
+1 Organic Extinction|NEC|1
+1 Parhelion II|NEC|1
+1 Peacewalker Colossus|NEC|1
+15 Plains|NEO|1
+1 Port Town|NEC|1
+1 Prairie Stream|NEC|1
+1 Prodigy's Prototype|NEO|1
+1 Raff Capashen, Ship's Mage|NEC|1
+1 Raiders' Karve|NEC|1
+1 Reality Shift|NEC|1
+1 Release to Memory|NEC|1
+1 Research Thief|NEC|1
+1 Riddlesmith|NEC|1
+1 Sai, Master Thopterist|NEC|1
+1 Shimmer Myr|NEC|1
+1 Shorikai, Genesis Engine|NEC|1
+1 Silver Myr|NEC|1
+1 Skycloud Expanse|NEC|1
+1 Skysovereign, Consul Flagship|NEC|1
+1 Smuggler's Copter|NEC|1
+1 Sol Ring|NEC|1
+1 Solemn Simulacrum|NEC|1
+1 Spire of Industry|NEC|1
+1 Sram, Senior Edificer|NEC|1
+1 Surgehacker Mech|NEO|1
+1 Swift Reconfiguration|NEC|1
+1 Swords to Plowshares|NEC|1
+1 Temple of Enlightenment|NEC|1
+1 Teshar, Ancestor's Apostle|NEC|1
+1 Thopter Spy Network|NEC|1
+1 Thoughtcast|NEC|1
+1 Universal Surveillance|NEC|1
+1 Vedalken Engineer|NEC|1
+1 Weatherlight|NEC|1
+1 Whirler Rogue|NEC|1
+[Sideboard]
+

--- a/forge-gui/res/quest/commanderprecons/Cabaretti Cacophony [NCC] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Cabaretti Cacophony [NCC] [2022].dck
@@ -1,0 +1,93 @@
+[metadata]
+Name=Cabaretti Cacophony [NCC] [2022]
+[Commander]
+1 Kitt Kanto, Mayhem Diva|NCC|1
+[Main]
+1 Agitator Ant|NCC|1
+1 Arasta of the Endless Web|NCC|1
+1 Arcane Signet|NCC|1
+1 Artifact Mutation|NCC|1
+1 Ash Barrens|NCC|1
+1 Assemble the Legion|NCC|1
+1 Aura Mutation|NCC|1
+1 Awakening Zone|NCC|1
+1 Beast Within|NCC|1
+1 Beastmaster Ascension|NCC|1
+1 Bess, Soul Nourisher|NCC|1
+1 Bloodthirsty Blade|NCC|1
+1 Boros Charm|NCC|1
+1 Boss's Chauffeur|NCC|1
+1 Cabaretti Charm|SNC|1
+1 Cabaretti Confluence|NCC|1
+1 Cabaretti Courtyard|SNC|1
+1 Call the Coppercoats|NCC|1
+1 Camaraderie|NCC|1
+1 Canopy Vista|NCC|1
+1 Castle Ardenvale|NCC|1
+1 Castle Embereth|NCC|1
+1 Champion of Lambholt|NCC|1
+1 Cinder Glade|NCC|1
+1 Command Tower|NCC|1
+1 Commander's Sphere|NCC|1
+1 Crash the Party|NCC|1
+1 Cultivate|NCC|1
+1 Duelist's Heritage|NCC|1
+1 Exotic Orchard|NCC|1
+1 False Floor|NCC|1
+1 Felidar Retreat|NCC|1
+1 Fell the Mighty|NCC|1
+1 Fellwar Stone|NCC|1
+8 Forest|SNC|1
+1 Fortified Village|NCC|1
+1 Gahiji, Honored One|NCC|1
+1 Game Trail|NCC|1
+1 Grand Crescendo|NCC|1
+1 Harmonize|NCC|1
+1 Idol of Oblivion|NCC|1
+1 Indulge // Excess|NCC|1
+1 Intangible Virtue|NCC|1
+1 Jungle Shrine|NCC|1
+1 Kazuul, Tyrant of the Cliffs|NCC|1
+1 Killer Service|NCC|1
+1 Leafkin Druid|NCC|1
+1 Life of the Party|NCC|1
+1 Magus of the Wheel|NCC|1
+1 March of the Multitudes|NCC|1
+1 Martial Coup|NCC|1
+1 Master of Ceremonies|NCC|1
+1 Mossfire Valley|NCC|1
+4 Mountain|SNC|1
+1 Myriad Landscape|NCC|1
+1 Naya Panorama|NCC|1
+1 Orzhov Advokist|NCC|1
+1 Outpost Siege|NCC|1
+1 Path of Ancestry|NCC|1
+1 Path to Exile|NCC|1
+1 Phabine, Boss's Confidant|NCC|1
+4 Plains|SNC|1
+1 Prosperous Partnership|NCC|1
+1 Rose Room Treasurer|NCC|1
+1 Rugged Prairie|NCC|1
+1 Rumor Gatherer|SNC|1
+1 Sakura-Tribe Elder|NCC|1
+1 Sandwurm Convergence|NCC|1
+1 Scepter of Celebration|NCC|1
+1 Scute Swarm|NCC|1
+1 Seize the Spotlight|NCC|1
+1 Selvala, Explorer Returned|NCC|1
+1 Shamanic Revelation|NCC|1
+1 Sizzling Soloist|SNC|1
+1 Sol Ring|NCC|1
+1 Sungrass Prairie|NCC|1
+1 Sylvan Offering|NCC|1
+1 Temple of Triumph|NCC|1
+1 Thriving Bluff|NCC|1
+1 Thriving Grove|NCC|1
+1 Thriving Heath|NCC|1
+1 Thunderfoot Baloth|NCC|1
+1 Vivien's Stampede|NCC|1
+1 Windbrisk Heights|NCC|1
+1 Wood Elves|NCC|1
+1 Zurzoth, Chaos Rider|NCC|1
+[Sideboard]
+

--- a/forge-gui/res/quest/commanderprecons/Draconic Dissent [CLB] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Draconic Dissent [CLB] [2022].dck
@@ -1,0 +1,84 @@
+[metadata]
+Name=Draconic Dissent [CLB] [2022]
+[Commander]
+1 Firkraag, Cunning Instigator|CLB|2
+[Main]
+1 Aether Gale|CLB|1
+1 Agitator Ant|CLB|1
+1 Angler Turtle|CLB|1
+1 Arcane Signet|CLB|1
+1 Artificer Class|CLB|1
+1 Ash Barrens|CLB|1
+1 Astral Dragon|CLB|2
+1 Avatar of Slaughter|CMA|1
+1 Baeloth Barrityl, Entertainer|CLB|2
+1 Blasphemous Act|CLB|1
+1 Bloodthirsty Blade|CLB|1
+1 Bothersome Quasit|CLB|2
+1 Brash Taunter|CLB|1
+1 Burnished Hart|CLB|1
+1 Castle Vantress|CLB|1
+1 Chain Reaction|CLB|1
+1 Chaos Dragon|CLB|1
+1 Chaos Warp|CLB|1
+1 Clan Crafter|CLB|2
+1 Command Tower|CLB|1
+1 Compulsive Research|CLB|1
+1 Curse of Opulence|CLB|1
+1 Curse of the Swine|CLB|1
+1 Curse of Verbosity|CLB|1
+1 Death Kiss|CLB|2
+1 Desolate Lighthouse|CLB|1
+1 Disrupt Decorum|CLB|1
+1 Dissipation Field|CLB|1
+1 Domineering Will|CLB|1
+1 Dragon's Hoard|CLB|1
+1 Drakuseth, Maw of Flames|CLB|1
+1 Fellwar Stone|CLB|1
+1 Geode Rager|CLB|1
+1 Goblin Spymaster|CLB|1
+1 Hedron Archive|CLB|1
+12 Island|CLB|1
+1 Izzet Boilerworks|CLB|1
+1 Izzet Signet|CLB|1
+1 Kazuul, Tyrant of the Cliffs|CLB|1
+1 Keiga, the Tide Star|CLB|1
+1 Kher Keep|CLB|1
+1 Loot Dispute|CLB|1
+1 Midnight Clock|CLB|1
+1 Mind Stone|CLB|1
+1 Mocking Doppelganger|CLB|2
+12 Mountain|CLB|1
+1 Myriad Landscape|CLB|1
+1 Niv-Mizzet, Parun|CLB|1
+1 Path of Ancestry|CLB|1
+1 Prismari Campus|CLB|1
+1 Propaganda|CLB|1
+1 Psychic Impetus|CLB|1
+1 Pursued Whale|CLB|1
+1 Reins of Power|CLB|1
+1 Reliquary Tower|CLB|1
+1 Rowan Kenrith|CLB|1
+1 Ryusei, the Falling Star|CLB|1
+1 Shiny Impetus|CLB|1
+1 Sly Instigator|CLB|1
+1 Sol Ring|CLB|1
+1 Solemn Simulacrum|CLB|1
+1 Spectacular Showdown|CLB|2
+1 Sprite Dragon|CLB|1
+1 Steel Hellkite|CLB|1
+1 Stuffy Doll|CLB|1
+1 Talisman of Creativity|CLB|1
+1 Temple of Epiphany|CLB|1
+1 Temple of the False God|CLB|1
+1 Terrain Generator|CLB|1
+1 Territorial Hellkite|CLB|1
+1 The Akroan War|CLB|1
+1 Thunder Dragon|CLB|1
+1 Vengeful Ancestor|CLB|1
+1 Wandering Fumarole|CLB|1
+1 Warmonger Hellkite|CLB|1
+1 Wayfarer's Bauble|CLB|1
+1 Will Kenrith|CLB|1
+[Sideboard]
+

--- a/forge-gui/res/quest/commanderprecons/Exit from Exile [CLB] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Exit from Exile [CLB] [2022].dck
@@ -1,0 +1,85 @@
+[metadata]
+Name=Exit from Exile [CLB] [2022]
+[Commander]
+1 Faldorn, Dread Wolf Herald|CLB|2
+[Main]
+1 Arasta of the Endless Web|CLB|1
+1 Arcane Signet|CLB|1
+1 Ash Barrens|CLB|1
+1 Aurora Phoenix|CLB|1
+1 Battle Mammoth|CLB|1
+1 Beanstalk Giant|CLB|1
+1 Beast Within|CLB|1
+1 Blighted Woodland|CLB|1
+1 Bloodbraid Elf|CLB|1
+1 Bonecrusher Giant|CLB|1
+1 Castle Embereth|CLB|1
+1 Chaos Wand|CLB|1
+1 Cinder Glade|CLB|1
+1 Command Tower|CLB|1
+1 Cultivate|CLB|1
+1 Delayed Blast Fireball|CLB|2
+1 Demon Bolt|CLB|1
+1 Dire Fleet Daredevil|CLB|1
+1 Dream Pillager|CLB|1
+1 Durnan of the Yawning Portal|CLB|2
+1 Embereth Shieldbreaker|CLB|1
+1 End-Raze Forerunners|CLB|1
+1 Escape to the Wilds|CLB|1
+1 Etali, Primal Storm|CLB|1
+1 Explore|CLB|1
+1 Ezuri's Predation|CLB|1
+12 Forest|CLB|1
+1 Game Trail|CLB|1
+1 Greater Gargadon|CLB|1
+1 Green Slime|CLB|2
+1 Grumgully, the Generous|CLB|1
+1 Gruul Turf|CLB|1
+1 Highland Forest|CLB|1
+1 Hornet Queen|CLB|1
+1 Ignite the Future|CLB|1
+1 Izzet Chemister|CLB|1
+1 Jeska's Will|CLB|1
+1 Journey to the Lost City|CLB|2
+1 Kessig Wolf Run|CLB|1
+1 Kodama's Reach|CLB|1
+1 Laelia, the Blade Reforged|CLB|1
+1 Light Up the Stage|CLB|1
+1 Lovestruck Beast|CLB|1
+1 Managorger Hydra|CLB|1
+1 Mizzium Mortars|CLB|1
+1 Mossfire Valley|CLB|1
+1 Mosswort Bridge|CLB|1
+11 Mountain|CLB|1
+1 Myriad Landscape|CLB|1
+1 Nalfeshnee|CLB|2
+1 Natural Reclamation|CLB|1
+1 Nature's Lore|CLB|1
+1 Outpost Siege|CLB|1
+1 Passionate Archaeologist|CLB|2
+1 Primeval Bounty|CLB|1
+1 Raging Ravine|CLB|1
+1 Return of the Wildspeaker|CLB|1
+1 Sakura-Tribe Elder|CLB|1
+1 Sandwurm Convergence|CLB|1
+1 Sarevok's Tome|CLB|2
+1 Search for Tomorrow|CLB|1
+1 Sol Ring|CLB|1
+1 Spinerock Knoll|CLB|1
+1 Stolen Strategy|CLB|1
+1 Sweet-Gum Recluse|CLB|1
+1 Tectonic Giant|CLB|1
+1 Temple of Abandon|CLB|1
+1 Temple of the False God|CLB|1
+1 Terramorph|CLB|1
+1 Three Visits|CLB|1
+1 Tlincalli Hunter|CLB|2
+1 Urabrask the Hidden|CLB|1
+1 Venture Forth|CLB|2
+1 Vivien, Champion of the Wilds|CLB|1
+1 Volcanic Torrent|CLB|1
+1 Warstorm Surge|CLB|1
+1 Wild-Magic Sorcerer|CLB|1
+1 Xenagos, the Reveler|CLB|1
+[Sideboard]
+

--- a/forge-gui/res/quest/commanderprecons/Forces of the Imperium [40K] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Forces of the Imperium [40K] [2022].dck
@@ -1,0 +1,89 @@
+[metadata]
+Name=Forces of the Imperium [40K] [2022]
+[Commander]
+1 Inquisitor Greyfax|40K|1
+[Main]
+1 And They Shall Know No Fear|40K|1
+1 Arcane Sanctum|40K|1
+1 Arcane Signet|40K|1
+1 Arco-Flagellant|40K|1
+1 Ash Barrens|40K|1
+1 Assault Intercessor|40K|1
+1 Bastion Protector|40K|1
+1 Belisarius Cawl|40K|1
+1 Birth of the Imperium|40K|1
+1 Callidus Assassin|40K|1
+1 Celestine, the Living Saint|40K|1
+1 Choked Estuary|40K|1
+1 Collective Effort|40K|1
+1 Command Tower|40K|3
+1 Commander's Sphere|40K|1
+1 Commissar Severina Raine|40K|1
+1 Company Commander|40K|1
+1 Cybernetica Datasmith|40K|1
+1 Darkwater Catacombs|40K|1
+1 Defenders of Humanity|40K|1
+1 Deny the Witch|40K|1
+1 Deploy to the Front|40K|1
+1 Dismal Backwater|40K|1
+1 Entrapment Maneuver|40K|1
+1 Epistolary Librarian|40K|1
+1 Everflowing Chalice|40K|1
+1 Evolving Wilds|40K|1
+1 Exotic Orchard|40K|1
+1 Exterminatus|40K|1
+1 Fell the Mighty|40K|1
+1 For the Emperor!|40K|1
+1 Grey Knight Paragon|40K|1
+1 Hour of Reckoning|40K|1
+1 Inquisitor Eisenhorn|40K|1
+1 Inquisitorial Rosette|40K|1
+5 Island|40K|1
+1 Knight Paladin|40K|1
+1 Launch the Fleet|40K|1
+1 Marneus Calgar|40K|1
+1 Martial Coup|40K|1
+1 Memorial to Glory|40K|1
+1 Mind Stone|40K|1
+1 Mortify|40K|1
+1 Neyam Shai Murad|40K|1
+1 Path of Ancestry|40K|1
+8 Plains|40K|1
+1 Port Town|40K|1
+1 Prairie Stream|40K|1
+1 Primaris Chaplain|40K|1
+1 Primaris Eliminator|40K|1
+1 Reaver Titan|40K|1
+1 Reconnaissance Mission|40K|1
+1 Redemptor Dreadnought|40K|1
+1 Sanguinary Priest|40K|1
+1 Scoured Barrens|40K|1
+1 Sicarian Infiltrator|40K|1
+1 Sister Hospitaller|40K|1
+1 Sister of Silence|40K|1
+1 Sister Repentia|40K|1
+1 Skullclamp|40K|1
+1 Skycloud Expanse|40K|1
+1 Sol Ring|40K|3
+1 Space Marine Devastator|40K|1
+1 Space Marine Scout|40K|1
+1 Sunken Hollow|40K|1
+7 Swamp|40K|5
+1 Swords to Plowshares|40K|1
+1 Talisman of Dominance|40K|1
+1 Talisman of Hierarchy|40K|1
+1 Talisman of Progress|40K|1
+1 Terramorphic Expanse|40K|1
+1 The Flesh Is Weak|40K|1
+1 The Golden Throne|40K|1
+1 Thunderhawk Gunship|40K|1
+1 Thunderwolf Cavalry|40K|1
+1 Tranquil Cove|40K|1
+1 Triumph of Saint Katherine|40K|1
+1 Ultramarines Honour Guard|40K|1
+1 Utter End|40K|1
+1 Vanguard Suppressor|40K|1
+1 Vexilus Praetor|40K|1
+1 Zephyrim|40K|1
+[Sideboard]
+

--- a/forge-gui/res/quest/commanderprecons/Legends' Legacy [DMC] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Legends' Legacy [DMC] [2022].dck
@@ -1,0 +1,93 @@
+[metadata]
+Name=Legends' Legacy [DMC] [2022]
+[Commander]
+1 Dihada, Binder of Wills|DMC|1
+[Main]
+1 Adriana, Captain of the Guard|DMC|1
+1 Alesha, Who Smiles at Death|DMC|1
+1 Ambition's Cost|DMC|1
+1 Anafenza, Kin-Tree Spirit|DMC|1
+1 Arcane Signet|DMC|1
+1 Arvad the Cursed|DMC|1
+1 Ashling the Pilgrim|DMC|1
+1 Battlefield Forge|DMC|1
+1 Bedevil|DMC|1
+1 Bell Borca, Spectral Sergeant|DMC|1
+1 Blackblade Reforged|DMC|1
+1 Bladewing, Deathless Tyrant|DMC|1
+1 Bojuka Bog|DMC|1
+1 Bontu's Monument|DMC|1
+1 Boros Garrison|DMC|1
+1 Cadric, Soul Kindler|DMC|1
+1 Captain Lannery Storm|DMC|1
+1 Caves of Koilos|DMU|1
+1 Command Tower|DMC|1
+1 Commander's Sphere|DMC|1
+1 Day of Destiny|DMC|1
+1 Dragonskull Summit|DMC|1
+1 Drana, Liberator of Malakir|DMC|1
+1 Etali, Primal Storm|DMC|1
+1 Evolving Wilds|DMC|1
+1 Faithless Looting|DMC|1
+1 Fellwar Stone|DMC|1
+1 Foreboding Ruins|DMC|1
+1 Garna, the Bloodflame|DMC|1
+1 Geier Reach Sanitarium|DMC|1
+1 Generous Gift|DMC|1
+1 Gerrard's Hourglass Pendant|DMC|1
+1 Hazoret's Monument|DMC|1
+1 Hedron Archive|DMC|1
+1 Hero's Blade|DMC|1
+1 Hero's Downfall|DMC|1
+1 Heroes' Podium|DMC|1
+1 Honor-Worn Shaku|DMC|1
+1 Jazal Goldmane|DMC|1
+1 Josu Vess, Lich Knight|DMC|1
+1 Kari Zev, Skyship Raider|DMC|1
+1 Kaya's Wrath|DMC|1
+1 Kothophed, Soul Hoarder|DMC|1
+1 Krenko, Tin Street Kingpin|DMC|1
+1 Mikokoro, Center of the Sea|DMC|1
+1 Mobilized District|DMC|1
+1 Moira, Urborg Haunt|DMC|1
+1 Mortify|DMC|1
+5 Mountain|DMU|1
+1 Neheb, Dreadhorde Champion|DMC|1
+1 Night's Whisper|DMC|1
+1 Nomad Outpost|DMC|1
+1 Odric, Lunarch Marshal|DMC|1
+1 Oketra's Monument|DMC|1
+1 Orzhov Basilica|DMC|1
+6 Plains|DMU|1
+1 Primevals' Glorious Rebirth|DMC|1
+1 Rakdos Carnarium|DMC|1
+1 Read the Bones|DMC|1
+1 Reliquary Tower|DMC|1
+1 Shanid, Sleepers' Scourge|DMC|1
+1 Shivan Gorge|DMC|1
+1 Shizo, Death's Storehouse|DMC|1
+1 Smoldering Marsh|DMC|1
+1 Sol Ring|DMC|1
+5 Swamp|DMU|1
+1 Sword of the Chosen|DMC|1
+1 Tajic, Blade of the Legion|DMC|1
+1 Temple of Malice|DMC|1
+1 Temple of Silence|DMC|1
+1 Temple of Triumph|DMC|1
+1 Tenza, Godo's Maul|DMC|1
+1 Terramorphic Expanse|DMC|1
+1 Teshar, Ancestor's Apostle|DMC|1
+1 The Circle of Loyalty|DMC|1
+1 The Peregrine Dynamo|DMC|1
+1 The Reaver Cleaver|DMC|1
+1 Thrill of Possibility|DMC|1
+1 Traxos, Scourge of Kroog|DMC|1
+1 Tyrite Sanctum|DMC|1
+1 Unbreakable Formation|DMC|1
+1 Urza's Ruinous Blast|DMC|1
+1 Verrak, Warped Sengir|DMC|1
+1 Wear // Tear|DMC|1
+1 Zeriam, Golden Wind|DMC|1
+1 Zetalpa, Primal Dawn|DMC|1
+[Sideboard]
+

--- a/forge-gui/res/quest/commanderprecons/Maestros Massacre [NCC] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Maestros Massacre [NCC] [2022].dck
@@ -1,0 +1,95 @@
+[metadata]
+Name=Maestros Massacre [NCC] [2022]
+[Commander]
+1 Perrie, the Pulverizer|NCC|1
+[Main]
+1 Agent's Toolkit|NCC|1
+1 Ajani Unyielding|NCC|1
+1 Angelic Sleuth|NCC|1
+1 Arcane Signet|NCC|1
+1 Ash Barrens|NCC|1
+1 Aven Courier|NCC|1
+1 Aven Mimeomancer|NCC|1
+1 Avenging Huntbonder|NCC|1
+1 Bant Charm|NCC|1
+1 Bant Panorama|NCC|1
+1 Bribe Taker|NCC|1
+1 Brokers Charm|SNC|1
+1 Brokers Confluence|NCC|1
+1 Brokers Hideout|SNC|1
+1 Canopy Vista|NCC|1
+1 Command Tower|NCC|1
+1 Commander's Sphere|NCC|1
+1 Contractual Safeguard|NCC|1
+1 Crystalline Giant|NCC|1
+1 Damning Verdict|NCC|1
+1 Declaration in Stone|NCC|1
+1 Denry Klin, Editor in Chief|NCC|1
+1 Devoted Druid|NCC|1
+1 Everflowing Chalice|NCC|1
+1 Evolution Sage|NCC|1
+1 Exotic Orchard|NCC|1
+1 Exotic Pets|SNC|1
+1 Family's Favor|NCC|1
+1 Fathom Mage|NCC|1
+1 Fellwar Stone|NCC|1
+1 Flooded Grove|NCC|1
+5 Forest|SNC|1
+1 Forgotten Ancient|NCC|1
+1 Fortified Village|NCC|1
+1 Gavel of the Righteous|NCC|1
+1 Gavony Township|NCC|1
+1 Generous Gift|NCC|1
+1 Grateful Apparition|NCC|1
+1 Hoofprints of the Stag|NCC|1
+1 Incubation Druid|NCC|1
+4 Island|SNC|1
+1 Jenara, Asura of War|NCC|1
+1 Karn's Bastion|NCC|1
+1 Kros, Defense Contractor|NCC|1
+1 Littjara Mirrorlake|NCC|1
+1 Llanowar Reborn|NCC|1
+1 Luminarch Aspirant|NCC|1
+1 Midnight Clock|NCC|1
+1 Myriad Landscape|NCC|1
+1 Nesting Grounds|NCC|1
+1 Oblivion Stone|NCC|1
+1 Oracle's Vault|NCC|1
+1 Park Heights Maverick|NCC|1
+1 Path of Ancestry|NCC|1
+5 Plains|SNC|1
+1 Planar Outburst|NCC|1
+1 Port Town|NCC|1
+1 Power Conduit|NCC|1
+1 Prairie Stream|NCC|1
+1 Primal Empathy|NCC|1
+1 Resourceful Defense|NCC|1
+1 Rishkar's Expertise|NCC|1
+1 Rishkar, Peema Renegade|NCC|1
+1 Roalesk, Apex Hybrid|NCC|1
+1 Scavenging Ooze|NCC|1
+1 Seaside Citadel|NCC|1
+1 Shield Broker|NCC|1
+1 Skyboon Evangelist|NCC|1
+1 Skycloud Expanse|NCC|1
+1 Skyship Plunderer|NCC|1
+1 Slippery Bogbonder|NCC|1
+1 Sol Ring|NCC|1
+1 Steelbane Hydra|NCC|1
+1 Storm of Forms|NCC|1
+1 Sungrass Prairie|NCC|1
+1 Swiftfoot Boots|NCC|1
+1 Temple of Mystery|NCC|1
+1 Tezzeret's Gambit|NCC|1
+1 Thrummingbird|NCC|1
+1 Together Forever|NCC|1
+1 Urban Evolution|NCC|1
+1 Vivid Creek|NCC|1
+1 Vivid Grove|NCC|1
+1 Vivid Meadow|NCC|1
+1 Vorel of the Hull Clade|NCC|1
+1 Wall of Roots|NCC|1
+1 Wickerbough Elder|NCC|1
+1 Wingspan Mentor|NCC|1
+[Sideboard]
+

--- a/forge-gui/res/quest/commanderprecons/Mind Flayarrrs [CLB] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Mind Flayarrrs [CLB] [2022].dck
@@ -1,0 +1,88 @@
+[metadata]
+Name=Mind Flayarrrs [CLB] [2022]
+[Commander]
+1 Captain N'ghathrod|CLB|2
+[Main]
+1 Aboleth Spawn|CLB|2
+1 Arcane Signet|CLB|1
+1 Ash Barrens|CLB|1
+1 Black Market|CLB|1
+1 Brainstealer Dragon|CLB|2
+1 Chasm Skulker|CLB|1
+1 Choked Estuary|CLB|1
+1 Command Tower|CLB|1
+1 Consuming Aberration|CLB|1
+1 Creeping Tar Pit|CLB|1
+1 Crippling Fear|CLB|1
+1 Curtains' Call|CLB|1
+1 Dark Hatchling|CLB|1
+1 Darkwater Catacombs|CLB|1
+1 Dauthi Horror|CLB|1
+1 Dimir Aqueduct|CLB|1
+1 Dimir Keyrune|CLB|1
+1 Dimir Signet|CLB|1
+1 Dross Harvester|CLB|1
+1 Drown in the Loch|CLB|1
+1 Drownyard Temple|CLB|1
+1 Dusk Mangler|CLB|1
+1 Endless Evil|CLB|2
+1 Everflowing Chalice|CLB|1
+1 Exotic Orchard|CLB|1
+1 Extract from Darkness|CLB|1
+1 Fact or Fiction|CLB|1
+1 Feed the Swarm|CLB|1
+1 Forgotten Creation|CLB|1
+1 Fractured Sanity|CLB|1
+1 From the Catacombs|CLB|2
+1 Grazilaxx, Illithid Scholar|CLB|1
+1 Grell Philosopher|CLB|2
+1 Guiltfeeder|CLB|1
+1 Haunted One|CLB|2
+1 Herald's Horn|CLB|1
+1 Hex|CLB|1
+1 Hullbreaker Horror|CLB|1
+1 Hunted Horror|CLB|1
+1 In Garruk's Wake|CLB|1
+9 Island|CLB|1
+1 Leyline of Anticipation|CLB|1
+1 Lightning Greaves|CLB|1
+1 Memory Plunder|CLB|1
+1 Mind Flayer|CLB|1
+1 Mind Stone|CLB|1
+1 Mindcrank|CLB|1
+1 Myriad Landscape|CLB|1
+1 Nemesis of Reason|CLB|1
+1 Nephalia Drownyard|CLB|1
+1 Nighthowler|CLB|1
+1 Nihilith|CLB|1
+1 Overcharged Amalgam|CLB|1
+1 Path of Ancestry|CLB|1
+1 Phyrexian Rager|CLB|1
+1 Phyrexian Revoker|CLB|1
+1 Plague Spitter|CLB|1
+1 Port of Karfell|CLB|1
+1 Psionic Ritual|CLB|2
+1 Psychosis Crawler|CLB|1
+1 Pull from Tomorrow|CLB|1
+1 Ravenous Chupacabra|CLB|1
+1 Reflections of Littjara|CLB|1
+1 River of Tears|CLB|1
+1 Rogue's Passage|CLB|1
+1 Sewer Nemesis|CLB|1
+1 Sludge Monster|CLB|1
+1 Sol Ring|CLB|1
+1 Spellskite|CLB|1
+1 Sunken Hollow|CLB|1
+11 Swamp|CLB|1
+1 Syphon Mind|CLB|1
+1 Tainted Isle|CLB|1
+1 Talisman of Dominance|CLB|1
+1 Temple of Deceit|CLB|1
+1 Temple of the False God|CLB|1
+1 Thought Vessel|CLB|1
+1 Uchuulon|CLB|2
+1 Wharf Infiltrator|CLB|1
+1 Woe Strider|CLB|1
+1 Zellix, Sanity Flayer|CLB|2
+[Sideboard]
+

--- a/forge-gui/res/quest/commanderprecons/Mishra's Burnished Banner [BRC] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Mishra's Burnished Banner [BRC] [2022].dck
@@ -1,0 +1,97 @@
+[metadata]
+Name=Mishra's Burnished Banner [BRC] [2022]
+[Commander]
+1 Mishra, Eminent One|BRC|1
+[Main]
+1 Abrade|BRC|1
+1 Arcane Signet|BRC|1
+1 Ash Barrens|BRC|1
+1 Ashnod the Uncaring|BRC|1
+1 Audacious Reshapers|BRC|1
+1 Bedevil|BRC|1
+1 Blasphemous Act|BRC|1
+1 Blast-Furnace Hellkite|BRC|1
+1 Brudiclad, Telchor Engineer|BRC|1
+1 Buried Ruin|BRC|1
+1 Chaos Warp|BRC|1
+1 Command Tower|BRC|1
+1 Commander's Sphere|BRC|1
+1 Crumbling Necropolis|BRC|1
+1 Cursed Mirror|BRC|1
+1 Darkwater Catacombs|BRC|1
+1 Dimir Aqueduct|BRC|1
+1 Dimir Signet|BRC|1
+1 Dreamstone Hedron|BRC|1
+1 Drossforge Bridge|BRC|1
+1 Emry, Lurker of the Loch|BRC|1
+1 Executioner's Capsule|BRC|1
+1 Exotic Orchard|BRC|1
+1 Expressive Iteration|BRC|1
+1 Fact or Fiction|BRC|1
+1 Fain, the Broker|BRC|1
+1 Faithless Looting|BRC|1
+1 Farid, Enterprising Salvager|BRC|1
+1 Feed the Swarm|BRC|1
+1 Fellwar Stone|BRC|1
+1 Geth, Lord of the Vault|BRC|1
+1 Glint Raker|BRC|1
+1 Great Furnace|BRC|1
+1 Hedron Archive|BRC|1
+1 Hellkite Igniter|BRC|1
+1 Herald of Anguish|BRC|1
+1 Ichor Wellspring|BRC|1
+1 Idol of Oblivion|BRC|1
+5 Island|BRC|1
+1 Izzet Boilerworks|BRC|1
+1 Jhoira, Weatherlight Captain|BRC|1
+1 Lithoform Engine|BRC|1
+1 Machine God's Effigy|BRC|1
+1 Master Transmuter|BRC|1
+1 Metalwork Colossus|BRC|1
+1 Mind Stone|BRC|1
+1 Mirrorworks|BRC|1
+1 Mistvault Bridge|BRC|1
+1 Mnemonic Sphere|BRC|1
+2 Mountain|BRC|1
+2 Mountain|BRC|2
+1 Muzzio, Visionary Architect|BRC|1
+1 Mycosynth Wellspring|BRC|1
+1 Myriad Landscape|BRC|1
+1 Nihil Spellbomb|BRC|1
+1 Oblivion Stone|BRC|1
+1 Oni-Cult Anvil|BRC|1
+1 Padeem, Consul of Innovation|BRC|1
+1 Path of Ancestry|BRC|1
+1 Prophetic Prism|BRC|1
+1 Rakdos Carnarium|BRC|1
+1 Rakdos Signet|BRC|1
+1 Reliquary Tower|BRC|1
+1 Scavenged Brawler|BRC|1
+1 Seat of the Synod|BRC|1
+1 Servo Schematic|BRC|1
+1 Shadowblood Ridge|BRC|1
+1 Silas Renn, Seeker Adept|BRC|1
+1 Silverbluff Bridge|BRC|1
+1 Slobad, Goblin Tinkerer|BRC|1
+1 Smelting Vat|BRC|1
+1 Smoldering Marsh|BRC|1
+1 Sol Ring|BRC|1
+1 Spine of Ish Sah|BRC|1
+1 Strionic Resonator|BRC|1
+4 Swamp|BRC|1
+1 Temple of Deceit|BRC|1
+1 Temple of Epiphany|BRC|1
+1 Temple of Malice|BRC|1
+1 Terisiare's Devastation|BRC|1
+1 Terramorphic Expanse|BRC|1
+1 Thirst for Knowledge|BRC|1
+1 Thoughtcast|BRC|1
+1 Thran Dynamo|BRC|1
+1 Trading Post|BRC|1
+1 Traxos, Scourge of Kroog|BRC|1
+1 Vault of Whispers|BRC|1
+1 Wayfarer's Bauble|BRC|1
+1 Wondrous Crucible|BRC|1
+1 Workshop Elders|BRC|1
+[Sideboard]
+

--- a/forge-gui/res/quest/commanderprecons/Necron Dynasties [40K] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Necron Dynasties [40K] [2022].dck
@@ -1,0 +1,79 @@
+[metadata]
+Name=Necron Dynasties [40K] [2022]
+[Commander]
+1 Szarekh, the Silent King|40K|1
+[Main]
+1 Anrakyr the Traveller|40K|1
+1 Arcane Signet|40K|1
+1 Barren Moor|40K|1
+1 Beacon of Unrest|40K|1
+1 Biotransference|40K|1
+1 Caged Sun|40K|1
+1 Canoptek Scarab Swarm|40K|1
+1 Canoptek Spyder|40K|1
+1 Canoptek Tomb Sentinel|40K|1
+1 Canoptek Wraith|40K|1
+1 Chronomancer|40K|1
+1 Commander's Sphere|40K|1
+1 Convergence of Dominion|40K|1
+1 Cranial Plating|40K|1
+1 Cryptek|40K|1
+1 Cryptothrall|40K|1
+1 Darkness|40K|1
+1 Defile|40K|1
+1 Desert of the Glorified|40K|1
+1 Dread Return|40K|1
+1 Endless Atlas|40K|1
+1 Flayed One|40K|1
+1 Ghost Ark|40K|1
+1 Gilded Lotus|40K|1
+1 Go for the Throat|40K|1
+1 Hedron Archive|40K|1
+1 Hexmark Destroyer|40K|1
+1 Illuminor Szeras|40K|1
+1 Imotekh the Stormlord|40K|1
+1 Living Death|40K|1
+1 Lokhust Heavy Destroyer|40K|1
+1 Lychguard|40K|1
+1 Mask of Memory|40K|1
+1 Mind Stone|40K|1
+1 Mutilate|40K|1
+1 Myriad Landscape|40K|1
+1 Mystic Forge|40K|1
+1 Necron Deathmark|40K|1
+1 Necron Monolith|40K|1
+1 Necron Overlord|40K|1
+1 Night Scythe|40K|1
+1 Out of the Tombs|40K|1
+1 Plasmancer|40K|1
+1 Polluted Mire|40K|1
+1 Psychomancer|40K|1
+1 Reliquary Tower|40K|1
+1 Resurrection Orb|40K|1
+1 Royal Warden|40K|1
+1 Sautekh Immortal|40K|1
+1 Sceptre of Eternal Glory|40K|1
+1 Sculpting Steel|40K|1
+1 Shard of the Nightbringer|40K|1
+1 Shard of the Void Dragon|40K|1
+1 Skorpekh Destroyer|40K|1
+1 Skorpekh Lord|40K|1
+1 Sol Ring|40K|4
+11 Swamp|40K|1
+11 Swamp|40K|3
+8 Swamp|40K|4
+1 Technomancer|40K|1
+1 The War in Heaven|40K|1
+1 Their Name Is Death|40K|1
+1 Their Number Is Legion|40K|1
+1 Thought Vessel|40K|1
+1 Tomb Blade|40K|1
+1 Tomb Fortress|40K|1
+1 Trazyn the Infinite|40K|1
+1 Triarch Praetorian|40K|1
+1 Triarch Stalker|40K|1
+1 Unstable Obelisk|40K|1
+1 Vault of Whispers|40K|1
+1 Wayfarer's Bauble|40K|1
+[Sideboard]
+

--- a/forge-gui/res/quest/commanderprecons/Obscura Operation [NCC] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Obscura Operation [NCC] [2022].dck
@@ -1,0 +1,92 @@
+[metadata]
+Name=Obscura Operation [NCC] [2022]
+[Commander]
+1 Kamiz, Obscura Oculus|NCC|1
+[Main]
+1 Aerial Extortionist|NCC|1
+1 Alela, Artful Provocateur|NCC|1
+1 An Offer You Can't Refuse|SNC|1
+1 Arcane Sanctum|NCC|1
+1 Arcane Signet|NCC|1
+1 Archon of Coronation|NCC|1
+1 Ash Barrens|NCC|1
+1 Austere Command|NCC|1
+1 Azorius Signet|NCC|1
+1 Cephalid Facetaker|NCC|1
+1 Champion of Wits|NCC|1
+1 Change of Plans|NCC|1
+1 Chasm Skulker|NCC|1
+1 Choked Estuary|NCC|1
+1 Command Tower|NCC|1
+1 Commander's Sphere|NCC|1
+1 Commit // Memory|NCC|1
+1 Creeping Tar Pit|NCC|1
+1 Currency Converter|NCC|1
+1 Custodi Lich|NCC|1
+1 Daring Saboteur|NCC|1
+1 Darkwater Catacombs|NCC|1
+1 Daxos of Meletis|NCC|1
+1 Dimir Signet|NCC|1
+1 Dragonlord Ojutai|NCC|1
+1 Drana, Liberator of Malakir|NCC|1
+1 Dusk // Dawn|NCC|1
+1 Esper Panorama|NCC|1
+1 Exotic Orchard|NCC|1
+1 Fallen Shinobi|NCC|1
+1 Fellwar Stone|NCC|1
+1 Fetid Heath|NCC|1
+1 Ghostly Pilferer|NCC|1
+1 Graveblade Marauder|NCC|1
+1 Identity Thief|NCC|1
+1 In Too Deep|NCC|1
+1 Inkfathom Witch|NCC|1
+6 Island|SNC|1
+1 Jailbreak|NCC|1
+1 Lethal Scheme|NCC|1
+1 Life Insurance|NCC|1
+1 Looter il-Kor|NCC|1
+1 Mask of Riddles|NCC|1
+1 Mask of the Schemer|NCC|1
+1 Misfortune Teller|NCC|1
+1 Myriad Landscape|NCC|1
+1 Nadir Kraken|NCC|1
+1 Nightmare Unmaking|NCC|1
+1 Obscura Charm|SNC|1
+1 Obscura Confluence|NCC|1
+1 Obscura Storefront|SNC|1
+1 Orzhov Signet|NCC|1
+1 Oskar, Rubbish Reclaimer|NCC|1
+1 Path of Ancestry|NCC|1
+5 Plains|SNC|1
+1 Port Town|NCC|1
+1 Prairie Stream|NCC|1
+1 Profane Command|NCC|1
+1 Quietus Spike|NCC|1
+1 Rogue's Passage|NCC|1
+1 Shadowmage Infiltrator|NCC|1
+1 Silent-Blade Oni|NCC|1
+1 Skycloud Expanse|NCC|1
+1 Skyway Robber|NCC|1
+1 Smuggler's Share|NCC|1
+1 Sol Ring|NCC|1
+1 Stolen Identity|NCC|1
+1 Strionic Resonator|NCC|1
+1 Sun Titan|NCC|1
+1 Sunken Hollow|NCC|1
+6 Swamp|SNC|1
+1 Swiftfoot Boots|NCC|1
+1 Swords to Plowshares|NCC|1
+1 Temple of Silence|NCC|1
+1 Thief of Sanity|NCC|1
+1 Thriving Heath|NCC|1
+1 Thriving Isle|NCC|1
+1 Thriving Moor|NCC|1
+1 Tivit, Seller of Secrets|NCC|1
+1 Treasure Cruise|NCC|1
+1 Utter End|NCC|1
+1 Wayfarer's Bauble|NCC|1
+1 Whirler Rogue|NCC|1
+1 Wrexial, the Risen Deep|NCC|1
+1 Writ of Return|NCC|1
+[Sideboard]
+

--- a/forge-gui/res/quest/commanderprecons/Painbow [DMC] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Painbow [DMC] [2022].dck
@@ -1,0 +1,100 @@
+[metadata]
+Name=Painbow [DMC] [2022]
+[Commander]
+1 Jared Carthalion|DMC|1
+[Main]
+1 Abundant Growth|DMC|1
+1 Abzan Charm|DMC|1
+1 Arcane Sanctum|DMC|1
+1 Arcane Signet|DMC|1
+1 Archelos, Lagoon Mystic|DMC|1
+1 Atla Palani, Nest Tender|DMC|1
+1 Bad River|DMC|1
+1 Baleful Strix|DMC|1
+1 Beast Within|DMC|1
+1 Canopy Vista|DMC|1
+1 Cascading Cataracts|DMC|1
+1 Chromanticore|DMC|1
+1 Cinder Glade|DMC|1
+1 Coalition Relic|DMC|1
+1 Coiling Oracle|DMC|1
+1 Command Tower|DMC|1
+1 Commander's Sphere|DMC|1
+1 Crumbling Necropolis|DMC|1
+1 Crystal Quarry|DMC|1
+1 Cultivate|DMC|1
+1 Duneblast|DMC|1
+1 Echoing Truth|DMC|1
+1 Evolving Wilds|DMC|1
+1 Exotic Orchard|DMC|1
+1 Explore|DMC|1
+1 Explosive Vegetation|DMC|1
+1 Faeburrow Elder|DMC|1
+1 Fallaji Wayfarer|DMC|1
+1 Farseek|DMC|1
+1 Fellwar Stone|DMC|1
+1 Flood Plain|DMC|1
+3 Forest|DMU|1
+1 Frontier Bivouac|DMC|1
+1 Fusion Elemental|DMC|1
+1 Glint-Eye Nephilim|DMC|1
+1 Grasslands|DMC|1
+1 Growth Spiral|DMC|1
+1 Hero of Precinct One|DMC|1
+1 Illuna, Apex of Wishes|DMC|1
+1 Iridian Maelstrom|DMC|1
+2 Island|DMU|1
+1 Jenson Carthalion, Druid Exile|DMC|1
+1 Jungle Shrine|DMC|1
+1 Knight of New Alara|DMC|1
+1 Kodama's Reach|DMC|1
+1 Krosan Verge|DMC|1
+1 Lavalanche|DMC|1
+1 Maelstrom Archangel|DMC|1
+1 Maelstrom Nexus|DMC|1
+1 Mana Cannons|DMC|1
+1 Merciless Eviction|DMC|1
+1 Migration Path|DMC|1
+2 Mountain|DMU|1
+1 Mountain Valley|DMC|1
+1 Murmuring Bosk|DMC|1
+1 Mystic Monastery|DMC|1
+1 Naya Charm|DMC|1
+1 Nethroi, Apex of Death|DMC|1
+1 Nomad Outpost|DMC|1
+1 O-Kagachi, Vengeful Kami|DMC|1
+1 Obsidian Obelisk|DMC|1
+1 Opulent Palace|DMC|1
+1 Painful Truths|DMC|1
+1 Path to Exile|DMC|1
+1 Path to the World Tree|DMC|1
+2 Plains|DMU|1
+1 Prairie Stream|DMC|1
+1 Primeval Spawn|DMC|1
+1 Prophetic Prism|DMC|1
+1 Radiant Flames|DMC|1
+1 Rienne, Angel of Rebirth|DMC|1
+1 Rocky Tar Pit|DMC|1
+1 Sandsteppe Citadel|DMC|1
+1 Savage Lands|DMC|1
+1 Search for Tomorrow|DMC|1
+1 Seaside Citadel|DMC|1
+1 Selvala, Explorer Returned|DMC|1
+1 Smoldering Marsh|DMC|1
+1 Solemn Simulacrum|DMC|1
+1 Sultai Charm|DMC|1
+1 Sunken Hollow|DMC|1
+1 Surrak Dragonclaw|DMC|1
+2 Swamp|DMU|1
+1 Sylvan Reclamation|DMC|1
+1 Terminate|DMC|1
+1 Terramorphic Expanse|DMC|1
+1 Tiller Engine|DMC|1
+1 Time Wipe|DMC|1
+1 Transguild Courier|DMC|1
+1 Two-Headed Hellkite|DMC|1
+1 Unite the Coalition|DMC|1
+1 Xyris, the Writhing Storm|DMC|1
+1 Zaxara, the Exemplary|DMC|1
+[Sideboard]
+

--- a/forge-gui/res/quest/commanderprecons/Party Time [CLB] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Party Time [CLB] [2022].dck
@@ -1,0 +1,86 @@
+[metadata]
+Name=Party Time [CLB] [2022]
+[Commander]
+1 Nalia de'Arnise|CLB|2
+[Main]
+1 Arcane Signet|CLB|1
+1 Archpriest of Iona|CLB|1
+1 Ash Barrens|CLB|1
+1 Austere Command|CLB|1
+1 Aven Mindcensor|CLB|1
+1 Black Market Connections|CLB|2
+1 Bloodsoaked Champion|CLB|1
+1 Bojuka Bog|CLB|1
+1 Burakos, Party Leader|CLB|2
+1 Butcher of Malakir|CLB|1
+1 Bygone Bishop|CLB|1
+1 Calculating Lich|CLB|1
+1 Castle Locthwain|CLB|1
+1 Changeling Outcast|CLB|1
+1 Command Tower|CLB|1
+1 Corpse Augur|CLB|1
+1 Crib Swap|CLB|1
+1 Deep Gnome Terramancer|CLB|2
+1 Despark|CLB|1
+1 Dire Fleet Ravager|CLB|1
+1 Dusk // Dawn|CLB|1
+1 Eight-and-a-Half-Tails|CLB|1
+1 Felisa, Fang of Silverquill|CLB|1
+1 Firja's Retribution|CLB|1
+1 Folk Hero|CLB|2
+1 Frontline Medic|CLB|1
+1 Galepowder Mage|CLB|1
+1 Glorious Protector|CLB|1
+1 Gonti, Lord of Luxury|CLB|1
+1 Grim Haruspex|CLB|1
+1 Grim Hireling|CLB|1
+1 Harper Recruiter|CLB|2
+1 High Priest of Penance|CLB|1
+1 Irregular Cohort|CLB|1
+1 Jazal Goldmane|CLB|1
+1 Mage's Attendant|CLB|1
+1 Magus of the Balance|CLB|1
+1 Malakir Blood-Priest|CLB|1
+1 Mardu Strike Leader|CLB|1
+1 Maskwood Nexus|CLB|1
+1 Mikaeus, the Lunarch|CLB|1
+1 Mindblade Render|CLB|1
+1 Mirror Entity|CLB|1
+1 Mortuary Mire|CLB|1
+1 Mother of Runes|CLB|1
+1 Multiclass Baldric|CLB|2
+1 Mutavault|CLB|1
+1 Myriad Landscape|CLB|1
+1 Nighthawk Scavenger|CLB|1
+1 Order of Whiteclay|CLB|1
+1 Orzhov Basilica|CLB|1
+1 Orzhov Signet|CLB|1
+1 Path of Ancestry|CLB|1
+10 Plains|CLB|1
+1 Pontiff of Blight|CLB|1
+1 Priest of Ancient Lore|CLB|1
+1 Puppeteer Clique|CLB|1
+1 Rumor Gatherer|CLB|1
+1 Seasoned Dungeoneer|CLB|2
+1 Selfless Spirit|CLB|1
+1 Sevinne's Reclamation|CLB|1
+1 Shambling Vent|CLB|1
+1 Skullclamp|CLB|1
+1 Snowfield Sinkhole|CLB|1
+1 Sol Ring|CLB|1
+1 Solemn Doomguide|CLB|2
+1 Solemn Recruit|CLB|1
+1 Squad Commander|CLB|1
+1 Starlit Sanctum|CLB|1
+1 Stick Together|CLB|2
+10 Swamp|CLB|1
+1 Tainted Field|CLB|1
+1 Talisman of Hierarchy|CLB|1
+1 Temple of Silence|CLB|1
+1 Thwart the Grave|CLB|1
+1 Unbreakable Formation|CLB|1
+1 Valiant Changeling|CLB|1
+1 Vault of the Archangel|CLB|1
+1 War Room|CLB|1
+1 Windbrisk Heights|CLB|1
+1 Zulaport Cutthroat|CLB|1

--- a/forge-gui/res/quest/commanderprecons/Riveteer Rampage [NCC] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Riveteer Rampage [NCC] [2022].dck
@@ -1,0 +1,93 @@
+[metadata]
+Name=Riveteer Rampage [NCC] [2022]
+[Commander]
+1 Henzie "Toolbox" Torre|NCC|1
+[Main]
+1 Arcane Signet|NCC|1
+1 Artisan of Kozilek|NCC|1
+1 Ash Barrens|NCC|1
+1 Avenger of Zendikar|NCC|1
+1 Bellowing Mauler|NCC|1
+1 Blasphemous Act|NCC|1
+1 Blighted Woodland|NCC|1
+1 Caldaia Guardian|NCC|1
+1 Chaos Warp|NCC|1
+1 Cinder Glade|NCC|1
+1 Command Tower|NCC|1
+1 Commander's Sphere|NCC|1
+1 Deathbringer Regent|NCC|1
+1 Deathreap Ritual|NCC|1
+1 Disciple of Bolas|NCC|1
+1 Dodgy Jalopy|NCC|1
+1 Etali, Primal Storm|NCC|1
+1 Evolutionary Leap|NCC|1
+1 Exotic Orchard|NCC|1
+1 Explore|NCC|1
+1 Farseek|NCC|1
+1 Fellwar Stone|NCC|1
+1 First Responder|NCC|1
+1 Foreboding Ruins|NCC|1
+6 Forest|SNC|1
+1 Game Trail|NCC|1
+1 Garruk's Uprising|NCC|1
+1 Giant Adephage|NCC|1
+1 Glittering Stockpile|SNC|1
+1 Greenwarden of Murasa|NCC|1
+1 Grime Gorger|NCC|1
+1 Indrik Stomphowler|NCC|1
+1 Industrial Advancement|NCC|1
+1 Inferno Titan|NCC|1
+1 Jolene, the Plunder Queen|NCC|1
+1 Jund Panorama|NCC|1
+1 Kessig Wolf Run|NCC|1
+1 Kodama's Reach|NCC|1
+1 Kresh the Bloodbraided|NCC|1
+1 Life's Legacy|NCC|1
+1 Lifecrafter's Bestiary|NCC|1
+1 Mezzio Mugger|NCC|1
+1 Migration Path|NCC|1
+1 Mitotic Slime|NCC|1
+1 Mossfire Valley|NCC|1
+1 Mosswort Bridge|NCC|1
+5 Mountain|SNC|1
+1 Myriad Landscape|NCC|1
+1 Next of Kin|NCC|1
+1 Noxious Gearhulk|NCC|1
+1 Overgrown Battlement|NCC|1
+1 Painful Truths|NCC|1
+1 Path of Ancestry|NCC|1
+1 Protection Racket|NCC|1
+1 Rain of Riches|NCC|1
+1 Rampant Growth|NCC|1
+1 Riveteers Charm|SNC|1
+1 Riveteers Confluence|NCC|1
+1 Riveteers Overlook|SNC|1
+1 Savage Lands|NCC|1
+1 Shadowblood Ridge|NCC|1
+1 Smoldering Marsh|NCC|1
+1 Sol Ring|NCC|1
+1 Solemn Simulacrum|NCC|1
+1 Spinerock Knoll|NCC|1
+1 Stalking Vengeance|NCC|1
+4 Swamp|SNC|1
+1 Temple of Malady|NCC|1
+1 Temple of the False God|NCC|1
+1 Temur Sabertooth|NCC|1
+1 Terminate|NCC|1
+1 The Beamtown Bullies|NCC|1
+1 Thragtusk|NCC|1
+1 Thriving Bluff|NCC|1
+1 Thriving Grove|NCC|1
+1 Thriving Moor|NCC|1
+1 Treeshaker Chimera|NCC|1
+1 Turf War|NCC|1
+1 Twilight Mire|NCC|1
+1 Victimize|NCC|1
+1 Warstorm Surge|NCC|1
+1 Wave of Rats|NCC|1
+1 Weathered Sentinels|NCC|1
+1 Windgrace's Judgment|NCC|1
+1 Woodfall Primus|NCC|1
+1 World Shaper|NCC|1
+[Sideboard]
+

--- a/forge-gui/res/quest/commanderprecons/Tyranid Swarm [40K] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Tyranid Swarm [40K] [2022].dck
@@ -1,0 +1,87 @@
+[metadata]
+Name=Tyranid Swarm [40K] [2022]
+[Commander]
+1 The Swarmlord|40K|1
+[Main]
+1 Aberrant|40K|1
+1 Abundance|40K|1
+1 Acolyte Hybrid|40K|1
+1 Aetherize|40K|1
+1 Arcane Signet|40K|1
+1 Ash Barrens|40K|1
+1 Atalan Jackal|40K|1
+1 Biophagus|40K|1
+1 Bone Sabres|40K|1
+1 Bred for the Hunt|40K|1
+1 Broodlord|40K|1
+1 Cave of Temptation|40K|1
+1 Cinder Glade|40K|1
+1 Clamavus|40K|1
+1 Command Tower|40K|1
+1 Cultivate|40K|1
+1 Death's Presence|40K|1
+1 Deathleaper, Terror Weapon|40K|1
+1 Evolving Wilds|40K|1
+1 Exocrine|40K|1
+1 Exotic Orchard|40K|1
+1 Explore|40K|1
+1 Farseek|40K|1
+8 Forest|40K|1
+1 Frontier Bivouac|40K|1
+1 Game Trail|40K|1
+1 Gargoyle Flock|40K|1
+1 Genestealer Locus|40K|1
+1 Genestealer Patriarch|40K|1
+1 Ghyrson Starn, Kelermorph|40K|1
+1 Goliath Truck|40K|1
+1 Hardened Scales|40K|1
+1 Harrow|40K|1
+1 Haruspex|40K|1
+1 Herald's Horn|40K|1
+1 Hierophant Bio-Titan|40K|1
+1 Hormagaunt Horde|40K|1
+1 Hull Breach|40K|1
+1 Icon of Ancestry|40K|1
+1 Inspiring Call|40K|1
+7 Island|40K|3
+1 Lictor|40K|1
+1 Magus Lucea Kane|40K|1
+1 Malanthrope|40K|1
+1 Mawloc|40K|1
+7 Mountain|40K|1
+1 New Horizons|40K|1
+1 Nexos|40K|1
+1 Old One Eye|40K|1
+1 Opal Palace|40K|1
+1 Overgrowth|40K|1
+1 Path of Ancestry|40K|1
+1 Purestrain Genestealer|40K|1
+1 Rampant Growth|40K|1
+1 Ravener|40K|1
+1 Rugged Highlands|40K|1
+1 Screamer-Killer|40K|1
+1 Shadow in the Warp|40K|1
+1 Sol Ring|40K|1
+1 Sporocyst|40K|1
+1 Starstorm|40K|1
+1 Temple of Abandon|40K|1
+1 Temple of Epiphany|40K|1
+1 Temple of Mystery|40K|1
+1 Termagant Swarm|40K|1
+1 Terramorphic Expanse|40K|1
+1 Tervigon|40K|1
+1 The First Tyrannic War|40K|1
+1 The Red Terror|40K|1
+1 Thornwood Falls|40K|1
+1 Toxicrene|40K|1
+1 Trygon Prime|40K|1
+1 Tyranid Harridan|40K|1
+1 Tyranid Invasion|40K|1
+1 Tyranid Prime|40K|1
+1 Tyrant Guard|40K|1
+1 Unclaimed Territory|40K|1
+1 Venomthrope|40K|1
+1 Winged Hive Tyrant|40K|1
+1 Zoanthrope|40K|1
+[Sideboard]
+

--- a/forge-gui/res/quest/commanderprecons/Upgrades Unleashed [NEC] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Upgrades Unleashed [NEC] [2022].dck
@@ -1,0 +1,82 @@
+[metadata]
+Name=Upgrades Unleashed [NEC] [2022]
+[Commander]
+1 Chishiro, the Shattered Blade|NEC|1
+[Main]
+1 Acidic Slime|NEC|1
+1 Agitator Ant|NEC|1
+1 Akki Battle Squad|NEC|1
+1 Arcane Signet|NEC|1
+1 Ascendant Acolyte|NEC|1
+1 Bear Umbra|NEC|1
+1 Beast Within|NEC|1
+1 Blackblade Reforged|NEC|1
+1 Bonehoard|NEC|1
+1 Chain Reaction|NEC|1
+1 Champion of Lambholt|NEC|1
+1 Chaos Warp|NEC|1
+1 Cinder Glade|NEC|1
+1 Collision of Realms|NEC|1
+1 Command Tower|NEC|1
+1 Concord with the Kami|NEC|1
+1 Decimate|NEC|1
+1 Elemental Mastery|NEC|1
+1 Exotic Orchard|NEC|1
+1 Fertilid|NEC|1
+1 Fireshrieker|NEC|1
+14 Forest|NEO|1
+1 Forgotten Ancient|NEC|1
+1 Game Trail|NEC|1
+1 Genesis Hydra|NEC|1
+1 Goblin Razerunners|NEC|1
+1 Grumgully, the Generous|NEC|1
+1 Gruul Turf|NEC|1
+1 Hunter's Insight|NEC|1
+1 Invigorating Hot Spring|NEO|1
+1 Kaima, the Fractured Calm|NEC|1
+1 Kami of Celebration|NEC|1
+1 Kodama's Reach|NEC|1
+1 Komainu Battle Armor|NEC|1
+1 Kosei, Penitent Warlord|NEC|1
+1 Krenko, Tin Street Kingpin|NEC|1
+1 Loyal Guardian|NEC|1
+1 Mage Slayer|NEC|1
+1 Mossfire Valley|NEC|1
+12 Mountain|NEO|1
+1 Nissa, Voice of Zendikar|NEC|1
+1 One with the Kami|NEC|1
+1 Opal Palace|NEC|1
+1 Oran-Rief, the Vastwood|NEC|1
+1 Ordeal of Nylea|NEC|1
+1 Orochi Merge-Keeper|NEO|1
+1 Ox of Agonas|NEC|1
+1 Primeval Protector|NEC|1
+1 Raging Ravine|NEC|1
+1 Rampant Growth|NEC|1
+1 Rampant Rejuvenator|NEC|1
+1 Rhythm of the Wild|NEC|1
+1 Rishkar's Expertise|NEC|1
+1 Rishkar, Peema Renegade|NEC|1
+1 Sakura-Tribe Elder|NEC|1
+1 Shamanic Revelation|NEC|1
+1 Shifting Shadow|NEC|1
+1 Silkguard|NEC|1
+1 Smoke Spirits' Aid|NEC|1
+1 Snake Umbra|NEC|1
+1 Sol Ring|NEC|1
+1 Soul's Majesty|NEC|1
+1 Spearbreaker Behemoth|NEC|1
+1 Starstorm|NEC|1
+1 Swiftfoot Boots|NEC|1
+1 Sword of Vengeance|NEC|1
+1 Tanuki Transplanter|NEC|1
+1 Taurean Mauler|NEC|1
+1 Temple of Abandon|NEC|1
+1 Towashi Guide-Bot|NEO|1
+1 Ulasht, the Hate Seed|NEC|1
+1 Unquenchable Fury|NEC|1
+1 Vastwood Surge|NEC|1
+1 Walking Skyscraper|NEO|1
+1 Whiptongue Hydra|NEC|1
+[Sideboard]
+

--- a/forge-gui/res/quest/commanderprecons/Urza's Iron Alliance [BRC] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Urza's Iron Alliance [BRC] [2022].dck
@@ -1,0 +1,99 @@
+[metadata]
+Name=Urza's Iron Alliance [BRC] [2022]
+[Commander]
+1 Alela, Artful Provocateur|BRC|1
+1 Urza, Chief Artificer|BRC|1
+[Main]
+1 Ancient Den|BRC|1
+1 Angel of the Ruins|BRC|1
+1 Arcane Sanctum|BRC|1
+1 Arcane Signet|BRC|1
+1 Armix, Filigree Thrasher|BRC|1
+1 Ash Barrens|BRC|1
+1 Austere Command|BRC|1
+1 Azorius Chancery|BRC|1
+1 Azorius Signet|BRC|1
+1 Baleful Strix|BRC|1
+1 Bident of Thassa|BRC|1
+1 Bojuka Bog|BRC|1
+1 Bronze Guardian|BRC|1
+1 Chief of the Foundry|BRC|1
+1 Chrome Courier|BRC|1
+1 Command Tower|BRC|1
+1 Cranial Plating|BRC|1
+1 Darksteel Citadel|BRC|1
+1 Darksteel Juggernaut|BRC|1
+1 Despark|BRC|1
+1 Digsite Engineer|BRC|1
+1 Dimir Aqueduct|BRC|1
+1 Dimir Signet|BRC|1
+1 Etched Champion|BRC|1
+1 Etherium Sculptor|BRC|1
+1 Ethersworn Adjudicator|BRC|1
+1 Evolving Wilds|BRC|1
+1 Exotic Orchard|BRC|1
+1 Filigree Attendant|BRC|1
+1 Goldmire Bridge|BRC|1
+1 Hexavus|BRC|1
+1 Indomitable Archangel|BRC|1
+4 Island|BRC|2
+1 Kayla's Music Box|BRC|1
+1 Liquimetal Torque|BRC|1
+1 Losheel, Clockwork Scholar|BRC|1
+1 March of Progress|BRC|1
+1 Marionette Master|BRC|1
+1 Master of Etherium|BRC|1
+1 Mistvault Bridge|BRC|1
+1 Myr Battlesphere|BRC|1
+1 Noxious Gearhulk|BRC|1
+1 One with the Machine|BRC|1
+1 Orzhov Basilica|BRC|1
+1 Orzhov Signet|BRC|1
+1 Path of Ancestry|BRC|1
+1 Phyrexian Rebirth|BRC|1
+2 Plains|BRC|1
+2 Plains|BRC|2
+1 Prairie Stream|BRC|1
+1 Preordain|BRC|1
+1 Razortide Bridge|BRC|1
+1 Relic of Progenitus|BRC|1
+1 River of Tears|BRC|1
+1 Sai, Master Thopterist|BRC|1
+1 Sanwell, Avenger Ace|BRC|1
+1 Scholar of New Horizons|BRC|1
+1 Seat of the Synod|BRC|1
+1 Sharding Sphinx|BRC|1
+1 Sharuum the Hegemon|BRC|1
+1 Shimmer Dragon|BRC|1
+1 Skullclamp|BRC|1
+1 Skycloud Expanse|BRC|1
+1 Sol Ring|BRC|1
+1 Solemn Simulacrum|BRC|1
+1 Sphinx's Revelation|BRC|1
+1 Spire of Industry|BRC|1
+1 Steel Hellkite|BRC|1
+1 Steel Overseer|BRC|1
+1 Sunken Hollow|BRC|1
+4 Swamp|BRC|2
+1 Swiftfoot Boots|BRC|1
+1 Swords to Plowshares|BRC|1
+1 Tawnos, Solemn Survivor|BRC|1
+1 Tempered Steel|BRC|1
+1 Temple of Deceit|BRC|1
+1 Temple of Enlightenment|BRC|1
+1 Temple of Silence|BRC|1
+1 Teshar, Ancestor's Apostle|BRC|1
+1 Thopter Shop|BRC|1
+1 Thopter Spy Network|BRC|1
+1 Thought Monitor|BRC|1
+1 Thought Vessel|BRC|1
+1 Unbreakable Formation|BRC|1
+1 Urza's Ruinous Blast|BRC|1
+1 Vault of Whispers|BRC|1
+1 Vedalken Humiliator|BRC|1
+1 Vindicate|BRC|1
+1 Whirler Rogue|BRC|1
+1 Wire Surgeons|BRC|1
+1 Wreck Hunter|BRC|1
+[Sideboard]
+


### PR DESCRIPTION
This includes all the new commander decks from 2022 except the Ruinous Powers one since we are missing "Seeker of Slaanesh". 

While most of these decks can be downloaded from the net decks, these usually miss the correct art. Also this makes the decks available in Quest mode.