### PR TITLE
Cost$ cleanup: Main event: Folder 'm' part 2

### DIFF
--- a/forge-gui/res/cardsfolder/e/ertais_meddling.txt
+++ b/forge-gui/res/cardsfolder/e/ertais_meddling.txt
@@ -2,7 +2,7 @@ Name:Ertai's Meddling
 ManaCost:X U
 Types:Instant
 Text:X can't be 0.\r\n
-A:SP$ ChangeZone | TgtZone$ Stack | TargetType$ Spell | ValidTgts$ Card | Origin$ Stack | Destination$ Exile | Imprint$ True | WithCountersType$ DELAY | WithCountersAmount$ X | WithCountersPlacer$ TargetedController | SubAbility$ DBDelayEffect | SpellDescription$ Target spell's controller exiles it with X delay counters on it.
+A:SP$ ChangeZone | Cost$ XMin1 X U | TgtZone$ Stack | TargetType$ Spell | ValidTgts$ Card | Origin$ Stack | Destination$ Exile | Imprint$ True | WithCountersType$ DELAY | WithCountersAmount$ X | WithCountersPlacer$ TargetedController | SubAbility$ DBDelayEffect | SpellDescription$ Target spell's controller exiles it with X delay counters on it.
 SVar:X:Count$xPaid
 SVar:DBDelayEffect:DB$ Effect | EffectOwner$ TargetedController | RememberSpell$ Targeted | ImprintCards$ Imprinted | ConditionDefined$ Imprinted | ConditionPresent$ Card.inZoneExile | Triggers$ TrigDelay,TrigExile | Duration$ Permanent | SubAbility$ DBForget
 SVar:DBForget:DB$ Cleanup | ClearImprinted$ True

--- a/forge-gui/res/cardsfolder/m/mercurial_transformation.txt
+++ b/forge-gui/res/cardsfolder/m/mercurial_transformation.txt
@@ -1,7 +1,7 @@
 Name:Mercurial Transformation
 ManaCost:1 U
 Types:Sorcery Lesson
-A:SP$ Animate | Cost$ 1 U | ValidTgts$ Permanent.nonLand | TgtPrompt$ Select target nonland permanent | RemoveAllAbilities$ True | SubAbility$ DBChoose | SpellDescription$ Until end of turn, target nonland permanent loses all abilities and becomes your choice of a blue Frog creature with base power and toughness 1/1 or a blue Octopus creature with base power and toughness 4/4.
+A:SP$ Animate | ValidTgts$ Permanent.nonLand | TgtPrompt$ Select target nonland permanent | RemoveAllAbilities$ True | SubAbility$ DBChoose | SpellDescription$ Until end of turn, target nonland permanent loses all abilities and becomes your choice of a blue Frog creature with base power and toughness 1/1 or a blue Octopus creature with base power and toughness 4/4.
 SVar:DBChoose:DB$ GenericChoice | Defined$ You | Choices$ DBFrog,DBOctopus | StackDescription$ None
 SVar:DBFrog:DB$ Animate | Power$ 1 | Toughness$ 1 | Colors$ Blue | OverwriteColors$ True | Types$ Creature,Frog | RemoveCardTypes$ True | RemoveCreatureTypes$ True | IsCurse$ True | Defined$ Targeted | SpellDescription$ Until end of turn, target nonland permanent loses all abilities and becomes a blue Frog with base power and toughness 1/1.
 SVar:DBOctopus:DB$ Animate | Power$ 4 | Toughness$ 4 | Colors$ Blue | OverwriteColors$ True | Types$ Creature,Octopus | RemoveCardTypes$ True | RemoveCreatureTypes$ True | IsCurse$ True | Defined$ Targeted | SpellDescription$ Until end of turn, target nonland permanent loses all abilities and becomes a blue Octopus with base power and toughness 4/4.

--- a/forge-gui/res/cardsfolder/m/mercy_killing.txt
+++ b/forge-gui/res/cardsfolder/m/mercy_killing.txt
@@ -1,7 +1,7 @@
 Name:Mercy Killing
 ManaCost:2 GW
 Types:Instant
-A:SP$ Destroy | Cost$ 2 GW | ValidTgts$ Creature | TgtPrompt$ Select target creature | Sacrifice$ True | SubAbility$ DBToken | SpellDescription$ Target creature's controller sacrifices it, then creates X 1/1 green and white Elf Warrior creature tokens, where X is that creature's power.
+A:SP$ Destroy | ValidTgts$ Creature | TgtPrompt$ Select target creature | Sacrifice$ True | SubAbility$ DBToken | SpellDescription$ Target creature's controller sacrifices it, then creates X 1/1 green and white Elf Warrior creature tokens, where X is that creature's power.
 SVar:DBToken:DB$ Token | TokenAmount$ X | TokenScript$ gw_1_1_elf_warrior | TokenOwner$ TargetedController
 SVar:X:Targeted$CardPower
 Oracle:Target creature's controller sacrifices it, then creates X 1/1 green and white Elf Warrior creature tokens, where X is that creature's power.

--- a/forge-gui/res/cardsfolder/m/merfolk_secretkeeper_venture_deeper.txt
+++ b/forge-gui/res/cardsfolder/m/merfolk_secretkeeper_venture_deeper.txt
@@ -10,5 +10,5 @@ ALTERNATE
 Name:Venture Deeper
 ManaCost:U
 Types:Sorcery Adventure
-A:SP$ Mill | Cost$ U | NumCards$ 4 | ValidTgts$ Player | TgtPrompt$ Choose a player | SpellDescription$ Target player mills four cards. (Then exile this card. You may cast the creature later from exile.)
+A:SP$ Mill | NumCards$ 4 | ValidTgts$ Player | TgtPrompt$ Choose a player | SpellDescription$ Target player mills four cards. (Then exile this card. You may cast the creature later from exile.)
 Oracle:Target player mills four cards. (Then exile this card. You may cast the creature later from exile.)

--- a/forge-gui/res/cardsfolder/m/metal_fatigue.txt
+++ b/forge-gui/res/cardsfolder/m/metal_fatigue.txt
@@ -1,6 +1,6 @@
 Name:Metal Fatigue
 ManaCost:2 W
 Types:Instant
-A:SP$ TapAll | Cost$ 2 W | ValidCards$ Artifact | SpellDescription$ Tap all artifacts.
+A:SP$ TapAll | ValidCards$ Artifact | SpellDescription$ Tap all artifacts.
 AI:RemoveDeck:Random
 Oracle:Tap all artifacts.

--- a/forge-gui/res/cardsfolder/m/metallic_mastery.txt
+++ b/forge-gui/res/cardsfolder/m/metallic_mastery.txt
@@ -1,6 +1,6 @@
 Name:Metallic Mastery
 ManaCost:2 R
 Types:Sorcery
-A:SP$ GainControl | Cost$ 2 R | ValidTgts$ Artifact | TgtPrompt$ Select target artifact | LoseControl$ EOT | Untap$ True | AddKWs$ Haste | SpellDescription$ Gain control of target artifact until end of turn. Untap that artifact. It gains haste until end of turn.
+A:SP$ GainControl | ValidTgts$ Artifact | TgtPrompt$ Select target artifact | LoseControl$ EOT | Untap$ True | AddKWs$ Haste | SpellDescription$ Gain control of target artifact until end of turn. Untap that artifact. It gains haste until end of turn.
 SVar:PlayMain1:TRUE
 Oracle:Gain control of target artifact until end of turn. Untap that artifact. It gains haste until end of turn.

--- a/forge-gui/res/cardsfolder/m/metallic_rebuke.txt
+++ b/forge-gui/res/cardsfolder/m/metallic_rebuke.txt
@@ -2,5 +2,5 @@ Name:Metallic Rebuke
 ManaCost:2 U
 Types:Instant
 K:Improvise
-A:SP$ Counter | Cost$ 2 U | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | UnlessCost$ 3 | SpellDescription$ Counter target spell unless its controller pays {3}.
+A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | UnlessCost$ 3 | SpellDescription$ Counter target spell unless its controller pays {3}.
 Oracle:Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nCounter target spell unless its controller pays {3}.

--- a/forge-gui/res/cardsfolder/m/metamorphose.txt
+++ b/forge-gui/res/cardsfolder/m/metamorphose.txt
@@ -1,7 +1,7 @@
 Name:Metamorphose
 ManaCost:1 U
 Types:Instant
-A:SP$ ChangeZone | Cost$ 1 U | ValidTgts$ Permanent | TgtPrompt$ Select target permanent | Origin$ Battlefield | Destination$ Library | LibraryPosition$ 0 | SubAbility$ DBChange | SpellDescription$ Put target permanent an opponent controls on top of its owner's library. That opponent may put an artifact, creature, enchantment, or land card from their hand onto the battlefield.
+A:SP$ ChangeZone | ValidTgts$ Permanent | TgtPrompt$ Select target permanent | Origin$ Battlefield | Destination$ Library | LibraryPosition$ 0 | SubAbility$ DBChange | SpellDescription$ Put target permanent an opponent controls on top of its owner's library. That opponent may put an artifact, creature, enchantment, or land card from their hand onto the battlefield.
 SVar:DBChange:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | ChangeType$ Artifact,Creature,Enchantment,Land | DefinedPlayer$ TargetedController | ChangeNum$ 1
 AI:RemoveDeck:All
 Oracle:Put target permanent an opponent controls on top of its owner's library. That opponent may put an artifact, creature, enchantment, or land card from their hand onto the battlefield.

--- a/forge-gui/res/cardsfolder/m/meteor_blast.txt
+++ b/forge-gui/res/cardsfolder/m/meteor_blast.txt
@@ -1,6 +1,6 @@
 Name:Meteor Blast
 ManaCost:X R R R
 Types:Sorcery
-A:SP$ DealDamage | Cost$ X R R R | ValidTgts$ Any | TgtPrompt$ Select X targets | TargetMin$ X | TargetMax$ X | NumDmg$ 4 | SpellDescription$ CARDNAME deals 4 damage to each of X targets.
+A:SP$ DealDamage | ValidTgts$ Any | TgtPrompt$ Select X targets | TargetMin$ X | TargetMax$ X | NumDmg$ 4 | SpellDescription$ CARDNAME deals 4 damage to each of X targets.
 SVar:X:Count$xPaid
 Oracle:Meteor Blast deals 4 damage to each of X targets.

--- a/forge-gui/res/cardsfolder/m/meteor_shower.txt
+++ b/forge-gui/res/cardsfolder/m/meteor_shower.txt
@@ -1,7 +1,7 @@
 Name:Meteor Shower
 ManaCost:X X R
 Types:Sorcery
-A:SP$ DealDamage | Cost$ X X R | ValidTgts$ Any | TgtPrompt$ Select targets to distribute damage to | NumDmg$ DistroDmg | TargetMin$ 0 | TargetMax$ MaxTgts | DividedAsYouChoose$ DistroDmg | SpellDescription$ CARDNAME deals X plus 1 damage divided as you choose among any number of targets.
+A:SP$ DealDamage | ValidTgts$ Any | TgtPrompt$ Select targets to distribute damage to | NumDmg$ DistroDmg | TargetMin$ 0 | TargetMax$ MaxTgts | DividedAsYouChoose$ DistroDmg | SpellDescription$ CARDNAME deals X plus 1 damage divided as you choose among any number of targets.
 SVar:MaxTgts:PlayerCountPlayers$Amount/Plus.MaxPermanents
 SVar:MaxPermanents:Count$Valid Any
 SVar:DistroDmg:SVar$X/Plus.1

--- a/forge-gui/res/cardsfolder/m/meteor_swarm.txt
+++ b/forge-gui/res/cardsfolder/m/meteor_swarm.txt
@@ -1,6 +1,6 @@
 Name:Meteor Swarm
 ManaCost:X R R R
 Types:Sorcery
-A:SP$ DealDamage | Cost$ X R R R | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select X target creatures and/or planeswalkers | NumDmg$ 8 | TargetMin$ X | TargetMax$ X | DividedAsYouChoose$ 8 | SpellDescription$ CARDNAME deals 8 damage divided as you choose among X target creatures and/or planeswalkers.
+A:SP$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select X target creatures and/or planeswalkers | NumDmg$ 8 | TargetMin$ X | TargetMax$ X | DividedAsYouChoose$ 8 | SpellDescription$ CARDNAME deals 8 damage divided as you choose among X target creatures and/or planeswalkers.
 SVar:X:Count$xPaid
 Oracle:Meteor Swarm deals 8 damage divided as you choose among X target creatures and/or planeswalkers.

