### PR TITLE
Fix the AI never playing Chain Lightning

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/CopySpellAbilityAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CopySpellAbilityAi.java
@@ -22,7 +22,7 @@ public class CopySpellAbilityAi extends SpellAbilityAi {
         String logic = sa.getParamOrDefault("AILogic", "");
 
         if (game.getStack().isEmpty()) {
-            return sa.isMandatory();
+            return sa.isMandatory() || "Always".equals(logic);
         }
 
         final SpellAbility top = game.getStack().peekAbility();

--- a/forge-gui/res/cardsfolder/c/chain_lightning.txt
+++ b/forge-gui/res/cardsfolder/c/chain_lightning.txt
@@ -2,5 +2,5 @@ Name:Chain Lightning
 ManaCost:R
 Types:Sorcery
 A:SP$ DealDamage | ValidTgts$ Any | TgtPrompt$ Select target | NumDmg$ 3 | SubAbility$ DBCopy1 | SpellDescription$ CARDNAME deals 3 damage to any target. Then that player or that permanent's controller may pay {R}{R}. If the player does, they may copy this spell and may choose a new target for that copy.
-SVar:DBCopy1:DB$ CopySpellAbility | Defined$ Parent | Controller$ TargetedOrController | UnlessPayer$ TargetedOrController | UnlessCost$ R R | UnlessSwitched$ True | MayChooseTarget$ True | StackDescription$ None
+SVar:DBCopy1:DB$ CopySpellAbility | Defined$ Parent | Controller$ TargetedOrController | UnlessPayer$ TargetedOrController | UnlessCost$ R R | UnlessSwitched$ True | MayChooseTarget$ True | AILogic$ Always | StackDescription$ None
 Oracle:Chain Lightning deals 3 damage to any target. Then that player or that permanent's controller may pay {R}{R}. If the player does, they may copy this spell and may choose a new target for that copy.


### PR DESCRIPTION
The AI can most likely be improved here by deciding when it's more viable to play it, but so far, this will allow the AI to play the card (will try to respond to every opponent's activation if able).
Fixes #6704 