### PR TITLE
Aura without Enchant shouldnt't stay attached

### DIFF
--- a/forge-game/src/main/java/forge/game/GameEntity.java
+++ b/forge-game/src/main/java/forge/game/GameEntity.java
@@ -275,7 +275,7 @@ public abstract class GameEntity extends GameObject implements IIdentifiable {
             tgt = sa.getTargetRestrictions();
         }
 
-        return !((tgt != null) && !isValid(tgt.getValidTgts(), aura.getController(), aura, sa));
+        return tgt != null && isValid(tgt.getValidTgts(), aura.getController(), aura, sa);
     }
 
     // Counters!

--- a/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
@@ -1450,7 +1450,11 @@ public class AbilityUtils {
 
         // Needed - Equip an untapped creature with Sword of the Paruns then cast Deadshot on it. Should deal 2 more damage.
         game.getAction().checkStaticAbilities(); // this will refresh continuous abilities for players and permanents.
-        game.getTriggerHandler().collectTriggerForWaiting();
+        if (sa.isReplacementAbility()) {
+            game.getTriggerHandler().collectTriggerForWaiting();
+        } else {
+            game.getTriggerHandler().resetActiveTriggers();
+        }
         AbilityUtils.resolveApiAbility(abSub, game);
     }
 

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -6340,7 +6340,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
             return isValid(tgt.getValidTgts(), aura.getController(), aura, sa);
         }
 
-        return true;
+        return false;
     }
 
     @Override

--- a/forge-gui/res/cardsfolder/a/arixmethes_slumbering_isle.txt
+++ b/forge-gui/res/cardsfolder/a/arixmethes_slumbering_isle.txt
@@ -5,8 +5,8 @@ PT:12/12
 K:ETBReplacement:Other:LandTapped
 SVar:LandTapped:DB$ Tap | Defined$ Self | SubAbility$ DBAddCounter | ETB$ True | SpellDescription$ CARDNAME enters the battlefield tapped with five slumber counters on it.
 SVar:DBAddCounter:DB$ PutCounter | Defined$ Self | ETB$ True | CounterType$ SLUMBER | CounterNum$ 5
-S:Mode$ Continuous | Affected$ Card.Self+counters_GE1_SLUMBER | AddType$ Land | RemoveCardTypes$ True | Description$ As long as CARDNAME has a slumber counter on it, it's a land. (It's not a creature.)
-T:Mode$ SpellCast | ValidCard$ Card | ValidActivatingPlayer$ You | Execute$ TrigRemoveCounter | TriggerZones$ Battlefield | OptionalDecider$ You | TriggerDescription$ Whenever you cast a spell, you may remove a slumber counter from CARDNAME.
+S:Mode$ Continuous | Affected$ Card.Self+counters_GE1_SLUMBER | AddType$ Land | RemoveCardTypes$ True | Description$ As long as NICKNAME has a slumber counter on it, it's a land. (It's not a creature.)
+T:Mode$ SpellCast | ValidCard$ Card | ValidActivatingPlayer$ You | Execute$ TrigRemoveCounter | TriggerZones$ Battlefield | OptionalDecider$ You | TriggerDescription$ Whenever you cast a spell, you may remove a slumber counter from NICKNAME.
 SVar:TrigRemoveCounter:DB$ RemoveCounter | Defined$ Self | CounterType$ SLUMBER | CounterNum$ 1 | AILogic$ Always
 A:AB$ Mana | Cost$ T | Produced$ G U | SpellDescription$ Add {G}{U}.
 Oracle:Arixmethes, Slumbering Isle enters the battlefield tapped with five slumber counters on it.\nAs long as Arixmethes has a slumber counter on it, it's a land. (It's not a creature.)\nWhenever you cast a spell, you may remove a slumber counter from Arixmethes.\n{T}: Add {G}{U}.


### PR DESCRIPTION
> If you target an Aura with Immovable Rod's last ability, it will lose its enchant ability and be put into its owner's graveyard because it can't legally enchant anything.

Also partial tweak for #2229