### PR TITLE
CI: Test on all current Java LTS versions (8, 11 ,17, and 21)

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -5,15 +5,23 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: true
       matrix:
-        java: [ '8', '11' ]
-    name: Test with Java ${{ matrix.Java }}
+        java: ['8', '11']
+        experimental: [false]
+        include:
+          - java: '17'
+            experimental: true
+          - java: '21'
+            experimental: true
+    name: Test with Java ${{ matrix.java }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}


### PR DESCRIPTION
Tests on JDK 17 and 21 are optional (since they currently fail).

The very existence of these tests will increase the awareness on the importance of code compatibility with newer Java versions, thus enabling future transitions to be implemented gradually.

Making the code run on JDK 11 took a lot of hacking. This will reduce the effort for eventual future transitions.