### PR TITLE
OTC: Thieving Varmint, Thunderclap Drake, Tower Winder

### DIFF
--- a/forge-gui/res/cardsfolder/a/awakener_druid.txt
+++ b/forge-gui/res/cardsfolder/a/awakener_druid.txt
@@ -3,5 +3,5 @@ ManaCost:2 G
 Types:Creature Human Druid
 PT:1/1
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigAnimate | TriggerDescription$ When CARDNAME enters the battlefield, target Forest becomes a 4/5 green Treefolk creature for as long as CARDNAME is on the battlefield. It's still a land.
-SVar:TrigAnimate:DB$ Animate | ValidTgts$ Forest | TgtPrompt$ Select target Forest | Types$ Creature,Treefolk | Power$ 4 | Toughness$ 5 | Colors$ Green | Duration$ AsLongAsInPlay
+SVar:TrigAnimate:DB$ Animate | ValidTgts$ Forest | TgtPrompt$ Select target Forest | Types$ Creature,Treefolk | Power$ 4 | Toughness$ 5 | Colors$ Green | OverwriteColors$ True | Duration$ AsLongAsInPlay
 Oracle:When Awakener Druid enters the battlefield, target Forest becomes a 4/5 green Treefolk creature for as long as Awakener Druid remains on the battlefield. It's still a land.

--- a/forge-gui/res/cardsfolder/b/balduvian_frostwaker.txt
+++ b/forge-gui/res/cardsfolder/b/balduvian_frostwaker.txt
@@ -2,6 +2,6 @@ Name:Balduvian Frostwaker
 ManaCost:2 U
 Types:Creature Human Wizard
 PT:1/1
-A:AB$ Animate | Cost$ U T | ValidTgts$ Land.Snow | TgtPrompt$ Select target snow land | Power$ 2 | Toughness$ 2 | Types$ Creature,Elemental | Colors$ Blue | Keywords$ Flying | Duration$ Permanent | AILogic$ EOT | SpellDescription$ Target snow land becomes a 2/2 blue Elemental creature with flying. It's still a land.
+A:AB$ Animate | Cost$ U T | ValidTgts$ Land.Snow | TgtPrompt$ Select target snow land | Power$ 2 | Toughness$ 2 | Types$ Creature,Elemental | Colors$ Blue | OverwriteColors$ True | Keywords$ Flying | Duration$ Permanent | AILogic$ EOT | SpellDescription$ Target snow land becomes a 2/2 blue Elemental creature with flying. It's still a land.
 AI:RemoveDeck:Random
 Oracle:{U}, {T}: Target snow land becomes a 2/2 blue Elemental creature with flying. It's still a land.

--- a/forge-gui/res/cardsfolder/b/brenard_ginger_sculptor.txt
+++ b/forge-gui/res/cardsfolder/b/brenard_ginger_sculptor.txt
@@ -5,7 +5,7 @@ PT:3/3
 S:Mode$ Continuous | Affected$ Creature.Food+YouCtrl,Creature.Golem+YouCtrl | AddPower$ 2 | AddToughness$ 2 | AddKeyword$ Trample | Description$ Each creature you control that's a Food or a Golem gets +2/+2 and has trample.
 T:Mode$ ChangesZone | ValidCard$ Creature.nonToken+Other+YouCtrl | Origin$ Battlefield | Destination$ Graveyard | TriggerZones$ Battlefield | Execute$ TrigExile | OptionalDecider$ You | TriggerDescription$ Whenever another nontoken creature you control dies, you may exile it. If you do, create a token that's a copy of that creature, except it's a 1/1 Food Golem artifact creature in addition to its other types and it has "{2}, {T}, Sacrifice this artifact: You gain 3 life."
 SVar:TrigExile:DB$ ChangeZone | Defined$ TriggeredNewCardLKICopy | Origin$ Graveyard | Destination$ Exile | RememberChanged$ True | SubAbility$ DBCopy
