### PR TITLE
Add options to skip multi-pack opening, buy all

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorConstructed.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorConstructed.java
@@ -6,12 +6,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -46,9 +46,9 @@ import java.util.Map.Entry;
  * Child controller for constructed deck editor UI.
  * This is the least restrictive mode;
  * all cards are available.
- * 
+ *
  * <br><br><i>(C at beginning of class name denotes a control class.)</i>
- * 
+ *
  * @author Forge
  * @version $Id: CEditorConstructed.java 24868 2014-02-17 05:08:05Z drdev $
  */
@@ -354,7 +354,7 @@ public final class CEditorConstructed extends CDeckEditor<Deck> {
             break;
         case Sideboard:
             cmb.addMoveItems(localizer.getMessage("lblRemove"), localizer.getMessage("lblfromsideboard"));
-            cmb.addMoveAlternateItems("Move", "to deck");
+            cmb.addMoveAlternateItems(localizer.getMessage("lblMove"), localizer.getMessage("lbltodeck"));
             break;
         case Commander:
             cmb.addMoveItems(localizer.getMessage("lblRemove"), localizer.getMessage("lblascommander"));
@@ -398,7 +398,7 @@ public final class CEditorConstructed extends CDeckEditor<Deck> {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see forge.gui.deckeditor.ACEditorBase#resetTables()
      */
     @Override
@@ -420,7 +420,7 @@ public final class CEditorConstructed extends CDeckEditor<Deck> {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see forge.gui.deckeditor.ACEditorBase#getController()
      */
     @Override

--- a/forge-gui/src/main/java/forge/gamemodes/quest/QuestSpellShop.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/QuestSpellShop.java
@@ -208,6 +208,8 @@ public class QuestSpellShop {
 
         ItemPool<InventoryItem> itemsToAdd = new ItemPool<>(InventoryItem.class);
 
+        boolean skipRemainingPacks = false;
+
         for (Entry<InventoryItem, Integer> itemEntry : itemsToBuy) {
             final InventoryItem item = itemEntry.getKey();
 
@@ -249,14 +251,14 @@ public class QuestSpellShop {
                     if (booster instanceof BoxedProduct && FModel.getPreferences().getPrefBoolean(FPref.UI_OPEN_PACKS_INDIV)) {
 
                         int totalPacks = ((BoxedProduct) booster).boosterPacksRemaining();
-                        boolean skipTheRest = false;
+                        boolean skipRemainingBoxedPacks = false;
                         final List<PaperCard> remainingCards = new ArrayList<>();
 
-                        while (((BoxedProduct) booster).boosterPacksRemaining() > 0 && !skipTheRest) {
-                            skipTheRest = GuiBase.getInterface().showBoxedProduct(booster.getName(), "You have found the following cards inside (Booster Pack " + (totalPacks - ((BoxedProduct) booster).boosterPacksRemaining() + 1) + " of " + totalPacks + "):", ((BoxedProduct) booster).getNextBoosterPack());
+                        while (((BoxedProduct) booster).boosterPacksRemaining() > 0 && !skipRemainingBoxedPacks) {
+                            skipRemainingBoxedPacks = GuiBase.getInterface().showBoxedProduct(booster.getName(), "You have found the following cards inside (Booster Pack " + (totalPacks - ((BoxedProduct) booster).boosterPacksRemaining() + 1) + " of " + totalPacks + "):", ((BoxedProduct) booster).getNextBoosterPack());
                         }
 
-                        if (skipTheRest) {
+                        if (skipRemainingBoxedPacks) {
                             while (((BoxedProduct) booster).boosterPacksRemaining() > 0) {
                                 remainingCards.addAll(((BoxedProduct) booster).getNextBoosterPack());
                             }
@@ -269,7 +271,21 @@ public class QuestSpellShop {
                         }
 
                     } else {
-                        GuiBase.getInterface().showCardList(booster.getName(), "You have found the following cards inside:", newCards);
+                        if (!skipRemainingPacks) {
+                            // if we're showing the last pack (or if there is only one), don't
+                            // bother showing the "open all remaining" button.
+                            boolean displayingLastPack = (qty == 1) || (i == (qty-1));
+                            if (displayingLastPack) {
+                                GuiBase.getInterface().showCardList(booster.getName(), "You have found the following cards inside:", newCards);
+                            } else {
+                                int currentPack = i + 1;
+                                int totalPacks = qty;
+                                skipRemainingPacks = GuiBase.getInterface().showBoxedProduct(
+                                    booster.getName(),
+                                    "You have found the following cards inside (Pack " + currentPack + " of " + totalPacks + "):",
+                                    newCards);
+                            }
+                        }
                     }
                 }
             }

--- a/forge-gui/src/main/java/forge/itemmanager/SItemManagerUtil.java
+++ b/forge-gui/src/main/java/forge/itemmanager/SItemManagerUtil.java
@@ -5,6 +5,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map.Entry;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 
 import forge.card.CardRules;
@@ -65,7 +66,7 @@ public final class SItemManagerUtil {
         DECK_COLORLESS  (FSkinProp.IMG_MANA_COLORLESS, null, "lblColorlessdecks"),
         DECK_MULTICOLOR (GuiBase.getInterface().isLibgdxPort() ? FSkinProp.IMG_HDMULTI :
                          FSkinProp.IMG_MULTI,          null, "lblMulticolordecks"),
-    	
+
         FOIL_OLD  (FSkinProp.FOIL_11,   null, "lblOldstyleFoilcards"),
         FOIL_NEW  (FSkinProp.FOIL_01,   null, "lblNewstyleFoilcards"),
         FOIL_NONE (FSkinProp.ICO_CLOSE, null, "lblNon-Foilcards"),
@@ -92,6 +93,36 @@ public final class SItemManagerUtil {
         @Override
         public FSkinProp getSkinProp() {
             return skinProp;
+        }
+    }
+
+    public enum SpecialQuantity {
+        QUANTITY_X   (-1, Localizer.getInstance().getMessage("lblXcopiesof")),
+        //QUANTITY_ALL (-2, Localizer.getInstance().getMessage("lblAllcopiesof"));
+        QUANTITY_ALL (-2, "all copies of");
+
+        public final int quantity_code;
+        public final String label;
+
+        SpecialQuantity(final int quantity_code, final String label){
+            this.quantity_code = quantity_code;
+            this.label = label;
+        }
+
+        public static Optional<SpecialQuantity> lookupSpecialQuantity(int quantity_code) {
+            for (SpecialQuantity special_quantity : SpecialQuantity.values()) {
+                if (special_quantity.quantity_code == quantity_code) {
+                    return Optional.fromNullable(special_quantity);
+                }
+            }
+            return Optional.absent();
+        }
+
+        static String getItemDisplayPrefix(int quantity_code) {
+            // This should only be called for negative quantity_codes, so the '? copies of'
+            // case should never be returned (and is just there to return something).
+            SpecialQuantity special_quantity = lookupSpecialQuantity(quantity_code).orNull();
+            return (special_quantity != null) ? special_quantity.label : "? copies of";
         }
     }
 
@@ -136,8 +167,8 @@ public final class SItemManagerUtil {
             if (itemCount != 1) {
                 result = itemCount + " " + result + "s";
             }
-            if (qty < 0) { //treat negative numbers as unknown quantity
-                result = localizer.getMessage("lblXcopiesof") + " " + result;
+            if (qty < 0) { //treat negative numbers as a special quantity
+                result = SpecialQuantity.getItemDisplayPrefix(qty) + " " + result;
             }
             else if (qty != 1) {
                 result = qty + " " + localizer.getMessage("lblcopiesof")+ " " + result;


### PR DESCRIPTION
There are two changes here, both focus on buying multiple packs from the quest shop.

1. Adds an option to skip multi-pack opening by reusing the `showBoxedProduct()` method.  This will only be shown (on the non-final packs) if multiple packs have been purchased.
2. Adds a context menu option to "buy all".  This is as an alternative to buying X and scrolling down.  This option will only be shown for buying, and only when the quantity available exceeds the playset size.

"Open All Remaining" button shown when buying multiple packs
![image](https://github.com/Card-Forge/forge/assets/1411138/550790d5-6d8f-45c9-96af-cffe3e67f5e9)

New buy all context menu option:
![image](https://github.com/Card-Forge/forge/assets/1411138/e4b521db-e325-4d0c-a852-9031c6530127)

(Unless quantity available is <= 4)
![image](https://github.com/Card-Forge/forge/assets/1411138/9a84c4cc-aa9b-49a6-a73f-ff0731f82d39)

