### PR TITLE
January 2025 cleanup: pass 4

### DIFF
--- a/forge-gui/res/cardsfolder/a/abstruse_appropriation.txt
+++ b/forge-gui/res/cardsfolder/a/abstruse_appropriation.txt
@@ -2,7 +2,7 @@ Name:Abstruse Appropriation
 ManaCost:2 W B
 Types:Instant
 K:Devoid
-A:SP$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Permanent.nonLand | RememberChanged$ True | TgtPromt$ Select target nonland permanent | SubAbility$ DBEffect | SpellDescription$ Exile target nonland permanent.
+A:SP$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Permanent.nonLand | RememberChanged$ True | TgtPrompt$ Select target nonland permanent | SubAbility$ DBEffect | SpellDescription$ Exile target nonland permanent.
 SVar:DBEffect:DB$ Effect | RememberObjects$ Remembered | StaticAbilities$ MayPlay,ManaConvert | SubAbility$ DBCleanup | Duration$ Permanent | ForgetOnMoved$ Exile | SpellDescription$ You may cast that card for as long as it remains exiled, and you may spend colorless mana as though it were mana of any color to cast that spell.
 SVar:MayPlay:Mode$ Continuous | MayPlay$ True | EffectZone$ Command | Affected$ Card.IsRemembered+nonLand | AffectedZone$ Exile | Description$ You may cast that card for as long as it remains exiled.
 SVar:ManaConvert:Mode$ ManaConvert | ValidPlayer$ You | ValidCard$ Card.IsRemembered | ValidSA$ Spell.MayPlaySource | ManaConversion$ C->AnyColor | AffectedZone$ Exile | Description$ You may spend colorless mana as though it were mana of any color to cast that spell.

--- a/forge-gui/res/cardsfolder/a/apothecary_stomper.txt
+++ b/forge-gui/res/cardsfolder/a/apothecary_stomper.txt
@@ -5,7 +5,7 @@ PT:4/4
 K:Vigilance
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigCharm | TriggerDescription$ When this creature enters, ABILITY
 SVar:TrigCharm:DB$ Charm | Choices$ DBPutCounter,DBGainLife
