### PR TITLE
27 cards from 2024 Unknown Events (1 is in mystery booster 2)

### DIFF
--- a/forge-gui/res/cardsfolder/a/ateoclock.txt
+++ b/forge-gui/res/cardsfolder/a/ateoclock.txt
@@ -2,7 +2,7 @@ Name:Ate-o'-Clock
 ManaCost:2 G
 Types:Instant
 K:Replicate:2 G
-A:SP$ CopyPermanent | Choices$ Creature.token+YouCtrl | NumCopies$ 1 | Populate$ True | SubAbility$ DBProlif | StackDescription$ SpellDescription | SpellDescription$ Populate.
+A:SP$ CopyPermanent | Choices$ Creature.token+YouCtrl | NumCopies$ 1 | Populate$ True | SubAbility$ DBProlif | SpellDescription$ Populate. Proliferate. Investigate. Regenerate target creature.
 SVar:DBProlif:DB$ Proliferate | SubAbility$ DBInvestigate
 SVar:DBInvestigate:DB$ Investigate | SubAbility$ DBRegen
 SVar:DBRegen:DB$ Regenerate | ValidTgts$ Creature | TgtPrompt$ Select target creature

--- a/forge-gui/res/cardsfolder/a/ateoclock.txt
+++ b/forge-gui/res/cardsfolder/a/ateoclock.txt
@@ -1,0 +1,11 @@
+Name:Ate-o'-Clock
+ManaCost:2 G
+Types:Instant
+K:Replicate:2 G
+A:SP$ CopyPermanent | Choices$ Creature.token+YouCtrl | NumCopies$ 1 | Populate$ True | SubAbility$ DBProlif | StackDescription$ SpellDescription | SpellDescription$ Populate.
+SVar:DBProlif:DB$ Proliferate | SubAbility$ DBInvestigate
+SVar:DBInvestigate:DB$ Investigate | SubAbility$ DBRegen
+SVar:DBRegen:DB$ Regenerate | ValidTgts$ Creature | TgtPrompt$ Select target creature
+DeckHas:Ability$Proliferate
+DeckHints:Ability$Token|Counters
+Oracle:Populate. Proliferate. Investigate.\nRegenerate target creature.\nReplicate {2}{G} (When you cast this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copy.)

--- a/forge-gui/res/cardsfolder/b/black_tulip.txt
+++ b/forge-gui/res/cardsfolder/b/black_tulip.txt
@@ -1,0 +1,5 @@
+Name:Black Tulip
+ManaCost:0
+Types:Artifact
+A:AB$ Mana | Cost$ T Exile<1/CARDNAME> | Produced$ Any | Amount$ 3 | AILogic$ BlackLotus | CheckSVar$ Count$YourTurns | SVarCompare$ GE6 | SpellDescription$ Add three mana of any one color. You can't activate this ability until you've begun your sixth turn of the game (Keep track if this is in your deck!)
+Oracle:{T}, Exile Black Tulip: Add three mana of any one color. You can't activate this ability until you've begun your sixth turn of the game (Keep track if this is in your deck!)

