### PR TITLE
Cost$ cleanup: straggler pass #3

### DIFF
--- a/forge-gui/res/cardsfolder/a/alive_well.txt
+++ b/forge-gui/res/cardsfolder/a/alive_well.txt
@@ -2,7 +2,7 @@ Name:Alive
 ManaCost:3 G
 Types:Sorcery
 K:Fuse
-A:SP$ Token | Cost$ 3 G | TokenAmount$ 1 | TokenScript$ g_3_3_centaur | TokenOwner$ You | SpellDescription$ Create a 3/3 green Centaur creature token.
+A:SP$ Token | TokenAmount$ 1 | TokenScript$ g_3_3_centaur | TokenOwner$ You | SpellDescription$ Create a 3/3 green Centaur creature token.
 DeckHas:Ability$Token
 AlternateMode:Split
 Oracle:Create a 3/3 green Centaur creature token.\nFuse (You may cast one or both halves of this card from your hand.)
@@ -12,6 +12,6 @@ ALTERNATE
 Name:Well
 ManaCost:W
 Types:Sorcery
-A:SP$ GainLife | Cost$ W | LifeAmount$ X | SpellDescription$ You gain 2 life for each creature you control.
+A:SP$ GainLife | LifeAmount$ X | SpellDescription$ You gain 2 life for each creature you control.
 SVar:X:Count$TypeYouCtrl.Creature/Times.2
 Oracle:You gain 2 life for each creature you control.\nFuse (You may cast one or both halves of this card from your hand.)

--- a/forge-gui/res/cardsfolder/a/appeal_authority.txt
+++ b/forge-gui/res/cardsfolder/a/appeal_authority.txt
@@ -1,7 +1,7 @@
 Name:Appeal
 ManaCost:G
 Types:Sorcery
-A:SP$ Pump | Cost$ G | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | NumDef$ +X | KW$ Trample | SpellDescription$ Until end of turn, target creature gains trample and gets +X/+X, where X is the number of creatures you control.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | NumDef$ +X | KW$ Trample | SpellDescription$ Until end of turn, target creature gains trample and gets +X/+X, where X is the number of creatures you control.
 SVar:X:Count$TypeYouCtrl.Creature
 AlternateMode:Split
 Oracle:Until end of turn, target creature gains trample and gets +X/+X, where X is the number of creatures you control.
@@ -12,6 +12,6 @@ Name:Authority
 ManaCost:1 W
 Types:Sorcery
 K:Aftermath
-A:SP$ Tap | Cost$ 1 W | TargetMin$ 0 | TargetMax$ 2 | TgtPrompt$ Choose target creature your opponent controls | ValidTgts$ Creature.OppCtrl | SubAbility$ DBPumpAll | SpellDescription$ Tap up to two target creatures your opponents control. Creatures you control gain vigilance until end of turn.
+A:SP$ Tap | TargetMin$ 0 | TargetMax$ 2 | TgtPrompt$ Choose target creature your opponent controls | ValidTgts$ Creature.OppCtrl | SubAbility$ DBPumpAll | SpellDescription$ Tap up to two target creatures your opponents control. Creatures you control gain vigilance until end of turn.
 SVar:DBPumpAll:DB$ PumpAll | ValidCards$ Creature.YouCtrl | KW$ Vigilance
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nTap up to two target creatures your opponents control. Creatures you control gain vigilance until end of turn.

--- a/forge-gui/res/cardsfolder/a/armed_dangerous.txt
+++ b/forge-gui/res/cardsfolder/a/armed_dangerous.txt
@@ -2,7 +2,7 @@ Name:Armed
 ManaCost:1 R
 Types:Sorcery
 K:Fuse
-A:SP$ Pump | Cost$ 1 R | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +1 | NumDef$ +1 | KW$ Double Strike | SpellDescription$ Target creature gets +1/+1 and gains double strike until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +1 | NumDef$ +1 | KW$ Double Strike | SpellDescription$ Target creature gets +1/+1 and gains double strike until end of turn.
 AlternateMode:Split
 Oracle:Target creature gets +1/+1 and gains double strike until end of turn.\nFuse (You may cast one or both halves of this card from your hand.)
 
@@ -11,5 +11,5 @@ ALTERNATE
 Name:Dangerous
 ManaCost:3 G
 Types:Sorcery
-A:SP$ Pump | Cost$ 3 G | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ HIDDEN All creatures able to block CARDNAME do so. | SpellDescription$ All creatures able to block target creature this turn do so this turn.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ HIDDEN All creatures able to block CARDNAME do so. | SpellDescription$ All creatures able to block target creature this turn do so this turn.
 Oracle:All creatures able to block target creature this turn do so.\nFuse (You may cast one or both halves of this card from your hand.)

--- a/forge-gui/res/cardsfolder/a/assault_battery.txt
+++ b/forge-gui/res/cardsfolder/a/assault_battery.txt
@@ -1,7 +1,7 @@
 Name:Assault
 ManaCost:R
 Types:Sorcery
-A:SP$ DealDamage | Cost$ R | NumDmg$ 2 | ValidTgts$ Any | SpellDescription$ Assault deals 2 damage to any target.
+A:SP$ DealDamage | NumDmg$ 2 | ValidTgts$ Any | SpellDescription$ Assault deals 2 damage to any target.
 AlternateMode:Split
 Oracle:Assault deals 2 damage to any target.
 
@@ -10,5 +10,5 @@ ALTERNATE
 Name:Battery
 ManaCost:3 G
 Types:Sorcery
-A:SP$ Token | Cost$ 3 G | TokenScript$ g_3_3_elephant | TokenOwner$ You | SpellDescription$ Create a 3/3 green Elephant creature token.
+A:SP$ Token | TokenScript$ g_3_3_elephant | TokenOwner$ You | SpellDescription$ Create a 3/3 green Elephant creature token.
 Oracle:Create a 3/3 green Elephant creature token.

--- a/forge-gui/res/cardsfolder/a/assure_assemble.txt
+++ b/forge-gui/res/cardsfolder/a/assure_assemble.txt
@@ -1,7 +1,7 @@
 Name:Assure
 ManaCost:G/W G/W
 Types:Instant
-A:SP$ PutCounter | Cost$ G/W G/W | ValidTgts$ Creature | TgtPrompt$ Select target creature | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBPump | SpellDescription$ Put a +1/+1 counter on target creature. That creature gains indestructible until end of turn.
+A:SP$ PutCounter | ValidTgts$ Creature | TgtPrompt$ Select target creature | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBPump | SpellDescription$ Put a +1/+1 counter on target creature. That creature gains indestructible until end of turn.
 SVar:DBPump:DB$ Pump | Defined$ Targeted | KW$ Indestructible
 AlternateMode:Split
 Oracle:Put a +1/+1 counter on target creature. That creature gains indestructible until end of turn.
@@ -11,6 +11,6 @@ ALTERNATE
 Name:Assemble
 ManaCost:4 G W
 Types:Instant
-A:SP$ Token | Cost$ 4 G W | TokenAmount$ 3 | TokenScript$ gw_2_2_elf_knight_vigilance | SpellDescription$ Create three 2/2 green and white Elf Knight creature tokens with vigilance.
+A:SP$ Token | TokenAmount$ 3 | TokenScript$ gw_2_2_elf_knight_vigilance | SpellDescription$ Create three 2/2 green and white Elf Knight creature tokens with vigilance.
 DeckHas:Ability$Counters|Token
 Oracle:Create three 2/2 green and white Elf Knight creature tokens with vigilance.

--- a/forge-gui/res/cardsfolder/a/assure_assemble.txt
+++ b/forge-gui/res/cardsfolder/a/assure_assemble.txt
@@ -1,5 +1,5 @@
 Name:Assure
-ManaCost:G/W G/W
+ManaCost:GW GW
 Types:Instant
 A:SP$ PutCounter | ValidTgts$ Creature | TgtPrompt$ Select target creature | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBPump | SpellDescription$ Put a +1/+1 counter on target creature. That creature gains indestructible until end of turn.
 SVar:DBPump:DB$ Pump | Defined$ Targeted | KW$ Indestructible

--- a/forge-gui/res/cardsfolder/b/beck_call.txt
+++ b/forge-gui/res/cardsfolder/b/beck_call.txt
@@ -2,7 +2,7 @@ Name:Beck
 ManaCost:G U
 Types:Sorcery
 K:Fuse
-A:SP$ Effect | Cost$ G U | Name$ Beck Effect | Triggers$ CreatureEntered | SpellDescription$ Whenever a creature enters the battlefield this turn, you may draw a card.
+A:SP$ Effect | Name$ Beck Effect | Triggers$ CreatureEntered | SpellDescription$ Whenever a creature enters the battlefield this turn, you may draw a card.
 SVar:CreatureEntered:Mode$ ChangesZone | ValidCard$ Creature | Origin$ Any | Destination$ Battlefield | Execute$ TrigDraw | TriggerZones$ Command | OptionalDecider$ You | TriggerDescription$ Whenever a creature enters the battlefield this turn, you may draw a card.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1
 AlternateMode:Split
@@ -13,5 +13,5 @@ ALTERNATE
 Name:Call
 ManaCost:4 W U
 Types:Sorcery
-A:SP$ Token | Cost$ 4 W U | TokenAmount$ 4 | TokenScript$ w_1_1_bird_flying | TokenOwner$ You | SpellDescription$ Create four 1/1 white Bird creature tokens with flying.
+A:SP$ Token | TokenAmount$ 4 | TokenScript$ w_1_1_bird_flying | TokenOwner$ You | SpellDescription$ Create four 1/1 white Bird creature tokens with flying.
 Oracle:Create four 1/1 white Bird creature tokens with flying.\nFuse (You may cast one or both halves of this card from your hand.)

--- a/forge-gui/res/cardsfolder/b/bedeck_bedazzle.txt
+++ b/forge-gui/res/cardsfolder/b/bedeck_bedazzle.txt
@@ -1,7 +1,7 @@
 Name:Bedeck
 ManaCost:BR BR
 Types:Instant
-A:SP$ Pump | Cost$ BR BR | ValidTgts$ Creature | NumAtt$ +3 | NumDef$ -3 | IsCurse$ True | SpellDescription$ Target creature gets +3/-3 until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | NumAtt$ +3 | NumDef$ -3 | IsCurse$ True | SpellDescription$ Target creature gets +3/-3 until end of turn.
 AlternateMode:Split
 Oracle:Target creature gets +3/-3 until end of turn.
 
@@ -10,6 +10,6 @@ ALTERNATE
 Name:Bedazzle
 ManaCost:4 B R
 Types:Instant
-A:SP$ Destroy | Cost$ 4 B R | ValidTgts$ Land.nonBasic | TgtPrompt$ Select target nonbasic land. | SubAbility$ DBDamage | SpellDescription$ Destroy target nonbasic land. CARDNAME deals 2 damage to target opponent or planeswalker.
+A:SP$ Destroy | ValidTgts$ Land.nonBasic | TgtPrompt$ Select target nonbasic land. | SubAbility$ DBDamage | SpellDescription$ Destroy target nonbasic land. CARDNAME deals 2 damage to target opponent or planeswalker.
 SVar:DBDamage:DB$ DealDamage | ValidTgts$ Player.Opponent,Card.Planeswalker | TgtPrompt$ Select target opponent or planeswalker | NumDmg$ 2
 Oracle:Destroy target nonbasic land. Bedazzle deals 2 damage to target opponent or planeswalker.

--- a/forge-gui/res/cardsfolder/b/boom_bust.txt
+++ b/forge-gui/res/cardsfolder/b/boom_bust.txt
@@ -1,7 +1,7 @@
 Name:Boom
 ManaCost:1 R
 Types:Sorcery
-A:SP$ Pump | Cost$ 1 R | TgtPrompt$ Choose target land you control to destroy | ValidTgts$ Land.YouCtrl | AILogic$ Destroy | IsCurse$ True | SubAbility$ DestroyOpp | SpellDescription$ Destroy target land you control and target land you don't control. | StackDescription$ None
+A:SP$ Pump | TgtPrompt$ Choose target land you control to destroy | ValidTgts$ Land.YouCtrl | AILogic$ Destroy | IsCurse$ True | SubAbility$ DestroyOpp | SpellDescription$ Destroy target land you control and target land you don't control. | StackDescription$ None
 SVar:DestroyOpp:DB$ Pump | TgtPrompt$ Choose target land you don't control to destroy | ValidTgts$ Land.YouDontCtrl | AILogic$ Destroy | IsCurse$ True | SubAbility$ DBDestroy | StackDescription$ None
 SVar:DBDestroy:DB$ Destroy | Defined$ Targeted
 AlternateMode:Split
@@ -12,5 +12,5 @@ ALTERNATE
 Name:Bust
 ManaCost:5 R
 Types:Sorcery
-A:SP$ DestroyAll | Cost$ 5 R | ValidCards$ Land | SpellDescription$ Destroy all lands.
+A:SP$ DestroyAll | ValidCards$ Land | SpellDescription$ Destroy all lands.
 Oracle:Destroy all lands.

--- a/forge-gui/res/cardsfolder/b/breaking_entering.txt
+++ b/forge-gui/res/cardsfolder/b/breaking_entering.txt
@@ -2,7 +2,7 @@ Name:Breaking
 ManaCost:U B
 Types:Sorcery
 K:Fuse
-A:SP$ Mill | Cost$ U B | NumCards$ 8 | ValidTgts$ Player | TgtPrompt$ Choose a player | SpellDescription$ Target player mills eight cards.
+A:SP$ Mill | NumCards$ 8 | ValidTgts$ Player | TgtPrompt$ Choose a player | SpellDescription$ Target player mills eight cards.
 AlternateMode:Split
 Oracle:Target player mills eight cards.\nFuse (You may cast one or both halves of this card from your hand.)
 

--- a/forge-gui/res/cardsfolder/c/carnival_carnage.txt
+++ b/forge-gui/res/cardsfolder/c/carnival_carnage.txt
@@ -1,7 +1,7 @@
 Name:Carnival
 ManaCost:BR
 Types:Instant
-A:SP$ DealDamage | Cost$ BR | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ 1 | SubAbility$ DBDealDamage | SpellDescription$ CARDNAME deals 1 damage to target creature or planeswalker and 1 damage to that permanent's controller.
+A:SP$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ 1 | SubAbility$ DBDealDamage | SpellDescription$ CARDNAME deals 1 damage to target creature or planeswalker and 1 damage to that permanent's controller.
 SVar:DBDealDamage:DB$ DealDamage | Defined$ TargetedController | NumDmg$ 1
 AlternateMode:Split
 Oracle:Carnival deals 1 damage to target creature or planeswalker and 1 damage to that permanent's controller.
@@ -11,6 +11,6 @@ ALTERNATE
 Name:Carnage
 ManaCost:2 B R
 Types:Sorcery
-A:SP$ DealDamage | Cost$ 2 B R | ValidTgts$ Player.Opponent | NumDmg$ 3 | SubAbility$ DBDiscard | SpellDescription$ CARDNAME deals 3 damage to target opponent. That player discards two cards.
+A:SP$ DealDamage | ValidTgts$ Player.Opponent | NumDmg$ 3 | SubAbility$ DBDiscard | SpellDescription$ CARDNAME deals 3 damage to target opponent. That player discards two cards.
 SVar:DBDiscard:DB$ Discard | Defined$ TargetedPlayer | NumCards$ 2 | Mode$ TgtChoose
 Oracle:Carnage deals 3 damage to target opponent. That player discards two cards.

--- a/forge-gui/res/cardsfolder/c/catch_release.txt
+++ b/forge-gui/res/cardsfolder/c/catch_release.txt
@@ -2,7 +2,7 @@ Name:Catch
 ManaCost:1 U R
 Types:Sorcery
 K:Fuse
-A:SP$ GainControl | Cost$ 1 U R | ValidTgts$ Permanent | TgtPrompt$ Select target permanent | LoseControl$ EOT | Untap$ True | AddKWs$ Haste | SpellDescription$ Gain control of target permanent until end of turn. Untap it. It gains haste until end of turn.
+A:SP$ GainControl | ValidTgts$ Permanent | TgtPrompt$ Select target permanent | LoseControl$ EOT | Untap$ True | AddKWs$ Haste | SpellDescription$ Gain control of target permanent until end of turn. Untap it. It gains haste until end of turn.
 AlternateMode:Split
 Oracle:Gain control of target permanent until end of turn. Untap it. It gains haste until end of turn.\nFuse (You may cast one or both halves of this card from your hand.)
 
@@ -11,6 +11,6 @@ ALTERNATE
 Name:Release
 ManaCost:4 R W
 Types:Sorcery
-A:SP$ RepeatEach | Cost$ 4 R W | RepeatPlayers$ Player | RepeatSubAbility$ DBSac | SpellDescription$ Each player sacrifices an artifact, a creature, an enchantment, a land, and a planeswalker.
+A:SP$ RepeatEach | RepeatPlayers$ Player | RepeatSubAbility$ DBSac | SpellDescription$ Each player sacrifices an artifact, a creature, an enchantment, a land, and a planeswalker.
 SVar:DBSac:DB$ Sacrifice | Defined$ Player.IsRemembered | SacValid$ Artifact & Creature & Enchantment & Land & Planeswalker | SacEachValid$ True
 Oracle:Each player sacrifices an artifact, a creature, an enchantment, a land, and a planeswalker.\nFuse (You may cast one or both halves of this card from your hand.)

--- a/forge-gui/res/cardsfolder/c/claim_fame.txt
+++ b/forge-gui/res/cardsfolder/c/claim_fame.txt
@@ -1,7 +1,7 @@
 Name:Claim
 ManaCost:B
 Types:Sorcery
