### PR TITLE
Update cackling_observer.txt

### DIFF
--- a/forge-gui/res/cardsfolder/c/cackling_observer.txt
+++ b/forge-gui/res/cardsfolder/c/cackling_observer.txt
@@ -5,7 +5,7 @@ PT:3/1
 K:Flying
 T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigReveal | TriggerDescription$ When CARDNAME enters, target opponent reveals each nonland card in their hand. You choose one of those cards and exile it.
 SVar:TrigReveal:DB$ Reveal | ValidTgts$ Opponent | RevealAllValid$ Card.nonLand+TargetedPlayerCtrl | RememberRevealed$ True | SubAbility$ DBExile
-SVar:DBExile:DB$ ChangeZone | Origin$ Hand | Destination$ Exile | DefinedPlayer$ Targeted | Chooser$ You | ChangeType$ Card.nonLand+nonCreature | Imprint$ True | Mandatory$ True | SubAbility$ DBClearRemembered
+SVar:DBExile:DB$ ChangeZone | Origin$ Hand | Destination$ Exile | DefinedPlayer$ Targeted | Chooser$ You | ChangeType$ Card.IsRemembered | Imprint$ True | Mandatory$ True | SubAbility$ DBClearRemembered
 SVar:DBClearRemembered:DB$ Cleanup | ClearRemembered$ True
 T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Battlefield | Destination$ Any | Execute$ TrigSeek | TriggerDescription$ When CARDNAME leaves the battlefield, the exiled card's owner seeks a nonland card with lesser mana value than the exiled card.
 SVar:TrigSeek:DB$ Seek | Defined$ ImprintedController | Type$ Card.cmcLTX | SubAbility$ DBCleanup


### PR DESCRIPTION
The `SVar:DBExile` line was restricting what could be exiled to less than the nonland cards revealed in target opponent's hand.