### PR TITLE
Adventure Mode: Update printings in decks

### DIFF
--- a/forge-gui/res/adventure/Shandalar/decks/ashmouth_devil.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/ashmouth_devil.dck
@@ -3,12 +3,12 @@ Name=ashmouth_devil
 [Main]
 2 Bladebrand|MID|1
 1 Bloodgift Demon|ISD|1
-1 Burn Down the House|MID|2
+1 Burn Down the House|MID|1
 1 Curse of Shaken Faith|MID|1
-1 Demonic Bargain|VOW|2
+1 Demonic Bargain|VOW|1
 1 Demonic Rising|AVR|1
 1 Demonlord of Ashmouth|AVR|1
-1 Dreadfeast Demon|VOW|2
+1 Dreadfeast Demon|VOW|1
 1 Dreadhound|MID|1
 4 Ecstatic Awakener|MID|1
 4 Evolving Wilds|MID|1
@@ -16,18 +16,16 @@ Name=ashmouth_devil
 1 Field of Ruin|MID|1
 1 Frenzied Devils|VOW|1
 2 Grisly Ritual|VOW|1
-1 Haunted Ridge|MID|2
+1 Haunted Ridge|MID|1
 2 Heckling Fiends|DKA|1
 1 Immolation|MID|1
 1 Jerren, Corrupted Bishop|MID|1
 1 Lord of the Forsaken|MID|1
-1 Mask of Griselbrand|MID|2
+1 Mask of Griselbrand|MID|1
 1 Mountain|ISD|1
 1 Mountain|ISD|3
-1 Mountain|MID|2
-1 Mountain|MID|3
-1 Mountain|VOW|1
-1 Mountain|VOW|3
+2 Mountain|MID|3
+2 Mountain|VOW|3
 4 Novice Occultist|MID|1
 1 Play with Fire|MID|1
 1 Reckless Impulse|VOW|1
@@ -36,8 +34,5 @@ Name=ashmouth_devil
 1 Skirsdag High Priest|ISD|1
 2 Swamp|ISD|2
 2 Swamp|ISD|3
-1 Swamp|MID|1
-3 Swamp|MID|2
-1 Swamp|VOW|1
-2 Swamp|VOW|2
-1 Swamp|VOW|4
+4 Swamp|MID|3
+4 Swamp|VOW|3

--- a/forge-gui/res/adventure/Shandalar/decks/bandit.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/bandit.dck
@@ -14,7 +14,7 @@ Name=bandit
 1 Dunerider Outlaw|PLC|1
 1 Falkenrath Marauders|ISD|1
 1 Fangblade Brigand|MID|1
-1 Field of Ruin|DBL|1
+1 Field of Ruin|MID|1
 1 Geier Reach Bandit|SOI|1
 1 Godo, Bandit Warlord|CHK|1
 1 Graveblade Marauder|ORI|1
@@ -34,8 +34,8 @@ Name=bandit
 2 Mountain|M14|3
 1 Mountain Bandit|PTK|1
 1 Murder|CN2|1
-1 Pillage|PLIST|1
-1 Rahilda, Wanted Cutthroat|Y22|1
+1 Pillage|MH1|1
+1 Rahilda, Wanted Cutthroat|YMID|1
 2 Raiders' Wake|XLN|1
 1 Robber of the Rich|ELD|1
 1 Skirk Marauder|ARC|1

--- a/forge-gui/res/adventure/Shandalar/decks/basri.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/basri.dck
@@ -1,12 +1,10 @@
 [metadata]
 Name=basri
-[Avatar]
-
 [Main]
 4 Adherent of Hope|M21|1
 1 Angel of Vitality|M20|1
-1 Angelic Accord|M14|1
-3 Anointed Chorister|J21|1
+1 Angelic Accord|IMA|1
+3 Anointed Chorister|M21|1
 2 Aven Gagglemaster|M21|1
 1 Baneslayer Angel|M21|1
 2 Basri's Acolyte|M21|1
@@ -16,34 +14,22 @@ Name=basri
 1 Bishop of Wings|M20|1
 2 Chastise|9ED|1
 4 Makeshift Battalion|WAR|1
-2 Plains|AKH|1
-1 Plains|AKH|2
+3 Plains|AKH|2
 2 Plains|AKH|3
 2 Plains|ISD|2
 1 Plains|ISD|3
-2 Plains|M21|1
+3 Plains|M21|1
 1 Plains|M21|2
 1 Plains|M21|3
-1 Plains|M21|4
 5 Plains|RNA|1
 2 Plains|THB|3
 4 Radiant Fountain|M21|1
 1 Sigiled Contender|M21|1
 2 Silverstrike|SOI|1
-1 Speaker of the Heavens|PLIST|1
-1 Swift Justice|RTR|1
+1 Speaker of the Heavens|M21|1
+1 Swift Justice|DDN|1
 1 Tandem Tactics|BFZ|1
 2 Tempered Veteran|M21|1
 1 Tenacity|SOI|1
 1 Trusted Pegasus|WAR|1
-1 Voice of the Blessed|VOW|2
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-
+1 Voice of the Blessed|VOW|1

--- a/forge-gui/res/adventure/Shandalar/decks/beholder.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/beholder.dck
@@ -1,10 +1,7 @@
 [metadata]
 Name=Beholder
-[Avatar]
-
 [Main]
-3 Baleful Beholder|AFR|1
-1 Baleful Beholder|AFR|2
+4 Baleful Beholder|AFR|1
 1 Baleful Strix|AFC|1
 1 Chaos Dragon|AFC|1
 1 Death Tyrant|AFC|1
@@ -34,13 +31,3 @@ Name=Beholder
 1 Wight|AFR|1
 1 Xanathar, Guild Kingpin|AFR|1
 1 Xorn|AFR|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/black_wiz3.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/black_wiz3.dck
@@ -7,7 +7,7 @@ Name=black_wiz3
 1 Cemetery Recruitment|EMN|1
 1 Cruel Revival|ORI|1
 1 Dark Salvation|EMN|1
-1 Demonic Tutor|DDC|1
+1 Demonic Tutor|DVD|1
 2 Ghastly Gloomhunter|ZNR|1
 2 Goremand|M21|1
 1 Liliana's Devotee|M21|1
@@ -19,7 +19,7 @@ Name=black_wiz3
 1 Liliana's Shade|M13|1
 1 Liliana's Specter|M11|1
 1 Liliana's Standard Bearer|M21|1
-1 Liliana's Steward|J21|1
+1 Liliana's Steward|M21|1
 1 Liliana, Death Mage|M21|1
 1 Macabre Waltz|SOI|1
 1 Massacre Wurm|M21|1
@@ -42,8 +42,7 @@ Name=black_wiz3
 1 Swamp|KLD|2
 2 Swamp|KLD|3
 2 Swamp|M20|1
-1 Swamp|M21|1
-1 Swamp|M21|4
+2 Swamp|M21|1
 1 Swamp|STX|1
 3 Swamp|STX|2
 3 Tattered Mummy|AKH|1

--- a/forge-gui/res/adventure/Shandalar/decks/br_elemental.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/br_elemental.dck
@@ -15,21 +15,14 @@ Name=BR Elemental
 2 Dragonskull Summit|DMC|1
 2 Elemental Expressionist|STX|1
 4 Flame Burst|ODY|1
-2 Haunted Ridge|MID|2
+2 Haunted Ridge|MID|1
 4 Incandescent Soulstoke|MM2|1
 4 Kulrath Knight|SHM|1
-2 Mountain|ONE|1
-3 Mountain|ONE|2
-1 Mountain|ONE|3
-1 Mountain|ONE|4
+7 Mountain|ONE|3
 2 Necroskitter|TD2|1
 2 Nyxathid|JMP|1
 1 Obsidian Fireheart|ZEN|1
 4 Pardic Firecat|ODY|1
 2 Smoldering Marsh|DMC|1
 2 Spitemare|DDH|1
-3 Swamp|ONE|1
-2 Swamp|ONE|2
-1 Swamp|ONE|3
-[Sideboard]
-
+6 Swamp|ONE|3

--- a/forge-gui/res/adventure/Shandalar/decks/cathar.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/cathar.dck
@@ -1,7 +1,5 @@
 [metadata]
 Name=cathar
-[Avatar]
-
 [Main]
 1 Adamant Will|VOW|1
 1 Adeline, Resplendent Cathar|MID|1
@@ -17,35 +15,22 @@ Name=cathar
 4 Flare of Faith|MID|1
 1 Forest|AVR|1
 1 Forest|ISD|1
-1 Forest|MID|1
-1 Forest|VOW|2
+1 Forest|MID|3
+1 Forest|VOW|3
 4 Gryff Rider|VOW|1
 2 Gryffwing Cavalry|VOW|1
-1 Intrepid Adversary|MID|2
-1 Overgrown Farmland|MID|2
+1 Intrepid Adversary|MID|1
+1 Overgrown Farmland|MID|1
 1 Parish-Blade Trainee|VOW|1
 2 Plains|AVR|2
 1 Plains|AVR|3
 2 Plains|ISD|2
 2 Plains|ISD|3
-1 Plains|MID|1
-3 Plains|MID|3
-1 Plains|VOW|2
-1 Plains|VOW|3
-2 Plains|VOW|4
+4 Plains|MID|3
+4 Plains|VOW|3
 1 Sanctify|VOW|1
-1 Sigarda, Champion of Light|MID|2
+1 Sigarda, Champion of Light|MID|1
 1 Thalia, Guardian of Thraben|VOW|1
 2 Timberland Guide|MID|1
 1 Torens, Fist of the Angels|VOW|1
 1 Vampire Slayer|VOW|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/cave_spider.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/cave_spider.dck
@@ -1,7 +1,5 @@
 [metadata]
 Name=cave_spider
-[Avatar]
-
 [Main]
 1 Aquastrand Spider|MM2|1
 1 Arachnogenesis|C15|1
@@ -20,7 +18,7 @@ Name=cave_spider
 2 Ishkanah, Broodmother|YMID|1
 2 Ishkanah, Grafwidow|EMN|1
 1 Llanowar Greenwidow|DMU|1
-2 Lolth, Spider Queen|PLIST|1
+2 Lolth, Spider Queen|AFR|1
 1 Mountain|MH2|1
 2 Penumbra Spider|MB1|1
 1 Spider Spawning|C15|1
@@ -34,13 +32,3 @@ Name=cave_spider
 4 Verdant Catacombs|MM3|1
 2 Vinesoul Spider|YDMU|1
 4 Ziatora's Proving Ground|SNC|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/centaur_warrior.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/centaur_warrior.dck
