### PR TITLE
forge-game: tests: replace TestNG with Junit 5

### DIFF
--- a/forge-game/pom.xml
+++ b/forge-game/pom.xml
@@ -24,9 +24,9 @@
             <version>1.2</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/forge-game/pom.xml
+++ b/forge-game/pom.xml
@@ -24,9 +24,9 @@
             <version>1.2</version>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <version>7.4.0</version>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/forge-game/pom.xml
+++ b/forge-game/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>forge-game</artifactId>
     <name>Forge Game</name>
 
+    <properties>
+        <junit.version>5.10.1</junit.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>forge</groupId>
@@ -24,9 +28,9 @@
             <version>1.2</version>
         </dependency>
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>5.10.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/forge-game/src/test/java/forge/game/ability/AbilityKeyTest.java
+++ b/forge-game/src/test/java/forge/game/ability/AbilityKeyTest.java
@@ -2,8 +2,10 @@ package forge.game.ability;
 
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Maps;
 
@@ -13,7 +15,7 @@ public class AbilityKeyTest {
     @Test
     public void testFromStringWorksForAllKeys() {
         for (AbilityKey key : AbilityKey.values()) {
-            Assert.assertEquals(key, AbilityKey.fromString(key.toString()));
+            assertEquals(key, AbilityKey.fromString(key.toString()));
         }
     }
 
@@ -23,6 +25,6 @@ public class AbilityKeyTest {
         Map<AbilityKey, Object> newMap = AbilityKey.newMap(map);
 
         // An actual copy should be made.
-        Assert.assertNotSame(map, newMap);
+        assertNotSame(map, newMap);
     }
 }

--- a/forge-game/src/test/java/forge/game/ability/AbilityKeyTest.java
+++ b/forge-game/src/test/java/forge/game/ability/AbilityKeyTest.java
@@ -1,26 +1,24 @@
 package forge.game.ability;
 
-import org.testng.annotations.Test;
-import org.testng.AssertJUnit;
 import java.util.Map;
 
 import com.google.common.collect.Maps;
 