-SVar:DBPutCounter:DB$ PutCounter | ValidTgts$ Creature.YouCtrl | Tgtprompt$ Select target creature you control | CounterType$ P1P1 | CounterNum$ 2 | SpellDescription$ Put two +1/+1 counters on target creature you control.
+SVar:DBPutCounter:DB$ PutCounter | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | CounterType$ P1P1 | CounterNum$ 2 | SpellDescription$ Put two +1/+1 counters on target creature you control.
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ 4 | SpellDescription$ You gain 4 life.
 DeckHas:Ability$LifeGain
 Oracle:Vigilance (Attacking doesn't cause this creature to tap.)\nWhen this creature enters, choose one —\n• Put two +1/+1 counters on target creature you control.\n• You gain 4 life.

--- a/forge-gui/res/cardsfolder/a/ayula_queen_among_bears.txt
+++ b/forge-gui/res/cardsfolder/a/ayula_queen_among_bears.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature Bear
 PT:2/2
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Bear.YouCtrl+Other | TriggerZones$ Battlefield | Execute$ TrigChoose | TriggerDescription$ Whenever another Bear you control enters, ABILITY
 SVar:TrigChoose:DB$ Charm | Choices$ DBCounter,DBPump
-SVar:DBCounter:DB$ PutCounter | ValidTgts$ Bear | Tgtprompt$ Select target Bear | CounterType$ P1P1 | CounterNum$ 2 | SpellDescription$ Put two +1/+1 counters on target Bear.
+SVar:DBCounter:DB$ PutCounter | ValidTgts$ Bear | TgtPrompt$ Select target Bear | CounterType$ P1P1 | CounterNum$ 2 | SpellDescription$ Put two +1/+1 counters on target Bear.
 SVar:DBPump:DB$ Pump | ValidTgts$ Bear.YouCtrl | TgtPrompt$ Choose target creature you control | SubAbility$ DBFight | SpellDescription$ Target Bear you control fights target creature you don't control.
 SVar:DBFight:DB$ Fight | Defined$ ParentTarget | ValidTgts$ Creature.YouDontCtrl | TgtPrompt$ Choose target creature you don't control
 DeckHas:Ability$Counters

--- a/forge-gui/res/cardsfolder/b/brightling.txt
+++ b/forge-gui/res/cardsfolder/b/brightling.txt
@@ -5,7 +5,7 @@ PT:3/3
 A:AB$ Pump | Cost$ W | KW$ Vigilance | Defined$ Self | SpellDescription$ CARDNAME gains vigilance until end of turn.
 A:AB$ Pump | Cost$ W | KW$ Lifelink | Defined$ Self | SpellDescription$ CARDNAME gains lifelink until end of turn.
 A:AB$ ChangeZone | Cost$ W | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return CARDNAME to its owner's hand.
-A:AB$ Pump | Cost$ 1 | Subability$ ABChoice | SpellDescription$ CARDNAME gets +1/-1 or -1/+1 until end of turn.
+A:AB$ Pump | Cost$ 1 | SubAbility$ ABChoice | SpellDescription$ CARDNAME gets +1/-1 or -1/+1 until end of turn.
 SVar:ABChoice:DB$ GenericChoice | Defined$ You | Choices$ ABPump1,ABPump2
 SVar:ABPump1:DB$ Pump | Defined$ Self | NumAtt$ +1 | NumDef$ -1 | SpellDescription$ +1/-1
 SVar:ABPump2:DB$ Pump | Defined$ Self | NumAtt$ -1 | NumDef$ +1 | SpellDescription$ -1/+1

--- a/forge-gui/res/cardsfolder/b/brightling.txt
+++ b/forge-gui/res/cardsfolder/b/brightling.txt
@@ -5,8 +5,7 @@ PT:3/3
 A:AB$ Pump | Cost$ W | KW$ Vigilance | Defined$ Self | SpellDescription$ CARDNAME gains vigilance until end of turn.
 A:AB$ Pump | Cost$ W | KW$ Lifelink | Defined$ Self | SpellDescription$ CARDNAME gains lifelink until end of turn.
 A:AB$ ChangeZone | Cost$ W | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return CARDNAME to its owner's hand.
-A:AB$ Pump | Cost$ 1 | SubAbility$ ABChoice | SpellDescription$ CARDNAME gets +1/-1 or -1/+1 until end of turn.
-SVar:ABChoice:DB$ GenericChoice | Defined$ You | Choices$ ABPump1,ABPump2
-SVar:ABPump1:DB$ Pump | Defined$ Self | NumAtt$ +1 | NumDef$ -1 | SpellDescription$ +1/-1
-SVar:ABPump2:DB$ Pump | Defined$ Self | NumAtt$ -1 | NumDef$ +1 | SpellDescription$ -1/+1
+A:AB$ GenericChoice | Cost$ 1 | Choices$ PumpAtt,PumpDef | SpellDescription$ CARDNAME gets +1/-1 or -1/+1 until end of turn.
+SVar:PumpAtt:DB$ Pump | Defined$ Self | NumAtt$ +1 | NumDef$ -1 | SpellDescription$ CARDNAME gets +1/-1 until end of turn.
+SVar:PumpDef:DB$ Pump | Defined$ Self | NumAtt$ -1 | NumDef$ +1 | SpellDescription$ CARDNAME gets -1/+1 until end of turn.
 Oracle:{W}: Brightling gains vigilance until end of turn.\n{W}: Brightling gains lifelink until end of turn.\n{W}: Return Brightling to its owner's hand.\n{1}: Brightling gets +1/-1 or -1/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/b/bronzebeak_foragers.txt
+++ b/forge-gui/res/cardsfolder/b/bronzebeak_foragers.txt
@@ -4,7 +4,7 @@ Types:Creature Dinosaur
 PT:3/4
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ When CARDNAME enters, for each opponent, exile up to one target nonland permanent that player controls until CARDNAME leaves the battlefield.
 SVar:TrigExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Permanent.nonLand+OppCtrl | TargetMin$ 0 | TargetMax$ OneEach | TargetsForEachPlayer$ True | TgtPrompt$ Select up to one target nonland permanent each opponent controls | Duration$ UntilHostLeavesPlay
-A:AB$ ChangeZone | Cost$ X W | Origin$ Exile | Destination$ Graveyard | TgtPrompt$ Select target permanent card exiled with CARDNAME with mana value X | Subability$ TrigLife | ValidTgts$ Permanent.ExiledWithSource+cmcEQX | SpellDescription$ Put target card with mana value X exiled with CARDNAME into its owner's graveyard. You gain X life.
+A:AB$ ChangeZone | Cost$ X W | Origin$ Exile | Destination$ Graveyard | TgtPrompt$ Select target permanent card exiled with CARDNAME with mana value X | SubAbility$ TrigLife | ValidTgts$ Permanent.ExiledWithSource+cmcEQX | SpellDescription$ Put target card with mana value X exiled with CARDNAME into its owner's graveyard. You gain X life.
 SVar:TrigLife:DB$ GainLife | Defined$ You | LifeAmount$ X
 SVar:X:Count$xPaid
 SVar:OneEach:PlayerCountOpponents$Amount

--- a/forge-gui/res/cardsfolder/b/buy_your_silence.txt
+++ b/forge-gui/res/cardsfolder/b/buy_your_silence.txt
@@ -1,7 +1,7 @@
 Name:Buy Your Silence
 ManaCost:4 W
 Types:Sorcery
-A:SP$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Permanent.nonLand | TgtPromt$ Select target nonland permanent | SubAbility$ DBTreasure | StackDescription$ SpellDescription | SpellDescription$ Exile target nonland permanent. Its controller creates a Treasure token. (It's an artifact with "{T}, Sacrifice this artifact: Add one mana of any color.")
+A:SP$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Permanent.nonLand | TgtPrompt$ Select target nonland permanent | SubAbility$ DBTreasure | StackDescription$ SpellDescription | SpellDescription$ Exile target nonland permanent. Its controller creates a Treasure token. (It's an artifact with "{T}, Sacrifice this artifact: Add one mana of any color.")
 SVar:DBTreasure:DB$ Token | TokenAmount$ 1 | TokenScript$ c_a_treasure_sac | TokenOwner$ TargetedController
 DeckHas:Ability$Sacrifice|Token & Type$Treasure|Artifact
 Oracle:Exile target nonland permanent. Its controller creates a Treasure token. (It's an artifact with "{T}, Sacrifice this artifact: Add one mana of any color.")

--- a/forge-gui/res/cardsfolder/c/comet_stellar_pup.txt
+++ b/forge-gui/res/cardsfolder/c/comet_stellar_pup.txt
@@ -6,7 +6,7 @@ A:AB$ RollDice | Cost$ AddCounter<0/LOYALTY> | Planeswalker$ True | ResultSubAbi
 SVar:Token:DB$ PutCounter | CounterType$ LOYALTY | CounterNum$ 2 | SubAbility$ DBToken | SpellDescription$ 1 or 2 – [+2], then create two 1/1 green Squirrel creature tokens. They gain haste until end of turn.
 SVar:DBToken:DB$ Token | TokenAmount$ 2 | TokenScript$ g_1_1_squirrel | PumpKeywords$ Haste | PumpDuration$ EOT
 SVar:Unearth:DB$ RemoveCounter | CounterType$ LOYALTY | CounterNum$ 1 | SubAbility$ DBChangeZone | SpellDescription$ 3 – [-1], then return a card with mana value 2 or less from your graveyard to your hand.
-SVar:DBChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | Mandatory$ True | ChangeType$ Card.YouOwn+cmcLE2 | ChangeDescription$ Choose a card with mana value 2 or less | Hidden$ True
+SVar:DBChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | Mandatory$ True | ChangeType$ Card.YouOwn+cmcLE2 | ChangeTypeDesc$ Choose a card with mana value 2 or less | Hidden$ True
 SVar:Damage:DB$ DealDamage | NumDmg$ X | CardChoices$ Creature | PlayerChoices$ Player | SubAbility$ DBRemoveCounters | SpellDescription$ 4 or 5 – CARDNAME deals damage equal to the number of loyalty counters on him to a creature or player, then [-2].
 SVar:X:Count$CardCounters.LOYALTY
 SVar:DBRemoveCounters:DB$ RemoveCounter | CounterType$ LOYALTY | CounterNum$ 2 | SubAbility$ DBCleanup

--- a/forge-gui/res/cardsfolder/c/coveted_jewel.txt
+++ b/forge-gui/res/cardsfolder/c/coveted_jewel.txt
@@ -4,7 +4,7 @@ Types:Artifact
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ When CARDNAME enters, draw three cards.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 3
 A:AB$ Mana | Cost$ T | Produced$ Any | Amount$ 3 | SpellDescription$ Add three mana of any one color.
-T:Mode$ AttackerUnblockedOnce | ValidAttackingPlayer$ Player.Opponent | ValidDefender$ You | TriggerZones$ Battlefield | Execute$ TrigDraw2 | TriggerDescription$ Whenever one or more creatures an opponent controls attack you and aren't blocked, that player draws three cards and gains control of CARDNAME. Untap it.
+T:Mode$ AttackerUnblockedOnce | ValidAttackingPlayer$ Player.Opponent | ValidDefenders$ You | TriggerZones$ Battlefield | Execute$ TrigDraw2 | TriggerDescription$ Whenever one or more creatures an opponent controls attack you and aren't blocked, that player draws three cards and gains control of CARDNAME. Untap it.
 SVar:TrigDraw2:DB$ Draw | Defined$ TriggeredAttackingPlayer | NumCards$ 3 | SubAbility$ DBGainGontrol
 SVar:DBGainGontrol:DB$ GainControl | NewController$ TriggeredAttackingPlayer | Untap$ True
 Oracle:When Coveted Jewel enters, draw three cards.\n{T}: Add three mana of any one color.\nWhenever one or more creatures an opponent controls attack you and aren't blocked, that player draws three cards and gains control of Coveted Jewel. Untap it.

--- a/forge-gui/res/cardsfolder/c/coveted_jewel.txt
+++ b/forge-gui/res/cardsfolder/c/coveted_jewel.txt
@@ -4,7 +4,7 @@ Types:Artifact
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ When CARDNAME enters, draw three cards.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 3
 A:AB$ Mana | Cost$ T | Produced$ Any | Amount$ 3 | SpellDescription$ Add three mana of any one color.
-T:Mode$ AttackerUnblockedOnce | ValidAttackingPlayer$ Player.Opponent | ValidDefenders$ You | TriggerZones$ Battlefield | Execute$ TrigDraw2 | TriggerDescription$ Whenever one or more creatures an opponent controls attack you and aren't blocked, that player draws three cards and gains control of CARDNAME. Untap it.
+T:Mode$ AttackerUnblockedOnce | ValidAttackingPlayer$ Player.Opponent | ValidDefender$ You | TriggerZones$ Battlefield | Execute$ TrigDraw2 | TriggerDescription$ Whenever one or more creatures an opponent controls attack you and aren't blocked, that player draws three cards and gains control of CARDNAME. Untap it.
 SVar:TrigDraw2:DB$ Draw | Defined$ TriggeredAttackingPlayer | NumCards$ 3 | SubAbility$ DBGainGontrol
 SVar:DBGainGontrol:DB$ GainControl | NewController$ TriggeredAttackingPlayer | Untap$ True
 Oracle:When Coveted Jewel enters, draw three cards.\n{T}: Add three mana of any one color.\nWhenever one or more creatures an opponent controls attack you and aren't blocked, that player draws three cards and gains control of Coveted Jewel. Untap it.

--- a/forge-gui/res/cardsfolder/d/dazzling_lights.txt
+++ b/forge-gui/res/cardsfolder/d/dazzling_lights.txt
@@ -1,7 +1,7 @@
 Name:Dazzling Lights
 ManaCost:U
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ -3 | IsCurse$ True | Subability$ DBSurveil | SpellDescription$ Target creature gets -3/-0 until end of turn. Surveil 2.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ -3 | IsCurse$ True | SubAbility$ DBSurveil | SpellDescription$ Target creature gets -3/-0 until end of turn. Surveil 2.
 SVar:DBSurveil:DB$ Surveil | Defined$ You | Amount$ 2
 DeckHas:Ability$Surveil|Graveyard
 Oracle:Target creature gets -3/-0 until end of turn.\nSurveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)

--- a/forge-gui/res/cardsfolder/d/deadly_visit.txt
+++ b/forge-gui/res/cardsfolder/d/deadly_visit.txt
@@ -1,7 +1,7 @@
 Name:Deadly Visit
 ManaCost:3 B B
 Types:Sorcery
-A:SP$ Destroy | ValidTgts$ Creature | TgtPrompt$ Select target creature | Subability$ DBSurveil | SpellDescription$ Destroy target creature. Surveil 2 (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)
+A:SP$ Destroy | ValidTgts$ Creature | TgtPrompt$ Select target creature | SubAbility$ DBSurveil | SpellDescription$ Destroy target creature. Surveil 2 (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)
 SVar:DBSurveil:DB$ Surveil | Amount$ 2
 DeckHas:Ability$Surveil|Graveyard
 Oracle:Destroy target creature.\nSurveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)

--- a/forge-gui/res/cardsfolder/e/endling.txt
+++ b/forge-gui/res/cardsfolder/e/endling.txt
@@ -5,8 +5,9 @@ PT:3/3
 A:AB$ Pump | Cost$ B | KW$ Menace | Defined$ Self | SpellDescription$ CARDNAME gains menace until end of turn.
 A:AB$ Pump | Cost$ B | Defined$ Self | KW$ Deathtouch | SpellDescription$ CARDNAME gains deathtouch until end of turn.
 A:AB$ Pump | Cost$ B | Defined$ Self | KW$ Undying | SpellDescription$ CARDNAME gains undying until end of turn.
-A:AB$ Pump | Cost$ 1 | Defined$ Self | NumAtt$ +1 | NumDef$ -1 | SpellDescription$ CARDNAME gets +1/-1 until end of turn.
-A:AB$ Pump | Cost$ 1 | Defined$ Self | NumAtt$ -1 | NumDef$ +1 | SpellDescription$ CARDNAME gets -1/+1 until end of turn.
+A:AB$ GenericChoice | Cost$ 1 | Choices$ PumpAtt,PumpDef | SpellDescription$ CARDNAME gets +1/-1 or -1/+1 until end of turn.
+SVar:PumpAtt:DB$ Pump | Defined$ Self | NumAtt$ +1 | NumDef$ -1 | SpellDescription$ CARDNAME gets +1/-1 until end of turn.
+SVar:PumpDef:DB$ Pump | Defined$ Self | NumAtt$ -1 | NumDef$ +1 | SpellDescription$ CARDNAME gets -1/+1 until end of turn.
 AI:RemoveDeck:Random
 AI:RemoveDeck:All
 Oracle:{B}: Endling gains menace until end of turn.\n{B}: Endling gains deathtouch until end of turn.\n{B}: Endling gains undying until end of turn. (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)\n{1}: Endling gets +1/-1 or -1/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/e/endurance_bobblehead.txt
+++ b/forge-gui/res/cardsfolder/e/endurance_bobblehead.txt
@@ -2,7 +2,7 @@ Name:Endurance Bobblehead
 ManaCost:3
 Types:Artifact Bobblehead
 A:AB$ Mana | Cost$ T | Produced$ Any | SpellDescription$ Add one mana of any color.
-A:AB$ Pump | Cost$ 3 T | ValidTgts$ Creature.YouCtrl | TargetMin$ 0 | NumAtt$ +1 | TargetMax$ X | KW$ Indestructible | TargetPrompt$ Select up to X target creatures you control | SorcerySpeed$ True | SpellDescription$ Up to X target creatures you control get +1/+0 and gain indestructible until end of turn, where X is the number of Bobbleheads you control as you activate this ability. Activate only as a sorcery.
+A:AB$ Pump | Cost$ 3 T | ValidTgts$ Creature.YouCtrl | TargetMin$ 0 | NumAtt$ +1 | TargetMax$ X | KW$ Indestructible | TgtPrompt$ Select up to X target creatures you control | SorcerySpeed$ True | SpellDescription$ Up to X target creatures you control get +1/+0 and gain indestructible until end of turn, where X is the number of Bobbleheads you control as you activate this ability. Activate only as a sorcery.
 SVar:X:Count$Valid Bobblehead.YouCtrl
 DeckNeeds:Type$Bobblehead
 Oracle:{T}: Add one mana of any color.\n{3}, {T}: Up to X target creatures you control get +1/+0 and gain indestructible until end of turn, where X is the number of Bobbleheads you control as you activate this ability. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/g/geometric_weird.txt
+++ b/forge-gui/res/cardsfolder/g/geometric_weird.txt
@@ -4,5 +4,5 @@ Types:Creature Weird
 PT:1/1
 SVar:X:Count$MaxDistinctOnStack
 T:Mode$ Phase | Phase$ End of Turn | TriggerZones$ Battlefield | Execute$ TrigGeo | OptionalDecider$ You | TriggerDescription$ At the beginning of each end step, you may have CARDNAME's base power and toughness each become equal to the greatest number of spells and abilities from different sources that were on the stack simultaneously that turn.
-SVar:TrigGeo:DB$ Animate | Duration$ Permanent | Power$ X | Toughness$ X | CARDNAME's base power and toughness each become equal to the greatest number of spells and abilities from different sources that were on the stack simultaneously that turn.
+SVar:TrigGeo:DB$ Animate | Duration$ Permanent | Power$ X | Toughness$ X
 Oracle:At the beginning of each end step, you may have Geometric Weird's base power and toughness each become equal to the greatest number of spells and abilities from different sources that were on the stack simultaneously that turn.

--- a/forge-gui/res/cardsfolder/g/goblin_polka_band.txt
+++ b/forge-gui/res/cardsfolder/g/goblin_polka_band.txt
@@ -2,7 +2,7 @@ Name:Goblin Polka Band
 ManaCost:R R
 Types:Creature Goblin
 PT:1/1
-A:AB$ Tap | Announce$ TgtNum | AnnounceTitle$ any number of creatures to target | Cost$ X 2 T | XColor$ Red | CostDesc$ {2}, {T}: | ValidTgts$ Creature.untapped | TargetMin$ TgtNum | TargetMax$ TgtNum | TargetsAtRandom$ True | RememberTapped$ True | AILogic$ GoblinPolkaBand | SubAbility$ GoblinHangover | SpellDescription$ Tap any number of random target creatures. Goblins tapped in this way do not untap during their controllers' next untap phases. This ability costs {R} more to activate for each target.
+A:AB$ Tap | Announce$ TgtNum | AnnounceTitle$ any number of creatures to target | Cost$ X 2 T | XColor$ R | CostDesc$ {2}, {T}: | ValidTgts$ Creature.untapped | TargetMin$ TgtNum | TargetMax$ TgtNum | TargetsAtRandom$ True | RememberTapped$ True | AILogic$ GoblinPolkaBand | SubAbility$ GoblinHangover | SpellDescription$ Tap any number of random target creatures. Goblins tapped in this way do not untap during their controllers' next untap phases. This ability costs {R} more to activate for each target.
 SVar:GoblinHangover:DB$ PumpAll | ValidCards$ Goblin.IsRemembered | KW$ HIDDEN This card doesn't untap during your next untap step. | Duration$ Permanent
 SVar:TgtNum:Number$0
 SVar:X:SVar$TgtNum

--- a/forge-gui/res/cardsfolder/g/goblin_polka_band.txt
+++ b/forge-gui/res/cardsfolder/g/goblin_polka_band.txt
@@ -2,7 +2,7 @@ Name:Goblin Polka Band
 ManaCost:R R
 Types:Creature Goblin
 PT:1/1
-A:AB$ Tap | Announce$ TgtNum | AnnounceTitle$ any number of creatures to target | Cost$ X 2 T | XColor$ R | CostDesc$ {2}, {T}: | ValidTgts$ Creature.untapped | TargetMin$ TgtNum | TargetMax$ TgtNum | TargetsAtRandom$ True | RememberTapped$ True | AILogic$ GoblinPolkaBand | SubAbility$ GoblinHangover | SpellDescription$ Tap any number of random target creatures. Goblins tapped in this way do not untap during their controllers' next untap phases. This ability costs {R} more to activate for each target.
+A:AB$ Tap | Announce$ TgtNum | AnnounceTitle$ any number of creatures to target | Cost$ X 2 T | XColor$ Red | CostDesc$ {2}, {T}: | ValidTgts$ Creature.untapped | TargetMin$ TgtNum | TargetMax$ TgtNum | TargetsAtRandom$ True | RememberTapped$ True | AILogic$ GoblinPolkaBand | SubAbility$ GoblinHangover | SpellDescription$ Tap any number of random target creatures. Goblins tapped in this way do not untap during their controllers' next untap phases. This ability costs {R} more to activate for each target.
 SVar:GoblinHangover:DB$ PumpAll | ValidCards$ Goblin.IsRemembered | KW$ HIDDEN This card doesn't untap during your next untap step. | Duration$ Permanent
 SVar:TgtNum:Number$0
 SVar:X:SVar$TgtNum

--- a/forge-gui/res/cardsfolder/h/hide_seek.txt
+++ b/forge-gui/res/cardsfolder/h/hide_seek.txt
@@ -10,7 +10,7 @@ ALTERNATE
 Name:Seek
 ManaCost:W B
 Types:Instant
-A:SP$ ChangeZone | ValidTgts$ Opponent | TgtPrompt$ Select target opponent | Origin$ Library | DefinedPlayer$ Targeted | Chooser$ You | Destination$ Exile | Changetype$ Card | ChangeNum$ 1 | RememberChanged$ True | IsCurse$ True | AILogic$ BestCard | SubAbility$ DBGainLife | StackDescription$ SpellDescription | SpellDescription$ Search target opponent's library for a card and exile it. You gain life equal to its mana value. Then that player shuffles.
+A:SP$ ChangeZone | ValidTgts$ Opponent | TgtPrompt$ Select target opponent | Origin$ Library | DefinedPlayer$ Targeted | Chooser$ You | Destination$ Exile | ChangeType$ Card | ChangeNum$ 1 | RememberChanged$ True | IsCurse$ True | AILogic$ BestCard | SubAbility$ DBGainLife | StackDescription$ SpellDescription | SpellDescription$ Search target opponent's library for a card and exile it. You gain life equal to its mana value. Then that player shuffles.
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Remembered$CardManaCost

--- a/forge-gui/res/cardsfolder/h/humiliate.txt
+++ b/forge-gui/res/cardsfolder/h/humiliate.txt
@@ -1,7 +1,7 @@
 Name:Humiliate
 ManaCost:W B
 Types:Sorcery
-A:SP$ Discard | ValidTgts$ Opponent | DiscardValid$ Card.nonLand | NumCards$ 1 | Mode$ RevealYouChoose | Subability$ DBPutCounter | SpellDescription$ Target opponent reveals their hand. You choose a nonland card from it. That player discards that card. Put a +1/+1 counter on a creature you control.
+A:SP$ Discard | ValidTgts$ Opponent | DiscardValid$ Card.nonLand | NumCards$ 1 | Mode$ RevealYouChoose | SubAbility$ DBPutCounter | SpellDescription$ Target opponent reveals their hand. You choose a nonland card from it. That player discards that card. Put a +1/+1 counter on a creature you control.
 SVar:DBPutCounter:DB$ PutCounter | Choices$ Creature.YouCtrl | CounterType$ P1P1 | CounterNum$ 1
 DeckHas:Ability$Counters
 Oracle:Target opponent reveals their hand. You choose a nonland card from it. That player discards that card. Put a +1/+1 counter on a creature you control.

--- a/forge-gui/res/cardsfolder/i/imoen_trickster_friend.txt
+++ b/forge-gui/res/cardsfolder/i/imoen_trickster_friend.txt
@@ -33,7 +33,7 @@ PT:3/2
 S:Mode$ CantBlockBy | ValidAttacker$ Creature.Self | Description$ CARDNAME can't be blocked.
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigImmTrigger | TriggerZones$ Battlefield | TriggerDescription$ Whenever NICKNAME deals combat damage to a player, you may exile an instant or sorcery card from your graveyard. When you do, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.
 SVar:TrigImmTrigger:AB$ ImmediateTrigger | Cost$ ExileFromGrave<1/Instant;Sorcery/instant or sorcery> | Execute$ TrigTap | Secondary$ True | TriggerDescription$ When you do, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.
-SVar:TrigTap:DB$ Tap | ValidTgts$ Creature.OppCtrl | TgtPromopt$ Select target creature an opponent controls | SubAbility$ DBPump
+SVar:TrigTap:DB$ Tap | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | SubAbility$ DBPump
 SVar:DBPump:DB$ Pump | Defined$ Targeted | Duration$ Permanent | KW$ HIDDEN This card doesn't untap during your next untap step.
 DeckHints:Ability$Graveyard & Type$Instant|Sorcery
 Oracle:Imoen, Wily Trickster can't be blocked.\nWhenever Imoen deals combat damage to a player, you may exile an instant or sorcery card from your graveyard. When you do, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.

--- a/forge-gui/res/cardsfolder/l/last_night_together.txt
+++ b/forge-gui/res/cardsfolder/l/last_night_together.txt
@@ -3,7 +3,7 @@ ManaCost:3 R G
 Types:Sorcery
 A:SP$ ChooseCard | ValidTgts$ Creature | TgtPrompt$ Choose two target creatures | TargetMin$ 2 | TargetMax$ 2 | Amount$ 2 | Defined$ You | DefinedCards$ Targeted | AtRandom$ True | SubAbility$ DBUntap | SpellDescription$ Choose two target creatures.
 SVar:DBUntap:DB$ Untap | Defined$ Targeted | SubAbility$ DBPutCounter | SpellDescription$ Untap them.
-SVar:DBPutCounter:DB$ PutCounter | Defined$ Targeted | CounterType$ P1P1 | CounterNum$ 2 | SubAbility$ DBPump | Put two +1/+1 counters on each of them.
+SVar:DBPutCounter:DB$ PutCounter | Defined$ Targeted | CounterType$ P1P1 | CounterNum$ 2 | SubAbility$ DBPump | SpellDescription$ Put two +1/+1 counters on each of them.
 SVar:DBPump:DB$ Pump | Defined$ Targeted | KW$ Vigilance & Indestructible & Haste | SubAbility$ DBAddCombat | SpellDescription$ They gain vigilance, indestructible, and haste until end of turn.
 SVar:DBAddCombat:DB$ AddPhase | ExtraPhase$ Combat | ExtraPhaseDelayedTrigger$ DelTrigStatic | ExtraPhaseDelayedTriggerExcute$ TrigEffect | ConditionPhases$ Main1,Main2 | SpellDescription$ After this main phase, there is an additional combat phase. Only the chosen creatures can attack during that combat phase.
 SVar:DelTrigStatic:Mode$ Phase | Static$ True | Phase$ BeginCombat | TriggerDescription$ After this main phase, there is an additional combat phase. Only the chosen creatures can attack during that combat phase.

--- a/forge-gui/res/cardsfolder/l/leyline_tyrant.txt
+++ b/forge-gui/res/cardsfolder/l/leyline_tyrant.txt
@@ -5,7 +5,7 @@ PT:4/4
 K:Flying
 S:Mode$ UnspentMana | ValidPlayer$ You | ManaType$ Red | Description$ You don't lose unspent red mana as steps and phases end.
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigImmediateTrig | TriggerDescription$ When CARDNAME dies, you may pay any amount of {R}. When you do, it deals that much damage to any target.
-SVar:TrigImmediateTrig:AB$ ImmediateTrigger | Cost$ X | XColor$ R | XAnnounceTitle$ any amount of red mana to pay | Execute$ TrigDamage | TriggerDescription$ When you do, CARDNAME deals that much damage to any target.
+SVar:TrigImmediateTrig:AB$ ImmediateTrigger | Cost$ X | XColor$ Red | XAnnounceTitle$ any amount of red mana to pay | Execute$ TrigDamage | TriggerDescription$ When you do, CARDNAME deals that much damage to any target.
 SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Any | NumDmg$ X
 SVar:X:Count$xPaid
 Oracle:Flying\nYou don't lose unspent red mana as steps and phases end.\nWhen Leyline Tyrant dies, you may pay any amount of {R}. When you do, it deals that much damage to any target.

--- a/forge-gui/res/cardsfolder/l/leyline_tyrant.txt
+++ b/forge-gui/res/cardsfolder/l/leyline_tyrant.txt
@@ -5,7 +5,7 @@ PT:4/4
 K:Flying
 S:Mode$ UnspentMana | ValidPlayer$ You | ManaType$ Red | Description$ You don't lose unspent red mana as steps and phases end.
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigImmediateTrig | TriggerDescription$ When CARDNAME dies, you may pay any amount of {R}. When you do, it deals that much damage to any target.
-SVar:TrigImmediateTrig:AB$ ImmediateTrigger | Cost$ X | XColor$ Red | XAnnounceTitle$ any amount of red mana to pay | Execute$ TrigDamage | TriggerDescription$ When you do, CARDNAME deals that much damage to any target.
+SVar:TrigImmediateTrig:AB$ ImmediateTrigger | Cost$ X | XColor$ R | XAnnounceTitle$ any amount of red mana to pay | Execute$ TrigDamage | TriggerDescription$ When you do, CARDNAME deals that much damage to any target.
 SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Any | NumDmg$ X
 SVar:X:Count$xPaid
 Oracle:Flying\nYou don't lose unspent red mana as steps and phases end.\nWhen Leyline Tyrant dies, you may pay any amount of {R}. When you do, it deals that much damage to any target.

--- a/forge-gui/res/cardsfolder/l/live_fast.txt
+++ b/forge-gui/res/cardsfolder/l/live_fast.txt
@@ -2,6 +2,6 @@ Name:Live Fast
 ManaCost:2 B
 Types:Sorcery
 A:SP$ Draw | NumCards$ 2 | SubAbility$ DBLoseLife | SpellDescription$ You draw two cards, lose 2 life, and get {E}{E} (two energy counters).
-SVar:DBLoseLife:DB$ LoseLife | LifeAmount$ 2 | Subability$ DBEnergy
+SVar:DBLoseLife:DB$ LoseLife | LifeAmount$ 2 | SubAbility$ DBEnergy
 SVar:DBEnergy:DB$ PutCounter | Defined$ You | CounterType$ ENERGY | CounterNum$ 2
 Oracle:You draw two cards, lose 2 life, and get {E}{E} (two energy counters).

--- a/forge-gui/res/cardsfolder/m/master_of_the_wild_hunt_avatar.txt
+++ b/forge-gui/res/cardsfolder/m/master_of_the_wild_hunt_avatar.txt
@@ -5,6 +5,6 @@ HandLifeModifier:+1/+3
 A:AB$ GenericChoice | Cost$ 2 G | Choices$ Wolf,Antelope,Cat,Rhino | ActivationZone$ Command | AtRandom$ True | StackDescription$ SpellDescription | SpellDescription$ Create a green creature token that's a 2/2 Wolf, a 2/3 Antelope with forestwalk, a 3/2 Cat with shroud, or a 4/4 Rhino with trample, chosen at random.
 SVar:Wolf:DB$ Token | TokenAmount$ 1 | TokenScript$ g_2_2_wolf | TokenOwner$ You | SpellDescription$ Wolf
 SVar:Antelope:DB$ Token | TokenAmount$ 1 | TokenScript$ g_2_3_antelope_forestwalk | TokenOwner$ You | SpellDescription$ Antelope
-SVar:Cat:DB$ Token | TokenAmount$ 1 | TokenScript$ g_3_2_cat_shroud | TokenOwner$ You | SpellDscription$ Cat
+SVar:Cat:DB$ Token | TokenAmount$ 1 | TokenScript$ g_3_2_cat_shroud | TokenOwner$ You | SpellDescription$ Cat
 SVar:Rhino:DB$ Token | TokenAmount$ 1 | TokenScript$ g_4_4_rhino_trample | TokenOwner$ You | SpellDescription$ Rhino
 Oracle:Hand +1, life +3\n{2}{G}: Create a green creature token that's a 2/2 Wolf, a 2/3 Antelope with forestwalk, a 3/2 Cat with shroud, or a 4/4 Rhino with trample, chosen at random.

--- a/forge-gui/res/cardsfolder/m/mephitic_vapors.txt
+++ b/forge-gui/res/cardsfolder/m/mephitic_vapors.txt
@@ -1,7 +1,7 @@
 Name:Mephitic Vapors
 ManaCost:2 B
 Types:Sorcery
-A:SP$ PumpAll | ValidCards$ Creature | NumAtt$ -1 | NumDef$ -1 | IsCurse$ True | Subability$ DBSurveil | SpellDescription$ All creatures get -1/-1 until end of turn.
+A:SP$ PumpAll | ValidCards$ Creature | NumAtt$ -1 | NumDef$ -1 | IsCurse$ True | SubAbility$ DBSurveil | SpellDescription$ All creatures get -1/-1 until end of turn.
 SVar:DBSurveil:DB$ Surveil | Amount$ 2
 DeckHas:Ability$Surveil|Graveyard
 Oracle:All creatures get -1/-1 until end of turn.\nSurveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)

--- a/forge-gui/res/cardsfolder/m/mordor_muster.txt
+++ b/forge-gui/res/cardsfolder/m/mordor_muster.txt
@@ -2,7 +2,7 @@ Name:Mordor Muster
 ManaCost:1 B
 Types:Sorcery
 A:SP$ Draw | SubAbility$ DBLoseLife | SpellDescription$ You draw a card and you lose 1 life.
-SVar:DBLoseLife:DB$ LoseLife | LifeAmount$ 1 | Subability$ DBAmass
+SVar:DBLoseLife:DB$ LoseLife | LifeAmount$ 1 | SubAbility$ DBAmass
 SVar:DBAmass:DB$ Amass | Type$ Orc | Num$ 1 | SpellDescription$ Amass Orcs 1. (Put a +1/+1 counter on an Army you control. It's also an Orc. If you don't control an Army, create a 0/0 black Orc Army creature token first.)
 DeckHas:Ability$Token|Counters & Type$Orc|Army
 Oracle:You draw a card and you lose 1 life.\nAmass Orcs 1. (Put a +1/+1 counter on an Army you control. It's also an Orc. If you don't control an Army, create a 0/0 black Orc Army creature token first.)

--- a/forge-gui/res/cardsfolder/m/multiform_wonder.txt
+++ b/forge-gui/res/cardsfolder/m/multiform_wonder.txt
@@ -5,8 +5,7 @@ PT:3/3
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigEnergy | TriggerDescription$ When CARDNAME enters, you get {E}{E}{E} (three energy counters).
 SVar:TrigEnergy:DB$ PutCounter | Defined$ You | CounterType$ ENERGY | CounterNum$ 3
 A:AB$ Pump | Cost$ PayEnergy<1> | KWChoice$ Flying,Vigilance,Lifelink | StackDescription$ SpellDescription | SpellDescription$ CARDNAME gains your choice of flying, vigilance, or lifelink until end of turn.
-A:AB$ Pump | Cost$ PayEnergy<1> | SubAbility$ ABChoice | StackDescription$ SpellDescription | SpellDescription$ CARDNAME gets +2/-2 or -2/+2 until end of turn.
-SVar:ABChoice:DB$ GenericChoice | Defined$ You | Choices$ ABPump1,ABPump2
+A:AB$ GenericChoice | Cost$ PayEnergy<1> | Defined$ You | Choices$ ABPump1,ABPump2 | StackDescription$ SpellDescription | SpellDescription$ CARDNAME gets +2/-2 or -2/+2 until end of turn.
 SVar:ABPump1:DB$ Pump | Defined$ Self | NumAtt$ +2 | NumDef$ -2 | SpellDescription$ +2/-2
 SVar:ABPump2:DB$ Pump | Defined$ Self | NumAtt$ -2 | NumDef$ +2 | SpellDescription$ -2/+2
 Oracle:When Multiform Wonder enters, you get {E}{E}{E} (three energy counters).\nPay {E}: Multiform Wonder gains your choice of flying, vigilance, or lifelink until end of turn.\nPay {E}: Multiform Wonder gets +2/-2 or -2/+2 until end of turn.

--- a/forge-gui/res/cardsfolder/m/multiform_wonder.txt
+++ b/forge-gui/res/cardsfolder/m/multiform_wonder.txt
@@ -5,7 +5,7 @@ PT:3/3
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigEnergy | TriggerDescription$ When CARDNAME enters, you get {E}{E}{E} (three energy counters).
 SVar:TrigEnergy:DB$ PutCounter | Defined$ You | CounterType$ ENERGY | CounterNum$ 3
 A:AB$ Pump | Cost$ PayEnergy<1> | KWChoice$ Flying,Vigilance,Lifelink | StackDescription$ SpellDescription | SpellDescription$ CARDNAME gains your choice of flying, vigilance, or lifelink until end of turn.
-A:AB$ Pump | Cost$ PayEnergy<1> | Subability$ ABChoice | StackDescription$ SpellDescription | SpellDescription$ CARDNAME gets +2/-2 or -2/+2 until end of turn.
+A:AB$ Pump | Cost$ PayEnergy<1> | SubAbility$ ABChoice | StackDescription$ SpellDescription | SpellDescription$ CARDNAME gets +2/-2 or -2/+2 until end of turn.
 SVar:ABChoice:DB$ GenericChoice | Defined$ You | Choices$ ABPump1,ABPump2
 SVar:ABPump1:DB$ Pump | Defined$ Self | NumAtt$ +2 | NumDef$ -2 | SpellDescription$ +2/-2
 SVar:ABPump2:DB$ Pump | Defined$ Self | NumAtt$ -2 | NumDef$ +2 | SpellDescription$ -2/+2

--- a/forge-gui/res/cardsfolder/n/neutralize_the_guards.txt
+++ b/forge-gui/res/cardsfolder/n/neutralize_the_guards.txt
@@ -1,7 +1,7 @@
 Name:Neutralize the Guards
 ManaCost:2 B
 Types:Instant
-A:SP$ PumpAll | ValidTgts$ Opponent | TgtPrompt$ Select target player | ValidCards$ Creature | NumAtt$ -1 | NumDef$ -1 | Subability$ DBSurveil | SpellDescription$ Creatures target opponent controls get -1/-1 until end of turn. Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)
+A:SP$ PumpAll | ValidTgts$ Opponent | TgtPrompt$ Select target player | ValidCards$ Creature | NumAtt$ -1 | NumDef$ -1 | SubAbility$ DBSurveil | SpellDescription$ Creatures target opponent controls get -1/-1 until end of turn. Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)
 SVar:DBSurveil:DB$ Surveil | Defined$ You | Amount$ 2
 DeckHas:Ability$Surveil|Graveyard
 Oracle:Creatures target opponent controls get -1/-1 until end of turn. Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)

