### PR TITLE
Update Unfinity.txt to include eternal cards

### DIFF
--- a/forge-gui/res/editions/Unfinity.txt
+++ b/forge-gui/res/editions/Unfinity.txt
@@ -7,17 +7,12 @@ ScryfallCode=UNF
 
 [cards]
 F1 M Standard Procedure @Igor Grechanyi
-2 C Aerialephant @Yangtian Li
 F3 U Assembled Ensemble @Jakub Kasper
 F4 C Bar Entry @Leonardo Santanna
-5 C _____ Bird Gets the Worm @Greg Staples
-6 C Clowning Around @Ralph Horsley
-7 U Complaints Clerk @Michael Phillippi
 F8 M Far Out @Bram Sels
 F9 R Form of the Approach of the Second Sun @Aaron J. Riley
 F10 U Get Your Head in the Game @Vincent Christiaens
 F11 C Gobsmacked @Marco Bucci
-12 C A Good Day to Pie @Zoltan Boros
 F13 C Hat Trick @Sebastian Giacobino
 F14 C Impounding Lot-Bot @Ralph Horsley
 F15 C Jetpack Janitor @Tyler Walpole
@@ -26,115 +21,335 @@ F17 U Knight in _____ Armor @Sam Hogg
 F18 C Leading Performance @Tomek Larek
 F19 R Main Event Horizon @Mike Burns
 F20 C Now You See Me . . . @Sam Hogg
-21 U Park Bleater @April Prime
 F22 U Park Re-Entry @Ernanda Souza
-23 U Pin Collection @Ben Maier
-24 C Ride Guide @José Parodi
-25 C Robo-Piñata @Jeff Miracola
-26 C Sanguine Sipper @Ernanda Souza
 F27 R Solaflora, Intergalactic Icon @Aaron J. Riley
-28 R Starlight Spectacular @Marco Bucci
 F29 R Surprise Party @Sean Murray
-30 U Sword-Swallowing Seraph @Vladimir Krisetskiy
 F31 C T.A.P.P.E.R. @David Sladek
 F32 U Trapeze Artist @Ernanda Souza
 F33 U Animate Object @Greg Staples
 F34 U Astroquarium @Tyler Walpole
-35 U Baaallerina @April Prime
 F36 C Bag Check @Tyler Walpole
-37 C Bamboozling Beeble @Jeff Miracola
-38 U Bioluminary @Vincent Christiaens
 F39 C Blufferfish @Christopher Burdett
-40 C Boing! @Gaboleps
 F41 U Busted! @Igor Grechanyi
-42 C Command Performance @Kirsten Zirngibl
-43 C Croakid Amphibonaut @Gaboleps
 F44 C Decisions, Decisions @Setor Fiadzigbey
-45 R Exchange of Words @Zoltan Boros
 F46 R Fluros of Myra's Marvels @Gaboleps
 F47 C Focused Funambulist @Setor Fiadzigbey
-48 C Glitterflitter @Yangtian Li
 F49 R How Is This a Par Three?! @Mike Burns
-50 U Make a _____ Splash @Leonardo Santanna
 F51 R Mobile Clone @Setor Fiadzigbey
-52 U Monitor Monitor @Igor Grechanyi
-53 C Motion Sickness @Raluca Marinescu
 F54 U Octo Opus @Tomek Larek
 F55 M Phone a Friend @Ben Wootten
 F56 M Plate Spinning @Raluca Marinescu
-57 C Prize Wall @Andrea Radeck
-58 C Seasoned Buttoneer @Tomek Larek
 F59 C Super-Duper Lost @Vincent Christiaens
 F60 R Treacherous Trapezist @Dave Greco
-61 U _____ _____ _____ Trespasser @Igor Grechanyi
-62 C Unlawful Entry @Francis Tneh
-63 R Vedalken Squirrel-Whacker @Vladimir Krisetskiy
-64 C Wizards of the _____ @Anna Christenson
 F65 R Animate Graveyard @Mike Burns
-66 U Attempted Murder @Greg Staples
-67 R Black Hole @Greg Bobrowski
-68 C Carnival Carnivore @Carl Critchlow
-69 C Deadbeat Attendant @Sebastian Giacobino
-70 U Discourtesy Clerk @Vladimir Krisetskiy
 F71 C Disemvowel @Ralph Horsley
-72 C Dissatisfied Customer @Yangtian Li
-73 C Down for Repairs @Igor Grechanyi
 F74 M Exit Through the Grift Shop @Chris Seaman
 F75 U Gray Merchant of Alphabet @Yangtian Li
 F76 U Haberthrasher @April Prime
 F77 R Knife and Death @Caio Monteiro
-78 U Last Voyage of the _____ @Caio Monteiro
-79 R "Lifetime" Pass Holder @Jeff Miracola
-80 C Line Cutter @Paolo Parente
-81 U Night Shift of the Living Dead @Sebastian Giacobino
 F82 R Nocturno of Myra's Marvels @Gaboleps
 F83 M Photo Op @Setor Fiadzigbey
 F84 C Questionable Cuisine @Chuck Lukacs
-85 U Quick Fixer @Francis Tsai
 F86 C Rat in the Hat @Filip Burburan
 F87 U A Real Handful @Tomek Larek
-88 R Saw in Half @Sebastian Giacobino
-89 U Scampire @Armand Baltazar
-90 C Scared Stiff @José Parodi
 F91 C Scooch @Filipe Pagliuso
-92 C Six-Sided Die @Ben Wootten
-93 C Soul Swindler @Alexander Mokhov
-94 C Step Right Up @Bruce Brenneise
-95 C Wolf in _____ Clothing @April Prime
-96 C Xenosquirrels @April Prime
 F97 C Aardwolf's Advantage @Tomek Larek
 F98 C Amped Up @Jamroz Gary
 F99 C Art Appreciation @April Prime
-100 U _____ Balls of Fire @David Sladek
-101 C Big Winner @Paolo Parente
 F102 R Carnival Barker @Dave Greco
-103 C Circuits Act @Jakub Kasper
 F104 R Devil K. Nevil @Paolo Parente
 F105 R Don't Try This at Home @Tyler Walpole
