### PR TITLE
Fix exiling sometimes handled incomplete for combined permanents

### DIFF
--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -271,6 +271,10 @@ public class GameAction {
                 copied.setExiledBy(c.getExiledBy());
                 copied.setDrawnThisTurn(c.getDrawnThisTurn());
 
+                if (c.isTransformed()) {
+                    copied.incrementTransformedTimestamp();
+                }
+
                 if (cause != null && cause.isSpell() && c.equals(cause.getHostCard())) {
                     copied.setCastSA(cause);
                     copied.setSplitStateToPlayAbility(cause);

--- a/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
@@ -895,7 +895,16 @@ public abstract class SpellAbilityEffect {
         return activator.getController().chooseSingleEntityForEffect(options, sa, Localizer.getInstance().getMessage("lblChoosePlayer"), null);
     }
 
+    public static void handleExiledWith(final Iterable<Card> movedCards, final SpellAbility cause) {
+        for (Card c : movedCards) {
+            handleExiledWith(c, cause);
+        }
+    }
     public static void handleExiledWith(final Card movedCard, final SpellAbility cause) {
+        if (movedCard.isToken()) {
+            return;
+        }
+
         Card exilingSource = cause.getHostCard();
         // during replacement LKI might be used
         if (cause.isReplacementAbility() && exilingSource.isLKI()) {

--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneAllEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneAllEffect.java
@@ -161,6 +161,10 @@ public class ChangeZoneAllEffect extends SpellAbilityEffect {
                 }
             }
 
+            if (remLKI) {
+                source.addRemembered(CardUtil.getLKICopy(c));
+            }
+
             Map<AbilityKey, Object> moveParams = AbilityKey.newMap();
             moveParams.put(AbilityKey.LastStateBattlefield, lastStateBattlefield);
             moveParams.put(AbilityKey.LastStateGraveyard, lastStateGraveyard);
@@ -218,13 +222,6 @@ public class ChangeZoneAllEffect extends SpellAbilityEffect {
                                 source.addRemembered(card);
                             }
                         }
-                    }
-                }
-                if (remLKI) {
-                    final Card lki = CardUtil.getLKICopy(c);
-                    game.getCardState(source).addRemembered(lki);
-                    if (!source.isRemembered(lki)) {
-                        source.addRemembered(lki);
                     }
                 }
                 if (forget != null) {

--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneAllEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneAllEffect.java
@@ -186,7 +186,7 @@ public class ChangeZoneAllEffect extends SpellAbilityEffect {
                 movedCard = game.getAction().moveToPlay(c, sa.getActivatingPlayer(), sa, moveParams);
             } else {
                 movedCard = game.getAction().moveTo(destination, c, libraryPos, sa, moveParams);
-                if (destination == ZoneType.Exile && !c.isToken()) {
+                if (destination == ZoneType.Exile) {
                     handleExiledWith(movedCard, sa);
                 }
                 if (sa.hasParam("ExileFaceDown")) {

--- a/forge-game/src/main/java/forge/game/ability/effects/PlayEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PlayEffect.java
@@ -296,6 +296,7 @@ public class PlayEffect extends SpellAbilityEffect {
                     continue;
                 }
                 state = CardStateName.Transformed;
+                tgtCard.incrementTransformedTimestamp();
             }
 
             // TODO if cost isn't replaced should include alternative ones

--- a/forge-game/src/main/java/forge/game/trigger/TriggerHandler.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerHandler.java
@@ -457,8 +457,7 @@ public class TriggerHandler {
             Card original = (Card) runParams.get(AbilityKey.Card);
             CardCollection mergedCards = (CardCollection) runParams.get(AbilityKey.MergedCards);
             mergedCards.set(mergedCards.indexOf(original), original);
-            Map<AbilityKey, Object> newParams = AbilityKey.mapFromCard(original);
-            newParams.putAll(runParams);
+            Map<AbilityKey, Object> newParams = AbilityKey.newMap(runParams);
             if ("Battlefield".equals(regtrig.getParam("Origin"))) {
                 // If yes, only trigger once
                 newParams.put(AbilityKey.Card, mergedCards);

--- a/forge-gui/res/cardsfolder/a/abdel_adrian_gorions_ward.txt
+++ b/forge-gui/res/cardsfolder/a/abdel_adrian_gorions_ward.txt
@@ -3,7 +3,7 @@ ManaCost:4 W
 Types:Legendary Creature Human Warrior
 PT:4/4
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ When CARDNAME enters the battlefield, exile any number of other nonland permanents you control until NICKNAME leaves the battlefield. Create a 1/1 white Soldier creature token for each permanent exiled this way.
-SVar:TrigExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | Hidden$ True | ChangeType$ Permanent.Other+nonLand+YouCtrl | ChangeNum$ MaxTgts | RememberChanged$ True | SelectPrompt$ Choose any number of other nonland permanents you control | Duration$ UntilHostLeavesPlay | SubAbility$ DBToken
+SVar:TrigExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | Hidden$ True | ChangeType$ Permanent.Other+nonLand+YouCtrl | ChangeNum$ MaxTgts | RememberLKI$ True | SelectPrompt$ Choose any number of other nonland permanents you control | Duration$ UntilHostLeavesPlay | SubAbility$ DBToken
 SVar:DBToken:DB$ Token | TokenAmount$ X | TokenScript$ w_1_1_soldier | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Remembered$Amount

--- a/forge-gui/res/cardsfolder/d/darigaaz_reincarnated.txt
+++ b/forge-gui/res/cardsfolder/d/darigaaz_reincarnated.txt
@@ -7,7 +7,7 @@ K:Trample
 K:Haste
 R:Event$ Moved | ActiveZones$ Battlefield | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | ReplaceWith$ Exile | Description$ If CARDNAME would die, instead exile it with three egg counters on it.
 SVar:Exile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | Defined$ ReplacedCard | WithCountersType$ EGG | WithCountersAmount$ 3
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Exile | IsPresent$ Card.Self+counters_GE1_EGG | PresentZone$ Exile | Execute$ DBRemoveCounter | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is exiled with an egg counter on it, remove an egg counter from it. Then if CARDNAME has no egg counters on it, return it to the battlefield.
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Exile | IsPresent$ Card.Self+counters_GE1_EGG | PresentZone$ Exile | Execute$ DBRemoveCounter | TriggerDescription$ At the beginning of your upkeep, if NICKAME is exiled with an egg counter on it, remove an egg counter from it. Then if NICKNAME has no egg counters on it, return it to the battlefield.
 SVar:DBRemoveCounter:DB$ RemoveCounter | Defined$ Self | CounterType$ EGG | CounterNum$ 1 | SubAbility$ DBReturn
 SVar:DBReturn:DB$ ChangeZone | Defined$ Self | Origin$ Exile | Destination$ Battlefield | ConditionDefined$ Self | ConditionPresent$ Card.counters_EQ0_EGG
 Oracle:Flying, trample, haste\nIf Darigaaz Reincarnated would die, instead exile it with three egg counters on it.\nAt the beginning of your upkeep, if Darigaaz is exiled with an egg counter on it, remove an egg counter from it. Then if Darigaaz has no egg counters on it, return it to the battlefield.


### PR DESCRIPTION
This fixes some exiling of combined permanents interactions:
- ExiledWith, e.g. _Helvault_ not returning all components
- WithCountersType, e.g. Etrata only putting HIT counters on the first

Closes #3070