### PR TITLE
Alchemy Rebalancing for April 4, 2023

### DIFF
--- a/forge-gui/res/cardsfolder/f/futurist_operative.txt
+++ b/forge-gui/res/cardsfolder/f/futurist_operative.txt
@@ -5,4 +5,5 @@ PT:3/4
 S:Mode$ Continuous | Affected$ Card.Self | SetPower$ 1 | SetToughness$ 1 | AddType$ Human & Citizen | RemoveCreatureTypes$ True | IsPresent$ Card.Self+tapped | Description$ As long as CARDNAME is tapped, it is a Human Citizen with base power and toughness 1/1 and it can't be blocked.
 S:Mode$ CantBlockBy | ValidAttacker$ Card.Self | IsPresent$ Card.Self+tapped
 A:AB$ Untap | Cost$ 2 U | SpellDescription$ Untap CARDNAME.
+DeckHas:Type$Citizen
 Oracle:As long as Futurist Operative is tapped, it is a Human Citizen with base power and toughness 1/1 and it can't be blocked.\n{2}{U}: Untap Futurist Operative.

--- a/forge-gui/res/cardsfolder/h/hinterland_chef.txt
+++ b/forge-gui/res/cardsfolder/h/hinterland_chef.txt
@@ -1,7 +1,7 @@
 Name:Hinterland Chef
 ManaCost:2 G
 Types:Creature Human Scout
-PT:3/3
+PT:3/4
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDraft | TriggerDescription$ When CARDNAME enters the battlefield, draft a card from CARDNAME's spellbook. It perpetually becomes a Food artifact in addition to its other types and perpetually gains "{2}, {T}, Sacrifice this creature: You gain 3 life."
 SVar:TrigDraft:DB$ Draft | Spellbook$ Almighty Brushwagg,Frilled Sandwalla,Moss Viper,Brushstrider,Highland Game,Ironshell Beetle,Lotus Cobra,Kazandu Nectarpot,Gilded Goose,Nessian Hornbeetle,Scurrid Colony,Territorial Boar,Deathbonnet Sprout,Spore Crawler,Moldgraf Millipede | RememberDrafted$ True | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | RememberObjects$ Remembered | StaticAbilities$ PerpetualAbility | Duration$ Permanent | Triggers$ Update | Name$ Hinterland Chef's Perpetual Effect | SubAbility$ DBCleanup

--- a/forge-gui/res/cardsfolder/k/krydle_of_baldurs_gate.txt
+++ b/forge-gui/res/cardsfolder/k/krydle_of_baldurs_gate.txt
@@ -10,5 +10,6 @@ SVar:DBScry:DB$ Scry
 T:Mode$ AttackersDeclared | AttackingPlayer$ You | Execute$ TrigUnblockable | TriggerZones$ Battlefield | TriggerDescription$ Whenever you attack, you may pay {2}. If you do, target creature can't be blocked this turn.
 SVar:TrigUnblockable:AB$ Effect | Cost$ 2 | ValidTgts$ Creature | RememberObjects$ Targeted | StaticAbilities$ Unblockable
 SVar:Unblockable:Mode$ CantBlockBy | ValidAttacker$ Card.IsRemembered | Description$ This creature can't be blocked this turn.
-DeckHas:Ability$LifeGain
+SVar:HasAttackEffect:TRUE
+DeckHas:Ability$LifeGain|Mill
 Oracle:Whenever Krydle of Baldur's Gate deals combat damage to a player, that player loses 1 life and mills a card, then you gain 1 life and scry 1.\nWhenever you attack, you may pay {2}. If you do, target creature can't be blocked this turn.