--- a/forge-gui/res/cardsfolder/b/bloodsplatter_vampire.txt
+++ b/forge-gui/res/cardsfolder/b/bloodsplatter_vampire.txt
@@ -1,0 +1,8 @@
+Name:Bloodspatter Vampire
+ManaCost:1 B
+Types:Creature Vampire
+PT:2/1
+K:Flying
+R:Event$ CreateToken | ActiveZones$ Battlefield | ValidPlayer$ Opponent | ValidToken$ Clue | ReplaceWith$ TokenReplace | Description$ If an opponent would create a Clue, they create a Blood instead.
+SVar:TokenReplace:DB$ ReplaceToken | Type$ ReplaceToken | ValidCard$ Clue | TokenScript$ c_a_blood_draw
+Oracle:Flying\nIf an opponent would create a Clue, they create a Blood instead. (It's an artifact with {1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.)

--- a/forge-gui/res/cardsfolder/d/deep_dish_pizza.txt
+++ b/forge-gui/res/cardsfolder/d/deep_dish_pizza.txt
@@ -1,0 +1,9 @@
+Name:Deep Dish Pizza
+ManaCost:no cost
+Types:Artifact Food
+K:Suspend:2:2
+A:AB$ GainLife | Cost$ 2 T Sac<1/CARDNAME> | LifeAmount$ 3 | SubAbility$ DBDraw | SpellDescription$ Gain 3 life, draw three cards, and CARDNAME deals 3 damage to each opponent.
+SVar:DBDraw:DB$ Draw | NumCards$ 3 | SubAbility$ DBDamage
+SVar:DBDamage:DB$ DealDamage | Defined$ Opponent | NumDmg$ 3
+DeckHas:Ability$LifeGain|Sacrifice
+Oracle:Suspend 2—{2} (Deep Dish Pizza has no mana cost and must be suspended.)\n{2}, {T}, Sacrifice Deep Dish Pizza: Gain 3 life, draw three cards, and Deep Dish Pizza deals 3 damage to each opponent. 

--- a/forge-gui/res/cardsfolder/d/disguise_agent.txt
+++ b/forge-gui/res/cardsfolder/d/disguise_agent.txt
@@ -1,0 +1,6 @@
+Name:Disguise Agent
+ManaCost:1 U
+Types:Creature Vedalken Detective
+PT:1/3
+S:Mode$ Continuous | Affected$ Card.YouOwn+IsCommander | AffectedZone$ Battlefield,Hand,Graveyard,Exile,Stack,Library,Command | AddKeyword$ Disguise:CardManaCost | Description$ Commanders you own have disguise. Their disguise cost is equal to their mana cost.
+Oracle:Commanders you own have disguise. Their disguise cost is equal to their mana cost.

--- a/forge-gui/res/cardsfolder/e/elemental_my_dear.txt
+++ b/forge-gui/res/cardsfolder/e/elemental_my_dear.txt
@@ -1,0 +1,12 @@
+Name:Elemental, My Dear
+ManaCost:X U U
+Types:Sorcery
+A:SP$ Investigate | Num$ X | SubAbility$ DBToken | SpellDescription$ Investigate X times, then create an 0/0 Blue Elemental creature token.
+SVar:DBToken:DB$ Token | TokenScript$ u_0_0_elemental | RememberTokens$ True | SubAbility$ DBPutCounters
+SVar:DBPutCounters:DB$ PutCounter | Defined$ Remembered | CounterType$ P1P1 | CounterNum$ Y | StackDescription$ SpellDescription | SubAbility$ DBCleanup | SpellDescription$ Put +1/+1 counters on that token equal to the number of Clues you control.
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:X:Count$xPaid
+SVar:Y:Count$Valid Clue.YouCtrl
+DeckHas:Ability$Token|Counters & Type$Elemental|Clue
+DeckHints:Type$Clue
+Oracle:Investigate X times, then create an 0/0 Blue Elemental creature token. Put +1/+1 counters on that token equal to the number of Clues you control.

--- a/forge-gui/res/cardsfolder/h/halving_season.txt
+++ b/forge-gui/res/cardsfolder/h/halving_season.txt
@@ -1,0 +1,9 @@
+Name:Halving Season
+ManaCost:4 B
+Types:Enchantment
+R:Event$ CreateToken | ActiveZones$ Battlefield | ValidToken$ Card.OppCtrl | ReplaceWith$ HalveToken | EffectOnly$ True | Description$ If an opponent would create one or more tokens, they create half that many of each of those kinds of tokens instead, rounded down.
+SVar:HalveToken:DB$ ReplaceToken | Type$ Amount | Amount$ HalfDown | ValidCard$ Card.OppCtrl
+R:Event$ AddCounter | ActiveZones$ Battlefield | ValidSource$ Opponent | ValidObject$ Permanent.inZoneBattlefield,Player | ReplaceWith$ HalfCounters | Description$ If an opponent would put one or more counters on a permanent or player, they put half that many of each of those kinds of counters on that permanent or player instead, rounded down.
+SVar:HalfCounters:DB$ ReplaceCounter | ValidSource$ Opponent | Amount$ Y
+SVar:Y:ReplaceCount$CounterNum/HalfDown
+Oracle:If an opponent would create one or more tokens, they create half that many of each of those kinds of tokens instead, rounded down.\nIf an opponent would put one or more counters on a permanent or player, they put half that many of each of those kinds of counters on that permanent or player instead, rounded down.

--- a/forge-gui/res/cardsfolder/k/karlovs_crossbow.txt
+++ b/forge-gui/res/cardsfolder/k/karlovs_crossbow.txt
@@ -1,0 +1,10 @@
+Name:Karlov's Crossbow
+ManaCost:5
+Types:Artifact Equipment
+T:Mode$ Attacks | ValidCard$ Card.EquippedBy | Execute$ TrigSac | TriggerDescription$ Whenever equipped creature attacks, sacrifice CARDNAME and destroy target creature an opponent controls.
+SVar:TrigSac:DB$ Sacrifice | SubAbility$ DBDestroy
+SVar:DBDestroy:DB$ Destroy | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls.
+K:Equip:1
+A:AB$ Effect | Cost$ 0 Reveal<1/CARDNAME> | Forecast$ True | Name$ Emblem — Karlov's Crossbow | StaticAbilities$ ReduceCost | Duration$ Permanent | AILogic$ Always | SpellDescription$ For the remainder of the game, spells you cast named Karlov's Crossbow cost {1} less to cast. (Activate only during your upkeep and only once each turn.)
+SVar:ReduceCost:Mode$ ReduceCost | ValidCard$ Card.namedKarlov's Crossbow | Type$ Spell | Activator$ You | Amount$ 1 | Description$ Spells you cast named Karlov's Crossbow cost {1} less to cast.
+Oracle:Whenever equipped creature attacks, sacrifice Karlov's Crossbow and destroy target creature an opponent controls.\nEquip {1}\nForecast — {0}, Reveal Karlov's Crossbow from your hand: For the remainder of the game, spells you cast named Karlov's Crossbow cost {1} less to cast. (Activate only during your upkeep and only once each turn.)

--- a/forge-gui/res/cardsfolder/l/leisure_bicycle.txt
+++ b/forge-gui/res/cardsfolder/l/leisure_bicycle.txt
@@ -1,0 +1,11 @@
+Name:Leisure Bicycle
+ManaCost:2
+Types:Artifact Vehicle
+PT:3/1
+K:Crew:1
+K:Cycling:2
+T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigExplore | TriggerDescription$ Whenever CARDNAME attacks, target creature that crewed it this turn explores.
+SVar:TrigExplore:DB$ Explore | ValidTgts$ Creature.CrewedThisTurn | TgtPrompt$ Select target creature that crewed it this turn
+DeckHas:Ability$Counters|Discard
+SVar:HasAttackEffect:TRUE
+Oracle:Whenever Leisure Bicycle attacks, target creature that crewed it this turn explores.\nCrew 1\nCycling {2}

--- a/forge-gui/res/cardsfolder/p/primetime_suspect.txt
+++ b/forge-gui/res/cardsfolder/p/primetime_suspect.txt
@@ -1,0 +1,11 @@
+Name:Primetime Suspect
+ManaCost:1 G
+Types:Enchantment Aura
+K:Enchant creature
+A:SP$ Attach | ValidTgts$ Creature | AILogic$ Pump
+T:Mode$ Attacks | ValidCard$ Card.AttachedBy | Execute$ TrigChange | TriggerZones$ Battlefield | OptionalDecider$ You | TriggerDescription$ Whenever enchanted creature attacks, you may search your library for a land card, put that card onto the battlefield tapped, then shuffle. If enchanted creature is suspected, you search for two lands instead.
+SVar:TrigChange:DB$ ChangeZone | Origin$ Library | Destination$ Battlefield | Tapped$ True | ChangeType$ Land | ChangeNum$ X | ShuffleNonMandatory$ True
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddSVar$ AE
+SVar:X:Count$Valid Creature.EnchantedBy+IsSuspected/Plus.1
+SVar:AE:SVar:HasAttackEffect:TRUE
+Oracle:Enchant creature\nWhenever enchanted creature attacks, you may search your library for a land card, put that card onto the battlefield tapped, then shuffle. If enchanted creature is suspected, you search for two lands instead.

--- a/forge-gui/res/cardsfolder/s/simic_slaw.txt
+++ b/forge-gui/res/cardsfolder/s/simic_slaw.txt
@@ -1,0 +1,10 @@
+Name:Simic Slaw
+ManaCost:2
+Types:Artifact Food Clue
+T:Mode$ ChangesZoneAll | TriggerZones$ Battlefield | ValidCards$ Creature | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigCounter | TriggerDescription$ Whenever one or more creatures die, put a charge counter on CARDNAME.
+SVar:TrigCounter:DB$ PutCounter | CounterType$ CHARGE
+A:AB$ Draw | Cost$ 2 Sac<1/CARDNAME> | NumCards$ X | SubAbility$ DBLife | SpellDescription$ Draw X cards and gain X life, where X is the number of charge counters on CARDNAME.
+SVar:DBLife:DB$ GainLife | LifeAmount$ X
+SVar:X:Count$CardCounters.CHARGE
+DeckHas:Ability$LifeGain|Sacrifice|Counters
+Oracle:Whenever one or more creatures die, put a charge counter on Simic Slaw.\n{2}, Sacrifice Simic Slaw: Draw X cards and gain X life, where X is the number of charge counters on Simic Slaw. 

--- a/forge-gui/res/cardsfolder/t/the_bear_force_pilot.txt
+++ b/forge-gui/res/cardsfolder/t/the_bear_force_pilot.txt
@@ -1,0 +1,9 @@
+Name:The Bear Force Pilot
+ManaCost:1 G
+Types:Legendary Creature Bear Pilot
+PT:2/2
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters the battlefield, create a colorless artifact Vehicle token with flying, "This creature gets +1/+1 for each Bear you control," and Crew 2.
+SVar:TrigToken:DB$ Token | TokenScript$ bear_force_one
+DeckHas:Ability$Token & Type$Artifact|Vehicle
+DeckHints:Type$Bear
+Oracle:When The Bear Force Pilot enters the battlefield, create a colorless artifact Vehicle token with flying, "This creature gets +1/+1 for each Bear you control," and Crew 2.

--- a/forge-gui/res/cardsfolder/t/the_crafter.txt
+++ b/forge-gui/res/cardsfolder/t/the_crafter.txt
@@ -1,0 +1,12 @@
+Name:The Crafter
+ManaCost:3 R
+Types:Legendary Artifact Creature Human
+PT:3/4
+K:Affinity:Artifact
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters the battlefield, create two colorless Scrap artifact tokens (They have no abilities.)
+SVar:TrigToken:DB$ Token | TokenAmount$ 2 | TokenScript$ scrap
+A:AB$ Token | Cost$ T Sac<1/Artifact> | TokenScript$ bling | SpellDescription$ Create an equipment token named Bling with "Equipped creature gets +1/+0" and "Equip {1}."
+SVar:AIPreference:SacCost$Artifact.nonCreature+nonEquipment+Token+powerLE1+toughnessEQ1
+DeckHas:Ability$Token|Sacrifice & Type$Equipment
+DeckHints:Type$Artifact
+Oracle:Affinity for artifacts\nWhen The Crafter enters the battlefield, create two colorless Scrap artifact tokens (They have no abilities.)\n{T}, Sacrifice an artifact: Create an equipment token named Bling with "Equipped creature gets +1/+0" and "Equip {1}."

--- a/forge-gui/res/cardsfolder/t/the_crimson_avenger.txt
+++ b/forge-gui/res/cardsfolder/t/the_crimson_avenger.txt
@@ -1,0 +1,13 @@
+Name:The Crimson Avenger
+ManaCost:3 R R
+Types:Legendary Creature Human Wizard
+PT:3/2
+K:Flash
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChoose | TriggerDescription$ When CARDNAME enters the battlefield, choose target spell an opponent controls. Reveal cards from the top of your library until you reveal a card that shares a mana value with it. Cast that card without paying its mana cost. Then shuffle your library.
+SVar:TrigChoose:DB$ Pump | TargetType$ Spell | TgtZone$ Stack | ValidTgts$ Card.OppCtrl | TgtPrompt$ Select target spell an opponent controls | SubAbility$ CrimsonCascade
+SVar:CrimsonCascade:DB$ DigUntil | Defined$ You | Amount$ 1 | Valid$ Card.cmcEQX | NoMoveRevealed$ True | RememberFound$ True | SubAbility$ CascadeCast
+SVar:CascadeCast:DB$ Play | Defined$ Remembered | WithoutManaCost$ True | ValidSA$ Spell | SubAbility$ YouShuffle
+SVar:YouShuffle:DB$ Shuffle | Defined$ You | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:X:Targeted$CardManaCost
+Oracle:Flash\nWhen The Crimson Avenger enters the battlefield, choose target spell an opponent controls. Reveal cards from the top of your library until you reveal a card that shares a mana value with it. Cast that card without paying its mana cost. Then shuffle your library.

--- a/forge-gui/res/cardsfolder/t/the_duke_of_midrange.txt
+++ b/forge-gui/res/cardsfolder/t/the_duke_of_midrange.txt
@@ -1,0 +1,13 @@
+Name:The Duke of Midrange
+ManaCost:2 B R G
+Types:Legendary Creature Lhurgoyf Wizard
+PT:*/1+*
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChoose | TriggerDescription$ When CARDNAME enters the battlefield, choose one of Thoughtseize, Lightning Bolt, or Abrupt Decay. Cast a copy of the chosen card without paying its mana cost.
+SVar:TrigChoose:DB$ NameCard | Defined$ You | ChooseFromList$ Thoughtseize,Lightning Bolt,Abrupt Decay | SubAbility$ DBCast
+SVar:DBCast:DB$ Play | CopyFromChosenName$ True | WithoutManaCost$ True | StackDescription$ None
+S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ Y | Description$ CARDNAME's power is equal to the number of card types among all cards in all graveyards, and its toughness is equal to that number plus 1.
+SVar:X:Count$ValidGraveyard Card$CardTypes
+SVar:Y:SVar$X/Plus.1
+SVar:PlayMain1:TRUE
+DeckHints:Ability$Graveyard
+Oracle:When The Duke of Midrange enters the battlefield, choose one of Thoughtseize, Lightning Bolt, or Abrupt Decay. Cast a copy of the chosen card without paying its mana cost.\nThe Duke of Midrange's power is equal to the number of card types among all cards in all graveyards, and its toughness is equal to that number plus 1.

--- a/forge-gui/res/cardsfolder/t/the_great_juggernaut.txt
+++ b/forge-gui/res/cardsfolder/t/the_great_juggernaut.txt
@@ -1,0 +1,13 @@
+Name:The Great Juggernaut
+ManaCost:3 R
+Types:Legendary Artifact Creature Juggernaut
+PT:5/3
+K:UpkeepCost:Discard<1/Card>
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigShuffle | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME attacks, shuffle your library then exile the top card of your library. You may play that card without paying its mana cost this turn.
+SVar:TrigShuffle:DB$ Shuffle | Defined$ You | SubAbility$ DBExile
+SVar:DBExile:DB$ Dig | Defined$ You | DigNum$ 1 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBEffect
+SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ DBPlay | SubAbility$ DBCleanup | ExileOnMoved$ Exile
+SVar:DBPlay:Mode$ Continuous | MayPlay$ True | MayPlayWithoutManaCost$ True | EffectZone$ Command | Affected$ Card.IsRemembered | AffectedZone$ Exile | Description$ You may play the exiled card without paying its mana cost.
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:HasAttackEffect:TRUE
+Oracle:At the beginning of your upkeep, sacrifice The Great Juggernaut unless you discard a card.\nWhenever The Great Juggernaut attacks, shuffle your library then exile the top card of your library. You may play that card without paying its mana cost this turn.

--- a/forge-gui/res/cardsfolder/t/the_juzam_master.txt
+++ b/forge-gui/res/cardsfolder/t/the_juzam_master.txt
@@ -1,0 +1,9 @@
+Name:The Juzam Master
+ManaCost:2 B B
+Types:Legendary Creature Human Wizard
+PT:4/5
+S:Mode$ Continuous | Affected$ Creature.YouCtrl | AddPower$ 1 | AddTrigger$ JuzamTrigger | Description$ Creatures you control get +1/+0 and have "At the beginning of your upkeep, this creature deals 1 damage to you."
+SVar:JuzamTrigger:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDealDamage | TriggerDescription$ At the beginning of your upkeep, this creature deals 1 damage to you.
+SVar:TrigDealDamage:DB$ DealDamage | Defined$ You | NumDmg$ 1
+SVar:PlayMain1:TRUE
+Oracle:Creatures you control get +1/+0 and have "At the beginning of your upkeep, this creature deals 1 damage to you."

--- a/forge-gui/res/cardsfolder/t/the_keeper_of_dark_pacts.txt
+++ b/forge-gui/res/cardsfolder/t/the_keeper_of_dark_pacts.txt
@@ -1,0 +1,11 @@
+Name:The Keeper of Dark Pacts
+ManaCost:4 B
+Types:Legendary Creature Human Wizard
+PT:4/4
+K:Starting intensity:1
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigLoseLife | TriggerDescription$ At the beginning of your upkeep, you lose 1 life and draw a card. Then, double the amount of life you lose and cards you draw for the rest of the game from this ability. (This is true even if this leaves the battlefield and returns.)
+SVar:TrigLoseLife:DB$ LoseLife | Defined$ You | LifeAmount$ X | SubAbility$ DBDraw
+SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ X | SubAbility$ DBIntensify
+SVar:DBIntensify:DB$ Intensify | Amount$ X
+SVar:X:Count$Intensity
+Oracle:At the beginning of your upkeep, you lose 1 life and draw a card. Then, double the amount of life you lose and cards you draw for the rest of the game from this ability. (This is true even if this leaves the battlefield and returns.)

--- a/forge-gui/res/cardsfolder/t/the_keeper_of_the_yellow_hat.txt
+++ b/forge-gui/res/cardsfolder/t/the_keeper_of_the_yellow_hat.txt
@@ -1,0 +1,9 @@
+Name:The Keeper of the Yellow Hat
+ManaCost:W U
+Types:Legendary Creature Human Wizard
+PT:1/1
+S:Mode$ CantBeCast | ValidCard$ Card.Self | EffectZone$ All | Caster$ Player.Active | CheckSVar$ Count$YourTurns | SVarCompare$ LE7 | Description$ You can't cast CARDNAME during your first seven turns of the game. (Keep track if you're playing with this!)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters the battlefield, create a legendary artifact equipment token named Yellow Hat with equip {2} and "Equiped creature gets +4/+4 and gains lifelink."
+SVar:TrigToken:DB$ Token | TokenScript$ yellow_hat
+DeckHas:Ability$Token & Type$Artifact|Equipment
+Oracle:You can't cast Keeper of the Yellow Hat during your first seven turns of the game. (Keep track if you're playing with this!)\nWhen The Keeper of the Yellow Hat enters the battlefield, create a legendary artifact equipment token named Yellow Hat with equip {2} and "Equiped creature gets +4/+4 and gains lifelink."