--- a/forge-gui/res/cardsfolder/m/midnight_charm.txt
+++ b/forge-gui/res/cardsfolder/m/midnight_charm.txt
@@ -1,7 +1,7 @@
 Name:Midnight Charm
 ManaCost:B
 Types:Instant
-A:SP$ Charm | Cost$ B | Choices$ DBDamage,DBPump,DBTap
+A:SP$ Charm | Choices$ DBDamage,DBPump,DBTap
 SVar:DBDamage:DB$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature to deal damage | NumDmg$ 1 | SubAbility$ DBGain | SpellDescription$ CARDNAME deals 1 damage to target creature and you gain 1 life.
 SVar:DBGain:DB$ GainLife | Defined$ You | LifeAmount$ 1
 SVar:DBPump:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature to gain First Strike | KW$ First Strike | SpellDescription$ Target creature gains first strike until end of turn.

--- a/forge-gui/res/cardsfolder/m/midnight_haunting.txt
+++ b/forge-gui/res/cardsfolder/m/midnight_haunting.txt
@@ -1,5 +1,5 @@
 Name:Midnight Haunting
 ManaCost:2 W
 Types:Instant
-A:SP$ Token | Cost$ 2 W | TokenAmount$ 2 | TokenScript$ w_1_1_spirit_flying | TokenOwner$ You | SpellDescription$ Create two 1/1 white Spirit creature tokens with flying.
+A:SP$ Token | TokenAmount$ 2 | TokenScript$ w_1_1_spirit_flying | TokenOwner$ You | SpellDescription$ Create two 1/1 white Spirit creature tokens with flying.
 Oracle:Create two 1/1 white Spirit creature tokens with flying.

--- a/forge-gui/res/cardsfolder/m/midnight_recovery.txt
+++ b/forge-gui/res/cardsfolder/m/midnight_recovery.txt
@@ -2,7 +2,7 @@ Name:Midnight Recovery
 ManaCost:3 B
 Types:Sorcery
 K:Cipher
-A:SP$ ChangeZone | Cost$ 3 B | Origin$ Graveyard | Destination$ Hand | TgtPrompt$ Choose target creature card in your graveyard | ValidTgts$ Creature.YouOwn | SubAbility$ Cipher | SpellDescription$ Return target creature card from your graveyard to your hand.
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Hand | TgtPrompt$ Choose target creature card in your graveyard | ValidTgts$ Creature.YouOwn | SubAbility$ Cipher | SpellDescription$ Return target creature card from your graveyard to your hand.
 SVar:Cipher:DB$ Encode | Defined$ Self
 DeckNeeds:Type$Creature
 Oracle:Return target creature card from your graveyard to your hand.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)

--- a/forge-gui/res/cardsfolder/m/midnight_ritual.txt
+++ b/forge-gui/res/cardsfolder/m/midnight_ritual.txt
@@ -1,7 +1,7 @@
 Name:Midnight Ritual
 ManaCost:X 2 B
 Types:Sorcery
-A:SP$ ChangeZone | Cost$ X 2 B | Origin$ Graveyard | Destination$ Exile | TgtPrompt$ Choose X target creature cards in your graveyard | ValidTgts$ Creature.YouOwn | TargetMin$ X | TargetMax$ X | SubAbility$ DBToken | StackDescription$ {p:You} exiles {c:Targeted} from their graveyard. For each creature card exiled this way, {p:You} creates a 2/2 black Zombie creature token. | SpellDescription$ Exile X target creature cards from your graveyard. For each creature card exiled this way, create a 2/2 black Zombie creature token.
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Exile | TgtPrompt$ Choose X target creature cards in your graveyard | ValidTgts$ Creature.YouOwn | TargetMin$ X | TargetMax$ X | SubAbility$ DBToken | StackDescription$ {p:You} exiles {c:Targeted} from their graveyard. For each creature card exiled this way, {p:You} creates a 2/2 black Zombie creature token. | SpellDescription$ Exile X target creature cards from your graveyard. For each creature card exiled this way, create a 2/2 black Zombie creature token.
 SVar:DBToken:DB$ Token | TokenScript$ b_2_2_zombie | TokenOwner$ You | TokenAmount$ X
 SVar:X:Count$xPaid
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/m/might_beyond_reason.txt
+++ b/forge-gui/res/cardsfolder/m/might_beyond_reason.txt
@@ -1,7 +1,7 @@
 Name:Might Beyond Reason
 ManaCost:3 G
 Types:Instant
-A:SP$ PutCounter | Cost$ 3 G | CounterNum$ X | CounterType$ P1P1 | ValidTgts$ Creature | TgtPrompt$ Select target creature | SpellDescription$ Put two +1/+1 counters on target creature. Delirium — Put three +1/+1 counters on that creature instead if there are four or more card types among cards in your graveyard.
+A:SP$ PutCounter | CounterNum$ X | CounterType$ P1P1 | ValidTgts$ Creature | TgtPrompt$ Select target creature | SpellDescription$ Put two +1/+1 counters on target creature. Delirium — Put three +1/+1 counters on that creature instead if there are four or more card types among cards in your graveyard.
 SVar:X:Count$Delirium.3.2
 DeckHints:Ability$Graveyard|Discard
 DeckHas:Ability$Delirium

--- a/forge-gui/res/cardsfolder/m/might_of_alara.txt
+++ b/forge-gui/res/cardsfolder/m/might_of_alara.txt
@@ -1,7 +1,7 @@
 Name:Might of Alara
 ManaCost:G
 Types:Instant
-A:SP$ Pump | Cost$ G | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | NumDef$ +X | SpellDescription$ Domain — Target creature gets +1/+1 until end of turn for each basic land type among lands you control.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | NumDef$ +X | SpellDescription$ Domain — Target creature gets +1/+1 until end of turn for each basic land type among lands you control.
 SVar:X:Count$Domain
 AI:RemoveDeck:Random
 Oracle:Domain — Target creature gets +1/+1 until end of turn for each basic land type among lands you control.

--- a/forge-gui/res/cardsfolder/m/might_of_murasa.txt
+++ b/forge-gui/res/cardsfolder/m/might_of_murasa.txt
@@ -2,6 +2,6 @@ Name:Might of Murasa
 ManaCost:1 G
 Types:Instant
 K:Kicker:2 G
-A:SP$ Pump | Cost$ 1 G | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ X | NumDef$ X | SpellDescription$ Target creature gets +3/+3 until end of turn. If this spell was kicked, that creature gets +5/+5 until end of turn instead.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ X | NumDef$ X | SpellDescription$ Target creature gets +3/+3 until end of turn. If this spell was kicked, that creature gets +5/+5 until end of turn instead.
 SVar:X:Count$Kicked.5.3
 Oracle:Kicker {2}{G} (You may pay an additional {2}{G} as you cast this spell.)\nTarget creature gets +3/+3 until end of turn. If this spell was kicked, that creature gets +5/+5 until end of turn instead.

--- a/forge-gui/res/cardsfolder/m/might_of_oaks.txt
+++ b/forge-gui/res/cardsfolder/m/might_of_oaks.txt
@@ -1,5 +1,5 @@
 Name:Might of Oaks
 ManaCost:3 G
 Types:Instant
-A:SP$ Pump | Cost$ 3 G | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +7 | NumDef$ +7 | SpellDescription$ Target creature gets +7/+7 until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +7 | NumDef$ +7 | SpellDescription$ Target creature gets +7/+7 until end of turn.
 Oracle:Target creature gets +7/+7 until end of turn.

--- a/forge-gui/res/cardsfolder/m/might_of_old_krosa.txt
+++ b/forge-gui/res/cardsfolder/m/might_of_old_krosa.txt
@@ -1,6 +1,6 @@
 Name:Might of Old Krosa
 ManaCost:G
 Types:Instant
-A:SP$ Pump | Cost$ G | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ X | NumDef$ X | AILogic$ Main1IfAble | SpellDescription$ Target creature gets +2/+2 until end of turn. If you cast this spell during your main phase, that creature gets +4/+4 until end of turn instead.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ X | NumDef$ X | AILogic$ Main1IfAble | SpellDescription$ Target creature gets +2/+2 until end of turn. If you cast this spell during your main phase, that creature gets +4/+4 until end of turn instead.
 SVar:X:Count$IfCastInOwnMainPhase.4.2
 Oracle:Target creature gets +2/+2 until end of turn. If you cast this spell during your main phase, that creature gets +4/+4 until end of turn instead.

--- a/forge-gui/res/cardsfolder/m/might_of_the_masses.txt
+++ b/forge-gui/res/cardsfolder/m/might_of_the_masses.txt
@@ -1,6 +1,6 @@
 Name:Might of the Masses
 ManaCost:G
 Types:Instant
-A:SP$ Pump | Cost$ G | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | NumDef$ +X | SpellDescription$ Target creature gets +1/+1 until end of turn for each creature you control.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | NumDef$ +X | SpellDescription$ Target creature gets +1/+1 until end of turn for each creature you control.
 SVar:X:Count$TypeYouCtrl.Creature
 Oracle:Target creature gets +1/+1 until end of turn for each creature you control.

--- a/forge-gui/res/cardsfolder/m/might_of_the_nephilim.txt
+++ b/forge-gui/res/cardsfolder/m/might_of_the_nephilim.txt
@@ -1,7 +1,7 @@
 Name:Might of the Nephilim
 ManaCost:1 G
 Types:Instant
-A:SP$ Pump | Cost$ 1 G | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | NumDef$ +X | SpellDescription$ Target creature gets +2/+2 until end of turn for each of its colors.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | NumDef$ +X | SpellDescription$ Target creature gets +2/+2 until end of turn for each of its colors.
 SVar:X:Targeted$CardNumColors/Times.2
 AI:RemoveDeck:All
 Oracle:Target creature gets +2/+2 until end of turn for each of its colors.

--- a/forge-gui/res/cardsfolder/m/mighty_leap.txt
+++ b/forge-gui/res/cardsfolder/m/mighty_leap.txt
@@ -1,5 +1,5 @@
 Name:Mighty Leap
 ManaCost:1 W
 Types:Instant
-A:SP$ Pump | Cost$ 1 W | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +2 | NumDef$ +2 | KW$ Flying | SpellDescription$ Target creature gets +2/+2 and gains flying until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +2 | NumDef$ +2 | KW$ Flying | SpellDescription$ Target creature gets +2/+2 and gains flying until end of turn.
 Oracle:Target creature gets +2/+2 and gains flying until end of turn.

--- a/forge-gui/res/cardsfolder/m/migration_path.txt
+++ b/forge-gui/res/cardsfolder/m/migration_path.txt
@@ -1,6 +1,6 @@
 Name:Migration Path
 ManaCost:3 G
 Types:Sorcery
-A:SP$ ChangeZone | Cost$ 3 G | Origin$ Library | Destination$ Battlefield | Tapped$ True | ChangeType$ Land.Basic | ChangeNum$ 2 | StackDescription$ SpellDescription | SpellDescription$ Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.
+A:SP$ ChangeZone | Origin$ Library | Destination$ Battlefield | Tapped$ True | ChangeType$ Land.Basic | ChangeNum$ 2 | StackDescription$ SpellDescription | SpellDescription$ Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.
 K:Cycling:2
 Oracle:Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.\nCycling {2} ({2}, Discard this card: Draw a card.)

--- a/forge-gui/res/cardsfolder/m/migratory_route.txt
+++ b/forge-gui/res/cardsfolder/m/migratory_route.txt
@@ -1,7 +1,7 @@
 Name:Migratory Route
 ManaCost:3 W U
 Types:Sorcery
-A:SP$ Token | Cost$ 3 W U | TokenAmount$ 4 | TokenScript$ w_1_1_bird_flying | TokenOwner$ You | SpellDescription$ Create four 1/1 white Bird creature tokens with flying.
+A:SP$ Token | TokenAmount$ 4 | TokenScript$ w_1_1_bird_flying | TokenOwner$ You | SpellDescription$ Create four 1/1 white Bird creature tokens with flying.
 K:TypeCycling:Basic:2
 DeckHas:Ability$Token
 Oracle:Create four 1/1 white Bird creature tokens with flying.\nBasic landcycling {2} ({2}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)

--- a/forge-gui/res/cardsfolder/m/mimeofacture.txt
+++ b/forge-gui/res/cardsfolder/m/mimeofacture.txt
@@ -2,6 +2,6 @@ Name:Mimeofacture
 ManaCost:3 U
 Types:Sorcery
 K:Replicate:3 U
