### PR TITLE
Formats: Fix Explorer and Arena Standard

### DIFF
--- a/forge-gui/res/formats/Archived/Arena Standard/2017-09-07.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2017-09-07.txt
@@ -1,6 +1,6 @@
 [format]
 Name:Arena Standard (2017-09-07)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2017-09-07
 Sets:XLN

--- a/forge-gui/res/formats/Archived/Arena Standard/2018-01-18.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2018-01-18.txt
@@ -1,6 +1,6 @@
 [format]
 Name:Arena Standard (RIX)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2018-01-18
 Sets:XLN, RIX

--- a/forge-gui/res/formats/Archived/Arena Standard/2018-03-22.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2018-03-22.txt
@@ -1,6 +1,6 @@
 [format]
 Name:Arena Standard (AKH/HOU)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2018-03-22
 Sets:XLN, RIX, AKH, HOU

--- a/forge-gui/res/formats/Archived/Arena Standard/2018-04-26.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2018-04-26.txt
@@ -1,6 +1,6 @@
 [format]
 Name:Arena Standard (DOM)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2018-04-26
 Sets:XLN, RIX, AKH, HOU, DOM

--- a/forge-gui/res/formats/Archived/Arena Standard/2018-06-07.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2018-06-07.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (KLD/AER)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2018-06-07
 Sets:XLN, RIX, AKH, HOU, DOM, KLD, AER, W17
 Banned:Aetherworks Marvel; Attune with Aether; Felidar Guardian; Rampaging Ferocidon; Ramunap Ruins; Rogue Refiner; Smuggler's Copter

--- a/forge-gui/res/formats/Archived/Arena Standard/2018-07-12.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2018-07-12.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (M19)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2018-07-12
 Sets:XLN, RIX, AKH, HOU, DOM, KLD, AER, W17, M19, ANA, PANA
 Banned:Aetherworks Marvel; Attune with Aether; Felidar Guardian; Rampaging Ferocidon; Ramunap Ruins; Rogue Refiner; Smuggler's Copter

--- a/forge-gui/res/formats/Archived/Arena Standard/2018-09-27.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2018-09-27.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (GRN)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2018-09-27
 Sets:XLN, RIX, DOM, M19, ANA, PANA, GRN
 Banned:Rampaging Ferocidon

--- a/forge-gui/res/formats/Archived/Arena Standard/2018-11-15.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2018-11-15.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (G18)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2018-11-15
 Sets:XLN, RIX, DOM, M19, ANA, PANA, GRN, G18
 Banned:Rampaging Ferocidon

--- a/forge-gui/res/formats/Archived/Arena Standard/2019-01-17.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2019-01-17.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (RNA)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2019-01-17
 Sets:XLN, RIX, DOM, M19, ANA, PANA, GRN, G18, RNA
 Banned:Rampaging Ferocidon

--- a/forge-gui/res/formats/Archived/Arena Standard/2019-02-14.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2019-02-14.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (2019-02-14)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2019-02-14
 Sets:XLN, RIX, DOM, M19, ANA, PANA, GRN, G18, RNA
 Banned:Nexus of Fate; Rampaging Ferocidon

--- a/forge-gui/res/formats/Archived/Arena Standard/2019-04-25.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2019-04-25.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (WAR)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2019-04-25
 Sets:XLN, RIX, DOM, M19, ANA, PANA, GRN, G18, RNA, WAR
 Banned:Nexus of Fate; Rampaging Ferocidon

--- a/forge-gui/res/formats/Archived/Arena Standard/2019-07-02.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2019-07-02.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (M20)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2019-07-02
 Sets:XLN, RIX, DOM, M19, ANA, PANA, GRN, G18, RNA, WAR, M20
 Banned:Nexus of Fate; Rampaging Ferocidon

--- a/forge-gui/res/formats/Archived/Arena Standard/2019-09-26.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2019-09-26.txt
@@ -1,6 +1,6 @@
 [format]
 Name:Arena Standard (ELD)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2019-09-26
 Sets:ANA, PANA, GRN, RNA, WAR, M20, ELD

--- a/forge-gui/res/formats/Archived/Arena Standard/2019-10-24.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2019-10-24.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (2019-10-24)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2019-10-24
 Sets:ANA, PANA, GRN, RNA, WAR, M20, ELD
 Banned:Field of the Dead

