### PR TITLE
Add a few upcoming MH3/M3C cards

### DIFF
--- a/forge-gui/res/cardsfolder/r/rootless_yew.txt
+++ b/forge-gui/res/cardsfolder/r/rootless_yew.txt
@@ -3,5 +3,5 @@ ManaCost:3 G G
 Types:Creature Treefolk
 PT:5/4
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigChange | TriggerDescription$ When CARDNAME dies, search your library for a creature card with power or toughness 6 or greater, reveal it, put it into your hand, then shuffle.
-SVar:TrigChange:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Creature.cmcGE6 | ChangeNum$ 1 | ShuffleNonMandatory$ True
+SVar:TrigChange:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Creature.powerGE6,Creature.toughnessGE6 | ChangeNum$ 1 | ShuffleNonMandatory$ True
 Oracle:When Rootless Yew dies, search your library for a creature card with power or toughness 6 or greater, reveal it, put it into your hand, then shuffle.

--- a/forge-gui/res/cardsfolder/upcoming/angelic_aberration.txt
+++ b/forge-gui/res/cardsfolder/upcoming/angelic_aberration.txt
@@ -1,0 +1,15 @@
+Name:Angelic Aberration
+ManaCost:5 W
+Types:Creature Eldrazi Angel
+PT:4/4
+K:Devoid
+K:Flying
+K:Vigilance
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSac | TriggerDescription$ When CARDNAME enters the battlefield, sacrifice any number of creatures each with base power or toughness 1 or less. Create that many 4/4 colorless Eldrazi Angel creature tokens with flying and vigilance.
+SVar:TrigSac:DB$ Sacrifice | Defined$ You | Amount$ SacX | SacValid$ Creature.YouCtrl+basePowerLE1,Creature.YouCtrl+baseToughnessLE1 | RememberSacrificed$ True | Optional$ True | SubAbility$ DBToken
+SVar:DBToken:DB$ Token | TokenAmount$ X | TokenScript$ c_4_4_eldrazi_angel_flying_vigilance | TokenOwner$ You | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:SacX:Count$Valid Creature.YouCtrl+basePowerLE1,Creature.YouCtrl+baseToughnessLE1
+SVar:X:Remembered$Amount
+DeckHints:Type$Eldrazi
+Oracle:Devoid\nFlying, vigilance\nWhen Angelic Aberration enters the battlefield, sacrifice any number of creatures each with base power or toughness 1 or less. Create that many 4/4 colorless Eldrazi Angel creature tokens with flying and vigilance.

--- a/forge-gui/res/cardsfolder/upcoming/ghostfire_slice.txt
+++ b/forge-gui/res/cardsfolder/upcoming/ghostfire_slice.txt
@@ -1,0 +1,7 @@
+Name:Ghostfire Slice
+ManaCost:2 R
+Types:Instant
+K:Devoid
+S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 2 | EffectZone$ All | IsPresent$ Permanent.MultiColor+OppCtrl | Description$ CARDNAME costs {2} less to cast if an opponent controls a multicolored permanent.
+A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ 4 | SpellDescription$ CARDNAME deals 4 damage to any target.
+Oracle:Devoid (This card has no color.)\nThis spell costs {2} less to cast if an opponent controls a multicolored permanent.\nGhostfire Slice deals 4 damage to any target.

--- a/forge-gui/res/cardsfolder/upcoming/marionette_apprentice.txt
+++ b/forge-gui/res/cardsfolder/upcoming/marionette_apprentice.txt
@@ -1,0 +1,10 @@
+Name:Marionette Apprentice
+ManaCost:1 B
+Types:Creature Human Artificer
+PT:1/2
+K:Fabricate:1
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.Other+YouCtrl,Artifact.Other+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigLoseLife | TriggerDescription$ Whenever another creature or artifact you control is put into a graveyard from the battlefield, each opponent loses 1 life.
+SVar:TrigLoseLife:DB$ LoseLife | Defined$ Opponent | LifeAmount$ 1
+DeckHas:Ability$Counters|Token
+DeckHints:Type$Artifact
+Oracle:Fabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)\nWhenever another creature or artifact you control is put into a graveyard from the battlefield, each opponent loses 1 life.

