### PR TITLE
Add the target card name to the prompt for Time Travel

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/CountersPutOrRemoveEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CountersPutOrRemoveEffect.java
@@ -115,7 +115,7 @@ public class CountersPutOrRemoveEffect extends SpellAbilityEffect {
         CounterType chosenType = pc.chooseCounterType(list, sa, prompt, params);
 
         params.put("CounterType", chosenType);
-        prompt = Localizer.getInstance().getMessage("lblWhatToDoWithTargetCounter",  chosenType.getName()) + " ";
+        prompt = Localizer.getInstance().getMessage("lblWhatToDoWithTargetCounter",  chosenType.getName(), CardTranslation.getTranslatedName(tgtCard.getName())) + " ";
         boolean putCounter;
         if (sa.hasParam("RemoveConditionSVar")) {
             final Card host = sa.getHostCard();

--- a/forge-game/src/main/java/forge/game/ability/effects/TimeTravelEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/TimeTravelEffect.java
@@ -54,7 +54,7 @@ public class TimeTravelEffect extends SpellAbilityEffect {
                 Map<String, Object> params = Maps.newHashMap();
                 params.put("Target", c);
                 params.put("CounterType", counterType);
-                prompt = Localizer.getInstance().getMessage("lblWhatToDoWithTargetCounter", counterType.getName(), CardTranslation.getTranslatedName(host.getName())) + " ";
+                prompt = Localizer.getInstance().getMessage("lblWhatToDoWithTargetCounter", counterType.getName(), CardTranslation.getTranslatedName(c.getName())) + " ";
                 boolean putCounter = pc.chooseBinary(sa, prompt, BinaryChoiceType.AddOrRemove, params);
 
                 if (putCounter) {

--- a/forge-game/src/main/java/forge/game/ability/effects/TimeTravelEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/TimeTravelEffect.java
@@ -17,6 +17,7 @@ import forge.game.player.PlayerController;
 import forge.game.player.PlayerController.BinaryChoiceType;
 import forge.game.spellability.SpellAbility;
 import forge.game.zone.ZoneType;
+import forge.util.CardTranslation;
 import forge.util.Localizer;
 import forge.util.collect.FCollection;
 
@@ -53,7 +54,7 @@ public class TimeTravelEffect extends SpellAbilityEffect {
                 Map<String, Object> params = Maps.newHashMap();
                 params.put("Target", c);
                 params.put("CounterType", counterType);
-                prompt = Localizer.getInstance().getMessage("lblWhatToDoWithTargetCounter",  counterType.getName()) + " ";
+                prompt = Localizer.getInstance().getMessage("lblWhatToDoWithTargetCounter", counterType.getName(), CardTranslation.getTranslatedName(host.getName())) + " ";
                 boolean putCounter = pc.chooseBinary(sa, prompt, BinaryChoiceType.AddOrRemove, params);
 
                 if (putCounter) {

--- a/forge-gui/res/languages/de-DE.properties
+++ b/forge-gui/res/languages/de-DE.properties
@@ -1967,7 +1967,7 @@ lblDoYouWantPutTargetP1P1CountersOnCard=Möchtest du {0} +1/+1-Marken auf {1} le
 #CountersPutOrRemoveEffect.java
 lblWouldYouLikePutRemoveCounters=Möchtest du zu {1} ''{0}'' Marken hinzufügen oder ''{0}'' Marken entfernen?
 lblSelectCounterTypeToAddOrRemove=Wähle Marken-Typ fürs Hinzufügen/Entfernen
-lblWhatToDoWithTargetCounter=Was soll getan werden mit dieser {0}-Marke
+lblWhatToDoWithTargetCounter=Was soll getan werden mit dieser {0}-Marke auf {1}
 #CountersRemoveEffect.java
 lblAllCounters=alle Marken
 lblACounters=eine Marke

--- a/forge-gui/res/languages/en-US.properties
+++ b/forge-gui/res/languages/en-US.properties
@@ -1972,7 +1972,7 @@ lblDoYouWantPutTargetP1P1CountersOnCard=Do you want to put {0} +1/+1 counters on
 #CountersPutOrRemoveEffect.java
 lblWouldYouLikePutRemoveCounters=Would you like to add ''{0}'' counters to or remove ''{0}'' counters from {1}?
 lblSelectCounterTypeToAddOrRemove=Select type of counters to add or remove
-lblWhatToDoWithTargetCounter=Choose what to do with ''{0}'' counter
+lblWhatToDoWithTargetCounter=Choose what to do with ''{0}'' counter on {1}
 #CountersRemoveEffect.java
 lblAllCounters=all counters
 lblACounters=a counter

--- a/forge-gui/res/languages/es-ES.properties
+++ b/forge-gui/res/languages/es-ES.properties
@@ -1968,7 +1968,7 @@ lblDoYouWantPutTargetP1P1CountersOnCard=¿Quieres poner {0} contadores +1/+1 en 
 #CountersPutOrRemoveEffect.java
 lblWouldYouLikePutRemoveCounters=¿Quieres añadir contadores ''{0}'' o eliminar contadores ''{0}'' de {1}?
 lblSelectCounterTypeToAddOrRemove=Selecciona el tipo de contadores a añadir o eliminar
-lblWhatToDoWithTargetCounter=Qué hacer con ese contador ''{0}''
+lblWhatToDoWithTargetCounter=Qué hacer con ese contador ''{0}'' en {1}
 #CountersRemoveEffect.java
 lblAllCounters=todos los contadores
 lblACounters=un contador

--- a/forge-gui/res/languages/fr-FR.properties
+++ b/forge-gui/res/languages/fr-FR.properties
@@ -1971,7 +1971,7 @@ lblDoYouWantPutTargetP1P1CountersOnCard=Voulez-vous mettre {0} marqueurs +1/+1 s
 #CountersPutOrRemoveEffect.java
 lblWouldYouLikePutRemoveCounters=Voulez-vous ajouter des marqueurs ''{0}'' ou supprimer des marqueurs ''{0}'' de {1} ?
 lblSelectCounterTypeToAddOrRemove=Sélectionner le type de marqueurs à ajouter ou supprimer
-lblWhatToDoWithTargetCounter=Choisissez quoi faire avec le marqueur ''{0}''
+lblWhatToDoWithTargetCounter=Choisissez quoi faire avec le marqueur ''{0}'' sur {1}
 #CountersRemoveEffect.java
 lblAllCounters=tous les marqueurs
 lblACounters=un marqueur

--- a/forge-gui/res/languages/it-IT.properties
+++ b/forge-gui/res/languages/it-IT.properties
@@ -1968,7 +1968,7 @@ lblDoYouWantPutTargetP1P1CountersOnCard=Vuoi aggiungere {0} segnalino/i +1/+1 a 
 #CountersPutOrRemoveEffect.java
 lblWouldYouLikePutRemoveCounters=Would you like to add ''{0}'' counters to or remove ''{0}'' counters from {1}?
 lblSelectCounterTypeToAddOrRemove=Scegli il tipo di segnalini da aggiungere o rimuovere
-lblWhatToDoWithTargetCounter=Cosa fare con quel segnalino ''{0}''
+lblWhatToDoWithTargetCounter=Cosa fare con quel segnalino ''{0}'' a {1}
 #CountersRemoveEffect.java
 lblAllCounters=tutti i segnalini
 lblACounters=un segnalino

--- a/forge-gui/res/languages/ja-JP.properties
+++ b/forge-gui/res/languages/ja-JP.properties
@@ -1967,7 +1967,7 @@ lblDoYouWantPutTargetP1P1CountersOnCard={1}の上に {0}個の +1/+1 カウン�
 #CountersPutOrRemoveEffect.java
 lblWouldYouLikePutRemoveCounters=Would you like to add ''{0}'' counters to or remove ''{0}'' counters from {1}?
 lblSelectCounterTypeToAddOrRemove=置ける／取り除くカウンターの種類を選ぶ
-lblWhatToDoWithTargetCounter=「{0}」カウンターをどうしますか？
+lblWhatToDoWithTargetCounter={1}の上に 「{0}」カウンターをどうしますか？
 #CountersRemoveEffect.java
 lblAllCounters=全てのカウンター
 lblACounters=一個のカウンター

--- a/forge-gui/res/languages/pt-BR.properties
+++ b/forge-gui/res/languages/pt-BR.properties
@@ -2029,7 +2029,7 @@ lblDoYouWantPutTargetP1P1CountersOnCard=Você quer colocar {0} +1/+1 marcadores 
 #CountersPutOrRemoveEffect.java
 lblWouldYouLikePutRemoveCounters=Você gostaria de adicionar ''{0}'' marcadores ou remover ''{0}'' marcadores de {1}?
 lblSelectCounterTypeToAddOrRemove=Selecione o tipo de marcadores para adicionar ou remover
-lblWhatToDoWithTargetCounter=Escolha o que fazer com o marcador ''{0}''
+lblWhatToDoWithTargetCounter=Escolha o que fazer com o marcador ''{0}'' em {1}
 #CountersRemoveEffect.java
 lblAllCounters=todos os marcadores
 lblACounters=um marcador

--- a/forge-gui/res/languages/zh-CN.properties
+++ b/forge-gui/res/languages/zh-CN.properties
@@ -1972,7 +1972,7 @@ lblDoYouWantPutTargetP1P1CountersOnCard=你想要放置{0}个+1+1指示物到{1}
 #CountersPutOrRemoveEffect.java
 lblWouldYouLikePutRemoveCounters=你想要对{1}添加/移除“{0}”指示物吗？
 lblSelectCounterTypeToAddOrRemove=选择要添加或移除的指示物的类型
-lblWhatToDoWithTargetCounter=如何使用''{0}''指示物
+lblWhatToDoWithTargetCounter=如何使用 {1} 上的“{0}”指示物
 #CountersRemoveEffect.java
 lblAllCounters=所有指示物
 lblACounters=一个指示物


### PR DESCRIPTION
Previously, the message would be identical for every card chosen, and it was impossible to know whether you should click "Add a counter" or "Remove a counter"
It was also visually impossible to tell that anything had happened at all after clicking one of the options, since the prompt was immediately replaced by a new one and the counters are added all at once after all selections have been made. This could look similar to a frozen/crashed client

Translations need review - I've used google translate and tried to tweak the wordings a bit to match the text that was previously there on this and similar strings