### PR TITLE
Basic AI for Chalice of the Void, minor DamageDealAi improvement

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/DamageAiBase.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DamageAiBase.java
@@ -1,14 +1,11 @@
 package forge.ai.ability;
 
-import com.google.common.collect.Iterables;
-
 import forge.ai.ComputerUtil;
 import forge.ai.ComputerUtilCombat;
 import forge.ai.SpellAbilityAi;
 import forge.game.Game;
 import forge.game.card.Card;
 import forge.game.card.CardCollectionView;
-import forge.game.card.CardPredicates;
 import forge.game.keyword.Keyword;
 import forge.game.phase.PhaseHandler;
 import forge.game.phase.PhaseType;

--- a/forge-ai/src/main/java/forge/ai/ability/DamageAiBase.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DamageAiBase.java
@@ -46,11 +46,6 @@ public abstract class DamageAiBase extends SpellAbilityAi {
     }
 
     protected boolean shouldTgtP(final Player comp, final SpellAbility sa, final int d, final boolean noPrevention) {
-        // TODO: once the "planeswalker redirection" rule is removed completely, just remove this code and
-        // remove the "burn Planeswalkers" code in the called method.
-        return shouldTgtP(comp, sa, d, noPrevention, false);
-    }
-    protected boolean shouldTgtP(final Player comp, final SpellAbility sa, final int d, final boolean noPrevention, final boolean noPlaneswalkerRedirection) {
         int restDamage = d;
         final Game game = comp.getGame();
         Player enemy = comp.getWeakestOpponent();
@@ -87,13 +82,6 @@ public abstract class DamageAiBase extends SpellAbilityAi {
                     return true;
                 }
             }