-106 C Eelectrocute @Dave Greco
-107 C _____ Goblin @Chuck Lukacs
-108 U Goblin Airbrusher @Caroline Gariba
 F109 U Goblin Blastronauts @Dave Allsop
 F110 R Goblin Cruciverbalist @Mike Burns
 F111 U Goblin Girder Gang @Tyler Walpole
 F112 R Ignacio of Myra's Marvels @Gaboleps
 F113 U Juggletron @Matt Dixon
-114 C Minotaur de Force @Gaboleps
-115 C Non-Human Cannonball @Ralph Horsley
 F116 R Omniclown Colossus @Ralph Horsley
-117 C One-Clown Band @Ralph Horsley
 F118 M Opening Ceremony @Greg Bobrowski
-119 U Priority Boarding @Greg Bobrowski
-120 U Proficient Pyrodancer @John Thacker
-121 C Rad Rascal @Dmitry Burmak
 F122 C Rock Star @Dave Allsop
-123 C Slight Malfunction @Greg Bobrowski
 F124 U Ticking Mime Bomb @Greg Bobrowski
 F125 U Trigger Happy @Jamroz Gary
 F126 M Vorthos, Steward of Myth @Caroline Gariba
-127 C Wee Champion @Raluca Marinescu
 F128 C Well Done @Gaboleps
 F129 C Alpha Guard @Caroline Gariba
