### PR TITLE
Miscallaneous Cleanup Part 3

### DIFF
--- a/forge-adventure/src/main/java/forge/adventure/editor/BiomeEdit.java
+++ b/forge-adventure/src/main/java/forge/adventure/editor/BiomeEdit.java
@@ -51,12 +51,12 @@ public class BiomeEdit extends FormPanel {
         add(terrain);
         add(structures);
 
-        name.getDocument().addDocumentListener(new DocumentChangeListener(() -> BiomeEdit.this.updateTerrain()));
-        tilesetName.getDocument().addDocumentListener(new DocumentChangeListener(() -> BiomeEdit.this.updateTerrain()));
-        color.getDocument().addDocumentListener(new DocumentChangeListener(() -> BiomeEdit.this.updateTerrain()));
+        name.getDocument().addDocumentListener(new DocumentChangeListener(BiomeEdit.this::updateTerrain));
+        tilesetName.getDocument().addDocumentListener(new DocumentChangeListener(BiomeEdit.this::updateTerrain));
+        color.getDocument().addDocumentListener(new DocumentChangeListener(BiomeEdit.this::updateTerrain));
         collision.addChangeListener(e -> BiomeEdit.this.updateTerrain());
-        spriteNames.getEdit().getDocument().addDocumentListener(new DocumentChangeListener(() -> BiomeEdit.this.updateTerrain()));
-        enemies.getEdit().getDocument().addDocumentListener(new DocumentChangeListener(() -> BiomeEdit.this.updateTerrain()));
+        spriteNames.getEdit().getDocument().addDocumentListener(new DocumentChangeListener(BiomeEdit.this::updateTerrain));
+        enemies.getEdit().getDocument().addDocumentListener(new DocumentChangeListener(BiomeEdit.this::updateTerrain));
         terrain.addChangeListener(e -> BiomeEdit.this.updateTerrain());
 
 
@@ -64,7 +64,7 @@ public class BiomeEdit extends FormPanel {
         startPointY.addChangeListener(e -> BiomeEdit.this.updateTerrain());
         noiseWeight.addChangeListener(e -> BiomeEdit.this.updateTerrain());
         distWeight.addChangeListener(e -> BiomeEdit.this.updateTerrain());
-        tilesetAtlas.getEdit().getDocument().addDocumentListener(new DocumentChangeListener(() -> BiomeEdit.this.updateTerrain()));
+        tilesetAtlas.getEdit().getDocument().addDocumentListener(new DocumentChangeListener(BiomeEdit.this::updateTerrain));
         width.addChangeListener(e -> BiomeEdit.this.updateTerrain());
         height.addChangeListener(e -> BiomeEdit.this.updateTerrain());
         refresh();

--- a/forge-adventure/src/main/java/forge/adventure/editor/BiomeStructureDataMappingEditor.java
+++ b/forge-adventure/src/main/java/forge/adventure/editor/BiomeStructureDataMappingEditor.java
@@ -135,8 +135,8 @@ public class BiomeStructureDataMappingEditor extends JComponent {
             add("color:",color);
             add("collision:",collision);
 
-            name.getDocument().addDocumentListener(new DocumentChangeListener(() -> BiomeStructureDataMappingEdit.this.update()));
-            color.getDocument().addDocumentListener(new DocumentChangeListener(() -> BiomeStructureDataMappingEdit.this.update()));
+            name.getDocument().addDocumentListener(new DocumentChangeListener(BiomeStructureDataMappingEdit.this::update));
+            color.getDocument().addDocumentListener(new DocumentChangeListener(BiomeStructureDataMappingEdit.this::update));
             collision.addChangeListener(e -> BiomeStructureDataMappingEdit.this.update());
             refresh();
         }

--- a/forge-adventure/src/main/java/forge/adventure/editor/BiomeStructureEdit.java
+++ b/forge-adventure/src/main/java/forge/adventure/editor/BiomeStructureEdit.java
@@ -45,7 +45,7 @@ public class BiomeStructureEdit extends FormPanel {
         add(center);
         add(data);
 
-        structureAtlasPath.getDocument().addDocumentListener(new DocumentChangeListener(() -> BiomeStructureEdit.this.updateStructure()));
+        structureAtlasPath.getDocument().addDocumentListener(new DocumentChangeListener(BiomeStructureEdit.this::updateStructure));
 
 
         x.addChangeListener(e -> BiomeStructureEdit.this.updateStructure());
@@ -55,8 +55,8 @@ public class BiomeStructureEdit extends FormPanel {
         randomPosition.addChangeListener(e -> BiomeStructureEdit.this.updateStructure());
 
         N.addChangeListener(e -> BiomeStructureEdit.this.updateStructure());
-        sourcePath.getDocument().addDocumentListener(new DocumentChangeListener(() -> BiomeStructureEdit.this.updateStructure()));
-        maskPath.getDocument().addDocumentListener(new DocumentChangeListener(() -> BiomeStructureEdit.this.updateStructure()));
+        sourcePath.getDocument().addDocumentListener(new DocumentChangeListener(BiomeStructureEdit.this::updateStructure));
+        maskPath.getDocument().addDocumentListener(new DocumentChangeListener(BiomeStructureEdit.this::updateStructure));
         periodicInput.addChangeListener(e -> BiomeStructureEdit.this.updateStructure());
         ground.addChangeListener(e -> BiomeStructureEdit.this.updateStructure());
         symmetry.addChangeListener(e -> BiomeStructureEdit.this.updateStructure());

--- a/forge-adventure/src/main/java/forge/adventure/editor/BiomeTerrainEdit.java
+++ b/forge-adventure/src/main/java/forge/adventure/editor/BiomeTerrainEdit.java
@@ -27,7 +27,7 @@ public class BiomeTerrainEdit extends FormPanel {
         center.add("resolution:",resolution);
         add(center,preview);
 
-        spriteName.getDocument().addDocumentListener(new DocumentChangeListener(() -> BiomeTerrainEdit.this.updateTerrain()));
+        spriteName.getDocument().addDocumentListener(new DocumentChangeListener(BiomeTerrainEdit.this::updateTerrain));
 
         min.addChangeListener(e -> BiomeTerrainEdit.this.updateTerrain());
         max.addChangeListener(e -> BiomeTerrainEdit.this.updateTerrain());

--- a/forge-adventure/src/main/java/forge/adventure/editor/DialogOptionEdit.java
+++ b/forge-adventure/src/main/java/forge/adventure/editor/DialogOptionEdit.java
@@ -40,8 +40,8 @@ public class DialogOptionEdit extends FormPanel {
 
         add(middle);
 
-        name.getDocument().addDocumentListener(new DocumentChangeListener(() -> DialogOptionEdit.this.updateDialog()));
-        text.getDocument().addDocumentListener(new DocumentChangeListener(() -> DialogOptionEdit.this.updateDialog()));
+        name.getDocument().addDocumentListener(new DocumentChangeListener(DialogOptionEdit.this::updateDialog));
+        text.getDocument().addDocumentListener(new DocumentChangeListener(DialogOptionEdit.this::updateDialog));
 
 
     }

--- a/forge-adventure/src/main/java/forge/adventure/editor/EditorMainWindow.java
+++ b/forge-adventure/src/main/java/forge/adventure/editor/EditorMainWindow.java
@@ -42,7 +42,7 @@ public class EditorMainWindow extends JFrame {
         BorderLayout layout=new BorderLayout();
         JToolBar toolBar = new JToolBar("toolbar");
         JButton newButton=new JButton("open ParticleEditor");
-        newButton.addActionListener(e -> EventQueue.invokeLater(() ->new ParticleEditor()));
+        newButton.addActionListener(e -> EventQueue.invokeLater(ParticleEditor::new));
         toolBar.add(newButton);
         setLayout(layout);
         toolBar.setFloatable(false);

--- a/forge-adventure/src/main/java/forge/adventure/editor/EffectEditor.java
+++ b/forge-adventure/src/main/java/forge/adventure/editor/EffectEditor.java
@@ -42,8 +42,8 @@ public class EffectEditor extends JComponent  {
         lifeModifier.addChangeListener(e -> EffectEditor.this.updateEffect());
         moveSpeed.addChangeListener(e -> EffectEditor.this.updateEffect());
         colorView.addChangeListener(e -> EffectEditor.this.updateEffect());
-        name.getDocument().addDocumentListener(new DocumentChangeListener(() -> EffectEditor.this.updateEffect()));
-        startBattleWithCard.getEdit().getDocument().addDocumentListener(new DocumentChangeListener(() -> EffectEditor.this.updateEffect()));
+        name.getDocument().addDocumentListener(new DocumentChangeListener(EffectEditor.this::updateEffect));
+        startBattleWithCard.getEdit().getDocument().addDocumentListener(new DocumentChangeListener(EffectEditor.this::updateEffect));
         if(opponent!=null)
 
             opponent.addChangeListener(e -> EffectEditor.this.updateEffect());

--- a/forge-adventure/src/main/java/forge/adventure/editor/EnemyEdit.java
+++ b/forge-adventure/src/main/java/forge/adventure/editor/EnemyEdit.java
@@ -289,7 +289,7 @@ public class EnemyEdit extends FormPanel {
             tags.add(e.nextElement());
         }
 
-        tags.removeIf(q -> q.isEmpty());
+        tags.removeIf(String::isEmpty);
         currentData.questTags = tags.toArray(currentData.questTags);
         QuestController.getInstance().refresh();
         filterExisting(enemyModel);

--- a/forge-adventure/src/main/java/forge/adventure/editor/ItemEdit.java
+++ b/forge-adventure/src/main/java/forge/adventure/editor/ItemEdit.java
@@ -38,10 +38,10 @@ public class ItemEdit extends JComponent {
         add(effect);
         add(new Box.Filler(new Dimension(0,0),new Dimension(0,Integer.MAX_VALUE),new Dimension(0,Integer.MAX_VALUE)));
 
-        nameField.getDocument().addDocumentListener(new DocumentChangeListener(() -> ItemEdit.this.updateItem()));
-        equipmentSlot.getDocument().addDocumentListener(new DocumentChangeListener(() -> ItemEdit.this.updateItem()));
-        description.getDocument().addDocumentListener(new DocumentChangeListener(() -> ItemEdit.this.updateItem()));
-        iconName.getDocument().addDocumentListener(new DocumentChangeListener(() -> ItemEdit.this.updateItem()));
+        nameField.getDocument().addDocumentListener(new DocumentChangeListener(ItemEdit.this::updateItem));
+        equipmentSlot.getDocument().addDocumentListener(new DocumentChangeListener(ItemEdit.this::updateItem));
+        description.getDocument().addDocumentListener(new DocumentChangeListener(ItemEdit.this::updateItem));
+        iconName.getDocument().addDocumentListener(new DocumentChangeListener(ItemEdit.this::updateItem));
         cost.addChangeListener(e -> ItemEdit.this.updateItem());
         questItem.addChangeListener(e -> ItemEdit.this.updateItem());
         effect.addChangeListener(e -> ItemEdit.this.updateItem());

--- a/forge-adventure/src/main/java/forge/adventure/editor/RewardEdit.java
+++ b/forge-adventure/src/main/java/forge/adventure/editor/RewardEdit.java
@@ -58,18 +58,18 @@ public class RewardEdit extends FormPanel {
         probability.addChangeListener(e -> RewardEdit.this.updateReward());
         count.addChangeListener(e -> RewardEdit.this.updateReward());
         addMaxCount.addChangeListener(e -> RewardEdit.this.updateReward());
-        cardName.getDocument().addDocumentListener(new DocumentChangeListener(() -> RewardEdit.this.updateReward()));
-        itemName.getDocument().addDocumentListener(new DocumentChangeListener(() -> RewardEdit.this.updateReward()));
-        editions.getEdit().getDocument().addDocumentListener(new DocumentChangeListener(() -> RewardEdit.this.updateReward()));
-        colors.getEdit().getDocument().addDocumentListener(new DocumentChangeListener(() -> RewardEdit.this.updateReward()));
-        rarity.getEdit().getDocument().addDocumentListener(new DocumentChangeListener(() -> RewardEdit.this.updateReward()));
-        subTypes.getEdit().getDocument().addDocumentListener(new DocumentChangeListener(() -> RewardEdit.this.updateReward()));
-        cardTypes.getEdit().getDocument().addDocumentListener(new DocumentChangeListener(() -> RewardEdit.this.updateReward()));
-        superTypes.getEdit().getDocument().addDocumentListener(new DocumentChangeListener(() -> RewardEdit.this.updateReward()));
-        manaCosts.getEdit().getDocument().addDocumentListener(new DocumentChangeListener(() -> RewardEdit.this.updateReward()));
-        keyWords.getEdit().getDocument().addDocumentListener(new DocumentChangeListener(() -> RewardEdit.this.updateReward()));
+        cardName.getDocument().addDocumentListener(new DocumentChangeListener(RewardEdit.this::updateReward));
+        itemName.getDocument().addDocumentListener(new DocumentChangeListener(RewardEdit.this::updateReward));
+        editions.getEdit().getDocument().addDocumentListener(new DocumentChangeListener(RewardEdit.this::updateReward));
+        colors.getEdit().getDocument().addDocumentListener(new DocumentChangeListener(RewardEdit.this::updateReward));
+        rarity.getEdit().getDocument().addDocumentListener(new DocumentChangeListener(RewardEdit.this::updateReward));
+        subTypes.getEdit().getDocument().addDocumentListener(new DocumentChangeListener(RewardEdit.this::updateReward));
+        cardTypes.getEdit().getDocument().addDocumentListener(new DocumentChangeListener(RewardEdit.this::updateReward));
+        superTypes.getEdit().getDocument().addDocumentListener(new DocumentChangeListener(RewardEdit.this::updateReward));
+        manaCosts.getEdit().getDocument().addDocumentListener(new DocumentChangeListener(RewardEdit.this::updateReward));
+        keyWords.getEdit().getDocument().addDocumentListener(new DocumentChangeListener(RewardEdit.this::updateReward));
         colorType.addActionListener((e -> RewardEdit.this.updateReward()));
-        cardText.getDocument().addDocumentListener(new DocumentChangeListener(() -> RewardEdit.this.updateReward()));
+        cardText.getDocument().addDocumentListener(new DocumentChangeListener(RewardEdit.this::updateReward));
 
     }
 

--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -666,7 +666,7 @@ public class AiController {
         List<SpellAbility> all = ComputerUtilAbility.getSpellAbilities(cards, player);
 
         try {
-            Collections.sort(all, ComputerUtilAbility.saEvaluator); // put best spells first
+            all.sort(ComputerUtilAbility.saEvaluator); // put best spells first
             ComputerUtilAbility.sortCreatureSpells(all);
         } catch (IllegalArgumentException ex) {
             System.err.println(ex.getMessage());
@@ -1589,7 +1589,7 @@ public class AiController {
             return null;
 
         try {
-            Collections.sort(all, ComputerUtilAbility.saEvaluator); // put best spells first
+            all.sort(ComputerUtilAbility.saEvaluator); // put best spells first
             ComputerUtilAbility.sortCreatureSpells(all);
         } catch (IllegalArgumentException ex) {
             System.err.println(ex.getMessage());

--- a/forge-ai/src/main/java/forge/ai/ComputerUtil.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtil.java
@@ -2591,7 +2591,7 @@ public class ComputerUtil {
                             chosen = b;
                         }
                     }
-                    if (chosen.equals("")) {
+                    if (chosen.isEmpty()) {
                         for (String b : basics) {
                             if (Iterables.any(possibleCards, CardPredicates.isType(b))) {
                                 chosen = b;

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
@@ -2092,6 +2092,7 @@ public class ComputerUtilCard {
             for (Card card2 : card.getEnchantedBy()) {
                 if (card2.getOwner() != ai) {
                     disabledByEnemy = true;
+                    break;
                 }
             }
             if (!disabledByEnemy) {

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
@@ -965,7 +965,7 @@ public class ComputerUtilCard {
             if (color.hasGreen()) map.get(4).setValue(map.get(4).getValue() + 1);
         }
 
-        Collections.sort(map, Comparator.<Pair<Byte, Integer>>comparingInt(Pair::getValue).reversed());
+        map.sort(Comparator.<Pair<Byte, Integer>>comparingInt(Pair::getValue).reversed());
 
         // will this part be once dropped?
         List<String> result = new ArrayList<>(cntColors);

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCombat.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCombat.java
@@ -421,7 +421,7 @@ public class ComputerUtilCombat {
             final List<Card> blockers = combat.getBlockers(attacker);
 
             if (blockers.isEmpty()) {
-                if (!attacker.getSVar("MustBeBlocked").equals("")) {
+                if (!attacker.getSVar("MustBeBlocked").isEmpty()) {
                     boolean cond = false;
                     String condVal = attacker.getSVar("MustBeBlocked");
                     boolean isAttackingPlayer = combat.getDefenderByAttacker(attacker) instanceof Player;
@@ -490,7 +490,7 @@ public class ComputerUtilCombat {
             final List<Card> blockers = combat.getBlockers(attacker);
 
             if (blockers.isEmpty()) {
-                if (!attacker.getSVar("MustBeBlocked").equals("")) {
+                if (!attacker.getSVar("MustBeBlocked").isEmpty()) {
                     return true;
                 }
             }

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
@@ -1040,7 +1040,7 @@ public class ComputerUtilMana {
         // If it's a low priority spell (it's explicitly marked so elsewhere in the AI with a SVar), always
         // obey mana reservations for Main 2; otherwise, obey mana reservations depending on the "chance to reserve"
         // AI profile variable.
-        if (sa.getSVar("LowPriorityAI").equals("")) {
+        if (sa.getSVar("LowPriorityAI").isEmpty()) {
             if (chanceToReserve == 0 || MyRandom.getRandom().nextInt(100) >= chanceToReserve) {
                 return false;
             }

--- a/forge-ai/src/main/java/forge/ai/SpecialCardAi.java
+++ b/forge-ai/src/main/java/forge/ai/SpecialCardAi.java
@@ -791,7 +791,7 @@ public class SpecialCardAi {
                     sa.getParamOrDefault("ChangeNum", "1"), sa);
             CardCollection lib = CardLists.filter(ai.getCardsIn(ZoneType.Library),
                     Predicates.not(CardPredicates.nameEquals(sa.getHostCard().getName())));
-            Collections.sort(lib, CardLists.CmcComparatorInv);
+            lib.sort(CardLists.CmcComparatorInv);
 
             // Additional cards which are difficult to auto-classify but which are generally good to Intuition for
             List<String> highPriorityNamedCards = Lists.newArrayList("Accumulated Knowledge", "Take Inventory");
@@ -888,7 +888,7 @@ public class SpecialCardAi {
             // If we're playing Reanimator, we're really interested just in the highest CMC spells, not the
             // ones we necessarily have multiples of
             if (ComputerUtil.isPlayingReanimator(ai)) {
-                Collections.sort(libHighPriorityList, CardLists.CmcComparatorInv);
+                libHighPriorityList.sort(CardLists.CmcComparatorInv);
             }
 
             // Otherwise, try to grab something that is hopefully decent to grab, in priority order
@@ -1502,7 +1502,7 @@ public class SpecialCardAi {
             if (atTargetCMCInLib.isEmpty()) {
                 atTargetCMCInLib = CardLists.filter(creatsInLib, CardPredicates.greaterCMC(numManaSrcs));
             }
-            Collections.sort(atTargetCMCInLib, CardLists.CmcComparatorInv);
+            atTargetCMCInLib.sort(CardLists.CmcComparatorInv);
             if (atTargetCMCInLib.isEmpty()) {
                 // Nothing to aim for?
                 return null;
@@ -1510,11 +1510,11 @@ public class SpecialCardAi {
 
             // Cards in hand that are below the max CMC affordable by the AI
             CardCollection belowMaxCMC = CardLists.filter(creatsInHand, CardPredicates.lessCMC(numManaSrcs - 1));
-            Collections.sort(belowMaxCMC, Collections.reverseOrder(CardLists.CmcComparatorInv));
+            belowMaxCMC.sort(Collections.reverseOrder(CardLists.CmcComparatorInv));
 
             // Cards in hand that are above the max CMC affordable by the AI
             CardCollection aboveMaxCMC = CardLists.filter(creatsInHand, CardPredicates.greaterCMC(numManaSrcs + 1));
-            Collections.sort(aboveMaxCMC, CardLists.CmcComparatorInv);
+            aboveMaxCMC.sort(CardLists.CmcComparatorInv);
 
             Card maxCMC = !aboveMaxCMC.isEmpty() ? aboveMaxCMC.getFirst() : null;
             Card minCMC = !belowMaxCMC.isEmpty() ? belowMaxCMC.getFirst() : null;
@@ -1547,7 +1547,7 @@ public class SpecialCardAi {
             // worth to fill the graveyard now
             if (ComputerUtil.isPlayingReanimator(ai) && !creatsInLib.isEmpty()) {
                 CardCollection creatsInHandByCMC = new CardCollection(creatsInHand);
-                Collections.sort(creatsInHandByCMC, CardLists.CmcComparatorInv);
+                creatsInHandByCMC.sort(CardLists.CmcComparatorInv);
                 return creatsInHandByCMC.getFirst();
             }
 
@@ -1569,14 +1569,14 @@ public class SpecialCardAi {
             if (atTargetCMCInLib.isEmpty()) {
                 atTargetCMCInLib = CardLists.filter(creatsInLib, CardPredicates.greaterCMC(numManaSrcs));
             }
-            Collections.sort(atTargetCMCInLib, CardLists.CmcComparatorInv);
+            atTargetCMCInLib.sort(CardLists.CmcComparatorInv);
 
             Card bestInLib = atTargetCMCInLib != null ? atTargetCMCInLib.getFirst() : null;
 
             if (bestInLib == null && ComputerUtil.isPlayingReanimator(ai)) {
                 // For Reanimator, we don't mind grabbing the biggest thing possible to recycle it again with SotF later.
                 CardCollection creatsInLibByCMC = new CardCollection(creatsInLib);
-                Collections.sort(creatsInLibByCMC, CardLists.CmcComparatorInv);
+                creatsInLibByCMC.sort(CardLists.CmcComparatorInv);
                 return creatsInLibByCMC.getFirst();
             }
 

--- a/forge-ai/src/main/java/forge/ai/ability/ChooseCardAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ChooseCardAi.java
@@ -168,7 +168,7 @@ public class ChooseCardAi extends SpellAbilityAi {
             logic = logic.replace("NotSelf", "");
         }
         Card choice = null;
-        if (logic.equals("")) {
+        if (logic.isEmpty()) {
             // Base Logic is choose "best"
             choice = ComputerUtilCard.getBestAI(options);
         } else if ("WorstCard".equals(logic)) {

--- a/forge-ai/src/main/java/forge/ai/ability/DamagePreventAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DamagePreventAi.java
@@ -51,6 +51,7 @@ public class DamagePreventAi extends SpellAbilityAi {
                 for (final Object o : objects) {
                     if (threatenedObjects.contains(o)) {
                         chance = true;
+                        break;
                     }
                 }
             } else {

--- a/forge-ai/src/main/java/forge/ai/ability/EffectAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/EffectAi.java
@@ -427,7 +427,7 @@ public class EffectAi extends SpellAbilityAi {
         if (sa.usesTargeting() && !sa.getTargetRestrictions().canTgtPlayer()) {
             // try to target the opponent's best targetable permanent, if able
             CardCollection oppPerms = CardLists.getValidCards(aiPlayer.getOpponents().getCardsIn(sa.getTargetRestrictions().getZone()), sa.getTargetRestrictions().getValidTgts(), aiPlayer, sa.getHostCard(), sa);
-            oppPerms = CardLists.filter(oppPerms, card -> sa.canTarget(card));
+            oppPerms = CardLists.filter(oppPerms, sa::canTarget);
             if (!oppPerms.isEmpty()) {
                 sa.resetTargets();
                 sa.getTargets().add(ComputerUtilCard.getBestAI(oppPerms));
@@ -437,7 +437,7 @@ public class EffectAi extends SpellAbilityAi {
             if (mandatory) {
                 // try to target the AI's worst targetable permanent, if able
                 CardCollection aiPerms = CardLists.getValidCards(aiPlayer.getCardsIn(sa.getTargetRestrictions().getZone()), sa.getTargetRestrictions().getValidTgts(), aiPlayer, sa.getHostCard(), sa);
-                aiPerms = CardLists.filter(aiPerms, card -> sa.canTarget(card));
+                aiPerms = CardLists.filter(aiPerms, sa::canTarget);
                 if (!aiPerms.isEmpty()) {
                     sa.resetTargets();
                     sa.getTargets().add(ComputerUtilCard.getWorstAI(aiPerms));

--- a/forge-core/src/main/java/forge/CardStorageReader.java
+++ b/forge-core/src/main/java/forge/CardStorageReader.java
@@ -382,25 +382,14 @@ public class CardStorageReader {
      * @return a new Card instance
      */
     protected final CardRules loadCard(final CardRules.Reader reader, final File file) {
-        FileInputStream fileInputStream = null;
-        try {
-            fileInputStream = new FileInputStream(file);
+        try (InputStream fileInputStream = java.nio.file.Files.newInputStream(file.toPath())) {
             reader.reset();
             final List<String> lines = readScript(fileInputStream);
             return reader.readCard(lines, Files.getNameWithoutExtension(file.getName()));
         } catch (final FileNotFoundException ex) {
             throw new RuntimeException("CardReader : run error -- file not found: " + file.getPath(), ex);
         } catch (final Exception ex) {
-            System.out.println("Error loading cardscript " + file.getName() + ". Please close Forge and resolve this.");
-            throw ex;
-        } finally {
-            try {
-                assert fileInputStream != null;
-                fileInputStream.close();
-            } catch (final IOException ignored) {
-                // 11:08
-                // PM
-            }
+            throw new RuntimeException("Error loading cardscript " + file.getName() + ". Please close Forge and resolve this.", ex);
         }
     }
 

--- a/forge-core/src/main/java/forge/FTrace.java
+++ b/forge-core/src/main/java/forge/FTrace.java
@@ -15,11 +15,7 @@ public class FTrace {
     }
 
     public static FTrace get(String name0) {
-        FTrace trace = traces.get(name0);
-        if (trace == null) {
-            trace = new FTrace(name0);
-            traces.put(name0, trace);
-        }
+        FTrace trace = traces.computeIfAbsent(name0, FTrace::new);
         return trace;
     }
 

--- a/forge-core/src/main/java/forge/ImageKeys.java
+++ b/forge-core/src/main/java/forge/ImageKeys.java
@@ -337,7 +337,7 @@ public final class ImageKeys {
                         File f = new File(lookupDirectory);
                         if (f.exists() && f.isDirectory()) {
                             for (String ext : FILE_EXTENSIONS) {
-                                if (ext.equals(""))
+                                if (ext.isEmpty())
                                     continue;
                                 File placeholder;
                                 String fb1 = fullborderFile.replace(setKey+"/","")+ext;
@@ -371,7 +371,7 @@ public final class ImageKeys {
     private static File findFile(String dir, String filename) {
         if (dir.equals(CACHE_CARD_PICS_DIR)) {
             for (String ext : FILE_EXTENSIONS) {
-                if (ext.equals(""))
+                if (ext.isEmpty())
                     continue;
 
                 File f = new File(dir, filename + ext);

--- a/forge-core/src/main/java/forge/ImageKeys.java
+++ b/forge-core/src/main/java/forge/ImageKeys.java
@@ -323,7 +323,7 @@ public final class ImageKeys {
     }
     public static boolean hasSetLookup(String filename) {
         if (!StaticData.instance().getSetLookup().isEmpty()) {
-            return StaticData.instance().getSetLookup().keySet().stream().anyMatch(setKey -> filename.startsWith(setKey));
+            return StaticData.instance().getSetLookup().keySet().stream().anyMatch(filename::startsWith);
         }
 
         return false;

--- a/forge-core/src/main/java/forge/card/CardDb.java
+++ b/forge-core/src/main/java/forge/card/CardDb.java
@@ -218,7 +218,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
                     CardRequest request = fromPreferredArtEntry(preferredArt, isFoil);
                     if (request != null)  // otherwise, simply discard it and go on.
                         return request;
-                    System.err.println(String.format("[LOG]: Faulty Entry in Preferred Art for Card %s - Please check!", cardName));
+                    System.err.printf("[LOG]: Faulty Entry in Preferred Art for Card %s - Please check!%n", cardName);
                 }
             }
             // finally, check whether any between artIndex and CollectorNumber has been set

--- a/forge-core/src/main/java/forge/card/CardRules.java
+++ b/forge-core/src/main/java/forge/card/CardRules.java
@@ -283,6 +283,7 @@ public final class CardRules implements ICardCharacteristics {
         for (String staticAbility : mainPart.getStaticAbilities()) { // Check for Grist
             if (staticAbility.contains("CharacteristicDefining$ True") && staticAbility.contains("AddType$ Creature")) {
                 creature = true;
+                break;
             }
         }
         if (type.isLegendary() && creature) {

--- a/forge-core/src/main/java/forge/deck/Deck.java
+++ b/forge-core/src/main/java/forge/deck/Deck.java
@@ -123,7 +123,7 @@ public class Deck extends DeckBase implements Iterable<Entry<DeckSection, CardPo
             result.add(c.getKey());
         }
         if (result.size() > 1) { //sort by type so signature spell comes after oathbreaker
-            Collections.sort(result, Comparator.comparing(c -> c.getRules().canBeSignatureSpell()));
+            result.sort(Comparator.comparing(c -> c.getRules().canBeSignatureSpell()));
         }
         return result;
     }

--- a/forge-core/src/main/java/forge/deck/Deck.java
+++ b/forge-core/src/main/java/forge/deck/Deck.java
@@ -550,7 +550,7 @@ public class Deck extends DeckBase implements Iterable<Entry<DeckSection, CardPo
     }
 
     public void setAiHints(String aiHintsInfo) {
-        if (aiHintsInfo == null || aiHintsInfo.trim().equals("")) {
+        if (aiHintsInfo == null || aiHintsInfo.trim().isEmpty()) {
             return;
         }
         String[] hints = aiHintsInfo.split("\\|");

--- a/forge-core/src/main/java/forge/deck/DeckBase.java
+++ b/forge-core/src/main/java/forge/deck/DeckBase.java
@@ -75,7 +75,7 @@ public abstract class DeckBase implements Serializable, Comparable<DeckBase>, In
     public void setName(String deckName) { this.name = deckName; }
 
     public boolean hasName() {
-        return !(this.name.equals(""));
+        return !(this.name.isEmpty());
     }
 
     public String getDirectory() {

--- a/forge-core/src/main/java/forge/deck/DeckGroup.java
+++ b/forge-core/src/main/java/forge/deck/DeckGroup.java
@@ -87,7 +87,7 @@ public class DeckGroup extends DeckBase {
         if (aiDecks.size() < 2) {
             return;
         }
-        Collections.sort(aiDecks, comparator);
+        aiDecks.sort(comparator);
     }
     
     @Override

--- a/forge-core/src/main/java/forge/deck/DeckGroup.java
+++ b/forge-core/src/main/java/forge/deck/DeckGroup.java
@@ -19,7 +19,6 @@ package forge.deck;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 

--- a/forge-core/src/main/java/forge/deck/DeckRecognizer.java
+++ b/forge-core/src/main/java/forge/deck/DeckRecognizer.java
@@ -111,13 +111,13 @@ public class DeckRecognizer {
         // WARNING MESSAGES
         // ================
         public static Token UnknownCard(final String cardName, final String setCode, final int count) {
-            String ttext = setCode == null || setCode.equals("") ? cardName :
+            String ttext = setCode == null || setCode.isEmpty() ? cardName :
                     String.format("%s [%s]", cardName, setCode);
             return new Token(TokenType.UNKNOWN_CARD, count, ttext);
         }
 
         public static Token UnsupportedCard(final String cardName, final String setCode, final int count) {
-            String ttext = setCode == null || setCode.equals("") ? cardName :
+            String ttext = setCode == null || setCode.isEmpty() ? cardName :
                     String.format("%s [%s]", cardName, setCode);
             return new Token(TokenType.UNSUPPORTED_CARD, count, ttext);
         }
@@ -846,7 +846,7 @@ public class DeckRecognizer {
         }
         if (isCardRarity(text)){
             String tokenText = cardRarityTokenMatch(text);
-            if (tokenText != null && !tokenText.trim().equals(""))
+            if (tokenText != null && !tokenText.trim().isEmpty())
                 return new Token(TokenType.CARD_RARITY, tokenText);
             return null;
         }

--- a/forge-core/src/main/java/forge/util/CardTranslation.java
+++ b/forge-core/src/main/java/forge/util/CardTranslation.java
@@ -1,13 +1,13 @@
 package forge.util;
 
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.*;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
-
-import com.google.common.base.Charsets;
 
 public class CardTranslation {
 
@@ -24,7 +24,7 @@ public class CardTranslation {
     private static void readTranslationFile(String language, String languagesDirectory) {
         String filename = "cardnames-" + language + ".txt";
 
-        try (LineReader translationFile = new LineReader(new FileInputStream(languagesDirectory + filename), Charsets.UTF_8)) {
+        try (LineReader translationFile = new LineReader(Files.newInputStream(Paths.get(languagesDirectory + filename)), StandardCharsets.UTF_8)) {
             for (String line : translationFile.readLines()) {
                 String[] matches = line.split("\\|");
                 if (matches.length >= 2) {

--- a/forge-core/src/main/java/forge/util/CardTranslation.java
+++ b/forge-core/src/main/java/forge/util/CardTranslation.java
@@ -251,7 +251,7 @@ public class CardTranslation {
     public static void buildOracleMapping(String faceName, String oracleText) {
         if (!needsTranslation() || oracleMappings.containsKey(faceName)) return;
         String translatedText = getTranslatedOracle(faceName);
-        if (translatedText.equals("")) {
+        if (translatedText.isEmpty()) {
             // english card only, fall back
             return;
         }

--- a/forge-core/src/main/java/forge/util/FileUtil.java
+++ b/forge-core/src/main/java/forge/util/FileUtil.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import java.io.*;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -252,7 +253,7 @@ public final class FileUtil {
         final List<String> list = new ArrayList<>();
         try {
             final BufferedReader in = new BufferedReader(
-                    new InputStreamReader(new FileInputStream(file), "UTF-8"));
+                    new InputStreamReader(Files.newInputStream(file.toPath()), StandardCharsets.UTF_8));
             String line;
             while ((line = in.readLine()) != null) {
                 if (mayTrim) {

--- a/forge-core/src/main/java/forge/util/NameGenerator.java
+++ b/forge-core/src/main/java/forge/util/NameGenerator.java
@@ -245,7 +245,7 @@ public final class NameGenerator {
         	Collections.addAll(all, fantasyMales);
         	Collections.addAll(all, genericFemales);
         	Collections.addAll(all, fantasyFemales);
-        	sourceList = all.toArray(new String[all.size()]);
+        	sourceList = all.toArray(new String[0]);
         	useMoniker = MyRandom.getRandom().nextFloat() <= 0.04f;
         	break;
         }

--- a/forge-core/src/main/java/forge/util/collect/FCollection.java
+++ b/forge-core/src/main/java/forge/util/collect/FCollection.java
@@ -525,7 +525,7 @@ public class FCollection<T> implements List<T>, /*Set<T>,*/ FCollectionView<T>, 
      * {@inheritDoc}
      */
     public void sort(final Comparator<? super T> comparator) {
-        Collections.sort(list, comparator);
+        list.sort(comparator);
     }
 
     /**

--- a/forge-core/src/main/java/forge/util/maps/MapToAmountUtil.java
+++ b/forge-core/src/main/java/forge/util/maps/MapToAmountUtil.java
@@ -133,7 +133,7 @@ public final class MapToAmountUtil {
         for (final Entry<T, Integer> entry : map.entrySet()) {
             entries.add(Pair.of(entry.getKey(), entry.getValue()));
         }
-        Collections.sort(entries, Entry.comparingByValue());
+        entries.sort(Entry.comparingByValue());
         return entries;
     }
 

--- a/forge-core/src/main/java/forge/util/storage/StorageReaderRecursiveFolderWithUserFolder.java
+++ b/forge-core/src/main/java/forge/util/storage/StorageReaderRecursiveFolderWithUserFolder.java
@@ -98,7 +98,7 @@ public abstract class StorageReaderRecursiveFolderWithUserFolder<T> extends Stor
 
         forgeFormats.addAll(customFormats);
 
-        final File[] files = forgeFormats.toArray(new File[forgeFormats.size()]);
+        final File[] files = forgeFormats.toArray(new File[0]);
 
         for (final File file : files) {
             try {

--- a/forge-game/src/main/java/forge/game/CardTraitBase.java
+++ b/forge-game/src/main/java/forge/game/CardTraitBase.java
@@ -655,7 +655,7 @@ public abstract class CardTraitBase extends GameObject implements IHasCardView, 
         Map<String, String> result = Maps.newHashMap(output);
         for (Map.Entry<String, String> e : input.entrySet()) {
             String value = e.getValue();
-            result.put(e.getKey(), output.containsKey(value) ? output.get(value) : value);
+            result.put(e.getKey(), output.getOrDefault(value, value));
         }
         return result;
     }

--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -2470,7 +2470,7 @@ public class GameAction {
                         Localizer.getInstance().getMessage("lblMilledToZone", destination.getTranslatedName()) + ")";
                 if (showRevealDialog) {
                     final String message = Localizer.getInstance().getMessage("lblMilledCards");
-                    final boolean addSuffix = !toZoneStr.equals("");
+                    final boolean addSuffix = !toZoneStr.isEmpty();
                     game.getAction().reveal(milledPlayer, destination, p, false, message, addSuffix);
                 }
                 game.getGameLog().add(GameLogEntryType.ZONE_CHANGE, p + " milled " +

--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -1143,7 +1143,7 @@ public class GameAction {
                 .compareTrueFirst(a.hasParam("CharacteristicDefining"), b.hasParam("CharacteristicDefining"))
                 .compare(a.getHostCard().getLayerTimestamp(), b.getHostCard().getLayerTimestamp())
                 .result();
-        Collections.sort(staticAbilities, comp);
+        staticAbilities.sort(comp);
 
         final Map<StaticAbility, CardCollectionView> affectedPerAbility = Maps.newHashMap();
         for (final StaticAbilityLayer layer : StaticAbilityLayer.CONTINUOUS_LAYERS) {

--- a/forge-game/src/main/java/forge/game/GameActionUtil.java
+++ b/forge-game/src/main/java/forge/game/GameActionUtil.java
@@ -588,7 +588,7 @@ public final class GameActionUtil {
                     }
                     result.getPayCosts().add(cost);
                     reset = true;
-                    result.setOptionalKeywordAmount(ki, Integer.valueOf(n));
+                    result.setOptionalKeywordAmount(ki, Integer.parseInt(n));
                 }
             } else if (o.equals("Conspire")) {
                 final String conspireCost = "tapXType<2/Creature.SharesColorWith/" +

--- a/forge-game/src/main/java/forge/game/GameEntityCounterTable.java
+++ b/forge-game/src/main/java/forge/game/GameEntityCounterTable.java
@@ -78,7 +78,7 @@ public class GameEntityCounterTable extends ForwardingTable<Optional<Player>, Ga
         }
         Map<CounterType, Integer> alreadyRemoved = column(ge).get(Optional.absent());
         for (Map.Entry<CounterType, Integer> e : ge.getCounters().entrySet()) {
-            int rest = e.getValue() - (alreadyRemoved.containsKey(e.getKey()) ? alreadyRemoved.get(e.getKey()) : 0);
+            int rest = e.getValue() - (alreadyRemoved.getOrDefault(e.getKey(), 0));
             if (rest > 0) {
                 result.put(e.getKey(), rest);
             }

--- a/forge-game/src/main/java/forge/game/GameFormat.java
+++ b/forge-game/src/main/java/forge/game/GameFormat.java
@@ -465,9 +465,8 @@ public class GameFormat implements Comparable<GameFormat> {
             super("Format collections", reader);
             naturallyOrdered = reader.naturallyOrdered;
             reverseDateOrdered = new ArrayList<>(naturallyOrdered);
-            Collections.sort(naturallyOrdered);
-            //Why this refactor doesnt work on some android phones? -> reverseDateOrdered.sort(new InverseDateComparator());
-            Collections.sort(reverseDateOrdered, new InverseDateComparator());
+            naturallyOrdered.sort(Comparator.naturalOrder());
+            reverseDateOrdered.sort(new InverseDateComparator());
         }
 
         public Iterable<GameFormat> getOrderedList() {

--- a/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
@@ -485,7 +485,7 @@ public class AbilityUtils {
         } else if (calcX[0].startsWith("PlayerCount")) {
             final String hType = calcX[0].substring(11);
             final FCollection<Player> players = new FCollection<>();
-            if (hType.equals("Players") || hType.equals("")) {
+            if (hType.equals("Players") || hType.isEmpty()) {
                 players.addAll(game.getPlayers());
                 val = playerXCount(players, calcX[1], card, ability);
             } else if (hType.equals("YourTeam")) {

--- a/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
@@ -430,7 +430,7 @@ public abstract class SpellAbilityEffect {
     	String trigStr = "Mode$ Phase | Phase$ End of Turn | TriggerZones$ Battlefield " +
     	     "| TriggerDescription$ At the beginning of" + whose + "end step, " + location.toLowerCase()
                 + " CARDNAME.";
-        if (!player.equals("")) {
+        if (!player.isEmpty()) {
             trigStr += " | Player$ " + player;
         }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
@@ -1078,7 +1078,7 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
                 searchedLibrary = false;
             }
 
-            if (!defined && !changeType.equals("") && !changeType.startsWith("EACH")) {
+            if (!defined && !changeType.isEmpty() && !changeType.startsWith("EACH")) {
                 fetchList = (CardCollection)AbilityUtils.filterListByType(fetchList, sa.getParam("ChangeType"), sa);
             }
             fetchList.sort();
@@ -1481,7 +1481,7 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
                 }
             }
 
-            if (((!ZoneType.Battlefield.equals(destination) && !changeType.equals("") && !defined && !changeType.equals("Card"))
+            if (((!ZoneType.Battlefield.equals(destination) && !changeType.isEmpty() && !defined && !changeType.equals("Card"))
                     || (sa.hasParam("Reveal") && !movedCards.isEmpty())) && !sa.hasParam("NoReveal")) {
                 game.getAction().reveal(movedCards, player);
             }

--- a/forge-game/src/main/java/forge/game/ability/effects/CharmEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CharmEffect.java
@@ -173,7 +173,7 @@ public class CharmEffect extends SpellAbilityEffect {
                 if (spree) {
                     sb.append("+ " + new Cost(sub.getParam("SpreeCost"), false).toSimpleString() + " \u2014 ");
                 } else if (sub.hasParam("Pawprint")) {
-                    sb.append(StringUtils.repeat("{P}", Integer.valueOf(sub.getParam("Pawprint"))) + " \u2014 ");
+                    sb.append(StringUtils.repeat("{P}", Integer.parseInt(sub.getParam("Pawprint"))) + " \u2014 ");
                 } else {
                     sb.append("\u2022 ");
                 }

--- a/forge-game/src/main/java/forge/game/ability/effects/ChooseCardEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChooseCardEffect.java
@@ -245,7 +245,7 @@ public class ChooseCardEffect extends SpellAbilityEffect {
                     } else if (value.equals("ChosenType")) {
                         tag = host.getChosenType();
                     }
-                    if (!tag.equals("")) {
+                    if (!tag.isEmpty()) {
                         title = title + " (" + tag +")";
                     }
                 }

--- a/forge-game/src/main/java/forge/game/ability/effects/CountersMoveEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CountersMoveEffect.java
@@ -362,7 +362,7 @@ public class CountersMoveEffect extends SpellAbilityEffect {
         if (cnum > 0) {
             src.subtractCounter(cType, cnum, activator);
             game.updateLastStateForCard(src);
-            countersToAdd.put(cType, (countersToAdd.containsKey(cType) ? countersToAdd.get(cType) : 0) + cnum);
+            countersToAdd.put(cType, (countersToAdd.getOrDefault(cType, 0)) + cnum);
         }
     }
 }

--- a/forge-game/src/main/java/forge/game/ability/effects/CountersPutEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CountersPutEffect.java
@@ -690,7 +690,7 @@ public class CountersPutEffect extends SpellAbilityEffect {
     protected CounterType chooseTypeFromList(SpellAbility sa, String list, GameEntity obj, PlayerController pc) {
         List<CounterType> choices = Lists.newArrayList();
         for (String s : list.split(",")) {
-            if (!s.equals("") && (!sa.hasParam("UniqueType") || obj.getCounters(CounterType.getType(s)) == 0)) {
+            if (!s.isEmpty() && (!sa.hasParam("UniqueType") || obj.getCounters(CounterType.getType(s)) == 0)) {
                 CounterType type = CounterType.getType(s);
                 if (!choices.contains(type)) {
                     choices.add(type);

--- a/forge-game/src/main/java/forge/game/ability/effects/MakeCardEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/MakeCardEffect.java
@@ -149,7 +149,7 @@ public class MakeCardEffect extends SpellAbilityEffect {
 
             for (final String name : names) {
                 int toMake = amount;
-                if (!name.equals("")) {
+                if (!name.isEmpty()) {
                     while (toMake > 0) {
                         PaperCard pc;
                         if (pack != null) {

--- a/forge-game/src/main/java/forge/game/ability/effects/PeekAndRevealEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PeekAndRevealEffect.java
@@ -41,7 +41,7 @@ public class PeekAndRevealEffect extends SpellAbilityEffect {
 
         final StringBuilder sb = new StringBuilder();
 
-        sb.append(who.equals("") ? peeker : who);
+        sb.append(who.isEmpty() ? peeker : who);
         sb.append(verb).append("the top ");
         sb.append(numPeek > 1 ? Lang.getNumeral(numPeek) + " cards " : "card ").append("of ").append(whose);
         sb.append(" library.");

--- a/forge-game/src/main/java/forge/game/ability/effects/ProtectAllEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ProtectAllEffect.java
@@ -82,7 +82,7 @@ public class ProtectAllEffect extends SpellAbilityEffect {
 
         // Deal with permanents
         final String valid = sa.getParamOrDefault("ValidCards", "");
-        if (!valid.equals("")) {
+        if (!valid.isEmpty()) {
             CardCollectionView list = CardLists.getValidCards(game.getCardsIn(ZoneType.Battlefield), valid, sa.getActivatingPlayer(), host, sa);
 
             for (final Card tgtC : list) {
@@ -107,7 +107,7 @@ public class ProtectAllEffect extends SpellAbilityEffect {
 
         // Deal with Players
         final String players = sa.getParamOrDefault("ValidPlayers", "");
-        if (!players.equals("")) {
+        if (!players.isEmpty()) {
             for (final Player player : AbilityUtils.getDefinedPlayers(host, players, sa)) {
                 player.addChangedKeywords(gainsKWList, ImmutableList.of(), timestamp, 0);
 

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -7950,26 +7950,14 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
                 }
             }
         } else {
-            List<String> result = chosenModesTurn.get(original);
-            if (result == null) {
-                result = Lists.newArrayList();
-                chosenModesTurn.put(original, result);
-            }
+            List<String> result = chosenModesTurn.computeIfAbsent(original, k -> Lists.newArrayList());
             result.add(mode);
 
-            result = chosenModesGame.get(original);
-            if (result == null) {
-                result = Lists.newArrayList();
-                chosenModesGame.put(original, result);
-            }
+            result = chosenModesGame.computeIfAbsent(original, k -> Lists.newArrayList());
             result.add(mode);
 
             if (yourCombat) {
-                result = chosenModesYourCombat.get(original);
-                if (result == null) {
-                    result = Lists.newArrayList();
-                    chosenModesYourCombat.put(original, result);
-                }
+                result = chosenModesYourCombat.computeIfAbsent(original, k -> Lists.newArrayList());
                 result.add(mode);
             }
         }

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -2809,7 +2809,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
         for (final StaticAbility stAb : state.getStaticAbilities()) {
             if (!stAb.isSecondary() && !stAb.isClassAbility()) {
                 final String stAbD = stAb.toString();
-                if (!stAbD.equals("")) {
+                if (!stAbD.isEmpty()) {
                     boolean disabled = getGame() != null && getController() != null && game.getAge() != GameStage.Play && !stAb.checkConditions();
                     if (disabled) sb.append(grayTag);
                     sb.append(stAbD);
@@ -3187,7 +3187,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars {
         for (final StaticAbility stAb : state.getStaticAbilities()) {
             if (!stAb.isSecondary()) {
                 final String stAbD = stAb.toString();
-                if (!stAbD.equals("")) {
+                if (!stAbD.isEmpty()) {
                     sb.append(stAbD).append("\r\n");
                 }
             }

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -683,7 +683,7 @@ public class CardFactoryUtil {
         }
 
         String repeffstr = "Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield "
-                + "| Secondary$ True | ReplacementResult$ Updated | Description$ " + desc + (!extraparams.equals("") ? " | " + extraparams : "");
+                + "| Secondary$ True | ReplacementResult$ Updated | Description$ " + desc + (!extraparams.isEmpty() ? " | " + extraparams : "");
 
         ReplacementEffect re = ReplacementHandler.parseReplacement(repeffstr, card.getCard(), intrinsic, card);
 

--- a/forge-game/src/main/java/forge/game/card/CardLists.java
+++ b/forge-game/src/main/java/forge/game/card/CardLists.java
@@ -80,7 +80,7 @@ public class CardLists {
      * @param list
      */
     public static void sortByCmcDesc(final List<Card> list) {
-        Collections.sort(list, CmcComparatorInv);
+        list.sort(CmcComparatorInv);
     }
 
     /**
@@ -91,7 +91,7 @@ public class CardLists {
      * @param list
      */
     public static void sortByToughnessAsc(final List<Card> list) {
-        Collections.sort(list, ToughnessComparator);
+        list.sort(ToughnessComparator);
     }
 
     /**
@@ -102,7 +102,7 @@ public class CardLists {
      * @param list
      */
     public static void sortByToughnessDesc(final List<Card> list) {
-        Collections.sort(list, ToughnessComparatorInv);
+        list.sort(ToughnessComparatorInv);
     }
 
     /**
@@ -113,7 +113,7 @@ public class CardLists {
      * @param list
      */
     public static void sortByPowerAsc(final List<Card> list) {
-        Collections.sort(list, PowerComparator);
+        list.sort(PowerComparator);
     }
 
     // the higher the attack the better
@@ -125,7 +125,7 @@ public class CardLists {
      * @param list
      */
     public static void sortByPowerDesc(final List<Card> list) {
-        Collections.sort(list, Collections.reverseOrder(PowerComparator));
+        list.sort(Collections.reverseOrder(PowerComparator));
     }
 
     /**

--- a/forge-game/src/main/java/forge/game/card/CardProperty.java
+++ b/forge-game/src/main/java/forge/game/card/CardProperty.java
@@ -1602,7 +1602,7 @@ public class CardProperty {
             if (!(property.contains("LKI") ? lki : card).isAttacking()) return false;
             if (property.equals("attacking")) return true;
             if (property.endsWith("Alone")) {
-                return CardLists.count(card.getGame().getLastStateBattlefield(), c -> c.isAttacking()) == 1;
+                return CardLists.count(card.getGame().getLastStateBattlefield(), Card::isAttacking) == 1;
             }
             if (property.equals("attackingYou")) return combat.isAttacking(card, sourceController);
             if (property.equals("attackingSame")) {

--- a/forge-game/src/main/java/forge/game/card/token/TokenInfo.java
+++ b/forge-game/src/main/java/forge/game/card/token/TokenInfo.java
@@ -104,7 +104,7 @@ public class TokenInfo {
         if (c.getType().isLegendary()) {
             relevantTypes.add("Legendary");
         }
-        return relevantTypes.toArray(new String[relevantTypes.size()]);
+        return relevantTypes.toArray(new String[0]);
     }
 
     private Card toCard(Game game) {

--- a/forge-game/src/main/java/forge/game/cost/Cost.java
+++ b/forge-game/src/main/java/forge/game/cost/Cost.java
@@ -254,8 +254,8 @@ public class Cost implements Serializable {
             }
         }
 
-        if (parsedMana == null && (manaParts.length() > 0 || !xMin.equals(""))) {
-            parsedMana = new CostPartMana(new ManaCost(new ManaCostParser(manaParts.toString())), xMin.equals("") ? null : xMin);
+        if (parsedMana == null && (manaParts.length() > 0 || !xMin.isEmpty())) {
+            parsedMana = new CostPartMana(new ManaCost(new ManaCostParser(manaParts.toString())), xMin.isEmpty() ? null : xMin);
         }
         if (parsedMana != null) {
             costParts.add(parsedMana);

--- a/forge-game/src/main/java/forge/game/cost/Cost.java
+++ b/forge-game/src/main/java/forge/game/cost/Cost.java
@@ -118,7 +118,7 @@ public class Cost implements Serializable {
         // Things that are pretty much happen at the end (Untap) 16+
         // Things that NEED to happen last 100+
 
-        Collections.sort(this.costParts, (o1, o2) -> ObjectUtils.compare(o1.paymentOrder(), o2.paymentOrder()));
+        this.costParts.sort((o1, o2) -> ObjectUtils.compare(o1.paymentOrder(), o2.paymentOrder()));
     }
 
     /**

--- a/forge-game/src/main/java/forge/game/keyword/Keyword.java
+++ b/forge-game/src/main/java/forge/game/keyword/Keyword.java
@@ -272,10 +272,7 @@ public enum Keyword {
 
     public static List<Keyword> getAllKeywords() {
         Keyword[] values = values();
-        List<Keyword> keywords = new ArrayList<>();
-        for (int i = 1; i < values.length; i++) { //skip UNDEFINED
-            keywords.add(values[i]);
-        }
+        List<Keyword> keywords = new ArrayList<>(Arrays.asList(values).subList(1, values.length)); //skip UNDEFINED
         return keywords;
     }
 

--- a/forge-game/src/main/java/forge/game/mana/ManaCostBeingPaid.java
+++ b/forge-game/src/main/java/forge/game/mana/ManaCostBeingPaid.java
@@ -263,11 +263,7 @@ public class ManaCostBeingPaid {
     private void increaseShard(final ManaCostShard shard, final int toAdd, final boolean forX) {
         if (toAdd <= 0) { return; }
 
-        ShardCount sc = unpaidShards.get(shard);
-        if (sc == null) {
-            sc = new ShardCount();
-            unpaidShards.put(shard, sc);
-        }
+        ShardCount sc = unpaidShards.computeIfAbsent(shard, k -> new ShardCount());
         if (forX) {
             sc.xCount += toAdd;
         }

--- a/forge-game/src/main/java/forge/game/phase/Untap.java
+++ b/forge-game/src/main/java/forge/game/phase/Untap.java
@@ -149,7 +149,7 @@ public class Untap extends Phase {
             }
         }
         final CardCollection untapList = new CardCollection(list);
-        final String[] restrict = restrictUntap.keySet().toArray(new String[restrictUntap.keySet().size()]);
+        final String[] restrict = restrictUntap.keySet().toArray(new String[0]);
         list = CardLists.filter(list, c -> {
             if (!Untap.canUntap(c)) {
                 return false;

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
@@ -782,7 +782,7 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
         // Thus, to protect the original's set from changes, we make a copy right here.
         optionalCosts = EnumSet.copyOf(optionalCosts);
         optionalCosts.add(cost);
-        if (!cost.getPip().equals("")) {
+        if (!cost.getPip().isEmpty()) {
             pipsToReduce.add(cost.getPip());
         }
     }

--- a/forge-game/src/main/java/forge/game/spellability/StackItemView.java
+++ b/forge-game/src/main/java/forge/game/spellability/StackItemView.java
@@ -84,15 +84,15 @@ public class StackItemView extends TrackableObject implements IHasCardView {
             if (kicked && !generic)
                 OptionalCostString += "Kicked";
             if (entwined)
-                OptionalCostString += OptionalCostString.equals("") ? "Entwined" : ", Entwined";
+                OptionalCostString += OptionalCostString.isEmpty() ? "Entwined" : ", Entwined";
             if (buyback)
-                OptionalCostString += OptionalCostString.equals("") ? "Buyback" : ", Buyback";
+                OptionalCostString += OptionalCostString.isEmpty() ? "Buyback" : ", Buyback";
             if (retraced)
-                OptionalCostString += OptionalCostString.equals("") ? "Retraced" : ", Retraced";
+                OptionalCostString += OptionalCostString.isEmpty() ? "Retraced" : ", Retraced";
             if (jumpstart)
-                OptionalCostString += OptionalCostString.equals("") ? "Jumpstart" : ", Jumpstart";
+                OptionalCostString += OptionalCostString.isEmpty() ? "Jumpstart" : ", Jumpstart";
             if (additional || generic)
-                OptionalCostString += OptionalCostString.equals("") ? "Additional" : ", Additional";
+                OptionalCostString += OptionalCostString.isEmpty() ? "Additional" : ", Additional";
         }
         set(TrackableProperty.OptionalCosts, OptionalCostString);
     }

--- a/forge-game/src/main/java/forge/game/trigger/Trigger.java
+++ b/forge-game/src/main/java/forge/game/trigger/Trigger.java
@@ -202,7 +202,7 @@ public abstract class Trigger extends TriggerReplacementBase {
                     }
                 }
             }
-            if (saDesc.equals("")) { // in case we haven't found anything better
+            if (saDesc.isEmpty()) { // in case we haven't found anything better
                 saDesc = sa.toString();
             }
             // string might have leading whitespace

--- a/forge-gui-desktop/src/main/java/forge/ImageCache.java
+++ b/forge-gui-desktop/src/main/java/forge/ImageCache.java
@@ -185,14 +185,14 @@ public class ImageCache {
         }
         if (altState)
             imageKey = imageKey.substring(0, imageKey.length() - ImageKeys.BACKFACE_POSTFIX.length());
-        if (!specColor.equals(""))
+        if (!specColor.isEmpty())
             imageKey = imageKey.substring(0, imageKey.length() - ImageKeys.SPECFACE_W.length());
         if (imageKey.startsWith(ImageKeys.CARD_PREFIX)) {
             ipc = ImageUtil.getPaperCardFromImageKey(imageKey);
             if (ipc != null) {
                 if (altState) {
                     imageKey = ipc.getCardAltImageKey();
-                } else if (!specColor.equals("")) {
+                } else if (!specColor.isEmpty()) {
                     switch (specColor) {
                         case "white":
                             imageKey = ipc.getCardWSpecImageKey();

--- a/forge-gui-desktop/src/main/java/forge/control/FControl.java
+++ b/forge-gui-desktop/src/main/java/forge/control/FControl.java
@@ -234,7 +234,7 @@ public enum FControl implements KeyEventDispatcher {
                 FModel.getQuest().load(QuestDataIO.loadData(data));
             } catch(IOException ex) {
                 ex.printStackTrace();
-                System.out.println(String.format("Error loading quest data (%s).. skipping for now..", questname));
+                System.err.printf("Error loading quest data (%s).. skipping for now..%n", questname);
             }
         }
 

--- a/forge-gui-desktop/src/main/java/forge/gui/ImportSourceAnalyzer.java
+++ b/forge-gui-desktop/src/main/java/forge/gui/ImportSourceAnalyzer.java
@@ -445,7 +445,7 @@ public class ImportSourceAnalyzer {
         analyzeListedDir(root, ForgeConstants.CACHE_ICON_PICS_DIR, new ListedAnalyzer() {
             @Override
             public String map(final String filename) {
-                return iconFileNames.containsKey(filename) ? iconFileNames.get(filename) : null;
+                return iconFileNames.getOrDefault(filename, null);
             }
 
             @Override
@@ -617,7 +617,7 @@ public class ImportSourceAnalyzer {
         analyzeListedDir(root, targetDir, new ListedAnalyzer() {
             @Override
             public String map(final String filename) {
-                return fileDb.containsKey(filename) ? fileDb.get(filename) : null;
+                return fileDb.getOrDefault(filename, null);
             }
 
             @Override

--- a/forge-gui-desktop/src/main/java/forge/gui/framework/SResizingUtil.java
+++ b/forge-gui-desktop/src/main/java/forge/gui/framework/SResizingUtil.java
@@ -147,9 +147,8 @@ public final class SResizingUtil {
 
         double roughVal = 0;
         int smoothVal = 0;
-        
-        Set<Component> existingComponents = new HashSet<>();
-        existingComponents.addAll(Arrays.asList(pnlContent.getComponents()));
+
+        Set<Component> existingComponents = new HashSet<>(Arrays.asList(pnlContent.getComponents()));
 
         // This is the core of the pixel-perfect layout. To avoid ±1 px errors on borders
         // from rounding individual panels, the intermediate values (exactly accurate, in %)

--- a/forge-gui-desktop/src/main/java/forge/itemmanager/ItemManager.java
+++ b/forge-gui-desktop/src/main/java/forge/itemmanager/ItemManager.java
@@ -826,11 +826,7 @@ public abstract class ItemManager<T extends InventoryItem> extends JPanel implem
     @SuppressWarnings("unchecked")
     public void addFilter(final ItemFilter<? extends T> filter) {
         final Class<? extends ItemFilter<? extends T>> filterClass = (Class<? extends ItemFilter<? extends T>>) filter.getClass();
-        List<ItemFilter<? extends T>> classFilters = this.filters.get(filterClass);
-        if (classFilters == null) {
-            classFilters = new ArrayList<>();
-            this.filters.put(filterClass, classFilters);
-        }
+        List<ItemFilter<? extends T>> classFilters = this.filters.computeIfAbsent(filterClass, k -> new ArrayList<>());
         if (classFilters.size() > 0) {
             //if filter with the same class already exists, try to merge if allowed
             //NOTE: can always use first filter for these checks since if

--- a/forge-gui-desktop/src/main/java/forge/itemmanager/views/ItemListView.java
+++ b/forge-gui-desktop/src/main/java/forge/itemmanager/views/ItemListView.java
@@ -160,7 +160,7 @@ public final class ItemListView<T extends InventoryItem> extends ItemView<T> {
                 columns.add(colOverrides.get(colConfig.getDef()));
             }
         }
-        Collections.sort(columns, Comparator.comparingInt(ItemTableColumn::getIndex));
+        columns.sort(Comparator.comparingInt(ItemTableColumn::getIndex));
 
         //hide table header if only showing single string column
         final boolean hideHeader = (config.getCols().size() == 1 && config.getCols().containsKey(ColumnDef.STRING));

--- a/forge-gui-desktop/src/main/java/forge/itemmanager/views/ItemListView.java
+++ b/forge-gui-desktop/src/main/java/forge/itemmanager/views/ItemListView.java
@@ -34,7 +34,6 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionAdapter;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.LinkedList;

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/DeckImport.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/DeckImport.java
@@ -518,7 +518,7 @@ public class DeckImport<TModel extends DeckBase> extends FDialog {
             // we set it to the current one (if any) or set a new one.
             // In this way, if this deck will replace the current one, the name will be kept the same!
             if (!deck.hasName()){
-                if (currentDeckName.equals(""))
+                if (currentDeckName.isEmpty())
                     deck.setName(Localizer.getInstance().getMessage("lblNewDeckName"));
                 else
                     deck.setName(currentDeckName);

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/DeckController.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/DeckController.java
@@ -102,7 +102,7 @@ public class DeckController<T extends DeckBase> {
                 newModel();
                 isStored = false;
             } else
-                isStored = !this.modelPath.equals("");
+                isStored = !this.modelPath.isEmpty();
         } else {
             CardPool catalogClone = new CardPool(view.getInitialCatalog());
             deck = pickFromCatalog(deck, catalogClone);

--- a/forge-gui-desktop/src/main/java/forge/screens/home/gauntlet/ContestGauntletLister.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/gauntlet/ContestGauntletLister.java
@@ -46,7 +46,7 @@ public class ContestGauntletLister extends JPanel {
         this.removeAll();
         final List<RowPanel> tempRows = new ArrayList<>();
         final List<GauntletData> sorted = new ArrayList<>(gd0);
-        Collections.sort(sorted, Comparator.comparing(GauntletData::getName));
+        sorted.sort(Comparator.comparing(GauntletData::getName));
 
         // Title row
         // Note: careful with the widths of the rows here;

--- a/forge-gui-desktop/src/main/java/forge/screens/home/gauntlet/ContestGauntletLister.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/gauntlet/ContestGauntletLister.java
@@ -4,7 +4,6 @@ import java.awt.Color;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 

--- a/forge-gui-desktop/src/main/java/forge/screens/home/gauntlet/ContestGauntletLister.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/gauntlet/ContestGauntletLister.java
@@ -45,8 +45,7 @@ public class ContestGauntletLister extends JPanel {
     public void setGauntlets(final List<GauntletData> gd0) {
         this.removeAll();
         final List<RowPanel> tempRows = new ArrayList<>();
-        final List<GauntletData> sorted = new ArrayList<>();
-        sorted.addAll(gd0);
+        final List<GauntletData> sorted = new ArrayList<>(gd0);
         Collections.sort(sorted, Comparator.comparing(GauntletData::getName));
 
         // Title row

--- a/forge-gui-desktop/src/main/java/forge/screens/home/gauntlet/QuickGauntletLister.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/gauntlet/QuickGauntletLister.java
@@ -64,8 +64,7 @@ public class QuickGauntletLister extends JPanel {
     public void refresh() {
         this.removeAll();
         final List<RowPanel> tempRows = new ArrayList<>();
-        final List<GauntletData> sorted = new ArrayList<>();
-        sorted.addAll(gauntlets);
+        final List<GauntletData> sorted = new ArrayList<>(gauntlets);
         Collections.sort(sorted, Comparator.comparing(x -> x.getName().toLowerCase()));
 
         // Title row

--- a/forge-gui-desktop/src/main/java/forge/screens/home/gauntlet/QuickGauntletLister.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/gauntlet/QuickGauntletLister.java
@@ -65,7 +65,7 @@ public class QuickGauntletLister extends JPanel {
         this.removeAll();
         final List<RowPanel> tempRows = new ArrayList<>();
         final List<GauntletData> sorted = new ArrayList<>(gauntlets);
-        Collections.sort(sorted, Comparator.comparing(x -> x.getName().toLowerCase()));
+        sorted.sort(Comparator.comparing(x -> x.getName().toLowerCase()));
 
         // Title row
         // Note: careful with the widths of the rows here;

--- a/forge-gui-desktop/src/main/java/forge/screens/home/gauntlet/QuickGauntletLister.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/gauntlet/QuickGauntletLister.java
@@ -4,7 +4,6 @@ import java.awt.Color;
 import java.awt.event.MouseEvent;
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 

--- a/forge-gui-desktop/src/main/java/forge/screens/home/quest/CSubmenuQuestLoadData.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/quest/CSubmenuQuestLoadData.java
@@ -60,11 +60,11 @@ public enum CSubmenuQuestLoadData implements ICDoc {
         arrQuests.clear();
         for (final File f : arrFiles) {
             try {
-                System.out.println(String.format("About to load quest (%s)... ", f.getName()));
+                System.out.printf("About to load quest (%s)... %n", f.getName());
                 arrQuests.put(f.getName(), QuestDataIO.loadData(f));
             } catch(IOException ex) {
                 ex.printStackTrace();
-                System.out.println(String.format("Error loading quest data (%s).. skipping for now..", f.getName()));
+                System.err.printf("Error loading quest data (%s).. skipping for now..%n", f.getName());
                 restorableQuests.add(f.getName());
             }
         }

--- a/forge-gui-desktop/src/main/java/forge/screens/home/quest/DialogChooseFormats.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/quest/DialogChooseFormats.java
@@ -122,7 +122,7 @@ public class DialogChooseFormats {
 
 		choices.addAll(formats);
 		final FCheckBoxList<FCheckBox> cbl = new FCheckBoxList<>(false);
-		cbl.setListData(formats.toArray(new FCheckBox[formats.size()]));
+		cbl.setListData(formats.toArray(new FCheckBox[0]));
 		cbl.setVisibleRowCount(Math.min(20, formats.size()));
 
 		if (focused) {

--- a/forge-gui-desktop/src/main/java/forge/screens/home/quest/DialogChooseSets.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/quest/DialogChooseSets.java
@@ -183,30 +183,28 @@ public class DialogChooseSets {
 			spinnersEditionTypeMap.put(editionType, spinner);
 		}
 		// == SPINNERS ACTION PERFORMED ==
-		editionTypeSpinners.forEach(spinner -> {
-			spinner.addChangeListener(e -> {
-                // As soon as the value of a spinner becomes different from zero,
-                // enabled the random selection button.
-                int spinValue = (int) spinner.getValue();
-                if (spinValue > 0) {
-                    if (!randomSelectionButton.isEnabled())
-                        randomSelectionButton.setEnabled(true);
-                } else {
-                    // Similarly, when all spinners are set to zero,
-                    // disable the random selection button
-                    boolean allZeros = true;
-                    for (FSpinner spin : editionTypeSpinners) {
-                        int value = (int) spin.getValue();
-                        if (value != 0) {
-                            allZeros = false;
-                            break;
-                        }
-                    }
-                    if (allZeros)
-                        randomSelectionButton.setEnabled(false);
-                }
-            });
-		});
+		editionTypeSpinners.forEach(spinner -> spinner.addChangeListener(e -> {
+			// As soon as the value of a spinner becomes different from zero,
+			// enabled the random selection button.
+			int spinValue = (int) spinner.getValue();
+			if (spinValue > 0) {
+				if (!randomSelectionButton.isEnabled())
+					randomSelectionButton.setEnabled(true);
+			} else {
+			// Similarly, when all spinners are set to zero,
+			// disable the random selection button
+				boolean allZeros = true;
+				for (FSpinner spin : editionTypeSpinners) {
+					int value = (int) spin.getValue();
+					if (value != 0) {
+						allZeros = false;
+						break;
+					}
+				}
+				if (allZeros)
+					randomSelectionButton.setEnabled(false);
+			}
+		}));
 
 		// == ADD SPINNERS AND LABELS TO THE PANEL ==
 		JPanel typeFieldsPanel = null;

--- a/forge-gui-desktop/src/main/java/forge/screens/home/quest/QuestFileLister.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/quest/QuestFileLister.java
@@ -76,8 +76,7 @@ public class QuestFileLister extends JPanel {
     public void setQuests(List<QuestData> qd0) {
         this.removeAll();
         List<RowPanel> tempRows = new ArrayList<>();
-        List<QuestData> sorted = new ArrayList<>();
-        sorted.addAll(qd0);
+        List<QuestData> sorted = new ArrayList<>(qd0);
         Collections.sort(sorted, Comparator.comparing(x -> x.getName().toLowerCase()));
 
         // Title row

--- a/forge-gui-desktop/src/main/java/forge/screens/home/quest/QuestFileLister.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/quest/QuestFileLister.java
@@ -5,7 +5,6 @@ import java.awt.Font;
 import java.awt.event.MouseEvent;
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;

--- a/forge-gui-desktop/src/main/java/forge/screens/home/quest/QuestFileLister.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/quest/QuestFileLister.java
@@ -77,7 +77,7 @@ public class QuestFileLister extends JPanel {
         this.removeAll();
         List<RowPanel> tempRows = new ArrayList<>();
         List<QuestData> sorted = new ArrayList<>(qd0);
-        Collections.sort(sorted, Comparator.comparing(x -> x.getName().toLowerCase()));
+        sorted.sort(Comparator.comparing(x -> x.getName().toLowerCase()));
 
         // Title row
         // Note: careful with the widths of the rows here;

--- a/forge-gui-desktop/src/main/java/forge/screens/home/settings/CSubmenuPreferences.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/settings/CSubmenuPreferences.java
@@ -412,9 +412,7 @@ public enum CSubmenuPreferences implements ICDoc {
         final FComboBox<String> comboBox = createComboBox(new String[] {"Off", "AI", "Human For AI"}, userSetting);
         final String selectedItem = this.prefs.getPref(userSetting);
         panel.setComboBox(comboBox, selectedItem);
-        comboBox.addActionListener(actionEvent -> {
-            AiProfileUtil.setAiSideboardingMode(AiProfileUtil.AISideboardingMode.normalizedValueOf(comboBox.getSelectedItem()));
-        });
+        comboBox.addActionListener(actionEvent -> AiProfileUtil.setAiSideboardingMode(AiProfileUtil.AISideboardingMode.normalizedValueOf(comboBox.getSelectedItem())));
     }
 
     private void initializeSoundSetsComboBox() {

--- a/forge-gui-desktop/src/main/java/forge/sound/AltSoundSystem.java
+++ b/forge-gui-desktop/src/main/java/forge/sound/AltSoundSystem.java
@@ -44,7 +44,7 @@ class AsyncSoundRegistry {
     }
 
     public synchronized static int getNumIterations(String soundName) {
-        return soundsPlayed.containsKey(soundName) ? soundsPlayed.get(soundName) : 0;
+        return soundsPlayed.getOrDefault(soundName, 0);
     }
 }
 

--- a/forge-gui-desktop/src/main/java/forge/toolbox/FCheckBoxTree.java
+++ b/forge-gui-desktop/src/main/java/forge/toolbox/FCheckBoxTree.java
@@ -209,7 +209,7 @@ public class FCheckBoxTree extends JTree {
     }
 
     public TreePath[] getCheckedPaths() {
-        return checkedPaths.toArray(new TreePath[checkedPaths.size()]);
+        return checkedPaths.toArray(new TreePath[0]);
     }
 
     /**
@@ -227,7 +227,7 @@ public class FCheckBoxTree extends JTree {
                 checkedValues.add(data.item);
             }
         }
-        return checkedValues.toArray(new Object[checkedValues.size()]);
+        return checkedValues.toArray(new Object[0]);
     }
 
     // Returns true in case that the node is selected, has children but not all of them are selected

--- a/forge-gui-desktop/src/main/java/forge/toolbox/FSkin.java
+++ b/forge-gui-desktop/src/main/java/forge/toolbox/FSkin.java
@@ -940,11 +940,7 @@ public class FSkin {
 
     /** @return {@link java.awt.font} */
     private static Font getFixedFont(final int size) {
-        Font fixedFont = fixedFonts.get(size);
-        if (fixedFont == null) {
-            fixedFont = new Font("Monospaced", Font.PLAIN, size);
-            fixedFonts.put(size, fixedFont);
-        }
+        Font fixedFont = fixedFonts.computeIfAbsent(size, s -> new Font("Monospaced", Font.PLAIN, s));
         return fixedFont;
     }
 

--- a/forge-gui-desktop/src/main/java/forge/toolbox/imaging/FImageUtil.java
+++ b/forge-gui-desktop/src/main/java/forge/toolbox/imaging/FImageUtil.java
@@ -94,7 +94,7 @@ public final class FImageUtil {
             PaperCard card = ImageUtil.getPaperCardFromImageKey(key);
             if (altState) {
                 imageKey = card.getCardAltImageKey();
-            } else if (!specColor.equals("")) {
+            } else if (!specColor.isEmpty()) {
                 switch (specColor) {
                     case "white":
                         imageKey = card.getCardWSpecImageKey();
@@ -119,7 +119,7 @@ public final class FImageUtil {
         if(altState) {
             imageKey = imageKey.substring(0, imageKey.length() - ImageKeys.BACKFACE_POSTFIX.length());
             imageKey += "full.jpg";
-        } else if (!specColor.equals("")) {
+        } else if (!specColor.isEmpty()) {
             imageKey = imageKey.substring(0, imageKey.length() - ImageKeys.SPECFACE_W.length());
             imageKey += "full.jpg";
         }

--- a/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingZone.java
+++ b/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingZone.java
@@ -147,7 +147,7 @@ public class FloatingZone extends FloatingCardArea {
         if (zoneCards != null) {
             cardList = new FCollection<>(zoneCards);
             if (sortedByName) {
-                Collections.sort(cardList, comp);
+                cardList.sort(comp);
             }
             return cardList;
         } else {

--- a/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingZone.java
+++ b/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingZone.java
@@ -18,7 +18,6 @@
 package forge.view.arcane;
 
 import java.awt.event.MouseEvent;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;

--- a/forge-gui-desktop/src/test/java/forge/card/CardMockTestCase.java
+++ b/forge-gui-desktop/src/test/java/forge/card/CardMockTestCase.java
@@ -36,7 +36,7 @@ import forge.util.TextUtil;
         ImageKeys.class, ForgeConstants.class, Localizer.class })
 @SuppressStaticInitializationFor({ "forge.ImageCache", "forge.localinstance.properties.ForgeConstants" })
 @PowerMockIgnore({ "javax.xml.*", "org.xml.sax.*", "com.sun.org.apache.xerces.*", "org.w3c.dom.*",
-        "org.springframework.context.*", "org.apache.log4j.*" })
+        "org.springframework.context.*", "org.apache.log4j.*", "jdk.internal.reflect.*", "javax.imageio.*" })
 public class CardMockTestCase extends PowerMockTestCase {
 
     public static final String MOCKED_LOCALISED_STRING = "any localised string";

--- a/forge-gui-mobile/src/forge/Graphics.java
+++ b/forge-gui-mobile/src/forge/Graphics.java
@@ -1371,7 +1371,7 @@ public class Graphics {
         Dtransforms.removeFirst();
         transformCount--;
         if (transformCount != Dtransforms.size()) {
-            System.err.println(String.format("Stack count: %d, transformCount: %d", Dtransforms.size(), transformCount));
+            System.err.printf("Stack count: %d, transformCount: %d%n", Dtransforms.size(), transformCount);
             transformCount = 0;
             Dtransforms.clear();
         }

--- a/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
+++ b/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
@@ -861,7 +861,7 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
     }
 
     public void removeItem(String name) {
-        if (name == null || name.equals("")) return;
+        if (name == null || name.isEmpty()) return;
         inventoryItems.removeValue(name, false);
         if (equippedItems.values().contains(name) && !inventoryItems.contains(name, false)) {
             equippedItems.values().remove(name);

--- a/forge-gui-mobile/src/forge/adventure/pointofintrest/PointOfInterest.java
+++ b/forge-gui-mobile/src/forge/adventure/pointofintrest/PointOfInterest.java
@@ -10,6 +10,7 @@ import forge.adventure.util.*;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Random;
 
 /**
@@ -80,9 +81,7 @@ public class PointOfInterest implements Serializable, SaveFileContent {
         data = d;
         active = d.active;
         position.set(pos);
-        for (DialogData.ActionData.QuestFlag flag : data.questFlagsToActivate) {
-            questFlagsToActivate.add(flag);
-        }
+        questFlagsToActivate.addAll(Arrays.asList(data.questFlagsToActivate));
 
         rectangle.set(position.x, position.y, sprite.getWidth(), sprite.getHeight());
     }

--- a/forge-gui-mobile/src/forge/adventure/pointofintrest/PointOfInterestChanges.java
+++ b/forge-gui-mobile/src/forge/adventure/pointofintrest/PointOfInterestChanges.java
@@ -147,7 +147,7 @@ public class PointOfInterestChanges implements SaveFileContent  {
 
     public void addObjectReputation(int id, int delta)
     {
-        reputation.put(id, (reputation.containsKey(id)?reputation.get(id):0) + delta);
+        reputation.put(id, (reputation.getOrDefault(id, 0)) + delta);
     }
 
     public int getMapReputation(){

--- a/forge-gui-mobile/src/forge/adventure/scene/ArenaScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/ArenaScene.java
@@ -246,13 +246,11 @@ public class ArenaScene extends UIScene implements IAfterMatch {
         started = true;
         DuelScene duelScene = DuelScene.instance();
         EnemySprite enemy = enemies.get(enemies.size - 1);
-        FThreads.invokeInEdtNowOrLater(() -> {
-            Forge.setTransitionScreen(new TransitionScreen(() -> {
-                started = false;
-                duelScene.initDuels(WorldStage.getInstance().getPlayerSprite(), enemy, true, null);
-                Forge.switchScene(duelScene);
-            }, Forge.takeScreenshot(), true, false, false, false, "", Current.player().avatar(), enemy.getAtlasPath(), Current.player().getName(), enemy.getName()));
-        });
+        FThreads.invokeInEdtNowOrLater(() -> Forge.setTransitionScreen(new TransitionScreen(() -> {
+            started = false;
+            duelScene.initDuels(WorldStage.getInstance().getPlayerSprite(), enemy, true, null);
+            Forge.switchScene(duelScene);
+        }, Forge.takeScreenshot(), true, false, false, false, "", Current.player().avatar(), enemy.getAtlasPath(), Current.player().getName(), enemy.getName())));
     }
 
     public boolean start() {

--- a/forge-gui-mobile/src/forge/adventure/scene/DeckSelectScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/DeckSelectScene.java
@@ -52,8 +52,8 @@ public class DeckSelectScene extends UIScene {
         back = ui.findActor("return");
         edit = ui.findActor("edit");
         rename = ui.findActor("rename");
-        ui.onButtonPress("return", () -> DeckSelectScene.this.back());
-        ui.onButtonPress("edit", () -> DeckSelectScene.this.edit());
+        ui.onButtonPress("return", DeckSelectScene.this::back);
+        ui.onButtonPress("edit", DeckSelectScene.this::edit);
         ui.onButtonPress("rename", () -> {
             textInput.setText(Current.player().getSelectedDeck().getName());
             showRenameDialog();

--- a/forge-gui-mobile/src/forge/adventure/scene/EventScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/EventScene.java
@@ -547,12 +547,10 @@ public class EventScene extends MenuScene implements IAfterMatch {
             DuelScene duelScene = DuelScene.instance();
             EnemySprite enemy = humanMatch.p2.getSprite();
             currentEvent.nextOpponent = humanMatch.p2;
-            FThreads.invokeInEdtNowOrLater(() -> {
-                Forge.setTransitionScreen(new TransitionScreen(() -> {
-                    duelScene.initDuels(WorldStage.getInstance().getPlayerSprite(), enemy, false, currentEvent);
-                    Forge.switchScene(duelScene);
-                }, Forge.takeScreenshot(), true, false, false, false, "", Current.player().avatar(), enemy.getAtlasPath(), Current.player().getName(), enemy.getName(), humanMatch.p1.getRecord(), humanMatch.p2.getRecord()));
-            });
+            FThreads.invokeInEdtNowOrLater(() -> Forge.setTransitionScreen(new TransitionScreen(() -> {
+                duelScene.initDuels(WorldStage.getInstance().getPlayerSprite(), enemy, false, currentEvent);
+                Forge.switchScene(duelScene);
+            }, Forge.takeScreenshot(), true, false, false, false, "", Current.player().avatar(), enemy.getAtlasPath(), Current.player().getName(), enemy.getName(), humanMatch.p1.getRecord(), humanMatch.p2.getRecord())));
         }
         else
         {

--- a/forge-gui-mobile/src/forge/adventure/scene/InventoryScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/InventoryScene.java
@@ -73,7 +73,7 @@ public class InventoryScene extends UIScene {
                                 }
                             }
                             String item = Current.player().itemInSlot(slotName);
-                            if (item != null && !item.equals("")) {
+                            if (item != null && !item.isEmpty()) {
                                 Button changeButton = null;
                                 for (Button invButton : inventoryButtons) {
                                     if (itemLocation.get(invButton) != null && itemLocation.get(invButton).equals(item)) {
@@ -246,7 +246,7 @@ public class InventoryScene extends UIScene {
             if (Current.player().getShards() < data.shardsNeeded)
                 useButton.setDisabled(true);
 
-            if (data.equipmentSlot == null || data.equipmentSlot.equals("")) {
+            if (data.equipmentSlot == null || data.equipmentSlot.isEmpty()) {
                 equipButton.setDisabled(true);
             } else {
                 equipButton.setDisabled(false);
@@ -380,7 +380,7 @@ public class InventoryScene extends UIScene {
             if (slot.getValue().getChildren().size >= 2)
                 slot.getValue().removeActorAt(1, false);
             String equippedItem = Current.player().itemInSlot(slot.getKey());
-            if (equippedItem == null || equippedItem.equals(""))
+            if (equippedItem == null || equippedItem.isEmpty())
                 continue;
             ItemData item = ItemData.getItem(equippedItem);
             if (item != null) {

--- a/forge-gui-mobile/src/forge/adventure/scene/NewGameScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/NewGameScene.java
@@ -173,10 +173,10 @@ public class NewGameScene extends MenuScene {
         gender.setCurrentIndex(rand.nextInt());
         colorId.setCurrentIndex(rand.nextInt());
         race.setCurrentIndex(rand.nextInt());
-        ui.onButtonPress("back", () -> NewGameScene.this.back());
-        ui.onButtonPress("start", () -> NewGameScene.this.start());
-        ui.onButtonPress("leftAvatar", () -> NewGameScene.this.leftAvatar());
-        ui.onButtonPress("rightAvatar", () -> NewGameScene.this.rightAvatar());
+        ui.onButtonPress("back", NewGameScene.this::back);
+        ui.onButtonPress("start", NewGameScene.this::start);
+        ui.onButtonPress("leftAvatar", NewGameScene.this::leftAvatar);
+        ui.onButtonPress("rightAvatar", NewGameScene.this::rightAvatar);
         difficultyHelp.addListener(new ClickListener(){ public void clicked(InputEvent e, float x, float y){ showDifficultyHelp(); }});
         modeHelp.addListener(new ClickListener(){ public void clicked(InputEvent e, float x, float y){ showModeHelp(); }});
     }

--- a/forge-gui-mobile/src/forge/adventure/scene/SpellSmithScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/SpellSmithScene.java
@@ -114,7 +114,7 @@ public class SpellSmithScene extends UIScene {
             }
         }
 
-        ui.onButtonPress("done", () -> SpellSmithScene.this.done());
+        ui.onButtonPress("done", SpellSmithScene.this::done);
         ui.onButtonPress("pullUsingGold", () -> SpellSmithScene.this.pullCard(false));
         ui.onButtonPress("pullUsingShards", () -> SpellSmithScene.this.pullCard(true));
         ui.onButtonPress("BReset", () -> {

--- a/forge-gui-mobile/src/forge/adventure/scene/SpellSmithScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/SpellSmithScene.java
@@ -281,7 +281,7 @@ public class SpellSmithScene extends UIScene {
         loadEditions(); //just to be safe since it's preloaded, if somehow edition is null, then reload it
         editionList.clearListeners();
         editionList.clearItems();
-        editionList.setItems(editions.toArray(new CardEdition[editions.size()]));
+        editionList.setItems(editions.toArray(new CardEdition[0]));
         editionList.addListener(new ChangeListener() {
             @Override
             public void changed(ChangeEvent event, Actor actor) {

--- a/forge-gui-mobile/src/forge/adventure/stage/GameHUD.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/GameHUD.java
@@ -295,7 +295,7 @@ public class GameHUD extends Stage {
                 updatelife = true;
             }
         } else {
-            if (!lifepointsTextColor.equals("")) {
+            if (!lifepointsTextColor.isEmpty()) {
                 lifepointsTextColor = "";
                 updatelife = true;
             }

--- a/forge-gui-mobile/src/forge/adventure/stage/MapStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/MapStage.java
@@ -701,7 +701,7 @@ public class MapStage extends GameStage {
                             filteredPossibleShops = possibleShops;
                         }
                         Array<ShopData> shops;
-                        if (filteredPossibleShops.size == 0 || shopList.equals(""))
+                        if (filteredPossibleShops.size == 0 || shopList.isEmpty())
                             shops = WorldData.getShopList();
                         else {
                             shops = new Array<>();

--- a/forge-gui-mobile/src/forge/adventure/util/KeyBoardDialog.java
+++ b/forge-gui-mobile/src/forge/adventure/util/KeyBoardDialog.java
@@ -123,11 +123,11 @@ public class KeyBoardDialog extends Dialog {
         key0 = Controls.newTextButton("0", () -> kbLabel.setText(kbLabel.getText()+"0"));
         keyDot = Controls.newTextButton(".", () -> kbLabel.setText(kbLabel.getText()+"."));
         keyComma = Controls.newTextButton(",", () -> kbLabel.setText(kbLabel.getText()+","));
-        keyShift = Controls.newTextButton("Aa", () -> shiftKey());
+        keyShift = Controls.newTextButton("Aa", this::shiftKey);
         keyBackspace = Controls.newTextButton("<<", () -> kbLabel.setText(removeLastChar(String.valueOf(kbLabel.getText()))));
         keySpace = Controls.newTextButton("SPACE", () -> kbLabel.setText(kbLabel.getText()+" "));
-        keyOK = Controls.newTextButton("OK", () -> setKeyboardDialogText());
-        keyAbort = Controls.newTextButton("Abort", () -> abortKeyInput());
+        keyOK = Controls.newTextButton("OK", this::setKeyboardDialogText);
+        keyAbort = Controls.newTextButton("Abort", this::abortKeyInput);
         this.getContentTable().add(kbLabel).width(220).height(20).colspan(10).expandX().align(Align.center);
         this.getButtonTable().row();
         this.getButtonTable().add(key1).width(20).height(20);

--- a/forge-gui-mobile/src/forge/adventure/world/SimpleTiledModel.java
+++ b/forge-gui-mobile/src/forge/adventure/world/SimpleTiledModel.java
@@ -143,18 +143,14 @@ public class SimpleTiledModel extends Model {
         for (int t = 0; t < cardinality; t++) {
           ColorMap xtileData = tileData.get(tilename);
           this.tiles.add(
-              tile.apply(
-                (Integer x, Integer y) -> (xtileData.getColor(x, y))
-              )
+              tile.apply(xtileData::getColor)
             );
           this.tilenames.add(String.format("%s %s", tilename, t));
         }
       } else {
         ColorMap xtileData = tileData.get(tilename);
         this.tiles.add(
-            tile.apply(
-              (Integer x, Integer y) -> (xtileData.getColor(x, y))
-            )
+            tile.apply(xtileData::getColor)
           );
         
         this.tilenames.add(String.format("%s 0", tilename));

--- a/forge-gui-mobile/src/forge/assets/FSkinFont.java
+++ b/forge-gui-mobile/src/forge/assets/FSkinFont.java
@@ -1,8 +1,9 @@
 package forge.assets;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 
 import com.badlogic.gdx.Gdx;
@@ -370,7 +371,7 @@ public class FSkinFont {
         String[] translationFilePaths = { ForgeConstants.LANG_DIR + "cardnames-" + langCode + ".txt",
                 ForgeConstants.LANG_DIR + langCode + ".properties" };
         for (String translationFilePath : translationFilePaths) {
-            try (LineReader translationFile = new LineReader(new FileInputStream(translationFilePath),
+            try (LineReader translationFile = new LineReader(Files.newInputStream(Paths.get(translationFilePath)),
                     StandardCharsets.UTF_8)) {
                 for (String fileLine : translationFile.readLines()) {
                     final int stringLength = fileLine.length();

--- a/forge-gui-mobile/src/forge/itemmanager/ItemManager.java
+++ b/forge-gui-mobile/src/forge/itemmanager/ItemManager.java
@@ -207,7 +207,7 @@ public abstract class ItemManager<T extends InventoryItem> extends FContainer im
                 cols.add(colOverrides.get(colConfig.getDef()));
             }
         }
-        Collections.sort(cols, Comparator.comparingInt(arg0 -> arg0.getConfig().getIndex()));
+        cols.sort(Comparator.comparingInt(arg0 -> arg0.getConfig().getIndex()));
 
         sortCols.clear();
         if (cbxSortOptions != null) {

--- a/forge-gui-mobile/src/forge/screens/LoadingOverlay.java
+++ b/forge-gui-mobile/src/forge/screens/LoadingOverlay.java
@@ -57,7 +57,7 @@ public class LoadingOverlay extends FOverlay {
         loader.show();
         FThreads.invokeInBackgroundThread(() -> {
             task.run();
-            FThreads.invokeInEdtLater(() -> loader.hide());
+            FThreads.invokeInEdtLater(loader::hide);
         });
     }
 

--- a/forge-gui-mobile/src/forge/screens/gauntlet/LoadGauntletScreen.java
+++ b/forge-gui-mobile/src/forge/screens/gauntlet/LoadGauntletScreen.java
@@ -273,8 +273,7 @@ public class LoadGauntletScreen extends LaunchScreen {
         }
 
         public void refresh() {
-            List<GauntletData> sorted = new ArrayList<>();
-            sorted.addAll(gauntlets);
+            List<GauntletData> sorted = new ArrayList<>(gauntlets);
             Collections.sort(sorted, Comparator.comparing(x -> x.getName().toLowerCase()));
             setListData(sorted);
         }

--- a/forge-gui-mobile/src/forge/screens/gauntlet/LoadGauntletScreen.java
+++ b/forge-gui-mobile/src/forge/screens/gauntlet/LoadGauntletScreen.java
@@ -3,7 +3,6 @@ package forge.screens.gauntlet;
 import java.io.File;
 import java.text.NumberFormat;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 

--- a/forge-gui-mobile/src/forge/screens/gauntlet/LoadGauntletScreen.java
+++ b/forge-gui-mobile/src/forge/screens/gauntlet/LoadGauntletScreen.java
@@ -274,7 +274,7 @@ public class LoadGauntletScreen extends LaunchScreen {
 
         public void refresh() {
             List<GauntletData> sorted = new ArrayList<>(gauntlets);
-            Collections.sort(sorted, Comparator.comparing(x -> x.getName().toLowerCase()));
+            sorted.sort(Comparator.comparing(x -> x.getName().toLowerCase()));
             setListData(sorted);
         }
 

--- a/forge-gui-mobile/src/forge/screens/match/MatchScreen.java
+++ b/forge-gui-mobile/src/forge/screens/match/MatchScreen.java
@@ -1184,7 +1184,7 @@ public class MatchScreen extends FScreen {
     private boolean hasActivePlane() {
         if (MatchController.instance.getGameView() != null)
             if (MatchController.instance.getGameView().getPlanarPlayer() != null) {
-                return !MatchController.instance.getGameView().getPlanarPlayer().getCurrentPlaneName().equals("");
+                return !MatchController.instance.getGameView().getPlanarPlayer().getCurrentPlaneName().isEmpty();
             }
         return false;
     }

--- a/forge-gui-mobile/src/forge/screens/match/views/VStack.java
+++ b/forge-gui-mobile/src/forge/screens/match/views/VStack.java
@@ -380,7 +380,7 @@ public class VStack extends FDropDown {
             int index = text.indexOf(name);
             String newtext = "";
             String cId =  "(" + sourceCard.getId() + ")";
-            String optionalCostString = !stackInstance.getOptionalCostString().equals("") ? " ("+ stackInstance.getOptionalCostString() + ")" : "";
+            String optionalCostString = !stackInstance.getOptionalCostString().isEmpty() ? " ("+ stackInstance.getOptionalCostString() + ")" : "";
 
             if (index == -1) {
                 newtext = TextUtil.fastReplace(text.trim(), "  ", " ");

--- a/forge-gui-mobile/src/forge/screens/online/OnlineLobbyScreen.java
+++ b/forge-gui-mobile/src/forge/screens/online/OnlineLobbyScreen.java
@@ -115,7 +115,7 @@ public class OnlineLobbyScreen extends LobbyScreen implements IOnlineLobby {
                         }
                         chatInterface.addMessage(result);
                         if (!joinServer) {
-                            FThreads.invokeInBackgroundThread(() -> NetConnectUtil.copyHostedServerUrl());
+                            FThreads.invokeInBackgroundThread(NetConnectUtil::copyHostedServerUrl);
                         }
                         //update menu buttons
                         OnlineScreen.Lobby.update();

--- a/forge-gui-mobile/src/forge/screens/planarconquest/LoadConquestScreen.java
+++ b/forge-gui-mobile/src/forge/screens/planarconquest/LoadConquestScreen.java
@@ -2,7 +2,6 @@ package forge.screens.planarconquest;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;

--- a/forge-gui-mobile/src/forge/screens/planarconquest/LoadConquestScreen.java
+++ b/forge-gui-mobile/src/forge/screens/planarconquest/LoadConquestScreen.java
@@ -301,8 +301,7 @@ public class LoadConquestScreen extends LaunchScreen {
         }
 
         public void setConquests(List<ConquestData> qd0) {
-            List<ConquestData> sorted = new ArrayList<>();
-            sorted.addAll(qd0);
+            List<ConquestData> sorted = new ArrayList<>(qd0);
             Collections.sort(sorted, Comparator.comparing(x -> x.getName().toLowerCase()));
             setListData(sorted);
         }

--- a/forge-gui-mobile/src/forge/screens/planarconquest/LoadConquestScreen.java
+++ b/forge-gui-mobile/src/forge/screens/planarconquest/LoadConquestScreen.java
@@ -302,7 +302,7 @@ public class LoadConquestScreen extends LaunchScreen {
 
         public void setConquests(List<ConquestData> qd0) {
             List<ConquestData> sorted = new ArrayList<>(qd0);
-            Collections.sort(sorted, Comparator.comparing(x -> x.getName().toLowerCase()));
+            sorted.sort(Comparator.comparing(x -> x.getName().toLowerCase()));
             setListData(sorted);
         }
 

--- a/forge-gui-mobile/src/forge/screens/planarconquest/NewConquestScreen.java
+++ b/forge-gui-mobile/src/forge/screens/planarconquest/NewConquestScreen.java
@@ -37,7 +37,7 @@ public class NewConquestScreen extends MultiStepWizardScreen<NewConquestScreenMo
     @Override
     protected void finish() {
         //create new quest in game thread so option panes can wait for input
-        ThreadUtil.invokeInGameThread(() -> newConquest());
+        ThreadUtil.invokeInGameThread(this::newConquest);
     }
 
     private void newConquest() {

--- a/forge-gui-mobile/src/forge/screens/quest/LoadQuestScreen.java
+++ b/forge-gui-mobile/src/forge/screens/quest/LoadQuestScreen.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;

--- a/forge-gui-mobile/src/forge/screens/quest/LoadQuestScreen.java
+++ b/forge-gui-mobile/src/forge/screens/quest/LoadQuestScreen.java
@@ -85,7 +85,7 @@ public class LoadQuestScreen extends LaunchScreen {
                 try {
                     arrQuests.put(f.getName(), QuestDataIO.loadData(f));
                 } catch (IOException e) {
-                    System.err.println(String.format("Failed to load quest '%s'", f.getName()));
+                    System.err.printf("Failed to load quest '%s'%n", f.getName());
                     // Failed to load last quest, don't continue with quest loading stuff
                     return;
                 }

--- a/forge-gui-mobile/src/forge/screens/quest/LoadQuestScreen.java
+++ b/forge-gui-mobile/src/forge/screens/quest/LoadQuestScreen.java
@@ -300,8 +300,7 @@ public class LoadQuestScreen extends LaunchScreen {
         }
 
         public void setQuests(List<QuestData> qd0) {
-            List<QuestData> sorted = new ArrayList<>();
-            sorted.addAll(qd0);
+            List<QuestData> sorted = new ArrayList<>(qd0);
             Collections.sort(sorted, Comparator.comparing(x -> x.getName().toLowerCase()));
             setListData(sorted);
         }

--- a/forge-gui-mobile/src/forge/screens/quest/LoadQuestScreen.java
+++ b/forge-gui-mobile/src/forge/screens/quest/LoadQuestScreen.java
@@ -301,7 +301,7 @@ public class LoadQuestScreen extends LaunchScreen {
 
         public void setQuests(List<QuestData> qd0) {
             List<QuestData> sorted = new ArrayList<>(qd0);
-            Collections.sort(sorted, Comparator.comparing(x -> x.getName().toLowerCase()));
+            sorted.sort(Comparator.comparing(x -> x.getName().toLowerCase()));
             setListData(sorted);
         }
 

--- a/forge-gui-mobile/src/forge/screens/quest/NewQuestScreen.java
+++ b/forge-gui-mobile/src/forge/screens/quest/NewQuestScreen.java
@@ -181,7 +181,7 @@ public class NewQuestScreen extends FScreen {
     private final FLabel btnEmbark = add(new FLabel.ButtonBuilder()
             .font(FSkinFont.get(22)).text(Forge.getLocalizer().getMessage("lblEmbark")).icon(FSkinImage.QUEST_ZEP).command(event -> {
                 //create new quest in game thread so option panes can wait for input
-                ThreadUtil.invokeInGameThread(() -> newQuest());
+                ThreadUtil.invokeInGameThread(this::newQuest);
             }).build());
 
     public NewQuestScreen() {

--- a/forge-gui-mobile/src/forge/screens/quest/QuestLaunchScreen.java
+++ b/forge-gui-mobile/src/forge/screens/quest/QuestLaunchScreen.java
@@ -24,7 +24,7 @@ public abstract class QuestLaunchScreen extends LaunchScreen {
     protected void startMatch() {
         FThreads.invokeInBackgroundThread(() -> {
             if (QuestUtil.canStartGame()) {
-                FThreads.invokeInEdtLater(() -> LoadingOverlay.show(Forge.getLocalizer().getMessage("lblLoadingNewGame"), true, () -> QuestUtil.finishStartingGame()));
+                FThreads.invokeInEdtLater(() -> LoadingOverlay.show(Forge.getLocalizer().getMessage("lblLoadingNewGame"), true, QuestUtil::finishStartingGame));
                 return;
             }
         });

--- a/forge-gui-mobile/src/forge/screens/quest/QuestMenu.java
+++ b/forge-gui-mobile/src/forge/screens/quest/QuestMenu.java
@@ -127,7 +127,7 @@ public class QuestMenu extends FPopupMenu implements IVQuestStats {
                 try {
                     FModel.getQuest().load(QuestDataIO.loadData(data));
                 } catch (IOException e) {
-                    System.err.println(String.format("Failed to load quest '%s'", questname));
+                    System.err.printf("Failed to load quest '%s'%n", questname);
                     // Failed to load last quest, don't continue with quest loading stuff
                     return;
                 }

--- a/forge-gui-mobile/src/forge/screens/quest/QuestMenu.java
+++ b/forge-gui-mobile/src/forge/screens/quest/QuestMenu.java
@@ -51,14 +51,14 @@ public class QuestMenu extends FPopupMenu implements IVQuestStats {
         //invoke in background thread so prompts can work
         ThreadUtil.invokeInGameThread(() -> {
             QuestUtil.chooseAndUnlockEdition();
-            FThreads.invokeInEdtLater(() -> updateCurrentQuestScreen());
+            FThreads.invokeInEdtLater(QuestMenu::updateCurrentQuestScreen);
         });
     });
     private static final FMenuItem travelItem = new FMenuItem(Forge.getLocalizer().getMessage("btnTravel"), FSkinImage.QUEST_MAP, event -> {
         //invoke in background thread so prompts can work
         ThreadUtil.invokeInGameThread(() -> {
             QuestUtil.travelWorld();
-            FThreads.invokeInEdtLater(() -> updateCurrentQuestScreen());
+            FThreads.invokeInEdtLater(QuestMenu::updateCurrentQuestScreen);
         });
     });
     private static final FMenuItem prefsItem = new FMenuItem(Forge.getLocalizer().getMessage("Preferences"), Forge.hdbuttons ? FSkinImage.HDPREFERENCE : FSkinImage.SETTINGS, event -> setCurrentScreen(prefsScreen));

--- a/forge-gui-mobile/src/forge/screens/quest/QuestSpellShopScreen.java
+++ b/forge-gui-mobile/src/forge/screens/quest/QuestSpellShopScreen.java
@@ -64,7 +64,7 @@ public class QuestSpellShopScreen extends TabPageScreen<QuestSpellShopScreen> {
                 else {
                     inventoryPage.activateItems(items);
                 }
-                FThreads.invokeInEdtLater(() -> updateCreditsLabel());
+                FThreads.invokeInEdtLater(this::updateCreditsLabel);
             });
         });
     }

--- a/forge-gui-mobile/src/forge/screens/quest/QuestTournamentsScreen.java
+++ b/forge-gui-mobile/src/forge/screens/quest/QuestTournamentsScreen.java
@@ -84,19 +84,19 @@ public class QuestTournamentsScreen extends QuestLaunchScreen implements IQuestT
         controller = new QuestTournamentController(this);
         btnSpendToken.setCommand(event -> {
             //must run in background thread to handle alerts
-            FThreads.invokeInBackgroundThread(() -> controller.spendToken());
+            FThreads.invokeInBackgroundThread(controller::spendToken);
         });
         btnEditDeck.setCommand(event -> editDeck(true));
         btnLeaveTournament.setCommand(event -> {
             //must run in background thread to handle alerts
-            FThreads.invokeInBackgroundThread(() -> controller.endTournamentAndAwardPrizes());
+            FThreads.invokeInBackgroundThread(controller::endTournamentAndAwardPrizes);
         });
 
         // TODO: is it possible to somehow reuse the original btnEditDeck/btnLeaveTournament
         btnEditDeckInTourn.setCommand(event -> editDeck(true));
         btnLeaveTournamentInTourn.setCommand(event -> {
             //must run in background thread to handle alerts
-            FThreads.invokeInBackgroundThread(() -> controller.endTournamentAndAwardPrizes());
+            FThreads.invokeInBackgroundThread(controller::endTournamentAndAwardPrizes);
         });
 
         pnlPrepareDeck.add(btnEditDeck);

--- a/forge-gui-mobile/src/forge/screens/settings/SettingsPage.java
+++ b/forge-gui-mobile/src/forge/screens/settings/SettingsPage.java
@@ -60,7 +60,7 @@ public class SettingsPage extends TabPage<SettingsScreen> {
             public void valueChanged(String newValue) {
                 // if the new locale needs to use CJK font, disallow change if UI_CJK_FONT is not set yet
                 ForgePreferences prefs = FModel.getPreferences();
-                if (prefs.getPref(FPref.UI_CJK_FONT).equals("") &&
+                if (prefs.getPref(FPref.UI_CJK_FONT).isEmpty() &&
                         (newValue.equals("zh-CN") || newValue.equals("ja-JP"))) {
                     String message = "Please download CJK font (from \"Files\"), and set it before change language.";
                     if (newValue.equals("zh-CN")) {

--- a/forge-gui-mobile/src/forge/toolbox/GuiChoose.java
+++ b/forge-gui-mobile/src/forge/toolbox/GuiChoose.java
@@ -3,7 +3,6 @@ package forge.toolbox;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 

--- a/forge-gui-mobile/src/forge/toolbox/GuiChoose.java
+++ b/forge-gui-mobile/src/forge/toolbox/GuiChoose.java
@@ -340,7 +340,7 @@ public class GuiChoose {
     // If comparer is NULL, T has to be comparable. Otherwise you'll get an exception from inside the Arrays.sort() routine
     public static <T> void sortedGetChoices(final String message, final int min, final int max, final List<T> choices, Comparator<T> comparer, final Callback<List<T>> callback) {
         // You may create a copy of source list if callers expect the collection to be unchanged
-        Collections.sort(choices, comparer);
+        choices.sort(comparer);
         getChoices(message, min, max, choices, callback);
     }
 }

--- a/forge-gui/src/main/java/forge/deck/DeckProxy.java
+++ b/forge-gui/src/main/java/forge/deck/DeckProxy.java
@@ -35,8 +35,6 @@ public class DeckProxy implements InventoryItem {
     protected final String deckType;
     protected final IStorage<? extends IHasName> storage;
 
-    public static final Function<DeckProxy, String> FN_GET_NAME = arg0 -> arg0.getName();
-
     // cached values
     protected ColorSet color;
     protected ColorSet colorIdentity;

--- a/forge-gui/src/main/java/forge/deck/io/DeckPreferences.java
+++ b/forge-gui/src/main/java/forge/deck/io/DeckPreferences.java
@@ -119,11 +119,7 @@ public class DeckPreferences {
 
     public static DeckPreferences getPrefs(DeckProxy deck) {
         String key = deck.getUniqueKey();
-        DeckPreferences prefs = allPrefs.get(key);
-        if (prefs == null) {
-            prefs = new DeckPreferences();
-            allPrefs.put(key, prefs);
-        }
+        DeckPreferences prefs = allPrefs.computeIfAbsent(key, k -> new DeckPreferences());
         return prefs;
     }
 

--- a/forge-gui/src/main/java/forge/gamemodes/gauntlet/GauntletIO.java
+++ b/forge-gui/src/main/java/forge/gamemodes/gauntlet/GauntletIO.java
@@ -98,7 +98,7 @@ public class GauntletIO {
 
     public static GauntletData loadGauntlet(final File xmlSaveFile) {
         boolean isCorrupt = false;
-        try (GZIPInputStream zin = new GZIPInputStream(new FileInputStream(xmlSaveFile));
+        try (GZIPInputStream zin = new GZIPInputStream(Files.newInputStream(xmlSaveFile.toPath()));
              InputStreamReader reader = new InputStreamReader(zin)) {
             final GauntletData data = (GauntletData)GauntletIO.getSerializer(true).fromXML(reader);
 

--- a/forge-gui/src/main/java/forge/gamemodes/limited/BoosterDraft.java
+++ b/forge-gui/src/main/java/forge/gamemodes/limited/BoosterDraft.java
@@ -173,7 +173,7 @@ public class BoosterDraft implements IBoosterDraft {
                 if (myDrafts.isEmpty()) {
                     SOptionPane.showMessageDialog(Localizer.getInstance().getMessage("lblNotFoundCustomDraftFiles"));
                 } else {
-                    Collections.sort(myDrafts, Comparator.comparing(DeckBase::getName));
+                    myDrafts.sort(Comparator.comparing(DeckBase::getName));
 
                     final CustomLimited customDraft = SGuiChoose.oneOrNone(Localizer.getInstance().getMessage("lblChooseCustomDraft"), myDrafts);
                     if (customDraft == null) {

--- a/forge-gui/src/main/java/forge/gamemodes/match/HostedMatch.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/HostedMatch.java
@@ -1,7 +1,6 @@
 package forge.gamemodes.match;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/forge-gui/src/main/java/forge/gamemodes/match/HostedMatch.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/HostedMatch.java
@@ -134,7 +134,7 @@ public class HostedMatch {
         }
 
         final List<RegisteredPlayer> sortedPlayers = Lists.newArrayList(players);
-        Collections.sort(sortedPlayers, (p1, p2) -> {
+        sortedPlayers.sort((p1, p2) -> {
 
             final int v1 = p1.getPlayer() instanceof LobbyPlayerHuman ? 0 : 1;
             final int v2 = p2.getPlayer() instanceof LobbyPlayerHuman ? 0 : 1;

--- a/forge-gui/src/main/java/forge/gamemodes/match/input/InputSelectEntitiesFromList.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/input/InputSelectEntitiesFromList.java
@@ -44,7 +44,7 @@ public class InputSelectEntitiesFromList<T extends GameEntity> extends InputSele
         super(controller, Math.min(min, validChoices0.size()), Math.min(max, validChoices0.size()), sa0, tallyType0, tally0);
         validChoices = validChoices0;
         if (min > validChoices.size()) { // pfps does this really do anything useful??
-            System.out.println(String.format("Trying to choose at least %d things from a list with only %d things!", min, validChoices.size()));
+            System.out.printf("Trying to choose at least %d things from a list with only %d things!%n", min, validChoices.size());
         }
         ArrayList<CardView> vCards = new ArrayList<>();
         for (T c : validChoices0) {

--- a/forge-gui/src/main/java/forge/gamemodes/net/CompatibleObjectDecoder.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/CompatibleObjectDecoder.java
@@ -37,7 +37,7 @@ public class CompatibleObjectDecoder extends LengthFieldBasedFrameDecoder {
         try {
             var5 = ois.readObject();
         } catch (StreamCorruptedException e) {
-            System.err.println(String.format("Version Mismatch: %s", e.getMessage()));
+            System.err.printf("Version Mismatch: %s%n", e.getMessage());
         } finally {
             ois.close();
         }

--- a/forge-gui/src/main/java/forge/gamemodes/net/GameProtocolHandler.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/GameProtocolHandler.java
@@ -41,7 +41,7 @@ public abstract class GameProtocolHandler<T> extends ChannelInboundHandlerAdapte
             if (method == null) {
                 //throw new IllegalStateException(String.format("Method %s not found", protocolMethod.name()));
                 catchedError[0] += String.format("IllegalStateException: Method %s not found (GameProtocolHandler.java Line 43)\n", protocolMethod.name());
-                System.err.println(String.format("Method %s not found", protocolMethod.name()));
+                System.err.printf("Method %s not found%n", protocolMethod.name());
             }
 
             final Object[] args = event.getObjects();
@@ -58,7 +58,7 @@ public abstract class GameProtocolHandler<T> extends ChannelInboundHandlerAdapte
                     try {
                         method.invoke(toInvoke, args);
                     } catch (final IllegalAccessException | IllegalArgumentException e) {
-                        System.err.println(String.format("Unknown protocol method %s with %d args", methodName, args == null ? 0 : args.length));
+                        System.err.printf("Unknown protocol method %s with %d args%n", methodName, args == null ? 0 : args.length);
                     } catch (final InvocationTargetException e) {
                         //throw new RuntimeException(e.getTargetException());
                         catchedError[0] += (String.format("RuntimeException: %s (GameProtocolHandler.java Line 65)\n", e.getTargetException().toString()));
@@ -72,10 +72,10 @@ public abstract class GameProtocolHandler<T> extends ChannelInboundHandlerAdapte
                             protocolMethod.checkReturnValue(theReply);
                             reply = (Serializable) theReply;
                         } else if (theReply != null) {
-                            System.err.println(String.format("Non-serializable return type %s for method %s, returning null", returnType.getName(), methodName));
+                            System.err.printf("Non-serializable return type %s for method %s, returning null%n", returnType.getName(), methodName);
                         }
                     } catch (final IllegalAccessException | IllegalArgumentException e) {
-                        System.err.println(String.format("Unknown protocol method %s with %d args, replying with null", methodName, args == null ? 0 : args.length));
+                        System.err.printf("Unknown protocol method %s with %d args, replying with null%n", methodName, args == null ? 0 : args.length);
                     } catch (final NullPointerException | InvocationTargetException e) {
                         //throw new RuntimeException(e.getTargetException());
                         catchedError[0] += e.toString();

--- a/forge-gui/src/main/java/forge/gamemodes/net/ProtocolMethod.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/ProtocolMethod.java
@@ -138,7 +138,7 @@ public enum ProtocolMethod {
             }
             return candidate;
         } catch (final NoSuchMethodException | SecurityException e) {
-            System.err.println(String.format("Warning: class contains no accessible method named %s", name()));
+            System.err.printf("Warning: class contains no accessible method named %s%n", name());
             return getMethodNoArgs();
         }
     }
@@ -147,7 +147,7 @@ public enum ProtocolMethod {
         try {
             return mode.toInvoke.getMethod(name(), (Class<?>[]) null);
         } catch (final NoSuchMethodException | SecurityException e) {
-            System.err.println(String.format("Warning: class contains no accessible arg-less method named %s", name()));
+            System.err.printf("Warning: class contains no accessible arg-less method named %s%n", name());
             return null;
         }
     }
@@ -168,7 +168,7 @@ public enum ProtocolMethod {
                 final Class<?> type = this.args[iArg];
                 if (!ReflectionUtil.isInstance(arg, type)) {
                     //throw new InternalError(String.format("Protocol method %s: illegal argument (%d) of type %s, %s expected", name(), iArg, arg.getClass().getName(), type.getName()));
-                    System.err.println(String.format("InternalError: Protocol method %s: illegal argument (%d) of type %s, %s expected (ProtocolMethod.java)", name(), iArg, arg.getClass().getName(), type.getName()));
+                    System.err.printf("InternalError: Protocol method %s: illegal argument (%d) of type %s, %s expected (ProtocolMethod.java)%n", name(), iArg, arg.getClass().getName(), type.getName());
                 }
             }
         } catch (Exception e) {
@@ -183,7 +183,7 @@ public enum ProtocolMethod {
         }
         if (!ReflectionUtil.isInstance(value, returnType)) {
             //throw new IllegalStateException(String.format("Protocol method %s: illegal return object type %s returned by client, expected %s", name(), value.getClass().getName(), getReturnType().getName()));
-            System.err.println(String.format("IllegalStateException: Protocol method %s: illegal return object type %s returned by client, expected %s  (ProtocolMethod.java)", name(), value.getClass().getName(), getReturnType().getName()));
+            System.err.printf("IllegalStateException: Protocol method %s: illegal return object type %s returned by client, expected %s  (ProtocolMethod.java)%n", name(), value.getClass().getName(), getReturnType().getName());
         }
     }
 }

--- a/forge-gui/src/main/java/forge/gamemodes/net/client/GameClientHandler.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/client/GameClientHandler.java
@@ -215,7 +215,7 @@ final class GameClientHandler extends GameProtocolHandler<IGuiGame> {
         }
 
         final List<RegisteredPlayer> sortedPlayers = Lists.newArrayList(players);
-        Collections.sort(sortedPlayers, (p1, p2) -> {
+        sortedPlayers.sort((p1, p2) -> {
             final int v1 = p1.getPlayer() instanceof LobbyPlayerHuman ? 0 : 1;
             final int v2 = p2.getPlayer() instanceof LobbyPlayerHuman ? 0 : 1;
             return Integer.compare(v1, v2);

--- a/forge-gui/src/main/java/forge/gamemodes/quest/BoosterUtils.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/BoosterUtils.java
@@ -580,8 +580,8 @@ public final class BoosterUtils {
 
     public static void sort(List<PaperCard> cards) {
         //sort cards alphabetically so colors appear together and rares appear on top
-        Collections.sort(cards, Comparator.comparing(PaperCard::getName));
-        Collections.sort(cards, Comparator.comparing(c -> c.getRules().getColor()));
-        Collections.sort(cards, Comparator.comparing(PaperCard::getRarity).reversed());
+        cards.sort(Comparator.comparing(PaperCard::getName));
+        cards.sort(Comparator.comparing(c -> c.getRules().getColor()));
+        cards.sort(Comparator.comparing(PaperCard::getRarity).reversed());
     }
 }

--- a/forge-gui/src/main/java/forge/gamemodes/quest/QuestEventDraft.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/QuestEventDraft.java
@@ -300,11 +300,7 @@ public class QuestEventDraft implements IQuestEvent {
             int value;
             final String boosterName = FModel.getMagicDb().getEditions().get(boosterSet).getName() + " Booster Pack";
 
-            if (MAP_PRICES.containsKey(boosterName)) {
-                value = MAP_PRICES.get(boosterName);
-            } else {
-                value = 395;
-            }
+            value = MAP_PRICES.getOrDefault(boosterName, 395);
 
             boosterPrices += value;
         }
@@ -529,11 +525,7 @@ public class QuestEventDraft implements IQuestEvent {
 
         final String boosterName = booster.getName();
 
-        if (MAP_PRICES.containsKey(boosterName)) {
-            value = MAP_PRICES.get(boosterName);
-        } else {
-            value = 395;
-        }
+        value = MAP_PRICES.getOrDefault(boosterName, 395);
 
         return value;
 
@@ -961,11 +953,7 @@ public class QuestEventDraft implements IQuestEvent {
             int value;
             final String boosterName = FModel.getMagicDb().getEditions().get(boosterSet).getName() + " Booster Pack";
 
-            if (MAP_PRICES.containsKey(boosterName)) {
-                value = MAP_PRICES.get(boosterName);
-            } else {
-                value = 395;
-            }
+            value = MAP_PRICES.getOrDefault(boosterName, 395);
 
             entryFee += value;
 

--- a/forge-gui/src/main/java/forge/gamemodes/quest/QuestEventDraft.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/QuestEventDraft.java
@@ -251,6 +251,7 @@ public class QuestEventDraft implements IQuestEvent {
         for (final String name : aiNames) {
             if (playerName.equals(name)) {
                 isHumanPlayer = false;
+                break;
             }
         }
 
@@ -812,6 +813,7 @@ public class QuestEventDraft implements IQuestEvent {
                 for (CardEdition set : block.getSets()) {
                     if (!allowedQuestSets.contains(set)) {
                         blockAllowed = false;
+                        break;
                     }
                 }
 

--- a/forge-gui/src/main/java/forge/gamemodes/quest/QuestEventDraft.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/QuestEventDraft.java
@@ -1003,7 +1003,7 @@ public class QuestEventDraft implements IQuestEvent {
         }
 
         final boolean oldSetsFirst = sets.get(0).getDate().before(FModel.getMagicDb().getEditions().get("SOM").getDate());
-        Collections.sort(allowedSets, (edition1, edition2) -> {
+        allowedSets.sort((edition1, edition2) -> {
             if (edition1.getDate().before(edition2.getDate())) {
                 return oldSetsFirst ? -1 : 1;
             } else if (edition1.getDate().after(edition2.getDate())) {

--- a/forge-gui/src/main/java/forge/gamemodes/quest/QuestUtilUnlockSets.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/QuestUtilUnlockSets.java
@@ -167,7 +167,7 @@ public class QuestUtilUnlockSets {
         }
 
         // sort by distance, then by code desc
-        Collections.sort(excludedWithDistances, (o1, o2) -> {
+        excludedWithDistances.sort((o1, o2) -> {
             long delta = o2.right - o1.right;
             return delta < 0 ? -1 : delta == 0 ? 0 : 1;
         });

--- a/forge-gui/src/main/java/forge/gamemodes/quest/bazaar/QuestPetStorage.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/bazaar/QuestPetStorage.java
@@ -92,11 +92,7 @@ public class QuestPetStorage {
         * Refactoring this to List<QuestPetController> list = this.petsBySlot.computeIfAbsent(Integer.valueOf(iSlot), k -> new ArrayList<QuestPetController>());
         * will cause Android not to compile
         * */
-        List<QuestPetController> list = this.petsBySlot.get(iSlot);
-        if (null == list) {
-            list = new ArrayList<>();
-            this.petsBySlot.put(iSlot, list);
-        }
+        List<QuestPetController> list = this.petsBySlot.computeIfAbsent(iSlot, k -> new ArrayList<>());
         this.petsByName.put(petCtrl.getName(), petCtrl);
         list.add(petCtrl);
     }

--- a/forge-gui/src/main/java/forge/gamemodes/quest/data/QuestAssets.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/data/QuestAssets.java
@@ -157,11 +157,8 @@ public class QuestAssets {
      * @param level int
      */
     public final void setPetLevel(final String name, final int level) {
-        QuestItemCondition cond = this.combatPets.get(name);
-        if (null == cond) {
-            cond = new QuestItemCondition(); // pets have only level that should be serialized for now
-            this.combatPets.put(name, cond);
-        }
+        QuestItemCondition cond = this.combatPets.computeIfAbsent(name, k -> new QuestItemCondition());
+        // pets have only level that should be serialized for now
         cond.setLevel(level);
     }
 

--- a/forge-gui/src/main/java/forge/gamemodes/quest/io/QuestDataIO.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/io/QuestDataIO.java
@@ -129,7 +129,7 @@ public class QuestDataIO {
         QuestData data;
         final StringBuilder xml = new StringBuilder();
 
-        try (GZIPInputStream zin = new GZIPInputStream(new FileInputStream(xmlSaveFile));
+        try (GZIPInputStream zin = new GZIPInputStream(Files.newInputStream(xmlSaveFile.toPath()));
              InputStreamReader reader = new InputStreamReader(zin)) {
             final char[] buf = new char[1024];
             while (reader.ready()) {

--- a/forge-gui/src/main/java/forge/gamemodes/tournament/TournamentIO.java
+++ b/forge-gui/src/main/java/forge/gamemodes/tournament/TournamentIO.java
@@ -79,7 +79,7 @@ public class TournamentIO {
 
     public static TournamentData loadTournament(final File xmlSaveFile) {
         boolean isCorrupt = false;
-        try (GZIPInputStream zin = new GZIPInputStream(new FileInputStream(xmlSaveFile));
+        try (GZIPInputStream zin = new GZIPInputStream(Files.newInputStream(xmlSaveFile.toPath()));
              InputStreamReader reader = new InputStreamReader(zin)) {
             final TournamentData data = (TournamentData)TournamentIO.getSerializer(true).fromXML(reader);
 

--- a/forge-gui/src/main/java/forge/gamemodes/tournament/system/AbstractTournament.java
+++ b/forge-gui/src/main/java/forge/gamemodes/tournament/system/AbstractTournament.java
@@ -107,11 +107,11 @@ public abstract class AbstractTournament implements Serializable {
 
     public void sortAllPlayers(String sortType) {
         if (sortType.equals("score")) {
-            Collections.sort(allPlayers, (o1, o2) -> o2.getScore() - o1.getScore());
+            allPlayers.sort((o1, o2) -> o2.getScore() - o1.getScore());
         } else if (sortType.equals("index")) {
-            Collections.sort(allPlayers, (o1, o2) -> o2.getIndex() - o1.getIndex());
+            allPlayers.sort((o1, o2) -> o2.getIndex() - o1.getIndex());
         } else if (sortType.equals("swiss")) {
-            Collections.sort(allPlayers, (o1, o2) -> o2.getSwissScore() - o1.getSwissScore());
+            allPlayers.sort((o1, o2) -> o2.getSwissScore() - o1.getSwissScore());
         }
     }
 

--- a/forge-gui/src/main/java/forge/gamemodes/tournament/system/TournamentSwiss.java
+++ b/forge-gui/src/main/java/forge/gamemodes/tournament/system/TournamentSwiss.java
@@ -134,7 +134,7 @@ public class TournamentSwiss extends AbstractTournament {
             return pairSwissGroup(players);
         }
 
-        Collections.sort(players, Comparator.comparingInt(o -> availableOpponents.get(o).size()));
+        players.sort(Comparator.comparingInt(o -> availableOpponents.get(o).size()));
 
         while (players.size() > 1) {
             TournamentPlayer initialPlayer = players.get(0);

--- a/forge-gui/src/main/java/forge/gui/card/CardPreferences.java
+++ b/forge-gui/src/main/java/forge/gui/card/CardPreferences.java
@@ -28,11 +28,7 @@ public class CardPreferences {
 
     public static CardPreferences getPrefs(IPaperCard card) {
         String cardName = card.getName();
-        CardPreferences prefs = allPrefs.get(cardName);
-        if (prefs == null) {
-            prefs = new CardPreferences(cardName);
-            allPrefs.put(cardName, prefs);
-        }
+        CardPreferences prefs = allPrefs.computeIfAbsent(cardName, CardPreferences::new);
         return prefs;
     }
 

--- a/forge-gui/src/main/java/forge/gui/download/GuiDownloadService.java
+++ b/forge-gui/src/main/java/forge/gui/download/GuiDownloadService.java
@@ -338,7 +338,7 @@ public abstract class GuiDownloadService implements Runnable {
             }
             catch (final FileNotFoundException fnfe) {
                 String formatStr = "  Error - the LQ picture %s could not be found on the server. [%s] - %s";
-                System.out.println(String.format(formatStr, fileDest.getName(), url, fnfe.getMessage()));
+                System.out.printf((formatStr) + "%n", fileDest.getName(), url, fnfe.getMessage());
             }
             catch (final Exception ex) {
                 Log.error("LQ Pictures", "Error downloading pictures", ex);

--- a/forge-gui/src/main/java/forge/gui/download/GuiDownloadZipService.java
+++ b/forge-gui/src/main/java/forge/gui/download/GuiDownloadZipService.java
@@ -232,7 +232,7 @@ public class GuiDownloadZipService extends GuiDownloadService {
         final byte[] buffer = new byte[1024];
         int len;
 
-        try (BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(outPath))) {
+        try (BufferedOutputStream out = new BufferedOutputStream(java.nio.file.Files.newOutputStream(Paths.get(outPath)))) {
             while ((len = in.read(buffer)) >= 0) {
                 out.write(buffer, 0, len);
             }

--- a/forge-gui/src/main/java/forge/itemmanager/AdvancedSearch.java
+++ b/forge-gui/src/main/java/forge/itemmanager/AdvancedSearch.java
@@ -4,7 +4,6 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;

--- a/forge-gui/src/main/java/forge/itemmanager/AdvancedSearch.java
+++ b/forge-gui/src/main/java/forge/itemmanager/AdvancedSearch.java
@@ -297,7 +297,7 @@ public class AdvancedSearch {
                 List<PaperCard> cards = FModel.getMagicDb().getCommonCards().getAllCards(input.getName());
                 if (cards.size() <= 1) { return true; }
 
-                Collections.sort(cards, FModel.getMagicDb().getEditions().CARD_EDITION_COMPARATOR);
+                cards.sort(FModel.getMagicDb().getEditions().CARD_EDITION_COMPARATOR);
                 return cards.get(0) == input;
             }
         }),
@@ -528,7 +528,7 @@ public class AdvancedSearch {
                 List<PaperCard> cards = FModel.getMagicDb().getCommonCards().getAllCards(input.getName());
                 if (cards.size() <= 1) { return true; }
 
-                Collections.sort(cards, FModel.getMagicDb().getEditions().CARD_EDITION_COMPARATOR);
+                cards.sort(FModel.getMagicDb().getEditions().CARD_EDITION_COMPARATOR);
                 return cards.get(0) == input;
             }
         }),

--- a/forge-gui/src/main/java/forge/itemmanager/ItemManagerModel.java
+++ b/forge-gui/src/main/java/forge/itemmanager/ItemManagerModel.java
@@ -124,7 +124,7 @@ public final class ItemManagerModel<T extends InventoryItem> {
     public void refreshSort() {
         final List<Entry<T, Integer>> list = getOrderedList();
         if (list.isEmpty()) { return; }
-        try { Collections.sort(list, new MyComparator()); }
+        try { list.sort(new MyComparator()); }
         //fix NewDeck editor not loading on Android if a user deleted unwanted sets on edition folder
         catch (IllegalArgumentException ex) {}
     }

--- a/forge-gui/src/main/java/forge/localinstance/properties/ForgeProfileProperties.java
+++ b/forge-gui/src/main/java/forge/localinstance/properties/ForgeProfileProperties.java
@@ -18,8 +18,8 @@
 package forge.localinstance.properties;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Map;
 import java.util.Properties;
 
@@ -62,7 +62,7 @@ public class ForgeProfileProperties {
         final File propFile = new File(ForgeConstants.PROFILE_FILE);
         try {
             if (propFile.canRead() && !isUsingAppDirectory) {
-                props.load(new FileInputStream(propFile));
+                props.load(Files.newInputStream(propFile.toPath()));
             }
         } catch (final IOException e) {
             System.err.println("error while reading from profile properties file");

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -2175,9 +2175,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
                 for (final DeckSection s : new TreeSet<>(removedUnplayableCards.keySet())) {
                     if (DeckSection.Sideboard.equals(s))
                         continue;
-                    for (PaperCard c : removedUnplayableCards.get(s)) {
-                        labels.add(c);
-                    }
+                    labels.addAll(removedUnplayableCards.get(s));
                 }
                 if (!labels.isEmpty())
                     getGui().reveal(localizer.getMessage("lblActionFromPlayerDeck", message, Lang.getInstance().getPossessedObject(MessageUtil.mayBeYou(player, p), "")),

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -1343,7 +1343,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
 
         // create sorted list from map from least to most frequent
         List<Entry<String, Integer>> sortedList = Lists.newArrayList(typesInDeck.entrySet());
-        Collections.sort(sortedList, Entry.comparingByValue());
+        sortedList.sort(Entry.comparingByValue());
 
         // loop through sorted list and move each type to the front of the
         // validTypes collection

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -2589,7 +2589,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
             final Card card = gameCacheCounters.get(cv);
 
             final ImmutableList<CounterType> counters = subtract ? ImmutableList.copyOf(card.getCounters().keySet())
-                    : ImmutableList.copyOf(Collections2.transform(CounterEnumType.values, input -> CounterType.get(input)));
+                    : ImmutableList.copyOf(Collections2.transform(CounterEnumType.values, CounterType::get));
 
             final CounterType counter = getGui().oneOrNone(localizer.getMessage("lblWhichTypeofCounter"), counters);
             if (counter == null) {

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -1723,7 +1723,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
         for (int i = 0; i < num; i++) {
             if (sa.hasParam("Pawprint")) {
                 final int tmpPaw = chosenPawprint;
-                spellViewCache.values().removeIf(ab -> Integer.valueOf(ab.getParam("Pawprint")) > num - tmpPaw);
+                spellViewCache.values().removeIf(ab -> Integer.parseInt(ab.getParam("Pawprint")) > num - tmpPaw);
             }
             final List<SpellAbilityView> choices = Lists.newArrayList(spellViewCache.keySet());
 

--- a/forge-gui/src/main/java/forge/sound/SoundSystem.java
+++ b/forge-gui/src/main/java/forge/sound/SoundSystem.java
@@ -283,7 +283,7 @@ public class SoundSystem {
             invalidateSoundCache();
         }
 
-        return availableSets.toArray(new String[availableSets.size()]);
+        return availableSets.toArray(new String[0]);
     }
 
     public String getSoundDirectory() {
@@ -341,6 +341,6 @@ public class SoundSystem {
             MusicPlaylist.invalidateMusicPlaylist();
         }
 
-        return availableSets.toArray(new String[availableSets.size()]);
+        return availableSets.toArray(new String[0]);
     }
 }

--- a/forge-gui/src/main/java/forge/util/ZipUtil.java
+++ b/forge-gui/src/main/java/forge/util/ZipUtil.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
@@ -55,7 +56,7 @@ public class ZipUtil {
     public static String unzip(File fileZip, File destDir) throws IOException {
         StringBuilder val = new StringBuilder();
         byte[] buffer = new byte[1024];
-        ZipInputStream zis = new ZipInputStream(new FileInputStream(fileZip));
+        ZipInputStream zis = new ZipInputStream(Files.newInputStream(fileZip.toPath()));
         ZipEntry zipEntry = zis.getNextEntry();
         while (zipEntry != null) {
             File newFile = newFile(destDir, zipEntry);

--- a/forge-lda/src/forge/lda/dataset/BagOfWords.java
+++ b/forge-lda/src/forge/lda/dataset/BagOfWords.java
@@ -69,9 +69,7 @@ public final class BagOfWords {
             try {
                 if (format.isDeckLegal(deck) && deck.getMain().toFlatList().size() == 60) {
                     legalDecks.add(deck);
-                    for (PaperCard card : deck.getMain().toFlatList()) {
-                        cardSet.add(card);
-                    }
+                    cardSet.addAll(deck.getMain().toFlatList());
                 }
             }catch(Exception e){
                 System.out.println("Skipping deck "+deck.getName());

--- a/forge-lda/src/forge/lda/lda/inference/InferenceProperties.java
+++ b/forge-lda/src/forge/lda/lda/inference/InferenceProperties.java
@@ -16,10 +16,10 @@
 
 package forge.lda.lda.inference;
 
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Properties;
 
 public class InferenceProperties {
@@ -63,8 +63,8 @@ public class InferenceProperties {
 }
 
 class PropertiesLoader {
-    public InputStream getInputStream(String fileName) throws FileNotFoundException {
+    public InputStream getInputStream(String fileName) throws IOException {
         if (fileName == null) throw new NullPointerException();
-        return new FileInputStream(fileName);
+        return Files.newInputStream(Paths.get(fileName));
     }
 }

--- a/forge-lda/src/forge/lda/lda/inference/internal/Documents.java
+++ b/forge-lda/src/forge/lda/lda/inference/internal/Documents.java
@@ -45,7 +45,7 @@ class Documents {
         //System.out.println(docID);
         //System.out.println(bow.getWords(docID).toString());
         return bow.getWords(docID).stream()
-                                  .map(id -> vocabs.get(id))
+                                  .map(vocabs::get)
                                   .collect(Collectors.toList());
     }
 

--- a/forge-lda/src/main/java/forge/lda/LDAModelGenetrator.java
+++ b/forge-lda/src/main/java/forge/lda/LDAModelGenetrator.java
@@ -254,7 +254,7 @@ public final class LDAModelGenetrator {
         }
         Comparator<Archetype> archetypeComparator = (o1, o2) -> o2.getDeckCount().compareTo(o1.getDeckCount());
 
-        Collections.sort(unfilteredTopics,archetypeComparator);
+        unfilteredTopics.sort(archetypeComparator);
         return unfilteredTopics;
     }
 
@@ -263,7 +263,7 @@ public final class LDAModelGenetrator {
     @SuppressWarnings("unchecked")
     private static <K, V> Map<K, V> sortByValue(Map<K, V> map) {
         List<Map.Entry<K, V>> list = new LinkedList<>(map.entrySet());
-        Collections.sort(list, (Comparator<Object>) (o1, o2) -> ((Comparable<V>) ((Map.Entry<K, V>) (o2)).getValue()).compareTo(((Map.Entry<K, V>) (o1)).getValue()));
+        list.sort((Comparator<Object>) (o1, o2) -> ((Comparable<V>) ((Map.Entry<K, V>) (o2)).getValue()).compareTo(((Map.Entry<K, V>) (o1)).getValue()));
 
         Map<K, V> result = new LinkedHashMap<>();
         for (Map.Entry<K, V> entry : list) {


### PR DESCRIPTION
Continuing from #5737, this set of adjustments is a bit more varied in scope. A few more lambdas and method references have been applied that were passed over in the previous batch. Some helper methods have been applied and some wrapper methods have been unwrapped.

A significant change is the switch from `new FileInputStream` to `Files.newInputStream` in a few places, particularly when reading cards and other resources. As I understand it, the underlying implementation it uses on modern JVMs is much less prone to stalling for garbage collection. In practice, I've noticed the reported time it takes to load cards has gone from ~1700ms to ~1300ms, and I've yet to experience any prolonged hangs that I've occasionally encountered on startup previously. Fingers crossed.