### PR TITLE
Update planequake.txt

### DIFF
--- a/forge-gui/res/cardsfolder/p/planequake.txt
+++ b/forge-gui/res/cardsfolder/p/planequake.txt
@@ -1,6 +1,6 @@
 Name:Planequake
 ManaCost:X R
 Types:Sorcery
-A:SP$ DamageAll | ValidCards$ Creature.withoutFlying | ValidPlayers$ Player | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to each creature without flying and each planeswalker. If X is 10 or more, open the "Uncovered Cavern" plot booster.
+A:SP$ DamageAll | ValidCards$ Creature.withoutFlying,Planeswalker | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to each creature without flying and each planeswalker. If X is 10 or more, open the "Uncovered Cavern" plot booster.
 SVar:X:Count$xPaid
 Oracle:Planequake deals X damage to each creature without flying and each planeswalker. If X is 10 or more, open the "Uncovered Cavern" plot booster.


### PR DESCRIPTION
As reported, this one was mistakenly dealing damage to players, contrary to its `Oracle:` text.