-A:SP$ Pump | Cost$ 3 U | ValidTgts$ Permanent.OppCtrl | TgtPrompt$ Choose target permanent an opponent controls | IsCurse$ True | StackDescription$ None | SubAbility$ DBChangeZone | SpellDescription$ Choose target permanent an opponent controls. Search that player's library for a card with the same name and put it onto the battlefield under your control. Then that player shuffles.
+A:SP$ Pump | ValidTgts$ Permanent.OppCtrl | TgtPrompt$ Choose target permanent an opponent controls | IsCurse$ True | StackDescription$ None | SubAbility$ DBChangeZone | SpellDescription$ Choose target permanent an opponent controls. Search that player's library for a card with the same name and put it onto the battlefield under your control. Then that player shuffles.
 SVar:DBChangeZone:DB$ ChangeZone | Origin$ Library | Destination$ Battlefield | DefinedPlayer$ TargetedController | Chooser$ You | ChangeType$ Targeted.sameName | ChangeNum$ 1 | GainControl$ True | Shuffle$ True
 Oracle:Replicate {3}{U} (When you cast this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)\nChoose target permanent an opponent controls. Search that player's library for a card with the same name and put it onto the battlefield under your control. Then that player shuffles.

--- a/forge-gui/res/cardsfolder/m/miming_slime.txt
+++ b/forge-gui/res/cardsfolder/m/miming_slime.txt
@@ -1,7 +1,7 @@
 Name:Miming Slime
 ManaCost:2 G
 Types:Sorcery
-A:SP$ Token | Cost$ 2 G | TokenAmount$ 1 | TokenScript$ g_x_x_ooze | TokenOwner$ You | TokenPower$ X | TokenToughness$ X | SpellDescription$ Create an X/X green Ooze creature token, where X is the greatest power among creatures you control.
+A:SP$ Token | TokenAmount$ 1 | TokenScript$ g_x_x_ooze | TokenOwner$ You | TokenPower$ X | TokenToughness$ X | SpellDescription$ Create an X/X green Ooze creature token, where X is the greatest power among creatures you control.
 SVar:X:Count$Valid Creature.YouCtrl$GreatestPower
 SVar:NeedsToPlay:Creature.YouCtrl
 DeckHas:Ability$Token & Type$Ooze

--- a/forge-gui/res/cardsfolder/m/minamos_meddling.txt
+++ b/forge-gui/res/cardsfolder/m/minamos_meddling.txt
@@ -1,7 +1,7 @@
 Name:Minamo's Meddling
 ManaCost:2 U U
 Types:Instant
-A:SP$ Counter | Cost$ 2 U U | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | SubAbility$ DBDisCard | RememberSplicedOntoCounteredSpell$ True | SpellDescription$ Counter target spell. That spell's controller reveals their hand, then discards each card with the same name as a card spliced onto that spell.
+A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | SubAbility$ DBDisCard | RememberSplicedOntoCounteredSpell$ True | SpellDescription$ Counter target spell. That spell's controller reveals their hand, then discards each card with the same name as a card spliced onto that spell.
 SVar:DBDisCard:DB$ Discard | Defined$ TargetedController | DiscardValid$ Card.sharesNameWith Remembered | Mode$ RevealDiscardAll | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Counter target spell. That spell's controller reveals their hand, then discards each card with the same name as a card spliced onto that spell.

--- a/forge-gui/res/cardsfolder/m/mind_bend.txt
+++ b/forge-gui/res/cardsfolder/m/mind_bend.txt
@@ -1,7 +1,7 @@
 Name:Mind Bend
 ManaCost:U
 Types:Instant
-A:SP$ GenericChoice | Cost$ U | ValidTgts$ Permanent | TgtPrompt$ Choose target permanent | Choices$ ChangeColor,ChangeType | Defined$ You | SpellDescription$ Change the text of target permanent by replacing all instances of one color word with another or one basic land type with another. (For example, you may change "nonblack creature" to "nongreen creature" or "forestwalk" to "islandwalk." This effect lasts indefinitely.)
+A:SP$ GenericChoice | ValidTgts$ Permanent | TgtPrompt$ Choose target permanent | Choices$ ChangeColor,ChangeType | Defined$ You | SpellDescription$ Change the text of target permanent by replacing all instances of one color word with another or one basic land type with another. (For example, you may change "nonblack creature" to "nongreen creature" or "forestwalk" to "islandwalk." This effect lasts indefinitely.)
 SVar:ChangeColor:DB$ ChangeText | Defined$ ParentTarget | ChangeColorWord$ Choose Choose | Duration$ Permanent | SpellDescription$ Change color
 SVar:ChangeType:DB$ ChangeText | Defined$ ParentTarget | ChangeTypeWord$ ChooseBasicLandType ChooseBasicLandType | Duration$ Permanent | SpellDescription$ Change type
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/m/mind_bomb.txt
+++ b/forge-gui/res/cardsfolder/m/mind_bomb.txt
@@ -1,7 +1,7 @@
 Name:Mind Bomb
 ManaCost:U
 Types:Sorcery
-A:SP$ RepeatEach | Cost$ U | RepeatSubAbility$ DBChoose | RepeatPlayers$ Player | SpellDescription$ Each player may discard up to three cards. CARDNAME deals damage to each player equal to 3 minus the number of cards they discarded this way.
+A:SP$ RepeatEach | RepeatSubAbility$ DBChoose | RepeatPlayers$ Player | SpellDescription$ Each player may discard up to three cards. CARDNAME deals damage to each player equal to 3 minus the number of cards they discarded this way.
 SVar:DBChoose:DB$ ChooseNumber | Defined$ Player.IsRemembered | Min$ 0 | Max$ 3 | AILogic$ LoseLife | SubAbility$ DBDiscard
 SVar:DBDiscard:DB$ Discard | Defined$ Player.IsRemembered | NumCards$ X | Mode$ TgtChoose | RememberDiscarded$ True | SubAbility$ DBLoseLife
 SVar:DBLoseLife:DB$ LoseLife | Defined$ Player.IsRemembered | LifeAmount$ Z | SubAbility$ DBCleanup

--- a/forge-gui/res/cardsfolder/m/mind_burst.txt
+++ b/forge-gui/res/cardsfolder/m/mind_burst.txt
@@ -1,7 +1,7 @@
 Name:Mind Burst
 ManaCost:1 B
 Types:Sorcery
-A:SP$ Discard | Cost$ 1 B | ValidTgts$ Player | NumCards$ X | Mode$ TgtChoose | SpellDescription$ Target player discards X cards, where X is one plus the number of cards named Mind Burst in all graveyards.
+A:SP$ Discard | ValidTgts$ Player | NumCards$ X | Mode$ TgtChoose | SpellDescription$ Target player discards X cards, where X is one plus the number of cards named Mind Burst in all graveyards.
 SVar:X:Count$NamedInAllYards.Mind Burst/Plus.1
 DeckHints:Name$Mind Burst
 Oracle:Target player discards X cards, where X is one plus the number of cards named Mind Burst in all graveyards.

--- a/forge-gui/res/cardsfolder/m/mind_drain.txt
+++ b/forge-gui/res/cardsfolder/m/mind_drain.txt
@@ -1,7 +1,7 @@
 Name:Mind Drain
 ManaCost:2 B
 Types:Sorcery
-A:SP$ Discard | Cost$ 2 B | ValidTgts$ Opponent | NumCards$ 2 | Mode$ TgtChoose | SubAbility$ DBMill | SpellDescription$ Target opponent discards two cards, mills a card, and loses 1 life. You gain 1 life. (To mill a card, a player puts the top card of their library into their graveyard.)
+A:SP$ Discard | ValidTgts$ Opponent | NumCards$ 2 | Mode$ TgtChoose | SubAbility$ DBMill | SpellDescription$ Target opponent discards two cards, mills a card, and loses 1 life. You gain 1 life. (To mill a card, a player puts the top card of their library into their graveyard.)
 SVar:DBMill:DB$ Mill | Defined$ Targeted | NumCards$ 1 | SubAbility$ DBLoseLife
 SVar:DBLoseLife:DB$ LoseLife | Defined$ Targeted | LifeAmount$ 1 | SubAbility$ DBGainLife
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1

--- a/forge-gui/res/cardsfolder/m/mind_funeral.txt
+++ b/forge-gui/res/cardsfolder/m/mind_funeral.txt
@@ -1,5 +1,5 @@
 Name:Mind Funeral
 ManaCost:1 U B
 Types:Sorcery
-A:SP$ DigUntil | Cost$ 1 U B | ValidTgts$ Opponent | TgtPrompt$ Select target opponent | Amount$ 4 | Valid$ Land | ValidDescription$ land | RevealedDestination$ Graveyard | IsCurse$ True | SpellDescription$ Target opponent reveals cards from the top of their library until four land cards are revealed. That player puts all cards revealed this way into their graveyard.
+A:SP$ DigUntil | ValidTgts$ Opponent | TgtPrompt$ Select target opponent | Amount$ 4 | Valid$ Land | ValidDescription$ land | RevealedDestination$ Graveyard | IsCurse$ True | SpellDescription$ Target opponent reveals cards from the top of their library until four land cards are revealed. That player puts all cards revealed this way into their graveyard.
 Oracle:Target opponent reveals cards from the top of their library until four land cards are revealed. That player puts all cards revealed this way into their graveyard.

--- a/forge-gui/res/cardsfolder/m/mind_games.txt
+++ b/forge-gui/res/cardsfolder/m/mind_games.txt
@@ -1,7 +1,7 @@
 Name:Mind Games
 ManaCost:U
 Types:Instant
-A:SP$ Tap | Cost$ U | TgtPrompt$ Choose target artifact, creature or land | ValidTgts$ Artifact,Creature,Land | SpellDescription$ Tap target artifact, creature or land.
+A:SP$ Tap | TgtPrompt$ Choose target artifact, creature or land | ValidTgts$ Artifact,Creature,Land | SpellDescription$ Tap target artifact, creature or land.
 K:Buyback:2 U
 AI:RemoveDeck:All
 Oracle:Buyback {2}{U} (You may pay an additional {2}{U} as you cast this spell. If you do, put this card into your hand as it resolves.)\nTap target artifact, creature, or land.

--- a/forge-gui/res/cardsfolder/m/mind_grind.txt
+++ b/forge-gui/res/cardsfolder/m/mind_grind.txt
@@ -1,6 +1,6 @@
 Name:Mind Grind
 ManaCost:X U B
 Types:Sorcery
-A:SP$ DigUntil | Defined$ Player.Opponent | Amount$ X | Valid$ Land | ValidDescription$ land | RevealedDestination$ Graveyard | SpellDescription$ Each opponent reveals cards from the top of their library until they reveal X land cards, then puts all cards revealed this way into their graveyard. X can't be 0.
+A:SP$ DigUntil | Cost$ XMin1 X U B | Defined$ Player.Opponent | Amount$ X | Valid$ Land | ValidDescription$ land | RevealedDestination$ Graveyard | SpellDescription$ Each opponent reveals cards from the top of their library until they reveal X land cards, then puts all cards revealed this way into their graveyard. X can't be 0.
 SVar:X:Count$xPaid
 Oracle:Each opponent reveals cards from the top of their library until they reveal X land cards, then puts all cards revealed this way into their graveyard. X can't be 0.

--- a/forge-gui/res/cardsfolder/m/mind_grind.txt
+++ b/forge-gui/res/cardsfolder/m/mind_grind.txt
@@ -1,6 +1,6 @@
 Name:Mind Grind
 ManaCost:X U B
 Types:Sorcery
-A:SP$ DigUntil | Cost$ XMin1 X U B | Defined$ Player.Opponent | Amount$ X | Valid$ Land | ValidDescription$ land | RevealedDestination$ Graveyard | SpellDescription$ Each opponent reveals cards from the top of their library until they reveal X land cards, then puts all cards revealed this way into their graveyard. X can't be 0.
+A:SP$ DigUntil | Defined$ Player.Opponent | Amount$ X | Valid$ Land | ValidDescription$ land | RevealedDestination$ Graveyard | SpellDescription$ Each opponent reveals cards from the top of their library until they reveal X land cards, then puts all cards revealed this way into their graveyard. X can't be 0.
 SVar:X:Count$xPaid
 Oracle:Each opponent reveals cards from the top of their library until they reveal X land cards, then puts all cards revealed this way into their graveyard. X can't be 0.

--- a/forge-gui/res/cardsfolder/m/mind_knives.txt
+++ b/forge-gui/res/cardsfolder/m/mind_knives.txt
@@ -1,5 +1,5 @@
 Name:Mind Knives
 ManaCost:1 B
 Types:Sorcery
-A:SP$ Discard | Cost$ 1 B | ValidTgts$ Opponent | NumCards$ 1 | Mode$ Random | SpellDescription$ Target opponent discards a card at random.
+A:SP$ Discard | ValidTgts$ Opponent | NumCards$ 1 | Mode$ Random | SpellDescription$ Target opponent discards a card at random.
 Oracle:Target opponent discards a card at random.

