### PR TITLE
ReplacementHandler: fix adding CastSA Keyword again

### DIFF
--- a/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
@@ -173,6 +173,10 @@ public class ReplacementHandler {
                 }
                 // need to copy stored keywords from lki into real object to prevent the replacement effect from making new ones
                 affectedCard.setStoredKeywords(affectedLKI.getStoredKeywords(), true);
+                if (affectedCard.getCastSA() != null && affectedCard.getCastSA().getKeyword() != null) {
+                   // need to readd the CastSA Keyword into the Card
+                   affectedCard.addKeywordForStaticAbility(affectedCard.getCastSA().getKeyword());
+                }
                 runParams.put(AbilityKey.Affected, affectedCard);
                 runParams.put(AbilityKey.NewCard, CardUtil.getLKICopy(affectedLKI));
             }


### PR DESCRIPTION
Closes #2464

This should Fix Henzie giving Blitz without breaking Riot or other cards