### PR TITLE
M3C: final 2 "easy" cards

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/localized_destruction.txt
+++ b/forge-gui/res/cardsfolder/upcoming/localized_destruction.txt
@@ -1,0 +1,9 @@
+Name:Localized Destruction
+ManaCost:3 W W
+Types:Sorcery
+A:SP$ PutCounter | Defined$ You | CounterType$ ENERGY | SubAbility$ DBChooseNumber | StackDescription$ SpellDescription | SpellDescription$ You get {E} (an energy counter), then you may pay one or more {E}.
+SVar:DBChooseNumber:DB$ ChooseNumber | Max$ Count$YourCountersEnergy | ListTitle$ Choose amount of energy to pay | SubAbility$ DBPumpAll | StackDescription$ None
+SVar:DBPumpAll:DB$ PumpAll | ConditionCheckSVar$ X | UnlessCost$ Mandatory PayEnergy<X> | UnlessPayer$ You | UnlessSwitched$ True | ValidCards$ Creature.YouCtrl+powerEQX | KW$ Indestructible | SubAbility$ DBDestroyAll | StackDescription$ SpellDescription | SpellDescription$ If you do, each creature you control with power equal to the amount of {E} paid this way gains indestructible until end of turn.,,,,,,
+SVar:X:Count$ChosenNumber
+SVar:DBDestroyAll:DB$ DestroyAll | ValidCards$ Creature | SpellDescription$ Destroy all creatures.
+Oracle:You get {E} (an energy counter), then you may pay one or more {E}. If you do, each creature you control with power equal to the amount of {E} paid this way gains indestructible until end of turn.\nDestroy all creatures.

--- a/forge-gui/res/cardsfolder/upcoming/selective_obliteration.txt
+++ b/forge-gui/res/cardsfolder/upcoming/selective_obliteration.txt
@@ -1,0 +1,10 @@
+Name:Selective Obliteration
+ManaCost:3 C C
+Types:Sorcery
+A:SP$ RepeatEach | RepeatPlayers$ Player | RepeatSubAbility$ DBChooseColor | SubAbility$ ExileAll | SpellDescription$ Each player chooses a color.
+SVar:DBChooseColor:DB$ ChooseColor | Defined$ Remembered | AILogic$ MostProminentComputerControls | SubAbility$ FilterForExile
+SVar:FilterForExile:DB$ Pump | RememberObjects$ Valid Permanent.RememberedPlayerCtrl+MonoColor+ChosenColor
+SVar:ExileAll:DB$ ChangeZoneAll | Origin$ Battlefield | Destination$ Exile | ChangeType$ Card.nonColorless+IsNotRemembered | SubAbility$ DBCleanup | SpellDescription$ Then exile each permanent unless it's colorless or it's only the color its controller chose.
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+AI:RemoveDeck:All
+Oracle:Each player chooses a color. Then exile each permanent unless it's colorless or it's only the color its controller chose.


### PR DESCRIPTION
AI will need help to pick a logical color for Selective Obliteration

Right now it always picks Black

Seems like it needs to be:
 - color of "best" mono colored permanent AI controls
 - color of highest number of mono colored permanents AI controls

I poked around in PlayerControllerAi.chooseColor but I don't think that's the right spot