### PR TITLE
"this combat" bug

### DIFF
--- a/forge-game/src/main/java/forge/game/card/CardDamageHistory.java
+++ b/forge-game/src/main/java/forge/game/card/CardDamageHistory.java
@@ -309,5 +309,8 @@ public class CardDamageHistory {
 
     public void endCombat() {
         damagedThisCombat.clear();
+        setCreatureAttackedThisCombat(null, -1);
+        setCreatureBlockedThisCombat(false);
+        setCreatureGotBlockedThisCombat(false);
     }
 }

--- a/forge-game/src/main/java/forge/game/combat/Combat.java
+++ b/forge-game/src/main/java/forge/game/combat/Combat.java
@@ -31,6 +31,7 @@ import forge.game.spellability.SpellAbility;
 import forge.game.spellability.SpellAbilityStackInstance;
 import forge.game.staticability.StaticAbilityAssignCombatDamageAsUnblocked;
 import forge.game.trigger.TriggerType;
+import forge.game.zone.ZoneType;
 import forge.util.CardTranslation;
 import forge.util.Localizer;
 import forge.util.collect.FCollection;
@@ -155,10 +156,8 @@ public class Combat {
         combatantsThatDealtFirstStrikeDamage.clear();
 
         //clear tracking for cards that care about "this combat"
-        for (Card c : attackers) {
-            c.getDamageHistory().endCombat();
-        }
-        for (Card c : blockers) {
+        Game game = playerWhoAttacks.getGame();
+        for (Card c : game.getCardsIncludePhasingIn(ZoneType.Battlefield)) {
             c.getDamageHistory().endCombat();
         }
         playerWhoAttacks.clearAttackedPlayersMyCombat();

--- a/forge-game/src/main/java/forge/game/combat/Combat.java
+++ b/forge-game/src/main/java/forge/game/combat/Combat.java
@@ -154,13 +154,20 @@ public class Combat {
         lkiCache.clear();
         combatantsThatDealtFirstStrikeDamage.clear();
 
-        //update view for all attackers and blockers
+        //clear tracking for cards that care about "this combat"
         for (Card c : attackers) {
             c.getDamageHistory().endCombat();
-            c.updateAttackingForView();
         }
         for (Card c : blockers) {
             c.getDamageHistory().endCombat();
+        }
+        playerWhoAttacks.clearAttackedPlayersMyCombat();
+
+        //update view for all attackers and blockers
+        for (Card c : attackers) {
+            c.updateAttackingForView();
+        }
+        for (Card c : blockers) {
             c.updateBlockingForView();
         }
     }

--- a/forge-game/src/main/java/forge/game/phase/PhaseHandler.java
+++ b/forge-game/src/main/java/forge/game/phase/PhaseHandler.java
@@ -17,7 +17,6 @@
  */
 package forge.game.phase;
 
-<<<<<<< HEAD
 import com.google.common.base.Predicates;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Lists;
@@ -28,23 +27,6 @@ import forge.game.ability.AbilityKey;
 import forge.game.ability.effects.AddTurnEffect;
 import forge.game.ability.effects.SkipPhaseEffect;
 import forge.game.card.*;
-=======
-import java.util.*;
-
-import com.google.common.collect.*;
-import forge.game.card.*;
-import org.apache.commons.lang3.time.StopWatch;
-
-import forge.game.Game;
-import forge.game.GameEntity;
-import forge.game.GameEntityCounterTable;
-import forge.game.GameStage;
-import forge.game.GameType;
-import forge.game.GlobalRuleChange;
-import forge.game.ability.AbilityKey;
-import forge.game.ability.effects.AddTurnEffect;
-import forge.game.ability.effects.SkipPhaseEffect;
->>>>>>> 0a59add7a1 (fixed bug in cards using 'this combat')
 import forge.game.card.CardPredicates.Presets;
 import forge.game.combat.Combat;
 import forge.game.combat.CombatUtil;

--- a/forge-game/src/main/java/forge/game/phase/PhaseHandler.java
+++ b/forge-game/src/main/java/forge/game/phase/PhaseHandler.java
@@ -17,6 +17,7 @@
  */
 package forge.game.phase;
 
+<<<<<<< HEAD
 import com.google.common.base.Predicates;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Lists;
@@ -27,6 +28,23 @@ import forge.game.ability.AbilityKey;
 import forge.game.ability.effects.AddTurnEffect;
 import forge.game.ability.effects.SkipPhaseEffect;
 import forge.game.card.*;
+=======
+import java.util.*;
+
+import com.google.common.collect.*;
+import forge.game.card.*;
+import org.apache.commons.lang3.time.StopWatch;
+
+import forge.game.Game;
+import forge.game.GameEntity;
+import forge.game.GameEntityCounterTable;
+import forge.game.GameStage;
+import forge.game.GameType;
+import forge.game.GlobalRuleChange;
+import forge.game.ability.AbilityKey;
+import forge.game.ability.effects.AddTurnEffect;
+import forge.game.ability.effects.SkipPhaseEffect;
+>>>>>>> 0a59add7a1 (fixed bug in cards using 'this combat')
 import forge.game.card.CardPredicates.Presets;
 import forge.game.combat.Combat;
 import forge.game.combat.CombatUtil;
@@ -675,7 +693,6 @@ public class PhaseHandler implements java.io.Serializable {
             game.getTriggerHandler().runTrigger(TriggerType.AttackersDeclared, runParams, false);
         }
 
-        playerTurn.clearAttackedPlayersMyCombat();
         for (final Card c : combat.getAttackers()) {
             CombatUtil.checkDeclaredAttacker(game, c, combat, true);
         }
@@ -1275,9 +1292,6 @@ public class PhaseHandler implements java.io.Serializable {
     }
 
     public void endCombat() {
-        for (Player player : game.getPlayers()) {
-            player.resetCombatantsThisCombat();
-        }
         game.getEndOfCombat().executeUntil();
         game.getEndOfCombat().executeUntilEndOfPhase(playerTurn);
         if (inCombat()) {

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -2735,23 +2735,6 @@ public class Player extends GameEntity implements Comparable<Player> {
         view.updateCurrentPlaneName(currentPlanes.toString().replaceAll(" \\(.*","").replace("[",""));
     }
 
-    public final void resetCombatantsThisCombat() {
-        // resets the status of attacked/blocked this phase
-        CardCollectionView list = getCardsIn(ZoneType.Battlefield, false);
-
-        for (Card c : list) {
-            if (c.getDamageHistory().getCreatureAttackedThisCombat() > 0) {
-                c.getDamageHistory().setCreatureAttackedThisCombat(null, -1);
-            }
-            if (c.getDamageHistory().getCreatureBlockedThisCombat()) {
-                c.getDamageHistory().setCreatureBlockedThisCombat(false);
-            }
-            if (c.getDamageHistory().getCreatureGotBlockedThisCombat()) {
-                c.getDamageHistory().setCreatureGotBlockedThisCombat(false);
-            }
-        }
-    }
-
     public CardCollectionView getInboundTokens() {
         return inboundTokens;
     }


### PR DESCRIPTION
Fixed a bug with cards that care about "this combat". For example warriors stand could be used offensively. Also cleaned up a little bit by moving all of the expiry for "this combat" effects to the same place. 