### PR TITLE
BIG: Oltec Matterweaver, Vaultborn Tyrant

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/insatiable_avarice.txt
+++ b/forge-gui/res/cardsfolder/upcoming/insatiable_avarice.txt
@@ -2,7 +2,7 @@ Name:Insatiable Avarice
 ManaCost:B
 Types:Sorcery
 K:Spree
-A:SP$ Charm | Choices$ DBTutor,DBDraw | MinCharmNum$ 1 | CharmNum$ 3 | Spree$ True
+A:SP$ Charm | Choices$ DBTutor,DBDraw | MinCharmNum$ 1 | CharmNum$ 2 | Spree$ True
 SVar:DBTutor:DB$ ChangeZone | SpreeCost$ 2 | Origin$ Library | Destination$ Library | LibraryPosition$ 0 | ChangeType$ Card | ChangeNum$ 1 | Mandatory$ True | SpellDescription$ Search your library for a card, then shuffle and put that card on top.
 SVar:DBDraw:DB$ Draw | SpreeCost$ B B | NumCards$ 3 | ValidTgts$ Player | TgtPrompt$ Choose a player | SubAbility$ DBLoseLife | SpellDescription$ Target player draws three cards and loses 3 life.
 SVar:DBLoseLife:DB$ LoseLife | LifeAmount$ 3 | Defined$ Targeted

--- a/forge-gui/res/cardsfolder/upcoming/oltec_matterweaver.txt
+++ b/forge-gui/res/cardsfolder/upcoming/oltec_matterweaver.txt
@@ -1,0 +1,11 @@
+Name:Oltec Matterweaver
+ManaCost:2 W
+Types:Creature Human Artificer
+PT:2/4
+T:Mode$ SpellCast | ValidCard$ Creature | ValidActivatingPlayer$ You | Execute$ TrigCharm | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a creature spell, ABILITY
+SVar:TrigCharm:DB$ Charm | Choices$ DBToken,DBCopy | CharmNum$ 1
+SVar:DBToken:DB$ Token | TokenAmount$ 1 | TokenScript$ c_1_1_a_gnome | TokenOwner$ You | SpellDescription$ Create a 1/1 colorless Gnome artifact creature token.
+SVar:DBCopy:DB$ CopyPermanent | ValidTgts$ Artifact.token+YouCtrl | NumCopies$ 1 | TgtPrompt$ Select target artifact token you control | SpellDescription$ Create a token that’s a copy of target artifact token you control.
+DeckHas:Ability$Token
+DeckHints:Ability$Token
+Oracle:Whenever you cast a creature spell, choose one —\n• Create a 1/1 colorless Gnome artifact creature token.\n• Create a token that’s a copy of target artifact token you control.

--- a/forge-gui/res/cardsfolder/upcoming/vaultborn_tyrant.txt
+++ b/forge-gui/res/cardsfolder/upcoming/vaultborn_tyrant.txt
@@ -3,10 +3,10 @@ ManaCost:5 G G
 Types:Creature Dinosaur
 PT:6/6
 K:Trample
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self,Creature.powerGE4+Other+YouCtrl | Execute$ TrigGainLife | TriggerDescription$ When CARDNAME enters the battlefield, you gain 3 life and draw a card.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self,Creature.powerGE4+Other+YouCtrl | Execute$ TrigGainLife | TriggerDescription$ When CARDNAME or another creature with power 4 or greater enters the battlefield under your control, you gain 3 life and draw a card.
 SVar:TrigGainLife:DB$ GainLife | LifeAmount$ 3 | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self+!token | Execute$ DBCopy | TriggerDescription$ When CARDNAME dies, if it’s not a token, create a token that’s a copy of it, except it’s an artifact in addition to its other types.
 SVar:DBCopy:DB$ CopyPermanent | Defined$ TriggeredCard | AddTypes$ Artifact
-DeckHas:Ability$Token
+DeckHas:Ability$Token & Type$Artifact
 Oracle:Trample\nWhenever Vaultborn Tyrant or another creature with power 4 or greater enters the battlefield under your control, you gain 3 life and draw a card.\nWhen Vaultborn Tyrant dies, if it’s not a token, create a token that’s a copy of it, except it’s an artifact in addition to its other types.

--- a/forge-gui/res/cardsfolder/upcoming/vaultborn_tyrant.txt
+++ b/forge-gui/res/cardsfolder/upcoming/vaultborn_tyrant.txt
@@ -1,0 +1,12 @@
+Name:Vaultborn Tyrant
+ManaCost:5 G G
+Types:Creature Dinosaur
+PT:6/6
+K:Trample
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self,Creature.powerGE4+Other+YouCtrl | Execute$ TrigGainLife | TriggerDescription$ When CARDNAME enters the battlefield, you gain 3 life and draw a card.
+SVar:TrigGainLife:DB$ GainLife | LifeAmount$ 3 | SubAbility$ DBDraw
+SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self+!token | Execute$ DBCopy | TriggerDescription$ When CARDNAME dies, if it’s not a token, create a token that’s a copy of it, except it’s an artifact in addition to its other types.
+SVar:DBCopy:DB$ CopyPermanent | Defined$ TriggeredCard | AddTypes$ Artifact
+DeckHas:Ability$Token
+Oracle:Trample\nWhenever Vaultborn Tyrant or another creature with power 4 or greater enters the battlefield under your control, you gain 3 life and draw a card.\nWhen Vaultborn Tyrant dies, if it’s not a token, create a token that’s a copy of it, except it’s an artifact in addition to its other types.


### PR DESCRIPTION
Tested card scripts for:
- [Oltec Matterweaver](https://scryfall.com/card/big/3/oltec-matterweaver)
- [Vaultborn Tyrant](https://scryfall.com/card/big/20/vaultborn-tyrant)

Minor fixes:
- Corrected `CharmNum$` on Insatiable Avarice.