### PR TITLE
Fix mana cost of Raze to the Ground

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/raze_to_the_ground.txt
+++ b/forge-gui/res/cardsfolder/upcoming/raze_to_the_ground.txt
@@ -1,5 +1,5 @@
 Name:Raze to the Ground
-ManaCost:1 R
+ManaCost:2 R
 Types:Sorcery
 K:This spell can't be countered.
 A:SP$ Destroy | ValidTgts$ Artifact | SubAbility$ DBDraw | RememberLKI$ True | AlwaysRemember$ True | SpellDescription$ Destroy target artifact. If its mana value was 1 or less, draw a card.


### PR DESCRIPTION
Mana cost is wrong. Should be 2R instead of 1R.

See: https://scryfall.com/card/bro/149/raze-to-the-ground
