### PR TITLE
ACR: Ezio, Brash Novice

### DIFF
--- a/forge-gui/res/cardsfolder/h/hero_of_bretagard.txt
+++ b/forge-gui/res/cardsfolder/h/hero_of_bretagard.txt
@@ -1,4 +1,4 @@
-Name:Hero of Bretagard
+Name:Hero of Bretagard 2
 ManaCost:2 W
 Types:Creature Human Warrior
 PT:1/1
@@ -6,7 +6,7 @@ T:Mode$ ChangesZoneAll | Origin$ Hand | Destination$ Exile | ValidCards$ Card.Yo
 T:Mode$ ChangesZoneAll | ValidCause$ SpellAbility.YouCtrl | Origin$ Battlefield | Destination$ Exile | Execute$ TrigPutCounter | TriggerZones$ Battlefield | Secondary$ True | TriggerDescription$ Whenever one or more cards are put into exile from your hand or a spell or ability you control exiles one or more permanents from the battlefield, put that many +1/+1 counters on CARDNAME.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ X
 S:Mode$ Continuous | Affected$ Card.Self | CheckSVar$ Y | SVarCompare$ GT4 | AddKeyword$ Flying | AddType$ Angel | Description$ As long as CARDNAME has five or more counters on it, it has flying and is an Angel in addition to its other types.
-S:Mode$ Continuous | Affected$ Card.Self | CheckSVar$ Y | SVarCompare$ GT9 | AddKeyword$ Indestructible | AddType$ Angel & God | Description$ As long as CARDNAME has ten or more counters on it, it indestructible and is a God in addition to its other types.
+S:Mode$ Continuous | Affected$ Card.Self | CheckSVar$ Y | SVarCompare$ GT9 | AddKeyword$ Indestructible | AddType$ God | Description$ As long as CARDNAME has ten or more counters on it, it has indestructible and is a God in addition to its other types.
 SVar:X:TriggerCount$Amount
 SVar:Y:Count$CardCounters.ALL
 DeckHas:Ability$Counters

--- a/forge-gui/res/cardsfolder/h/hero_of_bretagard.txt
+++ b/forge-gui/res/cardsfolder/h/hero_of_bretagard.txt
@@ -1,4 +1,4 @@
-Name:Hero of Bretagard 2
+Name:Hero of Bretagard
 ManaCost:2 W
 Types:Creature Human Warrior
 PT:1/1

--- a/forge-gui/res/cardsfolder/upcoming/ezio_brash_novice.txt
+++ b/forge-gui/res/cardsfolder/upcoming/ezio_brash_novice.txt
@@ -1,0 +1,9 @@
+Name:Ezio, Brash Novice
+ManaCost:1 RW
+Types:Legendary Creature Human
+PT:1/1
+T:Mode$ Attacks | ValidCard$ Creature.Self | Execute$ TrigPutCounter | TriggerDescription$ Whenever CARDNAME attacks, put a +1/+1 counter on it.
+SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
+S:Mode$ Continuous | Affected$ Card.Self | CheckSVar$ X | SVarCompare$ GT1 | AddKeyword$ First Strike | AddType$ Assassin | Description$ As long as CARDNAME has two or more counters on it, it has first strike and is an Assassin in addition to its other types.
+SVar:X:Count$CardCounters.ALL
+Oracle:Whenever Ezio, Brash Novice attacks, put a +1/+1 counter on it.\nAs long as Ezio has two or more counters on it, it has first strike and is an Assassin in addition to its other types.

--- a/forge-gui/res/cardsfolder/upcoming/ezio_brash_novice.txt
+++ b/forge-gui/res/cardsfolder/upcoming/ezio_brash_novice.txt
@@ -4,6 +4,6 @@ Types:Legendary Creature Human
 PT:1/1
 T:Mode$ Attacks | ValidCard$ Creature.Self | Execute$ TrigPutCounter | TriggerDescription$ Whenever CARDNAME attacks, put a +1/+1 counter on it.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
-S:Mode$ Continuous | Affected$ Card.Self | CheckSVar$ X | SVarCompare$ GT1 | AddKeyword$ First Strike | AddType$ Assassin | Description$ As long as CARDNAME has two or more counters on it, it has first strike and is an Assassin in addition to its other types.
+S:Mode$ Continuous | Affected$ Card.Self | CheckSVar$ X | SVarCompare$ GT1 | AddKeyword$ First Strike | AddType$ Assassin | Description$ As long as NICKNAME has two or more counters on it, it has first strike and is an Assassin in addition to its other types.
 SVar:X:Count$CardCounters.ALL
 Oracle:Whenever Ezio, Brash Novice attacks, put a +1/+1 counter on it.\nAs long as Ezio has two or more counters on it, it has first strike and is an Assassin in addition to its other types.


### PR DESCRIPTION
Noticed [Ezio, Brash Novice](https://scryfall.com/card/acr/55/ezio-brash-novice) was missing from repository, so I scripted it and tested it successfully. 
Also fixed redundancy and a typo in one of the source cards, [Hero of Bretagard](https://scryfall.com/card/khc/4/hero-of-bretagard): as the second static ability adds the God type without overwriting existing creature types, it doesn't need to reiterate the Angel type granted by the first static ability. Tested the new script version: it works as expected. 