-A:SP$ ChangeZone | Cost$ B | Origin$ Graveyard | Destination$ Battlefield | TgtPrompt$ Choose target creature in your graveyard | ValidTgts$ Creature.YouCtrl+cmcLE2 | SpellDescription$ Return target creature card with mana value 2 or less from your graveyard to the battlefield.
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | TgtPrompt$ Choose target creature in your graveyard | ValidTgts$ Creature.YouCtrl+cmcLE2 | SpellDescription$ Return target creature card with mana value 2 or less from your graveyard to the battlefield.
 AlternateMode:Split
 Oracle:Return target creature card with mana value 2 or less from your graveyard to the battlefield.
 
@@ -11,5 +11,5 @@ Name:Fame
 ManaCost:1 R
 Types:Sorcery
 K:Aftermath
-A:SP$ Pump | Cost$ 1 R | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +2 | KW$ Haste | SpellDescription$ Target creature gets +2/+0 and gains haste until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +2 | KW$ Haste | SpellDescription$ Target creature gets +2/+0 and gains haste until end of turn.
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nTarget creature gets +2/+0 and gains haste until end of turn.

--- a/forge-gui/res/cardsfolder/c/collision_colossus.txt
+++ b/forge-gui/res/cardsfolder/c/collision_colossus.txt
@@ -1,7 +1,7 @@
 Name:Collision
 ManaCost:1 RG
 Types:Instant
-A:SP$ DealDamage | Cost$ 1 RG | ValidTgts$ Creature.withFlying | TgtPrompt$ Select target creature with flying | NumDmg$ 6 | SpellDescription$ CARDNAME deals 6 damage to target creature with flying.
+A:SP$ DealDamage | ValidTgts$ Creature.withFlying | TgtPrompt$ Select target creature with flying | NumDmg$ 6 | SpellDescription$ CARDNAME deals 6 damage to target creature with flying.
 AlternateMode:Split
 Oracle:Collision deals 6 damage to target creature with flying.
 
@@ -10,5 +10,5 @@ ALTERNATE
 Name:Colossus
 ManaCost:R G
 Types:Instant
-A:SP$ Pump | Cost$ R G | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +4 | NumDef$ +2 | KW$ Trample | SpellDescription$ Target creature gets +4/+2 and gains trample until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +4 | NumDef$ +2 | KW$ Trample | SpellDescription$ Target creature gets +4/+2 and gains trample until end of turn.
 Oracle:Target creature gets +4/+2 and gains trample until end of turn.

--- a/forge-gui/res/cardsfolder/c/commit_memory.txt
+++ b/forge-gui/res/cardsfolder/c/commit_memory.txt
@@ -12,6 +12,6 @@ Name:Memory
 ManaCost:4 U U
 Types:Sorcery
 K:Aftermath
-A:SP$ ChangeZoneAll | ChangeType$ Card | Origin$ Hand,Graveyard | Destination$ Library | Shuffle$ True | Random$ True | SubAbility$ DBDraw | UseAllOriginZones$ True | AILogic$ TimeTwister | SpellDescription$ Each player shuffles their graveyard and hand into their library, then draws seven cards.
+A:SP$ ChangeZoneAll | ChangeType$ Card | Origin$ Hand,Graveyard | Destination$ Library | Shuffle$ True | SubAbility$ DBDraw | UseAllOriginZones$ True | AILogic$ TimeTwister | SpellDescription$ Each player shuffles their graveyard and hand into their library, then draws seven cards.
 SVar:DBDraw:DB$ Draw | NumCards$ 7 | Defined$ Player | StackDescription$ None
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nEach player shuffles their hand and graveyard into their library, then draws seven cards.

--- a/forge-gui/res/cardsfolder/c/commit_memory.txt
+++ b/forge-gui/res/cardsfolder/c/commit_memory.txt
@@ -1,7 +1,7 @@
 Name:Commit
 ManaCost:3 U
 Types:Instant
-A:SP$ ChangeZone | Cost$ 3 U | TgtZone$ Stack,Battlefield | Origin$ Battlefield,Stack | Destination$ Library | ValidTgts$ Permanent.nonLand,Card.inZoneStack | TgtPrompt$ Select target spell or nonland permanent | LibraryPosition$ 1 | Fizzle$ True | SpellDescription$ Put target spell or nonland permanent into its owner's library second from the top.
+A:SP$ ChangeZone | TgtZone$ Stack,Battlefield | Origin$ Battlefield,Stack | Destination$ Library | ValidTgts$ Permanent.nonLand,Card.inZoneStack | TgtPrompt$ Select target spell or nonland permanent | LibraryPosition$ 1 | Fizzle$ True | SpellDescription$ Put target spell or nonland permanent into its owner's library second from the top.
 # Library Position is zero indexed. So 1 is second from the top
 AlternateMode:Split
 Oracle:Put target spell or nonland permanent into its owner's library second from the top.
@@ -12,6 +12,6 @@ Name:Memory
 ManaCost:4 U U
 Types:Sorcery
 K:Aftermath
-A:SP$ ChangeZoneAll | Cost$ 4 U U | ChangeType$ Card | Origin$ Hand,Graveyard | Destination$ Library | Shuffle$ True | SubAbility$ DBDraw | UseAllOriginZones$ True | AILogic$ TimeTwister | SpellDescription$ Each player shuffles their graveyard and hand into their library, then draws seven cards.
+A:SP$ ChangeZoneAll | ChangeType$ Card | Origin$ Hand,Graveyard | Destination$ Library | Shuffle$ True | Random$ True | SubAbility$ DBDraw | UseAllOriginZones$ True | AILogic$ TimeTwister | SpellDescription$ Each player shuffles their graveyard and hand into their library, then draws seven cards.
 SVar:DBDraw:DB$ Draw | NumCards$ 7 | Defined$ Player | StackDescription$ None
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nEach player shuffles their hand and graveyard into their library, then draws seven cards.

--- a/forge-gui/res/cardsfolder/c/consecrate_consume.txt
+++ b/forge-gui/res/cardsfolder/c/consecrate_consume.txt
@@ -1,7 +1,7 @@
 Name:Consecrate
 ManaCost:1 WB
 Types:Instant
-A:SP$ ChangeZone | Cost$ 1 WB | Origin$ Graveyard | Destination$ Exile | TgtPrompt$ Choose target card in a graveyard | ValidTgts$ Card | SpellDescription$ Exile target card from a graveyard. | SubAbility$ DBDraw
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Exile | TgtPrompt$ Choose target card in a graveyard | ValidTgts$ Card | SpellDescription$ Exile target card from a graveyard. | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | SpellDescription$ Draw a card.
 AlternateMode:Split
 Oracle:Exile target card from a graveyard.\nDraw a card.
@@ -11,7 +11,7 @@ ALTERNATE
 Name:Consume
 ManaCost:2 W B
 Types:Sorcery
-A:SP$ Sacrifice | Cost$ 2 W B | ValidTgts$ Player | SacValid$ Creature.greatestPowerControlledByTargeted | SubAbility$ DBGainLife | SacMessage$ the creature with the highest power | RememberSacrificed$ True | SpellDescription$ Target player sacrifices a creature with the greatest power among creatures they control. You gain life equal to its power.
+A:SP$ Sacrifice | ValidTgts$ Player | SacValid$ Creature.greatestPowerControlledByTargeted | SubAbility$ DBGainLife | SacMessage$ the creature with the highest power | RememberSacrificed$ True | SpellDescription$ Target player sacrifices a creature with the greatest power among creatures they control. You gain life equal to its power.
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:RememberedLKI$CardPower

--- a/forge-gui/res/cardsfolder/c/consign_oblivion.txt
+++ b/forge-gui/res/cardsfolder/c/consign_oblivion.txt
@@ -1,7 +1,7 @@
 Name:Consign
 ManaCost:1 U
 Types:Instant
-A:SP$ ChangeZone | Cost$ 1 U | ValidTgts$ Permanent.nonLand | TgtPrompt$ Select target nonland permanent | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return target nonland permanent to its owner's hand.
+A:SP$ ChangeZone | ValidTgts$ Permanent.nonLand | TgtPrompt$ Select target nonland permanent | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return target nonland permanent to its owner's hand.
 AlternateMode:Split
 Oracle:Return target nonland permanent to its owner's hand.
 
@@ -11,5 +11,5 @@ Name:Oblivion
 ManaCost:4 B
 Types:Sorcery
 K:Aftermath
-A:SP$ Discard | Cost$ 4 B | ValidTgts$ Opponent | NumCards$ 2 | Mode$ TgtChoose | SpellDescription$ Target opponent discards two cards.
+A:SP$ Discard | ValidTgts$ Opponent | NumCards$ 2 | Mode$ TgtChoose | SpellDescription$ Target opponent discards two cards.
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nTarget opponent discards two cards.

--- a/forge-gui/res/cardsfolder/c/crime_punishment.txt
+++ b/forge-gui/res/cardsfolder/c/crime_punishment.txt
@@ -1,7 +1,7 @@
 Name:Crime
 ManaCost:3 W B
 Types:Sorcery
-A:SP$ ChangeZone | Cost$ 3 W B | Origin$ Graveyard | Destination$ Battlefield | GainControl$ True | TgtPrompt$ Choose target creature or enchantment in an opponent's graveyard | ValidTgts$ Creature.OppCtrl,Enchantment.OppCtrl | SpellDescription$ Put target creature or enchantment card from an opponent's graveyard onto the battlefield under your control.
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | GainControl$ True | TgtPrompt$ Choose target creature or enchantment in an opponent's graveyard | ValidTgts$ Creature.OppCtrl,Enchantment.OppCtrl | SpellDescription$ Put target creature or enchantment card from an opponent's graveyard onto the battlefield under your control.
 AlternateMode:Split
 Oracle:Put target creature or enchantment card from an opponent's graveyard onto the battlefield under your control.
 
@@ -10,6 +10,6 @@ ALTERNATE
 Name:Punishment
 ManaCost:X B G
 Types:Sorcery
-A:SP$ DestroyAll | Cost$ X B G | ValidCards$ Artifact.cmcEQX,Creature.cmcEQX,Enchantment.cmcEQX | SpellDescription$ Destroy each artifact, creature, and enchantment with mana value X.
+A:SP$ DestroyAll | ValidCards$ Artifact.cmcEQX,Creature.cmcEQX,Enchantment.cmcEQX | SpellDescription$ Destroy each artifact, creature, and enchantment with mana value X.
 SVar:X:Count$xPaid
 Oracle:Destroy each artifact, creature, and enchantment with mana value X.

--- a/forge-gui/res/cardsfolder/c/cut_ribbons.txt
+++ b/forge-gui/res/cardsfolder/c/cut_ribbons.txt
@@ -1,7 +1,7 @@
 Name:Cut
 ManaCost:1 R
 Types:Sorcery
-A:SP$ DealDamage | Cost$ 1 R | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 4 | SpellDescription$ CARDNAME deals 4 damage to target creature.
+A:SP$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 4 | SpellDescription$ CARDNAME deals 4 damage to target creature.
 AlternateMode:Split
 Oracle:Cut deals 4 damage to target creature.
 
@@ -11,6 +11,6 @@ Name:Ribbons
 ManaCost:X B B
 Types:Sorcery
 K:Aftermath
-A:SP$ LoseLife | Cost$ X B B | Defined$ Player.Opponent | LifeAmount$ X | SpellDescription$ Each opponent loses X life.
+A:SP$ LoseLife | Defined$ Player.Opponent | LifeAmount$ X | SpellDescription$ Each opponent loses X life.
 SVar:X:Count$xPaid
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nEach opponent loses X life.

--- a/forge-gui/res/cardsfolder/d/damn.txt
+++ b/forge-gui/res/cardsfolder/d/damn.txt
@@ -1,6 +1,6 @@
 Name:Damn
 ManaCost:B B
 Types:Sorcery
-A:SP$ Destroy | Cost$ B B | ValidTgts$ Creature | TgtPrompt$ Select target creature | NoRegen$ True | SpellDescription$ Destroy target creature. A creature destroyed this way can't be regenerated.
-A:SP$ DestroyAll | Cost$ 2 W W | ValidCards$ Creature | NoRegen$ True | SpellDescription$ Destroy each creature. A creature destroyed this way can't be regenerated.
+K:Overload:2 W W
+A:SP$ Destroy | ValidTgts$ Creature | TgtPrompt$ Select target creature | NoRegen$ True | SpellDescription$ Destroy target creature. A creature destroyed this way can't be regenerated.
 Oracle:Destroy target creature. A creature destroyed this way can't be regenerated.\nOverload {2}{W}{W} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")

--- a/forge-gui/res/cardsfolder/d/dead_gone.txt
+++ b/forge-gui/res/cardsfolder/d/dead_gone.txt
@@ -1,7 +1,7 @@
 Name:Dead
 ManaCost:R
 Types:Instant
-A:SP$ DealDamage | Cost$ R | ValidTgts$ Creature | NumDmg$ 2 | SpellDescription$ Dead deals 2 damage to target creature.
+A:SP$ DealDamage | ValidTgts$ Creature | NumDmg$ 2 | SpellDescription$ Dead deals 2 damage to target creature.
 AlternateMode:Split
 Oracle:Dead deals 2 damage to target creature.
 
@@ -10,5 +10,5 @@ ALTERNATE
 Name:Gone
 ManaCost:2 R
 Types:Instant
-A:SP$ ChangeZone | Cost$ 2 R | ValidTgts$ Creature.YouDontCtrl | TgtPrompt$ Select target creature you don't control | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return target creature you don't control to its owner's hand.
+A:SP$ ChangeZone | ValidTgts$ Creature.YouDontCtrl | TgtPrompt$ Select target creature you don't control | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return target creature you don't control to its owner's hand.
 Oracle:Return target creature you don't control to its owner's hand.

--- a/forge-gui/res/cardsfolder/d/depose_deploy.txt
+++ b/forge-gui/res/cardsfolder/d/depose_deploy.txt
@@ -1,5 +1,5 @@
 Name:Depose
-ManaCost:1 W/U
+ManaCost:1 WU
 Types:Instant
 A:SP$ Tap | ValidTgts$ Creature | SubAbility$ DBDraw | SpellDescription$ Tap target creature. Draw a card.
 SVar:DBDraw:DB$ Draw | NumCards$ 1

--- a/forge-gui/res/cardsfolder/d/depose_deploy.txt
+++ b/forge-gui/res/cardsfolder/d/depose_deploy.txt
@@ -1,7 +1,7 @@
 Name:Depose
 ManaCost:1 W/U
 Types:Instant
-A:SP$ Tap | Cost$ 1 WU | ValidTgts$ Creature | SubAbility$ DBDraw | SpellDescription$ Tap target creature. Draw a card.
+A:SP$ Tap | ValidTgts$ Creature | SubAbility$ DBDraw | SpellDescription$ Tap target creature. Draw a card.
 SVar:DBDraw:DB$ Draw | NumCards$ 1
 AlternateMode:Split
 Oracle:Tap target creature.\nDraw a card.
@@ -11,7 +11,7 @@ ALTERNATE
 Name:Deploy
 ManaCost:2 W U
 Types:Instant
-A:SP$ Token | Cost$ 2 W U | TokenAmount$ 2 | TokenOwner$ You | TokenScript$ c_1_1_a_thopter_flying | SubAbility$ DBGainLife | SpellDescription$ Create two 1/1 colorless Thopter artifact creature tokens with flying, then you gain 1 life for each creature you control.
+A:SP$ Token | TokenAmount$ 2 | TokenOwner$ You | TokenScript$ c_1_1_a_thopter_flying | SubAbility$ DBGainLife | SpellDescription$ Create two 1/1 colorless Thopter artifact creature tokens with flying, then you gain 1 life for each creature you control.
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ X
 SVar:X:Count$TypeYouCtrl.Creature
 DeckHas:Ability$Token

--- a/forge-gui/res/cardsfolder/d/destined_lead.txt
+++ b/forge-gui/res/cardsfolder/d/destined_lead.txt
@@ -1,7 +1,7 @@
 Name:Destined
 ManaCost:1 B
 Types:Instant
-A:SP$ Pump | Cost$ 1 B | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +1 | KW$ Indestructible | SpellDescription$ Target creature gets +1/+0 and gains indestructible until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +1 | KW$ Indestructible | SpellDescription$ Target creature gets +1/+0 and gains indestructible until end of turn.
 AlternateMode:Split
 Oracle:Target creature gets +1/+0 and gains indestructible until end of turn.
 
@@ -11,5 +11,5 @@ Name:Lead
 ManaCost:3 G
 Types:Sorcery
 K:Aftermath
-A:SP$ Pump | Cost$ 3 G | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ HIDDEN All creatures able to block CARDNAME do so. | SpellDescription$ All creatures able to block target creature this turn do so.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ HIDDEN All creatures able to block CARDNAME do so. | SpellDescription$ All creatures able to block target creature this turn do so.
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nAll creatures able to block target creature this turn do so.

--- a/forge-gui/res/cardsfolder/d/discovery_dispersal.txt
+++ b/forge-gui/res/cardsfolder/d/discovery_dispersal.txt
@@ -1,7 +1,7 @@
 Name:Discovery
-ManaCost:1 U/B
+ManaCost:1 UB
 Types:Sorcery
-A:SP$ Surveil | Cost$ 1 U/B | Amount$ 2 | SubAbility$ DBDraw | SpellDescription$ Surveil 2, then draw a card.
+A:SP$ Surveil | Amount$ 2 | SubAbility$ DBDraw | SpellDescription$ Surveil 2, then draw a card.
 SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1
 DeckHas:Ability$Surveil|Graveyard
 AlternateMode:Split
@@ -12,7 +12,7 @@ ALTERNATE
 Name:Dispersal
 ManaCost:3 U B
 Types:Instant
