### PR TITLE
ETB update: 'tokenscripts', 'custom_cards' in `\adventure` 

### DIFF
--- a/forge-gui/res/adventure/common/custom_cards/grolnok_boss_effect.txt
+++ b/forge-gui/res/adventure/common/custom_cards/grolnok_boss_effect.txt
@@ -3,7 +3,7 @@ ManaCost:no cost
 Colors:black,green,blue
 Types:Enchantment
 S:Mode$ Continuous | Affected$ Enchantment.nonAura+Other,Artifact | EffectZone$ Command | SetPower$ AffectedX | SetToughness$ AffectedX | AddType$ Creature | Description$ Artifacts and enchantments are creatures in addition to their other types and has base power and base toughness each equal to its mana value.
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.nonToken+OppCtrl | TriggerZones$ Command | Execute$ TrigDualCopy | TriggerDescription$ Whenever a nontoken creature enters the battlefield under an opponents control, create a token that's a copy of that creature except it's a 1/1 green Frog.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.nonToken+OppCtrl | TriggerZones$ Command | Execute$ TrigDualCopy | TriggerDescription$ Whenever a nontoken creature an opponent controls enters, create a token that's a copy of that creature except it's a 1/1 green Frog.
 SVar:TrigDualCopy:DB$ CopyPermanent | Defined$ TriggeredCardLKICopy | SetPower$ 1 | SetToughness$ 1 | SetColor$ Green | SetCreatureTypes$ Frog
 SVar:AffectedX:Count$CardManaCost
-Oracle:Artifacts and enchantments are creatures in addition to their other types and has base power and base toughness each equal to its mana value.\nWhenever a nontoken creature enters the battlefield under an opponents control, create a token that's a copy of that creature except it's a 1/1 green Frog.
+Oracle:Artifacts and enchantments are creatures in addition to their other types and has base power and base toughness each equal to its mana value.\nWhenever a nontoken creature an opponent controls enters, create a token that's a copy of that creature except it's a 1/1 green Frog.

--- a/forge-gui/res/adventure/common/custom_cards/lorthos_presence.txt
+++ b/forge-gui/res/adventure/common/custom_cards/lorthos_presence.txt
@@ -2,6 +2,6 @@ Name:Lorthos' Presence
 ManaCost:no cost
 Colors:blue
 Types:Enchantment
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Permanent.nonLand+OppCtrl | TriggerZones$ Command | Execute$ TrigStunCounter | TriggerDescription$ Whenever a nonland permanent enters the battlefield under an opponent's control, put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Permanent.nonLand+OppCtrl | TriggerZones$ Command | Execute$ TrigStunCounter | TriggerDescription$ Whenever a nonland permanent an opponent controls enters, put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)
 SVar:TrigStunCounter:DB$ PutCounter | Defined$ TriggeredCard | CounterType$ Stun | CounterNum$ 1
-Oracle:Whenever a nonland permanent enters the battlefield under an opponent's control, put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)
+Oracle:Whenever a nonland permanent an opponent controls enters, put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)

--- a/forge-gui/res/adventure/common/custom_cards/third_head_of_the_hydra.txt
+++ b/forge-gui/res/adventure/common/custom_cards/third_head_of_the_hydra.txt
@@ -7,8 +7,8 @@ K:Defender
 S:Mode$ Continuous | Affected$ You | AddKeyword$ You can't lose the game. | Description$ You can't lose the game and your opponents can't win the game.
 S:Mode$ Continuous | Affected$ Opponent | AddKeyword$ You can't win the game. | Secondary$ True | Description$ You can't lose the game and your opponents can't win the game.
 K:ETBReplacement:Other:AddExtraCounter:Mandatory:Battlefield:Hydra.Other+YouCtrl
