### PR TITLE
Add music back to town events/draft scene

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/scene/DraftScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/DraftScene.java
@@ -3,6 +3,7 @@ package forge.adventure.scene;
 import forge.adventure.data.AdventureEventData;
 import forge.adventure.stage.GameHUD;
 import forge.screens.FScreen;
+import forge.sound.MusicPlaylist;
 import forge.sound.SoundSystem;
 
 /**
@@ -32,7 +33,8 @@ public class DraftScene extends ForgeScene {
     @Override
     public void enter() {
         GameHUD.getInstance().getTouchpad().setVisible(false);
-        SoundSystem.instance.pause();
+        GameHUD.getInstance().pauseMusic();
+        SoundSystem.instance.setBackgroundMusic(MusicPlaylist.MENUS);
         screen = null;
         getScreen();
         screen.refresh();

--- a/forge-gui-mobile/src/forge/adventure/scene/EventScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/EventScene.java
@@ -13,12 +13,14 @@ import forge.Forge;
 import forge.adventure.character.EnemySprite;
 import forge.adventure.data.*;
 import forge.adventure.player.AdventurePlayer;
+import forge.adventure.stage.GameHUD;
 import forge.adventure.stage.IAfterMatch;
 import forge.adventure.stage.WorldStage;
 import forge.adventure.util.*;
 import forge.adventure.world.WorldSave;
 import forge.gui.FThreads;
 import forge.screens.TransitionScreen;
+import forge.sound.MusicPlaylist;
 import forge.sound.SoundSystem;
 import forge.util.Callback;
 import forge.util.MyRandom;
@@ -378,7 +380,8 @@ public class EventScene extends MenuScene implements IAfterMatch {
     @Override
     public void enter() {
         super.enter();
-        SoundSystem.instance.pause();
+        GameHUD.getInstance().pauseMusic();
+        SoundSystem.instance.setBackgroundMusic(MusicPlaylist.MENUS);
         scrollContainer.clear();
 
         if (money != null) {

--- a/forge-gui-mobile/src/forge/adventure/scene/PlayerStatisticScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/PlayerStatisticScene.java
@@ -17,6 +17,7 @@ import forge.adventure.character.EnemySprite;
 import forge.adventure.data.EnemyData;
 import forge.adventure.data.WorldData;
 import forge.adventure.player.AdventurePlayer;
+import forge.adventure.stage.GameHUD;
 import forge.adventure.util.Config;
 import forge.adventure.util.Controls;
 import forge.adventure.util.Current;
@@ -31,6 +32,8 @@ import forge.localinstance.achievements.CardActivationAchievements;
 import forge.localinstance.achievements.PlaneswalkerAchievements;
 import forge.model.FModel;
 import forge.player.GamePlayerUtil;
+import forge.sound.MusicPlaylist;
+import forge.sound.SoundSystem;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Map;
@@ -186,6 +189,10 @@ public class PlayerStatisticScene extends UIScene {
     @Override
     public void enter() {
         super.enter();
+
+        GameHUD.getInstance().pauseMusic();
+        SoundSystem.instance.setBackgroundMusic(MusicPlaylist.MENUS);
+
         achievementContainer.clear();
         updateAchievements(cardActivation, true);
         updateAchievements(planeswalkers, true);


### PR DESCRIPTION
After the double music fix was implemented previously, the town event / draft screens went completely silent. This PR intends to add music back to those scenes without the "double music" effect. Not sure what music was originally intended for these screens, so for now, I'm using the Menus playlist for contrast against the normal Town playlist played in town as such.

Also fixes double music playback in the player stats screen.
