### PR TITLE
Update ghostfire.txt

### DIFF
--- a/forge-gui/res/cardsfolder/g/ghostfire.txt
+++ b/forge-gui/res/cardsfolder/g/ghostfire.txt
@@ -2,5 +2,5 @@ Name:Ghostfire
 ManaCost:2 R
 Types:Instant
 A:SP$ DealDamage | Cost$ 2 R | ValidTgts$ Any | NumDmg$ 3 | SpellDescription$ CARDNAME deals 3 damage to any target.
-Colors:colorless
+S:Mode$ Continuous | EffectZone$ All | Affected$ Card.Self | CharacteristicDefining$ True | SetColor$ Colorless | Description$ CARDNAME is colorless.
 Oracle:Ghostfire is colorless.\nGhostfire deals 3 damage to any target.


### PR DESCRIPTION
Fixes a bug where Ghostfire is considered to have colorless *identity* in addition to being colorless itself, and thus is allowed to appear in Commander, Oathbreaker, etc decks that shouldn't be allowed to have it due to lacking red in their color identity.