### PR TITLE
Alchemy Rebalancing for January 17, 2023

### DIFF
--- a/forge-gui/res/cardsfolder/g/goblin_trapfinder.txt
+++ b/forge-gui/res/cardsfolder/g/goblin_trapfinder.txt
@@ -2,14 +2,14 @@ Name:Goblin Trapfinder
 ManaCost:R
 Types:Creature Goblin
 PT:1/1
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ DBSeek | TriggerDescription$ When CARDNAME dies, seek a creature card with mana value 3 or less. That card perpetually gains haste, "This spell costs {2} less to cast," and "At the beginning of your end step, sacrifice this creature."
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ DBSeek | TriggerDescription$ When CARDNAME dies, seek a creature card with mana value 3 or less. That card perpetually gains haste, "This spell costs {1} less to cast," and "At the beginning of your end step, sacrifice this creature."
 SVar:DBSeek:DB$ ChangeZone | Origin$ Library | Destination$ Hand | AtRandom$ True | NoShuffle$ True | NoLooking$ True | NoReveal$ True | ChangeNum$ 1 | ChangeType$ Creature.cmcLE3+YouOwn | RememberChanged$ True | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | StaticAbilities$ PerpetualAbility | RememberObjects$ Remembered | Triggers$ Update | Name$ Goblin Trapfinder's Perpetual Effect | Duration$ Permanent
-SVar:PerpetualAbility:Mode$ Continuous | Affected$ Card.IsRemembered | AddTrigger$ TrigSac | AddStaticAbility$ PerpetualReduceCost | AddKeyword$ Haste | EffectZone$ Command | | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | Description$ This card perpetually gains haste, "This spell costs {2} less to cast," and "At the beginning of your end step, sacrifice this creature."
-SVar:PerpetualReduceCost:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 2 | EffectZone$ All | Description$ This spell costs {2} less to cast.
+SVar:PerpetualAbility:Mode$ Continuous | Affected$ Card.IsRemembered | AddTrigger$ TrigSac | AddStaticAbility$ PerpetualReduceCost | AddKeyword$ Haste | EffectZone$ Command | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | Description$ This card perpetually gains haste, "This spell costs {1} less to cast," and "At the beginning of your end step, sacrifice this creature."
+SVar:PerpetualReduceCost:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 1 | EffectZone$ All | Description$ This spell costs {1} less to cast.
 SVar:TrigSac:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | Execute$ TrigSacrifice | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your end step, sacrifice this creature.
 SVar:TrigSacrifice:DB$ Sacrifice
 SVar:Update:Mode$ ChangesZone | Origin$ Any | Destination$ Any | Static$ True | ValidCard$ Card.IsRemembered | Execute$ DBUpdate
 SVar:DBUpdate:DB$ UpdateRemember
 DeckHas:Ability$Sacrifice
-Oracle:When Goblin Trapfinder dies, seek a creature card with mana value 3 or less. That card perpetually gains haste, "This spell costs {2} less to cast," and "At the beginning of your end step, sacrifice this creature."
+Oracle:When Goblin Trapfinder dies, seek a creature card with mana value 3 or less. That card perpetually gains haste, "This spell costs {1} less to cast," and "At the beginning of your end step, sacrifice this creature."

--- a/forge-gui/res/cardsfolder/i/imperial_blademaster.txt
+++ b/forge-gui/res/cardsfolder/i/imperial_blademaster.txt
@@ -1,7 +1,7 @@
 Name:Imperial Blademaster
 ManaCost:1 R W
 Types:Creature Human Samurai
-PT:2/2
+PT:2/3
 K:Double Strike
 T:Mode$ Attacks | ValidCard$ Samurai.YouCtrl,Warrior.YouCtrl | Alone$ True | TriggerZones$ Battlefield | Execute$ TrigDraft | TriggerDescription$ Whenever a Samurai or Warrior you control attacks alone, draft a card from Imperial Blademaster's spellbook.
 SVar:TrigDraft:DB$ Draft | Spellbook$ Eiganjo Exemplar,Imperial Subduer,Ancestral Katana,Selfless Samurai,Norika Yamazaki; the Poet,Akki Ronin,Peerless Samurai,Heiko Yamazaki; the General,Asari Captain,Eiganjo Uprising,Eater of Virtue,Sunblade Samurai,Reinforced Ronin,Adamant Will,Tempered in Solitude

