### PR TITLE
CardFactoryUtil: Read Ahead use DisableTriggers

### DIFF
--- a/forge-game/src/main/java/forge/game/ForgeScript.java
+++ b/forge-game/src/main/java/forge/game/ForgeScript.java
@@ -9,6 +9,7 @@ import forge.game.ability.AbilityUtils;
 import forge.game.ability.ApiType;
 import forge.game.card.Card;
 import forge.game.card.CardState;
+import forge.game.card.CounterEnumType;
 import forge.game.cost.Cost;
 import forge.game.mana.Mana;
 import forge.game.mana.ManaCostBeingPaid;
@@ -236,6 +237,13 @@ public class ForgeScript {
             return sa.hasParam("Nightbound");
         } else if (property.equals("paidPhyrexianMana")) {
             return sa.getSpendPhyrexianMana() > 0;
+        } else if (property.equals("ChapterNotLore")) {
+            if (!sa.isChapter()) {
+                return false;
+            }
+            if (sa.getChapter() == sa.getHostCard().getCounters(CounterEnumType.LORE)) {
+                return false;
+            }
         } else if (property.equals("LastChapter")) {
             return sa.isLastChapter();
         } else if (property.startsWith("ManaSpent")) {

--- a/forge-game/src/main/java/forge/game/ability/effects/CountersPutEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CountersPutEffect.java
@@ -488,10 +488,6 @@ public class CountersPutEffect extends SpellAbilityEffect {
                         }
                     }
 
-                    if (sa.hasParam("ReadAhead")) {
-                        gameCard.setReadAhead(counterAmount);
-                    }
-
                     if (sa.hasParam("Tribute")) {
                         // make a copy to check if it would be on the battlefield
                         Card noTributeLKI = CardUtil.getLKICopy(gameCard);

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -347,8 +347,6 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
     private ReplacementEffect shieldCounterReplaceDestroy = null;
     private ReplacementEffect stunCounterReplaceUntap = null;
 
-    private Integer readAhead = null;
-
     // Enumeration for CMC request types
     public enum SplitCMCMode {
         CurrentSideCMC,
@@ -7252,13 +7250,6 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
             return true;
         }
         return StaticAbilityIgnoreLegendRule.ignoreLegendRule(this);
-    }
-
-    public Integer getReadAhead() {
-        return readAhead;
-    }
-    public void setReadAhead(int value) {
-        readAhead = value;
     }
 
     public boolean attackVigilance() {

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -1787,7 +1787,7 @@ public class CardFactoryUtil {
                     sa.setLastChapter(idx == abs.size());
 
                     StringBuilder trigStr = new StringBuilder("Mode$ CounterAdded | ValidCard$ Card.Self | TriggerZones$ Battlefield");
-                    trigStr.append("| Chapter$ True | CounterType$ LORE | CounterAmount$ EQ").append(i);
+                    trigStr.append("| Chapter$ ").append(i).append(" | CounterType$ LORE | CounterAmount$ EQ").append(i);
                     if (i != idx) {
                         trigStr.append(" | Secondary$ True");
                     }
@@ -3829,6 +3829,10 @@ public class CardFactoryUtil {
                 }
             }
             effect += " | Description$ " + desc;
+            inst.addStaticAbility(StaticAbility.create(effect, state.getCard(), state, intrinsic));
+        } else if (keyword.startsWith("Read ahead")) {
+            String effect = "Mode$ DisableTriggers | ValidCard$ Card.Self+ThisTurnEntered | ValidTrigger$ Triggered.ChapterNotLore | Secondary$ True" +
+                    " | Description$ Chapter abilities of this Saga can’t trigger the turn it entered the battlefield unless it has exactly the number of lore counters on it specified in the chapter symbol of that ability.";
             inst.addStaticAbility(StaticAbility.create(effect, state.getCard(), state, intrinsic));
         } else if (keyword.equals("Shroud")) {
             String effect = "Mode$ CantTarget | Shroud$ True | ValidCard$ Card.Self | Secondary$ True"

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityDisableTriggers.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityDisableTriggers.java
@@ -57,6 +57,11 @@ public class StaticAbilityDisableTriggers {
             return false;
         }
 
+        // Trigger currently has no isValid, take Trigger Ability instead
+        if (!stAb.matchesValidParam("ValidTrigger", regtrig.getOverridingAbility())) {
+            return false;
+        }
+
         if (stAb.hasParam("ValidMode")) {
             if (!ArrayUtils.contains(stAb.getParam("ValidMode").split(","), trigMode.toString())) {
                 return false;

--- a/forge-game/src/main/java/forge/game/trigger/Trigger.java
+++ b/forge-game/src/main/java/forge/game/trigger/Trigger.java
@@ -613,4 +613,10 @@ public abstract class Trigger extends TriggerReplacementBase {
     public SpellAbility ensureAbility() {
         return ensureAbility(this);
     }
+
+    @Override
+    public void setOverridingAbility(SpellAbility overridingAbility0) {
+        super.setOverridingAbility(overridingAbility0);
+        overridingAbility0.setTrigger(this);
+    }
 }

--- a/forge-game/src/main/java/forge/game/trigger/TriggerCounterAdded.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerCounterAdded.java
@@ -89,19 +89,6 @@ public class TriggerCounterAdded extends Trigger {
             }
         }
 
-        // TODO check CR for Read Ahead when they are out
-        // for now assume it only is about etb counter
-        if (hasParam("Chapter") && runParams.containsKey(AbilityKey.ETB) && true == (boolean)runParams.get(AbilityKey.ETB)) {
-            Card card = (Card)runParams.get(AbilityKey.Card);
-            Integer readAhead = card.getReadAhead();
-            if (readAhead != null) {
-                final int actualAmount = (Integer) runParams.get(AbilityKey.CounterAmount);
-                if (actualAmount < readAhead) {
-                    return false;
-                }
-            }
-        }
-
         return true;
     }
 


### PR DESCRIPTION
Closes #1489

I first thought about adding isValid to Trigger but then i thought it might be too complicated

the ReadAhead on PutCounter i keep for now, it might not be needed because you can get the Keyword from the SpellAbility anyway now, but it might be useful for AI to not choose TOO high or TOO low in case of counter doubler like Vorinclex

AI might need a bit more tweaking?