### PR TITLE
Riot: refactor into UnlessCost like Fabricate

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtil.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtil.java
@@ -30,7 +30,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 
 import forge.ai.AiCardMemory.MemorySet;
-import forge.ai.ability.ChooseGenericEffectAi;
 import forge.ai.ability.ProtectAi;
 import forge.ai.ability.TokenAi;
 import forge.card.CardStateName;
@@ -290,7 +289,7 @@ public class ComputerUtil {
         SpellAbility newSA = sa.copyWithNoManaCost();
         newSA.setActivatingPlayer(ai, true);
 
-        if (!CostPayment.canPayAdditionalCosts(newSA.getPayCosts(), newSA) || !ComputerUtilMana.canPayManaCost(newSA, ai, 0, false)) {
+        if (!CostPayment.canPayAdditionalCosts(newSA.getPayCosts(), newSA, false) || !ComputerUtilMana.canPayManaCost(newSA, ai, 0, false)) {
             return false;
         }
 
@@ -1176,7 +1175,7 @@ public class ComputerUtil {
             return true;
         }
 
-        if (cardState.hasKeyword(Keyword.RIOT) && ChooseGenericEffectAi.preferHasteForRiot(sa, ai)) {
+        if (cardState.hasKeyword(Keyword.RIOT) && SpecialAiLogic.preferHasteForRiot(sa, ai)) {
             // Planning to choose Haste for Riot, so do this in Main 1
             return true;
         }

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCombat.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCombat.java
@@ -1488,7 +1488,7 @@ public class ComputerUtilCombat {
                     continue;
                 }
                 if (sa.hasParam("Cost")) {
-                    if (!CostPayment.canPayAdditionalCosts(sa.getPayCosts(), sa, false)) {
+                    if (!CostPayment.canPayAdditionalCosts(sa.getPayCosts(), sa, true)) {
                         continue;
                     }
                 }

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCombat.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCombat.java
@@ -1257,7 +1257,7 @@ public class ComputerUtilCombat {
             sa.setActivatingPlayer(source.getController(), true);
 
             if (sa.hasParam("Cost")) {
-                if (!CostPayment.canPayAdditionalCosts(sa.getPayCosts(), sa)) {
+                if (!CostPayment.canPayAdditionalCosts(sa.getPayCosts(), sa, true)) {
                     continue;
                 }
             }
@@ -1454,7 +1454,7 @@ public class ComputerUtilCombat {
                     continue;
                 }
                 if (sa.hasParam("Cost")) {
-                    if (!CostPayment.canPayAdditionalCosts(sa.getPayCosts(), sa)) {
+                    if (!CostPayment.canPayAdditionalCosts(sa.getPayCosts(), sa, true)) {
                         continue;
                     }
                 }
@@ -1488,7 +1488,7 @@ public class ComputerUtilCombat {
                     continue;
                 }
                 if (sa.hasParam("Cost")) {
-                    if (!CostPayment.canPayAdditionalCosts(sa.getPayCosts(), sa)) {
+                    if (!CostPayment.canPayAdditionalCosts(sa.getPayCosts(), sa, false)) {
                         continue;
                     }
                 }

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
@@ -636,7 +636,7 @@ public class ComputerUtilCost {
         }
 
         return ComputerUtilMana.canPayManaCost(sa, player, extraManaNeeded, effect)
-                && CostPayment.canPayAdditionalCosts(sa.getPayCosts(), sa);
+                && CostPayment.canPayAdditionalCosts(sa.getPayCosts(), sa, effect);
     }
 
     public static boolean willPayUnlessCost(SpellAbility sa, Player payer, Cost cost, boolean alreadyPaid, FCollectionView<Player> payers) {
@@ -760,6 +760,8 @@ public class ComputerUtilCost {
             int evalToken = ComputerUtilCard.evaluateCreatureList(tokenList);
 
             return evalToken < evalCounter;
+        } else if ("Riot".equals(aiLogic)) {
+            return !SpecialAiLogic.preferHasteForRiot(sa, payer);
         }
 
         // Check for shocklands and similar ETB replacement effects

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
@@ -976,7 +976,7 @@ public class ComputerUtilMana {
             // Check if AI can still play this mana ability
             ma.setActivatingPlayer(ai, true);
             // if the AI can't pay the additional costs skip the mana ability
-            if (!CostPayment.canPayAdditionalCosts(ma.getPayCosts(), ma)) {
+            if (!CostPayment.canPayAdditionalCosts(ma.getPayCosts(), ma, false)) {
                 return false;
             } else if (ma.getRestrictions() != null && ma.getRestrictions().isInstantSpeed()) {
                 return false;
@@ -1517,7 +1517,7 @@ public class ComputerUtilMana {
                 if (cost != null) {
                     // if the AI can't pay the additional costs skip the mana ability
                     m.setActivatingPlayer(ai, true);
-                    if (!CostPayment.canPayAdditionalCosts(m.getPayCosts(), m)) {
+                    if (!CostPayment.canPayAdditionalCosts(m.getPayCosts(), m, false)) {
                         continue;
                     }
 

--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -1063,6 +1063,9 @@ public class PlayerControllerAi extends PlayerController {
         final Ability emptyAbility = new AbilityStatic(source, cost, sa.getTargetRestrictions()) { @Override public void resolve() { } };
         emptyAbility.setActivatingPlayer(player, true);
         emptyAbility.setTriggeringObjects(sa.getTriggeringObjects());
+        emptyAbility.setReplacingObjects(sa.getReplacingObjects());
+        emptyAbility.setTrigger(sa.getTrigger());
+        emptyAbility.setReplacementEffect(sa.getReplacementEffect());
         emptyAbility.setSVars(sa.getSVars());
         emptyAbility.setCardState(sa.getCardState());
         emptyAbility.setXManaCostPaid(sa.getRootAbility().getXManaCostPaid());

--- a/forge-ai/src/main/java/forge/ai/ability/ChooseGenericEffectAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ChooseGenericEffectAi.java
@@ -3,7 +3,6 @@ package forge.ai.ability;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import forge.ai.ComputerUtilAbility;
 import forge.ai.ComputerUtilCost;
 import forge.ai.SpellAbilityAi;
@@ -11,9 +10,7 @@ import forge.ai.SpellApiToAi;
 import forge.card.MagicColor;
 import forge.game.Game;
 import forge.game.card.*;
-import forge.game.combat.Combat;
 import forge.game.cost.Cost;
-import forge.game.keyword.Keyword;
 import forge.game.phase.PhaseHandler;
 import forge.game.phase.PhaseType;
 import forge.game.player.Player;
@@ -84,9 +81,7 @@ public class ChooseGenericEffectAi extends SpellAbilityAi {
     public SpellAbility chooseSingleSpellAbility(Player player, SpellAbility sa, List<SpellAbility> spells,
             Map<String, Object> params) {
         Card host = sa.getHostCard();
-        final String sourceName = ComputerUtilAbility.getAbilitySourceName(sa);
         final Game game = host.getGame();
-        final Combat combat = game.getCombat();
         final String logic = sa.getParam("AILogic");
         if (logic == null) {
             return spells.get(0);

--- a/forge-ai/src/main/java/forge/ai/ability/ChooseGenericEffectAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ChooseGenericEffectAi.java
@@ -33,8 +33,6 @@ public class ChooseGenericEffectAi extends SpellAbilityAi {
     protected boolean checkAiLogic(final Player ai, final SpellAbility sa, final String aiLogic) {
         if ("Khans".equals(aiLogic) || "Dragons".equals(aiLogic)) {
             return true;
-        } else if ("Riot".equals(aiLogic)) {
-            return true;
         } else if ("Pump".equals(aiLogic) || "BestOption".equals(aiLogic)) {
             for (AbilitySub sb : sa.getAdditionalAbilityList("Choices")) {
                 if (SpellApiToAi.Converter.get(sb.getApi()).canPlayAIWithSubs(ai, sb)) {
@@ -287,54 +285,7 @@ public class ChooseGenericEffectAi extends SpellAbilityAi {
             if (!filtered.isEmpty()) {
                 return filtered.get(0);
             }
-        } else if ("Riot".equals(logic)) {
-            SpellAbility counterSA = spells.get(0), hasteSA = spells.get(1);
-            return preferHasteForRiot(sa, player) ? hasteSA : counterSA;
         }
         return spells.get(0);   // return first choice if no logic found
-    }
-
-    public static boolean preferHasteForRiot(SpellAbility sa, Player player) {
-        // returning true means preferring Haste, returning false means preferring a +1/+1 counter
-        final Card host = sa.getHostCard();
-        final Game game = host.getGame();
-        final Card copy = CardUtil.getLKICopy(host);
-        copy.setLastKnownZone(player.getZone(ZoneType.Battlefield));
-
-        // check state it would have on the battlefield
-        CardCollection preList = new CardCollection(copy);
-        game.getAction().checkStaticAbilities(false, Sets.newHashSet(copy), preList);
-        // reset again?
-        game.getAction().checkStaticAbilities(false);
-
-        // can't gain counters, use Haste
-        if (!copy.canReceiveCounters(CounterEnumType.P1P1)) {
-            return true;
-        }
-
-        // already has Haste, use counter
-        if (copy.hasKeyword(Keyword.HASTE)) {
-            return false;
-        }
-
-        // not AI turn
-        if (!game.getPhaseHandler().isPlayerTurn(player)) {
-            return false;
-        }
-
-        // not before Combat
-        if (!game.getPhaseHandler().getPhase().isBefore(PhaseType.COMBAT_DECLARE_ATTACKERS)) {
-            return false;
-        }
-
-        // TODO check other opponents too if able
-        final Player opp = player.getWeakestOpponent();
-        if (opp != null) {
-            // TODO add predict Combat Damage?
-            return opp.getLife() < copy.getNetPower();
-        }
-
-        // haste might not be good enough?
-        return false;
     }
 }

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -5532,6 +5532,10 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
             // KeywordCollection#getAmount
 
             final String[] parse = kw.contains(":") ? kw.split(":") : kw.split(" ");
+            if (parse.length < 2) {
+                count++;
+                continue;
+            }
             final String s = parse[1];
             if (StringUtils.isNumeric(s)) {
                count += Integer.parseInt(s);

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -2445,21 +2445,11 @@ public class CardFactoryUtil {
             ReplacementEffect cardre = createETBReplacement(card, ReplacementLayer.Other, repeatSA, false, true, intrinsic, "Card.Self", "");
 
             inst.addReplacement(cardre);
-        } else if (keyword.startsWith("Riot")) {
-            final String choose = "DB$ GenericChoice | AILogic$ Riot | SpellDescription$ Riot";
+        } else if (keyword.equals("Riot")) {
+            final String hasteStr = "DB$ Animate | Defined$ Self | Keywords$ Haste | Duration$ Permanent | UnlessCost$ AddCounter<1/P1P1> | UnlessPayer$ You | UnlessAI$ Riot | SpellDescription$ Riot";
 
-            final String counter = "DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | ETB$ True | CounterNum$ 1" +
-                                " | SpellDescription$ Put a +1/+1 counter on it.";
-            final String haste = "DB$ Animate | Defined$ Self | Keywords$ Haste | Duration$ Permanent | SpellDescription$ Haste";
-
-            SpellAbility saChoose = AbilityFactory.getAbility(choose, card);
-
-            List<AbilitySub> list = Lists.newArrayList();
-            list.add((AbilitySub)AbilityFactory.getAbility(counter, card));
-            list.add((AbilitySub)AbilityFactory.getAbility(haste, card));
-            saChoose.setAdditionalAbilityList("Choices", list);
-
-            ReplacementEffect cardre = createETBReplacement(card, ReplacementLayer.Other, saChoose, false, true, intrinsic, "Card.Self", "");
+            final SpellAbility hasteSa = AbilityFactory.getAbility(hasteStr, card);
+            ReplacementEffect cardre = createETBReplacement(card, ReplacementLayer.Other, hasteSa, false, true, intrinsic, "Card.Self", "");
 
             inst.addReplacement(cardre);
         }  else if (keyword.equals("Sunburst")) {

--- a/forge-game/src/main/java/forge/game/cost/CostPayment.java
+++ b/forge-game/src/main/java/forge/game/cost/CostPayment.java
@@ -95,13 +95,13 @@ public class CostPayment extends ManaConversionMatrix {
      *            a {@link forge.game.spellability.SpellAbility} object.
      * @return a boolean.
      */
-    public static boolean canPayAdditionalCosts(Cost cost, final SpellAbility ability) {
+    public static boolean canPayAdditionalCosts(Cost cost, final SpellAbility ability, final boolean effect) {
         if (cost == null) {
             return true;
         }
 
         cost = CostAdjustment.adjust(cost, ability);
-        return cost.canPay(ability, false);
+        return cost.canPay(ability, effect);
     }
 
     /**

--- a/forge-game/src/main/java/forge/game/cost/CostPutCounter.java
+++ b/forge-game/src/main/java/forge/game/cost/CostPutCounter.java
@@ -150,7 +150,7 @@ public class CostPutCounter extends CostPartWithList {
         final Card source = ability.getHostCard();
         final Game game = source.getGame();
         if (this.payCostFromSource()) {
-            if (isETBRelacement(ability, effect)) {
+            if (isETBReplacement(ability, effect)) {
                 final Card copy = CardUtil.getLKICopy(source);
                 copy.setLastKnownZone(payer.getZone(ZoneType.Battlefield));
 
@@ -202,7 +202,7 @@ public class CostPutCounter extends CostPartWithList {
     @Override
     protected Card doPayment(Player payer, SpellAbility ability, Card targetCard, final boolean effect) {
         final int i = getAbilityAmount(ability);
-        if (isETBRelacement(ability, effect)) {
+        if (isETBReplacement(ability, effect)) {
             targetCard.addEtbCounter(getCounter(), i, payer);
         } else {
             targetCard.addCounter(getCounter(), i, payer, counterTable);
@@ -241,7 +241,7 @@ public class CostPutCounter extends CostPartWithList {
         counterTable.clear();
     }
 
-    protected boolean isETBRelacement(final SpellAbility ability, final boolean effect) {
+    protected boolean isETBReplacement(final SpellAbility ability, final boolean effect) {
        if (!effect) {
            return false;
        }

--- a/forge-game/src/main/java/forge/game/cost/CostPutCounter.java
+++ b/forge-game/src/main/java/forge/game/cost/CostPutCounter.java
@@ -19,13 +19,21 @@ package forge.game.cost;
 
 import java.util.List;
 
+import com.google.common.collect.Sets;
+
+import forge.game.Game;
 import forge.game.GameEntityCounterTable;
+import forge.game.ability.AbilityKey;
 import forge.game.card.Card;
+import forge.game.card.CardCollection;
 import forge.game.card.CardLists;
 import forge.game.card.CardPredicates;
+import forge.game.card.CardUtil;
 import forge.game.card.CounterEnumType;
 import forge.game.card.CounterType;
 import forge.game.player.Player;
+import forge.game.replacement.ReplacementEffect;
+import forge.game.replacement.ReplacementType;
 import forge.game.spellability.SpellAbility;
 import forge.game.zone.ZoneType;
 
@@ -140,15 +148,36 @@ public class CostPutCounter extends CostPartWithList {
     @Override
     public final boolean canPay(final SpellAbility ability, final Player payer, final boolean effect) {
         final Card source = ability.getHostCard();
+        final Game game = source.getGame();
         if (this.payCostFromSource()) {
-            return source.isInPlay() && (getAbilityAmount(ability) == 0 || source.canReceiveCounters(this.counter));
+            if (isETBRelacement(ability, effect)) {
+                final Card copy = CardUtil.getLKICopy(source);
+                copy.setLastKnownZone(payer.getZone(ZoneType.Battlefield));
+
+                // check state it would have on the battlefield
+                CardCollection preList = new CardCollection(copy);
+                game.getAction().checkStaticAbilities(false, Sets.newHashSet(copy), preList);
+                // reset again?
+                game.getAction().checkStaticAbilities(false);
+                if (copy.canReceiveCounters(getCounter())) {
+                    return true;
+                }
+            } else {
+                if (!source.isInPlay()) {
+                    return false;
+                }
+                if (source.canReceiveCounters(getCounter())) {
+                    return true;
+                }
+            }
+            return getAbilityAmount(ability) == 0;
         }
 
         // 3 Cards have Put a -1/-1 Counter on a Creature you control.
         List<Card> typeList = CardLists.getValidCards(source.getGame().getCardsIn(ZoneType.Battlefield),
                 this.getType().split(";"), payer, source, ability);
 
-        typeList = CardLists.filter(typeList, CardPredicates.canReceiveCounters(this.counter));
+        typeList = CardLists.filter(typeList, CardPredicates.canReceiveCounters(getCounter()));
 
         return !typeList.isEmpty();
     }
@@ -172,8 +201,12 @@ public class CostPutCounter extends CostPartWithList {
 
     @Override
     protected Card doPayment(Player payer, SpellAbility ability, Card targetCard, final boolean effect) {
-        final int i = this.getAbilityAmount(ability);
-        targetCard.addCounter(this.getCounter(), i, payer, counterTable);
+        final int i = getAbilityAmount(ability);
+        if (isETBRelacement(ability, effect)) {
+            targetCard.addEtbCounter(getCounter(), i, payer);
+        } else {
+            targetCard.addCounter(getCounter(), i, payer, counterTable);
+        }
         return targetCard;
     }
 
@@ -208,4 +241,27 @@ public class CostPutCounter extends CostPartWithList {
         counterTable.clear();
     }
 
+    protected boolean isETBRelacement(final SpellAbility ability, final boolean effect) {
+       if (!effect) {
+           return false;
+       }
+       // only for itself?
+       if (!payCostFromSource()) {
+           return false;
+       }
+       if (ability == null) {
+           return false;
+       }
+       if (!ability.isReplacementAbility()) {
+           return false;
+       }
+       ReplacementEffect re = ability.getReplacementEffect();
+       if (re.getMode() != ReplacementType.Moved) {
+           return false;
+       }
+       if (!ability.getHostCard().equals(ability.getReplacingObject(AbilityKey.Card))) {
+           return false;
+       }
+       return true;
+   }
 }

--- a/forge-game/src/main/java/forge/game/spellability/AbilityActivated.java
+++ b/forge-game/src/main/java/forge/game/spellability/AbilityActivated.java
@@ -90,7 +90,7 @@ public abstract class AbilityActivated extends SpellAbility implements Cloneable
             return false;
         }
 
-        return CostPayment.canPayAdditionalCosts(this.getPayCosts(), this);
+        return CostPayment.canPayAdditionalCosts(this.getPayCosts(), this, false);
     }
 
     /** {@inheritDoc} */

--- a/forge-game/src/main/java/forge/game/spellability/Spell.java
+++ b/forge-game/src/main/java/forge/game/spellability/Spell.java
@@ -112,7 +112,7 @@ public abstract class Spell extends SpellAbility implements java.io.Serializable
             return false;
         }
 
-        if (!CostPayment.canPayAdditionalCosts(this.getPayCosts(), this)) {
+        if (!CostPayment.canPayAdditionalCosts(this.getPayCosts(), this, false)) {
             return false;
         }
 

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
@@ -827,6 +827,9 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
     public void setReplacingObject(final AbilityKey type, final Object o) {
         replacingObjects.put(type, o);
     }
+    public void setReplacingObjects(final Map<AbilityKey, Object> repParams) {
+        replacingObjects = AbilityKey.newMap(repParams);
+    }
     public void setReplacingObjectsFrom(final Map<AbilityKey, Object> repParams, final AbilityKey... types) {
         int typesLength = types.length;
         for (int i = 0; i < typesLength; i += 1) {


### PR DESCRIPTION
This refactors Riot into an UnlessCost similar to Fabricate

because the rules say, if you can't put counters on the creature, then it needs to gain haste

See #1076