### PR TITLE
Edit pile cleanup: Line reordering, second pass: part 1, folders 'a' to 'b'

### DIFF
--- a/forge-gui/res/cardsfolder/a/adherent_of_hope.txt
+++ b/forge-gui/res/cardsfolder/a/adherent_of_hope.txt
@@ -4,6 +4,6 @@ Types:Creature Human Soldier
 PT:2/1
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | IsPresent$ Planeswalker.Basri+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ At the beginning of combat on your turn, if you control a Basri planeswalker, put a +1/+1 counter on CARDNAME.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
-DeckNeeds:Type$Basri
 DeckHas:Ability$Counters
+DeckNeeds:Type$Basri
 Oracle:At the beginning of combat on your turn, if you control a Basri planeswalker, put a +1/+1 counter on Adherent of Hope.

--- a/forge-gui/res/cardsfolder/a/akal_pakal_first_among_equals.txt
+++ b/forge-gui/res/cardsfolder/a/akal_pakal_first_among_equals.txt
@@ -5,6 +5,6 @@ PT:1/5
 T:Mode$ Phase | Phase$ End of Turn | TriggerZones$ Battlefield | CheckSVar$ X | SVarCompare$ GE1 | Execute$ TrigDig | TriggerDescription$ At the beginning of each player's end step, if an artifact entered the battlefield under your control this turn, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.
 SVar:TrigDig:DB$ Dig | DigNum$ 2 | ChangeNum$ 1 | DestinationZone2$ Graveyard | NoReveal$ True
 SVar:X:Count$ThisTurnEntered_Battlefield_Artifact.YouCtrl
-DeckNeeds:Type$Artifact
 DeckHas:Ability$Graveyard
+DeckNeeds:Type$Artifact
 Oracle:At the beginning of each player's end step, if an artifact entered the battlefield under your control this turn, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.

--- a/forge-gui/res/cardsfolder/a/alistair_the_brigadier.txt
+++ b/forge-gui/res/cardsfolder/a/alistair_the_brigadier.txt
@@ -7,7 +7,7 @@ SVar:TrigToken:DB$ Token | TokenScript$ w_1_1_soldier
 T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPumpAll | TriggerDescription$ Whenever NICKNAME attacks, you may pay {8}. If you do, creatures you control get +X/+X until end of turn, where X is the number of historic permanents you control.
 SVar:TrigPumpAll:AB$ PumpAll | Cost$ 8 | ValidCards$ Creature.YouCtrl | NumAtt$ X | NumDef$ X
 SVar:X:Count$Valid Permanent.YouCtrl+Historic
+SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Token
 DeckHints:Type$Artifact|Legendary|Saga
-SVar:HasAttackEffect:TRUE
 Oracle:Whenever you cast a historic spell, create a 1/1 white Soldier creature token. (Artifacts, legendaries, and Sagas are historic.)\nWhenever Alistair attacks, you may pay {8}. If you do, creatures you control get +X/+X until end of turn, where X is the number of historic permanents you control.

--- a/forge-gui/res/cardsfolder/a/anavolver.txt
+++ b/forge-gui/res/cardsfolder/a/anavolver.txt
@@ -11,6 +11,6 @@ SVar:VolverPumped:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNu
 SVar:VolverResilience:DB$ Animate | Defined$ Self | Abilities$ ABRegen | Duration$ Permanent
 SVar:ABRegen:AB$ Regenerate | Cost$ PayLife<3> | SpellDescription$ Regenerate CARDNAME.
 AI:RemoveDeck:Random
-DeckNeeds:Color$Blue|Black
 DeckHas:Ability$Counters
+DeckNeeds:Color$Blue|Black
 Oracle:Kicker {1}{U} and/or {B} (You may pay an additional {1}{U} and/or {B} as you cast this spell.)\nIf Anavolver was kicked with its {1}{U} kicker, it enters with two +1/+1 counters on it and with flying.\nIf Anavolver was kicked with its {B} kicker, it enters with a +1/+1 counter on it and with "Pay 3 life: Regenerate Anavolver."

--- a/forge-gui/res/cardsfolder/a/angel_of_invention.txt
+++ b/forge-gui/res/cardsfolder/a/angel_of_invention.txt
@@ -7,6 +7,6 @@ K:Vigilance
 K:Lifelink
 K:Fabricate:2
 S:Mode$ Continuous | Affected$ Creature.Other+YouCtrl | AddPower$ 1 | AddToughness$ 1 | Description$ Other creatures you control get +1/+1.
-DeckHas:Ability$Counters|Token
 SVar:PlayMain1:TRUE
+DeckHas:Ability$Counters|Token
 Oracle:Flying, vigilance, lifelink\nFabricate 2 (When this creature enters, put two +1/+1 counters on it or create two 1/1 colorless Servo artifact creature tokens.)\nOther creatures you control get +1/+1.

--- a/forge-gui/res/cardsfolder/a/angel_of_unity.txt
+++ b/forge-gui/res/cardsfolder/a/angel_of_unity.txt
@@ -9,7 +9,7 @@ T:Mode$ SpellCast | ValidCard$ Card.Party | ValidActivatingPlayer$ You | Execute
 SVar:TrigChoose:DB$ ChooseCard | ChoiceZone$ Hand | Choices$ Creature.Party+YouOwn | ChoiceTitle$ Choose a party creature card in your hand | Amount$ 1 | SubAbility$ DBPump
 SVar:DBPump:DB$ Pump | Defined$ ChosenCard | PumpZone$ Hand | NumAtt$ 1 | NumDef$ 1 | Duration$ Perpetual | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearChosenCard$ True
-DeckHas:Ability$Party|LifeGain
 SVar:BuffedBy:Cleric,Rogue,Warrior,Wizard
+DeckHas:Ability$Party|LifeGain
 DeckHints:Type$Rogue|Warrior|Wizard
 Oracle:Flying, lifelink\nWhenever Angel of Unity enters or you cast a party spell, choose a party creature card in your hand. It perpetually gets +1/+1. (A party card or spell is a Cleric, Rogue, Warrior, or Wizard.)

--- a/forge-gui/res/cardsfolder/a/anikthea_hand_of_erebos.txt
+++ b/forge-gui/res/cardsfolder/a/anikthea_hand_of_erebos.txt
@@ -9,8 +9,8 @@ T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigExile | Secondary$ True | 
 SVar:TrigExile:DB$ ChangeZone | ValidTgts$ Enchantment.nonAura+YouCtrl | Origin$ Graveyard | TargetMin$ 0 | TargetMax$ 1 | Destination$ Exile | TgtPrompt$ Select up to one target non-Aura enchantment card from your graveyard | RememberChanged$ True | SubAbility$ DBCopy
 SVar:DBCopy:DB$ CopyPermanent | Defined$ Remembered | SetPower$ 3 | SetToughness$ 3 | AddTypes$ Creature & Zombie | SetColor$ Black | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Token|Graveyard
 DeckHints:Ability$Graveyard|Mill
 DeckNeeds:Type$Enchantment
-SVar:HasAttackEffect:TRUE
 Oracle:Menace\nOther enchantment creatures you control have menace.\nWhenever Anikthea enters or attacks, exile up to one target non-Aura enchantment card from your graveyard. Create a token that's a copy of that card, except it's a 3/3 black Zombie creature in addition to its other types.