+F141 R Hardy of Myra's Marvels @Gaboleps
+F142 U Icing Manipulator @Raluca Marinescu
+F143 C An Incident Has Occurred @Greg Bobrowski
+F144 R Jermane, Pride of the Circus @Alexander Mokhov
+F145 M Killer Cosplay @Leonardo Santanna
+F147 C Mistakes Were Made @Ralph Horsley
+F151 U Pie-Eating Contest @Simon Dominic
+F152 C Plot Armor @Gaboleps
+F154 R Sole Performer @Anna Christenson
+F155 R Spelling Bee @Caroline Gariba
+F158 R Tchotchke Elemental @Sean Murray
+F159 M Tug of War @Gaboleps
+F162 U Angelic Harold @Aaron J. Riley
+F163 U "Brims" Barone, Midway Mobster @Sebastian Giacobino
+F165 R Claire D'Loon, Joy Sculptor @Igor Grechanyi
+F168 M Grand Marshal Macie @Marco Bucci
+F169 M It Came from Planet Glurg @Marco Bucci
+F170 M Lila, Hospitality Hostess @Yangtian Li
+F172 R Meet and Greet "Sisay" @Setor Fiadzigbey
+F176 U Pietra, Crafter of Clowns @Armand Baltazar
+F181 R Truss, Chief Engineer @Aaron J. Riley
+F183 U Autograph Book @Ben Maier
+F184 R Blue Ribbon @Chuck Lukacs
+F187 R D00-DL, Caricaturist @Ralph Horsley
+F189 M Greatest Show in the Multiverse @Alix Branwyn
+F190 C Park Map @Kirsten Zirngibl
+F192 R Souvenir T-Shirt @Michael Phillippi
+F197 U The Big Top @Kirsten Zirngibl
+F198 C Nearby Planet @Bruce Brenneise
+F199 R Urza's Fun House @Dmitry Burmak
+F203a R Centrifuge @Greg Staples $A
+F203b R Centrifuge @Greg Staples $B
+F207a C Cover the Spot @Jeff Miracola $A
+F207b C Cover the Spot @Jeff Miracola $B
+F207c C Cover the Spot @Jeff Miracola $C
+F207d C Cover the Spot @Jeff Miracola $D
+F208a C Dart Throw @Gaboleps $A
+F208b C Dart Throw @Gaboleps $B
+F208c C Dart Throw @Gaboleps $C
+F208d C Dart Throw @Gaboleps $D
+F213a R Gallery of Legends @Jakub Kasper $A
+F213b R Gallery of Legends @Jakub Kasper $B
+F214a R Gift Shop @Matt Gaser $A
+F214b R Gift Shop @Matt Gaser $B
+F215a U Guess Your Fate @Bruce Brenneise $A
+F215b U Guess Your Fate @Bruce Brenneise $B
+F215c U Guess Your Fate @Bruce Brenneise $C
+F215d U Guess Your Fate @Bruce Brenneise $D
+F220a R Log Flume @Marco Bucci $A
+F220b R Log Flume @Marco Bucci $B
+F221a R Memory Test @Setor Fiadzigbey $A
+F221b R Memory Test @Setor Fiadzigbey $B
+F224a R Push Your Luck @Sebastian Giacobino $A
+F224b R Push Your Luck @Sebastian Giacobino $B
+F226a U Scavenger Hunt @Jamroz Gary $A
+F226b U Scavenger Hunt @Jamroz Gary $B
+F226c U Scavenger Hunt @Jamroz Gary $C
+F226d U Scavenger Hunt @Jamroz Gary $D
+F226e U Scavenger Hunt @Jamroz Gary $E
+F226f U Scavenger Hunt @Jamroz Gary $F
+F228a U Squirrel Stack @Andrea Radeck $A
+F228b U Squirrel Stack @Andrea Radeck $B
+F228c U Squirrel Stack @Andrea Radeck $C
+F228d U Squirrel Stack @Andrea Radeck $D
+F228e U Squirrel Stack @Andrea Radeck $E
+F228f U Squirrel Stack @Andrea Radeck $F
+F230a U The Superlatorium @Simon Dominic $A
+F230b U The Superlatorium @Simon Dominic $B
+F230c U The Superlatorium @Simon Dominic $C
+F230d U The Superlatorium @Simon Dominic $D
+F230e U The Superlatorium @Simon Dominic $E
+F230f U The Superlatorium @Simon Dominic $F
+F233a U Trivia Contest @Caroline Gariba $A
+F233b U Trivia Contest @Caroline Gariba $B
+F233c U Trivia Contest @Caroline Gariba $C
+F233d U Trivia Contest @Caroline Gariba $D
+F233e U Trivia Contest @Caroline Gariba $E
+F233f U Trivia Contest @Caroline Gariba $F
+F245 R Katerina of Myra's Marvels @David Semple
+F246 R Solaflora, Intergalactic Icon @Scooter
+F247 R Fluros of Myra's Marvels @David Semple
+F248 R Nocturno of Myra's Marvels @David Semple
+F249 R Devil K. Nevil @David Semple
+F250 R Ignacio of Myra's Marvels @David Semple
+F251 M Vorthos, Steward of Myth @Stephanie Buscema
+F252 R Hardy of Myra's Marvels @David Semple
+F253 R Jermane, Pride of the Circus @Scooter
+F255 U Angelic Harold @Stephanie Buscema
+F256 U "Brims" Barone, Midway Mobster @Stephanie Buscema
+F258 R Claire D'Loon, Joy Sculptor @Scooter
+F260 M Grand Marshal Macie @Scooter
+F261 M It Came from Planet Glurg @Scooter
+F262 M Lila, Hospitality Hostess @Scooter
+F264 R Meet and Greet "Sisay" @Scooter
+F268 U Pietra, Crafter of Clowns @Stephanie Buscema
+F272 R Truss, Chief Engineer @Scooter
+F274 R D00-DL, Caricaturist @Scooter
+F287 M Standard Procedure @Igor Grechanyi
+F289 U Assembled Ensemble @Jakub Kasper
+F290 C Bar Entry @Leonardo Santanna
+F294 M Far Out @Bram Sels
+F295 R Form of the Approach of the Second Sun @Aaron J. Riley
+F296 U Get Your Head in the Game @Vincent Christiaens
+F297 C Gobsmacked @Marco Bucci
+F299 C Hat Trick @Sebastian Giacobino
+F300 C Impounding Lot-Bot @Ralph Horsley
+F301 C Jetpack Janitor @Tyler Walpole
+F302 R Katerina of Myra's Marvels @Gaboleps
+F303 U Knight in _____ Armor @Sam Hogg
+F304 C Leading Performance @Tomek Larek
+F305 R Main Event Horizon @Mike Burns
+F306 C Now You See Me . . . @Sam Hogg
+F308 U Park Re-Entry @Ernanda Souza
+F313 R Solaflora, Intergalactic Icon @Aaron J. Riley
+F315 R Surprise Party @Sean Murray
+F317 C T.A.P.P.E.R. @David Sladek
+F318 U Trapeze Artist @Ernanda Souza
+F319 U Animate Object @Greg Staples
+F320 U Astroquarium @Tyler Walpole
+F322 C Bag Check @Tyler Walpole
+F325 C Blufferfish @Christopher Burdett
+F327 U Busted! @Igor Grechanyi
+F330 C Decisions, Decisions @Setor Fiadzigbey
+F332 R Fluros of Myra's Marvels @Gaboleps
+F333 C Focused Funambulist @Setor Fiadzigbey
+F335 R How Is This a Par Three?! @Mike Burns
+F337 R Mobile Clone @Setor Fiadzigbey
+F340 U Octo Opus @Tomek Larek
+F341 M Phone a Friend @Ben Wootten
+F342 M Plate Spinning @Raluca Marinescu
+F345 C Super-Duper Lost @Vincent Christiaens
+F346 R Treacherous Trapezist @Dave Greco
+F351 R Animate Graveyard @Mike Burns
+F357 C Disemvowel @Ralph Horsley
+F360 M Exit Through the Grift Shop @Chris Seaman
+F361 U Gray Merchant of Alphabet @Yangtian Li
+F362 U Haberthrasher @April Prime
+F363 R Knife and Death @Caio Monteiro
+F368 R Nocturno of Myra's Marvels @Gaboleps
+F369 M Photo Op @Setor Fiadzigbey
+F370 C Questionable Cuisine @Chuck Lukacs
+F372 C Rat in the Hat @Filip Burburan
+F373 U A Real Handful @Tomek Larek
+F377 C Scooch @Filip Burburan
+F383 C Aardwolf's Advantage @Tomek Larek
+F384 C Amped Up @Jamroz Gary
+F385 C Art Appreciation @April Prime
+F388 R Carnival Barker @Dave Greco
+F390 R Devil K. Nevil @Paolo Parente
+F391 R Don't Try This at Home @Tyler Walpole
+F395 U Goblin Blastronauts @Dave Allsop
+F396 R Goblin Cruciverbalist @Mike Burns
+F397 U Goblin Girder Gang @Tyler Walpole
+F398 R Ignacio of Myra's Marvels @Gaboleps
+F399 U Juggletron @Matt Dixon
+F402 R Omniclown Colossus @Ralph Horsley
+F404 M Opening Ceremony @Greg Bobrowski
+F408 C Rock Star @Dave Allsop
+F410 U Ticking Mime Bomb @Greg Bobrowski
+F411 U Trigger Happy @Jamroz Gary
+F412 M Vorthos, Steward of Myth @Caroline Gariba
+F414 C Well Done @Gaboleps
+F415 C Alpha Guard @Caroline Gariba
+F427 R Hardy of Myra's Marvels @Gaboleps
+F428 U Icing Manipulator @Raluca Marinescu
+F429 C An Incident Has Occurred @Greg Bobrowski
+F430 R Jermane, Pride of the Circus @Alexander Mokhov
+F431 M Killer Cosplay @Leonardo Santanna
+F433 C Mistakes Were Made @Ralph Horsley
+F437 U Pie-Eating Contest @Simon Dominic
+F438 C Plot Armor @Gaboleps
+F440 R Sole Performer @Anna Christenson
+F441 R Spelling Bee @Caroline Gariba
+F444 R Tchotchke Elemental @Sean Murray
+F445 M Tug of War @Gaboleps
+F448 U Angelic Harold @Aaron J. Riley
+F449 U "Brims" Barone, Midway Mobster @Sebastian Giacobino
+F451 R Claire D'Loon, Joy Sculptor @Igor Grechanyi
+F454 M Grand Marshal Macie @Marco Bucci
+F455 M It Came from Planet Glurg @Marco Bucci
+F456 M Lila, Hospitality Hostess @Yangtian Li
+F458 R Meet and Greet "Sisay" @Setor Fiadzigbey
+F462 U Pietra, Crafter of Clowns @Armand Baltazar
+F467 R Truss, Chief Engineer @Aaron J. Riley
+F469 U Autograph Book @Ben Maier
+F470 R Blue Ribbon @Chuck Lukacs
+F473 R D00-DL, Caricaturist @Ralph Horsley
+F475 M Greatest Show in the Multiverse @Alix Branwyn
+F476 C Park Map @Kirsten Zirngibl
+F478 R Souvenir T-Shirt @Michael Phillippi
+F483 U The Big Top @Kirsten Zirngibl
+F484 C Nearby Planet @Bruce Brenneise
+F485 R Urza's Fun House @Dmitry Burmak
+F496 R Katerina of Myra's Marvels @David Semple
+F497 R Solaflora, Intergalactic Icon @Scooter
+F498 R Fluros of Myra's Marvels @David Semple
+F499 R Nocturno of Myra's Marvels @David Semple
+F500 R Devil K. Nevil @David Semple
+F501 R Ignacio of Myra's Marvels @David Semple
+F502 M Vorthos, Steward of Myth @Stephanie Buscema
+F503 R Hardy of Myra's Marvels @David Semple
+F504 R Jermane, Pride of the Circus @Scooter
+F506 U Angelic Harold @Stephanie Buscema
+F507 U "Brims" Barone, Midway Mobster @Stephanie Buscema
+F509 R Claire D'Loon, Joy Sculptor @Scooter
+F511 M Grand Marshal Macie @Scooter
+F512 M It Came from Planet Glurg @Scooter
+F513 M Lila, Hospitality Hostess @Scooter
+F515 R Meet and Greet "Sisay" @Scooter
+F519 U Pietra, Crafter of Clowns @Stephanie Buscema
+F523 R Truss, Chief Engineer @Scooter
+F525 R D00-DL, Caricaturist @Scooter
+F538 R Water Gun Balloon Game @Ralph Horsley
+
+[eternal]
+2 C Aerialephant @Yangtian Li
+5 C _____ Bird Gets the Worm @Greg Staples
+6 C Clowning Around @Ralph Horsley
+7 U Complaints Clerk @Michael Phillippi
+12 C A Good Day to Pie @Zoltan Boros
+21 U Park Bleater @April Prime
+23 U Pin Collection @Ben Maier
+24 C Ride Guide @José Parodi
+25 C Robo-Piñata @Jeff Miracola
+26 C Sanguine Sipper @Ernanda Souza
+28 R Starlight Spectacular @Marco Bucci
+30 U Sword-Swallowing Seraph @Vladimir Krisetskiy
+35 U Baaallerina @April Prime
+37 C Bamboozling Beeble @Jeff Miracola
+38 U Bioluminary @Vincent Christiaens
+40 C Boing! @Gaboleps
+42 C Command Performance @Kirsten Zirngibl
+43 C Croakid Amphibonaut @Gaboleps
+45 R Exchange of Words @Zoltan Boros
+48 C Glitterflitter @Yangtian Li
+50 U Make a _____ Splash @Leonardo Santanna
+52 U Monitor Monitor @Igor Grechanyi
+53 C Motion Sickness @Raluca Marinescu
+57 C Prize Wall @Andrea Radeck
+58 C Seasoned Buttoneer @Tomek Larek
+61 U _____ _____ _____ Trespasser @Igor Grechanyi
+62 C Unlawful Entry @Francis Tneh
+63 R Vedalken Squirrel-Whacker @Vladimir Krisetskiy
+64 C Wizards of the _____ @Anna Christenson
+66 U Attempted Murder @Greg Staples
+67 R Black Hole @Greg Bobrowski
+68 C Carnival Carnivore @Carl Critchlow
+69 C Deadbeat Attendant @Sebastian Giacobino
+70 U Discourtesy Clerk @Vladimir Krisetskiy
+72 C Dissatisfied Customer @Yangtian Li
+73 C Down for Repairs @Igor Grechanyi
+78 U Last Voyage of the _____ @Caio Monteiro
+79 R "Lifetime" Pass Holder @Jeff Miracola
+80 C Line Cutter @Paolo Parente
+81 U Night Shift of the Living Dead @Sebastian Giacobino
+85 U Quick Fixer @Francis Tsai
+88 R Saw in Half @Sebastian Giacobino
+89 U Scampire @Armand Baltazar
+90 C Scared Stiff @José Parodi
+92 C Six-Sided Die @Ben Wootten
+93 C Soul Swindler @Alexander Mokhov
+94 C Step Right Up @Bruce Brenneise
+95 C Wolf in _____ Clothing @April Prime
+96 C Xenosquirrels @April Prime
+100 U _____ Balls of Fire @David Sladek
+101 C Big Winner @Paolo Parente
+103 C Circuits Act @Jakub Kasper
+106 C Eelectrocute @Dave Greco
+107 C _____ Goblin @Chuck Lukacs
+108 U Goblin Airbrusher @Caroline Gariba
+114 C Minotaur de Force @Gaboleps
+115 C Non-Human Cannonball @Ralph Horsley
+117 C One-Clown Band @Ralph Horsley
+119 U Priority Boarding @Greg Bobrowski
+120 U Proficient Pyrodancer @John Thacker
+121 C Rad Rascal @Dmitry Burmak
+123 C Slight Malfunction @Greg Bobrowski
+127 C Wee Champion @Raluca Marinescu
 130 C Atomwheel Acrobats @Tomek Larek
 131 C Blorbian Buddy @Ernanda Souza
 132 R Centaur of Attention @Leonardo Santanna
