### PR TITLE
Panharmonicon: support LKI of cause

### DIFF
--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityDisableTriggers.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityDisableTriggers.java
@@ -70,7 +70,11 @@ public class StaticAbilityDisableTriggers {
 
         if (trigMode.equals(TriggerType.ChangesZone)) {
             // Cause of the trigger – the card changing zones
-            if (!stAb.matchesValidParam("ValidCause", runParams.get(AbilityKey.Card))) {
+            Card moved = (Card) runParams.get(AbilityKey.Card);
+            if ("Battlefield".equals(regtrig.getParam("Origin"))) {
+                moved = (Card) runParams.get(AbilityKey.CardLKI);
+            }
+            if (!stAb.matchesValidParam("ValidCause", moved)) {
                 return false;
             }
             if (!stAb.matchesValidParam("Destination", runParams.get(AbilityKey.Destination))) {

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityPanharmonicon.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityPanharmonicon.java
@@ -89,7 +89,11 @@ public class StaticAbilityPanharmonicon {
 
         if (trigMode.equals(TriggerType.ChangesZone)) {
             // Cause of the trigger – the card changing zones
-            if (!stAb.matchesValidParam("ValidCause", runParams.get(AbilityKey.Card))) {
+            Card moved = (Card) runParams.get(AbilityKey.Card);
+            if ("Battlefield".equals(trigger.getParam("Origin"))) {
+                moved = (Card) runParams.get(AbilityKey.CardLKI);
+            }
+            if (!stAb.matchesValidParam("ValidCause", moved)) {
                 return false;
             }
             if (!stAb.matchesValidParam("Origin", runParams.get(AbilityKey.Origin))) {


### PR DESCRIPTION
> Look at each creature as it exists on the battlefield, taking into account continuous effects, to determine whether any triggered abilities will trigger multiple times. For example, if a land that has become a creature dies, an ability that triggers when it dies triggers twice.