### PR TITLE
Pom: exclude tritonus-share

### DIFF
--- a/forge-gui-desktop/pom.xml
+++ b/forge-gui-desktop/pom.xml
@@ -1,11 +1,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<artifactId>forge</artifactId>
-		<groupId>forge</groupId>
-		<version>1.6.62-SNAPSHOT</version>
-	</parent>
+    <parent>
+        <artifactId>forge</artifactId>
+        <groupId>forge</groupId>
+        <version>1.6.62-SNAPSHOT</version>
+    </parent>
 
     <artifactId>forge-gui-desktop</artifactId>
     <packaging>jar</packaging>
@@ -269,6 +269,12 @@
             <groupId>com.sipgate</groupId>
             <artifactId>mp3-wav</artifactId>
             <version>1.0.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.googlecode.soundlibs</groupId>
+                    <artifactId>tritonus-share</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.twelvemonkeys.imageio</groupId>


### PR DESCRIPTION
without the exclude i get this:

```java

        try {
            audioLine = AudioSystem.getSourceDataLine(format, selectedMixer);
            audioLine.open(format);
        } catch (Exception e) {
            return;
        }

```

With this Problem:

`The method getSourceDataLine(AudioFormat, Mixer.Info) is undefined for the type AudioSystem`