### PR TITLE
Make set codes case-insensitive during deck import

### DIFF
--- a/forge-core/src/main/java/forge/card/CardEdition.java
+++ b/forge-core/src/main/java/forge/card/CardEdition.java
@@ -173,7 +173,7 @@ public final class CardEdition implements Comparable<CardEdition> {
             this.rarity = rarity;
             this.artistName = artistName;
         }
- 
+
         public String toString() {
             StringBuilder sb = new StringBuilder();
             if (collectorNumber != null) {
@@ -531,6 +531,11 @@ public final class CardEdition implements Comparable<CardEdition> {
         public Reader(File path, boolean isCustomEditions) {
             super(path, CardEdition.FN_GET_CODE);
             this.isCustomEditions = isCustomEditions;
+        }
+
+        protected Map<String, CardEdition> createMap() {
+            // Create our own map to make it case-insensitive for set codes.
+            return new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         }
 
         @Override

--- a/forge-core/src/main/java/forge/util/storage/StorageReaderBase.java
+++ b/forge-core/src/main/java/forge/util/storage/StorageReaderBase.java
@@ -1,6 +1,8 @@
 package forge.util.storage;
 
 import java.io.File;
+import java.util.Map;
+import java.util.TreeMap;
 
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
@@ -11,6 +13,10 @@ public abstract class StorageReaderBase<T> implements IItemReader<T> {
     protected final Function<? super T, String> keySelector;
     public StorageReaderBase(final Function<? super T, String> keySelector0) {
         keySelector = keySelector0;
+    }
+
+    protected Map<String, T> createMap() {
+        return new TreeMap<>();
     }
 
     @Override

--- a/forge-core/src/main/java/forge/util/storage/StorageReaderFile.java
+++ b/forge-core/src/main/java/forge/util/storage/StorageReaderFile.java
@@ -6,12 +6,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -19,7 +19,6 @@ package forge.util.storage;
 
 import java.io.File;
 import java.util.Map;
-import java.util.TreeMap;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -29,7 +28,7 @@ import forge.util.FileUtil;
 
 /**
  * This class treats every line of a given file as a source for a named object.
- * 
+ *
  * @param <T>
  *            the generic type
  */
@@ -52,14 +51,14 @@ public abstract class StorageReaderFile<T> extends StorageReaderBase<T> {
 
     @Override
     public Map<String, T> readAll() {
-        final Map<String, T> result = new TreeMap<>();
+        final Map<String, T> result = createMap();
 
         int idx = 0;
         for (String line : FileUtil.readFile(file)) {
             line = line.trim();
             if (line.isEmpty()) {
                 continue; //ignore blank or whitespace lines
-            }  
+            }
 
             if (!lineContainsObject(line)) {
                 continue;

--- a/forge-core/src/main/java/forge/util/storage/StorageReaderFileSections.java
+++ b/forge-core/src/main/java/forge/util/storage/StorageReaderFileSections.java
@@ -6,12 +6,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -21,7 +21,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -31,7 +30,7 @@ import forge.util.FileUtil;
 
 /**
  * This class treats every line of a given file as a source for a named object.
- * 
+ *
  * @param <T>
  *            the generic type
  */
@@ -50,10 +49,6 @@ public abstract class StorageReaderFileSections<T> extends StorageReaderBase<T> 
     @Override
     public String getFullPath() {
         return file.getPath();
-    }
-
-    protected Map<String, T> createMap() {
-        return new TreeMap<>();
     }
 
     /* (non-Javadoc)
@@ -116,7 +111,7 @@ public abstract class StorageReaderFileSections<T> extends StorageReaderBase<T> 
 
     /**
      * TODO: Write javadoc for this method.
-     * 
+     *
      * @param line
      *            the line
      * @return the t
@@ -125,7 +120,7 @@ public abstract class StorageReaderFileSections<T> extends StorageReaderBase<T> 
 
     /**
      * Line contains object.
-     * 
+     *
      * @param line
      *            the line
      * @return true, if successful

--- a/forge-core/src/main/java/forge/util/storage/StorageReaderFolder.java
+++ b/forge-core/src/main/java/forge/util/storage/StorageReaderFolder.java
@@ -6,12 +6,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.TreeMap;
 
 import com.google.common.base.Function;
 
@@ -88,7 +87,7 @@ public abstract class StorageReaderFolder<T> extends StorageReaderBase<T> {
      */
     @Override
     public Map<String, T> readAll() {
-        final Map<String, T> result = new TreeMap<>();
+        final Map<String, T> result = createMap();
 
         final File[] files = this.directory.listFiles(this.getFileFilter());
         for (final File file : files) {
@@ -122,7 +121,7 @@ public abstract class StorageReaderFolder<T> extends StorageReaderBase<T> {
 
     /**
      * TODO: Write javadoc for this method.
-     * 
+     *
      * @return FilenameFilter to pick only relevant objects for deserialization
      */
     protected abstract FilenameFilter getFileFilter();

--- a/forge-core/src/main/java/forge/util/storage/StorageReaderRecursiveFolderWithUserFolder.java
+++ b/forge-core/src/main/java/forge/util/storage/StorageReaderRecursiveFolderWithUserFolder.java
@@ -6,12 +6,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.TreeMap;
 
 import com.google.common.base.Function;
 
@@ -93,7 +92,7 @@ public abstract class StorageReaderRecursiveFolderWithUserFolder<T> extends Stor
      */
     @Override
     public Map<String, T> readAll() {
-        final Map<String, T> result = new TreeMap<>();
+        final Map<String, T> result = createMap();
 
         Collection<File> forgeFormats = listFileTree(directory);
         Collection<File> customFormats = listFileTree(userDirectory);
@@ -145,7 +144,7 @@ public abstract class StorageReaderRecursiveFolderWithUserFolder<T> extends Stor
 
     /**
      * TODO: Write javadoc for this method.
-     * 
+     *
      * @return FilenameFilter to pick only relevant objects for deserialization
      */
     protected abstract FilenameFilter getFileFilter();


### PR DESCRIPTION
This moves the createMap() function up to the StorageReaderBase class and makes all subclasses call this function in readAll() to allow subclasses to override this.  We then override this in the CardEdition Reader class to create a case-insensitive map for the card sets during deck import.  This matches the way set aliases are already using a case-insensitive map, so lowercase set codes (e.g. Moxfield and other sites exports) will work for all sets during deck import.