### PR TITLE
AI: Account for transformable cards (e.g. Incubator tokens) when considering defenders

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiAttackController.java
+++ b/forge-ai/src/main/java/forge/ai/AiAttackController.java
@@ -153,7 +153,9 @@ public class AiAttackController {
                         && sa.getRestrictions().checkOtherRestrictions(c, sa, defender)) {
                     Card transformedCopy = CardUtil.getLKICopy(c);
                     transformedCopy.setState(CardStateName.Transformed, false);
-                    defenders.add(transformedCopy);
+                    if (transformedCopy.isCreature()) {
+                        defenders.add(transformedCopy);
+                    }
                 }
             }
         }

--- a/forge-ai/src/main/java/forge/ai/AiAttackController.java
+++ b/forge-ai/src/main/java/forge/ai/AiAttackController.java
@@ -17,28 +17,17 @@
  */
 package forge.ai;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-
-import forge.card.CardStateName;
-import forge.game.card.*;
-import forge.game.staticability.StaticAbility;
-import forge.game.staticability.StaticAbilityAssignCombatDamageAsUnblocked;
-import org.apache.commons.lang3.tuple.Pair;
-
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-
 import forge.ai.ability.AnimateAi;
 import forge.card.CardTypeView;
 import forge.game.GameEntity;
 import forge.game.ability.AbilityUtils;
 import forge.game.ability.ApiType;
 import forge.game.ability.effects.ProtectEffect;
+import forge.game.card.*;
 import forge.game.combat.Combat;
 import forge.game.combat.CombatUtil;
 import forge.game.combat.GlobalAttackRestrictions;
@@ -48,6 +37,8 @@ import forge.game.player.Player;
 import forge.game.player.PlayerCollection;
 import forge.game.spellability.SpellAbility;
 import forge.game.spellability.SpellAbilityPredicates;
+import forge.game.staticability.StaticAbility;
+import forge.game.staticability.StaticAbilityAssignCombatDamageAsUnblocked;
 import forge.game.trigger.Trigger;
 import forge.game.trigger.TriggerType;
 import forge.game.zone.Zone;
