### PR TITLE
MAT: spark_rupture.txt

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/spark_rupture.txt
+++ b/forge-gui/res/cardsfolder/upcoming/spark_rupture.txt
@@ -1,0 +1,9 @@
+Name:Spark Rupture
+ManaCost:2 W
+Types:Enchantment
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ When CARDNAME enters the battlefield, draw a card.
+SVar:TrigDraw:DB$ Draw
+S:Mode$ Continuous | Affected$ Planeswalker.counters_GE1_LOYALTY | AddType$ Creature | RemoveCardTypes$ True | RemoveAllAbilities$ True | SetPower$ AffectedX | SetToughness$ AffectedX | Description$ Each planeswalker with one or more loyalty counters on it loses all abilities and is a creature with power and toughness each equal to the number of loyalty counters on it.
+SVar:AffectedX:Count$CardCounters.LOYALTY
+SVar:NonStackingEffect:True
+Oracle:When Spark Rupture enters the battlefield, draw a card.\nEach planeswalker with one or more loyalty counters on it loses all abilities and is a creature with power and toughness each equal to the number of loyalty counters on it.


### PR DESCRIPTION
There was some discussion regarding this one in the Discord, but it seems to work fine without engine changes... making it its own PR in case it gets hairy with corner cases or something.

It seems to work properly on Planeswalkers that are already on the battlefield when it is cast, and on any other Planeswalkers that ETB afterward.

Planeswalkers also seem to revert properly after it is removed.