### PR TITLE
July 2024 cleanup: code

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/ChooseGenericEffectAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ChooseGenericEffectAi.java
@@ -206,7 +206,7 @@ public class ChooseGenericEffectAi extends SpellAbilityAi {
             }
 
             // milling against Tamiyo is pointless
-            if (owner.isCardInCommand("Emblem - Tamiyo, the Moon Sage")) {
+            if (owner.isCardInCommand("Emblem — Tamiyo, the Moon Sage")) {
                 return allow;
             }
 

--- a/forge-core/src/main/java/forge/util/CardTranslation.java
+++ b/forge-core/src/main/java/forge/util/CardTranslation.java
@@ -59,7 +59,7 @@ public class CardTranslation {
             try {
                 if (name.endsWith(" Token")) {
                     return translateTokenName(name);
-                } else if (name.startsWith("Emblem - ") || name.contains("'s Effect") || name.contains("'s Boon")) {
+                } else if (name.startsWith("Emblem — ") || name.contains("'s Effect") || name.contains("'s Boon")) {
                     return translateEffectNames(name);
                 } else if (knownEffectNames.contains(name)) {
                     return translateKnownEffectNames(name);
@@ -173,8 +173,8 @@ public class CardTranslation {
                 }
                 translatedEffectNames.put(name, fname);
                 return fname;
-            } else if (finalname.startsWith("Emblem - ")) {
-                String []s = finalname.split(" - ");
+            } else if (finalname.startsWith("Emblem — ")) {
+                String []s = finalname.split(" — ");
                 try {
                     fname = translatednames.get(s[1].endsWith(" ") ? s[1].substring(0, s[1].lastIndexOf(" ")) : s[1]);
                     if (fname == null || fname.isEmpty())

--- a/forge-game/src/main/java/forge/game/ability/effects/EffectEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/EffectEffect.java
@@ -149,7 +149,7 @@ public class EffectEffect extends SpellAbilityEffect {
             image = ImageKeys.getTokenKey(
             TextUtil.fastReplace(
                 TextUtil.fastReplace(
-                    TextUtil.fastReplace(name.toLowerCase(), " - ", "_"),
+                    TextUtil.fastReplace(name.toLowerCase(), " — ", "_"),
                         ",", ""),
                     " ", "_").toLowerCase());
         } else { // use host image

--- a/forge-gui/res/lists/altwin-achievements.txt
+++ b/forge-gui/res/lists/altwin-achievements.txt
@@ -46,4 +46,4 @@ Triskaidekaphile|The Luckiest Number|13, 169, 2197, 28561...
 Triskaidekaphobia|The Fear of 13|It's just a silly ancient superstition... right?
 Vessel of the All-Consuming|Consumed by Hidetsugu|Fade into nothingness.
 Vorpal Sword|Snicker-Snack!|He left it dead, and with its head / He went galumphing back.
-Emblem - Vraska, Golgari Queen|The Flurry of Assassins|How good is your dodging?
+Emblem — Vraska, Golgari Queen|The Flurry of Assassins|How good is your dodging?

--- a/forge-gui/src/main/java/forge/localinstance/achievements/AltWinAchievements.java
+++ b/forge-gui/src/main/java/forge/localinstance/achievements/AltWinAchievements.java
@@ -43,7 +43,7 @@ public class AltWinAchievements extends AchievementCollection {
 
             Achievement achievement = achievements.get(altWinCondition);
             if (achievement == null) {
-                achievement = achievements.get("Emblem - " + altWinCondition); // indirectly winning through an emblem
+                achievement = achievements.get("Emblem — " + altWinCondition); // indirectly winning through an emblem
             }
             if (achievement != null) {
                 achievement.update(player);


### PR DESCRIPTION
Addressing code issues relevant to this pull request series:
- Per [discussion](https://github.com/Card-Forge/forge/pull/5518#discussion_r1667378878), attempted to locate all the spots where the code refers to emblems in association with an `-` (en-dash), so that changing the `-` to an  `—` (em-dash) in emblem names goes smoothly.