### PR TITLE
Update norns_fetchling.txt

### DIFF
--- a/forge-gui/res/cardsfolder/n/norns_fetchling.txt
+++ b/forge-gui/res/cardsfolder/n/norns_fetchling.txt
@@ -6,8 +6,8 @@ K:Toxic:1
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigBranch | TriggerDescription$ When CARDNAME enters, conjure a card named Plains into your hand. If an opponent has three or more poison counters, you may seek a nonland card instead.
 SVar:TrigBranch:DB$ Branch | BranchConditionSVar$ X | BranchConditionSVarCompare$ GE3 | TrueSubAbility$ DBGenericChoice | FalseSubAbility$ ConjurePlains
 SVar:DBGenericChoice:DB$ GenericChoice | Choices$ SeekNonLand,ConjurePlains
-SVar:SeekNonLand:DB$ Seek | Type$ Card.nonLand | StackDescription$ Seek a nonland card.
-SVar:ConjurePlains:DB$ MakeCard | Conjure$ True | Name$ Plains | Zone$ Hand | StackDescription$ Conjure a card named Plains into your hand.
+SVar:SeekNonLand:DB$ Seek | Type$ Card.nonLand | SpellDescription$ You may seek a nonland card.
+SVar:ConjurePlains:DB$ MakeCard | Conjure$ True | Name$ Plains | Zone$ Hand | SpellDescription$ Conjure a card named Plains into your hand.
 SVar:X:PlayerCountOpponents$HighestCounters.Poison
 DeckHints:Keyword$Toxic|Infect
 Oracle:Toxic 1\nCorrupted — When Norn's Fetchling enters, conjure a card named Plains into your hand. If an opponent has three or more poison counters, you may seek a nonland card instead.

--- a/forge-gui/res/cardsfolder/n/norns_fetchling.txt
+++ b/forge-gui/res/cardsfolder/n/norns_fetchling.txt
@@ -6,7 +6,7 @@ K:Toxic:1
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigBranch | TriggerDescription$ When CARDNAME enters, conjure a card named Plains into your hand. If an opponent has three or more poison counters, you may seek a nonland card instead.
 SVar:TrigBranch:DB$ Branch | BranchConditionSVar$ X | BranchConditionSVarCompare$ GE3 | TrueSubAbility$ DBGenericChoice | FalseSubAbility$ ConjurePlains
 SVar:DBGenericChoice:DB$ GenericChoice | Choices$ SeekNonLand,ConjurePlains
-SVar:SeekNonLand:DB$ Seek | Type$ Card.nonLand | SpellDescription$ You may seek a nonland card.
+SVar:SeekNonLand:DB$ Seek | Type$ Card.nonLand | SpellDescription$ Seek a nonland card.
 SVar:ConjurePlains:DB$ MakeCard | Conjure$ True | Name$ Plains | Zone$ Hand | SpellDescription$ Conjure a card named Plains into your hand.
 SVar:X:PlayerCountOpponents$HighestCounters.Poison
 DeckHints:Keyword$Toxic|Infect


### PR DESCRIPTION
The prompt for selecting between conjuring a Plains and seeking a nonland card for the enters trigger wasn't showing any text disambiguating between the two options. `SpellDescription$` replaced `StackDescription$` to correct this.