### PR TITLE
Keyword: Impending

### DIFF
--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -2494,7 +2494,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
                         || keyword.startsWith("Bestow") || keyword.startsWith("Surge")
                         || keyword.startsWith("Transmute") || keyword.startsWith("Suspend")
                         || keyword.startsWith("Dash") || keyword.startsWith("Disturb")
-                        || keyword.equals("Undaunted") || keyword.startsWith("Monstrosity")
+                        || keyword.equals("Undaunted") || keyword.startsWith("Monstrosity") || keyword.startsWith("Impending")
                         || keyword.startsWith("Embalm") || keyword.equals("Prowess")
                         || keyword.startsWith("Eternalize") || keyword.startsWith("Reinforce")
                         || keyword.startsWith("Champion") || keyword.startsWith("Freerunning") || keyword.startsWith("Prowl") || keyword.startsWith("Adapt")

--- a/forge-game/src/main/java/forge/game/card/CardProperty.java
+++ b/forge-game/src/main/java/forge/game/card/CardProperty.java
@@ -1882,6 +1882,14 @@ public class CardProperty {
                 return false;
             }
             return card.getCastSA().isEvoke();
+        } else if (property.equals("impended")) {
+            if (card.getCastSA() == null) {
+                return false;
+            }
+            if (AbilityUtils.isUnlinkedFromCastSA(spellAbility, card)) {
+                return false;
+            }
+            return card.getCastSA().isImpending();
         } else if (property.equals("prowled")) {
             if (card.getCastSA() == null) {
                 return false;

--- a/forge-game/src/main/java/forge/game/keyword/Keyword.java
+++ b/forge-game/src/main/java/forge/game/keyword/Keyword.java
@@ -106,6 +106,7 @@ public enum Keyword {
     HEXPROOF("Hexproof", Hexproof.class, true, "This can't be the target of %s spells or abilities your opponents control."),
     HIDEAWAY("Hideaway", KeywordWithAmount.class, false, "When this permanent enters the battlefield, look at the top {%d:card} of your library, exile one face down, then put the rest on the bottom of your library."),
     HORSEMANSHIP("Horsemanship", SimpleKeyword.class, true, "This creature can't be blocked except by creatures with horsemanship."),
+    IMPENDING("Impending", KeywordWithCostAndAmount.class, false, "If you cast this spell for its impending cost, it enters with {%2$d:time counter} and isn’t a creature until the last is removed. At the beginning of your end step, remove a time counter from it."),
     IMPROVISE("Improvise", SimpleKeyword.class, true, "Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}."),
     INDESTRUCTIBLE("Indestructible", SimpleKeyword.class, true, "Effects that say \"destroy\" don't destroy this."),
     INFECT("Infect", SimpleKeyword.class, true, "This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters."),

--- a/forge-game/src/main/java/forge/game/spellability/AlternativeCost.java
+++ b/forge-game/src/main/java/forge/game/spellability/AlternativeCost.java
@@ -12,6 +12,7 @@ public enum AlternativeCost {
     Flashback,
     Foretold,
     Freerunning,
+    Impending,
     Madness,
     MTMtE, // More Than Meets the Eye (Transformers Universes Beyond)
     Mutate,

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
@@ -1553,6 +1553,10 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
         return isAlternativeCost(AlternativeCost.Freerunning);
     }
 
+    public final boolean isImpending() {
+        return isAlternativeCost(AlternativeCost.Impending);
+    }
+
     public final boolean isMadness() {
         return isAlternativeCost(AlternativeCost.Madness);
     }

--- a/forge-gui/res/cardsfolder/upcoming/overlord_of_the_hauntwoods.txt
+++ b/forge-gui/res/cardsfolder/upcoming/overlord_of_the_hauntwoods.txt
@@ -1,0 +1,10 @@
+Name:Overlord of the Hauntwoods
+ManaCost:3 G G
+Types:Enchantment Creature Avatar Horror
+PT:6/5
+K:Impending:4:1 G G
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ Whenever CARDNAME enters or attacks, create a tapped colorless land token named Everywhere that is every basic land type.
+T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Secondary$ True | Execute$ TrigToken | TriggerDescription$ Whenever CARDNAME enters or attacks, create a tapped colorless land token named Everywhere that is every basic land type.
+SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ everywhere | LockTokenScript$ True
+Oracle:Impending 4—{1}{G}{G} (If you cast this spell for its impending cost, it enters with four time counters and isn’t a creature until the last is removed. At the beginning of your end step, remove a time counter from it.)\nWhenever Overlord of the Hauntwoods enters or attacks, create a tapped colorless land token named Everywhere that is every basic land type.
+

--- a/forge-gui/res/cardsfolder/upcoming/overlord_of_the_hauntwoods.txt
+++ b/forge-gui/res/cardsfolder/upcoming/overlord_of_the_hauntwoods.txt
@@ -5,6 +5,5 @@ PT:6/5
 K:Impending:4:1 G G
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ Whenever CARDNAME enters or attacks, create a tapped colorless land token named Everywhere that is every basic land type.
 T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Secondary$ True | Execute$ TrigToken | TriggerDescription$ Whenever CARDNAME enters or attacks, create a tapped colorless land token named Everywhere that is every basic land type.
-SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ everywhere | LockTokenScript$ True
+SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ everywhere | LockTokenScript$ True | TokenTapped$ True
 Oracle:Impending 4—{1}{G}{G} (If you cast this spell for its impending cost, it enters with four time counters and isn’t a creature until the last is removed. At the beginning of your end step, remove a time counter from it.)\nWhenever Overlord of the Hauntwoods enters or attacks, create a tapped colorless land token named Everywhere that is every basic land type.
-

--- a/forge-gui/res/tokenscripts/everywhere.txt
+++ b/forge-gui/res/tokenscripts/everywhere.txt
@@ -1,0 +1,4 @@
+Name:Everywhere
+ManaCost:no cost
+Types:Land Plains Island Swamp Mountain Forest
+Oracle:


### PR DESCRIPTION
Closes #5481

First try of Impending Keyword and Everywhere Land Token. These might be updated later when we know more about the rules.


The Current Implementation of Impending uses a Static Ability that can be enabled by any Time counter.

The Everywhere Land currently has the Land types hard coded, so it can be affected by Card Text Changes.
While The Creature should not, that's why the "LockTokenScript"