### PR TITLE
upscale ibis from 60% to 130%

### DIFF
--- a/forge-gui/res/adventure/common/world/enemies.json
+++ b/forge-gui/res/adventure/common/world/enemies.json
@@ -12544,7 +12544,7 @@
 	"spawnRate": 1,
 	"difficulty": 0.1,
 	"speed": 25,
-	"scale": 0.6,
+	"scale": 1.3,
 	"life": 11,
 	"rewards": [
 		{


### PR DESCRIPTION
Ibis sprite is too small. Turns out it is even being scaled *down*! Scaling it up instead.