### PR TITLE
Add an option to use all card variants in Adventure Mode

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/data/RewardData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/RewardData.java
@@ -104,7 +104,7 @@ public class RewardData implements Serializable {
                 return false;
             if(input.getRules().isCustom())
                 return false;
-            return allCardVariants || !Arrays.asList(Config.instance().getConfigData().restrictedCards).contains(input.getName());
+            return !Arrays.asList(Config.instance().getConfigData().restrictedCards).contains(input.getName());
         });
         //Filter AI cards for enemies.
         allEnemyCards=Iterables.filter(allCards, input -> {

--- a/forge-gui-mobile/src/forge/adventure/data/RewardData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/RewardData.java
@@ -82,16 +82,18 @@ public class RewardData implements Serializable {
     private static Iterable<PaperCard> allCards;
     private static Iterable<PaperCard> allEnemyCards;
 
+    private static Collection<PaperCard> getFullCardPool() {
+        return Config.instance().getSettingData().useAllCardVariants ?
+                FModel.getMagicDb().getCommonCards().getAllCards() : FModel.getMagicDb().getCommonCards().getUniqueCardsNoAlt();
+    }
+
     static private void initializeAllCards(){
         RewardData legals = Config.instance().getConfigData().legalCards;
-        boolean allCardVariants = Config.instance().getSettingData().useAllCardVariants;
 
         if(legals==null)
-            allCards = allCardVariants ? FModel.getMagicDb().getCommonCards().getAllCards()
-                    : FModel.getMagicDb().getCommonCards().getUniqueCardsNoAlt();
+            allCards = getFullCardPool();
         else
-            allCards = Iterables.filter(allCardVariants ? FModel.getMagicDb().getCommonCards().getAllCards()
-                    : FModel.getMagicDb().getCommonCards().getUniqueCardsNoAlt(), new CardUtil.CardPredicate(legals, true));
+            allCards = Iterables.filter(getFullCardPool(), new CardUtil.CardPredicate(legals, true));
         //Filter out specific cards.
         allCards = Iterables.filter(allCards, input -> {
             if(input == null)

--- a/forge-gui-mobile/src/forge/adventure/data/RewardData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/RewardData.java
@@ -84,10 +84,14 @@ public class RewardData implements Serializable {
 
     static private void initializeAllCards(){
         RewardData legals = Config.instance().getConfigData().legalCards;
+        boolean allCardVariants = Config.instance().getSettingData().useAllCardVariants;
+
         if(legals==null)
-            allCards = FModel.getMagicDb().getCommonCards().getUniqueCardsNoAlt();
+            allCards = allCardVariants ? FModel.getMagicDb().getCommonCards().getAllCards()
+                    : FModel.getMagicDb().getCommonCards().getUniqueCardsNoAlt();
         else
-            allCards = Iterables.filter(FModel.getMagicDb().getCommonCards().getUniqueCardsNoAlt(),  new CardUtil.CardPredicate(legals, true));
+            allCards = Iterables.filter(allCardVariants ? FModel.getMagicDb().getCommonCards().getAllCards()
+                    : FModel.getMagicDb().getCommonCards().getUniqueCardsNoAlt(), new CardUtil.CardPredicate(legals, true));
         //Filter out specific cards.
         allCards = Iterables.filter(allCards, input -> {
             if(input == null)
@@ -100,7 +104,7 @@ public class RewardData implements Serializable {
                 return false;
             if(input.getRules().isCustom())
                 return false;
-            return !Arrays.asList(Config.instance().getConfigData().restrictedCards).contains(input.getName());
+            return allCardVariants || !Arrays.asList(Config.instance().getConfigData().restrictedCards).contains(input.getName());
         });
         //Filter AI cards for enemies.
         allEnemyCards=Iterables.filter(allCards, input -> {

--- a/forge-gui-mobile/src/forge/adventure/data/RewardData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/RewardData.java
@@ -82,18 +82,13 @@ public class RewardData implements Serializable {
     private static Iterable<PaperCard> allCards;
     private static Iterable<PaperCard> allEnemyCards;
 
-    private static Collection<PaperCard> getFullCardPool() {
-        return Config.instance().getSettingData().useAllCardVariants ?
-                FModel.getMagicDb().getCommonCards().getAllCards() : FModel.getMagicDb().getCommonCards().getUniqueCardsNoAlt();
-    }
-
     static private void initializeAllCards(){
         RewardData legals = Config.instance().getConfigData().legalCards;
 
         if(legals==null)
-            allCards = getFullCardPool();
+            allCards = CardUtil.getFullCardPool();
         else
-            allCards = Iterables.filter(getFullCardPool(), new CardUtil.CardPredicate(legals, true));
+            allCards = Iterables.filter(CardUtil.getFullCardPool(), new CardUtil.CardPredicate(legals, true));
         //Filter out specific cards.
         allCards = Iterables.filter(allCards, input -> {
             if(input == null)

--- a/forge-gui-mobile/src/forge/adventure/data/RewardData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/RewardData.java
@@ -10,7 +10,6 @@ import forge.adventure.util.Reward;
 import forge.adventure.world.WorldSave;
 import forge.deck.Deck;
 import forge.item.PaperCard;
-import forge.model.FModel;
 
 import java.io.Serializable;
 import java.util.*;
@@ -167,8 +166,15 @@ public class RewardData implements Serializable {
                 case "card":
                 case "randomCard":
                     if( cardName != null && !cardName.isEmpty() ) {
-                        for(int i = 0; i < count + addedCount; i++) {
-                            ret.add(new Reward(allCardVariants ? CardUtil.getCardByName(cardName) : StaticData.instance().getCommonCards().getCard(cardName), isNoSell));
+                        if (allCardVariants) {
+                            PaperCard card = CardUtil.getCardByName(cardName);
+                            for (int i = 0; i < count + addedCount; i++) {
+                                ret.add(new Reward(CardUtil.getCardByNameAndEdition(cardName, card.getEdition()), isNoSell));
+                            }
+                        } else {
+                            for (int i = 0; i < count + addedCount; i++) {
+                                ret.add(new Reward(StaticData.instance().getCommonCards().getCard(cardName), isNoSell));
+                            }
                         }
                     } else {
                         for(PaperCard card:CardUtil.generateCards(isForEnemy ? allEnemyCards:allCards,this, count+addedCount, rewardRandom)) {

--- a/forge-gui-mobile/src/forge/adventure/data/RewardData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/RewardData.java
@@ -2,6 +2,7 @@ package forge.adventure.data;
 
 import com.badlogic.gdx.utils.Array;
 import com.google.common.collect.Iterables;
+import forge.StaticData;
 import forge.adventure.util.CardUtil;
 import forge.adventure.util.Config;
 import forge.adventure.util.Current;
@@ -148,7 +149,7 @@ public class RewardData implements Serializable {
                     for (RewardData r : cardUnion) {
                         if( r.cardName != null && !r.cardName.isEmpty() ) {
                             PaperCard pc = allCardVariants ? CardUtil.getCardByName(r.cardName)
-                                    : FModel.getMagicDb().getCommonCards().getCard(r.cardName);
+                                    : StaticData.instance().getCommonCards().getCard(r.cardName);
                             if (pc != null)
                                 pool.add(pc);
                         } else {
@@ -167,7 +168,7 @@ public class RewardData implements Serializable {
                 case "randomCard":
                     if( cardName != null && !cardName.isEmpty() ) {
                         for(int i = 0; i < count + addedCount; i++) {
-                            ret.add(new Reward(allCardVariants ? CardUtil.getCardByName(cardName) : FModel.getMagicDb().getCommonCards().getCard(cardName), isNoSell));
+                            ret.add(new Reward(allCardVariants ? CardUtil.getCardByName(cardName) : StaticData.instance().getCommonCards().getCard(cardName), isNoSell));
                         }
                     } else {
                         for(PaperCard card:CardUtil.generateCards(isForEnemy ? allEnemyCards:allCards,this, count+addedCount, rewardRandom)) {

--- a/forge-gui-mobile/src/forge/adventure/data/RewardData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/RewardData.java
@@ -236,8 +236,27 @@ public class RewardData implements Serializable {
     }
     static public List<PaperCard> rewardsToCards(Iterable<Reward> dataList) {
         ArrayList<PaperCard> ret=new ArrayList<PaperCard>();
-        for (Reward data:dataList) {
-            ret.add(data.getCard());
+
+        boolean allCardVariants = Config.instance().getSettingData().useAllCardVariants;
+
+        if (allCardVariants) {
+            String basicLandEdition = "";
+            for (Reward data : dataList) {
+                PaperCard card = data.getCard();
+                if (card.isVeryBasicLand()) {
+                    // ensure that all basid lands share the same edition so the deck doesn't look odd
+                    if (basicLandEdition.isEmpty()) {
+                        basicLandEdition = card.getEdition();
+                    }
+                    ret.add(CardUtil.getCardByNameAndEdition(card.getName(), basicLandEdition));
+                } else {
+                    ret.add(card);
+                }
+            }
+        } else {
+            for (Reward data : dataList) {
+                ret.add(data.getCard());
+            }
         }
         return ret;
     }

--- a/forge-gui-mobile/src/forge/adventure/data/RewardData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/RewardData.java
@@ -2,7 +2,6 @@ package forge.adventure.data;
 
 import com.badlogic.gdx.utils.Array;
 import com.google.common.collect.Iterables;
-import forge.StaticData;
 import forge.adventure.util.CardUtil;
 import forge.adventure.util.Config;
 import forge.adventure.util.Current;
@@ -129,6 +128,7 @@ public class RewardData implements Serializable {
 
     public Array<Reward> generate(boolean isForEnemy, Iterable<PaperCard> cards, boolean useSeedlessRandom, boolean isNoSell) {
 
+        boolean allCardVariants = Config.instance().getSettingData().useAllCardVariants;
         Random rewardRandom = useSeedlessRandom?new Random():WorldSave.getCurrentSave().getWorld().getRandom();
         //Keep using same generation method for shop rewards, but fully randomize loot drops by not using the instance pre-seeded by the map
 
@@ -147,7 +147,8 @@ public class RewardData implements Serializable {
                     HashSet<PaperCard> pool = new HashSet<>();
                     for (RewardData r : cardUnion) {
                         if( r.cardName != null && !r.cardName.isEmpty() ) {
-                            PaperCard pc = StaticData.instance().getCommonCards().getCard(r.cardName);
+                            PaperCard pc = allCardVariants ? CardUtil.getCardByName(r.cardName)
+                                    : FModel.getMagicDb().getCommonCards().getCard(r.cardName);
                             if (pc != null)
                                 pool.add(pc);
                         } else {
@@ -166,7 +167,7 @@ public class RewardData implements Serializable {
                 case "randomCard":
                     if( cardName != null && !cardName.isEmpty() ) {
                         for(int i = 0; i < count + addedCount; i++) {
-                            ret.add(new Reward(StaticData.instance().getCommonCards().getCard(cardName), isNoSell));
+                            ret.add(new Reward(allCardVariants ? CardUtil.getCardByName(cardName) : FModel.getMagicDb().getCommonCards().getCard(cardName), isNoSell));
                         }
                     } else {
                         for(PaperCard card:CardUtil.generateCards(isForEnemy ? allEnemyCards:allCards,this, count+addedCount, rewardRandom)) {

--- a/forge-gui-mobile/src/forge/adventure/data/SettingData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/SettingData.java
@@ -21,4 +21,5 @@ public class SettingData {
     public boolean dayNightBG;
     public boolean disableWinLose;
     public boolean showShopOverlay;
+    public boolean useAllCardVariants;
 }

--- a/forge-gui-mobile/src/forge/adventure/scene/SettingsScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/SettingsScene.java
@@ -220,6 +220,13 @@ public class SettingsScene extends UIScene {
                 Config.instance().saveSettings();
             }
         });
+        addSettingField(Forge.getLocalizer().getMessage("lblUseAllCardVariants"), Config.instance().getSettingData().useAllCardVariants, new ChangeListener() {
+            @Override
+            public void changed(ChangeEvent event, Actor actor) {
+                Config.instance().getSettingData().useAllCardVariants = ((CheckBox) actor).isChecked();
+                Config.instance().saveSettings();
+            }
+        });
         addCheckBox(Forge.getLocalizer().getMessage("lblCardName"), ForgePreferences.FPref.UI_OVERLAY_CARD_NAME);
         addSettingSlider(Forge.getLocalizer().getMessage("cbAdjustMusicVolume"), ForgePreferences.FPref.UI_VOL_MUSIC, 0, 100);
         addSettingSlider(Forge.getLocalizer().getMessage("cbAdjustSoundsVolume"), ForgePreferences.FPref.UI_VOL_SOUNDS, 0, 100);

--- a/forge-gui-mobile/src/forge/adventure/util/CardUtil.java
+++ b/forge-gui-mobile/src/forge/adventure/util/CardUtil.java
@@ -595,9 +595,20 @@ public class CardUtil {
     }
 
     private static Collection<PaperCard> generateLands(String landName,int count) {
+        boolean allCardVariants = Config.instance().getSettingData().useAllCardVariants;
         Collection<PaperCard> ret=new ArrayList<>();
-        for(int i=0;i<count;i++)
-            ret.add(FModel.getMagicDb().getCommonCards().getCard(landName));
+
+        if (allCardVariants) {
+            PaperCard randomLand = getCardByName(landName);
+            String edition = randomLand.getEdition();
+
+            for (int i = 0; i < count; i++) {
+                ret.add(getCardByNameAndEdition(landName, edition));
+            }
+        } else {
+            for (int i = 0; i < count; i++)
+                ret.add(FModel.getMagicDb().getCommonCards().getCard(landName));
+        }
 
         return ret;
     }

--- a/forge-gui-mobile/src/forge/adventure/util/CardUtil.java
+++ b/forge-gui-mobile/src/forge/adventure/util/CardUtil.java
@@ -715,6 +715,14 @@ public class CardUtil {
         return generateBoosterPackAsDeck(edition);
     }
 
+    public static PaperCard getCardByName(String cardName) {
+        return Aggregates.random(Iterables.filter(getFullCardPool(), input -> input.getCardName().equals(cardName)));
+    }
+
+    public static PaperCard getCardByNameAndEdition(String cardName, String edition) {
+        return Aggregates.random(Iterables.filter(getFullCardPool(), input -> input.getCardName().equals(cardName) && input.getEdition().equals(edition)));
+    }
+
     public static Collection<PaperCard> getFullCardPool() {
         return Config.instance().getSettingData().useAllCardVariants ?
                 FModel.getMagicDb().getCommonCards().getAllCards() : FModel.getMagicDb().getCommonCards().getUniqueCardsNoAlt();

--- a/forge-gui-mobile/src/forge/adventure/util/CardUtil.java
+++ b/forge-gui-mobile/src/forge/adventure/util/CardUtil.java
@@ -714,5 +714,10 @@ public class CardUtil {
         CardEdition edition = Aggregates.random(possibleEditions);
         return generateBoosterPackAsDeck(edition);
     }
+
+    public static Collection<PaperCard> getFullCardPool() {
+        return Config.instance().getSettingData().useAllCardVariants ?
+                FModel.getMagicDb().getCommonCards().getAllCards() : FModel.getMagicDb().getCommonCards().getUniqueCardsNoAlt();
+    }
 }
 

--- a/forge-gui-mobile/src/forge/adventure/util/CardUtil.java
+++ b/forge-gui-mobile/src/forge/adventure/util/CardUtil.java
@@ -450,6 +450,8 @@ public class CardUtil {
         int colorLess=0;
         int cardCount=nonLands.size();
         List<PaperCard> cards=new ArrayList<>();
+        boolean allCardVariants=Config.instance().getSettingData().useAllCardVariants;
+
         for(PaperCard nonLand:nonLands)
         {
             red+=nonLand.getRules().getManaCost().getShardCount(ManaCostShard.RED);
@@ -463,6 +465,11 @@ public class CardUtil {
         int neededLands=template.count-cardCount;
         int neededDualLands= Math.round (neededLands*template.rares);
         int neededBase=neededLands-neededDualLands;
+        String edition = "";
+        if (allCardVariants) {
+            PaperCard templateLand = CardUtil.getCardByName("Plains");
+            edition = templateLand.getEdition();
+        }
         if(sum==0.)
         {
             cards.addAll(generateLands("Wastes",neededLands));
@@ -474,11 +481,11 @@ public class CardUtil {
             int forest=Math.round(neededBase*(green/sum));
             int plains=Math.round(neededBase*(white/sum));
             int swamp=Math.round(neededBase*(black/sum));
-            cards.addAll(generateLands("Plains",plains));
-            cards.addAll(generateLands("Island",island));
-            cards.addAll(generateLands("Forest",forest));
-            cards.addAll(generateLands("Mountain",mount));
-            cards.addAll(generateLands("Swamp",swamp));
+            cards.addAll(generateLands("Plains",plains,edition));
+            cards.addAll(generateLands("Island",island,edition));
+            cards.addAll(generateLands("Forest",forest,edition));
+            cards.addAll(generateLands("Mountain",mount,edition));
+            cards.addAll(generateLands("Swamp",swamp,edition));
             List<String> landTypes=new ArrayList<>();
             if(mount>0)
                 landTypes.add("Mountain");
@@ -594,14 +601,19 @@ public class CardUtil {
         return ret;
     }
 
-    private static Collection<PaperCard> generateLands(String landName,int count) {
+    private static Collection<PaperCard> generateLands(String landName, int count) {
+        return generateLands(landName, count, "");
+    }
+
+    private static Collection<PaperCard> generateLands(String landName, int count, String edition) {
         boolean allCardVariants = Config.instance().getSettingData().useAllCardVariants;
-        Collection<PaperCard> ret=new ArrayList<>();
+        Collection<PaperCard> ret = new ArrayList<>();
 
         if (allCardVariants) {
-            PaperCard randomLand = getCardByName(landName);
-            String edition = randomLand.getEdition();
-
+            if (edition.isEmpty()) {
+                PaperCard templateLand = getCardByName(landName);
+                edition = templateLand.getEdition();
+            }
             for (int i = 0; i < count; i++) {
                 ret.add(getCardByNameAndEdition(landName, edition));
             }

--- a/forge-gui/res/languages/de-DE.properties
+++ b/forge-gui/res/languages/de-DE.properties
@@ -2985,6 +2985,7 @@ lblToken=Spielstein
 lblBackToAdventure=Zurück zum Abenteuer
 lblDisableWinLose=Deaktivieren Sie Winslose Overlay
 lblShowShopOverlay=Shop -Artikelname anzeigen
+lblUseAllCardVariants=Use Card Variants from All Sets (Restart Required)
 lblExitToWoldMap=Zurück zur Weltkarte?
 lblStartArena=Willst du in die Arena gehen?
 lblWouldYouLikeDestroy=Möchten Sie {0} zerstören?

--- a/forge-gui/res/languages/en-US.properties
+++ b/forge-gui/res/languages/en-US.properties
@@ -2997,6 +2997,7 @@ lblQuitAdventureEventMatch=Quit Match (will count as a loss)
 lblQuitAdventureEvent=You have matches left to play!\nLeaving the event early will forfeit your potential future winnings.\nYou will still receive winnings as if you conceded your remaining matches.\n\nWould you still like to quit the event?
 lblDisableWinLose=Disable WinLose Overlay
 lblShowShopOverlay=Display Shop Item names
+lblUseAllCardVariants=Use Card Variants from All Sets (Restart Required)
 lblExitToWoldMap=Exit to the World Map?
 lblStartArena=Do you want to go into the Arena?
 lblWouldYouLikeDestroy=Would you like to destroy {0}?

--- a/forge-gui/res/languages/es-ES.properties
+++ b/forge-gui/res/languages/es-ES.properties
@@ -2988,6 +2988,7 @@ lblToken=Simbólico
 lblBackToAdventure=Volver a la aventura
 lblDisableWinLose=Desactivar WinLose Overlay
 lblShowShopOverlay=Nombre del artículo de la tienda de exhibición
+lblUseAllCardVariants=Use Card Variants from All Sets (Restart Required)
 lblExitToWoldMap=Salir al mapa del mundo?
 lblStartArena=¿Quieres ir a la arena?
 lblWouldYouLikeDestroy=¿Le gustaría destruir {0}?

--- a/forge-gui/res/languages/fr-FR.properties
+++ b/forge-gui/res/languages/fr-FR.properties
@@ -2992,6 +2992,7 @@ lblToken=Jeton
 lblBackToAdventure=Retour à l'aventure
 lblDisableWinLose=Désactiver la superposition Winlose
 lblShowShopOverlay=Nom de l'article de la boutique d'affichage
+lblUseAllCardVariants=Use Card Variants from All Sets (Restart Required)
 lblExitToWoldMap=Sortir sur la carte du monde?
 lblStartArena=Voulez-vous entrer dans l''arène?
 lblWouldYouLikeDestroy=Souhaitez-vous détruire {0}?

--- a/forge-gui/res/languages/it-IT.properties
+++ b/forge-gui/res/languages/it-IT.properties
@@ -2991,6 +2991,7 @@ lblToken=Gettone
 lblBackToAdventure=Torna all'avventura
 lblDisableWinLose=Disabilita overlay winlose
 lblShowShopOverlay=Visualizza il nome dell'articolo del negozio
+lblUseAllCardVariants=Use Card Variants from All Sets (Restart Required)
 lblExitToWoldMap=Esci alla mappa del mondo?
 lblStartArena=Vuoi andare nell''arena?
 lblWouldYouLikeDestroy=Vorresti distruggere {0}?

--- a/forge-gui/res/languages/ja-JP.properties
+++ b/forge-gui/res/languages/ja-JP.properties
@@ -2987,6 +2987,7 @@ lblToken=トークン
 lblBackToAdventure=冒険に戻ります
 lblDisableWinLose=Winloseオーバーレイを無効にします
 lblShowShopOverlay=ショップアイテム名を表示します
+lblUseAllCardVariants=Use Card Variants from All Sets (Restart Required)
 lblExitToWoldMap=世界地図に終了しますか？
 lblStartArena=アリーナに行きたいですか？
 lblWouldYouLikeDestroy={0}を破壊しますか？

--- a/forge-gui/res/languages/pt-BR.properties
+++ b/forge-gui/res/languages/pt-BR.properties
@@ -3077,6 +3077,7 @@ lblToken=Símbolo
 lblBackToAdventure=De volta à aventura
 lblDisableWinLose=Desative a sobreposição de Winlose
 lblShowShopOverlay=Nome do item da loja de exibição
+lblUseAllCardVariants=Use Card Variants from All Sets (Restart Required)
 lblExitToWoldMap=Sair para o mapa do mundo?
 lblStartArena=Você quer entrar na arena?
 lblWouldYouLikeDestroy=Você gostaria de destruir {0}?

--- a/forge-gui/res/languages/zh-CN.properties
+++ b/forge-gui/res/languages/zh-CN.properties
@@ -2975,6 +2975,7 @@ lblToken=令牌
 lblBackToAdventure=回到冒险
 lblDisableWinLose=禁用Winlose覆盖
 lblShowShopOverlay=展示商店项目名称
+lblUseAllCardVariants=Use Card Variants from All Sets (Restart Required)
 lblExitToWoldMap=退出世界地图？
 lblStartArena=您想进入竞技场吗？
 lblWouldYouLikeDestroy=您想销毁{0}吗？


### PR DESCRIPTION
Adds an option (off by default) to Adventure Mode that adds variants of all cards from all sets to the mix. This effectively ignores the card art preference option ("latest art", "original art", etc.) and simply allows to encounter different variations of the same card in shops. I haven't noticed any negative effects from doing this when playing through a nearly complete Adventure run. As a side effect, you might have a slightly higher chance of encountering a duplicate card in a shop (potentially as a variant from a different set), but I'm not sure if that's the case, as I'm pretty sure I've seen duplicates with this option off as well. If there are any possible issues with this, please let me know.