### PR TITLE
Adventure: Add two new dungeons to the Red biome

### DIFF
--- a/forge-gui/res/adventure/Shandalar/maps/map/lavaforge_1.tmx
+++ b/forge-gui/res/adventure/Shandalar/maps/map/lavaforge_1.tmx
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.9" tiledversion="1.9.1" orientation="orthogonal" renderorder="right-down" width="30" height="17" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="60">
+ <editorsettings>
+  <export target="wastetown..tmx" format="tmx"/>
+ </editorsettings>
+ <properties>
+  <property name="dungeonEffect">{
+  &quot;startBattleWithCard&quot;: [ &quot;Sulfuric Vortex|EMA|1&quot; ],
+}</property>
+ </properties>
+ <tileset firstgid="1" source="../tileset/main.tsx"/>
+ <tileset firstgid="10113" source="../tileset/buildings.tsx"/>
+ <layer id="7" name="Collision" width="30" height="17">
+  <data encoding="base64" compression="zlib">
+   eJxjYMAOVnNg4uEOVgH9uIuHgWENHfwKswuEd/NAxHby0NZ+kJ0wu7CBnTSyWxaPnch2U8PvHpwINj6/YrOfHvGODUiT4E58gJhwRgY7B8heYsFyYHw8B8bnShzx8gwoV89NvHnUCmdS7SYmbblxQjCMTcjuFRyoGFsY1QLd94KAWZQCkFueI9kBYtPazuEOnnPixiug8byCA7caYgAA2K8zEQ==
+  </data>
+ </layer>
+ <layer id="1" name="Background" width="30" height="17">
+  <data encoding="base64" compression="zlib">
+   eJy1lLkRwyAQRQmUQD/W4a6sq1Fh2T24CS3DbKIRy18LgpcxPB6Xt8b4Ez0xOWN+jcyLxozE82IOLagz8LGR7YZrsHHt7AzzIW7u1jaf+7iBQd3aZsmZ8l6N0zZLc2nRuHMdWtD9Lu3ltxXuqdRe2ovuO3JnarjR+1r6zJH/qIZ3oX3oKnd/E2e8Z7rvriH1tmYnd9fyIv5/fA+iJVaH/SXvQl6p8wBa/68t
+  </data>
+ </layer>
+ <layer id="2" name="Ground" width="30" height="17">
+  <data encoding="base64" compression="zlib">
+   eJytlV1OwkAQx8c2lC5wB/EMJj4YnzkA8upHvIk8K/higicwnkIs3kR9FfGhMYLiTHYmO93WSmNJftluu8x/vrIziQAmzDWy13QcIFtgGYUA8wAgRRbIBe4vQ7t/R/rIYWDfybcFn39FrnAPyo5oin3hPgaYImtj14fY/mfMzNneXPlA+3GYhzS1bbKjNbUWtACOjePbOB+m7APZG5XYL4NyC6zpa5VxYpyNj4Z7fkIbz0iPV01Prbtcw6MN9XT8lHutSZy3AYYbQPFWiXXYzGvrmO/MZrpV81sUt/Qd6W530By+6/JKtAt8qZrfMn3puzU/iy9FuV/i98e4Hu3feo9y0PWgX53aCdqZMV8m2+MvLcj8qCfqyjfFqHucnqXXbo17J2fOatI9NS4e0ZZe2+lYPf2tzngnUfb+lbubGARW9xP1lw1b49U/6pyomsqMkbny5t3lA54LN+qOJv1ZnOcvfyjOfW+WUU773oxKWZt06a6kuAmIXM11LcQfX5/iXBl3VudU5uIicKSMroX4oLW1vn+3JZxXfVZyWjQPNT+9VvL7
+  </data>
+ </layer>
+ <layer id="6" name="Clutter" width="30" height="17">
+  <data encoding="base64" compression="zlib">
+   eJxjYBgFIFDNO9AuQAUyQFw1QG7aRUWzPrNT0TA0EEclc2qQwlmMhYFBHAlLsBBnhiYjeXb/gNKB0HCSJkHvZiS3hZERzoScvBmH3wNZSbeLENiCFOafcJj/ngr2wuJ3G9RvyH75SYZ5DljEAvDExQdW/H7EB/aQqL4OKV2Dyjcykygc7ERiE1NG0KP8gtkB89tOnCqpCxjRaHoBatkLAB0+FMk=
+  </data>
+ </layer>
+ <layer id="3" name="Foreground" width="30" height="17">
+  <properties>
+   <property name="spriteLayer" type="bool" value="true"/>
+  </properties>
+  <data encoding="base64" compression="zlib">
+   eJzNlUtOw0AMhp0FEzaNlPYgIKXAgoolIDgEiANwiJbXGlQe4iFxoEoUroDK4wQI0cJYsTXO1DMIyIJf+qVkJp3PduwGIK63mW8e+KP6BqCTTnOSOs5uAJySzxrTTF/Pdr1n11/M7xjsc+t2VvpCsGWezELvUSzdNM5PhIvMMUJeyOiHxjGRlYDuLrFD++Bxl6zvyYsKl2s8Iv51E2ArL72dV89F9QTfV6Gc79cB15mJe0eU64dljcmfxL9p6rn7GoocHyJc7R1JboiPeoz025zo00SJh/sJ915NmMue5I67783AvL0/MaV3Z6tcTcjGvRFxl1sAlzavnQhXMiRL67W+MrsypgN71rpx98yX7rTKvYF99inQ2+BdF8p79cXs0KxwrpibNlcTW7t3YZzRoddnMfaaqRpjOaZ63lHfr9rrQ2/er7w4bgPzJhX7BmAsm8bVeIOYUphrW6ytpPr/70/FOQzSer4X/53L7Dq4X+YsdYM=
+  </data>
+ </layer>
+ <objectgroup id="4" name="Objects">
+  <object id="38" template="../obj/entry_up.tx" x="208" y="272"/>
+  <object id="50" template="../obj/treasure.tx" x="378.5" y="93">
+   <properties>
+    <property name="reward">[{
+  &quot;type&quot;: &quot;randomCard&quot;,
+  &quot;count&quot;: 2,
+  &quot;probability&quot;: 1,
+  &quot;colors&quot;: [ &quot;red&quot; ]
+},{
+  &quot;type&quot;: &quot;randomCard&quot;,
+  &quot;count&quot;: 1,
+  &quot;probability&quot;: 1,
+  &quot;rarity&quot;: [ &quot;mythicrare&quot; ],
+  &quot;colors&quot;: [ &quot;red&quot; ]
+},{
+  &quot;type&quot;: &quot;randomCard&quot;,
+  &quot;count&quot;: 1,
+  &quot;probability&quot;: 0.6,
+  &quot;rarity&quot;: [ &quot;rare&quot;, &quot;mythicrare&quot; ],
+  &quot;addMaxCount&quot;: 1
+},{
+  &quot;type&quot;: &quot;randomCard&quot;,
+  &quot;count&quot;: 1,
+  &quot;probability&quot;: 0.5,
+  &quot;addMaxCount&quot;: 2
+}]</property>
+   </properties>
+  </object>
+  <object id="51" template="../obj/treasure.tx" x="128.5" y="58">
+   <properties>
+    <property name="reward">[{
+  &quot;type&quot;: &quot;randomCard&quot;,
+  &quot;count&quot;: 2,
+  &quot;probability&quot;: 1,
+  &quot;colors&quot;: [ &quot;red&quot; ]
+},{
+  &quot;type&quot;: &quot;randomCard&quot;,
+  &quot;count&quot;: 1,
+  &quot;probability&quot;: 1,
+  &quot;rarity&quot;: [ &quot;rare&quot; ],
+  &quot;colors&quot;: [ &quot;red&quot; ]
+},{
+  &quot;type&quot;: &quot;randomCard&quot;,
+  &quot;count&quot;: 1,
+  &quot;probability&quot;: 0.6,
+  &quot;rarity&quot;: [ &quot;uncommon&quot;, &quot;rare&quot; ],
+  &quot;addMaxCount&quot;: 1
+},{
+  &quot;type&quot;: &quot;randomCard&quot;,
+  &quot;count&quot;: 1,
+  &quot;probability&quot;: 0.5,
+  &quot;addMaxCount&quot;: 2
+}]</property>
+   </properties>
+  </object>
+  <object id="52" template="../obj/gold.tx" x="17" y="110">
+   <properties>
+    <property name="reward">[
+  {
+    &quot;type&quot;: &quot;gold&quot;,
+    &quot;count&quot;: 110,
+    &quot;addMaxCount&quot;: 50
+ }
+]</property>
+   </properties>
+  </object>
+  <object id="53" template="../obj/gold.tx" x="305.5" y="178">
+   <properties>
+    <property name="reward">[
+  {
+    &quot;type&quot;: &quot;gold&quot;,
+    &quot;count&quot;: 110,
+    &quot;addMaxCount&quot;: 50
+ }
+]</property>
+   </properties>
+  </object>
+  <object id="54" template="../obj/gold.tx" x="165.5" y="77">
+   <properties>
+    <property name="reward">[
+  {
+    &quot;type&quot;: &quot;gold&quot;,
+    &quot;count&quot;: 110,
+    &quot;addMaxCount&quot;: 50
+ }
+]</property>
+   </properties>
+  </object>
+  <object id="55" template="../obj/enemy.tx" x="160.167" y="200.5">
+   <properties>
+    <property name="enemy" value="Viashino"/>
+   </properties>
+  </object>
+  <object id="56" template="../obj/enemy.tx" x="50.5" y="124.5">
+   <properties>
+    <property name="enemy" value="Minotaur Flayer"/>
+   </properties>
+  </object>
+  <object id="57" template="../obj/enemy.tx" x="193" y="109.5">
+   <properties>
+    <property name="enemy" value="Kavu"/>
+   </properties>
+  </object>
+  <object id="58" template="../obj/enemy.tx" x="251.5" y="156">
+   <properties>
+    <property name="effect">{
+ &quot;lifeModifier&quot;: 6,
+ &quot;startBattleWithCard&quot;: [ &quot;c_a_treasure_sac&quot; ]
+}</property>
+    <property name="enemy" value="Red Wiz2"/>
+   </properties>
+  </object>
+  <object id="59" template="../obj/enemy.tx" x="366" y="125.5">
+   <properties>
+    <property name="effect">{
+ &quot;lifeModifier&quot;: 4,
+ &quot;startBattleWithCard&quot;: [ &quot;Irencrag Pyromancer|ELD|1&quot; ]
+}</property>
+    <property name="enemy" value="Mindclaw Shaman"/>
+   </properties>
+  </object>
+ </objectgroup>
+</map>