@@ -1,7 +1,5 @@
 [metadata]
 Name=centaur_warrior
-[Avatar]
-
 [Main]
 1 Alive // Well|DGM|1
 1 Avenging Arrow|RTR|1
@@ -12,7 +10,7 @@ Name=centaur_warrior
 1 Conclave Cavalier|GRN|1
 1 Conclave Mentor|M21|1
 1 Courser of Kruphix|BNG|1
-1 Courser of Kruphix|TSR|1
+1 Courser of Kruphix|J22|1
 1 Coursers' Accord|RTR|1
 1 Dowsing Shaman|RAV|1
 1 Fated Intervention|BNG|1
@@ -20,8 +18,7 @@ Name=centaur_warrior
 1 Forest|RTR|3
 1 Forest|RTR|4
 1 Forest|RTR|5
-2 Forest|THB|1
-3 Forest|THB|2
+5 Forest|THB|2
 1 Forest|THB|3
 1 Herald of the Pantheon|ORI|1
 1 Krosan Druid|DOM|1
@@ -52,13 +49,3 @@ Name=centaur_warrior
 1 Trostani's Judgment|RTR|1
 1 Vitu-Ghazi Guildmage|RTR|1
 1 Wildwood Patrol|M21|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/challenger_20_allied_fires.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/challenger_20_allied_fires.dck
@@ -7,13 +7,13 @@ Name=challenger_20_allied_fires
 2 Fae of Wishes|ELD|1
 4 Fires of Invention|ELD|1
 4 Interplanar Beacon|WAR|1
-5 Island|MID|1
+5 Island|MID|3
 3 Kasmina, Enigmatic Mentor|WAR|1
 1 Kenrith, the Returned King|ELD|1
-2 Mountain|MID|1
+2 Mountain|MID|3
 4 Narset, Parter of Veils|SLD|1
-4 Omen of the Sea|J21|1
-2 Plains|MID|1
+4 Omen of the Sea|THB|1
+2 Plains|MID|3
 2 Saheeli, Sublime Artificer|SLD|1
 3 Sarkhan the Masterless|SLD|1
 1 Steam Vents|GRN|1
@@ -25,5 +25,3 @@ Name=challenger_20_allied_fires
 3 Tranquil Cove|NEO|1
 1 Ugin, the Ineffable|WAR|1
 4 Wind-Scarred Crag|NEO|1
-[Sideboard]
-

--- a/forge-gui/res/adventure/Shandalar/decks/challenger_20_cavalcade_charge.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/challenger_20_cavalcade_charge.dck
@@ -7,12 +7,10 @@ Name=challenger_20_cavalcade_charge
 3 Chandra, Acolyte of Flame|M20|1
 1 Embercleave|ELD|1
 4 Fervent Champion|ELD|1
-4 Light Up the Stage|PLIST|1
+4 Light Up the Stage|RNA|1
 18 Mountain|ELD|1
 4 Rimrock Knight|ELD|1
 4 Runaway Steam-Kin|GRN|1
 4 Scorch Spitter|M20|1
 3 Tin Street Dodger|RNA|1
 4 Torbran, Thane of Red Fell|ELD|1
-[Sideboard]
-

--- a/forge-gui/res/adventure/Shandalar/decks/challenger_20_final_adventure.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/challenger_20_final_adventure.dck
@@ -13,12 +13,10 @@ Name=challenger_20_final_adventure
 2 Knight of the Ebon Legion|M20|1
 4 Lovestruck Beast|ELD|1
 4 Lucky Clover|ELD|1
-2 Midnight Reaper|SLD|1
+2 Midnight Reaper|GRN|1
 2 Murderous Rider|ELD|1
 4 Order of Midnight|ELD|1
 4 Smitten Swordmaster|ELD|1
 8 Swamp|ELD|1
 2 Temple of Malady|M21|1
 1 Vraska, Golgari Queen|GRN|1
-[Sideboard]
-

--- a/forge-gui/res/adventure/Shandalar/decks/challenger_20_flash_of_ferocity.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/challenger_20_flash_of_ferocity.dck
@@ -19,5 +19,3 @@ Name=challenger_20_flash_of_ferocity
 2 Unsummon|M20|1
 1 Wavebreak Hippocamp|THB|1
 4 Wildborn Preserver|ELD|1
-[Sideboard]
-

--- a/forge-gui/res/adventure/Shandalar/decks/challenger_21_azorius_control.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/challenger_21_azorius_control.dck
@@ -8,19 +8,17 @@ Name=Challenger_21_Azorius_Control
 2 Dream Trawler|THB|1
 3 Elspeth Conquers Death|THB|1
 1 Emeria's Call|ZNR|1
-2 Glass Casket|J21|1
+2 Glass Casket|ELD|1
 8 Island|KHM|1
-1 Negate|STA|1
-3 Neutralize|J21|1
-4 Omen of the Sea|J21|1
+1 Negate|DMU|1
+3 Neutralize|IKO|1
+4 Omen of the Sea|THB|1
 8 Plains|KHM|1
 1 Saw It Coming|KHM|1
-1 Shark Typhoon|SLC|1
+1 Shark Typhoon|IKO|1
 2 Shatter the Sky|THB|1
 2 Skyclave Cleric|ZNR|1
 4 Temple of Enlightenment|VOC|1
 4 The Birth of Meletis|THB|1
 3 Thirst for Meaning|THB|1
 4 Tranquil Cove|KHC|1
-[Sideboard]
-

--- a/forge-gui/res/adventure/Shandalar/decks/challenger_21_mono-red_aggro.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/challenger_21_mono-red_aggro.dck
@@ -2,8 +2,8 @@
 Name=challenger_21_mono-red_aggro
 [Main]
 4 Akoum Hellhound|ZNR|1
-4 Anax, Hardened in the Forge|PLIST|1
-4 Bonecrusher Giant|PLIST|1
+4 Anax, Hardened in the Forge|THB|1
+4 Bonecrusher Giant|ELD|1
 2 Castle Embereth|NCC|1
 1 Embercleave|ELD|1
 4 Fervent Champion|ELD|1
@@ -12,8 +12,6 @@ Name=challenger_21_mono-red_aggro
 4 Rimrock Knight|ELD|1
 4 Roil Eruption|ZNR|1
 2 Shatterskull Smashing|ZNR|1
-4 Shock|STA|1
+4 Shock|M21|1
 4 Spikefield Hazard|ZNR|1
 3 Torbran, Thane of Red Fell|ELD|1
-[Sideboard]
-

--- a/forge-gui/res/adventure/Shandalar/decks/challenger_22_dimir_control.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/challenger_22_dimir_control.dck
@@ -11,17 +11,15 @@ Name=AI 22 Dimir Control
 2 Hero's Downfall|VOW|1
 1 Hullbreaker Horror|VOW|1
 4 Ice Tunnel|KHM|1
-1 Infernal Grasp|DBL|1
+1 Infernal Grasp|MID|1
 2 Iymrith, Desert Doom|AFR|1
 2 Jwari Disruption|ZNR|1
 1 March of Wretched Sorrow|NEO|1
 4 Memory Deluge|MID|1
 2 Parasitic Grasp|VOW|1
-3 Power Word Kill|GDY|1
+3 Power Word Kill|AFR|1
 3 Saw It Coming|KHM|1
 4 Shipwreck Marsh|MID|1
 5 Snow-Covered Island|J22|1
 7 Snow-Covered Swamp|KHM|1
 2 Thirst for Discovery|VOW|1
-[Sideboard]
-

--- a/forge-gui/res/adventure/Shandalar/decks/challenger_22_gruul_stompy.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/challenger_22_gruul_stompy.dck
@@ -2,26 +2,20 @@
 Name=AI 22 Gruul Stompy
 [Main]
 4 Abrade|SCD|1
-4 Briarbridge Tracker|DBL|1
-4 Forest|MID|1
-3 Forest|MID|2
-3 Forest|MID|3
+4 Briarbridge Tracker|MID|1
+10 Forest|MID|3
 1 Goldspan Dragon|KHM|1
-2 Halana and Alena, Partners|DBL|1
+2 Halana and Alena, Partners|VOW|1
 4 Jaspera Sentinel|KHM|1
 2 Lair of the Hydra|AFR|1
-1 Light Up the Night|DBL|1
+1 Light Up the Night|MID|1
 4 Magda, Brazen Outlaw|KHM|1
-4 Mountain|MID|1
-2 Mountain|MID|2
-2 Mountain|MID|3
+8 Mountain|MID|3
 4 Ranger Class|AFR|1
-4 Rockfall Vale|DBL|1
+4 Rockfall Vale|MID|1
 4 Snakeskin Veil|KHM|1
 1 Thundering Rebuke|ZNR|1
-2 Tovolar's Huntmaster|DBL|1
-1 Tovolar, Dire Overlord|DBL|1
+2 Tovolar's Huntmaster|MID|1
+1 Tovolar, Dire Overlord|MID|1
 2 Twinshot Sniper|NEO|1
-2 Ulvenwald Oddity|DBL|1
-[Sideboard]
-
+2 Ulvenwald Oddity|VOW|1

--- a/forge-gui/res/adventure/Shandalar/decks/challenger_22_mono_white_aggro.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/challenger_22_mono_white_aggro.dck
@@ -2,11 +2,11 @@
 Name=AI 22 Mono White Aggro
 [Main]
 4 Clarion Spirit|KHM|1
-4 Codespell Cleric|J21|1
-3 Elite Spellbinder|SLC|1
-3 Faceless Haven|PPRO|1
+4 Codespell Cleric|KHM|1
+3 Elite Spellbinder|STX|1
+3 Faceless Haven|KHM|1
 2 Fateful Absence|MID|1
-1 Intrepid Adversary|DBL|1
+1 Intrepid Adversary|MID|1
 2 Kabira Takedown|ZNR|1
 4 Luminarch Aspirant|NCC|1
 4 Monk of the Open Hand|AFR|1
@@ -14,7 +14,5 @@ Name=AI 22 Mono White Aggro
 2 Reidane, God of the Worthy|KHM|1
 2 Skyclave Apparition|ZNR|1
 20 Snow-Covered Plains|KHM|1
-2 Thalia, Guardian of Thraben|DKA|1
+2 Thalia, Guardian of Thraben|VOW|1
 4 Usher of the Fallen|KHM|1
-[Sideboard]
-

