### PR TITLE
Edition update: IKO (add Arena only Zilortha variant)

### DIFF
--- a/forge-gui/res/editions/Ikoria Lair of Behemoths.txt
+++ b/forge-gui/res/editions/Ikoria Lair of Behemoths.txt
@@ -289,6 +289,7 @@ ScryfallCode=IKO
 
 [buy a box]
 275 M Zilortha, Strength Incarnate @Antonio José Manzanedo
+275a M Zilortha, Strength Incarnate @Chase Stone
 
 [borderless]
 276 M Lukka, Coppercoat Outcast @Kieran Yanner


### PR DESCRIPTION
It has unique artwork: https://scryfall.com/card/iko/275a/zilortha-strength-incarnate