### PR TITLE
Game: add CountersRemovedThisTurn

### DIFF
--- a/forge-game/src/main/java/forge/game/Game.java
+++ b/forge-game/src/main/java/forge/game/Game.java
@@ -124,6 +124,7 @@ public class Game {
     private CardZoneTable untilHostLeavesPlayTriggerList = new CardZoneTable();
 
     private Table<CounterType, Player, List<Pair<Card, Integer>>> countersAddedThisTurn = HashBasedTable.create();
+    private Multimap<CounterType, Pair<Card, Integer>> countersRemovedThisTurn = ArrayListMultimap.create();
 
     private FCollection<CardDamageHistory> globalDamageHistory = new FCollection<>();
     private IdentityHashMap<Pair<Integer, Boolean>, Pair<Card, GameEntity>> damageThisTurnLKI = new IdentityHashMap<>();
@@ -1102,6 +1103,7 @@ public class Game {
 
     public void onCleanupPhase() {
         clearCounterAddedThisTurn();
+        clearCounterRemovedThisTurn();
         clearGlobalDamageHistory();
         // some cards need this info updated even after a player lost, so don't skip them
         for (Player player : getRegisteredPlayers()) {
@@ -1140,6 +1142,24 @@ public class Game {
 
     public void clearCounterAddedThisTurn() {
         countersAddedThisTurn.clear();
+    }
+
+    public void addCounterRemovedThisTurn(CounterType cType, Card card, Integer value) {
+        countersRemovedThisTurn.put(cType, Pair.of(CardUtil.getLKICopy(card), value));
+    }
+
+    public int getCounterRemovedThisTurn(CounterType cType, String validCard, Card source, Player sourceController, CardTraitBase ctb) {
+        int result = 0;
+        for (Pair<Card, Integer> p : countersRemovedThisTurn.get(cType)) {
+            if (p.getKey().isValid(validCard.split(","), sourceController, source, ctb)) {
+                result += p.getValue();
+            }
+        }
+        return result;
+    }
+
+    public void clearCounterRemovedThisTurn() {
+        countersRemovedThisTurn.clear();
     }
 
     /**

--- a/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
@@ -958,6 +958,7 @@ public class AbilityUtils {
      *            a {@link forge.game.spellability.SpellAbility} object.
      * @return a {@link java.util.ArrayList} object.
      */
+    @SuppressWarnings("unchecked")
     public static PlayerCollection getDefinedPlayers(final Card card, final String def, final CardTraitBase sa) {
         final PlayerCollection players = new PlayerCollection();
         String changedDef = (def == null) ? "You" : applyAbilityTextChangeEffects(def, sa); // default to Self
@@ -2744,6 +2745,12 @@ public class AbilityUtils {
             CounterType cType = CounterType.getType(parts[1]);
 
             return doXMath(game.getCounterAddedThisTurn(cType, parts[2], parts[3], c, player, ctb), expr, c, ctb);
+        }
+        if (sq[0].startsWith("CountersRemovedThisTurn")) {
+            final String[] parts = l[0].split(" ");
+            CounterType cType = CounterType.getType(parts[1]);
+
+            return doXMath(game.getCounterRemovedThisTurn(cType, parts[2], c, player, ctb), expr, c, ctb);
         }
 
         // count valid cards in any specified zone/s

--- a/forge-game/src/main/java/forge/game/ability/effects/RestartGameEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/RestartGameEffect.java
@@ -54,6 +54,7 @@ public class RestartGameEffect extends SpellAbilityEffect {
 
         game.getStack().reset();
         game.clearCounterAddedThisTurn();
+        game.clearCounterRemovedThisTurn();
         game.setMonarch(null);
         game.setHasInitiative(null);
         game.setDayTime(null);

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -1427,7 +1427,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
     public final boolean hasDoubleStrike() {
         return hasKeyword(Keyword.DOUBLE_STRIKE);
     }
-    
+
     public final boolean hasDoubleTeam() {
         return hasKeyword(Keyword.DOUBLE_TEAM);
     }
@@ -1588,6 +1588,8 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
 
         // Play the Subtract Counter sound
         getGame().fireEvent(new GameEventCardCounters(this, counterName, oldValue, newValue));
+
+        getGame().addCounterRemovedThisTurn(counterName, this, delta);
 
         // Run triggers
         int curCounters = oldValue;


### PR DESCRIPTION
Closes #2267

this is for:
>  Activate only if an oil counter was removed from a permanent you controlled this turn or a permanent with an oil counter on it was put into a graveyard this turn.

The second part should be easy