### PR TITLE
Minor typo fixes patch + Ent-Draught Basin tap fix

### DIFF
--- a/forge-gui/res/cardsfolder/b/blight_herder.txt
+++ b/forge-gui/res/cardsfolder/b/blight_herder.txt
@@ -2,7 +2,7 @@ Name:Blight Herder
 ManaCost:5
 Types:Creature Eldrazi Processor
 PT:4/5
-T:Mode$ SpellCast | ValidCard$ Card.Self | OptionalDecider$ You | Execute$ TrigToken | OptionalDecider$ You | TriggerDescription$ When you cast CARDNAME, you may put two cards your opponents own from exile into their owners' graveyards. If you do, create three 1/1 colorless Eldrazi Scion creature tokens. They have "Sacrifice this creature: Add {C}."
+T:Mode$ SpellCast | ValidCard$ Card.Self | OptionalDecider$ You | Execute$ TrigToken | OptionalDecider$ You | TriggerDescription$ When you cast this spell, you may put two cards your opponents own from exile into their owners' graveyards. If you do, create three 1/1 colorless Eldrazi Scion creature tokens. They have "Sacrifice this creature: Add {C}."
 SVar:TrigToken:AB$ Token | Cost$ ExiledMoveToGrave<2/Card.OppOwn/cards your opponents own> | TokenAmount$ 3 | TokenScript$ c_1_1_eldrazi_scion_sac | TokenOwner$ You
 DeckHints:Keyword$Ingest & Type$Eldrazi
 DeckHas:Ability$Mana.Colorless|Token

--- a/forge-gui/res/cardsfolder/e/emergency_powers.txt
+++ b/forge-gui/res/cardsfolder/e/emergency_powers.txt
@@ -1,7 +1,7 @@
 Name:Emergency Powers
 ManaCost:5 W U
 Types:Instant
-A:SP$ ChangeZoneAll | ChangeType$ Card | Origin$ Hand,Graveyard | Destination$ Library | Shuffle$ True | Random$ True | SubAbility$ DBDraw | UseAllOriginZones$ True | AILogic$ Timetwister | StackDescription$ SpellDescription | SpellDescription$ Each player shuffles their hand and hand into their library, then draws seven cards. Exile CARDNAME.
+A:SP$ ChangeZoneAll | ChangeType$ Card | Origin$ Hand,Graveyard | Destination$ Library | Shuffle$ True | Random$ True | SubAbility$ DBDraw | UseAllOriginZones$ True | AILogic$ Timetwister | StackDescription$ SpellDescription | SpellDescription$ Each player shuffles their hand and graveyard into their library, then draws seven cards. Exile CARDNAME.
 SVar:DBDraw:DB$ Draw | NumCards$ 7 | Defined$ Player | SubAbility$ DBAddendum | StackDescription$ None
 SVar:DBAddendum:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | ChoiceZone$ Hand | Amount$ 1 | ChangeType$ Permanent.cmcLE7+YouCtrl | ChangeNum$ 1 | AILogic$ BestCard | ConditionPlayerTurn$ True | ConditionPhases$ Main1,Main2 | ConditionDefined$ Self | ConditionPresent$ Card.wasCast | SubAbility$ DBExile | StackDescription$ SpellDescription | SpellDescription$ Addendum - If you cast this spell during your main phase, you may put a permanent card with mana value 7 or less from your hand onto the battlefield.
 SVar:DBExile:DB$ ChangeZone | Origin$ Stack | Destination$ Exile | StackDescription$ None

--- a/forge-gui/res/cardsfolder/e/ent_draught_basin.txt
+++ b/forge-gui/res/cardsfolder/e/ent_draught_basin.txt
@@ -1,7 +1,7 @@
 Name:Ent-Draught Basin
 ManaCost:2
 Types:Artifact
-A:AB$ PutCounter | Cost$ X | CounterType$ P1P1 | ValidTgts$ Creature.powerEQX | TgtPrompt$ Select target creature with power X | CounterNum$ 1 | SorcerySpeed$ True | SpellDescription$ Put a +1/+1 counter on target creature with power X. Activate only as a sorcery.
+A:AB$ PutCounter | Cost$ T X | CounterType$ P1P1 | ValidTgts$ Creature.powerEQX | TgtPrompt$ Select target creature with power X | CounterNum$ 1 | SorcerySpeed$ True | SpellDescription$ Put a +1/+1 counter on target creature with power X. Activate only as a sorcery.
 SVar:X:Count$xPaid
 DeckHas:Ability$Counters
 Oracle:{X}, {T}: Put a +1/+1 counter on target creature with power X. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/g/graveyard_marshal.txt
+++ b/forge-gui/res/cardsfolder/g/graveyard_marshal.txt
@@ -2,7 +2,7 @@ Name:Graveyard Marshal
 ManaCost:B B
 Types:Creature Zombie Soldier
 PT:3/2
-A:AB$ Token | Cost$ 2 B ExileFromGrave<1/Creature> | TokenAmount$ 1 | TokenScript$ b_2_2_zombie | TokenOwner$ You | TokenTapped$ True | SpellDescription$ Exile target creature card from your graveyard: Create a 2/2 black Zombie creature token.
+A:AB$ Token | Cost$ 2 B ExileFromGrave<1/Creature> | TokenAmount$ 1 | TokenScript$ b_2_2_zombie | TokenOwner$ You | TokenTapped$ True | SpellDescription$ Create a 2/2 black Zombie creature token.
 SVar:AIPreference:ExileFromGraveCost$Creature.cmcLE1+inZoneGraveyard
 DeckHas:Ability$Token
 Oracle:{2}{B}, Exile a creature card from your graveyard: Create a tapped 2/2 black Zombie creature token.

