### PR TITLE
Add back faced cards to writeDeckHtml

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/DeckHtmlSerializer.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/DeckHtmlSerializer.java
@@ -75,6 +75,11 @@ public class DeckHtmlSerializer {
                     final PaperCard r = card.getKey();
                     final String url = ForgeConstants.URL_PIC_DOWNLOAD + ImageUtil.getDownloadUrl(r, "");
                     list.add(url);
+
+                    if (r.hasBackFace()) {
+                        final String backUrl = ForgeConstants.URL_PIC_DOWNLOAD + ImageUtil.getDownloadUrl(r, "back");
+                        list.add(backUrl);
+                    }
                 }
             }
 


### PR DESCRIPTION
First: super cool project!

When printing a deck from forge-desktop-gui, cards with back faces were not fully represented. This simple PR, simply adds back faced cards to the output of `DeckHtmlSerializer.writeDeckHtml`.

/ Henry