-        }
-
-        // burn Planeswalkers
-        // TODO: Must be removed completely when the "planeswalker redirection" rule is removed.
-        if (!noPlaneswalkerRedirection
-                && Iterables.any(enemy.getCardsIn(ZoneType.Battlefield), CardPredicates.Presets.PLANESWALKERS)) {
-            return true;
         }
 
         if (avoidTargetP(comp, sa)) {

--- a/forge-ai/src/main/java/forge/ai/ability/DamageDealAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DamageDealAi.java
@@ -735,7 +735,7 @@ public class DamageDealAi extends DamageAiBase {
                         || (SpellAbilityAi.isSorcerySpeed(sa, ai) && phase.is(PhaseType.MAIN2))
                         || immediately) {
                     boolean pingAfterAttack = "PingAfterAttack".equals(logic) && phase.getPhase().isAfter(PhaseType.COMBAT_DECLARE_ATTACKERS) && phase.isPlayerTurn(ai);
-                    if (pingAfterAttack || shouldTgtP(ai, sa, dmg, noPrevention)) {
+                    if ((pingAfterAttack && !avoidTargetP(ai, sa)) || shouldTgtP(ai, sa, dmg, noPrevention)) {
                         tcs.add(enemy);
                         if (divided) {
                             sa.addDividedAllocation(enemy, dmg);

--- a/forge-ai/src/main/java/forge/ai/ability/DamageDealAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DamageDealAi.java
@@ -630,7 +630,7 @@ public class DamageDealAi extends DamageAiBase {
             if (tgt.canTgtPlaneswalker()) {
                 // We can damage planeswalkers with this, consider targeting.
                 Card c = dealDamageChooseTgtPW(ai, sa, dmg, noPrevention, enemy, false);
-                if (c != null && !shouldTgtP(ai, sa, dmg, noPrevention, true)) {
+                if (c != null && !shouldTgtP(ai, sa, dmg, noPrevention)) {
                     tcs.add(c);
                     if (divided) {
                         int assignedDamage = ComputerUtilCombat.getEnoughDamageToKill(c, dmg, source, false, noPrevention);
@@ -751,7 +751,7 @@ public class DamageDealAi extends DamageAiBase {
                         || (SpellAbilityAi.isSorcerySpeed(sa, ai) && phase.is(PhaseType.MAIN2))
                         || immediately) {
                     boolean pingAfterAttack = "PingAfterAttack".equals(logic) && phase.getPhase().isAfter(PhaseType.COMBAT_DECLARE_ATTACKERS) && phase.isPlayerTurn(ai);
-                    if ((pingAfterAttack || shouldTgtP(ai, sa, dmg, noPrevention)) && !avoidTargetP(ai,sa)) {
+                    if (pingAfterAttack || shouldTgtP(ai, sa, dmg, noPrevention)) {
                         tcs.add(enemy);
                         if (divided) {
                             sa.addDividedAllocation(enemy, dmg);

--- a/forge-ai/src/main/java/forge/ai/ability/DamageDealAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DamageDealAi.java
@@ -746,17 +746,17 @@ public class DamageDealAi extends DamageAiBase {
                 }
                 return false;
             }
-            // TODO: Improve Damage, we shouldn't just target the player just because we can
             if (sa.canTarget(enemy) && sa.canAddMoreTarget()) {
-                if (((phase.is(PhaseType.END_OF_TURN) && phase.getNextTurn().equals(ai))
+                if ((phase.is(PhaseType.END_OF_TURN) && phase.getNextTurn().equals(ai))
                         || (SpellAbilityAi.isSorcerySpeed(sa, ai) && phase.is(PhaseType.MAIN2))
-                        || ("PingAfterAttack".equals(logic) && phase.getPhase().isAfter(PhaseType.COMBAT_DECLARE_ATTACKERS) && phase.isPlayerTurn(ai))
-                        || immediately || shouldTgtP(ai, sa, dmg, noPrevention)) &&
-                        (!avoidTargetP(ai, sa))) {
-                    tcs.add(enemy);
-                    if (divided) {
-                        sa.addDividedAllocation(enemy, dmg);
-                        break;
+                        || immediately) {
+                    boolean pingAfterAttack = "PingAfterAttack".equals(logic) && phase.getPhase().isAfter(PhaseType.COMBAT_DECLARE_ATTACKERS) && phase.isPlayerTurn(ai);
+                    if ((pingAfterAttack || shouldTgtP(ai, sa, dmg, noPrevention)) && !avoidTargetP(ai,sa)) {
+                        tcs.add(enemy);
+                        if (divided) {
+                            sa.addDividedAllocation(enemy, dmg);
+                            break;
+                        }
                     }
                 }
             }

--- a/forge-ai/src/main/java/forge/ai/ability/DamageDealAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DamageDealAi.java
@@ -1,28 +1,10 @@
 package forge.ai.ability;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
-
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-
-import forge.ai.AiController;
-import forge.ai.AiProps;
-import forge.ai.ComputerUtil;
-import forge.ai.ComputerUtilAbility;
-import forge.ai.ComputerUtilCard;
-import forge.ai.ComputerUtilCombat;
-import forge.ai.ComputerUtilCost;
-import forge.ai.ComputerUtilMana;
-import forge.ai.PlayerControllerAi;
-import forge.ai.SpecialCardAi;
-import forge.ai.SpellAbilityAi;
+import forge.ai.*;
 import forge.card.MagicColor;
 import forge.card.mana.ManaCost;
 import forge.game.Game;
@@ -30,11 +12,7 @@ import forge.game.GameEntity;
 import forge.game.GameObject;
 import forge.game.ability.AbilityUtils;
 import forge.game.ability.ApiType;
-import forge.game.card.Card;
-import forge.game.card.CardCollection;
-import forge.game.card.CardLists;
-import forge.game.card.CardPredicates;
-import forge.game.card.CounterEnumType;
+import forge.game.card.*;
 import forge.game.cost.Cost;
 import forge.game.cost.CostPartMana;
 import forge.game.keyword.Keyword;
@@ -51,6 +29,12 @@ import forge.game.staticability.StaticAbilityMustTarget;
 import forge.game.zone.ZoneType;
 import forge.util.Aggregates;
 import forge.util.MyRandom;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 public class DamageDealAi extends DamageAiBase {
     @Override

--- a/forge-ai/src/main/java/forge/ai/ability/PermanentAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PermanentAi.java
@@ -1,21 +1,14 @@
 package forge.ai.ability;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
-
 import forge.ai.ComputerUtil;
 import forge.ai.ComputerUtilCost;
 import forge.ai.ComputerUtilMana;
 import forge.ai.SpellAbilityAi;
 import forge.card.CardType.Supertype;
 import forge.card.mana.ManaCost;
-import forge.game.card.Card;
-import forge.game.card.CardCollection;
-import forge.game.card.CardCollectionView;
-import forge.game.card.CardLists;
-import forge.game.card.CardPredicates;
+import forge.game.card.*;
 import forge.game.cost.Cost;
 import forge.game.keyword.KeywordInterface;
 import forge.game.mana.ManaCostBeingPaid;
@@ -24,6 +17,7 @@ import forge.game.phase.PhaseType;
 import forge.game.player.Player;
 import forge.game.spellability.SpellAbility;
 import forge.game.zone.ZoneType;
+import org.apache.commons.lang3.StringUtils;
 
 public class PermanentAi extends SpellAbilityAi {
 
@@ -49,19 +43,19 @@ public class PermanentAi extends SpellAbilityAi {
      */
     @Override
     protected boolean checkApiLogic(final Player ai, final SpellAbility sa) {
-        final Card card = sa.getHostCard();
+        final Card source = sa.getHostCard();
 
         // check on legendary
-        if (!card.ignoreLegendRule() && ai.isCardInPlay(card.getName())) {
+        if (!source.ignoreLegendRule() && ai.isCardInPlay(source.getName())) {
             // TODO check the risk we'd lose the effect with bad timing
-            if (!card.hasSVar("AILegendaryException")) {
+            if (!source.hasSVar("AILegendaryException")) {
                 // AiPlayDecision.WouldDestroyLegend
                 return false;
             } else {
-                String specialRule = card.getSVar("AILegendaryException");
+                String specialRule = source.getSVar("AILegendaryException");
                 if ("TwoCopiesAllowed".equals(specialRule)) {
                     // One extra copy allowed on the battlefield, e.g. Brothers Yamazaki
-                    if (CardLists.count(ai.getCardsIn(ZoneType.Battlefield), CardPredicates.nameEquals(card.getName())) > 1) {
+                    if (CardLists.count(ai.getCardsIn(ZoneType.Battlefield), CardPredicates.nameEquals(source.getName())) > 1) {
                         return false;
                     }
                 } else if ("AlwaysAllowed".equals(specialRule)) {
@@ -73,23 +67,7 @@ public class PermanentAi extends SpellAbilityAi {
             }
         }
 
-        /* -- not used anymore after Ixalan (Planeswalkers are now legendary, not unique by subtype) --
-        if (card.isPlaneswalker()) {
-            CardCollection list = CardLists.filter(ai.getCardsIn(ZoneType.Battlefield),
-                    CardPredicates.Presets.PLANESWALKERS);
-            for (String type : card.getType().getSubtypes()) { // determine
-                                                               // planewalker
-                                                               // subtype
-                final CardCollection cl = CardLists.getType(list, type);
-                if (!cl.isEmpty()) {
-                    // AiPlayDecision.WouldDestroyOtherPlaneswalker
-                    return false;
-                }
-                break;
-            }
-        }*/
-
-        if (card.getType().hasSupertype(Supertype.World)) {
+        if (source.getType().hasSupertype(Supertype.World)) {
             CardCollection list = CardLists.getType(ai.getCardsIn(ZoneType.Battlefield), "World");
             if (!list.isEmpty()) {
                 // AiPlayDecision.WouldDestroyWorldEnchantment
@@ -101,7 +79,6 @@ public class PermanentAi extends SpellAbilityAi {
         if (mana.countX() > 0) {
             // Set PayX here to maximum value.
             final int xPay = ComputerUtilCost.getMaxXValue(sa, ai, false);
-            final Card source = sa.getHostCard();
             if (source.hasConverge()) {
                 int nColors = ComputerUtilMana.getConvergeCount(sa, ai);
                 for (int i = 1; i <= xPay; i++) {
@@ -123,7 +100,7 @@ public class PermanentAi extends SpellAbilityAi {
             }
         } else if (mana.isZero()) {
             // if mana is zero, but card mana cost does have X, then something is wrong
-            ManaCost cardCost = card.getManaCost();
+            ManaCost cardCost = source.getManaCost();
             if (cardCost != null && cardCost.countX() > 0) {
                 // AiPlayDecision.CantPlayAi
                 return false;
@@ -143,6 +120,32 @@ public class PermanentAi extends SpellAbilityAi {
             sa.setXManaCostPaid(xPay);
         }
 
+        if ("ChaliceOfTheVoid".equals(source.getSVar("AICurseEffect"))) {
+            int maxX = sa.getXManaCostPaid(); // as set above
+            CardCollection otherChalices = CardLists.filter(ai.getGame().getCardsIn(ZoneType.Battlefield), CardPredicates.nameEquals("Chalice of the Void"));
+            outer: for (int i = 0; i <= maxX; i++) {
+                for (Card chalice : otherChalices) {
+                    if (chalice.getCounters(CounterEnumType.CHARGE) == i) {
+                        continue outer; // already disabled, no point in adding another one
+                    }
+                }
+                // assume the AI knows the deck lists of its opponents
+                CardCollection aiCards = CardLists.filter(ai.getAllCards(), CardPredicates.hasCMC(i));
+                CardCollection oppCards = CardLists.filter(ai.getStrongestOpponent().getAllCards(), CardPredicates.hasCMC(i));
+                if (i == 0) {
+                    aiCards = CardLists.filter(aiCards, Predicates.not(CardPredicates.isType("Land")));
+                    oppCards = CardLists.filter(oppCards, Predicates.not(CardPredicates.isType("Land")));
+                    // also filter out other Chalices in our own deck
+                    aiCards = CardLists.filter(aiCards, Predicates.not(CardPredicates.nameEquals("Chalice of the Void")));
+                }
+                if (oppCards.size() > 3 && oppCards.size() >= aiCards.size() * 2) {
+                    sa.setXManaCostPaid(i);
+                    return true;
+                }
+            }
+            return false;
+        }
+
         if (sa.hasParam("Announce") && sa.getParam("Announce").startsWith("Multikicker")) {
             // String announce = sa.getParam("Announce");
             ManaCost mkCost = sa.getMultiKickerManaCost();
@@ -152,13 +155,13 @@ public class PermanentAi extends SpellAbilityAi {
                 mCost = ManaCost.combine(mCost, mkCost);
                 ManaCostBeingPaid mcbp = new ManaCostBeingPaid(mCost);
                 if (!ComputerUtilMana.canPayManaCost(mcbp, sa, ai, false)) {
-                    card.setKickerMagnitude(i);
+                    source.setKickerMagnitude(i);
                     sa.setSVar("Multikicker", String.valueOf(i));
                     break;
                 }
-                card.setKickerMagnitude(i + 1);
+                source.setKickerMagnitude(i + 1);
             }
-            if (isZeroCost && card.getKickerMagnitude() == 0) {
+            if (isZeroCost && source.getKickerMagnitude() == 0) {
                 // Bail if the card cost was {0} and no multikicker was paid (e.g. Everflowing Chalice).
                 // TODO: update this if there's ever a card where it makes sense to play it for {0} with no multikicker
                 return false;
@@ -166,13 +169,13 @@ public class PermanentAi extends SpellAbilityAi {
         }
 
         // don't play cards without being able to pay the upkeep for
-        for (KeywordInterface inst : card.getKeywords()) {
+        for (KeywordInterface inst : source.getKeywords()) {
             String ability = inst.getOriginal();
             if (ability.startsWith("UpkeepCost")) {
                 final String[] k = ability.split(":");
                 final String costs = k[1];
 
-                final SpellAbility emptyAbility = new SpellAbility.EmptySa(card, ai);
+                final SpellAbility emptyAbility = new SpellAbility.EmptySa(source, ai);
                 emptyAbility.setPayCosts(new Cost(costs, true));
                 emptyAbility.setTargetRestrictions(sa.getTargetRestrictions());
                 emptyAbility.setCardState(sa.getCardState());
@@ -186,8 +189,8 @@ public class PermanentAi extends SpellAbilityAi {
         }
 
         // check for specific AI preferences
-        if (card.hasSVar("AICastPreference")) {
-            String pref = card.getSVar("AICastPreference");
+        if (source.hasSVar("AICastPreference")) {
+            String pref = source.getSVar("AICastPreference");
             String[] groups = StringUtils.split(pref, "|");
             boolean dontCast = false;
             for (String group : groups) {
@@ -205,7 +208,7 @@ public class PermanentAi extends SpellAbilityAi {
                     // Only cast unless there are X or more cards like this on the battlefield under AI control already,
                     CardCollectionView valid = param.contains("Globally") ? ai.getGame().getCardsIn(ZoneType.Battlefield)
                             : ai.getCardsIn(ZoneType.Battlefield);
-                    CardCollection ctrld = CardLists.filter(valid, CardPredicates.nameEquals(card.getName()));
+                    CardCollection ctrld = CardLists.filter(valid, CardPredicates.nameEquals(source.getName()));
 
                     int numControlled = 0;
                     if (param.endsWith("WithoutOppAuras")) {
@@ -242,7 +245,7 @@ public class PermanentAi extends SpellAbilityAi {
                     // if there are X-1 mana sources in play but the AI has an extra land in hand
                     CardCollection m = ComputerUtilMana.getAvailableManaSources(ai, true);
                     int extraMana = CardLists.count(ai.getCardsIn(ZoneType.Hand), CardPredicates.Presets.LANDS) > 0 ? 1 : 0;
-                    if (card.getName().equals("Illusions of Grandeur")) {
+                    if (source.getName().equals("Illusions of Grandeur")) {
                         // TODO: this is currently hardcoded for specific Illusions-Donate cost reduction spells, need to make this generic.
                        extraMana += Math.min(3, CardLists.filter(ai.getCardsIn(ZoneType.Battlefield), Predicates.or(CardPredicates.nameEquals("Sapphire Medallion"), CardPredicates.nameEquals("Helm of Awakening"))).size()) * 2; // each cost-reduction spell accounts for {1} in both Illusions and Donate
                     }
@@ -260,7 +263,7 @@ public class PermanentAi extends SpellAbilityAi {
                         break; // disregard other preferences, always cast as a last resort
                     }
                 } else if (param.equals("OnlyFromZone")) {
-                    if (!card.getZone().getZoneType().toString().equals(value)) {
+                    if (!source.getZone().getZoneType().toString().equals(value)) {
                         dontCast = true;
                         break; // limit casting to a specific zone only
                     }

--- a/forge-gui/res/cardsfolder/c/chalice_of_the_void.txt
+++ b/forge-gui/res/cardsfolder/c/chalice_of_the_void.txt
@@ -7,5 +7,5 @@ SVar:TrigCounter:DB$ Counter | Defined$ TriggeredSpellAbility
 SVar:X:Count$xPaid
 SVar:Y:Count$CardCounters.CHARGE
 SVar:AICurseEffect:ChaliceOfTheVoid
-AI:RemoveDeck:All
+AI:RemoveDeck:Random
 Oracle:Chalice of the Void enters the battlefield with X charge counters on it.\nWhenever a player casts a spell with mana value equal to the number of charge counters on Chalice of the Void, counter that spell.


### PR DESCRIPTION
Not the smartest thing in the world, but better than nothing.
Can be improved if the AI looks at the library/hand contents instead of all cards (assuming that it knows the deck lists *and* looks at the graveyard and exile for what already left the game), but it's a bit more like outright cheating, so I don't know, lol :)
I'm not sure if the AI should really go above X=2 or X=3 for this card or so, it's usually played for low X in specific decks against specific (usually low-cost) threats, so... Not sure too, haha.

Also fixes #3442, improving damage prediction when deciding to deal damage to the opponent with AF DealDamage.