--- a/forge-gui/res/cardsfolder/a/anoint_with_affliction.txt
+++ b/forge-gui/res/cardsfolder/a/anoint_with_affliction.txt
@@ -3,6 +3,6 @@ ManaCost:1 B
 Types:Instant
 A:SP$ ChangeZone | Defined$ Targeted | ValidTgts$ Creature | ConditionCheckSVar$ X | ConditionSVarCompare$ GE3 | Origin$ Battlefield | Destination$ Exile | SubAbility$ NotPoisoned | SpellDescription$ Exile target creature if it has mana value 3 or less. Corrupted — Exile that creature instead if its controller has three or more poison counters.
 SVar:NotPoisoned:DB$ ChangeZone | Defined$ Targeted | Origin$ Battlefield | Destination$ Exile | ConditionDefined$ Targeted | ConditionPresent$ Creature.cmcLE3
-DeckHints:Ability$Proliferate & Keyword$Infect|Toxic
 SVar:X:TargetedController$Counters.Poison
+DeckHints:Ability$Proliferate & Keyword$Infect|Toxic
 Oracle:Exile target creature if it has mana value 3 or less.\nCorrupted — Exile that creature instead if its controller has three or more poison counters.

--- a/forge-gui/res/cardsfolder/a/anowon_the_ruin_thief.txt
+++ b/forge-gui/res/cardsfolder/a/anowon_the_ruin_thief.txt
@@ -8,6 +8,6 @@ SVar:TrigMill:DB$ Mill | Defined$ TriggeredTarget | NumCards$ X | RememberMilled
 SVar:DBDraw:DB$ Draw | Defined$ You | ConditionDefined$ Remembered | ConditionPresent$ Creature | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:TriggerCount$DamageAmount
-DeckNeeds:Type$Rogue
 DeckHas:Ability$Mill
+DeckNeeds:Type$Rogue
 Oracle:Other Rogues you control get +1/+1.\nWhenever one or more Rogues you control deal combat damage to a player, that player mills a card for each 1 damage dealt to them. If the player mills at least one creature card this way, you draw a card. (To mill a card, a player puts the top card of their library into their graveyard.)

--- a/forge-gui/res/cardsfolder/a/aquastrand_spider.txt
+++ b/forge-gui/res/cardsfolder/a/aquastrand_spider.txt
@@ -4,7 +4,7 @@ Types:Creature Spider Mutant
 PT:0/0
 K:Graft:2
 A:AB$ Pump | Cost$ G | ValidTgts$ Creature.counters_GE1_P1P1 | TgtPrompt$ Select target creature with a +1/+1 counter | KW$ Reach | SpellDescription$ Target creature with a +1/+1 counter on it gains reach until end of turn. (It can block creatures with flying.)
-DeckNeeds:Ability$Counters
-DeckHas:Ability$Counters
 SVar:AIGraftPreference:DontMoveCounterIfLethal
+DeckHas:Ability$Counters
+DeckNeeds:Ability$Counters
 Oracle:Graft 2 (This creature enters with two +1/+1 counters on it. Whenever another creature enters, you may move a +1/+1 counter from this creature onto it.)\n{G}: Target creature with a +1/+1 counter on it gains reach until end of turn. (It can block creatures with flying.)

--- a/forge-gui/res/cardsfolder/a/aragorn_and_arwen_wed.txt
+++ b/forge-gui/res/cardsfolder/a/aragorn_and_arwen_wed.txt
@@ -8,6 +8,6 @@ T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPutCounterAll | Secondary$
 SVar:TrigPutCounterAll:DB$ PutCounterAll | ValidCards$ Creature.YouCtrl+StrictlyOther | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBGainLife
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ X
 SVar:X:Count$Valid Creature.YouCtrl+StrictlyOther
-DeckHas:Ability$Counters|LifeGain
 SVar:HasAttackEffect:TRUE
+DeckHas:Ability$Counters|LifeGain
 Oracle:Vigilance\nWhenever Aragorn and Arwen, Wed enters or attacks, put a +1/+1 counter on each other creature you control. You gain 1 life for each other creature you control.

--- a/forge-gui/res/cardsfolder/a/arcane_infusion.txt
+++ b/forge-gui/res/cardsfolder/a/arcane_infusion.txt
@@ -3,6 +3,6 @@ ManaCost:U R
 Types:Instant
 A:SP$ Dig | DigNum$ 4 | ChangeNum$ 1 | Optional$ True | ForceRevealToController$ True | ChangeValid$ Card.Instant,Card.Sorcery | RestRandomOrder$ True | StackDescription$ SpellDescription | SpellDescription$ Look at the top four cards of your library. You may reveal an instant or sorcery card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.
 K:Flashback:3 U R
-DeckNeeds:Type$Instant|Sorcery
 DeckHas:Ability$Graveyard
+DeckNeeds:Type$Instant|Sorcery
 Oracle:Look at the top four cards of your library. You may reveal an instant or sorcery card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nFlashback {3}{U}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)

--- a/forge-gui/res/cardsfolder/a/arcane_proxy.txt
+++ b/forge-gui/res/cardsfolder/a/arcane_proxy.txt
@@ -7,6 +7,6 @@ T:Mode$ ChangesZone | ValidCard$ Card.Self+wasCastByYou | Destination$ Battlefie
 SVar:TrigExile:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | TgtPrompt$ Select target instant or sorcery card with mana value less than or equal to CARDNAME's power | ValidTgts$ Instant.YouOwn+cmcLEX,Sorcery.YouOwn+cmcLEX | RememberChanged$ True | SubAbility$ DBPlay
 SVar:DBPlay:DB$ Play | Valid$ Card.IsRemembered | ValidZone$ Exile | Controller$ You | CopyCard$ True | WithoutManaCost$ True | ValidSA$ Spell | Optional$ True | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-DeckHints:Type$Instant|Sorcery & Color$Blue
 SVar:X:Count$CardPower
