### PR TITLE
Scarecrow Captain fix

### DIFF
--- a/forge-gui/res/adventure/Shandalar/world/enemies.json
+++ b/forge-gui/res/adventure/Shandalar/world/enemies.json
@@ -12445,16 +12445,6 @@
 			"type": "deckCard",
 			"probability": 1,
 			"count": 2,
-			"addMaxCount": 4,
-			"rarity": [
-				"common",
-				"uncommon"
-			]
-		},
-		{
-			"type": "deckCard",
-			"probability": 1,
-			"count": 2,
 			"rarity": [
 				"rare"
 			],


### PR DESCRIPTION
prevent the captain giving Sol Ring (which is classed as an uncommon) to the player