### PR TITLE
Alchemy Rebalancing for January 12, 2024

### DIFF
--- a/forge-gui/res/cardsfolder/a/astral_confrontation.txt
+++ b/forge-gui/res/cardsfolder/a/astral_confrontation.txt
@@ -4,4 +4,4 @@ Types:Instant
 S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {1} less to cast for each opponent you're attacking.
 SVar:X:PlayerCountPropertyYou$OpponentsAttackedThisCombat
 A:SP$ ChangeZone | Cost$ 4 W | ValidTgts$ Creature | TgtPrompt$ Select target creature | Origin$ Battlefield | Destination$ Exile | SpellDescription$ Exile target creature.
-Oracle:This spell costs 1 less to cast for each opponent you're attacking.\nExile target creature.
+Oracle:This spell costs {1} less to cast for each opponent you're attacking.\nExile target creature.

--- a/forge-gui/res/cardsfolder/b/banquet_guests.txt
+++ b/forge-gui/res/cardsfolder/b/banquet_guests.txt
@@ -10,4 +10,4 @@ SVar:Y:SVar$X/Twice
 A:AB$ Pump | Cost$ 2 Sac<1/Food> | Defined$ Self | KW$ Indestructible | SpellDescription$ CARDNAME gains indestructible until end of turn.
 DeckHints:Type$Food
 DeckHas:Ability$Counters|Sacrifice
-Oracle:Affinity for Food (This spell costs 1 less to cast for each Food you control.)\nTrample\nBanquet Guests enters the battlefield with twice X +1/+1 counters on it.\n{2}, Sacrifice a Food: Banquet Guests gains indestructible until end of turn.
+Oracle:Affinity for Food (This spell costs {1} less to cast for each Food you control.)\nTrample\nBanquet Guests enters the battlefield with twice X +1/+1 counters on it.\n{2}, Sacrifice a Food: Banquet Guests gains indestructible until end of turn.

