### PR TITLE
Destroy: refactor fake into SacrificeAll

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/DamageEachAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DamageEachAi.java
@@ -26,6 +26,7 @@ public class DamageEachAi extends DamageAiBase {
             }
             sa.resetTargets();
             sa.getTargets().add(weakestOpp);
+            return weakestOpp.canLoseLife() && !weakestOpp.cantLoseForZeroOrLessLife();
         }
         
         final String damage = sa.getParam("NumDmg");

--- a/forge-ai/src/main/java/forge/ai/ability/DestroyAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DestroyAi.java
@@ -2,15 +2,10 @@ package forge.ai.ability;
 
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
-
 import forge.ai.*;
 import forge.game.ability.AbilityUtils;
 import forge.game.ability.ApiType;
-import forge.game.card.Card;
-import forge.game.card.CardCollection;
-import forge.game.card.CardLists;
-import forge.game.card.CardPredicates;
-import forge.game.card.CounterEnumType;
+import forge.game.card.*;
 import forge.game.cost.Cost;
 import forge.game.cost.CostPart;
 import forge.game.cost.CostSacrifice;
@@ -33,9 +28,7 @@ public class DestroyAi extends SpellAbilityAi {
         final Card source = sa.getHostCard();
         if (sa.usesTargeting()) {
             sa.resetTargets();
-            if ("MadSarkhanDragon".equals(aiLogic)) {
-                return SpecialCardAi.SarkhanTheMad.considerMakeDragon(ai, sa);
-            } else if (aiLogic.startsWith("MinLoyalty.")) {
+            if (aiLogic.startsWith("MinLoyalty.")) {
                 int minLoyalty = Integer.parseInt(aiLogic.substring(aiLogic.indexOf(".") + 1));
                 if (source.getCounters(CounterEnumType.LOYALTY) < minLoyalty) {
                     return false;

--- a/forge-ai/src/main/java/forge/ai/ability/SacrificeAllAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/SacrificeAllAi.java
@@ -2,6 +2,7 @@ package forge.ai.ability;
 
 import forge.ai.ComputerUtilCard;
 import forge.ai.ComputerUtilCost;
+import forge.ai.SpecialCardAi;
 import forge.ai.SpellAbilityAi;
 import forge.game.card.Card;
 import forge.game.cost.Cost;
@@ -30,8 +31,10 @@ public class SacrificeAllAi extends SpellAbilityAi {
             if (ai.getCreaturesInPlay().size() < 5 || ai.getCreaturesInPlay().size() * 150 < ComputerUtilCard.evaluateCreatureList(ai.getCreaturesInPlay())) {
                 return false;
             }
+        } else if (logic.equals("MadSarkhanDragon")) {
+            return SpecialCardAi.SarkhanTheMad.considerMakeDragon(ai, sa);
         }
-        
+
         if (!DestroyAllAi.doMassRemovalLogic(ai, sa)) {
             return false;
         }

--- a/forge-game/src/main/java/forge/game/ability/effects/DestroyEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DestroyEffect.java
@@ -26,7 +26,7 @@ public class DestroyEffect extends SpellAbilityEffect {
         if (tgtCards.isEmpty()) return sa.getParamOrDefault("SpellDescription", "");
         final boolean justOne = tgtCards.size() == 1;
 
-        sb.append(sa.hasParam("Sacrifice") ? "Sacrifice " : "Destroy ").append(Lang.joinHomogenous(tgtCards));
+        sb.append("Destroy ").append(Lang.joinHomogenous(tgtCards));
 
         if (sa.hasParam("Radiance")) {
             final String thing = sa.getParamOrDefault("ValidTgts", "thing");
@@ -88,20 +88,14 @@ public class DestroyEffect extends SpellAbilityEffect {
         final Game game = host.getGame();
         final boolean remDestroyed = sa.hasParam("RememberDestroyed");
         final boolean noRegen = sa.hasParam("NoRegen");
-        final boolean sac = sa.hasParam("Sacrifice");
         final boolean alwaysRem = sa.hasParam("AlwaysRemember");
-        boolean destroyed = false;
 
         SpellAbility cause = sa;
         if (sa.isReplacementAbility()) {
             cause = (SpellAbility) sa.getReplacingObject(AbilityKey.Cause);
         }
 
-        if (sac) {
-            destroyed = game.getAction().sacrifice(gameCard, cause, true, params) != null;
-        } else {
-            destroyed = game.getAction().destroy(gameCard, cause, !noRegen, params);
-        }
+        boolean destroyed = game.getAction().destroy(gameCard, cause, !noRegen, params);
         if (destroyed && remDestroyed) {
             host.addRemembered(gameCard);
         }

--- a/forge-gui/res/cardsfolder/a/animate_dead.txt
+++ b/forge-gui/res/cardsfolder/a/animate_dead.txt
@@ -9,7 +9,7 @@ SVar:DBAnimate:DB$ Animate | Defined$ Self | OverwriteSpells$ True | Abilities$ 
 SVar:DBAttach:DB$ Attach | Defined$ Remembered | SubAbility$ DBDelay
 SVar:DBDelay:DB$ DelayedTrigger | Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Battlefield | Execute$ TrigSacrifice | RememberObjects$ RememberedLKI | TriggerDescription$ When CARDNAME leaves the battlefield, that creature's controller sacrifices it.
 SVar:NewAttach:SP$ Attach | Cost$ 1 B | ValidTgts$ Creature.IsRemembered | AILogic$ Pump
-SVar:TrigSacrifice:DB$ Destroy | Sacrifice$ True | Defined$ DelayTriggerRememberedLKI
+SVar:TrigSacrifice:DB$ SacrificeAll | Defined$ DelayTriggerRememberedLKI
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | ValidCard$ Card.Self | Execute$ DBCleanup | Static$ True
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ -1 | Description$ Enchanted creature gets -1/-0.

--- a/forge-gui/res/cardsfolder/a/arcum_dagsson.txt
+++ b/forge-gui/res/cardsfolder/a/arcum_dagsson.txt
@@ -2,6 +2,6 @@ Name:Arcum Dagsson
 ManaCost:3 U
 Types:Legendary Creature Human Artificer
 PT:2/2
-A:AB$ Destroy | Cost$ T | ValidTgts$ Creature.Artifact | TgtPrompt$ Select target artifact creature | Sacrifice$ True | SubAbility$ DBChange | SpellDescription$ Target artifact creature's controller sacrifices it. That player may search their library for a noncreature artifact card, put it onto the battlefield, then shuffle.
+A:AB$ SacrificeAll | Cost$ T | Defined$ Targeted | ValidTgts$ Creature.Artifact | TgtPrompt$ Select target artifact creature | SubAbility$ DBChange | SpellDescription$ Target artifact creature's controller sacrifices it. That player may search their library for a noncreature artifact card, put it onto the battlefield, then shuffle.
 SVar:DBChange:DB$ ChangeZone | Optional$ True | Origin$ Library | Destination$ Battlefield | ChangeType$ Artifact.nonCreature | DefinedPlayer$ TargetedController | ShuffleNonMandatory$ True
 Oracle:{T}: Target artifact creature's controller sacrifices it. That player may search their library for a noncreature artifact card, put it onto the battlefield, then shuffle.

--- a/forge-gui/res/cardsfolder/a/ashling_the_extinguisher.txt
+++ b/forge-gui/res/cardsfolder/a/ashling_the_extinguisher.txt
@@ -3,6 +3,6 @@ ManaCost:2 B B
 Types:Legendary Creature Elemental Shaman
 PT:4/4
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigDestroy | CombatDamage$ True | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, choose target creature that player controls. The player sacrifices that creature.
-SVar:TrigDestroy:DB$ Destroy | ValidTgts$ Creature.ControlledBy TriggeredTarget | Sacrifice$ True | TgtPrompt$ Select target creature that player controls
+SVar:TrigDestroy:DB$ SacrificeAll | Defined ThisTargeted | ValidTgts$ Creature.ControlledBy TriggeredTarget | TgtPrompt$ Select target creature that player controls
 SVar:MustBeBlocked:True
 Oracle:Whenever Ashling, the Extinguisher deals combat damage to a player, choose target creature that player controls. The player sacrifices that creature.

--- a/forge-gui/res/cardsfolder/b/barrins_spite.txt
+++ b/forge-gui/res/cardsfolder/b/barrins_spite.txt
@@ -3,7 +3,7 @@ ManaCost:2 U B
 Types:Sorcery
 A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Choose two target creatures controlled by the same player | TargetMin$ 2 | TargetMax$ 2 | TargetUnique$ True | TargetsWithSameController$ True | RememberTargets$ True | IsCurse$ True | SubAbility$ DBChooseSac | StackDescription$ SpellDescription | SpellDescription$ Choose two target creatures controlled by the same player. Their controller chooses and sacrifices one of them. Return the other to its owner's hand.
 SVar:DBChooseSac:DB$ ChooseCard | Choices$ Card.IsRemembered | Defined$ TargetedController | ChoiceTitle$ Choose one to sacrifice | ForgetChosen$ True | SubAbility$ DBSac | StackDescription$ None | AILogic$ WorstCard
-SVar:DBSac:DB$ Destroy | Defined$ ChosenCard | Sacrifice$ True | SubAbility$ DBBounce | StackDescription$ None
+SVar:DBSac:DB$ SacrificeAll | Defined$ ChosenCard | SubAbility$ DBBounce | StackDescription$ None
 SVar:DBBounce:DB$ ChangeZone | Defined$ Remembered | Origin$ Battlefield | Destination$ Hand | SubAbility$ DBCleanup | StackDescription$ None
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Choose two target creatures controlled by the same player. Their controller chooses and sacrifices one of them. Return the other to its owner's hand.

--- a/forge-gui/res/cardsfolder/b/basalt_golem.txt
+++ b/forge-gui/res/cardsfolder/b/basalt_golem.txt
@@ -5,7 +5,7 @@ PT:2/4
 S:Mode$ CantBlockBy | ValidAttacker$ Creature.Self | ValidBlocker$ Artifact.Creature | Description$ CARDNAME can't be blocked by artifact creatures.
 T:Mode$ AttackerBlockedByCreature | ValidCard$ Card.Self | ValidBlocker$ Creature | Execute$ TrigEndCombat | TriggerDescription$ Whenever CARDNAME becomes blocked by a creature, that creature's controller sacrifices it at end of combat. If the player does, they create a 0/2 colorless Wall artifact creature token with defender.
 SVar:TrigEndCombat:DB$ DelayedTrigger | Mode$ Phase | Phase$ EndCombat | Execute$ TrigSacBlocker | RememberObjects$ TriggeredBlockerLKICopy | TriggerDescription$ At end of combat, the controller of the creature that blocked CARDNAME sacrifices that creature. If the player does, they create a 0/2 colorless Wall artifact creature token with defender.
-SVar:TrigSacBlocker:DB$ Destroy | Defined$ DelayTriggerRememberedLKI | Sacrifice$ True | SubAbility$ DBToken | RememberDestroyed$ True
+SVar:TrigSacBlocker:DB$ SacrificeAll | Defined$ DelayTriggerRememberedLKI | SubAbility$ DBToken | RememberSacrificed$ True
 SVar:DBToken:DB$ Token | TokenAmount$ 1 | TokenScript$ c_0_2_a_wall_defender | TokenOwner$ DelayTriggerRememberedController | ConditionDefined$ Remembered | ConditionPresent$ Card | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Basalt Golem can't be blocked by artifact creatures.\nWhenever Basalt Golem becomes blocked by a creature, that creature's controller sacrifices it at end of combat. If the player does, they create a 0/2 colorless Wall artifact creature token with defender.

--- a/forge-gui/res/cardsfolder/d/dance_of_the_dead.txt
+++ b/forge-gui/res/cardsfolder/d/dance_of_the_dead.txt
@@ -9,7 +9,7 @@ SVar:DBAnimate:DB$ Animate | Defined$ Self | OverwriteSpells$ True | Abilities$ 
 SVar:DBAttach:DB$ Attach | Defined$ Remembered | SubAbility$ DBDelay
 SVar:DBDelay:DB$ DelayedTrigger | Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Battlefield | Execute$ TrigSacrifice | RememberObjects$ RememberedLKI | TriggerDescription$ When CARDNAME leaves the battlefield, that creature's controller sacrifices it.
 SVar:NewAttach:SP$ Attach | Cost$ 1 B | ValidTgts$ Creature.IsRemembered | AILogic$ Pump
-SVar:TrigSacrifice:DB$ Destroy | Sacrifice$ True | Defined$ DirectRemembered
+SVar:TrigSacrifice:DB$ SacrificeAll | Defined$ DirectRemembered
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | ValidCard$ Card.Self | Execute$ DBCleanup | Static$ True
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | AddToughness$ 1 | AddHiddenKeyword$ CARDNAME doesn't untap during your untap step. | Description$ Enchanted creature gets +1/+1 and doesn't untap during its controller's untap step.

--- a/forge-gui/res/cardsfolder/d/demonic_hordes.txt
+++ b/forge-gui/res/cardsfolder/d/demonic_hordes.txt
@@ -7,7 +7,7 @@ A:AB$ Destroy | ValidTgts$ Land | TgtPrompt$ Select target land. | Cost$ T | Spe
 SVar:DBTap:DB$ Tap | Defined$ Self | UnlessCost$ B B B | UnlessPayer$ You | UnlessResolveSubs$ WhenNotPaid | SubAbility$ DBChooseOpponent
 SVar:DBChooseOpponent:DB$ ChoosePlayer | Defined$ You | Choices$ Player.Opponent | ChoiceTitle$ Choose an opponent | SubAbility$ DBChooseLand
 SVar:DBChooseLand:DB$ ChooseCard | Defined$ ChosenPlayer | Choices$ Land.YouCtrl | Mandatory$ True | ChoiceTitle$ Select a land for opponent to sacrifice | SubAbility$ DBSacLand
-SVar:DBSacLand:DB$ Destroy | Sacrifice$ True | Defined$ ChosenCard
+SVar:DBSacLand:DB$ SacrificeAll | Defined$ ChosenCard
 SVar:PlayMain1:FALSE
 DeckHas:Ability$Sacrifice
 Oracle:{T}: Destroy target land.\nAt the beginning of your upkeep, unless you pay {B}{B}{B}, tap Demonic Hordes and sacrifice a land of an opponent's choice.

--- a/forge-gui/res/cardsfolder/i/incriminate.txt
+++ b/forge-gui/res/cardsfolder/i/incriminate.txt
@@ -3,5 +3,5 @@ ManaCost:1 B
 Types:Sorcery
 A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Choose two target creatures controlled by the same player | TargetMin$ 2 | TargetMax$ 2 | TargetUnique$ True | TargetsWithSameController$ True | IsCurse$ True | SubAbility$ DBChooseSac | StackDescription$ SpellDescription | SpellDescription$ Choose two target creatures controlled by the same player. That player sacrifices one of them.
 SVar:DBChooseSac:DB$ ChooseCard | DefinedCards$ Targeted | Defined$ TargetedController | ChoiceTitle$ Choose one to sacrifice | SubAbility$ DBSac | StackDescription$ None | AILogic$ WorstCard
-SVar:DBSac:DB$ Destroy | Defined$ ChosenCard | Sacrifice$ True | StackDescription$ None
+SVar:DBSac:DB$ SacrificeAll | Defined$ ChosenCard | StackDescription$ None
 Oracle:Choose two target creatures controlled by the same player. That player sacrifices one of them.

--- a/forge-gui/res/cardsfolder/m/mercy_killing.txt
+++ b/forge-gui/res/cardsfolder/m/mercy_killing.txt
@@ -1,7 +1,7 @@
 Name:Mercy Killing
 ManaCost:2 GW
 Types:Instant
-A:SP$ Destroy | ValidTgts$ Creature | TgtPrompt$ Select target creature | Sacrifice$ True | SubAbility$ DBToken | SpellDescription$ Target creature's controller sacrifices it, then creates X 1/1 green and white Elf Warrior creature tokens, where X is that creature's power.
+A:SP$ SacrificeAll | Defined$ Targeted | ValidTgts$ Creature | TgtPrompt$ Select target creature | SubAbility$ DBToken | SpellDescription$ Target creature's controller sacrifices it, then creates X 1/1 green and white Elf Warrior creature tokens, where X is that creature's power.
 SVar:DBToken:DB$ Token | TokenAmount$ X | TokenScript$ gw_1_1_elf_warrior | TokenOwner$ TargetedController
 SVar:X:Targeted$CardPower
 Oracle:Target creature's controller sacrifices it, then creates X 1/1 green and white Elf Warrior creature tokens, where X is that creature's power.

--- a/forge-gui/res/cardsfolder/m/myriad_construct.txt
+++ b/forge-gui/res/cardsfolder/m/myriad_construct.txt
@@ -8,7 +8,7 @@ SVar:DBPutCounter:DB$ PutCounter | ETB$ True | Defined$ Self | CounterType$ P1P1
 SVar:X:Count$Valid Land.nonBasic+OppCtrl
 SVar:NeedsToPlayKicked:Land.nonBasic+OppCtrl
 T:Mode$ BecomesTarget | ValidTarget$ Card.Self | TriggerZones$ Battlefield | ValidSource$ Spell | Execute$ TrigSac | TriggerDescription$ When CARDNAME becomes the target of a spell, sacrifice it and create a number of 1/1 colorless Construct artifact creature tokens equal to its power.
-SVar:TrigSac:DB$ Destroy | Defined$ Self | Sacrifice$ True | RememberLKI$ True | SubAbility$ DBToken
+SVar:TrigSac:DB$ SacrificeAll | Defined$ Self | RememberSacrificed$ True | SubAbility$ DBToken
 SVar:DBToken:DB$ Token | TokenAmount$ Y | TokenScript$ c_1_1_a_construct | TokenOwner$ You | SubAbility$ DBCleanup
 SVar:Y:RememberedLKI$CardPower
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/n/necromancy.txt
+++ b/forge-gui/res/cardsfolder/n/necromancy.txt
@@ -8,7 +8,7 @@ SVar:Aurify:DB$ Animate | IsPresent$ Card.Self | Types$ Aura | OverwriteSpells$ 
 SVar:NewAttach:SP$ Attach | Cost$ 2 B | ValidTgts$ Creature.IsRemembered | AILogic$ Pump
 SVar:DBDelay:DB$ DelayedTrigger | Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Battlefield | Execute$ TrigSacrifice | RememberObjects$ RememberedLKI | TriggerDescription$ When CARDNAME leaves the battlefield, that creature's controller sacrifices it.
 SVar:NecromAttach:DB$ Attach | Defined$ Remembered | SubAbility$ DBDelay
-SVar:TrigSacrifice:DB$ Destroy | Sacrifice$ True | Defined$ DelayTriggerRememberedLKI
+SVar:TrigSacrifice:DB$ SacrificeAll | Defined$ DelayTriggerRememberedLKI
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | ValidCard$ Card.Self | Execute$ DBCleanup | Static$ True
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:NeedsToPlayVar:Y GE1

--- a/forge-gui/res/cardsfolder/r/reality_acid.txt
+++ b/forge-gui/res/cardsfolder/r/reality_acid.txt
@@ -5,5 +5,5 @@ K:Enchant permanent
 K:Vanishing:3
 A:SP$ Attach | Cost$ 2 U | ValidTgts$ Permanent | TgtPrompt$ Select target permanent | AILogic$ Curse
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | ValidCard$ Card.Self | Execute$ TrigSac | TriggerDescription$ When CARDNAME leaves the battlefield, enchanted permanent's controller sacrifices it.
-SVar:TrigSac:DB$ Destroy | Sacrifice$ True | Defined$ AttachedBy TriggeredCardLKICopy
+SVar:TrigSac:DB$ SacrificeAll | Defined$ AttachedBy TriggeredCardLKICopy
 Oracle:Enchant permanent\nVanishing 3 (This Aura enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Reality Acid leaves the battlefield, enchanted permanent's controller sacrifices it.

--- a/forge-gui/res/cardsfolder/r/retribution.txt
+++ b/forge-gui/res/cardsfolder/r/retribution.txt
@@ -3,7 +3,7 @@ ManaCost:2 R R
 Types:Sorcery
 A:SP$ Pump | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select two target creature an opponent controls | TargetMin$ 2 | TargetMax$ 2 | TargetsFromSingleZone$ True | IsCurse$ True | RememberTargets$ True | SubAbility$ DBChoose | StackDescription$ SpellDescription | SpellDescription$ Choose two target creatures an opponent controls. That player chooses and sacrifices one of those creatures. Put a -1/-1 counter on the other.
 SVar:DBChoose:DB$ ChooseCard | Defined$ TargetedController | Mandatory$ True | Choices$ Creature.IsRemembered | ChoiceTitle$ Choose one to sacrifice | ForgetChosen$ True | AILogic$ WorstCard | SubAbility$ DBSac | StackDescription$ None
-SVar:DBSac:DB$ Destroy | Defined$ ChosenCard | Sacrifice$ True | SubAbility$ DBPutCounter | StackDescription$ None
+SVar:DBSac:DB$ SacrificeAll | Defined$ ChosenCard | SubAbility$ DBPutCounter | StackDescription$ None
 SVar:DBPutCounter:DB$ PutCounter | Defined$ Remembered | CounterType$ M1M1 | CounterNum$ 1 | StackDescription$ None | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Choose two target creatures an opponent controls. That player chooses and sacrifices one of those creatures. Put a -1/-1 counter on the other.

--- a/forge-gui/res/cardsfolder/r/reweave.txt
+++ b/forge-gui/res/cardsfolder/r/reweave.txt
@@ -2,7 +2,7 @@ Name:Reweave
 ManaCost:5 U
 Types:Instant Arcane
 K:Splice:Arcane:2 U U
-A:SP$ Destroy | ValidTgts$ Permanent | Sacrifice$ True | SubAbility$ DBDigUntil | RememberLKI$ True | StackDescription$ {p:TargetedController} destroys {c:Targeted}. If {p:TargetedController} does, | SpellDescription$ Target permanent's controller sacrifices it. If the player does, they reveal cards from the top of their library until they reveal a permanent card that shares a card type with the sacrificed permanent, put that card onto the battlefield, then shuffle.
+A:SP$ SacrificeAll | Defined$ Targeted | ValidTgts$ Permanent | SubAbility$ DBDigUntil | RememberSacrificed$ True | StackDescription$ {p:TargetedController} destroys {c:Targeted}. If {p:TargetedController} does, | SpellDescription$ Target permanent's controller sacrifices it. If the player does, they reveal cards from the top of their library until they reveal a permanent card that shares a card type with the sacrificed permanent, put that card onto the battlefield, then shuffle.
 SVar:DBDigUntil:DB$ DigUntil | Defined$ RememberedController | ConditionDefined$ Remembered | ConditionPresent$ Card | ConditionCompare$ EQ1 | Valid$ Permanent.sharesCardTypeWith RememberedLKI | ValidDescription$ permanent card that shares a card type with the sacrificed permanent | FoundDestination$ Battlefield | RevealedDestination$ Library | Shuffle$ True | StackDescription$ they reveal cards from the top of their library until they reveal a permanent card that shares a card type with {c:Targeted}, put that card onto the battlefield, then shuffle their library. | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/rebalanced/a-incriminate.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-incriminate.txt
@@ -3,6 +3,6 @@ ManaCost:B
 Types:Sorcery
 A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Choose two target creatures controlled by the same player | TargetMin$ 2 | TargetMax$ 2 | TargetUnique$ True | TargetsWithSameController$ True | RememberTargets$ True | IsCurse$ True | SubAbility$ DBChooseSac | StackDescription$ SpellDescription | SpellDescription$ Choose two target creatures controlled by the same player. That player sacrifices one of them.
 SVar:DBChooseSac:DB$ ChooseCard | Choices$ Card.IsRemembered | Defined$ TargetedController | ChoiceTitle$ Choose one to sacrifice | SubAbility$ DBSac | StackDescription$ None | AILogic$ WorstCard
-SVar:DBSac:DB$ Destroy | Defined$ ChosenCard | Sacrifice$ True | SubAbility$ DBCleanup | StackDescription$ None
+SVar:DBSac:DB$ SacrificeAll | Defined$ ChosenCard | SubAbility$ DBCleanup | StackDescription$ None
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Choose two target creatures controlled by the same player. That player sacrifices one of them.

--- a/forge-gui/res/cardsfolder/s/sarkhan_the_mad.txt
+++ b/forge-gui/res/cardsfolder/s/sarkhan_the_mad.txt
@@ -6,7 +6,7 @@ A:AB$ Dig | Cost$ AddCounter<0/LOYALTY> | DigNum$ 1 | Reveal$ True | ChangeNum$ 
 SVar:DBDamage:DB$ DealDamage | Defined$ Self | NumDmg$ Y | SubAbility$ DBCleanup | AILogic$ MadSarkhanDigDmg
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:Y:Remembered$CardManaCost
-A:AB$ Destroy | Cost$ SubCounter<2/LOYALTY> | ValidTgts$ Creature | Sacrifice$ True | SubAbility$ DBToken | Planeswalker$ True | AILogic$ MadSarkhanDragon | SpellDescription$ Target creature's controller sacrifices it, then that player creates a 5/5 red Dragon creature token with flying.
+A:AB$ SacrificeAll | Cost$ SubCounter<2/LOYALTY> | Defined$ Targeted | ValidTgts$ Creature | SubAbility$ DBToken | Planeswalker$ True | AILogic$ MadSarkhanDragon | SpellDescription$ Target creature's controller sacrifices it, then that player creates a 5/5 red Dragon creature token with flying.
 SVar:DBToken:DB$ Token | TokenAmount$ 1 | TokenScript$ r_5_5_dragon_flying | TokenOwner$ TargetedController
 A:AB$ EachDamage | Cost$ SubCounter<4/LOYALTY> | Planeswalker$ True | Ultimate$ True | ValidCards$ Dragon.Creature+YouCtrl | ValidDescription$ Dragon creature you control | NumDmg$ Count$CardPower | DamageDesc$ damage equal to its power | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | AILogic$ MadSarkhanUltimate | SpellDescription$ Each Dragon creature you control deals damage equal to its power to target player or planeswalker.
 DeckHas:Ability$Sacrifice|Token & Type$Dragon

--- a/forge-gui/res/cardsfolder/s/shape_anew.txt
+++ b/forge-gui/res/cardsfolder/s/shape_anew.txt
@@ -1,6 +1,6 @@
 Name:Shape Anew
 ManaCost:3 U
 Types:Sorcery
-A:SP$ Destroy | ValidTgts$ Artifact | TgtPrompt$ Select target artifact | Sacrifice$ True | SubAbility$ DBDig | SpellDescription$ The controller of target artifact sacrifices it, then reveals cards from the top of their library until they reveal an artifact card. That player puts that card onto the battlefield, then shuffles all other cards revealed this way into their library.
+A:SP$ SacrificeAll | Defined$ Targeted | ValidTgts$ Artifact | TgtPrompt$ Select target artifact | SubAbility$ DBDig | SpellDescription$ The controller of target artifact sacrifices it, then reveals cards from the top of their library until they reveal an artifact card. That player puts that card onto the battlefield, then shuffles all other cards revealed this way into their library.
 SVar:DBDig:DB$ DigUntil | Defined$ TargetedController | Valid$ Artifact | ValidDescription$ artifact | FoundDestination$ Battlefield | RevealedDestination$ Library | Shuffle$ True
 Oracle:The controller of target artifact sacrifices it, then reveals cards from the top of their library until they reveal an artifact card. That player puts that card onto the battlefield, then shuffles all other cards revealed this way into their library.


### PR DESCRIPTION
Closes #5719 

This reworks "Sacrifice" Effects that were hiding inside Destroy Effects via SacrificeAll

i'm not yet happy with them, i think i would like them more if they were Sacrifice Effects instead of All.
or that Defined is required then using Targets?


- [x] Remove Engine Support for `Sacrifice$`
- [x] move AI for MadSarkhanDragon