### PR TITLE
OTC: Orochi Soul-Reaver, Pyretic Charge, Sand Scout

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/orochi_soul_reaver.txt
+++ b/forge-gui/res/cardsfolder/upcoming/orochi_soul_reaver.txt
@@ -1,0 +1,10 @@
+Name:Orochi Soul-Reaver
+ManaCost:5 B
+Types:Creature Snake Ninja Rogue
+PT:5/4
+K:Ninjutsu:3 B
+T:Mode$ DamageDoneOnce | ValidSource$ Creature.YouCtrl | TriggerZones$ Battlefield | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigTreasure | TriggerDescription$ Whenever one or more creatures you control deal combat damage to a player, create a Treasure token and manifest the top card of that player's library. (Put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)
+SVar:TrigTreasure:DB$ Token | TokenAmount$ 1 | TokenScript$ c_a_treasure_sac | TokenOwner$ You | SubAbility$ DBManifest
+SVar:DBManifest:DB$ Manifest | Amount$ 1 | Defined$ ValidLibrary Card.TopLibrary+ControlledBy TriggeredTarget
+DeckHas:Ability$Token & Type$Treasure
+Oracle:Ninjutsu {3}{B} ({3}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever one or more creatures you control deal combat damage to a player, create a Treasure token and manifest the top card of that player's library. (Put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)

--- a/forge-gui/res/cardsfolder/upcoming/pyretic_charge.txt
+++ b/forge-gui/res/cardsfolder/upcoming/pyretic_charge.txt
@@ -2,7 +2,7 @@ Name:Pyretic Charge
 ManaCost:4 R
 Types:Sorcery
 K:Plot:3 R
-A:SP$ Discard | Mode$ Hand | RememberDiscarded$ True | Defined$ You | SubAbility$ BetThat | SpellDescription$ Discard your hand, then draw two cards. For each card discarded this way, creatures you control get +1/+0 until end of turn.
+A:SP$ Discard | Mode$ Hand | RememberDiscarded$ True | Defined$ You | SubAbility$ BetThat | SpellDescription$ Discard your hand, then draw four cards. For each card discarded this way, creatures you control get +1/+0 until end of turn.
 SVar:BetThat:DB$ Draw | Defined$ You | NumCards$ 4 | SubAbility$ DBPumpAll
 SVar:DBPumpAll:DB$ PumpAll | ValidCards$ Creature.YouCtrl | NumAtt$ +X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/upcoming/pyretic_charge.txt
+++ b/forge-gui/res/cardsfolder/upcoming/pyretic_charge.txt
@@ -1,0 +1,11 @@
+Name:Pyretic Charge
+ManaCost:4 R
+Types:Sorcery
+K:Plot:3 R
+A:SP$ Discard | Mode$ Hand | RememberDiscarded$ True | Defined$ You | SubAbility$ BetThat | SpellDescription$ Discard your hand, then draw two cards. For each card discarded this way, creatures you control get +1/+0 until end of turn.
+SVar:BetThat:DB$ Draw | Defined$ You | NumCards$ 4 | SubAbility$ DBPumpAll
+SVar:DBPumpAll:DB$ PumpAll | ValidCards$ Creature.YouCtrl | NumAtt$ +X | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:X:Remembered$Amount
+DeckHas:Ability$Discard
+Oracle:Discard your hand, then draw four cards. For each card discarded this way, creatures you control get +1/+0 until end of turn.\nPlot {3}{R} (You may pay {3}{R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)

--- a/forge-gui/res/cardsfolder/upcoming/sand_scout.txt
+++ b/forge-gui/res/cardsfolder/upcoming/sand_scout.txt
@@ -1,0 +1,12 @@
+Name:Sand Scout
+ManaCost:1 W
+Types:Creature Human Scout
+PT:2/2
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChange | CheckSVar$ Y | SVarCompare$ GTX | TriggerDescription$ When CARDNAME enters the battlefield, if an opponent controls more lands than you, search your library for a Desert card, put it onto the battlefield tapped, then shuffle.
+SVar:TrigChange:DB$ ChangeZone | Origin$ Library | Destination$ Battlefield | Tapped$ True | ChangeType$ Desert | ChangeNum$ 1
+T:Mode$ ChangesZoneAll | ValidCards$ Land.YouOwn+nonToken | Origin$ Any | Destination$ Graveyard | TriggerZones$ Battlefield | ActivationLimit$ 1 | Execute$ TrigToken | TriggerDescription$ Whenever one or more land cards are put into your graveyard from anywhere, create a 1/1 red, green, and white Sand Warrior creature token. This ability triggers only once each turn.
+SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ rgw_1_1_sand_warrior | TokenOwner$ You
+SVar:X:Count$Valid Land.YouCtrl
+SVar:Y:PlayerCountOpponents$HighestValid Land.YouCtrl
+DeckHas:Ability$Graveyard|Token & Type$Sand|Warrior & Colors$Red|Green
+Oracle:When Sand Scout enters the battlefield, if an opponent controls more lands than you, search your library for a Desert card, put it onto the battlefield tapped, then shuffle.\nWhenever one or more land cards are put into your graveyard from anywhere, create a 1/1 red, green, and white Sand Warrior creature token. This ability triggers only once each turn.


### PR DESCRIPTION
Tested card scripts for:
- [Orochi Soul-Reaver](https://scryfall.com/card/otc/22/orochi-soul-reaver)
- [Pyretic Charge](https://scryfall.com/card/otc/29/pyretic-charge)
- [Sand Scout](https://scryfall.com/card/otc/11/sand-scout)