### PR TITLE
CardChangedType: use Enum Flags for removeAllSubTypes

### DIFF
--- a/forge-core/src/main/java/forge/card/CardChangedType.java
+++ b/forge-core/src/main/java/forge/card/CardChangedType.java
@@ -17,6 +17,8 @@
  */
 package forge.card;
 
+import java.util.Set;
+
 /**
  * <p>
  * CardType class.
@@ -26,31 +28,30 @@ package forge.card;
  * @version $Id: CardType.java 24393 2014-01-21 06:27:36Z Max mtg $
  */
 public class CardChangedType {
+
+    public enum Remove {
+        SuperTypes,
+        CardTypes,
+        SubTypes,
+        LandTypes,
+        CreatureTypes,
+        ArtifactTypes,
+        EnchantmentTypes,
+        ;
+    }
+
     // takes care of individual card types
     private final CardType addType;
     private final CardType removeType;
     private final boolean addAllCreatureTypes;
-    private final boolean removeSuperTypes;
-    private final boolean removeCardTypes;
-    private final boolean removeSubTypes;
-    private final boolean removeLandTypes;
-    private final boolean removeCreatureTypes;
-    private final boolean removeArtifactTypes;
-    private final boolean removeEnchantmentTypes;
+    private final Set<Remove> remove;
 
     public CardChangedType(final CardType addType0, final CardType removeType0, final boolean addAllCreatureTypes0,
-            final boolean removeSuperType0, final boolean removeCardType0, final boolean removeSubType0,
-            final boolean removeLandType0, final boolean removeCreatureType0, final boolean removeArtifactType0, final boolean removeEnchantmentTypes0) {
+            final Set<Remove> remove0) {
         addType = addType0;
         removeType = removeType0;
         addAllCreatureTypes = addAllCreatureTypes0;
-        removeSuperTypes = removeSuperType0;
-        removeCardTypes = removeCardType0;
-        removeSubTypes = removeSubType0;
-        removeLandTypes = removeLandType0;
-        removeCreatureTypes = removeCreatureType0;
-        removeArtifactTypes = removeArtifactType0;
-        removeEnchantmentTypes = removeEnchantmentTypes0;
+        remove = remove0;
     }
 
     public final CardType getAddType() {
@@ -66,30 +67,30 @@ public class CardChangedType {
     }
 
     public final boolean isRemoveSuperTypes() {
-        return removeSuperTypes;
+        return remove.contains(Remove.SuperTypes);
     }
 
     public final boolean isRemoveCardTypes() {
-        return removeCardTypes;
+        return remove.contains(Remove.CardTypes);
     }
 
     public final boolean isRemoveSubTypes() {
-        return removeSubTypes;
+        return remove.contains(Remove.SubTypes);
     }
 
     public final boolean isRemoveLandTypes() {
-        return removeLandTypes;
+        return remove.contains(Remove.LandTypes);
     }
 
     public final boolean isRemoveCreatureTypes() {
-        return removeCreatureTypes;
+        return remove.contains(Remove.CreatureTypes);
     }
 
     public final boolean isRemoveArtifactTypes() {
-        return removeArtifactTypes;
+        return remove.contains(Remove.ArtifactTypes);
     }
 
     public final boolean isRemoveEnchantmentTypes() {
-        return removeEnchantmentTypes;
+        return remove.contains(Remove.EnchantmentTypes);
     }
 }

--- a/forge-core/src/main/java/forge/card/CardChangedType.java
+++ b/forge-core/src/main/java/forge/card/CardChangedType.java
@@ -29,25 +29,14 @@ import java.util.Set;
  */
 public class CardChangedType {
 
-    public enum Remove {
-        SuperTypes,
-        CardTypes,
-        SubTypes,
-        LandTypes,
-        CreatureTypes,
-        ArtifactTypes,
-        EnchantmentTypes,
-        ;
-    }
-
     // takes care of individual card types
     private final CardType addType;
     private final CardType removeType;
     private final boolean addAllCreatureTypes;
-    private final Set<Remove> remove;
+    private final Set<RemoveType> remove;
 
     public CardChangedType(final CardType addType0, final CardType removeType0, final boolean addAllCreatureTypes0,
-            final Set<Remove> remove0) {
+            final Set<RemoveType> remove0) {
         addType = addType0;
         removeType = removeType0;
         addAllCreatureTypes = addAllCreatureTypes0;
@@ -67,30 +56,30 @@ public class CardChangedType {
     }
 
     public final boolean isRemoveSuperTypes() {
-        return remove.contains(Remove.SuperTypes);
+        return remove.contains(RemoveType.SuperTypes);
     }
 
     public final boolean isRemoveCardTypes() {
-        return remove.contains(Remove.CardTypes);
+        return remove.contains(RemoveType.CardTypes);
     }
 
     public final boolean isRemoveSubTypes() {
-        return remove.contains(Remove.SubTypes);
+        return remove.contains(RemoveType.SubTypes);
     }
 
     public final boolean isRemoveLandTypes() {
-        return remove.contains(Remove.LandTypes);
+        return remove.contains(RemoveType.LandTypes);
     }
 
     public final boolean isRemoveCreatureTypes() {
-        return remove.contains(Remove.CreatureTypes);
+        return remove.contains(RemoveType.CreatureTypes);
     }
 
     public final boolean isRemoveArtifactTypes() {
-        return remove.contains(Remove.ArtifactTypes);
+        return remove.contains(RemoveType.ArtifactTypes);
     }
 
     public final boolean isRemoveEnchantmentTypes() {
-        return remove.contains(Remove.EnchantmentTypes);
+        return remove.contains(RemoveType.EnchantmentTypes);
     }
 }

--- a/forge-core/src/main/java/forge/card/RemoveType.java
+++ b/forge-core/src/main/java/forge/card/RemoveType.java
@@ -1,0 +1,12 @@
+package forge.card;
+
+public enum RemoveType {
+    SuperTypes,
+    CardTypes,
+    SubTypes,
+    LandTypes,
+    CreatureTypes,
+    ArtifactTypes,
+    EnchantmentTypes,
+    ;
+}

--- a/forge-game/src/main/java/forge/game/ability/effects/AmassEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/AmassEffect.java
@@ -9,8 +9,8 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
-import forge.card.CardChangedType;
 import forge.card.CardType;
+import forge.card.RemoveType;
 import forge.game.Game;
 import forge.game.GameEntityCounterTable;
 import forge.game.ability.AbilityUtils;
@@ -106,7 +106,7 @@ public class AmassEffect extends TokenEffectBase {
         // change type after counters
         long ts = game.getNextTimestamp();
         for (final Card tgtCard : tgtCards) {
-            tgtCard.addChangedCardTypes(CardType.parse(type, true), null, false, EnumSet.noneOf(CardChangedType.Remove.class), ts, 0, true, false);
+            tgtCard.addChangedCardTypes(CardType.parse(type, true), null, false, EnumSet.noneOf(RemoveType.class), ts, 0, true, false);
         }
     }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/AmassEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/AmassEffect.java
@@ -1,5 +1,6 @@
 package forge.game.ability.effects;
 
+import java.util.EnumSet;
 import java.util.Map;
 
 import org.apache.commons.lang3.mutable.MutableBoolean;
@@ -8,6 +9,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import forge.card.CardChangedType;
 import forge.card.CardType;
 import forge.game.Game;
 import forge.game.GameEntityCounterTable;
@@ -104,7 +106,7 @@ public class AmassEffect extends TokenEffectBase {
         // change type after counters
         long ts = game.getNextTimestamp();
         for (final Card tgtCard : tgtCards) {
-            tgtCard.addChangedCardTypes(CardType.parse(type, true), null, false, false, false, false, false, false, false, false, ts, 0, true, false);
+            tgtCard.addChangedCardTypes(CardType.parse(type, true), null, false, EnumSet.noneOf(CardChangedType.Remove.class), ts, 0, true, false);
         }
     }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/AnimateEffectBase.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/AnimateEffectBase.java
@@ -17,11 +17,14 @@
  */
 package forge.game.ability.effects;
 
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 import com.google.common.collect.Lists;
 
 import forge.GameCommand;
+import forge.card.CardChangedType;
 import forge.card.CardType;
 import forge.card.ColorSet;
 import forge.card.mana.ManaCost;
@@ -51,13 +54,23 @@ public abstract class AnimateEffectBase extends SpellAbilityEffect {
         final Game game = source.getGame();
 
         boolean addAllCreatureTypes = sa.hasParam("AddAllCreatureTypes");
-        boolean removeSuperTypes = sa.hasParam("RemoveSuperTypes");
-        boolean removeCardTypes = sa.hasParam("RemoveCardTypes");
-        boolean removeSubTypes = sa.hasParam("RemoveSubTypes");
-        boolean removeLandTypes = sa.hasParam("RemoveLandTypes");
-        boolean removeCreatureTypes = sa.hasParam("RemoveCreatureTypes");
-        boolean removeArtifactTypes = sa.hasParam("RemoveArtifactTypes");
-        boolean removeEnchantmentTypes = sa.hasParam("RemoveEnchantmentTypes");
+
+        Set<CardChangedType.Remove> remove = EnumSet.noneOf(CardChangedType.Remove.class);
+        if (sa.hasParam("RemoveSuperTypes"))
+            remove.add(CardChangedType.Remove.SuperTypes);
+        if (sa.hasParam("RemoveCardTypes"))
+            remove.add(CardChangedType.Remove.CardTypes);
+        if (sa.hasParam("RemoveSubTypes"))
+            remove.add(CardChangedType.Remove.SubTypes);
+        if (sa.hasParam("RemoveLandTypes"))
+            remove.add(CardChangedType.Remove.LandTypes);
+        if (sa.hasParam("RemoveCreatureTypes"))
+            remove.add(CardChangedType.Remove.CreatureTypes);
+        if (sa.hasParam("RemoveArtifactTypes"))
+            remove.add(CardChangedType.Remove.ArtifactTypes);
+        if (sa.hasParam("RemoveEnchantmentTypes"))
+            remove.add(CardChangedType.Remove.EnchantmentTypes);
+
         boolean removeNonManaAbilities = sa.hasParam("RemoveNonManaAbilities");
         boolean removeAll = sa.hasParam("RemoveAllAbilities");
 
@@ -65,10 +78,8 @@ public abstract class AnimateEffectBase extends SpellAbilityEffect {
             source.addRemembered(c);
         }
 
-        if (!addType.isEmpty() || !removeType.isEmpty() || addAllCreatureTypes || removeSuperTypes
-                || removeCardTypes || removeSubTypes || removeLandTypes || removeCreatureTypes || removeArtifactTypes || removeEnchantmentTypes) {
-            c.addChangedCardTypes(addType, removeType, addAllCreatureTypes, removeSuperTypes, removeCardTypes, removeSubTypes,
-                    removeLandTypes, removeCreatureTypes, removeArtifactTypes, removeEnchantmentTypes, timestamp, 0, true, false);
+        if (!addType.isEmpty() || !removeType.isEmpty() || addAllCreatureTypes || !remove.isEmpty()) {
+            c.addChangedCardTypes(addType, removeType, addAllCreatureTypes, remove, timestamp, 0, true, false);
         }
 
         c.addChangedCardKeywords(keywords, removeKeywords, removeAll, timestamp, 0);
@@ -167,7 +178,7 @@ public abstract class AnimateEffectBase extends SpellAbilityEffect {
         }
 
         // after unanimate to add RevertCost
-        if (removeAll || removeLandTypes
+        if (removeAll || removeNonManaAbilities
                 || !addedAbilities.isEmpty() || !removedAbilities.isEmpty() || !addedTriggers.isEmpty()
                 || !addedReplacements.isEmpty() || !addedStaticAbilities.isEmpty()) {
             c.addChangedCardTraits(addedAbilities, removedAbilities, addedTriggers, addedReplacements,

--- a/forge-game/src/main/java/forge/game/ability/effects/AnimateEffectBase.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/AnimateEffectBase.java
@@ -24,9 +24,9 @@ import java.util.Set;
 import com.google.common.collect.Lists;
 
 import forge.GameCommand;
-import forge.card.CardChangedType;
 import forge.card.CardType;
 import forge.card.ColorSet;
+import forge.card.RemoveType;
 import forge.card.mana.ManaCost;
 import forge.card.mana.ManaCostParser;
 import forge.game.Game;
@@ -55,21 +55,21 @@ public abstract class AnimateEffectBase extends SpellAbilityEffect {
 
         boolean addAllCreatureTypes = sa.hasParam("AddAllCreatureTypes");
 
-        Set<CardChangedType.Remove> remove = EnumSet.noneOf(CardChangedType.Remove.class);
+        Set<RemoveType> remove = EnumSet.noneOf(RemoveType.class);
         if (sa.hasParam("RemoveSuperTypes"))
-            remove.add(CardChangedType.Remove.SuperTypes);
+            remove.add(RemoveType.SuperTypes);
         if (sa.hasParam("RemoveCardTypes"))
-            remove.add(CardChangedType.Remove.CardTypes);
+            remove.add(RemoveType.CardTypes);
         if (sa.hasParam("RemoveSubTypes"))
-            remove.add(CardChangedType.Remove.SubTypes);
+            remove.add(RemoveType.SubTypes);
         if (sa.hasParam("RemoveLandTypes"))
-            remove.add(CardChangedType.Remove.LandTypes);
+            remove.add(RemoveType.LandTypes);
         if (sa.hasParam("RemoveCreatureTypes"))
-            remove.add(CardChangedType.Remove.CreatureTypes);
+            remove.add(RemoveType.CreatureTypes);
         if (sa.hasParam("RemoveArtifactTypes"))
-            remove.add(CardChangedType.Remove.ArtifactTypes);
+            remove.add(RemoveType.ArtifactTypes);
         if (sa.hasParam("RemoveEnchantmentTypes"))
-            remove.add(CardChangedType.Remove.EnchantmentTypes);
+            remove.add(RemoveType.EnchantmentTypes);
 
         boolean removeNonManaAbilities = sa.hasParam("RemoveNonManaAbilities");
         boolean removeAll = sa.hasParam("RemoveAllAbilities");

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -1505,7 +1505,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
             counterTypeTimestamps.put(counterType, timestamp);
             // becomes land in instead of other card types
             addChangedCardTypes(new CardType(ImmutableList.of("Land"), false), null, false,
-                    EnumSet.of(CardChangedType.Remove.CardTypes, CardChangedType.Remove.SubTypes),
+                    EnumSet.of(RemoveType.CardTypes, RemoveType.SubTypes),
                     timestamp, 0, updateView, false);
 
             String abStr = "AB$ ManaReflected | Cost$ T | Valid$ Defined.Self | ColorOrType$ Color | ReflectProperty$ Is | SpellDescription$ Add one mana of any of this card's colors.";
@@ -3729,7 +3729,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
             long ts = getGame().getNextTimestamp();
             // 702.151b Attaching an Equipment with reconfigure to another creature causes the Equipment to stop being a creature until it becomes unattached from that creature.
             // it is not a Static Ability
-            addChangedCardTypes(null, CardType.parse("Creature", true), false, EnumSet.noneOf(CardChangedType.Remove.class), ts, 0, true, false);
+            addChangedCardTypes(null, CardType.parse("Creature", true), false, EnumSet.noneOf(RemoveType.class), ts, 0, true, false);
 
             GameCommand unattach = new GameCommand() {
                 private static final long serialVersionUID = 1L;
@@ -3917,9 +3917,9 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
 
     public final void addChangedCardTypesByText(final CardType addType, final long timestamp, final long staticId, final boolean updateView) {
         changedCardTypesByText.put(timestamp, staticId, new CardChangedType(addType, null, false,
-                EnumSet.of(CardChangedType.Remove.SuperTypes,
-                        CardChangedType.Remove.CardTypes,
-                        CardChangedType.Remove.SubTypes)));
+                EnumSet.of(RemoveType.SuperTypes,
+                        RemoveType.CardTypes,
+                        RemoveType.SubTypes)));
 
         // setting card type via text, does overwrite any other word change effects?
         this.changedTextColors.addEmpty(timestamp, staticId);
@@ -3931,7 +3931,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
     }
 
     public final void addChangedCardTypes(final CardType addType, final CardType removeType, final boolean addAllCreatureTypes,
-            final Set<CardChangedType.Remove> remove,
+            final Set<RemoveType> remove,
             final long timestamp, final long staticId, final boolean updateView, final boolean cda) {
         (cda ? changedCardTypesCharacterDefining : changedCardTypes).put(timestamp, staticId, new CardChangedType(
                 addType, removeType, addAllCreatureTypes, remove));
@@ -3941,7 +3941,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
     }
 
     public final void addChangedCardTypes(final Iterable<String> types, final Iterable<String> removeTypes, final boolean addAllCreatureTypes,
-            final Set<CardChangedType.Remove> remove,
+            final Set<RemoveType> remove,
             final long timestamp, final long staticId, final boolean updateView, final boolean cda) {
         CardType addType = null;
         CardType removeType = null;
@@ -4855,7 +4855,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
             }
         }
 
-        this.changedTypeByText = new CardChangedType(new CardType(toAdd, true), new CardType(toRemove, true), false, EnumSet.noneOf(CardChangedType.Remove.class));
+        this.changedTypeByText = new CardChangedType(new CardType(toAdd, true), new CardType(toRemove, true), false, EnumSet.noneOf(RemoveType.class));
 
         currentState.updateChangedText();
 
@@ -6068,7 +6068,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
         bestowTimestamp = getGame().getNextTimestamp();
         addChangedCardTypes(new CardType(Collections.singletonList("Aura"), true),
                 new CardType(Collections.singletonList("Creature"), true),
-                false, EnumSet.of(CardChangedType.Remove.EnchantmentTypes), bestowTimestamp, 0, updateView, false);
+                false, EnumSet.of(RemoveType.EnchantmentTypes), bestowTimestamp, 0, updateView, false);
         addChangedCardKeywords(Collections.singletonList("Enchant creature"), Lists.newArrayList(),
                 false, bestowTimestamp, 0, updateView);
     }

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -1504,7 +1504,9 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
             long timestamp = game.getNextTimestamp();
             counterTypeTimestamps.put(counterType, timestamp);
             // becomes land in instead of other card types
-            addChangedCardTypes(new CardType(ImmutableList.of("Land"), false), null, false, false, true, true, false, false, false, false, timestamp, 0, updateView, false);
+            addChangedCardTypes(new CardType(ImmutableList.of("Land"), false), null, false,
+                    EnumSet.of(CardChangedType.Remove.CardTypes, CardChangedType.Remove.SubTypes),
+                    timestamp, 0, updateView, false);
 
             String abStr = "AB$ ManaReflected | Cost$ T | Valid$ Defined.Self | ColorOrType$ Color | ReflectProperty$ Is | SpellDescription$ Add one mana of any of this card's colors.";
 
@@ -3727,7 +3729,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
             long ts = getGame().getNextTimestamp();
             // 702.151b Attaching an Equipment with reconfigure to another creature causes the Equipment to stop being a creature until it becomes unattached from that creature.
             // it is not a Static Ability
-            addChangedCardTypes(null, CardType.parse("Creature", true), false, false, false, false, false, false, false, false, ts, 0, true, false);
+            addChangedCardTypes(null, CardType.parse("Creature", true), false, EnumSet.noneOf(CardChangedType.Remove.class), ts, 0, true, false);
 
             GameCommand unattach = new GameCommand() {
                 private static final long serialVersionUID = 1L;
@@ -3914,7 +3916,10 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
     }
 
     public final void addChangedCardTypesByText(final CardType addType, final long timestamp, final long staticId, final boolean updateView) {
-        changedCardTypesByText.put(timestamp, staticId, new CardChangedType(addType, null, false, true, true, true, false, false, false, false));
+        changedCardTypesByText.put(timestamp, staticId, new CardChangedType(addType, null, false,
+                EnumSet.of(CardChangedType.Remove.SuperTypes,
+                        CardChangedType.Remove.CardTypes,
+                        CardChangedType.Remove.SubTypes)));
 
         // setting card type via text, does overwrite any other word change effects?
         this.changedTextColors.addEmpty(timestamp, staticId);
@@ -3926,22 +3931,17 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
     }
 
     public final void addChangedCardTypes(final CardType addType, final CardType removeType, final boolean addAllCreatureTypes,
-            final boolean removeSuperTypes, final boolean removeCardTypes, final boolean removeSubTypes,
-            final boolean removeLandTypes, final boolean removeCreatureTypes, final boolean removeArtifactTypes,
-            final boolean removeEnchantmentTypes,
+            final Set<CardChangedType.Remove> remove,
             final long timestamp, final long staticId, final boolean updateView, final boolean cda) {
         (cda ? changedCardTypesCharacterDefining : changedCardTypes).put(timestamp, staticId, new CardChangedType(
-                addType, removeType, addAllCreatureTypes, removeSuperTypes, removeCardTypes, removeSubTypes,
-                removeLandTypes, removeCreatureTypes, removeArtifactTypes, removeEnchantmentTypes));
+                addType, removeType, addAllCreatureTypes, remove));
         if (updateView) {
             updateTypesForView();
         }
     }
 
     public final void addChangedCardTypes(final Iterable<String> types, final Iterable<String> removeTypes, final boolean addAllCreatureTypes,
-            final boolean removeSuperTypes, final boolean removeCardTypes, final boolean removeSubTypes,
-            final boolean removeLandTypes, final boolean removeCreatureTypes, final boolean removeArtifactTypes,
-            final boolean removeEnchantmentTypes,
+            final Set<CardChangedType.Remove> remove,
             final long timestamp, final long staticId, final boolean updateView, final boolean cda) {
         CardType addType = null;
         CardType removeType = null;
@@ -3953,9 +3953,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
             removeType = new CardType(removeTypes, true);
         }
 
-        addChangedCardTypes(addType, removeType, addAllCreatureTypes, removeSuperTypes, removeCardTypes, removeSubTypes,
-                removeLandTypes, removeCreatureTypes, removeArtifactTypes, removeEnchantmentTypes,
-                timestamp, staticId, updateView, cda);
+        addChangedCardTypes(addType, removeType, addAllCreatureTypes, remove, timestamp, staticId, updateView, cda);
     }
 
     public final void removeChangedCardTypes(final long timestamp, final long staticId) {
@@ -4857,7 +4855,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
             }
         }
 
