### PR TITLE
Default preference targeting arcs always on

### DIFF
--- a/forge-gui/src/main/java/forge/localinstance/properties/ForgePreferences.java
+++ b/forge-gui/src/main/java/forge/localinstance/properties/ForgePreferences.java
@@ -118,7 +118,7 @@ public class ForgePreferences extends PreferencesStore<ForgePreferences.FPref> {
         UI_SKIN ("Default"),
         UI_CJK_FONT (""),
         UI_PREFERRED_AVATARS_ONLY ("false"),
-        UI_TARGETING_OVERLAY ("0"),
+        UI_TARGETING_OVERLAY ("2"),
         UI_TIMED_TARGETING_OVERLAY_UPDATES ("true"),
         UI_ENABLE_SOUNDS ("true"),
         UI_ENABLE_MUSIC ("true"),


### PR DESCRIPTION
Changing default preference for targeting arcs "always on" setting "2".