--- a/forge-gui/res/adventure/Shandalar/decks/challenger_22_rakdos_vampires.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/challenger_22_rakdos_vampires.dck
@@ -5,25 +5,19 @@ Name=AI 22 Rakdos Vampires
 4 Bloodfell Caves|SCD|1
 4 Bloodtithe Harvester|VOW|1
 2 Den of the Bugbear|AFR|1
-2 Dominating Vampire|DBL|1
-2 Florian, Voldaren Scion|DBL|1
-1 Henrika Domnathi|DBL|1
+2 Dominating Vampire|VOW|1
+2 Florian, Voldaren Scion|MID|1
+1 Henrika Domnathi|VOW|1
 4 Immersturm Predator|KHM|1
-2 Infernal Grasp|DBL|1
-1 Mountain|VOW|1
-2 Mountain|VOW|2
-3 Mountain|VOW|4
+2 Infernal Grasp|MID|1
+6 Mountain|VOW|3
 2 Mukotai Soulripper|NEO|1
-2 Oni-Cult Anvil|BRC|1
+2 Oni-Cult Anvil|NEO|1
 2 Sokenzan Smelter|NEO|1
-5 Swamp|VOW|1
-1 Swamp|VOW|2
-1 Swamp|VOW|4
+7 Swamp|VOW|3
 2 Vampire Socialite|MID|1
 1 Village Rites|J22|1
 4 Voldaren Bloodcaster|VOW|1
 4 Voldaren Epicure|VOW|1
-3 Voldaren Estate|DBL|1
+3 Voldaren Estate|VOW|1
 4 Voltage Surge|NEO|1
-[Sideboard]
-

--- a/forge-gui/res/adventure/Shandalar/decks/chandra3.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/chandra3.dck
@@ -12,13 +12,13 @@ Name=AI Chandra 3
 2 Chandra's Spitfire|J22|1
 2 Chandra, Awakened Inferno|M20|1
 2 Chandra, Pyromaster|AKR|1
-2 Chandra, Torch of Defiance|KLR|1
-4 Geistflame Reservoir|DBL|1
+2 Chandra, Torch of Defiance|KLD|1
+4 Geistflame Reservoir|MID|1
 2 Lava Coil|2X2|1
 2 Light Up the Stage|RNA|1
 2 Lightning Strike|DMU|1
-21 Mountain|DMR|1
+8 Mountain|DMU|1
+5 Mountain|DMU|2
+8 Mountain|DMU|3
 2 Shock|M21|1
 2 Skullcrack|GTC|1
-[Sideboard]
-

--- a/forge-gui/res/adventure/Shandalar/decks/chandra4.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/chandra4.dck
@@ -3,7 +3,7 @@ Name=AI Chandra B 1
 [Main]
 4 Chain Lightning|JMP|1
 4 Chandra's Phoenix|PM12|1
-1 Chandra, Fire of Kaladesh|PS15|1
+1 Chandra, Fire of Kaladesh|ORI|1
 2 Chandra, Pyromaster|AKR|1
 2 Chandra, Torch of Defiance|KLD|1
 4 Grim Lavamancer|G06|1
@@ -13,5 +13,3 @@ Name=AI Chandra B 1
 4 Pyromancer Ascension|ZEN|1
 4 Searing Blaze|WWK|1
 4 Skullcrack|GTC|1
-[Sideboard]
-

--- a/forge-gui/res/adventure/Shandalar/decks/chandra5.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/chandra5.dck
@@ -6,7 +6,7 @@ Name=AI Chandra B 2
 1 Chandra, Fire Artisan|SLD|1
 1 Chandra, Pyromaster|AKR|1
 1 Chandra, Torch of Defiance|KLD|1
-4 Fireball|PLIST|1
+4 Fireball|CLB|1
 4 Lightning Bolt|M10|1
 4 Magma Jet|5DN|1
 4 Monastery Swiftspear|KTK|1
@@ -15,5 +15,3 @@ Name=AI Chandra B 2
 4 Rift Bolt|TSP|1
 4 Searing Blaze|WWK|1
 4 Skullcrack|GTC|1
-[Sideboard]
-

--- a/forge-gui/res/adventure/Shandalar/decks/chandra6.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/chandra6.dck
@@ -3,7 +3,7 @@ Name=AI Chandra B 3
 [Main]
 4 Chain Lightning|JMP|1
 4 Chandra's Phoenix|PM12|1
-1 Chandra, Fire of Kaladesh|PS15|1
+1 Chandra, Fire of Kaladesh|ORI|1
 2 Chandra, Pyromaster|AKR|1
 2 Chandra, Torch of Defiance|KLD|1
 4 Grim Lavamancer|G06|1
@@ -13,5 +13,3 @@ Name=AI Chandra B 3
 4 Pyromancer Ascension|ZEN|1
 4 Searing Blaze|WWK|1
 4 Skullcrack|GTC|1
-[Sideboard]
-

--- a/forge-gui/res/adventure/Shandalar/decks/chicken.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/chicken.dck
@@ -1,9 +1,7 @@
 [metadata]
 Name=chicken
-[Avatar]
-
 [Main]
-4 Battle Screech|J21|1
+4 Battle Screech|MH1|1
 4 Chicken Egg|UGL|1
 4 Chicken à la King|UND|1
 4 Disenchant|M20|1
@@ -20,13 +18,3 @@ Name=chicken
 4 Spara's Headquarters|SNC|1
 4 Verdant Catacombs|SLU|1
 4 Zodiac Rooster|PRM|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/counter.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/counter.dck
@@ -1,7 +1,5 @@
 [metadata]
 Name=counter
-[Avatar]
-
 [Main]
 1 Arcane Investigator|AFR|1
 2 Avalanche Caller|KHM|1
@@ -9,7 +7,7 @@ Name=counter
 2 Counterspell|MH2|1
 1 Delver of Secrets|MID|1
 3 Devious Cover-Up|MID|1
-2 Dismiss|J21|1
+2 Dismiss|J22|1
 2 Dissipate|MID|1
 1 Etherium Spinner|MH2|1
 1 Frost Augur|KHM|1
@@ -38,13 +36,3 @@ Name=counter
 1 Waterfall Aerialist|STX|1
 1 Whispering Wizard|VOW|1
 2 You Find the Villains' Lair|AFR|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/curselord.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/curselord.dck
@@ -1,7 +1,5 @@
 [metadata]
 Name=Curses
-[Avatar]
-
 [Main]
 2 Akoum Refuge|ZEN|1
 2 Bitterheart Witch|ISD|1
@@ -31,18 +29,8 @@ Name=Curses
 4 Swamp|ISD|3
 1 Tainted Peak|AFC|1
 1 Terminate|ARB|1
-2 Torment of Scarabs|HA4|1
+2 Torment of Scarabs|HOU|1
 2 Trespasser's Curse|AKR|1
 1 Urborg, Tomb of Yawgmoth|PLC|1
 3 Wall of Bone|GVL|1
 1 Wall of Bone|M10|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/cyclops.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/cyclops.dck
@@ -10,8 +10,7 @@ Name=cyclops
 1 Flummoxed Cyclops|THB|1
 1 Gluttonous Cyclops|JOU|1
 1 Lightning Strike|AJMP|1
-4 Mountain|THB|1
-3 Mountain|THB|2
+7 Mountain|THB|2
 6 Mountain|THB|3
 3 Mountain|THS|1
 4 Mountain|THS|2

--- a/forge-gui/res/adventure/Shandalar/decks/dawnhart_witch.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/dawnhart_witch.dck
@@ -3,7 +3,7 @@ Name=dawnhart_witch
 [Main]
 2 Ambitious Farmhand|MID|1
 1 Augur of Autumn|MID|2
-3 Candlegrove Witch|MID|2
+3 Candlegrove Witch|MID|1
 1 Candlelit Cavalry|MID|1
 1 Candletrap|MID|1
 1 Cathar's Call|MID|1
@@ -11,28 +11,24 @@ Name=dawnhart_witch
 1 Crossroads Candleguide|MID|1
 2 Dawnhart Mentor|MID|1
 1 Dawnhart Rejuvenator|MID|1
-2 Dawnhart Wardens|MID|2
+2 Dawnhart Wardens|MID|1
 1 Defend the Celestus|MID|1
 1 Duelcraft Trainer|MID|1
 4 Evolving Wilds|MID|1
-3 Forest|MID|1
-4 Forest|MID|2
-3 Forest|MID|3
+10 Forest|MID|3
 4 Harvesttide Sentry|MID|1
 1 Hedgewitch's Mask|MID|1
 1 Jack-o'-Lantern|MID|1
 1 Join the Dance|MID|1
 1 Katilda, Dawnhart Prime|MID|1
 1 Might of the Old Ways|MID|1
-1 Overgrown Farmland|MID|2
+1 Overgrown Farmland|MID|1
 1 Path to the Festival|MID|1
-4 Plains|MID|1
-1 Plains|MID|2
-4 Plains|MID|3
+9 Plains|MID|3
 1 Rite of Harmony|MID|2
 1 Ritual Guardian|MID|1
 1 Ritual of Hope|MID|1
-1 Saryth, the Viper's Fang|MID|2
-1 Sigarda, Champion of Light|MID|2
+1 Saryth, the Viper's Fang|MID|1
+1 Sigarda, Champion of Light|MID|1
 1 Sungold Barrage|MID|1
 1 Sunset Revelry|MID|1

--- a/forge-gui/res/adventure/Shandalar/decks/death_knight.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/death_knight.dck
@@ -1,7 +1,7 @@
 [metadata]
 Name=death_knight
 [Main]
-1 Abnormal Endurance|J21|1
+1 Abnormal Endurance|M19|1
 1 Alchemist's Gift|M21|1
 1 Bloodcrazed Paladin|XLN|1
 1 Cadaverous Knight|HOP|1

--- a/forge-gui/res/adventure/Shandalar/decks/fear.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/fear.dck
@@ -1,10 +1,8 @@
 [metadata]
 Name=fear
-[Avatar]
-
 [Main]
-1 Abnormal Endurance|J21|1
-1 Alchemist's Gift|J21|1
+1 Abnormal Endurance|M19|1
+1 Alchemist's Gift|M21|1
 1 Avatar of Woe|PCY|1
 1 Commander Greven il-Vec|TPR|1
 1 Corpse Churn|CMR|1
@@ -17,8 +15,8 @@ Name=fear
 1 Guiltfeeder|JUD|1
 1 Hero's Downfall|VOW|1
 1 Malefic Scythe|M21|1
-1 Mind Rake|J21|1
-1 Murder|J21|1
+1 Mind Rake|MB1|1
+1 Murder|MB1|1
 2 Nezumi Cutthroat|A25|1
 2 Phobian Phantasm|CSP|1
 1 Poison the Cup|KHM|1
