### PR TITLE
Roaring Toeclaws fix

### DIFF
--- a/forge-gui/res/cardsfolder/t/the_roaring_toeclaws.txt
+++ b/forge-gui/res/cardsfolder/t/the_roaring_toeclaws.txt
@@ -2,7 +2,7 @@ Name:The Roaring Toeclaws
 ManaCost:3 G G
 Types:Legendary Creature Dinosaur
 PT:5/5
-T:Mode$ Untaps | ValidCard$ Card.Self,Creature.Other+YouCtrl+powerGE5 | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Whenever CARDNAME or another creature you control with mana value five or greater becomes untapped, put +1/+1 counters on it equal to its power.
+T:Mode$ Untaps | ValidCard$ Card.Self,Creature.Other+YouCtrl+cmcGE5 | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Whenever CARDNAME or another creature you control with mana value five or greater becomes untapped, put +1/+1 counters on it equal to its power.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ TriggeredCard | CounterType$ P1P1 | CounterNum$ X
 SVar:X:TriggeredCard$CardPower
 DeckHas:Ability$Counters


### PR DESCRIPTION
Roaring Toeclaws fix to check Mana Value, rather than power