### PR TITLE
update RewardActor, SpellSmithScene, InventoryScene

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/scene/InventoryScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/InventoryScene.java
@@ -230,6 +230,7 @@ public class InventoryScene  extends UIScene {
             }
         }
         itemDescription.setText(data.name+"\n"+data.getDescription());
+        itemDescription.layout();
 
 
     }

--- a/forge-gui-mobile/src/forge/adventure/scene/SpellSmithScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/SpellSmithScene.java
@@ -358,7 +358,7 @@ public class SpellSmithScene extends UIScene {
         if (cost_low > -1) totalCost *= 2.5f; //And CMC cost multiplier.
 
         cardPool = StreamSupport.stream(P.spliterator(), false).collect(Collectors.toList());
-        poolSize.setText(((cardPool.size() > 0 ? "[FOREST]" : "[RED]")) + cardPool.size() + " possible card" + (cardPool.size() != 1 ? "s" : ""));
+        poolSize.setText(((cardPool.size() > 0 ? "[/][FOREST]" : "[/][RED]")) + cardPool.size() + " possible card" + (cardPool.size() != 1 ? "s" : ""));
         currentPrice = (int) totalCost;
         currentShardPrice = (int) (totalCost * 0.2f); //Intentionally rounding up via the cast to int
         pullUsingGold.setText("Pull: " + currentPrice + "[+gold]");

--- a/forge-gui-mobile/src/forge/adventure/util/Controls.java
+++ b/forge-gui-mobile/src/forge/adventure/util/Controls.java
@@ -447,7 +447,7 @@ public class Controls {
             }
             else {
                 currencyAmount = Current.player().getGold();
-                currencyIcon = "[+Gold]";
+                currencyIcon = "[+Gold] "; //fix space since gold sprite is wider than a single glyph
                 Current.player().onGoldChange(() -> update(AdventurePlayer.current().getGold(),true));
             }
             label.setText(getLabelText(currencyAmount));

--- a/forge-gui-mobile/src/forge/adventure/util/RewardActor.java
+++ b/forge-gui-mobile/src/forge/adventure/util/RewardActor.java
@@ -254,7 +254,7 @@ public class RewardActor extends Actor implements Disposable, ImageFetcher.Callb
                         fetcher.fetchImage(reward.getCard().getImageKey(false), this);
                         if (reward.getCard().hasBackFace()) {
                             if (!ImageCache.imageKeyFileExists(reward.getCard().getImageKey(true))) {
-                                fetcher.fetchImage(reward.getCard().getImageKey(true), this);
+                                fetcher.fetchImage(reward.getCard().getImageKey(true), null);
                             }
                         }
                     }