--- a/forge-gui/res/cardsfolder/o/obsessive_collector.txt
+++ b/forge-gui/res/cardsfolder/o/obsessive_collector.txt
@@ -1,7 +1,7 @@
 Name:Obsessive Collector
 ManaCost:3 U
 Types:Creature Spirit
-PT:4/3
+PT:4/4
 K:Flying
 K:Ward:2
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigSeek | CombatDamage$ True | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, seek a card with mana value equal to the number of cards in your hand.

--- a/forge-gui/res/cardsfolder/rebalanced/a-akki_ronin.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-akki_ronin.txt
@@ -1,0 +1,10 @@
+Name:A-Akki Ronin
+ManaCost:R
+Types:Creature Goblin Samurai
+PT:1/2
+T:Mode$ Attacks | ValidCard$ Samurai.YouCtrl,Warrior.YouCtrl | Alone$ True | Execute$ TrigChangeZone | TriggerZones$ Battlefield | TriggerDescription$ Whenever a Samurai or Warrior you control attacks alone, you may put a card from your hand on the bottom of your library. If you do, draw a card.
+SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Hand | Destination$ Library | Hand$ Library | LibraryPosition$ -1 | ChangeNum$ 1 | RememberChanged$ True | SubAbility$ DBDraw
+SVar:DBDraw:DB$ Draw | NumCards$ 1 | ConditionDefined$ Remembered | ConditionPresent$ Card | ConditionCompare$ GE1 | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+DeckHints:Type$Samurai|Warrior
+Oracle:Whenever a Samurai or Warrior you control attacks alone, you may put a card from your hand on the bottom of your library. If you do, draw a card.

--- a/forge-gui/res/cardsfolder/rebalanced/a-ancestral_katana.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-ancestral_katana.txt
@@ -1,0 +1,11 @@
+Name:A-Ancestral Katana
+ManaCost:1 W
+Types:Artifact Equipment
+T:Mode$ Attacks | ValidCard$ Samurai.YouCtrl,Warrior.YouCtrl | Alone$ True | TriggerZones$ Battlefield | Execute$ TrigImmediateTrig | TriggerDescription$ Whenever a Samurai or Warrior you control attacks alone, you may pay {1}. When you do, attach CARDNAME to it.
+SVar:TrigImmediateTrig:AB$ ImmediateTrigger | Cost$ 1 | Execute$ TrigAttach | RememberObjects$ TriggeredAttackerLKICopy | TriggerDescription$ When you do, attach CARDNAME to it.
+SVar:TrigAttach:DB$ Attach | Defined$ DelayTriggerRememberedLKI
+S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 2 | AddToughness$ 2 | AddStaticAbility$ FirstStrike | Description$ Equipped creature gets +2/+2 and has "This creature has first strike as long as it's attacking."
+SVar:FirstStrike:Mode$ Continuous | Affected$ Card.Self+attacking | AddKeyword$ First Strike | Description$ This creature has first strike as long as it's attacking.
+K:Equip:2
+DeckHints:Type$Samurai|Warrior
+Oracle:Whenever a Samurai or Warrior you control attacks alone, you may pay {1}. When you do, attach Ancestral Katana to it.\nEquipped creature gets +2/+2 and has "This creature has first strike as long as it's attacking."\nEquip {2}

--- a/forge-gui/res/cardsfolder/rebalanced/a-asari_captain.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-asari_captain.txt
@@ -1,0 +1,11 @@
+Name:A-Asari Captain
+ManaCost:1 R W
+Types:Creature Human Samurai
+PT:2/1
+K:Trample
+K:Haste
+T:Mode$ Attacks | ValidCard$ Samurai.YouCtrl,Warrior.YouCtrl | Alone$ True | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever a Samurai or Warrior you control attacks alone, it gets +1/+0 until end of turn for each Samurai or Warrior you control.
+SVar:TrigPump:DB$ Pump | Defined$ TriggeredAttackerLKICopy | NumAtt$ +X
+SVar:X:Count$Valid Samurai.YouCtrl,Warrior.YouCtrl
+DeckHints:Type$Samurai|Warrior
+Oracle:Trample, haste\nWhenever a Samurai or Warrior you control attacks alone, it gets +1/+0 until end of turn for each Samurai or Warrior you control.

