### PR TITLE
Fixes gleaned from notes: pass #1

### DIFF
--- a/forge-gui/res/cardsfolder/c/call_forth_the_tempest.txt
+++ b/forge-gui/res/cardsfolder/c/call_forth_the_tempest.txt
@@ -4,5 +4,5 @@ Types:Sorcery
 K:Cascade
 K:Cascade
 A:SP$ DamageAll | NumDmg$ X | ValidCards$ Creature.OppCtrl | ValidDescription$ each creature your opponents controls | SpellDescription$ CARDNAME deals damage to each creature your opponents control equal to the total mana value of other spells you've cast this turn.
-SVar:X:Count$ThisTurnCast_Card.YouCtrl+Other$SumCMC
+SVar:X:Count$ThisTurnCast_Card.YouCtrl+!CastSaSource$SumCMC
 Oracle:Cascade, cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order. Then do it again.)\nCall Forth the Tempest deals damage to each creature your opponents control equal to the total mana value of other spells you've cast this turn.

--- a/forge-gui/res/cardsfolder/d/dimir_strandcatcher.txt
+++ b/forge-gui/res/cardsfolder/d/dimir_strandcatcher.txt
@@ -8,8 +8,8 @@ SVar:TrigSurveil:DB$ Surveil | Amount$ X
 T:Mode$ Phase | Phase$ End of Turn | TriggerZones$ Battlefield | CheckSVar$ Y | SVarCompare$ GE3 | Execute$ TrigDraw | TriggerDescription$ At the beginning of each end step, if three or more cards were put into your graveyard from anywhere other than the battlefield this turn, draw a card.
 SVar:TrigDraw:DB$ Draw
 SVar:X:PlayerCountPropertyYou$OpponentsAttackedThisCombat
-SVar:Y:Count$ThisTurnEntered_Graveyard_Card.YouOwn/Minus.CountHand
-SVar:CountHand:Count$ThisTurnEntered_Graveyard_from_Battlefield_Card.YouOwn
+SVar:Y:Count$ThisTurnEntered_Graveyard_Card.YouOwn/Minus.Z
+SVar:Z:Count$ThisTurnEntered_Graveyard_from_Battlefield_Card.YouOwn
 DeckHints:Ability$Mill
 DeckHas:Ability$Surveil|Graveyard
 Oracle:Flying\nWhenever you attack, surveil X, where X is the number of opponents being attacked.\nAt the beginning of each end step, if three or more cards were put into your graveyard from anywhere other than the battlefield this turn, draw a card.

--- a/forge-gui/res/cardsfolder/d/dream_thief.txt
+++ b/forge-gui/res/cardsfolder/d/dream_thief.txt
@@ -5,5 +5,5 @@ PT:2/1
 K:Flying
 T:Mode$ ChangesZone | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ When CARDNAME enters, draw a card if you've cast another blue spell this turn.
 SVar:TrigDraw:DB$ Draw | Defined$ You | ConditionCheckSVar$ X
-SVar:X:Count$ThisTurnCast_Card.Other+Blue+YouCtrl
+SVar:X:Count$ThisTurnCast_Card.!CastSaSource+Blue+YouCtrl
 Oracle:Flying\nWhen Dream Thief enters, draw a card if you've cast another blue spell this turn.

--- a/forge-gui/res/cardsfolder/h/hotheaded_giant.txt
+++ b/forge-gui/res/cardsfolder/h/hotheaded_giant.txt
@@ -4,5 +4,5 @@ Types:Creature Giant Warrior
 PT:4/4
 K:Haste
 K:etbCounter:M1M1:2:CheckSVar$ OtherRedCast | SVarCompare$ EQ0:CARDNAME enters with two -1/-1 counters on it unless you've cast another red spell this turn.
-SVar:OtherRedCast:Count$ThisTurnCast_Card.Red+Other+YouCtrl
+SVar:OtherRedCast:Count$ThisTurnCast_Card.Red+!CastSaSource+YouCtrl
 Oracle:Haste\nHotheaded Giant enters with two -1/-1 counters on it unless you've cast another red spell this turn.

--- a/forge-gui/res/cardsfolder/l/lock_and_load.txt
+++ b/forge-gui/res/cardsfolder/l/lock_and_load.txt
@@ -4,5 +4,5 @@ Types:Sorcery
 K:Plot:3 U
 A:SP$ Draw | Defined$ You | NumCards$ 1 | SubAbility$ DBDrawX | StackDescription$ SpellDescription | SpellDescription$ Draw a card, then draw a card for each other instant and sorcery spell you've cast this turn.
 SVar:DBDrawX:DB$ Draw | Defined$ You | NumCards$ X | StackDescription$ None
-SVar:X:Count$ThisTurnCast_Instant.YouCtrl,Sorcery.YouCtrl/Minus.1
+SVar:X:Count$ThisTurnCast_Instant.YouCtrl,Sorcery.YouCtrl+!CastSaSource
 Oracle:Draw a card, then draw a card for each other instant and sorcery spell you've cast this turn.\nPlot {3}{U} (You may pay {3}{U} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)

