### PR TITLE
Fixes gleaned from notes: pass #3

### DIFF
--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -1415,7 +1415,7 @@ public class CardFactoryUtil {
             inst.addTrigger(trigger);
         } else if (keyword.startsWith("Impending")) {
             // Remove Time counter trigger
-            final String endTrig = "Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | IsPresent$ Card.Self+counters_GE1_TIME" +
+            final String endTrig = "Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | IsPresent$ Card.Self+impended+counters_GE1_TIME" +
                     " | Secondary$ True | TriggerDescription$ At the beginning of your end step, remove a time counter from it.";
 
             final String remove = "DB$ RemoveCounter | Defined$ Self | CounterType$ TIME | CounterNum$ 1";
@@ -2354,17 +2354,7 @@ public class CardFactoryUtil {
             final String effect = "DB$ PutCounter | Defined$ ReplacedCard | CounterType$ TIME | CounterNum$ " + m
                     + " | ETB$ True | SpellDescription$ " + desc;
 
-            SpellAbility repAb = AbilityFactory.getAbility(effect, card);
-
-            String staticEffect = "DB$ Effect | StaticAbilities$ NoCreature | ExileOnCounter$ TIME | Duration$ UntilHostLeavesPlay";
-
-            String staticNoCreature = "Mode$ Continuous | Affected$ Card.EffectSource+counters_GE1_TIME | RemoveType$ Creature | Description$ EFFECTSOURCE isn't a creature.";
-
-            AbilitySub effectAb = (AbilitySub)AbilityFactory.getAbility(staticEffect, card);
-            effectAb.setSVar("NoCreature", staticNoCreature);
-            repAb.setSubAbility(effectAb);
-
-            final ReplacementEffect re = createETBReplacement(card, ReplacementLayer.Other, repAb, false, true, intrinsic, "Card.Self+impended", "");
+            final ReplacementEffect re = createETBReplacement(card, ReplacementLayer.Other, effect, false, true, intrinsic, "Card.Self+impended", "");
 
             inst.addReplacement(re);
         } else if (keyword.equals("Jump-start")) {
@@ -3997,6 +3987,9 @@ public class CardFactoryUtil {
         } else if (keyword.equals("Horsemanship")) {
             String effect = "Mode$ CantBlockBy | ValidAttacker$ Creature.Self | ValidBlocker$ Creature.withoutHorsemanship | Secondary$ True " +
                     " | Description$ Horsemanship (" + inst.getReminderText() + ")";
+            inst.addStaticAbility(StaticAbility.create(effect, state.getCard(), state, intrinsic));
+        } else if (keyword.startsWith("Impending")) {
+            String effect = "Mode$ Continuous | Affected$ Card.Self+impended+counters_GE1_TIME | RemoveType$ Creature | Secondary$ True";
             inst.addStaticAbility(StaticAbility.create(effect, state.getCard(), state, intrinsic));
         } else if (keyword.equals("Intimidate")) {
             String effect = "Mode$ CantBlockBy | ValidAttacker$ Creature.Self | ValidBlocker$ Creature.nonArtifact+!SharesColorWith | Secondary$ True " +

--- a/forge-gui/res/cardsfolder/a/agatha_of_the_vile_cauldron.txt
+++ b/forge-gui/res/cardsfolder/a/agatha_of_the_vile_cauldron.txt
@@ -2,7 +2,7 @@ Name:Agatha of the Vile Cauldron
 ManaCost:R G
 Types:Legendary Creature Human Warlock
 PT:1/1
-S:Mode$ ReduceCost | ValidCard$ Creature.YouCtrl | Type$ Ability | Amount$ X | MinMana$ 1 | AffectedZone$ Battlefield | Description$ Activated abilities of creatures you control cost X less to activate, where X is CARDNAME's power. This effect can't reduce the mana in that cost to less than one mana.
+S:Mode$ ReduceCost | ValidCard$ Creature.YouCtrl | Type$ Ability | Amount$ X | MinMana$ 1 | AffectedZone$ Battlefield | Description$ Activated abilities of creatures you control cost {X} less to activate, where X is CARDNAME's power. This effect can't reduce the mana in that cost to less than one mana.
 A:AB$ PumpAll | Cost$ 4 R G | ValidCards$ Creature.YouCtrl+StrictlyOther | NumAtt$ +1 | NumDef$ +1 | KW$ Trample & Haste | SpellDescription$ Other creatures you control get +1/+1 and gain trample and haste until end of turn.
 SVar:X:Count$CardPower
-Oracle:Activated abilities of creatures you control cost X less to activate, where X is Agatha of the Vile Cauldron's power. This effect can't reduce the mana in that cost to less than one mana.\n{4}{R}{G}: Other creatures you control get +1/+1 and gain trample and haste until end of turn.
+Oracle:Activated abilities of creatures you control cost {X} less to activate, where X is Agatha of the Vile Cauldron's power. This effect can't reduce the mana in that cost to less than one mana.\n{4}{R}{G}: Other creatures you control get +1/+1 and gain trample and haste until end of turn.

--- a/forge-gui/res/cardsfolder/c/combustible_gearhulk.txt
+++ b/forge-gui/res/cardsfolder/c/combustible_gearhulk.txt
@@ -5,8 +5,8 @@ PT:6/6
 K:First Strike
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ DBChoice | TriggerDescription$ When CARDNAME enters, target opponent may have you draw three cards. If the player doesn't, you mill three cards, then CARDNAME deals damage to that player equal to the total mana value of those cards.
 SVar:DBChoice:DB$ GenericChoice | ValidTgts$ Opponent | Choices$ CombustDraw,CombustDamage | AILogic$ CombustibleGearhulk
-SVar:CombustDraw:DB$ Draw | Defined$ You | NumCards$ 3 | SpellDescription$ Controller draws three cards
-SVar:CombustDamage:DB$ Mill | Defined$ You | NumCards$ 3 | RememberMilled$ True | SubAbility$ DamageOpponent | SpellDescription$ Controller mills three cards, then CARDNAME deals damage to you equal to their total mana value.
+SVar:CombustDraw:DB$ Draw | Defined$ You | NumCards$ 3 | SpellDescription$ CARDNAME's controller draws three cards.
+SVar:CombustDamage:DB$ Mill | Defined$ You | NumCards$ 3 | RememberMilled$ True | SubAbility$ DamageOpponent | SpellDescription$ CARDNAME's controller mills three cards, then it deals damage to you equal to the total mana value of those cards.
 SVar:DamageOpponent:DB$ DealDamage | Defined$ ParentTarget | NumDmg$ X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Remembered$SumCMC

--- a/forge-gui/res/cardsfolder/d/doors_of_durin.txt
+++ b/forge-gui/res/cardsfolder/d/doors_of_durin.txt
@@ -3,7 +3,7 @@ ManaCost:3 R G
 Types:Legendary Artifact
 T:Mode$ AttackersDeclared | AttackingPlayer$ You | Execute$ TrigScry | TriggerZones$ Battlefield | TriggerDescription$ Whenever you attack, scry 2, then you may reveal the top card of your library. If it's a creature card, put it onto the battlefield tapped and attacking. Until your next turn, it gains trample if you control a Dwarf and hexproof if you control an Elf.
 SVar:TrigScry:DB$ Scry | ScryNum$ 2 | SubAbility$ DBDig
-SVar:DBDig:DB$ Dig | DigNum$ 1 | ChangeNum$ All | Optional$ True | Reveal$ True | ChangeValid$ Creature | DestinationZone$ Battlefield | Tapped$ True | Attacking$ True | RememberChanged$ True | SubAbility$ DBPumpTrample
+SVar:DBDig:DB$ Dig | DigNum$ 1 | ChangeNum$ All | RevealOptional$ True | RememberRevealed$ True | ChangeValid$ Creature.IsRemembered | DestinationZone$ Battlefield | Tapped$ True | Attacking$ True | SubAbility$ DBPumpTrample
 SVar:DBPumpTrample:DB$ Pump | Defined$ Remembered | KW$ Trample | Duration$ UntilYourNextTurn | ConditionPresent$ Dwarf.YouCtrl | SubAbility$ DBPumpHexproof
 SVar:DBPumpHexproof:DB$ Pump | Defined$ Remembered | KW$ Hexproof | Duration$ UntilYourNextTurn | ConditionPresent$ Elf.YouCtrl | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/g/grist_voracious_larva_grist_the_plague_swarm.txt
+++ b/forge-gui/res/cardsfolder/g/grist_voracious_larva_grist_the_plague_swarm.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature Insect
 PT:1/2
 K:Deathtouch
 T:Mode$ ChangesZone | Origin$ Graveyard | Destination$ Battlefield | ValidCard$ Card.Self,Creature.YouCtrl | Execute$ TrigTransform | TriggerZones$ Battlefield | TriggerDescription$ When CARDNAME or another creature you control enters, if it entered from your graveyard or you cast it from your graveyard, you may pay {G}. If you do, exile NICKNAME, then return it to the battlefield transformed under its owner's control.
-T:Mode$ ChangesZone | Destination$ Battlefield | ValidCard$ Card.Self+wasCastFromYourGraveyardByYou,Creature.YouCtrl+wasCastFromYourGraveyardByYou | Execute$ TrigTransform | TriggerZones$ Battlefield | Secondary$ True | TriggerDescription$ When CARDNAME enters, if it entered from your graveyard or you cast it from your graveyard, you may pay {G}. If you do, exile NICKNAME, then return it to the battlefield transformed under its owner's control.
+T:Mode$ ChangesZone | Destination$ Battlefield | ValidCard$ Card.Self+wasCastFromYourGraveyardByYou,Creature.YouCtrl+wasCastFromYourGraveyardByYou | Execute$ TrigTransform | TriggerZones$ Battlefield | Secondary$ True | TriggerDescription$ When CARDNAME or another creature you control enters, if it entered from your graveyard or you cast it from your graveyard, you may pay {G}. If you do, exile NICKNAME, then return it to the battlefield transformed under its owner's control.
 SVar:TrigTransform:AB$ ChangeZone | Cost$ G | Origin$ Battlefield | Destination$ Exile | RememberChanged$ True | SubAbility$ DBReturn
 SVar:DBReturn:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Battlefield | Transformed$ True | ForgetOtherRemembered$ True | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/i/isolated_watchtower.txt
+++ b/forge-gui/res/cardsfolder/i/isolated_watchtower.txt
@@ -2,8 +2,8 @@ Name:Isolated Watchtower
 ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
-A:AB$ Scry | Cost$ 2 T | ScryNum$ 1 | SubAbility$ DBReveal | CheckSVar$ X | SVarCompare$ GEY | SpellDescription$ Scry 1, then you may reveal the top card of your library. If a basic land card is revealed this way, put it onto the battlefield tapped. Activate only if an opponent controls at least two more lands than you.
-SVar:DBReveal:DB$ Dig | Optional$ True | DigNum$ 1 | Reveal$ True | ChangeValid$ Land.Basic | DestinationZone$ Battlefield | Tapped$ True | DestinationZone2$ Library | LibraryPosition2$ 0
+A:AB$ Scry | Cost$ 2 T | ScryNum$ 1 | SubAbility$ DBReveal | CheckSVar$ X | SVarCompare$ GEY | StackDescription$ REP Scry_{p:You} scries & you may_they may & your_their & put_{p:You} puts & . Activate only if an opponent controls at least two more lands than you._. | SpellDescription$ Scry 1, then you may reveal the top card of your library. If a basic land card is revealed this way, put it onto the battlefield tapped. Activate only if an opponent controls at least two more lands than you.
+SVar:DBReveal:DB$ Dig | DigNum$ 1 | RevealOptional$ True | RememberRevealed$ True | ChangeValid$ Land.Basic+IsRemembered | ChangeNum$ All | DestinationZone$ Battlefield | Tapped$ True | DestinationZone2$ Library | LibraryPosition2$ 0 | StackDescription$ None
 SVar:X:PlayerCountOpponents$HighestValid Land.YouCtrl
 SVar:Y:Count$Valid Land.YouCtrl/Plus.2
 Oracle:{T}: Add {C}.\n{2}, {T}: Scry 1, then you may reveal the top card of your library. If a basic land card is revealed this way, put it onto the battlefield tapped. Activate only if an opponent controls at least two more lands than you.

--- a/forge-gui/res/cardsfolder/i/isolated_watchtower.txt
+++ b/forge-gui/res/cardsfolder/i/isolated_watchtower.txt
@@ -3,7 +3,8 @@ ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Scry | Cost$ 2 T | ScryNum$ 1 | SubAbility$ DBReveal | CheckSVar$ X | SVarCompare$ GEY | StackDescription$ REP Scry_{p:You} scries & you may_they may & your_their & put_{p:You} puts & . Activate only if an opponent controls at least two more lands than you._. | SpellDescription$ Scry 1, then you may reveal the top card of your library. If a basic land card is revealed this way, put it onto the battlefield tapped. Activate only if an opponent controls at least two more lands than you.
-SVar:DBReveal:DB$ Dig | DigNum$ 1 | RevealOptional$ True | RememberRevealed$ True | ChangeValid$ Land.Basic+IsRemembered | ChangeNum$ All | DestinationZone$ Battlefield | Tapped$ True | DestinationZone2$ Library | LibraryPosition2$ 0 | StackDescription$ None
+SVar:DBReveal:DB$ Dig | DigNum$ 1 | RevealOptional$ True | RememberRevealed$ True | ChangeValid$ Land.Basic+IsRemembered | ChangeNum$ All | DestinationZone$ Battlefield | Tapped$ True | DestinationZone2$ Library | LibraryPosition2$ 0 | SubAbility$ DBCleanup | StackDescription$ None
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:PlayerCountOpponents$HighestValid Land.YouCtrl
 SVar:Y:Count$Valid Land.YouCtrl/Plus.2
 Oracle:{T}: Add {C}.\n{2}, {T}: Scry 1, then you may reveal the top card of your library. If a basic land card is revealed this way, put it onto the battlefield tapped. Activate only if an opponent controls at least two more lands than you.

--- a/forge-gui/res/cardsfolder/p/palantir_of_orthanc.txt
+++ b/forge-gui/res/cardsfolder/p/palantir_of_orthanc.txt
@@ -5,8 +5,8 @@ T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefiel
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ INFLUENCE | CounterNum$ 1 | SubAbility$ DBScry
 SVar:DBScry:DB$ Scry | ScryNum$ 2 | SubAbility$ DBChoice
 SVar:DBChoice:DB$ GenericChoice | ValidTgts$ Opponent | Choices$ CombustDraw,CombustDamage | AILogic$ CombustibleGearhulk
-SVar:CombustDraw:DB$ Draw | Defined$ You | NumCards$ 1 | SpellDescription$ Controller draws a card
-SVar:CombustDamage:DB$ Mill | Defined$ You | NumCards$ X | RememberMilled$ True | SubAbility$ DamageOpponent | SpellDescription$ Controller mills X cards, where X is the number of influence counters on CARDNAME, and that player loses life equal to the total mana value of those cards.
+SVar:CombustDraw:DB$ Draw | Defined$ You | NumCards$ 1 | SpellDescription$ CARDNAME's controller draws a card.
+SVar:CombustDamage:DB$ Mill | Defined$ You | NumCards$ X | RememberMilled$ True | SubAbility$ DamageOpponent | SpellDescription$ CARDNAME's controller mills X cards, where X is the number of influence counters on it, and you lose life equal to the total mana value of those cards.
 SVar:DamageOpponent:DB$ LoseLife | Defined$ ParentTarget | LifeAmount$ Y | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Count$CardCounters.INFLUENCE

--- a/forge-gui/res/cardsfolder/u/urza_assembles_the_titans.txt
+++ b/forge-gui/res/cardsfolder/u/urza_assembles_the_titans.txt
@@ -3,8 +3,8 @@ ManaCost:3 W W
 Types:Enchantment Saga
 K:Read ahead
 K:Chapter:3:DBScry,DBChangeZone,DBLoyalty
-SVar:DBScry:DB$ Scry | ScryNum$ 4 | SubAbility$ DBDig | SpellAbility$ Scry 4, then you may reveal the top card of your library. If a planeswalker card is revealed this way, put it into your hand.
-SVar:DBDig:DB$ Dig | DigNum$ 1 | Reveal$ True | ChangeNum$ All | ChangeValid$ Planeswalker | LibraryPosition2$ 0
+SVar:DBScry:DB$ Scry | ScryNum$ 4 | SubAbility$ DBDig | SpellDescription$ Scry 4, then you may reveal the top card of your library. If a planeswalker card is revealed this way, put it into your hand.
+SVar:DBDig:DB$ Dig | DigNum$ 1 | Optional$ True | Reveal$ True | ChangeNum$ All | ChangeValid$ Planeswalker | LibraryPosition2$ 0
 SVar:DBChangeZone:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | ChangeType$ Planeswalker.cmcLE6 | ChangeNum$ 1 | SpellDescription$ You may put a planeswalker card with mana value 6 or less from your hand onto the battlefield.
 SVar:DBLoyalty:DB$ Effect | StaticAbilities$ PWTwice | SpellDescription$ You may activate the loyalty abilities of planeswalkers you control twice this turn rather than only once.
 SVar:PWTwice:Mode$ NumLoyaltyAct | ValidCard$ Planeswalker.YouCtrl | Twice$ True | Description$ You may activate the loyalty abilities of planeswalkers you control twice this turn rather than only once.

--- a/forge-gui/res/cardsfolder/u/urza_assembles_the_titans.txt
+++ b/forge-gui/res/cardsfolder/u/urza_assembles_the_titans.txt
@@ -4,7 +4,7 @@ Types:Enchantment Saga
 K:Read ahead
 K:Chapter:3:DBScry,DBChangeZone,DBLoyalty
 SVar:DBScry:DB$ Scry | ScryNum$ 4 | SubAbility$ DBDig | SpellDescription$ Scry 4, then you may reveal the top card of your library. If a planeswalker card is revealed this way, put it into your hand.
-SVar:DBDig:DB$ Dig | DigNum$ 1 | Optional$ True | Reveal$ True | ChangeNum$ All | ChangeValid$ Planeswalker | LibraryPosition2$ 0
+SVar:DBDig:DB$ Dig | DigNum$ 1 | RevealOptional$ True | RememberRevealed$ True | ChangeNum$ All | ChangeValid$ Planeswalker.IsRemembered | LibraryPosition2$ 0
 SVar:DBChangeZone:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | ChangeType$ Planeswalker.cmcLE6 | ChangeNum$ 1 | SpellDescription$ You may put a planeswalker card with mana value 6 or less from your hand onto the battlefield.
 SVar:DBLoyalty:DB$ Effect | StaticAbilities$ PWTwice | SpellDescription$ You may activate the loyalty abilities of planeswalkers you control twice this turn rather than only once.
 SVar:PWTwice:Mode$ NumLoyaltyAct | ValidCard$ Planeswalker.YouCtrl | Twice$ True | Description$ You may activate the loyalty abilities of planeswalkers you control twice this turn rather than only once.

--- a/forge-gui/res/cardsfolder/u/urza_assembles_the_titans.txt
+++ b/forge-gui/res/cardsfolder/u/urza_assembles_the_titans.txt
@@ -4,7 +4,8 @@ Types:Enchantment Saga
 K:Read ahead
 K:Chapter:3:DBScry,DBChangeZone,DBLoyalty
 SVar:DBScry:DB$ Scry | ScryNum$ 4 | SubAbility$ DBDig | SpellDescription$ Scry 4, then you may reveal the top card of your library. If a planeswalker card is revealed this way, put it into your hand.
-SVar:DBDig:DB$ Dig | DigNum$ 1 | RevealOptional$ True | RememberRevealed$ True | ChangeNum$ All | ChangeValid$ Planeswalker.IsRemembered | LibraryPosition2$ 0
+SVar:DBDig:DB$ Dig | DigNum$ 1 | RevealOptional$ True | RememberRevealed$ True | ChangeNum$ All | ChangeValid$ Planeswalker.IsRemembered | LibraryPosition2$ 0 | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:DBChangeZone:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | ChangeType$ Planeswalker.cmcLE6 | ChangeNum$ 1 | SpellDescription$ You may put a planeswalker card with mana value 6 or less from your hand onto the battlefield.
 SVar:DBLoyalty:DB$ Effect | StaticAbilities$ PWTwice | SpellDescription$ You may activate the loyalty abilities of planeswalkers you control twice this turn rather than only once.
 SVar:PWTwice:Mode$ NumLoyaltyAct | ValidCard$ Planeswalker.YouCtrl | Twice$ True | Description$ You may activate the loyalty abilities of planeswalkers you control twice this turn rather than only once.


### PR DESCRIPTION
- Minor copyedits
◦ [Agatha of the Vile Cauldron](https://scryfall.com/card/woe/199/agatha-of-the-vile-cauldron)
◦ [Grist, Voracious Larva // Grist, the Plague Swarm](https://scryfall.com/card/mh3/251/grist-voracious-larva-grist-the-plague-swarm)
- Standardizing `GenericChoice` options for [Combustible Gearhulk](https://scryfall.com/card/dsc/163/combustible-gearhulk) and [Palantír of Orthanc](https://scryfall.com/card/ltr/247/palant%C3%ADr-of-orthanc)
- Fixing mid-effect "you may reveal the top card of your library" step not actually being optional, along with some cleanup
◦ [Doors of Durin](https://scryfall.com/card/ltr/199/doors-of-durin)
◦ [Isolated Watchtower](https://scryfall.com/card/c18/59/isolated-watchtower)
◦ [Urza Assembles the Titans](https://scryfall.com/card/dmu/37/urza-assembles-the-titans)