--- a/forge-gui/res/cardsfolder/t/the_magic_bandit.txt
+++ b/forge-gui/res/cardsfolder/t/the_magic_bandit.txt
@@ -1,0 +1,14 @@
+Name:The Magic Bandit
+ManaCost:3 B
+Types:Legendary Creature Human Rogue
+PT:3/2
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigDig | TriggerZones$ Battlefield | TriggerDescription$ When CARDNAME deals combat damage to an opponent, exile the top card of that player's library. You may cast that card for as long as it remains exiled, and mana of any type can be spent to cast that spell.
+SVar:TrigDig:DB$ Dig | DigNum$ 1 | Defined$ TriggeredTarget | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBEffect
+SVar:DBEffect:DB$ Effect | RememberObjects$ Remembered | StaticAbilities$ STPlay | Duration$ Permanent | ForgetOnMoved$ Exile | SubAbility$ DBCleanup
+SVar:STPlay:Mode$ Continuous | MayPlay$ True | MayPlayIgnoreType$ True | EffectZone$ Command | Affected$ Card.IsRemembered+nonLand | AffectedZone$ Exile | Description$ You may cast that card for as long as it remains exiled, and mana of any type can be spent to cast that spell.
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+T:Mode$ SpellCast | ValidCard$ Card.YouDontOwn | ValidActivatingPlayer$ You | Execute$ TrigCopySpell | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a spell or play a land you don't own, copy it.
+SVar:TrigCopySpell:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility
+T:Mode$ LandPlayed | ValidCard$ Land.YouCtrl+YouDontOwn | TriggerZones$ Battlefield | Execute$ TrigCopyLand | Secondary$ True | TriggerDescription$ Whenever you cast a spell or play a land you don't own, copy it.
+SVar:TrigCopyLand:DB$ CopyPermanent | Defined$ TriggeredCardLKICopy
+Oracle:When The Magic Bandit deals combat damage to an opponent, exile the top card of that player's library. You may cast that card for as long as it remains exiled, and mana of any type can be spent to cast that spell.\nWhenever you cast a spell or play a land you don't own, copy it.

