### PR TITLE
Tribal to Kindred update

### DIFF
--- a/forge-core/src/main/java/forge/card/CardType.java
+++ b/forge-core/src/main/java/forge/card/CardType.java
@@ -60,7 +60,7 @@ public final class CardType implements Comparable<CardType>, CardTypeView {
         Planeswalker(true, "planeswalkers"),
         Scheme(false, "schemes"),
         Sorcery(false, "sorceries"),
-        Tribal(false, "tribals"),
+        Kindred(false, "kindreds"),
         Vanguard(false, "vanguards");
 
         public final boolean isPermanent;
@@ -235,7 +235,7 @@ public final class CardType implements Comparable<CardType>, CardTypeView {
 
     public boolean setCreatureTypes(Collection<String> ctypes) {
         // if it isn't a creature then this has no effect
-        if (!isCreature() && !isTribal()) {
+        if (!isCreature() && !isKindred()) {
             return false;
         }
         boolean changed = Iterables.removeIf(subtypes, Predicates.IS_CREATURE_TYPE);
@@ -274,7 +274,7 @@ public final class CardType implements Comparable<CardType>, CardTypeView {
     @Override
     public Set<String> getCreatureTypes() {
         final Set<String> creatureTypes = Sets.newHashSet();
-        if (!isCreature() && !isTribal()) {
+        if (!isCreature() && !isKindred()) {
             return creatureTypes;
         }
         if (hasAllCreatureTypes()) { // it should return list of all creature types
@@ -334,7 +334,7 @@ public final class CardType implements Comparable<CardType>, CardTypeView {
 
     @Override
     public boolean hasAllCreatureTypes() {
-        if (!isCreature() && !isTribal()) { return false; }
+        if (!isCreature() && !isKindred()) { return false; }
         return this.allCreatureTypes;
     }
 
@@ -348,7 +348,7 @@ public final class CardType implements Comparable<CardType>, CardTypeView {
 
     @Override
     public boolean hasCreatureType(String creatureType) {
-        if (!isCreature() && !isTribal()) { return false; }
+        if (!isCreature() && !isKindred()) { return false; }
 
         creatureType = toMixedCase(creatureType);
         if (!isACreatureType(creatureType)) { return false; }
@@ -479,8 +479,8 @@ public final class CardType implements Comparable<CardType>, CardTypeView {
     }
 
     @Override
-    public boolean isTribal() {
-        return coreTypes.contains(CoreType.Tribal);
+    public boolean isKindred() {
+        return coreTypes.contains(CoreType.Kindred);
     }
 
     @Override
@@ -509,7 +509,7 @@ public final class CardType implements Comparable<CardType>, CardTypeView {
 
     @Override
     public boolean isOutlaw() {
-        if (!isCreature() && !isTribal()) {
+        if (!isCreature() && !isKindred()) {
             return false;
         }
         return !Collections.disjoint(getCreatureTypes(), Constant.OUTLAW_TYPES);
@@ -618,13 +618,13 @@ public final class CardType implements Comparable<CardType>, CardTypeView {
         if (this.incomplete) {
             return;
         }
-        if (!isCreature() && !isTribal()) {
+        if (!isCreature() && !isKindred()) {
             allCreatureTypes = false;
         }
         if (subtypes.isEmpty()) {
             return;
         }
-        if (!isCreature() && !isTribal()) {
+        if (!isCreature() && !isKindred()) {
             Iterables.removeIf(subtypes, Predicates.IS_CREATURE_TYPE);
         }
         if (!isLand()) {
@@ -691,10 +691,10 @@ public final class CardType implements Comparable<CardType>, CardTypeView {
         if (ctOther == null) {
             return false;
         }
-        if (!isCreature() && !isTribal()) {
+        if (!isCreature() && !isKindred()) {
             return false;
         }
-        if (!ctOther.isCreature() && !ctOther.isTribal()) {
+        if (!ctOther.isCreature() && !ctOther.isKindred()) {
             return false;
         }
 

--- a/forge-core/src/main/java/forge/card/CardTypeView.java
+++ b/forge-core/src/main/java/forge/card/CardTypeView.java
@@ -49,7 +49,7 @@ public interface CardTypeView extends Iterable<String>, Serializable {
     boolean isBasicLand();
     boolean isPlane();
     boolean isPhenomenon();
-    boolean isTribal();
+    boolean isKindred();
     boolean isDungeon();
 
     boolean isAttachment();

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -5449,7 +5449,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
     public final boolean isBasicLand()  { return getType().isBasicLand(); }
     public final boolean isSnow()       { return getType().isSnow(); }
 
-    public final boolean isTribal()     { return getType().isTribal(); }
+    public final boolean isKindred()     { return getType().isKindred(); }
     public final boolean isSorcery()    { return getType().isSorcery(); }
     public final boolean isInstant()    { return getType().isInstant(); }
 

--- a/forge-gui/res/cardsfolder/a/all_is_dust.txt
+++ b/forge-gui/res/cardsfolder/a/all_is_dust.txt
@@ -1,5 +1,5 @@
 Name:All Is Dust
 ManaCost:7
-Types:Tribal Sorcery Eldrazi
+Types:Kindred Sorcery Eldrazi
 A:SP$ SacrificeAll | Cost$ 7 | ValidCards$ Permanent.nonColorless | SpellDescription$ Each player sacrifices all permanents they control that are one or more colors.
 Oracle:Each player sacrifices all permanents they control that are one or more colors.

--- a/forge-gui/res/cardsfolder/a/altar_of_the_goyf.txt
+++ b/forge-gui/res/cardsfolder/a/altar_of_the_goyf.txt
@@ -1,6 +1,6 @@
 Name:Altar of the Goyf
 ManaCost:5
-Types:Tribal Artifact Lhurgoyf
+Types:Kindred Artifact Lhurgoyf
 T:Mode$ Attacks | ValidCard$ Creature.YouCtrl | Alone$ True | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever a creature you control attacks alone, it gets +X/+X until end of turn, where X is the number of card types among cards in all graveyards.
 SVar:TrigPump:DB$ Pump | Defined$ TriggeredAttackerLKICopy | NumAtt$ +X | NumDef$ +X
 S:Mode$ Continuous | Affected$ Creature.Lhurgoyf+YouCtrl | AddKeyword$ Trample | Description$ Lhurgoyf creatures you control have trample.

--- a/forge-gui/res/cardsfolder/a/aminatous_augury.txt
+++ b/forge-gui/res/cardsfolder/a/aminatous_augury.txt
@@ -12,7 +12,7 @@ SVar:PlayAr:Mode$ Continuous | Affected$ Artifact.YouCtrl+IsRemembered | MayPlay
 SVar:PlayEn:Mode$ Continuous | Affected$ Enchantment.YouCtrl+IsRemembered | MayPlay$ True | MayPlayWithoutManaCost$ True | MayPlayLimit$ 1 | MayPlayText$ Enchantment | EffectZone$ Command | AffectedZone$ Exile
 SVar:PlayIn:Mode$ Continuous | Affected$ Instant.YouCtrl+IsRemembered | MayPlay$ True | MayPlayWithoutManaCost$ True | MayPlayLimit$ 1 | MayPlayText$ Instant | EffectZone$ Command | AffectedZone$ Exile
 SVar:PlaySo:Mode$ Continuous | Affected$ Sorcery.YouCtrl+IsRemembered | MayPlay$ True | MayPlayWithoutManaCost$ True | MayPlayLimit$ 1 | MayPlayText$ Sorcery | EffectZone$ Command | AffectedZone$ Exile
-SVar:PlayTr:Mode$ Continuous | Affected$ Tribal.YouCtrl+IsRemembered | MayPlay$ True | MayPlayWithoutManaCost$ True | MayPlayLimit$ 1 | MayPlayText$ Tribal | EffectZone$ Command | AffectedZone$ Exile
+SVar:PlayTr:Mode$ Continuous | Affected$ Kindred.YouCtrl+IsRemembered | MayPlay$ True | MayPlayWithoutManaCost$ True | MayPlayLimit$ 1 | MayPlayText$ Kindred | EffectZone$ Command | AffectedZone$ Exile
 SVar:PlayTr:Mode$ Continuous | Affected$ Battle.YouCtrl+IsRemembered | MayPlay$ True | MayPlayWithoutManaCost$ True | MayPlayLimit$ 1 | MayPlayText$ Battle | EffectZone$ Command | AffectedZone$ Exile
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Exile the top eight cards of your library. You may put a land card from among them onto the battlefield. Until end of turn, for each nonland card type, you may cast a spell of that type from among the exiled cards without paying its mana cost.

--- a/forge-gui/res/cardsfolder/a/aminatous_augury.txt
+++ b/forge-gui/res/cardsfolder/a/aminatous_augury.txt
@@ -5,14 +5,14 @@ A:SP$ Dig | Defined$ You | DigNum$ 8 | ChangeNum$ All | DestinationZone$ Exile |
 SVar:DBChooseLand:DB$ ChooseCard | Defined$ You | Choices$ Land.IsRemembered | Mandatory$ True | Amount$ 1 | ChoiceZone$ Exile | SubAbility$ DBChangeZone
 SVar:DBChangeZone:DB$ ChangeZone | Optional$ True | Defined$ ChosenCard | Origin$ Exile | Destination$ Battlefield | ForgetChanged$ True | SubAbility$ DBCleanupChosen
 SVar:DBCleanupChosen:DB$ Cleanup | ClearChosenCard$ True | SubAbility$ DBEffect
-SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ PlayCr,PlayPl,PlayAr,PlayEn,PlayIn,PlaySo,PlayTr | SubAbility$ DBCleanup | ForgetOnMoved$ Exile
+SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ PlayCr,PlayPl,PlayAr,PlayEn,PlayIn,PlaySo,PlayKi,PlayBa | SubAbility$ DBCleanup | ForgetOnMoved$ Exile
 SVar:PlayCr:Mode$ Continuous | Affected$ Creature.YouCtrl+IsRemembered | MayPlay$ True | MayPlayWithoutManaCost$ True | MayPlayLimit$ 1 | MayPlayText$ Creature | EffectZone$ Command | AffectedZone$ Exile
 SVar:PlayPl:Mode$ Continuous | Affected$ Planeswalker.YouCtrl+IsRemembered | MayPlay$ True | MayPlayWithoutManaCost$ True | MayPlayLimit$ 1 | MayPlayText$ Planeswalker | EffectZone$ Command | AffectedZone$ Exile
 SVar:PlayAr:Mode$ Continuous | Affected$ Artifact.YouCtrl+IsRemembered | MayPlay$ True | MayPlayWithoutManaCost$ True | MayPlayLimit$ 1 | MayPlayText$ Artifact | EffectZone$ Command | AffectedZone$ Exile
 SVar:PlayEn:Mode$ Continuous | Affected$ Enchantment.YouCtrl+IsRemembered | MayPlay$ True | MayPlayWithoutManaCost$ True | MayPlayLimit$ 1 | MayPlayText$ Enchantment | EffectZone$ Command | AffectedZone$ Exile
 SVar:PlayIn:Mode$ Continuous | Affected$ Instant.YouCtrl+IsRemembered | MayPlay$ True | MayPlayWithoutManaCost$ True | MayPlayLimit$ 1 | MayPlayText$ Instant | EffectZone$ Command | AffectedZone$ Exile
 SVar:PlaySo:Mode$ Continuous | Affected$ Sorcery.YouCtrl+IsRemembered | MayPlay$ True | MayPlayWithoutManaCost$ True | MayPlayLimit$ 1 | MayPlayText$ Sorcery | EffectZone$ Command | AffectedZone$ Exile
-SVar:PlayTr:Mode$ Continuous | Affected$ Kindred.YouCtrl+IsRemembered | MayPlay$ True | MayPlayWithoutManaCost$ True | MayPlayLimit$ 1 | MayPlayText$ Kindred | EffectZone$ Command | AffectedZone$ Exile
-SVar:PlayTr:Mode$ Continuous | Affected$ Battle.YouCtrl+IsRemembered | MayPlay$ True | MayPlayWithoutManaCost$ True | MayPlayLimit$ 1 | MayPlayText$ Battle | EffectZone$ Command | AffectedZone$ Exile
+SVar:PlayKi:Mode$ Continuous | Affected$ Kindred.YouCtrl+IsRemembered | MayPlay$ True | MayPlayWithoutManaCost$ True | MayPlayLimit$ 1 | MayPlayText$ Kindred | EffectZone$ Command | AffectedZone$ Exile
+SVar:PlayBa:Mode$ Continuous | Affected$ Battle.YouCtrl+IsRemembered | MayPlay$ True | MayPlayWithoutManaCost$ True | MayPlayLimit$ 1 | MayPlayText$ Battle | EffectZone$ Command | AffectedZone$ Exile
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Exile the top eight cards of your library. You may put a land card from among them onto the battlefield. Until end of turn, for each nonland card type, you may cast a spell of that type from among the exiled cards without paying its mana cost.

--- a/forge-gui/res/cardsfolder/a/aquitects_will.txt
+++ b/forge-gui/res/cardsfolder/a/aquitects_will.txt
@@ -1,6 +1,6 @@
 Name:Aquitect's Will
 ManaCost:U
-Types:Tribal Sorcery Merfolk
+Types:Kindred Sorcery Merfolk
 A:SP$ PutCounter | Cost$ U | ValidTgts$ Land | TgtPrompt$ Select target land | CounterType$ FLOOD | CounterNum$ 1 | SubAbility$ DBEffect | SpellDescription$ Put a flood counter on target land. That land is an island in addition to its other types for as long as it has a flood counter on it. If you control a Merfolk, draw a card.
 SVar:DBEffect:DB$ Effect | RememberObjects$ Targeted | StaticAbilities$ FountainStatic | ForgetOnMoved$ Battlefield | ForgetCounter$ FLOOD | Duration$ Permanent | SubAbility$ DBDraw
 SVar:FountainStatic:Mode$ Continuous | EffectZone$ Command | Affected$ Card.IsRemembered | AddType$ Island | Description$ That land is an island in addition to its other types for as long as it has a flood counter on it.

--- a/forge-gui/res/cardsfolder/a/atraxa_grand_unifier.txt
+++ b/forge-gui/res/cardsfolder/a/atraxa_grand_unifier.txt
@@ -6,7 +6,7 @@ K:Flying
 K:Vigilance
 K:Deathtouch
 K:Lifelink
-T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigReveal | TriggerDescription$ When CARDNAME enters the battlefield, reveal the top ten cards of your library. For each card type, you may put a card of that type from among the revealed cards into your hand. Put the rest on the bottom of your library in a random order. (Artifact, battle, creature, enchantment, instant, land, planeswalker, and sorcery are card types.)
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigReveal | TriggerDescription$ When CARDNAME enters the battlefield, reveal the top ten cards of your library. For each card type, you may put a card of that type from among the revealed cards into your hand. Put the rest on the bottom of your library in a random order. (Artifact, battle, creature, enchantment, instant, kindred, land, planeswalker, and sorcery are card types.)
 SVar:TrigReveal:DB$ PeekAndReveal | PeekAmount$ 10 | Reveal$ True | ImprintRevealed$ True | SubAbility$ TrigRepeatTypes
 SVar:TrigRepeatTypes:DB$ RepeatEach | RepeatTypesFrom$ Card.IsImprinted | TypesFromZone$ Library | RepeatSubAbility$ ChooseCard | SubAbility$ DBChangeZone
 SVar:ChooseCard:DB$ ChooseCard | Choices$ Card.ChosenType+YouOwn+IsImprinted | ChoiceZone$ Library | RememberChosen$ True
@@ -14,4 +14,4 @@ SVar:DBChangeZone:DB$ ChangeZone | Origin$ Library | Destination$ Hand | Defined
 SVar:ShuffleRest:DB$ ChangeZoneAll | Origin$ Library | Destination$ Library | LibraryPosition$ -1 | RandomOrder$ True | ChangeType$ Card.IsImprinted+!IsRemembered | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearImprinted$ True
 DeckHas:Ability$LifeGain
-Oracle:Flying, vigilance, deathtouch, lifelink\nWhen Atraxa, Grand Unifier enters the battlefield, reveal the top ten cards of your library. For each card type, you may put a card of that type from among the revealed cards into your hand. Put the rest on the bottom of your library in a random order. (Artifact, battle, creature, enchantment, instant, land, planeswalker, and sorcery are card types.)
+Oracle:Flying, vigilance, deathtouch, lifelink\nWhen Atraxa, Grand Unifier enters the battlefield, reveal the top ten cards of your library. For each card type, you may put a card of that type from among the revealed cards into your hand. Put the rest on the bottom of your library in a random order. (Artifact, battle, creature, enchantment, instant, kindred, land, planeswalker, and sorcery are card types.)

--- a/forge-gui/res/cardsfolder/b/bitterblossom.txt
+++ b/forge-gui/res/cardsfolder/b/bitterblossom.txt
@@ -1,6 +1,6 @@
 Name:Bitterblossom
 ManaCost:1 B
-Types:Tribal Enchantment Faerie
+Types:Kindred Enchantment Faerie
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigLoseLife | TriggerDescription$ At the beginning of your upkeep, you lose 1 life and create a 1/1 black Faerie Rogue creature token with flying.
 SVar:TrigLoseLife:DB$ LoseLife | LifeAmount$ 1 | SubAbility$ DBToken
 SVar:DBToken:DB$ Token | TokenAmount$ 1 | TokenScript$ b_1_1_faerie_rogue_flying | TokenOwner$ You

--- a/forge-gui/res/cardsfolder/b/blades_of_velis_vel.txt
+++ b/forge-gui/res/cardsfolder/b/blades_of_velis_vel.txt
@@ -1,6 +1,6 @@
 Name:Blades of Velis Vel
 ManaCost:1 R
-Types:Tribal Instant Shapeshifter
+Types:Kindred Instant Shapeshifter
 K:Changeling
 A:SP$ Pump | Cost$ 1 R | TargetMin$ 0 | TargetMax$ 2 | NumAtt$ +2 | ValidTgts$ Creature | TgtPrompt$ Select target Creature | SubAbility$ DBAnimate | SpellDescription$ Up to two target creatures each get +2/+0 and gain all creature types until end of turn.
 SVar:DBAnimate:DB$ Animate | Defined$ Targeted | AddAllCreatureTypes$ True

--- a/forge-gui/res/cardsfolder/b/blood_oath.txt
+++ b/forge-gui/res/cardsfolder/b/blood_oath.txt
@@ -1,11 +1,11 @@
 Name:Blood Oath
 ManaCost:3 R
 Types:Instant
-A:SP$ ChooseType | Defined$ You | Type$ Card | SubAbility$ DBReveal | SpellDescription$ Choose a card type. Target opponent reveals their hand. CARDNAME deals 3 damage to that player for each card of the chosen type revealed this way. (Artifact, battle, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
+A:SP$ ChooseType | Defined$ You | Type$ Card | SubAbility$ DBReveal | SpellDescription$ Choose a card type. Target opponent reveals their hand. CARDNAME deals 3 damage to that player for each card of the chosen type revealed this way. (Artifact, battle, creature, enchantment, instant, kindred, land, planeswalker, and sorcery are card types.)
 SVar:DBReveal:DB$ RevealHand | RememberRevealed$ True | ValidTgts$ Opponent | TgtPrompt$ Select target opponent to reveal their hand | SubAbility$ DBDamage
 SVar:DBDamage:DB$ DealDamage | Defined$ Targeted | NumDmg$ X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:SVar$Y/Times.3
 SVar:Y:Remembered$Valid Card.ChosenType
 AI:RemoveDeck:All
-Oracle:Choose a card type. Target opponent reveals their hand. Blood Oath deals 3 damage to that player for each card of the chosen type revealed this way. (Artifact, battle, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
+Oracle:Choose a card type. Target opponent reveals their hand. Blood Oath deals 3 damage to that player for each card of the chosen type revealed this way. (Artifact, battle, creature, enchantment, instant, kindred, land, planeswalker, and sorcery are card types.)

--- a/forge-gui/res/cardsfolder/b/blood_oath.txt
+++ b/forge-gui/res/cardsfolder/b/blood_oath.txt
@@ -8,4 +8,4 @@ SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:SVar$Y/Times.3
 SVar:Y:Remembered$Valid Card.ChosenType
 AI:RemoveDeck:All
-Oracle:Choose a card type. Target opponent reveals their hand. Blood Oath deals 3 damage to that player for each card of the chosen type revealed this way. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and tribal are card types.)
+Oracle:Choose a card type. Target opponent reveals their hand. Blood Oath deals 3 damage to that player for each card of the chosen type revealed this way. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)

--- a/forge-gui/res/cardsfolder/b/blood_oath.txt
+++ b/forge-gui/res/cardsfolder/b/blood_oath.txt
@@ -1,11 +1,11 @@
 Name:Blood Oath
 ManaCost:3 R
 Types:Instant
-A:SP$ ChooseType | Defined$ You | Type$ Card | SubAbility$ DBReveal | SpellDescription$ Choose a card type. Target opponent reveals their hand. CARDNAME deals 3 damage to that player for each card of the chosen type revealed this way.
+A:SP$ ChooseType | Defined$ You | Type$ Card | SubAbility$ DBReveal | SpellDescription$ Choose a card type. Target opponent reveals their hand. CARDNAME deals 3 damage to that player for each card of the chosen type revealed this way. (Artifact, battle, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
 SVar:DBReveal:DB$ RevealHand | RememberRevealed$ True | ValidTgts$ Opponent | TgtPrompt$ Select target opponent to reveal their hand | SubAbility$ DBDamage
 SVar:DBDamage:DB$ DealDamage | Defined$ Targeted | NumDmg$ X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:SVar$Y/Times.3
 SVar:Y:Remembered$Valid Card.ChosenType
 AI:RemoveDeck:All
-Oracle:Choose a card type. Target opponent reveals their hand. Blood Oath deals 3 damage to that player for each card of the chosen type revealed this way. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
+Oracle:Choose a card type. Target opponent reveals their hand. Blood Oath deals 3 damage to that player for each card of the chosen type revealed this way. (Artifact, battle, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)

--- a/forge-gui/res/cardsfolder/b/boggart_birth_rite.txt
+++ b/forge-gui/res/cardsfolder/b/boggart_birth_rite.txt
@@ -1,6 +1,6 @@
 Name:Boggart Birth Rite
 ManaCost:B
-Types:Tribal Sorcery Goblin
+Types:Kindred Sorcery Goblin
 A:SP$ ChangeZone | Cost$ B | Origin$ Graveyard | Destination$ Hand | TgtPrompt$ Choose target Goblin card in your graveyard | ValidTgts$ Goblin.YouCtrl | SpellDescription$ Return target Goblin card from your graveyard to your hand.
 AI:RemoveDeck:Random
 Oracle:Return target Goblin card from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/b/boggart_shenanigans.txt
+++ b/forge-gui/res/cardsfolder/b/boggart_shenanigans.txt
@@ -1,6 +1,6 @@
 Name:Boggart Shenanigans
 ManaCost:2 R
-Types:Tribal Enchantment Goblin
+Types:Kindred Enchantment Goblin
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Goblin.Other+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigDamage | OptionalDecider$ You | TriggerDescription$ Whenever another Goblin you control is put into a graveyard from the battlefield, you may have CARDNAME deal 1 damage to target player or planeswalker.
 SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | NumDmg$ 1
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/b/bound_in_silence.txt
+++ b/forge-gui/res/cardsfolder/b/bound_in_silence.txt
@@ -1,6 +1,6 @@
 Name:Bound in Silence
 ManaCost:2 W
-Types:Tribal Enchantment Rebel Aura
+Types:Kindred Enchantment Rebel Aura
 K:Enchant creature
 A:SP$ Attach | Cost$ 2 W | ValidTgts$ Creature | AILogic$ Curse
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Enchanted creature can't attack or block.

--- a/forge-gui/res/cardsfolder/c/cloak_and_dagger.txt
+++ b/forge-gui/res/cardsfolder/c/cloak_and_dagger.txt
@@ -1,6 +1,6 @@
 Name:Cloak and Dagger
 ManaCost:2
-Types:Tribal Artifact Rogue Equipment
+Types:Kindred Artifact Rogue Equipment
 K:Equip:3
 S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 2 | AddKeyword$ Shroud | Description$ Equipped creature gets +2/+0 and has shroud. (It can't be the target of spells or abilities.)
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.Rogue | TriggerZones$ Battlefield | Execute$ TrigAttach | OptionalDecider$ You | TriggerDescription$ Whenever a Rogue creature enters the battlefield, you may attach CARDNAME to it.

--- a/forge-gui/res/cardsfolder/c/consuming_bonfire.txt
+++ b/forge-gui/res/cardsfolder/c/consuming_bonfire.txt
@@ -1,6 +1,6 @@
 Name:Consuming Bonfire
 ManaCost:3 R R
-Types:Tribal Sorcery Elemental
+Types:Kindred Sorcery Elemental
 A:SP$ Charm | Cost$ 3 R R | Choices$ DBDmg,DBDmg2
 SVar:DBDmg:DB$ DealDamage | ValidTgts$ Creature.nonElemental | NumDmg$ 4 | SpellDescription$ CARDNAME deals 4 damage to target non-Elemental creature.
 SVar:DBDmg2:DB$ DealDamage | ValidTgts$ Creature.Treefolk | NumDmg$ 7 | SpellDescription$ CARDNAME deals 7 damage to target Treefolk creature.

--- a/forge-gui/res/cardsfolder/c/creeping_renaissance.txt
+++ b/forge-gui/res/cardsfolder/c/creeping_renaissance.txt
@@ -2,7 +2,7 @@ Name:Creeping Renaissance
 ManaCost:3 G G
 Types:Sorcery
 K:Flashback:5 G G
-A:SP$ ChooseType | Defined$ You | Type$ Card | InvalidTypes$ Instant,Sorcery,Tribal | SubAbility$ DBReturn | SpellDescription$ Choose a permanent type. Return all cards of the chosen type from your graveyard to your hand.
+A:SP$ ChooseType | Defined$ You | Type$ Card | InvalidTypes$ Instant,Sorcery,Kindred | SubAbility$ DBReturn | SpellDescription$ Choose a permanent type. Return all cards of the chosen type from your graveyard to your hand.
 SVar:DBReturn:DB$ ChangeZoneAll | Origin$ Graveyard | Destination$ Hand | ChangeType$ Card.ChosenType+YouCtrl
 AI:RemoveDeck:All
 Oracle:Choose a permanent type. Return all cards of the chosen type from your graveyard to your hand.\nFlashback {5}{G}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)

--- a/forge-gui/res/cardsfolder/c/crib_swap.txt
+++ b/forge-gui/res/cardsfolder/c/crib_swap.txt
@@ -1,6 +1,6 @@
 Name:Crib Swap
 ManaCost:2 W
-Types:Tribal Instant Shapeshifter
+Types:Kindred Instant Shapeshifter
 K:Changeling
 A:SP$ ChangeZone | Cost$ 2 W | ValidTgts$ Creature | TgtPrompt$ Select target creature | Origin$ Battlefield | Destination$ Exile | IsCurse$ True | SubAbility$ DBToken | AILogic$ Pongify | SpellDescription$ Exile target creature. Its controller creates a 1/1 colorless Shapeshifter creature token with changeling.
 SVar:DBToken:DB$ Token | TokenAmount$ 1 | TokenScript$ c_1_1_shapeshifter_changeling | TokenOwner$ TargetedController

--- a/forge-gui/res/cardsfolder/c/crush_underfoot.txt
+++ b/forge-gui/res/cardsfolder/c/crush_underfoot.txt
@@ -1,6 +1,6 @@
 Name:Crush Underfoot
 ManaCost:1 R
-Types:Tribal Instant Giant
+Types:Kindred Instant Giant
 A:SP$ ChooseCard | Cost$ 1 R | Defined$ You | Mandatory$ True | Choices$ Creature.Giant+YouCtrl | ChoiceTitle$ Choose a Giant creature you control | SubAbility$ DBDmg | SpellDescription$ Choose a Giant creature you control. It deals damage equal to its power to target creature.
 SVar:DBDmg:DB$ DealDamage | NumDmg$ X | DamageSource$ ChosenCard | ValidTgts$ Creature
 SVar:X:Count$Valid Card.ChosenCard$CardPower

--- a/forge-gui/res/cardsfolder/d/diviners_wand.txt
+++ b/forge-gui/res/cardsfolder/d/diviners_wand.txt
@@ -1,6 +1,6 @@
 Name:Diviner's Wand
 ManaCost:3
-Types:Tribal Artifact Wizard Equipment
+Types:Kindred Artifact Wizard Equipment
 K:Equip:3
 S:Mode$ Continuous | Affected$ Card.EquippedBy | AddAbility$ DivinerDraw | AddTrigger$ TrigDraw | AddSVar$ DivinerTrigPump | Description$ Equipped creature has "Whenever you draw a card, this creature gets +1/+1 and gains flying until end of turn" and "{4}: Draw a card."
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.Wizard | TriggerZones$ Battlefield | Execute$ TrigAttach | OptionalDecider$ You | TriggerDescription$ Whenever a Wizard creature enters the battlefield, you may attach CARDNAME to it.

--- a/forge-gui/res/cardsfolder/e/ego_erasure.txt
+++ b/forge-gui/res/cardsfolder/e/ego_erasure.txt
@@ -1,6 +1,6 @@
 Name:Ego Erasure
 ManaCost:2 U
-Types:Tribal Instant Shapeshifter
+Types:Kindred Instant Shapeshifter
 K:Changeling
 A:SP$ PumpAll | ValidTgts$ Player | ValidCards$ Creature | NumAtt$ -2 | NumDef$ -0 | IsCurse$ True | SubAbility$ DBAnimateAll | SpellDescription$ Creatures target player controls get -2/-0 and lose all creature types until end of turn.
 SVar:DBAnimateAll:DB$ AnimateAll | ValidCards$ Creature.TargetedPlayerCtrl | RemoveCreatureTypes$ True | StackDescription$ None

--- a/forge-gui/res/cardsfolder/e/eldrazi_conscription.txt
+++ b/forge-gui/res/cardsfolder/e/eldrazi_conscription.txt
@@ -1,6 +1,6 @@
 Name:Eldrazi Conscription
 ManaCost:8
-Types:Tribal Enchantment Eldrazi Aura
+Types:Kindred Enchantment Eldrazi Aura
 K:Enchant creature
 A:SP$ Attach | Cost$ 8 | ValidTgts$ Creature | AILogic$ Pump
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 10 | AddToughness$ 10 | AddKeyword$ Trample & Annihilator:2 | Description$ Enchanted creature gets +10/+10 and has trample and annihilator 2. (Whenever it attacks, defending player sacrifices two permanents.)

--- a/forge-gui/res/cardsfolder/e/elvish_promenade.txt
+++ b/forge-gui/res/cardsfolder/e/elvish_promenade.txt
@@ -1,6 +1,6 @@
 Name:Elvish Promenade
 ManaCost:3 G
-Types:Tribal Sorcery Elf
+Types:Kindred Sorcery Elf
 A:SP$ Token | Cost$ 3 G | TokenAmount$ X | TokenScript$ g_1_1_elf_warrior | TokenOwner$ You | SpellDescription$ Create a 1/1 green Elf Warrior creature token for each Elf you control.
 SVar:X:Count$Valid Elf.YouCtrl
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/e/eyeblights_ending.txt
+++ b/forge-gui/res/cardsfolder/e/eyeblights_ending.txt
@@ -1,5 +1,5 @@
 Name:Eyeblight's Ending
 ManaCost:2 B
-Types:Tribal Instant Elf
+Types:Kindred Instant Elf
 A:SP$ Destroy | Cost$ 2 B | ValidTgts$ Creature.nonElf | TgtPrompt$ Select target non-Elf creature | SpellDescription$ Destroy target non-Elf creature.
 Oracle:Destroy target non-Elf creature.

--- a/forge-gui/res/cardsfolder/e/eyes_of_the_wisent.txt
+++ b/forge-gui/res/cardsfolder/e/eyes_of_the_wisent.txt
@@ -1,6 +1,6 @@
 Name:Eyes of the Wisent
 ManaCost:1 G
-Types:Tribal Enchantment Elemental
+Types:Kindred Enchantment Elemental
 T:Mode$ SpellCast | ValidCard$ Card.Blue | ValidActivatingPlayer$ Opponent | TriggerZones$ Battlefield | PlayerTurn$ True | Execute$ TrigToken | OptionalDecider$ You | TriggerDescription$ Whenever an opponent casts a blue spell during your turn, you may create a 4/4 green Elemental creature token.
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ g_4_4_elemental | TokenOwner$ You
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/f/faerie_tauntings.txt
+++ b/forge-gui/res/cardsfolder/f/faerie_tauntings.txt
@@ -1,6 +1,6 @@
 Name:Faerie Tauntings
 ManaCost:2 B
-Types:Tribal Enchantment Faerie
+Types:Kindred Enchantment Faerie
 T:Mode$ SpellCast | ValidCard$ Card | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | OpponentTurn$ True | Execute$ TrigLoseLife | OptionalDecider$ You | TriggerDescription$ Whenever you cast a spell during an opponent's turn, you may have each opponent lose 1 life.
 SVar:TrigLoseLife:DB$ LoseLife | Defined$ Player.Opponent | LifeAmount$ 1
 Oracle:Whenever you cast a spell during an opponent's turn, you may have each opponent lose 1 life.

--- a/forge-gui/res/cardsfolder/f/faerie_trickery.txt
+++ b/forge-gui/res/cardsfolder/f/faerie_trickery.txt
@@ -1,5 +1,5 @@
 Name:Faerie Trickery
 ManaCost:1 U U
-Types:Tribal Instant Faerie
+Types:Kindred Instant Faerie
 A:SP$ Counter | Cost$ 1 U U | TargetType$ Spell | TgtPrompt$ Select target non-Faerie spell | ValidTgts$ Card.nonFaerie | Destination$ Exile | SpellDescription$ Counter target non-Faerie spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.
 Oracle:Counter target non-Faerie spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.

--- a/forge-gui/res/cardsfolder/f/favor_of_the_mighty.txt
+++ b/forge-gui/res/cardsfolder/f/favor_of_the_mighty.txt
@@ -1,6 +1,6 @@
 Name:Favor of the Mighty
 ManaCost:1 W
-Types:Tribal Enchantment Giant
+Types:Kindred Enchantment Giant
 S:Mode$ Continuous | Affected$ Creature.greatestCMC_Creature | AddKeyword$ Protection from all colors | Description$ Each creature with the highest mana value has protection from all colors.
 SVar:NonStackingEffect:True
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/f/fertile_imagination.txt
+++ b/forge-gui/res/cardsfolder/f/fertile_imagination.txt
@@ -9,4 +9,4 @@ SVar:X:SVar$Y/Twice
 SVar:Y:Remembered$Valid Card.ChosenType
 AI:RemoveDeck:All
 DeckHas:Ability$Token
-Oracle:Choose a card type. Target opponent reveals their hand. Create two 1/1 green Saproling creature tokens for each card of the chosen type revealed this way. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and tribal are card types.)
+Oracle:Choose a card type. Target opponent reveals their hand. Create two 1/1 green Saproling creature tokens for each card of the chosen type revealed this way. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)

--- a/forge-gui/res/cardsfolder/f/fertile_imagination.txt
+++ b/forge-gui/res/cardsfolder/f/fertile_imagination.txt
@@ -1,7 +1,7 @@
 Name:Fertile Imagination
 ManaCost:2 G G
 Types:Sorcery
-A:SP$ ChooseType | Defined$ You | Type$ Card | SubAbility$ DBReveal | SpellDescription$ Choose a card type. Target opponent reveals their hand. Create two 1/1 green Saproling creature tokens for each card of the chosen type revealed this way.
+A:SP$ ChooseType | Defined$ You | Type$ Card | SubAbility$ DBReveal | SpellDescription$ Choose a card type. Target opponent reveals their hand. Create two 1/1 green Saproling creature tokens for each card of the chosen type revealed this way. (Artifact, battle, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
 SVar:DBReveal:DB$ RevealHand | RememberRevealed$ True | ValidTgts$ Opponent | TgtPrompt$ Select target opponent | SubAbility$ DBToken
 SVar:DBToken:DB$ Token | TokenAmount$ X | TokenScript$ g_1_1_saproling | TokenOwner$ You | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
@@ -9,4 +9,4 @@ SVar:X:SVar$Y/Twice
 SVar:Y:Remembered$Valid Card.ChosenType
 AI:RemoveDeck:All
 DeckHas:Ability$Token
-Oracle:Choose a card type. Target opponent reveals their hand. Create two 1/1 green Saproling creature tokens for each card of the chosen type revealed this way. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
+Oracle:Choose a card type. Target opponent reveals their hand. Create two 1/1 green Saproling creature tokens for each card of the chosen type revealed this way. (Artifact, battle, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)

--- a/forge-gui/res/cardsfolder/f/fertile_imagination.txt
+++ b/forge-gui/res/cardsfolder/f/fertile_imagination.txt
@@ -1,7 +1,7 @@
 Name:Fertile Imagination
 ManaCost:2 G G
 Types:Sorcery
-A:SP$ ChooseType | Defined$ You | Type$ Card | SubAbility$ DBReveal | SpellDescription$ Choose a card type. Target opponent reveals their hand. Create two 1/1 green Saproling creature tokens for each card of the chosen type revealed this way. (Artifact, battle, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
+A:SP$ ChooseType | Defined$ You | Type$ Card | SubAbility$ DBReveal | SpellDescription$ Choose a card type. Target opponent reveals their hand. Create two 1/1 green Saproling creature tokens for each card of the chosen type revealed this way. (Artifact, battle, creature, enchantment, instant, kindred, land, planeswalker, and sorcery are card types.)
 SVar:DBReveal:DB$ RevealHand | RememberRevealed$ True | ValidTgts$ Opponent | TgtPrompt$ Select target opponent | SubAbility$ DBToken
 SVar:DBToken:DB$ Token | TokenAmount$ X | TokenScript$ g_1_1_saproling | TokenOwner$ You | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
@@ -9,4 +9,4 @@ SVar:X:SVar$Y/Twice
 SVar:Y:Remembered$Valid Card.ChosenType
 AI:RemoveDeck:All
 DeckHas:Ability$Token
-Oracle:Choose a card type. Target opponent reveals their hand. Create two 1/1 green Saproling creature tokens for each card of the chosen type revealed this way. (Artifact, battle, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
+Oracle:Choose a card type. Target opponent reveals their hand. Create two 1/1 green Saproling creature tokens for each card of the chosen type revealed this way. (Artifact, battle, creature, enchantment, instant, kindred, land, planeswalker, and sorcery are card types.)

--- a/forge-gui/res/cardsfolder/f/feudkillers_verdict.txt
+++ b/forge-gui/res/cardsfolder/f/feudkillers_verdict.txt
@@ -1,6 +1,6 @@
 Name:Feudkiller's Verdict
 ManaCost:4 W W
-Types:Tribal Sorcery Giant
+Types:Kindred Sorcery Giant
 A:SP$ GainLife | Cost$ 4 W W | Defined$ You | LifeAmount$ 10 | SubAbility$ Token | SpellDescription$ You gain 10 life. Then if you have more life than an opponent, create a 5/5 white Giant Warrior creature token.
 SVar:Token:DB$ Token | ConditionLifeTotal$ You | ConditionLifeAmount$ GTX | TokenAmount$ 1 | TokenScript$ w_5_5_giant_warrior | TokenOwner$ You
 SVar:X:PlayerCountOpponents$LowestLifeTotal

--- a/forge-gui/res/cardsfolder/f/fodder_launch.txt
+++ b/forge-gui/res/cardsfolder/f/fodder_launch.txt
@@ -1,6 +1,6 @@
 Name:Fodder Launch
 ManaCost:3 B
-Types:Tribal Sorcery Goblin
+Types:Kindred Sorcery Goblin
 A:SP$ Pump | Cost$ 3 B Sac<1/Goblin> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ -5 | NumDef$ -5 | IsCurse$ True | SubAbility$ DBDealDamage | SpellDescription$ Target creature gets -5/-5 until end of turn. CARDNAME deals 5 damage to that creature's controller.
 SVar:DBDealDamage:DB$ DealDamage | Defined$ TargetedController | NumDmg$ 5
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/g/giants_ire.txt
+++ b/forge-gui/res/cardsfolder/g/giants_ire.txt
@@ -1,6 +1,6 @@
 Name:Giant's Ire
 ManaCost:3 R
-Types:Tribal Sorcery Giant
+Types:Kindred Sorcery Giant
 A:SP$ DealDamage | Cost$ 3 R | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | NumDmg$ 4 | SubAbility$ DBDraw | SpellDescription$ CARDNAME deals 4 damage to target player or planeswalker. If you control a Giant, draw a card.
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | ConditionPresent$ Giant.YouCtrl | ConditionCompare$ GE1 | ConditionDescription$ If you control a Giant,
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/g/gilt_leaf_ambush.txt
+++ b/forge-gui/res/cardsfolder/g/gilt_leaf_ambush.txt
@@ -1,6 +1,6 @@
 Name:Gilt-Leaf Ambush
 ManaCost:2 G
-Types:Tribal Instant Elf
+Types:Kindred Instant Elf
 A:SP$ Token | Cost$ 2 G | TokenAmount$ 2 | TokenScript$ g_1_1_elf_warrior | TokenOwner$ You | SubAbility$ DBClash | RememberTokens$ True | SpellDescription$ Create two 1/1 green Elf Warrior creature tokens. Clash with an opponent. If you win, those creatures gain deathtouch until end of turn.
 SVar:DBClash:DB$ Clash | WinSubAbility$ AdditionalPump
 SVar:AdditionalPump:DB$ PumpAll | ValidCards$ Creature.IsRemembered | KW$ Deathtouch | SubAbility$ DBCleanUp

--- a/forge-gui/res/cardsfolder/h/holistic_wisdom.txt
+++ b/forge-gui/res/cardsfolder/h/holistic_wisdom.txt
@@ -1,7 +1,7 @@
 Name:Holistic Wisdom
 ManaCost:1 G G
 Types:Enchantment
-A:AB$ Pump | Cost$ 2 ExileFromHand<1/Card> | SubAbility$ DBChangeZone | ValidTgts$ Card.YouOwn | TgtZone$ Graveyard | StackDescription$ None | SpellDescription$ Return target card from your graveyard to your hand if it shares a card type with the card exiled this way. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and tribal are card types.)
+A:AB$ Pump | Cost$ 2 ExileFromHand<1/Card> | SubAbility$ DBChangeZone | ValidTgts$ Card.YouOwn | TgtZone$ Graveyard | StackDescription$ None | SpellDescription$ Return target card from your graveyard to your hand if it shares a card type with the card exiled this way. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
 SVar:DBChangeZone:DB$ ChangeZone | Defined$ ParentTarget | Origin$ Graveyard | Destination$ Hand | ConditionDefined$ ParentTarget | ConditionPresent$ Card.sharesCardTypeWith Exiled | ConditionCompare$ GE1
 AI:RemoveDeck:All
-Oracle:{2}, Exile a card from your hand: Return target card from your graveyard to your hand if it shares a card type with the card exiled this way. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and tribal are card types.)
+Oracle:{2}, Exile a card from your hand: Return target card from your graveyard to your hand if it shares a card type with the card exiled this way. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)

--- a/forge-gui/res/cardsfolder/h/holistic_wisdom.txt
+++ b/forge-gui/res/cardsfolder/h/holistic_wisdom.txt
@@ -1,7 +1,7 @@
 Name:Holistic Wisdom
 ManaCost:1 G G
 Types:Enchantment
-A:AB$ Pump | Cost$ 2 ExileFromHand<1/Card> | SubAbility$ DBChangeZone | ValidTgts$ Card.YouOwn | TgtZone$ Graveyard | StackDescription$ None | SpellDescription$ Return target card from your graveyard to your hand if it shares a card type with the card exiled this way. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
+A:AB$ Pump | Cost$ 2 ExileFromHand<1/Card> | SubAbility$ DBChangeZone | ValidTgts$ Card.YouOwn | TgtZone$ Graveyard | StackDescription$ None | SpellDescription$ Return target card from your graveyard to your hand if it shares a card type with the card exiled this way. (Artifact, battle, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
 SVar:DBChangeZone:DB$ ChangeZone | Defined$ ParentTarget | Origin$ Graveyard | Destination$ Hand | ConditionDefined$ ParentTarget | ConditionPresent$ Card.sharesCardTypeWith Exiled | ConditionCompare$ GE1
 AI:RemoveDeck:All
 Oracle:{2}, Exile a card from your hand: Return target card from your graveyard to your hand if it shares a card type with the card exiled this way. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)

--- a/forge-gui/res/cardsfolder/h/holistic_wisdom.txt
+++ b/forge-gui/res/cardsfolder/h/holistic_wisdom.txt
@@ -4,4 +4,4 @@ Types:Enchantment
 A:AB$ Pump | Cost$ 2 ExileFromHand<1/Card> | SubAbility$ DBChangeZone | ValidTgts$ Card.YouOwn | TgtZone$ Graveyard | StackDescription$ None | SpellDescription$ Return target card from your graveyard to your hand if it shares a card type with the card exiled this way. (Artifact, battle, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
 SVar:DBChangeZone:DB$ ChangeZone | Defined$ ParentTarget | Origin$ Graveyard | Destination$ Hand | ConditionDefined$ ParentTarget | ConditionPresent$ Card.sharesCardTypeWith Exiled | ConditionCompare$ GE1
 AI:RemoveDeck:All
-Oracle:{2}, Exile a card from your hand: Return target card from your graveyard to your hand if it shares a card type with the card exiled this way. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
+Oracle:{2}, Exile a card from your hand: Return target card from your graveyard to your hand if it shares a card type with the card exiled this way. (Artifact, battle, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)

--- a/forge-gui/res/cardsfolder/h/holistic_wisdom.txt
+++ b/forge-gui/res/cardsfolder/h/holistic_wisdom.txt
@@ -1,7 +1,7 @@
 Name:Holistic Wisdom
 ManaCost:1 G G
 Types:Enchantment
-A:AB$ Pump | Cost$ 2 ExileFromHand<1/Card> | SubAbility$ DBChangeZone | ValidTgts$ Card.YouOwn | TgtZone$ Graveyard | StackDescription$ None | SpellDescription$ Return target card from your graveyard to your hand if it shares a card type with the card exiled this way. (Artifact, battle, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
+A:AB$ Pump | Cost$ 2 ExileFromHand<1/Card> | SubAbility$ DBChangeZone | ValidTgts$ Card.YouOwn | TgtZone$ Graveyard | StackDescription$ None | SpellDescription$ Return target card from your graveyard to your hand if it shares a card type with the card exiled this way. (Artifact, battle, creature, enchantment, instant, kindred, land, planeswalker, and sorcery are card types.)
 SVar:DBChangeZone:DB$ ChangeZone | Defined$ ParentTarget | Origin$ Graveyard | Destination$ Hand | ConditionDefined$ ParentTarget | ConditionPresent$ Card.sharesCardTypeWith Exiled | ConditionCompare$ GE1
 AI:RemoveDeck:All
-Oracle:{2}, Exile a card from your hand: Return target card from your graveyard to your hand if it shares a card type with the card exiled this way. (Artifact, battle, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
+Oracle:{2}, Exile a card from your hand: Return target card from your graveyard to your hand if it shares a card type with the card exiled this way. (Artifact, battle, creature, enchantment, instant, kindred, land, planeswalker, and sorcery are card types.)

--- a/forge-gui/res/cardsfolder/h/hoofprints_of_the_stag.txt
+++ b/forge-gui/res/cardsfolder/h/hoofprints_of_the_stag.txt
@@ -1,6 +1,6 @@
 Name:Hoofprints of the Stag
 ManaCost:1 W
-Types:Tribal Enchantment Elemental
+Types:Kindred Enchantment Elemental
 T:Mode$ Drawn | ValidCard$ Card.YouCtrl | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigPutCounter | TriggerDescription$ Whenever you draw a card, you may put a hoofprint counter on CARDNAME.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ HOOFPRINT | CounterNum$ 1
 A:AB$ Token | Cost$ 2 W SubCounter<4/HOOFPRINT> | TokenAmount$ 1 | TokenScript$ w_4_4_elemental_flying | TokenOwner$ You | PlayerTurn$ True | SpellDescription$ Create a 4/4 white Elemental creature token with flying. Activate only during your turn.

--- a/forge-gui/res/cardsfolder/h/hunting_triad.txt
+++ b/forge-gui/res/cardsfolder/h/hunting_triad.txt
@@ -1,6 +1,6 @@
 Name:Hunting Triad
 ManaCost:3 G
-Types:Tribal Sorcery Elf
+Types:Kindred Sorcery Elf
 A:SP$ Token | Cost$ 3 G | TokenAmount$ 3 | TokenScript$ g_1_1_elf_warrior | TokenOwner$ You | SpellDescription$ Create three 1/1 green Elf Warrior creature tokens.
 K:Reinforce:3:3 G
 DeckHas:Ability$Counters|Token

--- a/forge-gui/res/cardsfolder/k/knowledge_exploitation.txt
+++ b/forge-gui/res/cardsfolder/k/knowledge_exploitation.txt
@@ -1,6 +1,6 @@
 Name:Knowledge Exploitation
 ManaCost:5 U U
-Types:Tribal Sorcery Rogue
+Types:Kindred Sorcery Rogue
 K:Prowl:3 U
 A:SP$ ChangeZone | Cost$ 5 U U | ValidTgts$ Opponent | Origin$ Library | Destination$ Library | ChangeType$ Instant,Sorcery | ChangeNum$ 1 | RememberChanged$ True | Reveal$ True | Shuffle$ False | DefinedPlayer$ Targeted | Chooser$ You | SubAbility$ DBPlay | StackDescription$ Search {p:Targeted}'s library for an instant or sorcery card | SpellDescription$ Search target opponent's library for an instant or sorcery card. You may cast that card without paying its mana cost. Then that player shuffles.
 SVar:DBPlay:DB$ Play | Defined$ Remembered | Controller$ You | WithoutManaCost$ True | ValidSA$ Spell | Optional$ True | SubAbility$ DBShuffle

--- a/forge-gui/res/cardsfolder/l/largepox.txt
+++ b/forge-gui/res/cardsfolder/l/largepox.txt
@@ -1,18 +1,18 @@
 Name:Largepox
 ManaCost:B B B B
 Types:Sorcery
-A:SP$ Discard | NumCards$ 1 | Mode$ TgtChoose | Defined$ Player | SubAbility$ DBLoseLife | SpellDescription$ Each player discards a card, then loses 1 life, then sacrifices an artifact, a creature, an enchantment, a land, a planeswalker, and a tribal permanent, then exiles a card from their graveyard, then puts the top card of their library into their graveyard, then removes a counter from a permanent they control, then gets a poison counter.
+A:SP$ Discard | NumCards$ 1 | Mode$ TgtChoose | Defined$ Player | SubAbility$ DBLoseLife | SpellDescription$ Each player discards a card, then loses 1 life, then sacrifices an artifact, a creature, an enchantment, a land, a planeswalker, and a kindred permanent, then exiles a card from their graveyard, then puts the top card of their library into their graveyard, then removes a counter from a permanent they control, then gets a poison counter.
 SVar:DBLoseLife:DB$ LoseLife | Defined$ Player | LifeAmount$ 1 | AILifeThreshold$ 1 | SubAbility$ DBSacArtifact
 SVar:DBSacArtifact:DB$ Sacrifice | SacValid$ Artifact | Defined$ Player | SubAbility$ DBSacCreature
 SVar:DBSacCreature:DB$ Sacrifice | SacValid$ Creature | Defined$ Player | SubAbility$ DBSacEnchantment
 SVar:DBSacEnchantment:DB$ Sacrifice | SacValid$ Enchantment | Defined$ Player | SubAbility$ DBSacLand
 SVar:DBSacLand:DB$ Sacrifice | SacValid$ Land | Defined$ Player | SubAbility$ DBSacPlaneswalker
-SVar:DBSacPlaneswalker:DB$ Sacrifice | SacValid$ Planeswalker | Defined$ Player | SubAbility$ DBSacTribal
-SVar:DBSacTribal:DB$ Sacrifice | SacValid$ Tribal | Defined$ Player | SubAbility$ DBGraveyard
+SVar:DBSacPlaneswalker:DB$ Sacrifice | SacValid$ Planeswalker | Defined$ Player | SubAbility$ DBSacKindred
+SVar:DBSacKindred:DB$ Sacrifice | SacValid$ Kindred | Defined$ Player | SubAbility$ DBGraveyard
 SVar:DBGraveyard:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | ChangeType$ Card | DefinedPlayer$ Player | Mandatory$ True | ChangeType$ Card | ChangeNum$ 1 | Hidden$ True | SubAbility$ DBMill
 SVar:DBMill:DB$ Mill | NumCards$ 1 | Defined$ Player | SubAbility$ DBCounter
 SVar:DBCounter:DB$ RepeatEach | RepeatPlayers$ Player | RepeatSubAbility$ DBChooseCounter | SubAbility$ DBPoison
 SVar:DBChooseCounter:DB$ ChooseCard | Choices$ Permanent.RememberedPlayerCtrl+HasCounters | Defined$ Remembered | Amount$ 1 | Mandatory$ True | SubAbility$ DBOneCounter
 SVar:DBOneCounter:DB$ RemoveCounter | Defined$ ChosenCard | CounterNum$ 1 | CounterType$ Any
 SVar:DBPoison:DB$ Poison | Defined$ Player | Num$ 1
-Oracle:Each player discards a card, then loses 1 life, then sacrifices an artifact, a creature, an enchantment, a land, a planeswalker, and a tribal permanent, then exiles a card from their graveyard, then puts the top card of their library into their graveyard, then removes a counter from a permanent they control, then gets a poison counter.
+Oracle:Each player discards a card, then loses 1 life, then sacrifices an artifact, a creature, an enchantment, a land, a planeswalker, and a kindred permanent, then exiles a card from their graveyard, then puts the top card of their library into their graveyard, then removes a counter from a permanent they control, then gets a poison counter.

--- a/forge-gui/res/cardsfolder/l/lignify.txt
+++ b/forge-gui/res/cardsfolder/l/lignify.txt
@@ -1,6 +1,6 @@
 Name:Lignify
 ManaCost:1 G
-Types:Tribal Enchantment Treefolk Aura
+Types:Kindred Enchantment Treefolk Aura
 K:Enchant creature
 A:SP$ Attach | Cost$ 1 G | ValidTgts$ Creature | AILogic$ Curse
 S:Mode$ Continuous | Affected$ Card.EnchantedBy | SetPower$ 0 | SetToughness$ 4 | AddType$ Treefolk | RemoveCreatureTypes$ True | RemoveAllAbilities$ True | Description$ Enchanted creature is a Treefolk with base power and toughness 0/4 and loses all abilities.

--- a/forge-gui/res/cardsfolder/m/merrow_commerce.txt
+++ b/forge-gui/res/cardsfolder/m/merrow_commerce.txt
@@ -1,6 +1,6 @@
 Name:Merrow Commerce
 ManaCost:1 U
-Types:Tribal Enchantment Merfolk
+Types:Kindred Enchantment Merfolk
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ UntapMerfolk | TriggerDescription$ At the beginning of your end step, untap all Merfolk you control.
 SVar:UntapMerfolk:DB$ UntapAll | ValidCards$ Merfolk.YouCtrl | SpellDescription$ Untap all Merfolk you control.
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/m/militias_pride.txt
+++ b/forge-gui/res/cardsfolder/m/militias_pride.txt
@@ -1,6 +1,6 @@
 Name:Militia's Pride
 ManaCost:1 W
-Types:Tribal Enchantment Kithkin
+Types:Kindred Enchantment Kithkin
 T:Mode$ Attacks | ValidCard$ Creature.nonToken+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever a nontoken creature you control attacks, you may pay {W}. If you do, create a 1/1 white Kithkin Soldier creature token that's tapped and attacking.
 SVar:TrigToken:AB$Token | Cost$ W | TokenAmount$ 1 | TokenScript$ w_1_1_kithkin_soldier | TokenOwner$ You | TokenTapped$ True | TokenAttacking$ True
 Oracle:Whenever a nontoken creature you control attacks, you may pay {W}. If you do, create a 1/1 white Kithkin Soldier creature token that's tapped and attacking.

--- a/forge-gui/res/cardsfolder/m/mirror_golem.txt
+++ b/forge-gui/res/cardsfolder/m/mirror_golem.txt
@@ -8,20 +8,22 @@ T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | Static$ True | Va
 SVar:DBCleanup:DB$ Cleanup | ClearImprinted$ True
 T:Mode$ ChangesZone | ValidCard$ Card.IsImprinted+ExiledWithSourceLKI | Origin$ Exile | Execute$ DBForget | Static$ True
 SVar:DBForget:DB$ Pump | ForgetImprinted$ TriggeredCard
-S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Protection:Creature | CheckSVar$ CheckCreature | SVarCompare$ GE1 | Description$ CARDNAME has protection from each of the exiled card's card types. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and tribal are card types.)
+S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Protection:Creature | CheckSVar$ CheckCreature | SVarCompare$ GE1 | Description$ CARDNAME has protection from each of the exiled card's card types. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
 S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Protection:Land | CheckSVar$ CheckLand | SVarCompare$ GE1
 S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Protection:Enchantment | CheckSVar$ CheckEnchantment | SVarCompare$ GE1
 S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Protection:Artifact | CheckSVar$ CheckArtifact | SVarCompare$ GE1
 S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Protection:Instant | CheckSVar$ CheckInstant | SVarCompare$ GE1
 S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Protection:Sorcery | CheckSVar$ CheckSorcery | SVarCompare$ GE1
 S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Protection:Planeswalker | CheckSVar$ CheckPlaneswalker | SVarCompare$ GE1
-S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Protection:Tribal | CheckSVar$ CheckTribal | SVarCompare$ GE1
+S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Protection:Kindred | CheckSVar$ CheckKindred | SVarCompare$ GE1
+S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Protection:Battle | CheckSVar$ CheckBattle | SVarCompare$ GE1
 SVar:CheckCreature:Imprinted$Valid Creature
 SVar:CheckArtifact:Imprinted$Valid Artifact
 SVar:CheckEnchantment:Imprinted$Valid Enchantment
 SVar:CheckInstant:Imprinted$Valid Instant
 SVar:CheckSorcery:Imprinted$Valid Sorcery
 SVar:CheckPlaneswalker:Imprinted$Valid Planeswalker
-SVar:CheckTribal:Imprinted$Valid Tribal
+SVar:CheckKindred:Imprinted$Valid Kindred
+SVar:CheckBattle:Imprinted$Valid Battle
 SVar:CheckLand:Imprinted$Valid Land
-Oracle:Imprint — When Mirror Golem enters the battlefield, you may exile target card from a graveyard.\nMirror Golem has protection from each of the exiled card's card types. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and tribal are card types.)
+Oracle:Imprint — When Mirror Golem enters the battlefield, you may exile target card from a graveyard.\nMirror Golem has protection from each of the exiled card's card types. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)

--- a/forge-gui/res/cardsfolder/m/mirror_golem.txt
+++ b/forge-gui/res/cardsfolder/m/mirror_golem.txt
@@ -8,7 +8,7 @@ T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | Static$ True | Va
 SVar:DBCleanup:DB$ Cleanup | ClearImprinted$ True
 T:Mode$ ChangesZone | ValidCard$ Card.IsImprinted+ExiledWithSourceLKI | Origin$ Exile | Execute$ DBForget | Static$ True
 SVar:DBForget:DB$ Pump | ForgetImprinted$ TriggeredCard
-S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Protection:Creature | CheckSVar$ CheckCreature | SVarCompare$ GE1 | Description$ CARDNAME has protection from each of the exiled card's card types. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
+S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Protection:Creature | CheckSVar$ CheckCreature | SVarCompare$ GE1 | Description$ CARDNAME has protection from each of the exiled card's card types. (Artifact, battle, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
 S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Protection:Land | CheckSVar$ CheckLand | SVarCompare$ GE1
 S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Protection:Enchantment | CheckSVar$ CheckEnchantment | SVarCompare$ GE1
 S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Protection:Artifact | CheckSVar$ CheckArtifact | SVarCompare$ GE1
@@ -26,4 +26,4 @@ SVar:CheckPlaneswalker:Imprinted$Valid Planeswalker
 SVar:CheckKindred:Imprinted$Valid Kindred
 SVar:CheckBattle:Imprinted$Valid Battle
 SVar:CheckLand:Imprinted$Valid Land
-Oracle:Imprint — When Mirror Golem enters the battlefield, you may exile target card from a graveyard.\nMirror Golem has protection from each of the exiled card's card types. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
+Oracle:Imprint — When Mirror Golem enters the battlefield, you may exile target card from a graveyard.\nMirror Golem has protection from each of the exiled card's card types. (Artifact, battle, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)

--- a/forge-gui/res/cardsfolder/m/mirror_golem.txt
+++ b/forge-gui/res/cardsfolder/m/mirror_golem.txt
@@ -8,7 +8,7 @@ T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | Static$ True | Va
 SVar:DBCleanup:DB$ Cleanup | ClearImprinted$ True
 T:Mode$ ChangesZone | ValidCard$ Card.IsImprinted+ExiledWithSourceLKI | Origin$ Exile | Execute$ DBForget | Static$ True
 SVar:DBForget:DB$ Pump | ForgetImprinted$ TriggeredCard
-S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Protection:Creature | CheckSVar$ CheckCreature | SVarCompare$ GE1 | Description$ CARDNAME has protection from each of the exiled card's card types. (Artifact, battle, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
+S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Protection:Creature | CheckSVar$ CheckCreature | SVarCompare$ GE1 | Description$ CARDNAME has protection from each of the exiled card's card types. (Artifact, battle, creature, enchantment, instant, kindred, land, planeswalker, and sorcery are card types.)
 S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Protection:Land | CheckSVar$ CheckLand | SVarCompare$ GE1
 S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Protection:Enchantment | CheckSVar$ CheckEnchantment | SVarCompare$ GE1
 S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Protection:Artifact | CheckSVar$ CheckArtifact | SVarCompare$ GE1

--- a/forge-gui/res/cardsfolder/m/mirror_golem.txt
+++ b/forge-gui/res/cardsfolder/m/mirror_golem.txt
@@ -26,4 +26,4 @@ SVar:CheckPlaneswalker:Imprinted$Valid Planeswalker
 SVar:CheckKindred:Imprinted$Valid Kindred
 SVar:CheckBattle:Imprinted$Valid Battle
 SVar:CheckLand:Imprinted$Valid Land
-Oracle:Imprint — When Mirror Golem enters the battlefield, you may exile target card from a graveyard.\nMirror Golem has protection from each of the exiled card's card types. (Artifact, battle, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
+Oracle:Imprint — When Mirror Golem enters the battlefield, you may exile target card from a graveyard.\nMirror Golem has protection from each of the exiled card's card types. (Artifact, battle, creature, enchantment, instant, kindred, land, planeswalker, and sorcery are card types.)

--- a/forge-gui/res/cardsfolder/m/morsel_theft.txt
+++ b/forge-gui/res/cardsfolder/m/morsel_theft.txt
@@ -1,6 +1,6 @@
 Name:Morsel Theft
 ManaCost:2 B B
-Types:Tribal Sorcery Rogue
+Types:Kindred Sorcery Rogue
 K:Prowl:1 B
 A:SP$ LoseLife | Cost$ 2 B B | ValidTgts$ Player | TgtPrompt$ Select a player | LifeAmount$ 3 | SubAbility$ DBGainLife | SpellDescription$ Target player loses 3 life and you gain 3 life. If CARDNAME's prowl cost was paid, draw a card.
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 3 | SubAbility$ DBDraw

--- a/forge-gui/res/cardsfolder/n/nameless_inversion.txt
+++ b/forge-gui/res/cardsfolder/n/nameless_inversion.txt
@@ -1,6 +1,6 @@
 Name:Nameless Inversion
 ManaCost:1 B
-Types:Tribal Instant Shapeshifter
+Types:Kindred Instant Shapeshifter
 K:Changeling
 A:SP$ Pump | Cost$ 1 B | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +3 | NumDef$ -3 | IsCurse$ True | SubAbility$ DBAnimate | SpellDescription$ Target creature gets +3/-3 and loses all creature types until end of turn.
 SVar:DBAnimate:DB$ Animate | Defined$ Targeted | Types$ Creature | RemoveCreatureTypes$ True

--- a/forge-gui/res/cardsfolder/n/noggin_whack.txt
+++ b/forge-gui/res/cardsfolder/n/noggin_whack.txt
@@ -1,6 +1,6 @@
 Name:Noggin Whack
 ManaCost:2 B B
-Types:Tribal Sorcery Rogue
+Types:Kindred Sorcery Rogue
 K:Prowl:1 B
 A:SP$ Discard | Cost$ 2 B B | ValidTgts$ Player | Mode$ RevealYouChoose | RevealNumber$ 3 | NumCards$ 2 | SpellDescription$ Target player reveals three cards from their hand. You choose two of them. That player discards those cards.
 DeckNeeds:Type$Rogue

--- a/forge-gui/res/cardsfolder/n/not_of_this_world.txt
+++ b/forge-gui/res/cardsfolder/n/not_of_this_world.txt
@@ -1,6 +1,6 @@
 Name:Not of This World
 ManaCost:7
-Types:Tribal Instant Eldrazi
+Types:Kindred Instant Eldrazi
 S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ CostReduction | Relative$ True | EffectZone$ All | Description$ This spell costs {7} less to cast if it targets a spell or ability that targets a creature you control with power 7 or greater.
 A:SP$ Counter | Cost$ 7 | TargetType$ Spell,Activated,Triggered | TgtPrompt$ Select target spell or ability that targets a permanent you control | ValidTgts$ Card,Emblem | TargetValidTargeting$ Permanent.YouCtrl+inRealZoneBattlefield | SpellDescription$ Counter target spell or ability that targets a permanent you control.
 SVar:CostReduction:Count$Compare CheckTgt GE1.7.0

--- a/forge-gui/res/cardsfolder/n/notorious_throng.txt
+++ b/forge-gui/res/cardsfolder/n/notorious_throng.txt
@@ -1,6 +1,6 @@
 Name:Notorious Throng
 ManaCost:3 U
-Types:Tribal Sorcery Rogue
+Types:Kindred Sorcery Rogue
 K:Prowl:5 U
 A:SP$ Token | Cost$ 3 U | TokenAmount$ X | TokenScript$ b_1_1_faerie_rogue_flying | TokenOwner$ You | SubAbility$ DBTakeTurn | SpellDescription$ Create X 1/1 black Faerie Rogue creature tokens with flying, where X is the damage dealt to your opponents this turn. If CARDNAME's prowl cost was paid, take an extra turn after this one.
 SVar:DBTakeTurn:DB$ AddTurn | NumTurns$ 1 | ConditionDefined$ Self | ConditionPresent$ Card.prowled

--- a/forge-gui/res/cardsfolder/o/obsidian_battle_axe.txt
+++ b/forge-gui/res/cardsfolder/o/obsidian_battle_axe.txt
@@ -1,6 +1,6 @@
 Name:Obsidian Battle-Axe
 ManaCost:3
-Types:Tribal Artifact Warrior Equipment
+Types:Kindred Artifact Warrior Equipment
 K:Equip:3
 S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 2 | AddToughness$ 1 | AddKeyword$ Haste | Description$ Equipped creature gets +2/+1 and has haste.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.Warrior | TriggerZones$ Battlefield | Execute$ TrigAttach | OptionalDecider$ You | TriggerDescription$ Whenever a Warrior creature enters the battlefield, you may attach CARDNAME to it.

--- a/forge-gui/res/cardsfolder/p/peppersmoke.txt
+++ b/forge-gui/res/cardsfolder/p/peppersmoke.txt
@@ -1,6 +1,6 @@
 Name:Peppersmoke
 ManaCost:B
-Types:Tribal Instant Faerie
+Types:Kindred Instant Faerie
 A:SP$ Pump | Cost$ B | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ -1 | NumDef$ -1 | IsCurse$ True | SubAbility$ DBDraw | SpellDescription$ Target creature gets -1/-1 until end of turn. If you control a Faerie, draw a card.
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | ConditionPresent$ Faerie.YouCtrl | ConditionCompare$ GE1 | ConditionDescription$ If you control a Faerie,
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/p/prowess_of_the_fair.txt
+++ b/forge-gui/res/cardsfolder/p/prowess_of_the_fair.txt
@@ -1,6 +1,6 @@
 Name:Prowess of the Fair
 ManaCost:1 B
-Types:Tribal Enchantment Elf
+Types:Kindred Enchantment Elf
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Elf.nonToken+Other+YouOwn | TriggerZones$ Battlefield | Execute$ TrigToken | OptionalDecider$ You | TriggerDescription$ Whenever another nontoken Elf is put into your graveyard from the battlefield, you may create a 1/1 green Elf Warrior creature token.
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ g_1_1_elf_warrior | TokenOwner$ You
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/r/reach_of_branches.txt
+++ b/forge-gui/res/cardsfolder/r/reach_of_branches.txt
@@ -1,6 +1,6 @@
 Name:Reach of Branches
 ManaCost:4 G
-Types:Tribal Instant Treefolk
+Types:Kindred Instant Treefolk
 A:SP$ Token | Cost$ 4 G | TokenAmount$ 1 | TokenScript$ g_2_5_treefolk_shaman | TokenOwner$ You | SpellDescription$ Create a 2/5 green Treefolk Shaman creature token.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Forest.YouCtrl | TriggerZones$ Graveyard | OptionalDecider$ You | Execute$ TrigReturn | TriggerDescription$ Whenever a Forest enters the battlefield under your control, you may return CARDNAME from your graveyard to your hand.
 SVar:TrigReturn:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | Defined$ Self

--- a/forge-gui/res/cardsfolder/r/rebellion_of_the_flamekin.txt
+++ b/forge-gui/res/cardsfolder/r/rebellion_of_the_flamekin.txt
@@ -1,6 +1,6 @@
 Name:Rebellion of the Flamekin
 ManaCost:3 R
-Types:Tribal Enchantment Elemental
+Types:Kindred Enchantment Elemental
 T:Mode$ Clashed | ValidPlayer$ You | Won$ True | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigTokenW | TriggerDescription$ Whenever you clash, you may pay {1}. If you do, create a 3/1 red Elemental Shaman creature token. If you won, that token gains haste until end of turn. (This ability triggers after the clash ends.)
 SVar:TrigTokenW:AB$Token | Cost$ 1 | TokenOwner$ You | TokenAmount$ 1 | TokenScript$ r_3_1_elemental_shaman | RememberTokens$ True | ForgetOtherRemembered$ True | SubAbility$ AdditionalPump
 SVar:AdditionalPump:DB$ PumpAll | ValidCards$ Creature.IsRemembered | KW$ Haste | SubAbility$ DBCleanup

--- a/forge-gui/res/cardsfolder/r/rootgrapple.txt
+++ b/forge-gui/res/cardsfolder/r/rootgrapple.txt
@@ -1,6 +1,6 @@
 Name:Rootgrapple
 ManaCost:4 G
-Types:Tribal Instant Treefolk
+Types:Kindred Instant Treefolk
 A:SP$ Destroy | Cost$ 4 G | ValidTgts$ Permanent.nonCreature | TgtPrompt$ Select target noncreature permanent | SubAbility$ DBDraw | SpellDescription$ Destroy target noncreature permanent. If you control a Treefolk, draw a card.
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | ConditionPresent$ Treefolk.YouCtrl | ConditionCompare$ GE1 | ConditionDescription$ If you control a Treefolk,
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/s/sages_dousing.txt
+++ b/forge-gui/res/cardsfolder/s/sages_dousing.txt
@@ -1,6 +1,6 @@
 Name:Sage's Dousing
 ManaCost:2 U
-Types:Tribal Instant Wizard
+Types:Kindred Instant Wizard
 A:SP$ Counter | Cost$ 2 U | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | UnlessCost$ 3 | SubAbility$ DBDraw | SpellDescription$ Counter target spell unless its controller pays {3}. If you control a Wizard, draw a card.
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | ConditionPresent$ Wizard.YouCtrl | ConditionCompare$ GE1 | ConditionDescription$ If you control a Wizard,
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/s/sarahs_wings.txt
+++ b/forge-gui/res/cardsfolder/s/sarahs_wings.txt
@@ -1,6 +1,6 @@
 Name:Sarah's Wings
 ManaCost:W
-Types:Tribal Instant Angel
+Types:Kindred Instant Angel
 A:SP$ Pump | Cost$ W | ValidTgts$ Creature,Player | TgtPrompt$ Select target creature or player | KW$ Flying | SubAbility$ NoDamage | SpellDescription$ Target creature or player gains flying until end of turn.
 SVar:NoDamage:DB$ Effect | ReplacementEffects$ RPrevent | EffectOwner$ TargetedPlayer | ConditionPlayerDefined$ Targeted | ConditionPlayerContains$ Targeted | SpellDescription$ (Players with flying can't be dealt damage by creatures without flying.)
 SVar:RPrevent:Event$ DamageDone | Prevent$ True | ActiveZones$ Command | ValidTarget$ You | ValidSource$ Creature.withoutFlying | Description$ Prevent all damage that would be dealt to you this turn by creatures without flying.

--- a/forge-gui/res/cardsfolder/s/shields_of_velis_vel.txt
+++ b/forge-gui/res/cardsfolder/s/shields_of_velis_vel.txt
@@ -1,6 +1,6 @@
 Name:Shields of Velis Vel
 ManaCost:W
-Types:Tribal Instant Shapeshifter
+Types:Kindred Instant Shapeshifter
 K:Changeling
 A:SP$ PumpAll | Cost$ W | ValidTgts$ Player | TgtPrompt$ Select target player | ValidCards$ Creature | NumAtt$ +0 | NumDef$ +1 | SubAbility$ DBAnimate | SpellDescription$ Creatures target player controls get +0/+1 and gain all creature types until end of turn.
 SVar:DBAnimate:DB$ AnimateAll | ValidCards$ Creature.TargetedPlayerCtrl | AddAllCreatureTypes$ True

--- a/forge-gui/res/cardsfolder/s/shifting_loyalties.txt
+++ b/forge-gui/res/cardsfolder/s/shifting_loyalties.txt
@@ -1,7 +1,7 @@
 Name:Shifting Loyalties
 ManaCost:5 U
 Types:Sorcery
-A:SP$ ExchangeControl | TargetMin$ 2 | TargetMax$ 2 | ValidTgts$ Permanent | TgtPrompt$ Select target permanents that share a permanent type | TargetsWithSameCardType$ True | SpellDescription$ Exchange control of two target permanents that share a card type.
+A:SP$ ExchangeControl | TargetMin$ 2 | TargetMax$ 2 | ValidTgts$ Permanent | TgtPrompt$ Select target permanents that share a permanent type | TargetsWithSameCardType$ True | SpellDescription$ Exchange control of two target permanents that share a card type. (Artifact, battle, creature, enchantment, kindred, land, and planeswalker are card types.)
 AI:RemoveDeck:All
 AI:RemoveDeck:Random
-Oracle:Exchange control of two target permanents that share a card type. (Artifact, creature, enchantment, land, and planeswalker are card types.)
+Oracle:Exchange control of two target permanents that share a card type. (Artifact, battle, creature, enchantment, kindred, land, and planeswalker are card types.)

--- a/forge-gui/res/cardsfolder/s/skittering_invasion.txt
+++ b/forge-gui/res/cardsfolder/s/skittering_invasion.txt
@@ -1,6 +1,6 @@
 Name:Skittering Invasion
 ManaCost:7
-Types:Tribal Sorcery Eldrazi
+Types:Kindred Sorcery Eldrazi
 A:SP$ Token | Cost$ 7 | TokenAmount$ 5 | TokenScript$ c_0_1_eldrazi_spawn_sac | TokenOwner$ You | SpellDescription$ Create five 0/1 colorless Eldrazi Spawn creature tokens. They have "Sacrifice this creature: Add {C}."
 DeckHints:Type$Eldrazi
 DeckHas:Ability$Mana.Colorless|Token

--- a/forge-gui/res/cardsfolder/s/stream_of_unconsciousness.txt
+++ b/forge-gui/res/cardsfolder/s/stream_of_unconsciousness.txt
@@ -1,6 +1,6 @@
 Name:Stream of Unconsciousness
 ManaCost:U
-Types:Tribal Instant Wizard
+Types:Kindred Instant Wizard
 A:SP$ Pump | Cost$ U | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ -4 | IsCurse$ True | SubAbility$ DBDraw | SpellDescription$ Target creature gets -4/-0 until end of turn. If you control a Wizard, draw a card.
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | ConditionPresent$ Wizard.YouCtrl | ConditionCompare$ GE1 | ConditionDescription$ If you control a Wizard,
 DeckHints:Type$Wizard

--- a/forge-gui/res/cardsfolder/s/summon_the_school.txt
+++ b/forge-gui/res/cardsfolder/s/summon_the_school.txt
@@ -1,6 +1,6 @@
 Name:Summon the School
 ManaCost:3 W
-Types:Tribal Sorcery Merfolk
+Types:Kindred Sorcery Merfolk
 A:SP$ Token | Cost$ 3 W | TokenAmount$ 2 | TokenScript$ u_1_1_merfolk_wizard | TokenOwner$ You | SpellDescription$ Create two 1/1 blue Merfolk Wizard creature tokens.
 A:AB$ ChangeZone | Cost$ tapXType<4/Merfolk> | Origin$ Graveyard | Destination$ Hand | ActivationZone$ Graveyard | SpellDescription$ Return CARDNAME from your graveyard to your hand.
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/s/surge_of_thoughtweft.txt
+++ b/forge-gui/res/cardsfolder/s/surge_of_thoughtweft.txt
@@ -1,6 +1,6 @@
 Name:Surge of Thoughtweft
 ManaCost:1 W
-Types:Tribal Instant Kithkin
+Types:Kindred Instant Kithkin
 A:SP$ PumpAll | Cost$ 1 W | ValidCards$ Creature.YouCtrl | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DBDraw | SpellDescription$ Creatures you control get +1/+1 until end of turn. If you control a Kithkin, draw a card.
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | ConditionPresent$ Kithkin.YouCtrl | ConditionCompare$ GE1 | ConditionDescription$ If you control a Kithkin,
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/t/tarfire.txt
+++ b/forge-gui/res/cardsfolder/t/tarfire.txt
@@ -1,5 +1,5 @@
 Name:Tarfire
 ManaCost:R
-Types:Tribal Instant Goblin
+Types:Kindred Instant Goblin
 A:SP$ DealDamage | Cost$ R | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to any target.
 Oracle:Tarfire deals 2 damage to any target.

--- a/forge-gui/res/cardsfolder/t/thieves_fortune.txt
+++ b/forge-gui/res/cardsfolder/t/thieves_fortune.txt
@@ -1,6 +1,6 @@
 Name:Thieves' Fortune
 ManaCost:2 U
-Types:Tribal Instant Rogue
+Types:Kindred Instant Rogue
 K:Prowl:U
 A:SP$ Dig | Cost$ 2 U | DigNum$ 4 | ChangeNum$ 1 | NoReveal$ True | SpellDescription$ Look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.
 DeckNeeds:Type$Rogue

--- a/forge-gui/res/cardsfolder/t/thornbite_staff.txt
+++ b/forge-gui/res/cardsfolder/t/thornbite_staff.txt
@@ -1,6 +1,6 @@
 Name:Thornbite Staff
 ManaCost:2
-Types:Tribal Artifact Shaman Equipment
+Types:Kindred Artifact Shaman Equipment
 K:Equip:4
 S:Mode$ Continuous | Affected$ Card.EquippedBy | AddAbility$ Damage | AddTrigger$ TrigChangeZone | AddSVar$ ThornbiteTrigUntap | Description$ Equipped creature has "{2}, {T}: This creature deals 1 damage to any target" and "Whenever a creature dies, untap this creature."
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.Shaman | TriggerZones$ Battlefield | Execute$ TrigAttach | OptionalDecider$ You | TriggerDescription$ Whenever a Shaman creature enters the battlefield, you may attach CARDNAME to it.

--- a/forge-gui/res/cardsfolder/v/veterans_armaments.txt
+++ b/forge-gui/res/cardsfolder/v/veterans_armaments.txt
@@ -1,6 +1,6 @@
 Name:Veteran's Armaments
 ManaCost:2
-Types:Tribal Artifact Soldier Equipment
+Types:Kindred Artifact Soldier Equipment
 K:Equip:2
 S:Mode$ Continuous | Affected$ Card.EquippedBy | AddTrigger$ HeroAttack & HeroBlock | AddSVar$ HeroPump & ArmamentsX | Description$ Equipped creature has "Whenever this creature attacks or blocks, it gets +1/+1 until end of turn for each attacking creature."
 SVar:HeroAttack:Mode$ Attacks | ValidCard$ Card.Self | Execute$ HeroPump | TriggerDescription$ Whenever CARDNAME attacks or blocks, it gets +1/+1 until end of turn for each attacking creature.

--- a/forge-gui/res/cardsfolder/v/vigean_intuition.txt
+++ b/forge-gui/res/cardsfolder/v/vigean_intuition.txt
@@ -1,7 +1,7 @@
 Name:Vigean Intuition
 ManaCost:3 G U
 Types:Instant
-A:SP$ ChooseType | Defined$ You | Type$ Card | SubAbility$ DBDig | SpellDescription$ Choose a card type, then reveal the top four cards of your library. Put all cards of the chosen type revealed this way into your hand and the rest into your graveyard. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and tribal are card types.)
+A:SP$ ChooseType | Defined$ You | Type$ Card | SubAbility$ DBDig | SpellDescription$ Choose a card type, then reveal the top four cards of your library. Put all cards of the chosen type revealed this way into your hand and the rest into your graveyard. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
 SVar:DBDig:DB$ Dig | DigNum$ 4 | Reveal$ True | ChangeNum$ All | ChangeValid$ Card.ChosenType | DestinationZone2$ Graveyard
 AI:RemoveDeck:All
-Oracle:Choose a card type, then reveal the top four cards of your library. Put all cards of the chosen type revealed this way into your hand and the rest into your graveyard. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and tribal are card types.)
+Oracle:Choose a card type, then reveal the top four cards of your library. Put all cards of the chosen type revealed this way into your hand and the rest into your graveyard. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)

--- a/forge-gui/res/cardsfolder/v/vigean_intuition.txt
+++ b/forge-gui/res/cardsfolder/v/vigean_intuition.txt
@@ -1,7 +1,7 @@
 Name:Vigean Intuition
 ManaCost:3 G U
 Types:Instant
-A:SP$ ChooseType | Defined$ You | Type$ Card | SubAbility$ DBDig | SpellDescription$ Choose a card type, then reveal the top four cards of your library. Put all cards of the chosen type revealed this way into your hand and the rest into your graveyard. (Artifact, battle, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
+A:SP$ ChooseType | Defined$ You | Type$ Card | SubAbility$ DBDig | SpellDescription$ Choose a card type, then reveal the top four cards of your library. Put all cards of the chosen type revealed this way into your hand and the rest into your graveyard. (Artifact, battle, creature, enchantment, instant, kindred, land, planeswalker, and sorcery are card types.)
 SVar:DBDig:DB$ Dig | DigNum$ 4 | Reveal$ True | ChangeNum$ All | ChangeValid$ Card.ChosenType | DestinationZone2$ Graveyard
 AI:RemoveDeck:All
-Oracle:Choose a card type, then reveal the top four cards of your library. Put all cards of the chosen type revealed this way into your hand and the rest into your graveyard. (Artifact, battle, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
+Oracle:Choose a card type, then reveal the top four cards of your library. Put all cards of the chosen type revealed this way into your hand and the rest into your graveyard. (Artifact, battle, creature, enchantment, instant, kindred, land, planeswalker, and sorcery are card types.)

--- a/forge-gui/res/cardsfolder/v/vigean_intuition.txt
+++ b/forge-gui/res/cardsfolder/v/vigean_intuition.txt
@@ -1,7 +1,7 @@
 Name:Vigean Intuition
 ManaCost:3 G U
 Types:Instant
-A:SP$ ChooseType | Defined$ You | Type$ Card | SubAbility$ DBDig | SpellDescription$ Choose a card type, then reveal the top four cards of your library. Put all cards of the chosen type revealed this way into your hand and the rest into your graveyard. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
+A:SP$ ChooseType | Defined$ You | Type$ Card | SubAbility$ DBDig | SpellDescription$ Choose a card type, then reveal the top four cards of your library. Put all cards of the chosen type revealed this way into your hand and the rest into your graveyard. (Artifact, battle, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
 SVar:DBDig:DB$ Dig | DigNum$ 4 | Reveal$ True | ChangeNum$ All | ChangeValid$ Card.ChosenType | DestinationZone2$ Graveyard
 AI:RemoveDeck:All
-Oracle:Choose a card type, then reveal the top four cards of your library. Put all cards of the chosen type revealed this way into your hand and the rest into your graveyard. (Artifact, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)
+Oracle:Choose a card type, then reveal the top four cards of your library. Put all cards of the chosen type revealed this way into your hand and the rest into your graveyard. (Artifact, battle, creature, enchantment, instant, land, planeswalker, sorcery, and kindred are card types.)

--- a/forge-gui/res/cardsfolder/v/violet_pall.txt
+++ b/forge-gui/res/cardsfolder/v/violet_pall.txt
@@ -1,6 +1,6 @@
 Name:Violet Pall
 ManaCost:4 B
-Types:Tribal Instant Faerie
+Types:Kindred Instant Faerie
 A:SP$ Destroy | Cost$ 4 B | ValidTgts$ Creature.nonBlack | TgtPrompt$ Select target nonblack creature | SubAbility$ DBToken | SpellDescription$ Destroy target nonblack creature. Create a 1/1 black Faerie Rogue creature token with flying.
 SVar:DBToken:DB$ Token | TokenAmount$ 1 | TokenScript$ b_1_1_faerie_rogue_flying | TokenOwner$ You
 Oracle:Destroy target nonblack creature. Create a 1/1 black Faerie Rogue creature token with flying.

--- a/forge-gui/res/cardsfolder/w/warren_weirding.txt
+++ b/forge-gui/res/cardsfolder/w/warren_weirding.txt
@@ -1,6 +1,6 @@
 Name:Warren Weirding
 ManaCost:1 B
-Types:Tribal Sorcery Goblin
+Types:Kindred Sorcery Goblin
 A:SP$ Sacrifice | Cost$ 1 B | ValidTgts$ Player | SacValid$ Creature | SacMessage$ Creature | RememberSacrificed$ True | SubAbility$ DBToken | SpellDescription$ Target player sacrifices a creature. If a Goblin is sacrificed this way, that player creates two 1/1 black Goblin Rogue creature tokens, and those tokens gain haste until end of turn.
 SVar:DBToken:DB$ Token | ConditionDefined$ Remembered | ConditionPresent$ Card.Goblin | ConditionCompare$ GE1 | TokenAmount$ 2 | TokenScript$ b_1_1_goblin_rogue | TokenOwner$ Targeted | RememberTokens$ True | ForgetOtherRemembered$ True | SubAbility$ AdditionalPump
 SVar:AdditionalPump:DB$ PumpAll | ValidCards$ Creature.IsRemembered | KW$ Haste | SubAbility$ DBCleanup

--- a/forge-gui/res/cardsfolder/w/wings_of_velis_vel.txt
+++ b/forge-gui/res/cardsfolder/w/wings_of_velis_vel.txt
@@ -1,6 +1,6 @@
 Name:Wings of Velis Vel
 ManaCost:1 U
-Types:Tribal Instant Shapeshifter
+Types:Kindred Instant Shapeshifter
 K:Changeling
 A:SP$ Animate | Cost$ 1 U | ValidTgts$ Creature | TgtPrompt$ Select target creature | Power$ 4 | Toughness$ 4 | Keywords$ Flying | AddAllCreatureTypes$ True | SpellDescription$ Until end of turn, target creature has base power and toughness 4/4, gains all creature types, and gains flying.
 AI:RemoveDeck:All

--- a/forge-gui/src/main/java/forge/itemmanager/GroupDef.java
+++ b/forge-gui/src/main/java/forge/itemmanager/GroupDef.java
@@ -106,7 +106,7 @@ public enum GroupDef {
             }),
 
     CARD_TYPE("lblType",
-            new String[] { "Planeswalker", "Creature", "Sorcery", "Instant", "Artifact", "Enchantment", "Land", "Tribal instant", "Battle" },
+            new String[] { "Planeswalker", "Creature", "Sorcery", "Instant", "Artifact", "Enchantment", "Land", "Kindred instant", "Battle" },
             new Function<Integer, ColumnDef>() {
                 @Override
                 public ColumnDef apply(final Integer groupIndex) {
@@ -127,7 +127,7 @@ public enum GroupDef {
                         if (type.isCreature()) {
                             return 1;
                         }
-                        if (type.isTribal() && type.isInstant()) {
+                        if (type.isKindred() && type.isInstant()) {
                             return 7;
                         }
                         if (type.isInstant()) {

--- a/forge-gui/src/main/java/forge/itemmanager/GroupDef.java
+++ b/forge-gui/src/main/java/forge/itemmanager/GroupDef.java
@@ -106,7 +106,7 @@ public enum GroupDef {
             }),
 
     CARD_TYPE("lblType",
-            new String[] { "Planeswalker", "Creature", "Sorcery", "Instant", "Artifact", "Enchantment", "Land", "Kindred instant", "Battle" },
+            new String[] { "Planeswalker", "Creature", "Sorcery", "Instant", "Artifact", "Enchantment", "Land", "Battle" },
             new Function<Integer, ColumnDef>() {
                 @Override
                 public ColumnDef apply(final Integer groupIndex) {
@@ -127,9 +127,6 @@ public enum GroupDef {
                         if (type.isCreature()) {
                             return 1;
                         }
-                        if (type.isKindred() && type.isInstant()) {
-                            return 7;
-                        }
                         if (type.isInstant()) {
                             return 3;
                         }
@@ -143,7 +140,7 @@ public enum GroupDef {
                             return 5;
                         }
                         if (type.isBattle()) {
-                            return 8;
+                            return 7;
                         }
                         if (type.isLand()) {
                             return 6;


### PR DESCRIPTION
Looked like a simple enough case of search and replace. I left the translations alone to be done at a later date by those more knowledgeable than me. I also didn't touch `mtg-data.txt` which I presume will also be updated later. The remainder of 'tribal' instances are deck names, descriptions of decks and puzzles, etc., thus not relevant.

**Other fixes**
- Updated [Mirror Golem](https://scryfall.com/card/mrd/208/mirror-golem) to reflect the existence of battles.
- [Aminatou's Augury](https://scryfall.com/card/cmm/73/aminatous-augury) had its `Effect`'s `PlayTr` static ability referred to by both the lines for kindred and battle. Disambiguated between the two.
- ~My only conundrum is whether the reminder text on cards like [Holistic Wisdom](https://scryfall.com/card/ody/243/holistic-wisdom) should be updated to include a mention to battles.~ 
‣ Might as well then. Alphabetizing the order in [Largepox](https://scryfall.com/card/cmb2/44/largepox) will probably best wait for the Oracle update (if it happens at all).
- On `GroupDef.java`: Removed "Kindred instant" as a "group by: Type" category on the Card Catalog as it was manifestly out of place.