### PR TITLE
Fix Doubling Cube producing C out of nothing if floating colors have gap

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
@@ -875,11 +875,10 @@ public class ComputerUtilMana {
             ManaPool.refundMana(manaSpentToPay, ai, sa);
             if (test) {
                 resetPayment(paymentList);
-                return false;
             } else {
                 System.out.println("ComputerUtilMana: payManaCost() cost was not paid for " + sa.toString() + " (" +  sa.getHostCard().getName() + "). Didn't find what to pay for " + toPay);
-                return false;
             }
+            return false;
         }
 
         if (test) {

--- a/forge-game/src/main/java/forge/game/ability/effects/ManaEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ManaEffect.java
@@ -222,7 +222,7 @@ public class ManaEffect extends SpellAbilityEffect {
                 } else if (type.startsWith("DoubleManaInPool")) {
                     StringBuilder sb = new StringBuilder();
                     for (byte color : ManaAtom.MANATYPES) {
-                        sb.append(StringUtils.repeat(MagicColor.toShortString(color), " ", p.getManaPool().getAmountOfColor(color))).append(" ");
+                        sb.append(StringUtils.repeat(MagicColor.toShortString(color) + " ", p.getManaPool().getAmountOfColor(color)));
                     }
                     abMana.setExpressChoice(sb.toString().trim());
                 }

--- a/forge-gui/res/cardsfolder/h/hargilde_kindly_runechanter.txt
+++ b/forge-gui/res/cardsfolder/h/hargilde_kindly_runechanter.txt
@@ -2,7 +2,7 @@ Name:Hargilde, Kindly Runechanter
 ManaCost:2 W U
 Types:Legendary Creature Human
 PT:2/3
-A:AB$ Mana | Cost$ T | Produced$ C | Amount$ 2 | RestrictValid$ Spell.Artifact,Activated.Artifact | SpellDescription$ Add {C}{C}. Spend this mana only to cast artifact spells or activate abilities of artifacts.
+A:AB$ Mana | Cost$ T | Produced$ C | Amount$ 2 | RestrictValid$ Spell.Artifact,Activated.Artifact+inZoneBattlefield | SpellDescription$ Add {C}{C}. Spend this mana only to cast artifact spells or activate abilities of artifacts.
 K:Friends forever
 DeckNeeds:Type$Artifact
 Oracle:{T}: Add {C}{C}. Spend this mana only to cast artifact spells or activate abilities of artifacts.\nFriends forever (You can have two commanders if both have friends forever.)

--- a/forge-gui/src/main/java/forge/gamemodes/match/input/InputPayMana.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/input/InputPayMana.java
@@ -364,6 +364,11 @@ public abstract class InputPayMana extends InputSyncronizedBase {
                     if (restrictionsMet) {
                         player.getManaPool().payManaFromAbility(saPaidFor, manaCost, chosen);
                     }
+                    if (!restrictionsMet || chosen.getPayCosts().hasManaCost()) {
+                        // force refresh in case too much mana got spent
+                        updateButtons();
+                        canPayManaCost = null;
+                    }
                     onManaAbilityPaid();
                 }
                 // Need to call this to unlock


### PR DESCRIPTION
Also prevent autopay letting you cheat away the cost partly when activating an ability that could not produce fitting mana, e.g.:
![image](https://github.com/Card-Forge/forge/assets/8506892/c481e10f-c82d-41d5-b89c-cda1b9db4bd5)