### PR TITLE
Update ogre_battlecaster.txt

### DIFF
--- a/forge-gui/res/cardsfolder/o/ogre_battlecaster.txt
+++ b/forge-gui/res/cardsfolder/o/ogre_battlecaster.txt
@@ -3,12 +3,12 @@ ManaCost:2 R
 Types:Creature Ogre Shaman
 PT:3/3
 K:First Strike
-T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigDT | TriggerDescription$ Whenever CARDNAME attacks, you may cast target instant or sorcery card from your graveyard by paying {R}{R} in addition to its other costs. If that spell would be put into a graveyard, exile it instead. When you cast that spell, CARDNAME gets +X/+0 until end of turn, where X is that spell's mana value.
-SVar:TrigDT:DB$ DelayedTrigger | ValidTgts$ Instant.YouOwn,Sorcery.YouOwn | TgtZone$ Graveyard | TgtPrompt$ Select target instant or sorcery card | Mode$ SpellCast | ValidCard$ Card.IsTriggerRemembered | Execute$ TrigPump | RememberObjects$ Targeted | SubAbility$ DBPlay | TriggerDescription$ When you cast that spell, CARDNAME gets +X/+0 until end of turn, where X is that spell's mana value.
-SVar:DBPlay:DB$ Play | Defined$ Targeted | ValidSA$ Spell | ReplaceGraveyard$ Exile | PlayRaiseCost$ R R | Optional$ True
-SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +X | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearTriggered$ True
-SVar:X:TriggeredStackInstance$CardManaCostLKI
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPlay | TriggerDescription$ Whenever CARDNAME attacks, you may cast target instant or sorcery card from your graveyard by paying {R}{R} in addition to its other costs. If that spell would be put into a graveyard, exile it instead. When you cast that spell, CARDNAME gets +X/+0 until end of turn, where X is that spell's mana value.
+SVar:TrigPlay:DB$ Play | ValidTgts$ Instant.YouOwn,Sorcery.YouOwn | TgtZone$ Graveyard | TgtPrompt$ Select target instant or sorcery card | ValidSA$ Spell | ReplaceGraveyard$ Exile | PlayRaiseCost$ R R | Optional$ True | RememberPlayed$ True | SubAbility$ TrigDT
+SVar:TrigDT:DB$ ImmediateTrigger | Execute$ TrigPump | RememberObjects$ Remembered | ConditionDefined$ Remembered | ConditionPresent$ Card | SubAbility$ DBCleanup | TriggerDescription$ When you cast that spell, CARDNAME gets +X/+0 until end of turn, where X is that spell's mana value.
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +X
+SVar:X:TriggerRemembered$CardManaCostLKI
 AI:RemoveDeck:All
 SVar:HasAttackEffect:TRUE
 DeckHints:Type$Instant|Sorcery

--- a/forge-gui/res/cardsfolder/o/ogre_battlecaster.txt
+++ b/forge-gui/res/cardsfolder/o/ogre_battlecaster.txt
@@ -5,9 +5,9 @@ PT:3/3
 K:First Strike
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigDT | TriggerDescription$ Whenever CARDNAME attacks, you may cast target instant or sorcery card from your graveyard by paying {R}{R} in addition to its other costs. If that spell would be put into a graveyard, exile it instead. When you cast that spell, CARDNAME gets +X/+0 until end of turn, where X is that spell's mana value.
 SVar:TrigDT:DB$ DelayedTrigger | ValidTgts$ Instant.YouOwn,Sorcery.YouOwn | TgtZone$ Graveyard | TgtPrompt$ Select target instant or sorcery card | Mode$ SpellCast | ValidCard$ Card.IsTriggerRemembered | Execute$ TrigPump | RememberObjects$ Targeted | SubAbility$ DBPlay | TriggerDescription$ When you cast that spell, CARDNAME gets +X/+0 until end of turn, where X is that spell's mana value.
-SVar:DBPlay:DB$ Play | Defined$ Targeted | ValidSA$ Spell | ReplaceGraveyard$ Exile | PlayRaiseCost$ R R | Optional$ True | SubAbility$ DBCleanup
+SVar:DBPlay:DB$ Play | Defined$ Targeted | ValidSA$ Spell | ReplaceGraveyard$ Exile | PlayRaiseCost$ R R | Optional$ True
+SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearTriggered$ True
-SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +X
 SVar:X:TriggeredStackInstance$CardManaCostLKI
 AI:RemoveDeck:All
 SVar:HasAttackEffect:TRUE


### PR DESCRIPTION
Following up on a report that [Ogre Battlecaster](https://scryfall.com/card/j22/36/ogre-battlecaster) wasn't getting the power buff after targeted card was cast. Turns out a `Cleanup` happened a bit too early. Tested the fix to satisfaction, including X spells.