### PR TITLE
Draft: Battle AI support [highly sketchy]

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiAttackController.java
+++ b/forge-ai/src/main/java/forge/ai/AiAttackController.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-import forge.card.CardType;
 import forge.game.staticability.StaticAbility;
 import forge.game.staticability.StaticAbilityAssignCombatDamageAsUnblocked;
 import org.apache.commons.lang3.tuple.Pair;

--- a/forge-ai/src/main/java/forge/ai/ability/PlayAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PlayAi.java
@@ -185,6 +185,12 @@ public class PlayAi extends SpellAbilityAi {
                         return true;
                     }
                 }
+                // FIXME: This is an ugly hack, ideally the TODO above needs to be resolved regarding MDFC so the AI knows it's casting the other face of the card
+                // (useful not only for battles, but for other DFC stuff as well)
+                if (sa.hasParam("CastTransformed") && sa.hasParam("WithoutManaCost") && c.isBattle()) {
+                    return true; // TODO: This needs to actually test playability of the transformed side (especially if it's a Sorcery, but permanents may need a test as well)
+                                 // However, I don't see a way to grab the spell/SA-like object from the transformed side so that canPlayFromEffectAI can evaluate it.
+                }
                 return false;
             }
         });


### PR DESCRIPTION
Warning: Here be dragons. Or, rather, highly sketchy, ugly test code that sort of, kind of works in certain scenarios and is meant more as a demonstration of what's necessary to do to support Battle AI than serve as the definitive implementation.

This is the first attempt at a very basic sketchy draft of what could become the foundation of the future AI support for Battles.

What it currently does:
- It modifies the AI attack controller in a way that allows it to overcome the limitations of the current implementation and determine the Battles that can be attacked and scenarios in which it's possible to attack them. For the most part, this works, but it's very basic and there is no randomness or chance variation at which this will happen. Thus, the AI *will* attack its own Battles given the opportunity (within the current constraints).
- It modifies the choice of the defending opponent when a Battle is the defender card so that the AI chooses the opposing player (e.g. the defender of the said Battle) if the "defender" is set to a Battle. Before this was done, the AI attacked itself with the remaining creatures that it didn't want to assign to attack a Battle (rather than attacking the opponent).
- It adds an [ugly and hacky] way for the AI to play the flip side of the Battle once it loses all its counters. Note that this is done as a workaround for now - the proper way to do it would be to modify the code in PlayAi and probably elsewhere, too, to properly determine that the flip side of a DFC card is being queried about. I tried a few things but couldn't determine a way to do it - neither method that returns spells or SAs seems to work for getState(CardStateName.Transformed). Help needed here in the form of code contributions.

What it currently DOESN'T do:
- It doesn't yet allow the AI to defend Battles. In fact, there seems to be no way at all to defend a Battle at the moment, even for a human player (see below), so this will most likely need a mechanics update too.
- It doesn't yet introduce any form of advanced parametrization, heuristics, or profile options for attacking/defending Battles, so the AI support is rudimentary and highly predictable.
- It doesn't introduce the cleanest AI support possible. Most certainly this can be done in a multitude of better ways, the point of this PR for now is to highlight the possibilities and the potential issues so that better code can be written and contributed.

What problems it highlights in the Battle implementation as a whole:
- At the very least, it seems like blocking mechanics isn't updated to account for Battles in any way. During the Declare Blockers step, the declareBlockers call isn't made for the player who is the defender of the Battle, which makes it impossible for both the human and the AI to actually defend a Battle.
- The AI may need better hooks in the attack/block controllers for cleaner support code (e.g. better integrated with the code that defines creature lists and chooses defenders and defending opponents), but this can be done later once the basic support and all the mechanics are figured out.

Please note that I would welcome any and all help in the form of code contributions. Feel free to improve this PR and submit code improvements to it. Unfortunately, I don't have enough spare time at the moment in order to complete this project on my own, and I don't have the necessary knowledge to improve the game mechanics to support e.g. defending Battles. Thanks a lot in advance for help!