### PR TITLE
Adventure: check restrictedEditions and allowedEditions when generating rewards

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/util/CardUtil.java
+++ b/forge-gui-mobile/src/forge/adventure/util/CardUtil.java
@@ -298,7 +298,16 @@ public class CardUtil {
             }
             if(type.editions!=null&&type.editions.length!=0)
             {
-                editions.addAll(Arrays.asList(type.editions));
+                ConfigData configData = Config.instance().getConfigData();
+                for(String edition: type.editions){
+                    // Ignore "forbidden" editions
+                    if (configData.allowedEditions != null) {
+                        if (Arrays.asList(configData.allowedEditions).contains(edition))
+                            editions.add(edition);
+                    } else if (!Arrays.asList(configData.restrictedEditions).contains(edition)){
+                        editions.add(edition);
+                    }
+                }
             }
             if(type.superTypes!=null&&type.superTypes.length!=0)
             {


### PR DESCRIPTION
Hi everyone,
when Forge Adventure generates a reward it doesn't check if the requested card(s) editions are permitted by `restrictedEditions`/`allowedEditions`, so if someone is building a new world that's initially cloned from the default one, it ends up with "forbidden" reward cards.
This PR simply ignores those editions, so for example if a reward is defined as:
```
{
        "type": "card",
        "probability": 1,
        "count": 1,
        "editions": [
                "M22",
                "M21"
        ],
        "colors": [
                "red"
        ],
        "rarity": [
                "rare"
        ]
}
```
but `restrictedEditions` contains M21 and M22, the reward will be chosen among red rares of any non-forbidden edition.