@@ -57,6 +48,12 @@ import forge.util.Expressions;
 import forge.util.MyRandom;
 import forge.util.collect.FCollection;
 import forge.util.collect.FCollectionView;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 
 
 /**
@@ -137,9 +134,11 @@ public class AiAttackController {
             }
         };
         for (Card c : CardLists.filter(defender.getCardsIn(ZoneType.Battlefield), canAnimate)) {
+            /* TODO: is the commented out code still necessary for anything?
             if (c.isToken() && c.getCopiedPermanent() == null && !c.canTransform(null)) {
                 continue;
             }
+            */
             for (SpellAbility sa : Iterables.filter(c.getSpellAbilities(), SpellAbilityPredicates.isApi(ApiType.Animate))) {
                 if (ComputerUtilCost.canPayCost(sa, defender, false)
                         && sa.getRestrictions().checkOtherRestrictions(c, sa, defender)) {
@@ -149,13 +148,9 @@ public class AiAttackController {
             }
             // Transform (e.g. Incubator tokens)
             for (SpellAbility sa : Iterables.filter(c.getSpellAbilities(), SpellAbilityPredicates.isApi(ApiType.SetState))) {
-                if ("Transform".equals(sa.getParam("Mode")) && ComputerUtilCost.canPayCost(sa, defender, false)
-                        && sa.getRestrictions().checkOtherRestrictions(c, sa, defender)) {
-                    Card transformedCopy = CardUtil.getLKICopy(c);
-                    transformedCopy.setState(CardStateName.Transformed, false);
-                    if (transformedCopy.isCreature()) {
+                Card transformedCopy = ComputerUtilCombat.canTransform(c);
+                if (transformedCopy.isCreature()) {
                         defenders.add(transformedCopy);
-                    }
                 }
             }
         }

--- a/forge-ai/src/main/java/forge/ai/AiAttackController.java
+++ b/forge-ai/src/main/java/forge/ai/AiAttackController.java
@@ -150,7 +150,7 @@ public class AiAttackController {
             for (SpellAbility sa : Iterables.filter(c.getSpellAbilities(), SpellAbilityPredicates.isApi(ApiType.SetState))) {
                 Card transformedCopy = ComputerUtilCombat.canTransform(c);
                 if (transformedCopy.isCreature()) {
-                        defenders.add(transformedCopy);
+                    defenders.add(transformedCopy);
                 }
             }
         }

--- a/forge-ai/src/main/java/forge/ai/AiAttackController.java
+++ b/forge-ai/src/main/java/forge/ai/AiAttackController.java
@@ -127,6 +127,8 @@ public class AiAttackController {
 
     public static List<Card> getOpponentCreatures(final Player defender) {
         List<Card> defenders = defender.getCreaturesInPlay();
+        int totalMana = ComputerUtilMana.getAvailableManaEstimate(defender, true);
+        int manaReserved = 0; // for paying the cost to transform
         Predicate<Card> canAnimate = new Predicate<Card>() {
             @Override
             public boolean apply(Card c) {
@@ -150,7 +152,11 @@ public class AiAttackController {
             for (SpellAbility sa : Iterables.filter(c.getSpellAbilities(), SpellAbilityPredicates.isApi(ApiType.SetState))) {
                 Card transformedCopy = ComputerUtilCombat.canTransform(c);
                 if (transformedCopy.isCreature()) {
-                    defenders.add(transformedCopy);
+                    int saCMC = sa.getPayCosts().getTotalMana().getCMC(); // FIXME: imprecise, only works 100% for colorless mana
+                    if (totalMana - manaReserved >= saCMC) {
+                        manaReserved += saCMC;
+                        defenders.add(transformedCopy);
+                    }
                 }
             }
         }

--- a/forge-ai/src/main/java/forge/ai/AiAttackController.java
+++ b/forge-ai/src/main/java/forge/ai/AiAttackController.java
@@ -145,14 +145,20 @@ public class AiAttackController {
                 if (ComputerUtilCost.canPayCost(sa, defender, false)
                         && sa.getRestrictions().checkOtherRestrictions(c, sa, defender)) {
                     Card animatedCopy = AnimateAi.becomeAnimated(c, sa);
-                    defenders.add(animatedCopy);
+                    int saCMC = sa.getPayCosts() != null && sa.getPayCosts().hasManaCost() ?
+                            sa.getPayCosts().getTotalMana().getCMC() : 0; // FIXME: imprecise, only works 100% for colorless mana
+                    if (totalMana - manaReserved >= saCMC) {
+                        manaReserved += saCMC;
+                        defenders.add(animatedCopy);
+                    }
                 }
             }
             // Transform (e.g. Incubator tokens)
             for (SpellAbility sa : Iterables.filter(c.getSpellAbilities(), SpellAbilityPredicates.isApi(ApiType.SetState))) {
                 Card transformedCopy = ComputerUtilCombat.canTransform(c);
                 if (transformedCopy.isCreature()) {
-                    int saCMC = sa.getPayCosts().getTotalMana().getCMC(); // FIXME: imprecise, only works 100% for colorless mana
+                    int saCMC = sa.getPayCosts() != null && sa.getPayCosts().hasManaCost() ?
+                            sa.getPayCosts().getTotalMana().getCMC() : 0; // FIXME: imprecise, only works 100% for colorless mana
                     if (totalMana - manaReserved >= saCMC) {
                         manaReserved += saCMC;
                         defenders.add(transformedCopy);

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCombat.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCombat.java
@@ -2307,7 +2307,7 @@ public class ComputerUtilCombat {
      * @param original original creature
      * @return transform creature if possible, original creature otherwise
      */
-    private final static Card canTransform(Card original) {
+    public final static Card canTransform(Card original) {
         if (original.isTransformable() && !original.isInAlternateState()) {
             for (SpellAbility sa : original.getSpellAbilities()) {
                 if (sa.getApi() == ApiType.SetState && ComputerUtilCost.canPayCost(sa, original.getController(), false)) {


### PR DESCRIPTION
Fixes #3061 .

The code at AiAttackController.java:140-141 originally skipped all checks for tokens in this manner (probably for speed?) I currently made an exclusion to consider transformable tokens such as Incubator stuff, is that a viable solution? :/