### PR TITLE
Fix static trigger messing up LTB trigger

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
@@ -1378,7 +1378,7 @@ public class AbilityUtils {
         Player pl = sa.getActivatingPlayer();
         final Game game = pl.getGame();
 
-        if (sa.isTrigger() && sa.getParent() == null) {
+        if (sa.isTrigger() && !sa.getTrigger().isStatic() && sa.getParent() == null) {
             // when trigger cost are paid before the effect does resolve, need to clean the trigger
             game.getTriggerHandler().resetActiveTriggers();
         }

--- a/forge-game/src/main/java/forge/game/ability/effects/AnimateEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/AnimateEffect.java
@@ -207,7 +207,7 @@ public class AnimateEffect extends AnimateEffectBase {
         if (sa.hasParam("AtEOT") && !tgts.isEmpty()) {
             registerDelayedTrigger(sa, sa.getParam("AtEOT"), tgts);
         }
-    } // animateResolve extends SpellEffect {
+    }
 
     /* (non-Javadoc)
      * @see forge.card.abilityfactory.SpellEffect#getStackDescription(java.util.Map, forge.card.spellability.SpellAbility)

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -2564,7 +2564,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
                     continue;
                 }
                 for (final StaticAbility stAb : ca.getStaticAbilities()) {
-                    if (stAb.isSuppressed() || !stAb.checkConditions()) {
+                    if (!stAb.checkConditions()) {
                         continue;
                     }
 

--- a/forge-game/src/main/java/forge/game/cost/CostAdjustment.java
+++ b/forge-game/src/main/java/forge/game/cost/CostAdjustment.java
@@ -430,7 +430,7 @@ public class CostAdjustment {
     }    
 
     private static boolean checkRequirement(final SpellAbility sa, final StaticAbility st) {
-        if (st.isSuppressed() || !st.checkConditions()) {
+        if (!st.checkConditions()) {
             return false;
         }
 

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
@@ -1752,7 +1752,7 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
     }
 
     public boolean isZeroTargets() {
-        return getMinTargets() == 0 && getTargets().size() == 0;
+        return getMinTargets() == 0 && getTargets().isEmpty();
     }
 
     public boolean isMinTargetChosen() {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8506892/222907145-563b04a3-3c54-4604-bb3d-33fbb2aa89cf.png)

- SBA for lethal damage -> ``runWaitingTriggers``
- the static trigger to remove the Effect card for the Dies RE would run
- LTB trigger would be lost

@Hanmac
here's the original commit:
https://github.com/Card-Forge/forge/commit/f990f1

even without knowing the full case I doubt you wanted to do it for static ones?