### PR TITLE
AI: simple Reveal logic, example implementation for Delver of Secrets

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiCardMemory.java
+++ b/forge-ai/src/main/java/forge/ai/AiCardMemory.java
@@ -60,7 +60,7 @@ public class AiCardMemory {
         MARKED_TO_AVOID_REENTRY, // These cards may cause a stack smash when processed recursively, and are thus marked to avoid a crash
         PAYS_TAP_COST, // These cards will be tapped as part of a cost and cannot be chosen in another part
         PAYS_SAC_COST, // These cards will be sacrificed as part of a cost and cannot be chosen in another part
-        REVEALED_CARDS // stub, not linked to AI code yet
+        REVEALED_CARDS // These cards were recently revealed to the AI by a call to PlayerControllerAi.reveal
     }
 
     private final Set<Card> memMandatoryAttackers;

--- a/forge-ai/src/main/java/forge/ai/AiCardMemory.java
+++ b/forge-ai/src/main/java/forge/ai/AiCardMemory.java
@@ -59,8 +59,8 @@ public class AiCardMemory {
         CHOSEN_FOG_EFFECT, // These cards are marked as the Fog-like effect the AI is planning to cast this turn
         MARKED_TO_AVOID_REENTRY, // These cards may cause a stack smash when processed recursively, and are thus marked to avoid a crash
         PAYS_TAP_COST, // These cards will be tapped as part of a cost and cannot be chosen in another part
-        PAYS_SAC_COST // These cards will be sacrificed as part of a cost and cannot be chosen in another part
-        //REVEALED_CARDS // stub, not linked to AI code yet
+        PAYS_SAC_COST, // These cards will be sacrificed as part of a cost and cannot be chosen in another part
+        REVEALED_CARDS // stub, not linked to AI code yet
     }
 
     private final Set<Card> memMandatoryAttackers;