@@ -146,65 +361,35 @@ F129 C Alpha Guard @Caroline Gariba
 138 U Fight the _____ Fight @Greg Staples
 139 C Finishing Move @Dmitry Burmak
 140 C Grabby Tabby @Filipe Pagliuso
-F141 R Hardy of Myra's Marvels @Gaboleps
-F142 U Icing Manipulator @Raluca Marinescu
-F143 C An Incident Has Occurred @Greg Bobrowski
-F144 R Jermane, Pride of the Circus @Alexander Mokhov
-F145 M Killer Cosplay @Leonardo Santanna
 146 U Lineprancers @Ben Maier
-F147 C Mistakes Were Made @Ralph Horsley
 148 C _____-o-saurus @Leonardo Santanna
 149 U Pair o' Dice Lost @Bruce Brenneise
 150 C Petting Zookeeper @Sebastian Giacobino
-F151 U Pie-Eating Contest @Simon Dominic
-F152 C Plot Armor @Gaboleps
 153 U Resolute Veggiesaur @Leonardo Santanna
-F154 R Sole Performer @Anna Christenson
-F155 R Spelling Bee @Caroline Gariba
 156 U Squirrel Squatters @Andrea Radeck
 157 C Stiltstrider @Leonardo Santanna
-F158 R Tchotchke Elemental @Sean Murray
-F159 M Tug of War @Gaboleps
 160 C Vegetation Abomination @Mike Burns
 161 U Ambassador Blorpityblorpboop @Dave Greco
