### PR TITLE
Fix some rebalanced errors

### DIFF
--- a/forge-gui/res/cardsfolder/rebalanced/a-visions_of_phyrexia.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-visions_of_phyrexia.txt
@@ -1,10 +1,10 @@
 Name:A-Visions of Phyrexia
-ManaCost:2 R R
+ManaCost:3 R
 Types:Enchantment
-T:Mode$ Phase | Phase$ Upkeep | TriggerZones$ Battlefield | ValidPlayer$ You | Execute$ TrigExile | TriggerDescription$ At the beginning of your upkeep, exile the top two cards of your library. Until your next end step, you may play one of those cards.
+T:Mode$ Phase | Phase$ Upkeep | TriggerZones$ Battlefield | ValidPlayer$ You | Execute$ TrigExile | TriggerDescription$ At the beginning of your upkeep, exile the top two cards of your library. You may play one of those cards this turn.
 SVar:TrigExile:DB$ Dig | Defined$ You | DigNum$ 2 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBEffect
-SVar:DBEffect:DB$ Effect | StaticAbilities$ STPlay | Triggers$ Play1,Play2 | RememberObjects$ Remembered | ForgetOnMoved$ Exile | Duration$ UntilYourNextEndStep | SubAbility$ DBCleanup
-SVar:STPlay:Mode$ Continuous | EffectZone$ Command | AffectedZone$ Exile | Affected$ Card.IsRemembered | MayPlay$ True | Description$ Until your next end step, you may play one of those cards.
+SVar:DBEffect:DB$ Effect | StaticAbilities$ STPlay | Triggers$ Play1,Play2 | RememberObjects$ Remembered | ForgetOnMoved$ Exile | SubAbility$ DBCleanup
+SVar:STPlay:Mode$ Continuous | EffectZone$ Command | AffectedZone$ Exile | Affected$ Card.IsRemembered | MayPlay$ True | Description$ You may play one of those cards this turn.
 SVar:Play1:Mode$ SpellCast | ValidCard$ Card.IsRemembered | ValidActivatingPlayer$ You | TriggerZones$ Command | Execute$ ExileSelf | Static$ True
 SVar:Play2:Mode$ LandPlayed | ValidCard$ Land.IsRemembered | TriggerZones$ Command | Execute$ ExileSelf | Static$ True
 SVar:ExileSelf:DB$ ChangeZone | Origin$ Command | Destination$ Exile
@@ -18,4 +18,4 @@ SVar:TrigReset:DB$ StoreSVar | SVar$ LandsPlayedFromExile | Type$ Number | Expre
 SVar:X:Count$ThisTurnCast_Card.YouCtrl+wasCastFromExile/Plus.LandsPlayedFromExile
 SVar:LandsPlayedFromExile:Number$0
 DeckHas:Ability$Token & Type$Artifact
-Oracle:At the beginning of your upkeep, exile the top two cards of your library. Until your next end step, you may play one of those cards.\nAt the beginning of your end step, if you didn't play a card from exile this turn, create a tapped Powerstone token.
+Oracle:At the beginning of your upkeep, exile the top two cards of your library. You may play one of those cards this turn.\nAt the beginning of your end step, if you didn't play a card from exile this turn, create a tapped Powerstone token.

--- a/forge-gui/res/editions/Dominaria United.txt
+++ b/forge-gui/res/editions/Dominaria United.txt
@@ -471,6 +471,7 @@ A170 R A-Llanowar Loamspeaker @Zara Alfonso
 A176 C A-Scout the Wilderness @A. M. Sartor
 A181 C A-Sunbathing Rootwalla @Campbell White
 A207 U A-Nael, Avizoa Aeronaut @Miguel Mercado
+A211 U A-Radha, Coalition Warlord @Randy Vargas
 A217 U A-Rulik Mons, Warren Chief @Tuan Duong Chu
 A220 M A-Soul of Windgrace @Liiga Smilshkalne
 A222 U A-Tatyova, Steward of Tides @Howard Lyon

--- a/forge-gui/res/editions/Multiverse Legends.txt
+++ b/forge-gui/res/editions/Multiverse Legends.txt
@@ -202,9 +202,6 @@ ScryfallCode=MUL
 194 R Yorion, Sky Nomad @Justine Mara Andersen
 195 R Zirda, the Dawnwaker @Justine Mara Andersen
 
-[rebalanced]
-A55 U A-Radha, Coalition Warlord @Justin Hernandez & Alexis Hernandez
-
 [draft booster]
 2 Anafenza, Kin-Tree Spirit|MUL
 7 Daxos, Blessed by the Sun|MUL


### PR DESCRIPTION
Wizards' being Wizards'

The patch notes for A-Visions of Phyrexia do not reflfect the card on Arena so I've fixed it.

They also included A-Radha, Coalition Warlord from MUL when the rest were from DMU/BRO so moved it to group with the rest.