--- a/forge-gui/res/adventure/Shandalar/maps/map/lavaforge_2.tmx
+++ b/forge-gui/res/adventure/Shandalar/maps/map/lavaforge_2.tmx
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.9" tiledversion="1.9.1" orientation="orthogonal" renderorder="right-down" width="30" height="17" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="64">
+ <editorsettings>
+  <export target="wastetown..tmx" format="tmx"/>
+ </editorsettings>
+ <properties>
+  <property name="dungeonEffect">{
+  &quot;startBattleWithCard&quot;: [ &quot;Burning Sands|ODY|1&quot; ],
+}</property>
+ </properties>
+ <tileset firstgid="1" source="../tileset/main.tsx"/>
+ <tileset firstgid="10113" source="../tileset/buildings.tsx"/>
+ <layer id="7" name="Collision" width="30" height="17">
+  <data encoding="base64" compression="zlib">
+   eJzVlNsKwyAMhvWuwp5Lyl507PBWbdfBXmJK+9MsxERlN/shUCTmy6k6dygG5+7Db+wflOvNuqV85/S9JPNusyl9PxrrqPX3O5PycA527mEr3xKYWl7gz7vRHFblrsX0io8XDP0/dzCzRtZbTZzdy5RmWqOenYskxzF8x2nhQj37TntcYr9PdpwpHHtJ86Bxeb0WV1LJj/c/Fub/TOfXoY4r7bRkkLVzfMZWPK0/LVzULOkybG/CSnxwxu/wPEpvDGdLsV/KP8bz1eZUUzt4NYK/ZVY86z736dEHpU9ZKQ==
+  </data>
+ </layer>
+ <layer id="1" name="Background" width="30" height="17">
+  <data encoding="base64" compression="zlib">
+   eJy7zsnAcB0Hfs2CH+PSRwkmZCct7BVlx42pbT/MDHx24rOfHnai44Gwk1y7B9JeSu0kx25q2kuK3dS2l1h30NpeXHYPlL3ElFFD1V5CbiDHzbTyOzHlL7XsRS7HaFXnAQDfK/8w
+  </data>
+ </layer>
+ <layer id="2" name="Ground" width="30" height="17">
+  <data encoding="base64" compression="zlib">
+   eJydlbFOw0AMhl2VIQldmtIZGGFHlMLOU6RFHdkoCHYeAwQrj1EoLGWlSDADT0HaYitnnev4UolIv6I7Rf7O//13mcYAHdR5AlADgFEEsMAx4LgXlzVHPUXFt2f4TRfHU9R7XMx9uPEqHShmiFfFHia+Bo+7K7hWj2Mc5/h+dm/WS7TMXgi+1B7OXyae0XH9dRU3E70QcxaXa5F+A3zNpp6JMzS8YLb0VjPvUoB+s9B9usxnL2gNFpv0hXW/hX5Qb46bVfSZI2/mtFBsuQaLTcxj1PW610Psc8e9nhjeHrYAbtNCgwr2wK29L2psNgC2UEns39sNz9W99gK1aQ3M1t7Lnilrj5GX9EDmTa8zF7U1n9ifzgPyft4s+1115nhvQ1zeU1mX1W77NWjfOW8yc5It86y57KeVJcr31Yafs9hW5mR++F6h+UkdYLfuv79JfZ6OWuWc6bnQvsjM6XtGZ1E+Vg+WeD1W5gaB/WYvuGfr2cH507VCI5FTGkuf5LljT/iOoz1nz6nHfXF3TFz9muK91sP/CL1HVcqEtxdJwZZnYGLwxpF9TuT3q8T1+rH/d7IfufBFngm6V/Re/Ud8R/0B2R3vqA==
+  </data>
+ </layer>
+ <layer id="6" name="Clutter" width="30" height="17">
+  <data encoding="base64" compression="zlib">
+   eJzVlT0OwjAMhcuUgfpuILHCPRoQt+F0TNAB2GjUWjLua/PjLFiyrCSOPz9FSZrmf+22HePGUMNTWY3eGaATj31tLfiZbCxdN6UnlHdv6zN1TohXoZfPR7I5/2RgytyO5tpjbmHqPan1l+ZK2JrP4537XZd2BPMx9kHdE81DvbB/phjOHnFSNCONuWcbq4v6it3rdwYL7UecpXGJPs3lOxLsQpiFmLXspVjsezfn51rpuyajX3mju0rvtyesM+V/eAwa+3aMz8G/148UeA==
+  </data>
+ </layer>
+ <layer id="3" name="Foreground" width="30" height="17">
+  <properties>
+   <property name="spriteLayer" type="bool" value="true"/>
+  </properties>
+  <data encoding="base64" compression="zlib">
+   eJytlU1OwzAQhScJ7IiPgYBtWrgJoHILTsECASr9gWMVuEWldlNVsGMse5SX0bgOpSO9NHFsf2/GdvpQE507oguWj+VJ+C0MpeIMxsscTxXRuiRasV6q8Pwc5dsf65bj+2tOjpkKYXvmlBmzqHkd2r1Pndc3X17Z07Bq2wZ8/9PDADJEb6yBC3qPbPGGzElp13lcBj+aj30a1zJSGrp2HGWYFl884Fog94r1EXWpuH3ytNYbPWD+TSIv3S5DtkU+z5SXDXAXkONnhtu3vrvqbq053ms/xZ656rnHaq01V0K+D/+psZW3nD08d1M4u8jWXNqDaY2XGjRqn0nM+P3tgXLW8ntuofYZxqFqbXHVluvUelfO13y5ibqLfUbxOVcn/Y2RWMH+8myZi4A3L8OzNa/47RN4zk9dl4184UkI6+uoWzvpnxPOJ/+9eK6Wyodm3x/ba/aX+AVxyWVB
+  </data>
+ </layer>
+ <objectgroup id="4" name="Objects">
+  <object id="38" template="../obj/entry_up.tx" x="208" y="272"/>
+  <object id="50" template="../obj/treasure.tx" x="378.5" y="93">
+   <properties>
+    <property name="reward">[{
+  &quot;type&quot;: &quot;randomCard&quot;,
+  &quot;count&quot;: 2,
+  &quot;probability&quot;: 1,
+  &quot;colors&quot;: [ &quot;red&quot; ]
+},{
+  &quot;type&quot;: &quot;randomCard&quot;,
+  &quot;count&quot;: 1,
+  &quot;probability&quot;: 1,
+  &quot;rarity&quot;: [ &quot;mythicrare&quot; ],
+  &quot;colors&quot;: [ &quot;red&quot; ]
+},{
+  &quot;type&quot;: &quot;randomCard&quot;,
+  &quot;count&quot;: 1,
+  &quot;probability&quot;: 0.6,
+  &quot;rarity&quot;: [ &quot;rare&quot;, &quot;mythicrare&quot; ],
+  &quot;addMaxCount&quot;: 1
+},{
+  &quot;type&quot;: &quot;randomCard&quot;,
+  &quot;count&quot;: 1,
+  &quot;probability&quot;: 0.5,
+  &quot;addMaxCount&quot;: 2
+}]</property>
+   </properties>
+  </object>
+  <object id="51" template="../obj/treasure.tx" x="272.5" y="79.3333">
+   <properties>
+    <property name="reward">[{
+  &quot;type&quot;: &quot;randomCard&quot;,
+  &quot;count&quot;: 2,
+  &quot;probability&quot;: 1,
+  &quot;colors&quot;: [ &quot;red&quot; ]
+},{
+  &quot;type&quot;: &quot;randomCard&quot;,
+  &quot;count&quot;: 1,
+  &quot;probability&quot;: 1,
+  &quot;rarity&quot;: [ &quot;rare&quot; ],
+  &quot;colors&quot;: [ &quot;red&quot; ]
+},{
+  &quot;type&quot;: &quot;randomCard&quot;,
+  &quot;count&quot;: 1,
+  &quot;probability&quot;: 0.6,
+  &quot;rarity&quot;: [ &quot;uncommon&quot;, &quot;rare&quot; ],
+  &quot;addMaxCount&quot;: 1
+},{
+  &quot;type&quot;: &quot;randomCard&quot;,
+  &quot;count&quot;: 1,
+  &quot;probability&quot;: 0.5,
+  &quot;addMaxCount&quot;: 2
+}]</property>
+   </properties>
+  </object>
+  <object id="52" template="../obj/gold.tx" x="146.333" y="128.667">
+   <properties>
+    <property name="reward">[
+  {
+    &quot;type&quot;: &quot;gold&quot;,
+    &quot;count&quot;: 110,
+    &quot;addMaxCount&quot;: 50
+ }
+]</property>
+   </properties>
+  </object>
+  <object id="53" template="../obj/gold.tx" x="416.167" y="141.333">
+   <properties>
+    <property name="reward">[
+  {
+    &quot;type&quot;: &quot;gold&quot;,
+    &quot;count&quot;: 110,
+    &quot;addMaxCount&quot;: 50
+ }
+]</property>
+   </properties>
+  </object>
+  <object id="54" template="../obj/gold.tx" x="287.5" y="253.667">
+   <properties>
+    <property name="reward">[
+  {
+    &quot;type&quot;: &quot;gold&quot;,
+    &quot;count&quot;: 110,
+    &quot;addMaxCount&quot;: 50
+ }
+]</property>
+   </properties>
+  </object>
+  <object id="55" template="../obj/enemy.tx" x="146.167" y="171.833">
+   <properties>
+    <property name="enemy" value="Viashino"/>
+   </properties>
+  </object>
+  <object id="56" template="../obj/enemy.tx" x="45.1667" y="121.833">
+   <properties>
+    <property name="enemy" value="Amonkhet Minotaur"/>
+   </properties>
+  </object>
+  <object id="57" template="../obj/enemy.tx" x="266.333" y="222.167">
+   <properties>
+    <property name="enemy" value="Flame Elemental"/>
+   </properties>
+  </object>
+  <object id="58" template="../obj/enemy.tx" x="252.833" y="45.3333">
+   <properties>
+    <property name="effect">{
+ &quot;lifeModifier&quot;: 4,
+ &quot;startBattleWithCard&quot;: [ &quot;Flagstones of Trokair|TSR|1&quot; ]
+}</property>
+    <property name="enemy" value="Axgard Dwarf"/>
+   </properties>
+  </object>
+  <object id="59" template="../obj/enemy.tx" x="335.333" y="146.167">
+   <properties>
+    <property name="effect">{
+ &quot;lifeModifier&quot;: 4,
+ &quot;startBattleWithCard&quot;: [ &quot;Desert|AFC|1&quot; ]
+}</property>
+    <property name="enemy" value="Red Wiz2"/>
+   </properties>
+  </object>
+  <object id="61" template="../obj/treasure.tx" x="418" y="238.667">
+   <properties>
+    <property name="reward">[{
+  &quot;type&quot;: &quot;randomCard&quot;,
+  &quot;count&quot;: 2,
+  &quot;probability&quot;: 1,
+  &quot;colors&quot;: [ &quot;red&quot; ]
+},{
+  &quot;type&quot;: &quot;randomCard&quot;,
+  &quot;count&quot;: 1,
+  &quot;probability&quot;: 1,
+  &quot;rarity&quot;: [ &quot;rare&quot; ],
+  &quot;colors&quot;: [ &quot;red&quot; ]
+},{
+  &quot;type&quot;: &quot;randomCard&quot;,
+  &quot;count&quot;: 1,
+  &quot;probability&quot;: 0.6,
+  &quot;rarity&quot;: [ &quot;uncommon&quot;, &quot;rare&quot; ],
+  &quot;addMaxCount&quot;: 1
+},{
+  &quot;type&quot;: &quot;randomCard&quot;,
+  &quot;count&quot;: 1,
+  &quot;probability&quot;: 0.5,
+  &quot;addMaxCount&quot;: 2
+}]</property>
+   </properties>
+  </object>
+  <object id="62" template="../obj/enemy.tx" x="354" y="240">
+   <properties>
+    <property name="enemy" value="Dinosaur"/>
+   </properties>
+  </object>
+  <object id="63" template="../obj/enemy.tx" x="256.667" y="126">
+   <properties>
+    <property name="enemy" value="Wild-Magic Sorcerer"/>
+   </properties>
+  </object>
+ </objectgroup>
+</map>

