### PR TITLE
OTC: Vengeful Regrowth, Vihaan, We Ride at Dawn

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/vengeful_regrowth.txt
+++ b/forge-gui/res/cardsfolder/upcoming/vengeful_regrowth.txt
@@ -1,0 +1,10 @@
+Name:Vengeful Regrowth
+ManaCost:4 G G
+Types:Sorcery
+K:Flashback:6 G G
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | TargetMin$ 0 | TargetMax$ 3 | TgtPrompt$ Choose target land card in your graveyard | ValidTgts$ Land.YouCtrl | RememberChanged$ True | Tapped$ True | SubAbility$ DBToken | SpellDescription$ Return up to three target land cards from your graveyard to the battlefield tapped. Create that many 4/2 green Plant Warrior creature tokens with reach.
+SVar:DBToken:DB$ Token | TokenAmount$ X | TokenOwner$ You | TokenScript$ g_4_2_plant_warrior_reach | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:X:Remembered$Amount
+DeckHas:Ability$|Token & Type$Plant|Warrior
+Oracle:Return up to three target land cards from your graveyard to the battlefield tapped. Create that many 4/2 green Plant Warrior creature tokens with reach.\nFlashback {6}{G}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)

--- a/forge-gui/res/cardsfolder/upcoming/vihaan_goldwaker.txt
+++ b/forge-gui/res/cardsfolder/upcoming/vihaan_goldwaker.txt
@@ -1,0 +1,10 @@
+Name:Vihaan, Goldwaker
+ManaCost:R W B
+Types:Legendary Creature Dwarf Warlock
+PT:3/3
+S:Mode$ Continuous | Affected$ Creature.Outlaw+Other+YouCtrl | AddKeyword$ Haste & Vigilance | Description$ Other outlaws you control have vigilance and haste. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)
+T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigAnimateAll | TriggerDescription$ At the beginning of combat on your turn, you may have Treasures you control become 3/3 Construct Assassin artifact creatures in addition to their other types until end of turn.
+SVar:TrigAnimateAll:DB$ AnimateAll | ValidCards$ Artifact.Treasure+YouCtrl | Power$ 3 | Toughness$ 3 | Types$ Artifact,Creature,Construct,Assassin
+DeckHints:Type$Assassin|Mercenary|Pirates|Rogues|Warlock
+DeckNeeds:Type$Treasure
+Oracle:Other outlaws you control have vigilance and haste. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)\nAt the beginning of combat on your turn, you may have Treasures you control become 3/3 Construct Assassin artifact creatures in addition to their other types until end of turn.

--- a/forge-gui/res/cardsfolder/upcoming/we_ride_at_dawn.txt
+++ b/forge-gui/res/cardsfolder/upcoming/we_ride_at_dawn.txt
@@ -1,0 +1,9 @@
+Name:We Ride at Dawn
+ManaCost:2 W
+Types:Enchantment
+S:Mode$ Continuous | Affected$ Card.Creature+Legendary+YouCtrl | AffectedZone$ Stack | AddKeyword$ Convoke | Description$ Legendary creature spells you cast have convoke. (Your creatures can help cast those spells. Each creature you tap while casting a legendary creature spell pays for {1} or one mana of that creature’s color.)
+T:Mode$ Attacks | ValidCard$ Card.IsCommander+YouOwn | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever your commander attacks, create a 1/1 red Mercenary creature token with "{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery."
+SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ r_1_1_mercenary_tappump | TokenOwner$ You
+DeckNeeds:Type$Legendary & Type$Creature
+DeckHas:Ability$Token & Type$Mercenary & Color$Red
+Oracle:Legendary creature spells you cast have convoke. (Your creatures can help cast those spells. Each creature you tap while casting a legendary creature spell pays for {1} or one mana of that creature’s color.)\nWhenever your commander attacks, create a 1/1 red Mercenary creature token with "{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery."

--- a/forge-gui/res/cardsfolder/v/vexing_puzzlebox.txt
+++ b/forge-gui/res/cardsfolder/v/vexing_puzzlebox.txt
@@ -4,7 +4,7 @@ Types:Artifact
 T:Mode$ RolledDieOnce | TriggerZones$ Battlefield | ValidPlayer$ You | Execute$ TrigPutCounter | TriggerDescription$ Whenever you roll one or more dice, put a number of charge counters on CARDNAME equal to the result.
 SVar:DiceResult:TriggerCountMax$Result
 SVar:TrigPutCounter:DB$ PutCounter | CounterType$ CHARGE | CounterNum$ DiceResult
-A:AB$ Mana | Cost$ T | Produced$ Any | SubAbility$ DBRollDice | SpellDescription$ {T}: Add one mana of any color. Roll a d20.
+A:AB$ Mana | Cost$ T | Produced$ Any | SubAbility$ DBRollDice | SpellDescription$ Add one mana of any color. Roll a d20.
 SVar:DBRollDice:DB$ RollDice | Sides$ 20
 A:AB$ ChangeZone | Cost$ T SubCounter<100/CHARGE> | Origin$ Library | Destination$ Battlefield | ChangeType$ Artifact | ChangeNum$ 1 | SpellDescription$ Search your library for an artifact card, put that card onto the battlefield, then shuffle.
 AI:RemoveDeck:Random


### PR DESCRIPTION
Tested card scripts for:
- [Vengeful Regrowth](https://scryfall.com/card/otc/35/vengeful-regrowth)
- [Vihaan, Goldwaker](https://scryfall.com/card/otc/8/vihaan-goldwaker)
- [We Ride at Dawn](https://scryfall.com/card/otc/12/we-ride-at-dawn)

Minor fixes:
- Vexing Puzzlebox: cleaning up extraneous duplication on the first activated ability's `SpellDescription$`.