### PR TITLE
StaticAbilityAlternativeCost: improve X handling

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
@@ -1323,7 +1323,7 @@ public class ComputerUtilMana {
                 final int multiplicator = Math.max(xCounter, 1);
                 manaToAdd = extraMana * multiplicator;
             } else {
-                manaToAdd = AbilityUtils.calculateAmount(card, "X", sa) * xCounter;
+                manaToAdd = AbilityUtils.calculateAmount(card, sa.getParamOrDefault("XAlternative", "X"), sa) * xCounter;
             }
 
             if (manaToAdd < 1 && payCosts != null && payCosts.getCostMana().getXMin() > 0) {

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -3433,11 +3433,12 @@ public class CardFactoryUtil {
         } else if (keyword.startsWith("Encore")) {
             final String[] k = keyword.split(":");
             final String manacost = k[1];
+            final String extra = k.length > 2 ? "| " + k[2] : "";
 
             final String effect = "AB$ CopyPermanent | Cost$ " + manacost + " ExileFromGrave<1/CARDNAME> | ActivationZone$ Graveyard" +
                     "| SorcerySpeed$ True | Defined$ Self | PumpKeywords$ Haste | RememberTokens$ True | ForEach$ Opponent" +
                     "| AtEOT$ Sacrifice | PrecostDesc$ Encore | CostDesc$ " + ManaCostParser.parse(manacost) +
-                    "| SpellDescription$ (" + inst.getReminderText() + ")";
+                    "| SpellDescription$ (" + inst.getReminderText() + ")" + extra;
 
             final SpellAbility sa = AbilityFactory.getAbility(effect, card);
 

--- a/forge-game/src/main/java/forge/game/spellability/AbilityManaPart.java
+++ b/forge-game/src/main/java/forge/game/spellability/AbilityManaPart.java
@@ -400,6 +400,7 @@ public class AbilityManaPart implements java.io.Serializable {
                     continue;
                 }
                 // TODO Thassa's Intervention with "twice {X}" is tricky
+                // TODO Volcano Hellion can't be handled without refactor to just have it passed down directly
                 if (restriction.endsWith("X") && payment.getCostMana().getAmountOfX() > 0) {
                     return true;
                 }

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityAlternativeCost.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityAlternativeCost.java
@@ -32,15 +32,17 @@ public class StaticAbilityAlternativeCost {
                     continue;
                 }
 
-                Cost cost = new Cost(stAb.getParam("Cost"), sa.isAbility());
+                String costTemplate = stAb.getParam("Cost");
+                costTemplate = costTemplate.replace("ConvertedManaCost", Integer.toString(source.getCMC()));
+
+                Cost cost = new Cost(costTemplate, sa.isAbility());
                 // set the cost to this directly to bypass non mana cost
                 final SpellAbility newSA = sa.isAbility() ? sa.copyWithDefinedCost(cost) : sa.copyWithManaCostReplaced(pl, cost);
                 newSA.setActivatingPlayer(pl);
                 newSA.setBasicSpell(false);
 
-                if (cost.hasXInAnyCostPart()) {
-                    // TODO this is problematic for Spells that already have (non-mana) X SVar
-                    newSA.setSVar("X", stAb.getSVar("X"));
+                if (stAb.hasParam("XAlternative")) {
+                    newSA.putParam("XAlternative", stAb.getParam("XAlternative"));
                 }
 
                 if (stAb.hasParam("Announce")) {

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
@@ -820,15 +820,15 @@ public final class StaticAbilityContinuous {
                 List<StaticAbility> addedStaticAbility = Lists.newArrayList();
                 // add abilities
                 if (addAbilities != null) {
-                    for (String abilty : addAbilities) {
-                        if (abilty.contains("CardManaCost")) {
-                            abilty = TextUtil.fastReplace(abilty, "CardManaCost", affectedCard.getManaCost().getShortString());
-                        } else if (abilty.contains("ConvertedManaCost")) {
+                    for (String ability : addAbilities) {
+                        if (ability.contains("CardManaCost")) {
+                            ability = TextUtil.fastReplace(ability, "CardManaCost", affectedCard.getManaCost().getShortString());
+                        } else if (ability.contains("ConvertedManaCost")) {
                             final String costcmc = Integer.toString(affectedCard.getCMC());
-                            abilty = TextUtil.fastReplace(abilty, "ConvertedManaCost", costcmc);
+                            ability = TextUtil.fastReplace(ability, "ConvertedManaCost", costcmc);
                         }
-                        if (abilty.startsWith("AB") || abilty.startsWith("ST")) { // grant the ability
-                            addedAbilities.add(affectedCard.getSpellAbilityForStaticAbility(abilty, stAb));
+                        if (ability.startsWith("AB") || ability.startsWith("ST")) { // grant the ability
+                            addedAbilities.add(affectedCard.getSpellAbilityForStaticAbility(ability, stAb));
                         }
                     }
                 }

--- a/forge-gui/res/cardsfolder/b/bludgeon_brawl.txt
+++ b/forge-gui/res/cardsfolder/b/bludgeon_brawl.txt
@@ -1,7 +1,7 @@
 Name:Bludgeon Brawl
 ManaCost:2 R
 Types:Enchantment
-S:Mode$ Continuous | Affected$ Artifact.nonCreature+nonEquipment | AddKeyword$ Equip:ConvertedManaCost | AddType$ Equipment | RemoveArtifactTypes$ True | AddStaticAbility$ EquipPump | Description$ Each noncreature, non-Equipment artifact is an Equipment with equip X and "Equipped creature gets +X/+0," where X is that artifact's mana value.
+S:Mode$ Continuous | Affected$ Artifact.nonCreature+nonEquipment | AddKeyword$ Equip:X:::XAlternative$ Number$ConvertedManaCost | AddType$ Equipment | RemoveArtifactTypes$ True | AddStaticAbility$ EquipPump | Description$ Each noncreature, non-Equipment artifact is an Equipment with equip {X} and "Equipped creature gets +X/+0," where X is that artifact's mana value.
 SVar:EquipPump:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ ConvertedManaCost | Description$ Equipped creature gets +X/+0, where X is CARDNAME's mana value.
 AI:RemoveDeck:Random
 Oracle:Each noncreature, non-Equipment artifact is an Equipment with equip {X} and "Equipped creature gets +X/+0," where X is that artifact's mana value.

--- a/forge-gui/res/cardsfolder/g/graywaters_fixer.txt
+++ b/forge-gui/res/cardsfolder/g/graywaters_fixer.txt
@@ -2,7 +2,7 @@ Name:Graywater's Fixer
 ManaCost:2 B R
 Types:Creature Lizard Mercenary
 PT:4/4
-S:Mode$ Continuous | EffectZone$ Battlefield | AffectedZone$ Graveyard | Affected$ Creature.Outlaw+YouCtrl | AddKeyword$ Encore:ConvertedManaCost | Description$ Each outlaw creature card in your graveyard has encore {X}, where X is its mana value. (Exile it and pay its encore cost: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)
+S:Mode$ Continuous | EffectZone$ Battlefield | AffectedZone$ Graveyard | Affected$ Creature.Outlaw+YouCtrl | AddKeyword$ Encore:X:XAlternative$ Number$ConvertedManaCost | Description$ Each outlaw creature card in your graveyard has encore {X}, where X is its mana value. (Exile it and pay its encore cost: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)
 DeckHas:Ability$Token|Graveyard
 DeckHints:Type$Mercenary|Assassin|Warlock|Pirate|Assassin
 Oracle:Each outlaw creature card in your graveyard has encore {X}, where X is its mana value. (Exile it and pay its encore cost: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)

--- a/forge-gui/res/cardsfolder/k/kentaro_the_smiling_cat.txt
+++ b/forge-gui/res/cardsfolder/k/kentaro_the_smiling_cat.txt
@@ -3,6 +3,5 @@ ManaCost:1 W
 Types:Legendary Creature Human Samurai
 PT:2/1
 K:Bushido:1
-S:Mode$ AlternativeCost | ValidSA$ Spell.Samurai | ValidPlayer$ You | Cost$ X | Description$ You may pay {X} rather than pay the mana cost for Samurai spells you cast, where X is that spell's mana value.
-SVar:X:Count$CardManaCost
+S:Mode$ AlternativeCost | ValidSA$ Spell.Samurai | ValidPlayer$ You | Cost$ X | XAlternative$ Count$CardManaCost | Description$ You may pay {X} rather than pay the mana cost for Samurai spells you cast, where X is that spell's mana value.
 Oracle:Bushido 1 (Whenever this creature blocks or becomes blocked, it gets +1/+1 until end of turn.)\nYou may pay {X} rather than pay the mana cost for Samurai spells you cast, where X is that spell's mana value.

--- a/forge-gui/res/cardsfolder/m/marshland_bloodcaster.txt
+++ b/forge-gui/res/cardsfolder/m/marshland_bloodcaster.txt
@@ -4,8 +4,7 @@ Types:Creature Vampire Warlock
 PT:3/5
 K:Flying
 A:AB$ Effect | Cost$ 1 B T | StaticAbilities$ ReduceCost | Triggers$ TrigCastSpell | SpellDescription$ Rather than pay the mana cost of the next spell you cast this turn, you may pay life equal to that spell's mana value.
-SVar:ReduceCost:Mode$ AlternativeCost | ValidSA$ Spell | ValidPlayer$ You | Cost$ PayLife<X> | Description$ Rather than pay the mana cost of the next spell you cast this turn, you may pay life equal to that spell's mana value.
+SVar:ReduceCost:Mode$ AlternativeCost | ValidSA$ Spell | ValidPlayer$ You | Cost$ PayLife<ConvertedManaCost> | Description$ Rather than pay the mana cost of the next spell you cast this turn, you may pay life equal to that spell's mana value.
 SVar:TrigCastSpell:Mode$ SpellCast | ValidActivatingPlayer$ You | TriggerZones$ Command | Execute$ RemoveEffect | Static$ True
 SVar:RemoveEffect:DB$ ChangeZone | Origin$ Command | Destination$ Exile
-SVar:X:Count$CardManaCost
 Oracle:Flying\n{1}{B}, {T}: Rather than pay the mana cost of the next spell you cast this turn, you may pay life equal to that spell's mana value.

--- a/forge-gui/res/cardsfolder/s/sliver_gravemother.txt
+++ b/forge-gui/res/cardsfolder/s/sliver_gravemother.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature Sliver
 PT:6/6
 K:Encore:5
 S:Mode$ IgnoreLegendRule | ValidCard$ Sliver.YouCtrl | Description$ The "legend rule" doesn't apply to Slivers you control.
-S:Mode$ Continuous | EffectZone$ Battlefield | AffectedZone$ Graveyard | Affected$ Sliver.Creature+YouCtrl | AddKeyword$ Encore:ConvertedManaCost | Description$ Each Sliver creature card in your graveyard has encore {X}, where X is its mana value.
+S:Mode$ Continuous | EffectZone$ Battlefield | AffectedZone$ Graveyard | Affected$ Sliver.Creature+YouCtrl | AddKeyword$ Encore:X:XAlternative$ Number$ConvertedManaCost | Description$ Each Sliver creature card in your graveyard has encore {X}, where X is its mana value.
 DeckNeeds:Type$Sliver
 DeckHas:Ability$Token|Graveyard
 Oracle:The "legend rule" doesn't apply to Slivers you control.\nEach Sliver creature card in your graveyard has encore {X}, where X is its mana value.\nEncore {5} ({5}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)

--- a/forge-gui/src/main/java/forge/player/HumanPlay.java
+++ b/forge-gui/src/main/java/forge/player/HumanPlay.java
@@ -557,13 +557,13 @@ public class HumanPlay {
         final Card source = ability.getHostCard();
         ManaCostBeingPaid toPay = new ManaCostBeingPaid(realCost);
 
-        String xInCard = ability.getSVar("X");
+        String xInCard = ability.getParamOrDefault("XAlternative", ability.getSVar("X"));
         String xColor = ability.getXColor();
         if (source.hasKeyword("Spend only colored mana on X. No more than one mana of each color may be spent this way.")) {
             xColor = "WUBRGX";
         }
         if (mc.getAmountOfX() > 0 && !"Count$xPaid".equals(xInCard)) { // announce X will overwrite whatever was in card script
-            int xPaid = AbilityUtils.calculateAmount(source, "X", ability);
+            int xPaid = AbilityUtils.calculateAmount(source, xInCard, ability);
             toPay.setXManaCostPaid(xPaid, xColor);
             ability.setXManaCostPaid(xPaid);
         }

--- a/forge-gui/src/main/java/forge/player/HumanPlaySpellAbility.java
+++ b/forge-gui/src/main/java/forge/player/HumanPlaySpellAbility.java
@@ -260,7 +260,7 @@ public class HumanPlaySpellAbility {
 
         if (needX) {
             if (cost.hasXInAnyCostPart()) {
-                final String sVar = ability.getSVar("X"); //only prompt for new X value if card doesn't determine it another way
+                final String sVar = ability.getParamOrDefault("XAlternative", ability.getSVar("X")); //only prompt for new X value if card doesn't determine it another way
                 // check if X != 0 is even allowed or the X shard got removed
                 boolean replacedXshard = ability.isSpell() && ability.getHostCard().getManaCost().countX() > 0 &&
                         (cost.hasNoManaCost() || cost.getCostMana().getAmountOfX() == 0);


### PR DESCRIPTION
Fixes using _Marshland Bloodcaster_ ability for casting breaking in case the spell uses some hardcoded X SVar.

Also reworked hopefully all remaining {X} cases, so that the calculation only happens before you pay.
(This makes them work with the `CostContainsX` mana restriction - currently done in 4 cards).