### PR TITLE
Update temporal_aperture.txt

### DIFF
--- a/forge-gui/res/cardsfolder/t/temporal_aperture.txt
+++ b/forge-gui/res/cardsfolder/t/temporal_aperture.txt
@@ -3,10 +3,12 @@ ManaCost:2
 Types:Artifact
 A:AB$ Shuffle | Cost$ 5 T | SubAbility$ DBReveal | SpellDescription$ Shuffle your library, then reveal the top card. Until end of turn, for as long as that card remains on top of your library, play with the top card of your library revealed and you may play that card without paying its mana cost. (If it has X in its mana cost, X is 0.)
 SVar:DBReveal:DB$ Dig | DigNum$ 1 | Reveal$ True | ChangeNum$ All | ChangeValid$ Card | DestinationZone$ Library | LibraryPosition$ 0 | LibraryPosition2$ 0 | RememberChanged$ True | SubAbility$ DBAperture
-SVar:DBAperture:DB$ Effect | StaticAbilities$ STPlay | RememberObjects$ RememberedCard | Triggers$ StillTopCheck | SpellDescription$ Until end of turn, for as long as that card remains on top of your library, play with the top card of your library revealed and you may play that card without paying its mana cost. | SubAbility$ DBCleanup
+SVar:DBAperture:DB$ Effect | StaticAbilities$ STPlay | RememberObjects$ RememberedCard | Triggers$ StillTopCheck,ShuffleCheck | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-SVar:STPlay:Mode$ Continuous | EffectZone$ Command | Affected$ Card.TopLibrary+YouCtrl+IsRemembered | AffectedZone$ Library | MayPlay$ True | MayPlayWithoutManaCost$ True | MayLookAt$ Player
+SVar:STPlay:Mode$ Continuous | EffectZone$ Command | Affected$ Card.TopLibrary+YouCtrl+IsRemembered | AffectedZone$ Library | MayPlay$ True | MayPlayWithoutManaCost$ True | MayLookAt$ Player | Description$ Until end of turn, for as long as the revealed card remains on top of your library, play with the top card of your library revealed and you may play that card without paying its mana cost. (If it has X in its mana cost, X is 0.)
 SVar:StillTopCheck:Mode$ Always | TriggerZones$ Command | IsPresent$ Card.TopLibrary+YouCtrl+IsNotRemembered | PresentZone$ Library | Execute$ ExileEffect | Static$ True
-SVar:ExileEffect:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
+SVar:ShuffleCheck:Mode$ Shuffled | ValidPlayer$ You | TriggerZones$ Command | Execute$ ExileEffect | Static$ True
+SVar:ExileEffect:DB$ ChangeZone | Defined$ Self | ConditionCheckSVar$ Resolved | ConditionSVarCompare$ EQ2 | Origin$ Command | Destination$ Exile
+SVar:Resolved:Count$ResolvedThisTurn
 AI:RemoveDeck:All
 Oracle:{5}, {T}: Shuffle your library, then reveal the top card. Until end of turn, for as long as that card remains on top of your library, play with the top card of your library revealed and you may play that card without paying its mana cost. (If it has X in its mana cost, X is 0.)


### PR DESCRIPTION
As requested by @tool4ever, adding a static trigger to [Temporal Aperture](https://scryfall.com/card/usg/310/temporal-aperture)'s command zone effect to check for library shuffling. The resulting script tested as expected. Closes https://github.com/Card-Forge/forge/issues/3391 . Also, took the opportunity to clean up an extraneous `SpellDescription$` parameter.