### PR TITLE
Hotel of Fears bugfix, planar types

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/hotel_of_fears.txt
+++ b/forge-gui/res/cardsfolder/upcoming/hotel_of_fears.txt
@@ -11,8 +11,8 @@ SVar:Y:Remembered$CardManaCost
 T:Mode$ ChaosEnsues | TriggerZones$ Command | Execute$ TrigChooseColor | TriggerDescription$ Praise Him — Whenever chaos ensues, choose a color. Put X +1/+1 counters on target creature you control, where X is your devotion to that color. Then sacrifice another creature. (Your devotion to a color is the number of mana symbols of that color in the mana costs of permanents you control.)
 SVar:TrigChooseColor:DB$ ChooseColor | AILogic$ MostProminentInComputerDeck | SubAbility$ DBPutCounter
 SVar:DBPutCounter:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ X | TgtPrompt$ Select target creature you control | ValidTgts$ Creature.YouCtrl | SubAbility$ DBSacrifice
-SVar:DBSacrifice:DB$ Sacrifice | SacValid$ Creature.NotDefinedTargeted | SacMessage$ Another target creature | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearChosenColor$ True
+SVar:DBSacrifice:DB$ Sacrifice | SacValid$ Creature.NotDefinedTargeted | SacMessage$ Another target creature | SubAbility$ DBCleanup2
+SVar:DBCleanup2:DB$ Cleanup | ClearChosenColor$ True
 SVar:X:Count$Devotion.Chosen
 DeckHas:Ability$Counters|Sacrifice
 Oracle:At the beginning of your upkeep, exile the top card of your library. You lose life equal to its mana value. You may play that card this turn.\nPraise Him — Whenever chaos ensues, choose a color. Put X +1/+1 counters on target creature you control, where X is your devotion to that color. Then sacrifice another creature. (Your devotion to a color is the number of mana symbols of that color in the mana costs of permanents you control.)

--- a/forge-gui/res/lists/TypeLists.txt
+++ b/forge-gui/res/lists/TypeLists.txt
@@ -457,6 +457,7 @@ Ixalan
 Kaladesh
 Kaldheim
 Kamigawa
+Kandoka
 Karsus
 Kephalai
 Kinshala
@@ -470,6 +471,7 @@ Mercadia
 Mirrodin
 Moag
 Mongseng
+Moon
 Muraganda
 Necros
 New Earth


### PR DESCRIPTION
Fixes a bug where, if a card exiled with Hotel of Fears isn't played before end of turn, the next player during their upkeep would lose life equal to that card's mana value plus the mana value of their own exiled card (and further stacking if that card isn't played, and so on). Also adds two planar types from WHO plane cards that are already merged but didn't update the TypeLists