--- a/forge-gui/res/cardsfolder/rebalanced/a-binding_geist_spectral_binding.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-binding_geist_spectral_binding.txt
@@ -1,0 +1,24 @@
+Name:A-Binding Geist
+ManaCost:1 U
+Types:Creature Spirit
+PT:2/1
+K:Disturb:U
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, target creature an opponent controls gets -2/-0 until your next turn.
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | NumAtt$ -2 | IsCurse$ True | Duration$ UntilYourNextTurn
+SVar:HasAttackEffect:TRUE
+DeckHas:Ability$Graveyard
+AlternateMode:DoubleFaced
+Oracle:Whenever Binding Geist attacks, target creature an opponent controls gets -2/-0 until your next turn.\nDisturb {U}
+
+ALTERNATE
+
+Name:A-Spectral Binding
+ManaCost:no cost
+Colors:blue
+Types:Enchantment Aura
+K:Enchant creature
+A:SP$ Attach | ValidTgts$ Creature | TgtPrompt$ Select target creature | AILogic$ Curse
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ -2 | Description$ Enchanted creature gets -2/-0.
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Graveyard | ReplaceWith$ Exile | Description$ If CARDNAME would be put into a graveyard from anywhere, exile it instead.
+SVar:Exile:DB$ ChangeZone | Hidden$ True | Origin$ All | Destination$ Exile | Defined$ ReplacedCard
+Oracle:Enchant creature\nEnchanted creature gets -2/-0.\nIf Spectral Binding would be put into a graveyard from anywhere, exile it instead.

--- a/forge-gui/res/cardsfolder/rebalanced/a-brine_comber_brinebound_gift.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-brine_comber_brinebound_gift.txt
@@ -1,0 +1,30 @@
+Name:A-Brine Comber
+ManaCost:1 W U
+Types:Creature Spirit
+PT:2/2
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters the battlefield or becomes the target of an Aura spell, create a 1/1 white Spirit creature token with flying.
+T:Mode$ BecomesTarget | ValidTarget$ Card.Self | ValidSource$ Spell.Aura | TriggerZones$ Battlefield | Execute$ TrigToken | Secondary$ True | TriggerDescription$ When CARDNAME enters the battlefield or becomes the target of an Aura spell, create a 1/1 white Spirit creature token with flying.
+SVar:TrigToken:DB$ Token | TokenScript$ w_1_1_spirit_flying
+K:Disturb:W U
+SVar:EnchantMe:Multiple
+DeckHas:Ability$Graveyard|Token
+DeckHints:Type$Enchantment
+AlternateMode:DoubleFaced
+Oracle:Whenever Brine Comber enters the battlefield or becomes the target of an Aura spell, create a 1/1 white Spirit creature token with flying.\nDisturb {W}{U}
+
+ALTERNATE
+
+Name:A-Brinebound Gift
+ManaCost:no cost
+Colors:white,blue
+Types:Enchantment Aura
+K:Enchant creature
+A:SP$ Attach | ValidTgts$ Creature | TgtPrompt$ Select target creature | AILogic$ Pump
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters the battlefield or enchanted creature becomes the target of an Aura spell, create a 1/1 white Spirit creature token with flying.
+T:Mode$ BecomesTarget | ValidTarget$ Creature.EnchantedBy | ValidSource$ Spell.Aura | TriggerZones$ Battlefield | Execute$ TrigToken | Secondary$ True | TriggerDescription$ When CARDNAME enters the battlefield or enchanted creature becomes the target of an Aura spell, create a 1/1 white Spirit creature token with flying.
+SVar:TrigToken:DB$ Token | TokenScript$ w_1_1_spirit_flying
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Graveyard | ReplaceWith$ Exile | Description$ If CARDNAME would be put into a graveyard from anywhere, exile it instead.
+SVar:Exile:DB$ ChangeZone | Hidden$ True | Origin$ All | Destination$ Exile | Defined$ ReplacedCard
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddSVar$ EnchantTarget | Secondary$ True
+SVar:EnchantTarget:SVar:EnchantMe:Multiple
+Oracle:Enchant creature\nWhenever Brinebound Gift enters the battlefield or enchanted creature becomes the target of an Aura spell, create a 1/1 white Spirit creature token with flying.\nIf Brinebound Gift would be put into a graveyard from anywhere, exile it instead.

