### PR TITLE
Several AI improvements

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtil.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtil.java
@@ -1080,6 +1080,11 @@ public class ComputerUtil {
             }
         }
 
+        // cast Blitz in main 1 if the creature attacks
+        if (sa.isBlitz() && ComputerUtilCard.doesSpecifiedCreatureAttackAI(ai, card)) {
+            return true;
+        }
+
         // try not to cast Raid creatures in main 1 if an attack is likely
         if ("Count$AttackersDeclared".equals(card.getSVar("RaidTest")) && !cardState.hasKeyword(Keyword.HASTE)) {
             for (Card potentialAtkr: ai.getCreaturesInPlay()) {

--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -23,10 +23,7 @@ import forge.game.ability.effects.CharmEffect;
 import forge.game.card.*;
 import forge.game.card.CardPredicates.Presets;
 import forge.game.combat.Combat;
-import forge.game.cost.Cost;
-import forge.game.cost.CostEnlist;
-import forge.game.cost.CostPart;
-import forge.game.cost.CostPartMana;
+import forge.game.cost.*;
 import forge.game.keyword.Keyword;
 import forge.game.keyword.KeywordInterface;
 import forge.game.mana.Mana;
@@ -1445,6 +1442,13 @@ public class PlayerControllerAi extends PlayerController {
     @Override
     public int chooseNumberForKeywordCost(SpellAbility sa, Cost cost, KeywordInterface keyword, String prompt, int max) {
         // TODO: improve the logic depending on the keyword and the playability of the cost-modified SA (enough targets present etc.)
+
+        if (keyword.getKeyword() == Keyword.CASUALTY
+                && "true".equalsIgnoreCase(sa.getHostCard().getSVar("AINoCasualtyPayment"))) {
+            // TODO: Grisly Sigil - currently will be misplayed if Casualty is paid (the cost is always paid, targeting is wrong).
+            return 0;
+        }
+
         int chosenAmount = 0;
 
         Cost costSoFar = sa.getPayCosts().copy();

--- a/forge-ai/src/main/java/forge/ai/SpecialCardAi.java
+++ b/forge-ai/src/main/java/forge/ai/SpecialCardAi.java
@@ -632,7 +632,6 @@ public class SpecialCardAi {
             CardCollection potentialTgts = CardLists.filterControlledBy(CardUtil.getValidCardsToTarget(sa), ai.getOpponents());
 
             for (Card c : potentialTgts) {
-
                 int potentialDamage = c.getAssignedDamage(false, null) > 0 ? 3 : 1; // TODO: account for damage reduction
                 if (c.canBeDestroyed()) {
                     int damageToDeal = c.isCreature() ? c.getNetToughness() : c.getCurrentLoyalty();

--- a/forge-ai/src/main/java/forge/ai/SpecialCardAi.java
+++ b/forge-ai/src/main/java/forge/ai/SpecialCardAi.java
@@ -629,10 +629,9 @@ public class SpecialCardAi {
     public static class GrislySigil {
         public static boolean consider(final Player ai, final SpellAbility sa) {
             // TODO: improve targeting support for Casualty 1
-            CardCollection validTgts = CardLists.filterControlledBy(CardUtil.getValidCardsToTarget(sa), ai.getOpponents());
-            CardCollection potentialTgts = new CardCollection();
+            CardCollection potentialTgts = CardLists.filterControlledBy(CardUtil.getValidCardsToTarget(sa), ai.getOpponents());
 
-            for (Card c : validTgts) {
+            for (Card c : potentialTgts) {
 
                 int potentialDamage = c.getAssignedDamage(false, null) > 0 ? 3 : 1; // TODO: account for damage reduction
                 if (c.canBeDestroyed()) {

--- a/forge-ai/src/main/java/forge/ai/SpecialCardAi.java
+++ b/forge-ai/src/main/java/forge/ai/SpecialCardAi.java
@@ -625,6 +625,34 @@ public class SpecialCardAi {
         }
     }
 
+    // Grisly Sigil
+    public static class GrislySigil {
+        public static boolean consider(final Player ai, final SpellAbility sa) {
+            // TODO: improve targeting support for Casualty 1
+            List<Card> validTgts = CardUtil.getValidCardsToTarget(sa);
+            CardCollection potentialTgts = new CardCollection();
+
+            for (Card c : validTgts) {
+
+                int potentialDamage = c.getAssignedDamage(false, null) > 0 ? 3 : 1; // TODO: account for damage reduction
+                if (c.canBeDestroyed()) {
+                    int damageToDeal = c.isCreature() ? c.getNetToughness() : c.getCurrentLoyalty();
+                    if (damageToDeal <= c.getAssignedDamage() + potentialDamage) {
+                        potentialTgts.add(c);
+                    }
+                }
+            }
+
+            if (!potentialTgts.isEmpty()) {
+                sa.resetTargets();
+                sa.getTargets().add(ComputerUtilCard.getBestAI(potentialTgts));
+                return true;
+            }
+
+            return false;
+        }
+    }
+
     // Guilty Conscience
     public static class GuiltyConscience {
         public static Card getBestAttachTarget(final Player ai, final SpellAbility sa, final List<Card> list) {

--- a/forge-ai/src/main/java/forge/ai/SpecialCardAi.java
+++ b/forge-ai/src/main/java/forge/ai/SpecialCardAi.java
@@ -629,7 +629,7 @@ public class SpecialCardAi {
     public static class GrislySigil {
         public static boolean consider(final Player ai, final SpellAbility sa) {
             // TODO: improve targeting support for Casualty 1
-            List<Card> validTgts = CardUtil.getValidCardsToTarget(sa);
+            CardCollection validTgts = CardLists.filterControlledBy(CardUtil.getValidCardsToTarget(sa), ai.getOpponents());
             CardCollection potentialTgts = new CardCollection();
 
             for (Card c : validTgts) {

--- a/forge-ai/src/main/java/forge/ai/SpellApiToAi.java
+++ b/forge-ai/src/main/java/forge/ai/SpellApiToAi.java
@@ -34,7 +34,7 @@ public enum SpellApiToAi {
             .put(ApiType.BidLife, BidLifeAi.class)
             .put(ApiType.BlankLine, AlwaysPlayAi.class)
             .put(ApiType.Bond, BondAi.class)
-            .put(ApiType.Branch, AlwaysPlayAi.class)
+            .put(ApiType.Branch, BranchAi.class)
             .put(ApiType.Camouflage, ChooseCardAi.class)
             .put(ApiType.ChangeCombatants, ChangeCombatantsAi.class)
             .put(ApiType.ChangeTargets, ChangeTargetsAi.class)

--- a/forge-ai/src/main/java/forge/ai/ability/BranchAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/BranchAi.java
@@ -1,0 +1,31 @@
+package forge.ai.ability;
+
+
+import java.util.Map;
+
+import forge.ai.SpecialCardAi;
+import forge.ai.SpellAbilityAi;
+import forge.game.player.Player;
+import forge.game.player.PlayerActionConfirmMode;
+import forge.game.spellability.SpellAbility;
+
+public class BranchAi extends SpellAbilityAi {
+    /* (non-Javadoc)
+     * @see forge.card.abilityfactory.SpellAiLogic#canPlayAI(forge.game.player.Player, java.util.Map, forge.card.spellability.SpellAbility)
+     */
+    @Override
+    protected boolean canPlayAI(Player aiPlayer, SpellAbility sa) {
+        final String aiLogic = sa.getParamOrDefault("AILogic", "");
+        if ("GrislySigil".equals(aiLogic)) {
+            return SpecialCardAi.GrislySigil.consider(aiPlayer, sa);
+        }
+
+        // TODO: expand for other cases where the AI is needed to make a decision on a branch
+        return true;
+    }
+
+    @Override
+    public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
+        return true;
+    }
+}

--- a/forge-ai/src/main/java/forge/ai/ability/PermanentCreatureAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PermanentCreatureAi.java
@@ -79,6 +79,11 @@ public class PermanentCreatureAi extends PermanentAi {
             }
         }
 
+        // Blitz Keyword: avoid casting in Main2
+        if (sa.isBlitz() && ph.getPhase().isAfter(PhaseType.MAIN1)) {
+            return false;
+        }
+
         // Prevent the computer from summoning Ball Lightning type creatures
         // after attacking
         if (card.hasSVar("EndOfTurnLeavePlay")

--- a/forge-gui/res/cardsfolder/b/bring_the_ending.txt
+++ b/forge-gui/res/cardsfolder/b/bring_the_ending.txt
@@ -1,9 +1,9 @@
 Name:Bring the Ending
 ManaCost:1 U
 Types:Instant
-A:SP$ Branch | BranchConditionSVar$ X | TargetType$ Spell | TgtZone$ Stack | ValidTgts$ Card | BranchConditionSVarCompare$ GE3 | TrueSubAbility$ Counter | FalseSubAbility$ CounterUnless | SpellDescription$ Counter target spell unless its controller pays {2}. Corrupted — Counter that spell instead if its controller has three or more poison counter.
+A:SP$ Branch | BranchConditionSVar$ X | TargetType$ Spell | TgtZone$ Stack | ValidTgts$ Card | BranchConditionSVarCompare$ GE3 | TrueSubAbility$ Counter | FalseSubAbility$ CounterUnless | SpellDescription$ Counter target spell unless its controller pays {2}. Corrupted — Counter that spell instead if its controller has three or more poison counters.
 SVar:CounterUnless:DB$ Counter | Defined$ Targeted | UnlessCost$ 2
 SVar:Counter:DB$ Counter | Defined$ Targeted
 SVar:X:TargetedController$PoisonCounters
 DeckHints:Keyword$Infect|Toxic
-Oracle:Counter target spell unless its controller pays {2}.\nCorrupted — Counter that spell instead if its controller has three or more poison counter.
+Oracle:Counter target spell unless its controller pays {2}.\nCorrupted — Counter that spell instead if its controller has three or more poison counters.

--- a/forge-gui/res/cardsfolder/g/grisly_sigil.txt
+++ b/forge-gui/res/cardsfolder/g/grisly_sigil.txt
@@ -2,11 +2,12 @@ Name:Grisly Sigil
 ManaCost:B
 Types:Sorcery
 K:Casualty:1
-A:SP$ Branch | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Choose target creature or planeswalker | BranchConditionSVar$ X | TrueSubAbility$ Damage3 | FalseSubAbility$ Damage1 | SpellDescription$ Choose target creature or planeswalker. If it was dealt noncombat damage this turn, CARDNAME deals 3 damage to it and you gain 3 life. Otherwise, CARDNAME deals 1 damage to it and you gain 1 life.
+A:SP$ Branch | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Choose target creature or planeswalker | BranchConditionSVar$ X | TrueSubAbility$ Damage3 | FalseSubAbility$ Damage1 | AILogic$ GrislySigil | SpellDescription$ Choose target creature or planeswalker. If it was dealt noncombat damage this turn, CARDNAME deals 3 damage to it and you gain 3 life. Otherwise, CARDNAME deals 1 damage to it and you gain 1 life.
 SVar:Damage3:DB$ DealDamage | Defined$ Targeted | NumDmg$ 3 | SubAbility$ DBGain3Life
 SVar:Damage1:DB$ DealDamage | Defined$ Targeted | NumDmg$ 1 | SubAbility$ DBGain1Life
 SVar:DBGain3Life:DB$ GainLife | LifeAmount$ 3
 SVar:DBGain1Life:DB$ GainLife | LifeAmount$ 1
 SVar:X:Targeted$Valid Card.wasDealtNonCombatDamageThisTurn
 DeckHas:Ability$Sacrifice|LifeGain
+SVar:AINoCasualtyPayment:TRUE
 Oracle:Casualty 1 (As you cast this spell, you may sacrifice a creature with power 1 or greater. When you do, copy this spell and you may choose new targets for the copy.)\nChoose target creature or planeswalker. If it was dealt noncombat damage this turn, Grisly Sigil deals 3 damage to it and you gain 3 life. Otherwise, Grisly Sigil deals 1 damage to it and you gain 1 life.

--- a/forge-gui/res/cardsfolder/h/hold_for_ransom.txt
+++ b/forge-gui/res/cardsfolder/h/hold_for_ransom.txt
@@ -4,6 +4,6 @@ Types:Enchantment Aura
 K:Enchant creature
 A:SP$ Attach | ValidTgts$ Creature | AILogic$ Curse
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | AddAbility$ PayRansom | Description$ Enchanted creature can't attack or block and has "{7}: Hold for Ransom's controller sacrifices it and draws a card. Activate only as a sorcery."
-SVar:PayRansom:AB$ SacrificeAll | Cost$ 7 | Defined$ OriginalHost | Controller$ OriginalHostController | SubAbility$ DBDraw | SorcerySpeed$ True | SpellDescription$ ORIGINALHOST's controller sacrifices it and draws a card. Activate only as a sorcery.
+SVar:PayRansom:AB$ SacrificeAll | Cost$ 7 | Defined$ OriginalHost | Controller$ OriginalHostController | SubAbility$ DBDraw | SorcerySpeed$ True | AILogic$ Always | SpellDescription$ ORIGINALHOST's controller sacrifices it and draws a card. Activate only as a sorcery.
 SVar:DBDraw:DB$ Draw | Defined$ OriginalHostController
 Oracle:Enchant creature\nEnchanted creature can't attack or block and has "{7}: Hold for Ransom's controller sacrifices it and draws a card. Activate only as a sorcery."


### PR DESCRIPTION
- Improved Blitz AI support (will cast in Main 1 when viable, will avoid casting in Main 2).
- Hold for Ransom AI hint to actually use the ability when able.
- Basic AI support for Grisly Sigil so that at least it doesn't fizzle.
- Basic BranchAi framework, currently will mostly just return true, but may be used for special logic when needed.

Current issues, most likely for the future PR:
- Grisly Sigil is very basic. Casualty payment is currently disabled for it (the AI will always pay for it, and when it does, it'll also fail to target something else, choosing the same target as for the original). Probably needs #3262 in order to work better, as well as some improvement to the targeting system for copied spells.