### PR TITLE
Add puzzle PS_BLB3, add support for class level to GameState.

### DIFF
--- a/forge-ai/src/main/java/forge/ai/GameState.java
+++ b/forge-ai/src/main/java/forge/ai/GameState.java
@@ -391,6 +391,10 @@ public abstract class GameState {
                 }
                 newText.append("|MergedCards:").append(TextUtil.join(mergedCardNames, ","));
             }
+
+            if (c.getClassLevel() > 1) {
+                newText.append("|ClassLevel:").append(c.getClassLevel());
+            }
         }
 
         if (zoneType == ZoneType.Exile) {
@@ -1394,6 +1398,8 @@ public abstract class GameState {
                     c.setTurnInZone(turn);
                 } else if (info.equals("IsToken")) {
                     c.setGamePieceType(GamePieceType.TOKEN);
+                } else if (info.equals("ClassLevel:")) {
+                    c.setClassLevel(Integer.parseInt(info.substring(info.indexOf(':') + 1)));
                 }
             }
 

--- a/forge-gui/res/puzzle/PS_BLB3.pzl
+++ b/forge-gui/res/puzzle/PS_BLB3.pzl
@@ -1,0 +1,18 @@
+[metadata]
+Name:Possibility Storm - Bloomburrow #03
+URL:https://i0.wp.com/www.possibilitystorm.com/wp-content/uploads/2024/08/latest-1-scaled.jpg?ssl=1
+Goal:Win
+Turns:1
+Difficulty:Rare
+Description:Win this turn. Assume any cards you or your opponent could draw are not relevant to the puzzle. Ensure your solution considers all possible opponent decisions. Good luck!
+[state]
+turn=1
+activeplayer=p0
+activephase=MAIN1
+p0life=5
+p0hand=Bitter Reunion;Season of the Burrow;Harvestrite Host;For the Common Good
+p0library=Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt
+p0battlefield=Baylen, the Haymaker;Alchemist's Talent;Plains;Copperline Gorge;Copperline Gorge;T:c_a_treasure_sac;T:c_a_treasure_sac;T:c_a_treasure_sac;T:c_a_treasure_sac;T:c_a_treasure_sac
+p1life=12
+p1library=Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt
+p1battlefield=Vengeful Tracker


### PR DESCRIPTION
GameState update isn't strictly necessary for this puzzle since it defaults to the class level of 1, but I thought it would be a good addition anyway.