### PR TITLE
Add several puzzles (ONE, MOM)

### DIFF
--- a/forge-ai/src/main/java/forge/ai/GameState.java
+++ b/forge-ai/src/main/java/forge/ai/GameState.java
@@ -303,6 +303,10 @@ public abstract class GameState {
                 newText.append("|Flipped");
             } else if (c.getCurrentStateName().equals(CardStateName.Meld)) {
                 newText.append("|Meld");
+                if (c.getMeldedWith() != null) {
+                    newText.append("|MeldedWith:");
+                    newText.append(c.getMeldedWith().getName());
+                }
             } else if (c.getCurrentStateName().equals(CardStateName.Modal)) {
                 newText.append("|Modal");
             }
@@ -1245,6 +1249,16 @@ public abstract class GameState {
                     c.setBackSide(true);
                 } else if (info.startsWith("Flipped")) {
                     c.setState(CardStateName.Flipped, true);
+                } else if (info.startsWith("MeldedWith")) {
+                    String meldCardName = info.substring(info.indexOf(':') + 1).replace("^", ",");
+                    Card meldTarget;
+                    PaperCard pc = StaticData.instance().getCommonCards().getCard(meldCardName);
+                    if (pc == null) {
+                        System.err.println("ERROR: Tried to create a non-existent card named " + meldCardName + " (as a MeldedWith card) when loading game state!");
+                        continue;
+                    }
+                    meldTarget = Card.fromPaperCard(pc, c.getOwner());
+                    c.setMeldedWith(meldTarget);
                 } else if (info.startsWith("Meld")) {
                     c.setState(CardStateName.Meld, true);
                     c.setBackSide(true);

--- a/forge-game/src/main/java/forge/game/GameActionUtil.java
+++ b/forge-game/src/main/java/forge/game/GameActionUtil.java
@@ -868,6 +868,9 @@ public final class GameActionUtil {
         final Game game = ability.getActivatingPlayer().getGame();
 
         if (fromZone != null) { // and not a copy
+            // might have been an alternative lki host
+            oldCard = ability.getCardState().getCard();
+ 
             oldCard.setCastSA(null);
             oldCard.setCastFrom(null);
             // add back to where it came from, hopefully old state

--- a/forge-game/src/main/java/forge/game/ability/effects/PlayEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PlayEffect.java
@@ -296,7 +296,6 @@ public class PlayEffect extends SpellAbilityEffect {
                     continue;
                 }
                 state = CardStateName.Transformed;
-                tgtCard.incrementTransformedTimestamp();
             }
 
             // TODO if cost isn't replaced should include alternative ones
@@ -418,6 +417,10 @@ public class PlayEffect extends SpellAbilityEffect {
 
             if (sa.hasParam("Madness")) {
                 tgtSA.setAlternativeCost(AlternativeCost.Madness);
+            }
+
+            if (sa.hasParam("CastTransformed")) {
+                tgtSA.putParam("CastTransformed", "True");
             }
 
             if (tgtSA.usesTargeting() && !optional) {

--- a/forge-game/src/main/java/forge/game/card/CardView.java
+++ b/forge-game/src/main/java/forge/game/card/CardView.java
@@ -1452,7 +1452,7 @@ public class CardView extends GameEntityView {
         public boolean hasLandwalk() {
             return get(TrackableProperty.HasLandwalk);
         }
-        public boolean hasHasAftermath() {
+        public boolean hasAftermath() {
             return get(TrackableProperty.HasAftermath);
         }
 

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -3183,7 +3183,7 @@ public class Player extends GameEntity implements Comparable<Player> {
             {
                 final String drawTrig = "Mode$ Phase | Phase$ End of Turn | TriggerZones$ Command | " +
                 "ValidPlayer$ You |  TriggerDescription$ At the beginning of your end step, draw a card.";
-                final String drawEff = "AB$ Draw | Cost$ 0 | Defined$ You";
+                final String drawEff = "DB$ Draw | Defined$ You";
 
                 final Trigger drawTrigger = TriggerHandler.parseTrigger(drawTrig, monarchEffect, true);
 
@@ -3194,7 +3194,7 @@ public class Player extends GameEntity implements Comparable<Player> {
             {
                 final String damageTrig = "Mode$ DamageDone | ValidSource$ Creature | ValidTarget$ You | CombatDamage$ True | TriggerZones$ Command |" +
                 " TriggerDescription$ Whenever a creature deals combat damage to you, its controller becomes the monarch.";
-                final String damageEff = "AB$ BecomeMonarch | Cost$ 0 | Defined$ TriggeredSourceController";
+                final String damageEff = "DB$ BecomeMonarch | Defined$ TriggeredSourceController";
 
                 final Trigger damageTrigger = TriggerHandler.parseTrigger(damageTrig, monarchEffect, true);
 

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbilityRestriction.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbilityRestriction.java
@@ -369,7 +369,7 @@ public class SpellAbilityRestriction extends SpellAbilityVariables {
         }
 
         // Explicit Aftermath check there
-        if (sa.isAftermath() && !c.isInZone(ZoneType.Graveyard)) {
+        if ((sa.isAftermath() || sa.isDisturb()) && !c.isInZone(ZoneType.Graveyard)) {
             return false;
         }
 

--- a/forge-gui-mobile/src/forge/card/CardImageRenderer.java
+++ b/forge-gui-mobile/src/forge/card/CardImageRenderer.java
@@ -416,7 +416,7 @@ public class CardImageRenderer {
         if (alt == null)
             alt = card.getAlternateState().getCard();
         CardView cv = altState && isFaceDown ? alt : card;
-        boolean isAftermath = altState ? cv.getAlternateState().hasHasAftermath() : cv.getRightSplitState().hasHasAftermath();
+        boolean isAftermath = altState ? cv.getAlternateState().hasAftermath() : cv.getRightSplitState().hasAftermath();
         if (!isAftermath) {
             CardEdition ed = FModel.getMagicDb().getEditions().get(cv.getCurrentState().getSetCode());
             boolean isOldFrame = ed != null && !ed.isModern();

--- a/forge-gui/res/cardsfolder/a/aethersquall_ancient.txt
+++ b/forge-gui/res/cardsfolder/a/aethersquall_ancient.txt
@@ -5,5 +5,5 @@ PT:6/6
 K:Flying
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigEnergy | TriggerDescription$ At the beginning of your upkeep, you get {E}{E}{E} (three energy counters).
 SVar:TrigEnergy:DB$ PutCounter | Defined$ You | CounterType$ ENERGY | CounterNum$ 3
-A:AB$ ChangeZoneAll | Cost$ PayEnergy<8> | ChangeType$ Creature.Other | SorcerySpeed$ True | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return all other creatures to their owners' hands. Activate only as a sorcery.
+A:AB$ ChangeZoneAll | Cost$ PayEnergy<8> | ChangeType$ Creature.StrictlyOther | SorcerySpeed$ True | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return all other creatures to their owners' hands. Activate only as a sorcery.
 Oracle:Flying\nAt the beginning of your upkeep, you get {E}{E}{E} (three energy counters).\nPay {E}{E}{E}{E}{E}{E}{E}{E}: Return all other creatures to their owners' hands. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/f/first_responder.txt
+++ b/forge-gui/res/cardsfolder/f/first_responder.txt
@@ -4,7 +4,7 @@ Types:Creature Ogre Citizen
 PT:3/3
 K:Vigilance
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigReturn | TriggerDescription$ At the beginning of your end step, you may return another creature you control to its owner's hand, then put a number of +1/+1 counters equal to that creature's power on CARDNAME.
-SVar:TrigReturn:DB$ ChangeZone | Origin$ Battlefield | Destination$ Hand | Hidden$ True | ChangeType$ Creature.Other+YouCtrl | RememberLKI$ True | SubAbility$ DBPutCounter
+SVar:TrigReturn:DB$ ChangeZone | Origin$ Battlefield | Destination$ Hand | Hidden$ True | ChangeType$ Creature.StrictlyOther+YouCtrl | RememberLKI$ True | SubAbility$ DBPutCounter
 SVar:DBPutCounter:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:RememberedLKI$CardPower

--- a/forge-gui/res/cardsfolder/k/kethek_crucible_goliath.txt
+++ b/forge-gui/res/cardsfolder/k/kethek_crucible_goliath.txt
@@ -3,7 +3,7 @@ ManaCost:2 R B
 Types:Legendary Creature Phyrexian Beast
 PT:4/4
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | Execute$ TrigSac | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your end step, you may sacrifice another creature. If you do, reveal cards from the top of your library until you reveal a nonlegendary creature card with lesser mana value, put it onto the battlefield, then put the rest on the bottom of your library in a random order.
-SVar:TrigSac:AB$ DigUntil | Cost$ Sac<1/Creature.Other/another creature> | Defined$ You | Valid$ Card.Creature+nonLegendary+cmcLTX | FoundDestination$ Battlefield | RevealedDestination$ Library | RevealRandomOrder$ True
+SVar:TrigSac:AB$ DigUntil | Cost$ Sac<1/Creature.StrictlyOther/another creature> | Defined$ You | Valid$ Card.Creature+nonLegendary+cmcLTX | FoundDestination$ Battlefield | RevealedDestination$ Library | RevealRandomOrder$ True
 SVar:X:Sacrificed$CardManaCost
 DeckHas:Ability$Sacrifice
 Oracle:At the beginning of your end step, you may sacrifice another creature. If you do, reveal cards from the top of your library until you reveal a nonlegendary creature card with lesser mana value, put it onto the battlefield, then put the rest on the bottom of your library in a random order.

--- a/forge-gui/res/cardsfolder/l/loyal_unicorn.txt
+++ b/forge-gui/res/cardsfolder/l/loyal_unicorn.txt
@@ -4,9 +4,9 @@ Types:Creature Unicorn
 PT:3/4
 K:Vigilance
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | IsPresent$ Card.IsCommander+YouOwn+YouCtrl | TriggerZones$ Battlefield | Execute$ PreventEffect | TriggerDescription$ Lieutenant — At the beginning of combat on your turn, if you control your commander, prevent all combat damage that would be dealt to creatures you control this turn.
-SVar:PreventEffect:DB$ Effect | ReplacementEffects$ RPrevent | ValidTgts$ You | Description$ Prevent all combat damage that would be dealt to creatures you control this turn.
+SVar:PreventEffect:DB$ Effect | ReplacementEffects$ RPrevent | ValidTgts$ You | SubAbility$ DBPumpAll
 SVar:RPrevent:Event$ DamageDone | Prevent$ True | IsCombat$ True | ActiveZones$ Command | ValidTarget$ Creature.YouCtrl | Description$ Prevent all combat damage that would be dealt to creatures you control this turn.
-S:Mode$ Continuous | Affected$ Creature.Other+YouCtrl | AddKeyword$ Vigilance | Description$ Other creatures you control gain vigilance until end of turn.
+SVar:DBPumpAll:DB$ PumpAll | ValidCards$ Creature.StrictlyOther+YouCtrl | KW$ Vigilance
 SVar:BuffedBy:Card.IsCommander
 AI:RemoveDeck:Random
 Oracle:Vigilance\nLieutenant — At the beginning of combat on your turn, if you control your commander, prevent all combat damage that would be dealt to creatures you control this turn. Other creatures you control gain vigilance until end of turn.

--- a/forge-gui/res/cardsfolder/z/ziatora_the_incinerator.txt
+++ b/forge-gui/res/cardsfolder/z/ziatora_the_incinerator.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature Demon Dragon
 PT:6/6
 K:Flying
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | Execute$ DBTrigger | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your end step, you may sacrifice another creature. When you do, CARDNAME deals damage equal to that creature's power to any target and you create three Treasure tokens.
-SVar:DBTrigger:AB$ ImmediateTrigger | Cost$ Sac<1/Creature.Other/another creature> | Execute$ DBDealDmg | AILogic$ SacForDamage | RememberObjects$ Sacrificed | TriggerDescription$ When you do, CARDNAME deals damage equal to that creature's power to any target and you create three Treasure tokens.
+SVar:DBTrigger:AB$ ImmediateTrigger | Cost$ Sac<1/Creature.StrictlyOther/another creature> | Execute$ DBDealDmg | AILogic$ SacForDamage | RememberObjects$ Sacrificed | TriggerDescription$ When you do, CARDNAME deals damage equal to that creature's power to any target and you create three Treasure tokens.
 SVar:DBDealDmg:DB$ DealDamage | ValidTgts$ Any | TgtPrompt$ Select any target to deal the damage to | NumDmg$ XPower | SubAbility$ DBToken
 SVar:DBToken:DB$ Token | TokenAmount$ 3 | TokenScript$ c_a_treasure_sac
 SVar:XPower:TriggerRemembered$CardPower

--- a/forge-gui/res/puzzle/PS_MOM1.pzl
+++ b/forge-gui/res/puzzle/PS_MOM1.pzl
@@ -1,0 +1,21 @@
+[metadata]
+Name:Possibility Storm - March of the Machines #01
+URL:https://twitter.com/mtgpuzzles/status/1648895487607554054/photo/1
+Goal:Win
+Turns:1
+Difficulty:Uncommon
+Description:Win this turn. Assume that any cards you could access from your library are irrelevant to the solution. Remember that your solution must satisfy all opponent decisions (including both blocking and activated abilities.)
+[state]
+turn=1
+activeplayer=p0
+activephase=MAIN1
+p0life=20
+p0landsplayed=0
+p0landsplayedlastturn=0
+p0hand=Annihilating Glare;Boon-Bringer Valkyrie;Night Clubber
+p0library=Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt
+p0battlefield=Drana and Linvala;Knight of Dusk's Shadow;Swamp;Swamp;Swamp;Shattered Sanctum;Shattered Sanctum
+p1life=10
+p1landsplayed=0
+p1landsplayedlastturn=0
+p1battlefield=Cutthroat Centurion;Cutthroat Centurion;Mandible Justiciar

--- a/forge-gui/res/puzzle/PS_MOM2.pzl
+++ b/forge-gui/res/puzzle/PS_MOM2.pzl
@@ -1,0 +1,20 @@
+[metadata]
+Name:Possibility Storm - March of the Machines #02
+URL:https://i2.wp.com/www.possibilitystorm.com/wp-content/uploads/2023/04/latest-1-scaled.jpg?ssl=1
+Goal:Win
+Turns:1
+Difficulty:Rare
+Description:Win this turn. Battles are a new card type that you cast, and is then defended by your opponent. You can attack it and deal it damage like planeswalkers. When defeated, its owner casts it transformed. Remember that your solution must satisfy all possible blocking decisions.
+[state]
+turn=1
+activeplayer=p0
+activephase=MAIN1
+p0life=20
+p0landsplayed=0
+p0landsplayedlastturn=0
+p0hand=Rampaging Raptor;Mountain;Into the Fire;Volcanic Spite
+p0battlefield=Invasion of Karsus|Counters:DEFENSE=2;Invasion of Kaldheim|Counters:DEFENSE=2;Dwarven Forge-Chanter;Mountain;Mountain;Mountain;Mountain
+p1life=8
+p1landsplayed=0
+p1landsplayedlastturn=0
+p1battlefield=Invasion of Xerex|Counters:DEFENSE=2;Swordsworn Cavalier;Swordsworn Cavalier

--- a/forge-gui/res/puzzle/PS_ONE3.pzl
+++ b/forge-gui/res/puzzle/PS_ONE3.pzl
@@ -1,0 +1,20 @@
+[metadata]
+Name:Possibility Storm - Phyrexia: All Will Be One #03
+URL:https://i1.wp.com/www.possibilitystorm.com/wp-content/uploads/2023/02/latest-1-scaled.jpg?ssl=1
+Goal:Win Before Opponent's Next Turn
+Turns:9999
+Difficulty:Mythic
+Description:Start in your first main phase and win before your opponent's next turn. Your opponent has no board, and you have no land! You have 20 cards remaining in your library. Assume any of them that you could draw are not relevant to the solution.
+[state]
+turn=1
+activeplayer=p0
+activephase=MAIN1
+p0life=20
+p0landsplayed=0
+p0landsplayedlastturn=0
+p0hand=Cement Shoes;Prophetic Prism
+p0battlefield=Kaito, Dancing Shadow|Counters:LOYALTY=3;Tezzeret, Betrayer of Flesh|Counters:LOYALTY=2;Urza, Planeswalker|Meld|MeldedWith:The Mightstone and Weakstone|Counters:LOYALTY=7;Levitating Statue;Ichormoon Gauntlet
+p0library=Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt
+p1life=21
+p1landsplayed=0
+p1landsplayedlastturn=0

--- a/forge-gui/res/puzzle/PS_ONE4.pzl
+++ b/forge-gui/res/puzzle/PS_ONE4.pzl
@@ -1,0 +1,22 @@
+[metadata]
+Name:Possibility Storm - Phyrexia: All Will Be One #04
+URL:https://i1.wp.com/www.possibilitystorm.com/wp-content/uploads/2023/03/latest-scaled.jpg?ssl=1
+Goal:Win
+Turns:1
+Difficulty:Uncommon
+Description:Win this turn. Assume that any cards you could draw are irrelevant to the solution.
+[state]
+turn=1
+activeplayer=p0
+activephase=MAIN1
+p0life=5
+p0landsplayed=0
+p0landsplayedlastturn=0
+p0hand=Volt Charge;Furnace Skullbomb;Experimental Augury;Blazing Crescendo
+p0library=Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt
+p0battlefield=Tekuthal, Inquiry Dominus;Ichor Synthesizer;Serum-Core Chimera|Counters:OIL=2;Cacophony Scamp;Urabrask's Forge|Counters:OIL=2;Island;Island;Mountain;Mountain;Mountain
+p1life=16
+p1landsplayed=0
+p1landsplayedlastturn=0
+p1battlefield=Phyrexian Vindicator;Porcelain Zealot;Porcelain Zealot;Porcelain Zealot
+p1counters=POISON=4

--- a/forge-gui/res/puzzle/PS_ONE5.pzl
+++ b/forge-gui/res/puzzle/PS_ONE5.pzl
@@ -1,0 +1,21 @@
+[metadata]
+Name:Possibility Storm - Phyrexia: All Will Be One #05
+URL:https://i0.wp.com/www.possibilitystorm.com/wp-content/uploads/2023/03/latest-1-scaled.jpg?ssl=1
+Goal:Win
+Turns:1
+Difficulty:Uncommon
+Description:Win this turn. Assume that any cards that you could access from your library are irrelevant to the solution. Remember that your solution must satisfy all opponent decisions (including both blocking and activated abilities.)
+[state]
+turn=1
+activeplayer=p0
+activephase=MAIN1
+p0life=20
+p0landsplayed=0
+p0landsplayedlastturn=0
+p0hand=Annihilating Glare;Drown in Ichor;Charforger
+p0library=Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt
+p0battlefield=Churning Reservoir;Cutthroat Centurion;Cutthroat Centurion;Furnace Strider|Counters:OIL=1;Swamp;Swamp;Mountain;Mountain;Mountain
+p1life=8
+p1landsplayed=0
+p1landsplayedlastturn=0
+p1battlefield=Drana and Linvala;Benalish Sleeper;Necrosquito|Counters:OIL=3

--- a/forge-gui/src/main/java/forge/gamemodes/puzzle/Puzzle.java
+++ b/forge-gui/src/main/java/forge/gamemodes/puzzle/Puzzle.java
@@ -196,6 +196,11 @@ public class Puzzle extends GameState implements InventoryItem, Comparable<Puzzl
                 String countOTB = "Count$Valid " + targets;
                 clearSA.setSVar("PermCount", countOTB);
                 break;
+            case "win before opponent's next turn":
+                trig = "Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Opponent | TriggerZones$ Command | Static$ True | " +
+                        " | TriggerDescription$ At the beginning of your opponent's next turn, you lose the game.";
+                eff = "DB$ LosesGame | Defined$ You";
+                break;
             default:
                 break;
         }

--- a/forge-gui/src/main/java/forge/player/HumanPlay.java
+++ b/forge-gui/src/main/java/forge/player/HumanPlay.java
@@ -109,7 +109,7 @@ public class HumanPlay {
 
         final HumanPlaySpellAbility req = new HumanPlaySpellAbility(controller, sa);
         if (!req.playAbility(true, false, false)) {
-            Card rollback = p.getGame().getCardState(sa.getHostCard());
+            Card rollback = p.getGame().getCardState(source);
             if (castFaceDown) {
                 rollback.setFaceDown(false);
             } else if (flippedToCast) {


### PR DESCRIPTION
- Added puzzles PS_ONE3-5, PS_MOM1-2.
- Added support for the puzzle goal "Win before your opponent's next turn" (needed for PS_ONE3).
- Added support for MeldedWith in the game state (needed for PS_ONE3).