--- a/forge-gui/res/cardsfolder/l/lonely_end.txt
+++ b/forge-gui/res/cardsfolder/l/lonely_end.txt
@@ -4,7 +4,7 @@ Types:Instant
 A:SP$ Charm | Choices$ DBDebuff,DBLoyalty | CharmNum$ 1
 SVar:DBDebuff:DB$ Pump | ValidTgts$ Creature | NumAtt$ -3 | NumDef$ -3 | SubAbility$ DBGainLife | SpellDescription$ Target creature gets -3/-3 until end of turn.
 SVar:DBLoyalty:DB$ RemoveCounter | ValidTgts$ Planeswalker | CounterType$ LOYALTY | CounterNum$ 3 | SubAbility$ DBGainLife | SpellDescription$ Remove three loyalty counters from target planeswalker.
-SVar:DBGainLife:DB$ GainLife | LifeAmount$ 2 | ConditionCheckSVar$ X | ConditionSVarCompare$ EQ0 | SpellDescription$ If you weren't the starting player, you gain two life.
+SVar:DBGainLife:DB$ GainLife | LifeAmount$ 3 | ConditionCheckSVar$ X | ConditionSVarCompare$ EQ0 | SpellDescription$ If you weren't the starting player, you gain 3 life.
 SVar:X:Count$StartingPlayer.1.0
 DeckHas:Ability$LifeGain
-Oracle:Choose one -\n• Target creature gets -3/-3 until end of turn.\n• Remove three loyalty counters from target planeswalker.\nIf you weren't the starting player, you gain 2 life.
+Oracle:Choose one -\n• Target creature gets -3/-3 until end of turn.\n• Remove three loyalty counters from target planeswalker.\nIf you weren't the starting player, you gain 3 life.

--- a/forge-gui/res/cardsfolder/m/moon_circuit_hacker.txt
+++ b/forge-gui/res/cardsfolder/m/moon_circuit_hacker.txt
@@ -3,7 +3,7 @@ ManaCost:1 U
 Types:Enchantment Creature Human Ninja
 PT:2/1
 K:Ninjutsu:U
-T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigDraw | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, you may draw a card. If you do, discard a card.
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigDraw | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, you may draw a card. If you do, discard a card unless CARDNAME entered the battlefield this turn.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1 | SubAbility$ DBDiscard
 SVar:DBDiscard:DB$ Discard | Defined$ You | Mode$ TgtChoose | NumCards$ 1 | ConditionDefined$ Self | ConditionPresent$ Card.ThisTurnEntered | ConditionCompare$ EQ0
 DeckHas:Ability$Discard

--- a/forge-gui/res/cardsfolder/n/nightclub_bouncer.txt
+++ b/forge-gui/res/cardsfolder/n/nightclub_bouncer.txt
@@ -3,8 +3,8 @@ ManaCost:2 U U
 Types:Creature Human Rogue
 PT:2/3
 K:Flash
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigReturn | TriggerDescription$ When CARDNAME enters the battlefield, return target nonland permanent an opponent controls to its owner's hand. It perpetually gains "This spell costs {1} more to cast."
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigReturn | TriggerDescription$ When CARDNAME enters the battlefield, return target nonland permanent an opponent controls to its owner's hand. It perpetually gains "This spell costs {2} more to cast."
 SVar:TrigReturn:DB$ ChangeZone | ValidTgts$ Permanent.nonLand+OppCtrl | Origin$ Battlefield | Destination$ Hand | RememberChanged$ True | TgtPrompt$ Choose target nonland permanent an opponent controls | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | RememberObjects$ Remembered | StaticAbilities$ PerpetualAbility | Name$ Nightclub Bouncer's Perpetual Effect | Duration$ Permanent
-SVar:PerpetualAbility:Mode$ RaiseCost | ValidCard$ Card.IsRemembered | Type$ Spell | Amount$ 1 | EffectZone$ All | Description$ This spell costs {1} more to cast.
-Oracle:Flash\nWhen Nightclub Bouncer enters the battlefield, return target nonland permanent an opponent controls to its owner's hand. It perpetually gains "This spell costs {1} more to cast."
+SVar:PerpetualAbility:Mode$ RaiseCost | ValidCard$ Card.IsRemembered | Type$ Spell | Amount$ 2 | EffectZone$ All | Description$ This spell costs {2} more to cast.
+Oracle:Flash\nWhen Nightclub Bouncer enters the battlefield, return target nonland permanent an opponent controls to its owner's hand. It perpetually gains "This spell costs {2} more to cast."

