### PR TITLE
Missing up to one logic.

### DIFF
--- a/forge-gui/res/cardsfolder/rebalanced/a-tyvar_kell.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-tyvar_kell.txt
@@ -4,7 +4,7 @@ Types:Legendary Planeswalker Tyvar
 Loyalty:4
 S:Mode$ Continuous | Affected$ Elf.YouCtrl | AddAbility$ Mana | Description$ Elves you control have "{T}: Add {B}."
 SVar:Mana:AB$ Mana | Cost$ T | Produced$ B | Amount$ 1 | SpellDescription$ Add {B}.
-A:AB$ PutCounter | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | ValidTgts$ Elf | TgtPrompt$ Select target Elf | CounterType$ P1P1 | CounterNum$ 2 | SubAbility$ DBUntap | SpellDescription$ Put two +1/+1 counters on up to one target Elf. Untap it. It gains deathtouch until end of turn.
+A:AB$ PutCounter | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | TargetMin$ 0 | TargetMax$ 1 | ValidTgts$ Elf | TgtPrompt$ Select target Elf | CounterType$ P1P1 | CounterNum$ 2 | SubAbility$ DBUntap | SpellDescription$ Put two +1/+1 counters on up to one target Elf. Untap it. It gains deathtouch until end of turn.
 SVar:DBUntap:DB$ Untap | Defined$ Targeted | SubAbility$ DBPump
 SVar:DBPump:DB$ Pump | KW$ Deathtouch | Defined$ Targeted
 A:AB$ Token | Cost$ AddCounter<0/LOYALTY> | TokenAmount$ 1 | TokenScript$ g_1_1_elf_warrior | TokenOwner$ You | Planeswalker$ True | SpellDescription$ Create a 1/1 green Elf Warrior creature token.

--- a/forge-gui/res/cardsfolder/t/tyvar_kell.txt
+++ b/forge-gui/res/cardsfolder/t/tyvar_kell.txt
@@ -4,7 +4,7 @@ Types:Legendary Planeswalker Tyvar
 Loyalty:3
 S:Mode$ Continuous | Affected$ Elf.YouCtrl | AddAbility$ Mana | Description$ Elves you control have "{T}: Add {B}."
 SVar:Mana:AB$ Mana | Cost$ T | Produced$ B | Amount$ 1 | SpellDescription$ Add {B}.
-A:AB$ PutCounter | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | ValidTgts$ Elf | TgtPrompt$ Select target Elf | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBUntap | SpellDescription$ Put a +1/+1 counter on up to one target Elf. Untap it. It gains deathtouch until end of turn.
+A:AB$ PutCounter | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | TargetMin$ 0 | TargetMax$ 1 | ValidTgts$ Elf | TgtPrompt$ Select target Elf | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBUntap | SpellDescription$ Put a +1/+1 counter on up to one target Elf. Untap it. It gains deathtouch until end of turn.
 SVar:DBUntap:DB$ Untap | Defined$ Targeted | SubAbility$ DBPump
 SVar:DBPump:DB$ Pump | KW$ Deathtouch | Defined$ Targeted
 A:AB$ Token | Cost$ AddCounter<0/LOYALTY> | TokenAmount$ 1 | TokenScript$ g_1_1_elf_warrior | TokenOwner$ You | Planeswalker$ True | SpellDescription$ Create a 1/1 green Elf Warrior creature token.


### PR DESCRIPTION
The +1 loyalty ability reads "Put a +1/+1 counter on up to one target Elf."