### PR TITLE
remove add-opens from mandatory.java.args, use MANIFEST.mf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 .settings
 .classpath
 .project
+.checkstyle
 
 # Ignore VS Code config files
 
@@ -24,6 +25,8 @@
 
 nbactions.xml
 
+# Ignore flattened pom
+.flattened-pom.xml
 
 # Ignore binaries, temp files and test output, everywhere
 

--- a/forge-gui-desktop/pom.xml
+++ b/forge-gui-desktop/pom.xml
@@ -18,28 +18,7 @@
         <parsedVersion.incrementalVersion>0</parsedVersion.incrementalVersion>
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
-        <mandatory.java.args>--add-opens java.desktop/java.beans=ALL-UNNAMED
-            --add-opens java.desktop/javax.swing.border=ALL-UNNAMED
-            --add-opens java.desktop/javax.swing.event=ALL-UNNAMED
-            --add-opens java.desktop/sun.swing=ALL-UNNAMED 
-            --add-opens java.desktop/java.awt.image=ALL-UNNAMED
-            --add-opens java.desktop/java.awt.color=ALL-UNNAMED
-            --add-opens java.desktop/sun.awt.image=ALL-UNNAMED
-            --add-opens java.desktop/javax.swing=ALL-UNNAMED
-            --add-opens java.desktop/java.awt=ALL-UNNAMED
-            --add-opens java.base/java.util=ALL-UNNAMED
-            --add-opens java.base/java.lang=ALL-UNNAMED
-            --add-opens java.base/java.lang.reflect=ALL-UNNAMED
-            --add-opens java.base/java.text=ALL-UNNAMED
-            --add-opens java.desktop/java.awt.font=ALL-UNNAMED
-            --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
-            --add-opens java.base/sun.nio.ch=ALL-UNNAMED 
-            --add-opens java.base/java.nio=ALL-UNNAMED
-            --add-opens java.base/java.math=ALL-UNNAMED
-            --add-opens java.base/java.util.concurrent=ALL-UNNAMED
-            --add-opens java.base/java.net=ALL-UNNAMED 
-            -Dio.netty.tryReflectionSetAccessible=true -Dfile.encoding=UTF-8
-        </mandatory.java.args>
+        <mandatory.java.args>-Xmx4096m -Dio.netty.tryReflectionSetAccessible=true -Dfile.encoding=UTF-8</mandatory.java.args>
     </properties>
 
     <build>

--- a/forge-gui-desktop/src/main/config/forge.cmd
+++ b/forge-gui-desktop/src/main/config/forge.cmd
@@ -16,7 +16,7 @@ if %jver% LEQ 16 (
 )
 
 if %jver% GEQ 17 (
-  java -Xmx4096m $mandatory.java.args$ -jar $project.build.finalName$
+  java $mandatory.java.args$ -jar $project.build.finalName$
   popd
   exit /b 0
 )

--- a/forge-gui-desktop/src/main/config/forge.command
+++ b/forge-gui-desktop/src/main/config/forge.command
@@ -1,3 +1,3 @@
 #!/bin/sh
 cd $(dirname "${0}")
-java -Xmx4096m $mandatory.java.args$ -jar $project.build.finalName$
+java $mandatory.java.args$ -jar $project.build.finalName$

--- a/forge-gui-desktop/src/main/config/forge.sh
+++ b/forge-gui-desktop/src/main/config/forge.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 cd $(dirname "${0}")
-java -Xmx4096m $mandatory.java.args$ -jar $project.build.finalName$
+java $mandatory.java.args$ -jar $project.build.finalName$


### PR DESCRIPTION
fixes the --add-opens problem with the run-scripts using the Manifest.mf