### PR TITLE
fix: Add Set Codes to Commander Pre Cons

### DIFF
--- a/forge-gui/res/quest/commanderprecons/Adaptive Enchantment [C18] [2018].dck
+++ b/forge-gui/res/quest/commanderprecons/Adaptive Enchantment [C18] [2018].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Adaptive Enchantment [C18] [2018]
+Set=C18
 [Commander]
 1 Estrid, the Masked|C18|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Ahoy Mateys [LCC] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Ahoy Mateys [LCC] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Ahoy Mateys [LCC] [2023]
+Set=LCC
 [Commander]
 1 Admiral Brass, Unsinkable|LCC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Angels They're Just Like Us, but Cooler and with Wings [SLD] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Angels They're Just Like Us, but Cooler and with Wings [SLD] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Angels: They're Just Like Us, but Cooler and with Wings [SLD] [2023]
+Set=SLD
 [Commander]
 1 Bruna, the Fading Light|SLD|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Animated Army [BLC] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Animated Army [BLC] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Animated Army [BLC] [2024]
+Set=BLC
 [Commander]
 1 Bello, Bard of the Brambles|BLC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Arcane Maelstrom [C20] [2020].dck
+++ b/forge-gui/res/quest/commanderprecons/Arcane Maelstrom [C20] [2020].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Arcane Maelstrom [C20] [2020]
+Set=C20
 [commander]
 1 Kalamax, the Stormsire+|C20
 [main]

--- a/forge-gui/res/quest/commanderprecons/Arcane Wizardry [C17] [2017].dck
+++ b/forge-gui/res/quest/commanderprecons/Arcane Wizardry [C17] [2017].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Arcane Wizardry [C17] [2017]
+Set=C17
 [Commander]
 1 Inalla, Archmage Ritualist|C17
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Arm for Battle [CMR] [2020].dck
+++ b/forge-gui/res/quest/commanderprecons/Arm for Battle [CMR] [2020].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Arm for Battle [CMR] [2020]
+Set=CMR
 [commander]
 1 Wyleth, Soul of Steel+|CMR
 [main]

--- a/forge-gui/res/quest/commanderprecons/Aura of Courage [AFC] [2021].dck
+++ b/forge-gui/res/quest/commanderprecons/Aura of Courage [AFC] [2021].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Aura of Courage [AFC] [2021]
+Set=AFC
 [commander]
 1 Galea, Kindler of Hope+|AFC
 [main]

--- a/forge-gui/res/quest/commanderprecons/Bedecked Brokers [NCC] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Bedecked Brokers [NCC] [2022].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Bedecked Brokers [NCC] [2022]
+Set=NCC
 [Commander]
 1 Perrie, the Pulverizer|NCC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Blame Game [MKC] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Blame Game [MKC] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Blame Game [MKC] [2024]
+Set=MKC
 [Commander]
 1 Nelly Borca, Impulsive Accuser|MKC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Blast from the Past [WHO] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Blast from the Past [WHO] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Blast from the Past [WHO] [2023]
+Set=WHO
 [Commander]
 1 The Fourth Doctor|WHO|1
 1 Sarah Jane Smith|WHO|1

--- a/forge-gui/res/quest/commanderprecons/Blood Rites [LCC] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Blood Rites [LCC] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Blood Rites [LCC] [2023]
+Set=LCC
 [Commander]
 1 Clavileño, First of the Blessed|LCC|3
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Breed Lethality [C16] [2016].dck
+++ b/forge-gui/res/quest/commanderprecons/Breed Lethality [C16] [2016].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Breed Lethality [C16] [2016]
+Set=C16
 [Commander]
 1 Atraxa, Praetors' Voice+|C16
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Breed Lethality [CM2] [2018].dck
+++ b/forge-gui/res/quest/commanderprecons/Breed Lethality [CM2] [2018].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Breed Lethality [CM2] [2018]
+Set=CM2
 [Commander]
 1 Atraxa, Praetors' Voice+|CM2
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Buckle Up [NEC] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Buckle Up [NEC] [2022].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Buckle Up [NEC] [2022]
+Set=NEC
 [Commander]
 1 Kotori, Pilot Prodigy|NEC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Built from Scratch [C14] [2014].dck
+++ b/forge-gui/res/quest/commanderprecons/Built from Scratch [C14] [2014].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Built from Scratch [C14] [2014]
+Set=C14
 [Commander]
 1 Daretti, Scrap Savant|C14
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Built from Scratch [CM2] [2018].dck
+++ b/forge-gui/res/quest/commanderprecons/Built from Scratch [CM2] [2018].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Built from Scratch [CM2] [2018]
+Set=CM2
 [Commander]
 1 Daretti, Scrap Savant+|CM2
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Cabaretti Cacophony [NCC] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Cabaretti Cacophony [NCC] [2022].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Cabaretti Cacophony [NCC] [2022]
+Set=NCC
 [Commander]
 1 Kitt Kanto, Mayhem Diva|NCC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Call for Backup [MOC] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Call for Backup [MOC] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Call for Backup [MOC] [2023]
