### PR TITLE
AI: AttachAi should avoid enchanting or equipping crewed vehicles

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/AttachAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/AttachAi.java
@@ -1248,11 +1248,23 @@ public class AttachAi extends SpellAbilityAi {
         	}
 
         	// should not attach Auras to creatures that does leave the play
-        	// TODO also should not attach Auras to creatures cast with Dash
             prefList = CardLists.filter(prefList, new Predicate<Card>() {
                 @Override
                 public boolean apply(final Card c) {
                     return !c.hasSVar("EndOfTurnLeavePlay");
+                }
+            });
+        }
+
+        // Should not attach things to crewed vehicles that will stop being creatures soon
+        // Equipping in Main 1 on creatures that actually attack is probably fine though
+        // TODO Somehow test for definitive advantage (e.g. opponent low on health, AI is attacking)
+        // to be able to deal the final blow with an enchanted vehicle like that
+        if (attachSource.isAura() || attachSource.isEquipment()) {
+            prefList = CardLists.filter(prefList, new Predicate<Card>() {
+                @Override
+                public boolean apply(Card card) {
+                    return card.getTimesCrewedThisTurn() == 0 || (attachSource.isEquipment() && attachSource.getGame().getPhaseHandler().is(PhaseType.MAIN1, ai));
                 }
             });
         }

--- a/forge-ai/src/main/java/forge/ai/ability/AttachAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/AttachAi.java
@@ -1260,7 +1260,14 @@ public class AttachAi extends SpellAbilityAi {
         // Equipping in Main 1 on creatures that actually attack is probably fine though
         // TODO Somehow test for definitive advantage (e.g. opponent low on health, AI is attacking)
         // to be able to deal the final blow with an enchanted vehicle like that
-        if (attachSource.isAura() || attachSource.isEquipment()) {
+        boolean canOnlyTargetCreatures = true;
+        for (String valid : sa.getTargetRestrictions().getValidTgts()) {
+            if (!valid.startsWith("Creature")) {
+                canOnlyTargetCreatures = false;
+                break;
+            }
+        }
+        if (canOnlyTargetCreatures && (attachSource.isAura() || attachSource.isEquipment())) {
             prefList = CardLists.filter(prefList, new Predicate<Card>() {
                 @Override
                 public boolean apply(Card card) {


### PR DESCRIPTION
- AI will avoid enchanting crewed vehicles since that leads to card disadvantage and in most cases, that AI does this by mistake as opposed to some kind of a strategic way that leads to definitive advantage. Probably worth somehow implementing a check where the AI may be able to gain critical advantage or outright win by enchanting the said vehicle and attacking with it (e.g. when the opponent is low on health) - could be something for a future PR, not sure yet.
- AI will avoid equipping crewed vehicles for the same reason. The current exception is when the AI is actually attacking with the said vehicle this turn, when equipping it is likely to cause more damage (for the cost of mana for equip). Not sure how useful this is, probably needs testing and may need tweaking.
- Tested the AI not enchanting creatures cast with Dash or Blitz (already works as expected). If a check is implemented above for gaining significant advantage / winning, it may probably be implemented on Dash/Blitz too if it works. Probably stuff for a future PR though.