### PR TITLE
OTJ: At Knifepoint, Intrepid Stablemaster, Magebane Lizard, Marauding Sphinx, Ornery Tumblewagg

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/at_knifepoint.txt
+++ b/forge-gui/res/cardsfolder/upcoming/at_knifepoint.txt
@@ -1,0 +1,7 @@
+Name:At Knifepoint
+ManaCost:1 B R
+Types:Enchantment
+S:Mode$ Continuous | Affected$ Creature.Outlaw+YouCtrl | AddKeyword$ First Strike | Condition$ PlayerTurn | Description$ As long as it's your turn, outlaws you control have first strike. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)
+T:Mode$ CommitCrime | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigToken | ActivationLimit$ 1 | TriggerDescription$ Whenever you commit a crime, create a 1/1 red Mercenary creature token with "{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery." This ability triggers only once each turn.
+SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ r_1_1_mercenary_tappump | TokenOwner$ You
+Oracle:As long as it's your turn, outlaws you control have first strike. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)\nWhenever you commit a crime, create a 1/1 red Mercenary creature token with "{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery." This ability triggers only once each turn.

--- a/forge-gui/res/cardsfolder/upcoming/at_knifepoint.txt
+++ b/forge-gui/res/cardsfolder/upcoming/at_knifepoint.txt
@@ -4,4 +4,6 @@ Types:Enchantment
 S:Mode$ Continuous | Affected$ Creature.Outlaw+YouCtrl | AddKeyword$ First Strike | Condition$ PlayerTurn | Description$ As long as it's your turn, outlaws you control have first strike. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)
 T:Mode$ CommitCrime | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigToken | ActivationLimit$ 1 | TriggerDescription$ Whenever you commit a crime, create a 1/1 red Mercenary creature token with "{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery." This ability triggers only once each turn.
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ r_1_1_mercenary_tappump | TokenOwner$ You
+DeckHas:Ability$Token & Type$Mercenary
+DeckHints:Type$Assassin|Mercenary|Pirate|Rogue|Warlock
 Oracle:As long as it's your turn, outlaws you control have first strike. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)\nWhenever you commit a crime, create a 1/1 red Mercenary creature token with "{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery." This ability triggers only once each turn.

--- a/forge-gui/res/cardsfolder/upcoming/intrepid_stablemaster.txt
+++ b/forge-gui/res/cardsfolder/upcoming/intrepid_stablemaster.txt
@@ -1,0 +1,8 @@
+Name:Intrepid Stablemaster
+ManaCost:1 G
+Types:Creature Human Scout
+PT:2/2
+K:Reach
+A:AB$ Mana | Cost$ T | Produced$ G | SpellDescription$ Add {G}.
+A:AB$ Mana | Cost$ T | Produced$ Any | Amount$ 2 | RestrictValid$ Spell.Mount,Spell.Vehicle | SpellDescription$ Add two mana of any one color. Spend this mana only to cast Mount or Vehicle spells.
+Oracle:Reach\n{T}: Add {G}.\n{T}: Add two mana of any one color. Spend this mana only to cast Mount or Vehicle spells.

--- a/forge-gui/res/cardsfolder/upcoming/magebane_lizard.txt
+++ b/forge-gui/res/cardsfolder/upcoming/magebane_lizard.txt
@@ -1,0 +1,8 @@
+Name:Magebane Lizard
+ManaCost:1 R
+Types:Creature Lizard
+PT:1/4
+T:Mode$ SpellCast | TriggerZones$ Battlefield | ValidCard$ Card.nonCreature | ValidActivatingPlayer$ Player | Execute$ TrigDmg | TriggerDescription$ Whenever a player casts a noncreature spell, CARDNAME deals damage to that player equal to the number of noncreature spells they've cast this turn.
+SVar:TrigDmg:DB$ DealDamage | Defined$ TriggeredActivator | NumDmg$ X
+SVar:X:Count$ThisTurnCast_Card.nonCreature+ControlledBy TriggeredPlayer
+Oracle:Whenever a player casts a noncreature spell, Magebane Lizard deals damage to that player equal to the number of noncreature spells they've cast this turn.

--- a/forge-gui/res/cardsfolder/upcoming/marauding_sphinx.txt
+++ b/forge-gui/res/cardsfolder/upcoming/marauding_sphinx.txt
@@ -1,0 +1,11 @@
+Name:Marauding Sphinx
+ManaCost:3 U U
+Types:Creature Sphinx Rogue
+PT:3/5
+K:Flying
+K:Vigilance
+K:Ward:2
+T:Mode$ CommitCrime | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigSurveil | ActivationLimit$ 1 | TriggerDescription$ Whenever you commit a crime, surveil 2. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyard is a crime.)
+SVar:TrigSurveil:DB$ Surveil | Defined$ You | Amount$ 2
+DeckHas:Ability$Surveil|Graveyard
+Oracle:Flying, vigilance, ward {2}\nWhenever you commit a crime, surveil 2. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)

--- a/forge-gui/res/cardsfolder/upcoming/ornery_tumblewagg.txt
+++ b/forge-gui/res/cardsfolder/upcoming/ornery_tumblewagg.txt
@@ -1,0 +1,13 @@
+Name:Ornery Tumblewagg
+ManaCost:2 G
+Types:Creature Brushwagg Mount
+PT:2/2
+K:Saddle:2
+T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ At the beginning of combat on your turn, put a +1/+1 counter on target creature.
+SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Creature | CounterType$ P1P1 | CounterNum$ 1
+T:Mode$ Attacks | ValidCard$ Card.Self+IsSaddled | TriggerZones$ Battlefield | Execute$ TrigDoubleCounters | TriggerDescription$ Whenever CARDNAME attacks while saddled, double the number of +1/+1 counters on target creature.
+SVar:TrigDoubleCounters:DB$ MultiplyCounter | ValidTgts$ Creature | CounterType$ P1P1
+SVar:HasAttackEffect:TRUE
+DeckHas:Ability$Counters
+DeckHints:Ability$Counters
+Oracle:At the beginning of combat on your turn, put a +1/+1 counter on target creature.\nWhenever Ornery Tumblewagg attacks while saddled, double the number of +1/+1 counters on target creature.\nSaddle 2 (Tap any number of other creatures you control with total power 2 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)

--- a/forge-gui/res/cardsfolder/upcoming/wanted_griffin.txt
+++ b/forge-gui/res/cardsfolder/upcoming/wanted_griffin.txt
@@ -5,4 +5,5 @@ PT:3/2
 K:Flying
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME dies, create a 1/1 red Mercenary creature token with "{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery."
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ r_1_1_mercenary_tappump | TokenOwner$ You
+DeckHas:Ability$Token & Type$Mercenary
 Oracle:Flying\nWhen Wanted Griffin dies, create a 1/1 red Mercenary creature token with "{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery."


### PR DESCRIPTION
Tested card scripts for:
- [At Knifepoint](https://www.magicspoiler.com/mtg-spoiler/at-knifepoint/)
- [Intrepid Stablemaster](https://www.magicspoiler.com/mtg-spoiler/intrepid-stablemaster/)
- [Magebane Lizard](https://www.magicspoiler.com/mtg-spoiler/magebane-lizard/)
- [Marauding Sphinx](https://www.magicspoiler.com/mtg-spoiler/marauding-sphinx/)
- [Ornery Tumblewagg](https://www.magicspoiler.com/mtg-spoiler/ornery-tumblewagg/)

Minor fixes:
- Added missing AI deckbuilding tags on At Knifepoint and Wanted Griffin