### PR TITLE
Update Game.java

### DIFF
--- a/forge-game/src/main/java/forge/game/Game.java
+++ b/forge-game/src/main/java/forge/game/Game.java
@@ -891,7 +891,7 @@ public class Game {
                 }
             }
             runParams.put(AbilityKey.Cards, planesLeavingGame);
-            game.getTriggerHandler().runTrigger(TriggerType.PlaneswalkedFrom, runParams, false);
+            getTriggerHandler().runTrigger(TriggerType.PlaneswalkedFrom, runParams, false);
             planarController.planeswalkTo(null, new CardCollection(planarController.getZone(ZoneType.PlanarDeck).get(0)));
         }
 

--- a/forge-game/src/main/java/forge/game/Game.java
+++ b/forge-game/src/main/java/forge/game/Game.java
@@ -882,6 +882,16 @@ public class Game {
             if (planarController.equals(p)) {
                 planarController = getNextPlayerAfter(p);
             }
+            final Map<AbilityKey, Object> runParams = AbilityKey.newMap();
+            CardCollection planesLeavingGame =  new CardCollection();
+            for (Card c : getActivePlanes()) {
+                if ((c != null) && (c.getOwner().equals(p))) {
+                    planesLeavingGame.add(c);
+                    planarController.removeCurrentPlane(c);
+                }
+            }
+            runParams.put(AbilityKey.Cards, planesLeavingGame);
+            game.getTriggerHandler().runTrigger(TriggerType.PlaneswalkedFrom, runParams, false);
             planarController.planeswalkTo(null, new CardCollection(planarController.getZone(ZoneType.PlanarDeck).get(0)));
         }
 

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -2755,6 +2755,13 @@ public class Player extends GameEntity implements Comparable<Player> {
     }
 
     /**
+     * Removes a particular plane from the active plane list.
+     */
+    public void removeCurrentPlane(Card c) {
+        currentPlanes.remove(c);
+    }
+
+    /**
      * Sets up the first plane of a round.
      */
     public void initPlane() {


### PR DESCRIPTION
Closes #3318

(Agetian noted in that issue that passing a null for the SpellAbility argument in Player.planeswalk would cause issues with Player.java:2701-2702, but Player.planeswalk has since been altered and no longer has those lines anyway, so I think that should be moot now?)

I've tested with all three combinations of
1. planar controller leaves the game while also the owner of an active plane (next player becomes planar controller, planeswalks)
2. planar controller leaves the game but doesn't own an active plane (next player takes control of active planes)
3. planar owner leaves the game when not the planar controller (planar controller planeswalks)