### PR TITLE
OTC: Kirri, Leyline Dowser, Lock and Load

### DIFF
--- a/forge-gui/res/cardsfolder/h/honor_worn_shaku.txt
+++ b/forge-gui/res/cardsfolder/h/honor_worn_shaku.txt
@@ -2,6 +2,6 @@ Name:Honor-Worn Shaku
 ManaCost:3
 Types:Artifact
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
-A:AB$ Untap | Cost$ tapXType<1/Permanent.Legendary> | CostDesc$ Tap an untapped legendary permanent you control: | SpellDescription$ Untap CARDNAME.
+A:AB$ Untap | Cost$ tapXType<1/Permanent.Legendary/untapped legendary permanent> | SpellDescription$ Untap CARDNAME.
 AI:RemoveDeck:Random
 Oracle:{T}: Add {C}.\nTap an untapped legendary permanent you control: Untap Honor-Worn Shaku.

--- a/forge-gui/res/cardsfolder/s/show_of_confidence.txt
+++ b/forge-gui/res/cardsfolder/s/show_of_confidence.txt
@@ -3,7 +3,7 @@ ManaCost:1 W
 Types:Instant
 T:Mode$ SpellCast | ValidCard$ Card.Self | Execute$ TrigCopy | TriggerDescription$ When you cast this spell, copy it for each other instant and sorcery spell you've cast this turn. You may choose new targets for the copies.
 SVar:TrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | Amount$ X | MayChooseTarget$ True
-SVar:X:Count$ThisTurnCast_Instant.YouCtrl,Sorcery.YouCtrl/Minus.1
+SVar:X:Count$ThisTurnCast_Instant.Other+YouCtrl,Sorcery.Other+YouCtrl
 A:SP$ PutCounter | Cost$ 1 W | ValidTgts$ Creature | TgtPrompt$ Select target creature | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBPump | SpellDescription$ Put a +1/+1 counter on target creature.
 SVar:DBPump:DB$ Pump | Defined$ Targeted | KW$ Vigilance
 DeckHas:Ability$Counters

--- a/forge-gui/res/cardsfolder/s/show_of_confidence.txt
+++ b/forge-gui/res/cardsfolder/s/show_of_confidence.txt
@@ -3,7 +3,7 @@ ManaCost:1 W
 Types:Instant
 T:Mode$ SpellCast | ValidCard$ Card.Self | Execute$ TrigCopy | TriggerDescription$ When you cast this spell, copy it for each other instant and sorcery spell you've cast this turn. You may choose new targets for the copies.
 SVar:TrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | Amount$ X | MayChooseTarget$ True
-SVar:X:Count$ThisTurnCast_Instant.Other+YouCtrl,Sorcery.Other+YouCtrl
+SVar:X:Count$ThisTurnCast_Instant.YouCtrl,Sorcery.YouCtrl/Minus.1
 A:SP$ PutCounter | Cost$ 1 W | ValidTgts$ Creature | TgtPrompt$ Select target creature | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBPump | SpellDescription$ Put a +1/+1 counter on target creature.
 SVar:DBPump:DB$ Pump | Defined$ Targeted | KW$ Vigilance
 DeckHas:Ability$Counters

--- a/forge-gui/res/cardsfolder/upcoming/kirri_talented_sprout.txt
+++ b/forge-gui/res/cardsfolder/upcoming/kirri_talented_sprout.txt
@@ -1,0 +1,9 @@
+Name:Kirri, Talented Sprout
+ManaCost:1 R G W
+Types:Legendary Creature Plant Druid
+PT:0/3
+S:Mode$ Continuous | Affected$ Plant.Other+YouCtrl,Treefolk.Other+YouCtrl | AddPower$ 2 | Description$ Other Plants and Treefolk you control get +2/+0.
+T:Mode$ Phase | Phase$ Main2 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigChangeZone | TriggerDescription$ At the beginning of your postcombat main phase, return target Plant, Treefolk, or land card from your graveyard to your hand.
+SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Plant.YouOwn,Treefolk.YouOwn,Land.YouOwn | TgtPrompt$ Select target Plant, Treefolk, or land card from your graveyard
+DeckNeeds:Ability$Graveyard & Type$Plant|Treefolk
+Oracle:Other Plants and Treefolk you control get +2/+0.\nAt the beginning of your postcombat main phase, return target Plant, Treefolk, or land card from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/upcoming/leyline_dowser.txt
+++ b/forge-gui/res/cardsfolder/upcoming/leyline_dowser.txt
@@ -1,7 +1,7 @@
 Name:Leyline Dowser
 ManaCost:2
 Types:Artifact
