### PR TITLE
Fix Essence Vortex (unless costs not referencing targets properly)

### DIFF
--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -1068,6 +1068,7 @@ public class PlayerControllerAi extends PlayerController {
         emptyAbility.setSVars(sa.getSVars());
         emptyAbility.setCardState(sa.getCardState());
         emptyAbility.setXManaCostPaid(sa.getRootAbility().getXManaCostPaid());
+        emptyAbility.setTargets(sa.getTargets().clone());
 
         if (ComputerUtilCost.willPayUnlessCost(sa, player, cost, alreadyPaid, allPayers)) {
             boolean result = ComputerUtil.playNoStack(player, emptyAbility, getGame(), true); // AI needs something to resolve to pay that cost


### PR DESCRIPTION
Repro:

Cast Essence Vortex on opponents creature
AI pays 0 life to save creature, because the Unless Ghsot ability doesn't have a reference to the Target. 