### PR TITLE
Wall of Shadows + Thought Lash fix

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -1473,11 +1473,9 @@ public class AiController {
             return singleSpellAbilityList(simPicker.chooseSpellAbilityToPlay(null));
         }
 
-        CardCollection landsWannaPlay = ComputerUtilAbility.getAvailableLandsToPlay(game, player);
         CardCollection playBeforeLand = CardLists.filter(
             player.getCardsIn(ZoneType.Hand), CardPredicates.hasSVar("PlayBeforeLandDrop")
         );
-
         if (!playBeforeLand.isEmpty()) {
             SpellAbility wantToPlayBeforeLand = chooseSpellAbilityToPlayFromList(
                 ComputerUtilAbility.getSpellAbilities(playBeforeLand, player), false
@@ -1486,7 +1484,8 @@ public class AiController {
                 return singleSpellAbilityList(wantToPlayBeforeLand);
             }
         }
-
+        
+        CardCollection landsWannaPlay = ComputerUtilAbility.getAvailableLandsToPlay(game, player);
         if (landsWannaPlay != null) {
             landsWannaPlay = filterLandsToPlay(landsWannaPlay);
             Log.debug("Computer " + game.getPhaseHandler().getPhase().nameForUi);

--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -43,8 +43,6 @@ import forge.game.card.CardView;
 import forge.game.card.CounterType;
 import forge.game.combat.Combat;
 import forge.game.cost.Cost;
-import forge.game.cost.CostAdjustment;
-import forge.game.cost.CostExile;
 import forge.game.cost.CostPart;
 import forge.game.cost.CostPartMana;
 import forge.game.keyword.KeywordInterface;
@@ -697,24 +695,6 @@ public class PlayerControllerAi extends PlayerController {
         final Ability ability = new AbilityStatic(c, cost, null) { @Override public void resolve() {} };
         ability.setActivatingPlayer(c.getController(), true);
         ability.setCardState(sa.getCardState());
-
-        // FIXME: This is a hack to check if the AI can play the "exile from library" pay costs (Cumulative Upkeep,
-        // e.g. Thought Lash). We have to do it and bail early if the AI can't pay, because otherwise the AI will
-        // pay the cost partially, which should not be possible
-        int nExileLib = 0;
-        List<CostPart> parts = CostAdjustment.adjust(cost, sa).getCostParts();
-        for (final CostPart part : parts) {
-            if (part instanceof CostExile) {
-                CostExile exile = (CostExile) part;
-                if (exile.from == ZoneType.Library) {
-                    nExileLib += exile.convertAmount();
-                }
-            }
-        }
-        if (nExileLib > c.getController().getCardsIn(ZoneType.Library).size()) {
-            return false;
-        }
-        // - End of hack for Exile a card from library Cumulative Upkeep -
 
         if (ComputerUtilCost.canPayCost(ability, c.getController(), true)) {
             ComputerUtil.playNoStack(c.getController(), ability, getGame(), true);

--- a/forge-game/src/main/java/forge/game/cost/Cost.java
+++ b/forge-game/src/main/java/forge/game/cost/Cost.java
@@ -906,9 +906,10 @@ public class Cost implements Serializable {
                 } else {
                     costParts.add(0, new CostPartMana(oldManaCost.toManaCost(), r));
                 }
-            } else if (part instanceof CostDiscard || part instanceof CostDraw ||
-                    part instanceof CostAddMana || part instanceof CostPayLife
-                    || part instanceof CostPutCounter || part instanceof CostTapType) {
+            } else if (part instanceof CostDiscard || part instanceof CostDraw
+                    || part instanceof CostAddMana || part instanceof CostPayLife
+                    || part instanceof CostPutCounter || part instanceof CostTapType
+                    || part instanceof CostExile) {
                 boolean alreadyAdded = false;
                 for (final CostPart other : costParts) {
                     if ((other.getClass().equals(part.getClass()) || (part instanceof CostPutCounter && ((CostPutCounter)part).getCounter().is(CounterEnumType.LOYALTY))) &&
@@ -941,6 +942,12 @@ public class Cost implements Serializable {
                             costParts.add(new CostAddMana(amount, part.getType(), part.getTypeDescription()));
                         } else if (part instanceof CostPayLife) {
                             costParts.add(new CostPayLife(amount, part.getTypeDescription()));
+                        } else if (part instanceof CostExile) {
+                            ZoneType z = ((CostExile) part).getFrom();
+                            if (((CostExile) other).getFrom() != z) {
+                                continue;
+                            }
+                            costParts.add(new CostExile(amount, part.getType(), part.getTypeDescription(), z));
                         }
                         toRemove.add(other);
                         alreadyAdded = true;

--- a/forge-game/src/main/java/forge/game/cost/CostAdjustment.java
+++ b/forge-game/src/main/java/forge/game/cost/CostAdjustment.java
@@ -116,13 +116,11 @@ public class CostAdjustment {
         int count = 0;
 
         if (st.hasParam("ForEachShard")) {
-            CostPartMana mc = cost.getCostMana();
-            if (mc != null) {
-                byte atom = ManaAtom.fromName(st.getParam("ForEachShard").toLowerCase());
-                for (ManaCostShard shard : mc.getManaCostFor(sa)) {
-                    if ((shard.getColorMask() & atom) != 0) {
-                        ++count;
-                    }
+            ManaCost mc = sa.getHostCard().getManaCost();
+            byte atom = ManaAtom.fromName(st.getParam("ForEachShard").toLowerCase());
+            for (ManaCostShard shard : mc) {
+                if ((shard.getColorMask() & atom) != 0) {
+                    ++count;
                 }
             }
         } else if (st.hasParam("Amount")) {

--- a/forge-game/src/main/java/forge/game/cost/CostPayment.java
+++ b/forge-game/src/main/java/forge/game/cost/CostPayment.java
@@ -37,7 +37,6 @@ import forge.game.mana.ManaCostBeingPaid;
 import forge.game.mana.ManaPool;
 import forge.game.player.Player;
 import forge.game.spellability.SpellAbility;
-import forge.game.zone.ZoneType;
 
 /**
  * <p>
@@ -200,12 +199,9 @@ public class CostPayment extends ManaConversionMatrix {
             PaymentDecision decision = part.accept(decisionMaker);
             if (null == decision) return false;
 
-            // the AI will try to exile the same card repeatedly unless it does it immediately
-            final boolean payImmediately = part instanceof CostExile && ((CostExile) part).from == ZoneType.Library;
-
             // wrap the payment and push onto the cost stack
             game.costPaymentStack.push(part, this);
-            if ((decisionMaker.paysRightAfterDecision() || payImmediately) && !part.payAsDecided(decisionMaker.getPlayer(), decision, ability, decisionMaker.isEffect())) {
+            if (decisionMaker.paysRightAfterDecision() && !part.payAsDecided(decisionMaker.getPlayer(), decision, ability, decisionMaker.isEffect())) {
                 game.costPaymentStack.pop(); // cost is resolved
                 return false;
             }

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityCantTarget.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityCantTarget.java
@@ -17,8 +17,14 @@
  */
 package forge.game.staticability;
 
+import java.util.Iterator;
+import java.util.List;
+
+import com.google.common.collect.Lists;
+
 import forge.game.Game;
 import forge.game.GameEntity;
+import forge.game.ability.ApiType;
 import forge.game.card.Card;
 import forge.game.keyword.Keyword;
 import forge.game.player.Player;
@@ -149,15 +155,27 @@ public class StaticAbilityCantTarget {
             return false;
         }
 
-        if (spellAbility.hasParam("ValidTgts") &&
-                (stAb.hasParam("SourceCanOnlyTarget")
-                && (!spellAbility.getParam("ValidTgts").contains(stAb.getParam("SourceCanOnlyTarget"))
-                    || spellAbility.getParam("ValidTgts").contains(","))
-                    || spellAbility.getParam("ValidTgts").contains("non" + stAb.getParam("SourceCanOnlyTarget")
-                    )
-                )
-           ){
-            return false;
+        if (stAb.hasParam("SourceCanOnlyTarget")) {
+            SpellAbility root = spellAbility.getRootAbility();
+            List<SpellAbility> choices = null;
+            if (root.getApi() == ApiType.Charm) {
+                choices = Lists.newArrayList(root.getAdditionalAbilityList("Choices"));
+            } else {
+                choices = Lists.newArrayList(root);
+            }
+            Iterator<SpellAbility> it = choices.iterator();
+            SpellAbility next = it.next();
+            while (next != null) {
+                if (next.usesTargeting() && (!next.getParam("ValidTgts").contains(stAb.getParam("SourceCanOnlyTarget"))
+                        || next.getParam("ValidTgts").contains(","))
+                        || next.getParam("ValidTgts").contains("non" + stAb.getParam("SourceCanOnlyTarget"))) {
+                    return false;
+                }
+                next = next.getSubAbility();
+                if (next == null && it.hasNext()) {
+                    next = it.next();
+                }
+            }
         }
 
         return true;

--- a/forge-gui/src/main/java/forge/player/HumanPlay.java
+++ b/forge-gui/src/main/java/forge/player/HumanPlay.java
@@ -322,7 +322,7 @@ public class HumanPlay {
                 } else {
                     from = costExile.getFrom();
                     CardCollection list = CardLists.getValidCards(p.getCardsIn(from), part.getType().split(";"), p, source, sourceAbility);
-                    final int nNeeded = getAmountFromPart(costPart, source, sourceAbility);
+                    final int nNeeded = getAmountFromPart(part, source, sourceAbility);
                     if (list.size() < nNeeded) {
                         return false;
                     }


### PR DESCRIPTION
> Can be targeted by a modal spell that can target a non-Wall in one of its modes, even if it has a mode that targets only Walls. That spell can, in theory, target a non-Wall, so it is not a “spell that can target only Walls”. 