### PR TITLE
Planechase inherent effects

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtilAbility.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilAbility.java
@@ -257,7 +257,16 @@ public class ComputerUtilAbility {
 
             // deprioritize planar die roll marked with AIRollPlanarDieParams:LowPriority$ True
             if (ApiType.RollPlanarDice == a.getApi() || ApiType.RollPlanarDice == b.getApi()) {
-                for (Card c : a.getGame().getActivePlanes()) {
+                Card hostCardForGame = a.getHostCard();
+                if (hostCardForGame == null) {
+                    if (b.getHostCard() != null) {
+                        hostCardForGame = b.getHostCard();
+                    } else {
+                        return 0; // fallback if neither SA have a host card somehow
+                    }
+                }
+                Game game = hostCardForGame.getGame();
+                for (Card c : game.getActivePlanes()) {
                     if (c.hasSVar("AIRollPlanarDieParams") && c.getSVar("AIRollPlanarDieParams").toLowerCase().matches(".*lowpriority\\$\\s*true.*")) {
                         if (ApiType.RollPlanarDice == a.getApi()) {
                             return 1;

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilAbility.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilAbility.java
@@ -256,10 +256,16 @@ public class ComputerUtilAbility {
             }
 
             // deprioritize planar die roll marked with AIRollPlanarDieParams:LowPriority$ True
-            if (ApiType.RollPlanarDice == a.getApi() && a.getHostCard() != null && a.getHostCard().hasSVar("AIRollPlanarDieParams") && a.getHostCard().getSVar("AIRollPlanarDieParams").toLowerCase().matches(".*lowpriority\\$\\s*true.*")) {
-                return 1;
-            } else if (ApiType.RollPlanarDice == b.getApi() && b.getHostCard() != null && b.getHostCard().hasSVar("AIRollPlanarDieParams") && b.getHostCard().getSVar("AIRollPlanarDieParams").toLowerCase().matches(".*lowpriority\\$\\s*true.*")) {
-                return -1;
+            if (ApiType.RollPlanarDice == a.getApi() || ApiType.RollPlanarDice == b.getApi()) {
+                for (Card c : a.getGame().getActivePlanes()) {
+                    if (c.hasSVar("AIRollPlanarDieParams") && c.getSVar("AIRollPlanarDieParams").toLowerCase().matches(".*lowpriority\\$\\s*true.*")) {
+                        if (ApiType.RollPlanarDice == a.getApi()) {
+                            return 1;
+                        } else {
+                            return -1;
+                        }
+                    }
+                }
             }
 
             // deprioritize pump spells with pure energy cost (can be activated last,

--- a/forge-ai/src/main/java/forge/ai/ability/RollPlanarDiceAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/RollPlanarDiceAi.java
@@ -19,9 +19,16 @@ public class RollPlanarDiceAi extends SpellAbilityAi {
      */
     @Override
     protected boolean canPlayAI(Player ai, SpellAbility sa) {
-        AiController aic = ((PlayerControllerAi)ai.getController()).getAi();
-        Card plane = sa.getHostCard();
+        for (Card c : ai.getGame().getActivePlanes()) {
+            if (willRollOnPlane(ai, c)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
+    private boolean willRollOnPlane(Player ai, Card plane) {
+        AiController aic = ((PlayerControllerAi)ai.getController()).getAi();
         boolean decideToRoll = false;
         boolean rollInMain1 = false;
         String modeName = "never";

--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -2098,7 +2098,7 @@ public class GameAction {
             if (game.getRules().hasAppliedVariant(GameType.Planechase)) {
                 first.initPlane();
                 for (final Player p1 : game.getPlayers()) {
-                    p1.getZone(ZoneType.Command).add(p1.createPlanechaseEffects(game));
+                    p1.createPlanechaseEffects(game);
                 }
             }
 

--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -2097,6 +2097,9 @@ public class GameAction {
             //<THIS CODE WILL WORK WITH PHASE = NULL>
             if (game.getRules().hasAppliedVariant(GameType.Planechase)) {
                 first.initPlane();
+                for (final Player p1 : game.getPlayers()) {
+                    p1.getZone(ZoneType.Command).add(p1.createPlanechaseEffects(game));
+                }
             }
 
             first = runOpeningHandActions(first);

--- a/forge-game/src/main/java/forge/game/PlanarDice.java
+++ b/forge-game/src/main/java/forge/game/PlanarDice.java
@@ -87,6 +87,11 @@ public enum PlanarDice {
         runParams.put(AbilityKey.Result, Arrays.asList(0));
         roller.getGame().getTriggerHandler().runTrigger(TriggerType.RolledDieOnce, runParams, false);
 
+        if (res == Chaos) {
+            runParams = AbilityKey.mapFromPlayer(roller);
+            roller.getGame().getTriggerHandler().runTrigger(TriggerType.ChaosEnsues, runParams, false);
+        }
+
         return res;
     }
 

--- a/forge-game/src/main/java/forge/game/card/CardFactory.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactory.java
@@ -318,23 +318,9 @@ public class CardFactory {
 
         // ******************************************************************
         // ************** Link to different CardFactories *******************
-        if (card.isPlane()) {
-            buildPlaneAbilities(card);
-        }
         buildBattleAbilities(card);
         CardFactoryUtil.setupKeywordedAbilities(card); // Should happen AFTER setting left/right split abilities to set Fuse ability to both sides
         card.updateStateForView();
-    }
-
-    private static void buildPlaneAbilities(Card card) {
-        String specialA = "ST$ RollPlanarDice | Cost$ X | SorcerySpeed$ True | Activator$ Player | SpecialAction$ True" +
-                " | ActivationZone$ Command | SpellDescription$ Roll the planar dice. X is equal to the number of " +
-                "times you have previously taken this action this turn. | CostDesc$ {X}: ";
-
-        SpellAbility planarRoll = AbilityFactory.getAbility(specialA, card);
-        planarRoll.setSVar("X", "Count$PlanarDiceSpecialActionThisTurn");
-
-        card.addSpellAbility(planarRoll);
     }
 
     private static void buildBattleAbilities(Card card) {

--- a/forge-game/src/main/java/forge/game/card/CardFactory.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactory.java
@@ -327,23 +327,6 @@ public class CardFactory {
     }
 
     private static void buildPlaneAbilities(Card card) {
-        String trigger = "Mode$ PlanarDice | Result$ Planeswalk | TriggerZones$ Command | Secondary$ True | " +
-                "TriggerDescription$ Whenever you roll the Planeswalker symbol on the planar die, planeswalk.";
-
-        String rolledWalk = "DB$ Planeswalk | Cause$ PlanarDie";
-
-        Trigger planesWalkTrigger = TriggerHandler.parseTrigger(trigger, card, true);
-        planesWalkTrigger.setOverridingAbility(AbilityFactory.getAbility(rolledWalk, card));
-        card.addTrigger(planesWalkTrigger);
-
-        String chaosTrig = "Mode$ PlanarDice | Result$ Chaos | TriggerZones$ Command | Static$ True";
-
-        String rolledChaos = "DB$ ChaosEnsues";
-
-        Trigger chaosTrigger = TriggerHandler.parseTrigger(chaosTrig, card, true);
-        chaosTrigger.setOverridingAbility(AbilityFactory.getAbility(rolledChaos, card));
-        card.addTrigger(chaosTrigger);
-
         String specialA = "ST$ RollPlanarDice | Cost$ X | SorcerySpeed$ True | Activator$ Player | SpecialAction$ True" +
                 " | ActivationZone$ Command | SpellDescription$ Roll the planar dice. X is equal to the number of " +
                 "times you have previously taken this action this turn. | CostDesc$ {X}: ";

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -3228,12 +3228,6 @@ public class Player extends GameEntity implements Comparable<Player> {
         planesWalkTrigger.setOverridingAbility(AbilityFactory.getAbility(rolledWalk, eff));
         eff.addTrigger(planesWalkTrigger);
 
-        String chaosTrig = "Mode$ PlanarDice | ValidPlayer$ You | Result$ Chaos | TriggerZones$ Command | Static$ True";
-        String rolledChaos = "DB$ ChaosEnsues";
-        Trigger chaosTrigger = TriggerHandler.parseTrigger(chaosTrig, eff, true);
-        chaosTrigger.setOverridingAbility(AbilityFactory.getAbility(rolledChaos, eff));
-        eff.addTrigger(chaosTrigger);
-
         String specialA = "ST$ RollPlanarDice | Cost$ X | SorcerySpeed$ True | Activator$ Player | SpecialAction$ True" +
                 " | ActivationZone$ Command | SpellDescription$ Roll the planar dice. X is equal to the number of " +
                 "times you have previously taken this action this turn. | CostDesc$ {X}: ";

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -3212,7 +3212,13 @@ public class Player extends GameEntity implements Comparable<Player> {
 
     public Card createPlanechaseEffects(Game game) {
         final String name = "Planechase Effect";
-        final Card eff = new Card(game.nextCardId(), game); //can't be DetachedCardEffect because there's no linked card
+        final Card eff = new Card(game.nextCardId(), game){
+            @Override
+            public Card getCardForUi() {
+                List<Card> currentPlanes = getOwner().getGame().getActivePlanes();
+                return (currentPlanes == null || currentPlanes.size() == 0) ? null : currentPlanes.get(0); //use current plane for the sake of UI display logic
+            }
+        };
         eff.setTimestamp(game.getNextTimestamp());
         eff.setName(name);
         eff.setOwner(this);

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -3210,6 +3210,35 @@ public class Player extends GameEntity implements Comparable<Player> {
         return eff;
     }
 
+    public Card createPlanechaseEffects(Game game) {
+        final String name = "Planechase Effect";
+        final Card eff = new Card(game.nextCardId(), game); //can't be DetachedCardEffect because there's no linked card
+        eff.setTimestamp(game.getNextTimestamp());
+        eff.setName(name);
+        eff.setOwner(this);
+        eff.setImmutable(true);
+
+        if (game.getRules().hasAppliedVariant(GameType.Planechase)) {
+            String trigger = "Mode$ PlanarDice | Result$ Planeswalk | TriggerZones$ Command | ValidPlayer$ You | Secondary$ True | " +
+                    "TriggerDescription$ Whenever you roll the Planeswalker symbol on the planar die, planeswalk.";
+
+            String rolledWalk = "DB$ Planeswalk | Cause$ PlanarDie";
+
+            Trigger planesWalkTrigger = TriggerHandler.parseTrigger(trigger, eff, true);
+            planesWalkTrigger.setOverridingAbility(AbilityFactory.getAbility(rolledWalk, eff));
+            eff.addTrigger(planesWalkTrigger);
+
+            String chaosTrig = "Mode$ PlanarDice | ValidPlayer$ You | Result$ Chaos | TriggerZones$ Command | Static$ True";
+
+            String rolledChaos = "DB$ ChaosEnsues";
+
+            Trigger chaosTrigger = TriggerHandler.parseTrigger(chaosTrig, eff, true);
+            chaosTrigger.setOverridingAbility(AbilityFactory.getAbility(rolledChaos, eff));
+            eff.addTrigger(chaosTrigger);
+        }
+        return eff;
+    }
+
     public void createTheRing(Card host) {
         final PlayerZone com = getZone(ZoneType.Command);
         if (theRing == null) {

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -3210,39 +3210,40 @@ public class Player extends GameEntity implements Comparable<Player> {
         return eff;
     }
 
-    public Card createPlanechaseEffects(Game game) {
-        final String name = "Planechase Effect";
-        final Card eff = new Card(game.nextCardId(), game){
-            @Override
-            public Card getCardForUi() {
-                List<Card> currentPlanes = getOwner().getGame().getActivePlanes();
-                return (currentPlanes == null || currentPlanes.size() == 0) ? null : currentPlanes.get(0); //use current plane for the sake of UI display logic
-            }
-        };
+    public void createPlanechaseEffects(Game game) {
+        final PlayerZone com = getZone(ZoneType.Command);
+        final String name = "Planar Dice";
+        final Card eff = new Card(game.nextCardId(), game);
         eff.setTimestamp(game.getNextTimestamp());
         eff.setName(name);
         eff.setOwner(this);
         eff.setImmutable(true);
+        String image = ImageKeys.getTokenKey("planechase");
+        eff.setImageKey(image);
 
-        if (game.getRules().hasAppliedVariant(GameType.Planechase)) {
-            String trigger = "Mode$ PlanarDice | Result$ Planeswalk | TriggerZones$ Command | ValidPlayer$ You | Secondary$ True | " +
-                    "TriggerDescription$ Whenever you roll the Planeswalker symbol on the planar die, planeswalk.";
+        String trigger = "Mode$ PlanarDice | Result$ Planeswalk | TriggerZones$ Command | ValidPlayer$ You | Secondary$ True | " +
+                "TriggerDescription$ Whenever you roll the Planeswalker symbol on the planar die, planeswalk.";
+        String rolledWalk = "DB$ Planeswalk | Cause$ PlanarDie";
+        Trigger planesWalkTrigger = TriggerHandler.parseTrigger(trigger, eff, true);
+        planesWalkTrigger.setOverridingAbility(AbilityFactory.getAbility(rolledWalk, eff));
+        eff.addTrigger(planesWalkTrigger);
 
-            String rolledWalk = "DB$ Planeswalk | Cause$ PlanarDie";
+        String chaosTrig = "Mode$ PlanarDice | ValidPlayer$ You | Result$ Chaos | TriggerZones$ Command | Static$ True";
+        String rolledChaos = "DB$ ChaosEnsues";
+        Trigger chaosTrigger = TriggerHandler.parseTrigger(chaosTrig, eff, true);
+        chaosTrigger.setOverridingAbility(AbilityFactory.getAbility(rolledChaos, eff));
+        eff.addTrigger(chaosTrigger);
 
-            Trigger planesWalkTrigger = TriggerHandler.parseTrigger(trigger, eff, true);
-            planesWalkTrigger.setOverridingAbility(AbilityFactory.getAbility(rolledWalk, eff));
-            eff.addTrigger(planesWalkTrigger);
-
-            String chaosTrig = "Mode$ PlanarDice | ValidPlayer$ You | Result$ Chaos | TriggerZones$ Command | Static$ True";
-
-            String rolledChaos = "DB$ ChaosEnsues";
-
-            Trigger chaosTrigger = TriggerHandler.parseTrigger(chaosTrig, eff, true);
-            chaosTrigger.setOverridingAbility(AbilityFactory.getAbility(rolledChaos, eff));
-            eff.addTrigger(chaosTrigger);
-        }
-        return eff;
+        String specialA = "ST$ RollPlanarDice | Cost$ X | SorcerySpeed$ True | Activator$ Player | SpecialAction$ True" +
+                " | ActivationZone$ Command | SpellDescription$ Roll the planar dice. X is equal to the number of " +
+                "times you have previously taken this action this turn. | CostDesc$ {X}: ";
+        SpellAbility planarRoll = AbilityFactory.getAbility(specialA, eff);
+        planarRoll.setSVar("X", "Count$PlanarDiceSpecialActionThisTurn");
+        eff.addSpellAbility(planarRoll);
+        
+        eff.updateStateForView();
+        com.add(eff);
+        this.updateZoneForView(com);
     }
 
     public void createTheRing(Card host) {


### PR DESCRIPTION
Closes #4262, by moving the planeswalking ability and the static chaos trigger to an effect carried with the player in a planechase game. Technically the special action to roll the planar die should be part of it too, but then you either have to make the "Planechase Effect" card visible in the UI so that human players can actually click it to roll, or rework how the UI relates to planechase entirely