--- a/forge-gui/res/cardsfolder/t/the_marvelous_scientist.txt
+++ b/forge-gui/res/cardsfolder/t/the_marvelous_scientist.txt
@@ -1,0 +1,17 @@
+Name:The Marvelous Scientist
+ManaCost:1 U R
+Types:Legendary Creature Human Wizard
+PT:2/2
+K:ETBReplacement:Other:SiegeChoice
+SVar:SiegeChoice:DB$ GenericChoice | Choices$ Cosplay,Science | Defined$ You | SetChosenMode$ True | ShowChoice$ ExceptSelf | SpellDescription$ As this creature enters the battlefield, choose cosplay or science.
+SVar:Cosplay:DB$ Pump | SpellDescription$ Cosplay
+SVar:Science:DB$ Pump | SpellDescription$ Science
+S:Mode$ Continuous | Affected$ Card.Self+ChosenModeCosplay | AddTrigger$ CosplayTrigger | Description$ • Cosplay — Whenever you cast a creature or planeswalker spell, this creature's base power and toughness each become equal to that spell's mana value until end of turn.
+S:Mode$ Continuous | Affected$ Card.Self+ChosenModeScience | AddTrigger$ ScienceTrigger | Description$ • Science — Whenever you cast an instant or sorcery spell, this creature deals 2 damage to each opponent.
+SVar:CosplayTrigger:Mode$ SpellCast | ValidCard$ Creature,Planeswalker | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigAnimate | TriggerDescription$ Whenever you cast a creature or planeswalker spell, this creature's base power and toughness each become equal to that spell's mana value until end of turn.
+SVar:TrigAnimate:DB$ Animate | Power$ X | Toughness$ X
+SVar:X:TriggeredStackInstance$CardManaCostLKI
+SVar:ScienceTrigger:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDamage | TriggerDescription$ Whenever you cast an instant or sorcery spell, this creature deals 2 damage to each opponent.
+SVar:TrigDamage:DB$ DealDamage | Defined$ Player.Opponent | NumDmg$ 2
+DeckHints:Type$Instant|Sorcery
+Oracle:As this creature enters the battlefield, choose cosplay or science.\n• Cosplay — Whenever you cast a creature or planeswalker spell, this creature's base power and toughness each become equal to that spell's mana value until end of turn.\n• Science — Whenever you cast an instant or sorcery spell, this creature deals 2 damage to each opponent.

