### PR TITLE
NPE guard for cases like Dunerider Outlaw dealing damage.

### DIFF
--- a/forge-game/src/main/java/forge/game/card/CardDamageHistory.java
+++ b/forge-game/src/main/java/forge/game/card/CardDamageHistory.java
@@ -270,11 +270,13 @@ public class CardDamageHistory {
             if (isCombat != null && damage.getRight() != isCombat) {
                 continue;
             }
-            if (validSourceCard != null && !sourceToTarget.getLeft().isValid(validSourceCard.split(","), sourceController, source == null ? sourceToTarget.getLeft() : source, ctb)) {
-                continue;
-            }
-            if (validTargetEntity != null && !sourceToTarget.getRight().isValid(validTargetEntity.split(","), sourceController, source, ctb)) {
-                continue;
+            if (sourceToTarget != null) {
+                if (validSourceCard != null && !sourceToTarget.getLeft().isValid(validSourceCard.split(","), sourceController, source == null ? sourceToTarget.getLeft() : source, ctb)) {
+                    continue;
+                }
+                if (validTargetEntity != null && !sourceToTarget.getRight().isValid(validTargetEntity.split(","), sourceController, source, ctb)) {
+                    continue;
+                }
             }
             sum += damage.getLeft();
             if (anyIsEnough) {


### PR DESCRIPTION
This seems to make Dunerider Outlaw to work correctly and not crash after dealing damage, but I'm not sure if maybe this is masking a bigger issue elsewhere in the code, so needs some consideration and review.

Test case for this: the AI has Dunerider Outlaw and attacks into the human's empty battlefield. Without the NPE guard, the game will crash.