-A:SP$ RepeatEach | Cost$ 3 U B | RepeatPlayers$ Player.Opponent | RepeatSubAbility$ TrigChooseReturn | SubAbility$ DBReturn | SpellDescription$ Each opponent returns a nonland permanent they control with the highest mana value among permanents they control to its owner's hand, then discards a card.
+A:SP$ RepeatEach | RepeatPlayers$ Player.Opponent | RepeatSubAbility$ TrigChooseReturn | SubAbility$ DBReturn | SpellDescription$ Each opponent returns a nonland permanent they control with the highest mana value among permanents they control to its owner's hand, then discards a card.
 SVar:TrigChooseReturn:DB$ ChooseCard | Defined$ Remembered | Choices$ Permanent.greatestCMC_NonLandPermanentControlledByRemembered | ChoiceTitle$ Choose a nonland permanent with the highest mana value | Mandatory$ True | RememberChosen$ True
 SVar:DBReturn:DB$ ChangeZone | Origin$ Battlefield | Destination$ Hand | Defined$ Remembered | SubAbility$ DBDiscard
 SVar:DBDiscard:DB$ Discard | Defined$ Player.Opponent | NumCards$ 1 | Mode$ TgtChoose | SubAbility$ DBCleanup

--- a/forge-gui/res/cardsfolder/d/down_dirty.txt
+++ b/forge-gui/res/cardsfolder/d/down_dirty.txt
@@ -2,7 +2,7 @@ Name:Down
 ManaCost:3 B
 Types:Sorcery
 K:Fuse
-A:SP$ Discard | Cost$ 3 B | ValidTgts$ Player | NumCards$ 2 | Mode$ TgtChoose | SpellDescription$ Target player discards two cards.
+A:SP$ Discard | ValidTgts$ Player | NumCards$ 2 | Mode$ TgtChoose | SpellDescription$ Target player discards two cards.
 AlternateMode:Split
 Oracle:Target player discards two cards.\nFuse (You may cast one or both halves of this card from your hand.)
 
@@ -11,5 +11,5 @@ ALTERNATE
 Name:Dirty
 ManaCost:2 G
 Types:Sorcery
-A:SP$ ChangeZone | Cost$ 2 G | TgtPrompt$ Select target card in your graveyard | ValidTgts$ Card.YouCtrl | Origin$ Graveyard | Destination$ Hand | SpellDescription$ Return target card from your graveyard to your hand.
+A:SP$ ChangeZone | TgtPrompt$ Select target card in your graveyard | ValidTgts$ Card.YouCtrl | Origin$ Graveyard | Destination$ Hand | SpellDescription$ Return target card from your graveyard to your hand.
 Oracle:Return target card from your graveyard to your hand.\nFuse (You may cast one or both halves of this card from your hand.)

--- a/forge-gui/res/cardsfolder/d/driven_despair.txt
+++ b/forge-gui/res/cardsfolder/d/driven_despair.txt
@@ -1,7 +1,7 @@
 Name:Driven
 ManaCost:1 G
 Types:Sorcery
-A:SP$ AnimateAll | Cost$ 1 G | ValidCards$ Creature.YouCtrl | Keywords$ Trample | Triggers$ Trig1 | StackDescription$ SpellDescription | SpellDescription$ Until end of turn, creatures you control gain trample and "Whenever this creature deals combat damage to a player, draw a card."
+A:SP$ AnimateAll | ValidCards$ Creature.YouCtrl | Keywords$ Trample | Triggers$ Trig1 | StackDescription$ SpellDescription | SpellDescription$ Until end of turn, creatures you control gain trample and "Whenever this creature deals combat damage to a player, draw a card."
 SVar:Trig1:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ Eff1 | CombatDamage$ True | TriggerDescription$ Whenever this creature deals combat damage to a player, draw a card.
 SVar:Eff1:DB$ Draw | NumCards$ 1
 AlternateMode:Split
@@ -13,7 +13,7 @@ Name:Despair
 ManaCost:1 B
 Types:Sorcery
 K:Aftermath
-A:SP$ AnimateAll | Cost$ 1 B | ValidCards$ Creature.YouCtrl | Keywords$ Menace | Triggers$ Trig2 | StackDescription$ SpellDescription | SpellDescription$ Until end of turn, creatures you control gain menace and "Whenever this creature deals combat damage to a player, that player discards a card."
+A:SP$ AnimateAll | ValidCards$ Creature.YouCtrl | Keywords$ Menace | Triggers$ Trig2 | StackDescription$ SpellDescription | SpellDescription$ Until end of turn, creatures you control gain menace and "Whenever this creature deals combat damage to a player, that player discards a card."
 SVar:Trig2:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ Eff2 | CombatDamage$ True | TriggerDescription$ Whenever this creature deals combat damage to a player, that player discards a card.
 SVar:Eff2:DB$ Discard | Defined$ TriggeredTarget | NumCards$ 1 | Mode$ TgtChoose
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nUntil end of turn, creatures you control gain menace and "Whenever this creature deals combat damage to a player, that player discards a card."

--- a/forge-gui/res/cardsfolder/d/dusk_dawn.txt
+++ b/forge-gui/res/cardsfolder/d/dusk_dawn.txt
@@ -1,7 +1,7 @@
 Name:Dusk
 ManaCost:2 W W
 Types:Sorcery
-A:SP$ DestroyAll | Cost$ 2 W W | ValidCards$ Creature.powerGE3 | SpellDescription$ Destroy all creatures with power 3 or greater.
+A:SP$ DestroyAll | ValidCards$ Creature.powerGE3 | SpellDescription$ Destroy all creatures with power 3 or greater.
 SVar:NeedsToPlayVar:Y GTZ
 SVar:Y:Count$Valid Creature.OppCtrl+powerGE3
 SVar:Z:Count$Valid Creature.YouCtrl+powerGE3
@@ -14,7 +14,7 @@ Name:Dawn
 ManaCost:3 W W
 Types:Sorcery
 K:Aftermath
-A:SP$ ChangeZoneAll | Cost$ 3 W W | ChangeType$ Creature.powerLE2+YouCtrl | Origin$ Graveyard | Destination$ Hand | SpellDescription$ Return all creature cards with power 2 or less from your graveyard to your hand.
+A:SP$ ChangeZoneAll | ChangeType$ Creature.powerLE2+YouCtrl | Origin$ Graveyard | Destination$ Hand | SpellDescription$ Return all creature cards with power 2 or less from your graveyard to your hand.
 SVar:SplitNeedsToPlayVar:ZZ GE1
 SVar:ZZ:Count$ValidGraveyard Creature.YouCtrl+powerLE2
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nReturn all creature cards with power 2 or less from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/e/essence_filter.txt
+++ b/forge-gui/res/cardsfolder/e/essence_filter.txt
@@ -1,7 +1,7 @@
 Name:Essence Filter
 ManaCost:1 G G
 Types:Sorcery
-A:SP$ DestroyAll | Cost$ 1 G G | ValidCards$ Enchantment | SpellDescription$ Destroy all enchantments
-A:SP$ DestroyAll | Cost$ 1 G G | ValidCards$ Enchantment.nonWhite | SpellDescription$ or all nonwhite enchantments.
+A:SP$ DestroyAll | ValidCards$ Enchantment | SpellDescription$ Destroy all enchantments
+A:SP$ DestroyAll | ValidCards$ Enchantment.nonWhite | SpellDescription$ or all nonwhite enchantments.
 DeckHints:Color$White
 Oracle:Destroy all enchantments or all nonwhite enchantments.

--- a/forge-gui/res/cardsfolder/e/essence_filter.txt
+++ b/forge-gui/res/cardsfolder/e/essence_filter.txt
@@ -1,7 +1,8 @@
-Name:Essence Filter
+Name:Essence Filter 2
 ManaCost:1 G G
 Types:Sorcery
-A:SP$ DestroyAll | ValidCards$ Enchantment | SpellDescription$ Destroy all enchantments
-A:SP$ DestroyAll | ValidCards$ Enchantment.nonWhite | SpellDescription$ or all nonwhite enchantments.
+A:SP$ GenericChoice | Choices$ DBKillAllEnch,DBKillNonWEnch | Defined$ You | AILogic$ BestOption | StackDescription$ SpellDescription | SpellDescription$ Destroy all enchantments or all nonwhite enchantments.
+SVar:DBKillAllEnch:DB$ DestroyAll | ValidCards$ Enchantment | SpellDescription$ Destroy all enchantments.
+SVar:DBKillNonWEnch:DB$ DestroyAll | ValidCards$ Enchantment.nonWhite | SpellDescription$ Destroy all nonwhite enchantments.
 DeckHints:Color$White
 Oracle:Destroy all enchantments or all nonwhite enchantments.

--- a/forge-gui/res/cardsfolder/e/essence_filter.txt
+++ b/forge-gui/res/cardsfolder/e/essence_filter.txt
@@ -1,4 +1,4 @@
-Name:Essence Filter 2
+Name:Essence Filter
 ManaCost:1 G G
 Types:Sorcery
 A:SP$ GenericChoice | Choices$ DBKillAllEnch,DBKillNonWEnch | Defined$ You | AILogic$ BestOption | StackDescription$ SpellDescription | SpellDescription$ Destroy all enchantments or all nonwhite enchantments.

--- a/forge-gui/res/cardsfolder/e/expansion_explosion.txt
+++ b/forge-gui/res/cardsfolder/e/expansion_explosion.txt
@@ -1,7 +1,7 @@
 Name:Expansion
-ManaCost:U/R U/R
+ManaCost:UR UR
 Types:Instant
-A:SP$ CopySpellAbility | Cost$ U/R U/R | ValidTgts$ Card.Instant+cmcLE4,Card.Sorcery+cmcLE4 | TargetType$ Spell | MayChooseTarget$ True | SpellDescription$ Copy target instant or sorcery spell with mana value 4 or less. You may choose new targets for the copy.
+A:SP$ CopySpellAbility | ValidTgts$ Card.Instant+cmcLE4,Card.Sorcery+cmcLE4 | TargetType$ Spell | MayChooseTarget$ True | SpellDescription$ Copy target instant or sorcery spell with mana value 4 or less. You may choose new targets for the copy.
 AlternateMode:Split
 Oracle:Copy target instant or sorcery spell with mana value 4 or less. You may choose new targets for the copy.
 
@@ -10,7 +10,7 @@ ALTERNATE
 Name:Explosion
 ManaCost:X U U R R
 Types:Instant
-A:SP$ DealDamage | Cost$ X U U R R | ValidTgts$ Any | NumDmg$ X | SubAbility$ DBDraw | SpellDescription$ CARDNAME deals X damage to any target. Target player draws X cards.
+A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ X | SubAbility$ DBDraw | SpellDescription$ CARDNAME deals X damage to any target. Target player draws X cards.
 SVar:DBDraw:DB$ Draw | NumCards$ X | ValidTgts$ Player | TgtPrompt$ Select target player
 SVar:X:Count$xPaid
 Oracle:Explosion deals X damage to any target. Target player draws X cards.

--- a/forge-gui/res/cardsfolder/f/failure_comply.txt
+++ b/forge-gui/res/cardsfolder/f/failure_comply.txt
@@ -1,7 +1,7 @@
 Name:Failure
 ManaCost:1 U
 Types:Instant
-A:SP$ ChangeZone | Cost$ 1 U | ValidTgts$ Card | TargetType$ Spell | TgtZone$ Stack | Origin$ Stack | Fizzle$ True | Destination$ Hand | SpellDescription$ Return target spell to its owner's hand.
+A:SP$ ChangeZone | ValidTgts$ Card | TargetType$ Spell | TgtZone$ Stack | Origin$ Stack | Fizzle$ True | Destination$ Hand | SpellDescription$ Return target spell to its owner's hand.
 AlternateMode:Split
 Oracle:Return target spell to its owner's hand.
 
@@ -11,7 +11,7 @@ Name:Comply
 ManaCost:W
 Types:Sorcery
 K:Aftermath
-A:SP$ NameCard | Cost$ W | Defined$ You | SubAbility$ DBEffect | SpellDescription$ Choose a card name. Until your next turn, your opponents can't cast spells with the chosen name.
+A:SP$ NameCard | Defined$ You | SubAbility$ DBEffect | SpellDescription$ Choose a card name. Until your next turn, your opponents can't cast spells with the chosen name.
 SVar:DBEffect:DB$ Effect | StaticAbilities$ CantCast | Duration$ UntilYourNextTurn
 SVar:CantCast:Mode$ CantBeCast | ValidCard$ Card.nonLand+NamedCard | Caster$ Opponent | EffectZone$ Command | Description$ Your opponents can't cast spells with the chosen name.
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nChoose a card name. Until your next turn, your opponents can't cast spells with the chosen name.

--- a/forge-gui/res/cardsfolder/f/far_away.txt
+++ b/forge-gui/res/cardsfolder/f/far_away.txt
@@ -2,7 +2,7 @@ Name:Far
 ManaCost:1 U
 Types:Instant
 K:Fuse
-A:SP$ ChangeZone | Cost$ 1 U | ValidTgts$ Creature | TgtPrompt$ Select target creature | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return target creature to its owner's hand.
+A:SP$ ChangeZone | ValidTgts$ Creature | TgtPrompt$ Select target creature | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return target creature to its owner's hand.
 AlternateMode:Split
 Oracle:Return target creature to its owner's hand.\nFuse (You may cast one or both halves of this card from your hand.)
 
@@ -11,5 +11,5 @@ ALTERNATE
 Name:Away
 ManaCost:2 B
 Types:Instant
-A:SP$ Sacrifice | Cost$ 2 B | ValidTgts$ Player | SacValid$ Creature | SacMessage$ Creature | SpellDescription$ Target player sacrifices a creature.
+A:SP$ Sacrifice | ValidTgts$ Player | SacValid$ Creature | SacMessage$ Creature | SpellDescription$ Target player sacrifices a creature.
 Oracle:Target player sacrifices a creature.\nFuse (You may cast one or both halves of this card from your hand.)

--- a/forge-gui/res/cardsfolder/f/farm_market.txt
+++ b/forge-gui/res/cardsfolder/f/farm_market.txt
@@ -1,7 +1,7 @@
 Name:Farm
 ManaCost:2 W
 Types:Instant
-A:SP$ Destroy | Cost$ 2 W | ValidTgts$ Creature.attacking,Creature.blocking | TgtPrompt$ Select target attacking or blocking creature | SpellDescription$ Destroy target attacking or blocking creature.
+A:SP$ Destroy | ValidTgts$ Creature.attacking,Creature.blocking | TgtPrompt$ Select target attacking or blocking creature | SpellDescription$ Destroy target attacking or blocking creature.
 AlternateMode:Split
 Oracle:Destroy target attacking or blocking creature.
 
@@ -11,6 +11,6 @@ Name:Market
 ManaCost:2 U
 Types:Sorcery
 K:Aftermath
-A:SP$ Draw | Cost$ 2 U | NumCards$ 2 | SpellDescription$ Draw two cards, then discard two cards. | SubAbility$ DBDiscard
+A:SP$ Draw | NumCards$ 2 | SpellDescription$ Draw two cards, then discard two cards. | SubAbility$ DBDiscard
 SVar:DBDiscard:DB$ Discard | Defined$ You | NumCards$ 2 | Mode$ TgtChoose
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nDraw two cards, then discard two cards.

--- a/forge-gui/res/cardsfolder/f/find_finality.txt
+++ b/forge-gui/res/cardsfolder/f/find_finality.txt
@@ -1,7 +1,7 @@
 Name:Find
-ManaCost:B/G B/G
+ManaCost:BG BG
 Types:Sorcery
-A:SP$ ChangeZone | Cost$ B/G B/G | Origin$ Graveyard | Destination$ Hand | TargetMin$ 0 | TargetMax$ 2 | TgtPrompt$ Choose target creature card in your graveyard | ValidTgts$ Creature.YouOwn | SpellDescription$ Return up to two target creature cards from your graveyard to your hand.
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Hand | TargetMin$ 0 | TargetMax$ 2 | TgtPrompt$ Choose target creature card in your graveyard | ValidTgts$ Creature.YouOwn | SpellDescription$ Return up to two target creature cards from your graveyard to your hand.
 AlternateMode:Split
 Oracle:Return up to two target creature cards from your graveyard to your hand.
 
@@ -10,7 +10,7 @@ ALTERNATE
 Name:Finality
 ManaCost:4 B G
 Types:Sorcery
-A:SP$ PutCounter | Cost$ 4 B G | Choices$ Creature.YouCtrl | ChoiceOptional$ True | CounterType$ P1P1 | CounterNum$ 2 | SubAbility$ DBPumpAll | StackDescription$ SpellDescription | SpellDescription$ You may put two +1/+1 counters on a creature you control. Then all creatures get -4/-4 until end of turn.
+A:SP$ PutCounter | Choices$ Creature.YouCtrl | ChoiceOptional$ True | CounterType$ P1P1 | CounterNum$ 2 | SubAbility$ DBPumpAll | StackDescription$ SpellDescription | SpellDescription$ You may put two +1/+1 counters on a creature you control. Then all creatures get -4/-4 until end of turn.
 SVar:DBPumpAll:DB$ PumpAll | ValidCards$ Creature | NumAtt$ -4 | NumDef$ -4 | IsCurse$ True
 DeckHas:Ability$Counters
 Oracle:You may put two +1/+1 counters on a creature you control. Then all creatures get -4/-4 until end of turn.

--- a/forge-gui/res/cardsfolder/f/fire_ice.txt
+++ b/forge-gui/res/cardsfolder/f/fire_ice.txt
@@ -1,7 +1,7 @@
 Name:Fire
 ManaCost:1 R
 Types:Instant
-A:SP$ DealDamage | Cost$ 1 R | ValidTgts$ Any | TgtPrompt$ Select any target to distribute damage to | NumDmg$ 2 | TargetMin$ 1 | TargetMax$ 2 | DividedAsYouChoose$ 2 | SpellDescription$ Fire deals 2 damage divided as you choose among one or two targets.
+A:SP$ DealDamage | ValidTgts$ Any | TgtPrompt$ Select any target to distribute damage to | NumDmg$ 2 | TargetMin$ 1 | TargetMax$ 2 | DividedAsYouChoose$ 2 | SpellDescription$ Fire deals 2 damage divided as you choose among one or two targets.
 AlternateMode:Split
 Oracle:Fire deals 2 damage divided as you choose among one or two targets.
 
