### PR TITLE
Exiled card becomes new object when it's exiled

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -1618,8 +1618,7 @@ public class AiController {
             AiPlayDecision opinion = canPlayAndPayFor(sa);
 
             // reset LastStateBattlefield
-            sa.setLastStateBattlefield(CardCollection.EMPTY);
-            sa.setLastStateGraveyard(CardCollection.EMPTY);
+            sa.clearLastState();
             // PhaseHandler ph = game.getPhaseHandler();
             // System.out.printf("Ai thinks '%s' of %s -> %s @ %s %s >>> \n", opinion, sa.getHostCard(), sa, Lang.getPossesive(ph.getPlayerTurn().getName()), ph.getPhase());
 

--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -306,7 +306,6 @@ public class GameAction {
             }
 
             copied.setUnearthed(c.isUnearthed());
-            copied.setTapped(false);
 
             // need to copy counters when card enters another zone than hand or library
             if (lastKnownInfo.hasKeyword("Counters remain on CARDNAME as it moves to any zone other than a player's hand or library.") &&
@@ -647,7 +646,6 @@ public class GameAction {
             }
             game.getTriggerHandler().runTrigger(TriggerType.ChangesController, runParams2, false);
         }
-        // AllZone.getStack().chooseOrderOfSimultaneousStackEntryAll();
 
         if (suppress) {
             game.getTriggerHandler().clearSuppression(TriggerType.ChangesZone);

--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -226,6 +226,17 @@ public class GameAction {
         if (suppress || toBattlefield) {
             copied = c;
 
+            // 400.8. If an object in the exile zone is exiled, it doesn't change zones,
+            // but it becomes a new object that has just been exiled.
+            if (zoneTo.is(ZoneType.Exile)) {
+                copied = CardFactory.copyCard(c, false);
+                copied.setTimestamp(game.getNextTimestamp());
+
+                if (c.hasKeyword("Counters remain on CARDNAME as it moves to any zone other than a player's hand or library.")) {
+                    copied.setCounters(Maps.newHashMap(c.getCounters()));
+                }
+            }
+
             if (lastKnownInfo == null) {
                 lastKnownInfo = CardUtil.getLKICopy(c);
             }
@@ -600,7 +611,7 @@ public class GameAction {
         }
 
         // only now that the LKI preserved it
-        if (!zoneTo.is(ZoneType.Exile) && !zoneTo.is(ZoneType.Stack)) {
+        if (!zoneTo.is(ZoneType.Stack)) {
             c.cleanupExiledWith();
         }
 
@@ -923,10 +934,6 @@ public class GameAction {
         return result;
     }
     public final Card exile(final Card c, SpellAbility cause, Map<AbilityKey, Object> params) {
-        if (game.isCardExiled(c)) {
-            return c;
-        }
-
         final Zone origin = c.getZone();
         final PlayerZone removed = c.getOwner().getZone(ZoneType.Exile);
         final Card copied = moveTo(removed, c, cause, params);

--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -223,19 +223,8 @@ public class GameAction {
 
         // Don't copy Tokens, copy only cards leaving the battlefield
         // and returning to hand (to recreate their spell ability information)
-        if (suppress || toBattlefield) {
+        if (toBattlefield || (suppress && zoneTo.getZoneType().isHidden())) {
             copied = c;
-
-            // 400.8. If an object in the exile zone is exiled, it doesn't change zones,
-            // but it becomes a new object that has just been exiled.
-            if (zoneTo.is(ZoneType.Exile)) {
-                copied = CardFactory.copyCard(c, false);
-                copied.setTimestamp(game.getNextTimestamp());
-
-                if (c.hasKeyword("Counters remain on CARDNAME as it moves to any zone other than a player's hand or library.")) {
-                    copied.setCounters(Maps.newHashMap(c.getCounters()));
-                }
-            }
 
             if (lastKnownInfo == null) {
                 lastKnownInfo = CardUtil.getLKICopy(c);
@@ -396,7 +385,7 @@ public class GameAction {
             }
         }
 
-        if (!zoneTo.is(ZoneType.Stack) && !suppress) {
+        if (!zoneTo.is(ZoneType.Stack)) {
             // reset timestamp in changezone effects so they have same timestamp if ETB simultaneously
             copied.setTimestamp(game.getNextTimestamp());
         }

--- a/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
@@ -561,9 +561,9 @@ public class AbilityUtils {
             }
         } else if (calcX[0].equals("OriginalHost")) {
             val = xCount(ability.getOriginalHost(), calcX[1], ability);
-        } else if (calcX[0].equals("LastStateBattlefield") && ability instanceof SpellAbility) {
-            Card c = ((SpellAbility) ability).getLastStateBattlefield().get(card);
-            val = c == null ? 0 : xCount(c, calcX[1], ability);
+        } else if (calcX[0].equals("ThisTurnCast") && ability instanceof SpellAbility) {
+            String[] def = calcX[1].split("\\$", 2);
+            val = handlePaid(CardUtil.getThisTurnCast(def[0], card, ability, player), def[1], card, ability);
         } else if (calcX[0].startsWith("ExiledWith")) {
             val = handlePaid(card.getExiledCards(), calcX[1], card, ability);
 	    } else if (calcX[0].startsWith("Convoked")) {

--- a/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
@@ -561,9 +561,6 @@ public class AbilityUtils {
             }
         } else if (calcX[0].equals("OriginalHost")) {
             val = xCount(ability.getOriginalHost(), calcX[1], ability);
-        } else if (calcX[0].equals("ThisTurnCast") && ability instanceof SpellAbility) {
-            String[] def = calcX[1].split("\\$", 2);
-            val = handlePaid(CardUtil.getThisTurnCast(def[0], card, ability, player), def[1], card, ability);
         } else if (calcX[0].startsWith("ExiledWith")) {
             val = handlePaid(card.getExiledCards(), calcX[1], card, ability);
 	    } else if (calcX[0].startsWith("Convoked")) {

--- a/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
@@ -393,11 +393,16 @@ public abstract class SpellAbilityEffect {
     }
 
     public static void addForgetOnMovedTrigger(final Card card, final String zone) {
-        String trig = "Mode$ ChangesZone | ValidCard$ Card.IsRemembered | Origin$ " + zone + " | ExcludedDestinations$ Stack | Destination$ Any | TriggerZones$ Command | Static$ True";
+        String trig = "Mode$ ChangesZone | ValidCard$ Card.IsRemembered | Origin$ " + zone + " | ExcludedDestinations$ Stack,Exile | Destination$ Any | TriggerZones$ Command | Static$ True";
+        String trig2 = "Mode$ Exiled | ValidCard$ Card.IsRemembered | TriggerZones$ Command | Static$ True";
 
         final Trigger parsedTrigger = TriggerHandler.parseTrigger(trig, card, true);
-        parsedTrigger.setOverridingAbility(getForgetSpellAbility(card));
+        final Trigger parsedTrigger2 = TriggerHandler.parseTrigger(trig2, card, true);
+        SpellAbility forget = getForgetSpellAbility(card);
+        parsedTrigger.setOverridingAbility(forget);
+        parsedTrigger2.setOverridingAbility(forget);
         card.addTrigger(parsedTrigger);
+        card.addTrigger(parsedTrigger2);
     }
 
     protected static void addForgetOnCastTrigger(final Card card) {

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -327,7 +327,6 @@ public class Player extends GameEntity implements Comparable<Player> {
 
         game.getTriggerHandler().suppressMode(TriggerType.ChangesZone);
         activeScheme = getZone(ZoneType.SchemeDeck).get(0);
-        // gameAction moveTo ?
         game.getAction().moveTo(ZoneType.Command, activeScheme, null, moveParams);
         game.getTriggerHandler().clearSuppression(TriggerType.ChangesZone);
 
@@ -3268,9 +3267,7 @@ public class Player extends GameEntity implements Comparable<Player> {
         }
 
         final TriggerHandler triggerHandler = game.getTriggerHandler();
-        triggerHandler.suppressMode(TriggerType.ChangesZone);
-        game.getAction().moveTo(ZoneType.Command, initiativeEffect, null, null);
-        triggerHandler.clearSuppression(TriggerType.ChangesZone);
+        com.add(initiativeEffect);
         triggerHandler.clearActiveTriggers(initiativeEffect, null);
         triggerHandler.registerActiveTrigger(initiativeEffect, false);
 

--- a/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
@@ -231,7 +231,7 @@ public class ReplacementHandler {
         chosenRE.setHasRun(true);
         hasRun.add(chosenRE);
         chosenRE.setOtherChoices(possibleReplacers);
-        ReplacementResult res = executeReplacement(runParams, chosenRE, decider, game);
+        ReplacementResult res = executeReplacement(runParams, chosenRE, decider);
         if (res == ReplacementResult.NotReplaced) {
             if (!possibleReplacers.isEmpty()) {
                 res = run(event, runParams);
@@ -287,8 +287,7 @@ public class ReplacementHandler {
      *            the replacement effect to run
      */
     private ReplacementResult executeReplacement(final Map<AbilityKey, Object> runParams,
-        final ReplacementEffect replacementEffect, final Player decider, final Game game) {
-
+        final ReplacementEffect replacementEffect, final Player decider) {
         SpellAbility effectSA = null;
 
         Card host = replacementEffect.getHostCard();
@@ -441,7 +440,7 @@ public class ReplacementHandler {
         int damage = (int) runParams.get(AbilityKey.DamageAmount);
         Map<String, String> mapParams = re.getMapParams();
 
-        ReplacementResult res = executeReplacement(runParams, re, decider, game);
+        ReplacementResult res = executeReplacement(runParams, re, decider);
         GameEntity newTarget = (GameEntity) runParams.get(AbilityKey.Affected);
         int newDamage = (int) runParams.get(AbilityKey.DamageAmount);
 

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
@@ -201,6 +201,11 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
         this.lastStateGraveyard = new CardCollection(lastStateGraveyard);
     }
 
+    public void clearLastState() {
+        lastStateBattlefield = null;
+        lastStateGraveyard = null;
+    }
+
     protected SpellAbility(final Card iSourceCard, final Cost toPay) {
         this(iSourceCard, toPay, null);
     }

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
@@ -828,10 +828,6 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
         if (isActivatedAbility()) {
             setXManaCostPaid(null);
         }
-
-        // reset last state when finished resolving
-        setLastStateBattlefield(CardCollection.EMPTY);
-        setLastStateGraveyard(CardCollection.EMPTY);
     }
 
     // key for autoyield - the card description (including number) (if there is a card) plus the effect description

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbilityCondition.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbilityCondition.java
@@ -243,7 +243,7 @@ public class SpellAbilityCondition extends SpellAbilityVariables {
         if (params.containsKey("ConditionTargetsSingleTarget")) {
             this.setTargetsSingleTarget(true);
         }
-    } // setConditions
+    }
 
     /**
      * <p>

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbilityRestriction.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbilityRestriction.java
@@ -189,7 +189,7 @@ public class SpellAbilityRestriction extends SpellAbilityVariables {
             this.setClassLevelOperator(params.get("ClassLevel").substring(0, 2));
             this.setClassLevel(params.get("ClassLevel").substring(2));
         }
-    } // end setRestrictions()
+    }
 
     /**
      * <p>

--- a/forge-game/src/main/java/forge/game/trigger/TriggerHandler.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerHandler.java
@@ -528,9 +528,6 @@ public class TriggerHandler {
             sa = sa.copy(host, controller, false);
         }
 
-        sa.setLastStateBattlefield(game.getLastStateBattlefield());
-        sa.setLastStateGraveyard(game.getLastStateGraveyard());
-
         sa.setTrigger(regtrig);
         sa.setSourceTrigger(regtrig.getId());
         regtrig.setTriggeringObjects(sa, runParams);
@@ -565,7 +562,6 @@ public class TriggerHandler {
         //wrapperAbility.setDescription(wrapperAbility.getStackDescription());
         //wrapperAbility.setDescription(wrapperAbility.toUnsuppressedString());
 
-        wrapperAbility.setLastStateBattlefield(game.getLastStateBattlefield());
         if (regtrig.isStatic()) {
             wrapperAbility.getActivatingPlayer().getController().playTrigger(host, wrapperAbility, isMandatory);
         } else {

--- a/forge-game/src/main/java/forge/game/trigger/TriggerSpellAbilityCastOrCopy.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerSpellAbilityCastOrCopy.java
@@ -279,11 +279,12 @@ public class TriggerSpellAbilityCastOrCopy extends Trigger {
         sa.setTriggeringObject(AbilityKey.LifeAmount, castSA.getAmountLifePaid());
         sa.setTriggeringObjectsFrom(
                 runParams,
-            AbilityKey.Player,
-            AbilityKey.Activator,
-            AbilityKey.CurrentStormCount,
-            AbilityKey.CurrentCastSpells
-        );
+                AbilityKey.CardLKI,
+                AbilityKey.Player,
+                AbilityKey.Activator,
+                AbilityKey.CurrentStormCount,
+                AbilityKey.CurrentCastSpells
+                );
     }
 
     @Override

--- a/forge-game/src/main/java/forge/game/zone/MagicStack.java
+++ b/forge-game/src/main/java/forge/game/zone/MagicStack.java
@@ -320,6 +320,14 @@ public class MagicStack /* extends MyObservable */ implements Iterable<SpellAbil
 
         // Copied spells aren't cast per se so triggers shouldn't run for them.
         Map<AbilityKey, Object> runParams = AbilityKey.mapFromPlayer(sp.getHostCard().getController());
+
+        if (sp.isSpell() && !sp.isCopied()) {
+            final Card lki = CardUtil.getLKICopy(sp.getHostCard());
+            runParams.put(AbilityKey.CardLKI, lki);
+            thisTurnCast.add(lki);
+            sp.getActivatingPlayer().addSpellCastThisTurn();
+        }
+
         runParams.put(AbilityKey.Cost, sp.getPayCosts());
         runParams.put(AbilityKey.Activator, sp.getActivatingPlayer());
         runParams.put(AbilityKey.CastSA, si.getSpellAbility(true));
@@ -461,10 +469,6 @@ public class MagicStack /* extends MyObservable */ implements Iterable<SpellAbil
 
         GameActionUtil.checkStaticAfterPaying(sp.getHostCard());
 
-        if (sp.isSpell() && !sp.isCopied()) {
-            thisTurnCast.add(CardUtil.getLKICopy(sp.getHostCard()));
-            sp.getActivatingPlayer().addSpellCastThisTurn();
-        }
         if (sp.isActivatedAbility() && sp.isPwAbility()) {
             sp.getActivatingPlayer().setActivateLoyaltyAbilityThisTurn(true);
         }

--- a/forge-game/src/main/java/forge/game/zone/MagicStack.java
+++ b/forge-game/src/main/java/forge/game/zone/MagicStack.java
@@ -44,7 +44,6 @@ import forge.game.ability.AbilityKey;
 import forge.game.ability.AbilityUtils;
 import forge.game.ability.ApiType;
 import forge.game.card.Card;
-import forge.game.card.CardCollection;
 import forge.game.card.CardUtil;
 import forge.game.event.EventValueChangeType;
 import forge.game.event.GameEventCardStatsChanged;
@@ -694,8 +693,6 @@ public class MagicStack /* extends MyObservable */ implements Iterable<SpellAbil
         frozenStack.remove(si);
         game.updateStackForView();
         SpellAbility sa = si.getSpellAbility(false);
-        sa.setLastStateBattlefield(CardCollection.EMPTY);
-        sa.setLastStateGraveyard(CardCollection.EMPTY);
         game.fireEvent(new GameEventSpellRemovedFromStack(sa));
     }
 

--- a/forge-gui/res/cardsfolder/i/imminent_doom.txt
+++ b/forge-gui/res/cardsfolder/i/imminent_doom.txt
@@ -6,5 +6,5 @@ T:Mode$ SpellCast | ValidCard$ Card.cmcEQX | ValidActivatingPlayer$ You | Trigge
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Any | NumDmg$ Y | SubAbility$ DBPutCounter
 SVar:DBPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ DOOM | CounterNum$ 1
 SVar:X:Count$CardCounters.DOOM
-SVar:Y:ThisTurnCast$Card.TriggeredCard$CardManaCost
+SVar:Y:TriggeredCardLKI$CardManaCost
 Oracle:Imminent Doom enters the battlefield with a doom counter on it.\nWhenever you cast a spell with mana value equal to the number of doom counters on Imminent Doom, Imminent Doom deals that much damage to any target. Then put a doom counter on Imminent Doom.

--- a/forge-gui/res/cardsfolder/i/imminent_doom.txt
+++ b/forge-gui/res/cardsfolder/i/imminent_doom.txt
@@ -6,5 +6,5 @@ T:Mode$ SpellCast | ValidCard$ Card.cmcEQX | ValidActivatingPlayer$ You | Trigge
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Any | NumDmg$ Y | SubAbility$ DBPutCounter
 SVar:DBPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ DOOM | CounterNum$ 1
 SVar:X:Count$CardCounters.DOOM
-SVar:Y:LastStateBattlefield$CardCounters.DOOM
+SVar:Y:ThisTurnCast$Card.TriggeredCard$CardManaCost
 Oracle:Imminent Doom enters the battlefield with a doom counter on it.\nWhenever you cast a spell with mana value equal to the number of doom counters on Imminent Doom, Imminent Doom deals that much damage to any target. Then put a doom counter on Imminent Doom.


### PR DESCRIPTION
This fixes a missing opportunity to "reduce" some of the interactions of an exiled card.

For testing have _Rest in Peace_ and try to remove exiled cards with _Pull from Eternity_:
- with the activated ability of _Torrent Elemental_ on the stack it should be prevented from ETB
- ExiledWith links should break
- MayPlay stuff should end
- etc.

Because the rules say it doesn't change zones this would also stop effect cleanup, but luckily we have another trigger for this.

- [x] Fix _Imminent Doom_