### PR TITLE
OTJ: Spinewoods Paladin, Stagecoach Security, Steer Clear, Sterling Hound, Sterling Keykeeper, Stingerback Terror

### DIFF
--- a/forge-gui/res/cardsfolder/d/dimir_informant.txt
+++ b/forge-gui/res/cardsfolder/d/dimir_informant.txt
@@ -2,7 +2,7 @@ Name:Dimir Informant
 ManaCost:2 U
 Types:Creature Human Rogue
 PT:1/4
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSurveil | TriggerDescription$ When CARDNAME enters the battlefield, then surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on the top of your library in any order.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSurveil | TriggerDescription$ When CARDNAME enters the battlefield, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on the top of your library in any order.)
 SVar:TrigSurveil:DB$ Surveil | Defined$ You | Amount$ 2
 DeckHas:Ability$Surveil|Graveyard
 Oracle:When Dimir Informant enters the battlefield, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)

--- a/forge-gui/res/cardsfolder/g/geralfs_masterpiece.txt
+++ b/forge-gui/res/cardsfolder/g/geralfs_masterpiece.txt
@@ -6,7 +6,6 @@ K:Flying
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ -X | AddToughness$ -X | Description$ CARDNAME gets -1/-1 for each card in your hand.
 A:AB$ ChangeZone | Cost$ 3 U Discard<3/Card> | Origin$ Graveyard | Destination$ Battlefield | ActivationZone$ Graveyard | Tapped$ True | SpellDescription$ Return CARDNAME from your graveyard to the battlefield tapped.
 SVar:X:Count$InYourHand
-SVar:NeedsToPlayVar:Y LE6
-SVar:Y:Count$CardsInYourHand
+SVar:NeedsToPlayVar:X LE6
 SVar:BuffedBy:Card
 Oracle:Flying\nGeralf's Masterpiece gets -1/-1 for each card in your hand.\n{3}{U}, Discard three cards: Return Geralf's Masterpiece from your graveyard to the battlefield tapped.

--- a/forge-gui/res/cardsfolder/g/grim_strider.txt
+++ b/forge-gui/res/cardsfolder/g/grim_strider.txt
@@ -5,6 +5,5 @@ PT:6/6
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ -X | AddToughness$ -X | Description$ CARDNAME gets -1/-1 for each card in your hand.
 SVar:X:Count$InYourHand
 SVar:BuffedBy:Card
-SVar:NeedsToPlayVar:Y LE5
-SVar:Y:Count$CardsInYourHand
+SVar:NeedsToPlayVar:X LE5
 Oracle:Grim Strider gets -1/-1 for each card in your hand.

--- a/forge-gui/res/cardsfolder/g/grim_strider.txt
+++ b/forge-gui/res/cardsfolder/g/grim_strider.txt
@@ -4,6 +4,6 @@ Types:Creature Horror
 PT:6/6
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ -X | AddToughness$ -X | Description$ CARDNAME gets -1/-1 for each card in your hand.
 SVar:X:Count$InYourHand
-SVar:BuffedBy:Card
 SVar:NeedsToPlayVar:X LE5
+SVar:BuffedBy:Card
 Oracle:Grim Strider gets -1/-1 for each card in your hand.

--- a/forge-gui/res/cardsfolder/upcoming/roxanne_starfall_savant.txt
+++ b/forge-gui/res/cardsfolder/upcoming/roxanne_starfall_savant.txt
@@ -7,6 +7,8 @@ T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigToken | TriggerZones$ Batt
 SVar:TrigToken:DB$ Token | TokenScript$ meteorite | TokenAmount$ 1 | TokenTapped$ True | TokenOwner$ You
 T:Mode$ TapsForMana | ValidCard$ Artifact.token | Activator$ You | Execute$ TrigMana | TriggerZones$ Battlefield | Static$ True | TriggerDescription$ Whenever you tap an artifact token for mana, add one mana of any type that permanent produced.
 SVar:TrigMana:DB$ ManaReflected | ColorOrType$ Type | ReflectProperty$ Produced | Defined$ You
