### PR TITLE
Edition updates: DCI, INR, PMEI, PRES

### DIFF
--- a/forge-gui/res/editions/DCI Promos.txt
+++ b/forge-gui/res/editions/DCI Promos.txt
@@ -1,9 +1,10 @@
 [metadata]
-Code=PDCI
+Code=DCI
 Date=2006-01-01
 Name=DCI Promos
+Code2=PDCI
 Type=Promo
-ScryfallCode=PDCI
+ScryfallCode=DCI
 
 [cards]
 1 R Wood Elves @Rebecca Guay

--- a/forge-gui/res/editions/Innistrad Remastered.txt
+++ b/forge-gui/res/editions/Innistrad Remastered.txt
@@ -11,7 +11,7 @@ ScryfallCode=INR
 11 M Archangel Avacyn @James Ryman
 30 U Lingering Souls @Johann Bodin
 45 C Thraben Inspector @Matt Stewart
-55 R Cackling Counterpart @David Rapoza
+55 U Cackling Counterpart @David Rapoza
 59 R Deadeye Navigator @Lie Setiawan
 72 C Lantern Bearer @Zoltan Boros
 74 R Mausoleum Wanderer @Kieran Yanner
@@ -42,7 +42,7 @@ ScryfallCode=INR
 328 M Edgar Markov @Betty Jiang
 330 M Emrakul, the Promised End @Jaime Jones
 331 C It of the Horrid Swarm @Jason Felix
-353 R Cackling Counterpart @David Rapoza
+353 U Cackling Counterpart @David Rapoza
 360 R Mausoleum Wanderer @Kieran Yanner
 369 C Think Twice @Anthony Francisco
 372 U Blood Artist @LA Draws
@@ -58,7 +58,7 @@ ScryfallCode=INR
 449 M Archangel Avacyn @James Ryman
 470 R Huntmaster of the Fells @Chris Rahn
 475 M Liliana of the Veil @Steve Argyle
-478 R Snapcaster Mage @Volkan Baǵa
+478 M Snapcaster Mage @Volkan Baǵa
 481 M Emrakul, the Promised End @Josh Newton
 486 M The Meathook Massacre @James Bousema
 491 M Edgar Markov @Jack Hughes

--- a/forge-gui/res/editions/Media Inserts.txt
+++ b/forge-gui/res/editions/Media Inserts.txt
@@ -1,70 +1,70 @@
 [metadata]
 Code=PMEI
 Date=1995-01-01
-Name=Media Inserts
+Name=Media and Collaboration Promos
 Type=Promo
 ScryfallCode=PMEI
 
 [cards]
