### PR TITLE
Add XstartOnFirstThread to Mac runner

### DIFF
--- a/forge-gui-mobile-dev/src/main/config/forge-adventure.command
+++ b/forge-gui-mobile-dev/src/main/config/forge-adventure.command
@@ -1,3 +1,3 @@
 #!/bin/sh
 cd $(dirname "${0}")
-java -Xmx4096m -Dfile.encoding=UTF-8 -jar $project.build.finalName$
+java -XstartOnFirstThread -Xmx4096m -Dfile.encoding=UTF-8 -jar $project.build.finalName$


### PR DESCRIPTION
I know very little about java development, but this seems to at least be a workaround for the currently not launchable adventure file on mac.