--- a/forge-gui/res/formats/Archived/Arena Standard/2019-11-18.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2019-11-18.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (2019-11-18)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2019-11-18
 Sets:ANA, PANA, GRN, RNA, WAR, M20, ELD
 Banned:Field of the Dead; Oko, Thief of Crowns; Once Upon a Time; Veil of Summer

--- a/forge-gui/res/formats/Archived/Arena Standard/2020-01-16.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2020-01-16.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (THB)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2020-01-16
 Sets:ANA, PANA, GRN, RNA, WAR, M20, ELD, THB
 Banned:Field of the Dead; Oko, Thief of Crowns; Once Upon a Time; Veil of Summer

--- a/forge-gui/res/formats/Archived/Arena Standard/2020-04-16.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2020-04-16.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (IKO)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2020-04-16
 Sets:ANA, PANA, GRN, RNA, WAR, M20, ELD, THB, IKO
 Banned:Field of the Dead; Oko, Thief of Crowns; Once Upon a Time; Veil of Summer

--- a/forge-gui/res/formats/Archived/Arena Standard/2020-06-04.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2020-06-04.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (2020-06-04)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2020-06-04
 Sets:ANA, PANA, GRN, RNA, WAR, M20, ELD, THB, IKO
 Banned:Agent of Treachery; Field of the Dead; Fires of Invention; Oko, Thief of Crowns; Once Upon a Time; Veil of Summer

--- a/forge-gui/res/formats/Archived/Arena Standard/2020-06-25.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2020-06-25.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (M21)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2020-06-25
 Sets:ANA, PANA, GRN, RNA, WAR, M20, ELD, THB, IKO, M21
 Banned:Agent of Treachery; Field of the Dead; Fires of Invention; Oko, Thief of Crowns; Once Upon a Time; Veil of Summer

--- a/forge-gui/res/formats/Archived/Arena Standard/2020-08-03.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2020-08-03.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (2020-08-03)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2020-08-03
 Sets:ANA, PANA, GRN, RNA, WAR, M20, ELD, THB, IKO, M21
 Banned:Agent of Treachery; Cauldron Familiar; Field of the Dead; Fires of Invention; Growth Spiral; Oko, Thief of Crowns; Once Upon a Time; Teferi, Time Raveler; Veil of Summer; Wilderness Reclamation

--- a/forge-gui/res/formats/Archived/Arena Standard/2020-08-12.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2020-08-12.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (ANB)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2020-08-12
 Sets:ANA, PANA, GRN, RNA, WAR, M20, ELD, THB, IKO, M21, ANB
 Banned:Agent of Treachery; Cauldron Familiar; Field of the Dead; Fires of Invention; Growth Spiral; Oko, Thief of Crowns; Once Upon a Time; Teferi, Time Raveler; Veil of Summer; Wilderness Reclamation

--- a/forge-gui/res/formats/Archived/Arena Standard/2020-09-17.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2020-09-17.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (ZNR)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2020-09-17
 Sets:ANA, PANA, ELD, THB, IKO, M21, ANB, ZNR
 Banned:Cauldron Familiar; Fires of Invention; Oko, Thief of Crowns; Once Upon a Time

--- a/forge-gui/res/formats/Archived/Arena Standard/2020-09-28.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2020-09-28.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (2020-09-28)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2020-09-28
 Sets:ANA, PANA, ELD, THB, IKO, M21, ANB, ZNR
 Banned:Cauldron Familiar; Fires of Invention; Oko, Thief of Crowns; Once Upon a Time; Uro, Titan of Nature's Wrath

--- a/forge-gui/res/formats/Archived/Arena Standard/2020-10-12.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2020-10-12.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (2020-10-12)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2020-10-12
 Sets:ANA, PANA, ELD, THB, IKO, M21, ANB, ZNR
 Banned:Cauldron Familiar; Escape to the Wilds; Fires of Invention; Lucky Clover; Oko, Thief of Crowns; Omnath, Locus of Creation; Once Upon a Time; Uro, Titan of Nature's Wrath

--- a/forge-gui/res/formats/Archived/Arena Standard/2021-01-28.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2021-01-28.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (KHM)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2021-01-28
 Sets:ANA, PANA, ELD, THB, IKO, M21, ANB, ZNR, KHM
 Banned:Cauldron Familiar; Escape to the Wilds; Fires of Invention; Lucky Clover; Oko, Thief of Crowns; Omnath, Locus of Creation; Once Upon a Time; Uro, Titan of Nature's Wrath