-A:AB$ Mill | Cost$ 1 T | NumCards$ 1 | Defined$ You | RememberMilled$ True | SubAbility$ DBChangeZone | SpellDescription$ Mill a card.
+A:AB$ Mill | Cost$ 1 T | NumCards$ 1 | Defined$ You | RememberMilled$ True | SubAbility$ DBChangeZone | SpellDescription$ Mill a card. You may put an instant or sorcery card milled this way into your hand.
 SVar:DBChangeZone:DB$ ChangeZone | Hidden$ True | Origin$ Graveyard,Exile | Destination$ Hand | ChangeType$ Instant.IsRemembered,Sorcery.IsRemembered | SelectPrompt$ You may select an instant or sorcery card | RememberChanged$ True | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 A:AB$ Untap | Cost$ tapXType<1/Creature.Legendary/untapped legendary creature> | SpellDescription$ Untap CARDNAME.

--- a/forge-gui/res/cardsfolder/upcoming/leyline_dowser.txt
+++ b/forge-gui/res/cardsfolder/upcoming/leyline_dowser.txt
@@ -1,0 +1,16 @@
+Name:Leyline Dowser
+ManaCost:2
+Types:Artifact
+A:AB$ Mill | Cost$ 1 T | NumCards$ 1 | Defined$ You | RememberMilled$ True | SubAbility$ DBChangeZone | SpellDescription$ Mill a card.
+SVar:DBChangeZone:DB$ ChangeZone | Hidden$ True | Origin$ Graveyard,Exile | Destination$ Hand | ChangeType$ Instant.IsRemembered,Sorcery.IsRemembered | SelectPrompt$ You may select an instant or sorcery card | RememberChanged$ True | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+A:AB$ Untap | Cost$ tapXType<1/Creature.Legendary/untapped legendary creature> | SpellDescription$ Untap CARDNAME.
+DeckHas:Ability$Mill
+DeckNeeds:Type$Instant|Sorcery & Type$Legendary
+Oracle:{1}, {T}: Mill a card. You may put an instant or sorcery card milled this way into your hand.\nTap an untapped legendary creature you control: Untap Leyline Dowser.
+
+
+
+
+
+

--- a/forge-gui/res/cardsfolder/upcoming/leyline_dowser.txt
+++ b/forge-gui/res/cardsfolder/upcoming/leyline_dowser.txt
@@ -1,16 +1,10 @@
 Name:Leyline Dowser
 ManaCost:2
 Types:Artifact
-A:AB$ Mill | Cost$ 1 T | NumCards$ 1 | Defined$ You | RememberMilled$ True | SubAbility$ DBChangeZone | SpellDescription$ Mill a card. You may put an instant or sorcery card milled this way into your hand.
+A:AB$ Mill | Cost$ 1 T | NumCards$ 1 | Defined$ You | RememberMilled$ True | SubAbility$ DBChangeZone | SpellDescription$ Mill a card.
 SVar:DBChangeZone:DB$ ChangeZone | Hidden$ True | Origin$ Graveyard,Exile | Destination$ Hand | ChangeType$ Instant.IsRemembered,Sorcery.IsRemembered | SelectPrompt$ You may select an instant or sorcery card | RememberChanged$ True | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 A:AB$ Untap | Cost$ tapXType<1/Creature.Legendary/untapped legendary creature> | SpellDescription$ Untap CARDNAME.
 DeckHas:Ability$Mill
 DeckNeeds:Type$Instant|Sorcery & Type$Legendary
 Oracle:{1}, {T}: Mill a card. You may put an instant or sorcery card milled this way into your hand.\nTap an untapped legendary creature you control: Untap Leyline Dowser.
-
-
-
-
-
-

