### PR TITLE
refactor ChangeZone -> Seek for Alchemy seek cards

### DIFF
--- a/forge-gui/res/cardsfolder/d/discover_the_formula.txt
+++ b/forge-gui/res/cardsfolder/d/discover_the_formula.txt
@@ -1,7 +1,7 @@
 Name:Discover the Formula
 ManaCost:4 U U
 Types:Instant
-A:SP$ ChangeZone | Origin$ Library | Destination$ Hand | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | NoReveal$ True | ChangeNum$ 3 | ChangeType$ Card.nonLand | SubAbility$ DBEffect | StackDescription$ SpellDescription | SpellDescription$ Seek three nonland cards, then nonland cards in your hand perpetually gain "This spell costs {1} less to cast."
+A:SP$ Seek | Num$ 3 | Type$ Card.nonLand | SubAbility$ DBEffect | StackDescription$ SpellDescription | SpellDescription$ Seek three nonland cards, then nonland cards in your hand perpetually gain "This spell costs {1} less to cast."
 SVar:DBEffect:DB$ Effect | RememberObjects$ ValidHand Card.nonLand+YouOwn | StaticAbilities$ PerpetualAbility | Duration$ Permanent | Triggers$ Update | Name$ Discover the Formula's Perpetual Effect
 SVar:PerpetualAbility:Mode$ Continuous | Affected$ Card.IsRemembered | AddStaticAbility$ ReduceCost | EffectZone$ Command | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | Description$ Each nonland card in your hand perpetually gains "This spell costs {1} less to cast."
 SVar:ReduceCost:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 1 | EffectZone$ All | Description$ This spell costs {1} less to cast.

--- a/forge-gui/res/cardsfolder/m/manor_guardian.txt
+++ b/forge-gui/res/cardsfolder/m/manor_guardian.txt
@@ -3,5 +3,5 @@ ManaCost:2 B
 Types:Creature Demon
 PT:4/3
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigSeek | TriggerDescription$ When CARDNAME dies, each player seeks a nonland card with mana value 2 or less.
-SVar:TrigSeek:DB$ ChangeZone | Origin$ Library | Destination$ Hand | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | NoReveal$ True | ChangeType$ Card.nonLand+cmcLE2 | ChangeNum$ 1 | DefinedPlayer$ Player
+SVar:TrigSeek:DB$ Seek | Defined$ Player | Type$ Card.nonLand+cmcLE2
 Oracle:When Manor Guardian dies, each player seeks a nonland card with mana value 2 or less.

--- a/forge-gui/res/cardsfolder/n/norns_fetchling.txt
+++ b/forge-gui/res/cardsfolder/n/norns_fetchling.txt
@@ -6,8 +6,8 @@ K:Toxic:1
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigBranch | TriggerDescription$ When CARDNAME enters the battlefield, conjure a card named Plains into your hand. If an opponent has three or more poison counters, you may seek a nonland card instead.  
 SVar:TrigBranch:DB$ Branch | BranchConditionSVar$ X | BranchConditionSVarCompare$ GE3 | TrueSubAbility$ DBGenericChoice | FalseSubAbility$ ConjurePlains
 SVar:DBGenericChoice:DB$ GenericChoice | Choices$ SeekNonLand,ConjurePlains
-SVar:SeekNonLand:DB$ ChangeZone | Origin$ Library | Destination$ Hand | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | NoReveal$ True | ChangeType$ Card.nonLand | ChangeNum$ 1 | StackDescription$ Seek a nonland card.
-SVar:ConjurePlains:DB$ MakeCard | Conjure$ True | Name$ Plains | Zone$ Hand | StackDescription$ Conjure a card named Plains into your hand 
+SVar:SeekNonLand:DB$ Seek | Type$ Card.nonLand | StackDescription$ Seek a nonland card.
+SVar:ConjurePlains:DB$ MakeCard | Conjure$ True | Name$ Plains | Zone$ Hand | StackDescription$ Conjure a card named Plains into your hand.
 SVar:X:PlayerCountOpponents$HighestPoisonCounters
 DeckHints:Keyword$Toxic|Infect
 Oracle:Toxic 1\nCorrupted - When Norn's Fetchling enters the battlefield, conjure a card named Plains into your hand. If an opponent has three or more poison counters, you may seek a nonland card instead.

--- a/forge-gui/res/cardsfolder/o/obscura_polymorphist.txt
+++ b/forge-gui/res/cardsfolder/o/obscura_polymorphist.txt
@@ -4,5 +4,5 @@ Types:Creature Cephalid Wizard
 PT:2/2
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ When CARDNAME enters the battlefield, exile up to one target creature. Its controller seeks a creature card.
 SVar:TrigExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Creature | TgtPrompt$ Select up to one target creature | TargetMin$ 0 | TargetMax$ 1 | SubAbility$ DBSeek
-SVar:DBSeek:DB$ ChangeZone | Origin$ Library | Destination$ Hand | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | NoReveal$ True | ChangeType$ Card.Creature | ChangeNum$ 1 | DefinedPlayer$ TargetedController
+SVar:DBSeek:DB$ Seek | Defined$ TargetedController | Type$ Creature
 Oracle:When Obscura Polymorphist enters the battlefield, exile up to one target creature. Its controller seeks a creature card.