--- a/forge-gui/res/cardsfolder/p/pearl_collector.txt
+++ b/forge-gui/res/cardsfolder/p/pearl_collector.txt
@@ -6,7 +6,7 @@ K:Deathtouch
 K:Lifelink
 T:Mode$ Phase | Phase$ Main2 | CheckSVar$ YouLifeGained | SVarCompare$ GE4 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigConjure | GameActivationLimit$ 1 | TriggerDescription$ At the beginning of your postcombat main phase, if you gained 4 or more life this turn, conjure a card named Mox Pearl into your hand. This ability triggers only once.
 SVar:TrigConjure:DB$ MakeCard | Conjure$ True | Name$ Mox Pearl | Zone$ Hand
-A:AB$ Pump | Cost$ 2 W | KW$ Lifelink | ValidTgts$ Creature.Other | TargetPrompt$ Select up to one other target creature | Duration$ Perpetual | SpellDescription$ Another target creature perpetually gains lifelink.
+A:AB$ Pump | Cost$ 2 W | KW$ Lifelink | ValidTgts$ Creature.Other | TgtPrompt$ Select up to one other target creature | Duration$ Perpetual | SpellDescription$ Another target creature perpetually gains lifelink.
 SVar:YouLifeGained:Count$LifeYouGainedThisTurn
 DeckHas:Type$Artifact & Ability$LifeGain
 DeckHints:Ability$LifeGain

