### PR TITLE
Animate effect cleanup pass #2.5

### DIFF
--- a/forge-gui/res/cardsfolder/a/angels_tomb.txt
+++ b/forge-gui/res/cardsfolder/a/angels_tomb.txt
@@ -2,6 +2,6 @@ Name:Angel's Tomb
 ManaCost:3
 Types:Artifact
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigAnimateTomb | OptionalDecider$ You | TriggerDescription$ Whenever a creature enters the battlefield under your control, you may have CARDNAME become a 3/3 white Angel artifact creature with flying until end of turn.
-SVar:TrigAnimateTomb:DB$ Animate | Defined$ Self | Power$ 3 | Toughness$ 3 | Types$ Artifact,Creature,Angel | Colors$ White | OverwriteColors$ True | Keywords$ Flying
+SVar:TrigAnimateTomb:DB$ Animate | Defined$ Self | Power$ 3 | Toughness$ 3 | Types$ Artifact,Creature,Angel | RemoveCreatureTypes$ True | Colors$ White | OverwriteColors$ True | Keywords$ Flying
 SVar:BuffedBy:Creature
 Oracle:Whenever a creature enters the battlefield under your control, you may have Angel's Tomb become a 3/3 white Angel artifact creature with flying until end of turn.

--- a/forge-gui/res/cardsfolder/a/arlinn_the_packs_hope_arlinn_the_moons_fury.txt
+++ b/forge-gui/res/cardsfolder/a/arlinn_the_packs_hope_arlinn_the_moons_fury.txt
@@ -21,5 +21,5 @@ Types:Legendary Planeswalker Arlinn
 Loyalty:4
 K:Nightbound
 A:AB$ Mana | Cost$ AddCounter<2/LOYALTY> | Planeswalker$ True | Produced$ R G | SpellDescription$ Add {R}{G}.
-A:AB$ Animate | Cost$ AddCounter<0/LOYALTY> | Planeswalker$ True | Defined$ Self | Power$ 5 | Toughness$ 5 | Keywords$ Trample & Indestructible & Haste | Types$ Creature,Werewolf | RemoveCardTypes$ True | StackDescription$ SpellDescription | SpellDescription$ Until end of turn, CARDNAME becomes a 5/5 Werewolf creature with trample, indestructible, and haste.
+A:AB$ Animate | Cost$ AddCounter<0/LOYALTY> | Planeswalker$ True | Defined$ Self | Power$ 5 | Toughness$ 5 | Keywords$ Trample & Indestructible & Haste | Types$ Creature,Werewolf | RemoveCreatureTypes$ True | RemoveCardTypes$ True | StackDescription$ SpellDescription | SpellDescription$ Until end of turn, CARDNAME becomes a 5/5 Werewolf creature with trample, indestructible, and haste.
 Oracle:Nightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)\n[+2]: Add {R}{G}.\n[0]: Until end of turn, Arlinn, the Moon's Fury becomes a 5/5 Werewolf creature with trample, indestructible, and haste.

--- a/forge-gui/res/cardsfolder/c/cavernous_maw.txt
+++ b/forge-gui/res/cardsfolder/c/cavernous_maw.txt
@@ -2,7 +2,7 @@ Name:Cavernous Maw
 ManaCost:no cost
 Types:Land Cave
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
-A:AB$ Animate | Cost$ 2 | CheckSVar$ X | SVarCompare$ GE3 | Defined$ Self | Power$ 3 | Toughness$ 3 | Types$ Creature,Elemental | RemoveCreatureTypes$ True | SpellDescription$ CARDNAME becomes a 3/3 Elemental creature until end of turn. It's still a Cave land. Activate only if the number of other Caves you control plus the number of Cave cards in your graveyard is three or greater.
+A:AB$ Animate | Cost$ 2 | CheckSVar$ X | SVarCompare$ GE3 | Defined$ Self | Power$ 3 | Toughness$ 3 | Types$ Creature,Elemental | SpellDescription$ CARDNAME becomes a 3/3 Elemental creature until end of turn. It's still a Cave land. Activate only if the number of other Caves you control plus the number of Cave cards in your graveyard is three or greater.
 SVar:X:Count$ValidGraveyard,Battlefield Cave.YouOwn+Other
 DeckHas:Type$Elemental
 DeckHints:Type$Cave & Ability$Graveyard|Mill

