### PR TITLE
Fix cheating when paying hybrid shards with combo abilities

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
@@ -962,7 +962,12 @@ public class ComputerUtilMana {
             ManaCostShard toPay, SpellAbility saPayment) {
         AbilityManaPart m = saPayment.getManaPart();
         if (m.isComboMana()) {
-            m.setExpressChoice(ColorSet.fromMask(toPay.getColorMask()));
+            // usually we'll want to produce color that matches the shard
+            ColorSet shared = ColorSet.fromMask(toPay.getColorMask()).getSharedColors(ColorSet.fromNames(m.getComboColors(saPayment).split(" ")));
+            // but other effects might still lead to a more permissive payment
+            if (!shared.isColorless()) {
+                m.setExpressChoice(ColorSet.fromMask(shared.iterator().next()));
+            }
             getComboManaChoice(ai, saPayment, sa, cost);
         }
         else if (saPayment.getApi() == ApiType.ManaReflected) {

--- a/forge-ai/src/main/java/forge/ai/ability/ControlGainAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ControlGainAi.java
@@ -112,7 +112,7 @@ public class ControlGainAi extends SpellAbilityAi {
 
         // Don't steal something if I can't Attack without, or prevent it from blocking at least
         if (lose.contains("EOT")
-                && ai.getGame().getPhaseHandler().getPhase().isAfter(PhaseType.COMBAT_DECLARE_ATTACKERS)
+                && game.getPhaseHandler().getPhase().isAfter(PhaseType.COMBAT_DECLARE_ATTACKERS)
                 && !sa.isTrigger()) {
             return false;
         }

--- a/forge-ai/src/main/java/forge/ai/ability/CounterAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CounterAi.java
@@ -144,7 +144,7 @@ public class CounterAi extends SpellAbilityAi {
             String logic = sa.getParam("AILogic");
             if ("Never".equals(logic)) {
                 return false;
-            } else if (logic.startsWith("MinCMC.")) {
+            } else if (logic.startsWith("MinCMC.")) { // TODO fix Daze and fold into AITgts
                 int minCMC = Integer.parseInt(logic.substring(7));
                 if (tgtCMC < minCMC) {
                     return false;

--- a/forge-game/src/main/java/forge/game/ability/effects/SacrificeEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/SacrificeEffect.java
@@ -122,9 +122,8 @@ public class SacrificeEffect extends SpellAbilityEffect {
                     String [] msgArray = msg.split(" & ");
                     List<CardCollection> validTargetsList = new ArrayList<>(validArray.length);
                     for (String subValid : validArray) {
-                        CardCollectionView validTargets = AbilityUtils.filterListByType(battlefield, subValid, sa);
-                        validTargets = CardLists.filter(validTargets, CardPredicates.canBeSacrificedBy(sa, true));
-                        validTargetsList.add(new CardCollection(validTargets));
+                        CardCollection validTargets = CardLists.filter(AbilityUtils.filterListByType(battlefield, subValid, sa), CardPredicates.canBeSacrificedBy(sa, true));
+                        validTargetsList.add(validTargets);
                     }
                     CardCollection chosenCards = new CardCollection();
                     for (int i = 0; i < validArray.length; ++i) {

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -523,7 +523,13 @@ public class CardFactoryUtil {
     public static List<String> sharedKeywords(final Iterable<String> kw, final String[] restrictions,
             final Iterable<ZoneType> zones, final Card host, CardTraitBase ctb) {
         final List<String> filteredkw = Lists.newArrayList();
-        final Player p = host.getController();
+        Player p = null;
+        if (ctb instanceof SpellAbility) {
+            p = ((SpellAbility)ctb).getActivatingPlayer();
+        }
+        if (p == null) {
+            p = host.getController();
+        }
         CardCollectionView cardlist = p.getGame().getCardsIn(zones);
         final Set<String> landkw = Sets.newHashSet();
         final Set<String> protectionkw = Sets.newHashSet();

--- a/forge-game/src/main/java/forge/game/combat/CombatUtil.java
+++ b/forge-game/src/main/java/forge/game/combat/CombatUtil.java
@@ -1126,7 +1126,7 @@ public class CombatUtil {
         if (!canBlock(blocker, nextTurn)) {
             return false;
         }
-        
+
         if (isUnblockableFromLandwalk(attacker, blocker.getController())
         		&& !blocker.hasKeyword("CARDNAME can block creatures with landwalk abilities as though they didn't have those abilities.")) {
             return false;

--- a/forge-gui/res/cardsfolder/o/odric_master_tactician.txt
+++ b/forge-gui/res/cardsfolder/o/odric_master_tactician.txt
@@ -3,8 +3,7 @@ ManaCost:2 W W
 Types:Legendary Creature Human Soldier
 PT:3/4
 K:First Strike
-T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | CheckSVar$ OdricTest | SVarCompare$ GE3 | NoResolvingCheck$ True | Execute$ TrigOdricEffect | TriggerDescription$ Whenever CARDNAME and at least three other creatures attack, you choose which creatures block this combat and how those creatures block.
+T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | IsPresent$ Creature.attacking+Other | PresentCompare$ GE3 | NoResolvingCheck$ True | Execute$ TrigOdricEffect | TriggerDescription$ Whenever CARDNAME and at least three other creatures attack, you choose which creatures block this combat and how those creatures block.
 SVar:TrigOdricEffect:DB$ DeclareCombatants | DeclareBlockers$ True
-SVar:OdricTest:Count$Valid Creature.attacking+Other
 AI:RemoveDeck:All
 Oracle:First strike (This creature deals combat damage before creatures without first strike.)\nWhenever Odric, Master Tactician and at least three other creatures attack, you choose which creatures block this combat and how those creatures block.

--- a/forge-gui/res/cardsfolder/upcoming/archivist_of_gondor.txt
+++ b/forge-gui/res/cardsfolder/upcoming/archivist_of_gondor.txt
@@ -5,6 +5,6 @@ PT:2/3
 T:Mode$ DamageDone | ValidSource$ Card.IsCommander+YouOwn | ValidTarget$ Player | CheckSVar$ Monarch | SVarCompare$ EQ0 | CombatDamage$ True | Execute$ TrigMonarch | TriggerZones$ Battlefield | TriggerDescription$ When your commander deals combat damage to a player, if there is no monarch, you become the monarch.
 SVar:TrigMonarch:DB$ BecomeMonarch | Defined$ You 
 SVar:Monarch:PlayerCountPlayers$HasPropertyisMonarch
-T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ Player.IsMonarch | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ At the beginning of the monarch's end step, that player draws a card.
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ Player.isMonarch | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ At the beginning of the monarch's end step, that player draws a card.
 SVar:TrigDraw:DB$ Draw | Defined$ TriggeredPlayer
 Oracle:When your commander deals combat damage to a player, if there is no monarch, you become the monarch.\nAt the beginning of the monarch's end step, that player draws a card.

--- a/forge-gui/res/cardsfolder/upcoming/the_grey_havens.txt
+++ b/forge-gui/res/cardsfolder/upcoming/the_grey_havens.txt
@@ -3,7 +3,7 @@ ManaCost:no cost
 Types:Legendary Land
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters the battlefield, scry 1.
 SVar:TrigScry:DB$ Scry | ScryNum$ 1
-A:AB$ Mana | Cost$ T | Produced$ C | Amount$ 1 | SpellDescription$ Add {C}
+A:AB$ Mana | Cost$ T | Produced$ C | Amount$ 1 | SpellDescription$ Add {C}.
 A:AB$ ManaReflected | Cost$ T | ColorOrType$ Color | Valid$ Defined.ValidGraveyard Creature.Legendary+YouOwn | ReflectProperty$ Is | SpellDescription$ Add one mana of any color among legendary creature cards in your graveyard.
 DeckHints:Type$Legendary & Type$Creature
-Oracle:When The Grey Havens enters the battlefield, scry 1.{T}: Add {C}.\n{T}: Add one mana of any color among legendary creature cards in your graveyard.
+Oracle:When The Grey Havens enters the battlefield, scry 1.\n{T}: Add {C}.\n{T}: Add one mana of any color among legendary creature cards in your graveyard.

--- a/forge-gui/res/cardsfolder/v/valakut_the_molten_pinnacle.txt
+++ b/forge-gui/res/cardsfolder/v/valakut_the_molten_pinnacle.txt
@@ -2,7 +2,7 @@ Name:Valakut, the Molten Pinnacle
 ManaCost:no cost
 Types:Land
 K:CARDNAME enters the battlefield tapped.
-T:Mode$ ChangesZone | ValidCard$ Mountain.YouCtrl | Origin$ Any | Destination$ Battlefield | OptionalDecider$ You | Execute$ TrigDamage | IsPresent$ Mountain.YouCtrl | PresentCompare$ GE6 | TriggerZones$ Battlefield | TriggerDescription$ Whenever a Mountain enters the battlefield under your control, if you control at least five other Mountains, you may have CARDNAME deal 3 damage to any target.
-SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Any | NumDmg$ 3
+T:Mode$ ChangesZone | ValidCard$ Mountain.YouCtrl | Origin$ Any | Destination$ Battlefield | OptionalDecider$ You | Execute$ TrigDamage | IsPresent$ Mountain.YouCtrl | PresentCompare$ GE6 | NoResolvingCheck$ True | TriggerZones$ Battlefield | TriggerDescription$ Whenever a Mountain enters the battlefield under your control, if you control at least five other Mountains, you may have CARDNAME deal 3 damage to any target.
+SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Any | NumDmg$ 3 | ConditionPresent$ Mountain.YouCtrl+NotTriggeredCard | ConditionCompare$ GE5
 A:AB$ Mana | Cost$ T | Produced$ R | SpellDescription$ Add {R}.
 Oracle:Valakut, the Molten Pinnacle enters the battlefield tapped.\nWhenever a Mountain enters the battlefield under your control, if you control at least five other Mountains, you may have Valakut, the Molten Pinnacle deal 3 damage to any target.\n{T}: Add {R}.

--- a/forge-gui/res/cardsfolder/v/valakut_the_molten_pinnacle.txt
+++ b/forge-gui/res/cardsfolder/v/valakut_the_molten_pinnacle.txt
@@ -2,7 +2,7 @@ Name:Valakut, the Molten Pinnacle
 ManaCost:no cost
 Types:Land
 K:CARDNAME enters the battlefield tapped.
-T:Mode$ ChangesZone | ValidCard$ Mountain.YouCtrl | Origin$ Any | Destination$ Battlefield | OptionalDecider$ You | Execute$ TrigDamage | IsPresent$ Mountain.YouCtrl | PresentCompare$ GE6 | NoResolvingCheck$ True | TriggerZones$ Battlefield | TriggerDescription$ Whenever a Mountain enters the battlefield under your control, if you control at least five other Mountains, you may have CARDNAME deal 3 damage to any target.
-SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Any | NumDmg$ 3 | ConditionPresent$ Mountain.YouCtrl+NotTriggeredCard | ConditionCompare$ GE5
+T:Mode$ ChangesZone | ValidCard$ Mountain.YouCtrl | Origin$ Any | Destination$ Battlefield | Execute$ TrigDamage | IsPresent$ Mountain.YouCtrl | PresentCompare$ GE6 | NoResolvingCheck$ True | TriggerZones$ Battlefield | TriggerDescription$ Whenever a Mountain enters the battlefield under your control, if you control at least five other Mountains, you may have CARDNAME deal 3 damage to any target.
+SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Any | NumDmg$ 3 | ConditionPresent$ Mountain.YouCtrl+NotTriggeredCard | ConditionCompare$ GE5 | OptionalDecider$ You
 A:AB$ Mana | Cost$ T | Produced$ R | SpellDescription$ Add {R}.
 Oracle:Valakut, the Molten Pinnacle enters the battlefield tapped.\nWhenever a Mountain enters the battlefield under your control, if you control at least five other Mountains, you may have Valakut, the Molten Pinnacle deal 3 damage to any target.\n{T}: Add {R}.


### PR DESCRIPTION
- Closes #3400

- > If a Mountain you control leaves the battlefield between the time Valakut’s second ability triggers and the time it resolves, be aware if that was the Mountain that caused Valakut’s ability to trigger or not. If it was, Valakut’s count isn’t affected; if it wasn’t, Valakut’s count goes down by one.

- Closes #3404