### PR TITLE
ETB update: Card folder 'm', part 4

### DIFF
--- a/forge-gui/res/cardsfolder/m/multiform_wonder.txt
+++ b/forge-gui/res/cardsfolder/m/multiform_wonder.txt
@@ -2,11 +2,11 @@ Name:Multiform Wonder
 ManaCost:5
 Types:Artifact Creature Construct
 PT:3/3
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigEnergy | TriggerDescription$ When CARDNAME enters the battlefield, you get {E}{E}{E} (three energy counters).
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigEnergy | TriggerDescription$ When CARDNAME enters, you get {E}{E}{E} (three energy counters).
 SVar:TrigEnergy:DB$ PutCounter | Defined$ You | CounterType$ ENERGY | CounterNum$ 3
 A:AB$ Pump | Cost$ PayEnergy<1> | KWChoice$ Flying,Vigilance,Lifelink | StackDescription$ SpellDescription | SpellDescription$ CARDNAME gains your choice of flying, vigilance, or lifelink until end of turn.
 A:AB$ Pump | Cost$ PayEnergy<1> | Subability$ ABChoice | StackDescription$ SpellDescription | SpellDescription$ CARDNAME gets +2/-2 or -2/+2 until end of turn.
 SVar:ABChoice:DB$ GenericChoice | Defined$ You | Choices$ ABPump1,ABPump2
 SVar:ABPump1:DB$ Pump | Defined$ Self | NumAtt$ +2 | NumDef$ -2 | SpellDescription$ +2/-2
 SVar:ABPump2:DB$ Pump | Defined$ Self | NumAtt$ -2 | NumDef$ +2 | SpellDescription$ -2/+2
-Oracle:When Multiform Wonder enters the battlefield, you get {E}{E}{E} (three energy counters).\nPay {E}: Multiform Wonder gains your choice of flying, vigilance, or lifelink until end of turn.\nPay {E}: Multiform Wonder gets +2/-2 or -2/+2 until end of turn.
+Oracle:When Multiform Wonder enters, you get {E}{E}{E} (three energy counters).\nPay {E}: Multiform Wonder gains your choice of flying, vigilance, or lifelink until end of turn.\nPay {E}: Multiform Wonder gets +2/-2 or -2/+2 until end of turn.

--- a/forge-gui/res/cardsfolder/m/mummy_paramount.txt
+++ b/forge-gui/res/cardsfolder/m/mummy_paramount.txt
@@ -2,8 +2,8 @@ Name:Mummy Paramount
 ManaCost:1 W
 Types:Creature Zombie
 PT:2/2
-T:Mode$ ChangesZone | ValidCard$ Zombie.Other+YouCtrl | Origin$ Any | Destination$ Battlefield | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever another Zombie enters the battlefield under your control, CARDNAME gets +1/+1 until end of turn.
+T:Mode$ ChangesZone | ValidCard$ Zombie.Other+YouCtrl | Origin$ Any | Destination$ Battlefield | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever another Zombie you control enters, CARDNAME gets +1/+1 until end of turn.
 SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +1 | NumDef$ +1
 SVar:BuffedBy:Zombie
 DeckHints:Type$Zombie
-Oracle:Whenever another Zombie enters the battlefield under your control, Mummy Paramount gets +1/+1 until end of turn.
+Oracle:Whenever another Zombie you control enters, Mummy Paramount gets +1/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/m/munda_ambush_leader.txt
+++ b/forge-gui/res/cardsfolder/m/munda_ambush_leader.txt
@@ -3,7 +3,7 @@ ManaCost:2 R W
 Types:Legendary Creature Kor Ally
 PT:3/4
 K:Haste
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self,Ally.Other+YouCtrl | Execute$ TrigDig | OptionalDecider$ You | TriggerDescription$ Rally — Whenever CARDNAME or another Ally enters the battlefield under your control, you may look at the top four cards of your library. If you do, reveal any number of Ally cards from among them, then put those cards on top of your library in any order and the rest on the bottom in any order.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self,Ally.Other+YouCtrl | Execute$ TrigDig | OptionalDecider$ You | TriggerDescription$ Rally — Whenever CARDNAME or another Ally you control enters, you may look at the top four cards of your library. If you do, reveal any number of Ally cards from among them, then put those cards on top of your library in any order and the rest on the bottom in any order.
 SVar:TrigDig:DB$ Dig | DigNum$ 4 | AnyNumber$ True | ChangeValid$ Ally | DestinationZone$ Library | LibraryPosition$ 0
 DeckHints:Type$Ally
-Oracle:Haste\nRally — Whenever Munda, Ambush Leader or another Ally enters the battlefield under your control, you may look at the top four cards of your library. If you do, reveal any number of Ally cards from among them, then put those cards on top of your library in any order and the rest on the bottom in any order.
+Oracle:Haste\nRally — Whenever Munda, Ambush Leader or another Ally you control enters, you may look at the top four cards of your library. If you do, reveal any number of Ally cards from among them, then put those cards on top of your library in any order and the rest on the bottom in any order.

--- a/forge-gui/res/cardsfolder/m/munitions_expert.txt
+++ b/forge-gui/res/cardsfolder/m/munitions_expert.txt
@@ -3,8 +3,8 @@ ManaCost:B R
 Types:Creature Goblin
 PT:1/1
 K:Flash
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDamage | OptionalDecider$ You | TriggerDescription$ When CARDNAME enters the battlefield, you may have it deal damage to target creature or planeswalker equal to the number of Goblins you control.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDamage | OptionalDecider$ You | TriggerDescription$ When CARDNAME enters, you may have it deal damage to target creature or planeswalker equal to the number of Goblins you control.
 SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ X
 SVar:X:Count$TypeYouCtrl.Goblin
 DeckHints:Type$Goblin
-Oracle:Flash\nWhen Munitions Expert enters the battlefield, you may have it deal damage to target creature or planeswalker equal to the number of Goblins you control.
+Oracle:Flash\nWhen Munitions Expert enters, you may have it deal damage to target creature or planeswalker equal to the number of Goblins you control.

--- a/forge-gui/res/cardsfolder/m/murasa.txt
+++ b/forge-gui/res/cardsfolder/m/murasa.txt
@@ -1,9 +1,9 @@
 Name:Murasa
 ManaCost:no cost
 Types:Plane Zendikar
-T:Mode$ ChangesZone | ValidCard$ Creature.nonToken | Origin$ Any | Destination$ Battlefield | TriggerZones$ Command | Execute$ TrigRamp | OptionalDecider$ TriggeredCardController | TriggerDescription$ Whenever a nontoken creature enters the battlefield, its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle.
+T:Mode$ ChangesZone | ValidCard$ Creature.nonToken | Origin$ Any | Destination$ Battlefield | TriggerZones$ Command | Execute$ TrigRamp | OptionalDecider$ TriggeredCardController | TriggerDescription$ Whenever a nontoken creature enters, its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle.
 SVar:TrigRamp:DB$ ChangeZone | Origin$ Library | Destination$ Battlefield | Tapped$ True | ChangeType$ Land.Basic | ChangeNum$ 1 | DefinedPlayer$ TriggeredCardController | ShuffleNonMandatory$ True
 T:Mode$ ChaosEnsues | TriggerZones$ Command | Execute$ RolledChaos | TriggerDescription$ Whenever chaos ensues, target land becomes a 4/4 creature that's still a land.
 SVar:RolledChaos:DB$ Animate | ValidTgts$ Land | Power$ 4 | Toughness$ 4 | Types$ Creature | Duration$ Permanent
 SVar:AIRollPlanarDieParams:Mode$ Always
-Oracle:Whenever a nontoken creature enters the battlefield, its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle.\nWhenever chaos ensues, target land becomes a 4/4 creature that's still a land.
+Oracle:Whenever a nontoken creature enters, its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle.\nWhenever chaos ensues, target land becomes a 4/4 creature that's still a land.

--- a/forge-gui/res/cardsfolder/m/murasa_pyromancer.txt
+++ b/forge-gui/res/cardsfolder/m/murasa_pyromancer.txt
@@ -2,10 +2,10 @@ Name:Murasa Pyromancer
 ManaCost:4 R R
 Types:Creature Human Shaman Ally
 PT:3/2
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self,Ally.Other+YouCtrl | OptionalDecider$ You | Execute$ TrigDamage | TriggerDescription$ Whenever CARDNAME or another Ally enters the battlefield under your control, you may have CARDNAME deal damage to target creature equal to the number of Allies you control.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self,Ally.Other+YouCtrl | OptionalDecider$ You | Execute$ TrigDamage | TriggerDescription$ Whenever CARDNAME or another Ally you control enters, you may have CARDNAME deal damage to target creature equal to the number of Allies you control.
 SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ NumAllies
 SVar:NumAllies:Count$Valid Ally.YouCtrl
 SVar:PlayMain1:TRUE
 SVar:BuffedBy:Ally
 AI:RemoveDeck:Random
-Oracle:Whenever Murasa Pyromancer or another Ally enters the battlefield under your control, you may have Murasa Pyromancer deal damage to target creature equal to the number of Allies you control.
+Oracle:Whenever Murasa Pyromancer or another Ally you control enters, you may have Murasa Pyromancer deal damage to target creature equal to the number of Allies you control.

