### PR TITLE
Miracle&Madness: use ManaCost instead of CardManaCost

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/PlayEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PlayEffect.java
@@ -91,6 +91,7 @@ public class PlayEffect extends SpellAbilityEffect {
         final boolean forget = sa.hasParam("ForgetPlayed");
         final boolean hasTotalCMCLimit = sa.hasParam("WithTotalCMC");
         final boolean altCost = sa.hasParam("WithoutManaCost") || sa.hasParam("PlayCost");
+        final boolean altCostManaCost = "ManaCost".equals(sa.getParam("PlayCost"));
         int totalCMCLimit = Integer.MAX_VALUE;
         final Player controller;
         if (sa.hasParam("Controller")) {
@@ -345,6 +346,9 @@ public class PlayEffect extends SpellAbilityEffect {
 
             // lands will be played
             if (tgtSA.isLandAbility()) {
+                if (altCostManaCost) {
+                    continue;
+                }
                 tgtSA.resolve();
                 amount--;
                 if (remember) {
@@ -380,7 +384,7 @@ public class PlayEffect extends SpellAbilityEffect {
             } else if (sa.hasParam("PlayCost")) {
                 Cost abCost;
                 String cost = sa.getParam("PlayCost");
-                if (cost.equals("ManaCost")) {
+                if (altCostManaCost) {
                     if (unpayableCost) {
                         continue;
                     }

--- a/forge-game/src/main/java/forge/game/ability/effects/PlayEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PlayEffect.java
@@ -384,7 +384,7 @@ public class PlayEffect extends SpellAbilityEffect {
                     if (unpayableCost) {
                         continue;
                     }
-                    abCost = new Cost(source.getManaCost(), false);
+                    abCost = new Cost(tgtSA.getCardState().getManaCost(), false);
                 } else if (cost.equals("SuspendCost")) {
                     abCost = Iterables.find(tgtCard.getNonManaAbilities(), s -> s.isKeyword(Keyword.SUSPEND)).getPayCosts();
                 } else {
@@ -428,7 +428,7 @@ public class PlayEffect extends SpellAbilityEffect {
                 tgtSA.putParam("RaiseCost", raise);
             }
 
-            if (sa.hasParam("Madness")) {
+            if (sa.isKeyword(Keyword.MADNESS)) {
                 tgtSA.setAlternativeCost(AlternativeCost.Madness);
             }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/PlayEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PlayEffect.java
@@ -309,6 +309,10 @@ public class PlayEffect extends SpellAbilityEffect {
                 sas.removeIf(sp -> !sp.isValid(valid, controller , source, sa));
             }
 
+            if (altCostManaCost) {
+                sas.removeIf(sp -> sp.getPayCosts().getCostMana().getMana().isNoCost());
+            }
+
             if (hasTotalCMCLimit) {
                 Iterator<SpellAbility> it = sas.iterator();
                 while (it.hasNext()) {
@@ -346,9 +350,6 @@ public class PlayEffect extends SpellAbilityEffect {
 
             // lands will be played
             if (tgtSA.isLandAbility()) {
-                if (altCostManaCost) {
-                    continue;
-                }
                 tgtSA.resolve();
                 amount--;
                 if (remember) {
@@ -385,9 +386,6 @@ public class PlayEffect extends SpellAbilityEffect {
                 Cost abCost;
                 String cost = sa.getParam("PlayCost");
                 if (altCostManaCost) {
-                    if (unpayableCost) {
-                        continue;
-                    }
                     abCost = new Cost(tgtSA.getCardState().getManaCost(), false);
                 } else if (cost.equals("SuspendCost")) {
                     abCost = Iterables.find(tgtCard.getNonManaAbilities(), s -> s.isKeyword(Keyword.SUSPEND)).getPayCosts();

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -1460,12 +1460,17 @@ public class CardFactoryUtil {
             final String[] k = keyword.split(":");
             final String manacost = k[1];
 
-            final String trigStr = "Mode$ Exiled | ValidCard$ Card.Self | Madness$ True | Secondary$ True"
-                    + " | TriggerDescription$ Play Madness " + ManaCostParser.parse(manacost) + " - " + card.getName();
+            StringBuilder desc = new StringBuilder("Play Madness ");
+            if (!"ManaCost".equals(manacost)) {
+                desc.append(ManaCostParser.parse(manacost)).append(" ");
+            }
+            desc.append(" - " + card.getName());
+
+            final String trigStr = "Mode$ Exiled | ValidCard$ Card.Self | Secondary$ True | TriggerDescription$ " + desc.toString();
 
             final String playMadnessStr = "DB$ Play | Defined$ Self | ValidSA$ Spell | PlayCost$ " + manacost +
                     " | ConditionDefined$ Self | ConditionPresent$ Card.StrictlySelf+inZoneExile" +
-                    " | Optional$ True | RememberPlayed$ True | Madness$ True";
+                    " | Optional$ True | RememberPlayed$ True";
 
             final String moveToYardStr = "DB$ ChangeZone | Defined$ Self.StrictlySelf | Origin$ Exile" +
                     " | Destination$ Graveyard | TrackDiscarded$ True | ConditionDefined$ Remembered | ConditionPresent$ Card" +
@@ -1518,7 +1523,10 @@ public class CardFactoryUtil {
             final String manacost = k[1];
             final String abStrReveal = "DB$ Reveal | Defined$ You | RevealDefined$ Self"
                     + " | MiracleCost$ " + manacost;
-            final String abStrPlay = "DB$ Play | Defined$ Self | Optional$ True | PlayCost$ " + manacost;
+            String abStrPlay = "DB$ Play | Defined$ Self | Optional$ True | PlayCost$ " + manacost;
+            if (k.length >= 2) {
+                abStrPlay += " | PlayReduceCost$ " + k[2];
+            }
 
             String revealed = "DB$ ImmediateTrigger | TriggerDescription$ CARDNAME - Miracle";
 

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -2395,8 +2395,17 @@ public class CardFactoryUtil {
 
             inst.addReplacement(re);
         } else if (keyword.startsWith("Madness")) {
+            final String[] k = keyword.split(":");
+            final String manacost = k[1];
+
+            StringBuilder desc = new StringBuilder("Madness");
+            if (!"ManaCost".equals(manacost)) {
+                desc.append(" ").append(ManaCostParser.parse(manacost));
+            }
+            desc.append(": If you discard this card, discard it into exile.");
+
             String repeffstr = "Event$ Moved | ActiveZones$ Hand | ValidCard$ Card.Self | Discard$ True | Secondary$ True "
-                    + " | Description$ Madness: If you discard this card, discard it into exile.";
+                    + " | Description$ " + desc;
             ReplacementEffect re = ReplacementHandler.parseReplacement(repeffstr, host, intrinsic, card);
             String sVarMadness = "DB$ ChangeZone | Hidden$ True | Origin$ All | Destination$ Exile | Defined$ ReplacedCard";
 

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import forge.GameCommand;
 import forge.card.*;
-import forge.card.mana.ManaCost;
 import forge.game.Game;
 import forge.game.StaticEffect;
 import forge.game.StaticEffects;
@@ -33,7 +32,6 @@ import forge.game.card.*;
 import forge.game.cost.Cost;
 import forge.game.keyword.Keyword;
 import forge.game.keyword.KeywordInterface;
-import forge.game.mana.ManaCostBeingPaid;
 import forge.game.player.Player;
 import forge.game.player.PlayerCollection;
 import forge.game.replacement.ReplacementEffect;
@@ -744,20 +742,8 @@ public final class StaticAbilityContinuous {
                     newKeywords.addAll(extraKeywords);
 
                     newKeywords = Lists.transform(newKeywords, input -> {
-                        int reduced = 0;
-                        if (stAb.hasParam("ReduceCost")) {
-                           reduced = AbilityUtils.calculateAmount(hostCard, stAb.getParam("ReduceCost"), stAb);
-                        }
                         if (input.contains("CardManaCost")) {
-                            ManaCost cost;
-                            if (reduced > 0) {
-                                ManaCostBeingPaid mcbp = new ManaCostBeingPaid(affectedCard.getManaCost());
-                                mcbp.decreaseGenericMana(reduced);
-                                cost = mcbp.toManaCost();
-                            } else {
-                                cost = affectedCard.getManaCost();
-                            }
-                            input = input.replace("CardManaCost", cost.getShortString());
+                            input = input.replace("CardManaCost", affectedCard.getManaCost().getShortString());
                         } else if (input.contains("ConvertedManaCost")) {
                             final String costcmc = Integer.toString(affectedCard.getCMC());
                             input = input.replace("ConvertedManaCost", costcmc);

--- a/forge-game/src/main/java/forge/game/trigger/TriggerExiled.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerExiled.java
@@ -84,7 +84,7 @@ public class TriggerExiled extends Trigger {
             return false;
         }
 
-        if (hasParam("Madness")) {
+        if (isKeyword(Keyword.MADNESS)) {
             if (cause == null || !cause.isKeyword(Keyword.MADNESS)) {
                 return false;
             }

--- a/forge-game/src/main/java/forge/game/trigger/TriggerExiled.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerExiled.java
@@ -18,6 +18,7 @@
 package forge.game.trigger;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -88,7 +89,7 @@ public class TriggerExiled extends Trigger {
             if (cause == null || !cause.isKeyword(Keyword.MADNESS)) {
                 return false;
             }
-            if (getKeyword().getStatic() != null && !getKeyword().getStatic().equals(cause.getKeyword().getStatic())) {
+            if (!Objects.equals(getKeyword().getStatic(), cause.getKeyword().getStatic())) {
                 return false;
             }
         }

--- a/forge-game/src/main/java/forge/game/trigger/TriggerExiled.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerExiled.java
@@ -88,6 +88,9 @@ public class TriggerExiled extends Trigger {
             if (cause == null || !cause.isKeyword(Keyword.MADNESS)) {
                 return false;
             }
+            if (getKeyword().getStatic() != null && !getKeyword().getStatic().equals(cause.getKeyword().getStatic())) {
+                return false;
+            }
         }
 
         return true;

--- a/forge-gui/res/cardsfolder/a/aminatou_veil_piercer.txt
+++ b/forge-gui/res/cardsfolder/a/aminatou_veil_piercer.txt
@@ -4,6 +4,6 @@ Types:Legendary Creature Human Wizard
 PT:2/4
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigSurveil | TriggerDescription$ At the beginning of your upkeep, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)
 SVar:TrigSurveil:DB$ Surveil | Amount$ 2
-S:Mode$ Continuous | Affected$ Card.Enchantment+YouOwn | AffectedZone$ Hand | AddKeyword$ Miracle:CardManaCost | ReduceCost$ 4 | Description$ Each enchantment card in your hand has miracle. Its miracle cost is equal to its mana cost reduced by {4}. (You may cast a card for its miracle cost when you draw it if it's the first card you drew this turn.)
+S:Mode$ Continuous | Affected$ Card.Enchantment+YouOwn | AffectedZone$ Hand | AddKeyword$ Miracle:ManaCost:4 | Description$ Each enchantment card in your hand has miracle. Its miracle cost is equal to its mana cost reduced by {4}. (You may cast a card for its miracle cost when you draw it if it's the first card you drew this turn.)
 DeckHints:Ability$Graveyard & Type$Enchantment
 Oracle:At the beginning of your upkeep, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)\nEach enchantment card in your hand has miracle. Its miracle cost is equal to its mana cost reduced by {4}. (You may cast a card for its miracle cost when you draw it if it's the first card you drew this turn.)

--- a/forge-gui/res/cardsfolder/f/falkenrath_gorger.txt
+++ b/forge-gui/res/cardsfolder/f/falkenrath_gorger.txt
@@ -2,5 +2,5 @@ Name:Falkenrath Gorger
 ManaCost:R
 Types:Creature Vampire Berserker
 PT:2/1
-S:Mode$ Continuous | Affected$ Creature.YouOwn+Vampire | AffectedZone$ Hand,Library,Graveyard,Exile,Command,Stack | AddKeyword$ Madness:CardManaCost | Description$ Each Vampire creature card you own that isn't on the battlefield has madness. The madness cost is equal to its mana cost. (If you discard a card with madness, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)
+S:Mode$ Continuous | Affected$ Creature.YouOwn+Vampire | AffectedZone$ Hand,Library,Graveyard,Exile,Command,Stack | AddKeyword$ Madness:ManaCost | Description$ Each Vampire creature card you own that isn't on the battlefield has madness. The madness cost is equal to its mana cost. (If you discard a card with madness, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)
 Oracle:Each Vampire creature card you own that isn't on the battlefield has madness. The madness cost is equal to its mana cost. (If you discard a card with madness, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)


### PR DESCRIPTION
This fixes the Problem with Miracle and Madness not using the right value for Spells to cast.

I'm not 100% happy with PlayReduceCost yet, because i think this should reduce the cost BEFORE you choose values for X or how 2-hybrid costs are chosen.