### PR TITLE
Fix timestamp reset messing up LKI

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
@@ -710,7 +710,14 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
                         game.getCombat().getBandOfAttacker(movedCard).setBlocked(false);
                         combatChanged = true;
                     }
+
                     movedCard.setTimestamp(ts);
+                    if (movedCard.isInPlay()) {
+                        // need to also update LKI
+                        List<Card> lki = movedCard.getZone().getCardsAddedThisTurn(null);
+                        lki.get(lki.lastIndexOf(movedCard)).setTimestamp(ts);
+                    }
+
                     if (sa.hasParam("AttachAfter") && movedCard.isAttachment()) {
                         CardCollection list = AbilityUtils.getDefinedCards(hostCard, sa.getParam("AttachAfter"), sa);
                         if (list.isEmpty()) {
@@ -1401,6 +1408,11 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
                     movedCard = game.getAction().moveToPlay(c, c.getController(), sa, moveParams);
 
                     movedCard.setTimestamp(ts);
+                    if (movedCard.isInPlay()) {
+                        // need to also update LKI
+                        List<Card> lki = movedCard.getZone().getCardsAddedThisTurn(null);
+                        lki.get(lki.lastIndexOf(movedCard)).setTimestamp(ts);
+                    }
 
                     if (sa.hasParam("AttachAfter") && movedCard.isAttachment() && movedCard.isInPlay()) {
                         CardCollection list = AbilityUtils.getDefinedCards(source, sa.getParam("AttachAfter"), sa);

--- a/forge-game/src/main/java/forge/game/trigger/TriggerChangesZone.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerChangesZone.java
@@ -17,6 +17,7 @@
  */
 package forge.game.trigger;
 
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -111,6 +112,7 @@ public class TriggerChangesZone extends Trigger {
             }
             if ("Battlefield".equals(runParams.get(AbilityKey.Destination))) {
                 List<Card> etbLKI = moved.getController().getZone(ZoneType.Battlefield).getCardsAddedThisTurn(null);
+                Collections.sort(etbLKI, CardPredicates.compareByTimestamp());
                 moved = etbLKI.get(etbLKI.lastIndexOf(moved));
             }
 

--- a/forge-game/src/main/java/forge/game/trigger/TriggerSpellAbilityCastOrCopy.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerSpellAbilityCastOrCopy.java
@@ -86,10 +86,6 @@ public class TriggerSpellAbilityCastOrCopy extends Trigger {
             return false;
         }
 
-        if (!matchesValidParam("ValidControllingPlayer", cast.getController())) {
-            return false;
-        }
-
         if (hasParam("ValidActivatingPlayer")) {
             Player activator;
             if (spellAbility.isManaAbility()) {

--- a/forge-gui/res/cardsfolder/a/ardenn_intrepid_archaeologist.txt
+++ b/forge-gui/res/cardsfolder/a/ardenn_intrepid_archaeologist.txt
@@ -2,9 +2,8 @@ Name:Ardenn, Intrepid Archaeologist
 ManaCost:2 W
 Types:Legendary Creature Kor Scout
 PT:2/2
-T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | Execute$ TrigTarget | TriggerZones$ Battlefield | OptionalDecider$ You | TriggerDescription$ At the beginning of combat on your turn, you may attach any number of Auras and Equipment you control to target permanent or player.
-SVar:TrigTarget:DB$ Pump | ValidTgts$ Permanent,Player | TgtPrompt$ Select target permanent or player | SubAbility$ DBAttach
-SVar:DBAttach:DB$ Attach | Defined$ Targeted | Object$ Valid Aura.YouCtrl,Equipment.YouCtrl | Optional$ True
+T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | Execute$ TrigAttach | TriggerZones$ Battlefield | OptionalDecider$ You | TriggerDescription$ At the beginning of combat on your turn, you may attach any number of Auras and Equipment you control to target permanent or player.
+SVar:TrigAttach:DB$ Attach | Defined$ Targeted | ValidTgts$ Permanent,Player | TgtPrompt$ Select target permanent or player | Object$ Valid Aura.YouCtrl,Equipment.YouCtrl | Optional$ True
 K:Partner
 DeckHints:Type$Aura|Equipment
 Oracle:At the beginning of combat on your turn, you may attach any number of Auras and Equipment you control to target permanent or player.\nPartner (You can have two commanders if both have partner.)

--- a/forge-gui/res/cardsfolder/a/ardenn_intrepid_archaeologist.txt
+++ b/forge-gui/res/cardsfolder/a/ardenn_intrepid_archaeologist.txt
@@ -3,10 +3,8 @@ ManaCost:2 W
 Types:Legendary Creature Kor Scout
 PT:2/2
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | Execute$ TrigTarget | TriggerZones$ Battlefield | OptionalDecider$ You | TriggerDescription$ At the beginning of combat on your turn, you may attach any number of Auras and Equipment you control to target permanent or player.
-SVar:TrigTarget:DB$ Pump | ValidTgts$ Permanent,Player | TgtPrompt$ Select target permanent or player | RememberObjects$ Targeted | SubAbility$ DBAttach
-SVar:DBAttach:DB$ RepeatEach | UseImprinted$ True | RepeatSubAbility$ DBRepeatAttach | SubAbility$ DBCleanup | RepeatCards$ Aura.YouCtrl,Equipment.YouCtrl
-SVar:DBRepeatAttach:DB$ Attach | Defined$ Remembered | Object$ Imprinted | Optional$ True
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:TrigTarget:DB$ Pump | ValidTgts$ Permanent,Player | TgtPrompt$ Select target permanent or player | SubAbility$ DBAttach
+SVar:DBAttach:DB$ Attach | Defined$ Targeted | Object$ Valid Aura.YouCtrl,Equipment.YouCtrl | Optional$ True
 K:Partner
 DeckHints:Type$Aura|Equipment
 Oracle:At the beginning of combat on your turn, you may attach any number of Auras and Equipment you control to target permanent or player.\nPartner (You can have two commanders if both have partner.)

--- a/forge-gui/res/cardsfolder/a/armed_and_armored.txt
+++ b/forge-gui/res/cardsfolder/a/armed_and_armored.txt
@@ -2,12 +2,9 @@ Name:Armed and Armored
 ManaCost:1 W
 Types:Instant
 A:SP$ AnimateAll | Cost$ 1 W | Types$ Creature,Artifact | ValidCards$ Vehicle.YouCtrl | SubAbility$ ChooseDwarf | StackDescription$ Vehicles {p:You} controls become artifact creatures until end of turn. | SpellDescription$ Vehicles you control become artifact creatures until end of turn. Choose a Dwarf you control. Attach any number of Equipment you control to it.
-SVar:ChooseDwarf:DB$ ChooseCard | Defined$ You | Mandatory$ True | Choices$ Dwarf.YouCtrl | ChoiceTitle$ Choose a Dwarf you control | StackDescription$ {p:You} chooses a Dwarf they control and attaches any number of Equipment they control to it. | ImprintChosen$ True | SubAbility$ ChooseEquipment
-SVar:ChooseEquipment:DB$ ChooseCard | Defined$ You | MinAmount$ 0 | Amount$ X | Choices$ Equipment.YouCtrl | StackDescription$ None | ChoiceTitle$ Choose any number of Equipment you control | ForgetChosen$ True | SubAbility$ DeployDwarf
-SVar:DeployDwarf:DB$ RepeatEach | RepeatSubAbility$ ArmDwarf | RepeatCards$ Card.ChosenCard | SubAbility$ DBCleanup
-SVar:ArmDwarf:DB$ Attach | Object$ Remembered | Defined$ Imprinted | StackDescription$ None
-SVar:DBCleanup:DB$ Cleanup | ClearChosenCard$ True | ClearRemembered$ True | ClearImprinted$ True
-SVar:X:Count$Valid Equipment.YouCtrl
+SVar:ChooseDwarf:DB$ ChooseCard | Defined$ You | Mandatory$ True | Choices$ Dwarf.YouCtrl | ChoiceTitle$ Choose a Dwarf you control | StackDescription$ {p:You} chooses a Dwarf they control and attaches any number of Equipment they control to it. | SubAbility$ ArmDwarf
+SVar:ArmDwarf:DB$ Attach | Object$ Equipment.YouCtrl | Defined$ ChosenCard | Optional$ True | StackDescription$ None | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearChosenCard$ True
 DeckNeeds:Type$Vehicle|Dwarf
 DeckHints:Type$Equipment
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/a/armed_and_armored.txt
+++ b/forge-gui/res/cardsfolder/a/armed_and_armored.txt
@@ -1,10 +1,8 @@
 Name:Armed and Armored
 ManaCost:1 W
 Types:Instant
-A:SP$ AnimateAll | Cost$ 1 W | Types$ Creature,Artifact | ValidCards$ Vehicle.YouCtrl | SubAbility$ ChooseDwarf | StackDescription$ Vehicles {p:You} controls become artifact creatures until end of turn. | SpellDescription$ Vehicles you control become artifact creatures until end of turn. Choose a Dwarf you control. Attach any number of Equipment you control to it.
-SVar:ChooseDwarf:DB$ ChooseCard | Defined$ You | Mandatory$ True | Choices$ Dwarf.YouCtrl | ChoiceTitle$ Choose a Dwarf you control | StackDescription$ {p:You} chooses a Dwarf they control and attaches any number of Equipment they control to it. | SubAbility$ ArmDwarf
-SVar:ArmDwarf:DB$ Attach | Object$ Equipment.YouCtrl | Defined$ ChosenCard | Optional$ True | StackDescription$ None | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearChosenCard$ True
+A:SP$ AnimateAll | Cost$ 1 W | Types$ Creature,Artifact | ValidCards$ Vehicle.YouCtrl | SubAbility$ ArmDwarf | StackDescription$ Vehicles {p:You} controls become artifact creatures until end of turn. | SpellDescription$ Vehicles you control become artifact creatures until end of turn. Choose a Dwarf you control. Attach any number of Equipment you control to it.
+SVar:ArmDwarf:DB$ Attach | Object$ Valid Equipment.YouCtrl | Defined$ Valid Dwarf.YouCtrl | Optional$ True | StackDescription$ {p:You} chooses a Dwarf they control and attaches any number of Equipment they control to it.
 DeckNeeds:Type$Vehicle|Dwarf
 DeckHints:Type$Equipment
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/h/haakon_stromgald_scourge_avatar.txt
+++ b/forge-gui/res/cardsfolder/h/haakon_stromgald_scourge_avatar.txt
@@ -4,7 +4,7 @@ Types:Vanguard
 HandLifeModifier:+0/-3
 A:AB$ Effect | ActivationZone$ Command | Cost$ PayLife<1> | TgtZone$ Graveyard | ValidTgts$ Creature.YouOwn | PumpZone$ Graveyard | TgtPrompt$ Select target creature in your graveyard, you may play it this turn | RememberObjects$ Targeted | StaticAbilities$ Play | ExileOnMoved$ Graveyard | SpellDescription$ You may cast target creature card in your graveyard this turn.
 SVar:Play:Mode$ Continuous | MayPlay$ True | EffectZone$ Command | Affected$ Card.IsRemembered | AffectedZone$ Graveyard | Description$ You may play remembered card.
-T:Mode$ SpellCast | ValidCard$ Creature.wasCastFromYourGraveyard | ValidControllingPlayer$ You | TriggerZones$ Command | Execute$ TrigAnimate | TriggerDescription$ Whenever you cast a creature spell from your graveyard, it becomes a black Zombie Knight.
+T:Mode$ SpellCast | ValidCard$ Creature.wasCastFromYourGraveyard | ValidActivatingPlayer$ You | TriggerZones$ Command | Execute$ TrigAnimate | TriggerDescription$ Whenever you cast a creature spell from your graveyard, it becomes a black Zombie Knight.
 SVar:TrigAnimate:DB$ Animate | Defined$ TriggeredCard | Types$ Zombie,Knight | Colors$ Black | OverwriteColors$ True | Duration$ Permanent | RemoveCreatureTypes$ True
 R:Event$ Moved | ValidCard$ Card.Zombie+Knight | Destination$ Graveyard | ReplaceWith$ DBExile | Description$ If a Zombie Knight would be put into your graveyard from the battlefield, exile it instead.
 SVar:DBExile:DB$ ChangeZone | Defined$ ReplacedCard | Origin$ Battlefield | Destination$ Exile

--- a/forge-gui/res/cardsfolder/h/heavenly_blademaster.txt
+++ b/forge-gui/res/cardsfolder/h/heavenly_blademaster.txt
@@ -5,9 +5,7 @@ PT:3/6
 K:Flying
 K:Double Strike
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ DBAttach | OptionalDecider$ You | TriggerDescription$ When CARDNAME enters the battlefield, you may attach any number of Auras and Equipment you control to it.
-SVar:DBAttach:DB$ RepeatEach | RepeatSubAbility$ DBRepeatAttach | RepeatCards$ Aura.YouCtrl,Equipment.YouCtrl
-SVar:DBRepeatAttach:DB$ Attach | Object$ Remembered | Optional$ True | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBAttach:DB$ Attach | Object$ Valid Aura.YouCtrl,Equipment.YouCtrl | Optional$ True
 AI:RemoveDeck:Random
 S:Mode$ Continuous | Affected$ Creature.Other+YouCtrl | AddPower$ X | AddToughness$ X | Description$ Other creatures you control get +1/+1 for each Aura and Equipment attached to CARDNAME.
 SVar:X:Count$Valid Equipment.Attached,Aura.Attached


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/8506892/213483982-2005511d-346f-4307-aa87-08c049138d13.png)

Another fix required as a result of the stricter check from #2248.
It would be nice to make that part deprecated instead, but I think that will require game timestamps first.

Some nice Attach cleanup as bonus.