### PR TITLE
CMB1 land tokens fix

### DIFF
--- a/forge-gui/res/tokenscripts/c_l_forest.txt
+++ b/forge-gui/res/tokenscripts/c_l_forest.txt
@@ -1,4 +1,6 @@
 Name:Forest Token
 ManaCost:no cost
 Types:Land Forest
-Oracle:
+A:AB$ Mana | Cost$ T | Produced$ G | SpellDescription$ Add {G}.
+DeckHas:Ability$Mana.Green
+Oracle:{T}: Add {G}.

--- a/forge-gui/res/tokenscripts/c_l_forest.txt
+++ b/forge-gui/res/tokenscripts/c_l_forest.txt
@@ -1,6 +1,5 @@
 Name:Forest Token
 ManaCost:no cost
 Types:Land Forest
-A:AB$ Mana | Cost$ T | Produced$ G | SpellDescription$ Add {G}.
 DeckHas:Ability$Mana.Green
-Oracle:{T}: Add {G}.
+Oracle:({T}: Add {G}.)

--- a/forge-gui/res/tokenscripts/c_l_wastes.txt
+++ b/forge-gui/res/tokenscripts/c_l_wastes.txt
@@ -1,6 +1,6 @@
 Name:Wastes Token
 ManaCost:no cost
-Types:Land
+Types:Land Wastes
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 DeckHas:Ability$Mana.Colorless
 Oracle:{T}: Add {C}.


### PR DESCRIPTION
- Forest land tokens created by Generated Horizons have "{T}: Add {G}" per rule 305.6.
- Tokens created by Waste Land are land tokens with the land subtype Wastes, which doesn't appear anywhere else yet.