### PR TITLE
Update PlaneswalkEffect.java

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/PlaneswalkEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PlaneswalkEffect.java
@@ -24,16 +24,16 @@ public class PlaneswalkEffect extends SpellAbilityEffect {
             return;
         }
 
+        if (sa.hasParam("Optional") && !sa.getActivatingPlayer().getController().confirmAction(sa, null,
+                Localizer.getInstance().getMessage("lblWouldYouLikeToPlaneswalk"), null)) {
+                    return;
+        }
+
         final Map<AbilityKey, Object> repParams = AbilityKey.mapFromAffected(activator);
         Object cause = sa.hasParam("Cause") ? sa.getParam("Cause") : sa;
         repParams.put(AbilityKey.Cause, cause);
         if (game.getReplacementHandler().run(ReplacementType.Planeswalk, repParams) == ReplacementResult.Replaced) {
             return;
-        }
-
-        if (sa.hasParam("Optional") && !sa.getActivatingPlayer().getController().confirmAction(sa, null,
-                Localizer.getInstance().getMessage("lblWouldYouLikeToPlaneswalk"), null)) {
-                    return;
         }
 
         if (!sa.hasParam("DontPlaneswalkAway")) {


### PR DESCRIPTION
Fixes an issue where planeswalk replacements were being applied before confirmation for optional planeswalks, thus making it so that one couldn't choose not to planeswalk with TARDIS's attack trigger if one also controls Susan Foreman