-F162 U Angelic Harold @Aaron J. Riley
-F163 U "Brims" Barone, Midway Mobster @Sebastian Giacobino
 164 R Captain Rex Nebula @Alexander Mokhov
-F165 R Claire D'Loon, Joy Sculptor @Igor Grechanyi
 166 M Comet, Stellar Pup @Jeff Miracola
 167 U Dee Kay, Finder of the Lost @Vladimir Krisetskiy
-F168 M Grand Marshal Macie @Marco Bucci
-F169 M It Came from Planet Glurg @Marco Bucci
-F170 M Lila, Hospitality Hostess @Yangtian Li
 171 M Magar of the Magic Strings @Tomek Larek
-F172 R Meet and Greet "Sisay" @Setor Fiadzigbey
 173 U Monoxa, Midway Manager @Igor Grechanyi
 174 R The Most Dangerous Gamer @Aaron J. Riley
 175 M Myra the Magnificent @Eric Wilkerson
-F176 U Pietra, Crafter of Clowns @Armand Baltazar
 177 U Roxi, Publicist to the Stars @Dmitry Burmak
 178 M Space Beleren @Tyler Jacobson
 179 U The Space Family Goblinson @Armand Baltazar
 180 U Spinnerette, Arachnobat @Alexander Mokhov
-F181 R Truss, Chief Engineer @Aaron J. Riley
 182 U Tusk and Whiskers @Chris Seaman
-F183 U Autograph Book @Ben Maier
-F184 R Blue Ribbon @Chuck Lukacs
 185 R Celebr-8000 @Ralph Horsley
 186 R Clown Car @Ralph Horsley
-F187 R D00-DL, Caricaturist @Ralph Horsley
 188 C Draconian Gate-Bot @Ralph Horsley
-F189 M Greatest Show in the Multiverse @Alix Branwyn
-F190 C Park Map @Kirsten Zirngibl
 191 U _____ _____ Rocketship @Ralph Horsley
-F192 R Souvenir T-Shirt @Michael Phillippi
 193 U Strength-Testing Hammer @Gaboleps
 194 C Ticket Turbotubes @Matt Gaser
 195 C Ticketomaton @Michael Phillippi
 196 U Wicker Picker @Igor Grechanyi
-F197 U The Big Top @Kirsten Zirngibl
-F198 C Nearby Planet @Bruce Brenneise
-F199 R Urza's Fun House @Dmitry Burmak
 200a U Balloon Stand @Jakub Kasper $A
 200b U Balloon Stand @Jakub Kasper $B
 200c U Balloon Stand @Jakub Kasper $C
@@ -219,8 +404,6 @@ F199 R Urza's Fun House @Dmitry Burmak
 202d U Bumper Cars @Gabor Szikszai $D
 202e U Bumper Cars @Gabor Szikszai $E
 202f U Bumper Cars @Gabor Szikszai $F
-F203a R Centrifuge @Greg Staples $A
-F203b R Centrifuge @Greg Staples $B
 204a C Clown Extruder @Marco Bucci $A
 204b C Clown Extruder @Marco Bucci $B
 204c C Clown Extruder @Marco Bucci $C
@@ -235,14 +418,6 @@ F203b R Centrifuge @Greg Staples $B
 206d C Costume Shop @Raluca Marinescu $D
 206e C Costume Shop @Raluca Marinescu $E
 206f C Costume Shop @Raluca Marinescu $F
-F207a C Cover the Spot @Jeff Miracola $A
-F207b C Cover the Spot @Jeff Miracola $B
-F207c C Cover the Spot @Jeff Miracola $C
-F207d C Cover the Spot @Jeff Miracola $D
-F208a C Dart Throw @Gaboleps $A
-F208b C Dart Throw @Gaboleps $B
-F208c C Dart Throw @Gaboleps $C
-F208d C Dart Throw @Gaboleps $D
 209a C Drop Tower @Dmitry Burmak $A
 209b C Drop Tower @Dmitry Burmak $B
 209c C Drop Tower @Dmitry Burmak $C
@@ -260,14 +435,6 @@ F208d C Dart Throw @Gaboleps $D
 212d C Fortune Teller @Jamroz Gary $D
 212e C Fortune Teller @Jamroz Gary $E
 212f C Fortune Teller @Jamroz Gary $F
-F213a R Gallery of Legends @Jakub Kasper $A
-F213b R Gallery of Legends @Jakub Kasper $B
-F214a R Gift Shop @Matt Gaser $A
-F214b R Gift Shop @Matt Gaser $B
-F215a U Guess Your Fate @Bruce Brenneise $A
-F215b U Guess Your Fate @Bruce Brenneise $B
-F215c U Guess Your Fate @Bruce Brenneise $C
-F215d U Guess Your Fate @Bruce Brenneise $D
 216a R Hall of Mirrors @Vincent Christiaens $A
 216b R Hall of Mirrors @Vincent Christiaens $B
 217a R Haunted House @Dmitry Burmak $A
@@ -282,10 +449,6 @@ F215d U Guess Your Fate @Bruce Brenneise $D
 219d C Kiddie Coaster @Marco Bucci $D
 219e C Kiddie Coaster @Marco Bucci $E
 219f C Kiddie Coaster @Marco Bucci $F
-F220a R Log Flume @Marco Bucci $A
-F220b R Log Flume @Marco Bucci $B
-F221a R Memory Test @Setor Fiadzigbey $A
-F221b R Memory Test @Setor Fiadzigbey $B
 222a R Merry-Go-Round @Carl Critchlow $A
 222b R Merry-Go-Round @Carl Critchlow $B
 223a C Pick-a-Beeble @Dave Greco $A
@@ -294,50 +457,24 @@ F221b R Memory Test @Setor Fiadzigbey $B
 223d C Pick-a-Beeble @Dave Greco $D
 223e C Pick-a-Beeble @Dave Greco $E
 223f C Pick-a-Beeble @Dave Greco $F
-F224a R Push Your Luck @Sebastian Giacobino $A
-F224b R Push Your Luck @Sebastian Giacobino $B
 225a U Roller Coaster @Gabor Szikszai $A
 225b U Roller Coaster @Gabor Szikszai $B
 225c U Roller Coaster @Gabor Szikszai $C
 225d U Roller Coaster @Gabor Szikszai $D
