### PR TITLE
Reduce inventory clutter for unique items

### DIFF
--- a/forge-adventure/src/main/java/forge/adventure/editor/ItemEdit.java
+++ b/forge-adventure/src/main/java/forge/adventure/editor/ItemEdit.java
@@ -16,6 +16,7 @@ public class ItemEdit extends JComponent {
     EffectEditor effect=new EffectEditor(false);
     JTextField description=new JTextField();
     JCheckBox questItem=new JCheckBox();
+    JCheckBox unique = new JCheckBox();
     JSpinner cost= new JSpinner(new SpinnerNumberModel(0, 0, 100000, 1));
 
     private boolean updating=false;
@@ -32,6 +33,7 @@ public class ItemEdit extends JComponent {
         parameters.add("description:",description);
         parameters.add("iconName",iconName);
         parameters.add("questItem",questItem);
+        parameters.add("unique",unique);
         parameters.add("cost",cost);
 
         add(parameters);
@@ -44,6 +46,7 @@ public class ItemEdit extends JComponent {
         iconName.getDocument().addDocumentListener(new DocumentChangeListener(() -> ItemEdit.this.updateItem()));
         cost.addChangeListener(e -> ItemEdit.this.updateItem());
         questItem.addChangeListener(e -> ItemEdit.this.updateItem());
+        unique.addChangeListener(e -> ItemEdit.this.updateItem());
         effect.addChangeListener(e -> ItemEdit.this.updateItem());
         refresh();
     }
@@ -57,6 +60,7 @@ public class ItemEdit extends JComponent {
         currentData.description=description.getText();
         currentData.iconName=iconName.getText();
         currentData.questItem=questItem.isSelected();
+        currentData.unique=unique.isSelected();
         currentData.cost=((Integer)  cost.getValue()).intValue();
     }
 
@@ -79,6 +83,7 @@ public class ItemEdit extends JComponent {
         description.setText(currentData.description);
         iconName.setText(currentData.iconName);
         questItem.setSelected(currentData.questItem);
+        unique.setSelected(currentData.unique);
         cost.setValue(currentData.cost);
 
         updating=false;

--- a/forge-gui-mobile/src/forge/adventure/data/ItemData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/ItemData.java
@@ -22,6 +22,7 @@ public class ItemData {
     public String description; //Manual description of the item.
     public String iconName;
     public boolean questItem=false;
+    public boolean unique=false;
     public int cost=1000;
 
     public boolean usableOnWorldMap;
@@ -92,6 +93,8 @@ public class ItemData {
             result += effect.getDescription();
         if(shardsNeeded != 0)
             result +=  shardsNeeded+" [+Shards]";
+        if (unique)
+            result += " (unique)";
         return result;
     }
 

--- a/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
+++ b/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
@@ -299,7 +299,7 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
             //Prevent items with wrong names from getting through. Hell breaks loose if it causes null pointers.
             //This only needs to be done on load.
             for (String i : inv) {
-                if (ItemData.getItem(i) != null) inventoryItems.add(i);
+                if (ItemData.getItem(i) != null) addItem(i);
                 else {
                     System.err.printf("Cannot find item name %s\n", i);
                     //Allow official© permission for the player to get a refund. We will allow it this time.
@@ -469,7 +469,7 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
                 break;
             case Item:
                 if (reward.getItem() != null)
-                    inventoryItems.add(reward.getItem().name);
+                    addItem(reward.getItem().name);
                 break;
             case Life:
                 addMaxLife(reward.getCount());
@@ -764,6 +764,7 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
 
     public boolean addItem(String name) {
         ItemData item = ItemData.getItem(name);
+        if (item.unique && inventoryItems.contains(name, false)) return false;
         if (item == null)
             return false;
         inventoryItems.add(name);

--- a/forge-gui/res/adventure/Shandalar/world/items.json
+++ b/forge-gui/res/adventure/Shandalar/world/items.json
@@ -885,6 +885,7 @@
 	"commandOnUse": "teleport to poi Spawn",
 	"iconName": "ColorlessRune",
 	"questItem": true,
+  "unique": true,
 	"shardsNeeded": 1,
 	"cost": 100
 },


### PR DESCRIPTION
Non-consumable quest items cannot be deleted. Multiples clutter inventory.
This change allows some items to be marked as unique such that only one
instance of a unique item may reside in the player's inventory. Note that
quest items can still have multiples if not explicitly marked as unique.