### PR TITLE
Cost$ cleanup: Instants and Sorceries with supertypes: Legendary, snow

### DIFF
--- a/forge-gui/res/cardsfolder/b/blessing_of_frost.txt
+++ b/forge-gui/res/cardsfolder/b/blessing_of_frost.txt
@@ -1,7 +1,7 @@
 Name:Blessing of Frost
 ManaCost:3 G
 Types:Snow Sorcery
-A:SP$ PutCounter | Cost$ 3 G | Choices$ Creature.YouCtrl | ChoiceTitle$ Choose any number of creatures you control to distribute counters to | CounterType$ P1P1 | CounterNum$ X | ChoiceAmount$ X | MinChoiceAmount$ 0 | DividedAsYouChoose$ X | SubAbility$ DBDraw | SpellDescription$ Distribute X +1/+1 counters among any number of creatures you control, where X is the amount of {S} spent to cast this spell.
+A:SP$ PutCounter | Choices$ Creature.YouCtrl | ChoiceTitle$ Choose any number of creatures you control to distribute counters to | CounterType$ P1P1 | CounterNum$ X | ChoiceAmount$ X | MinChoiceAmount$ 0 | DividedAsYouChoose$ X | SubAbility$ DBDraw | SpellDescription$ Distribute X +1/+1 counters among any number of creatures you control, where X is the amount of {S} spent to cast this spell.
 SVar:X:Count$CastTotalManaSpent Snow
 SVar:DBDraw:DB$ Draw | NumCards$ Y | SpellDescription$ Then draw a card for each creature you control with power 4 or greater.
 SVar:Y:Count$Valid Creature.powerGE4+YouCtrl

--- a/forge-gui/res/cardsfolder/b/blood_on_the_snow.txt
+++ b/forge-gui/res/cardsfolder/b/blood_on_the_snow.txt
@@ -1,7 +1,7 @@
 Name:Blood on the Snow
 ManaCost:4 B B
 Types:Snow Sorcery
-A:SP$ Charm | Cost$ 4 B B | Choices$ DestroyCtrs,DestroyPWs | CharmNum$ 1 | SubAbility$ NoopDesc
+A:SP$ Charm | Choices$ DestroyCtrs,DestroyPWs | CharmNum$ 1 | SubAbility$ NoopDesc
 SVar:DestroyCtrs:DB$ DestroyAll | ValidCards$ Creature | SubAbility$ DBReturn | SpellDescription$ Destroy all creatures.
 SVar:DestroyPWs:DB$ DestroyAll | ValidCards$ Planeswalker | SubAbility$ DBReturn | SpellDescription$ Destroy all planeswalkers.
 SVar:DBReturn:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | Hidden$ True | Mandatory$ True | ChangeType$ Creature.YouOwn+cmcLEX,Planeswalker.YouOwn+cmcLEX | ChangeTypeDesc$ creature or planeswalker card with mana value X or less

--- a/forge-gui/res/cardsfolder/g/graven_lore.txt
+++ b/forge-gui/res/cardsfolder/g/graven_lore.txt
@@ -1,7 +1,7 @@
 Name:Graven Lore
 ManaCost:3 U U
 Types:Snow Instant
-A:SP$ Scry | Cost$ 3 U U | ScryNum$ X | SubAbility$ DBDraw | SpellDescription$ Scry X, where X is the amount of {S} spent to cast this spell, then draw three cards. ({S} is mana from a snow source.)
+A:SP$ Scry | ScryNum$ X | SubAbility$ DBDraw | SpellDescription$ Scry X, where X is the amount of {S} spent to cast this spell, then draw three cards. ({S} is mana from a snow source.)
 SVar:DBDraw:DB$ Draw | NumCards$ 3
 SVar:X:Count$CastTotalManaSpent Snow
 SVar:AIPreference:ManaFrom$Snow

--- a/forge-gui/res/cardsfolder/j/jayas_immolating_inferno.txt
+++ b/forge-gui/res/cardsfolder/j/jayas_immolating_inferno.txt
@@ -1,6 +1,6 @@
 Name:Jaya's Immolating Inferno
 ManaCost:X R R
 Types:Legendary Sorcery
-A:SP$ DealDamage | Cost$ X R R | ValidTgts$ Any | TargetMin$ 0 | TargetMax$ 3 | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to each of up to three targets.
+A:SP$ DealDamage | ValidTgts$ Any | TargetMin$ 0 | TargetMax$ 3 | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to each of up to three targets.
 SVar:X:Count$xPaid
 Oracle:(You may cast a legendary sorcery only if you control a legendary creature or planeswalker.)\nJaya's Immolating Inferno deals X damage to each of up to three targets.