-SVar:DBCopy:DB$ CopyPermanent | Defined$ TriggeredCardLKICopy | SetPower$ 1 | SetToughness$ 1 | AddAbilities$ FoodSac | AddTypes$ Food & Golem & Artifact | ConditionDefined$ Remembered | ConditionPresent$ Card | SubAbility$ DBCleanup
+SVar:DBCopy:DB$ CopyPermanent | Defined$ TriggeredCardLKICopy | SetPower$ 1 | SetToughness$ 1 | AddAbilities$ FoodSac | AddTypes$ Food & Golem & Artifact & Creature | ConditionDefined$ Remembered | ConditionPresent$ Card | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:FoodSac:AB$ GainLife | Cost$ 2 T Sac<1/CARDNAME/this artifact> | Defined$ You | LifeAmount$ 3 | SpellDescription$ You gain 3 life.
 DeckHas:Ability$Token

--- a/forge-gui/res/cardsfolder/h/halsin_emerald_archdruid.txt
+++ b/forge-gui/res/cardsfolder/h/halsin_emerald_archdruid.txt
@@ -2,7 +2,7 @@ Name:Halsin, Emerald Archdruid
 ManaCost:3 G
 Types:Legendary Creature Elf Druid
 PT:2/4
-A:AB$ Animate | Cost$ 1 | ValidTgts$ Permanent.token+YouCtrl | TgtPrompt$ Select target token you control | Power$ 4 | Toughness$ 4 | Types$ Creature,Bear | SpellDescription$ Until end of turn, target token you control becomes a green Bear creature with base power and toughness 4/4 in addition to its other types and colors.
+A:AB$ Animate | Cost$ 1 | ValidTgts$ Permanent.token+YouCtrl | TgtPrompt$ Select target token you control | Power$ 4 | Toughness$ 4 | Types$ Creature,Bear | Colors$ Green | SpellDescription$ Until end of turn, target token you control becomes a green Bear creature with base power and toughness 4/4 in addition to its other types and colors.
 K:Choose a Background
 DeckNeeds:Ability$Token
 DeckHas:Type$Bear

--- a/forge-gui/res/cardsfolder/h/hedge_whisperer.txt
+++ b/forge-gui/res/cardsfolder/h/hedge_whisperer.txt
@@ -3,7 +3,7 @@ ManaCost:G
 Types:Creature Elf Druid Detective
 PT:0/3
 K:You may choose not to untap CARDNAME during your untap step.
-A:AB$ Animate | Cost$ 3 G T CollectEvidence<4> | Duration$ UntilUntaps | ValidTgts$ Land.YouCtrl | Power$ 5 | Toughness$ 5 | Types$ Creature,Plant,Bear | Keywords$ Haste | Colors$ Green | SorcerySpeed$ True | TgtPrompt$ Select target land you control | SpellDescription$ Target land you control becomes a 5/5 green Plant Boar creature with haste for as long as CARDNAME remains tapped. It's still a land. Activate only as a sorcery. (To collect evidence 4, exile cards with total mana value 4 or greater from your graveyard.)
+A:AB$ Animate | Cost$ 3 G T CollectEvidence<4> | Duration$ UntilUntaps | ValidTgts$ Land.YouCtrl | Power$ 5 | Toughness$ 5 | Types$ Creature,Plant,Boar | Keywords$ Haste | Colors$ Green | OverwriteColors$ True | SorcerySpeed$ True | TgtPrompt$ Select target land you control | SpellDescription$ Target land you control becomes a 5/5 green Plant Boar creature with haste for as long as CARDNAME remains tapped. It's still a land. Activate only as a sorcery. (To collect evidence 4, exile cards with total mana value 4 or greater from your graveyard.)
 DeckHints:Ability$Graveyard|Mill|Discard|Dredge
 DeckHas:Type$Boar|Plant
 Oracle:You may choose not to untap Hedge Whisperer during your untap step.\n{3}{G}, {T}, Collect evidence 4: Target land you control becomes a 5/5 green Plant Boar creature with haste for as long as Hedge Whisperer remains tapped. It's still a land. Activate only as a sorcery. (To collect evidence 4, exile cards with total mana value 4 or greater from your graveyard.)

