### PR TITLE
SLD: Rainbow Dash

### DIFF
--- a/forge-gui/res/cardsfolder/r/rainbow_dash.txt
+++ b/forge-gui/res/cardsfolder/r/rainbow_dash.txt
@@ -1,0 +1,14 @@
+Name:Rainbow Dash
+ManaCost:1 R W
+Types:Legendary Creature Pegasus
+PT:2/2
+K:Flying
+K:Haste
+T:Mode$ Attacks | ValidCard$ Creature.withFlying+YouCtrl,Creature.withHaste+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigGetCooler | TriggerDescription$ Whenever a creature you control with flying and/or haste attacks, you get 20% cooler. (You start at 0% coolness.)
+SVar:TrigGetCooler:DB$ Effect | Name$ Coolness Badge | StaticAbilities$ STCoolness | Duration$ Permanent
+SVar:STCoolness:Mode$ Continuous | EffectZone$ Command | Affected$ You | Description$ You get 20% cooler.
+A:AB$ Mana | Cost$ T | ConditionCheckSVar$ RDCoolness | ConditionSVarCompare$ GE5 | Produced$ W U B R G | PrecostDesc$ Sonic Rainboom — | SpellDescription$ If you're at least 100% cool, add {W}{U}{B}{R}{G}, draw a card, and reset your coolness. | SubAbility$ DBDraw
+SVar:DBDraw:DB$ Draw | NumCards$ 1 | ConditionCheckSVar$ RDCoolness | ConditionSVarCompare$ GE5 | SubAbility$ ResetCoolness
+SVar:ResetCoolness:DB$ ChangeZoneAll | ConditionCheckSVar$ RDCoolness | ConditionSVarCompare$ GE5 | ChangeType$ Effect.YouCtrl+namedCoolness Badge | Origin$ Command | Destination$ Exile
+SVar:RDCoolness:Count$ValidCommand Effect.YouCtrl+namedCoolness Badge
+Oracle:Flying, haste\nWhenever a creature you control with flying and/or haste attacks, you get 20% cooler. (You start at 0% coolness.)\nSonic Rainboom — {T}: If you're at least 100% cool, add {W}{U}{B}{R}{G}, draw a card, and reset your coolness.


### PR DESCRIPTION
[Rainbow Dash](https://scryfall.com/card/sld/1540/rainbow-dash) seemed like an easy enough, near-blackborder card, so I ran it by [ForgeScribeGPT4](https://chatgpt.com/g/g-TGeM8rWuF-forgescribegpt4) to see what it would generate. I would have loved to track coolness as a stored variable like the model hinted at but, unfortunately, there weren't any readily available examples of how to display a number on a command zone effect. This not to mention how the model is rather... hopeful about what flies in Forge's game engine. 
Thus the solution for now is to accumulate and count `Coolness Badge` effects.