### PR TITLE
Fixing Nykthos, Shrine to Nyx and other related cards

### DIFF
--- a/forge-gui/res/cardsfolder/a/astral_cornucopia.txt
+++ b/forge-gui/res/cardsfolder/a/astral_cornucopia.txt
@@ -4,6 +4,7 @@ Types:Artifact
 K:etbCounter:CHARGE:X
 SVar:X:Count$xPaid
 A:AB$ ChooseColor | Cost$ T | AILogic$ MostProminentInComputerDeck | SubAbility$ DBMana | SpellDescription$ Choose a color. Add one mana of that color for each charge counter on CARDNAME.
-SVar:DBMana:DB$ Mana | Produced$ Chosen | Amount$ Y
+SVar:DBMana:DB$ Mana | Produced$ Chosen | Amount$ Y | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearChosenColor$ True
 SVar:Y:Count$CardCounters.CHARGE
 Oracle:Astral Cornucopia enters with X charge counters on it.\n{T}: Choose a color. Add one mana of that color for each charge counter on Astral Cornucopia.

--- a/forge-gui/res/cardsfolder/n/nykthos_shrine_to_nyx.txt
+++ b/forge-gui/res/cardsfolder/n/nykthos_shrine_to_nyx.txt
@@ -3,6 +3,7 @@ ManaCost:no cost
 Types:Legendary Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ ChooseColor | Cost$ 2 T | SubAbility$ DBMana | AILogic$ MostProminentComputerControls | AINoRecursiveCheck$ True | SpellDescription$ Choose a color. Add an amount of mana of that color equal to your devotion to that color. (Your devotion to a color is the number of mana symbols of that color in the mana costs of permanents you control.)
-SVar:DBMana:DB$ Mana | Produced$ Chosen | Amount$ X
+SVar:DBMana:DB$ Mana | Produced$ Chosen | Amount$ X | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearChosenColor$ True
 SVar:X:Count$Devotion.Chosen
 Oracle:{T}: Add {C}.\n{2}, {T}: Choose a color. Add an amount of mana of that color equal to your devotion to that color. (Your devotion to a color is the number of mana symbols of that color in the mana costs of permanents you control.)

--- a/forge-gui/res/cardsfolder/n/nyx.txt
+++ b/forge-gui/res/cardsfolder/n/nyx.txt
@@ -6,7 +6,8 @@ T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Enchan
 SVar:TrigGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1
 T:Mode$ ChaosEnsues | TriggerZones$ Command | Execute$ RolledChaos | TriggerDescription$ Whenever chaos ensues, choose a color. Add an amount of mana of that color equal to your devotion to that color.
 SVar:RolledChaos:DB$ ChooseColor | SubAbility$ DBMana | AILogic$ MostProminentComputerControls | AINoRecursiveCheck$ True
-SVar:DBMana:DB$ Mana | Produced$ Chosen | Amount$ X
+SVar:DBMana:DB$ Mana | Produced$ Chosen | Amount$ X | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearChosenColor$ True
 SVar:X:Count$Devotion.Chosen
 DeckHas:Ability$LifeGain
 DeckHints:Type$Enchantment

--- a/forge-gui/res/cardsfolder/n/nyx_lotus.txt
+++ b/forge-gui/res/cardsfolder/n/nyx_lotus.txt
@@ -3,7 +3,7 @@ ManaCost:4
 Types:Legendary Artifact
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
-A:AB$ ChooseColor | Cost$ T | AILogic$ MostProminentInComputerDeck | SubAbility$ DBMana | SpellDescription$ Choose a color. Add an amount of mana of that color equal to your devotion to that color.
+A:AB$ ChooseColor | Cost$ T | AILogic$ MostProminentComputerControls | AINoRecursiveCheck$ True | SubAbility$ DBMana | SpellDescription$ Choose a color. Add an amount of mana of that color equal to your devotion to that color.
 SVar:DBMana:DB$ Mana | Produced$ Chosen | Amount$ X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearChosenColor$ True
 SVar:X:Count$Devotion.Chosen

