### PR TITLE
Fixing Vexyr, Ich-Tekik's Heir triggering from library

### DIFF
--- a/forge-gui/res/cardsfolder/v/vexyr_ich_tekiks_heir.txt
+++ b/forge-gui/res/cardsfolder/v/vexyr_ich_tekiks_heir.txt
@@ -2,8 +2,9 @@ Name:Vexyr, Ich-Tekik's Heir
 ManaCost:G W U
 Types:Legendary Creature Phyrexian Artificer
 PT:3/4
-T:Mode$ SeekAll | ValidPlayer$ You | Execute$ TrigToken | TriggerDescription$ Whenever you seek one or more cards, create a 3/3 colorless Phyrexian Golem artifact creature token.
+T:Mode$ SeekAll | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever you seek one or more cards, create a 3/3 colorless Phyrexian Golem artifact creature token.
 SVar:TrigToken:DB$ Token | TokenScript$ c_3_3_a_phyrexian_golem
 S:Mode$ Continuous | Affected$ Golem.YouCtrl | AddKeyword$ Vigilance | Description$ Golems you control have vigilance.
+DeckHas:Ability$Token & Type$Golem
 DeckHints:Type$Golem
 Oracle:Whenever you seek one or more cards, create a 3/3 colorless Phyrexian Golem artifact creature token.\nGolems you control have vigilance.


### PR DESCRIPTION
Closes https://github.com/Card-Forge/forge/issues/5192 . 
As described in the bug report, a missing `TriggerZones$ Battlefield` parameter allowed the card to trigger from anywhere. That is now resolved. While I was at it, I added relevant deckbuilding tags.