### PR TITLE
Flashback: use castKeyword

### DIFF
--- a/forge-ai/src/main/java/forge/ai/simulation/GameCopier.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameCopier.java
@@ -356,7 +356,7 @@ public class GameCopier {
 
             newCard.setChangedCardTypes(c.getChangedCardTypesTable());
             newCard.setChangedCardTypesCharacterDefining(c.getChangedCardTypesCharacterDefiningTable());
-            newCard.setChangedCardKeywords(c.getChangedCardKeywords(), true);
+            newCard.setChangedCardKeywords(c.getChangedCardKeywords());
             newCard.setChangedCardNames(c.getChangedCardNames());
 
             for (Table.Cell<Long, Long, List<String>> kw : c.getHiddenExtrinsicKeywordsTable().cellSet()) {

--- a/forge-ai/src/main/java/forge/ai/simulation/GameCopier.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameCopier.java
@@ -356,7 +356,7 @@ public class GameCopier {
 
             newCard.setChangedCardTypes(c.getChangedCardTypesTable());
             newCard.setChangedCardTypesCharacterDefining(c.getChangedCardTypesCharacterDefiningTable());
-            newCard.setChangedCardKeywords(c.getChangedCardKeywords());
+            newCard.setChangedCardKeywords(c.getChangedCardKeywords(), true);
             newCard.setChangedCardNames(c.getChangedCardNames());
 
             for (Table.Cell<Long, Long, List<String>> kw : c.getHiddenExtrinsicKeywordsTable().cellSet()) {

--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -268,7 +268,7 @@ public class GameAction {
                 // when moving to stack, copy changed card information
                 copied.setChangedCardColors(c.getChangedCardColorsTable());
                 copied.setChangedCardColorsCharacterDefining(c.getChangedCardColorsCharacterDefiningTable());
-                copied.setChangedCardKeywords(c.getChangedCardKeywords());
+                copied.setChangedCardKeywords(c.getChangedCardKeywords(), false);
                 copied.setChangedCardTypes(c.getChangedCardTypesTable());
                 copied.setChangedCardTypesCharacterDefining(c.getChangedCardTypesCharacterDefiningTable());
                 copied.setChangedCardNames(c.getChangedCardNames());
@@ -622,7 +622,9 @@ public class GameAction {
         if (zoneTo.is(ZoneType.Stack) && cause != null && cause.isSpell() && !cause.isIntrinsic() && c.equals(cause.getHostCard())) {
             if (cause.getKeyword() != null) {
                 if (!copied.getKeywords().contains(cause.getKeyword())) {
-                    copied.addChangedCardKeywordsInternal(ImmutableList.of(cause.getKeyword()), null, false, game.getTimestamp(), 0, false);
+                    copied.addChangedCardKeywordsInternal(ImmutableList.of(cause.getKeyword()), null, false, game.getNextTimestamp(), 0, false);
+                    // update Keyword Cache
+                    copied.updateKeywords();
                 }
             }
         }

--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -273,11 +273,13 @@ public class GameAction {
                 copied.setExiledBy(c.getExiledBy());
                 copied.setDrawnThisTurn(c.getDrawnThisTurn());
 
-                // copy bestow timestamp
-                copied.setBestowTimestamp(c.getBestowTimestamp());
 
                 if (cause != null && cause.isSpell() && c.equals(cause.getHostCard())) {
                     copied.setCastSA(cause);
+                    copied.setSplitStateToPlayAbility(cause);
+
+                    // CR 112.2 A spell’s controller is, by default, the player who put it on the stack.
+                    copied.setController(cause.getActivatingPlayer(), 0);
                     KeywordInterface kw = cause.getKeyword();
                     if (kw != null) {
                         copied.addKeywordForStaticAbility(kw);
@@ -864,17 +866,7 @@ public class GameAction {
         return moveToStack(c, cause, params);
     }
     public final Card moveToStack(final Card c, SpellAbility cause, Map<AbilityKey, Object> params) {
-        Card result = moveTo(game.getStackZone(), c, cause, params);
-        if (cause != null && cause.isSpell() && result.equals(cause.getHostCard())) {
-            result.setSplitStateToPlayAbility(cause);
-
-            // CR 112.2 A spell’s controller is, by default, the player who put it on the stack.
-            result.setController(cause.getActivatingPlayer(), 0);
-            // for triggers like from Wild-Magic Sorcerer
-            game.getAction().checkStaticAbilities(false);
-            game.getTriggerHandler().resetActiveTriggers();
-        }
-        return result;
+        return moveTo(game.getStackZone(), c, cause, params);
     }
 
     public final Card moveToGraveyard(final Card c, SpellAbility cause) {

--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -265,25 +265,13 @@ public class GameAction {
             copied.setTimestamp(c.getTimestamp());
 
             if (zoneTo.is(ZoneType.Stack)) {
-                // when moving to stack, copy changed card information
-                copied.setChangedCardColors(c.getChangedCardColorsTable());
-                copied.setChangedCardColorsCharacterDefining(c.getChangedCardColorsCharacterDefiningTable());
-                copied.setChangedCardKeywords(c.getChangedCardKeywords(), false);
-                copied.setChangedCardTypes(c.getChangedCardTypesTable());
-                copied.setChangedCardTypesCharacterDefining(c.getChangedCardTypesCharacterDefiningTable());
-                copied.setChangedCardNames(c.getChangedCardNames());
-                copied.setChangedCardTraits(c.getChangedCardTraits());
-                copied.setDrawnThisTurn(c.getDrawnThisTurn());
-
-                copied.copyChangedTextFrom(c);
-
-                // clean up changes that come from its own static abilities
-                copied.cleanupCopiedChangesFrom(c);
+                // try not to copy changed stats when moving to stack
 
                 // copy exiled properties when adding to stack
                 // will be cleanup later in MagicStack
                 copied.setExiledWith(c.getExiledWith());
                 copied.setExiledBy(c.getExiledBy());
+                copied.setDrawnThisTurn(c.getDrawnThisTurn());
 
                 // copy bestow timestamp
                 copied.setBestowTimestamp(c.getBestowTimestamp());

--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -619,7 +619,7 @@ public class GameAction {
         checkStaticAbilities();
 
         // 400.7g try adding keyword back into card if it doesn't already have it
-        if (zoneTo.is(ZoneType.Stack) && cause != null && cause.isSpell() && c.equals(cause.getHostCard())) {
+        if (zoneTo.is(ZoneType.Stack) && cause != null && cause.isSpell() && !cause.isIntrinsic() && c.equals(cause.getHostCard())) {
             if (cause.getKeyword() != null) {
                 if (!copied.getKeywords().contains(cause.getKeyword())) {
                     copied.addChangedCardKeywordsInternal(ImmutableList.of(cause.getKeyword()), null, false, game.getTimestamp(), 0, false);

--- a/forge-game/src/main/java/forge/game/GameActionUtil.java
+++ b/forge-game/src/main/java/forge/game/GameActionUtil.java
@@ -224,6 +224,7 @@ public final class GameActionUtil {
 
                         newSA.setAlternativeCost(AlternativeCost.Escape);
                         newSA.getRestrictions().setZone(ZoneType.Graveyard);
+                        newSA.setIntrinsic(inst.isIntrinsic());
 
                         alternatives.add(newSA);
                     } else if (keyword.startsWith("Flashback")) {
@@ -255,6 +256,7 @@ public final class GameActionUtil {
                         flashback.setAlternativeCost(AlternativeCost.Flashback);
                         flashback.getRestrictions().setZone(ZoneType.Graveyard);
                         flashback.setKeyword(inst);
+                        flashback.setIntrinsic(inst.isIntrinsic());
                         alternatives.add(flashback);
                     } else if (keyword.startsWith("Foretell")) {
                         // Foretell cast only from Exile

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -20,6 +20,7 @@ package forge.game.card;
 import com.esotericsoftware.minlog.Log;
 import com.google.common.base.Predicates;
 import com.google.common.collect.*;
+
 import forge.GameCommand;
 import forge.StaticData;
 import forge.card.*;
@@ -4584,6 +4585,17 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
     public final void addKeywordForStaticAbility(KeywordInterface kw) {
         if (kw.getStaticId() > 0) {
             storedKeywords.put(kw.getStaticId(), kw.getOriginal(), kw);
+        }
+    }
+
+    public Table<Long, String, KeywordInterface> getStoredKeywords() {
+        return storedKeywords;
+    }
+
+    public void setStoredKeywords(Table<Long, String, KeywordInterface> table, boolean lki) {
+        storedKeywords.clear();
+        for (Table.Cell<Long, String, KeywordInterface> c : table.cellSet()) {
+            storedKeywords.put(c.getRowKey(), c.getColumnKey(), c.getValue().copy(this, lki));
         }
     }
 

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -6876,19 +6876,10 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
         this.changedCardTypesCharacterDefining.putAll(changedCardTypes);
     }
 
-    public void setChangedCardKeywords(Table<Long, Long, KeywordsChange> changedCardKeywords, boolean copy) {
+    public void setChangedCardKeywords(Table<Long, Long, KeywordsChange> changedCardKeywords) {
         this.changedCardKeywords.clear();
         for (Table.Cell<Long, Long, KeywordsChange> entry : changedCardKeywords.cellSet()) {
-            KeywordsChange result = entry.getValue();
-            if (copy) {
-                result = result.copy(this, true);
-            } else {
-                // do not copy the keywords, just update the host
-                for (KeywordInterface k : result.getKeywords()) {
-                    k.setHostCard(this);
-                }
-            }
-            this.changedCardKeywords.put(entry.getRowKey(), entry.getColumnKey(), result);
+            this.changedCardKeywords.put(entry.getRowKey(), entry.getColumnKey(), entry.getValue().copy(this, true));
         }
     }
 

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -6876,10 +6876,19 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
         this.changedCardTypesCharacterDefining.putAll(changedCardTypes);
     }
 
-    public void setChangedCardKeywords(Table<Long, Long, KeywordsChange> changedCardKeywords) {
+    public void setChangedCardKeywords(Table<Long, Long, KeywordsChange> changedCardKeywords, boolean copy) {
         this.changedCardKeywords.clear();
         for (Table.Cell<Long, Long, KeywordsChange> entry : changedCardKeywords.cellSet()) {
-            this.changedCardKeywords.put(entry.getRowKey(), entry.getColumnKey(), entry.getValue().copy(this, true));
+            KeywordsChange result = entry.getValue();
+            if (copy) {
+                result = result.copy(this, true);
+            } else {
+                // do not copy the keywords, just update the host
+                for (KeywordInterface k : result.getKeywords()) {
+                    k.setHostCard(this);
+                }
+            }
+            this.changedCardKeywords.put(entry.getRowKey(), entry.getColumnKey(), result);
         }
     }
 

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -2285,7 +2285,7 @@ public class CardFactoryUtil {
         } else if (keyword.startsWith("Flashback")) {
             StringBuilder sb = new StringBuilder();
             sb.append("Event$ Moved | ValidCard$ Card.Self | Origin$ Stack | ExcludeDestination$ Exile ");
-            sb.append("| ValidStackSa$ Spell.Flashback | Description$ Flashback");
+            sb.append("| ValidStackSa$ Spell.Flashback+castKeyword | Description$ Flashback");
 
             if (keyword.contains(":")) { // K:Flashback:Cost:ExtraParams:ExtraDescription
                 final String[] k = keyword.split(":");

--- a/forge-game/src/main/java/forge/game/card/CardUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardUtil.java
@@ -293,6 +293,8 @@ public final class CardUtil {
         newCopy.setChangedCardNames(in.getChangedCardNames());
         newCopy.setChangedCardTraits(in.getChangedCardTraits());
 
+        newCopy.setStoredKeywords(in.getStoredKeywords(), true);
+
         newCopy.copyChangedTextFrom(in);
 
         newCopy.setTimestamp(in.getTimestamp());

--- a/forge-game/src/main/java/forge/game/card/CardUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardUtil.java
@@ -287,7 +287,7 @@ public final class CardUtil {
 
         newCopy.setChangedCardColors(in.getChangedCardColorsTable());
         newCopy.setChangedCardColorsCharacterDefining(in.getChangedCardColorsCharacterDefiningTable());
-        newCopy.setChangedCardKeywords(in.getChangedCardKeywords(), true);
+        newCopy.setChangedCardKeywords(in.getChangedCardKeywords());
         newCopy.setChangedCardTypes(in.getChangedCardTypesTable());
         newCopy.setChangedCardTypesCharacterDefining(in.getChangedCardTypesCharacterDefiningTable());
         newCopy.setChangedCardNames(in.getChangedCardNames());

--- a/forge-game/src/main/java/forge/game/card/CardUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardUtil.java
@@ -287,7 +287,7 @@ public final class CardUtil {
 
         newCopy.setChangedCardColors(in.getChangedCardColorsTable());
         newCopy.setChangedCardColorsCharacterDefining(in.getChangedCardColorsCharacterDefiningTable());
-        newCopy.setChangedCardKeywords(in.getChangedCardKeywords());
+        newCopy.setChangedCardKeywords(in.getChangedCardKeywords(), true);
         newCopy.setChangedCardTypes(in.getChangedCardTypesTable());
         newCopy.setChangedCardTypesCharacterDefining(in.getChangedCardTypesCharacterDefiningTable());
         newCopy.setChangedCardNames(in.getChangedCardNames());

--- a/forge-game/src/main/java/forge/game/keyword/KeywordInstance.java
+++ b/forge-game/src/main/java/forge/game/keyword/KeywordInstance.java
@@ -20,6 +20,9 @@ import io.sentry.Breadcrumb;
 import io.sentry.Sentry;
 
 public abstract class KeywordInstance<T extends KeywordInstance<?>> implements KeywordInterface {
+    private Card hostCard = null;
+    private boolean intrinsic = false;
+
     private Keyword keyword;
     private String original;
     private long staticId = 0;
@@ -87,6 +90,8 @@ public abstract class KeywordInstance<T extends KeywordInstance<?>> implements K
      * @see forge.game.keyword.KeywordInterface#createTraits(forge.game.card.Card, boolean, boolean)
      */
     public final void createTraits(final Card host, final boolean intrinsic, final boolean clear) {
+        this.hostCard = host;
+        this.intrinsic = intrinsic;
         if (clear) {
             triggers.clear();
             replacements.clear();
@@ -249,7 +254,7 @@ public abstract class KeywordInstance<T extends KeywordInstance<?>> implements K
     public KeywordInterface copy(final Card host, final boolean lki) {
         try {
             KeywordInstance<?> result = (KeywordInstance<?>) super.clone();
-
+            result.hostCard = host;
             result.abilities = Lists.newArrayList();
             for (SpellAbility sa : this.abilities) {
                 SpellAbility copy = sa.copy(host, lki);
@@ -300,11 +305,17 @@ public abstract class KeywordInstance<T extends KeywordInstance<?>> implements K
         return !list.isEmpty() && keyword.isMultipleRedundant;
     }
 
+    @Override
+    public Card getHostCard() {
+        return hostCard;
+    }
+
     /* (non-Javadoc)
      * @see forge.game.keyword.KeywordInterface#setHostCard(forge.game.card.Card)
      */
     @Override
     public void setHostCard(Card host) {
+        this.hostCard = host;
         for (SpellAbility sa : this.abilities) {
             sa.setHostCard(host);
         }
@@ -323,7 +334,13 @@ public abstract class KeywordInstance<T extends KeywordInstance<?>> implements K
     }
 
     @Override
+    public boolean isIntrinsic() {
+        return intrinsic;
+    }
+
+    @Override
     public void setIntrinsic(final boolean value) {
+        this.intrinsic = value;
         for (SpellAbility sa : this.abilities) {
             sa.setIntrinsic(value);
         }

--- a/forge-game/src/main/java/forge/game/keyword/KeywordInterface.java
+++ b/forge-game/src/main/java/forge/game/keyword/KeywordInterface.java
@@ -11,6 +11,11 @@ import forge.game.trigger.Trigger;
 
 public interface KeywordInterface extends Cloneable {
 
+    Card getHostCard();
+    void setHostCard(final Card host);
+    boolean isIntrinsic();
+    void setIntrinsic(final boolean value);
+
     String getOriginal();
 
     Keyword getKeyword();
@@ -34,8 +39,6 @@ public interface KeywordInterface extends Cloneable {
     void addSpellAbility(final SpellAbility s);
     void addStaticAbility(final StaticAbility st);
 
-    void setHostCard(final Card host);
-    void setIntrinsic(final boolean value);
 
     /**
      * @return the triggers


### PR DESCRIPTION
This makes Flashback use castKeyword

meaning if a spell has multiple instances of the keyword, the Exile Replacement should only activate once

Also casting a card with Flashback doesn't add a second instance onto it if its intrinsic

Keyword instances now have HostCard and Intrinsic available (its mostly knowing when the SpellAbility is created in GameActionUtil for Split Cards)