--- a/forge-gui/res/formats/Archived/Arena Standard/2021-04-15.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2021-04-15.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (STX)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2021-04-15
 Sets:ANA, PANA, ELD, THB, IKO, M21, ANB, ZNR, KHM, STX
 Banned:Cauldron Familiar; Escape to the Wilds; Fires of Invention; Lucky Clover; Oko, Thief of Crowns; Omnath, Locus of Creation; Once Upon a Time; Uro, Titan of Nature's Wrath

--- a/forge-gui/res/formats/Archived/Arena Standard/2021-07-08.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2021-07-08.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (AFR)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2021-07-08
 Sets:ANA, PANA, ELD, THB, IKO, M21, ANB, ZNR, KHM, STX, AFR
 Banned:Cauldron Familiar; Escape to the Wilds; Fires of Invention; Lucky Clover; Oko, Thief of Crowns; Omnath, Locus of Creation; Once Upon a Time; Uro, Titan of Nature's Wrath

--- a/forge-gui/res/formats/Archived/Arena Standard/2021-09-16.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2021-09-16.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (MID)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2021-09-16
 Sets:ANA, PANA, ANB, ZNR, KHM, STX, AFR, MID
 Banned:Omnath, Locus of Creation

--- a/forge-gui/res/formats/Archived/Arena Standard/2021-11-17.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2021-11-17.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (VOW)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2021-11-17
 Sets:ANA, PANA, ANB, ZNR, KHM, STX, AFR, MID, VOW
 Banned:Omnath, Locus of Creation

--- a/forge-gui/res/formats/Archived/Arena Standard/2022-01-27.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2022-01-27.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (2022-01-27)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2022-01-27
 Sets:ANA, PANA, ANB, ZNR, KHM, STX, AFR, MID, VOW
 Banned:Alrund's Epiphany; Divide by Zero; Faceless Haven; Omnath, Locus of Creation

--- a/forge-gui/res/formats/Archived/Arena Standard/2022-02-10.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2022-02-10.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (NEO)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2022-02-10
 Sets:ANA, PANA, ANB, ZNR, KHM, STX, AFR, MID, VOW, NEO
 Banned:Alrund's Epiphany; Divide by Zero; Faceless Haven; Omnath, Locus of Creation

--- a/forge-gui/res/formats/Archived/Arena Standard/2022-03-17.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2022-03-17.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (2022-03-17)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2022-03-17
 Sets:ZNR, KHM, STX, AFR, MID, VOW, NEO
 Banned:Alrund's Epiphany; Divide by Zero; Faceless Haven; Omnath, Locus of Creation

--- a/forge-gui/res/formats/Archived/Arena Standard/2022-04-28.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2022-04-28.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (SNC)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2022-04-28
 Sets:ZNR, KHM, STX, AFR, MID, VOW, NEO, SNC
 Banned:Alrund's Epiphany; Divide by Zero; Faceless Haven; Omnath, Locus of Creation

--- a/forge-gui/res/formats/Archived/Arena Standard/2022-09-01.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2022-09-01.txt
@@ -1,6 +1,6 @@
 [format]
 Name:Arena Standard (DMU)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2022-09-01
 Sets:MID, VOW, NEO, SNC, DMU

--- a/forge-gui/res/formats/Archived/Arena Standard/2022-10-13.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2022-10-13.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (2022-10-13)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2022-10-13
 Sets:MID, VOW, NEO, SNC, DMU
 Banned:The Meathook Massacre

--- a/forge-gui/res/formats/Archived/Arena Standard/2022-11-15.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2022-11-15.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (BRO)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2022-11-15
 Sets:MID, VOW, NEO, SNC, DMU, BRO
 Banned:The Meathook Massacre

--- a/forge-gui/res/formats/Archived/Arena Standard/2023-02-07.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2023-02-07.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Arena Standard (ONE)
 Type:Archived
-Subtype:Arena
+Subtype:Standard
 Effective:2023-02-07
 Sets:MID, VOW, NEO, SNC, DMU, BRO, ONE
 Banned:The Meathook Massacre

--- a/forge-gui/res/formats/Archived/Explorer/2022-04-28.txt
+++ b/forge-gui/res/formats/Archived/Explorer/2022-04-28.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Explorer (2022-04-28)
 Type:Archived
