### PR TITLE
Update ulamog_the_defiler.txt

### DIFF
--- a/forge-gui/res/cardsfolder/u/ulamog_the_defiler.txt
+++ b/forge-gui/res/cardsfolder/u/ulamog_the_defiler.txt
@@ -2,7 +2,7 @@ Name:Ulamog, the Defiler
 ManaCost:10
 Types:Legendary Creature Eldrazi
 PT:7/7
-K:Ward:Sac<2/Permanent/permanents>
+K:Ward:Sac<2/Permanent>
 T:Mode$ SpellCast | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ When you cast this spell, target opponent exiles half their library, rounded up.
 SVar:TrigExile:DB$ Dig | ValidTgts$ Opponent | DestinationZone$ Exile | DigNum$ X | ChangeNum$ All
 SVar:X:TargetedPlayer$CardsInLibrary/HalfUp


### PR DESCRIPTION
Turns out specifying a plural when the text generation for in-game display of card text already has the basic rules down for simple cases gives unwittingly humorous results.

![image](https://github.com/user-attachments/assets/fc11daca-ba26-4193-8bc6-2c760ea22ecf)

~Guess my initial lapse setting this up as a draft wasn't such a lapse at all as I looked further and found a case that isn't as easy to fix.~ → This is best handled on a new issue: https://github.com/Card-Forge/forge/issues/5916