--- a/forge-gui/res/cardsfolder/p/pollenbright_druid.txt
+++ b/forge-gui/res/cardsfolder/p/pollenbright_druid.txt
@@ -4,7 +4,7 @@ Types:Creature Elf Druid
 PT:1/1
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigCharm | TriggerDescription$ When CARDNAME enters, ABILITY
 SVar:TrigCharm:DB$ Charm | Choices$ DBCounter,DBProliferate
-SVar:DBCounter:DB$ PutCounter | ValidTgts$ Creature | Tgtprompt$ Select target creature | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on target creature.
+SVar:DBCounter:DB$ PutCounter | ValidTgts$ Creature | TgtPrompt$ Select target creature | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on target creature.
 SVar:DBProliferate:DB$ Proliferate | SpellDescription$ Proliferate (Choose any number of permanents and/or players, then give each another counter of each kind already there.)
 SVar:PlayMain1:TRUE
 DeckHas:Ability$Counters & Ability$Proliferate

--- a/forge-gui/res/cardsfolder/q/quarrels_end.txt
+++ b/forge-gui/res/cardsfolder/q/quarrels_end.txt
@@ -1,7 +1,7 @@
 Name:Quarrel's End
 ManaCost:2 R
 Types:Sorcery
-A:SP$ Draw | Cost$ 2 R Discard<1/Card/card> | NumCards$ 2 | SubAbility$ DBToken | SpellDescripion$ Draw two cards and create a 1/1 white Human Soldier creature token.
+A:SP$ Draw | Cost$ 2 R Discard<1/Card/card> | NumCards$ 2 | SubAbility$ DBToken | SpellDescription$ Draw two cards and create a 1/1 white Human Soldier creature token.
 SVar:DBToken:DB$ Token | TokenOwner$ You | TokenAmount$ 1 | TokenScript$ w_1_1_human_soldier
 DeckHas:Ability$Discard|Token & Type$Human|Soldier
 Oracle:As an additional cost to cast this spell, discard a card.\nDraw two cards and create a 1/1 white Human Soldier creature token.

