### PR TITLE
CantHaveKeyword can prevent effect creation

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/AnimateEffectBase.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/AnimateEffectBase.java
@@ -82,7 +82,9 @@ public abstract class AnimateEffectBase extends SpellAbilityEffect {
             c.addChangedCardTypes(addType, removeType, addAllCreatureTypes, remove, timestamp, 0, true, false);
         }
 
-        c.addChangedCardKeywords(keywords, removeKeywords, removeAll, timestamp, 0);
+        if (!keywords.isEmpty() || !removeKeywords.isEmpty() || removeAll) {
+            c.addChangedCardKeywords(keywords, removeKeywords, removeAll, timestamp, 0);
+        }
 
         // do this after changing types in case it wasn't a creature before
         if (power != null || toughness != null) {

--- a/forge-game/src/main/java/forge/game/ability/effects/CounterEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CounterEffect.java
@@ -302,8 +302,6 @@ public class CounterEffect extends SpellAbilityEffect {
             movedCard = game.getAction().moveToGraveyard(c, srcSA, params);
         } else if (destination.equals("Exile")) {
             movedCard = game.getAction().exile(c, srcSA, params);
-        } else if (destination.equals("TopOfLibrary")) {
-            movedCard = game.getAction().moveToLibrary(c, srcSA, params);
         } else if (destination.equals("Hand")) {
             movedCard = game.getAction().moveToHand(c, srcSA, params);
         } else if (destination.equals("Battlefield")) {
@@ -314,6 +312,8 @@ public class CounterEffect extends SpellAbilityEffect {
                 movedCard = game.getAction().moveToPlay(c, srcSA.getActivatingPlayer(), srcSA, params);
                 movedCard.setController(srcSA.getActivatingPlayer(), 0);
             }
+        } else if (destination.equals("TopOfLibrary")) {
+            movedCard = game.getAction().moveToLibrary(c, srcSA, params);
         } else if (destination.equals("BottomOfLibrary")) {
             movedCard = game.getAction().moveToBottomOfLibrary(c, srcSA, params);
         } else if (destination.equals("ShuffleIntoLibrary")) {

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -4683,7 +4683,17 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
         if (keywords != null) {
             long idx = 1;
             for (String kw : keywords) {
-                kws.add(getKeywordForStaticAbility(kw, staticId, idx));
+                // CR 113.11
+                boolean canHave = true;
+                for (Keyword cantKW : getCantHaveKeyword()) {
+                    if (kw.startsWith(cantKW.toString())) {
+                        canHave = false;
+                        break;
+                    }
+                }
+                if (canHave) {
+                    kws.add(getKeywordForStaticAbility(kw, staticId, idx));
+                }
                 idx++;
             }
         }


### PR DESCRIPTION
> For example, if you control Archetype of Courage, a spell cast by an opponent that gives creatures they control first strike wouldn’t cause the creatures to have first strike, even if later in the turn Archetype of Courage left the battlefield.