### PR TITLE
MH3 Precon decks

### DIFF
--- a/forge-gui/res/quest/commanderprecons/Creative Energy [M3C] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Creative Energy [M3C] [2024].dck
@@ -1,0 +1,94 @@
+[metadata]
+Name=Creative Energy [M3C] [2024]
+[Commander]
+1 Satya, Aetherflux Genius|M3C|1
+[Main]
+1 Aethergeode Miner|M3C|1
+1 Aethersquall Ancient|M3C|1
+1 Aetherstorm Roc|M3C|1
+1 Aethertide Whale|M3C|1
+1 Amped Raptor|MH3|1
+1 Angel of Invention|M3C|1
+1 Aurora Shifter|M3C|2
+1 Blaster Hulk|M3C|2
+1 Brudiclad, Telchor Engineer|M3C|1
+1 Burnished Hart|M3C|1
+1 Cayth, Famed Mechanist|M3C|1
+1 Combustible Gearhulk|M3C|1
+1 Goldspan Dragon|M3C|1
+1 Grenzo, Havoc Raiser|M3C|1
+1 Lightning Runner|M3C|1
+1 Myr Battlesphere|M3C|1
+1 Overclocked Electromancer|M3C|2
+1 Professional Face-Breaker|M3C|1
+1 Razorfield Ripper|M3C|2
+1 Roil Cartographer|MH3|1
+1 Salvation Colossus|M3C|2
+1 Silverquill Lecturer|M3C|2
+1 Skyclave Apparition|M3C|1
+1 Solemn Simulacrum|M3C|1
+1 Sphinx of the Revelation|M3C|2
+1 Whirler Virtuoso|M3C|1
+1 Aether Refinery|M3C|2
+1 Aethersphere Harvester|M3C|1
+1 Aetherworks Marvel|M3C|1
+1 Arcane Signet|M3C|1
+1 Bespoke Battlewagon|MH3|1
+1 Bident of Thassa|M3C|1
+1 Coalition Relic|M3C|1
+1 Conversion Apparatus|M3C|2
+1 Coveted Jewel|M3C|1
+1 Decoction Module|M3C|1
+1 Filigree Racer|M3C|2
+1 Gonti's Aether Heart|M3C|1
+1 Hourglass of the Lost|M3C|2
+1 Izzet Generatorium|MH3|1
+1 Midnight Clock|M3C|1
+1 Sol Ring|M3C|1
+1 Solar Transformer|MH3|1
+1 Stone Idol Generator|M3C|2
+1 Talisman of Conviction|M3C|1
+1 Talisman of Creativity|M3C|1
+1 Talisman of Progress|M3C|1
+1 Unstable Amulet|MH3|1
+1 Wayfarer's Bauble|M3C|1
+1 Era of Innovation|M3C|1
+1 Legion Loyalty|M3C|1
+1 Scurry of Gremlins|MH3|1
+1 Akroma's Will|M3C|1
+1 Glimmer of Genius|M3C|1
+1 Swords to Plowshares|M3C|1
+1 Austere Command|M3C|1
+1 Confiscation Coup|M3C|1
+1 Farewell|M3C|1
+1 Jolted Awake|MH3|1
+1 Localized Destruction|M3C|2
+1 Tezzeret's Gambit|M3C|1
+1 Adarkar Wastes|M3C|1
+1 Aether Hub|M3C|1
+1 Azorius Chancery|M3C|1
+1 Battlefield Forge|M3C|1
+1 Castle Vantress|M3C|1
+1 Command Tower|M3C|1
+1 Demolition Field|M3C|1
+1 Frostboil Snarl|M3C|1
+1 Furycalm Snarl|M3C|1
+1 Izzet Boilerworks|M3C|1
+1 Mystic Gate|M3C|1
+1 Mystic Monastery|M3C|1
+1 Port Town|M3C|1
+1 Prairie Stream|M3C|1
+1 Shivan Reef|M3C|1
+1 Temple of Enlightenment|M3C|1
+1 Temple of Epiphany|M3C|1
+1 Temple of Triumph|M3C|1
+2 Island|MH3|1
+2 Island|MH3|2
+1 Island|MH3|3
+2 Mountain|MH3|1
+2 Mountain|MH3|2
+1 Mountain|MH3|3
+4 Plains|MH3|1
+3 Plains|MH3|2
+3 Plains|MH3|3
+[Sideboard]

