### PR TITLE
Fix zeppelin token script

### DIFF
--- a/forge-gui/res/tokenscripts/zeppelin.txt
+++ b/forge-gui/res/tokenscripts/zeppelin.txt
@@ -1,6 +1,6 @@
 Name:Zeppelin
 ManaCost:no cost
-Types:Artifact Creature
+Types:Artifact Vehicle
 PT:5/5
 K:Flying
 K:Crew:3


### PR DESCRIPTION
Changed card type from "Artifact Creature" to "Artifact Vehicle" to match "Lita, Mechanical Engineer" card's text.

![zeppelin token creation text](https://user-images.githubusercontent.com/5010195/206895486-a56f50e7-efb3-403b-985c-b4e17e15b4c6.png)
