### PR TITLE
Update cardstates after creating token from prototype

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/TokenEffectBase.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/TokenEffectBase.java
@@ -114,6 +114,8 @@ public abstract class TokenEffectBase extends SpellAbilityEffect {
 
             for (int i = 0; i < cellAmount; i++) {
                 Card tok = new CardCopyService(prototype).copyCard(true);
+                // disconnect from prototype
+                tok.getStates().forEach(cs -> tok.getState(cs).resetOriginalHost());
                 // Crafty Cutpurse would change under which control it does enter,
                 // but it shouldn't change who creates the token
                 tok.setOwner(creator);

--- a/forge-game/src/main/java/forge/game/card/CardState.java
+++ b/forge-game/src/main/java/forge/game/card/CardState.java
@@ -748,6 +748,21 @@ public class CardState extends GameObject implements IHasSVars {
         }
     }
 
+    public void resetOriginalHost() {
+        final List<CardTraitBase> allAbs = ImmutableList.<CardTraitBase>builder()
+            .addAll(manaAbilities)
+            .addAll(nonManaAbilities)
+            .addAll(triggers)
+            .addAll(replacementEffects)
+            .addAll(staticAbilities)
+            .build();
+        for (final CardTraitBase ctb : allAbs) {
+            if (ctb.isIntrinsic()) {
+                ctb.setCardState(this);
+            }
+        }
+    }
+
     public void updateChangedText() {
         final List<CardTraitBase> allAbs = ImmutableList.<CardTraitBase>builder()
             .addAll(manaAbilities)

--- a/forge-game/src/main/java/forge/game/card/CardState.java
+++ b/forge-game/src/main/java/forge/game/card/CardState.java
@@ -18,7 +18,6 @@
 package forge.game.card;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -748,15 +747,18 @@ public class CardState extends GameObject implements IHasSVars {
         }
     }
 
+    public ImmutableList<CardTraitBase> getTraits() {
+        return ImmutableList.<CardTraitBase>builder()
+                .addAll(manaAbilities)
+                .addAll(nonManaAbilities)
+                .addAll(triggers)
+                .addAll(replacementEffects)
+                .addAll(staticAbilities)
+                .build();
+    }
+
     public void resetOriginalHost() {
-        final List<CardTraitBase> allAbs = ImmutableList.<CardTraitBase>builder()
-            .addAll(manaAbilities)
-            .addAll(nonManaAbilities)
-            .addAll(triggers)
-            .addAll(replacementEffects)
-            .addAll(staticAbilities)
-            .build();
-        for (final CardTraitBase ctb : allAbs) {
+        for (final CardTraitBase ctb : getTraits()) {
             if (ctb.isIntrinsic()) {
                 ctb.setCardState(this);
             }
@@ -764,14 +766,7 @@ public class CardState extends GameObject implements IHasSVars {
     }
 
     public void updateChangedText() {
-        final List<CardTraitBase> allAbs = ImmutableList.<CardTraitBase>builder()
-            .addAll(manaAbilities)
-            .addAll(nonManaAbilities)
-            .addAll(triggers)
-            .addAll(replacementEffects)
-            .addAll(staticAbilities)
-            .build();
-        for (final CardTraitBase ctb : allAbs) {
+        for (final CardTraitBase ctb : getTraits()) {
             if (ctb.isIntrinsic()) {
                 ctb.changeText();
             }
@@ -779,14 +774,7 @@ public class CardState extends GameObject implements IHasSVars {
     }
 
     public void changeTextIntrinsic(Map<String,String> colorMap, Map<String,String> typeMap) {
-        final List<CardTraitBase> allAbs = ImmutableList.<CardTraitBase>builder()
-            .addAll(manaAbilities)
-            .addAll(nonManaAbilities)
-            .addAll(triggers)
-            .addAll(replacementEffects)
-            .addAll(staticAbilities)
-            .build();
-        for (final CardTraitBase ctb : allAbs) {
+        for (final CardTraitBase ctb : getTraits()) {
             if (ctb.isIntrinsic()) {
                 ctb.changeTextIntrinsic(colorMap, typeMap);
             }

--- a/forge-gui/res/cardsfolder/e/eriette_the_beguiler.txt
+++ b/forge-gui/res/cardsfolder/e/eriette_the_beguiler.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature Human Warlock
 PT:4/4
 K:Lifelink
 T:Mode$ Attached | ValidSource$ Aura.YouCtrl | TargetRelativeToSource$ Permanent.nonLand+OppCtrl+cmcLEX | TriggerZones$ Battlefield | Execute$ TrigGainControl | TriggerDescription$ Whenever an Aura you control becomes attached to a nonland permanent an opponent controls with mana value less than or equal to that Aura's mana value, gain control of that permanent for as long as that Aura is attached to it.
-SVar:TrigGainControl:DB$ GainControl | NewController$ You | Defined$ TriggeredTarget | Duration$ UntilSourceUnattached
+SVar:TrigGainControl:DB$ GainControl | NewController$ You | Defined$ TriggeredTarget | LoseControl$ UntilSourceUnattached
 SVar:X:Count$CardManaCost
 DeckHas:Ability$LifeGain
 DeckNeeds:Type$Aura

--- a/forge-gui/res/tokenscripts/rock.txt
+++ b/forge-gui/res/tokenscripts/rock.txt
@@ -2,6 +2,6 @@ Name:Rock
 ManaCost:no cost
 Types:Artifact Equipment
 S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddAbility$ ThrowRock | Description$ Equipped creature has "{1}, {T}, Sacrifice CARDNAME: This creature deals 2 damage to any target."
-SVar:ThrowRock:AB$ DealDamage | Cost$ 1 T Sac<1/Card.Attached+namedRock/Rock> | CostDesc$ {1}, {T}, Sacrifice ORIGINALHOST: | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to any target.
+SVar:ThrowRock:AB$ DealDamage | Cost$ 1 T Sac<1/OriginalHost/Rock> | CostDesc$ {1}, {T}, Sacrifice ORIGINALHOST: | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to any target.
 K:Equip:1
 Oracle:Equipped creature has "{1}, {T}, Sacrifice Rock: This creature deals 2 damage to any target."\nEquip {1}

--- a/forge-gui/res/tokenscripts/rock.txt
+++ b/forge-gui/res/tokenscripts/rock.txt
@@ -2,6 +2,6 @@ Name:Rock
 ManaCost:no cost
 Types:Artifact Equipment
 S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddAbility$ ThrowRock | Description$ Equipped creature has "{1}, {T}, Sacrifice CARDNAME: This creature deals 2 damage to any target."
-SVar:ThrowRock:AB$ DealDamage | Cost$ 1 T Sac<1/OriginalHost/Rock> | CostDesc$ {1}, {T}, Sacrifice ORIGINALHOST: | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to any target.
+SVar:ThrowRock:AB$ DealDamage | Cost$ 1 T Sac<1/Card.Attached+namedRock/Rock> | CostDesc$ {1}, {T}, Sacrifice ORIGINALHOST: | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to any target.
 K:Equip:1
 Oracle:Equipped creature has "{1}, {T}, Sacrifice Rock: This creature deals 2 damage to any target."\nEquip {1}


### PR DESCRIPTION
Reverts the previous cleanup.

@Hanmac
The problem is when the final token gets created from its prototype the traits that get copied over will have that original CardState instead.

Since this seems to be a bigger flaw in the engine related to #143 I probably can't do anything else here 🤔

Closes #5677