### PR TITLE
Fix Monoxa triggering on opponents' dice rolls.

### DIFF
--- a/forge-gui/res/cardsfolder/m/monoxa_midway_manager.txt
+++ b/forge-gui/res/cardsfolder/m/monoxa_midway_manager.txt
@@ -2,7 +2,7 @@ Name:Monoxa, Midway Manager
 ManaCost:2 B R
 Types:Legendary Creature Vampire Employee
 PT:3/3
-T:Mode$ RolledDie | TriggerZones$ Battlefield | Execute$ Pump1 | ValidResult$ GE3 | TriggerDescription$ Whenever you roll a 3 or higher, CARDNAME gains first strike until end of turn. If the roll was 4 or higher, it gains menace until end of turn. If the roll was 5 or higher, it gains lifelink until end of turn.
+T:Mode$ RolledDie | TriggerZones$ Battlefield | Execute$ Pump1 | ValidResult$ GE3 | ValidPlayer$ You | TriggerDescription$ Whenever you roll a 3 or higher, CARDNAME gains first strike until end of turn. If the roll was 4 or higher, it gains menace until end of turn. If the roll was 5 or higher, it gains lifelink until end of turn.
 SVar:Pump1:DB$ Pump | KW$ First Strike | SubAbility$ Pump2
 SVar:Pump2:DB$ Pump | KW$ Menace | ConditionCheckSVar$ X | ConditionSVarCompare$ GE4 | SubAbility$ Pump3
 SVar:Pump3:DB$ Pump | KW$ Lifelink | ConditionCheckSVar$ X | ConditionSVarCompare$ GE5


### PR DESCRIPTION
Adds a parameter so Monoxa only triggers off the controller's die rolls.