### PR TITLE
Add puzzle PS_LCI01 (needs GameState update/fix)

### DIFF
--- a/forge-gui/res/puzzle/PS_LCI01.pzl
+++ b/forge-gui/res/puzzle/PS_LCI01.pzl
@@ -1,0 +1,17 @@
+[metadata]
+Name:Possibility Storm - Lost Caverns of Ixalan #01
+URL:https://i1.wp.com/www.possibilitystorm.com/wp-content/uploads/2023/11/latest-scaled.jpg?ssl=1
+Goal:Win
+Turns:1
+Difficulty:Rare
+Description:Win this turn. Start in your first main phase (the 4th lore counter has just been put on Roar of the Fifth People and the ability is being put on the stack). Assume both graveyards start empty and that your opponent has no spells they could cast this turn. Remember that your solution must satisfy all possible blocking decisions. Good luck!
+[state]
+turn=1
+activeplayer=p0
+activephase=UPKEEP
+activephaseadvance=MAIN1
+p0life=20
+p0hand=Light 'Em Up;Sibling Rivalry;Kessig Flamebreather;Rampaging Geoderm
+p0battlefield=Earthshaker Dreadmaw;Huatli, Poet of Unity|Transformed|Counters:LORE=3;T:g_3_3_dinosaur;T:g_3_3_dinosaur;The Skullspore Nexus;Mountain;Mountain;Mountain;Forest;Forest;Forest
+p1life=40
+p1battlefield=Ojer Axonil, Deepest Might;Breeches, Eager Pillager;Heartflame Duelist


### PR DESCRIPTION
For some reason, when the Saga goes to the graveyard, its front face trigger fires, as if it was untransformed. I tried updating its LKI info via game.updateLastStateForCard after setting the card to the Transformed card state, as well as forcing an update of the card in the setState call, but the net effect is the same - as soon as the card goes to the graveyard, its front face trigger fires away. I tried debugging this and got as far as GameAction#changeZone, in which the temporary "copied" object seems to have the front face characteristics (such as the Creature type, for instance). I couldn't figure out why this happens though. I could use some help here... What do you think @Hanmac @tool4ever ?

On a possibly related note, there seems to be an issue with other things not happening as they should in a somewhat similar-ish fashion. For instance, if a card that gives Hexproof to a player is put on the battlefield via a GameState setup, the player will visually have Hexproof but it will be possible for the opponent to target that said player with things. Not sure if it's related or a separate issue.