### PR TITLE
flag cards AI is consistently bad at.

### DIFF
--- a/forge-gui/res/cardsfolder/e/elderscale_wurm.txt
+++ b/forge-gui/res/cardsfolder/e/elderscale_wurm.txt
@@ -9,4 +9,6 @@ R:Event$ LifeReduced | ActiveZones$ Battlefield | ValidPlayer$ You | Result$ LT7
 SVar:ReduceLoss:DB$ ReplaceEffect | VarName$ Result | VarValue$ X
 SVar:X:ReplaceCount$Result/NMinus.7
 SVar:ElderscaleCondition:Count$YourLifeTotal
+#NOTE: If the opponent controls the wurm, AI won't take into consideration that combat damage may be ineffective.
+AI:RemoveDeck:All
 Oracle:Trample\nWhen Elderscale Wurm enters the battlefield, if your life total is less than 7, your life total becomes 7.\nAs long as you have 7 or more life, damage that would reduce your life total to less than 7 reduces it to 7 instead.

--- a/forge-gui/res/cardsfolder/e/endless_swarm.txt
+++ b/forge-gui/res/cardsfolder/e/endless_swarm.txt
@@ -6,4 +6,6 @@ A:SP$ Token | Cost$ 5 G G G | TokenAmount$ X | TokenScript$ g_1_1_snake | TokenO
 SVar:X:Count$InYourHand
 #NOTE: The AI will not stop making land drops after casting this spell (so, random decks may also utilize manlands and other cards with activation cost already on the battlefield to the maximum effect)
 AI:RemoveDeck:Random
+#NOTE: Memory leak.
+AI:RemoveDeck:All
 Oracle:Create a 1/1 green Snake creature token for each card in your hand.\nEpic (For the rest of the game, you can't cast spells. At the beginning of each of your upkeeps, copy this spell except for its epic ability.)

--- a/forge-gui/res/cardsfolder/g/grothama_all_devouring.txt
+++ b/forge-gui/res/cardsfolder/g/grothama_all_devouring.txt
@@ -10,4 +10,6 @@ SVar:TrigRepeat:DB$ RepeatEach | RepeatPlayers$ Player | RepeatSubAbility$ TrigD
 SVar:TrigDraw:DB$ Draw | Defined$ Remembered | NumCards$ X
 SVar:X:TriggeredCard$TotalDamageThisTurn Card.RememberedPlayerCtrl
 SVar:HasAttackEffect:TRUE
+#NOTE: AI will always choose to activate the "fight Grothama" ability if one of its creatures attacks.
+AI:RemoveDeck:All
 Oracle:Other creatures have "Whenever this creature attacks, you may have it fight Grothama, All-Devouring."\nWhen Grothama leaves the battlefield, each player draws cards equal to the amount of damage dealt to Grothama this turn by sources they controlled.

--- a/forge-gui/res/cardsfolder/t/tempting_wurm.txt
+++ b/forge-gui/res/cardsfolder/t/tempting_wurm.txt
@@ -6,4 +6,6 @@ T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.S
 SVar:EachOpponent:DB$ RepeatEach | RepeatPlayers$ Player.Opponent | RepeatSubAbility$ TemptingChange
 SVar:TemptingChange:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | ChangeType$ Artifact,Creature,Enchantment,Land | DefinedPlayer$ Remembered | ChangeNum$ X
 SVar:X:Count$ValidHand Artifact.RememberedPlayerCtrl,Creature.RememberedPlayerCtrl,Enchantment.RememberedPlayerCtrl,Land.RememberedPlayerCtrl
+#NOTE: AI will play Tempting Wurm on turn two when the opponent still has a full hand.
+AI:RemoveDeck:All
 Oracle:When Tempting Wurm enters the battlefield, each opponent may put any number of artifact, creature, enchantment, and/or land cards from their hand onto the battlefield.


### PR DESCRIPTION
Elderscale Wurm, Grothama, Tempting Wurm, and Endless Swarm are all consistently problematic for AI. Adding flags with comments.