### PR TITLE
Fix RE choice for different sources

### DIFF
--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -1859,7 +1859,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
         if (possibleReplacers.size() == 1) {
             return first;
         }
-        final List<String> res = possibleReplacers.stream().map(ReplacementEffect::getDescription).collect(Collectors.toList());
+        final List<String> res = possibleReplacers.stream().map(ReplacementEffect::toString).collect(Collectors.toList());
         final String firstStr = res.get(0);
         final String prompt = localizer.getMessage("lblChooseFirstApplyReplacementEffect");
         for (int i = 1; i < res.size(); i++) {


### PR DESCRIPTION
@kevlahnota
reverting with `toString` is much better, otherwise it can't recognize situations such as:

> If two or more players each have resolved Crafty Cutpurse’s triggered ability and a token would be created, the token’s would-be controller chooses one of the applicable Crafty Cutpurse effects to apply. Then the new would-be controller of the token repeats this process among the remaining Crafty Cutpurse effects, and so on, until there are no more possible such effects to apply. Each effect can be applied to the token only once this way. 