-F226a U Scavenger Hunt @Jamroz Gary $A
-F226b U Scavenger Hunt @Jamroz Gary $B
-F226c U Scavenger Hunt @Jamroz Gary $C
-F226d U Scavenger Hunt @Jamroz Gary $D
-F226e U Scavenger Hunt @Jamroz Gary $E
-F226f U Scavenger Hunt @Jamroz Gary $F
 227a C Spinny Ride @Aaron J. Riley $A
 227b C Spinny Ride @Aaron J. Riley $B
 227c C Spinny Ride @Aaron J. Riley $C
 227d C Spinny Ride @Aaron J. Riley $D
 227e C Spinny Ride @Aaron J. Riley $E
 227f C Spinny Ride @Aaron J. Riley $F
-F228a U Squirrel Stack @Andrea Radeck $A
-F228b U Squirrel Stack @Andrea Radeck $B
-F228c U Squirrel Stack @Andrea Radeck $C
-F228d U Squirrel Stack @Andrea Radeck $D
-F228e U Squirrel Stack @Andrea Radeck $E
-F228f U Squirrel Stack @Andrea Radeck $F
 229a R Storybook Ride @Dmitry Burmak $A
 229b R Storybook Ride @Dmitry Burmak $B
-F230a U The Superlatorium @Simon Dominic $A
-F230b U The Superlatorium @Simon Dominic $B
-F230c U The Superlatorium @Simon Dominic $C
-F230d U The Superlatorium @Simon Dominic $D
-F230e U The Superlatorium @Simon Dominic $E
-F230f U The Superlatorium @Simon Dominic $F
 231a R Swinging Ship @Mike Burns $A
 231b R Swinging Ship @Mike Burns $B
 232a U Trash Bin @Greg Bobrowski $A
 232b U Trash Bin @Greg Bobrowski $B
 232c U Trash Bin @Greg Bobrowski $C
 232d U Trash Bin @Greg Bobrowski $D
-F233a U Trivia Contest @Caroline Gariba $A
-F233b U Trivia Contest @Caroline Gariba $B
-F233c U Trivia Contest @Caroline Gariba $C
-F233d U Trivia Contest @Caroline Gariba $D
-F233e U Trivia Contest @Caroline Gariba $E
-F233f U Trivia Contest @Caroline Gariba $F
 234a R Tunnel of Love @Vladimir Krisetskiy $A
 234b R Tunnel of Love @Vladimir Krisetskiy $B
 235 L Plains @Adam Paquette
@@ -350,36 +487,17 @@ F233f U Trivia Contest @Caroline Gariba $F
 242 L Swamp @Adam Paquette
 243 L Mountain @Adam Paquette
 244 L Forest @Adam Paquette
-F245 R Katerina of Myra's Marvels @David Semple
-F246 R Solaflora, Intergalactic Icon @Scooter
-F247 R Fluros of Myra's Marvels @David Semple
-F248 R Nocturno of Myra's Marvels @David Semple
-F249 R Devil K. Nevil @David Semple
-F250 R Ignacio of Myra's Marvels @David Semple
-F251 M Vorthos, Steward of Myth @Stephanie Buscema
-F252 R Hardy of Myra's Marvels @David Semple
-F253 R Jermane, Pride of the Circus @Scooter
 254 U Ambassador Blorpityblorpboop @David Semple
-F255 U Angelic Harold @Stephanie Buscema
-F256 U "Brims" Barone, Midway Mobster @Stephanie Buscema
 257 R Captain Rex Nebula @Scooter
-F258 R Claire D'Loon, Joy Sculptor @Scooter
 259 U Dee Kay, Finder of the Lost @Scooter
-F260 M Grand Marshal Macie @Scooter
-F261 M It Came from Planet Glurg @Scooter
-F262 M Lila, Hospitality Hostess @Scooter
 263 M Magar of the Magic Strings @David Semple
-F264 R Meet and Greet "Sisay" @Scooter
 265 U Monoxa, Midway Manager @Scooter
 266 R The Most Dangerous Gamer @Scooter
 267 M Myra the Magnificent @Stephanie Buscema
-F268 U Pietra, Crafter of Clowns @Stephanie Buscema
 269 U Roxi, Publicist to the Stars @Scooter
 270 U The Space Family Goblinson @David Semple
 271 U Spinnerette, Arachnobat @David Semple
-F272 R Truss, Chief Engineer @Scooter
 273 U Tusk and Whiskers @David Semple
-F274 R D00-DL, Caricaturist @Scooter
 275 M Comet, Stellar Pup @David Semple
 276 M Space Beleren @Scooter
 277 R Hallowed Fountain @Piotr Dura
@@ -392,135 +510,69 @@ F274 R D00-DL, Caricaturist @Scooter
 284 R Overgrown Tomb @Cliff Childs
 285 R Sacred Foundry @Cliff Childs
 286 R Breeding Pool @Bruce Brenneise
-F287 M Standard Procedure @Igor Grechanyi
 288 C Aerialephant @Yangtian Li
-F289 U Assembled Ensemble @Jakub Kasper
-F290 C Bar Entry @Leonardo Santanna
 291 C _____ Bird Gets the Worm @Greg Staples
 292 C Clowning Around @Ralph Horsley
 293 U Complaints Clerk @Michael Phillippi
-F294 M Far Out @Bram Sels
-F295 R Form of the Approach of the Second Sun @Aaron J. Riley
-F296 U Get Your Head in the Game @Vincent Christiaens
-F297 C Gobsmacked @Marco Bucci
 298 C A Good Day to Pie @Zoltan Boros
-F299 C Hat Trick @Sebastian Giacobino
-F300 C Impounding Lot-Bot @Ralph Horsley
-F301 C Jetpack Janitor @Tyler Walpole
-F302 R Katerina of Myra's Marvels @Gaboleps
-F303 U Knight in _____ Armor @Sam Hogg
-F304 C Leading Performance @Tomek Larek
-F305 R Main Event Horizon @Mike Burns
-F306 C Now You See Me . . . @Sam Hogg
 307 U Park Bleater @April Prime
-F308 U Park Re-Entry @Ernanda Souza
 309 U Pin Collection @Ben Maier
 310 C Ride Guide @José Parodi
 311 C Robo-Piñata @Jeff Miracola
 312 C Sanguine Sipper @Ernanda Souza
-F313 R Solaflora, Intergalactic Icon @Aaron J. Riley
 314 R Starlight Spectacular @Marco Bucci
