### PR TITLE
Update niko_aris.txt

### DIFF
--- a/forge-gui/res/cardsfolder/n/niko_aris.txt
+++ b/forge-gui/res/cardsfolder/n/niko_aris.txt
@@ -8,7 +8,7 @@ SVar:X:Count$xPaid
 A:AB$ Effect | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | StaticAbilities$ Unblockable | Triggers$ Trig | TargetMin$ 0 | TargetMax$ 1 | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | RememberObjects$ Targeted | ExileOnMoved$ Battlefield | StackDescription$ SpellDescription | SpellDescription$ Up to one target creature you control can't be blocked this turn. Whenever that creature deals damage this turn, return it to its owner's hand.
 SVar:Unblockable:Mode$ CantBlockBy | ValidAttacker$ Card.IsRemembered | Description$ This creature can't be blocked this turn.
 SVar:Trig:Mode$ DamageDealtOnce | ValidSource$ Creature.IsRemembered | Execute$ Eff | TriggerDescription$ Whenever this creature deals damage this turn, return it to its owner's hand.
-SVar:Eff:DB$ ChangeZone | ValidTgts$ Creature.IsRemembered | Origin$ Battlefield | Destination$ Hand
+SVar:Eff:DB$ ChangeZone | Defined$ Remembered | Origin$ Battlefield | Destination$ Hand
 A:AB$ DealDamage | Cost$ SubCounter<1/LOYALTY> | Planeswalker$ True | ValidTgts$ Creature.tapped | NumDmg$ Y | TgtPrompt$ Select target tapped creature | SpellDescription$ CARDNAME deals 2 damage to target tapped creature for each card you've drawn this turn.
 SVar:Y:Count$YouDrewThisTurn/Twice
 A:AB$ Token | Cost$ SubCounter<1/LOYALTY> | Planeswalker$ True | TokenAmount$ 1 | TokenScript$ c_e_shard_draw | TokenOwner$ You | SpellDescription$ Create a Shard token.


### PR DESCRIPTION
A minor if mostly formal fix. 
While the loyalty ability setting up the effect with the static and triggered abilities targets, the triggered ability itself doesn't. The corner case that comes to mind is if the creature gains shroud in between being targeted and dealing damage. 
The script was tested and the trigger found to still work as expected.