### PR TITLE
PH20: Mountain Mover

### DIFF
--- a/forge-gui/res/cardsfolder/m/mountain_mover.txt
+++ b/forge-gui/res/cardsfolder/m/mountain_mover.txt
@@ -1,0 +1,14 @@
+Name:Mountain Mover
+ManaCost:2 R
+Types:Artifact Vehicle
+PT:5/3
+K:Flying
+K:Haste
+K:Crew:3
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ LiftMountain | TriggerDescription$ Whenever CARDNAME enters or attacks, put a Mountain card from outside the game underneath it.
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ LiftMountain | Secondary$ True | TriggerDescription$ Whenever CARDNAME enters or attacks, put a Mountain card from outside the game underneath it.
+SVar:LiftMountain:DB$ ChangeZone | Reveal$ True | Origin$ Sideboard | Destination$ Exile | ChangeType$ Card.Mountain+YouOwn | ChangeTypeDesc$ Mountain card they own | ChangeNum$ 1 | Hidden$ True
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | ValidCard$ Card.Self | Execute$ DropMountain | TriggerDescription$ When CARDNAME leaves the battlefield, put all cards underneath it onto the battlefield.
+SVar:DropMountain:DB$ ChangeZone | Defined$ ExiledWith | Origin$ Exile | Destination$ Battlefield | GainControl$ True
+Text:(Developer's note: For clarity, the first triggered ability has you choosing a Mountain card you own from your sideboard, reveal it and then put it in exile. The second triggered ability puts all cards exiled with this permanent onto the battlefield under the control of this permanent's controller.)
+Oracle:Flying, haste\nWhenever Mountain Mover enters or attacks, put a Mountain card from outside the game underneath it.\nWhen Mountain Mover leaves the battlefield, put all cards underneath it onto the battlefield.\nCrew 3


### PR DESCRIPTION
An outline of the rationale for adapting this one to Forge follows: 

[Mountain Mover](https://scryfall.com/card/ph20/2/mountain-mover)'s card text reads fairly close to the first printing rules text for [Purgatory](https://scryfall.com/card/mir/275/purgatory) and [Cold Storage](https://scryfall.com/card/tmp/280/cold-storage). Thus interpreting it for Forge's game engine should follow the errata for those cards, functional or otherwise. 
Furthermore, since this is a fairly recent, exceedingly limited run funny card, created well after the consolidation of "set aside" and "removed from the game" and the renaming of that zone to "exile", we can assume there was a looser approach to writing this card up. So, in a similar way to the more serious cards I mentioned, "underneath Mountain Mover" is taken to mean "exile". It's noteworthy here that Arena displays remembered exiled cards under the card that's remembering them. 
The lack of clarification regarding the ownership of cards pulled from outside the game and control of the same when they enter the battlefield is taken as a lapse. It's assumed that the controller of the first triggered ability looks for cards they own and the controller of the second triggered ability gains control of the permanents as those are put onto the battlefield. In support of this is the ruling for another funny card, [Frontier Explorer](https://scryfall.com/card/cmb2/6/frontier-explorer), that also doesn't mention ownership of cards pulled from outside the game explicitly. For tournaments, you're directed to look in your sideboard for relevant cards you own, while casually you can search your own collection. It's this stricter interpretation that is implemented here, though eventually a more flexible wish effect that looks more or less widely depending on the format should preferably be implemented as was discussed on Discord.