### PR TITLE
Improve AI land evaluation

### DIFF
--- a/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
@@ -161,7 +161,7 @@ public class GameStateEvaluator {
         if (c.isCreature()) {
             return eval.evaluateCreature(c);
         } else if (c.isLand()) {
-            int value = 100;
+            int value = 0;
             // for each mana color a land generates for free, increase the value by one
             // for each mana a land can produce, add one hundred.
             int max_produced = 0;
@@ -174,7 +174,17 @@ public class GameStateEvaluator {
                 }
             }
             value = 100 * max_produced;
-            value += colors_produced.size();
+            int size = max(colors_produced.size(), colors_produced.contains("Any") ? 5 : 0);
+            value += size * 2;
+
+            // add a value for each activated ability that the land has that's not an activated ability.
+            for (SpellAbility m: c.getNonManaAbilities()) {
+                // more than the value of having a card in hand, so if a land has an activated ability but
+                // not a mana ability, it will still be played.
+                value += 6;
+            }
+
+
             return value;
         } else if (c.isEnchantingCard()) {
             // TODO: Should provide value in whatever it's enchanting?

--- a/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
@@ -6,8 +6,13 @@ import forge.game.card.Card;
 import forge.game.card.CounterEnumType;
 import forge.game.phase.PhaseType;
 import forge.game.player.Player;
+import forge.game.spellability.AbilityManaPart;
 import forge.game.spellability.SpellAbility;
 import forge.game.zone.ZoneType;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import static java.lang.Math.max;
 
@@ -160,11 +165,15 @@ public class GameStateEvaluator {
             // for each mana color a land generates for free, increase the value by one
             // for each mana a land can produce, add one hundred.
             int max_produced = 0;
-            int possible_colors = 0;
+            Set<String> colors_produced = new HashSet<>();
             for (SpellAbility m: c.getManaAbilities()) {
-                max_produced = max(max_produced, m.amountOfManaGenerated(false));
+                max_produced = max(max_produced, m.amountOfManaGenerated(true));
+                for (AbilityManaPart mp : m.getAllManaParts()) {
+                    colors_produced.addAll(Arrays.asList(mp.mana(m).split(" ")));
+                }
             }
             value = 100 * max_produced;
+            value += colors_produced.size();
             return value;
         } else if (c.isEnchantingCard()) {
             // TODO: Should provide value in whatever it's enchanting?

--- a/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
@@ -139,6 +139,11 @@ public class GameStateEvaluator {
                 debugPrint("    "+nonAbilityText.replaceAll("CARDNAME", c.getName()));
             }
         }
+
+        // TODO evaluate mana base quality
+
+        // TODO evaluate holding mana open for counterspells
+
         debugPrint("Score = " + score);
         return new Score(score, summonSickScore);
     }

--- a/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
@@ -6,7 +6,10 @@ import forge.game.card.Card;
 import forge.game.card.CounterEnumType;
 import forge.game.phase.PhaseType;
 import forge.game.player.Player;
+import forge.game.spellability.SpellAbility;
 import forge.game.zone.ZoneType;
