### PR TITLE
Alchemy Rebalancing for May 30, 2023

### DIFF
--- a/forge-gui/res/cardsfolder/rebalanced/a-kumano_faces_kakkazan_etching_of_kumano.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-kumano_faces_kakkazan_etching_of_kumano.txt
@@ -1,0 +1,28 @@
+Name:A-Kumano Faces Kakkazan
+ManaCost:R
+Types:Enchantment Saga
+K:Saga:3:DBDamage,DBEffectAddCounter,DBTransform
+SVar:DBDamage:DB$ DamageAll | NumDmg$ 1 | ValidPlayers$ Opponent | ValidCards$ Planeswalker.OppCtrl | SpellDescription$ CARDNAME deals 1 damage to each opponent and 1 damage to each planeswalker they control.
+SVar:DBEffectAddCounter:DB$ Effect | Triggers$ TrigSpellCast | SpellDescription$ When you cast your next creature spell this turn, that creature enters the battlefield with an additional +1/+1 counter on it.
+SVar:TrigSpellCast:Mode$ SpellCast | ValidCard$ Creature | ValidActivatingPlayer$ You | OneOff$ True | Static$ True | TriggerZones$ Command | Execute$ ReplEffAddCounter | TriggerDescription$ When you cast your next creature spell this turn, that creature enters the battlefield with an additional +1/+1 counter on it.
+SVar:ReplEffAddCounter:DB$ Effect | ReplacementEffects$ ETBAddCounter | RememberObjects$ TriggeredCard | Execute$ TrigRemoveSelf
+SVar:ETBAddCounter:Event$ Moved | Origin$ Stack | Destination$ Battlefield | ValidCard$ Card.IsRemembered | ReplaceWith$ ETBAddExtraCounter | ReplacementResult$ Updated
+SVar:ETBAddExtraCounter:DB$ PutCounter | ETB$ True | Defined$ ReplacedCard | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ TrigRemoveSelf
+SVar:TrigRemoveSelf:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
+SVar:DBTransform:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | RememberChanged$ True | SubAbility$ DBReturn | SpellDescription$ Exile this Saga, then return it to the battlefield transformed under your control.
+SVar:DBReturn:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Battlefield | Transformed$ True | GainControl$ True | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+DeckHas:Ability$Counters
+AlternateMode:DoubleFaced
+Oracle:(As this Saga enters and after your draw step, add a lore counter.)\nI — Kumano Faces Kakkazan deals 1 damage to each opponent and each planeswalker they control.\nII — When you cast your next creature spell this turn, that creature enters the battlefield with an additional +1/+1 counter on it.\nIII — Exile this Saga, then return it to the battlefield transformed under your control.
+
+ALTERNATE
+
+Name:A-Etching of Kumano
+ManaCost:no cost
+Colors:red
+Types:Enchantment Creature Human Shaman
+PT:2/2
+R:Event$ Moved | ValidLKI$ Creature.DamagedByCard.YouCtrl,Creature.DamagedByEmblem.YouCtrl | Destination$ Graveyard | ReplaceWith$ DBExile | ActiveZones$ Battlefield | Description$ If a creature dealt damage this turn by a source you controlled would die, exile it instead.
+SVar:DBExile:DB$ ChangeZone | Defined$ ReplacedCard | Origin$ Battlefield | Destination$ Exile
+Oracle:If a creature dealt damage this turn by a source you controlled would die, exile it instead.

--- a/forge-gui/res/cardsfolder/t/traumatic_prank.txt
+++ b/forge-gui/res/cardsfolder/t/traumatic_prank.txt
@@ -1,5 +1,5 @@
 Name:Traumatic Prank
-ManaCost:2 R
+ManaCost:3 R
 Types:Sorcery
 A:SP$ GainControl | ValidTgts$ Creature | LoseControl$ EOT | Untap$ True | SubAbility$ DBEffect | SpellDescription$ Gain control of target creature until end of turn. Untap that creature. It perpetually gains haste, "This creature can't block," and "At the beginning of your upkeep, this creature deals 1 damage to you."
 SVar:DBEffect:DB$ Effect | RememberObjects$ Targeted | StaticAbilities$ TraumaticPrank | Name$ Traumatic Prank's Perpetual Effect | Duration$ Permanent

--- a/forge-gui/res/editions/Kamigawa Neon Dynasty.txt
+++ b/forge-gui/res/editions/Kamigawa Neon Dynasty.txt
@@ -548,6 +548,7 @@ A95 U A-Dokuchi Silencer @David Rapoza
 A114 M A-Nashi, Moon Sage's Scion @Valera Lutfullina
 A116 U A-Nezumi Prowler @Joseph Weston
 A131 C A-Akki Ronin @Olivier Bernard
+A152 U A-Kumano Faces Kakkazan @Mike Bierek
 A156 C A-Peerless Samurai @Micah Epstein
 A215 U A-Asari Captain @Donato Giancola
 A232 R A-Raiyuu, Storm's Edge @Heonhwa Choe


### PR DESCRIPTION
> We have a couple of rebalances coming Tuesday, May 30, to the Alchemy format.

Source: https://magic.wizards.com/en/news/mtg-arena/mtg-arena-announcements-may-29-2023

- [x] Kumano Faces Kakkazan // Etching of Kumano (loses haste)
- [x] Traumatic Prank (cost increases to 3R from 2R - Alchemy only card therefore no new script)