### PR TITLE
Fix to Bug in PC Walk Down Animations

### DIFF
--- a/forge-gui/res/adventure/Shandalar/sprites/heroes/devil_f.atlas
+++ b/forge-gui/res/adventure/Shandalar/sprites/heroes/devil_f.atlas
@@ -130,7 +130,7 @@ WalkDown
   xy: 144, 16
   size: 16, 16        
 WalkDown 
-  xy: 160, 0
+  xy: 160, 16
   size: 16, 16          
 WalkDown 
   xy: 176, 16

--- a/forge-gui/res/adventure/Shandalar/sprites/heroes/devil_m.atlas
+++ b/forge-gui/res/adventure/Shandalar/sprites/heroes/devil_m.atlas
@@ -130,7 +130,7 @@ WalkDown
   xy: 144, 16
   size: 16, 16        
 WalkDown 
-  xy: 160, 0
+  xy: 160, 16
   size: 16, 16          
 WalkDown 
   xy: 176, 16

--- a/forge-gui/res/adventure/Shandalar/sprites/heroes/dwarf_f.atlas
+++ b/forge-gui/res/adventure/Shandalar/sprites/heroes/dwarf_f.atlas
@@ -130,7 +130,7 @@ WalkDown
   xy: 144, 16
   size: 16, 16        
 WalkDown 
-  xy: 160, 0
+  xy: 160, 16
   size: 16, 16          
 WalkDown 
   xy: 176, 16

--- a/forge-gui/res/adventure/Shandalar/sprites/heroes/dwarf_m.atlas
+++ b/forge-gui/res/adventure/Shandalar/sprites/heroes/dwarf_m.atlas
@@ -130,7 +130,7 @@ WalkDown
   xy: 144, 16
   size: 16, 16        
 WalkDown 
-  xy: 160, 0
+  xy: 160, 16
   size: 16, 16          
 WalkDown 
   xy: 176, 16

--- a/forge-gui/res/adventure/Shandalar/sprites/heroes/elf_f.atlas
+++ b/forge-gui/res/adventure/Shandalar/sprites/heroes/elf_f.atlas
@@ -130,7 +130,7 @@ WalkDown
   xy: 144, 16
   size: 16, 16        
 WalkDown 
-  xy: 160, 0
+  xy: 160, 16
   size: 16, 16          
 WalkDown 
   xy: 176, 16

--- a/forge-gui/res/adventure/Shandalar/sprites/heroes/elf_m.atlas
+++ b/forge-gui/res/adventure/Shandalar/sprites/heroes/elf_m.atlas
@@ -130,7 +130,7 @@ WalkDown
   xy: 144, 16
   size: 16, 16        
 WalkDown 
-  xy: 160, 0
+  xy: 160, 16
   size: 16, 16          
 WalkDown 
   xy: 176, 16

--- a/forge-gui/res/adventure/Shandalar/sprites/heroes/human_f.atlas
+++ b/forge-gui/res/adventure/Shandalar/sprites/heroes/human_f.atlas
@@ -130,7 +130,7 @@ WalkDown
   xy: 144, 16
   size: 16, 16        
 WalkDown 
-  xy: 160, 0
+  xy: 160, 16
   size: 16, 16          
 WalkDown 
   xy: 176, 16

--- a/forge-gui/res/adventure/Shandalar/sprites/heroes/human_m.atlas
+++ b/forge-gui/res/adventure/Shandalar/sprites/heroes/human_m.atlas
@@ -130,7 +130,7 @@ WalkDown
   xy: 144, 16
   size: 16, 16        
 WalkDown 
-  xy: 160, 0
+  xy: 160, 16
   size: 16, 16          
 WalkDown 
   xy: 176, 16

--- a/forge-gui/res/adventure/Shandalar/sprites/heroes/kor_f.atlas
+++ b/forge-gui/res/adventure/Shandalar/sprites/heroes/kor_f.atlas
@@ -130,7 +130,7 @@ WalkDown
   xy: 144, 16
   size: 16, 16        
 WalkDown 
-  xy: 160, 0
+  xy: 160, 16
   size: 16, 16          
 WalkDown 
   xy: 176, 16

