### PR TITLE
Fix language bundle log string

### DIFF
--- a/forge-core/src/main/java/forge/util/Localizer.java
+++ b/forge-core/src/main/java/forge/util/Localizer.java
@@ -159,7 +159,7 @@ public class Localizer {
                 e.printStackTrace();
             }
 
-            System.out.println("Language '" + resourceBundle.toString() + "' loaded successfully.");
+            System.out.println("Language '" + resourceBundle.getBaseBundleName() + "' loaded successfully.");
 
             notifyObservers();
 


### PR DESCRIPTION
ResourceBundle doesn't have an overriden toString but has a nice `baseBundle` name as per https://docs.oracle.com/javase/8/docs/api/java/util/ResourceBundle.html#getBaseBundleName--

Replace one with the other.

Before:
```
Language 'java.util.PropertyResourceBundle@49e53c76' loaded successfully.
```

After:
```
Language 'en-US' loaded successfully.
```