### PR TITLE
Update pom.xml

### DIFF
--- a/forge-gui-desktop/pom.xml
+++ b/forge-gui-desktop/pom.xml
@@ -167,13 +167,29 @@
                             <Implementation-Title>${project.name}</Implementation-Title>
                             <Implementation-Version>${snapshot-version}</Implementation-Version>
                             <Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
-                            <Add-Opens>java.desktop/java.beans java.desktop/javax.swing.border
-                                java.desktop/javax.swing.event java.desktop/sun.swing java.desktop/java.awt.image
-                                java.desktop/java.awt.color java.desktop/sun.awt.image java.desktop/javax.swing
-                                java.desktop/java.awt java.base/java.util java.base/java.lang
-                                java.base/java.lang.reflect java.base/java.text java.desktop/java.awt.font
-                                java.base/jdk.internal.misc java.base/sun.nio.ch java.base/java.nio java.base/java.math
-                                java.base/java.util.concurrent java.base/java.net
+                            <Add-Opens>
+<![CDATA[
+ java.desktop/java.beans
+ java.desktop/javax.swing.border
+ java.desktop/javax.swing.event
+ java.desktop/sun.swing
+ java.desktop/java.awt.image
+ java.desktop/java.awt.color
+ java.desktop/sun.awt.image
+ java.desktop/javax.swing
+ java.desktop/java.awt
+ java.base/java.util
+ java.base/java.lang
+ java.base/java.lang.reflect
+ java.base/java.text
+ java.desktop/java.awt.font
+ java.base/jdk.internal.misc
+ java.base/sun.nio.ch
+ java.base/java.nio
+ java.base/java.math
+ java.base/java.util.concurrent
+ java.base/java.net                                     
+]]>
                             </Add-Opens>
                             <Main-Class>forge.view.Main</Main-Class>
                         </manifestEntries>


### PR DESCRIPTION
The Goal is to get it working on macOS again, right now they are ignored for some reason
I couldn't reproduce it on linux

the Mainfest from the Snapshot currently looks like this:

```
Manifest-Version: 1.0
Created-By: Maven Archiver 3.5.0
Build-Jdk-Spec: 17
Add-Opens: java.desktop/java.beans java.desktop/javax.swing.border
     
                            java.desktop/javax.swing.event java.desktop/
 sun.swing java.desktop/java.awt.image
                                j
 ava.desktop/java.awt.color java.desktop/sun.awt.image java.desktop/java
 x.swing
                                java.desktop/java.awt java.base
 /java.util java.base/java.lang
                                java.bas
 e/java.lang.reflect java.base/java.text java.desktop/java.awt.font
    
                             java.base/jdk.internal.misc java.base/sun.n
 io.ch java.base/java.nio java.base/java.math
                          
       java.base/java.util.concurrent java.base/java.net
Implementation-Title: Forge
Implementation-Vendor: CardForge
Implementation-Version: 2.0.02-SNAPSHOT-01.05
Main-Class: forge.view.Main


```

the extra new lines might mess this up