+Set=MOC
 [Commander]
 1 Bright-Palm, Soul Awakener|MOC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Call the Spirits [C15] [2015].dck
+++ b/forge-gui/res/quest/commanderprecons/Call the Spirits [C15] [2015].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Call the Spirits [C15] [2015]
+Set=C15
 Description=Daxos the Returned travels across Theros in a never-ending search, surrounded by spirits that are drawn to his power. As mighty enchantments enter the battlefield, the spirits he summons grow larger and larger, leaving his enemies overwhelmed.
 [Commander]
 1 Daxos the Returned+|C15

--- a/forge-gui/res/quest/commanderprecons/Cavalry Charge [MOC] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Cavalry Charge [MOC] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Cavalry Charge [MOC] [2023]
+Set=MOC
 [Commander]
 1 Sidar Jabari of Zhalfir|MOC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Chaos Incarnate [SCD] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Chaos Incarnate [SCD] [2022].dck
@@ -1,5 +1,6 @@
 [metadata]
 name=Chaos Incarnate [SCD] [2022]
+Set=SCD
 [Commander]
 1 Kardur, Doomscourge|SCD|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Corrupting Influence [ONC] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Corrupting Influence [ONC] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 name=Corrupting Influence [ONC] [2023]
+Set=ONC
 [Commander]
 1 Ixhel, Scion of Atraxa|ONC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Counterpunch [COM] [2011].dck
+++ b/forge-gui/res/quest/commanderprecons/Counterpunch [COM] [2011].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Counterpunch [COM] [2011]
+Set=COM
 [Commander]
 1 Ghave, Guru of Spores|COM
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Coven Counters [MIC] [2021].dck
+++ b/forge-gui/res/quest/commanderprecons/Coven Counters [MIC] [2021].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Coven Counters [MIC] [2021]
+Set=MIC
 [commander]
 1 Leinore, Autumn Sovereign+|MIC
 [main]

--- a/forge-gui/res/quest/commanderprecons/Creative Energy [M3C] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Creative Energy [M3C] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Creative Energy [M3C] [2024]
+Set=M3C
 [Commander]
 1 Satya, Aetherflux Genius|M3C|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Deadly Disguise [MKC] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Deadly Disguise [MKC] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Deadly Disguise [MKC] [2024]
+Set=MKC
 [Commander]
 1 Kaust, Eyes of the Glade|MKC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Death Toll [DSC] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Death Toll [DSC] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Death Toll [DSC] [2024]
+Set=DSC
 [Commander]
 1 Winter, Cynical Opportunist|DSC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Deep Clue Sea [MKC] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Deep Clue Sea [MKC] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Deep Clue Sea [MKC] [2024]
+Set=MKC
 [Commander]
 1 Morska, Undersea Sleuth|MKC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Desert Bloom [OTC] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Desert Bloom [OTC] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Desert Bloom [OTC] [2024]
+Set=OTC
 [Commander]
 1 Yuma, Proud Protector|OTC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Devour for Power [CM2] [2018].dck
+++ b/forge-gui/res/quest/commanderprecons/Devour for Power [CM2] [2018].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Devour for Power [CM2] [2018]
+Set=CM2
 [Commander]
 1 The Mimeoplasm+|CM2
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Devour for Power [COM] [2011].dck
+++ b/forge-gui/res/quest/commanderprecons/Devour for Power [COM] [2011].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Devour for Power [COM] [2011]
+Set=COM
 [Commander]
 1 The Mimeoplasm|COM
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Divine Convocation [MOC] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Divine Convocation [MOC] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Divine Convocation [MOC] [2023]
+Set=MOC
 [Commander]
 1 Kasla, the Broken Halo|MOC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Draconic Destruction [SCD] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Draconic Destruction [SCD] [2022].dck
@@ -1,5 +1,6 @@
 [metadata]
 name=Draconic Destruction [SCD] [2022]
+Set=SCD
 [Commander]
 1 Atarka, World Render|SCD|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Draconic Dissent [CLB] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Draconic Dissent [CLB] [2022].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Draconic Dissent [CLB] [2022]
+Set=CLB
 [Commander]
 1 Firkraag, Cunning Instigator|CLB|2
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Draconic Domination [C17] [2017].dck
+++ b/forge-gui/res/quest/commanderprecons/Draconic Domination [C17] [2017].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Draconic Domination [C17] [2017]
+Set=C17
 [Commander]
 1 The Ur-Dragon|C17
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Draconic Rage [AFC] [2021].dck
+++ b/forge-gui/res/quest/commanderprecons/Draconic Rage [AFC] [2021].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Draconic Rage [AFC] [2021]
+Set=AFC
 [commander]
 1 Vrondiss, Rage of Ancients+|AFC
 [main]