--- a/forge-gui/res/cardsfolder/t/the_massive_zatcatl.txt
+++ b/forge-gui/res/cardsfolder/t/the_massive_zatcatl.txt
@@ -1,0 +1,8 @@
+Name:The Massive Zatcatl
+ManaCost:5 G G
+Types:Legendary Creature Elf Cat Wizard
+PT:6/6
+T:Mode$ SpellCast | ValidCard$ Creature | ValidActivatingPlayer$ You | Execute$ TrigDraw | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a creature spell, draw a card.
+SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1
+A:AB$ Mana | Cost$ tapXType<3/Creature> | Produced$ G | Amount$ 3 | SpellDescription$ Add {G}{G}{G}.
+Oracle:Whenever you cast a creature spell, draw a card.\nTap three untapped creatures you control: Add {G}{G}{G}.

--- a/forge-gui/res/cardsfolder/t/the_master_of_cuisine.txt
+++ b/forge-gui/res/cardsfolder/t/the_master_of_cuisine.txt
@@ -1,0 +1,14 @@
+Name:The Master of Cuisine
+ManaCost:R G W
+Types:Legendary Creature Human Chef
+PT:3/3
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ Whenever this creature attacks, create a Food token.
+SVar:TrigToken:DB$ Token | TokenScript$ c_a_food_sac
+T:Mode$ Sacrificed | ValidCard$ Food.YouCtrl | Execute$ TrigChoose | TriggerZones$ Battlefield | TriggerDescription$ Whenever you sacrifice a food, ABILITY
+SVar:TrigChoose:DB$ Charm | Choices$ Gelato,Pasta,Pizza | CharmNum$ 1
+SVar:Gelato:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ Haste & Trample | SpellDescription$ Gelato — Target creature gains haste and trample until end of turn.
+SVar:Pasta:DB$ Scry | ScryNum$ 1 | SpellDescription$ Pasta — Scry 1.
+SVar:Pizza:DB$ Tap | ValidTgts$ Creature | SpellDescription$ Pizza — Tap target creature.
+DeckHas:Ability$Token & Type$Artifact|Food
+DeckHints:Type$Food
+Oracle:Whenever this creature attacks, create a Food token.\nWhenever you sacrifice a food, choose one\n• Gelato — Target creature gains haste and trample until end of turn.\n• Pasta — Scry 1.\n• Pizza — Tap target creature.

