### PR TITLE
TurnFaceUp Trigger use LKI for Card

### DIFF
--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -844,7 +844,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
             game.getReplacementHandler().run(ReplacementType.TurnFaceUp, repParams);
 
             // Run triggers
-            final Map<AbilityKey, Object> runParams = AbilityKey.mapFromCard(this);
+            final Map<AbilityKey, Object> runParams = AbilityKey.mapFromCard(CardCopyService.getLKICopy(this));
             runParams.put(AbilityKey.Cause, cause);
 
             triggerHandler.registerActiveTrigger(this, false);

--- a/forge-gui/res/cardsfolder/p/pyrotechnic_performer.txt
+++ b/forge-gui/res/cardsfolder/p/pyrotechnic_performer.txt
@@ -3,7 +3,7 @@ ManaCost:1 R
 Types:Creature Viashino Assassin
 PT:3/2
 K:Disguise:R
-T:Mode$ TurnFaceUp | ValidCard$ Card.Self,Creature.Other+YouCtrl | Execute$ TrigDealDamage | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME or another creature you control is turned face up, that creature deals damage equal to its power to each opponent.
-SVar:TrigDealDamage:DB$ DealDamage | Defined$ Opponent | NumDmg$ X | DamageSource$ TriggeredCard
+T:Mode$ TurnFaceUp | ValidCard$ Card.Self,Creature.Other+YouCtrl | Execute$ TrigDealDamage | TriggerZones$ Battlefield | NoTimestampCheck$ True | TriggerDescription$ Whenever CARDNAME or another creature you control is turned face up, that creature deals damage equal to its power to each opponent.
+SVar:TrigDealDamage:DB$ DealDamage | Defined$ Opponent | NumDmg$ X | DamageSource$ TriggeredCardLKICopy
 SVar:X:TriggeredCard$CardPower
 Oracle:Disguise {R} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhenever Pyrotechnic Performer or another creature you control is turned face up, that creature deals damage equal to its power to each opponent.


### PR DESCRIPTION
DamageSource for this now uses LKI from trigger

@tool4ever we need to update the other Cards using TriggeredCardLKICopy

we either need to update more Cards using `NoTimestampCheck` or we need to add `DealDamage` to the updated API in `WrappedAbility` 