### PR TITLE
GameFormat: filter Rebalanced cards

### DIFF
--- a/forge-core/src/main/java/forge/StaticData.java
+++ b/forge-core/src/main/java/forge/StaticData.java
@@ -900,4 +900,17 @@ public class StaticData {
         this.enableSmartCardArtSelection = isEnabled;
     }
 
+    public boolean isRebalanced(String name)
+    {
+        if (!name.startsWith("A-")) {
+            return false;
+        }
+        for(PaperCard pc : this.getCommonCards().getAllCards(name)) {
+            CardEdition e = this.editions.get(pc.getEdition());
+            if (e != null && e.isRebalanced(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/forge-core/src/main/java/forge/card/CardEdition.java
+++ b/forge-core/src/main/java/forge/card/CardEdition.java
@@ -375,7 +375,8 @@ public final class CardEdition implements Comparable<CardEdition> {
     public String getSheetReplaceCardFromSheet2() { return sheetReplaceCardFromSheet2; }
     public String[] getChaosDraftThemes() { return chaosDraftThemes; }
 
-    public List<CardInSet> getCards() { return cardMap.get("cards"); }
+    public List<CardInSet> getCards() { return cardMap.get(EditionSectionWithCollectorNumbers.CARDS.getName()); }
+    public List<CardInSet> getRebalancedCards() { return cardMap.get(EditionSectionWithCollectorNumbers.REBALANCED.getName()); }
     public List<CardInSet> getAllCardsInSet() {
         return cardsInSet;
     }
@@ -399,6 +400,15 @@ public final class CardEdition implements Comparable<CardEdition> {
             }
         }
         return this.cardsInSetLookupMap.get(cardName);
+    }
+
+    public boolean isRebalanced(String cardName) {
+        for (CardInSet cis : getRebalancedCards()) {
+            if (cis.name.equals(cardName)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public boolean isModern() { return getDate().after(parseDate("2003-07-27")); } //8ED and above are modern except some promo cards and others
@@ -899,7 +909,7 @@ public final class CardEdition implements Comparable<CardEdition> {
                         }
                     }));
             Iterator<CardEdition> editionsIterator = editionsWithBasicLands.iterator();
-            List<CardEdition> selectedEditions = new ArrayList();
+            List<CardEdition> selectedEditions = new ArrayList<CardEdition>();
             while (editionsIterator.hasNext())
                 selectedEditions.add(editionsIterator.next());
             if (selectedEditions.isEmpty())

--- a/forge-core/src/main/java/forge/item/IPaperCard.java
+++ b/forge-core/src/main/java/forge/item/IPaperCard.java
@@ -223,6 +223,19 @@ public interface IPaperCard extends InventoryItem, Serializable {
             public static final Predicate<PaperCard> IS_WHITE = Predicates.color(true, false, MagicColor.WHITE);
             public static final Predicate<PaperCard> IS_COLORLESS = Predicates.color(true, true, MagicColor.COLORLESS);
 
+            public static final Predicate<PaperCard> IS_UNREBALANCED = new Predicate<PaperCard>() {
+                @Override
+                public boolean apply(PaperCard input) {
+                    return input.isUnRebalanced();
+                }
+            };
+            public static final Predicate<PaperCard> IS_REBALANCED = new Predicate<PaperCard>() {
+
+                @Override
+                public boolean apply(PaperCard input) {
+                    return input.isRebalanced();
+                }
+            };
         }
     }
 
@@ -246,4 +259,5 @@ public interface IPaperCard extends InventoryItem, Serializable {
     String getCardRSpecImageKey();
     String getCardGSpecImageKey();
 
+    public boolean isRebalanced();
 }

--- a/forge-core/src/main/java/forge/item/ItemPredicate.java
+++ b/forge-core/src/main/java/forge/item/ItemPredicate.java
@@ -51,7 +51,6 @@ public abstract class ItemPredicate {
      */
     public static class Presets {
         /** The Item IsPack. */
-        @SuppressWarnings("unchecked")
         public static final Predicate<InventoryItem> IS_PACK_OR_DECK = Predicates.or(IsBoosterPack, IsFatPack, IsTournamentPack, IsStarterDeck, IsPrebuiltDeck);
     }
 }

--- a/forge-core/src/main/java/forge/item/PaperCard.java
+++ b/forge-core/src/main/java/forge/item/PaperCard.java
@@ -419,23 +419,9 @@ public class PaperCard implements Comparable<IPaperCard>, InventoryItemFromSet, 
         return sortableName;
     }
     public boolean isUnRebalanced() {
-        if (this.getEdition() == null) {
-            return false;
-        }
-        CardEdition edition = StaticData.instance().getEditions().get(this.getEdition());
-        if (edition == null) {
-            return false;
-        }
-        return edition.isRebalanced("A-" + this.name);
+        return StaticData.instance().isRebalanced("A-" + name);
     }
     public boolean isRebalanced() {
-        if (this.getEdition() == null) {
-            return false;
-        }
-        CardEdition edition = StaticData.instance().getEditions().get(this.getEdition());
-        if (edition == null) {
-            return false;
-        }
-        return edition.isRebalanced(this.name);
+        return StaticData.instance().isRebalanced(name);
     }
 }