--- a/forge-gui/res/cardsfolder/g/glint_hawk_idol.txt
+++ b/forge-gui/res/cardsfolder/g/glint_hawk_idol.txt
@@ -2,7 +2,7 @@ Name:Glint Hawk Idol
 ManaCost:2
 Types:Artifact
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Artifact.Other+YouCtrl | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigAnimate | TriggerDescription$ Whenever another artifact enters the battlefield under your control, you may have CARDNAME become a 2/2 Bird artifact creature with flying until end of turn.
-SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 2 | Toughness$ 2 | Types$ Artifact,Creature,Bird | Keywords$ Flying
+SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 2 | Toughness$ 2 | Types$ Artifact,Creature,Bird | RemoveCreatureTypes$ True | Keywords$ Flying
 A:AB$ Animate | Cost$ W | Defined$ Self | Power$ 2 | Toughness$ 2 | Types$ Artifact,Creature,Bird | RemoveCreatureTypes$ True | Keywords$ Flying | SpellDescription$ CARDNAME becomes a 2/2 Bird artifact creature with flying until end of turn.
 SVar:BuffedBy:Artifact
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/h/hidden_ancients.txt
+++ b/forge-gui/res/cardsfolder/h/hidden_ancients.txt
@@ -2,5 +2,5 @@ Name:Hidden Ancients
 ManaCost:1 G
 Types:Enchantment
 T:Mode$ SpellCast | ValidCard$ Enchantment | ValidActivatingPlayer$ Opponent | TriggerZones$ Battlefield | IsPresent$ Card.Self+Enchantment | Execute$ TrigAnimate | TriggerDescription$ When an opponent casts an enchantment spell, if CARDNAME is an enchantment, CARDNAME becomes a 5/5 Treefolk creature.
-SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 5 | Toughness$ 5 | Types$ Creature,Treefolk | RemoveCardTypes$ True | Duration$ Permanent
+SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 5 | Toughness$ 5 | Types$ Creature,Treefolk | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent
 Oracle:When an opponent casts an enchantment spell, if Hidden Ancients is an enchantment, Hidden Ancients becomes a 5/5 Treefolk creature.

--- a/forge-gui/res/cardsfolder/h/hidden_gibbons.txt
+++ b/forge-gui/res/cardsfolder/h/hidden_gibbons.txt
@@ -2,6 +2,6 @@ Name:Hidden Gibbons
 ManaCost:G
 Types:Enchantment
 T:Mode$ SpellCast | ValidCard$ Instant | ValidActivatingPlayer$ Opponent | TriggerZones$ Battlefield | IsPresent$ Card.Self+Enchantment | Execute$ TrigAnimate | TriggerDescription$ When an opponent casts an instant spell, if CARDNAME is an enchantment, CARDNAME becomes a 4/4 Ape creature.
-SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 4 | Toughness$ 4 | Types$ Creature,Ape | RemoveCardTypes$ True | Duration$ Permanent
+SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 4 | Toughness$ 4 | Types$ Creature,Ape | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent
 DeckHas:Type$Ape
 Oracle:When an opponent casts an instant spell, if Hidden Gibbons is an enchantment, Hidden Gibbons becomes a 4/4 Ape creature.

--- a/forge-gui/res/cardsfolder/h/hidden_guerrillas.txt
+++ b/forge-gui/res/cardsfolder/h/hidden_guerrillas.txt
@@ -2,5 +2,5 @@ Name:Hidden Guerrillas
 ManaCost:G
 Types:Enchantment
 T:Mode$ SpellCast | ValidCard$ Artifact | ValidActivatingPlayer$ Opponent | TriggerZones$ Battlefield | IsPresent$ Card.Self+Enchantment | Execute$ TrigAnimate | TriggerDescription$ When an opponent casts an artifact spell, if CARDNAME is an enchantment, CARDNAME becomes a 5/3 Soldier creature with trample.
-SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 5 | Toughness$ 3 | Keywords$ Trample | Types$ Creature,Soldier | RemoveCardTypes$ True | Duration$ Permanent
+SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 5 | Toughness$ 3 | Keywords$ Trample | Types$ Creature,Soldier | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent
 Oracle:When an opponent casts an artifact spell, if Hidden Guerrillas is an enchantment, Hidden Guerrillas becomes a 5/3 Soldier creature with trample.

--- a/forge-gui/res/cardsfolder/h/hidden_herd.txt
+++ b/forge-gui/res/cardsfolder/h/hidden_herd.txt
@@ -2,5 +2,5 @@ Name:Hidden Herd
 ManaCost:G
 Types:Enchantment
 T:Mode$ LandPlayed | ValidCard$ Land.nonBasic+OppCtrl | TriggerZones$ Battlefield | IsPresent$ Card.Self+Enchantment | Execute$ TrigAnimate | TriggerDescription$ When an opponent plays a nonbasic land, if CARDNAME is an enchantment, CARDNAME becomes a 3/3 Beast creature.
-SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 3 | Toughness$ 3 | Types$ Creature,Beast | RemoveCardTypes$ True | Duration$ Permanent
+SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 3 | Toughness$ 3 | Types$ Creature,Beast | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent
 Oracle:When an opponent plays a nonbasic land, if Hidden Herd is an enchantment, Hidden Herd becomes a 3/3 Beast creature.

