### PR TITLE
Draft rankings:  make split cards retrievable

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/limited/ReadDraftRankings.java
+++ b/forge-gui/src/main/java/forge/gamemodes/limited/ReadDraftRankings.java
@@ -114,6 +114,9 @@ public class ReadDraftRankings {
             // This should be updated
             String safeName = StringUtils.stripAccents(cardName);
 
+            // handle split cards
+            safeName = safeName.replace(" // ", " ");
+
             // If a card has no ranking, don't try to look it up --BBU
             if (draftRankings.get(edition).get(safeName) == null) {
                 // System.out.println("WARNING! " + safeName + " NOT found in " + edition);


### PR DESCRIPTION
Fixes #4522

Not the prettiest solution though.

Proof it works:
<img width="141" alt="Screenshot 2024-01-16 at 11 29 21" src="https://github.com/Card-Forge/forge/assets/621371/b24ab319-8c0f-40ff-8560-3d708f77827c">