--- a/forge-gui/res/cardsfolder/k/kamahls_druidic_vow.txt
+++ b/forge-gui/res/cardsfolder/k/kamahls_druidic_vow.txt
@@ -1,7 +1,7 @@
 Name:Kamahl's Druidic Vow
 ManaCost:X G G
 Types:Legendary Sorcery
-A:SP$ Dig | Cost$ X G G | DigNum$ X | Reveal$ True | AnyNumber$ True | ChangeValid$ Land,Permanent.Legendary+cmcLEX | DestinationZone$ Battlefield | DestinationZone2$ Graveyard | SpellDescription$ Reveal the top X cards of your library. You may put any number of land and/or legendary permanent cards with mana value X or less from among them onto the battlefield. Put the rest into your graveyard.
+A:SP$ Dig | DigNum$ X | Reveal$ True | AnyNumber$ True | ChangeValid$ Land,Permanent.Legendary+cmcLEX | DestinationZone$ Battlefield | DestinationZone2$ Graveyard | SpellDescription$ Reveal the top X cards of your library. You may put any number of land and/or legendary permanent cards with mana value X or less from among them onto the battlefield. Put the rest into your graveyard.
 SVar:X:Count$xPaid
 SVar:NeedsToPlayVar:Z GE6
 SVar:Z:Count$Valid Land.YouCtrl+untapped

--- a/forge-gui/res/cardsfolder/k/karns_temporal_sundering.txt
+++ b/forge-gui/res/cardsfolder/k/karns_temporal_sundering.txt
@@ -1,7 +1,7 @@
 Name:Karn's Temporal Sundering
 ManaCost:4 U U
 Types:Legendary Sorcery
-A:SP$ AddTurn | Cost$ 4 U U | ValidTgts$ Player | TgtPrompt$ Select target player to take an extra turn | NumTurns$ 1 | SubAbility$ DBReturn | SpellDescription$ Target player takes an extra turn after this one. Return up to one target nonland permanent to its owner's hand. Exile CARDNAME.
+A:SP$ AddTurn | ValidTgts$ Player | TgtPrompt$ Select target player to take an extra turn | NumTurns$ 1 | SubAbility$ DBReturn | SpellDescription$ Target player takes an extra turn after this one. Return up to one target nonland permanent to its owner's hand. Exile CARDNAME.
 SVar:DBReturn:DB$ ChangeZone | ValidTgts$ Permanent.nonLand | TgtPrompt$ Select target nonland permanent to return to hand | TargetMin$ 0 | TargetMax$ 1 | Origin$ Battlefield | Destination$ Hand | SubAbility$ DBExile
 SVar:DBExile:DB$ ChangeZone | Origin$ Stack | Destination$ Exile
 Oracle:(You may cast a legendary sorcery only if you control a legendary creature or planeswalker.)\nTarget player takes an extra turn after this one. Return up to one target nonland permanent to its owner's hand. Exile Karn's Temporal Sundering.

--- a/forge-gui/res/cardsfolder/p/primevals_glorious_rebirth.txt
+++ b/forge-gui/res/cardsfolder/p/primevals_glorious_rebirth.txt
@@ -1,5 +1,5 @@
 Name:Primevals' Glorious Rebirth
 ManaCost:5 W B
 Types:Legendary Sorcery
-A:SP$ ChangeZoneAll | Cost$ 5 W B | ChangeType$ Permanent.Legendary+YouCtrl | Origin$ Graveyard | Destination$ Battlefield | SpellDescription$ Return all legendary permanent cards from your graveyard to the battlefield.
+A:SP$ ChangeZoneAll | ChangeType$ Permanent.Legendary+YouCtrl | Origin$ Graveyard | Destination$ Battlefield | SpellDescription$ Return all legendary permanent cards from your graveyard to the battlefield.
 Oracle:(You may cast a legendary sorcery only if you control a legendary creature or planeswalker.)\nReturn all legendary permanent cards from your graveyard to the battlefield.

--- a/forge-gui/res/cardsfolder/s/search_for_glory.txt
+++ b/forge-gui/res/cardsfolder/s/search_for_glory.txt
@@ -1,7 +1,7 @@
 Name:Search for Glory
 ManaCost:2 W
 Types:Snow Sorcery
