### PR TITLE
Update anduril_flame_of_the_west.txt

### DIFF
--- a/forge-gui/res/cardsfolder/a/anduril_flame_of_the_west.txt
+++ b/forge-gui/res/cardsfolder/a/anduril_flame_of_the_west.txt
@@ -6,7 +6,7 @@ T:Mode$ Attacks | ValidCard$ Card.AttachedBy | Execute$ TrigBranch | TriggerDesc
 SVar:TrigBranch:DB$ Branch | BranchConditionSVar$ X | BranchConditionSVarCompare$ EQ1 | TrueSubAbility$ Legendary | FalseSubAbility$ NonLegendary
 SVar:Legendary:DB$ Token | TokenAmount$ 2 | TokenScript$ w_1_1_spirit_flying | TokenOwner$ You | TokenTapped$ True | TokenAttacking$ True
 SVar:NonLegendary:DB$ Token | TokenAmount$ 2 | TokenScript$ w_1_1_spirit_flying | TokenOwner$ You | TokenTapped$ True
-SVar:X:Count$Valid Creature.EquippedBy+Legendary
+SVar:X:Count$Valid Creature.TriggedAttacker+Legendary
 SVar:AE:SVar:HasAttackEffect:TRUE
 K:Equip:2
 DeckHas:Ability$Token & Type$Spirit

--- a/forge-gui/res/cardsfolder/a/anduril_flame_of_the_west.txt
+++ b/forge-gui/res/cardsfolder/a/anduril_flame_of_the_west.txt
@@ -6,7 +6,7 @@ T:Mode$ Attacks | ValidCard$ Card.AttachedBy | Execute$ TrigBranch | TriggerDesc
 SVar:TrigBranch:DB$ Branch | BranchConditionSVar$ X | BranchConditionSVarCompare$ EQ1 | TrueSubAbility$ Legendary | FalseSubAbility$ NonLegendary
 SVar:Legendary:DB$ Token | TokenAmount$ 2 | TokenScript$ w_1_1_spirit_flying | TokenOwner$ You | TokenTapped$ True | TokenAttacking$ True
 SVar:NonLegendary:DB$ Token | TokenAmount$ 2 | TokenScript$ w_1_1_spirit_flying | TokenOwner$ You | TokenTapped$ True
-SVar:X:Count$Valid Creature.TriggedAttacker+Legendary
+SVar:X:TriggeredAttacker$Valid Card.Legendary
 SVar:AE:SVar:HasAttackEffect:TRUE
 K:Equip:2
 DeckHas:Ability$Token & Type$Spirit


### PR DESCRIPTION
Equipments that trigger on the equipped creature attacking should check the same creature on resolution, but they often check the equipped creature (which may have incorrect results if the equipment is moved to another creature with the ability on stack). If this looks alright, I can change them to work with TriggeredAttacker instead.