--- a/forge-gui/res/cardsfolder/r/ravenous_pursuit.txt
+++ b/forge-gui/res/cardsfolder/r/ravenous_pursuit.txt
@@ -3,7 +3,7 @@ ManaCost:1 G
 Types:Sorcery
 A:SP$ Pump | ValidTgts$ Creature.YouCtrl | AILogic$ PowerDmg | TgtPrompt$ Select target creature you control | SubAbility$ DBDamage | StackDescription$ None | SpellDescription$ Target creature you control deals damage equal to its power to target creature.
 SVar:DBDamage:DB$ DealDamage | ValidTgts$ Creature.YouDontCtrl | TgtPrompt$ Select target creature you don't control | AILogic$ PowerDmg | NumDmg$ ParentTargeted$CardPower | ExcessSVar$ Excess | DamageSource$ ParentTarget | SubAbility$ DBChooseCard
-SVar:DBChooseCard:DB$ ChooseCard | ChoiceZone$ Hand | Choices$ Creature.YouOwn | ChoiceTitle$ Choose a creature card in your hand | Madatory$ True | SubAbility$ DBEffect | SpellDescription$ Choose a creature card in your hand. | StackDescription$ SpellDescription
+SVar:DBChooseCard:DB$ ChooseCard | ChoiceZone$ Hand | Choices$ Creature.YouOwn | ChoiceTitle$ Choose a creature card in your hand | Mandatory$ True | SubAbility$ DBEffect | SpellDescription$ Choose a creature card in your hand. | StackDescription$ SpellDescription
 SVar:DBEffect:DB$ Pump | Defined$ ChosenCard | PumpZone$ Hand | NumAtt$ Excess | NumDef$ Excess | Duration$ Perpetual | SubAbility$ DBCleanup | StackDescription$ SpellDescription | SpellDescription$ It perpetually gets +X/+X, where X is the amount of excess damage dealt this way.
 SVar:DBCleanup:DB$ Cleanup | ClearChosenCard$ True
 Oracle:Target creature you control deals damage equal to its power to target creature you don't control. Choose a creature card in your hand. It perpetually gets +X/+X, where X is the amount of excess damage dealt this way.

