### PR TITLE
Typo cleanup pass #3

### DIFF
--- a/forge-gui/res/cardsfolder/a/artistic_refusal.txt
+++ b/forge-gui/res/cardsfolder/a/artistic_refusal.txt
@@ -7,4 +7,4 @@ SVar:DBCounter:DB$ Counter | TargetType$ Spell | ValidTgts$ Card | SpellDescript
 SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 2 | SubAbility$ DBDiscard | SpellDescription$ Draw two cards, then discard a card.
 SVar:DBDiscard:DB$ Discard | Mode$ TgtChoose
 DeckHas:Ability$Discard
-Oracle:Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nChoose one or both —\n• Counter target spell.\n•Draw two cards, then discard a card.
+Oracle:Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nChoose one or both —\n• Counter target spell.\n• Draw two cards, then discard a card.

--- a/forge-gui/res/cardsfolder/a/aurelias_fury.txt
+++ b/forge-gui/res/cardsfolder/a/aurelias_fury.txt
@@ -6,7 +6,7 @@ SVar:CowedByAurelia:DB$ TapAll | ValidCards$ Creature.IsRemembered | SubAbility$
 SVar:SpellLimitations:DB$ Effect | StaticAbilities$ STCantBeCast | RememberObjects$ Player.IsRemembered | SubAbility$ DBCleanup
 SVar:STCantBeCast:Mode$ CantBeCast | EffectZone$ Command | ValidCard$ Card.nonCreature | Caster$ Player.IsRemembered | Description$ Players damaged by Aurelia's Fury can't cast creature spells this turn.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-SVar:MaxTgts:PlayerCountPlayers$Amount/Plus.NumCreatures
-SVar:NumCreatures:Count$Valid Any
+SVar:MaxTgts:PlayerCountPlayers$Amount/Plus.MaxPermanents
+SVar:MaxPermanents:Count$Valid Any
 SVar:X:Count$xPaid
 Oracle:Aurelia's Fury deals X damage divided as you choose among any number of targets. Tap each creature dealt damage this way. Players dealt damage this way can't cast noncreature spells this turn.

--- a/forge-gui/res/cardsfolder/a/avacyns_judgment.txt
+++ b/forge-gui/res/cardsfolder/a/avacyns_judgment.txt
@@ -3,8 +3,8 @@ ManaCost:1 R
 Types:Sorcery
 K:Madness:X R
 A:SP$ DealDamage | Cost$ 1 R | ValidTgts$ Any | TgtPrompt$ Select any number of targets to distribute damage to | NumDmg$ Y | TargetMin$ 0 | TargetMax$ MaxTgts | DividedAsYouChoose$ Y | SpellDescription$ CARDNAME deals 2 damage divided as you choose among any number of targets. If CARDNAME's madness cost was paid, it deals X damage instead.
-SVar:MaxTgts:PlayerCountPlayers$Amount/Plus.NumCreatures
-SVar:NumCreatures:Count$Valid Any
+SVar:MaxTgts:PlayerCountPlayers$Amount/Plus.MaxPermanents
+SVar:MaxPermanents:Count$Valid Any
 SVar:Y:Count$Madness.X.2
 SVar:X:Count$xPaid
 DeckHints:Ability$Discard

--- a/forge-gui/res/cardsfolder/b/barbarian_guides.txt
+++ b/forge-gui/res/cardsfolder/b/barbarian_guides.txt
@@ -3,7 +3,7 @@ ManaCost:2 R
 Types:Creature Human Barbarian
 PT:1/2
 A:AB$ ChooseType | Cost$ 2 R T | Defined$ You | Type$ Land | SubAbility$ DBPump | StackDescription$ SpellDescription | SpellDescription$ Choose a land type. Target creature you control gains snow landwalk of the chosen type until end of turn.
-SVar:DBPump:DB$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | KW$ Landwalk:ChosenType.Snow:Snow Chosentype | DefinedKW$ ChosenType | StackDescription$ None | SubAbility$ DBDelTrig
+SVar:DBPump:DB$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | KW$ Landwalk:ChosenType.Snow:Snow ChosenType | DefinedKW$ ChosenType | StackDescription$ None | SubAbility$ DBDelTrig
 SVar:DBDelTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | RememberObjects$ ParentTarget | Execute$ TrigReturn | SpellDescription$ Return that creature to its owner's hand at the beginning of the next end step.
 SVar:TrigReturn:DB$ ChangeZone | Defined$ DelayTriggerRememberedLKI | Origin$ Battlefield | Destination$ Hand
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/b/builders_bane.txt
+++ b/forge-gui/res/cardsfolder/b/builders_bane.txt
@@ -1,8 +1,8 @@
 Name:Builder's Bane
 ManaCost:X X R
 Types:Sorcery