--- a/forge-core/src/main/java/forge/item/PaperCard.java
+++ b/forge-core/src/main/java/forge/item/PaperCard.java
@@ -418,4 +418,24 @@ public class PaperCard implements Comparable<IPaperCard>, InventoryItemFromSet, 
     public String getSortableName() {
         return sortableName;
     }
+    public boolean isUnRebalanced() {
+        if (this.getEdition() == null) {
+            return false;
+        }
+        CardEdition edition = StaticData.instance().getEditions().get(this.getEdition());
+        if (edition == null) {
+            return false;
+        }
+        return edition.isRebalanced("A-" + this.name);
+    }
+    public boolean isRebalanced() {
+        if (this.getEdition() == null) {
+            return false;
+        }
+        CardEdition edition = StaticData.instance().getEditions().get(this.getEdition());
+        if (edition == null) {
+            return false;
+        }
+        return edition.isRebalanced(this.name);
+    }
 }

--- a/forge-core/src/main/java/forge/item/PaperToken.java
+++ b/forge-core/src/main/java/forge/item/PaperToken.java
@@ -13,6 +13,7 @@ import forge.card.ColorSet;
 import forge.util.MyRandom;
 
 public class PaperToken implements InventoryItemFromSet, IPaperCard {
+    private static final long serialVersionUID = 1L;
     private String name;
     private CardEdition edition;
     private ArrayList<String> imageFileName = new ArrayList<>();
@@ -199,5 +200,8 @@ public class PaperToken implements InventoryItemFromSet, IPaperCard {
 
     public String getImageKey(int artIndex) {
         return ImageKeys.TOKEN_PREFIX + imageFileName.get(artIndex).replace(" ", "_");
+    }
+    public boolean isRebalanced() {
+        return false;
     }
 }

--- a/forge-game/src/main/java/forge/game/GameFormat.java
+++ b/forge-game/src/main/java/forge/game/GameFormat.java
@@ -139,6 +139,13 @@ public class GameFormat implements Comparable<GameFormat> {
     }
     protected Predicate<PaperCard> buildFilter(boolean printed) {
         Predicate<PaperCard> p = Predicates.not(IPaperCard.Predicates.names(this.getBannedCardNames()));
+
+        if (FormatSubType.ARENA.equals(this.getFormatSubType())) {
+            p = Predicates.and(p, Predicates.not(IPaperCard.Predicates.Presets.IS_UNREBALANCED));
+        } else {
+            p = Predicates.and(p, Predicates.not(IPaperCard.Predicates.Presets.IS_REBALANCED));
+        }
+
         if (!this.getAllowedSetCodes().isEmpty()) {
             p = Predicates.and(p, printed ?
                     IPaperCard.Predicates.printedInSets(this.getAllowedSetCodes(), printed) :


### PR DESCRIPTION
This makes "A-" cards not legal in other formats other Arena ones,
while also stopping the Replaced Cards being legal in Arena

I'm unsure about the naming, or if i should put a cache around the checks?

do we need to update any format files? or did we forget to ban the cards respectively?

Also we might need to update the LDA data? I mean it does slightly check for the format, but maybe not always?