@@ -34,17 +32,7 @@ Name=fear
 1 Swamp|SHM|2
 3 Swamp|SHM|3
 3 Swamp|SHM|4
-1 Tourach's Canticle|J21|1
+1 Tourach's Canticle|MH2|1
 1 Unburial Rites|AFC|1
 1 Undercity Shade|RAV|1
 1 Woebearer|MRD|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/firegiant.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/firegiant.dck
@@ -1,7 +1,5 @@
 [metadata]
 Name=firegiant
-[Avatar]
-
 [Main]
 3 Bonecrusher Giant|CLB|1
 2 Calamity Bearer|KHM|1
@@ -9,7 +7,7 @@ Name=firegiant
 3 Fire Giant's Fury|KHM|1
 2 Hill Giant|30A|1
 2 Inferno Titan|C15|1
-24 Mountain|KLR|2
+24 Mountain|KHM|1
 2 Quakebringer|KHM|1
 4 Squash|KHM|1
 3 Stinkdrinker Daredevil|CM2|1
@@ -18,13 +16,3 @@ Name=firegiant
 2 Thundercloud Shaman|CM2|1
 4 Two-Headed Giant|DOM|1
 2 Zalto, Fire Giant Duke|AFR|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/firegiantboss.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/firegiantboss.dck
@@ -1,7 +1,5 @@
 [metadata]
 Name=firegiantboss
-[Avatar]
-
 [Main]
 2 Blood Moon|2XM|1
 4 Borderland Behemoth|C15|1
@@ -11,18 +9,8 @@ Name=firegiantboss
 4 Hammerfist Giant|C15|1
 4 Inferno Titan|CM2|1
 4 Magma Giant|CM2|1
-28 Mountain|KLR|2
+28 Mountain|KHM|1
 4 Quakebringer|KHM|1
 4 Squash|KHM|1
 4 Sunrise Sovereign|C15|1
 4 Thundercloud Shaman|CM2|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/frost_titan.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/frost_titan.dck
@@ -1,7 +1,5 @@
 [metadata]
 Name=frost_titan
-[Avatar]
-
 [Main]
 2 Adarkar Wastes|DMU|1
 1 Aerial Responder|KLR|1
@@ -25,19 +23,9 @@ Name=frost_titan
 1 Prowling Felidar|ZNR|1
 2 Savor the Moment|SHM|1
 2 Serra Sphinx|2XM|1
-1 Sleep|PLIST|1
+1 Sleep|M19|1
 1 Tamiyo, the Moon Sage|AVR|1
 3 Tempest Drake|VIS|1
 2 Topan Freeblade|IMA|1
 2 Vulshok Gauntlets|2XM|1
 1 Weathered Sentinels|NCC|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/fungus.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/fungus.dck
@@ -1,7 +1,5 @@
 [metadata]
 Name=fungus
-[Avatar]
-
 [Main]
 2 Deathbonnet Sprout|MID|1
 6 Forest|CLB|1
@@ -10,7 +8,7 @@ Name=fungus
 4 Forest|CLB|4
 4 Fungusaur|30A|1
 1 Mycoloth|C15|1
-4 Spore Swarm|J21|1
+4 Spore Swarm|DOM|1
 4 Sporecrown Thallid|DOM|1
 4 Sporemound|ZNC|1
 1 Sporeweb Weaver|M21|1
@@ -21,13 +19,3 @@ Name=fungus
 4 The Weatherseed Treaty|DMU|1
 2 Undercellar Myconid|CLB|1
 1 Verdeloth the Ancient|ARC|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/gargoyle.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/gargoyle.dck
@@ -22,9 +22,7 @@ Name=gargoyle
 2 Plains|RAV|2
 2 Plains|RAV|4
 4 Plains|RNA|1
-3 Plains|VOW|1
-1 Plains|VOW|2
-1 Plains|VOW|4
+5 Plains|VOW|3
 1 Sanctum Gargoyle|ALA|1
 4 Skyclave Sentinel|ZNR|1
 1 Stonecloaker|PLC|1

--- a/forge-gui/res/adventure/Shandalar/decks/ghost_blue.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/ghost_blue.dck
@@ -15,24 +15,20 @@ Name=Ghost Blue
 2 Island|ISD|1
 2 Island|ISD|2
 2 Island|ISD|3
-3 Island|MID|1
-2 Island|MID|2
-1 Island|MID|3
-2 Island|VOW|1
-2 Island|VOW|3
-2 Island|VOW|4
+6 Island|MID|3
+6 Island|VOW|3
 1 Latch Seeker|AVR|1
 1 Magnifying Glass|2XM|1
 1 Mausoleum Wanderer|EMN|1
 1 Nebelgast Herald|VOC|1
 2 Nebelgast Intruder|MID|1
-1 Patrician Geist|MID|2
+1 Patrician Geist|MID|1
 2 Phantom Carriage|MID|1
 1 Rattlechains|JMP|1
 4 Shipwreck Sifters|MID|1
 1 Shriekgeist|IMA|1
 1 Silent Departure|HA3|1
-1 Spectral Adversary|MID|2
+1 Spectral Adversary|MID|1
 1 Startled Awake|SOI|1
 1 Stormbound Geist|DKA|1
 4 Stormrider Spirit|MID|1

--- a/forge-gui/res/adventure/Shandalar/decks/ghoul.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/ghoul.dck
@@ -2,7 +2,7 @@
 Name=ghoul
 [Main]
 2 Bladestitched Skaab|MID|1
-1 Champion of the Perished|MID|3
+1 Champion of the Perished|MID|1
 4 Diregraf Horde|MID|1
 1 Drownyard Amalgam|MID|1
 2 Eaten Alive|MID|1
@@ -11,9 +11,8 @@ Name=ghoul
 1 Flip the Switch|MID|1
 2 Ghoulish Procession|MID|1
 1 Hobbling Zombie|MID|1
-4 Island|MID|2
-4 Island|MID|3
-1 Jadar, Ghoulcaller of Nephalia|MID|2
+8 Island|MID|3
+1 Jadar, Ghoulcaller of Nephalia|MID|1
 1 Morkrut Behemoth|MID|1
 2 Necrobite|AVR|1
 1 No Way Out|MID|1
@@ -21,10 +20,8 @@ Name=ghoul
 2 Revenge of the Drowned|MID|1
 1 Rotten Reunion|MID|1
 3 Seagraf Skaab|SOI|1
-1 Shipwreck Marsh|MID|2
+1 Shipwreck Marsh|MID|1
 4 Siege Zombie|MID|1
 1 Startle|MID|1
-3 Swamp|MID|1
-4 Swamp|MID|2
-4 Swamp|MID|3
+11 Swamp|MID|3
 1 Tainted Adversary|MID|1

--- a/forge-gui/res/adventure/Shandalar/decks/giant_crab.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/giant_crab.dck
@@ -1,11 +1,9 @@
 [metadata]
 Name=crab
-[Avatar]
-
 [Main]
 4 Bad River|DMC|1
-1 Charix, the Raging Isle|ZNR|2
-4 Hard Evidence|J21|1
+1 Charix, the Raging Isle|ZNR|1
+4 Hard Evidence|MH2|1
 4 Hedron Crab|ZEN|1
 4 Ice Tunnel|KHM|1
 4 Iceberg Cancrix|MH1|1
@@ -17,13 +15,3 @@ Name=crab
 6 Snow-Covered Swamp|CSP|1
 4 Uchuulon|CLB|2
 4 Visions of Beyond|UMA|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/goblin_artificer.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/goblin_artificer.dck
@@ -15,4 +15,4 @@ Name=goblin_artificer
 4 Sardian Avenger|BRC|1
 4 Shock|M21|1
 2 Treasure Nabber|C18|1
-2 Tuktuk the Explorer|PLIST|1
+2 Tuktuk the Explorer|2XM|1

--- a/forge-gui/res/adventure/Shandalar/decks/harpy.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/harpy.dck
@@ -1,7 +1,5 @@
 [metadata]
 Name=harpy
-[Avatar]
-
 [Main]
 1 Abhorrent Overlord|THS|1
 1 Aphemia, the Cacophony|THB|1
@@ -20,20 +18,9 @@ Name=harpy
 1 Screeching Harpy|TPR|1
 1 Shrike Harpy|BNG|1
 1 Sip of Hemlock|THS|1
-5 Swamp|THB|1
 3 Swamp|THB|2
-1 Swamp|THB|3
+6 Swamp|THB|3
 1 Swamp|THS|1
 6 Swamp|THS|2
 7 Swamp|THS|3
 3 Swamp|THS|4
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/harpy_2.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/harpy_2.dck
@@ -1,7 +1,5 @@
 [metadata]
 Name=harpy_2
-[Avatar]
-
 [Main]
 1 Aphemia, the Cacophony|THB|1
 1 Ashiok, Sculptor of Fears|THB|1
@@ -13,8 +11,7 @@ Name=harpy_2
 1 Fruit of Tizerus|THB|1
 1 Glimpse of Freedom|THB|1
 1 Insatiable Harpy|THS|1
-2 Island|THB|1
-1 Island|THB|2
+3 Island|THB|2
 1 Island|THS|2
 1 Island|THS|4
 1 Mausoleum Harpy|RIX|1
@@ -27,8 +24,7 @@ Name=harpy_2
 1 Screeching Harpy|TPR|1
 1 Shrike Harpy|BNG|1
 1 Sleep of the Dead|THB|1
-2 Swamp|THB|1
-4 Swamp|THB|2
+6 Swamp|THB|2
 3 Swamp|THB|3
 4 Swamp|THS|1
 1 Swamp|THS|3
@@ -36,13 +32,3 @@ Name=harpy_2
 1 Sweet Oblivion|THB|1
 1 Temple of Deceit|THB|1
 1 Unknown Shores|THB|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/haste_burn.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/haste_burn.dck
@@ -1,7 +1,5 @@
 [metadata]
 Name=haste_burn
-[Avatar]
-
 [Main]
 1 Arclight Phoenix|GRN|1
 1 Arni Brokenbrow|KHM|1
@@ -20,7 +18,7 @@ Name=haste_burn
 1 Hellrider|JMP|1
 1 Impetuous Sunchaser|BNG|1
 4 Lightning Bolt|M10|1
-1 Manaform Hellkite|VOW|2
+1 Manaform Hellkite|VOW|1
 1 Mardu Scout|FRF|1
 11 Mountain|C18|1
 9 Mountain|C18|2