+SVar:PlayMain1:TRUE
+SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Token & Type$Artifact
 DeckHints:Ability$Token & Type$Artifact|Token
 Oracle:Whenever Roxanne, Starfall Savant enters the battlefield or attacks, create a tapped colorless artifact token named Meteorite with "When Meteorite enters the battlefield, it deals 2 damage to any target" and "{T}: Add one mana of any color."\nWhenever you tap an artifact token for mana, add one mana of any type that artifact token produced.

--- a/forge-gui/res/cardsfolder/upcoming/spinewoods_paladin.txt
+++ b/forge-gui/res/cardsfolder/upcoming/spinewoods_paladin.txt
@@ -1,0 +1,9 @@
+Name:Spinewoods Paladin
+ManaCost:4 G
+Types:Creature Human Knight
+PT:5/4
+K:Trample
+K:Plot:3 G
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigGainLife | TriggerDescription$ When CARDNAME enters the battlefield, you gain 3 life.
+SVar:TrigGainLife:DB$ GainLife | LifeAmount$ 3
+Oracle:Trample\nWhen Spinewoods Paladin enters the battlefield, you gain 3 life.\nPlot {3}{G} (You may pay {3}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)

--- a/forge-gui/res/cardsfolder/upcoming/stagecoach_security.txt
+++ b/forge-gui/res/cardsfolder/upcoming/stagecoach_security.txt
@@ -1,0 +1,9 @@
+Name:Stagecoach Security
+ManaCost:4 W
+Types:Creature Human Soldier
+PT:4/5
+K:Plot:3 W
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPumpAll | TriggerDescription$ When CARDNAME enters the battlefield, creatures you control get +1/+1 and gain vigilance until end of turn.
+SVar:TrigPumpAll:DB$ PumpAll | ValidCards$ Creature.YouCtrl | NumAtt$ +1 | NumDef$ +1 | KW$ Vigilance
+SVar:PlayMain1:TRUE
+Oracle:When Stagecoach Security enters the battlefield, creatures you control get +1/+1 and gain vigilance until end of turn.\nPlot {3}{W} (You may pay {3}{W} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)

--- a/forge-gui/res/cardsfolder/upcoming/steer_clear.txt
+++ b/forge-gui/res/cardsfolder/upcoming/steer_clear.txt
@@ -1,0 +1,7 @@
+Name:Steer Clear
+ManaCost:W
+Types:Instant
+A:SP$ DealDamage | ValidTgts$ Creature.attacking,Creature.blocking | TgtPrompt$ Select target attacking or blocking creature | NumDmg$ X | SpellDescription$ CARDNAME deals 2 damage to target attacking or blocking creature. CARDNAME deals 4 damage to that creature instead if you controlled a Mount as you cast this spell.
+SVar:X:Count$Compare Y GE1.4.2
+SVar:Y:Count$LastStateBattlefieldWithFallback Permanent.Mount+YouCtrl
+Oracle:Steer Clear deals 2 damage to target attacking or blocking creature. Steer Clear deals 4 damage to that creature instead if you controlled a Mount as you cast this spell.

--- a/forge-gui/res/cardsfolder/upcoming/sterling_hound.txt
+++ b/forge-gui/res/cardsfolder/upcoming/sterling_hound.txt
@@ -2,7 +2,7 @@ Name:Sterling Hound
 ManaCost:3
 Types:Artifact Creature Dog
 PT:3/2
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSurveil | TriggerDescription$ When CARDNAME enters the battlefield, then surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on the top of your library in any order.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSurveil | TriggerDescription$ When CARDNAME enters the battlefield, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on the top of your library in any order.)
 SVar:TrigSurveil:DB$ Surveil | Defined$ You | Amount$ 2
 DeckHas:Ability$Surveil|Graveyard
 Oracle:When Sterling Hound enters the battlefield, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)