--- a/forge-gui/res/cardsfolder/rebalanced/a-circuit_mender.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-circuit_mender.txt
@@ -1,0 +1,10 @@
+Name:A-Circuit Mender
+ManaCost:3
+Types:Artifact Creature Insect
+PT:2/3
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Destination$ Battlefield | Execute$ TrigGainLife | TriggerDescription$ When CARDNAME enters the battlefield, you gain 3 life.
+SVar:TrigGainLife:DB$ GainLife | LifeAmount$ 3
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Battlefield | Execute$ TrigDraw | TriggerDescription$ When CARDNAME leaves the battlefield, draw a card.
+SVar:TrigDraw:DB$ Draw | NumCards$ 1
+DeckHas:Ability$LifeGain
+Oracle:When Circuit Mender enters the battlefield, you gain 3 life.\nWhen Circuit Mender leaves the battlefield, draw a card.

--- a/forge-gui/res/cardsfolder/rebalanced/a-dawnbringer_cleric.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-dawnbringer_cleric.txt
@@ -1,0 +1,11 @@
+Name:A-Dawnbringer Cleric
+ManaCost:1 W
+Types:Creature Human Cleric
+PT:1/4
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigCharm | TriggerDescription$ When CARDNAME enters the battlefield, ABILITY
+SVar:TrigCharm:DB$ Charm | Choices$ DBGainLife,DBDestroy,DBExileCard
+SVar:DBGainLife:DB$ GainLife | LifeAmount$ 2 | SpellDescription$ Cure Wounds — You gain 2 life.
+SVar:DBDestroy:DB$ Destroy | ValidTgts$ Enchantment | TgtPrompt$ Select target enchantment | SpellDescription$ Dispel Magic — Destroy target enchantment.
+SVar:DBExileCard:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | TgtPrompt$ Choose target card in a graveyard | ValidTgts$ Card | SpellDescription$ Gentle Repose — Exile target card from a graveyard.
+DeckHas:Ability$LifeGain
+Oracle:When Dawnbringer Cleric enters the battlefield, choose one —\n• Cure Wounds — You gain 2 life.\n• Dispel Magic — Destroy target enchantment.\n• Gentle Repose — Exile target card from a graveyard.

--- a/forge-gui/res/cardsfolder/rebalanced/a-dokuchi_silencer.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-dokuchi_silencer.txt
@@ -1,0 +1,11 @@
+Name:A-Dokuchi Silencer
+ManaCost:1 B
+Types:Creature Human Ninja
+PT:2/1
+K:Ninjutsu:1 B
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigImmediateTrig | CombatDamage$ True | OptionalDecider$ You | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, you may discard a card. When you do, destroy target creature or planeswalker that player controls.
+SVar:TrigImmediateTrig:AB$ ImmediateTrigger | Cost$ Discard<1/Card> | Execute$ TrigDestroy | CopyTriggeringObjects$ True | TriggerDescription$ When you do, destroy target creature or planeswalker that player controls.
+SVar:TrigDestroy:DB$ Destroy | ValidTgts$ Creature.ControlledBy TriggeredTarget,Planeswalker.ControlledBy TriggeredTarget | TgtPrompt$ Select target creature or planeswalker damaged player controls
+DeckHas:Ability$Discard
+SVar:AIPreference:DiscardCost$Card.cmcLE3
+Oracle:Ninjutsu {1}{B}\nWhenever Dokuchi Silencer deals combat damage to a player, you may discard a card. When you do, destroy target creature or planeswalker that player controls.

