### PR TITLE
update: add executable permissions for .command files during installation

### DIFF
--- a/forge-installer/libs/install.xml
+++ b/forge-installer/libs/install.xml
@@ -68,14 +68,23 @@
 			<file src="forge.sh" targetdir="$INSTALL_PATH/" override="true">
 				<additionaldata key="permission.file" value="775"/>
 			</file>
+			<file src="forge.command" targetdir="$INSTALL_PATH/" override="true">
+				<additionaldata key="permission.file" value="775"/>
+			</file>
 			<file src="forge-adventure.sh" targetdir="$INSTALL_PATH/" override="true">
+				<additionaldata key="permission.file" value="775"/>
+			</file>
+			<file src="forge-adventure.command" targetdir="$INSTALL_PATH/" override="true">
 				<additionaldata key="permission.file" value="775"/>
 			</file>
 			<file src="adventure-editor.sh" targetdir="$INSTALL_PATH/" override="true">
 				<additionaldata key="permission.file" value="775"/>
 			</file>
+			<file src="adventure-editor.command" targetdir="$INSTALL_PATH/" override="true">
+				<additionaldata key="permission.file" value="775"/>
+			</file>
 			<executable stage="never" failure="ignore" keep="true">
-				<fileset targetdir="$INSTALL_PATH/" includes="forge.sh,forge-adventure.sh,adventure-editor.sh"/>
+				<fileset targetdir="$INSTALL_PATH/" includes="forge.sh,forge.command,forge-adventure.sh,forge-adventure.command,adventure-editor.sh,adventure-editor.command"/>
 			</executable>
 		</pack>
 	</packs>

--- a/forge-installer/pom.xml
+++ b/forge-installer/pom.xml
@@ -206,13 +206,16 @@
                                         <chmod file="${project.build.directory}/${project.build.finalName}/forge-adventure.exe" perm="a+rx" />
                                         <chmod file="${project.build.directory}/${project.build.finalName}/adventure-editor.exe" perm="a+rx" />
                                         <copy todir="${basedir}/target">
-                                            <fileset dir="${project.build.directory}/../../forge-gui-desktop/target" includes="forge.sh" />
-                                            <fileset dir="${project.build.directory}/../../forge-gui-mobile-dev/target" includes="forge-adventure.sh" />
-                                            <fileset dir="${project.build.directory}/../../adventure-editor/target" includes="adventure-editor.sh" />
+                                            <fileset dir="${project.build.directory}/../../forge-gui-desktop/target" includes="forge.sh,forge.command" />
+                                            <fileset dir="${project.build.directory}/../../forge-gui-mobile-dev/target" includes="forge-adventure.sh,forge-adventure.command" />
+                                            <fileset dir="${project.build.directory}/../../adventure-editor/target" includes="adventure-editor.sh,adventure-editor.command" />
                                         </copy>
                                         <chmod file="${basedir}/target/forge.sh" perm="a+rx" />
+                                        <chmod file="${basedir}/target/forge.command" perm="a+rx" />
                                         <chmod file="${basedir}/target/forge-adventure.sh" perm="a+rx" />
+                                        <chmod file="${basedir}/target/forge-adventure.command" perm="a+rx" />
                                         <chmod file="${basedir}/target/adventure-editor.sh" perm="a+rx" />
+                                        <chmod file="${basedir}/target/adventure-editor.command" perm="a+rx" />
                                         <tar destfile="${basedir}/target/${project.build.finalName}.tar.bz2" compression="bzip2">
                                             <tarfileset filemode="755" dir="${project.build.directory}/${project.build.finalName}">
                                                 <include name="forge.sh" />


### PR DESCRIPTION
Add support for .command files on macOS

Previously, macOS users would need to manually set executable permissions on .command files after using forge-installer*.jar . This PR should make .command files properly marked as executable during installation, matching the behavior of .sh files on Unix/Linux systems.

Changes:
- Updated forge-installer's install.xml to handle .command files in the Script pack section with executable permissions (chmod 775)
- Modified pom.xml copy task to ensure .command files are included in the target directory alongside their .sh counterparts
- Added .command files to the executable fileset in IzPack configuration

This allows macOS users to double-click .command files to run Forge, Forge Adventure, and the Adventure Editor immediately after installation without manual intervention.