### PR TITLE
Update CardFactory CloneStates: fix SetPower and setToughness

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/CopyPermanentEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CopyPermanentEffect.java
@@ -264,19 +264,17 @@ public class CopyPermanentEffect extends TokenEffectBase {
     public static Card getProtoType(final SpellAbility sa, final Card original, final Player newOwner) {
         final Card host = sa.getHostCard();
         int id = newOwner == null ? 0 : newOwner.getGame().nextCardId();
-        final Card copy = new Card(id, original.getPaperCard(), host.getGame());
-        copy.setOwner(newOwner);
-        copy.setSetCode(original.getSetCode());
+        // need to create a physical card first, i need the original card faces
+        final Card copy = CardFactory.getCard(original.getPaperCard(), newOwner, id, host.getGame());
 
         copy.setTokenSpawningAbility(sa);
-        // 707.8a If an effect creates a token that is a copy of a transforming permanent or a transforming double-faced card not on the battlefield,
-        // the resulting token is a transforming token that has both a front face and a back face.
-        // The characteristics of each face are determined by the copiable values of the same face of the permanent it is a copy of, as modified by any other copy effects that apply to that permanent.
-        // If the token is a copy of a transforming permanent with its back face up, the token enters the battlefield with its back face up.
-        // This rule does not apply to tokens that are created with their own set of characteristics and enter the battlefield as a copy of a transforming permanent due to a replacement effect.
         if (original.isTransformable()) {
+            // 707.8a If an effect creates a token that is a copy of a transforming permanent or a transforming double-faced card not on the battlefield,
+            // the resulting token is a transforming token that has both a front face and a back face.
+            // The characteristics of each face are determined by the copiable values of the same face of the permanent it is a copy of, as modified by any other copy effects that apply to that permanent.
+            // If the token is a copy of a transforming permanent with its back face up, the token enters the battlefield with its back face up.
+            // This rule does not apply to tokens that are created with their own set of characteristics and enter the battlefield as a copy of a transforming permanent due to a replacement effect.
             copy.setBackSide(original.isBackSide());
-            copy.setRules(original.getRules());
             if (original.isTransformed()) {
                 copy.incrementTransformedTimestamp();
             }

--- a/forge-game/src/main/java/forge/game/card/CardFactory.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactory.java
@@ -809,7 +809,8 @@ public class CardFactory {
 
             // CR 208.3 A noncreature object not on the battlefield has power or toughness only if it has a power and toughness printed on it.
             // currently only LKI can be trusted?
-            if (state.getType().isCreature() || in.getOriginalState(originalState.getStateName()).getBasePowerString() != null) {
+            if ((sa.hasParam("SetPower") || sa.hasParam("SetToughness")) &&
+                (state.getType().isCreature() || (originalState != null && in.getOriginalState(originalState.getStateName()).getBasePowerString() != null))) {
                 if (sa.hasParam("SetPower")) {
                     state.setBasePower(AbilityUtils.calculateAmount(host, sa.getParam("SetPower"), sa));
                 }


### PR DESCRIPTION
fix around SetPower and setToughness

@tool4ever this should fix the possible NPE, or do you still want to debug why originalState might be null?