--- a/forge-gui/res/cardsfolder/m/mind_peel.txt
+++ b/forge-gui/res/cardsfolder/m/mind_peel.txt
@@ -1,6 +1,6 @@
 Name:Mind Peel
 ManaCost:B
 Types:Sorcery
-A:SP$ Discard | Cost$ B | ValidTgts$ Player | NumCards$ 1 | Mode$ TgtChoose | SpellDescription$ Target player discards a card.
+A:SP$ Discard | ValidTgts$ Player | NumCards$ 1 | Mode$ TgtChoose | SpellDescription$ Target player discards a card.
 K:Buyback:2 B B
 Oracle:Buyback {2}{B}{B} (You may pay an additional {2}{B}{B} as you cast this spell. If you do, put this card into your hand as it resolves.)\nTarget player discards a card.

--- a/forge-gui/res/cardsfolder/m/mind_ravel.txt
+++ b/forge-gui/res/cardsfolder/m/mind_ravel.txt
@@ -1,7 +1,7 @@
 Name:Mind Ravel
 ManaCost:2 B
 Types:Sorcery
-A:SP$ Discard | Cost$ 2 B | ValidTgts$ Player | NumCards$ 1 | Mode$ TgtChoose | SubAbility$ DelTrigSlowtrip | SpellDescription$ Target player discards a card. Draw a card at the beginning of the next turn's upkeep.
+A:SP$ Discard | ValidTgts$ Player | NumCards$ 1 | Mode$ TgtChoose | SubAbility$ DelTrigSlowtrip | SpellDescription$ Target player discards a card. Draw a card at the beginning of the next turn's upkeep.
 SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
 SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
 Oracle:Target player discards a card.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/m/mind_rot.txt
+++ b/forge-gui/res/cardsfolder/m/mind_rot.txt
@@ -1,6 +1,6 @@
 Name:Mind Rot
 ManaCost:2 B
 Types:Sorcery
-A:SP$ Discard | Cost$ 2 B | ValidTgts$ Player | NumCards$ 2 | Mode$ TgtChoose | SpellDescription$ Target player discards two cards.
+A:SP$ Discard | ValidTgts$ Player | NumCards$ 2 | Mode$ TgtChoose | SpellDescription$ Target player discards two cards.
 DeckHas:Ability$Discard
 Oracle:Target player discards two cards.

--- a/forge-gui/res/cardsfolder/m/mind_sculpt.txt
+++ b/forge-gui/res/cardsfolder/m/mind_sculpt.txt
@@ -1,5 +1,5 @@
 Name:Mind Sculpt
 ManaCost:1 U
 Types:Sorcery
-A:SP$ Mill | Cost$ 1 U | NumCards$ 7 | ValidTgts$ Opponent | SpellDescription$ Target opponent mills seven cards.
+A:SP$ Mill | NumCards$ 7 | ValidTgts$ Opponent | SpellDescription$ Target opponent mills seven cards.
 Oracle:Target opponent mills seven cards.

--- a/forge-gui/res/cardsfolder/m/mind_shatter.txt
+++ b/forge-gui/res/cardsfolder/m/mind_shatter.txt
@@ -1,6 +1,6 @@
 Name:Mind Shatter
 ManaCost:X B B
 Types:Sorcery
-A:SP$ Discard | Cost$ X B B | ValidTgts$ Player | NumCards$ X | Mode$ Random | SpellDescription$ Target player discards X cards at random.
+A:SP$ Discard | ValidTgts$ Player | NumCards$ X | Mode$ Random | SpellDescription$ Target player discards X cards at random.
 SVar:X:Count$xPaid
 Oracle:Target player discards X cards at random.

--- a/forge-gui/res/cardsfolder/m/mind_sludge.txt
+++ b/forge-gui/res/cardsfolder/m/mind_sludge.txt
@@ -1,6 +1,6 @@
 Name:Mind Sludge
 ManaCost:4 B
 Types:Sorcery
-A:SP$ Discard | Cost$ 4 B | ValidTgts$ Player | NumCards$ X | Mode$ TgtChoose | SpellDescription$ Target player discards a card for each Swamp you control.
+A:SP$ Discard | ValidTgts$ Player | NumCards$ X | Mode$ TgtChoose | SpellDescription$ Target player discards a card for each Swamp you control.
 SVar:X:Count$TypeYouCtrl.Swamp
 Oracle:Target player discards a card for each Swamp you control.

--- a/forge-gui/res/cardsfolder/m/mind_spring.txt
+++ b/forge-gui/res/cardsfolder/m/mind_spring.txt
@@ -1,6 +1,6 @@
 Name:Mind Spring
 ManaCost:X U U
 Types:Sorcery
-A:SP$ Draw | Cost$ X U U | NumCards$ X | SpellDescription$ Draw X cards.
+A:SP$ Draw | NumCards$ X | SpellDescription$ Draw X cards.
 SVar:X:Count$xPaid
 Oracle:Draw X cards.

--- a/forge-gui/res/cardsfolder/m/mind_twist.txt
+++ b/forge-gui/res/cardsfolder/m/mind_twist.txt
@@ -1,7 +1,7 @@
 Name:Mind Twist
 ManaCost:X B
 Types:Sorcery
-A:SP$ Discard | Cost$ X B | ValidTgts$ Player | NumCards$ X | Mode$ Random | SpellDescription$ Target player discards X cards at random.
+A:SP$ Discard | ValidTgts$ Player | NumCards$ X | Mode$ Random | SpellDescription$ Target player discards X cards at random.
 SVar:X:Count$xPaid
 DeckHas:Ability$Discard
 Oracle:Target player discards X cards at random.

--- a/forge-gui/res/cardsfolder/m/mind_warp.txt
+++ b/forge-gui/res/cardsfolder/m/mind_warp.txt
@@ -1,6 +1,6 @@
 Name:Mind Warp
 ManaCost:X 3 B
 Types:Sorcery
-A:SP$ Discard | Cost$ X 3 B | ValidTgts$ Player | Mode$ LookYouChoose | NumCards$ X | SpellDescription$ Target player reveals their hand. You choose X cards from it. That player discards those cards.
+A:SP$ Discard | ValidTgts$ Player | Mode$ LookYouChoose | NumCards$ X | SpellDescription$ Target player reveals their hand. You choose X cards from it. That player discards those cards.
 SVar:X:Count$xPaid
 Oracle:Look at target player's hand and choose X cards from it. That player discards those cards.

--- a/forge-gui/res/cardsfolder/m/mindculling.txt
+++ b/forge-gui/res/cardsfolder/m/mindculling.txt
@@ -1,6 +1,6 @@
 Name:Mindculling
 ManaCost:5 U
 Types:Sorcery
-A:SP$ Discard | Cost$ 5 U | ValidTgts$ Opponent | NumCards$ 2 | Mode$ TgtChoose | SubAbility$ DBDraw | SpellDescription$ You draw two cards and target opponent discards two cards.
+A:SP$ Discard | ValidTgts$ Opponent | NumCards$ 2 | Mode$ TgtChoose | SubAbility$ DBDraw | SpellDescription$ You draw two cards and target opponent discards two cards.
 SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 2
 Oracle:You draw two cards and target opponent discards two cards.

--- a/forge-gui/res/cardsfolder/m/minds_aglow.txt
+++ b/forge-gui/res/cardsfolder/m/minds_aglow.txt
@@ -1,7 +1,7 @@
 Name:Minds Aglow
 ManaCost:U
 Types:Sorcery
-A:SP$ RepeatEach | Cost$ U | RepeatPlayers$ Player | StartingWithActivator$ True | RepeatSubAbility$ DBPay | SubAbility$ DBDraw | StackDescription$ SpellDescription | SpellDescription$ Join forces — Starting with you, each player may pay any amount of mana. Each player draws X cards, where X is the total amount of mana paid this way.
+A:SP$ RepeatEach | RepeatPlayers$ Player | StartingWithActivator$ True | RepeatSubAbility$ DBPay | SubAbility$ DBDraw | StackDescription$ SpellDescription | SpellDescription$ Join forces — Starting with you, each player may pay any amount of mana. Each player draws X cards, where X is the total amount of mana paid this way.
 SVar:DBPay:DB$ ChooseNumber | Defined$ Player.IsRemembered | ChooseAnyNumber$ True | ListTitle$ Pay Any Mana | SubAbility$ DBStore
 SVar:DBStore:DB$ StoreSVar | SVar$ JoinForcesAmount | Type$ CountSVar | Expression$ JoinForcesAmount/Plus.Y | UnlessCost$ Y | UnlessPayer$ Player.IsRemembered | UnlessSwitched$ True | UnlessAI$ OnlyOwn
 SVar:DBDraw:DB$ Draw | Defined$ Player | NumCards$ JoinForcesAmount | SubAbility$ DBReset | StackDescription$ None

--- a/forge-gui/res/cardsfolder/m/minds_desire.txt
+++ b/forge-gui/res/cardsfolder/m/minds_desire.txt
@@ -2,7 +2,7 @@ Name:Mind's Desire
 ManaCost:4 U U
 Types:Sorcery
 K:Storm
-A:SP$ Shuffle | Cost$ 4 U U | SubAbility$ DBExile | AILogic$ Always | SpellDescription$ Shuffle your library. Then exile the top card of your library. Until end of turn, you may play that card without paying its mana cost.
+A:SP$ Shuffle | SubAbility$ DBExile | AILogic$ Always | SpellDescription$ Shuffle your library. Then exile the top card of your library. Until end of turn, you may play that card without paying its mana cost.
 SVar:DBExile:DB$ ChangeZone | Defined$ TopOfLibrary | Origin$ Library | Destination$ Exile | RememberChanged$ True | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | RememberObjects$ Remembered | StaticAbilities$ Play | SubAbility$ DBCleanup | ExileOnMoved$ Exile
 SVar:Play:Mode$ Continuous | MayPlay$ True | MayPlayWithoutManaCost$ True | EffectZone$ Command | Affected$ Card.IsRemembered | AffectedZone$ Exile | Description$ You may play remembered card.

--- a/forge-gui/res/cardsfolder/m/mindstab.txt
+++ b/forge-gui/res/cardsfolder/m/mindstab.txt
@@ -1,6 +1,6 @@
 Name:Mindstab
 ManaCost:5 B
 Types:Sorcery
-A:SP$ Discard | Cost$ 5 B | ValidTgts$ Player | NumCards$ 3 | Mode$ TgtChoose | SpellDescription$ Target player discards three cards.
+A:SP$ Discard | ValidTgts$ Player | NumCards$ 3 | Mode$ TgtChoose | SpellDescription$ Target player discards three cards.
 K:Suspend:4:B
 Oracle:Target player discards three cards.\nSuspend 4—{B} (Rather than cast this card from your hand, you may pay {B} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)

--- a/forge-gui/res/cardsfolder/m/mindstatic.txt
+++ b/forge-gui/res/cardsfolder/m/mindstatic.txt
@@ -1,5 +1,5 @@
 Name:Mindstatic
 ManaCost:3 U
 Types:Instant
-A:SP$ Counter | Cost$ 3 U | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | UnlessCost$ 6 | SpellDescription$ Counter target spell unless its controller pays {6}.
+A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | UnlessCost$ 6 | SpellDescription$ Counter target spell unless its controller pays {6}.
 Oracle:Counter target spell unless its controller pays {6}.

--- a/forge-gui/res/cardsfolder/m/mindswipe.txt
+++ b/forge-gui/res/cardsfolder/m/mindswipe.txt
@@ -1,7 +1,7 @@
 Name:Mindswipe
 ManaCost:X U R
 Types:Instant
-A:SP$ Counter | Cost$ X U R | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | UnlessCost$ X | SubAbility$ DBBurn | SpellDescription$ Counter target spell unless its controller pays {X}. CARDNAME deals {X} damage to that spell's controller.
+A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | UnlessCost$ X | SubAbility$ DBBurn | SpellDescription$ Counter target spell unless its controller pays {X}. CARDNAME deals {X} damage to that spell's controller.
 SVar:DBBurn:DB$ DealDamage | NumDmg$ X | Defined$ TargetedController
 SVar:X:Count$xPaid
 Oracle:Counter target spell unless its controller pays {X}. Mindswipe deals X damage to that spell's controller.

--- a/forge-gui/res/cardsfolder/m/mine_excavation.txt
+++ b/forge-gui/res/cardsfolder/m/mine_excavation.txt
@@ -1,6 +1,6 @@
 Name:Mine Excavation
 ManaCost:1 W
 Types:Sorcery