--- a/forge-gui/res/cardsfolder/rebalanced/a-devoted_grafkeeper_departed_soulkeeper.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-devoted_grafkeeper_departed_soulkeeper.txt
@@ -1,0 +1,24 @@
+Name:A-Devoted Grafkeeper
+ManaCost:W U
+Types:Creature Human Peasant
+PT:2/2
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigMill | TriggerDescription$ When CARDNAME enters the battlefield, mill four cards.
+SVar:TrigMill:DB$ Mill | NumCards$ 4 | Defined$ You
+T:Mode$ SpellCast | ValidCard$ Card.wasCastFromYourGraveyardByYou | ValidActivatingPlayer$ You | Execute$ TrigTap | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a spell from your graveyard, tap target creature you don't control.
+SVar:TrigTap:DB$ Tap | ValidTgts$ Creature.YouDontCtrl | TgtPrompt$ Select target creature you don't control
+DeckHas:Ability$Mill|Graveyard
+K:Disturb:1 W U
+AlternateMode:DoubleFaced
+Oracle:When Devoted Grafkeeper enters the battlefield, mill four cards.\nWhenever you cast a spell from your graveyard, tap target creature you don't control.\nDisturb {1}{W}{U}
+
+ALTERNATE
+
+Name:A-Departed Soulkeeper
+ManaCost:no cost
+Colors:white,blue
+Types:Creature Spirit
+PT:3/1
+K:Flying
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Graveyard | ReplaceWith$ Exile | Description$ If CARDNAME would be put into a graveyard from anywhere, exile it instead.
+SVar:Exile:DB$ ChangeZone | Hidden$ True | Origin$ All | Destination$ Exile | Defined$ ReplacedCard
+Oracle:Flying\nIf Departed Soulkeeper would be put into a graveyard from anywhere, exile it instead.

--- a/forge-gui/res/cardsfolder/rebalanced/a-dorothea_vengeful_victim_dorotheas_retribution.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-dorothea_vengeful_victim_dorotheas_retribution.txt
@@ -1,0 +1,30 @@
+Name:A-Dorothea, Vengeful Victim
+ManaCost:W U
+Types:Legendary Creature Spirit
+PT:4/4
+K:Flying
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ DelTrig | TriggerDescription$ When CARDNAME attacks or blocks, sacrifice it at end of combat.
+T:Mode$ Blocks | ValidCard$ Card.Self | Execute$ DelTrig | Secondary$ True | TriggerDescription$ Whenever CARDNAME attacks or blocks, sacrifice it at end of combat.
+SVar:DelTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ EndCombat | ValidPlayer$ Player | Execute$ TrigSacrifice | TriggerDescription$ Sacrifice CARDNAME at end of combat.
+SVar:TrigSacrifice:DB$ SacrificeAll | Defined$ Self | Controller$ You
+SVar:SacrificeEndCombat:True
+K:Disturb:W U
+DeckHas:Ability$Sacrifice|Graveyard|Token
+AlternateMode:DoubleFaced
+Oracle:Flying\nWhen Dorothea, Vengeful Victim attacks or blocks, sacrifice it at end of combat.\nDisturb {W}{U}
+
+ALTERNATE
+
+Name:A-Dorothea's Retribution
+ManaCost:no cost
+Colors:white,blue
+Types:Enchantment Aura
+K:Enchant creature
+A:SP$ Attach | ValidTgts$ Creature | TgtPrompt$ Select target creature | AILogic$ Pump
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddTrigger$ AttackTrigger | AddSVar$ AE | Description$ Enchanted creature has "Whenever this creature attacks, create a 4/4 white Spirit creature token with flying that's tapped and attacking. Sacrifice that token at end of combat."
+SVar:AttackTrigger:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever this creature attacks, create a 4/4 white Spirit creature token with flying that's tapped and attacking. Sacrifice that token at end of combat.
+SVar:TrigToken:DB$ Token | TokenScript$ w_4_4_spirit_flying | TokenTapped$ True | TokenAttacking$ True | AtEOT$ SacrificeCombat
+SVar:AE:SVar:HasAttackEffect:TRUE
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Graveyard | ReplaceWith$ Exile | Description$ If CARDNAME would be put into a graveyard from anywhere, exile it instead.
+SVar:Exile:DB$ ChangeZone | Hidden$ True | Origin$ All | Destination$ Exile | Defined$ ReplacedCard
+Oracle:Enchant creature\nEnchanted creature has "Whenever this creature attacks, create a 4/4 white Spirit creature token with flying that's tapped and attacking. Sacrifice that token at end of combat."\nIf Dorothea's Retribution would be put into a graveyard from anywhere, exile it instead.