-Subtype:Arena
+Subtype:Pioneer
 Effective:2022-04-28
 Sets:XLN, RIX, DOM, M19, GRN, G18, RNA, WAR, M20, ELD, THB, IKO, M21, ZNR, KHM, STX, AFR, MID, VOW, NEO, SNC
 Banned:Field of the Dead; Kethis, the Hidden Hand; Leyline of Abundance; Lurrus of the Dream-Den; Nexus of Fate; Oko, Thief of Crowns; Once Upon a Time; Teferi, Time Raveler; Underworld Breach; Uro, Titan of Nature's Wrath; Veil of Summer; Wilderness Reclamation

--- a/forge-gui/res/formats/Archived/Explorer/2022-05-12.txt
+++ b/forge-gui/res/formats/Archived/Explorer/2022-05-12.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Explorer (2022-05-12)
 Type:Archived
-Subtype:Arena
+Subtype:Pioneer
 Effective:2022-05-12
 Sets:XLN, RIX, DOM, M19, GRN, G18, RNA, WAR, M20, ELD, THB, IKO, M21, ZNR, KHM, STX, AFR, MID, VOW, NEO, SNC
 Banned:Field of the Dead; Kethis, the Hidden Hand; Leyline of Abundance; Lurrus of the Dream-Den; Nexus of Fate; Oko, Thief of Crowns; Once Upon a Time; Teferi, Time Raveler; Tibalt's Trickery; Underworld Breach; Uro, Titan of Nature's Wrath; Veil of Summer; Wilderness Reclamation; Winota, Joiner of Forces

--- a/forge-gui/res/formats/Archived/Explorer/2022-06-09.txt
+++ b/forge-gui/res/formats/Archived/Explorer/2022-06-09.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Explorer (2022-06-09)
 Type:Archived
-Subtype:Arena
+Subtype:Pioneer
 Effective:2022-06-09
 Sets:XLN, RIX, DOM, M19, GRN, G18, RNA, WAR, M20, ELD, THB, IKO, M21, ZNR, KHM, STX, AFR, MID, VOW, NEO, SNC
 Banned:Expressive Iteration; Field of the Dead; Kethis, the Hidden Hand; Leyline of Abundance; Lurrus of the Dream-Den; Nexus of Fate; Oko, Thief of Crowns; Once Upon a Time; Teferi, Time Raveler; Tibalt's Trickery; Underworld Breach; Uro, Titan of Nature's Wrath; Veil of Summer; Wilderness Reclamation; Winota, Joiner of Forces

--- a/forge-gui/res/formats/Archived/Explorer/2022-07-07.txt
+++ b/forge-gui/res/formats/Archived/Explorer/2022-07-07.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Explorer (2022-07-07)
 Type:Archived
-Subtype:Arena
+Subtype:Pioneer
 Effective:2022-07-07
 Sets:XLN, RIX, DOM, M19, GRN, G18, RNA, WAR, M20, ELD, THB, IKO, M21, ZNR, KHM, STX, AFR, MID, VOW, NEO, SNC
 Banned:Expressive Iteration; Field of the Dead; Kethis, the Hidden Hand; Leyline of Abundance; Lurrus of the Dream-Den; Nexus of Fate; Oko, Thief of Crowns; Once Upon a Time; Teferi, Time Raveler; Tibalt's Trickery; Underworld Breach; Uro, Titan of Nature's Wrath; Veil of Summer; Wilderness Reclamation; Winota, Joiner of Forces

--- a/forge-gui/res/formats/Archived/Explorer/2022-07-28.txt
+++ b/forge-gui/res/formats/Archived/Explorer/2022-07-28.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Explorer (EA1)
 Type:Archived
-Subtype:Arena
+Subtype:Pioneer
 Effective:2022-07-28
 Sets:XLN, RIX, DOM, M19, GRN, G18, RNA, WAR, M20, ELD, THB, IKO, M21, ZNR, KHM, STX, AFR, MID, VOW, NEO, SNC, EA1
 Banned:Expressive Iteration; Field of the Dead; Kethis, the Hidden Hand; Leyline of Abundance; Lurrus of the Dream-Den; Nexus of Fate; Oko, Thief of Crowns; Once Upon a Time; Teferi, Time Raveler; Tibalt's Trickery; Underworld Breach; Uro, Titan of Nature's Wrath; Veil of Summer; Wilderness Reclamation; Winota, Joiner of Forces