--- a/forge-gui/res/cardsfolder/h/hidden_predators.txt
+++ b/forge-gui/res/cardsfolder/h/hidden_predators.txt
@@ -2,5 +2,5 @@ Name:Hidden Predators
 ManaCost:G
 Types:Enchantment
 T:Mode$ Always | IsPresent$ Creature.powerGE4+OppCtrl | TriggerZones$ Battlefield | Execute$ TrigLurkingJackalsAnimate | IsPresent2$ Card.Self+Enchantment | ResolvingCheck$ IsPresent2 | TriggerDescription$ When an opponent controls a creature with power 4 or greater, if CARDNAME is an enchantment, CARDNAME becomes a 4/4 Beast creature.
-SVar:TrigLurkingJackalsAnimate:DB$ Animate | Types$ Creature,Beast | Power$ 4 | Toughness$ 4 | RemoveCardTypes$ True | Duration$ Permanent
+SVar:TrigLurkingJackalsAnimate:DB$ Animate | Types$ Creature,Beast | Power$ 4 | Toughness$ 4 | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent
 Oracle:When an opponent controls a creature with power 4 or greater, if Hidden Predators is an enchantment, Hidden Predators becomes a 4/4 Beast creature.

--- a/forge-gui/res/cardsfolder/h/hidden_spider.txt
+++ b/forge-gui/res/cardsfolder/h/hidden_spider.txt
@@ -2,5 +2,5 @@ Name:Hidden Spider
 ManaCost:G
 Types:Enchantment
 T:Mode$ SpellCast | ValidCard$ Creature.withFlying | ValidActivatingPlayer$ Opponent | TriggerZones$ Battlefield | IsPresent$ Card.Self+Enchantment | Execute$ TrigAnimate | TriggerDescription$ When an opponent casts a creature spell with flying, if CARDNAME is an enchantment, CARDNAME becomes a 3/5 Spider creature with reach. (It can block creatures with flying.)
-SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 3 | Toughness$ 5 | Keywords$ Reach | Types$ Creature,Spider | RemoveCardTypes$ True | Duration$ Permanent
+SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 3 | Toughness$ 5 | Keywords$ Reach | Types$ Creature,Spider | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent
 Oracle:When an opponent casts a creature spell with flying, if Hidden Spider is an enchantment, Hidden Spider becomes a 3/5 Spider creature with reach. (It can block creatures with flying.)

--- a/forge-gui/res/cardsfolder/h/hidden_stag.txt
+++ b/forge-gui/res/cardsfolder/h/hidden_stag.txt
@@ -2,8 +2,8 @@ Name:Hidden Stag
 ManaCost:1 G
 Types:Enchantment
 T:Mode$ LandPlayed | ValidCard$ Land.OppCtrl | IsPresent$ Card.Self+Enchantment | Execute$ TrigHiddenStagAnimateOppLand | TriggerZones$ Battlefield | TriggerDescription$ Whenever an opponent plays a land, if CARDNAME is an enchantment, CARDNAME becomes a 3/2 Elk Beast creature.
-SVar:TrigHiddenStagAnimateOppLand:DB$ Animate | Defined$ Self | Types$ Creature,Elk,Beast | Power$ 3 | Toughness$ 2 | RemoveCardTypes$ True | Duration$ Permanent
+SVar:TrigHiddenStagAnimateOppLand:DB$ Animate | Defined$ Self | Types$ Creature,Elk,Beast | Power$ 3 | Toughness$ 2 | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent
 T:Mode$ LandPlayed | ValidCard$ Land.YouCtrl | IsPresent$ Card.Self+Creature | Execute$ TrigHiddenStagAnimateYourLand | TriggerZones$ Battlefield | TriggerDescription$ Whenever you play a land, if CARDNAME is a creature, CARDNAME becomes an enchantment.
-SVar:TrigHiddenStagAnimateYourLand:DB$ Animate | Defined$ Self | Types$ Enchantment | RemoveCardTypes$ True | Duration$ Permanent
+SVar:TrigHiddenStagAnimateYourLand:DB$ Animate | Defined$ Self | Types$ Enchantment | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent
 AI:RemoveDeck:All
 Oracle:Whenever an opponent plays a land, if Hidden Stag is an enchantment, Hidden Stag becomes a 3/2 Elk Beast creature.\nWhenever you play a land, if Hidden Stag is a creature, Hidden Stag becomes an enchantment.

--- a/forge-gui/res/cardsfolder/l/lurking_evil.txt
+++ b/forge-gui/res/cardsfolder/l/lurking_evil.txt
@@ -1,7 +1,7 @@
 Name:Lurking Evil
 ManaCost:B B B
 Types:Enchantment
-A:AB$ Animate | Cost$ PayLife<X> | Types$ Creature,Phyrexian,Horror | Power$ 4 | Toughness$ 4 | Keywords$ Flying | RemoveCardTypes$ True | Duration$ Permanent | CostDesc$ Pay half your life, rounded up: | SpellDescription$ CARDNAME becomes a 4/4 Phyrexian Horror creature with flying.
+A:AB$ Animate | Cost$ PayLife<X> | Types$ Creature,Phyrexian,Horror | Power$ 4 | Toughness$ 4 | Keywords$ Flying | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent | CostDesc$ Pay half your life, rounded up: | SpellDescription$ CARDNAME becomes a 4/4 Phyrexian Horror creature with flying.
 SVar:X:Count$YourLifeTotal/HalfUp
 AI:RemoveDeck:Random
 Oracle:Pay half your life, rounded up: Lurking Evil becomes a 4/4 Phyrexian Horror creature with flying.