--- a/forge-gui/res/cardsfolder/rebalanced/a-dreamshackle_geist.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-dreamshackle_geist.txt
@@ -1,0 +1,10 @@
+Name:A-Dreamshackle Geist
+ManaCost:1 U U
+Types:Creature Spirit
+PT:3/2
+K:Flying
+T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | Execute$ TrigCharm | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of combat on your turn, ABILITY
+SVar:TrigCharm:DB$ Charm | Choices$ Tap,Freeze | CharmNum$ 1 | MinCharmNum$ 0
+SVar:Tap:DB$ Tap | ValidTgts$ Creature | TgtPrompt$ Select target creature | SpellDescription$ Tap target creature.
+SVar:Freeze:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ HIDDEN This card doesn't untap during your next untap step. | Duration$ Permanent | IsCurse$ True | SpellDescription$ Target creature doesn't untap during its controller's next untap step.
+Oracle:Flying\nAt the beginning of combat on your turn, choose up to one —\n• Tap target creature.\n• Target creature doesn't untap during its controller's next untap step.

--- a/forge-gui/res/cardsfolder/rebalanced/a-eiganjo_exemplar.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-eiganjo_exemplar.txt
@@ -1,0 +1,8 @@
+Name:A-Eiganjo Exemplar
+ManaCost:W
+Types:Enchantment Creature Human Samurai
+PT:1/1
+T:Mode$ Attacks | ValidCard$ Samurai.YouCtrl,Warrior.YouCtrl | Alone$ True | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever a Samurai or Warrior you control attacks alone, it gets +1/+1 until end of turn.
+SVar:TrigPump:DB$ Pump | Defined$ TriggeredAttackerLKICopy | NumAtt$ 1 | NumDef$ 1
+DeckHints:Type$Samurai|Warrior
+Oracle:Whenever a Samurai or Warrior you control attacks alone, it gets +1/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-gutter_skulker_gutter_shortcut.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-gutter_skulker_gutter_shortcut.txt
@@ -1,0 +1,23 @@
+Name:A-Gutter Skulker
+ManaCost:2 U
+Types:Creature Spirit
+PT:3/3
+K:Disturb:2 U
+S:Mode$ CantBlockBy | ValidAttacker$ Card.Self+attacking | IsPresent$ Card.Other+attacking | PresentCompare$ EQ0 | Description$ CARDNAME can't be blocked as long as it's attacking alone.
+DeckHas:Ability$Graveyard
+AlternateMode:DoubleFaced
+Oracle:Gutter Skulker can't be blocked as long as it's attacking alone.\nDisturb {2}{U}
+
+ALTERNATE
+
+Name:A-Gutter Shortcut
+ManaCost:no cost
+Colors:blue
+Types:Enchantment Aura
+K:Enchant creature
+A:SP$ Attach | ValidTgts$ Creature | AILogic$ Pump
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 3 | Description$ Enchanted creature gets +3/+0. It can't be blocked as long as it's attacking alone.
+S:Mode$ CantBlockBy | ValidAttacker$ Creature.EnchantedBy+attacking | IsPresent$ Card.attacking | PresentCompare$ EQ1 | Secondary$ True | Description$ It can't be blocked as long as it's attacking alone.
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Graveyard | ReplaceWith$ Exile | Description$ If CARDNAME would be put into a graveyard from anywhere, exile it instead.
+SVar:Exile:DB$ ChangeZone | Hidden$ True | Origin$ All | Destination$ Exile | Defined$ ReplacedCard
+Oracle:Enchant creature\nEnchanted creature gets +3/+0. It can't be blocked as long as it's attacking alone.\nIf Gutter Shortcut would be put into a graveyard from anywhere, exile it instead.

--- a/forge-gui/res/cardsfolder/rebalanced/a-imperial_subduer.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-imperial_subduer.txt
@@ -1,0 +1,8 @@
+Name:A-Imperial Subduer
+ManaCost:1 W
+Types:Creature Human Samurai
+PT:3/1
+T:Mode$ Attacks | ValidCard$ Samurai.YouCtrl,Warrior.YouCtrl | Alone$ True | TriggerZones$ Battlefield | Execute$ TrigTap | TriggerDescription$ Whenever a Samurai or Warrior you control attacks alone, tap target creature you don't control.
+SVar:TrigTap:DB$ Tap | ValidTgts$ Creature.YouDontCtrl | TgtPrompt$ Select target creature you don't control
+DeckHints:Type$Samurai|Warrior
+Oracle:Whenever a Samurai or Warrior you control attacks alone, tap target creature you don't control.

