### PR TITLE
Draft: flitting_guerrilla.txt

### DIFF
--- a/forge-game/src/main/java/forge/game/card/CardProperty.java
+++ b/forge-game/src/main/java/forge/game/card/CardProperty.java
@@ -1962,7 +1962,8 @@ public class CardProperty {
         } else if (property.startsWith("Triggered")) {
             if (spellAbility instanceof SpellAbility) {
                 final String key = property.substring(9);
-                Object o = ((SpellAbility)spellAbility).getTriggeringObject(AbilityKey.fromString(key));
+                SpellAbility sa = (SpellAbility) spellAbility;
+                Object o = sa.getRootAbility().getTriggeringObject(AbilityKey.fromString(key));
                 boolean found = false;
                 if (o != null) {
                     if (o instanceof CardCollection) {
@@ -1980,7 +1981,10 @@ public class CardProperty {
         } else if (property.startsWith("NotTriggered")) {
             final String key = property.substring("NotTriggered".length());
             if (spellAbility instanceof SpellAbility) {
-                if (card.equals(((SpellAbility)spellAbility).getTriggeringObject(AbilityKey.fromString(key)))) {
+                SpellAbility sa = (SpellAbility) spellAbility;
+                Object o = sa.getRootAbility().getTriggeringObject(AbilityKey.fromString(key));
+
+                if (card.equals(sa.getRootAbility().getTriggeringObject(AbilityKey.fromString(key)))) {
                     return false;
                 }
             } else {

--- a/forge-game/src/main/java/forge/game/card/CardProperty.java
+++ b/forge-game/src/main/java/forge/game/card/CardProperty.java
@@ -1982,8 +1982,6 @@ public class CardProperty {
             final String key = property.substring("NotTriggered".length());
             if (spellAbility instanceof SpellAbility) {
                 SpellAbility sa = (SpellAbility) spellAbility;
-                Object o = sa.getRootAbility().getTriggeringObject(AbilityKey.fromString(key));
-
                 if (card.equals(sa.getRootAbility().getTriggeringObject(AbilityKey.fromString(key)))) {
                     return false;
                 }

--- a/forge-gui/res/cardsfolder/upcoming/flitting_guerrilla.txt
+++ b/forge-gui/res/cardsfolder/upcoming/flitting_guerrilla.txt
@@ -4,9 +4,8 @@ Types:Creature Faerie Rogue
 PT:2/2
 K:Flying
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigMill | TriggerDescription$ When CARDNAME dies, each player mills two cards. Then you may exile CARDNAME. When you do, put target creature or battle card from your graveyard on top of your library. (To mill two cards, a player puts the top two cards of their library into their graveyard.)
-SVar:TrigMill:DB$ Mill | Defined$ Player | NumCards$ 2 | SubAbility$ DBRemember
-SVar:DBRemember:DB$ Pump | RememberObjects$ TriggeredNewCardLKICopy | SubAbility$ DBImmediateTrig
-SVar:DBImmediateTrig:DB$ ImmediateTrigger | Execute$ TrigChangeZone | UnlessCost$ ExileAnyGrave<1/Card.IsRemembered> | UnlessPayer$ You | UnlessSwitched$ True | TriggerDescription$ Then you may exile CARDNAME. When you do, put target creature or battle card from your graveyard on top of your library.
+SVar:TrigMill:DB$ Mill | Defined$ Player | NumCards$ 2 | SubAbility$ DBImmediateTrig
+SVar:DBImmediateTrig:DB$ ImmediateTrigger | Execute$ TrigChangeZone | UnlessCost$ ExileAnyGrave<1/Card.TriggeredNewCard> | UnlessPayer$ You | UnlessSwitched$ True | TriggerDescription$ Then you may exile CARDNAME. When you do, put target creature or battle card from your graveyard on top of your library.
 SVar:TrigChangeZone:DB$ ChangeZone | ValidTgts$ Creature.YouOwn,Battle.YouOwn | TgtPrompt$ Select target creature or battle card from your graveyard | Origin$ Graveyard | Destination$ Library | LibraryPosition$ 0
 DeckHas:Ability$Mill|Graveyard
 DeckHints:Type$Battle

--- a/forge-gui/res/cardsfolder/upcoming/flitting_guerrilla.txt
+++ b/forge-gui/res/cardsfolder/upcoming/flitting_guerrilla.txt
@@ -1,0 +1,13 @@
+Name:Flitting Guerrilla
+ManaCost:2 B
+Types:Creature Faerie Rogue
+PT:2/2
+K:Flying
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigMill | TriggerDescription$ When CARDNAME dies, each player mills two cards. Then you may exile CARDNAME. When you do, put target creature or battle card from your graveyard on top of your library. (To mill two cards, a player puts the top two cards of their library into their graveyard.)
+SVar:TrigMill:DB$ Mill | Defined$ Player | NumCards$ 2 | SubAbility$ DBRemember
+SVar:DBRemember:DB$ Pump | RememberObjects$ TriggeredNewCardLKICopy | SubAbility$ DBImmediateTrig
+SVar:DBImmediateTrig:DB$ ImmediateTrigger | Execute$ TrigChangeZone | UnlessCost$ ExileAnyGrave<1/Card.IsRemembered> | UnlessPayer$ You | UnlessSwitched$ True | TriggerDescription$ Then you may exile CARDNAME. When you do, put target creature or battle card from your graveyard on top of your library.
+SVar:TrigChangeZone:DB$ ChangeZone | ValidTgts$ Creature.YouOwn,Battle.YouOwn | TgtPrompt$ Select target creature or battle card from your graveyard | Origin$ Graveyard | Destination$ Library | LibraryPosition$ 0
+DeckHas:Ability$Mill|Graveyard
+DeckHints:Type$Battle
+Oracle:Flying\nWhen Flitting Guerrilla dies, each player mills two cards. Then you may exile Flitting Guerrilla. When you do, put target creature or battle card from your graveyard on top of your library. (To mill two cards, a player puts the top two cards of their library into their graveyard.)


### PR DESCRIPTION
Seems like we shouldn't need line 8 and be able to just use `ExileAnyGrave<1/Card.TriggeredNewCard>` in line 9 – but that doesn't work.

All other cards like that are AB$ with Cost$ but this kind of has to be DB$ with UnlessCost$ because it's after the Mill ☹️ 

Made this a separate PR in case the engine should be updated