### PR TITLE
Fixes for Mistbreath Elder, Long River Lurker, Waterspout Warden

### DIFF
--- a/forge-gui/res/cardsfolder/c/cutthroat_centurion.txt
+++ b/forge-gui/res/cardsfolder/c/cutthroat_centurion.txt
@@ -4,5 +4,5 @@ Types:Artifact Creature Phyrexian Warrior
 PT:2/2
 A:AB$ Pump | Cost$ Sac<1/Creature.Other;Artifact.Other/another creature or artifact> | Defined$ Self | NumDef$ 2 | NumAtt$ +2 | AILogic$ Aristocrat | ActivationLimit$ 1 | SpellDescription$ CARDNAME gets +2/+2 until end of turn. Activate only once each turn.
 DeckHas:Ability$Sacrifice
-SVar:AIPreference:SacCost$Artifact.token,Creature,token,Artifact.cmcEQ0+nonLegendary+notnamedBlack Lotus,Artifact.cmcEQ1,Artifact.cmcEQ2,Artifact.cmcEQ3,Creature.cmcLE3
+SVar:AIPreference:SacCost$Artifact.token,Creature.token,Artifact.cmcEQ0+nonLegendary+notnamedBlack Lotus,Artifact.cmcEQ1,Artifact.cmcEQ2,Artifact.cmcEQ3,Creature.cmcLE3
 Oracle:Sacrifice another artifact or creature: Cutthroat Centurion gets +2/+2 until end of turn. Activate only once each turn.

--- a/forge-gui/res/cardsfolder/upcoming/long_river_lurker.txt
+++ b/forge-gui/res/cardsfolder/upcoming/long_river_lurker.txt
@@ -7,7 +7,7 @@ S:Mode$ Continuous | Affected$ Frog.YouCtrl+Other | AddKeyword$ Ward:1 | Descrip
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigUnblockable | TriggerDescription$ When CARDNAME enters, target creature you control can't be blocked this turn. Whenever that creature deals combat damage this turn, you may exile it. If you do, return it to the battlefield under its owner's control.
 SVar:TrigUnblockable:DB$ Effect | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | RememberObjects$ Targeted | ExileOnMoved$ Battlefield | StaticAbilities$ Unblockable | Triggers$ TrigDamage
 SVar:Unblockable:Mode$ CantBlockBy | ValidAttacker$ Card.IsRemembered | Description$ This creature can't be blocked this turn.
-SVar:Trig:Mode$ DamageDealtOnce | ValidSource$ Creature.IsRemembered | CombatDamage$ True | Execute$ TrigExile | TriggerDescription$ Whenever this creature deals combat damage this turn, you may exile it. If you do, return it to the battlefield under its owner's control.
+SVar:TrigDamage:Mode$ DamageDealtOnce | ValidSource$ Creature.IsRemembered | CombatDamage$ True | Execute$ TrigExile | TriggerDescription$ Whenever this creature deals combat damage this turn, you may exile it. If you do, return it to the battlefield under its owner's control.
 SVar:TrigExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | RememberChanged$ True | SubAbility$ DBReturn
 SVar:DBReturn:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Battlefield | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/upcoming/mistbreath_elder.txt
+++ b/forge-gui/res/cardsfolder/upcoming/mistbreath_elder.txt
@@ -3,11 +3,10 @@ ManaCost:G
 Types:Creature Frog Warrior
 PT:2/2
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigBounce | TriggerDescription$ At the beginning of your upkeep, return another creature you control to its owner's hand. If you do, put a +1/+1 counter on CARDNAME. Otherwise, you may return CARDNAME to its owner's hand.
-SVar:TrigBounce:DB$ ChangeZone | Origin$ Battlefield | Destination$ Hand | ChangeType$ Creature.StrictlyOther+YouCtrl | ChangeNum$ 1 | Mandatory$ True | Hidden$ True | RememberChanged$ True | SubAbility$ DBBranch
-SVar:DBBranch:DB$ Branch | BranchConditionSVar$ X | BranchConditionSVarCompare$ GT0 | TrueSubAbility$ DBPutCounter | FalseSubAbility$ DBChangeZone
-SVar:DBPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBCleanup
+SVar:TrigBounce:DB$ ChangeZone | Origin$ Battlefield | Destination$ Hand | ChangeType$ Creature.StrictlyOther+YouCtrl | ChangeNum$ 1 | Mandatory$ True | Hidden$ True | RememberChanged$ True | SubAbility$ DBPutCounter
+SVar:DBPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1 | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1 | SubAbility$ DBChangeZone
+SVar:DBChangeZone:DB$ ChangeZone | Origin$ Battlefield | Destination$ Hand | Optional$ True | ConditionCheckSVar$ X | ConditionSVarCompare$ LE0 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-SVar:DBChangeZone:DB$ ChangeZone | Origin$ Battlefield | Destination$ Hand | Hidden$ True | ChangeType$ Card.Self
 SVar:X:Remembered$Amount
 AI:RemoveDeck:All
 Oracle:At the beginning of your upkeep, return another creature you control to its owner's hand. If you do, put a +1/+1 counter on Mistbreath Elder. Otherwise, you may return Mistbreath Elder to its owner's hand.

--- a/forge-gui/res/cardsfolder/upcoming/waterspout_warden.txt
+++ b/forge-gui/res/cardsfolder/upcoming/waterspout_warden.txt
@@ -2,7 +2,6 @@ Name:Waterspout Warden
 ManaCost:2 U
 Types:Creature Frog Soldier
 PT:3/2
-K:Haste
 T:Mode$ Attacks | ValidCard$ Creature.Self | CheckSVar$ X | SVarCompare$ GE1 | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, if another creature entered the battlefield under your control this turn, CARDNAME gains flying until end of turn.
 SVar:TrigPump:DB$ Pump | Defined$ Self | KW$ Flying
 SVar:X:Count$ThisTurnEntered_Battlefield_Creature.YouCtrl+StrictlyOther


### PR DESCRIPTION
Most of Mistbreath Elder's effects didn't work and it was a 4|4 for G instead of a 2|2.

Waterspout Warden had Haste for some reason.

Long River Lurker's effect straight-up crashed Forge due to a naming mismatch.