### PR TITLE
A quick fix for quest and help text for Adventure

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/scene/NewGameScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/NewGameScene.java
@@ -394,7 +394,7 @@ public class NewGameScene extends MenuScene {
                 summaryText.append("Mode: Chaos\n\nYou (and all enemies) will receive a random preconstructed deck.\n\nWarning: This will make encounter difficulty vary wildly from the developers' intent");
                 break;
             case Custom:
-                summaryText.append("Mode: Custom\n\nChoose your own preconstructed deck. Enemies can use receive a random genetic AI decks.\n\nWarning: This will make encounter difficulty vary wildly from the developers' intent");
+                summaryText.append("Mode: Custom\n\nChoose your own preconstructed deck. Enemies can receive a random genetic AI deck.\n\nWarning: This will make encounter difficulty vary wildly from the developers' intent");
                 break;
             default:
                 summaryText.append("No summary available for your this game mode.");

--- a/forge-gui/res/adventure/Shandalar/world/quests.json
+++ b/forge-gui/res/adventure/Shandalar/world/quests.json
@@ -4,7 +4,8 @@
         "isTemplate": true,
         "name": "Go Forth and Slay",
         "description": "Defeat two $(enemy_1)s and collect a reward",
-        "offerDialog": {
+        "offerDialog":
+        {
             "text": "\"Hey, you! Yeah, you, the big bad wizard with a surprised look on your face.\" A haggard old man shouts at you from the spot in which he sits, you could have sworn that side of the street was empty just seconds before.",
             "options": [
                 {
@@ -22,10 +23,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "1",
@@ -41,7 +44,7 @@
                         },
                         {
                             "name": "\"And what if I find the right people myself?\"",
-                            "text": "He shrugs as though that wouldn't bother him. \"Then I'll have to find someone bigger, badder, and most importantly faster than you to work with.\"",
+                            "text": "He shrugs as though that wouldn't bother him. \"Then I'll have to find someone bigger, badder, and most importantly, faster than you to work with.\"",
                             "options": [
                                 {
                                     "name": "\"Good luck with that.\" (Decline Quest)"
@@ -60,10 +63,12 @@
                                                     "setColorIdentity": "",
                                                     "advanceQuestFlag": "",
                                                     "advanceMapFlag": "",
-                                                    "setQuestFlag": {
+                                                    "setQuestFlag":
+                                                    {
                                                         "key": ""
                                                     },
-                                                    "setMapFlag": {
+                                                    "setMapFlag":
+                                                    {
                                                         "key": ""
                                                     },
                                                     "issueQuest": "1",
@@ -82,17 +87,20 @@
         },
         "prologue": {},
         "epilogue": {},
-        "failureDialog": {
+        "failureDialog":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -107,7 +115,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -125,11 +134,11 @@
                 "mapFlagValue": 1,
                 "count1": 2,
                 "objective": "Defeat",
-                "worldMapOK": true,
                 "enemyTags": [
                     "BiomeColorless"
                 ],
-                "prologue": {
+                "prologue":
+                {
                     "text": "The wasteland biome is usually a good place to look for $(enemy_1)s.",
                     "options": [
                         {
@@ -148,7 +157,8 @@
                 "mapFlagValue": 1,
                 "here": true,
                 "objective": "Travel",
-                "prologue": {
+                "prologue":
+                {
                     "text": "Having finally handled the pair of $(enemy_1), it's time to go collect your reward. As a reminder, you can track this quest in your quest log for navigation assistance.",
                     "options": [
                         {
@@ -156,7 +166,8 @@
                         }
                     ]
                 },
-                "epilogue": {
+                "epilogue":
+                {
                     "text": "You find your partner in this endeavor exactly where you left them. Not much of a partner in that case, but they hold up their side of the deal and you walk away with your half of the loot.",
                     "options": [
                         {
@@ -214,10 +225,7 @@
                         }
                     ]
                 },
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             }
         ],
         "questSourceTags": [
@@ -231,8 +239,9 @@
         "isTemplate": true,
         "name": "Wanderlust",
         "description": "Make a delivery to a distant location",
-        "offerDialog": {
-            "text": "\"Excuse me, but you look like a well traveled individual.\" A frazzled looking mage gets your attention. \"I have a letter of some great importance that MUST be hand delivered to $(poi_1), in the $(biome_1) lands. Would you be willing to handle this for me?\"",
+        "offerDialog":
+        {
+            "text": "\"Excuse me, but you look like a well traveled individual.\" A frazzled looking mage gets your attention. \"I have a letter of some great importance that MUST be hand delivered. Would you be willing to handle this for me?\"",
             "options": [
                 {
                     "name": "\"Why does it have to be hand delivered?\"",
@@ -252,10 +261,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "2",
@@ -278,10 +289,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "2",
@@ -293,8 +306,9 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
-            "text": "After a lot of travel, a little teleporting, or both, you finally arrive at your destination. The letter you are carrying looks no worse for wear, at least.",
+        "epilogue":
+        {
+            "text": "After a lot of travel, a little teleporting, or both, you finally arrive at your destination. The letter you are carrying looks no worse for wear at least.",
             "options": [
                 {
                     "name": "(Continue)",
@@ -311,10 +325,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "",
@@ -331,10 +347,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "",
@@ -363,10 +381,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "grantRewards": [
@@ -390,7 +410,7 @@
                                             "POIReference": ""
                                         }
                                     ],
-                                    "name": "You take the coins and place the letter in the bucket. \"I have to say, I do I find your demeanor unnerving.\" ",
+                                    "name": "You take the coins and place the letter in the bucket. \"I have to say, I do find your demeanor unnerving.\" ",
                                     "text": "(+2 local reputation)",
                                     "options": [
                                         {
@@ -404,7 +424,8 @@
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "text": "The trip just doesn't seem worth it anymore, and you give up on trying to reach $(poi_1).",
             "options": [
                 {
@@ -412,7 +433,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -425,7 +447,7 @@
             {
                 "id": 1,
                 "name": "Travel",
-                "description": "Make the long journey to $(poi_1)",
+                "description": "Make the long journey",
                 "mapFlag": "",
                 "mapFlagValue": 1,
                 "count1": 80,
@@ -434,8 +456,9 @@
                     "Town"
                 ],
                 "objective": "Travel",
-                "prologue": {
-                    "text": "Nothing like a really long walk to strech the legs, right? You could likely save yourself some time with the right spells, but... is that going to be safe?",
+                "prologue":
+                {
+                    "text": "Nothing like a really long journey to strech the legs, right? You could likely save yourself some time with the right spells, but... is that going to be safe?",
                     "options": [
                         {
                             "name": "(Begin your quest)"
@@ -452,7 +475,8 @@
         "isTemplate": true,
         "name": "(Almost) Open for Business",
         "description": "Assist a new merchant as they open their shop",
-        "offerDialog": {
+        "offerDialog":
+        {
             "text": "A portly man in the corner of the tavern catches your eye. \"I hear you're looking for work.\"",
             "options": [
                 {
@@ -460,7 +484,7 @@
                 },
                 {
                     "name": "So long as it pays. What do you need?",
-                    "text": "I'm new to town, and looking to open a new spell shop. But I need supplies that I had to leave behind. Can you go get them for me from $(poi_1)?",
+                    "text": "I'm new to town, and looking to open a new spell shop. But I need supplies that I had to leave behind. Can you go get them for me?",
                     "options": [
                         {
                             "name": "\"And the pay?\"",
@@ -473,10 +497,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "3",
@@ -499,17 +525,20 @@
         },
         "prologue": {},
         "epilogue": {},
-        "failureDialog": {
+        "failureDialog":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -524,7 +553,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -541,9 +571,9 @@
                 "mapFlag": "",
                 "mapFlagValue": 1,
                 "objective": "Leave",
-                "anyPOI": true,
                 "prologue": {},
-                "epilogue": {
+                "epilogue":
+                {
                     "text": "(As a reminder, you can track this quest from your quest log to get directions to your destination)",
                     "options": [
                         {
@@ -567,7 +597,8 @@
                 ],
                 "objective": "Travel",
                 "prologue": {},
-                "epilogue": {
+                "epilogue":
+                {
                     "text": "Upon arriving at the pickup point, you find a rather modest looking spellbook among the supplies. Presumably, this is the merchandise your employer is planning to sell",
                     "options": [
                         {
@@ -628,10 +659,12 @@
                                                             "setColorIdentity": "",
                                                             "advanceQuestFlag": "",
                                                             "advanceMapFlag": "",
-                                                            "setQuestFlag": {
+                                                            "setQuestFlag":
+                                                            {
                                                                 "key": ""
                                                             },
-                                                            "setMapFlag": {
+                                                            "setMapFlag":
+                                                            {
                                                                 "key": ""
                                                             },
                                                             "issueQuest": "",
@@ -669,10 +702,7 @@
                         }
                     ]
                 },
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             },
             {
                 "id": 3,
@@ -686,7 +716,8 @@
                 ],
                 "objective": "Travel",
                 "prologue": {},
-                "epilogue": {
+                "epilogue":
+                {
                     "text": "While you were gone, the new merchant has set up a tent filled with mismatched and bare shelves. It will be a little less bare now, but you doubt that their business will succeed.",
                     "options": [
                         {
@@ -712,10 +743,7 @@
                         }
                     ]
                 },
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    2
-                ]
+                "POIToken": ""
             }
         ],
         "questSourceTags": [
@@ -729,7 +757,8 @@
         "isTemplate": true,
         "name": "On the Hunt",
         "description": "Find and slay the $(enemy_2) before it escapes.",
-        "offerDialog": {
+        "offerDialog":
+        {
             "text": "A well dressed elf, probably a merchant, approaches you. \"Adventurer, are you available? A $(enemy_2) has been causing trouble in this area lately, and we need someone to take care of the matter.\"",
             "options": [
                 {
@@ -739,10 +768,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "4",
@@ -758,10 +789,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -788,10 +821,12 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "4",
@@ -807,10 +842,12 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "",
@@ -831,17 +868,20 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
+        "epilogue":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -849,7 +889,7 @@
                     "POIReference": ""
                 }
             ],
-            "text": "Consciously or unconsciously, you brush your shoulders off as you walk back in to town. The locals appear delighted that you have taken care of their problem. (+3 local reputation)",
+            "text": "Consciously or unconsciously, you brush your shoulders off as you walk back into town. The locals appear delighted that you have taken care of their problem. (+3 local reputation)",
             "options": [
                 {
                     "action": [
@@ -902,7 +942,8 @@
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "text": "You gave it your best effort, but today was not a successful hunt by any means. The $(enemy_2) will continue to be a problem for the area. (-2 town reputation)",
             "options": [
                 {
@@ -912,10 +953,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -927,7 +970,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -943,9 +987,8 @@
                 "description": "Leave town to begin the hunt",
                 "mapFlag": "",
                 "mapFlagValue": 1,
-                "count1": 0,
+                "count1": 15,
                 "objective": "Leave",
-                "anyPOI": true,
                 "prologue": {},
                 "epilogue": {},
                 "POIToken": ""
@@ -958,16 +1001,12 @@
                 "mapFlagValue": 1,
                 "count1": 30,
                 "objective": "Hunt",
-                "worldMapOK": true,
                 "enemyTags": [
                     "BiomeGreen"
                 ],
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             },
             {
                 "id": 3,
@@ -979,10 +1018,7 @@
                 "objective": "Travel",
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    2
-                ]
+                "POIToken": ""
             }
         ],
         "questSourceTags": [
@@ -997,7 +1033,8 @@
         "isTemplate": true,
         "name": "A Scheduled Burial",
         "description": "Find and slay the $(enemy_2) before it escapes.",
-        "offerDialog": {
+        "offerDialog":
+        {
             "text": "A cloaked and hooded humanoid approaches you and speaks in a quiet raspy voice. \"You'll do. I have need of a $(enemy_2). Dead or alive. And by alive, I mean dead. Quickly.\"",
             "options": [
                 {
@@ -1007,10 +1044,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "5",
@@ -1026,10 +1065,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -1056,10 +1097,12 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "5",
@@ -1075,10 +1118,12 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "",
@@ -1099,7 +1144,8 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
+        "epilogue":
+        {
             "text": "No sooner than you walk through the gates, a pair of ghouls scamper over and take the corpse from you. They disappear into a nearby building. Mere moments later, one returns with a wooden chest while the other carries away a matching one. (+3 local reputation)",
             "options": [
                 {
@@ -1109,10 +1155,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -1163,7 +1211,8 @@
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "text": "The $(enemy_2) escapes, and your opportunity is missed. Hopefully that doesn't result in your parts being harvested next. (-2 town reputation)",
             "options": [
                 {
@@ -1173,10 +1222,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -1188,7 +1239,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -1204,9 +1256,8 @@
                 "description": "Leave town to locate your victim",
                 "mapFlag": "",
                 "mapFlagValue": 1,
-                "count1": 0,
+                "count1": 15,
                 "objective": "Leave",
-                "anyPOI": true,
                 "prologue": {},
                 "epilogue": {},
                 "POIToken": ""
@@ -1219,16 +1270,12 @@
                 "mapFlagValue": 1,
                 "count1": 30,
                 "objective": "Hunt",
-                "worldMapOK": true,
                 "enemyTags": [
                     "BiomeBlack"
                 ],
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             },
             {
                 "id": 3,
@@ -1240,10 +1287,7 @@
                 "objective": "Travel",
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    2
-                ]
+                "POIToken": ""
             }
         ],
         "questSourceTags": [
@@ -1258,7 +1302,8 @@
         "isTemplate": true,
         "name": "High Plains Justice",
         "description": "Catch the $(enemy_2) before it escapes.",
-        "offerDialog": {
+        "offerDialog":
+        {
             "text": "As you walk out of the local inn, you spot a militiaman putting up wanted posters.",
             "options": [
                 {
@@ -1272,10 +1317,12 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "",
@@ -1302,10 +1349,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "",
@@ -1328,10 +1377,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "6",
@@ -1385,10 +1436,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "6",
@@ -1404,17 +1457,20 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
+        "epilogue":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -1463,10 +1519,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "",
@@ -1485,10 +1543,12 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "",
@@ -1500,10 +1560,12 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "grantRewards": [
@@ -1572,7 +1634,8 @@
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "text": "The $(enemy_2) has escaped, and will likely be trouble again in the future. (-2 town reputation)",
             "options": [
                 {
@@ -1582,10 +1645,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -1597,7 +1662,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -1613,9 +1679,8 @@
                 "description": "Begin the chase",
                 "mapFlag": "",
                 "mapFlagValue": 1,
-                "count1": 0,
+                "count1": 15,
                 "objective": "Leave",
-                "anyPOI": true,
                 "prologue": {},
                 "epilogue": {},
                 "POIToken": ""
@@ -1628,17 +1693,13 @@
                 "mapFlagValue": 1,
                 "count1": 30,
                 "objective": "Hunt",
-                "worldMapOK": true,
                 "enemyTags": [
                     "BiomeWhite",
                     "Human"
                 ],
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             },
             {
                 "id": 3,
@@ -1650,10 +1711,7 @@
                 "objective": "Travel",
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    2
-                ]
+                "POIToken": ""
             }
         ],
         "questSourceTags": [
@@ -1668,7 +1726,8 @@
         "isTemplate": true,
         "name": "Sacred Sands",
         "description": "Find and slay the $(enemy_2) before it escapes.",
-        "offerDialog": {
+        "offerDialog":
+        {
             "text": "Stepping out of the cool shade of the local tavern, you find yourself face to face with a Viashino adorned in tribal garb.",
             "options": [
                 {
@@ -1682,10 +1741,12 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "7",
@@ -1701,10 +1762,12 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "",
@@ -1729,10 +1792,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -1751,7 +1816,8 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
+        "epilogue":
+        {
             "text": "The Viashino holds still for a moment, regarding you with a long evaluating look. \"Shaman Cresh thanks you, and wishes your eggs to hatch well.\" (+3 local reputation)",
             "options": [
                 {
@@ -1761,10 +1827,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -1795,7 +1863,8 @@
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "text": "The $(enemy_2) will not be receiving vengeance today. (-2 town reputation)",
             "options": [
                 {
@@ -1805,10 +1874,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -1820,7 +1891,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -1836,9 +1908,8 @@
                 "description": "Leave town to begin the hunt",
                 "mapFlag": "",
                 "mapFlagValue": 1,
-                "count1": 0,
+                "count1": 15,
                 "objective": "Leave",
-                "anyPOI": true,
                 "prologue": {},
                 "epilogue": {},
                 "POIToken": ""
@@ -1851,16 +1922,12 @@
                 "mapFlagValue": 1,
                 "count1": 30,
                 "objective": "Hunt",
-                "worldMapOK": true,
                 "enemyTags": [
                     "BiomeRed"
                 ],
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             },
             {
                 "id": 3,
@@ -1872,10 +1939,7 @@
                 "objective": "Travel",
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    2
-                ]
+                "POIToken": ""
             }
         ],
         "questSourceTags": [
@@ -1889,8 +1953,9 @@
         "id": 8,
         "isTemplate": true,
         "name": "Remote Instruction",
-        "description": "Find the $(enemy_2) before it escapes and put on a show",
-        "offerDialog": {
+        "description": "Find the $(enemy_2) before it escapes, and put on a show",
+        "offerDialog":
+        {
             "text": "A robed wizard leads a more mundane dressed individual over to you. \"You there, you are a battle mage, yes?\"",
             "options": [
                 {
@@ -1912,10 +1977,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "7",
@@ -1935,10 +2002,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -1965,10 +2034,12 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "",
@@ -1995,10 +2066,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "8",
@@ -2016,10 +2089,12 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "",
@@ -2040,8 +2115,9 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
-            "text": "You feel a sense of elation joining the eery feeling that some has been watching you. You also wonder if you heard an indignant huff, or you just imagined it. Regardless, your pockets bulge with conjured rewards. (+3 local reputation)",
+        "epilogue":
+        {
+            "text": "You feel a sense of elation joining the eerie feeling that someone has been watching you. You also wonder if you heard an indignant huff, or you just imagined it. Regardless, your pockets bulge with conjured rewards. (+3 local reputation)",
             "options": [
                 {
                     "action": [
@@ -2104,7 +2180,8 @@
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "text": "You now feel as though you are being both watched AND mocked. (-2 town reputation)",
             "options": [
                 {
@@ -2114,10 +2191,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -2129,7 +2208,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -2145,11 +2225,11 @@
                 "description": "Leave town to begin the hunt",
                 "mapFlag": "",
                 "mapFlagValue": 1,
-                "count1": 0,
+                "count1": 15,
                 "objective": "Leave",
-                "anyPOI": true,
                 "prologue": {},
-                "epilogue": {
+                "epilogue":
+                {
                     "text": "No more than a step out of the town gates, you have a sudden and unshakable feeling that you are being watched.",
                     "options": [
                         {
@@ -2167,16 +2247,12 @@
                 "mapFlagValue": 1,
                 "count1": 30,
                 "objective": "Hunt",
-                "worldMapOK": true,
                 "enemyTags": [
                     "BiomeBlue"
                 ],
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             },
             {
                 "id": 3,
@@ -2188,10 +2264,7 @@
                 "objective": "Travel",
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    2
-                ]
+                "POIToken": ""
             }
         ],
         "questSourceTags": [
@@ -2206,7 +2279,8 @@
         "isTemplate": true,
         "name": "Waste 'em",
         "description": "Find and slay the $(enemy_2) before it escapes.",
-        "offerDialog": {
+        "offerDialog":
+        {
             "text": "A job board has been constructed outside the local inn, and you see that it is covered in various papers and posters.",
             "options": [
                 {
@@ -2225,7 +2299,7 @@
                                 },
                                 {
                                     "name": "Curious as to why this would be on the board, your gaze lingers for a moment.",
-                                    "text": "As you look at the wordless paper, words find their way in to your mind by unknown other means. 'FIND.' '{COLOR=red}KILL!{ENDCOLOR}' 'REWARD.'",
+                                    "text": "As you look at the wordless paper, words find their way into your mind by unknown, other, means. 'FIND.' '{COLOR=red}KILL!{ENDCOLOR}' 'REWARD.'",
                                     "options": [
                                         {
                                             "action": [
@@ -2234,10 +2308,12 @@
                                                     "setColorIdentity": "",
                                                     "advanceQuestFlag": "",
                                                     "advanceMapFlag": "",
-                                                    "setQuestFlag": {
+                                                    "setQuestFlag":
+                                                    {
                                                         "key": ""
                                                     },
-                                                    "setMapFlag": {
+                                                    "setMapFlag":
+                                                    {
                                                         "key": ""
                                                     },
                                                     "issueQuest": "9",
@@ -2257,10 +2333,12 @@
                                                             "setColorIdentity": "",
                                                             "advanceQuestFlag": "",
                                                             "advanceMapFlag": "",
-                                                            "setQuestFlag": {
+                                                            "setQuestFlag":
+                                                            {
                                                                 "key": ""
                                                             },
-                                                            "setMapFlag": {
+                                                            "setMapFlag":
+                                                            {
                                                                 "key": ""
                                                             },
                                                             "issueQuest": "9",
@@ -2275,7 +2353,7 @@
                                             ]
                                         },
                                         {
-                                            "name": "You decide that the invasive thoughts, if you can call them that, are unwelcomed, and you take a step back.",
+                                            "name": "You decide that the invasive thoughts, if you can call them that, are unwelcome, and you take a step back.",
                                             "text": "The thoughts urgently follow you for a moment. '{COLOR=red}KKKKiiiiill...{ENDCOLOR}' But as you take another step back, the words vanish from your mind.",
                                             "options": [
                                                 {
@@ -2294,10 +2372,12 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "",
@@ -2310,7 +2390,7 @@
                             "options": [
                                 {
                                     "name": "You continue to read.",
-                                    "text": "Secondly, another handwriting has scrawled over what might have actually been a romantic bit with the following. \"Don't bother. I killed him yesterday\"",
+                                    "text": "Secondly, another's handwriting has scrawled over what might have actually been a romantic bit, with the following. \"Don't bother. I killed him yesterday\"",
                                     "options": [
                                         {
                                             "name": "You shake your head and walk away. (Decline Quest)"
@@ -2336,8 +2416,9 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
-            "text": "Your unknown employer is still nowhere to be seen, and is not heard from again either. But you find a box waiting for you beneath the job board. The box is warded, as the scorch marks off to one side and smell of burnt hair confirm, but it opens at your approach. (+3 local reputation)",
+        "epilogue":
+        {
+            "text": "Your unknown employer is still nowhere to be seen, and is not heard from again either. But you find a box waiting for you beneath the job board. The box is warded, as the scorch marks off to one side and the smell of burnt hair confirm, but it opens at your approach. (+3 local reputation)",
             "options": [
                 {
                     "action": [
@@ -2346,10 +2427,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -2399,7 +2482,8 @@
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "text": "The $(enemy_2) eludes you. (-2 town reputation)",
             "options": [
                 {
@@ -2409,10 +2493,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -2424,7 +2510,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -2440,9 +2527,8 @@
                 "description": "Leave town to begin the hunt",
                 "mapFlag": "",
                 "mapFlagValue": 1,
-                "count1": 0,
+                "count1": 15,
                 "objective": "Leave",
-                "anyPOI": true,
                 "prologue": {},
                 "epilogue": {},
                 "POIToken": ""
@@ -2455,16 +2541,12 @@
                 "mapFlagValue": 1,
                 "count1": 30,
                 "objective": "Hunt",
-                "worldMapOK": true,
                 "enemyTags": [
                     "BiomeColorless"
                 ],
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             },
             {
                 "id": 3,
@@ -2476,10 +2558,7 @@
                 "objective": "Travel",
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    2
-                ]
+                "POIToken": ""
             }
         ],
         "questSourceTags": [
@@ -2493,7 +2572,8 @@
         "isTemplate": true,
         "name": "Room for New Growth",
         "description": "Clear out all enemies in the $(poi_1) and report back",
-        "offerDialog": {
+        "offerDialog":
+        {
             "text": "A druid approaches you. \"Will you help save our world?\"",
             "options": [
                 {
@@ -2503,10 +2583,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -2528,7 +2610,7 @@
                     "options": [
                         {
                             "name": "\"And what is, then?\"",
-                            "text": "\"The inhabitants of the nearby $(poi_1). They must be removed for the sake of balance and to ensure space is available for new life to grow.\" She nods as though this were an indisputable fact.",
+                            "text": "\"The inhabitants of the nearby $(poi_1). They must be removed, for the sake of balance and to ensure space is available for new life to grow.\" She nods as though this were an indisputable fact.",
                             "options": [
                                 {
                                     "action": [
@@ -2537,10 +2619,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "10",
@@ -2556,10 +2640,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "",
@@ -2581,7 +2667,7 @@
                 },
                 {
                     "name": "\"I'm beginning to think that is my role in life. What can I do for you?\"",
-                    "text": "\"The inhabitants of the nearby $(poi_1) must be removed for the sake of balance and to ensure space is available for new life to grow.\" She nods as though this were an indisputable fact.",
+                    "text": "\"The inhabitants of the nearby $(poi_1) must be removed, for the sake of balance and to ensure space is available for new life to grow.\" She nods as though this were an indisputable fact.",
                     "options": [
                         {
                             "action": [
@@ -2590,10 +2676,12 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "10",
@@ -2609,10 +2697,12 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "",
@@ -2621,7 +2711,7 @@
                                 }
                             ],
                             "name": "\"I'm not entirely sure I have time for that right now.\"",
-                            "text": "The druids face remains unchanged, but her voice grows a touch more quiet. \"The forest will remember this.\" (-1 Local Reputation)",
+                            "text": "The druid's face remains unchanged, but her voice grows a touch more quiet. \"The forest will remember this.\" (-1 Local Reputation)",
                             "options": [
                                 {
                                     "name": "(Continue)"
@@ -2633,17 +2723,20 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
+        "epilogue":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -2660,10 +2753,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -2727,7 +2822,7 @@
                             ]
                         }
                     ],
-                    "name": "\"Almost. I believe there's a reward due to level the scales.\"",
+                    "name": "\"Almost. I believe there's a reward due, to level the scales.\"",
                     "text": "(-1 Local Reputation) The druid frowns slightly, but hands you a bundle wrapped in small vines.",
                     "options": [
                         {
@@ -2818,17 +2913,20 @@
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -2843,7 +2941,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -2879,10 +2978,7 @@
                 "objective": "Travel",
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             }
         ],
         "questSourceTags": [
@@ -2897,8 +2993,9 @@
         "isTemplate": true,
         "name": "Eviction Notice",
         "description": "Clear all enemies from a dungeon",
-        "offerDialog": {
-            "text": "As you approach the town square, a man climbs down from a packed wagon. He glances around, then walks toward you.\"You there, you look like a capable individual!\"",
+        "offerDialog":
+        {
+            "text": "As you approach the town square, a man climbs down from a packed wagon. He glances around, then walks toward you.\"You there! You look like a capable individual!\"",
             "options": [
                 {
                     "name": "\"Capable just so happens to be my middle name.\"",
@@ -2910,7 +3007,7 @@
                             "options": [
                                 {
                                     "name": "\"I see. And I suppose you're looking for the current occupants to be removed?",
-                                    "text": "\"Yes! Exactly that! After all, I have this deed right here stating that we own this $(poi_1)!\" He briefly flashes some papers, but you notice some of the ink has smeared ink on them.",
+                                    "text": "\"Yes! Exactly that! After all, I have this deed right here stating that we own the land!\" He briefly flashes some papers, but you notice some of the ink has smeared on them.",
                                     "options": [
                                         {
                                             "action": [
@@ -2919,10 +3016,12 @@
                                                     "setColorIdentity": "",
                                                     "advanceQuestFlag": "",
                                                     "advanceMapFlag": "",
-                                                    "setQuestFlag": {
+                                                    "setQuestFlag":
+                                                    {
                                                         "key": ""
                                                     },
-                                                    "setMapFlag": {
+                                                    "setMapFlag":
+                                                    {
                                                         "key": ""
                                                     },
                                                     "issueQuest": "11",
@@ -2947,10 +3046,12 @@
                                                     "setColorIdentity": "",
                                                     "advanceQuestFlag": "",
                                                     "advanceMapFlag": "",
-                                                    "setQuestFlag": {
+                                                    "setQuestFlag":
+                                                    {
                                                         "key": ""
                                                     },
-                                                    "setMapFlag": {
+                                                    "setMapFlag":
+                                                    {
                                                         "key": ""
                                                     },
                                                     "issueQuest": "11",
@@ -2974,14 +3075,13 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
-            "text": "Your employer couldn't be happier to see you returning to town, as it means that he gets to leave. (+1 reputation in $(poi_3))",
+        "epilogue":
+        {
+            "text": "As soon as you turn to head back to town, you hear the squeaking of wagon wheels in the distance. Your employer comes in to view, and drives his wagon right up to you.",
             "options": [
                 {
                     "action": [
                         {
-                            "addMapReputation": 1,
-                            "POIReference": "$(poi_3)",
                             "grantRewards": [
                                 {
                                     "type": "shards",
@@ -3027,21 +3127,24 @@
                             ]
                         }
                     ],
-                    "name": "\"You might want to spend some time cleaning it before you move in, but the place is all yours.\" (Complete Quest)"
+                    "name": "\"You might want to spend some time cleaning it before you move in, but it's all yours.\" (Complete Quest)"
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -3049,14 +3152,15 @@
                     "POIReference": "$(poi_2)"
                 }
             ],
-            "text": "You decide that the rewards promised to you are not worth clearing out the current occupants of the $(poi_1). They were here first anyway. (-2 Local Reputation)",
+            "text": "You decide that the rewards promised to you are not worth clearing out the current occupants of the $(poi_1). They were there first, anyway. (-2 Local Reputation)",
             "options": [
                 {
                     "name": "(Quest Failed)"
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -3069,7 +3173,7 @@
             {
                 "id": 1,
                 "name": "Clear",
-                "description": "Travel to the $(poi_1) and defeat all enemies inside.",
+                "description": "Travel to the  $(poi_1) and defeat all enemies inside.",
                 "mapFlag": "",
                 "mapFlagValue": 1,
                 "count2": 25,
@@ -3089,23 +3193,9 @@
                 "mapFlag": "",
                 "mapFlagValue": 1,
                 "objective": "Leave",
-                "anyPOI": true,
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "$(poi_1)",
-                "prerequisiteIDs": [
-                    1
-                ]
-            },
-            {
-                "id": 3,
-                "name": "Return to town",
-                "description": "Go back to the settler in $(poi_3)",
-                "here": true,
-                "objective": "Travel",
-                "prerequisiteIDs": [
-                    2
-                ]
+                "POIToken": "$(poi_1)"
             }
         ]
     },
@@ -3114,7 +3204,8 @@
         "isTemplate": true,
         "name": "A Freshly Plowed Field",
         "description": "Clear out all enemies in the $(poi_2) and report back",
-        "offerDialog": {
+        "offerDialog":
+        {
             "text": "\"We need a new field to increase our harvest.\" A weathered but intimidating man in simple farmer's garb addresses you directly. \"This town is growing faster than my grain.\"",
             "options": [
                 {
@@ -3128,10 +3219,12 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "12",
@@ -3150,10 +3243,12 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "12",
@@ -3171,10 +3266,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -3193,7 +3290,8 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
+        "epilogue":
+        {
             "text": "You've barely finished clearing the area, and the imposing farmer is already preparing to harness one of his animals to a plow outside. Seeing you approach, he tosses you a satchel. \"Thanks.\" He then gets back to work.",
             "options": [
                 {
@@ -3263,17 +3361,20 @@
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -3288,7 +3389,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -3324,13 +3426,9 @@
                 "mapFlag": "",
                 "mapFlagValue": 1,
                 "objective": "Leave",
-                "anyPOI": true,
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             }
         ],
         "questSourceTags": [
@@ -3345,8 +3443,9 @@
         "isTemplate": true,
         "name": "The Onyx Compass",
         "description": "Clear out all enemies in the $(poi_2) and report back",
-        "offerDialog": {
-            "text": "\"You. Come here.\" The gnome speaking to you seems very out of place here. He wears a white pristine robe that was either a shirt or custom tailored for him. He acts like he belongs and that he owns the place, however.",
+        "offerDialog":
+        {
+            "text": "\"You. Come here.\" The gnome speaking to you seems very out of place here. He wears a white pristine robe that was either a long shirt, or custom tailored for him. He acts like he belongs and that he owns the place, however.",
             "options": [
                 {
                     "name": "Walk over without a word.",
@@ -3359,10 +3458,12 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "13",
@@ -3388,10 +3489,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "",
@@ -3414,10 +3517,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "",
@@ -3444,10 +3549,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -3455,7 +3562,7 @@
                             "POIReference": ""
                         }
                     ],
-                    "name": "You hold out your hand. \"Sorry, must be this tall to give orders\" (Decline Quest)",
+                    "name": "You hold out your hand. \"Sorry, must be at least this tall to give orders\" (Decline Quest)",
                     "text": "(-1 Local Reputation) He scowls and stomps away, one tiny step at a time.",
                     "options": [
                         {
@@ -3474,10 +3581,12 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "",
@@ -3495,10 +3604,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "",
@@ -3521,10 +3632,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "",
@@ -3549,10 +3662,12 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "13",
@@ -3566,17 +3681,20 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
+        "epilogue":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -3593,10 +3711,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "grantRewards": [
@@ -3665,17 +3785,20 @@
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -3683,14 +3806,15 @@
                     "POIReference": "$(poi_2)"
                 }
             ],
-            "text": "Despite the insistance of the needle you decide that you will not finish clearing the $(poi_2). As if it could sense this somehow, the onyx compass disappears. (-2 Local Reputation)",
+            "text": "Despite the insistance of the compass needle, you decide that you will not finish clearing the $(poi_2). As if it could sense this somehow, the onyx compass disappears. (-2 Local Reputation)",
             "options": [
                 {
                     "name": "(Quest Failed)"
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -3702,15 +3826,15 @@
         "rewardDescription": "Mana Shards, Uncommon & Rare cards",
         "stages": [
             {
-                "id": 1,
+                "id": 3,
                 "name": "Leave",
                 "description": "Leave town to begin your quest",
                 "mapFlag": "",
                 "mapFlagValue": 1,
                 "objective": "Leave",
-                "anyPOI": true,
                 "prologue": {},
-                "epilogue": {
+                "epilogue":
+                {
                     "text": "You retrieve the compass from its pouch as you approach the town's gate. It is made of a deeply dark stone, with a single red needle that indicates where to find your targets.",
                     "options": [
                         {
@@ -3718,7 +3842,7 @@
                         },
                         {
                             "name": "You take a closer look at the device.",
-                            "text": "The 'compass' is unlike most you have ever seen before. There is not a single marking on it anywhere, nor any color other than onyx save the crimson needle.",
+                            "text": "The 'compass' is unlike most you have seen before. There is not a single marking on it anywhere, nor any color other than onyx, save the crimson needle.",
                             "options": [
                                 {
                                     "name": "You put the compass away and carry on. (Continue)"
@@ -3752,14 +3876,12 @@
                 ],
                 "objective": "Clear",
                 "prologue": {},
-                "epilogue": {
+                "epilogue":
+                {
                     "text": "You check your compass, looking for your next target, only to find that the needle has disappeared entirely. Your task appears to be complete."
                 },
                 "failureDialog": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             },
             {
                 "id": 3,
@@ -3771,10 +3893,7 @@
                 "objective": "Travel",
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    2
-                ]
+                "POIToken": ""
             }
         ],
         "questSourceTags": [
@@ -3789,8 +3908,9 @@
         "isTemplate": true,
         "name": "A Vision of Destruction",
         "description": "Clear out all enemies in the $(poi_1) and report back",
-        "offerDialog": {
-            "text": "Walking in to the village, an old man looks up as if expecting you and rushes over (to the extent that he is able) \"$(playername). I need you to turn around and leave. NOW.\"",
+        "offerDialog":
+        {
+            "text": "Walking into the village, an old man looks up as if expecting you and rushes over (to the extent that he is able.) \"$(playername). I need you to turn around and leave. NOW!\"",
             "options": [
                 {
                     "name": "You take a good look at the old man, but do not recognize his features. \"Should I know you?\"",
@@ -3818,10 +3938,12 @@
                                                             "setColorIdentity": "",
                                                             "advanceQuestFlag": "",
                                                             "advanceMapFlag": "",
-                                                            "setQuestFlag": {
+                                                            "setQuestFlag":
+                                                            {
                                                                 "key": ""
                                                             },
-                                                            "setMapFlag": {
+                                                            "setMapFlag":
+                                                            {
                                                                 "key": ""
                                                             },
                                                             "issueQuest": "14",
@@ -3849,10 +3971,12 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "14",
@@ -3881,10 +4005,12 @@
                                                             "setColorIdentity": "",
                                                             "advanceQuestFlag": "",
                                                             "advanceMapFlag": "",
-                                                            "setQuestFlag": {
+                                                            "setQuestFlag":
+                                                            {
                                                                 "key": ""
                                                             },
-                                                            "setMapFlag": {
+                                                            "setMapFlag":
+                                                            {
                                                                 "key": ""
                                                             },
                                                             "issueQuest": "14",
@@ -3916,17 +4042,20 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
+        "epilogue":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -4003,23 +4132,26 @@
                     "text": "\"My vision was less than specific about whether or not it would be changed by your actions. So... yes.\"",
                     "options": [
                         {
-                            "name": "You glance around at a clear sky warily before going on in to town. (Complete Quest)"
+                            "name": "You glance around at a clear sky warily before going on into town. (Complete Quest)"
                         }
                     ]
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -4034,7 +4166,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -4059,7 +4192,8 @@
                 ],
                 "objective": "Clear",
                 "prologue": {},
-                "epilogue": {
+                "epilogue":
+                {
                     "text": "The $(poi_1) falls silent as you remove the last creature. You consider staying to welcome the dragon, should it appear, but something tells you that leaving would be a much better idea for now.",
                     "options": [
                         {
@@ -4080,10 +4214,7 @@
                 "objective": "Travel",
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             }
         ],
         "questSourceTags": [
@@ -4098,8 +4229,9 @@
         "isTemplate": true,
         "name": "A Private Island",
         "description": "Clear out all enemies in the $(poi_1) and report back",
-        "offerDialog": {
-            "text": "\"Excuse me, adventurer, but I'm in need of assistance.\" The man appears of modest means at first glance, but a closer inspection reveals that his average looking clothing is may as well be made for a king.",
+        "offerDialog":
+        {
+            "text": "\"Excuse me, adventurer, but I'm in need of assistance.\" The man appears of modest means at first glance, but a closer inspection reveals that his average looking clothing may as well be made for a king.",
             "options": [
                 {
                     "name": "\"Of course, what can I do for you?\"",
@@ -4120,10 +4252,12 @@
                                                     "setColorIdentity": "",
                                                     "advanceQuestFlag": "",
                                                     "advanceMapFlag": "",
-                                                    "setQuestFlag": {
+                                                    "setQuestFlag":
+                                                    {
                                                         "key": ""
                                                     },
-                                                    "setMapFlag": {
+                                                    "setMapFlag":
+                                                    {
                                                         "key": ""
                                                     },
                                                     "issueQuest": "15",
@@ -4139,7 +4273,7 @@
                                 },
                                 {
                                     "name": "\"I must decline. I respect the local inhabitants far more than faceless nobility.\" (Decline Quest)",
-                                    "text": "He gives you the smallest bow imaginable, just enough to say that one was given without indicating respect.",
+                                    "text": "He gives you the smallest bow imaginable, just enough to say that one was given, without indicating respect.",
                                     "options": [
                                         {
                                             "name": "(Continue)"
@@ -4174,7 +4308,7 @@
                 },
                 {
                     "name": "You can't put your finger on it, but something seems off about the man. \"This isn't a good time.\" (Decline Quest)",
-                    "text": "He gives you the smallest bow imaginable, just enough to say that one was given without indicating respect. (-1 Local Reputation)",
+                    "text": "He gives you the smallest bow imaginable, just enough to say that one was given, without indicating respect. (-1 Local Reputation)",
                     "options": [
                         {
                             "name": "(Continue)"
@@ -4184,7 +4318,8 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
+        "epilogue":
+        {
             "text": "With gentrification of the area on the behalf of nobility complete, you console your conscience with the rewards that materialize in front of you.",
             "options": [
                 {
@@ -4254,17 +4389,20 @@
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -4279,7 +4417,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -4318,10 +4457,7 @@
                 "objective": "Travel",
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             }
         ],
         "questSourceTags": [
@@ -4336,7 +4472,8 @@
         "isTemplate": true,
         "name": "Clearing the ledger",
         "description": "Clear out all enemies in the $(poi_1)and report back",
-        "offerDialog": {
+        "offerDialog":
+        {
             "text": "As you introduce yourself to the inside of the local inn for the night, another patron approaches you.",
             "options": [
                 {
@@ -4345,11 +4482,11 @@
                     "options": [
                         {
                             "name": "You wait for him to continue.",
-                            "text": "\"I've come in to an inheritance of a small estate that I've been expecting for years. Recently, I've had some hard times, and I've convinced some individuals to let me borrow against the land.\" ",
+                            "text": "\"I've come into an inheritance of a small estate, that I've been expecting for years. Recently, I've had some hard times, and I've convinced some individuals to let me borrow against the land.\" ",
                             "options": [
                                 {
                                     "name": "\"I see.\" You think you know where this is headed.",
-                                    "text": "The man looks sheepish. \"Unfortunately, I found that the land isn't exactly usable at the moment. Because it contains a $(poi_1) which is... \"occupied\". Would you be willing to clear it for me in exchange for other parts of the inheritance?\"",
+                                    "text": "The man looks sheepish. \"Unfortunately, I found that the land isn't exactly usable at the moment. Because it's occupied. Would you be willing to clear it for me in exchange for other parts of the inheritance?\"",
                                     "options": [
                                         {
                                             "action": [
@@ -4358,17 +4495,19 @@
                                                     "setColorIdentity": "",
                                                     "advanceQuestFlag": "",
                                                     "advanceMapFlag": "",
-                                                    "setQuestFlag": {
+                                                    "setQuestFlag":
+                                                    {
                                                         "key": ""
                                                     },
-                                                    "setMapFlag": {
+                                                    "setMapFlag":
+                                                    {
                                                         "key": ""
                                                     },
                                                     "issueQuest": "16",
                                                     "POIReference": ""
                                                 }
                                             ],
-                                            "name": "\"So long as I get to keep whatever I find along the way too.\" (Accept Quest)."
+                                            "name": "\"So long as I get to keep whatever I find along the way, too.\" (Accept Quest)."
                                         },
                                         {
                                             "name": "\"I don't think I'm interested. Sorry.\" (Decline Quest)"
@@ -4377,7 +4516,7 @@
                                 },
                                 {
                                     "name": "\"And why exactly do you need me?\"",
-                                    "text": "\"Well, it seems the land isn't empty, and I need someone to clear out the $(poi_1) which can be found there. You look like the sort that could handle it.\" ",
+                                    "text": "\"Well, it seems the land isn't empty, and I need someone to fix that. You look like the sort that could handle it.\" ",
                                     "options": [
                                         {
                                             "action": [
@@ -4386,10 +4525,12 @@
                                                     "setColorIdentity": "",
                                                     "advanceQuestFlag": "",
                                                     "advanceMapFlag": "",
-                                                    "setQuestFlag": {
+                                                    "setQuestFlag":
+                                                    {
                                                         "key": ""
                                                     },
-                                                    "setMapFlag": {
+                                                    "setMapFlag":
+                                                    {
                                                         "key": ""
                                                     },
                                                     "issueQuest": "16",
@@ -4414,10 +4555,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -4436,7 +4579,8 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
+        "epilogue":
+        {
             "text": "True to his word, the man provides you with a reward from his inheritance. It's worth far less than the land (now that it's been cleared), but it's still valuable in addition to what loot you already recovered in the $(poi_1).",
             "options": [
                 {
@@ -4496,17 +4640,20 @@
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -4521,7 +4668,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -4560,10 +4708,7 @@
                 "objective": "Travel",
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             }
         ],
         "questSourceTags": [
@@ -4577,7 +4722,8 @@
         "isTemplate": true,
         "name": "Bone Collector",
         "description": "Defeat 3 $(enemy_1)s",
-        "offerDialog": {
+        "offerDialog":
+        {
             "text": "A job board has been constructed outside the local inn, and you see that it is covered in various papers and posters.",
             "options": [
                 {
@@ -4588,16 +4734,16 @@
                     "text": "Most of the ads are nondescript, weather worn, or written in an unfamiliar language. A few catch your eye, however.",
                     "options": [
                         {
-                            "name": "You look at what seems to be an advertisment of some sort off to one side.",
+                            "name": "You look at what seems to be an advertisement of some sort, off to one side.",
                             "text": "It reads: \"Gimgee's self-replicating paper. When you need unlimited paper or to clear a forest from afar, it's got to be Gimgee's\".",
                             "options": [
                                 {
-                                    "name": "\"I'll file that away under things that make sense yet don't.\" (Decline Quest)"
+                                    "name": "\"I'll file that away under things that make sense, yet don't.\" (Decline Quest)"
                                 }
                             ]
                         },
                         {
-                            "name": "A folded piece of paper is nailed to the board. ",
+                            "name": "A folded piece of paper is nailed to the board.",
                             "text": "The visible portion says 'Take one' in clear and measured handwriting.",
                             "options": [
                                 {
@@ -4621,10 +4767,12 @@
                                                             "setColorIdentity": "",
                                                             "advanceQuestFlag": "",
                                                             "advanceMapFlag": "",
-                                                            "setQuestFlag": {
+                                                            "setQuestFlag":
+                                                            {
                                                                 "key": ""
                                                             },
-                                                            "setMapFlag": {
+                                                            "setMapFlag":
+                                                            {
                                                                 "key": ""
                                                             },
                                                             "issueQuest": "17",
@@ -4656,8 +4804,9 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
-            "text": "You feel awkward pulling your $(enemy_1)s in to town, but it doesn't actually seem that out of place here with other macabre scenes around. (This quest will only given in black biome in the future).",
+        "epilogue":
+        {
+            "text": "You feel awkward pulling your $(enemy_1)s in to town, but it doesn't actually seem that out of place here with other macabre scenes around. (This quest will only be given in the black biome in the future).",
             "options": [
                 {
                     "name": "You look around for someone that seems to be expecting bodies.",
@@ -4670,10 +4819,12 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "",
@@ -4704,11 +4855,11 @@
                                     ]
                                 }
                             ],
-                            "name": "You dump the $(enemy_1)s on to one of the wagons and collect your rewards. (+3 Local Reputation)"
+                            "name": "You dump the $(enemy_1s) onto one of the wagons and collect your rewards. (+3 Local Reputation)"
                         },
                         {
                             "name": "You take a closer look at the carts.",
-                            "text": "$(enemy_1)s and a few random creatures are filling most of one cart., while the other holds a few identical satchels of goods.",
+                            "text": "$(enemy_1)s and a few random creatures are filling most of one cart, while the other holds a few identical satchels of goods.",
                             "options": [
                                 {
                                     "name": "Turn your attention to the carts' attendant.",
@@ -4721,10 +4872,12 @@
                                                     "setColorIdentity": "",
                                                     "advanceQuestFlag": "",
                                                     "advanceMapFlag": "",
-                                                    "setQuestFlag": {
+                                                    "setQuestFlag":
+                                                    {
                                                         "key": ""
                                                     },
-                                                    "setMapFlag": {
+                                                    "setMapFlag":
+                                                    {
                                                         "key": ""
                                                     },
                                                     "issueQuest": "",
@@ -4755,7 +4908,7 @@
                                                     ]
                                                 }
                                             ],
-                                            "name": "You dump the $(enemy_1)s and collect your rewards.  (+3 Local Reputation)"
+                                            "name": "You dump the $(enemy_1s) and collect your rewards.  (+3 Local Reputation)"
                                         }
                                     ]
                                 }
@@ -4765,17 +4918,20 @@
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -4790,7 +4946,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -4808,12 +4965,12 @@
                 "mapFlagValue": 1,
                 "count1": 3,
                 "objective": "Defeat",
-                "worldMapOK": true,
                 "enemyTags": [
                     "BiomeBlack"
                 ],
                 "prologue": {},
-                "epilogue": {
+                "epilogue":
+                {
                     "text": "With the necessary $(enemy_1)s handled, it's time to go collect your rewards. (Don't forget you can track the quest to get directions back to town)",
                     "options": [
                         {
@@ -4833,10 +4990,7 @@
                 "objective": "Travel",
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             }
         ],
         "questSourceTags": [
@@ -4851,7 +5005,8 @@
         "isTemplate": true,
         "name": "A Focused Mind",
         "description": "Defeat 3 $(enemy_2)s",
-        "offerDialog": {
+        "offerDialog":
+        {
             "text": "A job board has been constructed outside the local inn, and you see that it is covered in various papers and posters.",
             "options": [
                 {
@@ -4862,7 +5017,7 @@
                     "text": "Most of the ads are nondescript, weather worn, or written in an unfamiliar language. A few catch your eye, however.",
                     "options": [
                         {
-                            "name": "You look at what seems to be an advertisment of some sort off to one side.",
+                            "name": "You look at what seems to be an advertisement of some sort, off to one side.",
                             "text": "\"A focused mind receives great rewards. Focus on defeating 3 $(enemy_2)s, and be rewarded.\"",
                             "options": [
                                 {
@@ -4875,10 +5030,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "18",
@@ -4903,10 +5060,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "18",
@@ -4922,7 +5081,8 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
+        "epilogue":
+        {
             "text": "\"Well done.\" You turn quickly to find a Djinn floating behind you. \"You have demonstrated great focus.\" A collection of treasures float over to you from his outstretched hand.",
             "options": [
                 {
@@ -4952,7 +5112,7 @@
                         }
                     ],
                     "name": "Warily take the items.",
-                    "text": "No sooner than you do, the Djinn dissapears in a puff of smoke. When you turn back, the $(enemy_2) you just defeated has vanished as well.",
+                    "text": "No sooner than you do, the Djinn disappears in a puff of smoke. When you turn back, the $(enemy_2) you just defeated has vanished as well.",
                     "options": [
                         {
                             "action": [
@@ -4961,10 +5121,12 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "",
@@ -4978,17 +5140,20 @@
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -5003,7 +5168,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -5020,7 +5186,6 @@
                 "mapFlag": "",
                 "mapFlagValue": 1,
                 "objective": "Leave",
-                "anyPOI": true,
                 "prologue": {},
                 "epilogue": {},
                 "POIToken": ""
@@ -5033,17 +5198,13 @@
                 "mapFlagValue": 1,
                 "count1": 3,
                 "objective": "Defeat",
-                "worldMapOK": true,
                 "enemyTags": [
                     "BiomeBlue"
                 ],
                 "prologue": {},
                 "epilogue": {},
                 "failureDialog": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             }
         ],
         "questSourceTags": [
@@ -5058,7 +5219,8 @@
         "isTemplate": true,
         "name": "Population Control",
         "description": "Defeat 3 $(enemy_1)s",
-        "offerDialog": {
+        "offerDialog":
+        {
             "text": "A haggard and tired looking elf puts down his bow at the door of the tavern. Another elf calls out to him. \"Long day's hunt?\"",
             "options": [
                 {
@@ -5075,10 +5237,12 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "",
@@ -5109,10 +5273,12 @@
                                                     "setColorIdentity": "",
                                                     "advanceQuestFlag": "",
                                                     "advanceMapFlag": "",
-                                                    "setQuestFlag": {
+                                                    "setQuestFlag":
+                                                    {
                                                         "key": ""
                                                     },
-                                                    "setMapFlag": {
+                                                    "setMapFlag":
+                                                    {
                                                         "key": ""
                                                     },
                                                     "issueQuest": "19",
@@ -5139,10 +5305,12 @@
                                                             "setColorIdentity": "",
                                                             "advanceQuestFlag": "",
                                                             "advanceMapFlag": "",
-                                                            "setQuestFlag": {
+                                                            "setQuestFlag":
+                                                            {
                                                                 "key": ""
                                                             },
-                                                            "setMapFlag": {
+                                                            "setMapFlag":
+                                                            {
                                                                 "key": ""
                                                             },
                                                             "issueQuest": "19",
@@ -5173,10 +5341,12 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "",
@@ -5190,17 +5360,20 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
+        "epilogue":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -5240,17 +5413,20 @@
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -5265,7 +5441,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -5283,7 +5460,6 @@
                 "mapFlagValue": 1,
                 "count1": 3,
                 "objective": "Defeat",
-                "worldMapOK": true,
                 "enemyTags": [
                     "Animal",
                     "BiomeGreen"
@@ -5304,10 +5480,7 @@
                 "prologue": {},
                 "epilogue": {},
                 "failureDialog": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             }
         ],
         "questSourceTags": [
@@ -5322,7 +5495,8 @@
         "isTemplate": true,
         "name": "Proving Yourself Worthy",
         "description": "Defeat 3 $(enemy_1)s",
-        "offerDialog": {
+        "offerDialog":
+        {
             "text": "\"Are you worthy, citizen?\" A heavily armored soldier stands at the center of the town square and is occasionally calling out at bypassers. \"Are YOU?\", he calls out to another one.",
             "options": [
                 {
@@ -5338,7 +5512,7 @@
                                     "text": "He laughs as if the question was ridiculous. \"I am, of course. And I need someone to prove that they are worthy of my teachings!\"",
                                     "options": [
                                         {
-                                            "name": "You decide to humor him. \"Let's say that I am, what then?\"",
+                                            "name": "You decide to humor him. \"Let's say that I am. What then?\"",
                                             "text": "He looks at you again, as though he hadn't actually paid attention to you before. \"Then you prove it. Defeat 3 $(enemy_1)s with honor.\"",
                                             "options": [
                                                 {
@@ -5351,10 +5525,12 @@
                                                             "setColorIdentity": "",
                                                             "advanceQuestFlag": "",
                                                             "advanceMapFlag": "",
-                                                            "setQuestFlag": {
+                                                            "setQuestFlag":
+                                                            {
                                                                 "key": ""
                                                             },
-                                                            "setMapFlag": {
+                                                            "setMapFlag":
+                                                            {
                                                                 "key": ""
                                                             },
                                                             "issueQuest": "20",
@@ -5413,10 +5589,12 @@
                                                                     "setColorIdentity": "",
                                                                     "advanceQuestFlag": "",
                                                                     "advanceMapFlag": "",
-                                                                    "setQuestFlag": {
+                                                                    "setQuestFlag":
+                                                                    {
                                                                         "key": ""
                                                                     },
-                                                                    "setMapFlag": {
+                                                                    "setMapFlag":
+                                                                    {
                                                                         "key": ""
                                                                     },
                                                                     "issueQuest": "20",
@@ -5440,10 +5618,12 @@
                                                             "setColorIdentity": "",
                                                             "advanceQuestFlag": "",
                                                             "advanceMapFlag": "",
-                                                            "setQuestFlag": {
+                                                            "setQuestFlag":
+                                                            {
                                                                 "key": ""
                                                             },
-                                                            "setMapFlag": {
+                                                            "setMapFlag":
+                                                            {
                                                                 "key": ""
                                                             },
                                                             "issueQuest": "20",
@@ -5472,7 +5652,8 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
+        "epilogue":
+        {
             "action": [
                 {
                     "grantRewards": [
@@ -5508,17 +5689,20 @@
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -5533,7 +5717,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -5551,7 +5736,6 @@
                 "mapFlagValue": 1,
                 "count1": 3,
                 "objective": "Defeat",
-                "worldMapOK": true,
                 "enemyTags": [
                     "BiomeWhite"
                 ],
@@ -5571,10 +5755,7 @@
                 "prologue": {},
                 "epilogue": {},
                 "failureDialog": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             }
         ],
         "questSourceTags": [
@@ -5589,7 +5770,8 @@
         "isTemplate": true,
         "name": "In the Name of Science",
         "description": "Defeat 3 $(enemy_1)s",
-        "offerDialog": {
+        "offerDialog":
+        {
             "text": "\"...but it's for SCIENCE!!!\" A young woman leaves the tavern in a hurry, with someone yelling at her back from the other side of the doorway. A dwarf in a labcoat with goggles on his head comes shuffling after.",
             "options": [
                 {
@@ -5598,7 +5780,7 @@
                     "options": [
                         {
                             "name": "\"It really depends on what they are.\" You look at him suspsiciously.",
-                            "text": "\"You're not a farmhand, so it will have to be.\" He thinks for a moment, pulling out a well worn notebook and flipping through the pages.",
+                            "text": "\"You're not a farmhand, so it will have to be...\" He thinks for a moment, pulling out a well worn notebook and flipping through the pages.",
                             "options": [
                                 {
                                     "name": "\"Another time perhaps, I need to keep moving.\" (Decline Quest)",
@@ -5620,10 +5802,12 @@
                                                     "setColorIdentity": "",
                                                     "advanceQuestFlag": "",
                                                     "advanceMapFlag": "",
-                                                    "setQuestFlag": {
+                                                    "setQuestFlag":
+                                                    {
                                                         "key": ""
                                                     },
-                                                    "setMapFlag": {
+                                                    "setMapFlag":
+                                                    {
                                                         "key": ""
                                                     },
                                                     "issueQuest": "21",
@@ -5647,7 +5831,8 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
+        "epilogue":
+        {
             "action": [
                 {}
             ],
@@ -5658,17 +5843,20 @@
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -5683,7 +5871,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -5701,7 +5890,6 @@
                 "mapFlagValue": 1,
                 "count1": 3,
                 "objective": "Defeat",
-                "worldMapOK": true,
                 "enemyTags": [
                     "BiomeColorless"
                 ],
@@ -5721,10 +5909,7 @@
                 "prologue": {},
                 "epilogue": {},
                 "failureDialog": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             }
         ],
         "questSourceTags": [
@@ -5738,7 +5923,8 @@
         "isTemplate": true,
         "name": "Shamanic Totems",
         "description": "Defeat 3 $(enemy_1)s",
-        "offerDialog": {
+        "offerDialog":
+        {
             "text": "A job board has been constructed outside the local inn, and you see that it is covered in various papers and posters.",
             "options": [
                 {
@@ -5749,7 +5935,7 @@
                     "text": "Most of the ads are nondescript, weather worn, or written in an unfamiliar language. A few catch your eye, however.",
                     "options": [
                         {
-                            "name": "You look at what seems to be an advertisment of some sort off to one side.",
+                            "name": "You look at what seems to be an advertisement of some sort, off to one side.",
                             "text": "It reads: \"Gimgee's rocks. When you need a good rock, think Gimgee's\".",
                             "options": [
                                 {
@@ -5768,10 +5954,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "22",
@@ -5790,7 +5978,8 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
+        "epilogue":
+        {
             "text": "The village shaman grins as you enter their tent. \"Yes, this is good. This is good. The spirits have been satisfied.\" (+3 Local Reputation)",
             "options": [
                 {
@@ -5823,17 +6012,20 @@
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -5848,7 +6040,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -5866,7 +6059,6 @@
                 "mapFlagValue": 1,
                 "count1": 3,
                 "objective": "Defeat",
-                "worldMapOK": true,
                 "enemyTags": [
                     "BiomeRed"
                 ],
@@ -5886,10 +6078,7 @@
                 "prologue": {},
                 "epilogue": {},
                 "failureDialog": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             }
         ],
         "questSourceTags": [
@@ -5904,29 +6093,57 @@
         "isTemplate": true,
         "name": "Heart of a Champion",
         "description": "Enter and win an upcoming arena event",
-        "offerDialog": {
+        "offerDialog":
+        {
             "text": "\"DO YOU HAVE WHAT IT TAKES? ARE YOU THE BEST IN SHANDALAR???\" A young girl yells at the top of her lungs at each passer by in the town. Most people come in to view already covering their ears, having heard this plenty of times before.",
             "options": [
                 {
-                    "name": "You walk over to her. \"Okay, kid, settle down, I heard you. What's this about?\"",
+                    "name": "You walk over to her. \"Okay kid, settle down, I heard you. What's this about?\"",
                     "text": "She looks surprised, and falls silent for a moment as she tries to remember what to do next. \"I uhhh... ummm...\" She pulls a piece of paper out of her pocket and prepares to read.",
                     "options": [
                         {
                             "action": [
                                 {
-                                    "addMapReputation": -1
+                                    "removeItem": "",
+                                    "setColorIdentity": "",
+                                    "advanceQuestFlag": "",
+                                    "advanceMapFlag": "",
+                                    "setQuestFlag":
+                                    {
+                                        "key": ""
+                                    },
+                                    "setMapFlag":
+                                    {
+                                        "key": ""
+                                    },
+                                    "issueQuest": "23",
+                                    "addMapReputation": -1,
+                                    "POIReference": ""
                                 }
                             ],
                             "name": "Take the paper from her.",
-                            "text": "\"HEY THAT'S MINE!!!\" (-1 Reputation) She finds her full ear-piercing volume again before pulling it away and reading. \"PROVE YOU'RE THE BEST IN THE ARENA! THE TOURNAMENT BEGINS SOON\"",
+                            "text": "\"HEY THAT'S MINE!!!\" She finds her full ear-piercing volume again before pulling it away and reading. \"PROVE YOU'RE THE BEST IN THE ARENA! THE TOURNAMENT BEGINS SOON\"",
                             "options": [
                                 {
                                     "action": [
                                         {
-                                            "issueQuest": "23"
+                                            "removeItem": "",
+                                            "setColorIdentity": "",
+                                            "advanceQuestFlag": "",
+                                            "advanceMapFlag": "",
+                                            "setQuestFlag":
+                                            {
+                                                "key": ""
+                                            },
+                                            "setMapFlag":
+                                            {
+                                                "key": ""
+                                            },
+                                            "issueQuest": "23",
+                                            "POIReference": ""
                                         }
                                     ],
-                                    "name": "\"Okay, sure, going somewhere far away seems good right now, wherever it may be.\" (Accept Quest)"
+                                    "name": "\"Okay, sure, going somewhere far away seems good right now.\" (Accept Quest)"
                                 },
                                 {
                                     "name": "\"No thanks, I think I'll go find somewhere quiet for a while.\" (Decline Quest)"
@@ -5940,7 +6157,20 @@
                                 {
                                     "action": [
                                         {
-                                            "issueQuest": "23"
+                                            "removeItem": "",
+                                            "setColorIdentity": "",
+                                            "advanceQuestFlag": "",
+                                            "advanceMapFlag": "",
+                                            "setQuestFlag":
+                                            {
+                                                "key": ""
+                                            },
+                                            "setMapFlag":
+                                            {
+                                                "key": ""
+                                            },
+                                            "issueQuest": "23",
+                                            "POIReference": ""
                                         }
                                     ],
                                     "name": "\"Okay, sure, going somewhere far away seems good right now.\" (Accept Quest)"
@@ -5964,8 +6194,9 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
-            "text": "The crowd goes wild as you finish your last opponent. You won't be paying for drinks in $(poi_1) for quite some time. (+3 reputation in $(poi_1))",
+        "epilogue":
+        {
+            "text": "The crowd goes wild as you finish your last opponent. You won't be paying for drinks in the $(poi_1) for quite some time. (+3 reputation in $(poi_1))",
             "options": [
                 {
                     "action": [
@@ -5988,26 +6219,27 @@
                                     "type": "gold",
                                     "count": 250
                                 }
-                            ],
-                            "addMapReputation": 3,
-                            "POIReference": "$(poi_1)"
+                            ]
                         }
                     ],
                     "name": "(Complete Quest)"
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -6041,7 +6273,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -6064,7 +6297,8 @@
                 ],
                 "objective": "Travel",
                 "prologue": {},
-                "epilogue": {
+                "epilogue":
+                {
                     "text": "As you walk through the $(poi_1) gates, you can feel the excitement building, eminating, radiating from the city's arena. Most of the populace is already there or on their way. ",
                     "options": [
                         {
@@ -6089,10 +6323,7 @@
                 "objective": "Arena",
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "$(poi_1)",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": "$(poi_1)"
             }
         ],
         "questSourceTags": [
@@ -6105,8 +6336,9 @@
         "id": 24,
         "isTemplate": true,
         "name": "Pest Control",
-        "description": "Defeat Xira and her hornets in her hive and report back",
-        "offerDialog": {
+        "description": "Defeat Xira and her hornets in her hive, and report back",
+        "offerDialog":
+        {
             "text": "Greetings, adventurer! I have a task that requires your assistance. You see, we have a bit of a situation with a giant insect named Xira. She's been causing quite a stir in our town with her penchant for organizing extravagant balls.",
             "options": [
                 {
@@ -6116,10 +6348,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -6127,7 +6361,7 @@
                             "POIReference": ""
                         }
                     ],
-                    "name": "Giant bugs holding balls eh ? Count me out. (Decline quest)",
+                    "name": "Giant bugs holding balls eh? Count me out. (Decline quest)",
                     "text": "Figured you weren't up to the challenge, come back to me when you are.",
                     "options": [
                         {
@@ -6136,8 +6370,8 @@
                     ]
                 },
                 {
-                    "name": "Let me guess, you want to me to deal with this situation ?",
-                    "text": "Well Yes, Let me explain the situation; Xira's balls have become a bit of a problem. She has been hosting them every night, and they're becoming increasingly extravagant and disruptive. The townspeople are getting tired of the constant noise and commotion, and it's affecting their daily lives.",
+                    "name": "Let me guess, you want to me to deal with this situation?",
+                    "text": "Well yes. Let me explain the situation; Xira's balls have become a bit of a problem. She has been hosting them every night, and they're becoming increasingly extravagant and disruptive. The townspeople are getting tired of the constant noise and commotion, and it's affecting their daily lives.",
                     "options": [
                         {
                             "name": "I see. So you want me to talk to Xira and ask her to stop?",
@@ -6150,10 +6384,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "24",
@@ -6169,10 +6405,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "",
@@ -6194,7 +6432,8 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
+        "epilogue":
+        {
             "text": "As you enter the village, the local towspeople rush towards you to thank you for your deeds  (+3 reputation in $(poi_1))",
             "options": [
                 {
@@ -6232,17 +6471,20 @@
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -6257,7 +6499,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -6270,7 +6513,7 @@
             {
                 "id": 1,
                 "name": "Clear",
-                "description": "Travel to $(poi_1) and defeat all enemies inside. The target location is in the Waste biome.",
+                "description": "Travel to the Xira's Hive and defeat all enemies inside. The target location is in the Waste biome.",
                 "mapFlag": "",
                 "mapFlagValue": 1,
                 "POITags": [
@@ -6284,7 +6527,7 @@
             {
                 "id": 2,
                 "name": "Travel",
-                "description": "Return to $(poi_2) and report your success in clearing $(poi_1).",
+                "description": "Return to town and report your success in clearing the $(poi_1).",
                 "mapFlag": "",
                 "mapFlagValue": 1,
                 "here": true,
@@ -6294,10 +6537,7 @@
                 "objective": "Travel",
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             }
         ],
         "questSourceTags": [
@@ -6311,7 +6551,8 @@
         "isTemplate": true,
         "name": "Mechanical Problems",
         "description": "Defeat Slobad and his artificers in his factory and report back",
-        "offerDialog": {
+        "offerDialog":
+        {
             "text": "Greetings, brave adventurer! I find myself in need of a courageous soul to undertake a perilous task.\nWithin the sprawling industrial district, an abandoned factory once owned by the notorious inventor Slobad has become a hotbed of danger and mechanical mayhem. ",
             "options": [
                 {
@@ -6321,10 +6562,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -6345,7 +6588,7 @@
                     "options": [
                         {
                             "name": "I see. So you want me to go to his factory and defeat him ?",
-                            "text": "Your task, should you accept it, is to venture into Slobad's factory and cleanse it of its mechanical menaces. You will face a myriad of strange mechs, each with its unique capabilities and behaviors. Additionally, the factory's artificers, skilled engineers corrupted by their own creations, will fiercely defend their inventions, making your mission all the more challenging.",
+                            "text": "Your task, should you accept it, is to venture into Slobad's factory and cleanse it of its mechanical menaces. You will face a myriad of strange mechs, each with its unique capabilities and behaviors. Additionally, the factory's artificers, skilled engineers corrupted by their own creations, will fiercely defend their inventions. Making your mission all the more challenging.",
                             "options": [
                                 {
                                     "action": [
@@ -6354,10 +6597,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "25",
@@ -6374,17 +6619,19 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "",
                                             "POIReference": ""
                                         }
                                     ],
-                                    "name": "\"Do you really think I have nothing better to do ? Find someone else to take care of it\" (Decline Quest)",
+                                    "name": "\"Do you really think I have nothing better to do? Find someone else to take care of it\" (Decline Quest)",
                                     "text": "Maven the Alchemist keeps a passive look on his face. \"Soon those things will be balanced as well.\"",
                                     "options": [
                                         {
@@ -6399,7 +6646,8 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
+        "epilogue":
+        {
             "text": "As you enter the village, the local towspeople rush towards you to thank you for your deeds  (+3 reputation in $(poi_1))",
             "options": [
                 {
@@ -6438,17 +6686,20 @@
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -6463,7 +6714,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -6476,7 +6728,7 @@
             {
                 "id": 1,
                 "name": "Clear",
-                "description": "Travel to Slobad's Factory and defeat all enemies inside. The target location is in the Waste biome.",
+                "description": "Travel to Slobad's Factory' and defeat all enemies inside. The target location is in the Waste biome.",
                 "mapFlag": "",
                 "mapFlagValue": 1,
                 "POITags": [
@@ -6490,17 +6742,14 @@
             {
                 "id": 2,
                 "name": "Travel",
-                "description": "Return to town and report your success in clearing $(poi_1).",
+                "description": "Return to town and report your success in clearing the $(poi_1).",
                 "mapFlag": "",
                 "mapFlagValue": 1,
                 "here": true,
                 "objective": "Travel",
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             }
         ],
         "questSourceTags": [
@@ -6514,8 +6763,9 @@
         "isTemplate": true,
         "name": "Spores of Death",
         "description": "Defeat Slimefoot and his fungi in his bog and report back",
-        "offerDialog": {
-            "text": " Ah, greetings, brave adventurer! I have a grave matter to discuss with you. We need a brave adventurer to deal with the rogue fungus Slimefoot. ",
+        "offerDialog":
+        {
+            "text": " Ah, greetings, brave adventurer! I have a grave matter to discuss with you. We need a brave adventurer to deal with the rogue fungus Slimefoot.",
             "options": [
                 {
                     "action": [
@@ -6524,10 +6774,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -6544,7 +6796,7 @@
                 },
                 {
                     "name": "Tell me more about Slimefoot and what I can do to stop it.",
-                    "text": "Thank you, noble adventurer. Slimefoot is a creature of pure malevolence, a monstrous being that has taken root in the heart of the treacherous swamp. Its corrosive touch and toxic aura have brought devastation to our lands. To defeat it, you must journey through the perilous swamp, filled with treacherous terrain and deadly creatures lurking within.",
+                    "text": "Thank you, noble adventurer. Slimefoot is a creature of pure malevolence. A monstrous being that has taken root in the heart of the treacherous swamp. Its corrosive touch and toxic aura have brought devastation to our lands. To defeat it, you must journey through the perilous swamp, filled with treacherous terrain and deadly creatures lurking within.",
                     "options": [
                         {
                             "name": "I see. So you want me to travel to Slimefoots swamp and defeat him ?",
@@ -6557,10 +6809,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "26",
@@ -6576,10 +6830,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "",
@@ -6601,7 +6857,8 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
+        "epilogue":
+        {
             "text": "As you enter the village, the local towspeople rush towards you to thank you for your deeds  (+3 reputation in $(poi_1))",
             "options": [
                 {
@@ -6636,17 +6893,20 @@
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -6661,7 +6921,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -6695,10 +6956,7 @@
                 "objective": "Travel",
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             }
         ],
         "questSourceTags": [
@@ -6713,7 +6971,8 @@
         "isTemplate": true,
         "name": "Slimy Business",
         "description": "Defeat the mother slime and other creatures in the old sewers and report back",
-        "offerDialog": {
+        "offerDialog":
+        {
             "text": "Greetings, brave adventurer! This town is currently plagued by a distressing problem in the form of a slime infestation. \nThe town council has been looking for a brave individual to take care of this.\n",
             "options": [
                 {
@@ -6723,10 +6982,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -6734,7 +6995,7 @@
                         }
                     ],
                     "name": "Sorry, I don't have to the time for this. (Decline Quest)",
-                    "text": "Figured you weren't up to the challenge, come back to me when you are. ",
+                    "text": "Figured you weren't up to the challenge, come back to me when you are.",
                     "options": [
                         {
                             "name": "(Continue)"
@@ -6756,10 +7017,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "27",
@@ -6775,18 +7038,20 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "",
                                             "POIReference": ""
                                         }
                                     ],
-                                    "name": "I don't intending to get slime on my armor, sorry you have to find someone else (Decline Quest)",
-                                    "text": "The merchant keeps a passive look on his face. \"Soon those things will be balanced as well.\"",
+                                    "name": "I don't intend to get slime on my armor. Sorry, you have to find someone else (Decline Quest)",
+                                    "text": "The merchant keeps a passive look on his face. \"All things perish in the end...\"",
                                     "options": [
                                         {
                                             "name": "(Continue)"
@@ -6800,7 +7065,8 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
+        "epilogue":
+        {
             "text": "As you enter the village, the local towspeople rush towards you to thank you for your deeds  (+3 reputation in $(poi_1))",
             "options": [
                 {
@@ -6841,17 +7107,20 @@
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -6866,7 +7135,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -6900,10 +7170,7 @@
                 "objective": "Travel",
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             }
         ],
         "questSourceTags": [
@@ -6918,7 +7185,8 @@
         "name": "Welcome to Shandalar",
         "description": "Learn about your surroundings",
         "offerDialog": {},
-        "prologue": {
+        "prologue":
+        {
             "text": "Darkness and silence surrounds you. A vague sense of falling slows second by second. ",
             "options": [
                 {
@@ -6932,9 +7200,8 @@
                     ]
                 },
                 {
-					"condition": [{"checkCharacterFlag": "newGamePlus"}],
                     "name": "Been here, done that. Show me to the enemies. (New Game+)",
-                    "text": "Okay, skipping all that hard work somebody put into dialog, the portal opens and you can leave.",
+                    "text": "Okay, skipping all that \"hard work\" somebody put into dialog, the portal opens and you can leave.",
                     "options": [
                         {
                             "action": [
@@ -6944,11 +7211,13 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
+                                    "setQuestFlag":
+                                    {
                                         "key": "mainQuest",
                                         "val": 1
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "",
@@ -6963,7 +7232,8 @@
         },
         "epilogue": {},
         "failureDialog": {},
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -6990,9 +7260,9 @@
                 "mapFlag": "",
                 "mapFlagValue": 1,
                 "objective": "Leave",
-                "anyPOI": true,
                 "prologue": {},
-                "epilogue": {
+                "epilogue":
+                {
                     "text": "So, you have a quest of sorts now: Find and free the planeswalkers. But is that really what you want to do? Despite the fog covering your memory, you are certain that you are powerful enough to take care of yourself.",
                     "options": [
                         {
@@ -7002,19 +7272,20 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
-                                        "key": "shandWalkers1",
+                                    "setQuestFlag":
+                                    {
+                                        "key": "seekWalkers",
                                         "val": 1
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "",
                                     "POIReference": ""
                                 }
                             ],
-                            "name": "I want to find the planeswalkers (Future release)",
-                            "isDisabled": true,
+                            "name": "I want to find the planeswalkers",
                             "text": "Well, shouting \"Planeswalkers, where are you?\" into the wastes won't do much. Travel to the nearest settlement and ask around for information.",
                             "options": [
                                 {
@@ -7024,10 +7295,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "29",
@@ -7051,18 +7324,44 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
-                                        "key": "exploreShand1",
+                                    "setQuestFlag":
+                                    {
+                                        "key": "exploreShand",
                                         "val": 1
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
-                                    "issueQuest": "30",
+                                    "issueQuest": "",
                                     "POIReference": ""
                                 }
                             ],
-                            "name": "I want to explore Shandalar ((Has a brief tutorial))"
+                            "name": "I want to explore and learn about Shandalar",
+                            "text": "Exploring it is. Find and enter a nearby dungeon.",
+                            "options": [
+                                {
+                                    "action": [
+                                        {
+                                            "removeItem": "",
+                                            "setColorIdentity": "",
+                                            "advanceQuestFlag": "",
+                                            "advanceMapFlag": "",
+                                            "setQuestFlag":
+                                            {
+                                                "key": ""
+                                            },
+                                            "setMapFlag":
+                                            {
+                                                "key": ""
+                                            },
+                                            "issueQuest": "30",
+                                            "POIReference": ""
+                                        }
+                                    ],
+                                    "name": "(Dismiss)"
+                                }
+                            ]
                         },
                         {
                             "action": [
@@ -7071,19 +7370,20 @@
                                     "setColorIdentity": "",
                                     "advanceQuestFlag": "",
                                     "advanceMapFlag": "",
-                                    "setQuestFlag": {
-                                        "key": "shandRep1",
+                                    "setQuestFlag":
+                                    {
+                                        "key": "shandRep",
                                         "val": 1
                                     },
-                                    "setMapFlag": {
+                                    "setMapFlag":
+                                    {
                                         "key": ""
                                     },
                                     "issueQuest": "",
                                     "POIReference": ""
                                 }
                             ],
-                            "name": "I want to make a name for myself (Future release)",
-                            "isDisabled": true,
+                            "name": "I want to make a name for myself",
                             "text": "Then let's go impress some people. But first, you need some impressive spells. Build your collection to begin your quest.",
                             "options": [
                                 {
@@ -7093,13 +7393,15 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "issueQuest": "31",
+                                            "issueQuest": "30",
                                             "POIReference": ""
                                         }
                                     ],
@@ -7109,10 +7411,7 @@
                         }
                     ]
                 },
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             }
         ],
         "storyQuest": true
@@ -7124,7 +7423,8 @@
         "description": "Find someone who knows more about the missing Planeswalkers",
         "offerDialog": {},
         "prologue": {},
-        "epilogue": {
+        "epilogue":
+        {
             "text": "The locals meet your inquiries with a little less disdain than when you first arrived asking questions without much coin to go along with them, but they can't deliver information they don't have.",
             "options": [
                 {
@@ -7141,7 +7441,7 @@
                                     "options": [
                                         {
                                             "name": "\"Go on...\"",
-                                            "text": "\"Every door was locked tight. A bad feeling came up my back as I realized just how quiet it was right before I heard splashing. I peeked round the corner, and found a merfolk waving his arms around and casting some spell.\"",
+                                            "text": "\"Every door was locked tight. A bad feeling came up my back as I realized just how quiet it was, right before I heard splashing. I peeked round the corner, and found a merfolk waving his arms around and casting some spell.\"",
                                             "options": [
                                                 {
                                                     "name": "\"What was the spell?\"",
@@ -7162,10 +7462,12 @@
                                                                                     "setColorIdentity": "",
                                                                                     "advanceQuestFlag": "",
                                                                                     "advanceMapFlag": "",
-                                                                                    "setQuestFlag": {
+                                                                                    "setQuestFlag":
+                                                                                    {
                                                                                         "key": ""
                                                                                     },
-                                                                                    "setMapFlag": {
+                                                                                    "setMapFlag":
+                                                                                    {
                                                                                         "key": ""
                                                                                     },
                                                                                     "issueQuest": "32",
@@ -7203,10 +7505,12 @@
                                                                     "setColorIdentity": "",
                                                                     "advanceQuestFlag": "",
                                                                     "advanceMapFlag": "",
-                                                                    "setQuestFlag": {
+                                                                    "setQuestFlag":
+                                                                    {
                                                                         "key": ""
                                                                     },
-                                                                    "setMapFlag": {
+                                                                    "setMapFlag":
+                                                                    {
                                                                         "key": ""
                                                                     },
                                                                     "issueQuest": "32",
@@ -7241,7 +7545,8 @@
             ]
         },
         "failureDialog": {},
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -7278,7 +7583,8 @@
                     "Town"
                 ],
                 "objective": "HaveReputation",
-                "prologue": {
+                "prologue":
+                {
                     "text": "As you enter this small town, the local population pays little notice to you as they go about their normal business. It appears that strangers are a familiar sight here, and not a particularly impactful one unless you are looking to spend your gold.",
                     "options": [
                         {
@@ -7317,10 +7623,7 @@
                     ]
                 },
                 "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": ""
             }
         ],
         "storyQuest": true
@@ -7328,55 +7631,13 @@
     {
         "id": 30,
         "isTemplate": true,
-        "autoTrack": true,
         "name": "Where Am I?",
-        "description": "Get your bearings in the world around you",
         "offerDialog": {},
         "prologue": {},
-        "epilogue": {
-            "text": "Like most small towns, there are more shops and market stalls than there are houses, with much of the town's occupants traveling in from the outlying areas each morning.",
-            "options": [
-                {
-                    "name": "(Continue)",
-                    "text": "Many merchants are peddling their wares, the most relevant to a wizard having colorful (if at times crude) signs in front of their shops advertising their specialties.",
-                    "options": [
-                        {
-                            "name": "(Continue)",
-                            "text": "The inn sounds just raucous enough to know that it is doing healthy business. You recall what you were told about the Challenge coins and contemplate putting them to use there.",
-                            "options": [
-                                {
-                                    "name": "(Continue)",
-                                    "text": "Perhaps the most intriguing of all, however, is the town hall with a notice board out front, advertising work for adventurers. What better way to make some coin while you explore?",
-                                    "options": [
-                                        {
-                                            "name": "(Continue)",
-                                            "action": [
-                                                {
-                                                    "removeItem": "",
-                                                    "setColorIdentity": "",
-                                                    "advanceQuestFlag": "",
-                                                    "advanceMapFlag": "",
-                                                    "setQuestFlag": {
-                                                        "key": ""
-                                                    },
-                                                    "setMapFlag": {
-                                                        "key": ""
-                                                    },
-                                                    "issueQuest": "43",
-                                                    "POIReference": ""
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
+        "epilogue": {},
         "failureDialog": {},
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -7384,212 +7645,6 @@
                 }
             ]
         },
-        "stages": [
-            {
-                "id": 1,
-                "name": "Travel to town",
-                "description": "Find a friendly settlement to be introduced to the services it offers",
-                "anyPOI": true,
-                "mapFlag": "",
-                "mapFlagValue": 1,
-                "POITags": [
-                    "Town"
-                ],
-                "objective": "Travel",
-                "prologue": {
-                    "text": "All major locations in Shandalar can be divided up in to one of two categories: towns and dungeons.",
-                    "options": [
-                        {
-                            "name": "(Continue)",
-                            "text": "A navigation arrow should now appear around your character. Follow it to a nearby town. Try to avoid any enemies that pop up along the way.",
-                            "options": [
-                                {
-                                    "name": "(Continue)",
-                                    "text": "Hint: Follow a road. All roads lead to a town. You also move faster on roads and fewer enemies will appear.",
-                                    "options": [
-                                        {
-                                            "name": "(Continue)"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "epilogue": {},
-                "POIToken": ""
-            },
-            {
-                "id": 2,
-                "name": "Leave town",
-                "description": "Head back out into the wilderness when you are ready to proceed",
-                "POITags": [
-                    "Town"
-                ],
-                "objective": "Leave",
-                "anyPOI": true,
-                "prologue": {
-                    "text": "Most towns in a given region of Shandalar will look very similar to one another, and offer the same basic services.",
-                    "options": [
-                        {
-                            "name": "(Continue)",
-                            "text": "The inn contains some special events. You can also sell extra cards there, or buy temporary extra health.\n\nThe '?' sign denotes a town square / job board where you can obtain side quests.\n\nAll of the other buildings with signs out front are shops, most of them sell cards.\n\nTo leave town, walk back toward the edge of the screen just below your current location.",
-                            "options": [
-                                {
-                                    "name": "(Continue)",
-                                    "text": "Entering a friendly town will also restore any missing hit points for free.\n\nExplore the town if you want, and leave when you are ready to continue.",
-                                    "options": [
-                                        {
-                                            "name": "(Continue)"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
-            },
-            {
-                "id": 3,
-                "name": "Find a Dungeon",
-                "description": "Find and enter any dungeon",
-                "anyPOI": true,
-                "mapFlag": "",
-                "mapFlagValue": 1,
-                "POITags": [
-                    "Dungeon"
-                ],
-                "objective": "Travel",
-                "prologue": {
-                    "text": "Your navigation arrow should now direct you to the nearest dungeon. Many quests will send you to dungeons, but you are also free to enter them without a quest. Follow the arrow and travel to a dungeon.",
-                    "options": [
-                        {
-                            "name": "(Continue)"
-                        }
-                    ]
-                },
-                "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    2
-                ]
-            },
-            {
-                "id": 4,
-                "name": "Win a duel",
-                "description": "Duel and defeat any enemy",
-                "worldMapOK": true,
-                "mixedEnemies": true,
-                "anyPOI": true,
-                "objective": "Defeat",
-                "prologue": {
-                    "text": "Many quests you undertake in your adventure will send you to one or more dungeons just like this one. Dungeons are filled with enemies, but also treasure like gold, mana shards, and cards.",
-                    "options": [
-                        {
-                            "name": "(Continue)",
-                            "text": "Your next objective is to defeat any single enemy in a duel. You can find them in a dungeon like this one, or wandering around outside on the world map. To begin a duel, simply walk in to the enemy.",
-                            "options": [
-                                {
-                                    "name": "(Continue)",
-                                    "text": "If you are defeated by the enemy, that's okay. If (when) that happens, you will lose some of your starting health and a percentage of your gold, but you've learned what to expect from that enemy in the future.",
-                                    "options": [
-                                        {
-                                            "name": "(Continue)",
-                                            "text": "Unlike on the world map, an enemy that defeats you in a dungeon will remain on the map; you can try to duel them again, or run away and seek out another opponent. If you want or need to heal yourself, go back to town.",
-                                            "options": [
-                                                {
-                                                    "name": "(Continue)",
-                                                    "text": "Some quests, like this one, have multiple objectives that can be achieved simultaneously. Your other current objective is to find and enter a cave on the world map. An enemy defeated in a cave or on the way there will count as the enemy to defeat for your first objective, so feel free to do these things in any order.",
-                                                    "options": [
-                                                        {
-                                                            "name": "(Continue)"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "epilogue": {
-                    "text": "Winning a duel grants you rewards; usually a combination of gold and cards. Some enemies drop a wider assortment of cards for variety, but others specifically give cards from their own deck. If you still need to visit a cave, do that now. Otherwise, it's time to return to town.",
-                    "options": [
-                        {
-                            "name": "(Continue)"
-                        }
-                    ]
-                },
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    3
-                ]
-            },
-            {
-                "id": 5,
-                "name": "Find a Cave",
-                "description": "Find and enter any cave",
-                "anyPOI": true,
-                "mapFlag": "",
-                "mapFlagValue": 1,
-                "POITags": [
-                    "Cave"
-                ],
-                "objective": "Travel",
-                "prologue": {},
-                "epilogue": {
-                    "text": "A cave is functionally identical to a dungeon, but can be classified separately for quest purposes; a cave would not have completed your objective to find a dungeon, nor would that dungeon count for this one.",
-                    "options": [
-                        {
-                            "name": "(Continue)",
-                            "text": "If you haven't defeated an enemy in a duel yet, you can pick a fight with an enemy here for that. Otherwise, you can return to town.",
-                            "options": [
-                                {
-                                    "name": "(Continue)"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    3
-                ]
-            },
-            {
-                "id": 5,
-                "name": "Go to a town",
-                "description": "Go to one of the nearby settlements",
-                "anyPOI": true,
-                "mapFlag": "",
-                "mapFlagValue": 1,
-                "POITags": [
-                    "Town"
-                ],
-                "objective": "Travel",
-                "prologue": {
-                    "text": "It's not a bad idea to occasionally visit town to sell extra cards, browse the shops, or pick up new quests.\n\nEvery town has its own assortment of shops and thus its own unique collections of cards for sale.",
-                    "options": [
-                        {
-                            "name": "(Continue)"
-                        }
-                    ]
-                },
-                "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    4,
-                    5
-                ]
-            }
-        ],
         "storyQuest": true
     },
     {
@@ -7600,7 +7655,8 @@
         "prologue": {},
         "epilogue": {},
         "failureDialog": {},
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -7619,7 +7675,8 @@
         "prologue": {},
         "epilogue": {},
         "failureDialog": {},
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -7637,7 +7694,6 @@
                 "POITags": [
                     "Quest_APortalToNowhere"
                 ],
-                "allowInactivePOI": true,
                 "objective": "Travel",
                 "prologue": {},
                 "epilogue": {},
@@ -7652,10 +7708,7 @@
                 "objective": "MapFlag",
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "$(poi_1)",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": "$(poi_1)"
             }
         ],
         "storyQuest": true
@@ -7669,7 +7722,8 @@
         "prologue": {},
         "epilogue": {},
         "failureDialog": {},
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -7698,10 +7752,7 @@
                 "objective": "MapFlag",
                 "prologue": {},
                 "epilogue": {},
-                "POIToken": "$(poi_1)",
-                "prerequisiteIDs": [
-                    1
-                ]
+                "POIToken": "$(poi_1)"
             }
         ],
         "storyQuest": true
@@ -7712,7 +7763,8 @@
         "name": "A Healthy Dose of Skep-ticism",
         "description": "Find Shandalar's largest Sliver hive",
         "offerDialog": {},
-        "prologue": {
+        "prologue":
+        {
             "text": "Quest 'A Healthy Dose of Skep-ticism' is a placeholder. It will eventually be replaced with an actual quest to explore the Skep. For now, this simply serves as directions to get there if you so desire. This placeholder quest does not provide any rewards.",
             "options": [
                 {
@@ -7722,7 +7774,8 @@
         },
         "epilogue": {},
         "failureDialog": {},
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -7755,7 +7808,8 @@
         "isTemplate": true,
         "name": "Kiora's Fall",
         "description": "Defeat the Kiora and her minions",
-        "offerDialog": {
+        "offerDialog":
+        {
             "text": "Village Elder: (Wrinkled brow, concerned tone) Ah, adventurer, have you heard of the looming threat? Kiora, the sea mage, stirs the depths with her restless sea creatures. We face a dire peril.",
             "options": [
                 {
@@ -7765,10 +7819,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -7776,7 +7832,7 @@
                         }
                     ],
                     "name": "Sorry, I don't have to the time for this. (Decline Quest)",
-                    "text": "Figured you weren't up to the challenge, come back to me when you are. ",
+                    "text": "Figured you weren't up to the challenge, come back to me when you are.",
                     "options": [
                         {
                             "name": "(Continue)"
@@ -7798,10 +7854,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "35",
@@ -7818,10 +7876,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "",
@@ -7829,7 +7889,7 @@
                                         }
                                     ],
                                     "name": "I don't think this is a quest for me  (Decline Quest)",
-                                    "text": "The merchant keeps a passive look on his face. \"Soon those things will be balanced as well.\"",
+                                    "text": "Shocked, the Elder shakes his head in dismay, \"Youngsters these days...\"",
                                     "options": [
                                         {
                                             "name": "(Continue)"
@@ -7843,7 +7903,8 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
+        "epilogue":
+        {
             "text": "As you enter the village, the local towspeople rush towards you to thank you for defeating Kiora. (+3 reputation in $(poi_1))",
             "options": [
                 {
@@ -7884,17 +7945,20 @@
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -7902,14 +7966,15 @@
                     "POIReference": "$(poi_2)"
                 }
             ],
-            "text": "After some reflection, you decide that the rewards promised to you are not worth the effort of clearing out the current occupants of the sewers. (-2 Local Reputation)",
+            "text": "After some reflection, you decide that the rewards promised to you are not worth the effort of defeating Kiora. (-2 Local Reputation)",
             "options": [
                 {
                     "name": "(Quest Failed)"
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -7961,7 +8026,8 @@
         "isTemplate": true,
         "name": "Teferi's Fall",
         "description": "Find and defeat Teferi",
-        "offerDialog": {
+        "offerDialog":
+        {
             "text": "Village Scholar: (Worried expression, hurried tone) Adventurer, we have a grave concern on our hands, and it concerns Teferi, the temporal mage. His actions threaten Shandalar's very fabric of time.",
             "options": [
                 {
@@ -7971,10 +8037,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -7982,7 +8050,7 @@
                         }
                     ],
                     "name": "Sorry, I don't have to the time for this. (Decline Quest)",
-                    "text": "Figured you weren't up to the challenge, come back to me when you are. ",
+                    "text": "Figured you weren't up to the challenge, come back to me when you are.",
                     "options": [
                         {
                             "name": "(Continue)"
@@ -7990,7 +8058,7 @@
                     ]
                 },
                 {
-                    "name": "Teferi? What's he doing that's causing such alarm?  ",
+                    "name": "Teferi? What's he doing that's causing such alarm? ",
                     "text": "(Frowning) Teferi's meddling with time magic has created temporal anomalies across Shandalar. The past, present, and future are becoming entangled, leading to chaos and unpredictability. It's a perilous situation.",
                     "options": [
                         {
@@ -8004,10 +8072,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "36",
@@ -8024,10 +8094,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "",
@@ -8035,7 +8107,7 @@
                                         }
                                     ],
                                     "name": "I don't think this is a quest for me  (Decline Quest)",
-                                    "text": "The merchant keeps a passive look on his face. \"Soon those things will be balanced as well.\"",
+                                    "text": "The Scholar keeps a passive look on his face. \"Soon, everything will come to naught.\"",
                                     "options": [
                                         {
                                             "name": "(Continue)"
@@ -8049,7 +8121,8 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
+        "epilogue":
+        {
             "text": "As you enter the village, the local towspeople rush towards you to thank you for your deeds.  (+3 reputation in $(poi_1))",
             "options": [
                 {
@@ -8090,17 +8163,20 @@
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -8115,7 +8191,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -8167,7 +8244,8 @@
         "isTemplate": true,
         "name": "The Drunken Plea",
         "description": "Confront the Phyrexians",
-        "offerDialog": {
+        "offerDialog":
+        {
             "text": "Hey there, bud! You see...hiccup... them metal monstrosities, the Phyrexians? Yeah, they're up to no good, I tell ya. I saw 'em, I did!",
             "options": [
                 {
@@ -8177,10 +8255,12 @@
                             "setColorIdentity": "",
                             "advanceQuestFlag": "",
                             "advanceMapFlag": "",
-                            "setQuestFlag": {
+                            "setQuestFlag":
+                            {
                                 "key": ""
                             },
-                            "setMapFlag": {
+                            "setMapFlag":
+                            {
                                 "key": ""
                             },
                             "issueQuest": "",
@@ -8188,7 +8268,7 @@
                         }
                     ],
                     "name": "Sorry, I don't have to the time for this. (Decline Quest)",
-                    "text": "Figured you weren't up to the challenge, come back to me when you are. ",
+                    "text": "Figured you weren't up to the challenge, come back to me when you are.",
                     "options": [
                         {
                             "name": "(Continue)"
@@ -8200,8 +8280,8 @@
                     "text": "These...hiccup... metal freaks! They ain't from around here, I swear. Saw 'em with me own eyes. They got them twisted, mechanical...things! Up to somethin' bad, they are!",
                     "options": [
                         {
-                            "name": "You've had quite a few drinks, Tim. Are you sure you're not imagining things? Phyrexians haven't been seen in these parts for thousands of years",
-                            "text": "Nonsense! Me eyes don't lie, friend. Them Phyrexians are real trouble, I'm tellin' ya. You gotta go, see for yourself. Kick 'em outta Shandalar!",
+                            "name": "You've had quite a few drinks, Tim. Are you sure you're not imagining things? Phyrexians haven't been seen in these parts for thousands of years.",
+                            "text": "Nonsense! Me eyes don't lie, friend. Them Phyrexians are real trouble, I'm tellin' ya. You gotta go. See for yourself. Kick 'em outta Shandalar!",
                             "options": [
                                 {
                                     "action": [
@@ -8210,10 +8290,12 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "37",
@@ -8230,17 +8312,20 @@
                                             "setColorIdentity": "",
                                             "advanceQuestFlag": "",
                                             "advanceMapFlag": "",
-                                            "setQuestFlag": {
+                                            "setQuestFlag":
+                                            {
                                                 "key": ""
                                             },
-                                            "setMapFlag": {
+                                            "setMapFlag":
+                                            {
                                                 "key": ""
                                             },
                                             "issueQuest": "",
                                             "POIReference": ""
                                         }
                                     ],
-                                    "name": "Sorry, I don't have time for this (Decline Text)",
+                                    "name": "Sorry, I don't have time for this (Decline Quest)",
+									"text": "Tipsy Tim gives you a morose look, then starts drinking more as he staggers away from you with profound disappointment.",
                                     "options": [
                                         {
                                             "name": "(Continue)"
@@ -8254,8 +8339,9 @@
             ]
         },
         "prologue": {},
-        "epilogue": {
-            "text": "As you enter the village, These...hiccup... metal freaks! They ain't from around here, I swear. Saw 'em with me own eyes. They got them twisted, mechanical...things! Up to somethin' bad, they are!  (+3 reputation in $(poi_1))",
+        "epilogue":
+        {
+            "text": "As you return to town, nobody seems impressed besides Tipsy Tim, who gives you a clap on the back. \"Those metal freaks...hiccup...You got rid of them you did!\" He then stumbles away happily.  (+3 reputation in $(poi_1))",
             "options": [
                 {
                     "action": [
@@ -8291,21 +8377,24 @@
                             ]
                         }
                     ],
-                    "name": "It's nothing I coudn't handle (Complete Quest)"
+                    "name": "You wave farewell to Tipsy Tim (Complete Quest)"
                 }
             ]
         },
-        "failureDialog": {
+        "failureDialog":
+        {
             "action": [
                 {
                     "removeItem": "",
                     "setColorIdentity": "",
                     "advanceQuestFlag": "",
                     "advanceMapFlag": "",
-                    "setQuestFlag": {
+                    "setQuestFlag":
+                    {
                         "key": ""
                     },
-                    "setMapFlag": {
+                    "setMapFlag":
+                    {
                         "key": ""
                     },
                     "issueQuest": "",
@@ -8320,7 +8409,8 @@
                 }
             ]
         },
-        "declinedDialog": {
+        "declinedDialog":
+        {
             "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
             "options": [
                 {
@@ -8366,3003 +8456,6 @@
             "forest_capital",
             "plains_capital",
             "swamp_capital"
-        ]
-    },
-    {
-        "id": 38,
-        "isTemplate": true,
-        "name": "Goblin Invasion",
-        "description": "Stop the Goblin invasion",
-        "offerDialog": {
-            "text": "From somewhere near the gate where you entered $(poi_3), a bell rings frantically.",
-            "options": [
-                {
-                    "name": "Go back and see what the noise is about.",
-                    "text": "\"GOBLINS!!!\" A haggard looking ranger exclaims as he sounds the alarm. \"Goblins are coming, hordes of them! To arms!!!\"",
-                    "options": [
-                        {
-                            "name": "This isn't your problem, leave it to the town guards. (Decline Quest, -1 local reputation)",
-                            "action": [
-                                {
-                                    "addMapReputation": -1,
-                                    "POIReference": "$(poi_3)"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "Commit to helping defend the town (Accept Quest)",
-                            "action": [
-                                {
-                                    "removeItem": "",
-                                    "setColorIdentity": "",
-                                    "advanceQuestFlag": "",
-                                    "advanceMapFlag": "",
-                                    "setQuestFlag": {
-                                        "key": ""
-                                    },
-                                    "setMapFlag": {
-                                        "key": ""
-                                    },
-                                    "issueQuest": "38",
-                                    "POIReference": ""
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "prologue": {},
-        "epilogue": {
-            "text": "With the Goblin attacks halted, the people of $(poi_3) shower you with thanks and quite a few coins as well. (+2 local reputation, +500 gold)",
-            "options": [
-                {
-                    "action": [
-                        {
-                            "addGold": 500,
-                            "addMapReputation": 2,
-                            "POIReference": "$(poi_3)"
-                        }
-                    ],
-                    "name": "(Quest complete)"
-                }
-            ]
-        },
-        "failureDialog": {
-            "action": [
-                {
-                    "removeItem": "",
-                    "setColorIdentity": "",
-                    "advanceQuestFlag": "",
-                    "advanceMapFlag": "",
-                    "setQuestFlag": {
-                        "key": ""
-                    },
-                    "setMapFlag": {
-                        "key": ""
-                    },
-                    "issueQuest": "",
-                    "addMapReputation": -2,
-                    "POIReference": "$(poi_3)"
-                }
-            ],
-            "text": "The day, and much of $(poi_3), belongs to the Goblin horde. (-2 Local Reputation)",
-            "options": [
-                {
-                    "name": "(Quest Failed)"
-                }
-            ]
-        },
-        "declinedDialog": {
-            "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
-            "options": [
-                {
-                    "name": "(Catching the not so subtle hint, you leave.)"
-                }
-            ]
-        },
-        "rewardDescription": "Gold and Reputation",
-        "stages": [
-            {
-                "id": 1,
-                "name": "Battle the Goblin horde",
-                "description": "Goblins are appearing all over. Win at least three duels against them.",
-                "mapFlag": "",
-                "mapFlagValue": 1,
-                "count1": 3,
-                "worldMapOK": true,
-                "objective": "Defeat",
-                "mixedEnemies": true,
-                "enemyTags": [
-                    "Goblin",
-                    "Minion"
-                ],
-                "enemyExcludeTags": [
-                    "Leader",
-                    "Boss"
-                ],
-                "prologue": {},
-                "epilogue": {
-                    "text": "The gobins are greatly diminished in number, but the bravest of them still press the attack on $(poi_3). Defeat one of the leaders to put a stop to all of this.",
-                    "options": [
-                        {
-                            "name": "(Continue)"
-                        }
-                    ]
-                },
-                "POIToken": ""
-            },
-            {
-                "id": 2,
-                "name": "Defeat a $(enemy_2)",
-                "description": "With the greenskin ranks thinned out, defeating one of their leaders should break the remaining horde's will to fight.",
-                "mapFlag": "",
-                "mapFlagValue": 1,
-                "count1": 1,
-                "objective": "Defeat",
-                "worldMapOK": true,
-                "enemyTags": [
-                    "Goblin",
-                    "Leader"
-                ],
-                "enemyExcludeTags": [
-                    "Boss"
-                ],
-                "prologue": {},
-                "epilogue": {
-                    "text": "A few more raiders remain, but they fight more defensively now. $(poi_3) should be safe, and you should return to report your success.",
-                    "options": [
-                        {
-                            "name": "(Continue)"
-                        }
-                    ]
-                },
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
-            },
-            {
-                "id": 3,
-                "name": "Travel",
-                "description": "Return to $(poi_3) and collect your rewards.",
-                "mapFlag": "",
-                "mapFlagValue": 1,
-                "here": true,
-                "objective": "Travel",
-                "prologue": {},
-                "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    2
-                ]
-            }
-        ],
-        "questSourceTags": [
-            "forest_town_generic",
-            "forest_town_identity",
-            "forest_town_tribal",
-            "island_town_generic",
-            "island_town_identity",
-            "island_town_tribal",
-            "plains_town_generic",
-            "plains_town_identity",
-            "plains_town_tribal",
-            "swamp_town_generic",
-            "swamp_town_identity",
-            "swamp_town_tribal",
-            "waste_town_generic",
-            "waste_town_identity",
-            "waste_town_tribal"
-        ]
-    },
-    {
-        "id": 39,
-        "isTemplate": true,
-        "name": "Merfolk Invasion",
-        "description": "Stop the Merfolk invasion",
-        "offerDialog": {
-            "text": "\"Traveler, we need every able body to be ready. Merfolk have been spotted nearby, and in very large numbers.\"",
-            "options": [
-                {
-                    "name": "Merfolk? Here?",
-                    "text": "\"Well\", the man's face twists slightly, \"...we may have sent some adventurers in search of an artifact recently. A portion of the group returned without it, but it appears they were followed.\"",
-                    "options": [
-                        {
-                            "name": "\"You called this onto yourself, fix it yourself.\" (Decline Quest, -1 local reputation)",
-                            "action": [
-                                {
-                                    "addMapReputation": -1,
-                                    "POIReference": "$(poi_3)"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "Join the fight. (Accept Quest)",
-                            "action": [
-                                {
-                                    "removeItem": "",
-                                    "setColorIdentity": "",
-                                    "advanceQuestFlag": "",
-                                    "advanceMapFlag": "",
-                                    "setQuestFlag": {
-                                        "key": ""
-                                    },
-                                    "setMapFlag": {
-                                        "key": ""
-                                    },
-                                    "issueQuest": "39",
-                                    "POIReference": ""
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "prologue": {},
-        "epilogue": {
-            "text": "Whether the merfolk got sufficient revenge, or your efforts drove them away, $(poi_3) is no longer under attack. (+2 local reputation, +500 gold)",
-            "options": [
-                {
-                    "action": [
-                        {
-                            "addGold": 500,
-                            "addMapReputation": 2,
-                            "POIReference": "$(poi_3)"
-                        }
-                    ],
-                    "name": "(Quest complete)"
-                }
-            ]
-        },
-        "failureDialog": {
-            "action": [
-                {
-                    "removeItem": "",
-                    "setColorIdentity": "",
-                    "advanceQuestFlag": "",
-                    "advanceMapFlag": "",
-                    "setQuestFlag": {
-                        "key": ""
-                    },
-                    "setMapFlag": {
-                        "key": ""
-                    },
-                    "issueQuest": "",
-                    "addMapReputation": -2,
-                    "POIReference": "$(poi_3)"
-                }
-            ],
-            "text": "You have failed to defend $(poi_3), and they are now at the mercy of the Merfolk. (-2 Local Reputation)",
-            "options": [
-                {
-                    "name": "(Quest Failed)"
-                }
-            ]
-        },
-        "declinedDialog": {
-            "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
-            "options": [
-                {
-                    "name": "(Catching the not so subtle hint, you leave.)"
-                }
-            ]
-        },
-        "rewardDescription": "Gold and Reputation",
-        "stages": [
-            {
-                "id": 1,
-                "name": "Battle the Merfolk raiders",
-                "description": "Defeat at least three Merfolk in defense of $(poi_3).",
-                "mapFlag": "",
-                "mapFlagValue": 1,
-                "count1": 3,
-                "objective": "Defeat",
-                "worldMapOK": true,
-                "mixedEnemies": true,
-                "enemyTags": [
-                    "Merfolk",
-                    "Minion"
-                ],
-                "enemyExcludeTags": [
-                    "Leader",
-                    "Boss"
-                ],
-                "prologue": {},
-                "epilogue": {
-                    "text": "With several Merfolk defeated, their champions begin to hunt for you..",
-                    "options": [
-                        {
-                            "name": "(Continue)"
-                        }
-                    ]
-                },
-                "POIToken": ""
-            },
-            {
-                "id": 2,
-                "name": "Defeat one of the Merfolk champions",
-                "description": "Defeating a Merfolk champion will hopefully be enough to turn the tide, so to say.",
-                "mapFlag": "",
-                "mapFlagValue": 1,
-                "count1": 1,
-                "objective": "Defeat",
-                "worldMapOK": true,
-                "enemyTags": [
-                    "Merfolk",
-                    "Leader"
-                ],
-                "enemyExcludeTags": [
-                    "Boss"
-                ],
-                "prologue": {},
-                "epilogue": {
-                    "text": "$(poi_3) has successfully been defended, and you should return to report your success.",
-                    "options": [
-                        {
-                            "name": "(Continue)"
-                        }
-                    ]
-                },
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
-            },
-            {
-                "id": 3,
-                "name": "Travel",
-                "description": "Return to $(poi_3) and collect your rewards.",
-                "mapFlag": "",
-                "mapFlagValue": 1,
-                "here": true,
-                "objective": "Travel",
-                "prologue": {},
-                "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    2
-                ]
-            }
-        ],
-        "questSourceTags": [
-            "forest_town_generic",
-            "forest_town_identity",
-            "forest_town_tribal",
-            "mountain_town_generic",
-            "mountain_town_identity",
-            "mountain_town_tribal",
-            "plains_town_generic",
-            "plains_town_identity",
-            "plains_town_tribal",
-            "swamp_town_generic",
-            "swamp_town_identity",
-            "swamp_town_tribal",
-            "waste_town_generic",
-            "waste_town_identity",
-            "waste_town_tribal"
-        ]
-    },
-    {
-        "id": 40,
-        "isTemplate": true,
-        "name": "Undead Invasion",
-        "description": "Stop the Undead invasion",
-        "offerDialog": {
-            "text": "Outside the walls of $(poi_3), corpses litter the ground. \"The problem is, they won't stay down.\" The town's mayor implores you to assist somehow.",
-            "options": [
-                {
-                    "name": "\"There is likely a necromancer at work here.\"",
-                    "text": "\"Can you stop them?\" The mayor gives you a hopeful look, knowing that the town's defenders are exhausted from fighting the same undead re-raised over and over.",
-                    "options": [
-                        {
-                            "name": "\"I have other things to do.\" (Decline Quest, -1 local reputation)",
-                            "action": [
-                                {
-                                    "addMapReputation": -1,
-                                    "POIReference": "$(poi_3)"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "Attack quickly while some of the corpses are still down. (Accept Quest)",
-                            "action": [
-                                {
-                                    "removeItem": "",
-                                    "setColorIdentity": "",
-                                    "advanceQuestFlag": "",
-                                    "advanceMapFlag": "",
-                                    "setQuestFlag": {
-                                        "key": ""
-                                    },
-                                    "setMapFlag": {
-                                        "key": ""
-                                    },
-                                    "issueQuest": "40",
-                                    "POIReference": ""
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "prologue": {},
-        "epilogue": {
-            "text": "Tonight, $(poi_3) can rest more easily, as the dead do not rise before they can be burned. (+2 local reputation, +500 gold)",
-            "options": [
-                {
-                    "action": [
-                        {
-                            "addGold": 500,
-                            "addMapReputation": 2,
-                            "POIReference": "$(poi_3)"
-                        }
-                    ],
-                    "name": "(Quest complete)"
-                }
-            ]
-        },
-        "failureDialog": {
-            "action": [
-                {
-                    "removeItem": "",
-                    "setColorIdentity": "",
-                    "advanceQuestFlag": "",
-                    "advanceMapFlag": "",
-                    "setQuestFlag": {
-                        "key": ""
-                    },
-                    "setMapFlag": {
-                        "key": ""
-                    },
-                    "issueQuest": "",
-                    "addMapReputation": -2,
-                    "POIReference": "$(poi_3)"
-                }
-            ],
-            "text": "The population of $(poi_3) has diminished significantly. The living population, that is... (-2 Local Reputation)",
-            "options": [
-                {
-                    "name": "(Quest Failed)"
-                }
-            ]
-        },
-        "declinedDialog": {
-            "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
-            "options": [
-                {
-                    "name": "(Catching the not so subtle hint, you leave.)"
-                }
-            ]
-        },
-        "rewardDescription": "Gold and Reputation",
-        "stages": [
-            {
-                "id": 1,
-                "name": "Battle the Undead",
-                "description": "Defeat at least three Undead in defense of $(poi_3).",
-                "mapFlag": "",
-                "mapFlagValue": 1,
-                "count1": 3,
-                "objective": "Defeat",
-                "worldMapOK": true,
-                "mixedEnemies": true,
-                "enemyTags": [
-                    "Undead",
-                    "Minion"
-                ],
-                "enemyExcludeTags": [
-                    "Leader",
-                    "Boss"
-                ],
-                "prologue": {},
-                "epilogue": {
-                    "text": "With each skirmish won, you found more hints of magic that led you closer to the dark wizards behind this attack. Now you can face them directly.",
-                    "options": [
-                        {
-                            "name": "(Continue)"
-                        }
-                    ]
-                },
-                "POIToken": ""
-            },
-            {
-                "id": 2,
-                "name": "Defeat a Necromancer threatening $(poi_3)",
-                "description": "Without Necromancers animating the dead, the defenders of $(poi_3) can regroup and recover.",
-                "mapFlag": "",
-                "mapFlagValue": 1,
-                "count1": 1,
-                "objective": "Defeat",
-                "worldMapOK": true,
-                "enemyTags": [
-                    "Necromancer"
-                ],
-                "enemyExcludeTags": [
-                    "Boss"
-                ],
-                "prologue": {},
-                "epilogue": {
-                    "text": "$(poi_3) has successfully been defended, and you should return to report your success.",
-                    "options": [
-                        {
-                            "name": "(Continue)"
-                        }
-                    ]
-                },
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
-            },
-            {
-                "id": 3,
-                "name": "Travel",
-                "description": "Return to $(poi_3) and collect your rewards.",
-                "mapFlag": "",
-                "mapFlagValue": 1,
-                "here": true,
-                "objective": "Travel",
-                "prologue": {},
-                "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    2
-                ]
-            }
-        ],
-        "questSourceTags": [
-            "forest_town_generic",
-            "forest_town_identity",
-            "forest_town_tribal",
-            "island_town_generic",
-            "island_town_identity",
-            "island_town_tribal",
-            "mountain_town_generic",
-            "mountain_town_identity",
-            "mountain_town_tribal",
-            "plains_town_generic",
-            "plains_town_identity",
-            "plains_town_tribal",
-            "waste_town_generic",
-            "waste_town_identity",
-            "waste_town_tribal"
-        ]
-    },
-    {
-        "id": 41,
-        "isTemplate": true,
-        "name": "Elven Invasion",
-        "description": "Stop the Elven invasion",
-        "offerDialog": {
-            "text": "\"Hail, stranger. I'm in need of a neutral party to settle a disagreement.\" A worried looking man approaches you, holding a small plant in clay pot.",
-            "options": [
-                {
-                    "name": "\"What can I do to help?\"",
-                    "text": "\"You see, I took this cutting from a giant tree. I mean GIANT. Biggest tree I've ever seen.\" Outside the town, you hear shouting. \"And, well, turns out, the elves seem to disagree with me having taken it...\"",
-                    "options": [
-                        {
-                            "name": "\"Then I suggest you give it back. Quickly.\" (Decline Quest, -1 local reputation)",
-                            "action": [
-                                {
-                                    "addMapReputation": -1,
-                                    "POIReference": "$(poi_3)"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "\"It's just a tree, I can handle some elves, and I support your bansai hobby.\" (Accept Quest)",
-                            "action": [
-                                {
-                                    "removeItem": "",
-                                    "setColorIdentity": "",
-                                    "advanceQuestFlag": "",
-                                    "advanceMapFlag": "",
-                                    "setQuestFlag": {
-                                        "key": ""
-                                    },
-                                    "setMapFlag": {
-                                        "key": ""
-                                    },
-                                    "issueQuest": "41",
-                                    "POIReference": ""
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "prologue": {},
-        "epilogue": {
-            "text": "The elves are still angry about the defilement of their sacred tree, but your efforts in defending $(poi_3) have convinced them to forgo revenge for now. (+2 local reputation, +500 gold)",
-            "options": [
-                {
-                    "action": [
-                        {
-                            "addGold": 500,
-                            "addMapReputation": 2,
-                            "POIReference": "$(poi_3)"
-                        }
-                    ],
-                    "name": "(Quest complete)"
-                }
-            ]
-        },
-        "failureDialog": {
-            "action": [
-                {
-                    "removeItem": "",
-                    "setColorIdentity": "",
-                    "advanceQuestFlag": "",
-                    "advanceMapFlag": "",
-                    "setQuestFlag": {
-                        "key": ""
-                    },
-                    "setMapFlag": {
-                        "key": ""
-                    },
-                    "issueQuest": "",
-                    "addMapReputation": -2,
-                    "POIReference": "$(poi_3)"
-                }
-            ],
-            "text": "No houseplant is worth this effort, but you've let the people of $(poi_3) down. (-2 Local Reputation)",
-            "options": [
-                {
-                    "name": "(Quest Failed)"
-                }
-            ]
-        },
-        "declinedDialog": {
-            "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
-            "options": [
-                {
-                    "name": "(Catching the not so subtle hint, you leave.)"
-                }
-            ]
-        },
-        "rewardDescription": "Gold and Reputation",
-        "stages": [
-            {
-                "id": 1,
-                "name": "Battle the Elves",
-                "description": "Defeat at least three Elves in defense of $(poi_3).",
-                "mapFlag": "",
-                "mapFlagValue": 1,
-                "count1": 3,
-                "objective": "Defeat",
-                "worldMapOK": true,
-                "mixedEnemies": true,
-                "enemyTags": [
-                    "Elf",
-                    "Minion"
-                ],
-                "enemyExcludeTags": [
-                    "Leader",
-                    "Boss"
-                ],
-                "prologue": {},
-                "epilogue": {
-                    "text": "Your defiant defense has gathered the attention of the elves' elite hunters and more powerful druids. Expect a greater challenge now.",
-                    "options": [
-                        {
-                            "name": "(Continue)"
-                        }
-                    ]
-                },
-                "POIToken": ""
-            },
-            {
-                "id": 2,
-                "name": "Defeat an elite Elf threatening $(poi_3)",
-                "description": "Deal with the best that the elves can throw at you and $(poi_3) in order to halt their attacks.",
-                "mapFlag": "",
-                "mapFlagValue": 1,
-                "count1": 1,
-                "objective": "Defeat",
-                "worldMapOK": true,
-                "enemyTags": [
-                    "Elf",
-                    "Leader"
-                ],
-                "enemyExcludeTags": [
-                    "Boss"
-                ],
-                "prologue": {},
-                "epilogue": {
-                    "text": "$(poi_3) has successfully been defended, and you should return to report your success.",
-                    "options": [
-                        {
-                            "name": "(Continue)"
-                        }
-                    ]
-                },
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
-            },
-            {
-                "id": 3,
-                "name": "Travel",
-                "description": "Return to $(poi_3) and collect your rewards.",
-                "mapFlag": "",
-                "mapFlagValue": 1,
-                "here": true,
-                "objective": "Travel",
-                "prologue": {},
-                "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    2
-                ]
-            }
-        ],
-        "questSourceTags": [
-            "island_town_generic",
-            "island_town_identity",
-            "island_town_tribal",
-            "mountain_town_generic",
-            "mountain_town_identity",
-            "mountain_town_tribal",
-            "plains_town_generic",
-            "plains_town_identity",
-            "plains_town_tribal",
-            "swamp_town_generic",
-            "swamp_town_identity",
-            "swamo_town_tribal",
-            "waste_town_generic",
-            "waste_town_identity",
-            "waste_town_tribal"
-        ]
-    },
-    {
-        "id": 42,
-        "isTemplate": true,
-        "name": "Soldier Invasion",
-        "description": "Stop the Soldier invasion",
-        "offerDialog": {
-            "text": "$(poi_3) is a bustle of frantic activity. The reason? A small army flying a foreign battle flag has been spotted on the horizon.",
-            "options": [
-                {
-                    "name": "Consider your options.",
-                    "text": "Defending the town will not be simple, but can you really just let them be conquered?",
-                    "options": [
-                        {
-                            "name": "\"This is not my fight.\" (Decline Quest, -1 local reputation)",
-                            "action": [
-                                {
-                                    "addMapReputation": -1,
-                                    "POIReference": "$(poi_3)"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "\"The invaders have no claim to these lands!\" (Accept Quest)",
-                            "action": [
-                                {
-                                    "removeItem": "",
-                                    "setColorIdentity": "",
-                                    "advanceQuestFlag": "",
-                                    "advanceMapFlag": "",
-                                    "setQuestFlag": {
-                                        "key": ""
-                                    },
-                                    "setMapFlag": {
-                                        "key": ""
-                                    },
-                                    "issueQuest": "42",
-                                    "POIReference": ""
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "prologue": {},
-        "epilogue": {
-            "text": "The leaders of $(poi_3) have you to thank for their freedom, and likely their heads. (+2 local reputation, +500 gold)",
-            "options": [
-                {
-                    "action": [
-                        {
-                            "addGold": 500,
-                            "addMapReputation": 2,
-                            "POIReference": "$(poi_3)"
-                        }
-                    ],
-                    "name": "(Quest complete)"
-                }
-            ]
-        },
-        "failureDialog": {
-            "action": [
-                {
-                    "removeItem": "",
-                    "setColorIdentity": "",
-                    "advanceQuestFlag": "",
-                    "advanceMapFlag": "",
-                    "setQuestFlag": {
-                        "key": ""
-                    },
-                    "setMapFlag": {
-                        "key": ""
-                    },
-                    "issueQuest": "",
-                    "addMapReputation": -2,
-                    "POIReference": "$(poi_3)"
-                }
-            ],
-            "text": "A new banner flies above the walls of $(poi_3), and a new set of tax collectors will follow. The locals will not soon forget who failed to protect them. (-2 Local Reputation)",
-            "options": [
-                {
-                    "name": "(Quest Failed)"
-                }
-            ]
-        },
-        "declinedDialog": {
-            "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
-            "options": [
-                {
-                    "name": "(Catching the not so subtle hint, you leave.)"
-                }
-            ]
-        },
-        "rewardDescription": "Gold and Reputation",
-        "stages": [
-            {
-                "id": 1,
-                "name": "Battle the Soldiers",
-                "description": "Defeat at least three Soldiers in defense of $(poi_3).",
-                "mapFlag": "",
-                "mapFlagValue": 1,
-                "count1": 3,
-                "objective": "Defeat",
-                "worldMapOK": true,
-                "mixedEnemies": true,
-                "enemyTags": [
-                    "Soldier",
-                    "IdentityWhite",
-                    "Minion"
-                ],
-                "enemyExcludeTags": [
-                    "Boss",
-                    "Leader"
-                ],
-                "prologue": {},
-                "epilogue": {
-                    "text": "The rank and file troops are no match for you, but breaking their resolve will require defeating one of the army's leaders.",
-                    "options": [
-                        {
-                            "name": "(Continue)"
-                        }
-                    ]
-                },
-                "POIToken": ""
-            },
-            {
-                "id": 2,
-                "name": "Defeat one of the commanders of the forces attacking $(poi_3)",
-                "description": "The rank and file troops are no match for you, but breaking their resolve will require defeating one of the army's leaders.",
-                "mapFlag": "",
-                "mapFlagValue": 1,
-                "count1": 1,
-                "objective": "Defeat",
-                "worldMapOK": true,
-                "enemyTags": [
-                    "Soldier",
-                    "IdentityWhite",
-                    "Leader"
-                ],
-                "enemyExcludeTags": [
-                    "Boss"
-                ],
-                "prologue": {},
-                "epilogue": {
-                    "text": "$(poi_3) has successfully been defended, and you should return to report your success.",
-                    "options": [
-                        {
-                            "name": "(Continue)"
-                        }
-                    ]
-                },
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
-            },
-            {
-                "id": 3,
-                "name": "Travel",
-                "description": "Return to $(poi_3) and collect your rewards.",
-                "mapFlag": "",
-                "mapFlagValue": 1,
-                "here": true,
-                "objective": "Travel",
-                "prologue": {},
-                "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    2
-                ]
-            }
-        ],
-        "questSourceTags": [
-            "forest_town_generic",
-            "forest_town_identity",
-            "forest_town_tribal",
-            "island_town_generic",
-            "island_town_identity",
-            "island_town_tribal",
-            "mountain_town_generic",
-            "mountain_town_identity",
-            "mountain_town_tribal",
-            "swamp_town_generic",
-            "swamp_town_identity",
-            "swamp_town_tribal",
-            "waste_town_generic",
-            "waste_town_identity",
-            "waste_town_tribal"
-        ]
-    },
-    {
-        "id": 43,
-        "isTemplate": true,
-        "name": "Your First Job",
-        "offerDialog": {},
-        "prologue": {},
-        "epilogue": {},
-        "failureDialog": {},
-        "declinedDialog": {
-            "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
-            "options": [
-                {
-                    "name": "(Catching the not so subtle hint, you leave.)"
-                }
-            ]
-        },
-        "storyQuest": true,
-        "stages": [
-            {
-                "id": 1,
-                "name": "Complete a side quest",
-                "description": "Side quests are available in all towns (look for the question mark) and can be a great way to collect extra loot while exploring Shandalar.",
-                "count1": 1,
-                "objective": "CompleteQuest",
-                "POITags": [
-                    "QuestSource"
-                ],
-                "anyPOI": true,
-                "prologue": {
-                    "text": "Note: Since this quest objective is to complete other quests, your navigation arrow will lead you to quest sources while you are tracking it. Once you accept a side quest, go in to your quest log and track that quest in order to update navigation hints.",
-                    "options": [
-                        {
-                            "name": "(Continue)"
-                        }
-                    ]
-                },
-                "epilogue": {},
-                "POIToken": ""
-            },
-            {
-                "id": 2,
-                "name": "Complete more side quests",
-                "description": "Side quests are available in all towns (look for the question mark) and can be a great way to collect extra loot while exploring Shandalar.",
-                "count1": 3,
-                "objective": "CompleteQuest",
-                "POITags": [
-                    "QuestSource"
-                ],
-                "anyPOI": true,
-                "prologue": {
-                    "text": "Your first job complete, you feel the slightest bit more experienced. And hopefully a little bit more wealthy.",
-                    "options": [
-                        {
-                            "name": "(Continue)",
-                            "text": "The townsfolk offer you a small discount in their shops for having helped them and suggest that there may be more work available. Continue to explore via quests and build up a little bit more of a reputation in the process. Remember to track this quest to find more sources, or track the quests you take on to find their objectives.",
-                            "options": [
-                                {
-                                    "name": "(Continue"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "epilogue": {
-                    "text": "A human male approaches you, dressed in a well tailored black coat adorned with silver flourishes and details. \"You there! Yes, you, the $(playerrace). You are the one who just finished a job for the locals, yes?\"",
-                    "options": [
-                        {
-                            "name": "\"Yes, that's right.\"",
-                            "text": "\"I have another job for you, and I won't take no for an answer...\"",
-                            "options": [
-                                {
-                                    "action": [
-                                        {
-                                            "removeItem": "",
-                                            "setColorIdentity": "",
-                                            "advanceQuestFlag": "",
-                                            "advanceMapFlag": "",
-                                            "setQuestFlag": {
-                                                "key": ""
-                                            },
-                                            "setMapFlag": {
-                                                "key": ""
-                                            },
-                                            "issueQuest": "44",
-                                            "POIReference": ""
-                                        }
-                                    ],
-                                    "name": "(Continue)"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
-            }
-        ]
-    },
-    {
-        "id": 44,
-        "isTemplate": true,
-        "name": "Find the Caravan",
-        "description": "A shipment of mana shards is overdue to arrive at $(poi_1). Find the caravan carrying it and make sure the shipment arrives.",
-        "offerDialog": {},
-        "prologue": {
-            "text": "\"My name is Donovan. Sir Donovan to most. And I have an urgent need for mana shards, far more than I can source in any one town.\" Realizing the financial implications of this, you suddenly feel as though his fine coat is Donovan's 'roughing it' attire despite the fact that it likely cost a year's wages for most people here in $(poi_1)",
-            "options": [
-                {
-                    "name": "\"I can't say I carry that many on me, but I suppose I could sell you some of what I have.\"",
-                    "text": "\"No, the problem is that I've already purchased them, and the caravan they were supposed to arrive on is far overdue. I need you to go find it, and quickly.\"",
-                    "options": [
-                        {
-                            "name": "\"I see...\"",
-                            "text": "\"Now then, you are already aware that I will not be taking no for an answer.\" Donovan hands you a sheet of paper from a stack that appears to have more copies of the same information. \"Here are the details on the caravan's planned route and my personal passphrase to use with the driver for identification. Go find my shipment. I must have it to continue my research.\"",
-                            "options": [
-                                {
-                                    "name": "It seems as if he really isn't giving you an opportunity to say no."
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "epilogue": {},
-        "failureDialog": {},
-        "declinedDialog": {
-            "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
-            "options": [
-                {
-                    "name": "(Catching the not so subtle hint, you leave.)"
-                }
-            ]
-        },
-        "storyQuest": true,
-        "stages": [
-            {
-                "id": 1,
-                "name": "Begin the search",
-                "description": "Leave $(poi_1) to search for the caravan.",
-                "mapFlag": "",
-                "mapFlagValue": 1,
-                "objective": "Leave",
-                "here": true,
-                "prologue": {},
-                "epilogue": {},
-                "POIToken": ""
-            },
-            {
-                "id": 2,
-                "name": "Find the caravan",
-                "description": "Travel to $(poi_2) in search of the missing shipment of mana shards",
-                "mapFlag": "",
-                "mapFlagValue": 1,
-                "count1": 50,
-                "count2": 10,
-                "objective": "Travel",
-                "POITags": [
-                    "QuestSource",
-                    "Sidequest",
-                    "Town",
-                    "BiomeColorless"
-                ],
-                "prologue": {
-                    "text": "You had hoped this would be an easy task and that the caravan would be approaching on the horizon as you exited the gates. Alas, that was not the case. Instead, you consult your map and head off toward the shipment's point of origin, $(poi_2).",
-                    "options": [
-                        {
-                            "name": "(Continue)"
-                        }
-                    ]
-                },
-                "epilogue": {},
-                "prerequisiteIDs": [
-                    1
-                ]
-            },
-            {
-                "id": 3,
-                "name": "Find the bandit cave",
-                "description": "",
-                "mapFlag": "",
-                "mapFlagValue": 1,
-                "objective": "Travel",
-                "allowInactivePOI": true,
-                "POITags": [
-                    "Quest_BanditCave"
-                ],
-                "prologue": {
-                    "text": "The people in $(poi_2) all claim not to have seen any travelers matching the description you were given of the merchants overdue in $(poi_1).",
-                    "options": [
-                        {
-                            "name": "(Continue)",
-                            "text": "However, many do mention reports of bandit attacks on the roads, and a farmer you spoke with believes he knows where their hideout is, a cave near his farm. He marks it on your map and you resolve to investigate.",
-                            "options": [
-                                {
-                                    "name": "(Continue)",
-                                    "action": [
-                                        {
-                                            "removeItem": "",
-                                            "setColorIdentity": "",
-                                            "advanceQuestFlag": "",
-                                            "advanceMapFlag": "",
-                                            "setQuestFlag": {
-                                                "key": "exploreShand1",
-                                                "val": 2
-                                            },
-                                            "setMapFlag": {
-                                                "key": ""
-                                            },
-                                            "issueQuest": "",
-                                            "POIReference": ""
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    2
-                ]
-            },
-            {
-                "id": 4,
-                "name": "Search the bandit cave",
-                "description": "Search the bandit cave for the missing shipment and defeat all enemies inside.",
-                "objective": "Clear",
-                "POITags": [
-                    "Quest_BanditCave"
-                ],
-                "prologue": {
-                    "text": "The cave you are looking for is very well hidden, and you might have missed it entirely had you not known where to look. Of course, the pair of ruffians lifting the last two small crates off of a wagon and carrying them inside does help identify the entrance.",
-                    "options": [
-                        {
-                            "text": "As you approach, you get a better look at the wagon. There's nothing about it which indicates what it once carried, but the fresh bloodstains on the driver's seat hint that these goods weren't paid for.",
-                            "name": "(Continue)",
-                            "options": [
-                                {
-                                    "name": "(Continue)"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "epilogue": {},
-                "POIToken": "$(poi_3)",
-                "prerequisiteIDs": [
-                    3
-                ]
-            },
-            {
-                "id": 5,
-                "name": "Return to $(poi_1)",
-                "description": "Travel back to $(poi_1) to discuss the next steps.",
-                "objective": "Travel",
-                "prologue": {
-                    "text": "Silver. Regular, mundane, unsmithed chunks of silver ore. That's all you find in the majority of the crates stashed away in the cave. Not having the tools or knowledge to mint the weighty metal into currency, and knowing that someone still living may have a rightful claim to it, you leave it behind.",
-                    "options": [
-                        {
-                            "text": "And as you have no further leads on the much more valuable shipment you are looking for, you should return to $(poi_1) and report in.",
-                            "name": "(Continue)",
-                            "options": [
-                                {
-                                    "name": "(Continue)"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "epilogue": {
-                    "text": "After you explain what you found, and what you didn't find, Sir Donovan hands you a pouch of coins that are most certainly spendable. \"You didn't find anything, but that doesn't mean you put in no effort on my behalf.\" (+500 gold)",
-                    "action": [
-                        {
-                            "addGold": 500,
-                            "addMapReputation": 2,
-                            "POIReference": "$(poi_1)"
-                        }
-                    ],
-                    "options": [
-                        {
-                            "name": "(Continue)",
-                            "text": "Then he pulls out a map of a completely different area in a mountainous region to the southwest. \"We should go back a step, and make sure the shipment left the mines to begin with.\"",
-                            "options": [
-                                {
-                                    "action": [
-                                        {
-                                            "removeItem": "",
-                                            "setColorIdentity": "",
-                                            "advanceQuestFlag": "",
-                                            "advanceMapFlag": "",
-                                            "setQuestFlag": {
-                                                "key": ""
-                                            },
-                                            "setMapFlag": {
-                                                "key": ""
-                                            },
-                                            "issueQuest": "45",
-                                            "POIReference": "",
-                                            "addItem": "Sir Donovan's Amulet"
-                                        }
-                                    ],
-                                    "name": "(Continue)",
-                                    "text": "Sir Donovan continues, \"You need not return here with your findings unless escorting the caravan. While my venture ultimately depends on having these shards, I have preparations to make elsewhere. Use this amulet once you have more information and I will be in touch.\" He hands you a small piece of iron jewelry, after which you nod and depart.",
-                                    "options": [
-                                        {
-                                            "name": "(Continue)"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "POIToken": "$(poi_1)",
-                "prerequisiteIDs": [
-                    4
-                ]
-            }
-        ]
-    },
-    {
-        "id": 45,
-        "isTemplate": true,
-        "name": "What's Yours Is Mine",
-        "description": "Still hunting for the missing mana shard shipment, Sir Donovan sends you to the mines from which they originate.",
-        "offerDialog": {},
-        "prologue": {},
-        "epilogue": {},
-        "failureDialog": {},
-        "declinedDialog": {
-            "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
-            "options": [
-                {
-                    "name": "(Catching the not so subtle hint, you leave.)"
-                }
-            ]
-        },
-        "storyQuest": true,
-        "stages": [
-            {
-                "id": 1,
-                "name": "Go to the $(poi_1)",
-                "description": "Travel to the mountain biome to find the $(poi_2) in search of the missing shipment.",
-                "objective": "Travel",
-                "POITags": [
-                    "Quest_ShardMines"
-                ],
-                "allowInactivePOI": true,
-                "prologue": {
-                    "text": "Consulting your map, Sir Donovan's directions lead you into the mountains found to the southwest.",
-                    "action": [
-                        {
-                            "removeItem": "",
-                            "setColorIdentity": "",
-                            "advanceQuestFlag": "",
-                            "advanceMapFlag": "",
-                            "setQuestFlag": {
-                                "key": "exploreShand1",
-                                "val": 3
-                            },
-                            "setMapFlag": {
-                                "key": ""
-                            },
-                            "issueQuest": "",
-                            "POIReference": ""
-                        }
-                    ],
-                    "options": [
-                        {
-                            "name": "(Continue)"
-                        }
-                    ]
-                },
-                "epilogue": {}
-            },
-            {
-                "id": 2,
-                "name": "Defeat the $(enemy_2)",
-                "description": "Find and defeat the leader of the pirates in the $(poi_1).",
-                "mapFlag": "",
-                "mapFlagValue": 1,
-                "count1": 1,
-                "objective": "Defeat",
-                "worldMapOK": false,
-                "POITags": [
-                    "Quest_ShardMines"
-                ],
-                "allowInactivePOI": true,
-                "enemyTags": [
-                    "Captain"
-                ],
-                "prologue": {
-                    "text": "Sir Donovan's directions are very precise, and you find the mining operation without much trouble. There is, however, an obvious sign of trouble when you arrive.",
-                    "options": [
-                        {
-                            "name": "(Continue)",
-                            "text": "Specifically, the sign which once designated this as the $(poi_1) - it has been painted over with a crude copy of the skull and crossbones seen on the pirate flag that has been strapped to the top of the sign. Pirates.",
-                            "options": [
-                                {
-                                    "name": "(Continue)",
-                                    "text": "Your average pirate is probably just following orders long enough to find some grog or loot. But there's always a captain somewhere steering the ship, so to say...",
-                                    "options": [
-                                        {
-                                            "name": "(Continue)"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
-            },
-            {
-                "id": 3,
-                "name": "Exit the mines",
-                "description": "Exit the mines when you are ready to continue.",
-                "objective": "Leave",
-                "anyPOI": true,
-                "prologue": {
-                    "text": "The latest entries in the captain's logbook confirms what you had seen while working your way into the mine - rather than being priceless treasures, the crystals in this mine are now basically worthless.",
-                    "options": [
-                        {
-                            "name": "\"So much for making it rich on pirate treasure\"",
-                            "text": "There may be some less industrial scale treasure to be found among any of the remaining pirates, but when you're ready you should contact Sir Donovan using his talisman.",
-                            "action": [
-                                {
-                                    "setQuestFlag": {
-                                        "key": "Quest_ShardMines_Epilogue",
-                                        "val": 1
-                                    }
-                                }
-                            ],
-                            "options": [
-                                {
-                                    "name": "(Continue)"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "prerequisiteIDs": [
-                    2
-                ]
-            },
-            {
-                "id": 4,
-                "name": "Contact Sir Donovan",
-                "description": "Use Donovan's amulet to contact him.",
-                "mapFlag": "Quest_ShardMines_EpilogueComplete",
-                "mapFlagValue": 1,
-                "here": true,
-                "objective": "QuestFlag",
-                "prologue": {
-                    "text": "When you are ready, you should use the amulet he gave you to tell Sir Donovan about the pirates, and that they've been dealt with.",
-                    "options": [
-                        {
-                            "name": "(Continue)",
-                            "options": [
-                                {
-                                    "condition": [
-                                        {
-                                            "item": "Sir Donovan's Amulet",
-                                            "not": true
-                                        }
-                                    ],
-                                    "action": [
-                                        {
-                                            "addItem": "Sir Donovan's Amulet"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "epilogue": {},
-                "prerequisiteIDs": [
-                    3
-                ]
-            },
-            {
-                "id": 5,
-                "name": "Go to a town",
-                "description": "The urge from Sir Donovan's amulet persists. It doesn't control you, speak to you, or anything else like that. You simply know somehow that it is what he wants you to do - go to a town.",
-                "objective": "Travel",
-                "anyPOI": true,
-                "POITags": [
-                    "Town"
-                ],
-                "prologue": {},
-                "epilogue": {
-                    "text": "Within moments of walking in to town, a wiry young elf approaches you. Or at least he looks young, it's so hard to tell with elves. He briefly holds out an amulet identical to the one Donovan gave you, and beckons you to follow him to the inn.",
-                    "options": [
-                        {
-                            "name": "(Continue)",
-                            "action": [
-                                {
-                                    "removeItem": "",
-                                    "setColorIdentity": "",
-                                    "advanceQuestFlag": "",
-                                    "advanceMapFlag": "",
-                                    "setQuestFlag": {
-                                        "key": ""
-                                    },
-                                    "setMapFlag": {
-                                        "key": ""
-                                    },
-                                    "issueQuest": "46",
-                                    "POIReference": ""
-                                }
-                            ],
-							"text": "Taking a corner table at the inn, the elf leans forward on his elbows and studies you for a moment. \"Yeah, you're the one. The name's Acirxes. I work with Donovan.\"",
-								"options": [
-									{
-										"name": "(Continue)",
-										"text": "\"Seeing as you walked here, I take it you didn't find our shipment.\"",
-										"options": [
-											{
-												"name": "Explain to Acirxes about the state of the mine, the pirate crew you found holed up within it, and the expended mana shards.",
-												"text": "\"I hate when a good vein runs dry. Cidryl was loaded with crystals, and compared to other operations they were easy to get to. But when there's no mana left, there's no mana left.\" Acirxes pauses.",
-												"options": [
-													{
-														"name": "\"So what now?\"",
-														"text": "\"Standard 'Keep working for us' fee.\" He slides you a coin pouch of a familiar size. \"Give me a couple days to track down the boss and bring him up to speed. I'll meet you here again soon.\" (+500 gold)",
-														"action": [
-															{
-																"addGold": 500
-															}
-														],
-														"options": [
-															{
-																"name": "(Continue)"
-															}
-														]
-													}
-												]
-											}
-										]
-									}
-								]
-                        }
-                    ]
-                },
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    4
-                ]
-            }
-        ]
-    },
-    {
-        "id": 46,
-        "isTemplate": true,
-        "name": "Busy Work",
-        "description": "Having reported the state of matters in the shard mines to his contact, you await further word from Sir Donovan. Until then, you are free to take on other jobs.",
-        "offerDialog": {},
-        "prologue": {},
-        "epilogue": {
-            "text": "A slight whistle alerts you to Acirxes' presence. You're not entirely sure if he has impeccible timing or if he watched you complete your most recent job, but it appears that Sir Donovan has more work for you.",
-            "options": [
-                {
-                    "name": "(Continue)",
-                    "action": [
-                        {
-                            "removeItem": "",
-                            "setColorIdentity": "",
-                            "advanceQuestFlag": "",
-                            "advanceMapFlag": "",
-                            "setQuestFlag": {
-                                "key": ""
-                            },
-                            "setMapFlag": {
-                                "key": ""
-                            },
-                            "issueQuest": "47",
-                            "POIReference": ""
-                        }
-                    ]
-                }
-            ]
-        },
-        "failureDialog": {},
-        "declinedDialog": {
-            "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
-            "options": [
-                {
-                    "name": "(Catching the not so subtle hint, you leave.)"
-                }
-            ]
-        },
-        "storyQuest": true,
-        "stages": [
-            {
-                "id": 1,
-                "name": "Do Side Quests",
-                "description": "Complete 3 side quests while waiting for Acirxes to find you again",
-                "count1": 3,
-                "objective": "CompleteQuest",
-                "POITags": [
-                    "QuestSource"
-                ],
-                "allowInactivePOI": true,
-                "anyPOI": true,
-                "prologue": {},
-                "epilogue": {}
-            }
-        ]
-    },
-    {
-        "id": 47,
-        "isTemplate": true,
-        "name": "Check Out The Library",
-        "description": "Sir Donovan wants you to search $(poi_1) for information on the mechanics of summoning.",
-        "offerDialog": {},
-        "prologue": {},
-        "epilogue": {},
-        "failureDialog": {},
-        "declinedDialog": {
-            "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
-            "options": [
-                {
-                    "name": "(Catching the not so subtle hint, you leave.)"
-                }
-            ]
-        },
-        "storyQuest": true,
-        "stages": [
-            {
-                "id": 1,
-                "name": "Find $(poi_1)",
-                "description": "Follow Acirxes' directions to $(poi_1) in the island biome to the northeast.",
-                "objective": "Travel",
-                "POITags": [
-                    "Quest_LibraryOfVarsil"
-                ],
-                "allowInactivePOI": true,
-                "prologue": {
-                    "text": "Acirxes furrows his brow, which for a brief time makes his youthful appearance fade into maturity. \"Boss says you're no mere hedge wizard, so I presume you understand somewhat of what spells actually do.\"",
-                    "options": [
-                        {
-                            "name": "You wonder where this is going, but simply nod for the moment.",
-                            "text": "He continues, \"Well the boss wants to know more than he does about specific aspects of spells, and likely more than you or I know too. He wants you to go to $(poi_1) and secure any books or research on the actual mechanics behind summoning spells.\"",
-                            "options": [
-                                {
-                                    "name": "\"Consider it done.\"",
-                                    "text": "\"If you can handle that, it should be a short trip from there to $(poi_4) after. I've got some... 'buisiness' to take care of there. I'll meet you at the inn on the north end of the central peninsula.\"",
-                                    "action": [
-                                        {
-                                            "setQuestFlag": {
-                                                "key": "exploreShand1",
-                                                "val": 4
-                                            }
-                                        }
-                                    ]
-                                },
-                                {
-                                    "name": "\"Fine, but why send me?\"",
-                                    "text": "\"You are a clever one.\" Acirxes pauses before responding further in a carefully measured tone. \"Because one of my peers found the library. And another one found the library and her body. And a third one found all of them and escaped alive. It's not your average library.\"",
-                                    "options": [
-                                        {
-                                            "name": "\"No, apparently not.\"",
-                                            "text": "\"So that's why we're sending you. Meet me in $(poi_4) after. I've got some... 'buisiness' to take care of there and I'll add a personal reward if you bring me back the head of whoever's running the show at the library.\" He looks away before walking off. \"I owe that much to Gwen...\"",
-                                            "options": [
-                                                {
-                                                    "name": "(Continue)",
-                                                    "action": [
-                                                        {
-                                                            "setQuestFlag": {
-                                                                "key": "exploreShand1",
-                                                                "val": 4
-                                                            }
-                                                        },
-                                                        {
-                                                            "setQuestFlag": {
-                                                                "key": "libraryOfVarsilBonusAvailable",
-                                                                "val": 1
-                                                            }
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "epilogue": {}
-            },
-            {
-                "id": 2,
-                "name": "Locate The Research",
-                "description": "Search $(poi_1) for research about the mechanics of summoning spells",
-                "mapFlag": "foundLibraryOfVarsilResearch",
-                "mapFlagValue": 1,
-                "here": true,
-                "objective": "QuestFlag",
-                "prologue": {
-                    "text": "The structure before you is enormous, looking more like an ancient fortress than a library.",
-                    "options": [
-                        {
-                            "name": "(Continue)",
-                            "text": "A small group of scholars carrying books around the entrance seems to confirm the building's purpose, but something odd about their manerisms has you on edge as you approach.",
-                            "options": [
-                                {
-                                    "name": "(Continue)"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "epilogue": {},
-                "POIToken": "",
-                "prerequisiteIDs": [
-                    1
-                ]
-            },
-            {
-                "id": 3,
-                "name": "Leave",
-                "anyPOI": true,
-                "description": "Find your way back to the entrance once you are ready",
-                "objective": "Leave",
-                "prologue": {},
-                "epilogue": {},
-                "prerequisiteIDs": [
-                    2
-                ]
-            },
-            {
-                "id": 4,
-                "name": "Travel to $(poi_4)",
-                "description": "Deliver the research to $(poi_4), the largest settlement in the islands",
-                "objective": "Travel",
-                "POITags": [
-                    "Capital",
-                    "BiomeBlue"
-                ],
-                "prologue": {},
-                "epilogue": {
-                    "text": "\"Welcome to $(poi_4), a shining beacon of civilization.\" You had just entered the tavern and it takes you a moment to realize that the voice from over your shoulder is speaking to you.",
-                    "options": [
-                        {
-                            "name": "[/]But that's not Acirxes...[]",
-                            "text": "\"I take it you were expecting my associate.\" Sir Donovan leads you to a table before continuing. \"Acirxes is on leave, indefinitely. Welcomed to return to my service, but only once he has fully overcome the grief of Guinneverre's passing; another of my employees whom he had somewhat of a relationship with.\"",
-                            "options": [
-                                {
-                                    "condition": [
-                                        {
-                                            "checkQuestFlag": "defeatedLibraryOfVarsilBoss"
-                                        },
-                                        {
-                                            "checkQuestFlag": "libraryOfVarsilBonusAvailable"
-                                        }
-                                    ],
-                                    "name": "\"About that...\" You hand him the research before telling Donovan about the giant automaton at the top of the library.",
-                                    "text": "\"Yes, Acirxes was quite adamant that I hold on to this for you.\" He hands you a small and ornate spellbook.",
-                                    "options": [
-                                        {
-                                            "action": [
-                                                {
-                                                    "grantRewards": [
-                                                        {
-                                                            "type": "card",
-                                                            "count": 1,
-                                                            "colors": [
-                                                                "Black"
-                                                            ],
-                                                            "rarity": [
-                                                                "Rare",
-                                                                "Mythic Rare"
-                                                            ]
-                                                        },
-                                                        {
-                                                            "type": "card",
-                                                            "count": 1,
-                                                            "colors": [
-                                                                "Blue"
-                                                            ],
-                                                            "rarity": [
-                                                                "Rare",
-                                                                "Mythic Rare"
-                                                            ]
-                                                        },
-                                                        {
-                                                            "type": "card",
-                                                            "count": 1,
-                                                            "colors": [
-                                                                "Green"
-                                                            ],
-                                                            "rarity": [
-                                                                "Rare",
-                                                                "Mythic Rare"
-                                                            ]
-                                                        },
-                                                        {
-                                                            "type": "card",
-                                                            "count": 1,
-                                                            "colors": [
-                                                                "Red"
-                                                            ],
-                                                            "rarity": [
-                                                                "Rare",
-                                                                "Mythic Rare"
-                                                            ]
-                                                        },
-                                                        {
-                                                            "type": "card",
-                                                            "count": 1,
-                                                            "colors": [
-                                                                "White"
-                                                            ],
-                                                            "rarity": [
-                                                                "Rare",
-                                                                "Mythic Rare"
-                                                            ]
-                                                        },
-                                                        {
-                                                            "type": "card",
-                                                            "count": 1,
-                                                            "colorType": "Colorless",
-                                                            "rarity": [
-                                                                "Rare",
-                                                                "Mythic Rare"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "name": "(Continue)",
-                                            "text": "\"Now, about the golems. I'm curious if they are related to another incident.\" Donovan pilfers through his satchel for a moment before giving you a map and your latest wages (+1000 gold). \"A historian got quite a surprise recently at a dig site, and I would like to know if the two groups have a common source.\"",
-                                            "options": [
-                                                {
-                                                    "name": "(Continue)",
-                                                    "action": [
-                                                        {
-                                                            "addGold": 1000,
-                                                            "issueQuest": "48"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "condition": [
-                                        {
-                                            "checkQuestFlag": "defeatedLibraryOfVarsilBoss"
-                                        },
-                                        {
-                                            "checkQuestFlag": "libraryOfVarsilBonusAvailable",
-                                            "not": true
-                                        }
-                                    ],
-                                    "name": "\"About that...\" You hand him the research before telling Donovan about the giant automaton at the top of the library.",
-                                    "text": "\"I'm curious if this is related to another incident.\" Donovan pilfers through his satchel for a moment before giving you a map and your latest wages (+1000 gold). \"A historian got quite a surprise recently at a dig site, and I would like to know if the two groups have a common source.\"",
-                                    "options": [
-                                        {
-                                            "name": "(Continue)",
-                                            "action": [
-                                                {
-                                                    "addGold": 1000,
-                                                    "issueQuest": "48"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "condition": [
-                                        {
-                                            "checkQuestFlag": "defeatedLibraryOfVarsilBoss",
-                                            "not": true
-                                        }
-                                    ],
-                                    "name": "Hand him the research and tell him about the occupants of the library.",
-                                    "text": "\"I'm curious if this is related to another incident.\" Donovan pilfers through his satchel for a moment before giving you a map and your latest wages (+500 gold). \"A historian got quite a surprise recently at a dig site, and I would like to know if the two groups have a common source.\"",
-                                    "options": [
-                                        {
-                                            "name": "(Continue)",
-                                            "action": [
-                                                {
-                                                    "addGold": 500,
-                                                    "issueQuest": "48"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "prerequisiteIDs": [
-                    3
-                ]
-            }
-        ]
-    },
-    {
-        "id": 48,
-        "isTemplate": true,
-        "name": "The Dig Site",
-        "description": "Determine if the golems you found previously are connected to those at $(poi_1)",
-        "offerDialog": {},
-        "prologue": {},
-        "epilogue": {},
-        "failureDialog": {},
-        "declinedDialog": {
-            "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
-            "options": [
-                {
-                    "name": "(Catching the not so subtle hint, you leave.)"
-                }
-            ]
-        },
-        "storyQuest": true,
-        "stages": [
-            {
-                "id": 1,
-                "name": "Find $(poi_1)",
-                "description": "Follow Donovan's map to $(poi_1) in the wastelands.",
-                "objective": "Travel",
-                "POITags": [
-                    "Quest_DigSite"
-                ],
-                "allowInactivePOI": true,
-                "prologue": {
-                    "text": "Sir Donovan gives you a sense of deja vu as he hands you a map and another of his amulets. \"Explore the site. Look for signs that the two groups are connected or distinct. Use the amulet when you're done and we'll find somewhere to meet.\"",
-                    "options": [
-                        {
-                            "name": "\"Understood.\"",
-                            "action": [
-                                {
-                                    "setQuestFlag": {
-                                        "key": "exploreShand1",
-                                        "val": 5
-                                    }
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "epilogue": {}
-            },
-            {
-                "id": 2,
-                "name": "Explore the site",
-                "description": "Search $(poi_1) and compare the mechanized occupants with your previous encounter",
-                "objective": "Fetch",
-                "itemNames": [
-                    "Landscape Sketchbook"
-                ],
-                "prologue": {
-                    "text": "Approaching the site from the south, your current path leads down into the freshly exposed entrance, now blocked by a metallic humanoid sentry.",
-                    "options": [
-                        {
-                            "name": "(Continue)",
-                            "text": "On your right stands a much newer structure which you presume serves as a habitation for the digging crew and the scholars who employ them.",
-                            "options": [
-                                {
-                                    "name": "(Continue)"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "epilogue": {},
-                "POIToken": "$(poi_1)",
-                "prerequisiteIDs": [
-                    1
-                ]
-            },
-            {
-                "id": 3,
-                "name": "Leave",
-                "description": "Find your way back to the entrance once you are ready",
-                "objective": "Leave",
-                "anyPOI": true,
-                "prologue": {},
-                "epilogue": {},
-                "prerequisiteIDs": [
-                    2
-                ]
-            },
-            {
-                "id": 4,
-                "name": "Contact Sir Donovan",
-                "description": "Use Donovan's talisman to contact him.",
-                "mapFlag": "exploreShand1",
-                "mapFlagValue": 7,
-                "objective": "QuestFlag",
-                "prologue": {
-                    "text": "When you are ready, you should use the amulet he gave you to contact Sir Donovan again.",
-                    "options": [
-                        {
-                            "name": "(Continue)",
-                            "action": [
-                                {
-                                    "setQuestFlag": {
-                                        "key": "exploreShand1",
-                                        "val": 6
-                                    }
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "epilogue": {
-                    "text": "Once again you get a feeling that you should go to a town. But it's a little more clear this time, and a particular name is on the tip of your tongue: $(poi_5). You should go there.",
-                    "options": [
-                        {
-                            "name": "(Continue)"
-                        }
-                    ]
-                },
-                "prerequisiteIDs": [
-                    3
-                ]
-            },
-            {
-                "id": 5,
-                "name": "Travel to $(poi_5)",
-                "description": "Deliver the research to $(poi_5), a wasteland town relatively far from $(poi_1)",
-                "objective": "Travel",
-                "count1": 70,
-                "count2": 10,
-                "POITags": [
-                    "Town",
-                    "BiomeColorless"
-                ],
-                "prologue": {},
-                "epilogue": {
-                    "text": "\"$(playername)?\" A middle aged woman approaches you in what passes for a town square here, slipping a small but very identifiable portrait of you into her cloak. \"We share's the bossman.\" As Acirxes did upon meeting you, she pulls her hand back out of her cloak to flash an amulet matching yours.",
-                    "options": [
-                        {
-                            "name": "You wonder to yourself where she got the portrait. [/]Who drew me, and when?[]",
-                            "text": "\"They calls me Viv. Those'n who knows me, it is.\"",
-                            "options": [
-                                {
-                                    "name": "\"That's quite an unusual accent you have.\"",
-                                    "text": "Viv shrugs. \"I says that evah-time one's of you blabs the samewise. And me jingle works samewise.\" To demonstrate her point, she shakes the usual coin pouch before tossing it to you. (+500 gold)\n\"So blabs it. Same metal men?\"",
-                                    "action": [
-                                        {
-                                            "addGold": 500
-                                        }
-                                    ],
-                                    "options": [
-                                        {
-                                            "name": "\"I don't think so.\"",
-                                            "text": "\"Thinks he do. Knows?\" For all the brevity of Viv's reply, it takes you a moment to realize she's asking if you're sure.",
-                                            "options": [
-                                                {
-                                                    "name": "\"Some of them were similar. More similar than most golems I've seen in the wild. But no big one this time. And there were several that were like nothing I saw in the library.\"",
-                                                    "text": "\"No big one this time.\" Viv gives a very passing echo of your words, even coming close to matching your natural voice. \"Bossman due certain a'love that one. Mayhap sends me back for that jingle bag next.\"",
-                                                    "options": [
-                                                        {
-                                                            "name": "\"Look... I'm not an expert on antique golem provenance.\"",
-                                                            "text": "\"Tell bossman that one instead, bigger laugh to hear.\" Before you can respond to that, she moves to walk off. \"Gets you the local jingle. Viv to bring bossman's words.\"",
-                                                            "options": [
-                                                                {
-                                                                    "name": "(Continue)",
-                                                                    "action": [
-                                                                        {
-                                                                            "issueQuest": "49"
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "name": "\"Yes, some of them were. Like a different builder with the same parts and hearing the same description, but distinct from the other's design.\"",
-                                                    "text": "Viv gives a knowing nod, as if she appreciates that description. \"Gets you the local jingle. Viv'll bring bossman's words.\" She then turns to leave.",
-                                                    "options": [
-                                                        {
-                                                            "name": "(Continue)",
-                                                            "action": [
-                                                                {
-                                                                    "issueQuest": "49"
-                                                                }
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "name": "\"I think so.\"",
-                                            "text": "\"Thinks he do. Knows?\" For all the brevity of Viv's reply, thanks to her unusual way of speaking it takes you a moment to realize she's asking if you're sure.",
-                                            "options": [
-                                                {
-                                                    "name": "\"Some of them were similar. More similar than most golems I've seen in the wild. But no big one this time. And there were several that were like nothing I saw in the library.\"",
-                                                    "text": "\"No big one this time.\" Viv gives a very passing echo of your words, even coming close to matching your natural voice. \"Bossman due certain a'love that one. Mayhap sends me back after that jingle bag.\"",
-                                                    "options": [
-                                                        {
-                                                            "name": "\"Look... I'm not an expert on antique golem provenance.\"",
-                                                            "text": "\"Tell bossman that one instead, bigger laugh to hear.\" Before you can respond to that, she moves to walk off. \"Gets you the local jingle. Viv to bring bossman's words.\"",
-                                                            "options": [
-                                                                {
-                                                                    "name": "(Continue)",
-                                                                    "action": [
-                                                                        {
-                                                                            "issueQuest": "49"
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "name": "\"Like a different builder copying the same example, but both doing it very well.\"",
-                                                    "text": "Viv gives a knowing nod, as if she appreciates that description. \"Gets you the local jingle. Viv'll bring bossman's words.\" She then turns to leave.",
-                                                    "options": [
-                                                        {
-                                                            "name": "(Continue)",
-                                                            "action": [
-                                                                {
-                                                                    "issueQuest": "49"
-                                                                }
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "name": "\"Donovan wanted to know if these two groups of automatons matched. I think don't think so. Similar, but different.\"",
-                                    "text": "\"Similar, but different.\" Viv gives a very passing echo of your words, even coming close to matching your natural voice. \"Makes samewise sense out Viv's mouth and yours, none. Mayhap bossman gets the words, or mayhap he sends me back after that jingle bag.\"",
-                                    "options": [
-                                        {
-                                            "name": "\"Look... I'm not an expert on antique golem provenance.\"",
-                                            "text": "\"Tell bossman that one instead, bigger laugh to hear.\" Before you can respond to that, she moves to walk off. \"Gets you the local jingle. Viv to bring bossman's words.\"",
-                                            "options": [
-                                                {
-                                                    "name": "(Continue)",
-                                                    "action": [
-                                                        {
-                                                            "issueQuest": "49"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "name": "\"Like a different builder with the same parts and hearing the same description, but distinct from the other's design.\"",
-                                            "text": "Viv suddenly gives a knowing nod, as if she appreciates that description more than the first. \"Gets you the local jingle. Viv to bring bossman's words.\" She then turns to leave.",
-                                            "options": [
-                                                {
-                                                    "name": "(Continue)",
-                                                    "action": [
-                                                        {
-                                                            "issueQuest": "49"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "name": "\"Donovan wanted to know if these two groups of automatons matched. I think so. Mostly at least.\"",
-                                    "text": "\"Thinks he do. Knows?\" For all the brevity of Viv's reply, it takes you a moment to realize she's asking if you're sure.",
-                                    "options": [
-                                        {
-                                            "name": "\"Some were very similar. More similar than most golems I've seen in the wild. No big one this time though, and several that I'd never seen anything like before.\"",
-                                            "text": "\"No big one this time.\" Viv gives a very passing echo of your words, even coming close to matching your natural voice. \"Bossman due certain a'love that one. Mayhap sends me back after that jingle bag.\"",
-                                            "options": [
-                                                {
-                                                    "name": "\"Look... I'm not an expert on antique golem provenance.\"",
-                                                    "text": "\"Tell bossman that one instead, bigger laugh to hear.\" Before you can respond to that, she moves to walk off. \"Gets you the local jingle. Viv to bring bossman's words.\"",
-                                                    "options": [
-                                                        {
-                                                            "name": "(Continue)",
-                                                            "action": [
-                                                                {
-                                                                    "issueQuest": "49"
-                                                                }
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "name": "\"Like a different builder copying the same example, and both doing it very well.\"",
-                                            "text": "Viv gives a knowing nod, as if she appreciates that description. \"Gets you the local jingle. Viv to bring bossman's words.\" She then turns to leave.",
-                                            "options": [
-                                                {
-                                                    "name": "(Continue)",
-                                                    "action": [
-                                                        {
-                                                            "issueQuest": "49"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "prerequisiteIDs": [
-                    4
-                ]
-            }
-        ]
-    },
-    {
-        "id": 49,
-        "isTemplate": true,
-        "name": "Busy Work 2",
-        "description": "You await further word from Sir Donovan via your new contact, Viv. Until then, you are free to take on other jobs.",
-        "offerDialog": {},
-        "prologue": {},
-        "epilogue": {},
-        "failureDialog": {},
-        "declinedDialog": {
-            "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
-            "options": [
-                {
-                    "name": "(Catching the not so subtle hint, you leave.)"
-                }
-            ]
-        },
-        "storyQuest": true,
-        "stages": [
-            {
-                "id": 1,
-                "name": "Do Side Quests",
-                "description": "Complete 3 side quests while waiting for Viv to find you again",
-                "count1": 3,
-                "objective": "CompleteQuest",
-                "POITags": [
-                    "QuestSource"
-                ],
-                "anyPOI": true,
-                "prologue": {},
-                "epilogue": {}
-            },
-            {
-                "id": 2,
-                "name": "Wait for Viv",
-                "description": "Give Viv more time to contact you.",
-                "count3": 3,
-                "objective": "Travel",
-                "anyPOI": true,
-                "POITags": [
-                    "QuestSource"
-                ],
-                "prologue": {
-                    "text": "No word from or sign of Viv yet, but you should expect to hear from her soon.",
-                    "options": [
-                        {
-                            "name": "(Continue)"
-                        }
-                    ]
-                },
-                "epilogue": {
-                    "text": "As you walk in to town, a familiar cloaked figure is waiting and watching for you.",
-                    "options": [
-                        {
-                            "name": "(Continue)"
-                        }
-                    ],
-                    "action": [
-                        {
-                            "removeItem": "",
-                            "setColorIdentity": "",
-                            "advanceQuestFlag": "",
-                            "advanceMapFlag": "",
-                            "setQuestFlag": {
-                                "key": ""
-                            },
-                            "setMapFlag": {
-                                "key": ""
-                            },
-                            "issueQuest": "50",
-                            "POIReference": ""
-                        }
-                    ]
-                },
-                "prerequisiteIDs": [
-                    1
-                ]
-            }
-        ]
-    },
-    {
-        "id": 50,
-        "isTemplate": true,
-        "name": "Welcome To The Jungle",
-        "description": "Search the Primal Jungle for an artifact referenced in the research from The Library of Varsil",
-        "offerDialog": {},
-        "prologue": {
-            "text": "You have and take the opportunity to speak to Viv before she appears to notice you.",
-            "action": [
-                {
-                    "setQuestFlag": {
-                        "key": "exploreShand1",
-                        "val": 6
-                    }
-                }
-            ],
-            "options": [
-                {
-                    "name": "\"There you are, Viv.\"",
-                    "text": "Sir Donovan's voice replies to you from under her cloak. \"$(playername) will have to wait a little longer, I need you to fetch those materials for the next batch right now.\" Viv drops her hood and her imitation of your employer. \"Tinker he does, things he needs.\" Viv then shrugs. \"Viv focus for jingle he give samewise you take.\"",
-                    "options": [
-                        {
-                            "name": "\"So what now?\"",
-                            "text": "\"Things bossman needs [i]again[].\" She emphasizes the word in a way that indicates it's your turn to fetch something. \"Things told in samewise books you gave.\" You receive another map, another amulet, and a short note. Viv summarily dismisses you by walking away before you can ask questions or read the note.",
-                            "options": [
-                                {
-                                    "name": "Continue"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "Remain silent",
-                            "text": "\"Bossman needs things [i]again[].\" It's difficult to tell with her, but there might have been a touch of amusement in her emphasis. \"Things told in samewise books you gave.\" You receive another map, another amulet, and a short note. Viv summarily dismisses you by walking away before you can ask questions or read the note.",
-                            "options": [
-                                {
-                                    "name": "Continue"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "name": "\"I was beginning to worry I was out of a job.\"",
-                    "text": "Sir Donovan's voice replies to you from under her cloak. \"$(playername) will have to wait a little longer, I need you to fetch those materials for the next batch right now.\" Viv drops her hood and her imitation of your employer. \"Tinker he does, things he needs.\" Viv then shrugs. \"Viv focus for jingle he give samewise you take.\"",
-                    "options": [
-                        {
-                            "name": "\"So what now?\"",
-                            "text": "\"Things bossman needs [i]again[].\" She emphasizes the word in a way that indicates it's your turn to fetch something. \"Things told in samewise books you gave.\" You receive another map, another amulet, and a short note. Viv summarily dismisses you by walking away before you can ask questions or read the note.",
-                            "options": [
-                                {
-                                    "name": "Continue"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "Remain silent",
-                            "text": "\"Bossman needs things [i]again[].\" It's difficult to tell with her, but there might have been a touch of amusement in her emphasis. \"Things told in samewise books you gave.\" You receive another map, another amulet, and a short note. Viv summarily dismisses you by walking away before you can ask questions or read the note.",
-                            "options": [
-                                {
-                                    "name": "Continue"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "epilogue": {},
-        "failureDialog": {},
-        "declinedDialog": {
-            "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
-            "options": [
-                {
-                    "name": "(Catching the not so subtle hint, you leave.)"
-                }
-            ]
-        },
-        "storyQuest": true,
-        "stages": [
-            {
-                "id": 1,
-                "name": "Find The Primal Jungle",
-                "description": "Follow the given map to the area Sir Donovan suggested you search",
-                "objective": "Travel",
-                "POITags": [
-                    "Quest_PrimalJungle"
-                ],
-                "allowInactivePOI": true,
-                "prologue": {},
-                "epilogue": {}
-            },
-            {
-                "id": 2,
-                "mapFlag": "SearchedForArtifact",
-                "mapFlagValue": 1,
-                "objective": "MapFlag",
-                "name": "Search for the artifact",
-                "description": "Sir Donovan suspects that some form of magic staff can be found in this area, and he wants you to retrieve it.",
-                "POITags": [
-                    "Quest_PrimalJungle"
-                ],
-                "allowInactivePOI": true,
-                "prologue": {},
-                "epilogue": {
-                    "text": "Along with the other items in the treasure chest you find a staff that matches the rough description from Donovan's note. Or at least it would if it hadn't been broken into pieces",
-                    "options": [
-                        {
-                            "name": "Gather up the pieces",
-                            "text": "You technically weren't asked to bring it back in one piece. Hopefully Sir Donovan will still want it.",
-                            "options": [
-                                {
-                                    "name": "(Continue)"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "prerequisiteIDs": [
-                    1
-                ]
-            },
-            {
-                "id": 3,
-                "name": "Return to $(poi_3)",
-                "description": "Find Viv again in $(poi_3) to report what you found, and what you didn't.",
-                "objective": "Travel",
-                "here": true,
-                "prologue": {},
-                "epilogue": {
-                    "text": "Viv frowns at you after listening to your explanation. \"Jingle bag to wait, staff already jingle. Very bad.\"",
-                    "options": [
-                        {
-                            "name": "\"You don't think Sir Donovan wants it anyway?\"",
-                            "text": "She shakes her head emphatically. \"We must make it new. I have a fix.\" She retrieves a pen and paper to scrawl a much rougher map than usual on short notice. \"Flower grows in cave here, scarlet. You must bring it here.\"",
-                            "options": [
-                                {
-                                    "name": "\"Scarlet flower, grows in the cave. Got it.\"",
-                                    "text": "\"...and smart wizard would take coat.\"",
-                                    "options": [
-                                        {
-                                            "name": "continue",
-                                            "action": [
-                                                {
-                                                    "setQuestFlag": {
-                                                        "key": "exploreShand1",
-                                                        "val": 7
-                                                    },
-                                                    "issueQuest": 51
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "prerequisiteIDs": [
-                    2
-                ]
-            }
-        ]
-    },
-    {
-        "id": 51,
-        "isTemplate": true,
-        "name": "Flower Fetching",
-        "description": "Bring Viv a flower from Frostbitten Cavern",
-        "offerDialog": {},
-        "prologue": {},
-        "epilogue": {},
-        "failureDialog": {},
-        "declinedDialog": {
-            "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
-            "options": [
-                {
-                    "name": "(Catching the not so subtle hint, you leave.)"
-                }
-            ]
-        },
-        "storyQuest": true,
-        "stages": [
-            {
-                "id": 1,
-                "name": "Find $(poi_1)",
-                "description": "Viv's crude map shows the way to $(poi_1) in the $(biome_1) biome",
-                "objective": "Travel",
-                "POITags": [
-                    "Quest_FrostbittenCavern"
-                ],
-                "allowInactivePOI": true,
-                "prologue": {},
-                "epilogue": {}
-            },
-            {
-                "id": 2,
-                "mapFlag": "hasAFlower",
-                "mapFlagValue": 1,
-                "objective": "MapFlag",
-                "name": "Retrieve the flower",
-                "description": "Viv said the flower would be located inside a cave",
-                "POITags": [
-                    "Quest_FrostbittenCavern"
-                ],
-                "allowInactivePOI": true,
-                "prologue": {},
-                "epilogue": {},
-                "prerequisiteIDs": [
-                    1
-                ]
-            },
-            {
-                "id": 3,
-                "name": "Return to $(poi_3)",
-                "description": "Bring the flower back to Viv in $(poi_3).",
-                "objective": "Travel",
-                "here": true,
-                "prologue": {},
-                "epilogue": {
-                    "text": "You find Viv right where you had agreed to meet, and Sir Donovan is there as well. He is staring intently at the newly repaired staff as Viv directs her gaze to you.",
-                    "options": [
-                        {
-                            "name": "You interrupt Donovan's inspection. \"So what does the staff do?\"",
-                            "text": "\"Nothing, not yet at least. Perhaps it will eventually.\" He runs his left hand across an engraving on the staff as if trying to draw out its secrets. \"But I believe we have something else to discuss, something potentially even more important than my research.\"",
-                            "options": [
-                                {
-                                    "name": "\"I'm listening.\"",
-                                    "text": "\"You've proven yourself to be reliable enough to my organization that I feel I can share its nature, if you have not already surmised it. Put bluntly, my associates and I make our living through the acquisition of information, the discreet sale of it, and occasionally, the role you have been most involved with, its direct application.\"",
-                                    "options": [
-                                        {
-                                            "name": "(Continue)",
-                                            "text": "\"It is the nature of our trade that more information is available to me than can be acted upon, especially in a timely manner. My research is an attempt to find ways to communicate more rapidly, and give more opportunities to act. Often now we must make decisions based on incomplete knowledge, and incomplete knowledge is all that I can offer you now.\"",
-                                            "options": [
-                                                {
-                                                    "name": "(Continue)",
-                                                    "text": "\"We had been monitoring the activities of several previously unknown wizards, they appeared to have begun working together toward some unknown greater goal, with an impressive degree of effectiveness to their individual actions.\"",
-                                                    "options": [
-                                                        {
-                                                            "name": "(Continue)",
-                                                            "text": "\"Several weeks ago, however, the group was quickly and methodically silenced, presumed killed, by a second group. But now it has been confirmed that all five of them were taken alive, and my network has determined where we believe they are being held.\"",
-                                                            "options": [
-                                                                {
-                                                                    "name": "\"So, this is the part where I do the 'direct application' thing, right?\"",
-                                                                    "text": "Donovan gives a hearty, if solemn, chuckle. \"Based on what I have seen of your work, I believe you to be capable of it. But this is not something I am asking of you. More that it is something I am offering to you.\"",
-                                                                    "options": [
-                                                                        {
-                                                                            "name": "\"I'm not sure that I follow your meaning.\"",
-                                                                            "text": "\"The efficiency you have shown in your work for me rivals what we had seen from the captured mages. I believe that if you were to free them, you could make some new and powerful allies. And taking on their captors now may mean that you find yourself in a conflict that would be forthcoming anyway, but on your terms and timing rather than theirs.\"",
-                                                                            "options": [
-                                                                                {
-                                                                                    "name": "\"I don't believe that I'm ready for this kind of confrontation.\" (Decline Quest)",
-                                                                                    "text": "\"Then hold on to one of my amulets. Use it to contact us if you change your mind.\"",
-                                                                                    "options": [
-                                                                                        {
-                                                                                            "name": "Understood. And thank you."
-                                                                                        }
-                                                                                    ]
-                                                                                },
-                                                                                {
-                                                                                    "name": "\"Adventure calls. Who am I to say no?\" (Accept Quest)",
-                                                                                    "action": [
-                                                                                        {
-                                                                                            "issueQuest": "52",
-                                                                                            "setQuestFlag": {
-                                                                                                "key": "exploreShand1",
-                                                                                                "val": 8
-                                                                                            }
-                                                                                        }
-                                                                                    ]
-                                                                                }
-                                                                            ]
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "name": "Give her both flowers",
-                            "condition": [
-                                {
-                                    "checkQuestFlag": "violetFlowerForViv"
-                                },
-                                {
-                                    "checkQuestFlag": "scarletFlowerForViv"
-                                }
-                            ],
-                            "text": "Viv has a thankful look, but you note what might be a twinge of disappointment underneath it. \"Fix was gentle. Unexpectedly. Not to need those now.\" Donovan then clears his throat, redirecting your attention.",
-                            "options": [
-                                {
-                                    "name": "\"So what does the staff do?\"",
-                                    "text": "\"Nothing, not yet at least. Perhaps it will eventually.\" He runs his left hand across an engraving on the staff as if trying to draw out its secrets. \"But I believe we have something else to discuss, something potentially even more important than my research.\"",
-                                    "options": [
-                                        {
-                                            "name": "\"I'm listening.\"",
-                                            "text": "\"You've proven yourself to be reliable enough to my organization that I feel I can share its nature, if you have not already surmised it. Put bluntly, my associates and I make our living through the acquisition of information, the discreet sale of it, and occasionally, the role you have been most involved with, its direct application.\"",
-                                            "options": [
-                                                {
-                                                    "name": "(Continue)",
-                                                    "text": "\"It is the nature of our trade that more information is available to me than can be acted upon, especially in a timely manner. My research is an attempt to find ways to communicate more rapidly, and give more opportunities to act. Often now we must make decisions based on incomplete knowledge, and incomplete knowledge is all that I can offer you now.\"",
-                                                    "options": [
-                                                        {
-                                                            "name": "(Continue)",
-                                                            "text": "\"We had been monitoring the activities of several previously unknown wizards, they appeared to have begun working together toward some unknown greater goal, with an impressive degree of effectiveness to their individual actions.\"",
-                                                            "options": [
-                                                                {
-                                                                    "name": "(Continue)",
-                                                                    "text": "\"Several weeks ago, however, the group was quickly and methodically silenced, presumed killed, by a second group. But now it has been confirmed that all five of them were taken alive, and my network has determined where we believe they are being held.\"",
-                                                                    "options": [
-                                                                        {
-                                                                            "name": "\"So, this is the part where I do the 'direct application' thing, right?\"",
-                                                                            "text": "Donovan gives a hearty, if solemn, chuckle. \"Based on what I have seen of your work, I believe you to be capable of it. But this is not something I am asking of you. More that it is something I am offering to you.\"",
-                                                                            "options": [
-                                                                                {
-                                                                                    "name": "\"I'm not sure that I follow your meaning.\"",
-                                                                                    "text": "\"The efficiency you have shown in your work for me rivals what we had seen from the captured mages. I believe that if you were to free them, you could make some new and powerful allies. And taking on their captors now may mean that you find yourself in a conflict that would be forthcoming anyway, but on your terms and timing rather than theirs.\"",
-                                                                                    "options": [
-                                                                                        {
-                                                                                            "name": "\"I don't believe that I'm ready for this kind of confrontation.\" (Decline Quest)",
-                                                                                            "text": "\"Then hold on to one of my amulets. Use it to contact us if you change your mind.\"",
-                                                                                            "options": [
-                                                                                                {
-                                                                                                    "name": "Understood. And thank you."
-                                                                                                }
-                                                                                            ]
-                                                                                        },
-                                                                                        {
-                                                                                            "name": "\"Adventure calls. Who am I to say no?\" (Accept Quest)",
-                                                                                            "action": [
-                                                                                                {
-                                                                                                    "issueQuest": "52",
-                                                                                                    "setQuestFlag": {
-                                                                                                        "key": "exploreShand1",
-                                                                                                        "val": 8
-                                                                                                    }
-                                                                                                }
-                                                                                            ]
-                                                                                        }
-                                                                                    ]
-                                                                                }
-                                                                            ]
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "name": "Give her the violet flower",
-                            "condition": [
-                                {
-                                    "checkQuestFlag": "violetFlowerForViv"
-                                }
-                            ],
-                            "text": "Viv shakes her head. \"Headstrong adventurers... Not right. But we find that the flower had no need.\" Donovan then clears his throat, redirecting your attention.",
-                            "action": [
-                                {
-                                    "setQuestFlag": {
-                                        "key": "violetFlowerForViv",
-                                        "val": 2
-                                    }
-                                }
-                            ],
-                            "options": [
-                                {
-                                    "name": "\"So what does the staff do?\"",
-                                    "text": "\"Nothing, not yet at least. Perhaps it will eventually.\" He runs his left hand across an engraving on the staff as if trying to draw out its secrets. \"But I believe we have something else to discuss, something potentially even more important than my research.\"",
-                                    "options": [
-                                        {
-                                            "name": "\"I'm listening.\"",
-                                            "text": "\"You've proven yourself to be reliable enough to my organization that I feel I can share its nature, if you have not already surmised it. Put bluntly, my associates and I make our living through the acquisition of information, the discreet sale of it, and occasionally, the role you have been most involved with, its direct application.\"",
-                                            "options": [
-                                                {
-                                                    "name": "(Continue)",
-                                                    "text": "\"It is the nature of our trade that more information is available to me than can be acted upon, especially in a timely manner. My research is an attempt to find ways to communicate more rapidly, and give more opportunities to act. Often now we must make decisions based on incomplete knowledge, and incomplete knowledge is all that I can offer you now.\"",
-                                                    "options": [
-                                                        {
-                                                            "name": "(Continue)",
-                                                            "text": "\"We had been monitoring the activities of several previously unknown wizards, they appeared to have begun working together toward some unknown greater goal, with an impressive degree of effectiveness to their individual actions.\"",
-                                                            "options": [
-                                                                {
-                                                                    "name": "(Continue)",
-                                                                    "text": "\"Several weeks ago, however, the group was quickly and methodically silenced, presumed killed, by a second group. But now it has been confirmed that all five of them were taken alive, and my network has determined where we believe they are being held.\"",
-                                                                    "options": [
-                                                                        {
-                                                                            "name": "\"So, this is the part where I do the 'direct application' thing, right?\"",
-                                                                            "text": "Donovan gives a hearty, if solemn, chuckle. \"Based on what I have seen of your work, I believe you to be capable of it. But this is not something I am asking of you. More that it is something I am offering to you.\"",
-                                                                            "options": [
-                                                                                {
-                                                                                    "name": "\"I'm not sure that I follow your meaning.\"",
-                                                                                    "text": "\"The efficiency you have shown in your work for me rivals what we had seen from the captured mages. I believe that if you were to free them, you could make some new and powerful allies. And taking on their captors now may mean that you find yourself in a conflict that would be forthcoming anyway, but on your terms and timing rather than theirs.\"",
-                                                                                    "options": [
-                                                                                        {
-                                                                                            "name": "\"I don't believe that I'm ready for this kind of confrontation.\" (Decline Quest)",
-                                                                                            "text": "\"Then hold on to one of my amulets. Use it to contact us if you change your mind.\"",
-                                                                                            "options": [
-                                                                                                {
-                                                                                                    "name": "Understood. And thank you."
-                                                                                                }
-                                                                                            ]
-                                                                                        },
-                                                                                        {
-                                                                                            "name": "\"Adventure calls. Who am I to say no?\" (Accept Quest)",
-                                                                                            "action": [
-                                                                                                {
-                                                                                                    "issueQuest": "52",
-                                                                                                    "setQuestFlag": {
-                                                                                                        "key": "exploreShand1",
-                                                                                                        "val": 8
-                                                                                                    }
-                                                                                                }
-                                                                                            ]
-                                                                                        }
-                                                                                    ]
-                                                                                }
-                                                                            ]
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "name": "Give her the crimson flower",
-                            "condition": [
-                                {
-                                    "checkQuestFlag": "scarletFlowerForViv"
-                                }
-                            ],
-                            "text": "Viv smiles and takes the flower, tucking it behind her ear. \"[i]Jingle[] accepted. The bloom was not for the fix.\" Donovan then clears his throat, redirecting your attention.",
-                            "action": [
-                                {
-                                    "setQuestFlag": {
-                                        "key": "scarletFlowerForViv",
-                                        "val": 2
-                                    }
-                                }
-                            ],
-                            "options": [
-                                {
-                                    "name": "\"So what does the staff do?\"",
-                                    "text": "\"Nothing, not yet at least. Perhaps it will eventually.\" He runs his left hand across an engraving on the staff as if trying to draw out its secrets. \"But I believe we have something else to discuss, something potentially even more important than my research.\"",
-                                    "options": [
-                                        {
-                                            "name": "\"I'm listening.\"",
-                                            "text": "\"You've proven yourself to be reliable enough to my organization that I feel I can share its nature, if you have not already surmised it. Put bluntly, my associates and I make our living through the acquisition of information, the discreet sale of it, and occasionally, the role you have been most involved with, its direct application.\"",
-                                            "options": [
-                                                {
-                                                    "name": "(Continue)",
-                                                    "text": "\"It is the nature of our trade that more information is available to me than can be acted upon, especially in a timely manner. My research is an attempt to find ways to communicate more rapidly, and give more opportunities to act. Often now we must make decisions based on incomplete knowledge, and incomplete knowledge is all that I can offer you now.\"",
-                                                    "options": [
-                                                        {
-                                                            "name": "(Continue)",
-                                                            "text": "\"We had been monitoring the activities of several previously unknown wizards, they appeared to have begun working together toward some unknown greater goal, with an impressive degree of effectiveness to their individual actions.\"",
-                                                            "options": [
-                                                                {
-                                                                    "name": "(Continue)",
-                                                                    "text": "\"Several weeks ago, however, the group was quickly and methodically silenced, presumed killed, by a second group. But now it has been confirmed that all five of them were taken alive, and my network has determined where we believe they are being held.\"",
-                                                                    "options": [
-                                                                        {
-                                                                            "name": "\"So, this is the part where I do the 'direct application' thing, right?\"",
-                                                                            "text": "Donovan gives a hearty, if solemn, chuckle. \"Based on what I have seen of your work, I believe you to be capable of it. But this is not something I am asking of you. More that it is something I am offering to you.\"",
-                                                                            "options": [
-                                                                                {
-                                                                                    "name": "\"I'm not sure that I follow your meaning.\"",
-                                                                                    "text": "\"The efficiency you have shown in your work for me rivals what we had seen from the captured mages. I believe that if you were to free them, you could make some new and powerful allies. And taking on their captors now may mean that you find yourself in a conflict that would be forthcoming anyway, but on your terms and timing rather than theirs.\"",
-                                                                                    "options": [
-                                                                                        {
-                                                                                            "name": "\"I don't believe that I'm ready for this kind of confrontation.\" (Decline Quest)",
-                                                                                            "text": "\"Then hold on to one of my amulets. Use it to contact us if you change your mind.\"",
-                                                                                            "options": [
-                                                                                                {
-                                                                                                    "name": "Understood. And thank you."
-                                                                                                }
-                                                                                            ]
-                                                                                        },
-                                                                                        {
-                                                                                            "name": "\"Adventure calls. Who am I to say no?\" (Accept Quest)",
-                                                                                            "action": [
-                                                                                                {
-                                                                                                    "issueQuest": "52",
-                                                                                                    "setQuestFlag": {
-                                                                                                        "key": "exploreShand1",
-                                                                                                        "val": 8
-                                                                                                    }
-                                                                                                },
-                                                                                                {
-                                                                                                    "setQuestFlag": {
-                                                                                                        "key": "mainQuest",
-                                                                                                        "val": 2
-                                                                                                    }
-                                                                                                }
-                                                                                            ]
-                                                                                        }
-                                                                                    ]
-                                                                                }
-                                                                            ]
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "prerequisiteIDs": [
-                    2
-                ]
-            }
-        ]
-    },
-    {
-        "id": 52,
-        "isTemplate": true,
-        "name": "The Enemy of My Enemy...",
-        "description": "Sir Donovan has given you a set of five locations where he believes that powerful wizards are being held.",
-        "offerDialog": {},
-        "prologue": {
-            "text": "Good luck",
-            "action": [
-                {
-                    "setQuestFlag": {
-                        "key": "mainQuest",
-                        "val": 2
-                    }
-                }
-            ],
-            "options": [
-                {
-                    "name": "(Continue)"
-                }
-            ]
-        },
-        "epilogue": {},
-        "failureDialog": {},
-        "declinedDialog": {
-            "text": "Come back tomorrow and perhaps I'll have something that you'll actually be willing to do.",
-            "options": [
-                {
-                    "name": "(Catching the not so subtle hint, you leave.)"
-                }
-            ]
-        },
-        "storyQuest": true,
-        "stages": [
-            {
-                "id": 1,
-                "name": "Find the Black Castle",
-                "description": "Find the Black Castle in the Swamp Biome",
-                "count1": 1,
-                "objective": "Travel",
-                "POITags": [
-                    "BiomeBlack",
-                    "Chapter1Boss"
-                ],
-                "allowInactivePOI": true,
-                "prologue": {},
-                "epilogue": {}
-            },
-            {
-                "id": 2,
-                "name": "Find the Blue Castle",
-                "description": "Find the Blue Castle in the Island Biome",
-                "count1": 1,
-                "objective": "Travel",
-                "POITags": [
-                    "BiomeBlue",
-                    "Chapter1Boss"
-                ],
-                "allowInactivePOI": true,
-                "prologue": {},
-                "epilogue": {}
-            },
-            {
-                "id": 3,
-                "name": "Find the Green Castle",
-                "description": "Find the Green Castle in the Forest Biome",
-                "count1": 1,
-                "objective": "Travel",
-                "POITags": [
-                    "BiomeGreen",
-                    "Chapter1Boss"
-                ],
-                "allowInactivePOI": true,
-                "prologue": {},
-                "epilogue": {}
-            },
-            {
-                "id": 4,
-                "name": "Find the Red Castle",
-                "description": "Find the Red Castle in the Mountain Biome",
-                "count1": 1,
-                "objective": "Travel",
-                "POITags": [
-                    "BiomeRed",
-                    "Chapter1Boss"
-                ],
-                "allowInactivePOI": true,
-                "prologue": {},
-                "epilogue": {}
-            },
-            {
-                "id": 5,
-                "name": "Find the White Castle",
-                "description": "Find the White Castle in the Plains Biome",
-                "count1": 1,
-                "objective": "Travel",
-                "POITags": [
-                    "BiomeWhite",
-                    "Chapter1Boss"
-                ],
-                "allowInactivePOI": true,
-                "prologue": {},
-                "epilogue": {}
-            },
-            {
-                "id": 6,
-                "name": "Rescue the Black Captive",
-                "description": "Free the wizard being held captive inside the Black Castle",
-                "objective": "QuestFlag",
-                "mapFlag": "Ch1BlackCastleComplete",
-                "POITags": [
-                    "BiomeBlack",
-                    "Chapter1Boss"
-                ],
-                "allowInactivePOI": true,
-                "prologue": {},
-                "epilogue": {},
-                "prerequisiteIDs": [
-                    1
-                ]
-            },
-            {
-                "id": 7,
-                "name": "Rescue the Blue Captive",
-                "description": "Free the wizard being held captive inside the Blue Castle",
-                "objective": "QuestFlag",
-                "mapFlag": "Ch1BlueCastleComplete",
-                "POITags": [
-                    "BiomeBlue",
-                    "Chapter1Boss"
-                ],
-                "allowInactivePOI": true,
-                "prologue": {},
-                "epilogue": {},
-                "prerequisiteIDs": [
-                    2
-                ]
-            },
-            {
-                "id": 8,
-                "name": "Rescue the Green Captive",
-                "description": "Free the wizard being held captive inside the Green Castle",
-                "objective": "QuestFlag",
-                "mapFlag": "Ch1GreenCastleComplete",
-                "POITags": [
-                    "BiomeGreen",
-                    "Chapter1Boss"
-                ],
-                "allowInactivePOI": true,
-                "prologue": {},
-                "epilogue": {},
-                "prerequisiteIDs": [
-                    3
-                ]
-            },
-            {
-                "id": 9,
-                "name": "Rescue the Red Captive",
-                "description": "Free the wizard being held captive inside the Red Castle",
-                "objective": "QuestFlag",
-                "mapFlag": "Ch1RedCastleComplete",
-                "mapFlagValue": 1,
-                "POITags": [
-                    "BiomeRed",
-                    "Chapter1Boss"
-                ],
-                "allowInactivePOI": true,
-                "prologue": {},
-                "epilogue": {},
-                "prerequisiteIDs": [
-                    4
-                ]
-            },
-            {
-                "id": 10,
-                "name": "Rescue the White Captive",
-                "description": "Free the wizard being held captive inside the White Castle",
-                "objective": "QuestFlag",
-                "mapFlag": "Ch1WhiteCastleComplete",
-                "POITags": [
-                    "BiomeWhite",
-                    "Chapter1Boss"
-                ],
-                "allowInactivePOI": true,
-                "prologue": {},
-                "epilogue": {},
-                "prerequisiteIDs": [
-                    5
-                ]
-            },
-            {
-                "id": 11,
-                "name": "Get Some Answers",
-                "description": "Return to the spawn point at the center of the wastes and speak to the mage there.",
-                "objective": "QuestFlag",
-                "mapFlag": "mainQuest",
-                "mapFlagValue": 3,
-                "POITags": [
-                    "Spawn"
-                ],
-                "prologue": {},
-                "epilogue": {},
-                "prerequisiteIDs": [
-                    6,
-                    7,
-                    8,
-                    9,
-                    10
-                ]
-            }
         ]
     }
 ]


### PR DESCRIPTION
Fixing some typos, grammatical errors, or missing text. Mostly in the quests.json but also a slight typo fix in the new-game screen for Chaos game play description.

Also seems to be applying automatic bracket formatting from notepad++ so that { and } are on equivalent horizontal space like in the rest of the system files.