### PR TITLE
Averna: use ReplaceCascade Effect

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
@@ -2295,10 +2295,6 @@ public class AbilityUtils {
         if (sq[0].equals("ExtraTurn")) {
             return doXMath(calculateAmount(c, sq[game.getPhaseHandler().getPlayerTurn().isExtraTurn() ? 1 : 2], ctb), expr, c, ctb);
         }
-        if (sq[0].equals("Averna")) {
-            String str = "As you cascade, you may put a land card from among the exiled cards onto the battlefield tapped.";
-            return doXMath(player.getKeywords().getAmount(str), expr, c, ctb);
-        }
         if (sq[0].equals("YourStartingLife")) {
             return doXMath(player.getStartingLife(), expr, c, ctb);
         }

--- a/forge-game/src/main/java/forge/game/ability/effects/DigUntilEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DigUntilEffect.java
@@ -14,7 +14,9 @@ import forge.game.card.CardLists;
 import forge.game.card.CardPredicates;
 import forge.game.card.CardZoneTable;
 import forge.game.event.GameEventCombatChanged;
+import forge.game.keyword.Keyword;
 import forge.game.player.Player;
+import forge.game.replacement.ReplacementType;
 import forge.game.spellability.SpellAbility;
 import forge.game.zone.PlayerZone;
 import forge.game.zone.ZoneType;
@@ -293,6 +295,17 @@ public class DigUntilEffect extends SpellAbilityEffect {
 
             if (shuffle) {
                 p.shuffle(sa);
+            }
+
+            if (sa.isKeyword(Keyword.CASCADE)) {
+                Map<AbilityKey, Object> runParams = AbilityKey.mapFromAffected(p);
+                runParams.put(AbilityKey.Cards, revealed);
+                game.getReplacementHandler().run(ReplacementType.Cascade, runParams);
+
+                if (sa.hasParam("RememberRevealed")) {
+                    final ZoneType removeZone = foundDest;
+                    host.removeRemembered(revealed.filter(c -> !c.isInZone(removeZone)));
+                }
             }
         } // end foreach player
         if (combatChanged) {

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -825,18 +825,10 @@ public class CardFactoryUtil {
             SpellAbility dig = AbilityFactory.getAbility(abString, card);
             dig.setSVar("CascadeX", "Count$CardManaCost");
 
-            final String dbLandPut = "DB$ ChangeZone | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1" +
-                    " | Hidden$ True | Origin$ Exile | Destination$ Battlefield | ChangeType$ Land.IsRemembered" +
-                    " | ChangeNum$ X | Tapped$ True | ForgetChanged$ True" +
-                    " | SelectPrompt$ You may select a land to put on the battlefield tapped";
-            AbilitySub landPut = (AbilitySub)AbilityFactory.getAbility(dbLandPut, card);
-            landPut.setSVar("X", "Count$Averna");
-            dig.setSubAbility(landPut);
-
             final String dbCascadeCast = "DB$ Play | Defined$ Imprinted | WithoutManaCost$ True | Optional$ True | ValidSA$ Spell.cmcLTCascadeX";
             AbilitySub cascadeCast = (AbilitySub)AbilityFactory.getAbility(dbCascadeCast, card);
             cascadeCast.setSVar("CascadeX", "Count$CardManaCost");
-            landPut.setSubAbility(cascadeCast);
+            dig.setSubAbility(cascadeCast);
 
             final String dbMoveToLib = "DB$ ChangeZoneAll | ChangeType$ Card.IsRemembered,Card.IsImprinted"
                     + " | Origin$ Exile | Destination$ Library | RandomOrder$ True | LibraryPosition$ -1";

--- a/forge-game/src/main/java/forge/game/replacement/ReplaceCascade.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplaceCascade.java
@@ -1,0 +1,28 @@
+package forge.game.replacement;
+
+import java.util.Map;
+
+import forge.game.ability.AbilityKey;
+import forge.game.card.Card;
+import forge.game.spellability.SpellAbility;
+
+public class ReplaceCascade extends ReplacementEffect {
+
+    public ReplaceCascade(Map<String, String> map, Card host, boolean intrinsic) {
+        super(map, host, intrinsic);
+    }
+
+    @Override
+    public boolean canReplace(Map<AbilityKey, Object> runParams) {
+        if (!matchesValidParam("ValidPlayer", runParams.get(AbilityKey.Affected))) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void setReplacingObjects(Map<AbilityKey, Object> runParams, SpellAbility sa) {
+        sa.setReplacingObject(AbilityKey.Player, runParams.get(AbilityKey.Affected));
+        sa.setReplacingObjectsFrom(runParams, AbilityKey.Cards);
+    }
+}

--- a/forge-game/src/main/java/forge/game/replacement/ReplacementType.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplacementType.java
@@ -17,6 +17,7 @@ public enum ReplacementType {
     Attached(ReplaceAttached.class),
     BeginPhase(ReplaceBeginPhase.class),
     BeginTurn(ReplaceBeginTurn.class),
+    Cascade(ReplaceCascade.class),
     Counter(ReplaceCounter.class),
     CopySpell(ReplaceCopySpell.class),
     CreateToken(ReplaceToken.class),

--- a/forge-gui/res/cardsfolder/a/averna_the_chaos_bloom.txt
+++ b/forge-gui/res/cardsfolder/a/averna_the_chaos_bloom.txt
@@ -2,5 +2,6 @@ Name:Averna, the Chaos Bloom
 ManaCost:G U R
 Types:Legendary Creature Elemental Shaman
 PT:4/2
-S:Mode$ Continuous | Affected$ You | AddKeyword$ As you cascade, you may put a land card from among the exiled cards onto the battlefield tapped. | Description$ As you cascade, you may put a land card from among the exiled cards onto the battlefield tapped. (Do this after the last card is exiled but before deciding whether to cast a nonland card.)
+R:Event$ Cascade | ValidPlayer$ You | ActiveZones$ Battlefield | ReplaceWith$ DBLand | ReplacementResult$ Updated | Description$ As you cascade, you may put a land card from among the exiled cards onto the battlefield tapped. (Do this after the last card is exiled but before deciding whether to cast a nonland card.)
+SVar:DBLand:DB$ ChangeZone | Hidden$ True | Origin$ Exile | ChooseFromDefined$ ReplacedCards | ChangeNum$ 1 | Destination$ Battlefield | ChangeType$ Land | Tapped$ True
 Oracle:As you cascade, you may put a land card from among the exiled cards onto the battlefield tapped. (Do this after the last card is exiled but before deciding whether to cast a nonland card.)


### PR DESCRIPTION
> 702.85b If an effect allows a player to take an action with one or more of the exiled cards “as you cascade,” the player may take that action after they have finished exiling cards due to the cascade ability. This action is taken before choosing whether to cast the last exiled card or, if no appropriate card was exiled, before putting the exiled cards on the bottom of their library in a random order.

In my opinion, putting a land into play is "an action", so it should happen in sequence?