--- a/forge-gui/res/cardsfolder/h/hall_of_tagsin.txt
+++ b/forge-gui/res/cardsfolder/h/hall_of_tagsin.txt
@@ -5,4 +5,4 @@ A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ 1 T | Produced$ Any | SpellDescription$ Add one mana of any color.
 A:AB$ Token | Cost$ 4 T | TokenAmount$ 1 | TokenTapped$ True | TokenScript$ c_a_powerstone | SpellDescription$ Create a tapped Powerstone token. (It's an artifact with "T: Add {C}. This mana can't be spent to cast a nonartifact spell.")
 DeckHas:Ability$Token & Type$Artifact
-Oracle:{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{4}, {T}, Create a tapped Powerstone token. (It's an artifact with "T: Add {C}. This mana can't be spent to cast a nonartifact spell.")
+Oracle:{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{4}, {T}: Create a tapped Powerstone token. (It's an artifact with "T: Add {C}. This mana can't be spent to cast a nonartifact spell.")

--- a/forge-gui/res/cardsfolder/h/hurkyls_prodigy.txt
+++ b/forge-gui/res/cardsfolder/h/hurkyls_prodigy.txt
@@ -4,10 +4,10 @@ Types:Creature Human Soldier
 PT:1/4
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters the battlefield, create a tapped Powerstone token.
 SVar:TrigToken:DB$ Token | TokenTapped$ True | TokenScript$ c_a_powerstone
-T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigUnblockable | TriggerDescription$ Whenever CARDNAME attacks, you may pay {3}. If you do, CARDNAME can't be blocked this turn and it perpetually gets +2/+0.
-SVar:TrigUnblockable:AB$ Effect | Cost$ 3 | StaticAbilities$ Unblockable | SubAbility$ DBPump
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigUnblockable | TriggerDescription$ Whenever CARDNAME attacks, you may pay {2}. If you do, CARDNAME can't be blocked this turn and it perpetually gets +2/+0.
+SVar:TrigUnblockable:AB$ Effect | Cost$ 2 | StaticAbilities$ Unblockable | SubAbility$ DBPump
 SVar:DBPump:DB$ Pump | NumAtt$ 2 | Duration$ Perpetual
 SVar:Unblockable:Mode$ CantBlockBy | ValidAttacker$ Card.EffectSource | Description$ EFFECTSOURCE can't be blocked this turn.
 SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Token & Type$Artifact|Powerstone
-Oracle:When Hurkyl's Prodigy enter the battlefield, create a tapped Powerstone token.\nWhenever Hurkyl's Prodigy attacks, you may pay {3}. If you do, Hurkyl's Prodigy can't be blocked this turn and it perpetually gets +2/+0.
+Oracle:When Hurkyl's Prodigy enter the battlefield, create a tapped Powerstone token.\nWhenever Hurkyl's Prodigy attacks, you may pay {2}. If you do, Hurkyl's Prodigy can't be blocked this turn and it perpetually gets +2/+0.

--- a/forge-gui/res/cardsfolder/i/irini_sengir.txt
+++ b/forge-gui/res/cardsfolder/i/irini_sengir.txt
@@ -2,6 +2,6 @@ Name:Irini Sengir
 ManaCost:2 B B
 Types:Legendary Creature Vampire Dwarf
 PT:2/2
-S:Mode$ RaiseCost | ValidCard$ Enchantment.White,Enchantment.Green | Type$ Spell | Amount$ 2 | Description$ White enchantment spells and green enchantment spells cost 2 more to cast.
+S:Mode$ RaiseCost | ValidCard$ Enchantment.White,Enchantment.Green | Type$ Spell | Amount$ 2 | Description$ White enchantment spells and green enchantment spells cost {2} more to cast.
 AI:RemoveDeck:Random
 Oracle:Green enchantment spells and white enchantment spells cost {2} more to cast.

--- a/forge-gui/res/cardsfolder/i/izzet_steam_maze.txt
+++ b/forge-gui/res/cardsfolder/i/izzet_steam_maze.txt
@@ -5,6 +5,6 @@ T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ Player |
 SVar:TrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | Controller$ TriggeredActivator | MayChooseTarget$ True
 T:Mode$ ChaosEnsues | TriggerZones$ Command | Execute$ RolledChaos | TriggerDescription$ Whenever chaos ensues, instant and sorcery spells you cast this turn cost {3} less to cast.
 SVar:RolledChaos:DB$ Effect | StaticAbilities$ ReduceSPcost
-SVar:ReduceSPcost:Mode$ ReduceCost | EffectZone$ Command | ValidCard$ Instant,Sorcery | Type$ Spell | Activator$ You | Amount$ 3 | Description$ Instant and sorcery spells you cast this turn cost 3 less to cast.
+SVar:ReduceSPcost:Mode$ ReduceCost | EffectZone$ Command | ValidCard$ Instant,Sorcery | Type$ Spell | Activator$ You | Amount$ 3 | Description$ Instant and sorcery spells you cast this turn cost {3} less to cast.
 SVar:AIRollPlanarDieParams:Mode$ Always | RollInMain1$ True
 Oracle:Whenever a player casts an instant or sorcery spell, that player copies it. The player may choose new targets for the copy.\nWhenever chaos ensues, instant and sorcery spells you cast this turn cost {3} less to cast.

--- a/forge-gui/res/cardsfolder/l/llanowar_greenwidow.txt
+++ b/forge-gui/res/cardsfolder/l/llanowar_greenwidow.txt
@@ -12,4 +12,5 @@ SVar:DiscardMe:2
 SVar:SacMe:1
 SVar:X:Count$Domain
 AI:RemoveDeck:Random
+DeckHas:Ability$Graveyard|Counters
 Oracle:Reach, trample\nDomain — {7}{G}: Return Llanowar Greenwidow from your graveyard to the battlefield tapped. It gains "If this permanent would leave the battlefield, exile it instead." This ability costs {1} less to activate for each basic land type among lands you control.

--- a/forge-gui/res/cardsfolder/l/llanowar_greenwidow.txt
+++ b/forge-gui/res/cardsfolder/l/llanowar_greenwidow.txt
@@ -12,5 +12,5 @@ SVar:DiscardMe:2
 SVar:SacMe:1
 SVar:X:Count$Domain
 AI:RemoveDeck:Random
-DeckHas:Ability$Graveyard|Counters
+DeckHas:Ability$Graveyard
 Oracle:Reach, trample\nDomain — {7}{G}: Return Llanowar Greenwidow from your graveyard to the battlefield tapped. It gains "If this permanent would leave the battlefield, exile it instead." This ability costs {1} less to activate for each basic land type among lands you control.

--- a/forge-gui/res/cardsfolder/l/llanowar_greenwidow.txt
+++ b/forge-gui/res/cardsfolder/l/llanowar_greenwidow.txt
@@ -11,6 +11,5 @@ SVar:Exile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | Defined$ 
 SVar:DiscardMe:2
 SVar:SacMe:1
 SVar:X:Count$Domain
-AI:RemoveDeck:Random
 DeckHas:Ability$Graveyard
 Oracle:Reach, trample\nDomain — {7}{G}: Return Llanowar Greenwidow from your graveyard to the battlefield tapped. It gains "If this permanent would leave the battlefield, exile it instead." This ability costs {1} less to activate for each basic land type among lands you control.

--- a/forge-gui/res/cardsfolder/l/llanowar_greenwidow.txt
+++ b/forge-gui/res/cardsfolder/l/llanowar_greenwidow.txt
@@ -12,4 +12,4 @@ SVar:DiscardMe:2
 SVar:SacMe:1
 SVar:X:Count$Domain
 AI:RemoveDeck:Random
-Oracle:{T}:Reach, trample\nDomain — {7}{G}: Return Llanowar Greenwidow from your graveyard to the battlefield tapped. It gains "If this permanent would leave the battlefield, exile it instead." This ability costs {1} less to activate for each basic land type among lands you control.
+Oracle:Reach, trample\nDomain — {7}{G}: Return Llanowar Greenwidow from your graveyard to the battlefield tapped. It gains "If this permanent would leave the battlefield, exile it instead." This ability costs {1} less to activate for each basic land type among lands you control.

--- a/forge-gui/res/cardsfolder/l/llanowar_loamspeaker.txt
+++ b/forge-gui/res/cardsfolder/l/llanowar_loamspeaker.txt
@@ -5,4 +5,4 @@ PT:1/3
 A:AB$ Mana | Cost$ T | Produced$ Any | SpellDescription$ Add one mana of any color.
 A:AB$ Animate | Cost$ T | ValidTgts$ Land.YouCtrl | TgtPrompt$ Select target land you control | Power$ 3 | Toughness$ 3 | Types$ Creature,Elemental | Keywords$ Haste | SorcerySpeed$ True | SpellDescription$ Target land you control becomes a 3/3 Elemental creature with haste until end of turn. It's still a land. Activate only as as sorcery.
 DeckHas:Type$Elemental
-Oracle:{T}: Add one mana of any color.\n{T}: Target land you control becomes a 3/3 Elemental creature with haste until end of turn. It's still a land. Activate only as as sorcery.
+Oracle:{T}: Add one mana of any color.\n{T}: Target land you control becomes a 3/3 Elemental creature with haste until end of turn. It's still a land. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/m/mindsplice_apparatus.txt
+++ b/forge-gui/res/cardsfolder/m/mindsplice_apparatus.txt
@@ -4,8 +4,8 @@ Types:Artifact
 K:Flash
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigCounter | TriggerDescription$ At the beginning of your upkeep, put an oil counter on CARDNAME.
 SVar:TrigCounter:DB$ PutCounter | Defined$ Self | CounterType$ OIL | CounterNum$ 1
-S:Mode$ ReduceCost | ValidCard$ Instant,Sorcery | Type$ Spell | Activator$ You | Amount$ X | Description$ Instant and sorcery spells you cast cost 1 less to cast for each oil counter on CARDNAME.
+S:Mode$ ReduceCost | ValidCard$ Instant,Sorcery | Type$ Spell | Activator$ You | Amount$ X | Description$ Instant and sorcery spells you cast cost {1} less to cast for each oil counter on CARDNAME.
 SVar:X:Count$CardCounters.OIL
 DeckHas:Ability$Counters
 DeckHints:Type$Instant|Sorcery
-Oracle:Flash\nAt the beginning of your upkeep, put an oil counter on Mindsplice Apparatus.\nInstant and sorcery spells you cast cost 1 less to cast for each oil counter on Mindsplice Apparatus.
+Oracle:Flash\nAt the beginning of your upkeep, put an oil counter on Mindsplice Apparatus.\nInstant and sorcery spells you cast cost {1} less to cast for each oil counter on Mindsplice Apparatus.

--- a/forge-gui/res/cardsfolder/r/radhas_firebrand.txt
+++ b/forge-gui/res/cardsfolder/r/radhas_firebrand.txt
@@ -3,7 +3,7 @@ ManaCost:1 R
 Types:Creature Human Warrior
 PT:3/1
 T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, target creature defending player controls with power less than CARDNAME's power can't block this turn.
-SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.DefenderCtrl+powerLTX | TgtPrompt$ Select target creature an opponent controls with power less than Radha's Firebrand's power | KW$ HIDDEN CARDNAME can't block. | IsCurse$ True
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.DefenderCtrl+powerLTX | TgtPrompt$ Select target creature an opponent controls with power less than CARDNAME's power | KW$ HIDDEN CARDNAME can't block. | IsCurse$ True
 A:AB$ Pump | Cost$ 5 R | ReduceCost$ Y | Defined$ Self | NumAtt$ +2 | NumDef$ +2 | ActivationLimit$ 1 | SpellDescription$ CARDNAME gets +2/+2 until end of turn. This ability costs {1} less to activate for each basic land type among lands you control. Activate only once each turn.
 SVar:X:Count$CardPower
 SVar:Y:Count$Domain

--- a/forge-gui/res/cardsfolder/r/radhas_firebrand.txt
+++ b/forge-gui/res/cardsfolder/r/radhas_firebrand.txt
@@ -3,7 +3,7 @@ ManaCost:1 R
 Types:Creature Human Warrior
 PT:3/1
 T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, target creature defending player controls with power less than CARDNAME's power can't block this turn.
-SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.DefenderCtrl+powerLTX | TgtPrompt$ Select target creature an opponent controls with power less than than Radha's Firebrand's power | KW$ HIDDEN CARDNAME can't block. | IsCurse$ True
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.DefenderCtrl+powerLTX | TgtPrompt$ Select target creature an opponent controls with power less than Radha's Firebrand's power | KW$ HIDDEN CARDNAME can't block. | IsCurse$ True
 A:AB$ Pump | Cost$ 5 R | ReduceCost$ Y | Defined$ Self | NumAtt$ +2 | NumDef$ +2 | ActivationLimit$ 1 | SpellDescription$ CARDNAME gets +2/+2 until end of turn. This ability costs {1} less to activate for each basic land type among lands you control. Activate only once each turn.
 SVar:X:Count$CardPower
 SVar:Y:Count$Domain

--- a/forge-gui/res/cardsfolder/r/rulik_mons_warren_chief.txt
+++ b/forge-gui/res/cardsfolder/r/rulik_mons_warren_chief.txt
@@ -3,7 +3,7 @@ ManaCost:1 R G G
 Types:Legendary Creature Goblin
 PT:3/3
 K:Menace
-T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ DBDig | TriggerDescription$ Whenever CARDNAME Chief attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped. If you didn't put a card onto the battlefield this way, create a 1/1 red Goblin creature token.
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ DBDig | TriggerDescription$ Whenever CARDNAME attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped. If you didn't put a card onto the battlefield this way, create a 1/1 red Goblin creature token.
 SVar:DBDig:DB$ Dig | DigNum$ 1 | ChangeNum$ 1 | ChangeValid$ Card.Land | ForceRevealToController$ True | Optional$ True | RememberChanged$ True | DestinationZone$ Battlefield | DestinationZone2$ Library | LibraryPosition2$ 0 | SubAbility$ DBToken
 SVar:DBToken:DB$ Token | ConditionDefined$ Remembered | ConditionPresent$ Card.inZoneBattlefield | ConditionCompare$ EQ0 | TokenScript$ r_1_1_goblin | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/rebalanced/a-briar_hydra.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-briar_hydra.txt
@@ -1,7 +1,7 @@
-Name:Briar Hydra
-ManaCost:5 G
+Name:A-Briar Hydra
+ManaCost:3 G
 Types:Creature Plant Hydra
-PT:6/6
+PT:5/5
 K:Trample
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ DBCounter | TriggerZones$ Battlefield | TriggerDescription$ Domain — Whenever CARDNAME deals combat damage to a player, put X +1/+1 counters on target creature you control, where X is the number of basic land types among lands you control.
 SVar:DBCounter:DB$ PutCounter | CounterNum$ X | CounterType$ P1P1 | ValidTgts$ Creature.YouCtrl

--- a/forge-gui/res/cardsfolder/rebalanced/a-excavation_explosion.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-excavation_explosion.txt
@@ -1,0 +1,7 @@
+Name:A-Excavation Explosion
+ManaCost:2 R
+Types:Instant
+A:SP$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ 4 | SubAbility$ DBToken | SpellDescription$ CARDNAME deals 4 damage to target creature or planeswalker. Create a tapped Powerstone token.
+SVar:DBToken:DB$ Token | TokenTapped$ True | TokenScript$ c_a_powerstone
+DeckHas:Ability$Token & Type$Artifact
+Oracle:Excavation Explosion deals 4 damage to target creature or planeswalker. Create a tapped Powerstone token.

--- a/forge-gui/res/cardsfolder/rebalanced/a-geology_enthusiast.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-geology_enthusiast.txt
@@ -1,0 +1,11 @@
+Name:A-Geology Enthusiast
+ManaCost:2 U U
+Types:Creature Human Artificer
+PT:3/4
+K:Vigilance
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ At the beginning of your end step, create a tapped Powerstone token.
+SVar:TrigToken:DB$ Token | TokenTapped$ True | TokenScript$ c_a_powerstone
+A:AB$ Draw | Cost$ 5 | SubAbility$ DBCounter | SpellDescription$ Draw a card and put a +1/+1 counter on CARDNAME.
+SVar:DBCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
+DeckHas:Ability$Token|Counters & Type$Artifact
+Oracle:Vigilance\nAt the beginning of your end step, create a tapped Powerstone token.\n{5}: Draw a card and put a +1/+1 counter on Geology Enthusiast.

--- a/forge-gui/res/cardsfolder/rebalanced/a-hall_of_tagsin.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-hall_of_tagsin.txt
@@ -1,0 +1,8 @@
+Name:A-Hall of Tagsin
+ManaCost:no cost
+Types:Land
+A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
+A:AB$ Mana | Cost$ 1 T | Produced$ Any | SpellDescription$ Add one mana of any color.
+A:AB$ Token | Cost$ 3 T | TokenAmount$ 1 | TokenTapped$ True | TokenScript$ c_a_powerstone | SpellDescription$ Create a tapped Powerstone token.
+DeckHas:Ability$Token & Type$Artifact
+Oracle:{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{3}, {T}, Create a tapped Powerstone token.

--- a/forge-gui/res/cardsfolder/rebalanced/a-hall_of_tagsin.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-hall_of_tagsin.txt
@@ -5,4 +5,4 @@ A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ 1 T | Produced$ Any | SpellDescription$ Add one mana of any color.
 A:AB$ Token | Cost$ 3 T | TokenAmount$ 1 | TokenTapped$ True | TokenScript$ c_a_powerstone | SpellDescription$ Create a tapped Powerstone token.
 DeckHas:Ability$Token & Type$Artifact
-Oracle:{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{3}, {T}, Create a tapped Powerstone token.
+Oracle:{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{3}, {T}: Create a tapped Powerstone token.

--- a/forge-gui/res/cardsfolder/rebalanced/a-karn_living_legacy.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-karn_living_legacy.txt
@@ -1,0 +1,14 @@
+Name:A-Karn, Living Legacy
+ManaCost:4
+Types:Legendary Planeswalker Karn
+Loyalty:4
+A:AB$ Token | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | TokenAmount$ 1 | TokenTapped$ True | TokenScript$ c_a_powerstone | TokenOwner$ You | SpellDescription$ Create a tapped Powerstone token.
+A:AB$ ChooseNumber | Cost$ AddCounter<0/LOYALTY> | Planeswalker$ True | Defined$ You | ChooseAnyNumber$ True | ListTitle$ Pay Any Mana | SubAbility$ DBDig | SpellDescription$ Pay any amount of mana. Look at that many cards from the top of your library, then put one of those cards into your hand and the rest on the bottom of your library in a random order.
+SVar:DBDig:DB$ Dig | DigNum$ X | ChangeNum$ 1 | RestRandomOrder$ True | UnlessCost$ X | UnlessPayer$ You | UnlessSwitched$ True
+A:AB$ Effect | Cost$ SubCounter<6/LOYALTY> | Planeswalker$ True | Ultimate$ True | AILogic$ Always | Stackable$ False | Name$ Emblem - Karn, Living Legacy | Image$ emblem_karn_living_legacy | Duration$ Permanent | Abilities$ KarnPing | SpellDescription$ You get an emblem with "Tap an untapped artifact you control: This emblem deals 1 damage to any target."
+SVar:KarnPing:AB$ DealDamage | Cost$ tapXType<1/Artifact> | ActivationZone$ Command | ValidTgts$ Any | NumDmg$ 1
+SVar:PlayMain1:TRUE
+DeckHas:Ability$Token & Type|Artifact
+DeckNeeds:Type$Artifact
+SVar:X:Count$ChosenNumber
+Oracle:[+1]: Create a tapped Powerstone token.\n[0]: Pay any amount of mana. Look at that many cards from the top of your library, then put one of those cards into your hand and the rest on the bottom of your library in a random order.\n[−6]: You get an emblem with "Tap an untapped artifact you control: This emblem deals 1 damage to any target."

--- a/forge-gui/res/cardsfolder/rebalanced/a-llanowar_greenwidow.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-llanowar_greenwidow.txt
@@ -6,6 +6,5 @@ K:Reach
 K:Trample
 A:AB$ ChangeZone | Cost$ 5 G | ReduceCost$ X | Origin$ Graveyard | Destination$ Battlefield | Tapped$ True | ActivationZone$ Graveyard | WithCountersType$ FINALITY | WithCountersAmount$ 1 | PrecostDesc$ Domain — | SpellDescription$ Return CARDNAME from your graveyard to the battlefield tapped with a finality counter on it. This ability costs {1} less to activate for each basic land type among lands you control.
 SVar:X:Count$Domain
-AI:RemoveDeck:Random
 DeckHas:Ability$Graveyard|Counters
 Oracle:Reach, trample\nDomain — {5}{G}: Return Llanowar Greenwidow from your graveyard to the battlefield tapped with a finality counter on it. This ability costs {1} less to activate for each basic land type among lands you control.

--- a/forge-gui/res/cardsfolder/rebalanced/a-llanowar_greenwidow.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-llanowar_greenwidow.txt
@@ -6,6 +6,6 @@ K:Reach
 K:Trample
 A:AB$ ChangeZone | Cost$ 5 G | ReduceCost$ X | Origin$ Graveyard | Destination$ Battlefield | Tapped$ True | ActivationZone$ Graveyard | WithCountersType$ FINALITY | WithCountersAmount$ 1 | PrecostDesc$ Domain — | SpellDescription$ Return CARDNAME from your graveyard to the battlefield tapped with a finality counter on it. This ability costs {1} less to activate for each basic land type among lands you control.
 SVar:X:Count$Domain
-DeckHas:Ability$Graveyard|Counters
 AI:RemoveDeck:Random
+DeckHas:Ability$Graveyard|Counters
 Oracle:Reach, trample\nDomain — {5}{G}: Return Llanowar Greenwidow from your graveyard to the battlefield tapped with a finality counter on it. This ability costs {1} less to activate for each basic land type among lands you control.

--- a/forge-gui/res/cardsfolder/rebalanced/a-llanowar_greenwidow.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-llanowar_greenwidow.txt
@@ -1,0 +1,11 @@
+Name:A-Llanowar Greenwidow
+ManaCost:2 G
+Types:Creature Spider
+PT:4/3
+K:Reach
+K:Trample
+A:AB$ ChangeZone | Cost$ 5 G | ReduceCost$ X | Origin$ Graveyard | Destination$ Battlefield | Tapped$ True | ActivationZone$ Graveyard | WithCountersType$ FINALITY | WithCountersAmount$ 1 | PrecostDesc$ Domain — | SpellDescription$ Return CARDNAME from your graveyard to the battlefield tapped with a finality counter on it. This ability costs {1} less to activate for each basic land type among lands you control.
+SVar:X:Count$Domain
+DeckHas:Ability$Graveyard|Counters
+AI:RemoveDeck:Random
+Oracle:Reach, trample\nDomain — {5}{G}: Return Llanowar Greenwidow from your graveyard to the battlefield tapped with a finality counter on it. This ability costs {1} less to activate for each basic land type among lands you control.

--- a/forge-gui/res/cardsfolder/rebalanced/a-llanowar_loamspeaker.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-llanowar_loamspeaker.txt
@@ -1,0 +1,8 @@
+Name:A-Llanowar Loamspeaker
+ManaCost:1 G
+Types:Creature Elf Druid
+PT:1/3
+A:AB$ Mana | Cost$ T | Produced$ Any | SpellDescription$ Add one mana of any color.
+A:AB$ Animate | Cost$ T | ValidTgts$ Land.YouCtrl | TgtPrompt$ Select target land you control | Power$ 4 | Toughness$ 4 | Types$ Creature,Elemental | Keywords$ Haste | SorcerySpeed$ True | SpellDescription$ Target land you control becomes a 4/4 Elemental creature with haste until end of turn. It's still a land. Activate only as as sorcery.
+DeckHas:Type$Elemental
+Oracle:{T}: Add one mana of any color.\n{T}: Target land you control becomes a 4/4 Elemental creature with haste until end of turn. It's still a land. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/rebalanced/a-merias_outrider.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-merias_outrider.txt
@@ -1,0 +1,10 @@
+Name:A-Meria's Outrider
+ManaCost:4 R
+Types:Creature Elf Archer
+PT:5/5
+K:Reach
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDamage | TriggerDescription$ Domain — When CARDNAME enters the battlefield, it deals damage equal to the number of basic land types among lands you control to any target.
+SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Any | NumDmg$ X
+SVar:X:Count$Domain
+AI:RemoveDeck:Random
+Oracle:Reach\nDomain — When Meria's Outrider enters the battlefield, it deals damage equal to the number of basic land types among lands you control to any target.

--- a/forge-gui/res/cardsfolder/rebalanced/a-mightstones_animation.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-mightstones_animation.txt
@@ -1,0 +1,11 @@
+Name:A-Mightstone's Animation
+ManaCost:2 U
+Types:Enchantment Aura
+K:Enchant artifact
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ When CARDNAME enters the battlefield, draw two cards, then discard a card.
+SVar:TrigDraw:DB$ Draw | NumCards$ 2 | SubAbility$ DBDiscard
+SVar:DBDiscard:DB$ Discard | NumCards$ 1 | Mode$ TgtChoose
+A:SP$ Attach | ValidTgts$ Artifact | AITgts$ Card.nonCreature | AILogic$ Animate
+S:Mode$ Continuous | Affected$ Artifact.EnchantedBy | SetPower$ 4 | SetToughness$ 4 | AddType$ Creature | Description$ Enchanted artifact is a creature with base power and toughness 4/4 in addition to its other types.
+DeckNeeds:Type$Artifact
+Oracle:Enchant artifact\nWhen Mightstone's Animation enters the battlefield, draw two cards, then discard a card.\nEnchanted artifact is a creature with base power and toughness 4/4 in addition to its other types.

--- a/forge-gui/res/cardsfolder/rebalanced/a-mishra_excavation_prodigy.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-mishra_excavation_prodigy.txt
@@ -1,0 +1,11 @@
+Name:A-Mishra, Excavation Prodigy
+ManaCost:1 R
+Types:Legendary Creature Human Artificer
+PT:2/1
+A:AB$ Draw | Cost$ 1 T Discard<1/Card> | SpellDescription$ Draw a card.
+T:Mode$ DiscardedAll | ValidPlayer$ You | ValidCard$ Card.Artifact | TriggerZones$ Battlefield | ActivationLimit$ 1 | Execute$ TrigMana | TriggerDescription$ Whenever you discard one or more artifact cards, add {R}{R}. This ability triggers only once each turn.
+SVar:TrigMana:DB$ Mana | Produced$ R R
+DeckHints:Type$Artifact
+DeckHas:Ability$Discard
+SVar:AIPreference:DiscardCost$Card.Artifact
+Oracle:{1},{T}, Discard a card: Draw a card.\nWhenever you discard one or more artifact cards, add {R}{R}. This ability triggers only once each turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-nael_avizoa_aeronaut.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-nael_avizoa_aeronaut.txt
@@ -1,0 +1,11 @@
+Name:A-Nael, Avizoa Aeronaut
+ManaCost:G U
+Types:Legendary Creature Elf Scout
+PT:2/2
+K:Flying
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigDig | CombatDamage$ True | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, look at the top X cards of your library, where X is the number of basic land types among lands you control. Put up to one of them on top of your library and the rest on the bottom in a random order. Then if there are five basic land types among lands you control, draw a card.
+SVar:TrigDig:DB$ Dig | DigNum$ X | Defined$ You | DestinationZone$ Library | RestRandomOrder$ True | LibraryPosition$ 0 | Optional$ True | SubAbility$ DBDraw
+SVar:DBDraw:DB$ Draw | ConditionCheckSVar$ X | ConditionSVarCompare$ EQ5
+SVar:X:Count$Domain
+AI:RemoveDeck:Random
+Oracle:Flying\nDomain — Whenever Nael, Avizoa Aeronaut deals combat damage to a player, look at the top X cards of your library, where X is the number of basic land types among lands you control. Put up to one of them on top of your library and the rest on the bottom in a random order. Then if there are five basic land types among lands you control, draw a card.

--- a/forge-gui/res/cardsfolder/rebalanced/a-radha_coalition_warlord.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-radha_coalition_warlord.txt
@@ -1,0 +1,10 @@
+Name:A-Radha, Coalition Warlord
+ManaCost:1 R G
+Types:Legendary Creature Elf Warrior
+PT:3/3
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ Domain — Whenever CARDNAME enters the battlefield or becomes tapped, another target creature you control gets +X/+X until end of turn, where X is the number of basic land types among lands you control.
+T:Mode$ Taps | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ Domain — Whenever CARDNAME enters the battlefield or becomes tapped, another target creature you control gets +X/+X until end of turn, where X is the number of basic land types among lands you control.
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.Other+YouCtrl  | TgtPrompt$ Select another target creature you control | NumAtt$ +X | NumDef$ +X 
+SVar:X:Count$Domain
+AI:RemoveDeck:Random
+Oracle:Domain — Whenever Radha, Coalition Warlord enters the battlefield or becomes tapped, another target creature you control gets +X/+X until end of turn, where X is the number of basic land types among lands you control.

--- a/forge-gui/res/cardsfolder/rebalanced/a-radhas_firebrand.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-radhas_firebrand.txt
@@ -3,7 +3,7 @@ ManaCost:1 R
 Types:Creature Human Warrior
 PT:3/1
 T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, target creature defending player controls with power less than or equal to CARDNAME's power can't block this turn.
-SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.DefenderCtrl+powerLEX | TgtPrompt$ Select target creature an opponent controls with power less than or equal to Radha's Firebrand's power | KW$ HIDDEN CARDNAME can't block. | IsCurse$ True
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.DefenderCtrl+powerLEX | TgtPrompt$ Select target creature an opponent controls with power less than or equal to CARDNAME's power | KW$ HIDDEN CARDNAME can't block. | IsCurse$ True
 A:AB$ Pump | Cost$ 5 R | ReduceCost$ Y | Defined$ Self | NumAtt$ +2 | NumDef$ +2 | ActivationLimit$ 1 | SpellDescription$ CARDNAME gets +2/+2 until end of turn. This ability costs {1} less to activate for each basic land type among lands you control. Activate only once each turn.
 SVar:X:Count$CardPower
 SVar:Y:Count$Domain

--- a/forge-gui/res/cardsfolder/rebalanced/a-radhas_firebrand.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-radhas_firebrand.txt
@@ -1,0 +1,12 @@
+Name:A-Radha's Firebrand
+ManaCost:1 R
+Types:Creature Human Warrior
+PT:3/1
+T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, target creature defending player controls with power less than or equal to CARDNAME's power can't block this turn.
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.DefenderCtrl+powerLEX | TgtPrompt$ Select target creature an opponent controls with power less than or equal to Radha's Firebrand's power | KW$ HIDDEN CARDNAME can't block. | IsCurse$ True
+A:AB$ Pump | Cost$ 5 R | ReduceCost$ Y | Defined$ Self | NumAtt$ +2 | NumDef$ +2 | ActivationLimit$ 1 | SpellDescription$ CARDNAME gets +2/+2 until end of turn. This ability costs {1} less to activate for each basic land type among lands you control. Activate only once each turn.
+SVar:X:Count$CardPower
+SVar:Y:Count$Domain
+SVar:HasAttackEffect:TRUE
+AI:RemoveDeck:Random
+Oracle:Whenever Radha's Firebrand attacks, target creature defending player controls with power less than or equal to Radha's Firebrand's power can't block this turn.\nDomain — {5}{R}: Radha's Firebrand gets +2/+2 until end of turn. This ability costs {1} less to activate for each basic land type among lands you control. Activate only once each turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-rulik_mons_warren_chief.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-rulik_mons_warren_chief.txt
@@ -1,0 +1,13 @@
+Name:A-Rulik Mons, Warren Chief
+ManaCost:1 R G G
+Types:Legendary Creature Goblin
+PT:4/4
+K:Menace
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ DBDig | TriggerDescription$ Whenever CARDNAME enters the battlefield or attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped. If you didn't put a card onto the battlefield this way, create a 1/1 red Goblin creature token.
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ DBDig | TriggerDescription$ Whenever CARDNAME enters the battlefield or attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped. If you didn't put a card onto the battlefield this way, create a 1/1 red Goblin creature token.
+SVar:DBDig:DB$ Dig | DigNum$ 1 | ChangeNum$ 1 | ChangeValid$ Card.Land | ForceRevealToController$ True | Optional$ True | RememberChanged$ True | DestinationZone$ Battlefield | DestinationZone2$ Library | LibraryPosition2$ 0 | SubAbility$ DBToken
+SVar:DBToken:DB$ Token | ConditionDefined$ Remembered | ConditionPresent$ Card.inZoneBattlefield | ConditionCompare$ EQ0 | TokenScript$ r_1_1_goblin | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+DeckHas:Ability$Token
+SVar:HasAttackEffect:TRUE
+Oracle:Menace\nWhenever Rulik Mons, Warren Chief enters the battlefield or attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped. If you didn't put a card onto the battlefield this way, create a 1/1 red Goblin creature token.

--- a/forge-gui/res/cardsfolder/rebalanced/a-saheeli_filigree_master.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-saheeli_filigree_master.txt
@@ -5,10 +5,10 @@ Loyalty:3
 A:AB$ Scry | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | ScryNum$ 2 | SubAbility$ DBDraw | SpellDescription$ Scry 2. If you control an artifact, draw a card.
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | ConditionPresent$ Artifact.YouCtrl | ConditionCompare$ GE1
 A:AB$ Token | Cost$ SubCounter<2/LOYALTY> | Planeswalker$ True | PumpDuration$ EOT | TokenAmount$ 2 | PumpKeywords$ Haste | TokenScript$ c_1_1_a_thopter_flying | TokenOwner$ You | SpellDescription$ Create two 1/1 colorless Thopter artifact creature tokens with flying. They gain haste until end of turn.
-A:AB$ Effect | Cost$ SubCounter<4/LOYALTY> | Name$ Emblem - Saheeli, Filigree Master | StaticAbilities$ EmblemArtifactPump,ReduceCost | Planeswalker$ True | Ultimate$ True | Stackable$ False | Duration$ Permanent | AILogic$ Always | SpellDescription$ You get an emblem with "Artifact creatures you control get +1/+1" and "Artifact spells you cast cost 1 less to cast."
+A:AB$ Effect | Cost$ SubCounter<4/LOYALTY> | Name$ Emblem - Saheeli, Filigree Master | StaticAbilities$ EmblemArtifactPump,ReduceCost | Planeswalker$ True | Ultimate$ True | Stackable$ False | Duration$ Permanent | AILogic$ Always | SpellDescription$ You get an emblem with "Artifact creatures you control get +1/+1" and "Artifact spells you cast cost {1} less to cast."
 SVar:EmblemArtifactPump:Mode$ Continuous | AddPower$ 1 | AddToughness$ 1 | EffectZone$ Command | Affected$ Artifact.YouCtrl | AffectedZone$ Battlefield | Description$ Artifact creatures you control get +1/+1.
-SVar:ReduceCost:Mode$ ReduceCost | ValidCard$ Artifact | Type$ Spell | Activator$ You | Amount$ 1 | Description$ Artifact spells you cast cost {1} less to cast. | Description$ Artifact spells you cast cost 1 less to cast.
+SVar:ReduceCost:Mode$ ReduceCost | ValidCard$ Artifact | Type$ Spell | Activator$ You | Amount$ 1 | Description$ Artifact spells you cast cost {1} less to cast.
 DeckHas:Ability$Token
 DeckHints:Type$Artifact
 DeckHas:Ability$Token & Type$Thopter
-Oracle:[+1]: Scry 2. If you control an artifact, draw a card.\n[-2]: Create two 1/1 colorless Thopter artifact creature tokens with flying. They gain haste until end of turn.\n[-4]: You get an emblem with "Artifact creatures you control get +1/+1" and "Artifact spells you cast cost 1 less to cast."
+Oracle:[+1]: Scry 2. If you control an artifact, draw a card.\n[-2]: Create two 1/1 colorless Thopter artifact creature tokens with flying. They gain haste until end of turn.\n[-4]: You get an emblem with "Artifact creatures you control get +1/+1" and "Artifact spells you cast cost {1} less to cast."

--- a/forge-gui/res/cardsfolder/rebalanced/a-saheeli_filigree_master.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-saheeli_filigree_master.txt
@@ -1,0 +1,14 @@
+Name:A-Saheeli, Filigree Master
+ManaCost:2 U R
+Types:Legendary Planeswalker Saheeli
+Loyalty:3
+A:AB$ Scry | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | ScryNum$ 2 | SubAbility$ DBDraw | SpellDescription$ Scry 2. If you control an artifact, draw a card.
+SVar:DBDraw:DB$ Draw | NumCards$ 1 | ConditionPresent$ Artifact.YouCtrl | ConditionCompare$ GE1
+A:AB$ Token | Cost$ SubCounter<2/LOYALTY> | Planeswalker$ True | PumpDuration$ EOT | TokenAmount$ 2 | PumpKeywords$ Haste | TokenScript$ c_1_1_a_thopter_flying | TokenOwner$ You | SpellDescription$ Create two 1/1 colorless Thopter artifact creature tokens with flying. They gain haste until end of turn.
+A:AB$ Effect | Cost$ SubCounter<4/LOYALTY> | Name$ Emblem - Saheeli, Filigree Master | StaticAbilities$ EmblemArtifactPump,ReduceCost | Planeswalker$ True | Ultimate$ True | Stackable$ False | Duration$ Permanent | AILogic$ Always | SpellDescription$ You get an emblem with "Artifact creatures you control get +1/+1" and "Artifact spells you cast cost 1 less to cast."
+SVar:EmblemArtifactPump:Mode$ Continuous | AddPower$ 1 | AddToughness$ 1 | EffectZone$ Command | Affected$ Artifact.YouCtrl | AffectedZone$ Battlefield | Description$ Artifact creatures you control get +1/+1.
+SVar:ReduceCost:Mode$ ReduceCost | ValidCard$ Artifact | Type$ Spell | Activator$ You | Amount$ 1 | Description$ Artifact spells you cast cost {1} less to cast. | Description$ Artifact spells you cast cost 1 less to cast.
+DeckHas:Ability$Token
+DeckHints:Type$Artifact
+DeckHas:Ability$Token & Type$Thopter
+Oracle:[+1]: Scry 2. If you control an artifact, draw a card.\n[-2]: Create two 1/1 colorless Thopter artifact creature tokens with flying. They gain haste until end of turn.\n[-4]: You get an emblem with "Artifact creatures you control get +1/+1" and "Artifact spells you cast cost 1 less to cast."

--- a/forge-gui/res/cardsfolder/rebalanced/a-scout_the_wilderness.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-scout_the_wilderness.txt
@@ -1,0 +1,9 @@
+Name:A-Scout the Wilderness
+ManaCost:2 G
+Types:Sorcery
+K:Kicker:W
+A:SP$ ChangeZone | Origin$ Library | Destination$ Battlefield | Tapped$ True | ChangeType$ Land.Basic | ChangeNum$ 1 | SubAbility$ DBToken | SpellDescription$ Search your library for a basic land card, put it onto the battlefield tapped, then shuffle. If this spell was kicked, create two 1/1 white Soldier creature tokens.
+SVar:DBToken:DB$ Token | TokenAmount$ 2 | TokenScript$ w_1_1_soldier | Condition$ Kicked
+DeckHints:Color$White
+DeckHas:Ability$Token & Type$Soldier
+Oracle:Kicker {W}\nSearch your library for a basic land card, put it onto the battlefield tapped, then shuffle. If this spell was kicked, create two 1/1 white Soldier creature tokens.

--- a/forge-gui/res/cardsfolder/rebalanced/a-soul_of_windgrace.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-soul_of_windgrace.txt
@@ -9,6 +9,6 @@ A:AB$ GainLife | Cost$ G Discard<1/Land> | LifeAmount$ 3 | SpellDescription$ You
 A:AB$ Draw | Cost$ R Discard<1/Land> | SpellDescription$ Draw a card.
 A:AB$ Pump | Cost$ B Discard<1/Land> | KW$ Indestructible | SubAbility$ DBTap | StackDescription$ SpellDescription | SpellDescription$ CARDNAME gains indestructible until end of turn.
 SVar:DBTap:DB$ Tap | Defined$ Self | StackDescription$ SpellDescription | SpellDescription$ Tap it.
-DeckHas:Ability$LifeGain|Discard & Keyword$Indestructible
+DeckHas:Ability$LifeGain|Discard|Graveyard & Keyword$Indestructible
 SVar:HasAttackEffect:TRUE
 Oracle:Whenever Soul of Windgrace enters the battlefield or attacks, you may put a land card from a graveyard onto the battlefield tapped under your control.\n{G}, Discard a land card: You gain 3 life.\n{R}, Discard a land card: Draw a card.\n{B}, Discard a land card: Soul of Windgrace gains indestructible until end of turn. Tap it.

--- a/forge-gui/res/cardsfolder/rebalanced/a-soul_of_windgrace.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-soul_of_windgrace.txt
@@ -1,0 +1,14 @@
+Name:A-Soul of Windgrace
+ManaCost:1 B R G
+Types:Legendary Creature Cat Avatar
+PT:5/4
+T:Mode$ ChangesZone | Origin$ Any | OptionalDecider$ You | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChangeZone | TriggerDescription$ Whenever CARDNAME enters the battlefield or attacks, you may put a land card from a graveyard onto the battlefield tapped under your control.
+T:Mode$ Attacks | ValidCard$ Card.Self | OptionalDecider$ You | Execute$ TrigChangeZone | Secondary$ True | TriggerDescription$ Whenever CARDNAME enters the battlefield or attacks, you may put a land card from a graveyard onto the battlefield tapped under your control.
+SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | GainControl$ True | Tapped$ True | Hidden$ True | ChangeType$ Land
+A:AB$ GainLife | Cost$ G Discard<1/Land> | LifeAmount$ 3 | SpellDescription$ You gain 3 life.
+A:AB$ Draw | Cost$ R Discard<1/Land> | SpellDescription$ Draw a card.
+A:AB$ Pump | Cost$ B Discard<1/Land> | KW$ Indestructible | SubAbility$ DBTap | StackDescription$ SpellDescription | SpellDescription$ CARDNAME gains indestructible until end of turn.
+SVar:DBTap:DB$ Tap | Defined$ Self | StackDescription$ SpellDescription | SpellDescription$ Tap it.
+DeckHas:Ability$LifeGain|Discard & Keyword$Indestructible
+SVar:HasAttackEffect:TRUE
+Oracle:Whenever Soul of Windgrace enters the battlefield or attacks, you may put a land card from a graveyard onto the battlefield tapped under your control.\n{G}, Discard a land card: You gain 3 life.\n{R}, Discard a land card: Draw a card.\n{B}, Discard a land card: Soul of Windgrace gains indestructible until end of turn. Tap it.

--- a/forge-gui/res/cardsfolder/rebalanced/a-splitting_the_powerstone.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-splitting_the_powerstone.txt
@@ -1,0 +1,8 @@
+Name:A-Splitting the Powerstone
+ManaCost:2 U
+Types:Instant
+A:SP$ Token | Cost$ 2 U Sac<1/Artifact> | TokenAmount$ 2 | TokenTapped$ True | TokenScript$ c_a_powerstone | TokenOwner$ You | SubAbility$ DBDraw | SpellDescription$ Create two tapped Powerstone tokens. Draw a card.
+SVar:DBDraw:DB$ Draw
+DeckHints:Type$Artifact
+DeckHas:Ability$Sacrifice|Token & Type$Artifact
+Oracle:As an additional cost to cast this spell, sacrifice an artifact.\nCreate two tapped Powerstone tokens. Draw a card.

--- a/forge-gui/res/cardsfolder/rebalanced/a-sprouting_goblin.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-sprouting_goblin.txt
@@ -1,0 +1,11 @@
+Name:A-Sprouting Goblin
+ManaCost:1 R
+Types:Creature Goblin Druid
+PT:2/2
+K:Kicker:G
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self+kicked | Execute$ TrigChange | TriggerDescription$ When CARDNAME enters the battlefield, if it was kicked, search your library for a land card with a basic land type, reveal it, put it into your hand, then shuffle.
+SVar:TrigChange:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Land.hasABasicLandType
+A:AB$ Draw | Cost$ T Sac<1/Land> | NumCards$ 1 | SpellDescription$ Draw a card.
+DeckHas:Ability$Sacrifice
+DeckHints:Color$Green
+Oracle:Kicker {G}\nWhen Sprouting Goblin enters the battlefield, if it was kicked, search your library for a land card with a basic land type, reveal it, put it into your hand, then shuffle.\n{T}, Sacrifice a land: Draw a card.

--- a/forge-gui/res/cardsfolder/rebalanced/a-sunbathing_rootwalla.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-sunbathing_rootwalla.txt
@@ -1,0 +1,8 @@
+Name:A-Sunbathing Rootwalla
+ManaCost:1 G
+Types:Creature Lizard
+PT:2/2
+A:AB$ Pump | Cost$ 1 G | Defined$ Self | NumAtt$ X | NumDef$ X | ActivationLimit$ 1 | PrecostDesc$ Domain — | SpellDescription$ Until end of turn, CARDNAME gets +1/+1 for each basic land type among lands you control. Activate only once each turn.
+SVar:X:Count$Domain
+AI:RemoveDeck:Random
+Oracle:Domain — {1}{G}: Until end of turn, Sunbathing Rootwalla gets +1/+1 for each basic land type among lands you control. Activate only once each turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-tatyova_steward_of_tides.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-tatyova_steward_of_tides.txt
@@ -1,0 +1,10 @@
+Name:A-Tatyova, Steward of Tides
+ManaCost:G G U
+Types:Legendary Creature Merfolk Druid
+PT:4/4
+S:Mode$ Continuous | Affected$ Creature.Land+YouCtrl | AddKeyword$ Flying | Description$ Land creatures you control have flying.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | IsPresent$ Land.YouCtrl | PresentCompare$ GE7 | TriggerZones$ Battlefield | Execute$ TrigAnimate | TriggerDescription$ Whenever a land enters the battlefield under your control, if you control seven or more lands, up to one target land you control becomes a 4/4 Elemental creature with haste. It's still a land.
+SVar:TrigAnimate:DB$ Animate | ValidTgts$ Land.YouCtrl | TargetMin$ 0 | TargetMax$ 1 | Duration$ Permanent | TgtPrompt$ Select up to one target land you control | Power$ 4 | Toughness$ 4 | Types$ Elemental,Creature | Keywords$ Haste
+DeckHints:Type$Land
+SVar:BuffedBy:Land
+Oracle:Land creatures you control have flying.\nWhenever a land enters the battlefield under your control, if you control seven or more lands, up to one target land you control becomes a 4/4 Elemental creature with haste. It's still a land.

--- a/forge-gui/res/cardsfolder/rebalanced/a-thran_portal.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-thran_portal.txt
@@ -1,0 +1,9 @@
+Name:A-Thran Portal
+ManaCost:no cost
+Types:Land Gate
+K:ETBReplacement:Other:DBChooseBasic
+SVar:DBChooseBasic:DB$ ChooseType | Type$ Basic Land | SpellDescription$ As CARDNAME enters the battlefield, choose a basic land type.
+S:Mode$ Continuous | Affected$ Card.Self | AddType$ ChosenType | Description$ CARDNAME is the chosen type in addition to its other types.
+S:Mode$ RaiseCost | Type$ Ability | ValidSpell$ Activated.ManaAbility | ValidCard$ Card.Self | Cost$ PayLife<1> | EffectZone$ All | Description$ Mana abilities of CARDNAME cost an additional 1 life to activate.
+AI:RemoveDeck:All
+Oracle:As Thran Portal enters the battlefield, choose a basic land type.\nThran Portal is the chosen type in addition to its other types.\nMana abilities of Thran Portal cost an additional 1 life to activate.

--- a/forge-gui/res/cardsfolder/rebalanced/a-thran_spider.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-thran_spider.txt
@@ -1,0 +1,10 @@
+Name:A-Thran Spider
+ManaCost:3
+Types:Artifact Creature Spider
+PT:2/4
+K:Reach
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters the battlefield, you and target opponent each create a tapped Powerstone token.
+SVar:TrigToken:DB$ Token | ValidTgts$ Opponent | TokenOwner$ TargetedAndYou | TokenAmount$ 1 | TokenTapped$ True | TokenScript$ c_a_powerstone
+A:SP$ Dig | Cost$ 7 | DigNum$ 4 | ChangeNum$ 1 | RestRandomOrder$ True | NoReveal$ True | SpellDescription$ Look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in a random order.
+DeckHas:Ability$Token
+Oracle:Reach\nWhen Thran Spider enters the battlefield, you and target opponent each create a tapped Powerstone token.\n{7}: Look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in a random order.

--- a/forge-gui/res/cardsfolder/rebalanced/a-urza_powerstone_prodigy.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-urza_powerstone_prodigy.txt
@@ -1,0 +1,11 @@
+Name:A-Urza, Powerstone Prodigy
+ManaCost:1 U
+Types:Legendary Creature Human Artificer
+PT:1/3
+A:AB$ Draw | Cost$ 1 T | SubAbility$ DBDiscard | SpellDescription$ Draw a card, then discard a card.
+SVar:DBDiscard:DB$ Discard | Mode$ TgtChoose
+T:Mode$ DiscardedAll | ValidPlayer$ You | ValidCard$ Card.Artifact | TriggerZones$ Battlefield | ActivationLimit$ 1 | Execute$ TrigPowerstone | TriggerDescription$ Whenever you discard one or more artifact cards, create a tapped Powerstone token. This ability triggers only once each turn.
+SVar:TrigPowerstone:DB$ Token | TokenTapped$ True | TokenScript$ c_a_powerstone
+DeckHas:Ability$Discard|Token & Type$Artifact
+DeckHints:Type$Artifact
+Oracle:{1}, {T}: Draw a card, then discard a card.\nWhenever you discard one or more artifact cards, create a tapped Powerstone token. This ability triggers only once each turn.

--- a/forge-gui/res/cardsfolder/rebalanced/a-urzas_command.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-urzas_command.txt
@@ -1,0 +1,12 @@
+Name:A-Urza's Command
+ManaCost:2 U U
+Types:Instant
+A:SP$ Charm | Choices$ DBPump,DBPowerStone,DBKarnstruct,DBDraw | CharmNum$ 2
+SVar:DBPump:DB$ PumpAll | ValidCards$ Card.Creature+YouDontCtrl | NumAtt$ -3 | SpellDescription$ Creatures you don't control get -3/-0 until end of turn.
+SVar:DBPowerStone:DB$ Token | TokenAmount$ 2 | TokenTapped$ True | TokenScript$ c_a_powerstone | SpellDescription$ Create two tapped Powerstone tokens.
+SVar:DBKarnstruct:DB$ Token |  TokenScript$ c_0_0_a_construct_total_artifacts | TokenTapped$ True | SpellDescription$ Create a tapped 0/0 colorless Construct artifact creature token with "This creature gets +1/+1 for each artifact you control."
+SVar:DBDraw:DB$ Scry | ScryNum$ 2 | SubAbility$ Draw | SpellDescription$ Scry 2, then draw a card.
+SVar:Draw:DB$ Draw | Defined$ You | NumCards$ 1
+DeckHas:Ability$Token & Type$Artifact|Construct
+DeckHints:Type$Urza
+Oracle:Choose two -\n•Creatures you don't control get -3/-0 until end of turn\n•Create two tapped Powerstone tokens.\n•Create a tapped 0/0 colorless Construct artifact creature token with "This creature gets +1/+1 for each artifact you control."\n• Scry 2, then draw a card.

--- a/forge-gui/res/cardsfolder/rebalanced/a-uurg_spawn_of_turg.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-uurg_spawn_of_turg.txt
@@ -7,6 +7,6 @@ T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | E
 SVar:TrigSurveil:DB$ Surveil | Amount$ 2
 A:AB$ GainLife | Cost$ 1 Sac<1/Land> | LifeAmount$ 2
 SVar:X:Count$TypeInYourYard.Land
-DeckHas:Ability$LifeGain|Graveyard
+DeckHas:Ability$LifeGain|Graveyard|Sacrifice
 DeckHints:Ability$Graveyard
 Oracle:Uurg, Spawn of Turg's power is equal to the number of land cards in your graveyard.\nAt the beginning of your upkeep, surveil 2.\n{1}, Sacrifice a land: You gain 2 life.

--- a/forge-gui/res/cardsfolder/rebalanced/a-uurg_spawn_of_turg.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-uurg_spawn_of_turg.txt
@@ -1,0 +1,12 @@
+Name:A-Uurg, Spawn of Turg
+ManaCost:B B G
+Types:Legendary Creature Frog Beast
+PT:*/5
+S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of land cards in your graveyard.
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigSurveil | TriggerDescription$ At the beginning of your upkeep, surveil 2.
+SVar:TrigSurveil:DB$ Surveil | Amount$ 2
+A:AB$ GainLife | Cost$ 1 Sac<1/Land> | LifeAmount$ 2
+SVar:X:Count$TypeInYourYard.Land
+DeckHas:Ability$LifeGain|Graveyard
+DeckHints:Ability$Graveyard
+Oracle:Uurg, Spawn of Turg's power is equal to the number of land cards in your graveyard.\nAt the beginning of your upkeep, surveil 2.\n{1}, Sacrifice a land: You gain 2 life.

--- a/forge-gui/res/cardsfolder/rebalanced/a-visions_of_phyrexia.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-visions_of_phyrexia.txt
@@ -1,0 +1,21 @@
+Name:A-Visions of Phyrexia
+ManaCost:2 R R
+Types:Enchantment
+T:Mode$ Phase | Phase$ Upkeep | TriggerZones$ Battlefield | ValidPlayer$ You | Execute$ TrigExile | TriggerDescription$ At the beginning of your upkeep, exile the top two cards of your library. Until your next end step, you may play one of those cards.
+SVar:TrigExile:DB$ Dig | Defined$ You | DigNum$ 2 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBEffect
+SVar:DBEffect:DB$ Effect | StaticAbilities$ STPlay | Triggers$ Play1,Play2 | RememberObjects$ Remembered | ForgetOnMoved$ Exile | Duration$ UntilYourNextEndStep | SubAbility$ DBCleanup
+SVar:STPlay:Mode$ Continuous | EffectZone$ Command | AffectedZone$ Exile | Affected$ Card.IsRemembered | MayPlay$ True | Description$ Until your next end step, you may play one of those cards.
+SVar:Play1:Mode$ SpellCast | ValidCard$ Card.IsRemembered | ValidActivatingPlayer$ You | TriggerZones$ Command | Execute$ ExileSelf | Static$ True
+SVar:Play2:Mode$ LandPlayed | ValidCard$ Land.IsRemembered | TriggerZones$ Command | Execute$ ExileSelf | Static$ True
+SVar:ExileSelf:DB$ ChangeZone | Origin$ Command | Destination$ Exile
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | CheckSVar$ X | SVarCompare$ EQ0 | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ At the beginning of your end step, if you didn't play a card from exile this turn, create a tapped Powerstone token.
+SVar:TrigToken:DB$ Token | TokenTapped$ True | TokenScript$ c_a_powerstone
+T:Mode$ LandPlayed | Origin$ Exile | ValidCard$ Land.YouCtrl | Execute$ StoreVar | Static$ True
+SVar:StoreVar:DB$ StoreSVar | SVar$ LandsPlayedFromExile | Type$ Number | Expression$ 1
+T:Mode$ Phase | Phase$ Cleanup | Execute$ TrigReset | Static$ True
+SVar:TrigReset:DB$ StoreSVar | SVar$ LandsPlayedFromExile | Type$ Number | Expression$ 0
+SVar:X:Count$ThisTurnCast_Card.YouCtrl+wasCastFromExile/Plus.LandsPlayedFromExile
+SVar:LandsPlayedFromExile:Number$0
+DeckHas:Ability$Token & Type$Artifact
+Oracle:At the beginning of your upkeep, exile the top two cards of your library. Until your next end step, you may play one of those cards.\nAt the beginning of your end step, if you didn't play a card from exile this turn, create a tapped Powerstone token.

--- a/forge-gui/res/cardsfolder/rebalanced/a-zar_ojanen_scion_of_efrava.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-zar_ojanen_scion_of_efrava.txt
@@ -1,0 +1,10 @@
+Name:A-Zar Ojanen, Scion of Efrava
+ManaCost:3 G W
+Types:Legendary Creature Cat Warrior
+PT:4/4
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPutcounter | TriggerDescription$ Domain — Whenever CARDNAME enters the battlefield or becomes tapped, put a +1/+1 counter on each creature you control with toughness less than the number of basic land types among lands you control.
+T:Mode$ Taps | ValidCard$ Card.Self | Execute$ TrigPutcounter | TriggerZones$ Battlefield | TriggerDescription$ Domain — Whenever CARDNAME enters the battlefield or becomes tapped, put a +1/+1 counter on each creature you control with toughness less than the number of basic land types among lands you control.
+SVar:TrigPutcounter:DB$ PutCounterAll | ValidCards$ Creature.YouCtrl+toughnessLTX | CounterType$ P1P1 | CounterNum$ 1
+SVar:X:Count$Domain
+DeckHas:Ability$Counters
+Oracle:Domain — Whenever Zar Ojanen, Scion of Efrava enters the battlefield or becomes tapped, put a +1/+1 counter on each creature you control with toughness less than the number of basic land types among lands you control.

--- a/forge-gui/res/cardsfolder/s/saheeli_filigree_master.txt
+++ b/forge-gui/res/cardsfolder/s/saheeli_filigree_master.txt
@@ -5,10 +5,10 @@ Loyalty:3
 A:AB$ Scry | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | ScryNum$ 1 | SubAbility$ DBDraw | SpellDescription$ Scry 1. You may tap an untapped artifact you control. If you do, draw a card.
 SVar:DBDraw:DB$ Draw | UnlessCost$ tapXType<1/Artifact> | UnlessPayer$ You | UnlessSwitched$ True
 A:AB$ Token | Cost$ SubCounter<2/LOYALTY> | Planeswalker$ True | PumpDuration$ EOT | TokenAmount$ 2 | PumpKeywords$ Haste | TokenScript$ c_1_1_a_thopter_flying | TokenOwner$ You | SpellDescription$ Create two 1/1 colorless Thopter artifact creature tokens with flying. They gain haste until end of turn.
-A:AB$ Effect | Cost$ SubCounter<4/LOYALTY> | Name$ Emblem - Saheeli, Filigree Master | StaticAbilities$ EmblemArtifactPump,ReduceCost | Planeswalker$ True | Ultimate$ True | Stackable$ False | Duration$ Permanent | AILogic$ Always | SpellDescription$ You get an emblem with "Artifact creatures you control get +1/+1" and "Artifact spells you cast cost 1 less to cast."
+A:AB$ Effect | Cost$ SubCounter<4/LOYALTY> | Name$ Emblem - Saheeli, Filigree Master | StaticAbilities$ EmblemArtifactPump,ReduceCost | Planeswalker$ True | Ultimate$ True | Stackable$ False | Duration$ Permanent | AILogic$ Always | SpellDescription$ You get an emblem with "Artifact creatures you control get +1/+1" and "Artifact spells you cast cost {1} less to cast."
 SVar:EmblemArtifactPump:Mode$ Continuous | AddPower$ 1 | AddToughness$ 1 | EffectZone$ Command | Affected$ Artifact.YouCtrl | AffectedZone$ Battlefield | Description$ Artifact creatures you control get +1/+1.
-SVar:ReduceCost:Mode$ ReduceCost | ValidCard$ Artifact | Type$ Spell | Activator$ You | Amount$ 1 | Description$ Artifact spells you cast cost {1} less to cast. | Description$ Artifact spells you cast cost 1 less to cast.
+SVar:ReduceCost:Mode$ ReduceCost | ValidCard$ Artifact | Type$ Spell | Activator$ You | Amount$ 1 | Description$ Artifact spells you cast cost {1} less to cast.
 DeckHas:Ability$Token
 DeckHints:Type$Artifact
 DeckHas:Ability$Token & Type$Thopter
-Oracle:[+1]: Scry 1. You may tap an untapped artifact you control. If you do, draw a card.\n[-2]: Create two 1/1 colorless Thopter artifact creature tokens with flying. They gain haste until end of turn.\n[-4]: You get an emblem with "Artifact creatures you control get +1/+1" and "Artifact spells you cast cost 1 less to cast."
+Oracle:[+1]: Scry 1. You may tap an untapped artifact you control. If you do, draw a card.\n[-2]: Create two 1/1 colorless Thopter artifact creature tokens with flying. They gain haste until end of turn.\n[-4]: You get an emblem with "Artifact creatures you control get +1/+1" and "Artifact spells you cast cost {1} less to cast."

--- a/forge-gui/res/cardsfolder/s/soul_of_windgrace.txt
+++ b/forge-gui/res/cardsfolder/s/soul_of_windgrace.txt
@@ -9,6 +9,6 @@ A:AB$ GainLife | Cost$ G Discard<1/Land> | LifeAmount$ 3 | SpellDescription$ You
 A:AB$ Draw | Cost$ 1 R Discard<1/Land> | SpellDescription$ Draw a card.
 A:AB$ Pump | Cost$ 2 B Discard<1/Land> | KW$ Indestructible | SubAbility$ DBTap | StackDescription$ SpellDescription | SpellDescription$ CARDNAME gains indestructible until end of turn.
 SVar:DBTap:DB$ Tap | Defined$ Self | StackDescription$ SpellDescription | SpellDescription$ Tap it.
-DeckHas:Ability$LifeGain|Discard & Keyword$Indestructible
+DeckHas:Ability$LifeGain|Discard|Graveyard & Keyword$Indestructible
 SVar:HasAttackEffect:TRUE
 Oracle:Whenever Soul of Windgrace enters the battlefield or attacks, you may put a land card from a graveyard onto the battlefield tapped under your control.\n{G}, Discard a land card: You gain 3 life.\n{1}{R}, Discard a land card: Draw a card.\n{2}{B}, Discard a land card: Soul of Windgrace gains indestructible until end of turn. Tap it.

--- a/forge-gui/res/cardsfolder/t/the_eleventh_hour.txt
+++ b/forge-gui/res/cardsfolder/t/the_eleventh_hour.txt
@@ -3,8 +3,8 @@ ManaCost:3 U
 Types:Enchantment Saga
 K:Chapter:3:DBSearch,DBFood,DBCopy
 SVar:DBSearch:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Card.Doctor | ChangeNum$ 1 | SpellDescription$ Search your library for a Doctor card, reveal it, put it into your hand, then shuffle.
-SVar:DBFood:DB$ Token | TokenAmount$ 1 | TokenScript$ c_a_food_sac,w_1_1_human_doctor_reduce | SpellDescription$ Create a Food token and a 1/1 white Human creature token with "Doctor spells you cast cost 1 less to cast."
+SVar:DBFood:DB$ Token | TokenAmount$ 1 | TokenScript$ c_a_food_sac,w_1_1_human_doctor_reduce | SpellDescription$ Create a Food token and a 1/1 white Human creature token with "Doctor spells you cast cost {1} less to cast."
 SVar:DBCopy:DB$ CopyPermanent | ValidTgts$ Creature | NewName$ Prisoner Zero | SetCreatureTypes$ Alien | AddTypes$ Legendary | SpellDescription$ Create a token that's a copy of target creature, except it's a legendary Alien named Prisoner Zero.
 DeckHas:Ability$Token|Sacrifice & Type$Alien|Human|Food|Artifact|Creature
 DeckNeeds:Type$Doctor
-Oracle:(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI — Search your library for a Doctor card, reveal it, put it into your hand, then shuffle.\nII — Create a Food token and a 1/1 white Human creature token with "Doctor spells you cast cost 1 less to cast."\nIII — Create a token that's a copy of target creature, except it's a legendary Alien named Prisoner Zero.
+Oracle:(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI — Search your library for a Doctor card, reveal it, put it into your hand, then shuffle.\nII — Create a Food token and a 1/1 white Human creature token with "Doctor spells you cast cost {1} less to cast."\nIII — Create a token that's a copy of target creature, except it's a legendary Alien named Prisoner Zero.

--- a/forge-gui/res/cardsfolder/u/uurg_spawn_of_turg.txt
+++ b/forge-gui/res/cardsfolder/u/uurg_spawn_of_turg.txt
@@ -7,6 +7,6 @@ T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | E
 SVar:TrigSurveil:DB$ Surveil | Amount$ 1
 A:AB$ GainLife | Cost$ B G Sac<1/Land> | LifeAmount$ 2
 SVar:X:Count$TypeInYourYard.Land
-DeckHas:Ability$LifeGain|Graveyard
+DeckHas:Ability$LifeGain|Graveyard|Sacrifice
 DeckHints:Ability$Graveyard
 Oracle:Uurg, Spawn of Turg's power is equal to the number of land cards in your graveyard.\nAt the beginning of your upkeep, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)\n{B}{G}, Sacrifice a land: You gain 2 life.

--- a/forge-gui/res/cardsfolder/y/yotian_courier.txt
+++ b/forge-gui/res/cardsfolder/y/yotian_courier.txt
@@ -6,9 +6,9 @@ K:Flying
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigCharm | TriggerDescription$ Whenever CARDNAME attacks, ABILITY
 SVar:TrigCharm:DB$ Charm | Choices$ Powerstone,Seek | ChoiceRestriction$ YourLastCombat
 SVar:Powerstone:DB$ Token | TokenTapped$ True | TokenScript$ c_a_powerstone | SpellDescription$ Create a tapped Powerstone token.
-SVar:Seek:DB$ Seek | Type$ Artifact.cmcEQX | SpellDescription$ Seek an artifact card with mana value equal to the number of Powerstones you control.
+SVar:Seek:DB$ Seek | Type$ Card.nonLand+cmcEQX | SpellDescription$ Seek a nonland card with mana value equal to the number of Powerstones you control.
 SVar:X:Count$Valid Powerstone.YouCtrl
 DeckNeeds:Type$Artifact
 DeckHas:Ability$Token & Type$Artifact
 SVar:HasAttackEffect:TRUE
-Oracle:Flying\nWhenever Yotian Courier attacks, choose one that wasn't chosen during your last combat —\n• Create a tapped Powerstone token.\n• Seek an artifact card with mana value equal to the number of Powerstones you control.
+Oracle:Flying\nWhenever Yotian Courier attacks, choose one that wasn't chosen during your last combat —\n• Create a tapped Powerstone token.\n• Seek a nonland card with mana value equal to the number of Powerstones you control.

--- a/forge-gui/res/editions/Dominaria United.txt
+++ b/forge-gui/res/editions/Dominaria United.txt
@@ -461,6 +461,24 @@ ScryfallCode=DMU
 435 M Sheoldred, the Apocalypse @Richard Whitters
 436 M Sheoldred, the Apocalypse @Richard Whitters
 
+[rebalanced]
+A1 M A-Karn, Living Legacy @Chris Rahn
+A138 C A-Meria's Outrider @Lius Lasahido
+A141 R A-Radha's Firebrand @Ângelo Bortolini
+A145 U A-Sprouting Goblin @Uriah Voth
+A169 R A-Llanowar Greenwidow @Jokubas Uogintas
+A170 R A-Llanowar Loamspeaker @Zara Alfonso
+A176 C A-Scout the Wilderness @A. M. Sartor
+A181 C A-Sunbathing Rootwalla @Campbell White
+A207 U A-Nael, Avizoa Aeronaut @Miguel Mercado
+A217 U A-Rulik Mons, Warren Chief @Tuan Duong Chu
+A220 M A-Soul of Windgrace @Liiga Smilshkalne
+A222 U A-Tatyova, Steward of Tides @Howard Lyon
+A225 U A-Uurg, Spawn of Turg @Nicholas Gregory
+A227 U A-Zar Ojanen, Scion of Efrava @Justine Cruz
+A259 R A-Thran Portal @Sarah Finnigan
+A286 R A-Briar Hydra @Caio Monteiro
+
 [lands]
 2 Plains|DMU|1
 2 Plains|DMU|2

--- a/forge-gui/res/editions/Multiverse Legends.txt
+++ b/forge-gui/res/editions/Multiverse Legends.txt
@@ -202,6 +202,9 @@ ScryfallCode=MUL
 194 R Yorion, Sky Nomad @Justine Mara Andersen
 195 R Zirda, the Dawnwaker @Justine Mara Andersen
 
+[rebalanced]
+A55 U A-Radha, Coalition Warlord @Justin Hernandez & Alexis Hernandez
+
 [draft booster]
 2 Anafenza, Kin-Tree Spirit|MUL
 7 Daxos, Blessed by the Sun|MUL
@@ -268,7 +271,6 @@ ScryfallCode=MUL
 1 Yarok, the Desecrated|MUL
 2 Yorion, Sky Nomad|MUL
 2 Zirda, the Dawnwaker|MUL
-
 
 [tokens]
 r_3_1_elemental_trample_haste

--- a/forge-gui/res/editions/The Brothers War.txt
+++ b/forge-gui/res/editions/The Brothers War.txt
@@ -407,7 +407,18 @@ ScryfallCode=BRO
 384 U Blanchwood Armor @Manuel Castañón
 
 [rebalanced]
+A58 C A-Mightstone's Animation @Igor Kieryluk
+A63 U A-Splitting the Powerstone @Campbell White
+A69 U A-Urza, Powerstone Prodigy @Donato Giancola
+A70 R A-Urza's Command @Dominik Mayer
+A132 C A-Excavation Explosion @Campbell White
+A140 U A-Mishra, Excavation Prodigy @Donato Giancola
+A156 R A-Visions of Phyrexia @Dominik Mayer
 A199 U A-Haywire Mite @Izzy
+A219 M A-Saheeli, Filigree Master @Aurore Folny
+A254 R A-Thran Spider @Joshua Cairos
+A263 R A-Hall of Tagsin @Christian Dimitrov
+A289 R A-Geology Enthusiast @Fajareka Setiawan
 
 [lands]
 2 Plains|BRO|1


### PR DESCRIPTION
Source: https://magic.wizards.com/en/news/mtg-arena/mtg-arena-announcements-january-12-2024

- [x] Briar Hydra
- [x] Excavation Explosion
- [x] Geology Enthusiast
- [x] Hall of Tagsin
- [x] Hurkyl's Prodigy (Alchemy only - no new script needed)
- [x] Karn, Living Legacy
- [x] Llanowar Greenwidow
- [x] Llanowar Loamspeaker
- [x] Meria's Outrider
- [x] Mightstone's Animation
- [x] Mishra, Excavation Prodigy
- [x] Nael, Avizoa Aeronaut
- [x] Radha's Firebrand
- [x] Radha, Coalition Warlord
- [x] Rulik Mons, Warren Chief
- [x] Saheeli, Filigree Master
- [x] Scout the Wilderness
- [x] Soul of Windgrace
- [x] Splitting the Powerstone
- [x] Sprouting Goblin
- [x] Sunbathing Rootwalla
- [x] Tatyova, Steward of Tides
- [x] Thran Portal
- [x] Thran Spider
- [x] Urza's Command
- [x] Urza, Powerstone Prodigy
- [x] Uurg, Spawn of Turg
- [x] Visions of Phyrexia
- [x] Yotian Courier (Alchemy only - no new script needed)
- [x] Zar Ojanen, Scion of Efrava