--- a/forge-gui/res/adventure/Shandalar/sprites/heroes/kor_m.atlas
+++ b/forge-gui/res/adventure/Shandalar/sprites/heroes/kor_m.atlas
@@ -130,7 +130,7 @@ WalkDown
   xy: 144, 16
   size: 16, 16        
 WalkDown 
-  xy: 160, 0
+  xy: 160, 16
   size: 16, 16          
 WalkDown 
   xy: 176, 16

--- a/forge-gui/res/adventure/Shandalar/sprites/heroes/metathran_f.atlas
+++ b/forge-gui/res/adventure/Shandalar/sprites/heroes/metathran_f.atlas
@@ -130,7 +130,7 @@ WalkDown
   xy: 144, 16
   size: 16, 16        
 WalkDown 
-  xy: 160, 0
+  xy: 160, 16
   size: 16, 16          
 WalkDown 
   xy: 176, 16

--- a/forge-gui/res/adventure/Shandalar/sprites/heroes/metathran_m.atlas
+++ b/forge-gui/res/adventure/Shandalar/sprites/heroes/metathran_m.atlas
@@ -130,7 +130,7 @@ WalkDown
   xy: 144, 16
   size: 16, 16        
 WalkDown 
-  xy: 160, 0
+  xy: 160, 16
   size: 16, 16          
 WalkDown 
   xy: 176, 16

--- a/forge-gui/res/adventure/Shandalar/sprites/heroes/phyrexian_r.atlas
+++ b/forge-gui/res/adventure/Shandalar/sprites/heroes/phyrexian_r.atlas
@@ -130,7 +130,7 @@ WalkDown
   xy: 144, 16
   size: 16, 16        
 WalkDown 
-  xy: 160, 0
+  xy: 160, 16
   size: 16, 16          
 WalkDown 
   xy: 176, 16

--- a/forge-gui/res/adventure/Shandalar/sprites/heroes/phyrexian_u.atlas
+++ b/forge-gui/res/adventure/Shandalar/sprites/heroes/phyrexian_u.atlas
@@ -130,7 +130,7 @@ WalkDown
   xy: 144, 16
   size: 16, 16        
 WalkDown 
-  xy: 160, 0
+  xy: 160, 16
   size: 16, 16          
 WalkDown 
   xy: 176, 16

--- a/forge-gui/res/adventure/Shandalar/sprites/heroes/undead_f.atlas
+++ b/forge-gui/res/adventure/Shandalar/sprites/heroes/undead_f.atlas
@@ -130,7 +130,7 @@ WalkDown
   xy: 144, 16
   size: 16, 16        
 WalkDown 
-  xy: 160, 0
+  xy: 160, 16
   size: 16, 16          
 WalkDown 
   xy: 176, 16

--- a/forge-gui/res/adventure/Shandalar/sprites/heroes/undead_m.atlas
+++ b/forge-gui/res/adventure/Shandalar/sprites/heroes/undead_m.atlas
@@ -130,7 +130,7 @@ WalkDown
   xy: 144, 16
   size: 16, 16        
 WalkDown 
-  xy: 160, 0
+  xy: 160, 16
   size: 16, 16          
 WalkDown 
   xy: 176, 16

--- a/forge-gui/res/adventure/Shandalar/sprites/heroes/viashino_f.atlas
+++ b/forge-gui/res/adventure/Shandalar/sprites/heroes/viashino_f.atlas
@@ -130,7 +130,7 @@ WalkDown
   xy: 144, 16
   size: 16, 16        
 WalkDown 
-  xy: 160, 0
+  xy: 160, 16
   size: 16, 16          
 WalkDown 
   xy: 176, 16

--- a/forge-gui/res/adventure/Shandalar/sprites/heroes/viashino_m.atlas
+++ b/forge-gui/res/adventure/Shandalar/sprites/heroes/viashino_m.atlas
@@ -130,7 +130,7 @@ WalkDown
   xy: 144, 16
   size: 16, 16        
 WalkDown 
-  xy: 160, 0
+  xy: 160, 16
   size: 16, 16          
 WalkDown 
   xy: 176, 16


### PR DESCRIPTION
Fix to bug in PC walking animations where the 3rd frame when walking directly down came from the idle animations instead of the walking ones.