--- a/forge-gui/res/cardsfolder/t/the_rebellious_intelligence.txt
+++ b/forge-gui/res/cardsfolder/t/the_rebellious_intelligence.txt
@@ -1,0 +1,8 @@
+Name:The Rebellious Intelligence
+ManaCost:5
+Types:Legendary Artifact Creature Rebel
+PT:5/5
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ TrigWish | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, put a random card from outside the game into your hand.
+SVar:TrigWish:DB$ ChangeZone | Origin$ Sideboard | Destination$ Hand | ChangeType$ Card.YouOwn | Hidden$ True | AtRandom$ True
+A:AB$ Mana | Cost$ T | Produced$ W U B R G | RestrictValid$ CantPayGenericCosts | SpellDescription$ Add {W}{U}{B}{R}{G}. This mana can't be spent to pay generic mana costs.
+Oracle:At the beginning of your upkeep, put a random card from outside the game into your hand. (In Commander sealed, that's everything you didn't play with. In any other commander game, find a way to select a random Magic card.)\n{T}: Add {W}{U}{B}{R}{G}. This mana can't be spent to pay generic mana costs.

--- a/forge-gui/res/cardsfolder/t/the_roaring_toeclaws.txt
+++ b/forge-gui/res/cardsfolder/t/the_roaring_toeclaws.txt
@@ -1,0 +1,9 @@
+Name:The Roaring Toeclaws
+ManaCost:3 G G
+Types:Legendary Creature Dinosaur
+PT:5/5
+T:Mode$ Untaps | ValidCard$ Card.Self,Creature.Other+YouCtrl+powerGE5 | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Whenever CARDNAME or another creature you control with mana value five or greater becomes untapped, put +1/+1 counters on it equal to its power.
+SVar:TrigPutCounter:DB$ PutCounter | Defined$ TriggeredCard | CounterType$ P1P1 | CounterNum$ X
+SVar:X:TriggeredCard$CardPower
+DeckHas:Ability$Counters
+Oracle:Whenever The Roaring Toeclaws or another creature you control with mana value five or greater becomes untapped, put +1/+1 counters on it equal to its power.

