### PR TITLE
Update Oracle text of some "main phase" related cards

### DIFF
--- a/forge-gui/res/cardsfolder/a/altar_of_shadows.txt
+++ b/forge-gui/res/cardsfolder/a/altar_of_shadows.txt
@@ -1,9 +1,9 @@
 Name:Altar of Shadows
 ManaCost:7
 Types:Artifact
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigGetMana | TriggerDescription$ At the beginning of your precombat main phase, add {B} for each charge counter on CARDNAME.
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigGetMana | TriggerDescription$ At the beginning of your first main phase, add {B} for each charge counter on CARDNAME.
 SVar:TrigGetMana:DB$ Mana | Produced$ B | Amount$ X | SpellDescription$ Add {B} for each charge counter on CARDNAME.
 A:AB$ Destroy | Cost$ 7 T | ValidTgts$ Creature | TgtPrompt$ Select target creature | SubAbility$ DBPutCounter | SpellDescription$ Destroy target creature. Then put a charge counter on CARDNAME.
 SVar:DBPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ CHARGE | CounterNum$ 1
 SVar:X:Count$CardCounters.CHARGE
-Oracle:At the beginning of your precombat main phase, add {B} for each charge counter on Altar of Shadows.\n{7}, {T}: Destroy target creature. Then put a charge counter on Altar of Shadows.
+Oracle:At the beginning of your first main phase, add {B} for each charge counter on Altar of Shadows.\n{7}, {T}: Destroy target creature. Then put a charge counter on Altar of Shadows.

--- a/forge-gui/res/cardsfolder/b/belbe_corrupted_observer.txt
+++ b/forge-gui/res/cardsfolder/b/belbe_corrupted_observer.txt
@@ -2,7 +2,7 @@ Name:Belbe, Corrupted Observer
 ManaCost:B G
 Types:Legendary Creature Phyrexian Zombie Elf
 PT:2/2
-T:Mode$ Phase | Phase$ Main2 | TriggerZones$ Battlefield | Execute$ TrigMana | TriggerDescription$ At the beginning of each player's postcombat main phase, that player adds {C}{C} for each of your opponents who lost life this turn. (Damage causes loss of life.)
+T:Mode$ Phase | Phase$ Main2 | TriggerZones$ Battlefield | Execute$ TrigMana | TriggerDescription$ At the beginning of each postcombat main phase, the active player adds {C}{C} for each of your opponents who lost life this turn. (Damage causes loss of life.)
 SVar:TrigMana:DB$ Mana | Produced$ C | Amount$ X | Defined$ TriggeredPlayer
 SVar:X:PlayerCountOpponents$HasPropertyLostLifeThisTurn/Twice
-Oracle:At the beginning of each player's postcombat main phase, that player adds {C}{C} for each of your opponents who lost life this turn. (Damage causes loss of life.)
+Oracle:At the beginning of each postcombat main phase, the active player adds {C}{C} for each of your opponents who lost life this turn. (Damage causes loss of life.)

--- a/forge-gui/res/cardsfolder/b/black_market.txt
+++ b/forge-gui/res/cardsfolder/b/black_market.txt
@@ -3,7 +3,7 @@ ManaCost:3 B B
 Types:Enchantment
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Whenever a creature dies, put a charge counter on CARDNAME.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ CHARGE | CounterNum$ 1
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigGetMana | TriggerDescription$ At the beginning of your precombat main phase, add {B} for each charge counter on CARDNAME.
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigGetMana | TriggerDescription$ At the beginning of your first main phase, add {B} for each charge counter on CARDNAME.
 SVar:TrigGetMana:DB$ Mana | Produced$ B | Amount$ X | SpellDescription$ Add {X}{B}
 SVar:X:Count$CardCounters.CHARGE
-Oracle:Whenever a creature dies, put a charge counter on Black Market.\nAt the beginning of your precombat main phase, add {B} for each charge counter on Black Market.
+Oracle:Whenever a creature dies, put a charge counter on Black Market.\nAt the beginning of your first main phase, add {B} for each charge counter on Black Market.

--- a/forge-gui/res/cardsfolder/b/black_market_connections.txt
+++ b/forge-gui/res/cardsfolder/b/black_market_connections.txt
@@ -1,7 +1,7 @@
 Name:Black Market Connections
 ManaCost:2 B
 Types:Enchantment
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigCharm | TriggerDescription$ At the beginning of your precombat main phase, ABILITY
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigCharm | TriggerDescription$ At the beginning of your first main phase, ABILITY
 SVar:TrigCharm:DB$ Charm | Choices$ DBTreasureLose1,DBDrawLose2,DBTokenLose3 | MinCharmNum$ 1 | CharmNum$ 3
 SVar:DBTreasureLose1:DB$ Token | TokenScript$ c_a_treasure_sac | SubAbility$ DBLoseLife1 | SpellDescription$ Sell Contraband — Create a Treasure token. You lose 1 life.
 SVar:DBDrawLose2:DB$ Draw | NumCards$ 1 | SubAbility$ DBLoseLife2 | SpellDescription$ Buy Information — Draw a card. You lose 2 life.
@@ -10,4 +10,4 @@ SVar:DBLoseLife1:DB$ LoseLife | LifeAmount$ 1 | Defined$ You
 SVar:DBLoseLife2:DB$ LoseLife | LifeAmount$ 2 | Defined$ You
 SVar:DBLoseLife3:DB$ LoseLife | LifeAmount$ 3 | Defined$ You
 DeckHas:Ability$Token|Sacrifice & Type$Artifact|Treasure|Shapeshifter
-Oracle:At the beginning of your precombat main phase, choose one or more —\n• Sell Contraband — Create a Treasure token. You lose 1 life.\n• Buy Information — Draw a card. You lose 2 life.\n• Hire a Mercenary — Create a 3/2 colorless Shapeshifter creature token with changeling. You lose 3 life.
+Oracle:At the beginning of your first main phase, choose one or more —\n• Sell Contraband — Create a Treasure token. You lose 1 life.\n• Buy Information — Draw a card. You lose 2 life.\n• Hire a Mercenary — Create a 3/2 colorless Shapeshifter creature token with changeling. You lose 3 life.

--- a/forge-gui/res/cardsfolder/b/blinkmoth_urn.txt
+++ b/forge-gui/res/cardsfolder/b/blinkmoth_urn.txt
@@ -1,8 +1,8 @@
 Name:Blinkmoth Urn
 ManaCost:5
 Types:Artifact
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ Player | TriggerZones$ Battlefield | PresentDefined$ Self | IsPresent$ Card.untapped | Execute$ TrigGetMana | TriggerDescription$ At the beginning of each player's precombat main phase, if CARDNAME is untapped, that player adds {C} for each artifact they control.
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ Player | TriggerZones$ Battlefield | PresentDefined$ Self | IsPresent$ Card.untapped | Execute$ TrigGetMana | TriggerDescription$ At the beginning of each player's first main phase, if CARDNAME is untapped, that player adds {C} for each artifact they control.
 SVar:TrigGetMana:DB$ Mana | Produced$ C | Amount$ X | Defined$ TriggeredPlayer
 SVar:X:Count$Valid Artifact.ActivePlayerCtrl
 AI:RemoveDeck:Random
-Oracle:At the beginning of each player's precombat main phase, if Blinkmoth Urn is untapped, that player adds {C} for each artifact they control.
+Oracle:At the beginning of each player's first main phase, if Blinkmoth Urn is untapped, that player adds {C} for each artifact they control.