+DeckHints:Type$Instant|Sorcery & Color$Blue
 Oracle:Prototype {1}{U}{U} — 2/1 (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\nWhen Arcane Proxy enters, if you cast it, exile target instant or sorcery card with mana value less than or equal to Arcane Proxy's power from your graveyard. Copy that card. You may cast the copy without paying its mana cost.

--- a/forge-gui/res/cardsfolder/a/arcbound_shikari.txt
+++ b/forge-gui/res/cardsfolder/a/arcbound_shikari.txt
@@ -6,6 +6,6 @@ K:First Strike
 T:Mode$ ChangesZone | ValidCard$ Card.Self | Destination$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ When CARDNAME enters, put a +1/+1 counter on each other artifact creature you control.
 SVar:TrigPutCounter:DB$ PutCounterAll | ValidCards$ Creature.Artifact+StrictlyOther+YouCtrl | CounterType$ P1P1 | CounterNum$ 1
 K:Modular:2
-DeckHas:Ability$Counters
 SVar:PlayMain1:TRUE
+DeckHas:Ability$Counters
 Oracle:First strike\nWhen Arcbound Shikari enters, put a +1/+1 counter on each other artifact creature you control.\nModular 2 (This creature enters with two +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)

--- a/forge-gui/res/cardsfolder/a/archpriest_of_iona.txt
+++ b/forge-gui/res/cardsfolder/a/archpriest_of_iona.txt
@@ -6,7 +6,7 @@ S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ 
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | CheckSVar$ X | SVarCompare$ EQ4 | Execute$ TrigPump | TriggerDescription$ At the beginning of combat on your turn, if you have a full party, target creature gets +1/+1 and gains flying until end of turn.
 SVar:TrigPump:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +1 | NumDef$ +1 | KW$ Flying
 SVar:X:Count$Party
-DeckHas:Ability$Party
 SVar:BuffedBy:Rogue,Warrior,Wizard
+DeckHas:Ability$Party
 DeckHints:Type$Rogue|Warrior|Wizard
 Oracle:Archpriest of Iona's power is equal to the number of creatures in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nAt the beginning of combat on your turn, if you have a full party, target creature gets +1/+1 and gains flying until end of turn.

--- a/forge-gui/res/cardsfolder/a/armed_and_armored.txt
+++ b/forge-gui/res/cardsfolder/a/armed_and_armored.txt
@@ -4,6 +4,6 @@ Types:Instant
 A:SP$ AnimateAll | Types$ Creature,Artifact | ValidCards$ Vehicle.YouCtrl | SubAbility$ ArmDwarf | StackDescription$ Vehicles {p:You} controls become artifact creatures until end of turn. | SpellDescription$ Vehicles you control become artifact creatures until end of turn. Choose a Dwarf you control. Attach any number of Equipment you control to it.
 SVar:ArmDwarf:DB$ Attach | Object$ Valid Equipment.YouCtrl | Defined$ Valid Dwarf.YouCtrl | Optional$ True | StackDescription$ {p:You} chooses a Dwarf they control and attaches any number of Equipment they control to it.
 AI:RemoveDeck:All
-DeckNeeds:Type$Vehicle|Dwarf
 DeckHints:Type$Equipment
+DeckNeeds:Type$Vehicle|Dwarf
 Oracle:Vehicles you control become artifact creatures until end of turn. Choose a Dwarf you control. Attach any number of Equipment you control to it.

--- a/forge-gui/res/cardsfolder/a/arms_race.txt
+++ b/forge-gui/res/cardsfolder/a/arms_race.txt
@@ -5,8 +5,8 @@ A:AB$ ChangeZone | Cost$ 3 R | Origin$ Hand | Destination$ Battlefield | ChangeT
 SVar:DBPump:DB$ Animate | Keywords$ Haste | Defined$ Remembered | Duration$ Permanent | AtEOT$ Sacrifice | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:NonStackingEffect:True
-AI:RemoveDeck:Random
 SVar:PlayMain1:ALWAYS
-DeckNeeds:Type$Artifact
+AI:RemoveDeck:Random
 DeckHas:Keyword$Haste & Ability$Sacrifice
+DeckNeeds:Type$Artifact
 Oracle:{3}{R}: You may put an artifact card from your hand onto the battlefield. The artifact gains haste. Sacrifice it at the beginning of the next end step.

--- a/forge-gui/res/cardsfolder/a/arrogant_outlaw.txt
+++ b/forge-gui/res/cardsfolder/a/arrogant_outlaw.txt
@@ -5,6 +5,6 @@ PT:3/2
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ GE1 | Execute$ TrigDrain | TriggerDescription$ When CARDNAME enters, if an opponent lost life this turn, each opponent loses 2 life and you gain 2 life.
 SVar:TrigDrain:DB$ LoseLife | Defined$ Player.Opponent | LifeAmount$ 2 | SubAbility$ DBGainLife
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 2
-DeckHas:Ability$LifeGain
 SVar:X:Count$LifeOppsLostThisTurn
+DeckHas:Ability$LifeGain
 Oracle:When Arrogant Outlaw enters, if an opponent lost life this turn, each opponent loses 2 life and you gain 2 life.

--- a/forge-gui/res/cardsfolder/a/artificer_class.txt
+++ b/forge-gui/res/cardsfolder/a/artificer_class.txt
@@ -8,6 +8,6 @@ SVar:TrigDigUntil:DB$ DigUntil | Valid$ Artifact | FoundDestination$ Hand | Reve
 K:Class:3:5 U:AddTrigger$ TriggerEndTurn
 SVar:TriggerEndTurn:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ CopyArtifact | Secondary$ True | TriggerDescription$ At the beginning of your end step, create a token that's a copy of target artifact you control.
 SVar:CopyArtifact:DB$ CopyPermanent | ValidTgts$ Artifact.YouCtrl | TgtPrompt$ Select target artifact you control to copy
-DeckNeeds:Type$Artifact
 DeckHas:Ability$Token
+DeckNeeds:Type$Artifact
 Oracle:(Gain the next level as a sorcery to add its ability.)\nThe first artifact spell you cast each turn costs {1} less to cast.\n{1}{U}: Level 2\nWhen this Class becomes level 2, reveal cards from the top of your library until you reveal an artifact card. Put that card into your hand and the rest on the bottom of your library in a random order.\n{5}{U}: Level 3\nAt the beginning of your end step, create a token that's a copy of target artifact you control.

--- a/forge-gui/res/cardsfolder/a/arvad_the_cursed.txt
+++ b/forge-gui/res/cardsfolder/a/arvad_the_cursed.txt
@@ -5,7 +5,7 @@ PT:3/3
 K:Deathtouch
 K:Lifelink
 S:Mode$ Continuous | Affected$ Creature.Legendary+Other+YouCtrl | AddPower$ 2 | AddToughness$ 2 | Description$ Other legendary creatures you control get +2/+2.
-AI:RemoveDeck:Random
 SVar:PlayMain1:TRUE
+AI:RemoveDeck:Random
 DeckHints:Type$Legendary
 Oracle:Deathtouch, lifelink\nOther legendary creatures you control get +2/+2.

--- a/forge-gui/res/cardsfolder/a/arwen_weaver_of_hope.txt
+++ b/forge-gui/res/cardsfolder/a/arwen_weaver_of_hope.txt
@@ -4,6 +4,6 @@ Types:Legendary Creature Elf Noble
 PT:2/1
 K:ETBReplacement:Other:AddExtraCounter:Mandatory:Battlefield:Creature.Other+YouCtrl
 SVar:AddExtraCounter:DB$ PutCounter | ETB$ True | Defined$ ReplacedCard | CounterType$ P1P1 | CounterNum$ X | SpellDescription$ Each other creature you control enters with a number of additional +1/+1 counters on it equal to CARDNAME's toughness.
-DeckHas:Ability$Counters
 SVar:X:Count$CardToughness
+DeckHas:Ability$Counters
 Oracle:Each other creature you control enters with a number of additional +1/+1 counters on it equal to Arwen, Weaver of Hope's toughness.

--- a/forge-gui/res/cardsfolder/a/ascendant_packleader.txt
+++ b/forge-gui/res/cardsfolder/a/ascendant_packleader.txt
@@ -5,6 +5,6 @@ PT:2/1
 K:etbCounter:P1P1:1:IsPresent$ Permanent.YouCtrl+cmcGE4:CARDNAME enters with a +1/+1 counter on it if you control a permanent with mana value 4 or greater.
 T:Mode$ SpellCast | ValidCard$ Card.cmcGE4 | ValidActivatingPlayer$ You | Execute$ TrigCounter | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a spell with mana value 4 or greater, put a +1/+1 counter on CARDNAME.
 SVar:TrigCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
-DeckHas:Ability$Counters
 SVar:BuffedBy:Permanent.cmcGE4
+DeckHas:Ability$Counters
 Oracle:Ascendant Packleader enters with a +1/+1 counter on it if you control a permanent with mana value 4 or greater.\nWhenever you cast a spell with mana value 4 or greater, put a +1/+1 counter on Ascendant Packleader.

--- a/forge-gui/res/cardsfolder/a/ash_party_crasher.txt
+++ b/forge-gui/res/cardsfolder/a/ash_party_crasher.txt
@@ -6,6 +6,6 @@ K:Haste
 T:Mode$ Attacks | ValidCard$ Creature.Self | CheckSVar$ Celebration | SVarCompare$ GE2 | Execute$ TrigPutCounter | TriggerDescription$ Celebration — Whenever CARDNAME attacks, if two or more nonland permanents entered the battlefield under your control this turn, put a +1/+1 counter on NICKNAME.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
 SVar:Celebration:Count$ThisTurnEntered_Battlefield_Permanent.nonLand+YouCtrl
-DeckHas:Ability$Counters
 SVar:HasAttackEffect:TRUE
+DeckHas:Ability$Counters
 Oracle:Haste\nCelebration — Whenever Ash, Party Crasher attacks, if two or more nonland permanents entered the battlefield under your control this turn, put a +1/+1 counter on Ash.

--- a/forge-gui/res/cardsfolder/a/ashad_the_lone_cyberman.txt
+++ b/forge-gui/res/cardsfolder/a/ashad_the_lone_cyberman.txt
@@ -6,7 +6,7 @@ S:Mode$ Continuous | Affected$ Card.Artifact+nonLegendary+YouCtrl | AffectedZone
 SVar:X:Count$ThisTurnCast_Artifact.nonLegendary+YouCtrl
 T:Mode$ Sacrificed | ValidCard$ Creature.Other | ValidPlayer$ You | Execute$ TrigPutCounter | TriggerZones$ Battlefield | TriggerDescription$ Whenever you sacrifice another creature, put a +1/+1 counter on CARDNAME.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
+SVar:AIDontSacToCasualty:TRUE
 DeckHas:Ability$Sacrifice|Counters
 DeckHints:Type$Artifact
-SVar:AIDontSacToCasualty:TRUE
 Oracle:The first nonlegendary artifact spell you cast each turn has casualty 2. (As you cast it, you may sacrifice a creature with power 2 or greater. When you do, copy it. A copy of an artifact spell becomes a token.)\nWhenever you sacrifice another creature, put a +1/+1 counter on Ashad, the Lone Cyberman.

--- a/forge-gui/res/cardsfolder/a/ashcoat_of_the_shadow_swarm.txt
+++ b/forge-gui/res/cardsfolder/a/ashcoat_of_the_shadow_swarm.txt
@@ -10,6 +10,6 @@ T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefiel
 SVar:TrigChange:AB$ ChangeZone | Cost$ Mill<4> | Origin$ Graveyard | Destination$ Hand | ChangeType$ Rat.Creature+YouOwn | ChangeNum$ 2 | Hidden$ True | SelectPrompt$ Select up to two Rat creature cards
 SVar:HasAttackEffect:TRUE
 SVar:HasBlockEffect:TRUE
-DeckNeeds:Type$Rat
 DeckHas:Ability$Mill|Graveyard
+DeckNeeds:Type$Rat
 Oracle:Whenever Ashcoat of the Shadow Swarm attacks or blocks, other Rats you control get +X/+X where X is the number of Rats you control.\nAt the beginning of your end step, you may mill four cards. If you do, return up to two Rat creature cards from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)

