### PR TITLE
PaidLists now store if the CostPart source is linked to host

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
@@ -796,6 +796,10 @@ public class ComputerUtilCost {
                 if (toBeCountered.isSpell() && !CardFactoryUtil.isCounterable(toBeCountered.getHostCard())) {
                     return false;
                 }
+                // no reason to pay if we don't plan to confirm
+                if (toBeCountered.isOptionalTrigger() && !SpellApiToAi.Converter.get(toBeCountered.getApi()).doTriggerNoCostWithSubs(payer, toBeCountered, false)) {
+                    return false;
+                }
                 // TODO check hasFizzled
             }
         }

--- a/forge-ai/src/main/java/forge/ai/ability/BecomesBlockedAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/BecomesBlockedAi.java
@@ -29,7 +29,6 @@ public class BecomesBlockedAi extends SpellAbilityAi {
         if (tgt != null) {
         	sa.resetTargets();
 	        CardCollection list = CardLists.filterControlledBy(game.getCardsIn(ZoneType.Battlefield), aiPlayer.getOpponents());
-	        list = CardLists.getValidCards(list, tgt.getValidTgts(), source.getController(), source, sa);
 	        list = CardLists.getTargetableCards(list, sa);
 	        list = CardLists.getNotKeyword(list, Keyword.TRAMPLE);
 

--- a/forge-ai/src/main/java/forge/ai/ability/BidLifeAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/BidLifeAi.java
@@ -26,7 +26,6 @@ public class BidLifeAi extends SpellAbilityAi {
             sa.resetTargets();
             if (tgt.canTgtCreature()) {
                 List<Card> list = CardLists.getTargetableCards(AiAttackController.choosePreferredDefenderPlayer(aiPlayer).getCardsIn(ZoneType.Battlefield), sa);
-                list = CardLists.getValidCards(list, tgt.getValidTgts(), source.getController(), source, sa);
                 if (list.isEmpty()) {
                     return false;
                 }

--- a/forge-ai/src/main/java/forge/ai/ability/DamageDealAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DamageDealAi.java
@@ -471,8 +471,7 @@ public class DamageDealAi extends DamageAiBase {
         }
         for (final Object o : objects) {
             if (o instanceof Card) {
-                final Card c = (Card) o;
-                hPlay.remove(c);
+                hPlay.remove(o);
             }
         }
         hPlay = CardLists.getTargetableCards(hPlay, sa);

--- a/forge-ai/src/main/java/forge/ai/ability/DamagePreventAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DamagePreventAi.java
@@ -91,8 +91,7 @@ public class DamagePreventAi extends SpellAbilityAi {
             }
             final List<Card> threatenedTargets = new ArrayList<>();
             // filter AIs battlefield by what I can target
-            List<Card> targetables = CardLists.getValidCards(ai.getCardsIn(ZoneType.Battlefield), tgt.getValidTgts(), ai, hostCard, sa);
-            targetables = CardLists.getTargetableCards(targetables, sa);
+            List<Card> targetables = CardLists.getTargetableCards(ai.getCardsIn(ZoneType.Battlefield), sa);
 
             for (final Card c : targetables) {
                 if (objects.contains(c)) {

--- a/forge-ai/src/main/java/forge/ai/ability/EffectAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/EffectAi.java
@@ -104,7 +104,6 @@ public class EffectAi extends SpellAbilityAi {
                         }
                     } else {
                         List<Card> list = game.getCombat().getAttackers();
-                        list = CardLists.getValidCards(list, tgt.getValidTgts(), sa.getActivatingPlayer(), sa.getHostCard(), sa);
                         list = CardLists.getTargetableCards(list, sa);
                         Card target = ComputerUtilCard.getBestCreatureAI(list);
                         if (target == null) {

--- a/forge-ai/src/main/java/forge/ai/ability/PhasesAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PhasesAi.java
@@ -111,10 +111,8 @@ public class PhasesAi extends SpellAbilityAi {
 
     private boolean phasesUnpreferredTargeting(final Game game, final SpellAbility sa, final boolean mandatory) {
         final Card source = sa.getHostCard();
-        final TargetRestrictions tgt = sa.getTargetRestrictions();
 
-        CardCollectionView list = game.getCardsIn(ZoneType.Battlefield);
-        list = CardLists.getTargetableCards(CardLists.getValidCards(list, tgt.getValidTgts(), source.getController(), source, sa), sa);
+        CardCollectionView list = CardLists.getTargetableCards(game.getCardsIn(ZoneType.Battlefield), sa);
 
         // in general, if it's our own creature, choose the weakest one, if it's the opponent's creature,
         // choose the strongest one

--- a/forge-ai/src/main/java/forge/ai/ability/PlayAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PlayAi.java
@@ -172,7 +172,7 @@ public class PlayAi extends SpellAbilityAi {
                             abCost = new Cost(sa.getParam("PlayCost"), false);
                         }
 
-                        spell = (Spell) spell.copyWithDefinedCost(abCost);
+                        spell = (Spell) spell.copyWithManaCostReplaced(spell.getActivatingPlayer(), abCost);
                     }
                     if (AiPlayDecision.WillPlay == ((PlayerControllerAi)ai.getController()).getAi().canPlayFromEffectAI(spell, !(isOptional || sa.hasParam("Optional")), true)) {
                         // Before accepting, see if the spell has a valid number of targets (it should at this point).

--- a/forge-ai/src/main/java/forge/ai/ability/RegenerateAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/RegenerateAi.java
@@ -87,9 +87,7 @@ public class RegenerateAi extends SpellAbilityAi {
         } else {
             sa.resetTargets();
             // filter AIs battlefield by what I can target
-            List<Card> targetables = CardLists.getValidCards(ai.getCardsIn(ZoneType.Battlefield), tgt.getValidTgts(),
-                    ai, hostCard, sa);
-            targetables = CardLists.getTargetableCards(targetables, sa);
+            List<Card> targetables = CardLists.getTargetableCards(ai.getCardsIn(ZoneType.Battlefield), sa);
 
             if (targetables.size() == 0) {
                 return false;
@@ -149,14 +147,10 @@ public class RegenerateAi extends SpellAbilityAi {
     }
 
     private static boolean regenMandatoryTarget(final Player ai, final SpellAbility sa, final boolean mandatory) {
-        final Card hostCard = sa.getHostCard();
         final Game game = ai.getGame();
-        final TargetRestrictions tgt = sa.getTargetRestrictions();
         sa.resetTargets();
         // filter AIs battlefield by what I can target
-        CardCollectionView targetables = game.getCardsIn(ZoneType.Battlefield);
-        targetables = CardLists.getValidCards(targetables, tgt.getValidTgts(), ai, hostCard, sa);
-        targetables = CardLists.getTargetableCards(targetables, sa);
+        CardCollectionView targetables = CardLists.getTargetableCards(game.getCardsIn(ZoneType.Battlefield), sa);
         final List<Card> compTargetables = CardLists.filterControlledBy(targetables, ai);
 
         if (targetables.size() == 0) {

--- a/forge-ai/src/main/java/forge/ai/ability/TokenAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/TokenAi.java
@@ -145,7 +145,6 @@ public class TokenAi extends SpellAbilityAi {
         /*
          * readParameters() is called in checkPhaseRestrictions
          */
-        final Card source = sa.getHostCard();
         final Game game = ai.getGame();
         final Player opp = ai.getWeakestOpponent();
 
@@ -174,9 +173,7 @@ public class TokenAi extends SpellAbilityAi {
                     sa.getTargets().add(ai);
                 } else {
                     // Flash Foliage
-                    CardCollection list =  ai.getOpponents().getCardsIn(ZoneType.Battlefield);
-                    list = CardLists.getValidCards(list, tgt.getValidTgts(), source.getController(), source, sa);
-                    list = CardLists.getTargetableCards(list, sa);
+                    CardCollection list = CardLists.getTargetableCards(ai.getOpponents().getCardsIn(ZoneType.Battlefield), sa);
                     CardCollection betterList = CardLists.filter(list, new Predicate<Card>() {
                         @Override
                         public boolean apply(Card c) {

--- a/forge-ai/src/main/java/forge/ai/ability/UntapAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/UntapAi.java
@@ -241,9 +241,7 @@ public class UntapAi extends SpellAbilityAi {
         final Card source = sa.getHostCard();
         final TargetRestrictions tgt = sa.getTargetRestrictions();
 
-        CardCollection list = CardLists.getValidCards(source.getGame().getCardsIn(ZoneType.Battlefield),
-                tgt.getValidTgts(), source.getController(), source, sa);
-        list = CardLists.getTargetableCards(list, sa);
+        CardCollection list = CardLists.getTargetableCards(source.getGame().getCardsIn(ZoneType.Battlefield), sa);
 
         // filter by enchantments and planeswalkers, their tapped state doesn't matter.
         final String[] tappablePermanents = { "Enchantment", "Planeswalker" };

--- a/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
@@ -144,7 +144,7 @@ public class AbilityUtils {
             c = hostCard.getEnchantingCard();
             if (c == null && sa instanceof SpellAbility) {
                 SpellAbility root = ((SpellAbility)sa).getRootAbility();
-                CardCollection sacrificed = root.getPaidList("Sacrificed");
+                CardCollection sacrificed = root.getPaidList("Sacrificed", true);
                 if (sacrificed != null && !sacrificed.isEmpty()) {
                     c = sacrificed.getFirst().getEnchantingCard();
                 }
@@ -742,29 +742,29 @@ public class AbilityUtils {
             } else { // these ones only for handling lists
                 Iterable<Card> list = null;
                 if (calcX[0].startsWith("Sacrificed")) {
-                    list = sa.getRootAbility().getPaidList("Sacrificed");
+                    list = sa.getRootAbility().getPaidList("Sacrificed", true);
                 }
                 else if (calcX[0].startsWith("Discarded")) {
                     final SpellAbility root = sa.getRootAbility();
-                    list = root.getPaidList("Discarded");
+                    list = root.getPaidList("Discarded", true);
                     if (null == list && root.isTrigger()) {
-                        list = root.getHostCard().getSpellPermanent().getPaidList("Discarded");
+                        list = root.getHostCard().getSpellPermanent().getPaidList("Discarded", true);
                     }
                 }
                 else if (calcX[0].startsWith("Exiled")) {
-                    list = sa.getRootAbility().getPaidList("Exiled");
+                    list = sa.getRootAbility().getPaidList("Exiled", true);
                 }
                 else if (calcX[0].startsWith("Milled")) {
-                    list = sa.getRootAbility().getPaidList("Milled");
+                    list = sa.getRootAbility().getPaidList("Milled", true);
                 }
                 else if (calcX[0].startsWith("Tapped")) {
-                    list = sa.getRootAbility().getPaidList("Tapped");
+                    list = sa.getRootAbility().getPaidList("Tapped", true);
                 }
                 else if (calcX[0].startsWith("Revealed")) {
-                    list = sa.getRootAbility().getPaidList("Revealed");
+                    list = sa.getRootAbility().getPaidList("Revealed", true);
                 }
                 else if (calcX[0].startsWith("Returned")) {
-                    list = sa.getRootAbility().getPaidList("Returned");
+                    list = sa.getRootAbility().getPaidList("Returned", true);
                 }
                 else if (calcX[0].startsWith("Targeted")) {
                     list = sa.findTargetedCards();
@@ -1606,40 +1606,40 @@ public class AbilityUtils {
 
         if (sa.hasParam("RememberCostCards") && !sa.getPaidHash().isEmpty()) {
             List <Card> noList = Lists.newArrayList();
-            Map<String, CardCollection> paidLists = sa.getPaidHash();
+            Table<String, Boolean, CardCollection> paidLists = sa.getPaidHash();
             if (sa.hasParam("RememberCostExcept")) {
                 noList.addAll(AbilityUtils.getDefinedCards(host, sa.getParam("RememberCostExcept"), sa));
             }
-            if (paidLists.containsKey("Exiled")) {
-                final CardCollection paidListExiled = sa.getPaidList("Exiled");
+            if (paidLists.contains("Exiled", true)) {
+                final CardCollection paidListExiled = sa.getPaidList("Exiled", true);
                 for (final Card exiledAsCost : paidListExiled) {
                     if (!noList.contains(exiledAsCost)) {
                         host.addRemembered(exiledAsCost);
                     }
                 }
-            } else if (paidLists.containsKey("Sacrificed")) {
-                final CardCollection paidListSacrificed = sa.getPaidList("Sacrificed");
+            } else if (paidLists.contains("Sacrificed", true)) {
+                final CardCollection paidListSacrificed = sa.getPaidList("Sacrificed", true);
                 for (final Card sacrificedAsCost : paidListSacrificed) {
                     if (!noList.contains(sacrificedAsCost)) {
                         host.addRemembered(sacrificedAsCost);
                     }
                 }
-            } else if (paidLists.containsKey("Tapped")) {
-                final CardCollection paidListTapped = sa.getPaidList("Tapped");
+            } else if (paidLists.contains("Tapped", true)) {
+                final CardCollection paidListTapped = sa.getPaidList("Tapped", true);
                 for (final Card tappedAsCost : paidListTapped) {
                     if (!noList.contains(tappedAsCost)) {
                         host.addRemembered(tappedAsCost);
                     }
                 }
-            } else if (paidLists.containsKey("Unattached")) {
-                final CardCollection paidListUnattached = sa.getPaidList("Unattached");
+            } else if (paidLists.contains("Unattached", true)) {
+                final CardCollection paidListUnattached = sa.getPaidList("Unattached", true);
                 for (final Card unattachedAsCost : paidListUnattached) {
                     if (!noList.contains(unattachedAsCost)) {
                         host.addRemembered(unattachedAsCost);
                     }
                 }
-            } else if (paidLists.containsKey("Discarded")) {
-                final CardCollection paidListDiscarded = sa.getPaidList("Discarded");
+            } else if (paidLists.contains("Discarded", true)) {
+                final CardCollection paidListDiscarded = sa.getPaidList("Discarded", true);
                 for (final Card discardedAsCost : paidListDiscarded) {
                     if (!noList.contains(discardedAsCost)) {
                         host.addRemembered(discardedAsCost);
@@ -3860,29 +3860,29 @@ public class AbilityUtils {
             SpellAbility root = ((SpellAbility)sa).getRootAbility();
             // TODO do we really need these checks?
             if (defined.startsWith("SacrificedCards")) {
-                list = root.getPaidList("SacrificedCards");
+                list = root.getPaidList("SacrificedCards", true);
             } else if (defined.startsWith("Sacrificed")) {
-                list = root.getPaidList("Sacrificed");
+                list = root.getPaidList("Sacrificed", true);
             } else if (defined.startsWith("Revealed")) {
-                list = root.getPaidList("Revealed");
+                list = root.getPaidList("Revealed", true);
             } else if (defined.startsWith("DiscardedCards")) {
-                list = root.getPaidList("DiscardedCards");
+                list = root.getPaidList("DiscardedCards", true);
             } else if (defined.startsWith("Discarded")) {
-                list = root.getPaidList("Discarded");
+                list = root.getPaidList("Discarded", true);
             } else if (defined.startsWith("ExiledCards")) {
-                list = root.getPaidList("ExiledCards");
+                list = root.getPaidList("ExiledCards", true);
             } else if (defined.startsWith("Exiled")) {
-                list = root.getPaidList("Exiled");
+                list = root.getPaidList("Exiled", true);
             } else if (defined.startsWith("Milled")) {
-                list = root.getPaidList("Milled");
+                list = root.getPaidList("Milled", true);
             } else if (defined.startsWith("TappedCards")) {
-                list = root.getPaidList("TappedCards");
+                list = root.getPaidList("TappedCards", true);
             } else if (defined.startsWith("Tapped")) {
-                list = root.getPaidList("Tapped");
+                list = root.getPaidList("Tapped", true);
             } else if (defined.startsWith("UntappedCards")) {
-                list = root.getPaidList("UntappedCards");
+                list = root.getPaidList("UntappedCards", true);
             } else if (defined.startsWith("Untapped")) {
-                list = root.getPaidList("Untapped");
+                list = root.getPaidList("Untapped", true);
             }
         }
         return list;

--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
@@ -696,7 +696,7 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
                     }
                     if (sa.isNinjutsu()) {
                         // Ninjutsu need to get the Defender of the Returned Creature
-                        final Card returned = sa.getPaidList("Returned").getFirst();
+                        final Card returned = sa.getPaidList("Returned", true).getFirst();
                         final GameEntity defender = game.getCombat().getDefenderByAttacker(returned);
                         game.getCombat().addAttacker(movedCard, defender);
                         game.getCombat().getBandOfAttacker(movedCard).setBlocked(false);

--- a/forge-game/src/main/java/forge/game/ability/effects/PlayEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PlayEffect.java
@@ -371,7 +371,7 @@ public class PlayEffect extends SpellAbilityEffect {
                     abCost = new Cost(cost, false);
                 }
 
-                tgtSA = tgtSA.copyWithDefinedCost(abCost);
+                tgtSA = tgtSA.copyWithManaCostReplaced(tgtSA.getActivatingPlayer(), abCost);
             }
 
             if (!optional) {

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -5847,7 +5847,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
         timesCrewedThisTurn += 1;
         Map<AbilityKey, Object> runParams = AbilityKey.newMap();
         runParams.put(AbilityKey.Vehicle, this);
-        runParams.put(AbilityKey.Crew, sa.getPaidList("TappedCards"));
+        runParams.put(AbilityKey.Crew, sa.getPaidList("TappedCards", true));
         game.getTriggerHandler().runTrigger(TriggerType.BecomesCrewed, runParams, false);
     }
 

--- a/forge-game/src/main/java/forge/game/card/CardLists.java
+++ b/forge-game/src/main/java/forge/game/card/CardLists.java
@@ -231,15 +231,15 @@ public class CardLists {
     }
 
     public static CardCollection getTargetableCards(Iterable<Card> cardList, SpellAbility source) {
-        CardCollection result = CardLists.filter(cardList, CardPredicates.isTargetableBy(source));
+        final CardCollection result = CardLists.filter(cardList, CardPredicates.isTargetableBy(source));
         // Filter more cards that can only be detected along with other candidates
         if (source.getTargets().isEmpty() && source.usesTargeting() && source.getMinTargets() >= 2) {
             CardCollection removeList = new CardCollection();
             TargetRestrictions tr = source.getTargetRestrictions();
-            for (final Card card : cardList) {
+            for (final Card card : result) {
                 if (tr.isSameController()) {
                     boolean found = false;
-                    for (final Card card2 : cardList) {
+                    for (final Card card2 : result) {
                         if (card != card2 && card.getController() == card2.getController()) {
                             found = true;
                             break;
@@ -252,7 +252,7 @@ public class CardLists {
 
                 if (tr.isWithoutSameCreatureType()) {
                     boolean found = false;
-                    for (final Card card2 : cardList) {
+                    for (final Card card2 : result) {
                         if (card != card2 && !card.sharesCreatureTypeWith(card2)) {
                             found = true;
                             break;
@@ -265,7 +265,7 @@ public class CardLists {
 
                 if (tr.isWithSameCreatureType()) {
                     boolean found = false;
-                    for (final Card card2 : cardList) {
+                    for (final Card card2 : result) {
                         if (card != card2 && card.sharesCreatureTypeWith(card2)) {
                             found = true;
                             break;
@@ -278,7 +278,7 @@ public class CardLists {
 
                 if (tr.isWithSameCardType()) {
                     boolean found = false;
-                    for (final Card card2 : cardList) {
+                    for (final Card card2 : result) {
                         if (card != card2 && card.sharesCardTypeWith(card2)) {
                             found = true;
                             break;

--- a/forge-game/src/main/java/forge/game/card/CardProperty.java
+++ b/forge-game/src/main/java/forge/game/card/CardProperty.java
@@ -866,9 +866,9 @@ public class CardProperty {
                 } else if (restriction.equals("MovedToGrave")) {
                     if (!(spellAbility instanceof SpellAbility)) {
                         final SpellAbility root = ((SpellAbility) spellAbility).getRootAbility();
-                        if (root != null && (root.getPaidList("MovedToGrave") != null)
-                                && !root.getPaidList("MovedToGrave").isEmpty()) {
-                            final CardCollectionView cards = root.getPaidList("MovedToGrave");
+                        if (root != null && (root.getPaidList("MovedToGrave", true) != null)
+                                && !root.getPaidList("MovedToGrave", true).isEmpty()) {
+                            final CardCollectionView cards = root.getPaidList("MovedToGrave", true);
                             for (final Card c : cards) {
                                 String name = c.getName();
                                 if (StringUtils.isEmpty(name)) {

--- a/forge-game/src/main/java/forge/game/card/CardUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardUtil.java
@@ -35,7 +35,6 @@ import forge.card.MagicColor;
 import forge.game.CardTraitBase;
 import forge.game.Game;
 import forge.game.GameEntity;
-import forge.game.GameObject;
 import forge.game.ability.AbilityKey;
 import forge.game.ability.AbilityUtils;
 import forge.game.ability.ApiType;
@@ -550,9 +549,9 @@ public final class CardUtil {
         final Game game = ability.getActivatingPlayer().getGame();
         final List<ZoneType> zone = tgt.getZone();
 
-        final boolean canTgtStack = zone.contains(ZoneType.Stack);
         List<Card> validCards = CardLists.getValidCards(game.getCardsIn(zone), tgt.getValidTgts(), ability.getActivatingPlayer(), activatingCard, ability);
         List<Card> choices = CardLists.getTargetableCards(validCards, ability);
+        final boolean canTgtStack = zone.contains(ZoneType.Stack);
         if (canTgtStack) {
             // Since getTargetableCards doesn't have additional checks if one of the Zones is stack
             // Remove the activating card from targeting itself if its on the Stack
@@ -560,55 +559,10 @@ public final class CardUtil {
                 choices.remove(activatingCard);
             }
         }
-        List<GameObject> targetedObjects = ability.getUniqueTargets();
 
         // Remove cards already targeted
         final List<Card> targeted = Lists.newArrayList(ability.getTargets().getTargetCards());
         choices.removeAll(targeted);
-
-        // Remove cards exceeding total CMC
-        if (ability.hasParam("MaxTotalTargetCMC")) {
-            int totalCMCTargeted = 0;
-            for (final Card c : targeted) {
-                totalCMCTargeted += c.getCMC();
-            }
-
-            final List<Card> choicesCopy = Lists.newArrayList(choices);
-            for (final Card c : choicesCopy) {
-                if (c.getCMC() > tgt.getMaxTotalCMC(activatingCard, ability) - totalCMCTargeted) {
-                    choices.remove(c);
-                }
-            }
-        }
-
-        // Remove cards exceeding total power
-        if (ability.hasParam("MaxTotalTargetPower")) {
-            int totalPowerTargeted = 0;
-            for (final Card c : targeted) {
-                totalPowerTargeted += c.getNetPower();
-            }
-
-            final List<Card> choicesCopy = Lists.newArrayList(choices);
-            for (final Card c : choicesCopy) {
-                if (c.getNetPower() > tgt.getMaxTotalPower(activatingCard, ability) - totalPowerTargeted) {
-                    choices.remove(c);
-                }
-            }
-        }
-
-        // If all cards (including subability targets) must have the same controller
-        if (tgt.isSameController() && !targetedObjects.isEmpty()) {
-            final List<Card> list = Lists.newArrayList();
-            for (final Object o : targetedObjects) {
-                if (o instanceof Card) {
-                    list.add((Card) o);
-                }
-            }
-            if (!list.isEmpty()) {
-                final Card card = list.get(0);
-                choices = CardLists.filter(choices, CardPredicates.sharesControllerWith(card));
-            }
-        }
 
         return choices;
     }

--- a/forge-game/src/main/java/forge/game/cost/Cost.java
+++ b/forge-game/src/main/java/forge/game/cost/Cost.java
@@ -210,6 +210,10 @@ public class Cost implements Serializable {
         costParts.add(new CostPartMana(cost, null));
     }
 
+    public Cost(String parse, final boolean bAbility) {
+        this(parse, bAbility, true);
+    }
+
     /**
      * <p>
      * Constructor for Cost.
@@ -219,7 +223,7 @@ public class Cost implements Serializable {
      * @param bAbility
      *            a boolean.
      */
-    public Cost(String parse, final boolean bAbility) {
+    public Cost(String parse, final boolean bAbility, final boolean intrinsic) {
         this.isAbility = bAbility;
         // when adding new costs for cost string, place them here
 
@@ -249,6 +253,9 @@ public class Cost implements Serializable {
                     if (cp instanceof CostPartMana) {
                         parsedMana = (CostPartMana) cp;
                     } else {
+                        if (cp instanceof CostPartWithList) {
+                            ((CostPartWithList)cp).setIntrinsic(intrinsic);
+                        }
                         this.costParts.add(cp);
                     }
                 else

--- a/forge-game/src/main/java/forge/game/cost/CostAdjustment.java
+++ b/forge-game/src/main/java/forge/game/cost/CostAdjustment.java
@@ -161,7 +161,7 @@ public class CostAdjustment {
             count = 1;
         }
         if (count > 0) {
-            Cost part = new Cost(scost, sa.isAbility());
+            Cost part = new Cost(scost, sa.isAbility(), sa.getHostCard().equals(hostCard));
             cost.mergeTo(part, count);
         }
     }

--- a/forge-game/src/main/java/forge/game/cost/CostExileFromStack.java
+++ b/forge-game/src/main/java/forge/game/cost/CostExileFromStack.java
@@ -105,7 +105,7 @@ public class CostExileFromStack extends CostPart {
     public final boolean payAsDecided(final Player ai, final PaymentDecision decision, SpellAbility ability, final boolean effect) {
         Game game = ai.getGame();
         for (final SpellAbility sa : decision.sp) {
-            ability.addCostToHashList(CardUtil.getLKICopy(sa.getHostCard()), "Exiled");
+            ability.addCostToHashList(CardUtil.getLKICopy(sa.getHostCard()), "Exiled", true);
             SpellAbilityStackInstance si = game.getStack().getInstanceFromSpellAbility(sa);
             if (si != null) {
                 game.getStack().remove(si);

--- a/forge-game/src/main/java/forge/game/cost/CostMill.java
+++ b/forge-game/src/main/java/forge/game/cost/CostMill.java
@@ -94,7 +94,7 @@ public class CostMill extends CostPart {
         Map<AbilityKey, Object> moveParams = AbilityKey.newMap();
         moveParams.put(AbilityKey.LastStateBattlefield, ai.getGame().getLastStateBattlefield());
         moveParams.put(AbilityKey.LastStateGraveyard, ai.getGame().getLastStateGraveyard());
-        ability.getPaidHash().put("Milled", (CardCollection) ai.mill(decision.c, ZoneType.Graveyard, false, ability, table, moveParams));
+        ability.getPaidHash().put("Milled", true, (CardCollection) ai.mill(decision.c, ZoneType.Graveyard, false, ability, table, moveParams));
         table.triggerChangesZoneAll(ai.getGame(), ability);
         return true;
     }

--- a/forge-game/src/main/java/forge/game/cost/CostPartMana.java
+++ b/forge-game/src/main/java/forge/game/cost/CostPartMana.java
@@ -127,9 +127,9 @@ public class CostPartMana extends CostPart {
     }
 
     public ManaCost getManaCostFor(SpellAbility sa) {
-        if (isExiledCreatureCost() && sa.getPaidList(CostExile.HashLKIListKey)!= null && !sa.getPaidList(CostExile.HashLKIListKey).isEmpty()) {
+        if (isExiledCreatureCost() && sa.getPaidList(CostExile.HashLKIListKey, true)!= null && !sa.getPaidList(CostExile.HashLKIListKey, true).isEmpty()) {
             // back from the brink
-            return sa.getPaidList(CostExile.HashLKIListKey).get(0).getManaCost();
+            return sa.getPaidList(CostExile.HashLKIListKey, true).get(0).getManaCost();
         }
         if (isEnchantedCreatureCost() && sa.getHostCard().isEnchantingCard()) {
             return sa.getHostCard().getEnchantingCard().getManaCost();

--- a/forge-game/src/main/java/forge/game/cost/CostPartWithList.java
+++ b/forge-game/src/main/java/forge/game/cost/CostPartWithList.java
@@ -38,6 +38,8 @@ public abstract class CostPartWithList extends CostPart {
     private final CardCollection lkiList = new CardCollection();
     protected final CardCollection cardList = new CardCollection();
 
+    private boolean intrinsic = true;
+
     protected final CardZoneTable table = new CardZoneTable();
     // set is here because executePayment() adds card to list, while ai's decide payment does the same thing.
     // set allows to avoid duplication
@@ -48,6 +50,10 @@ public abstract class CostPartWithList extends CostPart {
 
     public final CardCollectionView getCardList() {
     	return cardList;
+    }
+
+    public final void setIntrinsic(boolean b) {
+        intrinsic = b;
     }
 
     /**
@@ -71,11 +77,11 @@ public abstract class CostPartWithList extends CostPart {
         }
         final String lkiPaymentMethod = getHashForLKIList();
         for (final Card card : lkiList) {
-            sa.addCostToHashList(card, lkiPaymentMethod);
+            sa.addCostToHashList(card, lkiPaymentMethod, intrinsic);
         }
         final String cardPaymentMethod = getHashForCardList();
         for (final Card card : cardList) {
-            sa.addCostToHashList(card, cardPaymentMethod);
+            sa.addCostToHashList(card, cardPaymentMethod, intrinsic);
         }
     }
 

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbilityStackInstance.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbilityStackInstance.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.StringUtils;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.collect.TreeBasedTable;
 
 import forge.game.GameObject;
 import forge.game.IIdentifiable;
@@ -85,7 +86,7 @@ public class SpellAbilityStackInstance implements IIdentifiable, IHasCardView {
     private Integer xManaPaid = null;
 
     // Other Paid things
-    private final Map<String, CardCollection> paidHash;
+    private final TreeBasedTable<String, Boolean, CardCollection> paidHash;
 
     // Additional info
     // is Kicked, is Buyback
@@ -108,7 +109,7 @@ public class SpellAbilityStackInstance implements IIdentifiable, IHasCardView {
         activatingPlayer = sa.getActivatingPlayer();
 
         // Payment info
-        paidHash = Maps.newHashMap(ability.getPaidHash());
+        paidHash = TreeBasedTable.create(ability.getPaidHash());
         ability.resetPaidHash();
         splicedCards = sa.getSplicedCards();
 

--- a/forge-game/src/main/java/forge/game/spellability/TargetChoices.java
+++ b/forge-game/src/main/java/forge/game/spellability/TargetChoices.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ForwardingList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import forge.game.GameEntity;
@@ -100,8 +99,8 @@ public class TargetChoices extends ForwardingList<GameObject> implements Cloneab
         return Iterables.filter(targets, SpellAbility.class);
     }
 
-    public final List<GameEntity> getTargetEntities() {
-        return Lists.newArrayList(Iterables.filter(targets, GameEntity.class));
+    public final Iterable<GameEntity> getTargetEntities() {
+        return Iterables.filter(targets, GameEntity.class);
     }
 
     public final boolean isTargetingAnyCard() {

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
@@ -961,7 +961,7 @@ public final class StaticAbilityContinuous {
                     AbilityUtils.getDefinedPlayers(affectedCard, params.get("MayPlayPlayer"), stAb).get(0) :
                     controller;
                 affectedCard.setMayPlay(mayPlayController, mayPlayWithoutManaCost,
-                        mayPlayAltCost != null ? new Cost(mayPlayAltCost, false) : null, additional, mayPlayWithFlash,
+                        mayPlayAltCost != null ? new Cost(mayPlayAltCost, false, affectedCard.equals(hostCard)) : null, additional, mayPlayWithFlash,
                         mayPlayGrantZonePermissions, stAb);
 
                 // If the MayPlay effect only affected itself, check if it is in graveyard and give other player who cast Shaman's Trance MayPlay

--- a/forge-game/src/main/java/forge/game/trigger/Trigger.java
+++ b/forge-game/src/main/java/forge/game/trigger/Trigger.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
@@ -404,8 +405,7 @@ public abstract class Trigger extends TriggerReplacementBase {
             }
         } else if ("Sacrificed".equals(condition)) {
             final SpellAbility trigSA = (SpellAbility) runParams.get(AbilityKey.CastSA);
-            if (trigSA != null &&
-                    (trigSA.getPaidList("Sacrificed") == null || trigSA.getPaidList("Sacrificed").isEmpty())) {
+            if (trigSA != null && Iterables.isEmpty(trigSA.getPaidList("Sacrificed"))) {
                 return false;
             }
         } else if ("AttackedPlayerWithMostLife".equals(condition)) {

--- a/forge-game/src/main/java/forge/game/trigger/WrappedAbility.java
+++ b/forge-game/src/main/java/forge/game/trigger/WrappedAbility.java
@@ -7,6 +7,7 @@ import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
+import com.google.common.collect.TreeBasedTable;
 
 import forge.card.mana.ManaCost;
 import forge.game.Game;
@@ -108,23 +109,23 @@ public class WrappedAbility extends Ability {
     }
 
     @Override
-    public void setPaidHash(final Map<String, CardCollection> hash) {
+    public void setPaidHash(final TreeBasedTable<String, Boolean, CardCollection> hash) {
         sa.setPaidHash(hash);
     }
 
     @Override
-    public Map<String, CardCollection> getPaidHash() {
+    public TreeBasedTable<String, Boolean, CardCollection> getPaidHash() {
         return sa.getPaidHash();
     }
 
     @Override
-    public CardCollection getPaidList(final String str) {
-        return sa.getPaidList(str);
+    public CardCollection getPaidList(final String str, boolean intrinsic) {
+        return sa.getPaidList(str, intrinsic);
     }
 
     @Override
-    public void addCostToHashList(final Card c, final String str) {
-        sa.addCostToHashList(c, str);
+    public void addCostToHashList(final Card c, final String str, final boolean intrinsic) {
+        sa.addCostToHashList(c, str, intrinsic);
     }
 
     @Override

--- a/forge-game/src/main/java/forge/game/zone/MagicStack.java
+++ b/forge-game/src/main/java/forge/game/zone/MagicStack.java
@@ -362,7 +362,7 @@ public class MagicStack /* extends MyObservable */ implements Iterable<SpellAbil
             if (sp.hasParam("Crew")) {
                 // Trigger crews!
                 runParams.put(AbilityKey.Vehicle, sp.getHostCard());
-                runParams.put(AbilityKey.Crew, sp.getPaidList("TappedCards"));
+                runParams.put(AbilityKey.Crew, sp.getPaidList("TappedCards", true));
                 game.getTriggerHandler().runTrigger(TriggerType.Crewed, runParams, false);
             }
         } else {

--- a/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
@@ -1347,10 +1347,10 @@ public final class CMatchUI
                         enchantedEntityView = enchantedEntity.getView();
                         numSmallImages++;
                     } else if ((sa.getRootAbility() != null)
-                            && (sa.getRootAbility().getPaidList("Sacrificed") != null)
-                            && !sa.getRootAbility().getPaidList("Sacrificed").isEmpty()) {
+                            && (sa.getRootAbility().getPaidList("Sacrificed", true) != null)
+                            && !sa.getRootAbility().getPaidList("Sacrificed", true).isEmpty()) {
                         // If the player activated its ability by sacrificing the enchantment, the enchantment has not anything attached anymore and the ex-enchanted card has to be searched in other ways.. for example, the green enchantment "Carapace"
-                        enchantedEntity = sa.getRootAbility().getPaidList("Sacrificed").get(0).getEnchantingCard();
+                        enchantedEntity = sa.getRootAbility().getPaidList("Sacrificed", true).get(0).getEnchantingCard();
                         if (enchantedEntity != null) {
                             enchantedEntityView = enchantedEntity.getView();
                             numSmallImages++;

--- a/forge-gui/res/cardsfolder/b/barrins_spite.txt
+++ b/forge-gui/res/cardsfolder/b/barrins_spite.txt
@@ -1,8 +1,9 @@
 Name:Barrin's Spite
 ManaCost:2 U B
 Types:Sorcery
-A:SP$ Pump | Cost$ 2 U B | ValidTgts$ Creature | TgtPrompt$ Choose two target creatures controlled by the same player | TargetMin$ 2 | TargetMax$ 2 | TargetUnique$ True | TargetsWithSameController$ True | IsCurse$ True | SubAbility$ DBChooseSac | StackDescription$ SpellDescription | SpellDescription$ Choose two target creatures controlled by the same player. Their controller chooses and sacrifices one of them. Return the other to its owner's hand.
-SVar:DBChooseSac:DB$ ChooseCard | DefinedCards$ Targeted | Defined$ TargetedController | ChoiceTitle$ Choose one to sacrifice | SubAbility$ DBSac | StackDescription$ None | AILogic$ WorstCard
+A:SP$ Pump | Cost$ 2 U B | ValidTgts$ Creature | TgtPrompt$ Choose two target creatures controlled by the same player | TargetMin$ 2 | TargetMax$ 2 | TargetUnique$ True | TargetsWithSameController$ True | RememberTargets$ True | IsCurse$ True | SubAbility$ DBChooseSac | StackDescription$ SpellDescription | SpellDescription$ Choose two target creatures controlled by the same player. Their controller chooses and sacrifices one of them. Return the other to its owner's hand.
+SVar:DBChooseSac:DB$ ChooseCard | Choices$ Card.IsRemembered | Defined$ TargetedController | ChoiceTitle$ Choose one to sacrifice | ForgetChosen$ True | SubAbility$ DBSac | StackDescription$ None | AILogic$ WorstCard
 SVar:DBSac:DB$ Destroy | Defined$ ChosenCard | Sacrifice$ True | SubAbility$ DBBounce | StackDescription$ None
-SVar:DBBounce:DB$ ChangeZone | Defined$ Targeted | Origin$ Battlefield | Destination$ Hand | StackDescription$ None
+SVar:DBBounce:DB$ ChangeZone | Defined$ Remembered | Origin$ Battlefield | Destination$ Hand | SubAbility$ DBCleanup | StackDescription$ None
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Choose two target creatures controlled by the same player. Their controller chooses and sacrifices one of them. Return the other to its owner's hand.

--- a/forge-gui/res/cardsfolder/b/barrins_spite.txt
+++ b/forge-gui/res/cardsfolder/b/barrins_spite.txt
@@ -1,9 +1,8 @@
 Name:Barrin's Spite
 ManaCost:2 U B
 Types:Sorcery
-A:SP$ Pump | Cost$ 2 U B | ValidTgts$ Creature | TgtPrompt$ Choose two target creatures controlled by the same player | TargetMin$ 2 | TargetMax$ 2 | TargetUnique$ True | TargetsWithSameController$ True | RememberTargets$ True | IsCurse$ True | SubAbility$ DBChooseSac | StackDescription$ SpellDescription | SpellDescription$ Choose two target creatures controlled by the same player. Their controller chooses and sacrifices one of them. Return the other to its owner's hand.
-SVar:DBChooseSac:DB$ ChooseCard | Choices$ Card.IsRemembered | Defined$ TargetedController | ChoiceTitle$ Choose one to sacrifice | ForgetChosen$ True | SubAbility$ DBSac | StackDescription$ None | AILogic$ WorstCard
+A:SP$ Pump | Cost$ 2 U B | ValidTgts$ Creature | TgtPrompt$ Choose two target creatures controlled by the same player | TargetMin$ 2 | TargetMax$ 2 | TargetUnique$ True | TargetsWithSameController$ True | IsCurse$ True | SubAbility$ DBChooseSac | StackDescription$ SpellDescription | SpellDescription$ Choose two target creatures controlled by the same player. Their controller chooses and sacrifices one of them. Return the other to its owner's hand.
+SVar:DBChooseSac:DB$ ChooseCard | DefinedCards$ Targeted | Defined$ TargetedController | ChoiceTitle$ Choose one to sacrifice | SubAbility$ DBSac | StackDescription$ None | AILogic$ WorstCard
 SVar:DBSac:DB$ Destroy | Defined$ ChosenCard | Sacrifice$ True | SubAbility$ DBBounce | StackDescription$ None
-SVar:DBBounce:DB$ ChangeZone | Defined$ Remembered | Origin$ Battlefield | Destination$ Hand | SubAbility$ DBCleanup | StackDescription$ None
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBBounce:DB$ ChangeZone | Defined$ Targeted | Origin$ Battlefield | Destination$ Hand | StackDescription$ None
 Oracle:Choose two target creatures controlled by the same player. Their controller chooses and sacrifices one of them. Return the other to its owner's hand.

--- a/forge-gui/res/cardsfolder/e/eye_of_yawgmoth.txt
+++ b/forge-gui/res/cardsfolder/e/eye_of_yawgmoth.txt
@@ -1,7 +1,6 @@
 Name:Eye of Yawgmoth
 ManaCost:3
 Types:Artifact
-A:AB$ Dig | Cost$ 3 T Sac<1/Creature> | RememberCostCards$ True | DigNum$ X | ChangeNum$ 1 | DestinationZone2$ Exile | SpellDescription$ Reveal a number of cards from the top of your library equal to the sacrificed creature's power. Put one into your hand and exile the rest. | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-SVar:X:RememberedLKI$CardPower
+A:AB$ Dig | Cost$ 3 T Sac<1/Creature> | DigNum$ X | ChangeNum$ 1 | DestinationZone2$ Exile | SpellDescription$ Reveal a number of cards from the top of your library equal to the sacrificed creature's power. Put one into your hand and exile the rest.
+SVar:X:Sacrificed$CardPower
 Oracle:{3}, {T}, Sacrifice a creature: Reveal a number of cards from the top of your library equal to the sacrificed creature's power. Put one into your hand and exile the rest.

--- a/forge-gui/res/cardsfolder/i/incriminate.txt
+++ b/forge-gui/res/cardsfolder/i/incriminate.txt
@@ -1,8 +1,7 @@
 Name:Incriminate
 ManaCost:1 B
 Types:Sorcery
-A:SP$ Pump | Cost$ 1 B | ValidTgts$ Creature | TgtPrompt$ Choose two target creatures controlled by the same player | TargetMin$ 2 | TargetMax$ 2 | TargetUnique$ True | TargetsWithSameController$ True | RememberTargets$ True | IsCurse$ True | SubAbility$ DBChooseSac | StackDescription$ SpellDescription | SpellDescription$ Choose two target creatures controlled by the same player. That player sacrifices one of them.
-SVar:DBChooseSac:DB$ ChooseCard | Choices$ Card.IsRemembered | Defined$ TargetedController | ChoiceTitle$ Choose one to sacrifice | SubAbility$ DBSac | StackDescription$ None | AILogic$ WorstCard
-SVar:DBSac:DB$ Destroy | Defined$ ChosenCard | Sacrifice$ True | SubAbility$ DBCleanup | StackDescription$ None
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+A:SP$ Pump | Cost$ 1 B | ValidTgts$ Creature | TgtPrompt$ Choose two target creatures controlled by the same player | TargetMin$ 2 | TargetMax$ 2 | TargetUnique$ True | TargetsWithSameController$ True | IsCurse$ True | SubAbility$ DBChooseSac | StackDescription$ SpellDescription | SpellDescription$ Choose two target creatures controlled by the same player. That player sacrifices one of them.
+SVar:DBChooseSac:DB$ ChooseCard | DefinedCards$ Targeted | Defined$ TargetedController | ChoiceTitle$ Choose one to sacrifice | SubAbility$ DBSac | StackDescription$ None | AILogic$ WorstCard
+SVar:DBSac:DB$ Destroy | Defined$ ChosenCard | Sacrifice$ True | StackDescription$ None
 Oracle:Choose two target creatures controlled by the same player. That player sacrifices one of them.

--- a/forge-gui/res/cardsfolder/m/mutiny.txt
+++ b/forge-gui/res/cardsfolder/m/mutiny.txt
@@ -2,6 +2,6 @@ Name:Mutiny
 ManaCost:R
 Types:Sorcery
 A:SP$ Pump | Cost$ R | ValidTgts$ Creature.OppCtrl | AILogic$ PowerDmg | TgtPrompt$ Select target creature an opponent controls | SubAbility$ MutinyDamage | StackDescription$ None | SpellDescription$ Target creature an opponent controls deals damage equal to its power to another target creature that player controls.
-SVar:MutinyDamage:DB$ DealDamage | ValidTgts$ Creature.OppCtrl | TargetUnique$ True | TargetsWithSameController$ True | AILogic$ PowerDmg | NumDmg$ X | DamageSource$ ParentTarget
+SVar:MutinyDamage:DB$ DealDamage | ValidTgts$ Creature | TargetUnique$ True | TargetsWithDefinedController$ ParentTargetedController | AILogic$ PowerDmg | NumDmg$ X | DamageSource$ ParentTarget
 SVar:X:ParentTargeted$CardPower
 Oracle:Target creature an opponent controls deals damage equal to its power to another target creature that player controls.

--- a/forge-gui/src/main/java/forge/gamemodes/match/input/InputSelectTargets.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/input/InputSelectTargets.java
@@ -213,6 +213,20 @@ public final class InputSelectTargets extends InputSyncronizedBase {
             }
         }
 
+        if (sa.hasParam("MaxTotalTargetPower")) {
+            int maxTotalPower = tgt.getMaxTotalPower(sa.getHostCard(), sa);
+            if (maxTotalPower > 0) {
+                int soFar = Aggregates.sum(sa.getTargets().getTargetCards(), CardPredicates.Accessors.fnGetNetPower);
+                if (!sa.isTargeting(card)) {
+                    soFar += card.getNetPower();
+                }
+                if (soFar > maxTotalPower) {
+                    showMessage(sa.getHostCard() + " - Cannot target this card (power limit exceeded)");
+                    return false;
+                }
+            }
+        }
+
         // If all cards must have same controllers
         if (tgt.isSameController()) {
             final List<Player> targetedControllers = new ArrayList<>();
@@ -225,20 +239,6 @@ public final class InputSelectTargets extends InputSyncronizedBase {
             if (!targetedControllers.isEmpty() && !targetedControllers.contains(card.getController())) {
                 showMessage(sa.getHostCard() + " - Cannot target this card (must have same controller)");
                 return false;
-            }
-        }
-
-        if (sa.hasParam("MaxTotalTargetPower")) {
-            int maxTotalPower = tgt.getMaxTotalPower(sa.getHostCard(), sa);
-            if (maxTotalPower > 0) {
-                int soFar = Aggregates.sum(sa.getTargets().getTargetCards(), CardPredicates.Accessors.fnGetNetPower);
-                if (!sa.isTargeting(card)) {
-                    soFar += card.getNetPower();
-                }
-                if (soFar > maxTotalPower) {
-                    showMessage(sa.getHostCard() + " - Cannot target this card (power limit exceeded)");
-                    return false;
-                }
             }
         }
 

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -2012,17 +2012,18 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
 
         boolean result = select.chooseTargets(null, null, null, false, canFilterMustTarget);
 
-        final List<GameEntity> targets = currentAbility.getTargets().getTargetEntities();
+        final Iterable<GameEntity> targets = currentAbility.getTargets().getTargetEntities();
+        final int size = Iterables.size(targets);
         int amount = currentAbility.getStillToDivide();
 
         // assign divided as you choose values
-        if (result && targets.size() > 0 && amount > 0) {
+        if (result && size > 0 && amount > 0) {
             if (currentAbility.hasParam("DividedUpTo")) {
-                amount = chooseNumber(currentAbility, localizer.getMessage("lblHowMany"), targets.size(), amount);
+                amount = chooseNumber(currentAbility, localizer.getMessage("lblHowMany"), size, amount);
             }
-            if (targets.size() == 1) {
-                currentAbility.addDividedAllocation(targets.get(0), amount);
-            } else if (targets.size() == amount) {
+            if (size == 1) {
+                currentAbility.addDividedAllocation(Iterables.get(targets, 0), amount);
+            } else if (size == amount) {
                 for (GameEntity e : targets) {
                     currentAbility.addDividedAllocation(e, 1);
                 }
@@ -2030,7 +2031,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
                 for (GameEntity e : targets) {
                     currentAbility.addDividedAllocation(e, 0);
                 }
-            } else if (targets.size() > amount) {
+            } else if (size > amount) {
                 return false;
             } else {
                 String label = "lblDamage";
@@ -2041,7 +2042,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
                 }
                 label = localizer.getMessage(label).toLowerCase();
                 final CardView vSource = CardView.get(currentAbility.getHostCard());
-                final Map<Object, Integer> vTargets = new HashMap<>(targets.size());
+                final Map<Object, Integer> vTargets = new HashMap<>(size);
                 for (GameEntity e : targets) {
                     vTargets.put(GameEntityView.get(e), amount);
                 }

--- a/forge-gui/src/main/java/forge/player/TargetSelection.java
+++ b/forge-gui/src/main/java/forge/player/TargetSelection.java
@@ -118,7 +118,7 @@ public class TargetSelection {
             // Cancel ability if there aren't any valid Candidates
             return false;
         }
-        if (isMandatory() && candidates.size() == 0 && hasEnoughTargets) {
+        if (isMandatory() && candidates.isEmpty() && hasEnoughTargets) {
             // Mandatory target selection, that has no candidates but enough targets (Min == 0, but no choices)
             return true;
         }


### PR DESCRIPTION
Part for #2244:
Casting _Corbse Cobble_ via _Maestros Ascendancy_ now correctly only uses the stats from the original cost for the token P/T.

Some bonus cleanup especially in _CardUtil_, the removed parts turned redundant to ``SpellAbility.canTarget`` checks.