### PR TITLE
Cleanup following up on PR #5229

### DIFF
--- a/forge-gui/res/cardsfolder/a/aeolipile.txt
+++ b/forge-gui/res/cardsfolder/a/aeolipile.txt
@@ -1,5 +1,6 @@
 Name:Aeolipile
 ManaCost:2
 Types:Artifact
-A:AB$ DealDamage | Cost$ 1 T Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to any target.
+A:AB$ DealDamage | Cost$ 1 T Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ It deals 2 damage to any target.
+DeckHas:Ability$Sacrifice
 Oracle:{1}, {T}, Sacrifice Aeolipile: It deals 2 damage to any target.

--- a/forge-gui/res/cardsfolder/a/aerie_ouphes.txt
+++ b/forge-gui/res/cardsfolder/a/aerie_ouphes.txt
@@ -3,6 +3,7 @@ ManaCost:4 G
 Types:Creature Ouphe
 PT:3/3
 K:Persist
-A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Creature.withFlying | TgtPrompt$ Select target creature with flying | NumDmg$ X | SpellDescription$ CARDNAME deals damage equal to its power to target creature with flying.
+A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Creature.withFlying | TgtPrompt$ Select target creature with flying | NumDmg$ X | SpellDescription$ It deals damage equal to its power to target creature with flying.
 SVar:X:Sacrificed$CardPower
+DeckHas:Ability$Sacrifice
 Oracle:Sacrifice Aerie Ouphes: It deals damage equal to its power to target creature with flying.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)

--- a/forge-gui/res/cardsfolder/a/ancient_hydra.txt
+++ b/forge-gui/res/cardsfolder/a/ancient_hydra.txt
@@ -3,5 +3,7 @@ ManaCost:4 R
 Types:Creature Hydra
 PT:5/1
 K:Fading:5
-A:AB$ DealDamage | Cost$ 1 SubCounter<1/FADE> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to any target.
+A:AB$ DealDamage | Cost$ 1 SubCounter<1/FADE> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ It deals 1 damage to any target.
+DeckHas:Ability$Counters
+DeckHints:Ability$Proliferate
 Oracle:Fading 5 (This creature enters the battlefield with five fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)\n{1}, Remove a fade counter from Ancient Hydra: It deals 1 damage to any target.

--- a/forge-gui/res/cardsfolder/a/apocalypse_hydra.txt
+++ b/forge-gui/res/cardsfolder/a/apocalypse_hydra.txt
@@ -2,10 +2,12 @@ Name:Apocalypse Hydra
 ManaCost:X R G
 Types:Creature Hydra
 PT:0/0
-K:etbCounter:P1P1:Y:no Condition:CARDNAME enters the battlefield with X +1/+1 counters on it. If X is 5 or more, it enters the battlefield with an additional X +1/+1 counters on it.
-A:AB$ DealDamage | Cost$ 1 R SubCounter<1/P1P1> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to any target.
+K:etbCounter:P1P1:Y:no condition:CARDNAME enters the battlefield with X +1/+1 counters on it. If X is 5 or more, it enters the battlefield with an additional X +1/+1 counters on it.
+A:AB$ DealDamage | Cost$ 1 R SubCounter<1/P1P1> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ It deals 1 damage to any target.
 # This xPaid doesn't do anything, it's just needed to make Cost work properly
 SVar:X:Count$xPaid
 SVar:Y:Count$Compare X LT5.X.Z
 SVar:Z:Count$xPaid/Twice
+DeckHas:Ability$Counters
+DeckHints:Ability$Proliferate
 Oracle:Apocalypse Hydra enters the battlefield with X +1/+1 counters on it. If X is 5 or more, it enters the battlefield with an additional X +1/+1 counters on it.\n{1}{R}, Remove a +1/+1 counter from Apocalypse Hydra: It deals 1 damage to any target.

--- a/forge-gui/res/cardsfolder/a/apocalypse_hydra.txt
+++ b/forge-gui/res/cardsfolder/a/apocalypse_hydra.txt
@@ -2,7 +2,7 @@ Name:Apocalypse Hydra
 ManaCost:X R G
 Types:Creature Hydra
 PT:0/0
-K:etbCounter:P1P1:Y:no condition:CARDNAME enters the battlefield with X +1/+1 counters on it. If X is 5 or more, it enters the battlefield with an additional X +1/+1 counters on it.
+K:etbCounter:P1P1:Y:no Condition:CARDNAME enters the battlefield with X +1/+1 counters on it. If X is 5 or more, it enters the battlefield with an additional X +1/+1 counters on it.
 A:AB$ DealDamage | Cost$ 1 R SubCounter<1/P1P1> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ It deals 1 damage to any target.
 # This xPaid doesn't do anything, it's just needed to make Cost work properly
 SVar:X:Count$xPaid

--- a/forge-gui/res/cardsfolder/a/arcbound_javelineer.txt
+++ b/forge-gui/res/cardsfolder/a/arcbound_javelineer.txt
@@ -3,8 +3,8 @@ ManaCost:W
 Types:Artifact Creature Soldier
 PT:0/1
 K:Modular:1
-A:AB$ DealDamage | Cost$ T SubCounter<X/P1P1> | ValidTgts$ Creature.attacking,Creature.blocking | TgtPrompt$ Select target attacking or blocking creature | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to target attacking or blocking creature.
+A:AB$ DealDamage | Cost$ T SubCounter<X/P1P1> | ValidTgts$ Creature.attacking,Creature.blocking | TgtPrompt$ Select target attacking or blocking creature | NumDmg$ X | SpellDescription$ It deals X damage to target attacking or blocking creature.
 SVar:X:Count$xPaid
 DeckHas:Ability$Counters
-DeckHints:Type$Artifact & Ability$Counters
+DeckHints:Type$Artifact & Ability$Counters|Proliferate
 Oracle:{T}, Remove X +1/+1 counters from Arcbound Javelineer: It deals X damage to target attacking or blocking creature.\nModular 1 (This creature enters the battlefield with a +1/+1 counter on it. When it dies, you may put its +1/+1 counters on target artifact creature.)

--- a/forge-gui/res/cardsfolder/b/barbarian_lunatic.txt
+++ b/forge-gui/res/cardsfolder/b/barbarian_lunatic.txt
@@ -2,5 +2,6 @@ Name:Barbarian Lunatic
 ManaCost:2 R
 Types:Creature Human Barbarian
 PT:2/1
-A:AB$ DealDamage | Cost$ 2 R Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to target creature.
+A:AB$ DealDamage | Cost$ 2 R Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 2 | SpellDescription$ It deals 2 damage to target creature.
+DeckHas:Ability$Sacrifice
 Oracle:{2}{R}, Sacrifice Barbarian Lunatic: It deals 2 damage to target creature.

--- a/forge-gui/res/cardsfolder/b/barbarian_ring.txt
+++ b/forge-gui/res/cardsfolder/b/barbarian_ring.txt
@@ -4,4 +4,5 @@ Types:Land
 A:AB$ Mana | Cost$ T | Produced$ R | SubAbility$ DBPain | SpellDescription$ Add {R}. CARDNAME deals 1 damage to you.
 A:AB$ DealDamage | Cost$ R T Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 2 | Activation$ Threshold | PrecostDesc$ Threshold — | SpellDescription$ It deals 2 damage to any target. Activate only if seven or more cards are in your graveyard.
 SVar:DBPain:DB$ DealDamage | NumDmg$ 1 | Defined$ You
+DeckHas:Ability$Sacrifice
 Oracle:{T}: Add {R}. Barbarian Ring deals 1 damage to you.\nThreshold — {R}, {T}, Sacrifice Barbarian Ring: It deals 2 damage to any target. Activate only if seven or more cards are in your graveyard.

--- a/forge-gui/res/cardsfolder/b/blazing_torch.txt
+++ b/forge-gui/res/cardsfolder/b/blazing_torch.txt
@@ -3,7 +3,7 @@ ManaCost:1
 Types:Artifact Equipment
 K:Equip:1
 S:Mode$ CantBlockBy | ValidAttacker$ Creature.EquippedBy | ValidBlocker$ Creature.Vampire,Creature.Zombie | Description$ Equipped creature can't be blocked by Vampires or Zombies.
-S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddAbility$ TorchDamage | Description$ Equipped creature has "{T}, Sacrifice Blazing Torch: Blazing Torch deals 2 damage to any target."
+S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddAbility$ TorchDamage | Description$ Equipped creature has "{T}, Sacrifice CARDNAME: CARDNAME deals 2 damage to any target."
 SVar:TorchDamage:AB$ DealDamage | Cost$ T Sac<1/OriginalHost/Blazing Torch> | ValidTgts$ Any | NumDmg$ 2 | DamageSource$ OriginalHost | SpellDescription$ ORIGINALHOST deals 2 damage to any target.
 SVar:NonStackingAttachEffect:True
 DeckHas:Ability$Sacrifice

--- a/forge-gui/res/cardsfolder/b/blazing_torch.txt
+++ b/forge-gui/res/cardsfolder/b/blazing_torch.txt
@@ -3,7 +3,8 @@ ManaCost:1
 Types:Artifact Equipment
 K:Equip:1
 S:Mode$ CantBlockBy | ValidAttacker$ Creature.EquippedBy | ValidBlocker$ Creature.Vampire,Creature.Zombie | Description$ Equipped creature can't be blocked by Vampires or Zombies.
-S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddAbility$ TorchDamage | Description$ Equipped creature has "{T}, Sacrifice Blazing Torch: It deals 2 damage to any target."
+S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddAbility$ TorchDamage | Description$ Equipped creature has "{T}, Sacrifice Blazing Torch: Blazing Torch deals 2 damage to any target."
 SVar:TorchDamage:AB$ DealDamage | Cost$ T Sac<1/OriginalHost/Blazing Torch> | ValidTgts$ Any | NumDmg$ 2 | DamageSource$ OriginalHost | SpellDescription$ ORIGINALHOST deals 2 damage to any target.
 SVar:NonStackingAttachEffect:True
+DeckHas:Ability$Sacrifice
 Oracle:Equipped creature can't be blocked by Vampires or Zombies.\nEquipped creature has "{T}, Sacrifice Blazing Torch: Blazing Torch deals 2 damage to any target."\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)

--- a/forge-gui/res/cardsfolder/b/blighted_gorge.txt
+++ b/forge-gui/res/cardsfolder/b/blighted_gorge.txt
@@ -2,7 +2,7 @@ Name:Blighted Gorge
 ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
-A:AB$ DealDamage | Cost$ 4 R T Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to any target.
-DeckHas:Ability$Mana.Colorless
+A:AB$ DealDamage | Cost$ 4 R T Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ It deals 2 damage to any target.
+DeckHas:Ability$Mana.Colorless|Sacrifice
 DeckNeeds:Color$Red
 Oracle:{T}: Add {C}.\n{4}{R}, {T}, Sacrifice Blighted Gorge: It deals 2 damage to any target.

--- a/forge-gui/res/cardsfolder/b/blockbuster.txt
+++ b/forge-gui/res/cardsfolder/b/blockbuster.txt
@@ -2,5 +2,6 @@ Name:Blockbuster
 ManaCost:3 R R
 Types:Enchantment
 PT:6/6
-A:AB$ DamageAll | Cost$ 1 R Sac<1/CARDNAME> | ValidCards$ Creature.tapped | ValidPlayers$ Player | NumDmg$ 3 | ValidDescription$ each tapped creature and each player. | SpellDescription$ CARDNAME deals 3 damage to each tapped creature and each player.
+A:AB$ DamageAll | Cost$ 1 R Sac<1/CARDNAME> | ValidCards$ Creature.tapped | ValidPlayers$ Player | NumDmg$ 3 | ValidDescription$ each tapped creature and each player. | SpellDescription$ It deals 3 damage to each tapped creature and each player.
+DeckHas:Ability$Sacrifice
 Oracle:{1}{R}, Sacrifice Blockbuster: It deals 3 damage to each tapped creature and each player.

