### PR TITLE
Fix: Ravnica Remastered draft

### DIFF
--- a/forge-gui/res/blockdata/blocks.txt
+++ b/forge-gui/res/blockdata/blocks.txt
@@ -129,4 +129,4 @@ Wilds of Eldraine, 3/6/WOE, WOE
 Alchemy: Eldraine, 3/6/WOE, YWOE
 The Lost Caverns of Ixalan, 3/6/LCI, LCI
 Alchemy: Ixalan, 3/6/LCI, YLCI
-Ravnica Remastered, 3/6/RVR, RVR
+Ravnica Remastered, 3/6/RAV, RVR


### PR DESCRIPTION
I made a mistake while extending the blocks.txt file. Ravnica Remastered has no basics, so the entry there has the problem, that after the draft, the a.i. has no basics to choose from and will not add any to their decks.