### PR TITLE
Update oracle_en_vec.txt

### DIFF
--- a/forge-gui/res/cardsfolder/o/oracle_en_vec.txt
+++ b/forge-gui/res/cardsfolder/o/oracle_en_vec.txt
@@ -2,12 +2,12 @@ Name:Oracle en-Vec
 ManaCost:1 W
 Types:Creature Human Wizard
 PT:1/1
-A:AB$ ChooseCard | Cost$ T | ValidTgts$ Player.Opponent | MinAmount$ 0 | Amount$ X | Choices$ Creature | TargetControls$ True | ChoiceTitle$ Choose any number of creatures you control | PlayerTurn$ True | Reveal$ True | AILogic$ NextTurnAttacker | SubAbility$ DBOracleEffect | StackDescription$ SpellDescription | SpellDescription$ Target opponent chooses any number of creatures they control. During that player's next turn, the chosen creatures attack if able, and other creatures can't attack. At the beginning of that turn's end step, destroy each of the chosen creatures that didn't attack this turn. Activate only during your turn.
+A:AB$ ChooseCard | Cost$ T | ValidTgts$ Opponent | MinAmount$ 0 | Amount$ X | Choices$ Creature | TargetControls$ True | ChoiceTitle$ Choose any number of creatures you control | PlayerTurn$ True | Reveal$ True | RevealTitle$ Creatures chosen by opponent. | AILogic$ NextTurnAttacker | SubAbility$ DBOracleEffect | StackDescription$ REP Target opponent_{p:Targeted} & that player's_{p:Targeted}'s & . Activate only during your turn._. | SpellDescription$ Target opponent chooses any number of creatures they control. During that player's next turn, the chosen creatures attack if able, and other creatures can't attack. At the beginning of that turn's end step, destroy each of the chosen creatures that didn't attack this turn. Activate only during your turn.
 SVar:X:Count$Valid Creature.TargetedPlayerCtrl
 SVar:DBOracleEffect:DB$ Effect | EffectOwner$ TargetedPlayer | StaticAbilities$ ForceAttack,ForbidAttack | Triggers$ TrigDestroy | Duration$ UntilTheEndOfYourNextTurn | SubAbility$ DBCleanup
-SVar:ForceAttack:Mode$ MustAttack | EffectZone$ Command | AffectedZone$ Battlefield | ValidCreature$ Creature.YouCtrl+ChosenCard | Description$ During that player's next turn, the chosen creatures attack if able, and other creatures can't attack.
-SVar:ForbidAttack:Mode$ CantAttack | EffectZone$ Command | ValidCard$ Creature.YouCtrl+nonChosenCard | Description$ CARDNAME can't attack.
-SVar:TrigDestroy:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Command | Execute$ DBDestroy | TriggerDescription$ At the beginning of that turn's end step, destroy each of the chosen creatures that didn't attack this turn.
-SVar:DBDestroy:DB$ DestroyAll | ValidCards$ Creature.ChosenCard+notAttackedThisTurn
+SVar:ForceAttack:Mode$ MustAttack | EffectZone$ Command | AffectedZone$ Battlefield | ValidCreature$ Creature.YouCtrl+ChosenCardStrict | Description$ During your next turn, creatures chosen with EFFECTSOURCE attack if able.
+SVar:ForbidAttack:Mode$ CantAttack | EffectZone$ Command | ValidCard$ Creature.YouCtrl+!ChosenCardStrict | Description$ During your next turn, creatures NOT chosen with EFFECTSOURCE can't attack.
+SVar:TrigDestroy:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Command | Execute$ DBDestroy | TriggerDescription$ At the beginning of your next turn's end step, destroy each creature chosen with EFFECTSOURCE that didn't attack that turn.
+SVar:DBDestroy:DB$ DestroyAll | ValidCards$ Creature.ChosenCardStrict+notAttackedThisTurn
 SVar:DBCleanup:DB$ Cleanup | ClearChosenCard$ True
 Oracle:{T}: Target opponent chooses any number of creatures they control. During that player's next turn, the chosen creatures attack if able, and other creatures can't attack. At the beginning of that turn's end step, destroy each of the chosen creatures that didn't attack this turn. Activate only during your turn.


### PR DESCRIPTION
Closes https://github.com/Card-Forge/forge/issues/5290 .

The issue was that the effect created by Oracle en-Vec's activated ability was referring to the chosen creatures by `ChosenCard` which doesn't forget the chosen creature if it changes zones, hence why in the bug report the chosen, recast commander was affected by the end of turn trigger. As suggested in further discussion, `ChosenCardStrict` resolves this issue.
I also took the opportunity to clean up the script a bit, namely the `StackDescription` and` Description`s for the effect's abilities.