-public class AbilityKeyTest {
+import junit.framework.TestCase;
 
-    @Test
+public class AbilityKeyTest extends TestCase {
     public void testFromStringWorksForAllKeys() {
         for (AbilityKey key : AbilityKey.values()) {
-            AssertJUnit.assertEquals(key, AbilityKey.fromString(key.toString()));
+            assertEquals(key, AbilityKey.fromString(key.toString()));
         }
     }
 
-    @Test
     public void testCopyingEmptyMapWorks() {
         Map<AbilityKey, Object> map = Maps.newHashMap();
+
         Map<AbilityKey, Object> newMap = AbilityKey.newMap(map);
 
         // An actual copy should be made.
-        AssertJUnit.assertNotSame(map, newMap);
+        assertNotSame(map, newMap);
     }
 }

--- a/forge-game/src/test/java/forge/game/ability/AbilityKeyTest.java
+++ b/forge-game/src/test/java/forge/game/ability/AbilityKeyTest.java
@@ -2,23 +2,27 @@ package forge.game.ability;
 
 import java.util.Map;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 import com.google.common.collect.Maps;
 
-import junit.framework.TestCase;
 
-public class AbilityKeyTest extends TestCase {
+public class AbilityKeyTest {
+
+    @Test
     public void testFromStringWorksForAllKeys() {
         for (AbilityKey key : AbilityKey.values()) {
-            assertEquals(key, AbilityKey.fromString(key.toString()));
+            Assert.assertEquals(key, AbilityKey.fromString(key.toString()));
         }
     }
 
+    @Test
     public void testCopyingEmptyMapWorks() {
         Map<AbilityKey, Object> map = Maps.newHashMap();
-
         Map<AbilityKey, Object> newMap = AbilityKey.newMap(map);
 
         // An actual copy should be made.
-        assertNotSame(map, newMap);
+        Assert.assertNotSame(map, newMap);
     }
 }

--- a/forge-game/src/test/java/forge/game/mana/ManaCostBeingPaidTest.java
+++ b/forge-game/src/test/java/forge/game/mana/ManaCostBeingPaidTest.java
@@ -23,12 +23,12 @@ public class ManaCostBeingPaidTest {
     }
 
     private void runConvokeTest(String initialCost, byte[] colorsToPay, String[] expectedRemainder) {
-        ManaCostBeingPaid cost = createManaCostBeingPaid(initialCost);
+        ManaCostBeingPaid costBeingPaid = createManaCostBeingPaid(initialCost);
         for (int i = 0; i < colorsToPay.length; i++) {
-            assertEquals(expectedRemainder[i], cost.toString());
-            cost.payManaViaConvoke(colorsToPay[i]);
+            assertEquals(expectedRemainder[i], costBeingPaid.toString());
+            costBeingPaid.payManaViaConvoke(colorsToPay[i]);
         }
-        assertEquals("0", cost.toString());
+        assertEquals("0", costBeingPaid.toString());
     }
 
     private ManaCostBeingPaid createManaCostBeingPaid(String cost) {

--- a/forge-game/src/test/java/forge/game/mana/ManaCostBeingPaidTest.java
+++ b/forge-game/src/test/java/forge/game/mana/ManaCostBeingPaidTest.java
@@ -1,7 +1,5 @@
 package forge.game.mana;
 
-import org.testng.annotations.Test;
-import org.testng.AssertJUnit;
 import static forge.card.MagicColor.COLORLESS;
 import static forge.card.MagicColor.GREEN;
 import static forge.card.MagicColor.RED;
@@ -9,32 +7,27 @@ import static forge.card.MagicColor.WHITE;
 
 import forge.card.mana.ManaCost;
 import forge.card.mana.ManaCostParser;
+import junit.framework.TestCase;
 
-public class ManaCostBeingPaidTest {
-
-    @Test
+public class ManaCostBeingPaidTest extends TestCase {
     public void testPayManaViaConvoke() {
-        runConvokeTest("1 W W", new byte[] { WHITE, COLORLESS, WHITE }, new String[] { "{1}{W}{W}", "{1}{W}", "{W}" });
-        runConvokeTest("1 W W", new byte[] { COLORLESS, WHITE, WHITE }, new String[] { "{1}{W}{W}", "{W}{W}", "{W}" });
-        runConvokeTest("1 W W", new byte[] { GREEN, WHITE, WHITE }, new String[] { "{1}{W}{W}", "{W}{W}", "{W}" });
-        runConvokeTest("1 W G", new byte[] { GREEN, RED, WHITE }, new String[] { "{1}{W}{G}", "{1}{W}", "{W}" });
+        runConvokeTest("1 W W", new byte[]{WHITE, COLORLESS, WHITE}, new String[]{"{1}{W}{W}", "{1}{W}", "{W}"});
+        runConvokeTest("1 W W", new byte[]{COLORLESS, WHITE, WHITE}, new String[]{"{1}{W}{W}", "{W}{W}", "{W}"});
+        runConvokeTest("1 W W", new byte[]{GREEN, WHITE, WHITE}, new String[]{"{1}{W}{W}", "{W}{W}", "{W}"});
+        runConvokeTest("1 W G", new byte[]{GREEN, RED, WHITE}, new String[]{"{1}{W}{G}", "{1}{W}", "{W}"});
     }
 
     private void runConvokeTest(String initialCost, byte[] colorsToPay, String[] expectedRemainder) {
-        ManaCostBeingPaid costBeingPaid = createManaCostBeingPaid(initialCost);
-
+        ManaCostBeingPaid cost = createManaCostBeingPaid(initialCost);
         for (int i = 0; i < colorsToPay.length; i++) {
-            AssertJUnit.assertEquals(expectedRemainder[i], costBeingPaid.toString());
-            costBeingPaid.payManaViaConvoke(colorsToPay[i]);
+            assertEquals(expectedRemainder[i], cost.toString());
+            cost.payManaViaConvoke(colorsToPay[i]);
         }
-
-        AssertJUnit.assertEquals("0", costBeingPaid.toString());
+        assertEquals("0", cost.toString());
     }
 
-    private ManaCostBeingPaid createManaCostBeingPaid(String costString) {
-        ManaCostParser parsedCostString = new ManaCostParser(costString);
-        ManaCost manaCost = new ManaCost(parsedCostString);
-
-        return new ManaCostBeingPaid(manaCost);
+    private ManaCostBeingPaid createManaCostBeingPaid(String cost) {
+        ManaCostParser parser = new ManaCostParser(cost);
+        return new ManaCostBeingPaid(new ManaCost(parser));
     }
 }

--- a/forge-game/src/test/java/forge/game/mana/ManaCostBeingPaidTest.java
+++ b/forge-game/src/test/java/forge/game/mana/ManaCostBeingPaidTest.java
@@ -5,8 +5,9 @@ import static forge.card.MagicColor.GREEN;
 import static forge.card.MagicColor.RED;
 import static forge.card.MagicColor.WHITE;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 
 import forge.card.mana.ManaCost;
 import forge.card.mana.ManaCostParser;
@@ -24,10 +25,10 @@ public class ManaCostBeingPaidTest {
     private void runConvokeTest(String initialCost, byte[] colorsToPay, String[] expectedRemainder) {
         ManaCostBeingPaid cost = createManaCostBeingPaid(initialCost);
         for (int i = 0; i < colorsToPay.length; i++) {
-            Assert.assertEquals(expectedRemainder[i], cost.toString());
+            assertEquals(expectedRemainder[i], cost.toString());
             cost.payManaViaConvoke(colorsToPay[i]);
         }
-        Assert.assertEquals("0", cost.toString());
+        assertEquals("0", cost.toString());
     }
 
     private ManaCostBeingPaid createManaCostBeingPaid(String cost) {

--- a/forge-game/src/test/java/forge/game/mana/ManaCostBeingPaidTest.java
+++ b/forge-game/src/test/java/forge/game/mana/ManaCostBeingPaidTest.java
@@ -5,11 +5,15 @@ import static forge.card.MagicColor.GREEN;
 import static forge.card.MagicColor.RED;
 import static forge.card.MagicColor.WHITE;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 import forge.card.mana.ManaCost;
 import forge.card.mana.ManaCostParser;
-import junit.framework.TestCase;
 
-public class ManaCostBeingPaidTest extends TestCase {
+public class ManaCostBeingPaidTest {
+
+    @Test
     public void testPayManaViaConvoke() {
         runConvokeTest("1 W W", new byte[]{WHITE, COLORLESS, WHITE}, new String[]{"{1}{W}{W}", "{1}{W}", "{W}"});
         runConvokeTest("1 W W", new byte[]{COLORLESS, WHITE, WHITE}, new String[]{"{1}{W}{W}", "{W}{W}", "{W}"});
@@ -20,10 +24,10 @@ public class ManaCostBeingPaidTest extends TestCase {
     private void runConvokeTest(String initialCost, byte[] colorsToPay, String[] expectedRemainder) {
         ManaCostBeingPaid cost = createManaCostBeingPaid(initialCost);
         for (int i = 0; i < colorsToPay.length; i++) {
-            assertEquals(expectedRemainder[i], cost.toString());
+            Assert.assertEquals(expectedRemainder[i], cost.toString());
             cost.payManaViaConvoke(colorsToPay[i]);
         }
-        assertEquals("0", cost.toString());
+        Assert.assertEquals("0", cost.toString());
     }
 
     private ManaCostBeingPaid createManaCostBeingPaid(String cost) {


### PR DESCRIPTION
There are only a few tests with TestNG (which I originally converted from JUnit 3).

That conversion was a mistake: it's better if all tests use the same testing library.
Albeit at its latest version (JUnit 3 has been EoL'ed long time ago).