### PR TITLE
various Adventure-related things

### DIFF
--- a/forge-game/src/main/java/forge/game/card/CardProperty.java
+++ b/forge-game/src/main/java/forge/game/card/CardProperty.java
@@ -1316,7 +1316,14 @@ public class CardProperty {
                 }
             }
         } else if (property.startsWith("leastToughness")) {
-            final CardCollectionView cards = CardLists.filter(game.getCardsIn(ZoneType.Battlefield), Presets.CREATURES);
+            CardCollectionView cards = CardLists.filter(game.getCardsIn(ZoneType.Battlefield), Presets.CREATURES);
+            if (property.contains("ControlledBy")) {
+                FCollectionView<Player> p = AbilityUtils.getDefinedPlayers(source, property.split("ControlledBy")[1], spellAbility);
+                cards = CardLists.filterControlledBy(cards, p);
+                if (!cards.contains(card)) {
+                    return false;
+                }
+            }
             for (final Card crd : cards) {
                 if (crd.getNetToughness() < card.getNetToughness()) {
                     return false;

--- a/forge-game/src/main/java/forge/game/card/CardProperty.java
+++ b/forge-game/src/main/java/forge/game/card/CardProperty.java
@@ -1317,7 +1317,7 @@ public class CardProperty {
             }
         } else if (property.startsWith("leastToughness")) {
             CardCollectionView cards = CardLists.filter(game.getCardsIn(ZoneType.Battlefield), Presets.CREATURES);
-            if (property.contains("ControlledBy")) {
+            if (property.contains("ControlledBy")) { // 4/25/2023 only used for adventure mode Death Ring
                 FCollectionView<Player> p = AbilityUtils.getDefinedPlayers(source, property.split("ControlledBy")[1], spellAbility);
                 cards = CardLists.filterControlledBy(cards, p);
                 if (!cards.contains(card)) {

--- a/forge-gui/res/adventure/Shandalar/custom_cards/flame_sword.txt
+++ b/forge-gui/res/adventure/Shandalar/custom_cards/flame_sword.txt
@@ -1,9 +1,7 @@
 Name:Flame Sword
 Types:Artifact
-A:AB$ DealDamage | ActivationLimit$ 1 | Cost$ PayShards<3> | ActivationZone$ Command | ValidTgts$ Any | NumDmg$ Z | SubAbility$ Eject | SpellDescription$ Deal 3 damage to any target. If the target is a tapped creature, deal 5 damage to it instead.
-SVar:X:3
-SVar:Y:Targeted$Valid Creature.tapped/Times.2
-SVar:Z:SVar$X/Plus.Y
+A:AB$ DealDamage | ActivationLimit$ 1 | Cost$ PayShards<3> | ActivationZone$ Command | ValidTgts$ Any | NumDmg$ X | SubAbility$ Eject | SpellDescription$ CARDNAME deals 3 damage to any target, or 5 damage to target tapped creature.
+SVar:X:Count$Compare Y GE1.5.3
+SVar:Y:Targeted$Valid Creature.tapped
 SVar:Eject:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{M}{M}{M}: Flame Sword deals 3 damage to any target, or 5 damage to target tapped creature.
-

--- a/forge-gui/res/cardsfolder/p/penregon_besieged.txt
+++ b/forge-gui/res/cardsfolder/p/penregon_besieged.txt
@@ -7,4 +7,5 @@ SVar:DBEffect:DB$ Effect | StaticAbilities$ PerpetualDebuff | Name$ Penregon Bes
 SVar:PerpetualDebuff:Mode$ Continuous | Affected$ Card.ChosenCard | AddPower$ -1 | AddToughness$ -1 | EffectZone$ Command | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | Description$ This creature perpetually gets -1/-1.
 T:Mode$ Always | TriggerZones$ Battlefield | IsPresent$ Creature.OppCtrl | PresentCompare$ EQ0 | Execute$ TrigSac | TriggerDescription$ When your opponents control no creatures, sacrifice CARDNAME.
 SVar:TrigSac:DB$ Sacrifice
+DeckHas:Ability$Sacrifice
 Oracle:At the beginning of your end step, choose a creature with the least toughness among creatures your opponents control. It perpetually gets -1/-1.\nWhen your opponents control no creatures, sacrifice Penregon Besieged.

--- a/forge-gui/res/cardsfolder/p/penregon_besieged.txt
+++ b/forge-gui/res/cardsfolder/p/penregon_besieged.txt
@@ -2,7 +2,7 @@ Name:Penregon Besieged
 ManaCost:1 B
 Types:Enchantment
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigChoose | TriggerDescription$ At the beginning of your end step, choose a creature with the least toughness among creatures your opponents control. It perpetually gets -1/-1.
-SVar:TrigChoose:DB$ ChooseCard | Choices$ Creature.leastToughness+OppCtrl | ChoiceTitle$ Choose a creature with the least toughness among creatures your opponents control | Mandatory$ True | SubAbility$ DBEffect
+SVar:TrigChoose:DB$ ChooseCard | Choices$ Creature.leastToughnessControlledByOpponent | ChoiceTitle$ Choose a creature with the least toughness among creatures your opponents control | Mandatory$ True | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | StaticAbilities$ PerpetualDebuff | Name$ Penregon Besieged's Perpetual Effect | Duration$ Permanent
 SVar:PerpetualDebuff:Mode$ Continuous | Affected$ Card.ChosenCard | AddPower$ -1 | AddToughness$ -1 | EffectZone$ Command | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | Description$ This creature perpetually gets -1/-1.
 T:Mode$ Always | TriggerZones$ Battlefield | IsPresent$ Creature.OppCtrl | PresentCompare$ EQ0 | Execute$ TrigSac | TriggerDescription$ When your opponents control no creatures, sacrifice CARDNAME.


### PR DESCRIPTION
The CardProperty tweak will allow @jjayers99 to implement a rebalanced version of Death Ring. It smells like something we'll probably need in the future, so I think it's OK to put in even though no "actual" MtG cards use it yet.

EDIT: we actually need the CardProperty tweak to get Penregon Besieged working properly.