--- a/forge-gui/res/cardsfolder/upcoming/springheart_nantuko.txt
+++ b/forge-gui/res/cardsfolder/upcoming/springheart_nantuko.txt
@@ -1,0 +1,13 @@
+Name:Springheart Nantuko
+ManaCost:1 G
+Types:Enchantment Creature Insect Monk
+PT:1/1
+K:Bestow:1 G
+S:Mode$ Continuous | Affected$ Card.EnchantedBy | AddPower$ 1 | AddToughness$ 1 | Description$ Enchanted creature gets +1/+1.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigBranch | TriggerDescription$ Landfall — Whenever a land enters the battlefield under your control, you may pay {1}{G} if CARDNAME is attached to a creature you control. If you do, create a token that’s a copy of that creature. If you didn’t create a token this way, create a 1/1 green Insect creature token.
+SVar:TrigBranch:DB$ Branch | BranchConditionSVar$ X | BranchConditionSVarCompare$ EQ1 | TrueSubAbility$ TrigCopy | FalseSubAbility$ TrigToken
+SVar:TrigCopy:DB$ CopyPermanent | Defined$ Enchanted | UnlessCost$ 1 G | UnlessPayer$ You | UnlessSwitched$ True | UnlessResolveSubs$ WhenNotPaid | SubAbility$ TrigToken
+SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ g_1_1_insect
+SVar:X:Count$Valid Card.EnchantedBy+YouCtrl
+DeckHas:Ability$Token
+Oracle:Bestow {1}{G}\nEnchanted creature gets +1/+1.\nLandfall — Whenever a land enters the battlefield under your control, you may pay {1}{G} if Springheart Nantuko is attached to a creature you control. If you do, create a token that’s a copy of that creature. If you didn’t create a token this way, create a 1/1 green Insect creature token.

--- a/forge-gui/res/cardsfolder/upcoming/stump_stomp_burnwillow_clearing.txt
+++ b/forge-gui/res/cardsfolder/upcoming/stump_stomp_burnwillow_clearing.txt
@@ -1,0 +1,17 @@
+Name:Stump Stomp
+ManaCost:1 RG
+Types:Sorcery
+A:SP$ Pump | ValidTgts$ Creature.YouCtrl | AILogic$ PowerDmg | TgtPrompt$ Select target creature you control | SubAbility$ StompDamage | StackDescription$ None | SpellDescription$ Target creature you control deals damage equal to its power to target creature or planeswalker you don't control.
+SVar:StompDamage:DB$ DealDamage | AILogic$ PowerDmg | ValidTgts$ Creature.YouDontCtrl,Planeswalker.YouDontCtrl | TgtPrompt$ Select target creature or planeswalker you don't control | NumDmg$ X | DamageSource$ ParentTarget
+SVar:X:ParentTargeted$CardPower
+AlternateMode:Modal
+Oracle:Target creature you control deals damage equal to its power to target creature or planeswalker you don't control.
+
+ALTERNATE
+
+Name:Burnwillow Clearing
+ManaCost:no cost
+Types:Land
+K:CARDNAME enters the battlefield tapped.
+A:AB$ Mana | Cost$ T | Produced$ Combo R G | SpellDescription$ Add {R} or {G}.
+Oracle:Burnwillow Clearing enters the battlefield tapped.\n{T}: Add {R} or {G}.

--- a/forge-gui/res/cardsfolder/upcoming/utter_insignificance.txt
+++ b/forge-gui/res/cardsfolder/upcoming/utter_insignificance.txt
@@ -1,0 +1,9 @@
+Name:Utter Insignificance
+ManaCost:1 U
+Types:Enchantment Aura
+K:Flash
+K:Enchant creature
+A:SP$ Attach | Cost$ 1 U | ValidTgts$ Creature | AILogic$ Curse
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | SetPower$ 1 | SetToughness$ 1 | RemoveAllAbilities$ True | Description$ Enchanted creature loses all abilities and has base power and toughness 1/1.
+A:AB$ ChangeZone | Cost$ 2 C | Defined$ Enchanted | Origin$ Battlefield | Destination$ Exile | SpellDescription$ Exile enchanted creature.
+Oracle:Enchant creature\nEnchanted creature loses all abilities and has base power and toughness 1/1.\n{2}{C}: Exile enchanted creature.

--- a/forge-gui/res/tokenscripts/c_4_4_eldrazi_angel_flying_vigilance.txt
+++ b/forge-gui/res/tokenscripts/c_4_4_eldrazi_angel_flying_vigilance.txt
@@ -1,0 +1,7 @@
+Name:Eldrazi Angel Token
+ManaCost:no cost
+Types:Creature Eldrazi Angel
+K:Flying
+K:Vigilance
+PT:4/4
+Oracle:Flying, vigilance


### PR DESCRIPTION
All manually tested

Getting the nantuko to work was a mission 😅

The eldrazi angel tokens don't have an image. It can be pulled from here https://scryfall.com/card/tm3c/2/eldrazi-angel but I don't know the process for getting it onto cardforge.org so I've left it out of token-images.txt.

Also fixed an older card (Rootless Yew) that I ran into while looking up reference copies for abilities

Scryfall references:
* https://scryfall.com/card/mh3/171/springheart-nantuko
* https://scryfall.com/card/m3c/39/angelic-aberration
* https://scryfall.com/card/mh3/123/ghostfire-slice
* https://scryfall.com/card/mh3/100/marionette-apprentice
* https://scryfall.com/card/mh3/78/utter-insignificance
* https://scryfall.com/card/mh3/259/stump-stomp-burnwillow-clearing
* https://scryfall.com/card/khm/189/rootless-yew