--- a/forge-gui/res/cardsfolder/l/lurking_jackals.txt
+++ b/forge-gui/res/cardsfolder/l/lurking_jackals.txt
@@ -2,5 +2,5 @@ Name:Lurking Jackals
 ManaCost:B
 Types:Enchantment
 T:Mode$ Always | LifeTotal$ OpponentSmallest | LifeAmount$ LE10 | TriggerZones$ Battlefield | Execute$ TrigLurkingJackalsAnimate | IsPresent$ Card.Self+Enchantment | ResolvingCheck$ IsPresent | TriggerDescription$ When an opponent has 10 or less life, if CARDNAME is an enchantment, CARDNAME becomes a 3/2 Jackal creature.
-SVar:TrigLurkingJackalsAnimate:DB$ Animate | Types$ Creature,Jackal | Power$ 3 | Toughness$ 2 | RemoveCardTypes$ True | Duration$ Permanent
+SVar:TrigLurkingJackalsAnimate:DB$ Animate | Types$ Creature,Jackal | Power$ 3 | Toughness$ 2 | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent
 Oracle:When an opponent has 10 or less life, if Lurking Jackals is an enchantment, it becomes a 3/2 Jackal creature.

--- a/forge-gui/res/cardsfolder/l/lurking_skirge.txt
+++ b/forge-gui/res/cardsfolder/l/lurking_skirge.txt
@@ -2,5 +2,5 @@ Name:Lurking Skirge
 ManaCost:1 B
 Types:Enchantment
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | TriggerZones$ Battlefield | ValidCard$ Creature.OppOwn | IsPresent$ Card.Self+Enchantment | Execute$ TrigAnimate | TriggerDescription$ When a creature is put into an opponent's graveyard from the battlefield, if CARDNAME is an enchantment, CARDNAME becomes a 3/2 Phyrexian Imp creature with flying.
-SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 3 | Toughness$ 2 | Types$ Creature,Phyrexian,Imp | Keywords$ Flying | RemoveCardTypes$ True | Duration$ Permanent
+SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 3 | Toughness$ 2 | Types$ Creature,Phyrexian,Imp | Keywords$ Flying | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent
 Oracle:When a creature is put into an opponent's graveyard from the battlefield, if Lurking Skirge is an enchantment, Lurking Skirge becomes a 3/2 Phyrexian Imp creature with flying.

--- a/forge-gui/res/cardsfolder/o/opal_acrolith.txt
+++ b/forge-gui/res/cardsfolder/o/opal_acrolith.txt
@@ -2,7 +2,7 @@ Name:Opal Acrolith
 ManaCost:2 W
 Types:Enchantment
 T:Mode$ SpellCast | ValidCard$ Creature | ValidActivatingPlayer$ Opponent | TriggerZones$ Battlefield | IsPresent$ Card.Self+Enchantment | Execute$ TrigAnimate | TriggerDescription$ When an opponent casts a creature spell, if CARDNAME is an enchantment, CARDNAME becomes a 2/4 Soldier creature.
-A:AB$ Animate | Cost$ 0 | Defined$ Self | Types$ Enchantment | RemoveCardTypes$ True | Duration$ Permanent | SpellDescription$ CARDNAME becomes an enchantment.
-SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 2 | Toughness$ 4 | Types$ Creature,Soldier | RemoveCardTypes$ True | Duration$ Permanent
+A:AB$ Animate | Cost$ 0 | Defined$ Self | Types$ Enchantment | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent | SpellDescription$ CARDNAME becomes an enchantment.
+SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 2 | Toughness$ 4 | Types$ Creature,Soldier | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent
 AI:RemoveDeck:All
 Oracle:Whenever an opponent casts a creature spell, if Opal Acrolith is an enchantment, Opal Acrolith becomes a 2/4 Soldier creature.\n{0}: Opal Acrolith becomes an enchantment.

--- a/forge-gui/res/cardsfolder/o/opal_archangel.txt
+++ b/forge-gui/res/cardsfolder/o/opal_archangel.txt
@@ -2,5 +2,5 @@ Name:Opal Archangel
 ManaCost:4 W
 Types:Enchantment
 T:Mode$ SpellCast | ValidCard$ Creature | ValidActivatingPlayer$ Opponent | TriggerZones$ Battlefield | IsPresent$ Card.Self+Enchantment | Execute$ TrigAnimate | TriggerDescription$ When an opponent casts a creature spell, if CARDNAME is an enchantment, CARDNAME becomes a 5/5 Angel creature with flying and vigilance.
-SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 5 | Toughness$ 5 | Keywords$ Flying & Vigilance | Types$ Creature,Angel | RemoveCardTypes$ True | Duration$ Permanent
+SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 5 | Toughness$ 5 | Keywords$ Flying & Vigilance | Types$ Creature,Angel | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent
 Oracle:When an opponent casts a creature spell, if Opal Archangel is an enchantment, Opal Archangel becomes a 5/5 Angel creature with flying and vigilance.

--- a/forge-gui/res/cardsfolder/o/opal_avenger.txt
+++ b/forge-gui/res/cardsfolder/o/opal_avenger.txt
@@ -2,5 +2,5 @@ Name:Opal Avenger
 ManaCost:2 W
 Types:Enchantment
 T:Mode$ Always | LifeTotal$ You | LifeAmount$ LE10 | TriggerZones$ Battlefield | Execute$ TrigOpalAvengerAnimate | IsPresent$ Card.Self+Enchantment | ResolvingCheck$ IsPresent | TriggerDescription$ When you have 10 or less life, if CARDNAME is an enchantment, CARDNAME becomes a 3/5 Soldier creature.
-SVar:TrigOpalAvengerAnimate:DB$ Animate | Types$ Creature,Soldier | Power$ 3 | Toughness$ 5 | RemoveCardTypes$ True | Duration$ Permanent
+SVar:TrigOpalAvengerAnimate:DB$ Animate | Types$ Creature,Soldier | Power$ 3 | Toughness$ 5 | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent
 Oracle:When you have 10 or less life, if Opal Avenger is an enchantment, Opal Avenger becomes a 3/5 Soldier creature.

--- a/forge-gui/res/cardsfolder/o/opal_caryatid.txt
+++ b/forge-gui/res/cardsfolder/o/opal_caryatid.txt
@@ -2,5 +2,5 @@ Name:Opal Caryatid
 ManaCost:W
 Types:Enchantment
 T:Mode$ SpellCast | ValidCard$ Creature | ValidActivatingPlayer$ Opponent | TriggerZones$ Battlefield | IsPresent$ Card.Self+Enchantment | Execute$ TrigAnimate | TriggerDescription$ When an opponent casts a creature spell, if CARDNAME is an enchantment, CARDNAME becomes a 2/2 Soldier creature.
-SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 2 | Toughness$ 2 | Types$ Creature,Soldier | RemoveCardTypes$ True | Duration$ Permanent
+SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 2 | Toughness$ 2 | Types$ Creature,Soldier | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent
 Oracle:When an opponent casts a creature spell, if Opal Caryatid is an enchantment, Opal Caryatid becomes a 2/2 Soldier creature.

--- a/forge-gui/res/cardsfolder/o/opal_champion.txt
+++ b/forge-gui/res/cardsfolder/o/opal_champion.txt
@@ -2,5 +2,5 @@ Name:Opal Champion
 ManaCost:2 W
 Types:Enchantment
 T:Mode$ SpellCast | ValidCard$ Creature | ValidActivatingPlayer$ Opponent | TriggerZones$ Battlefield | IsPresent$ Card.Self+Enchantment | Execute$ TrigAnimate | TriggerDescription$ When an opponent casts a creature spell, if CARDNAME is an enchantment, CARDNAME becomes a 3/3 Knight creature with first strike.
-SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 3 | Toughness$ 3 | Keywords$ First Strike | Types$ Creature,Knight | RemoveCardTypes$ True | Duration$ Permanent
+SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 3 | Toughness$ 3 | Keywords$ First Strike | Types$ Creature,Knight | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent
 Oracle:When an opponent casts a creature spell, if Opal Champion is an enchantment, Opal Champion becomes a 3/3 Knight creature with first strike.

--- a/forge-gui/res/cardsfolder/o/opal_gargoyle.txt
+++ b/forge-gui/res/cardsfolder/o/opal_gargoyle.txt
@@ -2,5 +2,5 @@ Name:Opal Gargoyle
 ManaCost:1 W
 Types:Enchantment
 T:Mode$ SpellCast | ValidCard$ Creature | ValidActivatingPlayer$ Opponent | TriggerZones$ Battlefield | IsPresent$ Card.Self+Enchantment | Execute$ TrigAnimate | TriggerDescription$ When an opponent casts a creature spell, if CARDNAME is an enchantment, CARDNAME becomes a 2/2 Gargoyle creature with flying.
-SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 2 | Toughness$ 2 | Types$ Creature,Gargoyle | Keywords$ Flying | RemoveCardTypes$ True | Duration$ Permanent
+SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 2 | Toughness$ 2 | Types$ Creature,Gargoyle | Keywords$ Flying | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent
 Oracle:When an opponent casts a creature spell, if Opal Gargoyle is an enchantment, Opal Gargoyle becomes a 2/2 Gargoyle creature with flying.

