### PR TITLE
Deck-based AI hints metadata + predefined sideboarding plan support

### DIFF
--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -102,7 +102,8 @@ public class PlayerControllerAi extends PlayerController {
 
     @Override
     public List<PaperCard> sideboard(Deck deck, GameType gameType, String message) {
-        if (!getAi().getBooleanProperty(AiProps.SIDEBOARDING_ENABLE)) {
+        if (!getAi().getBooleanProperty(AiProps.SIDEBOARDING_ENABLE)
+            || !deck.has(DeckSection.Sideboard)) {
             return null;
         }
 

--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -4,7 +4,6 @@ import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.*;
 import forge.LobbyPlayer;
-import forge.StaticData;
 import forge.ai.ability.ProtectAi;
 import forge.card.CardStateName;
 import forge.card.ColorSet;

--- a/forge-core/src/main/java/forge/deck/Deck.java
+++ b/forge-core/src/main/java/forge/deck/Deck.java
@@ -27,7 +27,6 @@ import forge.card.CardRules;
 import forge.card.CardType;
 import forge.item.IPaperCard;
 import forge.item.PaperCard;
-import forge.util.TextUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 

--- a/forge-core/src/main/java/forge/deck/Deck.java
+++ b/forge-core/src/main/java/forge/deck/Deck.java
@@ -27,6 +27,7 @@ import forge.card.CardRules;
 import forge.card.CardType;
 import forge.item.IPaperCard;
 import forge.item.PaperCard;
+import forge.util.TextUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -48,6 +49,7 @@ public class Deck extends DeckBase implements Iterable<Entry<DeckSection, CardPo
     private final Set<String> tags = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
     // Supports deferring loading a deck until we actually need its contents. This works in conjunction with
     // the lazy card load feature to ensure we don't need to load all cards on start up.
+    private final Set<String> aiHints = new TreeSet<>();
     private Map<String, List<String>> deferredSections = null;
     private Map<String, List<String>> loadedSections = null;
     private String lastCardArtPreferenceUsed = "";
@@ -207,6 +209,7 @@ public class Deck extends DeckBase implements Iterable<Entry<DeckSection, CardPo
             result.parts.put(kv.getKey(), cp);
             cp.addAll(kv.getValue());
         }
+        result.setAiHints(StringUtils.join(aiHints, " | "));
     }
 
     /*
@@ -534,6 +537,29 @@ public class Deck extends DeckBase implements Iterable<Entry<DeckSection, CardPo
         }
         // do not include schemes / avatars and any non-regular cards
         return allCards;
+    }
+
+    public void setAiHints(String aiHintsInfo) {
+        if (aiHintsInfo == null || aiHintsInfo.trim().equals("")) {
+            return;
+        }
+        String[] hints = aiHintsInfo.split("\\|");
+        for (String hint : hints) {
+            aiHints.add(hint.trim());
+        }
+    }
+
+    public Set<String> getAiHints() {
+        return aiHints;
+    }
+
+    public String getAiHint(String name) {
+        for (String aiHint : aiHints) {
+            if (aiHint.toLowerCase().startsWith(name.toLowerCase() + "$")) {
+                return aiHint.substring(aiHint.indexOf("$") + 1).trim();
+            }
+        }
+        return "";
     }
 
     public UnplayableAICards getUnplayableAICards() {

--- a/forge-core/src/main/java/forge/deck/io/DeckFileHeader.java
+++ b/forge-core/src/main/java/forge/deck/io/DeckFileHeader.java
@@ -45,6 +45,7 @@ public class DeckFileHeader {
     private static final String PLAYER = "Player";
     private static final String CSTM_POOL = "Custom Pool";
     private static final String PLAYER_TYPE = "PlayerType";
+    public static final String AI_HINTS = "AiHints";
 
     private final DeckFormat deckType;
     private final boolean customPool;
@@ -55,12 +56,20 @@ public class DeckFileHeader {
     private final Set<String> tags;
 
     private final boolean intendedForAi;
+    private final String aiHints;
 
     /**
      * @return the intendedForAi
      */
     public boolean isIntendedForAi() {
         return intendedForAi;
+    }
+
+    /**
+     * @return the AI hints
+     */
+    public String getAiHints() {
+        return aiHints;
     }
 
     /**
@@ -75,6 +84,7 @@ public class DeckFileHeader {
         this.deckType = DeckFormat.smartValueOf(kvPairs.get(DeckFileHeader.DECK_TYPE), DeckFormat.Constructed);
         this.customPool = kvPairs.getBoolean(DeckFileHeader.CSTM_POOL);
         this.intendedForAi = "computer".equalsIgnoreCase(kvPairs.get(DeckFileHeader.PLAYER)) || "ai".equalsIgnoreCase(kvPairs.get(DeckFileHeader.PLAYER_TYPE));
+        this.aiHints = kvPairs.get(DeckFileHeader.AI_HINTS);
         this.tags = new TreeSet<>();
         
         String rawTags = kvPairs.get(DeckFileHeader.TAGS);

--- a/forge-core/src/main/java/forge/deck/io/DeckSerializer.java
+++ b/forge-core/src/main/java/forge/deck/io/DeckSerializer.java
@@ -53,6 +53,9 @@ public class DeckSerializer {
         if (!d.getTags().isEmpty()) {
             out.add(TextUtil.concatNoSpace(DeckFileHeader.TAGS,"=", StringUtils.join(d.getTags(), DeckFileHeader.TAGS_SEPARATOR)));
         }
+        if (!d.getAiHints().isEmpty()) {
+            out.add(TextUtil.concatNoSpace(DeckFileHeader.AI_HINTS, "=", StringUtils.join(d.getAiHints(), " | ")));
+        }
     
         for(Entry<DeckSection, CardPool> s : d) {
             out.add(TextUtil.enclosedBracket(s.getKey().toString()));
@@ -77,6 +80,7 @@ public class DeckSerializer {
 
         Deck d = new Deck(dh.getName());
         d.setComment(dh.getComment());
+        d.setAiHints(dh.getAiHints());
         d.getTags().addAll(dh.getTags());
         d.setDeferredSections(sections);
         return d;


### PR DESCRIPTION
Ok, so this is probably going to be slightly controversial/divisive, so hear me out :)
What this change does is it brings a possibility of creating a metadata line in the deck files (AIHints=...) which can be used to specify an assortment of hints for the AI for a specific deck. Currently, as a proof-of-concept demo, this brings the ability to create a predefined sideboarding plan for the AI to use (e.g. for fully transformative sideboards), but can be expanded for various AFs, for example, to specify card tutoring priorities relevant for a particular deck, etc.

The format is similar to the scripting language we use and is generally like this:
AIHints=HintName$ HintValue | HintName$ HintValue | ...

So, for the predefined AI sideboarding plan, it's possible to specify (for example):
AIHints=SideboardPlan$ Fang of Shingeki->Kami of Transience;Audacity->Michiko's Reign of Truth

The reason this is a controversial change is because this expands the deck file format to include an entry that is not specific to the deck composition itself but more to the AI's use of the deck, which may sort of make the deck format "impure". That said, our current deck format has supported non-deck data in it for the longest time (over 10 years), including a (practically unused) flag that was supposedly designed to support defining whether the deck was designed to be played by a human or by the AI (cf. PLAYER and PLAYER_TYPE definitions in DeckFileHeader.java, e.g. line 86). Some additional fields are supported as well, such as comments and tags, which expand the deck information as needed. Thus, I don't think it's completely unfeasible to add another potential field to the mix which would be AI-centric, especially considering that Forge is a game that, in the absolute majority of cases, is played against the AI opponents, as opposed to PvP network games.

Then again, I understand the concern that changes like this one would potentially "pollute" the deck format, so if there are any arguments for or against this approach, please let me know. This is the only way I'm aware of that I can support it. I tried imagining something with the extra files specifically for the purpose, but that felt too "bulky" to me and I couldn't devise a clean enough interface to make things interact as needed. So, if a different approach would be preferable, I think I wouldn't be the best man to implement it :)