### PR TITLE
Fix LKI entering battlefield

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -212,10 +212,16 @@ public class AiController {
     }
 
     public boolean checkETBEffects(final Card card, final SpellAbility sa, final ApiType api) {
-        // for xPaid stuff
-        card.setCastSA(sa);
+        boolean reset = false;
+        if (card.getCastSA() == null) {
+            // for xPaid stuff
+            card.setCastSA(sa);
+            reset = true;
+        }
         boolean result = checkETBEffectsPreparedCard(card, sa, api);
-        card.setCastSA(null);
+        if (reset) {
+            card.setCastSA(null);
+        }
         return result;
     }
 

--- a/forge-game/src/main/java/forge/game/ForgeScript.java
+++ b/forge-game/src/main/java/forge/game/ForgeScript.java
@@ -137,12 +137,6 @@ public class ForgeScript {
                 }
             }
             return found;
-        } else if (property.startsWith("HasSubtype")) {
-            final String subType = property.substring(11);
-            return cardState.getTypeWithChanges().hasSubtype(subType);
-        } else if (property.startsWith("HasNoSubtype")) {
-            final String subType = property.substring(13);
-            return !cardState.getTypeWithChanges().hasSubtype(subType);
         } else if (property.equals("hasActivatedAbilityWithTapCost")) {
             for (final SpellAbility sa : cardState.getSpellAbilities()) {
                 if (sa.isActivatedAbility() && sa.getPayCosts().hasTapCost()) {

--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -244,11 +244,11 @@ public class GameAction {
                 game.addChangeZoneLKIInfo(lastKnownInfo);
             }
 
-            // CR 707.12 casting of a card copy, don't copy it again
+            copied = new CardCopyService(c).copyCard(false);
+
+            // CR 707.12 casting of a card copy
             if (zoneTo.is(ZoneType.Stack) && c.isRealToken()) {
-                copied = c;
-            } else {
-                copied = new CardCopyService(c).copyCard(false);
+                copied.setCopiedPermanent(c.getCopiedPermanent());
             }
 
             copied.setGameTimestamp(c.getGameTimestamp());

--- a/forge-gui/res/cardsfolder/w/wandering_archaic_explore_the_vastlands.txt
+++ b/forge-gui/res/cardsfolder/w/wandering_archaic_explore_the_vastlands.txt
@@ -12,7 +12,7 @@ ALTERNATE
 Name:Explore the Vastlands
 ManaCost:3
 Types:Sorcery
-A:SP$ DigMultiple | Defined$ Player | DigNum$ 5 | Optional$ True | ChangeValid$ Land,Spell.HasNoSubtype Aura | RestRandomOrder$ True | SubAbility$ DBGainLife | SpellDescription$ Each player looks at the top five cards of their library and may reveal a land card and/or an instant or sorcery card from among them. Each player puts the cards they revealed this way into their hand and the rest on the bottom of their library in a random order. Each player gains 3 life.
+A:SP$ DigMultiple | Defined$ Player | DigNum$ 5 | Optional$ True | ChangeValid$ Land,Spell.!Aura | RestRandomOrder$ True | SubAbility$ DBGainLife | SpellDescription$ Each player looks at the top five cards of their library and may reveal a land card and/or an instant or sorcery card from among them. Each player puts the cards they revealed this way into their hand and the rest on the bottom of their library in a random order. Each player gains 3 life.
 SVar:DBGainLife:DB$ GainLife | Defined$ Player | LifeAmount$ 3 | StackDescription$ None
 DeckHas:Ability$LifeGain
 DeckHints:Type$Instant|Sorcery


### PR DESCRIPTION
![image](https://github.com/Card-Forge/forge/assets/8506892/e8c4ffb1-df6e-4eca-a517-40f3634b75d6)

The shortcut for card copies became problematic because in this case the host would still be LKI from the "Henzie" AltCost logic.