### PR TITLE
Incidental cleanup pass #1

### DIFF
--- a/forge-gui/res/cardsfolder/a/aeve_progenitor_ooze.txt
+++ b/forge-gui/res/cardsfolder/a/aeve_progenitor_ooze.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature Ooze
 PT:2/2
 K:Storm
 S:Mode$ Continuous | Affected$ Card.token+Self | RemoveType$ Legendary | Description$ CARDNAME isn't legendary if it's a token.
-K:etbCounter:P1P1:X:no condition:NICKNAME enters the battlefield with a +1/+1 counter on it for each other Ooze you control.
+K:etbCounter:P1P1:X:no Condition:NICKNAME enters the battlefield with a +1/+1 counter on it for each other Ooze you control.
 SVar:X:Count$LastStateBattlefield Ooze.YouCtrl+Other
 DeckHas:Ability$Counters
 Oracle:Storm (When you cast this spell, copy it for each spell cast before it this turn. Copies become tokens.)\nAeve, Progenitor Ooze isn't legendary if it's a token.\nAeve enters the battlefield with a +1/+1 counter on it for each other Ooze you control.

--- a/forge-gui/res/cardsfolder/a/ancient_imperiosaur.txt
+++ b/forge-gui/res/cardsfolder/a/ancient_imperiosaur.txt
@@ -5,7 +5,7 @@ PT:6/6
 K:Convoke
 K:Trample
 K:Ward:2
-K:etbCounter:P1P1:X:no condition:CARDNAME enters the battlefield with two +1/+1 counters on it for each creature that convoked it.
+K:etbCounter:P1P1:X:no Condition:CARDNAME enters the battlefield with two +1/+1 counters on it for each creature that convoked it.
 SVar:X:Convoked$Amount/Twice
 DeckHas:Ability$Counters
 Oracle:Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTrample, ward {2}\nAncient Imperiosaur enters the battlefield with two +1/+1 counters on it for each creature that convoked it.

--- a/forge-gui/res/cardsfolder/a/apex_hawks.txt
+++ b/forge-gui/res/cardsfolder/a/apex_hawks.txt
@@ -4,7 +4,7 @@ Types:Creature Bird
 PT:2/2
 K:Flying
 K:Multikicker:1 W
-K:etbCounter:P1P1:XKicked:no condition:CARDNAME enters the battlefield with a +1/+1 counter on it for each time it was kicked.
+K:etbCounter:P1P1:XKicked:no Condition:CARDNAME enters the battlefield with a +1/+1 counter on it for each time it was kicked.
 SVar:XKicked:Count$TimesKicked
 DeckHas:Ability$Counters
 Oracle:Multikicker {1}{W} (You may pay an additional {1}{W} any number of times as you cast this spell.)\nFlying\nApex Hawks enters the battlefield with a +1/+1 counter on it for each time it was kicked.

--- a/forge-gui/res/cardsfolder/a/apocalypse_hydra.txt
+++ b/forge-gui/res/cardsfolder/a/apocalypse_hydra.txt
@@ -2,7 +2,7 @@ Name:Apocalypse Hydra
 ManaCost:X R G
 Types:Creature Hydra
 PT:0/0
-K:etbCounter:P1P1:Y:no condition:CARDNAME enters the battlefield with X +1/+1 counters on it. If X is 5 or more, it enters the battlefield with an additional X +1/+1 counters on it.
+K:etbCounter:P1P1:Y:no Condition:CARDNAME enters the battlefield with X +1/+1 counters on it. If X is 5 or more, it enters the battlefield with an additional X +1/+1 counters on it.
 A:AB$ DealDamage | Cost$ 1 R SubCounter<1/P1P1> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to any target.
 # This xPaid doesn't do anything, it's just needed to make Cost work properly
 SVar:X:Count$xPaid

--- a/forge-gui/res/cardsfolder/b/balduvian_warlord.txt
+++ b/forge-gui/res/cardsfolder/b/balduvian_warlord.txt
@@ -3,7 +3,7 @@ ManaCost:3 R
 Types:Creature Human Barbarian
 PT:3/2
 A:AB$ RemoveFromCombat | Cost$ T | ActivationPhases$ Declare Blockers | ValidTgts$ Creature.blocking | Defined$ Targeted | UnblockCreaturesBlockedOnlyBy$ Targeted | SubAbility$ ChooseAttacker | SpellDescription$ Remove target blocking creature from combat. Creatures it was blocking that hadn't become blocked by another creature this combat become unblocked.
-SVar:ChooseAttacker:DB$ ChooseCard | Defined$ You | Choices$ Creature.attacking | ChoiceTitle$ Choose an attacker to block | Mandatory$ True | SubAbility$ Block | SpellDescriptions$ None | StackDescription$ None
+SVar:ChooseAttacker:DB$ ChooseCard | Defined$ You | Choices$ Creature.attacking | ChoiceTitle$ Choose an attacker to block | Mandatory$ True | SubAbility$ Block | SpellDescription$ None | StackDescription$ None
 SVar:Block:DB$ Block | DefinedAttacker$ ChosenCard | DefinedBlocker$ ParentTarget | SpellDescription$ Then it blocks an attacking creature of your choice. Activate only during the declare blockers step. | StackDescription$ SpellDescription | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearChosenCard$ True
 Oracle:{T}: Remove target blocking creature from combat. Creatures it was blocking that hadn't become blocked by another creature this combat become unblocked, then it blocks an attacking creature of your choice. Activate only during the declare blockers step.

