### PR TITLE
Update ashroot_animist.txt

### DIFF
--- a/forge-gui/res/cardsfolder/a/ashroot_animist.txt
+++ b/forge-gui/res/cardsfolder/a/ashroot_animist.txt
@@ -3,7 +3,7 @@ ManaCost:2 R G
 Types:Creature Lizard Druid
 PT:4/4
 K:Trample
-T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ When this creature attacks, another target attacking creature you control gets +X/+X until end of turn, where X is this creature's power.
-SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.attacking+Other+YouCtrl | TgtPrompt$ Select another target attacking creature you control | NumAtt$ X | NumDef$ X
+T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ When this creature attacks, another target creature you control gains trample and gets +X/+X until end of turn, where X is this creature's power.
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.Other+YouCtrl | TgtPrompt$ Select another target creature you control | NumAtt$ X | NumDef$ X | KW$ Trample
 SVar:X:Count$CardPower
-Oracle:Trample\nWhen this creature attacks, another target attacking creature you control gets +X/+X until end of turn, where X is this creature's power.
+Oracle:Trample\nWhen this creature attacks, another target creature you control gains trample and gets +X/+X until end of turn, where X is this creature's power.


### PR DESCRIPTION
Added the "trample" keyword and removed the "attacking" restriction from the triggered ability, to match the actual card.

Source: https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=679194