### PR TITLE
Improve various AI routines

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
@@ -237,7 +237,26 @@ public class ComputerUtilCard {
         final List<Card> nbLand = CardLists.filter(land, Predicates.not(CardPredicates.Presets.BASIC_LANDS));
 
         if (!nbLand.isEmpty()) {
-            // TODO - Rank non basics?
+            // TODO - Improve ranking various non-basic lands depending on context
+
+            // Urza's Mine/Tower/Power Plant
+            final CardCollectionView aiAvailable = nbLand.get(0).getController().getCardsIn(new ZoneType[] {ZoneType.Battlefield, ZoneType.Hand});
+            if (Iterables.any(list, CardPredicates.nameEquals("Urza's Mine"))) {
+                if (CardLists.filter(aiAvailable, CardPredicates.nameEquals("Urza's Mine")).isEmpty()) {
+                    return CardLists.filter(nbLand, CardPredicates.nameEquals("Urza's Mine")).getFirst();
+                }
+            }
+            if (Iterables.any(list, CardPredicates.nameEquals("Urza's Tower"))) {
+                if (CardLists.filter(aiAvailable, CardPredicates.nameEquals("Urza's Tower")).isEmpty()) {
+                    return CardLists.filter(nbLand, CardPredicates.nameEquals("Urza's Tower")).getFirst();
+                }
+            }
+            if (Iterables.any(list, CardPredicates.nameEquals("Urza's Power Plant"))) {
+                if (CardLists.filter(aiAvailable, CardPredicates.nameEquals("Urza's Power Plant")).isEmpty()) {
+                    return CardLists.filter(nbLand, CardPredicates.nameEquals("Urza's Power Plant")).getFirst();
+                }
+            }
+
             return Aggregates.random(nbLand);
         }
 

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
@@ -356,6 +356,14 @@ public class ComputerUtilCost {
                     if (!CardLists.filterControlledBy(source.getEnchantedBy(), source.getController()).isEmpty()) {
                         return false;
                     }
+                    if (source.isCreature()) {
+                        // e.g. Sakura Tribe-Elder
+                        final boolean beforeNextTurn = ai.getGame().getPhaseHandler().is(PhaseType.END_OF_TURN) && ai.getGame().getPhaseHandler().getNextTurn().equals(ai);
+                        final boolean inDanger = ComputerUtil.predictThreatenedObjects(ai, sourceAbility, true).contains(source);
+                        if (!(inDanger || beforeNextTurn)) {
+                            return false;
+                        }
+                    }
                     continue;
                 }
 

--- a/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
@@ -1665,9 +1665,14 @@ public class ChangeZoneAi extends SpellAbilityAi {
                 }
             }
             if (c == null) {
-                fetchList = CardLists.getNotType(fetchList, "Land");
-                // Prefer to pull a creature, generally more useful for AI.
-                c = chooseCreature(decider, CardLists.filter(fetchList, CardPredicates.Presets.CREATURES));
+                if (Iterables.all(fetchList, Presets.LANDS)) {
+                    // we're only choosing from lands, so get the best land
+                    c = ComputerUtilCard.getBestLandAI(fetchList);
+                } else {
+                    fetchList = CardLists.getNotType(fetchList, "Land");
+                    // Prefer to pull a creature, generally more useful for AI.
+                    c = chooseCreature(decider, CardLists.filter(fetchList, CardPredicates.Presets.CREATURES));
+                }
             }
             if (c == null) { // Could not find a creature.
                 if (decider.getLife() <= 5) { // Desperate?

--- a/forge-ai/src/main/java/forge/ai/ability/EffectAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/EffectAi.java
@@ -241,11 +241,10 @@ public class EffectAi extends SpellAbilityAi {
                     SpellAbility topStack = game.getStack().peekAbility();
                     final Player activator = topStack.getActivatingPlayer();
                     if (activator.isOpponentOf(ai)) {
-                        boolean changeZone = (topStack.getApi() == ApiType.ChangeZone || topStack.getApi() == ApiType.ChangeZoneAll)
-                                && "Battlefield".equals(topStack.getParam("Destination"));
-                        boolean reanimator = "true".equalsIgnoreCase(topStack.getSVar("IsReanimatorCard"))
-                                && (topStack.getApi() == ApiType.ChangeZone || topStack.getApi() == ApiType.ChangeZoneAll);
-                        if (changeZone || reanimator) {
+                        boolean changeZone = topStack.getApi() == ApiType.ChangeZone || topStack.getApi() == ApiType.ChangeZoneAll;
+                        boolean toBattlefield = "Battlefield".equals(topStack.getParam("Destination"));
+                        boolean reanimator = "true".equalsIgnoreCase(topStack.getSVar("IsReanimatorCard"));
+                        if (changeZone && (toBattlefield || reanimator)) {
                             if ("Creature".equals(topStack.getParam("ChangeType")) || topStack.getParamOrDefault("Defined", "").contains("Creature"))
                                 return true;
                         }

--- a/forge-ai/src/main/java/forge/ai/ability/EffectAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/EffectAi.java
@@ -195,7 +195,7 @@ public class EffectAi extends SpellAbilityAi {
                 }
                 return false;
             } else if (logic.equals("NoGain")) {
-            	// basic logic to cancel GainLife on stack
+                // basic logic to cancel GainLife on stack
                 if (!game.getStack().isEmpty()) {
                     SpellAbility topStack = game.getStack().peekAbility();
                     final Player activator = topStack.getActivatingPlayer();
@@ -232,6 +232,22 @@ public class EffectAi extends SpellAbilityAi {
                                     return true;
                                 }
                             }
+                        }
+                    }
+                }
+                return false;
+            } else if (logic.equals("NonCastCreature")) {
+                if (!game.getStack().isEmpty()) {
+                    SpellAbility topStack = game.getStack().peekAbility();
+                    final Player activator = topStack.getActivatingPlayer();
+                    if (activator.isOpponentOf(ai)) {
+                        boolean changeZone = (topStack.getApi() == ApiType.ChangeZone || topStack.getApi() == ApiType.ChangeZoneAll)
+                                && "Battlefield".equals(topStack.getParam("Destination"));
+                        boolean reanimator = "true".equalsIgnoreCase(topStack.getSVar("IsReanimatorCard"))
+                                && (topStack.getApi() == ApiType.ChangeZone || topStack.getApi() == ApiType.ChangeZoneAll);
+                        if (changeZone || reanimator) {
+                            if ("Creature".equals(topStack.getParam("ChangeType")) || topStack.getParamOrDefault("Defined", "").contains("Creature"))
+                                return true;
                         }
                     }
                 }

--- a/forge-ai/src/main/java/forge/ai/ability/EffectAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/EffectAi.java
@@ -237,6 +237,7 @@ public class EffectAi extends SpellAbilityAi {
                 }
                 return false;
             } else if (logic.equals("NonCastCreature")) {
+                // TODO: add support for more cases with more convoluted API setups
                 if (!game.getStack().isEmpty()) {
                     SpellAbility topStack = game.getStack().peekAbility();
                     final Player activator = topStack.getActivatingPlayer();

--- a/forge-gui/res/cardsfolder/m/mistcaller.txt
+++ b/forge-gui/res/cardsfolder/m/mistcaller.txt
@@ -2,7 +2,7 @@ Name:Mistcaller
 ManaCost:U
 Types:Creature Merfolk Wizard
 PT:1/1
-A:AB$ Effect | Cost$ Sac<1/CARDNAME> | ReplacementEffects$ EffRMoved | SpellDescription$ Until end of turn, if a nontoken creature would enter the battlefield and it wasn't cast, exile it instead.
+A:AB$ Effect | Cost$ Sac<1/CARDNAME> | ReplacementEffects$ EffRMoved | AILogic$ NonCastCreature | SpellDescription$ Until end of turn, if a nontoken creature would enter the battlefield and it wasn't cast, exile it instead.
 SVar:EffRMoved:Event$ Moved | ActiveZones$ Command | Destination$ Battlefield | ValidCard$ Creature.nonToken+wasNotCast | ReplaceWith$ EffDBChangeZone | Description$ If a nontoken creature would enter the battlefield and it wasn't cast, exile it instead.
 SVar:EffDBChangeZone:DB$ ChangeZone | Defined$ ReplacedCard | Hidden$ True | Origin$ All | Destination$ Exile
 Oracle:Sacrifice Mistcaller: Until end of turn, if a nontoken creature would enter the battlefield and it wasn't cast, exile it instead.


### PR DESCRIPTION
Fixes #3975 (not perfect, but at least the basic handling is there), improves AI pulling lands via AF ChangeZone in general.
Fixes #3780
Fixes #3707, although it's quite tricky to cover all possible variants, so I'm sure there are corner case and variant implementations of moving stuff from wherever to the Battlefield indirectly that are not yet covered.