--- a/forge-gui/res/cardsfolder/b/bloodfire_colossus.txt
+++ b/forge-gui/res/cardsfolder/b/bloodfire_colossus.txt
@@ -2,5 +2,6 @@ Name:Bloodfire Colossus
 ManaCost:6 R R
 Types:Creature Giant
 PT:6/6
-A:AB$ DamageAll | Cost$ R Sac<1/CARDNAME> | ValidCards$ Creature | ValidPlayers$ Player | NumDmg$ 6 | ValidDescription$ each creature and each player. | SpellDescription$ CARDNAME deals 6 damage to each creature and each player.
+A:AB$ DamageAll | Cost$ R Sac<1/CARDNAME> | ValidCards$ Creature | ValidPlayers$ Player | NumDmg$ 6 | ValidDescription$ each creature and each player. | SpellDescription$ It deals 6 damage to each creature and each player.
+DeckHas:Ability$Sacrifice
 Oracle:{R}, Sacrifice Bloodfire Colossus: It deals 6 damage to each creature and each player.

--- a/forge-gui/res/cardsfolder/b/bloodfire_dwarf.txt
+++ b/forge-gui/res/cardsfolder/b/bloodfire_dwarf.txt
@@ -2,5 +2,6 @@ Name:Bloodfire Dwarf
 ManaCost:R
 Types:Creature Dwarf
 PT:1/1
-A:AB$ DamageAll | Cost$ R Sac<1/CARDNAME> | ValidCards$ Creature.withoutFlying | NumDmg$ 1 | ValidDescription$ each creature without flying. | SpellDescription$ CARDNAME deals 1 damage to each creature without flying.
+A:AB$ DamageAll | Cost$ R Sac<1/CARDNAME> | ValidCards$ Creature.withoutFlying | NumDmg$ 1 | ValidDescription$ each creature without flying. | SpellDescription$ It deals 1 damage to each creature without flying.
+DeckHas:Ability$Sacrifice
 Oracle:{R}, Sacrifice Bloodfire Dwarf: It deals 1 damage to each creature without flying.

--- a/forge-gui/res/cardsfolder/b/bloodfire_kavu.txt
+++ b/forge-gui/res/cardsfolder/b/bloodfire_kavu.txt
@@ -2,6 +2,7 @@ Name:Bloodfire Kavu
 ManaCost:2 R R
 Types:Creature Kavu
 PT:2/2
-A:AB$ DamageAll | Cost$ R Sac<1/CARDNAME> | ValidCards$ Creature | NumDmg$ 2 | ValidDescription$ each creature. | SpellDescription$ CARDNAME deals 2 damage to each creature.
+A:AB$ DamageAll | Cost$ R Sac<1/CARDNAME> | ValidCards$ Creature | NumDmg$ 2 | ValidDescription$ each creature. | SpellDescription$ It deals 2 damage to each creature.
 AI:RemoveDeck:Random
+DeckHas:Ability$Sacrifice
 Oracle:{R}, Sacrifice Bloodfire Kavu: It deals 2 damage to each creature.

--- a/forge-gui/res/cardsfolder/b/bloodpyre_elemental.txt
+++ b/forge-gui/res/cardsfolder/b/bloodpyre_elemental.txt
@@ -2,5 +2,6 @@ Name:Bloodpyre Elemental
 ManaCost:4 R
 Types:Creature Elemental
 PT:4/1
-A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 4 | SorcerySpeed$ True | SpellDescription$ CARDNAME deals 4 damage to target creature. Activate only any time you could cast a sorcery.
+A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 4 | SorcerySpeed$ True | SpellDescription$ It deals 4 damage to target creature. Activate only any time you could cast a sorcery.
+DeckHas:Ability$Sacrifice
 Oracle:Sacrifice Bloodpyre Elemental: It deals 4 damage to target creature. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/c/chamber_sentry.txt
+++ b/forge-gui/res/cardsfolder/c/chamber_sentry.txt
@@ -4,11 +4,12 @@ Types:Artifact Creature Construct
 PT:0/0
 K:etbCounter:P1P1:Y:no Condition:CARDNAME enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.
 SVar:Y:Count$Converge
-A:AB$ DealDamage | Cost$ X T SubCounter<X/P1P1> | ValidTgts$ Any | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to any target.
+A:AB$ DealDamage | Cost$ X T SubCounter<X/P1P1> | ValidTgts$ Any | NumDmg$ X | SpellDescription$ It deals X damage to any target.
 SVar:X:Count$xPaid
 A:AB$ ChangeZone | Cost$ W U B R G | Origin$ Graveyard | Destination$ Hand | ActivationZone$ Graveyard | SpellDescription$ Return CARDNAME from your graveyard to your hand.
 SVar:DiscardMe:1
-DeckHas:Ability$Counters
 SVar:NeedsToPlayVar:Z GE1
 SVar:Z:Count$UniqueManaColorsProduced.ByUntappedSources
+DeckHas:Ability$Counters
+DeckHints:Ability$Proliferate
 Oracle:Chamber Sentry enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.\n{X}, {T}, Remove X +1/+1 counters from Chamber Sentry: It deals X damage to any target.\n{W}{U}{B}{R}{G}: Return Chamber Sentry from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/c/cinder_elemental.txt
+++ b/forge-gui/res/cardsfolder/c/cinder_elemental.txt
@@ -2,6 +2,7 @@ Name:Cinder Elemental
 ManaCost:3 R
 Types:Creature Elemental
 PT:2/2
-A:AB$ DealDamage | Cost$ X R T Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ X | AITgts$ BetterThanSource | SpellDescription$ CARDNAME deals X damage to any target.
+A:AB$ DealDamage | Cost$ X R T Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ X | AITgts$ BetterThanSource | SpellDescription$ It deals X damage to any target.
 SVar:X:Count$xPaid
+DeckHas:Ability$Sacrifice
 Oracle:{X}{R}, {T}, Sacrifice Cinder Elemental: It deals X damage to any target.

--- a/forge-gui/res/cardsfolder/c/cinder_shade.txt
+++ b/forge-gui/res/cardsfolder/c/cinder_shade.txt
@@ -3,7 +3,7 @@ ManaCost:1 B R
 Types:Creature Shade
 PT:1/1
 A:AB$ Pump | Cost$ B | Defined$ Self | NumAtt$ +1 | NumDef$ +1 | SpellDescription$ CARDNAME gets +1/+1 until end of turn.
-A:AB$ DealDamage | Cost$ R Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SpellDescription$ CARDNAME deals damage equal to its power to target creature.
+A:AB$ DealDamage | Cost$ R Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SpellDescription$ It deals damage equal to its power to target creature.
 SVar:X:Sacrificed$CardPower
 DeckHas:Ability$Sacrifice
 Oracle:{B}: Cinder Shade gets +1/+1 until end of turn.\n{R}, Sacrifice Cinder Shade: It deals damage equal to its power to target creature.

--- a/forge-gui/res/cardsfolder/c/crackling_club.txt
+++ b/forge-gui/res/cardsfolder/c/crackling_club.txt
@@ -4,5 +4,6 @@ Types:Enchantment Aura
 K:Enchant creature
 A:SP$ Attach | Cost$ R | ValidTgts$ Creature | AILogic$ Pump
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | Description$ Enchanted creature gets +1/+0.
-A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to target creature.
+A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 1 | SpellDescription$ It deals 1 damage to target creature.
+DeckHas:Ability$Sacrifice
 Oracle:Enchant creature\nEnchanted creature gets +1/+0.\nSacrifice Crackling Club: It deals 1 damage to target creature.

--- a/forge-gui/res/cardsfolder/c/crackling_triton.txt
+++ b/forge-gui/res/cardsfolder/c/crackling_triton.txt
@@ -2,5 +2,6 @@ Name:Crackling Triton
 ManaCost:2 U
 Types:Creature Merfolk Wizard
 PT:2/3
-A:AB$ DealDamage | Cost$ 2 R Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to any target.
+A:AB$ DealDamage | Cost$ 2 R Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ It deals 2 damage to any target.
+DeckHas:Ability$Sacrifice
 Oracle:{2}{R}, Sacrifice Crackling Triton: It deals 2 damage to any target.

--- a/forge-gui/res/cardsfolder/c/crater_elemental.txt
+++ b/forge-gui/res/cardsfolder/c/crater_elemental.txt
@@ -2,8 +2,9 @@ Name:Crater Elemental
 ManaCost:2 R
 Types:Creature Elemental
 PT:0/6
-A:AB$ DealDamage | Cost$ R T Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 4 | SpellDescription$ CARDNAME deals 4 damage to target creature.
+A:AB$ DealDamage | Cost$ R T Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 4 | SpellDescription$ It deals 4 damage to target creature.
 A:AB$ Animate | Cost$ 2 R | Defined$ Self | Power$ 8 | CheckSVar$ FormidableTest | SVarCompare$ GE8 | PrecostDesc$ Formidable — | SpellDescription$ CARDNAME has base power 8 until end of turn. Activate only if creatures you control have total power 8 or greater.
 SVar:FormidableTest:Count$SumPower_Creature.YouCtrl
 AI:RemoveDeck:All
+DeckHas:Ability$Sacrifice
 Oracle:{R}, {T}, Sacrifice Crater Elemental: It deals 4 damage to target creature.\nFormidable — {2}{R}: Crater Elemental has base power 8 until end of turn. Activate only if creatures you control have total power 8 or greater.

--- a/forge-gui/res/cardsfolder/c/cruel_sadist.txt
+++ b/forge-gui/res/cardsfolder/c/cruel_sadist.txt
@@ -3,7 +3,9 @@ ManaCost:B
 Types:Creature Human Assassin
 PT:1/1
 A:AB$ PutCounter | Cost$ B T PayLife<1> | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on CARDNAME.
-A:AB$ DealDamage | Cost$ 2 B T SubCounter<X/P1P1> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to target creature.
+A:AB$ DealDamage | Cost$ 2 B T SubCounter<X/P1P1> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SpellDescription$ It deals X damage to target creature.
 SVar:X:Count$xPaid
 AI:RemoveDeck:All
+DeckHas:Ability$Counters
+DeckHints:Ability$Proliferate
 Oracle:{B}, {T}, Pay 1 life: Put a +1/+1 counter on Cruel Sadist.\n{2}{B}, {T}, Remove X +1/+1 counters from Cruel Sadist: It deals X damage to target creature.

--- a/forge-gui/res/cardsfolder/d/dismissive_pyromancer.txt
+++ b/forge-gui/res/cardsfolder/d/dismissive_pyromancer.txt
@@ -3,5 +3,6 @@ ManaCost:1 R
 Types:Creature Human Wizard
 PT:2/2
 A:AB$ Draw | Defined$ You | Cost$ R T Discard<1/Card> | NumCards$ 1 | SpellDescription$ Draw a card.
-A:AB$ DealDamage | Cost$ 2 R T Sac<1/CARDNAME> | NumDmg$ 4 | ValidTgts$ Creature | TgtPrompt$ Select target creature | SpellDescription$ CARDNAME deals 4 damage to target creature.
+A:AB$ DealDamage | Cost$ 2 R T Sac<1/CARDNAME> | NumDmg$ 4 | ValidTgts$ Creature | TgtPrompt$ Select target creature | SpellDescription$ It deals 4 damage to target creature.
+DeckHas:Ability$Discard|Sacrifice
 Oracle:{R}, {T}, Discard a card: Draw a card.\n{2}{R}, {T}, Sacrifice Dismissive Pyromancer: It deals 4 damage to target creature.

--- a/forge-gui/res/cardsfolder/d/dive_bomber.txt
+++ b/forge-gui/res/cardsfolder/d/dive_bomber.txt
@@ -3,5 +3,6 @@ ManaCost:3 W
 Types:Creature Bird Soldier
 PT:2/2
 K:Flying
