### PR TITLE
J22: Creeping Bloodsucker and support

### DIFF
--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -2426,6 +2426,9 @@ public class GameAction {
                     }
                 }
             }
+            if (cause.hasParam("RememberAmount")) {
+                cause.getHostCard().addRemembered(damageMap.totalAmount());
+            }
         }
 
         preventMap.triggerPreventDamage(isCombat);

--- a/forge-gui/res/cardsfolder/upcoming/creeping_bloodsucker.txt
+++ b/forge-gui/res/cardsfolder/upcoming/creeping_bloodsucker.txt
@@ -1,0 +1,11 @@
+Name:Creeping Bloodsucker
+ManaCost:1 B
+Types:Creature Vampire
+PT:1/2
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ TrigDamage | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, CARDNAME deals 1 damage to each opponent. You gain life equal to the damage dealt this way.
+SVar:TrigDamage:DB$ DealDamage | Defined$ Opponent | NumDmg$ 1 | RememberAmount$ True | SubAbility$ DBGainLife
+SVar:DBGainLife:DB$ GainLife | LifeAmount$ X | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:X:Count$RememberedNumber
+DeckHas:Ability$LifeGain
+Oracle:At the beginning of your upkeep, Creeping Bloodsucker deals 1 damage to each opponent. You gain life equal to the damage dealt this way.


### PR DESCRIPTION
Similar cards use `SVar:Y:Count$TotalDamageDoneByThisTurn` but since this is a permanent, I thought it might be safer to do it this way.