--- a/forge-gui/res/quest/commanderprecons/Dungeons of Death [AFC] [2021].dck
+++ b/forge-gui/res/quest/commanderprecons/Dungeons of Death [AFC] [2021].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Dungeons of Death [AFC] [2021]
+Set=AFC
 [commander]
 1 Sefris of the Hidden Ways+|AFC
 [main]

--- a/forge-gui/res/quest/commanderprecons/Eldrazi Incursion [M3C] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Eldrazi Incursion [M3C] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Eldrazi Incursion [M3C] [2024]
+Set=M3C
 [Commander]
 1 Ulalek, Fused Atrocity|M3C|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Eldrazi Unbound [CMM] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Eldrazi Unbound [CMM] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Eldrazi Unbound [CMM] [2023]
+Set=CMM
 [Commander]
 1 Zhulodok, Void Gorger|CMM|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Elven Council [LTC] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Elven Council [LTC] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Elven Council [LTC] [2023]
+Set=LTC
 [Commander]
 1 Galadriel, Elven-Queen|LTC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Elven Empire [KHC] [2021].dck
+++ b/forge-gui/res/quest/commanderprecons/Elven Empire [KHC] [2021].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Elven Empire [KHC] [2021]
+Set=KHC
 [commander]
 1 Lathril, Blade of the Elves+|KHC
 [main]

--- a/forge-gui/res/quest/commanderprecons/Endless Punishment [DSC] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Endless Punishment [DSC] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Endless Punishment [DSC] [2024]
+Set=DSC
 [Commander]
 1 Valgavoth, Harrower of Souls|DSC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Enduring Enchantments [CMM] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Enduring Enchantments [CMM] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Enduring Enchantments [CMM] [2023]
+Set=CMM
 [Commander]
 1 Anikthea, Hand of Erebos|CMM|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Enhanced Evolution [C20] [2020].dck
+++ b/forge-gui/res/quest/commanderprecons/Enhanced Evolution [C20] [2020].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Enhanced Evolution [C20] [2020]
+Set=C20
 [commander]
 1 Otrimi, the Ever-Playful+|C20
 [main]

--- a/forge-gui/res/quest/commanderprecons/Entropic Uprising [C16] [2016].dck
+++ b/forge-gui/res/quest/commanderprecons/Entropic Uprising [C16] [2016].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Entropic Uprising [C16] [2016]
+Set=C16
 [Commander]
 1 Yidris, Maelstrom Wielder+|C16
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Eternal Bargain [C13] [2013].dck
+++ b/forge-gui/res/quest/commanderprecons/Eternal Bargain [C13] [2013].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Eternal Bargain [C13] [2013]
+Set=C13
 [Commander]
 1 Oloro, Ageless Ascetic|C13
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Evasive Maneuvers [C13] [2013].dck
+++ b/forge-gui/res/quest/commanderprecons/Evasive Maneuvers [C13] [2013].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Evasive Maneuvers [C13] [2013]
+Set=C13
 [Commander]
 1 Derevi, Empyrial Tactician|C13
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Evasive Maneuvers [CMA] [2017].dck
+++ b/forge-gui/res/quest/commanderprecons/Evasive Maneuvers [CMA] [2017].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Evasive Maneuvers [CMA] [2017]
+Set=CMA
 [Commander]
 1 Derevi, Empyrial Tactician|CMA
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Exit from Exile [CLB] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Exit from Exile [CLB] [2022].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Exit from Exile [CLB] [2022]
+Set=CLB
 [Commander]
 1 Faldorn, Dread Wolf Herald|CLB|2
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Explorers of the Deep [LCC] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Explorers of the Deep [LCC] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Explorers of the Deep [LCC] [2023]
+Set=LCC
 [Commander]
 1 Hakbal of the Surging Soul|LCC|4
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Exquisite Invention [C18] [2018].dck
+++ b/forge-gui/res/quest/commanderprecons/Exquisite Invention [C18] [2018].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Exquisite Invention [C18] [2018]
+Set=C18
 [Commander]
 1 Saheeli, the Gifted|C18|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Faceless Menace [C19] [2019].dck
+++ b/forge-gui/res/quest/commanderprecons/Faceless Menace [C19] [2019].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Faceless Menace [C19] [2019]
+Set=C19
 [Commander]
 1 Kadena, Slinking Sorcerer|C19|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Fae Dominion [WOC] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Fae Dominion [WOC] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Fae Dominion [WOC] [2023]
+Set=WOC
 [Commander]
 1 Tegwyll, Duke of Splendor|WOC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Family Matters [BLC] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Family Matters [BLC] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Family Matters [BLC] [2024]
+Set=BLC
 [Commander]
 1 Zinnia, Valley's Voice|BLC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Feline Ferocity [C17] [2017].dck
+++ b/forge-gui/res/quest/commanderprecons/Feline Ferocity [C17] [2017].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Feline Ferocity [C17] [2017]
+Set=C17
 [Commander]
 1 Arahbo, Roar of the World|C17
 [Main]

