### PR TITLE
Fixed puzzle PS_J221

### DIFF
--- a/forge-gui/res/puzzle/PS_J221.pzl
+++ b/forge-gui/res/puzzle/PS_J221.pzl
@@ -11,6 +11,6 @@ activeplayer=p0
 activephase=MAIN1
 p0life=20
 p0hand=Flicker of Fate;Wicked Wolf;Duskshell Crawler;Kami of Ancient Law;Goldnight Commander
-p0battlefield=Magnanimous Magistrate|Counters:REPRIEVE=5;Fierce Witchstalker;Alseid of Life's Bounty;Plains;Plains;Plains;Forest;Forest;Forest
+p0battlefield=Magnanimous Magistrate|Counters:REPR=5;Fierce Witchstalker;Alseid of Life's Bounty;Plains;Plains;Plains;Forest;Forest;Forest
 p1life=11
 p1battlefield=Mizzix, Replica Rider;Transcendent Envoy


### PR DESCRIPTION
Fixed the counters of Magnanimous Magistrate from REPRIEVE to REPR. Fix the cost of trigger ability of Magnanimous Magistrate can't be paid in this puzzle. 