### PR TITLE
Update overblaze.txt

### DIFF
--- a/forge-gui/res/cardsfolder/o/overblaze.txt
+++ b/forge-gui/res/cardsfolder/o/overblaze.txt
@@ -2,7 +2,7 @@ Name:Overblaze
 ManaCost:3 R
 Types:Instant Arcane
 K:Splice:Arcane:2 R R
-A:SP$ Effect | ValidTgts$ Permanent,Player | RememberObjects$ Targeted | ReplacementEffects$ OverblazeEvent | SpellDescription$ Each time target permanent would deal damage to a permanent or player this turn, it deals double that damage to that permanent or player instead.
+A:SP$ Effect | ValidTgts$ Permanent | RememberObjects$ Targeted | ReplacementEffects$ OverblazeEvent | SpellDescription$ Each time target permanent would deal damage to a permanent or player this turn, it deals double that damage to that permanent or player instead.
 SVar:OverblazeEvent:Event$ DamageDone | ValidSource$ Permanent.IsRemembered | ValidTarget$ Permanent,Player | ReplaceWith$ DmgTwice | Description$ Each time target permanent would deal noncombat damage to a permanent or player this turn, it deals double that damage instead.
 SVar:DmgTwice:DB$ ReplaceEffect | VarName$ DamageAmount | VarValue$ X
 SVar:X:ReplaceCount$DamageAmount/Twice

--- a/forge-gui/res/cardsfolder/o/overblaze.txt
+++ b/forge-gui/res/cardsfolder/o/overblaze.txt
@@ -3,7 +3,7 @@ ManaCost:3 R
 Types:Instant Arcane
 K:Splice:Arcane:2 R R
 A:SP$ Effect | ValidTgts$ Permanent | RememberObjects$ Targeted | ReplacementEffects$ OverblazeEvent | SpellDescription$ Each time target permanent would deal damage to a permanent or player this turn, it deals double that damage to that permanent or player instead.
-SVar:OverblazeEvent:Event$ DamageDone | ValidSource$ Permanent.IsRemembered | ValidTarget$ Permanent,Player | ReplaceWith$ DmgTwice | Description$ Each time target permanent would deal noncombat damage to a permanent or player this turn, it deals double that damage instead.
+SVar:OverblazeEvent:Event$ DamageDone | ValidSource$ Permanent.IsRemembered | ValidTarget$ Permanent,Player | ReplaceWith$ DmgTwice | Description$ Each time target permanent would deal damage to a permanent or player this turn, it deals double that damage instead.
 SVar:DmgTwice:DB$ ReplaceEffect | VarName$ DamageAmount | VarValue$ X
 SVar:X:ReplaceCount$DamageAmount/Twice
 SVar:PlayMain1:TRUE


### PR DESCRIPTION
Mostly formal fix as I don't think the concept of a player directly dealing damage to a target exists in Magic. Still, by comparison with other temporary replacement effects on damage, the target of the `Effect` is the permanent dealing the damage. A `ValidTgts$` involving players only comes into consideration later in the script, when who/what is dealt damage is of relevance for the effect's functionality.