### PR TITLE
Incidental cleanup pass #3

### DIFF
--- a/forge-gui/res/cardsfolder/d/dryad_arbor.txt
+++ b/forge-gui/res/cardsfolder/d/dryad_arbor.txt
@@ -1,6 +1,6 @@
 Name:Dryad Arbor
 ManaCost:no cost
+Colors:green
 Types:Land Creature Forest Dryad
 PT:1/1
-Colors:green
 Oracle:(Dryad Arbor isn't a spell, it's affected by summoning sickness, and it has "{T}: Add {G}.")

--- a/forge-gui/res/cardsfolder/e/elvish_impersonators.txt
+++ b/forge-gui/res/cardsfolder/e/elvish_impersonators.txt
@@ -1,6 +1,7 @@
 Name:Elvish Impersonators
 ManaCost:3 G
-Types:Creature Elves
+Types:Creature Elf
+# Departure from the letter of Oracle necessary so it gets kindred bonuses/maluses.
 PT:*/*
 K:ETBReplacement:Other:TrigRoll
 SVar:TrigRoll:DB$ RollDice | ResultSVar$ SetPwr | SubAbility$ RollTough | SpellDescription$ As CARDNAME enters the battlefield, roll a six-sided die twice. Its base power becomes the first result and its base toughness becomes the second result.

--- a/forge-gui/res/cardsfolder/e/elvish_impersonators.txt
+++ b/forge-gui/res/cardsfolder/e/elvish_impersonators.txt
@@ -1,7 +1,7 @@
 Name:Elvish Impersonators
 ManaCost:3 G
 Types:Creature Elf
-# Departure from the letter of Oracle necessary so it gets kindred bonuses/maluses.
+# Departure from the letter of Oracle necessary so this card gets/gains bonuses/maluses predicated on creature type.
 PT:*/*
 K:ETBReplacement:Other:TrigRoll
 SVar:TrigRoll:DB$ RollDice | ResultSVar$ SetPwr | SubAbility$ RollTough | SpellDescription$ As CARDNAME enters the battlefield, roll a six-sided die twice. Its base power becomes the first result and its base toughness becomes the second result.

--- a/forge-gui/res/cardsfolder/j/jasconian_isle.txt
+++ b/forge-gui/res/cardsfolder/j/jasconian_isle.txt
@@ -1,5 +1,6 @@
 Name:Jasconian Isle
 ManaCost:no cost
+Colors:blue
 Types:Land Creature Island Fish
 PT:3/4
 K:CARDNAME enters the battlefield tapped.

--- a/forge-gui/res/cardsfolder/r/robot_chicken.txt
+++ b/forge-gui/res/cardsfolder/r/robot_chicken.txt
@@ -1,7 +1,7 @@
 Name:Robot Chicken
 ManaCost:4
 Types:Artifact Creature Bird Construct
-# Departure from Oracle justified by https://magic.wizards.com/en/news/announcements/oracle-changes-2020-04-10, deeming it more fun that funny Chicken cards have the Bird creature type.
+# Departure from Oracle justified by https://magic.wizards.com/en/news/announcements/oracle-changes-2020-04-10, deeming it more fun that older funny Chicken cards have the Bird creature type instead.
 PT:2/2
 T:Mode$ SpellCast | ValidCard$ Card | ValidActivatingPlayer$ You | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a spell, put a 0/1 colorless Egg artifact creature token onto the battlefield.
 SVar:TrigToken:DB$ Token | TokenScript$ c_0_1_a_egg

--- a/forge-gui/res/cardsfolder/r/robot_chicken.txt
+++ b/forge-gui/res/cardsfolder/r/robot_chicken.txt
@@ -1,6 +1,7 @@
 Name:Robot Chicken
 ManaCost:4
-Types:Artifact Creature Chicken Construct
+Types:Artifact Creature Bird Construct
+# Departure from Oracle justified by https://magic.wizards.com/en/news/announcements/oracle-changes-2020-04-10, deeming it more fun that funny Chicken cards have the Bird creature type.
 PT:2/2
 T:Mode$ SpellCast | ValidCard$ Card | ValidActivatingPlayer$ You | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a spell, put a 0/1 colorless Egg artifact creature token onto the battlefield.
 SVar:TrigToken:DB$ Token | TokenScript$ c_0_1_a_egg


### PR DESCRIPTION
Had an idle look at the Card Catalog ordered by type:
- [Robot Chicken](https://scryfall.com/card/pcel/6/robot-chicken): Changed the unlisted Chicken type to Bird, following the rationale used for other old funny cards in the [Oracle Changes announcement for _Ikoria_](https://magic.wizards.com/en/news/announcements/oracle-changes-2020-04-10) (`CTRL + F` "FOWL PLAY"). `*`
- [Elvish Impersonators](https://scryfall.com/card/und/62/elvish-impersonators): Changed the creature type to the singular declension, since otherwise the card doesn't count as an Elf as the game engine understands it. The appended screenshot shows, for instance, that this creature isn't gaining forestwalk from an [Elvish Champion](https://scryfall.com/card/10e/261/elvish-champion), when it plainly should. `*`

![elvish_impersonators](https://github.com/Card-Forge/forge/assets/45150760/dedfef62-776e-4b7f-903e-9f13fbbb758a)
- [Jasconian Isle](https://scryfall.com/card/cmb2/117/jasconian-isle): Per ruling and reminder text, it should have color indicator line.
- Dryad Arbor: reordered lines so the color indicator is above the type line as in, for instance, all the TDFC cards.

`*` Since these are reversions, I thought it better, for purposes of clarity, to comment the reason for the departure from "Oracle as written" on the script.