### PR TITLE
Card cleanup

### DIFF
--- a/forge-gui/res/cardsfolder/a/animar_soul_of_elements.txt
+++ b/forge-gui/res/cardsfolder/a/animar_soul_of_elements.txt
@@ -1,5 +1,5 @@
 Name:Animar, Soul of Elements
-ManaCost:U R G
+ManaCost:G U R
 Types:Legendary Creature Elemental
 PT:1/1
 K:Protection from white

--- a/forge-gui/res/cardsfolder/d/damia_sage_of_stone.txt
+++ b/forge-gui/res/cardsfolder/d/damia_sage_of_stone.txt
@@ -1,5 +1,5 @@
 Name:Damia, Sage of Stone
-ManaCost:4 G U B
+ManaCost:4 B G U
 Types:Legendary Creature Gorgon Wizard
 PT:4/4
 K:Deathtouch

--- a/forge-gui/res/cardsfolder/d/doran_the_siege_tower.txt
+++ b/forge-gui/res/cardsfolder/d/doran_the_siege_tower.txt
@@ -1,5 +1,5 @@
 Name:Doran, the Siege Tower
-ManaCost:B G W
+ManaCost:W B G
 Types:Legendary Creature Treefolk Shaman
 PT:0/5
 S:Mode$ CombatDamageToughness | ValidCard$ Creature | Description$ Each creature assigns combat damage equal to its toughness rather than its power.

--- a/forge-gui/res/cardsfolder/f/fervent_charge.txt
+++ b/forge-gui/res/cardsfolder/f/fervent_charge.txt
@@ -1,5 +1,5 @@
 Name:Fervent Charge
-ManaCost:1 W B R
+ManaCost:1 R W B
 Types:Enchantment
 T:Mode$ Attacks | ValidCard$ Creature.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever a creature you control attacks, it gets +2/+2 until end of turn.
 SVar:TrigPump:DB$ Pump | Defined$ TriggeredAttackerLKICopy | NumAtt$ +2 | NumDef$ +2

--- a/forge-gui/res/cardsfolder/f/fungal_shambler.txt
+++ b/forge-gui/res/cardsfolder/f/fungal_shambler.txt
@@ -1,5 +1,5 @@
 Name:Fungal Shambler
-ManaCost:4 G U B
+ManaCost:4 B G U
 Types:Creature Fungus Beast
 PT:6/4
 K:Trample

--- a/forge-gui/res/cardsfolder/g/galea_kindler_of_hope.txt
+++ b/forge-gui/res/cardsfolder/g/galea_kindler_of_hope.txt
@@ -1,5 +1,5 @@
 Name:Galea, Kindler of Hope
-ManaCost:1 G U W
+ManaCost:1 G W U
 Types:Legendary Creature Elf Knight
 PT:4/4
 K:Vigilance

--- a/forge-gui/res/cardsfolder/g/ghave_guru_of_spores.txt
+++ b/forge-gui/res/cardsfolder/g/ghave_guru_of_spores.txt
@@ -1,5 +1,5 @@
 Name:Ghave, Guru of Spores
-ManaCost:2 B G W
+ManaCost:2 W B G
 Types:Legendary Creature Fungus Shaman
 PT:0/0
 K:etbCounter:P1P1:5

--- a/forge-gui/res/cardsfolder/g/guided_passage.txt
+++ b/forge-gui/res/cardsfolder/g/guided_passage.txt
@@ -1,5 +1,5 @@
 Name:Guided Passage
-ManaCost:U R G
+ManaCost:G U R
 Types:Sorcery
 A:SP$ PeekAndReveal | PeekAmount$ X | NoPeek$ True | SubAbility$ DBCreature | SpellDescription$ Reveal the cards in your library. An opponent chooses from among them a creature card, a land card, and a noncreature, nonland card. You put the chosen cards into your hand. Then shuffle.
 SVar:DBCreature:DB$ ChangeZone | ChangeType$ EACH Creature.YouOwn & Land.YouOwn & Card.nonCreature+nonLand+YouOwn | Mandatory$ True | Chooser$ Opponent | Origin$ Library | Destination$ Hand | Shuffle$ True

