### PR TITLE
InTurnOrder parameter check for specific cards that force turn order of opponents

### DIFF
--- a/forge-game/src/main/java/forge/game/GameActionUtil.java
+++ b/forge-game/src/main/java/forge/game/GameActionUtil.java
@@ -48,7 +48,6 @@ import forge.util.Lang;
 import forge.util.TextUtil;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -832,12 +831,8 @@ public final class GameActionUtil {
             return list;
         }
         CardCollection completeList = new CardCollection();
-        PlayerCollection players = new PlayerCollection(game.getPlayers());
         // CR 613.7m use APNAP
-        int indexAP = players.indexOf(game.getPhaseHandler().getPlayerTurn());
-        if (indexAP != -1) {
-            Collections.rotate(players, - indexAP);
-        }
+        PlayerCollection players = game.getPlayersInTurnOrder(game.getPhaseHandler().getPlayerTurn());
         for (Player p : players) {
             CardCollection subList = new CardCollection();
             for (Card c : list) {

--- a/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
@@ -1193,11 +1193,7 @@ public class AbilityUtils {
         } else if (defined.equals("You")) {
             players.add(player);
         } else if (defined.equals("Opponent")) {
-            if (sa.hasParam("InTurnOrder") && sa.getParam("InTurnOrder").equals("True")) {
-                players.addAll(player.getOpponentsInTurnOrder());
-            } else {
-                players.addAll(player.getOpponents());
-            }
+            players.addAll(player.getOpponents());
         } else if (defined.startsWith("NextPlayerToYour")) {
             Direction dir = defined.substring(16).equals("Left") ? Direction.Left : Direction.Right;
             players.add(game.getNextPlayerAfter(player, dir));

--- a/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
@@ -1193,7 +1193,11 @@ public class AbilityUtils {
         } else if (defined.equals("You")) {
             players.add(player);
         } else if (defined.equals("Opponent")) {
-            players.addAll(player.getOpponents());
+            if (sa.hasParam("InTurnOrder") && sa.getParam("InTurnOrder").equals("True")) {
+                players.addAll(player.getOpponentsInTurnOrder());
+            } else {
+                players.addAll(player.getOpponents());
+            }
         } else if (defined.startsWith("NextPlayerToYour")) {
             Direction dir = defined.substring(16).equals("Left") ? Direction.Left : Direction.Right;
             players.add(game.getNextPlayerAfter(player, dir));

--- a/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
@@ -279,6 +279,7 @@ public abstract class SpellAbilityEffect {
         return getPlayers(definedFirst, definedParam, sa, null);
     }
     private static PlayerCollection getPlayers(final boolean definedFirst, final String definedParam, final SpellAbility sa, List<Player> resultDuplicate) {
+        Game game = sa.getHostCard().getGame();
         PlayerCollection resultUnique = null;
         final boolean useTargets = sa.usesTargeting() && (!definedFirst || !sa.hasParam(definedParam));
         if (useTargets) {
@@ -301,10 +302,12 @@ public abstract class SpellAbilityEffect {
         }
 
         // try sort in APNAP order
-        int indexAP = resultDuplicate.indexOf(sa.getHostCard().getGame().getPhaseHandler().getPlayerTurn());
-        if (indexAP != -1) {
-            Collections.rotate(resultDuplicate, - indexAP);
+        Player starter = game.getPhaseHandler().getPlayerTurn();
+        if (sa.hasParam("StartingWith")) {
+            starter = AbilityUtils.getDefinedPlayers(sa.getHostCard(), sa.getParam("StartingWith"), sa).getFirst();
         }
+        PlayerCollection ordered = game.getPlayersInTurnOrder(starter);
+        resultDuplicate.sort(Comparator.comparingInt(ordered::indexOf));
         return resultUnique;
     }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/RepeatEachEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/RepeatEachEffect.java
@@ -173,10 +173,23 @@ public class RepeatEachEffect extends SpellAbilityEffect {
             }
             boolean optional = sa.hasParam("RepeatOptionalForEachPlayer");
             boolean nextTurn = sa.hasParam("NextTurnForEachPlayer");
-            if (sa.hasParam("StartingWithActivator")) {
-                int aidx = repeatPlayers.indexOf(activator);
-                if (aidx != -1) {
-                    Collections.rotate(repeatPlayers, -aidx);
+            if (sa.hasParam("StartingWith")) {
+                switch (sa.getParam("StartingWith")) {
+                    case "Opponent":
+                        // NAPAP Order
+                        int aidx = repeatPlayers.indexOf(game.getNextPlayerAfter(activator));
+                        if (aidx != -1) {
+                            Collections.rotate(repeatPlayers, -aidx);
+                        }
+                        break;
+                    case "You":
+                    default:
+                        // APNAP Order
+                        aidx = repeatPlayers.indexOf(activator);
+                        if (aidx != -1) {
+                            Collections.rotate(repeatPlayers, -aidx);
+                        }
+                        break;
                 }
             }
             for (final Player p : repeatPlayers) {

--- a/forge-game/src/main/java/forge/game/ability/effects/RepeatEachEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/RepeatEachEffect.java
@@ -56,8 +56,7 @@ public class RepeatEachEffect extends SpellAbilityEffect {
             } else {
                 zone.add(ZoneType.Battlefield);
             }
-            repeatCards = CardLists.getValidCards(game.getCardsIn(zone),
-                    sa.getParam("RepeatCards"), source.getController(), source, sa);
+            repeatCards = CardLists.getValidCards(game.getCardsIn(zone), sa.getParam("RepeatCards"), source.getController(), source, sa);
         }
         else if (sa.hasParam(("RepeatSpellAbilities"))) {
             repeatSas = Lists.newArrayList();
@@ -167,31 +166,13 @@ public class RepeatEachEffect extends SpellAbilityEffect {
         }
 
         if (sa.hasParam("RepeatPlayers")) {
-            final FCollection<Player> repeatPlayers = AbilityUtils.getDefinedPlayers(source, sa.getParam("RepeatPlayers"), sa);
+            final FCollection<Player> repeatPlayers = getDefinedPlayersOrTargeted(sa, "RepeatPlayers");
             if (sa.hasParam("ClearRememberedBeforeLoop")) {
                 source.clearRemembered();
             }
             boolean optional = sa.hasParam("RepeatOptionalForEachPlayer");
             boolean nextTurn = sa.hasParam("NextTurnForEachPlayer");
-            if (sa.hasParam("StartingWith")) {
-                switch (sa.getParam("StartingWith")) {
-                    case "Opponent":
-                        // NAPAP Order
-                        int aidx = repeatPlayers.indexOf(game.getNextPlayerAfter(activator));
-                        if (aidx != -1) {
-                            Collections.rotate(repeatPlayers, -aidx);
-                        }
-                        break;
-                    case "You":
-                    default:
-                        // APNAP Order
-                        aidx = repeatPlayers.indexOf(activator);
-                        if (aidx != -1) {
-                            Collections.rotate(repeatPlayers, -aidx);
-                        }
-                        break;
-                }
-            }
+
             for (final Player p : repeatPlayers) {
                 if (optional && !p.getController().confirmAction(repeat, null, sa.getParam("RepeatOptionalMessage"), null)) {
                     continue;

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -303,6 +303,10 @@ public class Player extends GameEntity implements Comparable<Player> {
         return game.getPlayers().filter(PlayerPredicates.isOpponentOf(this));
     }
 
+    public final PlayerCollection getOpponentsInTurnOrder() {
+        return game.getPlayersInTurnOrder(this).filter(PlayerPredicates.isOpponentOf(this));
+    }
+
     public final PlayerCollection getRegisteredOpponents() {
         return game.getRegisteredPlayers().filter(PlayerPredicates.isOpponentOf(this));
     }

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -303,10 +303,6 @@ public class Player extends GameEntity implements Comparable<Player> {
         return game.getPlayers().filter(PlayerPredicates.isOpponentOf(this));
     }
 
-    public final PlayerCollection getOpponentsInTurnOrder() {
-        return game.getPlayersInTurnOrder(this).filter(PlayerPredicates.isOpponentOf(this));
-    }
-
     public final PlayerCollection getRegisteredOpponents() {
         return game.getRegisteredPlayers().filter(PlayerPredicates.isOpponentOf(this));
     }

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -300,7 +300,7 @@ public class Player extends GameEntity implements Comparable<Player> {
      * Should keep player relations somewhere in the match structure
      */
     public final PlayerCollection getOpponents() {
-        return game.getPlayers().filter(PlayerPredicates.isOpponentOf(this));
+        return game.getPlayersInTurnOrder(this).filter(PlayerPredicates.isOpponentOf(this));
     }
 
     public final PlayerCollection getRegisteredOpponents() {

--- a/forge-gui/res/adventure/common/custom_cards/farmers_tools.txt
+++ b/forge-gui/res/adventure/common/custom_cards/farmers_tools.txt
@@ -1,7 +1,7 @@
 Name:Farmer's Tools
 ManaCost:no cost
 Types:Artifact
-A:AB$ RepeatEach | Cost$ PayShards<2> | ActivationZone$ Command | RepeatSubAbility$ DBChangeZone | RepeatPlayers$ Player | SubAbility$ Eject | StartingWithActivator$ True | SpellDescription$ Starting with you, each player may put a land card from their hand onto the battlefield. Exile Farmer's Tools.
+A:AB$ RepeatEach | Cost$ PayShards<2> | ActivationZone$ Command | RepeatSubAbility$ DBChangeZone | RepeatPlayers$ Player | SubAbility$ Eject | StartingWith$ You | SpellDescription$ Starting with you, each player may put a land card from their hand onto the battlefield. Exile Farmer's Tools.
 SVar:DBChangeZone:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | ChangeType$ Land.RememberedPlayerCtrl | DefinedPlayer$ Player.IsRemembered | Chooser$ Player.IsRemembered | ChangeNum$ 1 | Hidden$ True
 SVar:Eject:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{M}{M}: Starting with you, each player may put a land card from their hand onto the battlefield. Exile Farmer's Tools.

--- a/forge-gui/res/cardsfolder/a/alliance_of_arms.txt
+++ b/forge-gui/res/cardsfolder/a/alliance_of_arms.txt
@@ -1,7 +1,7 @@
 Name:Alliance of Arms
 ManaCost:W
 Types:Sorcery
-A:SP$ RepeatEach | RepeatPlayers$ Player | StartingWithActivator$ True | RepeatSubAbility$ DBPay | SubAbility$ DBToken | StackDescription$ SpellDescription | SpellDescription$ Join forces — Starting with you, each player may pay any amount of mana. Each player creates X 1/1 white Soldier creature tokens, where X is the total amount of mana paid this way.
+A:SP$ RepeatEach | RepeatPlayers$ Player | StartingWith$ You | RepeatSubAbility$ DBPay | SubAbility$ DBToken | StackDescription$ SpellDescription | SpellDescription$ Join forces — Starting with you, each player may pay any amount of mana. Each player creates X 1/1 white Soldier creature tokens, where X is the total amount of mana paid this way.
 SVar:DBPay:DB$ ChooseNumber | Defined$ Player.IsRemembered | ChooseAnyNumber$ True | ListTitle$ amount of mana to pay | SubAbility$ DBStore
 SVar:DBStore:DB$ StoreSVar | SVar$ JoinForcesAmount | Type$ CountSVar | Expression$ JoinForcesAmount/Plus.Y | UnlessCost$ Y | UnlessPayer$ Player.IsRemembered | UnlessSwitched$ True | UnlessAI$ OnlyOwn
 SVar:DBToken:DB$ Token | TokenAmount$ JoinForcesAmount | TokenScript$ w_1_1_soldier | TokenOwner$ Player | StackDescription$ None

--- a/forge-gui/res/cardsfolder/c/collective_voyage.txt
+++ b/forge-gui/res/cardsfolder/c/collective_voyage.txt
@@ -1,7 +1,7 @@
 Name:Collective Voyage
 ManaCost:G
 Types:Sorcery
-A:SP$ RepeatEach | RepeatPlayers$ Player | StartingWithActivator$ True | RepeatSubAbility$ DBPay | SubAbility$ DBSearch | StackDescription$ SpellDescription | SpellDescription$ Join forces — Starting with you, each player may pay any amount of mana. Each player searches their library for up to X basic land cards, where X is the total amount of mana paid this way, puts them onto the battlefield tapped, then shuffles.
+A:SP$ RepeatEach | RepeatPlayers$ Player | StartingWith$ You | RepeatSubAbility$ DBPay | SubAbility$ DBSearch | StackDescription$ SpellDescription | SpellDescription$ Join forces — Starting with you, each player may pay any amount of mana. Each player searches their library for up to X basic land cards, where X is the total amount of mana paid this way, puts them onto the battlefield tapped, then shuffles.
 SVar:DBPay:DB$ ChooseNumber | Defined$ Player.IsRemembered | ChooseAnyNumber$ True | ListTitle$ amount of mana to pay | SubAbility$ DBStore
 SVar:DBStore:DB$ StoreSVar | SVar$ JoinForcesAmount | Type$ CountSVar | Expression$ JoinForcesAmount/Plus.Y | UnlessCost$ Y | UnlessPayer$ Player.IsRemembered | UnlessSwitched$ True | UnlessAI$ OnlyOwn
 SVar:DBSearch:DB$ ChangeZone | DefinedPlayer$ Player | ChangeType$ Land.Basic | ChangeNum$ JoinForcesAmount | Origin$ Library | Destination$ Battlefield | Tapped$ True | SubAbility$ DBReset | StackDescription$ None

--- a/forge-gui/res/cardsfolder/d/disciple_of_caelus_nin.txt
+++ b/forge-gui/res/cardsfolder/d/disciple_of_caelus_nin.txt
@@ -3,7 +3,7 @@ ManaCost:4 W
 Types:Creature Human Wizard
 PT:3/4
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigRepeatEach | TriggerDescription$ When CARDNAME enters, starting with you, each player chooses up to five permanents they control. All permanents other than CARDNAME that weren't chosen this way phase out.
-SVar:TrigRepeatEach:DB$ RepeatEach | RepeatPlayers$ Player | StartingWithActivator$ True | RepeatSubAbility$ DBChoosePermanent | SubAbility$ DBPhaseOut
+SVar:TrigRepeatEach:DB$ RepeatEach | RepeatPlayers$ Player | StartingWith$ You | RepeatSubAbility$ DBChoosePermanent | SubAbility$ DBPhaseOut
 SVar:DBChoosePermanent:DB$ ChooseCard | ChoiceTitle$ Choose up to five permanents you control | MinAmount$ 0 | Amount$ 5 | Defined$ Remembered | Choices$ Permanent.RememberedPlayerCtrl | RememberChosen$ True | AILogic$ NotSelf
 SVar:DBPhaseOut:DB$ Phases | AllValid$ Permanent.Other+IsNotRemembered | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearChosenCard$ True | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/d/druid_of_purification.txt
+++ b/forge-gui/res/cardsfolder/d/druid_of_purification.txt
@@ -3,9 +3,8 @@ ManaCost:3 G
 Types:Creature Human Druid
 PT:2/3
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChoice | TriggerDescription$ When CARDNAME enters, starting with you, each player may choose an artifact or enchantment you don't control. Destroy each permanent chosen this way.
-SVar:TrigChoice:DB$ RepeatEach | RepeatPlayers$ Player | StartingWith$ You | RepeatSubAbility$ DBChoosePermanent | SubAbility$ DBDestroy
-SVar:DBChoosePermanent:DB$ ChooseCard | Defined$ Remembered | Choices$ Artifact.YouDontCtrl,Enchantment.YouDontCtrl | Optional$ True | ChoiceTitle$ Choose an artifact or enchantment | RememberChosen$ True
-SVar:DBDestroy:DB$ Destroy | Defined$ Remembered | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:TrigChoice:DB$ ChooseCard | Defined$ Player | StartingWith$ You | Choices$ Artifact.YouDontCtrl,Enchantment.YouDontCtrl | Optional$ True | ChoiceTitle$ Choose an artifact or enchantment | SubAbility$ DBDestroy
+SVar:DBDestroy:DB$ Destroy | Defined$ ChosenCard | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearChosenCard$ True
 AI:RemoveDeck:Random
 Oracle:When Druid of Purification enters, starting with you, each player may choose an artifact or enchantment you don't control. Destroy each permanent chosen this way.

--- a/forge-gui/res/cardsfolder/d/druid_of_purification.txt
+++ b/forge-gui/res/cardsfolder/d/druid_of_purification.txt
@@ -3,7 +3,7 @@ ManaCost:3 G
 Types:Creature Human Druid
 PT:2/3
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChoice | TriggerDescription$ When CARDNAME enters, starting with you, each player may choose an artifact or enchantment you don't control. Destroy each permanent chosen this way.
-SVar:TrigChoice:DB$ RepeatEach | RepeatPlayers$ Player | StartingWithActivator$ True | RepeatSubAbility$ DBChoosePermanent | SubAbility$ DBDestroy
+SVar:TrigChoice:DB$ RepeatEach | RepeatPlayers$ Player | StartingWith$ You | RepeatSubAbility$ DBChoosePermanent | SubAbility$ DBDestroy
 SVar:DBChoosePermanent:DB$ ChooseCard | Defined$ Remembered | Choices$ Artifact.YouDontCtrl,Enchantment.YouDontCtrl | Optional$ True | ChoiceTitle$ Choose an artifact or enchantment | RememberChosen$ True
 SVar:DBDestroy:DB$ Destroy | Defined$ Remembered | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/e/eureka.txt
+++ b/forge-gui/res/cardsfolder/e/eureka.txt
@@ -3,7 +3,7 @@ ManaCost:2 G G
 Types:Sorcery
 A:SP$ Repeat | RepeatSubAbility$ ResetCheck | RepeatCheckSVar$ NumPlayerGiveup | RepeatSVarCompare$ LTTotalPlayer | SubAbility$ FinalReset | StackDescription$ SpellDescription | SpellDescription$ Starting with you, each player may put a permanent card from their hand onto the battlefield. Repeat this process until no one puts a card onto the battlefield.
 SVar:ResetCheck:DB$ StoreSVar | SVar$ NumPlayerGiveup | Type$ Number | Expression$ 0 | SubAbility$ DBRepeatChoice
-SVar:DBRepeatChoice:DB$ RepeatEach | StartingWithActivator$ True | RepeatSubAbility$ DBChoice | RepeatPlayers$ Player
+SVar:DBRepeatChoice:DB$ RepeatEach | StartingWith$ You | RepeatSubAbility$ DBChoice | RepeatPlayers$ Player
 SVar:DBChoice:DB$ GenericChoice | Choices$ DBCheckHand,DBNoChange | Defined$ Player.IsRemembered
 SVar:DBCheckHand:DB$ StoreSVar | SVar$ NumPlayerGiveup | Type$ CountSVar | Expression$ NumPlayerGiveup/Plus.1 | ConditionCheckSVar$ CheckHand | ConditionSVarCompare$ EQ0 | SubAbility$ DBChoose | SpellDescription$ Choose a permanent to put onto the battlefield
 SVar:DBChoose:DB$ ChangeZone | DefinedPlayer$ Player.IsRemembered | Origin$ Hand | Destination$ Battlefield | ChangeType$ Permanent | ChangeNum$ 1 | ConditionCheckSVar$ CheckHand | ConditionSVarCompare$ GE1

--- a/forge-gui/res/cardsfolder/f/fortunate_few.txt
+++ b/forge-gui/res/cardsfolder/f/fortunate_few.txt
@@ -1,7 +1,7 @@
 Name:Fortunate Few
 ManaCost:3 W W
 Types:Sorcery
-A:SP$ RepeatEach | StartingWithActivator$ True | RepeatPlayers$ Player | RepeatSubAbility$ DBChoose | SubAbility$ DBDestroyAll | SpellDescription$ Choose a nonland permanent you don't control, then each other player chooses a nonland permanent they don't control that hasn't been chosen this way. Destroy all other nonland permanents.
+A:SP$ RepeatEach | StartingWith$ You | RepeatPlayers$ Player | RepeatSubAbility$ DBChoose | SubAbility$ DBDestroyAll | SpellDescription$ Choose a nonland permanent you don't control, then each other player chooses a nonland permanent they don't control that hasn't been chosen this way. Destroy all other nonland permanents.
 SVar:DBChoose:DB$ ChooseCard | Defined$ Player.IsRemembered | Choices$ Permanent.nonLand+!RememberedPlayerCtrl+IsNotRemembered | RememberChosen$ True | ChoiceZone$ Battlefield | AILogic$ WorstCard
 SVar:DBDestroyAll:DB$ DestroyAll | ValidCards$ Permanent.nonLand+IsNotRemembered | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/h/hypergenesis.txt
+++ b/forge-gui/res/cardsfolder/h/hypergenesis.txt
@@ -5,7 +5,7 @@ Types:Sorcery
 K:Suspend:3:1 G G
 A:SP$ Repeat | RepeatSubAbility$ ResetCheck | RepeatCheckSVar$ NumPlayerGiveup | RepeatSVarCompare$ LTTotalPlayer | SubAbility$ FinalReset | StackDescription$ SpellDescription | SpellDescription$ Starting with you, each player may put an artifact, creature, enchantment, or land card from their hand onto the battlefield. Repeat this process until no one puts a card onto the battlefield.
 SVar:ResetCheck:DB$ StoreSVar | SVar$ NumPlayerGiveup | Type$ Number | Expression$ 0 | SubAbility$ DBRepeatChoice
-SVar:DBRepeatChoice:DB$ RepeatEach | StartingWithActivator$ True | RepeatSubAbility$ DBChoice | RepeatPlayers$ Player
+SVar:DBRepeatChoice:DB$ RepeatEach | StartingWith$ You | RepeatSubAbility$ DBChoice | RepeatPlayers$ Player
 SVar:DBChoice:DB$ GenericChoice | Choices$ DBCheckHand,DBNoChange | Defined$ Player.IsRemembered
 SVar:DBCheckHand:DB$ StoreSVar | SVar$ NumPlayerGiveup | Type$ CountSVar | Expression$ NumPlayerGiveup/Plus.1 | ConditionCheckSVar$ CheckHand | ConditionSVarCompare$ EQ0 | SubAbility$ DBChoose | SpellDescription$ Choose an artifact, creature, enchantment, or land card from your hand onto the battlefield
 SVar:DBChoose:DB$ ChangeZone | DefinedPlayer$ Player.IsRemembered | Origin$ Hand | Destination$ Battlefield | ChangeType$ Artifact,Creature,Enchantment,Land | ChangeNum$ 1 | ConditionCheckSVar$ CheckHand | ConditionSVarCompare$ GE1

--- a/forge-gui/res/cardsfolder/l/liege_of_the_hollows.txt
+++ b/forge-gui/res/cardsfolder/l/liege_of_the_hollows.txt
@@ -3,7 +3,7 @@ ManaCost:2 G G
 Types:Creature Spirit
 PT:3/4
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ RepeatPayment | TriggerDescription$ When CARDNAME dies, each player may pay any amount of mana. Then each player creates a number of 1/1 green Squirrel creature tokens equal to the amount of mana they paid this way.
-SVar:RepeatPayment:DB$ RepeatEach | RepeatPlayers$ Player | StartingWithActivator$ True | ChangeZoneTable$ True | RepeatSubAbility$ DBPay | StackDescription$ When CARDNAME dies, each player may pay any amount of mana. Then each player creates a number of 1/1 green Squirrel creature tokens equal to the amount of mana they paid this way.
+SVar:RepeatPayment:DB$ RepeatEach | RepeatPlayers$ Player | StartingWith$ You | ChangeZoneTable$ True | RepeatSubAbility$ DBPay | StackDescription$ When CARDNAME dies, each player may pay any amount of mana. Then each player creates a number of 1/1 green Squirrel creature tokens equal to the amount of mana they paid this way.
 SVar:DBPay:DB$ ChooseNumber | Defined$ Player.IsRemembered | ChooseAnyNumber$ True | ListTitle$ amount of mana to pay | AILogic$ MaxForAnyController | SubAbility$ DBToken
 # TODO: ideally the tokens should be created simultaneously after all the players have finished paying mana, but that's difficult to implement.
 SVar:DBToken:DB$ Token | TokenAmount$ X | TokenScript$ g_1_1_squirrel | TokenOwner$ Player.IsRemembered | UnlessCost$ Y | UnlessPayer$ Player.IsRemembered | UnlessSwitched$ True

--- a/forge-gui/res/cardsfolder/m/mana_charged_dragon.txt
+++ b/forge-gui/res/cardsfolder/m/mana_charged_dragon.txt
@@ -6,7 +6,7 @@ K:Flying
 K:Trample
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigJoinForces | TriggerDescription$ Join forces — Whenever CARDNAME attacks or blocks, each player starting with you may pay any amount of mana. CARDNAME gets +X/+0 until end of turn, where X is the total amount of mana paid this way.
 T:Mode$ Blocks | ValidCard$ Card.Self | Execute$ TrigJoinForces | Secondary$ True | TriggerDescription$ Join forces — Whenever CARDNAME attacks or blocks, each player starting with you may pay any amount of mana. CARDNAME gets +X/+0 until end of turn, where X is the total amount of mana paid this way.
-SVar:TrigJoinForces:DB$ RepeatEach | RepeatPlayers$ Player | StartingWithActivator$ True | RepeatSubAbility$ DBPay | SubAbility$ DBPump
+SVar:TrigJoinForces:DB$ RepeatEach | RepeatPlayers$ Player | StartingWith$ You | RepeatSubAbility$ DBPay | SubAbility$ DBPump
 SVar:DBPay:DB$ ChooseNumber | Defined$ Player.IsRemembered | ChooseAnyNumber$ True | ListTitle$ amount of mana to pay | SubAbility$ DBStore
 SVar:DBStore:DB$ StoreSVar | SVar$ JoinForcesAmount | Type$ CountSVar | Expression$ JoinForcesAmount/Plus.Y | UnlessCost$ Y | UnlessPayer$ Player.IsRemembered | UnlessSwitched$ True | UnlessAI$ OnlyOwn
 SVar:DBPump:DB$ Pump | Defined$ Self | NumAtt$ JoinForcesAmount | SubAbility$ DBReset

--- a/forge-gui/res/cardsfolder/m/manifold_insights.txt
+++ b/forge-gui/res/cardsfolder/m/manifold_insights.txt
@@ -2,7 +2,7 @@ Name:Manifold Insights
 ManaCost:2 U
 Types:Sorcery
 A:SP$ PeekAndReveal | PeekAmount$ 10 | RevealValid$ Card | RememberRevealed$ True | SubAbility$ ChooseNonLand | SpellDescription$ Reveal the top ten cards of your library. Starting with the next opponent in turn order, each opponent chooses a different nonland card from among them. Put the chosen cards into your hand and the rest on the bottom of your library in a random order.
-SVar:ChooseNonLand:DB$ RepeatEach | RepeatPlayers$ Player.Opponent | InTurnOrder$ True | RepeatSubAbility$ OpponentsChoose | SubAbility$ ShipToBottom
+SVar:ChooseNonLand:DB$ RepeatEach | RepeatPlayers$ Player.Opponent | StartingWith$ Opponent | RepeatSubAbility$ OpponentsChoose | SubAbility$ ShipToBottom
 SVar:OpponentsChoose:DB$ ChooseCard | ChoiceZone$ Library | Choices$ Card.nonLand+IsRemembered | Defined$ Player.IsRemembered | ForgetChosen$ True | SubAbility$ ChosenToHand
 SVar:ChosenToHand:DB$ ChangeZone | Origin$ Library | Destination$ Hand | Defined$ ChosenCard
 SVar:ShipToBottom:DB$ ChangeZoneAll | ChangeType$ Card.IsRemembered | Origin$ Library | Destination$ Library | LibraryPosition$ -1 | RandomOrder$ True | SubAbility$ DBCleanup

--- a/forge-gui/res/cardsfolder/m/manifold_insights.txt
+++ b/forge-gui/res/cardsfolder/m/manifold_insights.txt
@@ -2,7 +2,7 @@ Name:Manifold Insights
 ManaCost:2 U
 Types:Sorcery
 A:SP$ PeekAndReveal | PeekAmount$ 10 | RevealValid$ Card | RememberRevealed$ True | SubAbility$ ChooseNonLand | SpellDescription$ Reveal the top ten cards of your library. Starting with the next opponent in turn order, each opponent chooses a different nonland card from among them. Put the chosen cards into your hand and the rest on the bottom of your library in a random order.
-SVar:ChooseNonLand:DB$ RepeatEach | RepeatPlayers$ Player.Opponent | RepeatSubAbility$ OpponentsChoose | SubAbility$ ShipToBottom
+SVar:ChooseNonLand:DB$ RepeatEach | RepeatPlayers$ Player.Opponent | InTurnOrder$ True | RepeatSubAbility$ OpponentsChoose | SubAbility$ ShipToBottom
 SVar:OpponentsChoose:DB$ ChooseCard | ChoiceZone$ Library | Choices$ Card.nonLand+IsRemembered | Defined$ Player.IsRemembered | ForgetChosen$ True | SubAbility$ ChosenToHand
 SVar:ChosenToHand:DB$ ChangeZone | Origin$ Library | Destination$ Hand | Defined$ ChosenCard
 SVar:ShipToBottom:DB$ ChangeZoneAll | ChangeType$ Card.IsRemembered | Origin$ Library | Destination$ Library | LibraryPosition$ -1 | RandomOrder$ True | SubAbility$ DBCleanup

--- a/forge-gui/res/cardsfolder/m/minds_aglow.txt
+++ b/forge-gui/res/cardsfolder/m/minds_aglow.txt
@@ -1,7 +1,7 @@
 Name:Minds Aglow
 ManaCost:U
 Types:Sorcery
-A:SP$ RepeatEach | RepeatPlayers$ Player | StartingWithActivator$ True | RepeatSubAbility$ DBPay | SubAbility$ DBDraw | StackDescription$ SpellDescription | SpellDescription$ Join forces — Starting with you, each player may pay any amount of mana. Each player draws X cards, where X is the total amount of mana paid this way.
+A:SP$ RepeatEach | RepeatPlayers$ Player | StartingWith$ You | RepeatSubAbility$ DBPay | SubAbility$ DBDraw | StackDescription$ SpellDescription | SpellDescription$ Join forces — Starting with you, each player may pay any amount of mana. Each player draws X cards, where X is the total amount of mana paid this way.
 SVar:DBPay:DB$ ChooseNumber | Defined$ Player.IsRemembered | ChooseAnyNumber$ True | ListTitle$ amount of mana to pay | SubAbility$ DBStore
 SVar:DBStore:DB$ StoreSVar | SVar$ JoinForcesAmount | Type$ CountSVar | Expression$ JoinForcesAmount/Plus.Y | UnlessCost$ Y | UnlessPayer$ Player.IsRemembered | UnlessSwitched$ True | UnlessAI$ OnlyOwn
 SVar:DBDraw:DB$ Draw | Defined$ Player | NumCards$ JoinForcesAmount | SubAbility$ DBReset | StackDescription$ None

--- a/forge-gui/res/cardsfolder/m/morphic_tide.txt
+++ b/forge-gui/res/cardsfolder/m/morphic_tide.txt
@@ -2,7 +2,7 @@ Name:Morphic Tide
 ManaCost:no cost
 Types:Phenomenon
 T:Mode$ PlaneswalkedTo | ValidCard$ Card.Self | Execute$ TrigPut | TriggerDescription$ When you encounter CARDNAME, each player shuffles all permanents they own into their library, then reveals that many cards from the top of their library. Each player puts all artifact, creature, land, and planeswalker cards revealed this way onto the battlefield, then does the same for enchantment cards, then puts all cards revealed this way that weren't put onto the battlefield on the bottom of their library in any order. (Then planeswalk away from this phenomenon.)
-SVar:TrigPut:DB$ RepeatEach | StartingWithActivator$ True | RepeatPlayers$ Player | RepeatSubAbility$ DBShuffle | SubAbility$ ChangePermanent
+SVar:TrigPut:DB$ RepeatEach | StartingWith$ You | RepeatPlayers$ Player | RepeatSubAbility$ DBShuffle | SubAbility$ ChangePermanent
 SVar:DBShuffle:DB$ ChangeZoneAll | ChangeType$ Permanent.RememberedPlayerOwn | Imprint$ True | Origin$ Battlefield | Destination$ Library | Shuffle$ True | SubAbility$ DBReveal
 SVar:DBReveal:DB$ PeekAndReveal | Defined$ Remembered | PeekAmount$ WarpX | NoPeek$ True | RememberRevealed$ True | SubAbility$ DBCleanImprint
 SVar:DBCleanImprint:DB$ Cleanup | ClearImprinted$ True

--- a/forge-gui/res/cardsfolder/p/plague_of_vermin.txt
+++ b/forge-gui/res/cardsfolder/p/plague_of_vermin.txt
@@ -3,7 +3,7 @@ ManaCost:6 B
 Types:Sorcery
 A:SP$ Repeat | RepeatSubAbility$ DBResetCheck | RepeatCheckSVar$ NumPlayerGiveup | RepeatSVarCompare$ LTTotalPlayer | SubAbility$ DBRepeatToken | StackDescription$ REP you_{p:You} | SpellDescription$ Starting with you, each player may pay any amount of life. Repeat this process until no one pays life. Each player creates a 1/1 black Rat creature token for each 1 life they paid this way.
 SVar:DBResetCheck:DB$ StoreSVar | SVar$ NumPlayerGiveup | Type$ Number | Expression$ 0 | SubAbility$ DBRepeatChoice
-SVar:DBRepeatChoice:DB$ RepeatEach | StartingWithActivator$ True | RepeatSubAbility$ DBChoice | RepeatPlayers$ Player
+SVar:DBRepeatChoice:DB$ RepeatEach | StartingWith$ You | RepeatSubAbility$ DBChoice | RepeatPlayers$ Player
 SVar:DBChoice:DB$ ChooseNumber | Defined$ Remembered | Max$ LifeTotal | AILogic$ Vermin | ListTitle$ amount of life to pay | SubAbility$ DBCheckPaid
 SVar:DBCheckPaid:DB$ StoreSVar | SVar$ NumPlayerGiveup | Type$ CountSVar | Expression$ NumPlayerGiveup/Plus.1 | ConditionCheckSVar$ X | ConditionSVarCompare$ EQ0 | SubAbility$ DBStore
 SVar:DBStore:DB$ StoreSVar | SVar$ EachPlayer | Type$ AdditiveForEach | Expression$ X | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1 | UnlessCost$ PayLife<X> | UnlessPayer$ Remembered | UnlessSwitched$ True | UnlessResolveSubs$ WhenNotPaid | SubAbility$ DBGiveUp | SpellDescription$ Pay the chosen amount of life.

--- a/forge-gui/res/cardsfolder/p/protection_racket.txt
+++ b/forge-gui/res/cardsfolder/p/protection_racket.txt
@@ -2,7 +2,7 @@ Name:Protection Racket
 ManaCost:2 B
 Types:Enchantment
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigRepeat | TriggerDescription$ At the beginning of your upkeep, repeat the following process for each opponent in turn order. Reveal the top card of your library. That player may pay life equal to that card's mana value. If they do, exile that card. Otherwise, put it into your hand.
-SVar:TrigRepeat:DB$ RepeatEach | RepeatPlayers$ Opponent | RepeatSubAbility$ DBReveal
+SVar:TrigRepeat:DB$ RepeatEach | RepeatPlayers$ Opponent | InTurnOrder$ True | RepeatSubAbility$ DBReveal
 SVar:DBReveal:DB$ PeekAndReveal | PeekAmount$ 1 | NoPeek$ True | RememberRevealed$ True | SubAbility$ DBExile
 SVar:DBExile:DB$ ChangeZone | UnlessCost$ PayLife<X> | UnlessPayer$ Remembered | UnlessSwitched$ True | Defined$ Remembered | Origin$ Library | Destination$ Exile | ForgetChanged$ True | SubAbility$ DBChangeZone
 SVar:DBChangeZone:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Hand | ForgetChanged$ True

--- a/forge-gui/res/cardsfolder/p/protection_racket.txt
+++ b/forge-gui/res/cardsfolder/p/protection_racket.txt
@@ -2,7 +2,7 @@ Name:Protection Racket
 ManaCost:2 B
 Types:Enchantment
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigRepeat | TriggerDescription$ At the beginning of your upkeep, repeat the following process for each opponent in turn order. Reveal the top card of your library. That player may pay life equal to that card's mana value. If they do, exile that card. Otherwise, put it into your hand.
-SVar:TrigRepeat:DB$ RepeatEach | RepeatPlayers$ Opponent | InTurnOrder$ True | RepeatSubAbility$ DBReveal
+SVar:TrigRepeat:DB$ RepeatEach | RepeatPlayers$ Opponent | StartingWith$ Opponent | RepeatSubAbility$ DBReveal
 SVar:DBReveal:DB$ PeekAndReveal | PeekAmount$ 1 | NoPeek$ True | RememberRevealed$ True | SubAbility$ DBExile
 SVar:DBExile:DB$ ChangeZone | UnlessCost$ PayLife<X> | UnlessPayer$ Remembered | UnlessSwitched$ True | Defined$ Remembered | Origin$ Library | Destination$ Exile | ForgetChanged$ True | SubAbility$ DBChangeZone
 SVar:DBChangeZone:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Hand | ForgetChanged$ True

--- a/forge-gui/res/cardsfolder/r/reality_shaping.txt
+++ b/forge-gui/res/cardsfolder/r/reality_shaping.txt
@@ -2,7 +2,7 @@ Name:Reality Shaping
 ManaCost:no cost
 Types:Phenomenon
 T:Mode$ PlaneswalkedTo | ValidCard$ Card.Self | Execute$ TrigPutFromHand | TriggerDescription$ When you encounter CARDNAME, starting with you, each player may put a permanent card from their hand onto the battlefield. (Then planeswalk away from this phenomenon.)
-SVar:TrigPutFromHand:DB$ RepeatEach | StartingWithActivator$ True | RepeatPlayers$ Player | RepeatSubAbility$ DBChangeZone | SubAbility$ PWAway
+SVar:TrigPutFromHand:DB$ RepeatEach | StartingWith$ You | RepeatPlayers$ Player | RepeatSubAbility$ DBChangeZone | SubAbility$ PWAway
 SVar:DBChangeZone:DB$ ChangeZone | DefinedPlayer$ Player.IsRemembered | Choser$ Player.IsRemembered | ChangeType$ Permanent | ChangeNum$ 1 | Origin$ Hand | Destination$ Battlefield
 SVar:PWAway:DB$ Planeswalk
 Oracle:When you encounter Reality Shaping, starting with you, each player may put a permanent card from their hand onto the battlefield. (Then planeswalk away from this phenomenon.)

--- a/forge-gui/res/cardsfolder/s/shared_trauma.txt
+++ b/forge-gui/res/cardsfolder/s/shared_trauma.txt
@@ -1,7 +1,7 @@
 Name:Shared Trauma
 ManaCost:B
 Types:Sorcery
-A:SP$ RepeatEach | RepeatPlayers$ Player | StartingWithActivator$ True | RepeatSubAbility$ DBPay | SubAbility$ DBMill | StackDescription$ SpellDescription | SpellDescription$ Join forces — Starting with you, each player may pay any amount of mana. Each player mills X cards, where X is the total amount of mana paid this way.
+A:SP$ RepeatEach | RepeatPlayers$ Player | StartingWith$ You | RepeatSubAbility$ DBPay | SubAbility$ DBMill | StackDescription$ SpellDescription | SpellDescription$ Join forces — Starting with you, each player may pay any amount of mana. Each player mills X cards, where X is the total amount of mana paid this way.
 SVar:DBPay:DB$ ChooseNumber | Defined$ Player.IsRemembered | ChooseAnyNumber$ True | ListTitle$ amount of mana to pay | SubAbility$ DBStore
 SVar:DBStore:DB$ StoreSVar | SVar$ JoinForcesAmount | Type$ CountSVar | Expression$ JoinForcesAmount/Plus.Y | UnlessCost$ Y | UnlessPayer$ Player.IsRemembered | UnlessSwitched$ True | UnlessAI$ OnlyOwn
 SVar:DBMill:DB$ Mill | Defined$ Player | NumCards$ JoinForcesAmount | SubAbility$ DBReset | StackDescription$ None

--- a/forge-gui/res/cardsfolder/t/the_horus_heresy.txt
+++ b/forge-gui/res/cardsfolder/t/the_horus_heresy.txt
@@ -1,13 +1,12 @@
 Name:The Horus Heresy
 ManaCost:3 U B R
 Types:Enchantment Saga
-K:Chapter:3:GainControl,DBDraw,DBRepeat
+K:Chapter:3:GainControl,DBDraw,DBChoose
 SVar:GainControl:DB$ GainControl | ValidTgts$ Creature.nonLegendary+OppCtrl | LoseControl$ LeavesPlay | TgtPrompt$ Select target nonlegendary creature an opponent controls to gain control of. | TargetMin$ 0 | TargetMax$ OneEach | TargetsForEachPlayer$ True | SpellDescription$ For each opponent, gain control of up to one target nonlegendary creature that player controls for as long as CARDNAME remains on the battlefield.
 SVar:OneEach:PlayerCountOpponents$Amount
 SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ X | SpellDescription$ Draw a card for each creature you control but don't own.
 SVar:X:Count$Valid Creature.YouDontOwn+YouCtrl
-SVar:DBRepeat:DB$ RepeatEach | RepeatPlayers$ Player | StartingWith$ You | RepeatSubAbility$ DBChooseCreature | SubAbility$ DBDestroy | SpellDescription$ Starting with you, each player chooses a creature. Destroy each creature chosen this way.
-SVar:DBChooseCreature:DB$ ChooseCard | Defined$ Remembered | Choices$ Creature | ChoiceTitle$ Choose a creature | Mandatory$ True | RememberChosen$ True
-SVar:DBDestroy:DB$ Destroy | Defined$ Remembered | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBChoose:DB$ ChooseCard | Defined$ Player | StartingWith$ You | Choices$ Creature | ChoiceTitle$ Choose a creature | Mandatory$ True | SpellDescription$ Starting with you, each player chooses a creature. Destroy each creature chosen this way.
+SVar:DBDestroy:DB$ Destroy | Defined$ ChosenCard | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearChosenCard$ True
 Oracle:(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI — For each opponent, gain control of up to one target nonlegendary creature that player controls for as long as The Horus Heresy remains on the battlefield.\nII — Draw a card for each creature you control but don't own.\nIII — Starting with you, each player chooses a creature. Destroy each creature chosen this way.

--- a/forge-gui/res/cardsfolder/t/the_horus_heresy.txt
+++ b/forge-gui/res/cardsfolder/t/the_horus_heresy.txt
@@ -6,7 +6,7 @@ SVar:GainControl:DB$ GainControl | ValidTgts$ Creature.nonLegendary+OppCtrl | Lo
 SVar:OneEach:PlayerCountOpponents$Amount
 SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ X | SpellDescription$ Draw a card for each creature you control but don't own.
 SVar:X:Count$Valid Creature.YouDontOwn+YouCtrl
-SVar:DBRepeat:DB$ RepeatEach | RepeatPlayers$ Player | StartingWithActivator$ True | RepeatSubAbility$ DBChooseCreature | SubAbility$ DBDestroy | SpellDescription$ Starting with you, each player chooses a creature. Destroy each creature chosen this way.
+SVar:DBRepeat:DB$ RepeatEach | RepeatPlayers$ Player | StartingWith$ You | RepeatSubAbility$ DBChooseCreature | SubAbility$ DBDestroy | SpellDescription$ Starting with you, each player chooses a creature. Destroy each creature chosen this way.
 SVar:DBChooseCreature:DB$ ChooseCard | Defined$ Remembered | Choices$ Creature | ChoiceTitle$ Choose a creature | Mandatory$ True | RememberChosen$ True
 SVar:DBDestroy:DB$ Destroy | Defined$ Remembered | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/t/thieves_auction.txt
+++ b/forge-gui/res/cardsfolder/t/thieves_auction.txt
@@ -3,7 +3,7 @@ ManaCost:4 R R R
 Types:Sorcery
 A:SP$ ChangeZoneAll | ChangeType$ Permanent.nonToken | Origin$ Battlefield | Destination$ Exile | RememberChanged$ True | SubAbility$ DBRepeatChoose | StackDescription$ SpellDescription | SpellDescription$ Exile all nontoken permanents. Starting with you, each player chooses one of the exiled cards and puts it onto the battlefield tapped under their control. Repeat this process until all cards exiled this way have been chosen.
 SVar:DBRepeatChoose:DB$ Repeat | RepeatSubAbility$ DBRepeat | RepeatDefined$ Remembered | RepeatPresent$ Card | StackDescription$ None
-SVar:DBRepeat:DB$ RepeatEach | StartingWithActivator$ True | RepeatPlayers$ Player | RepeatSubAbility$ DBChoose
+SVar:DBRepeat:DB$ RepeatEach | StartingWith$ You | RepeatPlayers$ Player | RepeatSubAbility$ DBChoose
 SVar:DBChoose:DB$ ChooseCard | Defined$ Player.IsRemembered | Choices$ Card.IsRemembered | ForgetChosen$ True | ChoiceZone$ Exile | SubAbility$ DBGainControl
 SVar:DBGainControl:DB$ ChangeZone | Origin$ Exile | Destination$ Battlefield | Defined$ ChosenCard | GainControl$ Player.IsRemembered | Tapped$ True
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/upcoming/sadistic_shell_game.txt
+++ b/forge-gui/res/cardsfolder/upcoming/sadistic_shell_game.txt
@@ -1,8 +1,8 @@
 Name:Sadistic Shell Game
 ManaCost:4 B
 Types:Sorcery
-A:SP$ RepeatEach | RepeatPlayers$ Opponent | RepeatSubAbility$ DBChooseCard | SubAbility$ DBDestroy | InTurnOrder$ True | StackDescription$ SpellDescription | SpellDescription$ Starting with the next opponent in turn order, each player chooses a creature you don’t control. Destroy the chosen creatures.
-SVar:DBChooseCard:DB$ ChooseCard | Choices$ Creature | Reveal$ True | Defined$ Player.IsRemembered | ControlledByPlayer$ Opponent | Mandatory$ True | ChoiceTitle$ Choose a creature to destroy | RememberChosen$ True | AILogic$ OppPreferred
+A:SP$ RepeatEach | RepeatPlayers$ Player | StartingWith$ Opponent | RepeatSubAbility$ DBChooseCard | SubAbility$ DBDestroy | StackDescription$ SpellDescription | SpellDescription$ Starting with the next opponent in turn order, each player chooses a creature you don’t control. Destroy the chosen creatures.
+SVar:DBChooseCard:DB$ ChooseCard | Choices$ Creature.YouDontCtrl | Reveal$ True | Defined$ Player.IsRemembered | Mandatory$ True | ChoiceTitle$ Choose a creature to destroy | RememberChosen$ True | AILogic$ OppPreferred
 SVar:DBDestroy:DB$ DestroyAll | ValidCards$ Card.Creature+IsRemembered | SubAbility$ DBCleanup | StackDescription$ Destroy the chosen creatures.
 SVar:DBCleanup:DB$ Cleanup | ClearChosenCard$ True | ClearRemembered$ True
 Oracle:Starting with the next opponent in turn order, each player chooses a creature you don’t control. Destroy the chosen creatures.

--- a/forge-gui/res/cardsfolder/upcoming/sadistic_shell_game.txt
+++ b/forge-gui/res/cardsfolder/upcoming/sadistic_shell_game.txt
@@ -1,8 +1,6 @@
 Name:Sadistic Shell Game
 ManaCost:4 B
 Types:Sorcery
-A:SP$ RepeatEach | RepeatPlayers$ Player | StartingWith$ Opponent | RepeatSubAbility$ DBChooseCard | SubAbility$ DBDestroy | StackDescription$ SpellDescription | SpellDescription$ Starting with the next opponent in turn order, each player chooses a creature you don’t control. Destroy the chosen creatures.
-SVar:DBChooseCard:DB$ ChooseCard | Choices$ Creature.YouDontCtrl | Reveal$ True | Defined$ Player.IsRemembered | Mandatory$ True | ChoiceTitle$ Choose a creature to destroy | RememberChosen$ True | AILogic$ OppPreferred
-SVar:DBDestroy:DB$ DestroyAll | ValidCards$ Card.Creature+IsRemembered | SubAbility$ DBCleanup | StackDescription$ Destroy the chosen creatures.
-SVar:DBCleanup:DB$ Cleanup | ClearChosenCard$ True | ClearRemembered$ True
-Oracle:Starting with the next opponent in turn order, each player chooses a creature you don’t control. Destroy the chosen creatures.
+A:SP$ ChooseCard | Choices$ Creature.YouDontCtrl | Reveal$ True | Defined$ Player | StartingWith$ Opponent | Mandatory$ True | ChoiceTitle$ Choose a creature to destroy | AILogic$ OppPreferred | SubAbility$ DBDestroy | StackDescription$ SpellDescription | SpellDescription$ Starting with the next opponent in turn order, each player chooses a creature you don't control. Destroy the chosen creatures.
+SVar:DBDestroy:DB$ DestroyAll | ValidCards$ Card.ChosenCard | StackDescription$ None
+Oracle:Starting with the next opponent in turn order, each player chooses a creature you don't control. Destroy the chosen creatures.

--- a/forge-gui/res/cardsfolder/upcoming/sadistic_shell_game.txt
+++ b/forge-gui/res/cardsfolder/upcoming/sadistic_shell_game.txt
@@ -1,0 +1,8 @@
+Name:Sadistic Shell Game
+ManaCost:4 B
+Types:Sorcery
+A:SP$ RepeatEach | RepeatPlayers$ Opponent | RepeatSubAbility$ DBChooseCard | SubAbility$ DBDestroy | InTurnOrder$ True | StackDescription$ SpellDescription | SpellDescription$ Starting with the next opponent in turn order, each player chooses a creature you don’t control. Destroy the chosen creatures.
+SVar:DBChooseCard:DB$ ChooseCard | Choices$ Creature | Reveal$ True | Defined$ Player.IsRemembered | ControlledByPlayer$ Player.Opponent | Mandatory$ True | ChoiceTitle$ Choose a creature to destroy | RememberChosen$ True | AILogic$ OppPreferred
+SVar:DBDestroy:DB$ DestroyAll | ValidCards$ Card.Creature+IsRemembered | SubAbility$ DBCleanup | StackDescription$ Destroy the chosen creatures.
+SVar:DBCleanup:DB$ Cleanup | ClearChosenCard$ True | ClearRemembered$ True
+Oracle: Starting with the next opponent in turn order, each player chooses a creature you don’t control. Destroy the chosen creatures.

--- a/forge-gui/res/cardsfolder/upcoming/sadistic_shell_game.txt
+++ b/forge-gui/res/cardsfolder/upcoming/sadistic_shell_game.txt
@@ -2,7 +2,7 @@ Name:Sadistic Shell Game
 ManaCost:4 B
 Types:Sorcery
 A:SP$ RepeatEach | RepeatPlayers$ Opponent | RepeatSubAbility$ DBChooseCard | SubAbility$ DBDestroy | InTurnOrder$ True | StackDescription$ SpellDescription | SpellDescription$ Starting with the next opponent in turn order, each player chooses a creature you don’t control. Destroy the chosen creatures.
-SVar:DBChooseCard:DB$ ChooseCard | Choices$ Creature | Reveal$ True | Defined$ Player.IsRemembered | ControlledByPlayer$ Player.Opponent | Mandatory$ True | ChoiceTitle$ Choose a creature to destroy | RememberChosen$ True | AILogic$ OppPreferred
+SVar:DBChooseCard:DB$ ChooseCard | Choices$ Creature | Reveal$ True | Defined$ Player.IsRemembered | ControlledByPlayer$ Opponent | Mandatory$ True | ChoiceTitle$ Choose a creature to destroy | RememberChosen$ True | AILogic$ OppPreferred
 SVar:DBDestroy:DB$ DestroyAll | ValidCards$ Card.Creature+IsRemembered | SubAbility$ DBCleanup | StackDescription$ Destroy the chosen creatures.
 SVar:DBCleanup:DB$ Cleanup | ClearChosenCard$ True | ClearRemembered$ True
-Oracle: Starting with the next opponent in turn order, each player chooses a creature you don’t control. Destroy the chosen creatures.
+Oracle:Starting with the next opponent in turn order, each player chooses a creature you don’t control. Destroy the chosen creatures.


### PR DESCRIPTION
* Added `InTurnOrder` parameter check for case when getting opponents in turn order to [AbilityUtils.java](forge-game/src/main/java/forge/game/ability/AbilityUtils.java)
* Added `getOpponentsInTurnOrder()` for same case to [Player.java](forge-game/src/main/java/forge/game/player/Player.java)

Note: Not many cards require forced turn order of opponents. Honestly, I could only find three. Turn order breaks when AI activates the ability due to normally just getting the opponents of the player. With AI the human is always at the top of the players list from [Game.java](forge-game/src/main/java/forge/game/Game.java)'s `getPlayers()` method. I have not tested this in net play at all so I am not sure how players are ordered in Game.java in an online game. ~~If there was an issue before this should solve the problem if Manifold Insights and Protection Racket are updated with `InTurnOrder$ True`. I will be committing chard changes for both and the new card Sadistic Shell Game.~~

Added updated cards to PR.

[Manifold Insights](https://scryfall.com/card/cm2/44/manifold-insights)
[Protection Racket](https://scryfall.com/card/ncc/39/protection-racket)
[Sadistic Shell Game](https://scryfall.com/card/dsc/24/sadistic-shell-game)