### PR TITLE
TriggerChangesZone: improve ETB check

### DIFF
--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -184,7 +184,7 @@ public class GameAction {
             // if to Battlefield and it is caused by an replacement effect,
             // try to get previous LKI if able
             ReplacementEffect re = cause.getReplacementEffect();
-            if (ReplacementType.Moved.equals(re.getMode())) {
+            if (ReplacementType.Moved.equals(re.getMode()) && cause.getReplacingObject(AbilityKey.CardLKI).equals(c)) {
                 lastKnownInfo = (Card) cause.getReplacingObject(AbilityKey.CardLKI);
             }
         }

--- a/forge-game/src/main/java/forge/game/trigger/TriggerChangesZone.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerChangesZone.java
@@ -109,6 +109,10 @@ public class TriggerChangesZone extends Trigger {
             if (leavesLKIZone) {
                 moved = (Card) runParams.get(AbilityKey.CardLKI);
             }
+            if ("Battlefield".equals(runParams.get(AbilityKey.Destination))) {
+                List<Card> etbLKI = moved.getController().getZone(ZoneType.Battlefield).getCardsAddedThisTurn(null);
+                moved = etbLKI.get(etbLKI.lastIndexOf(moved));
+            }
 
             if (!matchesValid(moved, getParam("ValidCard").split(","))) {
                 return false;


### PR DESCRIPTION
The accuracy for ETB checks is improved by using the LKI from the zone change.

I also had to fix a minor bug in GameAction: in some cases e.g. with _Kalitas, Traitor of Ghet_ on the token ETB it would grab the wrong LKI (from the previous replaced) and use that together with it.

This should allow _Mentor of the Meek_ to work in all cases like this:
![image](https://user-images.githubusercontent.com/8506892/212568532-c915af92-258d-42ad-9819-455cde3d1033.png)

which would previously not trigger it if you choose to attach the Equipment to the token from Nahiri +2.

However this doesn't take care of _Welcoming Vampire_ yet, but since LKI support in ChangesZoneAll is still lacking that should probably be addressed in a bigger work in the future.