--- a/forge-gui/res/cardsfolder/s/show_of_confidence.txt
+++ b/forge-gui/res/cardsfolder/s/show_of_confidence.txt
@@ -3,7 +3,7 @@ ManaCost:1 W
 Types:Instant
 T:Mode$ SpellCast | ValidCard$ Card.Self | Execute$ TrigCopy | TriggerDescription$ When you cast this spell, copy it for each other instant and sorcery spell you've cast this turn. You may choose new targets for the copies.
 SVar:TrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | Amount$ X | MayChooseTarget$ True
-SVar:X:Count$ThisTurnCast_Instant.YouCtrl,Sorcery.YouCtrl/Minus.1
+SVar:X:Count$ThisTurnCast_Instant.YouCtrl+!CastSaSource,Sorcery.YouCtrl
 A:SP$ PutCounter | ValidTgts$ Creature | TgtPrompt$ Select target creature | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBPump | SpellDescription$ Put a +1/+1 counter on target creature.
 SVar:DBPump:DB$ Pump | Defined$ Targeted | KW$ Vigilance
 DeckHas:Ability$Counters

--- a/forge-gui/res/cardsfolder/s/soul_reap.txt
+++ b/forge-gui/res/cardsfolder/s/soul_reap.txt
@@ -3,5 +3,5 @@ ManaCost:1 B
 Types:Sorcery
 A:SP$ Destroy | ValidTgts$ Creature.nonGreen | TgtPrompt$ Select target nongreen creature | SubAbility$ DBLoseLife | SpellDescription$ Destroy target nongreen creature. Its controller loses 3 life if you've cast another black spell this turn.
 SVar:DBLoseLife:DB$ LoseLife | Defined$ TargetedController | LifeAmount$ 3 | ConditionCheckSVar$ X
-SVar:X:Count$ThisTurnCast_Card.Black+Other+YouCtrl
+SVar:X:Count$ThisTurnCast_Card.Black+!CastSaSource+YouCtrl
 Oracle:Destroy target nongreen creature. Its controller loses 3 life if you've cast another black spell this turn.

--- a/forge-gui/res/cardsfolder/s/storm_entity.txt
+++ b/forge-gui/res/cardsfolder/s/storm_entity.txt
@@ -4,5 +4,5 @@ Types:Creature Elemental
 PT:1/1
 K:Haste
 K:etbCounter:P1P1:X:no Condition:CARDNAME enters with a +1/+1 counter on it for each other spell cast this turn.
-SVar:X:Count$ThisTurnCast_Card.Other
+SVar:X:Count$ThisTurnCast_Card.!CastSaSource
 Oracle:Haste\nStorm Entity enters with a +1/+1 counter on it for each other spell cast this turn.

--- a/forge-gui/res/cardsfolder/t/talaras_battalion.txt
+++ b/forge-gui/res/cardsfolder/t/talaras_battalion.txt
@@ -4,5 +4,5 @@ Types:Creature Elf Warrior
 PT:4/3
 K:Trample
 S:Mode$ CantBeCast | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ EQ0 | EffectZone$ All | Description$ Cast this spell only if you've cast another green spell this turn.
-SVar:X:Count$ThisTurnCast_Card.Green+Other+YouCtrl
+SVar:X:Count$ThisTurnCast_Card.Green+YouCtrl
 Oracle:Cast this spell only if you've cast another green spell this turn.\nTrample

--- a/forge-gui/res/cardsfolder/t/thrasta_tempests_roar.txt
+++ b/forge-gui/res/cardsfolder/t/thrasta_tempests_roar.txt
@@ -3,7 +3,7 @@ ManaCost:10 G G
 Types:Legendary Creature Dinosaur
 PT:7/7
 S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {3} less to cast for each other spell cast this turn.
-SVar:X:Count$ThisTurnCast_Card.Other/Times.3
+SVar:X:Count$ThisTurnCast_Card/Times.3
 K:Trample
 K:Haste
 K:Trample:Planeswalker

--- a/forge-gui/res/cardsfolder/t/thunder_salvo.txt
+++ b/forge-gui/res/cardsfolder/t/thunder_salvo.txt
@@ -2,5 +2,5 @@ Name:Thunder Salvo
 ManaCost:1 R
 Types:Instant
 A:SP$ DealDamage | ValidTgts$ Creature | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to target creature, where X is 2 plus the number of other spells you've cast this turn.
-SVar:X:Count$ThisTurnCast_Card.YouCtrl+Other/Plus.2
+SVar:X:Count$ThisTurnCast_Card.YouCtrl+!CastSaSource/Plus.2
 Oracle:Thunder Salvo deals X damage to target creature, where X is 2 plus the number of other spells you've cast this turn.


### PR DESCRIPTION
Tested fixes for:
- `Count$ThisTurnCast` where the spell that's being cast or resolving is excluded from the count. 

The above has been variably implemented by adding `Other` or `Minus.1` to the `SVar` syntax. 
The issue with the first option, in the context of a resolution check, is that a previous casting of the same card isn't counted even though these aren't the same object. The issue with the second option, for the same scenario, is that it doesn't account for corner cases involving abilities of objects that weren't cast that look back in time for information about what was cast during a turn.
In the context of checks during the casting of a spell (eg.: [Talara's Batallion](https://scryfall.com/card/ddu/24/talaras-battalion)), `Other` and the like are unnecessary since a spell is only considered cast when its costs are paid. Thus checks of this sort won't count such a spell as it's being cast.

- Minor standardizing cleanup for [Dimir Strandcatcher](https://scryfall.com/card/clu/30/dimir-strandcatcher)