### PR TITLE
Corrects cost of Shrine Keeper

### DIFF
--- a/forge-gui/res/cardsfolder/s/shrine_keeper.txt
+++ b/forge-gui/res/cardsfolder/s/shrine_keeper.txt
@@ -1,5 +1,5 @@
 Name:Shrine Keeper
-ManaCost:1 W
+ManaCost:W W
 Types:Creature Human Cleric
 PT:2/2
 Oracle:


### PR DESCRIPTION
Random starting card pile gave me this, and I noticed a discrepancy between the cost shown in the art and the devotion to white it should have been providing when casting Daybreak Chimera.
Source: [Shrine Keeper](https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=548127)