### PR TITLE
 DSK: Enduring Tenacity

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/enduring_tenacity.txt
+++ b/forge-gui/res/cardsfolder/upcoming/enduring_tenacity.txt
@@ -1,0 +1,12 @@
+Name:Enduring Tenacity
+ManaCost:2 B B
+Types:Enchantment Creature Snake Glimmer
+PT:4/3
+T:Mode$ LifeGained | ValidPlayer$ You | Execute$ TrigLoseLife | TriggerZones$ Battlefield | TriggerDescription$ Whenever you gain life, target opponent loses that much life.
+SVar:TrigLoseLife:DB$ LoseLife | ValidTgts$ Opponent | LifeAmount$ X
+SVar:X:TriggerCount$LifeAmount
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self+Creature | Execute$ DBReturn | TriggerDescription$ When CARDNAME dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)
+SVar:DBReturn:DB$ ChangeZone | Defined$ TriggeredNewCardLKICopy | Origin$ Graveyard | Destination$ Battlefield | AnimateSubAbility$ DBAnimate
+SVar:DBAnimate:DB$ Animate | Defined$ Remembered | Types$ Enchantment | RemoveCardTypes$ True | Duration$ Permanent
+DeckHints:Ability$LifeGain
+Oracle:Whenever you gain life, target opponent loses that much life.\nWhen Enduring Tenacity dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)


### PR DESCRIPTION
Tested card script for:
- [Enduring Tenacity](https://www.reddit.com/r/magicTCG/comments/1dphm0f/dsk_enduring_tenacity/)

While [ForgeScribeGPT4](https://chatgpt.com/g/g-TGeM8rWuF-forgescribegpt4) sped up laying things out, comparison with [Defiant Bloodlord](https://scryfall.com/card/c21/142/defiant-bloodlord) and [Old-Growth Troll](https://scryfall.com/card/khm/185/old-growth-troll) allowed me to curb the generative model's excesses. I assume Glimmer is a new enchantment type but the card seems to work fine without having that defined so I'd default to waiting on relevant explicit information to add it to `TypeLists.txt`.