--- a/forge-gui/res/cardsfolder/m/murasa_ranger.txt
+++ b/forge-gui/res/cardsfolder/m/murasa_ranger.txt
@@ -2,6 +2,6 @@ Name:Murasa Ranger
 ManaCost:3 G
 Types:Creature Human Warrior Ranger
 PT:3/3
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigPutCounters | TriggerDescription$ Landfall — Whenever a land enters the battlefield under your control, you may pay {3}{G}. If you do, put two +1/+1 counters on CARDNAME.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigPutCounters | TriggerDescription$ Landfall — Whenever a land you control enters, you may pay {3}{G}. If you do, put two +1/+1 counters on CARDNAME.
 SVar:TrigPutCounters:AB$ PutCounter | Cost$ 3 G | Defined$ Self | CounterType$ P1P1 | CounterNum$ 2
-Oracle:Landfall — Whenever a land enters the battlefield under your control, you may pay {3}{G}. If you do, put two +1/+1 counters on Murasa Ranger.
+Oracle:Landfall — Whenever a land you control enters, you may pay {3}{G}. If you do, put two +1/+1 counters on Murasa Ranger.

--- a/forge-gui/res/cardsfolder/m/murasa_sproutling.txt
+++ b/forge-gui/res/cardsfolder/m/murasa_sproutling.txt
@@ -3,7 +3,7 @@ ManaCost:2 G
 Types:Creature Plant Elemental
 PT:3/3
 K:Kicker:1 G
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self+kicked | Execute$ TrigChangeZone | TriggerDescription$ When CARDNAME enters the battlefield, if it was kicked, return target card with a kicker ability from your graveyard to your hand.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self+kicked | Execute$ TrigChangeZone | TriggerDescription$ When CARDNAME enters, if it was kicked, return target card with a kicker ability from your graveyard to your hand.
 SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | TgtPrompt$ Choose target card with a kicker ability | ValidTgts$ Card.withKicker+YouOwn,Card.withMultikicker+YouOwn
 DeckHas:Ability$Graveyard
-Oracle:Kicker {1}{G} (You may pay an additional {1}{G} as you cast this spell.)\nWhen Murasa Sproutling enters the battlefield, if it was kicked, return target card with a kicker ability from your graveyard to your hand.
+Oracle:Kicker {1}{G} (You may pay an additional {1}{G} as you cast this spell.)\nWhen Murasa Sproutling enters, if it was kicked, return target card with a kicker ability from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/m/murderous_redcap.txt
+++ b/forge-gui/res/cardsfolder/m/murderous_redcap.txt
@@ -3,8 +3,8 @@ ManaCost:2 BR BR
 Types:Creature Goblin Assassin
 PT:2/2
 K:Persist
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When CARDNAME enters the battlefield, it deals damage equal to its power to any target.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When CARDNAME enters, it deals damage equal to its power to any target.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Any | NumDmg$ X
 SVar:X:Count$CardPower
 SVar:PlayMain1:TRUE
-Oracle:When Murderous Redcap enters the battlefield, it deals damage equal to its power to any target.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)
+Oracle:When Murderous Redcap enters, it deals damage equal to its power to any target.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)

--- a/forge-gui/res/cardsfolder/m/murderous_redcap_avatar.txt
+++ b/forge-gui/res/cardsfolder/m/murderous_redcap_avatar.txt
@@ -2,7 +2,7 @@ Name:Murderous Redcap Avatar
 ManaCost:no cost
 Types:Vanguard
 HandLifeModifier:+0/-2
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.YouCtrl+HasCounters | TriggerZones$ Command | Execute$ TrigDamage | TriggerDescription$ Whenever a creature enters the battlefield under your control with a counter on it, you may have it deal damage equal to its power to any target.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.YouCtrl+HasCounters | TriggerZones$ Command | Execute$ TrigDamage | TriggerDescription$ Whenever a creature you control enters with a counter on it, you may have it deal damage equal to its power to any target.
 SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Any | DamageSource$ TriggeredCard | NumDmg$ Damage
 SVar:Damage:TriggeredCard$CardPower
-Oracle:Hand +0, life -2\nWhenever a creature enters the battlefield under your control with a counter on it, you may have it deal damage equal to its power to any target.
+Oracle:Hand +0, life -2\nWhenever a creature you control enters with a counter on it, you may have it deal damage equal to its power to any target.

--- a/forge-gui/res/cardsfolder/m/murk_strider.txt
+++ b/forge-gui/res/cardsfolder/m/murk_strider.txt
@@ -3,8 +3,8 @@ ManaCost:3 U
 Types:Creature Eldrazi Processor
 PT:3/2
 K:Devoid
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChangeZone | OptionalDecider$ You | TriggerDescription$ When CARDNAME enters the battlefield, you may put a card an opponent owns from exile into that player's graveyard. If you do, return target creature to its owner's hand.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChangeZone | OptionalDecider$ You | TriggerDescription$ When CARDNAME enters, you may put a card an opponent owns from exile into that player's graveyard. If you do, return target creature to its owner's hand.
 SVar:TrigChangeZone:AB$ ChangeZone | Cost$ ExiledMoveToGrave<1/Card.OppOwn/card an opponent owns> | ValidTgts$ Creature | TgtPrompt$ Select target creature | Origin$ Battlefield | Destination$ Hand
 SVar:PlayMain1:TRUE
 DeckHints:Keyword$Ingest
-Oracle:Devoid (This card has no color.)\nWhen Murk Strider enters the battlefield, you may put a card an opponent owns from exile into that player's graveyard. If you do, return target creature to its owner's hand.
+Oracle:Devoid (This card has no color.)\nWhen Murk Strider enters, you may put a card an opponent owns from exile into that player's graveyard. If you do, return target creature to its owner's hand.

--- a/forge-gui/res/cardsfolder/m/murktide_regent.txt
+++ b/forge-gui/res/cardsfolder/m/murktide_regent.txt
@@ -4,10 +4,10 @@ Types:Creature Dragon
 PT:3/3
 K:Delve
 K:Flying
-K:etbCounter:P1P1:X:no Condition:CARDNAME enters the battlefield with a +1/+1 counter on it for each instant and sorcery card exiled with it.
+K:etbCounter:P1P1:X:no Condition:CARDNAME enters with a +1/+1 counter on it for each instant and sorcery card exiled with it.
 SVar:X:Count$ValidExile Instant.ExiledWithSource,Sorcery.ExiledWithSource
 T:Mode$ ChangesZone | ValidCard$ Instant.YouOwn,Sorcery.YouOwn | Origin$ Graveyard | Destination$ Any | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Whenever an instant or sorcery card leaves your graveyard, put a +1/+1 counter on CARDNAME.
 SVar:TrigPutCounter:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ 1
 DeckNeeds:Type$Instant|Sorcery
 DeckHas:Ability$Counters
-Oracle:Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nFlying\nMurktide Regent enters the battlefield with a +1/+1 counter on it for each instant and sorcery card exiled with it.\nWhenever an instant or sorcery card leaves your graveyard, put a +1/+1 counter on Murktide Regent.
+Oracle:Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nFlying\nMurktide Regent enters with a +1/+1 counter on it for each instant and sorcery card exiled with it.\nWhenever an instant or sorcery card leaves your graveyard, put a +1/+1 counter on Murktide Regent.

--- a/forge-gui/res/cardsfolder/m/murmuring_bosk.txt
+++ b/forge-gui/res/cardsfolder/m/murmuring_bosk.txt
@@ -1,8 +1,8 @@
 Name:Murmuring Bosk
 ManaCost:no cost
 Types:Land Forest
-K:ETBReplacement:Other:DBTap
-SVar:DBTap:DB$ Tap | ETB$ True | Defined$ Self | UnlessCost$ Reveal<1/Treefolk> | UnlessPayer$ You | StackDescription$ enters the battlefield tapped. | SpellDescription$ As CARDNAME enters the battlefield, you may reveal a Treefolk card from your hand. If you don't, CARDNAME enters the battlefield tapped.
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplaceWith$ DBTap | ReplacementResult$ Updated | Description$ As CARDNAME enters, you may reveal a Treefolk card from your hand. If you don't, CARDNAME enters tapped.
+SVar:DBTap:DB$ Tap | ETB$ True | Defined$ Self | UnlessCost$ Reveal<1/Treefolk> | UnlessPayer$ You | StackDescription$ enters tapped.
 A:AB$ Mana | Cost$ T | Produced$ Combo W B | SubAbility$ DBPain | SpellDescription$ Add {W} or {B}. CARDNAME deals 1 damage to you.
 SVar:DBPain:DB$ DealDamage | NumDmg$ 1 | Defined$ You
-Oracle:({T}: Add {G}.)\nAs Murmuring Bosk enters the battlefield, you may reveal a Treefolk card from your hand. If you don't, Murmuring Bosk enters the battlefield tapped.\n{T}: Add {W} or {B}. Murmuring Bosk deals 1 damage to you.
+Oracle:({T}: Add {G}.)\nAs Murmuring Bosk enters, you may reveal a Treefolk card from your hand. If you don't, Murmuring Bosk enters tapped.\n{T}: Add {W} or {B}. Murmuring Bosk deals 1 damage to you.

--- a/forge-gui/res/cardsfolder/m/muse_drake.txt
+++ b/forge-gui/res/cardsfolder/m/muse_drake.txt
@@ -3,6 +3,6 @@ ManaCost:3 U
 Types:Creature Drake
 PT:1/3
 K:Flying
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ When CARDNAME enters the battlefield, draw a card.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ When CARDNAME enters, draw a card.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1
-Oracle:Flying\nWhen Muse Drake enters the battlefield, draw a card.
+Oracle:Flying\nWhen Muse Drake enters, draw a card.