@@ -10,6 +10,6 @@ ALTERNATE
 Name:Ice
 ManaCost:1 U
 Types:Instant
-A:SP$ Tap | Cost$ 1 U | ValidTgts$ Permanent | TgtPrompt$ Select target permanent | SubAbility$ DBDraw | SpellDescription$ Tap target permanent. Draw a card.
+A:SP$ Tap | ValidTgts$ Permanent | TgtPrompt$ Select target permanent | SubAbility$ DBDraw | SpellDescription$ Tap target permanent. Draw a card.
 SVar:DBDraw:DB$ Draw | NumCards$ 1
 Oracle:Tap target permanent.\nDraw a card.

--- a/forge-gui/res/cardsfolder/f/flesh_blood.txt
+++ b/forge-gui/res/cardsfolder/f/flesh_blood.txt
@@ -2,7 +2,7 @@ Name:Flesh
 ManaCost:3 B G
 Types:Sorcery
 K:Fuse
-A:SP$ ChangeZone | Cost$ 3 B G | Origin$ Graveyard | Destination$ Exile | TgtPrompt$ Choose target creature card in a graveyard | ValidTgts$ Creature | SubAbility$ DBPutCounter | SpellDescription$ Exile target creature card from a graveyard. Put X +1/+1 counters on target creature, where X is the power of the card you exiled.
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Exile | TgtPrompt$ Choose target creature card in a graveyard | ValidTgts$ Creature | SubAbility$ DBPutCounter | SpellDescription$ Exile target creature card from a graveyard. Put X +1/+1 counters on target creature, where X is the power of the card you exiled.
 SVar:DBPutCounter:DB$ PutCounter | ValidTgts$ Creature | TgtPrompt$ Select target creature to put counters | CounterType$ P1P1 | CounterNum$ X
 SVar:X:ParentTargeted$CardPower
 DeckHas:Ability$Counters
@@ -14,7 +14,7 @@ ALTERNATE
 Name:Blood
 ManaCost:R G
 Types:Sorcery
-A:SP$ Pump | Cost$ R G | ValidTgts$ Creature.YouCtrl | AILogic$ PowerDmg | TgtPrompt$ Select target creature you control | SubAbility$ BloodDamage | StackDescription$ None | SpellDescription$ Target creature you control deals damage equal to its power to any target.
+A:SP$ Pump | ValidTgts$ Creature.YouCtrl | AILogic$ PowerDmg | TgtPrompt$ Select target creature you control | SubAbility$ BloodDamage | StackDescription$ None | SpellDescription$ Target creature you control deals damage equal to its power to any target.
 SVar:BloodDamage:DB$ DealDamage | ValidTgts$ Any | AILogic$ PowerDmg | NumDmg$ Y | DamageSource$ ParentTarget
 SVar:Y:ParentTargeted$CardPower
 Oracle:Target creature you control deals damage equal to its power to any target.\nFuse (You may cast one or both halves of this card from your hand.)

--- a/forge-gui/res/cardsfolder/f/flower_flourish.txt
+++ b/forge-gui/res/cardsfolder/f/flower_flourish.txt
@@ -1,7 +1,7 @@
 Name:Flower
-ManaCost:G/W
+ManaCost:GW
 Types:Sorcery
-A:SP$ ChangeZone | Cost$ G/W | Origin$ Library | Destination$ Hand | ChangeType$ Land.Forest+Basic,Land.Plains+Basic | ChangeNum$ 1 | SpellDescription$ Search your library for a basic Forest or Plains card, reveal it, put it into your hand, then shuffle.
+A:SP$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Land.Forest+Basic,Land.Plains+Basic | ChangeNum$ 1 | SpellDescription$ Search your library for a basic Forest or Plains card, reveal it, put it into your hand, then shuffle.
 AlternateMode:Split
 Oracle:Search your library for a basic Forest or Plains card, reveal it, put it into your hand, then shuffle.
 
@@ -10,5 +10,5 @@ ALTERNATE
 Name:Flourish
 ManaCost:4 G W
 Types:Sorcery
-A:SP$ PumpAll | Cost$ 4 G W | ValidCards$ Creature.YouCtrl | NumAtt$ +2 | NumDef$ +2 | SpellDescription$ Creatures you control get +2/+2 until end of turn.
+A:SP$ PumpAll | ValidCards$ Creature.YouCtrl | NumAtt$ +2 | NumDef$ +2 | SpellDescription$ Creatures you control get +2/+2 until end of turn.
 Oracle:Creatures you control get +2/+2 until end of turn.

--- a/forge-gui/res/cardsfolder/g/give_take.txt
+++ b/forge-gui/res/cardsfolder/g/give_take.txt
@@ -2,7 +2,7 @@ Name:Give
 ManaCost:2 G
 Types:Sorcery
 K:Fuse
-A:SP$ PutCounter | Cost$ 2 G | ValidTgts$ Creature | TgtPrompt$ Select target creature to put counters | CounterType$ P1P1 | CounterNum$ 3 | SpellDescription$ Put three +1/+1 counters on target creature.
+A:SP$ PutCounter | ValidTgts$ Creature | TgtPrompt$ Select target creature to put counters | CounterType$ P1P1 | CounterNum$ 3 | SpellDescription$ Put three +1/+1 counters on target creature.
 DeckHas:Ability$Counters
 AlternateMode:Split
 Oracle:Put three +1/+1 counters on target creature.\nFuse (You may cast one or both halves of this card from your hand.)
@@ -12,7 +12,7 @@ ALTERNATE
 Name:Take
 ManaCost:2 U
 Types:Sorcery
-A:SP$ RemoveCounter | Cost$ 2 U | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control to remove counters | CounterType$ P1P1 | CounterNum$ All | RememberRemoved$ True | SubAbility$ DBDraw | SpellDescription$ Remove all +1/+1 counters from target creature you control. Draw that many cards.
+A:SP$ RemoveCounter | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control to remove counters | CounterType$ P1P1 | CounterNum$ All | RememberRemoved$ True | SubAbility$ DBDraw | SpellDescription$ Remove all +1/+1 counters from target creature you control. Draw that many cards.
 SVar:DBDraw:DB$ Draw | NumCards$ X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Count$RememberedSize

--- a/forge-gui/res/cardsfolder/g/graveyard_dig.txt
+++ b/forge-gui/res/cardsfolder/g/graveyard_dig.txt
@@ -1,6 +1,9 @@
 Name:Graveyard Dig
 ManaCost:1 BG
 Types:Sorcery
-A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Hand | TargetMin$ 0 | TargetMax$ 2 | TgtPrompt$ Choose up to two target black or green creature cards in your graveyard | ValidTgts$ Creature.YouCtrl+Black,Creature.YouCtrl+Green | SpellDescription$ Return up to two target black or green creature cards from your graveyard to your hand.
-A:SP$ ChangeZone | Cost$ 2 BG BG | Origin$ Graveyard | Destination$ Hand | TargetMin$ 0 | TargetMax$ 2 | TgtPrompt$ Choose up to two target creature cards in your graveyard | ValidTgts$ Creature.YouCtrl | SpellDescription$ Return up to two target creature cards from your graveyard to your hand.
+S:Mode$ AlternativeCost | ValidSA$ Spell.Self | EffectZone$ All | Cost$ 2 BG BG | Description$ You may cast this spell for {2}{B/G}{B/G}. If you do, ignore the bracketed text.
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Hand | TargetMin$ 0 | TargetMax$ X | TgtPrompt$ Choose up to two target black or green creature cards in your graveyard | ValidTgts$ Creature.YouCtrl+Black,Creature.YouCtrl+Green | SubAbility$ DBReturnAnyTwo | StackDescription$ SpellDescription | SpellDescription$ Return up to two target [black or green] creature cards from your graveyard to your hand.
+SVar:DBReturnAnyTwo:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | TargetMin$ 0 | TargetMax$ Y | TgtPrompt$ Choose up to two target creature cards in your graveyard | ValidTgts$ Creature.YouCtrl | StackDescription$ None
+SVar:X:Count$AltCost.0.2
+SVar:Y:Count$AltCost.2.0
 Oracle:Return up to two target [black or green] creature cards from your graveyard to your hand.\nYou may cast this spell for {2}{B/G}{B/G}. If you do, ignore the bracketed text.

--- a/forge-gui/res/cardsfolder/g/graveyard_dig.txt
+++ b/forge-gui/res/cardsfolder/g/graveyard_dig.txt
@@ -1,6 +1,6 @@
 Name:Graveyard Dig
 ManaCost:1 BG
 Types:Sorcery
-A:SP$ ChangeZone | Cost$ 1 BG | Origin$ Graveyard | Destination$ Hand | TargetMin$ 2 | TargetMax$ 2 | TgtPrompt$ Choose target creature card in your graveyard | ValidTgts$ Creature.YouCtrl+Black,Creature.YouCtrl+Green | SpellDescription$ Return two target black or green creature cards from your graveyard to your hand.
-A:SP$ ChangeZone | Cost$ 2 BG BG | Origin$ Graveyard | Destination$ Hand | TargetMin$ 2 | TargetMax$ 2 | TgtPrompt$ Choose target creature card in your graveyard | ValidTgts$ Creature.YouCtrl | SpellDescription$ Return two target creature cards from your graveyard to your hand.
-Oracle:Return up to two target black or green creature cards from your graveyard to your hand.\nYou may cast this spell for {2}{B/G}{B/G}. If you do, ignore the bracketed text.
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Hand | TargetMin$ 0 | TargetMax$ 2 | TgtPrompt$ Choose up to two target black or green creature cards in your graveyard | ValidTgts$ Creature.YouCtrl+Black,Creature.YouCtrl+Green | SpellDescription$ Return up to two target black or green creature cards from your graveyard to your hand.
+A:SP$ ChangeZone | Cost$ 2 BG BG | Origin$ Graveyard | Destination$ Hand | TargetMin$ 0 | TargetMax$ 2 | TgtPrompt$ Choose up to two target creature cards in your graveyard | ValidTgts$ Creature.YouCtrl | SpellDescription$ Return up to two target creature cards from your graveyard to your hand.
+Oracle:Return up to two target [black or green] creature cards from your graveyard to your hand.\nYou may cast this spell for {2}{B/G}{B/G}. If you do, ignore the bracketed text.

--- a/forge-gui/res/cardsfolder/g/grind_dust.txt
+++ b/forge-gui/res/cardsfolder/g/grind_dust.txt
@@ -1,7 +1,7 @@
 Name:Grind
 ManaCost:1 B
 Types:Sorcery
-A:SP$ PutCounter | Cost$ 1 B | ValidTgts$ Creature | TgtPrompt$ Select target creature | TargetMin$ 0 | TargetMax$ 2 | CounterType$ M1M1 | CounterNum$ 1 | IsCurse$ True | SpellDescription$ Put a -1/-1 counter on each of up to two target creatures.
+A:SP$ PutCounter | ValidTgts$ Creature | TgtPrompt$ Select target creature | TargetMin$ 0 | TargetMax$ 2 | CounterType$ M1M1 | CounterNum$ 1 | IsCurse$ True | SpellDescription$ Put a -1/-1 counter on each of up to two target creatures.
 DeckHas:Ability$Counters
 AlternateMode:Split
 Oracle:Put a -1/-1 counter on each of up to two target creatures.
@@ -12,6 +12,6 @@ Name:Dust
 ManaCost:3 W
 Types:Sorcery
 K:Aftermath
-A:SP$ ChangeZone | Cost$ 3 W | ValidTgts$ Creature.counters_GE1_M1M1 | TgtPrompt$ Select target creature that has a -1/-1 counter on it | TargetMin$ 0 | TargetMax$ MaxTargets | Origin$ Battlefield | Destination$ Exile | SpellDescription$ Exile any number of target creatures that have -1/-1 counters on them.
+A:SP$ ChangeZone | ValidTgts$ Creature.counters_GE1_M1M1 | TgtPrompt$ Select target creature that has a -1/-1 counter on it | TargetMin$ 0 | TargetMax$ MaxTargets | Origin$ Battlefield | Destination$ Exile | SpellDescription$ Exile any number of target creatures that have -1/-1 counters on them.
 SVar:MaxTargets:Count$Valid Creature.counters_GE_M1M1
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nExile any number of target creatures that have -1/-1 counters on them.

--- a/forge-gui/res/cardsfolder/h/heaven_earth.txt
+++ b/forge-gui/res/cardsfolder/h/heaven_earth.txt
@@ -1,7 +1,7 @@
 Name:Heaven
 ManaCost:X G
 Types:Instant
-A:SP$ DamageAll | Cost$ X G | ValidCards$ Creature.withFlying | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to each creature with flying.
+A:SP$ DamageAll | ValidCards$ Creature.withFlying | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to each creature with flying.
 SVar:X:Count$xPaid
 AI:RemoveDeck:Random
 AlternateMode:Split
@@ -13,6 +13,6 @@ Name:Earth
 ManaCost:X R R
 Types:Sorcery
 K:Aftermath
-A:SP$ DamageAll | Cost$ X R R | ValidCards$ Creature.withoutFlying | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to each creature without flying.
+A:SP$ DamageAll | ValidCards$ Creature.withoutFlying | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to each creature without flying.
 SVar:X:Count$xPaid
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nEarth deals X damage to each creature without flying.

--- a/forge-gui/res/cardsfolder/h/hide_seek.txt
+++ b/forge-gui/res/cardsfolder/h/hide_seek.txt
@@ -1,7 +1,7 @@
 Name:Hide
 ManaCost:R W
 Types:Instant
-A:SP$ ChangeZone | Cost$ R W | ValidTgts$ Artifact,Enchantment | TgtPrompt$ Select target artifact or enchantment | Origin$ Battlefield | Destination$ Library | LibraryPosition$ -1 | SpellDescription$ Put target artifact or enchantment on the bottom of its owner's library.
+A:SP$ ChangeZone | ValidTgts$ Artifact,Enchantment | TgtPrompt$ Select target artifact or enchantment | Origin$ Battlefield | Destination$ Library | LibraryPosition$ -1 | SpellDescription$ Put target artifact or enchantment on the bottom of its owner's library.
 AlternateMode:Split
 Oracle:Put target artifact or enchantment on the bottom of its owner's library.
 
@@ -10,7 +10,7 @@ ALTERNATE
 Name:Seek
 ManaCost:W B
 Types:Instant
-A:SP$ ChangeZone | Cost$ W B | ValidTgts$ Opponent | TgtPrompt$ Select target opponent | Origin$ Library | DefinedPlayer$ Targeted | Chooser$ You | Destination$ Exile | Changetype$ Card | ChangeNum$ 1 | RememberChanged$ True | IsCurse$ True | AILogic$ BestCard | SubAbility$ DBGainLife | StackDescription$ SpellDescription | SpellDescription$ Search target opponent's library for a card and exile it. You gain life equal to its mana value. Then that player shuffles.
+A:SP$ ChangeZone | ValidTgts$ Opponent | TgtPrompt$ Select target opponent | Origin$ Library | DefinedPlayer$ Targeted | Chooser$ You | Destination$ Exile | Changetype$ Card | ChangeNum$ 1 | RememberChanged$ True | IsCurse$ True | AILogic$ BestCard | SubAbility$ DBGainLife | StackDescription$ SpellDescription | SpellDescription$ Search target opponent's library for a card and exile it. You gain life equal to its mana value. Then that player shuffles.
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Remembered$CardManaCost

--- a/forge-gui/res/cardsfolder/h/hit_run.txt
+++ b/forge-gui/res/cardsfolder/h/hit_run.txt
@@ -1,7 +1,7 @@
 Name:Hit
 ManaCost:1 B R
 Types:Instant
-A:SP$ Sacrifice | Cost$ 1 B R | ValidTgts$ Player | SacValid$ Creature,Artifact | SacMessage$ Creature or Artifact | RememberSacrificed$ True | SubAbility$ DBDmg | SpellDescription$ Target player sacrifices an artifact or creature. Hit deals damage to that player equal to that permanent's mana value.
+A:SP$ Sacrifice | ValidTgts$ Player | SacValid$ Creature,Artifact | SacMessage$ Creature or Artifact | RememberSacrificed$ True | SubAbility$ DBDmg | SpellDescription$ Target player sacrifices an artifact or creature. Hit deals damage to that player equal to that permanent's mana value.
 SVar:DBDmg:DB$ DealDamage | NumDmg$ X | Defined$ Targeted | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Remembered$CardManaCost
@@ -13,6 +13,6 @@ ALTERNATE
 Name:Run
 ManaCost:3 R G
 Types:Instant
-A:SP$ PumpAll | Cost$ 3 R G | ValidCards$ Creature.attacking+YouCtrl | NumAtt$ +Y | SpellDescription$ Attacking creatures you control get +1/+0 until end of turn for each other attacking creature.
+A:SP$ PumpAll | ValidCards$ Creature.attacking+YouCtrl | NumAtt$ +Y | SpellDescription$ Attacking creatures you control get +1/+0 until end of turn for each other attacking creature.
 SVar:Y:Count$Valid Creature.attacking/Minus.1
 Oracle:Attacking creatures you control get +1/+0 until end of turn for each other attacking creature.

--- a/forge-gui/res/cardsfolder/i/illusion_reality.txt
+++ b/forge-gui/res/cardsfolder/i/illusion_reality.txt
@@ -1,7 +1,7 @@
 Name:Illusion
 ManaCost:U
 Types:Instant
