### PR TITLE
OTC: Forger's Foundry, Savvy Trader, Smirking Spelljacker, Smoldering Stagecoach

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
@@ -471,8 +471,8 @@ public abstract class SpellAbilityEffect {
         card.addTrigger(parsedTrigger2);
     }
 
-    protected static void addForgetOnCastTrigger(final Card card) {
-        String trig = "Mode$ SpellCast | ValidCard$ Card.IsRemembered | TriggerZones$ Command | Static$ True";
+    protected static void addForgetOnCastTrigger(final Card card, String valid) {
+        String trig = "Mode$ SpellCast | TriggerZones$ Command | Static$ True | ValidCard$ " + valid;
 
         final Trigger parsedTrigger = TriggerHandler.parseTrigger(trig, card, true);
         parsedTrigger.setOverridingAbility(getForgetSpellAbility(card));

--- a/forge-game/src/main/java/forge/game/ability/effects/EffectEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/EffectEffect.java
@@ -232,10 +232,8 @@ public class EffectEffect extends SpellAbilityEffect {
                 if (sa.hasParam("ForgetOnMoved")) {
                     addForgetOnMovedTrigger(eff, sa.getParam("ForgetOnMoved"));
                     if (!"Stack".equals(sa.getParam("ForgetOnMoved")) && !"False".equalsIgnoreCase(sa.getParam("ForgetOnCast"))) {
-                        addForgetOnCastTrigger(eff);
+                        addForgetOnCastTrigger(eff, "Card.IsRemembered");
                     }
-                } else if (sa.hasParam("ForgetOnCast")) {
-                    addForgetOnCastTrigger(eff);
                 } else if (sa.hasParam("ExileOnMoved")) {
                     addExileOnMovedTrigger(eff, sa.getParam("ExileOnMoved"));
                 }
@@ -245,6 +243,9 @@ public class EffectEffect extends SpellAbilityEffect {
                 if (sa.hasParam("ForgetCounter")) {
                     addForgetCounterTrigger(eff, sa.getParam("ForgetCounter"));
                 }
+            }
+            if (sa.hasParam("ForgetOnCast")) {
+                addForgetOnCastTrigger(eff, sa.getParam("ForgetOnCast"));
             }
 
             // Set Imprinted

--- a/forge-gui/res/cardsfolder/upcoming/forgers_foundry.txt
+++ b/forge-gui/res/cardsfolder/upcoming/forgers_foundry.txt
@@ -1,0 +1,10 @@
+Name:Forger's Foundry
+ManaCost:2 U
+Types:Artifact
+A:AB$ Mana | Cost$ T | Produced$ U | TriggersWhenSpent$ TrigSpent | SpellDescription$ Add {U}. When you spend this mana to cast an instant or sorcery spell with mana value 3 or less, you may exile that spell instead of putting it into its owner's graveyard as it resolves.
+SVar:TrigSpent:Mode$ SpellCast | ValidCard$ Instant.cmcLE3+YouCtrl,Sorcery.cmcLE3+YouCtrl | ValidActivatingPlayer$ You | Execute$ TrigEffect | TriggerDescription$ When you spend this mana to cast an instant or sorcery spell with mana value 3 or less, you may exile that spell instead of putting it into its owner's graveyard as it resolves.
+SVar:TrigEffect:DB$ Effect | ReplacementEffects$ MoveToExileReplace | RememberObjects$ TriggeredCard | ExileOnMoved$ Stack | SpellDescription$ You may exile that spell instead of putting it into its owner's graveyard as it resolves.
+SVar:MoveToExileReplace:Event$ Moved | ValidCard$ Card.IsRemembered | Origin$ Stack | Destination$ Graveyard | Fizzle$ False | ReplaceWith$ ReplaceExile | Optional$ True | Description$ You may exile that spell instead of putting it into its owner's graveyard as it resolves.
+SVar:ReplaceExile:DB$ ChangeZone | Defined$ ReplacedCard | Origin$ Stack | Destination$ Exile | ExiledWithEffectSource$ True
+A:AB$ Play | Cost$ 3 U U T | Defined$ ExiledWith | ValidSA$ Spell | Amount$ All | WithoutManaCost$ True | Optional$ True | SorcerySpeed$ True | SpellDescription$ You may cast any number of spells from among cards exiled with CARDNAME without paying their mana costs. Activate only as a sorcery.
+Oracle:{T}: Add {U}. When you spend this mana to cast an instant or sorcery spell with mana value 3 or less, you may exile that spell instead of putting it into its owner's graveyard as it resolves.\n{3}{U}{U}, {T}: You may cast any number of spells from among cards exiled with Forger's Foundry without paying their mana costs. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/upcoming/savvy_trader.txt
+++ b/forge-gui/res/cardsfolder/upcoming/savvy_trader.txt
@@ -2,7 +2,7 @@ Name:Savvy Trader
 ManaCost:3 G
 Types:Creature Human Citizen
 PT:3/3
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ When Savvy Trader enters the battlefield, exile target permanent card from your graveyard. You may play that card for as long as it remains exiled.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ When CARDNAME enters the battlefield, exile target permanent card from your graveyard. You may play that card for as long as it remains exiled.
 SVar:TrigExile:DB$ ChangeZone | ValidTgts$ Permanent.YouOwn | TgtPrompt$ Select target permanent card from your graveyard | Origin$ Graveyard | Destination$ Exile | Imprint$ True | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | StaticAbilities$ STPlay | ForgetOnMoved$ Exile | RememberObjects$ Imprinted | Duration$ Permanent | SubAbility$ DBCleanup
 SVar:STPlay:Mode$ Continuous | EffectZone$ Command | Affected$ Card.IsRemembered | MayPlay$ True | AffectedZone$ Exile | Description$ You may play that card for as long as it remains exiled.

--- a/forge-gui/res/cardsfolder/upcoming/savvy_trader.txt
+++ b/forge-gui/res/cardsfolder/upcoming/savvy_trader.txt
@@ -1,0 +1,12 @@
+Name:Savvy Trader
+ManaCost:3 G
+Types:Creature Human Citizen
+PT:3/3
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ When Savvy Trader enters the battlefield, exile target permanent card from your graveyard. You may play that card for as long as it remains exiled.
+SVar:TrigExile:DB$ ChangeZone | ValidTgts$ Permanent.YouOwn | TgtPrompt$ Select target permanent card from your graveyard | Origin$ Graveyard | Destination$ Exile | Imprint$ True | SubAbility$ DBEffect
+SVar:DBEffect:DB$ Effect | StaticAbilities$ STPlay | ForgetOnMoved$ Exile | RememberObjects$ Imprinted | Duration$ Permanent | SubAbility$ DBCleanup
+SVar:STPlay:Mode$ Continuous | EffectZone$ Command | Affected$ Card.IsRemembered | MayPlay$ True | AffectedZone$ Exile | Description$ You may play that card for as long as it remains exiled.
+SVar:DBCleanup:DB$ Cleanup | ClearImprinted$ True
+S:Mode$ ReduceCost | ValidCard$ Card.wasNotCastFromYourHand | Activator$ You | Type$ Spell | Amount$ 1 | Description$ Spells you cast from anywhere other than your hand cost {1} less to cast.
+DeckHas:Ability$Graveyard
+Oracle:When Savvy Trader enters the battlefield, exile target permanent card from your graveyard. You may play that card for as long as it remains exiled.\nSpells you cast from anywhere other than your hand cost {1} less to cast.

--- a/forge-gui/res/cardsfolder/upcoming/smirking_spelljacker.txt
+++ b/forge-gui/res/cardsfolder/upcoming/smirking_spelljacker.txt
@@ -5,11 +5,8 @@ PT:3/3
 K:Flash
 K:Flying
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ When CARDNAME enters the battlefield, exile target spell an opponent controls.
-SVar:TrigExile:DB$ ChangeZone | TargetType$ Spell.OppCtrl | ValidTgts$ Card | TgtZone$ Stack | Origin$ Stack | Fizzle$ True | Mandatory$ True | Destination$ Exile | IsCurse$ True | TgtPrompt$ Choose target spell an opponent controls | RememberChanged$ True
+SVar:TrigExile:DB$ ChangeZone | TargetType$ Spell.OppCtrl | ValidTgts$ Card | TgtZone$ Stack | Origin$ Stack | Fizzle$ True | Mandatory$ True | Destination$ Exile | IsCurse$ True | TgtPrompt$ Choose target spell an opponent controls
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPlay | IsPresent$ Card.ExiledWithSource | PresentZone$ Exile | TriggerDescription$ Whenever CARDNAME attacks, if a card is exiled with it, you may cast the exiled card without paying its mana cost.
-SVar:TrigPlay:DB$ Play | Defined$ Remembered | Amount$ All | Controller$ You | WithoutManaCost$ True | ValidSA$ Spell | Optional$ True | ForgetRemembered$ True
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | Static$ True | ValidCard$ Card.Self | Execute$ DBCleanup
-T:Mode$ ChangesZone | Origin$ Exile | Destination$ Any | Static$ True | ValidCard$ Card.IsRemembered | Execute$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:TrigPlay:DB$ Play | Defined$ ExiledWithSource | Amount$ All | Controller$ You | WithoutManaCost$ True | ValidSA$ Spell | Optional$ True
 SVar:HasAttackEffect:TRUE
 Oracle:Flash\nFlying\nWhen Smirking Spelljacker enters the battlefield, exile target spell an opponent controls.\nWhenever Smirking Spelljacker attacks, if a card is exiled with it, you may cast the exiled card without paying its mana cost.

--- a/forge-gui/res/cardsfolder/upcoming/smirking_spelljacker.txt
+++ b/forge-gui/res/cardsfolder/upcoming/smirking_spelljacker.txt
@@ -1,0 +1,15 @@
+Name:Smirking Spelljacker
+ManaCost:4 U
+Types:Creature Djinn Wizard Rogue
+PT:3/3
+K:Flash
+K:Flying
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ When CARDNAME enters the battlefield, exile target spell an opponent controls.
+SVar:TrigExile:DB$ ChangeZone | TargetType$ Spell.OppCtrl | ValidTgts$ Card | TgtZone$ Stack | Origin$ Stack | Fizzle$ True | Mandatory$ True | Destination$ Exile | IsCurse$ True | TgtPrompt$ Choose target spell an opponent controls | RememberChanged$ True
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPlay | IsPresent$ Card.ExiledWithSource | PresentZone$ Exile | TriggerDescription$ Whenever CARDNAME attacks, if a card is exiled with it, you may cast the exiled card without paying its mana cost.
+SVar:TrigPlay:DB$ Play | Defined$ Remembered | Amount$ All | Controller$ You | WithoutManaCost$ True | ValidSA$ Spell | Optional$ True | ForgetRemembered$ True
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | Static$ True | ValidCard$ Card.Self | Execute$ DBCleanup
+T:Mode$ ChangesZone | Origin$ Exile | Destination$ Any | Static$ True | ValidCard$ Card.IsRemembered | Execute$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:HasAttackEffect:TRUE
+Oracle:Flash\nFlying\nWhen Smirking Spelljacker enters the battlefield, exile target spell an opponent controls.\nWhenever Smirking Spelljacker attacks, if a card is exiled with it, you may cast the exiled card without paying its mana cost.

--- a/forge-gui/res/cardsfolder/upcoming/smoldering_stagecoach.txt
+++ b/forge-gui/res/cardsfolder/upcoming/smoldering_stagecoach.txt
@@ -9,10 +9,9 @@ SVar:TrigInstantEffect:DB$ Effect | StaticAbilities$ CascadeInstant | Triggers$ 
 SVar:DBSorceryEffect:DB$ Effect | StaticAbilities$ CascadeSorcery | Triggers$ ExileSorceryEff
 SVar:CascadeInstant:Mode$ Continuous | EffectZone$ Command | Affected$ Card.Instant+YouCtrl | AffectedZone$ Stack | AddKeyword$ Cascade | Description$ The next instant spell you cast this turn has cascade.
 SVar:CascadeSorcery:Mode$ Continuous | EffectZone$ Command | Affected$ Card.Sorcery+YouCtrl | AffectedZone$ Stack | AddKeyword$ Cascade | Description$ The next sorcery spell you cast this turn has cascade.
-SVar:ExileInstantEff:Mode$ SpellCast | EffectZone$ Command | ValidCard$ Card.Instant+YouCtrl | Execute$ RemoveInstantEff | Static$ True
-SVar:ExileSorceryEff:Mode$ SpellCast | EffectZone$ Command | ValidCard$ Card.Sorcery+YouCtrl | Execute$ RemoveSorceryEff | Static$ True
-SVar:RemoveInstantEff:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self
-SVar:RemoveSorceryEff:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self
+SVar:ExileInstantEff:Mode$ SpellCast | EffectZone$ Command | ValidCard$ Card.Instant+YouCtrl | Execute$ RemoveEff | Static$ True
+SVar:ExileSorceryEff:Mode$ SpellCast | EffectZone$ Command | ValidCard$ Card.Sorcery+YouCtrl | Execute$ RemoveEff | Static$ True
+SVar:RemoveEff:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self
 SVar:HasAttackEffect:TRUE
 K:Crew:2
 DeckHas:Keyword$Cascade

--- a/forge-gui/res/cardsfolder/upcoming/smoldering_stagecoach.txt
+++ b/forge-gui/res/cardsfolder/upcoming/smoldering_stagecoach.txt
@@ -1,0 +1,20 @@
+Name:Smoldering Stagecoach
+ManaCost:3 R
+Types:Artifact Vehicle
+PT:*/5
+S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of instant and sorcery cards in your graveyard.
+SVar:X:Count$ValidGraveyard Instant.YouOwn,Sorcery.YouOwn
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigInstantEffect | TriggerDescription$ Whenever CARDNAME attacks, the next instant spell and the next sorcery spell you cast this turn each have cascade.
+SVar:TrigInstantEffect:DB$ Effect | StaticAbilities$ CascadeInstant | Triggers$ ExileInstantEff | SubAbility$ DBSorceryEffect
+SVar:DBSorceryEffect:DB$ Effect | StaticAbilities$ CascadeSorcery | Triggers$ ExileSorceryEff
+SVar:CascadeInstant:Mode$ Continuous | EffectZone$ Command | Affected$ Card.Instant+YouCtrl | AffectedZone$ Stack | AddKeyword$ Cascade | Description$ The next instant spell you cast this turn has cascade.
+SVar:CascadeSorcery:Mode$ Continuous | EffectZone$ Command | Affected$ Card.Sorcery+YouCtrl | AffectedZone$ Stack | AddKeyword$ Cascade | Description$ The next sorcery spell you cast this turn has cascade.
+SVar:ExileInstantEff:Mode$ SpellCast | EffectZone$ Command | ValidCard$ Card.Instant+YouCtrl | Execute$ RemoveInstantEff | Static$ True
+SVar:ExileSorceryEff:Mode$ SpellCast | EffectZone$ Command | ValidCard$ Card.Sorcery+YouCtrl | Execute$ RemoveSorceryEff | Static$ True
+SVar:RemoveInstantEff:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self
+SVar:RemoveSorceryEff:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self
+SVar:HasAttackEffect:TRUE
+K:Crew:2
+DeckHas:Keyword$Cascade
+DeckHints:Type$Instant|Sorcery
+Oracle:Smoldering Stagecoach's power is equal to the number of instant and sorcery cards in your graveyard.\nWhenever Smoldering Stagecoach attacks, the next instant spell and the next sorcery spell you cast this turn each have cascade.\nCrew 2

--- a/forge-gui/res/cardsfolder/upcoming/smoldering_stagecoach.txt
+++ b/forge-gui/res/cardsfolder/upcoming/smoldering_stagecoach.txt
@@ -5,13 +5,10 @@ PT:*/5
 S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of instant and sorcery cards in your graveyard.
 SVar:X:Count$ValidGraveyard Instant.YouOwn,Sorcery.YouOwn
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigInstantEffect | TriggerDescription$ Whenever CARDNAME attacks, the next instant spell and the next sorcery spell you cast this turn each have cascade.
-SVar:TrigInstantEffect:DB$ Effect | StaticAbilities$ CascadeInstant | Triggers$ ExileInstantEff | SubAbility$ DBSorceryEffect
-SVar:DBSorceryEffect:DB$ Effect | StaticAbilities$ CascadeSorcery | Triggers$ ExileSorceryEff
+SVar:TrigInstantEffect:DB$ Effect | StaticAbilities$ CascadeInstant | ForgetOnCast$ Instant.YouCtrl | SubAbility$ DBSorceryEffect
+SVar:DBSorceryEffect:DB$ Effect | StaticAbilities$ CascadeSorcery | ForgetOnCast$ Sorcery.YouCtrl
 SVar:CascadeInstant:Mode$ Continuous | EffectZone$ Command | Affected$ Card.Instant+YouCtrl | AffectedZone$ Stack | AddKeyword$ Cascade | Description$ The next instant spell you cast this turn has cascade.
 SVar:CascadeSorcery:Mode$ Continuous | EffectZone$ Command | Affected$ Card.Sorcery+YouCtrl | AffectedZone$ Stack | AddKeyword$ Cascade | Description$ The next sorcery spell you cast this turn has cascade.
-SVar:ExileInstantEff:Mode$ SpellCast | EffectZone$ Command | ValidCard$ Card.Instant+YouCtrl | Execute$ RemoveEff | Static$ True
-SVar:ExileSorceryEff:Mode$ SpellCast | EffectZone$ Command | ValidCard$ Card.Sorcery+YouCtrl | Execute$ RemoveEff | Static$ True
-SVar:RemoveEff:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self
 SVar:HasAttackEffect:TRUE
 K:Crew:2
 DeckHas:Keyword$Cascade


### PR DESCRIPTION
Tested card scripts for:
- [Forger's Foundry](https://scryfall.com/card/otc/14/forgers-foundry)
- [Savvy Trader](https://scryfall.com/card/otc/33/savvy-trader)
- [Smirking Spelljacker](https://scryfall.com/card/otc/16/smirking-spelljacker)
- [Smoldering Stagecoach](https://scryfall.com/card/otc/30/smoldering-stagecoach)

On Smoldering Stagecoach, I wasn't entirely sure how to merge the common bits of the cascade-granting effects safely, if it is at all possible, so I opted for splitting them entirely. Yes, the structure there is interleaved so I could more easily compare each line to their counterpart. I can change that though.