### PR TITLE
 Fix AI not being able to use mana from tapped sources 

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
@@ -1019,8 +1019,6 @@ public class ComputerUtilMana {
             // if the AI can't pay the additional costs skip the mana ability
             if (!CostPayment.canPayAdditionalCosts(ma.getPayCosts(), ma)) {
                 return false;
-            } else if (sourceCard.isTapped()) {
-                return false;
             } else if (ma.getRestrictions() != null && ma.getRestrictions().isInstantSpeed()) {
                 return false;
             }

--- a/forge-game/src/main/java/forge/game/ability/effects/RevealEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/RevealEffect.java
@@ -32,7 +32,7 @@ public class RevealEffect extends SpellAbilityEffect {
             if (!p.isInGame()) {
                 continue;
             }
-            final CardCollectionView cardsInHand = p.getZone(ZoneType.Hand).getCards();
+            final CardCollectionView cardsInHand = p.getCardsIn(ZoneType.Hand);
             if (cardsInHand.isEmpty()) {
                 continue;
             }
@@ -47,17 +47,8 @@ public class RevealEffect extends SpellAbilityEffect {
                 if (valid.isEmpty())
                     continue;
 
-                if (sa.hasParam("NumCards")) {
-                    final int revealnum = Math.min(cardsInHand.size(), cnt);
-                    for (int i = 0; i < revealnum; i++) {
-                        final Card random = Aggregates.random(valid);
-                        revealed.add(random);
-                        valid.remove(random);
-                    }
-                } else {
-                    revealed.add(Aggregates.random(valid));
-                }
-
+                final int revealnum = Math.min(valid.size(), cnt);
+                revealed.addAll(Aggregates.random(valid, revealnum));
             } else if (sa.hasParam("RevealDefined")) {
                 revealed.addAll(AbilityUtils.getDefinedCards(host, sa.getParam("RevealDefined"), sa));
             } else if (sa.hasParam("RevealAllValid")) {
@@ -72,27 +63,22 @@ public class RevealEffect extends SpellAbilityEffect {
                 if (valid.isEmpty())
                     continue;
 
-                if (sa.hasParam("RevealAll")) { //for when cards to reveal are not in hand
-                    revealed.addAll(valid);
-                } else {
-                    if (cnt > valid.size())
-                        cnt = valid.size();
+                if (cnt > valid.size())
+                    cnt = valid.size();
 
-                    int min = cnt;
-                    if (anyNumber) {
-                        cnt = valid.size();
-                        min = 0;
-                    } else if (optional) {
-                        min = 0;
-                    }
-
-                    revealed.addAll(p.getController().chooseCardsToRevealFromHand(min, cnt, valid));
+                int min = cnt;
+                if (anyNumber) {
+                    cnt = valid.size();
+                    min = 0;
+                } else if (optional) {
+                    min = 0;
                 }
+
+                revealed.addAll(p.getController().chooseCardsToRevealFromHand(min, cnt, valid));
             }
 
             if (sa.hasParam("RevealToAll") || sa.hasParam("Random")) {
-                game.getAction().reveal(revealed, p, false,
-                        sa.getParamOrDefault("RevealTitle", ""));
+                game.getAction().reveal(revealed, p, false, sa.getParamOrDefault("RevealTitle", ""));
             } else {
                 game.getAction().reveal(revealed, p);
             }

--- a/forge-game/src/main/java/forge/game/ability/effects/VoteEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/VoteEffect.java
@@ -55,18 +55,18 @@ public class VoteEffect extends SpellAbilityEffect {
         final List<Object> voteType = Lists.newArrayList();
         final Card host = sa.getHostCard();
         final Game game = host.getGame();
+        final Player activator = sa.getActivatingPlayer();
 
         if (sa.hasParam("VoteType")) {
             voteType.addAll(Arrays.asList(sa.getParam("VoteType").split(",")));
         } else if (sa.hasParam("VoteCard")) {
             ZoneType zone = sa.hasParam("Zone") ? ZoneType.smartValueOf(sa.getParam("Zone")) : ZoneType.Battlefield;
-            voteType.addAll(CardLists.getValidCards(game.getCardsIn(zone), sa.getParam("VoteCard"), host.getController(), host, sa));
+            voteType.addAll(CardLists.getValidCards(game.getCardsIn(zone), sa.getParam("VoteCard"), activator, host, sa));
         }
         if (voteType.isEmpty()) {
             return;
         }
 
-        Player activator = sa.getActivatingPlayer();
 
         // starting with the activator
         int aidx = tgtPlayers.indexOf(activator);

--- a/forge-gui/res/cardsfolder/a/awakened_awareness.txt
+++ b/forge-gui/res/cardsfolder/a/awakened_awareness.txt
@@ -3,7 +3,7 @@ ManaCost:X U U
 Types:Enchantment Aura
 K:Enchant artifact or creature
 A:SP$ Attach | ValidTgts$ Artifact,Creature | TgtPrompt$ Select target artifact or creature
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | IsPresent$ Permanent.EnchantedBy+greatestPower | Execute$ TrigPutCounters | TriggerDescription$ When CARDNAME enters the battlefield, put X +1/+1 counters on enchanted permanent.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPutCounters | TriggerDescription$ When CARDNAME enters the battlefield, put X +1/+1 counters on enchanted permanent.
 SVar:TrigPutCounters:DB$ PutCounter | Defined$ Enchanted | CounterType$ P1P1 | CounterNum$ X
 SVar:X:Count$xPaid
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | SetPower$ 1 | SetToughness$ 1 | Description$ As long as enchanted permanent is a creature, it has base power and toughness 1/1.

--- a/forge-gui/res/cardsfolder/b/bioplasm.txt
+++ b/forge-gui/res/cardsfolder/b/bioplasm.txt
@@ -4,9 +4,8 @@ Types:Creature Ooze
 PT:4/4
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigExile | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME attacks, exile the top card of your library. If it's a creature card, CARDNAME gets +X/+Y until end of turn, where X is the exiled creature card's power and Y is its toughness.
 SVar:TrigExile:DB$ Dig | DigNum$ 1 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBPump
-SVar:DBPump:DB$ Pump | Defined$ Self | NumAtt$ X | NumDef$ Y | ConditionCheckSVar$ Z | ConditionSVarCompare$ EQ1 | SubAbility$ DBCleanup
+SVar:DBPump:DB$ Pump | Defined$ Self | NumAtt$ X | NumDef$ Y | ConditionDefined$ Remembered | ConditionPresent$ Creature | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Remembered$CardPower
 SVar:Y:Remembered$CardToughness
-SVar:Z:Remembered$Valid Creature
 Oracle:Whenever Bioplasm attacks, exile the top card of your library. If it's a creature card, Bioplasm gets +X/+Y until end of turn, where X is the exiled creature card's power and Y is its toughness.

--- a/forge-gui/res/cardsfolder/d/danitha_new_benalias_light.txt
+++ b/forge-gui/res/cardsfolder/d/danitha_new_benalias_light.txt
@@ -1,7 +1,7 @@
 Name:Danitha, New Benalia's Light
 ManaCost:1 G W
 Types:Legendary Creature Human Knight
-PT:2/3
+PT:2/2
 K:Vigilance
 K:Trample
 K:Lifelink

--- a/forge-gui/res/cardsfolder/g/ghitu_chronicler.txt
+++ b/forge-gui/res/cardsfolder/g/ghitu_chronicler.txt
@@ -6,6 +6,5 @@ K:Kicker:3 R
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self+kicked | Execute$ TrigChangeZone | TriggerDescription$ When CARDNAME enters the battlefield, if it was kicked, return target instant or sorcery card from your graveyard to your hand.
 SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Instant.YouCtrl,Sorcery.YouCtrl
 SVar:NeedsToPlayKickedVar:Z GE1
-SVar:Z:Count$ValidGraveyard Instant.YouOwn/Plus.Z1
-SVar:Z1:Count$ValidGraveyard Sorcery.YouOwn
+SVar:Z:Count$ValidGraveyard Instant.YouOwn,Sorcery.YouOwn
 Oracle:Kicker {3}{R} (You may pay an additional {3}{R} as you cast this spell.)\nWhen Ghitu Chronicler enters the battlefield, if it was kicked, return target instant or sorcery card from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/g/graveyard_shovel.txt
+++ b/forge-gui/res/cardsfolder/g/graveyard_shovel.txt
@@ -2,7 +2,6 @@ Name:Graveyard Shovel
 ManaCost:2
 Types:Artifact
 A:AB$ ChangeZone | Cost$ 2 T | ValidTgts$ Player | DefinedPlayer$ Targeted | TgtPrompt$ Select target player | Origin$ Graveyard | Destination$ Exile | ChangeType$ Card | ChangeNum$ 1 | Hidden$ True | Chooser$ Targeted | Mandatory$ True | SubAbility$ DBGainLife | ForgetOtherTargets$ True | RememberChanged$ True | IsCurse$ True | StackDescription$ Target player exiles a card from their graveyard. If it's a creature card, you gain 2 life. | SpellDescription$ Target player exiles a card from their graveyard. If it's a creature card, you gain 2 life.
-SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 2 | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1 | SubAbility$ DBCleanup
+SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 2 | ConditionDefined$ Remembered | ConditionnPresent$ Creature | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-SVar:X:Remembered$Valid Creature
 Oracle:{2}, {T}: Target player exiles a card from their graveyard. If it's a creature card, you gain 2 life.

--- a/forge-gui/res/cardsfolder/m/maelstrom_archangel_avatar.txt
+++ b/forge-gui/res/cardsfolder/m/maelstrom_archangel_avatar.txt
@@ -14,7 +14,7 @@ SVar:TrigRepeatEach:DB$ RepeatEach | UseImprinted$ True | RepeatCards$ Card.Note
 SVar:DBCopyRandom:DB$ NameCard | Defined$ You | AtRandom$ True | ValidCards$ Card.ManaCost=Imprinted | SubAbility$ DBMake
 SVar:DBMake:DB$ MakeCard | Name$ ChosenName | Zone$ None | RememberMade$ True | SubAbility$ DBClearNamed
 SVar:DBClearNamed:DB$ Cleanup | ClearNamedCard$ True
-SVar:DBReveal:DB$ Reveal | Defined$ You | RevealAll$ True | RevealDefined$ Remembered | RevealToAll$ True | RevealTitle$ OVERRIDE Cards created by Maelstrom Archangel Avatar | SubAbility$ DBChoose
+SVar:DBReveal:DB$ Reveal | Defined$ You | RevealDefined$ Remembered | RevealToAll$ True | RevealTitle$ OVERRIDE Cards created by Maelstrom Archangel Avatar | SubAbility$ DBChoose
 SVar:DBChoose:DB$ ChooseCard | UnlessCost$ 3 | UnlessPayer$ You | UnlessSwitched$ True | Choices$ Card.IsRemembered | ChoiceZone$ None | SubAbility$ DBCopyPerm | SpellDescription$ You may pay {3}. If you do, choose one of those copies. If a copy of a permanent card is chosen, you may create a token that's a copy of that card. If a copy of an instant or sorcery card is chosen, you may cast the copy without paying its mana cost.
 SVar:DBCopyPerm:DB$ CopyPermanent | Optional$ True | Defined$ ChosenCard | ConditionDefined$ ChosenCard | ConditionPresent$ Permanent | ConditionCompare$ GE1 | SubAbility$ DBCastSp
 SVar:DBCastSp:DB$ Play | Defined$ ChosenCard | ZoneRegardless$ True | Optional$ True | WithoutManaCost$ True | ValidSA$ Spell | ConditionDefined$ ChosenCard | ConditionPresent$ Permanent | ConditionCompare$ EQ0 | SubAbility$ DBCleanup

--- a/forge-gui/res/cardsfolder/r/rundvelt_hordemaster.txt
+++ b/forge-gui/res/cardsfolder/r/rundvelt_hordemaster.txt
@@ -5,10 +5,9 @@ PT:1/1
 S:Mode$ Continuous | AffectedZone$ Battlefield | Affected$ Goblin.Other+YouCtrl | AddPower$ 1 | AddToughness$ 1 | Description$ Other Goblins you control get +1/+1.
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self,Goblin.Other+YouCtrl | Execute$ TrigExile | TriggerDescription$ Whenever CARDNAME or another Goblin you control dies, exile the top card of your library.
 SVar:TrigExile:DB$ Dig | DigNum$ 1 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBEffect
-SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ Play | ForgetOnMoved$ Exile | Duration$ UntilTheEndOfYourNextTurn | ConditionCheckSVar$ Z | ConditionSVarCompare$ EQ1 | SubAbility$ DBCleanup
-SVar:Play:Mode$ Continuous | MayPlay$ True | EffectZone$ Command | Affected$ Card.IsRemembered | AffectedZone$ Exile | Description$ If it's a Goblin creature card, you may cast that card until the end of your next turn.
+SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ Play | ForgetOnMoved$ Exile | Duration$ UntilTheEndOfYourNextTurn | ConditionDefined$ Remembered | ConditionPresent$ Creature.Goblin | SubAbility$ DBCleanup
+SVar:Play:Mode$ Continuous | MayPlay$ True | EffectZone$ Command | Affected$ Card.IsRemembered+nonLand | AffectedZone$ Exile | Description$ If it's a Goblin creature card, you may cast that card until the end of your next turn.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-SVar:Z:Remembered$Valid Creature.Goblin
 SVar:PlayMain1:TRUE
 DeckNeeds:Type$Goblin
 DeckHints:Type$Goblin

--- a/forge-gui/res/cardsfolder/s/sapling_of_colfenor.txt
+++ b/forge-gui/res/cardsfolder/s/sapling_of_colfenor.txt
@@ -3,7 +3,7 @@ ManaCost:3 BG BG
 Types:Legendary Creature Treefolk Shaman
 PT:2/5
 K:Indestructible
-T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigDig | TriggerDescription$ Whenever Sapling of Colfenor attacks, reveal the top card of your library. If it's a creature card, you gain life equal to that card's toughness, lose life equal to its power, then put it into your hand.
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigDig | TriggerDescription$ Whenever CARDNAME attacks, reveal the top card of your library. If it's a creature card, you gain life equal to that card's toughness, lose life equal to its power, then put it into your hand.
 SVar:TrigDig:DB$ Dig | DigNum$ 1 | Reveal$ True | ChangeNum$ All | ChangeValid$ Creature | DestinationZone$ Hand | RememberChanged$ True | DestinationZone2$ Library | LibraryPosition2$ 0 | SubAbility$ DBGain
 SVar:DBGain:DB$ GainLife | LifeAmount$ Y | SubAbility$ DBLose
 SVar:DBLose:DB$ LoseLife | LifeAmount$ X | SubAbility$ DBCleanup

--- a/forge-gui/res/cardsfolder/t/tetsuo_imperial_champion.txt
+++ b/forge-gui/res/cardsfolder/t/tetsuo_imperial_champion.txt
@@ -7,6 +7,6 @@ SVar:TrigChoose:DB$ Charm | Choices$ DBDealDamage,DBCast | CharmNum$ 1
 SVar:DBDealDamage:DB$ DealDamage | ValidTgts$ Any | NumDmg$ X | SpellDescription$ NICKNAME deals damage equal to the highest mana value among Equipment attached to it to any target.
 SVar:DBCast:DB$ Play | ValidZone$ Hand | Valid$ Instant.YouCtrl+cmcLEX,Sorcery.YouCtrl+cmcLEX | ValidSA$ Spell | Optional$ True | WithoutManaCost$ True | AILogic$ ReplaySpell | SpellDescription$ You may cast an instant or sorcery spell from your hand with mana value less than or equal to the highest mana value among Equipment attached to NICKNAME without paying its mana cost. 
 SVar:X:Count$Valid Equipment.Attached$GreatestCMC
-SVar:EquipMe
+SVar:EquipMe:Once
 DeckHints:Type$Equipment
 Oracle:Whenever Tetsuo, Imperial Champion attacks, if it's equipped, choose one —\n• Tetsuo deals damage equal to the highest mana value among Equipment attached to it to any target.\n• You may cast an instant or sorcery spell from your hand with mana value less than or equal to the highest mana value among Equipment attached to Tetsuo without paying its mana cost.


### PR DESCRIPTION
While the amount of cards that can be activated for mana while being tapped isn't that large AI should really consider it.
The resposible block I removed was pretty ancient and the ``canPayAdditionalCosts`` above should already handle it fine.
But feel free to test a bit that no new cheating is introduced...

Here's my scenario which will now allow the AI to pay for the game winning ability asap:
![grafik](https://github.com/Card-Forge/forge/assets/8506892/bc7c0073-c170-4ad2-b666-d069eee6c65c)
[CRYPTOLITE.txt](https://github.com/Card-Forge/forge/files/11745298/CRYPTOLITE.txt)
