### PR TITLE
CardFactory: remove redundant copying

### DIFF
--- a/forge-game/src/main/java/forge/game/card/CardFactory.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactory.java
@@ -231,18 +231,12 @@ public class CardFactory {
             spell.setCastFaceDown(false);
         }
 
-        if (targetSA.usesTargeting()) {
-            // do for SubAbilities too?
-            copySA.setTargets(targetSA.getTargets().clone());
-        }
-
         //remove all costs
         if (!copySA.isTrigger()) {
             copySA.setPayCosts(new Cost("", targetSA.isAbility()));
         }
         copySA.setActivatingPlayer(controller);
 
-        copySA.setPaidHash(targetSA.getPaidHash());
         return copySA;
     }
 


### PR DESCRIPTION
Both of these are already done recursively by copy() so we can save just a few calls here.

https://github.com/Card-Forge/forge/blob/395eab4d59a54a26988b71b011452da171486a4f/forge-game/src/main/java/forge/game/spellability/SpellAbility.java#L1156