-4 C Fireball @Mark Tedin
-5 C Blue Elemental Blast @Richard Thomas
-6 R Diabolic Edict @Ron Spencer
-9 C Scent of Cinder @Carl Critchlow
-10 C Lightning Hounds @Andrew Robinson
-10★ C Jamuraan Lion @Stuart Griffin
-11 R Voltaic Key @Henry G. Higginbotham
-12 U Warmonger @Heather Hudson
-13 C Silver Drake @Alan Pollack
-14 C Phyrexian Rager @Mark Tedin
-15 R Shivan Dragon @Donato Giancola
-16 M Jace Beleren @Aleksi Briclot
-16j R Darksteel Juggernaut @Randis Albion
-17 U Cunning Sparkmage @Wayne Reynolds
-18 C Chandra's Outrage @Christopher Moeller
-19 U Chandra's Spitfire @Justin Sweet
-20 R Kuldotha Phoenix @Mike Bierek
-21 U Phantasmal Dragon @Wayne Reynolds
-22 C Sandbar Crocodile @Una Fricker
-23 C Zhalfirin Knight @John Bolton
-24 C Shrieking Drake @Ian Miller
-25 C Stream of Life @Terese Nielsen
-26 R Thorn Elemental @rk post
-27 C Parallax Dementia @Eric Peterson
-28 R Ascendant Evincar @Mark Zug
-29 R Archangel @Donato Giancola
-30 U Cast Down @Ittoku
-31 R Diabolic Edict @Ron Spencer
-32 R Shock @Randy Gallegos
-33 U Lava Coil @Wesley Burt & コーヘー
-34 R Duress @Lawrence Snelly
-35 R Voltaic Key @Henry G. Higginbotham
-36 U Daxos, Blessed by the Sun @Lius Lasahido
-37 R Staggering Insight @Dmitry Burmak
-38 R Dark Ritual @Tom Fleming
-39 R Sprite Dragon @Gabor Szikszai
-40 R Hypnotic Sprite @Irina Nordsol
-41 R Heliod's Pilgrim @Micah Epstein
-42 R Crop Rotation @DiTerlizzi
-43 R Tangled Florahedron @Randy Vargas
-44 R Counterspell @Hannibal King
-45 R Bone Shredder @Ron Spencer
-46 R Disenchant @Allen Williams
-47 R Wild Growth @Pat Lewis
-48 R Harald, King of Skemfar @Grzegorz Rutkowski
-49 R Usher of the Fallen @Anastasia Ovchinnikova
-50 R Frantic Search @Jeff Miracola
-51 R Mental Misstep @Erica Yang
-52 R Worn Powerstone @Henry G. Higginbotham
-53 R Gingerbrute @Vincent Proce
-54 R Ruin Crab @Simon Dominic
-55 R Avalanche Riders @Lake Hurwitz
-56 R Pyromancer's Gauntlet @Magali Villeneuve
-57 R Culling the Weak @Scott M. Fischer
-58 R Winged Boots @Filipe Pagliuso
-60 C Talruum Champion @Pete Venters
-61 C Shield Wall @Scott Kirschner
-63 R Snuff Out @Mike Ploog
-67 R Gush @Kev Walker
-80 M Jace, Memory Adept @D. Alexander Gregory
-81 M Ajani, Mentor of Heroes @Aaron Miller
-121 C Spined Wurm @Keith Parkinson
+19951 C Fireball @Mark Tedin
+19952 C Blue Elemental Blast @Richard Thomas
+19961 C Sandbar Crocodile @Una Fricker
+19962 C Zhalfirin Knight @John Bolton
+19963 C Jamuraan Lion @Stuart Griffin
+19971 C Talruum Champion @Pete Venters
+19972 C Shrieking Drake @Ian Miller
+19973 C Shield Wall @Scott Kirschner
+19974 C Stream of Life @Terese Nielsen
+19991 C Scent of Cinder @Carl Critchlow
+19992 U Warmonger @Heather Hudson
+20001 C Lightning Hounds @Andrew Robinson
+20002 C Silver Drake @Alan Pollack
+20003 R Thorn Elemental @rk post
+20004 R Archangel @Donato Giancola
+20005 C Phyrexian Rager @Mark Tedin
+20006 C Parallax Dementia @Eric Peterson
+20007 R Ascendant Evincar @Mark Zug
+20011 C Spined Wurm @Keith Parkinson
+20012 R Shivan Dragon @Donato Giancola
+20091 M Jace Beleren @Aleksi Briclot
+20101 R Darksteel Juggernaut @Randis Albion
+20102 U Cunning Sparkmage @Wayne Reynolds
+20103 C Chandra's Outrage @Christopher Moeller
+20104 U Chandra's Spitfire @Justin Sweet
+20105 R Kuldotha Phoenix @Mike Bierek
+20111 U Phantasmal Dragon @Wayne Reynolds
+20191 U Cast Down @Ittoku
+20192 R Diabolic Edict @Ron Spencer
+20193 R Shock @Randy Gallegos
+20194 U Lava Coil @Wesley Burt & コーヘー
+20195 R Hypnotic Sprite @Irina Nordsol
+20196 R Duress @Lawrence Snelly
+20201 R Voltaic Key @Henry G. Higginbotham
+20202 U Daxos, Blessed by the Sun @Lius Lasahido
+20203 R Staggering Insight @Dmitry Burmak
+20204 R Dark Ritual @Tom Fleming
+20205 R Sprite Dragon @Gabor Szikszai
+20206 R Heliod's Pilgrim @Micah Epstein
+20207 R Crop Rotation @DiTerlizzi
+20208 U Tangled Florahedron @Randy Vargas
+20211 R Counterspell @Hannibal King
+20212 R Bone Shredder @Ron Spencer
+20213 R Harald, King of Skemfar @Grzegorz Rutkowski
+20221 R Disenchant @Allen Williams
+20222 R Wild Growth @Pat Lewis
+20223 R Usher of the Fallen @Anastasia Ovchinnikova
+20224 R Frantic Search @Jeff Miracola
+20231 R Mental Misstep @Erica Yang
+20232 R Worn Powerstone @Henry G. Higginbotham
+20233 R Gingerbrute @Vincent Proce
+20234 R Ruin Crab @Simon Dominic
+20235 R Avalanche Riders @Lake Hurwitz
+20236 R Pyromancer's Gauntlet @Magali Villeneuve
+20237 R Winged Boots @Filipe Pagliuso
+20238 R Culling the Weak @Scott M. Fischer
+20241 R Snuff Out @Mike Ploog
+20242 M Jace, Memory Adept @D. Alexander Gregory
+20243 M Ajani, Mentor of Heroes @Aaron Miller
+20244 R Gush @Kev Walker
+20245 R Diabolic Edict @Ron Spencer
+20246 R Voltaic Key @Henry G. Higginbotham