-        this.changedTypeByText = new CardChangedType(new CardType(toAdd, true), new CardType(toRemove, true), false, false, false, false, false, false, false, false);
+        this.changedTypeByText = new CardChangedType(new CardType(toAdd, true), new CardType(toRemove, true), false, EnumSet.noneOf(CardChangedType.Remove.class));
 
         currentState.updateChangedText();
 
@@ -6070,7 +6068,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
         bestowTimestamp = getGame().getNextTimestamp();
         addChangedCardTypes(new CardType(Collections.singletonList("Aura"), true),
                 new CardType(Collections.singletonList("Creature"), true),
-                false, false, false, false, false, false, false, true, bestowTimestamp, 0, updateView, false);
+                false, EnumSet.of(CardChangedType.Remove.EnchantmentTypes), bestowTimestamp, 0, updateView, false);
         addChangedCardKeywords(Collections.singletonList("Enchant creature"), Lists.newArrayList(),
                 false, bestowTimestamp, 0, updateView);
     }

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
@@ -19,6 +19,7 @@ package forge.game.staticability;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -33,6 +34,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import forge.GameCommand;
+import forge.card.CardChangedType;
 import forge.card.CardStateName;
 import forge.card.CardType;
 import forge.card.ColorSet;
@@ -146,13 +148,7 @@ public final class StaticAbilityContinuous {
         boolean removeAllAbilities = false;
         boolean removeNonMana = false;
         boolean addAllCreatureTypes = false;
-        boolean removeSuperTypes = false;
-        boolean removeCardTypes = false;
-        boolean removeSubTypes = false;
-        boolean removeLandTypes = false;
-        boolean removeCreatureTypes = false;
-        boolean removeArtifactTypes = false;
-        boolean removeEnchantmentTypes = false;
+        Set<CardChangedType.Remove> remove = EnumSet.noneOf(CardChangedType.Remove.class);
 
         boolean overwriteColors = false;
 
@@ -453,25 +449,25 @@ public final class StaticAbilityContinuous {
                 addAllCreatureTypes = true;
             }
             if (params.containsKey("RemoveSuperTypes")) {
-                removeSuperTypes = true;
+                remove.add(CardChangedType.Remove.SuperTypes);
             }
             if (params.containsKey("RemoveCardTypes")) {
-                removeCardTypes = true;
+                remove.add(CardChangedType.Remove.CardTypes);
             }
             if (params.containsKey("RemoveSubTypes")) {
-                removeSubTypes = true;
+                remove.add(CardChangedType.Remove.SubTypes);
             }
             if (params.containsKey("RemoveLandTypes")) {
-                removeLandTypes = true;
+                remove.add(CardChangedType.Remove.LandTypes);
             }
             if (params.containsKey("RemoveCreatureTypes")) {
-                removeCreatureTypes = true;
+                remove.add(CardChangedType.Remove.CreatureTypes);
             }
             if (params.containsKey("RemoveArtifactTypes")) {
-                removeArtifactTypes = true;
+                remove.add(CardChangedType.Remove.ArtifactTypes);
             }
             if (params.containsKey("RemoveEnchantmentTypes")) {
-                removeEnchantmentTypes = true;
+                remove.add(CardChangedType.Remove.EnchantmentTypes);
             }
         }
 