-A:SP$ ChangeZone | Cost$ 1 W | ValidTgts$ Artifact,Enchantment | TgtPrompt$ Select target artifact or enchantment in a graveyard to return | Origin$ Graveyard | Destination$ Hand | SpellDescription$ Return target artifact or enchantment card from a graveyard to its owner's hand.
+A:SP$ ChangeZone | ValidTgts$ Artifact,Enchantment | TgtPrompt$ Select target artifact or enchantment in a graveyard to return | Origin$ Graveyard | Destination$ Hand | SpellDescription$ Return target artifact or enchantment card from a graveyard to its owner's hand.
 K:Conspire
 Oracle:Return target artifact or enchantment card from a graveyard to its owner's hand.\nConspire (As you cast this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)

--- a/forge-gui/res/cardsfolder/m/minions_murmurs.txt
+++ b/forge-gui/res/cardsfolder/m/minions_murmurs.txt
@@ -1,7 +1,7 @@
 Name:Minions' Murmurs
 ManaCost:2 B B
 Types:Sorcery
-A:SP$ Draw | Cost$ 2 B B | NumCards$ X | SpellDescription$ You draw X cards and you lose X life, where X is the number of creatures you control. | SubAbility$ DB1
+A:SP$ Draw | NumCards$ X | SpellDescription$ You draw X cards and you lose X life, where X is the number of creatures you control. | SubAbility$ DB1
 SVar:DB1:DB$ LoseLife | LifeAmount$ X
 SVar:X:Count$TypeYouCtrl.Creature
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/m/miraculous_recovery.txt
+++ b/forge-gui/res/cardsfolder/m/miraculous_recovery.txt
@@ -1,6 +1,6 @@
 Name:Miraculous Recovery
 ManaCost:4 W
 Types:Instant
-A:SP$ ChangeZone | Cost$ 4 W | Origin$ Graveyard | Destination$ Battlefield | TgtPrompt$ Choose target creature card in your graveyard | ValidTgts$ Creature.YouCtrl | SubAbility$ DBPutCounter | SpellDescription$ Return target creature card from your graveyard to the battlefield. Put a +1/+1 counter on it.
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | TgtPrompt$ Choose target creature card in your graveyard | ValidTgts$ Creature.YouCtrl | SubAbility$ DBPutCounter | SpellDescription$ Return target creature card from your graveyard to the battlefield. Put a +1/+1 counter on it.
 SVar:DBPutCounter:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ 1 | Defined$ Targeted
 Oracle:Return target creature card from your graveyard to the battlefield. Put a +1/+1 counter on it.

--- a/forge-gui/res/cardsfolder/m/mire_in_misery.txt
+++ b/forge-gui/res/cardsfolder/m/mire_in_misery.txt
@@ -1,5 +1,5 @@
 Name:Mire in Misery
 ManaCost:1 B
 Types:Sorcery
-A:SP$ Sacrifice | Cost$ 1 B | SacValid$ Creature,Enchantment | SacMessage$ Creature or Enchantment | Defined$ Player.Opponent | SpellDescription$ Each opponent sacrifices a creature or enchantment.
+A:SP$ Sacrifice | SacValid$ Creature,Enchantment | SacMessage$ Creature or Enchantment | Defined$ Player.Opponent | SpellDescription$ Each opponent sacrifices a creature or enchantment.
 Oracle:Each opponent sacrifices a creature or enchantment.

--- a/forge-gui/res/cardsfolder/m/mires_malice.txt
+++ b/forge-gui/res/cardsfolder/m/mires_malice.txt
@@ -1,6 +1,6 @@
 Name:Mire's Malice
 ManaCost:3 B
 Types:Sorcery
-A:SP$ Discard | Cost$ 3 B | ValidTgts$ Opponent | NumCards$ 2 | Mode$ TgtChoose | SpellDescription$ Target opponent discards two cards.
+A:SP$ Discard | ValidTgts$ Opponent | NumCards$ 2 | Mode$ TgtChoose | SpellDescription$ Target opponent discards two cards.
 K:Awaken:3:5 B
 Oracle:Target opponent discards two cards.\nAwaken 3—{5}{B} (If you cast this spell for {5}{B}, also put three +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)

--- a/forge-gui/res/cardsfolder/m/mires_toll.txt
+++ b/forge-gui/res/cardsfolder/m/mires_toll.txt
@@ -1,6 +1,6 @@
 Name:Mire's Toll
 ManaCost:B
 Types:Sorcery
-A:SP$ Discard | Cost$ B | ValidTgts$ Player | Mode$ RevealYouChoose | RevealNumber$ X | NumCards$ 1 | SpellDescription$ Target player reveals a number of cards from their hand equal to the number of Swamps you control. You choose one of them. That player discards that card.
+A:SP$ Discard | ValidTgts$ Player | Mode$ RevealYouChoose | RevealNumber$ X | NumCards$ 1 | SpellDescription$ Target player reveals a number of cards from their hand equal to the number of Swamps you control. You choose one of them. That player discards that card.
 SVar:X:Count$TypeYouCtrl.Swamp
 Oracle:Target player reveals a number of cards from their hand equal to the number of Swamps you control. You choose one of them. That player discards that card.

--- a/forge-gui/res/cardsfolder/m/mirran_mettle.txt
+++ b/forge-gui/res/cardsfolder/m/mirran_mettle.txt
@@ -1,6 +1,6 @@
 Name:Mirran Mettle
 ManaCost:G
 Types:Instant
-A:SP$ Pump | Cost$ G | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | NumDef$ +X | SpellDescription$ Target creature gets +2/+2 until end of turn. Metalcraft — That creature gets +4/+4 until end of turn instead if you control three or more artifacts.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | NumDef$ +X | SpellDescription$ Target creature gets +2/+2 until end of turn. Metalcraft — That creature gets +4/+4 until end of turn instead if you control three or more artifacts.
 SVar:X:Count$Metalcraft.4.2
 Oracle:Target creature gets +2/+2 until end of turn.\nMetalcraft — That creature gets +4/+4 until end of turn instead if you control three or more artifacts.

--- a/forge-gui/res/cardsfolder/m/mirror_match.txt
+++ b/forge-gui/res/cardsfolder/m/mirror_match.txt
@@ -1,7 +1,7 @@
 Name:Mirror Match
 ManaCost:4 U U
 Types:Instant
-A:SP$ RepeatEach | Cost$ 4 U U | RepeatCards$ Creature.attackingYouOrYourPW | UseImprinted$ True | RepeatSubAbility$ DBCloneAndBlock | SubAbility$ DelTrig | ActivationPhases$ Declare Blockers | ChangeZoneTable$ True | SpellDescription$ Cast this spell only during the declare blockers step. For each creature attacking you or a planeswalker you control, create a token that's a copy of that creature and that's blocking that creature. Exile those tokens at end of combat.
+A:SP$ RepeatEach | RepeatCards$ Creature.attackingYouOrYourPW | UseImprinted$ True | RepeatSubAbility$ DBCloneAndBlock | SubAbility$ DelTrig | ActivationPhases$ Declare Blockers | ChangeZoneTable$ True | SpellDescription$ Cast this spell only during the declare blockers step. For each creature attacking you or a planeswalker you control, create a token that's a copy of that creature and that's blocking that creature. Exile those tokens at end of combat.
 SVar:DBCloneAndBlock:DB$ CopyPermanent | Defined$ Imprinted | TokenBlocking$ Imprinted | RememberTokens$ True
 SVar:DelTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ EndCombat | Execute$ TrigExile | RememberObjects$ Remembered | TriggerDescription$ At end of combat, exile those tokens. | SubAbility$ DBCleanup
 SVar:TrigExile:DB$ ChangeZone | Defined$ DelayTriggerRememberedLKI | Origin$ Battlefield | Destination$ Exile

--- a/forge-gui/res/cardsfolder/m/miscalculation.txt
+++ b/forge-gui/res/cardsfolder/m/miscalculation.txt
@@ -1,6 +1,6 @@
 Name:Miscalculation
 ManaCost:1 U
 Types:Instant
-A:SP$ Counter | Cost$ 1 U | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | UnlessCost$ 2 | SpellDescription$ Counter target spell unless its controller pays {2}.
+A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | UnlessCost$ 2 | SpellDescription$ Counter target spell unless its controller pays {2}.
 K:Cycling:2
 Oracle:Counter target spell unless its controller pays {2}.\nCycling {2} ({2}, Discard this card: Draw a card.)

--- a/forge-gui/res/cardsfolder/m/miscast.txt
+++ b/forge-gui/res/cardsfolder/m/miscast.txt
@@ -1,5 +1,5 @@
 Name:Miscast
 ManaCost:U
 Types:Instant
-A:SP$ Counter | Cost$ U | TargetType$ Spell | ValidTgts$ Instant,Sorcery | UnlessCost$ 3 | TgtPrompt$ Select target instant or sorcery spell | SpellDescription$ Counter target instant or sorcery spell unless its controller pays {3}.
+A:SP$ Counter | TargetType$ Spell | ValidTgts$ Instant,Sorcery | UnlessCost$ 3 | TgtPrompt$ Select target instant or sorcery spell | SpellDescription$ Counter target instant or sorcery spell unless its controller pays {3}.
 Oracle:Counter target instant or sorcery spell unless its controller pays {3}.

--- a/forge-gui/res/cardsfolder/m/mischief_and_mayhem.txt
+++ b/forge-gui/res/cardsfolder/m/mischief_and_mayhem.txt
@@ -1,5 +1,5 @@
 Name:Mischief and Mayhem
 ManaCost:4 G
 Types:Sorcery
-A:SP$ Pump | Cost$ 4 G | TargetMin$ 0 | TargetMax$ 2 | NumAtt$ +4 | NumDef$ +4 | ValidTgts$ Creature | TgtPrompt$ Select target Creature | SpellDescription$ Up to two target creatures each get +4/+4 until end of turn.
+A:SP$ Pump | TargetMin$ 0 | TargetMax$ 2 | NumAtt$ +4 | NumDef$ +4 | ValidTgts$ Creature | TgtPrompt$ Select target Creature | SpellDescription$ Up to two target creatures each get +4/+4 until end of turn.
 Oracle:Up to two target creatures each get +4/+4 until end of turn.

--- a/forge-gui/res/cardsfolder/m/mise.txt
+++ b/forge-gui/res/cardsfolder/m/mise.txt
@@ -1,7 +1,7 @@
 Name:Mise
 ManaCost:U
 Types:Instant
-A:SP$ NameCard | Cost$ U | Defined$ You | ValidCards$ Card.nonLand | ValidDescription$ nonland | SubAbility$ DBReveal | SpellDescription$ Choose a nonland card name,
+A:SP$ NameCard | Defined$ You | ValidCards$ Card.nonLand | ValidDescription$ nonland | SubAbility$ DBReveal | SpellDescription$ Choose a nonland card name,
 SVar:DBReveal:DB$ PeekAndReveal | RememberRevealed$ True | SubAbility$ DBDraw | SpellDescription$ then reveal the top card of your library.
 SVar:DBDraw:DB$ Draw | NumCards$ 3 | ConditionDefined$ Remembered | ConditionPresent$ Card.NamedCard | ConditionCompare$ GE1 | SubAbility$ DBCleanup | SpellDescription$ If that card has the chosen name, you draw three cards.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/m/misery_charm.txt
+++ b/forge-gui/res/cardsfolder/m/misery_charm.txt
@@ -1,7 +1,7 @@
 Name:Misery Charm
 ManaCost:B
 Types:Instant
-A:SP$ Charm | Cost$ B | Choices$ DBDestroy,DBChangeZone,DBLoseLife | CharmNum$ 1
+A:SP$ Charm | Choices$ DBDestroy,DBChangeZone,DBLoseLife | CharmNum$ 1
 SVar:DBDestroy:DB$ Destroy | ValidTgts$ Creature.Cleric | TgtPrompt$ Select target cleric. | SpellDescription$ Destroy target Cleric.
 SVar:DBChangeZone:DB$ ChangeZone | ValidTgts$ Creature.Cleric | Origin$ Graveyard | Destination$ Hand | SpellDescription$ Return target Cleric card from your graveyard to your hand.
 SVar:DBLoseLife:DB$ LoseLife | ValidTgts$ Player | TgtPrompt$ Select a player to lose 2 life | LifeAmount$ 2 | SpellDescription$ Target player loses 2 life.

--- a/forge-gui/res/cardsfolder/m/misfortune.txt
+++ b/forge-gui/res/cardsfolder/m/misfortune.txt
@@ -1,7 +1,7 @@
 Name:Misfortune
 ManaCost:1 B R G
 Types:Sorcery
