### PR TITLE
Ban Leyline of Resonance in Arena Standard archive

### DIFF
--- a/forge-gui/res/formats/Archived/Arena Standard/2024-10-22.txt
+++ b/forge-gui/res/formats/Archived/Arena Standard/2024-10-22.txt
@@ -1,0 +1,7 @@
+[format]
+Name:Arena Standard (2024-10-22)
+Type:Archived
+Subtype:Standard
+Effective:2024-10-22
+Sets:DMU, BRO, ONE, MOM, MAT, WOE, LCI, MKM, OTJ, BIG, BLB, DSK
+Banned:Leyline of Resonance


### PR DESCRIPTION
Source: https://magic.wizards.com/en/news/announcements/mtg-arena-banned-and-restricted-announcement-october-22-2024

Didn't include the suspension in Alchemy because it's not a proper "ban" and is pending a rebalance.