### PR TITLE
Cleanup more ResolvingChecks

### DIFF
--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -509,13 +509,11 @@ public class Player extends GameEntity implements Comparable<Player> {
             return false;
         }
 
-        boolean newLifeSet = false;
-
         if (lifeGain > 0) {
             int oldLife = life;
             life += lifeGain;
             view.updateLife(this);
-            newLifeSet = true;
+            boolean firstGain = lifeGainedTimesThisTurn == 0;
             lifeGainedThisTurn += lifeGain;
             lifeGainedTimesThisTurn++;
 
@@ -529,13 +527,15 @@ public class Player extends GameEntity implements Comparable<Player> {
             runParams.put(AbilityKey.LifeAmount, lifeGain);
             runParams.put(AbilityKey.Source, source);
             runParams.put(AbilityKey.SourceSA, sa);
+            runParams.put(AbilityKey.FirstTime, firstGain);
             game.getTriggerHandler().runTrigger(TriggerType.LifeGained, runParams, false);
 
             game.fireEvent(new GameEventPlayerLivesChanged(this, oldLife, life));
-        } else {
-            System.out.println("Player - trying to gain negative or 0 life");
+            return true;
         }
-        return newLifeSet;
+
+        System.out.println("Player - trying to gain negative or 0 life");
+        return false;
     }
 
     public final boolean canGainLife() {

--- a/forge-game/src/main/java/forge/game/trigger/TriggerLifeGained.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerLifeGained.java
@@ -61,6 +61,12 @@ public class TriggerLifeGained extends Trigger {
             return false;
         }
 
+        if (hasParam("FirstTime")) {
+            if (!(boolean) runParams.get(AbilityKey.FirstTime)) {
+                return false;
+            }
+        }
+
         if (hasParam("Spell")) {
             final SpellAbility spellAbility = (SpellAbility) runParams.get(AbilityKey.SourceSA);
             if (spellAbility == null || !spellAbility.getRootAbility().isSpell()) {

--- a/forge-gui/res/cardsfolder/a/ankle_shanker.txt
+++ b/forge-gui/res/cardsfolder/a/ankle_shanker.txt
@@ -3,6 +3,6 @@ ManaCost:2 R W B
 Types:Creature Goblin Berserker
 PT:2/2
 K:Haste
-T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPump | NoResolvingCheck$ True | TriggerDescription$ Whenever CARDNAME attacks, creatures you control gain first strike and deathtouch until end of turn.
+T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, creatures you control gain first strike and deathtouch until end of turn.
 SVar:TrigPump:DB$ PumpAll | ValidCards$ Creature.YouCtrl | KW$ First Strike & Deathtouch
 Oracle:Haste\nWhenever Ankle Shanker attacks, creatures you control gain first strike and deathtouch until end of turn.

--- a/forge-gui/res/cardsfolder/a/attended_healer.txt
+++ b/forge-gui/res/cardsfolder/a/attended_healer.txt
@@ -2,10 +2,9 @@ Name:Attended Healer
 ManaCost:3 W
 Types:Creature Kor Cleric
 PT:2/3
-T:Mode$ LifeGained | ValidPlayer$ You | TriggerZones$ Battlefield | CheckSVar$ X | SVarCompare$ EQ1 | NoResolvingCheck$ True | Execute$ DBToken | TriggerDescription$ Whenever you gain life for the first time each turn, create a 1/1 white Cat creature token.
+T:Mode$ LifeGained | ValidPlayer$ You | TriggerZones$ Battlefield | FirstTime$ True | Execute$ DBToken | TriggerDescription$ Whenever you gain life for the first time each turn, create a 1/1 white Cat creature token.
 A:AB$ Pump | Cost$ 2 W | ValidTgts$ Cleric.Other | TgtPrompt$ Select another target Cleric | KW$ Lifelink | SpellDescription$ Another target Cleric gains lifelink until end of turn.
 SVar:DBToken:DB$ Token | TokenAmount$ 1 | TokenScript$ w_1_1_cat | TokenOwner$ You | SpellDescription$ Whenever you gain life for the first time each turn, create a 1/1 white Cat creature token.
-SVar:X:Count$LifeYouGainedTimesThisTurn
 DeckHints:Ability$LifeGain & Type$Cleric
 DeckHas:Ability$Token
 Oracle:Whenever you gain life for the first time each turn, create a 1/1 white Cat creature token.\n{2}{W}: Another target Cleric gains lifelink until end of turn.

--- a/forge-gui/res/cardsfolder/c/cleric_of_lifes_bond.txt
+++ b/forge-gui/res/cardsfolder/c/cleric_of_lifes_bond.txt
@@ -4,9 +4,8 @@ Types:Creature Vampire Cleric
 PT:2/2
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Cleric.Other+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigGainLife | TriggerDescription$ Whenever another Cleric enters the battlefield under your control, you gain 1 life.
 SVar:TrigGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1
-T:Mode$ LifeGained | TriggerZones$ Battlefield | ValidPlayer$ You | CheckSVar$ X | SVarCompare$ EQ1 | NoResolvingCheck$ True | Execute$ TrigPutCounter | TriggerDescription$ Whenever you gain life for the first time each turn, put a +1/+1 counter on CARDNAME.
+T:Mode$ LifeGained | TriggerZones$ Battlefield | ValidPlayer$ You | FirstTime$ True | Execute$ TrigPutCounter | TriggerDescription$ Whenever you gain life for the first time each turn, put a +1/+1 counter on CARDNAME.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
 DeckHas:Ability$LifeGain|Counters
 DeckHints:Type$Cleric
-SVar:X:Count$LifeYouGainedTimesThisTurn
 Oracle:Whenever another Cleric enters the battlefield under your control, you gain 1 life.\nWhenever you gain life for the first time each turn, put a +1/+1 counter on Cleric of Life's Bond.

--- a/forge-gui/res/cardsfolder/c/company_commander.txt
+++ b/forge-gui/res/cardsfolder/c/company_commander.txt
@@ -5,7 +5,7 @@ PT:2/4
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ Command Section — When CARDNAME enters the battlefield, create a number of 1/1 white Soldier creature tokens equal to the number of opponents you have.
 SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ w_1_1_soldier | TokenOwner$ You
 SVar:X:PlayerCountOpponents$Amount
-T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPump | NoResolvingCheck$ True | TriggerDescription$ Bring it Down! — Whenever CARDNAME attacks, creatures you control gain deathtouch until end of turn.
+T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Bring it Down! — Whenever CARDNAME attacks, creatures you control gain deathtouch until end of turn.
 SVar:TrigPump:DB$ PumpAll | ValidCards$ Creature.YouCtrl | KW$ Deathtouch
 SVar:HasAttackEffect:TRUE
 DeckHas:Keyword$Deathtouch & Ability$Token

--- a/forge-gui/res/cardsfolder/c/cunning_rhetoric.txt
+++ b/forge-gui/res/cardsfolder/c/cunning_rhetoric.txt
@@ -1,7 +1,7 @@
 Name:Cunning Rhetoric
 ManaCost:2 B
 Types:Enchantment
-T:Mode$ AttackersDeclared | AttackingPlayer$ Player.Opponent | AttackedTarget$ You,Planeswalker.YouCtrl | NoResolvingCheck$ True | TriggerZones$ Battlefield | Execute$ TrigExile | TriggerDescription$ Whenever an opponent attacks you and/or one or more planeswalkers you control, exile the top card of that player's library. You may play that card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast it.
+T:Mode$ AttackersDeclared | AttackingPlayer$ Player.Opponent | AttackedTarget$ You,Planeswalker.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigExile | TriggerDescription$ Whenever an opponent attacks you and/or one or more planeswalkers you control, exile the top card of that player's library. You may play that card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast it.
 SVar:TrigExile:DB$ Dig | Defined$ TriggeredAttackingPlayer | DigNum$ 1 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | RememberObjects$ Remembered | StaticAbilities$ STPlay | Duration$ Permanent | ExileOnMoved$ Exile | SubAbility$ DBCleanup
 SVar:STPlay:Mode$ Continuous | MayPlay$ True | MayPlayIgnoreColor$ True | EffectZone$ Command | Affected$ Card.IsRemembered | AffectedZone$ Exile | Description$ You may play that card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast it.

--- a/forge-gui/res/cardsfolder/c/curse_of_shaken_faith.txt
+++ b/forge-gui/res/cardsfolder/c/curse_of_shaken_faith.txt
@@ -4,6 +4,6 @@ Types:Enchantment Aura Curse
 K:Enchant player
 A:SP$ Attach | Cost$ 1 R | ValidTgts$ Player | AILogic$ Curse
 T:Mode$ SpellCast | ValidActivatingPlayer$ Player.EnchantedBy | ActivatorThisTurnCast$ GT1 | TriggerZones$ Battlefield | Execute$ TrigDamage | TriggerDescription$ Whenever enchanted player casts a spell other than the first spell they cast each turn or copies a spell, CARDNAME deals 2 damage to them.
-T:Mode$ SpellCopy | ValidActivatingPlayer$ Player.EnchantedBy | NoResolvingCheck$ True | TriggerZones$ Battlefield | Execute$ TrigDamage | Secondary$ True | TriggerDescription$ Whenever enchanted player casts a spell other than the first spell they cast each turn or copies a spell, CARDNAME deals 2 damage to them.
+T:Mode$ SpellCopy | ValidActivatingPlayer$ Player.EnchantedBy | TriggerZones$ Battlefield | Execute$ TrigDamage | Secondary$ True | TriggerDescription$ Whenever enchanted player casts a spell other than the first spell they cast each turn or copies a spell, CARDNAME deals 2 damage to them.
 SVar:TrigDamage:DB$ DealDamage | Defined$ TriggeredPlayer | NumDmg$ 2
 Oracle:Enchant player\nWhenever enchanted player casts a spell other than the first spell they cast each turn or copies a spell, Curse of Shaken Faith deals 2 damage to them.

--- a/forge-gui/res/cardsfolder/d/dance_with_calamity.txt
+++ b/forge-gui/res/cardsfolder/d/dance_with_calamity.txt
@@ -5,7 +5,7 @@ A:SP$ Shuffle | SubAbility$ DBChoose | StackDescription$ {p:You} shuffles their 
 SVar:DBChoose:DB$ GenericChoice | Choices$ DBRepeat,Play | Defined$ You
 SVar:DBRepeat:DB$ Repeat | RepeatSubAbility$ DBDig | RepeatOptional$ True | SubAbility$ Play  | SpellDescription$ As many times as you choose, you may exile the top card of your library
 SVar:DBDig:DB$ Dig | DigNum$ 1 | Reveal$ True | ChangeNum$ All | ChangeValid$ Card | DestinationZone$ Exile | RememberChanged$ True
-SVar:Play:DB$ Play | Defined$ Remembered | Amount$ All | WithoutManaCost$ True | Optional$ True | ConditionCheckSVar$ X | ConditionSVarCompare$ LE13 | SubAbility$ DBCleanup | SpellDescription$  If the total mana value of the cards exiled this way is 13 or less, you may cast any number of spells from among those cards without paying their mana costs.
+SVar:Play:DB$ Play | Defined$ Remembered | ValidSA$ Spell | Amount$ All | WithoutManaCost$ True | Optional$ True | ConditionCheckSVar$ X | ConditionSVarCompare$ LE13 | SubAbility$ DBCleanup | SpellDescription$  If the total mana value of the cards exiled this way is 13 or less, you may cast any number of spells from among those cards without paying their mana costs.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Remembered$SumCMC
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/d/deathless_knight.txt
+++ b/forge-gui/res/cardsfolder/d/deathless_knight.txt
@@ -3,8 +3,7 @@ ManaCost:B/G B/G B/G B/G
 Types:Creature Skeleton Knight
 PT:4/2
 K:Haste
-T:Mode$ LifeGained | ValidPlayer$ You | TriggerZones$ Graveyard | CheckSVar$ X | SVarCompare$ EQ1 | NoResolvingCheck$ True | Execute$ TrigReturn | TriggerDescription$ When you gain life for the first time each turn, return CARDNAME from your graveyard to your hand.
+T:Mode$ LifeGained | ValidPlayer$ You | TriggerZones$ Graveyard | FirstTime$ True | Execute$ TrigReturn | TriggerDescription$ When you gain life for the first time each turn, return CARDNAME from your graveyard to your hand.
 SVar:TrigReturn:DB$ ChangeZone | Defined$ Self | Origin$ Graveyard | Destination$ Hand
-SVar:X:Count$LifeYouGainedTimesThisTurn
 DeckHints:Ability$LifeGain
 Oracle:Haste\nWhen you gain life for the first time each turn, return Deathless Knight from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/h/howling_mine.txt
+++ b/forge-gui/res/cardsfolder/h/howling_mine.txt
@@ -1,6 +1,6 @@
 Name:Howling Mine
 ManaCost:2
 Types:Artifact
-T:Mode$ Phase | Phase$ Draw | ValidPlayer$ Player | TriggerZones$ Battlefield | IsPresent$ Card.Self+untapped | NoResolvingCheck$ True | Execute$ TrigDraw | TriggerDescription$ At the beginning of each player's draw step, if CARDNAME is untapped, that player draws an additional card.
+T:Mode$ Phase | Phase$ Draw | ValidPlayer$ Player | TriggerZones$ Battlefield | IsPresent$ Card.Self+untapped | Execute$ TrigDraw | TriggerDescription$ At the beginning of each player's draw step, if CARDNAME is untapped, that player draws an additional card.
 SVar:TrigDraw:DB$ Draw | NumCards$ 1 | Defined$ TriggeredPlayer | ConditionDefined$ Self | ConditionPresent$ Card.untapped
 Oracle:At the beginning of each player's draw step, if Howling Mine is untapped, that player draws an additional card.

--- a/forge-gui/res/cardsfolder/m/mana_vault.txt
+++ b/forge-gui/res/cardsfolder/m/mana_vault.txt
@@ -4,7 +4,7 @@ Types:Artifact
 A:AB$ Mana | Cost$ T | Produced$ C | Amount$ 3 | SpellDescription$ Add {C}{C}{C}.
 K:CARDNAME doesn't untap during your untap step.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigUntap | TriggerDescription$ At the beginning of your upkeep, you may pay {4}. If you do, untap CARDNAME.
-T:Mode$ Phase | Phase$ Draw | ValidPlayer$ You | IsPresent$ Card.Self+tapped | NoResolvingCheck$ True | Execute$ TrigDamage | TriggerDescription$ At the beginning of your draw step, if CARDNAME is tapped, it deals 1 damage to you.
+T:Mode$ Phase | Phase$ Draw | ValidPlayer$ You | IsPresent$ Card.Self+tapped | Execute$ TrigDamage | TriggerDescription$ At the beginning of your draw step, if CARDNAME is tapped, it deals 1 damage to you.
 SVar:TrigUntap:AB$ Untap | Cost$ 4 | Defined$ Self
 SVar:TrigDamage:DB$ DealDamage | Defined$ You | NumDmg$ 1 | ConditionDefined$ Self | ConditionPresent$ Card.tapped
 SVar:UntapMe:True

--- a/forge-gui/res/cardsfolder/n/nim_abomination.txt
+++ b/forge-gui/res/cardsfolder/n/nim_abomination.txt
@@ -2,6 +2,6 @@ Name:Nim Abomination
 ManaCost:2 B
 Types:Creature Zombie
 PT:3/4
-T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | IsPresent$ Card.Self+untapped | NoResolvingCheck$ True | Execute$ TrigLoseLife | TriggerDescription$ At the beginning of your end step, if CARDNAME is untapped, you lose 3 life.
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | IsPresent$ Card.Self+untapped | Execute$ TrigLoseLife | TriggerDescription$ At the beginning of your end step, if CARDNAME is untapped, you lose 3 life.
 SVar:TrigLoseLife:DB$ LoseLife | Defined$ You | LifeAmount$ 3 | ConditionDefined$ Self | ConditionPresent$ Card.untapped
 Oracle:At the beginning of your end step, if Nim Abomination is untapped, you lose 3 life.

--- a/forge-gui/res/cardsfolder/r/ratchet_field_medic_ratchet_rescue_racer.txt
+++ b/forge-gui/res/cardsfolder/r/ratchet_field_medic_ratchet_rescue_racer.txt
@@ -4,7 +4,7 @@ Types:Legendary Artifact Creature Robot
 PT:2/4
 K:More Than Meets the Eye:1 W
 K:Lifelink
-T:Mode$ LifeGained | TriggerZones$ Battlefield | ValidPlayer$ You | OptionalDecider$ You | NoResolvingCheck$ True | Execute$ TrigConvert | TriggerDescription$ Whenever you gain life, you may convert NICKNAME. When you do, return target artifact card with mana value less than or equal to the amount of life you gained this turn from your graveyard to the battlefield tapped.
+T:Mode$ LifeGained | TriggerZones$ Battlefield | ValidPlayer$ You | OptionalDecider$ You | Execute$ TrigConvert | TriggerDescription$ Whenever you gain life, you may convert NICKNAME. When you do, return target artifact card with mana value less than or equal to the amount of life you gained this turn from your graveyard to the battlefield tapped.
 SVar:TrigConvert:DB$ SetState | Mode$ Transform | SubAbility$ DBImmediateTrig | RememberChanged$ True
 SVar:DBImmediateTrig:DB$ ImmediateTrigger | ConditionDefined$ Remembered | ConditionPresent$ Card.Self | ConditionCompare$ GE1 | Execute$ DBReturn | TriggerDescription$ When you do, return target artifact card with mana value less than or equal to the amount of life you gained this turn from your graveyard to the battlefield tapped.
 SVar:DBReturn:DB$ ChangeZone | ValidTgts$ Artifact.cmcLEX+YouOwn | TgtPrompt$ Select target artifact card with mana value equal or less than the amount of life you gained this turn from your graveyard | Origin$ Graveyard | Destination$ Battlefield | Tapped$ True | SubAbility$ DBCleanup

--- a/forge-gui/res/cardsfolder/r/resolute_veggiesaur.txt
+++ b/forge-gui/res/cardsfolder/r/resolute_veggiesaur.txt
@@ -3,7 +3,7 @@ ManaCost:2 G
 Types:Creature Dinosaur Employee
 PT:3/3
 K:Trample
-T:Mode$ RolledDie | ValidPlayer$ You | TriggerZones$ Battlefield | Number$ 3 | NoResolvingCheck$ True | Execute$ TrigPutCounter | TriggerDescription$ Whenever you roll your third die each turn, put a +1/+1 counter on CARDNAME.
+T:Mode$ RolledDie | ValidPlayer$ You | TriggerZones$ Battlefield | Number$ 3 | Execute$ TrigPutCounter | TriggerDescription$ Whenever you roll your third die each turn, put a +1/+1 counter on CARDNAME.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
 DeckHas:Ability$Counters
 Oracle:Trample\nWhenever you roll your third die each turn, put a +1/+1 counter on Resolute Veggiesaur.

--- a/forge-gui/res/cardsfolder/v/voodoo_doll.txt
+++ b/forge-gui/res/cardsfolder/v/voodoo_doll.txt
@@ -2,7 +2,7 @@ Name:Voodoo Doll
 ManaCost:6
 Types:Artifact
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ TrigPutCounter | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, put a pin counter on CARDNAME.
-T:Mode$ Phase | Phase$ End of Turn | IsPresent$ Card.Self+untapped | NoResolvingCheck$ True | ValidPlayer$ You | Execute$ TrigDestroy | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your end step, if CARDNAME is untapped, destroy CARDNAME and it deals damage to you equal to the number of pin counters on it.
+T:Mode$ Phase | Phase$ End of Turn | IsPresent$ Card.Self+untapped | ValidPlayer$ You | Execute$ TrigDestroy | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your end step, if CARDNAME is untapped, destroy CARDNAME and it deals damage to you equal to the number of pin counters on it.
 A:AB$ DealDamage | Cost$ X X T | ValidTgts$ Any | NumDmg$ X | SpellDescription$ CARDNAME deals damage equal to the number of pin counters on it to any target. X is the number of pin counters on CARDNAME.
 SVar:TrigPutCounter:DB$ PutCounter | CounterType$ PIN | CounterNum$ 1 | Defined$ Self
 SVar:TrigDestroy:DB$ Destroy | Defined$ Self | SubAbility$ DBDealDamageYou | ConditionDefined$ Self | ConditionPresent$ Card.untapped

--- a/forge-gui/res/cardsfolder/w/whirlwind_denial.txt
+++ b/forge-gui/res/cardsfolder/w/whirlwind_denial.txt
@@ -1,6 +1,6 @@
 Name:Whirlwind Denial
 ManaCost:2 U
 Types:Instant
-A:SP$ RepeatEach | Cost$ 2 U | RepeatSpellAbilities$ Card.OppCtrl,Spell.OppCtrl,Activated.OppCtrl,Triggered.OppCtrl | Zone$ Stack | RepeatSubAbility$ DBCounterUnless | SpellDescription$ For each spell and ability your opponents control, counter it unless its controller pays {4}.
+A:SP$ RepeatEach | Cost$ 2 U | RepeatSpellAbilities$ Spell.OppCtrl,Activated.OppCtrl,Triggered.OppCtrl | RepeatSubAbility$ DBCounterUnless | SpellDescription$ For each spell and ability your opponents control, counter it unless its controller pays {4}.
 SVar:DBCounterUnless:DB$ Counter | Defined$ Remembered | UnlessCost$ 4 | UnlessPayer$ RememberedController | StackDescription$ Counter {c:Remembered}
 Oracle:For each spell and ability your opponents control, counter it unless its controller pays {4}.


### PR DESCRIPTION
In some corner cases checking "first time" triggers from script calculation could fail (e.g. multiple life gain during resolve).

Closes #3198