### PR TITLE
set Nazgûl variants as alternate art

### DIFF
--- a/forge-gui/res/editions/The Lord of the Rings Tales of Middle-earth.txt
+++ b/forge-gui/res/editions/The Lord of the Rings Tales of Middle-earth.txt
@@ -291,6 +291,8 @@ ScryfallCode=LTR
 279 L Mountain @Deven Rue
 280 L Forest @Deven Rue
 281 L Forest @Deven Rue
+
+[alternate art]
 332 U Nazgul @Wonchun Choi
 333 U Nazgul @Chris Cold
 334 U Nazgul @Nino Is


### PR DESCRIPTION
It seems to me that Nazgûl appear too frequently in generated draft boosters.

If I understand correctly, Nazgûl should have the same frequency as every other uncommon. (In RL it seems that the amount is split evenly among all art variants.) If I understand the BoosterGenerator.java code correctly, listing Nazgul 9x in the "cards" sections will make it appear 9x more frequently than in RL draft boosters.

My proposal would be to mark all but the first version als "alternate art", similar to M21 "Teferi, Master of Time"