### PR TITLE
Bunch of fixes

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiAttackController.java
+++ b/forge-ai/src/main/java/forge/ai/AiAttackController.java
@@ -1424,7 +1424,7 @@ public class AiAttackController {
                     continue;
                 }
                 if (sa.usesTargeting()) {
-                    sa.setActivatingPlayer(c.getController());
+                    sa.setActivatingPlayer(c.getController(), true);
                     List<Card> validTargets = CardUtil.getValidCardsToTarget(sa.getTargetRestrictions(), sa);
                     if (validTargets.isEmpty()) {
                         missTarget = true;

--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -165,7 +165,7 @@ public class AiController {
         for (final Card c : all) {
             for (final SpellAbility sa : c.getNonManaAbilities()) {
                 if (sa instanceof SpellPermanent) {
-                    sa.setActivatingPlayer(player);
+                    sa.setActivatingPlayer(player, true);
                     if (checkETBEffects(c, sa, ApiType.Counter)) {
                         spellAbilities.add(sa);
                     }
@@ -499,7 +499,7 @@ public class AiController {
                     if (reSA == null || !ApiType.Tap.equals(reSA.getApi())) {
                         continue;
                     }
-                    reSA.setActivatingPlayer(reSA.getHostCard().getController());
+                    reSA.setActivatingPlayer(reSA.getHostCard().getController(), true);
                     if (reSA.metConditions()) {
                         foundTapped = true;
                         break;
@@ -583,7 +583,7 @@ public class AiController {
 
         for (final SpellAbility sa : ComputerUtilAbility.getOriginalAndAltCostAbilities(possibleCounters, player)) {
             SpellAbility currentSA = sa;
-            sa.setActivatingPlayer(player);
+            sa.setActivatingPlayer(player, true);
             // check everything necessary
 
             AiPlayDecision opinion = canPlayAndPayFor(currentSA);
@@ -638,7 +638,7 @@ public class AiController {
             if (saApi == ApiType.Counter || saApi == exceptSA) {
                 continue;
             }
-            sa.setActivatingPlayer(player);
+            sa.setActivatingPlayer(player, true);
             // TODO: this currently only works as a limited prediction of permanent spells.
             // Ideally this should cast canPlaySa to determine that the AI is truly able/willing to cast a spell,
             // but that is currently difficult to implement due to various side effects leading to stack overflow.
@@ -1734,7 +1734,7 @@ public class AiController {
                 }
             }
 
-            sa.setActivatingPlayer(player);
+            sa.setActivatingPlayer(player, true);
             SpellAbility root = sa.getRootAbility();
 
             if (root.isSpell() || root.isTrigger() || root.isReplacementAbility()) {

--- a/forge-ai/src/main/java/forge/ai/ComputerUtil.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtil.java
@@ -244,7 +244,7 @@ public class ComputerUtil {
 
     // this is used for AI's counterspells
     public static final boolean playStack(SpellAbility sa, final Player ai, final Game game) {
-        sa.setActivatingPlayer(ai);
+        sa.setActivatingPlayer(ai, true);
         if (!ComputerUtilCost.canPayCost(sa, ai, false))
             return false;
 
@@ -284,7 +284,7 @@ public class ComputerUtil {
 
     public static final void playSpellAbilityForFree(final Player ai, final SpellAbility sa) {
         final Game game = ai.getGame();
-        sa.setActivatingPlayer(ai);
+        sa.setActivatingPlayer(ai, true);
 
         final Card source = sa.getHostCard();
         if (sa.isSpell() && !source.isCopiedSpell()) {
@@ -296,7 +296,7 @@ public class ComputerUtil {
 
     public static final boolean playSpellAbilityWithoutPayingManaCost(final Player ai, final SpellAbility sa, final Game game) {
         SpellAbility newSA = sa.copyWithNoManaCost();
-        newSA.setActivatingPlayer(ai);
+        newSA.setActivatingPlayer(ai, true);
 
         if (!CostPayment.canPayAdditionalCosts(newSA.getPayCosts(), newSA) || !ComputerUtilMana.canPayManaCost(newSA, ai, 0, false)) {
             return false;
@@ -336,7 +336,7 @@ public class ComputerUtil {
     }
 
     public static final void playNoStack(final Player ai, SpellAbility sa, final Game game, final boolean effect) {
-        sa.setActivatingPlayer(ai);
+        sa.setActivatingPlayer(ai, true);
         // TODO: We should really restrict what doesn't use the Stack
         if (ComputerUtilCost.canPayCost(sa, ai, effect)) {
             final Card source = sa.getHostCard();
@@ -955,7 +955,7 @@ public class ComputerUtil {
                     if (!sa.isActivatedAbility() || sa.getApi() != ApiType.Regenerate) {
                         continue; // Not a Regenerate ability
                     }
-                    sa.setActivatingPlayer(controller);
+                    sa.setActivatingPlayer(controller, true);
                     if (!(sa.canPlay() && ComputerUtilCost.canPayCost(sa, controller, false))) {
                         continue; // Can't play ability
                     }
@@ -1530,7 +1530,7 @@ public class ComputerUtil {
                 if (sa.getApi() != ApiType.DealDamage) {
                     continue;
                 }
-                sa.setActivatingPlayer(ai);
+                sa.setActivatingPlayer(ai, true);
                 final String numDam = sa.getParam("NumDmg");
                 int dmg = AbilityUtils.calculateAmount(sa.getHostCard(), numDam, sa);
                 if (dmg <= damage) {
@@ -2984,7 +2984,7 @@ public class ComputerUtil {
                 }
                 SpellAbility abTest = withoutPayingManaCost ? ab.copyWithNoManaCost() : ab.copy();
                 // at this point, we're assuming that card will be castable from whichever zone it's in by the AI player.
-                abTest.setActivatingPlayer(ai);
+                abTest.setActivatingPlayer(ai, true);
                 abTest.getRestrictions().setZone(c.getZone().getZoneType());
                 if (AiPlayDecision.WillPlay == aic.canPlaySa(abTest) && ComputerUtilCost.canPayCost(abTest, ai, false)) {
                     targets.add(c);

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilAbility.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilAbility.java
@@ -91,7 +91,7 @@ public class ComputerUtilAbility {
         List<SpellAbility> originListWithAddCosts = Lists.newArrayList();
         for (SpellAbility sa : originList) {
             // If this spell has alternative additional costs, add them instead of the unmodified SA itself
-            sa.setActivatingPlayer(player);
+            sa.setActivatingPlayer(player, true);
             originListWithAddCosts.addAll(GameActionUtil.getAdditionalCostSpell(sa));
         }
 
@@ -118,7 +118,7 @@ public class ComputerUtilAbility {
 
         final List<SpellAbility> result = Lists.newArrayList();
         for (SpellAbility sa : newAbilities) {
-            sa.setActivatingPlayer(player);
+            sa.setActivatingPlayer(player, true);
 
             // Optional cost selection through the AI controller
             boolean choseOptCost = false;

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
@@ -687,7 +687,7 @@ public class ComputerUtilCard {
                     if (!ComputerUtilCost.canPayCost(sa, opp, sa.isTrigger())) {
                         continue;
                     }
-                    sa.setActivatingPlayer(opp);
+                    sa.setActivatingPlayer(opp, true);
                     if (sa.canTarget(card)) {
                         continue;
                     }

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCombat.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCombat.java
@@ -1253,7 +1253,7 @@ public class ComputerUtilCombat {
                 continue;
             }
 
-            sa.setActivatingPlayer(source.getController());
+            sa.setActivatingPlayer(source.getController(), true);
 
             if (sa.hasParam("Cost")) {
                 if (!CostPayment.canPayAdditionalCosts(sa.getPayCosts(), sa)) {
@@ -1433,7 +1433,7 @@ public class ComputerUtilCombat {
             if (sa == null) {
                 continue;
             }
-            sa.setActivatingPlayer(source.getController());
+            sa.setActivatingPlayer(source.getController(), true);
 
             if (sa.usesTargeting()) {
                 continue; // targeted pumping not supported

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
@@ -526,7 +526,7 @@ public class ComputerUtilCost {
      */
     public static boolean canPayCost(final SpellAbility sa, final Player player, final boolean effect) {
         if (sa.getActivatingPlayer() == null) {
-            sa.setActivatingPlayer(player); // complaints on NPE had came before this line was added.
+            sa.setActivatingPlayer(player, true); // complaints on NPE had came before this line was added.
         }
 
         final boolean cannotBeCountered = !CardFactoryUtil.isCounterable(sa.getHostCard());

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
@@ -82,7 +82,7 @@ public class ComputerUtilMana {
     public static boolean hasEnoughManaSourcesToCast(final SpellAbility sa, final Player ai) {
         if (ai == null || sa == null)
             return false;
-        sa.setActivatingPlayer(ai);
+        sa.setActivatingPlayer(ai, true);
         return payManaCost(sa, ai, true, 0, false, false);
     }
 
@@ -90,7 +90,7 @@ public class ComputerUtilMana {
         int score = 0;
 
         for (SpellAbility ability : card.getSpellAbilities()) {
-            ability.setActivatingPlayer(card.getController());
+            ability.setActivatingPlayer(card.getController(), true);
             if (ability.isManaAbility()) {
                 score += ability.calculateScoreForManaAbility();
             }
@@ -1012,7 +1012,7 @@ public class ComputerUtilMana {
 
         if (checkCosts) {
             // Check if AI can still play this mana ability
-            ma.setActivatingPlayer(ai);
+            ma.setActivatingPlayer(ai, true);
             // if the AI can't pay the additional costs skip the mana ability
             if (!CostPayment.canPayAdditionalCosts(ma.getPayCosts(), ma)) {
                 return false;
@@ -1420,7 +1420,7 @@ public class ComputerUtilMana {
             maxProduced = 0;
 
             for (SpellAbility ma : src.getManaAbilities()) {
-                ma.setActivatingPlayer(p);
+                ma.setActivatingPlayer(p, true);
                 if (!checkPlayable || ma.canPlay()) {
                     int costsToActivate = ma.getPayCosts().getCostMana() != null ? ma.getPayCosts().getCostMana().convertAmount() : 0;
                     int producedMana = ma.getParamOrDefault("Produced", "").split(" ").length;
@@ -1459,7 +1459,7 @@ public class ComputerUtilMana {
             @Override
             public boolean apply(final Card c) {
                 for (final SpellAbility am : getAIPlayableMana(c)) {
-                    am.setActivatingPlayer(ai);
+                    am.setActivatingPlayer(ai, true);
                     if (!checkPlayable || (am.canPlay() && am.checkRestrictions(ai))) {
                         return true;
                     }
@@ -1516,7 +1516,7 @@ public class ComputerUtilMana {
                     needsLimitedResources |= !cost.isReusuableResource();
 
                     // if the AI can't pay the additional costs skip the mana ability
-                    m.setActivatingPlayer(ai);
+                    m.setActivatingPlayer(ai, true);
                     if (!CostPayment.canPayAdditionalCosts(m.getPayCosts(), m)) {
                         continue;
                     }
@@ -1585,7 +1585,7 @@ public class ComputerUtilMana {
                 if (DEBUG_MANA_PAYMENT) {
                     System.out.println("DEBUG_MANA_PAYMENT: groupSourcesByManaColor m = " + m);
                 }
-                m.setActivatingPlayer(ai);
+                m.setActivatingPlayer(ai, true);
                 if (checkPlayable && !m.canPlay()) {
                     continue;
                 }

--- a/forge-ai/src/main/java/forge/ai/GameState.java
+++ b/forge-ai/src/main/java/forge/ai/GameState.java
@@ -907,7 +907,6 @@ public abstract class GameState {
                     for (SpellAbility ab : saList) {
                         if (ab.getDescription().startsWith("Awaken")) {
                             ab.setActivatingPlayer(c.getController());
-                            ab.getSubAbility().setActivatingPlayer(c.getController());
                             // target for Awaken is set in its first subability
                             handleScriptedTargetingForSA(game, ab.getSubAbility(), tgtID);
                             sa = kwName.equals("AwakenOnly") ? ab.getSubAbility() : ab;

--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -695,7 +695,7 @@ public class PlayerControllerAi extends PlayerController {
     public boolean payManaOptional(Card c, Cost cost, SpellAbility sa, String prompt, ManaPaymentPurpose purpose) {
         // TODO replace with EmptySa
         final Ability ability = new AbilityStatic(c, cost, null) { @Override public void resolve() {} };
-        ability.setActivatingPlayer(c.getController());
+        ability.setActivatingPlayer(c.getController(), true);
         ability.setCardState(sa.getCardState());
 
         // FIXME: This is a hack to check if the AI can play the "exile from library" pay costs (Cumulative Upkeep,
@@ -1086,7 +1086,7 @@ public class PlayerControllerAi extends PlayerController {
         final Card source = sa.getHostCard();
         // TODO replace with EmptySa
         final Ability emptyAbility = new AbilityStatic(source, cost, sa.getTargetRestrictions()) { @Override public void resolve() { } };
-        emptyAbility.setActivatingPlayer(player);
+        emptyAbility.setActivatingPlayer(player, true);
         emptyAbility.setTriggeringObjects(sa.getTriggeringObjects());
         emptyAbility.setSVars(sa.getSVars());
         emptyAbility.setCardState(sa.getCardState());

--- a/forge-ai/src/main/java/forge/ai/SpellAbilityAi.java
+++ b/forge-ai/src/main/java/forge/ai/SpellAbilityAi.java
@@ -118,7 +118,7 @@ public abstract class SpellAbilityAi {
     protected boolean checkAiLogic(final Player ai, final SpellAbility sa, final String aiLogic) {
         if (aiLogic.equals("CheckCondition")) {
             SpellAbility saCopy = sa.copy();
-            saCopy.setActivatingPlayer(ai);
+            saCopy.setActivatingPlayer(ai, true);
             return saCopy.metConditions();
         }
 

--- a/forge-ai/src/main/java/forge/ai/ability/AttachAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/AttachAi.java
@@ -121,7 +121,7 @@ public class AttachAi extends SpellAbilityAi {
 
         if (ComputerUtilAbility.getAbilitySourceName(sa).equals("Chained to the Rocks")) {
             final SpellAbility effectExile = AbilityFactory.getAbility(source.getSVar("TrigExile"), source);
-            effectExile.setActivatingPlayer(ai);
+            effectExile.setActivatingPlayer(ai, true);
             final TargetRestrictions exile_tgt = effectExile.getTargetRestrictions();
             final List<Card> targets = CardUtil.getValidCardsToTarget(exile_tgt, effectExile);
             return !targets.isEmpty();

--- a/forge-ai/src/main/java/forge/ai/ability/CharmAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CharmAi.java
@@ -88,7 +88,7 @@ public class CharmAi extends SpellAbilityAi {
         AiController aic = ((PlayerControllerAi) ai.getController()).getAi();
         // First pass using standard canPlayAi() for good choices
         for (AbilitySub sub : choices) {
-            sub.setActivatingPlayer(ai);
+            sub.setActivatingPlayer(ai, true);
             if (AiPlayDecision.WillPlay == aic.canPlaySa(sub)) {
                 chosenList.add(sub);
                 if (chosenList.size() == num) {
@@ -219,13 +219,13 @@ public class CharmAi extends SpellAbilityAi {
         List<AbilitySub> chosenList = Lists.newArrayList();
         AiController aic = ((PlayerControllerAi) ai.getController()).getAi();
         for (AbilitySub sub : choices) {
-            sub.setActivatingPlayer(ai);
+            sub.setActivatingPlayer(ai, true);
             // Assign generic good choice to fill up choices if necessary 
             if ("Good".equals(sub.getParam("AILogic")) && aic.doTrigger(sub, false)) {
                 goodChoice = sub;
             } else {
                 // Standard canPlayAi()
-                sub.setActivatingPlayer(ai);
+                sub.setActivatingPlayer(ai, true);
                 if (AiPlayDecision.WillPlay == aic.canPlaySa(sub)) {
                     chosenList.add(sub);
                     if (chosenList.size() == min) {

--- a/forge-ai/src/main/java/forge/ai/ability/ChooseGenericEffectAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ChooseGenericEffectAi.java
@@ -102,7 +102,7 @@ public class ChooseGenericEffectAi extends SpellAbilityAi {
         } else if ("PayUnlessCost".equals(logic)) {
             for (final SpellAbility sp : spells) {
                 String unlessCost = sp.getParam("UnlessCost");
-                sp.setActivatingPlayer(sa.getActivatingPlayer());
+                sp.setActivatingPlayer(sa.getActivatingPlayer(), true);
                 Cost unless = new Cost(unlessCost, false);
                 SpellAbility paycost = new SpellAbility.EmptySa(sa.getHostCard(), player);
                 paycost.setPayCosts(unless);

--- a/forge-ai/src/main/java/forge/ai/ability/CountersPutAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CountersPutAi.java
@@ -427,7 +427,7 @@ public class CountersPutAi extends CountersAi {
                 }
 
                 // need to set Activating player
-                oa.setActivatingPlayer(ai);
+                oa.setActivatingPlayer(ai, true);
                 CardCollection targets = CardLists.getTargetableCards(ai.getOpponents().getCreaturesInPlay(), oa);
 
                 if (!targets.isEmpty()) {

--- a/forge-ai/src/main/java/forge/ai/ability/DelayedTriggerAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DelayedTriggerAi.java
@@ -26,7 +26,7 @@ public class DelayedTriggerAi extends SpellAbilityAi {
         if (trigsa == null) {
             return false;
         }
-        trigsa.setActivatingPlayer(ai);
+        trigsa.setActivatingPlayer(ai, true);
 
         if (trigsa instanceof AbilitySub) {
             return SpellApiToAi.Converter.get(trigsa.getApi()).chkDrawbackWithSubs(ai, (AbilitySub)trigsa);
@@ -43,7 +43,7 @@ public class DelayedTriggerAi extends SpellAbilityAi {
         }
 
         AiController aic = ((PlayerControllerAi)ai.getController()).getAi();
-        trigsa.setActivatingPlayer(ai);
+        trigsa.setActivatingPlayer(ai, true);
 
         if (!sa.hasParam("OptionalDecider")) {
             return aic.doTrigger(trigsa, true);
@@ -164,7 +164,7 @@ public class DelayedTriggerAi extends SpellAbilityAi {
         if (trigsa == null) {
             return false;
         }
-        trigsa.setActivatingPlayer(ai);
+        trigsa.setActivatingPlayer(ai, true);
         return AiPlayDecision.WillPlay == ((PlayerControllerAi)ai.getController()).getAi().canPlaySa(trigsa);
     }
 

--- a/forge-ai/src/main/java/forge/ai/ability/ImmediateTriggerAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ImmediateTriggerAi.java
@@ -20,7 +20,7 @@ public class ImmediateTriggerAi extends SpellAbilityAi {
             return false;
         }
 
-        trigsa.setActivatingPlayer(ai);
+        trigsa.setActivatingPlayer(ai, true);
 
         if (trigsa instanceof AbilitySub) {
             return SpellApiToAi.Converter.get(trigsa.getApi()).chkDrawbackWithSubs(ai, (AbilitySub)trigsa);
@@ -48,7 +48,7 @@ public class ImmediateTriggerAi extends SpellAbilityAi {
         }
 
         AiController aic = ((PlayerControllerAi)ai.getController()).getAi();
-        trigsa.setActivatingPlayer(ai);
+        trigsa.setActivatingPlayer(ai, true);
 
         return aic.doTrigger(trigsa, !"You".equals(sa.getParamOrDefault("OptionalDecider", "You")));
     }
@@ -65,7 +65,7 @@ public class ImmediateTriggerAi extends SpellAbilityAi {
             return false;
         }
 
-        trigsa.setActivatingPlayer(ai);
+        trigsa.setActivatingPlayer(ai, true);
         return AiPlayDecision.WillPlay == ((PlayerControllerAi)ai.getController()).getAi().canPlaySa(trigsa);
     }
 

--- a/forge-ai/src/main/java/forge/ai/ability/ManaEffectAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ManaEffectAi.java
@@ -226,7 +226,7 @@ public class ManaEffectAi extends SpellAbilityAi {
             if (testSaNoCost == null) {
                 continue;
             }
-            testSaNoCost.setActivatingPlayer(ai);
+            testSaNoCost.setActivatingPlayer(ai, true);
             if (((PlayerControllerAi)ai.getController()).getAi().canPlaySa(testSaNoCost) == AiPlayDecision.WillPlay) {
                 if (testSa.getHostCard().isPermanent() && !testSa.getHostCard().hasKeyword(Keyword.HASTE)
                     && !ai.getGame().getPhaseHandler().is(PhaseType.MAIN2)) {

--- a/forge-ai/src/main/java/forge/ai/ability/PermanentAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PermanentAi.java
@@ -176,7 +176,7 @@ public class PermanentAi extends SpellAbilityAi {
                 emptyAbility.setPayCosts(new Cost(costs, true));
                 emptyAbility.setTargetRestrictions(sa.getTargetRestrictions());
                 emptyAbility.setCardState(sa.getCardState());
-                emptyAbility.setActivatingPlayer(ai);
+                emptyAbility.setActivatingPlayer(ai, true);
 
                 if (!ComputerUtilCost.canPayCost(emptyAbility, ai, true)) {
                     // AiPlayDecision.AnotherTime

--- a/forge-ai/src/main/java/forge/ai/ability/PermanentNoncreatureAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PermanentNoncreatureAi.java
@@ -38,7 +38,7 @@ public class PermanentNoncreatureAi extends PermanentAi {
         if (host.hasSVar("OblivionRing")) {
             SpellAbility effectExile = AbilityFactory.getAbility(host.getSVar("TrigExile"), host);
             final ZoneType origin = ZoneType.listValueOf(effectExile.getParam("Origin")).get(0);
-            effectExile.setActivatingPlayer(ai);
+            effectExile.setActivatingPlayer(ai, true);
             CardCollection targets = CardLists.getTargetableCards(game.getCardsIn(origin), effectExile);
             if (sourceName.equals("Suspension Field") 
                     || sourceName.equals("Detention Sphere")) {

--- a/forge-ai/src/main/java/forge/ai/ability/PlayAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PlayAi.java
@@ -148,7 +148,7 @@ public class PlayAi extends SpellAbilityAi {
                 // of which spell was the reason for the choice can be used there
                 for (SpellAbility s : c.getBasicSpells(c.getState(CardStateName.Original))) {
                     Spell spell = (Spell) s;
-                    s.setActivatingPlayer(ai);
+                    s.setActivatingPlayer(ai, true);
                     // timing restrictions still apply
                     if (!s.getRestrictions().checkTimingRestrictions(c, s))
                         continue;

--- a/forge-ai/src/main/java/forge/ai/ability/RevealAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/RevealAi.java
@@ -39,7 +39,7 @@ public class RevealAi extends RevealAiBase {
             final Card c = sa.getHostCard();
             for (SpellAbility s : c.getBasicSpells()) {
                 Spell spell = (Spell) s;
-                s.setActivatingPlayer(ai);
+                s.setActivatingPlayer(ai, true);
                 // timing restrictions still apply
                 if (!s.getRestrictions().checkTimingRestrictions(c, s))
                     continue;

--- a/forge-ai/src/main/java/forge/ai/ability/VentureAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/VentureAi.java
@@ -47,7 +47,7 @@ public class VentureAi extends SpellAbilityAi {
 
         for (SpellAbility room : spells) {
             if (player.getController().isAI()) { // FIXME: is this needed? Can simulation ever run this for a non-AI player?
-                room.setActivatingPlayer(player);
+                room.setActivatingPlayer(player, true);
                 if (((PlayerControllerAi)player.getController()).getAi().canPlaySa(room) == AiPlayDecision.WillPlay) {
                     viableRooms.add(room);
                 }

--- a/forge-ai/src/main/java/forge/ai/simulation/PossibleTargetSelector.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/PossibleTargetSelector.java
@@ -65,7 +65,7 @@ public class PossibleTargetSelector {
         if (targetingSa == null) {
             return;
         }
-        sa.setActivatingPlayer(player);
+        sa.setActivatingPlayer(player, true);
         targetingSa.resetTargets();
         tgt = targetingSa.getTargetRestrictions();
         maxTargets = tgt.getMaxTargets(sa.getHostCard(), targetingSa);

--- a/forge-ai/src/main/java/forge/ai/simulation/SpellAbilityPicker.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/SpellAbilityPicker.java
@@ -84,7 +84,7 @@ public class SpellAbilityPicker {
             if (sa.isManaAbility()) {
                 continue;
             }
-            sa.setActivatingPlayer(player);
+            sa.setActivatingPlayer(player, true);
 
             AiPlayDecision opinion = canPlayAndPayForSim(sa);
             // print("  " + opinion + ": " + sa);

--- a/forge-game/src/main/java/forge/game/GameEntity.java
+++ b/forge-game/src/main/java/forge/game/GameEntity.java
@@ -228,6 +228,10 @@ public abstract class GameEntity extends GameObject implements IIdentifiable {
             return false;
         }
 
+        if (attach.isPhasedOut()) {
+            return false;
+        }
+
         // check for rules
         if (attach.isAura() && !canBeEnchantedBy(attach)) {
             return false;

--- a/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
@@ -750,8 +750,7 @@ public abstract class SpellAbilityEffect {
             CardCollectionView discardedByPlayer = discardedMap.get(p);
             if (!discardedByPlayer.isEmpty()) {
                 boolean firstDiscard = p.getNumDiscardedThisTurn() - discardedByPlayer.size() == 0;
-                final Map<AbilityKey, Object> runParams = AbilityKey.newMap();
-                runParams.put(AbilityKey.Player, p);
+                final Map<AbilityKey, Object> runParams = AbilityKey.mapFromPlayer(p);
                 runParams.put(AbilityKey.Cards, discardedByPlayer);
                 runParams.put(AbilityKey.Cause, sa);
                 runParams.put(AbilityKey.FirstTime, firstDiscard);

--- a/forge-game/src/main/java/forge/game/ability/effects/AnimateEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/AnimateEffect.java
@@ -168,6 +168,11 @@ public class AnimateEffect extends AnimateEffectBase {
         }
 
         for (final Card c : tgts) {
+            // CR 702.26e
+            if (c.isPhasedOut()) {
+                continue;
+            }
+
             doAnimate(c, sa, power, toughness, types, removeTypes, finalColors,
                     keywords, removeKeywords, hiddenKeywords,
                     abilities, triggers, replacements, stAbs, timestamp);

--- a/forge-game/src/main/java/forge/game/ability/effects/CharmEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CharmEffect.java
@@ -65,12 +65,10 @@ public class CharmEffect extends SpellAbilityEffect {
             // using getCardForUi game is not set, so can't guess max charm
             num = Integer.MAX_VALUE;
         } else {
-            // fallback needed while ability building @TRT please check why it broke CharmEffect without using try-catch
-            try {
-                if (sa.getActivatingPlayer() == null) {
-                    sa.setActivatingPlayer(source.getController());
-                }
-            } catch (Exception e) {}
+            // fallback needed while ability building
+            if (sa.getActivatingPlayer() == null) {
+                sa.setActivatingPlayer(source.getController(), true);
+            }
             num = Math.min(AbilityUtils.calculateAmount(source, sa.getParamOrDefault("CharmNum", "1"), sa), list.size());
         }
         final int min = sa.hasParam("MinCharmNum") ? AbilityUtils.calculateAmount(source, sa.getParam("MinCharmNum"), sa) : num;

--- a/forge-game/src/main/java/forge/game/ability/effects/CloneEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CloneEffect.java
@@ -52,7 +52,7 @@ public class CloneEffect extends SpellAbilityEffect {
         sb.append(" becomes a copy of ").append(cardToCopy).append(".");
 
         return sb.toString();
-    } // end cloneStackDescription()
+    }
 
     @Override
     public void resolve(SpellAbility sa) {
@@ -132,6 +132,10 @@ public class CloneEffect extends SpellAbilityEffect {
             }
         }
 
+        if (tgtCard.isPhasedOut()) {
+            return;
+        }
+
         final Long ts = game.getNextTimestamp();
         tgtCard.addCloneState(CardFactory.getCloneStates(cardToCopy, tgtCard, sa), ts);
 
@@ -189,6 +193,6 @@ public class CloneEffect extends SpellAbilityEffect {
         }
 
         game.fireEvent(new GameEventCardStatsChanged(tgtCard));
-    } // cloneResolve
+    }
 
 }

--- a/forge-game/src/main/java/forge/game/ability/effects/ControlGainEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ControlGainEffect.java
@@ -160,6 +160,9 @@ public class ControlGainEffect extends SpellAbilityEffect {
             if (!tgtC.isInPlay() || !tgtC.canBeControlledBy(newController)) {
                 continue;
             }
+            if (tgtC.isPhasedOut()) {
+                continue;
+            }
 
             if (sa.hasParam("Optional") && !activator.getController().confirmAction(sa, null,
                     Localizer.getInstance().getMessage("lblGainControlConfirm", newController,

--- a/forge-game/src/main/java/forge/game/ability/effects/DamageDealEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DamageDealEffect.java
@@ -269,6 +269,9 @@ public class DamageDealEffect extends DamageBaseEffect {
                         // timestamp different or not in play
                         continue;
                     }
+                    if (c.isPhasedOut()) {
+                        continue;
+                    }
                     if (!sa.usesTargeting() || gc.canBeTargetedBy(sa)) {
                         internalDamageDeal(sa, sourceLKI, gc, dmg, damageMap);
                     }

--- a/forge-game/src/main/java/forge/game/ability/effects/DamagePreventEffectBase.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DamagePreventEffectBase.java
@@ -17,7 +17,6 @@ import forge.game.spellability.AbilitySub;
 import forge.game.spellability.SpellAbility;
 import forge.game.trigger.TriggerType;
 import forge.game.zone.ZoneType;
-import forge.util.CardTranslation;
 import forge.util.TextUtil;
 
 public abstract class DamagePreventEffectBase extends SpellAbilityEffect {
@@ -25,7 +24,7 @@ public abstract class DamagePreventEffectBase extends SpellAbilityEffect {
         final Card hostCard = sa.getHostCard();
         final Game game = hostCard.getGame();
         final Player player = hostCard.getController();
-        final String name = CardTranslation.getTranslatedName(hostCard.getName()) + "'s Effect";
+        final String name = hostCard + "'s Effect";
         final String image = hostCard.getImageKey();
         StringBuilder sb = new StringBuilder("Event$ DamageDone | ActiveZones$ Command | ValidTarget$ ");
         sb.append((o instanceof Card ? "Card.IsRemembered" : "Player.IsRemembered"));

--- a/forge-game/src/main/java/forge/game/ability/effects/DebuffEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DebuffEffect.java
@@ -69,6 +69,10 @@ public class DebuffEffect extends SpellAbilityEffect {
         final long timestamp = game.getNextTimestamp();
 
         for (final Card tgtC : getTargetCards(sa)) {
+            if (tgtC.isPhasedOut()) {
+                continue;
+            }
+
             final List<String> addedKW = Lists.newArrayList();
             final List<String> removedKW = Lists.newArrayList();
             if (tgtC.isInPlay() && (!sa.usesTargeting() || tgtC.canBeTargetedBy(sa))) {

--- a/forge-game/src/main/java/forge/game/ability/effects/EffectEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/EffectEffect.java
@@ -27,7 +27,6 @@ import forge.game.trigger.Trigger;
 import forge.game.trigger.TriggerHandler;
 import forge.game.trigger.TriggerType;
 import forge.game.zone.ZoneType;
-import forge.util.CardTranslation;
 import forge.util.TextUtil;
 import forge.util.collect.FCollection;
 
@@ -114,7 +113,7 @@ public class EffectEffect extends SpellAbilityEffect {
 
         String name = sa.getParam("Name");
         if (name == null) {
-            name = CardTranslation.getTranslatedName(hostCard.getName()) + (sa.hasParam("Boon") ? "'s Boon" : "'s Effect");
+            name = hostCard + (sa.hasParam("Boon") ? "'s Boon" : "'s Effect");
         }
 
         // Unique Effects shouldn't be duplicated

--- a/forge-game/src/main/java/forge/game/ability/effects/EndCombatPhaseEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/EndCombatPhaseEffect.java
@@ -16,11 +16,14 @@ public class EndCombatPhaseEffect extends SpellAbilityEffect {
      */
     @Override
     public void resolve(SpellAbility sa) {
-        Game game = sa.getActivatingPlayer().getGame();
-        // Steps taken from gatherer's rulings on Time Stop.
-        // 1) All spells and abilities on the stack are exiled. This includes
-        // Time Stop, though it will continue to resolve. It also includes
-        // spells and abilities that can't be countered.
+        final Game game = sa.getActivatingPlayer().getGame();
+
+        // If an effect attempts to end the combat phase at any time that’s not a combat phase, nothing happens
+        if (game.getCombat() == null) {
+            return;
+        }
+
+        // 1) All spells and abilities on the stack are exiled.
         for (final Card c : Lists.newArrayList(game.getStackZone().getCards())) {
             game.getAction().exile(c, sa);
         }
@@ -28,15 +31,13 @@ public class EndCombatPhaseEffect extends SpellAbilityEffect {
         game.getStack().clearSimultaneousStack();
         game.getTriggerHandler().clearWaitingTriggers();
 
-        // 2) All attacking and blocking creatures are removed from combat.
-        //game.getPhaseHandler().endCombat();
-
-        // 3) State-based actions are checked. No player gets priority, and no
+        // 2) State-based actions are checked. No player gets priority, and no
         // triggered abilities are put onto the stack.
         game.getAction().checkStateEffects(true);
 
-        // 4) The current phase and/or step ends. The game skips straight to the
-        // cleanup step. The cleanup step happens in its entirety.
+        // 3) The current phase and step ends. The game skips straight to the postcombat main phase. As this happens,
+        // all attacking and blocking creatures are removed from combat and effects that last “until end of combat” expire.
+        game.getPhaseHandler().endCombat();
         game.getPhaseHandler().endCombatPhaseByEffect();
     }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/FogEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/FogEffect.java
@@ -10,7 +10,6 @@ import forge.game.replacement.ReplacementHandler;
 import forge.game.spellability.SpellAbility;
 import forge.game.trigger.TriggerType;
 import forge.game.zone.ZoneType;
-import forge.util.CardTranslation;
 
 public class FogEffect extends SpellAbilityEffect {
 
@@ -23,7 +22,7 @@ public class FogEffect extends SpellAbilityEffect {
     public void resolve(SpellAbility sa) {
         final Card hostCard = sa.getHostCard();
         final Game game = hostCard.getGame();
-        final String name = CardTranslation.getTranslatedName(hostCard.getName()) + "'s Effect";
+        final String name = hostCard + "'s Effect";
         final String image = hostCard.getImageKey();
         StringBuilder sb = new StringBuilder("Event$ DamageDone | ActiveZones$ Command | IsCombat$ True");
         sb.append(" | Prevent$ True | Description$ Prevent all combat damage this turn.");

--- a/forge-game/src/main/java/forge/game/ability/effects/PhasesEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PhasesEffect.java
@@ -81,6 +81,9 @@ public class PhasesEffect extends SpellAbilityEffect {
                 if (!tgtC.isPhasedOut()) {
                     tgtC.phase(false);
                     if (tgtC.isPhasedOut()) {
+                        if (sa.hasParam("RememberAffected")) {
+                            source.addRemembered(tgtC);
+                        }
                         tgtC.setWontPhaseInNormal(wontPhaseInNormal);
                     }
                 }

--- a/forge-game/src/main/java/forge/game/ability/effects/ProtectEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ProtectEffect.java
@@ -136,6 +136,9 @@ public class ProtectEffect extends SpellAbilityEffect {
             if (!tgtC.isInPlay()) {
                 continue;
             }
+            if (tgtC.isPhasedOut()) {
+                continue;
+            }
 
             // if this is a target, make sure we can still target now
             if (sa.usesTargeting() && !tgtC.canBeTargetedBy(sa)) {

--- a/forge-game/src/main/java/forge/game/ability/effects/PumpEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PumpEffect.java
@@ -423,6 +423,11 @@ public class PumpEffect extends SpellAbilityEffect {
         for (int j = 0; j < size; j++) {
             final Card tgtC = tgtCards.get(j);
 
+            // CR 702.26e
+            if (tgtC.isPhasedOut()) {
+                continue;
+            }
+
             // only pump things in PumpZone
             if (!tgtC.isInZone(pumpZone)) {
                 continue;

--- a/forge-game/src/main/java/forge/game/ability/effects/RegenerateBaseEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/RegenerateBaseEffect.java
@@ -15,7 +15,6 @@ import forge.game.trigger.Trigger;
 import forge.game.trigger.TriggerHandler;
 import forge.game.trigger.TriggerType;
 import forge.game.zone.ZoneType;
-import forge.util.CardTranslation;
 
 public abstract class RegenerateBaseEffect extends SpellAbilityEffect {
 
@@ -25,7 +24,7 @@ public abstract class RegenerateBaseEffect extends SpellAbilityEffect {
 
         // create Effect for Regeneration
         final Card eff = createEffect(
-                sa, sa.getActivatingPlayer(), CardTranslation.getTranslatedName(hostCard.getName()) + "'s Regeneration", hostCard.getImageKey());
+                sa, sa.getActivatingPlayer(), hostCard + "'s Regeneration", hostCard.getImageKey());
 
         eff.addRemembered(list);
         addForgetOnMovedTrigger(eff, "Battlefield");

--- a/forge-game/src/main/java/forge/game/ability/effects/SkipPhaseEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/SkipPhaseEffect.java
@@ -15,7 +15,6 @@ import forge.game.replacement.ReplacementLayer;
 import forge.game.spellability.SpellAbility;
 import forge.game.trigger.TriggerType;
 import forge.game.zone.ZoneType;
-import forge.util.CardTranslation;
 
 public class SkipPhaseEffect extends SpellAbilityEffect {
     
@@ -59,7 +58,7 @@ public class SkipPhaseEffect extends SpellAbilityEffect {
             final String duration, final String phase, final String step) {
         final Card hostCard = sa.getHostCard();
         final Game game = hostCard.getGame();
-        final String name = CardTranslation.getTranslatedName(hostCard.getName()) + "'s Effect";
+        final String name = hostCard + "'s Effect";
         final String image = hostCard.getImageKey();
         final boolean isNextThisTurn = duration != null && duration.equals("NextThisTurn");
 

--- a/forge-game/src/main/java/forge/game/ability/effects/SkipTurnEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/SkipTurnEffect.java
@@ -16,7 +16,6 @@ import forge.game.spellability.AbilitySub;
 import forge.game.spellability.SpellAbility;
 import forge.game.trigger.TriggerType;
 import forge.game.zone.ZoneType;
-import forge.util.CardTranslation;
 import forge.util.Lang;
 
 public class SkipTurnEffect extends SpellAbilityEffect {
@@ -39,7 +38,7 @@ public class SkipTurnEffect extends SpellAbilityEffect {
     public void resolve(SpellAbility sa) {
         final Card hostCard = sa.getHostCard();
         final Game game = hostCard.getGame();
-        final String name = CardTranslation.getTranslatedName(hostCard.getName()) + "'s Effect";
+        final String name = hostCard + "'s Effect";
         final String image = hostCard.getImageKey();
         final int numTurns = AbilityUtils.calculateAmount(hostCard, sa.getParam("NumTurns"), sa);
         String repeffstr = "Event$ BeginTurn | ActiveZones$ Command | ValidPlayer$ You " +

--- a/forge-game/src/main/java/forge/game/ability/effects/TapEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/TapEffect.java
@@ -20,6 +20,9 @@ public class TapEffect extends SpellAbilityEffect {
         }
 
         for (final Card tgtC : getTargetCards(sa)) {
+            if (tgtC.isPhasedOut()) {
+                continue;
+            }
             if (sa.usesTargeting() && !tgtC.canBeTargetedBy(sa)) {
                 continue;
             }

--- a/forge-game/src/main/java/forge/game/ability/effects/TapOrUntapEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/TapOrUntapEffect.java
@@ -38,6 +38,9 @@ public class TapOrUntapEffect extends SpellAbilityEffect {
         PlayerController pc = sa.getActivatingPlayer().getController();
         
         for (final Card tgtC : tgtCards) {
+            if (tgtC.isPhasedOut()) {
+                continue;
+            }
             if (tgtC.isInPlay() && ((tgt == null) || tgtC.canBeTargetedBy(sa))) {
                 // If the effected card is controlled by the same controller of the SA, default to untap.
                 boolean tap = pc.chooseBinary(sa, Localizer.getInstance().getMessage("lblTapOrUntapTarget", CardTranslation.getTranslatedName(tgtC.getName())), PlayerController.BinaryChoiceType.TapOrUntap,

--- a/forge-game/src/main/java/forge/game/ability/effects/UntapEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/UntapEffect.java
@@ -45,6 +45,9 @@ public class UntapEffect extends SpellAbilityEffect {
         } else {
             final CardCollection untargetedCards = CardUtil.getRadiance(sa);
             for (final Card tgtC : getTargetCards(sa)) {
+                if (tgtC.isPhasedOut()) {
+                    continue;
+                }
                 if (sa.usesTargeting() && !tgtC.canBeTargetedBy(sa)) {
                     continue;
                 }

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -579,6 +579,9 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
     }
 
     public boolean changeCardState(final String mode, final String customState, final SpellAbility cause) {
+        if (isPhasedOut()) {
+            return false;
+        }
         if (mode == null)
             return changeToState(CardStateName.smartValueOf(customState));
 
@@ -1434,6 +1437,9 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
 
     @Override
     public final boolean canReceiveCounters(final CounterType type) {
+        if (isPhasedOut()) {
+            return false;
+        }
         if (StaticAbilityCantPutCounter.anyCantPutCounter(this, type)) {
             return false;
         }
@@ -3667,6 +3673,10 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
 
     public final void unattachFromEntity(final GameEntity entity) {
         if (entityAttachedTo == null || !entityAttachedTo.equals(entity)) {
+            return;
+        }
+
+        if (isPhasedOut()) {
             return;
         }
 

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -827,6 +827,9 @@ public class Player extends GameEntity implements Comparable<Player> {
     }
 
     public final boolean canReceiveCounters(final CounterType type) {
+        if (!isInGame()) {
+            return false;
+        }
         if (StaticAbilityCantPutCounter.anyCantPutCounter(this, type)) {
             return false;
         }

--- a/forge-game/src/main/java/forge/game/trigger/WrappedAbility.java
+++ b/forge-game/src/main/java/forge/game/trigger/WrappedAbility.java
@@ -351,6 +351,10 @@ public class WrappedAbility extends Ability {
     public void setActivatingPlayer(final Player player) {
         sa.setActivatingPlayer(player);
     }
+    @Override
+    public boolean setActivatingPlayer(final Player player, final boolean lki) {
+        return sa.setActivatingPlayer(player, lki);
+    }
 
     @Override
     public String getDescription() {

--- a/forge-gui/res/cardsfolder/c/captain_of_the_mists.txt
+++ b/forge-gui/res/cardsfolder/c/captain_of_the_mists.txt
@@ -2,7 +2,7 @@ Name:Captain of the Mists
 ManaCost:2 U
 Types:Creature Human Wizard
 PT:2/3
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.Other+Human+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ Whenever another Human enters the battlefield under your control, untap CARDNAME.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Human.Other+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ Whenever another Human enters the battlefield under your control, untap CARDNAME.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
 A:AB$ TapOrUntap | Cost$ 1 U T | ValidTgts$ Permanent | TgtPrompt$ Select target permanent | SpellDescription$ You may tap or untap target permanent.
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/c/colfenor_the_last_yew.txt
+++ b/forge-gui/res/cardsfolder/c/colfenor_the_last_yew.txt
@@ -4,8 +4,7 @@ Types:Legendary Creature Treefolk Shaman
 PT:3/7
 K:Vigilance
 K:Reach
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.Other+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigChange | TriggerDescription$ Whenever CARDNAME or another creature you control dies, return up to one other target creature card with lesser toughness from your graveyard to your hand.
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigChange | Secondary$ True | TriggerDescription$ Whenever CARDNAME or another creature you control dies, return up to one other target creature card with lesser toughness from your graveyard to your hand.
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self,Creature.Other+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigChange | TriggerDescription$ Whenever CARDNAME or another creature you control dies, return up to one other target creature card with lesser toughness from your graveyard to your hand.
 SVar:TrigChange:DB$ ChangeZone | TargetMin$ 0 | TargetMax$ 1 | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Creature.Other+NotTriggeredNewCard+toughnessLTX+YouOwn | TgtPrompt$ Select up to one other target creature card with lesser toughness from your graveyard to return to your hand
 SVar:X:TriggeredCard$CardToughness
 DeckHas:Ability$Graveyard

--- a/forge-gui/res/cardsfolder/d/diregraf_captain.txt
+++ b/forge-gui/res/cardsfolder/d/diregraf_captain.txt
@@ -4,7 +4,7 @@ Types:Creature Zombie Soldier
 PT:2/2
 K:Deathtouch
 S:Mode$ Continuous | Affected$ Creature.Zombie+Other+YouCtrl | AddPower$ 1 | AddToughness$ 1 | Description$ Other Zombie creatures you control get +1/+1.
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.Zombie+Other+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigLoseLife | TriggerDescription$ Whenever another Zombie you control dies, target opponent loses 1 life.
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Zombie.Other+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigLoseLife | TriggerDescription$ Whenever another Zombie you control dies, target opponent loses 1 life.
 SVar:TrigLoseLife:DB$ LoseLife | LifeAmount$ 1 | ValidTgts$ Opponent | TgtPrompt$ Select target opponent
 SVar:PlayMain1:TRUE
 Oracle:Deathtouch\nOther Zombie creatures you control get +1/+1.\nWhenever another Zombie you control dies, target opponent loses 1 life.

--- a/forge-gui/res/cardsfolder/e/elderfang_venom.txt
+++ b/forge-gui/res/cardsfolder/e/elderfang_venom.txt
@@ -2,7 +2,7 @@ Name:Elderfang Venom
 ManaCost:2 B G
 Types:Enchantment
 S:Mode$ Continuous | Affected$ Elf.attacking+YouCtrl | AddKeyword$ Deathtouch | Description$ Attacking Elves you control have deathtouch.
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.Elf+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigLoseLife | TriggerDescription$ Whenever an Elf you control dies, each opponent loses 1 life and you gain 1 life.
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Elf.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigLoseLife | TriggerDescription$ Whenever an Elf you control dies, each opponent loses 1 life and you gain 1 life.
 SVar:TrigLoseLife:DB$ LoseLife | Defined$ Player.Opponent | LifeAmount$ 1 | SubAbility$ DBGainLife
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1
 DeckHints:Type$Elf

--- a/forge-gui/res/cardsfolder/g/general_kudro_of_drannith.txt
+++ b/forge-gui/res/cardsfolder/g/general_kudro_of_drannith.txt
@@ -3,7 +3,7 @@ ManaCost:1 W B
 Types:Legendary Creature Human Soldier
 PT:3/3
 S:Mode$ Continuous | Affected$ Human.Other+YouCtrl | AddPower$ 1 | AddToughness$ 1 | Description$ Other Humans you control get +1/+1.
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self,Creature.Other+Human+YouCtrl | Execute$ TrigExile | TriggerDescription$ Whenever CARDNAME or another Human enters the battlefield under your control, exile target card from an opponent's graveyard.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self,Human.Other+YouCtrl | Execute$ TrigExile | TriggerDescription$ Whenever CARDNAME or another Human enters the battlefield under your control, exile target card from an opponent's graveyard.
 SVar:TrigExile:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | TgtPrompt$ Choose target card in an opponent's graveyard | ValidTgts$ Card.OppOwn
 A:AB$ Destroy | Cost$ 2 Sac<2/Human> | ValidTgts$ Creature.powerGE4 | TgtPrompt$ Select target creature with power 4 or greater | SpellDescription$ Destroy target creature with power 4 or greater.
 DeckHints:Type$Human

--- a/forge-gui/res/cardsfolder/g/gusthas_scepter.txt
+++ b/forge-gui/res/cardsfolder/g/gusthas_scepter.txt
@@ -4,9 +4,7 @@ Types:Artifact
 A:AB$ ChangeZone | Cost$ T | ChangeType$ Card | ChangeNum$ 1 | Origin$ Hand | Destination$ Exile | ExileFaceDown$ True | RememberChanged$ True | Mandatory$ True | SubAbility$ DBEffect | SpellDescription$ Exile a card from your hand face down. You may look at it for as long as it remains exiled.
 SVar:DBEffect:DB$ Effect | RememberObjects$ Remembered | StaticAbilities$ STLook | Duration$ Permanent | ForgetOnMoved$ Exile
 SVar:STLook:Mode$ Continuous | MayLookAt$ You | EffectZone$ Command | Affected$ Card.IsRemembered | AffectedZone$ Exile | Description$ You may look at it for as long as it remains exiled.
-A:AB$ ChooseCard | Cost$ T | Defined$ You | Amount$ 1 | Mandatory$ True | AILogic$ AtLeast1 | ChoiceTitle$ Choose a card you own to put into your hand | Choices$ Card.IsRemembered+YouOwn+ExiledWithSource | ChoiceZone$ Exile | SubAbility$ MoveChosen | SpellDescription$ Return a card you own exiled with CARDNAME to your hand.
-SVar:MoveChosen:DB$ ChangeZone | Origin$ Exile | Destination$ Hand | Defined$ ChosenCard | ForgetChanged$ True | SubAbility$ DBCleanupChosen
-SVar:DBCleanupChosen:DB$ Cleanup | ClearChosenCard$ True
+A:AB$ ChangeZone | Cost$ T | Hidden$ True | ChangeType$ Card.IsRemembered+YouOwn+ExiledWithSource | Mandatory$ True | Origin$ Exile | Destination$ Hand | ForgetChanged$ True | SpellDescription$ Return a card you own exiled with CARDNAME to your hand.
 T:Mode$ ChangesZone | Origin$ Exile | Destination$ Any | Static$ True | ValidCard$ Card.IsRemembered+ExiledWithSource | Execute$ DBForget
 SVar:DBForget:DB$ Pump | ForgetObjects$ TriggeredCard
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | ValidCard$ Card.Self | Execute$ DBChangeZoneAll | TriggerDescription$ When you lose control of CARDNAME, put all cards exiled with CARDNAME into their owner's graveyard.

--- a/forge-gui/res/cardsfolder/m/myriad_construct.txt
+++ b/forge-gui/res/cardsfolder/m/myriad_construct.txt
@@ -5,6 +5,7 @@ PT:4/4
 K:Kicker:3
 R:Event$ Moved | ValidCard$ Card.Self+kicked | Destination$ Battlefield | ReplaceWith$ DBPutCounter | ReplacementResult$ Updated | Description$ If CARDNAME was kicked, it enters the battlefield with a +1/+1 counter on it for each nonbasic land your opponents control.
 SVar:DBPutCounter:DB$ PutCounter | ETB$ True | Defined$ Self | CounterType$ P1P1 | CounterNum$ X
+SVar:X:Count$Valid Land.nonBasic+OppCtrl
 SVar:NeedsToPlayKicked:Land.nonBasic+OppCtrl
 T:Mode$ BecomesTarget | ValidTarget$ Card.Self | TriggerZones$ Battlefield | ValidSource$ Spell | Execute$ TrigSac | TriggerDescription$ When CARDNAME becomes the target of a spell, sacrifice it and create a number of 1/1 colorless Construct artifact creature tokens equal to its power.
 SVar:TrigSac:DB$ Destroy | Defined$ Self | Sacrifice$ True | RememberLKI$ True | SubAbility$ DBToken

--- a/forge-gui/res/cardsfolder/o/out_of_time.txt
+++ b/forge-gui/res/cardsfolder/o/out_of_time.txt
@@ -2,8 +2,8 @@ Name:Out of Time
 ManaCost:1 W W
 Types:Enchantment
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigUntap | TriggerDescription$ When CARDNAME enters the battlefield, untap all creatures, then phase them out until CARDNAME leaves the battlefield. Put a time counter on CARDNAME for each creature phased out this way.
-SVar:TrigUntap:DB$ UntapAll | ValidCards$ Creature | RememberUntapped$ True | SubAbility$ DBPhase
-SVar:DBPhase:DB$ Phases | Defined$ Remembered | WontPhaseInNormal$ True | ConditionPresent$ Card.Self | SubAbility$ DBEffect
+SVar:TrigUntap:DB$ UntapAll | ValidCards$ Creature | SubAbility$ DBPhase
+SVar:DBPhase:DB$ Phases | AllValid$ Creature | RememberAffected$ True | WontPhaseInNormal$ True | ConditionPresent$ Card.Self | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | Triggers$ TrigComeBack | RememberObjects$ Remembered | ImprintCards$ Self | ConditionPresent$ Card.Self | Duration$ Permanent | ForgetOnPhasedIn$ True | SubAbility$ DBPutCounter
 SVar:TrigComeBack:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | ValidCard$ Card.IsImprinted | Execute$ DBPhaseIn | TriggerZones$ Command | TriggerController$ TriggeredCardController | Static$ True | TriggerDescription$ These creatures phase out until CARDNAME leaves the battlefield.
 SVar:DBPhaseIn:DB$ Phases | Defined$ Remembered | PhaseInOrOut$ True | SubAbility$ DBExileSelf

--- a/forge-gui/res/cardsfolder/r/river_sneak.txt
+++ b/forge-gui/res/cardsfolder/r/river_sneak.txt
@@ -3,7 +3,7 @@ ManaCost:1 U
 Types:Creature Merfolk Warrior
 PT:1/1
 S:Mode$ CantBlockBy | ValidAttacker$ Creature.Self | Description$ CARDNAME can't be blocked.
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.Merfolk+YouCtrl+Other | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever another Merfolk enters the battlefield under your control, CARDNAME gets +1/+1 until end of turn.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Merfolk.YouCtrl+Other | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever another Merfolk enters the battlefield under your control, CARDNAME gets +1/+1 until end of turn.
 SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ 1 | NumDef$ 1
 SVar:BuffedBy:Merfolk
 Oracle:River Sneak can't be blocked.\nWhenever another Merfolk enters the battlefield under your control, River Sneak gets +1/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-skemfar_avenger.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-skemfar_avenger.txt
@@ -2,7 +2,7 @@ Name:A-Skemfar Avenger
 ManaCost:1 B
 Types:Creature Elf Berserker
 PT:3/1
-T:Mode$ ChangesZone | ValidCard$ Creature.Elf+Other+YouCtrl,Creature.Berserker+Other+YouCtrl | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigDraw | TriggerZones$ Battlefield | TriggerDescription$ Whenever another Elf or Berserker you control dies, you draw a card and you lose 1 life.
+T:Mode$ ChangesZone | ValidCard$ Elf.Other+YouCtrl,Berserker.Other+YouCtrl | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigDraw | TriggerZones$ Battlefield | TriggerDescription$ Whenever another Elf or Berserker you control dies, you draw a card and you lose 1 life.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1 | SubAbility$ DBLoseLife
 SVar:DBLoseLife:DB$ LoseLife | Defined$ You | LifeAmount$ 1
 DeckHints:Type$Elf|Berserker

--- a/forge-gui/res/cardsfolder/s/skemfar_avenger.txt
+++ b/forge-gui/res/cardsfolder/s/skemfar_avenger.txt
@@ -2,7 +2,7 @@ Name:Skemfar Avenger
 ManaCost:1 B
 Types:Creature Elf Berserker
 PT:3/1
-T:Mode$ ChangesZone | ValidCard$ Creature.nonToken+Elf+Other+YouCtrl,Creature.nonToken+Berserker+Other+YouCtrl | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigDraw | TriggerZones$ Battlefield | TriggerDescription$ Whenever another nontoken Elf or Berserker you control dies, you draw a card and you lose 1 life.
+T:Mode$ ChangesZone | ValidCard$ Elf.nonToken+Other+YouCtrl,Berserker.nonToken+Other+YouCtrl | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigDraw | TriggerZones$ Battlefield | TriggerDescription$ Whenever another nontoken Elf or Berserker you control dies, you draw a card and you lose 1 life.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1 | SubAbility$ DBLoseLife
 SVar:DBLoseLife:DB$ LoseLife | Defined$ You | LifeAmount$ 1
 DeckHints:Type$Elf|Berserker


### PR DESCRIPTION
- I'm kind of hoping this speeds the AI up a bit, as the `canPlay` check was being called lots of times and can also get complex in some scenarios.
(There's no reason to provide it with fully updated View as its spell selection is thankfully not done by iterating via some kind of GUI interaction 😄 )

- Cherry-picked phasing fix from #117 and extended it, e.g. phased out _Haunted Plate Mail_ will no longer become animated or still be able to attach

- Fix _Out of Time_ counting cards with CantPhaseOut