--- a/forge-gui/res/cardsfolder/upcoming/leyline_dowser.txt
+++ b/forge-gui/res/cardsfolder/upcoming/leyline_dowser.txt
@@ -2,7 +2,7 @@ Name:Leyline Dowser
 ManaCost:2
 Types:Artifact
 A:AB$ Mill | Cost$ 1 T | NumCards$ 1 | Defined$ You | RememberMilled$ True | SubAbility$ DBChangeZone | SpellDescription$ Mill a card. You may put an instant or sorcery card milled this way into your hand.
-SVar:DBChangeZone:DB$ ChangeZone | Hidden$ True | Origin$ Graveyard,Exile | Destination$ Hand | ChangeType$ Instant.IsRemembered,Sorcery.IsRemembered | SelectPrompt$ You may select an instant or sorcery card | RememberChanged$ True | SubAbility$ DBCleanup
+SVar:DBChangeZone:DB$ ChangeZone | Hidden$ True | Origin$ Graveyard,Exile | Destination$ Hand | ChangeType$ Instant.IsRemembered,Sorcery.IsRemembered | SelectPrompt$ You may select an instant or sorcery card | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 A:AB$ Untap | Cost$ tapXType<1/Creature.Legendary/untapped legendary creature> | SpellDescription$ Untap CARDNAME.
 DeckHas:Ability$Mill

--- a/forge-gui/res/cardsfolder/upcoming/lock_and_load.txt
+++ b/forge-gui/res/cardsfolder/upcoming/lock_and_load.txt
@@ -1,0 +1,7 @@
+Name:Lock and Load
+ManaCost:2 U
+Types:Sorcery
+K:Plot:3 U
+A:SP$ Draw | Defined$ You | NumCards$ X | StackDescription$ SpellDescription | SpellDescription$ Draw a card, then draw a card for each other instant and sorcery spell you’ve cast this turn.
+SVar:X:Count$ThisTurnCast_Instant.Other+YouCtrl,Sorcery.Other+YouCtrl/Plus.1
+Oracle:Draw a card, then draw a card for each other instant and sorcery spell you’ve cast this turn.\nPlot {3}{U} (You may pay {3}{U} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)

--- a/forge-gui/res/cardsfolder/upcoming/lock_and_load.txt
+++ b/forge-gui/res/cardsfolder/upcoming/lock_and_load.txt
@@ -2,6 +2,7 @@ Name:Lock and Load
 ManaCost:2 U
 Types:Sorcery
 K:Plot:3 U
-A:SP$ Draw | Defined$ You | NumCards$ X | StackDescription$ SpellDescription | SpellDescription$ Draw a card, then draw a card for each other instant and sorcery spell you’ve cast this turn.
-SVar:X:Count$ThisTurnCast_Instant.Other+YouCtrl,Sorcery.Other+YouCtrl/Plus.1
-Oracle:Draw a card, then draw a card for each other instant and sorcery spell you’ve cast this turn.\nPlot {3}{U} (You may pay {3}{U} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)
+A:SP$ Draw | Defined$ You | NumCards$ 1 | SubAbility$ DBDrawX | StackDescription$ SpellDescription | SpellDescription$ Draw a card, then draw a card for each other instant and sorcery spell you've cast this turn.
+SVar:DBDrawX:DB$ Draw | Defined$ You | NumCards$ X | StackDescription$ None
+SVar:X:Count$ThisTurnCast_Instant.YouCtrl,Sorcery.YouCtrl/Minus.1
+Oracle:Draw a card, then draw a card for each other instant and sorcery spell you've cast this turn.\nPlot {3}{U} (You may pay {3}{U} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)


### PR DESCRIPTION
Tested card scripts for :
- [Kirri, Talented Sprout](https://scryfall.com/card/otc/7/kirri-talented-sprout)
- [Leyline Dowser](https://scryfall.com/card/otc/39/leyline-dowser)
- [Lock and Load](https://scryfall.com/card/otc/15/lock-and-load)

Minor fixes
- As a source for Lock and Load, I felt [Show of Confidence](https://scryfall.com/card/stx/28/show-of-confidence)'s counting `SVar` should follow the text of the card more closely even if that's unlikely to have functional significance anytime soon. Tested both new and updated cards to satisfaction.
- As a source for Leyline Dowser, updated [Honor-Worn Shaku](https://scryfall.com/card/cmm/954/honor-worn-shaku)'s second ability, subsuming the explicit `CostDesc$` into the `Cost$` parameter.