### PR TITLE
Fix Garth One-Eye

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/ChooseCardNameEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChooseCardNameEffect.java
@@ -50,7 +50,6 @@ public class ChooseCardNameEffect extends SpellAbilityEffect {
         boolean randomChoice = sa.hasParam("AtRandom");
         boolean chooseFromDefined = sa.hasParam("ChooseFromDefinedCards");
         boolean chooseFromList = sa.hasParam("ChooseFromList");
-        boolean chooseFromOneTimeList = sa.hasParam("ChooseFromOneTimeList");
 
         if (!randomChoice) {
             if (sa.hasParam("SelectPrompt")) {
@@ -105,6 +104,9 @@ public class ChooseCardNameEffect extends SpellAbilityEffect {
                 for (String name : names) {
                     // Cardnames that include "," must use ";" instead in ChooseFromList$ (i.e. Tovolar; Dire Overlord)
                     name = name.replace(";", ",");
+                    if (sa.hasParam("ExcludeChosen") && host.getNamedCards().contains(name)) {
+                        continue;
+                    }
                     faces.add(StaticData.instance().getCommonCards().getFaceByName(name));
                 }
                 if (randomChoice) {
@@ -112,23 +114,7 @@ public class ChooseCardNameEffect extends SpellAbilityEffect {
                 } else {
                     chosen = p.getController().chooseCardName(sa, faces, message);
                 }
-            } else if (chooseFromOneTimeList) {
-                String [] names = sa.getParam("ChooseFromOneTimeList").split(",");
-                List<ICardFace> faces = new ArrayList<>();
-                for (String name : names) {
-                    faces.add(StaticData.instance().getCommonCards().getFaceByName(name));
-                }
-                chosen = p.getController().chooseCardName(sa, faces, message);
-
-                // Remove chosen Name from List
-                StringBuilder sb = new StringBuilder();
-                for (String name : names) {
-                    if (chosen.equals(name)) continue;
-                    if (sb.length() > 0) sb.append(',');
-                    sb.append(name);
-                }
-                sa.putParam("ChooseFromOneTimeList", sb.toString());
-            } else {
+            }  else {
                 // use CardFace because you might name a alternate names
                 Predicate<ICardFace> cpp = Predicates.alwaysTrue();
                 if (sa.hasParam("ValidCards")) {
@@ -152,7 +138,9 @@ public class ChooseCardNameEffect extends SpellAbilityEffect {
                 }
             }
 
-            host.addNamedCard(chosen);
+            if (!chosen.isEmpty()) {
+                host.addNamedCard(chosen);
+            }
             if (!randomChoice) {
                 p.setNamedCard(chosen);
             }

--- a/forge-game/src/main/java/forge/game/ability/effects/PlayEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PlayEffect.java
@@ -161,7 +161,7 @@ public class PlayEffect extends SpellAbilityEffect {
                 return;
             }
         } else if (sa.hasParam("CopyFromChosenName")) {
-            String name = source.getNamedCard();
+            String name = controller.getNamedCard();
             if (name.trim().isEmpty()) return;
             Card card = Card.fromPaperCard(StaticData.instance().getCommonCards().getUniqueByName(name), controller);
             // so it gets added to stack

--- a/forge-game/src/main/java/forge/game/ability/effects/RollPlanarDiceEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/RollPlanarDiceEffect.java
@@ -33,6 +33,5 @@ public class RollPlanarDiceEffect extends SpellAbilityEffect {
         PlanarDice result = PlanarDice.roll(activator, null);
         String message = Localizer.getInstance().getMessage("lblPlanarDiceResult", result.toString());
         game.getAction().notifyOfValue(sa, activator, message, null);
-
     }
 }

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -288,7 +288,6 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
     private List<String> notedTypes = new ArrayList<>();
     private List<String> chosenColors;
     private List<String> chosenName = new ArrayList<>();
-    private String chosenName2 = "";
     private Integer chosenNumber;
     private Player chosenPlayer;
     private Player protectingPlayer;
@@ -1947,7 +1946,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
 
     // used for cards like Meddling Mage...
     public final String getNamedCard() {
-        return hasNamedCard() ? chosenName.get(0) : "";
+        return hasNamedCard() ? Iterables.getLast(chosenName) : "";
     }
     public final List<String> getNamedCards() {
         return chosenName == null ? Lists.newArrayList() : chosenName;
@@ -1963,7 +1962,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
     }
 
     public boolean hasNamedCard() {
-            return chosenName != null && !chosenName.isEmpty();
+        return chosenName != null && !chosenName.isEmpty();
     }
 
     public boolean hasChosenEvenOdd() {

--- a/forge-gui/res/cardsfolder/g/garth_one_eye.txt
+++ b/forge-gui/res/cardsfolder/g/garth_one_eye.txt
@@ -2,7 +2,7 @@ Name:Garth One-Eye
 ManaCost:W U B R G
 Types:Legendary Creature Human Wizard
 PT:5/5
-A:AB$ NameCard | Cost$ T | Defined$ You | ChooseFromOneTimeList$ Disenchant,Braingeyser,Terror,Shivan Dragon,Regrowth,Black Lotus | SubAbility$ DBCast | StackDescription$ SpellDescription | SpellDescription$ Choose a card name that hasn't been chosen from among Disenchant, Braingeyser, Terror, Shivan Dragon, Regrowth, and Black Lotus. Create a copy of the card with the chosen name. You may cast the copy. (You still pay its costs.)
+A:AB$ NameCard | Cost$ T | Defined$ You | ChooseFromList$ Disenchant,Braingeyser,Terror,Shivan Dragon,Regrowth,Black Lotus | ExcludeChosen$ True | SubAbility$ DBCast | StackDescription$ SpellDescription | SpellDescription$ Choose a card name that hasn't been chosen from among Disenchant, Braingeyser, Terror, Shivan Dragon, Regrowth, and Black Lotus. Create a copy of the card with the chosen name. You may cast the copy. (You still pay its costs.)
 SVar:DBCast:DB$ Play | CopyFromChosenName$ True | Optional$ True | StackDescription$ None
 AI:RemoveDeck:All
 Oracle:{T}: Choose a card name that hasn't been chosen from among Disenchant, Braingeyser, Terror, Shivan Dragon, Regrowth, and Black Lotus. Create a copy of the card with the chosen name. You may cast the copy. (You still pay its costs.)

--- a/forge-gui/res/cardsfolder/i/invasion_of_new_capenna_holy_frazzle_cannon.txt
+++ b/forge-gui/res/cardsfolder/i/invasion_of_new_capenna_holy_frazzle_cannon.txt
@@ -16,7 +16,7 @@ ManaCost:no cost
 Colors:white,black
 Types:Artifact Equipment
 T:Mode$ Attacks | ValidCard$ Creature.EquippedBy | Execute$ TrigPutCounters | TriggerDescription$ Whenever equipped creature attacks, put a +1/+1 counter on that creature and each other creature you control that shares a creature type with it.
-SVar:TrigPutCounters:DB$ PutCounterAll | ValidCards$ Creature.EquippedBy,Creature.YouCtrl+!Equippedby+sharesCreatureTypeWith Equipped | CounterType$ P1P1
+SVar:TrigPutCounters:DB$ PutCounterAll | ValidCards$ Creature.EquippedBy,Creature.YouCtrl+!EquippedBy+sharesCreatureTypeWith Equipped | CounterType$ P1P1
 DeckHas:Ability$Counters
 S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddSVar$ AE
 SVar:AE:SVar:HasAttackEffect:TRUE

--- a/forge-gui/res/cardsfolder/l/livaan_cultist_of_tiamat.txt
+++ b/forge-gui/res/cardsfolder/l/livaan_cultist_of_tiamat.txt
@@ -3,7 +3,7 @@ ManaCost:2 R
 Types:Legendary Creature Dragon Shaman
 PT:1/3
 T:Mode$ SpellCast | ValidCard$ Card.nonCreature | ValidActivatingPlayer$ You | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a noncreature spell, target creature gets +X/+0 until end of turn, where X is that spell's mana value.
-SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | NumAtt$ +X
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature you control | NumAtt$ +X
 SVar:X:TriggeredStackInstance$CardManaCostLKI
 K:Choose a Background
 Oracle:Whenever you cast a noncreature spell, target creature gets +X/+0 until end of turn, where X is that spell's mana value.\nChoose a Background (You can have a Background as a second commander.)

--- a/forge-gui/res/cardsfolder/w/willbreaker.txt
+++ b/forge-gui/res/cardsfolder/w/willbreaker.txt
@@ -3,5 +3,5 @@ ManaCost:3 U U
 Types:Creature Human Wizard
 PT:2/3
 T:Mode$ BecomesTarget | ValidTarget$ Creature.OppCtrl+inZoneBattlefield | ValidSource$ SpellAbility.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigGainControl | TriggerDescription$ Whenever a creature an opponent controls becomes the target of a spell or ability you control, gain control of that creature for as long as you control CARDNAME.
-SVar:TrigGainControl:DB$ GainControl | Defined$ TriggeredTarget | NewController$ You | LoseControl$ LeavesPlay,LoseControl
+SVar:TrigGainControl:DB$ GainControl | Defined$ TriggeredTargetLKICopy | NewController$ You | LoseControl$ LeavesPlay,LoseControl
 Oracle:Whenever a creature an opponent controls becomes the target of a spell or ability you control, gain control of that creature for as long as you control Willbreaker.


### PR DESCRIPTION
Follow-up to #3890 so it doesn't always use the choice of the first activation.

To be fair the "hasn't been chosen" part was also already broken because of the abilities no longer being unique thing.

Switched to using the part from _Conundrum Sphinx_ for now so we don't keep adding empty names after all choices are "exterminated". Feels bad because I'd like to get rid of that eventually but that is a worry for another day...

Closes #3895