### PR TITLE
Speed up London Mulligan when you just want to mulligan again.

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/match/input/InputLondonMulligan.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/input/InputLondonMulligan.java
@@ -60,7 +60,7 @@ public class InputLondonMulligan extends InputSyncronizedBase {
 
         StringBuilder sb = new StringBuilder();
 
-        getController().getGui().updateButtons(getOwner(), localizer.getMessage("lblOk"), "", cardsLeft == 0, false, true);
+        getController().getGui().updateButtons(getOwner(), localizer.getMessage("lblOk"), localizer.getMessage("lblAuto"), cardsLeft == 0, cardsLeft != 0, true);
 
         sb.append(String.format(localizer.getMessage("lblReturnForLondon"), cardsLeft));
 
@@ -77,6 +77,25 @@ public class InputLondonMulligan extends InputSyncronizedBase {
     protected final void onOk() {
         cardSelectLocked = true;
         done();
+    }
+
+    @Override
+    protected final void onCancel() {
+        int cardsLeft = toReturn - selected.size();
+        int count = 0;
+        for(Card c : player.getZone(ZoneType.Hand).getCards()) {
+            if (selected.contains(c)) { continue; }
+
+            selected.add(c);
+            setCardHighlight(c, selected.contains(c));
+            count++;
+
+            if (cardsLeft == count) {
+                break;
+            }
+        }
+
+        onOk();
     }
 
     private void done() {


### PR DESCRIPTION
Selext first N cards for London Mulligan. 

This does not automatically mulligan again, you need to click Auto to select N cards. 
Then click Mulligan to roll the next round of mulligans.