--- a/forge-gui-mobile/src/forge/adventure/world/BiomeTexture.java
+++ b/forge-gui-mobile/src/forge/adventure/world/BiomeTexture.java
@@ -121,6 +121,16 @@ public class BiomeTexture implements Serializable {
                     ArrayList<Pixmap> spics = new ArrayList<>();
                     if(!region.getTexture().getTextureData().isPrepared())
                         region.getTexture().getTextureData().prepare();
+                    //try to fix bleeding...
+                    float fix = 0.01f;
+                    float rx = region.getRegionX();
+                    float ry = region.getRegionY();
+                    float rwidth = region.getRegionWidth();
+                    float rheight = region.getRegionHeight();
+                    float invTexWidth = 1f / region.getTexture().getWidth();
+                    float invTexHeight = 1f / region.getTexture().getHeight();
+                    region.setRegion((rx + fix) * invTexWidth, (ry + fix) * invTexHeight, (rx + rwidth - fix) * invTexWidth, (ry + rheight - fix) * invTexHeight); // Trims Region
+                    //
                     Pixmap completePicture = region.getTexture().getTextureData().consumePixmap();
                     for (int y = 0; y < 4; y++) {
                         for (int x = 0; x < 3; x++) {

--- a/forge-gui-mobile/src/forge/adventure/world/World.java
+++ b/forge-gui-mobile/src/forge/adventure/world/World.java
@@ -805,6 +805,16 @@ public class World implements Disposable, SaveFileContent {
         {
             TextureAtlas atlas=Config.instance().getAtlas(tilesetName);
             TextureAtlas.AtlasRegion region=atlas.findRegion(tileSetNameWithIndex);
+            //try to fix bleeding...
+            float fix = 0.01f;
+            float rx = region.getRegionX();
+            float ry = region.getRegionY();
+            float rwidth = region.getRegionWidth();
+            float rheight = region.getRegionHeight();
+            float invTexWidth = 1f / region.getTexture().getWidth();
+            float invTexHeight = 1f / region.getTexture().getHeight();
+            region.setRegion((rx + fix) * invTexWidth, (ry + fix) * invTexHeight, (rx + rwidth - fix) * invTexWidth, (ry + rheight - fix) * invTexHeight); // Trims Region
+            //
             int tileSize=data.tileSize;
             Pixmap smallPixmap=new Pixmap(data.miniMapTileSize,data.miniMapTileSize, Pixmap.Format.RGBA8888);
             smallPixmap.setColor(0,0,0,0);

--- a/forge-gui/res/adventure/Shandalar/ui/spellsmith.json
+++ b/forge-gui/res/adventure/Shandalar/ui/spellsmith.json
@@ -181,7 +181,7 @@
     {
       "type": "Label",
       "name": "colorLabel",
-      "text": "tr(lblColors)", 
+      "text": "[/][BLACK]tr(lblColors)",
       "x": 10,
       "y": 90,
       "width": 100,
@@ -190,7 +190,7 @@
     {
       "type": "Label",
       "name": "vnXYKZJw_P5wMnHa1tH7-3",
-      "text": "tr(lblPlane)", 
+      "text": "[/][BLACK]tr(lblPlane)",
       "x": 10,
       "y": 30,
       "width": 100,
@@ -209,7 +209,7 @@
     {
       "type": "Label",
       "name": "vnXYKZJw_P5wMnHa1tH7-5",
-      "text": "tr(lblManaCost)",  
+      "text": "[/][BLACK]tr(lblManaCost)",
       "x": 10,
       "y": 150,
       "width": 100,
@@ -258,7 +258,7 @@
     {
       "type": "Label",
       "name": "vnXYKZJw_P5wMnHa1tH7-10", 
-      "text": "tr(lblRarity)",  
+      "text": "[/][BLACK]tr(lblRarity)",
       "x": 10,
       "y": 210,
       "width": 100,

--- a/forge-gui/res/adventure/Shandalar/ui/spellsmith_portrait.json
+++ b/forge-gui/res/adventure/Shandalar/ui/spellsmith_portrait.json
@@ -189,7 +189,7 @@
     {
       "type": "Label",
       "name": "colorLabel",
-      "text": "tr(lblColors)", 
+      "text": "[/][BLACK]tr(lblColors)",
       "x": 10,
       "y": 260,
       "width": 100,
@@ -198,7 +198,7 @@
     {
       "type": "Label",
       "name": "vnXYKZJw_P5wMnHa1tH7-3",
-      "text": "tr(lblPlane)", 
+      "text": "[/][BLACK]tr(lblPlane)",
       "x": 10,
       "y": 190,
       "width": 100,
@@ -217,7 +217,7 @@
     {
       "type": "Label",
       "name": "vnXYKZJw_P5wMnHa1tH7-5",
-      "text": "tr(lblManaCost)",  
+      "text": "[/][BLACK]tr(lblManaCost)",
       "x": 10,
       "y": 360,
       "width": 100,
@@ -266,7 +266,7 @@
     {
       "type": "Label",
       "name": "vnXYKZJw_P5wMnHa1tH7-10",
-      "text": "tr(lblRarity)",  
+      "text": "[/][BLACK]tr(lblRarity)",
       "x": 10,
       "y": 427,
       "width": 100,

--- a/forge-gui/src/main/java/forge/util/ImageFetcher.java
+++ b/forge-gui/src/main/java/forge/util/ImageFetcher.java
@@ -253,7 +253,8 @@ public abstract class ImageFetcher {
             FThreads.assertExecutedByEdt(true);
 
             for (Callback o : currentFetches.get(destPath)) {
-                o.onImageFetched();
+                if (o != null)
+                    o.onImageFetched();
             }
             currentFetches.remove(destPath);
         };


### PR DESCRIPTION
- silently download back image along with the front image. fixes #2551
- update SpellSmithScene label
- add an expiremental fix for texture bleeding. some weird/tall aspect ratio will still produce some bleeding.