### PR TITLE
Dross Skullbomb: Fix cost of activated ability

### DIFF
--- a/forge-gui/res/cardsfolder/d/dross_skullbomb.txt
+++ b/forge-gui/res/cardsfolder/d/dross_skullbomb.txt
@@ -2,7 +2,7 @@ Name:Dross Skullbomb
 ManaCost:1
 Types:Artifact
 A:AB$ Draw | Cost$ 1 Sac<1/CARDNAME> | SpellDescription$ Draw a card.
-A:AB$ ChangeZone | Cost$ 1 B Sac<1/CARDNAME> | Origin$ Graveyard | Destination$ Hand | TgtPrompt$ Select target creature card in your graveyard | ValidTgts$ Creature.YouCtrl | SorcerySpeed$ True | SubAbility$ DBDraw | SpellDescription$ Return target creature card from your graveyard to your hand. Draw a card. Activate only as a sorcery.
+A:AB$ ChangeZone | Cost$ 2 B Sac<1/CARDNAME> | Origin$ Graveyard | Destination$ Hand | TgtPrompt$ Select target creature card in your graveyard | ValidTgts$ Creature.YouCtrl | SorcerySpeed$ True | SubAbility$ DBDraw | SpellDescription$ Return target creature card from your graveyard to your hand. Draw a card. Activate only as a sorcery.
 SVar:DBDraw:DB$ Draw
 DeckNeeds:Color$Black
 DeckHas:Ability$Sacrifice|Graveyard


### PR DESCRIPTION
Activation cost was 1 B instead of 2 B.