--- a/forge-gui/res/cardsfolder/upcoming/sterling_hound.txt
+++ b/forge-gui/res/cardsfolder/upcoming/sterling_hound.txt
@@ -1,0 +1,8 @@
+Name:Sterling Hound
+ManaCost:3
+Types:Artifact Creature Dog
+PT:3/2
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSurveil | TriggerDescription$ When CARDNAME enters the battlefield, then surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on the top of your library in any order.)
+SVar:TrigSurveil:DB$ Surveil | Defined$ You | Amount$ 2
+DeckHas:Ability$Surveil|Graveyard
+Oracle:When Sterling Hound enters the battlefield, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)

--- a/forge-gui/res/cardsfolder/upcoming/sterling_keykeeper.txt
+++ b/forge-gui/res/cardsfolder/upcoming/sterling_keykeeper.txt
@@ -1,0 +1,7 @@
+Name:Sterling Keykeeper
+ManaCost:1 W
+Types:Creature Human Mercenary
+PT:2/2
+A:AB$ Tap | Cost$ 2 T | ValidTgts$ Creature.nonMount | TgtPrompt$ Select target non-Mount creature | SpellDescription$ Tap target non-Mount creature.
+SVar:NonCombatPriority:1
+Oracle:{2}, {T}: Tap target non-Mount creature.