--- a/forge-gui/res/cardsfolder/rebalanced/a-lantern_bearer_lanterns_lift.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-lantern_bearer_lanterns_lift.txt
@@ -1,0 +1,22 @@
+Name:A-Lantern Bearer
+ManaCost:U
+Types:Creature Spirit
+PT:1/1
+K:Flying
+K:Disturb:1 U
+DeckHas:Ability$Graveyard
+AlternateMode:DoubleFaced
+Oracle:Flying\nDisturb {1}{U}
+
+ALTERNATE
+
+Name:A-Lanterns' Lift
+ManaCost:no cost
+Colors:blue
+Types:Enchantment Aura
+K:Enchant creature
+A:SP$ Attach | ValidTgts$ Creature | TgtPrompt$ Select target creature | AILogic$ Pump
+S:Mode$ Continuous | Affected$ Card.EnchantedBy | AddPower$ 1 | AddToughness$ 1 | AddKeyword$ Flying | Description$ Enchanted creature gets +1/+1 and has flying.
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Graveyard | ReplaceWith$ Exile | Description$ If CARDNAME would be put into a graveyard from anywhere, exile it instead.
+SVar:Exile:DB$ ChangeZone | Hidden$ True | Origin$ All | Destination$ Exile | Defined$ ReplacedCard
+Oracle:Enchant creature\nEnchanted creature gets +1/+1 and has flying.\nIf Lanterns' Lift would be put into a graveyard from anywhere, exile it instead.

--- a/forge-gui/res/cardsfolder/rebalanced/a-mischievous_catgeist_catlike_curiosity.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-mischievous_catgeist_catlike_curiosity.txt
@@ -1,25 +1,25 @@
-Name:Mischievous Catgeist
+Name:A-Mischievous Catgeist
 ManaCost:1 U
 Types:Creature Cat Spirit
 PT:1/1
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, draw a card.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1
-K:Disturb:2 U
+K:Disturb:1 U
 DeckHas:Ability$Graveyard
 AlternateMode:DoubleFaced
-Oracle:Whenever Mischievous Catgeist deals combat damage to a player, draw card.\nDisturb {2}{U} (You may cast this card from your graveyard transformed for its disturb cost.)
+Oracle:Whenever Mischievous Catgeist deals combat damage to a player, draw card.\nDisturb {1}{U}
 
 ALTERNATE
 
-Name:Catlike Curiosity
+Name:A-Catlike Curiosity
 ManaCost:no cost
 Colors:blue
 Types:Enchantment Aura
 K:Enchant creature
 A:SP$ Attach | ValidTgts$ Creature | TgtPrompt$ Select target creature | AILogic$ Pump
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddTrigger$ TrigDamageDone | Description$ Enchanted creature has "Whenever this creature deals combat damage to a player, draw a card."
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | AddToughness$ 1 | AddTrigger$ TrigDamageDone | Description$ Enchanted creature gets +1/+1 and has "Whenever this creature deals combat damage to a player, draw a card."
 SVar:TrigDamageDone:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigDraw | TriggerDescription$ Whenever this creature deals combat damage to a player, draw a card.
 SVar:TrigDraw:DB$ Draw
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Graveyard | ReplaceWith$ Exile | Description$ If CARDNAME would be put into a graveyard from anywhere, exile it instead.
 SVar:Exile:DB$ ChangeZone | Hidden$ True | Origin$ All | Destination$ Exile | Defined$ ReplacedCard
-Oracle:Enchant creature\nEnchanted creature has "Whenever this creature deals combat damage to a player, draw a card."\nIf Catlike Curiosity would be put into a graveyard from anywhere, exile it instead.
+Oracle:Enchant creature\nEnchanted creature gets +1/+1 and has "Whenever this creature deals combat damage to a player, draw a card."\nIf Catlike Curiosity would be put into a graveyard from anywhere, exile it instead.

--- a/forge-gui/res/cardsfolder/rebalanced/a-patrician_geist.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-patrician_geist.txt
@@ -1,0 +1,9 @@
+Name:A-Patrician Geist
+ManaCost:2 U
+Types:Creature Spirit Knight
+PT:2/2
+K:Flying
+S:Mode$ Continuous | Affected$ Spirit.Other+YouCtrl | AddPower$ 1 | AddToughness$ 1 | Description$ Other Spirits you control get +1/+1.
+S:Mode$ ReduceCost | ValidCard$ Card.wasCastFromYourGraveyard | Type$ Spell | Activator$ You | Amount$ U | Description$ Spells you cast from your graveyard cost {U} less to cast.
+DeckHints:Ability$Graveyard & Type$Spirit
+Oracle:Flying\nOther Spirits you control get +1/+1.\nSpells you cast from your graveyard cost {U} less to cast.