--- a/forge-gui/res/cardsfolder/rebalanced/a-futurist_operative.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-futurist_operative.txt
@@ -1,0 +1,8 @@
+Name:A-Futurist Operative
+ManaCost:U
+Types:Creature Human Ninja
+PT:0/4
+S:Mode$ Continuous | Affected$ Card.Self | SetPower$ 1 | SetToughness$ 1 | AddType$ Human & Citizen | RemoveCreatureTypes$ True | IsPresent$ Card.Self+tapped | Description$ As long as CARDNAME is tapped, it is a Human Citizen with base power and toughness 1/1 and it can't be blocked.
+S:Mode$ CantBlockBy | ValidAttacker$ Card.Self | IsPresent$ Card.Self+tapped
+A:AB$ Untap | Cost$ 2 U | SpellDescription$ Untap CARDNAME.
+Oracle:As long as Futurist Operative is tapped, it is a Human Citizen with base power and toughness 1/1 and it can't be blocked.\n{2}{U}: Untap Futurist Operative.

--- a/forge-gui/res/cardsfolder/rebalanced/a-futurist_operative.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-futurist_operative.txt
@@ -5,4 +5,5 @@ PT:0/4
 S:Mode$ Continuous | Affected$ Card.Self | SetPower$ 1 | SetToughness$ 1 | AddType$ Human & Citizen | RemoveCreatureTypes$ True | IsPresent$ Card.Self+tapped | Description$ As long as CARDNAME is tapped, it is a Human Citizen with base power and toughness 1/1 and it can't be blocked.
 S:Mode$ CantBlockBy | ValidAttacker$ Card.Self | IsPresent$ Card.Self+tapped
 A:AB$ Untap | Cost$ 2 U | SpellDescription$ Untap CARDNAME.
+DeckHas:Type$Citizen
 Oracle:As long as Futurist Operative is tapped, it is a Human Citizen with base power and toughness 1/1 and it can't be blocked.\n{2}{U}: Untap Futurist Operative.

--- a/forge-gui/res/cardsfolder/rebalanced/a-haywire_mite.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-haywire_mite.txt
@@ -1,0 +1,11 @@
+Name:A-Haywire Mite
+ManaCost:1
+Types:Artifact Creature Insect
+PT:1/2
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigGainLife | TriggerDescription$ When CARDNAME dies, you gain 3 life.
+SVar:TrigGainLife:DB$ GainLife | LifeAmount$ 3
+A:AB$ ChangeZone | Cost$ G Sac<1/CARDNAME> | ValidTgts$ Enchantment.nonCreature,Artifact.nonCreature | TgtPrompt$ Select target noncreature artifact or noncreature enchantment | Origin$ Battlefield | Destination$ Exile | SpellDescription$ Exile target noncreature artifact or noncreature enchantment.
+DeckHas:Ability$LifeGain|Sacrifice 
+DeckHints:Color$Green
+SVar:SacMe:1
+Oracle:When Haywire Mite dies, you gain 3 life.\n{G}, Sacrifice Haywire Mite: Exile target noncreature artifact or noncreature enchantment.

--- a/forge-gui/res/cardsfolder/rebalanced/a-knockout_blow.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-knockout_blow.txt
@@ -1,0 +1,8 @@
+Name:A-Knockout Blow
+ManaCost:2 W
+Types:Instant
+S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 2 | ValidTarget$ Creature.Red | EffectZone$ All | Description$ This spell costs {2} less to cast if it targets a red creature.
+A:SP$ Destroy | ValidTgts$ Creature.tapped | TgtPrompt$ Select target tapped creature | SubAbility$ DBGainLife | SpellDescription$ Destroy target tapped creature. You gain 2 life.
+SVar:DBGainLife:DB$ GainLife | LifeAmount$ 2 | Defined$ You
+DeckHas:Ability$LifeGain
+Oracle:This spell costs {2} less to cast if it targets a red creature.\nDestroy target tapped creature. You gain 2 life.

