### PR TITLE
Removing extra shop entries from plains capital & swamp towns

### DIFF
--- a/forge-gui/res/adventure/Shandalar/maps/map/main_story/plains_capital.tmx
+++ b/forge-gui/res/adventure/Shandalar/maps/map/main_story/plains_capital.tmx
@@ -36,43 +36,43 @@
  <objectgroup id="4" name="Objects">
   <object id="41" template="../../obj/shop.tx" x="465" y="260">
    <properties>
-    <property name="shopList" value="Human,Boros,Orzhov,Selesnya,Selesnya,Azorius,White,Creature,Instant,Angel"/>
+    <property name="shopList" value="Human,Boros,Orzhov,Selesnya,Azorius,White,Creature,Instant,Angel"/>
    </properties>
   </object>
   <object id="56" template="../../obj/shop.tx" x="416" y="260">
    <properties>
-    <property name="shopList" value="Human,Boros,Orzhov,Selesnya,Selesnya,Azorius,White,Creature,Instant,Angel"/>
+    <property name="shopList" value="Human,Boros,Orzhov,Selesnya,Azorius,White,Creature,Instant,Angel"/>
    </properties>
   </object>
   <object id="57" template="../../obj/shop.tx" x="545" y="259">
    <properties>
-    <property name="shopList" value="Human,Boros,Orzhov,Selesnya,Selesnya,Azorius,White,Creature,Instant,Angel"/>
+    <property name="shopList" value="Human,Boros,Orzhov,Selesnya,Azorius,White,Creature,Instant,Angel"/>
    </properties>
   </object>
   <object id="43" template="../../obj/shop.tx" x="370" y="325">
    <properties>
-    <property name="shopList" value="Human,Boros,Orzhov,Selesnya,Selesnya,Azorius,White,Creature,Instant,Angel"/>
+    <property name="shopList" value="Human,Boros,Orzhov,Selesnya,Azorius,White,Creature,Instant,Angel"/>
    </properties>
   </object>
   <object id="47" template="../../obj/inn.tx" x="536" y="144"/>
   <object id="49" template="../../obj/shop.tx" x="417" y="324">
    <properties>
-    <property name="shopList" value="Human,Boros,Orzhov,Selesnya,Selesnya,Azorius,White,Creature,Instant,Angel"/>
+    <property name="shopList" value="Human,Boros,Orzhov,Selesnya,Azorius,White,Creature,Instant,Angel"/>
    </properties>
   </object>
   <object id="50" template="../../obj/shop.tx" x="465" y="323">
    <properties>
-    <property name="shopList" value="Human,Boros,Orzhov,Selesnya,Selesnya,Azorius,White,Creature,Instant,Angel"/>
+    <property name="shopList" value="Human,Boros,Orzhov,Selesnya,Azorius,White,Creature,Instant,Angel"/>
    </properties>
   </object>
   <object id="51" template="../../obj/shop.tx" x="545" y="325">
    <properties>
-    <property name="shopList" value="Human,Boros,Orzhov,Selesnya,Selesnya,Azorius,White,Creature,Instant,Angel"/>
+    <property name="shopList" value="Human,Boros,Orzhov,Selesnya,Azorius,White,Creature,Instant,Angel"/>
    </properties>
   </object>
   <object id="52" template="../../obj/shop.tx" x="369" y="261">
    <properties>
-    <property name="shopList" value="Human,Boros,Orzhov,Selesnya,Selesnya,Azorius,White,Creature,Instant,Angel"/>
+    <property name="shopList" value="Human,Boros,Orzhov,Selesnya,Azorius,White,Creature,Instant,Angel"/>
    </properties>
   </object>
   <object id="53" template="../../obj/spellsmith.tx" x="452" y="212"/>

--- a/forge-gui/res/adventure/Shandalar/maps/map/swamp_town.tmx
+++ b/forge-gui/res/adventure/Shandalar/maps/map/swamp_town.tmx
@@ -32,32 +32,32 @@
   <object id="38" template="../obj/entry_up.tx" x="208" y="272"/>
   <object id="41" template="../obj/shop.tx" x="129" y="146">
    <properties>
-    <property name="shopList" value="Instant,Creature,Black,Dimir,Rakdos,Orzhov,Golgari,Simic,Zombie "/>
+    <property name="shopList" value="Instant,Creature,Black,Dimir,Rakdos,Orzhov,Golgari,Zombie "/>
    </properties>
   </object>
   <object id="42" template="../obj/shop.tx" x="177" y="145">
    <properties>
-    <property name="shopList" value="Instant,Creature,Black,Dimir,Rakdos,Orzhov,Golgari,Simic,Zombie "/>
+    <property name="shopList" value="Instant,Creature,Black,Dimir,Rakdos,Orzhov,Golgari,Zombie "/>
    </properties>
   </object>
   <object id="43" template="../obj/shop.tx" x="321" y="129">
    <properties>
-    <property name="shopList" value="Instant,Creature,Black,Dimir,Rakdos,Orzhov,Golgari,Simic,Zombie "/>
+    <property name="shopList" value="Instant,Creature,Black,Dimir,Rakdos,Orzhov,Golgari,Zombie "/>
    </properties>
   </object>
   <object id="44" template="../obj/shop.tx" x="114" y="194">
    <properties>
-    <property name="shopList" value="Instant,Creature,Black,Dimir,Rakdos,Orzhov,Golgari,Simic,Zombie "/>
+    <property name="shopList" value="Instant,Creature,Black,Dimir,Rakdos,Orzhov,Golgari,Zombie "/>
    </properties>
   </object>
   <object id="45" template="../obj/shop.tx" x="273" y="130">
    <properties>
-    <property name="shopList" value="Instant,Creature,Black,Dimir,Rakdos,Orzhov,Golgari,Simic,Zombie "/>
+    <property name="shopList" value="Instant,Creature,Black,Dimir,Rakdos,Orzhov,Golgari,Zombie "/>
    </properties>
   </object>
   <object id="46" template="../obj/shop.tx" x="337" y="177">
    <properties>
-    <property name="shopList" value="Instant,Creature,Black,Dimir,Rakdos,Orzhov,Golgari,Simic,Zombie "/>
+    <property name="shopList" value="Instant,Creature,Black,Dimir,Rakdos,Orzhov,Golgari,Zombie "/>
    </properties>
   </object>
   <object id="47" template="../obj/inn.tx" x="230" y="98"/>


### PR DESCRIPTION
Prior to this change, Selesnya shops are twice as frequent in plains capital, and swamp towns contain Simic (UG) shops. Neither appears to be intended.