### PR TITLE
fixed elder spawn description

### DIFF
--- a/forge-gui/res/cardsfolder/e/elder_spawn.txt
+++ b/forge-gui/res/cardsfolder/e/elder_spawn.txt
@@ -2,7 +2,7 @@ Name:Elder Spawn
 ManaCost:4 U U U
 Types:Creature Spawn
 PT:6/6
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ TrigElderSpawnSacrifice | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, unless you sacrifice an Island, sacrifice CARDNAME and it deals 6 damage to you. CARDNAME can't be blocked by red creatures.
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ TrigElderSpawnSacrifice | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, unless you sacrifice an Island, sacrifice CARDNAME and it deals 6 damage to you. 
 SVar:TrigElderSpawnSacrifice:DB$ Sacrifice | SacValid$ Island | Optional$ True | RememberSacrificed$ True | SubAbility$ DBElderSpawnSacrificeMe
 SVar:DBElderSpawnSacrificeMe:DB$ Sacrifice | ConditionDefined$ Remembered | ConditionPresent$ Island | ConditionCompare$ EQ0 | SubAbility$ DBElderSpawnDamage
 SVar:DBElderSpawnDamage:DB$ DealDamage | Defined$ You | NumDmg$ 6 | ConditionDefined$ Remembered | ConditionPresent$ Island | ConditionCompare$ EQ0 | SubAbility$ DBElderSpawnCleanup


### PR DESCRIPTION
Description had "Elder Spawn can't be blocked by red creatures" twice. 