--- a/forge-gui/res/cardsfolder/a/ashnod_flesh_mechanist.txt
+++ b/forge-gui/res/cardsfolder/a/ashnod_flesh_mechanist.txt
@@ -6,6 +6,6 @@ K:Deathtouch
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigToken | OptionalDecider$ You | TriggerDescription$ Whenever CARDNAME attacks, you may sacrifice another creature. If you do, create a tapped Powerstone token.
 SVar:TrigToken:AB$ Token | Cost$ Sac<1/Creature.Other/another creature> | TokenTapped$ True | TokenScript$ c_a_powerstone
 A:AB$ Token | Cost$ 5 ExileFromGrave<1/Creature/creature card> | TokenTapped$ True | TokenScript$ c_3_3_a_zombie | SpellDescription$ Create a tapped 3/3 colorless Zombie artifact creature token.
-DeckHas:Ability$Sacrifice|Token|Graveyard & Type$Zombie|Artifact
 SVar:HasAttackEffect:TRUE
+DeckHas:Ability$Sacrifice|Token|Graveyard & Type$Zombie|Artifact
 Oracle:Deathtouch\nWhenever Ashnod, Flesh Mechanist attacks, you may sacrifice another creature. If you do, create a tapped Powerstone token.\n{5}, Exile a creature card from your graveyard: Create a tapped 3/3 colorless Zombie artifact creature token.

--- a/forge-gui/res/cardsfolder/a/ashnods_harvester.txt
+++ b/forge-gui/res/cardsfolder/a/ashnods_harvester.txt
@@ -5,7 +5,7 @@ PT:3/1
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ Whenever CARDNAME attacks, exile target card from a graveyard.
 SVar:TrigExile:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | ValidTgts$ Card
 K:Unearth:1 B
+SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Graveyard
 DeckHints:Color$Black
-SVar:HasAttackEffect:TRUE
 Oracle:Whenever Ashnod's Harvester attacks, exile target card from a graveyard.\nUnearth {1}{B} ({1}{B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)

--- a/forge-gui/res/cardsfolder/a/atog.txt
+++ b/forge-gui/res/cardsfolder/a/atog.txt
@@ -3,7 +3,7 @@ ManaCost:1 R
 Types:Creature Atog
 PT:1/2
 A:AB$ Pump | Cost$ Sac<1/Artifact> | Defined$ Self | NumAtt$ 2 | NumDef$ 2 | SpellDescription$ CARDNAME gets +2/+2 until end of turn.
-DeckNeeds:Type$Artifact
-DeckHas:Ability$Sacrifice
 SVar:AIPreference:SacCost$Artifact.token,Artifact.cmcEQ0+nonLegendary+notnamedBlack Lotus,Artifact.cmcEQ1,Artifact.cmcEQ2,Artifact.cmcEQ3
+DeckHas:Ability$Sacrifice
+DeckNeeds:Type$Artifact
 Oracle:Sacrifice an artifact: Atog gets +2/+2 until end of turn.

--- a/forge-gui/res/cardsfolder/a/aurelias_vindicator.txt
+++ b/forge-gui/res/cardsfolder/a/aurelias_vindicator.txt
@@ -10,6 +10,6 @@ T:Mode$ TurnFaceUp | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescript
 SVar:TrigExile:DB$ ChangeZone | TargetMin$ 0 | TargetMax$ X | IsCurse$ True | ValidTgts$ Creature.Other | TgtPrompt$ Choose up to X other target creatures from the battlefield and/or creature cards from graveyards | Origin$ Battlefield,Graveyard | Destination$ Exile
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | ValidCard$ Card.Self | Execute$ TrigReturn | TriggerDescription$ When CARDNAME leaves the battlefield, return the exiled cards to their owners' hands.
 SVar:TrigReturn:DB$ ChangeZoneAll | ChangeType$ Card.ExiledWithSource | Origin$ Exile | Destination$ Hand
-DeckHas:Ability$Graveyard
 SVar:X:Count$xPaid
+DeckHas:Ability$Graveyard
 Oracle:Flying, lifelink, ward {2}\nDisguise {X}{3}{W}\nWhen Aurelia's Vindicator is turned face up, exile up to X other target creatures from the battlefield and/or creature cards from graveyards.\nWhen Aurelia's Vindicator leaves the battlefield, return the exiled cards to their owners' hands.

--- a/forge-gui/res/cardsfolder/a/aven_courier.txt
+++ b/forge-gui/res/cardsfolder/a/aven_courier.txt
@@ -5,6 +5,6 @@ PT:1/1
 K:Flying
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPutCounter | TriggerDescription$ Whenever CARDNAME attacks, choose a counter on a permanent you control. Put a counter of that kind on target permanent you control if it doesn't have a counter of that kind on it.
 SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Permanent.YouCtrl | TgtPrompt$ Select target permanent you control | CounterType$ ExistingCounter | Choices$ Permanent.YouCtrl+HasCounters | PutOnDefined$ Targeted | OnlyNewKind$ True
-DeckNeeds:Ability$Counters
 SVar:HasAttackEffect:TRUE
+DeckNeeds:Ability$Counters
 Oracle:Flying\nWhenever Aven Courier attacks, choose a counter on a permanent you control. Put a counter of that kind on target permanent you control if it doesn't have a counter of that kind on it.

