### PR TITLE
DSK: Doomsday Excruciator

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/doomsday_excruciator.txt
+++ b/forge-gui/res/cardsfolder/upcoming/doomsday_excruciator.txt
@@ -4,9 +4,8 @@ Types:Creature Demon
 PT:6/6
 K:Flying
 T:Mode$ ChangesZone | ValidCard$ Card.Self+wasCast | Origin$ Any | Destination$ Battlefield | Execute$ TrigExcruciator | TriggerDescription$ When CARDNAME enters, if it was cast, each player exiles all but the bottom six cards of their library face down.
-SVar:TrigExcruciator:DB$ RepeatEach | RepeatPlayers$ Player | RepeatSubAbility$ DBDigExile | SubAbility$ DBCleanup
+SVar:TrigExcruciator:DB$ RepeatEach | RepeatPlayers$ Player | RepeatSubAbility$ DBDigExile
 SVar:DBDigExile:DB$ Dig | DigNum$ X | ChangeNum$ All | Defined$ Player.IsRemembered | DestinationZone$ Exile | ExileFaceDown$ True | NoReveal$ True
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Count$ValidLibrary Card.RememberedPlayerCtrl/Minus.6
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ At the beginning of your upkeep, draw a card.
 SVar:TrigDraw:DB$ Draw | NumCards$ 1 | Defined$ You

--- a/forge-gui/res/cardsfolder/upcoming/doomsday_excruciator.txt
+++ b/forge-gui/res/cardsfolder/upcoming/doomsday_excruciator.txt
@@ -1,0 +1,13 @@
+Name:Doomsday Excruciator
+ManaCost:B B B B B B
+Types:Creature Demon
+PT:6/6
+K:Flying
+T:Mode$ ChangesZone | ValidCard$ Card.Self+wasCast | Origin$ Any | Destination$ Battlefield | Execute$ TrigExcruciator | TriggerDescription$ When CARDNAME enters, if it was cast, each player exiles all but the bottom six cards of their library face down.
+SVar:TrigExcruciator:DB$ RepeatEach | RepeatPlayers$ Player | RepeatSubAbility$ DBDigExile | SubAbility$ DBCleanup
+SVar:DBDigExile:DB$ Dig | DigNum$ X | ChangeNum$ All | Defined$ Player.IsRemembered | DestinationZone$ Exile | ExileFaceDown$ True | NoReveal$ True
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:X:Count$ValidLibrary Card.RememberedPlayerCtrl/Minus.6
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ At the beginning of your upkeep, draw a card.
+SVar:TrigDraw:DB$ Draw | NumCards$ 1 | Defined$ You
+Oracle:Flying\nWhen Doomsday Excruciator enters, if it was cast, each player exiles all but the bottom six cards of their library face down.\nAt the beginning of your upkeep, draw a card.

--- a/forge-gui/res/tokenscripts/ur_1_1_otter_prowess.txt
+++ b/forge-gui/res/tokenscripts/ur_1_1_otter_prowess.txt
@@ -1,7 +1,7 @@
 Name:Otter Token
-Types:Creature Otter
-Colors:blue,red
 ManaCost:no cost
+Colors:blue,red
+Types:Creature Otter
 PT:1/1
 K:Prowess
 Oracle:Prowess


### PR DESCRIPTION
Tested card script for:
- [Doomsday Excruciator](https://scryfall.com/card/dsk/94/doomsday-excruciator)

Minor fix:
- Reordering lines on Ral, Crackling Wit's Otter token to conform to existing pattern.