### PR TITLE
Fix ArrayIndexOutOfBounds exception printed to stderr.

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/deckchooser/FDeckChooser.java
+++ b/forge-gui-desktop/src/main/java/forge/deckchooser/FDeckChooser.java
@@ -840,9 +840,9 @@ public class FDeckChooser extends JPanel implements IDecksComboBoxListener {
         try {
             if (StringUtils.isBlank(savedState)) {
                 return new ArrayList<>();
-            } else {
-                return Arrays.asList(savedState.split(";")[1].split(SELECTED_DECK_DELIMITER));
             }
+            final String[] parts = savedState.split(";", -1);
+            return Arrays.asList(parts[1].split(SELECTED_DECK_DELIMITER));
         } catch (final Exception ex) {
             System.err.println(ex + " [savedState=" + savedState + "]");
             return new ArrayList<>();

--- a/forge-gui-mobile/src/forge/deck/FDeckChooser.java
+++ b/forge-gui-mobile/src/forge/deck/FDeckChooser.java
@@ -1360,9 +1360,8 @@ public class FDeckChooser extends FScreen {
             if (StringUtils.isBlank(savedState)) {
                 return new ArrayList<>();
             }
-            else {
-                return Arrays.asList(savedState.split(";")[1].split(SELECTED_DECK_DELIMITER));
-            }
+            final String[] parts = savedState.split(";", -1);
+            return Arrays.asList(parts[1].split(SELECTED_DECK_DELIMITER));
         }
         catch (Exception ex) {
             System.err.println(ex + " [savedState=" + savedState + "]");


### PR DESCRIPTION
This would happen due to `split()` not including the trailing empty string if ending in a delimiter. Passing -1 as a 2nd arg fixes this. (Just avoids a printed error message, otherwise no behavior changes since the case would still result in an empty list.)