### PR TITLE
Phyrexian Server Request Implementation

### DIFF
--- a/forge-gui/res/adventure/Shandalar/world/enemies.json
+++ b/forge-gui/res/adventure/Shandalar/world/enemies.json
@@ -4421,7 +4421,8 @@
 			"count": 1,
 			"addMaxCount": 2,
 			"rarity": [
-				"rare"
+				"rare",
+				"mythicrare"
 			],
 			"cardTypes": [
 				"Creature",
@@ -4499,7 +4500,8 @@
 			"count": 1,
 			"addMaxCount": 1,
 			"rarity": [
-				"rare"
+				"rare",
+				"mythicrare"
 			],
 			"cardTypes": [
 				"Creature",
@@ -5892,7 +5894,8 @@
 			"count": 1,
 			"addMaxCount": 1,
 			"rarity": [
-				"rare"
+				"rare",
+				"mythicrare"
 			],
 			"cardTypes": [
 				"Creature",
@@ -5971,7 +5974,8 @@
 			"count": 1,
 			"addMaxCount": 2,
 			"rarity": [
-				"rare"
+				"rare",
+				"mythicrare"
 			],
 			"cardTypes": [
 				"Creature",
@@ -7979,7 +7983,8 @@
 			"count": 1,
 			"addMaxCount": 1,
 			"rarity": [
-				"rare"
+				"rare",
+				"mythicrare"
 			],
 			"cardTypes": [
 				"Creature",
@@ -8058,7 +8063,8 @@
 			"count": 1,
 			"addMaxCount": 2,
 			"rarity": [
-				"rare"
+				"rare",
+				"mythicrare"
 			],
 			"cardTypes": [
 				"Creature",
@@ -8740,7 +8746,8 @@
 			"count": 1,
 			"addMaxCount": 2,
 			"rarity": [
-				"rare"
+				"rare",
+				"mythicrare"
 			],
 			"cardTypes": [
 				"Creature",
@@ -8822,7 +8829,8 @@
 			"count": 1,
 			"addMaxCount": 1,
 			"rarity": [
-				"rare"
+				"rare",
+				"mythicrare"
 			],
 			"cardTypes": [
 				"Creature",
@@ -15539,7 +15547,8 @@
 			"count": 1,
 			"addMaxCount": 2,
 			"rarity": [
-				"rare"
+				"rare",
+				"mythicrare"
 			],
 			"cardTypes": [
 				"Creature",
@@ -15619,7 +15628,8 @@
 			"count": 1,
 			"addMaxCount": 1,
 			"rarity": [
-				"rare"
+				"rare",
+				"mythicrare"
 			],
 			"cardTypes": [
 				"Creature",

--- a/forge-gui/res/adventure/Shandalar/world/shops.json
+++ b/forge-gui/res/adventure/Shandalar/world/shops.json
@@ -5105,7 +5105,7 @@
 		},
 		{
 		  "count":1,
-		  "cardText": "infect|oil|proliferate|incubate|toxic|corrupted|phyrexian|poison|living weapon|for mirrodin"
+		  "cardText": "infect|oil|proliferate|incubate|toxic|corrupted|phyrexian|poison|living weapon|for mirrodin|compleated"
 		}
 	  ]
 	}]
@@ -5128,7 +5128,7 @@
 	{
 		"count":1,
 		"colors":["white"],
-		"cardText": "infect|oil|proliferate|incubate|toxic|corrupted|phyrexian|poison|living weapon"
+		"cardText": "infect|oil|proliferate|incubate|toxic|corrupted|phyrexian|poison|living weapon|compleated"
 	}]},
 	{
 		"count":3,
@@ -5140,7 +5140,7 @@
 		},
 		{
 		"count":1,
-		"cardText": "infect|oil|proliferate|incubate|toxic|corrupted|phyrexian|poison|living weapon"
+		"cardText": "infect|oil|proliferate|incubate|toxic|corrupted|phyrexian|poison|living weapon|compleated"
 		}
 	]}]},
 {                                    
@@ -5161,7 +5161,7 @@
 	{
 		"count":1,
 		"colors":["blue"],
-		"cardText": "infect|oil|proliferate|incubate|toxic|corrupted|phyrexian|poison|living weapon"
+		"cardText": "infect|oil|proliferate|incubate|toxic|corrupted|phyrexian|poison|living weapon|compleated"
 	}]},
 	{
 		"count":3,
@@ -5173,7 +5173,7 @@
 		},
 		{
 		"count":1,
-		"cardText": "infect|oil|proliferate|incubate|toxic|corrupted|phyrexian|poison|living weapon"
+		"cardText": "infect|oil|proliferate|incubate|toxic|corrupted|phyrexian|poison|living weapon|compleated"
 		}
 	]}]},
 {                                    
@@ -5194,7 +5194,7 @@
 	{
 		"count":1,
 		"colors":["green"],
-		"cardText": "infect|oil|proliferate|incubate|toxic|corrupted|phyrexian|poison|living weapon"
+		"cardText": "infect|oil|proliferate|incubate|toxic|corrupted|phyrexian|poison|living weapon|compleated"
 	}]},
 	{
 		"count":3,
@@ -5206,7 +5206,7 @@
 		},
 		{
 		"count":1,
-		"cardText": "infect|oil|proliferate|incubate|toxic|corrupted|phyrexian|poison|living weapon"
+		"cardText": "infect|oil|proliferate|incubate|toxic|corrupted|phyrexian|poison|living weapon|compleated"
 		}
 	]}]},
 {                                    
@@ -5227,7 +5227,7 @@
 	{
 		"count":1,
 		"colors":["red"],
-		"cardText": "infect|oil|proliferate|incubate|toxic|corrupted|phyrexian|poison|living weapon|for mirrodin"
+		"cardText": "infect|oil|proliferate|incubate|toxic|corrupted|phyrexian|poison|living weapon|for mirrodin|compleated"
 	}]},
 	{
 		"count":3,
@@ -5239,7 +5239,7 @@
 		},
 		{
 		"count":1,
-		"cardText": "infect|oil|proliferate|incubate|toxic|corrupted|phyrexian|poison|living weapon|for mirrodin"
+		"cardText": "infect|oil|proliferate|incubate|toxic|corrupted|phyrexian|poison|living weapon|for mirrodin|compleated"
 		}
 	]}]},
 {                                    
@@ -5260,7 +5260,7 @@
 	{
 		"count":1,
 		"colors":["black"],
-		"cardText": "infect|oil|proliferate|incubate|toxic|corrupted|phyrexian|poison|living weapon"
+		"cardText": "infect|oil|proliferate|incubate|toxic|corrupted|phyrexian|poison|living weapon|compleated"
 	}]},
 	{
 		"count":3,
@@ -5272,7 +5272,7 @@
 		},
 		{
 		"count":1,
-		"cardText": "infect|oil|proliferate|incubate|toxic|corrupted|phyrexian|poison|living weapon"
+		"cardText": "infect|oil|proliferate|incubate|toxic|corrupted|phyrexian|poison|living weapon|compleated"
 		}
 	]}]},
 {


### PR DESCRIPTION
.Makes it possible for phyrexian enemies to drop mythic rares. (Still very rarely.) 
.Adds missing keyword ("compleated") to the string search for Phyrexian shops.