--- a/forge-gui/res/adventure/Shandalar/maps/tileset/buildings.atlas
+++ b/forge-gui/res/adventure/Shandalar/maps/tileset/buildings.atlas
@@ -331,6 +331,9 @@ StonePyramid
 Mine
   xy: 96, 144
   size: 32, 32
+LavaForge
+  xy: 384, 336
+  size: 32, 32
 black_castle 
   xy: 0, 800
   size: 64, 64       

--- a/forge-gui/res/adventure/Shandalar/world/points_of_interest.json
+++ b/forge-gui/res/adventure/Shandalar/world/points_of_interest.json
@@ -1645,5 +1645,23 @@
         "spriteAtlas": "maps/tileset/buildings.atlas",
         "sprite": "Mine",
         "map": "maps/map/crawlspace.tmx"
-}
+},
+{
+        "name": "LavaForge1",
+        "type": "dungeon",
+        "count": 1,
+        "radiusFactor": 0.8,
+        "spriteAtlas": "maps/tileset/buildings.atlas",
+        "sprite": "LavaForge",
+        "map": "maps/map/lavaforge_1.tmx"
+},
+{
+        "name": "LavaForge2",
+        "type": "dungeon",
+        "count": 1,
+        "radiusFactor": 0.8,
+        "spriteAtlas": "maps/tileset/buildings.atlas",
+        "sprite": "LavaForge",
+        "map": "maps/map/lavaforge_2.tmx"
+} 
 ]

