### PR TITLE
Consider fog effects ruining assaults

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiAttackController.java
+++ b/forge-ai/src/main/java/forge/ai/AiAttackController.java
@@ -512,7 +512,6 @@ public class AiAttackController {
     }
 
     private boolean doAssault() {
-        // Beastmaster Ascension
         if (ai.isCardInPlay("Beastmaster Ascension") && this.attackers.size() > 1) {
             final CardCollectionView beastions = ai.getCardsIn(ZoneType.Battlefield, "Beastmaster Ascension");
             int minCreatures = 7;
@@ -523,6 +522,12 @@ public class AiAttackController {
             if (this.attackers.size() >= minCreatures) {
                 return true;
             }
+        }
+
+        // the real AI (running this AttackController) doesn't track if cards only get revealed to a subset of players
+        // - therefore in the few cases AI runs this for others conclusions might be wrong
+        if (ComputerUtil.hasAFogEffect(defendingOpponent, ai, true)) {
+            return false;
         }
 
         CardLists.sortByPowerDesc(this.attackers);

--- a/forge-ai/src/main/java/forge/ai/AiBlockController.java
+++ b/forge-ai/src/main/java/forge/ai/AiBlockController.java
@@ -1087,7 +1087,7 @@ public class AiBlockController {
         makeGangBlocks(combat);
 
         // When the AI holds some Fog effect, don't bother about lifeInDanger
-        if (!ComputerUtil.hasAFogEffect(ai, checkingOther)) {
+        if (!ComputerUtil.hasAFogEffect(ai, ai, checkingOther)) {
             lifeInDanger = ComputerUtilCombat.lifeInDanger(ai, combat);
             makeTradeBlocks(combat); // choose necessary trade blocks
 

--- a/forge-ai/src/main/java/forge/ai/ComputerUtil.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtil.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -1504,19 +1505,29 @@ public class ComputerUtil {
         return false;
     }
 
-    public static boolean hasAFogEffect(final Player ai, boolean checkingOther) {
-        final CardCollection all = new CardCollection(ai.getCardsIn(ZoneType.Battlefield));
+    public static boolean hasAFogEffect(final Player defender, final Player ai, boolean checkingOther) {
+        final CardCollection all = new CardCollection(defender.getCardsIn(ZoneType.Battlefield));
 
-        all.addAll(ai.getCardsActivableInExternalZones(true));
+        all.addAll(defender.getCardsActivableInExternalZones(true));
         // TODO check if cards can be viewed instead
         if (!checkingOther) {
-            all.addAll(ai.getCardsIn(ZoneType.Hand));
+            all.addAll(defender.getCardsIn(ZoneType.Hand));
+        }
+
+        Set<Card> revealed = AiCardMemory.getMemorySet(ai, MemorySet.REVEALED_CARDS);
+        if (revealed != null) {
+            for (Card c : revealed) {
+                // if the card moved to a hidden zone depending on the circumstances the AI could not have noticed...?
+                if (c.isInZone(ZoneType.Hand) && c.getOwner() == defender) {
+                    all.add(c);
+                }
+            }
         }
 
         for (final Card c : all) {
             // check if card is at least available to be played
             // further improvements might consider if AI has options to steal the spell by making it playable first
-            if (c.getZone().getPlayer() != null && c.getZone().getPlayer() != ai && c.mayPlay(ai).isEmpty()) {
+            if (c.getZone().getPlayer() != null && c.getZone().getPlayer() != defender && c.mayPlay(defender).isEmpty()) {
                 continue;
             }
             for (final SpellAbility sa : c.getSpellAbilities()) {
@@ -1531,13 +1542,13 @@ public class ComputerUtil {
                     if (!c.getController().isAI()) {
                         continue;
                     }
-                    if (AiCardMemory.isRememberedCard(ai, c, AiCardMemory.MemorySet.MARKED_TO_AVOID_REENTRY)) {
+                    if (AiCardMemory.isRememberedCard(defender, c, AiCardMemory.MemorySet.MARKED_TO_AVOID_REENTRY)) {
                         continue;
                     }
-                    AiCardMemory.rememberCard(ai, c, AiCardMemory.MemorySet.MARKED_TO_AVOID_REENTRY);
+                    AiCardMemory.rememberCard(defender, c, AiCardMemory.MemorySet.MARKED_TO_AVOID_REENTRY);
                 }
 
-                if (!ComputerUtilCost.canPayCost(sa, ai, false)) {
+                if (!ComputerUtilCost.canPayCost(sa, defender, false)) {
                     continue;
                 }
                 return true;

--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -341,7 +341,6 @@ public class PlayerControllerAi extends PlayerController {
 
     @Override
     public void reveal(CardCollectionView cards, ZoneType zone, Player owner, String messagePrefix) {
-        AiCardMemory.clearMemorySet(player, AiCardMemory.MemorySet.REVEALED_CARDS);
         for (Card c : cards) {
             AiCardMemory.rememberCard(player, c, AiCardMemory.MemorySet.REVEALED_CARDS);
         }
@@ -349,7 +348,6 @@ public class PlayerControllerAi extends PlayerController {
 
     @Override
     public void reveal(List<CardView> cards, ZoneType zone, PlayerView owner, String messagePrefix) {
-        AiCardMemory.clearMemorySet(player, AiCardMemory.MemorySet.REVEALED_CARDS);
         for (CardView cv : cards) {
             AiCardMemory.rememberCard(player, player.getGame().findByView(cv), AiCardMemory.MemorySet.REVEALED_CARDS);
         }

--- a/forge-ai/src/main/java/forge/ai/ability/RevealAiBase.java
+++ b/forge-ai/src/main/java/forge/ai/ability/RevealAiBase.java
@@ -35,7 +35,7 @@ public abstract class RevealAiBase extends SpellAbilityAi {
         }
 
         return true;
-    } // revealHandTargetAI()
+    }
 
     /* (non-Javadoc)
      * @see forge.card.abilityfactory.SpellAiLogic#chkAIDrawback(java.util.Map, forge.card.spellability.SpellAbility, forge.game.player.Player)

--- a/forge-ai/src/main/java/forge/ai/ability/SetStateAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/SetStateAi.java
@@ -212,7 +212,7 @@ public class SetStateAi extends SpellAbilityAi {
                 // both forms can attack, try to use the one with better value 
                 if (attackCard && attackTransformed) {
                     return valueCard <= valueTransformed;
-                } else if (attackTransformed) { // only transformed cam attack
+                } else if (attackTransformed) { // only transformed can attack
                     transformAttack = true;
                 }
             }

--- a/forge-game/src/main/java/forge/game/ability/effects/DigUntilEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DigUntilEffect.java
@@ -183,8 +183,10 @@ public class DigUntilEffect extends SpellAbilityEffect {
                     moveParams.put(AbilityKey.LastStateBattlefield, lastStateBattlefield);
                     moveParams.put(AbilityKey.LastStateGraveyard, lastStateGraveyard);
                     Card m = null;
-                    if (sa.hasParam("GainControl") && foundDest.equals(ZoneType.Battlefield)) {
-                        c.setController(sa.getActivatingPlayer(), game.getNextTimestamp());
+                    if (foundDest.equals(ZoneType.Battlefield)) {
+                        if (sa.hasParam("GainControl")) {
+                            c.setController(sa.getActivatingPlayer(), game.getNextTimestamp());
+                        }
                         if (sa.hasParam("Tapped")) {
                             c.setTapped(true);
                         }

--- a/forge-game/src/main/java/forge/game/ability/effects/PumpAllEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PumpAllEffect.java
@@ -87,12 +87,7 @@ public class PumpAllEffect extends SpellAbilityEffect {
                         game.fireEvent(new GameEventCardStatsChanged(tgtC));
                     }
                 };
-                if ("UntilLoseControlOfHost".equals(sa.getParam("Duration"))) {
-                    tgtC.addLeavesPlayCommand(untilEOT);
-                    tgtC.addChangeControllerCommand(untilEOT);
-                } else {
-                    addUntilCommand(sa, untilEOT);
-                }
+                addUntilCommand(sa, untilEOT);
             }
 
             game.fireEvent(new GameEventCardStatsChanged(tgtC));

--- a/forge-gui/res/cardsfolder/a/assembled_alphas.txt
+++ b/forge-gui/res/cardsfolder/a/assembled_alphas.txt
@@ -4,8 +4,8 @@ Types:Creature Wolf
 PT:5/5
 T:Mode$ AttackerBlockedByCreature | ValidCard$ Creature | ValidBlocker$ Card.Self | Execute$ TrigDamageAttacker | TriggerDescription$ Whenever CARDNAME blocks or becomes blocked by a creature, CARDNAME deals 3 damage to that creature and 3 damage to that creature's controller.
 T:Mode$ AttackerBlockedByCreature | ValidCard$ Card.Self | ValidBlocker$ Creature | Execute$ TrigDamageBlocker | Secondary$ True | TriggerDescription$ Whenever CARDNAME blocks or becomes blocked by a creature, CARDNAME deals 3 damage to that creature and 3 damage to that creature's controller.
-SVar:TrigDamageAttacker:DB$ DealDamage | Defined$ TriggeredAttackerLKICopy | NumDmg$ 3 | DamapeMap$ True | SubAbility$ DBDamageAtk
-SVar:TrigDamageBlocker:DB$ DealDamage | Defined$ TriggeredBlockerLKICopy | NumDmg$ 3 | DamapeMap$ True | SubAbility$ DBDamageBlk
+SVar:TrigDamageAttacker:DB$ DealDamage | Defined$ TriggeredAttackerLKICopy | NumDmg$ 3 | DamageMap$ True | SubAbility$ DBDamageAtk
+SVar:TrigDamageBlocker:DB$ DealDamage | Defined$ TriggeredBlockerLKICopy | NumDmg$ 3 | DamageMap$ True | SubAbility$ DBDamageBlk
 SVar:DBDamageAtk:DB$ DealDamage | Defined$ TriggeredAttackerController | NumDmg$ 3 | SubAbility$ DBDamageResolve
 SVar:DBDamageBlk:DB$ DealDamage | Defined$ TriggeredBlockerController | NumDmg$ 3 | SubAbility$ DBDamageResolve
 SVar:DBDamageResolve:DB$ DamageResolve

--- a/forge-gui/res/cardsfolder/f/fireflux_squad.txt
+++ b/forge-gui/res/cardsfolder/f/fireflux_squad.txt
@@ -5,7 +5,7 @@ PT:4/3
 K:Haste
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigExile | TriggerZones$ Battlefield | OptionalDecider$ You | TriggerDescription$ Whenever CARDNAME attacks, you may exile another target attacking creature you control. If you do, reveal cards from the top of your library until you reveal a creature card. Put that card onto the battlefield tapped and attacking and the rest on the bottom of your library in a random order.
 SVar:TrigExile:DB$ ChangeZone | ValidTgts$ Creature.attacking+Other+YouCtrl | TgtPrompt$ Select another target attacking creature you control | Origin$ Battlefield | Destination$ Exile | RememberChanged$ True | SubAbility$ DBDigUntil
-SVar:DBDigUntil:DB$ DigUntil | Valid$ Creature | ValidDescription$ Creature | FoundDestination$ Battlefield | Tapped$ True | Attacking$ True | GainControl$ True | RevealedDestination$ Library | RevealedLibraryPosition$ -1 | RevealRandomOrder$ True | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1 | SubAbility$ DBCleanup
+SVar:DBDigUntil:DB$ DigUntil | Valid$ Creature | ValidDescription$ Creature | FoundDestination$ Battlefield | Tapped$ True | Attacking$ True | RevealedDestination$ Library | RevealedLibraryPosition$ -1 | RevealRandomOrder$ True | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Remembered$Amount
 Oracle:Haste\nWhenever Fireflux Squad attacks, you may exile another target attacking creature you control. If you do, reveal cards from the top of your library until you reveal a creature card. Put that card onto the battlefield tapped and attacking and the rest on the bottom of your library in a random order.


### PR DESCRIPTION
While there are probably some other places that could benefit from this function for performance I've tried catching the most devastating counterattack scenario for starters...

AI now correctly decides to skip attacking since it would lose without a blocker (that is if you give it another strong enough wall it will still commit to bait it out):
![image](https://github.com/Card-Forge/forge/assets/8506892/60e76984-e9a8-4e17-b3e4-d3e677767a56)

It will obviously encounter memory loss on next turn but that's a problem we can think on some more.
