### PR TITLE
Fix failed trigger keeping the stack frozen

### DIFF
--- a/forge-game/src/main/java/forge/game/cost/CostExileFromStack.java
+++ b/forge-game/src/main/java/forge/game/cost/CostExileFromStack.java
@@ -87,7 +87,7 @@ public class CostExileFromStack extends CostPart {
             return true; // this will always work
         }
 
-        CardCollectionView list = payer.getCardsIn(ZoneType.Stack);
+        CardCollectionView list = source.getGame().getCardsIn(ZoneType.Stack);
 
         list = CardLists.getValidCards(list, type.split(";"), payer, source, ability);
 

--- a/forge-gui/src/main/java/forge/player/HumanPlaySpellAbility.java
+++ b/forge-gui/src/main/java/forge/player/HumanPlaySpellAbility.java
@@ -83,6 +83,7 @@ public class HumanPlaySpellAbility {
 
         boolean keywordColor = false;
         // freeze Stack. No abilities should go onto the stack while I'm filling requirements.
+        boolean refreeze = game.getStack().isFrozen();
         game.getStack().freezeStack();
 
         if (ability.isSpell() && !c.isCopiedSpell()) {
@@ -175,6 +176,9 @@ public class HumanPlaySpellAbility {
                 payment.refundPayment();
             } else {
                 GameActionUtil.rollbackAbility(ability, fromZone, zonePosition, payment, c);
+            }
+            if (!refreeze) {
+                game.getStack().unfreezeStack();
             }
 
             if (manaTypeConversion || manaColorConversion || keywordColor) {


### PR DESCRIPTION
So I think this bug (which only affects human) has been hiding and potentially causing confusion for quite a while because it's 1. a bit hard to notice and 2. also requires specific board states to occur which are usually not obvious either.

As you can see in the reported Screenshot Ward triggers way too late:
![grafik](https://user-images.githubusercontent.com/8506892/234798749-8f4244c0-5398-4125-92ab-6041022a384b.png)

This happens because the Spell cast by the AP also triggers a Magecraft ability which however fails targeting but leaves the stack frozen for the following (NAP) Ward trigger.