### PR TITLE
Updates "Can't be countered" into Replacement Effects

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -192,13 +192,12 @@ public class AiController {
                 if ("DestroyCreature".equals(curse) && sa.isSpell() && host.isCreature()
                         && !host.hasKeyword(Keyword.INDESTRUCTIBLE)) {
                     return true;
-                } else if ("CounterEnchantment".equals(curse) && sa.isSpell() && host.isEnchantment()
-                        && CardFactoryUtil.isCounterableBy(host, null)) {
+                } else if ("CounterEnchantment".equals(curse) && sa.isSpell() && host.isEnchantment() && host.isCounterableBy(null)) {
                     return true;
-                } else if ("ChaliceOfTheVoid".equals(curse) && sa.isSpell() && CardFactoryUtil.isCounterableBy(host, null)
+                } else if ("ChaliceOfTheVoid".equals(curse) && sa.isSpell() && host.isCounterableBy(null)
                         && host.getCMC() == c.getCounters(CounterEnumType.CHARGE)) {
                     return true;
-                } else if ("BazaarOfWonders".equals(curse) && sa.isSpell() && CardFactoryUtil.isCounterableBy(host, null)) {
+                } else if ("BazaarOfWonders".equals(curse) && sa.isSpell() && host.isCounterableBy(null)) {
                     String hostName = host.getName();
                     for (Card card : ccvGameBattlefield) {
                         if (!card.isToken() && card.sharesNameWith(host)) {
@@ -815,7 +814,7 @@ public class AiController {
         // Account for possible Ward after the spell is fully targeted
         // TODO: ideally, this should be done while targeting, so that a different target can be preferred if the best
         // one is warded and can't be paid for. (currently it will be stuck with the target until it could pay)
-        if (!sa.isSpell() || CardFactoryUtil.isCounterableBy(host, null)) {
+        if (!sa.isSpell() || host.isCounterableBy(null)) {
             for (TargetChoices tc : sa.getAllTargetChoices()) {
                 for (Card tgt : tc.getTargetCards()) {
                     // TODO some older cards don't use the keyword, so check for trigger instead

--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -193,12 +193,12 @@ public class AiController {
                         && !host.hasKeyword(Keyword.INDESTRUCTIBLE)) {
                     return true;
                 } else if ("CounterEnchantment".equals(curse) && sa.isSpell() && host.isEnchantment()
-                        && CardFactoryUtil.isCounterable(host)) {
+                        && CardFactoryUtil.isCounterableBy(host, null)) {
                     return true;
-                } else if ("ChaliceOfTheVoid".equals(curse) && sa.isSpell() && CardFactoryUtil.isCounterable(host)
+                } else if ("ChaliceOfTheVoid".equals(curse) && sa.isSpell() && CardFactoryUtil.isCounterableBy(host, null)
                         && host.getCMC() == c.getCounters(CounterEnumType.CHARGE)) {
                     return true;
-                } else if ("BazaarOfWonders".equals(curse) && sa.isSpell() && CardFactoryUtil.isCounterable(host)) {
+                } else if ("BazaarOfWonders".equals(curse) && sa.isSpell() && CardFactoryUtil.isCounterableBy(host, null)) {
                     String hostName = host.getName();
                     for (Card card : ccvGameBattlefield) {
                         if (!card.isToken() && card.sharesNameWith(host)) {
@@ -815,7 +815,7 @@ public class AiController {
         // Account for possible Ward after the spell is fully targeted
         // TODO: ideally, this should be done while targeting, so that a different target can be preferred if the best
         // one is warded and can't be paid for. (currently it will be stuck with the target until it could pay)
-        if (!sa.isSpell() || CardFactoryUtil.isCounterable(host)) {
+        if (!sa.isSpell() || CardFactoryUtil.isCounterableBy(host, null)) {
             for (TargetChoices tc : sa.getAllTargetChoices()) {
                 for (Card tgt : tc.getTargetCards()) {
                     // TODO some older cards don't use the keyword, so check for trigger instead

--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -192,12 +192,12 @@ public class AiController {
                 if ("DestroyCreature".equals(curse) && sa.isSpell() && host.isCreature()
                         && !host.hasKeyword(Keyword.INDESTRUCTIBLE)) {
                     return true;
-                } else if ("CounterEnchantment".equals(curse) && sa.isSpell() && host.isEnchantment() && host.isCounterableBy(null)) {
+                } else if ("CounterEnchantment".equals(curse) && sa.isSpell() && host.isEnchantment() && sa.isCounterableBy(null)) {
                     return true;
-                } else if ("ChaliceOfTheVoid".equals(curse) && sa.isSpell() && host.isCounterableBy(null)
+                } else if ("ChaliceOfTheVoid".equals(curse) && sa.isSpell() && sa.isCounterableBy(null)
                         && host.getCMC() == c.getCounters(CounterEnumType.CHARGE)) {
                     return true;
-                } else if ("BazaarOfWonders".equals(curse) && sa.isSpell() && host.isCounterableBy(null)) {
+                } else if ("BazaarOfWonders".equals(curse) && sa.isSpell() && sa.isCounterableBy(null)) {
                     String hostName = host.getName();
                     for (Card card : ccvGameBattlefield) {
                         if (!card.isToken() && card.sharesNameWith(host)) {
@@ -814,7 +814,7 @@ public class AiController {
         // Account for possible Ward after the spell is fully targeted
         // TODO: ideally, this should be done while targeting, so that a different target can be preferred if the best
         // one is warded and can't be paid for. (currently it will be stuck with the target until it could pay)
-        if (!sa.isSpell() || host.isCounterableBy(null)) {
+        if (!sa.isSpell() || sa.isCounterableBy(null)) {
             for (TargetChoices tc : sa.getAllTargetChoices()) {
                 for (Card tgt : tc.getTargetCards()) {
                     // TODO some older cards don't use the keyword, so check for trigger instead

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
@@ -522,11 +522,12 @@ public class ComputerUtilCost {
             sa.setActivatingPlayer(player, true); // complaints on NPE had came before this line was added.
         }
 
-        final boolean cannotBeCountered = sa.isSpell() && !sa.getHostCard().isCounterableBy(null);
+        boolean cannotBeCountered = false;
 
         // Check for stuff like Nether Void
         int extraManaNeeded = 0;
         if (sa instanceof Spell) {
+            cannotBeCountered = !sa.isCounterableBy(null);
             for (Card c : player.getGame().getCardsIn(ZoneType.Battlefield)) {
                 final String snem = c.getSVar("AI_SpellsNeedExtraMana");
                 if (!StringUtils.isBlank(snem)) {
@@ -796,7 +797,7 @@ public class ComputerUtilCost {
         if (ApiType.Counter.equals(sa.getApi())) {
             List<SpellAbility> spells = AbilityUtils.getDefinedSpellAbilities(source, sa.getParamOrDefault("Defined", "Targeted"), sa);
             for (SpellAbility toBeCountered : spells) {
-                if (toBeCountered.isSpell() && !toBeCountered.getHostCard().isCounterableBy(sa)) {
+                if (!toBeCountered.isCounterableBy(sa)) {
                     return false;
                 }
                 // no reason to pay if we don't plan to confirm

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
@@ -522,7 +522,7 @@ public class ComputerUtilCost {
             sa.setActivatingPlayer(player, true); // complaints on NPE had came before this line was added.
         }
 
-        final boolean cannotBeCountered = !sa.getHostCard().isCounterableBy(null);
+        final boolean cannotBeCountered = sa.isSpell() && !sa.getHostCard().isCounterableBy(null);
 
         // Check for stuff like Nether Void
         int extraManaNeeded = 0;

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
@@ -522,7 +522,7 @@ public class ComputerUtilCost {
             sa.setActivatingPlayer(player, true); // complaints on NPE had came before this line was added.
         }
 
-        final boolean cannotBeCountered = !CardFactoryUtil.isCounterable(sa.getHostCard());
+        final boolean cannotBeCountered = !CardFactoryUtil.isCounterableBy(sa.getHostCard(), null);
 
         // Check for stuff like Nether Void
         int extraManaNeeded = 0;
@@ -796,7 +796,7 @@ public class ComputerUtilCost {
         if (ApiType.Counter.equals(sa.getApi())) {
             List<SpellAbility> spells = AbilityUtils.getDefinedSpellAbilities(source, sa.getParamOrDefault("Defined", "Targeted"), sa);
             for (SpellAbility toBeCountered : spells) {
-                if (toBeCountered.isSpell() && !CardFactoryUtil.isCounterable(toBeCountered.getHostCard())) {
+                if (toBeCountered.isSpell() && !CardFactoryUtil.isCounterableBy(toBeCountered.getHostCard(), null)) {
                     return false;
                 }
                 // no reason to pay if we don't plan to confirm

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
@@ -522,7 +522,7 @@ public class ComputerUtilCost {
             sa.setActivatingPlayer(player, true); // complaints on NPE had came before this line was added.
         }
 
-        final boolean cannotBeCountered = !CardFactoryUtil.isCounterableBy(sa.getHostCard(), null);
+        final boolean cannotBeCountered = !sa.getHostCard().isCounterableBy(null);
 
         // Check for stuff like Nether Void
         int extraManaNeeded = 0;
@@ -796,7 +796,7 @@ public class ComputerUtilCost {
         if (ApiType.Counter.equals(sa.getApi())) {
             List<SpellAbility> spells = AbilityUtils.getDefinedSpellAbilities(source, sa.getParamOrDefault("Defined", "Targeted"), sa);
             for (SpellAbility toBeCountered : spells) {
-                if (toBeCountered.isSpell() && !CardFactoryUtil.isCounterableBy(toBeCountered.getHostCard(), null)) {
+                if (toBeCountered.isSpell() && !toBeCountered.getHostCard().isCounterableBy(sa)) {
                     return false;
                 }
                 // no reason to pay if we don't plan to confirm

--- a/forge-ai/src/main/java/forge/ai/ability/BidLifeAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/BidLifeAi.java
@@ -39,7 +39,7 @@ public class BidLifeAi extends SpellAbilityAi {
                     return false;
                 }
                 final SpellAbility topSA = game.getStack().peekAbility();
-                if (!topSA.getHostCard().isCounterableBy(sa) || aiPlayer.equals(topSA.getActivatingPlayer())) {
+                if (!topSA.isCounterableBy(sa) || aiPlayer.equals(topSA.getActivatingPlayer())) {
                     return false;
                 }
                 if (sa.canTargetSpellAbility(topSA)) {

--- a/forge-ai/src/main/java/forge/ai/ability/BidLifeAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/BidLifeAi.java
@@ -7,7 +7,6 @@ import forge.ai.ComputerUtilCard;
 import forge.ai.SpellAbilityAi;
 import forge.game.Game;
 import forge.game.card.Card;
-import forge.game.card.CardFactoryUtil;
 import forge.game.card.CardLists;
 import forge.game.player.Player;
 import forge.game.spellability.SpellAbility;
@@ -40,7 +39,7 @@ public class BidLifeAi extends SpellAbilityAi {
                     return false;
                 }
                 final SpellAbility topSA = game.getStack().peekAbility();
-                if (!CardFactoryUtil.isCounterableBy(topSA.getHostCard(), sa) || aiPlayer.equals(topSA.getActivatingPlayer())) {
+                if (!topSA.getHostCard().isCounterableBy(sa) || aiPlayer.equals(topSA.getActivatingPlayer())) {
                     return false;
                 }
                 if (sa.canTargetSpellAbility(topSA)) {

--- a/forge-ai/src/main/java/forge/ai/ability/CounterAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CounterAi.java
@@ -63,7 +63,7 @@ public class CounterAi extends SpellAbilityAi {
 
         if (sa.usesTargeting()) {
             final SpellAbility topSA = ComputerUtilAbility.getTopSpellAbilityOnStack(game, sa);
-            if ((topSA.isSpell() && !topSA.getHostCard().isCounterableBy(sa)) || ai.getYourTeam().contains(topSA.getActivatingPlayer())) {
+            if ((topSA.isSpell() && !topSA.isCounterableBy(sa)) || ai.getYourTeam().contains(topSA.getActivatingPlayer())) {
                 // might as well check for player's friendliness
                 return false;
             } else if (sa.hasParam("ConditionWouldDestroy") && !CounterEffect.checkForConditionWouldDestroy(sa, topSA)) {
@@ -324,7 +324,7 @@ public class CounterAi extends SpellAbilityAi {
                 leastBadOption = tgtSA;
             }
 
-            if ((tgtSA.isSpell() && !tgtSA.getHostCard().isCounterableBy(sa)) ||
+            if ((tgtSA.isSpell() && !tgtSA.isCounterableBy(sa)) ||
                 tgtSA.getActivatingPlayer() == ai ||
                 !tgtSA.getActivatingPlayer().isOpponentOf(ai)) {
                 // Is this a "better" least bad option

--- a/forge-ai/src/main/java/forge/ai/ability/CounterAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CounterAi.java
@@ -19,7 +19,6 @@ import forge.game.Game;
 import forge.game.ability.AbilityUtils;
 import forge.game.ability.ApiType;
 import forge.game.card.Card;
-import forge.game.card.CardFactoryUtil;
 import forge.game.cost.Cost;
 import forge.game.cost.CostDiscard;
 import forge.game.cost.CostExile;
@@ -64,7 +63,7 @@ public class CounterAi extends SpellAbilityAi {
 
         if (sa.usesTargeting()) {
             final SpellAbility topSA = ComputerUtilAbility.getTopSpellAbilityOnStack(game, sa);
-            if ((topSA.isSpell() && !CardFactoryUtil.isCounterableBy(topSA.getHostCard(), sa)) || ai.getYourTeam().contains(topSA.getActivatingPlayer())) {
+            if ((topSA.isSpell() && !topSA.getHostCard().isCounterableBy(sa)) || ai.getYourTeam().contains(topSA.getActivatingPlayer())) {
                 // might as well check for player's friendliness
                 return false;
             } else if (sa.hasParam("ConditionWouldDestroy") && !CounterEffect.checkForConditionWouldDestroy(sa, topSA)) {
@@ -325,7 +324,7 @@ public class CounterAi extends SpellAbilityAi {
                 leastBadOption = tgtSA;
             }
 
-            if ((tgtSA.isSpell() && !CardFactoryUtil.isCounterableBy(tgtSA.getHostCard(), sa)) ||
+            if ((tgtSA.isSpell() && !tgtSA.getHostCard().isCounterableBy(sa)) ||
                 tgtSA.getActivatingPlayer() == ai ||
                 !tgtSA.getActivatingPlayer().isOpponentOf(ai)) {
                 // Is this a "better" least bad option

--- a/forge-game/src/main/java/forge/game/ability/AbilityKey.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityKey.java
@@ -132,7 +132,6 @@ public enum AbilityKey {
     SurveilNum("SurveilNum"),
     Target("Target"),
     Targets("Targets"),
-    TgtSA("TgtSA"),
     Token("Token"),
     TokenNum("TokenNum"),
     Vehicle("Vehicle"),

--- a/forge-game/src/main/java/forge/game/ability/effects/CounterEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CounterEffect.java
@@ -100,7 +100,7 @@ public class CounterEffect extends SpellAbilityEffect {
                 sa.getHostCard().addRemembered(tgtSACard);
             }
 
-            if (tgtSA.isSpell() && !tgtSACard.isCounterableBy(sa)) {
+            if (tgtSA.isSpell() && !tgtSA.isCounterableBy(sa)) {
                 continue;
             }
 
@@ -109,7 +109,7 @@ public class CounterEffect extends SpellAbilityEffect {
                 continue;
             }
 
-            if (sa.hasParam("CounterNoManaSpell") && tgtSA.getTotalManaSpent() != 0) {
+            if (sa.hasParam("CounterNoManaSpell") && tgtSA.isSpell() && tgtSA.getTotalManaSpent() != 0) {
                 continue;
             }
 
@@ -276,8 +276,8 @@ public class CounterEffect extends SpellAbilityEffect {
 
         // Run any applicable replacement effects.
         final Map<AbilityKey, Object> repParams = AbilityKey.mapFromAffected(tgtSA.getHostCard());
-        repParams.put(AbilityKey.TgtSA, tgtSA);
-        repParams.put(AbilityKey.Cause, srcSA.getHostCard());
+        repParams.put(AbilityKey.SpellAbility, tgtSA);
+        repParams.put(AbilityKey.Cause, srcSA);
         if (game.getReplacementHandler().run(ReplacementType.Counter, repParams) != ReplacementResult.NotReplaced) {
             return false;
         }
@@ -329,7 +329,7 @@ public class CounterEffect extends SpellAbilityEffect {
         // Run triggers
         final Map<AbilityKey, Object> runParams = AbilityKey.mapFromCard(c);
         runParams.put(AbilityKey.Player, tgtSA.getActivatingPlayer());
-        runParams.put(AbilityKey.Cause, srcSA.getHostCard());
+        runParams.put(AbilityKey.Cause, srcSA);
         runParams.put(AbilityKey.CounteredSA, tgtSA);
         game.getTriggerHandler().runTrigger(TriggerType.Countered, runParams, false);
 

--- a/forge-game/src/main/java/forge/game/ability/effects/CounterEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CounterEffect.java
@@ -100,7 +100,7 @@ public class CounterEffect extends SpellAbilityEffect {
                 sa.getHostCard().addRemembered(tgtSACard);
             }
 
-            if (tgtSA.isSpell() && !CardFactoryUtil.isCounterableBy(tgtSACard, sa)) {
+            if (tgtSA.isSpell() && !tgtSACard.isCounterableBy(sa)) {
                 continue;
             }
 

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -2076,12 +2076,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
         final StringBuilder sbLong = new StringBuilder();
 
         for (String keyword : getHiddenExtrinsicKeywords()) {
-            if (keyword.startsWith("CantBeCounteredBy")) {
-                final String[] p = keyword.split(":");
-                sbLong.append(p[2]).append("\r\n");
-            } else {
-                sbLong.append(keyword).append("\r\n");
-            }
+            sbLong.append(keyword).append("\r\n");
         }
         if (sb.length() > 0) {
             sb.append("\r\n");
@@ -2107,10 +2102,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
         for (KeywordInterface inst : keywords) {
             String keyword = inst.getOriginal();
             try {
-                if (keyword.startsWith("CantBeCounteredBy")) {
-                    final String[] p = keyword.split(":");
-                    sbLong.append(p[2]).append("\r\n");
-                } else if (keyword.startsWith("etbCounter")) {
+                if (keyword.startsWith("etbCounter")) {
                     final String[] p = keyword.split(":");
                     final StringBuilder s = new StringBuilder();
                     if (p.length > 4) {
@@ -2925,7 +2917,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
                     sbCost.append(cost.toSimpleString());
                     sbAfter.append(sbCost).append(" (").append(inst.getReminderText()).append(")");
                     sbAfter.append("\r\n");
-                } else if (keyword.equals("CARDNAME can't be countered.") || keyword.equals("This spell can't be " +
+                } else if (keyword.equals("This spell can't be " +
                         "countered.") || keyword.equals("Remove CARDNAME from your deck before playing if you're not " +
                         "playing for ante.")) {
                     sbBefore.append(keyword);
@@ -5234,7 +5226,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
     }
 
     public final boolean isSpell() {
-        return isInstant() || isSorcery() || (isAura() && !isInZone((ZoneType.Battlefield)));
+        return isInZone(ZoneType.Stack) || isInstant() || isSorcery() || (isAura() && !isInZone(ZoneType.Battlefield));
     }
 
     public final boolean isLand()       { return getType().isLand(); }

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -51,7 +51,6 @@ import forge.game.player.PlayerCollection;
 import forge.game.replacement.ReplaceMoved;
 import forge.game.replacement.ReplacementEffect;
 import forge.game.replacement.ReplacementHandler;
-import forge.game.replacement.ReplacementLayer;
 import forge.game.replacement.ReplacementResult;
 import forge.game.replacement.ReplacementType;
 import forge.game.spellability.*;
@@ -5227,7 +5226,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
     }
 
     public final boolean isSpell() {
-        return isInZone(ZoneType.Stack) || isInstant() || isSorcery() || (isAura() && !isInZone(ZoneType.Battlefield));
+        return isInstant() || isSorcery() || (isAura() && !isInZone(ZoneType.Battlefield));
     }
 
     public final boolean isLand()       { return getType().isLand(); }
@@ -7689,12 +7688,5 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
             return true;
         }
         return StaticAbilityWitherDamage.isWitherDamage(this);
-    }
-
-    public boolean isCounterableBy(final SpellAbility sa) {
-        final Map<AbilityKey, Object> repParams = AbilityKey.mapFromAffected(this);
-        repParams.put(AbilityKey.Cause, sa);
-        List<ReplacementEffect> list = getGame().getReplacementHandler().getReplacementList(ReplacementType.Counter, repParams, ReplacementLayer.CantHappen);
-        return list.isEmpty();
     }
 }

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -2917,8 +2917,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
                     sbCost.append(cost.toSimpleString());
                     sbAfter.append(sbCost).append(" (").append(inst.getReminderText()).append(")");
                     sbAfter.append("\r\n");
-                } else if (keyword.equals("This spell can't be " +
-                        "countered.") || keyword.equals("Remove CARDNAME from your deck before playing if you're not " +
+                } else if (keyword.equals("Remove CARDNAME from your deck before playing if you're not " +
                         "playing for ante.")) {
                     sbBefore.append(keyword);
                     sbBefore.append("\r\n");

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -7692,10 +7692,6 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
     }
 
     public boolean isCounterableBy(final SpellAbility sa) {
-        if (hasKeyword("This spell can't be countered.")) {
-            return false;
-        }
-
         final Map<AbilityKey, Object> repParams = AbilityKey.mapFromAffected(this);
         repParams.put(AbilityKey.Cause, sa);
         List<ReplacementEffect> list = getGame().getReplacementHandler().getReplacementList(ReplacementType.Counter, repParams, ReplacementLayer.CantHappen);

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -51,6 +51,7 @@ import forge.game.player.PlayerCollection;
 import forge.game.replacement.ReplaceMoved;
 import forge.game.replacement.ReplacementEffect;
 import forge.game.replacement.ReplacementHandler;
+import forge.game.replacement.ReplacementLayer;
 import forge.game.replacement.ReplacementResult;
 import forge.game.replacement.ReplacementType;
 import forge.game.spellability.*;
@@ -7688,5 +7689,16 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
             return true;
         }
         return StaticAbilityWitherDamage.isWitherDamage(this);
+    }
+
+    public boolean isCounterableBy(final SpellAbility sa) {
+        if (hasKeyword("This spell can't be countered.")) {
+            return false;
+        }
+
+        final Map<AbilityKey, Object> repParams = AbilityKey.mapFromAffected(this);
+        repParams.put(AbilityKey.Cause, sa);
+        List<ReplacementEffect> list = getGame().getReplacementHandler().getReplacementList(ReplacementType.Counter, repParams, ReplacementLayer.CantHappen);
+        return list.isEmpty();
     }
 }

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -63,7 +63,6 @@ import forge.game.player.Player;
 import forge.game.replacement.ReplacementEffect;
 import forge.game.replacement.ReplacementHandler;
 import forge.game.replacement.ReplacementLayer;
-import forge.game.replacement.ReplacementType;
 import forge.game.spellability.AbilityStatic;
 import forge.game.spellability.AbilitySub;
 import forge.game.spellability.AlternativeCost;

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -245,25 +245,6 @@ public class CardFactoryUtil {
 
     /**
      * <p>
-     * isCounterable.
-     * </p>
-     *
-     * @param c
-     *            a {@link forge.game.card.Card} object.
-     * @return a boolean.
-     */
-    public static boolean isCounterable(final Card c) {
-        if (c.hasKeyword("CARDNAME can't be countered.") || c.hasKeyword("This spell can't be countered.")) {
-            return false;
-        }
-
-        final Map<AbilityKey, Object> repParams = AbilityKey.mapFromAffected(c);
-        List<ReplacementEffect> list = c.getGame().getReplacementHandler().getReplacementList(ReplacementType.Counter, repParams, ReplacementLayer.CantHappen);
-        return list.isEmpty();
-    }
-
-    /**
-     * <p>
      * isCounterableBy.
      * </p>
      *
@@ -274,19 +255,14 @@ public class CardFactoryUtil {
      * @return a boolean.
      */
     public static boolean isCounterableBy(final Card c, final SpellAbility sa) {
-        if (!isCounterable(c)) {
+        if (c.hasKeyword("This spell can't be countered.")) {
             return false;
         }
 
-        for (String o : c.getHiddenExtrinsicKeywords()) {
-            if (o.startsWith("CantBeCounteredBy")) {
-                final String[] m = o.split(":");
-                if (sa.isValid(m[1].split(","), c.getController(), c, null)) {
-                    return false;
-                }
-            }
-        }
-        return true;
+        final Map<AbilityKey, Object> repParams = AbilityKey.mapFromAffected(c);
+        repParams.put(AbilityKey.Cause, sa);
+        List<ReplacementEffect> list = c.getGame().getReplacementHandler().getReplacementList(ReplacementType.Counter, repParams, ReplacementLayer.CantHappen);
+        return list.isEmpty();
     }
 
     /**

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -245,28 +245,6 @@ public class CardFactoryUtil {
 
     /**
      * <p>
-     * isCounterableBy.
-     * </p>
-     *
-     * @param c
-     *            a {@link forge.game.card.Card} object.
-     * @param sa
-     *            the sa
-     * @return a boolean.
-     */
-    public static boolean isCounterableBy(final Card c, final SpellAbility sa) {
-        if (c.hasKeyword("This spell can't be countered.")) {
-            return false;
-        }
-
-        final Map<AbilityKey, Object> repParams = AbilityKey.mapFromAffected(c);
-        repParams.put(AbilityKey.Cause, sa);
-        List<ReplacementEffect> list = c.getGame().getReplacementHandler().getReplacementList(ReplacementType.Counter, repParams, ReplacementLayer.CantHappen);
-        return list.isEmpty();
-    }
-
-    /**
-     * <p>
      * countOccurrences.
      * </p>
      *

--- a/forge-game/src/main/java/forge/game/replacement/ReplaceCounter.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplaceCounter.java
@@ -47,10 +47,10 @@ public class ReplaceCounter extends ReplacementEffect {
         if (!matchesValidParam("ValidCard", runParams.get(AbilityKey.Affected))) {
             return false;
         }
-        if (!matchesValidParam("ValidCause", runParams.get(AbilityKey.Cause))) {
+        if (!matchesValidParam("ValidSA", runParams.get(AbilityKey.SpellAbility))) {
             return false;
         }
-        if (!matchesValidParam("ValidType", runParams.get(AbilityKey.TgtSA))) {
+        if (!matchesValidParam("ValidCause", runParams.get(AbilityKey.Cause))) {
             return false;
         }
         return true;

--- a/forge-game/src/main/java/forge/game/replacement/ReplaceCounter.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplaceCounter.java
@@ -50,13 +50,8 @@ public class ReplaceCounter extends ReplacementEffect {
         if (!matchesValidParam("ValidCause", runParams.get(AbilityKey.Cause))) {
             return false;
         }
-
-        if (hasParam("ValidType")) {
-            final SpellAbility spellAbility = (SpellAbility) runParams.get(AbilityKey.TgtSA);
-            String type = getParam("ValidType");
-            if (type.equals("Spell") && !spellAbility.isSpell()) {
-                return false;
-            }
+        if (!matchesValidParam("ValidType", runParams.get(AbilityKey.TgtSA))) {
+            return false;
         }
         return true;
     }

--- a/forge-game/src/main/java/forge/game/spellability/Spell.java
+++ b/forge-game/src/main/java/forge/game/spellability/Spell.java
@@ -17,17 +17,24 @@
  */
 package forge.game.spellability;
 
+import java.util.List;
+import java.util.Map;
+
 import org.apache.commons.lang3.ObjectUtils;
 
 import forge.card.CardStateName;
 import forge.card.mana.ManaCost;
 import forge.game.Game;
+import forge.game.ability.AbilityKey;
 import forge.game.card.Card;
 import forge.game.card.CardFactory;
 import forge.game.card.CardUtil;
 import forge.game.cost.Cost;
 import forge.game.cost.CostPayment;
 import forge.game.player.Player;
+import forge.game.replacement.ReplacementEffect;
+import forge.game.replacement.ReplacementLayer;
+import forge.game.replacement.ReplacementType;
 import forge.game.staticability.StaticAbilityCantBeCast;
 import forge.game.zone.ZoneType;
 
@@ -204,5 +211,13 @@ public abstract class Spell extends SpellAbility implements java.io.Serializable
         }
 
         return lkicheck ? source : null;
+    }
+
+    public boolean isCounterableBy(final SpellAbility sa) {
+        final Map<AbilityKey, Object> repParams = AbilityKey.mapFromAffected(getHostCard());
+        repParams.put(AbilityKey.SpellAbility, this);
+        repParams.put(AbilityKey.Cause, sa);
+        List<ReplacementEffect> list = getHostCard().getGame().getReplacementHandler().getReplacementList(ReplacementType.Counter, repParams, ReplacementLayer.CantHappen);
+        return list.isEmpty();
     }
 }

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
@@ -2533,4 +2533,8 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
         }
         return true;
     }
+
+    public boolean isCounterableBy(SpellAbility sa) {
+        return true;
+    }
 }

--- a/forge-gui/res/adventure/common/custom_cards/ghaltas_presence.txt
+++ b/forge-gui/res/adventure/common/custom_cards/ghaltas_presence.txt
@@ -2,6 +2,6 @@ Name:Ghalta's Presence
 ManaCost:no cost
 Colors:Green
 Types:Enchantment
-S:Mode$ Continuous | Affected$ Card | AddHiddenKeyword$ This spell can't be countered. | AffectedZone$ Stack | EffectZone$ Command | Description$ Spells can't be countered.
+R:Event$ Counter | ValidCard$ Spell | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Spells can't be countered.
 S:Mode$ RaiseCost | ValidCard$ Card.nonCreature+nonBattle | Type$ Spell | Activator$ Opponent | EffectZone$ Command | Amount$ 2 | Description$ Noncreature, nonbattle spells your opponent cast cost {2} more to cast.
 Oracle:Spells can't be countered.\nNoncreature, nonbattle spells your opponent cast cost {2} more to cast.

--- a/forge-gui/res/adventure/common/custom_cards/ghaltas_presence.txt
+++ b/forge-gui/res/adventure/common/custom_cards/ghaltas_presence.txt
@@ -2,6 +2,6 @@ Name:Ghalta's Presence
 ManaCost:no cost
 Colors:Green
 Types:Enchantment
-R:Event$ Counter | ValidCard$ Spell | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Spells can't be countered.
+R:Event$ Counter | ValidCard$ Card | ValidSA$ Spell | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Spells can't be countered.
 S:Mode$ RaiseCost | ValidCard$ Card.nonCreature+nonBattle | Type$ Spell | Activator$ Opponent | EffectZone$ Command | Amount$ 2 | Description$ Noncreature, nonbattle spells your opponent cast cost {2} more to cast.
 Oracle:Spells can't be countered.\nNoncreature, nonbattle spells your opponent cast cost {2} more to cast.

--- a/forge-gui/res/cardsfolder/a/abrupt_decay.txt
+++ b/forge-gui/res/cardsfolder/a/abrupt_decay.txt
@@ -1,6 +1,6 @@
 Name:Abrupt Decay
 ManaCost:B G
 Types:Instant
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ Destroy | Cost$ B G | ValidTgts$ Permanent.nonLand+cmcLE3 | TgtPrompt$ Select target nonland permanent with mana value 3 or less | SpellDescription$ Destroy target nonland permanent with mana value 3 or less.
 Oracle:This spell can't be countered.\nDestroy target nonland permanent with mana value 3 or less.

--- a/forge-gui/res/cardsfolder/a/abrupt_decay.txt
+++ b/forge-gui/res/cardsfolder/a/abrupt_decay.txt
@@ -1,6 +1,6 @@
 Name:Abrupt Decay
 ManaCost:B G
 Types:Instant
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ Destroy | Cost$ B G | ValidTgts$ Permanent.nonLand+cmcLE3 | TgtPrompt$ Select target nonland permanent with mana value 3 or less | SpellDescription$ Destroy target nonland permanent with mana value 3 or less.
 Oracle:This spell can't be countered.\nDestroy target nonland permanent with mana value 3 or less.

--- a/forge-gui/res/cardsfolder/a/akroma_angel_of_fury.txt
+++ b/forge-gui/res/cardsfolder/a/akroma_angel_of_fury.txt
@@ -8,5 +8,5 @@ K:Protection from white
 K:Protection from blue
 A:AB$ Pump | Cost$ R | Defined$ Self | NumAtt$ 1 | SpellDescription$ CARDNAME gets +1/+0 until end of turn.
 K:Morph:3 R R R
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 Oracle:This spell can't be countered.\nFlying, trample, protection from white and from blue\n{R}: Akroma, Angel of Fury gets +1/+0 until end of turn.\nMorph {3}{R}{R}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)

--- a/forge-gui/res/cardsfolder/a/akroma_angel_of_fury.txt
+++ b/forge-gui/res/cardsfolder/a/akroma_angel_of_fury.txt
@@ -8,5 +8,5 @@ K:Protection from white
 K:Protection from blue
 A:AB$ Pump | Cost$ R | Defined$ Self | NumAtt$ 1 | SpellDescription$ CARDNAME gets +1/+0 until end of turn.
 K:Morph:3 R R R
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 Oracle:This spell can't be countered.\nFlying, trample, protection from white and from blue\n{R}: Akroma, Angel of Fury gets +1/+0 until end of turn.\nMorph {3}{R}{R}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)

--- a/forge-gui/res/cardsfolder/a/allosaurus_shepherd.txt
+++ b/forge-gui/res/cardsfolder/a/allosaurus_shepherd.txt
@@ -2,7 +2,7 @@ Name:Allosaurus Shepherd
 ManaCost:G
 Types:Creature Elf Shaman
 PT:1/1
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
-R:Event$ Counter | ValidCard$ Spell.Green+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Green spells you control can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidSA$ Spell.Green+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Green spells you control can't be countered.
 A:AB$ AnimateAll | Cost$ 4 G G | ValidCards$ Creature.Elf+YouCtrl | Power$ 5 | Toughness$ 5 | Types$ Dinosaur | StackDescription$ SpellDescription | SpellDescription$ Until end of turn, each Elf creature you control has base power and toughness 5/5 and becomes a Dinosaur in addition to its other creature types.
 Oracle:Allosaurus Shepherd can't be countered.\nGreen spells you control can't be countered.\n{4}{G}{G}: Until end of turn, each Elf creature you control has base power and toughness 5/5 and becomes a Dinosaur in addition to its other creature types.

--- a/forge-gui/res/cardsfolder/a/allosaurus_shepherd.txt
+++ b/forge-gui/res/cardsfolder/a/allosaurus_shepherd.txt
@@ -3,6 +3,6 @@ ManaCost:G
 Types:Creature Elf Shaman
 PT:1/1
 R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
-S:Mode$ Continuous | Affected$ Card.Green+YouCtrl | AffectedZone$ Stack | AddHiddenKeyword$ This spell can't be countered. | Description$ Green spells you control can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Green+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Green spells you control can't be countered.
 A:AB$ AnimateAll | Cost$ 4 G G | ValidCards$ Creature.Elf+YouCtrl | Power$ 5 | Toughness$ 5 | Types$ Dinosaur | StackDescription$ SpellDescription | SpellDescription$ Until end of turn, each Elf creature you control has base power and toughness 5/5 and becomes a Dinosaur in addition to its other creature types.
 Oracle:Allosaurus Shepherd can't be countered.\nGreen spells you control can't be countered.\n{4}{G}{G}: Until end of turn, each Elf creature you control has base power and toughness 5/5 and becomes a Dinosaur in addition to its other creature types.

--- a/forge-gui/res/cardsfolder/a/allosaurus_shepherd.txt
+++ b/forge-gui/res/cardsfolder/a/allosaurus_shepherd.txt
@@ -2,7 +2,7 @@ Name:Allosaurus Shepherd
 ManaCost:G
 Types:Creature Elf Shaman
 PT:1/1
-K:CARDNAME can't be countered.
-S:Mode$ Continuous | Affected$ Card.Green+YouCtrl | AffectedZone$ Stack | AddHiddenKeyword$ CARDNAME can't be countered. | Description$ Green spells you control can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+S:Mode$ Continuous | Affected$ Card.Green+YouCtrl | AffectedZone$ Stack | AddHiddenKeyword$ This spell can't be countered. | Description$ Green spells you control can't be countered.
 A:AB$ AnimateAll | Cost$ 4 G G | ValidCards$ Creature.Elf+YouCtrl | Power$ 5 | Toughness$ 5 | Types$ Dinosaur | StackDescription$ SpellDescription | SpellDescription$ Until end of turn, each Elf creature you control has base power and toughness 5/5 and becomes a Dinosaur in addition to its other creature types.
 Oracle:Allosaurus Shepherd can't be countered.\nGreen spells you control can't be countered.\n{4}{G}{G}: Until end of turn, each Elf creature you control has base power and toughness 5/5 and becomes a Dinosaur in addition to its other creature types.

--- a/forge-gui/res/cardsfolder/a/altered_ego.txt
+++ b/forge-gui/res/cardsfolder/a/altered_ego.txt
@@ -2,7 +2,7 @@ Name:Altered Ego
 ManaCost:X 2 G U
 Types:Creature Shapeshifter
 PT:0/0
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 K:ETBReplacement:Copy:DBCopy:Optional
 SVar:DBCopy:DB$ Clone | Choices$ Creature.Other | SubAbility$ DBAddCounter | SpellDescription$ You may have CARDNAME enter the battlefield as a copy of any creature on the battlefield, except it enters with X additional +1/+1 counters on it.
 SVar:DBAddCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | ETB$ True | CounterNum$ X

--- a/forge-gui/res/cardsfolder/a/altered_ego.txt
+++ b/forge-gui/res/cardsfolder/a/altered_ego.txt
@@ -2,7 +2,7 @@ Name:Altered Ego
 ManaCost:X 2 G U
 Types:Creature Shapeshifter
 PT:0/0
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 K:ETBReplacement:Copy:DBCopy:Optional
 SVar:DBCopy:DB$ Clone | Choices$ Creature.Other | SubAbility$ DBAddCounter | SpellDescription$ You may have CARDNAME enter the battlefield as a copy of any creature on the battlefield, except it enters with X additional +1/+1 counters on it.
 SVar:DBAddCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | ETB$ True | CounterNum$ X

--- a/forge-gui/res/cardsfolder/a/autumns_veil.txt
+++ b/forge-gui/res/cardsfolder/a/autumns_veil.txt
@@ -1,8 +1,8 @@
 Name:Autumn's Veil
 ManaCost:G
 Types:Instant
-A:SP$ Effect | StaticAbilities$ AntiMagic,STCantBeTarget | SpellDescription$ Spells you control can't be countered by blue or black spells this turn, and creatures you control can't be the targets of blue or black spells this turn.
-SVar:AntiMagic:Mode$ Continuous | Affected$ Card.YouCtrl | AffectedZone$ Stack | EffectZone$ Command | AddHiddenKeyword$ CantBeCounteredBy:Spell.Blue,Spell.Black:CARDNAME can't be countered by blue or black spells. | Description$ Spells you control can't be countered by blue or black spells this turn.
+A:SP$ Effect | ReplacementEffects$ AntiMagic | StaticAbilities$ STCantBeTarget | SpellDescription$ Spells you control can't be countered by blue or black spells this turn, and creatures you control can't be the targets of blue or black spells this turn.
+SVar:AntiMagic:Event$ Counter | ValidCard$ Spell.YouCtrl | ValidCause$ Spell.Blue,Spell.Black | Layer$ CantHappen | Description$ Spells you control can't be countered by blue or black spells this turn.
 SVar:STCantBeTarget:Mode$ CantTarget | ValidCard$ Creature.YouCtrl | ValidSource$ Card.Blue,Card.Black | ValidSA$ Spell | EffectZone$ Command | Description$ Creatures you control can't be the targets of blue or black spells this turn.
 AI:RemoveDeck:All
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/a/autumns_veil.txt
+++ b/forge-gui/res/cardsfolder/a/autumns_veil.txt
@@ -2,7 +2,7 @@ Name:Autumn's Veil
 ManaCost:G
 Types:Instant
 A:SP$ Effect | ReplacementEffects$ AntiMagic | StaticAbilities$ STCantBeTarget | SpellDescription$ Spells you control can't be countered by blue or black spells this turn, and creatures you control can't be the targets of blue or black spells this turn.
-SVar:AntiMagic:Event$ Counter | ValidCard$ Spell.YouCtrl | ValidCause$ Spell.Blue,Spell.Black | Layer$ CantHappen | Description$ Spells you control can't be countered by blue or black spells this turn.
+SVar:AntiMagic:Event$ Counter | ValidSA$ Spell.YouCtrl | ValidCause$ Spell.Blue,Spell.Black | Layer$ CantHappen | Description$ Spells you control can't be countered by blue or black spells this turn.
 SVar:STCantBeTarget:Mode$ CantTarget | ValidCard$ Creature.YouCtrl | ValidSource$ Card.Blue,Card.Black | ValidSA$ Spell | EffectZone$ Command | Description$ Creatures you control can't be the targets of blue or black spells this turn.
 AI:RemoveDeck:All
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/b/banefire.txt
+++ b/forge-gui/res/cardsfolder/b/banefire.txt
@@ -1,8 +1,8 @@
 Name:Banefire
 ManaCost:X R
 Types:Sorcery
-A:SP$ DealDamage | Cost$ X R | ValidTgts$ Any | NumDmg$ X | ConditionCheckSVar$ X | ConditionSVarCompare$ LT5 | SubAbility$ BanefulDmg | SpellDescription$ CARDNAME deals X damage to any target.
-SVar:BanefulDmg:DB$ DealDamage | Defined$ Targeted | NumDmg$ X | NoPrevention$ True | ConditionCheckSVar$ X | ConditionSVarCompare$ GE5 | StackDescription$ If X is 5 or more, CARDNAME can't be countered by spells or abilities and the damage can't be prevented.
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | AddHiddenKeyword$ This spell can't be countered. | CheckSVar$ X | SVarCompare$ GE5 | Description$ If X is 5 or more, CARDNAME can't be countered by spells or abilities and the damage can't be prevented.
+A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to any target.
+S:Mode$ CantPreventDamage | ValidSource$ Spell.Self | EffectZone$ Stack | CheckSVar$ X | SVarCompare$ GE5 | Description$ If X is 5 or more, CARDNAME can't be countered by spells or abilities and the damage can't be prevented.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | CheckSVar$ X | SVarCompare$ GE5 | Secondary$ True | Description$ If X is 5 or more, CARDNAME can't be countered by spells or abilities and the damage can't be prevented.
 SVar:X:Count$xPaid
 Oracle:Banefire deals X damage to any target.\nIf X is 5 or more, this spell can't be countered and the damage can't be prevented.

--- a/forge-gui/res/cardsfolder/b/banefire.txt
+++ b/forge-gui/res/cardsfolder/b/banefire.txt
@@ -3,6 +3,6 @@ ManaCost:X R
 Types:Sorcery
 A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to any target.
 S:Mode$ CantPreventDamage | ValidSource$ Spell.Self | EffectZone$ Stack | CheckSVar$ X | SVarCompare$ GE5 | Description$ If X is 5 or more, CARDNAME can't be countered by spells or abilities and the damage can't be prevented.
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | CheckSVar$ X | SVarCompare$ GE5 | Secondary$ True | Description$ If X is 5 or more, CARDNAME can't be countered by spells or abilities and the damage can't be prevented.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | CheckSVar$ X | SVarCompare$ GE5 | Secondary$ True | Description$ If X is 5 or more, CARDNAME can't be countered by spells or abilities and the damage can't be prevented.
 SVar:X:Count$xPaid
 Oracle:Banefire deals X damage to any target.\nIf X is 5 or more, this spell can't be countered and the damage can't be prevented.

--- a/forge-gui/res/cardsfolder/b/baral_chief_of_compliance.txt
+++ b/forge-gui/res/cardsfolder/b/baral_chief_of_compliance.txt
@@ -3,7 +3,7 @@ ManaCost:1 U
 Types:Legendary Creature Human Wizard
 PT:1/3
 S:Mode$ ReduceCost | ValidCard$ Instant,Sorcery | Type$ Spell | Activator$ You | Amount$ 1 | Description$ Instant and sorcery spells you cast cost {1} less to cast.
-T:Mode$ Countered | ValidCause$ Card.YouCtrl,Emblem.YouCtrl | ValidCard$ Card | ValidType$ Spell | TriggerZones$ Battlefield | Execute$ TrigLoot | TriggerDescription$ Whenever a spell or ability you control counters a spell, you may draw a card. If you do, discard a card.
+T:Mode$ Countered | ValidCause$ SpellAbility.YouCtrl | ValidSA$ Spell | TriggerZones$ Battlefield | Execute$ TrigLoot | TriggerDescription$ Whenever a spell or ability you control counters a spell, you may draw a card. If you do, discard a card.
 SVar:TrigLoot:AB$ Discard | Defined$ You | Mode$ TgtChoose | NumCards$ 1 | Cost$ Draw<1/You>
 DeckHints:Type$Instant|Sorcery
 Oracle:Instant and sorcery spells you cast cost {1} less to cast.\nWhenever a spell or ability you control counters a spell, you may draw a card. If you do, discard a card.

--- a/forge-gui/res/cardsfolder/b/blurred_mongoose.txt
+++ b/forge-gui/res/cardsfolder/b/blurred_mongoose.txt
@@ -2,6 +2,6 @@ Name:Blurred Mongoose
 ManaCost:1 G
 Types:Creature Mongoose
 PT:2/1
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Shroud
 Oracle:This spell can't be countered.\nShroud (This creature can't be the target of spells or abilities.)

--- a/forge-gui/res/cardsfolder/b/blurred_mongoose.txt
+++ b/forge-gui/res/cardsfolder/b/blurred_mongoose.txt
@@ -2,6 +2,6 @@ Name:Blurred Mongoose
 ManaCost:1 G
 Types:Creature Mongoose
 PT:2/1
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Shroud
 Oracle:This spell can't be countered.\nShroud (This creature can't be the target of spells or abilities.)

--- a/forge-gui/res/cardsfolder/b/bound_determined.txt
+++ b/forge-gui/res/cardsfolder/b/bound_determined.txt
@@ -16,6 +16,6 @@ Name:Determined
 ManaCost:G U
 Types:Instant
 A:SP$ Effect | ReplacementEffects$ CantbeCountered | SubAbility$ DBDraw | SpellDescription$ Other spells you control can't be countered this turn. Draw a card.
-SVar:CantbeCountered:Event$ Counter | ValidCard$ Spell.YouCtrl | Layer$ CantHappen | Description$ Other spells you control can't be countered this turn.
+SVar:CantbeCountered:Event$ Counter | ValidSA$ Spell.YouCtrl | Layer$ CantHappen | Description$ Other spells you control can't be countered this turn.
 SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1
 Oracle:Other spells you control can't be countered this turn.\nDraw a card.

--- a/forge-gui/res/cardsfolder/b/bound_determined.txt
+++ b/forge-gui/res/cardsfolder/b/bound_determined.txt
@@ -16,6 +16,6 @@ Name:Determined
 ManaCost:G U
 Types:Instant
 A:SP$ Effect | Cost$ G U | StaticAbilities$ STCantbeCountered | SubAbility$ DBDraw | SpellDescription$ Other spells you control can't be countered this turn. Draw a card.
-SVar:STCantbeCountered:Mode$ Continuous | EffectZone$ Command | AffectedZone$ Stack | Affected$ Card.YouCtrl | AddHiddenKeyword$ CARDNAME can't be countered. | Description$ Other spells you control can't be countered this turn.
+SVar:STCantbeCountered:Mode$ Continuous | EffectZone$ Command | AffectedZone$ Stack | Affected$ Card.YouCtrl | AddHiddenKeyword$ This spell can't be countered. | Description$ Other spells you control can't be countered this turn.
 SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1
 Oracle:Other spells you control can't be countered this turn.\nDraw a card.

--- a/forge-gui/res/cardsfolder/b/bound_determined.txt
+++ b/forge-gui/res/cardsfolder/b/bound_determined.txt
@@ -1,7 +1,7 @@
 Name:Bound
 ManaCost:3 B G
 Types:Instant
-A:SP$ Sacrifice | Cost$ 3 B G | SacValid$ Creature | RememberSacrificed$ True | SubAbility$ DBReturnChoose | SpellDescription$ Sacrifice a creature. Return up to X cards from your graveyard to your hand, where X is the number of colors that creature was. Exile this card.
+A:SP$ Sacrifice | SacValid$ Creature | RememberSacrificed$ True | SubAbility$ DBReturnChoose | SpellDescription$ Sacrifice a creature. Return up to X cards from your graveyard to your hand, where X is the number of colors that creature was. Exile this card.
 SVar:DBReturnChoose:DB$ ChooseCard | Defined$ You | Choices$ Card.YouOwn | ChoiceZone$ Graveyard | Amount$ X | SubAbility$ DBReturn
 SVar:DBReturn:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | Defined$ ChosenCard | SubAbility$ ExileSelf
 SVar:ExileSelf:DB$ ChangeZone | Origin$ Stack | Destination$ Exile | Defined$ Self | SubAbility$ DBCleanup
@@ -15,7 +15,7 @@ ALTERNATE
 Name:Determined
 ManaCost:G U
 Types:Instant
-A:SP$ Effect | Cost$ G U | StaticAbilities$ STCantbeCountered | SubAbility$ DBDraw | SpellDescription$ Other spells you control can't be countered this turn. Draw a card.
-SVar:STCantbeCountered:Mode$ Continuous | EffectZone$ Command | AffectedZone$ Stack | Affected$ Card.YouCtrl | AddHiddenKeyword$ This spell can't be countered. | Description$ Other spells you control can't be countered this turn.
+A:SP$ Effect | ReplacementEffects$ CantbeCountered | SubAbility$ DBDraw | SpellDescription$ Other spells you control can't be countered this turn. Draw a card.
+SVar:CantbeCountered:Event$ Counter | ValidCard$ Spell.YouCtrl | Layer$ CantHappen | Description$ Other spells you control can't be countered this turn.
 SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1
 Oracle:Other spells you control can't be countered this turn.\nDraw a card.

--- a/forge-gui/res/cardsfolder/c/carnage_tyrant.txt
+++ b/forge-gui/res/cardsfolder/c/carnage_tyrant.txt
@@ -2,7 +2,7 @@ Name:Carnage Tyrant
 ManaCost:4 G G
 Types:Creature Dinosaur
 PT:7/6
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Trample
 K:Hexproof
 Oracle:This spell can't be countered.\nTrample, hexproof

--- a/forge-gui/res/cardsfolder/c/carnage_tyrant.txt
+++ b/forge-gui/res/cardsfolder/c/carnage_tyrant.txt
@@ -2,7 +2,7 @@ Name:Carnage Tyrant
 ManaCost:4 G G
 Types:Creature Dinosaur
 PT:7/6
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Trample
 K:Hexproof
 Oracle:This spell can't be countered.\nTrample, hexproof

--- a/forge-gui/res/cardsfolder/c/chandra_awakened_inferno.txt
+++ b/forge-gui/res/cardsfolder/c/chandra_awakened_inferno.txt
@@ -2,7 +2,7 @@ Name:Chandra, Awakened Inferno
 ManaCost:4 R R
 Types:Legendary Planeswalker Chandra
 Loyalty:6
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:AB$ Effect | Cost$ AddCounter<2/LOYALTY> | Planeswalker$ True | EffectOwner$ Player.Opponent | Name$ Emblem - Chandra, Awakened Inferno | Triggers$ BOTTrig | Duration$ Permanent | AILogic$ Always | SpellDescription$ Each opponent gets an emblem with "At the beginning of your upkeep, this emblem deals 1 damage to you."
 SVar:BOTTrig:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Command | Execute$ ChandraDmg | TriggerDescription$ At the beginning of your upkeep, this emblem deals 1 damage to you.
 SVar:ChandraDmg:DB$ DealDamage | Defined$ TriggeredPlayer | NumDmg$ 1

--- a/forge-gui/res/cardsfolder/c/chandra_awakened_inferno.txt
+++ b/forge-gui/res/cardsfolder/c/chandra_awakened_inferno.txt
@@ -2,7 +2,7 @@ Name:Chandra, Awakened Inferno
 ManaCost:4 R R
 Types:Legendary Planeswalker Chandra
 Loyalty:6
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:AB$ Effect | Cost$ AddCounter<2/LOYALTY> | Planeswalker$ True | EffectOwner$ Player.Opponent | Name$ Emblem - Chandra, Awakened Inferno | Triggers$ BOTTrig | Duration$ Permanent | AILogic$ Always | SpellDescription$ Each opponent gets an emblem with "At the beginning of your upkeep, this emblem deals 1 damage to you."
 SVar:BOTTrig:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Command | Execute$ ChandraDmg | TriggerDescription$ At the beginning of your upkeep, this emblem deals 1 damage to you.
 SVar:ChandraDmg:DB$ DealDamage | Defined$ TriggeredPlayer | NumDmg$ 1

--- a/forge-gui/res/cardsfolder/c/chimil_the_inner_sun.txt
+++ b/forge-gui/res/cardsfolder/c/chimil_the_inner_sun.txt
@@ -1,7 +1,7 @@
 Name:Chimil, the Inner Sun
 ManaCost:6
 Types:Legendary Artifact
-S:Mode$ Continuous | Affected$ Card.YouCtrl | AffectedZone$ Stack | AddHiddenKeyword$ This spell can't be countered. | Description$ Spells you control can't be countered.
+R:Event$ Counter | ValidCard$ Spell.YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Spells you control can't be countered.
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDiscover | TriggerDescription$ At the beginning of your end step, discover 5. (Exile cards from the top of your library until you exile a nonland card with mana value 5 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)
 SVar:TrigDiscover:DB$ Discover | Num$ 5
 Oracle:Spells you control can't be countered.\nAt the beginning of your end step, discover 5. (Exile cards from the top of your library until you exile a nonland card with mana value 5 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)

--- a/forge-gui/res/cardsfolder/c/chimil_the_inner_sun.txt
+++ b/forge-gui/res/cardsfolder/c/chimil_the_inner_sun.txt
@@ -1,7 +1,7 @@
 Name:Chimil, the Inner Sun
 ManaCost:6
 Types:Legendary Artifact
-R:Event$ Counter | ValidCard$ Spell.YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Spells you control can't be countered.
+R:Event$ Counter | ValidSA$ Spell.YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Spells you control can't be countered.
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDiscover | TriggerDescription$ At the beginning of your end step, discover 5. (Exile cards from the top of your library until you exile a nonland card with mana value 5 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)
 SVar:TrigDiscover:DB$ Discover | Num$ 5
 Oracle:Spells you control can't be countered.\nAt the beginning of your end step, discover 5. (Exile cards from the top of your library until you exile a nonland card with mana value 5 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)

--- a/forge-gui/res/cardsfolder/c/chromium_the_mutable.txt
+++ b/forge-gui/res/cardsfolder/c/chromium_the_mutable.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature Elder Dragon
 PT:7/7
 K:Flash
 K:Flying
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:AB$ Animate | Cost$ Discard<1/Card> | Types$ Human | Power$ 1 | Toughness$ 1 | Keywords$ Hexproof | RemoveAllAbilities$ True | RemoveCreatureTypes$ True | SubAbility$ DBUnblockable | SpellDescription$ Until end of turn, CARDNAME becomes a Human with base power and toughness 1/1, loses all abilities, and gains hexproof. It can't be blocked this turn.
 SVar:DBUnblockable:DB$ Effect | ExileOnMoved$ Battlefield | RememberObjects$ Self | StaticAbilities$ Unblockable
 SVar:Unblockable:Mode$ CantBlockBy | ValidAttacker$ Card.IsRemembered | Description$ This creature can't be blocked this turn.

--- a/forge-gui/res/cardsfolder/c/chromium_the_mutable.txt
+++ b/forge-gui/res/cardsfolder/c/chromium_the_mutable.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature Elder Dragon
 PT:7/7
 K:Flash
 K:Flying
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:AB$ Animate | Cost$ Discard<1/Card> | Types$ Human | Power$ 1 | Toughness$ 1 | Keywords$ Hexproof | RemoveAllAbilities$ True | RemoveCreatureTypes$ True | SubAbility$ DBUnblockable | SpellDescription$ Until end of turn, CARDNAME becomes a Human with base power and toughness 1/1, loses all abilities, and gains hexproof. It can't be blocked this turn.
 SVar:DBUnblockable:DB$ Effect | ExileOnMoved$ Battlefield | RememberObjects$ Self | StaticAbilities$ Unblockable
 SVar:Unblockable:Mode$ CantBlockBy | ValidAttacker$ Card.IsRemembered | Description$ This creature can't be blocked this turn.

--- a/forge-gui/res/cardsfolder/c/combust.txt
+++ b/forge-gui/res/cardsfolder/c/combust.txt
@@ -1,7 +1,7 @@
 Name:Combust
 ManaCost:1 R
 Types:Instant
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ DealDamage | Cost$ 1 R | ValidTgts$ Creature.White,Creature.Blue | NumDmg$ 5 | NoPrevention$ True | TgtPrompt$ Select target white or blue creature. | SpellDescription$ CARDNAME deals 5 damage to target white or blue creature. The damage can't be prevented.
 AI:RemoveDeck:Random
 Oracle:This spell can't be countered.\nCombust deals 5 damage to target white or blue creature. The damage can't be prevented.

--- a/forge-gui/res/cardsfolder/c/combust.txt
+++ b/forge-gui/res/cardsfolder/c/combust.txt
@@ -1,7 +1,7 @@
 Name:Combust
 ManaCost:1 R
 Types:Instant
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ DealDamage | Cost$ 1 R | ValidTgts$ Creature.White,Creature.Blue | NumDmg$ 5 | NoPrevention$ True | TgtPrompt$ Select target white or blue creature. | SpellDescription$ CARDNAME deals 5 damage to target white or blue creature. The damage can't be prevented.
 AI:RemoveDeck:Random
 Oracle:This spell can't be countered.\nCombust deals 5 damage to target white or blue creature. The damage can't be prevented.

--- a/forge-gui/res/cardsfolder/c/commence_the_endgame.txt
+++ b/forge-gui/res/cardsfolder/c/commence_the_endgame.txt
@@ -1,7 +1,7 @@
 Name:Commence the Endgame
 ManaCost:4 U U
 Types:Instant
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ Draw | Cost$ 4 U U | NumCards$ 2 | SpellDescription$ Draw two cards, then amass Zombies X, where X is the number of cards in your hand. (Put X +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.) | SubAbility$ DBAmass
 SVar:DBAmass:DB$ Amass | Type$ Zombie | Num$ X
 DeckHints:Ability$Amass & Type$Zombie

--- a/forge-gui/res/cardsfolder/c/commence_the_endgame.txt
+++ b/forge-gui/res/cardsfolder/c/commence_the_endgame.txt
@@ -1,7 +1,7 @@
 Name:Commence the Endgame
 ManaCost:4 U U
 Types:Instant
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ Draw | Cost$ 4 U U | NumCards$ 2 | SpellDescription$ Draw two cards, then amass Zombies X, where X is the number of cards in your hand. (Put X +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.) | SubAbility$ DBAmass
 SVar:DBAmass:DB$ Amass | Type$ Zombie | Num$ X
 DeckHints:Ability$Amass & Type$Zombie

--- a/forge-gui/res/cardsfolder/c/control_win_condition.txt
+++ b/forge-gui/res/cardsfolder/c/control_win_condition.txt
@@ -2,7 +2,7 @@ Name:Control Win Condition
 ManaCost:4 U U
 Types:Creature Whale
 PT:*/*
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Shroud
 S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of turns you've taken this game. (If this is in your deck, please keep track of your turns. This means you, Mark.)
 SVar:X:Count$YourTurns

--- a/forge-gui/res/cardsfolder/c/control_win_condition.txt
+++ b/forge-gui/res/cardsfolder/c/control_win_condition.txt
@@ -2,7 +2,7 @@ Name:Control Win Condition
 ManaCost:4 U U
 Types:Creature Whale
 PT:*/*
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Shroud
 S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of turns you've taken this game. (If this is in your deck, please keep track of your turns. This means you, Mark.)
 SVar:X:Count$YourTurns

--- a/forge-gui/res/cardsfolder/c/counterflux.txt
+++ b/forge-gui/res/cardsfolder/c/counterflux.txt
@@ -1,7 +1,7 @@
 Name:Counterflux
 ManaCost:U U R
 Types:Instant
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ Counter | Cost$ U U R | TargetType$ Spell | TgtPrompt$ Select target spell you don't control. | ValidTgts$ Card.YouDontCtrl | SpellDescription$ Counter target spell you don't control.
 A:SP$ Counter | Cost$ 1 U U R | AllValid$ Spell.YouDontCtrl | PrecostDesc$ Overload | CostDesc$ {1}{U}{U}{R} | NonBasicSpell$ True | SpellDescription$ (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.") | StackDescription$ Counter each spell you don't control.
 Oracle:This spell can't be countered.\nCounter target spell you don't control.\nOverload {1}{U}{U}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")

--- a/forge-gui/res/cardsfolder/c/counterflux.txt
+++ b/forge-gui/res/cardsfolder/c/counterflux.txt
@@ -1,7 +1,7 @@
 Name:Counterflux
 ManaCost:U U R
 Types:Instant
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ Counter | Cost$ U U R | TargetType$ Spell | TgtPrompt$ Select target spell you don't control. | ValidTgts$ Card.YouDontCtrl | SpellDescription$ Counter target spell you don't control.
 A:SP$ Counter | Cost$ 1 U U R | AllValid$ Spell.YouDontCtrl | PrecostDesc$ Overload | CostDesc$ {1}{U}{U}{R} | NonBasicSpell$ True | SpellDescription$ (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.") | StackDescription$ Counter each spell you don't control.
 Oracle:This spell can't be countered.\nCounter target spell you don't control.\nOverload {1}{U}{U}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")

--- a/forge-gui/res/cardsfolder/c/cragplate_baloth.txt
+++ b/forge-gui/res/cardsfolder/c/cragplate_baloth.txt
@@ -3,7 +3,7 @@ ManaCost:5 G G
 Types:Creature Beast
 PT:6/6
 K:Kicker:2 G
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Hexproof
 K:Haste
 K:etbCounter:P1P1:4:CheckSVar$ WasKicked:If CARDNAME was kicked, it enters the battlefield with four +1/+1 counters on it.

--- a/forge-gui/res/cardsfolder/c/cragplate_baloth.txt
+++ b/forge-gui/res/cardsfolder/c/cragplate_baloth.txt
@@ -3,7 +3,7 @@ ManaCost:5 G G
 Types:Creature Beast
 PT:6/6
 K:Kicker:2 G
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Hexproof
 K:Haste
 K:etbCounter:P1P1:4:CheckSVar$ WasKicked:If CARDNAME was kicked, it enters the battlefield with four +1/+1 counters on it.

--- a/forge-gui/res/cardsfolder/c/cunning_nightbonder.txt
+++ b/forge-gui/res/cardsfolder/c/cunning_nightbonder.txt
@@ -4,5 +4,5 @@ Types:Creature Human Rogue
 PT:2/2
 K:Flash
 S:Mode$ ReduceCost | ValidCard$ Card.hasKeywordFlash | Type$ Spell | Activator$ You | Amount$ 1 | Description$ Spells with flash you cast cost {1} less to cast and can't be countered.
-S:Mode$ Continuous | Affected$ Card.hasKeywordFlash+wasCastByYou | AffectedZone$ Stack | AddHiddenKeyword$ CARDNAME can't be countered. | Secondary$ True | Description$ Spells with flash you cast cost {1} less to cast and can't be countered.
+S:Mode$ Continuous | Affected$ Card.hasKeywordFlash+wasCastByYou | AffectedZone$ Stack | AddHiddenKeyword$ This spell can't be countered. | Secondary$ True | Description$ Spells with flash you cast cost {1} less to cast and can't be countered.
 Oracle:Flash\nSpells with flash you cast cost {1} less to cast and can't be countered.

--- a/forge-gui/res/cardsfolder/c/cunning_nightbonder.txt
+++ b/forge-gui/res/cardsfolder/c/cunning_nightbonder.txt
@@ -4,5 +4,5 @@ Types:Creature Human Rogue
 PT:2/2
 K:Flash
 S:Mode$ ReduceCost | ValidCard$ Card.hasKeywordFlash | Type$ Spell | Activator$ You | Amount$ 1 | Description$ Spells with flash you cast cost {1} less to cast and can't be countered.
-R:Event$ Counter | ValidCard$ Spell.hasKeywordFlash+wasCastByYou | Layer$ CantHappen | ActiveZones$ Battlefield | Secondary$ True | Description$ Spells with flash you cast cost {1} less to cast and can't be countered.
+R:Event$ Counter | ValidSA$ Spell.hasKeywordFlash+wasCastByYou | Layer$ CantHappen | ActiveZones$ Battlefield | Secondary$ True | Description$ Spells with flash you cast cost {1} less to cast and can't be countered.
 Oracle:Flash\nSpells with flash you cast cost {1} less to cast and can't be countered.

--- a/forge-gui/res/cardsfolder/c/cunning_nightbonder.txt
+++ b/forge-gui/res/cardsfolder/c/cunning_nightbonder.txt
@@ -4,5 +4,5 @@ Types:Creature Human Rogue
 PT:2/2
 K:Flash
 S:Mode$ ReduceCost | ValidCard$ Card.hasKeywordFlash | Type$ Spell | Activator$ You | Amount$ 1 | Description$ Spells with flash you cast cost {1} less to cast and can't be countered.
-S:Mode$ Continuous | Affected$ Card.hasKeywordFlash+wasCastByYou | AffectedZone$ Stack | AddHiddenKeyword$ This spell can't be countered. | Secondary$ True | Description$ Spells with flash you cast cost {1} less to cast and can't be countered.
+R:Event$ Counter | ValidCard$ Spell.hasKeywordFlash+wasCastByYou | Layer$ CantHappen | ActiveZones$ Battlefield | Secondary$ True | Description$ Spells with flash you cast cost {1} less to cast and can't be countered.
 Oracle:Flash\nSpells with flash you cast cost {1} less to cast and can't be countered.

--- a/forge-gui/res/cardsfolder/d/demonfire.txt
+++ b/forge-gui/res/cardsfolder/d/demonfire.txt
@@ -4,7 +4,7 @@ Types:Sorcery
 A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ X | RememberDamaged$ True | ReplaceDyingDefined$ Remembered.Creature | SubAbility$ DBCleanup | SpellDescription$ CARDNAME deals X damage to any target. If a creature dealt damage this way would die this turn, exile it instead.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 S:Mode$ CantPreventDamage | ValidSource$ Spell.Self | EffectZone$ Stack  | CheckSVar$ Y | SVarCompare$ EQ0 | Description$ Hellbent — If you have no cards in hand, this spell can't be countered and the damage can't be prevented.
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | CheckSVar$ Y | SVarCompare$ EQ0 | Secondary$ True | Description$ Hellbent — If you have no cards in hand, this spell can't be countered and the damage can't be prevented.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | CheckSVar$ Y | SVarCompare$ EQ0 | Secondary$ True | Description$ Hellbent — If you have no cards in hand, this spell can't be countered and the damage can't be prevented.
 SVar:X:Count$xPaid
 SVar:Y:Count$InYourHand
 Oracle:Demonfire deals X damage to any target. If a creature dealt damage this way would die this turn, exile it instead.\nHellbent — If you have no cards in hand, this spell can't be countered and the damage can't be prevented.

--- a/forge-gui/res/cardsfolder/d/demonfire.txt
+++ b/forge-gui/res/cardsfolder/d/demonfire.txt
@@ -1,10 +1,10 @@
 Name:Demonfire
 ManaCost:X R
 Types:Sorcery
-A:SP$ DealDamage | Cost$ X R | ValidTgts$ Any | NumDmg$ X | ConditionCheckSVar$ Y | ConditionSVarCompare$ GE1 | RememberDamaged$ True | ReplaceDyingDefined$ Remembered.Creature | SubAbility$ DBDemonfire | SpellDescription$ CARDNAME deals X damage to any target. If a creature dealt damage this way would die this turn, exile it instead.
-SVar:DBDemonfire:DB$ DealDamage | Defined$ Targeted | NumDmg$ X | NoPrevention$ True | ConditionCheckSVar$ Y | ConditionSVarCompare$ EQ0 | RememberDamaged$ True | ReplaceDyingDefined$ Remembered.Creature | SubAbility$ DBCleanup
+A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ X | RememberDamaged$ True | ReplaceDyingDefined$ Remembered.Creature | SubAbility$ DBCleanup | SpellDescription$ CARDNAME deals X damage to any target. If a creature dealt damage this way would die this turn, exile it instead.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | AddHiddenKeyword$ This spell can't be countered. | CheckSVar$ Y | SVarCompare$ EQ0 | Description$ Hellbent — If you have no cards in hand, this spell can't be countered and the damage can't be prevented.
+S:Mode$ CantPreventDamage | ValidSource$ Spell.Self | EffectZone$ Stack  | CheckSVar$ Y | SVarCompare$ EQ0 | Description$ Hellbent — If you have no cards in hand, this spell can't be countered and the damage can't be prevented.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | CheckSVar$ Y | SVarCompare$ EQ0 | Secondary$ True | Description$ Hellbent — If you have no cards in hand, this spell can't be countered and the damage can't be prevented.
 SVar:X:Count$xPaid
 SVar:Y:Count$InYourHand
 Oracle:Demonfire deals X damage to any target. If a creature dealt damage this way would die this turn, exile it instead.\nHellbent — If you have no cards in hand, this spell can't be countered and the damage can't be prevented.

--- a/forge-gui/res/cardsfolder/d/destiny_spinner.txt
+++ b/forge-gui/res/cardsfolder/d/destiny_spinner.txt
@@ -2,7 +2,7 @@ Name:Destiny Spinner
 ManaCost:1 G
 Types:Enchantment Creature Human
 PT:2/3
-R:Event$ Counter | ValidCard$ Spell.Creature+YouCtrl,Spell.Enchantment+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Creature and enchantment spells you control can't be countered.
+R:Event$ Counter | ValidSA$ Spell.Creature+YouCtrl,Spell.Enchantment+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Creature and enchantment spells you control can't be countered.
 DeckHints:Type$Creature|Enchantment
 A:AB$ Animate | Cost$ 3 G | ValidTgts$ Land.YouCtrl | TgtPrompt$ Select target land you control | Power$ X | Toughness$ X | Types$ Creature,Elemental | Keywords$ Trample & Haste | SpellDescription$ Target land you control becomes an X/X Elemental creature with trample and haste until end of turn, where X is the number of enchantments you control. It's still a land.
 SVar:X:Count$Valid Enchantment.YouCtrl

--- a/forge-gui/res/cardsfolder/d/destiny_spinner.txt
+++ b/forge-gui/res/cardsfolder/d/destiny_spinner.txt
@@ -2,7 +2,7 @@ Name:Destiny Spinner
 ManaCost:1 G
 Types:Enchantment Creature Human
 PT:2/3
-S:Mode$ Continuous | Affected$ Creature.YouCtrl,Enchantment.YouCtrl | AffectedZone$ Stack | AddHiddenKeyword$ This spell can't be countered. | Description$ Creature and enchantment spells you control can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Creature+YouCtrl,Spell.Enchantment+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Creature and enchantment spells you control can't be countered.
 DeckHints:Type$Creature|Enchantment
 A:AB$ Animate | Cost$ 3 G | ValidTgts$ Land.YouCtrl | TgtPrompt$ Select target land you control | Power$ X | Toughness$ X | Types$ Creature,Elemental | Keywords$ Trample & Haste | SpellDescription$ Target land you control becomes an X/X Elemental creature with trample and haste until end of turn, where X is the number of enchantments you control. It's still a land.
 SVar:X:Count$Valid Enchantment.YouCtrl

--- a/forge-gui/res/cardsfolder/d/destiny_spinner.txt
+++ b/forge-gui/res/cardsfolder/d/destiny_spinner.txt
@@ -2,7 +2,7 @@ Name:Destiny Spinner
 ManaCost:1 G
 Types:Enchantment Creature Human
 PT:2/3
-S:Mode$ Continuous | Affected$ Creature.YouCtrl,Enchantment.YouCtrl | AffectedZone$ Stack | AddHiddenKeyword$ CARDNAME can't be countered. | Description$ Creature and enchantment spells you control can't be countered.
+S:Mode$ Continuous | Affected$ Creature.YouCtrl,Enchantment.YouCtrl | AffectedZone$ Stack | AddHiddenKeyword$ This spell can't be countered. | Description$ Creature and enchantment spells you control can't be countered.
 DeckHints:Type$Creature|Enchantment
 A:AB$ Animate | Cost$ 3 G | ValidTgts$ Land.YouCtrl | TgtPrompt$ Select target land you control | Power$ X | Toughness$ X | Types$ Creature,Elemental | Keywords$ Trample & Haste | SpellDescription$ Target land you control becomes an X/X Elemental creature with trample and haste until end of turn, where X is the number of enchantments you control. It's still a land.
 SVar:X:Count$Valid Enchantment.YouCtrl

--- a/forge-gui/res/cardsfolder/d/domri_anarch_of_bolas.txt
+++ b/forge-gui/res/cardsfolder/d/domri_anarch_of_bolas.txt
@@ -6,7 +6,7 @@ S:Mode$ Continuous | Affected$ Creature.YouCtrl | AddPower$ 1 | Description$ Cre
 SVar:PlayMain1:TRUE
 A:AB$ Mana | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | Produced$ Combo R G | Amount$ 1 | AILogic$ Always | SubAbility$ DBEffect | SpellDescription$ Add {R} or {G}.
 SVar:DBEffect:DB$ Effect | ReplacementEffects$ AntiMagic | SpellDescription$ Creature spells you cast this turn can't be countered.
-SVar:AntiMagic:Event$ Counter | ValidCard$ Spell.Creature+wasCastByYou | Layer$ CantHappen | Description$ Creature spells you cast this turn can't be countered.
+SVar:AntiMagic:Event$ Counter | ValidSA$ Spell.Creature+wasCastByYou | Layer$ CantHappen | Description$ Creature spells you cast this turn can't be countered.
 A:AB$ Pump | Planeswalker$ True | Cost$ SubCounter<2/LOYALTY> | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Choose target creature you control | AILogic$ Fight | SpellDescription$ Target creature you control fights target creature you don't control. | SubAbility$ DBFight
 SVar:DBFight:DB$ Fight | Defined$ ParentTarget | ValidTgts$ Creature.YouDontCtrl | TgtPrompt$ Select target creature you don't control
 Oracle:Creatures you control get +1/+0.\n[+1]: Add {R} or {G}. Creature spells you cast this turn can't be countered.\n[-2]: Target creature you control fights target creature you don't control.

--- a/forge-gui/res/cardsfolder/d/domri_anarch_of_bolas.txt
+++ b/forge-gui/res/cardsfolder/d/domri_anarch_of_bolas.txt
@@ -6,7 +6,7 @@ S:Mode$ Continuous | Affected$ Creature.YouCtrl | AddPower$ 1 | Description$ Cre
 SVar:PlayMain1:TRUE
 A:AB$ Mana | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | Produced$ Combo R G | Amount$ 1 | AILogic$ Always | SubAbility$ DBEffect | SpellDescription$ Add {R} or {G}.
 SVar:DBEffect:DB$ Effect | StaticAbilities$ AntiMagic | SpellDescription$ Creature spells you cast this turn can't be countered
-SVar:AntiMagic:Mode$ Continuous | Affected$ Creature.wasCastByYou | AffectedZone$ Stack | EffectZone$ Command | AddHiddenKeyword$ CARDNAME can't be countered.
+SVar:AntiMagic:Mode$ Continuous | Affected$ Creature.wasCastByYou | AffectedZone$ Stack | EffectZone$ Command | AddHiddenKeyword$ This spell can't be countered.
 A:AB$ Pump | Planeswalker$ True | Cost$ SubCounter<2/LOYALTY> | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Choose target creature you control | AILogic$ Fight | SpellDescription$ Target creature you control fights target creature you don't control. | SubAbility$ DBFight
 SVar:DBFight:DB$ Fight | Defined$ ParentTarget | ValidTgts$ Creature.YouDontCtrl | TgtPrompt$ Select target creature you don't control
 Oracle:Creatures you control get +1/+0.\n[+1]: Add {R} or {G}. Creature spells you cast this turn can't be countered.\n[-2]: Target creature you control fights target creature you don't control.

--- a/forge-gui/res/cardsfolder/d/domri_anarch_of_bolas.txt
+++ b/forge-gui/res/cardsfolder/d/domri_anarch_of_bolas.txt
@@ -5,8 +5,8 @@ Loyalty:3
 S:Mode$ Continuous | Affected$ Creature.YouCtrl | AddPower$ 1 | Description$ Creatures you control get +1/+0.
 SVar:PlayMain1:TRUE
 A:AB$ Mana | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | Produced$ Combo R G | Amount$ 1 | AILogic$ Always | SubAbility$ DBEffect | SpellDescription$ Add {R} or {G}.
-SVar:DBEffect:DB$ Effect | StaticAbilities$ AntiMagic | SpellDescription$ Creature spells you cast this turn can't be countered
-SVar:AntiMagic:Mode$ Continuous | Affected$ Creature.wasCastByYou | AffectedZone$ Stack | EffectZone$ Command | AddHiddenKeyword$ This spell can't be countered.
+SVar:DBEffect:DB$ Effect | ReplacementEffects$ AntiMagic | SpellDescription$ Creature spells you cast this turn can't be countered.
+SVar:AntiMagic:Event$ Counter | ValidCard$ Spell.Creature+wasCastByYou | Layer$ CantHappen | Description$ Creature spells you cast this turn can't be countered.
 A:AB$ Pump | Planeswalker$ True | Cost$ SubCounter<2/LOYALTY> | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Choose target creature you control | AILogic$ Fight | SpellDescription$ Target creature you control fights target creature you don't control. | SubAbility$ DBFight
 SVar:DBFight:DB$ Fight | Defined$ ParentTarget | ValidTgts$ Creature.YouDontCtrl | TgtPrompt$ Select target creature you don't control
 Oracle:Creatures you control get +1/+0.\n[+1]: Add {R} or {G}. Creature spells you cast this turn can't be countered.\n[-2]: Target creature you control fights target creature you don't control.

--- a/forge-gui/res/cardsfolder/d/dovins_veto.txt
+++ b/forge-gui/res/cardsfolder/d/dovins_veto.txt
@@ -1,6 +1,6 @@
 Name:Dovin's Veto
 ManaCost:W U
 Types:Instant
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ Counter | Cost$ W U | TargetType$ Spell | TgtPrompt$ Select target noncreature Spell | ValidTgts$ Card.nonCreature | SpellDescription$ Counter target noncreature spell.
 Oracle:This spell can't be countered.\nCounter target noncreature spell.

--- a/forge-gui/res/cardsfolder/d/dovins_veto.txt
+++ b/forge-gui/res/cardsfolder/d/dovins_veto.txt
@@ -1,6 +1,6 @@
 Name:Dovin's Veto
 ManaCost:W U
 Types:Instant
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ Counter | Cost$ W U | TargetType$ Spell | TgtPrompt$ Select target noncreature Spell | ValidTgts$ Card.nonCreature | SpellDescription$ Counter target noncreature spell.
 Oracle:This spell can't be countered.\nCounter target noncreature spell.

--- a/forge-gui/res/cardsfolder/d/dragonlord_dromoka.txt
+++ b/forge-gui/res/cardsfolder/d/dragonlord_dromoka.txt
@@ -2,7 +2,7 @@ Name:Dragonlord Dromoka
 ManaCost:4 G W
 Types:Legendary Creature Elder Dragon
 PT:5/7
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Flying
 K:Lifelink
 S:Mode$ CantBeCast | ValidCard$ Card | Condition$ PlayerTurn | Caster$ Opponent | Description$ Your opponents can't cast spells during your turn.

--- a/forge-gui/res/cardsfolder/d/dragonlord_dromoka.txt
+++ b/forge-gui/res/cardsfolder/d/dragonlord_dromoka.txt
@@ -2,7 +2,7 @@ Name:Dragonlord Dromoka
 ManaCost:4 G W
 Types:Legendary Creature Elder Dragon
 PT:5/7
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Flying
 K:Lifelink
 S:Mode$ CantBeCast | ValidCard$ Card | Condition$ PlayerTurn | Caster$ Opponent | Description$ Your opponents can't cast spells during your turn.

--- a/forge-gui/res/cardsfolder/d/dragonlords_prerogative.txt
+++ b/forge-gui/res/cardsfolder/d/dragonlords_prerogative.txt
@@ -2,7 +2,7 @@ Name:Dragonlord's Prerogative
 ManaCost:4 U U
 Types:Instant
 S:Mode$ OptionalCost | EffectZone$ All | ValidCard$ Card.Self | ValidSA$ Spell | Cost$ Reveal<1/Dragon> | Description$ As an additional cost to cast this spell, you may reveal a Dragon card from your hand.
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | AddHiddenKeyword$ This spell can't be countered. | Presence$ Dragon | Description$ If you revealed a Dragon card or controlled a Dragon as you cast this spell, this spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Presence$ Dragon | Description$ If you revealed a Dragon card or controlled a Dragon as you cast this spell, this spell can't be countered.
 A:SP$ Draw | Cost$ 4 U U | NumCards$ 4 | SpellDescription$ Draw four cards.
 DeckHints:Type$Dragon
 Oracle:As an additional cost to cast this spell, you may reveal a Dragon card from your hand.\nIf you revealed a Dragon card or controlled a Dragon as you cast this spell, this spell can't be countered.\nDraw four cards.

--- a/forge-gui/res/cardsfolder/d/dragonlords_prerogative.txt
+++ b/forge-gui/res/cardsfolder/d/dragonlords_prerogative.txt
@@ -2,7 +2,7 @@ Name:Dragonlord's Prerogative
 ManaCost:4 U U
 Types:Instant
 S:Mode$ OptionalCost | EffectZone$ All | ValidCard$ Card.Self | ValidSA$ Spell | Cost$ Reveal<1/Dragon> | Description$ As an additional cost to cast this spell, you may reveal a Dragon card from your hand.
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Presence$ Dragon | Description$ If you revealed a Dragon card or controlled a Dragon as you cast this spell, this spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Presence$ Dragon | Description$ If you revealed a Dragon card or controlled a Dragon as you cast this spell, this spell can't be countered.
 A:SP$ Draw | Cost$ 4 U U | NumCards$ 4 | SpellDescription$ Draw four cards.
 DeckHints:Type$Dragon
 Oracle:As an additional cost to cast this spell, you may reveal a Dragon card from your hand.\nIf you revealed a Dragon card or controlled a Dragon as you cast this spell, this spell can't be countered.\nDraw four cards.

--- a/forge-gui/res/cardsfolder/e/emrakul_the_aeons_torn.txt
+++ b/forge-gui/res/cardsfolder/e/emrakul_the_aeons_torn.txt
@@ -2,7 +2,7 @@ Name:Emrakul, the Aeons Torn
 ManaCost:15
 Types:Legendary Creature Eldrazi
 PT:15/15
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Flying
 K:Protection:Spell.nonColorless:colored spells
 K:Annihilator:6

--- a/forge-gui/res/cardsfolder/e/emrakul_the_aeons_torn.txt
+++ b/forge-gui/res/cardsfolder/e/emrakul_the_aeons_torn.txt
@@ -2,7 +2,7 @@ Name:Emrakul, the Aeons Torn
 ManaCost:15
 Types:Legendary Creature Eldrazi
 PT:15/15
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Flying
 K:Protection:Spell.nonColorless:colored spells
 K:Annihilator:6

--- a/forge-gui/res/cardsfolder/e/exquisite_firecraft.txt
+++ b/forge-gui/res/cardsfolder/e/exquisite_firecraft.txt
@@ -2,5 +2,5 @@ Name:Exquisite Firecraft
 ManaCost:1 R R
 Types:Sorcery
 A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ 4 | SpellDescription$ CARDNAME deals 4 damage to any target.
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | IsPresent$ Instant.YouOwn,Sorcery.YouOwn | PresentZone$ Graveyard | PresentCompare$ GE2 | Description$ Spell mastery — If there are two or more instant and/or sorcery cards in your graveyard, this spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | IsPresent$ Instant.YouOwn,Sorcery.YouOwn | PresentZone$ Graveyard | PresentCompare$ GE2 | Description$ Spell mastery — If there are two or more instant and/or sorcery cards in your graveyard, this spell can't be countered.
 Oracle:Exquisite Firecraft deals 4 damage to any target.\nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, this spell can't be countered.

--- a/forge-gui/res/cardsfolder/e/exquisite_firecraft.txt
+++ b/forge-gui/res/cardsfolder/e/exquisite_firecraft.txt
@@ -2,5 +2,5 @@ Name:Exquisite Firecraft
 ManaCost:1 R R
 Types:Sorcery
 A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ 4 | SpellDescription$ CARDNAME deals 4 damage to any target.
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | AddHiddenKeyword$ This spell can't be countered. | IsPresent$ Instant.YouOwn,Sorcery.YouOwn | PresentZone$ Graveyard | PresentCompare$ GE2 | Description$ Spell mastery — If there are two or more instant and/or sorcery cards in your graveyard, this spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | IsPresent$ Instant.YouOwn,Sorcery.YouOwn | PresentZone$ Graveyard | PresentCompare$ GE2 | Description$ Spell mastery — If there are two or more instant and/or sorcery cards in your graveyard, this spell can't be countered.
 Oracle:Exquisite Firecraft deals 4 damage to any target.\nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, this spell can't be countered.

--- a/forge-gui/res/cardsfolder/f/fry.txt
+++ b/forge-gui/res/cardsfolder/f/fry.txt
@@ -1,7 +1,7 @@
 Name:Fry
 ManaCost:1 R
 Types:Instant
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ DealDamage | Cost$ 1 R | ValidTgts$ Creature.White,Planeswalker.White,Creature.Blue,Planeswalker.Blue | TgtPrompt$ Select target creature or planeswalker that's white or blue | NumDmg$ 5 | SpellDescription$ CARDNAME deals 5 damage to target creature or planeswalker that's white or blue.
 AI:RemoveDeck:Random
 Oracle:This spell can't be countered.\nFry deals 5 damage to target creature or planeswalker that's white or blue.

--- a/forge-gui/res/cardsfolder/f/fry.txt
+++ b/forge-gui/res/cardsfolder/f/fry.txt
@@ -1,7 +1,7 @@
 Name:Fry
 ManaCost:1 R
 Types:Instant
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ DealDamage | Cost$ 1 R | ValidTgts$ Creature.White,Planeswalker.White,Creature.Blue,Planeswalker.Blue | TgtPrompt$ Select target creature or planeswalker that's white or blue | NumDmg$ 5 | SpellDescription$ CARDNAME deals 5 damage to target creature or planeswalker that's white or blue.
 AI:RemoveDeck:Random
 Oracle:This spell can't be countered.\nFry deals 5 damage to target creature or planeswalker that's white or blue.

--- a/forge-gui/res/cardsfolder/g/gaeas_herald.txt
+++ b/forge-gui/res/cardsfolder/g/gaeas_herald.txt
@@ -2,5 +2,5 @@ Name:Gaea's Herald
 ManaCost:1 G
 Types:Creature Elf
 PT:1/1
-S:Mode$ Continuous | Affected$ Creature | AddHiddenKeyword$ CARDNAME can't be countered. | AffectedZone$ Stack | Description$ Creature spells can't be countered.
+S:Mode$ Continuous | Affected$ Creature | AddHiddenKeyword$ This spell can't be countered. | AffectedZone$ Stack | Description$ Creature spells can't be countered.
 Oracle:Creature spells can't be countered.

--- a/forge-gui/res/cardsfolder/g/gaeas_herald.txt
+++ b/forge-gui/res/cardsfolder/g/gaeas_herald.txt
@@ -2,5 +2,5 @@ Name:Gaea's Herald
 ManaCost:1 G
 Types:Creature Elf
 PT:1/1
-R:Event$ Counter | ValidCard$ Spell.Creature | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Creature spells can't be countered.
+R:Event$ Counter | ValidSA$ Spell.Creature | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Creature spells can't be countered.
 Oracle:Creature spells can't be countered.

--- a/forge-gui/res/cardsfolder/g/gaeas_herald.txt
+++ b/forge-gui/res/cardsfolder/g/gaeas_herald.txt
@@ -2,5 +2,5 @@ Name:Gaea's Herald
 ManaCost:1 G
 Types:Creature Elf
 PT:1/1
-S:Mode$ Continuous | Affected$ Creature | AddHiddenKeyword$ This spell can't be countered. | AffectedZone$ Stack | Description$ Creature spells can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Creature | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Creature spells can't be countered.
 Oracle:Creature spells can't be countered.

--- a/forge-gui/res/cardsfolder/g/gaeas_revenge.txt
+++ b/forge-gui/res/cardsfolder/g/gaeas_revenge.txt
@@ -2,7 +2,7 @@ Name:Gaea's Revenge
 ManaCost:5 G G
 Types:Creature Elemental
 PT:8/5
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Haste
 S:Mode$ CantTarget | ValidCard$ Card.Self | ValidSource$ Card.nonGreen | Description$ CARDNAME can't be the target of nongreen spells or abilities from nongreen sources.
 Oracle:This spell can't be countered.\nHaste\nGaea's Revenge can't be the target of nongreen spells or abilities from nongreen sources.

--- a/forge-gui/res/cardsfolder/g/gaeas_revenge.txt
+++ b/forge-gui/res/cardsfolder/g/gaeas_revenge.txt
@@ -2,7 +2,7 @@ Name:Gaea's Revenge
 ManaCost:5 G G
 Types:Creature Elemental
 PT:8/5
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Haste
 S:Mode$ CantTarget | ValidCard$ Card.Self | ValidSource$ Card.nonGreen | Description$ CARDNAME can't be the target of nongreen spells or abilities from nongreen sources.
 Oracle:This spell can't be countered.\nHaste\nGaea's Revenge can't be the target of nongreen spells or abilities from nongreen sources.

--- a/forge-gui/res/cardsfolder/g/goldbug_humanitys_ally_goldbug_scrappy_scout.txt
+++ b/forge-gui/res/cardsfolder/g/goldbug_humanitys_ally_goldbug_scrappy_scout.txt
@@ -19,7 +19,7 @@ Colors:white,blue
 Types:Legendary Artifact Vehicle
 PT:1/3
 K:Living metal
-R:Event$ Counter | ValidCard$ Spell.Human+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Human spells you control can't be countered.
+R:Event$ Counter | ValidSA$ Spell.Human+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Human spells you control can't be countered.
 T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | IsPresent$ Human.attacking+Other | Execute$ TrigDraw | TriggerDescription$ Whenever NICKNAME and at least one Human attack, draw a card and convert NICKNAME.
 SVar:TrigDraw:DB$ Draw | SubAbility$ DBConvert
 SVar:DBConvert:DB$ SetState | Mode$ Transform

--- a/forge-gui/res/cardsfolder/g/goldbug_humanitys_ally_goldbug_scrappy_scout.txt
+++ b/forge-gui/res/cardsfolder/g/goldbug_humanitys_ally_goldbug_scrappy_scout.txt
@@ -19,7 +19,7 @@ Colors:white,blue
 Types:Legendary Artifact Vehicle
 PT:1/3
 K:Living metal
-S:Mode$ Continuous | Affected$ Human.YouCtrl | AddHiddenKeyword$ This spell can't be countered. | AffectedZone$ Stack | Description$ Human spells you control can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Human+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Human spells you control can't be countered.
 T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | IsPresent$ Human.attacking+Other | Execute$ TrigDraw | TriggerDescription$ Whenever NICKNAME and at least one Human attack, draw a card and convert NICKNAME.
 SVar:TrigDraw:DB$ Draw | SubAbility$ DBConvert
 SVar:DBConvert:DB$ SetState | Mode$ Transform

--- a/forge-gui/res/cardsfolder/g/great_sable_stag.txt
+++ b/forge-gui/res/cardsfolder/g/great_sable_stag.txt
@@ -4,5 +4,5 @@ Types:Creature Elk
 PT:3/3
 K:Protection from blue
 K:Protection from black
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 Oracle:This spell can't be countered.\nProtection from blue and from black (This creature can't be blocked, targeted, dealt damage, or enchanted by anything blue or black.)

--- a/forge-gui/res/cardsfolder/g/great_sable_stag.txt
+++ b/forge-gui/res/cardsfolder/g/great_sable_stag.txt
@@ -4,5 +4,5 @@ Types:Creature Elk
 PT:3/3
 K:Protection from blue
 K:Protection from black
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 Oracle:This spell can't be countered.\nProtection from blue and from black (This creature can't be blocked, targeted, dealt damage, or enchanted by anything blue or black.)

--- a/forge-gui/res/cardsfolder/g/guile.txt
+++ b/forge-gui/res/cardsfolder/g/guile.txt
@@ -3,7 +3,7 @@ ManaCost:3 U U U
 Types:Creature Elemental Incarnation
 PT:6/6
 S:Mode$ MinMaxBlocker | ValidCard$ Creature.Self | Min$ 3 | Description$ CARDNAME can't be blocked except by three or more creatures.
-R:Event$ Counter | ActiveZones$ Battlefield | ValidType$ Spell | ValidCause$ Card.YouCtrl,Emblem.YouCtrl | ReplaceWith$ DBRemove | Description$ If a spell or ability you control would counter a spell, instead exile that spell and you may play that card without paying its mana cost.
+R:Event$ Counter | ActiveZones$ Battlefield | ValidSA$ Spell | ValidCause$ SpellAbility.YouCtrl | ReplaceWith$ DBRemove | Description$ If a spell or ability you control would counter a spell, instead exile that spell and you may play that card without paying its mana cost.
 SVar:DBRemove:DB$ ChangeZone | Defined$ ReplacedCard | Origin$ Stack | Destination$ Exile | Fizzle$ True | RememberChanged$ True | SubAbility$ DBPlay
 SVar:DBPlay:DB$ Play | Defined$ Remembered | WithoutManaCost$ True | Optional$ True | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/h/heated_debate.txt
+++ b/forge-gui/res/cardsfolder/h/heated_debate.txt
@@ -1,6 +1,6 @@
 Name:Heated Debate
 ManaCost:2 R
 Types:Instant
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ DealDamage | Cost$ 2 R | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker. | NumDmg$ 4 | SpellDescription$ CARDNAME deals 4 damage to target creature or planeswalker.
 Oracle:This spell can't be countered. (This includes by the ward ability.)\nHeated Debate deals 4 damage to target creature or planeswalker.

--- a/forge-gui/res/cardsfolder/h/heated_debate.txt
+++ b/forge-gui/res/cardsfolder/h/heated_debate.txt
@@ -1,6 +1,6 @@
 Name:Heated Debate
 ManaCost:2 R
 Types:Instant
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ DealDamage | Cost$ 2 R | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker. | NumDmg$ 4 | SpellDescription$ CARDNAME deals 4 damage to target creature or planeswalker.
 Oracle:This spell can't be countered. (This includes by the ward ability.)\nHeated Debate deals 4 damage to target creature or planeswalker.

--- a/forge-gui/res/cardsfolder/h/howlpack_piper_wildsong_howler.txt
+++ b/forge-gui/res/cardsfolder/h/howlpack_piper_wildsong_howler.txt
@@ -2,7 +2,7 @@ Name:Howlpack Piper
 ManaCost:3 G
 Types:Creature Human Werewolf
 PT:2/2
-K:CARDNAME can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:AB$ ChangeZone | Cost$ 1 G T | Origin$ Hand | Destination$ Battlefield | ChangeType$ Creature | ChangeNum$ 1 | SorcerySpeed$ True | RememberChanged$ True | SubAbility$ DBUntap | StackDescription$ You may put a creature card from your hand onto the battlefield. If it's a Wolf or Werewolf, untap CARDNAME. | SpellDescription$ You may put a creature card from your hand onto the battlefield. If it's a Wolf or Werewolf, untap CARDNAME. Activate only as a sorcery.
 SVar:DBUntap:DB$ Untap | Defined$ Self | ConditionDefined$ Remembered | ConditionPresent$ Wolf,Werewolf | ConditionCompare$ EQ1 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/h/howlpack_piper_wildsong_howler.txt
+++ b/forge-gui/res/cardsfolder/h/howlpack_piper_wildsong_howler.txt
@@ -2,7 +2,7 @@ Name:Howlpack Piper
 ManaCost:3 G
 Types:Creature Human Werewolf
 PT:2/2
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:AB$ ChangeZone | Cost$ 1 G T | Origin$ Hand | Destination$ Battlefield | ChangeType$ Creature | ChangeNum$ 1 | SorcerySpeed$ True | RememberChanged$ True | SubAbility$ DBUntap | StackDescription$ You may put a creature card from your hand onto the battlefield. If it's a Wolf or Werewolf, untap CARDNAME. | SpellDescription$ You may put a creature card from your hand onto the battlefield. If it's a Wolf or Werewolf, untap CARDNAME. Activate only as a sorcery.
 SVar:DBUntap:DB$ Untap | Defined$ Self | ConditionDefined$ Remembered | ConditionPresent$ Wolf,Werewolf | ConditionCompare$ EQ1 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/h/hullbreaker_horror.txt
+++ b/forge-gui/res/cardsfolder/h/hullbreaker_horror.txt
@@ -3,7 +3,7 @@ ManaCost:5 U U
 Types:Creature Kraken Horror
 PT:7/8
 K:Flash
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 T:Mode$ SpellCast | ValidCard$ Card | ValidActivatingPlayer$ You | Execute$ TrigCharm | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a spell, ABILITY
 SVar:TrigCharm:DB$ Charm | Choices$ ControlReturn,ControlBounce | MinCharmNum$ 0 | CharmNum$ 1
 SVar:ControlReturn:DB$ ChangeZone | ValidTgts$ Card.YouDontCtrl | TargetType$ Spell | TgtPrompt$ Select target spell you don't control | TgtZone$ Stack | Origin$ Stack | Fizzle$ True | Destination$ Hand | SpellDescription$ Return target spell you don't control to its owner's hand.

--- a/forge-gui/res/cardsfolder/h/hullbreaker_horror.txt
+++ b/forge-gui/res/cardsfolder/h/hullbreaker_horror.txt
@@ -3,7 +3,7 @@ ManaCost:5 U U
 Types:Creature Kraken Horror
 PT:7/8
 K:Flash
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 T:Mode$ SpellCast | ValidCard$ Card | ValidActivatingPlayer$ You | Execute$ TrigCharm | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a spell, ABILITY
 SVar:TrigCharm:DB$ Charm | Choices$ ControlReturn,ControlBounce | MinCharmNum$ 0 | CharmNum$ 1
 SVar:ControlReturn:DB$ ChangeZone | ValidTgts$ Card.YouDontCtrl | TargetType$ Spell | TgtPrompt$ Select target spell you don't control | TgtZone$ Stack | Origin$ Stack | Fizzle$ True | Destination$ Hand | SpellDescription$ Return target spell you don't control to its owner's hand.

--- a/forge-gui/res/cardsfolder/h/hunters_mark.txt
+++ b/forge-gui/res/cardsfolder/h/hunters_mark.txt
@@ -1,7 +1,7 @@
 Name:Hunter's Mark
 ManaCost:3 G
 Types:Instant
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 3 | ValidTarget$ Card.Blue+YouDontCtrl | EffectZone$ All | Description$ This spell costs {3} less to cast if it targets a blue permanent you don't control.
 A:SP$ Pump | ValidTgts$ Creature.YouCtrl | AILogic$ PowerDmg | NumAtt$ +1 | NumDef$ +1 | TgtPrompt$ Select target creature you control | SubAbility$ SoulsDamage | StackDescription$ {c:ThisTargetedCard} gets +1/+1 until end of turn. | SpellDescription$ Target creature you control gets +1/+1 until end of turn. It deals damage equal to its power to target creature you don't control.
 SVar:SoulsDamage:DB$ DealDamage | ValidTgts$ Creature.YouDontCtrl,Planeswalker.YouDontCtrl | AILogic$ PowerDmg | TgtPrompt$ Select target creature or planeswalker you don't control | NumDmg$ X | DamageSource$ ParentTarget | StackDescription$ Then {c:ParentTarget} deals damage equal to its power to {c:ThisTargetedCard}.

--- a/forge-gui/res/cardsfolder/h/hunters_mark.txt
+++ b/forge-gui/res/cardsfolder/h/hunters_mark.txt
@@ -1,7 +1,7 @@
 Name:Hunter's Mark
 ManaCost:3 G
 Types:Instant
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 3 | ValidTarget$ Card.Blue+YouDontCtrl | EffectZone$ All | Description$ This spell costs {3} less to cast if it targets a blue permanent you don't control.
 A:SP$ Pump | ValidTgts$ Creature.YouCtrl | AILogic$ PowerDmg | NumAtt$ +1 | NumDef$ +1 | TgtPrompt$ Select target creature you control | SubAbility$ SoulsDamage | StackDescription$ {c:ThisTargetedCard} gets +1/+1 until end of turn. | SpellDescription$ Target creature you control gets +1/+1 until end of turn. It deals damage equal to its power to target creature you don't control.
 SVar:SoulsDamage:DB$ DealDamage | ValidTgts$ Creature.YouDontCtrl,Planeswalker.YouDontCtrl | AILogic$ PowerDmg | TgtPrompt$ Select target creature or planeswalker you don't control | NumDmg$ X | DamageSource$ ParentTarget | StackDescription$ Then {c:ParentTarget} deals damage equal to its power to {c:ThisTargetedCard}.

--- a/forge-gui/res/cardsfolder/i/inescapable_blaze.txt
+++ b/forge-gui/res/cardsfolder/i/inescapable_blaze.txt
@@ -1,6 +1,6 @@
 Name:Inescapable Blaze
 ManaCost:4 R R
 Types:Instant
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ DealDamage | Cost$ 4 R R | ValidTgts$ Any | NumDmg$ 6 | SpellDescription$ CARDNAME deals 6 damage to any target.
 Oracle:This spell can't be countered.\nInescapable Blaze deals 6 damage to any target.

--- a/forge-gui/res/cardsfolder/i/inescapable_blaze.txt
+++ b/forge-gui/res/cardsfolder/i/inescapable_blaze.txt
@@ -1,6 +1,6 @@
 Name:Inescapable Blaze
 ManaCost:4 R R
 Types:Instant
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ DealDamage | Cost$ 4 R R | ValidTgts$ Any | NumDmg$ 6 | SpellDescription$ CARDNAME deals 6 damage to any target.
 Oracle:This spell can't be countered.\nInescapable Blaze deals 6 damage to any target.

--- a/forge-gui/res/cardsfolder/i/inferno_of_the_star_mounts.txt
+++ b/forge-gui/res/cardsfolder/i/inferno_of_the_star_mounts.txt
@@ -2,7 +2,7 @@ Name:Inferno of the Star Mounts
 ManaCost:4 R R
 Types:Legendary Creature Dragon
 PT:6/6
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Flying
 K:Haste
 A:AB$ Pump | Cost$ R | Defined$ Self | NumAtt$ +1 | SubAbility$ DBImmediateTrigger | AILogic$ InfernoOfTheStarMounts | SpellDescription$ CARDNAME gets +1/+0 until end of turn.

--- a/forge-gui/res/cardsfolder/i/inferno_of_the_star_mounts.txt
+++ b/forge-gui/res/cardsfolder/i/inferno_of_the_star_mounts.txt
@@ -2,7 +2,7 @@ Name:Inferno of the Star Mounts
 ManaCost:4 R R
 Types:Legendary Creature Dragon
 PT:6/6
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Flying
 K:Haste
 A:AB$ Pump | Cost$ R | Defined$ Self | NumAtt$ +1 | SubAbility$ DBImmediateTrigger | AILogic$ InfernoOfTheStarMounts | SpellDescription$ CARDNAME gets +1/+0 until end of turn.

--- a/forge-gui/res/cardsfolder/i/insist.txt
+++ b/forge-gui/res/cardsfolder/i/insist.txt
@@ -1,9 +1,9 @@
 Name:Insist
 ManaCost:G
 Types:Sorcery
-A:SP$ Effect | Triggers$ SpellCastTrig | SubAbility$ DBDraw | SpellDescription$ The next creature spell you cast this turn can't be countered.
+A:SP$ DelayedTrigger | Mode$ SpellCast | ValidCard$ Creature | ValidActivatingPlayer$ You | Execute$ DBEffect | ThisTurn$ True | Static$ True | SubAbility$ DBDraw | SpellDescription$ The next creature spell you cast this turn can't be countered.
+SVar:DBEffect:DB$ Effect | ReplacementEffects$ AntiMagic | RememberObjects$ TriggeredCard | ForgetOnMoved$ Stack
+SVar:AntiMagic:Event$ Counter | ValidCard$ Spell.IsRemembered | Layer$ CantHappen | Description$ This spell can't be countered.
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | SpellDescription$ Draw a card.
-SVar:SpellCastTrig:Mode$ SpellCast | ValidCard$ Creature | ValidActivatingPlayer$ You | Execute$ Insistence | OneOff$ True | Static$ True | TriggerDescription$ The next creature spell you cast this turn can't be countered.
-SVar:Insistence:DB$ Pump | Defined$ TriggeredCard | KW$ HIDDEN This spell can't be countered. | PumpZone$ Stack
 AI:RemoveDeck:All
 Oracle:The next creature spell you cast this turn can't be countered.\nDraw a card.

--- a/forge-gui/res/cardsfolder/i/insist.txt
+++ b/forge-gui/res/cardsfolder/i/insist.txt
@@ -4,6 +4,6 @@ Types:Sorcery
 A:SP$ Effect | Triggers$ SpellCastTrig | SubAbility$ DBDraw | SpellDescription$ The next creature spell you cast this turn can't be countered.
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | SpellDescription$ Draw a card.
 SVar:SpellCastTrig:Mode$ SpellCast | ValidCard$ Creature | ValidActivatingPlayer$ You | Execute$ Insistence | OneOff$ True | Static$ True | TriggerDescription$ The next creature spell you cast this turn can't be countered.
-SVar:Insistence:DB$ Pump | Defined$ TriggeredCard | KW$ HIDDEN CARDNAME can't be countered. | PumpZone$ Stack
+SVar:Insistence:DB$ Pump | Defined$ TriggeredCard | KW$ HIDDEN This spell can't be countered. | PumpZone$ Stack
 AI:RemoveDeck:All
 Oracle:The next creature spell you cast this turn can't be countered.\nDraw a card.

--- a/forge-gui/res/cardsfolder/i/insist.txt
+++ b/forge-gui/res/cardsfolder/i/insist.txt
@@ -3,7 +3,7 @@ ManaCost:G
 Types:Sorcery
 A:SP$ DelayedTrigger | Mode$ SpellCast | ValidCard$ Creature | ValidActivatingPlayer$ You | Execute$ DBEffect | ThisTurn$ True | Static$ True | SubAbility$ DBDraw | SpellDescription$ The next creature spell you cast this turn can't be countered.
 SVar:DBEffect:DB$ Effect | ReplacementEffects$ AntiMagic | RememberObjects$ TriggeredCard | ForgetOnMoved$ Stack
-SVar:AntiMagic:Event$ Counter | ValidCard$ Spell.IsRemembered | Layer$ CantHappen | Description$ This spell can't be countered.
+SVar:AntiMagic:Event$ Counter | ValidCard$ Card.IsRemembered | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | SpellDescription$ Draw a card.
 AI:RemoveDeck:All
 Oracle:The next creature spell you cast this turn can't be countered.\nDraw a card.

--- a/forge-gui/res/cardsfolder/i/isao_enlightened_bushi.txt
+++ b/forge-gui/res/cardsfolder/i/isao_enlightened_bushi.txt
@@ -2,7 +2,7 @@ Name:Isao, Enlightened Bushi
 ManaCost:2 G
 Types:Legendary Creature Human Samurai
 PT:2/1
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Bushido:2
 A:AB$ Regenerate | Cost$ 2 | ValidTgts$ Samurai | TgtPrompt$ Select target Samurai. | SpellDescription$ Regenerate target Samurai.
 DeckHints:Type$Samurai

--- a/forge-gui/res/cardsfolder/i/isao_enlightened_bushi.txt
+++ b/forge-gui/res/cardsfolder/i/isao_enlightened_bushi.txt
@@ -2,7 +2,7 @@ Name:Isao, Enlightened Bushi
 ManaCost:2 G
 Types:Legendary Creature Human Samurai
 PT:2/1
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Bushido:2
 A:AB$ Regenerate | Cost$ 2 | ValidTgts$ Samurai | TgtPrompt$ Select target Samurai. | SpellDescription$ Regenerate target Samurai.
 DeckHints:Type$Samurai

--- a/forge-gui/res/cardsfolder/k/kavu_chameleon.txt
+++ b/forge-gui/res/cardsfolder/k/kavu_chameleon.txt
@@ -2,7 +2,7 @@ Name:Kavu Chameleon
 ManaCost:3 G G
 Types:Creature Kavu
 PT:4/4
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:AB$ ChooseColor | Cost$ G | Defined$ You | SubAbility$ Animate | SpellDescription$ CARDNAME becomes the color of your choice until end of turn.
 SVar:Animate:DB$ Animate | Defined$ Self | Colors$ ChosenColor | OverwriteColors$ True
 Oracle:This spell can't be countered.\n{G}: Kavu Chameleon becomes the color of your choice until end of turn.

--- a/forge-gui/res/cardsfolder/k/kavu_chameleon.txt
+++ b/forge-gui/res/cardsfolder/k/kavu_chameleon.txt
@@ -2,7 +2,7 @@ Name:Kavu Chameleon
 ManaCost:3 G G
 Types:Creature Kavu
 PT:4/4
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:AB$ ChooseColor | Cost$ G | Defined$ You | SubAbility$ Animate | SpellDescription$ CARDNAME becomes the color of your choice until end of turn.
 SVar:Animate:DB$ Animate | Defined$ Self | Colors$ ChosenColor | OverwriteColors$ True
 Oracle:This spell can't be countered.\n{G}: Kavu Chameleon becomes the color of your choice until end of turn.

--- a/forge-gui/res/cardsfolder/k/koma_cosmos_serpent.txt
+++ b/forge-gui/res/cardsfolder/k/koma_cosmos_serpent.txt
@@ -2,7 +2,7 @@ Name:Koma, Cosmos Serpent
 ManaCost:3 G G U U
 Types:Legendary Creature Serpent
 PT:6/6
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 T:Mode$ Phase | Phase$ Upkeep | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ At the beginning of each upkeep, create a 3/3 blue Serpent creature token named Koma's Coil.
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ komas_coil | TokenOwner$ You
 A:AB$ Charm | Cost$ Sac<1/Serpent.Other/another Serpent> | Choices$ DBTap,DBPump

--- a/forge-gui/res/cardsfolder/k/koma_cosmos_serpent.txt
+++ b/forge-gui/res/cardsfolder/k/koma_cosmos_serpent.txt
@@ -2,7 +2,7 @@ Name:Koma, Cosmos Serpent
 ManaCost:3 G G U U
 Types:Legendary Creature Serpent
 PT:6/6
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 T:Mode$ Phase | Phase$ Upkeep | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ At the beginning of each upkeep, create a 3/3 blue Serpent creature token named Koma's Coil.
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ komas_coil | TokenOwner$ You
 A:AB$ Charm | Cost$ Sac<1/Serpent.Other/another Serpent> | Choices$ DBTap,DBPump

--- a/forge-gui/res/cardsfolder/l/last_march_of_the_ents.txt
+++ b/forge-gui/res/cardsfolder/l/last_march_of_the_ents.txt
@@ -1,7 +1,7 @@
 Name:Last March of the Ents
 ManaCost:6 G G
 Types:Sorcery
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ Draw | Defined$ You | NumCards$ X | SubAbility$ CheatBattlefield | SpellDescription$ Draw cards equal to the greatest toughness among creatures you control, then put any number of creature cards from your hand onto the battlefield.
 SVar:CheatBattlefield:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | ChangeType$ Creature | ChangeNum$ Y | StackDescription$ {p:You} puts any number of creature cards from their hand onto the battlefield 
 SVar:X:Count$Valid Creature.YouCtrl$GreatestToughness

--- a/forge-gui/res/cardsfolder/l/last_march_of_the_ents.txt
+++ b/forge-gui/res/cardsfolder/l/last_march_of_the_ents.txt
@@ -1,7 +1,7 @@
 Name:Last March of the Ents
 ManaCost:6 G G
 Types:Sorcery
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ Draw | Defined$ You | NumCards$ X | SubAbility$ CheatBattlefield | SpellDescription$ Draw cards equal to the greatest toughness among creatures you control, then put any number of creature cards from your hand onto the battlefield.
 SVar:CheatBattlefield:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | ChangeType$ Creature | ChangeNum$ Y | StackDescription$ {p:You} puts any number of creature cards from their hand onto the battlefield 
 SVar:X:Count$Valid Creature.YouCtrl$GreatestToughness

--- a/forge-gui/res/cardsfolder/l/last_word.txt
+++ b/forge-gui/res/cardsfolder/l/last_word.txt
@@ -2,5 +2,5 @@ Name:Last Word
 ManaCost:2 U U
 Types:Instant
 A:SP$ Counter | Cost$ 2 U U | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | SpellDescription$ Counter target spell.
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 Oracle:This spell can't be countered.\nCounter target spell.

--- a/forge-gui/res/cardsfolder/l/last_word.txt
+++ b/forge-gui/res/cardsfolder/l/last_word.txt
@@ -2,5 +2,5 @@ Name:Last Word
 ManaCost:2 U U
 Types:Instant
 A:SP$ Counter | Cost$ 2 U U | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | SpellDescription$ Counter target spell.
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 Oracle:This spell can't be countered.\nCounter target spell.

--- a/forge-gui/res/cardsfolder/l/leyline_of_lifeforce.txt
+++ b/forge-gui/res/cardsfolder/l/leyline_of_lifeforce.txt
@@ -3,7 +3,7 @@ ManaCost:2 G G
 Types:Enchantment
 K:MayEffectFromOpeningHand:FromHand
 SVar:FromHand:DB$ ChangeZone | Defined$ Self | Origin$ Hand | Destination$ Battlefield | SpellDescription$ If CARDNAME is in your opening hand, you may begin the game with it on the battlefield.
-S:Mode$ Continuous | Affected$ Creature | AddHiddenKeyword$ CARDNAME can't be countered. | AffectedZone$ Stack | Description$ Creature spells can't be countered.
+S:Mode$ Continuous | Affected$ Creature | AddHiddenKeyword$ This spell can't be countered. | AffectedZone$ Stack | Description$ Creature spells can't be countered.
 SVar:NonStackingEffect:True
 AI:RemoveDeck:Random
 Oracle:If Leyline of Lifeforce is in your opening hand, you may begin the game with it on the battlefield.\nCreature spells can't be countered.

--- a/forge-gui/res/cardsfolder/l/leyline_of_lifeforce.txt
+++ b/forge-gui/res/cardsfolder/l/leyline_of_lifeforce.txt
@@ -3,7 +3,7 @@ ManaCost:2 G G
 Types:Enchantment
 K:MayEffectFromOpeningHand:FromHand
 SVar:FromHand:DB$ ChangeZone | Defined$ Self | Origin$ Hand | Destination$ Battlefield | SpellDescription$ If CARDNAME is in your opening hand, you may begin the game with it on the battlefield.
-S:Mode$ Continuous | Affected$ Creature | AddHiddenKeyword$ This spell can't be countered. | AffectedZone$ Stack | Description$ Creature spells can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Creature | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Creature spells can't be countered.
 SVar:NonStackingEffect:True
 AI:RemoveDeck:Random
 Oracle:If Leyline of Lifeforce is in your opening hand, you may begin the game with it on the battlefield.\nCreature spells can't be countered.

--- a/forge-gui/res/cardsfolder/l/leyline_of_lifeforce.txt
+++ b/forge-gui/res/cardsfolder/l/leyline_of_lifeforce.txt
@@ -3,7 +3,7 @@ ManaCost:2 G G
 Types:Enchantment
 K:MayEffectFromOpeningHand:FromHand
 SVar:FromHand:DB$ ChangeZone | Defined$ Self | Origin$ Hand | Destination$ Battlefield | SpellDescription$ If CARDNAME is in your opening hand, you may begin the game with it on the battlefield.
-R:Event$ Counter | ValidCard$ Spell.Creature | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Creature spells can't be countered.
+R:Event$ Counter | ValidSA$ Spell.Creature | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Creature spells can't be countered.
 SVar:NonStackingEffect:True
 AI:RemoveDeck:Random
 Oracle:If Leyline of Lifeforce is in your opening hand, you may begin the game with it on the battlefield.\nCreature spells can't be countered.

--- a/forge-gui/res/cardsfolder/l/lier_disciple_of_the_drowned.txt
+++ b/forge-gui/res/cardsfolder/l/lier_disciple_of_the_drowned.txt
@@ -2,7 +2,7 @@ Name:Lier, Disciple of the Drowned
 ManaCost:3 U U
 Types:Legendary Creature Human Wizard
 PT:3/4
-R:Event$ Counter | ValidCard$ Spell | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Spells can't be countered.
+R:Event$ Counter | ValidSA$ Spell | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Spells can't be countered.
 S:Mode$ Continuous | Affected$ Instant.YouOwn,Sorcery.YouOwn | AffectedZone$ Graveyard | AddKeyword$ Flashback | Description$ Each instant and sorcery card in your graveyard has flashback. The flashback cost is equal to that card's mana cost.
 DeckHints:Type$Instant|Sorcery
 DeckHas:Ability$Graveyard

--- a/forge-gui/res/cardsfolder/l/lier_disciple_of_the_drowned.txt
+++ b/forge-gui/res/cardsfolder/l/lier_disciple_of_the_drowned.txt
@@ -2,7 +2,7 @@ Name:Lier, Disciple of the Drowned
 ManaCost:3 U U
 Types:Legendary Creature Human Wizard
 PT:3/4
-S:Mode$ Continuous | Affected$ Card | AddHiddenKeyword$ This spell can't be countered. | AffectedZone$ Stack | Description$ Spells can't be countered.
+R:Event$ Counter | ValidCard$ Spell | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Spells can't be countered.
 S:Mode$ Continuous | Affected$ Instant.YouOwn,Sorcery.YouOwn | AffectedZone$ Graveyard | AddKeyword$ Flashback | Description$ Each instant and sorcery card in your graveyard has flashback. The flashback cost is equal to that card's mana cost.
 DeckHints:Type$Instant|Sorcery
 DeckHas:Ability$Graveyard

--- a/forge-gui/res/cardsfolder/l/lightning_mare.txt
+++ b/forge-gui/res/cardsfolder/l/lightning_mare.txt
@@ -2,7 +2,7 @@ Name:Lightning Mare
 ManaCost:R R
 Types:Creature Elemental Horse
 PT:3/1
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 S:Mode$ CantBlockBy | ValidAttacker$ Creature.Self | ValidBlocker$ Creature.Blue | Description$ CARDNAME can't be blocked by blue creatures.
 A:AB$ Pump | Cost$ 1 R | ValidCard$ Card.Self | NumAtt$ +1 | NumDef$ +0 | SpellDescription$ CARDNAME gets +1/+0 until end of turn.
 Oracle:This spell can't be countered.\nLightning Mare can't be blocked by blue creatures.\n{1}{R}: Lightning Mare gets +1/+0 until end of turn.

--- a/forge-gui/res/cardsfolder/l/lightning_mare.txt
+++ b/forge-gui/res/cardsfolder/l/lightning_mare.txt
@@ -2,7 +2,7 @@ Name:Lightning Mare
 ManaCost:R R
 Types:Creature Elemental Horse
 PT:3/1
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 S:Mode$ CantBlockBy | ValidAttacker$ Creature.Self | ValidBlocker$ Creature.Blue | Description$ CARDNAME can't be blocked by blue creatures.
 A:AB$ Pump | Cost$ 1 R | ValidCard$ Card.Self | NumAtt$ +1 | NumDef$ +0 | SpellDescription$ CARDNAME gets +1/+0 until end of turn.
 Oracle:This spell can't be countered.\nLightning Mare can't be blocked by blue creatures.\n{1}{R}: Lightning Mare gets +1/+0 until end of turn.

--- a/forge-gui/res/cardsfolder/l/lithomantic_barrage.txt
+++ b/forge-gui/res/cardsfolder/l/lithomantic_barrage.txt
@@ -1,7 +1,7 @@
 Name:Lithomantic Barrage
 ManaCost:R
 Types:Sorcery
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ DealDamage | NumDmg$ X | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | StackDescription$ REP target creature or planeswalker_{c:Targeted} | IsCurse$ True | AITgts$ Creature.White,Creature.Blue,Planeswalker.White,Planeswalker.Blue | SpellDescription$ CARDNAME deals 1 damage to target creature or planeswalker. It deals 5 damage instead if that target is white and/or blue.
 SVar:Y:Targeted$Valid Creature.White,Creature.Blue,Planeswalker.White,Planeswalker.Blue
 SVar:X:Count$Compare Y GE1.5.1

--- a/forge-gui/res/cardsfolder/l/lithomantic_barrage.txt
+++ b/forge-gui/res/cardsfolder/l/lithomantic_barrage.txt
@@ -1,7 +1,7 @@
 Name:Lithomantic Barrage
 ManaCost:R
 Types:Sorcery
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ DealDamage | NumDmg$ X | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | StackDescription$ REP target creature or planeswalker_{c:Targeted} | IsCurse$ True | AITgts$ Creature.White,Creature.Blue,Planeswalker.White,Planeswalker.Blue | SpellDescription$ CARDNAME deals 1 damage to target creature or planeswalker. It deals 5 damage instead if that target is white and/or blue.
 SVar:Y:Targeted$Valid Creature.White,Creature.Blue,Planeswalker.White,Planeswalker.Blue
 SVar:X:Count$Compare Y GE1.5.1

--- a/forge-gui/res/cardsfolder/l/loxodon_smiter.txt
+++ b/forge-gui/res/cardsfolder/l/loxodon_smiter.txt
@@ -2,7 +2,7 @@ Name:Loxodon Smiter
 ManaCost:1 G W
 Types:Creature Elephant Soldier
 PT:4/4
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 R:Event$ Discard | ActiveZones$ Hand | ValidCard$ Card.Self | ValidSource$ Card.OppCtrl | ReplaceWith$ SurpriseETB | DiscardFromEffect$ True | Description$ If a spell or ability an opponent controls causes you to discard CARDNAME, put it onto the battlefield instead of putting it into your graveyard.
 SVar:SurpriseETB:DB$ ChangeZone | DefinedPlayer$ ReplacedPlayer | Defined$ ReplacedCard | Origin$ Hand | Destination$ Battlefield
 SVar:DiscardMeByOpp:2

--- a/forge-gui/res/cardsfolder/l/loxodon_smiter.txt
+++ b/forge-gui/res/cardsfolder/l/loxodon_smiter.txt
@@ -2,7 +2,7 @@ Name:Loxodon Smiter
 ManaCost:1 G W
 Types:Creature Elephant Soldier
 PT:4/4
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 R:Event$ Discard | ActiveZones$ Hand | ValidCard$ Card.Self | ValidSource$ Card.OppCtrl | ReplaceWith$ SurpriseETB | DiscardFromEffect$ True | Description$ If a spell or ability an opponent controls causes you to discard CARDNAME, put it onto the battlefield instead of putting it into your graveyard.
 SVar:SurpriseETB:DB$ ChangeZone | DefinedPlayer$ ReplacedPlayer | Defined$ ReplacedCard | Origin$ Hand | Destination$ Battlefield
 SVar:DiscardMeByOpp:2

--- a/forge-gui/res/cardsfolder/l/lullmage_mentor.txt
+++ b/forge-gui/res/cardsfolder/l/lullmage_mentor.txt
@@ -2,7 +2,7 @@ Name:Lullmage Mentor
 ManaCost:1 U U
 Types:Creature Merfolk Wizard
 PT:2/2
-T:Mode$ Countered | ValidCause$ Card.YouCtrl,Emblem.YouCtrl | ValidCard$ Card | ValidType$ Spell | OptionalDecider$ You | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever a spell or ability you control counters a spell, you may create a 1/1 blue Merfolk creature token.
+T:Mode$ Countered | ValidCause$ SpellAbility.YouCtrl | ValidSA$ Spell | OptionalDecider$ You | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever a spell or ability you control counters a spell, you may create a 1/1 blue Merfolk creature token.
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ u_1_1_merfolk | TokenOwner$ You
 A:AB$ Counter | Cost$ tapXType<7/Merfolk> | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | SpellDescription$ Counter target spell.
 Oracle:Whenever a spell or ability you control counters a spell, you may create a 1/1 blue Merfolk creature token.\nTap seven untapped Merfolk you control: Counter target spell.

--- a/forge-gui/res/cardsfolder/m/magic_missile.txt
+++ b/forge-gui/res/cardsfolder/m/magic_missile.txt
@@ -1,6 +1,6 @@
 Name:Magic Missile
 ManaCost:1 R R
 Types:Sorcery
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ DealDamage | Cost$ 1 R R | ValidTgts$ Any | TgtPrompt$ Select any target to distribute damage to | NumDmg$ 3 | TargetMin$ 1 | TargetMax$ 3 | DividedAsYouChoose$ 3 | SpellDescription$ CARDNAME deals 3 damage divided as you choose among one, two, or three targets.
 Oracle:This spell can't be countered.\nMagic Missile deals 3 damage divided as you choose among one, two, or three targets.

--- a/forge-gui/res/cardsfolder/m/magic_missile.txt
+++ b/forge-gui/res/cardsfolder/m/magic_missile.txt
@@ -1,6 +1,6 @@
 Name:Magic Missile
 ManaCost:1 R R
 Types:Sorcery
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ DealDamage | Cost$ 1 R R | ValidTgts$ Any | TgtPrompt$ Select any target to distribute damage to | NumDmg$ 3 | TargetMin$ 1 | TargetMax$ 3 | DividedAsYouChoose$ 3 | SpellDescription$ CARDNAME deals 3 damage divided as you choose among one, two, or three targets.
 Oracle:This spell can't be countered.\nMagic Missile deals 3 damage divided as you choose among one, two, or three targets.

--- a/forge-gui/res/cardsfolder/m/malevolent_hermit_benevolent_geist.txt
+++ b/forge-gui/res/cardsfolder/m/malevolent_hermit_benevolent_geist.txt
@@ -16,7 +16,7 @@ Colors:blue
 Types:Creature Spirit Wizard
 PT:2/2
 K:Flying
-S:Mode$ Continuous | Affected$ Card.nonCreature+YouCtrl | AffectedZone$ Stack | AddHiddenKeyword$ CARDNAME can't be countered. | Description$ Noncreature spells you control can't be countered.
+S:Mode$ Continuous | Affected$ Card.nonCreature+YouCtrl | AffectedZone$ Stack | AddHiddenKeyword$ This spell can't be countered. | Description$ Noncreature spells you control can't be countered.
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Graveyard | ReplaceWith$ Exile | Description$ If CARDNAME would be put into a graveyard from anywhere, exile it instead.
 SVar:Exile:DB$ ChangeZone | Hidden$ True | Origin$ All | Destination$ Exile | Defined$ ReplacedCard
 Oracle:Flying\nNoncreature spells you control can't be countered.\nIf Benevolent Geist would be put into a graveyard from anywhere, exile it instead.

--- a/forge-gui/res/cardsfolder/m/malevolent_hermit_benevolent_geist.txt
+++ b/forge-gui/res/cardsfolder/m/malevolent_hermit_benevolent_geist.txt
@@ -16,7 +16,7 @@ Colors:blue
 Types:Creature Spirit Wizard
 PT:2/2
 K:Flying
-R:Event$ Counter | ValidCard$ Spell.nonCreature+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Noncreature spells you control can't be countered.
+R:Event$ Counter | ValidSA$ Spell.nonCreature+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Noncreature spells you control can't be countered.
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Graveyard | ReplaceWith$ Exile | Description$ If CARDNAME would be put into a graveyard from anywhere, exile it instead.
 SVar:Exile:DB$ ChangeZone | Hidden$ True | Origin$ All | Destination$ Exile | Defined$ ReplacedCard
 Oracle:Flying\nNoncreature spells you control can't be countered.\nIf Benevolent Geist would be put into a graveyard from anywhere, exile it instead.

--- a/forge-gui/res/cardsfolder/m/malevolent_hermit_benevolent_geist.txt
+++ b/forge-gui/res/cardsfolder/m/malevolent_hermit_benevolent_geist.txt
@@ -16,7 +16,7 @@ Colors:blue
 Types:Creature Spirit Wizard
 PT:2/2
 K:Flying
-S:Mode$ Continuous | Affected$ Card.nonCreature+YouCtrl | AffectedZone$ Stack | AddHiddenKeyword$ This spell can't be countered. | Description$ Noncreature spells you control can't be countered.
+R:Event$ Counter | ValidCard$ Spell.nonCreature+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Noncreature spells you control can't be countered.
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Graveyard | ReplaceWith$ Exile | Description$ If CARDNAME would be put into a graveyard from anywhere, exile it instead.
 SVar:Exile:DB$ ChangeZone | Hidden$ True | Origin$ All | Destination$ Exile | Defined$ ReplacedCard
 Oracle:Flying\nNoncreature spells you control can't be countered.\nIf Benevolent Geist would be put into a graveyard from anywhere, exile it instead.

--- a/forge-gui/res/cardsfolder/m/mistcutter_hydra.txt
+++ b/forge-gui/res/cardsfolder/m/mistcutter_hydra.txt
@@ -2,7 +2,7 @@ Name:Mistcutter Hydra
 ManaCost:X G
 Types:Creature Hydra
 PT:0/0
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Haste
 K:Protection from blue
 K:etbCounter:P1P1:X

--- a/forge-gui/res/cardsfolder/m/mistcutter_hydra.txt
+++ b/forge-gui/res/cardsfolder/m/mistcutter_hydra.txt
@@ -2,7 +2,7 @@ Name:Mistcutter Hydra
 ManaCost:X G
 Types:Creature Hydra
 PT:0/0
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Haste
 K:Protection from blue
 K:etbCounter:P1P1:X

--- a/forge-gui/res/cardsfolder/n/nezahal_primal_tide.txt
+++ b/forge-gui/res/cardsfolder/n/nezahal_primal_tide.txt
@@ -2,7 +2,7 @@ Name:Nezahal, Primal Tide
 ManaCost:5 U U
 Types:Legendary Creature Elder Dinosaur
 PT:7/7
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 S:Mode$ Continuous | Affected$ You | SetMaxHandSize$ Unlimited | Description$ You have no maximum hand size.
 T:Mode$ SpellCast | TriggerZones$ Battlefield | ValidCard$ Card.nonCreature | ValidActivatingPlayer$ Opponent | Execute$ TrigDraw | TriggerDescription$ Whenever an opponent casts a noncreature spell, draw a card.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1

--- a/forge-gui/res/cardsfolder/n/nezahal_primal_tide.txt
+++ b/forge-gui/res/cardsfolder/n/nezahal_primal_tide.txt
@@ -2,7 +2,7 @@ Name:Nezahal, Primal Tide
 ManaCost:5 U U
 Types:Legendary Creature Elder Dinosaur
 PT:7/7
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 S:Mode$ Continuous | Affected$ You | SetMaxHandSize$ Unlimited | Description$ You have no maximum hand size.
 T:Mode$ SpellCast | TriggerZones$ Battlefield | ValidCard$ Card.nonCreature | ValidActivatingPlayer$ Opponent | Execute$ TrigDraw | TriggerDescription$ Whenever an opponent casts a noncreature spell, draw a card.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1

--- a/forge-gui/res/cardsfolder/n/niv_mizzet_parun.txt
+++ b/forge-gui/res/cardsfolder/n/niv_mizzet_parun.txt
@@ -3,7 +3,7 @@ ManaCost:U U U R R R
 Types:Legendary Creature Dragon Wizard
 PT:5/5
 K:Flying
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 T:Mode$ Drawn | ValidCard$ Card.YouOwn | TriggerZones$ Battlefield | Execute$ TrigDealDamage | TriggerDescription$ Whenever you draw a card, CARDNAME deals 1 damage to any target.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Any | NumDmg$ 1
 T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ Whenever a player casts an instant or sorcery spell, you draw a card.

--- a/forge-gui/res/cardsfolder/n/niv_mizzet_parun.txt
+++ b/forge-gui/res/cardsfolder/n/niv_mizzet_parun.txt
@@ -3,7 +3,7 @@ ManaCost:U U U R R R
 Types:Legendary Creature Dragon Wizard
 PT:5/5
 K:Flying
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 T:Mode$ Drawn | ValidCard$ Card.YouOwn | TriggerZones$ Battlefield | Execute$ TrigDealDamage | TriggerDescription$ Whenever you draw a card, CARDNAME deals 1 damage to any target.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Any | NumDmg$ 1
 T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ Whenever a player casts an instant or sorcery spell, you draw a card.

--- a/forge-gui/res/cardsfolder/o/obliterate.txt
+++ b/forge-gui/res/cardsfolder/o/obliterate.txt
@@ -2,5 +2,5 @@ Name:Obliterate
 ManaCost:6 R R
 Types:Sorcery
 A:SP$ DestroyAll | Cost$ 6 R R | ValidCards$ Artifact,Creature,Land | NoRegen$ True | SpellDescription$ Destroy all artifacts, creatures, and lands. They can't be regenerated.
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 Oracle:This spell can't be countered.\nDestroy all artifacts, creatures, and lands. They can't be regenerated.

--- a/forge-gui/res/cardsfolder/o/obliterate.txt
+++ b/forge-gui/res/cardsfolder/o/obliterate.txt
@@ -2,5 +2,5 @@ Name:Obliterate
 ManaCost:6 R R
 Types:Sorcery
 A:SP$ DestroyAll | Cost$ 6 R R | ValidCards$ Artifact,Creature,Land | NoRegen$ True | SpellDescription$ Destroy all artifacts, creatures, and lands. They can't be regenerated.
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 Oracle:This spell can't be countered.\nDestroy all artifacts, creatures, and lands. They can't be regenerated.

--- a/forge-gui/res/cardsfolder/o/overmaster.txt
+++ b/forge-gui/res/cardsfolder/o/overmaster.txt
@@ -1,9 +1,9 @@
 Name:Overmaster
 ManaCost:R
 Types:Sorcery
-A:SP$ Effect | Triggers$ SpellCastTrig | SubAbility$ DBDraw | SpellDescription$ The next instant or sorcery spell you cast this turn can't be countered.
+A:SP$ DelayedTrigger | Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | Execute$ DBEffect | ThisTurn$ True | Static$ True | SubAbility$ DBDraw | SpellDescription$ The next instant or sorcery spell you cast this turn can't be countered.
+SVar:DBEffect:DB$ Effect | ReplacementEffects$ AntiMagic | RememberObjects$ TriggeredCard | ForgetOnMoved$ Stack
+SVar:AntiMagic:Event$ Counter | ValidCard$ Spell.IsRemembered | Layer$ CantHappen | Description$ This spell can't be countered.
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | SpellDescription$ Draw a card.
-SVar:SpellCastTrig:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | Execute$ Mastery | OneOff$ True | Static$ True | TriggerDescription$ The next instant or sorcery spell you cast this turn can't be countered.
-SVar:Mastery:DB$ Pump | Defined$ TriggeredCard | KW$ HIDDEN This spell can't be countered. | PumpZone$ Stack
 AI:RemoveDeck:All
 Oracle:The next instant or sorcery spell you cast this turn can't be countered.\nDraw a card.

--- a/forge-gui/res/cardsfolder/o/overmaster.txt
+++ b/forge-gui/res/cardsfolder/o/overmaster.txt
@@ -4,6 +4,6 @@ Types:Sorcery
 A:SP$ Effect | Triggers$ SpellCastTrig | SubAbility$ DBDraw | SpellDescription$ The next instant or sorcery spell you cast this turn can't be countered.
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | SpellDescription$ Draw a card.
 SVar:SpellCastTrig:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | Execute$ Mastery | OneOff$ True | Static$ True | TriggerDescription$ The next instant or sorcery spell you cast this turn can't be countered.
-SVar:Mastery:DB$ Pump | Defined$ TriggeredCard | KW$ HIDDEN CARDNAME can't be countered. | PumpZone$ Stack
+SVar:Mastery:DB$ Pump | Defined$ TriggeredCard | KW$ HIDDEN This spell can't be countered. | PumpZone$ Stack
 AI:RemoveDeck:All
 Oracle:The next instant or sorcery spell you cast this turn can't be countered.\nDraw a card.

--- a/forge-gui/res/cardsfolder/o/overmaster.txt
+++ b/forge-gui/res/cardsfolder/o/overmaster.txt
@@ -3,7 +3,7 @@ ManaCost:R
 Types:Sorcery
 A:SP$ DelayedTrigger | Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | Execute$ DBEffect | ThisTurn$ True | Static$ True | SubAbility$ DBDraw | SpellDescription$ The next instant or sorcery spell you cast this turn can't be countered.
 SVar:DBEffect:DB$ Effect | ReplacementEffects$ AntiMagic | RememberObjects$ TriggeredCard | ForgetOnMoved$ Stack
-SVar:AntiMagic:Event$ Counter | ValidCard$ Spell.IsRemembered | Layer$ CantHappen | Description$ This spell can't be countered.
+SVar:AntiMagic:Event$ Counter | ValidCard$ Card.IsRemembered | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | SpellDescription$ Draw a card.
 AI:RemoveDeck:All
 Oracle:The next instant or sorcery spell you cast this turn can't be countered.\nDraw a card.

--- a/forge-gui/res/cardsfolder/o/overwhelming_denial.txt
+++ b/forge-gui/res/cardsfolder/o/overwhelming_denial.txt
@@ -3,5 +3,5 @@ ManaCost:2 U U
 Types:Instant
 K:Surge:U U
 A:SP$ Counter | Cost$ 2 U U | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | SpellDescription$ Counter target spell.
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 Oracle:Surge {U}{U} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nThis spell can't be countered.\nCounter target spell.

--- a/forge-gui/res/cardsfolder/o/overwhelming_denial.txt
+++ b/forge-gui/res/cardsfolder/o/overwhelming_denial.txt
@@ -3,5 +3,5 @@ ManaCost:2 U U
 Types:Instant
 K:Surge:U U
 A:SP$ Counter | Cost$ 2 U U | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | SpellDescription$ Counter target spell.
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 Oracle:Surge {U}{U} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nThis spell can't be countered.\nCounter target spell.

--- a/forge-gui/res/cardsfolder/p/pearl_lake_ancient.txt
+++ b/forge-gui/res/cardsfolder/p/pearl_lake_ancient.txt
@@ -4,6 +4,6 @@ Types:Creature Leviathan
 PT:6/7
 K:Flash
 K:Prowess
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:AB$ ChangeZone | Cost$ Return<3/Land> | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return CARDNAME to its owner's hand.
 Oracle:Flash\nThis spell can't be countered.\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nReturn three lands you control to their owner's hand: Return Pearl Lake Ancient to its owner's hand.

--- a/forge-gui/res/cardsfolder/p/pearl_lake_ancient.txt
+++ b/forge-gui/res/cardsfolder/p/pearl_lake_ancient.txt
@@ -4,6 +4,6 @@ Types:Creature Leviathan
 PT:6/7
 K:Flash
 K:Prowess
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:AB$ ChangeZone | Cost$ Return<3/Land> | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return CARDNAME to its owner's hand.
 Oracle:Flash\nThis spell can't be countered.\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nReturn three lands you control to their owner's hand: Return Pearl Lake Ancient to its owner's hand.

--- a/forge-gui/res/cardsfolder/p/petrified_wood_kin.txt
+++ b/forge-gui/res/cardsfolder/p/petrified_wood_kin.txt
@@ -2,7 +2,7 @@ Name:Petrified Wood-Kin
 ManaCost:6 G
 Types:Creature Elemental Warrior
 PT:3/3
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Bloodthirst:X
 K:Protection:Instant:instants
 Oracle:This spell can't be countered.\nBloodthirst X (This creature enters the battlefield with X +1/+1 counters on it, where X is the damage dealt to your opponents this turn.)\nProtection from instants

--- a/forge-gui/res/cardsfolder/p/petrified_wood_kin.txt
+++ b/forge-gui/res/cardsfolder/p/petrified_wood_kin.txt
@@ -2,7 +2,7 @@ Name:Petrified Wood-Kin
 ManaCost:6 G
 Types:Creature Elemental Warrior
 PT:3/3
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Bloodthirst:X
 K:Protection:Instant:instants
 Oracle:This spell can't be countered.\nBloodthirst X (This creature enters the battlefield with X +1/+1 counters on it, where X is the damage dealt to your opponents this turn.)\nProtection from instants

--- a/forge-gui/res/cardsfolder/p/prowling_serpopard.txt
+++ b/forge-gui/res/cardsfolder/p/prowling_serpopard.txt
@@ -2,7 +2,7 @@ Name:Prowling Serpopard
 ManaCost:1 G G
 Types:Creature Cat Snake
 PT:4/3
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 S:Mode$ Continuous | Affected$ Creature.YouCtrl | AffectedZone$ Stack | AddHiddenKeyword$ This spell can't be countered. | Description$ Creature spells you control can't be countered.
 SVar:PlayMain1:TRUE
 Oracle:This spell can't be countered.\nCreature spells you control can't be countered.

--- a/forge-gui/res/cardsfolder/p/prowling_serpopard.txt
+++ b/forge-gui/res/cardsfolder/p/prowling_serpopard.txt
@@ -2,7 +2,7 @@ Name:Prowling Serpopard
 ManaCost:1 G G
 Types:Creature Cat Snake
 PT:4/3
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
-R:Event$ Counter | ValidCard$ Spell.Creature+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Creature spells you control can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidSA$ Spell.Creature+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Creature spells you control can't be countered.
 SVar:PlayMain1:TRUE
 Oracle:This spell can't be countered.\nCreature spells you control can't be countered.

--- a/forge-gui/res/cardsfolder/p/prowling_serpopard.txt
+++ b/forge-gui/res/cardsfolder/p/prowling_serpopard.txt
@@ -3,6 +3,6 @@ ManaCost:1 G G
 Types:Creature Cat Snake
 PT:4/3
 R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
-S:Mode$ Continuous | Affected$ Creature.YouCtrl | AffectedZone$ Stack | AddHiddenKeyword$ This spell can't be countered. | Description$ Creature spells you control can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Creature+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Creature spells you control can't be countered.
 SVar:PlayMain1:TRUE
 Oracle:This spell can't be countered.\nCreature spells you control can't be countered.

--- a/forge-gui/res/cardsfolder/r/raze_to_the_ground.txt
+++ b/forge-gui/res/cardsfolder/r/raze_to_the_ground.txt
@@ -1,7 +1,7 @@
 Name:Raze to the Ground
 ManaCost:2 R
 Types:Sorcery
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ Destroy | ValidTgts$ Artifact | SubAbility$ DBDraw | RememberLKI$ True | AlwaysRemember$ True | SpellDescription$ Destroy target artifact. If its mana value was 1 or less, draw a card.
 SVar:DBDraw:DB$ Draw | ConditionCheckSVar$ X | ConditionSVarCompare$ LE1 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/r/raze_to_the_ground.txt
+++ b/forge-gui/res/cardsfolder/r/raze_to_the_ground.txt
@@ -1,7 +1,7 @@
 Name:Raze to the Ground
 ManaCost:2 R
 Types:Sorcery
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ Destroy | ValidTgts$ Artifact | SubAbility$ DBDraw | RememberLKI$ True | AlwaysRemember$ True | SpellDescription$ Destroy target artifact. If its mana value was 1 or less, draw a card.
 SVar:DBDraw:DB$ Draw | ConditionCheckSVar$ X | ConditionSVarCompare$ LE1 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/r/rending_volley.txt
+++ b/forge-gui/res/cardsfolder/r/rending_volley.txt
@@ -1,7 +1,7 @@
 Name:Rending Volley
 ManaCost:R
 Types:Instant
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ DealDamage | Cost$ R | ValidTgts$ Creature.White,Creature.Blue | NumDmg$ 4 | TgtPrompt$ Select target white or blue creature. | SpellDescription$ CARDNAME deals 4 damage to target white or blue creature.
 AI:RemoveDeck:Random
 Oracle:This spell can't be countered.\nRending Volley deals 4 damage to target white or blue creature.

--- a/forge-gui/res/cardsfolder/r/rending_volley.txt
+++ b/forge-gui/res/cardsfolder/r/rending_volley.txt
@@ -1,7 +1,7 @@
 Name:Rending Volley
 ManaCost:R
 Types:Instant
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ DealDamage | Cost$ R | ValidTgts$ Creature.White,Creature.Blue | NumDmg$ 4 | TgtPrompt$ Select target white or blue creature. | SpellDescription$ CARDNAME deals 4 damage to target white or blue creature.
 AI:RemoveDeck:Random
 Oracle:This spell can't be countered.\nRending Volley deals 4 damage to target white or blue creature.

--- a/forge-gui/res/cardsfolder/r/rhythm_of_the_wild.txt
+++ b/forge-gui/res/cardsfolder/r/rhythm_of_the_wild.txt
@@ -1,7 +1,7 @@
 Name:Rhythm of the Wild
 ManaCost:1 R G
 Types:Enchantment
-R:Event$ Counter | ValidCard$ Spell.Creature+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Creature spells you control can't be countered.
+R:Event$ Counter | ValidSA$ Spell.Creature+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Creature spells you control can't be countered.
 S:Mode$ Continuous | Affected$ Creature.nonToken+YouCtrl | AddKeyword$ Riot | Description$ Nontoken creatures you control have riot. (They enter the battlefield with your choice of a +1/+1 counter or haste.)
 SVar:PlayMain1:TRUE
 DeckHas:Ability$Counters

--- a/forge-gui/res/cardsfolder/r/rhythm_of_the_wild.txt
+++ b/forge-gui/res/cardsfolder/r/rhythm_of_the_wild.txt
@@ -1,7 +1,7 @@
 Name:Rhythm of the Wild
 ManaCost:1 R G
 Types:Enchantment
-S:Mode$ Continuous | Affected$ Creature.YouCtrl | AffectedZone$ Stack | AddHiddenKeyword$ This spell can't be countered. | Description$ Creature spells you control can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Creature+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Creature spells you control can't be countered.
 S:Mode$ Continuous | Affected$ Creature.nonToken+YouCtrl | AddKeyword$ Riot | Description$ Nontoken creatures you control have riot. (They enter the battlefield with your choice of a +1/+1 counter or haste.)
 SVar:PlayMain1:TRUE
 DeckHas:Ability$Counters

--- a/forge-gui/res/cardsfolder/r/rhythm_of_the_wild.txt
+++ b/forge-gui/res/cardsfolder/r/rhythm_of_the_wild.txt
@@ -1,7 +1,7 @@
 Name:Rhythm of the Wild
 ManaCost:1 R G
 Types:Enchantment
-S:Mode$ Continuous | Affected$ Creature.YouCtrl | AffectedZone$ Stack | AddHiddenKeyword$ CARDNAME can't be countered. | Description$ Creature spells you control can't be countered.
+S:Mode$ Continuous | Affected$ Creature.YouCtrl | AffectedZone$ Stack | AddHiddenKeyword$ This spell can't be countered. | Description$ Creature spells you control can't be countered.
 S:Mode$ Continuous | Affected$ Creature.nonToken+YouCtrl | AddKeyword$ Riot | Description$ Nontoken creatures you control have riot. (They enter the battlefield with your choice of a +1/+1 counter or haste.)
 SVar:PlayMain1:TRUE
 DeckHas:Ability$Counters

--- a/forge-gui/res/cardsfolder/r/rise_of_the_eldrazi.txt
+++ b/forge-gui/res/cardsfolder/r/rise_of_the_eldrazi.txt
@@ -1,7 +1,7 @@
 Name:Rise of the Eldrazi
 ManaCost:9 C C C
 Types:Sorcery
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ Destroy | ValidTgts$ Permanent| SubAbility$ DBDraw | SpellDescription$ Destroy target permanent.
 SVar:DBDraw:DB$ Draw | NumCards$ 4 | ValidTgts$ Player | TgtPrompt$ Select target player | SubAbility$ DBExtraTurn | SpellDescription$ Target player draws four cards.
 SVar:DBExtraTurn: DB$ AddTurn | Defined$ You | NumTurns$ 1 | SubAbility$ DBChange | SpellDescription$ Take an extra turn after this one.

--- a/forge-gui/res/cardsfolder/r/rise_of_the_eldrazi.txt
+++ b/forge-gui/res/cardsfolder/r/rise_of_the_eldrazi.txt
@@ -1,7 +1,7 @@
 Name:Rise of the Eldrazi
 ManaCost:9 C C C
 Types:Sorcery
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ Destroy | ValidTgts$ Permanent| SubAbility$ DBDraw | SpellDescription$ Destroy target permanent.
 SVar:DBDraw:DB$ Draw | NumCards$ 4 | ValidTgts$ Player | TgtPrompt$ Select target player | SubAbility$ DBExtraTurn | SpellDescription$ Target player draws four cards.
 SVar:DBExtraTurn: DB$ AddTurn | Defined$ You | NumTurns$ 1 | SubAbility$ DBChange | SpellDescription$ Take an extra turn after this one.

--- a/forge-gui/res/cardsfolder/r/root_sliver.txt
+++ b/forge-gui/res/cardsfolder/r/root_sliver.txt
@@ -2,6 +2,6 @@ Name:Root Sliver
 ManaCost:3 G
 Types:Creature Sliver
 PT:2/2
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
-R:Event$ Counter | ValidCard$ Spell.Sliver | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Sliver spells can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidSA$ Spell.Sliver | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Sliver spells can't be countered.
 Oracle:This spell can't be countered.\nSliver spells can't be countered.

--- a/forge-gui/res/cardsfolder/r/root_sliver.txt
+++ b/forge-gui/res/cardsfolder/r/root_sliver.txt
@@ -2,6 +2,6 @@ Name:Root Sliver
 ManaCost:3 G
 Types:Creature Sliver
 PT:2/2
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 S:Mode$ Continuous | Affected$ Sliver | AddHiddenKeyword$ This spell can't be countered. | AffectedZone$ Stack | Description$ Sliver spells can't be countered.
 Oracle:This spell can't be countered.\nSliver spells can't be countered.

--- a/forge-gui/res/cardsfolder/r/root_sliver.txt
+++ b/forge-gui/res/cardsfolder/r/root_sliver.txt
@@ -3,5 +3,5 @@ ManaCost:3 G
 Types:Creature Sliver
 PT:2/2
 R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
-S:Mode$ Continuous | Affected$ Sliver | AddHiddenKeyword$ This spell can't be countered. | AffectedZone$ Stack | Description$ Sliver spells can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Sliver | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Sliver spells can't be countered.
 Oracle:This spell can't be countered.\nSliver spells can't be countered.

--- a/forge-gui/res/cardsfolder/rebalanced/a-lier_disciple_of_the_drowned.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-lier_disciple_of_the_drowned.txt
@@ -2,7 +2,7 @@ Name:A-Lier, Disciple of the Drowned
 ManaCost:3 U U
 Types:Legendary Creature Human Wizard
 PT:3/4
-R:Event$ Counter | ValidCard$ Spell | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Spells can't be countered.
+R:Event$ Counter | ValidSA$ Spell | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Spells can't be countered.
 S:Mode$ Continuous | Affected$ Instant.YouOwn,Sorcery.YouOwn | AffectedZone$ Graveyard | AddKeyword$ Flashback | Condition$ PlayerTurn | Description$ As long as it's your turn, each instant and sorcery card in your graveyard has flashback. The flashback cost is equal to that card's mana cost.
 DeckHints:Type$Instant|Sorcery
 DeckHas:Ability$Graveyard

--- a/forge-gui/res/cardsfolder/rebalanced/a-lier_disciple_of_the_drowned.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-lier_disciple_of_the_drowned.txt
@@ -2,7 +2,7 @@ Name:A-Lier, Disciple of the Drowned
 ManaCost:3 U U
 Types:Legendary Creature Human Wizard
 PT:3/4
-S:Mode$ Continuous | Affected$ Card | AddHiddenKeyword$ This spell can't be countered. | AffectedZone$ Stack | Description$ Spells can't be countered.
+R:Event$ Counter | ValidCard$ Spell | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Spells can't be countered.
 S:Mode$ Continuous | Affected$ Instant.YouOwn,Sorcery.YouOwn | AffectedZone$ Graveyard | AddKeyword$ Flashback | Condition$ PlayerTurn | Description$ As long as it's your turn, each instant and sorcery card in your graveyard has flashback. The flashback cost is equal to that card's mana cost.
 DeckHints:Type$Instant|Sorcery
 DeckHas:Ability$Graveyard

--- a/forge-gui/res/cardsfolder/s/savage_summoning.txt
+++ b/forge-gui/res/cardsfolder/s/savage_summoning.txt
@@ -3,12 +3,11 @@ ManaCost:G
 Types:Instant
 R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ Effect | Cost$ G | StaticAbilities$ STFlash | Triggers$ SpellCastTrig | SpellDescription$ The next creature spell you cast this turn can be cast as though it had flash. That spell can't be countered. That creature enters the battlefield with an additional +1/+1 counter on it.
-SVar:STFlash:Mode$ CastWithFlash | ValidCard$ Card.Creature | ValidSA$ Spell | EffectZone$ Command | Caster$ You
-SVar:SpellCastTrig:Mode$ SpellCast | ValidCard$ Creature | ValidActivatingPlayer$ You | Execute$ SavageSummon | Static$ True | TriggerDescription$ The next creature spell you cast this turn can be cast as though it had flash. That spell can't be countered. That creature enters the battlefield with an additional +1/+1 counter on it.
-SVar:SavageSummon:DB$ Effect | StaticAbilities$ STCantBeCountered | ReplacementEffects$ ETBCounters | RememberObjects$ TriggeredCard | SubAbility$ ExileSelf
-SVar:STCantBeCountered:Mode$ Continuous | EffectZone$ Command | Affected$ Card.IsRemembered | AddHiddenKeyword$ This spell can't be countered. | AffectedZone$ Stack | Description$ That spell can't be countered.
+SVar:STFlash:Mode$ CastWithFlash | ValidCard$ Card.Creature | ValidSA$ Spell | Caster$ You
+SVar:SpellCastTrig:Mode$ SpellCast | ValidCard$ Creature | ValidActivatingPlayer$ You | Execute$ SavageSummon | OneOff$ True | Static$ True | TriggerDescription$ The next creature spell you cast this turn can be cast as though it had flash. That spell can't be countered. That creature enters the battlefield with an additional +1/+1 counter on it.
+SVar:SavageSummon:DB$ Effect | ReplacementEffects$ AntiMagic,ETBCounters | RememberObjects$ TriggeredCard | ForgetOnMoved$ Stack
+SVar:AntiMagic:Event$ Counter | ValidCard$ Spell.IsRemembered | Layer$ CantHappen | Description$ That spell can't be countered.
 SVar:ETBCounters:Event$ Moved | Origin$ Stack | Destination$ Battlefield | ValidCard$ Card.IsRemembered | ReplaceWith$ ETBAddExtraCounter | ReplacementResult$ Updated | Description$ That creature enters the battlefield with an additional +1/+1 counters on it.
-SVar:ETBAddExtraCounter:DB$ PutCounter | ETB$ True | Defined$ ReplacedCard | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ ExileSelf
-SVar:ExileSelf:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
+SVar:ETBAddExtraCounter:DB$ PutCounter | ETB$ True | Defined$ ReplacedCard | CounterType$ P1P1 | CounterNum$ 1
 AI:RemoveDeck:All
 Oracle:This spell can't be countered.\nThe next creature spell you cast this turn can be cast as though it had flash. That spell can't be countered. That creature enters the battlefield with an additional +1/+1 counter on it.

--- a/forge-gui/res/cardsfolder/s/savage_summoning.txt
+++ b/forge-gui/res/cardsfolder/s/savage_summoning.txt
@@ -1,12 +1,12 @@
 Name:Savage Summoning
 ManaCost:G
 Types:Instant
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ Effect | Cost$ G | StaticAbilities$ STFlash | Triggers$ SpellCastTrig | SpellDescription$ The next creature spell you cast this turn can be cast as though it had flash. That spell can't be countered. That creature enters the battlefield with an additional +1/+1 counter on it.
 SVar:STFlash:Mode$ CastWithFlash | ValidCard$ Card.Creature | ValidSA$ Spell | Caster$ You
 SVar:SpellCastTrig:Mode$ SpellCast | ValidCard$ Creature | ValidActivatingPlayer$ You | Execute$ SavageSummon | OneOff$ True | Static$ True | TriggerDescription$ The next creature spell you cast this turn can be cast as though it had flash. That spell can't be countered. That creature enters the battlefield with an additional +1/+1 counter on it.
 SVar:SavageSummon:DB$ Effect | ReplacementEffects$ AntiMagic,ETBCounters | RememberObjects$ TriggeredCard | ForgetOnMoved$ Stack
-SVar:AntiMagic:Event$ Counter | ValidCard$ Spell.IsRemembered | Layer$ CantHappen | Description$ That spell can't be countered.
+SVar:AntiMagic:Event$ Counter | ValidCard$ Card.IsRemembered | ValidSA$ Spell | Layer$ CantHappen | Description$ That spell can't be countered.
 SVar:ETBCounters:Event$ Moved | Origin$ Stack | Destination$ Battlefield | ValidCard$ Card.IsRemembered | ReplaceWith$ ETBAddExtraCounter | ReplacementResult$ Updated | Description$ That creature enters the battlefield with an additional +1/+1 counters on it.
 SVar:ETBAddExtraCounter:DB$ PutCounter | ETB$ True | Defined$ ReplacedCard | CounterType$ P1P1 | CounterNum$ 1
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/s/savage_summoning.txt
+++ b/forge-gui/res/cardsfolder/s/savage_summoning.txt
@@ -1,12 +1,12 @@
 Name:Savage Summoning
 ManaCost:G
 Types:Instant
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ Effect | Cost$ G | StaticAbilities$ STFlash | Triggers$ SpellCastTrig | SpellDescription$ The next creature spell you cast this turn can be cast as though it had flash. That spell can't be countered. That creature enters the battlefield with an additional +1/+1 counter on it.
 SVar:STFlash:Mode$ CastWithFlash | ValidCard$ Card.Creature | ValidSA$ Spell | EffectZone$ Command | Caster$ You
 SVar:SpellCastTrig:Mode$ SpellCast | ValidCard$ Creature | ValidActivatingPlayer$ You | Execute$ SavageSummon | Static$ True | TriggerDescription$ The next creature spell you cast this turn can be cast as though it had flash. That spell can't be countered. That creature enters the battlefield with an additional +1/+1 counter on it.
 SVar:SavageSummon:DB$ Effect | StaticAbilities$ STCantBeCountered | ReplacementEffects$ ETBCounters | RememberObjects$ TriggeredCard | SubAbility$ ExileSelf
-SVar:STCantBeCountered:Mode$ Continuous | EffectZone$ Command | Affected$ Card.IsRemembered | AddHiddenKeyword$ CARDNAME can't be countered. | AffectedZone$ Stack | Description$ That spell can't be countered.
+SVar:STCantBeCountered:Mode$ Continuous | EffectZone$ Command | Affected$ Card.IsRemembered | AddHiddenKeyword$ This spell can't be countered. | AffectedZone$ Stack | Description$ That spell can't be countered.
 SVar:ETBCounters:Event$ Moved | Origin$ Stack | Destination$ Battlefield | ValidCard$ Card.IsRemembered | ReplaceWith$ ETBAddExtraCounter | ReplacementResult$ Updated | Description$ That creature enters the battlefield with an additional +1/+1 counters on it.
 SVar:ETBAddExtraCounter:DB$ PutCounter | ETB$ True | Defined$ ReplacedCard | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ ExileSelf
 SVar:ExileSelf:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile

--- a/forge-gui/res/cardsfolder/s/scragnoth.txt
+++ b/forge-gui/res/cardsfolder/s/scragnoth.txt
@@ -3,5 +3,5 @@ ManaCost:4 G
 Types:Creature Beast
 PT:3/4
 K:Protection from blue
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 Oracle:This spell can't be countered.\nProtection from blue

--- a/forge-gui/res/cardsfolder/s/scragnoth.txt
+++ b/forge-gui/res/cardsfolder/s/scragnoth.txt
@@ -3,5 +3,5 @@ ManaCost:4 G
 Types:Creature Beast
 PT:3/4
 K:Protection from blue
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 Oracle:This spell can't be countered.\nProtection from blue

--- a/forge-gui/res/cardsfolder/s/shifting_ceratops.txt
+++ b/forge-gui/res/cardsfolder/s/shifting_ceratops.txt
@@ -2,7 +2,7 @@ Name:Shifting Ceratops
 ManaCost:2 G G
 Types:Creature Dinosaur
 PT:5/4
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Protection from blue
 A:AB$ Pump | Cost$ G | KWChoice$ Reach,Trample,Haste | StackDescription$ SpellDescription | SpellDescription$ CARDNAME gains your choice of reach, trample, or haste until end of turn.
 Oracle:This spell can't be countered.\nProtection from blue (This creature can't be blocked, targeted, dealt damage, enchanted, or equipped by anything blue.)\n{G}: Shifting Ceratops gains your choice of reach, trample, or haste until end of turn.

--- a/forge-gui/res/cardsfolder/s/shifting_ceratops.txt
+++ b/forge-gui/res/cardsfolder/s/shifting_ceratops.txt
@@ -2,7 +2,7 @@ Name:Shifting Ceratops
 ManaCost:2 G G
 Types:Creature Dinosaur
 PT:5/4
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Protection from blue
 A:AB$ Pump | Cost$ G | KWChoice$ Reach,Trample,Haste | StackDescription$ SpellDescription | SpellDescription$ CARDNAME gains your choice of reach, trample, or haste until end of turn.
 Oracle:This spell can't be countered.\nProtection from blue (This creature can't be blocked, targeted, dealt damage, enchanted, or equipped by anything blue.)\n{G}: Shifting Ceratops gains your choice of reach, trample, or haste until end of turn.

--- a/forge-gui/res/cardsfolder/s/skylasher.txt
+++ b/forge-gui/res/cardsfolder/s/skylasher.txt
@@ -3,7 +3,7 @@ ManaCost:1 G
 Types:Creature Insect
 PT:2/2
 K:Flash
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Reach
 K:Protection from blue
 Oracle:Flash\nThis spell can't be countered.\nReach, protection from blue

--- a/forge-gui/res/cardsfolder/s/skylasher.txt
+++ b/forge-gui/res/cardsfolder/s/skylasher.txt
@@ -3,7 +3,7 @@ ManaCost:1 G
 Types:Creature Insect
 PT:2/2
 K:Flash
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Reach
 K:Protection from blue
 Oracle:Flash\nThis spell can't be countered.\nReach, protection from blue

--- a/forge-gui/res/cardsfolder/s/slaughter_games.txt
+++ b/forge-gui/res/cardsfolder/s/slaughter_games.txt
@@ -1,7 +1,7 @@
 Name:Slaughter Games
 ManaCost:2 B R
 Types:Sorcery
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ NameCard | Cost$ 2 B R | Defined$ You | ValidCards$ Card.nonLand | ValidDesc$ nonland | SubAbility$ ExileYard | SpellDescription$ Choose a nonland card name. Search target opponent's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles.
 SVar:ExileYard:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | ValidTgts$ Player.Opponent | TgtPrompt$ Select target opponent | ChangeType$ Card.NamedCard | Chooser$ You | ChangeNum$ NumInYard | Hidden$ True | SubAbility$ ExileHand | StackDescription$ Search target opponent's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles their library.
 SVar:ExileHand:DB$ ChangeZone | Origin$ Hand | Destination$ Exile | DefinedPlayer$ Targeted | ChangeType$ Card.NamedCard | ChangeNum$ NumInHand | Chooser$ You | SubAbility$ ExileLib | StackDescription$ None

--- a/forge-gui/res/cardsfolder/s/slaughter_games.txt
+++ b/forge-gui/res/cardsfolder/s/slaughter_games.txt
@@ -1,7 +1,7 @@
 Name:Slaughter Games
 ManaCost:2 B R
 Types:Sorcery
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ NameCard | Cost$ 2 B R | Defined$ You | ValidCards$ Card.nonLand | ValidDesc$ nonland | SubAbility$ ExileYard | SpellDescription$ Choose a nonland card name. Search target opponent's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles.
 SVar:ExileYard:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | ValidTgts$ Player.Opponent | TgtPrompt$ Select target opponent | ChangeType$ Card.NamedCard | Chooser$ You | ChangeNum$ NumInYard | Hidden$ True | SubAbility$ ExileHand | StackDescription$ Search target opponent's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles their library.
 SVar:ExileHand:DB$ ChangeZone | Origin$ Hand | Destination$ Exile | DefinedPlayer$ Targeted | ChangeType$ Card.NamedCard | ChangeNum$ NumInHand | Chooser$ You | SubAbility$ ExileLib | StackDescription$ None

--- a/forge-gui/res/cardsfolder/s/spellbreaker_behemoth.txt
+++ b/forge-gui/res/cardsfolder/s/spellbreaker_behemoth.txt
@@ -2,6 +2,6 @@ Name:Spellbreaker Behemoth
 ManaCost:1 R G G
 Types:Creature Beast
 PT:5/5
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 S:Mode$ Continuous | Affected$ Creature.powerGE5+YouCtrl | AffectedZone$ Stack | AddHiddenKeyword$ This spell can't be countered. | Description$ Creature spells you control with power 5 or greater can't be countered.
 Oracle:This spell can't be countered.\nCreature spells you control with power 5 or greater can't be countered.

--- a/forge-gui/res/cardsfolder/s/spellbreaker_behemoth.txt
+++ b/forge-gui/res/cardsfolder/s/spellbreaker_behemoth.txt
@@ -2,6 +2,6 @@ Name:Spellbreaker Behemoth
 ManaCost:1 R G G
 Types:Creature Beast
 PT:5/5
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
-R:Event$ Counter | ValidCard$ Spell.Creature+powerGE5+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Creature spells you control with power 5 or greater can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidSA$ Spell.Creature+powerGE5+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Creature spells you control with power 5 or greater can't be countered.
 Oracle:This spell can't be countered.\nCreature spells you control with power 5 or greater can't be countered.

--- a/forge-gui/res/cardsfolder/s/spellbreaker_behemoth.txt
+++ b/forge-gui/res/cardsfolder/s/spellbreaker_behemoth.txt
@@ -3,5 +3,5 @@ ManaCost:1 R G G
 Types:Creature Beast
 PT:5/5
 R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
-S:Mode$ Continuous | Affected$ Creature.powerGE5+YouCtrl | AffectedZone$ Stack | AddHiddenKeyword$ This spell can't be countered. | Description$ Creature spells you control with power 5 or greater can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Creature+powerGE5+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Creature spells you control with power 5 or greater can't be countered.
 Oracle:This spell can't be countered.\nCreature spells you control with power 5 or greater can't be countered.

--- a/forge-gui/res/cardsfolder/s/sphinx_of_the_final_word.txt
+++ b/forge-gui/res/cardsfolder/s/sphinx_of_the_final_word.txt
@@ -4,6 +4,6 @@ Types:Creature Sphinx
 PT:5/5
 K:Flying
 K:Hexproof
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 S:Mode$ Continuous | Affected$ Instant.YouCtrl,Sorcery.YouCtrl | AddHiddenKeyword$ This spell can't be countered. | AffectedZone$ Stack | Description$ Instant and sorcery spells you control can't be countered.
 Oracle:This spell can't be countered.\nFlying, hexproof\nInstant and sorcery spells you control can't be countered.

--- a/forge-gui/res/cardsfolder/s/sphinx_of_the_final_word.txt
+++ b/forge-gui/res/cardsfolder/s/sphinx_of_the_final_word.txt
@@ -5,5 +5,5 @@ PT:5/5
 K:Flying
 K:Hexproof
 R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
-S:Mode$ Continuous | Affected$ Instant.YouCtrl,Sorcery.YouCtrl | AddHiddenKeyword$ This spell can't be countered. | AffectedZone$ Stack | Description$ Instant and sorcery spells you control can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Instant+YouCtrl,Spell.Sorcery+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Instant and sorcery spells you control can't be countered.
 Oracle:This spell can't be countered.\nFlying, hexproof\nInstant and sorcery spells you control can't be countered.

--- a/forge-gui/res/cardsfolder/s/sphinx_of_the_final_word.txt
+++ b/forge-gui/res/cardsfolder/s/sphinx_of_the_final_word.txt
@@ -4,6 +4,6 @@ Types:Creature Sphinx
 PT:5/5
 K:Flying
 K:Hexproof
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
-R:Event$ Counter | ValidCard$ Spell.Instant+YouCtrl,Spell.Sorcery+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Instant and sorcery spells you control can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidSA$ Spell.Instant+YouCtrl,Spell.Sorcery+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Instant and sorcery spells you control can't be countered.
 Oracle:This spell can't be countered.\nFlying, hexproof\nInstant and sorcery spells you control can't be countered.

--- a/forge-gui/res/cardsfolder/s/summoning_trap.txt
+++ b/forge-gui/res/cardsfolder/s/summoning_trap.txt
@@ -2,12 +2,12 @@ Name:Summoning Trap
 ManaCost:4 G G
 Types:Instant Trap
 #Keep track of countered cards even while in other zones, so no TriggerZones param. Clear tracked number each cleanup.
-T:Mode$ Countered | ValidCause$ Card.OppCtrl,Emblem.OppCtrl | ValidCard$ Creature.YouCtrl | ValidType$ Spell | Execute$ TrackValidCounters | Static$ True
+T:Mode$ Countered | ValidCause$ SpellAbility.OppCtrl | ValidSA$ Spell.Creature+wasCastByYou | Execute$ TrackValidCounters | Static$ True
 SVar:TrackValidCounters:DB$ StoreSVar | SVar$ SetTrap | Type$ CountSVar | Expression$ SetTrap/Plus.1
 T:Mode$ Phase | Phase$ Cleanup | Execute$ TrigReset | Static$ True
 SVar:TrigReset:DB$ StoreSVar | SVar$ SetTrap | Type$ Number | Expression$ 0
 SVar:SetTrap:Number$0
 #Set up main abilities
 SVar:AltCost:Cost$ 0 | CheckSVar$ SetTrap | SVarCompare$ GE1 | Description$ If a creature spell you cast this turn was countered by a spell or ability an opponent controlled, you may pay {0} rather than pay this spell's mana cost.
-A:SP$ Dig | Cost$ 4 G G | DigNum$ 7 | ChangeNum$ 1 | Optional$ True | ChangeValid$ Creature | DestinationZone$ Battlefield | SpellDescription$ Look at the top seven cards of your library. You may put a creature card from among them onto the battlefield. Put the rest on the bottom of your library in any order.
+A:SP$ Dig | DigNum$ 7 | ChangeNum$ 1 | Optional$ True | ChangeValid$ Creature | DestinationZone$ Battlefield | SpellDescription$ Look at the top seven cards of your library. You may put a creature card from among them onto the battlefield. Put the rest on the bottom of your library in any order.
 Oracle:If a creature spell you cast this turn was countered by a spell or ability an opponent controlled, you may pay {0} rather than pay this spell's mana cost.\nLook at the top seven cards of your library. You may put a creature card from among them onto the battlefield. Put the rest on the bottom of your library in any order.

--- a/forge-gui/res/cardsfolder/s/supreme_verdict.txt
+++ b/forge-gui/res/cardsfolder/s/supreme_verdict.txt
@@ -1,6 +1,6 @@
 Name:Supreme Verdict
 ManaCost:1 W W U
 Types:Sorcery
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ DestroyAll | Cost$ 1 W W U | ValidCards$ Creature | SpellDescription$ Destroy all creatures.
 Oracle:This spell can't be countered.\nDestroy all creatures.

--- a/forge-gui/res/cardsfolder/s/supreme_verdict.txt
+++ b/forge-gui/res/cardsfolder/s/supreme_verdict.txt
@@ -1,6 +1,6 @@
 Name:Supreme Verdict
 ManaCost:1 W W U
 Types:Sorcery
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ DestroyAll | Cost$ 1 W W U | ValidCards$ Creature | SpellDescription$ Destroy all creatures.
 Oracle:This spell can't be countered.\nDestroy all creatures.

--- a/forge-gui/res/cardsfolder/s/surrak_dragonclaw.txt
+++ b/forge-gui/res/cardsfolder/s/surrak_dragonclaw.txt
@@ -3,8 +3,8 @@ ManaCost:2 G U R
 Types:Legendary Creature Human Warrior
 PT:6/6
 K:Flash
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
-R:Event$ Counter | ValidCard$ Spell.Creature+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Creature spells you control can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidSA$ Spell.Creature+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Creature spells you control can't be countered.
 S:Mode$ Continuous | Affected$ Creature.Other+YouCtrl | AddKeyword$ Trample | Description$ Other creatures you control have trample.
 SVar:PlayMain1:TRUE
 Oracle:Flash\nThis spell can't be countered.\nCreature spells you control can't be countered.\nOther creatures you control have trample.

--- a/forge-gui/res/cardsfolder/s/surrak_dragonclaw.txt
+++ b/forge-gui/res/cardsfolder/s/surrak_dragonclaw.txt
@@ -3,7 +3,7 @@ ManaCost:2 G U R
 Types:Legendary Creature Human Warrior
 PT:6/6
 K:Flash
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 S:Mode$ Continuous | Affected$ Creature.YouCtrl | AffectedZone$ Stack | AddHiddenKeyword$ This spell can't be countered. | Description$ Creature spells you control can't be countered.
 S:Mode$ Continuous | Affected$ Creature.Other+YouCtrl | AddKeyword$ Trample | Description$ Other creatures you control have trample.
 SVar:PlayMain1:TRUE

--- a/forge-gui/res/cardsfolder/s/surrak_dragonclaw.txt
+++ b/forge-gui/res/cardsfolder/s/surrak_dragonclaw.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature Human Warrior
 PT:6/6
 K:Flash
 R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
-S:Mode$ Continuous | Affected$ Creature.YouCtrl | AffectedZone$ Stack | AddHiddenKeyword$ This spell can't be countered. | Description$ Creature spells you control can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Creature+YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Creature spells you control can't be countered.
 S:Mode$ Continuous | Affected$ Creature.Other+YouCtrl | AddKeyword$ Trample | Description$ Other creatures you control have trample.
 SVar:PlayMain1:TRUE
 Oracle:Flash\nThis spell can't be countered.\nCreature spells you control can't be countered.\nOther creatures you control have trample.

--- a/forge-gui/res/cardsfolder/t/taigam_ojutai_master.txt
+++ b/forge-gui/res/cardsfolder/t/taigam_ojutai_master.txt
@@ -2,7 +2,7 @@ Name:Taigam, Ojutai Master
 ManaCost:2 W U
 Types:Legendary Creature Human Monk
 PT:3/4
-S:Mode$ Continuous | Affected$ Instant.YouCtrl,Sorcery.YouCtrl,Dragon.YouCtrl | AddHiddenKeyword$ This spell can't be countered. | AffectedZone$ Stack | Description$ Instant, sorcery, and Dragon spells you control can't be countered.
+R:Event$ Counter | ValidCard$ Instant.YouCtrl,Sorcery.YouCtrl,Dragon.YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Instant, sorcery, and Dragon spells you control can't be countered.
 T:Mode$ SpellCast | ValidCard$ Instant.wasCastFromYourHand,Sorcery.wasCastFromYourHand | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | IsPresent$ Card.Self+attackedThisTurn | Execute$ TrigRebound | TriggerDescription$ Whenever you cast an instant or sorcery spell from your hand, if CARDNAME attacked this turn, that spell gains rebound.
 SVar:TrigRebound:DB$ Pump | Defined$ TriggeredCard | KW$ Rebound | PumpZone$ Stack
 Oracle:Instant, sorcery, and Dragon spells you control can't be countered.\nWhenever you cast an instant or sorcery spell from your hand, if Taigam, Ojutai Master attacked this turn, that spell gains rebound. (Exile the spell as it resolves. At the beginning of your next upkeep, you may cast that card from exile without paying its mana cost.)

--- a/forge-gui/res/cardsfolder/t/taigam_ojutai_master.txt
+++ b/forge-gui/res/cardsfolder/t/taigam_ojutai_master.txt
@@ -2,7 +2,7 @@ Name:Taigam, Ojutai Master
 ManaCost:2 W U
 Types:Legendary Creature Human Monk
 PT:3/4
-S:Mode$ Continuous | Affected$ Instant.YouCtrl,Sorcery.YouCtrl,Dragon.YouCtrl | AddHiddenKeyword$ CARDNAME can't be countered. | AffectedZone$ Stack | Description$ Instant, sorcery, and Dragon spells you control can't be countered.
+S:Mode$ Continuous | Affected$ Instant.YouCtrl,Sorcery.YouCtrl,Dragon.YouCtrl | AddHiddenKeyword$ This spell can't be countered. | AffectedZone$ Stack | Description$ Instant, sorcery, and Dragon spells you control can't be countered.
 T:Mode$ SpellCast | ValidCard$ Instant.wasCastFromYourHand,Sorcery.wasCastFromYourHand | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | IsPresent$ Card.Self+attackedThisTurn | Execute$ TrigRebound | TriggerDescription$ Whenever you cast an instant or sorcery spell from your hand, if CARDNAME attacked this turn, that spell gains rebound.
 SVar:TrigRebound:DB$ Pump | Defined$ TriggeredCard | KW$ Rebound | PumpZone$ Stack
 Oracle:Instant, sorcery, and Dragon spells you control can't be countered.\nWhenever you cast an instant or sorcery spell from your hand, if Taigam, Ojutai Master attacked this turn, that spell gains rebound. (Exile the spell as it resolves. At the beginning of your next upkeep, you may cast that card from exile without paying its mana cost.)

--- a/forge-gui/res/cardsfolder/t/taigam_ojutai_master.txt
+++ b/forge-gui/res/cardsfolder/t/taigam_ojutai_master.txt
@@ -2,7 +2,7 @@ Name:Taigam, Ojutai Master
 ManaCost:2 W U
 Types:Legendary Creature Human Monk
 PT:3/4
-R:Event$ Counter | ValidCard$ Instant.YouCtrl,Sorcery.YouCtrl,Dragon.YouCtrl | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Instant, sorcery, and Dragon spells you control can't be countered.
+R:Event$ Counter | ValidCard$ Instant.YouCtrl,Sorcery.YouCtrl,Dragon.YouCtrl | ValidSA$ Spell | Layer$ CantHappen | ActiveZones$ Battlefield | Description$ Instant, sorcery, and Dragon spells you control can't be countered.
 T:Mode$ SpellCast | ValidCard$ Instant.wasCastFromYourHand,Sorcery.wasCastFromYourHand | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | IsPresent$ Card.Self+attackedThisTurn | Execute$ TrigRebound | TriggerDescription$ Whenever you cast an instant or sorcery spell from your hand, if CARDNAME attacked this turn, that spell gains rebound.
 SVar:TrigRebound:DB$ Pump | Defined$ TriggeredCard | KW$ Rebound | PumpZone$ Stack
 Oracle:Instant, sorcery, and Dragon spells you control can't be countered.\nWhenever you cast an instant or sorcery spell from your hand, if Taigam, Ojutai Master attacked this turn, that spell gains rebound. (Exile the spell as it resolves. At the beginning of your next upkeep, you may cast that card from exile without paying its mana cost.)

--- a/forge-gui/res/cardsfolder/t/tears_of_valakut.txt
+++ b/forge-gui/res/cardsfolder/t/tears_of_valakut.txt
@@ -1,6 +1,6 @@
 Name:Tears of Valakut
 ManaCost:1 R
 Types:Instant
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ DealDamage | Cost$ 1 R | ValidTgts$ Creature.withFlying | NumDmg$ 5 | TgtPrompt$ Select target creature with flying. | SpellDescription$ CARDNAME deals 5 damage to target creature with flying.
 Oracle:This spell can't be countered.\nTears of Valakut deals 5 damage to target creature with flying.

--- a/forge-gui/res/cardsfolder/t/tears_of_valakut.txt
+++ b/forge-gui/res/cardsfolder/t/tears_of_valakut.txt
@@ -1,6 +1,6 @@
 Name:Tears of Valakut
 ManaCost:1 R
 Types:Instant
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ DealDamage | Cost$ 1 R | ValidTgts$ Creature.withFlying | NumDmg$ 5 | TgtPrompt$ Select target creature with flying. | SpellDescription$ CARDNAME deals 5 damage to target creature with flying.
 Oracle:This spell can't be countered.\nTears of Valakut deals 5 damage to target creature with flying.

--- a/forge-gui/res/cardsfolder/t/terra_stomper.txt
+++ b/forge-gui/res/cardsfolder/t/terra_stomper.txt
@@ -3,5 +3,5 @@ ManaCost:3 G G G
 Types:Creature Beast
 PT:8/8
 K:Trample
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 Oracle:This spell can't be countered.\nTrample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)

--- a/forge-gui/res/cardsfolder/t/terra_stomper.txt
+++ b/forge-gui/res/cardsfolder/t/terra_stomper.txt
@@ -3,5 +3,5 @@ ManaCost:3 G G G
 Types:Creature Beast
 PT:8/8
 K:Trample
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 Oracle:This spell can't be countered.\nTrample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)

--- a/forge-gui/res/cardsfolder/t/thought_distortion.txt
+++ b/forge-gui/res/cardsfolder/t/thought_distortion.txt
@@ -1,7 +1,7 @@
 Name:Thought Distortion
 ManaCost:4 B B
 Types:Sorcery
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ RevealHand | Cost$ 4 B B | ValidTgts$ Opponent | IsCurse$ True | SubAbility$ DBExile | SpellDescription$ Target opponent reveals their hand. Exile all noncreature, nonland cards from that player's hand and graveyard.
 SVar:DBExile:DB$ ChangeZoneAll | Origin$ Hand,Graveyard | Destination$ Exile | ChangeType$ Card.nonCreature+nonLand+TargetedPlayerCtrl
 Oracle:This spell can't be countered.\nTarget opponent reveals their hand. Exile all noncreature, nonland cards from that player's hand and graveyard.

--- a/forge-gui/res/cardsfolder/t/thought_distortion.txt
+++ b/forge-gui/res/cardsfolder/t/thought_distortion.txt
@@ -1,7 +1,7 @@
 Name:Thought Distortion
 ManaCost:4 B B
 Types:Sorcery
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ RevealHand | Cost$ 4 B B | ValidTgts$ Opponent | IsCurse$ True | SubAbility$ DBExile | SpellDescription$ Target opponent reveals their hand. Exile all noncreature, nonland cards from that player's hand and graveyard.
 SVar:DBExile:DB$ ChangeZoneAll | Origin$ Hand,Graveyard | Destination$ Exile | ChangeType$ Card.nonCreature+nonLand+TargetedPlayerCtrl
 Oracle:This spell can't be countered.\nTarget opponent reveals their hand. Exile all noncreature, nonland cards from that player's hand and graveyard.

--- a/forge-gui/res/cardsfolder/t/thrun_breaker_of_silence.txt
+++ b/forge-gui/res/cardsfolder/t/thrun_breaker_of_silence.txt
@@ -2,7 +2,7 @@ Name:Thrun, Breaker of Silence
 ManaCost:3 G G
 Types:Legendary Creature Troll Shaman
 PT:5/5
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Trample
 S:Mode$ CantTarget | ValidCard$ Card.Self | ValidSource$ Card.nonGreen+OppCtrl | Description$ CARDNAME can't be the target of nongreen spells your opponents control or abilities from nongreen sources your opponents control.
 S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Indestructible | Condition$ PlayerTurn | Description$ As long as it's your turn, NICKNAME has indestructible.

--- a/forge-gui/res/cardsfolder/t/thrun_breaker_of_silence.txt
+++ b/forge-gui/res/cardsfolder/t/thrun_breaker_of_silence.txt
@@ -2,7 +2,7 @@ Name:Thrun, Breaker of Silence
 ManaCost:3 G G
 Types:Legendary Creature Troll Shaman
 PT:5/5
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Trample
 S:Mode$ CantTarget | ValidCard$ Card.Self | ValidSource$ Card.nonGreen+OppCtrl | Description$ CARDNAME can't be the target of nongreen spells your opponents control or abilities from nongreen sources your opponents control.
 S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Indestructible | Condition$ PlayerTurn | Description$ As long as it's your turn, NICKNAME has indestructible.

--- a/forge-gui/res/cardsfolder/t/thrun_the_last_troll.txt
+++ b/forge-gui/res/cardsfolder/t/thrun_the_last_troll.txt
@@ -3,6 +3,6 @@ ManaCost:2 G G
 Types:Legendary Creature Troll Shaman
 PT:4/4
 A:AB$ Regenerate | Cost$ 1 G | SpellDescription$ Regenerate CARDNAME.
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Hexproof
 Oracle:This spell can't be countered.\nHexproof (This creature can't be the target of spells or abilities your opponents control.)\n{1}{G}: Regenerate Thrun, the Last Troll.

--- a/forge-gui/res/cardsfolder/t/thrun_the_last_troll.txt
+++ b/forge-gui/res/cardsfolder/t/thrun_the_last_troll.txt
@@ -3,6 +3,6 @@ ManaCost:2 G G
 Types:Legendary Creature Troll Shaman
 PT:4/4
 A:AB$ Regenerate | Cost$ 1 G | SpellDescription$ Regenerate CARDNAME.
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Hexproof
 Oracle:This spell can't be countered.\nHexproof (This creature can't be the target of spells or abilities your opponents control.)\n{1}{G}: Regenerate Thrun, the Last Troll.

--- a/forge-gui/res/cardsfolder/t/thryx_the_sudden_storm.txt
+++ b/forge-gui/res/cardsfolder/t/thryx_the_sudden_storm.txt
@@ -5,5 +5,5 @@ PT:4/5
 K:Flash
 K:Flying
 S:Mode$ ReduceCost | ValidCard$ Card.cmcGE5 | Type$ Spell | Activator$ You | Amount$ 1 | Description$ Spells you cast with mana value 5 or greater cost {1} less to cast and can't be countered.
-R:Event$ Counter | ValidCard$ Spell.cmcGE5+wasCastByYou | Layer$ CantHappen | ActiveZones$ Battlefield | Secondary$ True | Description$ Spells you cast with mana value 5 or greater cost {1} less to cast and can't be countered.
+R:Event$ Counter | ValidCard$ Card.cmcGE5+wasCastByYou | ValidSA$ Spell | Layer$ CantHappen | ActiveZones$ Battlefield | Secondary$ True | Description$ Spells you cast with mana value 5 or greater cost {1} less to cast and can't be countered.
 Oracle:Flash\nFlying\nSpells you cast with mana value 5 or greater cost {1} less to cast and can't be countered.

--- a/forge-gui/res/cardsfolder/t/thryx_the_sudden_storm.txt
+++ b/forge-gui/res/cardsfolder/t/thryx_the_sudden_storm.txt
@@ -5,5 +5,5 @@ PT:4/5
 K:Flash
 K:Flying
 S:Mode$ ReduceCost | ValidCard$ Card.cmcGE5 | Type$ Spell | Activator$ You | Amount$ 1 | Description$ Spells you cast with mana value 5 or greater cost {1} less to cast and can't be countered.
-S:Mode$ Continuous | Affected$ Card.cmcGE5+wasCastByYou | AffectedZone$ Stack | AddHiddenKeyword$ This spell can't be countered. | Secondary$ True | Description$ Spells you cast with mana value 5 or greater cost {1} less to cast and can't be countered.
+R:Event$ Counter | ValidCard$ Spell.cmcGE5+wasCastByYou | Layer$ CantHappen | ActiveZones$ Battlefield | Secondary$ True | Description$ Spells you cast with mana value 5 or greater cost {1} less to cast and can't be countered.
 Oracle:Flash\nFlying\nSpells you cast with mana value 5 or greater cost {1} less to cast and can't be countered.

--- a/forge-gui/res/cardsfolder/t/thryx_the_sudden_storm.txt
+++ b/forge-gui/res/cardsfolder/t/thryx_the_sudden_storm.txt
@@ -5,5 +5,5 @@ PT:4/5
 K:Flash
 K:Flying
 S:Mode$ ReduceCost | ValidCard$ Card.cmcGE5 | Type$ Spell | Activator$ You | Amount$ 1 | Description$ Spells you cast with mana value 5 or greater cost {1} less to cast and can't be countered.
-S:Mode$ Continuous | Affected$ Card.cmcGE5+wasCastByYou | AffectedZone$ Stack | AddHiddenKeyword$ CARDNAME can't be countered. | Secondary$ True | Description$ Spells you cast with mana value 5 or greater cost {1} less to cast and can't be countered.
+S:Mode$ Continuous | Affected$ Card.cmcGE5+wasCastByYou | AffectedZone$ Stack | AddHiddenKeyword$ This spell can't be countered. | Secondary$ True | Description$ Spells you cast with mana value 5 or greater cost {1} less to cast and can't be countered.
 Oracle:Flash\nFlying\nSpells you cast with mana value 5 or greater cost {1} less to cast and can't be countered.

--- a/forge-gui/res/cardsfolder/t/torch_breath.txt
+++ b/forge-gui/res/cardsfolder/t/torch_breath.txt
@@ -2,7 +2,7 @@ Name:Torch Breath
 ManaCost:X R
 Types:Instant
 S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 2 | ValidTarget$ Permanent.Blue | EffectZone$ All | Description$ This spell costs {2} less to cast if it targets a a blue permanent.
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to target creature or planeswalker.
 SVar:X:Count$xPaid
 Oracle:This spell costs {2} less to cast if it targets a blue permanent.\nThis spell can't be countered.\nTorch Breath deals X damage to target creature or planeswalker.

--- a/forge-gui/res/cardsfolder/t/torch_breath.txt
+++ b/forge-gui/res/cardsfolder/t/torch_breath.txt
@@ -2,7 +2,7 @@ Name:Torch Breath
 ManaCost:X R
 Types:Instant
 S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 2 | ValidTarget$ Permanent.Blue | EffectZone$ All | Description$ This spell costs {2} less to cast if it targets a a blue permanent.
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to target creature or planeswalker.
 SVar:X:Count$xPaid
 Oracle:This spell costs {2} less to cast if it targets a blue permanent.\nThis spell can't be countered.\nTorch Breath deals X damage to target creature or planeswalker.

--- a/forge-gui/res/cardsfolder/t/toski_bearer_of_secrets.txt
+++ b/forge-gui/res/cardsfolder/t/toski_bearer_of_secrets.txt
@@ -2,7 +2,7 @@ Name:Toski, Bearer of Secrets
 ManaCost:3 G
 Types:Legendary Creature Squirrel
 PT:1/1
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Indestructible
 S:Mode$ MustAttack | ValidCreature$ Card.Self | Description$ CARDNAME attacks each combat if able.
 T:Mode$ DamageDone | ValidSource$ Creature.YouCtrl | ValidTarget$ Player | CombatDamage$ True | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ Whenever a creature you control deals combat damage to a player, draw a card.

--- a/forge-gui/res/cardsfolder/t/toski_bearer_of_secrets.txt
+++ b/forge-gui/res/cardsfolder/t/toski_bearer_of_secrets.txt
@@ -2,7 +2,7 @@ Name:Toski, Bearer of Secrets
 ManaCost:3 G
 Types:Legendary Creature Squirrel
 PT:1/1
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Indestructible
 S:Mode$ MustAttack | ValidCreature$ Card.Self | Description$ CARDNAME attacks each combat if able.
 T:Mode$ DamageDone | ValidSource$ Creature.YouCtrl | ValidTarget$ Player | CombatDamage$ True | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ Whenever a creature you control deals combat damage to a player, draw a card.

--- a/forge-gui/res/cardsfolder/t/tyrranax_rex.txt
+++ b/forge-gui/res/cardsfolder/t/tyrranax_rex.txt
@@ -2,7 +2,7 @@ Name:Tyrranax Rex
 ManaCost:4 G G G
 Types:Creature Phyrexian Dinosaur
 PT:8/8
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Trample
 K:Ward:4
 K:Haste

--- a/forge-gui/res/cardsfolder/t/tyrranax_rex.txt
+++ b/forge-gui/res/cardsfolder/t/tyrranax_rex.txt
@@ -2,7 +2,7 @@ Name:Tyrranax Rex
 ManaCost:4 G G G
 Types:Creature Phyrexian Dinosaur
 PT:8/8
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Trample
 K:Ward:4
 K:Haste

--- a/forge-gui/res/cardsfolder/u/urzas_rage.txt
+++ b/forge-gui/res/cardsfolder/u/urzas_rage.txt
@@ -2,7 +2,7 @@ Name:Urza's Rage
 ManaCost:2 R
 Types:Instant
 K:Kicker:8 R
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ DealDamage | Cost$ 2 R | ValidTgts$ Any | NumDmg$ X | SubAbility$ Kicked | SpellDescription$ CARDNAME deals 3 damage to any target. If this spell was kicked, instead it deals 10 damage to that permanent or player and the damage can't be prevented.
 SVar:Kicked:DB$ DealDamage | Defined$ Targeted | NumDmg$ 10 | NoPrevention$ True | Condition$ Kicked | ConditionDescription$ If Urza's Rage was kicked,
 SVar:X:Count$Kicked.0.3

--- a/forge-gui/res/cardsfolder/u/urzas_rage.txt
+++ b/forge-gui/res/cardsfolder/u/urzas_rage.txt
@@ -2,7 +2,7 @@ Name:Urza's Rage
 ManaCost:2 R
 Types:Instant
 K:Kicker:8 R
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ DealDamage | Cost$ 2 R | ValidTgts$ Any | NumDmg$ X | SubAbility$ Kicked | SpellDescription$ CARDNAME deals 3 damage to any target. If this spell was kicked, instead it deals 10 damage to that permanent or player and the damage can't be prevented.
 SVar:Kicked:DB$ DealDamage | Defined$ Targeted | NumDmg$ 10 | NoPrevention$ True | Condition$ Kicked | ConditionDescription$ If Urza's Rage was kicked,
 SVar:X:Count$Kicked.0.3

--- a/forge-gui/res/cardsfolder/upcoming/out_cold.txt
+++ b/forge-gui/res/cardsfolder/upcoming/out_cold.txt
@@ -1,7 +1,7 @@
 Name:Out Cold
 ManaCost:3 U
 Types:Instant
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ Tap | ValidTgts$ Creature | SubAbility$ DBCounter | TargetMin$ 0 | TargetMax$ 2 | TgtPrompt$ Select up to two target creatures | SpellDescription$ Tap up to two target creatures and put a stun counter on each of them. Investigate. (If a permanent with a stun counter would become untapped, remove one from it instead.)
 SVar:DBCounter:DB$ PutCounter | Defined$ Targeted | CounterType$ Stun | CounterNum$ 1 | SubAbility$ DBInvestigate
 SVar:DBInvestigate:DB$ Investigate

--- a/forge-gui/res/cardsfolder/upcoming/out_cold.txt
+++ b/forge-gui/res/cardsfolder/upcoming/out_cold.txt
@@ -1,7 +1,7 @@
 Name:Out Cold
 ManaCost:3 U
 Types:Instant
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ Tap | ValidTgts$ Creature | SubAbility$ DBCounter | TargetMin$ 0 | TargetMax$ 2 | TgtPrompt$ Select up to two target creatures | SpellDescription$ Tap up to two target creatures and put a stun counter on each of them. Investigate. (If a permanent with a stun counter would become untapped, remove one from it instead.)
 SVar:DBCounter:DB$ PutCounter | Defined$ Targeted | CounterType$ Stun | CounterNum$ 1 | SubAbility$ DBInvestigate
 SVar:DBInvestigate:DB$ Investigate

--- a/forge-gui/res/cardsfolder/v/veil_of_summer.txt
+++ b/forge-gui/res/cardsfolder/v/veil_of_summer.txt
@@ -3,7 +3,7 @@ ManaCost:G
 Types:Instant
 A:SP$ Draw | Cost$ G | Defined$ You | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1 | SubAbility$ DBEffect | AILogic$ VeilOfSummer | StackDescription$ SpellDescription | SpellDescription$ Draw a card if an opponent has cast a blue or black spell this turn. Spells you control can't be countered this turn. You and permanents you control gain hexproof from blue and from black until end of turn. (You and they can't be the targets of blue or black spells or abilities your opponents control.)
 SVar:DBEffect:DB$ Effect | ReplacementEffects$ AntiMagic | SubAbility$ DBPump
-SVar:AntiMagic:Event$ Counter | ValidCard$ Spell.YouCtrl | Layer$ CantHappen | Description$ Spells you control can't be countered this turn.
+SVar:AntiMagic:Event$ Counter | ValidSA$ Spell.YouCtrl | Layer$ CantHappen | Description$ Spells you control can't be countered this turn.
 SVar:DBPump:DB$ Pump | Defined$ You | KW$ Hexproof:Card.Black:black & Hexproof:Card.Blue:blue | SubAbility$ DBPumpAll | StackDescription$ None
 SVar:DBPumpAll:DB$ PumpAll | ValidCards$ Permanent.YouCtrl | KW$ Hexproof:Card.Black:black & Hexproof:Card.Blue:blue
 SVar:X:Count$ThisTurnCast_Card.OppCtrl+Blue,Card.OppCtrl+Black

--- a/forge-gui/res/cardsfolder/v/veil_of_summer.txt
+++ b/forge-gui/res/cardsfolder/v/veil_of_summer.txt
@@ -2,8 +2,8 @@ Name:Veil of Summer
 ManaCost:G
 Types:Instant
 A:SP$ Draw | Cost$ G | Defined$ You | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1 | SubAbility$ DBEffect | AILogic$ VeilOfSummer | StackDescription$ SpellDescription | SpellDescription$ Draw a card if an opponent has cast a blue or black spell this turn. Spells you control can't be countered this turn. You and permanents you control gain hexproof from blue and from black until end of turn. (You and they can't be the targets of blue or black spells or abilities your opponents control.)
-SVar:DBEffect:DB$ Effect | StaticAbilities$ AntiMagic | SubAbility$ DBPump
-SVar:AntiMagic:Mode$ Continuous | Affected$ Card.YouCtrl | AffectedZone$ Stack | EffectZone$ Command | AddHiddenKeyword$ This spell can't be countered. | Description$ Spells you control can't be countered this turn.
+SVar:DBEffect:DB$ Effect | ReplacementEffects$ AntiMagic | SubAbility$ DBPump
+SVar:AntiMagic:Event$ Counter | ValidCard$ Spell.YouCtrl | Layer$ CantHappen | Description$ Spells you control can't be countered this turn.
 SVar:DBPump:DB$ Pump | Defined$ You | KW$ Hexproof:Card.Black:black & Hexproof:Card.Blue:blue | SubAbility$ DBPumpAll | StackDescription$ None
 SVar:DBPumpAll:DB$ PumpAll | ValidCards$ Permanent.YouCtrl | KW$ Hexproof:Card.Black:black & Hexproof:Card.Blue:blue
 SVar:X:Count$ThisTurnCast_Card.OppCtrl+Blue,Card.OppCtrl+Black

--- a/forge-gui/res/cardsfolder/v/veil_of_summer.txt
+++ b/forge-gui/res/cardsfolder/v/veil_of_summer.txt
@@ -3,7 +3,7 @@ ManaCost:G
 Types:Instant
 A:SP$ Draw | Cost$ G | Defined$ You | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1 | SubAbility$ DBEffect | AILogic$ VeilOfSummer | StackDescription$ SpellDescription | SpellDescription$ Draw a card if an opponent has cast a blue or black spell this turn. Spells you control can't be countered this turn. You and permanents you control gain hexproof from blue and from black until end of turn. (You and they can't be the targets of blue or black spells or abilities your opponents control.)
 SVar:DBEffect:DB$ Effect | StaticAbilities$ AntiMagic | SubAbility$ DBPump
-SVar:AntiMagic:Mode$ Continuous | Affected$ Card.YouCtrl | AffectedZone$ Stack | EffectZone$ Command | AddHiddenKeyword$ CARDNAME can't be countered. | Description$ Spells you control can't be countered this turn.
+SVar:AntiMagic:Mode$ Continuous | Affected$ Card.YouCtrl | AffectedZone$ Stack | EffectZone$ Command | AddHiddenKeyword$ This spell can't be countered. | Description$ Spells you control can't be countered this turn.
 SVar:DBPump:DB$ Pump | Defined$ You | KW$ Hexproof:Card.Black:black & Hexproof:Card.Blue:blue | SubAbility$ DBPumpAll | StackDescription$ None
 SVar:DBPumpAll:DB$ PumpAll | ValidCards$ Permanent.YouCtrl | KW$ Hexproof:Card.Black:black & Hexproof:Card.Blue:blue
 SVar:X:Count$ThisTurnCast_Card.OppCtrl+Blue,Card.OppCtrl+Black

--- a/forge-gui/res/cardsfolder/v/vexing_beetle.txt
+++ b/forge-gui/res/cardsfolder/v/vexing_beetle.txt
@@ -2,6 +2,6 @@ Name:Vexing Beetle
 ManaCost:4 G
 Types:Creature Insect
 PT:3/3
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 3 | AddToughness$ 3 | IsPresent$ Creature.OppCtrl | PresentCompare$ EQ0 | Description$ CARDNAME gets +3/+3 as long as no opponent controls a creature.
 Oracle:This spell can't be countered.\nVexing Beetle gets +3/+3 as long as no opponent controls a creature.

--- a/forge-gui/res/cardsfolder/v/vexing_beetle.txt
+++ b/forge-gui/res/cardsfolder/v/vexing_beetle.txt
@@ -2,6 +2,6 @@ Name:Vexing Beetle
 ManaCost:4 G
 Types:Creature Insect
 PT:3/3
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 3 | AddToughness$ 3 | IsPresent$ Creature.OppCtrl | PresentCompare$ EQ0 | Description$ CARDNAME gets +3/+3 as long as no opponent controls a creature.
 Oracle:This spell can't be countered.\nVexing Beetle gets +3/+3 as long as no opponent controls a creature.

--- a/forge-gui/res/cardsfolder/v/vexing_shusher.txt
+++ b/forge-gui/res/cardsfolder/v/vexing_shusher.txt
@@ -3,6 +3,7 @@ ManaCost:RG RG
 Types:Creature Goblin Shaman
 PT:2/2
 R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
-A:AB$ Pump | Cost$ RG | ValidTgts$ Card | TgtZone$ Stack | TargetType$ Spell | PumpZone$ Stack | KW$ HIDDEN This spell can't be countered. | SpellDescription$ Target spell can't be countered.
+A:AB$ Effect | Cost$ RG | ReplacementEffects$ AntiMagic | RememberObjects$ TargetedSource | ForgetOnMoved$ Stack | ValidTgts$ Card | TgtZone$ Stack | TargetType$ Spell | SpellDescription$ Target spell can't be countered.
+SVar:AntiMagic:Event$ Counter | ValidCard$ Spell.IsRemembered | Layer$ CantHappen | Description$ This spell can't be countered.
 AI:RemoveDeck:All
 Oracle:This spell can't be countered.\n{R/G}: Target spell can't be countered.

--- a/forge-gui/res/cardsfolder/v/vexing_shusher.txt
+++ b/forge-gui/res/cardsfolder/v/vexing_shusher.txt
@@ -2,8 +2,8 @@ Name:Vexing Shusher
 ManaCost:RG RG
 Types:Creature Goblin Shaman
 PT:2/2
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:AB$ Effect | Cost$ RG | ReplacementEffects$ AntiMagic | RememberObjects$ TargetedSource | ForgetOnMoved$ Stack | ValidTgts$ Card | TgtZone$ Stack | TargetType$ Spell | SpellDescription$ Target spell can't be countered.
-SVar:AntiMagic:Event$ Counter | ValidCard$ Spell.IsRemembered | Layer$ CantHappen | Description$ This spell can't be countered.
+SVar:AntiMagic:Event$ Counter | ValidCard$ Card.IsRemembered | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 AI:RemoveDeck:All
 Oracle:This spell can't be countered.\n{R/G}: Target spell can't be countered.

--- a/forge-gui/res/cardsfolder/v/vexing_shusher.txt
+++ b/forge-gui/res/cardsfolder/v/vexing_shusher.txt
@@ -2,7 +2,7 @@ Name:Vexing Shusher
 ManaCost:RG RG
 Types:Creature Goblin Shaman
 PT:2/2
-K:This spell can't be countered.
-A:AB$ Pump | Cost$ RG | ValidTgts$ Card | TgtZone$ Stack | TargetType$ Spell | PumpZone$ Stack | KW$ HIDDEN CARDNAME can't be countered. | SpellDescription$ Target spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+A:AB$ Pump | Cost$ RG | ValidTgts$ Card | TgtZone$ Stack | TargetType$ Spell | PumpZone$ Stack | KW$ HIDDEN This spell can't be countered. | SpellDescription$ Target spell can't be countered.
 AI:RemoveDeck:All
 Oracle:This spell can't be countered.\n{R/G}: Target spell can't be countered.

--- a/forge-gui/res/cardsfolder/v/void_rend.txt
+++ b/forge-gui/res/cardsfolder/v/void_rend.txt
@@ -1,6 +1,6 @@
 Name:Void Rend
 ManaCost:W U B
 Types:Instant
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ Destroy | ValidTgts$ Permanent.nonLand | TgtPrompt$ Select target nonland permanent | SpellDescription$ Destroy target nonland permanent.
 Oracle:This spell can't be countered.\nDestroy target nonland permanent.

--- a/forge-gui/res/cardsfolder/v/void_rend.txt
+++ b/forge-gui/res/cardsfolder/v/void_rend.txt
@@ -1,6 +1,6 @@
 Name:Void Rend
 ManaCost:W U B
 Types:Instant
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ Destroy | ValidTgts$ Permanent.nonLand | TgtPrompt$ Select target nonland permanent | SpellDescription$ Destroy target nonland permanent.
 Oracle:This spell can't be countered.\nDestroy target nonland permanent.

--- a/forge-gui/res/cardsfolder/v/volcanic_fallout.txt
+++ b/forge-gui/res/cardsfolder/v/volcanic_fallout.txt
@@ -1,6 +1,6 @@
 Name:Volcanic Fallout
 ManaCost:1 R R
 Types:Instant
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ DamageAll | Cost$ 1 R R | NumDmg$ 2 | ValidCards$ Creature | ValidPlayers$ Player | ValidDescription$ each creature and each player. | SpellDescription$ CARDNAME deals 2 damage to each creature and each player.
 Oracle:This spell can't be countered.\nVolcanic Fallout deals 2 damage to each creature and each player.

--- a/forge-gui/res/cardsfolder/v/volcanic_fallout.txt
+++ b/forge-gui/res/cardsfolder/v/volcanic_fallout.txt
@@ -1,6 +1,6 @@
 Name:Volcanic Fallout
 ManaCost:1 R R
 Types:Instant
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ DamageAll | Cost$ 1 R R | NumDmg$ 2 | ValidCards$ Creature | ValidPlayers$ Player | ValidDescription$ each creature and each player. | SpellDescription$ CARDNAME deals 2 damage to each creature and each player.
 Oracle:This spell can't be countered.\nVolcanic Fallout deals 2 damage to each creature and each player.

--- a/forge-gui/res/cardsfolder/w/wilson_refined_grizzly.txt
+++ b/forge-gui/res/cardsfolder/w/wilson_refined_grizzly.txt
@@ -2,7 +2,7 @@ Name:Wilson, Refined Grizzly
 ManaCost:1 G
 Types:Legendary Creature Bear Warrior
 PT:2/2
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Vigilance
 K:Reach
 K:Trample

--- a/forge-gui/res/cardsfolder/w/wilson_refined_grizzly.txt
+++ b/forge-gui/res/cardsfolder/w/wilson_refined_grizzly.txt
@@ -2,7 +2,7 @@ Name:Wilson, Refined Grizzly
 ManaCost:1 G
 Types:Legendary Creature Bear Warrior
 PT:2/2
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Vigilance
 K:Reach
 K:Trample

--- a/forge-gui/res/cardsfolder/w/wreak_havoc.txt
+++ b/forge-gui/res/cardsfolder/w/wreak_havoc.txt
@@ -2,5 +2,5 @@ Name:Wreak Havoc
 ManaCost:2 R G
 Types:Sorcery
 A:SP$ Destroy | Cost$ 2 R G | ValidTgts$ Artifact,Land | TgtPrompt$ Select target artifact or land | SpellDescription$ Destroy target artifact or land.
-R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
+R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 Oracle:This spell can't be countered.\nDestroy target artifact or land.

--- a/forge-gui/res/cardsfolder/w/wreak_havoc.txt
+++ b/forge-gui/res/cardsfolder/w/wreak_havoc.txt
@@ -2,5 +2,5 @@ Name:Wreak Havoc
 ManaCost:2 R G
 Types:Sorcery
 A:SP$ Destroy | Cost$ 2 R G | ValidTgts$ Artifact,Land | TgtPrompt$ Select target artifact or land | SpellDescription$ Destroy target artifact or land.
-K:This spell can't be countered.
+R:Event$ Counter | ValidCard$ Spell.Self | Layer$ CantHappen | Description$ This spell can't be countered.
 Oracle:This spell can't be countered.\nDestroy target artifact or land.


### PR DESCRIPTION
Closes #2688

This Removes the Hidden Keywords:
* `CARDNAME can't be countered.`
* `This spell can't be countered.`
* `CantBeCounteredBy`