@@ -29,16 +27,6 @@ Name=haste_burn
 1 Phoenix of Ash|THB|1
 1 Raging Minotaur|ME3|1
 1 Skitter of Lizards|CNS|1
-1 Toralf's Disciple|Y22|1
+1 Toralf's Disciple|YMID|1
 1 Volcanic Geyser|M21|1
 1 Wayward Guide-Beast|ZNR|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/hellhound.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/hellhound.dck
@@ -1,22 +1,18 @@
 [metadata]
 Name=hellhound
-[Avatar]
-
 [Main]
 4 Akoum Hellhound|ZNR|1
 2 Ashmouth Hound|ISD|1
 2 Blazing Hellhound|ORI|1
 2 Fiery Fall|C21|1
 3 Fiery Hellhound|DDI|1
-1 Haunted Ridge|MID|1
-3 Haunted Ridge|MID|2
+4 Haunted Ridge|MID|1
 4 Heightened Reflexes|IKO|1
 2 Igneous Cur|M21|1
 2 Into the Maw of Hell|ISD|1
-2 Magmatic Sinkhole|H1R|1
-3 Mountain|THB|1
-4 Mountain|THB|2
-2 Mountain|THB|3
+2 Magmatic Sinkhole|MH1|1
+6 Mountain|THB|2
+3 Mountain|THB|3
 2 Mountain|THS|1
 1 Mountain|THS|2
 4 Mountain|THS|3
@@ -29,13 +25,3 @@ Name=hellhound
 1 Valakut, the Molten Pinnacle|ZNE|1
 2 Volcanic Rush|MB1|1
 2 Wildfire Cerberus|JOU|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/horror.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/horror.dck
@@ -1,9 +1,7 @@
 [metadata]
 Name=horror
-[Avatar]
-
 [Main]
-1 Aboleth Spawn|CLB|1
+1 Aboleth Spawn|CLB|2
 1 Aetherize|ZNC|1
 1 Barrin's Spite|INV|1
 2 Blizzard Specter|IMA|1
@@ -18,25 +16,15 @@ Name=horror
 8 Island|MID|3
 3 Man-o'-War|EMA|1
 2 Mesmeric Fiend|A25|1
-1 Mindslicer|9ED|1
+1 Mindslicer|DMR|1
 1 Port of Karfell|KHM|1
 2 Ravenous Chupacabra|A25|1
-4 Recoil|DDH|1
+4 Recoil|DMR|1
 1 River's Rebuke|XLN|1
 1 Skull Fracture|ODY|1
 9 Swamp|MID|3
 2 Thing in the Ice|SOI|1
-2 Uchuulon|CLB|1
+2 Uchuulon|CLB|2
 2 Underground River|C16|1
 2 Warped Devotion|8ED|1
 1 Wash Out|CMA|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/human_archer.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/human_archer.dck
@@ -1,13 +1,11 @@
 [metadata]
 Name=human_archer
-[Avatar]
-
 [Main]
 1 Apprentice Sharpshooter|VOW|1
 2 Arbalest Elite|M12|1
 2 Arcus Acolyte|MH2|1
 1 Bassara Tower Archer|JOU|1
-1 Bird Admirer|MID|2
+1 Bird Admirer|MID|1
 1 Blossoming Sands|M21|1
 1 Bow of Nylea|THS|1
 1 Catti-brie of Mithral Hall|AFC|1
@@ -22,10 +20,8 @@ Name=human_archer
 1 Forest|AFR|1
 1 Forest|AFR|2
 2 Forest|AFR|3
-1 Forest|MID|1
-2 Forest|MID|2
-1 Forest|MID|3
-1 Fortify|J21|1
+4 Forest|MID|3
+1 Fortify|JMP|1
 1 Freewind Equenaut|DIS|1
 1 Fyndhorn Bow|ICE|1
 2 Grasslands|AFC|1
@@ -34,25 +30,14 @@ Name=human_archer
 1 Hunter's Mark|AFR|1
 2 Longbow Archer|VIS|1
 2 Mounted Archers|TPR|1
-1 Overgrown Farmland|MID|2
+1 Overgrown Farmland|MID|1
 2 Plains|AFR|1
 1 Plains|AFR|2
 2 Plains|AFR|4
-2 Plains|MID|1
-2 Plains|MID|3
+4 Plains|MID|3
 2 Ranger's Longbow|AFR|1
 1 Rashka the Slayer|HML|1
 1 Sawblade Slinger|VOW|1
 1 Silver Bolt|MID|1
 1 Trophy Hunter|RAV|1
 2 Viridian Longbow|MRD|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/human_soldier_token.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/human_soldier_token.dck
@@ -1,12 +1,10 @@
 [metadata]
 Name=human_soldier_token
-[Avatar]
-
 [Main]
 1 Adamant Will|VOW|1
 1 Angelic Quartermaster|VOW|1
 1 Captain of the Watch|M10|1
-1 Cemetery Protector|VOW|2
+1 Cemetery Protector|VOW|1
 1 Commanding Presence|THB|1
 1 Darien, King of Kjeldor|CSP|1
 1 Dawn of Hope|GRN|1
@@ -22,7 +20,7 @@ Name=human_soldier_token
 1 Iona's Judgment|CMR|1
 1 Keeper of the Accord|CMR|1
 1 Mobilization|10E|1
-1 Moment of Heroism|J21|1
+1 Moment of Heroism|JMP|1
 2 Perimeter Sergeant|IKO|1
 1 Plains|IKO|1
 3 Plains|IKO|2
@@ -43,13 +41,3 @@ Name=human_soldier_token
 1 Thraben Standard Bearer|EMN|1
 4 Veteran Armorsmith|M10|1
 4 Veteran Swordsmith|M10|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/humanoidrat.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/humanoidrat.dck
@@ -1,12 +1,10 @@
 [metadata]
 Name=humanoidrat
-[Avatar]
-
 [Main]
 2 Ashcoat of the Shadow Swarm|J22|1
 1 Feed the Swarm|CLB|1
 3 Ink-Eyes, Servant of Oni|PCA|1
-1 Karumonix, the Rat King|ONE|3
+1 Karumonix, the Rat King|ONE|1
 2 Marrow-Gnawer|CHK|1
 3 Mukotai Ambusher|NEO|1
 2 Murder|CMR|1
@@ -22,13 +20,3 @@ Name=humanoidrat
 24 Swamp|AFR|3
 3 Throat Slitter|PCA|1
 2 Tribute to Horobi|NEO|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/insect.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/insect.dck
@@ -1,7 +1,5 @@
 [metadata]
 Name=insect_toxic
-[Avatar]
-
 [Main]
 1 Beacon of Creation|5DN|1
 1 Blex, Vexing Pest|STX|1
@@ -31,16 +29,6 @@ Name=insect_toxic
 1 Spring-Leaf Avenger|NEO|1
 2 Swamp|STX|1
 2 Swamp Mosquito|TSB|1
-1 Vishgraz, the Doomhive|ONC|2
+1 Vishgraz, the Doomhive|ONC|1
 4 Woodland Chasm|KHM|1
 2 Zask, Skittering Swarmlord|J22|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/jellyfish.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/jellyfish.dck
@@ -1,14 +1,12 @@
 [metadata]
 Name=jellyfish
-[Avatar]
-
 [Main]
 4 Evolving Wilds|CM2|1
 1 Flood Plain|AFC|1
 4 Flumph|AFR|1
 1 Forest|CM2|1
 2 Forest|CM2|6
-4 Glimmerbell|J21|1
+4 Glimmerbell|IKO|1
 4 Gluntch, the Bestower|CLB|1
 4 Guard Gomazoa|MB1|1
 4 Hydroid Krasis|2X2|1
@@ -25,13 +23,3 @@ Name=jellyfish
 4 Terramorphic Expanse|DMC|1
 4 The Reality Chip|NEO|1
 4 Watchful Blisterzoa|ONE|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/lightning_elemental.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/lightning_elemental.dck
@@ -8,16 +8,12 @@ Name=Lightning Elemental
 4 Incinerate|10E|1
 4 Lightning Bolt|MED|1
 4 Lightning Elemental|10E|1
-4 Mountain|BRO|1
-2 Mountain|BRO|2
-3 Mountain|BRO|3
-7 Mountain|BRO|4
+9 Mountain|BRO|1
+7 Mountain|BRO|2
 2 Reverberate|M11|1
 4 Shock|10E|1
 4 Spark Elemental|10E|1
-4 Thunderbreak Regent|J21|1
+4 Thunderbreak Regent|DTK|1
 2 Thunderkin Awakener|M20|1
 2 Thundermaw Hellkite|M13|1
 2 Thunderous Wrath|AVR|1
-[Sideboard]
-

--- a/forge-gui/res/adventure/Shandalar/decks/mimic.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/mimic.dck
@@ -1,12 +1,10 @@
 [metadata]
 Name=Mimic
-[Avatar]
-
 [Main]
 1 Aetherling|DGM|1
 1 Archive Trap|ZEN|1
 1 Cairn Wanderer|C20|1
-2 Changeling Outcast|H1R|1
+2 Changeling Outcast|MH1|1
 1 Dermoplasm|LGN|1
 1 Dralnu's Pet|PLS|1
 1 Eldrazi Mimic|OGW|1
@@ -20,13 +18,12 @@ Name=Mimic
 1 Leonin Bladetrap|CMA|1
 1 Lethargy Trap|ZEN|1
 1 Metallic Mimic|KLR|1
-3 Mimic|AFR|1
-1 Mimic|AFR|2
+4 Mimic|AFR|1
 1 Mimic Vat|C20|1
 1 Mirrorhall Mimic|VOW|1
 1 Mistwalker|KHM|1
 1 Moonglove Changeling|MOR|1
-1 Morophon, the Boundless|PLIST|1
+1 Morophon, the Boundless|MH1|1
 1 Morphling|VMA|1
 2 Mothdust Changeling|MMA|1
 1 Needlebite Trap|ZEN|1
@@ -44,13 +41,3 @@ Name=Mimic
 1 Temple of Deceit|MIC|1
 1 Treasure Chest|AFR|3
 1 Whiplash Trap|C20|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/miniboss/chandra.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/miniboss/chandra.dck
@@ -10,28 +10,25 @@ Name=Chandra
 1 Chandra, Acolyte of Flame|M20|1
 1 Chandra, Awakened Inferno|M20|1
 1 Chandra, Bold Pyromancer|DOM|1