--- a/forge-gui/res/quest/commanderprecons/Eldrazi Incursion [M3C] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Eldrazi Incursion [M3C] [2024].dck
@@ -1,0 +1,104 @@
+[metadata]
+Name=Eldrazi Incursion [M3C] [2024]
+[Commander]
+1 Ulalek, Fused Atrocity|M3C|1
+[Main]
+1 Angelic Aberration|M3C|1
+1 Artisan of Kozilek|M3C|1
+1 Azlask, the Swelling Scourge|M3C|1
+1 Benthic Anomaly|M3C|1
+1 Bismuth Mindrender|M3C|1
+1 Chittering Dispatcher|M3C|1
+1 Deepfathom Skulker|M3C|1
+1 Drowner of Hope|M3C|1
+1 Elder Deep-Fiend|M3C|1
+1 Eldrazi Displacer|M3C|1
+1 Endbringer|M3C|1
+1 Glaring Fleshraker|MH3|1
+1 Hideous Taskmaster|M3C|2
+1 Inversion Behemoth|M3C|1
+1 Morophon, the Boundless|M3C|1
+1 Mutated Cultist|M3C|1
+1 Oblivion Sower|M3C|1
+1 Sifter of Skulls|M3C|1
+1 Sire of Stagnation|M3C|1
+1 Snapping Voidcraw|MH3|1
+1 Spawnbed Protector|M3C|1
+1 Titans' Vanguard|MH3|1
+1 Twins of Discord|M3C|1
+1 Ulamog's Crusher|M3C|1
+1 Ulamog's Dreadsire|M3C|1
+1 Ulamog's Nullifier|M3C|1
+1 Vile Redeemer|M3C|1
+1 Wastescape Battlemage|MH3|1
+1 World Breaker|M3C|1
+1 All Is Dust|M3C|1
+1 Ancient Stirrings|M3C|1
+1 Rishkar's Expertise|M3C|1
+1 Selective Obliteration|M3C|1
+1 Skittering Invasion|M3C|1
+1 Ugin's Insight|M3C|1
+1 Crib Swap|M3C|1
+1 Eldrazi Confluence|M3C|1
+1 Eldritch Immunity|M3C|1
+1 Kozilek's Return|M3C|1
+1 Return of the Wildspeaker|M3C|1
+1 Suffer the Past|M3C|1
+1 Warping Wail|M3C|1
+1 Awakening Zone|M3C|1
+1 Eldrazi Conscription|M3C|1
+1 Garruk's Uprising|M3C|1
+1 Imprisoned in the Moon|M3C|1
+1 Arcane Signet|M3C|1
+1 Dreamstone Hedron|M3C|1
+1 Eldrazi Monument|M3C|1
+1 Everflowing Chalice|M3C|1
+1 Forsaken Monument|M3C|1
+1 Hedron Archive|M3C|1
+1 Herald's Horn|M3C|1
+1 Idol of Oblivion|M3C|1
+1 Mystic Forge|M3C|1
+1 Sol Ring|M3C|1
+1 Talisman of Curiosity|M3C|1
+1 Talisman of Dominance|M3C|1
+1 Talisman of Impulse|M3C|1
+1 Talisman of Resilience|M3C|1
+1 Adarkar Wastes|M3C|1
+1 Ash Barrens|M3C|1
+1 Battlefield Forge|M3C|1
+1 Bonders' Enclave|M3C|1
+1 Brushland|M3C|1
+1 Cascading Cataracts|M3C|1
+1 Caves of Koilos|M3C|1
+1 Command Tower|M3C|1
+1 Corrupted Crossroads|M3C|1
+1 Eldrazi Temple|M3C|1
+1 Exotic Orchard|M3C|1
+1 Karplusan Forest|M3C|1
+1 Llanowar Wastes|M3C|1
+1 Opal Palace|M3C|1
+1 Path of Ancestry|M3C|1
+1 Reliquary Tower|M3C|1
+1 Ruins of Oran-Rief|M3C|1
+1 Secluded Courtyard|M3C|1
+1 Shivan Reef|M3C|1
+1 Shrine of the Forsaken Gods|M3C|1
+1 Spawning Bed|M3C|1
+1 Sulfurous Springs|M3C|1
+1 Tectonic Edge|M3C|1
+1 Temple of Malady|M3C|1
+1 Temple of Silence|M3C|1
+1 Tendo Ice Bridge|M3C|1
+1 Tomb of the Spirit Dragon|M3C|1
+1 Tranquil Landscape|MH3|1
+1 Twisted Landscape|MH3|1
+1 Unclaimed Territory|M3C|1
+1 Underground River|M3C|1
+1 Yavimaya Coast|M3C|1
+1 Wastes|M3C|1
+1 Plains|MH3|1
+1 Island|MH3|1
+1 Swamp|MH3|1
+1 Mountain|MH3|1
+1 Forest|MH3|1
+[Sideboard]

