### PR TITLE
Sync J21 to match Scryfall collector numbers [less destructive fix]

### DIFF
--- a/forge-gui/res/editions/Jumpstart Historic Horizons.txt
+++ b/forge-gui/res/editions/Jumpstart Historic Horizons.txt
@@ -782,17 +782,6 @@ ScryfallCode=J21
 774 C Scoured Barrens
 775 C Secluded Steppe
 776 R Sliver Hive
-777 C Swiftwater Cliffs
-778 C Thornwood Falls
-779 C Tranquil Cove
-780 C Tranquil Thicket
-781 C Unknown Shores
-782 C Wind-Scarred Crag
-783 L Plains
-784 L Island
-785 L Swamp
-786 L Mountain
-787 L Forest
 
 [rebalanced]
 A438 U A-Dragon's Rage Channeler @Martina Fackova

--- a/forge-gui/res/editions/Jumpstart Historic Horizons.txt
+++ b/forge-gui/res/editions/Jumpstart Historic Horizons.txt
@@ -27,8 +27,8 @@ ScryfallCode=J21
 19 R Subversive Acolyte @Darren Tan
 20 R Managorger Phoenix @Brian Valeza
 21 C Reckless Ringleader @Brian Valeza
-22 C Sarkhan's Scorn @Daarken
-23 M Sarkhan, Wanderer to Shiv @Grzegorz Rutkowski
+22 M Sarkhan, Wanderer to Shiv @Grzegorz Rutkowski
+23 C Sarkhan's Scorn @Daarken
 24 C Scion of Shiv @Grzegorz Rutkowski
 25 U Static Discharge @Liiga Smilshkalne
 26 M Freyalise, Skyshroud Partisan @Daarken


### PR DESCRIPTION
Fixes #2037

Less destructive version of #2038 as discussed [here](https://github.com/Card-Forge/forge/issues/2038#issuecomment-1340149577)

Changes:
- Swap collector numbers 22 and 23 to get correct Scryfall picture
- Remove [conjured cards](https://scryfall.com/search?order=set&q=set%3Aj21+is%3Aconjureonly&unique=prints), because their collector numbers match with different cards on Scryfall. If the images get fetched, they are wrong.