--- a/forge-gui/res/cardsfolder/t/the_spike_cactus.txt
+++ b/forge-gui/res/cardsfolder/t/the_spike_cactus.txt
@@ -1,0 +1,9 @@
+Name:The Spike Cactus
+ManaCost:1 G G
+Types:Legendary Creature Spike
+PT:0/0
+K:etbCounter:P1P1:X:no Condition:CARDNAME enters the battlefield with +1/+1 counters on it equal to the amount of mana spent to cast it.
+A:AB$ PutCounter | Cost$ 2 SubCounter<1/P1P1> | ValidTgts$ Creature | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on target creature.
+SVar:X:Count$CastTotalManaSpent
+DeckHas:Ability$Counters
+Oracle:The Spike Cactus enters the battlefield with +1/+1 counters on it equal to the amount of mana spent to cast it.\n{2}, Remove a +1/+1 counter from The Spike Cactus: Put a +1/+1 counter on target creature.

--- a/forge-gui/res/cardsfolder/t/the_value_knight.txt
+++ b/forge-gui/res/cardsfolder/t/the_value_knight.txt
@@ -1,0 +1,10 @@
+Name:The Value Knight
+ManaCost:3 U
+Types:Legendary Creature Human Knight
+PT:1/1
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters the battlefield, create Syr Acha, a 1/1 legendary red artifact creature Food Knight token with "{2}, {T}, Sacrifice this token: You gain 3 life. Until end of turn, if you would draw a card, draw two cards instead."
+SVar:TrigToken:DB$ Token | TokenScript$ syr_acha
+T:Mode$ Drawn | ValidCard$ Card.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Whenever you draw a card, put a +1/+1 counter on CARDNAME.
+SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
+DeckHas:Ability$Token|Counters & Type$Artifact|Food
+Oracle:When The Value Knight enters the battlefield, create Syr Acha, a 1/1 legendary red artifact creature Food Knight token with "{2}, {T}, Sacrifice this token: You gain 3 life. Until end of turn, if you would draw a card, draw two cards instead."\nWhenever you draw a card, put a +1/+1 counter on The Value Knight.

--- a/forge-gui/res/editions/Unknown Event Amsterdam 2024 Playtest Cards.txt
+++ b/forge-gui/res/editions/Unknown Event Amsterdam 2024 Playtest Cards.txt
@@ -1,0 +1,38 @@
+[metadata]
+Code=UEAMS24
+Date=2024-06-28
+Name=Unknown Event Amsterdam 2024 Playtest Cards
+Type=Funny
+
+[cards]
+1 U Windmill Slam
+2 R The Kami Knight
+3 R The Inspector Inspector
+4 R The Miniaturizer
+5 R The Pleasant Taxer
+6 R The Clever Magician
+7 R The Magic Bandit
+8 R The Juzam Master
+9 R The Zassacre Zirl
+10 R The Great Juggernaut
+11 R The Disciple of Nissa
+12 R The Massive Zatcatl
+13 R The Ash Lizard
+14 R The Egotistical Velociraptor
+15 R The Joiner of Cats
+16 R The Karst, Enchanted
+17 R The Keeper of Kaldra
+18 R The Keeper of the Yellow Hat
+19 R The Knight of Commentary
+20 R The Marvelous Scientist
+21 R The Master of Cuisine
+22 R The Trivia Mastermind
+23 R The Wise Sable
+24 U Bag of Stroopwafels
+25 U Black Tulip
+26 C Leisure Bicycle
+27 U Famous Museum
+28 R The Magic City, New
+
+[promo]
+29 M The Horizon Seeker

--- a/forge-gui/res/editions/Unknown Event Chicago 2024 Playtest Cards.txt
+++ b/forge-gui/res/editions/Unknown Event Chicago 2024 Playtest Cards.txt
@@ -1,0 +1,65 @@
+[metadata]
+Code=UECHI24
+Date=2024-02-23
+Name=Unknown Event Chicago 2024 Playtest Cards
+Type=Funny
+
+[cards]
+1 R Guild Pact
+2 R The Asker of More Mana
+3 R The Curve Keeper
+4 U Identify the Culprit
+5 C Illuminating Detective
+6 R The Keeper of Favorite Cards
+7 R The Knight of Weeks
+8 U Windy City Elemental
+9 R The Crab Queen
+10 R Disguise Agent
+11 C Educated Detective
+12 U Elemental, My Dear
+13 R The Fish Brewer
+14 C Irrefutable Evidence
+15 R The Rhystic Storyteller
+16 R The Value Knight
+17 U Bloodspatter Vampire
+18 C Demon Detective
+19 R The Disciple of Vess
+20 U Halving Season
+21 U Impressive Rat
+22 R The Keeper of Dark Pacts
+23 C Life at Stake
+24 C Aggressive Detective
+25 R The Crafter
+26 R The Crimson Avenger
+27 U Guess Who it Is!
+28 R The Knight of Land Drops
+29 U Ate-o'-Clock
+30 R The Bear Force Pilot
+31 C Investi-Gate
+32 C Growing Detective
+33 U Primetime Suspect
+34 R The Roaring Toeclaws
+35 R The Spike Cactus
+36 M The Beleaguered Boxer
+37 R The Dogronmaster
+38 R The Duke of Midrange
+39 R The Scholar of Seas
+40 R The Sprinkler of Stardust
+41 R The Water Maro
+42 U Deep Dish Pizza
+43 U Guilded Lotus
+44 U Interrogation Robot
+45 C Karlov's Crossbow
+46 R The Rebellious Intelligence
+47 C Simic Slaw
+48 U Trash Panda
+49 U That Which Was Compleated
+50 U Urza's Hot Dog Stand
+
+[promo]
+51 M The Collector
+
+[You Make The Card]
+1 Trash Panda|UECHI24
+1 That Which Was Compleated|UECHI24
+1 Urza's Hot Dog Stand|UECHI24