--- a/forge-gui/res/cardsfolder/b/balduvian_warlord.txt
+++ b/forge-gui/res/cardsfolder/b/balduvian_warlord.txt
@@ -2,8 +2,8 @@ Name:Balduvian Warlord
 ManaCost:3 R
 Types:Creature Human Barbarian
 PT:3/2
-A:AB$ RemoveFromCombat | Cost$ T | ActivationPhases$ Declare Blockers | ValidTgts$ Creature.blocking | Defined$ Targeted | UnblockCreaturesBlockedOnlyBy$ Targeted | SubAbility$ ChooseAttacker | SpellDescription$ Remove target blocking creature from combat. Creatures it was blocking that hadn't become blocked by another creature this combat become unblocked.
-SVar:ChooseAttacker:DB$ ChooseCard | Defined$ You | Choices$ Creature.attacking | ChoiceTitle$ Choose an attacker to block | Mandatory$ True | SubAbility$ Block | SpellDescription$ None | StackDescription$ None
+A:AB$ RemoveFromCombat | Cost$ T | ActivationPhases$ Declare Blockers | ValidTgts$ Creature.blocking | TgtPrompt$ Select target blocking creature | Defined$ Targeted | UnblockCreaturesBlockedOnlyBy$ Targeted | SubAbility$ ChooseAttacker | SpellDescription$ Remove target blocking creature from combat. Creatures it was blocking that hadn't become blocked by another creature this combat become unblocked.
+SVar:ChooseAttacker:DB$ ChooseCard | Defined$ You | Choices$ Creature.attacking | ChoiceTitle$ Choose an attacker to block | Mandatory$ True | SubAbility$ Block | StackDescription$ None
 SVar:Block:DB$ Block | DefinedAttacker$ ChosenCard | DefinedBlocker$ ParentTarget | SpellDescription$ Then it blocks an attacking creature of your choice. Activate only during the declare blockers step. | StackDescription$ SpellDescription | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearChosenCard$ True
 Oracle:{T}: Remove target blocking creature from combat. Creatures it was blocking that hadn't become blocked by another creature this combat become unblocked, then it blocks an attacking creature of your choice. Activate only during the declare blockers step.

--- a/forge-gui/res/cardsfolder/b/banquet_guests.txt
+++ b/forge-gui/res/cardsfolder/b/banquet_guests.txt
@@ -4,7 +4,7 @@ Types:Creature Halfling Citizen
 PT:0/0
 K:Affinity:Food
 K:Trample
-K:etbCounter:P1P1:Y
+K:etbCounter:P1P1:Y:no Condition:CARDNAME enters the battlefield with twice X +1/+1 counters on it.
 SVar:X:Count$xPaid
 SVar:Y:SVar$X/Twice
 A:AB$ Pump | Cost$ 2 Sac<1/Food> | Defined$ Self | KW$ Indestructible | SpellDescription$ CARDNAME gains indestructible until end of turn.

--- a/forge-gui/res/cardsfolder/c/cease_desist.txt
+++ b/forge-gui/res/cardsfolder/c/cease_desist.txt
@@ -1,7 +1,7 @@
 Name:Cease
 ManaCost:1 BG
 Types:Instant
-A:SP$ ChangeZone | TargetMin$ 0 | TargetMax$ 2 | TgtPrompt Select up to two target cards from a single graveyard | TargetsFromSingleZone$ True | Origin$ Graveyard | Destination$ Exile | ValidTgts$ Card | SubAbility$ DBGainLife | SpellDescription$ Exile up to two target cards from a single graveyard.
+A:SP$ ChangeZone | TargetMin$ 0 | TargetMax$ 2 | TgtPrompt$ Select up to two target cards from a single graveyard | TargetsFromSingleZone$ True | Origin$ Graveyard | Destination$ Exile | ValidTgts$ Card | SubAbility$ DBGainLife | SpellDescription$ Exile up to two target cards from a single graveyard.
 SVar:DBGainLife:DB$ GainLife | ValidTgts$ Player | LifeAmount$ 2 | SubAbility$ DBDraw | SpellDescription$ Target player gains 2 life and draws a card.
 SVar:DBDraw:DB$ Draw | Defined$ TargetedPlayer
 DeckHas:Ability$Graveyard|LifeGain

--- a/forge-gui/res/cardsfolder/c/clay_champion.txt
+++ b/forge-gui/res/cardsfolder/c/clay_champion.txt
@@ -2,7 +2,7 @@ Name:Clay Champion
 ManaCost:X 4
 Types:Artifact Creature Construct
 PT:2/2
-K:etbCounter:P1P1:GGx3:no condition:CARDNAME enters the battlefield with three +1/+1 counters on it for each {G}{G} spent to cast it.
+K:etbCounter:P1P1:GGx3:no Condition:CARDNAME enters the battlefield with three +1/+1 counters on it for each {G}{G} spent to cast it.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPutCounter | TriggerDescription$ When CARDNAME enters the battlefield, choose up to two other target creatures you control. For each {W}{W} spent to cast CARDNAME, put a +1/+1 counter on each of them.
 SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Creature.Other+YouCtrl | TgtPrompt$ Choose up to two other target creatures you control | TargetMin$ 0 | TargetMax$ 2 | CounterType$ P1P1 | CounterNum$ WW
 SVar:GG:Count$EachSpentToCast.G/HalfDown

