### PR TITLE
Fix advanced Flash logic messing with PlayEffectAi

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/PermanentCreatureAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PermanentCreatureAi.java
@@ -90,7 +90,7 @@ public class PermanentCreatureAi extends PermanentAi {
         if (ai.getController().isAI()) {
             advancedFlash = ((PlayerControllerAi)ai.getController()).getAi().getBooleanProperty(AiProps.FLASH_ENABLE_ADVANCED_LOGIC);
         }
-        if (card.hasKeyword(Keyword.FLASH) || (!ai.canCastSorcery() && sa.canCastTiming(ai) && !sa.hasParam("WithoutManaCost"))) {
+        if (card.hasKeyword(Keyword.FLASH) || (!ai.canCastSorcery() && sa.canCastTiming(ai) && !sa.isCastFromPlayEffect())) {
             if (advancedFlash) {
                 return doAdvancedFlashLogic(card, ai, sa);
             } else {

--- a/forge-ai/src/main/java/forge/ai/ability/PermanentCreatureAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PermanentCreatureAi.java
@@ -90,7 +90,7 @@ public class PermanentCreatureAi extends PermanentAi {
         if (ai.getController().isAI()) {
             advancedFlash = ((PlayerControllerAi)ai.getController()).getAi().getBooleanProperty(AiProps.FLASH_ENABLE_ADVANCED_LOGIC);
         }
-        if (card.hasKeyword(Keyword.FLASH) || (!ai.canCastSorcery() && sa.canCastTiming(ai))) {
+        if (card.hasKeyword(Keyword.FLASH) || (!ai.canCastSorcery() && sa.canCastTiming(ai) && !sa.hasParam("WithoutManaCost"))) {
             if (advancedFlash) {
                 return doAdvancedFlashLogic(card, ai, sa);
             } else {

--- a/forge-gui/res/puzzle/PS_PIP1.pzl
+++ b/forge-gui/res/puzzle/PS_PIP1.pzl
@@ -1,0 +1,17 @@
+[metadata]
+Name:Possibility Storm - Fallout #01
+URL:https://i2.wp.com/www.possibilitystorm.com/wp-content/uploads/2024/03/latest-1-scaled.jpg?ssl=1
+Goal:Win
+Turns:1
+Difficulty:Mythic
+Description:Win this turn. Remember that your solution must satisfy all possible opponent decisions. Your opponent has three energy counters and can activate Synth Eradicator.
+[state]
+turn=1
+activeplayer=p0
+activephase=MAIN1
+p0life=5
+p0hand=Young Deathclaws;Lethal Scheme;Winding Constrictor
+p0battlefield=Jason Bright, Glowing Prophet;Hancock, Ghoulish Mayor;Feral Ghoul;Temple of Mystery;Temple of Mystery;Temple of Mystery;Temple of Mystery;Temple of Malady;Temple of Malady
+p1life=10
+p1battlefield=T:c_1_1_a_thopter_flying;Whirler Rogue;Synth Eradicator
+p1counters=ENERGY=3


### PR DESCRIPTION
E.g. Discover X or a transformed Battle - assume that an out-of-timing permanent cast without paying its mana cost is good enough to not rely on advanced Flash considerations.