### PR TITLE
Player: use LifeReduced CantHappen for Archon of Coronation

### DIFF
--- a/forge-game/src/main/java/forge/game/CardTraitBase.java
+++ b/forge-game/src/main/java/forge/game/CardTraitBase.java
@@ -311,7 +311,7 @@ public abstract class CardTraitBase extends GameObject implements IHasCardView, 
             if ("True".equalsIgnoreCase(params.get("Bloodthirst")) != hostController.hasBloodthirst()) return false;
         }
         if (params.containsKey("FatefulHour")) {
-            if ("True".equalsIgnoreCase(params.get("FatefulHour")) != (hostController.getLife() < 5)) return false;
+            if ("True".equalsIgnoreCase(params.get("FatefulHour")) != (hostController.getLife() <= 5)) return false;
         }
         if (params.containsKey("Monarch")) {
             if ("True".equalsIgnoreCase(params.get("Monarch")) != hostController.isMonarch()) return false;

--- a/forge-game/src/main/java/forge/game/CardTraitBase.java
+++ b/forge-game/src/main/java/forge/game/CardTraitBase.java
@@ -311,7 +311,10 @@ public abstract class CardTraitBase extends GameObject implements IHasCardView, 
             if ("True".equalsIgnoreCase(params.get("Bloodthirst")) != hostController.hasBloodthirst()) return false;
         }
         if (params.containsKey("FatefulHour")) {
-            if ("True".equalsIgnoreCase(params.get("FatefulHour")) != (hostController.getLife() > 5)) return false;
+            if ("True".equalsIgnoreCase(params.get("FatefulHour")) != (hostController.getLife() < 5)) return false;
+        }
+        if (params.containsKey("Monarch")) {
+            if ("True".equalsIgnoreCase(params.get("Monarch")) != hostController.isMonarch()) return false;
         }
         if (params.containsKey("Revolt")) {
             if ("True".equalsIgnoreCase(params.get("Revolt")) != hostController.hasRevolt()) return false;

--- a/forge-gui/res/cardsfolder/a/archon_of_coronation.txt
+++ b/forge-gui/res/cardsfolder/a/archon_of_coronation.txt
@@ -5,5 +5,5 @@ PT:5/5
 K:Flying
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigMonarch | TriggerDescription$ When CARDNAME enters, you become the monarch.
 SVar:TrigMonarch:DB$ BecomeMonarch | Defined$ You
-S:Mode$ Continuous | Affected$ You | Condition$ Monarch | AddKeyword$ Damage doesn't cause you to lose life. | Description$ As long as you're the monarch, damage doesn't cause you to lose life. (When a creature deals combat damage to you, its controller still becomes the monarch.)
+R:Event$ LifeReduced | ValidPlayer$ You | IsDamage$ True | Monarch$ True | Layer$ CantHappen | Description$ As long as you're the monarch, damage doesn't cause you to lose life. (When a creature deals combat damage to you, its controller still becomes the monarch.)
 Oracle:Flying\nWhen Archon of Coronation enters, you become the monarch.\nAs long as you're the monarch, damage doesn't cause you to lose life. (When a creature deals combat damage to you, its controller still becomes the monarch.)


### PR DESCRIPTION
use LifeReduced CantHappen instead of Keyword

Also fixes FatefulHour flag on trigger/replacement