--- a/forge-gui/res/cardsfolder/r/return_to_nature.txt
+++ b/forge-gui/res/cardsfolder/r/return_to_nature.txt
@@ -2,7 +2,7 @@ Name:Return to Nature
 ManaCost:1 G
 Types:Instant
 A:SP$ Charm | Choices$ DBDestroyArtifact,DBDestroyEnchantment,DBExile
-SVar:DBDestroyArtifact:DB$ Destroy | ValidTgts$ Artifact | Tgtprompt$ Select target artifact | SpellDescription$ Destroy target artifact.
-SVar:DBDestroyEnchantment:DB$ Destroy | ValidTgts$ Enchantment | Tgtprompt$ Select target enchantment | SpellDescription$ Destroy target enchantment.
+SVar:DBDestroyArtifact:DB$ Destroy | ValidTgts$ Artifact | TgtPrompt$ Select target artifact | SpellDescription$ Destroy target artifact.
+SVar:DBDestroyEnchantment:DB$ Destroy | ValidTgts$ Enchantment | TgtPrompt$ Select target enchantment | SpellDescription$ Destroy target enchantment.
 SVar:DBExile:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | ValidTgts$ Card | TgtPrompt$ Select target card from a graveyard. | SpellDescription$ Exile target card fom a graveyard.
 Oracle:Choose one —\n• Destroy target artifact.\n• Destroy target enchantment.\n• Exile target card from a graveyard.

--- a/forge-gui/res/cardsfolder/r/rowan_scholar_of_sparks_will_scholar_of_frost.txt
+++ b/forge-gui/res/cardsfolder/r/rowan_scholar_of_sparks_will_scholar_of_frost.txt
@@ -23,7 +23,7 @@ S:Mode$ ReduceCost | ValidCard$ Instant,Sorcery | Type$ Spell | Activator$ You |
 A:AB$ Animate | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | ValidTgts$ Creature | TgtPrompt$ Select up to one target creature | TargetMin$ 0 | TargetMax$ 1 | Power$ 0 | Toughness$ 2 | Duration$ UntilYourNextTurn | SpellDescription$ Up to one target creature has base power and toughness 0/2 until your next turn.
 A:AB$ Draw | Cost$ SubCounter<3/LOYALTY> | Planeswalker$ True | NumCards$ 2 | SpellDescription$ Draw two cards.
 A:AB$ ChangeZone | Cost$ SubCounter<7/LOYALTY> | Planeswalker$ True | Ultimate$ True | ValidTgts$ Permanent | TgtPrompt$ Select up to five target permanents | TargetMin$ 0 | TargetMax$ 5 | Origin$ Battlefield | Destination$ Exile | RememberLKI$ True | SubAbility$ DBRepeat | SpellDescription$ Exile up to five target permanents. For each permanent exiled this way, its controller creates a 4/4 blue and red Elemental creature token.
-SVar:DBRepeat:DB$ RepeatEach | DefinedCards$ DirectRemembered | UseImprinted$ True | RepeatSubAbility$ DBToken | SubAbility$ DBCleanup | ChangeZoneTables$ True
+SVar:DBRepeat:DB$ RepeatEach | DefinedCards$ DirectRemembered | UseImprinted$ True | RepeatSubAbility$ DBToken | SubAbility$ DBCleanup | ChangeZoneTable$ True
 SVar:DBToken:DB$ Token | TokenScript$ ur_4_4_elemental | TokenOwner$ ImprintedController
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 DeckHas:Ability$Token

--- a/forge-gui/res/cardsfolder/rebalanced/a-buy_your_silence.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-buy_your_silence.txt
@@ -1,7 +1,7 @@
 Name:A-Buy Your Silence
 ManaCost:4 W
 Types:Instant
-A:SP$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Permanent.nonLand | TgtPromt$ Select target nonland permanent | SubAbility$ DBTreasure | StackDescription$ SpellDescription | SpellDescription$ Exile target nonland permanent. Its controller creates a Treasure token.
+A:SP$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Permanent.nonLand | TgtPrompt$ Select target nonland permanent | SubAbility$ DBTreasure | StackDescription$ SpellDescription | SpellDescription$ Exile target nonland permanent. Its controller creates a Treasure token.
 SVar:DBTreasure:DB$ Token | TokenAmount$ 1 | TokenScript$ c_a_treasure_sac | TokenOwner$ TargetedController
 DeckHas:Ability$Sacrifice|Token & Type$Treasure|Artifact
 Oracle:Exile target nonland permanent. Its controller creates a Treasure token.

--- a/forge-gui/res/cardsfolder/rebalanced/a-rowan_scholar_of_sparks_will_scholar_of_frost.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-rowan_scholar_of_sparks_will_scholar_of_frost.txt
@@ -23,7 +23,7 @@ S:Mode$ ReduceCost | ValidCard$ Instant,Sorcery | Type$ Spell | Activator$ You |
 A:AB$ Animate | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | ValidTgts$ Creature | TgtPrompt$ Select up to one target creature | TargetMin$ 0 | TargetMax$ 1 | Power$ 0 | Toughness$ 2 | Duration$ UntilYourNextTurn | SpellDescription$ Up to one target creature has base power and toughness 0/2 until your next turn.
 A:AB$ Draw | Cost$ SubCounter<3/LOYALTY> | Planeswalker$ True | NumCards$ 2 | SpellDescription$ Draw two cards.
 A:AB$ ChangeZone | Cost$ SubCounter<8/LOYALTY> | Planeswalker$ True | Ultimate$ True | ValidTgts$ Permanent | TgtPrompt$ Select up to five target permanents | TargetMin$ 0 | TargetMax$ 5 | Origin$ Battlefield | Destination$ Exile | RememberLKI$ True | SubAbility$ DBRepeat | SpellDescription$ Exile up to five target permanents. For each permanent exiled this way, its controller creates a 4/4 blue and red Elemental creature token.
-SVar:DBRepeat:DB$ RepeatEach | DefinedCards$ DirectRemembered | UseImprinted$ True | RepeatSubAbility$ DBToken | SubAbility$ DBCleanup | ChangeZoneTables$ True
+SVar:DBRepeat:DB$ RepeatEach | DefinedCards$ DirectRemembered | UseImprinted$ True | RepeatSubAbility$ DBToken | SubAbility$ DBCleanup | ChangeZoneTable$ True
 SVar:DBToken:DB$ Token | TokenScript$ ur_4_4_elemental | TokenOwner$ ImprintedController
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 DeckHas:Ability$Token

--- a/forge-gui/res/cardsfolder/s/shorecrasher_elemental.txt
+++ b/forge-gui/res/cardsfolder/s/shorecrasher_elemental.txt
@@ -5,8 +5,7 @@ PT:3/3
 K:Megamorph:4 U
 A:AB$ ChangeZone | Cost$ U | Defined$ Self | Origin$ Battlefield | Destination$ Exile | SubAbility$ DBReturn | SpellDescription$ Exile CARDNAME, then return it to the battlefield face down under its owner's control.
 SVar:DBReturn:DB$ ChangeZone | FaceDown$ True | Origin$ Exile | Destination$ Battlefield | Defined$ CorrectedSelf