--- a/forge-gui/res/cardsfolder/c/crowd_control_warden.txt
+++ b/forge-gui/res/cardsfolder/c/crowd_control_warden.txt
@@ -4,7 +4,7 @@ Types:Creature Centaur Soldier
 PT:4/4
 K:Disguise:3 GW GW
 K:etbCounter:P1P1:X:no Condition:As CARDNAME enters the battlefield or is turned face up, put X +1/+1 counters on it, where X is the number of other creatures you control.
-R:Event$ TurnFaceUp | ValidCard$ Card.Self | ReplaceWith$ AddCounters | ActiveZones$ Battlefield
+R:Event$ TurnFaceUp | ValidCard$ Card.Self | ReplaceWith$ AddCounters | ActiveZones$ Battlefield | Secondary$ True | Description$ As CARDNAME enters the battlefield or is turned face up, put X +1/+1 counters on it, where X is the number of other creatures you control.
 SVar:AddCounters:DB$ PutCounter | Defined$ Self | CounterNum$ X | CounterType$ P1P1
 SVar:X:Count$Valid Creature.YouCtrl+Other
 DeckHas:Ability$Counters

--- a/forge-gui/res/cardsfolder/c/crowd_control_warden.txt
+++ b/forge-gui/res/cardsfolder/c/crowd_control_warden.txt
@@ -3,8 +3,8 @@ ManaCost:3 G W
 Types:Creature Centaur Soldier
 PT:4/4
 K:Disguise:3 GW GW
-K:etbCounter:P1P1:X
-R:Event$ TurnFaceUp | ValidCard$ Card.Self | ReplaceWith$ AddCounters | ActiveZones$ Battlefield | Description$ As CARDNAME enters the battlefield or is turned face up, put X +1/+1 counters on it, where X is the number of other creatures you control.
+K:etbCounter:P1P1:X:no Condition:As CARDNAME enters the battlefield or is turned face up, put X +1/+1 counters on it, where X is the number of other creatures you control.
+R:Event$ TurnFaceUp | ValidCard$ Card.Self | ReplaceWith$ AddCounters | ActiveZones$ Battlefield
 SVar:AddCounters:DB$ PutCounter | Defined$ Self | CounterNum$ X | CounterType$ P1P1
 SVar:X:Count$Valid Creature.YouCtrl+Other
 DeckHas:Ability$Counters

--- a/forge-gui/res/cardsfolder/c/cult_conscript.txt
+++ b/forge-gui/res/cardsfolder/c/cult_conscript.txt
@@ -3,7 +3,7 @@ ManaCost:B
 Types:Creature Skeleton Warrior
 PT:2/1
 K:CARDNAME enters the battlefield tapped.
-A:AB$ ChangeZone | Cost$ 1 B | Origin$ Graveyard | Destination$ Battlefield | ActivationZone$ Graveyard | CheckSVar$ X | SVarCompare GT0 | SpellDescription$ Return CARDNAME from your graveyard to the battlefield. Activate only if a non-Skeleton creature died under your control this turn.
+A:AB$ ChangeZone | Cost$ 1 B | Origin$ Graveyard | Destination$ Battlefield | ActivationZone$ Graveyard | CheckSVar$ X | SVarCompare$ GT0 | SpellDescription$ Return CARDNAME from your graveyard to the battlefield. Activate only if a non-Skeleton creature died under your control this turn.
 SVar:X:Count$ThisTurnEntered_Graveyard_from_Battlefield_Creature.YouCtrl+nonSkeleton
 SVar:DiscardMe:1
 SVar:SacMe:1

--- a/forge-gui/res/cardsfolder/e/embodiment_of_agonies.txt
+++ b/forge-gui/res/cardsfolder/e/embodiment_of_agonies.txt
@@ -4,7 +4,7 @@ Types:Creature Demon
 PT:0/0
 K:Flying
 K:Deathtouch
-K:etbCounter:P1P1:X:no condition:CARDNAME enters the battlefield with a +1/+1 counter on it for each different mana cost among nonland cards in your graveyard.
+K:etbCounter:P1P1:X:no Condition:CARDNAME enters the battlefield with a +1/+1 counter on it for each different mana cost among nonland cards in your graveyard.
 SVar:X:Count$ExactManaCostGraveyard Card.nonLand+YouOwn
 SVar:NeedsToPlayVar:X GT2
 DeckHas:Ability$Counters

--- a/forge-gui/res/cardsfolder/e/enclave_elite.txt
+++ b/forge-gui/res/cardsfolder/e/enclave_elite.txt
@@ -4,7 +4,7 @@ Types:Creature Merfolk Soldier
 PT:2/2
 K:Landwalk:Island
 K:Multikicker:1 U
