### PR TITLE
Fix Green Castle crash on non-case insensitive file systems, fix Ghalta's Presence effect.

### DIFF
--- a/forge-gui/res/adventure/Shandalar/custom_cards/ghaltas_presence.txt
+++ b/forge-gui/res/adventure/Shandalar/custom_cards/ghaltas_presence.txt
@@ -3,5 +3,5 @@ ManaCost:no cost
 Colors:Green
 Types:Enchantment
 S:Mode$ Continuous | Affected$ Card | AddHiddenKeyword$ This spell can't be countered. | AffectedZone$ Stack | EffectZone$ Command | Description$ Spells can't be countered.
-S:Mode$ RaiseCost | ValidCard$ Card.nonCreature,Card.nonBattle | Type$ Spell | Activator$ Opponent | EffectZone$ Command | Amount$ 2 | Description$ Noncreature, nonbattle spells your opponent cast cost {2} more to cast.
+S:Mode$ RaiseCost | ValidCard$ Card.nonCreature+nonBattle | Type$ Spell | Activator$ Opponent | EffectZone$ Command | Amount$ 2 | Description$ Noncreature, nonbattle spells your opponent cast cost {2} more to cast.
 Oracle:Spells can't be countered.\nNoncreature, nonbattle spells your opponent cast cost {2} more to cast.

--- a/forge-gui/res/adventure/Shandalar/sprites/animals/wolf.atlas
+++ b/forge-gui/res/adventure/Shandalar/sprites/animals/wolf.atlas
@@ -1,4 +1,4 @@
-Wolf.png
+wolf.png
 size: 640,384
 format: RGBA8888
 filter: Nearest,Nearest


### PR DESCRIPTION
- Fix Green Castle crash on any non-Windows operating system with a case sensitive file system.
- Fix Ghalta's Presence increasing the cost of everything (most likely should be non-creature and non-battle for a single card, otherwise it increases the costs of [non-battle] creatures and [non-creature] battles.