-A:AB$ DealDamage | Cost$ T Sac<1/CARDNAME> | ValidTgts$ Creature.attacking,Creature.blocking | TgtPrompt$ Select target attacking or blocking creature | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to target attacking or blocking creature.
+A:AB$ DealDamage | Cost$ T Sac<1/CARDNAME> | ValidTgts$ Creature.attacking,Creature.blocking | TgtPrompt$ Select target attacking or blocking creature | NumDmg$ 2 | SpellDescription$ It deals 2 damage to target attacking or blocking creature.
+DeckHas:Ability$Sacrifice
 Oracle:Flying\n{T}, Sacrifice Dive Bomber: It deals 2 damage to target attacking or blocking creature.

--- a/forge-gui/res/cardsfolder/d/divebomber_griffin.txt
+++ b/forge-gui/res/cardsfolder/d/divebomber_griffin.txt
@@ -3,6 +3,7 @@ ManaCost:3 W W
 Types:Creature Griffin
 PT:3/2
 K:Flying
-A:AB$ DealDamage | Cost$ T Sac<1/CARDNAME> | ValidTgts$ Creature.attacking,Creature.blocking | AITgts$ BetterThanSource | TgtPrompt$ Select target attacking or blocking creature | NumDmg$ 3 | SpellDescription$ CARDNAME deals 3 damage to target attacking or blocking creature.
+A:AB$ DealDamage | Cost$ T Sac<1/CARDNAME> | ValidTgts$ Creature.attacking,Creature.blocking | AITgts$ BetterThanSource | TgtPrompt$ Select target attacking or blocking creature | NumDmg$ 3 | SpellDescription$ It deals 3 damage to target attacking or blocking creature.
 AI:RemoveDeck:All
+DeckHas:Ability$Sacrifice
 Oracle:Flying\n{T}, Sacrifice Divebomber Griffin: It deals 3 damage to target attacking or blocking creature.

--- a/forge-gui/res/cardsfolder/d/downdraft.txt
+++ b/forge-gui/res/cardsfolder/d/downdraft.txt
@@ -2,5 +2,6 @@ Name:Downdraft
 ManaCost:2 G
 Types:Enchantment
 A:AB$ Debuff | Cost$ G | ValidTgts$ Creature | TgtPrompt$ Select target creature | Keywords$ Flying | SpellDescription$ Target creature loses flying until end of turn.
-A:AB$ DamageAll | Cost$ Sac<1/CARDNAME> | ValidCards$ Creature.withFlying | NumDmg$ 2 | ValidDescription$ each creature with flying. | SpellDescription$ CARDNAME deals 2 damage to each creature with flying.
+A:AB$ DamageAll | Cost$ Sac<1/CARDNAME> | ValidCards$ Creature.withFlying | NumDmg$ 2 | ValidDescription$ each creature with flying. | SpellDescription$ It deals 2 damage to each creature with flying.
+DeckHas:Ability$Sacrifice
 Oracle:{G}: Target creature loses flying until end of turn.\nSacrifice Downdraft: It deals 2 damage to each creature with flying.

--- a/forge-gui/res/cardsfolder/d/duergar_assailant.txt
+++ b/forge-gui/res/cardsfolder/d/duergar_assailant.txt
@@ -2,5 +2,6 @@ Name:Duergar Assailant
 ManaCost:RW
 Types:Creature Dwarf Soldier
 PT:1/1
-A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Creature.attacking,Creature.blocking | TgtPrompt$ Select target attacking or blocking creature | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to target attacking or blocking creature.
+A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Creature.attacking,Creature.blocking | TgtPrompt$ Select target attacking or blocking creature | NumDmg$ 1 | SpellDescription$ It deals 1 damage to target attacking or blocking creature.
+DeckHas:Ability$Sacrifice
 Oracle:Sacrifice Duergar Assailant: It deals 1 damage to target attacking or blocking creature.

--- a/forge-gui/res/cardsfolder/e/ember_hauler.txt
+++ b/forge-gui/res/cardsfolder/e/ember_hauler.txt
@@ -2,5 +2,6 @@ Name:Ember Hauler
 ManaCost:R R
 Types:Creature Goblin
 PT:2/2
-A:AB$ DealDamage | Cost$ 1 Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to any target.
+A:AB$ DealDamage | Cost$ 1 Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ It deals 2 damage to any target.
+DeckHas:Ability$Sacrifice
 Oracle:{1}, Sacrifice Ember Hauler: It deals 2 damage to any target.

--- a/forge-gui/res/cardsfolder/e/expendable_troops.txt
+++ b/forge-gui/res/cardsfolder/e/expendable_troops.txt
@@ -3,4 +3,5 @@ ManaCost:1 W
 Types:Creature Human Soldier
 PT:2/1
 A:AB$ DealDamage | Cost$ T Sac<1/CARDNAME> | ValidTgts$ Creature.attacking,Creature.blocking | TgtPrompt$ Select target attacking or blocking creature | NumDmg$ 2 | SpellDescription$ It deals 2 damage to target attacking or blocking creature.
+DeckHas:Ability$Sacrifice
 Oracle:{T}, Sacrifice Expendable Troops: It deals 2 damage to target attacking or blocking creature.

--- a/forge-gui/res/cardsfolder/e/explosive_apparatus.txt
+++ b/forge-gui/res/cardsfolder/e/explosive_apparatus.txt
@@ -1,5 +1,6 @@
 Name:Explosive Apparatus
 ManaCost:1
 Types:Artifact
-A:AB$ DealDamage | Cost$ 3 T Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to any target.
+A:AB$ DealDamage | Cost$ 3 T Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ It deals 2 damage to any target.
+DeckHas:Ability$Sacrifice
 Oracle:{3}, {T}, Sacrifice Explosive Apparatus: It deals 2 damage to any target.

--- a/forge-gui/res/cardsfolder/f/fanatical_firebrand.txt
+++ b/forge-gui/res/cardsfolder/f/fanatical_firebrand.txt
@@ -3,5 +3,6 @@ ManaCost:R
 Types:Creature Goblin Pirate
 PT:1/1
 K:Haste
-A:AB$ DealDamage | Cost$ T Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to any target.
+A:AB$ DealDamage | Cost$ T Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ It deals 1 damage to any target.
+DeckHas:Ability$Sacrifice
 Oracle:Haste\n{T}, Sacrifice Fanatical Firebrand: It deals 1 damage to any target.

--- a/forge-gui/res/cardsfolder/f/fervent_paincaster.txt
+++ b/forge-gui/res/cardsfolder/f/fervent_paincaster.txt
@@ -3,5 +3,5 @@ ManaCost:2 R
 Types:Creature Human Wizard
 PT:3/1
 A:AB$ DealDamage | Cost$ T | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to target player or planeswalker.