--- a/forge-gui/res/cardsfolder/rebalanced/a-krydle_of_baldurs_gate.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-krydle_of_baldurs_gate.txt
@@ -10,5 +10,6 @@ SVar:DBScry:DB$ Scry
 T:Mode$ AttackersDeclared | AttackingPlayer$ You | Execute$ TrigUnblockable | TriggerZones$ Battlefield | TriggerDescription$ Whenever you attack, target creature can't be blocked this turn.
 SVar:TrigUnblockable:DB$ Effect | ValidTgts$ Creature | RememberObjects$ Targeted | StaticAbilities$ Unblockable | TgtPrompt$ Select target creature
 SVar:Unblockable:Mode$ CantBlockBy | ValidAttacker$ Card.IsRemembered | Description$ This creature can't be blocked this turn.
-DeckHas:Ability$LifeGain
+SVar:HasAttackEffect:TRUE
+DeckHas:Ability$LifeGain|Mill
 Oracle:Whenever Krydle of Baldur's Gate deals combat damage to a player, that player loses 1 life and mills a card, then you gain 1 life and scry 1.\nWhenever you attack, target creature can't be blocked this turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-krydle_of_baldurs_gate.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-krydle_of_baldurs_gate.txt
@@ -1,0 +1,14 @@
+Name:A-Krydle of Baldur's Gate
+ManaCost:U B
+Types:Legendary Creature Human Elf Rogue
+PT:1/3
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigLoseLife | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, that player loses 1 life and mills a card, then you gain 1 life and scry 1.
+SVar:TrigLoseLife:DB$ LoseLife | Defined$ TriggeredTarget | LifeAmount$ 1 | SubAbility$ DBMill
+SVar:DBMill:DB$ Mill | Defined$ TriggeredTarget | SubAbility$ DBGainLife
+SVar:DBGainLife:DB$ GainLife | LifeAmount$ 1 | SubAbility$ DBScry
+SVar:DBScry:DB$ Scry
+T:Mode$ AttackersDeclared | AttackingPlayer$ You | Execute$ TrigUnblockable | TriggerZones$ Battlefield | TriggerDescription$ Whenever you attack, target creature can't be blocked this turn.
+SVar:TrigUnblockable:DB$ Effect | ValidTgts$ Creature | RememberObjects$ Targeted | StaticAbilities$ Unblockable | TgtPrompt$ Select target creature
+SVar:Unblockable:Mode$ CantBlockBy | ValidAttacker$ Card.IsRemembered | Description$ This creature can't be blocked this turn.
+DeckHas:Ability$LifeGain
+Oracle:Whenever Krydle of Baldur's Gate deals combat damage to a player, that player loses 1 life and mills a card, then you gain 1 life and scry 1.\nWhenever you attack, target creature can't be blocked this turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-moon_circuit_hacker.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-moon_circuit_hacker.txt
@@ -1,0 +1,11 @@
+Name:A-Moon-Circuit Hacker
+ManaCost:1 U
+Types:Enchantment Creature Human Ninja
+PT:2/1
+K:Ninjutsu:U
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigScry | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, scry 2, then draw a card. Discard a card unless CARDNAME entered the battlefield this turn.
+SVar:TrigScry:DB$ Scry | ScryNum$ 2 | SubAbility$ DBDraw
+SVar:DBDraw:DB$ Draw | NumCards$ 1 | SubAbility$ DBDiscard
+SVar:DBDiscard:DB$ Discard | Defined$ You | Mode$ TgtChoose | NumCards$ 1 | ConditionDefined$ Self | ConditionPresent$ Card.ThisTurnEntered | ConditionCompare$ EQ0
+DeckHas:Ability$Discard
+Oracle:Ninjutsu {U}\nWhenever Moon-Circuit Hacker deals combat damage to a player, scry 2, then draw a card. Discard a card unless Moon-Circuit Hacker entered the battlefield this turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-nashi_moon_sages_scion.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-nashi_moon_sages_scion.txt
@@ -1,0 +1,14 @@
+Name:A-Nashi, Moon Sage's Scion
+ManaCost:1 B B
+Types:Legendary Creature Rat Ninja
+PT:3/2
+K:Ninjutsu:2 B
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigExile | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, exile the top card of each player's library. Until end of turn, you may play one of those cards. If you cast a spell this way, pay life equal to its mana value rather than paying its mana cost.
+SVar:TrigExile:DB$ Dig | DigNum$ 1 | ChangeNum$ All | Defined$ Player | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBEffect
+SVar:DBEffect:DB$ Effect | RememberObjects$ Remembered | StaticAbilities$ MayPlay | Triggers$ Play1,Play2 | SubAbility$ DBCleanup
+SVar:MayPlay:Mode$ Continuous | Affected$ Card.IsRemembered | AffectedZone$ Exile | MayPlay$ True | MayPlayAltManaCost$ PayLife<ConvertedManaCost> | Description$ Until end of turn, you may play one of those cards. If you cast a spell this way, pay life equal to its mana value rather than paying its mana cost.
+SVar:Play1:Mode$ SpellCast | ValidCard$ Card.IsRemembered | ValidActivatingPlayer$ You | TriggerZones$ Command | Execute$ ExileSelf | Static$ True
+SVar:Play2:Mode$ LandPlayed | ValidCard$ Land.IsRemembered | TriggerZones$ Command | Execute$ ExileSelf | Static$ True
+SVar:ExileSelf:DB$ ChangeZone | Origin$ Command | Destination$ Exile
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:Ninjutsu {2}{B}\nWhenever Nashi, Moon Sage's Scion deals combat damage to a player, exile the top card of each player's library. Until end of turn, you may play one of those cards. If you cast a spell this way, pay life equal to its mana value rather than paying its mana cost.

