### PR TITLE
Adventure: [Balance] Doppelganger enemy no longer drops basic lands

### DIFF
--- a/forge-gui/res/adventure/Shandalar/world/enemies.json
+++ b/forge-gui/res/adventure/Shandalar/world/enemies.json
@@ -2053,7 +2053,14 @@
 		{
 			"type": "deckCard",
 			"probability": 1,
-			"count": 1
+			"count": 1,
+			"rarity": [
+				"common",
+				"uncommon",
+				"rare",
+				"mythicrare",
+				"special"
+			]
 		},
 		{
 			"type": "gold",


### PR DESCRIPTION
I'm hesitant to submit balance fixes, but I hope this is not too controversial. There is an enemy in Adventure mode called "Doppelganger" who plays a copy of your deck and starts with 20 life on Normal difficulty. Currently, its reward is to give you one card that is a copy of a card in your deck (and sometimes some gold). This changes it so that the Doppelganger never gives you a basic land as that card. 

Note the the Doppelganger essentially gets more challenging as your deck improves, so it is always a difficult enemy. I think buffing the reward a little bit is okay.