### PR TITLE
MOM: more battle-adjacent cards

### DIFF
--- a/forge-gui/res/cardsfolder/f/fire_prophecy.txt
+++ b/forge-gui/res/cardsfolder/f/fire_prophecy.txt
@@ -2,7 +2,7 @@ Name:Fire Prophecy
 ManaCost:1 R
 Types:Instant
 A:SP$ DealDamage | Cost$ 1 R | ValidTgts$ Creature | NumDmg$ 3 | SubAbility$ DBBottom | SpellDescription$ CARDNAME deals 3 damage to target creature. You may put a card from your hand on the bottom of your library. If you do, draw a card.
-SVar:DBBottom:DB$ ChangeZone | Origin$ Hand | Destination$ Library | Hand$ Library | LibraryPosition$ -1 | ChangeNum$ 1 | RememberChanged$ True | SubAbility$ DBDraw
+SVar:DBBottom:DB$ ChangeZone | Origin$ Hand | Destination$ Library | LibraryPosition$ -1 | ChangeNum$ 1 | RememberChanged$ True | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | ConditionDefined$ Remembered | ConditionPresent$ Card | ConditionCompare$ GE1 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Fire Prophecy deals 3 damage to target creature. You may put a card from your hand on the bottom of your library. If you do, draw a card.

--- a/forge-gui/res/cardsfolder/m/mordenkainen.txt
+++ b/forge-gui/res/cardsfolder/m/mordenkainen.txt
@@ -3,7 +3,7 @@ ManaCost:4 U U
 Types:Legendary Planeswalker Mordenkainen
 Loyalty:5
 A:AB$ Draw | Cost$ AddCounter<2/LOYALTY> | Planeswalker$ True | NumCards$ 2 | SubAbility$ DBBottom | SpellDescription$ Draw two cards, then put a card from your hand on the bottom of your library.
-SVar:DBBottom:DB$ ChangeZone | Origin$ Hand | Destination$ Library | Hand$ Library | LibraryPosition$ -1 | ChangeNum$ 1
+SVar:DBBottom:DB$ ChangeZone | Origin$ Hand | Destination$ Library | LibraryPosition$ -1 | ChangeNum$ 1
 A:AB$ Token | Cost$ SubCounter<2/LOYALTY> | Planeswalker$ True | TokenOwner$ You | TokenScript$ u_x_x_dog_illusion_cardsinhand | TokenAmount$ 1 | SpellDescription$ Create a blue Dog Illusion creature token with "This creature's power and toughness are each equal to twice the number of cards in your hand."
 A:AB$ ChangeZoneAll | Cost$ SubCounter<10/LOYALTY> | Planeswalker$ True | Ultimate$ True | ChangeType$ Card.YouCtrl | Origin$ Hand | Destination$ Library | RememberChanged$ True | SubAbility$ DBChangeZoneAll | SpellDescription$ Exchange your hand and library, then shuffle. You get an emblem with "You have no maximum hand size."
 SVar:DBChangeZoneAll:DB$ ChangeZoneAll | ChangeType$ Card.YouCtrl+IsNotRemembered | Origin$ Library | Destination$ Hand | SubAbility$ DBShuffle

--- a/forge-gui/res/cardsfolder/rebalanced/a-akki_ronin.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-akki_ronin.txt
@@ -3,7 +3,7 @@ ManaCost:R
 Types:Creature Goblin Samurai
 PT:1/2
 T:Mode$ Attacks | ValidCard$ Samurai.YouCtrl,Warrior.YouCtrl | Alone$ True | Execute$ TrigChangeZone | TriggerZones$ Battlefield | TriggerDescription$ Whenever a Samurai or Warrior you control attacks alone, you may put a card from your hand on the bottom of your library. If you do, draw a card.
-SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Hand | Destination$ Library | Hand$ Library | LibraryPosition$ -1 | ChangeNum$ 1 | RememberChanged$ True | SubAbility$ DBDraw
+SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Hand | Destination$ Library | LibraryPosition$ -1 | ChangeNum$ 1 | RememberChanged$ True | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | ConditionDefined$ Remembered | ConditionPresent$ Card | ConditionCompare$ GE1 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 DeckHints:Type$Samurai|Warrior