@@ -77,6 +77,7 @@ public class AiCardMemory {
     private final Set<Card> memMarkedToAvoidReentry;
     private final Set<Card> memPaysTapCost;
     private final Set<Card> memPaysSacCost;
+    private final Set<Card> memRevealedCards;
 
     public AiCardMemory() {
         this.memMandatoryAttackers = new HashSet<>();
@@ -93,6 +94,7 @@ public class AiCardMemory {
         this.memHeldManaSourcesForNextSpell = new HashSet<>();
         this.memPaysTapCost = new HashSet<>();
         this.memPaysSacCost = new HashSet<>();
+        this.memRevealedCards = new HashSet<>();
     }
 
     private Set<Card> getMemorySet(MemorySet set) {
@@ -125,8 +127,8 @@ public class AiCardMemory {
                 return memPaysTapCost;
             case PAYS_SAC_COST:
                 return memPaysSacCost;
-            //case REVEALED_CARDS:
-            //    return memRevealedCards;
+            case REVEALED_CARDS:
+                return memRevealedCards;
             default:
                 return null;
         }

--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -350,14 +350,8 @@ public class PlayerControllerAi extends PlayerController {
     @Override
     public void reveal(List<CardView> cards, ZoneType zone, PlayerView owner, String messagePrefix) {
         AiCardMemory.clearMemorySet(player, AiCardMemory.MemorySet.REVEALED_CARDS);
-        // TODO: this is slow, iterating over all the cards in game for every CardView passed. Optimize?
         for (CardView cv : cards) {
-            for (Card c : player.getGame().getCardsInGame()) {
-                if (c.getId() == cv.getId()) {
-                    AiCardMemory.rememberCard(player, c, AiCardMemory.MemorySet.REVEALED_CARDS);
-                    break;
-                }
-            }
+            AiCardMemory.rememberCard(player, player.getGame().findByView(cv), AiCardMemory.MemorySet.REVEALED_CARDS);
         }
     }
 

--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -341,12 +341,24 @@ public class PlayerControllerAi extends PlayerController {
 
     @Override
     public void reveal(CardCollectionView cards, ZoneType zone, Player owner, String messagePrefix) {
-        // We don't know how to reveal cards to AI
+        AiCardMemory.clearMemorySet(player, AiCardMemory.MemorySet.REVEALED_CARDS);
+        for (Card c : cards) {
+            AiCardMemory.rememberCard(player, c, AiCardMemory.MemorySet.REVEALED_CARDS);
+        }
     }
 
     @Override
     public void reveal(List<CardView> cards, ZoneType zone, PlayerView owner, String messagePrefix) {
-        // We don't know how to reveal cards to AI
+        AiCardMemory.clearMemorySet(player, AiCardMemory.MemorySet.REVEALED_CARDS);
+        // TODO: this is slow, iterating over all the cards in game for every CardView passed. Optimize?
+        for (CardView cv : cards) {
+            for (Card c : player.getGame().getCardsInGame()) {
+                if (c.getId() == cv.getId()) {
+                    AiCardMemory.rememberCard(player, c, AiCardMemory.MemorySet.REVEALED_CARDS);
+                    break;
+                }
+            }
+        }
     }
 
     @Override

--- a/forge-ai/src/main/java/forge/ai/ability/PeekAndRevealAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PeekAndRevealAi.java
@@ -1,10 +1,6 @@
 package forge.ai.ability;
 
-import java.util.Map;
-import java.util.Set;
-
 import forge.ai.AiAttackController;
-import forge.ai.AiCardMemory;
 import forge.ai.SpellAbilityAi;
 import forge.ai.SpellApiToAi;
 import forge.game.card.Card;
@@ -17,6 +13,8 @@ import forge.game.spellability.AbilityStatic;
 import forge.game.spellability.AbilitySub;
 import forge.game.spellability.SpellAbility;
 import forge.game.zone.ZoneType;
+
+import java.util.Map;
 
 /** 
  * TODO: Write javadoc for this type.

--- a/forge-ai/src/main/java/forge/ai/ability/PeekAndRevealAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PeekAndRevealAi.java
@@ -8,6 +8,7 @@ import forge.ai.AiCardMemory;
 import forge.ai.SpellAbilityAi;
 import forge.ai.SpellApiToAi;
 import forge.game.card.Card;
+import forge.game.card.CardCollection;
 import forge.game.phase.PhaseHandler;
 import forge.game.phase.PhaseType;
 import forge.game.player.Player;
@@ -76,7 +77,7 @@ public class PeekAndRevealAi extends SpellAbilityAi {
     @Override
     public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
         if ("InstantOrSorcery".equals(sa.getParam("AILogic"))) {
-            Set<Card> revealed = AiCardMemory.getMemorySet(player, AiCardMemory.MemorySet.REVEALED_CARDS);
+            CardCollection revealed = (CardCollection) params.get("Revealed");
             for (Card c : revealed) {
                 if (!c.isInstant() && !c.isSorcery()) {
                     return false;

--- a/forge-ai/src/main/java/forge/ai/ability/PeekAndRevealAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PeekAndRevealAi.java
@@ -1,8 +1,10 @@
 package forge.ai.ability;
 
 import java.util.Map;
+import java.util.Set;
 
 import forge.ai.AiAttackController;
+import forge.ai.AiCardMemory;
 import forge.ai.SpellAbilityAi;
 import forge.ai.SpellApiToAi;
 import forge.game.card.Card;
@@ -73,6 +75,15 @@ public class PeekAndRevealAi extends SpellAbilityAi {
      */
     @Override
     public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
+        if ("InstantOrSorcery".equals(sa.getParam("AILogic"))) {
+            Set<Card> revealed = AiCardMemory.getMemorySet(player, AiCardMemory.MemorySet.REVEALED_CARDS);
+            for (Card c : revealed) {
+                if (!c.isInstant() && !c.isSorcery()) {
+                    return false;
+                }
+            }
+        }
+
         AbilitySub subAb = sa.getSubAbility();
         return subAb != null && SpellApiToAi.Converter.get(subAb.getApi()).chkDrawbackWithSubs(player, subAb);
     }

--- a/forge-game/src/main/java/forge/game/ability/effects/PeekAndRevealEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PeekAndRevealEffect.java
@@ -1,5 +1,6 @@
 package forge.game.ability.effects;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -77,6 +78,9 @@ public class PeekAndRevealEffect extends SpellAbilityEffect {
                 peekCards.add(library.get(i));
             }
 
+            Map<String, Object> params = new HashMap<>();
+            params.put("Revealed", peekCards);
+
             CardCollectionView revealableCards = CardLists.getValidCards(peekCards, revealValid, peekingPlayer, source, sa);
             boolean doReveal = !sa.hasParam("NoReveal") && !revealableCards.isEmpty();
             if (!noPeek) {
@@ -86,7 +90,7 @@ public class PeekAndRevealEffect extends SpellAbilityEffect {
             }
 
             if (doReveal && sa.hasParam("RevealOptional"))
-                doReveal = peekingPlayer.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblRevealCardToOtherPlayers"), null);
+                doReveal = peekingPlayer.getController().confirmAction(sa, null, Localizer.getInstance().getMessage("lblRevealCardToOtherPlayers"), params);
 
             if (doReveal) {
                 peekingPlayer.getGame().getAction().reveal(revealableCards, ZoneType.Library, libraryToPeek, !noPeek,

--- a/forge-gui/res/cardsfolder/d/delver_of_secrets_insectile_aberration.txt
+++ b/forge-gui/res/cardsfolder/d/delver_of_secrets_insectile_aberration.txt
@@ -3,7 +3,7 @@ ManaCost:U
 Types:Creature Human Wizard
 PT:1/1
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPeek | TriggerDescription$ At the beginning of your upkeep, look at the top card of your library. You may reveal that card. If an instant or sorcery card is revealed this way, transform CARDNAME.
-SVar:TrigPeek:DB$ PeekAndReveal | PeekAmount$ 1 | RevealOptional$ True | RememberRevealed$ True | SubAbility$ DBTransform
+SVar:TrigPeek:DB$ PeekAndReveal | PeekAmount$ 1 | RevealOptional$ True | RememberRevealed$ True | AILogic$ InstantOrSorcery | SubAbility$ DBTransform
 SVar:DBTransform:DB$ SetState | Defined$ Self | Mode$ Transform | ConditionDefined$ Remembered | ConditionPresent$ Card.Instant,Card.Sorcery | ConditionCompare$ EQ1 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 DeckHints:Type$Instant|Sorcery

--- a/forge-gui/res/draft/rankings.txt
+++ b/forge-gui/res/draft/rankings.txt
@@ -2027,7 +2027,7 @@
 #97|Essence Scatter|C|DMU
 #98|Destroy Evil|C|DMU
 #99|Radha, Coalition Warlord|U|DMU
-#100|Tura Kennerüd, Skyknight|U|DMU
+#100|Tura Kennerud, Skyknight|U|DMU
 #101|Argivian Cavalier|C|DMU
 #102|Runic Shot|U|DMU
 #103|Shalai's Acolyte|U|DMU


### PR DESCRIPTION
Makes the AI skip the reveal if it sees a non-Instant/non-Sorcery card on Delver of Secrets, for which it's optional.

Can most likely be used for other similar effects and possibly other stuff too.
Currently remembers only the last reveal (will clean up the revealed cards the next time something is revealed). If this is to be extended to allow some complex logic depending on what was revealed during the turn, this will need to be changed (the cleanup in the reveal method will need to be removed).

The overload of the "reveal" method with the CardView parameter is tricky because it doesn't allow to get to the card directly, so I'm currently using a "bruteforce" iteration over all the cards in the game to find the source. Can this be done faster/easier somehow? Luckily, this method isn't used as often, but still.