### PR TITLE
Fix RE messing up Triggers

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
@@ -1453,7 +1453,6 @@ public class AbilityUtils {
 
         // Needed - Equip an untapped creature with Sword of the Paruns then cast Deadshot on it. Should deal 2 more damage.
         game.getAction().checkStaticAbilities(); // this will refresh continuous abilities for players and permanents.
-        game.getTriggerHandler().resetActiveTriggers(!sa.isReplacementAbility());
         AbilityUtils.resolveApiAbility(abSub, game);
     }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/ExploreEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ExploreEffect.java
@@ -82,11 +82,9 @@ public class ExploreEffect extends SpellAbilityEffect {
             if (!revealedLand) {
                 // need to get newest game state to check
                 // if it is still on the battlefield
-                // and the timestamp didnt chamge
+                // and the timestamp didnt change
                 Card gamec = game.getCardState(c);
-                // if the card is not more in the game anymore
-                // this might still return true but its no problem
-                if (game.getZoneOf(gamec).is(ZoneType.Battlefield) && gamec.equalsWithTimestamp(c)) {
+                if (gamec.isInPlay() && gamec.equalsWithTimestamp(c)) {
                     c.addCounter(CounterEnumType.P1P1, 1, pl, table);
                 }
             }

--- a/forge-game/src/main/java/forge/game/ability/effects/RegenerateEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/RegenerateEffect.java
@@ -46,7 +46,7 @@ public class RegenerateEffect extends RegenerateBaseEffect {
     @Override
     public void resolve(SpellAbility sa) {
         // create Effect for Regeneration
-        createRegenerationEffect(sa, getTargetCards(sa));
+        createRegenerationEffect(sa, getDefinedCardsOrTargeted(sa));
     }
 
 }

--- a/forge-game/src/main/java/forge/game/trigger/WrappedAbility.java
+++ b/forge-game/src/main/java/forge/game/trigger/WrappedAbility.java
@@ -64,6 +64,7 @@ public class WrappedAbility extends Ability {
             ApiType.SetState,
             ApiType.Play,
             ApiType.SacrificeAll,
+            ApiType.Pump,
 
             ApiType.DelayedTrigger
             );

--- a/forge-gui/res/cardsfolder/a/armament_master.txt
+++ b/forge-gui/res/cardsfolder/a/armament_master.txt
@@ -2,7 +2,7 @@ Name:Armament Master
 ManaCost:W W
 Types:Creature Kor Soldier
 PT:2/2
-S:Mode$ Continuous | Affected$ Creature.Kor+Other+YouCtrl | AddPower$ X | AddToughness$ X | Description$ Other Kor creatures you control get +2/+2 for each Equipment attached to Armament Master.
+S:Mode$ Continuous | Affected$ Creature.Kor+Other+YouCtrl | AddPower$ X | AddToughness$ X | Description$ Other Kor creatures you control get +2/+2 for each Equipment attached to CARDNAME.
 SVar:X:Count$Valid Equipment.Attached/Times.2
 SVar:EquipMe:Multiple
 Oracle:Other Kor creatures you control get +2/+2 for each Equipment attached to Armament Master.

--- a/forge-gui/src/main/java/forge/player/HumanPlaySpellAbility.java
+++ b/forge-gui/src/main/java/forge/player/HumanPlaySpellAbility.java
@@ -30,6 +30,7 @@ import forge.card.MagicColor;
 import forge.game.Game;
 import forge.game.GameActionUtil;
 import forge.game.GameObject;
+import forge.game.ability.AbilityKey;
 import forge.game.ability.AbilityUtils;
 import forge.game.card.Card;
 import forge.game.card.CardPlayOption;
@@ -192,8 +193,10 @@ public class HumanPlaySpellAbility {
 
             if (skipStack) {
                 AbilityUtils.resolve(ability);
-                // Should unfreeze stack
-                game.getStack().unfreezeStack();
+                // Should unfreeze stack (but if it was a RE with a cause better to let it be handled by that)
+                if (!ability.isReplacementAbility() || ability.getRootAbility().getReplacingObject(AbilityKey.Cause) == null) {
+                    game.getStack().unfreezeStack();
+                }
             } else {
                 ensureAbilityHasDescription(ability);
                 game.getStack().addAndUnfreeze(ability);


### PR DESCRIPTION
- Fixed Valakut not triggering when ETB last together with enough mountains:
Got broken by https://github.com/Card-Forge/forge/commit/fb317f

- Closes #2229:
I went back to the original commit (https://github.com/Card-Forge/forge/commit/9c7871) and after testing consider it safe to remove completely because `clearActiveTriggers` now already takes care of avoiding a misfire