### PR TITLE
Fixing Bello's static ability

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/bello_bard_of_the_brambles.txt
+++ b/forge-gui/res/cardsfolder/upcoming/bello_bard_of_the_brambles.txt
@@ -2,7 +2,7 @@ Name:Bello, Bard of the Brambles
 ManaCost:1 R G
 Types:Legendary Creature Raccoon Bard
 PT:3/3
-S:Mode$ Continuous | Affected$ Artifact.nonEquipment+YouCtrl+cmcGE4,Enchantment.nonAura+YouCtrl+cmcGE4 | Condition$ PlayerTurn | SetPower$ 4 | SetToughness$ 4 | AddType$ Creature,Elemental | AddKeyword$ Indestructible & Haste | AddTrigger$ TrigDamageDone | Description$ During your turn, each non-Equipment artifact and non-Aura enchantment you control with mana value 4 or greater is a 4/4 Elemental creature in addition to its other types and has indestructible, haste, and "Whenever this creature deals combat damage to a player, draw a card."
+S:Mode$ Continuous | Affected$ Artifact.nonEquipment+YouCtrl+cmcGE4,Enchantment.nonAura+YouCtrl+cmcGE4 | Condition$ PlayerTurn | SetPower$ 4 | SetToughness$ 4 | AddType$ Creature & Elemental | AddKeyword$ Indestructible & Haste | AddTrigger$ TrigDamageDone | Description$ During your turn, each non-Equipment artifact and non-Aura enchantment you control with mana value 4 or greater is a 4/4 Elemental creature in addition to its other types and has indestructible, haste, and "Whenever this creature deals combat damage to a player, draw a card."
 SVar:TrigDamageDone:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigDraw | TriggerZones$ Battlefield | TriggerDescription$ Whenever this creature deals combat damage to a player, draw a card.
 SVar:TrigDraw:DB$ Draw | NumCards$ 1 | Defined$ You
 SVar:PlayMain1:ALWAYS


### PR DESCRIPTION
[Bello, Bard of the Brambles](https://scryfall.com/card/blc/1/bello-bard-of-the-brambles)'s static ability wasn't granting the relevant types the right way because the argument was using syntax for `$ Animate` effects (types separated by `,` instead of ` & ` as in similar continuous effects like [Ambush Commander](https://scryfall.com/card/scg/111/ambush-commander)). The script now works as expected. I also took the opportunity to change newline characters from `CR LF` (Windows) to `LF` (Unix). Closes https://github.com/Card-Forge/forge/issues/5574 .