### PR TITLE
Fix NPE when creating room token

### DIFF
--- a/forge-game/src/main/java/forge/game/card/CardCopyService.java
+++ b/forge-game/src/main/java/forge/game/card/CardCopyService.java
@@ -119,7 +119,7 @@ public class CardCopyService {
         c.setSetCode(in.getSetCode());
 
         for (final CardStateName state : in.getStates()) {
-            copyState(in, state, c, state);
+            copyState(in, state, c, state, false);
         }
 
         c.setState(in.getCurrentStateName(), false);

--- a/forge-gui/res/cardsfolder/upcoming/entity_tracker.txt
+++ b/forge-gui/res/cardsfolder/upcoming/entity_tracker.txt
@@ -4,7 +4,7 @@ Types:Creature Human Scout
 PT:2/3
 K:Flash
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Enchantment.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, draw a card.
-T:Mode$ FullyUnlock | ValidCard$ Card.Room | ValidPlayer$ You | Secondary$ True | Execute$ TrigDraw | TriggerDescription$ Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, draw a card.
+T:Mode$ FullyUnlock | ValidCard$ Card.Room | ValidPlayer$ You | Secondary$ True | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, draw a card.
 SVar:TrigDraw:DB$ Draw
 DeckNeeds:Type$Enchantment
 Oracle:Flash\nEerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, draw a card.


### PR DESCRIPTION
The problem was it tries to fetch the right state while still doing the left.
I really don't think we need that View update during copying anyway, so that's my solution.

Closes #6275
Closes #6276