### PR TITLE
Refresh active triggers after statics from ETB

### DIFF
--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -613,10 +613,6 @@ public class GameAction {
         }
 
         game.getTriggerHandler().clearActiveTriggers(copied, null);
-        // register all LTB trigger from last state battlefield
-        for (Card lki : lastBattlefield) {
-            game.getTriggerHandler().registerActiveLTBTrigger(lki);
-        }
         game.getTriggerHandler().registerActiveTrigger(copied, false);
 
         // play the change zone sound
@@ -1438,6 +1434,8 @@ public class GameAction {
             }
             setHoldCheckingStaticAbilities(false);
 
+            table.triggerChangesZoneAll(game, null);
+
             // important to collect first otherwise if a static fires it will mess up registered ones from LKI
             game.getTriggerHandler().collectTriggerForWaiting();
             if (game.getTriggerHandler().runWaitingTriggers()) {
@@ -1447,8 +1445,6 @@ public class GameAction {
             if (game.getCombat() != null) {
                 game.getCombat().removeAbsentCombatants();
             }
-
-            table.triggerChangesZoneAll(game, null);
 
             for (final Card c : cardsToUpdateLKI) {
                 game.updateLastStateForCard(c);

--- a/forge-game/src/main/java/forge/game/ability/effects/PermanentEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PermanentEffect.java
@@ -11,7 +11,6 @@ import forge.game.ability.SpellAbilityEffect;
 import forge.game.card.Card;
 import forge.game.card.CardZoneTable;
 import forge.game.spellability.SpellAbility;
-import forge.game.zone.ZoneType;
 
 public class PermanentEffect extends SpellAbilityEffect {
 
@@ -26,12 +25,8 @@ public class PermanentEffect extends SpellAbilityEffect {
     public void resolve(SpellAbility sa) {
         final Card host = sa.getHostCard();
         final Game game = host.getGame();
-        CardZoneTable table = new CardZoneTable();
-        ZoneType previousZone = host.getZone().getZoneType();
-
-        Map<AbilityKey, Object> moveParams = AbilityKey.newMap();
-        moveParams.put(AbilityKey.LastStateBattlefield, game.copyLastStateBattlefield());
-        moveParams.put(AbilityKey.LastStateGraveyard, game.copyLastStateGraveyard());
+        final Map<AbilityKey, Object> moveParams = AbilityKey.newMap();
+        final CardZoneTable table = AbilityKey.addCardZoneTableParams(moveParams, sa);
 
         final Card c = game.getAction().moveToPlay(host, host.getController(), sa, moveParams);
         sa.setHostCard(c);
@@ -47,10 +42,6 @@ public class PermanentEffect extends SpellAbilityEffect {
             registerDelayedTrigger(sa, "Sacrifice", Lists.newArrayList(c));
         }
 
-        ZoneType newZone = c.getZone().getZoneType();
-        if (newZone != previousZone) {
-            table.put(previousZone, newZone, c);
-        }
         table.triggerChangesZoneAll(game, sa);
     }
 }

--- a/forge-game/src/main/java/forge/game/card/CardZoneTable.java
+++ b/forge-game/src/main/java/forge/game/card/CardZoneTable.java
@@ -61,19 +61,11 @@ public class CardZoneTable extends ForwardingTable<ZoneType, ZoneType, CardColle
         return lastStateGraveyard;
     }
     public void setLastStateBattlefield(CardCollectionView lastState) {
-        if (lastState == null) {
-            lastStateBattlefield = CardCollection.EMPTY;
-        } else {
-            // store it in a new object, it might be from Game which can also refresh itself
-            lastStateBattlefield = new CardCollection(lastState);
-        }
+        // store it in a new object, it might be from Game which can also refresh itself
+        lastStateBattlefield = lastState == null ? CardCollection.EMPTY : new CardCollection(lastState);
     }
     public void setLastStateGraveyard(CardCollectionView lastState) {
-        if (lastState == null) {
-            lastStateGraveyard = CardCollection.EMPTY;
-        } else {
-            lastStateGraveyard = new CardCollection(lastState);
-        }
+        lastStateGraveyard = lastState == null ? CardCollection.EMPTY : new CardCollection(lastState);
     }
 
     /**


### PR DESCRIPTION
Refreshes active triggers before collecting, in line with
> 603.10. Normally, objects that exist immediately after an event are checked to see if the event matched any trigger conditions, and continuous effects that exist at that time are used to determine what the trigger conditions are and what the objects involved in the event look like.

For that to work with LTB trigger their registering has to be done after again (so they're not lost). This also means it's performed only once now for simultaneous zone change.

I tried to test a couple of basic scenarios and it seems to work...

Closes #5557