-F315 R Surprise Party @Sean Murray
 316 U Sword-Swallowing Seraph @Vladimir Krisetskiy
-F317 C T.A.P.P.E.R. @David Sladek
-F318 U Trapeze Artist @Ernanda Souza
-F319 U Animate Object @Greg Staples
-F320 U Astroquarium @Tyler Walpole
 321 U Baaallerina @April Prime
-F322 C Bag Check @Tyler Walpole
 323 C Bamboozling Beeble @Jeff Miracola
 324 U Bioluminary @Vincent Christiaens
-F325 C Blufferfish @Christopher Burdett
 326 C Boing! @Gaboleps
-F327 U Busted! @Igor Grechanyi
 328 C Command Performance @Kirsten Zirngibl
 329 C Croakid Amphibonaut @Gaboleps
-F330 C Decisions, Decisions @Setor Fiadzigbey
 331 R Exchange of Words @Zoltan Boros
-F332 R Fluros of Myra's Marvels @Gaboleps
-F333 C Focused Funambulist @Setor Fiadzigbey
 334 C Glitterflitter @Yangtian Li
-F335 R How Is This a Par Three?! @Mike Burns
 336 U Make a _____ Splash @Leonardo Santanna
-F337 R Mobile Clone @Setor Fiadzigbey
 338 U Monitor Monitor @Igor Grechanyi
 339 C Motion Sickness @Raluca Marinescu
-F340 U Octo Opus @Tomek Larek
-F341 M Phone a Friend @Ben Wootten
-F342 M Plate Spinning @Raluca Marinescu
 343 C Prize Wall @Andrea Radeck
 344 C Seasoned Buttoneer @Tomek Larek
-F345 C Super-Duper Lost @Vincent Christiaens
-F346 R Treacherous Trapezist @Dave Greco
 347 U _____ _____ _____ Trespasser @Igor Grechanyi
 348 C Unlawful Entry @Francis Tneh
 349 R Vedalken Squirrel-Whacker @Vladimir Krisetskiy
 350 C Wizards of the _____ @Anna Christenson
-F351 R Animate Graveyard @Mike Burns
 352 U Attempted Murder @Greg Staples
 353 R Black Hole @Greg Bobrowski
 354 C Carnival Carnivore @Carl Critchlow
 355 C Deadbeat Attendant @Sebastian Giacobino
 356 U Discourtesy Clerk @Vladimir Krisetskiy
-F357 C Disemvowel @Ralph Horsley
 358 C Dissatisfied Customer @Yangtian Li
 359 C Down for Repairs @Igor Grechanyi
-F360 M Exit Through the Grift Shop @Chris Seaman
-F361 U Gray Merchant of Alphabet @Yangtian Li
-F362 U Haberthrasher @April Prime
-F363 R Knife and Death @Caio Monteiro
 364 U Last Voyage of the _____ @Caio Monteiro
 365 R "Lifetime" Pass Holder @Jeff Miracola
 366 C Line Cutter @Paolo Parente
 367 U Night Shift of the Living Dead @Sebastian Giacobino
-F368 R Nocturno of Myra's Marvels @Gaboleps
-F369 M Photo Op @Setor Fiadzigbey
-F370 C Questionable Cuisine @Chuck Lukacs
 371 U Quick Fixer @Francis Tsai
-F372 C Rat in the Hat @Filip Burburan
-F373 U A Real Handful @Tomek Larek
 374 R Saw in Half @Sebastian Giacobino
 375 U Scampire @Armand Baltazar
 376 C Scared Stiff @José Parodi
-F377 C Scooch @Filip Burburan
 378 C Six-Sided Die @Ben Wootten
 379 C Soul Swindler @Alexander Mokhov
 380 C Step Right Up @Bruce Brenneise
 381 C Wolf in _____ Clothing @April Prime
 382 C Xenosquirrels @April Prime
-F383 C Aardwolf's Advantage @Tomek Larek
-F384 C Amped Up @Jamroz Gary
-F385 C Art Appreciation @April Prime
 386 U _____ Balls of Fire @David Sladek
 387 C Big Winner @Paolo Parente
-F388 R Carnival Barker @Dave Greco
 389 C Circuits Act @Jakub Kasper
-F390 R Devil K. Nevil @Paolo Parente
-F391 R Don't Try This at Home @Tyler Walpole
 392 C Eelectrocute @Dave Greco
 393 C _____ Goblin @Chuck Lukacs
 394 U Goblin Airbrusher @Caroline Gariba
-F395 U Goblin Blastronauts @Dave Allsop
-F396 R Goblin Cruciverbalist @Mike Burns
-F397 U Goblin Girder Gang @Tyler Walpole
-F398 R Ignacio of Myra's Marvels @Gaboleps
-F399 U Juggletron @Matt Dixon
 400 C Minotaur de Force @Gaboleps
 401 C Non-Human Cannonball @Ralph Horsley
-F402 R Omniclown Colossus @Ralph Horsley
 403 C One-Clown Band @Ralph Horsley
-F404 M Opening Ceremony @Greg Bobrowski
 405 U Priority Boarding @Greg Bobrowski
 406 U Proficient Pyrodancer @John Thacker
 407 C Rad Rascal @Dmitry Burmak
-F408 C Rock Star @Dave Allsop
 409 C Slight Malfunction @Greg Bobrowski
-F410 U Ticking Mime Bomb @Greg Bobrowski
-F411 U Trigger Happy @Jamroz Gary
-F412 M Vorthos, Steward of Myth @Caroline Gariba
 413 C Wee Champion @Raluca Marinescu
-F414 C Well Done @Gaboleps
-F415 C Alpha Guard @Caroline Gariba
 416 C Atomwheel Acrobats @Tomek Larek
 417 C Blorbian Buddy @Ernanda Souza
 418 R Centaur of Attention @Leonardo Santanna
@@ -532,65 +584,35 @@ F415 C Alpha Guard @Caroline Gariba
 424 U Fight the _____ Fight @Greg Staples
 425 C Finishing Move @Dmitry Burmak
 426 C Grabby Tabby @Filipe Pagliuso
-F427 R Hardy of Myra's Marvels @Gaboleps
-F428 U Icing Manipulator @Raluca Marinescu
-F429 C An Incident Has Occurred @Greg Bobrowski
-F430 R Jermane, Pride of the Circus @Alexander Mokhov
-F431 M Killer Cosplay @Leonardo Santanna
 432 U Lineprancers @Ben Maier
