### PR TITLE
Edit pile cleanup: Line reordering, first pass: part 1, folders 'a' to 'd'

### DIFF
--- a/forge-gui/res/cardsfolder/a/abdel_adrian_gorions_ward.txt
+++ b/forge-gui/res/cardsfolder/a/abdel_adrian_gorions_ward.txt
@@ -9,6 +9,6 @@ SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Remembered$Amount
 SVar:MaxTgts:Count$Valid Permanent.Other+nonLand+YouCtrl
 K:Choose a Background
-DeckHas:Ability$Token & Type$Soldier
 AI:RemoveDeck:Random
+DeckHas:Ability$Token & Type$Soldier
 Oracle:When Abdel Adrian, Gorion's Ward enters, exile any number of other nonland permanents you control until Abdel Adrian leaves the battlefield. Create a 1/1 white Soldier creature token for each permanent exiled this way.\nChoose a Background (You can have a Background as a second commander.)

--- a/forge-gui/res/cardsfolder/a/abstruse_interference.txt
+++ b/forge-gui/res/cardsfolder/a/abstruse_interference.txt
@@ -4,6 +4,6 @@ Types:Instant
 K:Devoid
 A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | UnlessCost$ 1 | SubAbility$ DBToken | SpellDescription$ Counter target spell unless its controller pays {1}.
 SVar:DBToken:DB$ Token | TokenAmount$ 1 | TokenScript$ c_1_1_eldrazi_scion_sac | TokenOwner$ You | SpellDescription$ You create a 1/1 colorless Eldrazi Scion creature token. It has "Sacrifice this creature: Add {C}." ({C} represents colorless mana.)
-DeckHints:Type$Eldrazi
 DeckHas:Ability$Mana.Colorless|Token
+DeckHints:Type$Eldrazi
 Oracle:Devoid (This card has no color.)\nCounter target spell unless its controller pays {1}. You create a 1/1 colorless Eldrazi Scion creature token. It has "Sacrifice this creature: Add {C}." ({C} represents colorless mana.)

--- a/forge-gui/res/cardsfolder/a/abzan_battle_priest.txt
+++ b/forge-gui/res/cardsfolder/a/abzan_battle_priest.txt
@@ -5,6 +5,6 @@ PT:3/2
 K:Outlast:W
 S:Mode$ Continuous | Affected$ Creature.YouCtrl+counters_GE1_P1P1 | AddKeyword$ Lifelink | Description$ Each creature you control with a +1/+1 counter on it has lifelink.
 SVar:PlayMain1:TRUE
-DeckHints:Ability$Counters
 DeckHas:Ability$Counters
