### PR TITLE
Update diseased_vermin.txt

### DIFF
--- a/forge-gui/res/cardsfolder/d/diseased_vermin.txt
+++ b/forge-gui/res/cardsfolder/d/diseased_vermin.txt
@@ -4,7 +4,7 @@ Types:Creature Rat
 PT:1/1
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigPutCounter | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, put an infection counter on it.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ INFECTION | CounterNum$ 1 | SubAbility$ DBRemember
-SVar:DBRemember:DB$ Pump | RememberObjects$ Opponent | StackDescription$ None
+SVar:DBRemember:DB$ Pump | RememberObjects$ TriggeredTarget | StackDescription$ None
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ DBDisease | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, Diseased Vermin deals X damage to target opponent previously dealt damage by it, where X is the number of infection counters on it.
 SVar:DBDisease:DB$ DealDamage | ValidTgts$ Opponent.IsRemembered | NumDmg$ X
 SVar:X:Count$CardCounters.INFECTION


### PR DESCRIPTION
Fixes issue where Diseased Vermin's upkeep trigger could target an opponent it hadn't damaged yet, as long as it had already damaged a different player