--- a/forge-gui/res/formats/Archived/Explorer/2022-09-01.txt
+++ b/forge-gui/res/formats/Archived/Explorer/2022-09-01.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Explorer (DMU)
 Type:Archived
-Subtype:Arena
+Subtype:Pioneer
 Effective:2022-09-01
 Sets:XLN, RIX, DOM, M19, GRN, G18, RNA, WAR, M20, ELD, THB, IKO, M21, ZNR, KHM, STX, AFR, MID, VOW, NEO, SNC, EA1, DMU
 Banned:Expressive Iteration; Field of the Dead; Kethis, the Hidden Hand; Leyline of Abundance; Lurrus of the Dream-Den; Nexus of Fate; Oko, Thief of Crowns; Once Upon a Time; Teferi, Time Raveler; Tibalt's Trickery; Underworld Breach; Uro, Titan of Nature's Wrath; Veil of Summer; Wilderness Reclamation; Winota, Joiner of Forces

--- a/forge-gui/res/formats/Archived/Explorer/2022-11-15.txt
+++ b/forge-gui/res/formats/Archived/Explorer/2022-11-15.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Explorer (BRO)
 Type:Archived
-Subtype:Arena
+Subtype:Pioneer
 Effective:2022-11-15
 Sets:XLN, RIX, DOM, M19, GRN, G18, RNA, WAR, M20, ELD, THB, IKO, M21, ZNR, KHM, STX, AFR, MID, VOW, NEO, SNC, EA1, DMU, BRO
 Banned:Expressive Iteration; Field of the Dead; Kethis, the Hidden Hand; Leyline of Abundance; Lurrus of the Dream-Den; Nexus of Fate; Oko, Thief of Crowns; Once Upon a Time; Teferi, Time Raveler; Tibalt's Trickery; Underworld Breach; Uro, Titan of Nature's Wrath; Veil of Summer; Wilderness Reclamation; Winota, Joiner of Forces

--- a/forge-gui/res/formats/Archived/Explorer/2022-12-13.txt
+++ b/forge-gui/res/formats/Archived/Explorer/2022-12-13.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Explorer (EA2)
 Type:Archived
-Subtype:Arena
+Subtype:Pioneer
 Effective:2022-12-13
 Sets:XLN, RIX, DOM, M19, GRN, G18, RNA, WAR, M20, ELD, THB, IKO, M21, ZNR, KHM, STX, AFR, MID, VOW, NEO, SNC, EA1, DMU, BRO, EA2
 Banned:Expressive Iteration; Field of the Dead; Kethis, the Hidden Hand; Leyline of Abundance; Lurrus of the Dream-Den; Nexus of Fate; Oko, Thief of Crowns; Once Upon a Time; Teferi, Time Raveler; Tibalt's Trickery; Underworld Breach; Uro, Titan of Nature's Wrath; Veil of Summer; Wilderness Reclamation; Winota, Joiner of Forces

--- a/forge-gui/res/formats/Archived/Explorer/2023-02-07.txt
+++ b/forge-gui/res/formats/Archived/Explorer/2023-02-07.txt
@@ -1,7 +1,7 @@
 [format]
 Name:Explorer (ONE)
 Type:Archived
-Subtype:Arena
+Subtype:Pioneer
 Effective:2023-02-07
 Sets:XLN, RIX, DOM, M19, GRN, G18, RNA, WAR, M20, ELD, THB, IKO, M21, ZNR, KHM, STX, AFR, MID, VOW, NEO, SNC, EA1, DMU, BRO, EA2, ONE
 Banned:Expressive Iteration; Field of the Dead; Kethis, the Hidden Hand; Leyline of Abundance; Lurrus of the Dream-Den; Nexus of Fate; Oko, Thief of Crowns; Once Upon a Time; Teferi, Time Raveler; Tibalt's Trickery; Underworld Breach; Uro, Titan of Nature's Wrath; Veil of Summer; Wilderness Reclamation; Winota, Joiner of Forces


### PR DESCRIPTION
This PR moves Explorer to Subtype:Pioneer and Arena Standard to Subtype:Standard from Subtype:Arena to allow for the correct versions of non-rebalanced cards to show and to bring them in line with the Arena rebalance fixes from #2620. This means that the formats have now moved in the list next to Pioneer and Standard respectively.