--- a/forge-gui/res/cardsfolder/i/intet_the_dreamer.txt
+++ b/forge-gui/res/cardsfolder/i/intet_the_dreamer.txt
@@ -1,5 +1,5 @@
 Name:Intet, the Dreamer
-ManaCost:3 U R G
+ManaCost:3 G U R
 Types:Legendary Creature Dragon
 PT:6/6
 K:Flying

--- a/forge-gui/res/cardsfolder/k/kaalia_of_the_vast.txt
+++ b/forge-gui/res/cardsfolder/k/kaalia_of_the_vast.txt
@@ -1,5 +1,5 @@
 Name:Kaalia of the Vast
-ManaCost:1 W B R
+ManaCost:1 R W B
 Types:Legendary Creature Human Cleric
 PT:2/2
 K:Flying

--- a/forge-gui/res/cardsfolder/m/maelstrom_wanderer.txt
+++ b/forge-gui/res/cardsfolder/m/maelstrom_wanderer.txt
@@ -1,5 +1,5 @@
 Name:Maelstrom Wanderer
-ManaCost:5 U R G
+ManaCost:5 G U R
 Types:Legendary Creature Elemental
 PT:7/5
 K:Cascade

--- a/forge-gui/res/cardsfolder/m/modo_the_gnarled_oracle.txt
+++ b/forge-gui/res/cardsfolder/m/modo_the_gnarled_oracle.txt
@@ -1,5 +1,5 @@
 Name:M'Odo, the Gnarled Oracle
-ManaCost:B U G
+ManaCost:B G U
 Types:Legendary Creature Zombie Elf Wizard
 PT:0/3
 A:AB$ DigUntil | Cost$ X Discard<1/Card> | ValidTgts$ Player | TgtPrompt$ Select target player | Valid$ Creature.cmcLEX | FoundDestination$ Battlefield | RevealedDestination$ Library | Shuffle$ True | GainControl$ True | CostDesc$ Eminence — {X}, Discard a card: | SpellDescription$ Target player reveals cards from the top of their library until they reveal a creature card with converted mana cost X or less. Put that card onto the battlefield under your control, then that player shuffles the rest into their library. Activate this ability only if CARDNAME is on the battlefield or in the command zone.

--- a/forge-gui/res/cardsfolder/n/numot_the_devastator.txt
+++ b/forge-gui/res/cardsfolder/n/numot_the_devastator.txt
@@ -1,5 +1,5 @@
 Name:Numot, the Devastator
-ManaCost:3 R W U
+ManaCost:3 U R W
 Types:Legendary Creature Dragon
 PT:6/6
 K:Flying

--- a/forge-gui/res/cardsfolder/o/oros_the_avenger.txt
+++ b/forge-gui/res/cardsfolder/o/oros_the_avenger.txt
@@ -1,5 +1,5 @@
 Name:Oros, the Avenger
-ManaCost:3 W B R
+ManaCost:3 R W B
 Types:Legendary Creature Dragon
 PT:6/6
 K:Flying

--- a/forge-gui/res/cardsfolder/o/overgrown_estate.txt
+++ b/forge-gui/res/cardsfolder/o/overgrown_estate.txt
@@ -1,5 +1,5 @@
 Name:Overgrown Estate
-ManaCost:B G W
+ManaCost:W B G
 Types:Enchantment
 A:AB$ GainLife | Cost$ Sac<1/Land> | Defined$ You | LifeAmount$ 3 | SpellDescription$ You gain 3 life.
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/p/palladia_mors_the_ruiner.txt
+++ b/forge-gui/res/cardsfolder/p/palladia_mors_the_ruiner.txt
@@ -1,5 +1,5 @@
 Name:Palladia-Mors, the Ruiner
-ManaCost:3 W R G
+ManaCost:3 R G W
 Types:Legendary Creature Elder Dragon
 PT:6/6
 K:Flying

--- a/forge-gui/res/cardsfolder/p/perrie_the_pulverizer.txt
+++ b/forge-gui/res/cardsfolder/p/perrie_the_pulverizer.txt
@@ -1,5 +1,5 @@
 Name:Perrie, the Pulverizer
