### PR TITLE
Fix the AI never playing Hare Apparent

### DIFF
--- a/forge-gui/res/cardsfolder/h/hare_apparent.txt
+++ b/forge-gui/res/cardsfolder/h/hare_apparent.txt
@@ -4,7 +4,7 @@ Types:Creature Rabbit Noble
 PT:2/2
 K:A deck can have any number of cards named CARDNAME.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When this creature enters, create a number of 1/1 white Rabbit creature tokens equal to the number of other creatures you control named Hare Apparent.
-SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ w_1_1_rabbit | TokenOwner$ You
+SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ w_1_1_rabbit | TokenOwner$ You | AILogic$ Always
 SVar:X:Count$Valid Creature.namedHare Apparent+YouCtrl+Other
 SVar:PlayMain1:TRUE
 DeckNeeds:Name$Hare Apparent


### PR DESCRIPTION
Fixes #6798.
Currently simply sets the relevant DB to always play, since Hare Apparent by itself (as a 2/2 creature) will stay even if no token is generated. Can probably be improved later, but not sure how :/