--- a/forge-gui/res/cardsfolder/p/perilous_iteration.txt
+++ b/forge-gui/res/cardsfolder/p/perilous_iteration.txt
@@ -2,7 +2,7 @@ Name:Perilous Iteration
 ManaCost:R G
 Types:Sorcery
 A:SP$ ChangeZone | Origin$ Library | Destination$ Hand | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | NoReveal$ True | ChangeType$ Card.YouOwn+cmcLE2 | ChangeNum$ 1 | RememberChanged$ True | SubAbility$ DBSeek | SpellDescription$ Seek a card with mana value 2 or less and a card with mana value 3 or greater. Discard those cards at the beginning of your next turn's end step.
-SVar:DBSeek:DB$ ChangeZone | Origin$ Library | Destination$ Hand | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | NoReveal$ True | ChangeType$ Card.YouOwn+cmcGE3 | ChangeNum$ 1 | RememberChanged$ True | SubAbility$ DBDelay
+SVar:DBSeek:DB$ ChangeZone | Type$ Card.YouOwn+cmcGE3 | Num$ 1 | RememberFound$ True | SubAbility$ DBDelay
 SVar:DBDelay:DB$ DelayedTrigger | DelayedTriggerDefinedPlayer$ You | Mode$ Phase | Phase$ End of Turn | Execute$ TrigDiscard | RememberObjects$ Remembered | TriggerDescription$ Discard those cards at the beginning of your next turn's end step.
 SVar:TrigDiscard:DB$ Discard | Mode$ Defined | DefinedCards$ DelayTriggerRemembered | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/s/seek_new_knowledge.txt
+++ b/forge-gui/res/cardsfolder/s/seek_new_knowledge.txt
@@ -1,6 +1,6 @@
 Name:Seek New Knowledge
 ManaCost:1 U
 Types:Instant
-A:SP$ ChangeZone | Origin$ Library | Destination$ Hand | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | NoReveal$ True | ChangeNum$ 2 | ChangeType$ Card.nonLand | SubAbility$ DBBottomCard | StackDescription$ SpellDescription | SpellDescription$ Seek two nonland cards, then put a card from your hand on the bottom of your library.
-SVar:DBBottomCard:DB$ ChangeZone | Origin$ Hand | Destination$ Library | LibraryPosition$ -1 | Mandatory$ True
+A:SP$ Seek | Num$ 2 | Type$ Card.nonLand | SubAbility$ DBBottomCard | StackDescription$ SpellDescription | SpellDescription$ Seek two nonland cards, then put a card from your hand on the bottom of your library.
+SVar:DBBottomCard:DB$ ChangeZone | Origin$ Hand | Destination$ Library | LibraryPosition$ -1 | Mandatory$ True | StackDescription$ None
 Oracle:Seek two nonland cards, then put a card from your hand on the bottom of your library.

--- a/forge-gui/res/cardsfolder/w/wandering_treefolk.txt
+++ b/forge-gui/res/cardsfolder/w/wandering_treefolk.txt
@@ -3,7 +3,7 @@ ManaCost:1 G
 Types:Creature Treefolk
 PT:2/3
 K:Vigilance
-A:AB$ ChangeZone | Cost$ 7 G | ReduceCost$ X | Origin$ Library | Destination$ Hand | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | NoReveal$ True | ChangeType$ Card.Creature | ChangeNum$ 1 | PrecostDesc$ Domain — | SpellDescription$ Seek a creature card. This ability costs {1} less to activate for each basic land type among lands you control.
+A:AB$ Seek | Cost$ 7 G | ReduceCost$ X | Type$ Creature | PrecostDesc$ Domain — | SpellDescription$ Seek a creature card. This ability costs {1} less to activate for each basic land type among lands you control.
 SVar:X:Count$Domain
 AI:RemoveDeck:Random
-Oracle:Vigilance\nDomain - {7}{G}:Seek a creature card. This ability costs {1} less to activate for each basic land type amount lands you control. 
+Oracle:Vigilance\nDomain - {7}{G}:Seek a creature card. This ability costs {1} less to activate for each basic land type among lands you control.

--- a/forge-gui/res/cardsfolder/y/yuan_ti_scaleshield.txt
+++ b/forge-gui/res/cardsfolder/y/yuan_ti_scaleshield.txt
@@ -2,6 +2,6 @@ Name:Yuan-Ti Scaleshield
 ManaCost:2 G
 Types:Instant
 A:SP$ PumpAll | ValidCards$ Permanent.YouCtrl | KW$ Hexproof & Indestructible | SubAbility$ DBSeek | SpellDescription$ Permanents you control gain hexproof and indestructible until end of turn. Seek a creature card if an opponent has cast a spell with mana value 3 or less this turn.
-SVar:DBSeek:DB$ ChangeZone | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1 | Origin$ Library | Destination$ Hand | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | NoReveal$ True | ChangeType$ Card.Creature | ChangeNum$ 1 
+SVar:DBSeek:DB$ Seek | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1 | Type$ Creature
 SVar:X:Count$ThisTurnCast_Card.cmcLE3+OppCtrl
 Oracle:Permanents you control gain hexproof and indestructible until end of turn.\nSeek a creature card if an opponent has cast a spell with mana value 3 or less this turn.


### PR DESCRIPTION
All cards using seek mechanic now need to use SeekEffect for proper trigger interaction (currently only Vexyr, Ich-Tekik's Heir)