--- a/forge-gui/res/cardsfolder/i/ignition_team.txt
+++ b/forge-gui/res/cardsfolder/i/ignition_team.txt
@@ -4,6 +4,6 @@ Types:Creature Goblin Warrior
 PT:0/0
 K:etbCounter:P1P1:X:no Condition:CARDNAME enters the battlefield with X +1/+1 counters on it, where X is the number of tapped lands on the battlefield.
 SVar:X:Count$Valid Land.tapped
-A:AB$ Animate | Cost$ 2 R SubCounter<1/P1P1> | ValidTgts$ Land | Power$ 4 | Toughness$ 4 | Types$ Creature,Elemental | Colors$ Red | SpellDescription$ Target land becomes a 4/4 red Elemental creature until end of turn. It's still a land.
+A:AB$ Animate | Cost$ 2 R SubCounter<1/P1P1> | ValidTgts$ Land | Power$ 4 | Toughness$ 4 | Types$ Creature,Elemental | Colors$ Red | OverwriteColors$ True | SpellDescription$ Target land becomes a 4/4 red Elemental creature until end of turn. It's still a land.
 AI:RemoveDeck:All
 Oracle:Ignition Team enters the battlefield with X +1/+1 counters on it, where X is the number of tapped lands on the battlefield.\n{2}{R}, Remove a +1/+1 counter from Ignition Team: Target land becomes a 4/4 red Elemental creature until end of turn. It's still a land.

--- a/forge-gui/res/cardsfolder/j/jolrael_voice_of_zhalfir.txt
+++ b/forge-gui/res/cardsfolder/j/jolrael_voice_of_zhalfir.txt
@@ -3,7 +3,7 @@ ManaCost:2 G U
 Types:Legendary Creature Human Druid
 PT:3/3
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigAnimate | TriggerDescription$ At the beginning of combat on your turn, up to one target land you control becomes an X/X green and blue Bird creature with flying and haste until end of turn, where X is the number of cards in your hand. It's still a land.
-SVar:TrigAnimate:DB$ Animate | ValidTgts$ Land.YouCtrl | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target land you control | Power$ X | Toughness$ X | Types$ Bird,Creature | Keywords$ Flying & Haste | Colors$ Green,Blue
+SVar:TrigAnimate:DB$ Animate | ValidTgts$ Land.YouCtrl | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target land you control | Power$ X | Toughness$ X | Types$ Bird,Creature | Keywords$ Flying & Haste | Colors$ Green,Blue | OverwriteColors$ True
 T:Mode$ DamageDone | ValidSource$ Creature.YouCtrl+Land | ValidTarget$ Player | CombatDamage$ True | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ Whenever a land creature you control deals combat damage to a player, draw a card.
 SVar:TrigDraw:DB$ Draw | NumCards$ 1
 SVar:X:Count$InYourHand

--- a/forge-gui/res/cardsfolder/k/koth_of_the_hammer.txt
+++ b/forge-gui/res/cardsfolder/k/koth_of_the_hammer.txt
@@ -3,7 +3,7 @@ ManaCost:2 R R
 Types:Legendary Planeswalker Koth
 Loyalty:3
 A:AB$ Untap | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | ValidTgts$ Mountain | TgtPrompt$ Select target Mountain | SubAbility$ DBAnimate | SpellDescription$ Untap target Mountain. It becomes a 4/4 red Elemental creature until end of turn. It's still a land.