--- a/forge-gui/res/cardsfolder/rebalanced/a-peerless_samurai.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-peerless_samurai.txt
@@ -1,0 +1,12 @@
+Name:A-Peerless Samurai
+ManaCost:1 R
+Types:Creature Human Samurai
+PT:2/1
+K:Menace
+T:Mode$ Attacks | ValidCard$ Samurai.YouCtrl,Warrior.YouCtrl | Alone$ True | TriggerZones$ Battlefield | Execute$ TrigEffect | TriggerDescription$ Whenever a Samurai or Warrior you control attacks alone, the next spell you cast this turn costs {1} less to cast.
+SVar:TrigEffect:DB$ Effect | StaticAbilities$ ReduceCost | Triggers$ TrigCastSpell
+SVar:ReduceCost:Mode$ ReduceCost | EffectZone$ Command | Type$ Spell | Activator$ You | Amount$ 1 | Description$ The next spell you cast this turn costs {1} less to cast.
+SVar:TrigCastSpell:Mode$ SpellCast | ValidActivatingPlayer$ You | TriggerZones$ Command | Execute$ RemoveEffect | Static$ True
+SVar:RemoveEffect:DB$ ChangeZone | Origin$ Command | Destination$ Exile
+DeckHints:Type$Samurai|Warrior
+Oracle:Menace\nWhenever a Samurai or Warrior you control attacks alone, the next spell you cast this turn costs {1} less to cast.

--- a/forge-gui/res/cardsfolder/rebalanced/a-phantom_carriage.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-phantom_carriage.txt
@@ -1,0 +1,8 @@
+Name:A-Phantom Carriage
+ManaCost:2 U U
+Types:Creature Spirit
+PT:4/4
+K:Flying
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ PhantomSearch | TriggerDescription$ When CARDNAME enters the battlefield, you may search your library for a card with flashback or disturb, put it into your graveyard, then shuffle.
+SVar:PhantomSearch:DB$ ChangeZone | Origin$ Library | Destination$ Graveyard | ChangeNum$ 1 | ChangeType$ Card.withFlashback+YouOwn,Card.withDisturb+YouOwn
+Oracle:Flying\nWhen Phantom Carriage enters the battlefield, you may search your library for a card with flashback or disturb, put it into your graveyard, then shuffle.

--- a/forge-gui/res/cardsfolder/rebalanced/a-raiyuu_storms_edge.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-raiyuu_storms_edge.txt
@@ -1,0 +1,10 @@
+Name:A-Raiyuu, Storm's Edge
+ManaCost:2 R W
+Types:Legendary Creature Human Samurai
+PT:4/4
+K:First Strike
+T:Mode$ Attacks | ValidCard$ Samurai.YouCtrl,Warrior.YouCtrl | Alone$ True | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ Whenever a Samurai or Warrior you control attacks alone, untap it. If it's the first combat phase of the turn, there is an additional combat phase after this phase.
+SVar:TrigUntap:DB$ Untap | Defined$ TriggeredAttackerLKICopy | SubAbility$ DBAddPhase
+SVar:DBAddPhase:DB$ AddPhase | ExtraPhase$ Combat | ConditionFirstCombat$ True | AfterPhase$ EndCombat
+DeckHints:Type$Samurai|Warrior
+Oracle:First strike\nWhenever a Samurai or Warrior you control attacks alone, untap it. If it's the first combat phase of the turn, there is an additional combat phase after this phase.

--- a/forge-gui/res/cardsfolder/rebalanced/a-shipwreck_sifters.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-shipwreck_sifters.txt
@@ -1,0 +1,12 @@
+Name:A-Shipwreck Sifters
+ManaCost:1 U
+Types:Creature Spirit
+PT:1/2
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ When CARDNAME enters the battlefield, draw a card, then discard a card.
+SVar:TrigDraw:DB$ Draw | NumCards$ 1 | SubAbility$ DBDiscard
+SVar:DBDiscard:DB$ Discard | NumCards$ 1 | Mode$ TgtChoose
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Graveyard | ValidCard$ Spirit.YouOwn,Card.YouOwn+withDisturb | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Whenever a Spirit or card with disturb is put into your graveyard from anywhere, put a +1/+1 counter on CARDNAME.
+SVar:TrigPutCounter:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ 1
+DeckHas:Ability$Discard|Counters
+DeckHints:Type$Spirit & Keyword$Disturb
+Oracle:When Shipwreck Sifters enters the battlefield, draw a card, then discard a card.\nWhenever a Spirit or card with disturb is put into your graveyard from anywhere, put a +1/+1 counter on Shipwreck Sifters.