--- a/forge-gui/res/adventure/Shandalar/world/red.json
+++ b/forge-gui/res/adventure/Shandalar/world/red.json
@@ -71,6 +71,8 @@
 	"BarbarianCamp",
 	"BarbarianCamp1",
 	"BarbarianCamp2",
+	"LavaForge1",
+	"LavaForge2",
 	"Maze",
 	"Maze1",
 	"Maze2",


### PR DESCRIPTION
This adds two new dungeons in the Red biome to the default Shandalar world in Adventure mode. They both use this sprite on the overworld map:

![LavaForge](https://user-images.githubusercontent.com/4433625/201453504-f7bf32cf-77c6-4b36-8c28-bda5e2453c19.png)

**"LavaForge1"**: Each enemy starts with [Sulfuric Vortex](https://scryfall.com/card/ema/150/sulfuric-vortex), putting pressure on the duel, especially if you don't have a lot of life. Burn spells are especially potent. Minibosses are a Red Wizard (who plays burn), and Mindclaw Shaman, who further punishes your life total for having cards in hand.

![LavaForge1](https://user-images.githubusercontent.com/4433625/201453622-73aa5631-29fc-488f-84a1-3c32d35bca97.png)

**"LavaForge2"**: Each enemy starts with  [Burning Sands](https://scryfall.com/card/ody/180/burning-sands), making it costly to lose creatures. It's a bit frustrating if you fall behind, but fun if you can get ahead and really bully the AI decks. The Red Wizard miniboss is especially challenging when it goes after your creatures. The other miniboss is a Red/White dwarf enemy that starts with [Flagstones of Trokair](https://scryfall.com/card/tsr/278/flagstones-of-trokair) (from testing, it looks like the AI knows to sacrifice that first).

![LavaForge2](https://user-images.githubusercontent.com/4433625/201453756-441d1201-ecb3-4bc1-b9eb-2101e075a1e8.png)

I hope you enjoy. :)
