### PR TITLE
Role: add StateBasedAction

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/TokenAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/TokenAi.java
@@ -1,5 +1,6 @@
 package forge.ai.ability;
 
+import java.util.List;
 import java.util.Map;
 
 import com.google.common.base.Predicate;
@@ -23,6 +24,7 @@ import forge.game.card.Card;
 import forge.game.card.CardCollection;
 import forge.game.card.CardLists;
 import forge.game.card.CardPredicates;
+import forge.game.card.CardUtil;
 import forge.game.card.token.TokenInfo;
 import forge.game.combat.Combat;
 import forge.game.cost.CostPart;
@@ -162,6 +164,11 @@ public class TokenAi extends SpellAbilityAi {
         final TargetRestrictions tgt = sa.getTargetRestrictions();
         if (tgt != null) {
             sa.resetTargets();
+
+            if (actualToken.getType().hasSubtype("Role")) {
+                return tgtRoleAura(ai, sa, actualToken, false);
+            }
+
             if (tgt.canOnlyTgtOpponent() || "Opponent".equals(sa.getParam("AITgts"))) {
                 if (sa.canTarget(opp)) {
                     sa.getTargets().add(opp);
@@ -253,9 +260,16 @@ public class TokenAi extends SpellAbilityAi {
 
     @Override
     protected boolean doTriggerAINoCost(Player ai, SpellAbility sa, boolean mandatory) {
+        Card actualToken = spawnToken(ai, sa);
+
         final TargetRestrictions tgt = sa.getTargetRestrictions();
         if (tgt != null) {
             sa.resetTargets();
+
+            if (actualToken.getType().hasSubtype("Role")) {
+                return tgtRoleAura(ai, sa, actualToken, mandatory);
+            }
+
             if (tgt.canOnlyTgtOpponent()) {
                 PlayerCollection targetableOpps = ai.getOpponents().filter(PlayerPredicates.isTargetableBy(sa));
                 if (mandatory && targetableOpps.isEmpty()) {
@@ -268,7 +282,6 @@ public class TokenAi extends SpellAbilityAi {
             }
         }
 
-        Card actualToken = spawnToken(ai, sa);
         String tokenPower = sa.getParamOrDefault("TokenPower", actualToken.getBasePowerString());
         String tokenToughness = sa.getParamOrDefault("TokenToughness", actualToken.getBaseToughnessString());
         String tokenAmount = sa.getParamOrDefault("TokenAmount", "1");
@@ -357,6 +370,45 @@ public class TokenAi extends SpellAbilityAi {
         final Game game = ai.getGame();
         ComputerUtilCard.applyStaticContPT(game, result, null);
         return result;
+    }
+
+    private boolean tgtRoleAura(final Player ai, final SpellAbility sa, final Card tok, final boolean mandatory) {
+        boolean isCurse = "Curse".equals(sa.getParam("AILogic")) ||
+                tok.getFirstAttachSpell().getParamOrDefault("AILogic", "").equals("Curse");
+        List<Card> tgts = CardUtil.getValidCardsToTarget(sa);
+
+        // look for card without role from ai
+        List<Card> prefListSBA = CardLists.filter(tgts, c ->
+        !Iterables.any(c.getAttachedCards(), att -> att.getController() == ai && att.getType().hasSubtype("Role")));
+
+        List<Card> prefList;
+        if (isCurse) {
+            prefList = CardLists.filterControlledBy(prefListSBA, ai.getOpponents());
+        } else {
+            prefList = CardLists.filterControlledBy(prefListSBA, ai.getYourTeam());
+        }
+
+        if (prefList.isEmpty()) {
+            if (mandatory) {
+                if (sa.isTargetNumberValid()) {
+                    // TODO try replace Curse <-> Pump depending on target controller
+                    return true;
+                }
+                if (!prefListSBA.isEmpty()) {
+                    sa.getTargets().add(ComputerUtilCard.getWorstCreatureAI(prefListSBA));
+                    return true;
+                }
+                if (!tgts.isEmpty()) {
+                    sa.getTargets().add(ComputerUtilCard.getWorstCreatureAI(tgts));
+                    return true;
+                }
+            }
+        } else {
+            sa.getTargets().add(ComputerUtilCard.getBestCreatureAI(prefList));
+            return true;
+        }
+
+        return false;
     }
 
 }

--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -1326,6 +1326,7 @@ public class GameAction {
 
                 checkAgainCard |= stateBasedAction_Saga(c, sacrificeList);
                 checkAgainCard |= stateBasedAction_Battle(c, noRegCreats);
+                checkAgainCard |= stateBasedAction_Role(c, noRegCreats);
                 checkAgainCard |= stateBasedAction704_attach(c, unAttachList); // Attachment
 
                 checkAgainCard |= stateBasedAction704_5r(c); // annihilate +1/+1 counters with -1/-1 ones
@@ -1526,6 +1527,28 @@ public class GameAction {
         }
         return checkAgain;
     }
+    private boolean stateBasedAction_Role(Card c, CardCollection removeList) {
+        if (!c.hasCardAttachments()) {
+            return false;
+        }
+        boolean checkAgain = false;
+        CardCollection roles = CardLists.filter(c.getAttachedCards(), CardPredicates.isType("Role"));
+        if (roles.isEmpty()) {
+            return false;
+        }
+
+        for (Player p : this.game.getPlayers()) {
+            CardCollection rolesByPlayer = CardLists.filterControlledBy(roles, p);
+            if (rolesByPlayer.size() <= 1) {
+                continue;
+            }
+            // sort by game timestamp
+            rolesByPlayer.sort(CardPredicates.compareByTimestamp());
+            removeList.addAll(rolesByPlayer.subList(0, rolesByPlayer.size() - 1));
+            checkAgain = true;
+        }
+        return checkAgain;
+    }
 
     private void stateBasedAction_Dungeon(Card c) {
         if (!c.getType().isDungeon() || !c.isInLastRoom()) {
@@ -1541,7 +1564,8 @@ public class GameAction {
 
         if (c.isAttachedToEntity()) {
             final GameEntity ge = c.getEntityAttachedTo();
-            if (!ge.canBeAttached(c, null, true)) {
+            // Rule 704.5q - Creature attached to an object or player, becomes unattached
+            if (c.isCreature() || c.isBattle() || !ge.canBeAttached(c, null, true)) {
                 unAttachList.add(c);
                 checkAgain = true;
             }
@@ -1555,10 +1579,7 @@ public class GameAction {
                 }
             }
         }
-        if ((c.isCreature() || c.isBattle()) && c.isAttachedToEntity()) { // Rule 704.5q - Creature attached to an object or player, becomes unattached
-            unAttachList.add(c);
-            checkAgain = true;
-        }
+
         return checkAgain;
     }
 

--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -1326,7 +1326,7 @@ public class GameAction {
 
                 checkAgainCard |= stateBasedAction_Saga(c, sacrificeList);
                 checkAgainCard |= stateBasedAction_Battle(c, noRegCreats);
-                checkAgainCard |= stateBasedAction_Role(c, noRegCreats);
+                checkAgainCard |= stateBasedAction_Role(c, unAttachList);
                 checkAgainCard |= stateBasedAction704_attach(c, unAttachList); // Attachment
 
                 checkAgainCard |= stateBasedAction704_5r(c); // annihilate +1/+1 counters with -1/-1 ones
@@ -1537,7 +1537,7 @@ public class GameAction {
             return false;
         }
 
-        for (Player p : this.game.getPlayers()) {
+        for (Player p : game.getPlayers()) {
             CardCollection rolesByPlayer = CardLists.filterControlledBy(roles, p);
             if (rolesByPlayer.size() <= 1) {
                 continue;

--- a/forge-gui/res/cardsfolder/upcoming/spellbook_vendor.txt
+++ b/forge-gui/res/cardsfolder/upcoming/spellbook_vendor.txt
@@ -1,0 +1,11 @@
+Name:Spellbook Vendor
+ManaCost:1 W
+Types:Creature Human Peasant
+PT:2/2
+K:Vigilance
+T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | Execute$ TrigImmediate | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of combat on your turn, you may pay {1}. When you do, create a Sorcerer Role token attached to target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has "Whenever this creature attacks, scry 1.")
+SVar:TrigImmediate:AB$ ImmediateTrigger | Cost$ 1 | Execute$ TrigToken | TriggerDescription$ When you do, create a Sorcerer Role token attached to target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has "Whenever this creature attacks, scry 1.")
+SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ role_sorcerer | TokenOwner$ You | AttachedTo$ Targeted | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control
+DeckHas:Ability$Token & Type$Role|Aura
+Oracle:Vigilance\nAt the beginning of combat on your turn, you may pay {1}. When you do, create a Sorcerer Role token attached to target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has "Whenever this creature attacks, scry 1.")
+

--- a/forge-gui/res/cardsfolder/upcoming/spellbook_vendor.txt
+++ b/forge-gui/res/cardsfolder/upcoming/spellbook_vendor.txt
@@ -8,4 +8,3 @@ SVar:TrigImmediate:AB$ ImmediateTrigger | Cost$ 1 | Execute$ TrigToken | Trigger
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ role_sorcerer | TokenOwner$ You | AttachedTo$ Targeted | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control
 DeckHas:Ability$Token & Type$Role|Aura
 Oracle:Vigilance\nAt the beginning of combat on your turn, you may pay {1}. When you do, create a Sorcerer Role token attached to target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has "Whenever this creature attacks, scry 1.")
-

--- a/forge-gui/res/cardsfolder/upcoming/spiteful_hexmage.txt
+++ b/forge-gui/res/cardsfolder/upcoming/spiteful_hexmage.txt
@@ -1,0 +1,9 @@
+Name:Spiteful Hexmage
+ManaCost:B
+Types:Creature Human Warlock
+PT:3/2
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters the battlefield, create a Cursed Role token attached to target creature you control. (if you control another Role on it, put that one into the graveyard. Enchanted creature is 1/1)
+SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ role_cursed | TokenOwner$ You | AttachedTo$ Targeted | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | SpellDescription$ Create a Wicked Role token attached to target creature you control.
+DeckHas:Ability$Token & Type$Role|Aura
+Oracle:When Spiteful Hexmage enters the battlefield, create a Cursed Role token attached to target creature you control. (if you control another Role on it, put that one into the graveyard. Enchanted creature is 1/1)
+

--- a/forge-gui/res/cardsfolder/upcoming/spiteful_hexmage.txt
+++ b/forge-gui/res/cardsfolder/upcoming/spiteful_hexmage.txt
@@ -3,7 +3,6 @@ ManaCost:B
 Types:Creature Human Warlock
 PT:3/2
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters the battlefield, create a Cursed Role token attached to target creature you control. (if you control another Role on it, put that one into the graveyard. Enchanted creature is 1/1)
-SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ role_cursed | TokenOwner$ You | AttachedTo$ Targeted | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | SpellDescription$ Create a Wicked Role token attached to target creature you control.
+SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ role_cursed | TokenOwner$ You | AttachedTo$ Targeted | ValidTgts$ Creature.YouCtrl | AILogic$ Curse | TgtPrompt$ Select target creature you control
 DeckHas:Ability$Token & Type$Role|Aura
 Oracle:When Spiteful Hexmage enters the battlefield, create a Cursed Role token attached to target creature you control. (if you control another Role on it, put that one into the graveyard. Enchanted creature is 1/1)
-

--- a/forge-gui/res/lists/TypeLists.txt
+++ b/forge-gui/res/lists/TypeLists.txt
@@ -315,6 +315,7 @@ Background
 Cartouche
 Class
 Curse
+Role
 Rune
 Saga
 Shrine

--- a/forge-gui/res/tokenscripts/role_cursed.txt
+++ b/forge-gui/res/tokenscripts/role_cursed.txt
@@ -6,4 +6,3 @@ A:SP$ Attach | Cost$ 0 | ValidTgts$ Creature | AILogic$ Curse
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | SetPower$ 1 | SetToughness$ 1 | Description$ Enchanted creature is 1/1
 SVar:SacMe:2
 Oracle:Enchant Creature\nEnchanted creature is 1/1
-

--- a/forge-gui/res/tokenscripts/role_cursed.txt
+++ b/forge-gui/res/tokenscripts/role_cursed.txt
@@ -1,0 +1,9 @@
+Name:Cursed
+ManaCost:no cost
+Types:Enchantment Aura Role
+K:Enchant creature
+A:SP$ Attach | Cost$ 0 | ValidTgts$ Creature | AILogic$ Curse
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | SetPower$ 1 | SetToughness$ 1 | Description$ Enchanted creature is 1/1
+SVar:SacMe:2
+Oracle:Enchant Creature\nEnchanted creature is 1/1
+

--- a/forge-gui/res/tokenscripts/role_monster.txt
+++ b/forge-gui/res/tokenscripts/role_monster.txt
@@ -5,4 +5,3 @@ K:Enchant creature
 A:SP$ Attach | Cost$ 0 | ValidTgts$ Creature | AILogic$ Pump
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | AddToughness$ 1 | AddKeyword$ Trample | Description$ Enchanted creature gets +1/+1 and has trample.
 Oracle:Enchant Creature\nEnchanted creature gets +1/+1 and has trample.
-

--- a/forge-gui/res/tokenscripts/role_monster.txt
+++ b/forge-gui/res/tokenscripts/role_monster.txt
@@ -1,0 +1,8 @@
+Name:Monster
+ManaCost:no cost
+Types:Enchantment Aura Role
+K:Enchant creature
+A:SP$ Attach | Cost$ 0 | ValidTgts$ Creature | AILogic$ Pump
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | AddToughness$ 1 | AddKeyword$ Trample | Description$ Enchanted creature gets +1/+1 and has trample.
+Oracle:Enchant Creature\nEnchanted creature gets +1/+1 and has trample.
+

--- a/forge-gui/res/tokenscripts/role_royal.txt
+++ b/forge-gui/res/tokenscripts/role_royal.txt
@@ -1,0 +1,8 @@
+Name:Royal
+ManaCost:no cost
+Types:Enchantment Aura Role
+K:Enchant creature
+A:SP$ Attach | Cost$ 0 | ValidTgts$ Creature | AILogic$ Pump
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | AddToughness$ 1 | AddKeyword$ Ward:1 | Description$ Enchanted creature gets +1/+1 and has ward {1}. (Whenever enchanted creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.) 
+Oracle:Enchant Creature\nEnchanted creature gets +1/+1 and has ward {1}. (Whenever enchanted creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)
+

--- a/forge-gui/res/tokenscripts/role_royal.txt
+++ b/forge-gui/res/tokenscripts/role_royal.txt
@@ -5,4 +5,3 @@ K:Enchant creature
 A:SP$ Attach | Cost$ 0 | ValidTgts$ Creature | AILogic$ Pump
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | AddToughness$ 1 | AddKeyword$ Ward:1 | Description$ Enchanted creature gets +1/+1 and has ward {1}. (Whenever enchanted creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.) 
 Oracle:Enchant Creature\nEnchanted creature gets +1/+1 and has ward {1}. (Whenever enchanted creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)
-

--- a/forge-gui/res/tokenscripts/role_sorcerer.txt
+++ b/forge-gui/res/tokenscripts/role_sorcerer.txt
@@ -1,0 +1,9 @@
+Name:Sorcerer
+ManaCost:no cost
+Types:Enchantment Aura Role
+K:Enchant creature
+A:SP$ Attach | Cost$ 0 | ValidTgts$ Creature | AILogic$ Pump
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | AddToughness$ 1  | AddTrigger$ AttackTrig | Description$ Enchanted creature gets +1/+1 and has "Whenever this creature attacks, scry 1."
+SVar:AttackTrig:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ Whenever this creature attacks, scry 1.
+SVar:TrigScry:DB$ Scry | ScryNum$ 1
+Oracle:Enchant Creature\nEnchanted creature gets +1/+1 and has "Whenever this creature attacks, scry 1."

--- a/forge-gui/res/tokenscripts/role_virtuous.txt
+++ b/forge-gui/res/tokenscripts/role_virtuous.txt
@@ -1,0 +1,9 @@
+Name:Virtuous
+ManaCost:no cost
+Types:Enchantment Aura Role
+K:Enchant creature
+A:SP$ Attach | Cost$ 0 | ValidTgts$ Creature | AILogic$ Pump
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ X | AddToughness$ X | Description$ Enchanted creature gets +1/+1 for each enchantment you control.
+SVar:X:Count$Valid Enchantment.YouCtrl
+Oracle:Enchant Creature\nEnchanted creature gets +1/+1.\nEnchanted creature gets +1/+1 for each enchantment you control.
+

--- a/forge-gui/res/tokenscripts/role_virtuous.txt
+++ b/forge-gui/res/tokenscripts/role_virtuous.txt
@@ -6,4 +6,3 @@ A:SP$ Attach | Cost$ 0 | ValidTgts$ Creature | AILogic$ Pump
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ X | AddToughness$ X | Description$ Enchanted creature gets +1/+1 for each enchantment you control.
 SVar:X:Count$Valid Enchantment.YouCtrl
 Oracle:Enchant Creature\nEnchanted creature gets +1/+1.\nEnchanted creature gets +1/+1 for each enchantment you control.
-

--- a/forge-gui/res/tokenscripts/role_wicked.txt
+++ b/forge-gui/res/tokenscripts/role_wicked.txt
@@ -1,0 +1,10 @@
+Name:Wicked
+ManaCost:no cost
+Types:Enchantment Aura Role
+K:Enchant creature
+A:SP$ Attach | Cost$ 0 | ValidTgts$ Creature | AILogic$ Pump
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | AddToughness$ 1 | Description$ Enchanted creature gets +1/+1 
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigDamage | TriggerDescription$ When this Aura is put into a graveyard, each opponent loses 1 life.
+SVar:TrigDamage:DB$ LoseLife | LifeAmount$ 1 | Defined$ Opponent
+Oracle:Enchant Creature\nEnchanted creature gets +1/+1.\nWhen this Aura is put into a graveyard, each opponent loses 1 life.
+

--- a/forge-gui/res/tokenscripts/role_wicked.txt
+++ b/forge-gui/res/tokenscripts/role_wicked.txt
@@ -7,4 +7,3 @@ S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | AddToughness
 T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigDamage | TriggerDescription$ When this Aura is put into a graveyard, each opponent loses 1 life.
 SVar:TrigDamage:DB$ LoseLife | LifeAmount$ 1 | Defined$ Opponent
 Oracle:Enchant Creature\nEnchanted creature gets +1/+1.\nWhen this Aura is put into a graveyard, each opponent loses 1 life.
-

--- a/forge-gui/res/tokenscripts/role_young_hero.txt
+++ b/forge-gui/res/tokenscripts/role_young_hero.txt
@@ -1,0 +1,10 @@
+Name:Young Hero
+ManaCost:no cost
+Types:Enchantment Aura Role
+K:Enchant creature
+A:SP$ Attach | Cost$ 0 | ValidTgts$ Creature | AILogic$ Pump
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddTrigger$ AttackTrig | Description$ Enchanted creature has "Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it."
+SVar:AttackTrig:Mode$ Attacks | ValidCard$ Card.Self | IsPresent$ Card.Self+toughnessLE3 | Execute$ TrigCounter | TriggerDescription$ Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it.
+SVar:TrigCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
+Oracle:Enchant Creature\nEnchanted creature has "Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it."
+

--- a/forge-gui/res/tokenscripts/role_young_hero.txt
+++ b/forge-gui/res/tokenscripts/role_young_hero.txt
@@ -7,4 +7,3 @@ S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddTrigger$ AttackTrig | D
 SVar:AttackTrig:Mode$ Attacks | ValidCard$ Card.Self | IsPresent$ Card.Self+toughnessLE3 | Execute$ TrigCounter | TriggerDescription$ Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it.
 SVar:TrigCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
 Oracle:Enchant Creature\nEnchanted creature has "Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it."
-


### PR DESCRIPTION
Closes #3685 

the Send to Graveyard should only be needed as StateBasedAction

as per rules, it looks like they are directly send to GY instead of getting unattached first? That might matter?
I still unattach them first for better trigger

As for the Cards that makes the Roles, @Agetian AI might need some logic to not add Roles to cards that already has Roles? (except the Cursed one?)