### PR TITLE
Format changes: Add BRR and Mishra's Bauble ban to Historic

### DIFF
--- a/forge-gui/res/formats/Archived/Historic/2022-11-15.txt
+++ b/forge-gui/res/formats/Archived/Historic/2022-11-15.txt
@@ -3,5 +3,5 @@ Name:Historic (BRO)
 Type:Archived
 Subtype:Arena
 Effective:2022-11-15
-Sets:XLN, RIX, DOM, M19, ANA, PANA, GRN, G18, RNA, WAR, M20, ELD, HA1, THB, HA2, IKO, HA3, M21, JMP, AJMP, AKR, ANB, ZNR, KLR, KHM, HA4, STX, STA, HA5, AFR, J21, MID, VOW, YMID, NEO, YNEO, SNC, YSNC, HBG, HA6, EA1, DMU, YDMU, BRO
-Banned:Agent of Treachery; Brainstorm; Channel; Counterspell; Dark Ritual; Demonic Tutor; Field of the Dead; Lightning Bolt; Memory Lapse; Natural Order; Nexus of Fate; Oko, Thief of Crowns; Once Upon a Time; Swords to Plowshares; Thassa's Oracle; Tibalt's Trickery; Time Warp; Uro, Titan of Nature's Wrath; Veil of Summer; Wilderness Reclamation
+Sets:XLN, RIX, DOM, M19, ANA, PANA, GRN, G18, RNA, WAR, M20, ELD, HA1, THB, HA2, IKO, HA3, M21, JMP, AJMP, AKR, ANB, ZNR, KLR, KHM, HA4, STX, STA, HA5, AFR, J21, MID, VOW, YMID, NEO, YNEO, SNC, YSNC, HBG, HA6, EA1, DMU, YDMU, BRO, BRR
+Banned:Agent of Treachery; Brainstorm; Channel; Counterspell; Dark Ritual; Demonic Tutor; Field of the Dead; Lightning Bolt; Memory Lapse; Mishra's Bauble; Natural Order; Nexus of Fate; Oko, Thief of Crowns; Once Upon a Time; Swords to Plowshares; Thassa's Oracle; Tibalt's Trickery; Time Warp; Uro, Titan of Nature's Wrath; Veil of Summer; Wilderness Reclamation

--- a/forge-gui/res/formats/Sanctioned/Historic.txt
+++ b/forge-gui/res/formats/Sanctioned/Historic.txt
@@ -4,5 +4,5 @@ Type:Digital
 Subtype:Arena
 Effective:2019-11-21
 Order:142
-Sets:XLN, RIX, DOM, M19, ANA, PANA, GRN, G18, RNA, WAR, M20, ELD, HA1, THB, HA2, IKO, HA3, M21, JMP, AJMP, AKR, ANB, ZNR, KLR, KHM, HA4, STX, STA, HA5, AFR, J21, MID, VOW, YMID, NEO, YNEO, SNC, YSNC, HBG, HA6, EA1, DMU, YDMU, BRO
-Banned:Agent of Treachery; Brainstorm; Channel; Counterspell; Dark Ritual; Demonic Tutor; Field of the Dead; Lightning Bolt; Memory Lapse; Natural Order; Nexus of Fate; Oko, Thief of Crowns; Once Upon a Time; Swords to Plowshares; Thassa's Oracle; Tibalt's Trickery; Time Warp; Uro, Titan of Nature's Wrath; Veil of Summer; Wilderness Reclamation
+Sets:XLN, RIX, DOM, M19, ANA, PANA, GRN, G18, RNA, WAR, M20, ELD, HA1, THB, HA2, IKO, HA3, M21, JMP, AJMP, AKR, ANB, ZNR, KLR, KHM, HA4, STX, STA, HA5, AFR, J21, MID, VOW, YMID, NEO, YNEO, SNC, YSNC, HBG, HA6, EA1, DMU, YDMU, BRO, BRR
+Banned:Agent of Treachery; Brainstorm; Channel; Counterspell; Dark Ritual; Demonic Tutor; Field of the Dead; Lightning Bolt; Memory Lapse; Mishra's Bauble; Natural Order; Nexus of Fate; Oko, Thief of Crowns; Once Upon a Time; Swords to Plowshares; Thassa's Oracle; Tibalt's Trickery; Time Warp; Uro, Titan of Nature's Wrath; Veil of Summer; Wilderness Reclamation


### PR DESCRIPTION
I missed the fact that BRR is legal in Historic on Arena and also that they preemptively banned Mishra's Bauble so have fixed it. There was also a ban for Historic Brawl but we don't currently support that.

Source: https://magic.wizards.com/en/news/mtg-arena/mtg-arena-state-game-the-brothers-war

![image](https://user-images.githubusercontent.com/18243520/205324807-0d830b88-f90a-4198-8104-5132afb88db2.png)
