### PR TITLE
Fixing Bludgeon Brawl

### DIFF
--- a/forge-gui/res/cardsfolder/b/bludgeon_brawl.txt
+++ b/forge-gui/res/cardsfolder/b/bludgeon_brawl.txt
@@ -1,7 +1,7 @@
-Name:Bludgeon Brawl
+Name:Bludgeon Brawl 2
 ManaCost:2 R
 Types:Enchantment
-S:Mode$ Continuous | Affected$ Artifact.nonCreature+nonEquipment | AddKeyword$ Equip:ConvertedManaCost | AddType$ Equipment | RemoveArtifactTypes$ True | AddStaticAbility$ EquipPump | Description$ Each noncreature, non-Equipment artifact is an Equipment with equip X and "Equipped creature gets +X/+0," where X is that artifact's mana value.
+S:Mode$ Continuous | Affected$ Artifact.nonCreature+nonEquipment | AddKeyword$ Equip:ConvertedManaCost | AddType$ Equipment | AddStaticAbility$ EquipPump | Description$ Each noncreature, non-Equipment artifact is an Equipment with equip X and "Equipped creature gets +X/+0," where X is that artifact's mana value.
 SVar:EquipPump:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ ConvertedManaCost | Description$ Equipped creature gets +X/+0, where X is CARDNAME's mana value.
 AI:RemoveDeck:Random
 Oracle:Each noncreature, non-Equipment artifact is an Equipment with equip {X} and "Equipped creature gets +X/+0," where X is that artifact's mana value.

--- a/forge-gui/res/cardsfolder/b/bludgeon_brawl.txt
+++ b/forge-gui/res/cardsfolder/b/bludgeon_brawl.txt
@@ -1,4 +1,4 @@
-Name:Bludgeon Brawl 2
+Name:Bludgeon Brawl
 ManaCost:2 R
 Types:Enchantment
 S:Mode$ Continuous | Affected$ Artifact.nonCreature+nonEquipment | AddKeyword$ Equip:ConvertedManaCost | AddType$ Equipment | AddStaticAbility$ EquipPump | Description$ Each noncreature, non-Equipment artifact is an Equipment with equip X and "Equipped creature gets +X/+0," where X is that artifact's mana value.


### PR DESCRIPTION
Per ruling on [Bludgeon Brawl](https://scryfall.com/card/nph/80/bludgeon-brawl), it shouldn't overwrite existing artifact subtypes, as shown in the appended screenshot of its effect on a Fortification, so the `RemoveArtifactTypes` parameter was removed. This also brings it in line with the similar effect on [Dan Lewis](https://scryfall.com/card/who/78/dan-lewis).

![image](https://github.com/Card-Forge/forge/assets/45150760/2de0acaa-1f02-4175-92ef-8e148cf125e0)
  