### PR TITLE
OTJ: Thunder Salvo, Trick Shot, Vault Plunderer

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/thunder_salvo.txt
+++ b/forge-gui/res/cardsfolder/upcoming/thunder_salvo.txt
@@ -1,0 +1,6 @@
+Name:Thunder Salvo
+ManaCost:1 R
+Types:Instant
+A:SP$ DealDamage | ValidTgts$ Creature | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to target creature, where X is 2 plus the number of other spells you’ve cast this turn.
+SVar:X:Count$ThisTurnCast_Card.YouCtrl+Other/Plus.2
+Oracle:Thunder Salvo deals X damage to target creature, where X is 2 plus the number of other spells you’ve cast this turn.

--- a/forge-gui/res/cardsfolder/upcoming/trick_shot.txt
+++ b/forge-gui/res/cardsfolder/upcoming/trick_shot.txt
@@ -1,0 +1,7 @@
+Name:Trick Shot
+ManaCost:4 R
+Types:Instant
+A:SP$ DealDamage | ValidTgts$ Creature | NumDmg$ 6 | DamageMap$ True | SubAbility$ MoreDamage | SpellDescription$ CARDNAME deals 6 damage to target creature and 2 damage to up to one other target creature token.
+SVar:MoreDamage:DB$ DealDamage | ValidTgts$ Creature.token | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one other target creature token | TargetUnique$ True | NumDmg$ 2 | SubAbility$ DBDamageResolve
+SVar:DBDamageResolve:DB$ DamageResolve
+Oracle:Trick Shot deals 6 damage to target creature and 2 damage to up to one other target creature token.

--- a/forge-gui/res/cardsfolder/upcoming/vault_plunderer.txt
+++ b/forge-gui/res/cardsfolder/upcoming/vault_plunderer.txt
@@ -1,0 +1,8 @@
+Name:Vault Plunderer
+ManaCost:2 B
+Types:Creature Human Rogue
+PT:3/1
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ When CARDNAME enters the battlefield, target player draws a card and loses 1 life.
+SVar:TrigDraw:DB$ Draw | NumCards$ 1 | ValidTgts$ Player | SubAbility$ DBLoseLife
+SVar:DBLoseLife:DB$ LoseLife | Defined$ Targeted | LifeAmount$ 1
+Oracle:When Vault Plunderer enters the battlefield, target player draws a card and loses 1 life.


### PR DESCRIPTION
Tested card scripts for:
- [Thunder Salvo](https://scryfall.com/card/otj/150/thunder-salvo)
- [Trick Shot](https://scryfall.com/card/otj/151/trick-shot)
- [Vault Plunderer](https://scryfall.com/card/otj/114/vault-plunderer)

On the chance the use of `DamageMap` and `DamageResolve` in Trick Shot is curious: I referenced the script partly from [Drakuseth, Maw of Flames](https://scryfall.com/card/cmm/218/drakuseth-maw-of-flames) and, given the similarity between the spell ability and the triggered ability, assumed that's what's to be used in this particular case.