### PR TITLE
BBD: Assist cards

### DIFF
--- a/forge-gui/res/cardsfolder/b/bloodborn_scoundrels.txt
+++ b/forge-gui/res/cardsfolder/b/bloodborn_scoundrels.txt
@@ -1,0 +1,10 @@
+Name:Bloodborn Scoundrels
+ManaCost:5 B
+Types:Creature Vampire Rogue
+PT:4/4
+K:Assist
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDrain | TriggerDescription$ When CARDNAME enters the battlefield, target opponent loses 2 life and you gain 2 life.
+SVar:TrigDrain:DB$ LoseLife | ValidTgts$ Opponent | LifeAmount$ 2 | SubAbility$ DBGainLife
+SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 2
+DeckHas:Ability$LifeGain
+Oracle:Assist (Another player can pay up to {5} of this spell's cost.)\nWhen Bloodborn Scoundrels enters the battlefield, target opponent loses 2 life and you gain 2 life.

--- a/forge-gui/res/cardsfolder/b/bring_down.txt
+++ b/forge-gui/res/cardsfolder/b/bring_down.txt
@@ -1,0 +1,6 @@
+Name:Bring Down
+ManaCost:3 W
+Types:Sorcery
+K:Assist
+A:SP$ Destroy | ValidTgts$ Creature.powerGE4 | TgtPrompt$ Select target creature with power 4 or greater | SpellDescription$ Destroy target creature with power 4 or greater.
+Oracle:Assist (Another player can pay up to {3} of this spell's cost.)\nDestroy target creature with power 4 or greater.

--- a/forge-gui/res/cardsfolder/d/dwarven_lightsmith.txt
+++ b/forge-gui/res/cardsfolder/d/dwarven_lightsmith.txt
@@ -1,0 +1,9 @@
+Name:Dwarven Lightsmith
+ManaCost:5 W
+Types:Creature Dwarf Cleric
+PT:3/4
+K:Assist
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPumpAll | TriggerDescription$ When CARDNAME enters the battlefield, creatures your team controls get +1/+1 until end of turn.
+SVar:TrigPumpAll:DB$ PumpAll | ValidCards$ Creature.YourTeamCtrl | NumAtt$ +1 | NumDef$ +1
+SVar:PlayMain1:ALWAYS
+Oracle:Assist (Another player can pay up to {5} of this spell's cost.)\nWhen Dwarven Lightsmith enters the battlefield, creatures your team controls get +1/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/f/fan_favorite.txt
+++ b/forge-gui/res/cardsfolder/f/fan_favorite.txt
@@ -1,0 +1,7 @@
+Name:Fan Favorite
+ManaCost:3 B
+Types:Creature Human Rogue
+PT:2/2
+K:Assist
+A:AB$ Pump | Cost$ 2 | Defined$ Self | NumAtt$ +1 | NumDef$ +1 | Activator$ Player | SpellDescription$ CARDNAME gets +1/+1 until end of turn. Any player may activate this ability.
+Oracle:Assist (Another player can pay up to {3} of this spell's cost.)\n{2}: Fan Favorite gets +1/+1 until end of turn. Any player may activate this ability.

--- a/forge-gui/res/cardsfolder/g/game_plan.txt
+++ b/forge-gui/res/cardsfolder/g/game_plan.txt
@@ -1,0 +1,8 @@
+Name:Game Plan
+ManaCost:5 U
+Types:Sorcery
+K:Assist
+A:SP$ ChangeZoneAll | ChangeType$ Card | Origin$ Hand,Graveyard | Destination$ Library | Shuffle$ True | UseAllOriginZones$ True | SubAbility$ DBDraw | AILogic$ Timetwister | SpellDescription$ Each player shuffles their hand and graveyard into their library, then draws seven cards. Exile CARDNAME.
+SVar:DBDraw:DB$ Draw | NumCards$ 7 | Defined$ Player | SubAbility$ DBChange
+SVar:DBChange:DB$ ChangeZone | Origin$ Stack | Destination$ Exile
+Oracle:Assist (Another player can pay up to {5} of this spell's cost.)\nEach player shuffles their hand and graveyard into their library, then draws seven cards. Exile Game Plan.

--- a/forge-gui/res/cardsfolder/g/gang_up.txt
+++ b/forge-gui/res/cardsfolder/g/gang_up.txt
@@ -1,0 +1,7 @@
+Name:Gang Up
+ManaCost:X B
+Types:Instant
+K:Assist
+A:SP$ Destroy | ValidTgts$ Creature.powerLEX | TgtPrompt$ Select target creature with power X or less | SpellDescription$ Destroy target creature with power X or less.
+SVar:X:Count$xPaid
+Oracle:Assist (Another player can pay up to {X} of this spell's cost. You choose the value of X.)\nDestroy target creature with power X or less.

--- a/forge-gui/res/cardsfolder/g/golden_argosy.txt
+++ b/forge-gui/res/cardsfolder/g/golden_argosy.txt
@@ -4,8 +4,9 @@ Types:Legendary Artifact Vehicle
 PT:3/6
 T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigFlicker | TriggerDescription$ Whenever CARDNAME attacks, exile each creature that crewed it this turn. Return them to the battlefield tapped under their owner's control at the beginning of the next end step.
 SVar:TrigFlicker:DB$ ChangeZoneAll | ChangeType$ Creature.CrewedThisTurn | Origin$ Battlefield | Destination$ Exile | RememberLKI$ True | SubAbility$ DelTrig
-SVar:DelTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ TrigReturn | RememberObjects$ RememberedLKI | TriggerDescription$ Return them to the battlefield tapped under their owner's control at the beginning of the next end step.
+SVar:DelTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ TrigReturn | RememberObjects$ RememberedLKI | SubAbility$ DBCleanup | TriggerDescription$ Return them to the battlefield tapped under their owner's control at the beginning of the next end step.
 SVar:TrigReturn:DB$ ChangeZone | Origin$ Exile | Destination$ Battlefield | Defined$ DelayTriggerRemembered | Tapped$ True
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 K:Crew:1
 SVar:HasAttackEffect:TRUE
 Oracle:Whenever Golden Argosy attacks, exile each creature that crewed it this turn. Return them to the battlefield tapped under their owner's control at the beginning of the next end step.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)

--- a/forge-gui/res/cardsfolder/g/golden_argosy.txt
+++ b/forge-gui/res/cardsfolder/g/golden_argosy.txt
@@ -4,7 +4,7 @@ Types:Legendary Artifact Vehicle
 PT:3/6
 T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigFlicker | TriggerDescription$ Whenever CARDNAME attacks, exile each creature that crewed it this turn. Return them to the battlefield tapped under their owner's control at the beginning of the next end step.
 SVar:TrigFlicker:DB$ ChangeZoneAll | ChangeType$ Creature.CrewedThisTurn | Origin$ Battlefield | Destination$ Exile | RememberLKI$ True | SubAbility$ DelTrig
-SVar:DelTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ TrigReturn | RememberObjects$ RememberedLKI | SubAbility$ DBCleanup | TriggerDescription$ Return them to the battlefield tapped under their owner's control at the beginning of the next end step.
+SVar:DelTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ TrigReturn | RememberObjects$ RememberedLKI | TriggerDescription$ Return them to the battlefield tapped under their owner's control at the beginning of the next end step.
 SVar:TrigReturn:DB$ ChangeZone | Origin$ Exile | Destination$ Battlefield | Defined$ DelayTriggerRemembered | Tapped$ True
 K:Crew:1
 SVar:HasAttackEffect:TRUE

--- a/forge-gui/res/cardsfolder/h/huddle_up.txt
+++ b/forge-gui/res/cardsfolder/h/huddle_up.txt
@@ -2,5 +2,5 @@ Name:Huddle Up
 ManaCost:2 U
 Types:Sorcery
 K:Assist
-A:SP$ Draw | Cost$ 2 U | NumCards$ 1 | ValidTgts$ Player | TargetMin$ 2 | TargetMax$ 2 | TgtPrompt$ Select target player | SpellDescription$ Two target players each draw a card.
+A:SP$ Draw | NumCards$ 1 | ValidTgts$ Player | TargetMin$ 2 | TargetMax$ 2 | TgtPrompt$ Select target player | SpellDescription$ Two target players each draw a card.
 Oracle:Assist (Another player can pay up to {2} of this spell's cost.)\nTwo target players each draw a card.

--- a/forge-gui/res/cardsfolder/h/huddle_up.txt
+++ b/forge-gui/res/cardsfolder/h/huddle_up.txt
@@ -1,0 +1,6 @@
+Name:Huddle Up
+ManaCost:2 U
+Types:Sorcery
+K:Assist
+A:SP$ Draw | Cost$ 2 U | NumCards$ 1 | ValidTgts$ Player | TargetMin$ 2 | TargetMax$ 2 | TgtPrompt$ Select target player | SpellDescription$ Two target players each draw a card.
+Oracle:Assist (Another player can pay up to {2} of this spell's cost.)\nTwo target players each draw a card.

--- a/forge-gui/res/cardsfolder/l/lava_field_overlord.txt
+++ b/forge-gui/res/cardsfolder/l/lava_field_overlord.txt
@@ -1,0 +1,9 @@
+Name:Lava-Field Overlord
+ManaCost:7 R R
+Types:Creature Dragon
+PT:5/4
+K:Assist
+K:Flying
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDamage | TriggerDescription$ When CARDNAME enters the battlefield, it deals 4 damage to target creature an opponent controls.
+SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | NumDmg$ 4
+Oracle:Assist (Another player can pay up to {7} of this spell's cost.)\nFlying\nWhen Lava-Field Overlord enters the battlefield, it deals 4 damage to target creature an opponent controls.

--- a/forge-gui/res/cardsfolder/m/magma_hellion.txt
+++ b/forge-gui/res/cardsfolder/m/magma_hellion.txt
@@ -1,0 +1,8 @@
+Name:Magma Hellion
+ManaCost:6 R
+Types:Creature Hellion
+PT:5/4
+K:Assist
+K:Trample
+K:Haste
+Oracle:Assist (Another player can pay up to {6} of this spell's cost.)\nTrample, haste

--- a/forge-gui/res/cardsfolder/o/out_of_bounds.txt
+++ b/forge-gui/res/cardsfolder/o/out_of_bounds.txt
@@ -2,5 +2,5 @@ Name:Out of Bounds
 ManaCost:3 U
 Types:Instant
 K:Assist
-A:SP$ Counter | Cost$ 3 U | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | SpellDescription$ Counter target spell.
+A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | SpellDescription$ Counter target spell.
 Oracle:Assist (Another player can pay up to {3} of this spell's cost.)\nCounter target spell.

--- a/forge-gui/res/cardsfolder/o/out_of_bounds.txt
+++ b/forge-gui/res/cardsfolder/o/out_of_bounds.txt
@@ -1,0 +1,6 @@
+Name:Out of Bounds
+ManaCost:3 U
+Types:Instant
+K:Assist
+A:SP$ Counter | Cost$ 3 U | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | SpellDescription$ Counter target spell.
+Oracle:Assist (Another player can pay up to {3} of this spell's cost.)\nCounter target spell.

--- a/forge-gui/res/cardsfolder/p/play_of_the_game.txt
+++ b/forge-gui/res/cardsfolder/p/play_of_the_game.txt
@@ -1,0 +1,6 @@
+Name:Play of the Game
+ManaCost:6 W W
+Types:Sorcery
+K:Assist
+A:SP$ ChangeZoneAll | Cost$ 6 W W | UseAllOriginZones$ True | Origin$ Battlefield | Destination$ Exile | ChangeType$ Permanent.nonLand | IsCurse$ True | SpellDescription$ Exile all nonland permanents.
+Oracle:Assist (Another player can pay up to {6} of this spell's cost.)\nExile all nonland permanents.

--- a/forge-gui/res/cardsfolder/p/play_of_the_game.txt
+++ b/forge-gui/res/cardsfolder/p/play_of_the_game.txt
@@ -2,5 +2,5 @@ Name:Play of the Game
 ManaCost:6 W W
 Types:Sorcery
 K:Assist
-A:SP$ ChangeZoneAll | Cost$ 6 W W | UseAllOriginZones$ True | Origin$ Battlefield | Destination$ Exile | ChangeType$ Permanent.nonLand | IsCurse$ True | SpellDescription$ Exile all nonland permanents.
+A:SP$ ChangeZoneAll | Origin$ Battlefield | Destination$ Exile | ChangeType$ Permanent.nonLand | IsCurse$ True | SpellDescription$ Exile all nonland permanents.
 Oracle:Assist (Another player can pay up to {6} of this spell's cost.)\nExile all nonland permanents.

--- a/forge-gui/res/cardsfolder/s/skystreamer.txt
+++ b/forge-gui/res/cardsfolder/s/skystreamer.txt
@@ -1,0 +1,10 @@
+Name:Skystreamer
+ManaCost:4 W
+Types:Creature Griffin
+PT:3/2
+K:Assist
+K:Flying
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ DBGainLife | TriggerDescription$ When CARDNAME enters the battlefield, target player gains 4 life.
+SVar:DBGainLife:DB$ GainLife | ValidTgts$ Player | TgtPrompt$ Select target player | LifeAmount$ 4 | SpellDescription$ Target player gains 4 life.
+DeckHas:Ability$LifeGain
+Oracle:Assist (Another player can pay up to {4} of this spell's cost.)\nFlying\nWhen Skystreamer enters the battlefield, target player gains 4 life.

--- a/forge-gui/res/cardsfolder/s/spellweaver_duo.txt
+++ b/forge-gui/res/cardsfolder/s/spellweaver_duo.txt
@@ -1,0 +1,8 @@
+Name:Spellweaver Duo
+ManaCost:6 U
+Types:Creature Human Wizard
+PT:4/4
+K:Assist
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChangeZone | OptionalDecider$ You | TriggerDescription$ When CARDNAME enters the battlefield, you may return target tapped creature to its owner's hand.
+SVar:TrigChangeZone:DB$ ChangeZone | ValidTgts$ Creature.tapped | TgtPrompt$ Select target tapped creature | Origin$ Battlefield | Destination$ Hand
+Oracle:Assist (Another player can pay up to {6} of this spell's cost.)\nWhen Spellweaver Duo enters the battlefield, you may return target tapped creature to its owner's hand.

--- a/forge-gui/res/cardsfolder/t/the_crowd_goes_wild.txt
+++ b/forge-gui/res/cardsfolder/t/the_crowd_goes_wild.txt
@@ -3,7 +3,7 @@ ManaCost:X G
 Types:Sorcery
 K:Assist
 A:SP$ PutCounter | CounterType$ P1P1 | TargetMin$ 0 | TargetMax$ X | ValidTgts$ Creature | TgtPrompt$ Select up to X target creatures | SubAbility$ DBTrample | SpellDescription$ Support X. (Put a +1/+1 counter on each of up to X target creatures.)
-SVar:DBTrample:DB$ PumpAll | Defined$ Creature.counters_GE1_P1P1 | KW$ Trample
+SVar:DBTrample:DB$ PumpAll | ValidCards$ Creature.counters_GE1_P1P1 | KW$ Trample | SpellDescription$ Each creature with a +1/+1 counter on it gains trample until end of turn.
 SVar:X:Count$xPaid
 DeckHas:Ability$Counters
 Oracle:Assist (Another player can pay up to {X} of this spell's cost. You choose the value of X.)\nSupport X. (Put a +1/+1 counter on each of up to X target creatures.)\nEach creature with a +1/+1 counter on it gains trample until end of turn.

--- a/forge-gui/res/cardsfolder/t/the_crowd_goes_wild.txt
+++ b/forge-gui/res/cardsfolder/t/the_crowd_goes_wild.txt
@@ -1,0 +1,9 @@
+Name:The Crowd Goes Wild
+ManaCost:X G
+Types:Sorcery
+K:Assist
+A:SP$ PutCounter | CounterType$ P1P1 | TargetMin$ 0 | TargetMax$ X | ValidTgts$ Creature | TgtPrompt$ Select up to X target creatures | SubAbility$ DBTrample | SpellDescription$ Support X. (Put a +1/+1 counter on each of up to X target creatures.)
+SVar:DBTrample:DB$ PumpAll | Defined$ Creature.counters_GE1_P1P1 | KW$ Trample
+SVar:X:Count$xPaid
+DeckHas:Ability$Counters
+Oracle:Assist (Another player can pay up to {X} of this spell's cost. You choose the value of X.)\nSupport X. (Put a +1/+1 counter on each of up to X target creatures.)\nEach creature with a +1/+1 counter on it gains trample until end of turn.

--- a/forge-gui/res/cardsfolder/v/vampire_charmseeker.txt
+++ b/forge-gui/res/cardsfolder/v/vampire_charmseeker.txt
@@ -1,0 +1,9 @@
+Name:Vampire Charmseeker
+ManaCost:6 U B
+Types:Creature Vampire Wizard
+PT:3/4
+K:Assist
+K:Flying
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChangeZone | TriggerDescription$ When CARDNAME enters the battlefield, return target instant, sorcery, or creature card from a graveyard to its owner's hand.
+SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Instant,Sorcery,Creature
+Oracle:Assist (Another player can pay up to {6} of this spell's cost.)\nFlying\nWhen Vampire Charmseeker enters the battlefield, return target instant, sorcery, or creature card from a graveyard to its owner's hand.


### PR DESCRIPTION
Scripts for the remaining Assist cards. Needs #4986. Charging Binox already in that PR.

- [x] Bloodborn Scoundrels
- [x] Bring Down
- [x] Dwarven Lightsmith
- [x] Fan Favorite
- [x] Game Plan
- [x] Gang Up
- [x] Huddle Up
- [x] Lava-Field Overlord
- [x] Magma Hellion
- [x] Out of Bounds
- [x] Play of the Game
- [x] Skystreamer
- [x] Spellweaver Duo
- [x] The Crowd Goes Wild
- [x] Vampire Charmseeker