--- a/forge-gui/res/cardsfolder/upcoming/nahiris_warcrafting.txt
+++ b/forge-gui/res/cardsfolder/upcoming/nahiris_warcrafting.txt
@@ -1,0 +1,9 @@
+Name:Nahiri's Warcrafting
+ManaCost:1 R R
+Types:Sorcery
+A:SP$ DealDamage | ValidTgts$ Creature,Planeswalker,Battle | TgtPrompt$ Select target creature, planeswalker, or battle | NumDmg$ 5 | ExcessSVar$ X | SubAbility$ DBDig | SpellDescription$ CARDNAME deals 5 damage to target creature, planeswalker, or battle.
+SVar:DBDig:DB$ Dig | DigNum$ X | ChangeNum$ 1 | Optional$ True | DestinationZone$ Exile | RestRandomOrder$ True | RememberChanged$ True | SubAbility$ DBEffect | SpellDescription$ Look at the top X cards of your library, where X is the excess damage dealt this way. You may exile one of those cards. Put the rest on the bottom of your library in a random order.
+SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ Play | SubAbility$ DBCleanup | ExileOnMoved$ Exile | SpellDescription$ You may play the exiled card this turn.
+SVar:Play:Mode$ Continuous | MayPlay$ True | EffectZone$ Command | Affected$ Card.IsRemembered | AffectedZone$ Exile | Description$ You may play the exiled card this turn.
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:Nahiri's Warcrafting deals 5 damage to target creature, planeswalker, or battle. Look at the top X cards of your library, where X is the excess damage dealt this way. You may exile one of those cards. Put the rest on the bottom of your library in a random order. You may play the exiled card this turn.

--- a/forge-gui/res/cardsfolder/upcoming/shatter_the_source.txt
+++ b/forge-gui/res/cardsfolder/upcoming/shatter_the_source.txt
@@ -1,0 +1,8 @@
+Name:Shatter the Source
+ManaCost:5 R
+Types:Instant
+K:Convoke
+A:SP$ Charm | Choices$ Damage,Destroy
+SVar:Damage:DB$ DealDamage | ValidTgts$ Creature,Planeswalker,Battle | TgtPrompt$ Select target creature, planeswalker, or battle | NumDmg$ 6 | StackDescription$ CARDNAME deals 6 damage to {c:Targeted}. | SpellDescription$ CARDNAME deals 6 damage to target creature, planeswalker, or battle.
+SVar:Destroy:DB$ Destroy | ValidTgts$ Artifact | StackDescription$ Destroy {c:Targeted}. | SpellDescription$ Destroy target artifact.
+Oracle:Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nChoose one —\n• Shatter the Source deals 6 damage to target creature, planeswalker, or battle.\n• Destroy target artifact.

--- a/forge-gui/res/cardsfolder/upcoming/thrashing_frontliner.txt
+++ b/forge-gui/res/cardsfolder/upcoming/thrashing_frontliner.txt
@@ -1,0 +1,9 @@
+Name:Thrashing Frontliner
+ManaCost:1 R
+Types:Creature Phyrexian Viashino
+PT:2/2
+K:Trample
+T:Mode$ AttackersDeclaredOneTarget | ValidAttackers$ Card.Self | AttackedTarget$ Battle | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME attacks a battle, it gets +1/+1 until end of turn.
+SVar:TrigPump:DB$ Pump | NumAtt$ 1 | NumDef$ 1
+AI:RemoveDeck:Random
+Oracle:Trample\nWhenever Thrashing Frontliner attacks a battle, it gets +1/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/upcoming/thrashing_frontliner.txt
+++ b/forge-gui/res/cardsfolder/upcoming/thrashing_frontliner.txt
@@ -3,7 +3,7 @@ ManaCost:1 R
 Types:Creature Phyrexian Viashino
 PT:2/2
 K:Trample
-T:Mode$ AttackersDeclaredOneTarget | ValidAttackers$ Card.Self | AttackedTarget$ Battle | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME attacks a battle, it gets +1/+1 until end of turn.
+T:Mode$ Attacks | ValidCard$ Card.Self | Attacked$ Battle | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME attacks a battle, it gets +1/+1 until end of turn.
 SVar:TrigPump:DB$ Pump | NumAtt$ 1 | NumDef$ 1
 AI:RemoveDeck:Random
 Oracle:Trample\nWhenever Thrashing Frontliner attacks a battle, it gets +1/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/upcoming/volcanic_spite.txt
+++ b/forge-gui/res/cardsfolder/upcoming/volcanic_spite.txt
@@ -1,8 +1,8 @@
 Name:Volcanic Spite
 ManaCost:1 R
 Types:Instant