-A:AB$ Pump | Cost$ 1 | SubAbility$ ABChoice | SpellDescription$ CARDNAME gets +1/-1 or -1/+1 until end of turn.
-SVar:ABChoice:DB$ GenericChoice | Defined$ You | Choices$ ABPump1,ABPump2
-SVar:ABPump1:DB$ Pump | Defined$ Self | NumAtt$ +1 | NumDef$ -1 | SpellDescription$ +1/-1
-SVar:ABPump2:DB$ Pump | Defined$ Self | NumAtt$ -1 | NumDef$ +1 | SpellDescription$ -1/+1
+A:AB$ GenericChoice | Cost$ 1 | Choices$ PumpAtt,PumpDef | SpellDescription$ CARDNAME gets +1/-1 or -1/+1 until end of turn.
+SVar:PumpAtt:DB$ Pump | Defined$ Self | NumAtt$ +1 | NumDef$ -1 | SpellDescription$ CARDNAME gets +1/-1 until end of turn.
+SVar:PumpDef:DB$ Pump | Defined$ Self | NumAtt$ -1 | NumDef$ +1 | SpellDescription$ CARDNAME gets -1/+1 until end of turn.
 Oracle:{U}: Exile Shorecrasher Elemental, then return it to the battlefield face down under its owner's control.\n{1}: Shorecrasher Elemental gets +1/-1 or -1/+1 until end of turn.\nMegamorph {4}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)

--- a/forge-gui/res/cardsfolder/s/shorecrasher_elemental.txt
+++ b/forge-gui/res/cardsfolder/s/shorecrasher_elemental.txt
@@ -5,7 +5,7 @@ PT:3/3
 K:Megamorph:4 U
 A:AB$ ChangeZone | Cost$ U | Defined$ Self | Origin$ Battlefield | Destination$ Exile | SubAbility$ DBReturn | SpellDescription$ Exile CARDNAME, then return it to the battlefield face down under its owner's control.
 SVar:DBReturn:DB$ ChangeZone | FaceDown$ True | Origin$ Exile | Destination$ Battlefield | Defined$ CorrectedSelf
-A:AB$ Pump | Cost$ 1 | Subability$ ABChoice | SpellDescription$ CARDNAME gets +1/-1 or -1/+1 until end of turn.
+A:AB$ Pump | Cost$ 1 | SubAbility$ ABChoice | SpellDescription$ CARDNAME gets +1/-1 or -1/+1 until end of turn.
 SVar:ABChoice:DB$ GenericChoice | Defined$ You | Choices$ ABPump1,ABPump2
 SVar:ABPump1:DB$ Pump | Defined$ Self | NumAtt$ +1 | NumDef$ -1 | SpellDescription$ +1/-1
 SVar:ABPump2:DB$ Pump | Defined$ Self | NumAtt$ -1 | NumDef$ +1 | SpellDescription$ -1/+1

--- a/forge-gui/res/cardsfolder/s/signature_slam.txt
+++ b/forge-gui/res/cardsfolder/s/signature_slam.txt
@@ -2,7 +2,7 @@ Name:Signature Slam
 ManaCost:2 G
 Types:Instant
 A:SP$ PutCounter | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | CounterType$ P1P1 | SubAbility$ DBEachDamage | SpellDescription$ Put a +1/+1 counter on target creature you control,
-SVar:DBEachDamage:DB$ EachDamage | DefinedDamagers$ Valid Creature.modified+YouCtrl | ValidTgts$ Creature.YouDontCtrl | TgtPrompt$ Select target creature you don't control | NumDmg$ Count$CardPower | ValidDesc$ modified creature you control | DamageDesc$ damage equal to its power | SpellDescription$ then each modified creature you control deals damage equal to its power to target creature you don't control. (Equipment, Auras you control, and counters are modifications.)
+SVar:DBEachDamage:DB$ EachDamage | DefinedDamagers$ Valid Creature.modified+YouCtrl | ValidTgts$ Creature.YouDontCtrl | TgtPrompt$ Select target creature you don't control | NumDmg$ Count$CardPower | ValidDescription$ modified creature you control | DamageDesc$ damage equal to its power | SpellDescription$ then each modified creature you control deals damage equal to its power to target creature you don't control. (Equipment, Auras you control, and counters are modifications.)
 DeckHas:Ability$Counters
 DeckHints:Type$Aura|Equipment & Ability$Counters
 Oracle:Put a +1/+1 counter on target creature you control, then each modified creature you control deals damage equal to its power to target creature you don't control. (Equipment, Auras you control, and counters are modifications.)

--- a/forge-gui/res/cardsfolder/s/sinister_sabotage.txt
+++ b/forge-gui/res/cardsfolder/s/sinister_sabotage.txt
@@ -1,7 +1,7 @@
 Name:Sinister Sabotage
 ManaCost:1 U U
 Types:Instant
-A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | Subability$ DBSurveil | SpellDescription$ Counter target spell. Surveil 1 (Look at the top card of your library. You may put that card into your graveyard.)
+A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | SubAbility$ DBSurveil | SpellDescription$ Counter target spell. Surveil 1 (Look at the top card of your library. You may put that card into your graveyard.)
 SVar:DBSurveil:DB$ Surveil | Amount$ 1
 DeckHas:Ability$Surveil|Graveyard
 Oracle:Counter target spell.\nSurveil 1. (Look at the top card of your library. You may put that card into your graveyard.)

--- a/forge-gui/res/cardsfolder/s/spellweaver_volute.txt
+++ b/forge-gui/res/cardsfolder/s/spellweaver_volute.txt
@@ -2,11 +2,11 @@ Name:Spellweaver Volute
 ManaCost:3 U U
 Types:Enchantment Aura
 K:Enchant instant card in a graveyard
-A:SP$ Attach | ValidTgts$ Instant | TgtZone$ Graveyard | TgtPrompt$ Select target instant card in a graveyard | AILogic$ Pump
+A:SP$ Attach | Cost$ 3 U U | ValidTgts$ Instant | TgtZone$ Graveyard | TgtPrompt$ Select target instant card in a graveyard | AILogic$ Pump
 T:Mode$ SpellCast | ValidCard$ Sorcery | ValidActivatingPlayer$ You | Execute$ TrigCopy | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a sorcery spell, copy the enchanted instant card. You may cast the copy without paying its mana cost. If you do, exile the enchanted card and attach CARDNAME to another instant card in a graveyard.
 SVar:TrigCopy:DB$ Play | Defined$ Enchanted | ValidSA$ Spell | WithoutManaCost$ True | Optional$ True | CopyCard$ True | RememberPlayed$ True | SubAbility$ DBExile
-SVar:DBExile:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | Defined$ Enchanted | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1 | References$ X | SubAbility$ DBAttach
-SVar:DBAttach:DB$ Attach | Choices$ Instant | ChoiceZone$ Graveyard | Object$ Self | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1 | References$ X | SubAbility$ DBCleanup
+SVar:DBExile:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | Defined$ Enchanted | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1 | SubAbility$ DBAttach
+SVar:DBAttach:DB$ Attach | Choices$ Instant | ChoiceZone$ Graveyard | Object$ Self | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Remembered$Amount
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/s/spellweaver_volute.txt
+++ b/forge-gui/res/cardsfolder/s/spellweaver_volute.txt
@@ -2,7 +2,7 @@ Name:Spellweaver Volute
 ManaCost:3 U U
 Types:Enchantment Aura
 K:Enchant instant card in a graveyard
-A:SP$ Attach | Cost$ 3 U U | ValidTgts$ Instant | TgtZone$ Graveyard | TgtPrompt$ Select target instant card in a graveyard | AILogic$ Pump
+A:SP$ Attach | ValidTgts$ Instant | TgtZone$ Graveyard | TgtPrompt$ Select target instant card in a graveyard | AILogic$ Pump
 T:Mode$ SpellCast | ValidCard$ Sorcery | ValidActivatingPlayer$ You | Execute$ TrigCopy | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a sorcery spell, copy the enchanted instant card. You may cast the copy without paying its mana cost. If you do, exile the enchanted card and attach CARDNAME to another instant card in a graveyard.
 SVar:TrigCopy:DB$ Play | Defined$ Enchanted | ValidSA$ Spell | WithoutManaCost$ True | Optional$ True | CopyCard$ True | RememberPlayed$ True | SubAbility$ DBExile
 SVar:DBExile:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | Defined$ Enchanted | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1 | SubAbility$ DBAttach

--- a/forge-gui/res/cardsfolder/t/thought_erasure.txt
+++ b/forge-gui/res/cardsfolder/t/thought_erasure.txt
@@ -1,7 +1,7 @@
 Name:Thought Erasure
 ManaCost:U B
 Types:Sorcery
-A:SP$ Discard | ValidTgts$ Opponent | DiscardValid$ Card.nonLand | NumCards$ 1 | Mode$ RevealYouChoose | Subability$ DBSurveil | SpellDescription$ Target opponent reveals their hand. You choose a nonland card from it. That player discards that card. Surveil 1 (Look at the top card of your library. You may put that card into your graveyard.)
+A:SP$ Discard | ValidTgts$ Opponent | DiscardValid$ Card.nonLand | NumCards$ 1 | Mode$ RevealYouChoose | SubAbility$ DBSurveil | SpellDescription$ Target opponent reveals their hand. You choose a nonland card from it. That player discards that card. Surveil 1 (Look at the top card of your library. You may put that card into your graveyard.)
 SVar:DBSurveil:DB$ Surveil | Amount$ 1
 DeckHas:Ability$Surveil|Graveyard
 Oracle:Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.\nSurveil 1. (Look at the top card of your library. You may put it into your graveyard.)

