### PR TITLE
Banned and Restricted Announcement for May 29, 2023

### DIFF
--- a/forge-gui/res/formats/Archived/Arena Standard/2023-05-30.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2023-05-30.txt
@@ -1,7 +1,7 @@
 [format]
-Name:Standard
-Order:101
+Name:Arena Standard (2023-05-30)
+Type:Archived
 Subtype:Standard
-Type:Sanctioned
+Effective:2023-05-30
 Sets:MID, VOW, NEO, SNC, DMU, BRO, ONE, MOM, MAT
 Banned:Fable of the Mirror-Breaker; Invoke Despair; Reckoner Bankbuster; The Meathook Massacre

--- a/forge-gui/res/formats/Archived/Standard/2023-05-29.txt
+++ b/forge-gui/res/formats/Archived/Standard/2023-05-29.txt
@@ -1,7 +1,7 @@
 [format]
-Name:Standard
-Order:101
+Name:Standard (2023-05-29)
+Type:Archived
 Subtype:Standard
-Type:Sanctioned
+Effective:2023-05-29
 Sets:MID, VOW, NEO, SNC, DMU, BRO, ONE, MOM, MAT
 Banned:Fable of the Mirror-Breaker; Invoke Despair; Reckoner Bankbuster; The Meathook Massacre


### PR DESCRIPTION
Standard:

- Fable of the Mirror-Breaker // Reflection of Kiki-Jiki is banned.
- Invoke Despair is banned.
- Reckoner Bankbuster is banned.

Effective Date:

- Tabletop and Magic Online: May 29, 2023
- MTG Arena: May 30, 2023

Source: https://magic.wizards.com/en/news/announcements/may-29-2023-banned-and-restricted-announcement
