### PR TITLE
Revert "update initial skin texture load"

### DIFF
--- a/forge-gui-mobile/src/forge/Forge.java
+++ b/forge-gui-mobile/src/forge/Forge.java
@@ -350,21 +350,12 @@ public class Forge implements ApplicationListener {
             FileHandle transitionFile = Config.instance().getFile("ui/transition.png");
             FileHandle titleBGFile = isLandscapeMode() ? Config.instance().getFile("ui/title_bg.png") : Config.instance().getFile("ui/title_bg_portrait.png");
             FileHandle vsIcon = Config.instance().getFile("ui/vs.png");
-            if (vsIcon.exists()) {
-                Texture old = getAssets().fallback_skins().put("vs", new Texture(vsIcon));
-                if (old != null)
-                    old.dispose();
-            }
-            if (transitionFile.exists()) {
-                Texture old = getAssets().fallback_skins().put("transition", new Texture(transitionFile));
-                if (old != null)
-                    old.dispose();
-            }
-            if (titleBGFile.exists()) {
-                Texture old = getAssets().fallback_skins().put("title", new Texture(titleBGFile));
-                if (old != null)
-                    old.dispose();
-            }
+            if (vsIcon.exists())
+                getAssets().fallback_skins().put("vs", new Texture(vsIcon));
+            if (transitionFile.exists())
+                getAssets().fallback_skins().put("transition", new Texture(transitionFile));
+            if (titleBGFile.exists())
+                getAssets().fallback_skins().put("title", new Texture(titleBGFile));
             AdventureScreen.preload();
         } catch (Exception e) {
             e.printStackTrace();

--- a/forge-gui-mobile/src/forge/assets/Assets.java
+++ b/forge-gui-mobile/src/forge/assets/Assets.java
@@ -1,6 +1,5 @@
 package forge.assets;
 
-import com.badlogic.gdx.Files.FileType;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.assets.AssetLoaderParameters;
 import com.badlogic.gdx.assets.AssetManager;
@@ -236,11 +235,12 @@ public class Assets implements Disposable {
             return getDummy();
         }
         //internal path can be inside apk or jar..
-        if (!FileType.Absolute.equals(file.type()) || file.path().contains("fallback_skin")) {
-            if (!fallback_skins().containsKey(file.path())) {
+        if (file.path().contains("fallback_skin")) {
+            Texture f = fallback_skins().get(file.path());
+            if (f == null) {
                 fallback_skins().put(file.path(), new Texture(file));
             }
-            return fallback_skins().get(file.path());
+            return f;
         }
         Texture t = manager.get(file.path(), Texture.class, false);
         if (t == null) {

--- a/forge-gui-mobile/src/forge/assets/FSkin.java
+++ b/forge-gui-mobile/src/forge/assets/FSkin.java
@@ -168,31 +168,39 @@ public class FSkin {
             }
 
             try {
-                int w=0, h=0;
-                Texture texF = Forge.getAssets().getTexture(f);
-                if (f2.exists()) {
-                    Texture texF2 = Forge.getAssets().getTexture(f2);
-                    w = texF2.getWidth();
-                    h = texF2.getHeight();
-                    splashScreen.setSplashTexture(new TextureRegion(texF2));
-                } else if (texF != null) {
-                    w = texF.getWidth();
-                    h = texF.getHeight();
-                    splashScreen.setSplashTexture(new TextureRegion(texF, 0, 0, w, h - 100));
+                int w, h;
+                if (f.path().contains("fallback_skin")) {
+                    //the file is not accesible by the assetmanager using absolute fileresolver since it resides on internal path or classpath
+                    Texture txSplash = new Texture(f);
+                    w = txSplash.getWidth();
+                    h = txSplash.getHeight();
+                    splashScreen.setSplashTexture(new TextureRegion(txSplash, 0, 0, w, h - 100));
+                } else {
+                    manager.load(f.path(), Texture.class);
+                    manager.finishLoadingAsset(f.path());
+                    w = manager.get(f.path(), Texture.class).getWidth();
+                    h = manager.get(f.path(), Texture.class).getHeight();
 
+                    if (f2.exists()) {
+                        manager.load(f2.path(), Texture.class, Forge.getAssets().getTextureFilter());
+                        manager.finishLoadingAsset(f2.path());
+                        splashScreen.setSplashTexture(new TextureRegion(manager.get(f2.path(), Texture.class)));
+                    } else {
+                        splashScreen.setSplashTexture(new TextureRegion(manager.get(f.path(), Texture.class), 0, 0, w, h - 100));
+                    }
                 }
                 Pixmap pxSplash = new Pixmap(f);
                 //override splashscreen startup
                 if (Forge.selector.equals("Adventure")) {
                     if (f3.exists()) {
-                        Texture advSplash = Forge.getAssets().getTexture(f3);
+                        Texture advSplash = new Texture(f3);
                         w = advSplash.getWidth();
                         h = advSplash.getHeight();
                         splashScreen.setSplashTexture(new TextureRegion(advSplash, 0, 0, w, h - 100));
                         pxSplash = new Pixmap(f3);
                     }
                     if (f4.exists()) {
-                        Texture advBG = Forge.getAssets().getTexture(f4);
+                        Texture advBG = new Texture(f4);
                         advBG.setWrap(Texture.TextureWrap.Repeat, Texture.TextureWrap.Repeat);
                         splashScreen.setSplashBGTexture(advBG);
                     }


### PR DESCRIPTION
- Reverts Card-Forge/forge#2657
- seems some devices needs skin texture directly to load if res is missing and fallbackskins are the only available