+DeckHints:Ability$Counters
 Oracle:Outlast {W} ({W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has lifelink.

--- a/forge-gui/res/cardsfolder/a/abzan_falconer.txt
+++ b/forge-gui/res/cardsfolder/a/abzan_falconer.txt
@@ -5,6 +5,6 @@ PT:2/3
 K:Outlast:W
 S:Mode$ Continuous | Affected$ Creature.YouCtrl+counters_GE1_P1P1 | AddKeyword$ Flying | Description$ Each creature you control wth a +1/+1 counter on it has flying.
 SVar:PlayMain1:TRUE
-DeckHints:Ability$Counters
 DeckHas:Ability$Counters
+DeckHints:Ability$Counters
 Oracle:Outlast {W} ({W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has flying.

--- a/forge-gui/res/cardsfolder/a/acolyte_of_bahamut.txt
+++ b/forge-gui/res/cardsfolder/a/acolyte_of_bahamut.txt
@@ -3,6 +3,6 @@ ManaCost:1 G
 Types:Legendary Enchantment Background
 S:Mode$ Continuous | Affected$ Creature.IsCommander+YouOwn | AddStaticAbility$ DragonReduce | Description$ Commander creatures you own have "The first Dragon spell you cast each turn costs {2} less to cast."
 SVar:DragonReduce:Mode$ ReduceCost | EffectZone$ Battlefield | ValidCard$ Card.Dragon | Activator$ You | Type$ Spell | OnlyFirstSpell$ True | Amount$ 2 | Description$ The first Dragon spell you cast each turn costs {2} less to cast.
-DeckNeeds:Type$Dragon
 AI:RemoveDeck:NonCommander
+DeckNeeds:Type$Dragon
 Oracle:Commander creatures you own have "The first Dragon spell you cast each turn costs {2} less to cast."

--- a/forge-gui/res/cardsfolder/a/adverse_conditions.txt
+++ b/forge-gui/res/cardsfolder/a/adverse_conditions.txt
@@ -5,6 +5,6 @@ K:Devoid
 A:SP$ Tap | TargetMin$ 0 | TargetMax$ 2 | TgtPrompt$ Choose target creature | ValidTgts$ Creature | SubAbility$ TrigPump | SpellDescription$ Tap up to two target creatures.
 SVar:TrigPump:DB$ Pump | Defined$ Targeted | KW$ HIDDEN This card doesn't untap during your next untap step. | Duration$ Permanent | SubAbility$ DBToken | SpellDescription$ Those creatures don't untap during their controller's next untap step.
 SVar:DBToken:DB$ Token | TokenAmount$ 1 | TokenScript$ c_1_1_eldrazi_scion_sac | TokenOwner$ You | SpellDescription$ Create a 1/1 colorless Eldrazi Scion creature token. It has "Sacrifice this creature: Add {C}."
-DeckHints:Type$Eldrazi
 DeckHas:Ability$Mana.Colorless|Token
+DeckHints:Type$Eldrazi
 Oracle:Devoid (This card has no color.)\nTap up to two target creatures. Those creatures don't untap during their controller's next untap step. Create a 1/1 colorless Eldrazi Scion creature token. It has "Sacrifice this creature: Add {C}."

--- a/forge-gui/res/cardsfolder/a/advice_from_the_fae.txt
+++ b/forge-gui/res/cardsfolder/a/advice_from_the_fae.txt
@@ -5,6 +5,6 @@ A:SP$ Dig | DigNum$ 5 | ChangeNum$ 1 | SubAbility$ Dig2 | ConditionCheckSVar$ X 
 SVar:Dig2:DB$ Dig | DigNum$ 5 | ChangeNum$ 2 | ConditionCheckSVar$ X | ConditionSVarCompare$ GTY
 SVar:X:Count$Valid Creature.YouCtrl
 SVar:Y:PlayerCountOther$HighestValid Creature.YouCtrl
-DeckNeeds:Color$Blue
 AI:RemoveDeck:Random
+DeckNeeds:Color$Blue
 Oracle:({2/U} can be paid with any two mana or with {U}. This card's mana value is 6.)\nLook at the top five cards of your library. If you control more creatures than each other player, put two of those cards into your hand. Otherwise, put one of them into your hand. Then put the rest on the bottom of your library in any order.

--- a/forge-gui/res/cardsfolder/a/aeronaut_cavalry.txt
+++ b/forge-gui/res/cardsfolder/a/aeronaut_cavalry.txt
@@ -5,6 +5,6 @@ PT:3/4
 K:Flying
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPut | TriggerDescription$ When CARDNAME enters, put a +1/+1 counter on another target Soldier you control.
 SVar:TrigPut:DB$ PutCounter | ValidTgts$ Soldier.Other+YouCtrl | TgtPrompt$ Select another target Soldier you control | CounterType$ P1P1
-DeckHints:Type$Soldier
 DeckHas:Ability$Counters
+DeckHints:Type$Soldier
 Oracle:Flying\nWhen Aeronaut Cavalry enters, put a +1/+1 counter on another target Soldier you control.

--- a/forge-gui/res/cardsfolder/a/aether_searcher.txt
+++ b/forge-gui/res/cardsfolder/a/aether_searcher.txt
@@ -1,7 +1,7 @@
 Name:Aether Searcher
 ManaCost:7
-PT:6/4
 Types:Artifact Creature Construct
+PT:6/4
 Draft:Reveal CARDNAME as you draft it.
 Draft:Reveal the next card you draft and note its name.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSearchHand | TriggerDescription$ When CARDNAME enters, you may search your hand and/or library for a card with a name noted as you drafted cards named Aether Searcher. You may cast it without paying its mana cost. If you searched your library this way, shuffle.

--- a/forge-gui/res/cardsfolder/a/agathas_champion.txt
+++ b/forge-gui/res/cardsfolder/a/agathas_champion.txt
@@ -7,6 +7,6 @@ K:Trample
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self+bargained | Execute$ TrigKicker | TriggerDescription$ When CARDNAME enters, if it was bargained, it fights up to one target creature you don't control. (Each deals damage equal to its power to the other.)
 SVar:TrigKicker:DB$ Fight | Defined$ TriggeredCardLKICopy | ValidTgts$ Creature.YouDontCtrl | TgtPrompt$ Select up to one target creature an opponent controls | TargetMin$ 0 | TargetMax$ 1
 SVar:PlayMain1:TRUE
-DeckHints:Type$Artifact|Enchantment & Ability$Token
 DeckHas:Ability$Sacrifice
+DeckHints:Type$Artifact|Enchantment & Ability$Token
 Oracle:Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nTrample\nWhen Agatha's Champion enters, if it was bargained, it fights up to one target creature you don't control. (Each deals damage equal to its power to the other.)

--- a/forge-gui/res/cardsfolder/a/agent_of_the_iron_throne.txt
+++ b/forge-gui/res/cardsfolder/a/agent_of_the_iron_throne.txt
@@ -4,6 +4,6 @@ Types:Legendary Enchantment Background
 S:Mode$ Continuous | Affected$ Creature.IsCommander+YouOwn | AddTrigger$ Dies | Description$ Commander creatures you own have "Whenever an artifact or creature you control is put into a graveyard from the battlefield, each opponent loses 1 life."
 SVar:Dies:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Artifact.YouCtrl,Creature.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigDrain | TriggerDescription$ Whenever an artifact or creature you control is put into a graveyard from the battlefield, each opponent loses 1 life.
 SVar:TrigDrain:DB$ LoseLife | Defined$ Opponent | LifeAmount$ 1
-DeckHints:Type$Artifact & Ability$Sacrifice
 AI:RemoveDeck:NonCommander
+DeckHints:Type$Artifact & Ability$Sacrifice
 Oracle:Commander creatures you own have "Whenever an artifact or creature you control is put into a graveyard from the battlefield, each opponent loses 1 life."

--- a/forge-gui/res/cardsfolder/a/agent_of_the_shadow_thieves.txt
+++ b/forge-gui/res/cardsfolder/a/agent_of_the_shadow_thieves.txt
@@ -5,6 +5,6 @@ S:Mode$ Continuous | Affected$ Creature.IsCommander+YouOwn | AddTrigger$ Attacks
 SVar:AttacksPlayer:Mode$ Attacks | ValidCard$ Card.Self | Attacked$ Player | Condition$ NoOpponentHasMoreLifeThanAttacked | Execute$ TrigPutCounter | TriggerDescription$ Whenever this creature attacks a player, if no opponent has more life than that player, put a +1/+1 counter on this creature. It gains deathtouch and indestructible until end of turn.
 SVar:TrigPutCounter:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ 1 | Defined$ Self | SubAbility$ DBPump
 SVar:DBPump:DB$ Pump | Defined$ Self | KW$ Deathtouch & Indestructible
-DeckHas:Ability$Counters
 AI:RemoveDeck:NonCommander
+DeckHas:Ability$Counters
 Oracle:Commander creatures you own have "Whenever this creature attacks a player, if no opponent has more life than that player, put a +1/+1 counter on this creature. It gains deathtouch and indestructible until end of turn."

--- a/forge-gui/res/cardsfolder/a/ainok_bond_kin.txt
+++ b/forge-gui/res/cardsfolder/a/ainok_bond_kin.txt
@@ -5,6 +5,6 @@ PT:2/1
 K:Outlast:1 W
 S:Mode$ Continuous | Affected$ Creature.YouCtrl+counters_GE1_P1P1 | AddKeyword$ First Strike | Description$ Each creature you control with a +1/+1 counter on it has first strike.
 SVar:PlayMain1:TRUE
-DeckHints:Ability$Counters
 DeckHas:Ability$Counters
+DeckHints:Ability$Counters
 Oracle:Outlast {1}{W} ({1}{W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has first strike.

--- a/forge-gui/res/cardsfolder/a/ajanis_aid.txt
+++ b/forge-gui/res/cardsfolder/a/ajanis_aid.txt
@@ -6,6 +6,6 @@ SVar:TrigSearch:DB$ ChangeZone | Origin$ Library | OriginAlternative$ Graveyard 
 A:AB$ ChooseCard | Cost$ Sac<1/CARDNAME> | Choices$ Creature | Mandatory$ True | AILogic$ NeedsPrevention | SubAbility$ DBEffect | SpellDescription$ Prevent all combat damage a creature of your choice would deal this turn.
 SVar:DBEffect:DB$ Effect | ReplacementEffects$ RPreventNextFromSource | RememberObjects$ ChosenCard | ExileOnMoved$ Battlefield
 SVar:RPreventNextFromSource:Event$ DamageDone | IsCombat$ True | ValidSource$ Card.IsRemembered | Prevent$ True | Description$ Prevent all combat damage a creature of your choice would deal this turn.
-DeckHints:Name$Ajani, Valiant Protector
 DeckHas:Ability$Sacrifice
+DeckHints:Name$Ajani, Valiant Protector
 Oracle:When Ajani's Aid enters, you may search your library and/or graveyard for a card named Ajani, Valiant Protector, reveal it, and put it into your hand. If you search your library this way, shuffle.\nSacrifice Ajani's Aid: Prevent all combat damage a creature of your choice would deal this turn.

--- a/forge-gui/res/cardsfolder/a/ajanis_pridemate.txt
+++ b/forge-gui/res/cardsfolder/a/ajanis_pridemate.txt
@@ -4,6 +4,6 @@ Types:Creature Cat Soldier
 PT:2/2
 T:Mode$ LifeGained | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Whenever you gain life, put a +1/+1 counter on CARDNAME.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
-DeckHints:Ability$LifeGain
 DeckHas:Ability$Counters
+DeckHints:Ability$LifeGain
 Oracle:Whenever you gain life, put a +1/+1 counter on Ajani's Pridemate.

--- a/forge-gui/res/cardsfolder/a/alandra_sky_dreamer.txt
+++ b/forge-gui/res/cardsfolder/a/alandra_sky_dreamer.txt
@@ -7,7 +7,7 @@ SVar:TrigToken:DB$ Token | TokenScript$ u_2_2_drake_flying
 T:Mode$ Drawn | ValidCard$ Card.YouCtrl | Number$ 5 | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever you draw your fifth card each turn, CARDNAME and Drakes you control get +X/+X until end of turn, where X is the number of cards in your hand.
 SVar:TrigPump:DB$ PumpAll | ValidCards$ Card.Self,Drake.YouCtrl | NumAtt$ X | NumDef$ X
 SVar:X:Count$InYourHand
+AI:RemoveDeck:Random
 DeckHas:Ability$Token & Type$Drake
 DeckHints:Type$Drake
-AI:RemoveDeck:Random
 Oracle:Whenever you draw your second card each turn, create a 2/2 blue Drake creature token with flying.\nWhenever you draw your fifth card each turn, Alandra, Sky Dreamer and Drakes you control get +X/+X until end of turn, where X is the number of cards in your hand.

--- a/forge-gui/res/cardsfolder/a/albiorix_goose_tyrant_wild_goose_chase.txt
+++ b/forge-gui/res/cardsfolder/a/albiorix_goose_tyrant_wild_goose_chase.txt
@@ -7,9 +7,9 @@ K:Trample
 K:Ward:1
 T:Mode$ Sacrificed | ValidPlayer$ You | ValidCard$ Card.token | TriggerZones$ Battlefield,Exile | Execute$ TrigPump | TriggerDescription$ Whenever you sacrifice a token, NICKNAME perpetually gets +1/+1. This ability also triggers if NICKNAME is in exile.
 SVar:TrigPump:DB$ Pump | PumpZone$ Battlefield,Exile | NumAtt$ 1 | NumDef$ 1 | Duration$ Perpetual
-AlternateMode:Adventure
 DeckHas:Ability$Discard|Token & Type$Food
 DeckHints:Ability$Token & Type$Treasure|Food|Clue
+AlternateMode:Adventure
 Oracle:Flying, Trample, Ward {1}\nWhenever you sacrifice a token, Albiorix perpetually gets +1/+1. This ability also triggers if Albiorix is in exile.
 
 ALTERNATE

--- a/forge-gui/res/cardsfolder/a/alquist_proft_master_sleuth.txt
+++ b/forge-gui/res/cardsfolder/a/alquist_proft_master_sleuth.txt
@@ -8,6 +8,6 @@ SVar:TrigInvestigate:DB$ Investigate
 A:AB$ Draw | Cost$ X W U U T Sac<1/Clue> | NumCards$ X | SubAbility$ DBGainLife | SpellDescription$ You draw X cards and gain X life.
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ X
 SVar:X:Count$xPaid
-DeckHints:Ability$Investigate
 DeckHas:Ability$Investigate|Token|Sacrifice|LifeGain & Type$Artifact|Clue
+DeckHints:Ability$Investigate
 Oracle:Vigilance\nWhen Alquist Proft, Master Sleuth enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")\n{X}{W}{U}{U}, {T}, Sacrifice a Clue: You draw X cards and gain X life.

--- a/forge-gui/res/cardsfolder/a/alrund_god_of_the_cosmos_hakka_whispering_raven.txt
+++ b/forge-gui/res/cardsfolder/a/alrund_god_of_the_cosmos_hakka_whispering_raven.txt
@@ -9,8 +9,8 @@ SVar:Z:SVar$X/Plus.Y
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigChooseCardType | TriggerDescription$ At the beginning of your end step, choose a card type, then reveal the top two cards of your library. Put all cards of the chosen type revealed this way into your hand and the rest on the bottom of your library in any order.
 SVar:TrigChooseCardType:DB$ ChooseType | Defined$ You | Type$ Card | SubAbility$ DBDig
 SVar:DBDig:DB$ Dig | DigNum$ 2 | Reveal$ True | ChangeNum$ All | ChangeValid$ Card.ChosenType | DestinationZone2$ Library | LibraryPosition$ -1
-DeckHints:Keyword$Foretell
 AI:RemoveDeck:All
+DeckHints:Keyword$Foretell
 AlternateMode:Modal
 Oracle:Alrund gets +1/+1 for each card in your hand and each foretold card you own in exile.\nAt the beginning of your end step, choose a card type, then reveal the top two cards of your library. Put all cards of the chosen type revealed this way into your hand and the rest on the bottom of your library in any order.
 

--- a/forge-gui/res/cardsfolder/a/altar_of_the_wretched_wretched_bonemass.txt
+++ b/forge-gui/res/cardsfolder/a/altar_of_the_wretched_wretched_bonemass.txt
@@ -8,9 +8,9 @@ SVar:Y:Sacrificed$CardPower
 K:Craft:2 B B XMin1 ExileCtrlOrGrave<X/Creature.Other>
 SVar:X:Count$xPaid
 A:AB$ ChangeZone | Cost$ 2 B | Origin$ Graveyard | Destination$ Hand | ActivationZone$ Graveyard | SpellDescription$ Return CARDNAME from your graveyard to your hand.
-DeckHints:Ability$Discard|Mill|Sacrifice
-DeckHas:Ability$Graveyard|Sacrifice|Mill
 AI:RemoveDeck:All
+DeckHas:Ability$Graveyard|Sacrifice|Mill
+DeckHints:Ability$Discard|Mill|Sacrifice
 AlternateMode:DoubleFaced
 Oracle:When Altar of the Wretched enters, you may sacrifice a nontoken creature. If you do, draw X cards, then mill X cards, where X is that creature's power.\nCraft with one or more creatures {2}{B}{B}\n{2}{B}: Return Altar of the Wretched from your graveyard to your hand.
 

--- a/forge-gui/res/cardsfolder/a/amzu_swarms_hunger.txt
+++ b/forge-gui/res/cardsfolder/a/amzu_swarms_hunger.txt
@@ -10,6 +10,6 @@ SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ bg_1_1_insect | Remembe
 SVar:DBPutCounter:DB$ PutCounter | Defined$ Remembered | CounterNum$ X | CounterType$ P1P1 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:TriggerObjectsCards$GreatestCMC
-DeckHints:Type$Insect & Ability$Graveyard
 DeckHas:Ability$Token & Ability$Graveyard
+DeckHints:Type$Insect & Ability$Graveyard
 Oracle:Flying, menace\nOther Insects you control have menace.\nWhenever one or more cards leave your graveyard, you may create a 1/1 black and green Insect creature token, then put a number of +1/+1 counters on it equal to the greatest mana value among those cards. Do this only once each turn.

--- a/forge-gui/res/cardsfolder/a/anchor_to_reality.txt
+++ b/forge-gui/res/cardsfolder/a/anchor_to_reality.txt
@@ -7,6 +7,6 @@ SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Count$Compare Y LTZ.2.0
 SVar:Y:Remembered$CardManaCost
 SVar:Z:Sacrificed$CardManaCost
-DeckNeeds:Type$Artifact|Creature|Equipment|Vehicle
 AI:RemoveDeck:Random
+DeckNeeds:Type$Artifact|Creature|Equipment|Vehicle
 Oracle:As an additional cost to cast this spell, sacrifice an artifact or creature.\nSearch your library for an Equipment or Vehicle card, put that card onto the battlefield, then shuffle. If it has mana value less than the sacrificed permanent's mana value, scry 2.

--- a/forge-gui/res/cardsfolder/a/angel_of_deliverance.txt
+++ b/forge-gui/res/cardsfolder/a/angel_of_deliverance.txt
@@ -6,6 +6,6 @@ K:Flying
 T:Mode$ DamageDealtOnce | ValidSource$ Card.Self | Execute$ TrigChange | Delirium$ True | TriggerZones$ Battlefield | TriggerDescription$ Delirium — Whenever CARDNAME deals damage, if there are four or more card types among cards in your graveyard, exile target creature an opponent controls.
 SVar:TrigChange:DB$ ChangeZone | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | Origin$ Battlefield | Destination$ Exile
 SVar:HasCombatEffect:TRUE
-DeckHints:Ability$Graveyard|Discard
 DeckHas:Ability$Delirium
+DeckHints:Ability$Graveyard|Discard
 Oracle:Flying\nDelirium — Whenever Angel of Deliverance deals damage, if there are four or more card types among cards in your graveyard, exile target creature an opponent controls.

--- a/forge-gui/res/cardsfolder/a/angelic_favor.txt
+++ b/forge-gui/res/cardsfolder/a/angelic_favor.txt
@@ -3,6 +3,6 @@ ManaCost:3 W
 Types:Instant
 S:Mode$ AlternativeCost | ValidSA$ Spell.Self | EffectZone$ All | Cost$ tapXType<1/Creature> | IsPresent$ Plains.YouCtrl | Description$ If you control a Plains, you may tap an untapped creature you control rather than pay this spell's mana cost.
 A:SP$ Token | TokenScript$ w_4_4_angel_flying | AtEOT$ Exile | ActivationPhases$ BeginCombat->EndCombat | StackDescription$ {p:You} creates a 4/4 white Angel creature token with flying. Exile it at the beginning of the next end step. | SpellDescription$ Cast this spell only during combat. Create a 4/4 white Angel creature token with flying. Exile it at the beginning of the next end step.
-DeckHas:Ability$Token
 AI:RemoveDeck:All
+DeckHas:Ability$Token
 Oracle:If you control a Plains, you may tap an untapped creature you control rather than pay this spell's mana cost.\nCast this spell only during combat.\nCreate a 4/4 white Angel creature token with flying. Exile it at the beginning of the next end step.

--- a/forge-gui/res/cardsfolder/a/angelic_sleuth.txt
+++ b/forge-gui/res/cardsfolder/a/angelic_sleuth.txt
@@ -5,6 +5,6 @@ PT:2/3
 K:Flying
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | ValidCard$ Permanent.YouCtrl+Other+HasCounters | TriggerZones$ Battlefield | Execute$ TrigInvestigate | TriggerDescription$ Whenever another permanent you control leaves the battlefield, if it had counters on it, investigate.
 SVar:TrigInvestigate:DB$ Investigate
-DeckHints:Ability$Counters
 DeckHas:Ability$Investigate|Token|Sacrifice & Type$Artifact|Clue
+DeckHints:Ability$Counters
 Oracle:Flying\nWhenever another permanent you control leaves the battlefield, if it had counters on it, investigate.

--- a/forge-gui/res/cardsfolder/a/anikthea_hand_of_erebos.txt
+++ b/forge-gui/res/cardsfolder/a/anikthea_hand_of_erebos.txt
@@ -10,7 +10,7 @@ SVar:TrigExile:DB$ ChangeZone | ValidTgts$ Enchantment.nonAura+YouCtrl | Origin$
 SVar:DBCopy:DB$ CopyPermanent | Defined$ Remembered | SetPower$ 3 | SetToughness$ 3 | AddTypes$ Creature & Zombie | SetColor$ Black | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 DeckHas:Ability$Token|Graveyard
-DeckNeeds:Type$Enchantment
 DeckHints:Ability$Graveyard|Mill
+DeckNeeds:Type$Enchantment
 SVar:HasAttackEffect:TRUE
 Oracle:Menace\nOther enchantment creatures you control have menace.\nWhenever Anikthea enters or attacks, exile up to one target non-Aura enchantment card from your graveyard. Create a token that's a copy of that card, except it's a 3/3 black Zombie creature in addition to its other types.

--- a/forge-gui/res/cardsfolder/a/animation_module.txt
+++ b/forge-gui/res/cardsfolder/a/animation_module.txt
@@ -4,6 +4,6 @@ Types:Artifact
 T:Mode$ CounterAddedOnce | ValidCard$ Permanent.YouCtrl | TriggerZones$ Battlefield | CounterType$ P1P1 | Execute$ TrigToken | TriggerDescription$ Whenever one or more +1/+1 counters are put on a permanent you control, you may pay {1}. If you do, create a 1/1 colorless Servo artifact creature token.
 SVar:TrigToken:AB$ Token | Cost$ 1 | TokenAmount$ 1 | TokenScript$ c_1_1_a_servo | TokenOwner$ You
 A:AB$ PutCounter | Cost$ 3 T | ValidTgts$ Permanent,Player | TgtPrompt$ Select target player or permanent | CounterType$ ExistingCounter | CounterNum$ 1 | AILogic$ AtOppEOT | SpellDescription$ Choose a counter on target permanent or player. Give that permanent or player another counter of that kind.
-DeckHints:Ability$Counters
 AI:RemoveDeck:All
+DeckHints:Ability$Counters
 Oracle:Whenever one or more +1/+1 counters are put on a permanent you control, you may pay {1}. If you do, create a 1/1 colorless Servo artifact creature token.\n{3}, {T}: Choose a counter on target permanent or player. Give that permanent or player another counter of that kind.

--- a/forge-gui/res/cardsfolder/a/aquatic_alchemist_bubble_up.txt
+++ b/forge-gui/res/cardsfolder/a/aquatic_alchemist_bubble_up.txt
@@ -4,8 +4,8 @@ Types:Creature Elemental
 PT:1/3
 T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | ActivatorThisTurnCast$ EQ1 | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast your first instant or sorcery spell each turn, CARDNAME gets +2/+0 until end of turn.
 SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ 2
-DeckHints:Type$Instant|Sorcery
 DeckHas:Ability$Graveyard
+DeckHints:Type$Instant|Sorcery
 AlternateMode:Adventure
 Oracle:Whenever you cast your first instant or sorcery spell each turn, Aquatic Alchemist gets +2/+0 until end of turn.
 

--- a/forge-gui/res/cardsfolder/a/arcane_melee.txt
+++ b/forge-gui/res/cardsfolder/a/arcane_melee.txt
@@ -2,6 +2,6 @@ Name:Arcane Melee
 ManaCost:4 U
 Types:Enchantment
 S:Mode$ ReduceCost | ValidCard$ Instant,Sorcery | Type$ Spell | Amount$ 2 | Description$ Instant and sorcery spells cost {2} less to cast.
-DeckNeeds:Type$Instant|Sorcery
 AI:RemoveDeck:Random
+DeckNeeds:Type$Instant|Sorcery
 Oracle:Instant and sorcery spells cost {2} less to cast.

--- a/forge-gui/res/cardsfolder/a/arcbound_wanderer.txt
+++ b/forge-gui/res/cardsfolder/a/arcbound_wanderer.txt
@@ -3,7 +3,7 @@ ManaCost:6
 Types:Artifact Creature Golem
 PT:0/0
 K:Modular:Sunburst
+AI:RemoveDeck:Random
 DeckHas:Ability$Counters
 DeckHints:Ability$Proliferate
-AI:RemoveDeck:Random
 Oracle:Modular—Sunburst (This creature enters with a +1/+1 counter on it for each color of mana spent to cast it. When it dies, you may put its +1/+1 counters on target artifact creature.)

--- a/forge-gui/res/cardsfolder/a/archfiend_of_the_dross.txt
+++ b/forge-gui/res/cardsfolder/a/archfiend_of_the_dross.txt
@@ -9,6 +9,6 @@ SVar:TrigRemoveCtr:DB$ RemoveCounter | Defined$ Self | CounterType$ OIL | Counte
 SVar:LoseGame:DB$ LosesGame | Defined$ You | ConditionDefined$ Self | ConditionPresent$ Card.counters_EQ0_OIL
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.OppCtrl | TriggerZones$ Battlefield | Execute$ TrigLoseLife | TriggerDescription$ Whenever a creature an opponent controls dies, its controller loses 2 life.
 SVar:TrigLoseLife:DB$ LoseLife | LifeAmount$ 2 | Defined$ TriggeredCardController
-DeckHas:Ability$Counters
 AI:RemoveDeck:Random
+DeckHas:Ability$Counters
 Oracle:Flying\nArchfiend of the Dross enters with four oil counters on it.\nAt the beginning of your upkeep, remove an oil counter from Archfiend of the Dross. Then if it has no oil counters on it, you lose the game.\nWhenever a creature an opponent controls dies, its controller loses 2 life.

--- a/forge-gui/res/cardsfolder/a/archghoul_of_thraben.txt
+++ b/forge-gui/res/cardsfolder/a/archghoul_of_thraben.txt
@@ -7,6 +7,6 @@ SVar:TrigPeek:DB$ PeekAndReveal | PeekAmount$ 1 | RevealValid$ Zombie | RevealOp
 SVar:DBToHand:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Hand | SubAbility$ DBToGrave
 SVar:DBToGrave:DB$ ChangeZone | Defined$ TopOfLibrary | Origin$ Library | Destination$ Graveyard | Optional$ True | ConditionDefined$ Remembered | ConditionPresent$ Card | ConditionCompare$ EQ0 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-DeckHints:Type$Zombie
 DeckHas:Ability$Graveyard
+DeckHints:Type$Zombie
 Oracle:Whenever Archghoul of Thraben or another Zombie you control dies, look at the top card of your library. If it's a Zombie card, you may reveal it and put it into your hand. If you don't put the card into your hand, you may put it into your graveyard.

--- a/forge-gui/res/cardsfolder/a/archivist_of_oghma.txt
+++ b/forge-gui/res/cardsfolder/a/archivist_of_oghma.txt
@@ -6,6 +6,6 @@ K:Flash
 T:Mode$ SearchedLibrary | ValidPlayer$ Player.Opponent | SearchOwnLibrary$ True | Execute$ TrigGainLife | TriggerZones$ Battlefield | TriggerDescription$ Whenever an opponent searches their library, you gain 1 life and draw a card.
 SVar:TrigGainLife:DB$ GainLife | LifeAmount$ 1 | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw
-DeckHas:Ability$LifeGain
 AI:RemoveDeck:Random
+DeckHas:Ability$LifeGain
 Oracle:Flash\nWhenever an opponent searches their library, you gain 1 life and draw a card.

--- a/forge-gui/res/cardsfolder/a/archon_of_suns_grace.txt
+++ b/forge-gui/res/cardsfolder/a/archon_of_suns_grace.txt
@@ -9,6 +9,6 @@ SVar:PlayMain1:TRUE
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Enchantment.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Constellation — Whenever an enchantment you control enters, create a 2/2 white Pegasus creature token with flying.
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ w_2_2_pegasus_flying | TokenOwner$ You
 DeckHas:Ability$Token
-DeckNeeds:Type$Enchantment
 DeckHints:Type$Pegasus
+DeckNeeds:Type$Enchantment
 Oracle:Flying, lifelink\nPegasus creatures you control have lifelink.\nConstellation — Whenever an enchantment you control enters, create a 2/2 white Pegasus creature token with flying.

--- a/forge-gui/res/cardsfolder/a/archons_glory.txt
+++ b/forge-gui/res/cardsfolder/a/archons_glory.txt
@@ -4,6 +4,6 @@ Types:Instant
 K:Bargain
 A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +2 | NumDef$ +2 | SubAbility$ PumpBargain | SpellDescription$ Target creature gets +2/+2 until end of turn. If this spell was bargained, that creature also gains flying and lifelink until end of turn.
 SVar:PumpBargain:DB$ Pump | Condition$ Bargain | KW$ Flying & Lifelink | Defined$ Targeted
-DeckHints:Type$Artifact|Enchantment & Ability$Token
 DeckHas:Ability$Sacrifice|LifeGain
+DeckHints:Type$Artifact|Enchantment & Ability$Token
 Oracle:Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nTarget creature gets +2/+2 until end of turn. If this spell was bargained, that creature also gains flying and lifelink until end of turn.

--- a/forge-gui/res/cardsfolder/a/argivian_archaeologist.txt
+++ b/forge-gui/res/cardsfolder/a/argivian_archaeologist.txt
@@ -4,7 +4,7 @@ Types:Creature Human Artificer
 PT:1/1
 A:AB$ ChangeZone | Cost$ W W T | TgtPrompt$ Choose target artifact card in your graveyard | ValidTgts$ Artifact.YouCtrl | Origin$ Graveyard | Destination$ Hand | SpellDescription$ Return target artifact card from your graveyard to your hand.
 AI:RemoveDeck:Random
-DeckNeeds:Type$Artifact
 DeckHas:Ability$Graveyard
 DeckHints:Ability$Graveyard|Mill
+DeckNeeds:Type$Artifact
 Oracle:{W}{W}, {T}: Return target artifact card from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/a/armed_and_armored.txt
+++ b/forge-gui/res/cardsfolder/a/armed_and_armored.txt
@@ -3,7 +3,7 @@ ManaCost:1 W
 Types:Instant
 A:SP$ AnimateAll | Types$ Creature,Artifact | ValidCards$ Vehicle.YouCtrl | SubAbility$ ArmDwarf | StackDescription$ Vehicles {p:You} controls become artifact creatures until end of turn. | SpellDescription$ Vehicles you control become artifact creatures until end of turn. Choose a Dwarf you control. Attach any number of Equipment you control to it.
 SVar:ArmDwarf:DB$ Attach | Object$ Valid Equipment.YouCtrl | Defined$ Valid Dwarf.YouCtrl | Optional$ True | StackDescription$ {p:You} chooses a Dwarf they control and attaches any number of Equipment they control to it.
+AI:RemoveDeck:All
 DeckNeeds:Type$Vehicle|Dwarf
 DeckHints:Type$Equipment
-AI:RemoveDeck:All
 Oracle:Vehicles you control become artifact creatures until end of turn. Choose a Dwarf you control. Attach any number of Equipment you control to it.

--- a/forge-gui/res/cardsfolder/a/arteeoh_dread_scavenger.txt
+++ b/forge-gui/res/cardsfolder/a/arteeoh_dread_scavenger.txt
@@ -9,6 +9,6 @@ SVar:TrigExchange:DB$ ExchangeControl | RememberExchanged$ True | ValidTgts$ Art
 SVar:TrigImmediateTrig:DB$ ImmediateTrigger | ConditionDefined$ Remembered | ConditionPresent$ Card | ConditionCompare$ GE2 | SubAbility$ DBCleanup | Execute$ TrigToken | TriggerDescription$ When you do, create a token that's a copy of target artifact you don't control, except it's a 1/1 green Squirrel creature token in addition to its other colors and types.
 SVar:TrigToken:DB$ CopyPermanent | ValidTgts$ Artifact.YouDontCtrl | TgtPrompt$ Select target artifact you don't control | SetPower$ 1 | SetToughness$ 1 | AddColors$ Green | AddTypes$ Creature & Squirrel
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-DeckHas:Ability$Token & Type$Squirrel
 AI:RemoveDeck:Random
+DeckHas:Ability$Token & Type$Squirrel
 Oracle:Flying, deathtouch\nWhenever Arteeoh deals combat damage to a player, you may exchange control of two other target artifacts. When you do, create a token that's a copy of target artifact you don't control, except it's a 1/1 green Squirrel creature token in addition to its other colors and types.

--- a/forge-gui/res/cardsfolder/a/artifact_mutation.txt
+++ b/forge-gui/res/cardsfolder/a/artifact_mutation.txt
@@ -4,6 +4,6 @@ Types:Instant
 A:SP$ Destroy | ValidTgts$ Artifact | TgtPrompt$ Select target artifact | NoRegen$ True | SubAbility$ TrigToken | SpellDescription$ Destroy target artifact. It can't be regenerated.
 SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ g_1_1_saproling | SpellDescription$ Create X 1/1 green Saproling creature tokens, where X is that artifact's mana value.
 SVar:X:Targeted$CardManaCost
-DeckHas:Ability$Token & Type$Saproling
 AI:RemoveDeck:Random
+DeckHas:Ability$Token & Type$Saproling
 Oracle:Destroy target artifact. It can't be regenerated. Create X 1/1 green Saproling creature tokens, where X is that artifact's mana value.

--- a/forge-gui/res/cardsfolder/a/asmoranomardicadaistinaculdacar.txt
+++ b/forge-gui/res/cardsfolder/a/asmoranomardicadaistinaculdacar.txt
@@ -8,7 +8,7 @@ SVar:X:PlayerCountPropertyYou$CardsDiscardedThisTurn
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | OptionalDecider$ You | Execute$ TrigChange | TriggerDescription$ When CARDNAME enters, you may search your library for a card named The Underworld Cookbook, reveal it, put it into your hand, then shuffle.
 SVar:TrigChange:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Card.namedThe Underworld Cookbook | ShuffleNonMandatory$ True
 A:AB$ DealDamage | Cost$ Sac<2/Food> | ValidTgts$ Creature | TgtPrompt$ Select target creature | DamageSource$ Targeted | NumDmg$ 6 | SpellDescription$ Target creature deals 6 damage to itself.
-DeckHints:Type$Discard
 DeckHas:Ability$Sacrifice
+DeckHints:Type$Discard
 DeckNeeds:Name$The Underworld Cookbook
 Oracle:As long as you've discarded a card this turn, you may pay {B/R} to cast this spell.\nWhen Asmoranomardicadaistinaculdacar enters, you may search your library for a card named The Underworld Cookbook, reveal it, put it into your hand, then shuffle.\nSacrifice two Foods: Target creature deals 6 damage to itself.

--- a/forge-gui/res/cardsfolder/a/audacious_reshapers.txt
+++ b/forge-gui/res/cardsfolder/a/audacious_reshapers.txt
@@ -6,7 +6,7 @@ A:AB$ DigUntil | Cost$ T Sac<1/Artifact> | Valid$ Artifact | ValidDescription$ a
 SVar:DBDealDamage:DB$ DealDamage | Defined$ You | NumDmg$ X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Remembered$Amount
+AI:RemoveDeck:Random
 DeckHas:Ability$Sacrifice
 DeckNeeds:Type$Artifact
-AI:RemoveDeck:Random
 Oracle:{T}, Sacrifice an artifact: Reveal cards from the top of your library until you reveal an artifact card. Put that card onto the battlefield and the rest on the bottom of your library in a random order. Audacious Reshapers deals damage to you equal to the number of cards revealed this way.

--- a/forge-gui/res/cardsfolder/a/auntie_blyte_bad_influence.txt
+++ b/forge-gui/res/cardsfolder/a/auntie_blyte_bad_influence.txt
@@ -8,6 +8,6 @@ SVar:TrigCounter:DB$ PutCounter | Defined$ Self | CounterNum$ Y | CounterType$ P
 SVar:Y:TriggerCount$DamageAmount
 A:AB$ DealDamage | Cost$ 1 R T SubCounter<X/P1P1/NICKNAME> | ValidTgts$ Any | NumDmg$ X | SpellDescription$ It deals X damage to any target.
 SVar:X:Count$xPaid
-DeckHas:Ability$Counters
 AI:RemoveDeck:Random
+DeckHas:Ability$Counters
 Oracle:Flying\nWhenever a source you control deals damage to you, put that many +1/+1 counters on Auntie Blyte, Bad Influence.\n{1}{R}, {T}, Remove X +1/+1 counters from Auntie Blyte: It deals X damage to any target.

--- a/forge-gui/res/cardsfolder/b/back_in_town.txt
+++ b/forge-gui/res/cardsfolder/b/back_in_town.txt
@@ -1,6 +1,6 @@
 Name:Back in Town
-Types:Sorcery
 ManaCost:X 2 B
+Types:Sorcery
 A:SP$ ChangeZone | TargetMin$ X | TargetMax$ X | ValidTgts$ Creature.YouOwn+Outlaw | TgtPrompt$ Select X target outlaw creatures in your graveyard | Origin$ Graveyard | Destination$ Battlefield | SpellDescription$ Return X target outlaw creature cards from your graveyard to the battlefield.
 SVar:X:Count$xPaid
 DeckHints:Type$Assassin|Mercenary|Pirate|Rogue|Warlock

--- a/forge-gui/res/cardsfolder/b/baird_argivian_recruiter.txt
+++ b/forge-gui/res/cardsfolder/b/baird_argivian_recruiter.txt
@@ -4,6 +4,6 @@ Types:Legendary Creature Human Soldier
 PT:2/2
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigToken | IsPresent$ Creature.YouCtrl+powerGTbasePower | TriggerDescription$ At the beginning of your end step, if you control a creature with power greater than its base power, create a 1/1 white Soldier creature token.
 SVar:TrigToken:DB$ Token | TokenScript$ w_1_1_soldier
-DeckHas:Ability$Token
 AI:RemoveDeck:Random
+DeckHas:Ability$Token
 Oracle:At the beginning of your end step, if you control a creature with power greater than its base power, create a 1/1 white Soldier creature token.

--- a/forge-gui/res/cardsfolder/b/balloon_stand.txt
+++ b/forge-gui/res/cardsfolder/b/balloon_stand.txt
@@ -1,12 +1,15 @@
 Name:Balloon Stand
 ManaCost:no cost
 Types:Artifact Attraction
-Variant:A:Lights:2 6
-Variant:B:Lights:3 6
-Variant:C:Lights:4 6
-Variant:D:Lights:5 6
 K:Visit:TrigCharm
 SVar:TrigCharm:DB$ Charm | Choices$ DBToken,DBPump
 SVar:DBToken:DB$ Token | TokenAmount$ 1 | TokenScript$ r_1_1_balloon_flying | TokenOwner$ You | SpellDescription$ Create a 1/1 red Balloon creature token with flying.
 SVar:DBPump:DB$ Pump | UnlessCost$ Sac<1/Balloon> | UnlessSwitched$ True | UnlessPayer$ You | ValidTgts$ Creature | KW$ Flying | SpellDescription$ Sacrifice a Balloon. If you do, target creature gains flying until end of turn.
 Oracle:Visit — Choose one.\n• Create a 1/1 red Balloon creature token with flying.\n• Sacrifice a Balloon. If you do, target creature gains flying until end of turn.
+
+# --- VARIANTS ---
+
+Variant:A:Lights:2 6
+Variant:B:Lights:3 6
+Variant:C:Lights:4 6
+Variant:D:Lights:5 6

--- a/forge-gui/res/cardsfolder/b/bazaar_of_baghdad.txt
+++ b/forge-gui/res/cardsfolder/b/bazaar_of_baghdad.txt
@@ -4,7 +4,7 @@ Types:Land
 A:AB$ Draw | Cost$ T | NumCards$ 2 | SpellDescription$ Draw two cards, then discard three cards. | SubAbility$ DBDiscard
 SVar:DBDiscard:DB$ Discard | Defined$ You | NumCards$ 3 | Mode$ TgtChoose
 AI:RemoveDeck:Random
-DeckNeeds:Ability$Graveyard
 DeckHas:Ability$Graveyard|Discard
 DeckHints:Ability$Graveyard|Discard & Type$Zombie|Necron|Phoenix|Skeleton & Keyword$Unearth|Dredge|Flashback
+DeckNeeds:Ability$Graveyard
 Oracle:{T}: Draw two cards, then discard three cards.

--- a/forge-gui/res/cardsfolder/b/beast_within.txt
+++ b/forge-gui/res/cardsfolder/b/beast_within.txt
@@ -3,6 +3,6 @@ ManaCost:2 G
 Types:Instant
 A:SP$ Destroy | ValidTgts$ Permanent | TgtPrompt$ Select target permanent | AITgts$ Card.cmcGE4 | SubAbility$ DBToken | SpellDescription$ Destroy target permanent. Its controller creates a 3/3 green Beast creature token.
 SVar:DBToken:DB$ Token | TokenAmount$ 1 | TokenScript$ g_3_3_beast | TokenOwner$ TargetedController
-DeckHas:Ability$Token
 AI:RemoveDeck:All
+DeckHas:Ability$Token
 Oracle:Destroy target permanent. Its controller creates a 3/3 green Beast creature token.

--- a/forge-gui/res/cardsfolder/b/begin_the_invasion.txt
+++ b/forge-gui/res/cardsfolder/b/begin_the_invasion.txt
@@ -3,6 +3,6 @@ ManaCost:X W U B R G
 Types:Sorcery
 A:SP$ ChangeZone | Origin$ Library | DifferentNames$ True | ChangeTypeDesc$ battle cards with different names | Destination$ Battlefield | ChangeType$ Card.Battle | ChangeNum$ X | SpellDescription$ Search your library for up to X battle cards with different names, put them onto the battlefield, then shuffle.
 SVar:X:Count$xPaid
-DeckNeeds:Type$Battle
 AI:RemoveDeck:Random
+DeckNeeds:Type$Battle
 Oracle:Search your library for up to X battle cards with different names, put them onto the battlefield, then shuffle.

--- a/forge-gui/res/cardsfolder/b/biowaste_blob.txt
+++ b/forge-gui/res/cardsfolder/b/biowaste_blob.txt
@@ -5,7 +5,7 @@ PT:0/0
 S:Mode$ Continuous | Affected$ Ooze.YouCtrl | AddPower$ 1 | AddToughness$ 1 | Description$ Oozes you control get +1/+1.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ TrigCopy | TriggerZones$ Battlefield | IsPresent$ Card.IsCommander+YouCtrl | PresentCompare$ GE1 | TriggerDescription$ At the beginning of your upkeep, if you control a commander, create a token that's a copy of CARDNAME.
 SVar:TrigCopy:DB$ CopyPermanent | Defined$ Self | NumCopies$ 1
+AI:RemoveDeck:NonCommander
 DeckNeeds:Type$Ooze
 DeckHas:Ability$Token
-AI:RemoveDeck:NonCommander
 Oracle:Oozes you control get +1/+1.\nAt the beginning of your upkeep, if you control a commander, create a token that's a copy of Biowaste Blob.

--- a/forge-gui/res/cardsfolder/b/blast_zone.txt
+++ b/forge-gui/res/cardsfolder/b/blast_zone.txt
@@ -7,6 +7,6 @@ A:AB$ PutCounter | Cost$ X X T | CounterType$ CHARGE | CounterNum$ X | SpellDesc
 SVar:X:Count$xPaid
 A:AB$ DestroyAll | Cost$ 3 T Sac<1/CARDNAME> | ValidCards$ Permanent.nonLand+cmcEQY | SpellDescription$ Destroy each nonland permanent with mana value equal to the number of charge counters on CARDNAME.
 SVar:Y:Count$CardCounters.CHARGE
-DeckHas:Ability$Counters
 AI:RemoveDeck:All
+DeckHas:Ability$Counters
 Oracle:Blast Zone enters with a charge counter on it.\n{T}: Add {C}.\n{X}{X}, {T}: Put X charge counters on Blast Zone.\n{3}, {T}, Sacrifice Blast Zone: Destroy each nonland permanent with mana value equal to the number of charge counters on Blast Zone.

--- a/forge-gui/res/cardsfolder/b/blighted_burgeoning.txt
+++ b/forge-gui/res/cardsfolder/b/blighted_burgeoning.txt
@@ -7,6 +7,6 @@ T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.S
 SVar:TrigIncubate:DB$ Incubate | Amount$ 2
 T:Mode$ TapsForMana | ValidCard$ Card.AttachedBy | Execute$ TrigMana | Static$ True | TriggerDescription$ Whenever enchanted land is tapped for mana, its controller adds an additional one mana of any color.
 SVar:TrigMana:DB$ Mana | Produced$ Any | Amount$ 1 | Defined$ TriggeredCardController
-DeckHas:Ability$Counters|Token
 AI:RemoveDeck:All
+DeckHas:Ability$Counters|Token
 Oracle:Enchant land\nWhen Blighted Burgeoning enters, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)\nWhenever enchanted land is tapped for mana, its controller adds an additional one mana of any color.

--- a/forge-gui/res/cardsfolder/b/bloodcurdler.txt
+++ b/forge-gui/res/cardsfolder/b/bloodcurdler.txt
@@ -8,6 +8,6 @@ SVar:TrigMill:DB$ Mill | Defined$ You | NumCards$ 1
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 1 | AddToughness$ 1 | AddTrigger$ EndScream | Condition$ Threshold | Description$ Threshold — As long as seven or more cards are in your graveyard, CARDNAME gets +1/+1 and has "At the beginning of your end step, exile two cards from your graveyard."
 SVar:EndScream:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ BloodExile | Secondary$ True | TriggerDescription$ At the beginning of your end step, exile two cards from your graveyard.
 SVar:BloodExile:DB$ ChangeZone | Hidden$ True | Mandatory$ True | ChangeType$ Card.YouCtrl | ChangeNum$ 2 | DefinedPlayer$ You | Origin$ Graveyard | Destination$ Exile
-DeckHints:Ability$Graveyard
 AI:RemoveDeck:Random
+DeckHints:Ability$Graveyard
 Oracle:Flying\nAt the beginning of your upkeep, mill a card.\nThreshold — As long as seven or more cards are in your graveyard, Bloodcurdler gets +1/+1 and has "At the beginning of your end step, exile two cards from your graveyard."

--- a/forge-gui/res/cardsfolder/b/bloodsoaked_altar.txt
+++ b/forge-gui/res/cardsfolder/b/bloodsoaked_altar.txt
@@ -3,6 +3,6 @@ ManaCost:4 B B
 Types:Artifact
 A:AB$ Token | Cost$ T PayLife<2> Discard<1/Card> Sac<1/Creature> | TokenAmount$ 1 | TokenScript$ b_5_5_demon_flying | TokenOwner$ You | SorcerySpeed$ True | SpellDescription$ Create a 5/5 black Demon creature token with flying. Activate only as a sorcery.
 SVar:AIPreference:DiscardCost$Card | SacCost$Creature.Token,Creature.cmcLE3
-DeckHas:Ability$Token
 AI:RemoveDeck:Random
+DeckHas:Ability$Token
 Oracle:{T}, Pay 2 life, Discard a card, Sacrifice a creature: Create a 5/5 black Demon creature token with flying. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/b/bloodthirsty_adversary.txt
+++ b/forge-gui/res/cardsfolder/b/bloodthirsty_adversary.txt
@@ -10,6 +10,6 @@ SVar:DBExile:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | TargetMin
 SVar:DBCopyCast:DB$ Play | Valid$ Card.IsRemembered | ValidZone$ Exile | Controller$ You | CopyCard$ True | WithoutManaCost$ True | ValidSA$ Spell | Optional$ True | Amount$ All | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Count$TriggerRememberAmount
-DeckHas:Ability$Counters
 AI:RemoveDeck:All
+DeckHas:Ability$Counters
 Oracle:Haste\nWhen Bloodthirsty Adversary enters, you may pay {2}{R} any number of times. When you pay this cost one or more times, put that many +1/+1 counters on Bloodthirsty Adversary, then exile up to that many target instant and/or sorcery cards with mana value 3 or less from your graveyard and copy them. You may cast any number of the copies without paying their mana costs.

--- a/forge-gui/res/cardsfolder/b/bog_naughty.txt
+++ b/forge-gui/res/cardsfolder/b/bog_naughty.txt
@@ -5,6 +5,6 @@ PT:3/3
 K:Flying
 A:AB$ Pump | Cost$ 2 B Sac<1/Food> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ -3 | NumDef$ -3 | IsCurse$ True | SpellDescription$ Target creature gets -3/-3 until end of turn.
 SVar:AIPreference:SacCost$Card.Food
-DeckHints:Ability$Food
 AI:RemoveDeck:All
+DeckHints:Ability$Food
 Oracle:Flying\n{2}{B}, Sacrifice a Food: Target creature gets -3/-3 until end of turn.

--- a/forge-gui/res/cardsfolder/b/bomat_courier.txt
+++ b/forge-gui/res/cardsfolder/b/bomat_courier.txt
@@ -6,6 +6,6 @@ K:Haste
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigExile | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME attacks, exile the top card of your library face down. (You can't look at it.)
 SVar:TrigExile:DB$ Dig | Defined$ You | DigNum$ 1 | ChangeNum$ All | DestinationZone$ Exile | ExileFaceDown$ True | NoReveal$ True
 A:AB$ ChangeZoneAll | Cost$ R Discard<0/Hand> Sac<1/CARDNAME> | ChangeType$ Card.ExiledWithSource | Origin$ Exile | Destination$ Hand | AILogic$ DiscardAllAndRetExiled.minAdv2 | SpellDescription$ Put all cards exiled with CARDNAME into their owners' hands.
-DeckNeeds:Color$Red
 AI:RemoveDeck:Random
+DeckNeeds:Color$Red
 Oracle:Haste\nWhenever Bomat Courier attacks, exile the top card of your library face down. (You can't look at it.)\n{R}, Discard your hand, Sacrifice Bomat Courier: Put all cards exiled with Bomat Courier into their owners' hands.

--- a/forge-gui/res/cardsfolder/b/bonus_round.txt
+++ b/forge-gui/res/cardsfolder/b/bonus_round.txt
@@ -4,7 +4,7 @@ Types:Sorcery
 A:SP$ Effect | Triggers$ TrigSpellCast | SpellDescription$ Until end of turn, whenever a player casts an instant or sorcery spell, that player copies it and may choose new targets for the copy.
 SVar:TrigSpellCast:Mode$ SpellCast | ValidCard$ Instant,Sorcery | TriggerZones$ Command | ValidActivatingPlayer$ Player | Execute$ TrigCopySpell | TriggerDescription$ Until end of turn, whenever a player casts an instant or sorcery spell, that player copies it and may choose new targets for the copy.
 SVar:TrigCopySpell:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | AILogic$ Always | Controller$ TriggeredCardController | MayChooseTarget$ True
-DeckNeeds:Type$Instant|Sorcery
-AI:RemoveDeck:Random
 SVar:PlayMain1:TRUE
+AI:RemoveDeck:Random
+DeckNeeds:Type$Instant|Sorcery
 Oracle:Until end of turn, whenever a player casts an instant or sorcery spell, that player copies it and may choose new targets for the copy.

--- a/forge-gui/res/cardsfolder/b/bosh_iron_golem.txt
+++ b/forge-gui/res/cardsfolder/b/bosh_iron_golem.txt
@@ -5,6 +5,6 @@ PT:6/7
 K:Trample
 A:AB$ DealDamage | Cost$ 3 R Sac<1/Artifact> | ValidTgts$ Any | NumDmg$ X | SpellDescription$ CARDNAME deals damage equal to the sacrificed artifact's mana value to any target.
 SVar:X:Sacrificed$CardManaCost
-DeckNeeds:Color$Red
 AI:RemoveDeck:All
+DeckNeeds:Color$Red
 Oracle:Trample\n{3}{R}, Sacrifice an artifact: Bosh, Iron Golem deals damage equal to the sacrificed artifact's mana value to any target.

--- a/forge-gui/res/cardsfolder/b/bounce_chamber.txt
+++ b/forge-gui/res/cardsfolder/b/bounce_chamber.txt
@@ -1,11 +1,14 @@
 Name:Bounce Chamber
 ManaCost:no cost
 Types:Artifact Attraction
-Variant:A:Lights:2 6
-Variant:B:Lights:3 6
-Variant:C:Lights:4 6
-Variant:D:Lights:5 6
 K:Visit:TrigChoose
 SVar:TrigChoose:DB$ ChooseCard | Choices$ Creature.YouDontCtrl+leastToughnessControlledByOpponent | ChoiceTitle$ Choose a creature with the least toughness among creatures your opponents control | Mandatory$ True | SubAbility$ DBBounce | SpellDescription$ Return a creature you don't control with the lowest toughness among creatures you don't control to its owner's hand.
 SVar:DBBounce:DB$ ChangeZone | Defined$ ChosenCard | Origin$ Battlefield | Destination$ Hand
 Oracle:Visit — Return a creature you don't control with the lowest toughness among creatures you don't control to its owner's hand. (If multiple creatures are tied, choose any one of them.)
+
+# --- VARIANTS ---
+
+Variant:A:Lights:2 6
+Variant:B:Lights:3 6
+Variant:C:Lights:4 6
+Variant:D:Lights:5 6

--- a/forge-gui/res/cardsfolder/b/bounty_board.txt
+++ b/forge-gui/res/cardsfolder/b/bounty_board.txt
@@ -1,6 +1,6 @@
 Name:Bounty Board
-Types:Artifact
 ManaCost:3
+Types:Artifact
 A:AB$ Mana | Cost$ T | Produced$ Any | SpellDescription$ Add one mana of any color.
 A:AB$ PutCounter | Cost$ 1 T | ValidTgts$ Creature | TgtPrompt$ Select target creature | CounterType$ BOUNTY | CounterNum$ 1 | IsCurse$ True | SorcerySpeed$ True | SpellDescription$ Put a bounty counter on target creature.
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.counters_GE1_BOUNTY | TriggerZones$ Battlefield | Execute$ TrigGainLife | TriggerDescription$ Whenever a creature with a bounty counter on it dies, each of its controller's opponents draws a card and gains 2 life.

--- a/forge-gui/res/cardsfolder/b/bounty_of_the_hunt.txt
+++ b/forge-gui/res/cardsfolder/b/bounty_of_the_hunt.txt
@@ -3,6 +3,6 @@ ManaCost:3 G G
 Types:Instant
 A:SP$ PutCounter | ValidTgts$ Creature | TgtPrompt$ Select target creature to distribute counters to | CounterType$ P1P1 | CounterNum$ 3 | TargetMin$ 1 | TargetMax$ 3 | DividedAsYouChoose$ 3 | RemovePhase$ Cleanup | SpellDescription$ Distribute three +1/+1 counters among one, two, or three target creatures. For each +1/+1 counter you put on a creature this way, remove a +1/+1 counter from that creature at the beginning of the next cleanup step.
 S:Mode$ AlternativeCost | ValidSA$ Spell.Self | EffectZone$ All | Cost$ ExileFromHand<1/Card.Green+Other> | Description$ You may exile a green card from your hand rather than pay this spell's mana cost.
-DeckHas:Ability$Counters
 AI:RemoveDeck:All
+DeckHas:Ability$Counters
 Oracle:You may exile a green card from your hand rather than pay this spell's mana cost.\nDistribute three +1/+1 counters among one, two, or three target creatures. For each +1/+1 counter you put on a creature this way, remove a +1/+1 counter from that creature at the beginning of the next cleanup step.

--- a/forge-gui/res/cardsfolder/b/briar_hydra.txt
+++ b/forge-gui/res/cardsfolder/b/briar_hydra.txt
@@ -6,6 +6,6 @@ K:Trample
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ DBCounter | TriggerZones$ Battlefield | TriggerDescription$ Domain — Whenever CARDNAME deals combat damage to a player, put X +1/+1 counters on target creature you control, where X is the number of basic land types among lands you control.
 SVar:DBCounter:DB$ PutCounter | CounterNum$ X | CounterType$ P1P1 | ValidTgts$ Creature.YouCtrl
 SVar:X:Count$Domain
-DeckHas:Ability$Counters
 AI:RemoveDeck:Random
+DeckHas:Ability$Counters
 Oracle:Trample\nDomain — Whenever Briar Hydra deals combat damage to a player, put X +1/+1 counters on target creature you control, where X is the number of basic land types among lands you control.

--- a/forge-gui/res/cardsfolder/b/brighthearth_banneret.txt
+++ b/forge-gui/res/cardsfolder/b/brighthearth_banneret.txt
@@ -4,7 +4,7 @@ Types:Creature Elemental Warrior
 PT:1/1
 S:Mode$ ReduceCost | ValidCard$ Elemental,Warrior | Type$ Spell | Activator$ You | Amount$ 1 | Description$ Elemental spells and Warrior spells you cast cost {1} less to cast.
 K:Reinforce:1:1 R
-DeckHints:Type$Elemental|Warrior
 DeckHas:Ability$Counters
+DeckHints:Type$Elemental|Warrior
 DeckNeeds:Type$Creature
 Oracle:Elemental spells and Warrior spells you cast cost {1} less to cast.\nReinforce 1—{1}{R} ({1}{R}, Discard this card: Put a +1/+1 counter on target creature.)

--- a/forge-gui/res/cardsfolder/b/bubbling_cauldron.txt
+++ b/forge-gui/res/cardsfolder/b/bubbling_cauldron.txt
@@ -5,7 +5,7 @@ A:AB$ GainLife | Cost$ 1 T Sac<1/Creature> | LifeAmount$ 4 | SpellDescription$ Y
 A:AB$ LoseLife | Cost$ 1 T Sac<1/Creature.namedFestering Newt/creature named Festering Newt> | Defined$ Player.Opponent | LifeAmount$ 4 | SubAbility$ DBGainLife | SpellDescription$ Each opponent loses 4 life. You gain life equal to the life lost this way. | StackDescription$ SpellDescription
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ AFLifeLost | StackDescription$ None
 SVar:AFLifeLost:Number$0
+AI:RemoveDeck:Random
 DeckHints:Name$Bogbrew Witch
 DeckNeeds:Name$Festering Newt
-AI:RemoveDeck:Random
 Oracle:{1}, {T}, Sacrifice a creature: You gain 4 life.\n{1}, {T}, Sacrifice a creature named Festering Newt: Each opponent loses 4 life. You gain life equal to the life lost this way.

--- a/forge-gui/res/cardsfolder/b/bumper_cars.txt
+++ b/forge-gui/res/cardsfolder/b/bumper_cars.txt
@@ -1,12 +1,15 @@
 Name:Bumper Cars
 ManaCost:no cost
 Types:Artifact Attraction
+K:Visit:TrigMustBeBlocked
+SVar:TrigMustBeBlocked:DB$ Pump | ValidTgts$ Creature | KW$ HIDDEN CARDNAME must be blocked if able. | AILogic$ Pump | SpellDescription$ Visit — Target creature must be blocked this turn if able.
+Oracle:Visit — Target creature must be blocked this turn if able.
+
+# --- VARIANTS ---
+
 Variant:A:Lights:2 3 6
 Variant:B:Lights:2 4 6
 Variant:C:Lights:2 5 6
 Variant:D:Lights:3 4 6
 Variant:E:Lights:3 5 6
 Variant:F:Lights:4 5 6
-K:Visit:TrigMustBeBlocked
-SVar:TrigMustBeBlocked:DB$ Pump | ValidTgts$ Creature | KW$ HIDDEN CARDNAME must be blocked if able. | AILogic$ Pump | SpellDescription$ Visit — Target creature must be blocked this turn if able.
-Oracle:Visit — Target creature must be blocked this turn if able.

--- a/forge-gui/res/cardsfolder/c/cactus_preserve.txt
+++ b/forge-gui/res/cardsfolder/c/cactus_preserve.txt
@@ -1,6 +1,6 @@
 Name:Cactus Preserve
-Types:Land Desert
 ManaCost:no cost
+Types:Land Desert
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 A:AB$ ManaReflected | Cost$ T | ColorOrType$ Type | Valid$ Land.YouCtrl | ReflectProperty$ Produce | SpellDescription$ Add one mana of any type that a land you control could produce.

--- a/forge-gui/res/cardsfolder/c/call_the_coppercoats.txt
+++ b/forge-gui/res/cardsfolder/c/call_the_coppercoats.txt
@@ -5,6 +5,6 @@ K:Strive:1 W
 A:SP$ Token | TokenAmount$ X | TokenScript$ w_1_1_human_soldier | TokenOwner$ You | ValidTgts$ Opponent | TargetMin$ 0 | TargetMax$ MaxTargets | TgtPrompt$ Choose any number of target opponents | SpellDescription$ Choose any number of target opponents. Create X 1/1 white Human Soldier creature tokens, where X is the number of creatures those opponents control.
 SVar:MaxTargets:PlayerCountOpponents$Amount
 SVar:X:Count$Valid Creature.TargetedPlayerCtrl
-DeckHas:Ability$Token
 AI:RemoveDeck:All
+DeckHas:Ability$Token
 Oracle:Strive — This spell costs {1}{W} more to cast for each target beyond the first.\nChoose any number of target opponents. Create X 1/1 white Human Soldier creature tokens, where X is the number of creatures those opponents control.

--- a/forge-gui/res/cardsfolder/c/cankerbloom.txt
+++ b/forge-gui/res/cardsfolder/c/cankerbloom.txt
@@ -6,7 +6,7 @@ A:AB$ Charm | Cost$ 1 Sac<1/CARDNAME> | Choices$ Artifact,Enchantment,Proliferat
 SVar:Artifact:DB$ Destroy | ValidTgts$ Artifact | SpellDescription$ Destroy target artifact.
 SVar:Enchantment:DB$ Destroy | ValidTgts$ Enchantment | SpellDescription$ Destroy target enchantment.
 SVar:Proliferate:DB$ Proliferate | SpellDescription$ Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)
+AI:RemoveDeck:Random
 DeckHas:Ability$Sacrifice|Proliferate
 DeckHints:Ability$Counters
-AI:RemoveDeck:Random
 Oracle:{1}, Sacrifice Cankerbloom: Choose one —\n• Destroy target artifact.\n• Destroy target enchantment.\n• Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)

--- a/forge-gui/res/cardsfolder/c/case_of_the_pilfered_proof.txt
+++ b/forge-gui/res/cardsfolder/c/case_of_the_pilfered_proof.txt
@@ -8,7 +8,7 @@ T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefiel
 SVar:Solved:DB$ AlterAttribute | Defined$ Self | Attributes$ Solved
 R:Event$ CreateToken | IsPresent$ Card.Self+IsSolved | ActiveZones$ Battlefield | ValidToken$ Card.YouCtrl | ReplaceWith$ DBReplace | Description$ Solved – If one or more tokens would be created under your control, those tokens plus a Clue token are created instead. (It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
 SVar:DBReplace:DB$ ReplaceToken | Type$ AddToken | Amount$ 1 | ValidCard$ Card.YouCtrl | TokenScript$ c_a_clue_draw
-DeckNeeds:Type$Detective
 DeckHas:Ability$Counters|Token|Sacrifice & Type$Artifact|Clue
 DeckHints:Ability$Token
+DeckNeeds:Type$Detective
 Oracle:Whenever a Detective you control enters and whenever a Detective you control is turned face up, put a +1/+1 counter on it.\nTo solve – You control three or more Detectives. (If unsolved, solve at the beginning of your end step.)\nSolved – If one or more tokens would be created under your control, those tokens plus a Clue token are created instead. (It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")

--- a/forge-gui/res/cardsfolder/c/cave_of_temptation.txt
+++ b/forge-gui/res/cardsfolder/c/cave_of_temptation.txt
@@ -4,6 +4,6 @@ Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ 1 T | Produced$ Any | SpellDescription$ Add one mana of any color.
 A:AB$ PutCounter | Cost$ 4 T Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | CounterType$ P1P1 | CounterNum$ 2 | SorcerySpeed$ True | SpellDescription$ Put two +1/+1 counters on target creature. Activate only as a sorcery.
-DeckHas:Ability$Counters
 AI:RemoveDeck:All
+DeckHas:Ability$Counters
 Oracle:{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{4}, {T}, Sacrifice Cave of Temptation: Put two +1/+1 counters on target creature. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/c/celestial_kirin.txt
+++ b/forge-gui/res/cardsfolder/c/celestial_kirin.txt
@@ -7,6 +7,6 @@ T:Mode$ SpellCast | ValidCard$ Spirit,Arcane | ValidActivatingPlayer$ You | Trig
 SVar:TrigDestroyAll:DB$ DestroyAll | ValidCards$ Permanent.cmcEQX
 SVar:X:TriggeredStackInstance$CardManaCostLKI
 AI:RemoveDeck:All
-DeckHints:Type$Spirit|Arcane
 AI:RemoveDeck:Random
+DeckHints:Type$Spirit|Arcane
 Oracle:Flying\nWhenever you cast a Spirit or Arcane spell, destroy all permanents with that spell's mana value.

--- a/forge-gui/res/cardsfolder/c/clan_crafter.txt
+++ b/forge-gui/res/cardsfolder/c/clan_crafter.txt
@@ -5,7 +5,7 @@ S:Mode$ Continuous | Affected$ Creature.IsCommander+YouOwn | AddAbility$ SacArt 
 SVar:SacArt:AB$ PutCounter | Cost$ 2 Sac<1/Artifact> | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBDraw | SpellDescription$ Put a +1/+1 counter on this creature and draw a card.
 SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1
 SVar:BuffedBy:Artifact
+AI:RemoveDeck:NonCommander
 DeckHints:Type$Artifact
 DeckHas:Ability$Sacrifice|Counters
-AI:RemoveDeck:NonCommander
 Oracle:Commander creatures you own have "{2}, Sacrifice an artifact: Put a +1/+1 counter on this creature and draw a card."

--- a/forge-gui/res/cardsfolder/c/cloakwood_hermit.txt
+++ b/forge-gui/res/cardsfolder/c/cloakwood_hermit.txt
@@ -5,7 +5,7 @@ S:Mode$ Continuous | Affected$ Creature.IsCommander+YouOwn | AddTrigger$ EndStep
 SVar:EndStep:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | CheckSVar$ X | Execute$ TrigToken | TriggerDescription$ At the beginning of your end step, if a creature card was put into your graveyard from anywhere this turn, create two tapped 1/1 green Squirrel creature tokens.
 SVar:TrigToken:DB$ Token | TokenAmount$ 2 | TokenScript$ g_1_1_squirrel | TokenTapped$ True
 SVar:X:Count$ThisTurnEntered_Graveyard_Creature.YouOwn+nonToken
+AI:RemoveDeck:NonCommander
 DeckHas:Ability$Token & Type$Squirrel
 DeckHints:Ability$Discard|Sacrifice
-AI:RemoveDeck:NonCommander
 Oracle:Commander creatures you own have "At the beginning of your end step, if a creature card was put into your graveyard from anywhere this turn, create two tapped 1/1 green Squirrel creature tokens."

--- a/forge-gui/res/cardsfolder/c/clown_extruder.txt
+++ b/forge-gui/res/cardsfolder/c/clown_extruder.txt
@@ -1,10 +1,13 @@
 Name:Clown Extruder
 ManaCost:no cost
 Types:Artifact Attraction
+K:Visit:TrigToken
+SVar:TrigToken:DB$ Token | TokenScript$ w_1_1_a_clown_robot | TokenOwner$ You | SpellDescription$ Create a 1/1 white Clown Robot artifact creature token.
+Oracle:Visit — Create a 1/1 white Clown Robot artifact creature token.
+
+# --- VARIANTS ---
+
 Variant:A:Lights:2 6
 Variant:B:Lights:3 6
 Variant:C:Lights:4 6
 Variant:D:Lights:5 6
-K:Visit:TrigToken
-SVar:TrigToken:DB$ Token | TokenScript$ w_1_1_a_clown_robot | TokenOwner$ You | SpellDescription$ Create a 1/1 white Clown Robot artifact creature token.
-Oracle:Visit — Create a 1/1 white Clown Robot artifact creature token.

--- a/forge-gui/res/cardsfolder/c/codsworth_handy_helper.txt
+++ b/forge-gui/res/cardsfolder/c/codsworth_handy_helper.txt
@@ -6,6 +6,6 @@ S:Mode$ Continuous | Affected$ Card.IsCommander+YouCtrl | AddKeyword$ Ward:2 | D
 A:AB$ Mana | Cost$ T | Produced$ W | RestrictValid$ Spell.Aura,Spell.Equipment | Amount$ 2 | SpellDescription$ Add {W}{W}. Spend this mana only to cast Aura and/or Equipment spells.
 A:AB$ Pump | Cost$ T | ValidTgts$ Aura.YouCtrl,Equipment.YouCtrl | TgtPrompt$ Select target Aura or Equipment you control | SubAbility$ DBAttach | SorcerySpeed$ True | SpellDescription$ Attach target Aura or Equipment you control to target creature you control. Activate only as a sorcery.
 SVar:DBAttach:DB$ Attach | Object$ ParentTarget | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control.
-DeckNeeds:Type$Aura|Equipment
 AI:RemoveDeck:NonCommander
+DeckNeeds:Type$Aura|Equipment
 Oracle:Commanders you control have ward {2}.\n{T}: Add {W}{W}. Spend this mana only to cast Aura and/or Equipment spells.\n{T}: Attach target Aura or Equipment you control to target creature you control. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/c/concession_stand.txt
+++ b/forge-gui/res/cardsfolder/c/concession_stand.txt
@@ -1,10 +1,13 @@
 Name:Concession Stand
 ManaCost:no cost
 Types:Artifact Attraction
+K:Visit:TrigFood
+SVar:TrigFood:DB$ Token | TokenScript$ c_a_food_sac | TokenOwner$ You | SpellDescription$ Create a Food token.
+Oracle:Visit — Create a Food token. (It's an artifact with "{2}, {T}, Sacrifice this artifact: You gain 3 life.")
+
+# --- VARIANTS ---
+
 Variant:A:Lights:2 6
 Variant:B:Lights:3 6
 Variant:C:Lights:4 6
 Variant:D:Lights:5 6
-K:Visit:TrigFood
-SVar:TrigFood:DB$ Token | TokenScript$ c_a_food_sac | TokenOwner$ You | SpellDescription$ Create a Food token.
-Oracle:Visit — Create a Food token. (It's an artifact with "{2}, {T}, Sacrifice this artifact: You gain 3 life.")

--- a/forge-gui/res/cardsfolder/c/contraband_livestock.txt
+++ b/forge-gui/res/cardsfolder/c/contraband_livestock.txt
@@ -6,6 +6,6 @@ SVar:DBRollDice:DB$ RollDice | Sides$ 20 | ResultSubAbilities$ 1-9:GreenOx,10-19
 SVar:GreenOx:DB$ Token | TokenAmount$ 1 | TokenScript$ g_4_4_ox | TokenOwner$ TargetedController | SpellDescription$ 1-9 VERT Its controller creates a 4/4 green Ox creature token.
 SVar:GreenBoar:DB$ Token | TokenAmount$ 1 | TokenScript$ g_2_2_boar | TokenOwner$ TargetedController | SpellDescription$ 10-19 VERT Its controller creates a 2/2 green Boar creature token.
 SVar:WhiteGoat:DB$ Token | TokenAmount$ 1 | TokenScript$ w_0_1_goat | TokenOwner$ TargetedController | SpellDescription$ 20 VERT Its controller creates a 0/1 white Goat creature token.
-DeckHas:Ability$Token
 AI:RemoveDeck:All
+DeckHas:Ability$Token
 Oracle:Exile target creature, then roll a d20.\n1-9 | Its controller creates a 4/4 green Ox creature token.\n10-19 | Its controller creates a 2/2 green Boar creature token.\n20 | Its controller creates a 0/1 white Goat creature token.

--- a/forge-gui/res/cardsfolder/c/cornered_crook.txt
+++ b/forge-gui/res/cardsfolder/c/cornered_crook.txt
@@ -5,7 +5,7 @@ PT:5/4
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | OptionalDecider$ You | Execute$ TrigImmediateTrig | TriggerDescription$ When CARDNAME enters, you may sacrifice an artifact. When you do, CARDNAME deals 3 damage to any target.
 SVar:TrigImmediateTrig:AB$ ImmediateTrigger | Cost$ Sac<1/Artifact> | Execute$ TrigDamage | SpellDescription$ When you do, CARDNAME deals 3 damage to any target.
 SVar:TrigDamage:DB$ DealDamage | NumDmg$ 3 | ValidTgts$ Any
+AI:RemoveDeck:Random
 DeckNeeds:Type$Artifact
 DeckHas:Ability$Sacrifice
-AI:RemoveDeck:Random
 Oracle:When Cornered Crook enters, you may sacrifice an artifact. When you do, Cornered Crook deals 3 damage to any target.

--- a/forge-gui/res/cardsfolder/c/criminal_past.txt
+++ b/forge-gui/res/cardsfolder/c/criminal_past.txt
@@ -4,7 +4,7 @@ Types:Legendary Enchantment Background
 S:Mode$ Continuous | Affected$ Creature.IsCommander+YouOwn | AddKeyword$ Menace | AddStaticAbility$ PowerGrave | Description$ Commander creatures you own have menace and "This creature gets +X/+0, where X is the number of creature cards in your graveyard." (A creature with menace can't be blocked except by two or more creatures.)
 SVar:PowerGrave:Mode$ Continuous | Affected$ Card.Self | AddPower$ X | This creature gets +X/+0, where X is the number of creature cards in your graveyard.
 SVar:X:Count$TypeInYourYard.Creature
+AI:RemoveDeck:NonCommander
 DeckHints:Ability$Discard|Mill|Sacrifice
 DeckHas:Ability$Graveyard
-AI:RemoveDeck:NonCommander
 Oracle:Commander creatures you own have menace and "This creature gets +X/+0, where X is the number of creature cards in your graveyard." (A creature with menace can't be blocked except by two or more creatures.)

--- a/forge-gui/res/cardsfolder/c/cryptbreaker.txt
+++ b/forge-gui/res/cardsfolder/c/cryptbreaker.txt
@@ -6,7 +6,7 @@ A:AB$ Token | Cost$ 1 B T Discard<1/Card> | TokenAmount$ 1 | TokenScript$ b_2_2_
 A:AB$ Draw | Cost$ tapXType<3/Zombie> | NumCards$ 1 | AILogic$ AtOppEOT | SpellDescription$ You draw a card and you lose 1 life. | SubAbility$ DBLoseLife
 SVar:DBLoseLife:DB$ LoseLife | LifeAmount$ 1
 SVar:AIPreference:DiscardCost$Card
+AI:RemoveDeck:Random
 DeckNeeds:Type$Zombie
 DeckHas:Ability$Token
-AI:RemoveDeck:Random
 Oracle:{1}{B}, {T}, Discard a card: Create a 2/2 black Zombie creature token.\nTap three untapped Zombies you control: You draw a card and you lose 1 life.

--- a/forge-gui/res/cardsfolder/c/cultist_of_the_absolute.txt
+++ b/forge-gui/res/cardsfolder/c/cultist_of_the_absolute.txt
@@ -5,6 +5,6 @@ S:Mode$ Continuous | Affected$ Creature.IsCommander+YouOwn | AddPower$ 3 | AddTo
 SVar:UpkeepSac:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigSac | TriggerDescription$ At the beginning of your upkeep, sacrifice a creature.
 SVar:TrigSac:DB$ Sacrifice | Defined$ You | SacValid$ Creature
 SVar:PlayMain1:TRUE
-DeckHas:Ability$Sacrifice
 AI:RemoveDeck:NonCommander
+DeckHas:Ability$Sacrifice
 Oracle:Commander creatures you own get +3/+3 and have flying, deathtouch, "Ward—Pay 3 life," and "At the beginning of your upkeep, sacrifice a creature."

--- a/forge-gui/res/cardsfolder/c/curse_artifact.txt
+++ b/forge-gui/res/cardsfolder/c/curse_artifact.txt
@@ -7,6 +7,6 @@ T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player.EnchantedController | Execut
 SVar:TrigCurseArtifactSacrifice:DB$ Sacrifice | Defined$ TriggeredPlayer | SacValid$ Artifact.EnchantedBy | Optional$ True | RememberSacrificed$ True | SubAbility$ DBCurseArtifactDamage
 SVar:DBCurseArtifactDamage:DB$ DealDamage | Defined$ TriggeredPlayer | NumDmg$ 2 | ConditionDefined$ Remembered | ConditionPresent$ Card | ConditionCompare$ EQ0 | SubAbility$ DBCurseArtifactCleanup
 SVar:DBCurseArtifactCleanup:DB$ Cleanup | ClearRemembered$ True
-DeckHas:Ability$Sacrifice
 AI:RemoveDeck:Random
+DeckHas:Ability$Sacrifice
 Oracle:Enchant artifact\nAt the beginning of the upkeep of enchanted artifact's controller, Curse Artifact deals 2 damage to that player unless they sacrifice that artifact.

--- a/forge-gui/res/cardsfolder/d/dark_temper.txt
+++ b/forge-gui/res/cardsfolder/d/dark_temper.txt
@@ -3,6 +3,6 @@ ManaCost:2 R
 Types:Instant
 A:SP$ DealDamage | ValidTgts$ Creature | NumDmg$ 2 | SubAbility$ DBDestroy | ConditionPresent$ Permanent.Black+YouCtrl | ConditionCompare$ EQ0 | SpellDescription$ CARDNAME deals 2 damage to target creature. If you control a black permanent, destroy the creature instead.
 SVar:DBDestroy:DB$ Destroy | Defined$ Targeted | ConditionPresent$ Permanent.Black+YouCtrl | ConditionCompare$ GE1 | ConditionDescription$ If you control a black permanent,
-DeckHints:Color$Black
 AI:RemoveDeck:Random
+DeckHints:Color$Black
 Oracle:Dark Temper deals 2 damage to target creature. If you control a black permanent, destroy the creature instead.

--- a/forge-gui/res/cardsfolder/d/deal_broker.txt
+++ b/forge-gui/res/cardsfolder/d/deal_broker.txt
@@ -1,7 +1,7 @@
 Name:Deal Broker
 ManaCost:3
-PT:2/3
 Types:Artifact Creature Construct
+PT:2/3
 Draft:Draft CARDNAME face up.
 Draft:Immediately after the draft, you may reveal a card in your card pool. Each other player may offer you one card in their card pool in exchange. You may accept any one offer.
 A:AB$ Draw | Cost$ T | Defined$ You | NumCards$ 1 | SubAbility$ Discard | SpellDescription$ Draw a card, then discard a card.

--- a/forge-gui/res/cardsfolder/d/deeproot_pilgrimage.txt
+++ b/forge-gui/res/cardsfolder/d/deeproot_pilgrimage.txt
@@ -3,7 +3,7 @@ ManaCost:1 U
 Types:Enchantment
 T:Mode$ TapAll | ValidCards$ Merfolk.nonToken+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever one or more nontoken Merfolk you control become tapped, create a 1/1 blue Merfolk creature token with hexproof.
 SVar:TrigToken:DB$ Token | TokenScript$ u_1_1_merfolk_hexproof
-DeckHas:Ability$Token & Type$Merfolk
 AI:RemoveDeck:Random
+DeckHas:Ability$Token & Type$Merfolk
 DeckNeeds:Type$Merfolk
 Oracle:Whenever one or more nontoken Merfolk you control become tapped, create a 1/1 blue Merfolk creature token with hexproof.

--- a/forge-gui/res/cardsfolder/d/deeproot_waters.txt
+++ b/forge-gui/res/cardsfolder/d/deeproot_waters.txt
@@ -3,7 +3,7 @@ ManaCost:2 U
 Types:Enchantment
 T:Mode$ SpellCast | ValidCard$ Merfolk | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever you cast a Merfolk spell, create a 1/1 blue Merfolk creature token with hexproof. (A creature with hexproof can't be the target of spells or abilities your opponents control.)
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ u_1_1_merfolk_hexproof | TokenOwner$ You
-DeckHas:Ability$Token
 AI:RemoveDeck:Random
+DeckHas:Ability$Token
 DeckNeeds:Type$Merfolk
 Oracle:Whenever you cast a Merfolk spell, create a 1/1 blue Merfolk creature token with hexproof. (A creature with hexproof can't be the target of spells or abilities your opponents control.)

--- a/forge-gui/res/cardsfolder/d/dire_flail_dire_blunderbuss.txt
+++ b/forge-gui/res/cardsfolder/d/dire_flail_dire_blunderbuss.txt
@@ -12,6 +12,7 @@ Oracle:Equipped creature gets +2/+0.\nEquip {1}\nCraft with artifact {3}{R}{R} (
 ALTERNATE
 
 Name:Dire Blunderbuss
+ManaCost:no cost
 Colors:red
 Types:Artifact Equipment
 S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 3 | AddTrigger$ AttacksTrig | Description$ Equipped creature gets +3/+0 and has "Whenever this creature attacks, you may sacrifice an artifact other than CARDNAME. When you do, this creature deals damage equal to its power to target creature."

--- a/forge-gui/res/cardsfolder/d/disa_the_restless.txt
+++ b/forge-gui/res/cardsfolder/d/disa_the_restless.txt
@@ -6,7 +6,7 @@ T:Mode$ ChangesZone | ValidCard$ Permanent.Lhurgoyf+YouOwn | Origin$ Library,Han
 SVar:TrigChangeZone:DB$ ChangeZone | Defined$ TriggeredCard | Origin$ Graveyard | Destination$ Battlefield
 T:Mode$ DamageDoneOnce | ValidSource$ Creature.YouCtrl | TriggerZones$ Battlefield | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigToken | TriggerDescription$ Whenever one or more creatures you control deal combat damage to a player, create a Tarmogoyf token. (It's a {1}{G} Lhurgoyf creature with "Tarmogoyf's power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1.")
 SVar:TrigToken:DB$ CopyPermanent | DefinedName$ Tarmogoyf
-DeckNeeds:Type$Lhurgoyf
 DeckHas:Ability$Token & Type$Lhurgoyf
 DeckHints:Ability$Mill
+DeckNeeds:Type$Lhurgoyf
 Oracle:Whenever a Lhurgoyf permanent card is put into your graveyard from anywhere other than the battlefield, put it onto the battlefield.\nWhenever one or more creatures you control deal combat damage to a player, create a Tarmogoyf token. (It's a {1}{G} Lhurgoyf creature with "Tarmogoyf's power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1.")

--- a/forge-gui/res/cardsfolder/d/disciple_of_bolas.txt
+++ b/forge-gui/res/cardsfolder/d/disciple_of_bolas.txt
@@ -9,6 +9,6 @@ SVar:DBDraw:DB$ Draw | NumCards$ X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:RememberedLKI$CardPower
 SVar:NeedsToPlay:Creature.YouCtrl
-DeckHas:Ability$LifeGain
 AI:RemoveDeck:All
+DeckHas:Ability$LifeGain
 Oracle:When Disciple of Bolas enters, sacrifice another creature. You gain X life and draw X cards, where X is that creature's power.

--- a/forge-gui/res/cardsfolder/d/doomsday_confluence.txt
+++ b/forge-gui/res/cardsfolder/d/doomsday_confluence.txt
@@ -6,6 +6,6 @@ SVar:DBSac:DB$ Sacrifice | Defined$ Player | SacValid$ Creature.nonArtifact | Sp
 SVar:DBToken:DB$ Token | TokenScript$ b_3_3_a_dalek_menace | SpellDescription$ Create a 3/3 black Dalek artifact creature token with menace.
 SVar:DBDiscard:DB$ Discard | Defined$ Opponent | Mode$ TgtChoose | SpellDescription$ Each opponent discards a card.
 SVar:X:Count$xPaid
-DeckHas:Ability$Sacrifice|Token|Discard & Type$Artifact|Dalek
 AI:RemoveDeck:All
+DeckHas:Ability$Sacrifice|Token|Discard & Type$Artifact|Dalek
 Oracle:Choose X. You may choose the same mode more than once.\n• Each player sacrifices a nonartifact creature.\n• Create a 3/3 black Dalek artifact creature token with menace.\n• Each opponent discards a card.

--- a/forge-gui/res/cardsfolder/d/dragon_cultist.txt
+++ b/forge-gui/res/cardsfolder/d/dragon_cultist.txt
@@ -4,6 +4,6 @@ Types:Legendary Enchantment Background
 S:Mode$ Continuous | Affected$ Creature.IsCommander+YouOwn | AddTrigger$ TrigDragon | Description$ Commander creatures you own have "At the beginning of your end step, if a source you controlled dealt 5 or more damage this turn, create a 4/4 red Dragon creature token with flying."
 SVar:TrigDragon:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | CheckDefinedPlayer$ You.damageDoneSingleSource GE5 | Execute$ DBDragon | TriggerDescription$ At the beginning of your end step, if a source you controlled dealt 5 or more damage this turn, create a 4/4 red Dragon creature token with flying.
 SVar:DBDragon:DB$ Token | TokenScript$ r_4_4_dragon_flying
-DeckHas:Ability$Token & Type$Dragon
 AI:RemoveDeck:NonCommander
+DeckHas:Ability$Token & Type$Dragon
 Oracle:Commander creatures you own have "At the beginning of your end step, if a source you controlled dealt 5 or more damage this turn, create a 4/4 red Dragon creature token with flying."

--- a/forge-gui/res/cardsfolder/d/dredging_claw.txt
+++ b/forge-gui/res/cardsfolder/d/dredging_claw.txt
@@ -7,6 +7,6 @@ SVar:TrigAttach:DB$ Attach | Defined$ TriggeredCard
 K:Equip:1 B
 AI:RemoveDeck:Random
 DeckHas:Keyword$Menace
-DeckNeeds:Color$Black
 DeckHints:Ability$Graveyard
+DeckNeeds:Color$Black
 Oracle:Equipped creature gets +1/+0 and has menace. (It's can't be blocked except by two or more creatures.)\nWhenever a creature enters from your graveyard, you may attach Dredging Claw to it.\nEquip {1}{B} ({1}{B}: Attach to target creature you control. Equip only as a sorcery.)

--- a/forge-gui/res/cardsfolder/d/drop_of_honey.txt
+++ b/forge-gui/res/cardsfolder/d/drop_of_honey.txt
@@ -7,6 +7,6 @@ SVar:DBDestroy:DB$ Destroy | Defined$ ChosenCard | NoRegen$ True
 T:Mode$ Always | TriggerZones$ Battlefield | IsPresent$ Creature | PresentCompare$ EQ0 | Execute$ TrigSac | TriggerDescription$ When there are no creatures on the battlefield, sacrifice CARDNAME.
 SVar:TrigSac:DB$ Sacrifice
 SVar:NeedsToPlay:Creature.YouDontCtrl+leastPower
-DeckHas:Ability$Sacrifice
 AI:RemoveDeck:All
+DeckHas:Ability$Sacrifice
 Oracle:At the beginning of your upkeep, destroy the creature with the least power. It can't be regenerated. If two or more creatures are tied for least power, you choose one of them.\nWhen there are no creatures on the battlefield, sacrifice Drop of Honey.

--- a/forge-gui/res/cardsfolder/d/drop_tower.txt
+++ b/forge-gui/res/cardsfolder/d/drop_tower.txt
@@ -1,15 +1,18 @@
 Name:Drop Tower
 ManaCost:no cost
 Types:Artifact Attraction
+K:Visit:TrigPump
+SVar:TrigPump:DB$ Effect | StaticAbilities$ Pump | ValidTgts$ Creature | Triggers$ ExileSelf | RememberObjects$ Targeted | SpellDescription$ Target creature gains flying until end of turn, or until any player rolls a 1, whichever comes first.
+SVar:Pump:Mode$ Continuous | Affected$ Card.IsRemembered | AddKeyword$ Flying | Description$ This creature gains flying until end of turn, or until any player rolls a 1.
+SVar:ExileSelf:Mode$ RolledDie | Execute$ TrigRemove | ValidResult$ EQ1 | Static$ True
+SVar:TrigRemove:DB$ ChangeZone | Origin$ Command | Defined$ Self | Destination$ Exiled
+Oracle:Visit — Target creature gains flying until end of turn, or until any player rolls a 1, whichever comes first.
+
+# --- VARIANTS ---
+
 Variant:A:Lights:2 3 6
 Variant:B:Lights:2 4 6
 Variant:C:Lights:2 5 6
 Variant:D:Lights:3 4 6
 Variant:E:Lights:3 5 6
 Variant:F:Lights:4 5 6
-K:Visit:TrigPump
-SVar:TrigPump:DB$ Effect | StaticAbilities$ Pump | ValidTgts$ Creature | Triggers$ ExileSelf | RememberObjects$ Targeted | SpellDescription$ Target creature gains flying until end of turn, or until any player rolls a 1, whichever comes first.
-SVar:Pump:Mode$ Continuous | Affected$ Card.IsRemembered | AddKeyword$ Flying | Description$ This creature gains flying until end of turn, or until any player rolls a 1.
-SVar:ExileSelf:Mode$ RolledDie | Execute$ TrigRemove | ValidResult$ EQ1 | Static$ True
-SVar:TrigRemove:DB$ ChangeZone | Origin$ Command | Defined$ Self | Destination$ Exile
-Oracle:Visit — Target creature gains flying until end of turn, or until any player rolls a 1, whichever comes first.

--- a/forge-gui/res/cardsfolder/d/drown_in_filth.txt
+++ b/forge-gui/res/cardsfolder/d/drown_in_filth.txt
@@ -4,6 +4,6 @@ Types:Sorcery
 A:SP$ Mill | NumCards$ 4 | Defined$ You | SubAbility$ DBPump | SpellDescription$ Choose target creature. Mill four cards, then that creature gets -1/-1 until end of turn for each land card in your graveyard.
 SVar:DBPump:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ -X | NumDef$ -X | IsCurse$ True
 SVar:X:Count$ValidGraveyard Land.YouOwn
-DeckHas:Ability$Graveyard
 AI:RemoveDeck:All
+DeckHas:Ability$Graveyard
 Oracle:Choose target creature. Mill four cards, then that creature gets -1/-1 until end of turn for each land card in your graveyard.


### PR DESCRIPTION
Reordering lines to have the scripts more consistently structured so future search and replace passes are more effective, Also, having similar items close by should avoid unnecessary redundancy (I found a few instances of multiple `Deck*:` tag lines that should have been condensed into one). 

**NB:** Most if not all of the seeming edit lapses will be resolved on the second pass.

**Pull requests in this series**
- https://github.com/Card-Forge/forge/pull/6295
- https://github.com/Card-Forge/forge/pull/6296
- https://github.com/Card-Forge/forge/pull/6297
- https://github.com/Card-Forge/forge/pull/6298
- https://github.com/Card-Forge/forge/pull/6299
- https://github.com/Card-Forge/forge/pull/6300
- https://github.com/Card-Forge/forge/pull/6301
- https://github.com/Card-Forge/forge/pull/6302
- https://github.com/Card-Forge/forge/pull/6303