### PR TITLE
fix crashes issue4472

### DIFF
--- a/forge-core/src/main/java/forge/card/CardDb.java
+++ b/forge-core/src/main/java/forge/card/CardDb.java
@@ -432,6 +432,9 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
         if (paperCard.getRules().getSplitType() == CardSplitType.Split) {
             //also include main part for split cards
             allCardsByName.put(paperCard.getRules().getMainPart().getName(), paperCard);
+        } else if (paperCard.getRules().getSplitType() == CardSplitType.Specialize) {
+            //also include specialize faces
+            for (ICardFace face : paperCard.getRules().getSpecializeParts().values()) allCardsByName.put(face.getName(), paperCard);
         }
     }
 

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -47,6 +47,7 @@ import forge.StaticData;
 import forge.ai.GameState;
 import forge.ai.PlayerControllerAi;
 import forge.card.CardDb;
+import forge.card.CardSplitType;
 import forge.card.CardStateName;
 import forge.card.ColorSet;
 import forge.card.ICardFace;
@@ -2849,10 +2850,19 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
             getGame().getAction().invoke(() -> {
                 if (targetZone == ZoneType.Battlefield) {
                     if (!forgeCard.getName().equals(f.getName())) {
-                        forgeCard.changeToState(forgeCard.getRules().getSplitType().getChangedStateName());
-                        if (forgeCard.getCurrentStateName().equals(CardStateName.Transformed) ||
-                                forgeCard.getCurrentStateName().equals(CardStateName.Modal)) {
-                            forgeCard.setBackSide(true);
+                        if (forgeCard.getRules().getSplitType().equals(CardSplitType.Specialize)) {
+                            for (Map.Entry<CardStateName, ICardFace> e : forgeCard.getRules().getSpecializeParts().entrySet()) {
+                                if (f.getName().equals(e.getValue().getName())) {
+                                    forgeCard.changeToState(e.getKey());
+                                    break;
+                                }
+                            }
+                        } else {
+                            forgeCard.changeToState(forgeCard.getRules().getSplitType().getChangedStateName());
+                            if (forgeCard.getCurrentStateName().equals(CardStateName.Transformed) ||
+                                    forgeCard.getCurrentStateName().equals(CardStateName.Modal)) {
+                                forgeCard.setBackSide(true);
+                            }
                         }
                     }
 


### PR DESCRIPTION
I think this should close #4472 

 - now you can add specialize faces to battlefield through Dev cheats
 -  In the issue's corner case with that Maelstrom Archangel Avatar Vanguard + the specialize face now Forge will spit out a non-specialized version of the card. Is that legal/correct? I'm sure we'll never know since this combines Alchemy and Vanguard. I'm not convinced that the Maelstrom Archangel Avatar should find a mana cost match at all.
 - seems like the CardDb code also makes loading the proper art for each specialize face work now