@@ -915,9 +911,8 @@ public final class StaticAbilityContinuous {
 
             // add Types
             if (addTypes != null || removeTypes != null || addAllCreatureTypes
-                    || removeSuperTypes || removeCardTypes || removeLandTypes || removeCreatureTypes || removeArtifactTypes || removeEnchantmentTypes) {
-                affectedCard.addChangedCardTypes(addTypes, removeTypes, addAllCreatureTypes, removeSuperTypes, removeCardTypes, removeSubTypes,
-                        removeLandTypes, removeCreatureTypes, removeArtifactTypes, removeEnchantmentTypes,
+                    || !remove.isEmpty()) {
+                affectedCard.addChangedCardTypes(addTypes, removeTypes, addAllCreatureTypes, remove,
                         hostCard.getTimestamp(), stAb.getId(), true, stAb.hasParam("CharacteristicDefining"));
             }
 

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
@@ -34,11 +34,11 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import forge.GameCommand;
-import forge.card.CardChangedType;
 import forge.card.CardStateName;
 import forge.card.CardType;
 import forge.card.ColorSet;
 import forge.card.MagicColor;
+import forge.card.RemoveType;
 import forge.game.Game;
 import forge.game.GlobalRuleChange;
 import forge.game.StaticEffect;
@@ -148,7 +148,7 @@ public final class StaticAbilityContinuous {
         boolean removeAllAbilities = false;
         boolean removeNonMana = false;
         boolean addAllCreatureTypes = false;
-        Set<CardChangedType.Remove> remove = EnumSet.noneOf(CardChangedType.Remove.class);
+        Set<RemoveType> remove = EnumSet.noneOf(RemoveType.class);
 
         boolean overwriteColors = false;
 
@@ -449,25 +449,25 @@ public final class StaticAbilityContinuous {
                 addAllCreatureTypes = true;
             }
             if (params.containsKey("RemoveSuperTypes")) {
-                remove.add(CardChangedType.Remove.SuperTypes);
+                remove.add(RemoveType.SuperTypes);
             }
             if (params.containsKey("RemoveCardTypes")) {
-                remove.add(CardChangedType.Remove.CardTypes);
+                remove.add(RemoveType.CardTypes);
             }
             if (params.containsKey("RemoveSubTypes")) {
-                remove.add(CardChangedType.Remove.SubTypes);
+                remove.add(RemoveType.SubTypes);
             }
             if (params.containsKey("RemoveLandTypes")) {
-                remove.add(CardChangedType.Remove.LandTypes);
+                remove.add(RemoveType.LandTypes);
             }
             if (params.containsKey("RemoveCreatureTypes")) {
-                remove.add(CardChangedType.Remove.CreatureTypes);
+                remove.add(RemoveType.CreatureTypes);
             }
             if (params.containsKey("RemoveArtifactTypes")) {
-                remove.add(CardChangedType.Remove.ArtifactTypes);
+                remove.add(RemoveType.ArtifactTypes);
             }
             if (params.containsKey("RemoveEnchantmentTypes")) {
-                remove.add(CardChangedType.Remove.EnchantmentTypes);
+                remove.add(RemoveType.EnchantmentTypes);
             }
         }
 


### PR DESCRIPTION
Closes #3223 

Maybe First part or first draft?

Currently it is just Internal Flags without Changing the Card Scripts

More Opinions about this?

- [x] Should the Enum be its own file, ~~or is `CardChangedType.Remove` okay~~?

Should we update the `RemoveLandTypes` params to be something like `RemoveAllTypes$ Land` ?