### PR TITLE
Effect cleanup can prevent any LTB trigger

### DIFF
--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -1439,6 +1439,8 @@ public class GameAction {
             }
             setHoldCheckingStaticAbilities(false);
 
+            // important to collect first otherwise if a static fires it will mess up registered ones from LKI
+            game.getTriggerHandler().collectTriggerForWaiting();
             if (game.getTriggerHandler().runWaitingTriggers()) {
                 checkAgain = true;
             }

--- a/forge-game/src/main/java/forge/game/ability/effects/RollDiceEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/RollDiceEffect.java
@@ -68,6 +68,9 @@ public class RollDiceEffect extends SpellAbilityEffect {
         return rollDiceForPlayer(sa, player, amount, sides, 0, 0, null);
     }
     private static int rollDiceForPlayer(SpellAbility sa, Player player, int amount, int sides, int ignore, int modifier, List<Integer> rollsResult) {
+        if (amount == 0) {
+            return 0;
+        }
         int advantage = getRollAdvange(player);
         amount += advantage;
         int total = 0;

--- a/forge-game/src/main/java/forge/game/trigger/TriggerHandler.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerHandler.java
@@ -180,7 +180,7 @@ public class TriggerHandler {
         return FileSection.parseToMap(trigParse, FileSection.DOLLAR_SIGN_KV_SEPARATOR);
     }
 
-    private void collectTriggerForWaiting() {
+    public void collectTriggerForWaiting() {
         for (final TriggerWaiting wt : waitingTriggers) {
             if (wt.getTriggers() != null)
                 continue;


### PR DESCRIPTION
Example: Target _Solemn Simulacrum_ with _Rogue's Passage_ and then deal lethal dmg to it

This is because the Static ExileOnMoved$ trigger will resolve first and the registered trigger from the LKI before death will be lost.

Notably it will fail with any combination of such cards but only if it dies from SBA, otherwise MagicStack handles it correctly.

I think a full call to ``resetActiveTriggers`` is unneeded / would be wrong during SBA.