### PR TITLE
Fix: Preening Champion only creates one token

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/preening_champion.txt
+++ b/forge-gui/res/cardsfolder/upcoming/preening_champion.txt
@@ -3,7 +3,7 @@ ManaCost:2 U
 Types:Creature Bird Knight
 PT:2/2
 K:Flying
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters the battlefield, create two 1/1 blue and red Elemental creature tokens.
-SVar:TrigToken:DB$ Token | TokenAmount$ 2 | TokenScript$ ur_1_1_elemental
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters the battlefield, create a 1/1 blue and red Elemental creature token.
+SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ ur_1_1_elemental
 DeckHas:Ability$Token & Type$Elemental
 Oracle:Flying\nWhen Preening Champion enters the battlefield, create a 1/1 blue and red Elemental creature token.


### PR DESCRIPTION
>  Preening Champion {2}{U}
> Creature — Bird Knight
> Flying
> When Preening Champion enters the battlefield, create a 1/1 blue and red Elemental creature token.

[Gatherer](https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=607100)