--- a/forge-gui/res/cardsfolder/b/bounty_of_the_luxa.txt
+++ b/forge-gui/res/cardsfolder/b/bounty_of_the_luxa.txt
@@ -1,11 +1,11 @@
 Name:Bounty of the Luxa
 ManaCost:2 G U
 Types:Enchantment
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigRemove | TriggerDescription$ At the beginning of your precombat main phase, remove all flood counters from CARDNAME. If no counters were removed this way, put a flood counter on CARDNAME and draw a card. Otherwise, add {C}{G}{U}.
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigRemove | TriggerDescription$ At the beginning of your first main phase, remove all flood counters from CARDNAME. If no counters were removed this way, put a flood counter on CARDNAME and draw a card. Otherwise, add {C}{G}{U}.
 SVar:TrigRemove:DB$ RemoveCounter | CounterType$ FLOOD | CounterNum$ All | RememberRemoved$ True | SubAbility$ DBPutCounter
 SVar:DBPutCounter:DB$ PutCounter | Defined$ Self | ConditionCheckSVar$ X | ConditionSVarCompare$ EQ0 | CounterType$ FLOOD | CounterNum$ 1 | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | ConditionCheckSVar$ X | ConditionSVarCompare$ EQ0 | SubAbility$ DBGetMana
 SVar:DBGetMana:DB$ Mana | Produced$ C G U | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Count$RememberedSize
-Oracle:At the beginning of your precombat main phase, remove all flood counters from Bounty of the Luxa. If no counters were removed this way, put a flood counter on Bounty of the Luxa and draw a card. Otherwise, add {C}{G}{U}.
+Oracle:At the beginning of your first main phase, remove all flood counters from Bounty of the Luxa. If no counters were removed this way, put a flood counter on Bounty of the Luxa and draw a card. Otherwise, add {C}{G}{U}.

--- a/forge-gui/res/cardsfolder/b/brazen_cannonade.txt
+++ b/forge-gui/res/cardsfolder/b/brazen_cannonade.txt
@@ -3,10 +3,10 @@ ManaCost:3 R
 Types:Enchantment
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.attacking+YouCtrl | Execute$ TrigDamage | TriggerZones$ Battlefield | TriggerDescription$ Whenever an attacking creature you control dies, CARDNAME deals 2 damage to each opponent.
 SVar:TrigDamage:DB$ DealDamage | Defined$ Opponent | NumDmg$ 2
-T:Mode$ Phase | Phase$ Main2 | ValidPlayer$ You | TriggerZones$ Battlefield | CheckSVar$ RaidTest | Execute$ TrigExile | TriggerDescription$ Raid — At the beginning of your postcombat main phase, if you attacked with a creature this turn, exile the top card of your library. Until end of combat on your next turn, you may play that card.
+T:Mode$ Phase | Phase$ Main2 | ValidPlayer$ You | TriggerZones$ Battlefield | CheckSVar$ RaidTest | Execute$ TrigExile | TriggerDescription$ Raid — At the beginning of each of your postcombat main phases, if you attacked this turn, exile the top card of your library. Until end of combat on your next turn, you may play that card.
 SVar:TrigExile:DB$ Dig | DigNum$ 1 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ Play | SubAbility$ DBCleanup | ExileOnMoved$ Exile | Duration$ UntilEndOfCombatYourNextTurn
 SVar:Play:Mode$ Continuous | MayPlay$ True | EffectZone$ Command | Affected$ Card.IsRemembered | AffectedZone$ Exile | Description$ Until end of combat on your next turn, you may play that card.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:RaidTest:Count$AttackersDeclared
-Oracle:Whenever an attacking creature you control dies, Brazen Cannonade deals 2 damage to each opponent.\nRaid — At the beginning of your postcombat main phase, if you attacked with a creature this turn, exile the top card of your library. Until end of combat on your next turn, you may play that card.
+Oracle:Whenever an attacking creature you control dies, Brazen Cannonade deals 2 damage to each opponent.\nRaid — At the beginning of each of your postcombat main phases, if you attacked this turn, exile the top card of your library. Until end of combat on your next turn, you may play that card.

--- a/forge-gui/res/cardsfolder/c/cabal_therapist.txt
+++ b/forge-gui/res/cardsfolder/c/cabal_therapist.txt
@@ -3,10 +3,10 @@ ManaCost:B
 Types:Creature Horror
 PT:1/1
 K:Menace
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | Execute$ DBImmediateTrigger | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your precombat main phase, you may sacrifice a creature. When you do, choose a nonland card name, then target player reveals their hand and discards all cards with that name.
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | Execute$ DBImmediateTrigger | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your first main phase, you may sacrifice a creature. When you do, choose a nonland card name, then target player reveals their hand and discards all cards with that name.
 SVar:DBImmediateTrigger:AB$ ImmediateTrigger | Execute$ NameCard | TriggerDescription$ You may sacrifice a creature. When you do, choose a nonland card name, then target player reveals their hand and discards all cards with that name. | Cost$ Sac<1/Creature>
 SVar:NameCard:DB$ NameCard | Defined$ You | ValidCards$ Card.nonLand | ValidDescription$ nonland | SubAbility$ DBDiscard | SpellDescription$ Choose a nonland card name. Target player reveals their hand and discards all cards with that name.
 SVar:DBDiscard:DB$ Discard | ValidTgts$ Player | Mode$ RevealDiscardAll | DiscardValid$ Card.NamedCard | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearNamedCard$ True
 AI:RemoveDeck:All
-Oracle:Menace\nAt the beginning of your precombat main phase, you may sacrifice a creature. When you do, choose a nonland card name, then target player reveals their hand and discards all cards with that name.
+Oracle:Menace\nAt the beginning of your first main phase, you may sacrifice a creature. When you do, choose a nonland card name, then target player reveals their hand and discards all cards with that name.

--- a/forge-gui/res/cardsfolder/c/coalition_relic.txt
+++ b/forge-gui/res/cardsfolder/c/coalition_relic.txt
@@ -3,9 +3,9 @@ ManaCost:3
 Types:Artifact
 A:AB$ Mana | Cost$ T | Produced$ Any | Amount$ 1 | SpellDescription$ Add one mana of any color.
 A:AB$ PutCounter | Cost$ T | CounterType$ CHARGE | CounterNum$ 1 | SpellDescription$ Put a charge counter on CARDNAME.
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigRemove | TriggerDescription$ At the beginning of your precombat main phase, remove all charge counters from CARDNAME. Add one mana of any color for each charge counter removed this way.
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigRemove | TriggerDescription$ At the beginning of your first main phase, remove all charge counters from CARDNAME. Add one mana of any color for each charge counter removed this way.
 SVar:TrigRemove:DB$ RemoveCounter | CounterType$ CHARGE | CounterNum$ All | RememberRemoved$ True | SubAbility$ TrigGetMana
 SVar:TrigGetMana:DB$ Mana | Produced$ Combo Any | Amount$ NumRemoved | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:NumRemoved:Count$RememberedSize
-Oracle:{T}: Add one mana of any color.\n{T}: Put a charge counter on Coalition Relic.\nAt the beginning of your precombat main phase, remove all charge counters from Coalition Relic. Add one mana of any color for each charge counter removed this way.
+Oracle:{T}: Add one mana of any color.\n{T}: Put a charge counter on Coalition Relic.\nAt the beginning of your first main phase, remove all charge counters from Coalition Relic. Add one mana of any color for each charge counter removed this way.