-1 Chandra, Dressed to Kill|VOW|2
+1 Chandra, Dressed to Kill|VOW|1
 1 Chandra, Fire Artisan|WAR|1
 2 Chandra, Fire of Kaladesh|V17|1
 1 Chandra, Flame's Catalyst|M21|1
 1 Chandra, Flame's Fury|M20|1
 1 Chandra, the Firebrand|M13|1
-1 Chandra, Torch of Defiance|Q06|1
+1 Chandra, Torch of Defiance|KLD|1
 1 Hammer of Bogardan|PD2|1
 2 Jaya's Immolating Inferno|DOM|1
 4 Karn's Bastion|WAR|1
 2 Karplusan Hound|DOM|1
 4 Keral Keep Disciples|M21|1
 4 Lightning Bolt|2X2|1
-12 Mountain|M21|1
+14 Mountain|M21|1
 2 Mountain|M21|2
 4 Mountain|M21|3
-2 Mountain|M21|4
 1 Oath of Chandra|OGW|1
 1 Pyromancer's Gauntlet|M14|1
 1 Pyromancer's Goggles|ORI|1
 2 Renegade Firebrand|KLD|1
 2 Toralf's Disciple|YMID|1
 4 Volt Charge|DDL|1
-[Sideboard]
-

--- a/forge-gui/res/adventure/Shandalar/decks/miniboss/garruk.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/miniboss/garruk.dck
@@ -1,7 +1,5 @@
 [metadata]
 Name=garruk
-[Avatar]
-
 [Main]
 1 Apex Altisaur|C19|1
 1 Argoth, Sanctum of Nature|BRO|1
@@ -9,7 +7,9 @@ Name=garruk
 1 Castle Garenbrig|ELD|1
 1 Elder Gargaroth|M21|1
 4 Elvish Mystic|KHC|1
-28 Forest|J14|1
+9 Forest|J22|1
+11 Forest|J22|2
+8 Forest|J22|3
 1 Garruk Wildspeaker|GVL|1
 2 Garruk's Harbinger|M21|1
 1 Garruk's Horde|M12|1
@@ -20,8 +20,8 @@ Name=garruk
 1 Gate to Manorborn|HBG|1
 1 Gemrazer|IKO|1
 1 Gingerbread Cabin|ELD|1
-1 Goreclaw, Terror of Qal Sisma|J21|1
-1 Kogla, the Titan Ape|IKO|2
+1 Goreclaw, Terror of Qal Sisma|J22|1
+1 Kogla, the Titan Ape|IKO|1
 2 Krosan Warchief|C13|1
 1 Nature's Chosen|ALL|1
 4 Nature's Claim|MB1|1
@@ -37,14 +37,4 @@ Name=garruk
 1 Thragtusk|MM3|1
 2 Wicked Wolf|ELD|1
 1 Wild Endeavor|AFC|1
-1 Yedora, Grave Gardener|C21|2
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-
+1 Yedora, Grave Gardener|C21|1

--- a/forge-gui/res/adventure/Shandalar/decks/miniboss/jace.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/miniboss/jace.dck
@@ -1,12 +1,10 @@
 [metadata]
 Name=jace_boss
-[Avatar]
-
 [Main]
 1 Ancestral Recall|30A|1
 1 Arcanis the Omnipotent|C17|1
 2 Azorius Signet|NEC|1
-1 Bruvac the Grandiloquent|PLIST|1
+1 Bruvac the Grandiloquent|JMP|1
 3 Counterspell|SLD|1
 1 Evacuation|C16|1
 4 Island|M10|1
@@ -24,7 +22,7 @@ Name=jace_boss
 1 Jace, Cunning Castaway|XLN|1
 1 Jace, Ingenious Mind-Mage|XLN|1
 1 Jace, Memory Adept|M14|1
-1 Jace, Mirror Mage|ZNR|2
+1 Jace, Mirror Mage|ZNR|1
 1 Jace, the Living Guildpact|M15|1
 1 Jace, the Mind Sculptor|EMA|1
 1 Jace, the Perfected Mind|ONE|1
@@ -42,13 +40,3 @@ Name=jace_boss
 1 Time Warp|E02|1
 1 Timetwister|OVNT|4
 4 Tundra|VMA|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/miniboss/nahiri.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/miniboss/nahiri.dck
@@ -1,7 +1,5 @@
 [metadata]
 Name=nahiri
-[Avatar]
-
 [Main]
 2 Akiri, Fearless Voyager|ZNR|1
 4 Arid Mesa|SLU|1
@@ -10,12 +8,12 @@ Name=nahiri
 4 Clifftop Retreat|DMR|1
 1 Cloudsteel Kirin|NEO|1
 1 Danitha Capashen, Paragon|J22|1
-2 Disenchant|S00|1
+2 Disenchant|M20|1
 1 Embercleave|ELD|1
 2 Fervent Champion|ELD|1
 2 Goblin Gaveleer|2XM|1
 4 Inspiring Vantage|KLD|1
-1 Kaldra Compleat|PLIST|1
+1 Kaldra Compleat|MH2|1
 1 Kemba, Kha Enduring|ONE|1
 1 Kemba, Kha Regent|2XM|1
 1 Lion Sash|NEO|1
@@ -27,7 +25,7 @@ Name=nahiri
 1 Nahiri, Heir of the Ancients|ZNR|1
 1 Nahiri, Storm of Stone|WAR|1
 1 Nahiri, the Harbinger|SOI|1
-1 Nahiri, the Lithomancer|PLIST|1
+1 Nahiri, the Lithomancer|C14|1
 1 Nahiri, the Unforgiving|ONE|1
 4 Plains|BRO|3
 4 Plateau|PRM|1
@@ -36,19 +34,8 @@ Name=nahiri
 1 Seraphic Greatsword|CMR|1
 4 Sram, Senior Edificer|NEC|1
 2 Stoneforge Mystic|2XM|1
-1 Sword of Body and Mind|2XM|1
-1 Sword of Body and Mind|MPS_KLD|1
-1 Sword of Feast and Famine|PLIST|1
+2 Sword of Body and Mind|2XM|1
+1 Sword of Feast and Famine|2XM|1
 1 Sword of Hearth and Home|MH2|1
 1 Sword of Sinew and Steel|MH1|1
 3 Swords to Plowshares|DMR|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/miniboss/ooze_boss.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/miniboss/ooze_boss.dck
@@ -2,7 +2,7 @@
 Name=slime_boss
 [Main]
 2 Acidic Slime|C18|1
-1 Aeve, Progenitor Ooze|J21|1
+1 Aeve, Progenitor Ooze|MH2|1
 4 Bayou|30A|1
 1 Beast Within|BBD|1
 2 Beast Within|C21|1

--- a/forge-gui/res/adventure/Shandalar/decks/miniboss/sliver_shandalar.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/miniboss/sliver_shandalar.dck
@@ -15,7 +15,7 @@ Name=sliver_shandalar
 1 Mountain|CMR|1
 2 Mountain|M14|1
 3 Mountain|M14|3
-2 Path to Exile|TSR|1
+2 Path to Exile|2X2|1
 2 Plains|M14|1
 3 Plains|M14|4
 3 Predatory Sliver|M14|1
@@ -26,5 +26,3 @@ Name=sliver_shandalar
 3 Striking Sliver|M14|1
 4 Terramorphic Expanse|AFC|1
 1 Thorncaster Sliver|M14|1
-[Sideboard]
-

--- a/forge-gui/res/adventure/Shandalar/decks/miniboss/teferi_boss.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/miniboss/teferi_boss.dck
@@ -1,7 +1,5 @@
 [metadata]
 Name=teferi_boss
-[Avatar]
-
 [Main]
 1 Back to Basics|UMA|1
 1 Balance|30A|1
@@ -21,26 +19,16 @@ Name=teferi_boss
 1 Teferi's Protege|J22|1
 3 Teferi's Sentinel|DOM|1
 1 Teferi's Tutelage|M21|1
-2 Teferi, Hero of Dominaria|PPRO|1
+2 Teferi, Hero of Dominaria|DOM|1
 1 Teferi, Mage of Zhalfir|IMA|1
-1 Teferi, Master of Time|M21|9
+1 Teferi, Master of Time|M21|1
 1 Teferi, Temporal Archmage|C14|1
 1 Teferi, Temporal Pilgrim|BRO|1
 1 Teferi, Time Raveler|WAR|1
 1 Teferi, Who Slows the Sunset|MID|1
 1 The Tabernacle at Pendrell Vale|OLGC|1
 1 Time Warp|E02|1
-2 Time Wipe|PWAR|1
+2 Time Wipe|WAR|1
 4 Tundra|30A|1
 1 Winter Orb|EMA|1
 1 Zhalfirin Void|PDOM|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/miniboss/tibalt.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/miniboss/tibalt.dck
@@ -1,7 +1,5 @@
 [metadata]
 Name=tibalt
-[Avatar]
-
 [Main]
 2 Auntie Blyte, Bad Influence|J22|1
 2 Burn Down the House|MID|1
@@ -17,20 +15,10 @@ Name=tibalt
 25 Mountain|JMP|6
 2 Power Word Kill|AFR|1
 2 Tibalt's Trickery|KHM|1
-2 Tibalt, Rakish Instigator|PLIST|1
+2 Tibalt, Rakish Instigator|WAR|2
 1 Tibalt, the Fiend-Blooded|AVR|1
 2 Tibalt, Wicked Tormentor|YMID|1
 3 Tiefling Outcasts|HBG|1
 2 Vexing Devil|UMA|1
 1 Wildfire Devils|C19|1
 2 Zurzoth, Chaos Rider|NCC|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/minotaur.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/minotaur.dck
@@ -18,8 +18,7 @@ Name=minotaur
 1 Mogis's Favor|THB|1
 1 Mogis's Marauder|THS|1
 1 Mogis, God of Slaughter|BNG|1
-2 Mountain|THB|1
-1 Mountain|THB|2
+3 Mountain|THB|2
 2 Mountain|THB|3
 1 Mountain|THS|1
 1 Mountain|THS|2
@@ -34,8 +33,7 @@ Name=minotaur
 1 Skophos Warleader|THB|1
 1 Soulreaper of Mogis|THB|1
 1 Spite of Mogis|JOU|1
-1 Swamp|THB|1
-4 Swamp|THB|2
+5 Swamp|THB|2
 2 Swamp|THS|1
 1 Swamp|THS|2
 2 Swamp|THS|4

--- a/forge-gui/res/adventure/Shandalar/decks/mummy.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/mummy.dck
@@ -1,7 +1,5 @@
 [metadata]
 Name=mummy
-[Avatar]
-
 [Main]
 2 Binding Mummy|AKR|1
 2 Compulsory Rest|AKH|1
