### PR TITLE
Tweak the initial spawn text in Adventure Mode

### DIFF
--- a/forge-gui/res/adventure/Shandalar/maps/map/main_story/spawn.tmx
+++ b/forge-gui/res/adventure/Shandalar/maps/map/main_story/spawn.tmx
@@ -41,31 +41,31 @@
   <object id="69" template="../../obj/enemy.tx" gid="2147495067" x="238" y="208">
    <properties>
     <property name="dialog">[{
-  &quot;text&quot;:&quot;HELLO PLANESWALKER {var=player_name}&quot;, 
+  &quot;text&quot;:&quot;Hello, planeswalker {var=player_name}&quot;,
   &quot;options&quot;:[
     {
 	  &quot;name&quot;:&quot;Why am I here&quot;,      
 	  &quot;condition&quot;:[ { &quot;checkMapFlag&quot;: &quot;intro&quot; ,&quot;not&quot;:true} ],    
-	  &quot;text&quot;:&quot;THIS... IS SHANDALAR A PLANE WHERE MANA IS SO PREVALENT AND USED BY ALL THAT IS SENTIENT EVEN THE COMMON PEOPLE USE SPELLS DAILY&quot;,
+	  &quot;text&quot;:&quot;This... is Shandalar. A plane where mana is so prevalent and used by all that is sentient. Even the common people use spells daily.&quot;,
 	  &quot;voiceFile&quot;:&quot;audio/WizPAR1.mp3&quot;,
 	  &quot;options&quot;:[
 		{      
-		  &quot;name&quot;:&quot;continue&quot;,      
-		  &quot;text&quot;:&quot;LIKE YOU,SOME PLANESWALKERS HAVE BEEN IMPRISONED HEREBY THE GUARDIANS IN THE CASTLES YOU MUST DEFEAT THEM IN BATTLE TO RELEASE US FROM THIS PLANE USE YOUR POWERS OF MAGIC TO CHALLENGE THEM&quot;,
+		  &quot;name&quot;:&quot;Continue&quot;,
+		  &quot;text&quot;:&quot;Like you, some planeswalkers have been imprisoned here by the guardians in the castles. You must defeat them in battle to release us from this plane. Use your powers of magic to challenge them.&quot;,
 		  &quot;voiceFile&quot;:&quot;audio/WizPAR2.mp3&quot;
 		  &quot;options&quot;:[
 			{
-			  &quot;name&quot;:&quot;continue&quot;, 
-				&quot;text&quot;:&quot;FIND THE PLANESWALKERS TRAPPED HERE  GUIDE THEM TO ME, THEY WILL HELP YOU ON YOUR JOURNEY.&quot;,
+			  &quot;name&quot;:&quot;Continue&quot;,
+				&quot;text&quot;:&quot;Find the planeswalkers trapped here. Guide them to me, they will help you on your journey.&quot;,
 				&quot;voiceFile&quot;:&quot;audio/WizPAR3.mp3&quot;,
 				&quot;options&quot;:[
 				{
-					&quot;name&quot;:&quot;continue&quot;, 
-					&quot;text&quot;:&quot;TAKE THIS RUNE YOU CAN USE IT ANYTIME TO RETURN HERE BE CAREFUL PLANESWALKER&quot;,
+					&quot;name&quot;:&quot;Continue&quot;,
+					&quot;text&quot;:&quot;Take this rune. You can use it anytime to return here. Be careful, planeswalker.&quot;,
 					&quot;voiceFile&quot;:&quot;audio/WizPAR4.mp3&quot;
 					&quot;options&quot;:[
 					{
-						&quot;name&quot;:&quot;thank you&quot;,
+						&quot;name&quot;:&quot;Thank you&quot;,
 						&quot;action&quot;:[{&quot;advanceMapFlag&quot;:&quot;intro&quot;},{&quot;addItem&quot;:&quot;Colorless rune&quot;}]
 					}]
 				}]


### PR DESCRIPTION
This has been bothering me for a while, though no one really got back to me on Discord as to whether this was done intentionally or not. At any rate, I believe it looks much better if it's done without all-caps and with proper punctuation. Some mistypes are fixed, too.