### PR TITLE
[Draft] Update LifeSetAi.java

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/LifeSetAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/LifeSetAi.java
@@ -109,6 +109,11 @@ public class LifeSetAi extends SpellAbilityAi {
         final Card source = sa.getHostCard();
         final String sourceName = ComputerUtilAbility.getAbilitySourceName(sa);
 
+        // TODO add AI logic for that
+        if (sa.hasParam("Redistribute")) {
+            return mandatory;
+        }
+
         final String amountStr = sa.getParam("LifeAmount");
 
         int amount;


### PR DESCRIPTION
Attempts to fix a crash when chaos ensues on The Doctor's Tomb during an AI's turn. (The AI can already safely use the one other Redistribute effect in the game - though it's removed from AI decks and they won't choose to do so, if you use dev tools to force them to cast Reverse the Sands, it won't crash.) However, from my testing this just results in chaos rolls on the AI's turn being ignored entirely, with the trigger not even going on the stack in the first place. (The Doctor's Tomb lacks AIRollPlanarDieParams anyway, but this crash can be relevant if chaos ensues through other effects, such as the "Will of the Planeswalkers" cycle or through Missy's villainous choice ability.)