-A:SP$ ChooseColor | Cost$ U | Defined$ You | SubAbility$ Animate | SpellDescription$ Target spell or permanent becomes the color of your choice until end of turn.
+A:SP$ ChooseColor | Defined$ You | SubAbility$ Animate | SpellDescription$ Target spell or permanent becomes the color of your choice until end of turn.
 SVar:Animate:DB$ Animate | ValidTgts$ Card | TgtPrompt$ Select target spell or permanent to change the color of | TgtZone$ Stack,Battlefield | Colors$ ChosenColor | OverwriteColors$ True
 AlternateMode:Split
 Oracle:Target spell or permanent becomes the color of your choice until end of turn.
@@ -11,5 +11,5 @@ ALTERNATE
 Name:Reality
 ManaCost:2 G
 Types:Instant
-A:SP$ Destroy | Cost$ 2 G | ValidTgts$ Artifact | TgtPrompt$ Select target artifact | SpellDescription$ Destroy target artifact.
+A:SP$ Destroy | ValidTgts$ Artifact | TgtPrompt$ Select target artifact | SpellDescription$ Destroy target artifact.
 Oracle:Destroy target artifact.

--- a/forge-gui/res/cardsfolder/i/incubation_incongruity.txt
+++ b/forge-gui/res/cardsfolder/i/incubation_incongruity.txt
@@ -1,7 +1,7 @@
 Name:Incubation
 ManaCost:GU
 Types:Sorcery
-A:SP$ Dig | Cost$ GU | DigNum$ 5 | ChangeNum$ 1 | Optional$ True | ForceRevealToController$ True | ChangeValid$ Card.Creature | RestRandomOrder$ True | SpellDescription$ Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.
+A:SP$ Dig | DigNum$ 5 | ChangeNum$ 1 | Optional$ True | ForceRevealToController$ True | ChangeValid$ Card.Creature | RestRandomOrder$ True | SpellDescription$ Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.
 AlternateMode:Split
 Oracle:Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.
 
@@ -10,6 +10,6 @@ ALTERNATE
 Name:Incongruity
 ManaCost:1 G U
 Types:Instant
-A:SP$ ChangeZone | Cost$ 1 G U | ValidTgts$ Creature | TgtPrompt$ Select target creature | Origin$ Battlefield | Destination$ Exile | SubAbility$ DBToken | SpellDescription$ Exile target creature. That creature's controller creates a 3/3 green Frog Lizard creature token.
+A:SP$ ChangeZone | ValidTgts$ Creature | TgtPrompt$ Select target creature | Origin$ Battlefield | Destination$ Exile | SubAbility$ DBToken | SpellDescription$ Exile target creature. That creature's controller creates a 3/3 green Frog Lizard creature token.
 SVar:DBToken:DB$ Token | TokenAmount$ 1 | TokenOwner$ TargetedController | TokenScript$ g_3_3_frog_lizard
 Oracle:Exile target creature. That creature's controller creates a 3/3 green Frog Lizard creature token.

--- a/forge-gui/res/cardsfolder/i/insult_injury.txt
+++ b/forge-gui/res/cardsfolder/i/insult_injury.txt
@@ -1,7 +1,7 @@
 Name:Insult
 ManaCost:2 R
 Types:Sorcery
-A:SP$ Effect | Cost$ 2 R | Name$ Insult Effect | StaticAbilities$ STCantPrevent | ReplacementEffects$ InsultDamageEvent | SpellDescription$ Damage can't be prevented this turn. If a source you control would deal damage this turn, it deals double that damage instead.
+A:SP$ Effect | Name$ Insult Effect | StaticAbilities$ STCantPrevent | ReplacementEffects$ InsultDamageEvent | SpellDescription$ Damage can't be prevented this turn. If a source you control would deal damage this turn, it deals double that damage instead.
 SVar:STCantPrevent:Mode$ CantPreventDamage | EffectZone$ Command | Description$ Damage can't be prevented.
 SVar:InsultDamageEvent:Event$ DamageDone | ValidSource$ Card.YouCtrl,Emblem.YouCtrl | ReplaceWith$ DmgTwice | Description$ If a source you control would deal damage this turn, it deals double that damage instead.
 SVar:DmgTwice:DB$ ReplaceEffect | VarName$ DamageAmount | VarValue$ X
@@ -15,6 +15,6 @@ Name:Injury
 ManaCost:2 R
 Types:Sorcery
 K:Aftermath
-A:SP$ DealDamage | Cost$ 2 R | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 2 | SubAbility$ DBDealDamage | SpellDescription$ CARDNAME deals 2 damage to target creature and 2 damage to target player or planeswalker.
+A:SP$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 2 | SubAbility$ DBDealDamage | SpellDescription$ CARDNAME deals 2 damage to target creature and 2 damage to target player or planeswalker.
 SVar:DBDealDamage:DB$ DealDamage | NumDmg$ 2 | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nInjury deals 2 damage to target creature and 2 damage to target player or planeswalker.

--- a/forge-gui/res/cardsfolder/i/integrity_intervention.txt
+++ b/forge-gui/res/cardsfolder/i/integrity_intervention.txt
@@ -1,7 +1,7 @@
 Name:Integrity
-ManaCost:R/W
+ManaCost:RW
 Types:Instant
-A:SP$ Pump | Cost$ R/W | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +2 | NumDef$ +2 | SpellDescription$ Target creature gets +2/+2 until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +2 | NumDef$ +2 | SpellDescription$ Target creature gets +2/+2 until end of turn.
 AlternateMode:Split
 Oracle:Target creature gets +2/+2 until end of turn.
 
@@ -10,6 +10,6 @@ ALTERNATE
 Name:Intervention
 ManaCost:2 R W
 Types:Instant
-A:SP$ DealDamage | Cost$ 2 R W | ValidTgts$ Any | NumDmg$ 3 | SubAbility$ DBGainLife | SpellDescription$ Target player deals 3 damage to any target and you gain 3 life.
+A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ 3 | SubAbility$ DBGainLife | SpellDescription$ Target player deals 3 damage to any target and you gain 3 life.
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 3
 Oracle:Intervention deals 3 damage to any target and you gain 3 life.

--- a/forge-gui/res/cardsfolder/i/invert_invent.txt
+++ b/forge-gui/res/cardsfolder/i/invert_invent.txt
@@ -1,7 +1,7 @@
 Name:Invert
-ManaCost:U/R
+ManaCost:UR
 Types:Instant
-A:SP$ Pump | Cost$ U/R | ValidTgts$ Creature | TargetMin$ 0 | TargetMax$ 2 | TgtPrompt$ Select target creature | KW$ HIDDEN CARDNAME's power and toughness are switched | SpellDescription$ Switch the power and toughness of each of up to two target creatures until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | TargetMin$ 0 | TargetMax$ 2 | TgtPrompt$ Select target creature | KW$ HIDDEN CARDNAME's power and toughness are switched | SpellDescription$ Switch the power and toughness of each of up to two target creatures until end of turn.
 AlternateMode:Split
 Oracle:Switch the power and toughness of each of up to two target creatures until end of turn.
 
@@ -10,7 +10,7 @@ ALTERNATE
 Name:Invent
 ManaCost:4 U R
 Types:Instant
-A:SP$ ChangeZone | Cost$ 4 U R | Origin$ Library | Destination$ Hand | ChangeType$ EACH Instant & Sorcery | SpellDescription$ Search your library for an instant card and/or a sorcery card, reveal them, put them into your hand, then shuffle.
+A:SP$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ EACH Instant & Sorcery | SpellDescription$ Search your library for an instant card and/or a sorcery card, reveal them, put them into your hand, then shuffle.
 AI:RemoveDeck:Random
 DeckHints:Type$Instant|Sorcery
 Oracle:Search your library for an instant card and/or a sorcery card, reveal them, put them into your hand, then shuffle.

--- a/forge-gui/res/cardsfolder/l/lava_storm.txt
+++ b/forge-gui/res/cardsfolder/l/lava_storm.txt
@@ -1,6 +1,7 @@
 Name:Lava Storm
 ManaCost:3 R R
 Types:Instant
-A:SP$ DamageAll | ValidCards$ Creature.attacking | NumDmg$ 2 | ValidDescription$ each attacking creature | SpellDescription$ CARDNAME deals 2 damage to each attacking creature
-A:SP$ DamageAll | ValidCards$ Creature.blocking | NumDmg$ 2 | ValidDescription$ each blocking creature | SpellDescription$ or CARDNAME deals 2 damage to each blocking creature.
+A:SP$ GenericChoice | Choices$ DBDmgAttackers,DBDmgBlockers | Defined$ You | AILogic$ BestOption | StackDescription$ SpellDescription | SpellDescription$ CARDNAME deals 2 damage to each attacking creature or CARDNAME deals 2 damage to each blocking creature
+SVar:DBDmgAttackers:DB$ DamageAll | ValidCards$ Creature.attacking | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to each attacking creature
+SVar:DBDmgBlockers:DB$ DamageAll | ValidCards$ Creature.blocking | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to each blocking creature.
 Oracle:Lava Storm deals 2 damage to each attacking creature or Lava Storm deals 2 damage to each blocking creature.

--- a/forge-gui/res/cardsfolder/l/lava_storm.txt
+++ b/forge-gui/res/cardsfolder/l/lava_storm.txt
@@ -1,6 +1,6 @@
 Name:Lava Storm
 ManaCost:3 R R
 Types:Instant
-A:SP$ DamageAll | Cost$ 3 R R | ValidCards$ Creature.attacking | NumDmg$ 2 | ValidDescription$ each attacking creature | SpellDescription$ CARDNAME deals 2 damage to each attacking creature
-A:SP$ DamageAll | Cost$ 3 R R | ValidCards$ Creature.blocking | NumDmg$ 2 | ValidDescription$ each blocking creature | SpellDescription$ or CARDNAME deals 2 damage to each blocking creature.
+A:SP$ DamageAll | ValidCards$ Creature.attacking | NumDmg$ 2 | ValidDescription$ each attacking creature | SpellDescription$ CARDNAME deals 2 damage to each attacking creature
+A:SP$ DamageAll | ValidCards$ Creature.blocking | NumDmg$ 2 | ValidDescription$ each blocking creature | SpellDescription$ or CARDNAME deals 2 damage to each blocking creature.
 Oracle:Lava Storm deals 2 damage to each attacking creature or Lava Storm deals 2 damage to each blocking creature.

--- a/forge-gui/res/cardsfolder/l/leave_chance.txt
+++ b/forge-gui/res/cardsfolder/l/leave_chance.txt
@@ -1,7 +1,7 @@
 Name:Leave
 ManaCost:1 W
 Types:Instant
-A:SP$ ChangeZone | Cost$ 1 W | ValidTgts$ Permanent.YouOwn | TgtPrompt$ Select target permanent you own | TargetMin$ 0 | TargetMax$ X | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return any number of target permanents you own to your hand.
+A:SP$ ChangeZone | ValidTgts$ Permanent.YouOwn | TgtPrompt$ Select target permanent you own | TargetMin$ 0 | TargetMax$ X | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return any number of target permanents you own to your hand.
 SVar:X:Count$Valid Permanent.YouOwn
 AlternateMode:Split
 Oracle:Return any number of target permanents you own to your hand.
@@ -12,7 +12,7 @@ Name:Chance
 ManaCost:3 R
 Types:Sorcery
 K:Aftermath
-A:SP$ Discard | Cost$ 3 R | AnyNumber$ True | Optional$ True | Mode$ TgtChoose | RememberDiscarded$ True | SubAbility$ DBDraw | SpellDescription$ Discard any number of cards, then draw that many cards.
+A:SP$ Discard | AnyNumber$ True | Optional$ True | Mode$ TgtChoose | RememberDiscarded$ True | SubAbility$ DBDraw | SpellDescription$ Discard any number of cards, then draw that many cards.
 SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ Y | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:Y:Remembered$Amount

--- a/forge-gui/res/cardsfolder/l/life_death.txt
+++ b/forge-gui/res/cardsfolder/l/life_death.txt
@@ -1,7 +1,7 @@
 Name:Life
 ManaCost:G
 Types:Sorcery
-A:SP$ AnimateAll | Cost$ G | Power$ 1 | Toughness$ 1 | Types$ Creature | ValidCards$ Land.YouCtrl | SpellDescription$ All lands you control become 1/1 creatures until end of turn. They're still lands.
+A:SP$ AnimateAll | Power$ 1 | Toughness$ 1 | Types$ Creature | ValidCards$ Land.YouCtrl | SpellDescription$ All lands you control become 1/1 creatures until end of turn. They're still lands.
 AlternateMode:Split
 Oracle:All lands you control become 1/1 creatures until end of turn. They're still lands.
 
@@ -10,7 +10,7 @@ ALTERNATE
 Name:Death
 ManaCost:1 B
 Types:Sorcery
-A:SP$ ChangeZone | Cost$ 1 B | Origin$ Graveyard | Destination$ Battlefield | ValidTgts$ Creature.YouOwn | TgtPrompt$ Choose target creature card in your graveyard | GainControl$ True | SubAbility$ DBLoseLifeYou | SpellDescription$ Return target creature card from your graveyard to the battlefield. You lose life equal to its mana value.
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | ValidTgts$ Creature.YouOwn | TgtPrompt$ Choose target creature card in your graveyard | GainControl$ True | SubAbility$ DBLoseLifeYou | SpellDescription$ Return target creature card from your graveyard to the battlefield. You lose life equal to its mana value.
 SVar:DBLoseLifeYou:DB$ LoseLife | Defined$ You | LifeAmount$ X
 SVar:X:Targeted$CardManaCost
 Oracle:Return target creature card from your graveyard to the battlefield. You lose life equal to its mana value.

--- a/forge-gui/res/cardsfolder/m/mouth_feed.txt
+++ b/forge-gui/res/cardsfolder/m/mouth_feed.txt
@@ -1,7 +1,7 @@
 Name:Mouth
 ManaCost:2 G
 Types:Sorcery
-A:SP$ Token | Cost$ 2 G | TokenAmount$ 1 | TokenScript$ g_3_3_hippo | TokenOwner$ You | SpellDescription$ Create a 3/3 green Hippo creature token.
+A:SP$ Token | TokenAmount$ 1 | TokenScript$ g_3_3_hippo | TokenOwner$ You | SpellDescription$ Create a 3/3 green Hippo creature token.
 DeckHas:Ability$Token
 AlternateMode:Split
 Oracle:Create a 3/3 green Hippo creature token.
@@ -12,6 +12,6 @@ Name:Feed
 ManaCost:3 G
 Types:Sorcery
 K:Aftermath
-A:SP$ Draw | Cost$ 3 G | NumCards$ X | SpellDescription$ Draw a card for each creature you control with power 3 or greater.
+A:SP$ Draw | NumCards$ X | SpellDescription$ Draw a card for each creature you control with power 3 or greater.
 SVar:X:Count$Valid Creature.YouCtrl+powerGE3
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nDraw a card for each creature you control with power 3 or greater.

--- a/forge-gui/res/cardsfolder/n/never_return.txt
+++ b/forge-gui/res/cardsfolder/n/never_return.txt
@@ -1,7 +1,7 @@
 Name:Never
 ManaCost:1 B B
 Types:Sorcery
-A:SP$ Destroy | Cost$ 1 B B | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | SpellDescription$ Destroy target creature or planeswalker.
+A:SP$ Destroy | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | SpellDescription$ Destroy target creature or planeswalker.
 AlternateMode:Split
 Oracle:Destroy target creature or planeswalker.
 
@@ -11,7 +11,7 @@ Name:Return
 ManaCost:3 B
 Types:Sorcery
 K:Aftermath
-A:SP$ ChangeZone | Cost$ 3 B | Origin$ Graveyard | Destination$ Exile | TgtPrompt$ Choose target card in a graveyard | ValidTgts$ Card | SubAbility$ DBToken | SpellDescription$ Exile target card from a graveyard. Create a 2/2 black Zombie creature token.
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Exile | TgtPrompt$ Choose target card in a graveyard | ValidTgts$ Card | SubAbility$ DBToken | SpellDescription$ Exile target card from a graveyard. Create a 2/2 black Zombie creature token.
 SVar:DBToken:DB$ Token | TokenAmount$ 1 | TokenScript$ b_2_2_zombie | TokenOwner$ You
 DeckHas:Ability$Token
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nExile target card from a graveyard. Create a 2/2 black Zombie creature token.

--- a/forge-gui/res/cardsfolder/n/night_day.txt
+++ b/forge-gui/res/cardsfolder/n/night_day.txt
@@ -1,7 +1,7 @@
 Name:Night
 ManaCost:B
 Types:Instant
-A:SP$ Pump | Cost$ B | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ -1 | NumDef$ -1 | IsCurse$ True | SpellDescription$ Target creature gets -1/-1 until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ -1 | NumDef$ -1 | IsCurse$ True | SpellDescription$ Target creature gets -1/-1 until end of turn.
 AlternateMode:Split
 Oracle:Target creature gets -1/-1 until end of turn.
 
@@ -10,5 +10,5 @@ ALTERNATE
 Name:Day
 ManaCost:2 W
 Types:Instant
-A:SP$ PumpAll | Cost$ 2 W | ValidTgts$ Player | TgtPrompt$ Select target player | ValidCards$ Creature | NumAtt$ +1 | NumDef$ +1 | SpellDescription$ Creatures target player controls get +1/+1 until end of turn.
+A:SP$ PumpAll | ValidTgts$ Player | TgtPrompt$ Select target player | ValidCards$ Creature | NumAtt$ +1 | NumDef$ +1 | SpellDescription$ Creatures target player controls get +1/+1 until end of turn.
 Oracle:Creatures target player controls get +1/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/o/odds_ends.txt
+++ b/forge-gui/res/cardsfolder/o/odds_ends.txt
@@ -1,7 +1,7 @@
 Name:Odds
 ManaCost:U R
 Types:Instant
