### PR TITLE
ACR: Altaïr, Haystack, The Animus

### DIFF
--- a/forge-game/src/main/java/forge/game/card/CounterEnumType.java
+++ b/forge-game/src/main/java/forge/game/card/CounterEnumType.java
@@ -269,6 +269,8 @@ public enum CounterEnumType {
 
     MATRIX("MATRX", 183, 174, 255),
 
+    MEMORY("MEMRY", 174, 183, 255),
+
     MINE("MINE", 255, 100, 127),
 
     MINING("MINNG", 184, 201, 207),
@@ -447,6 +449,7 @@ public enum CounterEnumType {
     FIRSTSTRIKE("First Strike"),
     DOUBLESTRIKE("Double Strike"),
     DEATHTOUCH("Deathtouch"),
+    HASTE("Haste"),
     HEXPROOF("Hexproof"),
     INDESTRUCTIBLE("Indestructible"),
     LIFELINK("Lifelink"),

--- a/forge-gui/res/cardsfolder/upcoming/altair_ibn_laahad.txt
+++ b/forge-gui/res/cardsfolder/upcoming/altair_ibn_laahad.txt
@@ -1,0 +1,15 @@
+Name:Altaïr Ibn-La'Ahad
+ManaCost:R W B
+Types:Legendary Creature Human Assassin
+PT:3/3
+K:First Strike
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ Whenever CARDNAME attacks, exile up to one target Assassin creature card from your graveyard with a memory counter on it. Then for each creature card you own in exile with a memory counter on it, create a tapped and attacking token that’s a copy of it. Exile those tokens at end of combat.
+SVar:TrigExile:DB$ ChangeZone | Imprint$ True | ValidTgts$ Creature.Assassin+YouCtrl | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target Assassin creature card from your graveyard | Origin$ Graveyard | Destination$ Exile | SubAbility$ DBPutCounter
+SVar:DBPutCounter:DB$ PutCounter | CounterType$ MEMORY | CounterNum$ 1 | Defined$ Imprinted | SubAbility$ DBCopyPermanent
+SVar:DBCopyPermanent:DB$ CopyPermanent | Defined$ ValidExile Card.Creature+YouOwn+counters_GE1_MEMORY | NumCopies$ 1 | TokenTapped$ True | TokenAttacking$ True | RememberTokens$ True | SubAbility$ DelTrig
+SVar:DelTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ EndCombat | Execute$ TrigExileTokens | RememberObjects$ Remembered | TriggerDescription$ At end of combat, exile those tokens. | SubAbility$ DBCleanup
+SVar:TrigExileTokens:DB$ ChangeZone | Defined$ DelayTriggerRememberedLKI | Origin$ Battlefield | Destination$ Exile
+SVar:DBCleanup:DB$ Cleanup | ClearImprinted$ True | ClearRemembered$ True
+DeckHas:Ability$Counters|Graveyard|Token
+DeckHints:Ability$Sacrifice|Discard|Mill & Type$Assassin
+Oracle:First strike\nWhenever Altaïr Ibn-La'Ahad attacks, exile up to one target Assassin creature card from your graveyard with a memory counter on it. Then for each creature card you own in exile with a memory counter on it, create a tapped and attacking token that’s a copy of it. Exile those tokens at end of combat.

--- a/forge-gui/res/cardsfolder/upcoming/altair_ibn_laahad.txt
+++ b/forge-gui/res/cardsfolder/upcoming/altair_ibn_laahad.txt
@@ -4,12 +4,8 @@ Types:Legendary Creature Human Assassin
 PT:3/3
 K:First Strike
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ Whenever CARDNAME attacks, exile up to one target Assassin creature card from your graveyard with a memory counter on it. Then for each creature card you own in exile with a memory counter on it, create a tapped and attacking token that’s a copy of it. Exile those tokens at end of combat.
-SVar:TrigExile:DB$ ChangeZone | Imprint$ True | ValidTgts$ Creature.Assassin+YouCtrl | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target Assassin creature card from your graveyard | Origin$ Graveyard | Destination$ Exile | SubAbility$ DBPutCounter
-SVar:DBPutCounter:DB$ PutCounter | CounterType$ MEMORY | CounterNum$ 1 | Defined$ Imprinted | SubAbility$ DBCopyPermanent
-SVar:DBCopyPermanent:DB$ CopyPermanent | Defined$ ValidExile Card.Creature+YouOwn+counters_GE1_MEMORY | NumCopies$ 1 | TokenTapped$ True | TokenAttacking$ True | RememberTokens$ True | SubAbility$ DelTrig
-SVar:DelTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ EndCombat | Execute$ TrigExileTokens | RememberObjects$ Remembered | TriggerDescription$ At end of combat, exile those tokens. | SubAbility$ DBCleanup
-SVar:TrigExileTokens:DB$ ChangeZone | Defined$ DelayTriggerRememberedLKI | Origin$ Battlefield | Destination$ Exile
-SVar:DBCleanup:DB$ Cleanup | ClearImprinted$ True | ClearRemembered$ True
+SVar:TrigExile:DB$ ChangeZone | ValidTgts$ Creature.Assassin+YouCtrl | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target Assassin creature card from your graveyard | Origin$ Graveyard | Destination$ Exile | WithCountersType$ MEMORY | SubAbility$ DBCopyPermanent
+SVar:DBCopyPermanent:DB$ CopyPermanent | Defined$ ValidExile Card.Creature+YouOwn+counters_GE1_MEMORY | NumCopies$ 1 | TokenTapped$ True | TokenAttacking$ True | AtEOT$ ExileCombat
 DeckHas:Ability$Counters|Graveyard|Token
 DeckHints:Ability$Sacrifice|Discard|Mill & Type$Assassin
 Oracle:First strike\nWhenever Altaïr Ibn-La'Ahad attacks, exile up to one target Assassin creature card from your graveyard with a memory counter on it. Then for each creature card you own in exile with a memory counter on it, create a tapped and attacking token that’s a copy of it. Exile those tokens at end of combat.

--- a/forge-gui/res/cardsfolder/upcoming/altair_ibn_laahad.txt
+++ b/forge-gui/res/cardsfolder/upcoming/altair_ibn_laahad.txt
@@ -3,9 +3,9 @@ ManaCost:R W B
 Types:Legendary Creature Human Assassin
 PT:3/3
 K:First Strike
-T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ Whenever CARDNAME attacks, exile up to one target Assassin creature card from your graveyard with a memory counter on it. Then for each creature card you own in exile with a memory counter on it, create a tapped and attacking token that’s a copy of it. Exile those tokens at end of combat.
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ Whenever CARDNAME attacks, exile up to one target Assassin creature card from your graveyard with a memory counter on it. Then for each creature card you own in exile with a memory counter on it, create a tapped and attacking token that's a copy of it. Exile those tokens at end of combat.
 SVar:TrigExile:DB$ ChangeZone | ValidTgts$ Creature.Assassin+YouCtrl | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target Assassin creature card from your graveyard | Origin$ Graveyard | Destination$ Exile | WithCountersType$ MEMORY | SubAbility$ DBCopyPermanent
 SVar:DBCopyPermanent:DB$ CopyPermanent | Defined$ ValidExile Card.Creature+YouOwn+counters_GE1_MEMORY | NumCopies$ 1 | TokenTapped$ True | TokenAttacking$ True | AtEOT$ ExileCombat
 DeckHas:Ability$Counters|Graveyard|Token
 DeckHints:Ability$Sacrifice|Discard|Mill & Type$Assassin
-Oracle:First strike\nWhenever Altaïr Ibn-La'Ahad attacks, exile up to one target Assassin creature card from your graveyard with a memory counter on it. Then for each creature card you own in exile with a memory counter on it, create a tapped and attacking token that’s a copy of it. Exile those tokens at end of combat.
+Oracle:First strike\nWhenever Altaïr Ibn-La'Ahad attacks, exile up to one target Assassin creature card from your graveyard with a memory counter on it. Then for each creature card you own in exile with a memory counter on it, create a tapped and attacking token that's a copy of it. Exile those tokens at end of combat.

--- a/forge-gui/res/cardsfolder/upcoming/haystack.txt
+++ b/forge-gui/res/cardsfolder/upcoming/haystack.txt
@@ -1,5 +1,5 @@
 Name:Haystack
 ManaCost:1 W
 Types:Artifact
-A:AB$ Phases | Cost$ 2 T | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | SpellDescription$ Target creature you control phases out. (Treat it and anything attached to it as though they don’t exist until your next turn.)
-Oracle:{2}, {T}: Target creature you control phases out. (Treat it and anything attached to it as though they don’t exist until your next turn.)
+A:AB$ Phases | Cost$ 2 T | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | SpellDescription$ Target creature you control phases out. (Treat it and anything attached to it as though they don't exist until your next turn.)
+Oracle:{2}, {T}: Target creature you control phases out. (Treat it and anything attached to it as though they don't exist until your next turn.)

--- a/forge-gui/res/cardsfolder/upcoming/haystack.txt
+++ b/forge-gui/res/cardsfolder/upcoming/haystack.txt
@@ -1,0 +1,5 @@
+Name:Haystack
+ManaCost:1 W
+Types:Artifact
+A:AB$ Phases | Cost$ 2 T | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control 
+Oracle:{2}, {T}: Target creature you control phases out.

--- a/forge-gui/res/cardsfolder/upcoming/haystack.txt
+++ b/forge-gui/res/cardsfolder/upcoming/haystack.txt
@@ -1,5 +1,5 @@
 Name:Haystack
 ManaCost:1 W
 Types:Artifact
-A:AB$ Phases | Cost$ 2 T | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control 
-Oracle:{2}, {T}: Target creature you control phases out.
+A:AB$ Phases | Cost$ 2 T | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | SpellDescription$ Target creature you control phases out. (Treat it and anything attached to it as though they don’t exist until your next turn.)
+Oracle:{2}, {T}: Target creature you control phases out. (Treat it and anything attached to it as though they don’t exist until your next turn.)

--- a/forge-gui/res/cardsfolder/upcoming/the_animus.txt
+++ b/forge-gui/res/cardsfolder/upcoming/the_animus.txt
@@ -1,0 +1,12 @@
+Name:The Animus
+ManaCost:2
+Types:Legendary Artifact
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigExile | TriggerDescription$ At the beginning of your end step, exile up to one target legendary creature card from a graveyard with a memory counter on it.
+SVar:TrigExile:DB$ ChangeZone | Imprint$ True | ValidTgts$ Creature.Legendary | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target legendary creature card from a graveyard | Origin$ Graveyard | Destination$ Exile | SubAbility$ DBPutCounter
+SVar:DBPutCounter:DB$ PutCounter | CounterType$ MEMORY | CounterNum$ 1 | Defined$ Imprinted | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearImprinted$ True
+A:AB$ Pump | Cost$ T | ValidTgts$ Creature.Legendary+counters_GE1_MEMORY | TgtZone$ Exile | SorcerySpeed$ True | TgtPrompt$ Select target creature card in exile with a memory counter on it | SubAbility$ DBClone | StackDescription$ SpellDescription | SpellDescription$ Until your next turn, target legendary creature you control becomes a copy of target creature card in exile with a memory counter on it. Activate only as a sorcery.
+SVar:DBClone:DB$ Clone | Defined$ ParentTarget | ValidTgts$ Creature.Legendary+YouCtrl | CloneTarget$ ThisTargetedCard | TgtPrompt$ Select target legendary creature you control | Duration$ UntilYourNextTurn
+DeckHas:Ability$Counters|Graveyard
+DeckHints:Ability$Sacrifice|Discard|Mill & Type$Legendary
+Oracle:At the beginning of your end step, exile up to one target legendary creature card from a graveyard with a memory counter on it.\n{T}: Until your next turn, target legendary creature you control becomes a copy of target creature card in exile with a memory counter on it. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/upcoming/the_animus.txt
+++ b/forge-gui/res/cardsfolder/upcoming/the_animus.txt
@@ -2,9 +2,7 @@ Name:The Animus
 ManaCost:2
 Types:Legendary Artifact
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigExile | TriggerDescription$ At the beginning of your end step, exile up to one target legendary creature card from a graveyard with a memory counter on it.
-SVar:TrigExile:DB$ ChangeZone | Imprint$ True | ValidTgts$ Creature.Legendary | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target legendary creature card from a graveyard | Origin$ Graveyard | Destination$ Exile | SubAbility$ DBPutCounter
-SVar:DBPutCounter:DB$ PutCounter | CounterType$ MEMORY | CounterNum$ 1 | Defined$ Imprinted | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearImprinted$ True
+SVar:TrigExile:DB$ ChangeZone | ValidTgts$ Creature.Legendary | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target legendary creature card from a graveyard | Origin$ Graveyard | Destination$ Exile | WithCountersType$ MEMORY
 A:AB$ Pump | Cost$ T | ValidTgts$ Creature.Legendary+counters_GE1_MEMORY | TgtZone$ Exile | SorcerySpeed$ True | TgtPrompt$ Select target creature card in exile with a memory counter on it | SubAbility$ DBClone | StackDescription$ SpellDescription | SpellDescription$ Until your next turn, target legendary creature you control becomes a copy of target creature card in exile with a memory counter on it. Activate only as a sorcery.
 SVar:DBClone:DB$ Clone | Defined$ ParentTarget | ValidTgts$ Creature.Legendary+YouCtrl | CloneTarget$ ThisTargetedCard | TgtPrompt$ Select target legendary creature you control | Duration$ UntilYourNextTurn
 DeckHas:Ability$Counters|Graveyard


### PR DESCRIPTION
Tested card scripts for:
- [Altaïr Ibn-La'Ahad](https://scryfall.com/card/acr/45/alta%C3%AFr-ibn-laahad)
- [Haystack](https://scryfall.com/card/acr/175/haystack)
- [The Animus](https://scryfall.com/card/acr/69/the-animus)

Also added memory counters used by two of the above and [Owen Grady](https://scryfall.com/card/rex/16/owen-grady-raptor-trainer)'s haste counters to `CounterEnumType.java`.