### PR TITLE
Adventure - POIChanges & reputation fix

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/data/AdventureQuestStage.java
+++ b/forge-gui-mobile/src/forge/adventure/data/AdventureQuestStage.java
@@ -279,10 +279,10 @@ public class AdventureQuestStage implements Serializable {
                         && ++progress1 >= count1 ? COMPLETE : status;
                 break;
             case Clear:
-                if (!event.clear) {
-                    break;
+                if (event.clear && event.winner) {
+                    status = COMPLETE;
                 }
-                //intentional fallthrough to DEFEAT
+                break;
             case Defeat:
                 if (event.type != AdventureQuestEventType.MATCHCOMPLETE)
                     break;

--- a/forge-gui-mobile/src/forge/adventure/scene/NewGameScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/NewGameScene.java
@@ -394,7 +394,7 @@ public class NewGameScene extends MenuScene {
                 summaryText.append("Mode: Chaos\n\nYou (and all enemies) will receive a random preconstructed deck.\n\nWarning: This will make encounter difficulty vary wildly from the developers' intent");
                 break;
             case Custom:
-                summaryText.append("Mode: Custom\n\nChoose your own preconstructed deck. Enemies can use receive a random genetic AI decks.\n\nWarning: This will make encounter difficulty vary wildly from the developers' intent");
+                summaryText.append("Mode: Custom\n\nChoose your own preconstructed deck. Enemies can receive a random genetic AI deck (difficult).\n\nWarning: This will make encounter difficulty vary wildly from the developers' intent");
                 break;
             default:
                 summaryText.append("No summary available for your this game mode.");

--- a/forge-gui-mobile/src/forge/adventure/scene/TileMapScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/TileMapScene.java
@@ -134,9 +134,11 @@ public class TileMapScene extends HudScene   {
     }
 
     public PointOfInterestChanges getPointOfInterestChanges(){
-        return WorldSave.getCurrentSave().getPointOfInterestChanges(rootPoint.getID() + rootPoint.getData().map);
+        return WorldSave.getCurrentSave().getPointOfInterestChanges(rootPoint.getID());
     }
     public PointOfInterestChanges getPointOfInterestChanges(String targetMap){
+        if (rootPoint.getID().endsWith(targetMap))
+            return getPointOfInterestChanges();
         return WorldSave.getCurrentSave().getPointOfInterestChanges(rootPoint.getID() + targetMap);
     }
 

--- a/forge-gui-mobile/src/forge/adventure/util/AdventureQuestController.java
+++ b/forge-gui-mobile/src/forge/adventure/util/AdventureQuestController.java
@@ -154,32 +154,28 @@ public class AdventureQuestController implements Serializable {
     private List<EnemySprite> enemySpriteList= new ArrayList<>();
     private int nextQuestID = 0;
     public void showQuestDialogs(GameStage stage) {
-        if (dialogQueue.peek() == null)
-        {
-            inDialog = false; //occasionally this wasn't clearing, causing dialogs to stop displaying
-        }
         List<AdventureQuestData> finishedQuests = new ArrayList<>();
 
             for (AdventureQuestData quest : Current.player().getQuests()) {
                 DialogData prologue = quest.getPrologue();
-                if (prologue != null && (!prologue.text.isEmpty()) ){
+                if (prologue != null){
                     dialogQueue.add(prologue);
                 }
                 for (AdventureQuestStage questStage : quest.stages)
                 {
                     if (questStage.getStatus() == INACTIVE)
                         continue;
-                    if (questStage.prologue != null && (!questStage.prologue.text.isEmpty()) && !questStage.prologueDisplayed){
+                    if (questStage.prologue != null && !questStage.prologueDisplayed){
                         questStage.prologueDisplayed = true;
                         dialogQueue.add(questStage.prologue);
                     }
 
-                    if (questStage.getStatus() == FAILED && questStage.failureDialog != null && !questStage.failureDialog.text.isEmpty()){
+                    if (questStage.getStatus() == FAILED && questStage.failureDialog != null){
                         dialogQueue.add(questStage.failureDialog);
                         continue;
                     }
 
-                    if (questStage.getStatus() == COMPLETE && questStage.epilogue != null && (!questStage.epilogue.text.isEmpty()) && !questStage.epilogueDisplayed){
+                    if (questStage.getStatus() == COMPLETE && questStage.epilogue != null && !questStage.epilogueDisplayed){
                         questStage.epilogueDisplayed = true;
                         dialogQueue.add(questStage.epilogue);
                     }
@@ -187,7 +183,7 @@ public class AdventureQuestController implements Serializable {
 
                 if (quest.failed){
                     finishedQuests.add(quest);
-                    if (quest.failureDialog != null && !quest.failureDialog.text.isEmpty()){
+                    if (quest.failureDialog != null){
                         dialogQueue.add(quest.failureDialog);
                     }
                 }
@@ -195,9 +191,8 @@ public class AdventureQuestController implements Serializable {
                 if (!quest.completed)
                     continue;
                 DialogData epilogue = quest.getEpilogue();
-                if (epilogue != null && (!epilogue.text.isEmpty())){
+                if (epilogue != null){
                     dialogQueue.add(epilogue);
-
                 }
                 finishedQuests.add(quest);
                 updateQuestComplete(quest);

--- a/forge-gui/res/adventure/Shandalar/world/quests.json
+++ b/forge-gui/res/adventure/Shandalar/world/quests.json
@@ -41,7 +41,7 @@
                         },
                         {
                             "name": "\"And what if I find the right people myself?\"",
-                            "text": "He shrugs as though that wouldn't bother him. \"Then I'll have to find someone bigger, badder, and most importantly faster than you to work with.\"",
+                            "text": "He shrugs as though that wouldn't bother him. \"Then I'll have to find someone bigger, badder, and most importantly, faster than you to work with.\"",
                             "options": [
                                 {
                                     "name": "\"Good luck with that.\" (Decline Quest)"
@@ -390,7 +390,7 @@
                                             "POIReference": ""
                                         }
                                     ],
-                                    "name": "You take the coins and place the letter in the bucket. \"I have to say, I do I find your demeanor unnerving.\" ",
+                                    "name": "You take the coins and place the letter in the bucket. \"I have to say, I do find your demeanor unnerving.\" ",
                                     "text": "(+2 local reputation)",
                                     "options": [
                                         {
@@ -849,7 +849,7 @@
                     "POIReference": ""
                 }
             ],
-            "text": "Consciously or unconsciously, you brush your shoulders off as you walk back in to town. The locals appear delighted that you have taken care of their problem. (+3 local reputation)",
+            "text": "Consciously or unconsciously, you brush your shoulders off as you walk back into town. The locals appear delighted that you have taken care of their problem. (+3 local reputation)",
             "options": [
                 {
                     "action": [
@@ -1889,7 +1889,7 @@
         "id": 8,
         "isTemplate": true,
         "name": "Remote Instruction",
-        "description": "Find the $(enemy_2) before it escapes and put on a show",
+        "description": "Find the $(enemy_2) before it escapes, and put on a show",
         "offerDialog": {
             "text": "A robed wizard leads a more mundane dressed individual over to you. \"You there, you are a battle mage, yes?\"",
             "options": [
@@ -2225,7 +2225,7 @@
                                 },
                                 {
                                     "name": "Curious as to why this would be on the board, your gaze lingers for a moment.",
-                                    "text": "As you look at the wordless paper, words find their way in to your mind by unknown other means. 'FIND.' '{COLOR=red}KILL!{ENDCOLOR}' 'REWARD.'",
+                                    "text": "As you look at the wordless paper, words find their way into your mind by unknown, other, means. 'FIND.' '{COLOR=red}KILL!{ENDCOLOR}' 'REWARD.'",
                                     "options": [
                                         {
                                             "action": [
@@ -2275,7 +2275,7 @@
                                             ]
                                         },
                                         {
-                                            "name": "You decide that the invasive thoughts, if you can call them that, are unwelcomed, and you take a step back.",
+                                            "name": "You decide that the invasive thoughts, if you can call them that, are unwelcome, and you take a step back.",
                                             "text": "The thoughts urgently follow you for a moment. '{COLOR=red}KKKKiiiiill...{ENDCOLOR}' But as you take another step back, the words vanish from your mind.",
                                             "options": [
                                                 {
@@ -2310,7 +2310,7 @@
                             "options": [
                                 {
                                     "name": "You continue to read.",
-                                    "text": "Secondly, another handwriting has scrawled over what might have actually been a romantic bit with the following. \"Don't bother. I killed him yesterday\"",
+                                    "text": "Secondly, another's handwriting has scrawled over what might have actually been a romantic bit, with the following. \"Don't bother. I killed him yesterday\"",
                                     "options": [
                                         {
                                             "name": "You shake your head and walk away. (Decline Quest)"
@@ -2528,7 +2528,7 @@
                     "options": [
                         {
                             "name": "\"And what is, then?\"",
-                            "text": "\"The inhabitants of the nearby $(poi_1). They must be removed for the sake of balance and to ensure space is available for new life to grow.\" She nods as though this were an indisputable fact.",
+                            "text": "\"The inhabitants of the nearby $(poi_1). They must be removed, for the sake of balance and to ensure space is available for new life to grow.\" She nods as though this were an indisputable fact.",
                             "options": [
                                 {
                                     "action": [
@@ -2581,7 +2581,7 @@
                 },
                 {
                     "name": "\"I'm beginning to think that is my role in life. What can I do for you?\"",
-                    "text": "\"The inhabitants of the nearby $(poi_1) must be removed for the sake of balance and to ensure space is available for new life to grow.\" She nods as though this were an indisputable fact.",
+                    "text": "\"The inhabitants of the nearby $(poi_1) must be removed, for the sake of balance and to ensure space is available for new life to grow.\" She nods as though this were an indisputable fact.",
                     "options": [
                         {
                             "action": [
@@ -2621,7 +2621,7 @@
                                 }
                             ],
                             "name": "\"I'm not entirely sure I have time for that right now.\"",
-                            "text": "The druids face remains unchanged, but her voice grows a touch more quiet. \"The forest will remember this.\" (-1 Local Reputation)",
+                            "text": "The druid's face remains unchanged, but her voice grows a touch more quiet. \"The forest will remember this.\" (-1 Local Reputation)",
                             "options": [
                                 {
                                     "name": "(Continue)"
@@ -2727,7 +2727,7 @@
                             ]
                         }
                     ],
-                    "name": "\"Almost. I believe there's a reward due to level the scales.\"",
+                    "name": "\"Almost. I believe there's a reward due, to level the scales.\"",
                     "text": "(-1 Local Reputation) The druid frowns slightly, but hands you a bundle wrapped in small vines.",
                     "options": [
                         {
@@ -2910,7 +2910,7 @@
                             "options": [
                                 {
                                     "name": "\"I see. And I suppose you're looking for the current occupants to be removed?",
-                                    "text": "\"Yes! Exactly that! After all, I have this deed right here stating that we own this $(poi_1)!\" He briefly flashes some papers, but you notice some of the ink has smeared ink on them.",
+                                    "text": "\"Yes! Exactly that! After all, I have this deed right here stating that we own this $(poi_1)!\" He briefly flashes some papers, but you notice some of the ink has smeared on them.",
                                     "options": [
                                         {
                                             "action": [
@@ -3049,7 +3049,7 @@
                     "POIReference": "$(poi_2)"
                 }
             ],
-            "text": "You decide that the rewards promised to you are not worth clearing out the current occupants of the $(poi_1). They were here first anyway. (-2 Local Reputation)",
+            "text": "You decide that the rewards promised to you are not worth clearing out the current occupants of the $(poi_1). They were there first, anyway. (-2 Local Reputation)",
             "options": [
                 {
                     "name": "(Quest Failed)"
@@ -3346,7 +3346,7 @@
         "name": "The Onyx Compass",
         "description": "Clear out all enemies in the $(poi_2) and report back",
         "offerDialog": {
-            "text": "\"You. Come here.\" The gnome speaking to you seems very out of place here. He wears a white pristine robe that was either a shirt or custom tailored for him. He acts like he belongs and that he owns the place, however.",
+            "text": "\"You. Come here.\" The gnome speaking to you seems very out of place here. He wears a white pristine robe that was either a long shirt, or custom tailored for him. He acts like he belongs and that he owns the place, however.",
             "options": [
                 {
                     "name": "Walk over without a word.",
@@ -3455,7 +3455,7 @@
                             "POIReference": ""
                         }
                     ],
-                    "name": "You hold out your hand. \"Sorry, must be this tall to give orders\" (Decline Quest)",
+                    "name": "You hold out your hand. \"Sorry, must be at least this tall to give orders\" (Decline Quest)",
                     "text": "(-1 Local Reputation) He scowls and stomps away, one tiny step at a time.",
                     "options": [
                         {
@@ -3683,7 +3683,7 @@
                     "POIReference": "$(poi_2)"
                 }
             ],
-            "text": "Despite the insistance of the needle you decide that you will not finish clearing the $(poi_2). As if it could sense this somehow, the onyx compass disappears. (-2 Local Reputation)",
+            "text": "Despite the insistance of the compass needle, you decide that you will not finish clearing the $(poi_2). As if it could sense this somehow, the onyx compass disappears. (-2 Local Reputation)",
             "options": [
                 {
                     "name": "(Quest Failed)"
@@ -3718,7 +3718,7 @@
                         },
                         {
                             "name": "You take a closer look at the device.",
-                            "text": "The 'compass' is unlike most you have ever seen before. There is not a single marking on it anywhere, nor any color other than onyx save the crimson needle.",
+                            "text": "The 'compass' is unlike most you have seen before. There is not a single marking on it anywhere, nor any color other than onyx, save the crimson needle.",
                             "options": [
                                 {
                                     "name": "You put the compass away and carry on. (Continue)"
@@ -4003,7 +4003,7 @@
                     "text": "\"My vision was less than specific about whether or not it would be changed by your actions. So... yes.\"",
                     "options": [
                         {
-                            "name": "You glance around at a clear sky warily before going on in to town. (Complete Quest)"
+                            "name": "You glance around at a clear sky warily before going on into town. (Complete Quest)"
                         }
                     ]
                 }
@@ -4139,7 +4139,7 @@
                                 },
                                 {
                                     "name": "\"I must decline. I respect the local inhabitants far more than faceless nobility.\" (Decline Quest)",
-                                    "text": "He gives you the smallest bow imaginable, just enough to say that one was given without indicating respect.",
+                                    "text": "He gives you the smallest bow imaginable, just enough to say that one was given, without indicating respect.",
                                     "options": [
                                         {
                                             "name": "(Continue)"
@@ -4174,7 +4174,7 @@
                 },
                 {
                     "name": "You can't put your finger on it, but something seems off about the man. \"This isn't a good time.\" (Decline Quest)",
-                    "text": "He gives you the smallest bow imaginable, just enough to say that one was given without indicating respect. (-1 Local Reputation)",
+                    "text": "He gives you the smallest bow imaginable, just enough to say that one was given, without indicating respect. (-1 Local Reputation)",
                     "options": [
                         {
                             "name": "(Continue)"
@@ -4345,7 +4345,7 @@
                     "options": [
                         {
                             "name": "You wait for him to continue.",
-                            "text": "\"I've come in to an inheritance of a small estate that I've been expecting for years. Recently, I've had some hard times, and I've convinced some individuals to let me borrow against the land.\" ",
+                            "text": "\"I've come into an inheritance of a small estate that I've been expecting for years. Recently, I've had some hard times, and I've convinced some individuals to let me borrow against the land.\" ",
                             "options": [
                                 {
                                     "name": "\"I see.\" You think you know where this is headed.",
@@ -4368,7 +4368,7 @@
                                                     "POIReference": ""
                                                 }
                                             ],
-                                            "name": "\"So long as I get to keep whatever I find along the way too.\" (Accept Quest)."
+                                            "name": "\"So long as I get to keep whatever I find along the way, too.\" (Accept Quest)."
                                         },
                                         {
                                             "name": "\"I don't think I'm interested. Sorry.\" (Decline Quest)"
@@ -4588,7 +4588,7 @@
                     "text": "Most of the ads are nondescript, weather worn, or written in an unfamiliar language. A few catch your eye, however.",
                     "options": [
                         {
-                            "name": "You look at what seems to be an advertisment of some sort off to one side.",
+                            "name": "You look at what seems to be an advertisement of some sort, off to one side.",
                             "text": "It reads: \"Gimgee's self-replicating paper. When you need unlimited paper or to clear a forest from afar, it's got to be Gimgee's\".",
                             "options": [
                                 {
@@ -4704,7 +4704,7 @@
                                     ]
                                 }
                             ],
-                            "name": "You dump the $(enemy_1)s on to one of the wagons and collect your rewards. (+3 Local Reputation)"
+                            "name": "You dump the $(enemy_1)s onto one of the wagons and collect your rewards. (+3 Local Reputation)"
                         },
                         {
                             "name": "You take a closer look at the carts.",
@@ -4862,7 +4862,7 @@
                     "text": "Most of the ads are nondescript, weather worn, or written in an unfamiliar language. A few catch your eye, however.",
                     "options": [
                         {
-                            "name": "You look at what seems to be an advertisment of some sort off to one side.",
+                            "name": "You look at what seems to be an advertisement of some sort off to one side.",
                             "text": "\"A focused mind receives great rewards. Focus on defeating 3 $(enemy_2)s, and be rewarded.\"",
                             "options": [
                                 {
@@ -4952,7 +4952,7 @@
                         }
                     ],
                     "name": "Warily take the items.",
-                    "text": "No sooner than you do, the Djinn dissapears in a puff of smoke. When you turn back, the $(enemy_2) you just defeated has vanished as well.",
+                    "text": "No sooner than you do, the Djinn disappears in a puff of smoke. When you turn back, the $(enemy_2) you just defeated has vanished as well.",
                     "options": [
                         {
                             "action": [
@@ -5338,7 +5338,7 @@
                                     "text": "He laughs as if the question was ridiculous. \"I am, of course. And I need someone to prove that they are worthy of my teachings!\"",
                                     "options": [
                                         {
-                                            "name": "You decide to humor him. \"Let's say that I am, what then?\"",
+                                            "name": "You decide to humor him. \"Let's say that I am. What then?\"",
                                             "text": "He looks at you again, as though he hadn't actually paid attention to you before. \"Then you prove it. Defeat 3 $(enemy_1)s with honor.\"",
                                             "options": [
                                                 {
@@ -5598,7 +5598,7 @@
                     "options": [
                         {
                             "name": "\"It really depends on what they are.\" You look at him suspsiciously.",
-                            "text": "\"You're not a farmhand, so it will have to be.\" He thinks for a moment, pulling out a well worn notebook and flipping through the pages.",
+                            "text": "\"You're not a farmhand, so it will have to be..\" He thinks for a moment, pulling out a well worn notebook and flipping through the pages.",
                             "options": [
                                 {
                                     "name": "\"Another time perhaps, I need to keep moving.\" (Decline Quest)",
@@ -5767,7 +5767,7 @@
                     "text": "Most of the ads are nondescript, weather worn, or written in an unfamiliar language. A few catch your eye, however.",
                     "options": [
                         {
-                            "name": "You look at what seems to be an advertisment of some sort off to one side.",
+                            "name": "You look at what seems to be an advertisement of some sort off to one side.",
                             "text": "It reads: \"Gimgee's rocks. When you need a good rock, think Gimgee's\".",
                             "options": [
                                 {
@@ -5926,7 +5926,7 @@
             "text": "\"DO YOU HAVE WHAT IT TAKES? ARE YOU THE BEST IN SHANDALAR???\" A young girl yells at the top of her lungs at each passer by in the town. Most people come in to view already covering their ears, having heard this plenty of times before.",
             "options": [
                 {
-                    "name": "You walk over to her. \"Okay, kid, settle down, I heard you. What's this about?\"",
+                    "name": "You walk over to her. \"Okay kid, settle down, I heard you. What's this about?\"",
                     "text": "She looks surprised, and falls silent for a moment as she tries to remember what to do next. \"I uhhh... ummm...\" She pulls a piece of paper out of her pocket and prepares to read.",
                     "options": [
                         {
@@ -6123,7 +6123,7 @@
         "id": 24,
         "isTemplate": true,
         "name": "Pest Control",
-        "description": "Defeat Xira and her hornets in her hive and report back",
+        "description": "Defeat Xira and her hornets in her hive, and report back",
         "offerDialog": {
             "text": "Greetings, adventurer! I have a task that requires your assistance. You see, we have a bit of a situation with a giant insect named Xira. She's been causing quite a stir in our town with her penchant for organizing extravagant balls.",
             "options": [
@@ -6155,7 +6155,7 @@
                 },
                 {
                     "name": "Let me guess, you want to me to deal with this situation ?",
-                    "text": "Well Yes, Let me explain the situation; Xira's balls have become a bit of a problem. She has been hosting them every night, and they're becoming increasingly extravagant and disruptive. The townspeople are getting tired of the constant noise and commotion, and it's affecting their daily lives.",
+                    "text": "Well yes. Let me explain the situation; Xira's balls have become a bit of a problem. She has been hosting them every night, and they're becoming increasingly extravagant and disruptive. The townspeople are getting tired of the constant noise and commotion, and it's affecting their daily lives.",
                     "options": [
                         {
                             "name": "I see. So you want me to talk to Xira and ask her to stop?",
@@ -6363,7 +6363,7 @@
                     "options": [
                         {
                             "name": "I see. So you want me to go to his factory and defeat him ?",
-                            "text": "Your task, should you accept it, is to venture into Slobad's factory and cleanse it of its mechanical menaces. You will face a myriad of strange mechs, each with its unique capabilities and behaviors. Additionally, the factory's artificers, skilled engineers corrupted by their own creations, will fiercely defend their inventions, making your mission all the more challenging.",
+                            "text": "Your task, should you accept it, is to venture into Slobad's factory and cleanse it of its mechanical menaces. You will face a myriad of strange mechs, each with its unique capabilities and behaviors. Additionally, the factory's artificers, skilled engineers corrupted by their own creations, will fiercely defend their inventions. Making your mission all the more challenging.",
                             "options": [
                                 {
                                     "action": [
@@ -6562,7 +6562,7 @@
                 },
                 {
                     "name": "Tell me more about Slimefoot and what I can do to stop it.",
-                    "text": "Thank you, noble adventurer. Slimefoot is a creature of pure malevolence, a monstrous being that has taken root in the heart of the treacherous swamp. Its corrosive touch and toxic aura have brought devastation to our lands. To defeat it, you must journey through the perilous swamp, filled with treacherous terrain and deadly creatures lurking within.",
+                    "text": "Thank you, noble adventurer. Slimefoot is a creature of pure malevolence. A monstrous being that has taken root in the heart of the treacherous swamp. Its corrosive touch and toxic aura have brought devastation to our lands. To defeat it, you must journey through the perilous swamp, filled with treacherous terrain and deadly creatures lurking within.",
                     "options": [
                         {
                             "name": "I see. So you want me to travel to Slimefoots swamp and defeat him ?",
@@ -6752,7 +6752,7 @@
                         }
                     ],
                     "name": "Sorry, I don't have to the time for this. (Decline Quest)",
-                    "text": "Figured you weren't up to the challenge, come back to me when you are. ",
+                    "text": "Figured you weren't up to the challenge, come back to me when you are.",
                     "options": [
                         {
                             "name": "(Continue)"
@@ -6803,8 +6803,8 @@
                                             "POIReference": ""
                                         }
                                     ],
-                                    "name": "I don't intending to get slime on my armor, sorry you have to find someone else (Decline Quest)",
-                                    "text": "The merchant keeps a passive look on his face. \"Soon those things will be balanced as well.\"",
+                                    "name": "I don't intend to get slime on my armor. Sorry, you have to find someone else (Decline Quest)",
+                                    "text": "The merchant keeps a passive look on his face. \"All things perish in the end..\"",
                                     "options": [
                                         {
                                             "name": "(Continue)"
@@ -7159,7 +7159,7 @@
                                     "options": [
                                         {
                                             "name": "\"Go on...\"",
-                                            "text": "\"Every door was locked tight. A bad feeling came up my back as I realized just how quiet it was right before I heard splashing. I peeked round the corner, and found a merfolk waving his arms around and casting some spell.\"",
+                                            "text": "\"Every door was locked tight. A bad feeling came up my back as I realized just how quiet it was, right before I heard splashing. I peeked round the corner, and found a merfolk waving his arms around and casting some spell.\"",
                                             "options": [
                                                 {
                                                     "name": "\"What was the spell?\"",
@@ -7794,7 +7794,7 @@
                         }
                     ],
                     "name": "Sorry, I don't have to the time for this. (Decline Quest)",
-                    "text": "Figured you weren't up to the challenge, come back to me when you are. ",
+                    "text": "Figured you weren't up to the challenge, come back to me when you are.",
                     "options": [
                         {
                             "name": "(Continue)"
@@ -7847,7 +7847,7 @@
                                         }
                                     ],
                                     "name": "I don't think this is a quest for me  (Decline Quest)",
-                                    "text": "The merchant keeps a passive look on his face. \"Soon those things will be balanced as well.\"",
+                                    "text": "Shocked, the Elder shakes his head in dismay, \"Youngsters these days...\"",
                                     "options": [
                                         {
                                             "name": "(Continue)"
@@ -7920,7 +7920,7 @@
                     "POIReference": "$(poi_2)"
                 }
             ],
-            "text": "After some reflection, you decide that the rewards promised to you are not worth the effort of clearing out the current occupants of the sewers. (-2 Local Reputation)",
+            "text": "After some reflection, you decide that the rewards promised to you are not worth the effort of defeating Kiora. (-2 Local Reputation)",
             "options": [
                 {
                     "name": "(Quest Failed)"
@@ -8000,7 +8000,7 @@
                         }
                     ],
                     "name": "Sorry, I don't have to the time for this. (Decline Quest)",
-                    "text": "Figured you weren't up to the challenge, come back to me when you are. ",
+                    "text": "Figured you weren't up to the challenge, come back to me when you are.",
                     "options": [
                         {
                             "name": "(Continue)"
@@ -8008,7 +8008,7 @@
                     ]
                 },
                 {
-                    "name": "Teferi? What's he doing that's causing such alarm?  ",
+                    "name": "Teferi? What's he doing that's causing such alarm?",
                     "text": "(Frowning) Teferi's meddling with time magic has created temporal anomalies across Shandalar. The past, present, and future are becoming entangled, leading to chaos and unpredictability. It's a perilous situation.",
                     "options": [
                         {
@@ -8053,7 +8053,7 @@
                                         }
                                     ],
                                     "name": "I don't think this is a quest for me  (Decline Quest)",
-                                    "text": "The merchant keeps a passive look on his face. \"Soon those things will be balanced as well.\"",
+                                    "text": "The Scholar keeps a passive look on his face. \"Soon, everything will come to naught.\"",
                                     "options": [
                                         {
                                             "name": "(Continue)"
@@ -8206,7 +8206,7 @@
                         }
                     ],
                     "name": "Sorry, I don't have to the time for this. (Decline Quest)",
-                    "text": "Figured you weren't up to the challenge, come back to me when you are. ",
+                    "text": "Figured you weren't up to the challenge, come back to me when you are.",
                     "options": [
                         {
                             "name": "(Continue)"
@@ -8219,7 +8219,7 @@
                     "options": [
                         {
                             "name": "You've had quite a few drinks, Tim. Are you sure you're not imagining things? Phyrexians haven't been seen in these parts for thousands of years",
-                            "text": "Nonsense! Me eyes don't lie, friend. Them Phyrexians are real trouble, I'm tellin' ya. You gotta go, see for yourself. Kick 'em outta Shandalar!",
+                            "text": "Nonsense! Me eyes don't lie, friend. Them Phyrexians are real trouble, I'm tellin' ya. You gotta go. See for yourself. Kick 'em outta Shandalar!",
                             "options": [
                                 {
                                     "action": [
@@ -8258,7 +8258,8 @@
                                             "POIReference": ""
                                         }
                                     ],
-                                    "name": "Sorry, I don't have time for this (Decline Text)",
+                                    "name": "Sorry, I don't have time for this (Decline Quest)",
+									"text": "Tipsy Tim gives you a morose look, then starts drinking more as he staggers away from you with profound disappointment.",
                                     "options": [
                                         {
                                             "name": "(Continue)"
@@ -8273,7 +8274,7 @@
         },
         "prologue": {},
         "epilogue": {
-            "text": "As you enter the village, These...hiccup... metal freaks! They ain't from around here, I swear. Saw 'em with me own eyes. They got them twisted, mechanical...things! Up to somethin' bad, they are!  (+3 reputation in $(poi_1))",
+            "text": "As you return to town, nobody seems impressed besides Tipsy Tim, who gives you a clap on the back. \"Those metal freaks...hiccup...You got rid of them you did!\" He then stumbles away happily. (+3 reputation in $(poi_1))",
             "options": [
                 {
                     "action": [
@@ -8309,7 +8310,7 @@
                             ]
                         }
                     ],
-                    "name": "It's nothing I coudn't handle (Complete Quest)"
+                    "name": "You wave farewell to Tipsy Tim (Complete Quest)"
                 }
             ]
         },

--- a/forge-gui/res/adventure/Shandalar/world/quests.json
+++ b/forge-gui/res/adventure/Shandalar/world/quests.json
@@ -4335,7 +4335,7 @@
         "id": 16,
         "isTemplate": true,
         "name": "Clearing the ledger",
-        "description": "Clear out all enemies in the $(poi_1)and report back",
+        "description": "Clear out all enemies in the $(poi_1) and report back",
         "offerDialog": {
             "text": "As you introduce yourself to the inside of the local inn for the night, another patron approaches you.",
             "options": [
@@ -5654,7 +5654,25 @@
             "text": "You walk back into the town with the requested cargo of $(enemy_1)s. You're unsure if they will be useful, but the dwarf seems extremely excited to begin his work. (+3 Local Reputation) ",
             "options": [
                 {
-                    "name": "You try to talk to him, but the dwarf is completely lost in his work already. You take the bundle he was carrying, assuming it to be your rewards. (Complete Quest)"
+                    "action": [
+                        {
+                            "grantRewards": [
+                                {
+                                    "type": "gold",
+                                    "count": 500
+                                },
+                                {
+                                    "type": "card",
+                                    "count": 4,
+                                    "addMaxCount": 4,
+                                    "rarity": [
+                                        "Common",
+										"Uncommon"
+                                    ]
+                                }
+                            ]
+                        }
+                    ],"name": "You try to talk to him, but the dwarf is completely lost in his work already. You take the bundle he was carrying, assuming it to be your rewards. (Complete Quest)"
                 }
             ]
         },
@@ -9704,6 +9722,7 @@
                 "enemyTags": [
                     "Captain"
                 ],
+				"mixedEnemies": true,
                 "prologue": {
                     "text": "Sir Donovan's directions are very precise, and you find the mining operation without much trouble. There is, however, an obvious sign of trouble when you arrive.",
                     "options": [
@@ -9768,7 +9787,7 @@
                 "description": "Use Donovan's amulet to contact him.",
                 "mapFlag": "Quest_ShardMines_EpilogueComplete",
                 "mapFlagValue": 1,
-                "here": true,
+                "worldMapOK": true,
                 "objective": "QuestFlag",
                 "prologue": {
                     "text": "When you are ready, you should use the amulet he gave you to tell Sir Donovan about the pirates, and that they've been dealt with.",


### PR DESCRIPTION
Corrects issue with change list for first map in a point of interest being looked up under different name based on how it was loaded (POI entry, inner map transition, external lookup)