### PR TITLE
Compleated update/fix

### DIFF
--- a/forge-game/src/main/java/forge/game/ForgeScript.java
+++ b/forge-game/src/main/java/forge/game/ForgeScript.java
@@ -235,7 +235,7 @@ public class ForgeScript {
         } else if (property.equals("Nightbound")) {
             return sa.hasParam("Nightbound");
         } else if (property.equals("paidPhyrexianMana")) {
-            return sa.getSpendPhyrexianMana();
+            return sa.getSpendPhyrexianMana() > 0;
         } else if (property.equals("LastChapter")) {
             return sa.isLastChapter();
         } else if (property.startsWith("ManaSpent")) {

--- a/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
@@ -2097,6 +2097,14 @@ public class AbilityUtils {
             return doXMath(castSA == null ? 0 : castSA.getPayingColors().countColors(), expr, c, ctb);
         }
 
+        if (sq[0].startsWith("EachPhyrexianPaidWithLife")) {
+            SpellAbility castSA = c.getCastSA();
+            if (castSA == null) {
+                return 0;
+            }
+            return doXMath(castSA.getSpendPhyrexianMana(), expr, c, ctb);
+        }
+
         if (sq[0].startsWith("EachSpentToCast")) {
             SpellAbility castSA = c.getCastSA();
             if (castSA == null) {

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -2215,16 +2215,16 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
                     final String[] k = keyword.split(":");
                     sbLong.append("Partner with ").append(k[1]).append(" (").append(inst.getReminderText()).append(")");
                 } else if (keyword.equals("Compleated")) {
+                    sbLong.append(keyword).append(" (");
                     final ManaCost mc = this.getManaCost();
                     if (mc != ManaCost.NO_COST && mc.getFirstPhyrexianHybridPip() != null) {
                         String hybrid = mc.getFirstPhyrexianHybridPip().replaceAll("\\{", "")
                                 .replaceAll("\\}","");
-                        String remText = inst.getReminderText();
                         String[] parts = hybrid.split("/");
-                        remText = remText.replace("$0", hybrid).replace("$1", parts[1])
-                                .replace("$2", parts[2]);
-                        sbLong.append(keyword).append(" (").append(remText).append(")");
+                        String rem = "{" + hybrid + "} can be paid with {" + parts[1] + "}, {" + parts[2] + "}, or 2 life. ";
+                        sbLong.append(rem);
                     }
+                    sbLong.append(inst.getReminderText()).append(")");
                 } else if (keyword.startsWith("Devour ")) {
                     final String[] k = keyword.split(":");
                     final String[] s = (k[0]).split(" ");

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -2172,8 +2172,10 @@ public class CardFactoryUtil {
 
             inst.addReplacement(re);
         } else if (keyword.equals("Compleated")) {
-            String sb = "etbCounter:LOYALTY:-2:ValidCard$ Card.CastSa Spell.paidPhyrexianMana:If life was paid, this planeswalker enters with two fewer loyalty counters";
+            String sb = "etbCounter:LOYALTY:PhySpent:CheckSVar$ PhySpent | SVarCompare$ LT0:This planeswalker" +
+                    " enters with two fewer loyalty counters for each Phyrexian mana symbol life was paid for";
             final ReplacementEffect re = makeEtbCounter(sb, card, intrinsic);
+            card.setSVar("PhySpent", "Count$EachPhyrexianPaidWithLife/Negative");
 
             inst.addReplacement(re);
         } else if (keyword.startsWith("Dredge")) {

--- a/forge-game/src/main/java/forge/game/keyword/Keyword.java
+++ b/forge-game/src/main/java/forge/game/keyword/Keyword.java
@@ -42,7 +42,7 @@ public enum Keyword {
     CHOOSE_A_BACKGROUND("Choose a Background", Partner.class, true, "You can have a Background as a second commander."),
     CIPHER("Cipher", SimpleKeyword.class, true, "Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost."),
     COMPANION("Companion", Companion.class, true, "Reveal your companion from outside the game if your deck meets the companion restriction."),
-    COMPLEATED("Compleated", SimpleKeyword.class, true, "{$0} can be paid with {$1}, {$2}, or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters."),
+    COMPLEATED("Compleated", SimpleKeyword.class, true, "This planeswalker enters with two fewer loyalty counters for each Phyrexian mana symbol life was paid for."),
     CONSPIRE("Conspire", SimpleKeyword.class, false, "As an additional cost to cast this spell, you may tap two untapped creatures you control that each share a color with it. If you do, copy it."),
     CONVOKE("Convoke", SimpleKeyword.class, true, "Your creatures can help cast this spell. Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color."),
     CREW("Crew", KeywordWithAmount.class, false, "Tap any number of creatures you control with total power %1$d or more: This Vehicle becomes an artifact creature until end of turn."),

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
@@ -108,7 +108,7 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
     private Card playEffectCard;
     private Pair<Long, Player> controlledByPlayer;
     private ManaCostBeingPaid manaCostBeingPaid;
-    private boolean spentPhyrexian = false;
+    private int spentPhyrexian = 0;
     private int paidLifeAmount = 0;
 
     private SpellAbility grantorOriginal;
@@ -614,11 +614,12 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
         payingMana.clear();
     }
 
-    public final boolean getSpendPhyrexianMana() {
+    //getSpendPhyrexianMana
+    public final int getSpendPhyrexianMana() {
         return this.spentPhyrexian;
     }
-    public final void setSpendPhyrexianMana(boolean value) {
-        this.spentPhyrexian = value;
+    public final void setSpendPhyrexianMana(boolean bool) {
+        this.spentPhyrexian = bool ? this.spentPhyrexian + 2 : 0;
     }
 
     public final int getAmountLifePaid() {

--- a/forge-gui-desktop/src/main/java/forge/toolbox/FSkin.java
+++ b/forge-gui-desktop/src/main/java/forge/toolbox/FSkin.java
@@ -1081,7 +1081,7 @@ public class FSkin {
         //format mana symbols to display as icons
         pattern = "\\{([A-Z0-9]+)\\}|\\{([A-Z0-9]+)/([A-Z0-9]+)\\}|(A-)|\\{([A-Z0-9]+)/([A-Z0-9]+)/([A-Z0-9]+)\\}"; //fancy pattern needed so "/" can be omitted from replacement
         try {
-            replacement = "<img src=\"" + new File(ForgeConstants.CACHE_SYMBOLS_DIR + "/$1$2$3$4$5$6.png").toURI().toURL().toString() + "\" width=" + SYMBOL_WIDTH + " height=" + SYMBOL_HEIGHT + ">";
+            replacement = "<img src=\"" + new File(ForgeConstants.CACHE_SYMBOLS_DIR + "/$1$2$3$4$5$6$7.png").toURI().toURL().toString() + "\" width=" + SYMBOL_WIDTH + " height=" + SYMBOL_HEIGHT + ">";
             str = str.replaceAll(pattern, replacement);
         } catch (final MalformedURLException e) {
             e.printStackTrace();


### PR DESCRIPTION
- fixes problem with display of Phyrexian hybrid following #1773 
- converts "life spent for Phyrexian mana" from boolean to int for loyalty calculations
- appropriate reminder text modifications for keyword display (will need to be checked against exact Oracle when it becomes available)

- closes #2106 
