### PR TITLE
Update urdnan_dromoka_warrior.txt

### DIFF
--- a/forge-gui/res/cardsfolder/u/urdnan_dromoka_warrior.txt
+++ b/forge-gui/res/cardsfolder/u/urdnan_dromoka_warrior.txt
@@ -2,7 +2,6 @@ Name:Urdnan, Dromoka Warrior
 ManaCost:1 W
 Types:Legendary Creature Human Warrior
 PT:1/1
-K:Flying
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPut | TriggerDescription$ When CARDNAME enters, put a +1/+1 counter on target creature.
 SVar:TrigPut:DB$ PutCounter | ValidTgts$ Creature | TgtPrompt$ Select target creature | CounterType$ P1P1
 T:Mode$ AttackersDeclared | AttackingPlayer$ You | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever you attack, target attacking creature with a +1/+1 counter on it gains first strike until end of turn. If that creature has two or more +1/+1 counters on it, it gains double strike until end of turn instead.


### PR DESCRIPTION
Removed the "Flying" keyword from Urdnan, Dromoka Warrior; this keyword does not seem to appear on the card (source: https://scryfall.com/card/j25/34/urdnan-dromoka-warrior).