@@ -11,7 +9,7 @@ Name=mummy
 2 Festering Mummy|AKH|1
 3 Final Reward|AKH|1
 2 Gravedigger|AKH|1
-3 Grind // Dust|PLIST|1
+3 Grind // Dust|HOU|1
 4 Isolated Chapel|DMR|1
 3 Miasmic Mummy|AKR|1
 3 Mummy Paramount|HOU|1
@@ -24,13 +22,3 @@ Name=mummy
 3 Unraveling Mummy|HOU|1
 1 Vengeful Pharaoh|M12|1
 4 Wayward Servant|AKH|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/phoenix.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/phoenix.dck
@@ -2,10 +2,10 @@
 Name=Phoenix
 [Main]
 2 Blood Crypt|RNA|1
-1 Cavern of Souls|2X2|3
+1 Cavern of Souls|2X2|1
 4 Chandra's Phoenix|M14|1
 2 Clifftop Retreat|DOM|1
-2 Delayed Blast Fireball|CLB|1
+2 Delayed Blast Fireball|CLB|2
 2 Dragonskull Summit|DMC|1
 2 Fireball|CLB|1
 2 Firestorm|WTH|1
@@ -17,7 +17,7 @@ Name=Phoenix
 2 Molten Echoes|VOC|1
 4 Mountain|DMU|1
 2 Mountain|DMU|2
-3 Mountain|DMU|4
+3 Mountain|DMU|3
 2 Otharri, Suns' Glory|ONC|1
 4 Phoenix Chick|DMU|1
 2 Sacred Foundry|GRN|1
@@ -28,5 +28,3 @@ Name=Phoenix
 2 Syrix, Carrier of the Flame|NCC|1
 4 Tomakul Phoenix|YBRO|1
 2 Wall of Fire|M13|1
-[Sideboard]
-

--- a/forge-gui/res/adventure/Shandalar/decks/ramp.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/ramp.dck
@@ -1,7 +1,5 @@
 [metadata]
 Name=ramp
-[Avatar]
-
 [Main]
 1 Aggressive Mammoth|M19|1
 2 Blighted Woodland|MIC|1
@@ -28,23 +26,13 @@ Name=ramp
 1 Naga Vitalist|AKR|1
 3 Nature's Lore|AFC|1
 1 Panglacial Wurm|CSP|1
-1 Paradise Druid|J21|1
+1 Paradise Druid|J22|1
 1 Ram Through|IKO|1
 2 Rampant Growth|AFC|1
-1 Reclusive Taxidermist|VOW|2
+1 Reclusive Taxidermist|VOW|1
 3 Rift Sower|MH2|1
 2 Rosethorn Acolyte|ELD|1
 1 Selvala, Heart of the Wilds|JMP|1
 1 Titanic Growth|M21|1
-1 Titanoth Rex|IKO|2
+1 Titanoth Rex|IKO|1
 1 Wild Endeavor|AFC|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/ratswarm.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/ratswarm.dck
@@ -1,10 +1,8 @@
 [metadata]
 Name=ratswarm
-[Avatar]
-
 [Main]
 4 Burglar Rat|JMP|1
-4 Drainpipe Vermin|J21|1
+4 Drainpipe Vermin|JMP|1
 4 Muck Rats|PO2|1
 4 Plague Rats|30A|1
 4 Plaguecrafter's Familiar|J21|1
@@ -15,13 +13,3 @@ Name=ratswarm
 4 Typhoid Rats|M15|1
 4 Wave of Rats|NCC|1
 4 Zodiac Rat|PRM|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/reanimator.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/reanimator.dck
@@ -1,9 +1,7 @@
 [metadata]
 Name=reanimator
-[Avatar]
-
 [Main]
-2 Ancient Brass Dragon|HBG|1
+2 Ancient Brass Dragon|CLB|1
 1 Archfiend of Despair|BBD|1
 4 City of Brass|2X2|1
 1 Debtors' Knell|C21|1
@@ -13,7 +11,7 @@ Name=reanimator
 1 Griselbrand|MM3|1
 4 Karmic Guide|MH2|1
 4 Mana Confluence|CMR|1
-2 Mikaeus, the Unhallowed|PLIST|1
+2 Mikaeus, the Unhallowed|UMA|1
 3 Mountain|MH2|1
 2 Mountain|MH2|2
 1 Overseer of the Damned|MIC|1
@@ -26,13 +24,3 @@ Name=reanimator
 4 Two-Headed Hellkite|DMC|1
 4 Unburial Rites|C20|1
 4 Wheel of Fortune|30A|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/satyr.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/satyr.dck
@@ -1,15 +1,12 @@
 [metadata]
 Name=Satyr
-[Avatar]
-
 [Main]
 1 Anax, Hardened in the Forge|THB|1
 1 Blood Aspirant|THB|1
 1 Boon Satyr|C18|1
 2 Careless Celebrant|THB|1
 2 Destructive Revelry|THS|1
-1 Forest|THB|1
-3 Forest|THB|2
+4 Forest|THB|2
 1 Forest|THS|1
 1 Forest|THS|2
 3 Forest|THS|3
@@ -20,8 +17,7 @@ Name=Satyr
 2 Lightning Strike|THS|1
 1 Lumbering Satyr|MMQ|1
 2 Mischief and Mayhem|BNG|1
-1 Mountain|THB|1
-2 Mountain|THB|2
+3 Mountain|THB|2
 3 Mountain|THB|3
 1 Mountain|THS|1
 3 Mountain|THS|2
@@ -45,13 +41,3 @@ Name=Satyr
 1 Voyaging Satyr|CN2|1
 2 Wild Celebrants|CMR|1
 1 Xenagos, God of Revels|BNG|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/scarecrow.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/scarecrow.dck
@@ -1,7 +1,5 @@
 [metadata]
 Name=scarecrow
-[Avatar]
-
 [Main]
 3 Ancient Tomb|UMA|1
 3 Colossal Plow|NEC|1
@@ -11,17 +9,7 @@ Name=scarecrow
 4 Meekstone|30A|1
 4 Scarecrone|JMP|1
 4 Scuttlemutt|JMP|1
-4 Signpost Scarecrow|PLIST|1
+4 Signpost Scarecrow|ELD|1
 21 Wastes|J22|1
 4 Wicker Witch|SOI|1
 4 Wickerwing Effigy|YMID|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/scarecrowcaptain.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/scarecrowcaptain.dck
@@ -1,14 +1,12 @@
 [metadata]
 Name=scarecrowleader
-[Avatar]
-
 [Main]
 2 All Is Dust|UMA|1
 3 Ancient Tomb|UMA|1
 2 Damnation|PLC|1
 3 Death Cloud|DST|1
 4 Defile|MH1|1
-3 Feed the Swarm|J21|1
+3 Feed the Swarm|CLB|1
 4 Gate of the Black Dragon|HBG|1
 4 Mind Stone|WTH|1
 4 Power Word Kill|AFR|1
@@ -18,13 +16,3 @@ Name=scarecrowleader
 4 Torment of Hailfire|HOU|1
 3 Unearth|ULG|1
 4 Witch's Cottage|ELD|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/sea_monster.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/sea_monster.dck
@@ -16,10 +16,10 @@ Name=sea_monster
 8 Island|DOM|3
 3 Island|JMP|6
 4 Island|M12|3
-4 Island|VOW|4
+4 Island|VOW|3
 2 Island|ZNR|3
 2 Kraken Hatchling|BBD|1
-1 Lorthos, the Tidemaker|PLIST|1
+1 Lorthos, the Tidemaker|C14|1
 1 Master of the Pearl Trident|DDT|1
 1 Merfolk Sovereign|E02|1
 1 Merfolk Wayfinder|DDT|1

--- a/forge-gui/res/adventure/Shandalar/decks/skeleton_2.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/skeleton_2.dck
@@ -1,12 +1,10 @@
 [metadata]
 Name=skeleton_2
-[Avatar]
-
 [Main]
 1 Abnormal Endurance|J21|1
 1 Augur of Skulls|FUT|1
 1 Barrier of Bones|GRN|1
-1 Blight Sickle|PLIST|1
+1 Blight Sickle|SHM|1
 1 Bone Dragon|M19|1
 2 Bone Shards|MH2|1
 1 Bone Splinters|ALA|1
@@ -47,13 +45,3 @@ Name=skeleton_2
 1 Unburial Rites|AFC|1
 1 Urborg Skeleton|INV|1
 1 Wall of Bone|M10|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/snake.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/snake.dck
@@ -1,13 +1,11 @@
 [metadata]
 Name=snake
-[Avatar]
-
 [Main]
 1 Ambush Viper|ISD|1
 2 Become Immense|KTK|1
 1 Cobra Trap|C15|1
 4 Death-Hood Cobra|NPH|1
-1 Deathcap Glade|VOW|2
+1 Deathcap Glade|VOW|1
 1 Desert|AFC|1
 3 Desert of the Glorified|AKR|1
 3 Desert of the Indomitable|AKR|1
@@ -39,20 +37,10 @@ Name=snake
 1 Seed the Land|SOK|1
 1 Seshiro the Anointed|CHK|1
 4 Snakeskin Veil|KHM|1
-1 Stonecoil Serpent|PRES|1
+1 Stonecoil Serpent|ELD|1
 1 Sunscorched Desert|AKR|1
 1 Swamp|CHK|4
 1 Swamp|THB|3
 1 Voracious Typhon|THB|1
 1 Wasteland Viper|GTC|1
 1 Zodiac Snake|PRM|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/squirrel.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/squirrel.dck
@@ -1,12 +1,10 @@
 [metadata]
 Name=squirrel
-[Avatar]
-
 [Main]
 4 Bayou|30A|1
 4 Chatter of the Squirrel|SLD|1
-2 Chatterfang, Squirrel General|J21|1
-2 Chitterspitter|J21|1
+2 Chatterfang, Squirrel General|MH2|1
+2 Chitterspitter|MH2|1
 1 Deep Forest Hermit|MH1|1
 1 Deranged Hermit|VMA|1
 1 Drey Keeper|MH2|1
@@ -17,25 +15,15 @@ Name=squirrel
 1 Liege of the Hollows|WTH|1
 4 Necroblossom Snarl|STX|1
 1 Nut Collector|DMR|1
-3 Ravenous Squirrel|J21|1
+3 Ravenous Squirrel|MH2|1
 2 Scurrid Colony|STX|1
 4 Squirrel Mob|MH2|1
 3 Squirrel Sanctuary|MH2|1