-SVar:AddExtraCounter:DB$ PutCounter | ETB$ True | Defined$ ReplacedCard | CounterType$ P1P1 | CounterNum$ 2 | SpellDescription$ Other Hydras you control enter the battlefield with two extra +1/+1 counters on them.
+SVar:AddExtraCounter:DB$ PutCounter | ETB$ True | Defined$ ReplacedCard | CounterType$ P1P1 | CounterNum$ 2 | SpellDescription$ Other Hydras you control enter with two extra +1/+1 counters on them.
 R:Event$ Moved | ActiveZones$ Battlefield | Origin$ Battlefield | ValidCard$ Card.Self | ReplaceWith$ Exile | Description$ If CARDNAME would leave the battlefield, instead exile it with three time counters on it. It gains suspend.
 SVar:Exile:DB$ ChangeZone | Hidden$ True | WithCountersType$ TIME | WithCountersAmount$ 3 | Origin$ All | Destination$ Exile | Defined$ ReplacedCard | SubAbility$ GiveSuspend
 SVar:GiveSuspend:DB$ PumpAll | ValidCards$ Card.withoutSuspend+YouOwn | KW$ Suspend | PumpZone$ Exile | Duration$ Permanent
-Oracle:Defender/nYou can't lose the game and your opponents can't win the game.\nOther Hydras you control enter the battlefield with two extra +1/+1 counters on them. \nIf Third Head of the Hydra would leave the battlefield, instead exile it with three time counters on it. It gains suspend.
+Oracle:Defender/nYou can't lose the game and your opponents can't win the game.\nOther Hydras you control enter with two extra +1/+1 counters on them. \nIf Third Head of the Hydra would leave the battlefield, instead exile it with three time counters on it. It gains suspend.

--- a/forge-gui/res/tokenscripts/meteorite.txt
+++ b/forge-gui/res/tokenscripts/meteorite.txt
@@ -1,7 +1,7 @@
 Name:Meteorite
 ManaCost:no cost
 Types:Artifact
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When CARDNAME enters the battlefield, it deals 2 damage to any target.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When CARDNAME enters, it deals 2 damage to any target.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Any | NumDmg$ 2
 A:AB$ Mana | Cost$ T | Produced$ Any | SpellDescription$ Add one mana of any color.
-Oracle:When Meteorite enters the battlefield, it deals 2 damage to any target.\n{T}: Add one mana of any color.
+Oracle:When Meteorite enters, it deals 2 damage to any target.\n{T}: Add one mana of any color.

--- a/forge-gui/res/tokenscripts/rg_1_1_dragon_flying_devour.txt
+++ b/forge-gui/res/tokenscripts/rg_1_1_dragon_flying_devour.txt
@@ -5,4 +5,4 @@ Colors:red,green
 PT:1/1
 K:Flying
 K:Devour:2
-Oracle:Flying, devour 2 (As this enters, you may sacrifice any number of creatures. It enters with twice that many +1/+1 counters on it.)
+Oracle:Flying, devour 2 (As this enters, you may sacrifice any number of creatures. This creature enters with twice that many +1/+1 counters on it.)

--- a/forge-gui/res/tokenscripts/rg_1_1_dragon_flying_devour.txt
+++ b/forge-gui/res/tokenscripts/rg_1_1_dragon_flying_devour.txt
@@ -5,4 +5,4 @@ Colors:red,green
 PT:1/1
 K:Flying
 K:Devour:2
-Oracle:Flying, devour 2 (As this token enters the battlefield, you may sacrifice any number of creatures. It enters the battlefield with twice that many +1/+1 counters on it.)
+Oracle:Flying, devour 2 (As this enters, you may sacrifice any number of creatures. It enters with twice that many +1/+1 counters on it.)

--- a/forge-gui/res/tokenscripts/rw_1_2_human_rogue_haste_damage.txt
+++ b/forge-gui/res/tokenscripts/rw_1_2_human_rogue_haste_damage.txt
@@ -4,6 +4,6 @@ Colors:red,white
 Types:Creature Human Rogue
 PT:1/2
 K:Haste
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When this creature enters the battlefield, it deals 1 damage to any target.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When this creature enters, it deals 1 damage to any target.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Any | NumDmg$ 1
-Oracle:Haste\nWhen this creature enters the battlefield, it deals 1 damage to any target.
+Oracle:Haste\nWhen this creature enters, it deals 1 damage to any target.


### PR DESCRIPTION
(Split off from https://github.com/Card-Forge/forge/pull/5720 )

Context for custom card edits:
- Grolnok's Boss Effect, Lorthos' Presence: [Faerie Artisans](https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=622700&printed=false)
- Third Head of the Hydra: [Gev, Scaled Scorch](https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=669128&printed=false)

The devour Dragon token script had the `Oracle:` reminder text brought in line with what's on other cards, such as [Bloodspore Thrinax](https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=627740&printed=false).