### PR TITLE
Anti-Cheat: fix refunding wrong mana

### DIFF
--- a/forge-game/src/main/java/forge/game/cost/CostExile.java
+++ b/forge-game/src/main/java/forge/game/cost/CostExile.java
@@ -101,10 +101,7 @@ public class CostExile extends CostPartWithList {
         }
 
         if (this.from.equals(ZoneType.Battlefield)) {
-            if (!this.payCostFromSource()) {
-                return String.format("Exile %s you control", Cost.convertAmountTypeToWords(i, this.getAmount(), desc));
-            }
-            return String.format("Exile %s", Cost.convertAmountTypeToWords(i, this.getAmount(), desc));
+            return String.format("Exile %s you control", Cost.convertAmountTypeToWords(i, this.getAmount(), desc));
         }
 
         if (!desc.equals("Card") && !desc.contains("card")) {

--- a/forge-game/src/main/java/forge/game/zone/MagicStack.java
+++ b/forge-game/src/main/java/forge/game/zone/MagicStack.java
@@ -199,12 +199,9 @@ public class MagicStack /* extends MyObservable */ implements Iterable<SpellAbil
         sa.undo();
         clearUndoStack(sa);
         sa.getActivatingPlayer().getManaPool().refundManaPaid(sa);
-        if (undoStack.isEmpty()) {
-            undoStackOwner = null;
-        }
         return true;
     }
-    private final void clearUndoStack(SpellAbility sa) {
+    public final void clearUndoStack(SpellAbility sa) {
         clearUndoStack(Lists.newArrayList(sa));
     }
     private final void clearUndoStack(List<SpellAbility> sas) {
@@ -212,6 +209,9 @@ public class MagicStack /* extends MyObservable */ implements Iterable<SpellAbil
             // reset in case a trigger stopped it on a previous activation
             sa.setUndoable(true);
             undoStack.remove(undoStack.lastIndexOf(sa));
+        }
+        if (undoStack.isEmpty()) {
+            undoStackOwner = null;
         }
     }
     public final void clearUndoStack() {

--- a/forge-gui/res/cardsfolder/upcoming/arek_false_goldwarden.txt
+++ b/forge-gui/res/cardsfolder/upcoming/arek_false_goldwarden.txt
@@ -5,7 +5,7 @@ PT:2/2
 K:Starting intensity:0
 T:Mode$ ChangesZone | ValidCard$ Creature.YouCtrl+Other | Origin$ Any | Destination$ Battlefield | TriggerZones$ Battlefield | Execute$ TrigIntensify | TriggerDescription$ Whenever another creature enters the battlefield under your control, perpetually increase the intensity of NICKNAME and all cards named Arek, False Goldwarden in your graveyard, hand and library by 1.
 SVar:TrigIntensify:DB$ Intensify | AllDefined$ Card.Self,Card.inZoneGraveyard+namedArek; False Goldwarden+YouOwn,Card.inZoneHand+namedArek; False Goldwarden+YouOwn,Card.inZoneLibrary+namedArek; False Goldwarden+YouOwn
-A:AB$ LoseLife | Cost$ 3 W B T Sac<1/NICKNAME> | LifeAmount$ X | SubAbility$ DBGainLife | SpellDescription$ Target opponent loses X life and you gain X life, where X is NICKNAME's Intensity.
+A:AB$ LoseLife | Cost$ 3 W B T Sac<1/NICKNAME> | ValidTgts$ Opponent | LifeAmount$ X | SubAbility$ DBGainLife | SpellDescription$ Target opponent loses X life and you gain X life, where X is NICKNAME's Intensity.
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ X 
 SVar:X:Count$Intensity
 DeckHas:Ability$LifeGain|Sacrifice


### PR DESCRIPTION
When undoing a mana ability it would remove the first matching mana from floating.

This meant if the generated mana had riders like _Pyromancer's Goggles_  and you had any other floating red mana with this trick you could Undo that many times to convert all into mana with the trigger.