### PR TITLE
Fix for QuestCommander deck editor

### DIFF
--- a/forge-core/src/main/java/forge/deck/Deck.java
+++ b/forge-core/src/main/java/forge/deck/Deck.java
@@ -539,7 +539,12 @@ public class Deck extends DeckBase implements Iterable<Entry<DeckSection, CardPo
     public CardPool getAllCardsInASinglePool() {
         return getAllCardsInASinglePool(true);
     }
+
     public CardPool getAllCardsInASinglePool(final boolean includeCommander) {
+        return getAllCardsInASinglePool(includeCommander, false);
+    }
+
+    public CardPool getAllCardsInASinglePool(final boolean includeCommander, boolean includeExtras) {
         final CardPool allCards = new CardPool(); // will count cards in this pool to enforce restricted
         allCards.addAll(this.getMain());
         if (this.has(DeckSection.Sideboard)) {
@@ -547,6 +552,11 @@ public class Deck extends DeckBase implements Iterable<Entry<DeckSection, CardPo
         }
         if (includeCommander && this.has(DeckSection.Commander)) {
             allCards.addAll(this.get(DeckSection.Commander));
+        }
+        if (includeExtras) {
+            for (DeckSection section : DeckSection.NONTRADITIONAL_SECTIONS)
+                if (this.has(section))
+                    allCards.addAll(this.get(section));
         }
         // do not include schemes / avatars and any non-regular cards
         return allCards;

--- a/forge-core/src/main/java/forge/deck/DeckSection.java
+++ b/forge-core/src/main/java/forge/deck/DeckSection.java
@@ -16,6 +16,11 @@ public enum DeckSection {
     Dungeon(0, Validators.DUNGEON_VALIDATOR),
     Attractions(0, Validators.ATTRACTION_VALIDATOR);
 
+    /**
+     * Array of DeckSections that contain nontraditional cards.
+     */
+    public static final DeckSection[] NONTRADITIONAL_SECTIONS = new DeckSection[]{Avatar, Planes, Schemes, Conspiracy, Dungeon, Attractions};
+
     private final int typicalSize; // Rules enforcement is done in DeckFormat class, this is for reference only
     private Function<PaperCard, Boolean> fnValidator;
 

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/ACEditorBase.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/ACEditorBase.java
@@ -214,7 +214,7 @@ public abstract class ACEditorBase<TItem extends InventoryItem, TModel extends D
 
         Iterable<Entry<String,Integer>> cardsByName = null;
         if (deck != null) {
-            final CardPool allCards = deck.getAllCardsInASinglePool(deck.has(DeckSection.Commander));
+            final CardPool allCards = deck.getAllCardsInASinglePool();
             cardsByName = Aggregates.groupSumBy(allCards, pc -> pc.getRules().getNormalizedName());
         }
 

--- a/forge-gui-mobile/src/forge/screens/quest/QuestMenu.java
+++ b/forge-gui-mobile/src/forge/screens/quest/QuestMenu.java
@@ -133,6 +133,7 @@ public class QuestMenu extends FPopupMenu implements IVQuestStats {
                 }
 
                 ((DeckController<Deck>)EditorType.Quest.getController()).setRootFolder(FModel.getQuest().getMyDecks());
+                ((DeckController<Deck>)EditorType.QuestCommander.getController()).setRootFolder(FModel.getQuest().getMyDecks());
                 ((DeckController<DeckGroup>)EditorType.QuestDraft.getController()).setRootFolder(FModel.getQuest().getDraftDecks());
                 if (reason == LaunchReason.StartQuestMode) {
                     if (QuestUtil.getCurrentDeck() == null) {


### PR DESCRIPTION
Resolves an issue where quest commander was functioning as quest mode in some ways, like commander mode in other ways, and like quest commander in no way whatsoever.

In doing this, I deleted this condition from the deck editor's constructor:
```
if (editorType0 == EditorType.QuestCommander) //fix saving quest commander
    editorType = EditorType.Quest;
else
    editorType = editorType0;
```
Removing something commented with the words "fix saving" leaves me very nervous because I'm not sure exactly what the issue there was. I did run into these lines in `QuestMenu.java` that seem like they could cause a quest commander deck saving issue since they don't include `EditorType.QuestCommander`:
```
((DeckController<Deck>)EditorType.Quest.getController()).setRootFolder(FModel.getQuest().getMyDecks());
((DeckController<DeckGroup>)EditorType.QuestDraft.getController()).setRootFolder(FModel.getQuest().getDraftDecks());
```

I added such a line in, and haven't encountered any issues while testing it. Still, if that's all it needed, I'm not sure why the workaround solution was used. 

All this to say, if anybody knows any more details about this, please chime in.