-A:SP$ Charm | Cost$ 1 B R G | Chooser$ Opponent | Choices$ Fortune,Misfortune
+A:SP$ Charm | Chooser$ Opponent | Choices$ Fortune,Misfortune
 SVar:Fortune:DB$ PutCounterAll | ValidCards$ Creature.YouCtrl | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBGainLife | SpellDescription$ Put a +1/+1 counter on each creature you control. You gain 4 life. | SubAbility$ DBGainLife
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ 4
 SVar:Misfortune:DB$ PutCounterAll | ValidCards$ Creature.ControlledBy ChoosingPlayer | CounterType$ M1M1 | CounterNum$ 1 | SubAbility$ DBLoseLife | SpellDescription$ You put a -1/-1 counter on each creature that player controls and CARDNAME deals 4 damage to that player. | SubAbility$ DBDamage

--- a/forge-gui/res/cardsfolder/m/misfortunes_gain.txt
+++ b/forge-gui/res/cardsfolder/m/misfortunes_gain.txt
@@ -1,6 +1,6 @@
 Name:Misfortune's Gain
 ManaCost:3 W
 Types:Sorcery
-A:SP$ Destroy | Cost$ 3 W | ValidTgts$ Creature | TgtPrompt$ Select target creature | SubAbility$ DBGainLife | SpellDescription$ Destroy target creature. Its owner gains 4 life.
+A:SP$ Destroy | ValidTgts$ Creature | TgtPrompt$ Select target creature | SubAbility$ DBGainLife | SpellDescription$ Destroy target creature. Its owner gains 4 life.
 SVar:DBGainLife:DB$ GainLife | Defined$ TargetedOwner | LifeAmount$ 4
 Oracle:Destroy target creature. Its owner gains 4 life.

--- a/forge-gui/res/cardsfolder/m/misguided_rage.txt
+++ b/forge-gui/res/cardsfolder/m/misguided_rage.txt
@@ -1,5 +1,5 @@
 Name:Misguided Rage
 ManaCost:2 R
 Types:Sorcery
-A:SP$ Sacrifice | Cost$ 2 R | ValidTgts$ Player | SacValid$ Permanent | SacMessage$ Permanent | SpellDescription$ Target player sacrifices a permanent.
+A:SP$ Sacrifice | ValidTgts$ Player | SacValid$ Permanent | SacMessage$ Permanent | SpellDescription$ Target player sacrifices a permanent.
 Oracle:Target player sacrifices a permanent.

--- a/forge-gui/res/cardsfolder/m/misinformation.txt
+++ b/forge-gui/res/cardsfolder/m/misinformation.txt
@@ -1,6 +1,6 @@
 Name:Misinformation
 ManaCost:B
 Types:Instant
-A:SP$ ChangeZone | Cost$ B | Origin$ Graveyard | Destination$ Library | LibraryPosition$ 0 | TgtPrompt$ Choose target card in opponent's graveyard | ValidTgts$ Card.OppOwn | TargetMin$ 0 | TargetMax$ 3 | Chooser$ You | SpellDescription$ Put up to three target cards from an opponent's graveyard on top of their library in any order.
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Library | LibraryPosition$ 0 | TgtPrompt$ Choose target card in opponent's graveyard | ValidTgts$ Card.OppOwn | TargetMin$ 0 | TargetMax$ 3 | Chooser$ You | SpellDescription$ Put up to three target cards from an opponent's graveyard on top of their library in any order.
 AI:RemoveDeck:All
 Oracle:Put up to three target cards from an opponent's graveyard on top of their library in any order.

--- a/forge-gui/res/cardsfolder/m/mission_briefing.txt
+++ b/forge-gui/res/cardsfolder/m/mission_briefing.txt
@@ -1,7 +1,7 @@
 Name:Mission Briefing
 ManaCost:U U
 Types:Instant
-A:SP$ Surveil | Cost$ U U | Amount$ 2 | SubAbility$ DBChooseCard | SpellDescription$ Surveil 2, then choose an instant or sorcery card in your graveyard. You may cast it this turn. If that spell would be put into your graveyard this turn, exile it instead. (To surveil 2, look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)
+A:SP$ Surveil | Amount$ 2 | SubAbility$ DBChooseCard | SpellDescription$ Surveil 2, then choose an instant or sorcery card in your graveyard. You may cast it this turn. If that spell would be put into your graveyard this turn, exile it instead. (To surveil 2, look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)
 SVar:DBChooseCard:DB$ ChooseCard | Choices$ Instant.YouCtrl,Sorcery.YouCtrl | ChoiceZone$ Graveyard | Mandatory$ True | SubAbility$ DBEffect | SpellDescription$ You may cast that card this turn. If that card would be put into your graveyard this turn, exile it instead.
 SVar:DBEffect:DB$ Effect | RememberObjects$ ChosenCard | StaticAbilities$ Play | ExileOnMoved$ Stack | ReplacementEffects$ ReplaceGraveyard
 SVar:Play:Mode$ Continuous | MayPlay$ True | EffectZone$ Command | Affected$ Card.IsRemembered | AffectedZone$ Graveyard | Description$ You may play remembered card.

--- a/forge-gui/res/cardsfolder/m/misstep.txt
+++ b/forge-gui/res/cardsfolder/m/misstep.txt
@@ -1,7 +1,7 @@
 Name:Misstep
 ManaCost:1 U
 Types:Sorcery
-A:SP$ Effect | Cost$ 1 U | ValidTgts$ Player | StaticAbilities$ DontUntap | Triggers$ RemoveEffect | Duration$ Permanent | RememberObjects$ Targeted | SpellDescription$ Creatures target player controls don't untap during that player's next untap step.
+A:SP$ Effect | ValidTgts$ Player | StaticAbilities$ DontUntap | Triggers$ RemoveEffect | Duration$ Permanent | RememberObjects$ Targeted | SpellDescription$ Creatures target player controls don't untap during that player's next untap step.
 SVar:DontUntap:Mode$ Continuous | EffectZone$ Command | AffectedZone$ Battlefield | Affected$ Creature.RememberedPlayerCtrl | AddHiddenKeyword$ This card doesn't untap during your next untap step. | Description$ Creatures target player controls don't untap during their next untap step.
 SVar:RemoveEffect:Mode$ Phase | Phase$ Untap | ValidPlayer$ Player.IsRemembered | TriggerZones$ Command | Static$ True | Execute$ ExileEffect
 SVar:ExileEffect:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile

--- a/forge-gui/res/cardsfolder/m/mitotic_manipulation.txt
+++ b/forge-gui/res/cardsfolder/m/mitotic_manipulation.txt
@@ -1,6 +1,6 @@
 Name:Mitotic Manipulation
 ManaCost:1 U U
 Types:Sorcery
-A:SP$ Dig | Cost$ 1 U U | DigNum$ 7 | ChangeValid$ Permanent.sharesNameWith Battlefield | ChangeNum$ 1 | Optional$ True | DestinationZone$ Battlefield | SpellDescription$ Look at the top seven cards of your library. You may put one of those cards onto the battlefield if it has the same name as a permanent. Put the rest on the bottom of your library in any order.
+A:SP$ Dig | DigNum$ 7 | ChangeValid$ Permanent.sharesNameWith Battlefield | ChangeNum$ 1 | Optional$ True | DestinationZone$ Battlefield | SpellDescription$ Look at the top seven cards of your library. You may put one of those cards onto the battlefield if it has the same name as a permanent. Put the rest on the bottom of your library in any order.
 AI:RemoveDeck:All
 Oracle:Look at the top seven cards of your library. You may put one of those cards onto the battlefield if it has the same name as a permanent. Put the rest on the bottom of your library in any order.

--- a/forge-gui/res/cardsfolder/m/mnemonic_betrayal.txt
+++ b/forge-gui/res/cardsfolder/m/mnemonic_betrayal.txt
@@ -1,7 +1,7 @@
 Name:Mnemonic Betrayal
 ManaCost:1 U B
 Types:Sorcery
-A:SP$ ChangeZoneAll | Cost$ 1 U B | Defined$ Player.Opponent | Origin$ Graveyard | Destination$ Exile | ChangeType$ Card | RememberChanged$ True | SubAbility$ DBEffect | SpellDescription$ Exile all card from all opponents' graveyards. You may cast those cards this turn, and you may spend it as though it were mana of any type to cast those spells. At the beginning of the next end step, if any of those cards remain exiled, return them to their owner's graveyards. Exile CARDNAME.
+A:SP$ ChangeZoneAll | Defined$ Player.Opponent | Origin$ Graveyard | Destination$ Exile | ChangeType$ Card | RememberChanged$ True | SubAbility$ DBEffect | SpellDescription$ Exile all card from all opponents' graveyards. You may cast those cards this turn, and you may spend it as though it were mana of any type to cast those spells. At the beginning of the next end step, if any of those cards remain exiled, return them to their owner's graveyards. Exile CARDNAME.
 SVar:DBEffect:DB$ Effect | Duration$ Permanent | StaticAbilities$ STPlay | RememberObjects$ Remembered | ForgetOnMoved$ Exile | SubAbility$ DelTrig
 SVar:STPlay:Mode$ Continuous | MayPlay$ True | MayPlayIgnoreType$ True | EffectZone$ Command | Affected$ Card.nonLand+IsRemembered | AffectedZone$ Exile | Description$ You may cast those cards this turn, and you may spend mana as though it were mana of any type to cast those spells.
 SVar:DelTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ TrigReturn | RememberObjects$ RememberedLKI | TriggerDescription$ At the beginning of the next end step, if any of those cards remain exiled, return them to their owner's graveyards. | SubAbility$ ExileSelf

--- a/forge-gui/res/cardsfolder/m/mnemonic_deluge.txt
+++ b/forge-gui/res/cardsfolder/m/mnemonic_deluge.txt
@@ -1,7 +1,7 @@
 Name:Mnemonic Deluge
 ManaCost:6 U U U
 Types:Sorcery
-A:SP$ ChangeZone | Cost$ 6 U U U | ValidTgts$ Instant,Sorcery | TgtPrompt$ Select target instant or sorcery card in a graveyard | Origin$ Graveyard | Destination$ Exile | RememberChanged$ True | SubAbility$ DBPlay | SpellDescription$ Exile target instant or sorcery card from a graveyard. Copy that card three times. You may cast the copies without paying their mana costs. Exile CARDNAME.
+A:SP$ ChangeZone | ValidTgts$ Instant,Sorcery | TgtPrompt$ Select target instant or sorcery card in a graveyard | Origin$ Graveyard | Destination$ Exile | RememberChanged$ True | SubAbility$ DBPlay | SpellDescription$ Exile target instant or sorcery card from a graveyard. Copy that card three times. You may cast the copies without paying their mana costs. Exile CARDNAME.
 SVar:DBPlay:DB$ Play | Defined$ Remembered | CopyCard$ True | Amount$ 3 | AllowRepeats$ True | Controller$ You | Optional$ True | WithoutManaCost$ True | ValidSA$ Spell | SubAbility$ DBExile | StackDescription$ Copy it three times. {p:You} may cast the copies without paying their mana cost.
 SVar:DBExile:DB$ ChangeZone | Defined$ Self | Origin$ Stack | Destination$ Exile | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/m/mnemonic_nexus.txt
+++ b/forge-gui/res/cardsfolder/m/mnemonic_nexus.txt
@@ -1,6 +1,6 @@
 Name:Mnemonic Nexus
 ManaCost:3 U
 Types:Instant
-A:SP$ ChangeZoneAll | Cost$ 3 U | Defined$ Player | ChangeType$ Card | Origin$ Graveyard | Destination$ Library | Shuffle$ True | SpellDescription$ Each player shuffles their graveyard into their library.
+A:SP$ ChangeZoneAll | Defined$ Player | ChangeType$ Card | Origin$ Graveyard | Destination$ Library | Shuffle$ True | SpellDescription$ Each player shuffles their graveyard into their library.
 AI:RemoveDeck:All
 Oracle:Each player shuffles their graveyard into their library.

--- a/forge-gui/res/cardsfolder/m/moan_of_the_unhallowed.txt
+++ b/forge-gui/res/cardsfolder/m/moan_of_the_unhallowed.txt
@@ -2,5 +2,5 @@ Name:Moan of the Unhallowed
 ManaCost:2 B B
 Types:Sorcery
 K:Flashback:5 B B
-A:SP$ Token | Cost$ 2 B B | TokenAmount$ 2 | TokenScript$ b_2_2_zombie | TokenOwner$ You | SpellDescription$ Create two 2/2 black Zombie creature tokens.
+A:SP$ Token | TokenAmount$ 2 | TokenScript$ b_2_2_zombie | TokenOwner$ You | SpellDescription$ Create two 2/2 black Zombie creature tokens.
 Oracle:Create two 2/2 black Zombie creature tokens.\nFlashback {5}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)

