### PR TITLE
Fix AI for cards like Shatterskull Smashing and Fireball

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/DamageDealAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DamageDealAi.java
@@ -95,8 +95,8 @@ public class DamageDealAi extends DamageAiBase {
         final String damage = sa.getParam("NumDmg");
         int dmg = AbilityUtils.calculateAmount(source, damage, sa);
 
-        if (damage.equals("X") || sourceName.equals("Crater's Claws")) {
-            if (sa.getSVar(damage).equals("Count$xPaid") || sourceName.equals("Crater's Claws")) {
+        if (damage.equals("X") || source.getSVar("X").equals("Count$xPaid") || sourceName.equals("Crater's Claws")) {
+            if (sa.getSVar("X").equals("Count$xPaid") || sa.getSVar(damage).equals("Count$xPaid") || sourceName.equals("Crater's Claws")) {
                 dmg = ComputerUtilCost.getMaxXValue(sa, ai, sa.isTrigger());
 
                 // Try not to waste spells like Blaze or Fireball on early targets, try to do more damage with them if possible

--- a/forge-ai/src/main/java/forge/ai/ability/ScryAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ScryAi.java
@@ -26,7 +26,7 @@ public class ScryAi extends SpellAbilityAi {
      */
     @Override
     protected boolean doTriggerAINoCost(Player ai, SpellAbility sa, boolean mandatory) {
-        if (sa.usesTargeting()) { // It doesn't appear that Scry ever targets
+        if (sa.usesTargeting()) {
             // ability is targeted
             sa.resetTargets();
 
@@ -130,6 +130,22 @@ public class ScryAi extends SpellAbilityAi {
 
         if (playReusable(ai, sa)) {
             randomReturn = true;
+        }
+
+        if (sa.usesTargeting()) {
+            if (sa.canTarget(ai)) {
+                sa.resetTargets();
+                sa.getTargets().add(ai);
+            } else {
+                for (Player p : ai.getAllies()) {
+                    if (sa.canTarget(p)) {
+                        sa.resetTargets();
+                        sa.getTargets().add(p);
+                        break;
+                    }
+                }
+            }
+            randomReturn = sa.isTargetNumberValid();
         }
 
         return randomReturn;

--- a/forge-ai/src/main/java/forge/ai/ability/ScryAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ScryAi.java
@@ -30,7 +30,25 @@ public class ScryAi extends SpellAbilityAi {
             // ability is targeted
             sa.resetTargets();
 
-            sa.getTargets().add(ai);
+            if (sa.canTarget(ai)) {
+                sa.getTargets().add(ai);
+            } else {
+                for (Player p : ai.getAllies()) {
+                    if (sa.canTarget(p)) {
+                        sa.getTargets().add(p);
+                        break;
+                    }
+                }
+                if (mandatory && !sa.isTargetNumberValid()) {
+                    for (Player p : ai.getOpponents()) {
+                        if (sa.canTarget(p)) {
+                            sa.getTargets().add(p);
+                            break;
+                        }
+                    }
+                }
+            }
+            return mandatory || sa.isTargetNumberValid();
         }
 
         return true;
@@ -133,13 +151,12 @@ public class ScryAi extends SpellAbilityAi {
         }
 
         if (sa.usesTargeting()) {
+            sa.resetTargets();
             if (sa.canTarget(ai)) {
-                sa.resetTargets();
                 sa.getTargets().add(ai);
             } else {
                 for (Player p : ai.getAllies()) {
                     if (sa.canTarget(p)) {
-                        sa.resetTargets();
                         sa.getTargets().add(p);
                         break;
                     }


### PR DESCRIPTION
Closes #5899

It looks like the implementation for cards like that has changed, which led to the AI not understanding them anymore. This seems to fix e.g. Shatterskull Smashing and Fireball, but I'm not sure what to do about the other if branches below (e.g. InYourHand etc.), do they need some form of tweaking too?