### PR TITLE
Delayed triggers vs. phased out

### DIFF
--- a/forge-game/src/main/java/forge/game/trigger/TriggerHandler.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerHandler.java
@@ -394,7 +394,8 @@ public class TriggerHandler {
             return false; // Trigger removed by effect
         }
 
-        if (!regtrig.zonesCheck(game.getZoneOf(regtrig.getHostCard()))) {
+        // do not check delayed
+        if (regtrig.getSpawningAbility() == null && !regtrig.zonesCheck(game.getZoneOf(regtrig.getHostCard()))) {
             return false; // Host card isn't where it needs to be.
         }
 


### PR DESCRIPTION
This fixes phasing affecting delayed triggers.

E.g. activating _Angel of Condemnation_ first ability, then phasing him out would only let the return trigger fire after phase in again.