### PR TITLE
OTJ: Nimble Brigand, Seize the Secrets, Shackle Slinger, Shepherd of the Clouds

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/nimble_brigand.txt
+++ b/forge-gui/res/cardsfolder/upcoming/nimble_brigand.txt
@@ -1,0 +1,8 @@
+Name:Nimble Brigand
+ManaCost:2 U
+Types:Creature Human Rogue
+PT:1/3
+S:Mode$ CantBlockBy | ValidAttacker$ Card.Self | CheckSVar$ Count$CommittedCrimeThisTurn.1.0 | Description$ CARDNAME can't be blocked if you've committed a crime this turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, draw a card.
+SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1
+Oracle:Nimble Brigand can't be blocked if you've committed a crime this turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\nWhenever Nimble Brigand deals combat damage to a player, draw a card.

--- a/forge-gui/res/cardsfolder/upcoming/seize_the_secrets.txt
+++ b/forge-gui/res/cardsfolder/upcoming/seize_the_secrets.txt
@@ -1,0 +1,6 @@
+Name:Seize the Secrets
+ManaCost:2 U
+Types:Sorcery
+S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 1 | EffectZone$ All | CheckSVar$ Count$CommittedCrimeThisTurn.1.0 | Description$ This spell costs {1} less to cast if you've committed a crime this turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)
+A:SP$ Draw | NumCards$ 2 | SpellDescription$ Draw two cards.
+Oracle:This spell costs {1} less to cast if you've committed a crime this turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\nDraw two cards.

--- a/forge-gui/res/cardsfolder/upcoming/shackle_slinger.txt
+++ b/forge-gui/res/cardsfolder/upcoming/shackle_slinger.txt
@@ -1,0 +1,9 @@
+Name:Shackle Slinger
+ManaCost:2 U
+Types:Creature Human Soldier
+PT:3/2
+T:Mode$ SpellCast | ValidCard$ Card.YouCtrl | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPutCounter | ActivatorThisTurnCast$ EQ2 | TriggerDescription$ Whenever you cast your second spell each turn, choose target creature an opponent controls. If it's tapped, put a stun counter on it. Otherwise, tap it. (If a permanent with a stun counter would become untapped, remove one from it instead.)
+SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | CounterType$ STUN | CounterNum$ 1 | ConditionDefined$ Targeted | ConditionPresent$ Creature.tapped | SubAbility$ DBTap
+SVar:DBTap:DB$ Tap | Defined$ Targeted | ConditionDefined$ Targeted | ConditionPresent$ Creature.untapped
+DeckHas:Ability$Counters
+Oracle:Whenever you cast your second spell each turn, choose target creature an opponent controls. If it's tapped, put a stun counter on it. Otherwise, tap it. (If a permanent with a stun counter would become untapped, remove one from it instead.)

--- a/forge-gui/res/cardsfolder/upcoming/shepherd_of_the_clouds.txt
+++ b/forge-gui/res/cardsfolder/upcoming/shepherd_of_the_clouds.txt
@@ -1,0 +1,12 @@
+Name:Shepherd of the Clouds
+ManaCost:4 W
+Types:Creature Pegasus
+PT:4/3
+K:Flying
+K:Vigilance
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Destination$ Battlefield | Execute$ TrigReturn | TriggerDescription$ When CARDNAME enters the battlefield, return target permanent card with mana value 3 or less from your graveyard to your hand. Return that card to the battlefield instead if you control a Mount.
+SVar:TrigReturn:DB$ ChangeZone | ValidTgts$ Permanent.YouCtrl+cmcLE3 | ConditionCheckSVar$ X | ConditionSVarCompare$ LT1 | TgtPrompt$ Select target permanent card with mana value 3 in your graveyard | Origin$ Graveyard | Destination$ Hand | SubAbility$ DBReturn
+SVar:DBReturn:DB$ ChangeZone | Defined$ Targeted | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1 | Origin$ Graveyard | Destination$ Battlefield
+SVar:X:Count$Valid Permanent.Mount+YouCtrl
+DeckHints:Type$Mount
+Oracle:Flying, vigilance\nWhen Shepherd of the Clouds enters the battlefield, return target permanent card with mana value 3 or less from your graveyard to your hand. Return that card to the battlefield instead if you control a Mount.


### PR DESCRIPTION
Tested card scripts for:
- [Nimble Brigand](https://scryfall.com/card/otj/58/nimble-brigand)
- [Seize the Secrets](https://scryfall.com/card/otj/64/seize-the-secrets)
- [Shackle Slinger](https://scryfall.com/card/otj/65/shackle-slinger)
- [Shepherd of the Clouds](https://scryfall.com/card/otj/28/shepherd-of-the-clouds)

I must say, regarding Nimble Brigand (and similar cards), that it would be nice to have the text: "`CARDNAME` can't be blocked" displayed on the card when the (non-)ability is active just to make things a bit clearer.