### PR TITLE
Renamed an invalid card for Chandra Adventure battle

### DIFF
--- a/forge-gui/res/adventure/Shandalar/maps/map/main_story/templeofchandra.tmx
+++ b/forge-gui/res/adventure/Shandalar/maps/map/main_story/templeofchandra.tmx
@@ -1514,7 +1514,7 @@
   <object id="183" template="../../obj/enemy.tx" x="67" y="940.5">
    <properties>
     <property name="effect">{
- &quot;startBattleWithCardInCommandZone&quot;: [ &quot;Chandra, Supreme Pyromancer&quot; ]
+ &quot;startBattleWithCardInCommandZone&quot;: [ &quot;Chandra, Bold Pyromancer&quot; ]
 }</property>
     <property name="enemy" value="Chandra"/>
     <property name="ignoreDungeonEffect" type="bool" value="false"/>


### PR DESCRIPTION
Chandra, Supreme Pyromancer doesn't seem to exist.  I'm guessing it should be Chandra, Bold Pyromancer, though "Novice" is another option.  A quick playtest showed reasonable difficulty for the encounter.