-A:SP$ ChangeZone | Cost$ 2 W | Origin$ Library | Destination$ Hand | ChangeType$ Permanent.Snow,Legendary,Saga | ChangeNum$ 1 | SubAbility$ DBGainLife | SpellDescription$ Search your library for a snow permanent card, a legendary card, or a Saga card, reveal it, put it into your hand, then shuffle. You gain 1 life for each {S} spent to cast this spell.
+A:SP$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Permanent.Snow,Legendary,Saga | ChangeNum$ 1 | SubAbility$ DBGainLife | SpellDescription$ Search your library for a snow permanent card, a legendary card, or a Saga card, reveal it, put it into your hand, then shuffle. You gain 1 life for each {S} spent to cast this spell.
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ X
 SVar:X:Count$CastTotalManaSpent Snow
 SVar:AIPreference:ManaFrom$Snow

--- a/forge-gui/res/cardsfolder/t/tundra_fumarole.txt
+++ b/forge-gui/res/cardsfolder/t/tundra_fumarole.txt
@@ -1,7 +1,7 @@
 Name:Tundra Fumarole
 ManaCost:1 R R
 Types:Snow Sorcery
-A:SP$ DealDamage | Cost$ 1 R R | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker. | NumDmg$ 4 | SubAbility$ DBColorlessMana | SpellDescription$ CARDNAME deals 4 damage to target creature or planeswalker. Add {C} for each {S} spent to cast this spell. Until end of turn, you don't lose this mana as steps and phases end. | StackDescription$ SpellDescription
+A:SP$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker. | NumDmg$ 4 | SubAbility$ DBColorlessMana | SpellDescription$ CARDNAME deals 4 damage to target creature or planeswalker. Add {C} for each {S} spent to cast this spell. Until end of turn, you don't lose this mana as steps and phases end. | StackDescription$ SpellDescription
 SVar:DBColorlessMana:DB$ Mana | Produced$ C | Amount$ X | PersistentMana$ True
 SVar:X:Count$CastTotalManaSpent Snow
 SVar:AIPreference:ManaFrom$Snow

--- a/forge-gui/res/cardsfolder/u/urzas_ruinous_blast.txt
+++ b/forge-gui/res/cardsfolder/u/urzas_ruinous_blast.txt
@@ -1,5 +1,5 @@
 Name:Urza's Ruinous Blast
 ManaCost:4 W
 Types:Legendary Sorcery
-A:SP$ ChangeZoneAll | Cost$ 4 W | UseAllOriginZones$ True | Origin$ Battlefield | Destination$ Exile | ChangeType$ Permanent.nonLand+nonLegendary | IsCurse$ True | SpellDescription$ Exile all nonland permanents that aren't legendary.
+A:SP$ ChangeZoneAll | UseAllOriginZones$ True | Origin$ Battlefield | Destination$ Exile | ChangeType$ Permanent.nonLand+nonLegendary | IsCurse$ True | SpellDescription$ Exile all nonland permanents that aren't legendary.
 Oracle:(You may cast a legendary sorcery only if you control a legendary creature or planeswalker.)\nExile all nonland permanents that aren't legendary.

--- a/forge-gui/res/cardsfolder/y/yawgmoths_vile_offering.txt
+++ b/forge-gui/res/cardsfolder/y/yawgmoths_vile_offering.txt
@@ -1,7 +1,7 @@
 Name:Yawgmoth's Vile Offering
 ManaCost:4 B
 Types:Legendary Sorcery
-A:SP$ ChangeZone | Cost$ 4 B | Origin$ Graveyard | Destination$ Battlefield | GainControl$ True | ValidTgts$ Creature,Planeswalker | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Choose target creature or planeswalker card in a graveyard | SubAbility$ DBDestroy | SpellDescription$ Put up to one target creature or planeswalker card from a graveyard onto the battlefield under your control. Destroy up to one target creature or planeswalker. Exile CARDNAME.
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | GainControl$ True | ValidTgts$ Creature,Planeswalker | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Choose target creature or planeswalker card in a graveyard | SubAbility$ DBDestroy | SpellDescription$ Put up to one target creature or planeswalker card from a graveyard onto the battlefield under your control. Destroy up to one target creature or planeswalker. Exile CARDNAME.
 SVar:DBDestroy:DB$ Destroy | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | TargetMin$ 0 | TargetMax$ 1 | SubAbility$ DBExile
 SVar:DBExile:DB$ ChangeZone | Origin$ Stack | Destination$ Exile
 Oracle:(You may cast a legendary sorcery only if you control a legendary creature or planeswalker.)\nPut up to one target creature or planeswalker card from a graveyard onto the battlefield under your control. Destroy up to one target creature or planeswalker. Exile Yawgmoth's Vile Offering.


### PR DESCRIPTION
These were missed for [the main event](https://github.com/Card-Forge/forge/pull/5081) a few months ago. That lapse is thus corrected.