### PR TITLE
Resolving ValidDesc$ vs ValidDescription$

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/ChooseCardNameEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChooseCardNameEffect.java
@@ -45,7 +45,7 @@ public class ChooseCardNameEffect extends SpellAbilityEffect {
 
         if (sa.hasParam("ValidCards")) {
             valid = sa.getParam("ValidCards");
-            validDesc = sa.getParam("ValidDesc");
+            validDesc = sa.getParam("ValidDescription");
         }
 
         boolean randomChoice = sa.hasParam("AtRandom");

--- a/forge-gui/res/cardsfolder/a/academic_probation.txt
+++ b/forge-gui/res/cardsfolder/a/academic_probation.txt
@@ -2,7 +2,7 @@ Name:Academic Probation
 ManaCost:1 W
 Types:Sorcery Lesson
 A:SP$ Charm | Cost$ 1 W | Choices$ DBNameCard,DBPump
-SVar:DBNameCard:DB$ NameCard | Defined$ You | ValidCards$ Card.nonLand | ValidDesc$ nonland | SubAbility$ DBEffect | SpellDescription$ Choose a nonland card name. Until your next turn, your opponents can't cast spells with the chosen name.
+SVar:DBNameCard:DB$ NameCard | Defined$ You | ValidCards$ Card.nonLand | ValidDescription$ nonland | SubAbility$ DBEffect | SpellDescription$ Choose a nonland card name. Until your next turn, your opponents can't cast spells with the chosen name.
 SVar:DBEffect:DB$ Effect | StaticAbilities$ CantCast | Duration$ UntilYourNextTurn
 SVar:CantCast:Mode$ CantBeCast | ValidCard$ Card.nonLand+NamedCard | Caster$ Opponent | EffectZone$ Command | Description$ Your opponents can't cast spells with the chosen name.
 SVar:DBPump:DB$ Pump | ValidTgts$ Permanent.nonLand | TgtPrompt$ Choose target nonland permanent | KW$ HIDDEN CARDNAME can't attack or block. & HIDDEN CARDNAME's activated abilities can't be activated. | IsCurse$ True | Duration$ UntilYourNextTurn | AILogic$ DetainNonLand | SpellDescription$ Choose target nonland permanent. Until your next turn, it can't attack or block, and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/a/ach_hans_run.txt
+++ b/forge-gui/res/cardsfolder/a/ach_hans_run.txt
@@ -2,7 +2,7 @@ Name:"Ach! Hans, Run!"
 ManaCost:2 R R G G
 Types:Enchantment
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigAch | TriggerDescription$ At the beginning of your upkeep, you may say "Ach! Hans, run! It's the . . ." and the name of a creature card. If you do, search your library for a card with that name, put it onto the battlefield, then shuffle your library. That creature gains haste. Exile it at the beginning of the next end step.
-SVar:TrigAch:DB$ NameCard | Defined$ You | ValidCards$ Card.Creature | ValidDesc$ creature | SubAbility$ DBSearch | SpellDescription$ You may say "Ach! Hans, run! It's the . . ." and the name of a creature card. If you do, search your library for a card with that name, put it onto the battlefield, then shuffle your library. That creature gains haste. Exile it at the beginning of the next end step.
+SVar:TrigAch:DB$ NameCard | Defined$ You | ValidCards$ Card.Creature | ValidDescription$ creature | SubAbility$ DBSearch | SpellDescription$ You may say "Ach! Hans, run! It's the . . ." and the name of a creature card. If you do, search your library for a card with that name, put it onto the battlefield, then shuffle your library. That creature gains haste. Exile it at the beginning of the next end step.
 SVar:DBSearch:DB$ ChangeZone | Origin$ Library | Destination$ Battlefield | ChangeType$ Card.NamedCard | RememberChanged$ True | SubAbility$ DBPump
 SVar:DBPump:DB$ Animate | Keywords$ Haste | Duration$ Permanent | AtEOT$ Exile | Defined$ Remembered | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearNamedCard$ True

--- a/forge-gui/res/cardsfolder/a/alpine_moon.txt
+++ b/forge-gui/res/cardsfolder/a/alpine_moon.txt
@@ -2,7 +2,7 @@ Name:Alpine Moon
 ManaCost:R
 Types:Enchantment
 K:ETBReplacement:Other:DBNameCard
-SVar:DBNameCard:DB$ NameCard | Defined$ You | ValidCards$ Card.Land+nonBasic | ValidDesc$ nonbasic land | SpellDescription$ As CARDNAME enters the battlefield, choose a nonbasic land card name.
+SVar:DBNameCard:DB$ NameCard | Defined$ You | ValidCards$ Card.Land+nonBasic | ValidDescription$ nonbasic land | SpellDescription$ As CARDNAME enters the battlefield, choose a nonbasic land card name.
 S:Mode$ Continuous | Affected$ Land.NamedCard+OppCtrl | RemoveAllAbilities$ True | RemoveLandTypes$ True | AddAbility$ ABMana | Description$ Lands your opponents control with the chosen name lose all land types and abilities, and they gain "{T}: Add one mana of any color."
 SVar:ABMana:AB$ Mana | Cost$ T | Produced$ Any | Amount$ 1 | SpellDescription$ Add one mana of any color.
 Oracle:As Alpine Moon enters the battlefield, choose a nonbasic land card name.\nLands your opponents control with the chosen name lose all land types and abilities, and they gain "{T}: Add one mana of any color."

--- a/forge-gui/res/cardsfolder/a/anzrags_rampage.txt
+++ b/forge-gui/res/cardsfolder/a/anzrags_rampage.txt
@@ -1,7 +1,7 @@
 Name:Anzrag's Rampage
 ManaCost:3 R R
 Types:Sorcery
-A:SP$ DestroyAll | ValidCards$ Artifact.YouDontCtrl | ValidDesc$ artifacts you don't control | SubAbility$ DBDig | SpellDescription$ Destroy all artifacts you don't control, then exile the top X cards of your library, where X is the number of artifacts that were put into graveyards from the battlefield this turn.
+A:SP$ DestroyAll | ValidCards$ Artifact.YouDontCtrl | ValidDescription$ artifacts you don't control | SubAbility$ DBDig | SpellDescription$ Destroy all artifacts you don't control, then exile the top X cards of your library, where X is the number of artifacts that were put into graveyards from the battlefield this turn.
 SVar:DBDig:DB$ Dig | DigNum$ X | ChangeNum$ All | ChangeValid$ Card | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBChangeZone
 SVar:DBChangeZone:DB$ ChangeZone | Origin$ Exile | Destination$ Battlefield | Imprint$ True | ChangeType$ Creature.IsRemembered | Hidden$ True | Optional$ True | ChangeNum$ 1 | SubAbility$ DBAnimate | SpellDescription$ You may put a creature card exiled this way onto the battlefield. It gains haste. Return it to your hand at the beginning of the next end step.
 SVar:DBAnimate:DB$ Animate | Keywords$ Haste | Duration$ Permanent | Defined$ Imprinted | SubAbility$ DBCleanup | AtEOT$ Hand

--- a/forge-gui/res/cardsfolder/b/booby_trap.txt
+++ b/forge-gui/res/cardsfolder/b/booby_trap.txt
@@ -2,7 +2,7 @@ Name:Booby Trap
 ManaCost:6
 Types:Artifact
 K:ETBReplacement:Other:DBNameCard
-SVar:DBNameCard:DB$ NameCard | Defined$ You | ValidCards$ Card.nonBasic | ValidDesc$ card other than a basic land | SubAbility$ ChooseP | SpellDescription$ As CARDNAME enters the battlefield, choose an opponent and a card name other than a basic land card name.
+SVar:DBNameCard:DB$ NameCard | Defined$ You | ValidCards$ Card.nonBasic | ValidDescription$ card other than a basic land | SubAbility$ ChooseP | SpellDescription$ As CARDNAME enters the battlefield, choose an opponent and a card name other than a basic land card name.
 SVar:ChooseP:DB$ ChoosePlayer | Defined$ You | Choices$ Opponent | AILogic$ Curse
 R:Event$ Draw | ActiveZones$ Battlefield | ValidPlayer$ Player.Chosen | ReplaceWith$ RevealedDraw | Description$ The chosen player reveals each card they draw.
 SVar:RevealedDraw:DB$ Draw | Defined$ Player.Chosen | NumCards$ 1 | SubAbility$ TrigReveal | RememberDrawn$ True

--- a/forge-gui/res/cardsfolder/b/brain_pry.txt
+++ b/forge-gui/res/cardsfolder/b/brain_pry.txt
@@ -1,7 +1,7 @@
 Name:Brain Pry
 ManaCost:1 B
 Types:Sorcery
-A:SP$ NameCard | Cost$ 1 B | Defined$ You | ValidCards$ Card.nonLand | ValidDesc$ nonland | SubAbility$ RevealHand | SpellDescription$ Choose a nonland card name. Target player reveals their hand. That player discards a card with that name. If they can't, you draw a card.
+A:SP$ NameCard | Cost$ 1 B | Defined$ You | ValidCards$ Card.nonLand | ValidDescription$ nonland | SubAbility$ RevealHand | SpellDescription$ Choose a nonland card name. Target player reveals their hand. That player discards a card with that name. If they can't, you draw a card.
 SVar:RevealHand:DB$ RevealHand | RememberRevealed$ True | ValidTgts$ Player | TgtPrompt$ Select target player | SubAbility$ DBDiscard
 SVar:DBDiscard:DB$ Discard | Defined$ Targeted | NumCards$ 1 | Mode$ TgtChoose | DiscardValid$ Card.NamedCard | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1 | ConditionDefined$ Remembered | ConditionPresent$ Card.NamedCard | ConditionCompare$ EQ0 | SubAbility$ DBCleanup

--- a/forge-gui/res/cardsfolder/c/cabal_therapist.txt
+++ b/forge-gui/res/cardsfolder/c/cabal_therapist.txt
@@ -5,7 +5,7 @@ PT:1/1
 K:Menace
 T:Mode$ Phase | PreCombatMain$ True | ValidPlayer$ You | Execute$ DBImmediateTrigger | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your precombat main phase, you may sacrifice a creature. When you do, choose a nonland card name, then target player reveals their hand and discards all cards with that name.
 SVar:DBImmediateTrigger:AB$ ImmediateTrigger | Execute$ NameCard | TriggerDescription$ You may sacrifice a creature. When you do, choose a nonland card name, then target player reveals their hand and discards all cards with that name. | Cost$ Sac<1/Creature>
-SVar:NameCard:DB$ NameCard | Defined$ You | ValidCards$ Card.nonLand | ValidDesc$ nonland | SubAbility$ DBDiscard | SpellDescription$ Choose a nonland card name. Target player reveals their hand and discards all cards with that name.
+SVar:NameCard:DB$ NameCard | Defined$ You | ValidCards$ Card.nonLand | ValidDescription$ nonland | SubAbility$ DBDiscard | SpellDescription$ Choose a nonland card name. Target player reveals their hand and discards all cards with that name.
 SVar:DBDiscard:DB$ Discard | ValidTgts$ Player | Mode$ RevealDiscardAll | DiscardValid$ Card.NamedCard | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearNamedCard$ True
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/c/cabal_therapy.txt
+++ b/forge-gui/res/cardsfolder/c/cabal_therapy.txt
@@ -2,7 +2,7 @@ Name:Cabal Therapy
 ManaCost:B
 Types:Sorcery
 K:Flashback:Sac<1/Creature>
-A:SP$ NameCard | Cost$ B | Defined$ You | ValidCards$ Card.nonLand | ValidDesc$ nonland | SubAbility$ DBDiscard | SpellDescription$ Choose a nonland card name. Target player reveals their hand and discards all cards with that name.
+A:SP$ NameCard | Cost$ B | Defined$ You | ValidCards$ Card.nonLand | ValidDescription$ nonland | SubAbility$ DBDiscard | SpellDescription$ Choose a nonland card name. Target player reveals their hand and discards all cards with that name.
 SVar:DBDiscard:DB$ Discard | ValidTgts$ Player | TgtPrompt$ Select target player | Mode$ RevealDiscardAll | DiscardValid$ Card.NamedCard
 AI:RemoveDeck:All
 Oracle:Choose a nonland card name. Target player reveals their hand and discards all cards with that name.\nFlashback—Sacrifice a creature. (You may cast this card from your graveyard for its flashback cost. Then exile it.)

--- a/forge-gui/res/cardsfolder/c/coercive_portal.txt
+++ b/forge-gui/res/cardsfolder/c/coercive_portal.txt
@@ -4,6 +4,6 @@ Types:Artifact
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ TrigVote | TriggerZones$ Battlefield | TriggerDescription$ Will of the Council — At the beginning of your upkeep, starting with you, each player votes for carnage or homage. If carnage gets more votes, sacrifice CARDNAME and destroy all nonland permanents. If homage gets more votes or the vote is tied, draw a card.
 SVar:TrigVote:DB$ Vote | Defined$ Player | VoteCarnage$ DBDestroyAll | VoteHomage$ DBDraw | Tied$ DBDraw | VoteType$ Carnage,Homage | AILogic$ CarnageOrHomage
 SVar:DBDestroyAll:DB$ Sacrifice | SacValid$ Self | SubAbility$ DBDestroy
-SVar:DBDestroy:DB$ DestroyAll | ValidCards$ Permanent.nonLand | ValidDesc$ all nonland permanents
+SVar:DBDestroy:DB$ DestroyAll | ValidCards$ Permanent.nonLand | ValidDescription$ all nonland permanents
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | Defined$ You
 Oracle:Will of the council — At the beginning of your upkeep, starting with you, each player votes for carnage or homage. If carnage gets more votes, sacrifice Coercive Portal and destroy all nonland permanents. If homage gets more votes or the vote is tied, draw a card.

--- a/forge-gui/res/cardsfolder/c/council_of_the_absolute.txt
+++ b/forge-gui/res/cardsfolder/c/council_of_the_absolute.txt
@@ -3,7 +3,7 @@ ManaCost:2 W U
 Types:Creature Human Advisor
 PT:2/4
 K:ETBReplacement:Other:DBNameCard
-SVar:DBNameCard:DB$ NameCard | Defined$ You | ValidCards$ Card.nonLand+nonCreature | ValidDesc$ Choose a noncreature, nonland card name. | SpellDescription$ As CARDNAME enters the battlefield, choose a noncreature, nonland card name.
+SVar:DBNameCard:DB$ NameCard | Defined$ You | ValidCards$ Card.nonLand+nonCreature | ValidDescription$ Choose a noncreature, nonland card name. | SpellDescription$ As CARDNAME enters the battlefield, choose a noncreature, nonland card name.
 S:Mode$ CantBeCast | ValidCard$ Card.NamedCard | Caster$ Player.Opponent | Description$ Your opponents can't cast cards with the chosen name.
 S:Mode$ ReduceCost | ValidCard$ Card.NamedCard | Type$ Spell | Activator$ You | Amount$ 2 | Description$ Spells with the chosen name you cast cost {2} less to cast.
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/c/cranial_extraction.txt
+++ b/forge-gui/res/cardsfolder/c/cranial_extraction.txt
@@ -1,7 +1,7 @@
 Name:Cranial Extraction
 ManaCost:3 B
 Types:Sorcery Arcane
-A:SP$ NameCard | Cost$ 3 B | Defined$ You | ValidCards$ Card.nonLand | ValidDesc$ nonland | SubAbility$ ExileYard | SpellDescription$ Choose a nonland card name. Search target player's graveyard, hand, and library for all cards with that name and exile them. Then that player shuffles.
+A:SP$ NameCard | Cost$ 3 B | Defined$ You | ValidCards$ Card.nonLand | ValidDescription$ nonland | SubAbility$ ExileYard | SpellDescription$ Choose a nonland card name. Search target player's graveyard, hand, and library for all cards with that name and exile them. Then that player shuffles.
 SVar:ExileYard:DB$ ChangeZoneAll | Origin$ Graveyard | Destination$ Exile | ValidTgts$ Player | TgtPrompt$ Select target player | ChangeType$ Card.NamedCard | SubAbility$ ExileHand | StackDescription$ None
 SVar:ExileHand:DB$ ChangeZone | Origin$ Hand | Destination$ Exile | DefinedPlayer$ Targeted | ChangeType$ Card.NamedCard | ChangeNum$ NumInHand | Chooser$ You | SubAbility$ ExileLib | StackDescription$ None
 SVar:ExileLib:DB$ ChangeZone | Origin$ Library | Destination$ Exile | DefinedPlayer$ Targeted | ChangeType$ Card.NamedCard | ChangeNum$ NumInLib | Chooser$ You | Search$ True | Shuffle$ True | SubAbility$ DBCleanup | StackDescription$ None

--- a/forge-gui/res/cardsfolder/d/day_of_the_moon.txt
+++ b/forge-gui/res/cardsfolder/d/day_of_the_moon.txt
@@ -2,6 +2,6 @@ Name:Day of the Moon
 ManaCost:2 R
 Types:Enchantment Saga
 K:Chapter:3:DBChoose,DBChoose,DBChoose
-SVar:DBChoose:DB$ NameCard | ValidCards$ Creature | ValidDesc$ creature | SubAbility$ DBGoad | SpellDescription$ Choose a creature card name, then goad all creatures with a name chosen for CARDNAME. (Until your next turn, they attack each combat if able and attack a player other than you if able.)
+SVar:DBChoose:DB$ NameCard | ValidCards$ Creature | ValidDescription$ creature | SubAbility$ DBGoad | SpellDescription$ Choose a creature card name, then goad all creatures with a name chosen for CARDNAME. (Until your next turn, they attack each combat if able and attack a player other than you if able.)
 SVar:DBGoad:DB$ Goad | Defined$ Valid Creature.NamedCard
 Oracle:(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II, III — Choose a creature card name, then goad all creatures with a name chosen for Day of the Moon. (Until your next turn, they attack each combat if able and attack a player other than you if able.)

--- a/forge-gui/res/cardsfolder/d/desperate_research.txt
+++ b/forge-gui/res/cardsfolder/d/desperate_research.txt
@@ -1,7 +1,7 @@
 Name:Desperate Research
 ManaCost:1 B
 Types:Sorcery
-A:SP$ NameCard | Cost$ 1 B | Defined$ You | ValidCards$ Card.nonBasic | ValidDesc$ card other than a basic land | SubAbility$ DBDig | SpellDescription$ Choose a card name other than a basic land card name. Reveal the top seven cards of your library and put all of them with that name into your hand. Exile the rest.
+A:SP$ NameCard | Cost$ 1 B | Defined$ You | ValidCards$ Card.nonBasic | ValidDescription$ card other than a basic land | SubAbility$ DBDig | SpellDescription$ Choose a card name other than a basic land card name. Reveal the top seven cards of your library and put all of them with that name into your hand. Exile the rest.
 SVar:DBDig:DB$ Dig | DigNum$ 7 | Reveal$ True | DestinationZone2$ Exile | ChangeValid$ Card.NamedCard | ChangeNum$ All
 AI:RemoveDeck:All
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/d/dispossess.txt
+++ b/forge-gui/res/cardsfolder/d/dispossess.txt
@@ -1,7 +1,7 @@
 Name:Dispossess
 ManaCost:2 B
 Types:Sorcery
-A:SP$ NameCard | Cost$ 2 B | Defined$ You | ValidCards$ Card.Artifact | ValidDesc$ nonland | SubAbility$ ExileYard | SpellDescription$ Choose an artifact card name. Search target opponent's graveyard, hand, and library for any number of cards with the chosen name and exile them. Then that player shuffles.
+A:SP$ NameCard | Cost$ 2 B | Defined$ You | ValidCards$ Card.Artifact | ValidDescription$ nonland | SubAbility$ ExileYard | SpellDescription$ Choose an artifact card name. Search target opponent's graveyard, hand, and library for any number of cards with the chosen name and exile them. Then that player shuffles.
 SVar:ExileYard:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | ValidTgts$ Player | TgtPrompt$ Select target player | ChangeType$ Card.NamedCard | Chooser$ You | ChangeNum$ NumInYard | Hidden$ True | SubAbility$ ExileHand
 SVar:ExileHand:DB$ ChangeZone | Origin$ Hand | Destination$ Exile | DefinedPlayer$ Targeted | ChangeType$ Card.NamedCard | ChangeNum$ NumInHand | Chooser$ You | SubAbility$ ExileLib
 SVar:ExileLib:DB$ ChangeZone | Origin$ Library | Destination$ Exile | DefinedPlayer$ Targeted | ChangeType$ Card.NamedCard | ChangeNum$ NumInLib | Chooser$ You | Shuffle$ True

--- a/forge-gui/res/cardsfolder/i/infinite_obliteration.txt
+++ b/forge-gui/res/cardsfolder/i/infinite_obliteration.txt
@@ -1,7 +1,7 @@
 Name:Infinite Obliteration
 ManaCost:1 B B
 Types:Sorcery
-A:SP$ NameCard | Cost$ 1 B B | Defined$ You | ValidCards$ Creature | ValidDesc$ creature | SubAbility$ ExileYard | SpellDescription$ Choose a creature card name. Search target opponent's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles.
+A:SP$ NameCard | Cost$ 1 B B | Defined$ You | ValidCards$ Creature | ValidDescription$ creature | SubAbility$ ExileYard | SpellDescription$ Choose a creature card name. Search target opponent's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles.
 SVar:ExileYard:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | ValidTgts$ Player.Opponent | TgtPrompt$ Select target opponent | ChangeType$ Card.NamedCard | Chooser$ You | ChangeNum$ NumInYard | Hidden$ True | SubAbility$ ExileHand | StackDescription$ Search target opponent's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles their library.
 SVar:ExileHand:DB$ ChangeZone | Origin$ Hand | Destination$ Exile | DefinedPlayer$ Targeted | ChangeType$ Card.NamedCard | ChangeNum$ NumInHand | Chooser$ You | SubAbility$ ExileLib | StackDescription$ None
 SVar:ExileLib:DB$ ChangeZone | Origin$ Library | Destination$ Exile | DefinedPlayer$ Targeted | ChangeType$ Card.NamedCard | ChangeNum$ NumInLib | Chooser$ You | Shuffle$ True | StackDescription$ None

--- a/forge-gui/res/cardsfolder/l/lost_legacy.txt
+++ b/forge-gui/res/cardsfolder/l/lost_legacy.txt
@@ -1,7 +1,7 @@
 Name:Lost Legacy
 ManaCost:1 B B
 Types:Sorcery
-A:SP$ NameCard | Cost$ 1 B B | Defined$ You | ValidCards$ Card.nonLand+nonArtifact | ValidDesc$ nonartifact, nonland | SubAbility$ ExileHand | SpellDescription$ Choose a nonartifact, nonland card name. Search target player's graveyard, hand, and library for any number of cards with that name and exile them. That player shuffles, then draws a card for each card exiled from their hand this way. | StackDescription$ SpellDescription
+A:SP$ NameCard | Cost$ 1 B B | Defined$ You | ValidCards$ Card.nonLand+nonArtifact | ValidDescription$ nonartifact, nonland | SubAbility$ ExileHand | SpellDescription$ Choose a nonartifact, nonland card name. Search target player's graveyard, hand, and library for any number of cards with that name and exile them. That player shuffles, then draws a card for each card exiled from their hand this way. | StackDescription$ SpellDescription
 SVar:ExileHand:DB$ ChangeZone | ValidTgts$ Player | TgtPrompt$ Select target player | RememberTargets$ True | Origin$ Hand | Destination$ Exile | DefinedPlayer$ TargetedPlayer | ChangeType$ Card.NamedCard | ChangeNum$ NumInHand | Chooser$ You | SubAbility$ ExileLib | RememberChanged$ True | StackDescription$ None
 SVar:ExileLib:DB$ ChangeZone | Origin$ Library | Destination$ Exile | DefinedPlayer$ TargetedPlayer | ChangeType$ Card.NamedCard | ChangeNum$ NumInLib | Chooser$ You | Shuffle$ True | SubAbility$ ExileYard | StackDescription$ None
 SVar:ExileYard:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | DefinedPlayer$ TargetedPlayer | ChangeType$ Card.NamedCard | ChangeNum$ NumInYard | Chooser$ You | Hidden$ True | SubAbility$ Draw | StackDescription$ None

--- a/forge-gui/res/cardsfolder/m/meddling_mage.txt
+++ b/forge-gui/res/cardsfolder/m/meddling_mage.txt
@@ -3,7 +3,7 @@ ManaCost:W U
 Types:Creature Human Wizard
 PT:2/2
 K:ETBReplacement:Other:DBNameCard
-SVar:DBNameCard:DB$ NameCard | Defined$ You | ValidCards$ Card.nonLand | ValidDesc$ nonland | SpellDescription$ As CARDNAME enters the battlefield, choose a nonland card name.
+SVar:DBNameCard:DB$ NameCard | Defined$ You | ValidCards$ Card.nonLand | ValidDescription$ nonland | SpellDescription$ As CARDNAME enters the battlefield, choose a nonland card name.
 S:Mode$ CantBeCast | ValidCard$ Card.NamedCard | Description$ Spells with the chosen name can't be cast.
 AI:RemoveDeck:Random
 Oracle:As Meddling Mage enters the battlefield, choose a nonland card name.\nSpells with the chosen name can't be cast.

--- a/forge-gui/res/cardsfolder/m/memoricide.txt
+++ b/forge-gui/res/cardsfolder/m/memoricide.txt
@@ -1,7 +1,7 @@
 Name:Memoricide
 ManaCost:3 B
 Types:Sorcery
-A:SP$ NameCard | Cost$ 3 B | Defined$ You | ValidCards$ Card.nonLand | ValidDesc$ nonland | SubAbility$ ExileYard | SpellDescription$ Choose a nonland card name. Search target player's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles.
+A:SP$ NameCard | Cost$ 3 B | Defined$ You | ValidCards$ Card.nonLand | ValidDescription$ nonland | SubAbility$ ExileYard | SpellDescription$ Choose a nonland card name. Search target player's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles.
 SVar:ExileYard:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | ValidTgts$ Player | TgtPrompt$ Select target player | ChangeType$ Card.NamedCard | Chooser$ You | ChangeNum$ NumInYard | Hidden$ True | SubAbility$ ExileHand | StackDescription$ Choose a nonland card name. Search target player's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles.
 SVar:ExileHand:DB$ ChangeZone | Origin$ Hand | Destination$ Exile | DefinedPlayer$ Targeted | ChangeType$ Card.NamedCard | ChangeNum$ NumInHand | Chooser$ You | SubAbility$ ExileLib | StackDescription$ None
 SVar:ExileLib:DB$ ChangeZone | Origin$ Library | Destination$ Exile | DefinedPlayer$ Targeted | ChangeType$ Card.NamedCard | ChangeNum$ NumInLib | Chooser$ You | Search$ True | Shuffle$ True | StackDescription$ None

--- a/forge-gui/res/cardsfolder/m/mindblaze.txt
+++ b/forge-gui/res/cardsfolder/m/mindblaze.txt
@@ -1,7 +1,7 @@
 Name:Mindblaze
 ManaCost:5 R
 Types:Sorcery
-A:SP$ NameCard | ValidCards$ Card.nonLand | ValidDesc$ nonland | SubAbility$ DBChooseNumber | SpellDescription$ Choose a nonland card name and a number greater than 0. Target player reveals their library. If that library contains exactly the chosen number of cards with the chosen name, CARDNAME deals 8 damage to that player. Then that player shuffles their library.
+A:SP$ NameCard | ValidCards$ Card.nonLand | ValidDescription$ nonland | SubAbility$ DBChooseNumber | SpellDescription$ Choose a nonland card name and a number greater than 0. Target player reveals their library. If that library contains exactly the chosen number of cards with the chosen name, CARDNAME deals 8 damage to that player. Then that player shuffles their library.
 SVar:DBChooseNumber:DB$ ChooseNumber | Min$ 1 | SubAbility$ DBReveal
 SVar:DBReveal:DB$ PeekAndReveal | PeekNum$ X | NoPeek$ True | ValidTgts$ Player | TgtPrompt$ Select target player | RememberRevealed$ True | SubAbility$ DBDamage
 SVar:DBDamage:DB$ DealDamage | NumDmg$ 8 | Defined$ Targeted | ConditionDefined$ Remembered | ConditionPresent$ Card.NamedCard | ConditionCompare$ EQY | SubAbility$ DBShuffle

--- a/forge-gui/res/cardsfolder/m/mise.txt
+++ b/forge-gui/res/cardsfolder/m/mise.txt
@@ -1,7 +1,7 @@
 Name:Mise
 ManaCost:U
 Types:Instant
-A:SP$ NameCard | Cost$ U | Defined$ You | ValidCards$ Card.nonLand | ValidDesc$ nonland | SubAbility$ DBReveal | SpellDescription$ Choose a nonland card name,
+A:SP$ NameCard | Cost$ U | Defined$ You | ValidCards$ Card.nonLand | ValidDescription$ nonland | SubAbility$ DBReveal | SpellDescription$ Choose a nonland card name,
 SVar:DBReveal:DB$ PeekAndReveal | RememberRevealed$ True | SubAbility$ DBDraw | SpellDescription$ then reveal the top card of your library.
 SVar:DBDraw:DB$ Draw | NumCards$ 3 | ConditionDefined$ Remembered | ConditionPresent$ Card.NamedCard | ConditionCompare$ GE1 | SubAbility$ DBCleanup | SpellDescription$ If that card has the chosen name, you draw three cards.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/n/necromentia.txt
+++ b/forge-gui/res/cardsfolder/n/necromentia.txt
@@ -1,7 +1,7 @@
 Name:Necromentia
 ManaCost:1 B B
 Types:Sorcery
-A:SP$ NameCard | Cost$ 1 B B | Defined$ You | ValidCards$ Card.nonBasic | ValidDesc$ card other than a basic land | SubAbility$ ExileYard | StackDescription$ SpellDescription | SpellDescription$ Choose a card name other than a basic land card name. Search target opponent's graveyard, hand, and library for any number of cards with that name and exile them. That player shuffles, then creates a 2/2 black Zombie creature token for each card exiled from their hand this way.
+A:SP$ NameCard | Cost$ 1 B B | Defined$ You | ValidCards$ Card.nonBasic | ValidDescription$ card other than a basic land | SubAbility$ ExileYard | StackDescription$ SpellDescription | SpellDescription$ Choose a card name other than a basic land card name. Search target opponent's graveyard, hand, and library for any number of cards with that name and exile them. That player shuffles, then creates a 2/2 black Zombie creature token for each card exiled from their hand this way.
 SVar:ExileYard:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | ValidTgts$ Player.Opponent | TgtPrompt$ Select target opponent | ChangeType$ Card.NamedCard | Chooser$ You | ChangeNum$ NumInYard | Hidden$ True | SubAbility$ ExileHand | StackDescription$ None
 SVar:ExileHand:DB$ ChangeZone | Origin$ Hand | Destination$ Exile | DefinedPlayer$ Targeted | ChangeType$ Card.NamedCard | ChangeNum$ NumInHand | Chooser$ You | RememberChanged$ True | SubAbility$ ExileLib | StackDescription$ None
 SVar:ExileLib:DB$ ChangeZone | Origin$ Library | Destination$ Exile | DefinedPlayer$ Targeted | ChangeType$ Card.NamedCard | ChangeNum$ NumInLib | Chooser$ You | Search$ True | Shuffle$ True | SubAbility$ DBToken | StackDescription$ None

--- a/forge-gui/res/cardsfolder/n/nevermore.txt
+++ b/forge-gui/res/cardsfolder/n/nevermore.txt
@@ -2,7 +2,7 @@ Name:Nevermore
 ManaCost:1 W W
 Types:Enchantment
 K:ETBReplacement:Other:DBNameCard
-SVar:DBNameCard:DB$ NameCard | Defined$ You | ValidCards$ Card.nonLand | ValidDesc$ nonland | SpellDescription$ As CARDNAME enters the battlefield, choose a nonland card name.
+SVar:DBNameCard:DB$ NameCard | Defined$ You | ValidCards$ Card.nonLand | ValidDescription$ nonland | SpellDescription$ As CARDNAME enters the battlefield, choose a nonland card name.
 S:Mode$ CantBeCast | ValidCard$ Card.NamedCard | Description$ Spells with the chosen name can't be cast.
 AI:RemoveDeck:Random
 Oracle:As Nevermore enters the battlefield, choose a nonland card name.\nSpells with the chosen name can't be cast.

--- a/forge-gui/res/cardsfolder/n/null_chamber.txt
+++ b/forge-gui/res/cardsfolder/n/null_chamber.txt
@@ -2,9 +2,9 @@ Name:Null Chamber
 ManaCost:3 W
 Types:World Enchantment
 K:ETBReplacement:Other:DBNameCard
-SVar:DBNameCard:DB$ NameCard | ValidCards$ Card.nonBasic | ValidDesc$ card other than a basic land | SubAbility$ ChooseP | SpellDescription$ As CARDNAME enters the battlefield, you and an opponent each choose a card name other than a basic land card name.
+SVar:DBNameCard:DB$ NameCard | ValidCards$ Card.nonBasic | ValidDescription$ card other than a basic land | SubAbility$ ChooseP | SpellDescription$ As CARDNAME enters the battlefield, you and an opponent each choose a card name other than a basic land card name.
 SVar:ChooseP:DB$ ChoosePlayer | Choices$ Opponent | SubAbility$ NameOpp
-SVar:NameOpp:DB$ NameCard | Defined$ ChosenPlayer | ValidCards$ Card.nonBasic | ValidDesc$ a card name other than a basic land card name
+SVar:NameOpp:DB$ NameCard | Defined$ ChosenPlayer | ValidCards$ Card.nonBasic | ValidDescription$ a card name other than a basic land card name
 S:Mode$ CantBeCast | ValidCard$ Card.NamedCard | Description$ Spells with the chosen names can't be cast and lands with the chosen names can't be played.
 S:Mode$ CantPlayLand | ValidCard$ Land.NamedCard
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/p/phyrexian_revoker.txt
+++ b/forge-gui/res/cardsfolder/p/phyrexian_revoker.txt
@@ -3,7 +3,7 @@ ManaCost:2
 Types:Artifact Creature Phyrexian Horror
 PT:2/1
 K:ETBReplacement:Other:DBNameCard
-SVar:DBNameCard:DB$ NameCard | Defined$ You | ValidCards$ Card.nonLand | ValidDesc$ nonland | SpellDescription$ As CARDNAME enters the battlefield, choose a nonland card name.
+SVar:DBNameCard:DB$ NameCard | Defined$ You | ValidCards$ Card.nonLand | ValidDescription$ nonland | SpellDescription$ As CARDNAME enters the battlefield, choose a nonland card name.
 S:Mode$ CantBeActivated | ValidCard$ Card.NamedCard | Description$ Activated abilities of sources with the chosen name can't be activated.
 AI:RemoveDeck:All
 Oracle:As Phyrexian Revoker enters the battlefield, choose a nonland card name.\nActivated abilities of sources with the chosen name can't be activated.

--- a/forge-gui/res/cardsfolder/p/psychic_paper.txt
+++ b/forge-gui/res/cardsfolder/p/psychic_paper.txt
@@ -2,7 +2,7 @@ Name:Psychic Paper
 ManaCost:2
 Types:Artifact Equipment
 R:Event$ Attached | ValidCard$ Card.Self | ValidTarget$ Creature | ReplaceWith$ ChooseName | ActiveZones$ Battlefield | Description$ As CARDNAME becomes attached to a creature, choose a creature card name and a creature type.
-SVar:ChooseName:DB$ NameCard | Defined$ You | ValidCards$ Creature | ValidDesc$ creature card | SubAbility$ ChooseCT | SpellDescription$ Choose a creature card name.
+SVar:ChooseName:DB$ NameCard | Defined$ You | ValidCards$ Creature | ValidDescription$ creature card | SubAbility$ ChooseCT | SpellDescription$ Choose a creature card name.
 SVar:ChooseCT:DB$ ChooseType | Defined$ You | Type$ Creature | SpellDescription$ Choose a creature type.
 S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddKeyword$ Ward:1 | SetName$ ChosenName | RemoveCreatureTypes$ True | AddType$ ChosenType | Description$ Equipped creature has ward {1}, it can't be blocked, and its name and creature type are the last chosen name and creature type.
 S:Mode$ CantBlockBy | ValidAttacker$ Creature.EquippedBy

--- a/forge-gui/res/cardsfolder/s/sanctum_of_serra.txt
+++ b/forge-gui/res/cardsfolder/s/sanctum_of_serra.txt
@@ -2,7 +2,7 @@ Name:Sanctum of Serra
 ManaCost:no cost
 Types:Plane Serra's Realm
 T:Mode$ PlaneswalkedFrom | ValidCard$ Plane.Self | Execute$ TrigDestroy | TriggerDescription$ When you planeswalk away from CARDNAME, destroy all nonland permanents.
-SVar:TrigDestroy:DB$ DestroyAll | ValidCards$ Permanent.nonLand | ValidDesc$ all nonland permanents
+SVar:TrigDestroy:DB$ DestroyAll | ValidCards$ Permanent.nonLand | ValidDescription$ all nonland permanents
 T:Mode$ ChaosEnsues | TriggerZones$ Command | Execute$ RolledChaos | OptionalDecider$ You | TriggerDescription$ Whenever chaos ensues, you may have your life total become 20.
 SVar:RolledChaos:DB$ SetLife | Defined$ You | LifeAmount$ 20
 SVar:AIRollPlanarDieParams:Mode$ Always

--- a/forge-gui/res/cardsfolder/s/silverquill_silencer.txt
+++ b/forge-gui/res/cardsfolder/s/silverquill_silencer.txt
@@ -3,7 +3,7 @@ ManaCost:W B
 Types:Creature Human Cleric
 PT:3/2
 K:ETBReplacement:Other:DBNameCard
-SVar:DBNameCard:DB$ NameCard | Defined$ You | ValidCards$ Card.nonLand | ValidDesc$ nonland | SpellDescription$ As CARDNAME enters the battlefield, choose a nonland card name.
+SVar:DBNameCard:DB$ NameCard | Defined$ You | ValidCards$ Card.nonLand | ValidDescription$ nonland | SpellDescription$ As CARDNAME enters the battlefield, choose a nonland card name.
 T:Mode$ SpellCast | ValidCard$ Card.NamedCard | ValidActivatingPlayer$ Opponent | Execute$ TrigDrain | TriggerDescription$ Whenever an opponent casts a spell with the chosen name, they lose 3 life and you draw a card.
 SVar:TrigDrain:DB$ LoseLife | Defined$ TriggeredActivator | LifeAmount$ 3 | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | Defined$ You

--- a/forge-gui/res/cardsfolder/s/slaughter_games.txt
+++ b/forge-gui/res/cardsfolder/s/slaughter_games.txt
@@ -2,7 +2,7 @@ Name:Slaughter Games
 ManaCost:2 B R
 Types:Sorcery
 R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
-A:SP$ NameCard | Cost$ 2 B R | Defined$ You | ValidCards$ Card.nonLand | ValidDesc$ nonland | SubAbility$ ExileYard | SpellDescription$ Choose a nonland card name. Search target opponent's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles.
+A:SP$ NameCard | Cost$ 2 B R | Defined$ You | ValidCards$ Card.nonLand | ValidDescription$ nonland | SubAbility$ ExileYard | SpellDescription$ Choose a nonland card name. Search target opponent's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles.
 SVar:ExileYard:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | ValidTgts$ Player.Opponent | TgtPrompt$ Select target opponent | ChangeType$ Card.NamedCard | Chooser$ You | ChangeNum$ NumInYard | Hidden$ True | SubAbility$ ExileHand | StackDescription$ Search target opponent's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles their library.
 SVar:ExileHand:DB$ ChangeZone | Origin$ Hand | Destination$ Exile | DefinedPlayer$ Targeted | ChangeType$ Card.NamedCard | ChangeNum$ NumInHand | Chooser$ You | SubAbility$ ExileLib | StackDescription$ None
 SVar:ExileLib:DB$ ChangeZone | Origin$ Library | Destination$ Exile | DefinedPlayer$ Targeted | ChangeType$ Card.NamedCard | ChangeNum$ NumInLib | Chooser$ You | Shuffle$ True | StackDescription$ None

--- a/forge-gui/res/cardsfolder/s/stain_the_mind.txt
+++ b/forge-gui/res/cardsfolder/s/stain_the_mind.txt
@@ -2,7 +2,7 @@ Name:Stain the Mind
 ManaCost:4 B
 Types:Sorcery
 K:Convoke
-A:SP$ NameCard | Cost$ 4 B | Defined$ You | ValidCards$ Card.nonLand | ValidDesc$ nonland | SubAbility$ ExileYard | SpellDescription$ Choose a nonland card name. Search target player's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles.
+A:SP$ NameCard | Cost$ 4 B | Defined$ You | ValidCards$ Card.nonLand | ValidDescription$ nonland | SubAbility$ ExileYard | SpellDescription$ Choose a nonland card name. Search target player's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles.
 SVar:ExileYard:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | ValidTgts$ Player | TgtPrompt$ Select target player | ChangeType$ Card.NamedCard | Chooser$ You | ChangeNum$ NumInYard | Hidden$ True | SubAbility$ ExileHand | StackDescription$ Choose a nonland card name. Search target player's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles.
 SVar:ExileHand:DB$ ChangeZone | Origin$ Hand | Destination$ Exile | DefinedPlayer$ Targeted | ChangeType$ Card.NamedCard | ChangeNum$ NumInHand | Chooser$ You | SubAbility$ ExileLib | StackDescription$ None
 SVar:ExileLib:DB$ ChangeZone | Origin$ Library | Destination$ Exile | DefinedPlayer$ Targeted | ChangeType$ Card.NamedCard | ChangeNum$ NumInLib | Chooser$ You | Shuffle$ True | StackDescription$ None

--- a/forge-gui/res/cardsfolder/t/thought_hemorrhage.txt
+++ b/forge-gui/res/cardsfolder/t/thought_hemorrhage.txt
@@ -1,7 +1,7 @@
 Name:Thought Hemorrhage
 ManaCost:2 B R
 Types:Sorcery
-A:SP$ NameCard | Cost$ 2 B R | ValidCards$ Card.nonLand | SubAbility$ DBReveal | ValidDesc$ nonland | SpellDescription$ Choose a nonland card name. Target player reveals their hand. CARDNAME deals 3 damage to that player for each card with the chosen name revealed this way. Search that player's graveyard, hand, and library for all cards with that name and exile them. Then that player shuffles their library.
+A:SP$ NameCard | Cost$ 2 B R | ValidCards$ Card.nonLand | SubAbility$ DBReveal | ValidDescription$ nonland | SpellDescription$ Choose a nonland card name. Target player reveals their hand. CARDNAME deals 3 damage to that player for each card with the chosen name revealed this way. Search that player's graveyard, hand, and library for all cards with that name and exile them. Then that player shuffles their library.
 SVar:DBReveal:DB$ RevealHand | RememberRevealed$ True | ValidTgts$ Player | TgtPrompt$ Select target player | SubAbility$ DBDamage
 SVar:DBDamage:DB$ DealDamage | Defined$ Targeted | NumDmg$ X | SubAbility$ ExileYard
 SVar:ExileYard:DB$ ChangeZoneAll | Origin$ Graveyard | Destination$ Exile | Defined$ Targeted | ChangeType$ Card.NamedCard | SubAbility$ ExileHand | StackDescription$ None

--- a/forge-gui/res/cardsfolder/v/voidstone_gargoyle.txt
+++ b/forge-gui/res/cardsfolder/v/voidstone_gargoyle.txt
@@ -4,7 +4,7 @@ Types:Creature Gargoyle
 PT:3/3
 K:Flying
 K:ETBReplacement:Other:DBNameCard
-SVar:DBNameCard:DB$ NameCard | Defined$ You | ValidCards$ Card.nonLand | ValidDesc$ nonland | SpellDescription$ As CARDNAME enters the battlefield, choose a nonland card name.
+SVar:DBNameCard:DB$ NameCard | Defined$ You | ValidCards$ Card.nonLand | ValidDescription$ nonland | SpellDescription$ As CARDNAME enters the battlefield, choose a nonland card name.
 S:Mode$ CantBeCast | ValidCard$ Card.NamedCard | Description$ Spells with the chosen name can't be cast.
 S:Mode$ CantBeActivated | ValidCard$ Card.NamedCard | Description$ Activated abilities of sources with the chosen name can't be activated.
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/w/wood_sage.txt
+++ b/forge-gui/res/cardsfolder/w/wood_sage.txt
@@ -2,7 +2,7 @@ Name:Wood Sage
 ManaCost:G U
 Types:Creature Human Druid
 PT:1/1
-A:AB$ NameCard | Cost$ T | Defined$ You | ValidCards$ Card.Creature | ValidDesc$ creature | SubAbility$ DBDig | SpellDescription$ Choose a creature card name. Reveal the top four cards of your library and put all of them with that name into your hand. Put the rest into your graveyard.
+A:AB$ NameCard | Cost$ T | Defined$ You | ValidCards$ Card.Creature | ValidDescription$ creature | SubAbility$ DBDig | SpellDescription$ Choose a creature card name. Reveal the top four cards of your library and put all of them with that name into your hand. Put the rest into your graveyard.
 SVar:DBDig:DB$ Dig | DigNum$ 4 | Reveal$ True | ChangeNum$ All | ChangeValid$ Card.NamedCard | DestinationZone2$ Graveyard | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearNamedCard$ True
 AI:RemoveDeck:All


### PR DESCRIPTION
Per discussion on Discord, resolving the `ValidDesc$`/`ValidDescription$` parameter duplication, with the less prevalent `ValidDesc$` being the deprecated one (33 vs 299 hits). (Work moved from https://github.com/Card-Forge/forge/pull/4776 )