### PR TITLE
Adventure fixes

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/data/AdventureQuestData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/AdventureQuestData.java
@@ -179,6 +179,9 @@ public class AdventureQuestData implements Serializable {
         stage.initialize();
 
         switch  (stage.objective){
+            case Arena:
+                stage.setTargetPOI(poiTokens);
+                break;
             case Clear:
                 stage.setTargetPOI(poiTokens);
                 break;

--- a/forge-gui/res/adventure/Shandalar/maps/map/teferi.tmx
+++ b/forge-gui/res/adventure/Shandalar/maps/map/teferi.tmx
@@ -1,23 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="30" height="17" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="96">
+<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="30" height="17" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="97">
  <editorsettings>
   <export target="wastetown..tmx" format="tmx"/>
  </editorsettings>
  <tileset firstgid="1" source="../tileset/main.tsx"/>
  <tileset firstgid="10113" source="../tileset/buildings.tsx"/>
+ <tileset firstgid="11905" source="../tileset/main-nocollide.tsx"/>
  <layer id="6" name="Collision" width="30" height="17">
   <data encoding="base64" compression="zlib">
-   eJzVkk0KwjAQhQMaiwu79DBCced53PQqWQl6BE/TjT1LsIMdOk1f2kkNiA8e+YHMl3mJMWM9CzMR7bHvJo9jDMT8FTcXc44bc2On5lrOLp9fwyWGm7GsHc6Zx3N57xRuvcN35vqNxT3GctNyj936cfjY2YF9LkGIQClcMjOqchjle2m5mj8UMiWXdNmnc31f0/e+Knolvbr6LWAgLr1FinwxdqXoJeTyGU0Otw3e13CRUC5Ipy3ep57lW5Jo3UYyX1JK/sxYy5Ki7LX/MKe+vfc/6Q0WVaCR
+   eJzbwM7AsGEUD3ksZkJd86axYmJs6rbgsPcaKwKTYq8ohRjZXmLtptROUTLClxp2kmovtewk1U30sncUUw+XsTEwlANxBRt97RWB0mJ09u8mIN4MxFsGQdjTAwMArIa2fg==
   </data>
  </layer>
  <layer id="1" name="Background" width="30" height="17">
   <data encoding="base64" compression="zlib">
-   eJwrYGdgKBgkGASQ2djAQNlLC7tJAehuJdddxIIPHBCszwWhQeAjB6r9hMIRl3vxgVI2BgZRdlTMwYNwDzpGdy85QJQdQaPjPk4IbiOASQG/mBHmY7MXBIixl1RwnZV0PbjANVbCcUILe/EBPS5IeoXh+fSxFgOIEkjvhOTJBaA0sY1GZo+C4QUA1S5VLg==
+   eJxjYECAekYGhgZGhgEBckwDY+9QBJHMDAxRzKTLkQpmsaDiX0BzfzKjisHUocuRCkDu/kUld5NiJ70Btf0ZwczQgBwfEUhxgJwO/tLRr8jpgN5xOgpGwSggDABapRie
   </data>
  </layer>
  <layer id="2" name="Grass" width="30" height="17">
   <data encoding="base64" compression="zlib">
-   eJxjYBgaYAM7Kh7q9rYxEqfuGisqpjUA2fGeg4FhFgsDgz4XKsYHPnBAMCX29nIyMIhiCeN2PGHVxwnB5AIDoL9UmDDt9SQQPyD12NxKLAD5CWYGslmEzEVXSypAt5NcTGpcU8tefBgZwNIsPexFxyIDYCd6+qEUl7ExMJQDcQUb/f3xgE7pZSRjAHobMkU=
+   eJxjYEAF9YwMDA2MDKNgBIM2YPzPYqG/vSpM2MXbaZgefzEzMBzHYq8njfMANjtHwSgYBaOAHgAAE7oFrg==
   </data>
  </layer>
  <layer id="3" name="Clutter" width="30" height="17" opacity="0.9">
@@ -25,7 +26,7 @@
    <property name="spriteLayer" type="bool" value="true"/>
   </properties>
   <data encoding="base64" compression="zlib">
-   eJxjYICAlewMDKuAeDUQrwHiaayomBCoY8Qvbwg0wwiLOe4cDAweQOwJxF4cmPYSsluGCb/8eaD+C3jMINZ/QwUsZMYUm8FCmhltwLhsx4I7sMTxK3YIbU+CHbjcowKNy2peCF0FpdWA4h5odsPspRTA/AoCyP40Btq9hpOB4RmSvUuR9BnzUmYnyK+iQD+IIPlDDSktI9tbjcWupZhCBAHIrm1sCDYM7EBiP8MSx9js/8BBmr0wcAjox8NArAnEYVAzQPGMbm8Z0J3lQFzBBokHZIDOxwYMuCD2wtIQLj3I9oLiFKQHFC9iSG5eBsTlSGEwhxlVD6kAZH4HE6q7NgHFNgPxFnZUu5DtsMKSb2D6QTTIDE0mVD0a0PAGYVWgu9XQywdmKEYDk9mIx0bsCPc3M0FwC1JaBrnNgJ04s7CF/1JuBBs5bHI4IHoM8Zidx4EII+S4Qk/TyOGPDyCno7NklkGE0i8heVz2outDT0fIAACuW1e6
+   eJxjYGBgiGRmYIgC4m9ALMvEwCAHxKSAekYGhjogbmDEryaCGVXNdyB/MgsDwxQgngrE01hIsxfkVhkC7gWpAfkLXQ3I7h9k+pccAAtjWgEfdgi9EM0OkD9nsGDGDT73gOKqHQvuwBK/r6D22mOJO2xhi889MFDNC6GroLQaE6bdHRzY3Y4PYHNPGyOCRvanMdDuNZwQu2FgKZI+Y17S7Ue3EwRUkMxXw8GuxmLXUkwhggBk1zY2THtP4LAXn/2k2gsDh4Dsw0CsiSQGimd0e9uQ4gIUD8gAnY/PXlgawqUH2V5QnIL0qDKhii8D4nKkMJjDjKoHm72EACzMYe6ChcsRJlS7kO2wwpLHYPpB9CGkcIXp0YCaCwtzNfQ8zwzFaGAyG/HYiB3h/sNI/kB2owE7cWZhA0u5EWzksMnhgOgxxGN2HgcijJDjitw0jZyOzrJTbgY58rjsRdeHno6QAQCJOVVS
   </data>
  </layer>
  <objectgroup id="4" name="Objects">
@@ -53,6 +54,7 @@
   <object id="64" template="../obj/enemy.tx" x="437.255" y="107.437" width="15.5419" height="16.9162">
    <properties>
     <property name="enemy" value="Crab"/>
+    <property name="threatRange" type="int" value="35"/>
    </properties>
   </object>
   <object id="65" template="../obj/enemy.tx" x="315.789" y="236.349">
@@ -102,10 +104,9 @@
   <object id="85" template="../obj/waypoint.tx" x="461" y="214.333"/>
   <object id="86" template="../obj/waypoint.tx" x="332.667" y="172.667"/>
   <object id="88" template="../obj/waypoint.tx" x="329.333" y="110.333"/>
-  <object id="91" template="../obj/collision.tx" x="-2.13163e-14" y="272.333" width="212" height="16"/>
-  <object id="92" template="../obj/collision.tx" x="211" y="271.667" width="295" height="16"/>
-  <object id="93" template="../obj/collision.tx" x="480" y="87.3333" width="30.6667" height="185.333"/>
-  <object id="94" template="../obj/collision.tx" x="-38" y="149.667" width="38" height="131.667"/>
+  <object id="92" template="../obj/collision.tx" x="0" y="271.667" width="480" height="16"/>
+  <object id="93" template="../obj/collision.tx" x="480" y="-16" width="16" height="304"/>
+  <object id="94" template="../obj/collision.tx" x="-16" y="-16" width="16" height="304"/>
   <object id="95" template="../obj/booster.tx" x="431" y="93.3333">
    <properties>
     <property name="reward">[
@@ -131,5 +132,6 @@
 </property>
    </properties>
   </object>
+  <object id="96" template="../obj/collision.tx" x="0" y="-16" width="480" height="16"/>
  </objectgroup>
 </map>

--- a/forge-gui/res/adventure/Shandalar/maps/tileset/main.tsx
+++ b/forge-gui/res/adventure/Shandalar/maps/tileset/main.tsx
@@ -1,6 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <tileset version="1.10" tiledversion="1.10.1" name="main" tilewidth="16" tileheight="16" tilecount="10112" columns="158">
  <image source="main.png" width="2528" height="1024"/>
+ <tile id="78">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="12" y="3" width="4" height="5"/>
+   <object id="2" x="8" y="4" width="4" height="6"/>
+   <object id="3" x="4" y="7" width="4" height="7"/>
+   <object id="4" x="2" y="13" width="2" height="3"/>
+  </objectgroup>
+ </tile>
+ <tile id="79">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="11" y="10" width="3" height="6"/>
+   <object id="2" x="7" y="8" width="5" height="4"/>
+   <object id="3" x="4" y="4" width="4" height="7"/>
+   <object id="4" x="0" y="3" width="4" height="5"/>
+  </objectgroup>
+ </tile>
  <tile id="105">
   <objectgroup draworder="index" id="2">
    <object id="1" x="1" y="0" width="14" height="14"/>
@@ -174,6 +190,24 @@
  <tile id="222">
   <objectgroup draworder="index" id="2">
    <object id="1" x="0" y="0" width="16" height="16"/>
+  </objectgroup>
+ </tile>
+ <tile id="236">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="12" y="12" width="4" height="3"/>
+   <object id="2" x="9" y="9" width="4" height="3"/>
+   <object id="3" x="7" y="6" width="4" height="3"/>
+   <object id="4" x="4" y="3" width="4" height="3"/>
+   <object id="5" x="2" y="0" width="4" height="3"/>
+  </objectgroup>
+ </tile>
+ <tile id="237">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="12" width="4" height="3"/>
+   <object id="2" x="3" y="9" width="4" height="3"/>
+   <object id="3" x="6" y="6" width="4" height="3"/>
+   <object id="4" x="9" y="3" width="4" height="3"/>
+   <object id="5" x="10" y="0" width="4" height="3"/>
   </objectgroup>
  </tile>
  <tile id="238">
@@ -414,6 +448,31 @@
  <tile id="388">
   <objectgroup draworder="index" id="2">
    <object id="1" x="0" y="0" width="16" height="16"/>
+  </objectgroup>
+ </tile>
+ <tile id="389">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="11" y="12" width="5" height="4"/>
+  </objectgroup>
+ </tile>
+ <tile id="390">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="12" width="16" height="3"/>
+  </objectgroup>
+ </tile>
+ <tile id="391">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="12" width="6" height="4"/>
+  </objectgroup>
+ </tile>
+ <tile id="393">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="3" y="12" width="13" height="4"/>
+  </objectgroup>
+ </tile>
+ <tile id="394">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="12" width="12" height="4"/>
   </objectgroup>
  </tile>
  <tile id="405">
@@ -713,12 +772,40 @@
    <object id="1" x="9" y="0" width="7" height="16"/>
   </objectgroup>
  </tile>
+ <tile id="547">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="10" y="0" width="5" height="16"/>
+  </objectgroup>
+ </tile>
+ <tile id="549">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="1" y="0" width="6" height="16"/>
+  </objectgroup>
+ </tile>
+ <tile id="550">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="9" y="3" width="7" height="13"/>
+  </objectgroup>
+ </tile>
+ <tile id="551">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="12" y="3" width="4" height="5"/>
+   <object id="2" x="8" y="4" width="4" height="6"/>
+   <object id="3" x="4" y="7" width="4" height="7"/>
+   <object id="4" x="2" y="13" width="2" height="3"/>
+  </objectgroup>
+ </tile>
  <tile id="552">
   <objectgroup draworder="index" id="2">
    <object id="1" x="11" y="10" width="3" height="6"/>
    <object id="2" x="7" y="8" width="5" height="4"/>
    <object id="3" x="4" y="4" width="4" height="7"/>
    <object id="4" x="0" y="3" width="4" height="5"/>
+  </objectgroup>
+ </tile>
+ <tile id="553">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="3" width="7" height="13"/>
   </objectgroup>
  </tile>
  <tile id="563">
@@ -1029,6 +1116,49 @@
  <tile id="704">
   <objectgroup draworder="index" id="2">
    <object id="1" x="0" y="0" width="16" height="16"/>
+  </objectgroup>
+ </tile>
+ <tile id="705">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="10" y="0" width="6" height="10"/>
+  </objectgroup>
+ </tile>
+ <tile id="706">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="1" width="16" height="10"/>
+  </objectgroup>
+ </tile>
+ <tile id="707">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="0" width="7" height="10"/>
+  </objectgroup>
+ </tile>
+ <tile id="708">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="9" y="0" width="7" height="13"/>
+  </objectgroup>
+ </tile>
+ <tile id="709">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="12" y="12" width="4" height="3"/>
+   <object id="2" x="9" y="9" width="4" height="3"/>
+   <object id="3" x="7" y="6" width="4" height="3"/>
+   <object id="4" x="4" y="3" width="4" height="3"/>
+   <object id="5" x="2" y="0" width="4" height="3"/>
+  </objectgroup>
+ </tile>
+ <tile id="710">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="12" width="4" height="3"/>
+   <object id="2" x="3" y="9" width="4" height="3"/>
+   <object id="3" x="6" y="6" width="4" height="3"/>
+   <object id="4" x="9" y="3" width="4" height="3"/>
+   <object id="5" x="10" y="0" width="4" height="3"/>
+  </objectgroup>
+ </tile>
+ <tile id="711">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="0" width="7" height="13"/>
   </objectgroup>
  </tile>
  <tile id="721">
@@ -1358,6 +1488,16 @@
    <object id="1" x="0" y="0" width="16" height="16"/>
   </objectgroup>
  </tile>
+ <tile id="867">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="3" y="0" width="13" height="9"/>
+  </objectgroup>
+ </tile>
+ <tile id="868">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="0" width="13" height="9"/>
+  </objectgroup>
+ </tile>
  <tile id="876">
   <objectgroup draworder="index" id="2">
    <object id="1" x="0" y="0" width="16" height="16"/>
@@ -1629,6 +1769,31 @@
    <object id="1" x="9" y="0" width="7" height="16"/>
   </objectgroup>
  </tile>
+ <tile id="1021">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="11" y="12" width="5" height="4"/>
+  </objectgroup>
+ </tile>
+ <tile id="1022">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="12" width="16" height="3"/>
+  </objectgroup>
+ </tile>
+ <tile id="1023">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="12" width="6" height="4"/>
+  </objectgroup>
+ </tile>
+ <tile id="1025">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="3" y="12" width="13" height="4"/>
+  </objectgroup>
+ </tile>
+ <tile id="1026">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="12" width="12" height="4"/>
+  </objectgroup>
+ </tile>
  <tile id="1034">
   <objectgroup draworder="index" id="2">
    <object id="1" x="0" y="0" width="6" height="16"/>
@@ -1890,12 +2055,40 @@
    <object id="1" x="0" y="0" width="16" height="16"/>
   </objectgroup>
  </tile>
+ <tile id="1179">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="10" y="0" width="5" height="16"/>
+  </objectgroup>
+ </tile>
+ <tile id="1181">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="1" y="0" width="6" height="16"/>
+  </objectgroup>
+ </tile>
+ <tile id="1182">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="9" y="3" width="7" height="13"/>
+  </objectgroup>
+ </tile>
+ <tile id="1183">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="12" y="3" width="4" height="5"/>
+   <object id="2" x="8" y="4" width="4" height="6"/>
+   <object id="3" x="4" y="7" width="4" height="7"/>
+   <object id="4" x="2" y="13" width="2" height="3"/>
+  </objectgroup>
+ </tile>
  <tile id="1184">
   <objectgroup draworder="index" id="2">
    <object id="1" x="11" y="10" width="3" height="6"/>
    <object id="2" x="7" y="8" width="5" height="4"/>
    <object id="3" x="4" y="4" width="4" height="7"/>
    <object id="4" x="0" y="3" width="4" height="5"/>
+  </objectgroup>
+ </tile>
+ <tile id="1185">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="3" width="7" height="13"/>
   </objectgroup>
  </tile>
  <tile id="1192">
@@ -2365,6 +2558,49 @@
    <object id="1" x="0" y="3" width="14" height="13"/>
   </objectgroup>
  </tile>
+ <tile id="1337">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="10" y="0" width="6" height="10"/>
+  </objectgroup>
+ </tile>
+ <tile id="1338">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="1" width="16" height="10"/>
+  </objectgroup>
+ </tile>
+ <tile id="1339">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="0" width="7" height="10"/>
+  </objectgroup>
+ </tile>
+ <tile id="1340">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="9" y="0" width="7" height="13"/>
+  </objectgroup>
+ </tile>
+ <tile id="1341">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="12" y="12" width="4" height="3"/>
+   <object id="2" x="9" y="9" width="4" height="3"/>
+   <object id="3" x="7" y="6" width="4" height="3"/>
+   <object id="4" x="4" y="3" width="4" height="3"/>
+   <object id="5" x="2" y="0" width="4" height="3"/>
+  </objectgroup>
+ </tile>
+ <tile id="1342">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="12" width="4" height="3"/>
+   <object id="2" x="3" y="9" width="4" height="3"/>
+   <object id="3" x="6" y="6" width="4" height="3"/>
+   <object id="4" x="9" y="3" width="4" height="3"/>
+   <object id="5" x="10" y="0" width="4" height="3"/>
+  </objectgroup>
+ </tile>
+ <tile id="1343">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="0" width="7" height="13"/>
+  </objectgroup>
+ </tile>
  <tile id="1345">
   <objectgroup draworder="index" id="2">
    <object id="1" x="0" y="10" width="16" height="6"/>
@@ -2762,6 +2998,16 @@
    <object id="1" x="0" y="0" width="14" height="16"/>
   </objectgroup>
  </tile>
+ <tile id="1499">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="3" y="0" width="13" height="9"/>
+  </objectgroup>
+ </tile>
+ <tile id="1500">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="0" width="13" height="9"/>
+  </objectgroup>
+ </tile>
  <tile id="1503">
   <objectgroup draworder="index" id="2">
    <object id="1" x="0" y="0" width="16" height="6"/>
@@ -3134,6 +3380,31 @@
    <object id="1" x="0" y="0" width="14" height="14"/>
   </objectgroup>
  </tile>
+ <tile id="1653">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="11" y="12" width="5" height="4"/>
+  </objectgroup>
+ </tile>
+ <tile id="1654">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="12" width="16" height="3"/>
+  </objectgroup>
+ </tile>
+ <tile id="1655">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="12" width="6" height="4"/>
+  </objectgroup>
+ </tile>
+ <tile id="1657">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="3" y="12" width="13" height="4"/>
+  </objectgroup>
+ </tile>
+ <tile id="1658">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="12" width="12" height="4"/>
+  </objectgroup>
+ </tile>
  <tile id="1662">
   <objectgroup draworder="index" id="2">
    <object id="1" x="10" y="0" width="6" height="16"/>
@@ -3484,12 +3755,40 @@
    <object id="2" x="0" y="0" width="16" height="16"/>
   </objectgroup>
  </tile>
+ <tile id="1811">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="10" y="0" width="5" height="16"/>
+  </objectgroup>
+ </tile>
+ <tile id="1813">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="1" y="0" width="6" height="16"/>
+  </objectgroup>
+ </tile>
+ <tile id="1814">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="9" y="3" width="7" height="13"/>
+  </objectgroup>
+ </tile>
+ <tile id="1815">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="12" y="3" width="4" height="5"/>
+   <object id="2" x="8" y="4" width="4" height="6"/>
+   <object id="3" x="4" y="7" width="4" height="7"/>
+   <object id="4" x="2" y="13" width="2" height="3"/>
+  </objectgroup>
+ </tile>
  <tile id="1816">
   <objectgroup draworder="index" id="2">
    <object id="1" x="11" y="10" width="3" height="6"/>
    <object id="2" x="7" y="8" width="5" height="4"/>
    <object id="3" x="4" y="4" width="4" height="7"/>
    <object id="4" x="0" y="3" width="4" height="5"/>
+  </objectgroup>
+ </tile>
+ <tile id="1817">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="3" width="7" height="13"/>
   </objectgroup>
  </tile>
  <tile id="1819">
@@ -3845,6 +4144,49 @@
   <objectgroup draworder="index" id="2">
    <object id="1" x="0" y="0" width="14" height="16"/>
    <object id="2" x="0" y="0" width="16" height="16"/>
+  </objectgroup>
+ </tile>
+ <tile id="1969">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="10" y="0" width="6" height="10"/>
+  </objectgroup>
+ </tile>
+ <tile id="1970">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="1" width="16" height="10"/>
+  </objectgroup>
+ </tile>
+ <tile id="1971">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="0" width="7" height="10"/>
+  </objectgroup>
+ </tile>
+ <tile id="1972">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="9" y="0" width="7" height="13"/>
+  </objectgroup>
+ </tile>
+ <tile id="1973">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="12" y="12" width="4" height="3"/>
+   <object id="2" x="9" y="9" width="4" height="3"/>
+   <object id="3" x="7" y="6" width="4" height="3"/>
+   <object id="4" x="4" y="3" width="4" height="3"/>
+   <object id="5" x="2" y="0" width="4" height="3"/>
+  </objectgroup>
+ </tile>
+ <tile id="1974">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="12" width="4" height="3"/>
+   <object id="2" x="3" y="9" width="4" height="3"/>
+   <object id="3" x="6" y="6" width="4" height="3"/>
+   <object id="4" x="9" y="3" width="4" height="3"/>
+   <object id="5" x="10" y="0" width="4" height="3"/>
+  </objectgroup>
+ </tile>
+ <tile id="1975">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="0" width="7" height="13"/>
   </objectgroup>
  </tile>
  <tile id="1977">
@@ -4210,6 +4552,16 @@
   <objectgroup draworder="index" id="2">
    <object id="1" x="0" y="0" width="14" height="14"/>
    <object id="2" x="0" y="0" width="16" height="16"/>
+  </objectgroup>
+ </tile>
+ <tile id="2131">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="3" y="0" width="13" height="9"/>
+  </objectgroup>
+ </tile>
+ <tile id="2132">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="0" y="0" width="13" height="9"/>
   </objectgroup>
  </tile>
  <tile id="2136">


### PR DESCRIPTION
Bugfix for quests that used Arena objectives, previously the quest offer dialog would hang because target POI was not being set properly.

Redo of Teferi Hideout collisions / terrain - Fixed blocked ramp to Teferi, extended shoreline slightly to give more natural appearance, added lots of missing corners to island clutter, replaced hidden collision layer with collision mapped terrain, removed tiles duplicated between layers, added threat range to eastern crab to defend booster pack