### PR TITLE
15 ACR/BLB/DSK cards

### DIFF
--- a/forge-game/src/main/java/forge/game/card/CounterEnumType.java
+++ b/forge-game/src/main/java/forge/game/card/CounterEnumType.java
@@ -340,6 +340,8 @@ public enum CounterEnumType {
     REPRIEVE("REPR", 240, 120, 50),
 
     REJECTION("REJECT", 212, 235, 242),
+
+    REV("REV", 255, 108, 111),
     
     RIBBON("RIBBON", 233, 245, 232),
 

--- a/forge-game/src/main/java/forge/game/card/CounterEnumType.java
+++ b/forge-game/src/main/java/forge/game/card/CounterEnumType.java
@@ -287,6 +287,8 @@ public enum CounterEnumType {
 
     NET("NET", 0, 221, 251),
 
+    NEST("NEST", 80, 80, 50),
+
     OIL("OIL", 99, 102, 106),
 
     OMEN("OMEN", 255, 178, 120),

--- a/forge-gui/res/cardsfolder/s/secret_plans.txt
+++ b/forge-gui/res/cardsfolder/s/secret_plans.txt
@@ -1,7 +1,7 @@
 Name:Secret Plans
 ManaCost:G U
 Types:Enchantment
-S:Mode$ Continuous | Affected$ Creature.faceDown+YouCtrl | AddToughness$ 1 | Description$ Face-Down creatures you control get +0/+1.
+S:Mode$ Continuous | Affected$ Creature.faceDown+YouCtrl | AddToughness$ 1 | Description$ Face-down creatures you control get +0/+1.
 T:Mode$ TurnFaceUp | ValidCard$ Permanent.YouCtrl | Execute$ TrigDraw | TriggerZones$ Battlefield | TriggerDescription$ Whenever a permanent you control is turned face up, draw a card.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1
 SVar:PlayMain1:TRUE

--- a/forge-gui/res/cardsfolder/upcoming/carrot_cake.txt
+++ b/forge-gui/res/cardsfolder/upcoming/carrot_cake.txt
@@ -1,0 +1,10 @@
+Name:Carrot Cake
+ManaCost:1 W
+Types:Artifact Food
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters and when you sacrifice it, create a 1/1 white Rabbit creature token and scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+T:Mode$ Sacrificed | ValidPlayer$ You | ValidCard$ Card.Self | Execute$ TrigToken | TriggerZones$ Battlefield | Secondary$ True | TriggerDescription$ When CARDNAME enters and when you sacrifice it, create a 1/1 white Rabbit creature token and scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ w_1_1_rabbit | TokenOwner$ You | SubAbility$ DBScry
+SVar:DBScry:DB$ Scry | ScryNum$ 1
+A:AB$ GainLife | Cost$ 2 T Sac<1/CARDNAME> | Defined$ You | LifeAmount$ 3 | SpellDescription$ You gain 3 life.
+DeckHas:Ability$LifeGain|Food|Token
+Oracle:When Carrot Cake enters and when you sacrifice it, create a 1/1 white Rabbit creature token and scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{2}, {T}, Sacrifice Carrot Cake: You gain 3 life.

--- a/forge-gui/res/cardsfolder/upcoming/chainsaw.txt
+++ b/forge-gui/res/cardsfolder/upcoming/chainsaw.txt
@@ -1,0 +1,12 @@
+Name:Chainsaw
+ManaCost:1 R
+Types:Artifact Equipment
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When CARDNAME enters, it deals 3 damage to up to one target creature.
+SVar:TrigDealDamage:DB$ DealDamage |  ValidTgts$ Creature | TgtPrompt$ Select up to one target creature | TargetMin$ 0 | TargetMax$ 1 | NumDmg$ 3
+T:Mode$ ChangesZoneAll | TriggerZones$ Battlefield | ValidCards$ Creature | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigPutCounter | TriggerDescription$ Whenever one or more creatures die, put a rev counter on CARDNAME.
+SVar:TrigPutCounter:DB$ PutCounter | CounterType$ REV
+S:Mode$ Continuous | Affected$ Card.EquippedBy | AddPower$ X | Description$ Equipped creature gets +X/+0, where X is the number of rev counters on CARDNAME.
+K:Equip:3
+SVar:X:Count$CardCounters.REV
+SVar:PlayMain1:TRUE
+Oracle:When Chainsaw enters, it deals 3 damage to up to one target creature.\nWhenever one or more creatures die, put a rev counter on Chainsaw.\nEquipped creature gets +X/+0, where X is the number of rev counters on Chainsaw.\nEquip {3}

--- a/forge-gui/res/cardsfolder/upcoming/cursed_recording.txt
+++ b/forge-gui/res/cardsfolder/upcoming/cursed_recording.txt
@@ -1,0 +1,12 @@
+Name:Cursed Recording
+ManaCost:2 R R
+Types:Artifact
+T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Whenever you cast an instant or sorcery spell, put a time counter on CARDNAME. Then if there are seven or more time counters on it, remove those counters and it deals 20 damage to you.
+SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ TIME | CounterNum$ 1 | SubAbility$ DBBranch
+SVar:DBBranch:DB$ Branch | BranchConditionSVar$ Count$CardCounters.TIME | BranchConditionSVarCompare$ GE7 | TrueSubAbility$ DBRemoveCounter
+SVar:DBRemoveCounter:DB$ RemoveCounter | CounterType$ TIME | CounterNum$ All | SubAbility$ DBDealDamage
+SVar:DBDealDamage:DB$ DealDamage | NumDmg$ 20 | Defined$ You
+A:AB$ DelayedTrigger | Cost$ T | AILogic$ SpellCopy | Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | ThisTurn$ True | Execute$ EffTrigCopy | SpellDescription$ When you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.
+SVar:EffTrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | MayChooseTarget$ True
+SVar:BuffedBy:Instant,Sorcery
+Oracle:Whenever you cast an instant or sorcery spell, put a time counter on Cursed Recording. Then if there are seven or more time counters on it, remove those counters and it deals 20 damage to you.\n{T}: When you next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.

--- a/forge-gui/res/cardsfolder/upcoming/early_winter.txt
+++ b/forge-gui/res/cardsfolder/upcoming/early_winter.txt
@@ -1,0 +1,7 @@
+Name:Early Winter
+ManaCost:4 B
+Types:Instant
+A:SP$ Charm | Choices$ DBChangeZone1,DBChangeZone2 | Defined$ You
+SVar:DBChangeZone1:DB$ ChangeZone | ValidTgts$ Creature | TgtPrompt$ Choose target creature | Origin$ Battlefield | Destination$ Exile | SpellDescription$ Exile target creature.
+SVar:DBChangeZone1:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Opponent | DefinedPlayer$ Targeted | Mandatory$ True | ChangeType$ Enchantment | ChangeNum$ 1 | Hidden$ True | IsCurse$ True | Chooser$ Targeted | TgtPrompt$ Select target opponent | SpellDescription$ Target opponent exiles an enchantment they control.
+Oracle:Choose one —\n• Exile target creature.\n• Target opponent exiles an enchantment they control.

--- a/forge-gui/res/cardsfolder/upcoming/fear_of_missing_out.txt
+++ b/forge-gui/res/cardsfolder/upcoming/fear_of_missing_out.txt
@@ -1,0 +1,11 @@
+Name:Fear of Missing Out
+ManaCost:1 R
+Types:Enchantment Creature Nightmare
+PT:2/3
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDiscard | TriggerDescription$ When CARDNAME enters the battlefield, discard a card, then draw a card. If CARDNAME's spectacle cost was paid, instead discard your hand, then draw three cards.
+SVar:TrigDiscard:DB$ Discard | NumCards$ 1 | Mode$ TgtChoose | SubAbility$ DBDraw
+SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1
+T:Mode$ Attacks | ValidCard$ Creature.Self | TriggerZones$ Battlefield | Execute$ TrigUntap | FirstAttack$ True | Delirium$ True | TriggerDescription$ Delirium — Whenever CARDNAME attacks for the first time each turn, if there are four or more card types among cards in your graveyard, untap target creature. After this phase, there is an additional combat phase.
+SVar:TrigUntap:DB$ Untap | ValidTgts$ Creature | TgtPrompt$ Select target creature | SubAbility$ DBAddCombat
+SVar:DBAddCombat:DB$ AddPhase | ExtraPhase$ Combat | AfterPhase$ EndCombat
+Oracle:When Fear of Missing Out enters, discard a card, then draw a card.\nDelirium — Whenever Fear of Missing Out attacks for the first time each turn, if there are four or more card types among cards in your graveyard, untap target creature. After this phase, there is an additional combat phase.

--- a/forge-gui/res/cardsfolder/upcoming/fear_of_missing_out.txt
+++ b/forge-gui/res/cardsfolder/upcoming/fear_of_missing_out.txt
@@ -2,7 +2,7 @@ Name:Fear of Missing Out
 ManaCost:1 R
 Types:Enchantment Creature Nightmare
 PT:2/3
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDiscard | TriggerDescription$ When CARDNAME enters the battlefield, discard a card, then draw a card. If CARDNAME's spectacle cost was paid, instead discard your hand, then draw three cards.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDiscard | TriggerDescription$ When CARDNAME enters, discard a card, then draw a card.
 SVar:TrigDiscard:DB$ Discard | NumCards$ 1 | Mode$ TgtChoose | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1
 T:Mode$ Attacks | ValidCard$ Creature.Self | TriggerZones$ Battlefield | Execute$ TrigUntap | FirstAttack$ True | Delirium$ True | TriggerDescription$ Delirium — Whenever CARDNAME attacks for the first time each turn, if there are four or more card types among cards in your graveyard, untap target creature. After this phase, there is an additional combat phase.

--- a/forge-gui/res/cardsfolder/upcoming/leyline_of_hope.txt
+++ b/forge-gui/res/cardsfolder/upcoming/leyline_of_hope.txt
@@ -1,0 +1,14 @@
+Name:Leyline of Hope
+ManaCost:2 W W
+Types:Enchantment
+K:MayEffectFromOpeningHand:FromHand
+SVar:FromHand:DB$ ChangeZone | Defined$ Self | Origin$ Hand | Destination$ Battlefield | SpellDescription$ If CARDNAME is in your opening hand, you may begin the game with it on the battlefield.
+R:Event$ GainLife | ActiveZones$ Battlefield | ValidPlayer$ You | ReplaceWith$ GainLife | AILogic$ DoubleLife | Description$ If you would gain life, you gain that much life plus 1 instead.
+SVar:GainLife:DB$ ReplaceEffect | VarName$ LifeGained | VarValue$ X
+S:Mode$ Continuous | Affected$ Creature.YouCtrl | AddPower$ 2 | AddToughness$ 2 | CheckSVar$ Y | SVarCompare$ GEZ | Description$ As long as you have at least 7 life more than your starting life total, creatures you control get +2/+2.
+SVar:X:ReplaceCount$LifeGained/Plus.1
+SVar:Y:Count$YourLifeTotal
+SVar:Z:Count$YourStartingLife/Plus.7
+SVar:PlayMain1:True
+DeckHints:Ability$LifeGain
+Oracle:If Leyline of Hope is in your opening hand, you may begin the game with it on the battlefield.\nIf you would gain life, you gain that much life plus 1 instead.\nAs long as you have at least 7 life more than your starting life total, creatures you control get +2/+2.

--- a/forge-gui/res/cardsfolder/upcoming/might_of_the_meek.txt
+++ b/forge-gui/res/cardsfolder/upcoming/might_of_the_meek.txt
@@ -1,0 +1,7 @@
+Name:Might of the Meek
+ManaCost:R
+Types:Instant
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ Trample | SubAbility$ DBPump | SpellDescription$ Target creature gains trample until end of turn. It also gets +1/+0 until end of turn if you control a Mouse. Draw a card.
+SVar:DBPump:DB$ Pump | Defined$ Targeted | NumAtt$ +1 | ConditionPresent$ Mouse.YouCtrl | ConditionCompare$ GE1 | ConditionDescription$ If you control a Mouse. | SubAbility$ DBDraw
+SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1
+Oracle:Target creature gains trample until end of turn. It also gets +1/+0 until end of turn if you control a Mouse.\nDraw a card.

--- a/forge-gui/res/cardsfolder/upcoming/pearl_of_wisdom.txt
+++ b/forge-gui/res/cardsfolder/upcoming/pearl_of_wisdom.txt
@@ -1,0 +1,6 @@
+Name:Pearl of Wisdom
+ManaCost:2 U
+Types:Sorcery
+S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 1 | EffectZone$ All | IsPresent$ Otter.YouCtrl | Description$ This spell costs {1} less to cast if you control an Otter.
+A:SP$ Draw | NumCards$ 2 | SpellDescription$ Draw two cards.
+Oracle:This spell costs {1} less to cast if you control an Otter.\nDraw two cards.

--- a/forge-gui/res/cardsfolder/upcoming/roshan_hidden_magister.txt
+++ b/forge-gui/res/cardsfolder/upcoming/roshan_hidden_magister.txt
@@ -1,0 +1,10 @@
+Name:Roshan, Hidden Magister
+ManaCost:3 B
+Types:Legendary Creature Human Assassin
+PT:4/4
+S:Mode$ Continuous | Affected$ Creature.YouCtrl+other | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | AddType$ Assassin | Description$ Other creatures you control are Assassins in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.
+S:Mode$ Continuous | Affected$ Creature.faceDown+YouCtrl | AddKeyword$ Menace | Description$ Face-down creatures you control have menace.
+T:Mode$ TurnFaceUp | ValidCard$ Permanent.YouCtrl | Execute$ TrigDraw | TriggerZones$ Battlefield | TriggerDescription$ Whenever a permanent you control is turned face up, you draw a card and you lose 1 life.
+SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1 | SubAbility$ DBLoseLife
+SVar:DBLoseLife:DB$ LoseLife | LifeAmount$ 1
+Oracle:Other creatures you control are Assassins in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.\nFace-down creatures you control have menace.\nWhenever a permanent you control is turned face up, you draw a card and you lose 1 life.

--- a/forge-gui/res/cardsfolder/upcoming/roshan_hidden_magister.txt
+++ b/forge-gui/res/cardsfolder/upcoming/roshan_hidden_magister.txt
@@ -2,7 +2,7 @@ Name:Roshan, Hidden Magister
 ManaCost:3 B
 Types:Legendary Creature Human Assassin
 PT:4/4
-S:Mode$ Continuous | Affected$ Creature.YouCtrl+other | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | AddType$ Assassin | Description$ Other creatures you control are Assassins in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.
+S:Mode$ Continuous | Affected$ Creature.YouCtrl+Other | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | AddType$ Assassin | Description$ Other creatures you control are Assassins in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.
 S:Mode$ Continuous | Affected$ Creature.faceDown+YouCtrl | AddKeyword$ Menace | Description$ Face-down creatures you control have menace.
 T:Mode$ TurnFaceUp | ValidCard$ Permanent.YouCtrl | Execute$ TrigDraw | TriggerZones$ Battlefield | TriggerDescription$ Whenever a permanent you control is turned face up, you draw a card and you lose 1 life.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1 | SubAbility$ DBLoseLife

--- a/forge-gui/res/cardsfolder/upcoming/salvation_swan.txt
+++ b/forge-gui/res/cardsfolder/upcoming/salvation_swan.txt
@@ -1,0 +1,12 @@
+Name:Salvation Swan
+ManaCost:3 W
+Types:Creature Bird Cleric
+PT:3/3
+K:Flash
+K:Flying
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self,Bird.other+YouCtrl | Execute$ TrigBlink | TriggerDescription$ Whenever CARDNAME or another Bird you control enters, exile up to one target creature you control without flying. Return it to the battlefield under its owner's control with a flying counter on it at the beginning of the next end step.
+SVar:TrigBlink:DB$ ChangeZone | TargetMin$ 0 | TargetMax$ 1 | ValidTgts$ Creature.YouCtrl+withoutFlying | TgtPrompt$ Select up to one target creature you control without flying | Origin$ Battlefield | Destination$ Exile | RememberChanged$ True | SubAbility$ DelTrig
+SVar:DelTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ TrigReturn | RememberObjects$ RememberedLKI | TriggerDescription$ Return the exiled card to the battlefield. | SubAbility$ DBCleanup
+SVar:TrigReturn:DB$ ChangeZone | Origin$ Exile | Destination$ Battlefield | Defined$ DelayTriggerRememberedLKI | WithCountersType$ Flying
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:Flash\nFlying\nWhenever Salvation Swan or another Bird you control enters, exile up to one target creature you control without flying. Return it to the battlefield under its owner's control with a flying counter on it at the beginning of the next end step.

--- a/forge-gui/res/cardsfolder/upcoming/salvation_swan.txt
+++ b/forge-gui/res/cardsfolder/upcoming/salvation_swan.txt
@@ -4,7 +4,7 @@ Types:Creature Bird Cleric
 PT:3/3
 K:Flash
 K:Flying
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self,Bird.other+YouCtrl | Execute$ TrigBlink | TriggerDescription$ Whenever CARDNAME or another Bird you control enters, exile up to one target creature you control without flying. Return it to the battlefield under its owner's control with a flying counter on it at the beginning of the next end step.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self,Bird.Other+YouCtrl | Execute$ TrigBlink | TriggerDescription$ Whenever CARDNAME or another Bird you control enters, exile up to one target creature you control without flying. Return it to the battlefield under its owner's control with a flying counter on it at the beginning of the next end step.
 SVar:TrigBlink:DB$ ChangeZone | TargetMin$ 0 | TargetMax$ 1 | ValidTgts$ Creature.YouCtrl+withoutFlying | TgtPrompt$ Select up to one target creature you control without flying | Origin$ Battlefield | Destination$ Exile | RememberChanged$ True | SubAbility$ DelTrig
 SVar:DelTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ TrigReturn | RememberObjects$ RememberedLKI | TriggerDescription$ Return the exiled card to the battlefield. | SubAbility$ DBCleanup
 SVar:TrigReturn:DB$ ChangeZone | Origin$ Exile | Destination$ Battlefield | Defined$ DelayTriggerRememberedLKI | WithCountersType$ Flying

--- a/forge-gui/res/cardsfolder/upcoming/screaming_nemesis.txt
+++ b/forge-gui/res/cardsfolder/upcoming/screaming_nemesis.txt
@@ -1,0 +1,12 @@
+Name:Screaming Nemesis
+ManaCost:2 R
+Types:Creature Spirit
+PT:3/3
+K:Haste
+T:Mode$ DamageDoneOnce | Execute$ TrigDamage | ValidTarget$ Card.Self | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME is dealt damage, it deals that much damage to any other target. If a player is dealt damage this way, they can't gain life for the rest of the game.
+SVar:TrigDamage:DB$ DealDamage | NumDmg$ X | ValidTgts$ Creature.Other,Player,Planeswalker.Other,Battle.Other | TgtPrompt$ Select any other target | RememberDamaged$ True | SubAbility DBEffect
+SVar:DBEffect:DB$ Effect | StaticAbilities$ CantGainLife | Duration$ Permanent | RememberObjects$ Player.IsRemembered | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:X:TriggerCount$DamageAmount
+SVar:HasCombatEffect:TRUE
+Oracle:Haste\nWhenever Screaming Nemesis is dealt damage, it deals that much damage to any other target. If a player is dealt damage this way, they can't gain life for the rest of the game.

--- a/forge-gui/res/cardsfolder/upcoming/screaming_nemesis.txt
+++ b/forge-gui/res/cardsfolder/upcoming/screaming_nemesis.txt
@@ -6,6 +6,7 @@ K:Haste
 T:Mode$ DamageDoneOnce | Execute$ TrigDamage | ValidTarget$ Card.Self | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME is dealt damage, it deals that much damage to any other target. If a player is dealt damage this way, they can't gain life for the rest of the game.
 SVar:TrigDamage:DB$ DealDamage | NumDmg$ X | ValidTgts$ Creature.Other,Player,Planeswalker.Other,Battle.Other | TgtPrompt$ Select any other target | RememberDamaged$ True | SubAbility DBEffect
 SVar:DBEffect:DB$ Effect | StaticAbilities$ CantGainLife | Duration$ Permanent | RememberObjects$ Player.IsRemembered | SubAbility$ DBCleanup
+SVar:CantGainLife:Mode$ CantGainLife | ValidPlayer$ Player.IsRemembered | Description$ The damaged player can't gain life for the rest of the game.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:TriggerCount$DamageAmount
 SVar:HasCombatEffect:TRUE

--- a/forge-gui/res/cardsfolder/upcoming/sunshower_druid.txt
+++ b/forge-gui/res/cardsfolder/upcoming/sunshower_druid.txt
@@ -1,0 +1,10 @@
+Name:Sunshower Druid
+ManaCost:G
+Types:Creature Frog Druid
+PT:1/1
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPutCounter | TriggerDescription$ When CARDNAME enters, put a +1/+1 counter on target creature and you gain 1 life.
+SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Creature | TgtPrompt$ Select target creature | CounterType$ P1P1 | SubAbility$ DBGainLife
+SVar:DBGainLife:DB$ GainLife | LifeAmount$ 1
+SVar:PlayMain1:TRUE
+DeckHas:Ability$Counters
+Oracle:When Sunshower Druid enters, put a +1/+1 counter on target creature and you gain 1 life.

--- a/forge-gui/res/cardsfolder/upcoming/the_wandering_rescuer.txt
+++ b/forge-gui/res/cardsfolder/upcoming/the_wandering_rescuer.txt
@@ -1,0 +1,9 @@
+Name:The Wandering Rescuer
+ManaCost:3 W W
+Types:Legendary Creature Human Samurai Noble
+PT:3/4
+K:Flash
+K:Convoke
+K:Double Strike
+S:Mode$ Continuous | Affected$ Creature.tapped+YouCtrl+Other | AddKeyword$ Hexproof | Description$ Other tapped creatures you control have hexproof.
+Oracle:Flash\nConvoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDouble strike\nOther tapped creatures you control have hexproof.

--- a/forge-gui/res/cardsfolder/upcoming/toby_beastie_befriender.txt
+++ b/forge-gui/res/cardsfolder/upcoming/toby_beastie_befriender.txt
@@ -1,0 +1,9 @@
+Name:Toby, Beastie Befriender
+ManaCost:2 W
+Types:Legendary Creature Human Wizard
+PT:1/1
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a 4/4 white Beast creature token with "This creature can't attack or block alone."
+SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ w_4_4_beast_lonely | TokenOwner$ You
+S:Mode$ Continuous | Affected$ Creature.token+YouCtrl | AddKeyword$ Flying | IsPresent$ Creature.token+YouCtrl | PresentCompare$ GE4 | Description$ As long as you control four or more creature tokens, creature tokens you control have flying.
+DeckHas:Ability$Token
+Oracle:When Toby, Beastie Befriender enters, create a 4/4 white Beast creature token with "This creature can't attack or block alone."\nAs long as you control four or more creature tokens, creature tokens you control have flying.

--- a/forge-gui/res/cardsfolder/upcoming/twitching_doll.txt
+++ b/forge-gui/res/cardsfolder/upcoming/twitching_doll.txt
@@ -1,0 +1,10 @@
+Name:Twitching Doll
+ManaCost:1 G
+Types:Artifact Creature Spider Toy
+PT:2/2
+A:AB$ Mana | Cost$ T | Produced$ Any | SubAbility$ DBPutCounter | SpellDescription$ Add one mana of any color. Put a nest counter on CARDNAME.
+SVar:DBPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ NEST
+A:AB$ Token | Cost$ T Sac<1/CARDNAME> | TokenOwner$ You | TokenAmount$ X | TokenScript$ g_2_2_spider_reach | SorcerySpeed$ True | SpellDescription$ Create a 2/2 green Spider creature token with reach for each counter on CARDNAME. Activate only as a sorcery.
+SVar:X:Count$CardCounters.ALL
+DeckHas:Ability$Token
+Oracle:{T}: Add one mana of any color. Put a nest counter on Twitching Doll.\n{T}, Sacrifice Twitching Doll: Create a 2/2 green Spider creature token with reach for each counter on Twitching Doll. Activate only as a sorcery.

--- a/forge-gui/res/lists/TypeLists.txt
+++ b/forge-gui/res/lists/TypeLists.txt
@@ -287,6 +287,7 @@ Thopter:Thopters
 Thrull:Thrulls
 Tiefling:Tieflings
 Time Lord:Time Lords
+Toy:Toys
 Treefolk:Treefolks
 Trilobite:Trilobites
 Triskelavite:Triskelavites

--- a/forge-gui/res/quest/commanderprecons/Eldrazi Incursion [M3C] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Eldrazi Incursion [M3C] [2024].dck
@@ -3,6 +3,7 @@ Name=Eldrazi Incursion [M3C] [2024]
 [Commander]
 1 Ulalek, Fused Atrocity|M3C|1
 [Main]
+1 Ugin, the Ineffable|M3C|1
 1 Angelic Aberration|M3C|1
 1 Artisan of Kozilek|M3C|1
 1 Azlask, the Swelling Scourge|M3C|1

--- a/forge-gui/res/tokenscripts/g_2_2_spider_reach.txt
+++ b/forge-gui/res/tokenscripts/g_2_2_spider_reach.txt
@@ -1,0 +1,7 @@
+Name:Spider Token
+ManaCost:no cost
+Types:Creature Spider
+PT:2/2
+Colors:green
+K:Reach
+Oracle:Reach

--- a/forge-gui/res/tokenscripts/w_4_4_beast_lonely.txt
+++ b/forge-gui/res/tokenscripts/w_4_4_beast_lonely.txt
@@ -1,0 +1,7 @@
+Name:Beast Token
+ManaCost:no cost
+Types:Creature Beast
+Colors:white
+PT:4/4
+K:CARDNAME can't attack or block alone.
+Oracle:This creature can't attack or block alone.


### PR DESCRIPTION
Added rev counters for Chainsaw and nest counters for Twitching Doll.
Added new tokens for Toby, Beastie Befriender and Twitching Doll.
Corrected a typo in Secret Plans.

Added ACR: Roshan, Hidden Magister
Added BLB: Carrot Cake, Early Winter, Might of the Meek, Pearl of Wisdon, Salvation Swan, Sunshower Druid
Added DSK: Chainsaw; Cursed Recording; Fear of Missing Out; Leyline of Hope; Screaming Nemesis; The Wandering Rescuer; Toby, Beastie Befriender; Twitching Doll