-A:SP$ DealDamage | ValidTgts$ Creature,Planeswalker,Battle | TgtPrompt$ Select target creature, planeswalker, or battle | NumDmg$ 3 | SubAbility$ DBBottom | SpellDescription$ CARDNAME deals 5 damage to target creature, planeswalker, or battle.
-SVar:DBBottom:DB$ ChangeZone | Origin$ Hand | Destination$ Library | Hand$ Library | LibraryPosition$ -1 | ChangeNum$ 1 | RememberChanged$ True | SubAbility$ DBDraw | StackDescription$ SpellDescription | SpellDescription$ You may put a card from your hand on the bottom of your library.
+A:SP$ DealDamage | ValidTgts$ Creature,Planeswalker,Battle | TgtPrompt$ Select target creature, planeswalker, or battle | NumDmg$ 3 | SubAbility$ DBBottom | SpellDescription$ CARDNAME deals 3 damage to target creature, planeswalker, or battle.
+SVar:DBBottom:DB$ ChangeZone | Origin$ Hand | Destination$ Library | LibraryPosition$ -1 | ChangeNum$ 1 | RememberChanged$ True | SubAbility$ DBDraw | StackDescription$ SpellDescription | SpellDescription$ You may put a card from your hand on the bottom of your library.
 SVar:DBDraw:DB$ Draw | ConditionDefined$ Remembered | ConditionPresent$ Card | ConditionCompare$ GE1 | SubAbility$ DBCleanup | StackDescription$ SpellDescription | SpellDescription$ If you do, draw a card.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Volcanic Spite deals 3 damage to target creature, planeswalker, or battle. You may put a card from your hand on the bottom of your library. If you do, draw a card.

--- a/forge-gui/res/cardsfolder/upcoming/volcanic_spite.txt
+++ b/forge-gui/res/cardsfolder/upcoming/volcanic_spite.txt
@@ -1,0 +1,8 @@
+Name:Volcanic Spite
+ManaCost:1 R
+Types:Instant
+A:SP$ DealDamage | ValidTgts$ Creature,Planeswalker,Battle | TgtPrompt$ Select target creature, planeswalker, or battle | NumDmg$ 3 | SubAbility$ DBBottom | SpellDescription$ CARDNAME deals 5 damage to target creature, planeswalker, or battle.
+SVar:DBBottom:DB$ ChangeZone | Origin$ Hand | Destination$ Library | Hand$ Library | LibraryPosition$ -1 | ChangeNum$ 1 | RememberChanged$ True | SubAbility$ DBDraw | StackDescription$ SpellDescription | SpellDescription$ You may put a card from your hand on the bottom of your library.
+SVar:DBDraw:DB$ Draw | ConditionDefined$ Remembered | ConditionPresent$ Card | ConditionCompare$ GE1 | SubAbility$ DBCleanup | StackDescription$ SpellDescription | SpellDescription$ If you do, draw a card.
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:Volcanic Spite deals 3 damage to target creature, planeswalker, or battle. You may put a card from your hand on the bottom of your library. If you do, draw a card.

--- a/forge-gui/res/cardsfolder/upcoming/war_trained_slasher.txt
+++ b/forge-gui/res/cardsfolder/upcoming/war_trained_slasher.txt
@@ -3,7 +3,7 @@ ManaCost:3 R
 Types:Creature Wolverine Dinosaur
 PT:4/3
 K:Menace
-T:Mode$ AttackersDeclaredOneTarget | ValidAttackers$ Card.Self | AttackedTarget$ Battle | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME attacks a battle, double its power until end of turn.
+T:Mode$ Attacks | ValidCard$ Card.Self | Attacked$ Battle | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME attacks a battle, double its power until end of turn.
 SVar:TrigPump:DB$ Pump | Defined$ TriggeredAttackerLKICopy | NumAtt$ +Y | Double$ True
 SVar:Y:TriggeredAttacker$CardPower
 Oracle:Menace (This creature can't be blocked except by two or more creatures.)\nWhenever War-Trained Slasher attacks a battle, double its power until end of turn.

--- a/forge-gui/res/cardsfolder/upcoming/war_trained_slasher.txt
+++ b/forge-gui/res/cardsfolder/upcoming/war_trained_slasher.txt
@@ -1,0 +1,9 @@
+Name:War-Trained Slasher
+ManaCost:3 R
+Types:Creature Wolverine Dinosaur
+PT:4/3
+K:Menace
+T:Mode$ AttackersDeclaredOneTarget | ValidAttackers$ Card.Self | AttackedTarget$ Battle | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME attacks a battle, double its power until end of turn.
+SVar:TrigPump:DB$ Pump | Defined$ TriggeredAttackerLKICopy | NumAtt$ +Y | Double$ True
+SVar:Y:TriggeredAttacker$CardPower
+Oracle:Menace (This creature can't be blocked except by two or more creatures.)\nWhenever War-Trained Slasher attacks a battle, double its power until end of turn.


### PR DESCRIPTION
Nothing that directly needs Battle for testing

I *think* this is the best trigger to use for Thrashing Frontliner / War-Trained Slasher … works fine in testing with an identical trigger using `AttackedTarget$ Planeswalker`

nahiris_warcrafting.txt
shatter_the_source.txt
thrashing_frontliner.txt
volcanic_spite.txt
war_trained_slasher.txt