### PR TITLE
Fix casting Chaotic Strike when no attacker gets declared

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/SacrificeAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/SacrificeAi.java
@@ -49,6 +49,7 @@ public class SacrificeAi extends SpellAbilityAi {
         final Card source = sa.getHostCard();
         final boolean destroy = sa.hasParam("Destroy");
         final String aiLogic = sa.getParamOrDefault("AILogic", "");
+        final String valid = sa.getParamOrDefault("SacValid", "Self");
 
         if (sa.usesTargeting()) {
             final PlayerCollection targetableOpps = ai.getOpponents().filter(PlayerPredicates.isTargetableBy(sa));
@@ -67,7 +68,6 @@ public class SacrificeAi extends SpellAbilityAi {
             if (mandatory) {
                 return true;
             }
-            final String valid = sa.getParam("SacValid");
             String num = sa.getParamOrDefault("Amount" , "1");
             final int amount = AbilityUtils.calculateAmount(source, num, sa);
 
@@ -107,7 +107,6 @@ public class SacrificeAi extends SpellAbilityAi {
 
         final String defined = sa.getParamOrDefault("Defined", "You");
         final String targeted = sa.getParamOrDefault("ValidTgts", "");
-        final String valid = sa.getParamOrDefault("SacValid", "Self");
         if (valid.equals("Self")) {
             // Self Sacrifice.
         } else if (defined.equals("Player") || targeted.equals("Player") || targeted.equals("Opponent")

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -1006,7 +1006,7 @@ public class CardFactoryUtil {
             final String delayTrigStg = "DB$ DelayedTrigger | Mode$ Phase | Phase$ EndCombat | ValidPlayer$ Player | " +
                     "TriggerDescription$ At end of combat, sacrifice CARDNAME.";
 
-            final String trigSacStg = "DB$ SacrificeAll | Defined$ Self | Controller$ You";
+            final String trigSacStg = "DB$ Sacrifice";
 
             SpellAbility delayTrigSA = AbilityFactory.getAbility(delayTrigStg, card);
 
@@ -1942,7 +1942,7 @@ public class CardFactoryUtil {
             String upkeepTrig = "Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | " +
                     "TriggerDescription$ " + sb.toString();
 
-            String effect = "DB$ SacrificeAll | Defined$ Self | Controller$ You | UnlessPayer$ You | UnlessCost$ " + k[1];
+            String effect = "DB$ Sacrifice | UnlessPayer$ You | UnlessCost$ " + k[1];
 
             final Trigger parsedTrigger = TriggerHandler.parseTrigger(upkeepTrig, card, intrinsic);
             parsedTrigger.setOverridingAbility(AbilityFactory.getAbility(effect, card));

--- a/forge-game/src/main/java/forge/game/phase/PhaseHandler.java
+++ b/forge-game/src/main/java/forge/game/phase/PhaseHandler.java
@@ -81,6 +81,7 @@ public class PhaseHandler implements java.io.Serializable {
     private transient Player pPlayerPriority = null;
     private transient Player pFirstPriority = null;
     private transient Combat combat = null;
+    private boolean skipDamageSteps = false;
     private boolean bRepeatCleanup = false;
 
     /** The need to next phase. */
@@ -222,13 +223,11 @@ public class PhaseHandler implements java.io.Serializable {
                 return playerTurn.isSkippingCombat();
 
             case COMBAT_DECLARE_BLOCKERS:
-                if (inCombat() && combat.getAttackers().isEmpty()) {
-                    endCombat();
-                }
+                skipDamageSteps = !inCombat() || combat.getAttackers().isEmpty();
                 //$FALL-THROUGH$
             case COMBAT_FIRST_STRIKE_DAMAGE:
             case COMBAT_DAMAGE:
-                return !inCombat();
+                return skipDamageSteps;
 
             default:
                 return false;
@@ -981,6 +980,10 @@ public class PhaseHandler implements java.io.Serializable {
 
     public final boolean beforeFirstPostCombatMainEnd() {
         return nMain2sThisTurn == 0;
+    }
+
+    public final boolean skippedDeclareBlockers() {
+        return skipDamageSteps;
     }
 
     private final static boolean DEBUG_PHASES = false;

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -293,7 +293,6 @@ public class Player extends GameEntity implements Comparable<Player> {
         game.getAction().moveToCommand(activeScheme, cause);
         game.getTriggerHandler().suppressMode(TriggerType.ChangesZone);
 
-        // Run triggers
         final Map<AbilityKey, Object> runParams = AbilityKey.newMap();
         runParams.put(AbilityKey.Scheme, activeScheme);
         game.getTriggerHandler().runTrigger(TriggerType.SetInMotion, runParams, false);
@@ -3279,7 +3278,7 @@ public class Player extends GameEntity implements Comparable<Player> {
         } else if (level == 3) {
             final String becomesBlockedTrig = "Mode$ AttackerBlockedByCreature | ValidCard$ Card.YouCtrl+IsRingbearer| ValidBlocker$ Creature | TriggerZones$ Command | TriggerDescription$ Whenever your Ring-bearer becomes blocked a creature, that creature's controller sacrifices it at the end of combat.";
             final String endOfCombatTrig = "DB$ DelayedTrigger | Mode$ Phase | Phase$ EndCombat | RememberObjects$ TriggeredBlockerLKICopy | TriggerDescription$ At end of combat, the controller of the creature that blocked CARDNAME sacrifices that creature.";
-            final String sacBlockerEffect = "DB$ Destroy | Defined$ DelayTriggerRememberedLKI | Sacrifice$ True";
+            final String sacBlockerEffect = "DB$ SacrificeAll | Defined$ DelayTriggerRememberedLKI";
 
             final Trigger becomesBlockedTrigger = TriggerHandler.parseTrigger(becomesBlockedTrig, getTheRing(), true);
 

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbilityRestriction.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbilityRestriction.java
@@ -140,6 +140,10 @@ public class SpellAbilityRestriction extends SpellAbilityVariables {
             this.setFirstCombatOnly(true);
         }
 
+        if (params.containsKey("ActivationAfterBlockers")) {
+            this.setAfterBlockersOnly(true);
+        }
+
         if (params.containsKey("ActivationGameTypes")) {
             this.setGameTypes(GameType.listValueOf(params.get("ActivationGameTypes")));
         }
@@ -328,6 +332,13 @@ public class SpellAbilityRestriction extends SpellAbilityVariables {
 
         if (this.getFirstCombatOnly()) {
             if (game.getPhaseHandler().getNumCombat() > (game.getPhaseHandler().inCombat() ? 1 : 0)) {
+                return false;
+            }
+        }
+
+        // CR 506.7f
+        if (this.getAfterBlockersOnly()) {
+            if (game.getPhaseHandler().skippedDeclareBlockers()) {
                 return false;
             }
         }

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbilityVariables.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbilityVariables.java
@@ -57,6 +57,8 @@ public class SpellAbilityVariables implements Cloneable {
 
     private boolean firstCombatOnly = false;
 
+    private boolean afterBlockersOnly = false;
+
     /** The GameTypes */
     private Set<GameType> gameTypes = EnumSet.noneOf(GameType.class);
 
@@ -621,6 +623,18 @@ public class SpellAbilityVariables implements Cloneable {
     }
     public final boolean setFirstCombatOnly(boolean first) {
         return this.firstCombatOnly = first;
+    }
+
+    /**
+     * Gets the declared blockers.
+     *
+     * @return declared blockers
+     */
+    public final boolean getAfterBlockersOnly() {
+        return this.afterBlockersOnly;
+    }
+    public final boolean setAfterBlockersOnly(boolean first) {
+        return this.afterBlockersOnly = first;
     }
 
     /**

--- a/forge-gui/res/cardsfolder/a/aleatory.txt
+++ b/forge-gui/res/cardsfolder/a/aleatory.txt
@@ -2,7 +2,7 @@ Name:Aleatory
 ManaCost:1 R
 Types:Instant
 Text:Cast CARDNAME only during combat after blockers are declared.
-A:SP$ FlipACoin | ValidTgts$ Creature | TgtPrompt$ Select target creature to gain +1/+1 | WinSubAbility$ AleatoryPump | LoseSubAbility$ DelTrigSlowtrip | ActivationPhases$ Declare Blockers->EndCombat | SpellDescription$ Flip a coin. If you win the flip, target creature gets +1/+1 until end of turn. Draw a card at the beginning of the next turn's upkeep.
+A:SP$ FlipACoin | ValidTgts$ Creature | TgtPrompt$ Select target creature to gain +1/+1 | WinSubAbility$ AleatoryPump | LoseSubAbility$ DelTrigSlowtrip | ActivationPhases$ Declare Blockers->EndCombat | ActivationAfterBlockers$ True | SpellDescription$ Flip a coin. If you win the flip, target creature gets +1/+1 until end of turn. Draw a card at the beginning of the next turn's upkeep.
 SVar:AleatoryPump:DB$ Pump | Defined$ Targeted | NumAtt$ 1 | NumDef$ 1 | SubAbility$ DelTrigSlowtrip
 SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
 SVar:DrawSlowtrip:DB$ Draw | Defined$ You

--- a/forge-gui/res/cardsfolder/c/chaotic_strike.txt
+++ b/forge-gui/res/cardsfolder/c/chaotic_strike.txt
@@ -2,7 +2,7 @@ Name:Chaotic Strike
 ManaCost:1 R
 Types:Instant
 Text:Cast CARDNAME only during combat after blockers are declared.
-A:SP$ FlipACoin | ValidTgts$ Creature | TgtPrompt$ Select target creature to gain +1/+1 | WinSubAbility$ ChaoticStrikePump | LoseSubAbility$ ChaoticStrikeDraw | ActivationPhases$ Declare Blockers->EndCombat | SpellDescription$ Flip a coin. If you win the flip, target creature gets +1/+1 until end of turn. Draw a card.
+A:SP$ FlipACoin | ValidTgts$ Creature | TgtPrompt$ Select target creature to gain +1/+1 | WinSubAbility$ ChaoticStrikePump | LoseSubAbility$ ChaoticStrikeDraw | ActivationPhases$ Declare Blockers->EndCombat | ActivationAfterBlockers$ True | SpellDescription$ Flip a coin. If you win the flip, target creature gets +1/+1 until end of turn. Draw a card.
 SVar:ChaoticStrikePump:DB$ Pump | Defined$ Targeted | NumAtt$ 1 | NumDef$ 1 | SubAbility$ ChaoticStrikeDraw
 SVar:ChaoticStrikeDraw:DB$ Draw | NumCards$ 1
 Oracle:Cast this spell only during combat after blockers are declared.\nFlip a coin. If you win the flip, target creature gets +1/+1 until end of turn.\nDraw a card.

--- a/forge-gui/res/cardsfolder/c/curtain_of_light.txt
+++ b/forge-gui/res/cardsfolder/c/curtain_of_light.txt
@@ -2,6 +2,6 @@ Name:Curtain of Light
 ManaCost:1 W
 Types:Instant
 Text:Cast CARDNAME only during combat after blockers are declared.
-A:SP$ BecomesBlocked | ValidTgts$ Creature.attacking+unblocked | TgtPrompt$ Select target unblocked attacking creature | SubAbility$ Draw | ActivationPhases$ Declare Blockers->EndCombat | SpellDescription$ Target unblocked attacking creature becomes blocked. (This spell works on creatures that can't be blocked.) Draw a card.
+A:SP$ BecomesBlocked | ValidTgts$ Creature.attacking+unblocked | TgtPrompt$ Select target unblocked attacking creature | SubAbility$ Draw | ActivationPhases$ Declare Blockers->EndCombat | ActivationAfterBlockers$ True | SpellDescription$ Target unblocked attacking creature becomes blocked. (This spell works on creatures that can't be blocked.) Draw a card.
 SVar:Draw:DB$ Draw | NumCards$ 1
 Oracle:Cast this spell only during combat after blockers are declared.\nTarget unblocked attacking creature becomes blocked. (This spell works on creatures that can't be blocked.)\nDraw a card.

--- a/forge-gui/res/cardsfolder/f/flash_foliage.txt
+++ b/forge-gui/res/cardsfolder/f/flash_foliage.txt
@@ -1,7 +1,7 @@
 Name:Flash Foliage
 ManaCost:2 G
 Types:Instant
-A:SP$ Token | ValidTgts$ Creature.attackingYou | TgtPrompt$ Select target creature attacking you | TokenAmount$ 1 | TokenScript$ g_1_1_saproling | TokenOwner$ You | TokenBlocking$ Targeted | ActivationPhases$ Declare Blockers->EndCombat | SubAbility$ DBDraw | StackDescription$ SpellDescription | SpellDescription$ Cast this spell only during combat after blockers are declared. Create a 1/1 green Saproling creature token that's blocking target creature attacking you. Draw a card.
+A:SP$ Token | ValidTgts$ Creature.attackingYou | TgtPrompt$ Select target creature attacking you | TokenAmount$ 1 | TokenScript$ g_1_1_saproling | TokenOwner$ You | TokenBlocking$ Targeted | ActivationPhases$ Declare Blockers->EndCombat | ActivationAfterBlockers$ True | SubAbility$ DBDraw | StackDescription$ SpellDescription | SpellDescription$ Cast this spell only during combat after blockers are declared. Create a 1/1 green Saproling creature token that's blocking target creature attacking you. Draw a card.
 SVar:DBDraw:DB$ Draw | NumCards$ 1
 DeckHas:Ability$Token
 Oracle:Cast this spell only during combat after blockers are declared.\nCreate a 1/1 green Saproling creature token that's blocking target creature attacking you.\nDraw a card.

--- a/forge-gui/res/cardsfolder/t/trap_runner.txt
+++ b/forge-gui/res/cardsfolder/t/trap_runner.txt
@@ -2,5 +2,5 @@ Name:Trap Runner
 ManaCost:2 W W
 Types:Creature Human Soldier
 PT:2/3
-A:AB$ BecomesBlocked | Cost$ T | ValidTgts$ Creature.attacking+unblocked | TgtPrompt$ Select target unblocked attacking creature | ActivationPhases$ Declare Blockers->EndCombat | SpellDescription$ Target unblocked attacking creature becomes blocked. Activate only during combat after blockers are declared. (This ability works on creatures that can't be blocked.)
+A:AB$ BecomesBlocked | Cost$ T | ValidTgts$ Creature.attacking+unblocked | TgtPrompt$ Select target unblocked attacking creature | ActivationPhases$ Declare Blockers->EndCombat | ActivationAfterBlockers$ True | SpellDescription$ Target unblocked attacking creature becomes blocked. Activate only during combat after blockers are declared. (This ability works on creatures that can't be blocked.)
 Oracle:{T}: Target unblocked attacking creature becomes blocked. Activate only during combat after blockers are declared. (This ability works on creatures that can't be blocked.)


### PR DESCRIPTION
> 506.7f. If a spell states that it may be cast "only during combat after blockers are declared," but the declare blockers step is skipped that combat phase (see rule 508.8), then the spell may not be cast during that combat phase.