--- a/forge-gui/res/cardsfolder/m/muster_the_departed.txt
+++ b/forge-gui/res/cardsfolder/m/muster_the_departed.txt
@@ -1,10 +1,10 @@
 Name:Muster the Departed
 ManaCost:2 W
 Types:Enchantment
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters the battlefield, create a 1/1 white Spirit creature token with flying.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a 1/1 white Spirit creature token with flying.
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ w_1_1_spirit_flying | TokenOwner$ You
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | CheckSVar$ Morbid | SVarCompare$ GE1 | Execute$ DBCopy | TriggerDescription$ Morbid — At the beginning of your end step, if a creature died this turn, populate. (Create a token that's a copy of a creature token you control.)
 SVar:DBCopy:DB$ CopyPermanent | Choices$ Creature.token+YouCtrl | NumCopies$ 1 | Populate$ True
 SVar:Morbid:Count$ThisTurnEntered_Graveyard_from_Battlefield_Creature
 DeckHas:Ability$Token & Type$Spirit
-Oracle:When Muster the Departed enters the battlefield, create a 1/1 white Spirit creature token with flying.\nMorbid — At the beginning of your end step, if a creature died this turn, populate. (Create a token that's a copy of a creature token you control.)
+Oracle:When Muster the Departed enters, create a 1/1 white Spirit creature token with flying.\nMorbid — At the beginning of your end step, if a creature died this turn, populate. (Create a token that's a copy of a creature token you control.)

--- a/forge-gui/res/cardsfolder/m/mutalith_vortex_beast.txt
+++ b/forge-gui/res/cardsfolder/m/mutalith_vortex_beast.txt
@@ -3,8 +3,8 @@ ManaCost:4 U R
 Types:Creature Mutant Beast
 PT:6/6
 K:Trample
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigFlipCoin | TriggerDescription$ Warp Vortex — When CARDNAME enters the battlefield, flip a coin for each opponent you have. For each flip you win, draw a card. For each flip you lose, CARDNAME deals 3 damage to that player.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigFlipCoin | TriggerDescription$ Warp Vortex — When CARDNAME enters, flip a coin for each opponent you have. For each flip you win, draw a card. For each flip you lose, CARDNAME deals 3 damage to that player.
 SVar:TrigFlipCoin:DB$ FlipACoin | ForEachPlayer$ Opponent | WinSubAbility$ DBDraw | LoseSubAbility$ DBDealDamage
 SVar:DBDraw:DB$ Draw | NumCards$ Wins
 SVar:DBDealDamage:DB$ DealDamage | NumDmg$ 3 | Defined$ Remembered
-Oracle:Trample\nWarp Vortex — When Mutalith Vortex Beast enters the battlefield, flip a coin for each opponent you have. For each flip you win, draw a card. For each flip you lose, Mutalith Vortex Beast deals 3 damage to that player.
+Oracle:Trample\nWarp Vortex — When Mutalith Vortex Beast enters, flip a coin for each opponent you have. For each flip you win, draw a card. For each flip you lose, Mutalith Vortex Beast deals 3 damage to that player.

--- a/forge-gui/res/cardsfolder/m/muxus_goblin_grandee.txt
+++ b/forge-gui/res/cardsfolder/m/muxus_goblin_grandee.txt
@@ -2,10 +2,10 @@ Name:Muxus, Goblin Grandee
 ManaCost:4 R R
 Types:Legendary Creature Goblin Noble
 PT:4/4
-T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigDig | TriggerDescription$ When CARDNAME enters the battlefield, reveal the top six cards of your library. Put all Goblin creature cards with mana value 5 or less from among them onto the battlefield and the rest on the bottom of your library in a random order.
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigDig | TriggerDescription$ When CARDNAME enters, reveal the top six cards of your library. Put all Goblin creature cards with mana value 5 or less from among them onto the battlefield and the rest on the bottom of your library in a random order.
 SVar:TrigDig:DB$ Dig | DigNum$ 6 | Reveal$ True | ChangeNum$ All | ChangeValid$ Creature.Goblin+cmcLE5 | DestinationZone$ Battlefield | DestinationZone2$ Library | LibraryPosition$ -1 | RestRandomOrder$ True
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ Whenever NICKNAME attacks, it gets +1/+1 until end of turn for each other Goblin you control.
 SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ X | NumDef$ X
 SVar:X:Count$Valid Goblin.Other+YouCtrl
 DeckHints:Type$Goblin
-Oracle:When Muxus, Goblin Grandee enters the battlefield, reveal the top six cards of your library. Put all Goblin creature cards with mana value 5 or less from among them onto the battlefield and the rest on the bottom of your library in a random order.\nWhenever Muxus attacks, it gets +1/+1 until end of turn for each other Goblin you control.
+Oracle:When Muxus, Goblin Grandee enters, reveal the top six cards of your library. Put all Goblin creature cards with mana value 5 or less from among them onto the battlefield and the rest on the bottom of your library in a random order.\nWhenever Muxus attacks, it gets +1/+1 until end of turn for each other Goblin you control.

--- a/forge-gui/res/cardsfolder/m/muzzios_preparations.txt
+++ b/forge-gui/res/cardsfolder/m/muzzios_preparations.txt
@@ -3,6 +3,6 @@ ManaCost:no cost
 Types:Conspiracy
 K:Hidden agenda
 K:ETBReplacement:Other:AddExtraCounter:Mandatory:Command:Creature.YouCtrl+NamedCard
-SVar:AddExtraCounter:DB$ PutCounter | ETB$ True | Defined$ ReplacedCard | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Each creature with the named card you control enters the battlefield with an additional +1/+1 counter on it.
+SVar:AddExtraCounter:DB$ PutCounter | ETB$ True | Defined$ ReplacedCard | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Each creature you control with the chosen name enters with an additional +1/+1 counter on it.
 SVar:AgendaLogic:MostProminentCreatureInComputerDeck
-Oracle:Hidden agenda (Start the game with this conspiracy face down in the command zone and secretly choose a card name. You may turn this conspiracy face up any time and reveal that name.)\nEach creature you control with the chosen name enters the battlefield with an additional +1/+1 counter on it.
+Oracle:Hidden agenda (Start the game with this conspiracy face down in the command zone and secretly choose a card name. You may turn this conspiracy face up any time and reveal that name.)\nEach creature you control with the chosen name enters with an additional +1/+1 counter on it.

--- a/forge-gui/res/cardsfolder/m/mwonvuli_beast_tracker.txt
+++ b/forge-gui/res/cardsfolder/m/mwonvuli_beast_tracker.txt
@@ -2,8 +2,8 @@ Name:Mwonvuli Beast Tracker
 ManaCost:1 G G
 Types:Creature Human Scout
 PT:2/1
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ ScoutSearch | TriggerDescription$ When CARDNAME enters the battlefield, search your library for a creature card with deathtouch, hexproof, reach or trample and reveal it. Shuffle your library, then put that card on top of it.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ ScoutSearch | TriggerDescription$ When CARDNAME enters, search your library for a creature card with deathtouch, hexproof, reach or trample and reveal it. Shuffle your library, then put that card on top of it.
 SVar:ScoutSearch:DB$ ChangeZone | Origin$ Library | Destination$ Library | LibraryPosition$ 0 | ChangeNum$ 1 | ChangeType$ Creature.withDeathtouch+YouCtrl,Creature.withHexproof+YouCtrl,Creature.withReach+YouCtrl,Creature.withTrample+YouCtrl
 AI:RemoveDeck:Random
 DeckHints:Keyword$Deathtouch|Hexproof|Reach|Trample
-Oracle:When Mwonvuli Beast Tracker enters the battlefield, search your library for a creature card with deathtouch, hexproof, reach, or trample and reveal it. Shuffle and put that card on top.
+Oracle:When Mwonvuli Beast Tracker enters, search your library for a creature card with deathtouch, hexproof, reach, or trample and reveal it. Shuffle and put that card on top.

--- a/forge-gui/res/cardsfolder/m/mycoloth.txt
+++ b/forge-gui/res/cardsfolder/m/mycoloth.txt
@@ -7,4 +7,4 @@ T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | E
 SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ g_1_1_saproling | TokenOwner$ You
 SVar:X:Count$CardCounters.P1P1
 DeckHas:Ability$Counters|Token
-Oracle:Devour 2 (As this enters the battlefield, you may sacrifice any number of creatures. This creature enters the battlefield with twice that many +1/+1 counters on it.)\nAt the beginning of your upkeep, create a 1/1 green Saproling creature token for each +1/+1 counter on Mycoloth.
+Oracle:Devour 2 (As this enters, you may sacrifice any number of creatures. This creature enters with twice that many +1/+1 counters on it.)\nAt the beginning of your upkeep, create a 1/1 green Saproling creature token for each +1/+1 counter on Mycoloth.

--- a/forge-gui/res/cardsfolder/m/myconid_spore_tender.txt
+++ b/forge-gui/res/cardsfolder/m/myconid_spore_tender.txt
@@ -2,6 +2,6 @@ Name:Myconid Spore Tender
 ManaCost:3 G
 Types:Creature Fungus
 PT:4/1
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDestroy | TriggerDescription$ Infesting Spores — When CARDNAME enters the battlefield, destroy up to one target artifact or enchantment.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDestroy | TriggerDescription$ Infesting Spores — When CARDNAME enters, destroy up to one target artifact or enchantment.
 SVar:TrigDestroy:DB$ Destroy | TargetMin$ 0 | TargetMax$ 1 | ValidTgts$ Artifact,Enchantment | TgtPrompt$ Select target artifact or enchantment
-Oracle:Infesting Spores — When Myconid Spore Tender enters the battlefield, destroy up to one target artifact or enchantment.
+Oracle:Infesting Spores — When Myconid Spore Tender enters, destroy up to one target artifact or enchantment.

--- a/forge-gui/res/cardsfolder/m/mycosynth_wellspring.txt
+++ b/forge-gui/res/cardsfolder/m/mycosynth_wellspring.txt
@@ -1,8 +1,8 @@
 Name:Mycosynth Wellspring
 ManaCost:2
 Types:Artifact
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChange | OptionalDecider$ You | TriggerDescription$ When CARDNAME enters the battlefield or is put into a graveyard from the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle.
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigChange | OptionalDecider$ You | Secondary$ True | TriggerDescription$ When CARDNAME enters the battlefield or is put into a graveyard from the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChange | OptionalDecider$ You | TriggerDescription$ When CARDNAME enters or is put into a graveyard from the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle.
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigChange | OptionalDecider$ You | Secondary$ True | TriggerDescription$ When CARDNAME enters or is put into a graveyard from the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle.
 SVar:TrigChange:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Land.Basic | ChangeNum$ 1 | ShuffleNonMandatory$ True
 SVar:SacMe:5
-Oracle:When Mycosynth Wellspring enters the battlefield or is put into a graveyard from the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle.
+Oracle:When Mycosynth Wellspring enters or is put into a graveyard from the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle.

--- a/forge-gui/res/cardsfolder/m/myojin_of_blooming_dawn.txt
+++ b/forge-gui/res/cardsfolder/m/myojin_of_blooming_dawn.txt
@@ -2,9 +2,9 @@ Name:Myojin of Blooming Dawn
 ManaCost:5 W W W
 Types:Legendary Creature Spirit
 PT:4/6
-K:etbCounter:Indestructible:1:CheckSVar$ FromHand:CARDNAME enters the battlefield with an indestructible counter on it if you cast it from your hand.
+K:etbCounter:Indestructible:1:CheckSVar$ FromHand:CARDNAME enters with an indestructible counter on it if you cast it from your hand.
 SVar:FromHand:Count$wasCastFromYourHandByYou.1.0
 A:AB$ Token | Cost$ SubCounter<1/Indestructible> | TokenScript$ c_1_1_spirit | TokenAmount$ X | SpellDescription$ Create a 1/1 colorless Spirit creature token for each permanent you control.
 SVar:X:Count$Valid Permanent.YouCtrl
 DeckHas:Ability$Token
-Oracle:Myojin of Blooming Dawn enters the battlefield with an indestructible counter on it if you cast it from your hand.\nRemove an indestructible counter from Myojin of Blooming Dawn: Create a 1/1 colorless Spirit creature token for each permanent you control.
+Oracle:Myojin of Blooming Dawn enters with an indestructible counter on it if you cast it from your hand.\nRemove an indestructible counter from Myojin of Blooming Dawn: Create a 1/1 colorless Spirit creature token for each permanent you control.

--- a/forge-gui/res/cardsfolder/m/myojin_of_cleansing_fire.txt
+++ b/forge-gui/res/cardsfolder/m/myojin_of_cleansing_fire.txt
@@ -2,8 +2,8 @@ Name:Myojin of Cleansing Fire
 ManaCost:5 W W W
 Types:Legendary Creature Spirit
 PT:4/6
-K:etbCounter:DIVINITY:1:CheckSVar$ FromHand:CARDNAME enters the battlefield with a divinity counter on it if you cast it from your hand.
+K:etbCounter:DIVINITY:1:CheckSVar$ FromHand:CARDNAME enters with a divinity counter on it if you cast it from your hand.
 SVar:FromHand:Count$wasCastFromYourHandByYou.1.0
 S:Mode$ Continuous | Affected$ Card.Self+counters_GE1_DIVINITY | AddKeyword$ Indestructible | Description$ CARDNAME has indestructible as long as it has a divinity counter on it.
 A:AB$ DestroyAll | Cost$ SubCounter<1/DIVINITY> | ValidCards$ Creature.StrictlyOther | SpellDescription$ Destroy all other creatures.
-Oracle:Myojin of Cleansing Fire enters the battlefield with a divinity counter on it if you cast it from your hand.\nMyojin of Cleansing Fire has indestructible as long as it has a divinity counter on it.\nRemove a divinity counter from Myojin of Cleansing Fire: Destroy all other creatures.
+Oracle:Myojin of Cleansing Fire enters with a divinity counter on it if you cast it from your hand.\nMyojin of Cleansing Fire has indestructible as long as it has a divinity counter on it.\nRemove a divinity counter from Myojin of Cleansing Fire: Destroy all other creatures.

--- a/forge-gui/res/cardsfolder/m/myojin_of_cryptic_dreams.txt
+++ b/forge-gui/res/cardsfolder/m/myojin_of_cryptic_dreams.txt
@@ -2,8 +2,8 @@ Name:Myojin of Cryptic Dreams
 ManaCost:5 U U U
 Types:Legendary Creature Spirit
 PT:3/3
-K:etbCounter:Indestructible:1:CheckSVar$ FromHand:CARDNAME enters the battlefield with an indestructible counter on it if you cast it from your hand.
+K:etbCounter:Indestructible:1:CheckSVar$ FromHand:CARDNAME enters with an indestructible counter on it if you cast it from your hand.
 SVar:FromHand:Count$wasCastFromYourHandByYou.1.0
 A:AB$ CopySpellAbility | Cost$ SubCounter<1/Indestructible> | TgtPrompt$ Select target permanent spell you control | ValidTgts$ Permanent.YouCtrl | TargetType$ Spell | Amount$ 3 | SpellDescription$ Copy target permanent spell you control three times. (The copies become tokens.)
 DeckHas:Ability$Token
-Oracle:Myojin of Cryptic Dreams enters the battlefield with an indestructible counter on it if you cast it from your hand.\nRemove an indestructible counter from Myojin of Cryptic Dreams: Copy target permanent spell you control three times. (The copies become tokens.)
+Oracle:Myojin of Cryptic Dreams enters with an indestructible counter on it if you cast it from your hand.\nRemove an indestructible counter from Myojin of Cryptic Dreams: Copy target permanent spell you control three times. (The copies become tokens.)

--- a/forge-gui/res/cardsfolder/m/myojin_of_grim_betrayal.txt
+++ b/forge-gui/res/cardsfolder/m/myojin_of_grim_betrayal.txt
@@ -2,8 +2,8 @@ Name:Myojin of Grim Betrayal
 ManaCost:5 B B B
 Types:Legendary Creature Spirit
 PT:5/2
-K:etbCounter:Indestructible:1:CheckSVar$ FromHand:CARDNAME enters the battlefield with an indestructible counter on it if you cast it from your hand.
+K:etbCounter:Indestructible:1:CheckSVar$ FromHand:CARDNAME enters with an indestructible counter on it if you cast it from your hand.
 SVar:FromHand:Count$wasCastFromYourHandByYou.1.0
 A:AB$ ChangeZone | Cost$ SubCounter<1/Indestructible> | Origin$ Graveyard | Destination$ Battlefield | Defined$ ValidGraveyard Creature.ThisTurnEntered | GainControl$ True | SpellDescription$ Put onto the battlefield under your control all creature cards in all graveyards that were put there from anywhere this turn.
 DeckHas:Ability$Graveyard
-Oracle:Myojin of Grim Betrayal enters the battlefield with an indestructible counter on it if you cast it from your hand.\nRemove an indestructible counter from Myojin of Grim Betrayal: Put onto the battlefield under your control all creature cards in all graveyards that were put there from anywhere this turn.
+Oracle:Myojin of Grim Betrayal enters with an indestructible counter on it if you cast it from your hand.\nRemove an indestructible counter from Myojin of Grim Betrayal: Put onto the battlefield under your control all creature cards in all graveyards that were put there from anywhere this turn.

--- a/forge-gui/res/cardsfolder/m/myojin_of_infinite_rage.txt
+++ b/forge-gui/res/cardsfolder/m/myojin_of_infinite_rage.txt
@@ -2,8 +2,8 @@ Name:Myojin of Infinite Rage
 ManaCost:7 R R R
 Types:Legendary Creature Spirit
 PT:7/4
-K:etbCounter:DIVINITY:1:CheckSVar$ FromHand:CARDNAME enters the battlefield with a divinity counter on it if you cast it from your hand.
+K:etbCounter:DIVINITY:1:CheckSVar$ FromHand:CARDNAME enters with a divinity counter on it if you cast it from your hand.
 SVar:FromHand:Count$wasCastFromYourHandByYou.1.0
 S:Mode$ Continuous | Affected$ Card.Self+counters_GE1_DIVINITY | AddKeyword$ Indestructible | Description$ CARDNAME has indestructible as long as it has a divinity counter on it.
 A:AB$ DestroyAll | Cost$ SubCounter<1/DIVINITY> | ValidCards$ Land | SpellDescription$ Destroy all lands.
-Oracle:Myojin of Infinite Rage enters the battlefield with a divinity counter on it if you cast it from your hand.\nMyojin of Infinite Rage has indestructible as long as it has a divinity counter on it.\nRemove a divinity counter from Myojin of Infinite Rage: Destroy all lands.
+Oracle:Myojin of Infinite Rage enters with a divinity counter on it if you cast it from your hand.\nMyojin of Infinite Rage has indestructible as long as it has a divinity counter on it.\nRemove a divinity counter from Myojin of Infinite Rage: Destroy all lands.

--- a/forge-gui/res/cardsfolder/m/myojin_of_lifes_web.txt
+++ b/forge-gui/res/cardsfolder/m/myojin_of_lifes_web.txt
@@ -2,10 +2,10 @@ Name:Myojin of Life's Web
 ManaCost:6 G G G
 Types:Legendary Creature Spirit
 PT:8/8
-K:etbCounter:DIVINITY:1:CheckSVar$ FromHand:CARDNAME enters the battlefield with a divinity counter on it if you cast it from your hand.
+K:etbCounter:DIVINITY:1:CheckSVar$ FromHand:CARDNAME enters with a divinity counter on it if you cast it from your hand.
 SVar:FromHand:Count$wasCastFromYourHandByYou.1.0
 S:Mode$ Continuous | Affected$ Card.Self+counters_GE1_DIVINITY | AddKeyword$ Indestructible | Description$ CARDNAME has indestructible as long as it has a divinity counter on it.
 A:AB$ ChangeZone | Cost$ SubCounter<1/DIVINITY> | Origin$ Hand | Destination$ Battlefield | ChangeType$ Creature | ChangeNum$ X | SpellDescription$ Put any number of creature cards from your hand onto the battlefield.
 SVar:X:Count$InYourHand.Creature
 AI:RemoveDeck:All
-Oracle:Myojin of Life's Web enters the battlefield with a divinity counter on it if you cast it from your hand.\nMyojin of Life's Web has indestructible as long as it has a divinity counter on it.\nRemove a divinity counter from Myojin of Life's Web: Put any number of creature cards from your hand onto the battlefield.
+Oracle:Myojin of Life's Web enters with a divinity counter on it if you cast it from your hand.\nMyojin of Life's Web has indestructible as long as it has a divinity counter on it.\nRemove a divinity counter from Myojin of Life's Web: Put any number of creature cards from your hand onto the battlefield.

--- a/forge-gui/res/cardsfolder/m/myojin_of_nights_reach.txt
+++ b/forge-gui/res/cardsfolder/m/myojin_of_nights_reach.txt
@@ -2,8 +2,8 @@ Name:Myojin of Night's Reach
 ManaCost:5 B B B
 Types:Legendary Creature Spirit
 PT:5/2
-K:etbCounter:DIVINITY:1:CheckSVar$ FromHand:CARDNAME enters the battlefield with a divinity counter on it if you cast it from your hand.
+K:etbCounter:DIVINITY:1:CheckSVar$ FromHand:CARDNAME enters with a divinity counter on it if you cast it from your hand.
 SVar:FromHand:Count$wasCastFromYourHandByYou.1.0
 S:Mode$ Continuous | Affected$ Card.Self+counters_GE1_DIVINITY | AddKeyword$ Indestructible | Description$ CARDNAME has indestructible as long as it has a divinity counter on it.
 A:AB$ Discard | Cost$ SubCounter<1/DIVINITY> | Defined$ Player.Opponent | Mode$ Hand | SpellDescription$ Each opponent discards their hand.
-Oracle:Myojin of Night's Reach enters the battlefield with a divinity counter on it if you cast it from your hand.\nMyojin of Night's Reach has indestructible as long as it has a divinity counter on it.\nRemove a divinity counter from Myojin of Night's Reach: Each opponent discards their hand.
+Oracle:Myojin of Night's Reach enters with a divinity counter on it if you cast it from your hand.\nMyojin of Night's Reach has indestructible as long as it has a divinity counter on it.\nRemove a divinity counter from Myojin of Night's Reach: Each opponent discards their hand.

--- a/forge-gui/res/cardsfolder/m/myojin_of_roaring_blades.txt
+++ b/forge-gui/res/cardsfolder/m/myojin_of_roaring_blades.txt
@@ -2,9 +2,9 @@ Name:Myojin of Roaring Blades
 ManaCost:5 R R R
 Types:Legendary Creature Spirit
 PT:7/4
-K:etbCounter:Indestructible:1:CheckSVar$ FromHand:CARDNAME enters the battlefield with an indestructible counter on it if you cast it from your hand.
+K:etbCounter:Indestructible:1:CheckSVar$ FromHand:CARDNAME enters with an indestructible counter on it if you cast it from your hand.
 SVar:FromHand:Count$wasCastFromYourHandByYou.1.0
 A:AB$ DealDamage | Cost$ SubCounter<1/Indestructible> | NumDmg$ 7 | TargetMin$ 0 | TargetMax$ 3 | ValidTgts$ Any | SpellDescription$ It deals 7 damage to each of up to three targets.
 DeckHas:Ability$Counters
 DeckHints:Ability$Proliferate
-Oracle:Myojin of Roaring Blades enters the battlefield with an indestructible counter on it if you cast it from your hand.\nRemove an indestructible counter from Myojin of Roaring Blades: It deals 7 damage to each of up to three targets.
+Oracle:Myojin of Roaring Blades enters with an indestructible counter on it if you cast it from your hand.\nRemove an indestructible counter from Myojin of Roaring Blades: It deals 7 damage to each of up to three targets.

--- a/forge-gui/res/cardsfolder/m/myojin_of_seeing_winds.txt
+++ b/forge-gui/res/cardsfolder/m/myojin_of_seeing_winds.txt
@@ -2,10 +2,10 @@ Name:Myojin of Seeing Winds
 ManaCost:7 U U U
 Types:Legendary Creature Spirit
 PT:3/3
-K:etbCounter:DIVINITY:1:CheckSVar$ FromHand:CARDNAME enters the battlefield with a divinity counter on it if you cast it from your hand.
+K:etbCounter:DIVINITY:1:CheckSVar$ FromHand:CARDNAME enters with a divinity counter on it if you cast it from your hand.
 SVar:FromHand:Count$wasCastFromYourHandByYou.1.0
 S:Mode$ Continuous | Affected$ Card.Self+counters_GE1_DIVINITY | AddKeyword$ Indestructible | Description$ CARDNAME has indestructible as long as it has a divinity counter on it.
 A:AB$ Draw | Cost$ SubCounter<1/DIVINITY> | NumCards$ X | SpellDescription$ Draw a card for each permanent you control.
 SVar:X:Count$Valid Permanent.YouCtrl
 AI:RemoveDeck:All
-Oracle:Myojin of Seeing Winds enters the battlefield with a divinity counter on it if you cast it from your hand.\nMyojin of Seeing Winds has indestructible as long as it has a divinity counter on it.\nRemove a divinity counter from Myojin of Seeing Winds: Draw a card for each permanent you control.
+Oracle:Myojin of Seeing Winds enters with a divinity counter on it if you cast it from your hand.\nMyojin of Seeing Winds has indestructible as long as it has a divinity counter on it.\nRemove a divinity counter from Myojin of Seeing Winds: Draw a card for each permanent you control.

--- a/forge-gui/res/cardsfolder/m/myojin_of_towering_might.txt
+++ b/forge-gui/res/cardsfolder/m/myojin_of_towering_might.txt
@@ -2,9 +2,9 @@ Name:Myojin of Towering Might
 ManaCost:5 G G G
 Types:Legendary Creature Spirit
 PT:8/8
-K:etbCounter:Indestructible:1:CheckSVar$ FromHand:CARDNAME enters the battlefield with an indestructible counter on it if you cast it from your hand.
+K:etbCounter:Indestructible:1:CheckSVar$ FromHand:CARDNAME enters with an indestructible counter on it if you cast it from your hand.
 SVar:FromHand:Count$wasCastFromYourHandByYou.1.0
 A:AB$ PutCounter | Cost$ SubCounter<1/Indestructible> | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select any number of target creatures you control | CounterType$ P1P1 | CounterNum$ 8 | TargetMin$ 0 | TargetMax$ 8 | DividedAsYouChoose$ 8 | SubAbility$ DBPump | SpellDescription$ Distribute eight +1/+1 counters among any number of target creatures you control.
 SVar:DBPump:DB$ Pump | KW$ Trample | Defined$ Targeted | SpellDescription$ They gain trample until end of turn.
 DeckHas:Ability$Counters & Keyword$Trample
-Oracle:Myojin of Towering Might enters the battlefield with an indestructible counter on it if you cast it from your hand.\nRemove an indestructible counter from Myojin of Towering Might: Distribute eight +1/+1 counters among any number of target creatures you control. They gain trample until end of turn.
+Oracle:Myojin of Towering Might enters with an indestructible counter on it if you cast it from your hand.\nRemove an indestructible counter from Myojin of Towering Might: Distribute eight +1/+1 counters among any number of target creatures you control. They gain trample until end of turn.

--- a/forge-gui/res/cardsfolder/m/myr_battlesphere.txt
+++ b/forge-gui/res/cardsfolder/m/myr_battlesphere.txt
@@ -2,11 +2,11 @@ Name:Myr Battlesphere
 ManaCost:7
 Types:Artifact Creature Myr Construct
 PT:4/7
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters the battlefield, create four 1/1 colorless Myr artifact creature tokens.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create four 1/1 colorless Myr artifact creature tokens.
 SVar:TrigToken:DB$ Token | TokenAmount$ 4 | TokenScript$ c_1_1_a_myr | TokenOwner$ You
 T:Mode$ Attacks | ValidCard$ Card.Self | OptionalDecider$ You | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, you may tap X untapped Myr you control. If you do, CARDNAME gets +X/+0 until end of turn and deals X damage to the player or planeswalker it's attacking.
 SVar:TrigPump:AB$ Pump | Cost$ tapXType<X/Myr> | Defined$ Self | NumAtt$ +X | NumDef$ +0 | SubAbility$ DBDealDamage
 SVar:DBDealDamage:DB$ DealDamage | Defined$ TriggeredDefender.Player & Valid Planeswalker.TriggeredDefender | NumDmg$ X
 SVar:X:Count$xPaid
 DeckHas:Ability$Token
-Oracle:When Myr Battlesphere enters the battlefield, create four 1/1 colorless Myr artifact creature tokens.\nWhenever Myr Battlesphere attacks, you may tap X untapped Myr you control. If you do, Myr Battlesphere gets +X/+0 until end of turn and deals X damage to the player or planeswalker it's attacking.
+Oracle:When Myr Battlesphere enters, create four 1/1 colorless Myr artifact creature tokens.\nWhenever Myr Battlesphere attacks, you may tap X untapped Myr you control. If you do, Myr Battlesphere gets +X/+0 until end of turn and deals X damage to the player or planeswalker it's attacking.

--- a/forge-gui/res/cardsfolder/m/myr_custodian.txt
+++ b/forge-gui/res/cardsfolder/m/myr_custodian.txt
@@ -2,7 +2,7 @@ Name:Myr Custodian
 ManaCost:3
 Types:Artifact Creature Myr
 PT:2/3
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters the battlefield, scry 2. Then each opponent may scry 1. (To scry X, that player looks at the top X cards of their library, then put any number of them on the bottom and the rest on top in any order.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2. Then each opponent may scry 1. (To scry X, that player looks at the top X cards of their library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 2 | SubAbility$ DBScry
 SVar:DBScry:DB$ Scry | ScryNum$ 1 | Defined$ Opponent | Optional$ True
-Oracle:When Myr Custodian enters the battlefield, scry 2. Then each opponent may scry 1. (To scry X, that player looks at the top X cards of their library, then put any number of them on the bottom and the rest on top in any order.)
+Oracle:When Myr Custodian enters, scry 2. Then each opponent may scry 1. (To scry X, that player looks at the top X cards of their library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/m/myr_kinsmith.txt
+++ b/forge-gui/res/cardsfolder/m/myr_kinsmith.txt
@@ -2,7 +2,7 @@ Name:Myr Kinsmith
 ManaCost:4
 Types:Artifact Creature Myr
 PT:3/1
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSearch | TriggerDescription$ When CARDNAME enters the battlefield, you may search your library for a Myr card, reveal it, put it into your hand, then shuffle.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSearch | TriggerDescription$ When CARDNAME enters, you may search your library for a Myr card, reveal it, put it into your hand, then shuffle.
 SVar:TrigSearch:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Myr | ChangeNum$ 1 | Shuffle$ True
 DeckHints:Type$Myr
-Oracle:When Myr Kinsmith enters the battlefield, you may search your library for a Myr card, reveal it, put it into your hand, then shuffle.
+Oracle:When Myr Kinsmith enters, you may search your library for a Myr card, reveal it, put it into your hand, then shuffle.

--- a/forge-gui/res/cardsfolder/m/myriad_construct.txt
+++ b/forge-gui/res/cardsfolder/m/myriad_construct.txt
@@ -3,14 +3,14 @@ ManaCost:4
 Types:Artifact Creature Construct
 PT:4/4
 K:Kicker:3
-R:Event$ Moved | ValidCard$ Card.Self+kicked | Destination$ Battlefield | ReplaceWith$ DBPutCounter | ReplacementResult$ Updated | Description$ If CARDNAME was kicked, it enters the battlefield with a +1/+1 counter on it for each nonbasic land your opponents control.
+R:Event$ Moved | ValidCard$ Card.Self+kicked | Destination$ Battlefield | ReplaceWith$ DBPutCounter | ReplacementResult$ Updated | Description$ If CARDNAME was kicked, it enters with a +1/+1 counter on it for each nonbasic land your opponents control.
 SVar:DBPutCounter:DB$ PutCounter | ETB$ True | Defined$ Self | CounterType$ P1P1 | CounterNum$ X
 SVar:X:Count$Valid Land.nonBasic+OppCtrl
 SVar:NeedsToPlayKicked:Land.nonBasic+OppCtrl
 T:Mode$ BecomesTarget | ValidTarget$ Card.Self | TriggerZones$ Battlefield | ValidSource$ Spell | Execute$ TrigSac | TriggerDescription$ When CARDNAME becomes the target of a spell, sacrifice it and create a number of 1/1 colorless Construct artifact creature tokens equal to its power.
-SVar:TrigSac:DB$ SacrificeAll | Defined$ Self | RememberSacrificed$ True | SubAbility$ DBToken
+SVar:TrigSac:DB$ Destroy | Defined$ Self | Sacrifice$ True | RememberLKI$ True | SubAbility$ DBToken
 SVar:DBToken:DB$ Token | TokenAmount$ Y | TokenScript$ c_1_1_a_construct | TokenOwner$ You | SubAbility$ DBCleanup
 SVar:Y:RememberedLKI$CardPower
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 DeckHas:Ability$Token|Counters
-Oracle:Kicker {3}\nIf Myriad Construct was kicked, it enters the battlefield with a +1/+1 counter on it for each nonbasic land your opponents control.\nWhen Myriad Construct becomes the target of a spell, sacrifice it and create a number of 1/1 colorless Construct artifact creature tokens equal to its power.
+Oracle:Kicker {3}\nIf Myriad Construct was kicked, it enters with a +1/+1 counter on it for each nonbasic land your opponents control.\nWhen Myriad Construct becomes the target of a spell, sacrifice it and create a number of 1/1 colorless Construct artifact creature tokens equal to its power.

--- a/forge-gui/res/cardsfolder/m/myriad_construct.txt
+++ b/forge-gui/res/cardsfolder/m/myriad_construct.txt
@@ -8,7 +8,7 @@ SVar:DBPutCounter:DB$ PutCounter | ETB$ True | Defined$ Self | CounterType$ P1P1
 SVar:X:Count$Valid Land.nonBasic+OppCtrl
 SVar:NeedsToPlayKicked:Land.nonBasic+OppCtrl
 T:Mode$ BecomesTarget | ValidTarget$ Card.Self | TriggerZones$ Battlefield | ValidSource$ Spell | Execute$ TrigSac | TriggerDescription$ When CARDNAME becomes the target of a spell, sacrifice it and create a number of 1/1 colorless Construct artifact creature tokens equal to its power.
-SVar:TrigSac:DB$ Destroy | Defined$ Self | Sacrifice$ True | RememberLKI$ True | SubAbility$ DBToken
+SVar:TrigSac:DB$ SacrificeAll | Defined$ Self | RememberSacrificed$ True | SubAbility$ DBToken
 SVar:DBToken:DB$ Token | TokenAmount$ Y | TokenScript$ c_1_1_a_construct | TokenOwner$ You | SubAbility$ DBCleanup
 SVar:Y:RememberedLKI$CardPower
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/m/myriad_landscape.txt
+++ b/forge-gui/res/cardsfolder/m/myriad_landscape.txt
@@ -1,7 +1,8 @@
 Name:Myriad Landscape
 ManaCost:no cost
 Types:Land
-K:CARDNAME enters the battlefield tapped.
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
+SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ ChangeZone | Cost$ 2 T Sac<1/CARDNAME> | Origin$ Library | Destination$ Battlefield | ChangeType$ Land.Basic | Tapped$ True | ChangeNum$ 2 | ShareLandType$ True | SpellDescription$ Search your library for up to two basic land cards that share a land type, put them onto the battlefield tapped, then shuffle.
-Oracle:Myriad Landscape enters the battlefield tapped.\n{T}: Add {C}.\n{2}, {T}, Sacrifice Myriad Landscape: Search your library for up to two basic land cards that share a land type, put them onto the battlefield tapped, then shuffle.
+Oracle:Myriad Landscape enters tapped.\n{T}: Add {C}.\n{2}, {T}, Sacrifice Myriad Landscape: Search your library for up to two basic land cards that share a land type, put them onto the battlefield tapped, then shuffle.

--- a/forge-gui/res/cardsfolder/m/mysterious_limousine.txt
+++ b/forge-gui/res/cardsfolder/m/mysterious_limousine.txt
@@ -2,10 +2,10 @@ Name:Mysterious Limousine
 ManaCost:3 W W
 Types:Artifact Vehicle
 PT:4/4
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ Whenever CARDNAME enters the battlefield or attacks, exile up to one other target creature until CARDNAME leaves the battlefield. If a creature is put into exile this way, return each other card exiled with CARDNAME to the battlefield under its owner's control.
-T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigExile | Secondary$ True | TriggerDescription$ Whenever CARDNAME enters the battlefield or attacks, exile up to one other target creature until CARDNAME leaves the battlefield. If a creature is put into exile this way, return each other card exiled with CARDNAME to the battlefield under its owner's control.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ Whenever CARDNAME enters or attacks, exile up to one other target creature until CARDNAME leaves the battlefield. If a creature is put into exile this way, return each other card exiled with CARDNAME to the battlefield under its owner's control.
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigExile | Secondary$ True | TriggerDescription$ Whenever CARDNAME enters or attacks, exile up to one other target creature until CARDNAME leaves the battlefield. If a creature is put into exile this way, return each other card exiled with CARDNAME to the battlefield under its owner's control.
 SVar:TrigExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Creature.Other | TgtPrompt$ Select up to one other target creature | TargetMin$ 0 | TargetMax$ 1 | Duration$ UntilHostLeavesPlay | RememberChanged$ True | SubAbility$ DBReturn
 SVar:DBReturn:DB$ ChangeZoneAll | Origin$ Exile | Destination$ Battlefield | ConditionDefined$ Remembered | ConditionPresent$ Card | ChangeType$ Card.ExiledWithSource+IsNotRemembered | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 K:Crew:2
-Oracle:Whenever Mysterious Limousine enters the battlefield or attacks, exile up to one other target creature until Mysterious Limousine leaves the battlefield. If a creature is put into exile this way, return each other card exiled with Mysterious Limousine to the battlefield under its owner's control.\nCrew 2
+Oracle:Whenever Mysterious Limousine enters or attacks, exile up to one other target creature until Mysterious Limousine leaves the battlefield. If a creature is put into exile this way, return each other card exiled with Mysterious Limousine to the battlefield under its owner's control.\nCrew 2

--- a/forge-gui/res/cardsfolder/m/mysterious_pathlighter.txt
+++ b/forge-gui/res/cardsfolder/m/mysterious_pathlighter.txt
@@ -4,6 +4,6 @@ Types:Creature Faerie
 PT:2/2
 K:Flying
 K:ETBReplacement:Other:AddExtraCounter:Mandatory:Battlefield:Creature.YouCtrl+AdventureCard
-SVar:AddExtraCounter:DB$ PutCounter | ETB$ True | Defined$ ReplacedCard | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Each creature you control that has an Adventure enters the battlefield with an additional +1/+1 counter on it. (It doesn't need to have gone on the adventure first.)
+SVar:AddExtraCounter:DB$ PutCounter | ETB$ True | Defined$ ReplacedCard | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Each creature you control that has an Adventure enters with an additional +1/+1 counter on it. (It doesn't need to have gone on the adventure first.)
 DeckHas:Ability$Counters
-Oracle:Flying\nEach creature you control that has an Adventure enters the battlefield with an additional +1/+1 counter on it. (It doesn't need to have gone on the adventure first.)
+Oracle:Flying\nEach creature you control that has an Adventure enters with an additional +1/+1 counter on it. (It doesn't need to have gone on the adventure first.)

--- a/forge-gui/res/cardsfolder/m/mysterious_stranger.txt
+++ b/forge-gui/res/cardsfolder/m/mysterious_stranger.txt
@@ -3,11 +3,11 @@ ManaCost:2 R R
 Types:Creature Human Rogue
 PT:3/2
 K:Flash
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigChangeZone | TriggerDescription$ When CARDNAME enters the battlefield, for each graveyard with an instant or sorcery card in it, exile target instant or sorcery card from that graveyard. If two or more cards are exiled this way, choose one of them at random and copy it. You may cast the copy without paying its mana cost.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigChangeZone | TriggerDescription$ When CARDNAME enters, for each graveyard with an instant or sorcery card in it, exile target instant or sorcery card from that graveyard. If two or more cards are exiled this way, choose one of them at random and copy it. You may cast the copy without paying its mana cost.
 SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | ValidTgts$ Instant,Sorcery | TgtPrompt$ For each player, select a target instant or sorcery card from their graveyard. | TargetMin$ OneEach | TargetMax$ OneEach | TargetsWithDifferentControllers$ True | RememberChanged$ True | SubAbility$ ChooseRandom
 SVar:ChooseRandom:DB$ ChooseCard | Choices$ Card.IsRemembered | ChoiceZone$ Exile | Defined$ You | Amount$ 1 | AtRandom$ True | ConditionCheckSVar$ CountExiled | ConditionSVarCompare$ GE2 | SubAbility$ DBPlay
 SVar:DBPlay:DB$ Play | Valid$ Card.ChosenCard | ValidSA$ Spell | ValidZone$ Exile | WithoutManaCost$ True | Optional$ True | CopyCard$ True
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearChosenCard$ True
 SVar:OneEach:PlayerCountPlayers$Amount
 SVar:CountExiled:Count$ValidExile Card.IsRemembered
-Oracle:Flash\nWhen Mysterious Stranger enters the battlefield, for each graveyard with an instant or sorcery card in it, exile target instant or sorcery card from that graveyard. If two or more cards are exiled this way, choose one of them at random and copy it. You may cast the copy without paying its mana cost.
+Oracle:Flash\nWhen Mysterious Stranger enters, for each graveyard with an instant or sorcery card in it, exile target instant or sorcery card from that graveyard. If two or more cards are exiled this way, choose one of them at random and copy it. You may cast the copy without paying its mana cost.

--- a/forge-gui/res/cardsfolder/m/mystic_barrier.txt
+++ b/forge-gui/res/cardsfolder/m/mystic_barrier.txt
@@ -1,11 +1,11 @@
 Name:Mystic Barrier
 ManaCost:4 W
 Types:Enchantment
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChooseDirection | TriggerDescription$ When CARDNAME enters the battlefield or at the beginning of your upkeep, choose left or right.
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigChooseDirection | Secondary$ True | TriggerDescription$ When CARDNAME enters the battlefield or at the beginning of your upkeep, choose left or right.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChooseDirection | TriggerDescription$ When CARDNAME enters or at the beginning of your upkeep, choose left or right.
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigChooseDirection | Secondary$ True | TriggerDescription$ When CARDNAME enters or at the beginning of your upkeep, choose left or right.
 SVar:TrigChooseDirection:AB$ ChooseDirection | Cost$ 0
 S:Mode$ CantAttack | DefenderNotNearestToYouInChosenDirection$ True | Description$ Each player may attack only the nearest opponent in the last chosen direction and planeswalkers controlled by that opponent.
 AI:RemoveDeck:Random
 SVar:NonStackingEffect:True
 AI:RemoveDeck:All
-Oracle:When Mystic Barrier enters the battlefield or at the beginning of your upkeep, choose left or right.\nEach player may attack only the nearest opponent in the last chosen direction and planeswalkers controlled by that opponent.
+Oracle:When Mystic Barrier enters or at the beginning of your upkeep, choose left or right.\nEach player may attack only the nearest opponent in the last chosen direction and planeswalkers controlled by that opponent.

--- a/forge-gui/res/cardsfolder/m/mystic_monastery.txt
+++ b/forge-gui/res/cardsfolder/m/mystic_monastery.txt
@@ -1,6 +1,7 @@
 Name:Mystic Monastery
 ManaCost:no cost
 Types:Land
-K:CARDNAME enters the battlefield tapped.
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
+SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 A:AB$ Mana | Cost$ T | Produced$ Combo U R W | SpellDescription$ Add {U}, {R}, or {W}.
-Oracle:Mystic Monastery enters the battlefield tapped.\n{T}: Add {U}, {R}, or {W}.
+Oracle:Mystic Monastery enters tapped.\n{T}: Add {U}, {R}, or {W}.

--- a/forge-gui/res/cardsfolder/m/mystic_reflection.txt
+++ b/forge-gui/res/cardsfolder/m/mystic_reflection.txt
@@ -1,8 +1,8 @@
 Name:Mystic Reflection
 ManaCost:1 U
 Types:Instant
-A:SP$ Effect | ValidTgts$ Creature.nonLegendary | TgtPrompt$ Choose target nonlegendary creature | RememberObjects$ Targeted | ReplacementEffects$ ReplaceETB | Triggers$ TrigRemove | SpellDescription$ Choose target nonlegendary creature. The next time one or more creatures or planeswalkers enter the battlefield this turn, they enter as copies of the chosen creature.
-SVar:ReplaceETB:Event$ Moved | Destination$ Battlefield | ValidCard$ Creature,Planeswalker | ReplaceWith$ EnterAsCopy | Layer$ Copy | ReplacementResult$ Updated | Description$ The next time one or more creatures or planeswalkers enter the battlefield this turn, they enter as copies of the chosen creature.
+A:SP$ Effect | ValidTgts$ Creature.nonLegendary | TgtPrompt$ Choose target nonlegendary creature | RememberObjects$ Targeted | ReplacementEffects$ ReplaceETB | Triggers$ TrigRemove | SpellDescription$ Choose target nonlegendary creature. The next time one or more creatures or planeswalkers enter this turn, they enter as copies of the chosen creature.
+SVar:ReplaceETB:Event$ Moved | Destination$ Battlefield | ValidCard$ Creature,Planeswalker | ReplaceWith$ EnterAsCopy | Layer$ Copy | ReplacementResult$ Updated | Description$ The next time one or more creatures or planeswalkers enter this turn, they enter as copies of the chosen creature.
 SVar:EnterAsCopy:DB$ Clone | Defined$ Remembered | CloneTarget$ ReplacedCard | SubAbility$ DBImprint
 SVar:DBImprint:DB$ Pump | ImprintCards$ ReplacedCard
 SVar:TrigRemove:Mode$ ChangesZoneAll | CheckSVar$ Z | Execute$ ExileSelf | Static$ True
@@ -10,4 +10,4 @@ SVar:ExileSelf:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ 
 SVar:Z:Imprinted$Amount
 K:Foretell:U
 AI:RemoveDeck:All
-Oracle:Choose target nonlegendary creature. The next time one or more creatures or planeswalkers enter the battlefield this turn, they enter as copies of the chosen creature.\nForetell {U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)
+Oracle:Choose target nonlegendary creature. The next time one or more creatures or planeswalkers enter this turn, they enter as copies of the chosen creature.\nForetell {U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)

--- a/forge-gui/res/cardsfolder/m/mystic_restraints.txt
+++ b/forge-gui/res/cardsfolder/m/mystic_restraints.txt
@@ -5,6 +5,6 @@ K:Flash
 K:Enchant creature
 A:SP$ Attach | Cost$ 2 U U | ValidTgts$ Creature | AILogic$ KeepTapped
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME doesn't untap during your untap step. | Description$ Enchanted creature doesn't untap during its controller's untap step.
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigTap | TriggerDescription$ When CARDNAME enters the battlefield, tap enchanted creature.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigTap | TriggerDescription$ When CARDNAME enters, tap enchanted creature.
 SVar:TrigTap:DB$ Tap | Defined$ Enchanted
-Oracle:Flash\nEnchant creature\nWhen Mystic Restraints enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.
+Oracle:Flash\nEnchant creature\nWhen Mystic Restraints enters, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.

--- a/forge-gui/res/cardsfolder/m/mystic_sanctuary.txt
+++ b/forge-gui/res/cardsfolder/m/mystic_sanctuary.txt
@@ -1,9 +1,9 @@
 Name:Mystic Sanctuary
 ManaCost:no cost
 Types:Land Island
-R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplaceWith$ LandTapped | ReplacementResult$ Updated | Description$ CARDNAME enters the battlefield tapped unless you control three or more other Islands.
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplaceWith$ LandTapped | ReplacementResult$ Updated | Description$ CARDNAME enters tapped unless you control three or more other Islands.
 SVar:LandTapped:DB$ Tap | Defined$ Self | ETB$ True | ConditionPresent$ Island.YouCtrl+Other | ConditionCompare$ LT3
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self+untapped | Execute$ TrigChange | OptionalDecider$ You | TriggerDescription$ When CARDNAME enters the battlefield untapped, you may put target instant or sorcery card from your graveyard on top of your library.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self+untapped | Execute$ TrigChange | OptionalDecider$ You | TriggerDescription$ When CARDNAME enters untapped, you may put target instant or sorcery card from your graveyard on top of your library.
 SVar:TrigChange:DB$ ChangeZone | TgtPrompt$ Choose target instant or sorcery card in your graveyard | ValidTgts$ Instant.YouOwn,Sorcery.YouOwn | Origin$ Graveyard | Destination$ Library
 DeckNeeds:Color$Blue
-Oracle:({T}: Add {U}.)\nMystic Sanctuary enters the battlefield tapped unless you control three or more other Islands.\nWhen Mystic Sanctuary enters the battlefield untapped, you may put target instant or sorcery card from your graveyard on top of your library.
+Oracle:({T}: Add {U}.)\nMystic Sanctuary enters tapped unless you control three or more other Islands.\nWhen Mystic Sanctuary enters untapped, you may put target instant or sorcery card from your graveyard on top of your library.

--- a/forge-gui/res/cardsfolder/m/mystic_snake.txt
+++ b/forge-gui/res/cardsfolder/m/mystic_snake.txt
@@ -3,6 +3,6 @@ ManaCost:1 G U U
 Types:Creature Snake
 PT:2/2
 K:Flash
-T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigCounter | TriggerDescription$ When CARDNAME enters the battlefield, counter target spell.
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigCounter | TriggerDescription$ When CARDNAME enters, counter target spell.
 SVar:TrigCounter:DB$ Counter | TargetType$ Spell | ValidTgts$ Card | TgtPrompt$ Select target spell
-Oracle:Flash\nWhen Mystic Snake enters the battlefield, counter target spell.
+Oracle:Flash\nWhen Mystic Snake enters, counter target spell.

--- a/forge-gui/res/cardsfolder/m/mystical_tether.txt
+++ b/forge-gui/res/cardsfolder/m/mystical_tether.txt
@@ -2,6 +2,6 @@ Name:Mystical Tether
 ManaCost:2 W
 Types:Enchantment
 K:MayFlashCost:2
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ When CARDNAME enters the battlefield, exile target artifact or creature an opponent controls until CARDNAME leaves the battlefield.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ When CARDNAME enters, exile target artifact or creature an opponent controls until CARDNAME leaves the battlefield.
 SVar:TrigExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Artifact.OppCtrl,Creature.OppCtrl | TgtPrompt$ Select target artifact or creature an opponent controls | Duration$ UntilHostLeavesPlay
-Oracle:You may cast Mystical Tether as though it had flash if you pay {2} more to cast it.\nWhen Mystical Tether enters the battlefield, exile target artifact or creature an opponent controls until Mystical Tether leaves the battlefield.
+Oracle:You may cast Mystical Tether as though it had flash if you pay {2} more to cast it.\nWhen Mystical Tether enters, exile target artifact or creature an opponent controls until Mystical Tether leaves the battlefield.

--- a/forge-gui/res/cardsfolder/m/mythos_of_illuna.txt
+++ b/forge-gui/res/cardsfolder/m/mythos_of_illuna.txt
@@ -1,9 +1,9 @@
 Name:Mythos of Illuna
 ManaCost:2 U U
 Types:Sorcery
-A:SP$ CopyPermanent | ValidTgts$ Permanent | TgtPrompt$ Select target permanent | ConditionManaNotSpent$ R G | SubAbility$ CopyFight | StackDescription$ SpellDescription | SpellDescription$ Create a token that's a copy of target permanent. If {R}{G} was spent to cast this spell, instead create a token that's a copy of that permanent, except the token has "When this permanent enters the battlefield, if it's a creature, it fights up to one target creature you don't control."
+A:SP$ CopyPermanent | ValidTgts$ Permanent | TgtPrompt$ Select target permanent | ConditionManaNotSpent$ R G | SubAbility$ CopyFight | StackDescription$ SpellDescription | SpellDescription$ Create a token that's a copy of target permanent. If {R}{G} was spent to cast this spell, instead create a token that's a copy of that permanent, except the token has "When this permanent enters, if it's a creature, it fights up to one target creature you don't control."
 SVar:CopyFight:DB$ CopyPermanent | Defined$ Targeted | ConditionManaSpent$ R G | AddTriggers$ TrigChange | AddSVars$ TrigFight,TrigChange | StackDescription$ None
-SVar:TrigChange:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.Self | Execute$ TrigFight | TriggerDescription$ When CARDNAME enters the battlefield, if it's a creature, it fights up to one target creature you don't control. (Each deals damage equal to its power to the other.)
+SVar:TrigChange:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.Self | Execute$ TrigFight | TriggerDescription$ When CARDNAME enters, if it's a creature, it fights up to one target creature you don't control. (Each deals damage equal to its power to the other.)
 SVar:TrigFight:DB$ Fight | Defined$ TriggeredCardLKICopy | ValidTgts$ Creature.YouDontCtrl | TgtPrompt$ Choose target creature you don't control | TargetMin$ 0 | TargetMax$ 1
 DeckHas:Ability$Token
-Oracle:Create a token that's a copy of target permanent. If {R}{G} was spent to cast this spell, instead create a token that's a copy of that permanent, except the token has "When this permanent enters the battlefield, if it's a creature, it fights up to one target creature you don't control."
+Oracle:Create a token that's a copy of target permanent. If {R}{G} was spent to cast this spell, instead create a token that's a copy of that permanent, except the token has "When this permanent enters, if it's a creature, it fights up to one target creature you don't control."

--- a/forge-gui/res/cardsfolder/m/mythweaver_poq.txt
+++ b/forge-gui/res/cardsfolder/m/mythweaver_poq.txt
@@ -4,6 +4,6 @@ Types:Legendary Creature Cat Shaman
 PT:*/*
 S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of lands you control.
 SVar:X:Count$Valid Land.YouCtrl
-T:Mode$ ChangesZoneAll | ValidCards$ Land.YouCtrl+nonToken | Destination$ Battlefield | TriggerZones$ Battlefield | ActivationLimit$ 1 | Execute$ TrigConjure | TriggerDescription$ Whenever one or more nontoken lands enter the battlefield under your control, for each of them, conjure a duplicate of it onto the battlefield. This ability triggers only once each turn.
+T:Mode$ ChangesZoneAll | ValidCards$ Land.YouCtrl+nonToken | Destination$ Battlefield | TriggerZones$ Battlefield | ActivationLimit$ 1 | Execute$ TrigConjure | TriggerDescription$ Whenever one or more nontoken lands you control enter, for each of them, conjure a duplicate of it onto the battlefield. This ability triggers only once each turn.
 SVar:TrigConjure:DB$ MakeCard | Conjure$ True | DefinedName$ TriggeredCards | Zone$ Battlefield
-Oracle:Mythweaver Poq's power and toughness are each equal to the number of lands you control.\nWhenever one or more nontoken lands enter the battlefield under your control, for each of them, conjure a duplicate of it onto the battlefield. This ability triggers only once each turn.
+Oracle:Mythweaver Poq's power and toughness are each equal to the number of lands you control.\nWhenever one or more nontoken lands you control enter, for each of them, conjure a duplicate of it onto the battlefield. This ability triggers only once each turn.


### PR DESCRIPTION
**Note:** While the only readily available source for [Mythweaver Poq](https://scryfall.com/card/ylci/19/mythweaver-poq) (Scryfall) has the effect trigger as "`Whenever one or more nontoken lands enter under your control, [...]`", comparing with landfall triggers in general and [Extraordinary Journey](https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=629549&printed=false) in particular would lead me to believe "`Whenever one or more nontoken lands you control enter, [...]`" is closer to the mark.