### PR TITLE
Fixing Rootwater Matriarch

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/ControlGainAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ControlGainAi.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
+import forge.ai.ComputerUtil;
 import forge.ai.ComputerUtilCard;
 import forge.ai.ComputerUtilCombat;
 import forge.ai.SpecialCardAi;
@@ -123,6 +124,9 @@ public class ControlGainAi extends SpellAbilityAi {
 
         CardCollection list = opponents.getCardsIn(ZoneType.Battlefield);
 
+                    // Filter AI-specific targets if provided
+            list = ComputerUtil.filterAITgts(sa, ai, list, true);
+
         list = CardLists.getValidCards(list, tgt.getValidTgts(), sa.getActivatingPlayer(), sa.getHostCard(), sa);
         
         if (list.isEmpty()) {
@@ -132,6 +136,10 @@ public class ControlGainAi extends SpellAbilityAi {
 
         // AI won't try to grab cards that are filtered out of AI decks on purpose
         list = CardLists.filter(list, c -> {
+            //if (sa.hasParam("AITgts")) {
+                    //if (!c.isValid(sa.getParam("AITgts"), sa.getActivatingPlayer(), sa.getHostCard(), sa))
+                    //return false;
+            //}
             if (!sa.canTarget(c)) {
                 return false;
             }

--- a/forge-ai/src/main/java/forge/ai/ability/ControlGainAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ControlGainAi.java
@@ -124,22 +124,11 @@ public class ControlGainAi extends SpellAbilityAi {
 
         CardCollection list = opponents.getCardsIn(ZoneType.Battlefield);
 
-                    // Filter AI-specific targets if provided
-            list = ComputerUtil.filterAITgts(sa, ai, list, true);
-
-        list = CardLists.getValidCards(list, tgt.getValidTgts(), sa.getActivatingPlayer(), sa.getHostCard(), sa);
-        
-        if (list.isEmpty()) {
-            // no valid targets, so we need to bail
-            return false;
-        }
+        // Filter AI-specific targets if provided
+        list = ComputerUtil.filterAITgts(sa, ai, list, false);
 
         // AI won't try to grab cards that are filtered out of AI decks on purpose
         list = CardLists.filter(list, c -> {
-            //if (sa.hasParam("AITgts")) {
-                    //if (!c.isValid(sa.getParam("AITgts"), sa.getActivatingPlayer(), sa.getHostCard(), sa))
-                    //return false;
-            //}
             if (!sa.canTarget(c)) {
                 return false;
             }

--- a/forge-gui/res/cardsfolder/r/rootwater_matriarch.txt
+++ b/forge-gui/res/cardsfolder/r/rootwater_matriarch.txt
@@ -2,9 +2,8 @@ Name:Rootwater Matriarch
 ManaCost:2 U U
 Types:Creature Merfolk
 PT:2/3
-A:AB$ GainControl | Cost$ T | ValidTgts$ Creature | AITgts$ Creature.Enchanted | LoseControl$ StaticCommandCheck | StaticCommandCheckSVar$ X | StaticCommandSVarCompare$ EQ0 | ConditionCheckSVar$ Y | ContionSVarCompare$ GE1 | SpellDescription$ Gain control of target creature for as long as that creature is enchanted.
+A:AB$ GainControl | Cost$ T | ValidTgts$ Creature | AILogic$ GainControl | AITgts$ Creature.enchanted | LoseControl$ StaticCommandCheck | StaticCommandCheckSVar$ X | StaticCommandSVarCompare$ EQ0 | ConditionCheckSVar$ Y | ConditionSVarCompare$ GE1 | SpellDescription$ Gain control of target creature for as long as that creature is enchanted.
 # The hostcard of SVar X is the controlled card
 SVar:X:Count$Valid Card.Self+enchanted
 SVar:Y:Targeted$Valid Card.enchanted
-AI:RemoveDeck:Random
 Oracle:{T}: Gain control of target creature for as long as that creature is enchanted.

--- a/forge-gui/res/cardsfolder/r/rootwater_matriarch.txt
+++ b/forge-gui/res/cardsfolder/r/rootwater_matriarch.txt
@@ -2,7 +2,7 @@ Name:Rootwater Matriarch
 ManaCost:2 U U
 Types:Creature Merfolk
 PT:2/3
-A:AB$ GainControl | Cost$ T | ValidTgts$ Creature | AILogic$ GainControl | AITgts$ Creature.enchanted | LoseControl$ StaticCommandCheck | StaticCommandCheckSVar$ X | StaticCommandSVarCompare$ EQ0 | ConditionCheckSVar$ Y | ConditionSVarCompare$ GE1 | SpellDescription$ Gain control of target creature for as long as that creature is enchanted.
+A:AB$ GainControl | Cost$ T | ValidTgts$ Creature | AITgts$ Creature.enchanted | AITgtsStrict$ True | LoseControl$ StaticCommandCheck | StaticCommandCheckSVar$ X | StaticCommandSVarCompare$ EQ0 | ConditionCheckSVar$ Y | ConditionSVarCompare$ GE1 | SpellDescription$ Gain control of target creature for as long as that creature is enchanted.
 # The hostcard of SVar X is the controlled card
 SVar:X:Count$Valid Card.Self+enchanted
 SVar:Y:Targeted$Valid Card.enchanted


### PR DESCRIPTION
The initial issue is that the AI will target creatures it can't keep with the [Matriarch](https://scryfall.com/card/tmp/83/rootwater-matriarch), as they're not enchanted.

Attempts to fix this through `ControlGainAi.java` bar one result in the AI stalling in an infinite loop. 
This is the **Line 139** edit by itself which has the AI seemingly ignore the Matriarch's ability entirely even with a likely enchanted creature on the board. Because of that this one has been included for convenience but has been commented out to be turned on (or off) as necessary.

The **Line 26** and **Line 127** edits combined by themselves result in the AI stalling when it starts a turn with the Matriarch and a targetable creature on the board.

The **Line 26** + **Line 127** + **Line 139** situation has the AI stall when the targetable creature is/becomes enchanted.

**Edit:** As reported by @tool4ever, these changes, after some cleaning, do have the Matriarch behaving as expected, so this PR is now ready for review.

