### PR TITLE
Adventure - Updated draft set filtering

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/data/AdventureEventData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/AdventureEventData.java
@@ -187,7 +187,9 @@ public class AdventureEventData implements Serializable {
 
         List<CardBlock> legalBlocks = new ArrayList<>();
         for (CardBlock b : src) { // for each block
-            boolean isOkay = !(b.getSets().isEmpty() && b.getCntBoostersDraft() > 0);
+            if (b.getSets().isEmpty() || (b.getCntBoostersDraft() < 1))
+                continue;
+            boolean isOkay = true;
             for (CardEdition c : b.getSets()) {
                 if (!allEditions.contains(c)) {
                     isOkay = false;


### PR DESCRIPTION
Correcting faulty logic in draft set filtering to filter out sealed-only sets