### PR TITLE
Fix Scapeshift returning Lake of the Dead + Swamp which it can sacrifice

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/SacrificeEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/SacrificeEffect.java
@@ -107,7 +107,7 @@ public class SacrificeEffect extends SpellAbilityEffect {
         } else {
             CardCollectionView choosenToSacrifice = null;
             for (final Player p : getTargetPlayers(sa)) {
-                CardCollectionView battlefield = p.getCardsIn(ZoneType.Battlefield);
+                CardCollectionView battlefield = CardLists.filter(zoneMovements.getLastStateBattlefield(), CardPredicates.isController(p));
                 if (sacEachValid) { // Sacrifice maximum permanents in any combination of types specified by SacValid
                     String [] validArray = valid.split(" & ");
                     String [] msgArray = msg.split(" & ");
@@ -154,6 +154,10 @@ public class SacrificeEffect extends SpellAbilityEffect {
                 choosenToSacrifice = GameActionUtil.orderCardsByTheirOwners(game, choosenToSacrifice, ZoneType.Graveyard, sa);
 
                 for (Card sac : choosenToSacrifice) {
+                    if (sac.isLKI()) {
+                        // expected during ETB replacement
+                        sac = game.getCardState(sac);
+                    }
                     Card lKICopy = zoneMovements.getLastStateBattlefield().get(sac);
                     boolean wasSacrificed = !destroy && game.getAction().sacrifice(sac, sa, true, params) != null;
                     boolean wasDestroyed = destroy && game.getAction().destroy(sac, sa, true, params);

--- a/forge-game/src/main/java/forge/game/ability/effects/SacrificeEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/SacrificeEffect.java
@@ -107,7 +107,9 @@ public class SacrificeEffect extends SpellAbilityEffect {
         } else {
             CardCollectionView choosenToSacrifice = null;
             for (final Player p : getTargetPlayers(sa)) {
-                CardCollectionView battlefield = CardLists.filter(zoneMovements.getLastStateBattlefield(), CardPredicates.isController(p));
+                CardCollection battlefield = new CardCollection(p.getCardsIn(ZoneType.Battlefield));
+                battlefield.removeIf(c -> !zoneMovements.getLastStateBattlefield().contains(c));
+
                 if (sacEachValid) { // Sacrifice maximum permanents in any combination of types specified by SacValid
                     String [] validArray = valid.split(" & ");
                     String [] msgArray = msg.split(" & ");
@@ -154,10 +156,6 @@ public class SacrificeEffect extends SpellAbilityEffect {
                 choosenToSacrifice = GameActionUtil.orderCardsByTheirOwners(game, choosenToSacrifice, ZoneType.Graveyard, sa);
 
                 for (Card sac : choosenToSacrifice) {
-                    if (sac.isLKI()) {
-                        // expected during ETB replacement
-                        sac = game.getCardState(sac);
-                    }
                     Card lKICopy = zoneMovements.getLastStateBattlefield().get(sac);
                     boolean wasSacrificed = !destroy && game.getAction().sacrifice(sac, sa, true, params) != null;
                     boolean wasDestroyed = destroy && game.getAction().destroy(sac, sa, true, params);


### PR DESCRIPTION
Imo we might not need any extra checks there because the logic from CardZoneTable already provides the right state:
https://github.com/Card-Forge/forge/blob/bfba7ea773c362cb288af907953390dcb0e62867/forge-game/src/main/java/forge/game/card/CardZoneTable.java#L47-L55

Urborg involved is also fine.

Closes #5299