### PR TITLE
Adventure: config setting 'allowedEditions'

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/data/AdventureEventData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/AdventureEventData.java
@@ -373,8 +373,14 @@ public class AdventureEventData implements Serializable {
             }
         }
 
-        for (String restricted : Config.instance().getConfigData().restrictedEditions) {
-            legalBlocks.removeIf(q -> q.getName().equals(restricted));
+        ConfigData configData = Config.instance().getConfigData();
+        if (configData.allowedEditions != null) {
+            List<String> allowed = Arrays.asList(configData.allowedEditions);
+            legalBlocks.removeIf(q -> !allowed.contains(q.getName()));
+        } else {
+            for (String restricted : configData.restrictedEditions) {
+                legalBlocks.removeIf(q -> q.getName().equals(restricted));
+            }
         }
         return legalBlocks.isEmpty() ? null : Aggregates.random(legalBlocks);
     }
@@ -388,8 +394,14 @@ public class AdventureEventData implements Serializable {
                 legalBlocks.add(b);
             }
         }
-        for (String restricted : Config.instance().getConfigData().restrictedEditions) {
-            legalBlocks.removeIf(q -> q.getName().equals(restricted));
+        ConfigData configData = Config.instance().getConfigData();
+        if (configData.allowedEditions != null) {
+            List<String> allowed = Arrays.asList(configData.allowedEditions);
+            legalBlocks.removeIf(q -> !allowed.contains(q.getName()));
+        } else {
+            for (String restricted : configData.restrictedEditions) {
+                legalBlocks.removeIf(q -> q.getName().equals(restricted));
+            }
         }
         return legalBlocks.isEmpty()?null:Aggregates.random(legalBlocks);
     }

--- a/forge-gui-mobile/src/forge/adventure/data/ConfigData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/ConfigData.java
@@ -22,4 +22,5 @@ public class ConfigData {
     public RewardData legalCards;
     public String[] restrictedCards;
     public String[] restrictedEditions;
+    public String[] allowedEditions;
 }

--- a/forge-gui-mobile/src/forge/adventure/data/RewardData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/RewardData.java
@@ -82,7 +82,8 @@ public class RewardData implements Serializable {
     private static Iterable<PaperCard> allEnemyCards;
 
     static private void initializeAllCards(){
-        RewardData legals = Config.instance().getConfigData().legalCards;
+        ConfigData configData = Config.instance().getConfigData();
+        RewardData legals = configData.legalCards;
 
         if(legals==null)
             allCards = CardUtil.getFullCardPool(false); // we need unique cards only here, so that a unique card can be chosen before a set variant is determined
@@ -96,11 +97,14 @@ public class RewardData implements Serializable {
                return false;
             if(input.getRules().getAiHints().getRemNonCommanderDecks())
                 return false;
-            if(Arrays.asList(Config.instance().getConfigData().restrictedEditions).contains(input.getEdition()))
+            if(configData.allowedEditions != null) {
+                if (!Arrays.asList(configData.allowedEditions).contains(input.getEdition()))
+                    return false;
+            } else if(Arrays.asList(configData.restrictedEditions).contains(input.getEdition()))
                 return false;
             if(input.getRules().isCustom())
                 return false;
-            return !Arrays.asList(Config.instance().getConfigData().restrictedCards).contains(input.getName());
+            return !Arrays.asList(configData.restrictedCards).contains(input.getName());
         });
         //Filter AI cards for enemies.
         allEnemyCards=Iterables.filter(allCards, input -> {

--- a/forge-gui-mobile/src/forge/adventure/scene/SpellSmithScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/SpellSmithScene.java
@@ -11,6 +11,7 @@ import com.github.tommyettinger.textra.TextraButton;
 import com.github.tommyettinger.textra.TextraLabel;
 import forge.Forge;
 import forge.StaticData;
+import forge.adventure.data.ConfigData;
 import forge.adventure.data.RewardData;
 import forge.adventure.util.*;
 import forge.card.CardEdition;
@@ -151,7 +152,10 @@ public class SpellSmithScene extends UIScene {
                     .filter(input2 -> input2.getEdition().equals(input.getCode())).collect(Collectors.toList());
             if (it.size() == 0)
                 return false;
-            return (!Arrays.asList(Config.instance().getConfigData().restrictedEditions).contains(input.getCode()));
+            ConfigData configData = Config.instance().getConfigData();
+            if (configData.allowedEditions != null)
+                return Arrays.asList(configData.allowedEditions).contains(input.getCode());
+            return (!Arrays.asList(configData.restrictedEditions).contains(input.getCode()));
         }).sorted(new Comparator<CardEdition>() {
             @Override
             public int compare(CardEdition e1, CardEdition e2) {

--- a/forge-gui-mobile/src/forge/adventure/util/CardUtil.java
+++ b/forge-gui-mobile/src/forge/adventure/util/CardUtil.java
@@ -6,6 +6,7 @@ import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
 import forge.StaticData;
+import forge.adventure.data.ConfigData;
 import forge.adventure.data.GeneratedDeckData;
 import forge.adventure.data.GeneratedDeckTemplateData;
 import forge.adventure.data.RewardData;
@@ -710,8 +711,12 @@ public class CardUtil {
     }
 
     public static Deck generateBoosterPackAsDeck(String code){
-
-        if (Arrays.asList(Config.instance().getConfigData().restrictedEditions).contains(code)){
+        ConfigData configData = Config.instance().getConfigData();
+        if (configData.allowedEditions != null) {
+            if (!Arrays.asList(configData.allowedEditions).contains(code)){
+                System.err.println("Cannot generate booster pack, '" + code + "' is not an allowed edition");
+            }
+        } else if (Arrays.asList(configData.restrictedEditions).contains(code)){
             System.err.println("Cannot generate booster pack, '" + code + "' is a restricted edition");
         }
 


### PR DESCRIPTION
Hi everyone,
here is a PR that adds a new config option: "allowedEditions". It works as an alternative to "restrictedEditions", so if someone wants to tinker with worlds limited to just a few sets, they can do so without having to provide a huge "restrictedEditions" list.