--- a/forge-gui/res/cardsfolder/rebalanced/a-nezumi_prowler.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-nezumi_prowler.txt
@@ -1,0 +1,9 @@
+Name:A-Nezumi Prowler
+ManaCost:1 B
+Types:Artifact Creature Rat Ninja
+PT:3/1
+K:Ninjutsu:1 B
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPutCounter | TriggerDescription$ When CARDNAME enters the battlefield, put a deathtouch counter and a lifelink counter on target creature you control.
+SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | CounterTypes$ Deathtouch,Lifelink | CounterNum$ 1
+DeckHas:Ability$Counters|LifeGain
+Oracle:Ninjutsu {1}{B}\nWhen Nezumi Prowler enters the battlefield, put a deathtouch counter and a lifelink counter on target creature you control.

--- a/forge-gui/res/cardsfolder/rebalanced/a-prosperous_thief.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-prosperous_thief.txt
@@ -1,0 +1,10 @@
+Name:A-Prosperous Thief
+ManaCost:2 U
+Types:Creature Human Ninja
+PT:2/4
+K:Ninjutsu:1 U
+T:Mode$ DamageDoneOnce | ValidSource$ Creature.Ninja+YouCtrl,Creature.Rogue+YouCtrl | TriggerZones$ Battlefield | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigToken | TriggerDescription$ Whenever one or more Ninja or Rogue creatures you control deal combat damage to a player, create a Treasure token.
+SVar:TrigToken:DB$ Token | TokenScript$ c_a_treasure_sac
+DeckHints:Type$Ninja|Rogue
+DeckHas:Ability$Token|Sacrifice & Type$Artifact|Treasure
+Oracle:Ninjutsu {1}{U}\nWhenever one or more Ninja or Rogue creatures you control deal combat damage to a player, create a Treasure token.

--- a/forge-gui/res/cardsfolder/rebalanced/a-satoru_umezawa.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-satoru_umezawa.txt
@@ -1,0 +1,8 @@
+Name:A-Satoru Umezawa
+ManaCost:1 U B
+Types:Legendary Creature Human Ninja
+PT:3/4
+T:Mode$ AbilityCast | ValidActivatingPlayer$ You | ValidSA$ Activated.Ninjutsu | TriggerZones$ Battlefield | ActivationLimit$ 1 | Execute$ TrigDig | TriggerDescription$ Whenever you activate a ninjutsu ability, look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order. This ability triggers only once each turn.
+SVar:TrigDig:DB$ Dig | DigNum$ 3 | ChangeNum$ 1
+S:Mode$ Continuous | Affected$ Creature.YouOwn | AffectedZone$ Hand | AddKeyword$ Ninjutsu:1 U B | Description$ Each creature card in your hand has ninjutsu {1}{U}{B}.
+Oracle:Whenever you activate a ninjutsu ability, look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order. This ability triggers only once each turn.\nEach creature card in your hand has ninjutsu {1}{U}{B}.