--- a/forge-gui/res/quest/commanderprecons/Graveyard Overdrive [M3C] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Graveyard Overdrive [M3C] [2024].dck
@@ -1,0 +1,102 @@
+[metadata]
+Name=Graveyard Overdrive [M3C] [2024]
+[Commander]
+1 Disa the Restless|M3C|1
+[Main]
+1 Accursed Marauder|MH3|1
+1 Anger|M3C|1
+1 Archon of Cruelty|M3C|1
+1 Barrowgoyf|M3C|2
+1 Bloodbraid Challenger|M3C|2
+1 Bloodbraid Elf|M3C|1
+1 Brawn|M3C|1
+1 Broodmate Tyrant|M3C|2
+1 Burnished Hart|M3C|1
+1 Coram, the Undertaker|M3C|1
+1 Exterminator Magmarch|M3C|2
+1 Eternal Witness|M3C|1
+1 Gluttonous Hellkite|M3C|2
+1 Graveshifter|M3C|1
+1 Ignoble Hierarch|M3C|1
+1 Infested Thrinax|M3C|2
+1 Izoni, Thousand-Eyed|M3C|1
+1 Junji, the Midnight Sky|M3C|1
+1 Lhurgoyf|M3C|1
+1 Mortivore|M3C|1
+1 Necrogoyf|M3C|1
+1 Pyrogoyf|M3C|2
+1 Polygoyf|M3C|2
+1 Sakura-Tribe Elder|M3C|1
+1 Sawhorn Nemesis|M3C|2
+1 Selvala, Heart of the Wilds|M3C|1
+1 Siege-Gang Lieutenant|M3C|2
+1 Stitcher's Supplier|M3C|1
+1 Syr Konrad, the Grim|M3C|1
+1 Yavimaya Elder|M3C|1
+1 Ziatora, the Incinerator|M3C|1
+1 Garruk, Apex Predator|M3C|1
+1 Grist, the Hunger Tide|M3C|1
+1 Liliana, Death's Majesty|M3C|1
+1 Altar of the Goyf|M3C|1
+1 Arcane Signet|M3C|1
+1 Lightning Greaves|M3C|1
+1 Maskwood Nexus|M3C|1
+1 Sol Ring|M3C|1
+1 Talisman of Impulse|M3C|1
+1 Talisman of Indulgence|M3C|1
+1 Talisman of Resilience|M3C|1
+1 The Reaver Cleaver|M3C|1
+1 Deadbridge Chant|M3C|1
+1 Deathreap Ritual|M3C|1
+1 Tarmogoyf Nest|M3C|2
+1 Bituminous Blast|M3C|1
+1 Grapple with the Past|M3C|1
+1 Grisly Salvage|M3C|1
+1 Kolaghan's Command|M3C|1
+1 Riveteers Charm|M3C|1
+1 Tempt with Mayhem|M3C|2
+1 Terminate|M3C|1
+1 Chandra's Ignition|M3C|1
+1 Faithless Looting|M3C|1
+1 Final Act|M3C|2
+1 Find // Finality|M3C|1
+1 Maelstrom Pulse|M3C|1
+1 Rampant Growth|M3C|1
+1 Syphon Mind|M3C|1
+1 Canyon Slough|M3C|1
+1 Cinder Glade|M3C|1
+1 Command Tower|M3C|1
+1 Dakmor Salvage|M3C|1
+1 Demolition Field|M3C|1
+1 Evolving Wilds|M3C|1
+1 Exotic Orchard|M3C|1
+1 Forgotten Cave|M3C|1
+1 Kessig Wolf Run|M3C|1
+1 Mossfire Valley|M3C|1
+1 Myriad Landscape|M3C|1
+1 Path of Ancestry|M3C|1
+1 Raging Ravine|M3C|1
+1 Riveteers Overlook|M3C|1
+1 Savage Lands|M3C|1
+1 Shadowblood Ridge|M3C|1
+1 Sheltered Thicket|M3C|1
+1 Smoldering Marsh|M3C|1
+1 Tainted Peak|M3C|1
+1 Tainted Wood|M3C|1
+1 Temple of Abandon|M3C|1
+1 Temple of Malady|M3C|1
+1 Temple of Malice|M3C|1
+1 Terramorphic Expanse|M3C|1
+1 Tranquil Thicket|M3C|1
+1 Twisted Landscape|MH3|1
+1 Viridescent Bog|M3C|1
+2 Forest|MH3|1
+2 Forest|MH3|2
+1 Forest|MH3|3
+1 Mountain|MH3|1
+1 Mountain|MH3|2
+1 Mountain|MH3|3
+2 Swamp|MH3|1
+1 Swamp|MH3|2
+1 Swamp|MH3|3
+[Sideboard]

