### PR TITLE
Update eomer_marshal_of_rohan.txt

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/eomer_marshal_of_rohan.txt
+++ b/forge-gui/res/cardsfolder/upcoming/eomer_marshal_of_rohan.txt
@@ -3,7 +3,7 @@ ManaCost:2 R R
 Types:Legendary Creature Human Knight
 PT:4/4
 K:Haste
-T:Mode$ ChangesZoneAll | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.attacking+Legendary+Other | TriggerZones$ Battlefield | Execute$ TrigUntapAll | ActivationLimit$ 1 | TriggerDescription$ Whenever one or more other attacking legendary creatures you control die, untap all creatures you control. After this phase, there is an additional combat phase. This ability triggers only once each turn.
+T:Mode$ ChangesZoneAll | Origin$ Battlefield | Destination$ Graveyard | ValidCards$ Creature.attackingLKI+Legendary+Other+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigUntapAll | ActivationLimit$ 1 | TriggerDescription$ Whenever one or more other attacking legendary creatures you control die, untap all creatures you control. After this phase, there is an additional combat phase. This ability triggers only once each turn.
 SVar:TrigUntapAll:DB$ UntapAll | ValidCards$ Creature.YouCtrl | SubAbility$ DBAddCombat
 SVar:DBAddCombat:DB$ AddPhase | ExtraPhase$ Combat | AfterPhase$ EndCombat
 DeckHints:Type$Legendary


### PR DESCRIPTION
Fixes bug where Eomer, Marshal of Rohan's triggered ability triggers upon any permanent being put into a graveyard, regardless of whether or not it was legendary, a creature, attacking, under your control, or other.