--- a/forge-gui/res/cardsfolder/p/prossh_skyraider_of_kher.txt
+++ b/forge-gui/res/cardsfolder/p/prossh_skyraider_of_kher.txt
@@ -3,7 +3,7 @@ ManaCost:3 B R G
 Types:Legendary Creature Dragon
 PT:5/5
 K:Flying
-T:Mode$ SpellCast | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When you cast CARDNAME, create X 0/1 red Kobold creature tokens named Kobolds of Kher Keep, where X is the amount of mana spent to cast CARDNAME.
+T:Mode$ SpellCast | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When you cast CARDNAME, create X 0/1 red Kobold creature tokens named Kobolds of Kher Keep, where X is the amount of mana spent to cast it.
 SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ kobolds_of_kher_keep | TokenOwner$ You
 SVar:X:Count$CastTotalManaSpent
 A:AB$ Pump | Cost$ Sac<1/Creature.Other/another creature> | Defined$ Self | NumAtt$ 1 | SpellDescription$ CARDNAME gets +1/+0 until end of turn.

--- a/forge-gui/res/cardsfolder/s/shadowborn_apostle.txt
+++ b/forge-gui/res/cardsfolder/s/shadowborn_apostle.txt
@@ -3,7 +3,7 @@ ManaCost:B
 Types:Creature Human Cleric
 PT:1/1
 K:A deck can have any number of cards named CARDNAME.
-A:AB$ ChangeZone | Cost$ B Sac<6/Creature.namedShadowborn Apostle/creatures named Shadowborn Apostle> | Origin$ Library | Destination$ Battlefield | ChangeType$ Creature.Demon | ChangeNum$ 1 | SpellDescription$ Search your library for a Demon creature, put it onto the battlefield, then shuffle.
+A:AB$ ChangeZone | Cost$ B Sac<6/Creature.namedShadowborn Apostle/creatures named Shadowborn Apostle> | Origin$ Library | Destination$ Battlefield | ChangeType$ Creature.Demon | ChangeNum$ 1 | SpellDescription$ Search your library for a Demon creature card, put it onto the battlefield, then shuffle.
 DeckNeeds:Name$Shadowborn Apostle
 DeckNeeds:Type$Demon
 DeckHints:Name$Shadowborn Demon

--- a/forge-gui/res/cardsfolder/t/titania_voice_of_gaea_titania_gaea_incarnate.txt
+++ b/forge-gui/res/cardsfolder/t/titania_voice_of_gaea_titania_gaea_incarnate.txt
@@ -28,7 +28,7 @@ K:Trample
 K:Haste
 S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of lands you control.
 SVar:X:Count$Valid Land.YouCtrl
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChangeZoneAll | TriggerDescription$ When NICKNAME enters the battlefield, return all land cards from your graveyard onto the battlefield tapped.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChangeZoneAll | TriggerDescription$ When NICKNAME enters the battlefield, return all land cards from your graveyard to the battlefield tapped.
 SVar:TrigChangeZoneAll:DB$ ChangeZoneAll | ChangeType$ Land.YouCtrl | Origin$ Graveyard | Destination$ Battlefield | Tapped$ True
 A:AB$ PutCounter | Cost$ 3 G | ValidTgts$ Land.YouCtrl | TgtPrompt$ Select target land you control | CounterType$ P1P1 | CounterNum$ 4 | SubAbility$ DBAnimate | SpellDescription$ Put 4 +1/+1 counters on target land you control. That land becomes a 0/0 Elemental creature with haste. It's still a land.
 SVar:DBAnimate:DB$ Animate | Defined$ ParentTarget | Power$ 0 | Toughness$ 0 | Types$ Creature,Elemental | Keywords$ Haste | Duration$ Permanent

--- a/forge-gui/res/editions/Commander 2021.txt
+++ b/forge-gui/res/editions/Commander 2021.txt
@@ -150,7 +150,7 @@ ScryfallCode=C21
 142 R Defiant Bloodlord @Craig J Spearing
 143 C Epicure of Blood @Anna Steinbauer
 144 C Feed the Swarm @Andrey Kuzinskiy
-145 R Greed @Izzy
+145 U Greed @Izzy
 146 R Infernal Offering @Anthony Palumbo
 147 M Necropolis Regent @Winona Nelson
 148 M Noxious Gearhulk @Lius Lasahido

--- a/forge-gui/res/editions/Kaldheim Commander.txt
+++ b/forge-gui/res/editions/Kaldheim Commander.txt
@@ -35,7 +35,7 @@ ScryfallCode=KHC
 27 U Goldnight Commander @Chris Rahn
 28 C Kor Cartographer @Ryan Pancoast
 29 R Marshal's Anthem @Matt Stewart
-30 U Momentary Blink @Evan Shipard
+30 C Momentary Blink @Evan Shipard
 31 R Restoration Angel @Jake Murray
 32 U Return to Dust @Wayne Reynolds
 33 R Storm Herd @Jim Nelson


### PR DESCRIPTION
I was going to do a small typo patch but found the Ent-Draught Basin error partway through, so hopefully it's okay to combine the fixes.

1 FUNCTIONAL CHANGE
Ent-Draught Basin now must tap to activate its ability, as it should be.

8 NON-FUNCTIONAL CHANGES
- Fixed six minor typos for the SpellDescription$ of various cards. These all show up fine in Deck Editor, but in the game, the SpellDescription takes over and there are typos in some of those. None of these are functional changes. See individual description for Graveyard Marshal.

- Changed two rarities (Greed C21 and Momentary Blink KHC).