### PR TITLE
Fix intrinsic ETB replacement not working if card enters from sideboard

### DIFF
--- a/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
@@ -151,7 +151,7 @@ public class ReplacementHandler {
                 return true;
             }
 
-        });
+        }, affectedCard != null && affectedCard.isInZone(ZoneType.Sideboard));
 
         if (checkAgain) {
             if (affectedLKI != null && affectedCard != null) {

--- a/forge-gui/res/cardsfolder/u/ulasht_the_hate_seed.txt
+++ b/forge-gui/res/cardsfolder/u/ulasht_the_hate_seed.txt
@@ -3,7 +3,7 @@ ManaCost:2 R G
 Types:Legendary Creature Hellion Hydra
 PT:0/0
 K:etbCounter:P1P1:X:no Condition:CARDNAME enters with a +1/+1 counter on it for each other red creature you control and a +1/+1 counter on it for each other green creature you control.
-A:AB$ DealDamage | Cost$ 1 SubCounter<1/P1P1> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 1 | SpellDescription$ Ulasht deals 1 damage to target creature.
+A:AB$ DealDamage | Cost$ 1 SubCounter<1/P1P1> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 1 | SpellDescription$ NICKNAME deals 1 damage to target creature.
 A:AB$ Token | Cost$ 1 SubCounter<1/P1P1> | TokenAmount$ 1 | TokenScript$ g_1_1_saproling | TokenOwner$ You | SpellDescription$ Create a 1/1 green Saproling creature token.
 SVar:X:Count$Valid Creature.YouCtrl+Red+Other/Plus.B
 SVar:B:Count$Valid Creature.YouCtrl+Green+Other


### PR DESCRIPTION
E. g. playing a land with "enters tapped" from _Wish_.