--- a/forge-gui/res/cardsfolder/rebalanced/a-silver_fur_master.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-silver_fur_master.txt
@@ -1,0 +1,9 @@
+Name:A-Silver-Fur Master
+ManaCost:U B
+Types:Creature Rat Ninja
+PT:2/2
+K:Ninjutsu:UB
+S:Mode$ ReduceCost | ValidCard$ Card | ValidSpell$ Activated.Ninjutsu | Activator$ You | Amount$ 1 | Description$ Ninjutsu abilities you activate cost {1} less to activate.
+S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Creature.Ninja+Other+YouCtrl,Creature.Rogue+Other+YouCtrl | AddPower$ 1 | AddToughness$ 1 | Description$ Other Ninja and Rogue creatures you control get +1/+1.
+DeckHints:Type$Ninja|Rogue
+Oracle:Ninjutsu {U/B}\nNinjutsu abilities you activate cost {1} less to activate.\nOther Ninja and Rogue creatures you control get +1/+1.

--- a/forge-gui/res/cardsfolder/rebalanced/a-thousand_faced_shadow.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-thousand_faced_shadow.txt
@@ -1,0 +1,10 @@
+Name:A-Thousand-Faced Shadow
+ManaCost:U
+Types:Creature Human Ninja
+PT:1/1
+K:Ninjutsu:2 U
+K:Flying
+T:Mode$ ChangesZone | ValidCard$ Card.Self+attacking | Origin$ Hand | Destination$ Battlefield | Execute$ TrigCopy | TriggerDescription$ When CARDNAME enters the battlefield from your hand, if it's attacking, create a token that's a copy of another target attacking creature. The token enters the battlefield tapped and attacking.
+SVar:TrigCopy:DB$ CopyPermanent | ValidTgts$ Creature.Other+attacking | TgtPrompt$ Select another target attacking creature | TokenTapped$ True | TokenAttacking$ True
+DeckHas:Ability$Token
+Oracle:Ninjutsu {2}{U}\nFlying\nWhen Thousand-Faced Shadow enters the battlefield from your hand, if it's attacking, create a token that's a copy of another target attacking creature. The token enters the battlefield tapped and attacking.

--- a/forge-gui/res/cardsfolder/s/swarm_saboteur.txt
+++ b/forge-gui/res/cardsfolder/s/swarm_saboteur.txt
@@ -2,9 +2,9 @@ Name:Swarm Saboteur
 ManaCost:1 B
 Types:Creature Human Ninja
 PT:2/2
-K:Ninjutsu:1 B
+K:Ninjutsu:B
 K:Deathtouch
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigConjure | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, conjure a card named Virus Beetle into your hand.
 SVar:TrigConjure:DB$ MakeCard | Conjure$ True | Name$ Virus Beetle | Zone$ Hand
 SVar:MustBeBlocked:True
-Oracle:Ninjutsu {1}{B}\nDeathtouch\nWhenever Swarm Saboteur deals combat damage to a player, conjure a card named Virus Beetle into your hand.
+Oracle:Ninjutsu {B}\nDeathtouch\nWhenever Swarm Saboteur deals combat damage to a player, conjure a card named Virus Beetle into your hand.

--- a/forge-gui/res/editions/Alchemy Horizons Baldur's Gate.txt
+++ b/forge-gui/res/editions/Alchemy Horizons Baldur's Gate.txt
@@ -308,6 +308,7 @@ ScryfallCode=HBG
 
 [rebalanced]
 A85 C A-Blessed Hippogriff @Leanna Crossan
+A87 C A-Dawnbringer Cleric @Lie Setiawan
 A104 C A-Steadfast Unicorn @John Thacker
 A117 C A-Dragonborn Looter @Julio Reyna
 A120 U A-Goggles of Night @Forrest Imel
