### PR TITLE
Miscallaneous Cleanup

### DIFF
--- a/forge-adventure/src/main/java/forge/adventure/editor/EditorMainWindow.java
+++ b/forge-adventure/src/main/java/forge/adventure/editor/EditorMainWindow.java
@@ -34,8 +34,7 @@ public class EditorMainWindow extends JFrame {
         Localizer.getInstance().initialize(FModel.getPreferences().getPref(ForgePreferences.FPref.UI_LANGUAGE), ForgeConstants.LANG_DIR);
         int var2 = var1.length;
 
-        for(int var3 = 0; var3 < var2; ++var3) {
-            UIManager.LookAndFeelInfo info = var1[var3];
+        for (UIManager.LookAndFeelInfo info : var1) {
             if ("Nimbus".equals(info.getName())) {
                 try {
                     UIManager.setLookAndFeel(info.getClassName());

--- a/forge-adventure/src/main/java/forge/adventure/editor/EffectEditor.java
+++ b/forge-adventure/src/main/java/forge/adventure/editor/EffectEditor.java
@@ -57,9 +57,9 @@ public class EffectEditor extends JComponent  {
  
 
         currentData.name=name.getText();
-        currentData.changeStartCards=((Integer)changeStartCards.getValue()).intValue();
-        currentData.lifeModifier= ((Integer)lifeModifier.getValue()).intValue();
-        currentData.moveSpeed= ((Float)moveSpeed.getValue()).floatValue();
+        currentData.changeStartCards = (Integer) changeStartCards.getValue();
+        currentData.lifeModifier = (Integer) lifeModifier.getValue();
+        currentData.moveSpeed = (Float) moveSpeed.getValue();
         currentData.startBattleWithCard = startBattleWithCard.getList();
         currentData.colorView = colorView.isSelected();
         currentData.opponent = opponent.currentData;

--- a/forge-adventure/src/main/java/forge/adventure/editor/FloatSpinner.java
+++ b/forge-adventure/src/main/java/forge/adventure/editor/FloatSpinner.java
@@ -14,6 +14,6 @@ public class FloatSpinner extends JSpinner{
     }
     public float floatValue()
     {
-        return ((Float)getValue()).floatValue();
+        return (Float) getValue();
     }
 }

--- a/forge-adventure/src/main/java/forge/adventure/editor/IntSpinner.java
+++ b/forge-adventure/src/main/java/forge/adventure/editor/IntSpinner.java
@@ -15,6 +15,6 @@ public class IntSpinner extends JSpinner {
     }
     public int intValue()
     {
-        return ((Integer)getValue()).intValue();
+        return (Integer) getValue();
     }
 }

--- a/forge-adventure/src/main/java/forge/adventure/editor/ItemEdit.java
+++ b/forge-adventure/src/main/java/forge/adventure/editor/ItemEdit.java
@@ -57,7 +57,7 @@ public class ItemEdit extends JComponent {
         currentData.description=description.getText();
         currentData.iconName=iconName.getText();
         currentData.questItem=questItem.isSelected();
-        currentData.cost=((Integer)  cost.getValue()).intValue();
+        currentData.cost= (Integer) cost.getValue();
     }
 
     public void setCurrentItem(ItemData data)

--- a/forge-adventure/src/main/java/forge/adventure/editor/RewardEdit.java
+++ b/forge-adventure/src/main/java/forge/adventure/editor/RewardEdit.java
@@ -122,7 +122,7 @@ public class RewardEdit extends FormPanel {
         updating=true;
         typeField.setSelectedItem(currentData.type);
 
-        probability.setValue(new Double(currentData.probability));
+        probability.setValue((double) currentData.probability);
         count.setValue(currentData.count);
         addMaxCount.setValue(currentData.addMaxCount);
         cardName.setText(currentData.cardName);

--- a/forge-ai/src/main/java/forge/ai/AiAttackController.java
+++ b/forge-ai/src/main/java/forge/ai/AiAttackController.java
@@ -1173,8 +1173,8 @@ public class AiAttackController {
         while (!attritionalAttackers.isEmpty() && humanLife > 0 && attackRounds < 99) {
             // sum attacker damage
             int damageThisRound = 0;
-            for (int y = 0; y < attritionalAttackers.size(); y++) {
-                damageThisRound += attritionalAttackers.get(y).getNetCombatDamage();
+            for (Card attritionalAttacker : attritionalAttackers) {
+                damageThisRound += attritionalAttacker.getNetCombatDamage();
             }
             // remove from player life
             humanLife -= damageThisRound;

--- a/forge-ai/src/main/java/forge/ai/AiCardMemory.java
+++ b/forge-ai/src/main/java/forge/ai/AiCardMemory.java
@@ -19,7 +19,6 @@
 package forge.ai;
 
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
 
 import forge.game.card.Card;

--- a/forge-ai/src/main/java/forge/ai/AiCardMemory.java
+++ b/forge-ai/src/main/java/forge/ai/AiCardMemory.java
@@ -164,10 +164,7 @@ public class AiCardMemory {
         Set<Card> memorySet = getMemorySet(set);
 
         if (memorySet != null) {
-            Iterator<Card> it = memorySet.iterator();
-
-            while (it.hasNext()) {
-                Card c = it.next();
+            for (Card c : memorySet) {
                 if (c.getName().equals(cardName)) {
                     return true;
                 }
@@ -191,10 +188,7 @@ public class AiCardMemory {
         Set<Card> memorySet = getMemorySet(set);
 
         if (memorySet != null) {
-            Iterator<Card> it = memorySet.iterator();
-
-            while (it.hasNext()) {
-                Card c = it.next();
+            for (Card c : memorySet) {
                 if (c.getName().equals(cardName) && c.getOwner().equals(owner)) {
                     return true;
                 }
@@ -259,10 +253,7 @@ public class AiCardMemory {
         Set<Card> memorySet = getMemorySet(set);
 
         if (memorySet != null) {
-            Iterator<Card> it = memorySet.iterator();
-
-            while (it.hasNext()) {
-                Card c = it.next();
+            for (Card c : memorySet) {
                 if (c.getName().equals(cardName)) {
                     return forgetCard(c, set);
                 }
@@ -284,10 +275,7 @@ public class AiCardMemory {
         Set<Card> memorySet = getMemorySet(set);
 
         if (memorySet != null) {
-            Iterator<Card> it = memorySet.iterator();
-
-            while (it.hasNext()) {
-                Card c = it.next();
+            for (Card c : memorySet) {
                 if (c.getName().equals(cardName) && c.getOwner().equals(owner)) {
                     return forgetCard(c, set);
                 }

--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -2112,9 +2112,9 @@ public class AiController {
         }
 
         // add the rest of land to the end of the deck
-        for (int i = 0; i < land.size(); i++) {
-            if (!library.contains(land.get(i))) {
-                library.add(land.get(i));
+        for (Card card : land) {
+            if (!library.contains(card)) {
+                library.add(card);
             }
         }
 

--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -1996,7 +1996,7 @@ public class AiController {
                 break;
             case FlipOntoBattlefield:
                 if ("DamageCreatures".equals(sa.getParam("AILogic"))) {
-                    int maxToughness = Integer.valueOf(sa.getSubAbility().getParam("NumDmg"));
+                    int maxToughness = Integer.parseInt(sa.getSubAbility().getParam("NumDmg"));
                     CardCollectionView rightToughness = CardLists.filter(pool, new Predicate<Card>() {
                         @Override
                         public boolean apply(Card card) {

--- a/forge-ai/src/main/java/forge/ai/AiProfileUtil.java
+++ b/forge-ai/src/main/java/forge/ai/AiProfileUtil.java
@@ -147,9 +147,9 @@ public class AiProfileUtil {
         if (children == null) {
             System.err.println("AIProfile > can't find AI profile directory!");
         } else {
-            for (int i = 0; i < children.length; i++) {
-                if (children[i].endsWith(AI_PROFILE_EXT)) {
-                    availableProfiles.add(children[i].substring(0, children[i].length() - AI_PROFILE_EXT.length()));
+            for (String child : children) {
+                if (child.endsWith(AI_PROFILE_EXT)) {
+                    availableProfiles.add(child.substring(0, child.length() - AI_PROFILE_EXT.length()));
                 }
             }
         }

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
@@ -983,11 +983,11 @@ public class ComputerUtilCard {
 
         for (final Card crd : list) {
             ColorSet color = crd.getColor();
-            if (color.hasWhite()) map.get(0).setValue(Integer.valueOf(map.get(0).getValue() + 1));
-            if (color.hasBlue()) map.get(1).setValue(Integer.valueOf(map.get(1).getValue() + 1));
-            if (color.hasBlack()) map.get(2).setValue(Integer.valueOf(map.get(2).getValue() + 1));
-            if (color.hasRed()) map.get(3).setValue(Integer.valueOf(map.get(3).getValue() + 1));
-            if (color.hasGreen()) map.get(4).setValue(Integer.valueOf(map.get(4).getValue() + 1));
+            if (color.hasWhite()) map.get(0).setValue(map.get(0).getValue() + 1);
+            if (color.hasBlue()) map.get(1).setValue(map.get(1).getValue() + 1);
+            if (color.hasBlack()) map.get(2).setValue(map.get(2).getValue() + 1);
+            if (color.hasRed()) map.get(3).setValue(map.get(3).getValue() + 1);
+            if (color.hasGreen()) map.get(4).setValue(map.get(4).getValue() + 1);
         }
 
         Collections.sort(map, new Comparator<Pair<Byte, Integer>>() {

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
@@ -710,7 +710,7 @@ public class ComputerUtilCost {
         } else if ("LowPriority".equals(aiLogic) && MyRandom.getRandom().nextInt(100) < 67) {
             return false;
         } else if (aiLogic != null && aiLogic.startsWith("Fabricate")) {
-            final int n = Integer.valueOf(aiLogic.substring("Fabricate".length()));
+            final int n = Integer.parseInt(aiLogic.substring("Fabricate".length()));
 
             // if host would leave the play or if host is useless, create tokens
             if (source.hasSVar("EndOfTurnLeavePlay") || ComputerUtilCard.isUselessCreature(payer, source)) {

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
@@ -491,7 +491,7 @@ public class ComputerUtilMana {
         if (!replaceAmount.isEmpty()) {
             int totalAmount = 1;
             for (SpellAbility saMana : replaceAmount) {
-                totalAmount *= Integer.valueOf(saMana.getParam("ReplaceAmount"));
+                totalAmount *= Integer.parseInt(saMana.getParam("ReplaceAmount"));
             }
             manaProduced = StringUtils.repeat(manaProduced, " ", totalAmount);
         }

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
@@ -222,8 +222,7 @@ public class ComputerUtilMana {
                     for (int i = 0; i < preferredShardAmount && i < prefSortedAbilities.size(); i++) {
                         finalAbilities.add(prefSortedAbilities.get(i));
                     }
-                    for (int i = 0; i < otherSortedAbilities.size(); i++) {
-                        SpellAbility ab = otherSortedAbilities.get(i);
+                    for (SpellAbility ab : otherSortedAbilities) {
                         if (!finalAbilities.contains(ab))
                             finalAbilities.add(ab);
                     }

--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -965,7 +965,7 @@ public class PlayerControllerAi extends PlayerController {
                             break;
                     }
                 }
-                return defaultVal != null && defaultVal.booleanValue();
+                return defaultVal != null && defaultVal;
             case UntapTimeVault: return false; // TODO Should AI skip his turn for time vault?
             case LeftOrRight: return brains.chooseDirection(sa);
             case OddsOrEvens: return brains.chooseEvenOdd(sa); // false is Odd, true is Even

--- a/forge-ai/src/main/java/forge/ai/ability/AlterAttributeAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/AlterAttributeAi.java
@@ -18,7 +18,7 @@ public class AlterAttributeAi extends SpellAbilityAi {
     @Override
     protected boolean checkApiLogic(Player aiPlayer, SpellAbility sa) {
         final Card source = sa.getHostCard();
-        boolean activate = Boolean.valueOf(sa.getParamOrDefault("Activate", "true"));
+        boolean activate = Boolean.parseBoolean(sa.getParamOrDefault("Activate", "true"));
         String[] attributes = sa.getParam("Attributes").split(",");
 
         if (sa.usesTargeting()) {
@@ -91,7 +91,7 @@ public class AlterAttributeAi extends SpellAbilityAi {
 
     @Override
     public boolean confirmAction(Player player, SpellAbility sa, PlayerActionConfirmMode mode, String message, Map<String, Object> params) {
-        boolean activate = Boolean.valueOf(sa.getParamOrDefault("Activate", "true"));
+        boolean activate = Boolean.parseBoolean(sa.getParamOrDefault("Activate", "true"));
         String[] attributes = sa.getParam("Attributes").split(",");
 
         for (String attr : attributes) {

--- a/forge-ai/src/main/java/forge/ai/ability/AttachAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/AttachAi.java
@@ -410,9 +410,7 @@ public class AttachAi extends SpellAbilityAi {
                 }
 
                 final Iterable<Card> auras = c.getEnchantedBy();
-                final Iterator<Card> itr = auras.iterator();
-                while (itr.hasNext()) {
-                    final Card aura = itr.next();
+                for (Card aura : auras) {
                     SpellAbility auraSA = aura.getSpells().get(0);
                     if (auraSA.getApi() == ApiType.Attach) {
                         if ("KeepTapped".equals(auraSA.getParam("AILogic"))) {

--- a/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
@@ -1390,7 +1390,7 @@ public class ChangeZoneAi extends SpellAbilityAi {
                 aiPlaneswalkers.sort(CardPredicates.compareByCounterType(CounterEnumType.LOYALTY));
                 for (Card pw : aiPlaneswalkers) {
                     int curLoyalty = pw.getCounters(CounterEnumType.LOYALTY);
-                    int freshLoyalty = Integer.valueOf(pw.getCurrentState().getBaseLoyalty());
+                    int freshLoyalty = Integer.parseInt(pw.getCurrentState().getBaseLoyalty());
                     if (freshLoyalty - curLoyalty >= loyaltyDiff && curLoyalty <= maxLoyaltyToConsider) {
                         return pw;
                     }
@@ -1748,7 +1748,7 @@ public class ChangeZoneAi extends SpellAbilityAi {
                         }
                         if (MyRandom.percentTrue(chance)) {
                             int curLoyalty = card.getCounters(CounterEnumType.LOYALTY);
-                            int freshLoyalty = Integer.valueOf(card.getCurrentState().getBaseLoyalty());
+                            int freshLoyalty = Integer.parseInt(card.getCurrentState().getBaseLoyalty());
                             if (freshLoyalty - curLoyalty >= loyaltyDiff && curLoyalty <= maxLoyaltyToConsider) {
                                 return true;
                             }

--- a/forge-ai/src/main/java/forge/ai/ability/EffectAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/EffectAi.java
@@ -308,7 +308,7 @@ public class EffectAi extends SpellAbilityAi {
                 }
                 if (logic.contains(":")) {
                     String[] k = logic.split(":");
-                    Integer i = Integer.valueOf(k[1]);
+                    int i = Integer.parseInt(k[1]);
                     return ai.getCreaturesInPlay().size() >= i;
                 }
                 return true;

--- a/forge-ai/src/main/java/forge/ai/ability/FlipOntoBattlefieldAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/FlipOntoBattlefieldAi.java
@@ -25,7 +25,7 @@ public class FlipOntoBattlefieldAi extends SpellAbilityAi {
         }
 
         if ("DamageCreatures".equals(logic)) {
-            int maxToughness = Integer.valueOf(sa.getSubAbility().getParam("NumDmg"));
+            int maxToughness = Integer.parseInt(sa.getSubAbility().getParam("NumDmg"));
             CardCollectionView rightToughness = CardLists.filter(aiPlayer.getOpponents().getCreaturesInPlay(), new Predicate<Card>() {
                 @Override
                 public boolean apply(Card card) {

--- a/forge-ai/src/main/java/forge/ai/ability/ManaAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ManaAi.java
@@ -169,7 +169,7 @@ public class ManaAi extends SpellAbilityAi {
             numCounters = host.getCounters(ctrType);
             manaReceived = numCounters;
             if (logic.startsWith("ManaRitualBattery.")) {
-                manaSurplus = Integer.valueOf(logic.substring(18)); // adds an extra mana even if no counters removed
+                manaSurplus = Integer.parseInt(logic.substring(18)); // adds an extra mana even if no counters removed
                 manaReceived += manaSurplus;
             }
         }

--- a/forge-ai/src/main/java/forge/ai/ability/TapAllAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/TapAllAi.java
@@ -52,7 +52,7 @@ public class TapAllAi extends SpellAbilityAi {
         if (sa.hasParam("AILogic")) {
             String logic = sa.getParam("AILogic");
             if (logic.startsWith("AtLeast")) {
-                Integer num = AbilityUtils.calculateAmount(source, logic.substring(7), sa);
+                int num = AbilityUtils.calculateAmount(source, logic.substring(7), sa);
                 if (validTappables.size() < num) {
                     return false;
                 }

--- a/forge-core/src/main/java/forge/CardStorageReader.java
+++ b/forge-core/src/main/java/forge/CardStorageReader.java
@@ -421,24 +421,11 @@ public class CardStorageReader {
      * @return a new Card instance
      */
     protected final CardRules loadCard(final CardRules.Reader rulesReader, final ZipEntry entry) {
-        InputStream zipInputStream = null;
-        try {
-            zipInputStream = this.zip.getInputStream(entry);
+        try (InputStream zipInputStream = this.zip.getInputStream(entry)) {
             rulesReader.reset();
-
             return rulesReader.readCard(readScript(zipInputStream), Files.getNameWithoutExtension(entry.getName()));
         } catch (final IOException exn) {
             throw new RuntimeException(exn);
-            // PM
-        } finally {
-            try {
-                if (zipInputStream != null) {
-                    zipInputStream.close();
-                }
-            } catch (final IOException ignored) {
-                // 11:08
-                // PM
-            }
         }
     }
 

--- a/forge-core/src/main/java/forge/card/CardAiHints.java
+++ b/forge-core/src/main/java/forge/card/CardAiHints.java
@@ -78,13 +78,13 @@ public class CardAiHints {
      */
     public Integer getAiStatusComparable() {
         if (this.isRemovedFromAIDecks && this.isRemovedFromRandomDecks) {
-            return Integer.valueOf(3);
+            return 3;
         } else if (this.isRemovedFromAIDecks) {
-            return Integer.valueOf(4);
+            return 4;
         } else if (this.isRemovedFromRandomDecks) {
-            return Integer.valueOf(2);
+            return 2;
         } else {
-            return Integer.valueOf(1);
+            return 1;
         }
     }
 

--- a/forge-core/src/main/java/forge/card/mana/ManaCost.java
+++ b/forge-core/src/main/java/forge/card/mana/ManaCost.java
@@ -242,7 +242,7 @@ public final class ManaCost implements Comparable<ManaCost>, Iterable<ManaCostSh
             if (this.hasNoCost) {
                 weight = -1; // for those who doesn't even have a 0 sign on card
             }
-            this.compareWeight = Float.valueOf(weight);
+            this.compareWeight = weight;
         }
         return this.compareWeight;
     }

--- a/forge-core/src/main/java/forge/deck/CardPool.java
+++ b/forge-core/src/main/java/forge/deck/CardPool.java
@@ -468,9 +468,7 @@ public class CardPool extends ItemPool<PaperCard> {
      */
     public CardPool getFilteredPool(Predicate<PaperCard> predicate) {
         CardPool filteredPool = new CardPool();
-        Iterator<PaperCard> cardsInPool = this.items.keySet().iterator();
-        while (cardsInPool.hasNext()) {
-            PaperCard c = cardsInPool.next();
+        for (PaperCard c : this.items.keySet()) {
             if (predicate.apply(c))
                 filteredPool.add(c, this.items.get(c));
         }

--- a/forge-core/src/main/java/forge/deck/DeckGroup.java
+++ b/forge-core/src/main/java/forge/deck/DeckGroup.java
@@ -100,8 +100,7 @@ public class DeckGroup extends DeckBase {
         DeckGroup myClone = (DeckGroup) clone;
         myClone.setHumanDeck((Deck) humanDeck.copyTo(getName())); //human deck name should always match DeckGroup name
 
-        for (int i = 0; i < aiDecks.size(); i++) {
-            Deck src = aiDecks.get(i);
+        for (Deck src : aiDecks) {
             myClone.addAiDeck((Deck) src.copyTo(src.getName()));
         }
     }

--- a/forge-core/src/main/java/forge/deck/generation/DeckGeneratorBase.java
+++ b/forge-core/src/main/java/forge/deck/generation/DeckGeneratorBase.java
@@ -267,9 +267,9 @@ public abstract class DeckGeneratorBase {
 
         for (ImmutablePair<FilterCMC, Integer> pair : cmcLevels) {
             Iterable<PaperCard> matchingCards = Iterables.filter(source, Predicates.compose(pair.getLeft(), PaperCard.FN_GET_RULES));
-            int cmcCountForPool = (int) Math.ceil(pair.getRight().intValue() * desiredOverTotal);
+            int cmcCountForPool = (int) Math.ceil(pair.getRight() * desiredOverTotal);
             
-            int addOfThisCmc = Math.round(pair.getRight().intValue() * requestedOverTotal);
+            int addOfThisCmc = Math.round(pair.getRight() * requestedOverTotal);
             trace.append(String.format("Adding %d cards for cmc range from a pool with %d cards:%n", addOfThisCmc, cmcCountForPool));
 
             final List<PaperCard> curved = Aggregates.random(matchingCards, cmcCountForPool);
@@ -332,7 +332,7 @@ public abstract class DeckGeneratorBase {
 
     protected static void increment(Map<String, Integer> map, String key, int delta) {
         final Integer boxed = map.get(key);
-        map.put(key, boxed == null ? delta : boxed.intValue() + delta);
+        map.put(key, boxed == null ? delta : boxed + delta);
     }
 
     public static final Predicate<CardRules> AI_CAN_PLAY = Predicates.and(CardRulesPredicates.IS_KEPT_IN_AI_DECKS, CardRulesPredicates.IS_KEPT_IN_RANDOM_DECKS);

--- a/forge-core/src/main/java/forge/util/Aggregates.java
+++ b/forge-core/src/main/java/forge/util/Aggregates.java
@@ -213,8 +213,8 @@ public class Aggregates {
             U k = fnGetField.apply(kv.getKey());
             Integer v = kv.getValue();
             Integer sum = result.get(k);
-            int n = v == null ? 0 : v.intValue();
-            int s = sum == null ? 0 : sum.intValue();
+            int n = v == null ? 0 : v;
+            int s = sum == null ? 0 : sum;
             result.put(k, s + n);
         }
         return result.entrySet();

--- a/forge-core/src/main/java/forge/util/Aggregates.java
+++ b/forge-core/src/main/java/forge/util/Aggregates.java
@@ -215,7 +215,7 @@ public class Aggregates {
             Integer sum = result.get(k);
             int n = v == null ? 0 : v.intValue();
             int s = sum == null ? 0 : sum.intValue();
-            result.put(k, Integer.valueOf(s + n)); 
+            result.put(k, s + n);
         }
         return result.entrySet();
     }

--- a/forge-core/src/main/java/forge/util/Base64Coder.java
+++ b/forge-core/src/main/java/forge/util/Base64Coder.java
@@ -63,7 +63,7 @@ public final class Base64Coder {
      * Constant.
      * <code>systemLineSeparator="System.getProperty(line.separator)"</code>
      */
-    private static final String SYSTEM_LINE_SEPARATOR = System.getProperty("line.separator");
+    private static final String SYSTEM_LINE_SEPARATOR = System.lineSeparator();
 
     // Mapping table from 6-bit nibbles to Base64 characters.
     /** Constant <code>map1=new char[64]</code>. */

--- a/forge-core/src/main/java/forge/util/Base64Coder.java
+++ b/forge-core/src/main/java/forge/util/Base64Coder.java
@@ -32,6 +32,7 @@
 package forge.util;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
@@ -89,9 +90,7 @@ public final class Base64Coder {
     private static byte[] map2 = new byte[128];
 
     static {
-        for (int i = 0; i < Base64Coder.map2.length; i++) {
-            Base64Coder.map2[i] = -1;
-        }
+        Arrays.fill(Base64Coder.map2, (byte) -1);
         for (int i = 0; i < 64; i++) {
             Base64Coder.map2[Base64Coder.map1[i]] = (byte) i;
         }

--- a/forge-core/src/main/java/forge/util/ItemPool.java
+++ b/forge-core/src/main/java/forge/util/ItemPool.java
@@ -90,7 +90,7 @@ public class ItemPool<T extends InventoryItem> implements Iterable<Entry<T, Inte
         if (from != null) {
             for (final Tin srcKey : from) {
                 if (clsHint.isInstance(srcKey)) {
-                    result.add((Tout) srcKey, Integer.valueOf(1));
+                    result.add((Tout) srcKey, 1);
                 }
             }
         }

--- a/forge-core/src/main/java/forge/util/ItemPool.java
+++ b/forge-core/src/main/java/forge/util/ItemPool.java
@@ -126,7 +126,7 @@ public class ItemPool<T extends InventoryItem> implements Iterable<Entry<T, Inte
             return 0;
         }
         final Integer boxed = items.get(item);
-        return boxed == null ? 0 : boxed.intValue();
+        return boxed == null ? 0 : boxed;
     }
 
     public final int countAll() {

--- a/forge-core/src/main/java/forge/util/TextUtil.java
+++ b/forge-core/src/main/java/forge/util/TextUtil.java
@@ -355,9 +355,7 @@ public class TextUtil {
      * @return The sort-friendly name of the card. Example: "The Hive" becomes "Hive The".
      */
     public static String moveArticleToEnd(String str) {
-        String articleWord;
-        for (int i = 0; i < ARTICLE_WORDS.length; i++) {
-            articleWord = ARTICLE_WORDS[i];
+        for (String articleWord : ARTICLE_WORDS) {
             if (str.startsWith(articleWord + " ")) {
                 str = str.substring(articleWord.length() + 1) + " " + articleWord;
                 return str;

--- a/forge-core/src/main/java/forge/util/maps/EnumMapToAmount.java
+++ b/forge-core/src/main/java/forge/util/maps/EnumMapToAmount.java
@@ -33,7 +33,7 @@ public class EnumMapToAmount<T extends Enum<T>> extends EnumMap<T, Integer> impl
         if (amount <= 0) { return; } // throw an exception maybe?
         Integer cur = get(item);
         int newVal = cur == null ? amount : amount + cur.intValue();
-        put(item, Integer.valueOf(newVal));
+        put(item, newVal);
     }
 
     @Override
@@ -54,7 +54,7 @@ public class EnumMapToAmount<T extends Enum<T>> extends EnumMap<T, Integer> impl
         if (cur == null) { return false; }
         int newVal = cur.intValue() - amount;
         if (newVal > 0) {
-            put(item, Integer.valueOf(newVal));
+            put(item, newVal);
         }
         else {
             remove(item);

--- a/forge-core/src/main/java/forge/util/maps/EnumMapToAmount.java
+++ b/forge-core/src/main/java/forge/util/maps/EnumMapToAmount.java
@@ -32,7 +32,7 @@ public class EnumMapToAmount<T extends Enum<T>> extends EnumMap<T, Integer> impl
     public void add(T item, int amount) {
         if (amount <= 0) { return; } // throw an exception maybe?
         Integer cur = get(item);
-        int newVal = cur == null ? amount : amount + cur.intValue();
+        int newVal = cur == null ? amount : amount + cur;
         put(item, newVal);
     }
 
@@ -52,7 +52,7 @@ public class EnumMapToAmount<T extends Enum<T>> extends EnumMap<T, Integer> impl
     public boolean substract(T item, int amount) {
         Integer cur = get(item);
         if (cur == null) { return false; }
-        int newVal = cur.intValue() - amount;
+        int newVal = cur - amount;
         if (newVal > 0) {
             put(item, newVal);
         }
@@ -73,7 +73,7 @@ public class EnumMapToAmount<T extends Enum<T>> extends EnumMap<T, Integer> impl
     public int countAll() {
         int c = 0;
         for (java.util.Map.Entry<T, Integer> kv : this.entrySet()) {
-            c += kv.getValue().intValue();
+            c += kv.getValue();
         }
         return c;
     }
@@ -81,6 +81,6 @@ public class EnumMapToAmount<T extends Enum<T>> extends EnumMap<T, Integer> impl
     @Override
     public int count(T item) {
         Integer cur = get(item);
-        return cur == null ? 0 : cur.intValue();
+        return cur == null ? 0 : cur;
     }
 }

--- a/forge-core/src/main/java/forge/util/maps/LinkedHashMapToAmount.java
+++ b/forge-core/src/main/java/forge/util/maps/LinkedHashMapToAmount.java
@@ -55,7 +55,7 @@ public class LinkedHashMapToAmount<T> extends LinkedHashMap<T, Integer> implemen
     public void add(final T item, final int amount) {
         if (amount <= 0) { return; } // throw an exception maybe?
         Integer cur = get(item);
-        int newVal = cur == null ? amount : amount + cur.intValue();
+        int newVal = cur == null ? amount : amount + cur;
         put(item, newVal);
     }
 
@@ -75,7 +75,7 @@ public class LinkedHashMapToAmount<T> extends LinkedHashMap<T, Integer> implemen
     public boolean substract(final T item, final int amount) {
         Integer cur = get(item);
         if (cur == null) { return false; }
-        int newVal = cur.intValue() - amount;
+        int newVal = cur - amount;
         if (newVal > 0) {
             put(item, newVal);
         } else {
@@ -95,7 +95,7 @@ public class LinkedHashMapToAmount<T> extends LinkedHashMap<T, Integer> implemen
     public int countAll() {
         int c = 0;
         for (java.util.Map.Entry<T, Integer> kv : this.entrySet()) {
-            c += kv.getValue().intValue();
+            c += kv.getValue();
         }
         return c;
     }
@@ -103,7 +103,7 @@ public class LinkedHashMapToAmount<T> extends LinkedHashMap<T, Integer> implemen
     @Override
     public int count(final T item) {
         Integer cur = get(item);
-        return cur == null ? 0 : cur.intValue();
+        return cur == null ? 0 : cur;
     }
     
 }

--- a/forge-core/src/main/java/forge/util/maps/LinkedHashMapToAmount.java
+++ b/forge-core/src/main/java/forge/util/maps/LinkedHashMapToAmount.java
@@ -56,7 +56,7 @@ public class LinkedHashMapToAmount<T> extends LinkedHashMap<T, Integer> implemen
         if (amount <= 0) { return; } // throw an exception maybe?
         Integer cur = get(item);
         int newVal = cur == null ? amount : amount + cur.intValue();
-        put(item, Integer.valueOf(newVal));
+        put(item, newVal);
     }
 
     @Override
@@ -77,7 +77,7 @@ public class LinkedHashMapToAmount<T> extends LinkedHashMap<T, Integer> implemen
         if (cur == null) { return false; }
         int newVal = cur.intValue() - amount;
         if (newVal > 0) {
-            put(item, Integer.valueOf(newVal));
+            put(item, newVal);
         } else {
             remove(item);
         }

--- a/forge-core/src/main/java/forge/util/maps/MapToAmountUtil.java
+++ b/forge-core/src/main/java/forge/util/maps/MapToAmountUtil.java
@@ -43,7 +43,7 @@ public final class MapToAmountUtil {
                 maxElement = entry.getKey();
             }
         }
-        return Pair.of(maxElement, Integer.valueOf(max));
+        return Pair.of(maxElement, max);
     }
 
     /**
@@ -98,7 +98,7 @@ public final class MapToAmountUtil {
                 minElement = entry.getKey();
             }
         }
-        return Pair.of(minElement, Integer.valueOf(min));
+        return Pair.of(minElement, min);
     }
 
     /**

--- a/forge-core/src/main/java/forge/util/maps/MapToAmountUtil.java
+++ b/forge-core/src/main/java/forge/util/maps/MapToAmountUtil.java
@@ -38,8 +38,8 @@ public final class MapToAmountUtil {
         int max = Integer.MIN_VALUE;
         T maxElement = null;
         for (final Entry<T, Integer> entry : map.entrySet()) {
-            if (entry.getValue().intValue() > max) {
-                max = entry.getValue().intValue();
+            if (entry.getValue() > max) {
+                max = entry.getValue();
                 maxElement = entry.getKey();
             }
         }
@@ -67,7 +67,7 @@ public final class MapToAmountUtil {
         final int max = Collections.max(map.values());
         final FCollection<T> set = new FCollection<>();
         for (final Entry<T, Integer> entry : map.entrySet()) {
-            if (entry.getValue().intValue() == max) {
+            if (entry.getValue() == max) {
                 set.add(entry.getKey());
             }
         }
@@ -93,8 +93,8 @@ public final class MapToAmountUtil {
         int min = Integer.MAX_VALUE;
         T minElement = null;
         for (final Entry<T, Integer> entry : map.entrySet()) {
-            if (entry.getValue().intValue() < min) {
-                min = entry.getValue().intValue();
+            if (entry.getValue() < min) {
+                min = entry.getValue();
                 minElement = entry.getKey();
             }
         }
@@ -122,7 +122,7 @@ public final class MapToAmountUtil {
         final int min = Collections.min(map.values());
         final FCollection<T> set = new FCollection<>();
         for (final Entry<T, Integer> entry : map.entrySet()) {
-            if (entry.getValue().intValue() == min) {
+            if (entry.getValue() == min) {
                 set.add(entry.getKey());
             }
         }

--- a/forge-game/src/main/java/forge/game/Game.java
+++ b/forge-game/src/main/java/forge/game/Game.java
@@ -259,7 +259,7 @@ public class Game {
 
 
     public void addPlayer(int id, Player player) {
-        playerCache.put(Integer.valueOf(id), player);
+        playerCache.put(id, player);
     }
 
     // methods that deal with saving, retrieving and clearing LKI information about cards on zone change
@@ -1320,7 +1320,7 @@ public class Game {
         }
     }
     public void addFacedownWhileCasting(Card c, int numDrawn) {
-        facedownWhileCasting.put(c, Integer.valueOf(numDrawn));
+        facedownWhileCasting.put(c, numDrawn);
     }
 
     public boolean isDay() {

--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -2065,7 +2065,7 @@ public class GameAction {
         if (landCount == 0) {
             return 0;
         }
-        return Float.valueOf(landCount)/Float.valueOf(deck.size());
+        return ((float) landCount) / ((float) deck.size());
     }
 
     private float getHandScore(List<Card> hand, float landRatio) {
@@ -2514,7 +2514,7 @@ public class GameAction {
                     lethalDamage.put(c, c.getExcessDamageValue(false));
                 }
 
-                e.setValue(Integer.valueOf(e.getKey().addDamageAfterPrevention(e.getValue(), sourceLKI, cause, isCombat, counterTable)));
+                e.setValue(e.getKey().addDamageAfterPrevention(e.getValue(), sourceLKI, cause, isCombat, counterTable));
                 sum += e.getValue();
 
                 sourceLKI.getDamageHistory().registerDamage(e.getValue(), isCombat, sourceLKI, e.getKey(), lkiCache);
@@ -2648,7 +2648,7 @@ public class GameAction {
 
     private static void unanimateOnAbortedChange(final SpellAbility cause, final Card c) {
         if (cause.hasParam("AnimateSubAbility")) {
-            long unanimateTimestamp = Long.valueOf(cause.getAdditionalAbility("AnimateSubAbility").getSVar("unanimateTimestamp"));
+            long unanimateTimestamp = Long.parseLong(cause.getAdditionalAbility("AnimateSubAbility").getSVar("unanimateTimestamp"));
             c.removeChangedCardKeywords(unanimateTimestamp, 0);
             c.removeChangedCardTypes(unanimateTimestamp, 0);
             c.removeChangedName(unanimateTimestamp, 0);

--- a/forge-game/src/main/java/forge/game/GameActionUtil.java
+++ b/forge-game/src/main/java/forge/game/GameActionUtil.java
@@ -887,7 +887,7 @@ public final class GameActionUtil {
             // skip GameAction
             oldCard.getZone().remove(oldCard);
             // in some rare cases the old position no longer exists (Panglacial Wurm + Selvala)
-            Integer newPosition = zonePosition >= 0 ? Math.min(Integer.valueOf(zonePosition), fromZone.size()) : null;
+            Integer newPosition = zonePosition >= 0 ? Math.min(zonePosition, fromZone.size()) : null;
             fromZone.add(oldCard, newPosition, null, true);
             ability.setHostCard(oldCard);
             ability.setXManaCostPaid(null);

--- a/forge-game/src/main/java/forge/game/GameActionUtil.java
+++ b/forge-game/src/main/java/forge/game/GameActionUtil.java
@@ -211,8 +211,8 @@ public final class GameActionUtil {
                         && source.isForetold() && !source.enteredThisTurn() && !source.getManaCost().isNoCost()) {
                     // Its foretell cost is equal to its mana cost reduced by {2}.
                     final SpellAbility foretold = sa.copy(activator);
-                    Integer reduced = Math.min(2, sa.getPayCosts().getCostMana().getMana().getGenericCost());
-                    foretold.putParam("ReduceCost", reduced.toString());
+                    int reduced = Math.min(2, sa.getPayCosts().getCostMana().getMana().getGenericCost());
+                    foretold.putParam("ReduceCost", Integer.toString(reduced));
                     foretold.setAlternativeCost(AlternativeCost.Foretold);
                     foretold.getRestrictions().setZone(ZoneType.Exile);
                     foretold.putParam("AfterDescription", "(Foretold)");

--- a/forge-game/src/main/java/forge/game/GameEntityCounterTable.java
+++ b/forge-game/src/main/java/forge/game/GameEntityCounterTable.java
@@ -78,7 +78,7 @@ public class GameEntityCounterTable extends ForwardingTable<Optional<Player>, Ga
         }
         Map<CounterType, Integer> alreadyRemoved = column(ge).get(Optional.absent());
         for (Map.Entry<CounterType, Integer> e : ge.getCounters().entrySet()) {
-            Integer rest = e.getValue() - (alreadyRemoved.containsKey(e.getKey()) ? alreadyRemoved.get(e.getKey()) : 0);
+            int rest = e.getValue() - (alreadyRemoved.containsKey(e.getKey()) ? alreadyRemoved.get(e.getKey()) : 0);
             if (rest > 0) {
                 result.put(e.getKey(), rest);
             }

--- a/forge-game/src/main/java/forge/game/GameFormat.java
+++ b/forge-game/src/main/java/forge/game/GameFormat.java
@@ -410,7 +410,7 @@ public class GameFormat implements Comparable<GameFormat> {
             } catch (Exception e) {
                 formatsubType = FormatSubType.CUSTOM;
             }
-            Integer idx = section.getInt("order");
+            int idx = section.getInt("order");
             String dateStr = section.get("effective");
             if (dateStr == null){
                 dateStr = DEFAULTDATE;

--- a/forge-game/src/main/java/forge/game/IIdentifiable.java
+++ b/forge-game/src/main/java/forge/game/IIdentifiable.java
@@ -7,7 +7,7 @@ public interface IIdentifiable {
     Function<IIdentifiable, Integer> FN_GET_ID = new Function<IIdentifiable, Integer>() {
         @Override
         public Integer apply(final IIdentifiable input) {
-            return Integer.valueOf(input.getId());
+            return input.getId();
         }
     };
 }

--- a/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
@@ -310,7 +310,7 @@ public class AbilityUtils {
         } else if (defined.startsWith("CardUID_")) {
             String idString = defined.substring(8);
             for (final Card cardByID : game.getCardsInGame()) {
-                if (cardByID.getId() == Integer.valueOf(idString)) {
+                if (cardByID.getId() == Integer.parseInt(idString)) {
                     cards.add(game.getCardState(cardByID));
                 }
             }

--- a/forge-game/src/main/java/forge/game/ability/effects/AlterAttributeEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/AlterAttributeEffect.java
@@ -15,7 +15,7 @@ import forge.util.TextUtil;
 public class AlterAttributeEffect extends SpellAbilityEffect {
     @Override
     public void resolve(SpellAbility sa) {
-        boolean activate = Boolean.valueOf(sa.getParamOrDefault("Activate", "true"));
+        boolean activate = Boolean.parseBoolean(sa.getParamOrDefault("Activate", "true"));
         String[] attributes = sa.getParam("Attributes").split(",");
         CardCollection defined = getDefinedCardsOrTargeted(sa, "Defined");
 

--- a/forge-game/src/main/java/forge/game/ability/effects/CamouflageEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CamouflageEffect.java
@@ -90,7 +90,7 @@ public class CamouflageEffect extends SpellAbilityEffect {
                 // Remove chosen creatures, unless it can block additional attackers
                 for (final Card blocker : blockers) {
                     int index = pool.indexOf(blocker);
-                    Integer blockedCount = blockedSoFar.get(index) + 1;
+                    int blockedCount = blockedSoFar.get(index) + 1;
                     if (!blocker.canBlockAny() && blocker.canBlockAdditional() < blockedCount) {
                         pool.remove(index);
                         blockedSoFar.remove(index);

--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeTextEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeTextEffect.java
@@ -25,7 +25,7 @@ public class ChangeTextEffect extends SpellAbilityEffect {
     public void resolve(final SpellAbility sa) {
         final Card source = sa.getHostCard();
         final Game game = source.getGame();
-        final Long timestamp = Long.valueOf(game.getNextTimestamp());
+        final Long timestamp = game.getNextTimestamp();
         final boolean permanent = "Permanent".equals(sa.getParam("Duration"));
 
         final String changedColorWordOriginal, changedColorWordNew;

--- a/forge-game/src/main/java/forge/game/ability/effects/CloneEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CloneEffect.java
@@ -142,7 +142,7 @@ public class CloneEffect extends SpellAbilityEffect {
 
             game.getTriggerHandler().clearActiveTriggers(tgtCard, null);
 
-            final Long ts = game.getNextTimestamp();
+            final long ts = game.getNextTimestamp();
             tgtCard.addCloneState(CardFactory.getCloneStates(cardToCopy, tgtCard, sa), ts);
 
             // set ETB tapped of clone

--- a/forge-game/src/main/java/forge/game/ability/effects/CopyPermanentEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CopyPermanentEffect.java
@@ -228,7 +228,7 @@ public class CopyPermanentEffect extends TokenEffectBase {
                 }
             } else if (chosenMap) {
                 if (sa.hasParam("ChosenMapIndex")) {
-                    final int index = Integer.valueOf(sa.getParam("ChosenMapIndex"));
+                    final int index = Integer.parseInt(sa.getParam("ChosenMapIndex"));
                     if (index >= host.getChosenMap().get(controller).size()) continue;
                     tgtCards.add(host.getChosenMap().get(controller).get(index));
                 } else tgtCards = host.getChosenMap().get(controller);

--- a/forge-game/src/main/java/forge/game/ability/effects/CounterEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CounterEffect.java
@@ -61,7 +61,7 @@ public class CounterEffect extends SpellAbilityEffect {
             // currently all effects using this are targeted in case the spell gets countered before
             // so don't need to worry about LKI (else X amounts would be missing)
             if (sa.hasParam("RememberCounteredCMC")) {
-                sa.getHostCard().addRemembered(Integer.valueOf(tgtSACard.getCMC()));
+                sa.getHostCard().addRemembered(tgtSACard.getCMC());
             }
             if (sa.hasParam("RememberForCounter")) {
                 sa.getHostCard().addRemembered(tgtSACard);

--- a/forge-game/src/main/java/forge/game/ability/effects/CountersMultiplyEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CountersMultiplyEffect.java
@@ -42,7 +42,7 @@ public class CountersMultiplyEffect extends SpellAbilityEffect {
         final Player player = sa.getActivatingPlayer();
 
         final CounterType counterType = getCounterType(sa);
-        final int n = Integer.valueOf(sa.getParamOrDefault("Multiplier", "2")) - 1;
+        final int n = Integer.parseInt(sa.getParamOrDefault("Multiplier", "2")) - 1;
 
         GameEntityCounterTable table = new GameEntityCounterTable();
         for (final Card tgtCard : getTargetCards(sa)) {

--- a/forge-game/src/main/java/forge/game/ability/effects/CountersPutAllEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CountersPutAllEffect.java
@@ -84,7 +84,7 @@ public class CountersPutAllEffect extends SpellAbilityEffect  {
             }
             if (sa.hasParam("AmountByChosenMap")) {
                 final String[] parse = sa.getParam("AmountByChosenMap").split(" INDEX ");
-                final int index = parse.length > 1 ? Integer.valueOf(parse[1]) : 0;
+                final int index = parse.length > 1 ? Integer.parseInt(parse[1]) : 0;
                 if (index >= host.getChosenMap().get(placer).size()) continue;
                 final Card chosen = host.getChosenMap().get(placer).get(index);
                 counterAmount = AbilityUtils.xCount(chosen, parse[0], sa);

--- a/forge-game/src/main/java/forge/game/ability/effects/CountersPutEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CountersPutEffect.java
@@ -634,7 +634,7 @@ public class CountersPutEffect extends SpellAbilityEffect {
         int totalAdded = table.totalValues();
         if (totalAdded > 0 && rememberAmount) {
             // TODO use SpellAbility Remember later
-            card.addRemembered(Integer.valueOf(totalAdded));
+            card.addRemembered(totalAdded);
         }
 
         if (sa.hasParam("RemovePhase")) {

--- a/forge-game/src/main/java/forge/game/ability/effects/CountersRemoveAllEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CountersRemoveAllEffect.java
@@ -79,7 +79,7 @@ public class CountersRemoveAllEffect extends SpellAbilityEffect {
             }
         }
         if (sa.hasParam("RememberAmount")) {
-            sa.getHostCard().addRemembered(Integer.valueOf(numberRemoved));
+            sa.getHostCard().addRemembered(numberRemoved);
         }
     }
 }

--- a/forge-game/src/main/java/forge/game/ability/effects/CountersRemoveEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CountersRemoveEffect.java
@@ -208,7 +208,7 @@ public class CountersRemoveEffect extends SpellAbilityEffect {
 
         if (totalRemoved > 0 && rememberAmount) {
             // TODO use SpellAbility Remember later
-            card.addRemembered(Integer.valueOf(totalRemoved));
+            card.addRemembered(totalRemoved);
         }
     }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/DigMultipleEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DigMultipleEffect.java
@@ -172,8 +172,7 @@ public class DigMultipleEffect extends SpellAbilityEffect {
                     }
                 } else {
                     // just move them randomly
-                    for (int i = 0; i < rest.size(); i++) {
-                        Card c = rest.get(i);
+                    for (Card c : rest) {
                         final ZoneType origin = c.getZone().getZoneType();
                         final PlayerZone toZone = c.getOwner().getZone(destZone2);
                         c = game.getAction().moveTo(toZone, c, sa);

--- a/forge-game/src/main/java/forge/game/ability/effects/DrainManaEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DrainManaEffect.java
@@ -57,7 +57,7 @@ public class DrainManaEffect extends SpellAbilityEffect {
             sa.getActivatingPlayer().getManaPool().add(drained);
         }
         if (sa.hasParam("RememberDrainedMana")) {
-            sa.getHostCard().addRemembered(Integer.valueOf(drained.size()));
+            sa.getHostCard().addRemembered(drained.size());
         }
     }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/MutateEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/MutateEffect.java
@@ -65,7 +65,7 @@ public class MutateEffect extends SpellAbilityEffect {
         // First remove current mutated states
         target.removeMutatedStates();
         // Now add all abilities from bottom cards
-        final Long ts = game.getNextTimestamp();
+        final long ts = game.getNextTimestamp();
         target.setMutatedTimestamp(ts);
 
         target.addCloneState(CardFactory.getMutatedCloneStates(target, sa), ts);

--- a/forge-game/src/main/java/forge/game/ability/effects/ProtectAllEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ProtectAllEffect.java
@@ -45,7 +45,7 @@ public class ProtectAllEffect extends SpellAbilityEffect {
     public void resolve(SpellAbility sa) {
         final Card host = sa.getHostCard();
         final Game game = sa.getActivatingPlayer().getGame();
-        final Long timestamp = game.getNextTimestamp();
+        final long timestamp = game.getNextTimestamp();
 
         final boolean isChoice = sa.getParam("Gains").contains("Choice");
         final List<String> choices = ProtectEffect.getProtectionList(sa);

--- a/forge-game/src/main/java/forge/game/ability/effects/ProtectAllEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ProtectAllEffect.java
@@ -45,7 +45,7 @@ public class ProtectAllEffect extends SpellAbilityEffect {
     public void resolve(SpellAbility sa) {
         final Card host = sa.getHostCard();
         final Game game = sa.getActivatingPlayer().getGame();
-        final Long timestamp = Long.valueOf(game.getNextTimestamp());
+        final Long timestamp = game.getNextTimestamp();
 
         final boolean isChoice = sa.getParam("Gains").contains("Choice");
         final List<String> choices = ProtectEffect.getProtectionList(sa);

--- a/forge-game/src/main/java/forge/game/ability/effects/RepeatEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/RepeatEffect.java
@@ -29,7 +29,7 @@ public class RepeatEffect extends SpellAbilityEffect {
         Integer maxRepeat = null;
         if (sa.hasParam("MaxRepeat")) {
             maxRepeat = AbilityUtils.calculateAmount(source, sa.getParam("MaxRepeat"), sa);
-            if (maxRepeat.intValue() == 0) return; // do nothing if maxRepeat is 0. the next loop will execute at least once
+            if (maxRepeat == 0) return; // do nothing if maxRepeat is 0. the next loop will execute at least once
         }
 
         //execute repeat ability at least once

--- a/forge-game/src/main/java/forge/game/ability/effects/ReplaceManaEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ReplaceManaEffect.java
@@ -72,7 +72,7 @@ public class ReplaceManaEffect extends SpellAbilityEffect {
             }
         } else if (sa.hasParam("ReplaceAmount")) {
             // replace amount = multiples
-            replaced = StringUtils.repeat(replaced, " ", Integer.valueOf(sa.getParam("ReplaceAmount")));
+            replaced = StringUtils.repeat(replaced, " ", Integer.parseInt(sa.getParam("ReplaceAmount")));
         }
         params.put(AbilityKey.Mana, replaced);
         // effect was updated

--- a/forge-game/src/main/java/forge/game/ability/effects/RollDiceEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/RollDiceEffect.java
@@ -306,9 +306,9 @@ public class RollDiceEffect extends SpellAbilityEffect {
         }
         if (rememberHighest) {
             int highest = 0;
-            for (int i = 0; i < results.size(); ++i) {
-                if (highest < results.get(i)) {
-                    highest = results.get(i);
+            for (Integer result : results) {
+                if (highest < result) {
+                    highest = result;
                 }
             }
             for (int i = 0; i < results.size(); ++i) {

--- a/forge-game/src/main/java/forge/game/ability/effects/StoreSVarEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/StoreSVarEffect.java
@@ -43,7 +43,7 @@ public class StoreSVarEffect extends SpellAbilityEffect {
             value = AbilityUtils.xCount(source, expr, sa);
         }
         else if (type.equals("Number")) {
-            value = Integer.valueOf(expr);
+            value = Integer.parseInt(expr);
         }
         else if (type.equals("CountSVar")) {
             if (expr.contains("/")) {

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -7370,7 +7370,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
             incrementTransformedTimestamp();
         }
         if (sa.hasParam("Prototype") && prototypeTimestamp == -1) {
-            Long next = game.getNextTimestamp();
+            long next = game.getNextTimestamp();
             addCloneState(CardFactory.getCloneStates(this, this, sa), next);
             prototypeTimestamp = next;
         }

--- a/forge-game/src/main/java/forge/game/card/CardChangedWords.java
+++ b/forge-game/src/main/java/forge/game/card/CardChangedWords.java
@@ -33,14 +33,14 @@ public final class CardChangedWords extends ForwardingMap<String, String> {
     }
 
     public Long addEmpty(final long timestamp, final long staticId) {
-        final Long stamp = Long.valueOf(timestamp);
+        final Long stamp = timestamp;
         map.put(stamp, staticId, new WordHolder()); // Table doesn't allow null value
         isDirty = true;
         return stamp;
     }
 
     public Long add(final long timestamp, final long staticId, final String originalWord, final String newWord) {
-        final Long stamp = Long.valueOf(timestamp);
+        final Long stamp = timestamp;
         map.put(stamp, staticId, new WordHolder(originalWord, newWord));
         isDirty = true;
         return stamp;

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -271,9 +271,7 @@ public class CardFactoryUtil {
     public static byte getMostProminentColors(final Iterable<Card> list) {
         int cntColors = MagicColor.WUBRG.length;
         final Integer[] map = new Integer[cntColors];
-        for (int i = 0; i < cntColors; i++) {
-            map[i] = 0;
-        }
+        Arrays.fill(map, 0);
 
         for (final Card crd : list) {
             ColorSet color = crd.getColor();
@@ -309,9 +307,6 @@ public class CardFactoryUtil {
     public static int[] SortColorsFromList(final CardCollection list) {
         int cntColors = MagicColor.WUBRG.length;
         final int[] map = new int[cntColors];
-        for (int i = 0; i < cntColors; i++) {
-            map[i] = 0;
-        }
 
         for (final Card crd : list) {
             ColorSet color = crd.getColor();
@@ -339,10 +334,7 @@ public class CardFactoryUtil {
             colorRestrictions.add(MagicColor.fromName(col));
         }
         int cntColors = colorRestrictions.size();
-        final Integer[] map = new Integer[cntColors];
-        for (int i = 0; i < cntColors; i++) {
-            map[i] = 0;
-        }
+        final int[] map = new int[cntColors];
 
         for (final Card crd : list) {
             ColorSet color = crd.getColor();

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -927,7 +927,7 @@ public class CardFactoryUtil {
         } else if (keyword.startsWith("Chapter")) {
             final String[] k = keyword.split(":");
             final String[] abs = k[2].split(",");
-            if (abs.length != Integer.valueOf(k[1])) {
+            if (abs.length != Integer.parseInt(k[1])) {
                 throw new RuntimeException("Saga max differ from Ability amount");
             }
 
@@ -2789,7 +2789,7 @@ public class CardFactoryUtil {
             origSA.appendSubAbility(newSA);
         } else if (keyword.startsWith("Class")) {
             final String[] k = keyword.split(":");
-            final int level = Integer.valueOf(k[1]);
+            final int level = Integer.parseInt(k[1]);
 
             final StringBuilder sbClass = new StringBuilder();
             sbClass.append("AB$ ClassLevelUp | Cost$ ").append(k[2]);

--- a/forge-game/src/main/java/forge/game/card/CardView.java
+++ b/forge-game/src/main/java/forge/game/card/CardView.java
@@ -1081,7 +1081,7 @@ public class CardView extends GameEntityView {
         if (hiddenId == null) {
             return getId();
         }
-        return hiddenId.intValue();
+        return hiddenId;
     }
     void updateHiddenId(final int hiddenId) {
         set(TrackableProperty.HiddenId, hiddenId);

--- a/forge-game/src/main/java/forge/game/combat/AttackConstraints.java
+++ b/forge-game/src/main/java/forge/game/combat/AttackConstraints.java
@@ -75,7 +75,7 @@ public class AttackConstraints {
             final MapToAmount<Card> causesToAttack = new LinkedHashMapToAmount<>();
             for (final Entry<Card, Integer> entry : attacksIfOtherAttacks.entrySet()) {
                 if (entry.getKey() != possibleAttacker) {
-                    causesToAttack.add(entry.getKey(), entry.getValue().intValue());
+                    causesToAttack.add(entry.getKey(), entry.getValue());
                 }
             }
 
@@ -224,7 +224,7 @@ public class AttackConstraints {
                 }
             }
             final Integer defMax = globalRestrictions.getDefenderMax().get(req.defender);
-            if (defMax != null && toDefender.count(req.defender) >= defMax.intValue()) {
+            if (defMax != null && toDefender.count(req.defender) >= defMax) {
                 // too many to this defender already
                 skip = true;
             } else if (null != CombatUtil.getAttackCost(req.attacker.getGame(), req.attacker, req.defender)) {
@@ -254,7 +254,7 @@ public class AttackConstraints {
                 final List<Attack> clonedReqs = deepClone(reqs);
                 for (final Entry<Card, Integer> causesToAttack : requirement.getCausesToAttack().entrySet()) {
                     for (final Attack a : findAll(reqs, causesToAttack.getKey())) {
-                        a.requirements += causesToAttack.getValue().intValue();
+                        a.requirements += causesToAttack.getValue();
                     }
                 }
                 // if maximum < no of possible attackers, try both with and without this creature

--- a/forge-game/src/main/java/forge/game/combat/AttackConstraints.java
+++ b/forge-game/src/main/java/forge/game/combat/AttackConstraints.java
@@ -121,7 +121,7 @@ public class AttackConstraints {
         final int globalMax = globalRestrictions.getMax();
         final int myMax = Ints.min(globalMax == -1 ? Integer.MAX_VALUE : globalMax, possibleAttackers.size());
         if (myMax == 0) {
-            return Pair.of(Collections.emptyMap(), Integer.valueOf(0));
+            return Pair.of(Collections.emptyMap(), 0);
         }
 
         final MapToAmount<Map<Card, GameEntity>> possible = new LinkedHashMapToAmount<>();
@@ -449,7 +449,7 @@ public class AttackConstraints {
     private final Function<Map<Card, GameEntity>, Integer> FN_COUNT_VIOLATIONS = new Function<Map<Card,GameEntity>, Integer>() {
         @Override
         public Integer apply(final Map<Card, GameEntity> input) {
-            return Integer.valueOf(countViolations(input));
+            return countViolations(input);
         }
     };
 }

--- a/forge-game/src/main/java/forge/game/combat/AttackRequirement.java
+++ b/forge-game/src/main/java/forge/game/combat/AttackRequirement.java
@@ -48,7 +48,7 @@ public class AttackRequirement {
 
         for (final GameEntity defender : possibleDefenders) {
             // use put here because we want to always put it, even if the value is 0
-            defenderSpecific.put(defender, Integer.valueOf(defenderSpecific.count(defender) + nAttackAnything));
+            defenderSpecific.put(defender, defenderSpecific.count(defender) + nAttackAnything);
         }
 
         // Remove GameEntities that are no longer on an opposing battlefield or are

--- a/forge-game/src/main/java/forge/game/combat/AttackRequirement.java
+++ b/forge-game/src/main/java/forge/game/combat/AttackRequirement.java
@@ -107,7 +107,7 @@ public class AttackRequirement {
 
                     // only count violations if the forced creature can actually attack and has no cost incurred for doing so
                     if (attackers.size() < max && !attackers.containsKey(mustAttack.getKey()) && CombatUtil.canAttack(mustAttack.getKey()) && CombatUtil.getAttackCost(defender.getGame(), mustAttack.getKey(), defender) == null) {
-                        violations += mustAttack.getValue().intValue();
+                        violations += mustAttack.getValue();
                     }
                 }
             }

--- a/forge-game/src/main/java/forge/game/combat/AttackingBand.java
+++ b/forge-game/src/main/java/forge/game/combat/AttackingBand.java
@@ -92,7 +92,7 @@ public class AttackingBand {
      */
     @Override
     public String toString() {
-        return String.format("%s %s", attackers.toString(), blocked == null ? " ? " : blocked.booleanValue() ? ">||" : ">>>" );
+        return String.format("%s %s", attackers.toString(), blocked == null ? " ? " : blocked ? ">||" : ">>>" );
     }
 
 }

--- a/forge-game/src/main/java/forge/game/combat/CombatUtil.java
+++ b/forge-game/src/main/java/forge/game/combat/CombatUtil.java
@@ -92,7 +92,7 @@ public class CombatUtil {
             return false;
         }
         final Pair<Map<Card, GameEntity>, Integer> bestAttack = constraints.getLegalAttackers();
-        return myViolations <= bestAttack.getRight().intValue();
+        return myViolations <= bestAttack.getRight();
     }
 
     /**
@@ -122,7 +122,7 @@ public class CombatUtil {
                 if (myViolations == -1) {
                     return false;
                 }
-                return myViolations <= bestAttack.getRight().intValue();
+                return myViolations <= bestAttack.getRight();
             }
         });
     }

--- a/forge-game/src/main/java/forge/game/combat/GlobalAttackRestrictions.java
+++ b/forge-game/src/main/java/forge/game/combat/GlobalAttackRestrictions.java
@@ -50,7 +50,7 @@ public class GlobalAttackRestrictions {
             if (max == null) {
                 continue;
             }
-            if (returnQuickly && max.intValue() == 0) {
+            if (returnQuickly && max == 0) {
                 // there's at least one creature attacking this defender
                 defenderTooMany.put(defender, 1);
                 break;
@@ -59,13 +59,13 @@ public class GlobalAttackRestrictions {
             for (final Entry<Card, GameEntity> attDef : attackers.entrySet()) {
                 if (attDef.getValue() == defender) {
                     count++;
-                    if (returnQuickly && count > max.intValue()) {
-                        defenderTooMany.put(defender, count - max.intValue());
+                    if (returnQuickly && count > max) {
+                        defenderTooMany.put(defender, count - max);
                         break outer;
                     }
                 }
             }
-            final int nDefTooMany = count - max.intValue();
+            final int nDefTooMany = count - max;
             if (nDefTooMany > 0) {
                 // Too many attackers to one defender!
                 defenderTooMany.put(defender, nDefTooMany);

--- a/forge-game/src/main/java/forge/game/cost/Cost.java
+++ b/forge-game/src/main/java/forge/game/cost/Cost.java
@@ -860,7 +860,7 @@ public class Cost implements Serializable {
             return Cost.convertAmountTypeToWords(amount, type);
         }
 
-        return Cost.convertIntAndTypeToWords(i.intValue(), type);
+        return Cost.convertIntAndTypeToWords(i, type);
     }
 
     /**

--- a/forge-game/src/main/java/forge/game/cost/CostAdjustment.java
+++ b/forge-game/src/main/java/forge/game/cost/CostAdjustment.java
@@ -473,7 +473,7 @@ public class CostAdjustment {
         if (!staticAbility.hasParam("Cost") && !staticAbility.hasParam("Color")) {
             int minMana = 0;
             if (staticAbility.hasParam("MinMana")) {
-                minMana = Integer.valueOf(staticAbility.getParam("MinMana"));
+                minMana = Integer.parseInt(staticAbility.getParam("MinMana"));
             }
 
             final int maxReduction = manaCost.getConvertedManaCost() - minMana - sumReduced;

--- a/forge-game/src/main/java/forge/game/cost/CostGainLife.java
+++ b/forge-game/src/main/java/forge/game/cost/CostGainLife.java
@@ -87,7 +87,7 @@ public class CostGainLife extends CostPart {
 
     @Override
     public final boolean payAsDecided(final Player ai, final PaymentDecision decision, SpellAbility ability, final boolean effect) {
-        Integer c = this.getAbilityAmount(ability);
+        int c = this.getAbilityAmount(ability);
         
         int playersLeft = cntPlayers;
         for (final Player opp : decision.players) {

--- a/forge-game/src/main/java/forge/game/mana/ManaConversionMatrix.java
+++ b/forge-game/src/main/java/forge/game/mana/ManaConversionMatrix.java
@@ -2,6 +2,8 @@ package forge.game.mana;
 
 import forge.card.mana.ManaAtom;
 
+import java.util.Arrays;
+
 public class ManaConversionMatrix {
     static byte[] identityMatrix = { ManaAtom.WHITE, ManaAtom.BLUE, ManaAtom.BLACK, ManaAtom.RED, ManaAtom.GREEN, ManaAtom.COLORLESS };
 
@@ -54,13 +56,9 @@ public class ManaConversionMatrix {
 
     public void restoreColorReplacements() {
         // By default each color can only be paid by itself ( {G} -> {G}, {C} -> {C}
-        for (int i = 0; i < colorConversionMatrix.length; i++) {
-            colorConversionMatrix[i] = identityMatrix[i];
-        }
+        System.arraycopy(identityMatrix, 0, colorConversionMatrix, 0, colorConversionMatrix.length);
         // By default all mana types are unrestricted
-        for (int i = 0; i < colorRestrictionMatrix.length; i++) {
-            colorRestrictionMatrix[i] = ManaAtom.ALL_MANA_TYPES;
-        }
+        Arrays.fill(colorRestrictionMatrix, ManaAtom.ALL_MANA_TYPES);
         snowForColor = false;
     }
 }

--- a/forge-game/src/main/java/forge/game/mulligan/MulliganService.java
+++ b/forge-game/src/main/java/forge/game/mulligan/MulliganService.java
@@ -36,24 +36,24 @@ public class MulliganService {
 
         boolean firstMullFree = game.getPlayers().size() > 2 || game.getRules().hasAppliedVariant(GameType.Brawl);
 
-        for (int i = 0; i < whoCanMulligan.size(); i++) {
+        for (Player player : whoCanMulligan) {
             MulliganDefs.MulliganRule rule = StaticData.instance().getMulliganRule();
             switch (rule) {
                 case Original:
-                    mulligans.add(new OriginalMulligan(whoCanMulligan.get(i), firstMullFree));
+                    mulligans.add(new OriginalMulligan(player, firstMullFree));
                     break;
                 case Paris:
-                    mulligans.add(new ParisMulligan(whoCanMulligan.get(i), firstMullFree));
+                    mulligans.add(new ParisMulligan(player, firstMullFree));
                     break;
                 case Vancouver:
-                    mulligans.add(new VancouverMulligan(whoCanMulligan.get(i), firstMullFree));
+                    mulligans.add(new VancouverMulligan(player, firstMullFree));
                     break;
                 case London:
-                    mulligans.add(new LondonMulligan(whoCanMulligan.get(i), firstMullFree));
+                    mulligans.add(new LondonMulligan(player, firstMullFree));
                     break;
                 default:
                     // Default to Vancouver mulligan for now. Should ideally never get here.
-                    mulligans.add(new VancouverMulligan(whoCanMulligan.get(i), firstMullFree));
+                    mulligans.add(new VancouverMulligan(player, firstMullFree));
                     break;
             }
         }

--- a/forge-game/src/main/java/forge/game/phase/Untap.java
+++ b/forge-game/src/main/java/forge/game/phase/Untap.java
@@ -209,7 +209,7 @@ public class Untap extends Phase {
             if (chosen != null) {
                 for (Entry<String, Integer> rest : restrictUntap.entrySet()) {
                     if (chosen.isValid(rest.getKey(), player, null, null)) {
-                        restrictUntap.put(rest.getKey(), rest.getValue().intValue() - 1);
+                        restrictUntap.put(rest.getKey(), rest.getValue() - 1);
                     }
                 }
                 restrictUntapped.add(chosen);

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -2805,7 +2805,7 @@ public class Player extends GameEntity implements Comparable<Player> {
     }
     public int getCommanderDamage(Card commander) {
         Integer damage = commanderDamage.get(commander);
-        return damage == null ? 0 : damage.intValue();
+        return damage == null ? 0 : damage;
     }
     public void addCommanderDamage(Card commander, int damage) {
         commanderDamage.merge(commander, damage, Integer::sum);

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -940,7 +940,7 @@ public class Player extends GameEntity implements Comparable<Player> {
     }
 
     public void setCounters(final CounterType counterType, final Integer num, Player source, boolean fireEvents) {
-        Integer old = getCounters(counterType);
+        int old = getCounters(counterType);
         setCounters(counterType, num);
         view.updateCounters(this);
         if (fireEvents) {

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -2902,7 +2902,7 @@ public class Player extends GameEntity implements Comparable<Player> {
                         try {
                             if (keyword.startsWith("etbCounter")) {
                                 final String[] p = keyword.split(":");
-                                c.addCounterInternal(CounterType.getType(p[1]), Integer.valueOf(p[2]), null, false, null, null);
+                                c.addCounterInternal(CounterType.getType(p[1]), Integer.parseInt(p[2]), null, false, null, null);
                             }
                         } catch (Exception e) {
                             e.printStackTrace();
@@ -3054,7 +3054,7 @@ public class Player extends GameEntity implements Comparable<Player> {
                 }
                 int generic = manaCost.getGenericCost();
                 if (generic > 0 || manaCost.getCMC() == 0) {
-                    if (!genericManaSymbols.add(Integer.valueOf(generic))) {
+                    if (!genericManaSymbols.add(generic)) {
                         return false;
                     }
                 }

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -2222,8 +2222,8 @@ public class Player extends GameEntity implements Comparable<Player> {
         if (incR.length > 1) {
             final String excR = incR[1];
             final String[] exR = excR.split("\\+"); // Exclusive Restrictions are ...
-            for (int j = 0; j < exR.length; j++) {
-                if (!hasProperty(exR[j], sourceController, source, spellAbility)) {
+            for (String s : exR) {
+                if (!hasProperty(s, sourceController, source, spellAbility)) {
                     return false;
                 }
             }
@@ -3544,11 +3544,11 @@ public class Player extends GameEntity implements Comparable<Player> {
     public String trimKeywords(String keywordTexts) {
         if (keywordTexts.contains("Protection:")) {
             List <String> lines = Arrays.asList(keywordTexts.split("\n"));
-            for (int i = 0; i < lines.size(); i++) {
-                if (lines.get(i).startsWith("Protection:")) {
-                    List<String> parts = Arrays.asList(lines.get(i).split(":"));
+            for (String line : lines) {
+                if (line.startsWith("Protection:")) {
+                    List<String> parts = Arrays.asList(line.split(":"));
                     if (parts.size() > 2) {
-                        keywordTexts = TextUtil.fastReplace(keywordTexts, lines.get(i), parts.get(2));
+                        keywordTexts = TextUtil.fastReplace(keywordTexts, line, parts.get(2));
                     }
                 }
             }

--- a/forge-game/src/main/java/forge/game/player/PlayerView.java
+++ b/forge-game/src/main/java/forge/game/player/PlayerView.java
@@ -365,7 +365,7 @@ public class PlayerView extends GameEntityView {
         Map<Integer, Integer> map = get(TrackableProperty.CommanderDamage);
         if (map == null) { return 0; }
         Integer damage = map.get(commander.getId());
-        return damage == null ? 0 : damage.intValue();
+        return damage == null ? 0 : damage;
     }
     void updateCommanderDamage(Player p) {
         Map<Integer, Integer> map = Maps.newHashMap();
@@ -388,7 +388,7 @@ public class PlayerView extends GameEntityView {
         Map<Integer, Integer> map = get(TrackableProperty.CommanderCast);
         if (map == null) { return 0; }
         Integer damage = map.get(commander.getId());
-        return damage == null ? 0 : damage.intValue();
+        return damage == null ? 0 : damage;
     }
 
     void updateCommanderCast(Player p, Card c) {
@@ -569,7 +569,7 @@ public class PlayerView extends GameEntityView {
             e.printStackTrace();
             count = null;
         }
-        return count != null ? count.intValue() : 0;
+        return count != null ? count : 0;
     }
     private Map<Byte, Integer> getMana() {
         return get(TrackableProperty.Mana);

--- a/forge-game/src/main/java/forge/game/replacement/ReplacementType.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplacementType.java
@@ -81,16 +81,8 @@ public enum ReplacementType {
                     ReplacementEffect res = c.newInstance(mapParams, host, intrinsic);
                     res.setMode(this);
                     return res;
-                } catch (IllegalArgumentException e) {
-                    // TODO Auto-generated catch block ignores the exception, but sends it to System.err and probably forge.log.
-                    e.printStackTrace();
-                } catch (InstantiationException e) {
-                    // TODO Auto-generated catch block ignores the exception, but sends it to System.err and probably forge.log.
-                    e.printStackTrace();
-                } catch (IllegalAccessException e) {
-                    // TODO Auto-generated catch block ignores the exception, but sends it to System.err and probably forge.log.
-                    e.printStackTrace();
-                } catch (InvocationTargetException e) {
+                } catch (IllegalArgumentException | InstantiationException | IllegalAccessException |
+                         InvocationTargetException e) {
                     // TODO Auto-generated catch block ignores the exception, but sends it to System.err and probably forge.log.
                     e.printStackTrace();
                 }

--- a/forge-game/src/main/java/forge/game/spellability/Spell.java
+++ b/forge-game/src/main/java/forge/game/spellability/Spell.java
@@ -203,7 +203,7 @@ public abstract class Spell extends SpellAbility implements java.io.Serializable
             if (!source.isLKI()) {
                 source = CardCopyService.getLKICopy(source);
             }
-            Long next = source.getGame().getNextTimestamp();
+            long next = source.getGame().getNextTimestamp();
             source.addCloneState(CardFactory.getCloneStates(source, source, this), next);
             lkicheck = true;
         }

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
@@ -827,9 +827,7 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
     }
 
     public void setTriggeringObjectsFrom(final Map<AbilityKey, Object> runParams, final AbilityKey... types) {
-        int typesLength = types.length;
-        for (int i = 0; i < typesLength; i += 1) {
-            AbilityKey type = types[i];
+        for (AbilityKey type : types) {
             if (runParams.containsKey(type)) {
                 triggeringObjects.put(type, runParams.get(type));
             }
@@ -868,9 +866,7 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
         replacingObjects = AbilityKey.newMap(repParams);
     }
     public void setReplacingObjectsFrom(final Map<AbilityKey, Object> repParams, final AbilityKey... types) {
-        int typesLength = types.length;
-        for (int i = 0; i < typesLength; i += 1) {
-            AbilityKey type = types[i];
+        for (AbilityKey type : types) {
             if (repParams.containsKey(type)) {
                 setReplacingObject(type, repParams.get(type));
             }
@@ -2210,8 +2206,8 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
         if (incR.length > 1) {
             final String excR = incR[1];
             final String[] exR = excR.split("\\+"); // Exclusive Restrictions are ...
-            for (int j = 0; j < exR.length; j++) {
-                if (!hasProperty(exR[j], sourceController, source, spellAbility)) {
+            for (String s : exR) {
+                if (!hasProperty(s, sourceController, source, spellAbility)) {
                     return testFailed;
                 }
             }

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityCantDraw.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityCantDraw.java
@@ -35,7 +35,7 @@ public class StaticAbilityCantDraw {
         if (!stAb.matchesValidParam("ValidPlayer", player)) {
             return amount;
         }
-        int limit = Integer.valueOf(stAb.getParamOrDefault("DrawLimit", "0"));
+        int limit = Integer.parseInt(stAb.getParamOrDefault("DrawLimit", "0"));
         int drawn = player.getNumDrawnThisTurn();
         return Math.min(Math.max(limit - drawn, 0), amount);
     }

--- a/forge-game/src/main/java/forge/game/trigger/TriggerCounterRemoved.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerCounterRemoved.java
@@ -76,7 +76,7 @@ public class TriggerCounterRemoved extends Trigger {
         if (hasParam("NewCounterAmount")) {
             final String amtString = getParam("NewCounterAmount");
             int amt = Integer.parseInt(amtString);
-            if(amt != addedNewCounterAmount.intValue()) {
+            if(amt != addedNewCounterAmount) {
                 return false;
             }
         }

--- a/forge-game/src/main/java/forge/game/zone/Zone.java
+++ b/forge-game/src/main/java/forge/game/zone/Zone.java
@@ -85,7 +85,7 @@ public class Zone implements java.io.Serializable, Iterable<Card> {
         add(c, index, latestState, false);
     }
     public void add(final Card c, Integer index, final Card latestState, final boolean rollback) {
-        if (index != null && cardList.isEmpty() && index.intValue() > 0) {
+        if (index != null && cardList.isEmpty() && index > 0) {
             // something went wrong, most likely the method fired when the game was in an unexpected state
             // (e.g. conceding during the mana payment prompt)
             System.out.println("Warning: tried to add a card to zone with a specific non-zero index, but the zone was empty! Canceling Zone#add to avoid a crash.");
@@ -133,7 +133,7 @@ public class Zone implements java.io.Serializable, Iterable<Card> {
             if (index == null) {
                 cardList.add(c);
             } else {
-                cardList.add(index.intValue(), c);
+                cardList.add(index, c);
             }
         }
         onChanged();

--- a/forge-game/src/main/java/forge/util/MessageUtil.java
+++ b/forge-game/src/main/java/forge/util/MessageUtil.java
@@ -12,7 +12,7 @@ public class MessageUtil {
     private MessageUtil() { }
 
     public static String formatMessage(String message, Player player, Object related) {
-        if (related instanceof Player && message.indexOf("{player") >= 0) {
+        if (related instanceof Player && message.contains("{player")) {
             String noun = mayBeYou(player, related);
             message = TextUtil.fastReplace(TextUtil.fastReplace(message, "{player}", noun),"{player's}", Lang.getInstance().getPossesive(noun));
         }
@@ -20,7 +20,7 @@ public class MessageUtil {
     }
 
     public static String formatMessage(String message, PlayerView player, Object related) {
-        if (related instanceof PlayerView && message.indexOf("{player") >= 0) {
+        if (related instanceof PlayerView && message.contains("{player")) {
             String noun = mayBeYou(player, related);
             message = TextUtil.fastReplace(TextUtil.fastReplace(message, "{player}", noun),"{player's}", Lang.getInstance().getPossesive(noun));
         }

--- a/forge-gui-desktop/src/main/java/forge/GuiDesktop.java
+++ b/forge-gui-desktop/src/main/java/forge/GuiDesktop.java
@@ -108,10 +108,7 @@ public class GuiDesktop implements IGuiBase {
             try {
                 SwingUtilities.invokeAndWait(proc);
             }
-            catch (final InterruptedException exn) {
-                throw new RuntimeException(exn);
-            }
-            catch (final InvocationTargetException exn) {
+            catch (final InterruptedException | InvocationTargetException exn) {
                 throw new RuntimeException(exn);
             }
         }

--- a/forge-gui-desktop/src/main/java/forge/control/KeyboardShortcuts.java
+++ b/forge-gui-desktop/src/main/java/forge/control/KeyboardShortcuts.java
@@ -142,7 +142,7 @@ public class KeyboardShortcuts {
                 StackItemView si = matchUI.getGameView().peekStack();
                 if (si != null && si.isAbility()) {
                     matchUI.setShouldAutoYield(si.getKey(), true);
-                    int triggerID = Integer.valueOf(si.getSourceTrigger());
+                    int triggerID = si.getSourceTrigger();
                     if (si.isOptionalTrigger() && matchUI.isLocalPlayer(si.getActivatingPlayer())) {
                         matchUI.setShouldAlwaysAcceptTrigger(triggerID);
                     }
@@ -160,7 +160,7 @@ public class KeyboardShortcuts {
                 StackItemView si = matchUI.getGameView().peekStack();
                 if (si != null && si.isAbility()) {
                     matchUI.setShouldAutoYield(si.getKey(), true);
-                    int triggerID = Integer.valueOf(si.getSourceTrigger());
+                    int triggerID = si.getSourceTrigger();
                     if (si.isOptionalTrigger() && matchUI.isLocalPlayer(si.getActivatingPlayer())) {
                         matchUI.setShouldAlwaysDeclineTrigger(triggerID);
                     }
@@ -312,7 +312,7 @@ public class KeyboardShortcuts {
             if (s.equals("16"))      { inputEvents[0] = 16; }
             else if (s.equals("17")) { inputEvents[1] = 17; }
             else {
-                keyEvent = Integer.valueOf(s);
+                keyEvent = Integer.parseInt(s);
             }
         }
 

--- a/forge-gui-desktop/src/main/java/forge/deckchooser/FDeckViewer.java
+++ b/forge-gui-desktop/src/main/java/forge/deckchooser/FDeckViewer.java
@@ -170,7 +170,7 @@ public class FDeckViewer extends FDialog {
     }
 
     private void copyToClipboard() {
-        final String nl = System.getProperty("line.separator");
+        final String nl = System.lineSeparator();
         final StringBuilder deckList = new StringBuilder();
         String dName = deck.getName();
         //fix copying a commander netdeck then importing it again...

--- a/forge-gui-desktop/src/main/java/forge/gui/GuiChoose.java
+++ b/forge-gui-desktop/src/main/java/forge/gui/GuiChoose.java
@@ -120,7 +120,7 @@ public class GuiChoose {
             if (str == null) { return null; } // that is 'cancel'
 
             if (StringUtils.isNumeric(str)) {
-                final Integer val = Integer.valueOf(str);
+                final int val = Integer.parseInt(str);
                 if (val >= min && val <= max) {
                     return val;
                 }

--- a/forge-gui-desktop/src/main/java/forge/gui/GuiChoose.java
+++ b/forge-gui-desktop/src/main/java/forge/gui/GuiChoose.java
@@ -78,7 +78,7 @@ public class GuiChoose {
 
         final Integer[] choices = new Integer[count];
         for (int i = 0; i < count; i++) {
-            choices[i] = Integer.valueOf(i + min);
+            choices[i] = i + min;
         }
         return GuiChoose.oneOrNone(message, choices);
     }
@@ -92,7 +92,7 @@ public class GuiChoose {
 
         final List<Object> choices = new ArrayList<>();
         for (int i = min; i <= cutoff; i++) {
-            choices.add(Integer.valueOf(i));
+            choices.add(i);
         }
         choices.add(Localizer.getInstance().getMessage("lblOtherInteger"));
 

--- a/forge-gui-desktop/src/main/java/forge/gui/GuiDialog.java
+++ b/forge-gui-desktop/src/main/java/forge/gui/GuiDialog.java
@@ -31,7 +31,7 @@ public class GuiDialog {
                 final String questionToUse = StringUtils.isBlank(question) ? "Activate card's ability?" : question;
                 final List<String> opts = options == null ? defaultConfirmOptions : options;
                 final int answer = FOptionPane.showOptionDialog(questionToUse, title, FOptionPane.QUESTION_ICON, opts, defaultIsYes ? 0 : 1);
-                return Boolean.valueOf(answer == 0);
+                return answer == 0;
             }};
 
         final FutureTask<Boolean> future = new FutureTask<>(confirmTask);

--- a/forge-gui-desktop/src/main/java/forge/gui/GuiDialog.java
+++ b/forge-gui-desktop/src/main/java/forge/gui/GuiDialog.java
@@ -37,7 +37,7 @@ public class GuiDialog {
         final FutureTask<Boolean> future = new FutureTask<>(confirmTask);
         FThreads.invokeInEdtAndWait(future);
         try {
-            return future.get().booleanValue();
+            return future.get();
         } catch (final InterruptedException | ExecutionException e) { // should be no exception here
             e.printStackTrace();
         }

--- a/forge-gui-desktop/src/main/java/forge/gui/framework/SLayoutIO.java
+++ b/forge-gui-desktop/src/main/java/forge/gui/framework/SLayoutIO.java
@@ -149,10 +149,7 @@ public final class SLayoutIO {
             writer.add(EF.createEndElement("", "", "layout"));
             writer.flush(); 
             writer.add(EF.createEndDocument());
-        } catch (FileNotFoundException e) {
-            // TODO Auto-generated catch block ignores the exception, but sends it to System.err and probably forge.log.
-            e.printStackTrace();
-        } catch (XMLStreamException e) {
+        } catch (FileNotFoundException | XMLStreamException e) {
             // TODO Auto-generated catch block ignores the exception, but sends it to System.err and probably forge.log.
             e.printStackTrace();
         } finally {
@@ -345,10 +342,7 @@ public final class SLayoutIO {
             }
             writer.flush(); 
             writer.add(EF.createEndDocument());
-        } catch (FileNotFoundException e) {
-            // TODO Auto-generated catch block ignores the exception, but sends it to System.err and probably forge.log.
-            e.printStackTrace();
-        } catch (XMLStreamException e) {
+        } catch (FileNotFoundException | XMLStreamException e) {
             // TODO Auto-generated catch block ignores the exception, but sends it to System.err and probably forge.log.
             e.printStackTrace();
         } finally {

--- a/forge-gui-desktop/src/main/java/forge/gui/framework/SLayoutIO.java
+++ b/forge-gui-desktop/src/main/java/forge/gui/framework/SLayoutIO.java
@@ -131,10 +131,8 @@ public final class SLayoutIO {
         final FileLocation file = ForgeConstants.WINDOW_LAYOUT_FILE;
         final String fWriteTo = file.userPrefLoc;
         final XMLOutputFactory out = XMLOutputFactory.newInstance();
-        FileOutputStream fos = null;
         XMLEventWriter writer = null;
-        try {
-            fos = new FileOutputStream(fWriteTo);
+        try (FileOutputStream fos = new FileOutputStream(fWriteTo)) {
             writer = out.createXMLEventWriter(fos);
 
             writer.add(EF.createStartDocument());
@@ -147,17 +145,14 @@ public final class SLayoutIO {
             writer.add(EF.createAttribute(Property.max, window.isMaximized() ? "1" : "0"));
             writer.add(EF.createAttribute(Property.fs, window.isFullScreen() ? "1" : "0"));
             writer.add(EF.createEndElement("", "", "layout"));
-            writer.flush(); 
+            writer.flush();
             writer.add(EF.createEndDocument());
-        } catch (FileNotFoundException | XMLStreamException e) {
+        } catch (XMLStreamException | IOException e) {
             // TODO Auto-generated catch block ignores the exception, but sends it to System.err and probably forge.log.
             e.printStackTrace();
         } finally {
-            if (writer != null ) {
-                try { writer.close(); } catch (XMLStreamException e) {}
-            }
-            if ( fos != null ) {
-                try { fos.close(); } catch (IOException e) {}
+            if (writer != null) {
+                try { writer.close(); } catch (XMLStreamException ignored) {}
             }
         }
     }

--- a/forge-gui-desktop/src/main/java/forge/gui/framework/SLayoutIO.java
+++ b/forge-gui-desktop/src/main/java/forge/gui/framework/SLayoutIO.java
@@ -404,7 +404,7 @@ public final class SLayoutIO {
         final FView view = FView.SINGLETON_INSTANCE;
         String defaultLayoutSerial = "";
         String userLayoutSerial = "";
-        Boolean resetLayout = false;
+        boolean resetLayout = false;
         FScreen screen = Singletons.getControl().getCurrentScreen();
         FAbsolutePositioner.SINGLETON_INSTANCE.hideAll();
         view.getPnlInsets().removeAll();

--- a/forge-gui-desktop/src/main/java/forge/itemmanager/filters/StatTypeFilter.java
+++ b/forge-gui-desktop/src/main/java/forge/itemmanager/filters/StatTypeFilter.java
@@ -1,7 +1,6 @@
 package forge.itemmanager.filters;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 import javax.swing.JPanel;

--- a/forge-gui-desktop/src/main/java/forge/itemmanager/filters/StatTypeFilter.java
+++ b/forge-gui-desktop/src/main/java/forge/itemmanager/filters/StatTypeFilter.java
@@ -79,10 +79,8 @@ public abstract class StatTypeFilter<T extends InventoryItem> extends ToggleButt
             btnPackOrDeck.setText(String.valueOf(count));
         }
 
-        Iterator<StatTypes> buttonMapStatsIterator = buttonMap.keySet().iterator();
-        while (buttonMapStatsIterator.hasNext()){
-            StatTypes statTypes = buttonMapStatsIterator.next();
-            if (statTypes.predicate != null){
+        for (StatTypes statTypes : buttonMap.keySet()) {
+            if (statTypes.predicate != null) {
                 int count = items.countAll(Predicates.compose(statTypes.predicate, PaperCard.FN_GET_RULES), PaperCard.class);
                 buttonMap.get(statTypes).setText(String.valueOf(count));
             }

--- a/forge-gui-desktop/src/main/java/forge/itemmanager/views/ImageView.java
+++ b/forge-gui-desktop/src/main/java/forge/itemmanager/views/ImageView.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
+import java.util.stream.IntStream;
 
 public class ImageView<T extends InventoryItem> extends ItemView<T> {
     private static final int PADDING = 5;
@@ -154,9 +155,7 @@ public class ImageView<T extends InventoryItem> extends ItemView<T> {
 
         SItemManagerUtil.populateImageViewOptions(itemManager0, cbGroupByOptions, cbPileByOptions);
 
-        for (Integer i = MIN_COLUMN_COUNT; i <= MAX_COLUMN_COUNT; i++) {
-            cbColumnCount.addItem(i);
-        }
+        IntStream.rangeClosed(MIN_COLUMN_COUNT, MAX_COLUMN_COUNT).forEach(cbColumnCount::addItem);
         cbGroupByOptions.setMaximumRowCount(cbGroupByOptions.getItemCount());
         cbPileByOptions.setMaximumRowCount(cbPileByOptions.getItemCount());
         cbColumnCount.setMaximumRowCount(cbColumnCount.getItemCount());
@@ -871,9 +870,7 @@ public class ImageView<T extends InventoryItem> extends ItemView<T> {
     @Override
     public void selectAll() {
         clearSelection();
-        for (Integer i = 0; i < getCount(); i++) {
-            selectedIndices.add(i);
-        }
+        IntStream.range(0, getCount()).forEach(selectedIndices::add);
         updateSelection();
     }
 

--- a/forge-gui-desktop/src/main/java/forge/itemmanager/views/ItemListView.java
+++ b/forge-gui-desktop/src/main/java/forge/itemmanager/views/ItemListView.java
@@ -273,8 +273,8 @@ public final class ItemListView<T extends InventoryItem> extends ItemView<T> {
     public Iterable<Integer> getSelectedIndices() {
         final List<Integer> indices = new ArrayList<>();
         final int[] selectedRows = this.table.getSelectedRows();
-        for (int i = 0; i < selectedRows.length; i++) {
-            indices.add(selectedRows[i]);
+        for (int selectedRow : selectedRows) {
+            indices.add(selectedRow);
         }
         return indices;
     }

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorQuest.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorQuest.java
@@ -165,7 +165,7 @@ public final class CEditorQuest extends CDeckEditor<Deck> {
             for (final Entry<PaperCard, Integer> e : deck.getMain()) {
                 final PaperCard card = e.getKey();
                 final Integer amount = result.get(card);
-                result.put(card, Integer.valueOf(amount == null ? 1 : 1 + amount.intValue()));
+                result.put(card, amount == null ? 1 : 1 + amount.intValue());
             }
         }
         return result;

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorQuest.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorQuest.java
@@ -165,7 +165,7 @@ public final class CEditorQuest extends CDeckEditor<Deck> {
             for (final Entry<PaperCard, Integer> e : deck.getMain()) {
                 final PaperCard card = e.getKey();
                 final Integer amount = result.get(card);
-                result.put(card, amount == null ? 1 : 1 + amount.intValue());
+                result.put(card, amount == null ? 1 : 1 + amount);
             }
         }
         return result;

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorQuestLimited.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorQuestLimited.java
@@ -138,7 +138,7 @@ public final class CEditorQuestLimited extends CDeckEditor<DeckGroup> {
             for (final Entry<PaperCard, Integer> e : deck.getMain()) {
                 final PaperCard card = e.getKey();
                 final Integer amount = result.get(card);
-                result.put(card, amount == null ? 1 : 1 + amount.intValue());
+                result.put(card, amount == null ? 1 : 1 + amount);
             }
         }
         return result;

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorQuestLimited.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorQuestLimited.java
@@ -138,7 +138,7 @@ public final class CEditorQuestLimited extends CDeckEditor<DeckGroup> {
             for (final Entry<PaperCard, Integer> e : deck.getMain()) {
                 final PaperCard card = e.getKey();
                 final Integer amount = result.get(card);
-                result.put(card, Integer.valueOf(amount == null ? 1 : 1 + amount.intValue()));
+                result.put(card, amount == null ? 1 : 1 + amount.intValue());
             }
         }
         return result;

--- a/forge-gui-desktop/src/main/java/forge/screens/home/PlayerPanel.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/PlayerPanel.java
@@ -209,11 +209,11 @@ public class PlayerPanel extends FPanel {
 
     void update() {
         avatarLabel.setEnabled(mayEdit);
-        avatarLabel.setIcon(FSkin.getAvatars().get(Integer.valueOf(type == LobbySlotType.OPEN ? -1 : avatarIndex)));
+        avatarLabel.setIcon(FSkin.getAvatars().get(type == LobbySlotType.OPEN ? -1 : avatarIndex));
         avatarLabel.repaintSelf();
 
         sleeveLabel.setEnabled(mayEdit);
-        sleeveLabel.setIcon(FSkin.getSleeves().get(Integer.valueOf(type == LobbySlotType.OPEN ? -1 : sleeveIndex)));
+        sleeveLabel.setIcon(FSkin.getSleeves().get(type == LobbySlotType.OPEN ? -1 : sleeveIndex));
         sleeveLabel.repaintSelf();
 
         txtPlayerName.setEnabled(mayEdit);
@@ -312,7 +312,7 @@ public class PlayerPanel extends FPanel {
                 lbl.setCommand(new UiCommand() {
                     @Override
                     public void run() {
-                        setAvatarIndex(Integer.valueOf(lbl.getName().substring(11)));
+                        setAvatarIndex(Integer.parseInt(lbl.getName().substring(11)));
                         aSel.setVisible(false);
                     }
                 });
@@ -368,7 +368,7 @@ public class PlayerPanel extends FPanel {
                 lbl.setCommand(new UiCommand() {
                     @Override
                     public void run() {
-                        setSleeveIndex(Integer.valueOf(lbl.getName().substring(11)));
+                        setSleeveIndex(Integer.parseInt(lbl.getName().substring(11)));
                         sSel.setVisible(false);
                     }
                 });

--- a/forge-gui-desktop/src/main/java/forge/screens/home/quest/CSubmenuQuestPrefs.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/quest/CSubmenuQuestPrefs.java
@@ -66,7 +66,7 @@ public enum CSubmenuQuestPrefs implements ICDoc {
             validationError = val == null ? localizer.getMessage("lblEnteraDecimal") : null;           
         } else {
             final Integer val = Ints.tryParse(i0.getText());
-            validationError = val == null ? localizer.getMessage("lblEnteraNumber") : prefs.validatePreference(i0.getQPref(), val.intValue());          
+            validationError = val == null ? localizer.getMessage("lblEnteraNumber") : prefs.validatePreference(i0.getQPref(), val);
         }
 
         if (validationError != null) {

--- a/forge-gui-desktop/src/main/java/forge/screens/home/quest/DialogChoosePoolDistribution.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/quest/DialogChoosePoolDistribution.java
@@ -314,7 +314,7 @@ public class DialogChoosePoolDistribution {
 
 	public int getNumberOfBoosters() {
 		try {
-			return Integer.valueOf(numberOfBoostersField.getText());
+			return Integer.parseInt(numberOfBoostersField.getText());
 		} catch (NumberFormatException e) {
 			return 0;
 		}

--- a/forge-gui-desktop/src/main/java/forge/screens/home/settings/VSubmenuPreferences.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/settings/VSubmenuPreferences.java
@@ -603,7 +603,7 @@ public enum VSubmenuPreferences implements IVSubmenu<CSubmenuPreferences> {
 
             for (final String s : codes) {
                 if (!s.isEmpty()) {
-                    displayText.add(KeyEvent.getKeyText(Integer.valueOf(s)));
+                    displayText.add(KeyEvent.getKeyText(Integer.parseInt(s)));
                 }
             }
 

--- a/forge-gui-desktop/src/main/java/forge/screens/match/VAssignCombatDamage.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/VAssignCombatDamage.java
@@ -459,12 +459,12 @@ public class VAssignCombatDamage {
             }
             else if (defender instanceof CardView) { // planeswalker
                 final CardView pw = (CardView)defender;
-                lethalDamage = Integer.valueOf(pw.getCurrentState().getLoyalty());
+                lethalDamage = Integer.parseInt(pw.getCurrentState().getLoyalty());
             }
         } else {
             lethalDamage = Math.max(0, card.getLethalDamage());
             if (card.getCurrentState().isPlaneswalker()) {
-                lethalDamage = Integer.valueOf(card.getCurrentState().getLoyalty());
+                lethalDamage = Integer.parseInt(card.getCurrentState().getLoyalty());
             } else if (attackerHasDeathtouch) {
                 lethalDamage = Math.min(lethalDamage, 1);
             }

--- a/forge-gui-desktop/src/main/java/forge/screens/match/VAssignGenericAmount.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/VAssignGenericAmount.java
@@ -220,7 +220,7 @@ public class VAssignGenericAmount {
             targetsMap.put(mp, at);
         } else if (at.entity instanceof Byte) {
             SkinImage manaSymbol;
-            Byte color = (Byte) at.entity;
+            byte color = (Byte) at.entity;
             if (color == MagicColor.WHITE) {
                 manaSymbol = FSkin.getImage(FSkinProp.IMG_MANA_W);
             } else if (color == MagicColor.BLUE) {

--- a/forge-gui-desktop/src/main/java/forge/screens/match/controllers/CDock.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/controllers/CDock.java
@@ -125,7 +125,7 @@ public class CDock implements ICDoc {
         final String temp = FModel.getPreferences()
                 .getPref(FPref.UI_TARGETING_OVERLAY);
         final Integer arcState = Ints.tryParse(temp);
-        setArcState(ArcState.values()[arcState == null ? 0 : arcState.intValue()]);
+        setArcState(ArcState.values()[arcState == null ? 0 : arcState]);
         refreshArcStateDisplay();
 
         view.getBtnConcede().setCommand(new UiCommand() {

--- a/forge-gui-desktop/src/main/java/forge/screens/match/controllers/CField.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/controllers/CField.java
@@ -79,7 +79,7 @@ public class CField implements ICDoc {
                     final Input ipm = controller.getInputQueue().getInput();
                     if (ipm instanceof InputPayMana && ipm.getOwner().equals(player)) {
                         final int oldMana = player.getMana(colorCode);
-                        controller.useMana(colorCode.byteValue());
+                        controller.useMana(colorCode);
                         return oldMana != player.getMana(colorCode);
                     }
                 }

--- a/forge-gui-desktop/src/main/java/forge/screens/match/controllers/CField.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/controllers/CField.java
@@ -80,7 +80,7 @@ public class CField implements ICDoc {
                     if (ipm instanceof InputPayMana && ipm.getOwner().equals(player)) {
                         final int oldMana = player.getMana(colorCode);
                         controller.useMana(colorCode.byteValue());
-                        return Boolean.valueOf(oldMana != player.getMana(colorCode));
+                        return oldMana != player.getMana(colorCode);
                     }
                 }
                 return Boolean.FALSE;

--- a/forge-gui-desktop/src/main/java/forge/screens/match/views/VStack.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/views/VStack.java
@@ -342,7 +342,7 @@ public class VStack implements IVDoc<CStack> {
 
         public void setStackInstance(final StackItemView item0) {
             item = item0;
-            triggerID = Integer.valueOf(item.getSourceTrigger());
+            triggerID = item.getSourceTrigger();
 
             jmiAutoYield.setSelected(controller.getMatchUI().shouldAutoYield(item.getKey()));
 

--- a/forge-gui-desktop/src/main/java/forge/screens/workshop/views/VCardScript.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/workshop/views/VCardScript.java
@@ -47,7 +47,7 @@ public enum VCardScript implements IVDoc<CCardScript> {
         scrollScript = new FScrollPane(txtScript, true);
         error = doc.addStyle("error", null);
         error.addAttribute(StyleConstants.Background, Color.red);
-        error.addAttribute(StyleConstants.Bold, Boolean.valueOf(true));
+        error.addAttribute(StyleConstants.Bold, Boolean.TRUE);
         empty = doc.addStyle("empty", null);
     }
 

--- a/forge-gui-desktop/src/main/java/forge/sound/AltSoundSystem.java
+++ b/forge-gui-desktop/src/main/java/forge/sound/AltSoundSystem.java
@@ -79,10 +79,7 @@ public class AltSoundSystem extends Thread {
         try {
             ByteArrayInputStream bis = new ByteArrayInputStream(AudioClip.getAudioClips(soundFile));
             audioInputStream = AudioSystem.getAudioInputStream(bis);
-        } catch (UnsupportedAudioFileException e) {
-            e.printStackTrace();
-            return;
-        } catch (IOException e) {
+        } catch (UnsupportedAudioFileException | IOException e) {
             e.printStackTrace();
             return;
         }

--- a/forge-gui-desktop/src/main/java/forge/toolbox/FRadioButton.java
+++ b/forge-gui-desktop/src/main/java/forge/toolbox/FRadioButton.java
@@ -21,7 +21,7 @@ public class FRadioButton  extends SkinnedRadioButton {
         super();
         this.setText(s0);
         if (null != selected) {
-            this.setSelected(selected.booleanValue());
+            this.setSelected(selected);
         }
         this.setForeground(FSkin.getColor(FSkin.Colors.CLR_TEXT));
         this.setFont(FSkin.getFont(14));

--- a/forge-gui-desktop/src/main/java/forge/toolbox/FTextArea.java
+++ b/forge-gui-desktop/src/main/java/forge/toolbox/FTextArea.java
@@ -51,8 +51,8 @@ public class FTextArea extends SkinnedTextArea {
         int maxLineWidth = 0;
         final FontMetrics metrics = this.getGraphics().getFontMetrics(this.getFont());
         final String[] lines = this.getText().split("(\r\n)|(\n)");
-        for (int i = 0; i < lines.length; i++) {
-            final int lineWidth = metrics.stringWidth(lines[i]);
+        for (String line : lines) {
+            final int lineWidth = metrics.stringWidth(line);
             if (lineWidth > maxLineWidth) {
                 maxLineWidth = lineWidth;
             }

--- a/forge-gui-desktop/src/main/java/forge/toolbox/FUndoManager.java
+++ b/forge-gui-desktop/src/main/java/forge/toolbox/FUndoManager.java
@@ -200,7 +200,7 @@ public class FUndoManager extends UndoManager implements DocumentListener {
         public UndoAction() {
             putValue(Action.NAME, "Undo");
             putValue(Action.SHORT_DESCRIPTION, getValue(Action.NAME));
-            putValue(Action.MNEMONIC_KEY, Integer.valueOf(KeyEvent.VK_U));
+            putValue(Action.MNEMONIC_KEY, KeyEvent.VK_U);
             putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_Z, InputEvent.CTRL_DOWN_MASK));
             setEnabled(false);
         }
@@ -229,7 +229,7 @@ public class FUndoManager extends UndoManager implements DocumentListener {
         public RedoAction() {
             putValue(Action.NAME, "Redo");
             putValue(Action.SHORT_DESCRIPTION, getValue(Action.NAME));
-            putValue(Action.MNEMONIC_KEY, Integer.valueOf(KeyEvent.VK_R));
+            putValue(Action.MNEMONIC_KEY, KeyEvent.VK_R);
             putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_Y, InputEvent.CTRL_DOWN_MASK));
             setEnabled(false);
         }

--- a/forge-gui-desktop/src/main/java/forge/toolbox/imaging/FImagePanel.java
+++ b/forge-gui-desktop/src/main/java/forge/toolbox/imaging/FImagePanel.java
@@ -338,7 +338,7 @@ public class FImagePanel extends JPanel {
     private void setImageScale() {
         if (this.sourceImage != null) {
             if (this.autoSizeMode != AutoSizeImageMode.OFF) {
-                Double newScale = FImageUtil.getBestFitScale(getSourceImageSize(), this.getSize());
+                double newScale = FImageUtil.getBestFitScale(getSourceImageSize(), this.getSize());
                 // apply DPI based scale
                 newScale *= GuiBase.getInterface().getScreenScale();
                 if (newScale != this.imageScale) {

--- a/forge-gui-desktop/src/main/java/forge/toolbox/special/PlayerDetailsPanel.java
+++ b/forge-gui-desktop/src/main/java/forge/toolbox/special/PlayerDetailsPanel.java
@@ -154,7 +154,7 @@ public class PlayerDetailsPanel extends JPanel {
      */
     public void updateManaPool() {
         for (final Pair<DetailLabel, Byte> label : manaLabels) {
-            final String mana = String.valueOf(player.getMana(label.getRight().byteValue()));
+            final String mana = String.valueOf(player.getMana(label.getRight()));
             label.getKey().setText(mana);
             label.getKey().setToolTip(mana);
         }

--- a/forge-gui-desktop/src/main/java/forge/view/arcane/CardPanel.java
+++ b/forge-gui-desktop/src/main/java/forge/view/arcane/CardPanel.java
@@ -762,10 +762,10 @@ public class CardPanel extends SkinnedPanel implements CardContainer, IDisposabl
             } else {
                 String keywordKey = card.getCurrentState().getKeywordKey();
                 String abilityText = card.getCurrentState().getAbilityText();
-                if (((keywordKey.indexOf("Flashback") == -1)
-                    && (keywordKey.indexOf("Flash") != -1))
-                        || ((abilityText.indexOf("May be played by") != -1)
-                                && (abilityText.indexOf("and as though it has flash") != -1))) {
+                if (((!keywordKey.contains("Flashback"))
+                    && (keywordKey.contains("Flash")))
+                        || ((abilityText.contains("May be played by"))
+                                && (abilityText.contains("and as though it has flash")))) {
                         hasFlash = !card.isFaceDown() && ((!ZoneType.Library.equals(card.getZone()) && !ZoneType.Hand.equals(card.getZone())) || matchUI.mayView(card));
                         if (hasFlash) {
                             CardFaceSymbols.drawAbilitySymbol("flash", g, cardXOffset + (cardWidth / 2) + (cardWidth / 3), cardWidth < 200 ? cardYOffset + 25 : cardYOffset + 50, cardWidth / 7, cardWidth / 7);

--- a/forge-gui-desktop/src/main/java/forge/view/arcane/PlayArea.java
+++ b/forge-gui-desktop/src/main/java/forge/view/arcane/PlayArea.java
@@ -320,8 +320,7 @@ public class PlayArea extends CardPanelContainer implements CardPanelMouseListen
         for (final CardStackRow row : this.rows) {
             int rowBottom = 0;
             x = PlayArea.GUTTER_X;
-            for (int stackIndex = 0, stackCount = row.size(); stackIndex < stackCount; stackIndex++) {
-                final CardStack stack = row.get(stackIndex);
+            for (final CardStack stack : row) {
                 rowBottom = Math.max(rowBottom, y + stack.getHeight());
                 x += stack.getWidth();
             }
@@ -608,8 +607,7 @@ public class PlayArea extends CardPanelContainer implements CardPanelMouseListen
         final List<CardView> toDelete = Lists.newArrayList(oldCards);
         final List<CardView> notToDelete = Lists.newLinkedList();
         for (final CardView c : modelCopy) {
-            for (int i = 0; i  < toDelete.size(); i++) {
-                final CardView c2 = toDelete.get(i);
+            for (final CardView c2 : toDelete) {
                 if (c.getId() == c2.getId()) {
                     notToDelete.add(c2);
                 }

--- a/forge-gui-desktop/src/main/java/forge/view/arcane/util/Animation.java
+++ b/forge-gui-desktop/src/main/java/forge/view/arcane/util/Animation.java
@@ -252,7 +252,7 @@ public abstract class Animation {
                 Container parent = animationPanel.getParent();
                 if (parent != layeredPane) {
                     layeredPane.add(animationPanel);
-                    layeredPane.setLayer(animationPanel, JLayeredPane.MODAL_LAYER.intValue());
+                    layeredPane.setLayer(animationPanel, JLayeredPane.MODAL_LAYER);
                 }
 
                 new Animation(speed) {

--- a/forge-gui-desktop/src/test/java/forge/gamesimulationtests/util/PlayerControllerForTests.java
+++ b/forge-gui-desktop/src/test/java/forge/gamesimulationtests/util/PlayerControllerForTests.java
@@ -649,7 +649,7 @@ public class PlayerControllerForTests extends PlayerController {
     @Override
     public int chooseNumber(SpellAbility sa, String title, List<Integer> values, Player relatedPlayer) {
         // TODO Auto-generated method stub
-        return Iterables.getFirst(values, Integer.valueOf(0));
+        return Iterables.getFirst(values, 0);
     }
 
     @Override

--- a/forge-gui-mobile-dev/src/forge/app/Main.java
+++ b/forge-gui-mobile-dev/src/forge/app/Main.java
@@ -75,7 +75,7 @@ public class Main {
 
         // Place the file "switch_orientation.ini" to your assets folder to make the game switch to landscape orientation (unless desktopMode = true)
         String switchOrientationFile = assetsDir + "switch_orientation.ini";
-        Boolean landscapeMode = FileUtil.doesFileExist(switchOrientationFile) || cmd.hasOption("landscape");
+        boolean landscapeMode = FileUtil.doesFileExist(switchOrientationFile) || cmd.hasOption("landscape");
         String[] res;
 
         // Width and height for standard smartphone/tablet mode (desktopMode = false)

--- a/forge-gui-mobile/src/forge/adventure/character/EnemySprite.java
+++ b/forge-gui-mobile/src/forge/adventure/character/EnemySprite.java
@@ -567,7 +567,7 @@ public class EnemySprite extends CharacterSprite implements Steerable<Vector2> {
 
     public float getLifetime() {
         //default and minimum value for time to remain on overworld map
-        Float lifetime = 20f;
+        float lifetime = 20f;
         return Math.max(data.lifetime, lifetime);
     }
 

--- a/forge-gui-mobile/src/forge/adventure/stage/WorldBackground.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/WorldBackground.java
@@ -129,10 +129,10 @@ public class WorldBackground extends Actor {
         chunkSize = WorldSave.getCurrentSave().getWorld().getChunkSize();
         if (chunks != null) {
             stage.getSpriteGroup().clear();
-            for (int i = 0; i < chunks.length; i++)
-                for (int j = 0; j < chunks[i].length; j++)
-                    if (chunks[i][j] != null)
-                        chunks[i][j].dispose();
+            for (Texture[] chunk : chunks)
+                for (Texture texture : chunk)
+                    if (texture != null)
+                        texture.dispose();
         }
         chunks = new Texture[WorldSave.getCurrentSave().getWorld().getWidthInTiles()][WorldSave.getCurrentSave().getWorld().getHeightInTiles()];
         Array[][] createChunks = new Array[WorldSave.getCurrentSave().getWorld().getWidthInTiles()][WorldSave.getCurrentSave().getWorld().getHeightInTiles()];

--- a/forge-gui-mobile/src/forge/adventure/world/Model.java
+++ b/forge-gui-mobile/src/forge/adventure/world/Model.java
@@ -42,7 +42,7 @@ abstract class Model {
   static int randomIndice(double[] arr, double r) {
     double sum = 0;
 
-    for (int j = 0; j < arr.length; j++) sum += arr[j];
+    for (double v : arr) sum += v;
 
     for (int j = 0; j < arr.length; j++) arr[j] /= sum;
 
@@ -181,8 +181,7 @@ abstract class Model {
         int[] p = this.propagator[d][stack2];
         int[][] compat = this.compatible[i2];
 
-        for (int l = 0; l < p.length; l++) {
-          int t2 = p[l];
+        for (int t2 : p) {
           int[] comp = compat[t2];
 
           comp[d]--;

--- a/forge-gui-mobile/src/forge/adventure/world/OpenSimplexNoise.java
+++ b/forge-gui-mobile/src/forge/adventure/world/OpenSimplexNoise.java
@@ -66,9 +66,9 @@ public class OpenSimplexNoise {
                 new Grad2(-0.38268343236509, 0.923879532511287),
                 new Grad2(-0.130526192220052, 0.99144486137381)
         };
-        for (int i = 0; i < grad2.length; i++) {
-            grad2[i].dx /= N2;
-            grad2[i].dy /= N2;
+        for (Grad2 value : grad2) {
+            value.dx /= N2;
+            value.dy /= N2;
         }
         for (int i = 0; i < PSIZE; i++) {
             GRADIENTS_2D[i] = grad2[i % grad2.length];
@@ -124,10 +124,10 @@ public class OpenSimplexNoise {
                 new Grad3(-0.24732126143473554, 1.6667938651159684, 2.838945207362466),
                 new Grad3(1.6667938651159684, -0.24732126143473554, 2.838945207362466)
         };
-        for (int i = 0; i < grad3.length; i++) {
-            grad3[i].dx /= N3;
-            grad3[i].dy /= N3;
-            grad3[i].dz /= N3;
+        for (Grad3 value : grad3) {
+            value.dx /= N3;
+            value.dy /= N3;
+            value.dz /= N3;
         }
         for (int i = 0; i < PSIZE; i++) {
             GRADIENTS_3D[i] = grad3[i % grad3.length];
@@ -295,11 +295,11 @@ public class OpenSimplexNoise {
                 new Grad4(0.7821684431180708, 0.4321472685365301, 0.4321472685365301, -0.12128480194602098),
                 new Grad4(0.753341017856078, 0.37968289875261624, 0.37968289875261624, 0.37968289875261624)
         };
-        for (int i = 0; i < grad4.length; i++) {
-            grad4[i].dx /= N4;
-            grad4[i].dy /= N4;
-            grad4[i].dz /= N4;
-            grad4[i].dw /= N4;
+        for (Grad4 value : grad4) {
+            value.dx /= N4;
+            value.dy /= N4;
+            value.dz /= N4;
+            value.dw /= N4;
         }
         for (int i = 0; i < PSIZE; i++) {
             GRADIENTS_4D[i] = grad4[i % grad4.length];

--- a/forge-gui-mobile/src/forge/adventure/world/SimpleTiledModel.java
+++ b/forge-gui-mobile/src/forge/adventure/world/SimpleTiledModel.java
@@ -202,11 +202,11 @@ public class SimpleTiledModel extends Model {
       
       
       int L = action.get(firstOccurrence.get(left[0]))[left.length == 1 ? 0
-          : Integer.valueOf(left[1])];
+          : Integer.parseInt(left[1])];
       int D = action.get(L)[1];
 
       int R = action.get(firstOccurrence.get(right[0]))[right.length == 1 ? 0
-          : Integer.valueOf(right[1])];
+          : Integer.parseInt(right[1])];
       int U = action.get(R)[1];
       
       

--- a/forge-gui-mobile/src/forge/adventure/world/WorldSave.java
+++ b/forge-gui-mobile/src/forge/adventure/world/WorldSave.java
@@ -101,7 +101,7 @@ public class WorldSave   {
             return QUICK_SAVE_SLOT;
         if (!name.contains("_") || !name.endsWith(".sav"))
             return INVALID_SAVE_SLOT;
-        return Integer.valueOf(name.split("_")[0]);
+        return Integer.parseInt(name.split("_")[0]);
     }
 
     static public String filename(int slot) {

--- a/forge-gui-mobile/src/forge/assets/FSkinFont.java
+++ b/forge-gui-mobile/src/forge/assets/FSkinFont.java
@@ -369,12 +369,12 @@ public class FSkinFont {
         }
         String[] translationFilePaths = { ForgeConstants.LANG_DIR + "cardnames-" + langCode + ".txt",
                 ForgeConstants.LANG_DIR + langCode + ".properties" };
-        for (int i = 0; i < translationFilePaths.length; i++) {
-            try (LineReader translationFile = new LineReader(new FileInputStream(translationFilePaths[i]),
+        for (String translationFilePath : translationFilePaths) {
+            try (LineReader translationFile = new LineReader(new FileInputStream(translationFilePath),
                     StandardCharsets.UTF_8)) {
                 for (String fileLine : translationFile.readLines()) {
                     final int stringLength = fileLine.length();
-                    for (int offset = 0; offset < stringLength;) {
+                    for (int offset = 0; offset < stringLength; ) {
                         final int codePoint = fileLine.codePointAt(offset);
                         if (!characterSet.contains(codePoint)) {
                             characterSet.add(codePoint);
@@ -386,7 +386,7 @@ public class FSkinFont {
                 translationFile.close();
             } catch (IOException e) {
                 if (!"en-US".equalsIgnoreCase(langCode))
-                    System.err.println("Error reading translation file: " + translationFilePaths[i]);
+                    System.err.println("Error reading translation file: " + translationFilePath);
             }
         }
         langUniqueCharacterSet.put(langCode, characters.toString());

--- a/forge-gui-mobile/src/forge/card/CardRenderer.java
+++ b/forge-gui-mobile/src/forge/card/CardRenderer.java
@@ -809,10 +809,10 @@ public class CardRenderer {
             //draw indicator for flash or can be cast at instant speed, enabled if show ability icons is enabled
             String keywordKey = card.getCurrentState().getKeywordKey();
             String abilityText = card.getCurrentState().getAbilityText();
-            if ((keywordKey.indexOf("Flash") != -1)
-                    || ((abilityText.indexOf("May be played by") != -1)
-                    && (abilityText.indexOf("and as though it has flash") != -1))) {
-                if (keywordKey.indexOf("Flashback") == -1)
+            if ((keywordKey.contains("Flash"))
+                    || ((abilityText.contains("May be played by"))
+                    && (abilityText.contains("and as though it has flash")))) {
+                if (!keywordKey.contains("Flashback"))
                     CardFaceSymbols.drawSymbol("flash", g, cx + ((cw * 2) / 2.3f), cy, cw / 5.5f, cw / 5.5f);
             }
         }

--- a/forge-gui-mobile/src/forge/deck/FDeckViewer.java
+++ b/forge-gui-mobile/src/forge/deck/FDeckViewer.java
@@ -83,7 +83,7 @@ public class FDeckViewer extends FScreen {
     };
 
     public static void copyDeckToClipboard(Deck deck) {
-        final String nl = System.getProperty("line.separator");
+        final String nl = System.lineSeparator();
         final StringBuilder deckList = new StringBuilder();
         String dName = deck.getName();
         //fix copying a commander netdeck then importing it again...

--- a/forge-gui-mobile/src/forge/itemmanager/views/ImageView.java
+++ b/forge-gui-mobile/src/forge/itemmanager/views/ImageView.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
+import java.util.stream.IntStream;
 
 public class ImageView<T extends InventoryItem> extends ItemView<T> {
     private static final float PADDING = Utils.scale(5);
@@ -673,9 +674,7 @@ public class ImageView<T extends InventoryItem> extends ItemView<T> {
     @Override
     public void selectAll() {
         clearSelection();
-        for (Integer i = 0; i < getCount(); i++) {
-            selectedIndices.add(i);
-        }
+        IntStream.range(0, getCount()).forEach(selectedIndices::add);
         updateSelection();
         onSelectionChange();
     }

--- a/forge-gui-mobile/src/forge/itemmanager/views/ItemListView.java
+++ b/forge-gui-mobile/src/forge/itemmanager/views/ItemListView.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.IntStream;
 
 import com.badlogic.gdx.math.Rectangle;
 
@@ -154,9 +155,7 @@ public final class ItemListView<T extends InventoryItem> extends ItemView<T> {
     @Override
     public void selectAll() {
         selectedIndices.clear();
-        for (Integer i = 0; i < getCount(); i++) {
-            selectedIndices.add(i);
-        }
+        IntStream.range(0, getCount()).forEach(i -> selectedIndices.add(i));
         onSelectionChange();
     }
 

--- a/forge-gui-mobile/src/forge/itemmanager/views/ItemListView.java
+++ b/forge-gui-mobile/src/forge/itemmanager/views/ItemListView.java
@@ -61,7 +61,7 @@ public final class ItemListView<T extends InventoryItem> extends ItemView<T> {
 
     private final ItemList list = new ItemList();
     private final ItemListModel listModel;
-    private List<Integer> selectedIndices = new ArrayList<>();
+    private final List<Integer> selectedIndices = new ArrayList<>();
 
     public ItemListModel getListModel() {
         return listModel;
@@ -155,7 +155,7 @@ public final class ItemListView<T extends InventoryItem> extends ItemView<T> {
     @Override
     public void selectAll() {
         selectedIndices.clear();
-        IntStream.range(0, getCount()).forEach(i -> selectedIndices.add(i));
+        IntStream.range(0, getCount()).forEach(selectedIndices::add);
         onSelectionChange();
     }
 

--- a/forge-gui-mobile/src/forge/screens/match/views/VAssignGenericAmount.java
+++ b/forge-gui-mobile/src/forge/screens/match/views/VAssignGenericAmount.java
@@ -181,7 +181,7 @@ public class VAssignGenericAmount extends FDialog {
                 obj = add(new MiscTargetPanel(player.getName(), MatchController.getPlayerAvatar(player)));
             } else if (entity instanceof Byte) {
                 FSkinImageInterface manaSymbol;
-                Byte color = (Byte) entity;
+                byte color = (Byte) entity;
                 if (color == MagicColor.WHITE) {
                     manaSymbol = Forge.getAssets().images().get(FSkinProp.IMG_MANA_W);
                 } else if (color == MagicColor.BLUE) {

--- a/forge-gui-mobile/src/forge/toolbox/GuiChoose.java
+++ b/forge-gui-mobile/src/forge/toolbox/GuiChoose.java
@@ -153,7 +153,7 @@ public class GuiChoose {
 
         final Integer[] choices = new Integer[count];
         for (int i = 0; i < count; i++) {
-            choices[i] = Integer.valueOf(i + min);
+            choices[i] = i + min;
         }
         oneOrNone(message, choices, callback);
     }
@@ -170,7 +170,7 @@ public class GuiChoose {
 
         List<Object> choices = new ArrayList<>();
         for (int i = min; i <= cutoff; i++) {
-            choices.add(Integer.valueOf(i));
+            choices.add(i);
         }
         choices.add(Forge.getLocalizer().getMessage("lblOther") + "...");
 

--- a/forge-gui-mobile/src/forge/toolbox/GuiChoose.java
+++ b/forge-gui-mobile/src/forge/toolbox/GuiChoose.java
@@ -210,7 +210,7 @@ public class GuiChoose {
                     return;
                 }
                 if (StringUtils.isNumeric(result)) {
-                    Integer val = Integer.valueOf(result);
+                    int val = Integer.parseInt(result);
                     if (val >= min && val <= max) {
                         callback.run(val);
                         return;

--- a/forge-gui-mobile/src/forge/toolbox/GuiDialog.java
+++ b/forge-gui-mobile/src/forge/toolbox/GuiDialog.java
@@ -31,7 +31,7 @@ public class GuiDialog {
         final List<String> opts = options == null ? defaultConfirmOptions : options;
         FOptionPane.showCardOptionDialog(c, questionToUse, title, FOptionPane.QUESTION_ICON, opts, defaultIsYes ? 0 : 1, new Callback<Integer>() {
             @Override public void run(final Integer result) {
-                callback.run(result.intValue() == 0);
+                callback.run(result == 0);
             }
         });
     }

--- a/forge-gui-mobile/src/forge/util/BlurUtils.java
+++ b/forge-gui-mobile/src/forge/util/BlurUtils.java
@@ -242,8 +242,7 @@ public class BlurUtils {
      */
     public static ByteBuffer unpack(int[] pixels) {
         ByteBuffer buf = BufferUtils.newByteBuffer(pixels.length * 4);
-        for (int src = 0; src < pixels.length; src++) {
-            int value = pixels[src];
+        for (int value : pixels) {
             buf.put((byte) ((value & 0xff000000) >>> 24))
                     .put((byte) ((value & 0x00ff0000) >>> 16))
                     .put((byte) ((value & 0x0000ff00) >>> 8))

--- a/forge-gui/src/main/java/forge/gamemodes/limited/CardRanker.java
+++ b/forge-gui/src/main/java/forge/gamemodes/limited/CardRanker.java
@@ -130,7 +130,7 @@ public class CardRanker {
     }
 
     public static double getRawScore(PaperCard card) {
-        Double rawScore;
+        double rawScore;
         if (MagicColor.Constant.BASIC_LANDS.contains(card.getName())) {
             rawScore = SCORE_UNPICKABLE;
         } else {

--- a/forge-gui/src/main/java/forge/gamemodes/limited/DeckColors.java
+++ b/forge-gui/src/main/java/forge/gamemodes/limited/DeckColors.java
@@ -69,7 +69,7 @@ public class DeckColors {
     public void setColorsByList(final List<Byte> colors) {
         colorMask = 0;
         for (final Byte col : colors) {
-            colorMask |= col.byteValue();
+            colorMask |= col;
         }
         chosen = null;
     }

--- a/forge-gui/src/main/java/forge/gamemodes/limited/WinstonDraft.java
+++ b/forge-gui/src/main/java/forge/gamemodes/limited/WinstonDraft.java
@@ -39,9 +39,8 @@ public class WinstonDraft extends BoosterDraft {
 
     private void initializeWinstonDraft() {
         this.deck = new Stack<>();
-        for (int i = 0; i < this.product.size(); i++) {
-            final Supplier<List<PaperCard>> supply = this.product.get(i);
-            for(int j = 0; j < NUM_PLAYERS; j++) {
+        for (final Supplier<List<PaperCard>> supply : this.product) {
+            for (int j = 0; j < NUM_PLAYERS; j++) {
                 // Remove Basic Lands from draft for simplicity
                 for (final PaperCard paperCard : Iterables.filter(supply.get(), Predicates.not(PaperCard.Predicates.Presets.IS_BASIC_LAND))) {
                     this.deck.add(paperCard);

--- a/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
@@ -525,7 +525,7 @@ public abstract class AbstractGuiGame implements IGuiGame, IMayViewCards {
 
     @Override
     public final boolean shouldAutoYield(final String key) {
-        String abilityKey = key.indexOf("): ") != -1 ? key.substring(key.indexOf("): ") + 3) : key;
+        String abilityKey = key.contains("): ") ? key.substring(key.indexOf("): ") + 3) : key;
         boolean yieldPerAbility = FModel.getPreferences().getPref(ForgePreferences.FPref.UI_AUTO_YIELD_MODE).equals(ForgeConstants.AUTO_YIELD_PER_ABILITY);
 
         return !getDisableAutoYields() && autoYields.contains(yieldPerAbility ? abilityKey : key);
@@ -533,7 +533,7 @@ public abstract class AbstractGuiGame implements IGuiGame, IMayViewCards {
 
     @Override
     public final void setShouldAutoYield(final String key, final boolean autoYield) {
-        String abilityKey = key.indexOf("): ") != -1 ? key.substring(key.indexOf("): ") + 3) : key;
+        String abilityKey = key.contains("): ") ? key.substring(key.indexOf("): ") + 3) : key;
         boolean yieldPerAbility = FModel.getPreferences().getPref(ForgePreferences.FPref.UI_AUTO_YIELD_MODE).equals(ForgeConstants.AUTO_YIELD_PER_ABILITY);
 
         if (autoYield) {

--- a/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
@@ -723,7 +723,7 @@ public abstract class AbstractGuiGame implements IGuiGame, IMayViewCards {
             } // that is 'cancel'
 
             if (StringUtils.isNumeric(str)) {
-                final Integer val = Integer.valueOf(str);
+                final int val = Integer.parseInt(str);
                 if (val >= min && val <= max) {
                     return val;
                 }

--- a/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
@@ -564,27 +564,27 @@ public abstract class AbstractGuiGame implements IGuiGame, IMayViewCards {
 
     @Override
     public final boolean shouldAlwaysAcceptTrigger(final int trigger) {
-        return Boolean.TRUE.equals(triggersAlwaysAccept.get(Integer.valueOf(trigger)));
+        return Boolean.TRUE.equals(triggersAlwaysAccept.get(trigger));
     }
 
     @Override
     public final boolean shouldAlwaysDeclineTrigger(final int trigger) {
-        return Boolean.FALSE.equals(triggersAlwaysAccept.get(Integer.valueOf(trigger)));
+        return Boolean.FALSE.equals(triggersAlwaysAccept.get(trigger));
     }
 
     @Override
     public final void setShouldAlwaysAcceptTrigger(final int trigger) {
-        triggersAlwaysAccept.put(Integer.valueOf(trigger), Boolean.TRUE);
+        triggersAlwaysAccept.put(trigger, Boolean.TRUE);
     }
 
     @Override
     public final void setShouldAlwaysDeclineTrigger(final int trigger) {
-        triggersAlwaysAccept.put(Integer.valueOf(trigger), Boolean.FALSE);
+        triggersAlwaysAccept.put(trigger, Boolean.FALSE);
     }
 
     @Override
     public final void setShouldAlwaysAskTrigger(final int trigger) {
-        triggersAlwaysAccept.remove(Integer.valueOf(trigger));
+        triggersAlwaysAccept.remove(trigger);
     }
 
     // End of Triggers preliminary choice
@@ -672,11 +672,11 @@ public abstract class AbstractGuiGame implements IGuiGame, IMayViewCards {
         final Integer[] choices = new Integer[count];
         if (sortDesc) {
             for (int i = 0; i < count; i++) {
-                choices[count - i - 1] = Integer.valueOf(i + min);
+                choices[count - i - 1] = i + min;
             }
         } else {
             for (int i = 0; i < count; i++) {
-                choices[i] = Integer.valueOf(i + min);
+                choices[i] = i + min;
             }
         }
         return oneOrNone(message, ImmutableList.copyOf(choices));
@@ -694,7 +694,7 @@ public abstract class AbstractGuiGame implements IGuiGame, IMayViewCards {
 
         final ImmutableList.Builder<Serializable> choices = ImmutableList.builder();
         for (int i = min; i <= cutoff; i++) {
-            choices.add(Integer.valueOf(i));
+            choices.add(i);
         }
         choices.add(Localizer.getInstance().getMessage("lblOtherInteger"));
 

--- a/forge-gui/src/main/java/forge/gamemodes/match/GameLobby.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/GameLobby.java
@@ -107,8 +107,8 @@ public abstract class GameLobby implements IHasGameType {
 
         final int nSlots = getNumberOfSlots();
         final boolean triesToChangeArchenemy = event.getArchenemy() != null;
-        final boolean archenemyRemoved = triesToChangeArchenemy && !event.getArchenemy().booleanValue();
-        final boolean hasArchenemyChanged = triesToChangeArchenemy && slot.isArchenemy() != event.getArchenemy().booleanValue();
+        final boolean archenemyRemoved = triesToChangeArchenemy && !event.getArchenemy();
+        final boolean hasArchenemyChanged = triesToChangeArchenemy && slot.isArchenemy() != event.getArchenemy();
 
         final boolean changed = slot.apply(event) || hasArchenemyChanged;
 
@@ -191,7 +191,7 @@ public abstract class GameLobby implements IHasGameType {
         final int[] result = new int[sAvatars.length];
         for (int i = 0; i < sAvatars.length; i++) {
             final Integer val = Ints.tryParse(sAvatars[i]);
-            result[i] = val == null ? -1 : val.intValue();
+            result[i] = val == null ? -1 : val;
         }
         return result;
     }
@@ -200,7 +200,7 @@ public abstract class GameLobby implements IHasGameType {
         final int[] result = new int[sSleeves.length];
         for (int i = 0; i < sSleeves.length; i++) {
             final Integer val = Ints.tryParse(sSleeves[i]);
-            result[i] = val == null ? -1 : val.intValue();
+            result[i] = val == null ? -1 : val;
         }
         return result;
     }

--- a/forge-gui/src/main/java/forge/gamemodes/match/LobbySlot.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/LobbySlot.java
@@ -62,15 +62,15 @@ public final class LobbySlot implements Serializable {
             changed = true;
         }
         if (data.getArchenemy() != null) {
-            setIsArchenemy(data.getArchenemy().booleanValue());
+            setIsArchenemy(data.getArchenemy());
             changed = true;
         }
         if (data.getReady() != null) {
-            setIsReady(data.getReady().booleanValue());
+            setIsReady(data.getReady());
             changed = true;
         }
         if (data.getDevMode() != null) {
-            setIsDevMode(data.getDevMode().booleanValue());
+            setIsDevMode(data.getDevMode());
             changed = true;
         }
         if (data.getAiOptions() != null) {

--- a/forge-gui/src/main/java/forge/gamemodes/net/ReplyPool.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/ReplyPool.java
@@ -18,20 +18,20 @@ public class ReplyPool {
 
     public void initialize(final int index) {
         synchronized (pool) {
-            pool.put(Integer.valueOf(index), new CompletableFuture());
+            pool.put(index, new CompletableFuture());
         }
     }
 
     public void complete(final int index, final Object value) {
         synchronized (pool) {
-            pool.get(Integer.valueOf(index)).set(value);
+            pool.get(index).set(value);
         }
     }
 
     public Object get(final int index) throws TimeoutException {
         final CompletableFuture future;
         synchronized (pool) {
-            future = pool.get(Integer.valueOf(index));
+            future = pool.get(index);
         }
         try {
             return future.get(5, TimeUnit.MINUTES);

--- a/forge-gui/src/main/java/forge/gamemodes/net/client/NetGameController.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/client/NetGameController.java
@@ -31,7 +31,7 @@ public class NetGameController implements IGameController {
 
     @Override
     public void useMana(final byte color) {
-        send(ProtocolMethod.useMana, Byte.valueOf(color));
+        send(ProtocolMethod.useMana, color);
     }
 
     @Override
@@ -118,7 +118,7 @@ public class NetGameController implements IGameController {
 
     @Override
     public void reorderHand(final CardView card, final int index) {
-        send(ProtocolMethod.reorderHand, card, Integer.valueOf(index));
+        send(ProtocolMethod.reorderHand, card, index);
     }
 
     private IMacroSystem macros;

--- a/forge-gui/src/main/java/forge/gamemodes/planarconquest/ConquestEvent.java
+++ b/forge-gui/src/main/java/forge/gamemodes/planarconquest/ConquestEvent.java
@@ -249,8 +249,7 @@ public class ConquestEvent {
 
         public int getTotalWins() {
             int wins = 0;
-            for (int i = 0; i < tiers.length; i++) {
-                ConquestRecord record = tiers[i];
+            for (ConquestRecord record : tiers) {
                 if (record != null) {
                     wins += record.getWins();
                 }
@@ -259,8 +258,7 @@ public class ConquestEvent {
         }
         public int getTotalLosses() {
             int losses = 0;
-            for (int i = 0; i < tiers.length; i++) {
-                ConquestRecord record = tiers[i];
+            for (ConquestRecord record : tiers) {
                 if (record != null) {
                     losses += record.getLosses();
                 }

--- a/forge-gui/src/main/java/forge/gamemodes/planarconquest/ConquestPlaneData.java
+++ b/forge-gui/src/main/java/forge/gamemodes/planarconquest/ConquestPlaneData.java
@@ -82,8 +82,7 @@ public class ConquestPlaneData implements IXmlWritable {
 
     public int getTotalWins() {
         int wins = 0;
-        for (int i = 0; i < eventResults.length; i++) {
-            ConquestEventRecord result = eventResults[i];
+        for (ConquestEventRecord result : eventResults) {
             if (result != null) {
                 wins += result.getTotalWins();
             }
@@ -93,8 +92,7 @@ public class ConquestPlaneData implements IXmlWritable {
 
     public int getTotalLosses() {
         int losses = 0;
-        for (int i = 0; i < eventResults.length; i++) {
-            ConquestEventRecord result = eventResults[i];
+        for (ConquestEventRecord result : eventResults) {
             if (result != null) {
                 losses += result.getTotalLosses();
             }

--- a/forge-gui/src/main/java/forge/gamemodes/quest/QuestEventDraft.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/QuestEventDraft.java
@@ -1069,7 +1069,7 @@ public class QuestEventDraft implements IQuestEvent {
             if (standings[i].equals(HUMAN)) {
                 bracket.addTournamentPlayer(GamePlayerUtil.getGuiPlayer());
             } else {
-                int idx = Integer.valueOf(standings[i]) - 1;
+                int idx = Integer.parseInt(standings[i]) - 1;
                 bracket.addTournamentPlayer(GamePlayerUtil.createAiPlayer(aiNames[idx], aiIcons[idx]), idx);
             }
         }
@@ -1088,7 +1088,7 @@ public class QuestEventDraft implements IQuestEvent {
                 // Bracket now up to date!
                 break;
             } else {
-                int idx = standings[i].equals(HUMAN) ? -1 : Integer.valueOf(standings[i]) - 1;
+                int idx = standings[i].equals(HUMAN) ? -1 : Integer.parseInt(standings[i]) - 1;
                 pairing.setWinnerByIndex(idx);
                 bracket.reportMatchCompletion(pairing);
             }

--- a/forge-gui/src/main/java/forge/gamemodes/quest/QuestEventLDADuelManager.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/QuestEventLDADuelManager.java
@@ -68,11 +68,11 @@ public class QuestEventLDADuelManager implements QuestEventDuelManagerInterface 
             duel.setTitle(archetype.getName());
             duel.setOpponentName(archetype.getName());
             QuestEventDifficulty diff = QuestEventDifficulty.EASY;
-            if(i <= Float.valueOf(archetypes.size())*.1){
+            if(i <= ((float) archetypes.size()) * 0.1){
                 diff = QuestEventDifficulty.EXPERT;
-            }else if(i <= Float.valueOf(archetypes.size())*.4){
+            }else if(i <= ((float) archetypes.size()) * 0.4){
                 diff = QuestEventDifficulty.HARD;
-            }else if(i <= Float.valueOf(archetypes.size())*.7) {
+            }else if(i <= ((float) archetypes.size()) * 0.7) {
                 diff = QuestEventDifficulty.MEDIUM;
             }
             duel.setDifficulty(diff);

--- a/forge-gui/src/main/java/forge/gamemodes/quest/QuestSpellShop.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/QuestSpellShop.java
@@ -161,8 +161,7 @@ public class QuestSpellShop {
     public static final Function<Entry<? extends InventoryItem, Integer>, Object> fnDeckGet = new Function<Entry<? extends InventoryItem, Integer>, Object>() {
         @Override
         public Object apply(final Entry<? extends InventoryItem, Integer> from) {
-            final Integer iValue = decksUsingMyCards.count(from.getKey());
-            return iValue.toString();
+            return Integer.toString(decksUsingMyCards.count(from.getKey()));
         }
     };
 

--- a/forge-gui/src/main/java/forge/gamemodes/quest/QuestUtilUnlockSets.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/QuestUtilUnlockSets.java
@@ -69,7 +69,7 @@ public class QuestUtilUnlockSets {
         final Map<String, Integer> mapPrices = prices.getPriceList();
         final List<ImmutablePair<CardEdition, Integer>> setPrices = new ArrayList<>();
 
-        Double multiplier = 1d;
+        double multiplier = 1d;
         int j = 0;
         for (CardEdition ed : getUnlockableEditions(qData)) {
             j++;

--- a/forge-gui/src/main/java/forge/gamemodes/quest/bazaar/QuestBazaarManager.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/bazaar/QuestBazaarManager.java
@@ -112,11 +112,7 @@ public class QuestBazaarManager {
                 items.put(name, ctrl);
             }
 
-        } catch (final SAXException e) {
-            e.printStackTrace();
-        } catch (final IOException e) {
-            e.printStackTrace();
-        } catch (final ParserConfigurationException e) {
+        } catch (final SAXException | IOException | ParserConfigurationException e) {
             e.printStackTrace();
         }
     }

--- a/forge-gui/src/main/java/forge/gamemodes/quest/bazaar/QuestPetStorage.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/bazaar/QuestPetStorage.java
@@ -76,11 +76,7 @@ public class QuestPetStorage {
                 this.addToMap(petCtrl);
             }
 
-        } catch (final SAXException e) {
-            e.printStackTrace();
-        } catch (final IOException e) {
-            e.printStackTrace();
-        } catch (final ParserConfigurationException e) {
+        } catch (final SAXException | IOException | ParserConfigurationException e) {
             e.printStackTrace();
         }
     }

--- a/forge-gui/src/main/java/forge/gamemodes/quest/bazaar/QuestPetStorage.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/bazaar/QuestPetStorage.java
@@ -96,10 +96,10 @@ public class QuestPetStorage {
         * Refactoring this to List<QuestPetController> list = this.petsBySlot.computeIfAbsent(Integer.valueOf(iSlot), k -> new ArrayList<QuestPetController>());
         * will cause Android not to compile
         * */
-        List<QuestPetController> list = this.petsBySlot.get(Integer.valueOf(iSlot));
+        List<QuestPetController> list = this.petsBySlot.get(iSlot);
         if (null == list) {
             list = new ArrayList<>();
-            this.petsBySlot.put(Integer.valueOf(iSlot), list);
+            this.petsBySlot.put(iSlot, list);
         }
         this.petsByName.put(petCtrl.getName(), petCtrl);
         list.add(petCtrl);
@@ -124,7 +124,7 @@ public class QuestPetStorage {
      */
     public List<QuestPetController> getAvaliablePets(final int iSlot, final QuestAssets qA) {
         final List<QuestPetController> result = new ArrayList<>();
-        final List<QuestPetController> allPossible = this.petsBySlot.get(Integer.valueOf(iSlot));
+        final List<QuestPetController> allPossible = this.petsBySlot.get(iSlot);
         if (null != allPossible) {
             for (final QuestPetController c : allPossible) {
                 if (qA.getPetLevel(c.getSaveFileKey()) > 0) {
@@ -143,7 +143,7 @@ public class QuestPetStorage {
      */
     public List<QuestPetController> getAllPets(final int iSlot) {
         final List<QuestPetController> result = new ArrayList<>();
-        final List<QuestPetController> allPossible = this.petsBySlot.get(Integer.valueOf(iSlot));
+        final List<QuestPetController> allPossible = this.petsBySlot.get(iSlot);
         if (null != allPossible) {
             result.addAll(allPossible);
         }

--- a/forge-gui/src/main/java/forge/gamemodes/quest/data/QuestAchievements.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/data/QuestAchievements.java
@@ -292,9 +292,6 @@ public class QuestAchievements {
         try {
             return drafts.get(currentDraft);
         }
-        catch(ArrayIndexOutOfBoundsException e) {
-            return null;
-        }
         catch(IndexOutOfBoundsException e) {
             return null;
         }

--- a/forge-gui/src/main/java/forge/gamemodes/quest/data/QuestAssets.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/data/QuestAssets.java
@@ -104,13 +104,8 @@ public class QuestAssets {
                 modern.takeDataFrom(current);
                 current = modern;
                 inventoryItems.put(itemType, modern);
-            } catch (InstantiationException e) {
-                e.printStackTrace();
-            } catch (IllegalAccessException e) {
-                e.printStackTrace();
-            } catch (InvocationTargetException e) {
-                e.printStackTrace();
-            } catch (NoSuchMethodException e) {
+            } catch (InstantiationException | IllegalAccessException | InvocationTargetException |
+                     NoSuchMethodException e) {
                 e.printStackTrace();
             }
 

--- a/forge-gui/src/main/java/forge/gamemodes/quest/io/MainWorldDuelReader.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/io/MainWorldDuelReader.java
@@ -8,7 +8,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;

--- a/forge-gui/src/main/java/forge/gamemodes/quest/io/MainWorldDuelReader.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/io/MainWorldDuelReader.java
@@ -77,17 +77,16 @@ public class MainWorldDuelReader extends StorageReaderFolder<QuestEventDuel> {
 
         // then I add wild decks in constructed directory
         Iterable<DeckProxy> constructedDecks = DeckProxy.getAllConstructedDecks();
-        Iterator<DeckProxy> it = constructedDecks.iterator();
 
-        while(it.hasNext()) {
-            Deck currDeck = it.next().getDeck();
+        for (DeckProxy constructedDeck : constructedDecks) {
+            Deck currDeck = constructedDeck.getDeck();
             final QuestEventDuel newDeck = read(currDeck);
             String newKey = keySelector.apply(newDeck);
             if (result.containsKey(newKey)) {
                 System.err.println("StorageReaderFolder: an object with key " + newKey + " is already present - skipping new entry");
             } else {
-                result.put(newKey, newDeck);                       
-            }            
+                result.put(newKey, newDeck);
+            }
         }
         
         return result;

--- a/forge-gui/src/main/java/forge/gui/card/CardDetailUtil.java
+++ b/forge-gui/src/main/java/forge/gui/card/CardDetailUtil.java
@@ -390,7 +390,7 @@ public class CardDetailUtil {
         // counter text
         if (card.getCounters() != null) {
             for (final Entry<CounterType, Integer> c : card.getCounters().entrySet()) {
-                if (c.getValue().intValue() != 0) {
+                if (c.getValue() != 0) {
                     if (area.length() != 0) {
                         area.append("\n");
                     }

--- a/forge-gui/src/main/java/forge/gui/control/FControlGamePlayback.java
+++ b/forge-gui/src/main/java/forge/gui/control/FControlGamePlayback.java
@@ -167,10 +167,7 @@ public class FControlGamePlayback extends IGameEventVisitor.Base<Void> {
                 gameThreadPauser.await();
                 gameThreadPauser.reset();
             }
-            catch (final InterruptedException e) {
-                e.printStackTrace();
-            }
-            catch (final BrokenBarrierException e) {
+            catch (final InterruptedException | BrokenBarrierException e) {
                 e.printStackTrace();
             }
         }
@@ -191,10 +188,7 @@ public class FControlGamePlayback extends IGameEventVisitor.Base<Void> {
             public void run() {
                 try {
                     gameThreadPauser.await();
-                } catch (final InterruptedException e) {
-                    // Auto-generated catch block ignores the exception, but sends it to System.err and probably forge.log.
-                    e.printStackTrace();
-                } catch (final BrokenBarrierException e) {
+                } catch (final InterruptedException | BrokenBarrierException e) {
                     // Auto-generated catch block ignores the exception, but sends it to System.err and probably forge.log.
                     e.printStackTrace();
                 }

--- a/forge-gui/src/main/java/forge/gui/util/SGuiChoose.java
+++ b/forge-gui/src/main/java/forge/gui/util/SGuiChoose.java
@@ -87,12 +87,12 @@ public class SGuiChoose {
         final Integer[] choices = new Integer[count];
         if (sortDesc) {
             for (int i = 0; i < count; i++) {
-                choices[count - i - 1] = Integer.valueOf(i + min);
+                choices[count - i - 1] = i + min;
             }
         }
         else {
             for (int i = 0; i < count; i++) {
-                choices[i] = Integer.valueOf(i + min);
+                choices[i] = i + min;
             }
         }
         return SGuiChoose.oneOrNone(message, choices);
@@ -107,7 +107,7 @@ public class SGuiChoose {
 
         final List<Object> choices = new ArrayList<>();
         for (int i = min; i <= cutoff; i++) {
-            choices.add(Integer.valueOf(i));
+            choices.add(i);
         }
         choices.add("...");
 

--- a/forge-gui/src/main/java/forge/gui/util/SGuiChoose.java
+++ b/forge-gui/src/main/java/forge/gui/util/SGuiChoose.java
@@ -136,7 +136,7 @@ public class SGuiChoose {
             if (str == null) { return null; } // that is 'cancel'
 
             if (StringUtils.isNumeric(str)) {
-                final Integer val = Integer.valueOf(str);
+                final int val = Integer.parseInt(str);
                 if (val >= min && val <= max) {
                     return val;
                 }

--- a/forge-gui/src/main/java/forge/itemmanager/AdvancedSearch.java
+++ b/forge-gui/src/main/java/forge/itemmanager/AdvancedSearch.java
@@ -822,7 +822,7 @@ public class AdvancedSearch {
             @Override
             public boolean apply(String input, List<String> values) {
                 if (input != null) {
-                    return input.toLowerCase().indexOf(values.get(0).toLowerCase()) != -1;
+                    return input.toLowerCase().contains(values.get(0).toLowerCase());
                 }
                 return false;
             }

--- a/forge-gui/src/main/java/forge/itemmanager/AdvancedSearch.java
+++ b/forge-gui/src/main/java/forge/itemmanager/AdvancedSearch.java
@@ -728,7 +728,7 @@ public class AdvancedSearch {
             @Override
             public boolean apply(Boolean input, List<Boolean> values) {
                 if (input != null) {
-                    return input.booleanValue();
+                    return input;
                 }
                 return false;
             }
@@ -737,7 +737,7 @@ public class AdvancedSearch {
             @Override
             public boolean apply(Boolean input, List<Boolean> values) {
                 if (input != null) {
-                    return !input.booleanValue();
+                    return !input;
                 }
                 return false;
             }
@@ -766,7 +766,7 @@ public class AdvancedSearch {
             @Override
             public boolean apply(Integer input, List<Integer> values) {
                 if (input != null) {
-                    return input.intValue() > values.get(0).intValue();
+                    return input > values.get(0);
                 }
                 return false;
             }
@@ -775,7 +775,7 @@ public class AdvancedSearch {
             @Override
             public boolean apply(Integer input, List<Integer> values) {
                 if (input != null) {
-                    return input.intValue() < values.get(0).intValue();
+                    return input < values.get(0);
                 }
                 return false;
             }
@@ -784,7 +784,7 @@ public class AdvancedSearch {
             @Override
             public boolean apply(Integer input, List<Integer> values) {
                 if (input != null) {
-                    return input.intValue() >= values.get(0).intValue();
+                    return input >= values.get(0);
                 }
                 return false;
             }
@@ -793,7 +793,7 @@ public class AdvancedSearch {
             @Override
             public boolean apply(Integer input, List<Integer> values) {
                 if (input != null) {
-                    return input.intValue() <= values.get(0).intValue();
+                    return input <= values.get(0);
                 }
                 return false;
             }
@@ -802,8 +802,7 @@ public class AdvancedSearch {
             @Override
             public boolean apply(Integer input, List<Integer> values) {
                 if (input != null) {
-                    int inputValue = input.intValue();
-                    return values.get(0).intValue() <= inputValue && inputValue <= values.get(1).intValue();
+                    return values.get(0) <= input && input <= values.get(1);
                 }
                 return false;
             }
@@ -812,8 +811,7 @@ public class AdvancedSearch {
             @Override
             public boolean apply(Integer input, List<Integer> values) {
                 if (input != null) {
-                    int inputValue = input.intValue();
-                    return values.get(0).intValue() < inputValue && inputValue < values.get(1).intValue();
+                    return values.get(0) < input && input < values.get(1);
                 }
                 return false;
             }

--- a/forge-gui/src/main/java/forge/itemmanager/ColumnDef.java
+++ b/forge-gui/src/main/java/forge/itemmanager/ColumnDef.java
@@ -619,7 +619,7 @@ public enum ColumnDef {
             if (result == Integer.MAX_VALUE) {
                 if (((IPaperCard) i).getRules().getType().isPlaneswalker()) {
                     String loy = ((IPaperCard) i).getRules().getInitialLoyalty();
-                    result = StringUtils.isNumeric(loy) ? Integer.valueOf(loy) : 0;
+                    result = StringUtils.isNumeric(loy) ? Integer.parseInt(loy) : 0;
                 }
             }
         }

--- a/forge-gui/src/main/java/forge/itemmanager/ItemManagerModel.java
+++ b/forge-gui/src/main/java/forge/itemmanager/ItemManagerModel.java
@@ -189,9 +189,7 @@ public final class ItemManagerModel<T extends InventoryItem> {
             final List<ItemPoolSorter<InventoryItem>> oneColSorters = new ArrayList<>(maxSortDepth);
 
             synchronized (colsToSort) {
-                final Iterator<ItemColumn> it = colsToSort.iterator();
-                while (it.hasNext()) {
-                    final ItemColumn col = it.next();
+                for (ItemColumn col : colsToSort) {
                     oneColSorters.add(new ItemPoolSorter<>(
                             col.getFnSort(),
                             col.getConfig().getSortState().equals(SortState.ASC)));

--- a/forge-gui/src/main/java/forge/itemmanager/ItemManagerModel.java
+++ b/forge-gui/src/main/java/forge/itemmanager/ItemManagerModel.java
@@ -20,7 +20,6 @@ package forge.itemmanager;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 

--- a/forge-gui/src/main/java/forge/player/HumanCostDecision.java
+++ b/forge-gui/src/main/java/forge/player/HumanCostDecision.java
@@ -753,9 +753,9 @@ public class HumanCostDecision extends CostDecisionMakerBase {
                     payableZone.add(p);
                 }
             }
-            return putFromSame(list, c.intValue(), payableZone, cost.from);
+            return putFromSame(list, c, payableZone, cost.from);
         } else {//Graveyard
-            return putFromMiscZone(ability, c.intValue(), list, cost.from);
+            return putFromMiscZone(ability, c, list, cost.from);
         }
     }
 

--- a/forge-gui/src/main/java/forge/player/HumanCostDecision.java
+++ b/forge-gui/src/main/java/forge/player/HumanCostDecision.java
@@ -480,7 +480,7 @@ public class HumanCostDecision extends CostDecisionMakerBase {
         if (list.size() < c) {
             return null;
         }
-        Integer min = c;
+        int min = c;
         if (ability.isOptionalTrigger()) {
             min = 0;
         }
@@ -684,7 +684,7 @@ public class HumanCostDecision extends CostDecisionMakerBase {
 
     @Override
     public PaymentDecision visit(final CostPayEnergy cost) {
-        Integer c = cost.getAbilityAmount(ability);
+        int c = cost.getAbilityAmount(ability);
 
         if (player.canPayEnergy(c) &&
                 confirmAction(cost, Localizer.getInstance().getMessage("lblPayEnergyConfirm", cost.toString(), String.valueOf(player.getCounters(CounterEnumType.ENERGY)), "{E}"))) {
@@ -695,7 +695,7 @@ public class HumanCostDecision extends CostDecisionMakerBase {
 
     @Override
     public PaymentDecision visit(final CostPayShards cost) {
-        Integer c = cost.getAbilityAmount(ability);
+        int c = cost.getAbilityAmount(ability);
 
         if (player.canPayShards(c) &&
                 confirmAction(cost, Localizer.getInstance().getMessage("lblPayShardsConfirm", cost.toString(), String.valueOf(player.getNumManaShards()), "{M} (Mana Shards)"))) {
@@ -725,7 +725,7 @@ public class HumanCostDecision extends CostDecisionMakerBase {
 
     @Override
     public PaymentDecision visit(final CostPutCardToLib cost) {
-        Integer c = cost.getAbilityAmount(ability);
+        int c = cost.getAbilityAmount(ability);
 
         final CardCollection list = CardLists.getValidCards(cost.sameZone ? player.getGame().getCardsIn(cost.getFrom()) :
                 player.getCardsIn(cost.getFrom()), cost.getType().split(";"), player, source, ability);
@@ -906,7 +906,7 @@ public class HumanCostDecision extends CostDecisionMakerBase {
             };
             inp.setMessage(Localizer.getInstance().getMessage("lblSelectNCardOfSameColorToReveal", String.valueOf(num)));
         } else {
-            Integer num = cost.getAbilityAmount(ability);
+            int num = cost.getAbilityAmount(ability);
 
             CardCollectionView hand = player.getCardsIn(cost.getRevealFrom());
             hand = CardLists.getValidCards(hand, cost.getType().split(";"), player, source, ability);

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -1903,7 +1903,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
             boolean needPrompt = !activePlayerSAs.get(0).isTrigger();
 
             // for the purpose of pre-ordering, no need for extra granularity
-            Integer idxAdditionalInfo = firstStr.indexOf(" [");
+            int idxAdditionalInfo = firstStr.indexOf(" [");
             StringBuilder saLookupKey = new StringBuilder(idxAdditionalInfo > 0 ? firstStr.substring(0, idxAdditionalInfo - 1) : firstStr);
 
             char delim = (char) 5;

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -691,14 +691,14 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
             for (int i = 0; i <= size; i++) {
                 choices.add(i + min);
             }
-            return getGui().one(title, choices.build()).intValue();
+            return getGui().one(title, choices.build());
         }
     }
 
     @Override
     public int chooseNumber(final SpellAbility sa, final String title, final List<Integer> choices,
                             final Player relatedPlayer) {
-        return getGui().one(title, choices).intValue();
+        return getGui().one(title, choices);
     }
 
     @Override
@@ -1171,7 +1171,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
         for (int i = 0; i <= cardsInGrave; i++) {
             cntChoice.add(i);
         }
-        final int chosenAmount = getGui().one(localizer.getMessage("lblDelveHowManyCards"), cntChoice.build()).intValue();
+        final int chosenAmount = getGui().one(localizer.getMessage("lblDelveHowManyCards"), cntChoice.build());
 
         GameEntityViewMap<Card, CardView> gameCacheGrave = GameEntityView.getMap(grave);
         for (int i = 0; i < chosenAmount; i++) {
@@ -1638,7 +1638,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
                 labels = ImmutableList.copyOf(kindOfChoice.toString().split("Or"));
         }
 
-        return InputConfirm.confirm(this, sa, question, defaultVal == null || defaultVal.booleanValue(), labels);
+        return InputConfirm.confirm(this, sa, question, defaultVal == null || defaultVal, labels);
     }
 
     @Override
@@ -1781,7 +1781,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
             colorNamesBuilder.add(MagicColor.toLongString(MagicColor.COLORLESS));
         }
         for (final Byte b : colors) {
-            colorNamesBuilder.add(MagicColor.toLongString(b.byteValue()));
+            colorNamesBuilder.add(MagicColor.toLongString(b));
         }
         final ImmutableList<String> colorNames = colorNamesBuilder.build();
         if (colorNames.size() > 2) {
@@ -3246,7 +3246,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
         }
 
         Integer v = getGui().getInteger(prompt, 0, max, 9);
-        return v == null ? 0 : v.intValue();
+        return v == null ? 0 : v;
     }
 
     @Override

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -689,7 +689,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
             final ImmutableList.Builder<Integer> choices = ImmutableList.builder();
             int size = max - min;
             for (int i = 0; i <= size; i++) {
-                choices.add(Integer.valueOf(i + min));
+                choices.add(i + min);
             }
             return getGui().one(title, choices.build()).intValue();
         }
@@ -1169,7 +1169,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
         final CardCollection toExile = new CardCollection();
         final ImmutableList.Builder<Integer> cntChoice = ImmutableList.builder();
         for (int i = 0; i <= cardsInGrave; i++) {
-            cntChoice.add(Integer.valueOf(i));
+            cntChoice.add(i);
         }
         final int chosenAmount = getGui().one(localizer.getMessage("lblDelveHowManyCards"), cntChoice.build()).intValue();
 

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -362,17 +362,14 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
         final CardView vSource = CardView.get(sa.getHostCard());
         final Map<Object, Integer> vAffected = new LinkedHashMap<>(manaAmount);
         Integer maxAmount = different ? 1 : manaAmount;
-        Iterator<Byte> it = colorSet.iterator();
-        while (it.hasNext()) {
-            vAffected.put(it.next(), maxAmount);
+        for (Byte color : colorSet) {
+            vAffected.put(color, maxAmount);
         }
         final Map<Object, Integer> vResult = getGui().assignGenericAmount(vSource, vAffected, manaAmount, false,
                 localizer.getMessage("lblMana").toLowerCase());
         Map<Byte, Integer> result = new HashMap<>();
         if (vResult != null) { //fix for netplay
-            it = colorSet.iterator();
-            while (it.hasNext()) {
-                Byte color = it.next();
+            for (Byte color : colorSet) {
                 if (vResult.containsKey(color)) {
                     result.put(color, vResult.get(color));
                 }

--- a/forge-gui/src/main/java/forge/player/TargetSelection.java
+++ b/forge-gui/src/main/java/forge/player/TargetSelection.java
@@ -85,8 +85,8 @@ public class TargetSelection {
         final TargetRestrictions tgt = getTgt();
 
         // Number of targets is explicitly set only if spell is being redirected (ex. Swerve or Redirect)
-        final int minTargets = numTargets != null ? numTargets.intValue() : ability.getMinTargets();
-        final int maxTargets = numTargets != null ? numTargets.intValue() : ability.getMaxTargets();
+        final int minTargets = numTargets != null ? numTargets : ability.getMinTargets();
+        final int maxTargets = numTargets != null ? numTargets : ability.getMaxTargets();
         //final int maxTotalCMC = tgt.getMaxTotalCMC(ability.getHostCard(), ability);
         final int numTargeted = ability.getTargets().size();
         final boolean isSingleZone = tgt.isSingleZone();

--- a/forge-gui/src/main/java/forge/util/MultiplexOutputStream.java
+++ b/forge-gui/src/main/java/forge/util/MultiplexOutputStream.java
@@ -48,16 +48,16 @@ public class MultiplexOutputStream extends OutputStream {
     /** {@inheritDoc} */
     @Override
     public final void write(final int b) throws IOException {
-        for (int i = 0; i < streams.length; i++) {
-            streams[i].write(b);
+        for (OutputStream stream : streams) {
+            stream.write(b);
         }
     }
 
     /** {@inheritDoc} */
     @Override
     public final void write(final byte[] b, final int off, final int len) throws IOException {
-        for (int i = 0; i < streams.length; i++) {
-            streams[i].write(b, off, len);
+        for (OutputStream stream : streams) {
+            stream.write(b, off, len);
         }
     }
 }

--- a/forge-gui/src/main/java/forge/util/XmlReader.java
+++ b/forge-gui/src/main/java/forge/util/XmlReader.java
@@ -86,7 +86,7 @@ public class XmlReader {
                     @Override
                     public Void evaluate() {
                         try {
-                            Integer arrayIndex = Integer.valueOf(currentElement.getTagName().substring(1)); //trim "i" prefix
+                            int arrayIndex = Integer.parseInt(currentElement.getTagName().substring(1)); //trim "i" prefix
                             if (arrayIndex >= 0 && arrayIndex < array.length) {
                                 V value = builder.evaluate();
                                 if (value != null) {

--- a/forge-lda/src/forge/lda/lda/LDA.java
+++ b/forge-lda/src/forge/lda/lda/LDA.java
@@ -173,7 +173,7 @@ public class LDA {
             for (Integer w : testDataset.getWords(d)) {
                 double sum = 0.0;
                 for (int t = 0; t < getNumTopics(); ++t) {
-                     sum += getTheta(d, t) * getPhi(t, w.intValue()); 
+                     sum += getTheta(d, t) * getPhi(t, w);
                 }
                 loglikelihood += Math.log(sum);
             }

--- a/forge-lda/src/main/java/forge/lda/LDAModelGenetrator.java
+++ b/forge-lda/src/main/java/forge/lda/LDAModelGenetrator.java
@@ -281,8 +281,7 @@ public final class LDAModelGenetrator {
         });
 
         Map<K, V> result = new LinkedHashMap<>();
-        for (Iterator<Map.Entry<K, V>> it = list.iterator(); it.hasNext();) {
-            Map.Entry<K, V> entry = (Map.Entry<K, V>) it.next();
+        for (Map.Entry<K, V> entry : list) {
             result.put(entry.getKey(), entry.getValue());
         }
 


### PR DESCRIPTION
A collection of IDE-suggested changes to utilize language and utility features, available since Java 8 or earlier. Biggest chunk is the cleanup of manual boxing and unboxing of reference types, as well as removing reference types where they were no longer needed.

No changes here should affect code semantics, and performance should be roughly equal or better. Changes were organized into commits based on type of change; it'll probably be easier to review them one commit at a time.