-A:SP$ Destroy | Cost$ X X R | ValidTgts$ Artifact | TargetMin$ 0 | TargetMax$ Maxtgt | RememberTargets$ True | SubAbility$ DBRepeat | StackDescription$ SpellDescription | SpellDescription$ Destroy X target artifacts. CARDNAME deals damage to each player equal to the number of artifacts they controlled that were put into a graveyard this way.
-SVar:Maxtgt:Count$Valid Artifact
+A:SP$ Destroy | Cost$ X X R | ValidTgts$ Artifact | TargetMin$ 0 | TargetMax$ MaxTgt | RememberTargets$ True | SubAbility$ DBRepeat | StackDescription$ SpellDescription | SpellDescription$ Destroy X target artifacts. CARDNAME deals damage to each player equal to the number of artifacts they controlled that were put into a graveyard this way.
+SVar:MaxTgt:Count$Valid Artifact
 SVar:X:TargetedObjects$Amount
 SVar:DBRepeat:DB$ RepeatEach | RepeatPlayers$ Player | RepeatSubAbility$ DBDmg | SubAbility$ DBCleanup | DamageMap$ True
 SVar:DBDmg:DB$ DealDamage | Defined$ Player.IsRemembered | NumDmg$ Y

--- a/forge-gui/res/cardsfolder/c/catch_release.txt
+++ b/forge-gui/res/cardsfolder/c/catch_release.txt
@@ -11,6 +11,6 @@ ALTERNATE
 Name:Release
 ManaCost:4 R W
 Types:Sorcery
-A:SP$ RepeatEach | Cost$ 4 R W | RepeatPlayers$ Player | RepeatSubAbility$ DBsac | SpellDescription$ Each player sacrifices an artifact, a creature, an enchantment, a land, and a planeswalker.
-SVar:DBsac:DB$ Sacrifice | Defined$ Player.IsRemembered | SacValid$ Artifact & Creature & Enchantment & Land & Planeswalker | SacEachValid$ True
+A:SP$ RepeatEach | Cost$ 4 R W | RepeatPlayers$ Player | RepeatSubAbility$ DBSac | SpellDescription$ Each player sacrifices an artifact, a creature, an enchantment, a land, and a planeswalker.
+SVar:DBSac:DB$ Sacrifice | Defined$ Player.IsRemembered | SacValid$ Artifact & Creature & Enchantment & Land & Planeswalker | SacEachValid$ True
 Oracle:Each player sacrifices an artifact, a creature, an enchantment, a land, and a planeswalker.\nFuse (You may cast one or both halves of this card from your hand.)

--- a/forge-gui/res/cardsfolder/c/choking_vines.txt
+++ b/forge-gui/res/cardsfolder/c/choking_vines.txt
@@ -2,9 +2,9 @@ Name:Choking Vines
 ManaCost:X G
 Types:Instant
 Text:Cast CARDNAME only during the declare blockers step.