-SVar:DBAnimate:DB$ Animate | Defined$ Targeted | Power$ 4 | Toughness$ 4 | Types$ Creature,Elemental | Colors$ Red
+SVar:DBAnimate:DB$ Animate | Defined$ Targeted | Power$ 4 | Toughness$ 4 | Types$ Creature,Elemental | Colors$ Red | OverwriteColors$ True
 A:AB$ Mana | Cost$ SubCounter<2/LOYALTY> | Planeswalker$ True | Produced$ R | Amount$ X | SpellDescription$ Add {R} for each Mountain you control.
 A:AB$ Effect | Cost$ SubCounter<5/LOYALTY> | Planeswalker$ True | Ultimate$ True | Name$ Emblem - Koth of the Hammer | Image$ emblem_koth_of_the_hammer | StaticAbilities$ STDamage | Stackable$ False | Duration$ Permanent | SpellDescription$ You get an emblem with "Mountains you control have '{T}: This land deals 1 damage to any target."
 SVar:STDamage:Mode$ Continuous | EffectZone$ Command | Affected$ Mountain.YouCtrl | AddAbility$ ABDealDamage | AffectedZone$ Battlefield | Description$ Mountains you control have "{T}: This land deals 1 damage to any target."

--- a/forge-gui/res/cardsfolder/r/roaring_earth.txt
+++ b/forge-gui/res/cardsfolder/r/roaring_earth.txt
@@ -4,7 +4,7 @@ Types:Enchantment
 T:Mode$ ChangesZone | Destination$ Battlefield | ValidCard$ Land.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Landfall - Whenever a land enters the battlefield under your control, put a +1/+1 counter on target creature or Vehicle you control.
 SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Creature.YouCtrl,Vehicle.YouCtrl | TgtPrompt$ Select target creature or Vehicle you control | CounterType$ P1P1 | CounterNum$ 1
 A:AB$ PutCounter | PrecostDesc$ Channel — | Cost$ X G G Discard<1/CARDNAME> | ActivationZone$ Hand | ValidTgts$ Land.YouCtrl | TgtPrompt$ Select target land you control | CounterType$ P1P1 | CounterNum$ X | SubAbility$ DBAnimate | SpellDescription$ Put X +1/+1 counters on target land you control. It becomes a 0/0 green Spirit creature with haste. It's still a land. | StackDescription$ {p:You} puts X +1/+1 counters on {c:Targeted}. It becomes a 0/0 green Spirit creature with haste. It's still a land.
-SVar:DBAnimate:DB$ Animate | Defined$ ParentTarget | Power$ 0 | Toughness$ 0 | Types$ Creature,Spirit | Colors$ Green | Keywords$ Haste | Duration$ Permanent | StackDescription$ None
+SVar:DBAnimate:DB$ Animate | Defined$ ParentTarget | Power$ 0 | Toughness$ 0 | Types$ Creature,Spirit | Colors$ Green | OverwriteColors$ True | Keywords$ Haste | Duration$ Permanent | StackDescription$ None
 SVar:X:Count$xPaid
 SVar:BuffedBy:Land
 DeckHas:Ability$Counters|Discard & Type$Spirit

--- a/forge-gui/res/cardsfolder/s/synth_infiltrator.txt
+++ b/forge-gui/res/cardsfolder/s/synth_infiltrator.txt
@@ -1,9 +1,9 @@
 Name:Synth Infiltrator
-ManaCost:3 U U 
+ManaCost:3 U U
 Types:Artifact Creature Synth
 PT:0/0
 K:Improvise
 K:ETBReplacement:Copy:DBCopy:Optional
-SVar:DBCopy:DB$ Clone | Choices$ Creature | AddTypes$ Artifact & Synth | SpellDescription$ You may have CARDNAME enter the battlefield as a copy of any creature on the battlefield, except it's a Synth artifact creature in addition to its other types.
+SVar:DBCopy:DB$ Clone | Choices$ Creature | AddTypes$ Artifact & Creature & Synth | SpellDescription$ You may have CARDNAME enter the battlefield as a copy of any creature on the battlefield, except it's a Synth artifact creature in addition to its other types.
 DeckHas:Ability$Counters
 Oracle:Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nYou may have Synth Infiltrator enter the battlefield as a copy of any creature on the battlefield, except it's a Synth artifact creature in addition to its other types.

