### PR TITLE
Update eastfarthing_farmer.txt

### DIFF
--- a/forge-gui/res/cardsfolder/e/eastfarthing_farmer.txt
+++ b/forge-gui/res/cardsfolder/e/eastfarthing_farmer.txt
@@ -4,7 +4,7 @@ Types:Creature Halfling Peasant
 PT:2/3
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigFood | TriggerDescription$ When CARDNAME enters, create a Food token. When you do, target creature you control gets +1/+1 until end of turn for each Food you control. (A Food token is an artifact with "{2}, {T}, Sacrifice this artifact: You gain 3 life.")
 SVar:TrigFood:DB$ Token | TokenAmount$ 1 | TokenScript$ c_a_food_sac | TokenOwner$ You | RememberOriginalTokens$ True | SubAbility$ DBImmediateTrig
-SVar:DBImmediateTrig:DB$ ImmediateTrigger | TriggerAmount$ Remembered$Amount | Execute$ TrigPump | SubAbility$ DBCleanup | TriggerDescription$ When you do, target creature you control gets +1/+1 until end of turn for each Food you control. (A Food token is an artifact with "{2}, {T}, Sacrifice this artifact: You gain 3 life.")
+SVar:DBImmediateTrig:DB$ ImmediateTrigger | TriggerAmount$ Remembered$Amount | Execute$ TrigPump | SubAbility$ DBCleanup | TriggerDescription$ When you do, target creature you control gets +1/+1 until end of turn for each Food you control.
 SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | NumAtt$ +X | NumDef$ +X
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Count$Valid Food.YouCtrl


### PR DESCRIPTION
Repeating the reminder text for what a Food **token** consists of seems unnecessary in the `Description$` for a reflexive trigger that cares about Foods in general, not just tokens.