### PR TITLE
CardFactoryUtil: Equip shouldn't care if it is a creature

### DIFF
--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -2928,18 +2928,8 @@ public class CardFactoryUtil {
             abilityStr.append(equipCost);
             abilityStr.append("| ValidTgts$ ").append(valid);
             abilityStr.append(" | TgtPrompt$ Select target ").append(vstr).append(" you control ");
-            if (card.hasKeyword(Keyword.RECONFIGURE)) {
-                /*
-                * 301.5c An Equipment that’s also a creature can’t equip a creature unless that Equipment has reconfigure (see rule 702.151, “Reconfigure”).
-                * An Equipment that loses the subtype “Equipment” can’t equip a creature. An Equipment can’t equip itself. An Equipment that equips an illegal
-                * or nonexistent permanent becomes unattached from that permanent but remains on the battlefield. (This is a state-based action. See rule 704.)
-                * An Equipment can’t equip more than one creature. If a spell or ability would cause an Equipment to equip more than one creature,
-                * the Equipment’s controller chooses which creature it equips.
-                */
-                abilityStr.append("| SorcerySpeed$ True | Equip$ True | AILogic$ Pump | IsPresent$ Equipment.Self ");
-            } else {
-                abilityStr.append("| SorcerySpeed$ True | Equip$ True | AILogic$ Pump | IsPresent$ Equipment.Self+nonCreature ");
-            }
+            // the if the Equipment can really attach should be part of the Attach Effect
+            abilityStr.append("| SorcerySpeed$ True | Equip$ True | AILogic$ Pump");
             // add AttachAi for some special cards
             if (card.hasSVar("AttachAi")) {
                 abilityStr.append("| ").append(card.getSVar("AttachAi"));
@@ -3526,7 +3516,7 @@ public class CardFactoryUtil {
             String effect = "AB$ ChangeZone | Cost$ " + manacost + " | Defined$ Self" +
                     " | Origin$ Graveyard | Destination$ Battlefield | SorcerySpeed$ True" +
                     " | ActivationZone$ Graveyard | Unearth$ True | " +
-                    " | PrecostDesc$ Unearth | StackDescription$ " +
+                    " | PrecostDesc$ Unearth | CostDesc$ " + ManaCostParser.parse(manacost) + " | StackDescription$ " +
                     "Unearth: Return CARDNAME to the battlefield. | SpellDescription$" +
                     " (" + inst.getReminderText() + ")";
 


### PR DESCRIPTION
found this while i was also doing the Unearth cost

rules wise an Artifact Equipment Creature with Equip can target itself with the Equip Ability
but of cause it doesn't has any effect (except you activated an ability)

@Agetian do we need more logic for AI so an Equipment Creature doesn't try to target itself?