### PR TITLE
Fix DeckHints only finding SimpleKeyword

### DIFF
--- a/forge-core/src/main/java/forge/card/CardRules.java
+++ b/forge-core/src/main/java/forge/card/CardRules.java
@@ -671,6 +671,16 @@ public final class CardRules implements ICardCharacteristics {
         return Iterables.contains(mainPart.getKeywords(), k);
     }
 
+    public boolean hasStartOfKeyword(final String k) {
+        for (final String inst : mainPart.getKeywords()) {
+            final String[] parts = inst.split(":");
+            if (parts[0].equals(k)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public Integer getKeywordMagnitude(final String k) {
         for (final String inst : mainPart.getKeywords()) {
             final String[] parts = inst.split(":");

--- a/forge-core/src/main/java/forge/card/CardRulesPredicates.java
+++ b/forge-core/src/main/java/forge/card/CardRulesPredicates.java
@@ -184,7 +184,7 @@ public final class CardRulesPredicates {
         return new Predicate<CardRules>() {
             @Override
             public boolean apply(final CardRules card) {
-                return card.hasKeyword(keyword);
+                return card.hasStartOfKeyword(keyword);
             }
         };
     }

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -3408,7 +3408,7 @@ public class Player extends GameEntity implements Comparable<Player> {
             return false;
         }
         return targetPlayer == null || !targetPlayer.equals(sa.getActivatingPlayer())
- || !hasKeyword("Spells and abilities you control can't cause you to search your library.");
+                || !hasKeyword("Spells and abilities you control can't cause you to search your library.");
     }
 
     public Card getKeywordCard() {

--- a/forge-gui/res/cardsfolder/h/hordewing_skaab.txt
+++ b/forge-gui/res/cardsfolder/h/hordewing_skaab.txt
@@ -3,12 +3,12 @@ ManaCost:4 U
 Types:Creature Zombie Horror
 PT:3/3
 K:Flying
-S:Mode$ Continuous | Affected$ Zombie.YouCtrl+Other | AddKeyword$ Flying | Description$ Other zombies you control have flying.
-T:Mode$ DamageAll | ValidSource$ Creature.Zombie+YouCtrl | ValidTarget$ Player.Opponent | CombatDamage$ True | TriggerZones$ Battlefield | Execute$ TrigDraw | OptionalDecider$ You | TriggerDescription$ Whenever one or more zombies you control deal combat damage to one or more of your opponents, you may draw cards equal to the number of opponents dealt damage this way. If you do, discard that many cards.
+S:Mode$ Continuous | Affected$ Zombie.YouCtrl+Other | AddKeyword$ Flying | Description$ Other Zombies you control have flying.
+T:Mode$ DamageAll | ValidSource$ Creature.Zombie+YouCtrl | ValidTarget$ Player.Opponent | CombatDamage$ True | TriggerZones$ Battlefield | Execute$ TrigDraw | OptionalDecider$ You | TriggerDescription$ Whenever one or more Zombies you control deal combat damage to one or more of your opponents, you may draw cards equal to the number of opponents dealt damage this way. If you do, discard that many cards.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ X | RememberDrawn$ True | SubAbility$ DBDiscard
 SVar:DBDiscard:DB$ Discard | ConditionDefined$ Remembered | ConditionPresent$ Card | ConditionCompare$ GEX | Defined$ You | Mode$ TgtChoose | NumCards$ X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:TriggeredPlayersTargets$Amount
 DeckHints:Type$Zombie
 DeckHas:Ability$Discard
-Oracle:Flying\nOther zombies you control have flying.\nWhenever one or more zombies you control deal combat damage to one or more of your opponents, you may draw cards equal to the number of opponents dealt damage this way. If you do, discard that many cards.
+Oracle:Flying\nOther Zombies you control have flying.\nWhenever one or more Zombies you control deal combat damage to one or more of your opponents, you may draw cards equal to the number of opponents dealt damage this way. If you do, discard that many cards.


### PR DESCRIPTION
This makes matching parametrized ones like `Keyword$Suspend` from _Alaundo the Seer_ actually work... 💩 