--- a/forge-gui/res/quest/commanderprecons/First Flight [SCD] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/First Flight [SCD] [2022].dck
@@ -1,5 +1,6 @@
 [metadata]
 name=First Flight [SCD] [2022]
+Set=SCD
 [Commander]
 1 Isperia, Supreme Judge|SCD|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Food and Fellowship [LTC] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Food and Fellowship [LTC] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Food and Fellowship [LTC] [2023]
+Set=LTC
 [Commander]
 1 Frodo, Adventurous Hobbit|LTC|1
 1 Sam, Loyal Attendant|LTC|1

--- a/forge-gui/res/quest/commanderprecons/Forces of the Imperium [40K] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Forces of the Imperium [40K] [2022].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Forces of the Imperium [40K] [2022]
+Set=40K
 [Commander]
 1 Inquisitor Greyfax|40K|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Forged in Stone [C14] [2014].dck
+++ b/forge-gui/res/quest/commanderprecons/Forged in Stone [C14] [2014].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Forged in Stone [C14] [2014]
+Set=C14
 [Commander]
 1 Nahiri, the Lithomancer|C14
 [Main]

--- a/forge-gui/res/quest/commanderprecons/From Cute to Brute [SLD] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/From Cute to Brute [SLD] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=From Cute to Brute [SLD] [2023]
+Set=SLD
 [Commander]
 1 Esika, God of the Tree|SLD|2
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Grand Larceny [OTC] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Grand Larceny [OTC] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Grand Larceny [OTC] [2024]
+Set=OTC
 [Commander]
 1 Gonti, Canny Acquisitor|OTC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Grave Danger [SCD] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Grave Danger [SCD] [2022].dck
@@ -1,5 +1,6 @@
 [metadata]
 name=Grave Danger [SCD] [2022]
+Set=SCD
 [Commander]
 1 Gisa and Geralf|SCD|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Graveyard Overdrive [M3C] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Graveyard Overdrive [M3C] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Graveyard Overdrive [M3C] [2024]
+Set=M3C
 [Commander]
 1 Disa the Restless|M3C|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Growing Threat [MOC] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Growing Threat [MOC] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Growing Threat [MOC] [2023]
+Set=MOC
 [Commander]
 1 Brimaz, Blight of Oreskos|MOC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Guided by Nature [C14] [2014].dck
+++ b/forge-gui/res/quest/commanderprecons/Guided by Nature [C14] [2014].dck
@@ -1,5 +1,6 @@
 [metadata]
-Name=Guided by Nature [C14] [2014}
+Name=Guided by Nature [C14] [2014]
+Set=C14
 [Commander]
 1 Freyalise, Llanowar's Fury|C14
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Guided by Nature [CMA] [2017].dck
+++ b/forge-gui/res/quest/commanderprecons/Guided by Nature [CMA] [2017].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Guided by Nature [CMA] [2017]
+Set=CMA
 [Commander]
 1 Freyalise, Llanowar's Fury|CMA
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Hail, Caesar [PIP] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Hail, Caesar [PIP] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Hail, Caesar [PIP] [2024]
+Set=PIP
 [Commander]
 1 Caesar, Legion's Emperor|PIP|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Heads I Win, Tails You Lose [SLD] [2021].dck
+++ b/forge-gui/res/quest/commanderprecons/Heads I Win, Tails You Lose [SLD] [2021].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Heads I Win, Tails You Lose [SLD] [2021]
+Set=SLD
 [commander]
 1 Okaun, Eye of Chaos+|SLD
 1 Zndrsplt, Eye of Wisdom+|SLD

--- a/forge-gui/res/quest/commanderprecons/Heavenly Inferno [CMA] [2017].dck
+++ b/forge-gui/res/quest/commanderprecons/Heavenly Inferno [CMA] [2017].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Heavenly Inferno [CMA] [2017]
+Set=CMA
 [Commander]
 1 Kaalia of the Vast|CMA
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Heavenly Inferno [COM] [2011].dck
+++ b/forge-gui/res/quest/commanderprecons/Heavenly Inferno [COM] [2011].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Heavenly Inferno [COM] [2011]
+Set=COM
 [Commander]
 1 Kaalia of the Vast|COM
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Invent Superiority [C16] [2016].dck
+++ b/forge-gui/res/quest/commanderprecons/Invent Superiority [C16] [2016].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Invent Superiority [C16] [2016]
+Set=C16
 [Commander]
 1 Breya, Etherium Shaper+|C16
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Jump Scare! [DSC] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Jump Scare! [DSC] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Jump Scare! [DSC] [2024]
+Set=DSC
 [Commander]
 1 Zimone, Mystery Unraveler|DSC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Land's Wrath [ZNC] [2020].dck
+++ b/forge-gui/res/quest/commanderprecons/Land's Wrath [ZNC] [2020].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Land's Wrath [ZNC] [2020]
+Set=ZNC
 [commander]
 1 Obuun, Mul Daya Ancestor+|ZNC
 [main]