-A:SP$ FlipACoin | Cost$ U R | NoCall$ True | HeadsSubAbility$ OddCounter | TailsSubAbility$ OddCopy | TgtZone$ Stack | TargetType$ Spell | ValidTgts$ Instant,Sorcery | TgtPrompt$ Select target Instant or Sorcery spell | SpellDescription$ Flip a coin. If it comes up heads, counter target instant or sorcery spell. If it comes up tails, copy that spell and you may choose new targets for the copy.
+A:SP$ FlipACoin | NoCall$ True | HeadsSubAbility$ OddCounter | TailsSubAbility$ OddCopy | TgtZone$ Stack | TargetType$ Spell | ValidTgts$ Instant,Sorcery | TgtPrompt$ Select target Instant or Sorcery spell | SpellDescription$ Flip a coin. If it comes up heads, counter target instant or sorcery spell. If it comes up tails, copy that spell and you may choose new targets for the copy.
 SVar:OddCounter:DB$ Counter | Defined$ Targeted
 SVar:OddCopy:DB$ CopySpellAbility | Defined$ Targeted | MayChooseTarget$ True
 AlternateMode:Split
@@ -12,5 +12,5 @@ ALTERNATE
 Name:Ends
 ManaCost:3 R W
 Types:Instant
-A:SP$ Sacrifice | Cost$ 3 R W | ValidTgts$ Player | TgtPrompt$ Select target player to make sacrifice | Amount$ 2 | SacValid$ Creature.attacking | SpellDescription$ Target player sacrifices two attacking creatures.
+A:SP$ Sacrifice | ValidTgts$ Player | TgtPrompt$ Select target player to make sacrifice | Amount$ 2 | SacValid$ Creature.attacking | SpellDescription$ Target player sacrifices two attacking creatures.
 Oracle:Target player sacrifices two attacking creatures.

--- a/forge-gui/res/cardsfolder/o/onward_victory.txt
+++ b/forge-gui/res/cardsfolder/o/onward_victory.txt
@@ -1,7 +1,7 @@
 Name:Onward
 ManaCost:2 R
 Types:Instant
-A:SP$ Pump | Cost$ 2 R | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | SpellDescription$ Target creature gets +X/+0 until end of turn, where X is its power.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | SpellDescription$ Target creature gets +X/+0 until end of turn, where X is its power.
 SVar:X:Targeted$CardPower
 AlternateMode:Split
 Oracle:Target creature gets +X/+0 until end of turn, where X is its power.
@@ -12,5 +12,5 @@ Name:Victory
 ManaCost:2 W
 Types:Sorcery
 K:Aftermath
-A:SP$ Pump | Cost$ 2 W | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ Double Strike | SpellDescription$ Target creature gains double strike until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ Double Strike | SpellDescription$ Target creature gains double strike until end of turn.
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nTarget creature gains double strike until end of turn.

--- a/forge-gui/res/cardsfolder/o/order_chaos.txt
+++ b/forge-gui/res/cardsfolder/o/order_chaos.txt
@@ -1,7 +1,7 @@
 Name:Order
 ManaCost:3 W
 Types:Instant
-A:SP$ ChangeZone | Cost$ 3 W | ValidTgts$ Creature.attacking | TgtPrompt$ Select target attacking creature | Origin$ Battlefield | Destination$ Exile | SpellDescription$ Exile target attacking creature.
+A:SP$ ChangeZone | ValidTgts$ Creature.attacking | TgtPrompt$ Select target attacking creature | Origin$ Battlefield | Destination$ Exile | SpellDescription$ Exile target attacking creature.
 AlternateMode:Split
 Oracle:Exile target attacking creature.
 
@@ -10,6 +10,6 @@ ALTERNATE
 Name:Chaos
 ManaCost:2 R
 Types:Instant
-A:SP$ Effect | Cost$ 2 R | Name$ Chaos Effect | StaticAbilities$ KWPump | AILogic$ Evasion | SpellDescription$ Creatures can't block this turn.
+A:SP$ Effect | Name$ Chaos Effect | StaticAbilities$ KWPump | AILogic$ Evasion | SpellDescription$ Creatures can't block this turn.
 SVar:KWPump:Mode$ Continuous | EffectZone$ Command | AffectedZone$ Battlefield | Affected$ Creature | AddHiddenKeyword$ CARDNAME can't block. | Description$ Creatures can't block this turn.
 Oracle:Creatures can't block this turn.

--- a/forge-gui/res/cardsfolder/p/pain_suffering.txt
+++ b/forge-gui/res/cardsfolder/p/pain_suffering.txt
@@ -1,7 +1,7 @@
 Name:Pain
 ManaCost:B
 Types:Sorcery
-A:SP$ Discard | Cost$ B | ValidTgts$ Player | NumCards$ 1 | Mode$ TgtChoose | SpellDescription$ Target player discards a card.
+A:SP$ Discard | ValidTgts$ Player | NumCards$ 1 | Mode$ TgtChoose | SpellDescription$ Target player discards a card.
 AlternateMode:Split
 Oracle:Target player discards a card.
 
@@ -10,5 +10,5 @@ ALTERNATE
 Name:Suffering
 ManaCost:3 R
 Types:Sorcery
-A:SP$ Destroy | Cost$ 3 R | ValidTgts$ Land | TgtPrompt$ Select target land | SpellDescription$ Destroy target land.
+A:SP$ Destroy | ValidTgts$ Land | TgtPrompt$ Select target land | SpellDescription$ Destroy target land.
 Oracle:Destroy target land.

--- a/forge-gui/res/cardsfolder/p/patricians_scorn.txt
+++ b/forge-gui/res/cardsfolder/p/patricians_scorn.txt
@@ -1,7 +1,7 @@
 Name:Patrician's Scorn
 ManaCost:3 W
 Types:Instant
-A:SP$ DestroyAll | Cost$ 3 W | ValidCards$ Enchantment | SpellDescription$ Destroy all enchantments.
-A:SP$ DestroyAll | Cost$ 0 | ValidCards$ Enchantment | CheckSVar$ X | SVarCompare$ GE1 | SpellDescription$ If you've cast another white spell this turn, you may cast this spell without paying its mana cost. Destroy all enchantments.
-SVar:X:Count$ThisTurnCast_Card.White+Other+YouCtrl
+S:Mode$ AlternativeCost | ValidSA$ Spell | ValidCard$ Card.Self | ValidPlayer$ You | Cost$ 0 | EffectZone$ All | CheckSVar$ X | Description$ If you've cast another white spell this turn, you may cast this spell without paying its mana cost.
+SVar:X:Count$ThisTurnCast_Card.White+YouCtrl
+A:SP$ DestroyAll | ValidCards$ Enchantment | SpellDescription$ Destroy all enchantments.
 Oracle:If you've cast another white spell this turn, you may cast this spell without paying its mana cost.\nDestroy all enchantments.

--- a/forge-gui/res/cardsfolder/p/prepare_fight.txt
+++ b/forge-gui/res/cardsfolder/p/prepare_fight.txt
@@ -1,7 +1,7 @@
 Name:Prepare
 ManaCost:1 W
 Types:Instant
-A:SP$ Untap | Cost$ 1 W | ValidTgts$ Creature | TgtPrompt$ Select target creature | SubAbility$ DBPump | SpellDescription$ Untap target creature. It gets +2/+2 and gains lifelink until end of turn.
+A:SP$ Untap | ValidTgts$ Creature | TgtPrompt$ Select target creature | SubAbility$ DBPump | SpellDescription$ Untap target creature. It gets +2/+2 and gains lifelink until end of turn.
 SVar:DBPump:DB$ Pump | Defined$ Targeted | NumAtt$ +2 | NumDef$ +2 | KW$ Lifelink
 AlternateMode:Split
 Oracle:Untap target creature. It gets +2/+2 and gains lifelink until end of turn.
@@ -12,6 +12,6 @@ Name:Fight
 ManaCost:3 G
 Types:Sorcery
 K:Aftermath
-A:SP$ Pump | Cost$ 3 G | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Choose target creature you control | SubAbility$ DBFight | SpellDescription$ Target creature you control fights target creature an opponent controls.
+A:SP$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Choose target creature you control | SubAbility$ DBFight | SpellDescription$ Target creature you control fights target creature an opponent controls.
 SVar:DBFight:DB$ Fight | Defined$ ParentTarget | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Choose target creature an opponent controls
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nTarget creature you control fights target creature an opponent controls.

--- a/forge-gui/res/cardsfolder/p/profit_loss.txt
+++ b/forge-gui/res/cardsfolder/p/profit_loss.txt
@@ -2,7 +2,7 @@ Name:Profit
 ManaCost:1 W
 Types:Instant
 K:Fuse
-A:SP$ PumpAll | Cost$ 1 W | ValidCards$ Creature.YouCtrl | NumAtt$ +1 | NumDef$ +1 | SpellDescription$ Creatures you control get +1/+1 until end of turn.
+A:SP$ PumpAll | ValidCards$ Creature.YouCtrl | NumAtt$ +1 | NumDef$ +1 | SpellDescription$ Creatures you control get +1/+1 until end of turn.
 AlternateMode:Split
 Oracle:Creatures you control get +1/+1 until end of turn.\nFuse (You may cast one or both halves of this card from your hand.)
 
@@ -11,5 +11,5 @@ ALTERNATE
 Name:Loss
 ManaCost:2 B
 Types:Instant
-A:SP$ PumpAll | Cost$ 2 B | ValidCards$ Creature.OppCtrl | NumAtt$ -1 | NumDef$ -1 | IsCurse$ True | SpellDescription$ Creatures your opponents control get -1/-1 until end of turn.
+A:SP$ PumpAll | ValidCards$ Creature.OppCtrl | NumAtt$ -1 | NumDef$ -1 | IsCurse$ True | SpellDescription$ Creatures your opponents control get -1/-1 until end of turn.
 Oracle:Creatures your opponents control get -1/-1 until end of turn.\nFuse (You may cast one or both halves of this card from your hand.)

--- a/forge-gui/res/cardsfolder/p/protect_serve.txt
+++ b/forge-gui/res/cardsfolder/p/protect_serve.txt
@@ -2,7 +2,7 @@ Name:Protect
 ManaCost:2 W
 Types:Instant
 K:Fuse
-A:SP$ Pump | Cost$ 2 W | ValidTgts$ Creature | TgtPrompt$ Select target creature to get +2/+4 | NumAtt$ +2 | NumDef$ +4 | SpellDescription$ Target creature you control gets +2/+4 until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature to get +2/+4 | NumAtt$ +2 | NumDef$ +4 | SpellDescription$ Target creature you control gets +2/+4 until end of turn.
 AlternateMode:Split
 Oracle:Target creature gets +2/+4 until end of turn.\nFuse (You may cast one or both halves of this card from your hand.)
 
@@ -11,5 +11,5 @@ ALTERNATE
 Name:Serve
 ManaCost:1 U
 Types:Instant
-A:SP$ Pump | Cost$ 1 U | ValidTgts$ Creature | TgtPrompt$ Select target creature to get -6/-0 | NumAtt$ -6 | IsCurse$ True | SpellDescription$ Target creature gets -6/-0 until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature to get -6/-0 | NumAtt$ -6 | IsCurse$ True | SpellDescription$ Target creature gets -6/-0 until end of turn.
 Oracle:Target creature gets -6/-0 until end of turn.\nFuse (You may cast one or both halves of this card from your hand.)

--- a/forge-gui/res/cardsfolder/p/pure_simple.txt
+++ b/forge-gui/res/cardsfolder/p/pure_simple.txt
@@ -1,7 +1,7 @@
 Name:Pure
 ManaCost:1 R G
 Types:Sorcery
-A:SP$ Destroy | Cost$ 1 R G | ValidTgts$ Permanent.MultiColor | TgtPrompt$ Select target multicolored permanent | SpellDescription$ Destroy target multicolored permanent.
+A:SP$ Destroy | ValidTgts$ Permanent.MultiColor | TgtPrompt$ Select target multicolored permanent | SpellDescription$ Destroy target multicolored permanent.
 AlternateMode:Split
 Oracle:Destroy target multicolored permanent.
 
@@ -10,5 +10,5 @@ ALTERNATE
 Name:Simple
 ManaCost:1 G W
 Types:Sorcery
-A:SP$ DestroyAll | Cost$ 1 G W | ValidCards$ Aura,Equipment | SpellDescription$ Destroy all Auras and Equipment.
+A:SP$ DestroyAll | ValidCards$ Aura,Equipment | SpellDescription$ Destroy all Auras and Equipment.
 Oracle:Destroy all Auras and Equipment.

--- a/forge-gui/res/cardsfolder/r/rags_riches.txt
+++ b/forge-gui/res/cardsfolder/r/rags_riches.txt
@@ -1,7 +1,7 @@
 Name:Rags
 ManaCost:2 B B
 Types:Sorcery
-A:SP$ PumpAll | Cost$ 2 B B | ValidCards$ Creature | NumAtt$ -2 | NumDef$ -2 | IsCurse$ True | SpellDescription$ All creatures get -2/-2 until end of turn.
+A:SP$ PumpAll | ValidCards$ Creature | NumAtt$ -2 | NumDef$ -2 | IsCurse$ True | SpellDescription$ All creatures get -2/-2 until end of turn.
 AlternateMode:Split
 Oracle:All creatures get -2/-2 until end of turn.
 
@@ -11,7 +11,7 @@ Name:Riches
 ManaCost:5 U U
 Types:Sorcery
 K:Aftermath
-A:SP$ RepeatEach | Cost$ 5 U U | AILogic$ OpponentHasCreatures | RepeatPlayers$ Player.Opponent | RepeatSubAbility$ ChooseCreature | SubAbility$ StealChosen | SpellDescription$ Each opponent chooses a creature they control. You gain control of those creatures.
+A:SP$ RepeatEach | AILogic$ OpponentHasCreatures | RepeatPlayers$ Player.Opponent | RepeatSubAbility$ ChooseCreature | SubAbility$ StealChosen | SpellDescription$ Each opponent chooses a creature they control. You gain control of those creatures.
 SVar:ChooseCreature:DB$ ChooseCard | Defined$ Remembered | Amount$ 1 | Choices$ Creature.RememberedPlayerCtrl | ChoiceTitle$ Choose a creature to be stolen | AILogic$ WorstCard | RememberChosen$ True | Mandatory$ True
 SVar:StealChosen:DB$ GainControl | AllValid$ Permanent.IsRemembered | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/r/ready_willing.txt
+++ b/forge-gui/res/cardsfolder/r/ready_willing.txt
@@ -2,7 +2,7 @@ Name:Ready
 ManaCost:1 G W
 Types:Instant
 K:Fuse
-A:SP$ PumpAll | Cost$ 1 G W | ValidCards$ Creature.YouCtrl | KW$ Indestructible | SubAbility$ DBUnTapAll | SpellDescription$ Creatures you control gain indestructible until end of turn. Untap each creature you control.
+A:SP$ PumpAll | ValidCards$ Creature.YouCtrl | KW$ Indestructible | SubAbility$ DBUnTapAll | SpellDescription$ Creatures you control gain indestructible until end of turn. Untap each creature you control.
 SVar:DBUnTapAll:DB$ UntapAll | ValidCards$ Creature.YouCtrl
 AlternateMode:Split
 Oracle:Creatures you control gain indestructible until end of turn. Untap each creature you control.\nFuse (You may cast one or both halves of this card from your hand.)
@@ -12,5 +12,5 @@ ALTERNATE
 Name:Willing
 ManaCost:1 W B
 Types:Instant
-A:SP$ PumpAll | Cost$ 1 W B | ValidCards$ Creature.YouCtrl | KW$ Deathtouch & Lifelink | SpellDescription$ Creatures you control gain deathtouch and lifelink until end of turn.
+A:SP$ PumpAll | ValidCards$ Creature.YouCtrl | KW$ Deathtouch & Lifelink | SpellDescription$ Creatures you control gain deathtouch and lifelink until end of turn.
 Oracle:Creatures you control gain deathtouch and lifelink until end of turn.\nFuse (You may cast one or both halves of this card from your hand.)

--- a/forge-gui/res/cardsfolder/r/reason_believe.txt
+++ b/forge-gui/res/cardsfolder/r/reason_believe.txt
@@ -1,7 +1,7 @@
 Name:Reason
 ManaCost:U
 Types:Sorcery
-A:SP$ Scry | Cost$ U | ScryNum$ 3 | SpellDescription$ Scry 3.
+A:SP$ Scry | ScryNum$ 3 | SpellDescription$ Scry 3.
 AlternateMode:Split
 Oracle:Scry 3.
 
@@ -11,5 +11,5 @@ Name:Believe
 ManaCost:4 G
 Types:Sorcery
 K:Aftermath
-A:SP$ Dig | Cost$ 4 G | DigNum$ 1 | ChangeNum$ 1 | Optional$ True | ChangeValid$ Creature | DestinationZone$ Battlefield | DestinationZone2$ Hand | SpellDescription$ Look at the top card of your library. You may put it onto the battlefield if it's a creature card. If you don't, put it into your hand.
+A:SP$ Dig | DigNum$ 1 | ChangeNum$ 1 | Optional$ True | ChangeValid$ Creature | DestinationZone$ Battlefield | DestinationZone2$ Hand | SpellDescription$ Look at the top card of your library. You may put it onto the battlefield if it's a creature card. If you don't, put it into your hand.
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nLook at the top card of your library. You may put it onto the battlefield if it's a creature card. If you don't, put it into your hand.

--- a/forge-gui/res/cardsfolder/r/reduce_rubble.txt
+++ b/forge-gui/res/cardsfolder/r/reduce_rubble.txt
@@ -1,7 +1,7 @@
 Name:Reduce
 ManaCost:2 U
 Types:Instant
-A:SP$ Counter | Cost$ 2 U | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | UnlessCost$ 3 | SpellDescription$ Counter target spell unless its controller pays {3}.
+A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | UnlessCost$ 3 | SpellDescription$ Counter target spell unless its controller pays {3}.
 AlternateMode:Split
 Oracle:Counter target spell unless its controller pays {3}.
 
