### PR TITLE
Add Demonic Covenant and supporting changes

### DIFF
--- a/forge-core/src/main/java/forge/card/CardType.java
+++ b/forge-core/src/main/java/forge/card/CardType.java
@@ -312,21 +312,6 @@ public final class CardType implements Comparable<CardType>, CardTypeView {
     }
 
     @Override
-    public Iterable<String> getAllTypes() {
-        final Set<String> allTypes = Sets.newHashSet();
-        for (final Supertype st : supertypes) {
-            allTypes.add(st.name());
-        }
-        for (final CoreType ct : coreTypes) {
-            allTypes.add(ct.name());
-        }
-        for (final String st : subtypes) {
-            allTypes.add(st);
-        }
-        return allTypes;
-    }
-
-    @Override
     public Set<String> getLandTypes() {
         final Set<String> landTypes = Sets.newHashSet();
         if (isLand()) {
@@ -806,10 +791,8 @@ public final class CardType implements Comparable<CardType>, CardTypeView {
         if (ctOther == null) {
             return false;
         }
-        List<String> ctOtherCoreTypes = new ArrayList<>();
-        ctOther.getAllTypes().forEach(ctOtherCoreTypes::add);
-        for (final String type : getAllTypes()) {
-            if (!ctOtherCoreTypes.contains(type)) {
+        for (final CoreType type : getCoreTypes()) {
+            if (!ctOther.hasType(type)) {
                 return false;
             }
         }

--- a/forge-core/src/main/java/forge/card/CardType.java
+++ b/forge-core/src/main/java/forge/card/CardType.java
@@ -312,6 +312,21 @@ public final class CardType implements Comparable<CardType>, CardTypeView {
     }
 
     @Override
+    public Iterable<String> getAllTypes() {
+        final Set<String> allTypes = Sets.newHashSet();
+        for (final Supertype st : supertypes) {
+            allTypes.add(st.name());
+        }
+        for (final CoreType ct : coreTypes) {
+            allTypes.add(ct.name());
+        }
+        for (final String st : subtypes) {
+            allTypes.add(st);
+        }
+        return allTypes;
+    }
+
+    @Override
     public Set<String> getLandTypes() {
         final Set<String> landTypes = Sets.newHashSet();
         if (isLand()) {
@@ -779,13 +794,26 @@ public final class CardType implements Comparable<CardType>, CardTypeView {
         if (ctOther == null) {
             return false;
         }
-
         for (final CoreType type : getCoreTypes()) {
             if (ctOther.hasType(type)) {
                 return true;
             }
         }
         return false;
+    }
+
+    public boolean sharesAllCardTypesWith(final CardTypeView ctOther) {
+        if (ctOther == null) {
+            return false;
+        }
+        List<String> ctOtherCoreTypes = new ArrayList<>();
+        ctOther.getAllTypes().forEach(ctOtherCoreTypes::add);
+        for (final String type : getAllTypes()) {
+            if (!ctOtherCoreTypes.contains(type)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public boolean sharesSubtypeWith(final CardTypeView ctOther) {

--- a/forge-core/src/main/java/forge/card/CardType.java
+++ b/forge-core/src/main/java/forge/card/CardType.java
@@ -796,6 +796,11 @@ public final class CardType implements Comparable<CardType>, CardTypeView {
                 return false;
             }
         }
+        for (final CoreType type : ctOther.getCoreTypes()) {
+            if (!this.hasType(type)) {
+                return false;
+            }
+        }
         return true;
     }
 

--- a/forge-core/src/main/java/forge/card/CardTypeView.java
+++ b/forge-core/src/main/java/forge/card/CardTypeView.java
@@ -13,6 +13,7 @@ public interface CardTypeView extends Iterable<String>, Serializable {
     Iterable<Supertype> getSupertypes();
     Iterable<String> getSubtypes();
     Iterable<String> getExcludedCreatureSubTypes();
+    Iterable<String> getAllTypes();
 
     Set<String> getCreatureTypes();
     Set<String> getLandTypes();
@@ -30,6 +31,7 @@ public interface CardTypeView extends Iterable<String>, Serializable {
     public boolean sharesLandTypeWith(final CardTypeView ctOther);
     public boolean sharesPermanentTypeWith(final CardTypeView ctOther);
     public boolean sharesCardTypeWith(final CardTypeView ctOther);
+    public boolean sharesAllCardTypesWith(final CardTypeView ctOther);
 
     boolean isPermanent();
     boolean isCreature();

--- a/forge-core/src/main/java/forge/card/CardTypeView.java
+++ b/forge-core/src/main/java/forge/card/CardTypeView.java
@@ -13,7 +13,6 @@ public interface CardTypeView extends Iterable<String>, Serializable {
     Iterable<Supertype> getSupertypes();
     Iterable<String> getSubtypes();
     Iterable<String> getExcludedCreatureSubTypes();
-    Iterable<String> getAllTypes();
 
     Set<String> getCreatureTypes();
     Set<String> getLandTypes();

--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -1870,6 +1870,8 @@ public class GameAction {
 
     public final CardCollection sacrifice(final Iterable<Card> list, final SpellAbility source, final boolean effect, Map<AbilityKey, Object> params) {
         Multimap<Player, Card> lki = MultimapBuilder.hashKeys().arrayListValues().build();
+        final boolean showRevealDialog = source != null && source.hasParam("ShowSacrificedCards");
+
         CardCollection result = new CardCollection();
         for (Card c : list) {
             if (c == null) {
@@ -1889,6 +1891,10 @@ public class GameAction {
             Card changed = sacrificeDestroy(c, source, params);
             if (changed != null) {
                 result.add(changed);
+            }
+            if (showRevealDialog) {
+                final String message = Localizer.getInstance().getMessage("lblSacrifice");
+                game.getAction().reveal(result, ZoneType.Graveyard, c.getOwner(), false, message, false);
             }
         }
         for (Map.Entry<Player, Collection<Card>> e : lki.asMap().entrySet()) {

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -6088,6 +6088,13 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
         return getType().sharesCardTypeWith(c1.getType());
     }
 
+    public final boolean sharesAllCardTypesWith(final Card c1) {
+        if (c1 == null) {
+            return false;
+        }
+        return getType().sharesAllCardTypesWith(c1.getType());
+    }
+
     public final boolean sharesControllerWith(final Card c1) {
         return c1 != null && getController().equals(c1.getController());
     }

--- a/forge-game/src/main/java/forge/game/card/CardPredicates.java
+++ b/forge-game/src/main/java/forge/game/card/CardPredicates.java
@@ -114,6 +114,10 @@ public final class CardPredicates {
         return c -> c.sharesCardTypeWith(card);
     }
 
+    public static Predicate<Card> sharesAllCardTypesWith(final Card card) {
+        return c -> c.sharesAllCardTypesWith(card);
+    }
+
     public static Predicate<Card> sharesCreatureTypeWith(final Card card) {
         return c -> c.sharesCreatureTypeWith(card);
     }

--- a/forge-game/src/main/java/forge/game/card/CardProperty.java
+++ b/forge-game/src/main/java/forge/game/card/CardProperty.java
@@ -847,6 +847,11 @@ public class CardProperty {
                         }
                 }
             }
+        } else if (property.startsWith("sharesAllCardTypesWithOther")) {
+            final String restriction = property.split("sharesAllCardTypesWithOther ")[1];
+            CardCollection list = AbilityUtils.getDefinedCards(source, restriction, spellAbility);
+            list.remove(card);
+            return Iterables.any(list, CardPredicates.sharesAllCardTypesWith(card));
         } else if (property.startsWith("sharesLandTypeWith")) {
             final String restriction = property.split("sharesLandTypeWith ")[1];
             if (!Iterables.any(AbilityUtils.getDefinedCards(source, restriction, spellAbility), CardPredicates.sharesLandTypeWith(card))) {

--- a/forge-gui/res/cardsfolder/upcoming/demonic_covenant.txt
+++ b/forge-gui/res/cardsfolder/upcoming/demonic_covenant.txt
@@ -1,14 +1,14 @@
 Name:Demonic Covenant
 ManaCost:4 B B
-Types:Kindred Enchantment Demonic
-T:Mode$ AttackersDeclared | ValidAttackers$ Creature.Demon+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigDrawAndDamage | TriggerDescription$ Whenever one or more Demons you control attack a player, you draw a card and lose 1 life.
+Types:Kindred Enchantment Demon
+T:Mode$ AttackersDeclaredOneTarget | ValidAttackers$ Creature.Demon+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigDrawAndDamage | TriggerDescription$ Whenever one or more Demons you control attack a player, you draw a card and lose 1 life.
 SVar:TrigDrawAndDamage:DB$ Draw | SubAbility$ DBLoseLife
 SVar:DBLoseLife:DB$ LoseLife | LifeAmount$ 1
 T:Mode$ Phase | Phase$ End of Turn | TriggerZones$ Battlefield | Execute$ TrigCreateAndMill | TriggerDescription$ At the beginning of your end step, create a 5/5 black Demon creature token with flying, then mill two cards.
 SVar:TrigCreateAndMill:DB$ Token | TokenAmount$ 1 | TokenScript$ b_5_5_demon_flying | TokenOwner$ You | SubAbility$ DBMill
 SVar:DBMill:DB$ Mill | NumCards$ 2 | RememberMilled$ True | ShowMilledCards$ True | SubAbility$ DBSacrifice | SpellDescription$ If two cards that share all their card types were milled this way, sacrifice CARDNAME.
-SVar:DBSacrifice:DB$ Sacrifice | SacValid$ Self | ConditionCheckSVar$ MilledSharesAllTypes | ConditionSVarCompare$ GE2 | SubAbility$ Cleanup
+SVar:DBSacrifice:DB$ Sacrifice | SacValid$ Self | ShowSacrificedCards$ True | ConditionCheckSVar$ MilledSharesAllTypes | ConditionSVarCompare$ GE2 | SubAbility$ Cleanup
 SVar:MilledSharesAllTypes:Remembered$Valid Card.sharesAllCardTypesWithOther Remembered
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 DeckHas:Ability$Token|Mill|Sacrifice
-Oracle:Whenever one or more Demons you control attack a player, you draw a card and lose 1 life.\nAt the beginning of your end step, create a 5/5 black Demon creature token with flying, then mill two cards. If two cards that share all their card types were milled this way, sacrifice CARDNAME.
+Oracle:Whenever one or more Demons you control attack a player, you draw a card and lose 1 life.\nAt the beginning of your end step, create a 5/5 black Demon creature token with flying, then mill two cards. If two cards that share all their card types were milled this way, sacrifice Demonic Covenant.

--- a/forge-gui/res/cardsfolder/upcoming/demonic_covenant.txt
+++ b/forge-gui/res/cardsfolder/upcoming/demonic_covenant.txt
@@ -1,12 +1,12 @@
 Name:Demonic Covenant
 ManaCost:4 B B
 Types:Kindred Enchantment Demon
-T:Mode$ AttackersDeclaredOneTarget | ValidAttackers$ Creature.Demon+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigDrawAndDamage | TriggerDescription$ Whenever one or more Demons you control attack a player, you draw a card and lose 1 life.
+T:Mode$ AttackersDeclaredOneTarget | AttackedTarget$ Player | ValidAttackers$ Creature.Demon+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigDrawAndDamage | TriggerDescription$ Whenever one or more Demons you control attack a player, you draw a card and lose 1 life.
 SVar:TrigDrawAndDamage:DB$ Draw | SubAbility$ DBLoseLife
 SVar:DBLoseLife:DB$ LoseLife | LifeAmount$ 1
-T:Mode$ Phase | Phase$ End of Turn | TriggerZones$ Battlefield | Execute$ TrigCreateAndMill | TriggerDescription$ At the beginning of your end step, create a 5/5 black Demon creature token with flying, then mill two cards.
+T:Mode$ Phase | Phase$ End of Turn | TriggerZones$ Battlefield | Execute$ TrigCreateAndMill | TriggerDescription$ At the beginning of your end step, create a 5/5 black Demon creature token with flying, then mill two cards. If two cards that share all their card types were milled this way, sacrifice CARDNAME.
 SVar:TrigCreateAndMill:DB$ Token | TokenAmount$ 1 | TokenScript$ b_5_5_demon_flying | TokenOwner$ You | SubAbility$ DBMill
-SVar:DBMill:DB$ Mill | NumCards$ 2 | RememberMilled$ True | ShowMilledCards$ True | SubAbility$ DBSacrifice | SpellDescription$ If two cards that share all their card types were milled this way, sacrifice CARDNAME.
+SVar:DBMill:DB$ Mill | NumCards$ 2 | RememberMilled$ True | ShowMilledCards$ True | SubAbility$ DBSacrifice
 SVar:DBSacrifice:DB$ Sacrifice | SacValid$ Self | ShowSacrificedCards$ True | ConditionCheckSVar$ MilledSharesAllTypes | ConditionSVarCompare$ GE2 | SubAbility$ Cleanup
 SVar:MilledSharesAllTypes:Remembered$Valid Card.sharesAllCardTypesWithOther Remembered
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/upcoming/demonic_covenant.txt
+++ b/forge-gui/res/cardsfolder/upcoming/demonic_covenant.txt
@@ -1,0 +1,14 @@
+Name:Demonic Covenant
+ManaCost:4 B B
+Types:Kindred Enchantment Demonic
+T:Mode$ AttackersDeclared | ValidAttackers$ Creature.Demon+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigDrawAndDamage | TriggerDescription$ Whenever one or more Demons you control attack a player, you draw a card and lose 1 life.
+SVar:TrigDrawAndDamage:DB$ Draw | SubAbility$ DBLoseLife
+SVar:DBLoseLife:DB$ LoseLife | LifeAmount$ 1
+T:Mode$ Phase | Phase$ End of Turn | TriggerZones$ Battlefield | Execute$ TrigCreateAndMill | TriggerDescription$ At the beginning of your end step, create a 5/5 black Demon creature token with flying, then mill two cards.
+SVar:TrigCreateAndMill:DB$ Token | TokenAmount$ 1 | TokenScript$ b_5_5_demon_flying | TokenOwner$ You | SubAbility$ DBMill
+SVar:DBMill:DB$ Mill | NumCards$ 2 | RememberMilled$ True | ShowMilledCards$ True | SubAbility$ DBSacrifice | SpellDescription$ If two cards that share all their card types were milled this way, sacrifice CARDNAME.
+SVar:DBSacrifice:DB$ Sacrifice | SacValid$ Self | ConditionCheckSVar$ MilledSharesAllTypes | ConditionSVarCompare$ GE2 | SubAbility$ Cleanup
+SVar:MilledSharesAllTypes:Remembered$Valid Card.sharesAllCardTypesWithOther Remembered
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+DeckHas:Ability$Token|Mill|Sacrifice
+Oracle:Whenever one or more Demons you control attack a player, you draw a card and lose 1 life.\nAt the beginning of your end step, create a 5/5 black Demon creature token with flying, then mill two cards. If two cards that share all their card types were milled this way, sacrifice CARDNAME.


### PR DESCRIPTION
- Added a method to CardTypeView that supports getting all types of a card (super, sub and core).
- Added a method to CardType that checks if a another card shares all types with the card.
- Added a parameter to CardProperty for "sharesAllCardTypesWithOther".
- Added a parameter to GameAction.sacrifice() for "ShowSacrificedCards".
  - Without showing that Demonic Covenant was sacrificed due to the milling the end of turn seems extremely abrupt. In a multiple player game it gets confusing quickly when an Enchantment just disappears without notification of some sort. I did not notice any sacrifices going to the Game Log and felt this was an pretty good solution.