--- a/forge-gui/res/quest/commanderprecons/Legends' Legacy [DMC] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Legends' Legacy [DMC] [2022].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Legends' Legacy [DMC] [2022]
+Set=DMC
 [Commander]
 1 Dihada, Binder of Wills|DMC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Lorehold Legacies [C21] [2021].dck
+++ b/forge-gui/res/quest/commanderprecons/Lorehold Legacies [C21] [2021].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Lorehold Legacies [C21] [2021]
+Set=C21
 [commander]
 1 Osgir, the Reconstructor+|C21
 [main]

--- a/forge-gui/res/quest/commanderprecons/Maestros Massacre [NCC] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Maestros Massacre [NCC] [2022].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Maestros Massacre [NCC] [2022]
+Set=NCC
 [Commander]
 1 Anhelo, the Painter|NCC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Masters of Evil [WHO] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Masters of Evil [WHO] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Masters of Evil [WHO] [2023]
+Set=WHO
 [Commander]
 1 Davros, Dalek Creator|WHO|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Merciless Rage [C19] [2019].dck
+++ b/forge-gui/res/quest/commanderprecons/Merciless Rage [C19] [2019].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Merciless Rage [C19] [2019]
+Set=C19
 [Commander]
 1 Anje Falkenrath|C19|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Mind Flayarrrs [CLB] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Mind Flayarrrs [CLB] [2022].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Mind Flayarrrs [CLB] [2022]
+Set=CLB
 [Commander]
 1 Captain N'ghathrod|CLB|2
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Mind Seize [C13] [2013].dck
+++ b/forge-gui/res/quest/commanderprecons/Mind Seize [C13] [2013].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Mind Seize [C13] [2013]
+Set=C13
 [Commander]
 1 Jeleva, Nephalia's Scourge|C13
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Miracle Worker [DSC] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Miracle Worker [DSC] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Miracle Worker [DSC] [2024]
+Set=DSC
 [Commander]
 1 Aminatou, Veil Piercer|DSC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Mirror Mastery [COM] [2011].dck
+++ b/forge-gui/res/quest/commanderprecons/Mirror Mastery [COM] [2011].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Mirror Mastery [COM] [2011]
+Set=COM
 [Commander]
 1 Riku of Two Reflections|COM
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Mishra's Burnished Banner [BRC] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Mishra's Burnished Banner [BRC] [2022].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Mishra's Burnished Banner [BRC] [2022]
+Set=BRC
 [Commander]
 1 Mishra, Eminent One|BRC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Most Wanted [OTC] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Most Wanted [OTC] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Most Wanted [OTC] [2024]
+Set=OTC
 [Commander]
 1 Olivia, Opulent Outlaw|OTC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Mutant Menace [PIP] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Mutant Menace [PIP] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Mutant Menace [PIP] [2024]
+Set=PIP
 [Commander]
 1 The Wise Mothman|PIP|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Mystic Intellect [C19] [2019].dck
+++ b/forge-gui/res/quest/commanderprecons/Mystic Intellect [C19] [2019].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Mystic Intellect [C19] [2019]
+Set=C19
 [Commander]
 1 Sevinne, the Chronoclasm|C19|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Nature of the Beast [C13] [2013].dck
+++ b/forge-gui/res/quest/commanderprecons/Nature of the Beast [C13] [2013].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Nature of the Beast [C13] [2013]
+Set=C13
 [Commander]
 1 Marath, Will of the Wild|C13
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Nature's Vengeance [C18] [2018].dck
+++ b/forge-gui/res/quest/commanderprecons/Nature's Vengeance [C18] [2018].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Nature's Vengeance [C18] [2018]
+Set=C18
 [Commander]
 1 Lord Windgrace|C18|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Necron Dynasties [40K] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Necron Dynasties [40K] [2022].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Necron Dynasties [40K] [2022]
+Set=40K
 [Commander]
 1 Szarekh, the Silent King|40K|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Obscura Operation [NCC] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Obscura Operation [NCC] [2022].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Obscura Operation [NCC] [2022]
+Set=NCC
 [Commander]
 1 Kamiz, Obscura Oculus|NCC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Open Hostility [C16] [2016].dck
+++ b/forge-gui/res/quest/commanderprecons/Open Hostility [C16] [2016].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Open Hostility [C16] [2016]
+Set=C16
 [Commander]
 1 Saskia the Unyielding+|C16
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Painbow [DMC] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Painbow [DMC] [2022].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Painbow [DMC] [2022]
+Set=DMC
 [Commander]
 1 Jared Carthalion|DMC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Paradox Power [WHO] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Paradox Power [WHO] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Paradox Power [WHO] [2023]
+Set=WHO
 [Commander]
 1 The Thirteenth Doctor|WHO|1
 1 Yasmin Khan|WHO|1