--- a/forge-gui/res/cardsfolder/u/under_construction_skyscraper.txt
+++ b/forge-gui/res/cardsfolder/u/under_construction_skyscraper.txt
@@ -8,6 +8,6 @@ DeckHas:Ability$Mana.Colorless
 S:Mode$ Continuous | Affected$ Card.Self | AddAbility$ ABManaAbzan | IsPresent$ Card.Self+counters_GE1_LEVEL+counters_LE7_LEVEL | Description$ LEVEL 1-7 {T}: Add {W}, {B}, {G}, or {C}.
 SVar:ABManaAbzan:AB$ Mana | Cost$ T | Produced$ Combo W B G C | SpellDescription$ Add {W}, {B}, {G}, or {C}.
 S:Mode$ Continuous | Affected$ Card.Self | AddAbility$ ABManaScry | IsPresent$ Card.Self+counters_GE8_LEVEL | Description$ LEVEL 8+ {T}: Add {W}, {B}, {G}, or {C}. Scry 1.
-SVar:ABManaScry:AB$ Mana | Cost$ T | Produced$ Combo W B G C | Subability$ DBScry | SpellDescription$ Add {W}, {B}, {G}, or {C}. Scry 1.
+SVar:ABManaScry:AB$ Mana | Cost$ T | Produced$ Combo W B G C | SubAbility$ DBScry | SpellDescription$ Add {W}, {B}, {G}, or {C}. Scry 1.
 SVar:DBScry:DB$ Scry | ScryNum$ 1
 Oracle:Level up {1} ({1}: Put a level counter on this. Level up only as a sorcery.)\n{T}: Add {C}.\nLEVEL 1-7\n{T}: Add {W}, {B}, {G}, or {C}.\nLEVEL 8+\n{T}: Add {W}, {B}, {G}, or {C}. Scry 1.

--- a/forge-gui/res/cardsfolder/u/unexplained_disappearance.txt
+++ b/forge-gui/res/cardsfolder/u/unexplained_disappearance.txt
@@ -1,7 +1,7 @@
 Name:Unexplained Disappearance
 ManaCost:1 U
 Types:Instant
-A:SP$ ChangeZone | ValidTgts$ Creature | TgtPrompt$ Select target creature | Origin$ Battlefield | Destination$ Hand | Subability$ DBSurveil | SpellDescription$ Return target creature to its owner's hand. Surveil 1 (Look at the top card of your library. You may put that card into your graveyard.)
+A:SP$ ChangeZone | ValidTgts$ Creature | TgtPrompt$ Select target creature | Origin$ Battlefield | Destination$ Hand | SubAbility$ DBSurveil | SpellDescription$ Return target creature to its owner's hand. Surveil 1 (Look at the top card of your library. You may put that card into your graveyard.)
 SVar:DBSurveil:DB$ Surveil | Amount$ 1
 DeckHas:Ability$Surveil|Graveyard
 Oracle:Return target creature to its owner's hand.\nSurveil 1. (Look at the top card of your library. You may put that card into your graveyard.)

--- a/forge-gui/res/cardsfolder/v/veko_deaths_doorkeeper.txt
+++ b/forge-gui/res/cardsfolder/v/veko_deaths_doorkeeper.txt
@@ -5,7 +5,7 @@ PT:1/3
 K:Extort
 A:AB$ ChangeZone | Cost$ T Sac<1/Creature.nonSpirit/nonspirit creature> | RememberChanged$ True | TgtPrompt$ Choose target creature card in your graveyard | ValidTgts$ Creature.YouOwn | Origin$ Graveyard | Destination$ Hand | SorcerySpeed$ True | SubAbility$ DBAnimate | AILogic$ SacAndRetFromGrave | SpellDescription$ Return target creature card from your graveyard to your hand. It perpetually becomes a Spirit, has base power and toughness 1/1, and gains "You may pay {W/B} rather than pay this spell's mana cost." Activate only as a sorcery.
 SVar:DBAnimate:DB$ Animate | Types$ Spirit | Defined$ Remembered | Power$ 1 | staticAbilities$ PerpAltCost | Toughness$ 1 | Duration$ Perpetual | SubAbility$ DBCleanup
-SVar:PerpAltCost:Mode$ Continuous | EffectZone$ All | MayPlay$ True | MayPlayAltManaCost$ WB | MayPlayDontGrantZonePermissions$ True | Affected$ Card.Self | AffectedZone$ Hand,Graveyard,Library,Exile,Command | Description$ "You may pay {W/B} rather than pay this spell's mana cost."
+SVar:PerpAltCost:Mode$ Continuous | EffectZone$ All | MayPlay$ True | MayPlayAltManaCost$ WB | MayPlayDontGrantZonePermissions$ True | Affected$ Card.Self | AffectedZone$ Hand,Graveyard,Library,Exile,Command | Description$ You may pay {W/B} rather than pay this spell's mana cost.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 DeckHas:Ability$Graveyard|LifeGain|Sacrifice
 Oracle:Extort\n{T}, Sacrifice a non-Spirit creature: Return target creature card from your graveyard to your hand. It perpetually becomes a Spirit, has base power and toughness 1/1, and gains "You may pay {W/B} rather than pay this spell's mana cost." Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/v/vraska_regal_gorgon.txt
+++ b/forge-gui/res/cardsfolder/v/vraska_regal_gorgon.txt
@@ -5,7 +5,7 @@ Loyalty:5
 A:AB$ PutCounter | Cost$ AddCounter<2/LOYALTY> | Planeswalker$ True | CounterNum$ 1 | CounterType$ P1P1 | TargetMin$ 0 | TargetMax$ 1 | ValidTgts$ Creature | TgtPrompt$ Select target creature | SubAbility$ DBPump | SpellDescription$ Put a +1/+1 counter on up to one target creature. That creature gains menace until end of turn.
 SVar:DBPump:DB$ Pump | Defined$ Targeted | KW$ Menace
 A:AB$ Destroy | Cost$ SubCounter<3/LOYALTY> | Planeswalker$ True | ValidTgts$ Creature | TgtPrompt$ Select target creature | SpellDescription$ Destroy target creature.
-A:AB$ PutCounterAll | Cost$ SubCounter<10/LOYALTY> | Planeswalker$ True | Ultimate$ True | ValidCards$ Creature.YouCtrl | CounterType$ P1P1 | CounterNum$ X | Reference$ X | SpellDescription$ For each creature card in your graveyard, put a +1/+1 counter on each creature you control.
+A:AB$ PutCounterAll | Cost$ SubCounter<10/LOYALTY> | Planeswalker$ True | Ultimate$ True | ValidCards$ Creature.YouCtrl | CounterType$ P1P1 | CounterNum$ X | SpellDescription$ For each creature card in your graveyard, put a +1/+1 counter on each creature you control.
 SVar:X:Count$ValidGraveyard Creature.YouCtrl
 DeckHas:Ability$Counters
 Oracle:[+2]: Put a +1/+1 counter on up to one target creature. That creature gains menace until end of turn.\n[-3]: Destroy target creature.\n[-10]: For each creature card in your graveyard, put a +1/+1 counter on each creature you control.

--- a/forge-gui/res/cardsfolder/w/warden_of_the_inner_sky.txt
+++ b/forge-gui/res/cardsfolder/w/warden_of_the_inner_sky.txt
@@ -4,7 +4,7 @@ Types:Creature Human Soldier
 PT:1/2
 SVar:X:Count$CardCounters.ALL
 S:Mode$ Continuous | Affected$ Card.Self | CheckSVar$ X | SVarCompare$ GE3 | AddKeyword$ Flying & Vigilance | Description$ As long as CARDNAME has three or more counters on it, it has flying and vigilance.
-A:AB$ PutCounter | Cost$ tapXType<3/Artifact;Creature/artifacts and/or creatures> | CounterType$ P1P1 | CounterNum$ 1 | SorcerySpeed$ True | Subability$ DBScry | SpellDescription$ Put a +1/+1 counter on CARDNAME. Scry 1. Activate only as a sorcery.
+A:AB$ PutCounter | Cost$ tapXType<3/Artifact;Creature/artifacts and/or creatures> | CounterType$ P1P1 | CounterNum$ 1 | SorcerySpeed$ True | SubAbility$ DBScry | SpellDescription$ Put a +1/+1 counter on CARDNAME. Scry 1. Activate only as a sorcery.
 SVar:DBScry:DB$ Scry | ScryNum$ 1
 DeckHas:Ability$Counters
 Oracle:As long as Warden of the Inner Sky has three or more counters on it, it has flying and vigilance.\nTap three untapped artifacts and/or creatures you control: Put a +1/+1 counter on Warden of the Inner Sky. Scry 1. Activate only as a sorcery.


### PR DESCRIPTION
Sifting card scripts for typos and other lapses, notably:
- Spellweaver Volute and Vraska, Regal Gorgon had deprecated `Reference$` parameters
- Goblin Polka Band and Leyline Tyrant's `XColor$` arguments were brought in line with the more common practice of spelling out color names for that parameter.