### PR TITLE
Maven: relocate platform-specific dependency

### DIFF
--- a/forge-adventure/pom.xml
+++ b/forge-adventure/pom.xml
@@ -19,13 +19,6 @@
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
-        <repository>
-        <id>4thline-repo</id>
-        <url>http://4thline.org/m2</url>
-        <snapshots>
-            <enabled>false</enabled>
-        </snapshots>
-    </repository>
     </repositories>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
@@ -273,16 +266,6 @@
         <dependency>
             <groupId>forge</groupId>
             <artifactId>forge-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>forge</groupId>
-            <artifactId>forge-game</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>forge</groupId>
-            <artifactId>forge-ai</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/forge-gui-desktop/pom.xml
+++ b/forge-gui-desktop/pom.xml
@@ -118,7 +118,7 @@
                         </goals>
                         <configuration>
                             <!-- TODO: insert placeholder for latest version tag -->
-                            <fromRef>forge-1.6.56</fromRef>
+                            <fromRef>forge-1.6.55</fromRef>
                             <file>../forge-gui/release-files/CHANGES.txt</file>
                             <templateContent>
 <![CDATA[

--- a/forge-gui-mobile/pom.xml
+++ b/forge-gui-mobile/pom.xml
@@ -74,6 +74,12 @@
             <artifactId>gdx-freetype</artifactId>
             <version>1.11.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.raeleus.TenPatch</groupId>
+            <artifactId>tenpatch</artifactId>
+            <version>5.2.3</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/forge-gui/pom.xml
+++ b/forge-gui/pom.xml
@@ -12,10 +12,6 @@
 
     <repositories>
         <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
-        <repository>
             <id>4thline-repo</id>
             <url>http://4thline.org/m2</url>
             <snapshots>
@@ -60,12 +56,6 @@
             <groupId>org.lz4</groupId>
             <artifactId>lz4-java</artifactId>
             <version>1.8.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.raeleus.TenPatch</groupId>
-            <artifactId>tenpatch</artifactId>
-            <version>5.2.3</version>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Now GDX will be excluded from Desktop JAR.