### PR TITLE
add five new decks by MasterXploder7 to standard/not in use.

### DIFF
--- a/forge-gui/res/adventure/common/decks/standard/not in use/dog_w_beginner.dck
+++ b/forge-gui/res/adventure/common/decks/standard/not in use/dog_w_beginner.dck
@@ -1,0 +1,26 @@
+[metadata]
+Name=Adventure - dog beginner
+[Avatar]
+
+[Main]
+4 Alpine Watchdog|M21|1
+4 Boros Mastiff|DGM|1
+4 Champion of Arashin|MB1|1
+4 Isamaru, Hound of Konda|FMB1|1
+24 Plains|M21|4
+4 Potion of Healing|AFR|1
+2 Rambunctious Mutt|M21|1
+2 Revitalize|M21|1
+4 Spirited Companion|NEO|1
+4 Tarkir Duneshaper|MOM|1
+4 Thraben Purebloods|ISD|1
+[Sideboard]
+
+[Planes]
+
+[Schemes]
+
+[Conspiracy]
+
+[Dungeon]
+

--- a/forge-gui/res/adventure/common/decks/standard/not in use/drake_ur_beginner.dck
+++ b/forge-gui/res/adventure/common/decks/standard/not in use/drake_ur_beginner.dck
@@ -1,0 +1,34 @@
+[metadata]
+Name=Amonkhet - Drakes 2 beginner
+[Avatar]
+
+[Main]
+4 Abrade|SCD|1
+2 Alandra, Sky Dreamer|J22|1
+2 Careful Study|ODY|1
+2 Crackling Drake|GRN|1
+4 Enigma Drake|AKR|1
+2 Faithless Looting|C14|1
+4 Force Away|KTK|1
+2 Frostboil Snarl|MOC|1
+2 Haunted Fengraf|DKA|1
+4 Incubation // Incongruity|RNA|1
+6 Island|AKR|4
+6 Mountain|AKR|4
+4 Reconnaissance Mission|VOC|1
+4 Swiftwater Cliffs|NEO|1
+2 Talrand, Sky Summoner|M13|1
+2 Temple of Epiphany|JOU|1
+3 Train of Thought|GPT|1
+3 Vision Skeins|DIS|1
+2 Wandering Fumarole|OGW|1
+[Sideboard]
+
+[Planes]
+
+[Schemes]
+
+[Conspiracy]
+
+[Dungeon]
+

--- a/forge-gui/res/adventure/common/decks/standard/not in use/drake_ur_mid.dck
+++ b/forge-gui/res/adventure/common/decks/standard/not in use/drake_ur_mid.dck
@@ -1,0 +1,29 @@
+[metadata]
+Name=Amonkhet - Drakes 3 mid
+[Avatar]
+
+[Main]
+4 Abrade|SCD|1
+3 Alandra, Sky Dreamer|J22|1
+3 Compulsive Research|E01|1
+3 Crackling Drake|GRN|1
+4 Enigma Drake|AKR|1
+4 Faithless Looting|DKA|1
+4 Force Away|KTK|1
+4 Incubation // Incongruity|RNA|1
+8 Island|AKR|4
+4 Izzet Charm|RTR|1
+8 Mountain|AKR|4
+4 Steam Vents|RTR|1
+4 Stormcarved Coast|VOW|1
+3 Talrand, Sky Summoner|M13|1
+[Sideboard]
+
+[Planes]
+
+[Schemes]
+
+[Conspiracy]
+
+[Dungeon]
+

--- a/forge-gui/res/adventure/common/decks/standard/not in use/drake_ur_unfair.dck
+++ b/forge-gui/res/adventure/common/decks/standard/not in use/drake_ur_unfair.dck
@@ -1,0 +1,30 @@
+[metadata]
+Name=Amonkhet - Drakes 1 unfair
+[Avatar]
+
+[Main]
+3 Alandra, Sky Dreamer|J22|1
+4 Brainstorm|SS1|1
+4 Crackling Drake|GRN|1
+4 Desolate Lighthouse|AVR|1
+4 Enigma Drake|AKR|1
+4 Fire // Ice|APC|1
+4 Izzet Charm|RTR|1
+4 Preordain|BRC|1
+4 Prismari Command|STX|2
+4 Scalding Tarn|MH2|1
+4 Steam Vents|RTR|1
+4 Stormcarved Coast|VOW|1
+4 Sulfur Falls|DOM|1
+3 Talrand, Sky Summoner|M13|1
+4 Volcanic Island|VMA|1
+[Sideboard]
+
+[Planes]
+
+[Schemes]
+
+[Conspiracy]
+
+[Dungeon]
+

--- a/forge-gui/res/adventure/common/decks/standard/not in use/zombie_drake_ubr.dck
+++ b/forge-gui/res/adventure/common/decks/standard/not in use/zombie_drake_ubr.dck
@@ -1,0 +1,47 @@
+[metadata]
+Name=Amonkhet - Drakes 4 grixis
+[Avatar]
+
+[Main]
+3 Alandra, Sky Dreamer|J22|1
+2 Blackmail|ONS|1
+2 Careful Study|ODY|1
+2 Crosis's Charm|PLS|1
+4 Crumbling Necropolis|DDH|1
+1 Dimir Charm|GTC|1
+1 Dragonskull Summit|E01|1
+1 Drowned Catacomb|E01|1
+4 Enigma Drake|AKR|1
+1 Far // Away|DGM|1
+1 Fire // Ice|APC|1
+2 Grixis Charm|DDH|1
+1 Haunted Ridge|MID|1
+4 Island|AKR|4
+1 Izzet Charm|RTR|1
+2 Maestros Charm|SNC|1
+4 Mountain|AKR|4
+1 Pain // Suffering|INV|1
+1 Rakdos Charm|RTR|1
+3 Scavenger Drake|ALA|1
+1 Shipwreck Marsh|MID|1
+2 Shock|STH|1
+1 Spite // Malice|INV|1
+1 Stormcarved Coast|VOW|1
+1 Sulfur Falls|DOM|1
+4 Swamp|AKR|4
+3 Talrand, Sky Summoner|M13|1
+1 Terminate|C17|1
+1 Toil // Trouble|DGM|1
+1 Turn // Burn|DGM|1
+1 Tyrant's Scorn|WAR|1
+3 Xander's Lounge|SNC|1
+[Sideboard]
+
+[Planes]
+
+[Schemes]
+
+[Conspiracy]
+
+[Dungeon]
+


### PR DESCRIPTION
MasterXploder7 created five decks a few weeks ago. Three of them are for the upcoming drake enemy, one is for a zombie drake that doesn't exist yet, and one is for the dog enemy. I leave it to the game balancers to make changes to enemies.json as required to implement the decks and migrate the decks out of the "not in use" directory.

Sidenote.... we need to get MasterXploder7 trained in the ways of Git....