### PR TITLE
Update shichifukujin_dragon.txt

### DIFF
--- a/forge-gui/res/cardsfolder/s/shichifukujin_dragon.txt
+++ b/forge-gui/res/cardsfolder/s/shichifukujin_dragon.txt
@@ -2,8 +2,9 @@ Name:Shichifukujin Dragon
 ManaCost:6 R R R
 Types:Creature Dragon
 PT:0/0
+# EDH Silver unofficial errata found at https://edhsilver.com/cards/uc/occ/shichifukujin-dragon/
 K:etbCounter:P1P1:7
-A:AB$ DelayedTrigger | Cost$ R R R SubCounter<2/P1P1> | SorcerySpeed$ True | Mode$ Phase | Phase$ End of Turn | Execute$ TrigPutCounter | TriggerDescription$ Put a +1/+1 counter on CARDNAME. | SpellDescription$ Put three +1/+1 counters on CARDNAME at end of turn. Play this ability as a sorcery.
+A:AB$ DelayedTrigger | Cost$ R R R SubCounter<2/P1P1> | SorcerySpeed$ True | Mode$ Phase | Phase$ End of Turn | Execute$ TrigPutCounter | TriggerDescription$ Put three +1/+1 counters on CARDNAME. | StackDescription$ REP Put_{p:You} puts & . Activate only as a sorcery._. | SpellDescription$ Put three +1/+1 counters on CARDNAME at the beginning of the next end step. Activate only as a sorcery.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 3
 DeckHas:Ability$Counters
 Oracle:When Shichifukujin Dragon comes into play, put seven +1/+1 counters on it.\n{R}{R}{R}, Sacrifice two +1/+1 counters: Put three +1/+1 counters on Shichifukujin Dragon at end of turn. Play this ability as a sorcery.


### PR DESCRIPTION
Cleaning up in-game display text with reference to the [EDH Silver unofficial errata](https://edhsilver.com/cards/uc/occ/shichifukujin-dragon/) and current Oracle templating of similar enough effects ([Mindwarper](https://scryfall.com/card/sth/64/mindwarper)). Took the opportunity to disambiguate between Card Detail text (`SpellDescription$`), activated ability stack item text (`StackDescription$`), and delayed trigger text (`TriggerDescription$`).