--- a/forge-gui/res/cardsfolder/r/rhystic_cave.txt
+++ b/forge-gui/res/cardsfolder/r/rhystic_cave.txt
@@ -2,6 +2,7 @@ Name:Rhystic Cave
 ManaCost:no cost
 Types:Land
 A:AB$ ChooseColor | Cost$ T | AILogic$ MostProminentInComputerDeck | SubAbility$ DBMana | InstantSpeed$ True | SpellDescription$ Choose a color. Add one mana of that color unless any player pays {1}. Activate only as an instant.
-SVar:DBMana:DB$ Mana | Produced$ Chosen | UnlessCost$ 1 | UnlessPayer$ Player | SpellDescription$ Add one mana of the chosen color.
+SVar:DBMana:DB$ Mana | Produced$ Chosen | UnlessCost$ 1 | UnlessPayer$ Player | SubAbility$ DBCleanup | SpellDescription$ Add one mana of the chosen color.
+SVar:DBCleanup:DB$ Cleanup | ClearChosenColor$ True
 AI:RemoveDeck:All
 Oracle:{T}: Choose a color. Add one mana of that color unless any player pays {1}. Activate only as an instant.

--- a/forge-gui/res/cardsfolder/upcoming/three_tree_city.txt
+++ b/forge-gui/res/cardsfolder/upcoming/three_tree_city.txt
@@ -4,7 +4,7 @@ Types:Legendary Land
 K:ETBReplacement:Other:ChooseCT
 SVar:ChooseCT:DB$ ChooseType | Defined$ You | Type$ Creature | SpellDescription$ As CARDNAME enters, choose a creature type. | AILogic$ MostProminentInComputerDeckNonToken
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
-A:AB$ ChooseColor | Cost$ 2 T | SubAbility$ DBMana | SpellDescription$ Choose a color. Add an amount of mana of that color equal to the number of creatures you control of the chosen type.
+A:AB$ ChooseColor | Cost$ 2 T | AILogic$ MostProminentInComputerDeck | SubAbility$ DBMana | SpellDescription$ Choose a color. Add an amount of mana of that color equal to the number of creatures you control of the chosen type.
 SVar:DBMana:DB$ Mana | Produced$ Chosen | Amount$ X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearChosenColor$ True
 SVar:X:Count$Valid Creature.ChosenType+YouCtrl

--- a/forge-gui/res/cardsfolder/upcoming/three_tree_city.txt
+++ b/forge-gui/res/cardsfolder/upcoming/three_tree_city.txt
@@ -5,6 +5,7 @@ K:ETBReplacement:Other:ChooseCT
 SVar:ChooseCT:DB$ ChooseType | Defined$ You | Type$ Creature | SpellDescription$ As CARDNAME enters, choose a creature type. | AILogic$ MostProminentInComputerDeckNonToken
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ ChooseColor | Cost$ 2 T | SubAbility$ DBMana | SpellDescription$ Choose a color. Add an amount of mana of that color equal to the number of creatures you control of the chosen type.
-SVar:DBMana:DB$ Mana | Produced$ Chosen | Amount$ X
+SVar:DBMana:DB$ Mana | Produced$ Chosen | Amount$ X | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearChosenColor$ True
 SVar:X:Count$Valid Creature.ChosenType+YouCtrl
 Oracle:As Three Tree City enters, choose a creature type.\n{T}: Add {C}.\n{2}, {T}: Choose a color. Add an amount of mana of that color equal to the number of creatures you control of the chosen type.


### PR DESCRIPTION
Mana abilities that require you to choose a color and then generate an arbitrary amount of mana of that color, like that of [Nykthos, Shrine to Nyx](https://scryfall.com/card/ths/223/nykthos-shrine-to-nyx), should have a `SubAbility$ DBCleanup` to immediately clear the chosen color on resolution.
I also took the opportunity to adjust the AI behavior tags for the mana abilities [Nyx Lotus](https://scryfall.com/card/thb/235/nyx-lotus) and [Three Tree City](https://scryfall.com/card/blb/260/three-tree-city) based on what's used for other effects of the same kind.