### PR TITLE
Fix Soulhunter Rakshasa and remove cat subtype from Rakshasa cards

### DIFF
--- a/forge-gui/res/cardsfolder/m/mahadi_emporium_master.txt
+++ b/forge-gui/res/cardsfolder/m/mahadi_emporium_master.txt
@@ -1,6 +1,6 @@
 Name:Mahadi, Emporium Master
 ManaCost:1 B R
-Types:Legendary Creature Cat Devil
+Types:Legendary Creature Devil
 PT:3/3
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ At the beginning of your end step, create a Treasure token for each creature that died this turn.
 SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ c_a_treasure_sac | TokenOwner$ You

--- a/forge-gui/res/cardsfolder/r/rakshasa_deathdealer.txt
+++ b/forge-gui/res/cardsfolder/r/rakshasa_deathdealer.txt
@@ -1,6 +1,6 @@
 Name:Rakshasa Deathdealer
 ManaCost:B G
-Types:Creature Cat Demon
+Types:Creature Demon
 PT:2/2
 A:AB$ Pump | Cost$ B G | Defined$ Self | NumAtt$ +2 | NumDef$ +2 | SpellDescription$ CARDNAME gets +2/+2 until end of turn.
 A:AB$ Regenerate | Cost$ B G | SpellDescription$ Regenerate CARDNAME.

--- a/forge-gui/res/cardsfolder/r/rakshasa_debaser.txt
+++ b/forge-gui/res/cardsfolder/r/rakshasa_debaser.txt
@@ -1,6 +1,6 @@
 Name:Rakshasa Debaser
 ManaCost:4 B B
-Types:Creature Cat Demon
+Types:Creature Demon
 PT:6/6
 K:Encore:6 B B
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigChangeZone | TriggerDescription$ Whenever CARDNAME attacks, put target creature card from defending player's graveyard onto the battlefield under your control.

--- a/forge-gui/res/cardsfolder/r/rakshasa_gravecaller.txt
+++ b/forge-gui/res/cardsfolder/r/rakshasa_gravecaller.txt
@@ -1,6 +1,6 @@
 Name:Rakshasa Gravecaller
 ManaCost:4 B
-Types:Creature Cat Demon
+Types:Creature Demon
 PT:3/6
 K:Exploit
 T:Mode$ Exploited | ValidCard$ Creature | ValidSource$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ When CARDNAME exploits a creature, create two 2/2 black Zombie creature tokens.

--- a/forge-gui/res/cardsfolder/r/rakshasa_vizier.txt
+++ b/forge-gui/res/cardsfolder/r/rakshasa_vizier.txt
@@ -1,6 +1,6 @@
 Name:Rakshasa Vizier
 ManaCost:2 B G U
-Types:Creature Cat Demon
+Types:Creature Demon
 PT:4/4
 T:Mode$ ChangesZoneAll | ValidCards$ Card.YouOwn | Origin$ Graveyard | Destination$ Exile | TriggerZones$ Battlefield | Execute$ TrigPutcounter | TriggerDescription$ Whenever one or more cards are put into exile from your graveyard, put that many +1/+1 counters on CARDNAME.
 SVar:TrigPutcounter:DB$ PutCounter | CounterType$ P1P1 | Defined$ Self | CounterNum$ X

--- a/forge-gui/res/cardsfolder/s/soulhunter_rakshasa.txt
+++ b/forge-gui/res/cardsfolder/s/soulhunter_rakshasa.txt
@@ -4,5 +4,5 @@ Types:Creature Demon
 PT:5/5
 K:CARDNAME can't block.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.wasCastFromYourHandByYou+Self | Execute$ TrigDmg | TriggerDescription$ When CARDNAME enters the battlefield, if you cast it from your hand, it deals 1 damage to target opponent for each Swamp you control.
-SVar:TrigDmg:DB$ DealDamage | ValidTgts$ Opponent | NumDmg$ Valid Swamp.YouCtrl
+SVar:TrigDmg:DB$ DealDamage | ValidTgts$ Opponent | NumDmg$ Count$Valid Swamp.YouCtrl
 Oracle:Soulhunter Rakshasa can't block.\nWhen Soulhunter Rakshasa enters the battlefield, if you cast it from your hand, it deals 1 damage to target opponent for each Swamp you control.

--- a/forge-gui/res/cardsfolder/s/soulhunter_rakshasa.txt
+++ b/forge-gui/res/cardsfolder/s/soulhunter_rakshasa.txt
@@ -4,6 +4,5 @@ Types:Creature Demon
 PT:5/5
 K:CARDNAME can't block.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.wasCastFromYourHandByYou+Self | Execute$ TrigDmg | TriggerDescription$ When CARDNAME enters the battlefield, if you cast it from your hand, it deals 1 damage to target opponent for each Swamp you control.
-SVar:TrigDmg:DB$ DealDamage | ValidTgts$ Opponent | TgtPrompt$ Select target opponent | NumDmg$ X
-SVar:X:Count$Valid Swamp.YouCtrl
+SVar:TrigDmg:DB$ DealDamage | ValidTgts$ Opponent | NumDmg$ Valid Swamp.YouCtrl
 Oracle:Soulhunter Rakshasa can't block.\nWhen Soulhunter Rakshasa enters the battlefield, if you cast it from your hand, it deals 1 damage to target opponent for each Swamp you control.

--- a/forge-gui/res/cardsfolder/s/soulhunter_rakshasa.txt
+++ b/forge-gui/res/cardsfolder/s/soulhunter_rakshasa.txt
@@ -1,8 +1,9 @@
 Name:Soulhunter Rakshasa
 ManaCost:3 B B
-Types:Creature Cat Demon
+Types:Creature Demon
 PT:5/5
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDmg | TriggerDescription$ When CARDNAME enters the battlefield, it deals 5 damage to target opponent.
-SVar:TrigDmg:DB$ DealDamage | Cost$ 3 B B | NumDmg$ 5 | ValidTgts$ Opponent | TgtPrompt$ Choose target opponent. | SpellDescription$ CARDNAME deals 5 damage to target opponent.
 K:CARDNAME can't block.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.wasCastFromYourHandByYou+Self | Execute$ TrigDmg | TriggerDescription$ When CARDNAME enters the battlefield, if you cast it from your hand, it deals 1 damage to target opponent for each Swamp you control.
+SVar:TrigDmg:DB$ DealDamage | ValidTgts$ Opponent | TgtPrompt$ Select target opponent | NumDmg$ X
+SVar:X:Count$Valid Swamp.YouCtrl
 Oracle:Soulhunter Rakshasa can't block.\nWhen Soulhunter Rakshasa enters the battlefield, if you cast it from your hand, it deals 1 damage to target opponent for each Swamp you control.


### PR DESCRIPTION
This was reported as not working as intended.
https://scryfall.com/card/anb/62/soulhunter-rakshasa

I also removed the cat subtype from relevant cards as seen here (I didn't make any of the other changes from the bottom of the article):
https://magic.wizards.com/en/news/announcements/card-updates-coming-with-khans-of-tarkir-on-mtg-arena