### PR TITLE
Enforce explicit plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,26 +96,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.0.0-M2</version>
-                    <executions>
-                        <execution>
-                            <id>enforce-versions</id>
-                            <phase>validate</phase>
-                            <goals>
-                                <goal>enforce</goal>
-                            </goals>
-                            <configuration>
-                                <rules>
-                                    <requireMavenVersion>
-                                        <version>[3.5.9,)</version>
-                                    </requireMavenVersion>
-                                    <requireJavaVersion>
-                                        <version>[1.8,)</version>
-                                    </requireJavaVersion>
-                                </rules>
-                            </configuration>
-                        </execution>
-                    </executions>
+                    <version>3.3.0</version>
                 </plugin>
 
                 <plugin>
@@ -157,6 +138,18 @@
                             <version>2.6</version>
                         </dependency>
                     </dependencies>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.3</version>
                 </plugin>
 
                 <plugin>
@@ -268,7 +261,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M2</version>
                 <executions>
                     <execution>
                         <id>enforce-versions</id>
@@ -279,11 +271,12 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>[3.1.1,)</version>
+                                    <version>[3.5.9,)</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
                                     <version>[1.8,)</version>
                                 </requireJavaVersion>
+                                <requirePluginVersions />
                             </rules>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Hi!

I recently bumped the Maven version in Nixpgks (NixOS/nixpkgs#238746) and ran into some small but annoying manual effort w.r.t. the `forge-mtg` package. The issue is that `forge-mtg` is packaged using the [double invocation](https://ryantm.github.io/nixpkgs/languages-frameworks/maven/#double-invocation) method which unfortunately breaks if not all maven plugin versions are set explicitly.

We're extending the documentation to prevent this (NixOS/nixpkgs#238774), but I'm reaching out to fix the packages which have already been packaged. In this PR, we explicitly set the versions of the only two plugins which hadn't been set explicitly before and add a check with the enforcer plugin to make sure this won't accidentally break in the future.

I took the liberty of deduplicating the configuration of the enforcer plugin, since this was already causing inconsistencies (`requireMavenVersion`).