-ManaCost:1 G U W
+ManaCost:1 G W U
 Types:Legendary Creature Rhino Soldier
 PT:3/3
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPut | TriggerDescription$ When NICKNAME enters the battlefield, put a shield counter on target creature. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)

--- a/forge-gui/res/cardsfolder/r/riku_of_two_reflections.txt
+++ b/forge-gui/res/cardsfolder/r/riku_of_two_reflections.txt
@@ -1,5 +1,5 @@
 Name:Riku of Two Reflections
-ManaCost:2 U R G
+ManaCost:2 G U R
 Types:Legendary Creature Human Wizard
 PT:2/2
 T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigCopySpell | TriggerDescription$ Whenever you cast an instant or sorcery spell, you may pay {U}{R}. If you do, copy that spell. You may choose new targets for the copy.

--- a/forge-gui/res/cardsfolder/r/ruhan_of_the_fomori.txt
+++ b/forge-gui/res/cardsfolder/r/ruhan_of_the_fomori.txt
@@ -1,5 +1,5 @@
 Name:Ruhan of the Fomori
-ManaCost:1 R W U
+ManaCost:1 U R W
 Types:Legendary Creature Giant Warrior
 PT:7/7
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | Execute$ TrigChoose | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of combat on your turn, choose an opponent at random. CARDNAME attacks that player this combat if able.

--- a/forge-gui/res/cardsfolder/t/tariel_reckoner_of_souls.txt
+++ b/forge-gui/res/cardsfolder/t/tariel_reckoner_of_souls.txt
@@ -1,5 +1,5 @@
 Name:Tariel, Reckoner of Souls
-ManaCost:4 W B R
+ManaCost:4 R W B
 Types:Legendary Creature Angel
 PT:4/7
 K:Flying

--- a/forge-gui/res/cardsfolder/t/teneb_the_harvester.txt
+++ b/forge-gui/res/cardsfolder/t/teneb_the_harvester.txt
@@ -1,5 +1,5 @@
 Name:Teneb, the Harvester
-ManaCost:3 B G W
+ManaCost:3 W B G
 Types:Legendary Creature Dragon
 PT:6/6
 K:Flying

--- a/forge-gui/res/cardsfolder/t/the_mimeoplasm.txt
+++ b/forge-gui/res/cardsfolder/t/the_mimeoplasm.txt
@@ -1,5 +1,5 @@
 Name:The Mimeoplasm
-ManaCost:2 G U B
+ManaCost:2 B G U
 Types:Legendary Creature Ooze
 PT:0/0
 K:ETBReplacement:Copy:MimeoChooseTwo:Optional

--- a/forge-gui/res/cardsfolder/t/thunderhawk_gunship.txt
+++ b/forge-gui/res/cardsfolder/t/thunderhawk_gunship.txt
@@ -10,4 +10,4 @@ SVar:TrigPump:DB$ PumpAll | ValidCards$ Creature.attacking+YouCtrl | KW$ Flying
 K:Crew:2
 DeckHas:Ability$Token & Type$Astartes|Warrior & Keyword$Viligance
 SVar:HasAttackingEffect:TRUE
-Oracle:Flying\nWhen Thunderhawk Gunship enters the battlefield, create two 2/2 white Astartes Warrior creature tokens with vigilance.\nWhenever Thunderhawk Gunship attacks, attacking creatures you control gain flying until end of turn.
+Oracle:Flying\nWhen Thunderhawk Gunship enters the battlefield, create two 2/2 white Astartes Warrior creature tokens with vigilance.\nWhenever Thunderhawk Gunship attacks, attacking creatures you control gain flying until end of turn.\nCrew 2

--- a/forge-gui/res/cardsfolder/v/vorosh_the_hunter.txt
+++ b/forge-gui/res/cardsfolder/v/vorosh_the_hunter.txt
@@ -1,5 +1,5 @@
 Name:Vorosh, the Hunter
-ManaCost:3 G U B
+ManaCost:3 B G U
 Types:Legendary Creature Dragon
 PT:6/6
 K:Flying


### PR DESCRIPTION
Reordered wedge and shard mana symbols for 23 cards. Updated oracle text for Thunderhawk Gunship.