--- a/forge-gui/res/cardsfolder/upcoming/thieving_varmint.txt
+++ b/forge-gui/res/cardsfolder/upcoming/thieving_varmint.txt
@@ -1,0 +1,8 @@
+Name:Thieving Varmint
+ManaCost:1 B
+Types:Creature Varmint
+PT:2/1
+K:Deathtouch
+K:Lifelink
+A:AB$ Mana | Cost$ T PayLife<1> | Produced$ Any | Amount$ 2 | RestrictValid$ Spell.YouDontOwn | SpellDescription$ Add two mana of any one color. Spend this mana only to cast spells you don't own.
+Oracle:Deathtouch, lifelink\n{T}, Pay 1 life: Add two mana of any one color. Spend this mana only to cast spells you don't own.

--- a/forge-gui/res/cardsfolder/upcoming/thunderclap_drake.txt
+++ b/forge-gui/res/cardsfolder/upcoming/thunderclap_drake.txt
@@ -1,0 +1,12 @@
+Name:Thunderclap Drake
+ManaCost:1 U
+Types:Creature Drake
+PT:2/1
+K:Flying
+S:Mode$ ReduceCost | ValidCard$ Instant,Sorcery | Type$ Spell | Activator$ You | Amount$ 1 | Description$ Instant and sorcery spells you cast cost {1} less to cast.
+A:AB$ DelayedTrigger | Cost$ 2 U Sac<1/CARDNAME> | AILogic$ SpellCopy | Execute$ EffTrigCopy | ThisTurn$ True | Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | SpellDescription$ When you cast your next instant or sorcery spell this turn, copy it for each time you’ve cast your commander from the command zone this game.
+SVar:EffTrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | Amount$ X
+SVar:X:Count$TotalCommanderCastFromCommandZone
+DeckHas:Ability$Sacrifice
+DeckHints:Type$Instant|Sorcery
+Oracle:Flying\nInstant and sorcery spells you cast cost {1} less to cast.\n{2}{U}, Sacrifice Thunderclap Drake: When you cast your next instant or sorcery spell this turn, copy it for each time you’ve cast your commander from the command zone this game.

--- a/forge-gui/res/cardsfolder/upcoming/thunderclap_drake.txt
+++ b/forge-gui/res/cardsfolder/upcoming/thunderclap_drake.txt
@@ -4,9 +4,9 @@ Types:Creature Drake
 PT:2/1
 K:Flying
 S:Mode$ ReduceCost | ValidCard$ Instant,Sorcery | Type$ Spell | Activator$ You | Amount$ 1 | Description$ Instant and sorcery spells you cast cost {1} less to cast.
-A:AB$ DelayedTrigger | Cost$ 2 U Sac<1/CARDNAME> | AILogic$ SpellCopy | Execute$ EffTrigCopy | ThisTurn$ True | Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | SpellDescription$ When you cast your next instant or sorcery spell this turn, copy it for each time you’ve cast your commander from the command zone this game.
-SVar:EffTrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | Amount$ X
+A:AB$ DelayedTrigger | Cost$ 2 U Sac<1/CARDNAME> | AILogic$ SpellCopy | Execute$ EffTrigCopy | ThisTurn$ True | Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | SpellDescription$ When you cast your next instant or sorcery spell this turn, copy it for each time you’ve cast your commander from the command zone this game. You may choose new targets for the copies.
+SVar:EffTrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | Amount$ X | MayChooseTarget$ True
 SVar:X:Count$TotalCommanderCastFromCommandZone
 DeckHas:Ability$Sacrifice
 DeckHints:Type$Instant|Sorcery
-Oracle:Flying\nInstant and sorcery spells you cast cost {1} less to cast.\n{2}{U}, Sacrifice Thunderclap Drake: When you cast your next instant or sorcery spell this turn, copy it for each time you’ve cast your commander from the command zone this game.
+Oracle:Flying\nInstant and sorcery spells you cast cost {1} less to cast.\n{2}{U}, Sacrifice Thunderclap Drake: When you cast your next instant or sorcery spell this turn, copy it for each time you’ve cast your commander from the command zone this game. You may choose new targets for the copies.

