### PR TITLE
OTC: Discreet Retreat, Dream-Thief's Bandana, Dune Chanter

### DIFF
--- a/forge-gui/res/cardsfolder/g/gorging_vulture.txt
+++ b/forge-gui/res/cardsfolder/g/gorging_vulture.txt
@@ -3,10 +3,10 @@ ManaCost:2 B
 Types:Creature Bird
 PT:2/2
 K:Flying
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigMill | TriggerDescription$ When CARDNAME enters the battlefield, mill four cards. You gain 1 life for each creature card put into your graveyard this way.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigMill | TriggerDescription$ When CARDNAME enters the battlefield, mill four cards. You gain 1 life for each creature card milled this way. (To mill a card, put the top card of your library into your graveyard.)
 SVar:TrigMill:DB$ Mill | NumCards$ 4 | Defined$ You | RememberMilled$ True | SubAbility$ DBGainLife
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Remembered$Valid Card.Creature
 DeckHas:Ability$Graveyard|LifeGain
-Oracle:Flying\nWhen Gorging Vulture enters the battlefield, mill four cards. You gain 1 life for each creature card put into your graveyard this way.
+Oracle:Flying\nWhen Gorging Vulture enters the battlefield, mill four cards. You gain 1 life for each creature card milled this way. (To mill a card, put the top card of your library into your graveyard.)

--- a/forge-gui/res/cardsfolder/upcoming/discreet_retreat.txt
+++ b/forge-gui/res/cardsfolder/upcoming/discreet_retreat.txt
@@ -1,0 +1,10 @@
+Name:Discreet Retreat
+ManaCost:3 B
+Types:Enchantment Aura
+A:SP$ Attach | ValidTgts$ Land | AILogic$ Pump
+S:Mode$ Continuous | Affected$ Card.EnchantedBy | AddAbility$ RetreatTap | Description$ Enchanted land has "{T}: Add two mana of any one color. Spend this mana only to cast outlaw spells or activate abilities from outlaw sources." (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)
+SVar:RetreatTap:AB$ Mana | Cost$ T | Produced$ Any | Amount$ 2 | RestrictValid$ Spell.Outlaw,Activated.Outlaw | SpellDescription$ Add two mana of any one color. Spend this mana only to cast outlaw spells or activate abilities from outlaw sources. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)
+T:Mode$ SpellCast | ValidCard$ Card.Outlaw | ValidActivatingPlayer$ You | ActivatorThisTurnCast$ EQ1 | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ Whenever you cast your first outlaw spell each turn, you draw a card and you lose 1 life.
+SVar:TrigDraw:DB$ Draw | NumCards$ 1 | Defined$ You | SubAbility$ DBLoseLife
+SVar:DBLoseLife:DB$ LoseLife | LifeAmount$ 1
+Oracle:Enchant land\nEnchanted land has "{T}: Add two mana of any one color. Spend this mana only to cast outlaw spells or activate abilities from outlaw sources." (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)\nWhenever you cast your first outlaw spell each turn, you draw a card and you lose 1 life.

--- a/forge-gui/res/cardsfolder/upcoming/discreet_retreat.txt
+++ b/forge-gui/res/cardsfolder/upcoming/discreet_retreat.txt
@@ -7,4 +7,5 @@ SVar:RetreatTap:AB$ Mana | Cost$ T | Produced$ Any | Amount$ 2 | RestrictValid$ 
 T:Mode$ SpellCast | ValidCard$ Card.Outlaw | ValidActivatingPlayer$ You | ActivatorThisTurnCast$ EQ1 | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ Whenever you cast your first outlaw spell each turn, you draw a card and you lose 1 life.
 SVar:TrigDraw:DB$ Draw | NumCards$ 1 | Defined$ You | SubAbility$ DBLoseLife
 SVar:DBLoseLife:DB$ LoseLife | LifeAmount$ 1
+DeckNeeds:Type$Assassin|Mercenary|Pirate|Rogue|Warlock
 Oracle:Enchant land\nEnchanted land has "{T}: Add two mana of any one color. Spend this mana only to cast outlaw spells or activate abilities from outlaw sources." (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)\nWhenever you cast your first outlaw spell each turn, you draw a card and you lose 1 life.

--- a/forge-gui/res/cardsfolder/upcoming/discreet_retreat.txt
+++ b/forge-gui/res/cardsfolder/upcoming/discreet_retreat.txt
@@ -1,6 +1,7 @@
 Name:Discreet Retreat
 ManaCost:3 B
 Types:Enchantment Aura
