### PR TITLE
CharmEffect: Remove redundant code

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/CharmEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CharmEffect.java
@@ -247,20 +247,6 @@ public class CharmEffect extends SpellAbilityEffect {
                 clone.putParam("StackDescription", "SpellDescription");
             }
 
-            // do not forget what was targeted by the subability
-            SpellAbility ssa = sub;
-            SpellAbility ssaClone = clone;
-            while (ssa != null) {
-                ssaClone.setTargetRestrictions(ssa.getTargetRestrictions());
-                if (ssa.getTargetCard() != null)
-                    ssaClone.setTargetCard(ssa.getTargetCard());
-                ssaClone.setTargetingPlayer(ssa.getTargetingPlayer());
-                ssaClone.setTargets(ssa.getTargets());
-
-                ssa = ssa.getSubAbility();
-                ssaClone = ssaClone.getSubAbility();
-            }
-
             // add Clone to Tail of sa
             sa.appendSubAbility(clone);
         }

--- a/forge-game/src/main/java/forge/game/phase/Untap.java
+++ b/forge-game/src/main/java/forge/game/phase/Untap.java
@@ -70,7 +70,7 @@ public class Untap extends Phase {
      */
     @Override
     public void executeAt() {
-        this.execute(this.at);
+        super.executeAt();
 
         doPhasing(game.getPhaseHandler().getPlayerTurn());
         doDayTime(game.getPhaseHandler().getPreviousPlayerTurn());

--- a/forge-gui/res/cardsfolder/b/biblioplex_kraken.txt
+++ b/forge-gui/res/cardsfolder/b/biblioplex_kraken.txt
@@ -5,7 +5,7 @@ PT:4/5
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters the battlefield, scry 3.
 SVar:TrigScry:DB$ Scry | ScryNum$ 3
 T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigUnblockable | TriggerDescription$ Whenever CARDNAME attacks, you may return another creature you control to it's owner's hand. If you do, CARDNAME can't be blocked this turn.
-SVar:TrigUnblockable:DB$ Effect | Cost$ Return<1/Creature.Other> | RememberObjects$ TriggeredAttacker | ExileOnMoved$ Battlefield | StaticAbilities$ Unblockable
+SVar:TrigUnblockable:AB$ Effect | Cost$ Return<1/Creature.Other> | RememberObjects$ TriggeredAttacker | ExileOnMoved$ Battlefield | StaticAbilities$ Unblockable
 SVar:Unblockable:Mode$ CantBlockBy | ValidAttacker$ Card.IsRemembered | Description$ This creature can't be blocked this turn.
 SVar:HasAttackEffect:TRUE
 Oracle:When Biblioplex Kraken enters the battlefield, scry 3.\nWhenever Biblioplex Kraken attacks, you may return another creature you control to it's owner's hand. If you do, Biblioplex Kraken can't be blocked this turn.

--- a/forge-gui/res/cardsfolder/c/captain_rex_nebula.txt
+++ b/forge-gui/res/cardsfolder/c/captain_rex_nebula.txt
@@ -7,7 +7,7 @@ SVar:TrigAnimate:DB$ Animate | ValidTgts$ Permanent.nonLand+YouCtrl | TgtPrompt$
 SVar:CrashLand:Mode$ DamageDealtOnce | ValidSource$ Card.Self | ValidTarget$ Player,Permanent | Execute$ RollCounters | TriggerZones$ Battlefield | TriggerDescription$ Crash Land — Whenever this Vehicle deals damage, roll a six-sided die. If the result is equal to this Vehicle's mana value, sacrifice this Vehicle, then it deals that much damage to any target.
 SVar:RollCounters:DB$ RollDice | ResultSVar$ Result | SubAbility$ Crash
 SVar:Crash:DB$ Sacrifice | Defined$ Card.Self | ConditionCheckSVar$ Result | ConditionSVarCompare$ EQY | SubAbility$ CrashDamage
-SVar:CrashDamage:DB$ DealDamage | ValidTgt$ Planeswalker,Player,Permanent | TgtPromp$ Choose any target | DamageAmount$ Y | ConditionCheckSVar$ Result | ConditionSVarCompare$ EQY
+SVar:CrashDamage:DB$ DealDamage | ValidTgt$ Planeswalker,Player,Permanent | TgtPromp$ Choose any target | NumDmg$ Y | ConditionCheckSVar$ Result | ConditionSVarCompare$ EQY
 SVar:X:Targeted$CardManaCost
 SVar:Y:Count$CardManaCost
 DeckHints:Type$Vehicle

--- a/forge-gui/res/cardsfolder/c/cuombajj_witches.txt
+++ b/forge-gui/res/cardsfolder/c/cuombajj_witches.txt
@@ -2,7 +2,8 @@ Name:Cuombajj Witches
 ManaCost:B B
 Types:Creature Human Wizard
 PT:1/3
-A:AB$ DealDamage | Cost$ T | ValidTgts$ Creature,Player,Planeswalker | TgtPrompt$ Select any target | NumDmg$ 1 | SubAbility$ DBDmg | SpellDescription$ CARDNAME deals 1 damage to any target and 1 damage to any target of an opponent's choice.
-SVar:DBDmg:DB$ DealDamage | TargetingPlayer$ Player.Opponent | ValidTgts$ Creature,Player,Planeswalker | TgtPrompt$ Select any target | NumDmg$ 1
+A:AB$ DealDamage | Cost$ T | ValidTgts$ Creature,Player,Planeswalker | TgtPrompt$ Select any target | NumDmg$ 1 | DamageMap$ True | SubAbility$ DBDmg | SpellDescription$ CARDNAME deals 1 damage to any target and 1 damage to any target of an opponent's choice.
+SVar:DBDmg:DB$ DealDamage | TargetingPlayer$ Player.Opponent | ValidTgts$ Creature,Player,Planeswalker | TgtPrompt$ Select any target | NumDmg$ 1 | SubAbility$ DBDamageResolve
+SVar:DBDamageResolve:DB$ DamageResolve
 AI:RemoveDeck:All
 Oracle:{T}: Cuombajj Witches deals 1 damage to any target and 1 damage to any target of an opponent's choice.

--- a/forge-gui/res/cardsfolder/i/isu_the_abominable.txt
+++ b/forge-gui/res/cardsfolder/i/isu_the_abominable.txt
@@ -4,7 +4,7 @@ Types:Legendary Snow Creature Yeti
 PT:5/5
 S:Mode$ Continuous | Affected$ Card.TopLibrary+YouCtrl | AffectedZone$ Library | MayLookAt$ You | Description$ You may look at the top card of your library any time.
 S:Mode$ Continuous | Affected$ Card.TopLibrary+YouCtrl+Snow | AffectedZone$ Library | MayPlay$ True | Description$ You may play snow lands and cast snow spells from the top of your library.
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Permanent.Snow+Other+YouCtrl | Execute$ TrigChoice | OptionalDecider$ You | TriggerDescription$ Whenever another snow permanent enters the battlefield under your control, you may pay {G}, {W}, or {U}. If you do, put a +1/+1 counter on CARDNAME.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Permanent.Snow+Other+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigChoice | OptionalDecider$ You | TriggerDescription$ Whenever another snow permanent enters the battlefield under your control, you may pay {G}, {W}, or {U}. If you do, put a +1/+1 counter on CARDNAME.
 SVar:TrigChoice:DB$ GenericChoice | Choices$ PayG,PayW,PayU
 SVar:PayG:DB$ PutCounter | UnlessCost$ G | UnlessPayer$ You | UnlessSwitched$ True | CounterType$ P1P1 | SpellDescription$ {G}: Put a +1/+1 counter on CARDNAME.
 SVar:PayW:DB$ PutCounter | UnlessCost$ W | UnlessPayer$ You | UnlessSwitched$ True | CounterType$ P1P1 | SpellDescription$ {W}: Put a +1/+1 counter on CARDNAME.

--- a/forge-gui/res/cardsfolder/p/portcullis.txt
+++ b/forge-gui/res/cardsfolder/p/portcullis.txt
@@ -1,10 +1,10 @@
 Name:Portcullis
 ManaCost:4
 Types:Artifact
-T:Mode$ ChangesZone | ValidCard$ Creature | Origin$ Any | Destination$ Battlefield | Execute$ TrigExile | TriggerZones$ Battlefield | TriggerDescription$ Whenever a creature enters the battlefield, if there are two or more other creatures on the battlefield, exile that creature.
-SVar:TrigExile:DB$ ChangeZone | ConditionPresent$ Creature | ConditionCompare$ GE3 | Defined$ TriggeredCard | RememberChanged$ True | Origin$ Battlefield | Destination$ Exile
-T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Battlefield | Destination$ Any | Execute$ TrigReturn | TriggerDescription$ Return that card to the battlefield under its owner's control when CARDNAME leaves the battlefield.
-SVar:TrigReturn:DB$ ChangeZoneAll | ChangeType$ Card.IsRemembered | Origin$ Exile | Destination$ Battlefield | SubAbility$ DBCleanup
+T:Mode$ ChangesZone | ValidCard$ Creature | Origin$ Any | Destination$ Battlefield | Execute$ TrigExile | IsPresent$ Creature | PresentCompare$ GE3 | TriggerZones$ Battlefield | TriggerDescription$ Whenever a creature enters the battlefield, if there are two or more other creatures on the battlefield, exile that creature.
+SVar:TrigExile:DB$ ChangeZone | Defined$ TriggeredCardLKICopy | RememberChanged$ True | Origin$ Battlefield | Destination$ Exile | SubAbility$ DBDelayTrig
+SVar:DBDelayTrig:DB$ DelayedTrigger | Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Battlefield | Destination$ Any | Execute$ TrigReturn | RememberObjects$ RememberedLKI | SubAbility$ DBCleanup | TriggerDescription$ Return that card to the battlefield under its owner's control when CARDNAME leaves the battlefield.
+SVar:TrigReturn:DB$ ChangeZoneAll | ChangeType$ Card.IsTriggerRemembered | Origin$ Exile | Destination$ Battlefield
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 AI:RemoveDeck:Random
 Oracle:Whenever a creature enters the battlefield, if there are two or more other creatures on the battlefield, exile that creature. Return that card to the battlefield under its owner's control when Portcullis leaves the battlefield.

--- a/forge-gui/res/cardsfolder/p/priority_boarding.txt
+++ b/forge-gui/res/cardsfolder/p/priority_boarding.txt
@@ -1,11 +1,11 @@
 Name:Priority Boarding
 ManaCost:2 R
 Types:Enchantment
-T:Mode$ RolledDie | TriggerZones$ Battlefield | Execute$ TrigReveal | ValidPlayer$ You | OptionalDecider$ You | ActivationLimit$ 1 | TriggerDescription$ Whenever you roll a die, you may reveal the top card of your library. Do this only once each turn. Whenever you reveal a card with mana value less than the result this way, you may exile it. If you do, you may play it this turn.
-SVar:TrigReveal:DB$ PeekAndReveal | NoPeek$ True | RememberRevealed$ True | SubAbility$ DBExile
-SVar:DBExile:DB$ ChangeZone | ConditionDefined$ Remembered | ConditionPresent$ Card.cmcLEX | Optional$ True | Defined$ Remembered | Origin$ Graveyard | Destination$ Exile | SubAbility$ DBEffect
-SVar:DBEffect:DB$ Effect | ConditionDefined$ Remembered | ConditionPresent$ Card.cmcLEX | StaticAbilities$ STPlay | RememberObjects$ Remembered | SubAbility$ DBCleanup
+T:Mode$ RolledDie | TriggerZones$ Battlefield | Execute$ TrigReveal | ValidPlayer$ You | OptionalDecider$ You | ResolvedLimit$ 1 | TriggerDescription$ Whenever you roll a die, you may reveal the top card of your library. Do this only once each turn. Whenever you reveal a card with mana value less than the result this way, you may exile it. If you do, you may play it this turn.
+SVar:TrigReveal:DB$ PeekAndReveal | NoPeek$ True | ImprintRevealed$ True | SubAbility$ DBExile
+SVar:DBExile:DB$ ChangeZone | ConditionDefined$ Imprinted | ConditionPresent$ Card.cmcLTX | Optional$ True | Defined$ Imprinted | RememberChanged$ True | Origin$ Library | Destination$ Exile | SubAbility$ DBEffect
+SVar:DBEffect:DB$ Effect | StaticAbilities$ STPlay | RememberObjects$ Remembered | SubAbility$ DBCleanup
 SVar:STPlay:Mode$ Continuous | MayPlay$ True | EffectZone$ Command | Affected$ Card.IsRemembered | AffectedZone$ Exile | Description$ You may play this card this turn.
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-SVar:X:TriggerCountMax$Result
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearImprinted$ True
+SVar:X:TriggerCount$Result
 Oracle:Whenever you roll a die, you may reveal the top card of your library. Do this only once each turn. Whenever you reveal a card with mana value less than the result this way, you may exile it. If you do, you may play it this turn.

--- a/forge-gui/res/cardsfolder/r/rubinia_soulsinger.txt
+++ b/forge-gui/res/cardsfolder/r/rubinia_soulsinger.txt
@@ -3,5 +3,5 @@ ManaCost:2 G W U
 Types:Legendary Creature Faerie
 PT:2/3
 K:You may choose not to untap CARDNAME during your untap step.
-A:AB$ GainControl | Cost$ T | ValidTgts$ Creature | TgtPrompt$ Select target creature | LoseControl$ Untap,LeavesPlay,LoseControl | SpellDescription$ Gain control of target creature for as long as you control Rubinia and Rubinia remains tapped.
+A:AB$ GainControl | Cost$ T | ValidTgts$ Creature | TgtPrompt$ Select target creature | LoseControl$ Untap,LeavesPlay,LoseControl | SpellDescription$ Gain control of target creature for as long as you control NICKNAME and NICKNAME remains tapped.
 Oracle:You may choose not to untap Rubinia Soulsinger during your untap step.\n{T}: Gain control of target creature for as long as you control Rubinia and Rubinia remains tapped.

--- a/forge-gui/res/cardsfolder/s/six_sided_die.txt
+++ b/forge-gui/res/cardsfolder/s/six_sided_die.txt
@@ -5,7 +5,7 @@ A:SP$ Pump | ValidTgts$ Creature | SubAbility$ DBRollDice | IsCurse$ True | Spel
 SVar:DBRollDice:DB$ RollDice | ResultSubAbilities$ 1:DBCurse,2:DBCounter,3:DBDrain,4:DBCurseBis,5:DBDestroy,6:DBExile | StackDescription$ Roll a six-sided die.
 SVar:DBCurse:DB$ Animate | Defined$ Targeted | Toughness$ 1 | SpellDescription$ 1 VERT It has base toughness 1 until end of turn.
 SVar:DBCounter:DB$ PutCounter | Defined$ Targeted | CounterType$ M1M1 | CounterNum$ 2 | SpellDescription$ 2 VERT Put two -1/-1 counters on it.
-SVar:DBDrain:DB$ DealDamage | Defined$ Targeted | DamageAmount$ 3 | SubAbility$ DBGainLife | SpellDescription$ 3 VERT CARDNAME deals 3 damage to it and you gain 3 life.
+SVar:DBDrain:DB$ DealDamage | Defined$ Targeted | NumDmg$ 3 | SubAbility$ DBGainLife | SpellDescription$ 3 VERT CARDNAME deals 3 damage to it and you gain 3 life.
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ 3 
 SVar:DBCurseBis:DB$ Pump | Defined$ Targeted | NumAtt$ -4 | NumDef$ -4 | SpellDescription$ 4 VERT It gets -4/-4 until end of turn.
 SVar:DBDestroy:DB$ Destroy | Defined$ Targeted | SpellDescription$ 5 VERT Destroy it.


### PR DESCRIPTION
I checked and the ``SpellAbility.copy`` should now safely retain all that information.

Closes #2012
Closes #2016