### PR TITLE
Grant abilities based on mana cost even if a card doesn't have one not just for Flashback

### DIFF
--- a/forge-core/src/main/java/forge/card/mana/ManaCost.java
+++ b/forge-core/src/main/java/forge/card/mana/ManaCost.java
@@ -42,7 +42,7 @@ public final class ManaCost implements Comparable<ManaCost>, Iterable<ManaCostSh
 
     private List<ManaCostShard> shards;
     private final int genericCost;
-    private final boolean hasNoCost; // lands cost
+    private boolean hasNoCost = true; // lands cost
     private String stringValue; // precalculated for toString;
 
     private Float compareWeight = null;
@@ -92,8 +92,8 @@ public final class ManaCost implements Comparable<ManaCost>, Iterable<ManaCostSh
      */
     public ManaCost(final IParserManaCost parser) {
         final List<ManaCostShard> shardsTemp = Lists.newArrayList();
-        this.hasNoCost = false;
         while (parser.hasNext()) {
+            this.hasNoCost = false;
             final ManaCostShard shard = parser.next();
             if (shard != null && shard != ManaCostShard.GENERIC) {
                 shardsTemp.add(shard);
@@ -281,6 +281,9 @@ public final class ManaCost implements Comparable<ManaCost>, Iterable<ManaCostSh
      * @return
      */
     public String getShortString() {
+        if (isNoCost()) {
+            return "-1";
+        }
     	StringBuilder sb = new StringBuilder();
         int generic = getGenericCost();
         if (this.isZero()) {

--- a/forge-core/src/main/java/forge/card/mana/ManaCostParser.java
+++ b/forge-core/src/main/java/forge/card/mana/ManaCostParser.java
@@ -54,7 +54,7 @@ public class ManaCostParser implements IParserManaCost {
      */
     @Override
     public final boolean hasNext() {
-        return this.nextToken < this.cost.length;
+        return this.nextToken < this.cost.length && !this.cost[this.nextToken].equals("-1");
     }
 
     /*

--- a/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
@@ -2740,6 +2740,7 @@ public class AbilityUtils {
             for (Card card : cards) {
                 manaCost.add(card.getManaCost().getShortString());
             }
+            manaCost.remove(ManaCost.NO_COST.getShortString());
 
             return doXMath(manaCost.size(), expr, c, ctb);
         }

--- a/forge-game/src/main/java/forge/game/ability/effects/PlayEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PlayEffect.java
@@ -389,9 +389,6 @@ public class PlayEffect extends SpellAbilityEffect {
                     abCost = Iterables.find(tgtCard.getNonManaAbilities(), s -> s.isKeyword(Keyword.SUSPEND)).getPayCosts();
                 } else {
                     if (cost.contains("ConvertedManaCost")) {
-                        if (unpayableCost) {
-                            continue;
-                        }
                         final String costcmc = Integer.toString(tgtCard.getCMC());
                         cost = cost.replace("ConvertedManaCost", costcmc);
                     }

--- a/forge-game/src/main/java/forge/game/ability/effects/PumpEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PumpEffect.java
@@ -474,15 +474,6 @@ public class PumpEffect extends SpellAbilityEffect {
             List<String> affectedKeywords = Lists.newArrayList(keywords);
 
             if (!affectedKeywords.isEmpty()) {
-                Iterables.removeIf(affectedKeywords, input -> {
-                    if (input.contains("CardManaCost")) {
-                        if (tgtC.getManaCost().isNoCost()) {
-                            return true;
-                        }
-                    }
-                    return false;
-                });
-
                 affectedKeywords = Lists.transform(affectedKeywords, input -> {
                     if (input.contains("CardManaCost")) {
                         input = input.replace("CardManaCost", tgtC.getManaCost().getShortString());

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -1462,7 +1462,7 @@ public class CardFactoryUtil {
             final String trigStr = "Mode$ Exiled | ValidCard$ Card.Self | Madness$ True | Secondary$ True"
                     + " | TriggerDescription$ Play Madness " + ManaCostParser.parse(manacost) + " - " + card.getName();
 
-            final String playMadnessStr = "DB$ Play | Defined$ Self | PlayCost$ " + manacost +
+            final String playMadnessStr = "DB$ Play | Defined$ Self | ValidSA$ Spell | PlayCost$ " + manacost +
                     " | ConditionDefined$ Self | ConditionPresent$ Card.StrictlySelf+inZoneExile" +
                     " | Optional$ True | RememberPlayed$ True | Madness$ True";
 

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
@@ -731,9 +731,6 @@ public final class StaticAbilityContinuous {
                     final List<String> extraKeywords = Lists.newArrayList();
 
                     Iterables.removeIf(newKeywords, input -> {
-                        if (input.contains("CardManaCost") && affectedCard.getManaCost().isNoCost()) {
-                            return true;
-                        }
                         // replace one Keyword with list of keywords
                         if (input.startsWith("Protection") && input.contains("CardColors")) {
                             for (Byte color : affectedCard.getColor()) {


### PR DESCRIPTION
> If a card with no mana cost gains flashback, it has no flashback cost. It can't be cast this way.

Related to #5289