--- a/forge-gui/res/quest/commanderprecons/Party Time [CLB] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Party Time [CLB] [2022].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Party Time [CLB] [2022]
+Set=CLB
 [Commander]
 1 Nalia de'Arnise|CLB|2
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Peace Offering [BLC] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Peace Offering [BLC] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Peace Offering [BLC] [2024]
+Set=BLC
 [Commander]
 1 Ms. Bumbleflower|BLC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Peer Through Time [C14] [2014].dck
+++ b/forge-gui/res/quest/commanderprecons/Peer Through Time [C14] [2014].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Peer Through Time [C14] [2014]
+Set=C14
 [Commander]
 1 Teferi, Temporal Archmage|C14
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Phantom Premonition [KHC] [2021].dck
+++ b/forge-gui/res/quest/commanderprecons/Phantom Premonition [KHC] [2021].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Phantom Premonition [KHC] [2021]
+Set=KHC
 [commander]
 1 Ranar the Ever-Watchful+|KHC
 [main]

--- a/forge-gui/res/quest/commanderprecons/Planar Portal [AFC] [2021].dck
+++ b/forge-gui/res/quest/commanderprecons/Planar Portal [AFC] [2021].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Planar Portal [AFC] [2021]
+Set=AFC
 [commander]
 1 Prosper, Tome-Bound+|AFC
 [main]

--- a/forge-gui/res/quest/commanderprecons/Planeswalker Party [CMM] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Planeswalker Party [CMM] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Planeswalker Party [CMM] [2023]
+Set=CMM
 [Commander]
 1 Commodore Guff|CMM|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Plunder the Graves [C15] [2015].dck
+++ b/forge-gui/res/quest/commanderprecons/Plunder the Graves [C15] [2015].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Plunder the Graves [C15] [2015]
+Set=C15
 [Commander]
 1 Meren of Clan Nel Toth+|C15
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Plunder the Graves [CMA] [2017].dck
+++ b/forge-gui/res/quest/commanderprecons/Plunder the Graves [CMA] [2017].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Plunder the Graves [CMA] [2017]
+Set=CMA
 [Commander]
 1 Meren of Clan Nel Toth+|CMA
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Political Puppets [COM] [2011].dck
+++ b/forge-gui/res/quest/commanderprecons/Political Puppets [COM] [2011].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Political Puppets [COM] [2011]
+Set=COM
 [Commander]
 1 Zedruu the Greathearted|COM
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Power Hungry [C13] [2013].dck
+++ b/forge-gui/res/quest/commanderprecons/Power Hungry [C13] [2013].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Power Hungry [C13] [2013]
+Set=C13
 [Commander]
 1 Prossh, Skyraider of Kher|C13
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Primal Genesis [C19] [2019] .dck
+++ b/forge-gui/res/quest/commanderprecons/Primal Genesis [C19] [2019] .dck
@@ -1,5 +1,6 @@
 [metadata]
-Name=Primal Genesis [C19] [2019] 
+Name=Primal Genesis [C19] [2019]
+Set=C19
 [Commander]
 1 Ghired, Conclave Exile|C19|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Prismari Performance [C21] [2021].dck
+++ b/forge-gui/res/quest/commanderprecons/Prismari Performance [C21] [2021].dck
@@ -1,6 +1,6 @@
 [metadata]
 Name=Prismari Performance [C21] [2021]
-
+Set=C21
 [commander]
 1 Zaffai, Thunder Conductor+|C21
 [main]

--- a/forge-gui/res/quest/commanderprecons/Quantum Quandrix [C21] [2021].dck
+++ b/forge-gui/res/quest/commanderprecons/Quantum Quandrix [C21] [2021].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Quantum Quandrix [C21] [2021]
+Set=C21
 [commander]
 1 Adrix and Nev, Twincasters+|C21
 [main]

--- a/forge-gui/res/quest/commanderprecons/Quick Draw [OTC] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Quick Draw [OTC] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Quick Draw [OTC] [2024]
+Set=OTC
 [Commander]
 1 Stella Lee, Wild Card|OTC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Raining Cats and Dogs [SLD] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Raining Cats and Dogs [SLD] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Raining Cats and Dogs [SLD] [2024]
+Set=SLD
 [Commander]
 1 Rin and Seri, Inseparable|SLD|4
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Reap the Tides [CMR] [2020].dck
+++ b/forge-gui/res/quest/commanderprecons/Reap the Tides [CMR] [2020].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Reap the Tides [CMR] [2020]
+Set=CMR
 [commander]
 1 Aesi, Tyrant of Gyre Strait+|CMR
 [main]

--- a/forge-gui/res/quest/commanderprecons/Rebellion Rising [ONC] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Rebellion Rising [ONC] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 name=Rebellion Rising [ONC] [2023]
+Set=ONC
 [Commander]
 1 Neyali, Suns' Vanguard|ONC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Revenant Recon [MKC] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Revenant Recon [MKC] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Revenant Recon [MKC] [2024]
