### PR TITLE
Fix getTotalPreventionShieldAmount

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/ManaEffectAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ManaEffectAi.java
@@ -89,7 +89,7 @@ public class ManaEffectAi extends SpellAbilityAi {
         if (logic.startsWith("ManaRitual")) {
              return ph.is(PhaseType.MAIN2, ai) || ph.is(PhaseType.MAIN1, ai);
         } else if ("AtOppEOT".equals(logic)) {
-            return !ai.getManaPool().hasBurn() && ph.is(PhaseType.END_OF_TURN) && ph.getNextTurn() == ai;
+            return (!ai.getManaPool().hasBurn() || !ai.canLoseLife() || ai.cantLoseForZeroOrLessLife()) && ph.is(PhaseType.END_OF_TURN) && ph.getNextTurn() == ai;
         }
         return super.checkPhaseRestrictions(ai, sa, ph, logic);
     }
@@ -261,7 +261,8 @@ public class ManaEffectAi extends SpellAbilityAi {
     }
 
     private boolean improvesPosition(Player ai, SpellAbility sa) {
-        boolean activateForTrigger = Iterables.any(Iterables.filter(sa.getHostCard().getTriggers(), CardTraitPredicates.hasParam("AILogic", "ActivateOnce")),
+        boolean activateForTrigger = (!ai.getManaPool().hasBurn() || !ai.canLoseLife() || ai.cantLoseForZeroOrLessLife()) &&
+                Iterables.any(Iterables.filter(sa.getHostCard().getTriggers(), CardTraitPredicates.hasParam("AILogic", "ActivateOnce")),
                 t -> sa.getHostCard().getAbilityActivatedThisTurn(t.getOverridingAbility()) == 0);
 
         PhaseHandler ph = ai.getGame().getPhaseHandler();

--- a/forge-game/src/main/java/forge/game/GameEntityView.java
+++ b/forge-game/src/main/java/forge/game/GameEntityView.java
@@ -45,7 +45,7 @@ public abstract class GameEntityView extends TrackableObject {
     public int getPreventNextDamage() {
         return get(TrackableProperty.PreventNextDamage);
     }
-    protected void updatePreventNextDamage(GameEntity e) {
+    public void updatePreventNextDamage(GameEntity e) {
         set(TrackableProperty.PreventNextDamage, e.getPreventNextDamageTotalShields());
     }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/DamagePreventEffectBase.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DamagePreventEffectBase.java
@@ -4,12 +4,13 @@ import java.util.List;
 
 import forge.GameCommand;
 import forge.game.Game;
-import forge.game.GameObject;
+import forge.game.GameEntity;
 import forge.game.ability.AbilityFactory;
 import forge.game.ability.AbilityKey;
 import forge.game.ability.AbilityUtils;
 import forge.game.ability.SpellAbilityEffect;
 import forge.game.card.Card;
+import forge.game.event.GameEventPlayerStatsChanged;
 import forge.game.player.Player;
 import forge.game.replacement.ReplacementEffect;
 import forge.game.replacement.ReplacementHandler;
@@ -20,7 +21,7 @@ import forge.game.zone.ZoneType;
 import forge.util.TextUtil;
 
 public abstract class DamagePreventEffectBase extends SpellAbilityEffect {
-    public static void addPreventNextDamage(SpellAbility sa, GameObject o, int numDam) {
+    public static void addPreventNextDamage(SpellAbility sa, GameEntity o, int numDam) {
         final Card hostCard = sa.getHostCard();
         final Game game = hostCard.getGame();
         final Player player = hostCard.getController();
@@ -40,9 +41,9 @@ public abstract class DamagePreventEffectBase extends SpellAbilityEffect {
         if (sa.hasParam("PreventionSubAbility")) {
             String subAbString = sa.getSVar(sa.getParam("PreventionSubAbility"));
             if (sa.hasParam("ShieldEffectTarget")) {
-                List<GameObject> effTgts = AbilityUtils.getDefinedObjects(hostCard, sa.getParam("ShieldEffectTarget"), sa);
+                List<GameEntity> effTgts = AbilityUtils.getDefinedEntities(hostCard, sa.getParam("ShieldEffectTarget"), sa);
                 String effTgtString = "";
-                for (final GameObject effTgt : effTgts) {
+                for (final GameEntity effTgt : effTgts) {
                     if (effTgt instanceof Card) {
                         effTgtString = "CardUID_" + String.valueOf(((Card) effTgt).getId());
                     } else if (effTgt instanceof Player) {
@@ -70,12 +71,21 @@ public abstract class DamagePreventEffectBase extends SpellAbilityEffect {
         eff.updateStateForView();
         game.getTriggerHandler().clearSuppression(TriggerType.ChangesZone);
 
+        o.getView().updatePreventNextDamage(o);
+        if (o instanceof Player) {
+            game.fireEvent(new GameEventPlayerStatsChanged((Player) o, false));
+        }
+
         game.getEndOfTurn().addUntil(new GameCommand() {
             private static final long serialVersionUID = 1L;
 
             @Override
             public void run() {
                 game.getAction().exile(eff, null);
+                o.getView().updatePreventNextDamage(o);
+                if (o instanceof Player) {
+                    game.fireEvent(new GameEventPlayerStatsChanged((Player) o, false));
+                }
             }
         });
     }

--- a/forge-game/src/main/java/forge/game/card/CardDamageMap.java
+++ b/forge-game/src/main/java/forge/game/card/CardDamageMap.java
@@ -19,6 +19,7 @@ import forge.game.Game;
 import forge.game.GameEntity;
 import forge.game.GameObjectPredicates;
 import forge.game.ability.AbilityKey;
+import forge.game.event.GameEventPlayerStatsChanged;
 import forge.game.player.Player;
 import forge.game.player.PlayerCollection;
 import forge.game.spellability.SpellAbility;
@@ -48,6 +49,11 @@ public class CardDamageMap extends ForwardingTable<Card, GameEntity, Integer> {
                 runParams.put(AbilityKey.IsCombatDamage, isCombat);
 
                 ge.getGame().getTriggerHandler().runTrigger(TriggerType.DamagePreventedOnce, runParams, false);
+
+                ge.getView().updatePreventNextDamage(ge);
+                if (ge instanceof Player) {
+                    ge.getGame().fireEvent(new GameEventPlayerStatsChanged((Player) ge, false));
+                }
             }
         }
     }

--- a/forge-game/src/main/java/forge/game/replacement/ReplacementEffect.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplacementEffect.java
@@ -145,7 +145,6 @@ public abstract class ReplacementEffect extends TriggerReplacementBase {
     public boolean requirementsCheck(Game game) {
         return this.requirementsCheck(game, this.getMapParams());
     }
-
     public boolean requirementsCheck(Game game, Map<String,String> params) {
         if (this.isSuppressed()) {
             return false; // Effect removed by effect

--- a/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
@@ -911,7 +911,8 @@ public class ReplacementHandler {
                             && re.hasParam("PreventionEffect")
                             && re.zonesCheck(game.getZoneOf(c))
                             && re.getOverridingAbility() != null
-                            && re.getOverridingAbility().getApi() == ApiType.ReplaceDamage) {
+                            && re.getOverridingAbility().getApi() == ApiType.ReplaceDamage
+                            && re.matchesValidParam("ValidTarget", o)) {
                         list.add(re);
                     }
                 }

--- a/forge-gui/res/cardsfolder/b/break_of_day.txt
+++ b/forge-gui/res/cardsfolder/b/break_of_day.txt
@@ -2,5 +2,6 @@ Name:Break of Day
 ManaCost:1 W
 Types:Instant
 A:SP$ PumpAll | Cost$ 1 W | ValidCards$ Creature.YouCtrl | NumAtt$ +1 | NumDef$ +1 | SubAbility$ FatefulHourPump | SpellDescription$ Creatures you control get +1/+1 until end of turn.
-SVar:FatefulHourPump:DB$ PumpAll | ValidCards$ Creature.YouCtrl | KW$ Indestructible | FatefulHour$ True | SpellDescription$ Fateful hour — If you have 5 or less life, those creatures gain indestructible until end of turn.
+SVar:FatefulHourPump:DB$ PumpAll | ValidCards$ Creature.YouCtrl | KW$ Indestructible | ConditionCheckSVar$ FatefulHour | ConditionSVarCompare$ LE5 | SpellDescription$ Fateful hour — If you have 5 or less life, those creatures gain indestructible until end of turn.
+SVar:FatefulHour:Count$YourLifeTotal
 Oracle:Creatures you control get +1/+1 until end of turn.\nFateful hour — If you have 5 or less life, those creatures gain indestructible until end of turn. (Damage and effects that say "destroy" don't destroy them.)

--- a/forge-gui/res/cardsfolder/o/ogre_slumlord.txt
+++ b/forge-gui/res/cardsfolder/o/ogre_slumlord.txt
@@ -2,7 +2,7 @@ Name:Ogre Slumlord
 ManaCost:3 B B
 Types:Creature Ogre Rogue
 PT:3/3
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.nonToken+Other | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever another nontoken creature dies, you may create a 1/1 black Rat creature token.
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.nonToken+Other | OptionalDecider$ You | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever another nontoken creature dies, you may create a 1/1 black Rat creature token.
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ b_1_1_rat | TokenOwner$ You
 S:Mode$ Continuous | Affected$ Creature.Rat+YouCtrl | AddKeyword$ Deathtouch | Description$ Rats you control have deathtouch.
 DeckHas:Ability$Token


### PR DESCRIPTION
After 2+ years this makes the function actually consider the affected GameEntity again for the few AI paths that use it.
I also rewired it with GUI - or is that too redundant anyway? :thinking: