### PR TITLE
Adventure: Fix "colorID" card rewards when a player's color identity is multicolor

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/data/RewardData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/RewardData.java
@@ -117,20 +117,6 @@ public class RewardData {
                 type="randomCard";
             int maxCount=Math.round(addMaxCount*Current.player().getDifficulty().rewardMaxFactor);
             int addedCount = (maxCount > 0 ? WorldSave.getCurrentSave().getWorld().getRandom().nextInt(maxCount) : 0);
-            if( colors != null && colors.length > 0 ) { //Filter special "colorID" case.
-                String C = Current.player().getColorIdentityLong();
-                for(int i = 0; i < colors.length; i++){
-                    if(colors[i].equals("colorID")){
-                        if(C.equals("colorless")) { //Colorless nullifies all other possible colors.
-                            //A quirk of the filter, but flavorful.
-                            colorType = "Colorless";
-                            colors = null;
-                            break;
-                        }
-                        else colors[i] = C;
-                    }
-                }
-            }
 
             switch(type) {
                 case "card":

--- a/forge-gui-mobile/src/forge/adventure/util/CardUtil.java
+++ b/forge-gui-mobile/src/forge/adventure/util/CardUtil.java
@@ -65,7 +65,7 @@ public class CardUtil {
 
             if(this.colors!= MagicColor.ALL_COLORS)
             {
-                if(!card.getRules().getColor().hasNoColorsExcept(this.colors)||card.getRules().getColor().isColorless())
+                if(!card.getRules().getColor().hasNoColorsExcept(this.colors)||(this.colors != MagicColor.COLORLESS && card.getRules().getColor().isColorless()))
                     return !this.shouldBeEqual;
             }
             if(colorType!=ColorType.Any)
@@ -182,7 +182,11 @@ public class CardUtil {
                 this.colors=0;
                 for(String color:type.colors)
                 {
-                    colors|=MagicColor.fromName(color.toLowerCase());
+                    if("colorID".equals(color))
+                        for (byte c : Current.player().getColorIdentity())
+                            colors |= c;
+                    else
+                        colors |= MagicColor.fromName(color.toLowerCase());
                 }
             }
             if(type.keyWords!=null&&type.keyWords.length!=0)


### PR DESCRIPTION
Enemies and chests in Adventure mode can drop cards of color "colorID", which is determined by the color identity of the player's currently selected deck. The current logic is flawed, since it relies on `Current.player().getColorIdentityLong()`, which will return the string "multi" if the color identity contains more than one color. This can be easily verified in the Adventure console (F10) via this command `setColorID wu`. "multi" isn't a color, so it doesn't match any cards.

To avoid building up a new array of colors in RewardData, I moved the logic that checks "colorID" to the CardPredicate instead, where it's easier to interact directly with the color objects. I also added a slight tweak to logic to make it work if your color identity is colorless (without the change, it does not match any cards).

Tested in Adventure mode with the `setColorID` command to test colorless, single color, and multicolor cases, then opened chests that had rewards using "colorID".