--- a/forge-gui/res/cardsfolder/a/axgard_armory.txt
+++ b/forge-gui/res/cardsfolder/a/axgard_armory.txt
@@ -6,6 +6,6 @@ SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 A:AB$ Mana | Cost$ T | Produced$ W | SpellDescription$ Add {W}.
 A:AB$ ChangeZone | Cost$ 1 R R W T Sac<1/CARDNAME> | Origin$ Library | Destination$ Hand | ChangeType$ EACH Aura & Equipment | StackDescription$ {p:You} searches their library for an Aura card and/or an Equipment card, reveals them, puts them into their hand, then shuffles their library. | SpellDescription$ Search your library for an Aura card and/or an Equipment card, reveal them, put them into your hand, then shuffle.
 AI:RemoveDeck:Random
-DeckNeeds:Type$Aura|Equipment
 DeckHas:Ability$Sacrifice
+DeckNeeds:Type$Aura|Equipment
 Oracle:Axgard Armory enters tapped.\n{T}: Add {W}.\n{1}{R}{R}{W}, {T}, Sacrifice Axgard Armory: Search your library for an Aura card and/or an Equipment card, reveal them, put them into your hand, then shuffle.

--- a/forge-gui/res/cardsfolder/b/baton_of_courage.txt
+++ b/forge-gui/res/cardsfolder/b/baton_of_courage.txt
@@ -4,8 +4,8 @@ Types:Artifact
 K:Flash
 K:Sunburst
 A:AB$ Pump | Cost$ SubCounter<1/CHARGE> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDef$ 1 | NumAtt$ 1 | SpellDescription$ Target creature gets +1/+1 until end of turn.
-AI:RemoveDeck:Random
 SVar:NeedsToPlayVar:Z GE1
 SVar:Z:Count$UniqueManaColorsProduced.ByUntappedSources
+AI:RemoveDeck:Random
 DeckHints:Ability$Proliferate
 Oracle:Flash\nSunburst (This enters with a charge counter on it for each color of mana spent to cast it.)\nRemove a charge counter from Baton of Courage: Target creature gets +1/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/b/benalish_emissary.txt
+++ b/forge-gui/res/cardsfolder/b/benalish_emissary.txt
@@ -5,6 +5,6 @@ PT:1/4
 K:Kicker:1 G
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self+kicked | Execute$ TrigKicker | TriggerDescription$ When CARDNAME enters, if it was kicked, destroy target land.
 SVar:TrigKicker:DB$ Destroy | ValidTgts$ Land | TgtPrompt$ Select target land
-DeckHints:Color$Green
 SVar:NeedsToPlayKicked:Land.OppCtrl
+DeckHints:Color$Green
 Oracle:Kicker {1}{G} (You may pay an additional {1}{G} as you cast this spell.)\nWhen Benalish Emissary enters, if it was kicked, destroy target land.

--- a/forge-gui/res/cardsfolder/b/benalish_partisan.txt
+++ b/forge-gui/res/cardsfolder/b/benalish_partisan.txt
@@ -8,7 +8,7 @@ SVar:TrigReturn:AB$ ChangeZone | Cost$ 1 W | Origin$ Graveyard | Destination$ Ba
 SVar:DBPump:DB$ Pump | Defined$ Remembered | NumAtt$ 1 | Duration$ Perpetual | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 K:Cycling:1 W
+SVar:SacMe:2
 DeckHas:Ability$LifeGain|Graveyard
 DeckNeeds:Keyword$Cycling
-SVar:SacMe:2
 Oracle:Lifelink\nWhenever you cycle another card, you may pay {1}{W}. If you do, return Benalish Partisan from your graveyard to the battlefield tapped and it perpetually gets +1/+0.\nCycling {1}{W}

--- a/forge-gui/res/cardsfolder/b/benthic_criminologists.txt
+++ b/forge-gui/res/cardsfolder/b/benthic_criminologists.txt
@@ -5,7 +5,7 @@ PT:4/5
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ Whenever CARDNAME enters or attacks, you may sacrifice an artifact. If you do, draw a card.
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigDraw | Secondary$ True | TriggerDescription$ Whenever CARDNAME enters or attacks, you may sacrifice an artifact. If you do, draw a card.
 SVar:TrigDraw:AB$ Draw | Cost$ Sac<1/Artifact>
-DeckHas:Ability$Sacrifice
 SVar:HasAttackEffect:TRUE
+DeckHas:Ability$Sacrifice
 DeckHints:Type$Artifact|Treasure|Food|Map|Clue
 Oracle:Whenever Benthic Criminologists enters or attacks, you may sacrifice an artifact. If you do, draw a card.

--- a/forge-gui/res/cardsfolder/b/bess_soul_nourisher.txt
+++ b/forge-gui/res/cardsfolder/b/bess_soul_nourisher.txt
@@ -7,8 +7,8 @@ SVar:TrigPutCounter:DB$ PutCounter | CounterType$ P1P1
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPumpAll | TriggerDescription$ Whenever NICKNAME attacks, each other creature you control with base power and toughness 1/1 gets +X/+X until end of turn, where X is the number of +1/+1 counters on NICKNAME.
 SVar:TrigPumpAll:DB$ PumpAll | ValidCards$ Creature.basePowerEQ1+baseToughnessEQ1+Other+YouCtrl | NumAtt$ +X | NumDef$ +X
 SVar:X:Count$CardCounters.P1P1
-DeckHas:Ability$Counters
-DeckHints:Type$Citizen
 SVar:HasAttackEffect:TRUE
 SVar:BuffedBy:Creature.powerEQ1,Creature.toughnessEQ1
+DeckHas:Ability$Counters
+DeckHints:Type$Citizen
 Oracle:Whenever one or more other creatures you control with base power and toughness 1/1 enter, put a +1/+1 counter on Bess, Soul Nourisher.\nWhenever Bess attacks, each other creature you control with base power and toughness 1/1 gets +X/+X until end of turn, where X is the number of +1/+1 counters on Bess.

--- a/forge-gui/res/cardsfolder/b/big_spender.txt
+++ b/forge-gui/res/cardsfolder/b/big_spender.txt
@@ -6,7 +6,7 @@ K:Haste
 T:Mode$ AttackerBlockedOnce | ValidCard$ Creature.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigTreasure | TriggerDescription$ Whenever one or more creatures you control become blocked, create a Treasure token.
 SVar:TrigTreasure:DB$ Token | TokenScript$ c_a_treasure_sac
 A:AB$ Draft | Cost$ Sac<2/Artifact> | Spellbook$ Arcane Encyclopedia,Daredevil Dragster,Diamond Mare,Filigree Familiar,Fountain of Renewal,Gilded Lotus,Golden Egg,Guild Globe,Heraldic Banner,Honored Heirloom,Key to the City,Prophetic Prism,Stuffed Bear,Treasure Vault,Zephyr Boots | SpellDescription$ Draft a card from CARDNAME's spellbook.
+SVar:AIPreference:SacCost$Treasure.Token,Artifact.Token
 DeckHas:Ability$Sacrifice|Token|Discard|LifeGain & Type$Treasure|Artifact|Horse|Fox|Food|Equipment|Bear
 DeckHints:Type$Treasure
-SVar:AIPreference:SacCost$Treasure.Token,Artifact.Token
 Oracle:Haste\nWhenever one or more creatures you control become blocked, create a Treasure token.\nSacrifice two artifacts: Draft a card from Big Spender's spellbook.

