### PR TITLE
ReplacementHandler: guard against StackOverflow if LKI gets used for Moved

### DIFF
--- a/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
@@ -200,7 +200,7 @@ public class ReplacementHandler {
                         }
                     }
 
-                    if (!replacementEffect.hasRun()
+                    if (!replacementEffect.hasRun() && !hasRun.contains(replacementEffect)
                             && (layer == null || replacementEffect.getLayer() == layer)
                             && event.equals(replacementEffect.getMode())
                             && !possibleReplacers.contains(replacementEffect)


### PR DESCRIPTION
There's a small risk that when it takes the RE from LKI another effect calls copyLastState after, in that case it will recreate it from the original and the `hasRun()` will be false again.
Now (if the RE could apply again) it will loop.

This would only affect scenarios where a full replacement is needed, luckily most are already done with Updated result.