--- a/forge-gui/res/cardsfolder/c/crack_in_time.txt
+++ b/forge-gui/res/cardsfolder/c/crack_in_time.txt
@@ -2,8 +2,8 @@ Name:Crack in Time
 ManaCost:3 W
 Types:Enchantment
 K:Vanishing:3
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExile | Secondary$ True | TriggerDescription$ When CARDNAME enters and at the beginning of your precombat main phase, exile target creature an opponent controls until CARDNAME leaves the battlefield.
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigExile | TriggerDescription$ When CARDNAME enters and at the beginning of your precombat main phase, exile target creature an opponent controls until CARDNAME leaves the battlefield.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExile | Secondary$ True | TriggerDescription$ When CARDNAME enters and at the beginning of your first main phase, exile target creature an opponent controls until CARDNAME leaves the battlefield.
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigExile | TriggerDescription$ When CARDNAME enters and at the beginning of your first main phase, exile target creature an opponent controls until CARDNAME leaves the battlefield.
 SVar:TrigExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | Duration$ UntilHostLeavesPlay
 DeckHas:Ability$Counters
-Oracle:Vanishing 3 (This enchantment enters with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Crack in Time enters and at the beginning of your precombat main phase, exile target creature an opponent controls until Crack in Time leaves the battlefield.
+Oracle:Vanishing 3 (This enchantment enters with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Crack in Time enters and at the beginning of your first main phase, exile target creature an opponent controls until Crack in Time leaves the battlefield.

--- a/forge-gui/res/cardsfolder/e/eladamris_vineyard.txt
+++ b/forge-gui/res/cardsfolder/e/eladamris_vineyard.txt
@@ -1,6 +1,6 @@
 Name:Eladamri's Vineyard
 ManaCost:G
 Types:Enchantment
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ Player | TriggerZones$ Battlefield | Execute$ TrigMana | TriggerDescription$ At the beginning of each player's precombat main phase, that player adds {G}{G}.
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ Player | TriggerZones$ Battlefield | Execute$ TrigMana | TriggerDescription$ At the beginning of each player's first main phase, that player adds {G}{G}.
 SVar:TrigMana:DB$ Mana | Produced$ G | Amount$ 2 | Defined$ TriggeredPlayer
-Oracle:At the beginning of each player's precombat main phase, that player adds {G}{G}.
+Oracle:At the beginning of each player's first main phase, that player adds {G}{G}.

--- a/forge-gui/res/cardsfolder/e/electrozoa.txt
+++ b/forge-gui/res/cardsfolder/e/electrozoa.txt
@@ -6,6 +6,6 @@ K:Flash
 K:Flying
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigEnergy | TriggerDescription$ When CARDNAME enters, you get {E}{E} (two energy counters).
 SVar:TrigEnergy:DB$ PutCounter | Defined$ You | CounterType$ ENERGY | CounterNum$ 2
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigTap | TriggerDescription$ At the beginning of your precombat main phase, tap CARDNAME unless you pay {E}.
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigTap | TriggerDescription$ At the beginning of your first main phase, tap CARDNAME unless you pay {E}.
 SVar:TrigTap:DB$ Tap | UnlessCost$ PayEnergy<1> | UnlessPayer$ You | Defined$ Self
-Oracle:Flash\nFlying\nWhen Electrozoa enters, you get {E}{E} (two energy counters).\nAt the beginning of your precombat main phase, tap Electrozoa unless you pay {E}.
+Oracle:Flash\nFlying\nWhen Electrozoa enters, you get {E}{E} (two energy counters).\nAt the beginning of your first main phase, tap Electrozoa unless you pay {E}.

--- a/forge-gui/res/cardsfolder/e/elemental_resonance.txt
+++ b/forge-gui/res/cardsfolder/e/elemental_resonance.txt
@@ -3,6 +3,6 @@ ManaCost:2 G G
 Types:Enchantment Aura
 K:Enchant permanent
 A:SP$ Attach | Cost$ 2 G G | ValidTgts$ Permanent | AILogic$ Pump
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigMana | TriggerDescription$ At the beginning of your precombat main phase, add mana equal to enchanted permanent's mana cost. (Mana cost includes color. If a mana symbol has multiple colors, choose one.)
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigMana | TriggerDescription$ At the beginning of your first main phase, add mana equal to enchanted permanent's mana cost. (Mana cost includes color. If a mana symbol has multiple colors, choose one.)
 SVar:TrigMana:DB$ Mana | Produced$ Special EnchantedManaCost
-Oracle:Enchant permanent\nAt the beginning of your precombat main phase, add mana equal to enchanted permanent's mana cost. (Mana cost includes color. If a mana symbol has multiple colors, choose one.)
+Oracle:Enchant permanent\nAt the beginning of your first main phase, add mana equal to enchanted permanent's mana cost. (Mana cost includes color. If a mana symbol has multiple colors, choose one.)

--- a/forge-gui/res/cardsfolder/f/florian_voldaren_scion.txt
+++ b/forge-gui/res/cardsfolder/f/florian_voldaren_scion.txt
@@ -3,10 +3,10 @@ ManaCost:1 B R
 Types:Legendary Creature Vampire Noble
 PT:3/3
 K:First Strike
-T:Mode$ Phase | Phase$ Main2 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDig | TriggerDescription$ At the beginning of your postcombat main phase, look at the top X cards of your library, where X is the total amount of life your opponents lost this turn. Exile one of those cards and put the rest on the bottom of your library in a random order. You may play the exiled card this turn.
+T:Mode$ Phase | Phase$ Main2 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDig | TriggerDescription$ At the beginning of each of your postcombat main phases, look at the top X cards of your library, where X is the total amount of life your opponents lost this turn. Exile one of those cards and put the rest on the bottom of your library in a random order. You may play the exiled card this turn.
 SVar:TrigDig:DB$ Dig | DigNum$ X | ChangeNum$ 1 | DestinationZone$ Exile | RestRandomOrder$ True | RememberChanged$ True | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ Play | SubAbility$ DBCleanup | ForgetOnMoved$ Exile
 SVar:Play:Mode$ Continuous | MayPlay$ True | EffectZone$ Command | Affected$ Card.IsRemembered | AffectedZone$ Exile | Description$ You may play the exiled card this turn.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Count$LifeOppsLostThisTurn
-Oracle:First strike\nAt the beginning of your postcombat main phase, look at the top X cards of your library, where X is the total amount of life your opponents lost this turn. Exile one of those cards and put the rest on the bottom of your library in a random order. You may play the exiled card this turn.
+Oracle:First strike\nAt the beginning of each of your postcombat main phases, look at the top X cards of your library, where X is the total amount of life your opponents lost this turn. Exile one of those cards and put the rest on the bottom of your library in a random order. You may play the exiled card this turn.

--- a/forge-gui/res/cardsfolder/f/foreboding_statue_forsaken_thresher.txt
+++ b/forge-gui/res/cardsfolder/f/foreboding_statue_forsaken_thresher.txt
@@ -17,6 +17,6 @@ Name:Forsaken Thresher
 ManaCost:no cost
 Types:Artifact Creature Construct
 PT:5/5
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigMana | TriggerDescription$ At the beginning of your precombat main phase, add one mana of any color.
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigMana | TriggerDescription$ At the beginning of your first main phase, add one mana of any color.
 SVar:TrigMana:DB$ Mana | Produced$ Any
-Oracle:At the beginning of your precombat main phase, add one mana of any color.
+Oracle:At the beginning of your first main phase, add one mana of any color.

--- a/forge-gui/res/cardsfolder/f/four_knocks.txt
+++ b/forge-gui/res/cardsfolder/f/four_knocks.txt
@@ -2,7 +2,7 @@ Name:Four Knocks
 ManaCost:2 W
 Types:Enchantment
 K:Vanishing:4
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ At the beginning of your precombat main phase, draw a card.
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ At the beginning of your first main phase, draw a card.
 SVar:TrigDraw:DB$ Draw
 DeckHas:Ability$Counters
-Oracle:Vanishing 4 (This enchantment enters with four time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nAt the beginning of your precombat main phase, draw a card.
+Oracle:Vanishing 4 (This enchantment enters with four time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nAt the beginning of your first main phase, draw a card.

--- a/forge-gui/res/cardsfolder/g/ghitu_embercoiler.txt
+++ b/forge-gui/res/cardsfolder/g/ghitu_embercoiler.txt
@@ -3,7 +3,7 @@ ManaCost:1 R
 Types:Creature Human Wizard
 PT:2/2
 K:Prowess
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigSeek | TriggerDescription$ At the beginning of your precombat main phase, you may discard a card. If you do, seek a card with greater mana value and exile it. Until the end of your next turn, you may play the exiled card.
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigSeek | TriggerDescription$ At the beginning of your first main phase, you may discard a card. If you do, seek a card with greater mana value and exile it. Until the end of your next turn, you may play the exiled card.
 SVar:TrigSeek:AB$ Seek | Cost$ Discard<1/Card> | Type$ Card.cmcGTX | RememberFound$ True | SubAbility$ DBExile
 SVar:X:Discarded$CardManaCost
 SVar:DBExile:DB$ ChangeZone | Origin$ Hand | Destination$ Exile | Defined$ Remembered | SubAbility$ DBEffect
@@ -11,4 +11,4 @@ SVar:DBEffect:DB$ Effect | RememberObjects$ Remembered | StaticAbilities$ MayPla
 SVar:MayPlay:Mode$ Continuous | Affected$ Card.IsRemembered | MayPlay$ True | EffectZone$ Command | AffectedZone$ Exile | Description$ Until the end of your next turn, you may play the exiled card.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 DeckHas:Ability$Discard
-Oracle:Prowess\nAt the beginning of your precombat main phase, you may discard a card. If you do, seek a card with greater mana value and exile it. Until the end of your next turn, you may play the exiled card.
+Oracle:Prowess\nAt the beginning of your first main phase, you may discard a card. If you do, seek a card with greater mana value and exile it. Until the end of your next turn, you may play the exiled card.

--- a/forge-gui/res/cardsfolder/h/hulking_raptor.txt
+++ b/forge-gui/res/cardsfolder/h/hulking_raptor.txt
@@ -3,6 +3,6 @@ ManaCost:2 G G
 Types:Creature Dinosaur
 PT:5/3
 K:Ward:2
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigMana | TriggerDescription$ At the beginning of your precombat main phase, add {G}{G}.
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigMana | TriggerDescription$ At the beginning of your first main phase, add {G}{G}.
 SVar:TrigMana:DB$ Mana | Produced$ G | Amount$ 2 | Defined$ TriggeredPlayer
-Oracle:Ward {2}\nAt the beginning of your precombat main phase, add {G}{G}.
+Oracle:Ward {2}\nAt the beginning of your first main phase, add {G}{G}.

--- a/forge-gui/res/cardsfolder/k/kirri_talented_sprout.txt
+++ b/forge-gui/res/cardsfolder/k/kirri_talented_sprout.txt
@@ -3,7 +3,7 @@ ManaCost:1 R G W
 Types:Legendary Creature Plant Druid
 PT:0/3
 S:Mode$ Continuous | Affected$ Plant.Other+YouCtrl,Treefolk.Other+YouCtrl | AddPower$ 2 | Description$ Other Plants and Treefolk you control get +2/+0.
-T:Mode$ Phase | Phase$ Main2 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigChangeZone | TriggerDescription$ At the beginning of your postcombat main phase, return target Plant, Treefolk, or land card from your graveyard to your hand.
+T:Mode$ Phase | Phase$ Main2 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigChangeZone | TriggerDescription$ At the beginning of each of your postcombat main phases, return target Plant, Treefolk, or land card from your graveyard to your hand.
 SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Plant.YouOwn,Treefolk.YouOwn,Land.YouOwn | TgtPrompt$ Select target Plant, Treefolk, or land card from your graveyard
 DeckNeeds:Ability$Graveyard & Type$Plant|Treefolk
-Oracle:Other Plants and Treefolk you control get +2/+0.\nAt the beginning of your postcombat main phase, return target Plant, Treefolk, or land card from your graveyard to your hand.
+Oracle:Other Plants and Treefolk you control get +2/+0.\nAt the beginning of each of your postcombat main phases, return target Plant, Treefolk, or land card from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/k/klothys_god_of_destiny.txt
+++ b/forge-gui/res/cardsfolder/k/klothys_god_of_destiny.txt
@@ -5,11 +5,11 @@ PT:4/5
 K:Indestructible
 S:Mode$ Continuous | Affected$ Card.Self | RemoveType$ Creature | CheckSVar$ X | SVarCompare$ LT7 | Description$ As long as your devotion to red and green is less than seven, NICKNAME isn't a creature.
 SVar:X:Count$DevotionDual.Red.Green
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigChangeZone | TriggerDescription$ At the beginning of your precombat main phase, exile target card from a graveyard. If it was a land card, add {R} or {G}. Otherwise, you gain 2 life and NICKNAME deals 2 damage to each opponent.
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigChangeZone | TriggerDescription$ At the beginning of your first main phase, exile target card from a graveyard. If it was a land card, add {R} or {G}. Otherwise, you gain 2 life and NICKNAME deals 2 damage to each opponent.
 SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | ValidTgts$ Card | TgtPrompt$ Select target card in a graveyard | RememberChanged$ True | SubAbility$ DBMana
 SVar:DBMana:DB$ Mana | Amount$ 1 | Produced$ Combo R G | ConditionDefined$ Remembered | ConditionPresent$ Land | ConditionCompare$ EQ1 | SubAbility$ DBGainLife
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 2 | ConditionDefined$ Remembered | ConditionPresent$ Land | ConditionCompare$ EQ0 | SubAbility$ DBDamage
 SVar:DBDamage:DB$ DealDamage | Defined$ Player.Opponent | NumDmg$ 2 | ConditionDefined$ Remembered | ConditionPresent$ Land | ConditionCompare$ EQ0 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 DeckHas:Ability$LifeGain
-Oracle:Indestructible\nAs long as your devotion to red and green is less than seven, Klothys isn't a creature.\nAt the beginning of your precombat main phase, exile target card from a graveyard. If it was a land card, add {R} or {G}. Otherwise, you gain 2 life and Klothys deals 2 damage to each opponent.
+Oracle:Indestructible\nAs long as your devotion to red and green is less than seven, Klothys isn't a creature.\nAt the beginning of your first main phase, exile target card from a graveyard. If it was a land card, add {R} or {G}. Otherwise, you gain 2 life and Klothys deals 2 damage to each opponent.

--- a/forge-gui/res/cardsfolder/m/magus_of_the_vineyard.txt
+++ b/forge-gui/res/cardsfolder/m/magus_of_the_vineyard.txt
@@ -2,6 +2,6 @@ Name:Magus of the Vineyard
 ManaCost:G
 Types:Creature Human Wizard
 PT:1/1
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ Player | Execute$ TrigMana | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of each player's precombat main phase, that player adds {G}{G}.
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ Player | Execute$ TrigMana | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of each player's first main phase, that player adds {G}{G}.
 SVar:TrigMana:DB$ Mana | Produced$ G | Amount$ 2 | Defined$ TriggeredPlayer
-Oracle:At the beginning of each player's precombat main phase, that player adds {G}{G}.
+Oracle:At the beginning of each player's first main phase, that player adds {G}{G}.

--- a/forge-gui/res/cardsfolder/m/megatron_tyrant_megatron_destructive_force.txt
+++ b/forge-gui/res/cardsfolder/m/megatron_tyrant_megatron_destructive_force.txt
@@ -4,13 +4,13 @@ Types:Legendary Artifact Creature Robot
 PT:7/5
 K:More Than Meets the Eye:1 R W B
 S:Mode$ CantBeCast | ValidCard$ Card | Caster$ Opponent | Phases$ BeginCombat->EndCombat | Description$ Your opponents can't cast spells during combat.
-T:Mode$ Phase | Phase$ Main2 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigConvert | OptionalDecider$ You | TriggerDescription$ At the beginning of your postcombat main phase, you may convert NICKNAME. If you do, add {C} for each 1 life your opponents have lost this turn.
+T:Mode$ Phase | Phase$ Main2 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigConvert | OptionalDecider$ You | TriggerDescription$ At the beginning of each of your postcombat main phases, you may convert NICKNAME. If you do, add {C} for each 1 life your opponents have lost this turn.
 SVar:TrigConvert:DB$ SetState | Mode$ Transform | RememberChanged$ True | SubAbility$ DBMana
 SVar:DBMana:DB$ Mana | ConditionDefined$ Remembered | ConditionPresent$ Card | Produced$ C | Amount$ X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Count$LifeOppsLostThisTurn
 AlternateMode:DoubleFaced
-Oracle:More Than Meets the Eye {1}{R}{W}{B} (You may cast this card converted for {1}{R}{W}{B}.)\nYour opponents can't cast spells during combat.\nAt the beginning of your postcombat main phase, you may convert Megatron. If you do, add {C} for each 1 life your opponents have lost this turn.
+Oracle:More Than Meets the Eye {1}{R}{W}{B} (You may cast this card converted for {1}{R}{W}{B}.)\nYour opponents can't cast spells during combat.\nAt the beginning of each of your postcombat main phases, you may convert Megatron. If you do, add {C} for each 1 life your opponents have lost this turn.
 
 ALTERNATE
 

--- a/forge-gui/res/cardsfolder/n/neheb_the_eternal.txt
+++ b/forge-gui/res/cardsfolder/n/neheb_the_eternal.txt
@@ -3,8 +3,8 @@ ManaCost:3 R R
 Types:Legendary Creature Zombie Minotaur Warrior
 PT:4/6
 K:Afflict:3
-T:Mode$ Phase | Phase$ Main2 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigMana | TriggerDescription$ At the beginning of your postcombat main phase, add {R} for each 1 life your opponents have lost this turn.
+T:Mode$ Phase | Phase$ Main2 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigMana | TriggerDescription$ At the beginning of each of your postcombat main phases, add {R} for each 1 life your opponents have lost this turn.
 SVar:TrigMana:DB$ Mana | Produced$ R | Amount$ X
 SVar:X:Count$LifeOppsLostThisTurn
 SVar:PlayMain1:TRUE
-Oracle:Afflict 3 (Whenever this creature becomes blocked, defending player loses 3 life.)\nAt the beginning of your postcombat main phase, add {R} for each 1 life your opponents have lost this turn.
+Oracle:Afflict 3 (Whenever this creature becomes blocked, defending player loses 3 life.)\nAt the beginning of each of your postcombat main phases, add {R} for each 1 life your opponents have lost this turn.

--- a/forge-gui/res/cardsfolder/o/old_one_eye.txt
+++ b/forge-gui/res/cardsfolder/o/old_one_eye.txt
@@ -6,8 +6,8 @@ K:Trample
 S:Mode$ Continuous | Affected$ Creature.Other+YouCtrl | AddKeyword$ Trample | Description$ Other creatures you control have trample.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a 5/5 green Tyranid creature token.
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ g_5_5_tyranid | TokenOwner$ You
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | IsPresent$ Card.StrictlySelf | TriggerZones$ Graveyard | PresentZone$ Graveyard | PresentPlayer$ You | Execute$ TrigReturn | TriggerDescription$ Fast Healing — At the beginning of your precombat main phase, you may discard two cards. If you do, return CARDNAME from your graveyard to your hand.
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | IsPresent$ Card.StrictlySelf | TriggerZones$ Graveyard | PresentZone$ Graveyard | PresentPlayer$ You | Execute$ TrigReturn | TriggerDescription$ Fast Healing — At the beginning of your first main phase, you may discard two cards. If you do, return CARDNAME from your graveyard to your hand.
 SVar:TrigReturn:AB$ ChangeZone | Cost$ Discard<2/Card> | Defined$ Self | Origin$ Graveyard | Destination$ Hand
 DeckHas:Ability$Graveyard|Discard|Token & Keyword$Trample
 SVar:PlayMain1:TRUE
-Oracle:Trample\nOther creatures you control have trample.\nWhen Old One Eye enters, create a 5/5 green Tyranid creature token.\nFast Healing — At the beginning of your precombat main phase, you may discard two cards. If you do, return Old One Eye from your graveyard to your hand.
+Oracle:Trample\nOther creatures you control have trample.\nWhen Old One Eye enters, create a 5/5 green Tyranid creature token.\nFast Healing — At the beginning of your first main phase, you may discard two cards. If you do, return Old One Eye from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/o/omnath_locus_of_all.txt
+++ b/forge-gui/res/cardsfolder/o/omnath_locus_of_all.txt
@@ -4,11 +4,11 @@ Types:Legendary Creature Phyrexian Elemental
 PT:4/4
 R:Event$ LoseMana | ValidPlayer$ You | ReplacementResult$ Replaced | ReplaceWith$ ConvertMana | ActiveZones$ Battlefield | Description$ If you would lose unspent mana, that mana becomes black instead.
 SVar:ConvertMana:DB$ ReplaceMana | ReplaceType$ Black
-T:Mode$ Phase | ValidPlayer$ You | Phase$ Main1 | TriggerZones$ Battlefield | Execute$ TrigPeek | TriggerDescription$ At the beginning of your precombat main phase, look at the top card of your library. You may reveal that card if it has three or more colored mana symbols in its mana cost. If you do, add three mana in any combination of its colors and put it into your hand. If you don't reveal it, put it into your hand.
+T:Mode$ Phase | ValidPlayer$ You | Phase$ Main1 | TriggerZones$ Battlefield | Execute$ TrigPeek | TriggerDescription$ At the beginning of your first main phase, look at the top card of your library. You may reveal that card if it has three or more colored mana symbols in its mana cost. If you do, add three mana in any combination of its colors and put it into your hand. If you don't reveal it, put it into your hand.
 SVar:TrigPeek:DB$ PeekAndReveal | Defined$ You | NoReveal$ True | RememberPeeked$ True | SubAbility$ DBReveal
 SVar:DBReveal:DB$ PeekAndReveal | Defined$ You | NoPeek$ True | RevealOptional$ True | ImprintRevealed$ True | ConditionCheckSVar$ ColorAmount | ConditionSVarCompare$ GE3 | SubAbility$ DBMana
 SVar:DBMana:DB$ ManaReflected | Produced$ Combo | ReflectProperty$ Is | ColorOrType$ Color | Amount$ 3 | Valid$ Defined.Imprinted | ConditionDefined$ Imprinted | ConditionPresent$ Card | SubAbility$ DBMove
 SVar:DBMove:DB$ ChangeZone | Origin$ Library | Destination$ Hand | Defined$ Remembered | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearImprinted$ True
 SVar:ColorAmount:Remembered$ChromaSource
-Oracle:If you would lose unspent mana, that mana becomes black instead.\nAt the beginning of your precombat main phase, look at the top card of your library. You may reveal that card if it has three or more colored mana symbols in its mana cost. If you do, add three mana in any combination of its colors and put it into your hand. If you don't reveal it, put it into your hand.
+Oracle:If you would lose unspent mana, that mana becomes black instead.\nAt the beginning of your first main phase, look at the top card of your library. You may reveal that card if it has three or more colored mana symbols in its mana cost. If you do, add three mana in any combination of its colors and put it into your hand. If you don't reveal it, put it into your hand.

--- a/forge-gui/res/cardsfolder/p/party_thrasher.txt
+++ b/forge-gui/res/cardsfolder/p/party_thrasher.txt
@@ -3,10 +3,10 @@ ManaCost:1 R
 Types:Creature Lizard Wizard
 PT:1/4
 S:Mode$ Continuous | Affected$ Card.YouCtrl+nonCreature+wasCastFromExile | AffectedZone$ Stack | AddKeyword$ Convoke | Description$ Noncreature spells you cast from exile have convoke. (Each creature you tap while casting a noncreature spell from exile pays for {1} or one mana of that creature's color.)
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigExile | TriggerDescription$ At the beginning of your precombat main phase, you may discard a card. If you do, exile the top two cards of your library, then choose one of them. You may play that card this turn.
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigExile | TriggerDescription$ At the beginning of your first main phase, you may discard a card. If you do, exile the top two cards of your library, then choose one of them. You may play that card this turn.
 SVar:TrigExile:AB$ Dig | Cost$ Discard<1/Card> | DigNum$ 2 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBChoose
 SVar:DBChoose:DB$ ChooseCard | Amount$ 1 | Mandatory$ True | Choices$ Card.IsRemembered | ChoiceZone$ Exile | ChoiceTitle$ Choose one of the exiled cards | SubAbility$ DBPlayEffect
 SVar:DBPlayEffect:DB$ Effect | StaticAbilities$ STPlay | ExileOnMoved$ Exile | SubAbility$ DBClearChosen
 SVar:STPlay:Mode$ Continuous | MayPlay$ True | EffectZone$ Command | Affected$ Card.ChosenCard | AffectedZone$ Exile | Description$ You may play the chosen card this turn.
 SVar:DBClearChosen:DB$ Cleanup | ClearChosenCard$ True | ClearRemembered$ True
-Oracle:Noncreature spells you cast from exile have convoke. (Each creature you tap while casting a noncreature spell from exile pays for {1} or one mana of that creature's color.)\nAt the beginning of your precombat main phase, you may discard a card. If you do, exile the top two cards of your library, then choose one of them. You may play that card this turn.
+Oracle:Noncreature spells you cast from exile have convoke. (Each creature you tap while casting a noncreature spell from exile pays for {1} or one mana of that creature's color.)\nAt the beginning of your first main phase, you may discard a card. If you do, exile the top two cards of your library, then choose one of them. You may play that card this turn.

--- a/forge-gui/res/cardsfolder/p/plasm_capture.txt
+++ b/forge-gui/res/cardsfolder/p/plasm_capture.txt
@@ -1,9 +1,9 @@
 Name:Plasm Capture
 ManaCost:G G U U
 Types:Instant
-A:SP$ Counter | TargetType$ Spell | RememberCounteredCMC$ True | ValidTgts$ Card | SubAbility$ DBDelTrig | SpellDescription$ Counter target spell. At the beginning of your next precombat main phase, add X mana in any combination of colors, where X is that spell's mana value.
-SVar:DBDelTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | Execute$ AddMana | TriggerDescription$ At the beginning of your next precombat main phase, add X mana in any combination of colors, where X is that spell's mana value. | RememberNumber$ True | SubAbility$ DBCleanup
+A:SP$ Counter | TargetType$ Spell | RememberCounteredCMC$ True | ValidTgts$ Card | SubAbility$ DBDelTrig | SpellDescription$ Counter target spell. At the beginning of your next first main phase, add X mana in any combination of colors, where X is that spell's mana value.
+SVar:DBDelTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | Execute$ AddMana | TriggerDescription$ At the beginning of your next first main phase, add X mana in any combination of colors, where X is that spell's mana value. | RememberNumber$ True | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:AddMana:DB$ Mana | Produced$ Combo Any | Amount$ X
 SVar:X:Count$TriggerRememberAmount
-Oracle:Counter target spell. At the beginning of your next precombat main phase, add X mana in any combination of colors, where X is that spell's mana value.
+Oracle:Counter target spell. At the beginning of your next first main phase, add X mana in any combination of colors, where X is that spell's mana value.

--- a/forge-gui/res/cardsfolder/r/ripples_of_undeath.txt
+++ b/forge-gui/res/cardsfolder/r/ripples_of_undeath.txt
@@ -1,9 +1,9 @@
 Name:Ripples of Undeath
 ManaCost:1 B
 Types:Enchantment
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigMill | TriggerDescription$ At the beginning of your precombat main phase, mill three cards. Then you may pay {1} and 3 life. If you do, put a card from among those cards into your hand.
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigMill | TriggerDescription$ At the beginning of your first main phase, mill three cards. Then you may pay {1} and 3 life. If you do, put a card from among those cards into your hand.
 SVar:TrigMill:DB$ Mill | NumCards$ 3 | RememberMilled$ True | SubAbility$ DBReturn
 SVar:DBReturn:DB$ ChangeZone | UnlessCost$ 1 PayLife<3> | UnlessPayer$ You | UnlessSwitched$ True | Hidden$ True | Origin$ Graveyard,Exile | Destination$ Hand | ChangeType$ Card.IsRemembered | SelectPrompt$ You may put a card from among them into your hand | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 DeckHas:Ability$Mill|Graveyard
-Oracle:At the beginning of your precombat main phase, mill three cards. Then you may pay {1} and 3 life. If you do, put a card from among those cards into your hand.
+Oracle:At the beginning of your first main phase, mill three cards. Then you may pay {1} and 3 life. If you do, put a card from among those cards into your hand.

--- a/forge-gui/res/cardsfolder/s/sanctum_of_calm_waters.txt
+++ b/forge-gui/res/cardsfolder/s/sanctum_of_calm_waters.txt
@@ -1,8 +1,8 @@
 Name:Sanctum of Calm Waters
 ManaCost:3 U
 Types:Legendary Enchantment Shrine
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ At the beginning of your precombat main phase, you may draw X cards, where X is the number of Shrines you control. If you do, discard a card.
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ At the beginning of your first main phase, you may draw X cards, where X is the number of Shrines you control. If you do, discard a card.
 SVar:TrigDraw:AB$ Discard | Defined$ You | Mode$ TgtChoose | NumCards$ 1 | Cost$ Draw<X/You>
 SVar:X:Count$TypeYouCtrl.Shrine
 DeckHints:Type$Shrine
-Oracle:At the beginning of your precombat main phase, you may draw X cards, where X is the number of Shrines you control. If you do, discard a card.
+Oracle:At the beginning of your first main phase, you may draw X cards, where X is the number of Shrines you control. If you do, discard a card.

--- a/forge-gui/res/cardsfolder/s/sanctum_of_fruitful_harvest.txt
+++ b/forge-gui/res/cardsfolder/s/sanctum_of_fruitful_harvest.txt
@@ -1,8 +1,8 @@
 Name:Sanctum of Fruitful Harvest
 ManaCost:2 G
 Types:Legendary Enchantment Shrine
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigMana | TriggerDescription$ At the beginning of your precombat main phase, add X mana of any one color, where X is the number of Shrines you control.
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigMana | TriggerDescription$ At the beginning of your first main phase, add X mana of any one color, where X is the number of Shrines you control.
 SVar:TrigMana:DB$ Mana | Produced$ Any | Amount$ X
 SVar:X:Count$TypeYouCtrl.Shrine
 DeckHints:Type$Shrine
-Oracle:At the beginning of your precombat main phase, add X mana of any one color, where X is the number of Shrines you control.
+Oracle:At the beginning of your first main phase, add X mana of any one color, where X is the number of Shrines you control.

--- a/forge-gui/res/cardsfolder/s/sanctum_of_stone_fangs.txt
+++ b/forge-gui/res/cardsfolder/s/sanctum_of_stone_fangs.txt
@@ -1,10 +1,10 @@
 Name:Sanctum of Stone Fangs
 ManaCost:1 B
 Types:Legendary Enchantment Shrine
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDrain | TriggerDescription$ At the beginning of your precombat main phase, each opponent loses X life and you gain X life, where X is the number of Shrines you control.
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDrain | TriggerDescription$ At the beginning of your first main phase, each opponent loses X life and you gain X life, where X is the number of Shrines you control.
 SVar:TrigDrain:DB$ LoseLife | Defined$ Player.Opponent | LifeAmount$ X | SubAbility$ DBGainLife
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ X
 SVar:X:Count$TypeYouCtrl.Shrine
 DeckHints:Type$Shrine
 DeckHas:Ability$LifeGain
-Oracle:At the beginning of your precombat main phase, each opponent loses X life and you gain X life, where X is the number of Shrines you control.
+Oracle:At the beginning of your first main phase, each opponent loses X life and you gain X life, where X is the number of Shrines you control.

--- a/forge-gui/res/cardsfolder/s/shadow_of_the_second_sun.txt
+++ b/forge-gui/res/cardsfolder/s/shadow_of_the_second_sun.txt
@@ -3,7 +3,7 @@ ManaCost:4 U U
 Types:Enchantment Aura
 K:Enchant player
 A:SP$ Attach | ValidTgts$ Player
-T:Mode$ Phase | Phase$ Main2 | ValidPlayer$ Player.EnchantedBy | TriggerZones$ Battlefield | Execute$ TrigAddPhase | TriggerDescription$ At the beginning of enchanted player's postcombat main phase, there is an additional beginning phase after this phase. (The end step happens after the added untap, upkeep, and draw steps.)
+T:Mode$ Phase | Phase$ Main2 | ValidPlayer$ Player.EnchantedBy | TriggerZones$ Battlefield | Execute$ TrigAddPhase | TriggerDescription$ At the beginning of each of enchanted player's postcombat main phases, there is an additional beginning phase after this phase. (The end step happens after the added untap, upkeep, and draw steps.)
 SVar:TrigAddPhase:DB$ AddPhase | ExtraPhase$ Beginning
 AI:RemoveDeck:Random
-Oracle:Enchant player\nAt the beginning of enchanted player's postcombat main phase, there is an additional beginning phase after this phase. (The end step happens after the added untap, upkeep, and draw steps.)
+Oracle:Enchant player\nAt the beginning of each of enchanted player's postcombat main phases, there is an additional beginning phase after this phase. (The end step happens after the added untap, upkeep, and draw steps.)

--- a/forge-gui/res/cardsfolder/s/sorin_of_house_markov_sorin_ravenous_neonate.txt
+++ b/forge-gui/res/cardsfolder/s/sorin_of_house_markov_sorin_ravenous_neonate.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature Human Noble
 PT:1/4
 K:Lifelink
 K:Extort
-T:Mode$ Phase | Phase$ Main2 | ValidPlayer$ You | TriggerZones$ Battlefield | CheckSVar$ LifeGained | SVarCompare$ GE3 | Execute$ TrigTransform | TriggerDescription$ At the beginning of your postcombat main phase, if you gained 3 or more life this turn, exile CARDNAME, then return him to the battlefield transformed under his owner's control.
+T:Mode$ Phase | Phase$ Main2 | ValidPlayer$ You | TriggerZones$ Battlefield | CheckSVar$ LifeGained | SVarCompare$ GE3 | Execute$ TrigTransform | TriggerDescription$ At the beginning of each of your postcombat main phases, if you gained 3 or more life this turn, exile CARDNAME, then return him to the battlefield transformed under his owner's control.
 SVar:TrigTransform:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | RememberChanged$ True | SubAbility$ DBReturn
 SVar:DBReturn:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Battlefield | Transformed$ True | ForgetOtherRemembered$ True | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
@@ -12,7 +12,7 @@ AlternateMode:DoubleFaced
 SVar:LifeGained:Count$LifeYouGainedThisTurn
 DeckHints:Ability$LifeGain
 DeckHas:Ability$LifeGain
-Oracle:Lifelink\nExtort (Whenever you cast a spell, you may pay {W/B}. If you do, each opponent loses 1 life and you gain that much life.)\nAt the beginning of your postcombat main phase, if you gained 3 or more life this turn, exile Sorin of House Markov, then return him to the battlefield transformed under his owner's control.
+Oracle:Lifelink\nExtort (Whenever you cast a spell, you may pay {W/B}. If you do, each opponent loses 1 life and you gain that much life.)\nAt the beginning of each of your postcombat main phases, if you gained 3 or more life this turn, exile Sorin of House Markov, then return him to the battlefield transformed under his owner's control.
 
 ALTERNATE
 

--- a/forge-gui/res/cardsfolder/s/sphinx_of_the_second_sun.txt
+++ b/forge-gui/res/cardsfolder/s/sphinx_of_the_second_sun.txt
@@ -3,7 +3,7 @@ ManaCost:6 U U
 Types:Creature Sphinx
 PT:6/6
 K:Flying
-T:Mode$ Phase | Phase$ Main2 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigAddPhase | TriggerDescription$ At the beginning of your postcombat main phase, there is an additional beginning phase after this phase. (The beginning phase includes the untap, upkeep, and draw steps.)
+T:Mode$ Phase | Phase$ Main2 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigAddPhase | TriggerDescription$ At the beginning of each of your postcombat main phases, there is an additional beginning phase after this phase. (The beginning phase includes the untap, upkeep, and draw steps.)
 SVar:TrigAddPhase:DB$ AddPhase | ExtraPhase$ Beginning
 SVar:PlayMain1:TRUE
-Oracle:Flying\nAt the beginning of your postcombat main phase, there is an additional beginning phase after this phase. (The beginning phase includes the untap, upkeep, and draw steps.)
+Oracle:Flying\nAt the beginning of each of your postcombat main phases, there is an additional beginning phase after this phase. (The beginning phase includes the untap, upkeep, and draw steps.)

--- a/forge-gui/res/cardsfolder/s/static_prison.txt
+++ b/forge-gui/res/cardsfolder/s/static_prison.txt
@@ -4,8 +4,8 @@ Types:Enchantment
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ When CARDNAME enters, exile target nonland permanent an opponent controls until CARDNAME leaves the battlefield. You get {E}{E} (two energy counters).
 SVar:TrigExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Permanent.nonLand+OppCtrl | SubAbility$ DBEnergy | TgtPrompt$ Select target nonland permanent an opponent controls | Duration$ UntilHostLeavesPlay
 SVar:DBEnergy:DB$ PutCounter | Defined$ You | CounterType$ ENERGY | CounterNum$ 2
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigSac | TriggerDescription$ At the beginning of your precombat main phase, sacrifice CARDNAME unless you pay {E}.
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigSac | TriggerDescription$ At the beginning of your first main phase, sacrifice CARDNAME unless you pay {E}.
 SVar:TrigSac:DB$ Sacrifice | UnlessCost$ PayEnergy<1> | UnlessPayer$ You
 SVar:PlayMain1:TRUE
 SVar:OblivionRing:TRUE
-Oracle:When Static Prison enters, exile target nonland permanent an opponent controls until Static Prison leaves the battlefield. You get {E}{E} (two energy counters).\nAt the beginning of your precombat main phase, sacrifice Static Prison unless you pay {E}.
+Oracle:When Static Prison enters, exile target nonland permanent an opponent controls until Static Prison leaves the battlefield. You get {E}{E} (two energy counters).\nAt the beginning of your first main phase, sacrifice Static Prison unless you pay {E}.

--- a/forge-gui/res/cardsfolder/t/thousand_moons_smithy_barracks_of_the_thousand.txt
+++ b/forge-gui/res/cardsfolder/t/thousand_moons_smithy_barracks_of_the_thousand.txt
@@ -3,12 +3,12 @@ ManaCost:2 W W
 Types:Legendary Artifact
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a white Gnome Soldier artifact creature token with "This creature's power and toughness are each equal to the number of artifacts and/or creatures you control."
 SVar:TrigToken:DB$ Token | TokenScript$ w_x_x_a_gnome_soldier_total_artifacts_creatures
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigTransform | TriggerDescription$ At the beginning of your precombat main phase, you may tap five untapped artifacts and/or creatures you control. If you do, transform CARDNAME.
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigTransform | TriggerDescription$ At the beginning of your first main phase, you may tap five untapped artifacts and/or creatures you control. If you do, transform CARDNAME.
 SVar:TrigTransform:AB$ SetState | Cost$ tapXType<5/Artifact;Creature/artifact or creature> | Defined$ Self | Mode$ Transform
 DeckHas:Ability$Token & Type$Gnome|Soldier
 DeckHints:Type$Artifact
 AlternateMode:DoubleFaced
-Oracle:When Thousand Moons Smithy enters, create a white Gnome Soldier artifact creature token with "This creature's power and toughness are each equal to the number of artifacts and/or creatures you control."\nAt the beginning of your precombat main phase, you may tap five untapped artifacts and/or creatures you control. If you do, transform Thousand Moons Smithy.
+Oracle:When Thousand Moons Smithy enters, create a white Gnome Soldier artifact creature token with "This creature's power and toughness are each equal to the number of artifacts and/or creatures you control."\nAt the beginning of your first main phase, you may tap five untapped artifacts and/or creatures you control. If you do, transform Thousand Moons Smithy.
 
 ALTERNATE
 

--- a/forge-gui/res/cardsfolder/t/tymna_the_weaver.txt
+++ b/forge-gui/res/cardsfolder/t/tymna_the_weaver.txt
@@ -3,9 +3,9 @@ ManaCost:1 W B
 Types:Legendary Creature Human Cleric
 PT:2/2
 K:Lifelink
-T:Mode$ Phase | Phase$ Main2 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ At the beginning of your postcombat main phase, you may pay X life, where X is the number of opponents that were dealt combat damage this turn. If you do, draw X cards.
+T:Mode$ Phase | Phase$ Main2 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ At the beginning of each of your postcombat main phases, you may pay X life, where X is the number of opponents that were dealt combat damage this turn. If you do, draw X cards.
 SVar:TrigDraw:AB$ Draw | Cost$ PayLife<X> | NumCards$ X
 SVar:X:PlayerCountRegisteredOpponents$HasPropertywasDealtCombatDamageThisTurn
 K:Partner
 SVar:PlayMain1:TRUE
-Oracle:Lifelink\nAt the beginning of your postcombat main phase, you may pay X life, where X is the number of opponents that were dealt combat damage this turn. If you do, draw X cards.\nPartner (You can have two commanders if both have partner.)
+Oracle:Lifelink\nAt the beginning of each of your postcombat main phases, you may pay X life, where X is the number of opponents that were dealt combat damage this turn. If you do, draw X cards.\nPartner (You can have two commanders if both have partner.)

--- a/forge-gui/res/cardsfolder/v/ventifact_bottle.txt
+++ b/forge-gui/res/cardsfolder/v/ventifact_bottle.txt
@@ -2,11 +2,11 @@ Name:Ventifact Bottle
 ManaCost:3
 Types:Artifact
 A:AB$ PutCounter | Cost$ X 1 T | CounterType$ CHARGE | CounterNum$ X | SorcerySpeed$ True | SpellDescription$ Put X charge counters on CARDNAME. Activate only any time you could cast a sorcery.
-T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigGetMana | CheckSVar$ Y | SVarCompare$ GE1 | TriggerDescription$ At the beginning of your precombat main phase, if CARDNAME has a charge counter on it, tap it and remove all charge counters from it. Add {C} for each charge counter removed this way.
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigGetMana | CheckSVar$ Y | SVarCompare$ GE1 | TriggerDescription$ At the beginning of your first main phase, if CARDNAME has a charge counter on it, tap it and remove all charge counters from it. Add {C} for each charge counter removed this way.
 SVar:TrigGetMana:DB$ Mana | Produced$ C | Amount$ Y | SubAbility$ TrigRemove
 SVar:TrigRemove:DB$ RemoveCounter | CounterType$ CHARGE | CounterNum$ Y | SubAbility$ DBTap
 SVar:DBTap:DB$ Tap | Defined$ Self
 SVar:X:Count$xPaid
 SVar:Y:Count$CardCounters.CHARGE
 AI:RemoveDeck:All
-Oracle:{X}{1}, {T}: Put X charge counters on Ventifact Bottle. Activate only as a sorcery.\nAt the beginning of your precombat main phase, if Ventifact Bottle has a charge counter on it, tap it and remove all charge counters from it. Add {C} for each charge counter removed this way.
+Oracle:{X}{1}, {T}: Put X charge counters on Ventifact Bottle. Activate only as a sorcery.\nAt the beginning of your first main phase, if Ventifact Bottle has a charge counter on it, tap it and remove all charge counters from it. Add {C} for each charge counter removed this way.

--- a/forge-gui/res/cardsfolder/w/world_at_war.txt
+++ b/forge-gui/res/cardsfolder/w/world_at_war.txt
@@ -1,8 +1,8 @@
 Name:World at War
 ManaCost:3 R R
 Types:Sorcery
-A:SP$ AddPhase | ExtraPhase$ Combat | AfterPhase$ Main2 | FollowedBy$ Main2 | BeforeFirstPostCombatMainEnd$ True | ExtraPhaseDelayedTrigger$ DelTrigUntap | ExtraPhaseDelayedTriggerExcute$ TrigUntapAll | SpellDescription$ After the first postcombat main phase this turn, there's an additional combat phase followed by an additional main phase. At the beginning of that combat, untap all creatures that attacked this turn.
+A:SP$ AddPhase | ExtraPhase$ Combat | AfterPhase$ Main2 | FollowedBy$ Main2 | BeforeFirstPostCombatMainEnd$ True | ExtraPhaseDelayedTrigger$ DelTrigUntap | ExtraPhaseDelayedTriggerExcute$ TrigUntapAll | SpellDescription$ After the second main phase this turn, there's an additional combat phase followed by an additional main phase. At the beginning of that combat, untap all creatures that attacked this turn.
 SVar:DelTrigUntap:Mode$ Phase | Phase$ BeginCombat | TriggerDescription$ At the beginning of that combat, untap all creatures that attacked this turn.
 SVar:TrigUntapAll:DB$ UntapAll | ValidCards$ Creature.attackedThisTurn
 K:Rebound
-Oracle:After the first postcombat main phase this turn, there's an additional combat phase followed by an additional main phase. At the beginning of that combat, untap all creatures that attacked this turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)
+Oracle:After the second main phase this turn, there's an additional combat phase followed by an additional main phase. At the beginning of that combat, untap all creatures that attacked this turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)


### PR DESCRIPTION
### Summary
- **Precombat Main Phase** → **First Main Phase**
- Updated "**Postcombat Main Phase**" cards to their current Oracle text
- World at War (**First Postcombat Main Phase** → **Second Main Phase**)