-F433 C Mistakes Were Made @Ralph Horsley
 434 C _____-o-saurus @Leonardo Santanna
 435 U Pair o' Dice Lost @Bruce Brenneise
 436 C Petting Zookeeper @Sebastian Giacobino
-F437 U Pie-Eating Contest @Simon Dominic
-F438 C Plot Armor @Gaboleps
 439 U Resolute Veggiesaur @Leonardo Santanna
-F440 R Sole Performer @Anna Christenson
-F441 R Spelling Bee @Caroline Gariba
 442 U Squirrel Squatters @Andrea Radeck
 443 C Stiltstrider @Leonardo Santanna
-F444 R Tchotchke Elemental @Sean Murray
-F445 M Tug of War @Gaboleps
 446 C Vegetation Abomination @Mike Burns
 447 U Ambassador Blorpityblorpboop @Dave Greco
-F448 U Angelic Harold @Aaron J. Riley
-F449 U "Brims" Barone, Midway Mobster @Sebastian Giacobino
 450 R Captain Rex Nebula @Alexander Mokhov
-F451 R Claire D'Loon, Joy Sculptor @Igor Grechanyi
 452 M Comet, Stellar Pup @Jeff Miracola
 453 U Dee Kay, Finder of the Lost @Vladimir Krisetskiy
-F454 M Grand Marshal Macie @Marco Bucci
-F455 M It Came from Planet Glurg @Marco Bucci
-F456 M Lila, Hospitality Hostess @Yangtian Li
 457 M Magar of the Magic Strings @Tomek Larek
-F458 R Meet and Greet "Sisay" @Setor Fiadzigbey
 459 U Monoxa, Midway Manager @Igor Grechanyi
 460 R The Most Dangerous Gamer @Aaron J. Riley
 461 M Myra the Magnificent @Eric Wilkerson
-F462 U Pietra, Crafter of Clowns @Armand Baltazar
 463 U Roxi, Publicist to the Stars @Dmitry Burmak
 464 M Space Beleren @Tyler Jacobson
 465 U The Space Family Goblinson @Armand Baltazar
 466 U Spinnerette, Arachnobat @Alexander Mokhov
-F467 R Truss, Chief Engineer @Aaron J. Riley
 468 U Tusk and Whiskers @Chris Seaman
-F469 U Autograph Book @Ben Maier
-F470 R Blue Ribbon @Chuck Lukacs
 471 R Celebr-8000 @Ralph Horsley
 472 R Clown Car @Ralph Horsley
-F473 R D00-DL, Caricaturist @Ralph Horsley
 474 C Draconian Gate-Bot @Ralph Horsley
-F475 M Greatest Show in the Multiverse @Alix Branwyn
-F476 C Park Map @Kirsten Zirngibl
 477 U _____ _____ Rocketship @Ralph Horsley
-F478 R Souvenir T-Shirt @Michael Phillippi
 479 U Strength-Testing Hammer @Gaboleps
 480 C Ticket Turbotubes @Matt Gaser
 481 C Ticketomaton @Michael Phillippi
 482 U Wicker Picker @Igor Grechanyi
-F483 U The Big Top @Kirsten Zirngibl
-F484 C Nearby Planet @Bruce Brenneise
-F485 R Urza's Fun House @Dmitry Burmak
 486 L Plains @Adam Paquette
 487 L Island @Adam Paquette
 488 L Swamp @Adam Paquette
@@ -601,36 +623,17 @@ F485 R Urza's Fun House @Dmitry Burmak
 493 L Swamp @Adam Paquette
 494 L Mountain @Adam Paquette
 495 L Forest @Adam Paquette
-F496 R Katerina of Myra's Marvels @David Semple
-F497 R Solaflora, Intergalactic Icon @Scooter
-F498 R Fluros of Myra's Marvels @David Semple
-F499 R Nocturno of Myra's Marvels @David Semple
-F500 R Devil K. Nevil @David Semple
-F501 R Ignacio of Myra's Marvels @David Semple
-F502 M Vorthos, Steward of Myth @Stephanie Buscema
-F503 R Hardy of Myra's Marvels @David Semple
-F504 R Jermane, Pride of the Circus @Scooter
 505 U Ambassador Blorpityblorpboop @David Semple
-F506 U Angelic Harold @Stephanie Buscema
-F507 U "Brims" Barone, Midway Mobster @Stephanie Buscema
 508 R Captain Rex Nebula @Scooter
-F509 R Claire D'Loon, Joy Sculptor @Scooter
 510 U Dee Kay, Finder of the Lost @Scooter
-F511 M Grand Marshal Macie @Scooter
-F512 M It Came from Planet Glurg @Scooter
-F513 M Lila, Hospitality Hostess @Scooter
 514 M Magar of the Magic Strings @David Semple
-F515 R Meet and Greet "Sisay" @Scooter
 516 U Monoxa, Midway Manager @Scooter
 517 R The Most Dangerous Gamer @Scooter
 518 M Myra the Magnificent @Stephanie Buscema
-F519 U Pietra, Crafter of Clowns @Stephanie Buscema
 520 U Roxi, Publicist to the Stars @Scooter
 521 U The Space Family Goblinson @David Semple
 522 U Spinnerette, Arachnobat @David Semple
-F523 R Truss, Chief Engineer @Scooter
 524 U Tusk and Whiskers @David Semple
-F525 R D00-DL, Caricaturist @Scooter
 526 M Comet, Stellar Pup @David Semple
 527 M Space Beleren @Scooter
 528 R Hallowed Fountain @Piotr Dura
@@ -643,7 +646,6 @@ F525 R D00-DL, Caricaturist @Scooter
 535 R Overgrown Tomb @Cliff Childs
 536 R Sacred Foundry @Cliff Childs
 537 R Breeding Pool @Bruce Brenneise
-F538 R Water Gun Balloon Game @Ralph Horsley
 
 [tokens]
 b_2_2_zombie_employee


### PR DESCRIPTION
With the recent creation of the eternal category to fix Zur the Enchanter I figured it would also be a good time to fix that same issue with Unfinity.

I believe I included the correct cards. At first I checked the legality on scryfall, but once I noticed that all the illegal cards seemed to start with "F" I just started to move the ones that didn't start with that without checking legality.