### PR TITLE
Adventure - fix ActionData deserialization

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/data/DialogData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/DialogData.java
@@ -44,6 +44,7 @@ public class DialogData implements Serializable {
     public String voiceFile;
 
     static public class ActionData implements Serializable {
+        public static final long serialVersionUID = 2848523275822677205L;
         static public class QuestFlag implements Serializable{
             public String key;
             public int val;


### PR DESCRIPTION
Fix for adventure save file deserialization error caused by adding a new field to ActionData.
(I've learned my lesson and this will not happen again.)