--- a/forge-gui/res/quest/commanderprecons/Tricky Terrain [M3C] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Tricky Terrain [M3C] [2024].dck
@@ -18,9 +18,9 @@ Name=Tricky Terrain [M3C] [2024]
 1 Magus of the Candelabra|M3C|1
 1 Poison Dart Frog|M3C|1
 1 Rampaging Baloths|M3C|1
-1 Rampant Frogantua|M3C|1
+1 Rampant Frogantua|M3C|2
 1 Ramunap Excavator|M3C|1
-1 Sage of the Maze|M3C|1
+1 Sage of the Maze|M3C|2
 1 Satyr Wayfinder|M3C|1
 1 Scute Swarm|M3C|1
 1 Skullwinder|M3C|1
@@ -28,13 +28,13 @@ Name=Tricky Terrain [M3C] [2024]
 1 Terastodon|M3C|1
 1 Ulvenwald Hydra|M3C|1
 1 Uro, Titan of Nature's Wrath|M3C|1
-1 Wonderscape Sage|M3C|1
-1 Aggressive Biomancy|M3C|1
+1 Wonderscape Sage|M3C|2
+1 Aggressive Biomancy|M3C|2
 1 Curse of the Swine|M3C|1
 1 Finale of Revelation|M3C|1
 1 Harmonize|M3C|1
 1 Hour of Promise|M3C|1
-1 March from Velis Vel|M3C|1
+1 March from Velis Vel|M3C|2
 1 Replication Technique|M3C|1
 1 Sylvan Scrying|M3C|1
 1 Treasure Cruise|M3C|1
@@ -47,8 +47,8 @@ Name=Tricky Terrain [M3C] [2024]
 1 Growth Spiral|M3C|1
 1 Pongify|M3C|1
 1 Summary Dismissal|M3C|1
-1 Copy Land|M3C|1
-1 Desert Warfare|M3C|1
+1 Copy Land|M3C|2
+1 Desert Warfare|M3C|2
 1 Mana Reflection|M3C|1
 1 Propaganda|M3C|1
 1 Arcane Signet|M3C|1
@@ -71,22 +71,22 @@ Name=Tricky Terrain [M3C] [2024]
 1 Hashep Oasis|M3C|1
 1 Hidden Cataract|M3C|1
 1 Hidden Nursery|M3C|1
-1 Horizon of Progress|M3C|1
+1 Horizon of Progress|M3C|2
 1 Lair of the Hydra|M3C|1
-1 Lazotep Quarry|M3C|1
+1 Lazotep Quarry|M3C|2
 1 Lumbering Falls|M3C|1
 1 Lush Oasis|M3C|1
 1 Overflowing Basin|M3C|1
-1 Planar Nexus|M3C|1
+1 Planar Nexus|M3C|2
 1 Quandrix Campus|M3C|1
 1 Simic Growth Chamber|M3C|1
 1 Simic Guildgate|M3C|1
-1 Sunken Palace|M3C|1
-1 Talon Gates of Madara|M3C|1
+1 Sunken Palace|M3C|2
+1 Talon Gates of Madara|M3C|2
 1 Temple of Mystery|M3C|1
 1 Thespian's Stage|M3C|1
 1 Thornwood Falls|M3C|1
-1 Trenchpost|M3C|1
+1 Trenchpost|M3C|2
 1 Urza's Mine|M3C|1
 1 Urza's Power Plant|M3C|1
 1 Urza's Tower|M3C|1


### PR DESCRIPTION
I tried to assign the right image numbers, as the first image for most of cards is the extended version. Since Overclocked Electromancer is still unimplemented, Creative Energy won't work yet.