### PR TITLE
Fixing Overzealous Muscle granting indestructible to players and not itself

### DIFF
--- a/forge-gui/res/cardsfolder/c/cathars_companion.txt
+++ b/forge-gui/res/cardsfolder/c/cathars_companion.txt
@@ -3,6 +3,6 @@ ManaCost:2 W
 Types:Creature Dog
 PT:3/1
 T:Mode$ SpellCast | ValidCard$ Card.nonCreature | ValidActivatingPlayer$ You | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a noncreature spell, CARDNAME gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it.)
-SVar:TrigPump:DB$ Pump | Defined$ Self | KW$ Indestructible | SpellDescription$ CARDNAME gains indestructible until end of turn.
+SVar:TrigPump:DB$ Pump | Defined$ Self | KW$ Indestructible
 SVar:BuffedBy:Card.nonLand+nonCreature
 Oracle:Whenever you cast a noncreature spell, Cathar's Companion gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it.)

--- a/forge-gui/res/cardsfolder/o/overzealous_muscle.txt
+++ b/forge-gui/res/cardsfolder/o/overzealous_muscle.txt
@@ -3,5 +3,5 @@ ManaCost:4 B
 Types:Creature Ogre Mercenary
 PT:5/4
 T:Mode$ CommitCrime | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPump | PlayerTurn$ True | TriggerDescription$ Whenever you commit a crime during your turn, CARDNAME gains indestructible until end of turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime. Damage and effects that say "destroy" don't destroy a creature with indestructible.)
-SVar:TrigPump:DB$ Pump | Defined$ Card.Self | KW$ Indestructible
+SVar:TrigPump:DB$ Pump | Defined$ Self | KW$ Indestructible
 Oracle:Whenever you commit a crime during your turn, Overzealous Muscle gains indestructible until end of turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime. Damage and effects that say "destroy" don't destroy a creature with indestructible.)


### PR DESCRIPTION
Comparing the scripts of [Overzealous Muscle](https://scryfall.com/card/otj/97/overzealous-muscle) and [Cathar's Companion](https://scryfall.com/card/jmp/94/cathars-companion), the only pertinent difference was `Defined$ Card.Self` on the first, contrasting `Defined$ Self` on the second. Testing Overzealous Muscle with the Companion's relevant argument for that parameter had the Ogre working properly. 
Noticing the latter was lacking `SpellDescription$` on the indestructible-granting line and not seeing that text displayed anywhere in the GUI for Cathar's Companion, I removed the `SpellDescription$` from the Dog's relevant line.