### PR TITLE
Move Altar of the Pantheon to its own static

### DIFF
--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -1159,6 +1159,9 @@ public class GameAction {
                 }
             }
             staticAbilities.addAll(toAdd);
+            for (Player p : game.getPlayers()) {
+                p.afterStaticAbilityLayer(layer);
+            }
         }
 
         for (final CardCollectionView affected : affectedPerAbility.values()) {

--- a/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
@@ -1938,8 +1938,8 @@ public class AbilityUtils {
                             colorOccurrences++;
                         }
                     }
-                    colorOccurrences += c0.getAmountOfKeyword("Your devotion to each color and each combination of colors is increased by one.");
                 }
+                colorOccurrences += player.getDevotionMod();
                 return doXMath(colorOccurrences, expr, c, ctb);
             }
         } // end ctb != null

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -114,6 +114,7 @@ public class Player extends GameEntity implements Comparable<Player> {
     private int venturedThisTurn;
     private int descended;
     private int numRingTemptedYou;
+    private int devotionMod;
     private boolean revolt = false;
     private Card ringBearer, theRing;
 
@@ -4016,5 +4017,17 @@ public class Player extends GameEntity implements Comparable<Player> {
                 .map(Card::getUnlockedRoomNames)
                 .flatMap(Collection::stream)
                 .collect(Collectors.toList());
+    }
+
+    public int getDevotionMod() {
+        return devotionMod;
+    }
+
+    public void afterStaticAbilityLayer(StaticAbilityLayer layer) {
+        if (layer != StaticAbilityLayer.TEXT) {
+            return;
+        }
+
+        devotionMod = StaticAbilityDevotion.getDevotionMod(this);
     }
 }

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityDevotion.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityDevotion.java
@@ -1,0 +1,29 @@
+package forge.game.staticability;
+
+import forge.game.Game;
+import forge.game.card.Card;
+import forge.game.player.Player;
+import forge.game.zone.ZoneType;
+
+public class StaticAbilityDevotion {
+
+    static String MODE = "Devotion";
+
+    public static int getDevotionMod(final Player player) {
+        int i = 0;
+        final Game game = player.getGame();
+        for (final Card ca : game.getCardsIn(ZoneType.STATIC_ABILITIES_SOURCE_ZONES)) {
+            for (final StaticAbility stAb : ca.getStaticAbilities()) {
+                if (!stAb.checkConditions(MODE)) {
+                    continue;
+                }
+                if (!stAb.matchesValidParam("ValidPlayer", player)) {
+                    continue;
+                }
+                int t = Integer.parseInt(stAb.getParamOrDefault("Value", "1"));
+                i = i + t;
+            }
+        }
+        return i;
+    }
+}

--- a/forge-gui/res/cardsfolder/a/altar_of_the_pantheon.txt
+++ b/forge-gui/res/cardsfolder/a/altar_of_the_pantheon.txt
@@ -1,7 +1,7 @@
 Name:Altar of the Pantheon
 ManaCost:3
 Types:Artifact
-K:Your devotion to each color and each combination of colors is increased by one.
+S:Mode$ Devotion | ValidPlayer$ You | Description$ Your devotion to each color and each combination of colors is increased by one.
 A:AB$ Mana | Cost$ T | Produced$ Any | SubAbility$ DBGainLife | SpellDescription$ Add one mana of any color. If you control a God, a Demigod, or a legendary enchantment, you gain 1 life.
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ 1 | ConditionPresent$ God.YouCtrl,Demigod.YouCtrl,Enchantment.YouCtrl+Legendary
 DeckHas:Ability$LifeGain


### PR DESCRIPTION
> 700.5a A player’s devotion to each color and combination of colors, taking into account any effects that modify devotion, is calculated after considering any copy, control, or text-changing effects but before any other effects that modify the characteristics of permanents. This is an exception to 613.10. See also rule 613, “Interaction of Continuous Effects.”