### PR TITLE
Adventure: Reward Scene Sort by Rarity

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/scene/RewardScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/RewardScene.java
@@ -26,6 +26,7 @@ import forge.item.PaperCard;
 import forge.sound.SoundEffectType;
 import forge.sound.SoundSystem;
 import forge.util.ItemPool;
+import java.util.Comparator;
 
 /**
  * Displays the rewards of a fight or a treasure
@@ -318,6 +319,14 @@ public class RewardScene extends UIScene {
     }
 
     public void loadRewards(Array<Reward> newRewards, Type type, ShopActor shopActor) {
+        // Sort the rewards based on the rarity of the card inside the reward/ lets give items rarity
+        newRewards.sort(Comparator.comparing(reward -> {
+            if (reward.getCard() != null && reward.getCard().getRarity() != null) {
+                return reward.getCard().getRarity().ordinal();
+            }
+            // Return a default value or handle the case where rarity is not present
+            return Integer.MAX_VALUE; // Assuming higher values mean less priority in sorting
+        }));
         clearSelectable();
         this.type = type;
         doneClicked = false;


### PR DESCRIPTION
Minor change to sort by rarity. This improves booster pack QoL as well as general shop browsing. It also improves monster loot viewing.
It does check to make sure it's a card, it doesn't affect the capital stores.

Mostly done for booster packs, because it's closer to opening boosters IRL then a pile.

I feel capital stores should organize the Heart and Teleport first, we could sort by cost as a fall back and that would go here.