-4 Squirrel Sovereign|J21|1
-1 Squirrel Wrangler|J21|1
+4 Squirrel Sovereign|MH2|1
+1 Squirrel Wrangler|SLD|1
 1 Swamp|MH2|1
 2 Swamp|MH2|2
 4 Swarmyard|SLD|1
 2 Toski, Bearer of Secrets|KHM|1
 1 Verdant Command|MH2|1
 4 Woodland Cemetery|DOM|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/torturer.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/torturer.dck
@@ -1,7 +1,5 @@
 [metadata]
 Name=torturer
-[Avatar]
-
 [Main]
 2 Damnation|SLD|1
 4 Hymn to Tourach|PRM|1
@@ -10,19 +8,9 @@ Name=torturer
 4 Reanimate|CC2|1
 2 Sinkhole|EMA|1
 4 Smallpox|TSR|1
-2 Sudden Edict|J21|1
+2 Sudden Edict|MH2|1
 24 Swamp|JMP|7
 2 Tergrid, God of Fright|KHM|1
 4 The Rack|PRM|1
 2 Tinybones, Trinket Thief|JMP|1
 3 Underworld Dreams|10E|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/treefolk.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/treefolk.dck
@@ -1,7 +1,5 @@
 [metadata]
 Name=treefolk
-[Avatar]
-
 [Main]
 1 Awakener Druid|M10|1
 1 Battlewand Oak|LRW|1
@@ -19,8 +17,7 @@ Name=treefolk
 1 Forest|M19|1
 2 Forest|M19|3
 3 Forest|M19|4
-1 Forest|MID|1
-1 Forest|MID|3
+2 Forest|MID|3
 2 Forest|PTK|3
 1 Forest|SHM|1
 1 Forest|SHM|3
@@ -54,13 +51,3 @@ Name=treefolk
 1 Weatherseed Totem|TSP|1
 1 Willow Dryad|POR|1
 1 Willow Geist|MID|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/vampire_blood_token_fly.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/vampire_blood_token_fly.dck
@@ -2,9 +2,9 @@
 Name=VAMPIRE Blood Token Fly
 [Main]
 1 Anje, Maid of Dishonor|VOW|1
-1 Belligerent Guest|VOW|2
+1 Belligerent Guest|VOW|1
 2 Blood Fountain|VOW|1
-1 Blood Petal Celebrant|VOW|2
+1 Blood Petal Celebrant|VOW|1
 1 Blood Servitor|VOW|1
 1 Bloodthirsty Adversary|MID|1
 1 Bloodtithe Collector|MID|1
@@ -14,32 +14,26 @@ Name=VAMPIRE Blood Token Fly
 1 Ceremonial Knife|VOW|1
 1 Courier Bat|VOW|1
 4 Evolving Wilds|VOW|1
-1 Falkenrath Forebear|VOW|2
+1 Falkenrath Forebear|VOW|1
 2 Gluttonous Guest|VOW|1
-1 Haunted Ridge|MID|2
+1 Haunted Ridge|MID|1
 2 Lacerate Flesh|VOW|1
-2 Mountain|MID|1
-2 Mountain|MID|3
-2 Mountain|VOW|1
-3 Mountain|VOW|4
+4 Mountain|MID|3
+5 Mountain|VOW|3
 1 Mounted Dreadknight|MID|1
 1 Olivia's Attendants|VOW|1
 1 Olivia, Crimson Bride|VOW|1
-2 Restless Bloodseeker|VOW|2
+2 Restless Bloodseeker|VOW|1
 1 Slaughter Specialist|MID|1
 2 Stolen Vitality|MID|1
-2 Swamp|MID|1
-1 Swamp|MID|2
-1 Swamp|MID|3
-2 Swamp|VOW|1
-1 Swamp|VOW|3
-2 Swamp|VOW|4
+4 Swamp|MID|3
+5 Swamp|VOW|3
 2 Vampire Interloper|MID|1
 1 Vampire Socialite|MID|1
 1 Vampire's Kiss|VOW|1
 2 Vampires' Vengeance|VOW|1
 1 Voldaren Bloodcaster|VOW|1
 1 Voldaren Epicure|VOW|1
-1 Voldaren Estate|VOW|2
+1 Voldaren Estate|VOW|1
 1 Voldaren Stinger|MID|1
 1 Wedding Invitation|VOW|1

--- a/forge-gui/res/adventure/Shandalar/decks/walkingbrain.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/walkingbrain.dck
@@ -1,17 +1,13 @@
 [metadata]
 Name=walkingbrain
-[Avatar]
-
 [Main]
 4 Annex|ONS|1
 1 Beguiler of Wills|DKA|1
 4 Confiscate|CMR|1
-2 Empress Galina|PLIST|1
+2 Empress Galina|INV|1
 2 Invoke the Winds|NEO|1
-9 Island|NEO|1
-6 Island|NEO|2
-4 Island|NEO|3
-5 Island|NEO|4
+14 Island|NEO|1
+10 Island|NEO|2
 1 Keiga, the Tide Star|CLB|1
 1 Kiora Bests the Sea God|THB|1
 4 Mind Flayer|AFR|1
@@ -21,13 +17,3 @@ Name=walkingbrain
 2 Steal Artifact|30A|1
 2 Steal Enchantment|TMP|1
 4 Thran Dynamo|C19|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/water_elemental.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/water_elemental.dck
@@ -1,7 +1,5 @@
 [metadata]
 Name=water_elemental
-[Avatar]
-
 [Main]
 1 Aethersnipe|UMA|1
 1 Air-Cult Elemental|AFR|1
@@ -10,7 +8,7 @@ Name=water_elemental
 1 Brine Elemental|TSP|1
 2 Cavalier of Gales|M20|1
 3 Cloudkin Seer|MB1|1
-4 Floodhound|J21|1
+4 Floodhound|J22|1
 3 Glimmerbell|IKO|1
 23 Island|BRO|4
 1 Nimbus of the Isles|BBD|1
@@ -23,13 +21,3 @@ Name=water_elemental
 2 Water Servant|M14|1
 2 Water Weird|HBG|1
 1 Watercourser|MB1|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-

--- a/forge-gui/res/adventure/Shandalar/decks/werewolf.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/werewolf.dck
@@ -3,9 +3,9 @@ Name=werewolf
 [Main]
 1 Avabruck Caretaker|VOW|1
 1 Ballista Watcher|VOW|1
-2 Bird Admirer|MID|2
+2 Bird Admirer|MID|1
 1 Brood Weaver|MID|1
-1 Cemetery Prowler|VOW|2
+1 Cemetery Prowler|VOW|1
 1 Child of the Pack|VOW|1
 1 End the Festivities|VOW|1
 4 Evolving Wilds|VOW|1
@@ -14,20 +14,20 @@ Name=werewolf
 3 Forest|SOI|2
 4 Forest|SOI|3
 1 Hookhand Mariner|VOW|1
-1 Howling Moon|VOW|2
+1 Howling Moon|VOW|1
 4 Hungry Ridgewolf|VOW|1
-1 Ill-Tempered Loner|VOW|2
+1 Ill-Tempered Loner|VOW|1
 1 Infestation Expert|VOW|1
 1 Into the Night|VOW|1
-1 Kessig Naturalist|MID|2
+1 Kessig Naturalist|MID|1
 2 Lunar Frenzy|MID|1
 5 Mountain|SOI|1
 3 Mountain|SOI|2
 2 Mountain|SOI|3
 1 Oakshade Stalker|VOW|1
-1 Outland Liberator|MID|2
+1 Outland Liberator|MID|1
 2 Packsong Pup|VOW|1
-1 Rockfall Vale|MID|2
+1 Rockfall Vale|MID|1
 4 Uncaged Fury|SOI|1
 1 Volatile Arsonist|VOW|1
 1 Weaver of Blossoms|VOW|1

--- a/forge-gui/res/adventure/Shandalar/decks/wild-magic_sorcerer.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/wild-magic_sorcerer.dck
@@ -8,16 +8,16 @@ Name=wild-magic_sorcerer
 2 Boarding Party|CMR|1
 1 Crashing Footfalls|MH1|1
 1 Creative Technique|C21|1
-2 Delayed Blast Fireball|CLB|1
+2 Delayed Blast Fireball|CLB|2
 2 Epochrasite|CM2|1
 1 Escape to the Wilds|ELD|1
-2 Faldorn, Dread Wolf Herald|CLB|1
+2 Faldorn, Dread Wolf Herald|CLB|2
 4 Forest|DOM|1
 2 Forest|DOM|2
 1 Forest|DOM|3
 2 Forest|DOM|4
 2 Goblin Anarchomancer|MH2|1
-1 Journey to the Lost City|CLB|1
+1 Journey to the Lost City|CLB|2
 1 Kami of Celebration|NEC|1
 2 Laelia, the Blade Reforged|C21|1
 1 Mosswort Bridge|NCC|1
@@ -32,7 +32,7 @@ Name=wild-magic_sorcerer
 1 Sweet-Gum Recluse|CMR|1
 1 Tectonic Giant|THB|1
 1 Valakut Exploration|ZNR|1
-1 Venture Forth|CLB|1
+1 Venture Forth|CLB|2
 1 Volcanic Torrent|CMR|1
 2 Wild-Magic Sorcerer|AFC|1
 2 Wooded Ridgeline|DMU|1

--- a/forge-gui/res/adventure/Shandalar/decks/yeti.dck
+++ b/forge-gui/res/adventure/Shandalar/decks/yeti.dck
@@ -1,7 +1,5 @@
 [metadata]
 Name=Yeti
-[Avatar]
-
 [Main]
 1 Blessing of Frost|KHM|1
 1 Drelnoch|CSP|1
@@ -11,7 +9,7 @@ Name=Yeti
 2 Highland Forest|KHM|1
 2 Highland Weald|CSP|1
 1 Hungering Yeti|FRF|1
-1 Ice-Fang Coatl|H1R|1
+1 Ice-Fang Coatl|MH1|1
 1 Icehide Troll|KHM|1
 1 Karplusan Strider|MM2|1
 1 Karplusan Yeti|9ED|1
@@ -40,13 +38,3 @@ Name=Yeti
 4 Volatile Fjord|KHM|1
 1 Wiitigo|ME2|1
 1 Woolly Mammoths|ME2|1
-[Sideboard]
-
-[Planes]
-
-[Schemes]
-
-[Conspiracy]
-
-[Dungeon]
-


### PR DESCRIPTION
This updates the printings of cards in many Adventure Mode decks to avoid online-only editions (when possible), and standardize frames to the same style. I tried to avoid changing anything that looked like a deliberate choice by the designer.