### PR TITLE
Quest reprint fix

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/quest/data/GameFormatQuest.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/data/GameFormatQuest.java
@@ -61,7 +61,7 @@ public final class GameFormatQuest extends GameFormat {
 		// Filter must be continuously rebuilt if the format is mutable
 		if(setRotation != null)
 			return super.buildFilter(true);
-		return super.getFilterRules();
+		return super.getFilterPrinted();
 	}
 
 	/**


### PR DESCRIPTION
After #1797 was merged, Quest mode was allowing card reprints in the spell shop and rewards that were not compliant with the current world or unlocked sets. It was unintentional and this PR fixes that. Thank you @Robbatog !