-A:AB$ DealDamage | Cost$ T Exert<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to target creature. (An exerted creature won't untap during your next untap step.)
+A:AB$ DealDamage | Cost$ T Exert<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 1 | SpellDescription$ It deals 1 damage to target creature. (An exerted creature won't untap during your next untap step.)
 Oracle:{T}: Fervent Paincaster deals 1 damage to target player or planeswalker.\n{T}, Exert Fervent Paincaster: It deals 1 damage to target creature. (An exerted creature won't untap during your next untap step.)

--- a/forge-gui/res/cardsfolder/f/festering_evil.txt
+++ b/forge-gui/res/cardsfolder/f/festering_evil.txt
@@ -2,6 +2,7 @@ Name:Festering Evil
 ManaCost:3 B B
 Types:Enchantment
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDamageAll | TriggerDescription$ At the beginning of your upkeep, CARDNAME deals 1 damage to each creature and each player.
-A:AB$ DamageAll | Cost$ B B Sac<1/CARDNAME> | ValidCards$ Creature | ValidPlayers$ Player | NumDmg$ 3 | ValidDescription$ each creature and each player. | SpellDescription$ CARDNAME deals 3 damage to each creature and each player.
+A:AB$ DamageAll | Cost$ B B Sac<1/CARDNAME> | ValidCards$ Creature | ValidPlayers$ Player | NumDmg$ 3 | ValidDescription$ each creature and each player. | SpellDescription$ It deals 3 damage to each creature and each player.
 SVar:TrigDamageAll:DB$ DamageAll | ValidCards$ Creature | ValidPlayers$ Player | NumDmg$ 1 | ValidDescription$ each creature and each player.
+DeckHas:Ability$Sacrifice
 Oracle:At the beginning of your upkeep, Festering Evil deals 1 damage to each creature and each player.\n{B}{B}, Sacrifice Festering Evil: It deals 3 damage to each creature and each player.

--- a/forge-gui/res/cardsfolder/f/fire_bowman.txt
+++ b/forge-gui/res/cardsfolder/f/fire_bowman.txt
@@ -2,5 +2,6 @@ Name:Fire Bowman
 ManaCost:R
 Types:Creature Human Soldier Archer
 PT:1/1
-A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 1 | PlayerTurn$ True | ActivationPhases$ Upkeep->BeginCombat | ActivationFirstCombat$ True | SpellDescription$ CARDNAME deals 1 damage to any target. Activate only during your turn, before attackers are declared.
+A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 1 | PlayerTurn$ True | ActivationPhases$ Upkeep->BeginCombat | ActivationFirstCombat$ True | SpellDescription$ It deals 1 damage to any target. Activate only during your turn, before attackers are declared.
+DeckHas:Ability$Sacrifice
 Oracle:Sacrifice Fire Bowman: It deals 1 damage to any target. Activate only during your turn, before attackers are declared.

--- a/forge-gui/res/cardsfolder/f/fire_shrine_keeper.txt
+++ b/forge-gui/res/cardsfolder/f/fire_shrine_keeper.txt
@@ -3,5 +3,6 @@ ManaCost:R
 Types:Creature Elemental
 PT:1/1
 K:Menace
-A:AB$ DealDamage | Cost$ 7 R T Sac<1/CARDNAME> | TargetMin$ 0 | TargetMax$ 2 | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 3 | SpellDescription$ CARDNAME deals 3 damage to each of up to two target creatures.
+A:AB$ DealDamage | Cost$ 7 R T Sac<1/CARDNAME> | TargetMin$ 0 | TargetMax$ 2 | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 3 | SpellDescription$ It deals 3 damage to each of up to two target creatures.
+DeckHas:Ability$Sacrifice
 Oracle:Menace\n{7}{R}, {T}, Sacrifice Fire Shrine Keeper: It deals 3 damage to each of up to two target creatures.

--- a/forge-gui/res/cardsfolder/f/fireforgers_puzzleknot.txt
+++ b/forge-gui/res/cardsfolder/f/fireforgers_puzzleknot.txt
@@ -3,5 +3,6 @@ ManaCost:2
 Types:Artifact
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When CARDNAME enters the battlefield, it deals 1 damage to any target.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Any | NumDmg$ 1
-A:AB$ DealDamage | Cost$ 2 R Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to any target.
+A:AB$ DealDamage | Cost$ 2 R Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ It deals 1 damage to any target.
+DeckHas:Ability$Sacrifice
 Oracle:When Fireforger's Puzzleknot enters the battlefield, it deals 1 damage to any target.\n{2}{R}, Sacrifice Fireforger's Puzzleknot: It deals 1 damage to any target.

--- a/forge-gui/res/cardsfolder/f/fireminds_research.txt
+++ b/forge-gui/res/cardsfolder/f/fireminds_research.txt
@@ -4,9 +4,10 @@ Types:Enchantment
 T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ DBPutCounter | TriggerDescription$ Whenever you cast an instant or sorcery spell, put a charge counter on CARDNAME.
 SVar:DBPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ CHARGE | CounterNum$ 1
 SVar:BuffedBy:Instant,Sorcery
-DeckHints:Type$Instant|Sorcery
 A:AB$ Draw | Cost$ 1 U SubCounter<2/CHARGE> | NumCards$ 1 | SpellDescription$ Draw a card.
-A:AB$ DealDamage | Cost$ 1 R SubCounter<5/CHARGE> | ValidTgts$ Any | NumDmg$ 5 | SpellDescription$ CARDNAME deals 5 damage to any target.
+A:AB$ DealDamage | Cost$ 1 R SubCounter<5/CHARGE> | ValidTgts$ Any | NumDmg$ 5 | SpellDescription$ It deals 5 damage to any target.
 AI:RemoveDeck:Random
+DeckHas:Ability$Counters
+DeckHints:Ability$Proliferate & Type$Instant|Sorcery
 DeckNeeds:Type$Instant|Sorcery
 Oracle:Whenever you cast an instant or sorcery spell, put a charge counter on Firemind's Research.\n{1}{U}, Remove two charge counters from Firemind's Research: Draw a card.\n{1}{R}, Remove five charge counters from Firemind's Research: It deals 5 damage to any target.

--- a/forge-gui/res/cardsfolder/f/five_alarm_fire.txt
+++ b/forge-gui/res/cardsfolder/f/five_alarm_fire.txt
@@ -3,5 +3,7 @@ ManaCost:1 R R
 Types:Enchantment
 T:Mode$ DamageDealtOnce | CombatDamage$ True | ValidSource$ Creature.YouCtrl | Execute$ TrigPutCounter | TriggerZones$ Battlefield | TriggerDescription$ Whenever a creature you control deals combat damage, put a blaze counter on CARDNAME.
 SVar:TrigPutCounter:DB$ PutCounter | CounterType$ BLAZE | CounterNum$ 1
-A:AB$ DealDamage | Cost$ SubCounter<5/BLAZE> | ValidTgts$ Any | NumDmg$ 5 | SpellDescription$ CARDNAME deals 5 damage to any target.
+A:AB$ DealDamage | Cost$ SubCounter<5/BLAZE> | ValidTgts$ Any | NumDmg$ 5 | SpellDescription$ It deals 5 damage to any target.
+DeckHas:Ability$Counters
+DeckHints:Ability$Proliferate
 Oracle:Whenever a creature you control deals combat damage, put a blaze counter on Five-Alarm Fire.\nRemove five blaze counters from Five-Alarm Fire: It deals 5 damage to any target.

--- a/forge-gui/res/cardsfolder/f/flame_elemental.txt
+++ b/forge-gui/res/cardsfolder/f/flame_elemental.txt
@@ -2,6 +2,7 @@ Name:Flame Elemental
 ManaCost:2 R R
 Types:Creature Elemental
 PT:3/2
-A:AB$ DealDamage | Cost$ R T Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SpellDescription$ CARDNAME deals damage equal to its power to target creature.
+A:AB$ DealDamage | Cost$ R T Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SpellDescription$ It deals damage equal to its power to target creature.
 SVar:X:Sacrificed$CardPower
+DeckHas:Ability$Sacrifice
 Oracle:{R}, {T}, Sacrifice Flame Elemental: It deals damage equal to its power to target creature.

--- a/forge-gui/res/cardsfolder/f/flamecast_wheel.txt
+++ b/forge-gui/res/cardsfolder/f/flamecast_wheel.txt
@@ -2,4 +2,5 @@ Name:Flamecast Wheel
 ManaCost:1
 Types:Artifact
 A:AB$ DealDamage | Cost$ 5 T Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 3 | SpellDescription$ It deals 3 damage to target creature.
+DeckHas:Ability$Sacrifice
 Oracle:{5}, {T}, Sacrifice Flamecast Wheel: It deals 3 damage to target creature.

--- a/forge-gui/res/cardsfolder/f/font_of_ire.txt
+++ b/forge-gui/res/cardsfolder/f/font_of_ire.txt
@@ -1,5 +1,6 @@
 Name:Font of Ire
 ManaCost:1 R
 Types:Enchantment
-A:AB$ DealDamage | Cost$ 3 R Sac<1/CARDNAME> | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | NumDmg$ 5 | SpellDescription$ CARDNAME deals 5 damage to target player or planeswalker.
+A:AB$ DealDamage | Cost$ 3 R Sac<1/CARDNAME> | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | NumDmg$ 5 | SpellDescription$ It deals 5 damage to target player or planeswalker.
+DeckHas:Ability$Sacrifice
 Oracle:{3}{R}, Sacrifice Font of Ire: It deals 5 damage to target player or planeswalker.

--- a/forge-gui/res/cardsfolder/g/ghitu_fire_eater.txt
+++ b/forge-gui/res/cardsfolder/g/ghitu_fire_eater.txt
@@ -2,6 +2,7 @@ Name:Ghitu Fire-Eater
 ManaCost:2 R
 Types:Creature Human Nomad
 PT:2/2
-A:AB$ DealDamage | Cost$ T Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ X | SpellDescription$ CARDNAME deals damage equal to its power to any target.
+A:AB$ DealDamage | Cost$ T Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ X | SpellDescription$ It deals damage equal to its power to any target.
 SVar:X:Sacrificed$CardPower
+DeckHas:Ability$Sacrifice
 Oracle:{T}, Sacrifice Ghitu Fire-Eater: It deals damage equal to its power to any target.

--- a/forge-gui/res/cardsfolder/g/ghost_lit_raider.txt
+++ b/forge-gui/res/cardsfolder/g/ghost_lit_raider.txt
@@ -3,5 +3,6 @@ ManaCost:2 R
 Types:Creature Spirit
 PT:2/1
 A:AB$ DealDamage | Cost$ 2 R T | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to target creature.
-A:AB$ DealDamage | Cost$ 3 R Discard<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 4 | ActivationZone$ Hand | PrecostDesc$ Channel — | SpellDescription$ CARDNAME deals 4 damage to target creature.
+A:AB$ DealDamage | Cost$ 3 R Discard<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 4 | ActivationZone$ Hand | PrecostDesc$ Channel — | SpellDescription$ It deals 4 damage to target creature.
+DeckHas:Ability$Discard
 Oracle:{2}{R}, {T}: Ghost-Lit Raider deals 2 damage to target creature.\nChannel — {3}{R}, Discard Ghost-Lit Raider: It deals 4 damage to target creature.

--- a/forge-gui/res/cardsfolder/g/goblin_bomb.txt
+++ b/forge-gui/res/cardsfolder/g/goblin_bomb.txt
@@ -5,5 +5,6 @@ T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | O
 SVar:TrigFlip:DB$ FlipACoin | WinSubAbility$ DBAddCounter | LoseSubAbility$ DBRemoveCounter
 SVar:DBAddCounter:DB$ PutCounter | Defined$ Self | CounterType$ FUSE | CounterNum$ 1
 SVar:DBRemoveCounter:DB$ RemoveCounter | Defined$ Self | CounterType$ FUSE | CounterNum$ 1
-A:AB$ DealDamage | Cost$ SubCounter<5/FUSE> Sac<1/CARDNAME> | ValidTgts$ Player,Planeswalker | TgtPrompt$ Choose target player or planeswalker | NumDmg$ 20 | SpellDescription$ CARDNAME deals 20 damage to target player or planeswalker.
+A:AB$ DealDamage | Cost$ SubCounter<5/FUSE> Sac<1/CARDNAME> | ValidTgts$ Player,Planeswalker | TgtPrompt$ Choose target player or planeswalker | NumDmg$ 20 | SpellDescription$ It deals 20 damage to target player or planeswalker.
+DeckHas:Ability$Counters|Sacrifice
 Oracle:At the beginning of your upkeep, you may flip a coin. If you win the flip, put a fuse counter on Goblin Bomb. If you lose the flip, remove a fuse counter from Goblin Bomb.\nRemove five fuse counters from Goblin Bomb and sacrifice it: It deals 20 damage to target player or planeswalker.

--- a/forge-gui/res/cardsfolder/g/goblin_dynamo.txt
+++ b/forge-gui/res/cardsfolder/g/goblin_dynamo.txt
@@ -3,7 +3,8 @@ ManaCost:5 R R
 Types:Creature Goblin Mutant
 PT:4/4
 A:AB$ DealDamage | Cost$ T | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to any target.
-A:AB$ DealDamage | Cost$ X R T Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to any target.
+A:AB$ DealDamage | Cost$ X R T Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ X | SpellDescription$ It deals X damage to any target.
 SVar:X:Count$xPaid
 AI:RemoveDeck:All
+DeckHas:Ability$Sacrifice
 Oracle:{T}: Goblin Dynamo deals 1 damage to any target.\n{X}{R}, {T}, Sacrifice Goblin Dynamo: It deals X damage to any target.

--- a/forge-gui/res/cardsfolder/g/goblin_firestarter.txt
+++ b/forge-gui/res/cardsfolder/g/goblin_firestarter.txt
@@ -2,5 +2,6 @@ Name:Goblin Firestarter
 ManaCost:R
 Types:Creature Goblin
 PT:1/1
-A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 1 | PlayerTurn$ True | ActivationPhases$ Upkeep->BeginCombat | ActivationFirstCombat$ True | SpellDescription$ CARDNAME deals 1 damage to any target. Activate only during your turn, before attackers are declared.
+A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 1 | PlayerTurn$ True | ActivationPhases$ Upkeep->BeginCombat | ActivationFirstCombat$ True | SpellDescription$ It deals 1 damage to any target. Activate only during your turn, before attackers are declared.
+DeckHas:Ability$Sacrifice
 Oracle:Sacrifice Goblin Firestarter: It deals 1 damage to any target. Activate only during your turn, before attackers are declared.

--- a/forge-gui/res/cardsfolder/g/goblin_legionnaire.txt
+++ b/forge-gui/res/cardsfolder/g/goblin_legionnaire.txt
@@ -2,7 +2,8 @@ Name:Goblin Legionnaire
 ManaCost:R W
 Types:Creature Goblin Soldier
 PT:2/2
-A:AB$ DealDamage | Cost$ R Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to any target.
+A:AB$ DealDamage | Cost$ R Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ It deals 2 damage to any target.
 A:AB$ PreventDamage | Cost$ W Sac<1/CARDNAME> | ValidTgts$ Any | Amount$ 2 | SpellDescription$ Prevent the next 2 damage that would be dealt to any target this turn.
 AI:RemoveDeck:All
+DeckHas:Ability$Sacrifice
 Oracle:{R}, Sacrifice Goblin Legionnaire: It deals 2 damage to any target.\n{W}, Sacrifice Goblin Legionnaire: Prevent the next 2 damage that would be dealt to any target this turn.

--- a/forge-gui/res/cardsfolder/g/goblin_skycutter.txt
+++ b/forge-gui/res/cardsfolder/g/goblin_skycutter.txt
@@ -2,6 +2,7 @@ Name:Goblin Skycutter
 ManaCost:1 R
 Types:Creature Goblin Warrior
 PT:2/1
-A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Creature.withFlying | TgtPrompt$ Select target creature with flying | NumDmg$ 2 | SubAbility$ DBDebuff | SpellDescription$ CARDNAME deals 2 damage to target creature with flying. That creature loses flying until end of turn.
+A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Creature.withFlying | TgtPrompt$ Select target creature with flying | NumDmg$ 2 | SubAbility$ DBDebuff | SpellDescription$ It deals 2 damage to target creature with flying. That creature loses flying until end of turn.
 SVar:DBDebuff:DB$ Debuff | Defined$ Targeted | Keywords$ Flying
+DeckHas:Ability$Sacrifice
 Oracle:Sacrifice Goblin Skycutter: It deals 2 damage to target creature with flying. That creature loses flying until end of turn.

--- a/forge-gui/res/cardsfolder/g/gremlin_mine.txt
+++ b/forge-gui/res/cardsfolder/g/gremlin_mine.txt
@@ -1,7 +1,8 @@
 Name:Gremlin Mine
 ManaCost:1
 Types:Artifact
-A:AB$ DealDamage | Cost$ 1 T Sac<1/CARDNAME> | ValidTgts$ Creature.Artifact | TgtPrompt$ Select target artifact creature | NumDmg$ 4 | SpellDescription$ CARDNAME deals 4 damage to target artifact creature.
+A:AB$ DealDamage | Cost$ 1 T Sac<1/CARDNAME> | ValidTgts$ Creature.Artifact | TgtPrompt$ Select target artifact creature | NumDmg$ 4 | SpellDescription$ It deals 4 damage to target artifact creature.
 A:AB$ RemoveCounter | Cost$ 1 T Sac<1/CARDNAME> | ValidTgts$ Artifact.nonCreature | TgtPrompt$ Select target noncreature artifact | CounterType$ CHARGE | CounterNum$ 4 | UpTo$ True | SpellDescription$ Remove up to four charge counters from target noncreature artifact.
 AI:RemoveDeck:All
+DeckHas:Ability$Sacrifice
 Oracle:{1}, {T}, Sacrifice Gremlin Mine: It deals 4 damage to target artifact creature.\n{1}, {T}, Sacrifice Gremlin Mine: Remove up to four charge counters from target noncreature artifact.

--- a/forge-gui/res/cardsfolder/h/heartfire_immolator.txt
+++ b/forge-gui/res/cardsfolder/h/heartfire_immolator.txt
@@ -3,6 +3,7 @@ ManaCost:1 R
 Types:Creature Human Wizard
 PT:2/2
 K:Prowess
-A:AB$ DealDamage | Cost$ R Sac<1/CARDNAME> | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ X | SpellDescription$ CARDNAME deals damage equal to its power to target creature or planeswalker.
+A:AB$ DealDamage | Cost$ R Sac<1/CARDNAME> | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ X | SpellDescription$ It deals damage equal to its power to target creature or planeswalker.
 SVar:X:Sacrificed$CardPower
+DeckHas:Ability$Sacrifice
 Oracle:Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\n{R}, Sacrifice Heartfire Immolator: It deals damage equal to its power to target creature or planeswalker.

--- a/forge-gui/res/cardsfolder/h/heliophial.txt
+++ b/forge-gui/res/cardsfolder/h/heliophial.txt
@@ -1,10 +1,11 @@
 Name:Heliophial
 ManaCost:5
 Types:Artifact
-A:AB$ DealDamage | Cost$ 2 Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ X | SpellDescription$ CARDNAME deals damage equal to the number of charge counters on it to any target.
+A:AB$ DealDamage | Cost$ 2 Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ X | SpellDescription$ It deals damage equal to the number of charge counters on it to any target.
 K:Sunburst
 SVar:X:Count$CardCounters.CHARGE
 SVar:NeedsToPlayVar:Z GE1
 SVar:Z:Count$UniqueManaColorsProduced.ByUntappedSources
+DeckHas:Ability$Counters|Sacrifice
 DeckHints:Ability$Proliferate
 Oracle:Sunburst (This enters the battlefield with a charge counter on it for each color of mana spent to cast it.)\n{2}, Sacrifice Heliophial: It deals damage equal to the number of charge counters on it to any target.

--- a/forge-gui/res/cardsfolder/i/icatian_javelineers.txt
+++ b/forge-gui/res/cardsfolder/i/icatian_javelineers.txt
@@ -3,5 +3,7 @@ ManaCost:W
 Types:Creature Human Soldier
 PT:1/1
 K:etbCounter:JAVELIN:1
-A:AB$ DealDamage | Cost$ T SubCounter<1/JAVELIN> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to any target.
+A:AB$ DealDamage | Cost$ T SubCounter<1/JAVELIN> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ It deals 1 damage to any target.
+DeckHas:Ability$Counters
+DeckHints:Ability$Proliferate
 Oracle:Icatian Javelineers enters the battlefield with a javelin counter on it.\n{T}, Remove a javelin counter from Icatian Javelineers: It deals 1 damage to any target.

--- a/forge-gui/res/cardsfolder/i/ill_gotten_inheritance.txt
+++ b/forge-gui/res/cardsfolder/i/ill_gotten_inheritance.txt
@@ -4,6 +4,7 @@ Types:Enchantment
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDealDamage | TriggerDescription$ At the beginning of your upkeep, CARDNAME deals 1 damage to each opponent and you gain 1 life.
 SVar:TrigDealDamage:DB$ DamageAll | ValidPlayers$ Player.Opponent | NumDmg$ 1 | SubAbility$ DBGainOneLife
 SVar:DBGainOneLife:DB$ GainLife | Defined$ You | LifeAmount$ 1
-A:AB$ DealDamage | Cost$ 5 B Sac<1/CARDNAME> | ValidTgts$ Opponent | NumDmg$ 4 | SubAbility$ DBGainFourLife | SpellDescription$ CARDNAME deals 4 damage to target opponent and you gain 4 life.
+A:AB$ DealDamage | Cost$ 5 B Sac<1/CARDNAME> | ValidTgts$ Opponent | NumDmg$ 4 | SubAbility$ DBGainFourLife | SpellDescription$ It deals 4 damage to target opponent and you gain 4 life.
 SVar:DBGainFourLife:DB$ GainLife | Defined$ You | LifeAmount$ 4
+DeckHas:Ability$Sacrifice
 Oracle:At the beginning of your upkeep, Ill-Gotten Inheritance deals 1 damage to each opponent and you gain 1 life.\n{5}{B}, Sacrifice Ill-Gotten Inheritance: It deals 4 damage to target opponent and you gain 4 life.

--- a/forge-gui/res/cardsfolder/i/immersturm_skullcairn.txt
+++ b/forge-gui/res/cardsfolder/i/immersturm_skullcairn.txt
@@ -3,6 +3,7 @@ ManaCost:no cost
 Types:Land
 K:CARDNAME enters the battlefield tapped.
 A:AB$ Mana | Cost$ T | Produced$ B | SpellDescription$ Add {B}.
-A:AB$ DealDamage | Cost$ 1 B R R T Sac<1/CARDNAME> | ValidTgts$ Player | TgtPrompt$ Select target player | NumDmg$ 3 | SubAbility$ DBDiscard | SorcerySpeed$ True | SpellDescription$ CARDNAME deals 3 damage to target player. That player discards a card. Activate only any time you could cast a sorcery.
+A:AB$ DealDamage | Cost$ 1 B R R T Sac<1/CARDNAME> | ValidTgts$ Player | TgtPrompt$ Select target player | NumDmg$ 3 | SubAbility$ DBDiscard | SorcerySpeed$ True | SpellDescription$ It deals 3 damage to target player. That player discards a card. Activate only any time you could cast a sorcery.
 SVar:DBDiscard:DB$ Discard | Defined$ TargetedPlayer | NumCards$ 1 | Mode$ TgtChoose
+DeckHas:Ability$Sacrifice
 Oracle:Immersturm Skullcairn enters the battlefield tapped.\n{T}: Add {B}.\n{1}{B}{R}{R}, {T}, Sacrifice Immersturm Skullcairn: It deals 3 damage to target player. That player discards a card. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/i/implement_of_combustion.txt
+++ b/forge-gui/res/cardsfolder/i/implement_of_combustion.txt
@@ -1,9 +1,10 @@
 Name:Implement of Combustion
 ManaCost:1
 Types:Artifact
-A:AB$ DealDamage | Cost$ R Sac<1/CARDNAME> | NumDmg$ 1 | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | SpellDescription$ CARDNAME deals 1 damage to target player or planeswalker.
+A:AB$ DealDamage | Cost$ R Sac<1/CARDNAME> | NumDmg$ 1 | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | SpellDescription$ It deals 1 damage to target player or planeswalker.
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ When CARDNAME is put into a graveyard from the battlefield, draw a card.
 SVar:TrigDraw:DB$ Draw | NumCards$ 1 | Defined$ TriggeredCardController
 AI:RemoveDeck:Random
+DeckHas:Ability$Sacrifice
 DeckNeeds:Color$Red
 Oracle:{R}, Sacrifice Implement of Combustion: It deals 1 damage to target player or planeswalker.\nWhen Implement of Combustion is put into a graveyard from the battlefield, draw a card.

--- a/forge-gui/res/cardsfolder/l/leonin_bladetrap.txt
+++ b/forge-gui/res/cardsfolder/l/leonin_bladetrap.txt
@@ -2,5 +2,6 @@ Name:Leonin Bladetrap
 ManaCost:3
 Types:Artifact
 K:Flash
-A:AB$ DamageAll | Cost$ 2 Sac<1/CARDNAME> | ValidCards$ Creature.attacking+withoutFlying | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to each attacking creature without flying.
+A:AB$ DamageAll | Cost$ 2 Sac<1/CARDNAME> | ValidCards$ Creature.attacking+withoutFlying | NumDmg$ 2 | SpellDescription$ It deals 2 damage to each attacking creature without flying.
+DeckHas:Ability$Sacrifice
 Oracle:Flash (You may cast this spell any time you could cast an instant.)\n{2}, Sacrifice Leonin Bladetrap: It deals 2 damage to each attacking creature without flying.

--- a/forge-gui/res/cardsfolder/l/lightning_spear.txt
+++ b/forge-gui/res/cardsfolder/l/lightning_spear.txt
@@ -3,5 +3,6 @@ ManaCost:1 R
 Types:Artifact Equipment
 K:Equip:1
 S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 1 | AddKeyword$ Trample | Description$ Equipped creature gets +1/+0 and has trample.
-A:AB$ DealDamage | Cost$ 2 R Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 3 | SpellDescription$ CARDNAME deals 3 damage to any target.
+A:AB$ DealDamage | Cost$ 2 R Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 3 | SpellDescription$ It deals 3 damage to any target.
+DeckHas:Ability$Sacrifice
 Oracle:Equipped creature gets +1/+0 and has trample.\n{2}{R}, Sacrifice Lightning Spear: It deals 3 damage to any target.\nEquip {1}

--- a/forge-gui/res/cardsfolder/m/mask_of_immolation.txt
+++ b/forge-gui/res/cardsfolder/m/mask_of_immolation.txt
@@ -6,9 +6,9 @@ SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ r_1_1_elemental | Token
 SVar:DBAttach:DB$ Attach | Defined$ Remembered | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 S:Mode$ Continuous | Affected$ Card.EquippedBy | AddAbility$ Damage | Description$ Equipped creature has "Sacrifice this creature: It deals 1 damage to any target."
-SVar:Damage:AB$DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to any target.
+SVar:Damage:AB$DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ It deals 1 damage to any target.
 SVar:NonStackingAttachEffect:True
-AI:RemoveDeck:All
-DeckHas:Ability$Token
 K:Equip:2
+AI:RemoveDeck:All
+DeckHas:Ability$Sacrifice|Token
 Oracle:When Mask of Immolation enters the battlefield, create a 1/1 red Elemental creature token, then attach Mask of Immolation to it.\nEquipped creature has "Sacrifice this creature: It deals 1 damage to any target."\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)

--- a/forge-gui/res/cardsfolder/m/mask_of_immolation.txt
+++ b/forge-gui/res/cardsfolder/m/mask_of_immolation.txt
@@ -10,5 +10,5 @@ SVar:Damage:AB$DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 1 |
 SVar:NonStackingAttachEffect:True
 K:Equip:2
 AI:RemoveDeck:All
-DeckHas:Ability$Sacrifice|Token
+DeckHas:Ability$Sacrifice|Token & Type$Elemental
 Oracle:When Mask of Immolation enters the battlefield, create a 1/1 red Elemental creature token, then attach Mask of Immolation to it.\nEquipped creature has "Sacrifice this creature: It deals 1 damage to any target."\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)

--- a/forge-gui/res/cardsfolder/m/minotaur_illusionist.txt
+++ b/forge-gui/res/cardsfolder/m/minotaur_illusionist.txt
@@ -3,6 +3,7 @@ ManaCost:3 U R
 Types:Creature Minotaur Wizard
 PT:3/4
 A:AB$ Pump | Cost$ 1 U | Defined$ Self | KW$ Shroud | SpellDescription$ CARDNAME gains shroud until end of turn.
-A:AB$ DealDamage | Cost$ R Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SpellDescription$ CARDNAME deals damage equal to its power to target creature.
+A:AB$ DealDamage | Cost$ R Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SpellDescription$ It deals damage equal to its power to target creature.
 SVar:X:Sacrificed$CardPower
+DeckHas:Ability$Sacrifice
 Oracle:{1}{U}: Minotaur Illusionist gains shroud until end of turn. (It can't be the target of spells or abilities.)\n{R}, Sacrifice Minotaur Illusionist: It deals damage equal to its power to target creature.

--- a/forge-gui/res/cardsfolder/m/molten_hydra.txt
+++ b/forge-gui/res/cardsfolder/m/molten_hydra.txt
@@ -3,6 +3,8 @@ ManaCost:1 R
 Types:Creature Hydra
 PT:1/1
 A:AB$ PutCounter | Cost$ 1 R R | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on CARDNAME.
-A:AB$ DealDamage | Cost$ T SubCounter<All/P1P1> | ValidTgts$ Any | NumDmg$ X | SpellDescription$ CARDNAME deals damage to any target equal to the number of +1/+1 counters removed this way.
+A:AB$ DealDamage | Cost$ T SubCounter<All/P1P1> | ValidTgts$ Any | NumDmg$ X | SpellDescription$ It deals damage to any target equal to the number of +1/+1 counters removed this way.
 SVar:X:SVar$CostCountersRemoved
+DeckHas:Ability$Counters
+DeckHints:Ability$Proliferate
 Oracle:{1}{R}{R}: Put a +1/+1 counter on Molten Hydra.\n{T}, Remove all +1/+1 counters from Molten Hydra: It deals damage to any target equal to the number of +1/+1 counters removed this way.

--- a/forge-gui/res/cardsfolder/m/mouth_of_ronom.txt
+++ b/forge-gui/res/cardsfolder/m/mouth_of_ronom.txt
@@ -2,6 +2,7 @@ Name:Mouth of Ronom
 ManaCost:no cost
 Types:Snow Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
-A:AB$ DealDamage | Cost$ 4 S T Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 4 | SpellDescription$ CARDNAME deals 4 damage to target creature.
+A:AB$ DealDamage | Cost$ 4 S T Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 4 | SpellDescription$ It deals 4 damage to target creature.
 AI:RemoveDeck:Random
+DeckHas:Ability$Sacrifice
 Oracle:{T}: Add {C}.\n{4}{S}, {T}, Sacrifice Mouth of Ronom: It deals 4 damage to target creature. ({S} can be paid with one mana from a snow source.)

--- a/forge-gui/res/cardsfolder/m/myojin_of_roaring_blades.txt
+++ b/forge-gui/res/cardsfolder/m/myojin_of_roaring_blades.txt
@@ -4,5 +4,7 @@ Types:Legendary Creature Spirit
 PT:7/4
 K:etbCounter:Indestructible:1:CheckSVar$ FromHand:CARDNAME enters the battlefield with an indestructible counter on it if you cast it from your hand.
 SVar:FromHand:Count$wasCastFromYourHandByYou.1.0
-A:AB$ DealDamage | Cost$ SubCounter<1/Indestructible> | NumDmg$ 7 | TargetMin$ 0 | TargetMax$ 3 | ValidTgts$ Any | SpellDescription$ CARDNAME deals 7 damage to each of up to three targets.
+A:AB$ DealDamage | Cost$ SubCounter<1/Indestructible> | NumDmg$ 7 | TargetMin$ 0 | TargetMax$ 3 | ValidTgts$ Any | SpellDescription$ It deals 7 damage to each of up to three targets.
+DeckHas:Ability$Counters
+DeckHints:Ability$Proliferate
 Oracle:Myojin of Roaring Blades enters the battlefield with an indestructible counter on it if you cast it from your hand.\nRemove an indestructible counter from Myojin of Roaring Blades: It deals 7 damage to each of up to three targets.

--- a/forge-gui/res/cardsfolder/p/pain_kami.txt
+++ b/forge-gui/res/cardsfolder/p/pain_kami.txt
@@ -2,7 +2,8 @@ Name:Pain Kami
 ManaCost:2 R
 Types:Creature Spirit
 PT:2/2
-A:AB$ DealDamage | Cost$ X R Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to target creature.
+A:AB$ DealDamage | Cost$ X R Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SpellDescription$ It deals X damage to target creature.
 SVar:X:Count$xPaid
 AI:RemoveDeck:Random
+DeckHas:Ability$Sacrifice
 Oracle:{X}{R}, Sacrifice Pain Kami: It deals X damage to target creature.

--- a/forge-gui/res/cardsfolder/p/pyre_zombie.txt
+++ b/forge-gui/res/cardsfolder/p/pyre_zombie.txt
@@ -2,10 +2,11 @@ Name:Pyre Zombie
 ManaCost:1 B R
 Types:Creature Zombie
 PT:2/1
-A:AB$ DealDamage | Cost$ 1 R R Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to any target.
+A:AB$ DealDamage | Cost$ 1 R R Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ It deals 2 damage to any target.
 #The IsPresent stuff in the trigger is necessary because it must be checked on resolve as well.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | IsPresent$ Card.StrictlySelf | PresentZone$ Graveyard | PresentPlayer$ You | TriggerZones$ Graveyard | OptionalDecider$ You | Execute$ TrigReturn | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard, you may pay {1}{B}{B}. If you do, return CARDNAME to your hand.
 SVar:TrigReturn:AB$ ChangeZone | Cost$ 1 B B | Defined$ Self | Origin$ Graveyard | Destination$ Hand
 SVar:SacMe:2
 SVar:DiscardMe:1
+DeckHas:Ability$Sacrifice
 Oracle:At the beginning of your upkeep, if Pyre Zombie is in your graveyard, you may pay {1}{B}{B}. If you do, return Pyre Zombie to your hand.\n{1}{R}{R}, Sacrifice Pyre Zombie: It deals 2 damage to any target.

--- a/forge-gui/res/cardsfolder/p/pyromania.txt
+++ b/forge-gui/res/cardsfolder/p/pyromania.txt
@@ -2,6 +2,7 @@ Name:Pyromania
 ManaCost:2 R
 Types:Enchantment
 A:AB$ DealDamage | Cost$ 1 R Discard<1/Random> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to any target.
-A:AB$ DealDamage | Cost$ 1 R Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to any target.
+A:AB$ DealDamage | Cost$ 1 R Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ It deals 1 damage to any target.
 AI:RemoveDeck:All
+DeckHas:Ability$Discard|Sacrifice
 Oracle:{1}{R}, Discard a card at random: Pyromania deals 1 damage to any target.\n{1}{R}, Sacrifice Pyromania: It deals 1 damage to any target.

--- a/forge-gui/res/cardsfolder/r/razor_boomerang.txt
+++ b/forge-gui/res/cardsfolder/r/razor_boomerang.txt
@@ -1,9 +1,9 @@
 Name:Razor Boomerang
 ManaCost:3
 Types:Artifact Equipment
-S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddAbility$ RazorDamage | AddSVar$ BoomerangCatch | Description$ Equipped creature has "{T}, Unattach CARDNAME: CARDNAME deals 1 damage to any target. Return CARDNAME to its owner's hand."
-SVar:RazorDamage:AB$ DealDamage | Cost$ T Unattach<OriginalHost/Razor Boomerang> | NumDmg$ 1 | DamageSource$ OriginalHost | ValidTgts$ Any | SubAbility$ BoomerangCatch | SpellDescription$ ORIGINALHOST deals 1 damage to any target. Return ORIGINALHOST to its owner's hand.
+S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddAbility$ RazorDamage | AddSVar$ BoomerangCatch | Description$ Equipped creature has "{T}, Unattach CARDNAME: It deals 1 damage to any target. Return CARDNAME to its owner's hand."
+SVar:RazorDamage:AB$ DealDamage | Cost$ T Unattach<OriginalHost/Razor Boomerang> | NumDmg$ 1 | DamageSource$ OriginalHost | ValidTgts$ Any | SubAbility$ BoomerangCatch | SpellDescription$ It deals 1 damage to any target. Return ORIGINALHOST to its owner's hand.
 SVar:BoomerangCatch:DB$ ChangeZone | Origin$ Battlefield | Destination$ Hand | Defined$ OriginalHost
 K:Equip:2
 SVar:NonStackingAttachEffect:True
-Oracle:Equipped creature has "{T}, Unattach Razor Boomerang: It deals 1 damage to any target. Return Razor Boomerang to its owner's hand."\nEquip {2}
+Oracle:Equipped creature has "{T}, Unattach Razor Boomerang: Razor Boomerang deals 1 damage to any target. Return Razor Boomerang to its owner's hand."\nEquip {2}

--- a/forge-gui/res/cardsfolder/r/razor_boomerang.txt
+++ b/forge-gui/res/cardsfolder/r/razor_boomerang.txt
@@ -6,4 +6,4 @@ SVar:RazorDamage:AB$ DealDamage | Cost$ T Unattach<OriginalHost/Razor Boomerang>
 SVar:BoomerangCatch:DB$ ChangeZone | Origin$ Battlefield | Destination$ Hand | Defined$ OriginalHost
 K:Equip:2
 SVar:NonStackingAttachEffect:True
-Oracle:Equipped creature has "{T}, Unattach Razor Boomerang: Razor Boomerang deals 1 damage to any target. Return Razor Boomerang to its owner's hand."\nEquip {2}
+Oracle:Equipped creature has "{T}, Unattach Razor Boomerang: It deals 1 damage to any target. Return Razor Boomerang to its owner's hand."\nEquip {2}

--- a/forge-gui/res/cardsfolder/s/scalding_cauldron.txt
+++ b/forge-gui/res/cardsfolder/s/scalding_cauldron.txt
@@ -1,5 +1,6 @@
 Name:Scalding Cauldron
 ManaCost:1
 Types:Artifact
-A:AB$ DealDamage | Cost$ 3 T Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 3 | SpellDescription$ CARDNAME deals 3 damage to target creature.
+A:AB$ DealDamage | Cost$ 3 T Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 3 | SpellDescription$ It deals 3 damage to target creature.
+DeckHas:Ability$Sacrifice
 Oracle:{3}, {T}, Sacrifice Scalding Cauldron: It deals 3 damage to target creature.

--- a/forge-gui/res/cardsfolder/s/scaldkin.txt
+++ b/forge-gui/res/cardsfolder/s/scaldkin.txt
@@ -3,5 +3,6 @@ ManaCost:3 U
 Types:Creature Elemental
 PT:2/2
 K:Flying
-A:AB$ DealDamage | Cost$ 2 R Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to any target.
+A:AB$ DealDamage | Cost$ 2 R Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ It deals 2 damage to any target.
+DeckHas:Ability$Sacrifice
 Oracle:Flying\n{2}{R}, Sacrifice Scaldkin: It deals 2 damage to any target.

--- a/forge-gui/res/cardsfolder/s/seal_of_fire.txt
+++ b/forge-gui/res/cardsfolder/s/seal_of_fire.txt
@@ -1,6 +1,7 @@
 Name:Seal of Fire
 ManaCost:R
 Types:Enchantment
-A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to any target.
+A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ It deals 2 damage to any target.
 SVar:PlayMain1:TRUE
+DeckHas:Ability$Sacrifice
 Oracle:Sacrifice Seal of Fire: It deals 2 damage to any target.

--- a/forge-gui/res/cardsfolder/s/shock_troops.txt
+++ b/forge-gui/res/cardsfolder/s/shock_troops.txt
@@ -2,5 +2,6 @@ Name:Shock Troops
 ManaCost:3 R
 Types:Creature Human Soldier
 PT:2/2
-A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to any target.
+A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ It deals 2 damage to any target.
+DeckHas:Ability$Sacrifice
 Oracle:Sacrifice Shock Troops: It deals 2 damage to any target.

--- a/forge-gui/res/cardsfolder/s/shrine_of_burning_rage.txt
+++ b/forge-gui/res/cardsfolder/s/shrine_of_burning_rage.txt
@@ -4,6 +4,8 @@ Types:Artifact
 T:Mode$ SpellCast | ValidCard$ Card.Red | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigAddCounter | TriggerDescription$ At the beginning of your upkeep or whenever you cast a red spell, put a charge counter on CARDNAME.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigAddCounter | Secondary$ True | TriggerDescription$ At the beginning of your upkeep or whenever you cast a red spell, put a charge counter on CARDNAME.
 SVar:TrigAddCounter:DB$ PutCounter | CounterType$ CHARGE | CounterNum$ 1
-A:AB$ DealDamage | Cost$ 3 T Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ X | SpellDescription$ CARDNAME deals damage equal to the number of charge counters on it to any target.
+A:AB$ DealDamage | Cost$ 3 T Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ X | SpellDescription$ It deals damage equal to the number of charge counters on it to any target.
 SVar:X:Count$CardCounters.CHARGE
+DeckHas:Ability$Counters|Sacrifice
+DeckHints:Ability$Proliferate
 Oracle:At the beginning of your upkeep or whenever you cast a red spell, put a charge counter on Shrine of Burning Rage.\n{3}, {T}, Sacrifice Shrine of Burning Rage: It deals damage equal to the number of charge counters on it to any target.

--- a/forge-gui/res/cardsfolder/s/silent_dart.txt
+++ b/forge-gui/res/cardsfolder/s/silent_dart.txt
@@ -1,5 +1,6 @@
 Name:Silent Dart
 ManaCost:1
 Types:Artifact
-A:AB$ DealDamage | Cost$ 4 T Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 3 | SpellDescription$ CARDNAME deals 3 damage to target creature.
+A:AB$ DealDamage | Cost$ 4 T Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 3 | SpellDescription$ It deals 3 damage to target creature.
+DeckHas:Ability$Sacrifice
 Oracle:{4}, {T}, Sacrifice Silent Dart: It deals 3 damage to target creature.

--- a/forge-gui/res/cardsfolder/s/silver_bolt.txt
+++ b/forge-gui/res/cardsfolder/s/silver_bolt.txt
@@ -1,7 +1,8 @@
 Name:Silver Bolt
 ManaCost:1
 Types:Artifact
-A:AB$ DealDamage | Cost$ 3 T Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 3 | RememberDamaged$ True | SubAbility$ DBDestroy | StackDescription$ CARDNAME deals 3 damage to {c:Targeted}. | SpellDescription$ CARDNAME deals 3 damage to target creature. If a Werewolf is dealt damage this way, destroy it.
+A:AB$ DealDamage | Cost$ 3 T Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 3 | RememberDamaged$ True | SubAbility$ DBDestroy | StackDescription$ CARDNAME deals 3 damage to {c:Targeted}. | SpellDescription$ It deals 3 damage to target creature. If a Werewolf is dealt damage this way, destroy it.
 SVar:DBDestroy:DB$ Destroy | Defined$ Remembered | ConditionDefined$ Remembered | ConditionPresent$ Creature.Werewolf | SubAbility$ DBCleanup | StackDescription$ If a Werewolf is dealt damage this way, destroy it.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+DeckHas:Ability$Sacrifice
 Oracle:{3}, {T}, Sacrifice Silver Bolt: It deals 3 damage to target creature. If a Werewolf is dealt damage this way, destroy it.

--- a/forge-gui/res/cardsfolder/s/smoldering_tar.txt
+++ b/forge-gui/res/cardsfolder/s/smoldering_tar.txt
@@ -3,5 +3,6 @@ ManaCost:2 B R
 Types:Enchantment
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigLoseLife | TriggerDescription$ At the beginning of your upkeep, target player loses 1 life.
 SVar:TrigLoseLife:DB$ LoseLife | ValidTgts$ Player | TgtPrompt$ Select a player | LifeAmount$ 1
-A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 4 | SorcerySpeed$ True | SpellDescription$ CARDNAME deals 4 damage to target creature. Activate only any time you could cast a sorcery.
+A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 4 | SorcerySpeed$ True | SpellDescription$ It deals 4 damage to target creature. Activate only any time you could cast a sorcery.
+DeckHas:Ability$Sacrifice
 Oracle:At the beginning of your upkeep, target player loses 1 life.\nSacrifice Smoldering Tar: It deals 4 damage to target creature. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/s/soldier_replica.txt
+++ b/forge-gui/res/cardsfolder/s/soldier_replica.txt
@@ -2,6 +2,7 @@ Name:Soldier Replica
 ManaCost:3
 Types:Artifact Creature Soldier
 PT:1/3
-A:AB$ DealDamage | Cost$ 1 W Sac<1/CARDNAME> | ValidTgts$ Creature.attacking,Creature.blocking | TgtPrompt$ Select target attacking or blocking creature | NumDmg$ 3 | SpellDescription$ CARDNAME deals 3 damage to target attacking or blocking creature.
+A:AB$ DealDamage | Cost$ 1 W Sac<1/CARDNAME> | ValidTgts$ Creature.attacking,Creature.blocking | TgtPrompt$ Select target attacking or blocking creature | NumDmg$ 3 | SpellDescription$ It deals 3 damage to target attacking or blocking creature.
 AI:RemoveDeck:All
+DeckHas:Ability$Sacrifice
 Oracle:{1}{W}, Sacrifice Soldier Replica: It deals 3 damage to target attacking or blocking creature.

--- a/forge-gui/res/cardsfolder/s/spitting_hydra.txt
+++ b/forge-gui/res/cardsfolder/s/spitting_hydra.txt
@@ -3,5 +3,7 @@ ManaCost:3 R R
 Types:Creature Hydra
 PT:0/0
 K:etbCounter:P1P1:4
-A:AB$ DealDamage | Cost$ 1 R SubCounter<1/P1P1> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to target creature.
+A:AB$ DealDamage | Cost$ 1 R SubCounter<1/P1P1> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 1 | SpellDescription$ It deals 1 damage to target creature.
+DeckHas:Ability$Counters
+DeckHints:Ability$Proliferate
 Oracle:Spitting Hydra enters the battlefield with four +1/+1 counters on it.\n{1}{R}, Remove a +1/+1 counter from Spitting Hydra: It deals 1 damage to target creature.

--- a/forge-gui/res/cardsfolder/s/springjaw_trap.txt
+++ b/forge-gui/res/cardsfolder/s/springjaw_trap.txt
@@ -2,5 +2,6 @@ Name:Springjaw Trap
 ManaCost:1
 Types:Artifact
 K:Flash
-A:AB$ DealDamage | Cost$ 4 T Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 3 | SpellDescription$ CARDNAME deals 3 damage to any target.
+A:AB$ DealDamage | Cost$ 4 T Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 3 | SpellDescription$ It deals 3 damage to any target.
+DeckHas:Ability$Sacrifice
 Oracle:Flash\n{4}, {T}, Sacrifice Springjaw Trap: It deals 3 damage to any target.

--- a/forge-gui/res/cardsfolder/t/talon_of_pain.txt
+++ b/forge-gui/res/cardsfolder/t/talon_of_pain.txt
@@ -3,8 +3,10 @@ ManaCost:4
 Types:Artifact
 T:Mode$ DamageDone | ValidSource$ Card.Other+YouCtrl,Emblem.YouCtrl | ValidTarget$ Opponent | TriggerZones$ Battlefield | Execute$ TalonPutCounter | TriggerDescription$ Whenever a source you control other than CARDNAME deals damage to an opponent, put a charge counter on CARDNAME.
 SVar:TalonPutCounter:DB$ PutCounter | CounterType$ CHARGE | CounterNum$ 1
-A:AB$ DealDamage | Cost$ X T SubCounter<X/CHARGE> | ValidTgts$ Any | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to any target.
+A:AB$ DealDamage | Cost$ X T SubCounter<X/CHARGE> | ValidTgts$ Any | NumDmg$ X | SpellDescription$ It deals X damage to any target.
 SVar:X:Count$xPaid
 # The X cost won't be limited by the number of charge counters, but if enough aren't present, the spell will be cancelled.
 AI:RemoveDeck:All
+DeckHas:Ability$Counters
+DeckHints:Ability$Proliferate
 Oracle:Whenever a source you control other than Talon of Pain deals damage to an opponent, put a charge counter on Talon of Pain.\n{X}, {T}, Remove X charge counters from Talon of Pain: It deals X damage to any target.

--- a/forge-gui/res/cardsfolder/t/ticking_gnomes.txt
+++ b/forge-gui/res/cardsfolder/t/ticking_gnomes.txt
@@ -3,5 +3,6 @@ ManaCost:3
 Types:Artifact Creature Gnome
 PT:3/3
 K:Echo:3
-A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to any target.
+A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ It deals 1 damage to any target.
+DeckHas:Ability$Sacrifice
 Oracle:Echo {3} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nSacrifice Ticking Gnomes: It deals 1 damage to any target.

--- a/forge-gui/res/cardsfolder/t/tinder_wall.txt
+++ b/forge-gui/res/cardsfolder/t/tinder_wall.txt
@@ -4,6 +4,7 @@ Types:Creature Plant Wall
 PT:0/3
 K:Defender
 A:AB$ Mana | Cost$ Sac<1/CARDNAME> | Produced$ R | Amount$ 2 | SpellDescription$ Add {R}{R}.
-A:AB$ DealDamage | Cost$ R Sac<1/CARDNAME> | ValidTgts$ Creature.blockedBySourceLKI | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to target creature it's blocking.
+A:AB$ DealDamage | Cost$ R Sac<1/CARDNAME> | ValidTgts$ Creature.blockedBySourceLKI | NumDmg$ 2 | SpellDescription$ It deals 2 damage to target creature it's blocking.
 AI:RemoveDeck:All
+DeckHas:Ability$Sacrifice
 Oracle:Defender (This creature can't attack.)\nSacrifice Tinder Wall: Add {R}{R}.\n{R}, Sacrifice Tinder Wall: It deals 2 damage to target creature it's blocking.

--- a/forge-gui/res/cardsfolder/t/toralf_god_of_fury_toralfs_hammer.txt
+++ b/forge-gui/res/cardsfolder/t/toralf_god_of_fury_toralfs_hammer.txt
@@ -15,7 +15,7 @@ Name:Toralf's Hammer
 ManaCost:1 R
 Types:Legendary Artifact Equipment
 S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddAbility$ HammerDamage | Description$ Equipped creature has "{1}{R}, {T}, Unattach CARDNAME: It deals 3 damage to any target. Return CARDNAME to it owner's hand."
-SVar:HammerDamage:AB$ DealDamage | Cost$ 1 R T Unattach<OriginalHost/Toralf's Hammer> | NumDmg$ 3 | DamageSource$ OriginalHost | ValidTgts$ Any | SubAbility$ HammerCatch | SpellDescription$ ORIGINALHOST deals 3 damage to any target. Return ORIGINALHOST to its owner's hand.
+SVar:HammerDamage:AB$ DealDamage | Cost$ 1 R T Unattach<OriginalHost/Toralf's Hammer> | NumDmg$ 3 | DamageSource$ OriginalHost | ValidTgts$ Any | SubAbility$ HammerCatch | SpellDescription$ It deals 3 damage to any target. Return ORIGINALHOST to its owner's hand.
 SVar:HammerCatch:DB$ ChangeZone | Origin$ Battlefield | Destination$ Hand | Defined$ OriginalHost
 S:Mode$ Continuous | Affected$ Card.EquippedBy+Legendary | AddPower$ 3 | Description$ Equipped creature gets +3/+0 as long as it's legendary.
 K:Equip:1 R

--- a/forge-gui/res/cardsfolder/t/torch_song.txt
+++ b/forge-gui/res/cardsfolder/t/torch_song.txt
@@ -1,8 +1,10 @@
 Name:Torch Song
 ManaCost:2 R
 Types:Enchantment
-A:AB$ DealDamage | Cost$ 2 R Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to any target, where X is the number of verse counters on CARDNAME.
+A:AB$ DealDamage | Cost$ 2 R Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ X | SpellDescription$ It deals X damage to any target, where X is the number of verse counters on CARDNAME.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigPutCounter | TriggerDescription$ At the beginning of your upkeep, you may put a verse counter on CARDNAME.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ VERSE | CounterNum$ 1
 SVar:X:Count$CardCounters.VERSE
+DeckHas:Ability$Counters|Sacrifice
+DeckHints:Ability$Proliferate
 Oracle:At the beginning of your upkeep, you may put a verse counter on Torch Song.\n{2}{R}, Sacrifice Torch Song: It deals X damage to any target, where X is the number of verse counters on Torch Song.

--- a/forge-gui/res/cardsfolder/t/torture_chamber.txt
+++ b/forge-gui/res/cardsfolder/t/torture_chamber.txt
@@ -3,10 +3,12 @@ ManaCost:3
 Types:Artifact
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ At the beginning of your upkeep, put a pain counter on CARDNAME.
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDealDamage | TriggerDescription$ At the beginning of your end step, CARDNAME deals damage to you equal to the number of pain counters on it.
-A:AB$ DealDamage | Cost$ 1 T SubCounter<All/PAIN> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ Y | SpellDescription$ CARDNAME deals damage to target creature equal to the number of pain counters removed this way.
+A:AB$ DealDamage | Cost$ 1 T SubCounter<All/PAIN> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ Y | SpellDescription$ It deals damage to target creature equal to the number of pain counters removed this way.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ PAIN | CounterNum$ 1
 SVar:TrigDealDamage:DB$ DealDamage | Defined$ You | NumDmg$ X
 SVar:X:Count$CardCounters.PAIN
 SVar:Y:SVar$CostCountersRemoved
 AI:RemoveDeck:All
+DeckHas:Ability$Counters
+DeckHints:Ability$Proliferate
 Oracle:At the beginning of your upkeep, put a pain counter on Torture Chamber.\nAt the beginning of your end step, Torture Chamber deals damage to you equal to the number of pain counters on it.\n{1}, {T}, Remove all pain counters from Torture Chamber: It deals damage to target creature equal to the number of pain counters removed this way.

--- a/forge-gui/res/cardsfolder/t/triskelion.txt
+++ b/forge-gui/res/cardsfolder/t/triskelion.txt
@@ -3,6 +3,7 @@ ManaCost:6
 Types:Artifact Creature Construct
 PT:1/1
 K:etbCounter:P1P1:3
-A:AB$ DealDamage | AILogic$ Triskelion | Cost$ SubCounter<1/P1P1> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to any target.
+A:AB$ DealDamage | AILogic$ Triskelion | Cost$ SubCounter<1/P1P1> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ It deals 1 damage to any target.
 DeckHas:Ability$Counters
+DeckHints:Ability$Proliferate
 Oracle:Triskelion enters the battlefield with three +1/+1 counters on it.\nRemove a +1/+1 counter from Triskelion: It deals 1 damage to any target.

--- a/forge-gui/res/cardsfolder/u/unyaro_bees.txt
+++ b/forge-gui/res/cardsfolder/u/unyaro_bees.txt
@@ -4,5 +4,6 @@ Types:Creature Insect
 PT:0/1
 K:Flying
 A:AB$ Pump | Cost$ G | NumAtt$ +1 | NumDef$ +1 | SpellDescription$ CARDNAME gets +1/+1 until end of turn.
-A:AB$ DealDamage | Cost$ 3 G Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to any target.
+A:AB$ DealDamage | Cost$ 3 G Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ It deals 2 damage to any target.
+DeckHas:Ability$Sacrifice
 Oracle:Flying\n{G}: Unyaro Bees gets +1/+1 until end of turn.\n{3}{G}, Sacrifice Unyaro Bees: It deals 2 damage to any target.

--- a/forge-gui/res/cardsfolder/v/vial_of_dragonfire.txt
+++ b/forge-gui/res/cardsfolder/v/vial_of_dragonfire.txt
@@ -1,6 +1,7 @@
 Name:Vial of Dragonfire
 ManaCost:2
 Types:Artifact
-A:AB$ DealDamage | Cost$ 2 T Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to target creature.
+A:AB$ DealDamage | Cost$ 2 T Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 2 | SpellDescription$ It deals 2 damage to target creature.
+DeckHas:Ability$Sacrifice
 DeckHints:Name$Renowned Weaponsmith
 Oracle:{2}, {T}, Sacrifice Vial of Dragonfire: It deals 2 damage to target creature.

--- a/forge-gui/res/cardsfolder/v/viridian_scout.txt
+++ b/forge-gui/res/cardsfolder/v/viridian_scout.txt
@@ -2,5 +2,6 @@ Name:Viridian Scout
 ManaCost:3 G
 Types:Creature Elf Warrior Scout
 PT:1/2
-A:AB$ DealDamage | Cost$ 2 G Sac<1/CARDNAME> | ValidTgts$ Creature.withFlying | TgtPrompt$ Select target creature with flying | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to target creature with flying.
+A:AB$ DealDamage | Cost$ 2 G Sac<1/CARDNAME> | ValidTgts$ Creature.withFlying | TgtPrompt$ Select target creature with flying | NumDmg$ 2 | SpellDescription$ It deals 2 damage to target creature with flying.
+DeckHas:Ability$Sacrifice
 Oracle:{2}{G}, Sacrifice Viridian Scout: It deals 2 damage to target creature with flying.

--- a/forge-gui/res/cardsfolder/w/walking_ballista.txt
+++ b/forge-gui/res/cardsfolder/w/walking_ballista.txt
@@ -4,6 +4,8 @@ Types:Artifact Creature Construct
 PT:0/0
 K:etbCounter:P1P1:X
 A:AB$ PutCounter | Cost$ 4 | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on CARDNAME.
-A:AB$ DealDamage | AILogic$ Triskelion | Cost$ SubCounter<1/P1P1> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to any target.
+A:AB$ DealDamage | AILogic$ Triskelion | Cost$ SubCounter<1/P1P1> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ It deals 1 damage to any target.
 SVar:X:Count$xPaid
+DeckHas:Ability$Counters
+DeckHints:Ability$Proliferate
 Oracle:Walking Ballista enters the battlefield with X +1/+1 counters on it.\n{4}: Put a +1/+1 counter on Walking Ballista.\nRemove a +1/+1 counter from Walking Ballista: It deals 1 damage to any target.

--- a/forge-gui/res/cardsfolder/w/war_torch_goblin.txt
+++ b/forge-gui/res/cardsfolder/w/war_torch_goblin.txt
@@ -2,5 +2,6 @@ Name:War-Torch Goblin
 ManaCost:R
 Types:Creature Goblin Warrior
 PT:1/1
-A:AB$ DealDamage | Cost$ R Sac<1/CARDNAME> | ValidTgts$ Creature.blocking | TgtPrompt$ Select target blocking creature | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to target blocking creature.
+A:AB$ DealDamage | Cost$ R Sac<1/CARDNAME> | ValidTgts$ Creature.blocking | TgtPrompt$ Select target blocking creature | NumDmg$ 2 | SpellDescription$ It deals 2 damage to target blocking creature.
+DeckHas:Ability$Sacrifice
 Oracle:{R}, Sacrifice War-Torch Goblin: It deals 2 damage to target blocking creature.

--- a/forge-gui/res/tokenscripts/c_1_1_a_triskelavite_flying_ammo.txt
+++ b/forge-gui/res/tokenscripts/c_1_1_a_triskelavite_flying_ammo.txt
@@ -3,5 +3,5 @@ ManaCost:no cost
 Types:Artifact Creature Triskelavite
 K:Flying
 PT:1/1
-A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to any target.
+A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ It deals 1 damage to any target.
 Oracle:Flying\nSacrifice this creature: It deals 1 damage to any target.

--- a/forge-gui/res/tokenscripts/land_mine.txt
+++ b/forge-gui/res/tokenscripts/land_mine.txt
@@ -1,5 +1,5 @@
 Name:Land Mine
 ManaCost:no cost
 Types:Artifact
-A:AB$ DealDamage | Cost$ R Sac<1/CARDNAME> | ValidTgts$ Creature.attacking+withoutFlying | TgtPrompt$ Select target attacking creature without flying | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to target attacking creature without flying.
+A:AB$ DealDamage | Cost$ R Sac<1/CARDNAME> | ValidTgts$ Creature.attacking+withoutFlying | TgtPrompt$ Select target attacking creature without flying | NumDmg$ 2 | SpellDescription$ It deals 2 damage to target attacking creature without flying.
 Oracle:{R}, Sacrifice this artifact: It deals 2 damage to target attacking creature without flying.

--- a/forge-gui/res/tokenscripts/tokenscripts/c_1_1_a_triskelavite_flying_ammo.txt
+++ b/forge-gui/res/tokenscripts/tokenscripts/c_1_1_a_triskelavite_flying_ammo.txt
@@ -1,0 +1,7 @@
+Name:Triskelavite Token
+ManaCost:no cost
+Types:Artifact Creature Triskelavite
+K:Flying
+PT:1/1
+A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ It deals 1 damage to any target.
+Oracle:Flying\nSacrifice this creature: It deals 1 damage to any target.

--- a/forge-gui/res/tokenscripts/tokenscripts/c_1_1_a_triskelavite_flying_ammo.txt
+++ b/forge-gui/res/tokenscripts/tokenscripts/c_1_1_a_triskelavite_flying_ammo.txt
@@ -1,7 +1,0 @@
-Name:Triskelavite Token
-ManaCost:no cost
-Types:Artifact Creature Triskelavite
-K:Flying
-PT:1/1
-A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ It deals 1 damage to any target.
-Oracle:Flying\nSacrifice this creature: It deals 1 damage to any target.

--- a/forge-gui/res/tokenscripts/tokenscripts/land_mine.txt
+++ b/forge-gui/res/tokenscripts/tokenscripts/land_mine.txt
@@ -1,0 +1,5 @@
+Name:Land Mine
+ManaCost:no cost
+Types:Artifact
+A:AB$ DealDamage | Cost$ R Sac<1/CARDNAME> | ValidTgts$ Creature.attacking+withoutFlying | TgtPrompt$ Select target attacking creature without flying | NumDmg$ 2 | SpellDescription$ It deals 2 damage to target attacking creature without flying.
+Oracle:{R}, Sacrifice this artifact: It deals 2 damage to target attacking creature without flying.

--- a/forge-gui/res/tokenscripts/tokenscripts/land_mine.txt
+++ b/forge-gui/res/tokenscripts/tokenscripts/land_mine.txt
@@ -1,5 +1,0 @@
-Name:Land Mine
-ManaCost:no cost
-Types:Artifact
-A:AB$ DealDamage | Cost$ R Sac<1/CARDNAME> | ValidTgts$ Creature.attacking+withoutFlying | TgtPrompt$ Select target attacking creature without flying | NumDmg$ 2 | SpellDescription$ It deals 2 damage to target attacking creature without flying.
-Oracle:{R}, Sacrifice this artifact: It deals 2 damage to target attacking creature without flying.


### PR DESCRIPTION
Namely this item on https://github.com/Card-Forge/forge/pull/5229 :
- "3 `CARDNAME` -> `It` changes in `SpellDescription` to match Oracle" 

Looked further into it: there were a lot more card scripts to update in this regard. There was also one to change in the opposite direction, [Blazing Torch](https://scryfall.com/card/isd/216/blazing-torch). 
I also took the opportunity to add relevant AI deckbuilding tags.