--- a/forge-gui/res/cardsfolder/upcoming/stingerback_terror.txt
+++ b/forge-gui/res/cardsfolder/upcoming/stingerback_terror.txt
@@ -1,0 +1,13 @@
+Name:Stingerback Terror
+ManaCost:2 R R
+Types:Creature Scorpion Dragon
+PT:7/7
+K:Flying
+K:Trample
+K:Plot:2 R
+S:Mode$ Continuous | Affected$ Card.Self | AddPower$ -X | AddToughness$ -X | Description$ CARDNAME gets -1/-1 for each card in your hand.
+SVar:X:Count$InYourHand
+SVar:BuffedBy:Card
+SVar:NeedsToPlayVar:Y LE6
+SVar:Y:Count$CardsInYourHand
+Oracle:Flying, trample\nStingerback Terror gets -1/-1 for each card in your hand.\nPlot {2}{R} (You may pay {2}{R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)

--- a/forge-gui/res/cardsfolder/upcoming/stingerback_terror.txt
+++ b/forge-gui/res/cardsfolder/upcoming/stingerback_terror.txt
@@ -8,6 +8,5 @@ K:Plot:2 R
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ -X | AddToughness$ -X | Description$ CARDNAME gets -1/-1 for each card in your hand.
 SVar:X:Count$InYourHand
 SVar:BuffedBy:Card
-SVar:NeedsToPlayVar:Y LE6
-SVar:Y:Count$CardsInYourHand
+SVar:NeedsToPlayVar:X LE6
 Oracle:Flying, trample\nStingerback Terror gets -1/-1 for each card in your hand.\nPlot {2}{R} (You may pay {2}{R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)

--- a/forge-gui/res/cardsfolder/upcoming/stingerback_terror.txt
+++ b/forge-gui/res/cardsfolder/upcoming/stingerback_terror.txt
@@ -7,6 +7,6 @@ K:Trample
 K:Plot:2 R
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ -X | AddToughness$ -X | Description$ CARDNAME gets -1/-1 for each card in your hand.
 SVar:X:Count$InYourHand
-SVar:BuffedBy:Card
 SVar:NeedsToPlayVar:X LE6
+SVar:BuffedBy:Card
 Oracle:Flying, trample\nStingerback Terror gets -1/-1 for each card in your hand.\nPlot {2}{R} (You may pay {2}{R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)

--- a/forge-gui/res/cardsfolder/upcoming/take_the_fall.txt
+++ b/forge-gui/res/cardsfolder/upcoming/take_the_fall.txt
@@ -4,5 +4,5 @@ Types:Instant
 A:SP$ Pump | ValidTgts$ Creature | NumAtt$ -X | IsCurse$ True | SubAbility$ DBDraw | StackDescription$ SpellDescription | SpellDescription$ Target creature gets -1/-0 until end of turn. It gets -4/-0 until end of turn instead if you control an outlaw. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.) Draw a card.
 SVar:DBDraw:DB$ Draw | NumCards$ 1
 SVar:X:Count$Compare Y GE1.4.1
-SVar:Y:Count$Valid Permanent.Outlaw
+SVar:Y:Count$Valid Permanent.Outlaw+YouCtrl
 Oracle:Target creature gets -1/-0 until end of turn. It gets -4/-0 until end of turn instead if you control an outlaw. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)\nDraw a card.

--- a/forge-gui/res/cardsfolder/upcoming/vaultborn_tyrant.txt
+++ b/forge-gui/res/cardsfolder/upcoming/vaultborn_tyrant.txt
@@ -6,7 +6,7 @@ K:Trample
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self,Creature.powerGE4+Other+YouCtrl | Execute$ TrigGainLife | TriggerDescription$ When CARDNAME or another creature with power 4 or greater enters the battlefield under your control, you gain 3 life and draw a card.
 SVar:TrigGainLife:DB$ GainLife | LifeAmount$ 3 | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self+!token | Execute$ DBCopy | TriggerDescription$ When CARDNAME dies, if it’s not a token, create a token that’s a copy of it, except it’s an artifact in addition to its other types.
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self+!token | Execute$ DBCopy | TriggerDescription$ When CARDNAME dies, if it's not a token, create a token that's a copy of it, except it's an artifact in addition to its other types.
 SVar:DBCopy:DB$ CopyPermanent | Defined$ TriggeredCard | AddTypes$ Artifact
 DeckHas:Ability$Token & Type$Artifact
-Oracle:Trample\nWhenever Vaultborn Tyrant or another creature with power 4 or greater enters the battlefield under your control, you gain 3 life and draw a card.\nWhen Vaultborn Tyrant dies, if it’s not a token, create a token that’s a copy of it, except it’s an artifact in addition to its other types.
+Oracle:Trample\nWhenever Vaultborn Tyrant or another creature with power 4 or greater enters the battlefield under your control, you gain 3 life and draw a card.\nWhen Vaultborn Tyrant dies, if it's not a token, create a token that's a copy of it, except it's an artifact in addition to its other types.

--- a/forge-gui/res/tokenscripts/meteorite.txt
+++ b/forge-gui/res/tokenscripts/meteorite.txt
@@ -4,5 +4,4 @@ Types:Artifact
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When CARDNAME enters the battlefield, it deals 2 damage to any target.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Any | NumDmg$ 2
 A:AB$ Mana | Cost$ T | Produced$ Any | SpellDescription$ Add one mana of any color.
-SVar:PlayMain1:TRUE
 Oracle:When Meteorite enters the battlefield, it deals 2 damage to any target.\n{T}: Add one mana of any color.


### PR DESCRIPTION
Tested card scripts for:
- [Spinewoods Paladin](https://scryfall.com/card/otj/183/spinewoods-paladin)
- [Stagecoach Security](https://scryfall.com/card/otj/30/stagecoach-security)
- [Steer Clear](https://scryfall.com/card/otj/31/steer-clear)
- [Sterling Hound](https://scryfall.com/card/otj/249/sterling-hound)
- [Sterling Keykeeper](https://scryfall.com/card/otj/32/sterling-keykeeper)
- [Stingerback Terror](https://scryfall.com/card/otj/147/stingerback-terror)

Minor fixes:
- Fixed Take the Fall missing a crucial `YouCtrl` on a counting `SVar`.
- Cleanup of Vault Tyrant's `Oracle` and `TriggerDescription` text.
- Moved the likely spurious `SVar:PlayMain1:TRUE` tag on the token version of Meteorite to Roxanne, Starfall Savant itself. Also added the required `SVar:HasAttackEffect:TRUE` for Primeval Titan-like abilities to the latter.
- Cleanup of Dimir Informant's `TriggerDescription` text.