--- a/forge-gui/res/editions/Innistrad Crimson Vow.txt
+++ b/forge-gui/res/editions/Innistrad Crimson Vow.txt
@@ -433,9 +433,16 @@ Prerelease=6 Boosters, 1 RareMythic+
 412 L Forest @Pig Hands
 
 [rebalanced]
+A48 C A-Binding Geist @Campbell White
 A52 U A-Cobbled Lancer @Igor Kieryluk
+A58 R A-Dreamshackle Geist @Andreas Zafiratos
+A62 U A-Gutter Skulker @Viko Menezes
 A63 R A-Hullbreaker Horror @Svetlin Velinov
+A66 C A-Lantern Bearer @Zoltan Boros
+A69 U A-Mischievous Catgeist @Denman Rooke
 A81 C A-Stitched Assistant @Andrey Kuzinskiy
+A233 U A-Brine Comber @Olena Richards
+A235 R A-Dorothea, Vengeful Victim @Marta Nael
 A247 U A-Sigardian Paladin @Slawomir Maniak
 A248 U A-Skull Skaab @Nicholas Gregory
 

--- a/forge-gui/res/editions/Innistrad Midnight Hunt.txt
+++ b/forge-gui/res/editions/Innistrad Midnight Hunt.txt
@@ -415,8 +415,12 @@ Prerelease=6 Boosters, 1 RareMythic+
 [rebalanced]
 A52 C A-Falcon Abomination @Brent Hollowell
 A59 M A-Lier, Disciple of the Drowned @Ekaterina Burmak
+A69 R A-Patrician Geist @Marta Nael
+A70 U A-Phantom Carriage @Igor Kieryluk
+A74 C A-Shipwreck Sifters @Svetlin Velinov
 A106 C A-Hobbling Zombie @Josh Hass
 A112 M A-The Meathook Massacre @Chris Seaman
+A218 U A-Devoted Grafkeeper @Raoul Vitale
 
 [tokens]
 b_1_1_bat_flying

--- a/forge-gui/res/editions/Kamigawa Neon Dynasty.txt
+++ b/forge-gui/res/editions/Kamigawa Neon Dynasty.txt
@@ -536,6 +536,15 @@ ScryfallCode=NEO
 513 M Jin-Gitaxias, Progress Tyrant @Richard Whitters
 514 M Jin-Gitaxias, Progress Tyrant @Richard Whitters
 
+[rebalanced]
+A1 C A-Ancestral Katana @Daniel Ljunggren
+A10 C A-Eiganjo Exemplar @Ernanda Souza
+A19 C A-Imperial Subduer @Zara Alfonso
+A131 C A-Akki Ronin @Olivier Bernard
+A156 C A-Peerless Samurai @Micah Epstein
+A215 U A-Asari Captain @Donato Giancola
+A232 R A-Raiyuu, Storm's Edge @Heonhwa Choe
+
 [lands]
 1 Plains|NEO|1
 1 Plains|NEO|2


### PR DESCRIPTION
It seems the original Mischievous Catgeist // Catlike Curiosity didn't match the card so updated that too.

Source: https://mtgarena-support.wizards.com/hc/en-us/articles/12438205894164-Patch-Notes-2022-22-50

- [x] Akki Ronin
- [x] Ancestral Katana
- [x] Asari Captain
- [x] Binding Geist // Spectral Binding
- [x] Brine Comber // Brinebound Gift
- [x] Devoted Grafkeeper // Departed Soulkeeper
- [x] Dorothea, Vengeful Victim // Dorothea's Retribution
- [x] Dreamshackle Geist
- [x] Eiganjo Exemplar
- [x] Goblin Trapfinder
- [x] Gutter Skulker // Gutter Shortcut
- [x] Imperial Blademaster
- [x] Imperial Subduer
- [x] Lantern Bearer // Lanterns' Lift
- [x] Mischievous Catgeist // Catlike Curiosity
- [x] Obsessive Collector
- [x] Patrician Geist
- [x] Peerless Samurai
- [x] Phantom Carriage
- [x] Raiyuu, Storm's Edge
- [x] Shipwreck Sifters