### PR TITLE
Fix valiant cards only triggering once per game rather than once per turn

### DIFF
--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -7206,6 +7206,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
         setRegeneratedThisTurn(0);
         resetShieldCount();
         setBecameTargetThisTurn(false);
+        setValiant(false);
         setFoughtThisTurn(false);
         turnedFaceUpThisTurn = false;
         clearMustBlockCards();


### PR DESCRIPTION
Copies the cleanup logic for `becameTargetThisTurn`

FLUP to #6178