### PR TITLE
Clean up lobby code and fix a deck deselect bug.

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/screens/home/CLobby.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/CLobby.java
@@ -1,7 +1,5 @@
 package forge.screens.home;
 
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.util.Arrays;
 import java.util.Vector;
 
@@ -10,8 +8,6 @@ import javax.swing.SwingUtilities;
 import com.google.common.collect.Iterables;
 
 import forge.deck.DeckProxy;
-import forge.deck.DeckType;
-import forge.deckchooser.FDeckChooser;
 import forge.localinstance.properties.ForgePreferences;
 import forge.localinstance.properties.ForgePreferences.FPref;
 import forge.model.FModel;
@@ -22,12 +18,10 @@ public class CLobby {
     private final VLobby view;
     public CLobby(final VLobby view) {
         this.view = view;
-        this.view.setForCommander(true);
     }
 
     private void addDecks(final Iterable<DeckProxy> commanderDecks, FList<Object> deckList, String... initialItems) {
-        Vector<Object> listData = new Vector<>();
-        listData.addAll(Arrays.asList(initialItems));
+        Vector<Object> listData = new Vector<>(Arrays.asList(initialItems));
         listData.add("Generate");
         if (!Iterables.isEmpty(commanderDecks)) {
             listData.add("Random");
@@ -46,89 +40,38 @@ public class CLobby {
     }
     
     public void update() {
-        SwingUtilities.invokeLater(new Runnable() {
-            @Override public final void run() {
-                final Iterable<DeckProxy> schemeDecks = DeckProxy.getAllSchemeDecks();
-                final Iterable<DeckProxy> planarDecks = DeckProxy.getAllPlanarDecks();
+        SwingUtilities.invokeLater(() -> {
+            final Iterable<DeckProxy> schemeDecks = DeckProxy.getAllSchemeDecks();
+            final Iterable<DeckProxy> planarDecks = DeckProxy.getAllPlanarDecks();
 
-                for (int i = 0; i < VLobby.MAX_PLAYERS; i++) {
-                    addDecks(schemeDecks, view.getSchemeDeckLists().get(i),
-                            "Use deck's scheme section (random if unavailable)");
-                    addDecks(planarDecks, view.getPlanarDeckLists().get(i),
-                            "Use deck's planes section (random if unavailable)");
-                    view.updateVanguardList(i);
-                }
-
-                // General updates when switching back to this view
-                view.getBtnStart().requestFocusInWindow();
+            for (int i = 0; i < VLobby.MAX_PLAYERS; i++) {
+                addDecks(schemeDecks, view.getSchemeDeckLists().get(i),
+                        "Use deck's scheme section (random if unavailable)");
+                addDecks(planarDecks, view.getPlanarDeckLists().get(i),
+                        "Use deck's planes section (random if unavailable)");
+                view.updateVanguardList(i);
             }
+
+            // General updates when switching back to this view
+            view.getBtnStart().requestFocusInWindow();
         });
     }
 
     public void initialize() {
-        for (int iSlot = 0; iSlot < VLobby.MAX_PLAYERS; iSlot++) {
-            final FDeckChooser fdc = view.getDeckChooser(iSlot);
-            fdc.initialize(FPref.CONSTRUCTED_DECK_STATES[iSlot], defaultDeckTypeForSlot(iSlot));
-            fdc.populate();
-            /*fdc.getDecksComboBox().addListener(new IDecksComboBoxListener() {
-                @Override public final void deckTypeSelected(final DecksComboBoxEvent ev) {
-                    view.focusOnAvatar();
-                }
-            });*/
-            final FDeckChooser fdccom = view.getCommanderDeckChooser(iSlot);
-            fdccom.initialize(FPref.COMMANDER_DECK_STATES[iSlot], defaultDeckTypeForCommanderSlot(iSlot));
-            fdccom.populate();
-            final FDeckChooser fdobcom = view.getOathbreakerDeckChooser(iSlot);
-            fdobcom.initialize(FPref.OATHBREAKER_DECK_STATES[iSlot], defaultDeckTypeForOathbreakerSlot(iSlot));
-            fdobcom.populate();
-            final FDeckChooser fdtlcom = view.getTinyLeaderDeckChooser(iSlot);
-            fdtlcom.initialize(FPref.TINY_LEADER_DECK_STATES[iSlot], defaultDeckTypeForTinyLeaderSlot(iSlot));
-            fdtlcom.populate();
-            final FDeckChooser fdbcom = view.getBrawlDeckChooser(iSlot);
-            fdbcom.initialize(FPref.BRAWL_DECK_STATES[iSlot], defaultDeckTypeForBrawlSlot(iSlot));
-            fdbcom.populate();
-        }
-
         final ForgePreferences prefs = FModel.getPreferences();
         // Checkbox event handling
-        view.getCbSingletons().addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(final ActionEvent arg0) {
-                prefs.setPref(FPref.DECKGEN_SINGLETONS, String.valueOf(view.getCbSingletons().isSelected()));
-                prefs.save();
-            }
+        view.getCbSingletons().addActionListener(arg0 -> {
+            prefs.setPref(FPref.DECKGEN_SINGLETONS, String.valueOf(view.getCbSingletons().isSelected()));
+            prefs.save();
         });
 
-        view.getCbArtifacts().addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(final ActionEvent arg0) {
-                prefs.setPref(FPref.DECKGEN_ARTIFACTS, String.valueOf(view.getCbArtifacts().isSelected()));
-                prefs.save();
-            }
+        view.getCbArtifacts().addActionListener(arg0 -> {
+            prefs.setPref(FPref.DECKGEN_ARTIFACTS, String.valueOf(view.getCbArtifacts().isSelected()));
+            prefs.save();
         });
 
         // Pre-select checkboxes
         view.getCbSingletons().setSelected(prefs.getPrefBoolean(FPref.DECKGEN_SINGLETONS));
         view.getCbArtifacts().setSelected(prefs.getPrefBoolean(FPref.DECKGEN_ARTIFACTS));
-    }
-
-    private static DeckType defaultDeckTypeForSlot(final int iSlot) {
-        return iSlot == 0 ? DeckType.PRECONSTRUCTED_DECK : DeckType.COLOR_DECK;
-    }
-
-    private static DeckType defaultDeckTypeForCommanderSlot(final int iSlot) {
-        return iSlot == 0 ? DeckType.COMMANDER_DECK : DeckType.RANDOM_CARDGEN_COMMANDER_DECK;
-    }
-
-    private static DeckType defaultDeckTypeForOathbreakerSlot(final int iSlot) {
-        return iSlot == 0 ? DeckType.OATHBREAKER_DECK : DeckType.RANDOM_CARDGEN_COMMANDER_DECK;
-    }
-
-    private static DeckType defaultDeckTypeForTinyLeaderSlot(final int iSlot) {
-        return iSlot == 0 ? DeckType.TINY_LEADERS_DECK : DeckType.RANDOM_CARDGEN_COMMANDER_DECK;
-    }
-
-    private static DeckType defaultDeckTypeForBrawlSlot(final int iSlot) {
-        return iSlot == 0 ? DeckType.BRAWL_DECK : DeckType.CUSTOM_DECK;
     }
 }

--- a/forge-gui-desktop/src/main/java/forge/screens/home/PlayerPanel.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/PlayerPanel.java
@@ -1,5 +1,6 @@
 package forge.screens.home;
 
+import forge.deckchooser.FDeckChooser;
 import java.awt.Graphics;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -102,6 +103,8 @@ public class PlayerPanel extends FPanel {
     private FCheckBox chkDevMode;
 
     private boolean allowNetworking;
+
+    private FDeckChooser deckChooser;
 
     private final VLobby lobby;
     public PlayerPanel(final VLobby lobby, final boolean allowNetworking, final int index, final LobbySlot slot, final boolean mayEdit, final boolean mayControl) {
@@ -463,10 +466,6 @@ public class PlayerPanel extends FPanel {
         radioAiUseSimulation.setSelected(useSimulation);
     }
 
-    public boolean isLocal() {
-        return type == LobbySlotType.LOCAL;
-    }
-
     public boolean isArchenemy() {
         return aeTeamComboBox.getSelectedIndex() == 0;
     }
@@ -540,9 +539,6 @@ public class PlayerPanel extends FPanel {
         }
     };
 
-    /**
-     * @param index
-     */
     private void addHandlersToVariantsControls() {
         // Archenemy buttons
         scmDeckSelectorBtn.setCommand(new Runnable() {
@@ -621,9 +617,6 @@ public class PlayerPanel extends FPanel {
         });
     }
 
-    /**
-     * @param index
-     */
     private void createPlayerTypeOptions() {
         radioHuman = new FRadioButton(localizer.getMessage("lblHuman"));
         radioAi = new FRadioButton(localizer.getMessage("lblAI"));
@@ -674,9 +667,6 @@ public class PlayerPanel extends FPanel {
         });
     }
 
-    /**
-     * @param index
-     */
     private void addHandlersDeckSelector() {
         deckBtn.setCommand(new Runnable() {
             @Override
@@ -688,10 +678,6 @@ public class PlayerPanel extends FPanel {
         });
     }
 
-    /**
-     * @param index
-     * @return
-     */
     private FLabel createNameRandomizer() {
         final FLabel newNameBtn = new FLabel.Builder().tooltip(localizer.getMessage("lblGetaNewRandomName")).iconInBackground(false)
                 .icon(FSkin.getIcon(FSkinProp.ICO_EDIT)).hoverable(true).opaque(false)
@@ -717,10 +703,6 @@ public class PlayerPanel extends FPanel {
         return newNameBtn;
     }
 
-    /**
-     * @param index
-     * @return
-     */
     private void createNameEditor() {
         String name;
         if (index == 0) {
@@ -897,5 +879,13 @@ public class PlayerPanel extends FPanel {
 
     public void setMayRemove(final boolean mayRemove) {
         this.mayRemove = mayRemove;
+    }
+
+    FDeckChooser getDeckChooser() {
+        return deckChooser;
+    }
+
+    void setDeckChooser(final FDeckChooser deckChooser) {
+        this.deckChooser = deckChooser;
     }
 }

--- a/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
@@ -216,7 +216,6 @@ public class VLobby implements ILobbyView {
 
     @Override
     public void update(final int slot, final LobbySlotType type) {
-        System.err.println("Update:"+slot+" / "+type);
         final FDeckChooser deckChooser = getPlayerPanel(slot).getDeckChooser();
         deckChooser.setIsAi(type==LobbySlotType.AI);
 
@@ -242,8 +241,6 @@ public class VLobby implements ILobbyView {
 
     @Override
     public void update(final boolean fullUpdate) {
-        System.err.println("Update:"+fullUpdate);
-
         activePlayersNum = lobby.getNumberOfSlots();
         addPlayerBtn.setEnabled(activePlayersNum < MAX_PLAYERS);
 

--- a/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
@@ -435,11 +435,11 @@ public class VLobby implements ILobbyView {
         deckPanels.add(deckPanel);
     }
 
-    private void selectMainDeck(final FDeckChooser mainChooser, final int playerIndex) {
-        if (hasVariant(GameType.Commander) || hasVariant(GameType.Oathbreaker) || hasVariant(GameType.TinyLeaders) || hasVariant(GameType.Brawl)) {
-            // These game types use specific deck panel
-            return;
-        }
+    private FDeckChooser getDeckChooser(final int iSlot) {
+        return getPlayerPanel(iSlot).getDeckChooser();
+    }
+
+    private void selectMainDeck(final FDeckChooser mainChooser, final int playerIndex, final boolean isCommanderDeck) {
         final DeckType type = mainChooser.getSelectedDeckType();
         final Deck deck = mainChooser.getDeck();
         // something went wrong, clear selection to prevent error loop
@@ -449,75 +449,11 @@ public class VLobby implements ILobbyView {
         final Collection<DeckProxy> selectedDecks = mainChooser.getLstDecks().getSelectedItems();
         if (playerIndex < activePlayersNum && lobby.mayEdit(playerIndex)) {
             final String text = type.toString() + ": " + Lang.joinHomogenous(selectedDecks, DeckProxy.FN_GET_NAME);
-            getPlayerPanel(playerIndex).setDeckSelectorButtonText(text);
-            fireDeckChangeListener(playerIndex, deck);
-        }
-        mainChooser.saveState();
-    }
-
-    private FDeckChooser getDeckChooser(final int iSlot) {
-        return getPlayerPanel(iSlot).getDeckChooser();
-    }
-
-    private void selectCommanderDeck(final FDeckChooser mainChooser, final int playerIndex) {
-        if (!hasVariant(GameType.Commander) && !hasVariant(GameType.Oathbreaker) && !hasVariant(GameType.TinyLeaders) && !hasVariant(GameType.Brawl)) {
-            // Only these game types use this specific deck panel
-            return;
-        }
-        final DeckType type = mainChooser.getSelectedDeckType();
-        final Deck deck = mainChooser.getDeck();
-        final Collection<DeckProxy> selectedDecks = mainChooser.getLstDecks().getSelectedItems();
-        if (playerIndex < activePlayersNum && lobby.mayEdit(playerIndex)) {
-            final String text = type.toString() + ": " + Lang.joinHomogenous(selectedDecks, DeckProxy.FN_GET_NAME);
-            getPlayerPanel(playerIndex).setCommanderDeckSelectorButtonText(text);
-            fireDeckChangeListener(playerIndex, deck);
-        }
-        mainChooser.saveState();
-    }
-
-    private void selectOathbreakerDeck(final FDeckChooser mainChooser, final int playerIndex) {
-        if (!hasVariant(GameType.Oathbreaker)) {
-            // Only these game types use this specific deck panel
-            return;
-        }
-        final DeckType type = mainChooser.getSelectedDeckType();
-        final Deck deck = mainChooser.getDeck();
-        final Collection<DeckProxy> selectedDecks = mainChooser.getLstDecks().getSelectedItems();
-        if (playerIndex < activePlayersNum && lobby.mayEdit(playerIndex)) {
-            final String text = type.toString() + ": " + Lang.joinHomogenous(selectedDecks, DeckProxy.FN_GET_NAME);
-            getPlayerPanel(playerIndex).setCommanderDeckSelectorButtonText(text);
-            fireDeckChangeListener(playerIndex, deck);
-        }
-        mainChooser.saveState();
-    }
-
-    private void selectTinyLeadersDeck(final FDeckChooser mainChooser, final int playerIndex) {
-        if (!hasVariant(GameType.TinyLeaders)) {
-            // Only these game types use this specific deck panel
-            return;
-        }
-        final DeckType type = mainChooser.getSelectedDeckType();
-        final Deck deck = mainChooser.getDeck();
-        final Collection<DeckProxy> selectedDecks = mainChooser.getLstDecks().getSelectedItems();
-        if (playerIndex < activePlayersNum && lobby.mayEdit(playerIndex)) {
-            final String text = type.toString() + ": " + Lang.joinHomogenous(selectedDecks, DeckProxy.FN_GET_NAME);
-            getPlayerPanel(playerIndex).setCommanderDeckSelectorButtonText(text);
-            fireDeckChangeListener(playerIndex, deck);
-        }
-        mainChooser.saveState();
-    }
-
-    private void selectBrawlDeck(final FDeckChooser mainChooser,final int playerIndex) {
-        if (!hasVariant(GameType.Brawl)) {
-            // Only these game types use this specific deck panel
-            return;
-        }
-        final DeckType type = mainChooser.getSelectedDeckType();
-        final Deck deck = mainChooser.getDeck();
-        final Collection<DeckProxy> selectedDecks = mainChooser.getLstDecks().getSelectedItems();
-        if (playerIndex < activePlayersNum && lobby.mayEdit(playerIndex)) {
-            final String text = type.toString() + ": " + Lang.joinHomogenous(selectedDecks, DeckProxy.FN_GET_NAME);
-            getPlayerPanel(playerIndex).setCommanderDeckSelectorButtonText(text);
+            if (isCommanderDeck) {
+                getPlayerPanel(playerIndex).setCommanderDeckSelectorButtonText(text);
+            } else {
+                getPlayerPanel(playerIndex).setDeckSelectorButtonText(text);
+            }
             fireDeckChangeListener(playerIndex, deck);
         }
         mainChooser.saveState();
@@ -850,35 +786,35 @@ public class VLobby implements ILobbyView {
                 final FDeckChooser fdc = new FDeckChooser(null, ai, GameType.Commander, true);
                 final DeckType type = iSlot == 0 ? DeckType.COMMANDER_DECK : DeckType.RANDOM_CARDGEN_COMMANDER_DECK;
                 fdc.initialize(FPref.COMMANDER_DECK_STATES[iSlot], type);
-                fdc.getLstDecks().setSelectCommand(() -> selectCommanderDeck(fdc, iSlot));
+                fdc.getLstDecks().setSelectCommand(() -> selectMainDeck(fdc, iSlot, true));
                 return fdc;
             }
             case TinyLeaders: {
                 final FDeckChooser fdc = new FDeckChooser(null, ai, GameType.TinyLeaders, true);
                 final DeckType type = iSlot == 0 ? DeckType.TINY_LEADERS_DECK : DeckType.RANDOM_CARDGEN_COMMANDER_DECK;
                 fdc.initialize(FPref.TINY_LEADER_DECK_STATES[iSlot], type);
-                fdc.getLstDecks().setSelectCommand(() -> selectTinyLeadersDeck(fdc, iSlot));
+                fdc.getLstDecks().setSelectCommand(() -> selectMainDeck(fdc, iSlot, true));
                 return fdc;
             }
             case Oathbreaker: {
                 final FDeckChooser fdc = new FDeckChooser(null, ai, GameType.Oathbreaker, true);
                 final DeckType type = iSlot == 0 ? DeckType.OATHBREAKER_DECK : DeckType.RANDOM_CARDGEN_COMMANDER_DECK;
                 fdc.initialize(FPref.OATHBREAKER_DECK_STATES[iSlot], type);
-                fdc.getLstDecks().setSelectCommand(() -> selectOathbreakerDeck(fdc, iSlot));
+                fdc.getLstDecks().setSelectCommand(() -> selectMainDeck(fdc, iSlot, true));
                 return fdc;
             }
             case Brawl: {
                 final FDeckChooser fdc = new FDeckChooser(null, ai, GameType.Brawl, true);
                 final DeckType type = iSlot == 0 ? DeckType.BRAWL_DECK : DeckType.CUSTOM_DECK;
                 fdc.initialize(FPref.BRAWL_DECK_STATES[iSlot], type);
-                fdc.getLstDecks().setSelectCommand(() -> selectBrawlDeck(fdc, iSlot));
+                fdc.getLstDecks().setSelectCommand(() -> selectMainDeck(fdc, iSlot, true));
                 return fdc;
             }
             default: {
                 final FDeckChooser fdc = new FDeckChooser(null, ai, GameType.Constructed, false);
                 final DeckType type = iSlot == 0 ? DeckType.PRECONSTRUCTED_DECK : DeckType.COLOR_DECK;
                 fdc.initialize(FPref.CONSTRUCTED_DECK_STATES[iSlot], type);
-                fdc.getLstDecks().setSelectCommand(() -> selectMainDeck(fdc, iSlot));
+                fdc.getLstDecks().setSelectCommand(() -> selectMainDeck(fdc, iSlot, false));
                 return fdc;
             }
         }

--- a/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
@@ -312,6 +312,7 @@ public class VLobby implements ILobbyView {
                 }
                 if (fullUpdate && (type == LobbySlotType.LOCAL || isSlotAI)) {
                     // Deck section selection
+                    panel.getDeckChooser().getLstDecks().getSelectCommand().run();
                     selectSchemeDeck(i);
                     selectPlanarDeck(i);
                     selectVanguardAvatar(i);

--- a/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
@@ -216,9 +216,8 @@ public class VLobby implements ILobbyView {
 
     @Override
     public void update(final int slot, final LobbySlotType type) {
-        final FDeckChooser deckChooser = getPlayerPanel(slot).getDeckChooser();
+        final FDeckChooser deckChooser = getDeckChooser(slot);
         deckChooser.setIsAi(type==LobbySlotType.AI);
-
         DeckType selectedDeckType = deckChooser.getSelectedDeckType();
         switch (selectedDeckType){
             case STANDARD_CARDGEN_DECK:
@@ -573,7 +572,7 @@ public class VLobby implements ILobbyView {
                 }
             }
             if (sel.equals("Random")) {
-                final Deck randomDeck = RandomDeckGenerator.getRandomUserDeck(lobby, getPlayerPanel(playerIndex).isAi());
+                final Deck randomDeck = RandomDeckGenerator.getRandomUserDeck(lobby, isPlayerAI(playerIndex));
                 planePool = randomDeck.get(DeckSection.Planes);
             }
         } else if (selected instanceof Deck) {
@@ -615,7 +614,7 @@ public class VLobby implements ILobbyView {
             if (sel.contains("Use deck's default avatar") && deck != null && deck.has(DeckSection.Avatar)) {
                 vanguardAvatar = deck.get(DeckSection.Avatar).get(0);
             } else { //Only other string is "Random"
-                if (getPlayerPanel(playerIndex).isAi()) { //AI
+                if (isPlayerAI(playerIndex)) { //AI
                     vanguardAvatar = Aggregates.random(getNonRandomAiAvatars());
                 } else { //Human
                     vanguardAvatar = Aggregates.random(getNonRandomHumanAvatars());
@@ -683,7 +682,7 @@ public class VLobby implements ILobbyView {
     public JPanel getPanelStart() { return pnlStart; }
     public List<FDeckChooser> getDeckChoosers() {
         List<FDeckChooser> choosers = new ArrayList<>(playerPanels.size());
-        for (PlayerPanel playerPanel : playerPanels) {
+        for (final PlayerPanel playerPanel : playerPanels) {
             choosers.add(playerPanel.getDeckChooser());
         }
         return choosers;


### PR DESCRIPTION
This PR cleans up game lobby code related to game types, specifically removing a lot of code duplication related to managing deck choosers for different game types. Instead, we now only keep around the deck choosers that correspond to the player slots being shown.

This also fixes a bug where changing the AI type (e.g. simulation) can deselect the deck, which would happen at least with Tiny Leaders. (This PR supersedes https://github.com/Card-Forge/forge/pull/2066).

Some other small clean ups are included that were suggested by IntelliJ (deleting unused methods, using lambdas, etc.).