--- a/forge-gui/res/editions/Resale Promos.txt
+++ b/forge-gui/res/editions/Resale Promos.txt
@@ -6,48 +6,51 @@ Type=Promo
 ScryfallCode=PRES
 
 [cards]
-1 R Llanowar Elves @Chris Rahn
-2 M Lathril, Blade of the Elves @Caroline Gariba
-2b M Jace, Memory Adept @D. Alexander Gregory
-9 M Ajani, Mentor of Heroes @Aaron Miller
-13★ U Loam Lion @Daniel Ljunggren
-26 R Felidar Sovereign @Zoltan Boros & Gabor Szikszai
-46 R Welcoming Vampire @Lorenzo Mastroianni
-47 R Thalia's Lancers @David Palumbo
-49 R Curator of Mysteries @Christine Choi
-52 R Cyclone Summoner @Andrey Kuzinskiy
-69 R Patrician Geist @Marta Nael
-100 R Etali, Primal Storm @Raymond Swanland
-118 R Headless Rider @E. M. Gist
-123 R Beast Whisperer @Matt Stewart
-124 R End-Raze Forerunners @Mathias Kollros
-125 R Calamity Bearer @Simon Dominic
-127 R Vito, Thorn of the Dusk Rose @Lie Setiawan
-133 R Opportunistic Dragon @Chris Rahn
-140 R Neheb, Dreadhorde Champion @Igor Kieryluk
-141★ R Goblin Chieftain @Sam Wood
-147 R Bristling Hydra @Chris Rahn
-149 R Atarka, World Render @Karl Kopinski
-149★ R Lathliss, Dragon Queen @Alex Konstad
-162 R Kogla, the Titan Ape @Chris Rahn
-172 R Gargos, Vicious Watcher @Mathias Kollros
-176 R Genesis Hydra @Peter Mohrbacher
-193 R Outland Colossus @Ryan Pancoast
-203 R Scute Swarm @Alex Konstad
-221★ R Oran-Rief, the Vastwood @Mike Bierek
-235 R Stonecoil Serpent @Mark Poole
-235★ R Nyx Lotus @Raoul Vitale
-374 R Valkyrie Harbinger @Tran Nguyen
-376 R Cleaving Reaper @Victor Adame Minguez
-A1 R Jaya Ballard, Task Mage @Matt Cavotta
-A2 R Brion Stoutarm @Zoltan Boros & Gabor Szikszai
-A3 R Broodmate Dragon @Vance Kovacs
-A4 R Retaliator Griffin @Jesper Ejsing
-A5 R Terra Stomper @Goran Josic
-A6 R Terastodon @Lars Grant-West
-A7 R Knight Exemplar @Jason Chan
-A8 R Sunblast Angel @Jason Chan
-A9 R Angel of Glory's Rise @James Ryman
-A10 R Hamletback Goliath @Paolo Parente & Brian Snõddy
-A11 R Angelic Skirmisher @David Rapoza
-A12 R Xathrid Necromancer @Maciej Kuciara
+1 R Angel of Glory's Rise @James Ryman
+2 R Angelic Skirmisher @David Rapoza
+3 R Felidar Sovereign @Zoltan Boros & Gabor Szikszai
+4 R Knight Exemplar @Jason Chan
+5 U Loam Lion @Daniel Ljunggren
+6 R Sunblast Angel @Jason Chan
+7 R Thalia's Lancers @David Palumbo
+8 R Valkyrie Harbinger @Tran Nguyen
+9 R Welcoming Vampire @Lorenzo Mastroianni
+10 R Curator of Mysteries @Christine Choi
+11 R Cyclone Summoner @Andrey Kuzinskiy
+12 R Patrician Geist @Marta Nael
+13 R Cleaving Reaper @Victor Adame Minguez
+14 R Headless Rider @E. M. Gist
+15 R Vito, Thorn of the Dusk Rose @Lie Setiawan
+16 R Xathrid Necromancer @Maciej Kuciara
+17 R Calamity Bearer @Simon Dominic
+18 R Etali, Primal Storm @Raymond Swanland
+19 R Goblin Chieftain @Sam Wood
+20 R Goro-Goro, Disciple of Ryusei @Mike Jordana
+21 R Hamletback Goliath @Paolo Parente & Brian Snõddy
+22 R Jaya Ballard, Task Mage @Matt Cavotta
+23 R Lathliss, Dragon Queen @Alex Konstad
+24 R Neheb, Dreadhorde Champion @Igor Kieryluk
+25 R Opportunistic Dragon @Chris Rahn
+26 R Beast Whisperer @Matt Stewart
+27 R Bristling Hydra @Chris Rahn
+28 R End-Raze Forerunners @Mathias Kollros
+29 R Gargos, Vicious Watcher @Mathias Kollros
+30 R Genesis Hydra @Peter Mohrbacher
+31 R Kogla, the Titan Ape @Chris Rahn
+32 R Llanowar Elves @Chris Rahn
+33 R Outland Colossus @Ryan Pancoast
+34 R Saryth, the Viper's Fang @Igor Kieryluk
+35 R Scute Swarm @Alex Konstad
+36 R Terastodon @Lars Grant-West
+37 R Terra Stomper @Goran Josic
+38 R Atarka, World Render @Karl Kopinski
+39 R Brion Stoutarm @Zoltan Boros & Gabor Szikszai
+40 R Broodmate Dragon @Vance Kovacs
+41 M Lathril, Blade of the Elves @Caroline Gariba
+42 R Liesa, Forgotten Archangel @Dmitry Burmak
+43 R Park Heights Pegasus @Randy Gallegos
+44 R Raiyuu, Storm's Edge @Heonhwa Choe
+45 R Retaliator Griffin @Jesper Ejsing
+46 R Nyx Lotus @Raoul Vitale
+47 R Stonecoil Serpent @Mark Poole
+48 R Oran-Rief, the Vastwood @Mike Bierek


### PR DESCRIPTION
See image below for Scryfall changes:

- Instead of deleting PRES (which would cause problems with quest mode etc,) I have updated the edition and audited the images on the ftp.
- PMEI has been renumbered and audited the images on the ftp.
- JP1 did not already exist in Forge and has no unique artwork so did not include.
- DCI set code updated from PDCI.

![Discord_8DwI3Rm3OR](https://github.com/user-attachments/assets/a59670c6-ec0e-4c18-96d7-740affba8e12)