### PR TITLE
Update long_river_lurker.txt

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/long_river_lurker.txt
+++ b/forge-gui/res/cardsfolder/upcoming/long_river_lurker.txt
@@ -8,7 +8,7 @@ T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.S
 SVar:TrigUnblockable:DB$ Effect | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | RememberObjects$ Targeted | ExileOnMoved$ Battlefield | StaticAbilities$ Unblockable | Triggers$ TrigDamage
 SVar:Unblockable:Mode$ CantBlockBy | ValidAttacker$ Card.IsRemembered | Description$ This creature can't be blocked this turn.
 SVar:TrigDamage:Mode$ DamageDealtOnce | ValidSource$ Creature.IsRemembered | CombatDamage$ True | OptionalDecider$ You | Execute$ TrigExile | TriggerDescription$ Whenever this creature deals combat damage this turn, you may exile it. If you do, return it to the battlefield under its owner's control.
-SVar:TrigExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | RememberChanged$ True | SubAbility$ DBReturn
+SVar:TrigExile:DB$ ChangeZone | Defined$ Remembered | Origin$ Battlefield | Destination$ Exile | RememberChanged$ True | SubAbility$ DBReturn
 SVar:DBReturn:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Battlefield | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Ward {1}\nOther Frogs you control have ward {1}.\nWhen Long River Lurker enters, target creature you control can't be blocked this turn. Whenever that creature deals combat damage this turn, you may exile it. If you do, return it to the battlefield under its owner's control.


### PR DESCRIPTION
The command zone effect trigger was missing a `Defined$` parameter. Tried the head off the overlap with https://github.com/Card-Forge/forge/pull/5867 but unfortunately it doesn't stick if you copy paste into a file while editing on browser. I hope the situation isn't too difficult to address as is.