### PR TITLE
CardFactory getCloneStates set PT for Vehicle

### DIFF
--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -3946,10 +3946,10 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
 
     // values that are printed on card
     public final String getBasePowerString() {
-        return (null == currentState.getBasePowerString()) ? "" + getBasePower() : currentState.getBasePowerString();
+        return (null == currentState.getBasePowerString()) ? String.valueOf(getBasePower()) : currentState.getBasePowerString();
     }
     public final String getBaseToughnessString() {
-        return (null == currentState.getBaseToughnessString()) ? "" + getBaseToughness() : currentState.getBaseToughnessString();
+        return (null == currentState.getBaseToughnessString()) ? String.valueOf(getBaseToughness()) : currentState.getBaseToughnessString();
     }
 
     // values that are printed on card

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -3930,38 +3930,32 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
         currentState.setBaseLoyalty(Integer.toString(n));
     }
 
-    // values that are printed on card
     public final int getBasePower() {
         return currentState.getBasePower();
     }
-
     public final int getBaseToughness() {
         return currentState.getBaseToughness();
     }
 
-    // values that are printed on card
     public final void setBasePower(final int n) {
         currentState.setBasePower(n);
     }
-
     public final void setBaseToughness(final int n) {
         currentState.setBaseToughness(n);
     }
 
     // values that are printed on card
     public final String getBasePowerString() {
-        return currentState.getBasePowerString();
+        return (null == currentState.getBasePowerString()) ? "" + getBasePower() : currentState.getBasePowerString();
     }
-
     public final String getBaseToughnessString() {
-        return currentState.getBaseToughnessString();
+        return (null == currentState.getBaseToughnessString()) ? "" + getBaseToughness() : currentState.getBaseToughnessString();
     }
 
     // values that are printed on card
     public final void setBasePowerString(final String s) {
         currentState.setBasePowerString(s);
     }
-
     public final void setBaseToughnessString(final String s) {
         currentState.setBaseToughnessString(s);
     }

--- a/forge-game/src/main/java/forge/game/card/CardFactory.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactory.java
@@ -764,7 +764,7 @@ public class CardFactory {
                 state.removeIntrinsicKeyword(kw);
             }
 
-            if (state.getType().isCreature()) {
+            if (state.getType().isCreature() || state.getType().hasSubtype("Vehicle")) {
                 if (sa.hasParam("SetPower")) {
                     state.setBasePower(AbilityUtils.calculateAmount(sa.getHostCard(), sa.getParam("SetPower"), sa));
                 }

--- a/forge-game/src/main/java/forge/game/card/CardFactory.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactory.java
@@ -568,7 +568,7 @@ public class CardFactory {
         c.setRules(in.getRules());
 
         return c;
-    } // copyStats()
+    }
 
     /**
      * Copy characteristics of a particular state of one card to those of a
@@ -764,12 +764,14 @@ public class CardFactory {
                 state.removeIntrinsicKeyword(kw);
             }
 
-            if (state.getType().isCreature() || state.getBasePowerString() != null) {
+            // CR 208.3 A noncreature object not on the battlefield has power or toughness only if it has a power and toughness printed on it.
+            // currently only LKI can be trusted?
+            if (state.getType().isCreature() || in.getOriginalState(originalState.getStateName()).getBasePowerString() != null) {
                 if (sa.hasParam("SetPower")) {
-                    state.setBasePower(AbilityUtils.calculateAmount(sa.getHostCard(), sa.getParam("SetPower"), sa));
+                    state.setBasePower(AbilityUtils.calculateAmount(host, sa.getParam("SetPower"), sa));
                 }
                 if (sa.hasParam("SetToughness")) {
-                    state.setBaseToughness(AbilityUtils.calculateAmount(sa.getHostCard(), sa.getParam("SetToughness"), sa));
+                    state.setBaseToughness(AbilityUtils.calculateAmount(host, sa.getParam("SetToughness"), sa));
                 }
             }
 

--- a/forge-game/src/main/java/forge/game/card/CardFactory.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactory.java
@@ -764,7 +764,7 @@ public class CardFactory {
                 state.removeIntrinsicKeyword(kw);
             }
 
-            if (state.getType().isCreature() || state.getType().hasSubtype("Vehicle")) {
+            if (state.getType().isCreature() || state.getBasePowerString() != null) {
                 if (sa.hasParam("SetPower")) {
                     state.setBasePower(AbilityUtils.calculateAmount(sa.getHostCard(), sa.getParam("SetPower"), sa));
                 }

--- a/forge-game/src/main/java/forge/game/card/CardState.java
+++ b/forge-game/src/main/java/forge/game/card/CardState.java
@@ -202,10 +202,10 @@ public class CardState extends GameObject implements IHasSVars {
 
     // values that are printed on card
     public final String getBasePowerString() {
-        return (null == basePowerString) ? "" + getBasePower() : basePowerString;
+        return basePowerString;
     }
     public final String getBaseToughnessString() {
-        return (null == baseToughnessString) ? "" + getBaseToughness() : baseToughnessString;
+        return baseToughnessString;
     }
 
     // values that are printed on card

--- a/forge-game/src/main/java/forge/game/card/CardUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardUtil.java
@@ -222,7 +222,7 @@ public final class CardUtil {
             newCopy.addAlternateState(CardStateName.Cloner, false);
             newCopy.getState(CardStateName.Cloner).copyFrom(in.getState(CardStateName.Cloner), true);
         }
-        //*/
+        */
 
         newCopy.setToken(in.isToken());
         newCopy.setCopiedSpell(in.isCopiedSpell());
@@ -232,6 +232,10 @@ public final class CardUtil {
         // lock in the current P/T
         newCopy.setBasePower(in.getCurrentPower());
         newCopy.setBaseToughness(in.getCurrentToughness());
+
+        // printed P/T
+        newCopy.setBasePowerString(in.getCurrentState().getBasePowerString());
+        newCopy.setBaseToughnessString(in.getCurrentState().getBaseToughnessString());
 
         // extra copy PT boost
         newCopy.setPTBoost(in.getPTBoostTable());


### PR DESCRIPTION
When an animated Vehicle dies, Kinzu of the Bleak Coven should make a token with PT = 1/1


But does this break Mindlink Mech?
> If a player crews Mindlink Mech with a nonlegendary permanent that is not normally a creature or Vehicle, the resulting permanent Mindlink Mech becomes is a 0/0 artifact creature and will usually be put into its owner's graveyard. This is because a copy effect can't set the power and toughness of a permanent if being a creature isn't part of that permanent's copiable characteristics. The crew effect is then applied after the copy effect, and it becomes a creature with no defined power or toughness, so both are set to 0. (2022-02-18)

should the set of PT before `state.addType(types)` ?