-K:etbCounter:P1P1:XKicked:no condition:CARDNAME enters the battlefield with a +1/+1 counter on it for each time it was kicked.
+K:etbCounter:P1P1:XKicked:no Condition:CARDNAME enters the battlefield with a +1/+1 counter on it for each time it was kicked.
 SVar:XKicked:Count$TimesKicked
 DeckHas:Ability$Counters
 Oracle:Multikicker {1}{U} (You may pay an additional {1}{U} any number of times as you cast this spell.)\nIslandwalk (This creature can't be blocked as long as defending player controls an Island.)\nEnclave Elite enters the battlefield with a +1/+1 counter on it for each time it was kicked.

--- a/forge-gui/res/cardsfolder/e/eternity_vessel.txt
+++ b/forge-gui/res/cardsfolder/e/eternity_vessel.txt
@@ -1,7 +1,7 @@
 Name:Eternity Vessel
 ManaCost:6
 Types:Artifact
-K:etbCounter:CHARGE:X
+K:etbCounter:CHARGE:X:no Condition:CARDNAME enters the battlefield with X charge counters on it, where X is your life total.
 SVar:X:Count$YourLifeTotal
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigLife | OptionalDecider$ You | TriggerDescription$ Landfall — Whenever a land enters the battlefield under your control, you may have your life total become the number of charge counters on CARDNAME.
 SVar:TrigLife:DB$ SetLife | Defined$ You | LifeAmount$ Y

--- a/forge-gui/res/cardsfolder/e/everflowing_chalice.txt
+++ b/forge-gui/res/cardsfolder/e/everflowing_chalice.txt
@@ -2,7 +2,7 @@ Name:Everflowing Chalice
 ManaCost:0
 Types:Artifact
 K:Multikicker:2
-K:etbCounter:CHARGE:XKicked:no condition:CARDNAME enters the battlefield with a charge counter on it for each time it was kicked.
+K:etbCounter:CHARGE:XKicked:no Condition:CARDNAME enters the battlefield with a charge counter on it for each time it was kicked.
 A:AB$ Mana | Cost$ T | Produced$ C | Amount$ X | SpellDescription$ Add {C} for each charge counter on CARDNAME.
 SVar:X:Count$CardCounters.CHARGE
 SVar:XKicked:Count$TimesKicked

--- a/forge-gui/res/cardsfolder/f/flametongue_yearling.txt
+++ b/forge-gui/res/cardsfolder/f/flametongue_yearling.txt
@@ -3,7 +3,7 @@ ManaCost:R R
 Types:Creature Kavu
 PT:2/1
 K:Multikicker:2
-K:etbCounter:P1P1:XKicked:no condition:CARDNAME enters the battlefield with a +1/+1 counter on it for each time it was kicked.
+K:etbCounter:P1P1:XKicked:no Condition:CARDNAME enters the battlefield with a +1/+1 counter on it for each time it was kicked.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When CARDNAME enters the battlefield, it deals damage equal to its power to target creature.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ Y
 SVar:X:Count$CardCounters.P1P1

--- a/forge-gui/res/cardsfolder/g/gnarlid_pack.txt
+++ b/forge-gui/res/cardsfolder/g/gnarlid_pack.txt
@@ -3,7 +3,7 @@ ManaCost:1 G
 Types:Creature Beast
 PT:2/2
 K:Multikicker:1 G
-K:etbCounter:P1P1:XKicked:no condition:CARDNAME enters the battlefield with a +1/+1 counter on it for each time it was kicked.
+K:etbCounter:P1P1:XKicked:no Condition:CARDNAME enters the battlefield with a +1/+1 counter on it for each time it was kicked.
 SVar:XKicked:Count$TimesKicked
 DeckHas:Ability$Counters
 Oracle:Multikicker {1}{G} (You may pay an additional {1}{G} any number of times as you cast this spell.)\nGnarlid Pack enters the battlefield with a +1/+1 counter on it for each time it was kicked.

--- a/forge-gui/res/cardsfolder/g/graceful_takedown.txt
+++ b/forge-gui/res/cardsfolder/g/graceful_takedown.txt
@@ -2,7 +2,7 @@ Name:Graceful Takedown
 ManaCost:1 G
 Types:Sorcery
 A:SP$ Pump | ValidTgts$ Creature.YouCtrl+enchanted | TargetMin$ 0 | TargetMax$ X | AILogic$ PowerDmg | RememberObjects$ ThisTargetedCard | SubAbility$ DBPumpBis | SpellDescription$ Any number of target enchanted creatures you control and up to one other target creature you control each deal damage equal to their power to target creature you don't control.
-SVar:DBPumpBis:DB$ Pump | ValidTgts$ Creature.YouCtrl | TargetUnique$ True | TargetMin$ 0 | TargetMax 1 | RememberObjects$ ThisTargetedCard | SubAbility$ DBEachDamage
+SVar:DBPumpBis:DB$ Pump | ValidTgts$ Creature.YouCtrl | TargetUnique$ True | TargetMin$ 0 | TargetMax$ 1 | RememberObjects$ ThisTargetedCard | SubAbility$ DBEachDamage
 SVar:X:Count$Valid Creature.YouCtrl+enchanted
 SVar:DBEachDamage:DB$ EachDamage | ValidTgts$ Creature.YouDontCtrl | TgtPrompt$ Select target creature you don't control | DefinedDamagers$ Remembered | NumDmg$ Count$CardPower | StackDescription$ REP target creature_{c:ThisTargetedCard} | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/g/grizzly_ghoul.txt
+++ b/forge-gui/res/cardsfolder/g/grizzly_ghoul.txt
@@ -3,7 +3,7 @@ ManaCost:2 B G
 Types:Creature Zombie Bear
 PT:4/3
 K:Trample
-K:etbCounter:P1P1:X:no condition:CARDNAME enters the battlefield with a +1/+1 counter on it for each creature that died this turn.
+K:etbCounter:P1P1:X:no Condition:CARDNAME enters the battlefield with a +1/+1 counter on it for each creature that died this turn.
 SVar:X:Count$ThisTurnEntered_Graveyard_from_Battlefield_Creature
 DeckHas:Ability$Counters
 Oracle:Trample\nGrizzly Ghoul enters the battlefield with a +1/+1 counter on it for each creature that died this turn.

--- a/forge-gui/res/cardsfolder/j/joraga_warcaller.txt
+++ b/forge-gui/res/cardsfolder/j/joraga_warcaller.txt
@@ -3,7 +3,7 @@ ManaCost:G
 Types:Creature Elf Warrior
 PT:1/1
 K:Multikicker:1 G
-K:etbCounter:P1P1:XKicked:no condition:CARDNAME enters the battlefield with a +1/+1 counter on it for each time it was kicked.
+K:etbCounter:P1P1:XKicked:no Condition:CARDNAME enters the battlefield with a +1/+1 counter on it for each time it was kicked.
 S:Mode$ Continuous | Affected$ Creature.Elf+Other+YouCtrl | AddPower$ X | AddToughness$ X | Description$ Other Elf creatures you control get +1/+1 for each +1/+1 counter on CARDNAME.
 SVar:X:Count$CardCounters.P1P1
 SVar:XKicked:Count$TimesKicked

--- a/forge-gui/res/cardsfolder/k/kinsbaile_borderguard.txt
+++ b/forge-gui/res/cardsfolder/k/kinsbaile_borderguard.txt
@@ -2,7 +2,7 @@ Name:Kinsbaile Borderguard
 ManaCost:1 W W
 Types:Creature Kithkin Soldier
 PT:1/1
-K:etbCounter:P1P1:X:no condition:CARDNAME enters the battlefield with a +1/+1 counter on it for each other Kithkin you control.
+K:etbCounter:P1P1:X:no Condition:CARDNAME enters the battlefield with a +1/+1 counter on it for each other Kithkin you control.
 SVar:X:Count$Valid Kithkin.YouCtrl+Other
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME dies, create a 1/1 white Kithkin Soldier creature token for each counter on it.
 SVar:TrigToken:DB$ Token | TokenAmount$ Y | TokenScript$ w_1_1_kithkin_soldier | TokenOwner$ TriggeredCardController

--- a/forge-gui/res/cardsfolder/k/knickknack_ouphe.txt
+++ b/forge-gui/res/cardsfolder/k/knickknack_ouphe.txt
@@ -2,7 +2,7 @@ Name:Knickknack Ouphe
 ManaCost:X G
 Types:Creature Ouphe
 PT:1/1
-K:etbCounter:P1P1:X:no condition:CARDNAME enters the battlefield with X +1/+1 counters on it.
+K:etbCounter:P1P1:X:no Condition:CARDNAME enters the battlefield with X +1/+1 counters on it.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDig | TriggerDescription$ When CARDNAME enters the battlefield, reveal the top X cards of your library. You may put any number of Aura cards with mana value X or less from among them onto the battlefield. Then put all cards revealed this way that weren't put onto the battlefield on the bottom of your library in a random order.
 SVar:TrigDig:DB$ Dig | DigNum$ X | Reveal$ True | ChangeValid$ Aura.cmcLEX | AnyNumber$ True | Optional$ True | DestinationZone$ Battlefield | DestinationZone2$ Library | LibraryPosition$ -1 | RestRandomOrder$ True
 SVar:X:Count$xPaid

--- a/forge-gui/res/cardsfolder/p/plundering_predator.txt
+++ b/forge-gui/res/cardsfolder/p/plundering_predator.txt
@@ -4,6 +4,6 @@ Types:Creature Dragon
 PT:3/3
 K:Flying
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDiscard | TriggerDescription$ When CARDNAME enters the battlefield, you may discard a card. If you do, draw a card.
-SVar:TrigDiscard:AB$ Draw | Cost$ Discard<1/Card> | NumCards 1
+SVar:TrigDiscard:AB$ Draw | Cost$ Discard<1/Card> | NumCards$ 1
 DeckHas:Ability$Discard
 Oracle:Flying\nWhen Plundering Predator enters the battlefield, you may discard a card. If you do, draw a card.

--- a/forge-gui/res/cardsfolder/q/quag_vampires.txt
+++ b/forge-gui/res/cardsfolder/q/quag_vampires.txt
@@ -4,7 +4,7 @@ Types:Creature Vampire Rogue
 PT:1/1
 K:Landwalk:Swamp
 K:Multikicker:1 B
-K:etbCounter:P1P1:XKicked:no condition:CARDNAME enters the battlefield with a +1/+1 counter on it for each time it was kicked.
+K:etbCounter:P1P1:XKicked:no Condition:CARDNAME enters the battlefield with a +1/+1 counter on it for each time it was kicked.
 SVar:XKicked:Count$TimesKicked
 DeckHas:Ability$Counters
 Oracle:Multikicker {1}{B} (You may pay an additional {1}{B} any number of times as you cast this spell.)\nSwampwalk (This creature can't be blocked as long as defending player controls a Swamp.)\nQuag Vampires enters the battlefield with a +1/+1 counter on it for each time it was kicked.

--- a/forge-gui/res/cardsfolder/r/rigging_runner.txt
+++ b/forge-gui/res/cardsfolder/r/rigging_runner.txt
@@ -3,6 +3,6 @@ ManaCost:R
 Types:Creature Goblin Pirate
 PT:1/1
 K:First Strike
-K:etbCounter:P1P1:1:CheckSVar$ RaidTest: Raid — CARDNAME enters the battlefield with a +1/+1 counter on it if you attacked this turn.
+K:etbCounter:P1P1:1:CheckSVar$ RaidTest:Raid — CARDNAME enters the battlefield with a +1/+1 counter on it if you attacked this turn.
 SVar:RaidTest:Count$AttackersDeclared
 Oracle:First strike\nRaid — Rigging Runner enters the battlefield with a +1/+1 counter on it if you attacked this turn.

--- a/forge-gui/res/cardsfolder/s/scrappy_bruiser.txt
+++ b/forge-gui/res/cardsfolder/s/scrappy_bruiser.txt
@@ -3,7 +3,7 @@ ManaCost:3 R
 Types:Creature Raccoon Warrior
 PT:3/4
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME attacks, up to one target attacking creature gets +2/+0 and gains trample until end of turn. Return that creature to its owner's hand at end of combat. (Return it only if it's on the battlefield.)
-SVar:TrigPump:DB$ Pump | TargetMin$ 0 | TargetMax 1 | ValidTgts$ Creature.attacking | TgtPrompt$ Select up to one target attacking creature | KW$ Trample | NumAtt$ +2 | SubAbility$ DBReturn
+SVar:TrigPump:DB$ Pump | TargetMin$ 0 | TargetMax$ 1 | ValidTgts$ Creature.attacking | TgtPrompt$ Select up to one target attacking creature | KW$ Trample | NumAtt$ +2 | SubAbility$ DBReturn
 SVar:DBReturn:DB$ DelayedTrigger | Mode$ Phase | Phase$ EndCombat | ValidPlayer$ Player | Execute$ TrigBounce | RememberObjects$ Targeted | TriggerDescription$ Return that creature to its owner's hand at end of combat.
 SVar:TrigBounce:DB$ ChangeZone | Origin$ Battlefield | Destination$ Hand | Defined$ DelayTriggerRememberedLKI
 SVar:HasAttackEffect:TRUE

--- a/forge-gui/res/cardsfolder/s/sirens_ruse.txt
+++ b/forge-gui/res/cardsfolder/s/sirens_ruse.txt
@@ -3,7 +3,7 @@ ManaCost:1 U
 Types:Instant
 A:SP$ ChangeZone | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | Origin$ Battlefield | Destination$ Exile | RememberLKI$ True | Imprint$ True | SubAbility$ DBReturn | SpellDescription$ Exile target creature you control, then return that card to the battlefield under its owner's control. If a Pirate was exiled this way, draw a card. | StackDescription$ SpellDescription
 SVar:DBReturn:DB$ ChangeZone | Defined$ Imprinted | Origin$ All | Destination$ Battlefield | SubAbility$ DBPirateDraw | StackDescription$ None
-SVar:DBPirateDraw:DB$ Draw | NumCards$ 1 | ConditionDefined Remembered | ConditionPresent$ Pirate | SubAbility$ DBCleanup | StackDescription$ None
+SVar:DBPirateDraw:DB$ Draw | NumCards$ 1 | ConditionDefined$ Remembered | ConditionPresent$ Pirate | SubAbility$ DBCleanup | StackDescription$ None
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearImprinted$ True
 AI:RemoveDeck:All
 Oracle:Exile target creature you control, then return that card to the battlefield under its owner's control. If a Pirate was exiled this way, draw a card.

--- a/forge-gui/res/cardsfolder/s/skitter_of_lizards.txt
+++ b/forge-gui/res/cardsfolder/s/skitter_of_lizards.txt
@@ -4,7 +4,7 @@ Types:Creature Lizard
 PT:1/1
 K:Haste
 K:Multikicker:1 R
-K:etbCounter:P1P1:XKicked:no condition:CARDNAME enters the battlefield with a +1/+1 counter on it for each time it was kicked.
+K:etbCounter:P1P1:XKicked:no Condition:CARDNAME enters the battlefield with a +1/+1 counter on it for each time it was kicked.
 SVar:XKicked:Count$TimesKicked
 DeckHas:Ability$Counters
 Oracle:Multikicker {1}{R} (You may pay an additional {1}{R} any number of times as you cast this spell.)\nHaste\nSkitter of Lizards enters the battlefield with a +1/+1 counter on it for each time it was kicked.

--- a/forge-gui/res/cardsfolder/s/slick_sequence.txt
+++ b/forge-gui/res/cardsfolder/s/slick_sequence.txt
@@ -1,7 +1,7 @@
 Name:Slick Sequence
 ManaCost:U R
 Types:Instant
-A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ 2 | SubAbility$ TrigDraw | SpellDescription CARDNAME deals 2 damage to any target.
+A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ 2 | SubAbility$ TrigDraw | SpellDescription$ CARDNAME deals 2 damage to any target.
 SVar:TrigDraw:DB$ Draw | ConditionCheckSVar$ X | ConditionSVarCompare$ GE2 | StackDescription$ SpellDescription | SpellDescription$ If you've cast another spell this turn, draw a card.
 SVar:X:Count$ThisTurnCast_Card.YouCtrl
 Oracle:Slick Sequence deals 2 damage to any target. If you've cast another spell this turn, draw a card.

--- a/forge-gui/res/cardsfolder/s/storm_fleet_aerialist.txt
+++ b/forge-gui/res/cardsfolder/s/storm_fleet_aerialist.txt
@@ -3,7 +3,7 @@ ManaCost:1 U
 Types:Creature Human Pirate
 PT:1/2
 K:Flying
-K:etbCounter:P1P1:1:CheckSVar$ RaidTest: Raid — CARDNAME enters the battlefield with a +1/+1 counter on it if you attacked this turn.
+K:etbCounter:P1P1:1:CheckSVar$ RaidTest:Raid — CARDNAME enters the battlefield with a +1/+1 counter on it if you attacked this turn.
 SVar:RaidTest:Count$AttackersDeclared
 DeckHas:Ability$Counters
 Oracle:Flying\nRaid — Storm Fleet Aerialist enters the battlefield with a +1/+1 counter on it if you attacked this turn.

--- a/forge-gui/res/cardsfolder/s/swaggering_corsair.txt
+++ b/forge-gui/res/cardsfolder/s/swaggering_corsair.txt
@@ -2,6 +2,6 @@ Name:Swaggering Corsair
 ManaCost:2 R
 Types:Creature Human Pirate
 PT:2/2
-K:etbCounter:P1P1:1:CheckSVar$ RaidTest: Raid — CARDNAME enters the battlefield with a +1/+1 counter on it if you attacked this turn.
+K:etbCounter:P1P1:1:CheckSVar$ RaidTest:Raid — CARDNAME enters the battlefield with a +1/+1 counter on it if you attacked this turn.
 SVar:RaidTest:Count$AttackersDeclared
 Oracle:Raid — Swaggering Corsair enters the battlefield with a +1/+1 counter on it if you attacked this turn.

--- a/forge-gui/res/cardsfolder/s/swarm_shambler.txt
+++ b/forge-gui/res/cardsfolder/s/swarm_shambler.txt
@@ -2,7 +2,7 @@ Name:Swarm Shambler
 ManaCost:G
 Types:Creature Fungus Beast
 PT:0/0
-K:etbCounter:P1P1:1:no Condition:CARDNAME enters the battlefield with a +1/+1 counter on it.
+K:etbCounter:P1P1:1
 T:Mode$ BecomesTarget | ValidTarget$ Creature.YouCtrl+counters_GE1_P1P1 | ValidSource$ Spell.OppCtrl | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever a creature you control with a +1/+1 counter on it becomes the target of a spell an opponent controls, create a 1/1 green Insect creature token.
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ g_1_1_insect | TokenOwner$ You
 A:AB$ PutCounter | Cost$ 1 T | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on CARDNAME.

--- a/forge-gui/res/cardsfolder/t/talions_throneguard.txt
+++ b/forge-gui/res/cardsfolder/t/talions_throneguard.txt
@@ -9,7 +9,7 @@ T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.S
 SVar:TrigReturn:DB$ ChangeZone | ValidTgts$ Permanent.nonLand,Card.inZoneStack | TgtZone$ Stack,Battlefield | TargetMin$ 0 | TargetMax$ 1 | Origin$ Battlefield,Stack | Fizzle$ True | Destination$ Hand | RememberChanged$ True | TgtPrompt$ Select up to one target spell or nonland permanent | SubAbility$ DBAnimate
 SVar:DBAnimate:DB$ Animate | Defined$ Remembered | ConditionDefined$ Self | ConditionPresent$ Card.bargained | staticAbilities$ RaiseCost | Duration$ Perpetual | SubAbility$ DBCleanup
 SVar:RaiseCost:Mode$ RaiseCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 2 | EffectZone$ All | Description$ This spell costs {2} more to cast.
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 DeckHints:Type$Artifact|Enchantment & Ability$Token
 DeckHas:Ability$Sacrifice
 Oracle:Flash\nBargain\nFlying\nWhen Talion's Throneguard enters the battlefield, return up to one target spell or nonland permanent to its owner's hand. If Talion's Throneguard was bargained, that card perpetually gains "This spell costs {2} more to cast."

--- a/forge-gui/res/cardsfolder/t/tidewalker.txt
+++ b/forge-gui/res/cardsfolder/t/tidewalker.txt
@@ -2,7 +2,7 @@ Name:Tidewalker
 ManaCost:2 U
 Types:Creature Elemental
 PT:*/*
-K:etbCounter:TIME:X:no Condition:Tidewalker enters the battlefield with a time counter on it for each Island you control.
+K:etbCounter:TIME:X:no Condition:CARDNAME enters the battlefield with a time counter on it for each Island you control.
 K:Vanishing
 S:Mode$ Continuous | EffectZone$ Battlefield | CharacteristicDefining$ True | SetPower$ Y | SetToughness$ Y | Description$ CARDNAME's power and toughness are each equal to the number of time counters on it.
 SVar:X:Count$Valid Island.YouCtrl

--- a/forge-gui/res/cardsfolder/t/triarch_stalker.txt
+++ b/forge-gui/res/cardsfolder/t/triarch_stalker.txt
@@ -3,7 +3,7 @@ ManaCost:3 B B
 Types:Artifact Creature Necron
 PT:4/5
 S:Mode$ Continuous | Affected$ Creature.attacking ChosenPlayer | AddKeyword$ Menace | Description$ Creatures attacking the last chosen player have menace.
-T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | Execute$ TrigChoose | TriggerZones$ Battlefield | TriggerDescriptionLure the Unwary — At the beginning of combat on your turn, choose an opponent.
+T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | Execute$ TrigChoose | TriggerZones$ Battlefield | TriggerDescription$ Lure the Unwary — At the beginning of combat on your turn, choose an opponent.
 SVar:TrigChoose:DB$ ChoosePlayer | Defined$ You | Choices$ Player.Opponent
 DeckHas:Keyword$Menace
 Oracle:Targeting Relay — At the beginning of combat on your turn, choose an opponent.\nCreatures attacking the last chosen player have menace.

--- a/forge-gui/res/cardsfolder/t/triarch_stalker.txt
+++ b/forge-gui/res/cardsfolder/t/triarch_stalker.txt
@@ -3,7 +3,7 @@ ManaCost:3 B B
 Types:Artifact Creature Necron
 PT:4/5
 S:Mode$ Continuous | Affected$ Creature.attacking ChosenPlayer | AddKeyword$ Menace | Description$ Creatures attacking the last chosen player have menace.
-T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | Execute$ TrigChoose | TriggerZones$ Battlefield | TriggerDescription$ Lure the Unwary — At the beginning of combat on your turn, choose an opponent.
+T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | Execute$ TrigChoose | TriggerZones$ Battlefield | TriggerDescription$ Targeting Relay — At the beginning of combat on your turn, choose an opponent.
 SVar:TrigChoose:DB$ ChoosePlayer | Defined$ You | Choices$ Player.Opponent
 DeckHas:Keyword$Menace
 Oracle:Targeting Relay — At the beginning of combat on your turn, choose an opponent.\nCreatures attacking the last chosen player have menace.

--- a/forge-gui/res/cardsfolder/u/utvara_hellkite.txt
+++ b/forge-gui/res/cardsfolder/u/utvara_hellkite.txt
@@ -3,7 +3,7 @@ ManaCost:6 R R
 Types:Creature Dragon
 PT:6/6
 K:Flying
-T:Mode$ Attacks | ValidCard$ Dragon.YouCtrl | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever a dragon you control attacks, create a 6/6 red Dragon creature token with flying.
+T:Mode$ Attacks | ValidCard$ Dragon.YouCtrl | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever a Dragon you control attacks, create a 6/6 red Dragon creature token with flying.
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ r_6_6_dragon_flying | TokenOwner$ You
 DeckHas:Ability$Token
 Oracle:Flying\nWhenever a Dragon you control attacks, create a 6/6 red Dragon creature token with flying.

--- a/forge-gui/res/cardsfolder/w/war_name_aspirant.txt
+++ b/forge-gui/res/cardsfolder/w/war_name_aspirant.txt
@@ -2,7 +2,7 @@ Name:War-Name Aspirant
 ManaCost:1 R
 Types:Creature Human Warrior
 PT:2/1
-K:etbCounter:P1P1:1:CheckSVar$ RaidTest: Raid — CARDNAME enters the battlefield with a +1/+1 counter on it if you attacked this turn.
+K:etbCounter:P1P1:1:CheckSVar$ RaidTest:Raid — CARDNAME enters the battlefield with a +1/+1 counter on it if you attacked this turn.
 SVar:RaidTest:Count$AttackersDeclared
 S:Mode$ CantBlockBy | ValidAttacker$ Creature.Self | ValidBlocker$ Creature.powerLE1 | Description$ CARDNAME can't be blocked by creatures with power 1 or less.
 Oracle:Raid — War-Name Aspirant enters the battlefield with a +1/+1 counter on it if you attacked this turn.\nWar-Name Aspirant can't be blocked by creatures with power 1 or less.

--- a/forge-gui/res/cardsfolder/w/wolverine_riders.txt
+++ b/forge-gui/res/cardsfolder/w/wolverine_riders.txt
@@ -4,7 +4,7 @@ Types:Creature Elf Warrior
 PT:4/4
 T:Mode$ Phase | Phase$ Upkeep | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ At the beginning of each upkeep, create a 1/1 green Elf Warrior creature token.
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ g_1_1_elf_Warrior | TokenOwner$ You
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Elf.Other+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigGainLife | TriggerDescription$ Whenever another elf enters the battlefield under your control, you gain life equal to its toughness.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Elf.Other+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigGainLife | TriggerDescription$ Whenever another Elf enters the battlefield under your control, you gain life equal to its toughness.
 SVar:TrigGainLife:DB$ GainLife | Defined$ You | LifeAmount$ X
 SVar:X:TriggeredCard$CardToughness
 SVar:PlayMain1:TRUE

--- a/forge-gui/res/cardsfolder/w/wyll_pact_bound_duelist.txt
+++ b/forge-gui/res/cardsfolder/w/wyll_pact_bound_duelist.txt
@@ -31,7 +31,7 @@ Types:Legendary Creature Human Warlock
 PT:5/5
 T:Mode$ Specializes | ValidCard$ Card.Self | Execute$ TrigImmediateTrig | TriggerDescription$ When this creature specializes, you may sacrifice another creature or an artifact. When you do, instant or sorcery card from your graveyard to your hand.
 SVar:TrigImmediateTrig:AB$ ImmediateTrigger | Cost$ Sac<1/Creature.Other;Artifact/another creature or an artifact> | Execute$ TrigReturn | TriggerDescription$ When you do, return target instant or sorcery card from your graveyard to your hand.
-SVar:TrigReturn:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Instant.YouOwn,Sorcery.YouOwn | Select target instant or sorcery card
+SVar:TrigReturn:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Instant.YouOwn,Sorcery.YouOwn | TgtPrompt$ Select target instant or sorcery card
 DeckHas:Ability$Sacrifice|Graveyard
 DeckHints:Type$Artifact|Instant|Sorcery
 Oracle:When this creature specializes, you may sacrifice another creature or an artifact. When you do, return target instant or sorcery card from your graveyard to your hand.


### PR DESCRIPTION
- Cleaning up `K:etbCounter` lines
○ `no condition` corrected to `no Condition`
○ Moved Crowd-Control Warden's description to a more appropriate place after testing.
○ Banquet Guests and Eternity Vessel had the relevant description added.
○ Removed the description from Swarm Shambler as it's adequately done via automatic text.
- Various typos and other editing lapses, not the least of which were instances of missing `$` on parameters.