### PR TITLE
Small code speed up: Avoid calling getFirstAbility() redundantly.

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/AbilityFactory.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityFactory.java
@@ -185,7 +185,8 @@ public final class AbilityFactory {
             String cost = mapParams.get("Cost");
             if (cost == null) {
                 if (type == AbilityRecordType.Spell) {
-                    if (state.getFirstAbility() != null && state.getFirstAbility().isSpell()) {
+                    SpellAbility firstAbility = state.getFirstAbility();
+                    if (firstAbility != null && firstAbility.isSpell()) {
                         // TODO might remove when Enchant Keyword is refactored
                         System.err.println(state.getName() + " already has Spell using mana cost");
                     }

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -2442,14 +2442,14 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
         }
 
         // add As an additional cost to Permanent spells
-        if (state.getFirstAbility() != null && type.isPermanent()) {
-            SpellAbility first = state.getFirstAbility();
+        SpellAbility first = state.getFirstAbility();
+        if (first != null && type.isPermanent()) {
             if (first.isSpell()) {
                 Cost cost = first.getPayCosts();
                 if (cost != null && !cost.isOnlyManaCost()) {
                     String additionalDesc = "";
-                    if (state.getFirstAbility().hasParam("AdditionalDesc")) {
-                        additionalDesc = state.getFirstAbility().getParam("AdditionalDesc");
+                    if (first.hasParam("AdditionalDesc")) {
+                        additionalDesc = first.getParam("AdditionalDesc");
                     }
                     sb.append(cost.toString().replace("\n", "")).append(" ").append(additionalDesc);
                     sb.append(linebreak);
@@ -3757,7 +3757,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
     public final CardTypeView getOriginalType() {
         return getOriginalType(currentState);
     }
-    public final  CardTypeView getOriginalType(CardState state) {
+    public final CardTypeView getOriginalType(CardState state) {
         return state.getType();
     }
 


### PR DESCRIPTION
This was showing up in simulation AI profiles.