### PR TITLE
Reapply fix IndexOutOfBoundsException in generateParticipants

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/data/AdventureEventData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/AdventureEventData.java
@@ -19,6 +19,7 @@ import forge.gamemodes.limited.LimitedPoolType;
 import forge.model.CardBlock;
 import forge.model.FModel;
 import forge.util.Aggregates;
+import forge.util.IterableUtil;
 import forge.util.MyRandom;
 import forge.util.StreamUtil;
 import org.apache.commons.lang3.tuple.Pair;
@@ -439,8 +440,8 @@ public class AdventureEventData implements Serializable {
     public void generateParticipants(int numberOfOpponents) {
         participants = new AdventureEventParticipant[numberOfOpponents + 1];
 
-        List<EnemyData> data = Aggregates.random(WorldData.getAllEnemies(), numberOfOpponents);
-        data.removeIf(q -> q.nextEnemy != null);
+        Iterable<EnemyData> validParticipants = IterableUtil.filter(WorldData.getAllEnemies(), q -> q.nextEnemy == null);
+        List<EnemyData> data = Aggregates.random(validParticipants, numberOfOpponents);
         for (int i = 0; i < numberOfOpponents; i++) {
             participants[i] = new AdventureEventParticipant().generate(data.get(i));
         }


### PR DESCRIPTION
Re: #6694

Ok I see what happened now. I edited this function in PR #6359 to fix issue #5354, but in doing so I introduced a usage of `Iterables.filter`, which I was simultaneously working to phase out on the de-guava-ing branch. I guess I tunnel-visioned on rewriting it using the Stream API rather than doing the sensible thing and swapping in `IterableUtil`. Then it broke because I tried to get clever with the generator function in `.toArray`.

This should fix the original crash and get us back where we were.