### PR TITLE
Improve ranking scraper

### DIFF
--- a/forge-gui/tools/RankingScraper.py
+++ b/forge-gui/tools/RankingScraper.py
@@ -47,6 +47,7 @@ def draftsimRankings(edition='KHM', extra=None):
 	cardlist = list(unique_cards.values())
 	cardlist.sort(key=lambda k:k['myrating'], reverse=True)
 	with open("../res/draft/rankings/" + edition.lower() + '.rnk', 'w') as out:
+		out.write('//Rank|Name|Rarity|Set\n')
 		for counter, card in enumerate(cardlist):
 			l = [str(counter+1), card['name'].replace('_', ' '), card['rarity'], edition]
 			out.write('#')

--- a/forge-gui/tools/RankingScraper.py
+++ b/forge-gui/tools/RankingScraper.py
@@ -37,6 +37,14 @@ def draftsimRankings(edition='KHM', extra=None):
 	print(txt3)
 
 	cardlist = json.loads(txt3)
+
+	# remove duplicates
+	unique_cards = dict()
+	for card in cardlist:
+		if card['name'] not in unique_cards:
+			unique_cards[card['name']] = card
+
+	cardlist = list(unique_cards.values())
 	cardlist.sort(key=lambda k:k['myrating'], reverse=True)
 	with open("../res/draft/rankings/" + edition.lower() + '.rnk', 'w') as out:
 		for counter, card in enumerate(cardlist):

--- a/forge-gui/tools/RankingScraper.py
+++ b/forge-gui/tools/RankingScraper.py
@@ -81,4 +81,4 @@ if __name__ == "__main__":
 
 	result = parser.parse_args()
 
-	draftsimRankings(result.setcode, result.name)
+	draftsimRankings(result.setcode, result.altpage)

--- a/forge-gui/tools/RankingScraper.py
+++ b/forge-gui/tools/RankingScraper.py
@@ -34,7 +34,7 @@ def draftsimRankings(edition='KHM', extra=None):
 
 	txt3 = txt + txt2
 	txt3 = txt3.replace(u'\xa9', '')
-	print(txt3)
+	# print(txt3)
 
 	cardlist = json.loads(txt3)
 


### PR DESCRIPTION
Some minor improvements:
- add proper ranking file header (was missing)
- disable debug output of json data
- fix name of altpage argument (script would not work without this fix)
- avoid duplicate card entries (was criticized here #4511 and fixed manually by paulsnoops)

Now the created ranking file looks nice and tidy.


---

Example usage (for Ravnica Remastered):
```sh
cd forge-gui/tools
python3 RankingScraper.py -c RVR    
```


I did not have all the dependencies installed and needed to do this beforehand:
```sh
 pip3 install requests 
```