--- a/forge-gui/res/cardsfolder/b/biowaste_blob.txt
+++ b/forge-gui/res/cardsfolder/b/biowaste_blob.txt
@@ -6,6 +6,6 @@ S:Mode$ Continuous | Affected$ Ooze.YouCtrl | AddPower$ 1 | AddToughness$ 1 | De
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ TrigCopy | TriggerZones$ Battlefield | IsPresent$ Card.IsCommander+YouCtrl | PresentCompare$ GE1 | TriggerDescription$ At the beginning of your upkeep, if you control a commander, create a token that's a copy of CARDNAME.
 SVar:TrigCopy:DB$ CopyPermanent | Defined$ Self | NumCopies$ 1
 AI:RemoveDeck:NonCommander
-DeckNeeds:Type$Ooze
 DeckHas:Ability$Token
+DeckNeeds:Type$Ooze
 Oracle:Oozes you control get +1/+1.\nAt the beginning of your upkeep, if you control a commander, create a token that's a copy of Biowaste Blob.

--- a/forge-gui/res/cardsfolder/b/blinding_drone.txt
+++ b/forge-gui/res/cardsfolder/b/blinding_drone.txt
@@ -4,6 +4,6 @@ Types:Creature Eldrazi Drone
 PT:1/3
 K:Devoid
 A:AB$ Tap | Cost$ C T | ValidTgts$ Creature | TgtPrompt$ Select target creature | SpellDescription$ Tap target creature.
-DeckHints:Ability$Mana.Colorless
 SVar:NonCombatPriority:1
+DeckHints:Ability$Mana.Colorless
 Oracle:Devoid (This card has no color.)\n{C}, {T}: Tap target creature. ({C} represents colorless mana.)

--- a/forge-gui/res/cardsfolder/b/blinding_souleater.txt
+++ b/forge-gui/res/cardsfolder/b/blinding_souleater.txt
@@ -3,7 +3,7 @@ ManaCost:3
 Types:Artifact Creature Phyrexian Cleric
 PT:1/3
 A:AB$ Tap | Cost$ WP T | ValidTgts$ Creature | TgtPrompt$ Select target creature | AIPhyrexianPayment$ Never | SpellDescription$ Tap target creature.
+SVar:NonCombatPriority:1
 AI:RemoveDeck:Random
 DeckNeeds:Color$White
-SVar:NonCombatPriority:1
 Oracle:{W/P}, {T}: Tap target creature. ({W/P} can be paid with either {W} or 2 life.)

--- a/forge-gui/res/cardsfolder/b/blitzwing_cruel_tormentor_blitzwing_adaptive_assailant.txt
+++ b/forge-gui/res/cardsfolder/b/blitzwing_cruel_tormentor_blitzwing_adaptive_assailant.txt
@@ -24,6 +24,6 @@ T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | Execute$ TrigRandomPump 
 SVar:TrigRandomPump:DB$ Pump | Defined$ Self | KW$ Flying & Indestructible | RandomKeyword$ True
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | TriggerZones$ Battlefield | Execute$ TrigConvert | TriggerDescription$ Whenever NICKNAME deals combat damage to a player, convert it.
 SVar:TrigConvert:DB$ SetState | Mode$ Transform
-DeckHas:Keyword$Flying|Indestructible
 SVar:HasAttackEffect:TRUE
