### PR TITLE
Increase SBA check precision

### DIFF
--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -1641,6 +1641,12 @@ public class GameAction {
         boolean checkAgain = false;
         if (c.isRealToken()) {
             final Zone zoneFrom = game.getZoneOf(c);
+
+            // card copies are allowed on the stack
+            if (zoneFrom.is(ZoneType.Stack) && c.getCopiedPermanent() != null) {
+                return false;
+            }
+
             if (!zoneFrom.is(ZoneType.Battlefield)) {
                 zoneFrom.remove(c);
                 checkAgain = true;

--- a/forge-game/src/main/java/forge/game/ability/effects/CopySpellAbilityEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CopySpellAbilityEffect.java
@@ -160,7 +160,6 @@ public class CopySpellAbilityEffect extends SpellAbilityEffect {
                             copies.add(copy);
                         }
                     }
-
                 }
             } else {
                 for (int i = 0; i < amount; i++) {
@@ -238,7 +237,7 @@ public class CopySpellAbilityEffect extends SpellAbilityEffect {
                 card.addRemembered(copies);
             }
         }
-    } // end resolve
+    }
 
     private void resetFirstTargetOnCopy(SpellAbility copy, GameEntity obj, SpellAbility targetedSA) {
         copy.resetFirstTarget(obj, targetedSA);


### PR DESCRIPTION
> 704.5e If a copy of a spell is in a zone other than the stack, it ceases to exist. If a copy of a card is in any zone other than the stack or the battlefield, it ceases to exist.

Fixes ETB replacements for casting copies