### PR TITLE
Fixing Grip of Chaos in-game display

### DIFF
--- a/forge-gui/res/cardsfolder/g/grip_of_chaos.txt
+++ b/forge-gui/res/cardsfolder/g/grip_of_chaos.txt
@@ -1,8 +1,8 @@
 Name:Grip of Chaos
 ManaCost:4 R R
 Types:Enchantment
-T:Mode$ SpellAbilityCopy | IsSingleTarget$ True | TriggerZones$ Battlefield | Execute$ TrigChangeTarget | TriggerDescription$ Whenever a spell or ability is put onto the stack, if it has a single target, reselect its target at random. (Select from among all legal targets.)
 T:Mode$ SpellAbilityCast | ValidSA$ SpellAbility.nonManaAbility | IsSingleTarget$ True | TriggerZones$ Battlefield | Execute$ TrigChangeTarget | TriggerDescription$ Whenever a spell or ability is put onto the stack, if it has a single target, reselect its target at random. (Select from among all legal targets.)
+T:Mode$ SpellAbilityCopy | IsSingleTarget$ True | TriggerZones$ Battlefield | Execute$ TrigChangeTarget | Secondary$ True | TriggerDescription$ Whenever a spell or ability is put onto the stack, if it has a single target, reselect its target at random. (Select from among all legal targets.)
 SVar:TrigChangeTarget:DB$ ChangeTargets | Defined$ TriggeredSpellAbility | RandomTarget$ True
 AI:RemoveDeck:Random
 Oracle:Whenever a spell or ability is put onto the stack, if it has a single target, reselect its target at random. (Select from among all legal targets.)


### PR DESCRIPTION
As [Grip of Chaos](https://scryfall.com/card/scg/98/grip-of-chaos) has two trigger condition lines for its trigger `SVar`, one should be marked as `Secondary$` so only one `TriggerDescription$` is displayed in the in-game Card Detail pane.