+DeckHas:Keyword$Flying|Indestructible
 Oracle:Living metal (As long as it's your turn, this Vehicle is also a creature.)\nAt the beginning of combat on your turn, choose flying or indestructible at random. Blitzwing gains that ability until end of turn.\nWhenever Blitzwing deals combat damage to a player, convert it.

--- a/forge-gui/res/cardsfolder/b/bloodcrazed_socialite.txt
+++ b/forge-gui/res/cardsfolder/b/bloodcrazed_socialite.txt
@@ -7,7 +7,7 @@ T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefi
 SVar:DBToken:DB$ Token | TokenScript$ c_a_blood_draw
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, you may sacrifice a Blood token. If you do, it gets +2/+2 until end of turn.
 SVar:TrigPump:AB$ Pump | Cost$ Sac<1/Blood.token/Blood token> | Defined$ Self | NumAtt$ +2 | NumDef$ +2 | SpellDescription$ CARDNAME gets +2/+2 until end of turn.
+SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Token|Sacrifice & Type$Blood
 DeckHints:Type$Blood
-SVar:HasAttackEffect:TRUE
 Oracle:Menace\nWhen Bloodcrazed Socialite enters, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")\nWhenever Bloodcrazed Socialite attacks, you may sacrifice a Blood token. If you do, it gets +2/+2 until end of turn.

--- a/forge-gui/res/cardsfolder/b/blossoming_bogbeast.txt
+++ b/forge-gui/res/cardsfolder/b/blossoming_bogbeast.txt
@@ -6,6 +6,6 @@ T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigGainLife | TriggerDescript
 SVar:TrigGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 2 | SubAbility$ DBPumpAll
 SVar:DBPumpAll:DB$ PumpAll | ValidCards$ Creature.YouCtrl | NumAtt$ X | NumDef$ X | KW$ Trample
 SVar:X:Count$LifeYouGainedThisTurn
-DeckHas:Ability$LifeGain
 SVar:HasAttackEffect:TRUE
+DeckHas:Ability$LifeGain
 Oracle:Whenever Blossoming Bogbeast attacks, you gain 2 life. Then creatures you control gain trample and get +X/+X until end of turn, where X is the amount of life you gained this turn.

--- a/forge-gui/res/cardsfolder/b/borborygmos_and_fblthp.txt
+++ b/forge-gui/res/cardsfolder/b/borborygmos_and_fblthp.txt
@@ -11,6 +11,6 @@ SVar:TrigDoubleDamage:DB$ DealDamage | NumDmg$ Count$TriggerRememberAmount | Val
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Count$RememberedSize/Twice
 A:AB$ ChangeZone | Cost$ 1 U | Origin$ Battlefield | Destination$ Library | LibraryPosition$ 2 | SpellDescription$ Put CARDNAME into its owner's library third from the top.
-DeckHas:Ability$Discard
 SVar:HasAttackEffect:TRUE
+DeckHas:Ability$Discard
 Oracle:Whenever Borborygmos and Fblthp enters or attacks, draw a card, then you may discard any number of land cards. When you discard one or more cards this way, Borborygmos and Fblthp deals twice that much damage to target creature.\n{1}{U}: Put Borborygmos and Fblthp into its owner's library third from the top.

--- a/forge-gui/res/cardsfolder/b/boromir_gondors_hope.txt
+++ b/forge-gui/res/cardsfolder/b/boromir_gondors_hope.txt
@@ -5,6 +5,6 @@ PT:3/4
 T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigDig | TriggerDescription$ Whenever CARDNAME enters or attacks, look at the top six cards of your library. You may reveal a Human or artifact card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigDig | Secondary$ True | TriggerDescription$ Whenever CARDNAME enters or attacks, look at the top six cards of your library. You may reveal a Human or artifact card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.
 SVar:TrigDig:DB$ Dig | DigNum$ 6 | ChangeNum$ 1 | Optional$ True | ForceRevealToController$ True | ChangeValid$ Human,Artifact | RestRandomOrder$ True
-DeckHints:Type$Human|Artifact
 SVar:HasAttackEffect:TRUE
+DeckHints:Type$Human|Artifact
 Oracle:Whenever Boromir, Gondor's Hope enters or attacks, look at the top six cards of your library. You may reveal a Human or artifact card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.

--- a/forge-gui/res/cardsfolder/b/bortuk_bonerattle.txt
+++ b/forge-gui/res/cardsfolder/b/bortuk_bonerattle.txt
@@ -6,6 +6,6 @@ T:Mode$ ChangesZone | ValidCard$ Card.wasCastByYou+Self | Destination$ Battlefie
 SVar:TrigChangeZone:DB$ ChangeZone | ValidTgts$ Creature.YouOwn | Origin$ Graveyard | Destination$ Battlefield | ConditionDefined$ Targeted | ConditionPresent$ Card.cmcLEX | SubAbility$ DBChangeZone
 SVar:DBChangeZone:DB$ ChangeZone | Defined$ Targeted | Origin$ Graveyard | Destination$ Hand | ConditionDefined$ Targeted | ConditionPresent$ Card.cmcGTX
 SVar:X:Count$Domain
-RemoveDeck:Random
+AI:RemoveDeck:Random
 DeckHas:Ability$Graveyard
 Oracle:Domain — When Bortuk Bonerattle enters, if you cast it, choose target creature card in your graveyard. Return that card to the battlefield if its mana value is less than or equal to the number of basic land types among lands you control. Otherwise, put it into your hand.

--- a/forge-gui/res/cardsfolder/b/bramblewood_paragon.txt
+++ b/forge-gui/res/cardsfolder/b/bramblewood_paragon.txt
@@ -5,6 +5,6 @@ PT:2/2
 K:ETBReplacement:Other:AddExtraCounter:Mandatory:Battlefield:Creature.Warrior+YouCtrl+Other
 SVar:AddExtraCounter:DB$ PutCounter | ETB$ True | Defined$ ReplacedCard | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Each other Warrior creature you control enters with an additional +1/+1 counter on it.
 S:Mode$ Continuous | Affected$ Creature.YouCtrl+counters_GE1_P1P1 | AddKeyword$ Trample | Description$ Each creature you control with a +1/+1 counter on it has trample.
-DeckNeeds:Type$Warrior
 DeckHas:Ability$Counters
+DeckNeeds:Type$Warrior
 Oracle:Each other Warrior creature you control enters with an additional +1/+1 counter on it.\nEach creature you control with a +1/+1 counter on it has trample.

--- a/forge-gui/res/cardsfolder/b/breath_of_the_sleepless.txt
+++ b/forge-gui/res/cardsfolder/b/breath_of_the_sleepless.txt
@@ -4,6 +4,6 @@ Types:Enchantment
 S:Mode$ CastWithFlash | ValidCard$ Spirit | ValidSA$ Spell | EffectZone$ Battlefield | Caster$ You | Description$ You may cast Spirit spells as though they had flash.
 T:Mode$ SpellCast | ValidCard$ Creature | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | OpponentTurn$ True | Execute$ TrigTap | TriggerDescription$ Whenever you cast a creature spell during an opponent's turn, tap up to one target creature.
 SVar:TrigTap:DB$ Tap | TargetMin$ 0 | TargetMax$ 1 | ValidTgts$ Creature | TgtPrompt$ Select up to one target creature
-DeckHints:Type$Spirit
 SVar:BuffedBy:Creature.withFlash
+DeckHints:Type$Spirit
 Oracle:You may cast Spirit spells as though they had flash.\nWhenever you cast a creature spell during an opponent's turn, tap up to one target creature.

--- a/forge-gui/res/cardsfolder/b/briarblade_adept.txt
+++ b/forge-gui/res/cardsfolder/b/briarblade_adept.txt
@@ -5,6 +5,6 @@ PT:3/4
 K:Encore:3 B
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, target creature an opponent controls gets -1/-1 until end of turn.
 SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | NumAtt$ -1 | NumDef$ -1 | IsCurse$ True
-DeckHas:Ability$Token
 SVar:HasAttackEffect:TRUE
+DeckHas:Ability$Token
 Oracle:Whenever Briarblade Adept attacks, target creature an opponent controls gets -1/-1 until end of turn.\nEncore {3}{B} ({3}{B}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)

--- a/forge-gui/res/cardsfolder/b/bribe_taker.txt
+++ b/forge-gui/res/cardsfolder/b/bribe_taker.txt
@@ -5,6 +5,6 @@ PT:6/6
 K:Trample
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPutCounter | TriggerDescription$ When CARDNAME enters, for each kind of counter on permanents you control, you may put your choice of a +1/+1 counter or a counter of that kind on CARDNAME.
 SVar:TrigPutCounter:DB$ PutCounter | CounterTypes$ EachType_Permanent.YouCtrl | AltChoiceForEach$ P1P1
-DeckNeeds:Ability$Counters
 DeckHas:Ability$Counters
+DeckNeeds:Ability$Counters
 Oracle:Trample\nWhen Bribe Taker enters, for each kind of counter on permanents you control, you may put your choice of a +1/+1 counter or a counter of that kind on Bribe Taker.

--- a/forge-gui/res/cardsfolder/b/brilliant_restoration.txt
+++ b/forge-gui/res/cardsfolder/b/brilliant_restoration.txt
@@ -2,6 +2,6 @@ Name:Brilliant Restoration
 ManaCost:3 W W W W
 Types:Sorcery
 A:SP$ ChangeZoneAll | ChangeType$ Artifact.YouOwn,Enchantment.YouOwn | Origin$ Graveyard | Destination$ Battlefield | SpellDescription$ Return all artifact and enchantment cards from your graveyard to the battlefield.
-DeckNeeds:Type$Artifact|Enchantment
 DeckHas:Ability$Graveyard
+DeckNeeds:Type$Artifact|Enchantment
 Oracle:Return all artifact and enchantment cards from your graveyard to the battlefield.

--- a/forge-gui/res/cardsfolder/b/bristlebud_farmer.txt
+++ b/forge-gui/res/cardsfolder/b/bristlebud_farmer.txt
@@ -9,7 +9,7 @@ T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigMill | TriggerDescription$
 SVar:TrigMill:AB$ Mill | Cost$ Sac<1/Food> | NumCards$ 3 | Defined$ You | RememberMilled$ True | SubAbility$ DBChangeZone
 SVar:DBChangeZone:DB$ ChangeZone | Hidden$ True | Origin$ Graveyard,Exile | Destination$ Hand | ChangeType$ Card.Permanent+YouOwn+IsRemembered | Optional$ True | SelectPrompt$ You may select a permanent milled this way | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Token|LifeGain|Sacrifice|Mill & Type$Food
 DeckHints:Type$Food
-SVar:HasAttackEffect:TRUE
 Oracle:Trample\nWhen Bristlebud Farmer enters, create two Food tokens. (They're artifacts with "{2}, {T}, Sacrifice this artifact: You gain 3 life.")\nWhenever Bristlebud Farmer attacks, you may sacrifice a Food. If you do, mill three cards. You may put a permanent card from among them into your hand.

--- a/forge-gui/res/cardsfolder/b/brood_butcher.txt
+++ b/forge-gui/res/cardsfolder/b/brood_butcher.txt
@@ -6,7 +6,7 @@ K:Devoid
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a 1/1 colorless Eldrazi Scion creature token. It has "Sacrifice this creature: Add {C}."
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ c_1_1_eldrazi_scion_sac | TokenOwner$ You
 A:AB$ Pump | Cost$ B G Sac<1/Creature> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ -2 | NumDef$ -2 | IsCurse$ True | SpellDescription$ Target creature gets -2/-2 until end of turn.
-DeckHints:Type$Eldrazi
-DeckHas:Ability$Mana.Colorless|Token
 SVar:AIPreference:SacCost$Creature.token
+DeckHas:Ability$Mana.Colorless|Token
+DeckHints:Type$Eldrazi
 Oracle:Devoid (This card has no color.)\nWhen Brood Butcher enters, create a 1/1 colorless Eldrazi Scion creature token. It has "Sacrifice this creature: Add {C}."\n{B}{G}, Sacrifice a creature: Target creature gets -2/-2 until end of turn.

--- a/forge-gui/res/cardsfolder/b/brothers_yamazaki.txt
+++ b/forge-gui/res/cardsfolder/b/brothers_yamazaki.txt
@@ -5,7 +5,7 @@ PT:2/1
 K:Bushido:1
 S:Mode$ IgnoreLegendRule | ValidCard$ Permanent.namedBrothers Yamazaki | IsPresent$ Permanent.namedBrothers Yamazaki | PresentCompare$ EQ2 | Description$ If there are exactly two permanents named Brothers Yamazaki on the battlefield, the "legend rule" doesn't apply to them.
 S:Mode$ Continuous | Affected$ Creature.Other+namedBrothers Yamazaki | AddPower$ 2 | AddToughness$ 2 | AddKeyword$ Haste | Description$ Each other creature named Brothers Yamazaki gets +2/+2 and has haste.
-DeckHints:Name$Brothers Yamazaki
 SVar:AILegendaryException:TwoCopiesAllowed
 SVar:PlayMain1:TRUE
+DeckHints:Name$Brothers Yamazaki
 Oracle:Bushido 1 (Whenever this creature blocks or becomes blocked, it gets +1/+1 until end of turn.)\nIf there are exactly two permanents named Brothers Yamazaki on the battlefield, the "legend rule" doesn't apply to them.\nEach other creature named Brothers Yamazaki gets +2/+2 and has haste.

--- a/forge-gui/res/cardsfolder/b/bruna_light_of_alabaster.txt
+++ b/forge-gui/res/cardsfolder/b/bruna_light_of_alabaster.txt
@@ -6,7 +6,7 @@ K:Flying
 K:Vigilance
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ Aurify | TriggerDescription$ Whenever CARDNAME attacks or blocks, you may attach to it any number of Auras on the battlefield and you may put onto the battlefield attached to it any number of Aura cards that could enchant it from your graveyard and/or hand.
 T:Mode$ Blocks | ValidCard$ Card.Self | Execute$ Aurify | Secondary$ True | TriggerDescription$ Whenever CARDNAME attacks or blocks, you may attach to it any number of Auras on the battlefield and you may put onto the battlefield attached to it any number of Aura cards that could enchant it from your graveyard and/or hand.
-SVar:Aurify:DB$ RepeatEach | RepeatSubAbility$ BrunaAttach | RepeatCards$ Aura.CanEnchantSource+NotAttachedTo | SubAbility$ ZoneAuras
+SVar:Aurify:DB$ RepeatEach | RepeatSubAbility$ BrunaAttach | RepeatCards$ Aura.CanEnchantSource+!Attached | SubAbility$ ZoneAuras
 SVar:BrunaAttach:DB$ Attach | Object$ Remembered | Defined$ Self | Optional$ True
 SVar:ZoneAuras:DB$ ChangeZone | Origin$ Hand,Graveyard | Destination$ Battlefield | ChangeType$ Aura.CanEnchantSource+YouOwn | AttachedTo$ Self | ChangeNum$ CountAuras | Optional$ True | Hidden$ True
 SVar:CountAuras:Count$ValidHand,Graveyard Aura.CanEnchantSource+YouOwn

--- a/forge-gui/res/cardsfolder/b/bruna_light_of_alabaster.txt
+++ b/forge-gui/res/cardsfolder/b/bruna_light_of_alabaster.txt
@@ -6,12 +6,12 @@ K:Flying
 K:Vigilance
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ Aurify | TriggerDescription$ Whenever CARDNAME attacks or blocks, you may attach to it any number of Auras on the battlefield and you may put onto the battlefield attached to it any number of Aura cards that could enchant it from your graveyard and/or hand.
 T:Mode$ Blocks | ValidCard$ Card.Self | Execute$ Aurify | Secondary$ True | TriggerDescription$ Whenever CARDNAME attacks or blocks, you may attach to it any number of Auras on the battlefield and you may put onto the battlefield attached to it any number of Aura cards that could enchant it from your graveyard and/or hand.
-SVar:Aurify:DB$ RepeatEach | RepeatSubAbility$ BrunaAttach | RepeatCards$ Aura.CanEnchantSource+!Attached | SubAbility$ ZoneAuras
+SVar:Aurify:DB$ RepeatEach | RepeatSubAbility$ BrunaAttach | RepeatCards$ Aura.CanEnchantSource+NotAttachedTo | SubAbility$ ZoneAuras
 SVar:BrunaAttach:DB$ Attach | Object$ Remembered | Defined$ Self | Optional$ True
 SVar:ZoneAuras:DB$ ChangeZone | Origin$ Hand,Graveyard | Destination$ Battlefield | ChangeType$ Aura.CanEnchantSource+YouOwn | AttachedTo$ Self | ChangeNum$ CountAuras | Optional$ True | Hidden$ True
 SVar:CountAuras:Count$ValidHand,Graveyard Aura.CanEnchantSource+YouOwn
 SVar:HasAttackEffect:TRUE
 SVar:HasBlockEffect:TRUE
-DeckNeeds:Type$Aura
 DeckHas:Ability$Graveyard
+DeckNeeds:Type$Aura
 Oracle:Flying, vigilance\nWhenever Bruna, Light of Alabaster attacks or blocks, you may attach to it any number of Auras on the battlefield and you may put onto the battlefield attached to it any number of Aura cards that could enchant it from your graveyard and/or hand.

--- a/forge-gui/res/cardsfolder/b/burakos_party_leader.txt
+++ b/forge-gui/res/cardsfolder/b/burakos_party_leader.txt
@@ -8,7 +8,7 @@ T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ Tr
 SVar:TrigLoseLife:DB$ LoseLife | Defined$ TriggeredDefendingPlayer | LifeAmount$ X | SubAbility$ DBTreasureTokens
 SVar:DBTreasureTokens:DB$ Token | TokenAmount$ X | TokenScript$ c_a_treasure_sac | TokenOwner$ You
 SVar:X:Count$Party
-DeckHints:Ability$Party & Type$Cleric|Rogue|Warrior|Wizard
 SVar:PlayMain1:TRUE
+DeckHints:Ability$Party & Type$Cleric|Rogue|Warrior|Wizard
 DeckHas:Ability$Token|Sacrifice & Type$Cleric|Rogue|Warrior|Wizard|Treasure|Artifact
 Oracle:Burakos, Party Leader is also a Cleric, Rogue, Warrior, and Wizard.\nWhenever Burakos attacks, defending player loses X life and you create X Treasure tokens, where X is the number of creatures in your party.\nChoose a Background

--- a/forge-gui/res/cardsfolder/b/byrke_long_ear_of_the_law.txt
+++ b/forge-gui/res/cardsfolder/b/byrke_long_ear_of_the_law.txt
@@ -7,7 +7,7 @@ T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.S
 SVar:TrigPutCounters:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ 1 | TargetMin$ 0 | TargetMax$ 2 | ValidTgts$ Creature | TgtPrompt$ Select up to two target creatures
 T:Mode$ Attacks | ValidCard$ Creature.YouCtrl+counters_GE1_P1P1 | Execute$ TrigDoubleCounters | TriggerZones$ Battlefield | TriggerDescription$ Whenever a creature you control with a +1/+1 counter on it attacks, double the number of +1/+1 counters on it.
 SVar:TrigDoubleCounters:DB$ MultiplyCounter | Defined$ TriggeredAttackerLKICopy | CounterType$ P1P1
+SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Counters
 DeckHints:Ability$Counters
-SVar:HasAttackEffect:TRUE
 Oracle:Vigilance\nWhen Byrke, Long Ear of the Law enters, put a +1/+1 counter on each of up to two target creatures.\nWhenever a creature you control with a +1/+1 counter on it attacks, double the number of +1/+1 counters on it.


### PR DESCRIPTION
Continuing the work started on https://github.com/Card-Forge/forge/pull/6294 , this time focusing on various tagging lines (`SVar:`, `AI:`, `Deck*:`).