### PR TITLE
Update desert_warfare.txt

### DIFF
--- a/forge-gui/res/cardsfolder/d/desert_warfare.txt
+++ b/forge-gui/res/cardsfolder/d/desert_warfare.txt
@@ -3,8 +3,8 @@ ManaCost:3 G
 Types:Enchantment
 T:Mode$ Sacrificed | ValidPlayer$ You | ValidCard$ Desert.YouCtrl | Execute$ TrigDelay | TriggerZones$ Battlefield | TriggerDescription$ Whenever you sacrifice a Desert and whenever a Desert card is put into your graveyard from your hand or library, put that card onto the battlefield under your control at the beginning of your next end step.
 T:Mode$ ChangesZone | ValidCard$ Desert.YouOwn | Origin$ Hand,Library | Destination$ Graveyard | TriggerZones$ Battlefield | Execute$ TrigDelay | Secondary$ True | TriggerDescription$ Whenever you sacrifice a Desert and whenever a Desert card is put into your graveyard from your hand or library, put that card onto the battlefield under your control at the beginning of your next end step.
-SVar:TrigDelay:DB$ DelayedTrigger | Mode$ Phase | RememberObjects$ TriggeredCardLKICopy | Phase$ End of Turn | ValidPlayer$ You | Execute$ TrigReturn | TriggerDescription$ Put that card onto the battlefield under your control at the beginning of your next end step.
-SVar:TrigReturn:DB$ ChangeZone | Defined$ DelayTriggerRememberedLKI | GainControl$ True | Origin$ Graveyard | Destination$ Battlefield
+SVar:TrigDelay:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | Execute$ TrigReturn | TriggerDescription$ Put that card onto the battlefield under your control at the beginning of your next end step.
+SVar:TrigReturn:DB$ ChangeZone | Defined$ Spawner>TriggeredCard | GainControl$ True | Origin$ Graveyard | Destination$ Battlefield
 T:Mode$ Phase | IsPresent$ Desert.YouCtrl | PresentCompare$ GE5 | Phase$ BeginCombat | ValidPlayer$ You | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of combat on your turn, if you control five or more Deserts, create that many 1/1 red, green, and white Sand Warrior creature tokens. They gain haste.
 SVar:TrigToken:DB$ Token | TokenAmount$ X | PumpKeywords$ Haste | TokenScript$ rgw_1_1_sand_warrior | TokenOwner$ You
 SVar:X:Count$Valid Desert.YouCtrl


### PR DESCRIPTION
After a bit of methodical testing, this PR closes https://github.com/Card-Forge/forge/issues/5392 : sacrificed, milled and discarded Deserts are now returned to the battlefield as expected.

**Edit:** Even the case where you have an [Yedora, Grave Gardener](https://scryfall.com/card/mkc/197/yedora-grave-gardener), a [Dune Chanter](https://scryfall.com/card/otc/31/dune-chanter) (to give all lands the Desert subtype), and sacrifice outlets for both creatures (such as [Ashnod's Altar](https://scryfall.com/card/cmm/368/ashnods-altar)) and Forests (like [Fortitude](https://scryfall.com/card/usg/253/fortitude)): the once face-down Forest Desert is returned to the battlefield as the front-face creature, which I believe is the expected behavior.