### PR TITLE
Two PIP cards

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/yes_man_personal_securitron.txt
+++ b/forge-gui/res/cardsfolder/upcoming/yes_man_personal_securitron.txt
@@ -3,7 +3,7 @@ ManaCost:2 W
 Types:Legendary Artifact Creature Robot
 PT:2/2
 A:AB$ GainControl | Cost$ T | Defined$ Self | ValidTgts$ Opponent | TgtPrompt$ Select target opponent | SubAbility$ DBImmediateTrigger | PlayerTurn$ True | StackDescription$ SpellDescription | SpellDescription$ Target opponent gains control of CARDNAME. When they do, you draw two cards and put a quest counter on NICKNAME.
-SVar:DBImmediateTrigger:DB$ ImmediateTrigger | ConditionDefined$ Self | ConditionPresent$ Card.ControlledBy ParentTarget | Execute$ DBDraw | StackDescription$ None
+SVar:DBImmediateTrigger:DB$ ImmediateTrigger | ConditionDefined$ Self | ConditionPresent$ Card.ControlledBy ParentTarget | Execute$ DBDraw | TriggerDescription$ When they do, you draw two cards and put a quest counter on NICKNAME.
 SVar:DBDraw:DB$ Draw | NumCards$ 2 | SubAbility$ DBCounter
 SVar:DBCounter:DB$ PutCounter | Defined$ Self | CounterType$ QUEST | CounterNum$ 1
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ Wild Card — When NICKNAME leaves the battlefield, its owner creates a tapped 1/1 white Soldier creature token for each quest counter on it.

--- a/forge-gui/res/cardsfolder/upcoming/yes_man_personal_securitron.txt
+++ b/forge-gui/res/cardsfolder/upcoming/yes_man_personal_securitron.txt
@@ -2,13 +2,12 @@ Name:Yes Man, Personal Securitron
 ManaCost:2 W
 Types:Legendary Artifact Creature Robot
 PT:2/2
-A:AB$ GainControl | Cost$ T | Defined$ Self | ValidTgts$ Opponent | TgtPrompt$ Select target opponent | SubAbility$ DBImmediateTrigger | PlayerTurn$ True | StackDescription$ SpellDescription | SpellDescription$ Target opponent gains control of CARDNAME. When they do, you draw two cards and put a quest counter on NICKNAME.
+A:AB$ GainControl | Cost$ T | Defined$ Self | ValidTgts$ Opponent | TgtPrompt$ Select target opponent | SubAbility$ DBImmediateTrigger | PlayerTurn$ True | StackDescription$ SpellDescription | SpellDescription$ Target opponent gains control of CARDNAME. When they do, you draw two cards and put a quest counter on NICKNAME. Activate only during your turn.
 SVar:DBImmediateTrigger:DB$ ImmediateTrigger | ConditionDefined$ Self | ConditionPresent$ Card.ControlledBy ParentTarget | Execute$ DBDraw | TriggerDescription$ When they do, you draw two cards and put a quest counter on NICKNAME.
 SVar:DBDraw:DB$ Draw | NumCards$ 2 | SubAbility$ DBCounter
 SVar:DBCounter:DB$ PutCounter | Defined$ Self | CounterType$ QUEST | CounterNum$ 1
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ Wild Card — When NICKNAME leaves the battlefield, its owner creates a tapped 1/1 white Soldier creature token for each quest counter on it.
-SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ w_1_1_soldier | TokenOwner$ TriggeredCardOwner | TokenTapped$ True | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ w_1_1_soldier | TokenOwner$ TriggeredCardOwner | TokenTapped$ True
 SVar:X:TriggeredCard$CardCounters.QUEST
 DeckHas:Ability$Counters|Token & Type$Soldier
 Oracle:{T}: Target opponent gains control of Yes Man, Personal Securitron. When they do, you draw two cards and put a quest counter on Yes Man. Activate only during your turn.\nWild Card — When Yes Man leaves the battlefield, its owner creates a tapped 1/1 white Soldier creature token for each quest counter on it.

