### PR TITLE
YBLB: Shellfish Scholar, Tasteful Offering, Tempest Trapper, Thought Rattle, Three Tree Battalion, Vigorous Farming

### DIFF
--- a/forge-game/src/main/java/forge/game/card/CardProperty.java
+++ b/forge-game/src/main/java/forge/game/card/CardProperty.java
@@ -674,6 +674,11 @@ public class CardProperty {
             if (cards.isEmpty() || !card.equals(cards.get(0))) {
                 return false;
             }
+        } else if (property.startsWith("TopLibraryLand")) {
+            CardCollection cards = CardLists.filter(card.getOwner().getCardsIn(ZoneType.Library), CardPredicates.Presets.LANDS);
+            if (cards.isEmpty() || !card.equals(cards.get(0))) {
+                return false;
+            }
         } else if (property.startsWith("TopLibrary")) {
             final CardCollectionView cards = card.getOwner().getCardsIn(ZoneType.Library);
             if (cards.isEmpty() || !card.equals(cards.get(0))) {

--- a/forge-gui/res/cardsfolder/upcoming/shellfish_scholar.txt
+++ b/forge-gui/res/cardsfolder/upcoming/shellfish_scholar.txt
@@ -1,0 +1,9 @@
+Name:Shellfish Scholar
+ManaCost:2 U
+Types:Creature Rat Wizard
+PT:3/2
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self,Rat.Other+YouCtrl | Execute$ TrigConjure | TriggerDescription$ Whenever CARDNAME or another Rat you control enters, conjure a card named Think Twice into your graveyard
+SVar:TrigConjure:DB$ MakeCard | Conjure$ True | Name$ Think Twice | Zone$ Graveyard | Amount$ 1
+A:AB$ Effect | Cost$ T | StaticAbilities$ StaticReduce | Activation$ Threshold | PrecostDesc$ Threshold — | SpellDescription$ Spells you cast from your graveyard this turn cost {2} less to cast. Activate only if seven or more cards are in your graveyard.
+SVar:StaticReduce:Mode$ ReduceCost | ValidCard$ Card.wasCastFromYourGraveyard | Type$ Spell | Activator$ You | Amount$ 2 | Description$ Spells you cast from your graveyard this turn cost {2} less to cast.
+Oracle:Whenever Shellfish Scholar or another Rat you control enters, conjure a card named Think Twice into your graveyard.\nThreshold — {T}: Spells you cast from your graveyard this turn cost {2} less to cast. Activate only if seven or more cards are in your graveyard.

--- a/forge-gui/res/cardsfolder/upcoming/tasteful_offering.txt
+++ b/forge-gui/res/cardsfolder/upcoming/tasteful_offering.txt
@@ -1,0 +1,9 @@
+Name:Tasteful Offering
+ManaCost:1 B
+Types:Sorcery
+A:SP$ Effect | Boon$ True | Duration$ Permanent | Triggers$ SacTrig | SubAbility$ DBToken | StackDescription$ REP You get_{p:You} gets & Create a_{p:You} creates a | SpellDescription$ You get a two-time boon with "Whenever you sacrifice one or more permanents, seek a nonland card." Create a Food token.
+SVar:SacTrig:Mode$ SacrificedOnce | ValidCard$ Permanent | ValidPlayer$ You | TriggerZones$ Command | BoonAmount$ 2 | Execute$ TrigSeek | TriggerDescription$ Whenever you sacrifice one or more permanents, seek a nonland card.
+SVar:TrigSeek:DB$ Seek | Num$ 1 | Type$ Card.nonLand
+SVar:DBToken:DB$ Token | TokenScript$ c_a_food_sac
+DeckHas:Ability$LifeGain|Token
+Oracle:You get a two-time boon with "Whenever you sacrifice one or more permanents, seek a nonland card." Create a Food token.

--- a/forge-gui/res/cardsfolder/upcoming/tempest_trapper.txt
+++ b/forge-gui/res/cardsfolder/upcoming/tempest_trapper.txt
@@ -1,0 +1,11 @@
+Name:Tempest Trapper
+ManaCost:3 U
+Types:Creature Otter Wizard
+PT:2/5
+A:AB$ Mana | Cost$ T | Produced$ Combo Any | Amount$ 2 | RestrictValid$ Spell.Instant,Spell.Sorcery | SpellDescription$ Add two mana in any combination of colors. Spend this mana only to cast instant or sorcery spells.
+T:Mode$ SpellCast | ValidCard$ Card.YouCtrl | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigExile | ActivatorThisTurnCast$ EQ3 | TriggerDescription$ Whenever you cast your third spell each turn, exile a random card from your library. Until end of turn, you may play that card without paying its mana cost.
+SVar:TrigExile:DB$ ChangeZone | DefinedPlayer$ You | ChangeType$ Card | ChangeNum$ 1 | Origin$ Library | Destination$ Exile | AtRandom$ True | Hidden$ True | NoLooking$ True | NoShuffle$ True | Mandatory$ True | RememberChanged$ True | SubAbility$ DBEffect
+SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ STPlay | SubAbility$ DBCleanup | ForgetOnMoved$ Exile
+SVar:STPlay:Mode$ Continuous | MayPlay$ True | EffectZone$ Command | Affected$ Card.IsRemembered | MayPlayWithoutManaCost$ True | AffectedZone$ Exile | Description$ You may play remembered card without paying its mana cost.
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:{T}: Add two mana in any combination of colors. Spend this mana only to cast instant or sorcery spells.\nWhenever you cast your third spell each turn, exile a random card from your library. Until end of turn, you may play that card without paying its mana cost.

--- a/forge-gui/res/cardsfolder/upcoming/thought_rattle.txt
+++ b/forge-gui/res/cardsfolder/upcoming/thought_rattle.txt
@@ -1,0 +1,10 @@
+Name:Thought Rattle
+ManaCost:U B
+Types:Sorcery
+A:SP$ Reveal | ValidTgts$ Opponent | RevealAllValid$ Card.nonLand+TargetedPlayerCtrl | RememberRevealed$ True | SubAbility$ DBExile | StackDescription$ REP Target opponent_{p:Targeted} & You choose_{p:You} chooses & Exile_{p:You} exiles & your graveyard_{p:You}'s graveyard & seek_they seek | SpellDescription$ Target opponent reveals each nonland card in their hand. You choose one of those cards. Exile that card. Threshold — If seven or more cards are in your graveyard, seek a Rat card. It perpetually gains "This spell costs 1 less to cast."
+SVar:DBExile:DB$ ChangeZone | Origin$ Hand | Destination$ Exile | DefinedPlayer$ Targeted | Chooser$ You | ChangeType$ Card.nonLand | ChangeTypeDesc$ nonland card | Mandatory$ True | SubAbility$ DBClearRemembered | StackDescription$ None
+SVar:DBClearRemembered:DB$ Cleanup | ClearRemembered$ True | SubAbility$ DBSeek
+SVar:DBSeek:DB$ Seek | Condition$ Threshold | Num$ 1 | Type$ Rat | RememberFound$ True | SubAbility$ DBAnimate | StackDescription$ None
+SVar:DBAnimate:DB$ Animate | Defined$ Remembered | staticAbilities$ ReduceCost | Duration$ Perpetual | StackDescription$ None
+SVar:ReduceCost:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 1 | EffectZone$ All | Description$ This spell costs {1} less to cast.
+Oracle:Target opponent reveals each nonland card in their hand. You choose one of those cards. Exile that card.\nThreshold — If seven or more cards are in your graveyard, seek a Rat card. It perpetually gains "This spell costs 1 less to cast."

--- a/forge-gui/res/cardsfolder/upcoming/three_tree_battalion.txt
+++ b/forge-gui/res/cardsfolder/upcoming/three_tree_battalion.txt
@@ -1,0 +1,8 @@
+Name:Three Tree Battalion
+ManaCost:3 W
+Types:Instant
+A:SP$ Dig | DigNum$ 6 | ChangeNum$ 1 | AILogic$ AtOppEOT | Optional$ True | ChangeValid$ Creature.YouCtrl+cmcLE3 | ChangeValidDesc$ creature card with mana value 3 or less | Reveal$ False | DestinationZone$ Battlefield | DestinationZone2$ Library | LibraryPosition$ -1 | RestRandomOrder$ True | RememberChanged$ True | SubAbility$ DBConjure | StackDescription$ REP Look at_{p:You} looks at & your library_their library & You may_{p:You} may & Put the_{p:You} puts the & your library_their library | SpellDescription$ Look at the top six cards of your library. You may put a creature card with mana value 3 or less from among them onto the battlefield, then conjure a duplicate of that card onto the battlefield. The duplicate perpetually has base power and toughness 1/1. Put the rest on the bottom of your library in a random order.
+SVar:DBConjure:DB$ MakeCard | Conjure$ True | DefinedName$ Remembered | ImprintMade$ True | Zone$ Battlefield | SubAbility$ DBAnimate | StackDescription$ None
+SVar:DBAnimate:DB$ Animate | Defined$ Imprinted | Power$ 1 | Toughness$ 1 | Duration$ Perpetual | SubAbility$ DBCleanup | StackDescription$ None
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearImprinted$ True
+Oracle:Look at the top six cards of your library. You may put a creature card with mana value 3 or less from among them onto the battlefield, then conjure a duplicate of that card onto the battlefield. The duplicate perpetually has base power and toughness 1/1. Put the rest on the bottom of your library in a random order.

--- a/forge-gui/res/cardsfolder/upcoming/vigorous_farming.txt
+++ b/forge-gui/res/cardsfolder/upcoming/vigorous_farming.txt
@@ -1,0 +1,10 @@
+Name:Vigorous Farming
+ManaCost:2 G
+Types:Enchantment
+R:Event$ Moved | ValidCard$ Land.YouCtrl | Destination$ Battlefield | ReplaceWith$ ETBUntapped | ReplacementResult$ Updated | ActiveZones$ Battlefield | Description$ Lands you control enter the battlefield untapped.
+SVar:ETBUntapped:DB$ Untap | ETB$ True | Defined$ ReplacedCard
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigAnimate | TriggerDescription$ At the beginning of your end step, the topmost land card in your library perpetually gains "Whenever this land is tapped for mana, add an additional {G}."
+SVar:TrigAnimate:DB$ Animate | Defined$ Land.TopLibraryLand+YouCtrl | Triggers$ ManaTap | Duration$ Perpetual
+SVar:ManaTap:Mode$ TapsForMana | ValidCard$ Card.Self | Execute$ TrigMana | Static$ True | TriggerDescription$ Whenever this land is tapped for mana, add an additional {G}.
+SVar:TrigMana:DB$ Mana | Produced$ G | Amount$ 1 | Defined$ TriggeredCardController
+Oracle:Lands you control enter the battlefield untapped.\nAt the beginning of your end step, the topmost land card in your library perpetually gains "Whenever this land is tapped for mana, add an additional {G}."

--- a/forge-gui/res/cardsfolder/upcoming/vigorous_farming.txt
+++ b/forge-gui/res/cardsfolder/upcoming/vigorous_farming.txt
@@ -4,7 +4,7 @@ Types:Enchantment
 R:Event$ Moved | ValidCard$ Land.YouCtrl | Destination$ Battlefield | ReplaceWith$ ETBUntapped | ReplacementResult$ Updated | ActiveZones$ Battlefield | Description$ Lands you control enter the battlefield untapped.
 SVar:ETBUntapped:DB$ Untap | ETB$ True | Defined$ ReplacedCard
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigAnimate | TriggerDescription$ At the beginning of your end step, the topmost land card in your library perpetually gains "Whenever this land is tapped for mana, add an additional {G}."
-SVar:TrigAnimate:DB$ Animate | Defined$ Land.TopLibraryLand+YouCtrl | Triggers$ ManaTap | Duration$ Perpetual
+SVar:TrigAnimate:DB$ Animate | Defined$ ValidLibrary Land.TopLibraryLand+YouCtrl | Triggers$ ManaTap | Duration$ Perpetual
 SVar:ManaTap:Mode$ TapsForMana | ValidCard$ Card.Self | Execute$ TrigMana | Static$ True | TriggerDescription$ Whenever this land is tapped for mana, add an additional {G}.
 SVar:TrigMana:DB$ Mana | Produced$ G | Amount$ 1 | Defined$ TriggeredCardController
 Oracle:Lands you control enter the battlefield untapped.\nAt the beginning of your end step, the topmost land card in your library perpetually gains "Whenever this land is tapped for mana, add an additional {G}."


### PR DESCRIPTION
Tested card scripts for these, [as revealed elsewhere](https://imgur.com/a/yblb-cards-AcWuoKt):
- [Shellfish Scholar](https://i.imgur.com/RRwX45r.png)
- [Tasteful Offering](https://i.imgur.com/bOUBRQA.png)
- [Tempest Trapper](https://i.imgur.com/QZi0BPo.png)
- [Three Tree Battalion](https://i.imgur.com/2wzqE6T.png)
- [Thought Rattle](https://i.imgur.com/R7p8a1G.png)
- [Vigorous Farming](https://i.imgur.com/i2tLsaE.png), with the necessary support added to `CardProperty.java`.

~WIP card script for:~
- ~[Vigorous Farming](https://i.imgur.com/i2tLsaE.png)~
• ~While the script doesn't work as it is, I took the pattern from `TopGraveyardCreature` as used in, for instance, [Shallow Grave](https://scryfall.com/card/mir/141/shallow-grave), even if I feel both could be generalized so the positioning can be mixed and matched with other characteristics as necessary, as the game develops further in this regard. I did try to adapt the Java code for `TopGraveyardCreature` into the new `TopLibraryLand` property but that didn't get me very far. The snippet below (placed at line 678 on [CardProperty.java](https://github.com/dracontes/forge/blob/rb-yblb-1/forge-game/src/main/java/forge/game/card/CardProperty.java) ) allows me to single out the right card but then the `Animate` effect isn't applied.~
```
        } else if (property.startsWith("TopLibraryLand")) {
            CardCollection cards = CardLists.filter(card.getOwner().getCardsIn(ZoneType.Library), CardPredicates.Presets.LANDS);
            if (cards.isEmpty() || !card.equals(cards.get(0))) {
                return false;
            }
```