### PR TITLE
Fixing Planeswalker's Mischief, Psychic Theft

### DIFF
--- a/forge-gui/res/cardsfolder/p/planeswalkers_mischief.txt
+++ b/forge-gui/res/cardsfolder/p/planeswalkers_mischief.txt
@@ -4,9 +4,9 @@ Types:Enchantment
 A:AB$ Reveal | Cost$ 3 U | Random$ True | RememberRevealed$ True | ValidTgts$ Opponent | SorcerySpeed$ True | SubAbility$ DBChangeZone | SpellDescription$ Target opponent reveals a card at random from their hand. If it's an instant or sorcery card, exile it. You may cast it without paying its mana cost for as long as it remains exiled. At the beginning of the next end step, if you haven't cast it, return it to its owner's hand. Activate only as a sorcery.
 SVar:DBChangeZone:DB$ ChangeZoneAll | ChangeType$ Instant.IsRemembered,Sorcery.IsRemembered | Origin$ Hand | Destination$ Exile | RememberChanged$ True | ForgetOtherRemembered$ True | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | StaticAbilities$ MischiefPlay | ExileOnMoved$ Exile | RememberObjects$ Remembered | Duration$ Permanent | SubAbility$ DBDelayedTrigger
-SVar:DBDelayedTrigger:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ MischiefReturn | IsPresent$ Card.IsRemembered | PresentZone$ Exile | RememberObjects$ Remembered | SubAbility$ DBCleanup | TriggerDescription$ At the beginning of the next end step, if that card is still exiled, put it into your graveyard and create a Treasure token.
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:MischiefPlay:Mode$ Continuous | MayPlay$ True | MayPlayWithoutManaCost$ True | EffectZone$ Command | Affected$ Card.IsRemembered+nonLand | AffectedZone$ Exile | Description$ You may cast the exiled instant or sorcery card without paying its mana cost for as long as it remains exiled.
-SVar:MischiefReturn:DB$ ChangeZone | Defined$ RememberedLKI | Origin$ Exile | Destination$ Hand
+SVar:DBDelayedTrigger:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ MischiefReturn | IsPresent$ Card.IsTriggerRemembered | PresentZone$ Exile | RememberObjects$ Remembered | SubAbility$ DBCleanup | TriggerDescription$ At the beginning of the next end step, if you haven't cast it, return it to its owner's hand.
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:MischiefReturn:DB$ ChangeZone | Defined$ DelayTriggerRememberedLKI | Origin$ Exile | Destination$ Hand
 SVar:NonStackingEffect:True
 Oracle:{3}{U}: Target opponent reveals a card at random from their hand. If it's an instant or sorcery card, exile it. You may cast it without paying its mana cost for as long as it remains exiled. At the beginning of the next end step, if you haven't cast it, return it to its owner's hand. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/p/psychic_theft.txt
+++ b/forge-gui/res/cardsfolder/p/psychic_theft.txt
@@ -3,9 +3,9 @@ ManaCost:1 U
 Types:Sorcery
 A:SP$ ChangeZone | ValidTgts$ Player | Origin$ Hand | Destination$ Exile | ChangeType$ Instant,Sorcery | Mandatory$ True | IsCurse$ True | Chooser$ You | ChangeNum$ 1 | RememberChanged$ True | SubAbility$ TheftEffect | SpellDescription$ Target player reveals their hand. You choose an instant or sorcery card from it and exile that card. | StackDescription$ SpellDescription
 SVar:TheftEffect:DB$ Effect | StaticAbilities$ STThieving | Duration$ Permanent | RememberObjects$ Remembered | ExileOnMoved$ Exile | SubAbility$ DBDelayedTrigger | SpellDescription$ You may cast that card for as long as it remains exiled.
-SVar:DBDelayedTrigger:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ TrigReturn | IsPresent$ Card.IsRemembered | PresentZone$ Exile | RememberObjects$ Remembered | SubAbility$ DBCleanup | SpellDescription$ At the beginning of the next end step, if you haven't cast the card, return it to its owner's hand.
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:STThieving:Mode$ Continuous | Affected$ Card.IsRemembered+nonLand | MayPlay$ True | EffectZone$ Command | AffectedZone$ Exile | Description$ You may cast that card for as long as it remains exiled.
-SVar:TrigReturn:DB$ ChangeZone | Defined$ RememberedLKI | Origin$ Exile | Destination$ Hand
+SVar:DBDelayedTrigger:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ TrigReturn | IsPresent$ Card.IsTriggerRemembered | PresentZone$ Exile | RememberObjects$ Remembered | SubAbility$ DBCleanup | SpellDescription$ At the beginning of the next end step, if you haven't cast the card, return it to its owner's hand.
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:TrigReturn:DB$ ChangeZone | Defined$ DelayTriggerRememberedLKI | Origin$ Exile | Destination$ Hand
 AI:RemoveDeck:All
 Oracle:Target player reveals their hand. You choose an instant or sorcery card from it and exile that card. You may cast that card for as long as it remains exiled. At the beginning of the next end step, if you haven't cast the card, return it to its owner's hand.


### PR DESCRIPTION
The delayed trigger for both [Planeswalker's Mischief](https://scryfall.com/card/pls/29/planeswalkers-mischief) and [Psychic Theft](https://scryfall.com/card/pcy/40/psychic-theft) wasn't working properly: the exiled card wasn't returned to hand if it wasn't cast. So, by comparison with [Bank Job](https://scryfall.com/card/ysnc/18/bank-job), a similar enough card, I restored the former cards' functionality.