### PR TITLE
Fix alternative costs from static abilities

### DIFF
--- a/forge-game/src/main/java/forge/game/GameActionUtil.java
+++ b/forge-game/src/main/java/forge/game/GameActionUtil.java
@@ -352,26 +352,28 @@ public final class GameActionUtil {
         return alternatives;
     }
     
-    /**
-     * Checks a card to see if it qualifies to receive keywords from static abilities
-     * that grant alternative casting costs to spells on the stack, for example
-     *  - Toolbox's ability that gives Blitz to creature spells with mana value 4 or greater
-     *  - Hunting Velociraptor's ability that gives Prowl to Dinosaur spells
-     * 
-     * @param source The card to check eligibility for.
-     * @return Zero or more spell abilities, each representing an alternative casting cost.
-     */
-    public static final FCollectionView<SpellAbility> getAlternativeCostsGrantedByStaticAbilities(Card source) {
-    	final FCollection<SpellAbility> alternatives = new FCollection<SpellAbility>();
-    	final Game game = source.getGame();
-    	
-        if (!game.getAction().hasStaticAbilityAffectingZone(ZoneType.Stack, StaticAbilityLayer.ABILITIES)) {
-        	return alternatives;
-        }
-        
-        // double freeze tracker, so it doesn't update view
-        game.getTracker().freeze();
-        
+	/**
+	 * Checks a card to see if it qualifies to receive keywords from static
+	 * abilities that grant alternative casting costs to spells on the stack, for
+	 * example, Toolbox's ability that gives blitz to creature spells with mana
+	 * value 4 or greater, and Hunting Velociraptor's ability that gives prowl to
+	 * Dinosaur spells.
+	 * 
+	 * @param source The card to check eligibility for.
+	 * @return Zero or more spell abilities, each representing an alternative
+	 *         casting cost.
+	 */
+	public static final FCollectionView<SpellAbility> getAlternativeCostsGrantedByStaticAbilities(Card source) {
+		final FCollection<SpellAbility> alternatives = new FCollection<SpellAbility>();
+		final Game game = source.getGame();
+
+		if (!game.getAction().hasStaticAbilityAffectingZone(ZoneType.Stack, StaticAbilityLayer.ABILITIES)) {
+			return alternatives;
+		}
+
+		// double freeze tracker, so it doesn't update view
+		game.getTracker().freeze();
+
 		Zone oldZone = source.getLastKnownZone();
 		Card creatureCandidate = source; // Candidate to receive keyword.
 		if (!source.isLKI()) {
@@ -390,7 +392,7 @@ public final class GameActionUtil {
 				// If the operation doesn't throw an IllegalArgumentException, the keyword
 				// is an alternative cost.
 				AlternativeCost.valueOf(keywordInterface.getKeyword().toString());
-			
+
 				for (SpellAbility iSa : keywordInterface.getAbilities()) {
 					// do only non intrinsic
 					if (!iSa.isIntrinsic()) {
@@ -414,7 +416,7 @@ public final class GameActionUtil {
 		game.getTracker().unfreeze();
 
 		return alternatives;
-    }
+	}
 
     public static List<OptionalCostValue> getOptionalCostValues(final SpellAbility sa) {
         final List<OptionalCostValue> costs = Lists.newArrayList();

--- a/forge-game/src/main/java/forge/game/GameActionUtil.java
+++ b/forge-game/src/main/java/forge/game/GameActionUtil.java
@@ -385,7 +385,6 @@ public final class GameActionUtil {
 		CardCollection preList = new CardCollection(creatureCandidate);
 		game.getAction().checkStaticAbilities(false, Sets.newHashSet(creatureCandidate), preList);
 
-		// currently only for Keyword Blitz, but should affect Dash probably too.
 		for (final KeywordInterface keywordInterface : creatureCandidate.getUnhiddenKeywords()) {
 			try {
 				// Try to find the keyword in the list of alternative cost keywords.

--- a/forge-game/src/main/java/forge/game/GameActionUtil.java
+++ b/forge-game/src/main/java/forge/game/GameActionUtil.java
@@ -352,70 +352,71 @@ public final class GameActionUtil {
         return alternatives;
     }
     
-	/**
-	 * Checks a card to see if it qualifies to receive keywords from static
-	 * abilities that grant alternative casting costs to spells on the stack, for
-	 * example, Toolbox's ability that gives blitz to creature spells with mana
-	 * value 4 or greater, and Hunting Velociraptor's ability that gives prowl to
-	 * Dinosaur spells.
-	 * 
-	 * @param source The card to check eligibility for.
-	 * @return Zero or more spell abilities, each representing an alternative
-	 *         casting cost.
-	 */
-	public static final FCollectionView<SpellAbility> getAlternativeCostsGrantedByStaticAbilities(Card source) {
-		final FCollection<SpellAbility> alternatives = new FCollection<SpellAbility>();
-		final Game game = source.getGame();
+    /**
+     * Checks a card to see if it qualifies to receive keywords from static
+     * abilities that grant alternative casting costs to spells on the stack, for
+     * example, Toolbox's ability that gives blitz to creature spells with mana
+     * value 4 or greater, and Hunting Velociraptor's ability that gives prowl to
+     * Dinosaur spells.
+     * 
+     * @param source The card to check eligibility for.
+     * @return Zero or more spell abilities, each representing an alternative
+     *         casting cost.
+     */
+    public static final FCollectionView<SpellAbility> getAlternativeCostsGrantedByStaticAbilities(Card source) {
+        final FCollection<SpellAbility> alternatives = new FCollection<SpellAbility>();
+        final Game game = source.getGame();
 
-		if (!game.getAction().hasStaticAbilityAffectingZone(ZoneType.Stack, StaticAbilityLayer.ABILITIES)) {
-			return alternatives;
-		}
+        if (!game.getAction().hasStaticAbilityAffectingZone(ZoneType.Stack, StaticAbilityLayer.ABILITIES)) {
+            return alternatives;
+        }
 
-		// double freeze tracker, so it doesn't update view
-		game.getTracker().freeze();
+        // double freeze tracker, so it doesn't update view
+        game.getTracker().freeze();
 
-		Zone oldZone = source.getLastKnownZone();
-		Card creatureCandidate = source; // Candidate to receive keyword.
-		if (!source.isLKI()) {
-			creatureCandidate = CardUtil.getLKICopy(source);
-		}
-		creatureCandidate.setLastKnownZone(game.getStackZone());
+        Zone oldZone = source.getLastKnownZone();
+        Card creatureCandidate = source; // Candidate to receive keyword.
+		
+        if (!source.isLKI()) {
+            creatureCandidate = CardUtil.getLKICopy(source);
+        }
 
-		creatureCandidate.clearStaticChangedCardKeywords(false);
-		CardCollection preList = new CardCollection(creatureCandidate);
-		game.getAction().checkStaticAbilities(false, Sets.newHashSet(creatureCandidate), preList);
+        creatureCandidate.setLastKnownZone(game.getStackZone());
+        creatureCandidate.clearStaticChangedCardKeywords(false);
+        CardCollection preList = new CardCollection(creatureCandidate);
+        game.getAction().checkStaticAbilities(false, Sets.newHashSet(creatureCandidate), preList);
 
-		for (final KeywordInterface keywordInterface : creatureCandidate.getUnhiddenKeywords()) {
-			try {
-				// Try to find the keyword in the list of alternative cost keywords.
-				// If the operation doesn't throw an IllegalArgumentException, the keyword
-				// is an alternative cost.
-				AlternativeCost.valueOf(keywordInterface.getKeyword().toString());
+        for (final KeywordInterface keywordInterface : creatureCandidate.getUnhiddenKeywords()) {
+            try {
+                // Try to find the keyword in the list of alternative cost keywords.
+                // If the operation doesn't throw an IllegalArgumentException, the keyword
+                // is an alternative cost.
+                AlternativeCost.valueOf(keywordInterface.getKeyword().toString());
 
-				for (SpellAbility iSa : keywordInterface.getAbilities()) {
-					// do only non intrinsic
-					if (!iSa.isIntrinsic()) {
-						iSa.setHostCard(source);
-						alternatives.add(iSa);
-					}
-				}
-			} catch (IllegalArgumentException e) {
-				// The keyword interface isn't for an alternative cost keyword.
-				continue;
-			}
-		}
+                for (SpellAbility iSa : keywordInterface.getAbilities()) {
+                    // do only non intrinsic
+                    if (!iSa.isIntrinsic()) {
+                        iSa.setHostCard(source);
+                        alternatives.add(iSa);
+                    }
+                }
+            } catch (IllegalArgumentException e) {
+                // The keyword interface isn't for an alternative cost keyword.
+                continue;
+            }
+        }
 
-		// need to reset to Old Zone, or canPlay fails.
-		creatureCandidate.setLastKnownZone(oldZone);
+        // need to reset to Old Zone, or canPlay fails.
+        creatureCandidate.setLastKnownZone(oldZone);
 
-		game.getAction().checkStaticAbilities(false);
-		// clear delayed changes, this check should not have updated the view.
-		game.getTracker().clearDelayed();
-		// need to unfreeze tracker.
-		game.getTracker().unfreeze();
+        game.getAction().checkStaticAbilities(false);
+        // clear delayed changes, this check should not have updated the view.
+        game.getTracker().clearDelayed();
+        // need to unfreeze tracker.
+        game.getTracker().unfreeze();
 
-		return alternatives;
-	}
+        return alternatives;
+    }
 
     public static List<OptionalCostValue> getOptionalCostValues(final SpellAbility sa) {
         final List<OptionalCostValue> costs = Lists.newArrayList();

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -7153,7 +7153,8 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
     public List<SpellAbility> getAllPossibleAbilities(final Player player, final boolean removeUnplayable) {
         CardState oState = getState(CardStateName.Original);
         final List<SpellAbility> abilities = Lists.newArrayList();
-        for (SpellAbility sa : getSpellAbilities()) {
+        FCollectionView<SpellAbility> spellAbilitiesFromStaticAbilities = GameActionUtil.getAlternativeCostsGrantedByStaticAbilities(this);
+        for (SpellAbility sa : Iterables.concat(getSpellAbilities(), spellAbilitiesFromStaticAbilities)) {
             //adventure spell check
             if (isAdventureCard() && sa.isAdventure()) {
                 if (getExiledWith() != null && getExiledWith().equals(this) && CardStateName.Adventure.equals(getExiledWith().getCurrentStateName()))

--- a/forge-gui/res/cardsfolder/h/henzie_toolbox_torre.txt
+++ b/forge-gui/res/cardsfolder/h/henzie_toolbox_torre.txt
@@ -2,7 +2,7 @@ Name:Henzie "Toolbox" Torre
 ManaCost:B R G
 Types: Legendary Creature Devil Rogue
 PT:3/3
-S:Mode$ Continuous | Affected$ Creature.YouCtrl | AffectedZone$ Stack | AddKeyword$ Blitz:CardManaCost:Spell.Creature+cmcGE4 | Description$ Each creature spell you cast with mana value 4 or greater has blitz. The blitz cost is equal to its mana cost. (You may choose to cast that spell for its blitz cost. If you do, it gains haste and "When this creature dies, draw a card." Sacrifice it at the beginning of the next end step.)
+S:Mode$ Continuous | Affected$ Creature.YouCtrl+cmcGE4 | AffectedZone$ Stack | AddKeyword$ Blitz:CardManaCost:Spell.Creature | Description$ Each creature spell you cast with mana value 4 or greater has blitz. The blitz cost is equal to its mana cost. (You may choose to cast that spell for its blitz cost. If you do, it gains haste and "When this creature dies, draw a card." Sacrifice it at the beginning of the next end step.)
 S:Mode$ ReduceCost | ValidCard$ Card | ValidSpell$ Spell.Blitz | Activator$ You | Amount$ X | Description$ Blitz costs you pay cost {1} less for each time you've cast your commander from the command zone this game.
 SVar:X:Count$TotalCommanderCastFromCommandZone
 Oracle:Each creature spell you cast with mana value 4 or greater has blitz. The blitz cost is equal to its mana cost. (You may choose to cast that spell for its blitz cost. If you do, it gains haste and "When this creature dies, draw a card." Sacrifice it at the beginning of the next end step.)\nBlitz costs you pay cost {1} less for each time you've cast your commander from the command zone this game.

--- a/forge-gui/res/cardsfolder/h/hunting_velociraptor.txt
+++ b/forge-gui/res/cardsfolder/h/hunting_velociraptor.txt
@@ -3,6 +3,6 @@ ManaCost:2 R
 Types:Creature Dinosaur
 PT:3/2
 K:First Strike
-S:Mode$ Continuous | Affected$ Dinosaur.YouCtrl | AddKeyword$ Prowl:2 R | AffectedZone$ Hand | Description$ Dinosaur spells you cast have prowl {2}{R}. (You may cast a spell for its prowl cost if you dealt combat damage to a player this turn with a creature with any of its creature types.)
+S:Mode$ Continuous | Affected$ Dinosaur.YouCtrl | AddKeyword$ Prowl:2 R | AffectedZone$ Stack | Description$ Dinosaur spells you cast have prowl {2}{R}. (You may cast a spell for its prowl cost if you dealt combat damage to a player this turn with a creature with any of its creature types.)
 DeckHints:Type$Dinosaur
 Oracle:First strike\nDinosaur spells you cast have prowl {2}{R}. (You may cast a spell for its prowl cost if you dealt combat damage to a player this turn with a creature with any of its creature types.)


### PR DESCRIPTION
Currently, when a static ability grants an alternative cost to spells (for example, Hunting Velociraptor giving Dinosaur spells "prowl", and Henzie "Toolbox" Torre giving mana value 4 and greater creature spells "blitz"), the alternative costs only apply when casting from the Hand. In the case of Toolbox, the mana value is also ignored, allowing any creature spell to be cast from the hand with blitz.

This change allows alternative costs granted from static abilities to function properly. The main change in behaviour here is that the alternative cost can be paid whenever it is supposed to be able to be paid. E.g. if you can cast creature spells from the top of your library, you can now cast them using alternative costs granted by static abilities. Basically, if you could cast it normally, and there aren't other restrictions for the alternative cost (e.g. "flashback" and "escape" only casting from the graveyard), then you are able to cast it using that cost (relevant rules here being `601.2`, `601.2b`, and `601.2f-h`).

## Overview
- Move "alternative costs from static ability" logic from inside `getAlternativeCosts` to new function `getAlternativeCostsGrantedByStaticAbilities` function which is called before alternative costs are retrieved for card
- Update "alternative costs from static ability" logic to check all alternative cost keywords, not just blitz
- Move `cmcGE4` restriction from Toolbox's static ability's `AddKeyword` parameter to its `Affected` parameter
- Change Hunting Velociraptor's static ability's `AffectedZone` parameter from `Hand` to `Stack`

## Testing
- No unit tests (I can add some if necessary)
- Local testing of both Toolbox and Hunting Velociraptor, ensuring
    - Restrictions are applied
    - Cost reductions are applied