### PR TITLE
Add Ravnica Remastered draft

### DIFF
--- a/forge-gui/res/blockdata/blocks.txt
+++ b/forge-gui/res/blockdata/blocks.txt
@@ -126,7 +126,7 @@ March of the Machine Jumpstart, -/2/MOM, Meta-Choose(S(MOM Brood 1)Brood 1;S(MOM
 The Lord of the Rings: Tales of Middle-earth, 3/6/LTR, LTR
 The Lord of the Rings: Tales of Middle-earth Jumpstart, -/2/LTR, Meta-Choose(S(LTR Courageous 1)Courageous 1;S(LTR Courageous 2)Courageous 2;S(LTR Tricksy 1)Tricksy 1;S(LTR Tricksy 2)Tricksy 2;S(LTR Mordor 1)Mordor 1;S(LTR Mordor 2)Mordor 1;S(LTR Marauders 1)Marauders 1;S(LTR Marauders 2)Marauders 1;S(LTR Journey 1)Journey 1;S(LTR Journey 2)Journey 2)Themes
 Wilds of Eldraine, 3/6/WOE, WOE
-Alchemy: Eldraine,3/6/WOE, YWOE
+Alchemy: Eldraine, 3/6/WOE, YWOE
 The Lost Caverns of Ixalan, 3/6/LCI, LCI
-Alchemy: Ixalan,3/6/LCI, YLCI
-Ravnica Remastered,3/6/RVR, RVR
+Alchemy: Ixalan, 3/6/LCI, YLCI
+Ravnica Remastered, 3/6/RVR, RVR

--- a/forge-gui/res/blockdata/blocks.txt
+++ b/forge-gui/res/blockdata/blocks.txt
@@ -129,3 +129,4 @@ Wilds of Eldraine, 3/6/WOE, WOE
 Alchemy: Eldraine,3/6/WOE, YWOE
 The Lost Caverns of Ixalan, 3/6/LCI, LCI
 Alchemy: Ixalan,3/6/LCI, YLCI
+Ravnica Remastered,3/6/RVR, RVR

--- a/forge-gui/res/draft/rankings/rvr.rnk
+++ b/forge-gui/res/draft/rankings/rvr.rnk
@@ -1,405 +1,292 @@
+//Rank|Name|Rarity|Set
 #1|Liliana, Dreadhorde General|M|RVR
 #2|Aurelia, Exemplar of Justice|M|RVR
-#3|Aurelia, Exemplar of Justice|M|RVR
-#4|Quasiduplicate|R|RVR
-#5|Ilharg, the Raze-Boar|M|RVR
-#6|Ilharg, the Raze-Boar|M|RVR
-#7|Nicol Bolas, Dragon-God|M|RVR
-#8|Niv-Mizzet, Parun|R|RVR
-#9|Niv-Mizzet, Parun|R|RVR
-#10|Cyclonic Rift|M|RVR
-#11|Lord of the Void|M|RVR
-#12|Massacre Girl|R|RVR
-#13|Demonfire|U|RVR
-#14|Hellkite Tyrant|R|RVR
-#15|Utvara Hellkite|M|RVR
-#16|Sphinx's Revelation|R|RVR
-#17|Tajic, Legion's Edge|R|RVR
-#18|Cyclonic Rift|M|RVR
-#19|Hellkite Tyrant|R|RVR
-#20|Lord of the Void|M|RVR
-#21|Massacre Girl|R|RVR
-#22|Sphinx's Revelation|R|RVR
-#23|Tajic, Legion's Edge|R|RVR
-#24|Utvara Hellkite|M|RVR
-#25|Midnight Reaper|R|RVR
-#26|Gideon Blackblade|M|RVR
-#27|Birds of Paradise|R|RVR
-#28|Birds of Paradise|R|RVR
-#29|Yeva, Nature's Herald|R|RVR
-#30|Assemble the Legion|R|RVR
-#31|Domri Rade|M|RVR
-#32|Ral Zarek|M|RVR
-#33|Murmuring Mystic|U|RVR
-#34|Chord of Calling|R|RVR
-#35|Golgari Grave-Troll|R|RVR
-#36|Protean Hulk|M|RVR
-#37|Master of Cruelties|M|RVR
-#38|Chord of Calling|R|RVR
-#39|Golgari Grave-Troll|R|RVR
-#40|Master of Cruelties|M|RVR
-#41|Protean Hulk|M|RVR
-#42|Legion Warboss|R|RVR
-#43|Guardian Project|M|RVR
-#44|Nightveil Predator|U|RVR
-#45|Sharktocrab|U|RVR
-#46|Guardian Project|M|RVR
-#47|Legion Warboss|R|RVR
-#48|Nightveil Sprite|U|RVR
-#49|Tidespout Tyrant|R|RVR
-#50|Stalking Vengeance|U|RVR
-#51|Borborygmos Enraged|R|RVR
-#52|Crackling Drake|U|RVR
-#53|Lightning Helix|U|RVR
-#54|Prime Speaker Zegana|R|RVR
-#55|Tolsimir Wolfblood|R|RVR
-#56|Find Finality|R|RVR
-#57|Thrash Threat|R|RVR
-#58|Response Resurgence|R|RVR
-#59|Assure Assemble|R|RVR
-#60|Borborygmos Enraged|R|RVR
-#61|Crackling Drake|U|RVR
-#62|Lightning Helix|U|RVR
-#63|Prime Speaker Zegana|R|RVR
-#64|Tidespout Tyrant|R|RVR
-#65|Tolsimir Wolfblood|R|RVR
-#66|Priest of Forgotten Gods|R|RVR
-#67|Arclight Phoenix|R|RVR
-#68|Conclave Cavalier|U|RVR
-#69|Golgari Findbroker|U|RVR
-#70|Golgari Guildmage|U|RVR
-#71|Putrefy|U|RVR
-#72|Rakdos Firewheeler|U|RVR
-#73|Scab-Clan Mauler|C|RVR
-#74|Selesnya Evangel|U|RVR
-#75|Teysa, Orzhov Scion|R|RVR
-#76|Truefire Captain|U|RVR
-#77|Arclight Phoenix|R|RVR
-#78|Putrefy|U|RVR
-#79|Teysa, Orzhov Scion|R|RVR
-#80|Urbis Protector|U|RVR
-#81|Spark Double|R|RVR
-#82|Dreadbore|R|RVR
-#83|Phytohydra|R|RVR
-#84|Rhythm of the Wild|U|RVR
-#85|Sky Hussar|U|RVR
-#86|Dreadbore|R|RVR
-#87|Rhythm of the Wild|U|RVR
-#88|Sky Hussar|U|RVR
-#89|Spark Double|R|RVR
-#90|Unbreakable Formation|R|RVR
-#91|Blade Juggler|C|RVR
-#92|Orzhov Enforcer|U|RVR
-#93|Lazav, the Multifarious|R|RVR
-#94|Sunder Shaman|U|RVR
-#95|Warrant Warden|R|RVR
-#96|Gate Colossus|U|RVR
-#97|Lazav, the Multifarious|R|RVR
-#98|Mistral Charger|U|RVR
-#99|Aetherplasm|U|RVR
-#100|Last Gasp|C|RVR
-#101|Mausoleum Turnkey|U|RVR
-#102|Ultimate Price|U|RVR
-#103|Woebringer Demon|U|RVR
-#104|Homing Lightning|U|RVR
-#105|Skewer the Critics|C|RVR
-#106|Overwhelm|U|RVR
-#107|Coiling Oracle|C|RVR
-#108|Frilled Mystic|U|RVR
-#109|Rakdos Guildmage|U|RVR
-#110|Rakdos, Lord of Riots|R|RVR
-#111|Savra, Queen of the Golgari|R|RVR
-#112|Selesnya Guildmage|U|RVR
-#113|Sphinx of New Prahv|U|RVR
-#114|Connive Concoct|R|RVR
-#115|Bedeck Bedazzle|R|RVR
-#116|Voyager Staff|U|RVR
-#117|Coiling Oracle|C|RVR
-#118|Frilled Mystic|U|RVR
-#119|Rakdos, Lord of Riots|R|RVR
-#120|Savra, Queen of the Golgari|R|RVR
-#121|Skewer the Critics|C|RVR
-#122|Ultimate Price|U|RVR
-#123|Azorius Justiciar|U|RVR
-#124|Faith's Fetters|C|RVR
-#125|Sunhome Stalwart|U|RVR
-#126|Golgari Thug|U|RVR
-#127|Azorius Guildmage|U|RVR
-#128|Boros Guildmage|U|RVR
-#129|Call of the Conclave|C|RVR
-#130|Cartel Aristocrat|U|RVR
-#131|Gruul Guildmage|U|RVR
-#132|Mayhem Devil|U|RVR
-#133|Call of the Conclave|C|RVR
-#134|Cartel Aristocrat|U|RVR
-#135|Faith's Fetters|C|RVR
-#136|Golgari Thug|U|RVR
-#137|Mayhem Devil|U|RVR
-#138|Conclave Equenaut|C|RVR
-#139|Summary Judgment|C|RVR
-#140|Cerulean Sphinx|U|RVR
-#141|Repeal|C|RVR
-#142|Orzhov Euthanist|C|RVR
-#143|Bloodfray Giant|U|RVR
-#144|Rakdos Pit Dragon|U|RVR
-#145|Band Together|C|RVR
-#146|Experiment One|U|RVR
-#147|Fungal Rebirth|U|RVR
-#148|Horncaller's Chant|C|RVR
-#149|Utopia Sprawl|U|RVR
-#150|Izzet Charm|U|RVR
-#151|Teferi, Time Raveler|M|RVR
-#152|Revival Revenge|R|RVR
-#153|Expansion Explosion|R|RVR
-#154|Experiment One|U|RVR
-#155|Izzet Charm|U|RVR
-#156|Utopia Sprawl|U|RVR
-#157|Condemn|U|RVR
-#158|Devouring Light|U|RVR
-#159|Ministrant of Obligation|U|RVR
-#160|Sinister Sabotage|C|RVR
-#161|Stab Wound|U|RVR
-#162|Mugging|C|RVR
-#163|Loaming Shaman|U|RVR
-#164|Moldervine Cloak|U|RVR
-#165|Wasteland Viper|U|RVR
-#166|Dimir Guildmage|U|RVR
-#167|Glowspore Shaman|C|RVR
-#168|Skyknight Legionnaire|C|RVR
-#169|Whisper Agent|C|RVR
-#170|Condemn|U|RVR
-#171|Devouring Light|U|RVR
-#172|Loaming Shaman|U|RVR
-#173|Moldervine Cloak|U|RVR
-#174|Angelic Exaltation|U|RVR
-#175|Boros Elite|C|RVR
-#176|Eyes in the Skies|C|RVR
-#177|Compulsive Research|C|RVR
-#178|Drift of Phantasms|C|RVR
-#179|Balustrade Spy|C|RVR
-#180|Plaguecrafter|U|RVR
-#181|Burning Prophet|C|RVR
-#182|Krenko, Mob Boss|R|RVR
-#183|Light Up the Stage|U|RVR
-#184|Crocanura|C|RVR
-#185|Fists of Ironwood|C|RVR
-#186|Gather Courage|C|RVR
-#187|Life from the Loam|R|RVR
-#188|Titanic Brawl|C|RVR
-#189|Blind Hunter|C|RVR
-#190|Gobhobbler Rats|C|RVR
-#191|Karlov of the Ghost Council|M|RVR
-#192|Moroii|U|RVR
-#193|Mourning Thrull|C|RVR
-#194|Simic Guildmage|U|RVR
-#195|Compulsive Research|C|RVR
-#196|Drift of Phantasms|C|RVR
-#197|Karlov of the Ghost Council|M|RVR
-#198|Krenko, Mob Boss|R|RVR
-#199|Life from the Loam|R|RVR
-#200|Light Up the Stage|U|RVR
-#201|Eyes Everywhere|U|RVR
-#202|Fblthp, the Lost|R|RVR
-#203|Pteramander|U|RVR
-#204|Dreadmalkin|U|RVR
-#205|Vindictive Vampire|U|RVR
-#206|Rubblebelt Maaka|C|RVR
-#207|Wojek Bodyguard|C|RVR
-#208|Drudge Beetle|C|RVR
-#209|Goblin Electromancer|C|RVR
-#210|Goblin Electromancer|C|RVR
-#211|Pteramander|U|RVR
-#212|Vindictive Vampire|U|RVR
-#213|Azorius Arrester|C|RVR
-#214|Rootborn Defenses|C|RVR
-#215|Tomik, Distinguished Advokist|R|RVR
-#216|Cloudfin Raptor|C|RVR
-#217|Downsize|C|RVR
-#218|Helium Squirter|C|RVR
-#219|Keymaster Rogue|C|RVR
-#220|Remand|U|RVR
-#221|Burglar Rat|C|RVR
-#222|Crypt Ghast|R|RVR
-#223|Dimir House Guard|C|RVR
-#224|Ill-Gotten Inheritance|C|RVR
-#225|Macabre Waltz|C|RVR
-#226|Sewer Shambler|C|RVR
-#227|Krenko's Command|C|RVR
-#228|Greater Mossdog|C|RVR
-#229|Open the Gates|C|RVR
-#230|Rampaging Rendhorn|C|RVR
-#231|Debt to the Deathless|U|RVR
-#232|Deputy of Acquittals|C|RVR
-#233|Izzet Guildmage|U|RVR
-#234|Orzhov Guildmage|U|RVR
-#235|Petrahydrox|C|RVR
-#236|Repudiate Replicate|R|RVR
-#237|Blood Crypt|R|RVR
-#238|Breeding Pool|R|RVR
-#239|Godless Shrine|R|RVR
-#240|Hallowed Fountain|R|RVR
-#241|Overgrown Tomb|R|RVR
-#242|Sacred Foundry|R|RVR
-#243|Steam Vents|R|RVR
-#244|Stomping Ground|R|RVR
-#245|Temple Garden|R|RVR
-#246|Watery Grave|R|RVR
-#247|Blood Crypt|R|RVR
-#248|Breeding Pool|R|RVR
-#249|Cloudfin Raptor|C|RVR
-#250|Crypt Ghast|R|RVR
-#251|Debt to the Deathless|U|RVR
-#252|Dimir House Guard|C|RVR
-#253|Godless Shrine|R|RVR
-#254|Hallowed Fountain|R|RVR
-#255|Krenko's Command|C|RVR
-#256|Overgrown Tomb|R|RVR
-#257|Sacred Foundry|R|RVR
-#258|Steam Vents|R|RVR
-#259|Stomping Ground|R|RVR
-#260|Temple Garden|R|RVR
-#261|Watery Grave|R|RVR
-#262|Armory Guard|C|RVR
-#263|Arrester's Zeal|C|RVR
-#264|Keening Apparition|C|RVR
-#265|Syndicate Messenger|C|RVR
-#266|To Arms!|U|RVR
-#267|Totally Lost|C|RVR
-#268|Disembowel|C|RVR
-#269|Thrill-Kill Assassin|C|RVR
-#270|Undercity's Embrace|C|RVR
-#271|Bomber Corps|C|RVR
-#272|Burning-Tree Vandal|C|RVR
-#273|Dogpile|C|RVR
-#274|Skullcrack|U|RVR
-#275|Siege Wurm|C|RVR
-#276|Footlight Fiend|C|RVR
-#277|Fresh-Faced Recruit|C|RVR
-#278|Judge's Familiar|C|RVR
-#279|Merfolk of the Depths|C|RVR
-#280|Slitherhead|C|RVR
-#281|Azorius Signet|U|RVR
-#282|Boros Signet|U|RVR
-#283|Dimir Signet|U|RVR
-#284|Golgari Signet|U|RVR
-#285|Gruul Signet|U|RVR
-#286|Izzet Signet|U|RVR
-#287|Orzhov Signet|U|RVR
-#288|Rakdos Signet|U|RVR
-#289|Selesnya Signet|U|RVR
-#290|Simic Signet|U|RVR
-#291|Azorius Guildgate|C|RVR
-#292|Boros Guildgate|C|RVR
-#293|Dimir Guildgate|C|RVR
-#294|Golgari Guildgate|C|RVR
-#295|Gruul Guildgate|C|RVR
-#296|Izzet Guildgate|C|RVR
-#297|Orzhov Guildgate|C|RVR
-#298|Rakdos Guildgate|C|RVR
-#299|Selesnya Guildgate|C|RVR
-#300|Simic Guildgate|C|RVR
-#301|Azorius Guildgate|C|RVR
-#302|Boros Guildgate|C|RVR
-#303|Dimir Guildgate|C|RVR
-#304|Golgari Guildgate|C|RVR
-#305|Gruul Guildgate|C|RVR
-#306|Izzet Guildgate|C|RVR
-#307|Orzhov Guildgate|C|RVR
-#308|Rakdos Guildgate|C|RVR
-#309|Selesnya Guildgate|C|RVR
-#310|Simic Guildgate|C|RVR
-#311|Skullcrack|U|RVR
-#312|Totally Lost|C|RVR
-#313|Basilica Guards|C|RVR
-#314|Blazing Archon|R|RVR
-#315|Kasmina's Transmutation|C|RVR
-#316|Kiora's Dambreaker|C|RVR
-#317|Leapfrog|C|RVR
-#318|Quench|C|RVR
-#319|Bladebrand|C|RVR
-#320|Shadow Alley Denizen|C|RVR
-#321|Greater Forgeling|C|RVR
-#322|Mortus Strider|C|RVR
-#323|Vernadi Shieldmate|C|RVR
-#324|Bottled Cloister|R|RVR
-#325|Chromatic Lantern|R|RVR
-#326|Blazing Archon|R|RVR
-#327|Bottled Cloister|R|RVR
-#328|Chromatic Lantern|R|RVR
-#329|Makeshift Battalion|C|RVR
-#330|Rising Populace|C|RVR
-#331|Radical Idea|C|RVR
-#332|Debtors' Transport|C|RVR
-#333|Tin Street Dodger|C|RVR
-#334|Civic Saber|U|RVR
-#335|Karn, the Great Creator|M|RVR
-#336|Bulwark Giant|C|RVR
-#337|Vedalken Mesmerist|C|RVR
-#338|Act of Treason|C|RVR
-#339|Burn Bright|C|RVR
-#340|Guttersnipe|U|RVR
-#341|Mizzix's Mastery|R|RVR
-#342|Taste for Mayhem|C|RVR
-#343|Farseek|U|RVR
-#344|Forced Adaptation|C|RVR
-#345|Silhana Ledgewalker|C|RVR
-#346|Sprouting Renewal|C|RVR
-#347|Wurmweaver Coil|U|RVR
-#348|Deathrite Shaman|R|RVR
-#349|Lavinia, Azorius Renegade|R|RVR
-#350|Mindleech Mass|R|RVR
-#351|Voidslime|R|RVR
-#352|Wild Cantor|C|RVR
-#353|Deathrite Shaman|R|RVR
-#354|Farseek|U|RVR
-#355|Guttersnipe|U|RVR
-#356|Lavinia, Azorius Renegade|R|RVR
-#357|Mindleech Mass|R|RVR
-#358|Mizzix's Mastery|R|RVR
-#359|Silhana Ledgewalker|C|RVR
-#360|Voidslime|R|RVR
-#361|Divine Visitation|M|RVR
-#362|Mephitic Vapors|C|RVR
-#363|Scorched Rusalka|C|RVR
-#364|Forced Landing|C|RVR
-#365|Divine Visitation|M|RVR
-#366|Persistent Petitioners|C|RVR
-#367|Cindervines|R|RVR
-#368|Kaya, Orzhov Usurper|R|RVR
-#369|Junktroller|U|RVR
-#370|Sword of the Paruns|R|RVR
-#371|Cindervines|R|RVR
-#372|Persistent Petitioners|C|RVR
-#373|Sword of the Paruns|R|RVR
-#374|Seal of the Guildpact|R|RVR
-#375|Seal of the Guildpact|R|RVR
-#376|Arboreal Grazer|C|RVR
-#377|Arboreal Grazer|C|RVR
-#378|Blind Obedience|R|RVR
-#379|Carom|C|RVR
-#380|Ghostway|R|RVR
-#381|Bruvac the Grandiloquent|M|RVR
-#382|Dark Confidant|M|RVR
-#383|Demolish|C|RVR
-#384|Siege of Towers|U|RVR
-#385|Blind Obedience|R|RVR
-#386|Bruvac the Grandiloquent|M|RVR
-#387|Dark Confidant|M|RVR
-#388|Ghostway|R|RVR
-#389|Copy Enchantment|R|RVR
-#390|Muddle the Mixture|U|RVR
-#391|Quicken|U|RVR
-#392|Infernal Tutor|R|RVR
-#393|Stitch in Time|R|RVR
-#394|Cloudstone Curio|M|RVR
-#395|Pariah's Shield|R|RVR
-#396|Silent Dart|U|RVR
-#397|Cloudstone Curio|M|RVR
-#398|Copy Enchantment|R|RVR
-#399|Infernal Tutor|R|RVR
-#400|Muddle the Mixture|U|RVR
-#401|Pariah's Shield|R|RVR
-#402|Quicken|U|RVR
-#403|Stitch in Time|R|RVR
-#404|Illusionist's Bracers|R|RVR
-#405|Illusionist's Bracers|R|RVR
+#3|Quasiduplicate|R|RVR
+#4|Ilharg, the Raze-Boar|M|RVR
+#5|Nicol Bolas, Dragon-God|M|RVR
+#6|Niv-Mizzet, Parun|R|RVR
+#7|Cyclonic Rift|M|RVR
+#8|Lord of the Void|M|RVR
+#9|Massacre Girl|R|RVR
+#10|Demonfire|U|RVR
+#11|Hellkite Tyrant|R|RVR
+#12|Utvara Hellkite|M|RVR
+#13|Sphinx's Revelation|R|RVR
+#14|Tajic, Legion's Edge|R|RVR
+#15|Midnight Reaper|R|RVR
+#16|Gideon Blackblade|M|RVR
+#17|Birds of Paradise|R|RVR
+#18|Yeva, Nature's Herald|R|RVR
+#19|Assemble the Legion|R|RVR
+#20|Domri Rade|M|RVR
+#21|Ral Zarek|M|RVR
+#22|Murmuring Mystic|U|RVR
+#23|Chord of Calling|R|RVR
+#24|Golgari Grave-Troll|R|RVR
+#25|Protean Hulk|M|RVR
+#26|Master of Cruelties|M|RVR
+#27|Legion Warboss|R|RVR
+#28|Guardian Project|M|RVR
+#29|Nightveil Predator|U|RVR
+#30|Sharktocrab|U|RVR
+#31|Nightveil Sprite|U|RVR
+#32|Tidespout Tyrant|R|RVR
+#33|Stalking Vengeance|U|RVR
+#34|Borborygmos Enraged|R|RVR
+#35|Crackling Drake|U|RVR
+#36|Lightning Helix|U|RVR
+#37|Prime Speaker Zegana|R|RVR
+#38|Tolsimir Wolfblood|R|RVR
+#39|Find Finality|R|RVR
+#40|Thrash Threat|R|RVR
+#41|Response Resurgence|R|RVR
+#42|Assure Assemble|R|RVR
+#43|Priest of Forgotten Gods|R|RVR
+#44|Arclight Phoenix|R|RVR
+#45|Conclave Cavalier|U|RVR
+#46|Golgari Findbroker|U|RVR
+#47|Golgari Guildmage|U|RVR
+#48|Putrefy|U|RVR
+#49|Rakdos Firewheeler|U|RVR
+#50|Scab-Clan Mauler|C|RVR
+#51|Selesnya Evangel|U|RVR
+#52|Teysa, Orzhov Scion|R|RVR
+#53|Truefire Captain|U|RVR
+#54|Urbis Protector|U|RVR
+#55|Spark Double|R|RVR
+#56|Dreadbore|R|RVR
+#57|Phytohydra|R|RVR
+#58|Rhythm of the Wild|U|RVR
+#59|Sky Hussar|U|RVR
+#60|Unbreakable Formation|R|RVR
+#61|Blade Juggler|C|RVR
+#62|Orzhov Enforcer|U|RVR
+#63|Lazav, the Multifarious|R|RVR
+#64|Sunder Shaman|U|RVR
+#65|Warrant Warden|R|RVR
+#66|Gate Colossus|U|RVR
+#67|Mistral Charger|U|RVR
+#68|Aetherplasm|U|RVR
+#69|Last Gasp|C|RVR
+#70|Mausoleum Turnkey|U|RVR
+#71|Ultimate Price|U|RVR
+#72|Woebringer Demon|U|RVR
+#73|Homing Lightning|U|RVR
+#74|Skewer the Critics|C|RVR
+#75|Overwhelm|U|RVR
+#76|Coiling Oracle|C|RVR
+#77|Frilled Mystic|U|RVR
+#78|Rakdos Guildmage|U|RVR
+#79|Rakdos, Lord of Riots|R|RVR
+#80|Savra, Queen of the Golgari|R|RVR
+#81|Selesnya Guildmage|U|RVR
+#82|Sphinx of New Prahv|U|RVR
+#83|Connive Concoct|R|RVR
+#84|Bedeck Bedazzle|R|RVR
+#85|Voyager Staff|U|RVR
+#86|Azorius Justiciar|U|RVR
+#87|Faith's Fetters|C|RVR
+#88|Sunhome Stalwart|U|RVR
+#89|Golgari Thug|U|RVR
+#90|Azorius Guildmage|U|RVR
+#91|Boros Guildmage|U|RVR
+#92|Call of the Conclave|C|RVR
+#93|Cartel Aristocrat|U|RVR
+#94|Gruul Guildmage|U|RVR
+#95|Mayhem Devil|U|RVR
+#96|Conclave Equenaut|C|RVR
+#97|Summary Judgment|C|RVR
+#98|Cerulean Sphinx|U|RVR
+#99|Repeal|C|RVR
+#100|Orzhov Euthanist|C|RVR
+#101|Bloodfray Giant|U|RVR
+#102|Rakdos Pit Dragon|U|RVR
+#103|Band Together|C|RVR
+#104|Experiment One|U|RVR
+#105|Fungal Rebirth|U|RVR
+#106|Horncaller's Chant|C|RVR
+#107|Utopia Sprawl|U|RVR
+#108|Izzet Charm|U|RVR
+#109|Teferi, Time Raveler|M|RVR
+#110|Revival Revenge|R|RVR
+#111|Expansion Explosion|R|RVR
+#112|Condemn|U|RVR
+#113|Devouring Light|U|RVR
+#114|Ministrant of Obligation|U|RVR
+#115|Sinister Sabotage|C|RVR
+#116|Stab Wound|U|RVR
+#117|Mugging|C|RVR
+#118|Loaming Shaman|U|RVR
+#119|Moldervine Cloak|U|RVR
+#120|Wasteland Viper|U|RVR
+#121|Dimir Guildmage|U|RVR
+#122|Glowspore Shaman|C|RVR
+#123|Skyknight Legionnaire|C|RVR
+#124|Whisper Agent|C|RVR
+#125|Angelic Exaltation|U|RVR
+#126|Boros Elite|C|RVR
+#127|Eyes in the Skies|C|RVR
+#128|Compulsive Research|C|RVR
+#129|Drift of Phantasms|C|RVR
+#130|Balustrade Spy|C|RVR
+#131|Plaguecrafter|U|RVR
+#132|Burning Prophet|C|RVR
+#133|Krenko, Mob Boss|R|RVR
+#134|Light Up the Stage|U|RVR
+#135|Crocanura|C|RVR
+#136|Fists of Ironwood|C|RVR
+#137|Gather Courage|C|RVR
+#138|Life from the Loam|R|RVR
+#139|Titanic Brawl|C|RVR
+#140|Blind Hunter|C|RVR
+#141|Gobhobbler Rats|C|RVR
+#142|Karlov of the Ghost Council|M|RVR
+#143|Moroii|U|RVR
+#144|Mourning Thrull|C|RVR
+#145|Simic Guildmage|U|RVR
+#146|Eyes Everywhere|U|RVR
+#147|Fblthp, the Lost|R|RVR
+#148|Pteramander|U|RVR
+#149|Dreadmalkin|U|RVR
+#150|Vindictive Vampire|U|RVR
+#151|Rubblebelt Maaka|C|RVR
+#152|Wojek Bodyguard|C|RVR
+#153|Drudge Beetle|C|RVR
+#154|Goblin Electromancer|C|RVR
+#155|Azorius Arrester|C|RVR
+#156|Rootborn Defenses|C|RVR
+#157|Tomik, Distinguished Advokist|R|RVR
+#158|Cloudfin Raptor|C|RVR
+#159|Downsize|C|RVR
+#160|Helium Squirter|C|RVR
+#161|Keymaster Rogue|C|RVR
+#162|Remand|U|RVR
+#163|Burglar Rat|C|RVR
+#164|Crypt Ghast|R|RVR
+#165|Dimir House Guard|C|RVR
+#166|Ill-Gotten Inheritance|C|RVR
+#167|Macabre Waltz|C|RVR
+#168|Sewer Shambler|C|RVR
+#169|Krenko's Command|C|RVR
+#170|Greater Mossdog|C|RVR
+#171|Open the Gates|C|RVR
+#172|Rampaging Rendhorn|C|RVR
+#173|Debt to the Deathless|U|RVR
+#174|Deputy of Acquittals|C|RVR
+#175|Izzet Guildmage|U|RVR
+#176|Orzhov Guildmage|U|RVR
+#177|Petrahydrox|C|RVR
+#178|Repudiate Replicate|R|RVR
+#179|Blood Crypt|R|RVR
+#180|Breeding Pool|R|RVR
+#181|Godless Shrine|R|RVR
+#182|Hallowed Fountain|R|RVR
+#183|Overgrown Tomb|R|RVR
+#184|Sacred Foundry|R|RVR
+#185|Steam Vents|R|RVR
+#186|Stomping Ground|R|RVR
+#187|Temple Garden|R|RVR
+#188|Watery Grave|R|RVR
+#189|Armory Guard|C|RVR
+#190|Arrester's Zeal|C|RVR
+#191|Keening Apparition|C|RVR
+#192|Syndicate Messenger|C|RVR
+#193|To Arms!|U|RVR
+#194|Totally Lost|C|RVR
+#195|Disembowel|C|RVR
+#196|Thrill-Kill Assassin|C|RVR
+#197|Undercity's Embrace|C|RVR
+#198|Bomber Corps|C|RVR
+#199|Burning-Tree Vandal|C|RVR
+#200|Dogpile|C|RVR
+#201|Skullcrack|U|RVR
+#202|Siege Wurm|C|RVR
+#203|Footlight Fiend|C|RVR
+#204|Fresh-Faced Recruit|C|RVR
+#205|Judge's Familiar|C|RVR
+#206|Merfolk of the Depths|C|RVR
+#207|Slitherhead|C|RVR
+#208|Azorius Signet|U|RVR
+#209|Boros Signet|U|RVR
+#210|Dimir Signet|U|RVR
+#211|Golgari Signet|U|RVR
+#212|Gruul Signet|U|RVR
+#213|Izzet Signet|U|RVR
+#214|Orzhov Signet|U|RVR
+#215|Rakdos Signet|U|RVR
+#216|Selesnya Signet|U|RVR
+#217|Simic Signet|U|RVR
+#218|Azorius Guildgate|C|RVR
+#219|Boros Guildgate|C|RVR
+#220|Dimir Guildgate|C|RVR
+#221|Golgari Guildgate|C|RVR
+#222|Gruul Guildgate|C|RVR
+#223|Izzet Guildgate|C|RVR
+#224|Orzhov Guildgate|C|RVR
+#225|Rakdos Guildgate|C|RVR
+#226|Selesnya Guildgate|C|RVR
+#227|Simic Guildgate|C|RVR
+#228|Basilica Guards|C|RVR
+#229|Blazing Archon|R|RVR
+#230|Kasmina's Transmutation|C|RVR
+#231|Kiora's Dambreaker|C|RVR
+#232|Leapfrog|C|RVR
+#233|Quench|C|RVR
+#234|Bladebrand|C|RVR
+#235|Shadow Alley Denizen|C|RVR
+#236|Greater Forgeling|C|RVR
+#237|Mortus Strider|C|RVR
+#238|Vernadi Shieldmate|C|RVR
+#239|Bottled Cloister|R|RVR
+#240|Chromatic Lantern|R|RVR
+#241|Makeshift Battalion|C|RVR
+#242|Rising Populace|C|RVR
+#243|Radical Idea|C|RVR
+#244|Debtors' Transport|C|RVR
+#245|Tin Street Dodger|C|RVR
+#246|Civic Saber|U|RVR
+#247|Karn, the Great Creator|M|RVR
+#248|Bulwark Giant|C|RVR
+#249|Vedalken Mesmerist|C|RVR
+#250|Act of Treason|C|RVR
+#251|Burn Bright|C|RVR
+#252|Guttersnipe|U|RVR
+#253|Mizzix's Mastery|R|RVR
+#254|Taste for Mayhem|C|RVR
+#255|Farseek|U|RVR
+#256|Forced Adaptation|C|RVR
+#257|Silhana Ledgewalker|C|RVR
+#258|Sprouting Renewal|C|RVR
+#259|Wurmweaver Coil|U|RVR
+#260|Deathrite Shaman|R|RVR
+#261|Lavinia, Azorius Renegade|R|RVR
+#262|Mindleech Mass|R|RVR
+#263|Voidslime|R|RVR
+#264|Wild Cantor|C|RVR
+#265|Divine Visitation|M|RVR
+#266|Mephitic Vapors|C|RVR
+#267|Scorched Rusalka|C|RVR
+#268|Forced Landing|C|RVR
+#269|Persistent Petitioners|C|RVR
+#270|Cindervines|R|RVR
+#271|Kaya, Orzhov Usurper|R|RVR
+#272|Junktroller|U|RVR
+#273|Sword of the Paruns|R|RVR
+#274|Seal of the Guildpact|R|RVR
+#275|Arboreal Grazer|C|RVR
+#276|Blind Obedience|R|RVR
+#277|Carom|C|RVR
+#278|Ghostway|R|RVR
+#279|Bruvac the Grandiloquent|M|RVR
+#280|Dark Confidant|M|RVR
+#281|Demolish|C|RVR
+#282|Siege of Towers|U|RVR
+#283|Copy Enchantment|R|RVR
+#284|Muddle the Mixture|U|RVR
+#285|Quicken|U|RVR
+#286|Infernal Tutor|R|RVR
+#287|Stitch in Time|R|RVR
+#288|Cloudstone Curio|M|RVR
+#289|Pariah's Shield|R|RVR
+#290|Silent Dart|U|RVR
+#291|Illusionist's Bracers|R|RVR

--- a/forge-gui/res/draft/rankings/rvr.rnk
+++ b/forge-gui/res/draft/rankings/rvr.rnk
@@ -1,0 +1,405 @@
+#1|Liliana, Dreadhorde General|M|RVR
+#2|Aurelia, Exemplar of Justice|M|RVR
+#3|Aurelia, Exemplar of Justice|M|RVR
+#4|Quasiduplicate|R|RVR
+#5|Ilharg, the Raze-Boar|M|RVR
+#6|Ilharg, the Raze-Boar|M|RVR
+#7|Nicol Bolas, Dragon-God|M|RVR
+#8|Niv-Mizzet, Parun|R|RVR
+#9|Niv-Mizzet, Parun|R|RVR
+#10|Cyclonic Rift|M|RVR
+#11|Lord of the Void|M|RVR
+#12|Massacre Girl|R|RVR
+#13|Demonfire|U|RVR
+#14|Hellkite Tyrant|R|RVR
+#15|Utvara Hellkite|M|RVR
+#16|Sphinx's Revelation|R|RVR
+#17|Tajic, Legion's Edge|R|RVR
+#18|Cyclonic Rift|M|RVR
+#19|Hellkite Tyrant|R|RVR
+#20|Lord of the Void|M|RVR
+#21|Massacre Girl|R|RVR
+#22|Sphinx's Revelation|R|RVR
+#23|Tajic, Legion's Edge|R|RVR
+#24|Utvara Hellkite|M|RVR
+#25|Midnight Reaper|R|RVR
+#26|Gideon Blackblade|M|RVR
+#27|Birds of Paradise|R|RVR
+#28|Birds of Paradise|R|RVR
+#29|Yeva, Nature's Herald|R|RVR
+#30|Assemble the Legion|R|RVR
+#31|Domri Rade|M|RVR
+#32|Ral Zarek|M|RVR
+#33|Murmuring Mystic|U|RVR
+#34|Chord of Calling|R|RVR
+#35|Golgari Grave-Troll|R|RVR
+#36|Protean Hulk|M|RVR
+#37|Master of Cruelties|M|RVR
+#38|Chord of Calling|R|RVR
+#39|Golgari Grave-Troll|R|RVR
+#40|Master of Cruelties|M|RVR
+#41|Protean Hulk|M|RVR
+#42|Legion Warboss|R|RVR
+#43|Guardian Project|M|RVR
+#44|Nightveil Predator|U|RVR
+#45|Sharktocrab|U|RVR
+#46|Guardian Project|M|RVR
+#47|Legion Warboss|R|RVR
+#48|Nightveil Sprite|U|RVR
+#49|Tidespout Tyrant|R|RVR
+#50|Stalking Vengeance|U|RVR
+#51|Borborygmos Enraged|R|RVR
+#52|Crackling Drake|U|RVR
+#53|Lightning Helix|U|RVR
+#54|Prime Speaker Zegana|R|RVR
+#55|Tolsimir Wolfblood|R|RVR
+#56|Find Finality|R|RVR
+#57|Thrash Threat|R|RVR
+#58|Response Resurgence|R|RVR
+#59|Assure Assemble|R|RVR
+#60|Borborygmos Enraged|R|RVR
+#61|Crackling Drake|U|RVR
+#62|Lightning Helix|U|RVR
+#63|Prime Speaker Zegana|R|RVR
+#64|Tidespout Tyrant|R|RVR
+#65|Tolsimir Wolfblood|R|RVR
+#66|Priest of Forgotten Gods|R|RVR
+#67|Arclight Phoenix|R|RVR
+#68|Conclave Cavalier|U|RVR
+#69|Golgari Findbroker|U|RVR
+#70|Golgari Guildmage|U|RVR
+#71|Putrefy|U|RVR
+#72|Rakdos Firewheeler|U|RVR
+#73|Scab-Clan Mauler|C|RVR
+#74|Selesnya Evangel|U|RVR
+#75|Teysa, Orzhov Scion|R|RVR
+#76|Truefire Captain|U|RVR
+#77|Arclight Phoenix|R|RVR
+#78|Putrefy|U|RVR
+#79|Teysa, Orzhov Scion|R|RVR
+#80|Urbis Protector|U|RVR
+#81|Spark Double|R|RVR
+#82|Dreadbore|R|RVR
+#83|Phytohydra|R|RVR
+#84|Rhythm of the Wild|U|RVR
+#85|Sky Hussar|U|RVR
+#86|Dreadbore|R|RVR
+#87|Rhythm of the Wild|U|RVR
+#88|Sky Hussar|U|RVR
+#89|Spark Double|R|RVR
+#90|Unbreakable Formation|R|RVR
+#91|Blade Juggler|C|RVR
+#92|Orzhov Enforcer|U|RVR
+#93|Lazav, the Multifarious|R|RVR
+#94|Sunder Shaman|U|RVR
+#95|Warrant Warden|R|RVR
+#96|Gate Colossus|U|RVR
+#97|Lazav, the Multifarious|R|RVR
+#98|Mistral Charger|U|RVR
+#99|Aetherplasm|U|RVR
+#100|Last Gasp|C|RVR
+#101|Mausoleum Turnkey|U|RVR
+#102|Ultimate Price|U|RVR
+#103|Woebringer Demon|U|RVR
+#104|Homing Lightning|U|RVR
+#105|Skewer the Critics|C|RVR
+#106|Overwhelm|U|RVR
+#107|Coiling Oracle|C|RVR
+#108|Frilled Mystic|U|RVR
+#109|Rakdos Guildmage|U|RVR
+#110|Rakdos, Lord of Riots|R|RVR
+#111|Savra, Queen of the Golgari|R|RVR
+#112|Selesnya Guildmage|U|RVR
+#113|Sphinx of New Prahv|U|RVR
+#114|Connive Concoct|R|RVR
+#115|Bedeck Bedazzle|R|RVR
+#116|Voyager Staff|U|RVR
+#117|Coiling Oracle|C|RVR
+#118|Frilled Mystic|U|RVR
+#119|Rakdos, Lord of Riots|R|RVR
+#120|Savra, Queen of the Golgari|R|RVR
+#121|Skewer the Critics|C|RVR
+#122|Ultimate Price|U|RVR
+#123|Azorius Justiciar|U|RVR
+#124|Faith's Fetters|C|RVR
+#125|Sunhome Stalwart|U|RVR
+#126|Golgari Thug|U|RVR
+#127|Azorius Guildmage|U|RVR
+#128|Boros Guildmage|U|RVR
+#129|Call of the Conclave|C|RVR
+#130|Cartel Aristocrat|U|RVR
+#131|Gruul Guildmage|U|RVR
+#132|Mayhem Devil|U|RVR
+#133|Call of the Conclave|C|RVR
+#134|Cartel Aristocrat|U|RVR
+#135|Faith's Fetters|C|RVR
+#136|Golgari Thug|U|RVR
+#137|Mayhem Devil|U|RVR
+#138|Conclave Equenaut|C|RVR
+#139|Summary Judgment|C|RVR
+#140|Cerulean Sphinx|U|RVR
+#141|Repeal|C|RVR
+#142|Orzhov Euthanist|C|RVR
+#143|Bloodfray Giant|U|RVR
+#144|Rakdos Pit Dragon|U|RVR
+#145|Band Together|C|RVR
+#146|Experiment One|U|RVR
+#147|Fungal Rebirth|U|RVR
+#148|Horncaller's Chant|C|RVR
+#149|Utopia Sprawl|U|RVR
+#150|Izzet Charm|U|RVR
+#151|Teferi, Time Raveler|M|RVR
+#152|Revival Revenge|R|RVR
+#153|Expansion Explosion|R|RVR
+#154|Experiment One|U|RVR
+#155|Izzet Charm|U|RVR
+#156|Utopia Sprawl|U|RVR
+#157|Condemn|U|RVR
+#158|Devouring Light|U|RVR
+#159|Ministrant of Obligation|U|RVR
+#160|Sinister Sabotage|C|RVR
+#161|Stab Wound|U|RVR
+#162|Mugging|C|RVR
+#163|Loaming Shaman|U|RVR
+#164|Moldervine Cloak|U|RVR
+#165|Wasteland Viper|U|RVR
+#166|Dimir Guildmage|U|RVR
+#167|Glowspore Shaman|C|RVR
+#168|Skyknight Legionnaire|C|RVR
+#169|Whisper Agent|C|RVR
+#170|Condemn|U|RVR
+#171|Devouring Light|U|RVR
+#172|Loaming Shaman|U|RVR
+#173|Moldervine Cloak|U|RVR
+#174|Angelic Exaltation|U|RVR
+#175|Boros Elite|C|RVR
+#176|Eyes in the Skies|C|RVR
+#177|Compulsive Research|C|RVR
+#178|Drift of Phantasms|C|RVR
+#179|Balustrade Spy|C|RVR
+#180|Plaguecrafter|U|RVR
+#181|Burning Prophet|C|RVR
+#182|Krenko, Mob Boss|R|RVR
+#183|Light Up the Stage|U|RVR
+#184|Crocanura|C|RVR
+#185|Fists of Ironwood|C|RVR
+#186|Gather Courage|C|RVR
+#187|Life from the Loam|R|RVR
+#188|Titanic Brawl|C|RVR
+#189|Blind Hunter|C|RVR
+#190|Gobhobbler Rats|C|RVR
+#191|Karlov of the Ghost Council|M|RVR
+#192|Moroii|U|RVR
+#193|Mourning Thrull|C|RVR
+#194|Simic Guildmage|U|RVR
+#195|Compulsive Research|C|RVR
+#196|Drift of Phantasms|C|RVR
+#197|Karlov of the Ghost Council|M|RVR
+#198|Krenko, Mob Boss|R|RVR
+#199|Life from the Loam|R|RVR
+#200|Light Up the Stage|U|RVR
+#201|Eyes Everywhere|U|RVR
+#202|Fblthp, the Lost|R|RVR
+#203|Pteramander|U|RVR
+#204|Dreadmalkin|U|RVR
+#205|Vindictive Vampire|U|RVR
+#206|Rubblebelt Maaka|C|RVR
+#207|Wojek Bodyguard|C|RVR
+#208|Drudge Beetle|C|RVR
+#209|Goblin Electromancer|C|RVR
+#210|Goblin Electromancer|C|RVR
+#211|Pteramander|U|RVR
+#212|Vindictive Vampire|U|RVR
+#213|Azorius Arrester|C|RVR
+#214|Rootborn Defenses|C|RVR
+#215|Tomik, Distinguished Advokist|R|RVR
+#216|Cloudfin Raptor|C|RVR
+#217|Downsize|C|RVR
+#218|Helium Squirter|C|RVR
+#219|Keymaster Rogue|C|RVR
+#220|Remand|U|RVR
+#221|Burglar Rat|C|RVR
+#222|Crypt Ghast|R|RVR
+#223|Dimir House Guard|C|RVR
+#224|Ill-Gotten Inheritance|C|RVR
+#225|Macabre Waltz|C|RVR
+#226|Sewer Shambler|C|RVR
+#227|Krenko's Command|C|RVR
+#228|Greater Mossdog|C|RVR
+#229|Open the Gates|C|RVR
+#230|Rampaging Rendhorn|C|RVR
+#231|Debt to the Deathless|U|RVR
+#232|Deputy of Acquittals|C|RVR
+#233|Izzet Guildmage|U|RVR
+#234|Orzhov Guildmage|U|RVR
+#235|Petrahydrox|C|RVR
+#236|Repudiate Replicate|R|RVR
+#237|Blood Crypt|R|RVR
+#238|Breeding Pool|R|RVR
+#239|Godless Shrine|R|RVR
+#240|Hallowed Fountain|R|RVR
+#241|Overgrown Tomb|R|RVR
+#242|Sacred Foundry|R|RVR
+#243|Steam Vents|R|RVR
+#244|Stomping Ground|R|RVR
+#245|Temple Garden|R|RVR
+#246|Watery Grave|R|RVR
+#247|Blood Crypt|R|RVR
+#248|Breeding Pool|R|RVR
+#249|Cloudfin Raptor|C|RVR
+#250|Crypt Ghast|R|RVR
+#251|Debt to the Deathless|U|RVR
+#252|Dimir House Guard|C|RVR
+#253|Godless Shrine|R|RVR
+#254|Hallowed Fountain|R|RVR
+#255|Krenko's Command|C|RVR
+#256|Overgrown Tomb|R|RVR
+#257|Sacred Foundry|R|RVR
+#258|Steam Vents|R|RVR
+#259|Stomping Ground|R|RVR
+#260|Temple Garden|R|RVR
+#261|Watery Grave|R|RVR
+#262|Armory Guard|C|RVR
+#263|Arrester's Zeal|C|RVR
+#264|Keening Apparition|C|RVR
+#265|Syndicate Messenger|C|RVR
+#266|To Arms!|U|RVR
+#267|Totally Lost|C|RVR
+#268|Disembowel|C|RVR
+#269|Thrill-Kill Assassin|C|RVR
+#270|Undercity's Embrace|C|RVR
+#271|Bomber Corps|C|RVR
+#272|Burning-Tree Vandal|C|RVR
+#273|Dogpile|C|RVR
+#274|Skullcrack|U|RVR
+#275|Siege Wurm|C|RVR
+#276|Footlight Fiend|C|RVR
+#277|Fresh-Faced Recruit|C|RVR
+#278|Judge's Familiar|C|RVR
+#279|Merfolk of the Depths|C|RVR
+#280|Slitherhead|C|RVR
+#281|Azorius Signet|U|RVR
+#282|Boros Signet|U|RVR
+#283|Dimir Signet|U|RVR
+#284|Golgari Signet|U|RVR
+#285|Gruul Signet|U|RVR
+#286|Izzet Signet|U|RVR
+#287|Orzhov Signet|U|RVR
+#288|Rakdos Signet|U|RVR
+#289|Selesnya Signet|U|RVR
+#290|Simic Signet|U|RVR
+#291|Azorius Guildgate|C|RVR
+#292|Boros Guildgate|C|RVR
+#293|Dimir Guildgate|C|RVR
+#294|Golgari Guildgate|C|RVR
+#295|Gruul Guildgate|C|RVR
+#296|Izzet Guildgate|C|RVR
+#297|Orzhov Guildgate|C|RVR
+#298|Rakdos Guildgate|C|RVR
+#299|Selesnya Guildgate|C|RVR
+#300|Simic Guildgate|C|RVR
+#301|Azorius Guildgate|C|RVR
+#302|Boros Guildgate|C|RVR
+#303|Dimir Guildgate|C|RVR
+#304|Golgari Guildgate|C|RVR
+#305|Gruul Guildgate|C|RVR
+#306|Izzet Guildgate|C|RVR
+#307|Orzhov Guildgate|C|RVR
+#308|Rakdos Guildgate|C|RVR
+#309|Selesnya Guildgate|C|RVR
+#310|Simic Guildgate|C|RVR
+#311|Skullcrack|U|RVR
+#312|Totally Lost|C|RVR
+#313|Basilica Guards|C|RVR
+#314|Blazing Archon|R|RVR
+#315|Kasmina's Transmutation|C|RVR
+#316|Kiora's Dambreaker|C|RVR
+#317|Leapfrog|C|RVR
+#318|Quench|C|RVR
+#319|Bladebrand|C|RVR
+#320|Shadow Alley Denizen|C|RVR
+#321|Greater Forgeling|C|RVR
+#322|Mortus Strider|C|RVR
+#323|Vernadi Shieldmate|C|RVR
+#324|Bottled Cloister|R|RVR
+#325|Chromatic Lantern|R|RVR
+#326|Blazing Archon|R|RVR
+#327|Bottled Cloister|R|RVR
+#328|Chromatic Lantern|R|RVR
+#329|Makeshift Battalion|C|RVR
+#330|Rising Populace|C|RVR
+#331|Radical Idea|C|RVR
+#332|Debtors' Transport|C|RVR
+#333|Tin Street Dodger|C|RVR
+#334|Civic Saber|U|RVR
+#335|Karn, the Great Creator|M|RVR
+#336|Bulwark Giant|C|RVR
+#337|Vedalken Mesmerist|C|RVR
+#338|Act of Treason|C|RVR
+#339|Burn Bright|C|RVR
+#340|Guttersnipe|U|RVR
+#341|Mizzix's Mastery|R|RVR
+#342|Taste for Mayhem|C|RVR
+#343|Farseek|U|RVR
+#344|Forced Adaptation|C|RVR
+#345|Silhana Ledgewalker|C|RVR
+#346|Sprouting Renewal|C|RVR
+#347|Wurmweaver Coil|U|RVR
+#348|Deathrite Shaman|R|RVR
+#349|Lavinia, Azorius Renegade|R|RVR
+#350|Mindleech Mass|R|RVR
+#351|Voidslime|R|RVR
+#352|Wild Cantor|C|RVR
+#353|Deathrite Shaman|R|RVR
+#354|Farseek|U|RVR
+#355|Guttersnipe|U|RVR
+#356|Lavinia, Azorius Renegade|R|RVR
+#357|Mindleech Mass|R|RVR
+#358|Mizzix's Mastery|R|RVR
+#359|Silhana Ledgewalker|C|RVR
+#360|Voidslime|R|RVR
+#361|Divine Visitation|M|RVR
+#362|Mephitic Vapors|C|RVR
+#363|Scorched Rusalka|C|RVR
+#364|Forced Landing|C|RVR
+#365|Divine Visitation|M|RVR
+#366|Persistent Petitioners|C|RVR
+#367|Cindervines|R|RVR
+#368|Kaya, Orzhov Usurper|R|RVR
+#369|Junktroller|U|RVR
+#370|Sword of the Paruns|R|RVR
+#371|Cindervines|R|RVR
+#372|Persistent Petitioners|C|RVR
+#373|Sword of the Paruns|R|RVR
+#374|Seal of the Guildpact|R|RVR
+#375|Seal of the Guildpact|R|RVR
+#376|Arboreal Grazer|C|RVR
+#377|Arboreal Grazer|C|RVR
+#378|Blind Obedience|R|RVR
+#379|Carom|C|RVR
+#380|Ghostway|R|RVR
+#381|Bruvac the Grandiloquent|M|RVR
+#382|Dark Confidant|M|RVR
+#383|Demolish|C|RVR
+#384|Siege of Towers|U|RVR
+#385|Blind Obedience|R|RVR
+#386|Bruvac the Grandiloquent|M|RVR
+#387|Dark Confidant|M|RVR
+#388|Ghostway|R|RVR
+#389|Copy Enchantment|R|RVR
+#390|Muddle the Mixture|U|RVR
+#391|Quicken|U|RVR
+#392|Infernal Tutor|R|RVR
+#393|Stitch in Time|R|RVR
+#394|Cloudstone Curio|M|RVR
+#395|Pariah's Shield|R|RVR
+#396|Silent Dart|U|RVR
+#397|Cloudstone Curio|M|RVR
+#398|Copy Enchantment|R|RVR
+#399|Infernal Tutor|R|RVR
+#400|Muddle the Mixture|U|RVR
+#401|Pariah's Shield|R|RVR
+#402|Quicken|U|RVR
+#403|Stitch in Time|R|RVR
+#404|Illusionist's Bracers|R|RVR
+#405|Illusionist's Bracers|R|RVR

--- a/forge-gui/res/editions/Ravnica Remastered.txt
+++ b/forge-gui/res/editions/Ravnica Remastered.txt
@@ -3,6 +3,7 @@ Code=RVR
 Date=2024-01-12
 Name=Ravnica Remastered
 Type=Reprint
+Booster=10 Common:!fromSheet("RVR Mana Fixing"):fromsheet("RVR cards"), 3 Uncommon:!fromSheet("RVR Mana Fixing"):fromSheet("RVR cards"), 1 RareMythic:fromSheet("RVR cards"), 1 fromSheet("RVR Mana Fixing")
 ScryfallCode=RVR
 
 [cards]
@@ -477,6 +478,39 @@ ScryfallCode=RVR
 465 M Maze's End @Cliff Childs
 466 R Thespian's Stage @John Avon
 467 R Niv-Mizzet, the Firemind @Todd Lockwood
+
+[Mana Fixing]
+7 Azorius Guildgate|RVR
+7 Boros Guildgate|RVR
+7 Dimir Guildgate|RVR
+7 Golgari Guildgate|RVR
+7 Gruul Guildgate|RVR
+7 Izzet Guildgate|RVR
+7 Orzhov Guildgate|RVR
+7 Rakdos Guildgate|RVR
+7 Selesnya Guildgate|RVR
+7 Simic Guildgate|RVR
+4 Azorius Signet|RVR
+4 Boros Signet|RVR
+4 Dimir Signet|RVR
+4 Golgari Signet|RVR
+4 Gruul Signet|RVR
+4 Izzet Signet|RVR
+4 Orzhov Signet|RVR
+4 Rakdos Signet|RVR
+4 Selesnya Signet|RVR
+4 Simic Signet|RVR
+1 Blood Crypt|RVR
+1 Breeding Pool|RVR
+1 Godless Shrine|RVR
+1 Hallowed Fountain|RVR
+1 Overgrown Tomb|RVR
+1 Sacred Foundry|RVR
+1 Steam Vents|RVR
+1 Stomping Ground|RVR
+1 Temple Garden|RVR
+1 Watery Grave|RVR
+1 Chromatic Lantern|RVR
 
 [tokens]
 b_2_2_zombie


### PR DESCRIPTION
Attempted to recreate the [booster collation ](https://magic.wizards.com/en/news/feature/collecting-ravnica-remastered)as good as possible:

> - 8–10 Commons
> - 3–4 Uncommons
> - 1 Rare or mythic rare
> - 1 Mana slot card
>   - 58% Guildgate (common)
>   - 33% Signet (uncommon)
>   - 9% Chromatic Lantern or a shock land (rare)
> - 1 Retro frame card of any rarity

I ignored the retro slot for now.