@@ -332,6 +333,7 @@ A215 U A-Jade Orb of Dragonkind @Olena Richards
 A217 R A-Monster Manual @David Gaillet
 A223 U A-Split the Spoils @Edgar Sánchez Hidalgo
 A232 R A-Baba Lysaga, Night Witch @Slawomir Maniak
+A239 U A-Krydle of Baldur's Gate @Bryan Sola
 A243 M A-Minsc & Boo, Timeless Heroes @Andreas Zafiratos
 A259 C A-Lantern of Revealing @Eytan Zana
 A262 U A-Navigation Orb @Robin Olausson

--- a/forge-gui/res/editions/Kamigawa Neon Dynasty.txt
+++ b/forge-gui/res/editions/Kamigawa Neon Dynasty.txt
@@ -540,10 +540,20 @@ ScryfallCode=NEO
 A1 C A-Ancestral Katana @Daniel Ljunggren
 A10 C A-Eiganjo Exemplar @Ernanda Souza
 A19 C A-Imperial Subduer @Zara Alfonso
+A53 U A-Futurist Operative @Justine Cruz
+A67 C A-Moon-Circuit Hacker @Tia Masic
+A73 U A-Prosperous Thief @Fajareka Setiawan
+A86 R A-Thousand-Faced Shadow @Ekaterina Burmak
+A95 U A-Dokuchi Silencer @David Rapoza
+A114 M A-Nashi, Moon Sage's Scion @Valera Lutfullina
+A116 U A-Nezumi Prowler @Joseph Weston
 A131 C A-Akki Ronin @Olivier Bernard
 A156 C A-Peerless Samurai @Micah Epstein
 A215 U A-Asari Captain @Donato Giancola
 A232 R A-Raiyuu, Storm's Edge @Heonhwa Choe
+A234 R A-Satoru Umezawa @Anna Pavleeva
+A236 U A-Silver-Fur Master @Carl Critchlow
+A242 U A-Circuit Mender @Hector Ortiz
 
 [lands]
 1 Plains|NEO|1

--- a/forge-gui/res/editions/Streets of New Capenna.txt
+++ b/forge-gui/res/editions/Streets of New Capenna.txt
@@ -496,6 +496,7 @@ ScryfallCode=SNC
 [rebalanced]
 A6 C A-Buy Your Silence @Tony Foti
 A7 C A-Celebrity Fencer @Inka Schulz
+A20 U A-Knockout Blow @Zoltan Boros
 A32 C A-Speakeasy Server @Scott Murphy
 A37 C A-Case the Joint @Stella Spente
 A53 C A-Psionic Snoop @Marcela Medeiros

--- a/forge-gui/res/editions/The Brothers War.txt
+++ b/forge-gui/res/editions/The Brothers War.txt
@@ -406,6 +406,9 @@ ScryfallCode=BRO
 383 U Sardian Cliffstomper @Joseph Weston
 384 U Blanchwood Armor @Manuel Castañón
 
+[rebalanced]
+A199 U A-Haywire Mite @Izzy
+
 [lands]
 2 Plains|BRO|1
 2 Plains|BRO|2


### PR DESCRIPTION
Source: https://magic.wizards.com/en/news/mtg-arena/alchemy-rebalancing-for-april-4-2023

- [x] Circuit Mender
- [x] Dawnbringer Cleric
- [x] Dokuchi Silencer
- [x] Futurist Operative
- [x] Haywire Mite
- [x] Hinterland Chef
- [x] Knockout Blow
- [x] Krydle of Baldur's Gate
- [x] Lonely End
- [x] Moon-Circuit Hacker
- [x] Nashi, Moon Sage's Scion
- [x] Nezumi Prowler
- [x] Nightclub Bouncer
- [x] Prosperous Thief
- [x] Satoru Umezawa
- [x] Silver-Fur Master
- [x] Swarm Saboteur
- [x] Thousand-Faced Shadow