--- a/forge-gui/res/cardsfolder/m/mob.txt
+++ b/forge-gui/res/cardsfolder/m/mob.txt
@@ -2,5 +2,5 @@ Name:Mob
 ManaCost:4 B
 Types:Instant
 K:Convoke
-A:SP$ Destroy | Cost$ 4 B | ValidTgts$ Creature | TgtPrompt$ Select target creature | SpellDescription$ Destroy target creature.
+A:SP$ Destroy | ValidTgts$ Creature | TgtPrompt$ Select target creature | SpellDescription$ Destroy target creature.
 Oracle:Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDestroy target creature.

--- a/forge-gui/res/cardsfolder/m/mob_justice.txt
+++ b/forge-gui/res/cardsfolder/m/mob_justice.txt
@@ -1,6 +1,6 @@
 Name:Mob Justice
 ManaCost:1 R
 Types:Sorcery
-A:SP$ DealDamage | Cost$ 1 R | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | NumDmg$ X | SpellDescription$ CARDNAME deals damage to target player or planeswalker equal to the number of creatures you control.
+A:SP$ DealDamage | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | NumDmg$ X | SpellDescription$ CARDNAME deals damage to target player or planeswalker equal to the number of creatures you control.
 SVar:X:Count$TypeYouCtrl.Creature
 Oracle:Mob Justice deals damage to target player or planeswalker equal to the number of creatures you control.

--- a/forge-gui/res/cardsfolder/m/mob_rule.txt
+++ b/forge-gui/res/cardsfolder/m/mob_rule.txt
@@ -1,7 +1,7 @@
 Name:Mob Rule
 ManaCost:4 R R
 Types:Sorcery
-A:SP$ Charm | Cost$ 4 R R | Choices$ DBBig,DBSmall
+A:SP$ Charm | Choices$ DBBig,DBSmall
 SVar:DBBig:DB$ GainControl | AllValid$ Creature.powerGE4 | Untap$ True | AddKWs$ Haste | LoseControl$ EOT | SpellDescription$ Gain control of all creatures with power 4 or greater until end of turn. Untap them. They gain haste until end of turn.
 SVar:DBSmall:DB$ GainControl | AllValid$ Creature.powerLE3 | Untap$ True | AddKWs$ Haste | LoseControl$ EOT | SpellDescription$ Gain control of all creatures with power 3 or less until end of turn. Untap them. They gain haste until end of turn.
 Oracle:Choose one —\n• Gain control of all creatures with power 4 or greater until end of turn. Untap those creatures. They gain haste until end of turn.\n• Gain control of all creatures with power 3 or less until end of turn. Untap those creatures. They gain haste until end of turn.

--- a/forge-gui/res/cardsfolder/m/mobilize.txt
+++ b/forge-gui/res/cardsfolder/m/mobilize.txt
@@ -1,5 +1,5 @@
 Name:Mobilize
 ManaCost:G
 Types:Sorcery
-A:SP$ UntapAll | Cost$ G | ValidCards$ Creature.YouCtrl | SpellDescription$ Untap all creatures you control.
+A:SP$ UntapAll | ValidCards$ Creature.YouCtrl | SpellDescription$ Untap all creatures you control.
 Oracle:Untap all creatures you control.

--- a/forge-gui/res/cardsfolder/m/mogg_infestation.txt
+++ b/forge-gui/res/cardsfolder/m/mogg_infestation.txt
@@ -1,7 +1,7 @@
 Name:Mogg Infestation
 ManaCost:3 R R
 Types:Sorcery
-A:SP$ DestroyAll | Cost$ 3 R R | ValidTgts$ Player | TgtPrompt$ Select target player | ValidCards$ Creature | ValidDescription$ all creatures targeted player controls | RememberDestroyed$ True | SubAbility$ DBTokenInfestation | SpellDescription$ Destroy all creatures target player controls. For each creature that died this way, that player creates two 1/1 red Goblin creature tokens.
+A:SP$ DestroyAll | ValidTgts$ Player | TgtPrompt$ Select target player | ValidCards$ Creature | ValidDescription$ all creatures targeted player controls | RememberDestroyed$ True | SubAbility$ DBTokenInfestation | SpellDescription$ Destroy all creatures target player controls. For each creature that died this way, that player creates two 1/1 red Goblin creature tokens.
 SVar:DBTokenInfestation:DB$ Token | TokenAmount$ X | TokenScript$ r_1_1_goblin | TokenOwner$ Targeted
 SVar:X:Remembered$Amount/Twice
 Oracle:Destroy all creatures target player controls. For each creature that died this way, that player creates two 1/1 red Goblin creature tokens.

--- a/forge-gui/res/cardsfolder/m/molder.txt
+++ b/forge-gui/res/cardsfolder/m/molder.txt
@@ -1,7 +1,7 @@
 Name:Molder
 ManaCost:X G
 Types:Instant
-A:SP$ Destroy | Cost$ X G | ValidTgts$ Artifact.cmcEQX,Enchantment.cmcEQX | TgtPrompt$ Select target artifact or enchantment | NoRegen$ True | SubAbility$ DBGainLife | SpellDescription$ Destroy target artifact or enchantment with mana value X. It can't be regenerated. You gain X life.
+A:SP$ Destroy | ValidTgts$ Artifact.cmcEQX,Enchantment.cmcEQX | TgtPrompt$ Select target artifact or enchantment | NoRegen$ True | SubAbility$ DBGainLife | SpellDescription$ Destroy target artifact or enchantment with mana value X. It can't be regenerated. You gain X life.
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ X
 SVar:X:Count$xPaid
 Oracle:Destroy target artifact or enchantment with mana value X. It can't be regenerated. You gain X life.

--- a/forge-gui/res/cardsfolder/m/molten_birth.txt
+++ b/forge-gui/res/cardsfolder/m/molten_birth.txt
@@ -1,7 +1,7 @@
 Name:Molten Birth
 ManaCost:1 R R
 Types:Sorcery
-A:SP$ Token | Cost$ 1 R R | TokenAmount$ 2 | TokenScript$ r_1_1_elemental | SubAbility$ MoltenFlip | SpellDescription$ Create two 1/1 red Elemental creature tokens, then flip a coin. If you win the flip, return CARDNAME to its owner's hand.
+A:SP$ Token | TokenAmount$ 2 | TokenScript$ r_1_1_elemental | SubAbility$ MoltenFlip | SpellDescription$ Create two 1/1 red Elemental creature tokens, then flip a coin. If you win the flip, return CARDNAME to its owner's hand.
 SVar:MoltenFlip:DB$ FlipACoin | WinSubAbility$ DBReturn
 SVar:DBReturn:DB$ ChangeZone | Origin$ Stack | Destination$ Hand | Defined$ Parent
 Oracle:Create two 1/1 red Elemental creature tokens, then flip a coin. If you win the flip, return Molten Birth to its owner's hand.

--- a/forge-gui/res/cardsfolder/m/molten_blast.txt
+++ b/forge-gui/res/cardsfolder/m/molten_blast.txt
@@ -1,7 +1,7 @@
 Name:Molten Blast
 ManaCost:2 R
 Types:Instant
-A:SP$ Charm | Cost$ 2 R | CharmNum$ 1 | Choices$ Shock,DestroyArtifact
+A:SP$ Charm | CharmNum$ 1 | Choices$ Shock,DestroyArtifact
 SVar:Shock:DB$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to target creature or planeswalker.
 SVar:DestroyArtifact:DB$ Destroy | ValidTgts$ Artifact | TgtPrompt$ Select target artifact | SpellDescription$ Destroy target artifact.
 Oracle:Choose one —\n• Molten Blast deals 2 damage to target creature or planeswalker.\n• Destroy target artifact.

--- a/forge-gui/res/cardsfolder/m/molten_disaster.txt
+++ b/forge-gui/res/cardsfolder/m/molten_disaster.txt
@@ -3,6 +3,6 @@ ManaCost:X R R
 Types:Sorcery
 K:Kicker:R
 S:Mode$ Continuous | EffectZone$ All | IsPresent$ Card.Self+kicked | PresentZone$ Stack | CharacteristicDefining$ True | AddKeyword$ Split second | Description$ If this spell was kicked, it has split second. (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)
-A:SP$ DamageAll | Cost$ X R R | ValidCards$ Creature.withoutFlying | ValidPlayers$ Player | NumDmg$ X | StackDescription$ SpellDescription | SpellDescription$ CARDNAME deals X damage to each creature without flying and each player.
+A:SP$ DamageAll | ValidCards$ Creature.withoutFlying | ValidPlayers$ Player | NumDmg$ X | StackDescription$ SpellDescription | SpellDescription$ CARDNAME deals X damage to each creature without flying and each player.
 SVar:X:Count$xPaid
 Oracle:Kicker {R} (You may pay an additional {R} as you cast this spell.)\nIf this spell was kicked, it has split second. (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nMolten Disaster deals X damage to each creature without flying and each player.

--- a/forge-gui/res/cardsfolder/m/molten_frame.txt
+++ b/forge-gui/res/cardsfolder/m/molten_frame.txt
@@ -1,6 +1,6 @@
 Name:Molten Frame
 ManaCost:1 R
 Types:Instant
-A:SP$ Destroy | Cost$ 1 R | ValidTgts$ Creature.Artifact | TgtPrompt$ Select target artifact creature | SpellDescription$ Destroy target artifact creature.
+A:SP$ Destroy | ValidTgts$ Creature.Artifact | TgtPrompt$ Select target artifact creature | SpellDescription$ Destroy target artifact creature.
 K:Cycling:2
 Oracle:Destroy target artifact creature.\nCycling {2} ({2}, Discard this card: Draw a card.)

--- a/forge-gui/res/cardsfolder/m/molten_psyche.txt
+++ b/forge-gui/res/cardsfolder/m/molten_psyche.txt
@@ -1,7 +1,7 @@
 Name:Molten Psyche
 ManaCost:1 R R
 Types:Sorcery
-A:SP$ RepeatEach | Cost$ 1 R R | RepeatPlayers$ Player | RepeatSubAbility$ ShuffleHand | SpellDescription$ Each player shuffles the cards from their hand into their library, then draws that many cards. Metalcraft — If you control three or more artifacts, CARDNAME deals damage to each opponent equal to the number of cards that player has drawn this turn.
+A:SP$ RepeatEach | RepeatPlayers$ Player | RepeatSubAbility$ ShuffleHand | SpellDescription$ Each player shuffles the cards from their hand into their library, then draws that many cards. Metalcraft — If you control three or more artifacts, CARDNAME deals damage to each opponent equal to the number of cards that player has drawn this turn.
 SVar:ShuffleHand:DB$ ChangeZoneAll | Defined$ Player.IsRemembered | Origin$ Hand | Destination$ Library | LibraryPosition$ -1 | RememberChanged$ True | Shuffle$ True | SubAbility$ PsychoDraw
 SVar:PsychoDraw:DB$ Draw | NumCards$ X | Defined$ Player.IsRemembered | SubAbility$ MindFlame
 SVar:MindFlame:DB$ DealDamage | Defined$ Player.Opponent+IsRemembered | NumDmg$ Y | ConditionPresent$ Artifact.YouCtrl | ConditionCompare$ GE3 | StackDescription$ None | SubAbility$ DBCleanup

--- a/forge-gui/res/cardsfolder/m/molten_rain.txt
+++ b/forge-gui/res/cardsfolder/m/molten_rain.txt
@@ -1,6 +1,6 @@
 Name:Molten Rain
 ManaCost:1 R R
 Types:Sorcery
-A:SP$ Destroy | Cost$ 1 R R | ValidTgts$ Land | TgtPrompt$ Select target land | SubAbility$ DBDamage | SpellDescription$ Destroy target land. If that land was nonbasic, CARDNAME deals 2 damage to the land's controller.
+A:SP$ Destroy | ValidTgts$ Land | TgtPrompt$ Select target land | SubAbility$ DBDamage | SpellDescription$ Destroy target land. If that land was nonbasic, CARDNAME deals 2 damage to the land's controller.
 SVar:DBDamage:DB$ DealDamage | Defined$ TargetedController | NumDmg$ 2 | ConditionDefined$ Targeted | ConditionPresent$ Land.Basic | ConditionCompare$ EQ0 | ConditionDescription$ If that land is nonbasic,
 Oracle:Destroy target land. If that land was nonbasic, Molten Rain deals 2 damage to the land's controller.

--- a/forge-gui/res/cardsfolder/m/moment_of_craving.txt
+++ b/forge-gui/res/cardsfolder/m/moment_of_craving.txt
@@ -1,6 +1,6 @@
 Name:Moment of Craving
 ManaCost:1 B
 Types:Instant
-A:SP$ Pump | Cost$ 1 B | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ -2 | NumDef$ -2 | IsCurse$ True | SubAbility$ DBGainLife | SpellDescription$ Target creature gets -2/-2 until end of turn. You gain 2 life.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ -2 | NumDef$ -2 | IsCurse$ True | SubAbility$ DBGainLife | SpellDescription$ Target creature gets -2/-2 until end of turn. You gain 2 life.
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 2
 Oracle:Target creature gets -2/-2 until end of turn. You gain 2 life.

--- a/forge-gui/res/cardsfolder/m/moment_of_heroism.txt
+++ b/forge-gui/res/cardsfolder/m/moment_of_heroism.txt
@@ -1,6 +1,6 @@
 Name:Moment of Heroism
 ManaCost:1 W
 Types:Instant
-A:SP$ Pump | Cost$ 1 W | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +2 | NumDef$ +2 | KW$ Lifelink | SpellDescription$ Target creature gets +2/+2 and gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +2 | NumDef$ +2 | KW$ Lifelink | SpellDescription$ Target creature gets +2/+2 and gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)
 DeckHas:Ability$LifeGain
 Oracle:Target creature gets +2/+2 and gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)

