### PR TITLE
Fixed 2 DSK cards

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/disturbing_mirth.txt
+++ b/forge-gui/res/cardsfolder/upcoming/disturbing_mirth.txt
@@ -2,7 +2,7 @@ Name:Disturbing Mirth
 ManaCost:B R
 Types:Enchantment
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ When CARDNAME enters, you may sacrifice another enchantment or creature. If you do, draw two cards.
-SVar:TrigDraw:AB$ Draw | Cost$ Sac<1/Enchantment.Other,Creature.Other/another enchantment or creature> | NumCards$ 2
+SVar:TrigDraw:AB$ Draw | Cost$ Sac<1/Enchantment.Other;Creature.Other/another enchantment or creature> | NumCards$ 2
 T:Mode$ Sacrificed | ValidPlayer$ You | ValidCard$ Card.Self | Execute$ TrigDread | TriggerZones$ Battlefield | TriggerDescription$ When you sacrifice CARDNAME, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)
 SVar:TrigDread:DB$ ManifestDread
 DeckHas:Ability$Sacrifice

--- a/forge-gui/res/cardsfolder/upcoming/trial_of_agony.txt
+++ b/forge-gui/res/cardsfolder/upcoming/trial_of_agony.txt
@@ -3,7 +3,7 @@ ManaCost:R
 Types:Sorcery
 A:SP$ Pump | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select two target creatures controlled by the same opponent | TargetMin$ 2 | TargetMax$ 2 | TargetsFromSingleZone$ True | IsCurse$ True | RememberTargets$ True | SubAbility$ DBChoose | StackDescription$ SpellDescription | SpellDescription$ Choose two target creatures controlled by the same opponent. That player chooses one of those creatures. CARDNAME deals 5 damage to that creature, and the other can't block this turn.
 SVar:DBChoose:DB$ ChooseCard | Defined$ TargetedController | Mandatory$ True | Choices$ Creature.IsRemembered | ChoiceTitle$ Choose one to take 5 damage | ForgetChosen$ True | SubAbility$ DBDealDamage
-SVar:DBDealDamage:DB$ DealDamage | Defined$ ChosenCard | SubAbility$ DBCantBlock
+SVar:DBDealDamage:DB$ DealDamage | NumDmg$ 5 | Defined$ ChosenCard | SubAbility$ DBCantBlock
 SVar:DBCantBlock:DB$ Pump | Defined$ Remembered | KW$ HIDDEN CARDNAME can't block. | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Choose two target creatures controlled by the same opponent. That player chooses one of those creatures. Trial of Agony deals 5 damage to that creature, and the other can't block this turn.


### PR DESCRIPTION
Fixed Trial of Agony which wasn't dealing the damage, and Disturbing Mirth which was only allowing you to sacrifice another enchantment (not a creature).