### PR TITLE
Adventure shop spawn correction

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/stage/MapStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/MapStage.java
@@ -599,20 +599,25 @@ public class MapStage extends GameStage {
                             restockPrice = 0;
                         }
 
-                        possibleShops = new Array<>(shopList.split(","));
-                        Array<String> filteredPossibleShops = possibleShops;
-                        if (!isRotatingShop)
-                            filteredPossibleShops.removeAll(shopsAlreadyPresent, false);
-                        if (filteredPossibleShops.notEmpty()){
-                            possibleShops = filteredPossibleShops;
+                        possibleShops = new Array<String>(shopList.split(","));
+                        Array<String> filteredPossibleShops = new Array<>();
+                        if (!isRotatingShop){
+                            for (String candidate : possibleShops)
+                            {
+                                if (!shopsAlreadyPresent.contains(candidate, false))
+                                    filteredPossibleShops.add(candidate);
+                            }
+                        }
+                        if (filteredPossibleShops.isEmpty()){
+                            filteredPossibleShops = possibleShops;
                         }
                         Array<ShopData> shops;
-                        if (possibleShops.size == 0 || shopList.equals(""))
+                        if (filteredPossibleShops.size == 0 || shopList.equals(""))
                             shops = WorldData.getShopList();
                         else {
                             shops = new Array<>();
                             for (ShopData data : new Array.ArrayIterator<>(WorldData.getShopList())) {
-                                if (possibleShops.contains(data.name, false)) {
+                                if (filteredPossibleShops.contains(data.name, false)) {
                                     data.restockPrice = restockPrice;
                                     shops.add(data);
                                 }


### PR DESCRIPTION
Previous code that was put in place to prevent duplicate shops from spawning if another option of that rarity was available was flawed due to shallow copy of possibleShops into filteredPossibleShops. Intention is to spawn all shops of given rarity at least once before spawning any duplicates, but still spawn from that list. With a shallow copy, the fallback option of possibleShops was also getting updated during the filtering of filteredPossibleShops. This caused potential duplicates to be replaced by ANY shop, regardless of biome or rarity.