-A:SP$ BecomesBlocked | Cost$ X G | ValidTgts$ Creature.attacking | TgtPrompt$ Select target attacking creature | TargetMin$ 0 | TargetMax$ Maxtgt | ActivationPhases$ Declare Blockers | RememberTargets$ True | SubAbility$ DBDamage | SpellDescription$ X target attacking creatures become blocked. CARDNAME deals 1 damage to each of those creatures. (This spell works on creatures that can't be blocked.)
+A:SP$ BecomesBlocked | Cost$ X G | ValidTgts$ Creature.attacking | TgtPrompt$ Select target attacking creature | TargetMin$ 0 | TargetMax$ MaxTgt | ActivationPhases$ Declare Blockers | RememberTargets$ True | SubAbility$ DBDamage | SpellDescription$ X target attacking creatures become blocked. CARDNAME deals 1 damage to each of those creatures. (This spell works on creatures that can't be blocked.)
 SVar:DBDamage:DB$ DamageAll | ValidCards$ Creature.IsRemembered | NumDmg$ 1 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:TargetedObjects$Amount
-SVar:Maxtgt:Count$Valid Creature.attacking
+SVar:MaxTgt:Count$Valid Creature.attacking
 Oracle:Cast this spell only during the declare blockers step.\nX target attacking creatures become blocked. Choking Vines deals 1 damage to each of those creatures. (This spell works on creatures that can't be blocked.)

--- a/forge-gui/res/cardsfolder/c/conflagrate.txt
+++ b/forge-gui/res/cardsfolder/c/conflagrate.txt
@@ -2,8 +2,8 @@ Name:Conflagrate
 ManaCost:X X R
 Types:Sorcery
 A:SP$ DealDamage | Cost$ X X R | ValidTgts$ Any | TgtPrompt$ Select any target to distribute damage to | NumDmg$ X | TargetMin$ 0 | TargetMax$ MaxTgts | DividedAsYouChoose$ X | SpellDescription$ CARDNAME deals X damage divided as you choose among any number of targets.
-SVar:MaxTgts:PlayerCountPlayers$Amount/Plus.NumCreatures
-SVar:NumCreatures:Count$Valid Any
+SVar:MaxTgts:PlayerCountPlayers$Amount/Plus.MaxPermanents
+SVar:MaxPermanents:Count$Valid Any
 SVar:X:Count$xPaid
 K:Flashback:R R Discard<X/Card/cards>
 Oracle:Conflagrate deals X damage divided as you choose among any number of targets.\nFlashback—{R}{R}, Discard X cards. (You may cast this card from your graveyard for its flashback cost. Then exile it.)

--- a/forge-gui/res/cardsfolder/d/deepwood_elder.txt
+++ b/forge-gui/res/cardsfolder/d/deepwood_elder.txt
@@ -2,10 +2,10 @@ Name:Deepwood Elder
 ManaCost:G G
 Types:Creature Dryad Spellshaper
 PT:2/2
-A:AB$ Animate | Cost$ X G G T Discard<1/Card> | TargetMin$ 0 | TargetMax$ Maxtgt | ValidTgts$ Land | TgtPrompt$ Select target land to become forest | Types$ Forest | RemoveLandTypes$ True | SpellDescription$ X target lands become Forests until end of turn.
+A:AB$ Animate | Cost$ X G G T Discard<1/Card> | TargetMin$ 0 | TargetMax$ MaxTgt | ValidTgts$ Land | TgtPrompt$ Select target land to become forest | Types$ Forest | RemoveLandTypes$ True | SpellDescription$ X target lands become Forests until end of turn.
 SVar:X:TargetedObjects$Amount
 AI:RemoveDeck:All
-SVar:Maxtgt:Count$Valid Land
+SVar:MaxTgt:Count$Valid Land
 AI:RemoveDeck:All
 AI:RemoveDeck:Random
 Oracle:{X}{G}{G}, {T}, Discard a card: X target lands become Forests until end of turn.

--- a/forge-gui/res/cardsfolder/f/fireball.txt
+++ b/forge-gui/res/cardsfolder/f/fireball.txt
@@ -4,8 +4,8 @@ Types:Sorcery
 S:Mode$ RaiseCost | ValidCard$ Card.Self | Type$ Spell | Amount$ IncreaseCost | Relative$ True | EffectZone$ All | Description$ This spell costs {1} more to cast for each target beyond the first.
 A:SP$ DealDamage | Cost$ X R | ValidTgts$ Any | NumDmg$ X | TargetMin$ 0 | TargetMax$ MaxTargets | DivideEvenly$ RoundedDown | SpellDescription$ CARDNAME deals X damage divided evenly, rounded down, among any number of targets.
 SVar:X:Count$xPaid
-SVar:MaxTargets:SVar$Maxplayer/Plus.Maxcreatureorplaneswalker
-SVar:Maxplayer:PlayerCountPlayers$Amount
-SVar:Maxcreatureorplaneswalker:Count$Valid Any
+SVar:MaxTargets:SVar$MaxPlayers/Plus.MaxPermanents
+SVar:MaxPlayers:PlayerCountPlayers$Amount
+SVar:MaxPermanents:Count$Valid Any
 SVar:IncreaseCost:TargetedObjects$Amount/Minus.1
 Oracle:This spell costs {1} more to cast for each target beyond the first.\nFireball deals X damage divided evenly, rounded down, among any number of targets.

--- a/forge-gui/res/cardsfolder/f/firestorm.txt
+++ b/forge-gui/res/cardsfolder/f/firestorm.txt
@@ -5,6 +5,6 @@ A:SP$ DealDamage | Cost$ R Discard<X/Card> | ValidTgts$ Any | TargetMin$ 0 | Tar
 SVar:X:TargetedObjects$Amount
 SVar:MaxTargets:SVar$MaxPlayers/Plus.MaxPermanents
 SVar:MaxPlayers:PlayerCountPlayers$Amount
-SVar:MaxPermanents:Count$Valid Creature,Planeswalker
+SVar:MaxPermanents:Count$Valid Any
 AI:RemoveDeck:All
 Oracle:As an additional cost to cast this spell, discard X cards.\nFirestorm deals X damage to each of X targets.

--- a/forge-gui/res/cardsfolder/f/firestorm.txt
+++ b/forge-gui/res/cardsfolder/f/firestorm.txt
@@ -3,8 +3,8 @@ ManaCost:R
 Types:Instant
 A:SP$ DealDamage | Cost$ R Discard<X/Card> | ValidTgts$ Any | TargetMin$ 0 | TargetMax$ MaxTargets | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to each of X targets.
 SVar:X:TargetedObjects$Amount
-SVar:MaxTargets:SVar$MaxPlayers/Plus.MaxCreaturesAndPlaneswalkers
+SVar:MaxTargets:SVar$MaxPlayers/Plus.MaxPermanents
 SVar:MaxPlayers:PlayerCountPlayers$Amount
-SVar:MaxCreaturesAndPlaneswalkers:Count$Valid Creature,Planeswalker
+SVar:MaxPermanents:Count$Valid Creature,Planeswalker
 AI:RemoveDeck:All
 Oracle:As an additional cost to cast this spell, discard X cards.\nFirestorm deals X damage to each of X targets.

--- a/forge-gui/res/cardsfolder/f/flockchaser_phantom.txt
+++ b/forge-gui/res/cardsfolder/f/flockchaser_phantom.txt
@@ -6,8 +6,8 @@ K:Convoke
 K:Flying
 K:Vigilance
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigEffect | TriggerDescription$ Whenever CARDNAME attacks, the next spell you cast this turn has convoke.
-SVar:TrigEffect:DB$ Effect | StaticAbilities$ GrandConvoke | Triggers$ ExileEffect
-SVar:GrandConvoke:Mode$ Continuous | EffectZone$ Command | Affected$ Card.YouCtrl | AffectedZone$ Stack | AddKeyword$ Convoke | Description$ The next spell you cast this turn has convoke.
+SVar:TrigEffect:DB$ Effect | StaticAbilities$ GrantConvoke | Triggers$ ExileEffect
+SVar:GrantConvoke:Mode$ Continuous | EffectZone$ Command | Affected$ Card.YouCtrl | AffectedZone$ Stack | AddKeyword$ Convoke | Description$ The next spell you cast this turn has convoke.
 SVar:ExileEffect:Mode$ SpellCast | EffectZone$ Command | ValidCard$ Card.YouCtrl | Execute$ RemoveEffect | Static$ True
 SVar:RemoveEffect:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self
 SVar:HasAttackEffect:TRUE

--- a/forge-gui/res/cardsfolder/g/game_of_chaos.txt
+++ b/forge-gui/res/cardsfolder/g/game_of_chaos.txt
@@ -3,11 +3,11 @@ ManaCost:R R R
 Types:Sorcery
 A:SP$ Repeat | Cost$ R R R | ValidTgts$ Opponent | IsCurse$ True | StackDescription$ SpellDescription | RepeatOptional$ True | RepeatSubAbility$ DBCleanup | RepeatOptionalDecider$ Remembered | SubAbility$ DBRestore | SpellDescription$ Flip a coin. If you win the flip, you gain 1 life and target opponent loses 1 life, and you decide whether to flip again. If you lose the flip, you lose 1 life and that opponent gains 1 life, and that player decides whether to flip again. Double the life stakes with each flip.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | SubAbility$ DBFlip
-SVar:DBFlip:DB$ FlipACoin | Caller$ You | WinSubAbility$ GainlifeYou | LoseSubAbility$ GainlifeOpp | SubAbility$ DoubleLifeStake
-SVar:GainlifeYou:DB$ GainLife | Defined$ You | LifeAmount$ NumLife | SubAbility$ LoseLifeOpp
+SVar:DBFlip:DB$ FlipACoin | Caller$ You | WinSubAbility$ GainLifeYou | LoseSubAbility$ GainLifeOpp | SubAbility$ DoubleLifeStake
+SVar:GainLifeYou:DB$ GainLife | Defined$ You | LifeAmount$ NumLife | SubAbility$ LoseLifeOpp
 SVar:LoseLifeOpp:DB$ LoseLife | Defined$ Targeted | LifeAmount$ NumLife | SubAbility$ RememberYou
 SVar:RememberYou:DB$ Pump | RememberObjects$ You
-SVar:GainlifeOpp:DB$ GainLife | Defined$ Targeted | LifeAmount$ NumLife | SubAbility$ LoseLifeYou
+SVar:GainLifeOpp:DB$ GainLife | Defined$ Targeted | LifeAmount$ NumLife | SubAbility$ LoseLifeYou
 SVar:LoseLifeYou:DB$ LoseLife | Defined$ You | LifeAmount$ NumLife | SubAbility$ RememberOpp
 SVar:RememberOpp:DB$ Pump | RememberObjects$ Targeted
 SVar:DoubleLifeStake:DB$ StoreSVar | SVar$ NumLife | Type$ CountSVar | Expression$ NumLife/Times.2

--- a/forge-gui/res/cardsfolder/h/henrika_domnathi_henrika_infernal_seer.txt
+++ b/forge-gui/res/cardsfolder/h/henrika_domnathi_henrika_infernal_seer.txt
@@ -11,7 +11,7 @@ SVar:DBLoseLife:DB$ LoseLife | Defined$ You | LifeAmount$ 1 | StackDescription$ 
 SVar:TransDom:DB$ SetState | Defined$ Self | Mode$ Transform | SpellDescription$ Transform CARDNAME.
 DeckHas:Ability$Sacrifice|LifeGain
 AlternateMode:DoubleFaced
-Oracle:Flying\nAt the beginning of combat on your turn, choose one that hasn't been chosen —\n• Each player sacrifices a creature.\n• You draw a card and you lose 1 life.\n•Transform Henrika Domnathi.
+Oracle:Flying\nAt the beginning of combat on your turn, choose one that hasn't been chosen —\n• Each player sacrifices a creature.\n• You draw a card and you lose 1 life.\n• Transform Henrika Domnathi.
 
 ALTERNATE
 

--- a/forge-gui/res/cardsfolder/h/hotel_of_fears.txt
+++ b/forge-gui/res/cardsfolder/h/hotel_of_fears.txt
@@ -2,8 +2,8 @@ Name:Hotel of Fears
 ManaCost:no cost
 Types:Plane Spacecraft
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ TrigExile | TriggerZones$ Command | TriggerDescription$ At the beginning of your upkeep, exile the top card of your library. You lose life equal to its mana value. You may play that card this turn.
-SVar:TrigExile:DB$ Dig | Defined$ You | DigNum$ 1 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBloseLife
-SVar:DBloseLife:DB$ LoseLife | LifeAmount$ Y | SubAbility$ DBEffect
+SVar:TrigExile:DB$ Dig | Defined$ You | DigNum$ 1 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBLoseLife
+SVar:DBLoseLife:DB$ LoseLife | LifeAmount$ Y | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | StaticAbilities$ STPlay | ForgetOnMoved$ Exile | RememberObjects$ Remembered | SubAbility$ DBCleanup
 SVar:STPlay:Mode$ Continuous | EffectZone$ Command | Affected$ Card.IsRemembered | MayPlay$ True | AffectedZone$ Exile | Description$ You may play them this turn.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/i/ichor_aberration.txt
+++ b/forge-gui/res/cardsfolder/i/ichor_aberration.txt
@@ -12,4 +12,4 @@ SVar:ReanimateSelf:DB$ Effect | StaticAbilities$ MayPlay | RememberObjects$ Self
 SVar:MayPlay:Mode$ Continuous | EffectZone$ Command | Affected$ Card.IsRemembered | MayPlay$ True | AffectedZone$ Graveyard | Description$ You may cast EFFECTSOURCE from your graveyard this turn.
 DeckHints:Ability$Proliferate
 DeckHas:Ability$Graveyard
-Oracle:Flying, defender\nAs long as Ichor Aberration's power is 7 or greater, it can attack as though it didn't have defender.\nWhenever you proliferate, if Ichor Aberation is in your graveyard or on the battlefield, Ichor Aberration perpetually gets +1/+1. You may cast it from your graveyard this turn.
+Oracle:Flying, defender\nAs long as Ichor Aberration's power is 7 or greater, it can attack as though it didn't have defender.\nWhenever you proliferate, if Ichor Aberration is in your graveyard or on the battlefield, Ichor Aberration perpetually gets +1/+1. You may cast it from your graveyard this turn.

--- a/forge-gui/res/cardsfolder/k/kaboom.txt
+++ b/forge-gui/res/cardsfolder/k/kaboom.txt
@@ -6,8 +6,8 @@ SVar:DBDigUntil:DB$ DigUntil | Defined$ You | Valid$ Card.nonLand | ValidDescrip
 SVar:DBDmg:DB$ DealDamage | Defined$ Remembered | NumDmg$ X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearImprinted$ True
 SVar:X:Imprinted$CardManaCost
-SVar:MaxTgt:SVar$MaxPl/Plus.MaxPW
-SVar:MaxPl:PlayerCountPlayers$Amount
+SVar:MaxTgt:SVar$MaxPlayers/Plus.MaxPW
+SVar:MaxPlayers:PlayerCountPlayers$Amount
 SVar:MaxPW:Count$Valid Planeswalker
 AI:RemoveDeck:All
 Oracle:Choose any number of target players or planeswalkers. For each of them, reveal cards from the top of your library until you reveal a nonland card, Kaboom! deals damage equal to that card's mana value to that player or planeswalker, then you put the revealed cards on the bottom of your library in any order.

--- a/forge-gui/res/cardsfolder/k/kaylas_command.txt
+++ b/forge-gui/res/cardsfolder/k/kaylas_command.txt
@@ -10,4 +10,4 @@ SVar:DBChangeZone:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeT
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ 2 | SubAbility$ DBScry | SpellDescription$ You gain 2 life and scry 2.
 SVar:DBScry:DB$ Scry | ScryNum$ 2
 DeckHas:Ability$Token|LifeGain|Counters & Type$Construct|Artifact & Keyword$DoubleStrike
-Oracle:Choose two: - \n• Create a 2/2 colorless Construct artifact creature token.\n• Put a +1/+1 counter on a creature you control. It gains double strike until end of turn.·\n• Search your library for a basic Plains card, reveal it, put it into your hand, then shuffle.·\n• You gain 2 life and scry 2.
+Oracle:Choose two: - \n• Create a 2/2 colorless Construct artifact creature token.\n• Put a +1/+1 counter on a creature you control. It gains double strike until end of turn.\n• Search your library for a basic Plains card, reveal it, put it into your hand, then shuffle.\n• You gain 2 life and scry 2.

--- a/forge-gui/res/cardsfolder/m/meteor_shower.txt
+++ b/forge-gui/res/cardsfolder/m/meteor_shower.txt
@@ -2,9 +2,8 @@ Name:Meteor Shower
 ManaCost:X X R
 Types:Sorcery
 A:SP$ DealDamage | Cost$ X X R | ValidTgts$ Any | TgtPrompt$ Select targets to distribute damage to | NumDmg$ DistroDmg | TargetMin$ 0 | TargetMax$ MaxTgts | DividedAsYouChoose$ DistroDmg | SpellDescription$ CARDNAME deals X plus 1 damage divided as you choose among any number of targets.
-SVar:NumPlayers:PlayerCountPlayers$Amount/Plus.NumCreaturesAndPlaneswalkers
-SVar:NumCreaturesAndPlaneswalkers:Count$Valid Any
-SVar:MaxTgts:SVar$NumPlayers
+SVar:MaxTgts:PlayerCountPlayers$Amount/Plus.MaxPermanents
+SVar:MaxPermanents:Count$Valid Any
 SVar:DistroDmg:SVar$X/Plus.1
 SVar:X:Count$xPaid
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/o/officious_interrogation.txt
+++ b/forge-gui/res/cardsfolder/o/officious_interrogation.txt
@@ -3,9 +3,9 @@ ManaCost:W U
 Types:Instant
 S:Mode$ RaiseCost | ValidCard$ Card.Self | Type$ Spell | Amount$ IncreaseCost | Relative$ True | Cost$ W U | EffectZone$ All | Description$ This spell costs {W}{U} more to cast for each target beyond the first.
 SVar:IncreaseCost:TargetedObjects$Amount/Minus.1
-A:SP$ Pump | ValidTgts$ Player | TargetMin$ 0 | TargetMax$ MaxPlayer | SubAbility$ DBInvestigate | SpellDescription$ Choose any number of target players.
+A:SP$ Pump | ValidTgts$ Player | TargetMin$ 0 | TargetMax$ MaxPlayers | SubAbility$ DBInvestigate | SpellDescription$ Choose any number of target players.
 SVar:DBInvestigate:DB$ Investigate | Num$ X | SpellDescription$ Investigate X times, where X is the total number of creatures those players control.
-SVar:MaxPlayer:PlayerCountPlayers$Amount
+SVar:MaxPlayers:PlayerCountPlayers$Amount
 SVar:X:Count$Valid Creature.TargetedPlayerCtrl
 DeckHas:Ability$Token & Type$Artifact|Clue
 Oracle:This spell costs {W}{U} more to cast for each target beyond the first.\nChoose any number of target players. Investigate X times, where X is the total number of creatures those players control.

--- a/forge-gui/res/cardsfolder/r/rolling_thunder.txt
+++ b/forge-gui/res/cardsfolder/r/rolling_thunder.txt
@@ -2,7 +2,7 @@ Name:Rolling Thunder
 ManaCost:X R R
 Types:Sorcery
 A:SP$ DealDamage | Cost$ X R R | ValidTgts$ Any | TgtPrompt$ Select any number of targets to distribute damage to | NumDmg$ X | TargetMin$ 0 | TargetMax$ MaxTgts | DividedAsYouChoose$ X | SpellDescription$ CARDNAME deals X damage divided as you choose among any number of targets.
-SVar:MaxTgts:PlayerCountPlayers$Amount/Plus.NumCreaturesAndPlaneswalkers
-SVar:NumCreaturesAndPlaneswalkers:Count$Valid Any
+SVar:MaxTgts:PlayerCountPlayers$Amount/Plus.MaxPermanents
+SVar:MaxPermanents:Count$Valid Any
 SVar:X:Count$xPaid
 Oracle:Rolling Thunder deals X damage divided as you choose among any number of targets.

--- a/forge-gui/res/cardsfolder/s/sacellum_godspeaker.txt
+++ b/forge-gui/res/cardsfolder/s/sacellum_godspeaker.txt
@@ -2,8 +2,8 @@ Name:Sacellum Godspeaker
 ManaCost:2 G
 Types:Creature Elf Druid
 PT:2/2
-A:AB$ Reveal | Cost$ T | RevealValid$ Creature.powerGE5+YouCtrl | AnyNumber$ True | RememberRevealed$ True | SubAbility$ DBspeakerMana | SpellDescription$ Reveal any number of creature cards with power 5 or greater from your hand. Add {G} for each card revealed this way.
-SVar:DBspeakerMana:DB$ Mana | Produced$ G | Amount$ X | SubAbility$ DBCleanup
+A:AB$ Reveal | Cost$ T | RevealValid$ Creature.powerGE5+YouCtrl | AnyNumber$ True | RememberRevealed$ True | SubAbility$ DBSpeakerMana | SpellDescription$ Reveal any number of creature cards with power 5 or greater from your hand. Add {G} for each card revealed this way.
+SVar:DBSpeakerMana:DB$ Mana | Produced$ G | Amount$ X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Remembered$Amount
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/s/serras_hymn.txt
+++ b/forge-gui/res/cardsfolder/s/serras_hymn.txt
@@ -5,7 +5,7 @@ T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | O
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ VERSE | CounterNum$ 1
 A:AB$ PreventDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Any | TgtPrompt$ Select any target to prevent damage to | Amount$ X | TargetMin$ 0 | TargetMax$ MaxTgts | DividedAsYouChoose$ X | SpellDescription$ Prevent the next X damage that would be dealt this turn to any number of targets, divided as you choose, where X is the number of verse counters on CARDNAME.
 SVar:X:Count$CardCounters.VERSE
-SVar:MaxTgts:PlayerCountPlayers$Amount/Plus.NumCreatures
-SVar:NumCreatures:Count$Valid Any
+SVar:MaxTgts:PlayerCountPlayers$Amount/Plus.MaxPermanents
+SVar:MaxPermanents:Count$Valid Any
 AI:RemoveDeck:All
 Oracle:At the beginning of your upkeep, you may put a verse counter on Serra's Hymn.\nSacrifice Serra's Hymn: Prevent the next X damage that would be dealt this turn to any number of targets, divided as you choose, where X is the number of verse counters on Serra's Hymn.

--- a/forge-gui/res/cardsfolder/s/soulfire_eruption.txt
+++ b/forge-gui/res/cardsfolder/s/soulfire_eruption.txt
@@ -7,8 +7,8 @@ SVar:DBDealDamage:DB$ DealDamage | Defined$ Remembered | NumDmg$ X | SubAbility$
 SVar:DBCleanup:DB$ Cleanup | ClearImprinted$ True
 SVar:DBEffect:DB$ Effect | StaticAbilities$ STMayPlay | Duration$ UntilTheEndOfYourNextTurn | RememberObjects$ ValidExile Card.ExiledWithSource | ForgetOnMoved$ Exile
 SVar:STMayPlay:Mode$ Continuous | Affected$ Card.IsRemembered | EffectZone$ Command | AffectedZone$ Exile | MayPlay$ True | Description$ You may play the exiled cards until the end of your next turn.
-SVar:MaxTgt:SVar$MaxPlayers/Plus.MaxPermanents
+SVar:MaxTgt:SVar$MaxPlayers/Plus.MaxCreaturesAndPW
 SVar:MaxPlayers:PlayerCountPlayers$Amount
-SVar:MaxPermanents:Count$Valid Creature,Planeswalker
+SVar:MaxCreaturesAndPW:Count$Valid Creature,Planeswalker
 SVar:X:Imprinted$CardManaCost
 Oracle:Choose any number of target creatures, planeswalkers, and/or players. For each of them, exile the top card of your library, then Soulfire Eruption deals damage equal to that card's mana value to that permanent or player. You may play the exiled cards until the end of your next turn.

--- a/forge-gui/res/cardsfolder/s/soulfire_eruption.txt
+++ b/forge-gui/res/cardsfolder/s/soulfire_eruption.txt
@@ -7,8 +7,8 @@ SVar:DBDealDamage:DB$ DealDamage | Defined$ Remembered | NumDmg$ X | SubAbility$
 SVar:DBCleanup:DB$ Cleanup | ClearImprinted$ True
 SVar:DBEffect:DB$ Effect | StaticAbilities$ STMayPlay | Duration$ UntilTheEndOfYourNextTurn | RememberObjects$ ValidExile Card.ExiledWithSource | ForgetOnMoved$ Exile
 SVar:STMayPlay:Mode$ Continuous | Affected$ Card.IsRemembered | EffectZone$ Command | AffectedZone$ Exile | MayPlay$ True | Description$ You may play the exiled cards until the end of your next turn.
-SVar:MaxTgt:SVar$MaxPl/Plus.MaxPerm
-SVar:MaxPl:PlayerCountPlayers$Amount
-SVar:MaxPerm:Count$Valid Creature,Planeswalker
+SVar:MaxTgt:SVar$MaxPlayers/Plus.MaxPermanents
+SVar:MaxPlayers:PlayerCountPlayers$Amount
+SVar:MaxPermanents:Count$Valid Creature,Planeswalker
 SVar:X:Imprinted$CardManaCost
 Oracle:Choose any number of target creatures, planeswalkers, and/or players. For each of them, exile the top card of your library, then Soulfire Eruption deals damage equal to that card's mana value to that permanent or player. You may play the exiled cards until the end of your next turn.

--- a/forge-gui/res/cardsfolder/s/subversive_acolyte.txt
+++ b/forge-gui/res/cardsfolder/s/subversive_acolyte.txt
@@ -11,4 +11,4 @@ SVar:DamageSac:Mode$ DamageDoneOnce | ValidTarget$ Card.Self | Execute$ TrigSac 
 SVar:TrigSac:DB$ Sacrifice | Amount$ X | SacValid$ Permanent
 SVar:X:TriggerCount$DamageAmount
 DeckHas:Ability$LifeGain|Sacrifice & Type$Cleric|Phyrexian
-Oracle:{2}, Pay 2 life: Choose one. Activate only once.\n• Subversive Acolyte becomes a Human Cleric. It gets +1/+1 and gains lifelink.\n•Subversive Acolyte becomes a Phyrexian. It gets +3/+2 and gains trample and "Whenever this creature is dealt damage, sacrifice that many permanents."
+Oracle:{2}, Pay 2 life: Choose one. Activate only once.\n• Subversive Acolyte becomes a Human Cleric. It gets +1/+1 and gains lifelink.\n• Subversive Acolyte becomes a Phyrexian. It gets +3/+2 and gains trample and "Whenever this creature is dealt damage, sacrifice that many permanents."

--- a/forge-gui/res/cardsfolder/t/the_fourth_doctor.txt
+++ b/forge-gui/res/cardsfolder/t/the_fourth_doctor.txt
@@ -3,10 +3,10 @@ ManaCost:2 G U
 Types:Legendary Creature Time Lord Doctor
 PT:4/4
 S:Mode$ Continuous | Affected$ Card.YouOwn+TopLibrary | EffectZone$ Battlefield | AffectedZone$ Library | MayLookAt$ You | Description$ You may look at the top card of your library any time.
-S:Mode$ Continuous | Affected$ Card.TopLibrary+YouCtrl+Historic | MayPlay$ True | MayPlayLimit$ 1 | EffectZone$ Battlefield | AffectedZone$ Library | Description$ Would You Like A…? — Once each turn, you may play a historic land or cast a historic spell from the top of your library. When you do, create a Food token. (Artifacts, legendaries, and Sagas are historic.)
+S:Mode$ Continuous | Affected$ Card.TopLibrary+YouCtrl+Historic | MayPlay$ True | MayPlayLimit$ 1 | EffectZone$ Battlefield | AffectedZone$ Library | Description$ Would You Like A . . . ? — Once each turn, you may play a historic land or cast a historic spell from the top of your library. When you do, create a Food token. (Artifacts, legendaries, and Sagas are historic.)
 T:Mode$ SpellCast | ValidCard$ Card | ValidSA$ Spell.MayPlaySource | Execute$ TrigFood | Secondary$ True | TriggerZones$ Battlefield | TriggerDescription$ When you do, create a Food token.
 T:Mode$ LandPlayed | ValidCard$ Land | ValidSA$ SpellAbility.MayPlaySource | TriggerZones$ Battlefield | Execute$ TrigFood | Secondary$ True | TriggerDescription$ When you do, create a Food token.
 SVar:TrigFood:DB$ Token | TokenAmount$ 1 | TokenScript$ c_a_food_sac | TokenOwner$ You
 DeckHints:Type$Artifact|Legendary|Saga
 DeckHas:Ability$Token|Sacrifice & Type$Food|Artifact
-Oracle:You may look at the top card of your library any time.\nWould You Like A…? — Once each turn, you may play a historic land or cast a historic spell from the top of your library. When you do, create a Food token. (Artifacts, legendaries, and Sagas are historic.)
+Oracle:You may look at the top card of your library any time.\nWould You Like A . . . ? — Once each turn, you may play a historic land or cast a historic spell from the top of your library. When you do, create a Food token. (Artifacts, legendaries, and Sagas are historic.)

--- a/forge-gui/res/cardsfolder/w/wand_of_the_worldsoul.txt
+++ b/forge-gui/res/cardsfolder/w/wand_of_the_worldsoul.txt
@@ -3,8 +3,8 @@ ManaCost:2 W
 Types:Artifact
 K:CARDNAME enters the battlefield tapped.
 A:AB$ Mana | Cost$ T | Produced$ W | SpellDescription$ Add {W}.
-A:AB$ Effect | Cost$ T | StaticAbilities$ GrandConvoke | Triggers$ ExileEffect | SpellDescription$ The next spell you cast this turn has convoke.
-SVar:GrandConvoke:Mode$ Continuous | EffectZone$ Command | Affected$ Card.YouCtrl | AffectedZone$ Stack | AddKeyword$ Convoke | Description$ The next spell you cast this turn has convoke.
+A:AB$ Effect | Cost$ T | StaticAbilities$ GrantConvoke | Triggers$ ExileEffect | SpellDescription$ The next spell you cast this turn has convoke.
+SVar:GrantConvoke:Mode$ Continuous | EffectZone$ Command | Affected$ Card.YouCtrl | AffectedZone$ Stack | AddKeyword$ Convoke | Description$ The next spell you cast this turn has convoke.
 SVar:ExileEffect:Mode$ SpellCast | EffectZone$ Command | ValidCard$ Card.YouCtrl | Execute$ RemoveEffect | Static$ True
 SVar:RemoveEffect:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self
 Oracle:Wand of the Worldsoul enters the battlefield tapped.\n{T}: Add {W}.\n{T}: The next spell you cast this turn has convoke.

--- a/forge-gui/res/cardsfolder/w/woeleecher.txt
+++ b/forge-gui/res/cardsfolder/w/woeleecher.txt
@@ -3,7 +3,7 @@ ManaCost:5 W
 Types:Creature Elemental
 PT:3/5
 A:AB$ RemoveCounter | Cost$ W T | ValidTgts$ Creature | AITgts$ Creature.counters_GE1_M1M1 | TgtPrompt$ Select target creature | CounterType$ M1M1 | CounterNum$ 1 | RememberRemoved$ True | SubAbility$ DBGainLife | SpellDescription$ Remove a -1/-1 counter from target creature. If you do, you gain 2 life.
-SVar:DBGainLife:DB$ GainLife | LifeAmount$ 2 | ConditionCheckSVar$ X | ConditonSVarCompare$ GE1 | SubAbility$ DBCleanup
+SVar:DBGainLife:DB$ GainLife | LifeAmount$ 2 | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Count$RememberedSize
 DeckHas:Ability$LifeGain

--- a/forge-gui/res/cardsfolder/w/wurmquake.txt
+++ b/forge-gui/res/cardsfolder/w/wurmquake.txt
@@ -7,5 +7,5 @@ SVar:X:Count$CastTotalManaSpent
 SVar:Y:PlayerCountOpponents$HasPropertyIsCorrupted
 K:Flashback:8 G G
 DeckHas:Ability$Token|Graveyard & Type$Phyrexian|Wurm & Keyword$Toxic
-DeckHints:Keyword$Toxic|Poisenous
+DeckHints:Keyword$Toxic|Poisonous
 Oracle:Corrupted — Create an X/X green Phyrexian Wurm creature token with trample and toxic 1, where X is the amount of mana spent to cast this spell. Then for each opponent with three or more poison counters, you create another one of those tokens.\nFlashback {8}{G}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)


### PR DESCRIPTION
Here's some stragglers that escaped the last typo cleanup ( https://github.com/Card-Forge/forge/pull/5036 ). I also took the opportunity to do some minor standardization of `SVar` items: a few rare ones that referred to the same concept under different aliases.

If the change to [The Fourth Doctor](https://scryfall.com/card/who/2/the-fourth-doctor) is curious it's because I'm following the standard set by ["Ach! Hans, Run!"](https://scryfall.com/card/unh/116/ach!-hans-run!) on how an ellipsis is displayed in a Magic card text box.