@@ -11,5 +11,5 @@ Name:Rubble
 ManaCost:2 R
 Types:Sorcery
 K:Aftermath
-A:SP$ Pump | Cost$ 2 R | ValidTgts$ Land | TargetMin$ 0 | TargetMax$ 3 | TgtPrompt$ Select target land | KW$ HIDDEN This card doesn't untap during your next untap step. | Duration$ Permanent | IsCurse$ True | SpellDescription$ Up to three target lands don't untap during their controller's next untap step.
+A:SP$ Pump | ValidTgts$ Land | TargetMin$ 0 | TargetMax$ 3 | TgtPrompt$ Select target land | KW$ HIDDEN This card doesn't untap during your next untap step. | Duration$ Permanent | IsCurse$ True | SpellDescription$ Up to three target lands don't untap during their controller's next untap step.
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nUp to three target lands don't untap during their controller's next untap step.

--- a/forge-gui/res/cardsfolder/r/refuse_cooperate.txt
+++ b/forge-gui/res/cardsfolder/r/refuse_cooperate.txt
@@ -1,7 +1,7 @@
 Name:Refuse
 ManaCost:3 R
 Types:Instant
-A:SP$ Pump | Cost$ 3 R | ValidTgts$ Card | TargetType$ Spell | TgtZone$ Stack | TgtPrompt$ Select target spell | PumpZone$ Stack | StackDescription$ None | SubAbility$ DBDmg | SpellDescription$ CARDNAME deals damage to target spell's controller equal to that spell's mana value.
+A:SP$ Pump | ValidTgts$ Card | TargetType$ Spell | TgtZone$ Stack | TgtPrompt$ Select target spell | PumpZone$ Stack | StackDescription$ None | SubAbility$ DBDmg | SpellDescription$ CARDNAME deals damage to target spell's controller equal to that spell's mana value.
 SVar:DBDmg:DB$ DealDamage | Defined$ TargetedController | NumDmg$ X
 SVar:X:Targeted$CardManaCost
 AI:RemoveDeck:All
@@ -14,5 +14,5 @@ Name:Cooperate
 ManaCost:2 U
 Types:Instant
 K:Aftermath
-A:SP$ CopySpellAbility | Cost$ 2 U | ValidTgts$ Instant,Sorcery | TargetType$ Spell | MayChooseTarget$ True | SpellDescription$ Copy target instant or sorcery spell. You may choose new targets for the copy.
+A:SP$ CopySpellAbility | ValidTgts$ Instant,Sorcery | TargetType$ Spell | MayChooseTarget$ True | SpellDescription$ Copy target instant or sorcery spell. You may choose new targets for the copy.
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nCopy target instant or sorcery spell. You may choose new targets for the copy.

--- a/forge-gui/res/cardsfolder/r/repudiate_replicate.txt
+++ b/forge-gui/res/cardsfolder/r/repudiate_replicate.txt
@@ -1,7 +1,7 @@
 Name:Repudiate
 ManaCost:GU GU
 Types:Instant