+K:Enchant land
 A:SP$ Attach | ValidTgts$ Land | AILogic$ Pump
 S:Mode$ Continuous | Affected$ Card.EnchantedBy | AddAbility$ RetreatTap | Description$ Enchanted land has "{T}: Add two mana of any one color. Spend this mana only to cast outlaw spells or activate abilities from outlaw sources." (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)
 SVar:RetreatTap:AB$ Mana | Cost$ T | Produced$ Any | Amount$ 2 | RestrictValid$ Spell.Outlaw,Activated.Outlaw | SpellDescription$ Add two mana of any one color. Spend this mana only to cast outlaw spells or activate abilities from outlaw sources. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)

--- a/forge-gui/res/cardsfolder/upcoming/dream_thiefs_bandana.txt
+++ b/forge-gui/res/cardsfolder/upcoming/dream_thiefs_bandana.txt
@@ -1,0 +1,10 @@
+Name:Dream-Thief's Bandana
+ManaCost:2
+Types:Artifact Equipment
+T:Mode$ DamageDone | ValidSource$ Creature.EquippedBy | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigDig | TriggerZones$ Battlefield | TriggerDescription$ Whenever equipped creature deals combat damage to a player, look at the top card of their library, then exile it face down. For as long as it remains exiled, you may play it, and mana of any type can be spent to cast that spell.
+SVar:TrigDig:DB$ Dig | DigNum$ 1 | Defined$ TriggeredTarget | ForceRevealToController$ True | ChangeNum$ All | DestinationZone$ Exile | ExileFaceDown$ True | RememberChanged$ True | SubAbility$ DBEffect
+SVar:DBEffect:DB$ Effect | StaticAbilities$ STPlay | RememberObjects$ RememberedCard | ForgetOnMoved$ Exile | Duration$ Permanent | SubAbility$ DBCleanup
+SVar:STPlay:Mode$ Continuous | MayLookAt$ You | MayPlay$ True | MayPlayIgnoreType$ True | EffectZone$ Command | Affected$ Card.IsRemembered | AffectedZone$ Exile | Description$ For as long as that card remains exiled, you may play it, and mana of any type can be spent to cast that spell.
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+K:Equip:1
+Oracle:Whenever equipped creature deals combat damage to a player, look at the top card of their library, then exile it face down. For as long as it remains exiled, you may play it, and mana of any type can be spent to cast that spell.\nEquip {1}

--- a/forge-gui/res/cardsfolder/upcoming/dune_chanter.txt
+++ b/forge-gui/res/cardsfolder/upcoming/dune_chanter.txt
@@ -1,0 +1,13 @@
+Name:Dune Chanter
+ManaCost:2 G
+Types:Creature Plant Druid
+PT:2/3
+K:Reach
+S:Mode$ Continuous | Affected$ Land.YouCtrl | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | AddType$ Desert | Description$ Lands you control and land cards you own that aren't on the battlefield are Deserts in addition to their other types.
+S:Mode$ Continuous | Affected$ Land.YouCtrl | AddAbility$ AnyMana | Description$ Lands you control have "{T}: Add one mana of any color."
+SVar:AnyMana:AB$ Mana | Cost$ T | Produced$ Any | Amount$ 1 | SpellDescription$ Add one mana of any color.
+A:AB$ Mill | Cost$ T | NumCards$ 2 | Defined$ You | RememberMilled$ True | SubAbility$ DBGainLife | SpellDescription$ Mill two cards. You gain 1 life for each land card milled this way.
+SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ X | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:X:Remembered$Valid Card.Land
+Oracle:Reach\nLands you control and land cards you own that aren't on the battlefield are Deserts in addition to their other types.\nLands you control have "{T}: Add one mana of any color."\n{T}: Mill two cards. You gain 1 life for each land card milled this way.

--- a/forge-gui/res/cardsfolder/upcoming/dune_chanter.txt
+++ b/forge-gui/res/cardsfolder/upcoming/dune_chanter.txt
@@ -10,4 +10,5 @@ A:AB$ Mill | Cost$ T | NumCards$ 2 | Defined$ You | RememberMilled$ True | SubAb
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Remembered$Valid Card.Land
+DeckHas:Ability$Graveyard|LifeGain & Type$Desert
 Oracle:Reach\nLands you control and land cards you own that aren't on the battlefield are Deserts in addition to their other types.\nLands you control have "{T}: Add one mana of any color."\n{T}: Mill two cards. You gain 1 life for each land card milled this way.


### PR DESCRIPTION
Tested card scripts for:
- [Discreet Retreat](https://scryfall.com/card/otc/20/discreet-retreat)
- [Dream-Thief's Bandana](https://scryfall.com/card/otc/38/dream-thiefs-bandana)
- [Dune Chanter](https://scryfall.com/card/otc/31/dune-chanter)

Minor fixes
- Updated Oracle and `TriggerDescription$` text for [Gorging Vulture](https://scryfall.com/card/clu/112/gorging-vulture).