### PR TITLE
Card: add Table for SwitchPT

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
@@ -1735,6 +1735,11 @@ public class ComputerUtilCard {
         pumped.setPTBoost(c.getPTBoostTable());
         pumped.addPTBoost(power + berserkPower, toughness, timestamp, 0);
 
+        pumped.setSwitchPTTable(c.getSwitchPTTable());
+        if (sa.hasParam("SwitchPT")) {
+            pumped.addSwitchPT(timestamp, 0);
+        }
+
         if (!kws.isEmpty()) {
             pumped.addChangedCardKeywords(kws, null, false, timestamp, null, false);
         }

--- a/forge-ai/src/main/java/forge/ai/ability/PumpAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PumpAi.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import forge.ai.*;
 import forge.game.Game;
+import forge.game.ability.AbilityKey;
 import forge.game.ability.AbilityUtils;
 import forge.game.ability.ApiType;
 import forge.game.card.*;
@@ -14,6 +15,9 @@ import forge.game.phase.PhaseHandler;
 import forge.game.phase.PhaseType;
 import forge.game.player.Player;
 import forge.game.player.PlayerActionConfirmMode;
+import forge.game.replacement.ReplacementEffect;
+import forge.game.replacement.ReplacementLayer;
+import forge.game.replacement.ReplacementType;
 import forge.game.spellability.SpellAbility;
 import forge.game.spellability.TargetRestrictions;
 import forge.game.zone.ZoneType;
@@ -473,35 +477,47 @@ public class PumpAi extends PumpAiBase {
             // Logic to kill opponent creatures
             CardCollection oppCreatures = CardLists.getTargetableCards(ai.getOpponents().getCreaturesInPlay(), sa);
             if (!oppCreatures.isEmpty()) {
-                CardCollection oppCreaturesFiltered = CardLists.filter(oppCreatures, new Predicate<Card>() {
+                CardCollection oppCreaturesFiltered = CardLists.filter(oppCreatures, card -> {
+                    // don't care about useless creatures
+                    if (ComputerUtilCard.isUselessCreature(ai, card)
+                            || card.hasSVar("EndOfTurnLeavePlay")) {
+                        return false;
+                    }
+                    // dies by target
+                    if (card.getSVar("Targeting").equals("Dies")) {
+                        return true;
+                    }
+                    // dies by state based action
+                    if (card.getNetPower() <= 0) {
+                        return true;
+                    }
+                    if (card.hasKeyword(Keyword.INDESTRUCTIBLE)) {
+                        return false;
+                    }
+                    // check if switching PT causes it to be lethal
+                    Card lki = CardCopyService.getLKICopy(card);
+                    lki.addSwitchPT(-1, 0);
 
-                    @Override
-                    public boolean apply(Card input) {
-                        // don't care about useless creatures
-                        if (ComputerUtilCard.isUselessCreature(ai, input)
-                                || input.hasSVar("EndOfTurnLeavePlay")) {
-                            return false;
-                        }
-                        // dies by target
-                        if (input.getSVar("Targeting").equals("Dies")) {
-                            return true;
-                        }
-                        // dies by state based action
-                        if (input.getNetPower() <= 0) {
-                            return true;
-                        }
-                        if (input.hasKeyword(Keyword.INDESTRUCTIBLE)) {
-                            return false;
-                        }
-                        // check if switching PT causes it to be lethal
-                        Card lki = CardUtil.getLKICopy(input);
-                        lki.addSwitchPT(-1, 0);
-                        if (input.getLethal() - input.getDamage() <= 0) {
-                            return true;
-                        }
+                    // check if creature could regenerate
+                    Map<AbilityKey, Object> runParams = AbilityKey.mapFromAffected(card);
+                    runParams.put(AbilityKey.Regeneration, true);
+                    List<ReplacementEffect> repDestoryList = game.getReplacementHandler().getReplacementList(ReplacementType.Destroy, runParams, ReplacementLayer.Other);
+                    // non-Regeneration one like Totem-Armor
+                    // should do it anyway to destroy the aura?
+                    if (repDestoryList.stream().anyMatch(r -> !r.hasParam("Regeneration"))) {
+                        return false;
+                    }
+                    // TODO make it force to use regen?
+                    // should check phase and make it before combat damage or better before blocker?
+                    if (repDestoryList.stream().anyMatch(r -> r.hasParam("Regeneration")) && card.canBeShielded()) {
                         return false;
                     }
 
+                    // maybe do it anyway to reduce its power?
+                    if (card.getLethal() - card.getDamage() > 0) {
+                        return false;
+                    }
+                    return true;
                 });
                 // the ones that die by switching PT
                 if (!oppCreaturesFiltered.isEmpty()) {

--- a/forge-ai/src/main/java/forge/ai/ability/PumpAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PumpAi.java
@@ -57,12 +57,6 @@ public class PumpAi extends PumpAiBase {
             return SpecialAiLogic.doAristocratLogic(ai, sa);
         } else if (aiLogic.startsWith("AristocratCounters")) {
             return SpecialAiLogic.doAristocratWithCountersLogic(ai, sa);
-        } else if (aiLogic.equals("SwitchPT")) {
-            // Some more AI would be even better, but this is a good start to prevent spamming
-            if (sa.isActivatedAbility() && sa.getActivationsThisTurn() > 0 && !sa.usesTargeting()) {
-                // Will prevent flipping back and forth
-                return false;
-            }
         }
 
         return super.checkAiLogic(ai, sa, aiLogic);
@@ -83,11 +77,6 @@ public class PumpAi extends PumpAiBase {
             if (!ph.is(PhaseType.COMBAT_DECLARE_BLOCKERS) && !isThreatened) {
                 return false;
             }
-        } else if (logic.equals("SwitchPT")) {
-            // Some more AI would be even better, but this is a good start to prevent spamming
-            if (ph.getPhase().isAfter(PhaseType.COMBAT_FIRST_STRIKE_DAMAGE) || !ph.inCombat()) {
-                return false;
-            }
         }
         return super.checkPhaseRestrictions(ai, sa, ph);
     }
@@ -101,6 +90,12 @@ public class PumpAi extends PumpAiBase {
                 return false;
             }
             if (ph.getPhase().isBefore(PhaseType.COMBAT_BEGIN) && ph.getPlayerTurn().isOpponentOf(ai)) {
+                return false;
+            }
+        }
+        if (sa.hasParam("SwitchPT")) {
+            // Some more AI would be even better, but this is a good start to prevent spamming
+            if (ph.getPhase().isAfter(PhaseType.COMBAT_FIRST_STRIKE_DAMAGE) || !ph.inCombat()) {
                 return false;
             }
         }
@@ -248,6 +243,14 @@ public class PumpAi extends PumpAiBase {
             }
         }
 
+        if (sa.hasParam("SwitchPT")) {
+            // Some more AI would be even better, but this is a good start to prevent spamming
+            if (sa.isActivatedAbility() && sa.getActivationsThisTurn() > 0 && !sa.usesTargeting()) {
+                // Will prevent flipping back and forth
+                return false;
+            }
+        }
+
         if (ComputerUtil.preventRunAwayActivations(sa)) {
             return false;
         }
@@ -356,7 +359,7 @@ public class PumpAi extends PumpAiBase {
     } // pumpPlayAI()
 
     private boolean pumpTgtAI(final Player ai, final SpellAbility sa, final int defense, final int attack, final boolean mandatory,
-    		boolean immediately) {
+                boolean immediately) {
         final List<String> keywords = sa.hasParam("KW") ? Arrays.asList(sa.getParam("KW").split(" & "))
                 : Lists.newArrayList();
         final Game game = ai.getGame();

--- a/forge-ai/src/main/java/forge/ai/simulation/GameCopier.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameCopier.java
@@ -356,6 +356,7 @@ public class GameCopier {
             newCard.setPTCharacterDefiningTable(c.getSetPTCharacterDefiningTable());
 
             newCard.setPTBoost(c.getPTBoostTable());
+            newCard.setSwitchPTTable(c.getSwitchPTTable());
             // TODO copy by map
             newCard.setDamage(c.getDamage());
             newCard.setDamageReceivedThisTurn(c.getDamageReceivedThisTurn());

--- a/forge-game/src/main/java/forge/game/ability/effects/PumpAllEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PumpAllEffect.java
@@ -45,7 +45,11 @@ public class PumpAllEffect extends SpellAbilityEffect {
                 continue;
             }
 
-            boolean redrawPT = false;
+            boolean redrawPT = sa.hasParam("SwitchPT");
+
+            if (sa.hasParam("SwitchPT")) {
+                tgtC.addSwitchPT(timestamp, 0);
+            }
 
             if (a != 0 || d != 0) {
                 if (perpetual) {
@@ -89,6 +93,7 @@ public class PumpAllEffect extends SpellAbilityEffect {
 
                     @Override
                     public void run() {
+                        tgtC.removeSwitchPT(timestamp, 0);
                         tgtC.removePTBoost(timestamp, 0);
                         tgtC.removeChangedCardKeywords(timestamp, 0);
                         tgtC.removeHiddenExtrinsicKeywords(timestamp, 0);

--- a/forge-game/src/main/java/forge/game/ability/effects/PumpEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PumpEffect.java
@@ -47,14 +47,17 @@ public class PumpEffect extends SpellAbilityEffect {
         final List<String> kws = Lists.newArrayList();
         final List<String> hiddenKws = Lists.newArrayList();
 
-        boolean redrawPT = false;
+        boolean redrawPT = sa.hasParam("SwitchPT");
         for (String kw : keywords) {
             if (kw.startsWith("HIDDEN")) {
                 hiddenKws.add(kw.substring(7));
-                redrawPT |= kw.contains("CARDNAME's power and toughness are switched");
             } else {
                 kws.add(kw);
             }
+        }
+
+        if (sa.hasParam("SwitchPT")) {
+            gameCard.addSwitchPT(timestamp, 0);
         }
 
         if (a != 0 || d != 0) {
@@ -113,6 +116,7 @@ public class PumpEffect extends SpellAbilityEffect {
                     host.removeGainControlTargets(gameCard);
 
                     gameCard.removePTBoost(timestamp, 0);
+                    gameCard.removeSwitchPT(timestamp, 0);
                     boolean updateText = gameCard.removeCanBlockAny(timestamp);
                     updateText |= gameCard.removeCanBlockAdditional(timestamp);
 

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -265,6 +265,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     private Table<Long, Long, Pair<Integer,Integer>> newPTCharacterDefining = TreeBasedTable.create(); // Layer 7a
     private Table<Long, Long, Pair<Integer,Integer>> newPT = TreeBasedTable.create(); // Layer 7b
     private Table<Long, Long, Pair<Integer,Integer>> boostPT = TreeBasedTable.create(); // Layer 7c
+    private Table<Long, Long, Boolean> switchPT = TreeBasedTable.create(); // Layer 7d
 
     private CardDamageHistory damageHistory = new CardDamageHistory();
     private final Map<Card, Integer> assignedDamageMap = Maps.newTreeMap();
@@ -4641,13 +4642,13 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     }
 
     public final StatBreakdown getNetPowerBreakdown() {
-        if (getAmountOfKeyword("CARDNAME's power and toughness are switched") % 2 != 0) {
+        if (isSwitchPT()) {
             return getUnswitchedToughnessBreakdown();
         }
         return getUnswitchedPowerBreakdown();
     }
     public final int getNetPower() {
-        if (getAmountOfKeyword("CARDNAME's power and toughness are switched") % 2 != 0) {
+        if (isSwitchPT()) {
             return getUnswitchedToughness();
         }
         return getUnswitchedPower();
@@ -4705,7 +4706,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     }
 
     public final StatBreakdown getNetToughnessBreakdown() {
-        if (getAmountOfKeyword("CARDNAME's power and toughness are switched") % 2 != 0) {
+        if (isSwitchPT()) {
             return getUnswitchedPowerBreakdown();
         }
         return getUnswitchedToughnessBreakdown();
@@ -4854,6 +4855,26 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
                 }
             } else executePerpetual(p);
         }
+    }
+
+    public boolean isSwitchPT() {
+        return switchPT.values().size() % 2 != 0;
+    }
+
+    public void addSwitchPT(final long timestamp, final long staticId) {
+        switchPT.put(timestamp, staticId, Boolean.TRUE);
+    }
+
+    public void removeSwitchPT(final long timestamp, final long staticId) {
+        switchPT.remove(timestamp, staticId);
+    }
+
+    public Table<Long, Long, Boolean> getSwitchPTTable() {
+        return ImmutableTable.copyOf(switchPT);
+    }
+    public void setSwitchPTTable(Table<Long, Long, Boolean> table) {
+        switchPT.clear();
+        switchPT.putAll(table);
     }
 
     public final boolean isUntapped() {

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -4624,36 +4624,6 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
         return total;
     }
 
-    public final StatBreakdown getUnswitchedPowerBreakdown() {
-        // 208.3 A noncreature permanent has no power or toughness
-        if (isInPlay() && !isCreature()) {
-            return new StatBreakdown();
-        }
-        return new StatBreakdown(getCurrentPower(), getTempPowerBoost(), getPowerBonusFromCounters());
-    }
-    public final int getUnswitchedPower() {
-        return getUnswitchedPowerBreakdown().getTotal();
-    }
-
-    public final int getPowerBonusFromCounters() {
-        return getCounters(CounterEnumType.P1P1) + getCounters(CounterEnumType.P1P2) + getCounters(CounterEnumType.P1P0)
-                - getCounters(CounterEnumType.M1M1) + 2 * getCounters(CounterEnumType.P2P2) - 2 * getCounters(CounterEnumType.M2M1)
-                - 2 * getCounters(CounterEnumType.M2M2) - getCounters(CounterEnumType.M1M0) + 2 * getCounters(CounterEnumType.P2P0);
-    }
-
-    public final StatBreakdown getNetPowerBreakdown() {
-        if (isSwitchPT()) {
-            return getUnswitchedToughnessBreakdown();
-        }
-        return getUnswitchedPowerBreakdown();
-    }
-    public final int getNetPower() {
-        if (isSwitchPT()) {
-            return getUnswitchedToughness();
-        }
-        return getUnswitchedPower();
-    }
-
     public final int getCurrentToughness() {
         int total = getBaseToughness();
         for (Pair<Integer, Integer> p : getPTIterable()) {
@@ -4687,6 +4657,33 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
         }
     }
 
+    public final StatBreakdown getUnswitchedPowerBreakdown() {
+        // 208.3 A noncreature permanent has no power or toughness
+        if (isInPlay() && !isCreature()) {
+            return new StatBreakdown();
+        }
+        return new StatBreakdown(getCurrentPower(), getTempPowerBoost(), getPowerBonusFromCounters());
+    }
+
+    public final int getPowerBonusFromCounters() {
+        if (!hasCounters()) {
+            return 0;
+        }
+        return getCounters(CounterEnumType.P1P1) + getCounters(CounterEnumType.P1P2) + getCounters(CounterEnumType.P1P0)
+                - getCounters(CounterEnumType.M1M1) + 2 * getCounters(CounterEnumType.P2P2) - 2 * getCounters(CounterEnumType.M2M1)
+                - 2 * getCounters(CounterEnumType.M2M2) - getCounters(CounterEnumType.M1M0) + 2 * getCounters(CounterEnumType.P2P0);
+    }
+
+    public final StatBreakdown getNetPowerBreakdown() {
+        if (isSwitchPT()) {
+            return getUnswitchedToughnessBreakdown();
+        }
+        return getUnswitchedPowerBreakdown();
+    }
+    public final int getNetPower() {
+        return getNetPowerBreakdown().getTotal();
+    }
+
     public final StatBreakdown getUnswitchedToughnessBreakdown() {
         // 208.3 A noncreature permanent has no power or toughness
         if (isInPlay() && !isCreature()) {
@@ -4694,11 +4691,11 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
         }
         return new StatBreakdown(getCurrentToughness(), getTempToughnessBoost(), getToughnessBonusFromCounters());
     }
-    public final int getUnswitchedToughness() {
-        return getUnswitchedToughnessBreakdown().getTotal();
-    }
 
     public final int getToughnessBonusFromCounters() {
+        if (!hasCounters()) {
+            return 0;
+        }
         return getCounters(CounterEnumType.P1P1) + 2 * getCounters(CounterEnumType.P1P2) - getCounters(CounterEnumType.M1M1)
                 + getCounters(CounterEnumType.P0P1) - 2 * getCounters(CounterEnumType.M0M2) + 2 * getCounters(CounterEnumType.P2P2)
                 - getCounters(CounterEnumType.M0M1) - getCounters(CounterEnumType.M2M1) - 2 * getCounters(CounterEnumType.M2M2)
@@ -4730,26 +4727,14 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
 
     // for cards like Giant Growth, etc.
     public final int getTempPowerBoost() {
-        int result = 0;
-        for (Pair<Integer, Integer> pair : boostPT.values()) {
-            if (pair.getLeft() != null) {
-                result += pair.getLeft();
-            }
-        }
-        return result;
+        return boostPT.values().stream().mapToInt(Pair::getLeft).sum();
     }
 
     public final int getTempToughnessBoost() {
-        int result = 0;
-        for (Pair<Integer, Integer> pair : boostPT.values()) {
-            if (pair.getRight() != null) {
-                result += pair.getRight();
-            }
-        }
-        return result;
+        return boostPT.values().stream().mapToInt(Pair::getRight).sum();
     }
 
-    public void addPTBoost(final Integer power, final Integer toughness, final long timestamp, final long staticId) {
+    public void addPTBoost(final int power, final int toughness, final long timestamp, final long staticId) {
         boostPT.put(timestamp, staticId, Pair.of(power, toughness));
     }
 

--- a/forge-game/src/main/java/forge/game/card/CardCopyService.java
+++ b/forge-game/src/main/java/forge/game/card/CardCopyService.java
@@ -301,6 +301,7 @@ public class CardCopyService {
 
         // extra copy PT boost
         newCopy.setPTBoost(copyFrom.getPTBoostTable());
+        newCopy.setSwitchPTTable(copyFrom.getSwitchPTTable());
 
         newCopy.setCounters(Maps.newHashMap(copyFrom.getCounters()));
 

--- a/forge-gui/res/cardsfolder/a/about_face.txt
+++ b/forge-gui/res/cardsfolder/a/about_face.txt
@@ -1,6 +1,5 @@
 Name:About Face
 ManaCost:R
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ HIDDEN CARDNAME's power and toughness are switched | SpellDescription$ Switch target creature's power and toughness until end of turn.
-AI:RemoveDeck:All
+A:SP$ Pump | ValidTgts$ Creature | SwitchPT$ True | SpellDescription$ Switch target creature's power and toughness until end of turn.
 Oracle:Switch target creature's power and toughness until end of turn.

--- a/forge-gui/res/cardsfolder/a/aeromoeba.txt
+++ b/forge-gui/res/cardsfolder/a/aeromoeba.txt
@@ -3,5 +3,5 @@ ManaCost:3 U
 Types:Creature Elemental Beast
 PT:2/4
 K:Flying
-A:AB$ Pump | Cost$ Discard<1/Card> | Defined$ Self | AILogic$ SwitchPT | KW$ HIDDEN CARDNAME's power and toughness are switched | SpellDescription$ Switch CARDNAME's power and toughness until end of turn.
+A:AB$ Pump | Cost$ Discard<1/Card> | Defined$ Self | SwitchPT$ True | SpellDescription$ Switch CARDNAME's power and toughness until end of turn.
 Oracle:Flying\nDiscard a card: Switch Aeromoeba's power and toughness until end of turn.

--- a/forge-gui/res/cardsfolder/a/aquamoeba.txt
+++ b/forge-gui/res/cardsfolder/a/aquamoeba.txt
@@ -2,6 +2,5 @@ Name:Aquamoeba
 ManaCost:1 U
 Types:Creature Elemental Beast
 PT:1/3
-A:AB$ Pump | Cost$ Discard<1/Card> | Defined$ Self | AILogic$ SwitchPT | KW$ HIDDEN CARDNAME's power and toughness are switched | SpellDescription$ Switch CARDNAME's power and toughness until end of turn.
-AI:RemoveDeck:All
+A:AB$ Pump | Cost$ Discard<1/Card> | Defined$ Self | SwitchPT$ True | SpellDescription$ Switch CARDNAME's power and toughness until end of turn.
 Oracle:Discard a card: Switch Aquamoeba's power and toughness until end of turn.

--- a/forge-gui/res/cardsfolder/c/calcite_snapper.txt
+++ b/forge-gui/res/cardsfolder/c/calcite_snapper.txt
@@ -4,6 +4,5 @@ Types:Creature Turtle
 PT:1/4
 K:Shroud
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigPump | TriggerDescription$ Landfall — Whenever a land you control enters, you may switch CARDNAME power and toughness until end of turn.
-SVar:TrigPump:DB$ Pump | Defined$ Self | KW$ HIDDEN CARDNAME's power and toughness are switched
-AI:RemoveDeck:All
+SVar:TrigPump:DB$ Pump | Defined$ Self | SwitchPT$ True
 Oracle:Shroud (This creature can't be the target of spells or abilities.)\nLandfall — Whenever a land you control enters, you may switch Calcite Snapper's power and toughness until end of turn.

--- a/forge-gui/res/cardsfolder/c/crag_puca.txt
+++ b/forge-gui/res/cardsfolder/c/crag_puca.txt
@@ -2,6 +2,6 @@ Name:Crag Puca
 ManaCost:UR UR UR
 Types:Creature Shapeshifter
 PT:2/4
-A:AB$ Pump | Cost$ UR | Defined$ Self | AILogic$ SwitchPT | KW$ HIDDEN CARDNAME's power and toughness are switched | SpellDescription$ Switch CARDNAME's power and toughness until end of turn.
+A:AB$ Pump | Cost$ UR | Defined$ Self | SwitchPT$ True | SpellDescription$ Switch CARDNAME's power and toughness until end of turn.
 AI:RemoveDeck:All
 Oracle:{U/R}: Switch Crag Puca's power and toughness until end of turn.

--- a/forge-gui/res/cardsfolder/c/crookclaw_transmuter.txt
+++ b/forge-gui/res/cardsfolder/c/crookclaw_transmuter.txt
@@ -5,6 +5,5 @@ PT:3/1
 K:Flash
 K:Flying
 T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigPump | TriggerDescription$ When CARDNAME enters, switch target creature's power and toughness until end of turn.
-SVar:TrigPump:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ HIDDEN CARDNAME's power and toughness are switched
-AI:RemoveDeck:All
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature | SwitchPT$ True
 Oracle:Flash\nFlying\nWhen Crookclaw Transmuter enters, switch target creature's power and toughness until end of turn.

--- a/forge-gui/res/cardsfolder/d/dwarven_thaumaturgist.txt
+++ b/forge-gui/res/cardsfolder/d/dwarven_thaumaturgist.txt
@@ -2,6 +2,6 @@ Name:Dwarven Thaumaturgist
 ManaCost:2 R
 Types:Creature Dwarf Shaman
 PT:1/2
-A:AB$ Pump | Cost$ T | ValidTgts$ Creature | KW$ HIDDEN CARDNAME's power and toughness are switched | TgtPrompt$ Select target creature. | SpellDescription$ Switch target creature's power and toughness until end of turn.
+A:AB$ Pump | Cost$ T | ValidTgts$ Creature | SwitchPT$ True | SpellDescription$ Switch target creature's power and toughness until end of turn.
 AI:RemoveDeck:All
 Oracle:{T}: Switch target creature's power and toughness until end of turn.

--- a/forge-gui/res/cardsfolder/f/fluxcharger.txt
+++ b/forge-gui/res/cardsfolder/f/fluxcharger.txt
@@ -4,7 +4,6 @@ Types:Creature Weird
 PT:1/5
 K:Flying
 T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigChangePT | OptionalDecider$ You | TriggerDescription$ Whenever you cast a instant or sorcery spell, you may switch CARDNAME's power and toughness until end of turn.
-SVar:TrigChangePT:DB$ Pump | KW$ HIDDEN CARDNAME's power and toughness are switched | Defined$ Self
-AI:RemoveDeck:All
+SVar:TrigChangePT:DB$ Pump | Defined$ Self | SwitchPT$ True
 DeckHints:Type$Instant|Sorcery
 Oracle:Flying\nWhenever you cast an instant or sorcery spell, you may switch Fluxcharger's power and toughness until end of turn.

--- a/forge-gui/res/cardsfolder/f/fluxcharger.txt
+++ b/forge-gui/res/cardsfolder/f/fluxcharger.txt
@@ -3,7 +3,7 @@ ManaCost:2 U R
 Types:Creature Weird
 PT:1/5
 K:Flying
-T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigChangePT | OptionalDecider$ You | TriggerDescription$ Whenever you cast a instant or sorcery spell, you may switch CARDNAME's power and toughness until end of turn.
+T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigChangePT | OptionalDecider$ You | TriggerDescription$ Whenever you cast an instant or sorcery spell, you may switch CARDNAME's power and toughness until end of turn.
 SVar:TrigChangePT:DB$ Pump | Defined$ Self | SwitchPT$ True
 DeckHints:Type$Instant|Sorcery
 Oracle:Flying\nWhenever you cast an instant or sorcery spell, you may switch Fluxcharger's power and toughness until end of turn.

--- a/forge-gui/res/cardsfolder/i/inside_out.txt
+++ b/forge-gui/res/cardsfolder/i/inside_out.txt
@@ -1,7 +1,6 @@
 Name:Inside Out
 ManaCost:1 UR
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ HIDDEN CARDNAME's power and toughness are switched | SpellDescription$ Switch target creature's power and toughness until end of turn. | SubAbility$ DBDraw
+A:SP$ Pump | ValidTgts$ Creature | SwitchPT$ True | SubAbility$ DBDraw | SpellDescription$ Switch target creature's power and toughness until end of turn.
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | SpellDescription$ Draw a card.
-AI:RemoveDeck:All
 Oracle:Switch target creature's power and toughness until end of turn.\nDraw a card.

--- a/forge-gui/res/cardsfolder/i/inversion_behemoth.txt
+++ b/forge-gui/res/cardsfolder/i/inversion_behemoth.txt
@@ -3,6 +3,6 @@ ManaCost:2 C C
 Types:Creature Eldrazi
 PT:2/9
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ At the beginning of combat on your turn, switch the power and toughness of each of any number of target creatures until end of turn.
-SVar:TrigPump:DB$ Pump | ValidTgts$ Creature | TargetMin$ 0 | TargetMax$ X | TgtPrompt$ Select any number of target creatures | KW$ HIDDEN CARDNAME's power and toughness are switched
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature | TargetMin$ 0 | TargetMax$ X | TgtPrompt$ Select any number of target creatures | SwitchPT$ True
 SVar:X:Count$Valid Creature
 Oracle:At the beginning of combat on your turn, switch the power and toughness of each of any number of target creatures until end of turn.

--- a/forge-gui/res/cardsfolder/i/invert_invent.txt
+++ b/forge-gui/res/cardsfolder/i/invert_invent.txt
@@ -1,7 +1,7 @@
 Name:Invert
 ManaCost:UR
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | TargetMin$ 0 | TargetMax$ 2 | TgtPrompt$ Select target creature | KW$ HIDDEN CARDNAME's power and toughness are switched | SpellDescription$ Switch the power and toughness of each of up to two target creatures until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | TargetMin$ 0 | TargetMax$ 2 | SwitchPT$ True | SpellDescription$ Switch the power and toughness of each of up to two target creatures until end of turn.
 AlternateMode:Split
 Oracle:Switch the power and toughness of each of up to two target creatures until end of turn.
 

--- a/forge-gui/res/cardsfolder/m/mangled_soulrager.txt
+++ b/forge-gui/res/cardsfolder/m/mangled_soulrager.txt
@@ -5,8 +5,8 @@ PT:1/4
 K:Flying
 K:Cycling:1 U
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ When CARDNAME enters, switch the power and toughness of each creature on the battlefield. You get a twelve-time boon with "Whenever a creature you control enters, switch its power and toughness."
-SVar:TrigPump:DB$ PumpAll | ValidCards$ Creature | PumpZone$ Battlefield | KW$ HIDDEN CARDNAME's power and toughness are switched | Duration$ Permanent | SubAbility$ DBBoon
+SVar:TrigPump:DB$ PumpAll | ValidCards$ Creature | PumpZone$ Battlefield | SwitchPT$ True | Duration$ Permanent | SubAbility$ DBBoon
 SVar:DBBoon:DB$ Effect | Boon$ True | Duration$ Permanent | Triggers$ CreatureETB
 SVar:CreatureETB:Mode$ ChangesZone | ValidCards$ Creature.YouCtrl | Destination$ Battlefield | TriggerZones$ Battlefield | BoonAmount$ 12 | Execute$ TrigPumpETB | TriggerDescription$ Whenever a creature you control enters, switch its power and toughness.
-SVar:TrigPumpETB:DB$ Pump | Defined$ TriggeredCardLKICopy | Duration$ Permanent | KW$ HIDDEN CARDNAME's power and toughness are switched
+SVar:TrigPumpETB:DB$ Pump | Defined$ TriggeredCardLKICopy | Duration$ Permanent | SwitchPT$ True
 Oracle:Flying\nWhen Mangled Soulrager enters, switch the power and toughness of each creature on the battlefield. You get a twelve-time boon with "Whenever a creature you control enters, switch its power and toughness."\nCycling {1}{U}

--- a/forge-gui/res/cardsfolder/m/mannichi_the_fevered_dream.txt
+++ b/forge-gui/res/cardsfolder/m/mannichi_the_fevered_dream.txt
@@ -2,6 +2,5 @@ Name:Mannichi, the Fevered Dream
 ManaCost:2 R
 Types:Legendary Creature Spirit
 PT:1/2
-A:AB$ PumpAll | Cost$ 1 R | ValidCards$ Creature | KW$ HIDDEN CARDNAME's power and toughness are switched | SpellDescription$ Switch each creature's power and toughness until end of turn.
-AI:RemoveDeck:All
+A:AB$ PumpAll | Cost$ 1 R | ValidCards$ Creature | SwitchPT$ True | SpellDescription$ Switch each creature's power and toughness until end of turn.
 Oracle:{1}{R}: Switch each creature's power and toughness until end of turn.

--- a/forge-gui/res/cardsfolder/m/merfolk_thaumaturgist.txt
+++ b/forge-gui/res/cardsfolder/m/merfolk_thaumaturgist.txt
@@ -2,6 +2,5 @@ Name:Merfolk Thaumaturgist
 ManaCost:2 U
 Types:Creature Merfolk Wizard
 PT:1/2
-A:AB$ Pump | Cost$ T | ValidTgts$ Creature | KW$ HIDDEN CARDNAME's power and toughness are switched | TgtPrompt$ Select target creature. | SpellDescription$ Switch target creature's power and toughness until end of turn.
-AI:RemoveDeck:All
+A:AB$ Pump | Cost$ T | ValidTgts$ Creature | SwitchPT$ True | SpellDescription$ Switch target creature's power and toughness until end of turn.
 Oracle:{T}: Switch target creature's power and toughness until end of turn.

--- a/forge-gui/res/cardsfolder/m/myr_quadropod.txt
+++ b/forge-gui/res/cardsfolder/m/myr_quadropod.txt
@@ -2,6 +2,6 @@ Name:Myr Quadropod
 ManaCost:4
 Types:Artifact Creature Myr
 PT:1/4
-A:AB$ Pump | Cost$ 3 | Defined$ Self | AILogic$ SwitchPT | KW$ HIDDEN CARDNAME's power and toughness are switched | SpellDescription$ Switch CARDNAME's power and toughness until end of turn.
+A:AB$ Pump | Cost$ 3 | Defined$ Self | SwitchPT$ True | SpellDescription$ Switch CARDNAME's power and toughness until end of turn.
 AI:RemoveDeck:All
 Oracle:{3}: Switch Myr Quadropod's power and toughness until end of turn.

--- a/forge-gui/res/cardsfolder/p/phantasmal_fiend.txt
+++ b/forge-gui/res/cardsfolder/p/phantasmal_fiend.txt
@@ -3,5 +3,5 @@ ManaCost:3 B
 Types:Creature Illusion
 PT:1/5
 A:AB$ Pump | Cost$ B | Defined$ Self | NumAtt$ +1 | NumDef$ -1 | SpellDescription$ CARDNAME gets +1/-1 until end of turn.
-A:AB$ Pump | Cost$ 1 U | Defined$ Self | AILogic$ SwitchPT | KW$ HIDDEN CARDNAME's power and toughness are switched | SpellDescription$ Switch CARDNAME's power and toughness until end of turn.
+A:AB$ Pump | Cost$ 1 U | Defined$ Self | SwitchPT$ True | SpellDescription$ Switch CARDNAME's power and toughness until end of turn.
 Oracle:{B}: Phantasmal Fiend gets +1/-1 until end of turn.\n{1}{U}: Switch Phantasmal Fiend's power and toughness until end of turn.

--- a/forge-gui/res/cardsfolder/r/reverse_the_polarity.txt
+++ b/forge-gui/res/cardsfolder/r/reverse_the_polarity.txt
@@ -3,7 +3,7 @@ ManaCost:1 U U
 Types:Instant
 A:SP$ Charm | Choices$ DBCounter,DBSwitch,DBUnblockable
 SVar:DBCounter:DB$ Counter | Defined$ ValidStack Spell.Other | SpellDescription$ Counter all other spells.
-SVar:DBSwitch:DB$ PumpAll | ValidCards$ Creature | KW$ HIDDEN CARDNAME's power and toughness are switched | SpellDescription$ Switch each creature's power and toughness until end of turn.
+SVar:DBSwitch:DB$ PumpAll | ValidCards$ Creature | SwitchPT$ True | SpellDescription$ Switch each creature's power and toughness until end of turn.
 SVar:DBUnblockable:DB$ Effect | StaticAbilities$ Unblockable | SpellDescription$ Creatures can't be blocked this turn.
 SVar:Unblockable:Mode$ CantBlockBy | ValidAttacker$ Creature | Description$ Creatures can't be blocked this turn.
 Oracle:Choose one —\n• Counter all other spells.\n• Switch each creature's power and toughness until end of turn.\n• Creatures can't be blocked this turn.

--- a/forge-gui/res/cardsfolder/s/strange_inversion.txt
+++ b/forge-gui/res/cardsfolder/s/strange_inversion.txt
@@ -2,7 +2,6 @@ Name:Strange Inversion
 ManaCost:2 R
 Types:Instant Arcane
 K:Splice:Arcane:1 R
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ HIDDEN CARDNAME's power and toughness are switched | SpellDescription$ Switch target creature's power and toughness until end of turn.
-AI:RemoveDeck:All
+A:SP$ Pump | ValidTgts$ Creature | SwitchPT$ True | SpellDescription$ Switch target creature's power and toughness until end of turn.
 DeckHints:Type$Arcane
 Oracle:Switch target creature's power and toughness until end of turn.\nSplice onto Arcane {1}{R} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)

--- a/forge-gui/res/cardsfolder/t/transmutation.txt
+++ b/forge-gui/res/cardsfolder/t/transmutation.txt
@@ -1,6 +1,5 @@
 Name:Transmutation
 ManaCost:1 B
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ HIDDEN CARDNAME's power and toughness are switched | SpellDescription$ Switch target creature's power and toughness until end of turn.
-AI:RemoveDeck:All
+A:SP$ Pump | ValidTgts$ Creature | SwitchPT$ True | SpellDescription$ Switch target creature's power and toughness until end of turn.
 Oracle:Switch target creature's power and toughness until end of turn.

--- a/forge-gui/res/cardsfolder/t/turtleshell_changeling.txt
+++ b/forge-gui/res/cardsfolder/t/turtleshell_changeling.txt
@@ -3,6 +3,5 @@ ManaCost:3 U
 Types:Creature Shapeshifter
 PT:1/4
 K:Changeling
-A:AB$ Pump | Cost$ 1 U | Defined$ Self | AILogic$ SwitchPT | KW$ HIDDEN CARDNAME's power and toughness are switched | SpellDescription$ Switch CARDNAME's power and toughness until end of turn.
-AI:RemoveDeck:All
+A:AB$ Pump | Cost$ 1 U | Defined$ Self | SwitchPT$ True | SpellDescription$ Switch CARDNAME's power and toughness until end of turn.
 Oracle:Changeling (This card is every creature type.)\n{1}{U}: Switch Turtleshell Changeling's power and toughness until end of turn.

--- a/forge-gui/res/cardsfolder/t/twisted_image.txt
+++ b/forge-gui/res/cardsfolder/t/twisted_image.txt
@@ -1,7 +1,6 @@
 Name:Twisted Image
 ManaCost:U
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ HIDDEN CARDNAME's power and toughness are switched | SpellDescription$ Switch target creature's power and toughness until end of turn. | SubAbility$ DBDraw
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | SwitchPT$ True | SubAbility$ DBDraw | SpellDescription$ Switch target creature's power and toughness until end of turn.
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | SpellDescription$ Draw a card.
-AI:RemoveDeck:All
 Oracle:Switch target creature's power and toughness until end of turn.\nDraw a card.

--- a/forge-gui/res/cardsfolder/t/twisted_reflection.txt
+++ b/forge-gui/res/cardsfolder/t/twisted_reflection.txt
@@ -4,5 +4,5 @@ Types:Instant
 K:Entwine:B
 A:SP$ Charm | Choices$ DBCurse,DBSwitch
 SVar:DBCurse:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature to get -6/-0 | NumAtt$ -6 | IsCurse$ True | SpellDescription$ Target creature gets -6/-0 until end of turn.
-SVar:DBSwitch:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ HIDDEN CARDNAME's power and toughness are switched | SpellDescription$ Switch target creature's power and toughness until end of turn.
+SVar:DBSwitch:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | SwitchPT$ True | SpellDescription$ Switch target creature's power and toughness until end of turn.
 Oracle:Choose one —\n• Target creature gets -6/-0 until end of turn.\n• Switch target creature's power and toughness until end of turn.\nEntwine {B} (Choose both if you pay the entwine cost.)

--- a/forge-gui/res/cardsfolder/v/valakut_fireboar.txt
+++ b/forge-gui/res/cardsfolder/v/valakut_fireboar.txt
@@ -3,6 +3,6 @@ ManaCost:4 R
 Types:Creature Elemental Boar
 PT:1/7
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, switch its power and toughness until end of turn.
-SVar:TrigPump:DB$ Pump | Defined$ Self | KW$ HIDDEN CARDNAME's power and toughness are switched
+SVar:TrigPump:DB$ Pump | Defined$ Self | SwitchPT$ True
 AI:RemoveDeck:Random
 Oracle:Whenever Valakut Fireboar attacks, switch its power and toughness until end of turn.

--- a/forge-gui/res/cardsfolder/w/wandering_fumarole.txt
+++ b/forge-gui/res/cardsfolder/w/wandering_fumarole.txt
@@ -5,5 +5,5 @@ R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementRe
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 A:AB$ Mana | Cost$ T | Produced$ Combo U R | SpellDescription$ Add {U} or {R}.
 A:AB$ Animate | Cost$ 2 U R | Defined$ Self | Power$ 1 | Toughness$ 4 | Types$ Creature,Elemental | Colors$ Blue,Red | OverwriteColors$ True | Abilities$ ABPump | SpellDescription$ Until end of turn, CARDNAME becomes a 1/4 blue and red Elemental creature with "{0}: Switch this creature's power and toughness until end of turn." It's still a land.
-SVar:ABPump:AB$ Pump | Cost$ 0 | Defined$ Self | AILogic$ SwitchPT | KW$ HIDDEN CARDNAME's power and toughness are switched | SpellDescription$ Switch this creature's power and toughness until end of turn.
+SVar:ABPump:AB$ Pump | Cost$ 0 | Defined$ Self | SwitchPT$ True | SpellDescription$ Switch this creature's power and toughness until end of turn.
 Oracle:Wandering Fumarole enters tapped.\n{T}: Add {U} or {R}.\n{2}{U}{R}: Until end of turn, Wandering Fumarole becomes a 1/4 blue and red Elemental creature with "{0}: Switch this creature's power and toughness until end of turn." It's still a land.

--- a/forge-gui/res/cardsfolder/w/windreaver.txt
+++ b/forge-gui/res/cardsfolder/w/windreaver.txt
@@ -5,6 +5,6 @@ PT:1/3
 K:Flying
 A:AB$ Pump | Cost$ W | Defined$ Self | KW$ Vigilance | SpellDescription$ CARDNAME gains vigilance until end of turn.
 A:AB$ Pump | Cost$ W | Defined$ Self | NumDef$ +1 | SpellDescription$ CARDNAME gets +0/+1 until end of turn.
-A:AB$ Pump | Cost$ U | Defined$ Self | AILogic$ SwitchPT | KW$ HIDDEN CARDNAME's power and toughness are switched | SpellDescription$ Switch CARDNAME's power and toughness until end of turn.
+A:AB$ Pump | Cost$ U | Defined$ Self | SwitchPT$ True | SpellDescription$ Switch CARDNAME's power and toughness until end of turn.
 A:AB$ ChangeZone | Cost$ U | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return CARDNAME to its owner's hand.
 Oracle:Flying\n{W}: Windreaver gains vigilance until end of turn.\n{W}: Windreaver gets +0/+1 until end of turn.\n{U}: Switch Windreaver's power and toughness until end of turn.\n{U}: Return Windreaver to its owner's hand.


### PR DESCRIPTION
Closes #3555 

- [x] remove Hidden Keyword `CARDNAME's power and toughness are switched`
- [ ] Extend the AI to check when to use that Ability
- [ ] Technically it should be its own layer, but we don't have a static ability for this?

AI cases:

- [ ]  In case of Attacking or Blocking to check if switched PT would be more in favor?
- [ ]  Use it as kill Spell if Creature has more damage than power or if power is negative? Need to calculate the right amount of PT after switch
- [ ]  AI probably need to respect isSwitchPT when checking for effects like +P/+T or -P/-T  ... especially if its like +X/-X or vise versa