--- a/forge-gui/res/cardsfolder/o/opal_guardian.txt
+++ b/forge-gui/res/cardsfolder/o/opal_guardian.txt
@@ -2,5 +2,5 @@ Name:Opal Guardian
 ManaCost:W W W
 Types:Enchantment
 T:Mode$ SpellCast | ValidCard$ Creature | ValidActivatingPlayer$ Opponent | TriggerZones$ Battlefield | IsPresent$ Card.Self+Enchantment | Execute$ TrigAnimate | TriggerDescription$ When an opponent casts a creature spell, if CARDNAME is an enchantment, CARDNAME becomes a 3/4 Gargoyle creature with flying and protection from red.
-SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 3 | Toughness$ 4 | Types$ Creature,Gargoyle | Keywords$ Flying & Protection from red | RemoveCardTypes$ True | Duration$ Permanent
+SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 3 | Toughness$ 4 | Types$ Creature,Gargoyle | Keywords$ Flying & Protection from red | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent
 Oracle:When an opponent casts a creature spell, if Opal Guardian is an enchantment, Opal Guardian becomes a 3/4 Gargoyle creature with flying and protection from red.

--- a/forge-gui/res/cardsfolder/o/opal_titan.txt
+++ b/forge-gui/res/cardsfolder/o/opal_titan.txt
@@ -2,6 +2,6 @@ Name:Opal Titan
 ManaCost:2 W W
 Types:Enchantment
 T:Mode$ SpellCast | ValidCard$ Creature | ValidActivatingPlayer$ Opponent | Execute$ TrigAnimate | IsPresent$ Card.Self+Enchantment | TriggerZones$ Battlefield | TriggerDescription$ When an opponent casts a creature spell, if CARDNAME is an enchantment, CARDNAME becomes a 4/4 Giant creature with protection from each of that spell's colors.
-SVar:TrigAnimate:DB$ Animate | Defined$ Self | Types$ Creature,Giant | Power$ 4 | Toughness$ 4 | RemoveCardTypes$ True | Duration$ Permanent | SubAbility$ DBProtection | Duration$ Permanent
+SVar:TrigAnimate:DB$ Animate | Defined$ Self | Types$ Creature,Giant | Power$ 4 | Toughness$ 4 | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent | SubAbility$ DBProtection | Duration$ Permanent
 SVar:DBProtection:DB$ Protection | Gains$ Defined TriggeredCard | Duration$ Permanent
 Oracle:When an opponent casts a creature spell, if Opal Titan is an enchantment, Opal Titan becomes a 4/4 Giant creature with protection from each of that spell's colors.

--- a/forge-gui/res/cardsfolder/s/sanguine_statuette.txt
+++ b/forge-gui/res/cardsfolder/s/sanguine_statuette.txt
@@ -4,6 +4,6 @@ Types:Artifact
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters the battlefield, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
 SVar:TrigToken:DB$ Token | TokenScript$ c_a_blood_draw
 T:Mode$ Sacrificed | ValidCard$ Blood.token+YouCtrl | Execute$ TrigAnimate | TriggerZones$ Battlefield | OptionalDecider$ You | TriggerDescription$ Whenever you sacrifice a Blood token, you may have CARDNAME become a 3/3 Vampire artifact creature with haste until end of turn.
-SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 3 | Toughness$ 3 | Types$ Vampire,Artifact,Creature | Keywords$ Haste
+SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 3 | Toughness$ 3 | Types$ Vampire,Artifact,Creature | RemoveCreatureTypes$ True | Keywords$ Haste
 DeckHas:Ability$Token|Sacrifice & Type$Blood|Vampire
 Oracle:When Sanguine Statuette enters the battlefield, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")\nWhenever you sacrifice a Blood token, you may have Sanguine Statuette become a 3/3 Vampire artifact creature with haste until end of turn.

--- a/forge-gui/res/cardsfolder/s/sarkhan_the_dragonspeaker.txt
+++ b/forge-gui/res/cardsfolder/s/sarkhan_the_dragonspeaker.txt
@@ -2,7 +2,7 @@ Name:Sarkhan, the Dragonspeaker
 ManaCost:3 R R
 Types:Legendary Planeswalker Sarkhan
 Loyalty:4