--- a/forge-gui/res/cardsfolder/upcoming/tower_winder.txt
+++ b/forge-gui/res/cardsfolder/upcoming/tower_winder.txt
@@ -1,0 +1,10 @@
+Name:Tower Winder
+ManaCost:1 G
+Types:Creature Snake
+PT:1/1
+K:Reach
+K:Deathtouch
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSearch | TriggerDescription$ When CARDNAME enters the battlefield, search your library and/or graveyard for a card named Command Tower, reveal it, and put it into your hand. If you search your library this way, shuffle.
+SVar:TrigSearch:DB$ ChangeZone | Hidden$ True | Origin$ Library | OriginAlternative$ Graveyard | Destination$ Hand | ChangeType$ Card.YouOwn+namedCommand Tower
+DeckHints:Name$Command Tower
+Oracle:Reach, deathtouch\nWhen Tower Winder enters the battlefield, search your library and/or graveyard for a card named Command Tower, reveal it, and put it into your hand. If you search your library this way, shuffle.

--- a/forge-gui/res/cardsfolder/w/woodwraith_corrupter.txt
+++ b/forge-gui/res/cardsfolder/w/woodwraith_corrupter.txt
@@ -2,5 +2,5 @@ Name:Woodwraith Corrupter
 ManaCost:3 B B G
 Types:Creature Elemental Horror
 PT:3/6
-A:AB$ Animate | Cost$ 1 B G T | ValidTgts$ Forest | TgtPrompt$ Select target Forest | Power$ 4 | Toughness$ 4 | Types$ Creature,Elemental,Horror | Colors$ Black,Green | Duration$ Permanent | AILogic$ EOT | SpellDescription$ Target Forest becomes a 4/4 black and green Elemental Horror creature. It's still a land.
+A:AB$ Animate | Cost$ 1 B G T | ValidTgts$ Forest | TgtPrompt$ Select target Forest | Power$ 4 | Toughness$ 4 | Types$ Creature,Elemental,Horror | Colors$ Black,Green | OverwriteColors$ True | Duration$ Permanent | AILogic$ EOT | SpellDescription$ Target Forest becomes a 4/4 black and green Elemental Horror creature. It's still a land.
 Oracle:{1}{B}{G}, {T}: Target Forest becomes a 4/4 black and green Elemental Horror creature. It's still a land.


### PR DESCRIPTION
Tested scripts for:
- [Thieving Varmint](https://scryfall.com/card/otc/59/thieving-varmint)
- [Thunderclap Drake](https://scryfall.com/card/otc/53/thunderclap-drake)
- [Tower Winder](https://scryfall.com/card/otc/70/tower-winder)

Minor fixes
- Per discussion on Discord, added `Creature` to the `AddTypes$` parameter of the `CopyPermanent` effect of [Brenard, Ginger Sculptor](https://scryfall.com/card/woc/27/brenard-ginger-sculptor) and [Synth Infiltrator](https://scryfall.com/card/pip/40/synth-infiltrator) to follow the relevant rulings. (Moved from https://github.com/Card-Forge/forge/pull/4776 )
- Similar effect review: 
• Halsin, Emerald Archdruid was missing the color-setting part of its ability
• Hedge Whisperer had the wrong creature type and since the ability, unlike Halsin's, doesn't mention in "addition to its other colors", the color part should overwrite any existing colors.
• Woodwraith Corrupter, Roaring Earth, Koth of the Hammer, Jolrael, Voice of Zhalfir, Ignition Team, Balduvian Frostwaker and Awakener Druid were also missing color overwriting.
• ~**TO DO** (if reasonable in scope): manlands and Genju cycle.~ Likely extensive enough a cleanup to merit its own dedicated pull request to set up at a later date (in the nearest future).