### PR TITLE
MKM: Forensic Gadgeteer

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/forensic_gadgeteer.txt
+++ b/forge-gui/res/cardsfolder/upcoming/forensic_gadgeteer.txt
@@ -2,7 +2,7 @@ Name:Forensic Gadgeteer
 ManaCost:2 U
 PT:2/3
 Types:Creature Vedalken Artificer Detective
-T:Mode$ SpellCast | ValidCard$ Artifact | ValidActivatingPlayer$ You | Execute$ TrigInvestigate | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast an artifact spell, investigate
+T:Mode$ SpellCast | ValidCard$ Artifact | ValidActivatingPlayer$ You | Execute$ TrigInvestigate | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast an artifact spell, investigate.
 SVar:TrigInvestigate:DB$ Investigate
-S:Mode$ ReduceCost | ValidCard$ Artifact | ValidActivatingPlayer$ You | Type$ Ability | Amount$ 1 | MinMana$ 1 | AffectedZone$ Battlefield | Description$ Activated abilities of artifacts you control {1} less to activate. This effect can't reduce the mana in that cost to less than one mana.
+S:Mode$ ReduceCost | ValidCard$ Artifact.YouCtrl | Type$ Ability | Amount$ 1 | MinMana$ 1 | AffectedZone$ Battlefield | Description$ Activated abilities of artifacts you control {1} less to activate. This effect can't reduce the mana in that cost to less than one mana.
 Oracle:Whenever you cast an artifact spell, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")\nActivated abilities of artifacts you control cost {1} less to activate. This effect can't reduce the mana in that cost to less than one mana.

--- a/forge-gui/res/cardsfolder/upcoming/forensic_gadgeteer.txt
+++ b/forge-gui/res/cardsfolder/upcoming/forensic_gadgeteer.txt
@@ -5,4 +5,4 @@ Types:Creature Vedalken Artificer Detective
 T:Mode$ SpellCast | ValidCard$ Artifact | ValidActivatingPlayer$ You | Execute$ TrigInvestigate | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast an artifact spell, investigate
 SVar:TrigInvestigate:DB$ Investigate
 S:Mode$ ReduceCost | ValidCard$ Artifact | ValidActivatingPlayer$ You | Type$ Ability | Amount$ 1 | MinMana$ 1 | AffectedZone$ Battlefield | Description$ Activated abilities of artifacts you control {1} less to activate. This effect can't reduce the mana in that cost to less than one mana.
-Oracle:Whenever you cast an artifact spell, investigate. (Create a colorless Clue artifact token with “{2}, Sacrifice this artifact: Draw a card.”)\nActivated abilities of artifacts you control cost {1} less to activate. This effect can't reduce the mana in that cost to less than one mana.
+Oracle:Whenever you cast an artifact spell, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")\nActivated abilities of artifacts you control cost {1} less to activate. This effect can't reduce the mana in that cost to less than one mana.

--- a/forge-gui/res/cardsfolder/upcoming/forensic_gadgeteer.txt
+++ b/forge-gui/res/cardsfolder/upcoming/forensic_gadgeteer.txt
@@ -1,0 +1,8 @@
+Name:Forensic Gadgeteer
+ManaCost:2 U
+PT:2/3
+Types:Creature Vedalken Artificer Detective
+T:Mode$ SpellCast | ValidCard$ Artifact | ValidActivatingPlayer$ You | Execute$ TrigInvestigate | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast an artifact spell, investigate
+SVar:TrigInvestigate:DB$ Investigate
+S:Mode$ ReduceCost | ValidCard$ Artifact | ValidActivatingPlayer$ You | Type$ Ability | Amount$ 1 | MinMana$ 1 | AffectedZone$ Battlefield | Description$ Activated abilities of artifacts you control {1} less to activate. This effect can't reduce the mana in that cost to less than one mana.
+Oracle:Whenever you cast an artifact spell, investigate. (Create a colorless Clue artifact token with “{2}, Sacrifice this artifact: Draw a card.”)\nActivated abilities of artifacts you control cost {1} less to activate. This effect can't reduce the mana in that cost to less than one mana.


### PR DESCRIPTION
Abilities copied/derived from:

~Heartstone~ Training Grounds - For the activation cost reduction ability, but to cover *your artifacts*

Riddlesmith - For the "Whenever you cast an artifact spell" trigger template, but to trigger investigation instead of looting

~Only point of doubt is I am unsure whether the `ValidActivatingPlayer$ You` constraint is correct for the cost reduction ability so that only your artifacts get the reduction bonus and not the opponent's. I couldn't figure out a good way to test that.~

All ~other~ abilities work as advertised based on the decks I've built and tested with this card.