### PR TITLE
Fix token names in LTR, CMM editions

### DIFF
--- a/forge-gui/res/editions/Commander Masters.txt
+++ b/forge-gui/res/editions/Commander Masters.txt
@@ -1076,9 +1076,9 @@ ScryfallCode=CMM
 
 [tokens]
 avacyn
-b_0_0_germ
-b_0_0_sliver_army
-b_0_0_zombie_army
+b_0_0_phyrexian_germ
+b_0_0_army
+b_0_0_army
 b_1_1_assassin_deathtouch_haste
 b_1_1_rat
 b_1_1_thrull

--- a/forge-gui/res/editions/The Lord of the Rings Tales of Middle-earth.txt
+++ b/forge-gui/res/editions/The Lord of the Rings Tales of Middle-earth.txt
@@ -490,8 +490,8 @@ ScryfallCode=LTR
 300 M Saruman of Many Colors @Wonchun Choi
 
 [tokens]
-b_0_0_orc_army
-b_0_0_orc_army
+b_0_0_army
+b_0_0_army
 ballistic_boulder
 c_a_food_sac
 c_a_food_sac


### PR DESCRIPTION
Currently army tokens aren't recoignised by types (zombie, orc, sliver etc.) so have renamed the entries inside LTR and CMM editions as they were throwing out errors due to not finding an existing script with typed names. Also fixed germ token line.