-A:AB$ Animate | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | Power$ 4 | Toughness$ 4 | Types$ Creature,Legendary,Dragon | Colors$ Red | OverwriteColors$ True | RemoveCardTypes$ True | Keywords$ Flying & Indestructible & Haste | SpellDescription$ Until end of turn, CARDNAME becomes a legendary 4/4 red Dragon creature with flying, indestructible, and haste. (He doesn't lose loyalty while he's not a planeswalker.)
+A:AB$ Animate | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | Power$ 4 | Toughness$ 4 | Types$ Creature,Legendary,Dragon | Colors$ Red | OverwriteColors$ True | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Keywords$ Flying & Indestructible & Haste | SpellDescription$ Until end of turn, CARDNAME becomes a legendary 4/4 red Dragon creature with flying, indestructible, and haste. (He doesn't lose loyalty while he's not a planeswalker.)
 A:AB$ DealDamage | Cost$ SubCounter<3/LOYALTY> | Planeswalker$ True | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 4 | SpellDescription$ CARDNAME deals 4 damage to target creature.
 A:AB$ Effect | Cost$ SubCounter<6/LOYALTY> | Planeswalker$ True | Ultimate$ True | Name$ Emblem - Sarkhan, the Dragonspeaker | Triggers$ BODTrig,EOTTrig | Duration$ Permanent | AILogic$ Always | SpellDescription$ You get an emblem with "At the beginning of your draw step, draw two additional cards" and "At the beginning of your end step, discard your hand."
 SVar:BODTrig:Mode$ Phase | Phase$ Draw | ValidPlayer$ You | TriggerZones$ Command | Execute$ SarkhanDraw | TriggerDescription$ At the beginning of your draw step, draw two additional cards.

--- a/forge-gui/res/cardsfolder/s/sarkhan_the_masterless.txt
+++ b/forge-gui/res/cardsfolder/s/sarkhan_the_masterless.txt
@@ -4,7 +4,7 @@ Types:Legendary Planeswalker Sarkhan
 Loyalty:5
 T:Mode$ Attacks | ValidCard$ Creature | Attacked$ You,Planeswalker.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigDamage | TriggerDescription$ Whenever a creature attacks you or a planeswalker you control, each Dragon you control deals 1 damage to that creature.
 SVar:TrigDamage:DB$ EachDamage | ValidCards$ Dragon.YouCtrl | NumDmg$ 1 | Defined$ TriggeredAttacker
-A:AB$ AnimateAll | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | Power$ 4 | Toughness$ 4 | Types$ Creature,Dragon | Colors$ Red | OverwriteColors$ True | RemoveCardTypes$ True | Keywords$ Flying | ValidCards$ Planeswalker.YouCtrl | AILogic$ Always | SpellDescription$ Until end of turn, each planeswalker you control becomes a 4/4 red Dragon creature and gains flying.
+A:AB$ AnimateAll | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | Power$ 4 | Toughness$ 4 | Types$ Creature,Dragon | RemoveCreatureTypes$ True | Colors$ Red | OverwriteColors$ True | RemoveCardTypes$ True | Keywords$ Flying | ValidCards$ Planeswalker.YouCtrl | AILogic$ Always | SpellDescription$ Until end of turn, each planeswalker you control becomes a 4/4 red Dragon creature and gains flying.
 A:AB$ Token | Cost$ SubCounter<3/LOYALTY> | TokenAmount$ 1 | TokenScript$ r_4_4_dragon_flying | TokenOwner$ You | Planeswalker$ True | SpellDescription$ Create a 4/4 red Dragon creature token with flying.
 DeckHas:Ability$Token
 Oracle:Whenever a creature attacks you or a planeswalker you control, each Dragon you control deals 1 damage to that creature.\n[+1]: Until end of turn, each planeswalker you control becomes a 4/4 red Dragon creature and gains flying.\n[-3]: Create a 4/4 red Dragon creature token with flying.

--- a/forge-gui/res/cardsfolder/v/veil_of_birds.txt
+++ b/forge-gui/res/cardsfolder/v/veil_of_birds.txt
@@ -2,5 +2,5 @@ Name:Veil of Birds
 ManaCost:U
 Types:Enchantment
 T:Mode$ SpellCast | ValidCard$ Card | ValidActivatingPlayer$ Opponent | TriggerZones$ Battlefield | IsPresent$ Card.Self+Enchantment | Execute$ TrigAnimate | TriggerDescription$ When an opponent casts a spell, if CARDNAME is an enchantment, CARDNAME becomes a 1/1 Bird creature with flying.
-SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 1 | Toughness$ 1 | Keywords$ Flying | Types$ Creature,Bird | RemoveCardTypes$ True | Duration$ Permanent
+SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 1 | Toughness$ 1 | Keywords$ Flying | Types$ Creature,Bird | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent
 Oracle:When an opponent casts a spell, if Veil of Birds is an enchantment, Veil of Birds becomes a 1/1 Bird creature with flying.

--- a/forge-gui/res/cardsfolder/v/veiled_apparition.txt
+++ b/forge-gui/res/cardsfolder/v/veiled_apparition.txt
@@ -2,5 +2,5 @@ Name:Veiled Apparition
 ManaCost:1 U
 Types:Enchantment
 T:Mode$ SpellCast | ValidCard$ Card | ValidActivatingPlayer$ Opponent | TriggerZones$ Battlefield | IsPresent$ Card.Self+Enchantment | Execute$ TrigAnimate | TriggerDescription$ When an opponent casts a spell, if CARDNAME is an enchantment, CARDNAME becomes a 3/3 Illusion creature with flying and "At the beginning of your upkeep, sacrifice CARDNAME unless you pay {1}{U}."
-SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 3 | Toughness$ 3 | Keywords$ Flying & UpkeepCost:1 U | Types$ Creature,Illusion | RemoveCardTypes$ True | Duration$ Permanent
+SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 3 | Toughness$ 3 | Keywords$ Flying & UpkeepCost:1 U | Types$ Creature,Illusion | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent
 Oracle:When an opponent casts a spell, if Veiled Apparition is an enchantment, Veiled Apparition becomes a 3/3 Illusion creature with flying and "At the beginning of your upkeep, sacrifice Veiled Apparition unless you pay {1}{U}."

--- a/forge-gui/res/cardsfolder/v/veiled_crocodile.txt
+++ b/forge-gui/res/cardsfolder/v/veiled_crocodile.txt
@@ -2,7 +2,7 @@ Name:Veiled Crocodile
 ManaCost:2 U
 Types:Enchantment
 T:Mode$ Always | CheckSVar$ X | SVarCompare$ EQ0 | TriggerZones$ Battlefield | Execute$ TrigVCAnimate | IsPresent$ Card.Self+Enchantment | ResolvingCheck$ IsPresent | TriggerDescription$ When a player has no cards in hand, if CARDNAME is an enchantment, CARDNAME becomes a 4/4 Crocodile creature.
-SVar:TrigVCAnimate:DB$ Animate | Types$ Creature,Crocodile | Power$ 4 | Toughness$ 4 | RemoveCardTypes$ True | Duration$ Permanent
+SVar:TrigVCAnimate:DB$ Animate | Types$ Creature,Crocodile | Power$ 4 | Toughness$ 4 | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent
 SVar:X:PlayerCountPlayers$LowestValidHand Card.YouOwn
 AI:RemoveDeck:Random
 Oracle:When a player has no cards in hand, if Veiled Crocodile is an enchantment, Veiled Crocodile becomes a 4/4 Crocodile creature.

--- a/forge-gui/res/cardsfolder/v/veiled_sentry.txt
+++ b/forge-gui/res/cardsfolder/v/veiled_sentry.txt
@@ -2,6 +2,6 @@ Name:Veiled Sentry
 ManaCost:U
 Types:Enchantment
 T:Mode$ SpellCast | ValidCard$ Card | ValidActivatingPlayer$ Opponent | Execute$ TrigAnimate | TriggerZones$ Battlefield | IsPresent$ Card.Self+Enchantment | TriggerDescription$ When an opponent casts a spell, if CARDNAME is an enchantment, CARDNAME becomes an Illusion creature with power and toughness each equal to that spell's mana value.
-SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ X | Toughness$ X | Types$ Creature,Illusion | RemoveCardTypes$ True | Duration$ Permanent
+SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ X | Toughness$ X | Types$ Creature,Illusion | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent
 SVar:X:TriggeredStackInstance$CardManaCostLKI
 Oracle:When an opponent casts a spell, if Veiled Sentry is an enchantment, Veiled Sentry becomes an Illusion creature with power and toughness each equal to that spell's mana value.

--- a/forge-gui/res/cardsfolder/v/veiled_serpent.txt
+++ b/forge-gui/res/cardsfolder/v/veiled_serpent.txt
@@ -2,7 +2,7 @@ Name:Veiled Serpent
 ManaCost:2 U
 Types:Enchantment
 T:Mode$ SpellCast | ValidCard$ Card | ValidActivatingPlayer$ Opponent | TriggerZones$ Battlefield | IsPresent$ Card.Self+Enchantment | Execute$ TrigAnimate | TriggerDescription$ When an opponent casts a spell, if CARDNAME is an enchantment, CARDNAME becomes a 4/4 Serpent creature with "This creature can't attack unless defending player controls an Island."
-SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 4 | Toughness$ 4 | staticAbilities$ VeiledSerpentST | Types$ Creature,Serpent | RemoveCardTypes$ True | Duration$ Permanent
+SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 4 | Toughness$ 4 | staticAbilities$ VeiledSerpentST | Types$ Creature,Serpent | RemoveCardTypes$ True | RemoveCreatureTypes$ True | Duration$ Permanent
 K:Cycling:2
 SVar:VeiledSerpentST:Mode$ CantAttack | ValidCard$ Card.Self | UnlessDefenderControls$ Island | Description$ CARDNAME can't attack unless defending player controls an Island.
 Oracle:When an opponent casts a spell, if Veiled Serpent is an enchantment, Veiled Serpent becomes a 4/4 Serpent creature with "This creature can't attack unless defending player controls an Island."\nCycling {2} ({2}, Discard this card: Draw a card.)


### PR DESCRIPTION
After further discussion here, https://github.com/Card-Forge/forge/pull/5016 , turns out I was a bit confused in my recollection of the rules around card type and subtype changes. This is a hopefully more correct attempt at what I was trying to do, which is to ensure that when the rules require it creature types are removed when cards self-animate.