### PR TITLE
Improve AI for Searing Blaze

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/DamageDealAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DamageDealAi.java
@@ -723,6 +723,7 @@ public class DamageDealAi extends DamageAiBase {
             if (sa.canTarget(enemy) && sa.canAddMoreTarget()) {
                 if ((phase.is(PhaseType.END_OF_TURN) && phase.getNextTurn().equals(ai))
                         || (isSorcerySpeed(sa, ai) && phase.is(PhaseType.MAIN2))
+                        || ("BurnCreatures".equals(logic) && !enemy.getCreaturesInPlay().isEmpty())
                         || immediately) {
                     boolean pingAfterAttack = "PingAfterAttack".equals(logic) && phase.getPhase().isAfter(PhaseType.COMBAT_DECLARE_ATTACKERS) && phase.isPlayerTurn(ai);
                     boolean isPWAbility = sa.isPwAbility() && sa.getPayCosts().hasSpecificCostType(CostPutCounter.class);

--- a/forge-gui/res/cardsfolder/s/searing_blaze.txt
+++ b/forge-gui/res/cardsfolder/s/searing_blaze.txt
@@ -1,7 +1,7 @@
 Name:Searing Blaze
 ManaCost:R R
 Types:Instant
-A:SP$ DealDamage | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | NumDmg$ SearingX | DamageMap$ True | SubAbility$ SearingDamage | SpellDescription$ CARDNAME deals 1 damage to target player or planeswalker and 1 damage to target creature that player or that planeswalker's controller controls. Landfall — If you had a land enter the battlefield under your control this turn, CARDNAME deals 3 damage to that player or planeswalker and 3 damage to that creature instead.
+A:SP$ DealDamage | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | NumDmg$ SearingX | DamageMap$ True | SubAbility$ SearingDamage | AILogic$ BurnCreatures | SpellDescription$ CARDNAME deals 1 damage to target player or planeswalker and 1 damage to target creature that player or that planeswalker's controller controls. Landfall — If you had a land enter the battlefield under your control this turn, CARDNAME deals 3 damage to that player or planeswalker and 3 damage to that creature instead.
 SVar:SearingDamage:DB$ DealDamage | ValidTgts$ Creature.ControlledBy ParentTargetedController,Creature.ControlledBy ParentTarget | TgtPrompt$ Select target creature that player or that planeswalker's controller controls | NumDmg$ SearingX | SubAbility$ DBDamageResolve
 SVar:DBDamageResolve:DB$ DamageResolve
 SVar:SearingX:Count$Landfall.3.1


### PR DESCRIPTION
This aims to improve AI for Searing Blaze so it doesn't limit itself too much with targeting the player specifically, aiming more at the creatures rather than the player's face. Fixes #3997. Not sure if there need to be any preferences for the phase at which this is done, currently the AI will consider it when able.