### PR TITLE
Molten Impact rebalance

### DIFF
--- a/forge-gui/res/cardsfolder/m/molten_impact.txt
+++ b/forge-gui/res/cardsfolder/m/molten_impact.txt
@@ -2,7 +2,7 @@ Name:Molten Impact
 ManaCost:1 R
 Types:Sorcery
 A:SP$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ 4 | ExcessSVar$ Excess | SubAbility$ DBDelayedTrigger | SpellDescription$ CARDNAME deals 4 damage to target creature or planeswalker.
-SVar:DBDelayedTrigger:DB$ DelayedTrigger | ConditionCheckSVar$ Excess | ConditionSVarCompare$ GE1 | RememberSVarAmount$ Excess | Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | Execute$ TrigDamage | TriggerDescription$ If excess damage was dealt this way, when you cast your next instant or sorcery spell, CARDNAME deals damage equal to the excess to target creature or planeswalker.
-SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ X
+SVar:DBDelayedTrigger:DB$ DelayedTrigger | ConditionCheckSVar$ Excess | ConditionSVarCompare$ GE1 | RememberSVarAmount$ Excess | Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | Execute$ TrigDamage | TriggerDescription$ If excess damage was dealt this way, when you cast your next instant or sorcery spell, CARDNAME deals damage equal to the excess to target creature or planeswalker an opponent controls.
+SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Creature.OppCtrl,Planeswalker.OppCtrl | TgtPrompt$ Select target creature or planeswalker an opponent controls | NumDmg$ X
 SVar:X:Count$TriggerRememberAmount
-Oracle:Molten Impact deals 4 damage to target creature or planeswalker. If excess damage was dealt this way, when you cast your next instant or sorcery spell, Molten Impact deals damage equal to the excess to target creature or planeswalker.
+Oracle:Molten Impact deals 4 damage to target creature or planeswalker. If excess damage was dealt this way, when you cast your next instant or sorcery spell, Molten Impact deals damage equal to the excess to target creature or planeswalker an opponent controls.


### PR DESCRIPTION
The Arena team made a small QoL rebalance of Molten Impact back in October.

"Minor quality-of-life rebalance to Molten Impact (in digital-only formats) to make it no longer force you to damage your own creatures when the opponent has an empty board"

Source:
https://mtgarena-support.wizards.com/hc/en-us/articles/5053877055380-Patch-Notes-2022-14-10
https://scryfall.com/card/yneo/22/molten-impact