### PR TITLE
Embalm and Eternalize use Keyword and Refactor Copy

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/CopyPermanentAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CopyPermanentAi.java
@@ -72,7 +72,7 @@ public class CopyPermanentAi extends SpellAbilityAi {
             }
         }
 
-        if (sa.hasParam("Embalm") || sa.hasParam("Eternalize")) {
+        if (sa.isEmbalm() || sa.isEternalize()) {
             // E.g. Vizier of Many Faces: check to make sure it makes sense to make the token now
             if (ComputerUtilCard.checkNeedsToPlayReqs(sa.getHostCard(), sa) != AiPlayDecision.WillPlay) {
                 return false;

--- a/forge-game/src/main/java/forge/game/CardTraitBase.java
+++ b/forge-game/src/main/java/forge/game/CardTraitBase.java
@@ -156,6 +156,13 @@ public abstract class CardTraitBase extends GameObject implements IHasCardView, 
         this.keyword = kw;
     }
 
+    public boolean isEmbalm() {
+        return isKeyword(Keyword.EMBALM);
+    }
+    public boolean isEternalize() {
+        return isKeyword(Keyword.ETERNALIZE);
+    }
+
     /**
      * <p>
      * isSecondary.

--- a/forge-game/src/main/java/forge/game/ForgeScript.java
+++ b/forge-game/src/main/java/forge/game/ForgeScript.java
@@ -225,6 +225,10 @@ public class ForgeScript {
             return sa.isDash();
         } else if (property.equals("Disturb")) {
             return sa.isDisturb();
+        } else if (property.equals("Embalm")) {
+            return sa.isEmbalm();
+        } else if (property.equals("Eternalize")) {
+            return sa.isEternalize();
         } else if (property.equals("Flashback")) {
             return sa.isFlashback();
         } else if (property.equals("Jumpstart")) {

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -6303,12 +6303,12 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
 
     public final boolean isEmbalmed() {
         SpellAbility sa = getTokenSpawningAbility();
-        return sa != null && sa.hasParam("Embalm");
+        return sa != null && sa.isEmbalm();
     }
 
     public final boolean isEternalized() {
         SpellAbility sa = getTokenSpawningAbility();
-        return sa != null && sa.hasParam("Eternalize");
+        return sa != null && sa.isEternalize();
     }
 
     public final int getExertedThisTurn() {

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -2832,7 +2832,8 @@ public class CardFactoryUtil {
             String costStr = kw[1];
 
             String effect = "AB$ CopyPermanent | Cost$ " + costStr + " ExileFromGrave<1/CARDNAME> " +
-            "| ActivationZone$ Graveyard | SorcerySpeed$ True | Embalm$ True " +
+            "| ActivationZone$ Graveyard | SorcerySpeed$ True " +
+            "| RemoveCost$ True | SetColor$ White | AddTypes$ Zombie" +
             "| PrecostDesc$ Embalm | CostDesc$ " + ManaCostParser.parse(costStr) + " | Defined$ Self " +
             "| StackDescription$ Embalm - CARDNAME "+
             "| SpellDescription$ (" + inst.getReminderText() + ")" ;
@@ -2968,7 +2969,8 @@ public class CardFactoryUtil {
             StringBuilder sb = new StringBuilder();
 
             sb.append("AB$ CopyPermanent | Cost$ ").append(costStr).append(" ExileFromGrave<1/CARDNAME>")
-            .append(" | Defined$ Self | ActivationZone$ Graveyard | SorcerySpeed$ True | Eternalize$ True");
+            .append(" | Defined$ Self | ActivationZone$ Graveyard | SorcerySpeed$ True")
+            .append(" | RemoveCost$ True | SetColor$ Black | AddTypes$ Zombie | SetPower$ 4 | SetToughness$ 4");
 
             sb.append(" | PrecostDesc$ Eternalize");
             if (!cost.isOnlyManaCost()) { //Something other than a mana cost
@@ -2976,7 +2978,7 @@ public class CardFactoryUtil {
             } else {
                 sb.append(" ");
             }
-            // don't use SimpleString there because it does has "and" between cost i dont want that
+            // don't use SimpleString there because it does has "and" between cost i don't want that
             costStr = cost.toString();
             // but now it has ": " at the end i want to remove
             sb.append("| CostDesc$ ").append(costStr, 0, costStr.length() - 2);

--- a/forge-game/src/main/java/forge/game/card/CardState.java
+++ b/forge-game/src/main/java/forge/game/card/CardState.java
@@ -312,6 +312,9 @@ public class CardState extends GameObject implements IHasSVars {
     public final boolean removeIntrinsicKeyword(final KeywordInterface s) {
         return intrinsicKeywords.remove(s);
     }
+    public final boolean removeIntrinsicKeyword(final Keyword k) {
+        return intrinsicKeywords.removeAll(k);
+    }
 
     public final FCollectionView<SpellAbility> getSpellAbilities() {
         FCollection<SpellAbility> newCol = new FCollection<>(manaAbilities);

--- a/forge-game/src/main/java/forge/game/trigger/TriggerSpellAbilityCastOrCopy.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerSpellAbilityCastOrCopy.java
@@ -190,12 +190,6 @@ public class TriggerSpellAbilityCastOrCopy extends Trigger {
             }
         }
 
-        if (hasParam("EternalizeOrEmbalm")) {
-            if (!spellAbility.hasParam("Eternalize") && !spellAbility.hasParam("Embalm")) {
-                return false;
-            }
-        }
-
         // use numTargets instead?
         if (hasParam("IsSingleTarget")) {
             Set<GameObject> targets = Sets.newHashSet();

--- a/forge-gui/res/cardsfolder/v/vizier_of_many_faces.txt
+++ b/forge-gui/res/cardsfolder/v/vizier_of_many_faces.txt
@@ -3,7 +3,7 @@ ManaCost:2 U U
 Types:Creature Shapeshifter Cleric
 PT:0/0
 K:ETBReplacement:Copy:DBCopy:Optional
-SVar:DBCopy:DB$ Clone | Choices$ Creature.Other | Embalm$ True | SpellDescription$ You may have CARDNAME enter the battlefield as a copy of any creature on the battlefield, except if CARDNAME was embalmed, the token has no mana cost, it's white, and it's a Zombie in addition to its other types.
+SVar:DBCopy:DB$ Clone | Choices$ Creature.Other | Embalm$ True | RemoveCost$ True | SetColor$ White | AddTypes$ Zombie | SpellDescription$ You may have CARDNAME enter the battlefield as a copy of any creature on the battlefield, except if CARDNAME was embalmed, the token has no mana cost, it's white, and it's a Zombie in addition to its other types.
 K:Embalm:3 U U
 SVar:NeedsToPlay:Creature
 DeckHas:Ability$Token

--- a/forge-gui/res/cardsfolder/v/vizier_of_the_anointed.txt
+++ b/forge-gui/res/cardsfolder/v/vizier_of_the_anointed.txt
@@ -4,7 +4,7 @@ Types:Creature Human Cleric
 PT:2/4
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ VizierSearch | TriggerDescription$ When CARDNAME enters the battlefield, you may search your library for a creature card with eternalize or embalm, put that card into your graveyard, then shuffle.
 SVar:VizierSearch:DB$ ChangeZone | Origin$ Library | Destination$ Graveyard | ChangeNum$ 1 | ChangeType$ Creature.withEmbalm+YouCtrl,Creature.withEternalize+YouCtrl
-T:Mode$ AbilityCast | ValidCard$ Creature.YouOwn | ValidActivatingPlayer$ You | EternalizeOrEmbalm$ True | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ Whenever you activate an eternalize or embalm ability, draw a card.
+T:Mode$ AbilityCast | ValidCard$ Creature.YouOwn | ValidActivatingPlayer$ You | ValidSA$ Activated.Eternalize,Activated.Embalm | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ Whenever you activate an eternalize or embalm ability, draw a card.
 SVar:TrigDraw:DB$ Draw | NumCards$ 1
 AI:RemoveDeck:Random
 DeckNeeds:Keyword$Eternalize|Embalm


### PR DESCRIPTION
Removed `EternalizeOrEmbalm` for Vizier of the Anointed

Refactored `Vizier of Many Faces` a bit 
Technically it could be affected by CardTextChanges, even if there isn't a card like that right now