+Set=MKC
 [Commander]
 1 Mirko, Obsessive Theorist|MKC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Riders of Rohan [LTC] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Riders of Rohan [LTC] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Riders of Rohan [LTC] [2023]
+Set=LTC
 [Commander]
 1 Éowyn, Shieldmaiden|LTC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Riveteer Rampage [NCC] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Riveteer Rampage [NCC] [2022].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Riveteer Rampage [NCC] [2022]
+Set=NCC
 [Commander]
 1 Henzie "Toolbox" Torre|NCC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Ruthless Regiment [C20] [2020].dck
+++ b/forge-gui/res/quest/commanderprecons/Ruthless Regiment [C20] [2020].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Ruthless Regiment [C20] [2020]
+Set=C20
 [commander]
 1 Jirina Kudro+|C20
 [main]

--- a/forge-gui/res/quest/commanderprecons/Science! [PIP] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Science! [PIP] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Science! [PIP] [2024]
+Set=PIP
 [Commander]
 1 Dr. Madison Li|PIP|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Scrappy Survivors [PIP] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Scrappy Survivors [PIP] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Scrappy Survivors [PIP] [2024]
+Set=PIP
 [Commander]
 1 Dogmeat, Ever Loyal|PIP|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Seize Control [C15] [2015].dck
+++ b/forge-gui/res/quest/commanderprecons/Seize Control [C15] [2015].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Seize Control [C15] [2015]
+Set=C15
 [Commander]
 1 Mizzix of the Izmagnus+|C15
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Silverquill Statement [C21] [2021].dck
+++ b/forge-gui/res/quest/commanderprecons/Silverquill Statement [C21] [2021].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Silverquill Statement [C21] [2021]
+Set=C21
 [commander]
 1 Breena, the Demagogue+|C21
 [main]

--- a/forge-gui/res/quest/commanderprecons/Sliver Swarm [CMM] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Sliver Swarm [CMM] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Sliver Swarm [CMM] [2023]
+Set=CMM
 [Commander]
 1 Sliver Gravemother|CMM|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Sneak Attack [ZNC] [2020].dck
+++ b/forge-gui/res/quest/commanderprecons/Sneak Attack [ZNC] [2020].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Sneak Attack [ZNC] [2020]
+Set=ZNC
 [commander]
 1 Anowon, the Ruin Thief+|ZNC
 [main]

--- a/forge-gui/res/quest/commanderprecons/Spirit Squadron [VOC] [2021].dck
+++ b/forge-gui/res/quest/commanderprecons/Spirit Squadron [VOC] [2021].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Spirit Squadron [VOC] [2021]
+Set=VOC
 [commander]
 1 Millicent, Restless Revenant+|VOC
 [main]

--- a/forge-gui/res/quest/commanderprecons/Squirreled Away [BLC] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Squirreled Away [BLC] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Squirreled Away [BLC] [2024]
+Set=BLC
 [Commander]
 1 Hazel of the Rootbloom|BLC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Stalwart Unity [C16] [2016].dck
+++ b/forge-gui/res/quest/commanderprecons/Stalwart Unity [C16] [2016].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Stalwart Unity [C16] [2016]
+Set=C16
 [Commander]
 1 Kynaios and Tiro of Meletis+|C16
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Subjective Reality [C18] [2018].dck
+++ b/forge-gui/res/quest/commanderprecons/Subjective Reality [C18] [2018].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Subjective Reality [C18] [2018]
+Set=C18
 [Commander]
 1 Aminatou, the Fateshifter|C18|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Swell the Host [C15] [2015].dck
+++ b/forge-gui/res/quest/commanderprecons/Swell the Host [C15] [2015].dck
@@ -1,5 +1,6 @@
 [metadata]
-Name=Swell the Host [C15] [2015] 
+Name=Swell the Host [C15] [2015]
+Set=C15
 [Commander]
 1 Ezuri, Claw of Progress+|C15
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Sworn to Darkness [C14] [2014].dck
+++ b/forge-gui/res/quest/commanderprecons/Sworn to Darkness [C14] [2014].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Sworn to Darkness [C14] [2014]
+Set=C14
 [Commander]
 1 Ob Nixilis of the Black Oath|C14
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Symbiotic Swarm [C20] [2020].dck
+++ b/forge-gui/res/quest/commanderprecons/Symbiotic Swarm [C20] [2020].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Symbiotic Swarm [C20] [2020]
+Set=C20
 [commander]
 1 Kathril, Aspect Warper+|C20
 [main]

--- a/forge-gui/res/quest/commanderprecons/The Host of Mordor [LTC] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/The Host of Mordor [LTC] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=The Host of Mordor [LTC] [2023]
+Set=LTC
 [Commander]
 1 Sauron, Lord of the Rings|LTC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/The Ruinous Powers [40K] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/The Ruinous Powers [40K] [2022].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=The Ruinous Powers [40K] [2022]