-A:SP$ Counter | Cost$ GU GU | TgtPrompt$ Select target Activated or Triggered Ability | ValidTgts$ Card,Emblem | TargetType$ Activated,Triggered | SpellDescription$ Counter target activated or triggered ability.
+A:SP$ Counter | TgtPrompt$ Select target Activated or Triggered Ability | ValidTgts$ Card,Emblem | TargetType$ Activated,Triggered | SpellDescription$ Counter target activated or triggered ability.
 AI:RemoveDeck:All
 AlternateMode:Split
 Oracle:Counter target activated or triggered ability. (Mana abilities can't be targeted.)
@@ -11,6 +11,6 @@ ALTERNATE
 Name:Replicate
 ManaCost:1 G U
 Types:Sorcery
-A:SP$ CopyPermanent | Cost$ 1 G U | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | SpellDescription$ Create a token that's a copy of target creature you control.
+A:SP$ CopyPermanent | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | SpellDescription$ Create a token that's a copy of target creature you control.
 DeckHas:Ability$Token
 Oracle:Create a token that's a copy of target creature you control.

--- a/forge-gui/res/cardsfolder/r/research_development.txt
+++ b/forge-gui/res/cardsfolder/r/research_development.txt
@@ -1,7 +1,7 @@
 Name:Research
 ManaCost:G U
 Types:Instant
-A:SP$ ChangeZone | Cost$ G U | Origin$ Sideboard | Destination$ Library | Shuffle$ True | ChangeType$ Card.YouOwn | ChangeNum$ 4 | Hidden$ True | StackDescription$ {p:You} shuffles up to four cards they own from outside the game into their library. | SpellDescription$ Shuffle up to four cards you own from outside the game into your library.
+A:SP$ ChangeZone | Origin$ Sideboard | Destination$ Library | Shuffle$ True | ChangeType$ Card.YouOwn | ChangeNum$ 4 | Hidden$ True | StackDescription$ {p:You} shuffles up to four cards they own from outside the game into their library. | SpellDescription$ Shuffle up to four cards you own from outside the game into your library.
 AI:RemoveDeck:Random
 AlternateMode:Split
 Oracle:Shuffle up to four cards you own from outside the game into your library.
@@ -11,6 +11,6 @@ ALTERNATE
 Name:Development
 ManaCost:3 U R
 Types:Instant
-A:SP$ Repeat | Cost$ 3 U R | RepeatSubAbility$ DBToken | MaxRepeat$ 3 | StackDescription$ SpellDescription | SpellDescription$ Create a 3/1 red Elemental creature token unless any opponent has you draw a card. Repeat this process two more times.
+A:SP$ Repeat | RepeatSubAbility$ DBToken | MaxRepeat$ 3 | StackDescription$ SpellDescription | SpellDescription$ Create a 3/1 red Elemental creature token unless any opponent has you draw a card. Repeat this process two more times.
 SVar:DBToken:DB$ Token | TokenAmount$ 1 | TokenScript$ r_3_1_elemental | TokenOwner$ You | UnlessPayer$ Player.Opponent | UnlessCost$ Draw<1/Player.YouActivator> | UnlessAI$ MorePowerful
 Oracle:Create a 3/1 red Elemental creature token unless any opponent has you draw a card. Repeat this process two more times.

--- a/forge-gui/res/cardsfolder/r/response_resurgence.txt
+++ b/forge-gui/res/cardsfolder/r/response_resurgence.txt
@@ -1,7 +1,7 @@
 Name:Response
-ManaCost:R/W R/W
+ManaCost:RW RW
 Types:Instant
-A:SP$ DealDamage | Cost$ R/W R/W | ValidTgts$ Creature.attacking,Creature.blocking | TgtPrompt$ Select target attacking or blocking creature | NumDmg$ 5 | SpellDescription$ CARDNAME deals 5 damage to target attacking or blocking creature.
+A:SP$ DealDamage | ValidTgts$ Creature.attacking,Creature.blocking | TgtPrompt$ Select target attacking or blocking creature | NumDmg$ 5 | SpellDescription$ CARDNAME deals 5 damage to target attacking or blocking creature.
 AlternateMode:Split
 Oracle:Response deals 5 damage to target attacking or blocking creature.
 
@@ -10,6 +10,6 @@ ALTERNATE
 Name:Resurgence
 ManaCost:3 R W
 Types:Sorcery
-A:SP$ PumpAll | Cost$ 3 R W | ValidCards$ Creature.YouCtrl | KW$ First Strike & Vigilance | SubAbility$ DBAddCombat | SpellDescription$ Creatures you control gain first strike and vigilance until end of turn. After this main phase, there is an additional combat phase followed by an additional main phase.
+A:SP$ PumpAll | ValidCards$ Creature.YouCtrl | KW$ First Strike & Vigilance | SubAbility$ DBAddCombat | SpellDescription$ Creatures you control gain first strike and vigilance until end of turn. After this main phase, there is an additional combat phase followed by an additional main phase.
 SVar:DBAddCombat:DB$ AddPhase | ExtraPhase$ Combat | FollowedBy$ Main2 | ConditionPhases$ Main1,Main2
 Oracle:Creatures you control gain first strike and vigilance until end of turn. After this main phase, there is an additional combat phase followed by an additional main phase.

--- a/forge-gui/res/cardsfolder/r/rise_fall.txt
+++ b/forge-gui/res/cardsfolder/r/rise_fall.txt
@@ -1,7 +1,7 @@
 Name:Rise
 ManaCost:U B
 Types:Sorcery
-A:SP$ ChangeZone | Cost$ U B | ValidTgts$ Creature | TgtPrompt$ Select target creature in a graveyard | Origin$ Graveyard | Destination$ Hand | SubAbility$ DBChangeZone | SpellDescription$ Return target creature card from a graveyard and target creature on the battlefield to their owners' hands.
+A:SP$ ChangeZone | ValidTgts$ Creature | TgtPrompt$ Select target creature in a graveyard | Origin$ Graveyard | Destination$ Hand | SubAbility$ DBChangeZone | SpellDescription$ Return target creature card from a graveyard and target creature on the battlefield to their owners' hands.
 SVar:DBChangeZone:DB$ ChangeZone | ValidTgts$ Creature | TgtPrompt$ Select target creature on the battlefield | Origin$ Battlefield | Destination$ Hand | IsCurse$ True
 AlternateMode:Split
 Oracle:Return target creature card from a graveyard and target creature on the battlefield to their owners' hands.
@@ -11,7 +11,7 @@ ALTERNATE
 Name:Fall
 ManaCost:B R
 Types:Sorcery
-A:SP$ Reveal | Cost$ B R | ValidTgts$ Player | IsCurse$ True | Random$ True | NumCards$ 2 | RememberRevealed$ True | SubAbility$ DBDiscard | SpellDescription$ Target player reveals two cards at random from their hand, then discards each nonland card revealed this way.
+A:SP$ Reveal | ValidTgts$ Player | IsCurse$ True | Random$ True | NumCards$ 2 | RememberRevealed$ True | SubAbility$ DBDiscard | SpellDescription$ Target player reveals two cards at random from their hand, then discards each nonland card revealed this way.
 SVar:DBDiscard:DB$ Discard | Mode$ Defined | Defined$ Targeted | DefinedCards$ ValidHand Card.nonLand+IsRemembered | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Target player reveals two cards at random from their hand, then discards each nonland card revealed this way.

--- a/forge-gui/res/cardsfolder/r/road_ruin.txt
+++ b/forge-gui/res/cardsfolder/r/road_ruin.txt
@@ -1,7 +1,7 @@
 Name:Road
 ManaCost:2 G
 Types:Instant
-A:SP$ ChangeZone | Cost$ 2 G | Origin$ Library | Destination$ Battlefield | ChangeType$ Land.Basic | ChangeNum$ 1 | Tapped$ True | SpellDescription$ Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.
+A:SP$ ChangeZone | Origin$ Library | Destination$ Battlefield | ChangeType$ Land.Basic | ChangeNum$ 1 | Tapped$ True | SpellDescription$ Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.
 AlternateMode:Split
 Oracle:Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.
 
@@ -11,6 +11,6 @@ Name:Ruin
 ManaCost:1 R R
 Types:Sorcery
 K:Aftermath
-A:SP$ DealDamage | Cost$ 1 R R | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SpellDescription$ CARDNAME deals damage to target creature equal to the number of lands you control.
+A:SP$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SpellDescription$ CARDNAME deals damage to target creature equal to the number of lands you control.
 SVar:X:Count$TypeYouCtrl.Land
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nRuin deals damage to target creature equal to the number of lands you control.

--- a/forge-gui/res/cardsfolder/r/rough_tumble.txt
+++ b/forge-gui/res/cardsfolder/r/rough_tumble.txt
@@ -1,7 +1,7 @@
 Name:Rough
 ManaCost:1 R
 Types:Sorcery
-A:SP$ DamageAll | Cost$ 1 R | ValidCards$ Creature.withoutFlying | NumDmg$ 2 | SpellDescription$ Rough deals 2 damage to each creature without flying.
+A:SP$ DamageAll | ValidCards$ Creature.withoutFlying | NumDmg$ 2 | SpellDescription$ Rough deals 2 damage to each creature without flying.
 AlternateMode:Split
 Oracle:Rough deals 2 damage to each creature without flying.
 
@@ -10,5 +10,5 @@ ALTERNATE
 Name:Tumble
 ManaCost:5 R
 Types:Sorcery
-A:SP$ DamageAll | Cost$ 5 R | ValidCards$ Creature.withFlying | NumDmg$ 6 | SpellDescription$ Tumble deals 6 damage to each creature with flying.
+A:SP$ DamageAll | ValidCards$ Creature.withFlying | NumDmg$ 6 | SpellDescription$ Tumble deals 6 damage to each creature with flying.
 Oracle:Tumble deals 6 damage to each creature with flying.

--- a/forge-gui/res/cardsfolder/s/said_done.txt
+++ b/forge-gui/res/cardsfolder/s/said_done.txt
@@ -1,7 +1,7 @@
 Name:Said
 ManaCost:2 U
 Types:Sorcery
-A:SP$ ChangeZone | Cost$ 2 U | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Instant.YouCtrl,Sorcery.YouCtrl | SpellDescription$ Return target instant or sorcery card from your graveyard to your hand.
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Instant.YouCtrl,Sorcery.YouCtrl | SpellDescription$ Return target instant or sorcery card from your graveyard to your hand.
 AlternateMode:Split
 Oracle:Return target instant or sorcery card from your graveyard to your hand.
 
@@ -10,6 +10,6 @@ ALTERNATE
 Name:Done
 ManaCost:3 U
 Types:Instant
-A:SP$ Tap | Cost$ 3 U | TargetMin$ 0 | TargetMax$ 2 | TgtPrompt$ Choose up to two target creatures | ValidTgts$ Creature | SubAbility$ TrigPump | StackDescription$ SpellDescription | SpellDescription$ Tap up to two target creatures. Those creatures don't untap during their controller's next untap step.
+A:SP$ Tap | TargetMin$ 0 | TargetMax$ 2 | TgtPrompt$ Choose up to two target creatures | ValidTgts$ Creature | SubAbility$ TrigPump | StackDescription$ SpellDescription | SpellDescription$ Tap up to two target creatures. Those creatures don't untap during their controller's next untap step.
 SVar:TrigPump:DB$ Pump | Defined$ Targeted | KW$ HIDDEN This card doesn't untap during your next untap step. | Duration$ Permanent | StackDescription$ None
 Oracle:Tap up to two target creatures. Those creatures don't untap during their controller's next untap step.

--- a/forge-gui/res/cardsfolder/s/spite_malice.txt
+++ b/forge-gui/res/cardsfolder/s/spite_malice.txt
@@ -1,7 +1,7 @@
 Name:Spite
 ManaCost:3 U
 Types:Instant
-A:SP$ Counter | Cost$ 3 U | TargetType$ Spell | TgtPrompt$ Select target noncreature spell | ValidTgts$ Card.nonCreature | SpellDescription$ Counter target noncreature spell.
+A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target noncreature spell | ValidTgts$ Card.nonCreature | SpellDescription$ Counter target noncreature spell.
 AlternateMode:Split
 Oracle:Counter target noncreature spell.
 
@@ -10,5 +10,5 @@ ALTERNATE
 Name:Malice
 ManaCost:3 B
 Types:Instant
-A:SP$ Destroy | Cost$ 3 B | ValidTgts$ Creature.nonBlack | TgtPrompt$ Select target nonblack creature | NoRegen$ True | SpellDescription$ Destroy target nonblack creature. It can't be regenerated.
+A:SP$ Destroy | ValidTgts$ Creature.nonBlack | TgtPrompt$ Select target nonblack creature | NoRegen$ True | SpellDescription$ Destroy target nonblack creature. It can't be regenerated.
 Oracle:Destroy target nonblack creature. It can't be regenerated.

--- a/forge-gui/res/cardsfolder/s/spring_mind.txt
+++ b/forge-gui/res/cardsfolder/s/spring_mind.txt
@@ -1,7 +1,7 @@
 Name:Spring
 ManaCost:2 G
 Types:Sorcery
-A:SP$ ChangeZone | Cost$ 2 G | Origin$ Library | Destination$ Battlefield | ChangeType$ Land.Basic | Tapped$ True | ChangeNum$ 1 | SpellDescription$ Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.
+A:SP$ ChangeZone | Origin$ Library | Destination$ Battlefield | ChangeType$ Land.Basic | Tapped$ True | ChangeNum$ 1 | SpellDescription$ Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.
 AlternateMode:Split
 Oracle:Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.
 
@@ -11,5 +11,5 @@ Name:Mind
 ManaCost:4 U U
 Types:Instant
 K:Aftermath
-A:SP$ Draw | Cost$ 4 U U | NumCards$ 2 | SpellDescription$ Draw two cards.
+A:SP$ Draw | NumCards$ 2 | SpellDescription$ Draw two cards.
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nDraw two cards.

--- a/forge-gui/res/cardsfolder/s/stand_deliver.txt
+++ b/forge-gui/res/cardsfolder/s/stand_deliver.txt
@@ -1,7 +1,7 @@
 Name:Stand
 ManaCost:W
 Types:Instant
-A:SP$ PreventDamage | Cost$ W | ValidTgts$ Creature | Amount$ 2 | TgtPrompt$ Select target creature | SpellDescription$ Prevent the next 2 damage that would be dealt to target creature this turn.
+A:SP$ PreventDamage | ValidTgts$ Creature | Amount$ 2 | TgtPrompt$ Select target creature | SpellDescription$ Prevent the next 2 damage that would be dealt to target creature this turn.
 AlternateMode:Split
 Oracle:Prevent the next 2 damage that would be dealt to target creature this turn.
 
@@ -10,5 +10,5 @@ ALTERNATE
 Name:Deliver
 ManaCost:2 U
 Types:Instant
-A:SP$ ChangeZone | Cost$ 2 U | ValidTgts$ Permanent | TgtPrompt$ Select target permanent | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return target permanent to its owner's hand.
+A:SP$ ChangeZone | ValidTgts$ Permanent | TgtPrompt$ Select target permanent | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return target permanent to its owner's hand.
 Oracle:Return target permanent to its owner's hand.

--- a/forge-gui/res/cardsfolder/s/status_statue.txt
+++ b/forge-gui/res/cardsfolder/s/status_statue.txt
@@ -1,7 +1,7 @@
 Name:Status
-ManaCost:B/G
+ManaCost:BG
 Types:Instant
-A:SP$ Pump | Cost$ B/G | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +1 | NumDef$ +1 | KW$ Deathtouch | SpellDescription$ Target creature gets +1/+1 and gains deathtouch until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +1 | NumDef$ +1 | KW$ Deathtouch | SpellDescription$ Target creature gets +1/+1 and gains deathtouch until end of turn.
 AlternateMode:Split
 Oracle:Target creature gets +1/+1 and gains deathtouch until end of turn.
 
@@ -10,5 +10,5 @@ ALTERNATE
 Name:Statue
 ManaCost:2 B G
 Types:Instant
-A:SP$ Destroy | Cost$ 2 B G | ValidTgts$ Artifact,Creature,Enchantment | TgtPrompt$ Select target artifact, creature or enchantment | SpellDescription$ Destroy target artifact, creature or enchantment.
+A:SP$ Destroy | ValidTgts$ Artifact,Creature,Enchantment | TgtPrompt$ Select target artifact, creature or enchantment | SpellDescription$ Destroy target artifact, creature or enchantment.
 Oracle:Destroy target artifact, creature, or enchantment.

--- a/forge-gui/res/cardsfolder/s/stoic_rebuttal.txt
+++ b/forge-gui/res/cardsfolder/s/stoic_rebuttal.txt
@@ -1,6 +1,6 @@
 Name:Stoic Rebuttal
 ManaCost:1 U U
 Types:Instant
-A:SP$ Counter | Cost$ 1 U U | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | IsPresent$ Artifact.YouCtrl | PresentCompare$ LT3 | SpellDescription$ Counter target spell.
-A:SP$ Counter | Cost$ U U | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | Activation$ Metalcraft | CostDesc$ Metalcraft — | SpellDescription$ This spell costs {1} less to cast if you control 3 or more artifacts.
+S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 1 | EffectZone$ All | IsPresent$ Artifact.YouCtrl | PresentCompare$ GE3 | Description$ Metalcraft — This spell costs {1} less to cast if you control three or more artifacts.
+A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | SpellDescription$ Counter target spell.
 Oracle:Metalcraft — This spell costs {1} less to cast if you control three or more artifacts.\nCounter target spell.

--- a/forge-gui/res/cardsfolder/s/stoic_rebuttal.txt
+++ b/forge-gui/res/cardsfolder/s/stoic_rebuttal.txt
@@ -1,6 +1,6 @@
 Name:Stoic Rebuttal
 ManaCost:1 U U
 Types:Instant
-S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 1 | EffectZone$ All | IsPresent$ Artifact.YouCtrl | PresentCompare$ GE3 | Description$ Metalcraft — This spell costs {1} less to cast if you control three or more artifacts.
+S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 1 | EffectZone$ All | Condition$ Metalcraft | Description$ Metalcraft — This spell costs {1} less to cast if you control three or more artifacts.
 A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | SpellDescription$ Counter target spell.
 Oracle:Metalcraft — This spell costs {1} less to cast if you control three or more artifacts.\nCounter target spell.

--- a/forge-gui/res/cardsfolder/s/struggle_survive.txt
+++ b/forge-gui/res/cardsfolder/s/struggle_survive.txt
@@ -1,7 +1,7 @@
 Name:Struggle
 ManaCost:2 R
 Types:Instant
-A:SP$ DealDamage | Cost$ 2 R | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SpellDescription$ CARDNAME deals damage to target creature equal to the number of lands you control.
+A:SP$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SpellDescription$ CARDNAME deals damage to target creature equal to the number of lands you control.
 SVar:X:Count$TypeYouCtrl.Land
 AlternateMode:Split
 Oracle:Struggle deals damage to target creature equal to the number of lands you control.
@@ -12,5 +12,5 @@ Name:Survive
 ManaCost:1 G
 Types:Sorcery
 K:Aftermath
-A:SP$ ChangeZoneAll | Cost$ 1 G | Defined$ Player | ChangeType$ Card | Origin$ Graveyard | Destination$ Library | Shuffle$ True | SpellDescription$ Each player shuffles their graveyard into their library.
+A:SP$ ChangeZoneAll | Defined$ Player | ChangeType$ Card | Origin$ Graveyard | Destination$ Library | Shuffle$ True | SpellDescription$ Each player shuffles their graveyard into their library.
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nEach player shuffles their graveyard into their library.

--- a/forge-gui/res/cardsfolder/s/supply_demand.txt
+++ b/forge-gui/res/cardsfolder/s/supply_demand.txt
@@ -1,7 +1,7 @@
 Name:Supply
 ManaCost:X G W
 Types:Sorcery
-A:SP$ Token | Cost$ X G W | TokenAmount$ X | TokenScript$ g_1_1_saproling | TokenOwner$ You | SpellDescription$ Create X 1/1 green Saproling creature tokens.
+A:SP$ Token | TokenAmount$ X | TokenScript$ g_1_1_saproling | TokenOwner$ You | SpellDescription$ Create X 1/1 green Saproling creature tokens.
 SVar:X:Count$xPaid
 DeckHas:Ability$Token
 AlternateMode:Split
@@ -12,5 +12,5 @@ ALTERNATE
 Name:Demand
 ManaCost:1 W U
 Types:Sorcery
-A:SP$ ChangeZone | Cost$ 1 W U | Origin$ Library | Destination$ Hand | ChangeType$ Card.MultiColor | ChangeNum$ 1 | SpellDescription$ Search your library for a multicolored card, reveal it, put it into your hand, then shuffle.
+A:SP$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Card.MultiColor | ChangeNum$ 1 | SpellDescription$ Search your library for a multicolored card, reveal it, put it into your hand, then shuffle.
 Oracle:Search your library for a multicolored card, reveal it, put it into your hand, then shuffle.

--- a/forge-gui/res/cardsfolder/t/thrash_threat.txt
+++ b/forge-gui/res/cardsfolder/t/thrash_threat.txt
@@ -1,7 +1,7 @@
 Name:Thrash
-ManaCost:R/G R/G
+ManaCost:RG RG
 Types:Instant
-A:SP$ Pump | Cost$ RG RG | ValidTgts$ Creature.YouCtrl | AILogic$ PowerDmg | TgtPrompt$ Select target creature you control | SubAbility$ SoulsDamage | StackDescription$ None | SpellDescription$ Target creature you control deals damage equal to its power to target creature you don't control
+A:SP$ Pump | ValidTgts$ Creature.YouCtrl | AILogic$ PowerDmg | TgtPrompt$ Select target creature you control | SubAbility$ SoulsDamage | StackDescription$ None | SpellDescription$ Target creature you control deals damage equal to its power to target creature you don't control
 SVar:SoulsDamage:DB$ DealDamage | ValidTgts$ Creature.YouDontCtrl,Planeswalker.YouDontCtrl | AILogic$ PowerDmg | TgtPrompt$ Select target creature or planeswalker you don't control | NumDmg$ X | DamageSource$ ParentTarget
 SVar:X:ParentTargeted$CardPower
 AlternateMode:Split
@@ -12,6 +12,6 @@ ALTERNATE
 Name:Threat
 ManaCost:2 R G
 Types:Sorcery
-A:SP$ Token | Cost$ 2 R G | TokenAmount$ 1 | TokenOwner$ You | TokenScript$ rg_4_4_beast_trample | SpellDescription$ Create a 4/4 red and green Beast creature token with trample.
+A:SP$ Token | TokenAmount$ 1 | TokenOwner$ You | TokenScript$ rg_4_4_beast_trample | SpellDescription$ Create a 4/4 red and green Beast creature token with trample.
 DeckHas:Ability$Token
 Oracle:Create a 4/4 red and green Beast creature token with trample.

--- a/forge-gui/res/cardsfolder/t/toil_trouble.txt
+++ b/forge-gui/res/cardsfolder/t/toil_trouble.txt
@@ -2,7 +2,7 @@ Name:Toil
 ManaCost:2 B
 Types:Sorcery
 K:Fuse
-A:SP$ Draw | Cost$ 2 B | NumCards$ 2 | ValidTgts$ Player | TgtPrompt$ Choose a player | SubAbility$ DBLoseLife | SpellDescription$ Target player draws two cards and loses 2 life.
+A:SP$ Draw | NumCards$ 2 | ValidTgts$ Player | TgtPrompt$ Choose a player | SubAbility$ DBLoseLife | SpellDescription$ Target player draws two cards and loses 2 life.
 SVar:DBLoseLife:DB$ LoseLife | LifeAmount$ 2 | Defined$ Targeted
 AlternateMode:Split
 Oracle:Target player draws two cards and loses 2 life.\nFuse (You may cast one or both halves of this card from your hand.)
@@ -12,6 +12,6 @@ ALTERNATE
 Name:Trouble
 ManaCost:2 R
 Types:Sorcery
-A:SP$ DealDamage | Cost$ 2 R | ValidTgts$ Player | NumDmg$ X | SpellDescription$ CARDNAME deals damage equal to the number of cards in target player's hand to that player.
+A:SP$ DealDamage | ValidTgts$ Player | NumDmg$ X | SpellDescription$ CARDNAME deals damage equal to the number of cards in target player's hand to that player.
 SVar:X:TargetedPlayer$CardsInHand
 Oracle:Trouble deals damage to target player equal to the number of cards in that player's hand.\nFuse (You may cast one or both halves of this card from your hand.)

--- a/forge-gui/res/cardsfolder/t/trial_error.txt
+++ b/forge-gui/res/cardsfolder/t/trial_error.txt
@@ -1,7 +1,7 @@
 Name:Trial
 ManaCost:W U
 Types:Instant
-A:SP$ ChangeZoneAll | Cost$ W U | ValidTgts$ Creature | TgtPrompt$ Select target creature | RememberTargets$ True | ChangeType$ Creature.blockingRemembered,Creature.isBlockedByRemembered | Origin$ Battlefield | Destination$ Hand | SubAbility$ DBCleanup | UseAllOriginZones$ True | SpellDescription$ Return all creatures blocking or blocked by target creature to their owner's hand.
+A:SP$ ChangeZoneAll | ValidTgts$ Creature | TgtPrompt$ Select target creature | RememberTargets$ True | ChangeType$ Creature.blockingRemembered,Creature.isBlockedByRemembered | Origin$ Battlefield | Destination$ Hand | SubAbility$ DBCleanup | UseAllOriginZones$ True | SpellDescription$ Return all creatures blocking or blocked by target creature to their owner's hand.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 AI:RemoveDeck:All
 AlternateMode:Split
@@ -12,5 +12,5 @@ ALTERNATE
 Name:Error
 ManaCost:U B
 Types:Instant
-A:SP$ Counter | Cost$ U B | TargetType$ Spell | TgtPrompt$ Select target multicolored spell | ValidTgts$ Card.MultiColor | SpellDescription$ Counter target multicolored spell.
+A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target multicolored spell | ValidTgts$ Card.MultiColor | SpellDescription$ Counter target multicolored spell.
 Oracle:Counter target multicolored spell.

--- a/forge-gui/res/cardsfolder/t/turn_burn.txt
+++ b/forge-gui/res/cardsfolder/t/turn_burn.txt
@@ -2,7 +2,7 @@ Name:Turn
 ManaCost:2 U
 Types:Instant
 K:Fuse
-A:SP$ Animate | Cost$ 2 U | ValidTgts$ Creature | TgtPrompt$ Select target creature | Power$ 0 | Toughness$ 1 | RemoveAllAbilities$ True | Colors$ Red | OverwriteColors$ True | Types$ Weird | RemoveCreatureTypes$ True | IsCurse$ True | SpellDescription$ Until end of turn, target creature loses all abilities and becomes a red Weird with base power and toughness 0/1.
+A:SP$ Animate | ValidTgts$ Creature | TgtPrompt$ Select target creature | Power$ 0 | Toughness$ 1 | RemoveAllAbilities$ True | Colors$ Red | OverwriteColors$ True | Types$ Weird | RemoveCreatureTypes$ True | IsCurse$ True | SpellDescription$ Until end of turn, target creature loses all abilities and becomes a red Weird with base power and toughness 0/1.
 AlternateMode:Split
 Oracle:Until end of turn, target creature loses all abilities and becomes a red Weird with base power and toughness 0/1.\nFuse (You may cast one or both halves of this card from your hand.)
 
@@ -11,5 +11,5 @@ ALTERNATE
 Name:Burn
 ManaCost:1 R
 Types:Instant
-A:SP$ DealDamage | Cost$ 1 R | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to any target.
+A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to any target.
 Oracle:Burn deals 2 damage to any target.\nFuse (You may cast one or both halves of this card from your hand.)

--- a/forge-gui/res/cardsfolder/w/warrant_warden.txt
+++ b/forge-gui/res/cardsfolder/w/warrant_warden.txt
@@ -1,7 +1,7 @@
 Name:Warrant
-ManaCost:W/U W/U
+ManaCost:WU WU
 Types:Instant
-A:SP$ ChangeZone | Cost$ WU WU | ValidTgts$ Creature.attacking,Creature.blocking | TgtPrompt$ Select target attacking or blocking creature. | Origin$ Battlefield | Destination$ Library | LibraryPosition$ 0 | SpellDescription$ Put target attacking or blocking creature on top of its owner's library.
+A:SP$ ChangeZone | ValidTgts$ Creature.attacking,Creature.blocking | TgtPrompt$ Select target attacking or blocking creature. | Origin$ Battlefield | Destination$ Library | LibraryPosition$ 0 | SpellDescription$ Put target attacking or blocking creature on top of its owner's library.
 AlternateMode:Split
 Oracle:Put target attacking or blocking creature on top of its owner's library.
 
@@ -10,5 +10,5 @@ ALTERNATE
 Name:Warden
 ManaCost:3 W U
 Types:Sorcery
-A:SP$ Token | Cost$ 3 W U | TokenAmount$ 1 | TokenOwner$ You | TokenScript$ wu_4_4_sphinx_flying_vigilance | SpellDescription$ Create a 4/4 white and blue Sphinx creature token with flying and vigilance.
+A:SP$ Token | TokenAmount$ 1 | TokenOwner$ You | TokenScript$ wu_4_4_sphinx_flying_vigilance | SpellDescription$ Create a 4/4 white and blue Sphinx creature token with flying and vigilance.
 Oracle:Create a 4/4 white and blue Sphinx creature token with flying and vigilance.

--- a/forge-gui/res/cardsfolder/w/wax_wane.txt
+++ b/forge-gui/res/cardsfolder/w/wax_wane.txt
@@ -1,7 +1,7 @@
 Name:Wax
 ManaCost:G
 Types:Instant
-A:SP$ Pump | Cost$ G | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +2 | NumDef$ +2 | SpellDescription$ Target creature gets +2/+2 until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +2 | NumDef$ +2 | SpellDescription$ Target creature gets +2/+2 until end of turn.
 AlternateMode:Split
 Oracle:Target creature gets +2/+2 until end of turn.
 
@@ -10,5 +10,5 @@ ALTERNATE
 Name:Wane
 ManaCost:W
 Types:Instant
-A:SP$ Destroy | Cost$ W | ValidTgts$ Enchantment | TgtPrompt$ Select target enchantment | SpellDescription$ Destroy target enchantment.
+A:SP$ Destroy | ValidTgts$ Enchantment | TgtPrompt$ Select target enchantment | SpellDescription$ Destroy target enchantment.
 Oracle:Destroy target enchantment.

--- a/forge-gui/res/cardsfolder/w/wear_tear.txt
+++ b/forge-gui/res/cardsfolder/w/wear_tear.txt
@@ -2,7 +2,7 @@ Name:Wear
 ManaCost:1 R
 Types:Instant
 K:Fuse
-A:SP$ Destroy | Cost$ 1 R | ValidTgts$ Artifact | TgtPrompt$ Select target artifact | SpellDescription$ Destroy target artifact.
+A:SP$ Destroy | ValidTgts$ Artifact | TgtPrompt$ Select target artifact | SpellDescription$ Destroy target artifact.
 AlternateMode:Split
 Oracle:Destroy target artifact.\nFuse (You may cast one or both halves of this card from your hand.)
 
@@ -11,5 +11,5 @@ ALTERNATE
 Name:Tear
 ManaCost:W
 Types:Instant
-A:SP$ Destroy | Cost$ W | ValidTgts$ Enchantment | TgtPrompt$ Select target enchantment | SpellDescription$ Destroy target enchantment.
+A:SP$ Destroy | ValidTgts$ Enchantment | TgtPrompt$ Select target enchantment | SpellDescription$ Destroy target enchantment.
 Oracle:Destroy target enchantment.\nFuse (You may cast one or both halves of this card from your hand.)


### PR DESCRIPTION
This time around dealing with scripts with two spell abilities: mostly split cards but with notable exceptions. Older scripts I retooled from hardcoded alternate cost/effect pairs are:
- [Damn](https://scryfall.com/card/lcc/191/damn)
- [Essence Filter](https://scryfall.com/card/me2/160/essence-filter)
- [Graveyard Dig](https://scryfall.com/card/cmb2/92/graveyard-dig)
- [Lava Storm](https://scryfall.com/card/wth/110/lava-storm)
- [Patrician's Scorn](https://scryfall.com/card/fut/29/patricians-scorn)
- [Stoic Rebuttal](https://scryfall.com/card/mm2/59/stoic-rebuttal)

I left cleave cards alone (except for Graveyard Dig's proto-cleave) for a latter more knowledgeable pass. I also took the opportunity to remove slashes from hybrid mana where I saw them: saves a few bytes.