--- a/forge-gui/res/cardsfolder/m/moment_of_silence.txt
+++ b/forge-gui/res/cardsfolder/m/moment_of_silence.txt
@@ -1,6 +1,6 @@
 Name:Moment of Silence
 ManaCost:W
 Types:Instant
-A:SP$ SkipPhase | Cost$ W | ValidTgts$ Player | TgtPrompt$ Select target player | Phase$ Combat | Duration$ NextThisTurn | SpellDescription$ Target player skips their next combat phase this turn.
+A:SP$ SkipPhase | ValidTgts$ Player | TgtPrompt$ Select target player | Phase$ Combat | Duration$ NextThisTurn | SpellDescription$ Target player skips their next combat phase this turn.
 AI:RemoveDeck:All
 Oracle:Target player skips their next combat phase this turn.

--- a/forge-gui/res/cardsfolder/m/moment_of_triumph.txt
+++ b/forge-gui/res/cardsfolder/m/moment_of_triumph.txt
@@ -1,6 +1,6 @@
 Name:Moment of Triumph
 ManaCost:W
 Types:Instant
-A:SP$ Pump | Cost$ W | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ 2 | NumDef$ 2 | SubAbility$ DBGainLife | SpellDescription$ Target creature gets +2/+2 until end of turn. You gain 2 life.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ 2 | NumDef$ 2 | SubAbility$ DBGainLife | SpellDescription$ Target creature gets +2/+2 until end of turn. You gain 2 life.
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 2
 Oracle:Target creature gets +2/+2 until end of turn. You gain 2 life.

--- a/forge-gui/res/cardsfolder/m/moment_of_truth.txt
+++ b/forge-gui/res/cardsfolder/m/moment_of_truth.txt
@@ -1,7 +1,7 @@
 Name:Moment of Truth
 ManaCost:1 U
 Types:Instant
-A:SP$ Dig | Cost$ 1 U | DigNum$ 3 | ChangeNum$ 1 | LibraryPosition2$ 0 | SkipReorder$ True | SubAbility$ DBDig | NoLooking$ True | SpellDescription$ Look at the top three cards of your library. Put one of those cards into your hand, one into your graveyard, and one on the bottom of your library. | StackDescription$ SpellDescription
+A:SP$ Dig | DigNum$ 3 | ChangeNum$ 1 | LibraryPosition2$ 0 | SkipReorder$ True | SubAbility$ DBDig | NoLooking$ True | SpellDescription$ Look at the top three cards of your library. Put one of those cards into your hand, one into your graveyard, and one on the bottom of your library. | StackDescription$ SpellDescription
 SVar:DBDig:DB$ Dig | DigNum$ 2 | ChangeNum$ 1 | DestinationZone$ Graveyard | NoLooking$ True | StackDescription$ None
 DeckHints:Ability$Graveyard
 Oracle:Look at the top three cards of your library. Put one of those cards into your hand, one into your graveyard, and one on the bottom of your library.

--- a/forge-gui/res/cardsfolder/m/momentary_blink.txt
+++ b/forge-gui/res/cardsfolder/m/momentary_blink.txt
@@ -2,7 +2,7 @@ Name:Momentary Blink
 ManaCost:1 W
 Types:Instant
 K:Flashback:3 U
-A:SP$ ChangeZone | Cost$ 1 W | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control. | SubAbility$ DBReturn | RememberTargets$ True | SpellDescription$ Exile target creature you control, then return it to the battlefield under its owner's control.
+A:SP$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control. | SubAbility$ DBReturn | RememberTargets$ True | SpellDescription$ Exile target creature you control, then return it to the battlefield under its owner's control.
 SVar:DBReturn:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Battlefield | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Exile target creature you control, then return it to the battlefield under its owner's control.\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)

--- a/forge-gui/res/cardsfolder/m/moments_peace.txt
+++ b/forge-gui/res/cardsfolder/m/moments_peace.txt
@@ -2,5 +2,5 @@ Name:Moment's Peace
 ManaCost:1 G
 Types:Instant
 K:Flashback:2 G
-A:SP$ Fog | Cost$ 1 G | SpellDescription$ Prevent all combat damage that would be dealt this turn.
+A:SP$ Fog | SpellDescription$ Prevent all combat damage that would be dealt this turn.
 Oracle:Prevent all combat damage that would be dealt this turn.\nFlashback {2}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)

--- a/forge-gui/res/cardsfolder/m/monomania.txt
+++ b/forge-gui/res/cardsfolder/m/monomania.txt
@@ -1,7 +1,7 @@
 Name:Monomania
 ManaCost:3 B B
 Types:Sorcery
-A:SP$ ChooseCard | Cost$ 3 B B | ValidTgts$ Player | Mandatory$ True | Choices$ Card | SubAbility$ DBDiscard | RememberChosen$ True | AILogic$ AtLeast2 | TargetControls$ True | ChoiceZone$ Hand | SpellDescription$ Target player chooses a card in their hand and discards the rest.
+A:SP$ ChooseCard | ValidTgts$ Player | Mandatory$ True | Choices$ Card | SubAbility$ DBDiscard | RememberChosen$ True | AILogic$ AtLeast2 | TargetControls$ True | ChoiceZone$ Hand | SpellDescription$ Target player chooses a card in their hand and discards the rest.
 SVar:DBDiscard:DB$ Discard | Defined$ Targeted | Mode$ NotRemembered | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Target player chooses a card in their hand and discards the rest.

--- a/forge-gui/res/cardsfolder/m/monstrify.txt
+++ b/forge-gui/res/cardsfolder/m/monstrify.txt
@@ -2,5 +2,5 @@ Name:Monstrify
 ManaCost:3 G
 Types:Sorcery
 K:Retrace
-A:SP$ Pump | Cost$ 3 G | ValidTgts$ Creature | NumAtt$ +4 | NumDef$ +4 | SpellDescription$ Target creature gets +4/+4 until end of turn. | TgtPrompt$ Select target creature.
+A:SP$ Pump | ValidTgts$ Creature | NumAtt$ +4 | NumDef$ +4 | SpellDescription$ Target creature gets +4/+4 until end of turn. | TgtPrompt$ Select target creature.
 Oracle:Target creature gets +4/+4 until end of turn.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)

--- a/forge-gui/res/cardsfolder/m/monstrous_growth.txt
+++ b/forge-gui/res/cardsfolder/m/monstrous_growth.txt
@@ -1,5 +1,5 @@
 Name:Monstrous Growth
 ManaCost:1 G
 Types:Sorcery
-A:SP$ Pump | Cost$ 1 G | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +4 | NumDef$ +4 | SpellDescription$ Target creature gets +4/+4 until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +4 | NumDef$ +4 | SpellDescription$ Target creature gets +4/+4 until end of turn.
 Oracle:Target creature gets +4/+4 until end of turn.

--- a/forge-gui/res/cardsfolder/m/monstrous_onslaught.txt
+++ b/forge-gui/res/cardsfolder/m/monstrous_onslaught.txt
@@ -1,6 +1,6 @@
 Name:Monstrous Onslaught
 ManaCost:3 G G
 Types:Sorcery
-A:SP$ DealDamage | Cost$ 3 G G | ValidTgts$ Creature | TgtPrompt$ Select target creatures to distribute damage to | NumDmg$ OrigPower | TargetMin$ 0 | TargetMax$ OrigPower | DividedAsYouChoose$ OrigPower | SpellDescription$ CARDNAME deals X damage divided as you choose among any number of target creatures, where X is the greatest power among creatures you control as you cast this spell.
+A:SP$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creatures to distribute damage to | NumDmg$ OrigPower | TargetMin$ 0 | TargetMax$ OrigPower | DividedAsYouChoose$ OrigPower | SpellDescription$ CARDNAME deals X damage divided as you choose among any number of target creatures, where X is the greatest power among creatures you control as you cast this spell.
 SVar:OrigPower:Count$Valid Creature.YouCtrl$GreatestPower
 Oracle:Monstrous Onslaught deals X damage divided as you choose among any number of target creatures, where X is the greatest power among creatures you control as you cast this spell.

--- a/forge-gui/res/cardsfolder/m/monstrous_step.txt
+++ b/forge-gui/res/cardsfolder/m/monstrous_step.txt
@@ -1,7 +1,7 @@
 Name:Monstrous Step
 ManaCost:4 G
 Types:Sorcery
-A:SP$ Pump | Cost$ 4 G | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +7 | NumDef$ +7 | SubAbility$ DBMustBlock | SpellDescription$ Target creature gets +7/+7 until end of turn. Up to one other target creature blocks it this turn if able.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +7 | NumDef$ +7 | SubAbility$ DBMustBlock | SpellDescription$ Target creature gets +7/+7 until end of turn. Up to one other target creature blocks it this turn if able.
 SVar:DBMustBlock:DB$ MustBlock | DefinedAttacker$ ParentTarget | ValidTgts$ Creature | TargetUnique$ True | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one other target creature to block
 K:Cycling:2
 Oracle:Target creature gets +7/+7 until end of turn. Up to one other target creature blocks it this turn if able.\nCycling {2} ({2}, Discard this card: Draw a card.)

--- a/forge-gui/res/cardsfolder/m/moonhold.txt
+++ b/forge-gui/res/cardsfolder/m/moonhold.txt
@@ -1,7 +1,7 @@
 Name:Moonhold
 ManaCost:2 RW
 Types:Instant
-A:SP$ Effect | Cost$ 2 RW | ValidTgts$ Player | IsCurse$ True | Name$ Moonhold Land Effect | StaticAbilities$ STCantPlayLand | EffectOwner$ Targeted | AILogic$ BeginningOfOppTurn | ConditionManaSpent$ R | SubAbility$ WPaid | SpellDescription$ Target player can't play lands this turn if {R} was spent to cast this spell and can't cast creature spells this turn if {W} was spent to cast this spell. (Do both if {R}{W} was spent.)
+A:SP$ Effect | ValidTgts$ Player | IsCurse$ True | Name$ Moonhold Land Effect | StaticAbilities$ STCantPlayLand | EffectOwner$ Targeted | AILogic$ BeginningOfOppTurn | ConditionManaSpent$ R | SubAbility$ WPaid | SpellDescription$ Target player can't play lands this turn if {R} was spent to cast this spell and can't cast creature spells this turn if {W} was spent to cast this spell. (Do both if {R}{W} was spent.)
 SVar:WPaid:DB$ Effect | Name$ Moonhold Creature Effect | IsCurse$ True | StaticAbilities$ STCantPlayCreats | EffectOwner$ Targeted | AILogic$ BeginningOfOppTurn | ConditionManaSpent$ W
 SVar:STCantPlayLand:Mode$ CantPlayLand | EffectZone$ Command | Player$ You | Description$ You can't play lands this turn.
 SVar:STCantPlayCreats:Mode$ CantBeCast | ValidCard$ Creature | EffectZone$ Command | Caster$ You | Description$ You can't cast creature spells this turn.


### PR DESCRIPTION
Other fixes:
- Prompted by [Mind Grind](https://scryfall.com/card/gtc/178/mind-grind) in this PR, reverted [Ertai's Meddling](https://scryfall.com/card/tmp/61/ertais-meddling) as I'd failed to take into account cards with the "X can't be 0" casting cost restriction on this main event pass. Fortunately these two are the only cards with such a restriction on their casting cost.