### PR TITLE
fix script

### DIFF
--- a/forge-ai/src/main/java/forge/ai/GameState.java
+++ b/forge-ai/src/main/java/forge/ai/GameState.java
@@ -1245,7 +1245,7 @@ public abstract class GameState {
                     System.err.println("ERROR: Tried to create a non-existent token named " + cardinfo[0] + " when loading game state!");
                     continue;
                 }
-                c = Card.fromPaperCard(token, player, player.getGame());
+                c = CardFactory.getCard(token, player, player.getGame());
             } else {
                 PaperCard pc = StaticData.instance().getCommonCards().getCard(cardinfo[0], setCode, artID);
                 if (pc == null) {

--- a/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
@@ -50,7 +50,7 @@ public class GameStateEvaluator {
             return null;
         }
         GameCopier copier = new GameCopier(evalGame);
-        Game gameCopy = copier.makeCopy();
+        Game gameCopy = copier.makeCopy(null, aiPlayer);
         gameCopy.getPhaseHandler().devAdvanceToPhase(PhaseType.COMBAT_DAMAGE, new Runnable() {
             @Override
             public void run() {

--- a/forge-game/src/main/java/forge/game/ability/effects/ChooseSourceEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChooseSourceEffect.java
@@ -56,25 +56,20 @@ public class ChooseSourceEffect extends SpellAbilityEffect {
 
             // Get the list of cards that are referenced by effects on the stack
             SpellAbility siSpellAbility = stackinst.getSpellAbility();
-            if (siSpellAbility.getTriggeringObjects() != null) {
-                for (Object c : siSpellAbility.getTriggeringObjects().values()) {
-                    if (c instanceof Card) {
-                        if (!stackSources.contains(c)) {
-                            referencedSources.add((Card) c);
-                        }
+            for (Object c : siSpellAbility.getTriggeringObjects().values()) {
+                if (c instanceof Card) {
+                    if (!stackSources.contains(c)) {
+                        referencedSources.add((Card) c);
                     }
                 }
             }
             if (siSpellAbility.getTargetCard() != null) {
                 referencedSources.add(siSpellAbility.getTargetCard());
             }
-            // TODO: is this necessary?
-            if (siSpellAbility.getReplacingObjects() != null) {
-                for (Object c : siSpellAbility.getReplacingObjects().values()) {
-                    if (c instanceof Card) {
-                        if (!stackSources.contains(c)) {
-                            referencedSources.add((Card) c);
-                        }
+            for (Object c : siSpellAbility.getReplacingObjects().values()) {
+                if (c instanceof Card) {
+                    if (!stackSources.contains(c)) {
+                        referencedSources.add((Card) c);
                     }
                 }
             }

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -6966,9 +6966,6 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
     public static Card fromPaperCard(IPaperCard pc, Player owner) {
         return CardFactory.getCard(pc, owner, owner == null ? null : owner.getGame());
     }
-    public static Card fromPaperCard(IPaperCard pc, Player owner, Game game) {
-        return CardFactory.getCard(pc, owner, game);
-    }
 
     private static final Map<PaperCard, Card> cp2card = Maps.newHashMap();
     public static Card getCardForUi(IPaperCard pc) {

--- a/forge-game/src/main/java/forge/game/card/CardFactory.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactory.java
@@ -652,8 +652,6 @@ public class CardFactory {
         if (p != null) {
             to.setActivatingPlayer(p, lki);
         }
-
-        //to.changeText();
     }
 
     /**

--- a/forge-game/src/main/java/forge/game/card/token/TokenInfo.java
+++ b/forge-game/src/main/java/forge/game/card/token/TokenInfo.java
@@ -17,6 +17,7 @@ import forge.card.MagicColor;
 import forge.game.Game;
 import forge.game.ability.AbilityUtils;
 import forge.game.card.Card;
+import forge.game.card.CardFactory;
 import forge.game.card.CardFactoryUtil;
 import forge.game.card.CardUtil;
 import forge.game.keyword.KeywordInterface;
@@ -279,7 +280,7 @@ public class TokenInfo {
         if (token == null) {
             return null;
         }
-        final Card result = Card.fromPaperCard(token, owner, game);
+        final Card result = CardFactory.getCard(token, owner, game);
 
         if (sa.hasParam("TokenPower")) {
             String str = sa.getParam("TokenPower");

--- a/forge-game/src/main/java/forge/game/zone/MagicStack.java
+++ b/forge-game/src/main/java/forge/game/zone/MagicStack.java
@@ -308,6 +308,8 @@ public class MagicStack /* extends MyObservable */ implements Iterable<SpellAbil
             // if not already copied use a fresh instance
             SpellAbility original = sp;
             sp = sp.copy();
+            // need to reapply text changes
+            sp.changeText();
             sp.setOriginalAbility(original);
             original.setXManaCostPaid(null);
         }

--- a/forge-gui-desktop/src/test/java/forge/ai/simulation/SimulationTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/simulation/SimulationTest.java
@@ -21,6 +21,7 @@ import forge.game.GameType;
 import forge.game.Match;
 import forge.game.card.Card;
 import forge.game.card.CardCollectionView;
+import forge.game.card.CardFactory;
 import forge.game.player.Player;
 import forge.game.player.RegisteredPlayer;
 import forge.game.spellability.SpellAbility;
@@ -158,7 +159,7 @@ public class SimulationTest {
             System.out.println("Failed to find token name " + name);
             return null;
         }
-        return Card.fromPaperCard(token, p, p.getGame());
+        return CardFactory.getCard(token, p, p.getGame());
     }
 
     protected List<Card> addTokens(String name, int amount, Player p) {

--- a/forge-gui/res/cardsfolder/i/ignoble_soldier.txt
+++ b/forge-gui/res/cardsfolder/i/ignoble_soldier.txt
@@ -3,7 +3,7 @@ ManaCost:2 W
 Types:Creature Human Soldier
 PT:3/1
 T:Mode$ AttackerBlocked | ValidCard$ Card.Self | Execute$ TrigNodamage | TriggerDescription$ Whenever CARDNAME becomes blocked, prevent all combat damage that would be dealt by it this turn.
-SVar:TrigNodamage:DB$ Effect | ReplacementEffects$ RPrevent | RememberObjects$ TriggeredAttacker | ExileOnMoved$ Battlefield
+SVar:TrigNodamage:DB$ Effect | ReplacementEffects$ RPrevent | RememberObjects$ TriggeredAttackerLKICopy | ExileOnMoved$ Battlefield
 SVar:RPrevent:Event$ DamageDone | Prevent$ True | IsCombat$ True | ValidSource$ Card.IsRemembered | Description$ Prevent all combat damage that would be dealt by it this turn.
 SVar:MustBeBlocked:True
 Oracle:Whenever Ignoble Soldier becomes blocked, prevent all combat damage that would be dealt by it this turn.

--- a/forge-gui/res/cardsfolder/i/ignoble_soldier.txt
+++ b/forge-gui/res/cardsfolder/i/ignoble_soldier.txt
@@ -3,7 +3,7 @@ ManaCost:2 W
 Types:Creature Human Soldier
 PT:3/1
 T:Mode$ AttackerBlocked | ValidCard$ Card.Self | Execute$ TrigNodamage | TriggerDescription$ Whenever CARDNAME becomes blocked, prevent all combat damage that would be dealt by it this turn.
-SVar:TrigNodamage:DB$ Effect | ReplacementEffects$ RPrevent | RememberObjects$ TriggeredCard | ExileOnMoved$ Battlefield
+SVar:TrigNodamage:DB$ Effect | ReplacementEffects$ RPrevent | RememberObjects$ TriggeredAttacker | ExileOnMoved$ Battlefield
 SVar:RPrevent:Event$ DamageDone | Prevent$ True | IsCombat$ True | ValidSource$ Card.IsRemembered | Description$ Prevent all combat damage that would be dealt by it this turn.
 SVar:MustBeBlocked:True
 Oracle:Whenever Ignoble Soldier becomes blocked, prevent all combat damage that would be dealt by it this turn.


### PR DESCRIPTION
Closes #3729

I did some preliminary work on the simulation to avoid cheating from hidden information, with the added performance benefit that less cards need to be copied fully.
E.g. in this scenario the AI "shouldn't" recognize it can draw->cast the Colossus instead of using the mana for the Griffin:
![image](https://github.com/Card-Forge/forge/assets/8506892/9f564c10-43d0-4296-8667-0611f3de934e)

But I need to refine it further so for now the path is disabled by default.