+
+import static java.lang.Math.max;
 
 public class GameStateEvaluator {
     private boolean debugging = false;
@@ -153,7 +156,16 @@ public class GameStateEvaluator {
         if (c.isCreature()) {
             return eval.evaluateCreature(c);
         } else if (c.isLand()) {
-            return 100;
+            int value = 100;
+            // for each mana color a land generates for free, increase the value by one
+            // for each mana a land can produce, add one hundred.
+            int max_produced = 0;
+            int possible_colors = 0;
+            for (SpellAbility m: c.getManaAbilities()) {
+                max_produced = max(max_produced, m.amountOfManaGenerated(false));
+            }
+            value = 100 * max_produced;
+            return value;
         } else if (c.isEnchantingCard()) {
             // TODO: Should provide value in whatever it's enchanting?
             // Else the computer would think that casting a Lifelink enchantment

--- a/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
@@ -8,6 +8,7 @@ import forge.game.phase.PhaseType;
 import forge.game.player.Player;
 import forge.game.spellability.AbilityManaPart;
 import forge.game.spellability.SpellAbility;
+import forge.game.staticability.StaticAbility;
 import forge.game.zone.ZoneType;
 
 import java.util.Arrays;
@@ -173,14 +174,20 @@ public class GameStateEvaluator {
                     colors_produced.addAll(Arrays.asList(mp.mana(m).split(" ")));
                 }
             }
-            value = 100 * max_produced;
+            value += 100 * max_produced;
             int size = max(colors_produced.size(), colors_produced.contains("Any") ? 5 : 0);
-            value += size * 2;
+            value += size * 6;
 
             // add a value for each activated ability that the land has that's not an activated ability.
             for (SpellAbility m: c.getNonManaAbilities()) {
                 // more than the value of having a card in hand, so if a land has an activated ability but
                 // not a mana ability, it will still be played.
+                value += 6;
+            }
+
+            // Add a value for each static ability that the land has
+            for (StaticAbility s : c.getStaticAbilities()) {
+                // More than the value of having a card in hand. See comment above
                 value += 6;
             }
 

--- a/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
@@ -167,6 +167,7 @@ public class GameStateEvaluator {
             int max_produced = 0;
             Set<String> colors_produced = new HashSet<>();
             for (SpellAbility m: c.getManaAbilities()) {
+                m.setActivatingPlayer(c.getController());
                 max_produced = max(max_produced, m.amountOfManaGenerated(true));
                 for (AbilityManaPart mp : m.getAllManaParts()) {
                     colors_produced.addAll(Arrays.asList(mp.mana(m).split(" ")));

--- a/forge-ai/src/main/java/forge/ai/simulation/SpellAbilityPicker.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/SpellAbilityPicker.java
@@ -64,7 +64,7 @@ public class SpellAbilityPicker {
         print("---- choose ability  (phase = " + phaseStr + ")");
     }
 
-    private List<SpellAbility> getCandidateSpellsAndAbilities() {
+    public List<SpellAbility> getCandidateSpellsAndAbilities() {
         CardCollection cards = ComputerUtilAbility.getAvailableCards(game, player);
         cards = ComputerUtilCard.dedupeCards(cards);
         List<SpellAbility> all = ComputerUtilAbility.getSpellAbilities(cards, player);
@@ -351,7 +351,7 @@ public class SpellAbilityPicker {
         return AiPlayDecision.WillPlay;
     }
 
-    private Score evaluateSa(final SimulationController controller, PhaseType phase, List<SpellAbility> saList, int saIndex) {
+    public Score evaluateSa(final SimulationController controller, PhaseType phase, List<SpellAbility> saList, int saIndex) {
         controller.evaluateSpellAbility(saList, saIndex);
         SpellAbility sa = saList.get(saIndex);
 

--- a/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
@@ -1651,7 +1651,16 @@ public class AbilityUtils {
         final String s2 = applyAbilityTextChangeEffects(s, ctb);
         final String[] l = s2.split("/");
         final String expr = CardFactoryUtil.extractOperators(s2);
-        final Player player = ctb == null ? null : ctb instanceof SpellAbility ? ((SpellAbility)ctb).getActivatingPlayer() : ctb.getHostCard().getController();
+
+        Player player = null;
+        if (ctb != null) {
+            if (ctb instanceof SpellAbility) {
+                player = ((SpellAbility)ctb).getActivatingPlayer();
+            }
+            if (player == null) {
+                player = ctb.getHostCard().getController();
+            }
+        }
 
         // accept straight numbers
         if (l[0].startsWith("Number$")) {

--- a/forge-gui-desktop/src/test/java/forge/ai/simulation/SimulationTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/simulation/SimulationTest.java
@@ -33,6 +33,22 @@ import forge.model.FModel;
 public class SimulationTest {
     private static boolean initialized = false;
 
+    public Game resetGame() {
+        // need to be done after FModel.initialize, or the Localizer isn't loaded yet
+        List<RegisteredPlayer> players = Lists.newArrayList();
+        Deck d1 = new Deck();
+        players.add(new RegisteredPlayer(d1).setPlayer(new LobbyPlayerAi("p2", null)));
+        Set<AIOption> options = new HashSet<>();
+        options.add(AIOption.USE_SIMULATION);
+        players.add(new RegisteredPlayer(d1).setPlayer(new LobbyPlayerAi("p1", options)));
+        GameRules rules = new GameRules(GameType.Constructed);
+        Match match = new Match(rules, players, "Test");
+        Game game = new Game(players, rules, match);
+        game.setAge(GameStage.Play);
+
+        return game;
+    }
+
     protected Game initAndCreateGame() {
         if (!initialized) {
             GuiBase.setInterface(new GuiDesktop());
@@ -47,19 +63,7 @@ public class SimulationTest {
             initialized = true;
         }
 
-        // need to be done after FModel.initialize, or the Localizer isn't loaded yet
-        List<RegisteredPlayer> players = Lists.newArrayList();
-        Deck d1 = new Deck();
-        players.add(new RegisteredPlayer(d1).setPlayer(new LobbyPlayerAi("p2", null)));
-        Set<AIOption> options = new HashSet<>();
-        options.add(AIOption.USE_SIMULATION);
-        players.add(new RegisteredPlayer(d1).setPlayer(new LobbyPlayerAi("p1", options)));
-        GameRules rules = new GameRules(GameType.Constructed);
-        Match match = new Match(rules, players, "Test");
-        Game game = new Game(players, rules, match);
-        game.setAge(GameStage.Play);
-
-        return game;
+        return resetGame();
     }
 
     protected GameSimulator createSimulator(Game game, Player p) {

--- a/forge-gui-desktop/src/test/java/forge/ai/simulation/SpellAbilityPickerSimulationTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/simulation/SpellAbilityPickerSimulationTest.java
@@ -306,8 +306,6 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN1, p);
         game.getAction().checkStateEffects(true);
 
-        System.out.println(new GameStateEvaluator().evalCard(game, null, desired));
-
         // ensure that the tapland is played
         SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
@@ -327,7 +325,6 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         addCardToZone("Opt", p, ZoneType.Hand);
         game.getPhaseHandler().devModeSet(PhaseType.MAIN1, p);
         game.getAction().checkStateEffects(true);
-        AssertJUnit.assertEquals(p, desired.getController());
 
         // ensure that the tron land is played
         SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
@@ -344,12 +341,34 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         Card desired = addCardToZone("Maze of Ith", p, ZoneType.Hand);
         game.getPhaseHandler().devModeSet(PhaseType.MAIN1, p);
         game.getAction().checkStateEffects(true);
-        AssertJUnit.assertEquals(p, desired.getController());
 
         // ensure that the land is played
         SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertEquals(desired, sa.getHostCard());
+    }
+
+    @Test
+    public void targetRainbowLandOverDual() {
+        Game game = initAndCreateGame();
+        Player p = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+        opponent.setLife(20, null);
+
+        // start with the opponent having a basic land, a dual, and a rainbow
+        addCard("Forest", opponent);
+        addCard("Breeding Pool", opponent);
+        Card desired = addCard("Mana Confluence", opponent);
+        addCard("Strip Mine", p);
+
+        // It doesn't want to use strip mine in main
+        game.getPhaseHandler().devModeSet(PhaseType.COMBAT_DECLARE_BLOCKERS, p);
+        game.getAction().checkStateEffects(true);
+
+        // ensure that the land is played
+        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
+        AssertJUnit.assertEquals(desired, sa.getTargetCard());
     }
 
     @Test

--- a/forge-gui-desktop/src/test/java/forge/ai/simulation/SpellAbilityPickerSimulationTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/simulation/SpellAbilityPickerSimulationTest.java
@@ -279,6 +279,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         Game game = initAndCreateGame();
         Player p = game.getPlayers().get(1);
 
+        // start with a hand with a basic, a tapland, and a card that can't be cast
         addCard("Forest", p);
         addCardToZone("Forest", p, ZoneType.Hand);
         Card guildgate = addCardToZone("Simic Guildgate", p, ZoneType.Hand);
@@ -286,9 +287,31 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getPhaseHandler().devModeSet(PhaseType.MAIN1, p);
         game.getAction().checkStateEffects(true);
 
+        // ensure that the tapland is paid
         SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertEquals(guildgate, sa.getHostCard());
+    }
+
+    @Test
+    public void playTronOverBasic() {
+        Game game = initAndCreateGame();
+        Player p = game.getPlayers().get(1);
+
+        // start with a hand with a basic, a Tron land, and a card that can't be cast
+        addCard("Urza's Tower", p);
+        addCard("Urza's Mine", p);
+        addCardToZone("Forest", p, ZoneType.Hand);
+        Card desired = addCardToZone("Urza's Power Plant", p, ZoneType.Hand);
+        addCardToZone("Opt", p, ZoneType.Hand);
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN1, p);
+        game.getAction().checkStateEffects(true);
+        AssertJUnit.assertEquals(p, desired.getController());
+
+        // ensure that the tapland is paid
+        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
+        AssertJUnit.assertEquals(desired, sa.getHostCard());
     }
 
     @Test

--- a/forge-gui-desktop/src/test/java/forge/ai/simulation/SpellAbilityPickerSimulationTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/simulation/SpellAbilityPickerSimulationTest.java
@@ -282,7 +282,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         // start with a hand with a basic, a tapland, and a card that can't be cast
         addCard("Forest", p);
         addCardToZone("Forest", p, ZoneType.Hand);
-        Card guildgate = addCardToZone("Simic Guildgate", p, ZoneType.Hand);
+        Card desired = addCardToZone("Simic Guildgate", p, ZoneType.Hand);
         addCardToZone("Centaur Courser", p, ZoneType.Hand);
         game.getPhaseHandler().devModeSet(PhaseType.MAIN1, p);
         game.getAction().checkStateEffects(true);
@@ -290,7 +290,28 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         // ensure that the tapland is paid
         SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
-        AssertJUnit.assertEquals(guildgate, sa.getHostCard());
+        AssertJUnit.assertEquals(desired, sa.getHostCard());
+    }
+
+    @Test
+    public void playBouncelandIfNoPlays() {
+        Game game = initAndCreateGame();
+        Player p = game.getPlayers().get(1);
+
+        // start with a hand with a basic, a bounceland, and a card that can't be cast
+        addCard("Forest", p);
+        addCardToZone("Forest", p, ZoneType.Hand);
+        Card desired = addCardToZone("Simic Growth Chamber", p, ZoneType.Hand);
+        addCardToZone("Centaur Courser", p, ZoneType.Hand);
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN1, p);
+        game.getAction().checkStateEffects(true);
+
+        System.out.println(new GameStateEvaluator().evalCard(game, null, desired));
+
+        // ensure that the tapland is paid
+        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
+        AssertJUnit.assertEquals(desired, sa.getHostCard());
     }
 
     @Test

--- a/forge-gui-desktop/src/test/java/forge/ai/simulation/SpellAbilityPickerSimulationTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/simulation/SpellAbilityPickerSimulationTest.java
@@ -308,7 +308,7 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
 
         System.out.println(new GameStateEvaluator().evalCard(game, null, desired));
 
-        // ensure that the tapland is paid
+        // ensure that the tapland is played
         SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertEquals(desired, sa.getHostCard());
@@ -329,7 +329,24 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
         game.getAction().checkStateEffects(true);
         AssertJUnit.assertEquals(p, desired.getController());
 
-        // ensure that the tapland is paid
+        // ensure that the tron land is played
+        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
+        AssertJUnit.assertEquals(desired, sa.getHostCard());
+    }
+
+    @Test
+    public void playManalessLands() {
+        Game game = initAndCreateGame();
+        Player p = game.getPlayers().get(1);
+
+        // start with a hand with a land that can't produce mana.
+        Card desired = addCardToZone("Maze of Ith", p, ZoneType.Hand);
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN1, p);
+        game.getAction().checkStateEffects(true);
+        AssertJUnit.assertEquals(p, desired.getController());
+
+        // ensure that the land is played
         SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
         SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
         AssertJUnit.assertEquals(desired, sa.getHostCard());

--- a/forge-gui-desktop/src/test/java/forge/ai/simulation/SpellAbilityPickerSimulationTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/simulation/SpellAbilityPickerSimulationTest.java
@@ -376,6 +376,30 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
     }
 
     @Test
+    public void targetUtilityLandOverRainbow() {
+        Game game = initAndCreateGame();
+        Player p = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+        opponent.setLife(20, null);
+
+        // start with the opponent having a basic land, a dual, and a rainbow
+        addCard("Forest", opponent);
+        addCard("Breeding Pool", opponent);
+        addCard("Mana Confluence", opponent);
+        Card desired = addCard("Mutavault", opponent);
+        addCard("Strip Mine", p);
+
+        // It doesn't want to use strip mine in main
+        game.getPhaseHandler().devModeSet(PhaseType.COMBAT_DECLARE_BLOCKERS, p);
+        game.getAction().checkStateEffects(true);
+
+        // ensure that the land is played
+        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
+        AssertJUnit.assertEquals(desired, sa.getTargetCard());
+    }
+
+    @Test
     public void ensureAllLandsArePlayable() {
         initAndCreateGame();
 

--- a/forge-gui-desktop/src/test/java/forge/ai/simulation/SpellAbilityPickerSimulationTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/simulation/SpellAbilityPickerSimulationTest.java
@@ -275,6 +275,23 @@ public class SpellAbilityPickerSimulationTest extends SimulationTest {
     }
 
     @Test
+    public void playTaplandIfNoPlays() {
+        Game game = initAndCreateGame();
+        Player p = game.getPlayers().get(1);
+
+        addCard("Forest", p);
+        addCardToZone("Forest", p, ZoneType.Hand);
+        Card guildgate = addCardToZone("Simic Guildgate", p, ZoneType.Hand);
+        addCardToZone("Centaur Courser", p, ZoneType.Hand);
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN1, p);
+        game.getAction().checkStateEffects(true);
+
+        SpellAbilityPicker picker = new SpellAbilityPicker(game, p);
+        SpellAbility sa = picker.chooseSpellAbilityToPlay(null);
+        AssertJUnit.assertEquals(guildgate, sa.getHostCard());
+    }
+
+    @Test
     public void testPlayRememberedCardsLand() {
         Game game = initAndCreateGame();
         Player p = game.getPlayers().get(1);


### PR DESCRIPTION
- Lands now have a small bonus for each color they can produce
- Lands now count for each mana they can produce

This does create a lot of messages like:
```
Forest Did not have activator set in SpellAbility_Condition.checkConditions()
```
Is that warning something to look out for or is it just noise that can be removed?