--- a/forge-gui/res/cardsfolder/upcoming/yes_man_personal_securitron.txt
+++ b/forge-gui/res/cardsfolder/upcoming/yes_man_personal_securitron.txt
@@ -1,0 +1,14 @@
+Name:Yes Man, Personal Securitron
+ManaCost:2 W
+Types:Legendary Artifact Creature Robot
+PT:2/2
+A:AB$ GainControl | Cost$ T | Defined$ Self | ValidTgts$ Opponent | TgtPrompt$ Select target opponent | SubAbility$ DBImmediateTrigger | PlayerTurn$ True | StackDescription$ SpellDescription | SpellDescription$ Target opponent gains control of CARDNAME. When they do, you draw two cards and put a quest counter on NICKNAME.
+SVar:DBImmediateTrigger:DB$ ImmediateTrigger | ConditionDefined$ Self | ConditionPresent$ Card.ControlledBy ParentTarget | Execute$ DBDraw | StackDescription$ None
+SVar:DBDraw:DB$ Draw | NumCards$ 2 | SubAbility$ DBCounter
+SVar:DBCounter:DB$ PutCounter | Defined$ Self | CounterType$ QUEST | CounterNum$ 1
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ Wild Card — When NICKNAME leaves the battlefield, its owner creates a tapped 1/1 white Soldier creature token for each quest counter on it.
+SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ w_1_1_soldier | TokenOwner$ TriggeredCardOwner | TokenTapped$ True | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:X:TriggeredCard$CardCounters.QUEST
+DeckHas:Ability$Counters|Token & Type$Soldier
+Oracle:{T}: Target opponent gains control of Yes Man, Personal Securitron. When they do, you draw two cards and put a quest counter on Yes Man. Activate only during your turn.\nWild Card — When Yes Man leaves the battlefield, its owner creates a tapped 1/1 white Soldier creature token for each quest counter on it.

--- a/forge-gui/res/cardsfolder/upcoming/young_deathclaws.txt
+++ b/forge-gui/res/cardsfolder/upcoming/young_deathclaws.txt
@@ -4,4 +4,6 @@ Types:Creature Lizard Mutant
 PT:4/2
 K:Menace
 S:Mode$ Continuous | Affected$ Creature.YouOwn | AffectedZone$ Graveyard | AddKeyword$ Scavenge:CardManaCost | Description$ Each creature card in your graveyard has scavenge. The scavenge cost is equal to its mana cost.
+DeckHas:Ability$Graveyard|Counters
+DeckHints:Ability$Graveyard|Mill|Discard
 Oracle:Menace (This creature can't be blocked except by two or more creatures.)\nEach creature card in your graveyard has scavenge. The scavenge cost is equal to its mana cost. (Exile a creature card from your graveyard and pay its mana cost: Put a number of +1/+1 counters equal to that card's power on target creature. Scavenge only as a sorcery.)

--- a/forge-gui/res/cardsfolder/upcoming/young_deathclaws.txt
+++ b/forge-gui/res/cardsfolder/upcoming/young_deathclaws.txt
@@ -1,0 +1,7 @@
+Name:Young Deathclaws
+ManaCost:2 B G
+Types:Creature Lizard Mutant
+PT:4/2
+K:Menace
+S:Mode$ Continuous | Affected$ Creature.YouOwn | AffectedZone$ Graveyard | AddKeyword$ Scavenge:CardManaCost | Description$ Each creature card in your graveyard has scavenge. The scavenge cost is equal to its mana cost.
+Oracle:Menace (This creature can't be blocked except by two or more creatures.)\nEach creature card in your graveyard has scavenge. The scavenge cost is equal to its mana cost. (Exile a creature card from your graveyard and pay its mana cost: Put a number of +1/+1 counters equal to that card's power on target creature. Scavenge only as a sorcery.)


### PR DESCRIPTION
- [Young Deathclaws](https://scryfall.com/card/pip/125/young-deathclaws)
- [Yes Man, Personal Securitron](https://scryfall.com/card/pip/29/yes-man-personal-securitron): While I was working on it, it wasn't showing the `StackDescription$` text I placed on the reflexive trigger. Hopefully setting it to `None` fixes things satisfactorily, though I understand that `StackDescription$` has current general issues being displayed correctly.