### PR TITLE
Battle: lazy build SpellPermanent on TDFC

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
@@ -2939,6 +2939,12 @@ public class AbilityUtils {
                 la.setCardState(original);
                 list.add(la);
             }
+            if (state == CardStateName.Transformed && tgtCard.isPermanent() && !tgtCard.isAura()) {
+                // casting defeated battle
+                Spell sp = new SpellPermanent(tgtCard, original);
+                sp.setCardState(original);
+                list.add(sp);
+            }
             if (tgtCard.isModal()) {
                 CardState modal = tgtCard.getState(CardStateName.Modal);
                 Iterables.addAll(list, tgtCard.getBasicSpells(modal));

--- a/forge-gui-desktop/src/main/java/forge/toolbox/imaging/FCardImageRenderer.java
+++ b/forge-gui-desktop/src/main/java/forge/toolbox/imaging/FCardImageRenderer.java
@@ -184,7 +184,7 @@ public class FCardImageRenderer {
             if (!card.isSplitCard() && !card.isFlipCard()) {
                 final CardStateView state = card.getState(card.isAdventureCard() ? false : altState);
                 if ((state.isCreature() && !state.getKeywordKey().contains("Level up"))
-                        || state.isPlaneswalker() || state.getType().hasSubtype("Vehicle"))
+                        || state.isPlaneswalker() || state.isVehicle())
                     hasPTBox = true;
             }
             if (hasPTBox) {
@@ -294,7 +294,7 @@ public class FCardImageRenderer {
         int headerHeight = NAME_SIZE + 2 * HEADER_PADDING;
         int typeBoxHeight = TYPE_SIZE + 2 * TYPE_PADDING;
         int ptBoxHeight = 0;
-        if (state.isCreature() || state.isPlaneswalker() || state.getType().hasSubtype("Vehicle")) {
+        if (state.isCreature() || state.isPlaneswalker() || state.isVehicle()) {
             //if P/T box needed, make room for it
             ptBoxHeight = headerHeight;
         }
@@ -839,7 +839,7 @@ public class FCardImageRenderer {
             TEXT_COLOR = Color.WHITE;
             pieces.add(String.valueOf(state.getLoyalty()));
         }
-        else if (state.getType().hasSubtype("Vehicle")) {
+        else if (state.isVehicle()) {
             Color [] vhColor = { new Color(128, 96, 64) };
             colors = vhColor;
             TEXT_COLOR = Color.WHITE;

--- a/forge-gui/res/cardsfolder/upcoming/invasion_of_amonkhet_lazotep_convert.txt
+++ b/forge-gui/res/cardsfolder/upcoming/invasion_of_amonkhet_lazotep_convert.txt
@@ -17,7 +17,6 @@ ManaCost:no cost
 Colors:blue,black
 Types:Creature Zombie
 PT:4/4
-A:SP$ PermanentCreature
 K:ETBReplacement:Copy:DBCopy:Optional
 SVar:DBCopy:DB$ Clone | Choices$ Creature | ChoiceZone$ Graveyard | SetPower$ 4 | SetToughness$ 4 | AddColors$ Black | AddTypes$ Zombie | SpellDescription$ You may have CARDNAME enter the battlefield as a copy of any creature card in a graveyard, except it's a 4/4 black Zombie in addition to its other types.
 Oracle:You may have Lazotep Convert enter the battlefield as a copy of any creature card in a graveyard, except it's a 4/4 black Zombie in addition to its other types.

--- a/forge-gui/res/cardsfolder/upcoming/invasion_of_dominaria_serra_faithkeeper.txt
+++ b/forge-gui/res/cardsfolder/upcoming/invasion_of_dominaria_serra_faithkeeper.txt
@@ -16,7 +16,6 @@ ManaCost:no cost
 Colors:white
 Types:Creature Angel
 PT:4/4
-A:SP$ PermanentCreature
 K:Flying
 K:Vigilance
 Oracle:Flying, vigilance

--- a/forge-gui/res/cardsfolder/upcoming/invasion_of_new_phyrexia_teferi_akosa_of_zhalfir.txt
+++ b/forge-gui/res/cardsfolder/upcoming/invasion_of_new_phyrexia_teferi_akosa_of_zhalfir.txt
@@ -16,7 +16,6 @@ ManaCost:no cost
 Colors:white,blue
 Types:Legendary Planeswalker Teferi
 Loyalty:4
-A:SP$ PermanentNoncreature
 A:AB$ Draw | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | NumCards$ 2 | SubAbility$ DBDiscard | SpellDescription$ Draw two cards.
 SVar:DBDiscard:DB$ Discard | NumCards$ 2 | Mode$ TgtChoose | UnlessType$ Creature | StackDescription$ SpellDescription | SpellDescription$ Then discard two cards unless you discard a creature card.
 A:AB$ Effect | Cost$ SubCounter<2/LOYALTY> | Planeswalker$ True | Name$ Emblem - Teferi Akosa of Zhalfir | Image$ emblem_teferi_akosa_of_zhalfir | StaticAbilities$ STPump | Duration$ Permanent | SpellDescription$ You get an emblem with "Knights you control get +1/+0 and have ward {1}."

--- a/forge-gui/res/cardsfolder/upcoming/invasion_of_zendikar_awakened_skyclave.txt
+++ b/forge-gui/res/cardsfolder/upcoming/invasion_of_zendikar_awakened_skyclave.txt
@@ -14,7 +14,6 @@ ManaCost:no cost
 Colors:green
 Types:Creature Elemental
 PT:4/4
-A:SP$ PermanentCreature
 K:Vigilance
 K:Haste
 S:Mode$ Continuous | Affected$ Card.Self | AddType$ Land | Description$ As long as CARDNAME is on the battlefield, it's a land in addition to its other types.


### PR DESCRIPTION
> If a permanent that is represented by a transforming double-faced card becomes a copy of a Siege, it will be exiled as that Siege's triggered ability resolves, then it will be cast transformed. Note that this applies only to transforming double-faced cards, not to modal double-faced cards that can normally be played using either face.

![grafik](https://user-images.githubusercontent.com/8506892/231701291-b7edfebf-fef4-4d26-bdcc-77f8fe2a3c15.png)

This will now correctly cast the back of _Aetherblade Agent_.