### PR TITLE
CardFactory: copySpellHost uses getCloneStates

### DIFF
--- a/forge-gui/res/cardsfolder/d/donal_herald_of_wings.txt
+++ b/forge-gui/res/cardsfolder/d/donal_herald_of_wings.txt
@@ -3,7 +3,7 @@ ManaCost:2 U U
 Types:Legendary Creature Human Wizard
 PT:3/3
 T:Mode$ SpellCast | TriggerZones$ Battlefield | ValidCard$ Creature.withFlying+nonLegendary | ValidActivatingPlayer$ You | ResolvedLimit$ 1 | Execute$ TrigCopy | OptionalDecider$ You | TriggerDescription$ Whenever you cast a nonlegendary creature spell with flying, you may copy it, except the copy is a 1/1 Spirit in addition to its other types. Do this only once each turn. (The copy becomes a token.)
-SVar:TrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | CopySetPower$ 1 | CopySetToughness$ 1 | CopyAddTypes$ Spirit
+SVar:TrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | SetPower$ 1 | SetToughness$ 1 | AddTypes$ Spirit
 DeckHas:Ability$Token
 DeckHints:Keyword$Flying
 SVar:BuffedBy:Creature.withFlying

--- a/forge-gui/res/cardsfolder/f/fork.txt
+++ b/forge-gui/res/cardsfolder/f/fork.txt
@@ -1,5 +1,5 @@
 Name:Fork
 ManaCost:R R
 Types:Instant
-A:SP$ CopySpellAbility | Cost$ R R | ValidTgts$ Instant,Sorcery | TargetType$ Spell | CopyIsColor$ Red | OverwriteColors$ True | MayChooseTarget$ True | SpellDescription$ Copy target instant or sorcery spell, except that the copy is red. You may choose new targets for the copy.
+A:SP$ CopySpellAbility | Cost$ R R | ValidTgts$ Instant,Sorcery | TargetType$ Spell | SetColor$ Red | MayChooseTarget$ True | SpellDescription$ Copy target instant or sorcery spell, except that the copy is red. You may choose new targets for the copy.
 Oracle:Copy target instant or sorcery spell, except that the copy is red. You may choose new targets for the copy.

--- a/forge-gui/res/cardsfolder/o/ob_nixilis_the_adversary.txt
+++ b/forge-gui/res/cardsfolder/o/ob_nixilis_the_adversary.txt
@@ -2,7 +2,7 @@ Name:Ob Nixilis, the Adversary
 ManaCost:1 B R
 Types:Legendary Planeswalker Nixilis
 Loyalty:3
-K:Casualty:X:NonLegendary$ True | CopySetLoyalty$ Casualty:The copy isn't legendary and has starting loyalty X.
+K:Casualty:X:NonLegendary$ True | SetLoyalty$ Casualty:The copy isn't legendary and has starting loyalty X.
 A:AB$ RepeatEach | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | RepeatPlayers$ Opponent | RepeatSubAbility$ DBDrain | SubAbility$ DBGainLife | SpellDescription$ Each opponent loses 2 life unless they discard a card. If you control a Demon or Devil, you gain 2 life.
 SVar:DBDrain:DB$ LoseLife | Defined$ Player.IsRemembered | LifeAmount$ 2 | UnlessCost$ Discard<1/Card> | UnlessPayer$ Player.IsRemembered
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ 2 | ConditionPresent$ Demon.YouCtrl,Devil.YouCtrl | StackDescription$ None

--- a/forge-gui/res/cardsfolder/t/tawnos_the_toymaker.txt
+++ b/forge-gui/res/cardsfolder/t/tawnos_the_toymaker.txt
@@ -3,7 +3,7 @@ ManaCost:3 G U
 Types:Legendary Creature Human Artificer
 PT:3/5
 T:Mode$ SpellCast | TriggerZones$ Battlefield | OptionalDecider$ You | ValidCard$ Creature.Bird,Creature.Beast | ValidActivatingPlayer$ You | NoResolvingCheck$ True | Execute$ TrigCopy | TriggerDescription$ Whenever you cast a Beast or Bird creature spell, you may copy it, except it's an artifact in addition to its other types. (The copy becomes a token.)
-SVar:TrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | CopyAddTypes$ Artifact
+SVar:TrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | AddTypes$ Artifact
 DeckNeeds:Type$Beast|Bird
 DeckHas:Ability$Token & Type$Artifact 
 Oracle:Whenever you cast a Beast or Bird creature spell, you may copy it, except it's an artifact in addition to its other types. (The copy becomes a token.)


### PR DESCRIPTION
Handles the SpellCopy part of #2866

- [ ] remove copyCopiableCharacteristics use in GameCopier
- [ ] maybe remove copyStats and remove copyState