### PR TITLE
Replace Cling with jupnp

### DIFF
--- a/forge-gui-android/proguard.cfg
+++ b/forge-gui-android/proguard.cfg
@@ -33,7 +33,7 @@
 -dontwarn org.checkerframework.**
 -dontwarn org.xmlpull.**
 -dontwarn org.apache.log4j.**
--dontwarn org.fourthline.cling.**
+-dontwarn org.jupnp.**
 -dontwarn org.seamless.http.**
 -dontwarn org.seamless.xhtml.**
 -dontwarn org.seamless.xml.**

--- a/forge-gui/pom.xml
+++ b/forge-gui/pom.xml
@@ -59,9 +59,14 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.fourthline.cling</groupId>
-            <artifactId>cling-support</artifactId>
-            <version>2.1.2</version>
+            <groupId>org.jupnp</groupId>
+            <artifactId>org.jupnp</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jupnp</groupId>
+            <artifactId>org.jupnp.support</artifactId>
+            <version>3.0.2</version>
         </dependency>
         <dependency>
             <groupId>org.lz4</groupId>

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
@@ -19,10 +19,10 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.serialization.ClassResolvers;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
-import org.fourthline.cling.UpnpService;
-import org.fourthline.cling.UpnpServiceImpl;
-import org.fourthline.cling.support.igd.PortMappingListener;
-import org.fourthline.cling.support.model.PortMapping;
+import org.jupnp.UpnpService;
+import org.jupnp.UpnpServiceImpl;
+import org.jupnp.support.igd.PortMappingListener;
+import org.jupnp.support.model.PortMapping;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -36,29 +36,16 @@ import java.util.function.Predicate;
 
 public final class FServerManager {
     private static FServerManager instance = null;
-
-    private byte[] externalAddress = new byte[]{8,8,8,8};
+    private final Map<Channel, RemoteClient> clients = Maps.newTreeMap();
+    private byte[] externalAddress = new byte[]{8, 8, 8, 8};
     private boolean isHosting = false;
     private EventLoopGroup bossGroup = new NioEventLoopGroup(1);
     private EventLoopGroup workerGroup = new NioEventLoopGroup();
     private UpnpService upnpService = null;
-    private final Map<Channel, RemoteClient> clients = Maps.newTreeMap();
     private ServerGameLobby localLobby;
     private ILobbyListener lobbyListener;
-    private final Thread shutdownHook = new Thread(() -> {
-        if (isHosting()) {
-            stopServer(false);
-        }
-    });
 
     private FServerManager() {
-    }
-
-    RemoteClient getClient(final Channel ch) {
-        return clients.get(ch);
-    }
-    IGameController getController(final int index) {
-        return localLobby.getController(index);
     }
 
     /**
@@ -73,6 +60,39 @@ public final class FServerManager {
         return instance;
     }
 
+    public static String getExternalAddress() {
+        BufferedReader in = null;
+        try {
+            URL whatismyip = new URL("https://checkip.amazonaws.com");
+            in = new BufferedReader(new InputStreamReader(
+                    whatismyip.openStream()));
+            return in.readLine();
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            if (in != null) {
+                try {
+                    in.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        return null;
+    }    private final Thread shutdownHook = new Thread(() -> {
+        if (isHosting()) {
+            stopServer(false);
+        }
+    });
+
+    RemoteClient getClient(final Channel ch) {
+        return clients.get(ch);
+    }
+
+    IGameController getController(final int index) {
+        return localLobby.getController(index);
+    }
+
     public void startServer(final int port) {
         try {
             final ServerBootstrap b = new ServerBootstrap()
@@ -85,7 +105,7 @@ public final class FServerManager {
                             final ChannelPipeline p = ch.pipeline();
                             p.addLast(
                                     new CompatibleObjectEncoder(),
-                                    new CompatibleObjectDecoder(9766*1024, ClassResolvers.cacheDisabled(null)),
+                                    new CompatibleObjectDecoder(9766 * 1024, ClassResolvers.cacheDisabled(null)),
                                     new MessageHandler(),
                                     new RegisterClientHandler(),
                                     new LobbyInputHandler(),
@@ -116,6 +136,7 @@ public final class FServerManager {
     public void stopServer() {
         stopServer(true);
     }
+
     private void stopServer(final boolean removeShutdownHook) {
         bossGroup.shutdownGracefully();
         workerGroup.shutdownGracefully();
@@ -143,18 +164,22 @@ public final class FServerManager {
         }
         broadcastTo(event, clients.values());
     }
+
     public void broadcastExcept(final NetEvent event, final RemoteClient notTo) {
         broadcastExcept(event, Collections.singleton(notTo));
     }
+
     public void broadcastExcept(final NetEvent event, final Collection<RemoteClient> notTo) {
         Predicate<RemoteClient> filter = Predicate.not(notTo::contains);
         broadcastTo(event, IterableUtil.filter(clients.values(), filter));
     }
+
     private void broadcastTo(final NetEvent event, final Iterable<RemoteClient> to) {
         for (final RemoteClient client : to) {
             broadcastTo(event, client);
         }
     }
+
     private void broadcastTo(final NetEvent event, final RemoteClient to) {
         event.updateForClient(to);
         to.send(event);
@@ -165,11 +190,9 @@ public final class FServerManager {
     }
 
     public void unsetReady() {
-        if (this.localLobby != null) {
-            if (this.localLobby.getSlot(0) != null) {
+        if (this.localLobby != null && this.localLobby.getSlot(0) != null) {
                 this.localLobby.getSlot(0).setIsReady(false);
                 updateLobbyState();
-            }
         }
     }
 
@@ -235,46 +258,31 @@ public final class FServerManager {
     public String getLocalAddress() {
         try {
             return getRoutableAddress(true, false);
-        }
-        catch (final Exception e) {
+        } catch (final Exception e) {
             e.printStackTrace();
             return "localhost";
         }
     }
 
-    public static String getExternalAddress() {
-        BufferedReader in = null;
-        try {
-            URL whatismyip = new URL("https://checkip.amazonaws.com");
-            in = new BufferedReader(new InputStreamReader(
-                    whatismyip.openStream()));
-            String ip = in.readLine();
-            return ip;
-        } catch (IOException e) {
-            e.printStackTrace();
-        } finally {
-            if (in != null) {
-                try {
-                    in.close();
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
-        }
-        return null;
-    }
-
     private void mapNatPort(final int port) {
         final String localAddress = getLocalAddress();
         final PortMapping portMapping = new PortMapping(port, localAddress, PortMapping.Protocol.TCP, "Forge");
+
+        // Shutdown existing UPnP service if already running
         if (upnpService != null) {
-            // Safeguard shutdown call, to prevent lingering port mappings
             upnpService.shutdown();
         }
+
         try {
-            upnpService = new UpnpServiceImpl(new PortMappingListener(portMapping));
+            // Create a new UPnP service instance
+            upnpService = new UpnpServiceImpl();
+
+            // Add a PortMappingListener
+            upnpService.getRegistry().addListener(new PortMappingListener(portMapping));
+
+            // Trigger device discovery
             upnpService.getControlPoint().search();
-        }catch (Error e){
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }
@@ -316,7 +324,8 @@ public final class FServerManager {
     }
 
     private class LobbyInputHandler extends ChannelInboundHandlerAdapter {
-        @Override public void channelRead(final ChannelHandlerContext ctx, final Object msg) throws Exception {
+        @Override
+        public void channelRead(final ChannelHandlerContext ctx, final Object msg) throws Exception {
             final RemoteClient client = clients.get(ctx.channel());
             if (msg instanceof LoginEvent) {
                 final LoginEvent event = (LoginEvent) msg;
@@ -349,5 +358,7 @@ public final class FServerManager {
             super.channelInactive(ctx);
         }
     }
+
+
 
 }

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
@@ -53,6 +53,15 @@ public final class FServerManager {
     private FServerManager() {
     }
 
+
+    RemoteClient getClient(final Channel ch) {
+        return clients.get(ch);
+    }
+
+    IGameController getController(final int index) {
+        return localLobby.getController(index);
+    }
+
     /**
      * Get the singleton instance of {@link FServerManager}.
      *
@@ -63,14 +72,6 @@ public final class FServerManager {
             instance = new FServerManager();
         }
         return instance;
-    }
-
-    RemoteClient getClient(final Channel ch) {
-        return clients.get(ch);
-    }
-
-    IGameController getController(final int index) {
-        return localLobby.getController(index);
     }
 
     public void startServer(final int port) {

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
@@ -44,6 +44,11 @@ public final class FServerManager {
     private UpnpService upnpService = null;
     private ServerGameLobby localLobby;
     private ILobbyListener lobbyListener;
+    private final Thread shutdownHook = new Thread(() -> {
+        if (isHosting()) {
+            stopServer(false);
+        }
+    });
 
     private FServerManager() {
     }
@@ -59,31 +64,6 @@ public final class FServerManager {
         }
         return instance;
     }
-
-    public static String getExternalAddress() {
-        BufferedReader in = null;
-        try {
-            URL whatismyip = new URL("https://checkip.amazonaws.com");
-            in = new BufferedReader(new InputStreamReader(
-                    whatismyip.openStream()));
-            return in.readLine();
-        } catch (IOException e) {
-            e.printStackTrace();
-        } finally {
-            if (in != null) {
-                try {
-                    in.close();
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
-        }
-        return null;
-    }    private final Thread shutdownHook = new Thread(() -> {
-        if (isHosting()) {
-            stopServer(false);
-        }
-    });
 
     RemoteClient getClient(final Channel ch) {
         return clients.get(ch);
@@ -264,6 +244,27 @@ public final class FServerManager {
         }
     }
 
+    public static String getExternalAddress() {
+        BufferedReader in = null;
+        try {
+            URL whatismyip = new URL("https://checkip.amazonaws.com");
+            in = new BufferedReader(new InputStreamReader(
+                    whatismyip.openStream()));
+            return in.readLine();
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            if (in != null) {
+                try {
+                    in.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        return null;
+    }
+
     private void mapNatPort(final int port) {
         final String localAddress = getLocalAddress();
         final PortMapping portMapping = new PortMapping(port, localAddress, PortMapping.Protocol.TCP, "Forge");
@@ -358,7 +359,4 @@ public final class FServerManager {
             super.channelInactive(ctx);
         }
     }
-
-
-
 }


### PR DESCRIPTION
```
Update forthline cling dependency to the more supported jupnp, removes http source.
FServerManager.java file formatted as a teduly
```
I believe this complies but Android builds fail to complete. The proguard step ends in error which fails the build