### PR TITLE
Follow-up tweak for when triggers are checked during resolve

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
@@ -1450,6 +1450,7 @@ public class AbilityUtils {
 
         // Needed - Equip an untapped creature with Sword of the Paruns then cast Deadshot on it. Should deal 2 more damage.
         game.getAction().checkStaticAbilities(); // this will refresh continuous abilities for players and permanents.
+        game.getTriggerHandler().collectTriggerForWaiting();
         AbilityUtils.resolveApiAbility(abSub, game);
     }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/RemoveFromGameEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/RemoveFromGameEffect.java
@@ -8,7 +8,6 @@ public class RemoveFromGameEffect extends SpellAbilityEffect {
 
     @Override
     public void resolve(SpellAbility sa) {
-
         for (final Card tgtC : getTargetCards(sa)) {
             tgtC.getGame().getAction().ceaseToExist(tgtC, true);
         }

--- a/forge-gui/res/cardsfolder/k/kynaios_and_tiro_of_meletis.txt
+++ b/forge-gui/res/cardsfolder/k/kynaios_and_tiro_of_meletis.txt
@@ -4,8 +4,7 @@ Types:Legendary Creature Human Soldier
 PT:2/8
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ At the beginning of your end step, draw a card. Each player may put a land card from their hand onto the battlefield, then each opponent who didn't draws a card.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1 | SubAbility$ EachPlayLand
-SVar:EachPlayLand:DB$ RepeatEach | RepeatPlayers$ Player | RepeatSubAbility$ MayPlayLand | SubAbility$ DBCleanup
-SVar:MayPlayLand:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | ChangeType$ Land | DefinedPlayer$ Remembered | ChangeNum$ 1 | RememberChanged$ True | SubAbility$ DrawAbstainers
-SVar:DrawAbstainers:DB$ Draw | Defined$ Player.Opponent+IsRemembered | NumCards$ 1 | ConditionDefined$ Remembered | ConditionPresent$ Land.RememberedPlayerCtrl | ConditionCompare$ EQ0
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearImprinted$ True
+SVar:EachPlayLand:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | ChangeType$ Land | DefinedPlayer$ Player | ChangeNum$ 1 | RememberChanged$ True | SubAbility$ DrawAbstainers
+SVar:DrawAbstainers:DB$ Draw | Defined$ OppNonRememberedOwner | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:At the beginning of your end step, draw a card. Each player may put a land card from their hand onto the battlefield, then each opponent who didn't draws a card.

--- a/forge-gui/res/cardsfolder/t/the_great_aurora.txt
+++ b/forge-gui/res/cardsfolder/t/the_great_aurora.txt
@@ -1,18 +1,13 @@
 Name:The Great Aurora
 ManaCost:6 G G G
 Types:Sorcery
-A:SP$ RepeatEach | Cost$ 6 G G G | RepeatPlayers$ Player | RepeatSubAbility$ DBStoreAmount | SubAbility$ RepeatLands | StackDescription$ SpellDescription | SpellDescription$ Each player shuffles all cards from their hand and all permanents they own into their library, then draws that many cards. Each player may put any number of land cards from their hand onto the battlefield. Exile The Great Aurora.
+A:SP$ RepeatEach | Cost$ 6 G G G | RepeatPlayers$ Player | RepeatSubAbility$ DBShuffle | SubAbility$ RepeatLands | StackDescription$ SpellDescription | SpellDescription$ Each player shuffles all cards from their hand and all permanents they own into their library, then draws that many cards. Each player may put any number of land cards from their hand onto the battlefield. Exile CARDNAME.
 # ChangeType is fine being "Card" because if it's on the battlefield, it has to be a permanent
-SVar:DBStoreAmount:DB$ StoreSVar | SVar$ AuroraY | Type$ Count | Expression$ Valid Card.RememberedPlayerOwn | SubAbility$ DBStoreAmount2
-SVar:DBStoreAmount2:DB$ StoreSVar | SVar$ AuroraZ | Type$ Count | Expression$ ValidHand Card.RememberedPlayerOwn | SubAbility$ DBShuffle
-SVar:DBShuffle:DB$ ChangeZoneAll | ChangeType$ Card.RememberedPlayerOwn | Origin$ Hand,Battlefield | Destination$ Library | Shuffle$ True | SubAbility$ DBDraw
-SVar:DBDraw:DB$ Draw | Defined$ Remembered | NumCards$ AuroraX
-SVar:AuroraX:SVar$AuroraY/Plus.AuroraZ
-SVar:AuroraY:Number$0
-SVar:AuroraZ:Number$0
-SVar:RepeatLands:DB$ RepeatEach | RepeatPlayers$ Player | RepeatSubAbility$ DBAurora | SubAbility$ DBCleanup
+SVar:DBShuffle:DB$ ChangeZoneAll | ChangeType$ Card.RememberedPlayerOwn | Origin$ Hand,Battlefield | Destination$ Library | Shuffle$ True | RememberChanged$ True | SubAbility$ DBDraw
+SVar:DBDraw:DB$ Draw | Defined$ Remembered | NumCards$ Remembered$Amount | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:RepeatLands:DB$ RepeatEach | RepeatPlayers$ Player | RepeatSubAbility$ DBAurora | SubAbility$ ExileAurora
 SVar:DBAurora:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | DefinedPlayer$ Remembered | Chooser$ Remembered | ChangeType$ Land | ChangeNum$ HandSize
 SVar:HandSize:Count$ValidHand Land.RememberedPlayerCtrl
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | SubAbility$ ExileAurora
 SVar:ExileAurora:DB$ ChangeZone | Origin$ Stack | Destination$ Exile | Defined$ Self
 Oracle:Each player shuffles all cards from their hand and all permanents they own into their library, then draws that many cards. Each player may put any number of land cards from their hand onto the battlefield. Exile The Great Aurora.


### PR DESCRIPTION
![image](https://github.com/Card-Forge/forge/assets/8506892/3c780a90-285a-4b8a-9619-4a8c07e0bad8)

For the same reason you could also get Zellix to trigger from the mill if he gets returned.