### PR TITLE
Fix using old target from previous checks

### DIFF
--- a/forge-gui/res/cardsfolder/d/domris_ambush.txt
+++ b/forge-gui/res/cardsfolder/d/domris_ambush.txt
@@ -1,8 +1,8 @@
 Name:Domri's Ambush
 ManaCost:R G
 Types:Sorcery
-A:SP$ PutCounter | Cost$ R G | ValidTgts$ Creature.YouCtrl | CounterType$ P1P1 | TgtPrompt$ Select target creature you control to put a +1/+1 counter | SubAbility$ DBDamage | SpellDescription$ Put a +1/+1 counter on target creature you control. Then that creature deals damage equal to its power to target creature or planeswalker you don't control.
-SVar:DBDamage:DB$ DealDamage | ValidTgts$ Creature.YouDontCtrl,Planeswalker.YouDontCtrl | TgtPrompt$ Select target creature or planeswalker you don't control | NumDmg$ X | DamageSource$ ParentTarget | AILogic$ DamageAfterPutCounter
+A:SP$ PutCounter | Cost$ R G | ValidTgts$ Creature.YouCtrl | CounterType$ P1P1 | TgtPrompt$ Select target creature you control to put a +1/+1 counter | SubAbility$ DBDamage | AILogic$ PowerDmg | SpellDescription$ Put a +1/+1 counter on target creature you control. Then that creature deals damage equal to its power to target creature or planeswalker you don't control.
+SVar:DBDamage:DB$ DealDamage | ValidTgts$ Creature.YouDontCtrl,Planeswalker.YouDontCtrl | TgtPrompt$ Select target creature or planeswalker you don't control | NumDmg$ X | DamageSource$ ParentTarget | AILogic$ PowerDmg
 SVar:X:ParentTargeted$CardPower
 DeckHas:Ability$Counters
 Oracle:Put a +1/+1 counter on target creature you control. Then that creature deals damage equal to its power to target creature or planeswalker you don't control.


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/8506892/224670756-3d8c3372-83d3-42e8-aecc-4d2c59cdce79.png)

I think the conditional ``resetTargets`` is just too risky as shown by this case...

@Agetian

do you remember why you fixed it like that:

https://github.com/Card-Forge/forge/commit/0ca045

At that time "PowerDmg" was not supported by ``CountersPutAi`` but that is now taken care of, so during my tests this seems to be played correctly?


Also made path for _Crater's Claws_ work again.