+Set=40K
 [Commander]
 1 Abaddon the Despoiler|40K|2
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Timeless Wisdom [C20] [2020].dck
+++ b/forge-gui/res/quest/commanderprecons/Timeless Wisdom [C20] [2020].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Timeless Wisdom [C20] [2020]
+Set=C20
 [commander]
 1 Gavi, Nest Warden+|C20
 [main]

--- a/forge-gui/res/quest/commanderprecons/Timey-Wimey [WHO] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Timey-Wimey [WHO] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Timey-Wimey [WHO] [2023]
+Set=WHO
 [Commander]
 1 The Tenth Doctor|WHO|1
 1 Rose Tyler|WHO|1

--- a/forge-gui/res/quest/commanderprecons/Tinker Time [MOC] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Tinker Time [MOC] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Tinker Time [MOC] [2023]
+Set=MOC
 [Commander]
 1 Gimbal, Gremlin Prodigy|MOC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Token Triumph [SCD] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Token Triumph [SCD] [2022].dck
@@ -1,5 +1,6 @@
 [metadata]
 name=Token Triumph [SCD] [2022]
+Set=SCD
 [Commander]
 1 Emmara, Soul of the Accord|SCD|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Tricky Terrain [M3C] [2024].dck
+++ b/forge-gui/res/quest/commanderprecons/Tricky Terrain [M3C] [2024].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Tricky Terrain [M3C] [2024]
+Set=M3C
 [Commander]
 1 Omo, Queen of Vesuva|M3C|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Tyranid Swarm [40K] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Tyranid Swarm [40K] [2022].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Tyranid Swarm [40K] [2022]
+Set=40K
 [Commander]
 1 The Swarmlord|40K|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Undead Unleashed [MIC] [2021].dck
+++ b/forge-gui/res/quest/commanderprecons/Undead Unleashed [MIC] [2021].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Undead Unleashed [MIC] [2021]
+Set=MIC
 [commander]
 1 Wilhelt, the Rotcleaver+|MIC
 [main]

--- a/forge-gui/res/quest/commanderprecons/Upgrades Unleashed [NEC] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Upgrades Unleashed [NEC] [2022].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Upgrades Unleashed [NEC] [2022]
+Set=NEC
 [Commander]
 1 Chishiro, the Shattered Blade|NEC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Urza's Iron Alliance [BRC] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/Urza's Iron Alliance [BRC] [2022].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Urza's Iron Alliance [BRC] [2022]
+Set=BRC
 [Commander]
 1 Urza, Chief Artificer|BRC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Vampiric Bloodline [VOC] [2021].dck
+++ b/forge-gui/res/quest/commanderprecons/Vampiric Bloodline [VOC] [2021].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Vampiric Bloodline [VOC] [2021]
+Set=VOC
 [commander]
 1 Strefan, Maurer Progenitor+|VOC
 [main]

--- a/forge-gui/res/quest/commanderprecons/Vampiric Bloodlust [C17] [2017].dck
+++ b/forge-gui/res/quest/commanderprecons/Vampiric Bloodlust [C17] [2017].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Vampiric Bloodlust [C17] [2017]
+Set=C17
 [Commander]
 1 Edgar Markov|C17
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Veloci-Ramp-Tor [LCC] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Veloci-Ramp-Tor [LCC] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Veloci-Ramp-Tor [LCC] [2023]
+Set=LCC
 [Commander]
 1 Pantlaza, Sun-Favored|LCC|4
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Virtue and Valor [WOC] [2023].dck
+++ b/forge-gui/res/quest/commanderprecons/Virtue and Valor [WOC] [2023].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Virtue and Valor [WOC] [2023]
+Set=WOC
 [Commander]
 1 Ellivere of the Wild Court|WOC|1
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Wade into Battle [C15] [2015].dck
+++ b/forge-gui/res/quest/commanderprecons/Wade into Battle [C15] [2015].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Wade into Battle [C15] [2015]
+Set=C15
 [Commander]
 1 Kalemne, Disciple of Iroas+|C15
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Wade into Battle [CM2] [2018].dck
+++ b/forge-gui/res/quest/commanderprecons/Wade into Battle [CM2] [2018].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Wade into Battle [CM2] [2018]
+Set=CM2
 [Commander]
 1 Kalemne, Disciple of Iroas+|CM2
 [Main]

--- a/forge-gui/res/quest/commanderprecons/Witherbloom Witchcraft [C21] [2021].dck
+++ b/forge-gui/res/quest/commanderprecons/Witherbloom Witchcraft [C21] [2021].dck
@@ -1,5 +1,6 @@
 [metadata]
 Name=Witherbloom Witchcraft [C21] [2021]
+Set=C21
 [commander]
 1 Willowdusk, Essence Seer+|C21
 [main]


### PR DESCRIPTION
This commit adds the set cons to the Commander Pre Cons so that they are correctly sorted when grouping for Set.