--- a/forge-gui/res/tokenscripts/bear_force_one.txt
+++ b/forge-gui/res/tokenscripts/bear_force_one.txt
@@ -1,0 +1,10 @@
+Name:Vehicle Token
+ManaCost:no cost
+Types:Artifact Vehicle
+PT:0/0
+K:Flying
+K:Crew:2
+S:Mode$ Continuous | Affected$ Card.Self | AddPower$ X | AddToughness$ X | Description$ This creature gets +1/+1 for each Bear you control.
+SVar:X:Count$Valid Bear.YouCtrl
+SVar:BuffedBy:Bear
+Oracle:Flying\nThis creature gets +1/+1 for each Bear you control.\nCrew 2

--- a/forge-gui/res/tokenscripts/bling.txt
+++ b/forge-gui/res/tokenscripts/bling.txt
@@ -1,0 +1,6 @@
+Name:Bling
+ManaCost:no cost
+Types:Artifact Equipment
+K:Equip:1
+S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 1 | Description$ Equipped creature gets +1/+0.
+Oracle:Equipped creature gets +1/+0.\nEquip {1}

--- a/forge-gui/res/tokenscripts/syr_acha.txt
+++ b/forge-gui/res/tokenscripts/syr_acha.txt
@@ -1,0 +1,10 @@
+Name:Syr Acha
+ManaCost:no cost
+Types:Legendary Artifact Creature Food Knight
+Colors:red
+PT:1/1
+A:AB$ GainLife | Cost$ 2 T Sac<1/CARDNAME> | LifeAmount$ 3 | SubAbility$ DBEffect | SpellDescription$ You gain 3 life.
+SVar:DBEffect:DB$ Effect | ReplacementEffects$ CardDrawn | StackDescription$ Until end of turn, if {p:You} would draw a card, they draw two cards instead. | SpellDescription$ Until end of turn, if you would draw a card, draw two cards instead.
+SVar:CardDrawn:Event$ Draw | ActiveZones$ Battlefield | ValidPlayer$ You | ReplaceWith$ DrawTwo | Description$ If you would draw a card, draw two cards instead.
+SVar:DrawTwo:DB$ Draw | Defined$ You | NumCards$ 2
+Oracle:{2}, {T}, Sacrifice this token: You gain 3 life. Until end of turn, if you would draw a card, draw two cards instead.

--- a/forge-gui/res/tokenscripts/u_0_0_elemental.txt
+++ b/forge-gui/res/tokenscripts/u_0_0_elemental.txt
@@ -1,0 +1,6 @@
+Name:Elemental Token
+ManaCost:no cost
+Types:Creature Elemental
+Colors:blue
+PT:0/0
+Oracle:

--- a/forge-gui/res/tokenscripts/yellow_hat.txt
+++ b/forge-gui/res/tokenscripts/yellow_hat.txt
@@ -1,0 +1,6 @@
+Name:Yellow Hat
+ManaCost:no cost
+Types:Legendary Artifact Equipment
+K:Equip:2
+S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 4 | AddToughness$ 4 | AddKeyword$ Lifelink | Description$ Equiped creature gets +4/+4 and gains lifelink.
+Oracle:Equiped creature gets +4/+4 and gains lifelink.\nEquip {2}


### PR DESCRIPTION
More cards from [Gavin's unknown event](https://mtg.fandom.com/wiki/Unknown_Event), following from #5913 to catch up to 2024. Although gavin hasn't made a video about the gencon event, so haven't included an edition for it yet and I haven't tried any of the 2 cards that are documented.

2 editions (chicago and amsterdam), 27 cards, 5 tokens.

Notes:

* Halving season is in mystery booster 2 too
* The Bear Force Pilot's token has no name on the card, and in the video Gavin says the token is supposed to be a 0/0
* The Duke of Midrange's actual card has 2 printing errors according to Gavin's video, which have been fixed here (the toughness is 1+\* to match the text, and the card us cast for free)
* The Keeper of Dark Pacts uses arena's intensity mechanic to keep track of its effect cause I did not know how to do it otherwise, and it works
* The Magic Bandit says to copy a played land, which nothing in the game currently does, so I went with making a token copy of the played card, which seems to work (even though it'll have inconsistent interactions with token doublers compared to token spells, but I don't think the rules actually cover "copying a land drop")
* The Rebellious Intelligence's reminder text tells you to get any card for its effect outside of draft, but I stuck to sideboard to match wish cards

EDIT: oh just saw that #5416 got done! I haven't managed to get dev forge running locally (these scripts were tested through the custom folder), but I'll probably do another pass of the unknown cards that use that after the next update.