### PR TITLE
January 2025 cleanup: pass 6, part C

### DIFF
--- a/forge-gui/res/cardsfolder/s/savage_alliance.txt
+++ b/forge-gui/res/cardsfolder/s/savage_alliance.txt
@@ -3,7 +3,7 @@ ManaCost:2 R
 Types:Instant
 K:Escalate:1
 A:SP$ Charm | MinCharmNum$ 1 | CharmNum$ 3 | Choices$ DBPumpAll,DBDamage1,DBDamage2
-SVar:DBPumpAll:DB$ PumpAll | ValidTgts$ Player | TgtPrompt$ Select target player to grant trample to each creature controlled | ValidCards$ Creature | KW$ Trample | SpellDescription$ Creatures target player controls gain trample until end of turn.
-SVar:DBDamage1:DB$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature to deal 2 damage | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to target creature.
-SVar:DBDamage2:DB$ DamageAll | NumDmg$ 1 | ValidTgts$ Opponent | TgtPrompt$ Select an opponent to deal 1 damage to each creature controlled | ValidCards$ Creature | ValidDescription$ each creature the opponent controls. | SpellDescription$ CARDNAME deals 1 damage to each creature target opponent controls.
+SVar:DBPumpAll:DB$ PumpAll | ValidTgts$ Player | TgtPrompt$ Select target player to have each creature they control gain trample | ValidCards$ Creature | KW$ Trample | SpellDescription$ Creatures target player controls gain trample until end of turn.
+SVar:DBDamage1:DB$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature to deal 2 damage to | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to target creature.
+SVar:DBDamage2:DB$ DamageAll | NumDmg$ 1 | ValidTgts$ Opponent | TgtPrompt$ Select target opponent to have each creature they control dealt 1 damage | ValidCards$ Creature | ValidDescription$ each creature the opponent controls. | SpellDescription$ CARDNAME deals 1 damage to each creature target opponent controls.
 Oracle:Escalate {1} (Pay this cost for each mode chosen beyond the first.)\nChoose one or more —\n• Creatures target player controls gain trample until end of turn.\n• Savage Alliance deals 2 damage to target creature.\n• Savage Alliance deals 1 damage to each creature target opponent controls.

--- a/forge-gui/res/cardsfolder/s/schismotivate.txt
+++ b/forge-gui/res/cardsfolder/s/schismotivate.txt
@@ -2,5 +2,5 @@ Name:Schismotivate
 ManaCost:1 U R
 Types:Instant
 A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature to get +4/+0 | NumAtt$ +4 | SubAbility$ DBPumpNeg | SpellDescription$ Target creature gets +4/+0 until end of turn. Another target creature gets -4/-0 until end of turn.
-SVar:DBPumpNeg:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select another creature to get -4/+0 | TargetUnique$ True | NumAtt$ -4 | IsCurse$ True
+SVar:DBPumpNeg:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select another target creature to get -4/+0 | TargetUnique$ True | NumAtt$ -4 | IsCurse$ True
 Oracle:Target creature gets +4/+0 until end of turn. Another target creature gets -4/-0 until end of turn.

--- a/forge-gui/res/cardsfolder/s/second_guess.txt
+++ b/forge-gui/res/cardsfolder/s/second_guess.txt
@@ -1,5 +1,5 @@
 Name:Second Guess
 ManaCost:1 U
 Types:Instant
-A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select second spell cast this turn. | ValidTgts$ Card.SecondSpellCastThisTurn | SpellDescription$ Counter target spell that's the second spell cast this turn.
+A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell that's the second spell cast this turn | ValidTgts$ Card.SecondSpellCastThisTurn | SpellDescription$ Counter target spell that's the second spell cast this turn.
 Oracle:Counter target spell that's the second spell cast this turn.

--- a/forge-gui/res/cardsfolder/s/serrated_arrows.txt
+++ b/forge-gui/res/cardsfolder/s/serrated_arrows.txt
@@ -4,5 +4,5 @@ Types:Artifact
 K:etbCounter:ARROWHEAD:3
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | IsPresent$ Card.Self+counters_GE1_ARROWHEAD | PresentCompare$ EQ0 | Execute$ TrigSac | TriggerDescription$ At the beginning of your upkeep, if there are no arrowhead counters on CARDNAME, sacrifice it.
 SVar:TrigSac:DB$ Sacrifice
-A:AB$ PutCounter | Cost$ T SubCounter<1/ARROWHEAD> | IsCurse$ True | ValidTgts$ Creature | TgtPrompt$ Select target Creature | CounterType$ M1M1 | CounterNum$ 1 | SpellDescription$ Put a -1/-1 counter on target creature.
+A:AB$ PutCounter | Cost$ T SubCounter<1/ARROWHEAD> | IsCurse$ True | ValidTgts$ Creature | CounterType$ M1M1 | CounterNum$ 1 | SpellDescription$ Put a -1/-1 counter on target creature.
 Oracle:Serrated Arrows enters with three arrowhead counters on it.\nAt the beginning of your upkeep, if there are no arrowhead counters on Serrated Arrows, sacrifice it.\n{T}, Remove an arrowhead counter from Serrated Arrows: Put a -1/-1 counter on target creature.

--- a/forge-gui/res/cardsfolder/s/setessan_tactics.txt
+++ b/forge-gui/res/cardsfolder/s/setessan_tactics.txt
@@ -4,7 +4,7 @@ Types:Instant
 K:Strive:G
 A:SP$ Pump | ValidTgts$ Creature | NumAtt$ +1 | NumDef$ +1 | TargetMin$ 0 | TargetMax$ MaxTargets | SubAbility$ DBAnimate | SpellDescription$ Until end of turn, any number of target creatures each get +1/+1 and gain "{T}: This creature fights another target creature."
 SVar:DBAnimate:DB$ Animate | Defined$ Targeted | Abilities$ SetessanFight
-SVar:SetessanFight:AB$ Fight | Cost$ T | Defined$ Self | ValidTgts$ Creature.Other | TgtPrompt$ Select another creature | SpellDescription$ CARDNAME fights another target creature.
+SVar:SetessanFight:AB$ Fight | Cost$ T | Defined$ Self | ValidTgts$ Creature.Other | TgtPrompt$ Select another target creature | SpellDescription$ CARDNAME fights another target creature.
 SVar:MaxTargets:Count$Valid Creature
 AI:RemoveDeck:All
 Oracle:Strive — This spell costs {G} more to cast for each target beyond the first.\nUntil end of turn, any number of target creatures each get +1/+1 and gain "{T}: This creature fights another target creature."

--- a/forge-gui/res/cardsfolder/s/shadowborn_demon.txt
+++ b/forge-gui/res/cardsfolder/s/shadowborn_demon.txt
@@ -4,7 +4,7 @@ Types:Creature Demon
 PT:5/6
 K:Flying
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDestroy | TriggerDescription$ When CARDNAME enters, destroy target non-Demon creature.
-SVar:TrigDestroy:DB$ Destroy | ValidTgts$ Creature.nonDemon | TgtPrompt$ Select target non-demon creature
+SVar:TrigDestroy:DB$ Destroy | ValidTgts$ Creature.nonDemon | TgtPrompt$ Select target non-Demon creature
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | IsPresent$ Creature.YouCtrl | PresentZone$ Graveyard | PresentCompare$ LT6 | Execute$ TrigSac | TriggerDescription$ At the beginning of your upkeep, if there are fewer than six creatures in your graveyard, sacrifice a creature.
 SVar:TrigSac:DB$ Sacrifice | Defined$ You | SacValid$ Creature
 Oracle:Flying\nWhen Shadowborn Demon enters, destroy target non-Demon creature.\nAt the beginning of your upkeep, if there are fewer than six creature cards in your graveyard, sacrifice a creature.

--- a/forge-gui/res/cardsfolder/s/shameless_charlatan.txt
+++ b/forge-gui/res/cardsfolder/s/shameless_charlatan.txt
@@ -2,6 +2,6 @@ Name:Shameless Charlatan
 ManaCost:1 U
 Types:Legendary Enchantment Background
 S:Mode$ Continuous | Affected$ Creature.IsCommander+YouOwn | AddAbility$ Copy | Description$ Commander creatures you own have "{2}{U}: This creature becomes a copy of another target creature."
-SVar:Copy:AB$ Clone | Cost$ 2 U | ValidTgts$ Creature.Other | TgtPrompt$ Select another creature | SpellDescription$ This creature becomes a copy of another target creature.
+SVar:Copy:AB$ Clone | Cost$ 2 U | ValidTgts$ Creature.Other | TgtPrompt$ Select another target creature | SpellDescription$ This creature becomes a copy of another target creature.
 AI:RemoveDeck:NonCommander
 Oracle:Commander creatures you own have "{2}{U}: This creature becomes a copy of another target creature."

--- a/forge-gui/res/cardsfolder/s/shatter_the_oath.txt
+++ b/forge-gui/res/cardsfolder/s/shatter_the_oath.txt
@@ -1,7 +1,7 @@
 Name:Shatter the Oath
 ManaCost:3 B B
 Types:Sorcery
-A:SP$ Destroy | ValidTgts$ Enchantment,Creature | TgtPrompt$ Select enchantment or creature | SubAbility$ TrigToken | SpellDescription$ Destroy target creature or enchantment. Create a Wicked Role token attached to up to one target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1. When this Aura is put into a graveyard, each opponent loses 1 life.)
+A:SP$ Destroy | ValidTgts$ Enchantment,Creature | TgtPrompt$ Select target creature or enchantment | SubAbility$ TrigToken | SpellDescription$ Destroy target creature or enchantment. Create a Wicked Role token attached to up to one target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1. When this Aura is put into a graveyard, each opponent loses 1 life.)
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ role_wicked | TokenOwner$ You | TargetMin$ 0 | TargetMax$ 1 | AttachedTo$ ThisTargetedCard | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select up to one target creature you control
 DeckHas:Ability$Token & Type$Role|Aura
 Oracle:Destroy target creature or enchantment. Create a Wicked Role token attached to up to one target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1. When this Aura is put into a graveyard, each opponent loses 1 life.)

--- a/forge-gui/res/cardsfolder/s/shifting_borders.txt
+++ b/forge-gui/res/cardsfolder/s/shifting_borders.txt
@@ -2,6 +2,6 @@ Name:Shifting Borders
 ManaCost:3 U
 Types:Instant Arcane
 K:Splice:Arcane:3 U
-A:SP$ ExchangeControl | ValidTgts$ Land | TgtPrompt$ Select target Land | TargetMin$ 2 | TargetMax$ 2 | SpellDescription$ Exchange control of two target lands.
+A:SP$ ExchangeControl | ValidTgts$ Land | TgtPrompt$ Select two target lands | TargetMin$ 2 | TargetMax$ 2 | SpellDescription$ Exchange control of two target lands.
 AI:RemoveDeck:All
 Oracle:Exchange control of two target lands.\nSplice onto Arcane {3}{U} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)

--- a/forge-gui/res/cardsfolder/s/shrapnel_blast.txt
+++ b/forge-gui/res/cardsfolder/s/shrapnel_blast.txt
@@ -1,5 +1,5 @@
 Name:Shrapnel Blast
 ManaCost:1 R
 Types:Instant
-A:SP$ DealDamage | Cost$ 1 R Sac<1/Artifact> | ValidTgts$ Any | TgtPrompt$ Select target | NumDmg$ 5 | SpellDescription$ CARDNAME deals 5 damage to any target.
+A:SP$ DealDamage | Cost$ 1 R Sac<1/Artifact> | ValidTgts$ Any | NumDmg$ 5 | SpellDescription$ CARDNAME deals 5 damage to any target.
 Oracle:As an additional cost to cast this spell, sacrifice an artifact.\nShrapnel Blast deals 5 damage to any target.

--- a/forge-gui/res/cardsfolder/s/simoon.txt
+++ b/forge-gui/res/cardsfolder/s/simoon.txt
@@ -1,5 +1,5 @@
 Name:Simoon
 ManaCost:R G
 Types:Instant
-A:SP$ DamageAll | NumDmg$ 1 | ValidTgts$ Opponent | TgtPrompt$ Select an opponent | ValidCards$ Creature | ValidDescription$ each creature the opponent controls. | SpellDescription$ CARDNAME deals 1 damage to each creature target opponent controls.
+A:SP$ DamageAll | NumDmg$ 1 | ValidTgts$ Opponent | ValidCards$ Creature | ValidDescription$ each creature the opponent controls. | SpellDescription$ CARDNAME deals 1 damage to each creature target opponent controls.
 Oracle:Simoon deals 1 damage to each creature target opponent controls.

--- a/forge-gui/res/cardsfolder/s/sirocco.txt
+++ b/forge-gui/res/cardsfolder/s/sirocco.txt
@@ -1,7 +1,7 @@
 Name:Sirocco
 ManaCost:1 R
 Types:Instant
-A:SP$ RevealHand | RememberRevealed$ True | ValidTgts$ Player | TgtPrompt$ Select target Player | SubAbility$ DBRepeatDiscard | SpellDescription$ Target player reveals their hand. For each blue instant card revealed this way, that player discards that card unless they pay 4 life.
+A:SP$ RevealHand | RememberRevealed$ True | ValidTgts$ Player | SubAbility$ DBRepeatDiscard | SpellDescription$ Target player reveals their hand. For each blue instant card revealed this way, that player discards that card unless they pay 4 life.
 SVar:DBRepeatDiscard:DB$ RepeatEach | UseImprinted$ True | RepeatCards$ Card.IsRemembered+Instant+Blue | Zone$ Hand | RepeatSubAbility$ DBDiscard | SubAbility$ DBCleanup
 SVar:DBDiscard:DB$ Discard | DefinedCards$ Imprinted | Mode$ Defined | UnlessCost$ PayLife<4> | UnlessPayer$ Targeted | StackDescription$ Discard {c:Imprinted}
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/s/skeleton_ship.txt
+++ b/forge-gui/res/cardsfolder/s/skeleton_ship.txt
@@ -4,6 +4,6 @@ Types:Legendary Creature Skeleton
 PT:0/3
 T:Mode$ Always | TriggerZones$ Battlefield | IsPresent$ Island.YouCtrl | PresentCompare$ EQ0 | Execute$ TrigSac | TriggerDescription$ When you control no Islands, sacrifice CARDNAME.
 SVar:TrigSac:DB$ Sacrifice
-A:AB$ PutCounter | Cost$ T | ValidTgts$ Creature | TgtPrompt$ Select target Creature | CounterType$ M1M1 | CounterNum$ 1 | IsCurse$ True | SpellDescription$ Put a -1/-1 counter on target creature.
+A:AB$ PutCounter | Cost$ T | ValidTgts$ Creature | CounterType$ M1M1 | CounterNum$ 1 | IsCurse$ True | SpellDescription$ Put a -1/-1 counter on target creature.
 SVar:NeedsToPlay:Island.YouCtrl
 Oracle:When you control no Islands, sacrifice Skeleton Ship.\n{T}: Put a -1/-1 counter on target creature.

--- a/forge-gui/res/cardsfolder/s/song_of_stupefaction.txt
+++ b/forge-gui/res/cardsfolder/s/song_of_stupefaction.txt
@@ -2,7 +2,7 @@ Name:Song of Stupefaction
 ManaCost:1 U
 Types:Enchantment Aura
 K:Enchant creature or Vehicle
-A:SP$ Attach | ValidTgts$ Creature,Vehicle | TgtPrompt$ Select target Creature or Vehicle | AITgts$ Creature | AILogic$ Curse
+A:SP$ Attach | ValidTgts$ Creature,Vehicle | TgtPrompt$ Select target creature or Vehicle | AITgts$ Creature | AILogic$ Curse
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigMill | TriggerDescription$ When CARDNAME enters, you may mill two cards. (You may put the top two cards of your library into your graveyard.)
 SVar:TrigMill:DB$ Mill | Defined$ You | NumCards$ 2 | Optional$ True
 S:Mode$ Continuous | Affected$ Permanent.EnchantedBy | AddPower$ -X | Description$ Fathomless descent — Enchanted permanent gets -X/-0, where X is the number of permanent cards in your graveyard.

--- a/forge-gui/res/cardsfolder/s/sonic_screwdriver.txt
+++ b/forge-gui/res/cardsfolder/s/sonic_screwdriver.txt
@@ -2,7 +2,7 @@ Name:Sonic Screwdriver
 ManaCost:3
 Types:Artifact
 A:AB$ Mana | Cost$ T | Produced$ Any | SpellDescription$ Add one mana of any color.
-A:AB$ Untap | Cost$ 1 T | ValidTgts$ Artifact.Other | TgtPrompt$ Select another target Artifact | SpellDescription$ Untap another target artifact.
+A:AB$ Untap | Cost$ 1 T | ValidTgts$ Artifact.Other | TgtPrompt$ Select another target artifact | SpellDescription$ Untap another target artifact.
 A:AB$ Scry | Cost$ 2 T | ScryNum$ 1 | SpellDescription$ Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 A:AB$ Effect | Cost$ 3 T | ValidTgts$ Creature | RememberObjects$ Targeted | ExileOnMoved$ Battlefield | StaticAbilities$ Unblockable | AILogic$ Pump | StackDescription$ {c:Targeted} can't be blocked this turn | SpellDescription$ Target creature can't be blocked this turn.
 SVar:Unblockable:Mode$ CantBlockBy | ValidAttacker$ Card.IsRemembered | Description$ This creature can't be blocked this turn.

--- a/forge-gui/res/cardsfolder/s/sorcerers_wand.txt
+++ b/forge-gui/res/cardsfolder/s/sorcerers_wand.txt
@@ -3,7 +3,7 @@ ManaCost:1
 Types:Artifact Equipment
 K:Equip:3
 S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddAbility$ WandDamage | AddSVar$ DBWandDmg | Description$ Equipped creature has "{T}: This creature deals 1 damage to target player or planeswalker. If this creature is a Wizard, it deals 2 damage instead."
-SVar:WandDamage:AB$ DealDamage | Cost$ T | ValidTgts$ Planeswalker,Player | TgtPrompt$ Select target Planeswalker or player | NumDmg$ 1 | ConditionDefined$ Self | ConditionPresent$ Creature.nonWizard | SubAbility$ DBWandDmg | StackDescription$ SpellDescription | SpellDescription$ This creature deals 1 damage to target player or planeswalker. If this creature is a Wizard, it deals 2 damage instead.
+SVar:WandDamage:AB$ DealDamage | Cost$ T | ValidTgts$ Planeswalker,Player | TgtPrompt$ Select target planeswalker or player | NumDmg$ 1 | ConditionDefined$ Self | ConditionPresent$ Creature.nonWizard | SubAbility$ DBWandDmg | StackDescription$ SpellDescription | SpellDescription$ This creature deals 1 damage to target player or planeswalker. If this creature is a Wizard, it deals 2 damage instead.
 SVar:DBWandDmg:DB$ DealDamage | Defined$ Targeted | NumDmg$ 2 | ConditionDefined$ Self | ConditionPresent$ Creature.Wizard | StackDescription$ None
 DeckHints:Type$Wizard
 Oracle:Equipped creature has "{T}: This creature deals 1 damage to target player or planeswalker. If this creature is a Wizard, it deals 2 damage instead."\nEquip {3}

--- a/forge-gui/res/cardsfolder/s/soul_manipulation.txt
+++ b/forge-gui/res/cardsfolder/s/soul_manipulation.txt
@@ -2,6 +2,6 @@ Name:Soul Manipulation
 ManaCost:1 U B
 Types:Instant
 A:SP$ Charm | MinCharmNum$ 1 | CharmNum$ 2 | Choices$ DBCounter,DBChangeZone
-SVar:DBCounter:DB$ Counter | TargetType$ Spell | TgtPrompt$ Select target Creature spell | ValidTgts$ Creature | SpellDescription$ Counter target creature spell.
+SVar:DBCounter:DB$ Counter | TargetType$ Spell | TgtPrompt$ Select target creature spell | ValidTgts$ Creature | SpellDescription$ Counter target creature spell.
 SVar:DBChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | TgtPrompt$ Choose target creature card in your graveyard | ValidTgts$ Creature.YouCtrl | SpellDescription$ Return target creature card from your graveyard to your hand.
 Oracle:Choose one or both —\n• Counter target creature spell.\n• Return target creature card from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/s/soulsworn_jury.txt
+++ b/forge-gui/res/cardsfolder/s/soulsworn_jury.txt
@@ -3,5 +3,5 @@ ManaCost:2 W
 Types:Creature Spirit
 PT:1/4
 K:Defender
-A:AB$ Counter | Cost$ 1 U Sac<1/CARDNAME> | TargetType$ Spell | TgtPrompt$ Select target Creature spell | ValidTgts$ Creature | SpellDescription$ Counter target creature spell.
+A:AB$ Counter | Cost$ 1 U Sac<1/CARDNAME> | TargetType$ Spell | TgtPrompt$ Select target creature spell | ValidTgts$ Creature | SpellDescription$ Counter target creature spell.
 Oracle:Defender (This creature can't attack.)\n{1}{U}, Sacrifice Soulsworn Jury: Counter target creature spell.

--- a/forge-gui/res/cardsfolder/s/specter_of_the_fens.txt
+++ b/forge-gui/res/cardsfolder/s/specter_of_the_fens.txt
@@ -3,7 +3,7 @@ ManaCost:3 B
 Types:Creature Specter
 PT:2/3
 K:Flying
-A:AB$ LoseLife | Cost$ 5 B | ValidTgts$ Opponent | TgtPrompt$ Select an opponent | LifeAmount$ 2 | SubAbility$ DBGainLife | SpellDescription$ Target opponent loses 2 life and you gain 2 life.
+A:AB$ LoseLife | Cost$ 5 B | ValidTgts$ Opponent | LifeAmount$ 2 | SubAbility$ DBGainLife | SpellDescription$ Target opponent loses 2 life and you gain 2 life.
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ 2
 DeckHas:Ability$LifeGain
 Oracle:Flying\n{5}{B}: Target opponent loses 2 life and you gain 2 life.

--- a/forge-gui/res/cardsfolder/s/spellshift.txt
+++ b/forge-gui/res/cardsfolder/s/spellshift.txt
@@ -1,8 +1,8 @@
 Name:Spellshift
 ManaCost:3 U
 Types:Instant
-A:SP$ Counter | TargetType$ Spell | ValidTgts$ Instant,Sorcery | TgtPrompt$ Select target Instant or Sorcery Spell | SubAbility$ DBDig | SpellDescription$ Counter target instant or sorcery spell. Its controller reveals cards from the top of their library until they reveal an instant or sorcery card. That player may cast that card without paying its mana cost. Then the player shuffles.
-SVar:DBDig:DB$ DigUntil | Defined$ TargetedController | Valid$ Instant,Sorcery | ValidDescription$ Sorcery or Instant | NoMoveRevealed$ True | RememberFound$ True | SubAbility$ DBPlay
+A:SP$ Counter | TargetType$ Spell | ValidTgts$ Instant,Sorcery | TgtPrompt$ Select target instant or sorcery spell | SubAbility$ DBDig | SpellDescription$ Counter target instant or sorcery spell. Its controller reveals cards from the top of their library until they reveal an instant or sorcery card. That player may cast that card without paying its mana cost. Then the player shuffles.
+SVar:DBDig:DB$ DigUntil | Defined$ TargetedController | Valid$ Instant,Sorcery | ValidDescription$ instant or sorcery | NoMoveRevealed$ True | RememberFound$ True | SubAbility$ DBPlay
 SVar:DBPlay:DB$ Play | Defined$ Remembered | ValidSA$ Spell | Controller$ TargetedController | WithoutManaCost$ True | Optional$ True | SubAbility$ DBShuffle
 SVar:DBShuffle:DB$ Shuffle | Defined$ TargetedController | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/s/squelch.txt
+++ b/forge-gui/res/cardsfolder/s/squelch.txt
@@ -1,6 +1,6 @@
 Name:Squelch
 ManaCost:1 U
 Types:Instant
-A:SP$ Counter | TgtPrompt$ Select target Activated Ability | ValidTgts$ Card | TargetType$ Activated | SubAbility$ DBDraw | SpellDescription$ Counter target activated ability. Draw a card.
+A:SP$ Counter | TgtPrompt$ Select target activated ability | ValidTgts$ Card | TargetType$ Activated | SubAbility$ DBDraw | SpellDescription$ Counter target activated ability. Draw a card.
 SVar:DBDraw:DB$ Draw | NumCards$ 1
 Oracle:Counter target activated ability. (Mana abilities can't be targeted.)\nDraw a card.

--- a/forge-gui/res/cardsfolder/s/stab.txt
+++ b/forge-gui/res/cardsfolder/s/stab.txt
@@ -1,5 +1,5 @@
 Name:Stab
 ManaCost:B
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ -2 | NumDef$ -2 | IsCurse$ True | SpellDescription$ Target Creature gets -2/-2 until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ -2 | NumDef$ -2 | IsCurse$ True | SpellDescription$ Target creature gets -2/-2 until end of turn.
 Oracle:Target creature gets -2/-2 until end of turn.

--- a/forge-gui/res/cardsfolder/s/steal_strength.txt
+++ b/forge-gui/res/cardsfolder/s/steal_strength.txt
@@ -2,5 +2,5 @@ Name:Steal Strength
 ManaCost:1 B
 Types:Instant
 A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature to get +1/+1 | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DBPumpNeg | SpellDescription$ Target creature gets +1/+1 until end of turn. Another target creature gets -1/-1 until end of turn.
-SVar:DBPumpNeg:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select another creature to get -1/-1 | TargetUnique$ True | NumAtt$ -1 | NumDef$ -1 | IsCurse$ True
+SVar:DBPumpNeg:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select another target creature to get -1/-1 | TargetUnique$ True | NumAtt$ -1 | NumDef$ -1 | IsCurse$ True
 Oracle:Target creature gets +1/+1 until end of turn. Another target creature gets -1/-1 until end of turn.

--- a/forge-gui/res/cardsfolder/s/steel_sabotage.txt
+++ b/forge-gui/res/cardsfolder/s/steel_sabotage.txt
@@ -2,6 +2,6 @@ Name:Steel Sabotage
 ManaCost:U
 Types:Instant
 A:SP$ Charm | Choices$ DBCounter,DBChangeZone | CharmNum$ 1
-SVar:DBCounter:DB$ Counter | TargetType$ Spell | TgtPrompt$ Select target Artifact spell | ValidTgts$ Artifact | SpellDescription$ Counter target artifact spell.
-SVar:DBChangeZone:DB$ ChangeZone | ValidTgts$ Artifact | TgtPrompt$ Select target artifact | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return target artifact to its owner's hand.
+SVar:DBCounter:DB$ Counter | TargetType$ Spell | TgtPrompt$ Select target artifact spell | ValidTgts$ Artifact | SpellDescription$ Counter target artifact spell.
+SVar:DBChangeZone:DB$ ChangeZone | ValidTgts$ Artifact | TgtPrompt$ Select target artifact to bounce | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return target artifact to its owner's hand.
 Oracle:Choose one —\n• Counter target artifact spell.\n• Return target artifact to its owner's hand.

--- a/forge-gui/res/cardsfolder/s/strafe.txt
+++ b/forge-gui/res/cardsfolder/s/strafe.txt
@@ -1,5 +1,5 @@
 Name:Strafe
 ManaCost:R
 Types:Sorcery
-A:SP$ DealDamage | ValidTgts$ Creature.nonRed | TgtPrompt$ Select target nonred Creature | NumDmg$ 3 | SpellDescription$ CARDNAME deals 3 damage to target nonred creature.
+A:SP$ DealDamage | ValidTgts$ Creature.nonRed | TgtPrompt$ Select target nonred creature | NumDmg$ 3 | SpellDescription$ CARDNAME deals 3 damage to target nonred creature.
 Oracle:Strafe deals 3 damage to target nonred creature.

--- a/forge-gui/res/cardsfolder/s/stratus_dancer.txt
+++ b/forge-gui/res/cardsfolder/s/stratus_dancer.txt
@@ -5,5 +5,5 @@ PT:2/1
 K:Flying
 K:Megamorph:1 U
 T:Mode$ TurnFaceUp | ValidCard$ Card.Self | Execute$ TrigCounter | TriggerZones$ Battlefield | TriggerDescription$ When CARDNAME is turned face up, counter target instant or sorcery spell.
-SVar:TrigCounter:DB$ Counter | TargetType$ Spell | ValidTgts$ Instant,Sorcery | TgtPrompt$ Select target Instant or Sorcery Spell
+SVar:TrigCounter:DB$ Counter | TargetType$ Spell | ValidTgts$ Instant,Sorcery | TgtPrompt$ Select target instant or sorcery spell
 Oracle:Flying\nMegamorph {1}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Stratus Dancer is turned face up, counter target instant or sorcery spell.

--- a/forge-gui/res/cardsfolder/s/stream_of_consciousness.txt
+++ b/forge-gui/res/cardsfolder/s/stream_of_consciousness.txt
@@ -1,7 +1,7 @@
 Name:Stream of Consciousness
 ManaCost:1 U
 Types:Instant Arcane
-A:SP$ Pump | ValidTgts$ Player | TgtPrompt$ Select target Player | SubAbility$ DBChangeZone | IsCurse$ True | SpellDescription$ Target player shuffles up to four target cards from their graveyard into their library.
-SVar:DBChangeZone:DB$ ChangeZone | TargetMin$ 0 | TargetMax$ 4 | TargetsWithDefinedController$ ParentTarget | Origin$ Graveyard | Destination$ Library | Shuffle$ True | TgtPrompt$ Choose target card | ValidTgts$ Card
+A:SP$ Pump | ValidTgts$ Player | SubAbility$ DBChangeZone | IsCurse$ True | SpellDescription$ Target player shuffles up to four target cards from their graveyard into their library.
+SVar:DBChangeZone:DB$ ChangeZone | TargetMin$ 0 | TargetMax$ 4 | TargetsWithDefinedController$ ParentTarget | Origin$ Graveyard | Destination$ Library | Shuffle$ True | TgtPrompt$ Select up to four target cards in targeted player's graveyard | ValidTgts$ Card
 AI:RemoveDeck:All
 Oracle:Target player shuffles up to four target cards from their graveyard into their library.

--- a/forge-gui/res/cardsfolder/s/stromgald_cabal.txt
+++ b/forge-gui/res/cardsfolder/s/stromgald_cabal.txt
@@ -2,6 +2,6 @@ Name:Stromgald Cabal
 ManaCost:1 B B
 Types:Creature Human Knight
 PT:2/2
-A:AB$ Counter | Cost$ T PayLife<1> | TargetType$ Spell | TgtPrompt$ Select target White spell | ValidTgts$ Card.White | SpellDescription$ Counter target white spell.
+A:AB$ Counter | Cost$ T PayLife<1> | TargetType$ Spell | TgtPrompt$ Select target white spell | ValidTgts$ Card.White | SpellDescription$ Counter target white spell.
 AI:RemoveDeck:Random
 Oracle:{T}, Pay 1 life: Counter target white spell.

--- a/forge-gui/res/cardsfolder/s/stronghold_biologist.txt
+++ b/forge-gui/res/cardsfolder/s/stronghold_biologist.txt
@@ -2,6 +2,6 @@ Name:Stronghold Biologist
 ManaCost:2 U
 Types:Creature Human Spellshaper
 PT:1/1
-A:AB$ Counter | Cost$ U U T Discard<1/Card> | AILogic$ MinCMC.4 | TargetType$ Spell | TgtPrompt$ Select target Creature spell | ValidTgts$ Card.Creature | SpellDescription$ Counter target creature spell.
+A:AB$ Counter | Cost$ U U T Discard<1/Card> | AILogic$ MinCMC.4 | TargetType$ Spell | TgtPrompt$ Select target creature spell | ValidTgts$ Card.Creature | SpellDescription$ Counter target creature spell.
 SVar:AIPreference:DiscardCost$Card.cmcEQ0,Card.cmcEQ1,Card.cmcEQ2,Card.cmcEQ3
 Oracle:{U}{U}, {T}, Discard a card: Counter target creature spell.

--- a/forge-gui/res/cardsfolder/s/suncrusher.txt
+++ b/forge-gui/res/cardsfolder/s/suncrusher.txt
@@ -3,7 +3,7 @@ ManaCost:9
 Types:Artifact Creature Construct
 PT:3/3
 K:Sunburst
-A:AB$ Destroy | Cost$ 4 T SubCounter<1/P1P1> | ValidTgts$ Creature | TgtPrompt$ Select target Creature | SpellDescription$ Destroy target creature.
+A:AB$ Destroy | Cost$ 4 T SubCounter<1/P1P1> | ValidTgts$ Creature | SpellDescription$ Destroy target creature.
 A:AB$ ChangeZone | Cost$ 2 SubCounter<1/P1P1> | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return CARDNAME to its owner's hand.
 SVar:NeedsToPlayVar:Z GE1
 SVar:Z:Count$UniqueManaColorsProduced.ByUntappedSources

--- a/forge-gui/res/cardsfolder/s/sunlance.txt
+++ b/forge-gui/res/cardsfolder/s/sunlance.txt
@@ -1,5 +1,5 @@
 Name:Sunlance
 ManaCost:W
 Types:Sorcery
-A:SP$ DealDamage | ValidTgts$ Creature.nonWhite | TgtPrompt$ Select target nonwhite Creature | NumDmg$ 3 | SpellDescription$ CARDNAME deals 3 damage to target nonwhite creature.
+A:SP$ DealDamage | ValidTgts$ Creature.nonWhite | TgtPrompt$ Select target nonwhite creature | NumDmg$ 3 | SpellDescription$ CARDNAME deals 3 damage to target nonwhite creature.
 Oracle:Sunlance deals 3 damage to target nonwhite creature.

--- a/forge-gui/res/cardsfolder/s/sunscape_master.txt
+++ b/forge-gui/res/cardsfolder/s/sunscape_master.txt
@@ -2,7 +2,7 @@ Name:Sunscape Master
 ManaCost:2 W W
 Types:Creature Human Wizard
 PT:2/2
-A:AB$ ChangeZone | Cost$ U U T | ValidTgts$ Creature | TgtPrompt$ Select target Creature | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return target creature to its owner's hand.
+A:AB$ ChangeZone | Cost$ U U T | ValidTgts$ Creature | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return target creature to its owner's hand.
 A:AB$ PumpAll | Cost$ G G T | ValidCards$ Creature.YouCtrl | NumAtt$ +2 | NumDef$ +2 | SpellDescription$ Creatures you control get +2/+2 until end of turn.
 AI:RemoveDeck:Random
 DeckNeeds:Color$Blue

--- a/forge-gui/res/cardsfolder/s/supply_drop.txt
+++ b/forge-gui/res/cardsfolder/s/supply_drop.txt
@@ -3,7 +3,7 @@ ManaCost:3
 Types:Artifact
 K:Flash
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ When CARDNAME enters, target creature you control gets +2/+2 until end of turn.
-SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select another creature | NumAtt$ +2 | NumDef$ +2
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | NumAtt$ +2 | NumDef$ +2
 A:AB$ Draw | Cost$ 4 T Sac<1/CARDNAME> | NumCards$ 1 | SpellDescription$ Draw a card.
 DeckHas:Ability$Sacrifice
 Oracle:Flash\nWhen Supply Drop enters, target creature you control gets +2/+2 until end of turn.\n{4}, {T}, Sacrifice Supply Drop: Draw a card.

--- a/forge-gui/res/cardsfolder/s/suppression_ray_orderly_plaza.txt
+++ b/forge-gui/res/cardsfolder/s/suppression_ray_orderly_plaza.txt
@@ -3,11 +3,11 @@ ManaCost:3 WU WU
 Types:Sorcery
 A:SP$ TapAll | ValidCards$ Creature | ValidTgts$ Player | RememberTapped$ True | SubAbility$ DBChooseNumber | StackDescription$ REP target player_{p:Targeted} | SpellDescription$ Tap all creatures target player controls.
 SVar:DBChooseNumber:DB$ ChooseNumber | Max$ Max | ListTitle$ amount of energy to pay | SubAbility$ DBStun | StackDescription$ None
-SVar:DBStun:DB$ PutCounter | UnlessCost$ PayEnergy<X> | UnlessPayer$ You | UnlessSwitched$ True | Choices$ Creature.IsRemembered | ChoiceAmount$ X | ChoiceTitle$ Choose up to X creatures tapped this way | CounterType$ Stun | StackDescription$ SpellDescription | SpellDescription$ You may pay X {E}, then choose up to X creatures tapped this way. Put a stun counter on each of them. (If a permanent with a stun counter would become untapped, remove one from it instead.)
+SVar:DBStun:DB$ PutCounter | UnlessCost$ PayEnergy<X> | UnlessPayer$ You | UnlessSwitched$ True | Choices$ Creature.IsRemembered | ChoiceAmount$ X | ChoiceTitle$ Choose up to that many creatures tapped this way | CounterType$ Stun | StackDescription$ SpellDescription | SpellDescription$ You may pay any amount of {E}. If you do, choose up to that many creatures tapped this way. Put a stun counter on each of them. (If a permanent with a stun counter would become untapped, remove one from it instead.)
 SVar:Max:Count$YourCountersEnergy
 SVar:X:Count$ChosenNumber
 AlternateMode:Modal
-Oracle:Tap all creatures target player controls. You may pay X {E}, then choose up to X creatures tapped this way. Put a stun counter on each of them. (If a permanent with a stun counter would become untapped, remove one from it instead.)
+Oracle:Tap all creatures target player controls. You may pay any amount of {E}. If you do, choose up to that many creatures tapped this way. Put a stun counter on each of them. (If a permanent with a stun counter would become untapped, remove one from it instead.)
 
 ALTERNATE
 

--- a/forge-gui/res/cardsfolder/s/surge_node.txt
+++ b/forge-gui/res/cardsfolder/s/surge_node.txt
@@ -2,6 +2,6 @@ Name:Surge Node
 ManaCost:1
 Types:Artifact
 K:etbCounter:CHARGE:6
-A:AB$ PutCounter | Cost$ 1 T SubCounter<1/CHARGE> | ValidTgts$ Artifact | TgtPrompt$ Select target Artifact | CounterType$ CHARGE | CounterNum$ 1 | SpellDescription$ Put a charge counter on target artifact.
+A:AB$ PutCounter | Cost$ 1 T SubCounter<1/CHARGE> | ValidTgts$ Artifact | CounterType$ CHARGE | CounterNum$ 1 | SpellDescription$ Put a charge counter on target artifact.
 AI:RemoveDeck:Random
 Oracle:Surge Node enters with six charge counters on it.\n{1}, {T}, Remove a charge counter from Surge Node: Put a charge counter on target artifact.

--- a/forge-gui/res/cardsfolder/s/symbiosis.txt
+++ b/forge-gui/res/cardsfolder/s/symbiosis.txt
@@ -1,5 +1,5 @@
 Name:Symbiosis
 ManaCost:1 G
 Types:Instant
-A:SP$ Pump | TargetMin$ 2 | TargetMax$ 2 | NumAtt$ +2 | NumDef$ +2 | ValidTgts$ Creature | TgtPrompt$ Select target Creature | SpellDescription$ Two target creatures each get +2/+2 until end of turn.
+A:SP$ Pump | TargetMin$ 2 | TargetMax$ 2 | NumAtt$ +2 | NumDef$ +2 | ValidTgts$ Creature | TgtPrompt$ Select two target creatures | SpellDescription$ Two target creatures each get +2/+2 until end of turn.
 Oracle:Two target creatures each get +2/+2 until end of turn.

--- a/forge-gui/res/cardsfolder/t/tandem_tactics.txt
+++ b/forge-gui/res/cardsfolder/t/tandem_tactics.txt
@@ -1,7 +1,7 @@
 Name:Tandem Tactics
 ManaCost:1 W
 Types:Instant
-A:SP$ Pump | TargetMin$ 0 | TargetMax$ 2 | NumAtt$ +1 | NumDef$ +2 | ValidTgts$ Creature | TgtPrompt$ Select target Creature | SubAbility$ DBGainLife | SpellDescription$ Up to two target creatures each get +1/+2 until end of turn. You gain 2 life.
+A:SP$ Pump | TargetMin$ 0 | TargetMax$ 2 | NumAtt$ +1 | NumDef$ +2 | ValidTgts$ Creature | TgtPrompt$ Select up to two target creatures | SubAbility$ DBGainLife | SpellDescription$ Up to two target creatures each get +1/+2 until end of turn. You gain 2 life.
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ 2
 DeckHas:Ability$LifeGain
 Oracle:Up to two target creatures each get +1/+2 until end of turn. You gain 2 life.

--- a/forge-gui/res/cardsfolder/t/teferis_care.txt
+++ b/forge-gui/res/cardsfolder/t/teferis_care.txt
@@ -1,7 +1,7 @@
 Name:Teferi's Care
 ManaCost:2 W
 Types:Enchantment
-A:AB$ Destroy | Cost$ W Sac<1/Enchantment> | ValidTgts$ Enchantment | TgtPrompt$ Select target enchantment | SpellDescription$ Destroy target enchantment.
-A:AB$ Counter | Cost$ 3 U U | TargetType$ Spell | TgtPrompt$ Select target Enchantment | ValidTgts$ Enchantment | SpellDescription$ Counter target enchantment spell.
+A:AB$ Destroy | Cost$ W Sac<1/Enchantment> | ValidTgts$ Enchantment | SpellDescription$ Destroy target enchantment.
+A:AB$ Counter | Cost$ 3 U U | TargetType$ Spell | TgtPrompt$ Select target enchantment spell | ValidTgts$ Enchantment | SpellDescription$ Counter target enchantment spell.
 AI:RemoveDeck:All
 Oracle:{W}, Sacrifice an enchantment: Destroy target enchantment.\n{3}{U}{U}: Counter target enchantment spell.

--- a/forge-gui/res/cardsfolder/t/the_monumental_facade.txt
+++ b/forge-gui/res/cardsfolder/t/the_monumental_facade.txt
@@ -3,6 +3,6 @@ ManaCost:no cost
 Types:Land Sphere
 K:etbCounter:OIL:2
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
-A:AB$ PutCounter | Cost$ T SubCounter<1/OIL> | ValidTgts$ Artifact.YouCtrl,Creature.YouCtrl | TgtPrompt$ Select target Artifact of Creature you control | SorcerySpeed$ True | CounterType$ OIL | SpellDescription$ Put an oil counter on target artifact or creature you control. Activate only as a sorcery.
+A:AB$ PutCounter | Cost$ T SubCounter<1/OIL> | ValidTgts$ Artifact.YouCtrl,Creature.YouCtrl | TgtPrompt$ Select target artifact of creature you control | SorcerySpeed$ True | CounterType$ OIL | SpellDescription$ Put an oil counter on target artifact or creature you control. Activate only as a sorcery.
 DeckHas:Ability$Counters
 Oracle:The Monumental Facade enters with two oil counters on it.\n{T}: Add {C}.\n{T}, Remove an oil counter from The Monumental Facade: Put an oil counter on target artifact or creature you control. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/t/the_motherlode_excavator.txt
+++ b/forge-gui/res/cardsfolder/t/the_motherlode_excavator.txt
@@ -3,7 +3,7 @@ ManaCost:3 R R
 Types:Legendary Artifact Creature Robot
 PT:5/5
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ When CARDNAME enters, choose target opponent. You get an amount of {E} (energy counters) equal to the number of nonbasic lands that player controls.
-SVar:TrigPump:DB$ Pump | IsCurse$ True | ValidTgts$ Opponent | TgtPrompt$ Select target Opponent | SubAbility$ DBEnergy
+SVar:TrigPump:DB$ Pump | IsCurse$ True | ValidTgts$ Opponent | SubAbility$ DBEnergy
 SVar:DBEnergy:DB$ PutCounter | Defined$ You | CounterType$ ENERGY | CounterNum$ X
 SVar:X:Count$Valid Land.nonBasic+TargetedPlayerCtrl
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigImmediateTrig | TriggerZones$ Battlefield | TriggerDescription$ Whenever NICKNAME attacks, you may pay {E}{E}{E}{E}. When you do, destroy target nonbasic land defending player controls, and creatures that player controls without flying can't block this turn.

--- a/forge-gui/res/cardsfolder/t/time_reaper.txt
+++ b/forge-gui/res/cardsfolder/t/time_reaper.txt
@@ -5,7 +5,7 @@ PT:4/4
 K:Flying
 K:Haste
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigChangeZone | TriggerDescription$ Consume Anomaly — Whenever CARDNAME deals combat damage to a player, put target face-up card they own in exile on the bottom of their library. If you do, you gain 3 life.
-SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Exile | LibraryPosition$ -1 | Destination$ Library | ValidTgts$ Card.faceUp | TgtPrompt$ Select target face up card in exile | ChangeNum$ 1 | RememberChanged$ True | SubAbility$ DBGainLife
+SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Exile | LibraryPosition$ -1 | Destination$ Library | ValidTgts$ Card.faceUp | TgtPrompt$ Select target face-up card in exile | ChangeNum$ 1 | RememberChanged$ True | SubAbility$ DBGainLife
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ 3 | ConditionDefined$ Remembered | ConditionPresent$ Card | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 DeckHas:Ability$LifeGain

--- a/forge-gui/res/cardsfolder/t/traitors_roar.txt
+++ b/forge-gui/res/cardsfolder/t/traitors_roar.txt
@@ -1,7 +1,7 @@
 Name:Traitor's Roar
 ManaCost:4 BR
 Types:Sorcery
-A:SP$ Tap | ValidTgts$ Creature.untapped | TgtPrompt$ Select an untapped creature | SubAbility$ DBDamage | SpellDescription$ Tap target untapped creature. It deals damage equal to its power to its controller.
+A:SP$ Tap | ValidTgts$ Creature.untapped | TgtPrompt$ Select target untapped creature | SubAbility$ DBDamage | SpellDescription$ Tap target untapped creature. It deals damage equal to its power to its controller.
 SVar:DBDamage:DB$ DealDamage | Defined$ TargetedController | DamageSource$ Targeted | NumDmg$ X
 SVar:X:Targeted$CardPower
 K:Conspire

--- a/forge-gui/res/cardsfolder/t/trap_essence.txt
+++ b/forge-gui/res/cardsfolder/t/trap_essence.txt
@@ -1,7 +1,7 @@
 Name:Trap Essence
 ManaCost:G U R
 Types:Instant
-A:SP$ Counter | TargetType$ Spell | ValidTgts$ Card.Creature | TgtPrompt$ Select target creature Spell | SpellDescription$ Counter target creature spell. Put two +1/+1 counters on up to one target creature. | SubAbility$ DBPutcounter
-SVar:DBPutcounter:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ 2 | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select target creature | ValidTgts$ Creature
+A:SP$ Counter | TargetType$ Spell | ValidTgts$ Card.Creature | TgtPrompt$ Select target creature spell | SpellDescription$ Counter target creature spell. Put two +1/+1 counters on up to one target creature. | SubAbility$ DBPutcounter
+SVar:DBPutcounter:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ 2 | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target creature | ValidTgts$ Creature
 DeckHas:Ability$Counters
 Oracle:Counter target creature spell. Put two +1/+1 counters on up to one target creature.

--- a/forge-gui/res/cardsfolder/t/triad_of_fates.txt
+++ b/forge-gui/res/cardsfolder/t/triad_of_fates.txt
@@ -2,11 +2,11 @@ Name:Triad of Fates
 ManaCost:2 W B
 Types:Legendary Creature Human Wizard
 PT:3/3
-A:AB$ PutCounter | Cost$ 1 T | ValidTgts$ Creature.Other | TgtPrompt$ Select another target Creature | CounterType$ FATE | CounterNum$ 1 | SpellDescription$ Put a fate counter on another target creature.
+A:AB$ PutCounter | Cost$ 1 T | ValidTgts$ Creature.Other | TgtPrompt$ Select another target creature | CounterType$ FATE | CounterNum$ 1 | SpellDescription$ Put a fate counter on another target creature.
 A:AB$ ChangeZone | Cost$ W T | ValidTgts$ Creature.counters_GE1_FATE | Origin$ Battlefield | Destination$ Exile | TgtPrompt$ Select target creature that has a fate counter | RememberTargets$ True | SubAbility$ DBReturn | SpellDescription$ Exile target creature that has a fate counter on it, then return it to the battlefield under its owner's control.
 SVar:DBReturn:DB$ ChangeZone | Defined$ Remembered | Origin$ Exile | Destination$ Battlefield | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-A:AB$ ChangeZone | Cost$ B T | ValidTgts$ Creature.counters_GE1_FATE | TgtPrompt$ Select target creature that has a fate counter | Origin$ Battlefield | Destination$ Exile | SpellDescription$ Exile target creature that has a fate counter on it. Its controller draws two cards. | SubAbility$ DBDraw
+A:AB$ ChangeZone | Cost$ B T | ValidTgts$ Creature.counters_GE1_FATE | TgtPrompt$ Select target creature that has a fate counter on it | Origin$ Battlefield | Destination$ Exile | SpellDescription$ Exile target creature that has a fate counter on it. Its controller draws two cards. | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw | Defined$ TargetedController | NumCards$ 2
 AI:RemoveDeck:All
 Oracle:{1}, {T}: Put a fate counter on another target creature.\n{W}, {T}: Exile target creature that has a fate counter on it, then return it to the battlefield under its owner's control.\n{B}, {T}: Exile target creature that has a fate counter on it. Its controller draws two cards.

--- a/forge-gui/res/cardsfolder/t/triton_tactics.txt
+++ b/forge-gui/res/cardsfolder/t/triton_tactics.txt
@@ -1,7 +1,7 @@
 Name:Triton Tactics
 ManaCost:U
 Types:Instant
-A:SP$ Pump | TargetMin$ 0 | TargetMax$ 2 | NumDef$ +3 | ValidTgts$ Creature | TgtPrompt$ Select target Creature | SubAbility$ DBUntap | SpellDescription$ Up to two target creatures each get +0/+3 until end of turn. Untap those creatures. At this turn's next end of combat, tap each creature that was blocked by one of those creatures this turn and it doesn't untap during its controller's next untap step.
+A:SP$ Pump | TargetMin$ 0 | TargetMax$ 2 | NumDef$ +3 | ValidTgts$ Creature | TgtPrompt$ Select up to two target creatures | SubAbility$ DBUntap | SpellDescription$ Up to two target creatures each get +0/+3 until end of turn. Untap those creatures. At this turn's next end of combat, tap each creature that was blocked by one of those creatures this turn and it doesn't untap during its controller's next untap step.
 SVar:DBUntap:DB$ Untap | Defined$ ParentTarget | SubAbility$ DBDelTrig
 SVar:DBDelTrig:DB$ DelayedTrigger | ThisTurn$ True | Mode$ Phase | Phase$ EndCombat | Execute$ TrigRemember | TriggerDescription$ At this turn's next end of combat, tap each creature that was blocked by one of those creatures this turn and it doesn't untap during its controller's next untap step. | RememberObjects$ ParentTarget
 SVar:TrigRemember:DB$ Pump | RememberObjects$ DelayTriggerRemembered | SubAbility$ TrigTap

--- a/forge-gui/res/cardsfolder/t/twigwalker.txt
+++ b/forge-gui/res/cardsfolder/t/twigwalker.txt
@@ -2,5 +2,5 @@ Name:Twigwalker
 ManaCost:2 G
 Types:Creature Insect
 PT:2/2
-A:AB$ Pump | Cost$ 1 G Sac<1/CARDNAME> | TargetMin$ 0 | TargetMax$ 2 | NumAtt$ +2 | NumDef$ +2 | ValidTgts$ Creature | TgtPrompt$ Select target Creature | SpellDescription$ Up to two target creatures each get +2/+2 until end of turn.
+A:AB$ Pump | Cost$ 1 G Sac<1/CARDNAME> | TargetMin$ 0 | TargetMax$ 2 | NumAtt$ +2 | NumDef$ +2 | ValidTgts$ Creature | TgtPrompt$ Select two target creatures | SpellDescription$ Up to two target creatures each get +2/+2 until end of turn.
 Oracle:{1}{G}, Sacrifice Twigwalker: Two target creatures each get +2/+2 until end of turn.

--- a/forge-gui/res/cardsfolder/u/ugins_mastery.txt
+++ b/forge-gui/res/cardsfolder/u/ugins_mastery.txt
@@ -4,6 +4,6 @@ Types:Enchantment
 T:Mode$ SpellCast | ValidCard$ Creature.Colorless | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigManifest | TriggerDescription$ Whenever you cast a colorless creature spell, manifest the top card of your library. (Put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)
 SVar:TrigManifest:DB$ Manifest
 T:Mode$ AttackersDeclared | ValidAttackers$ Creature.YouCtrl | Execute$ TrigState | TriggerZones$ Battlefield | CheckSVar$ PackTactics | SVarCompare$ GE6 | NoResolvingCheck$ True | TriggerDescription$ Whenever you attack with creatures with total power 6 or greater, you may turn a face-down creature you control face up.
-SVar:TrigState:DB$ SetState | Choices$ Creature.faceDown+YouCtrl | ChoiceTitle$ Select a facedown creature you control | Mode$ TurnFaceUp
+SVar:TrigState:DB$ SetState | Choices$ Creature.faceDown+YouCtrl | ChoiceTitle$ Select a face-down creature you control | Mode$ TurnFaceUp
 SVar:PackTactics:Count$SumPower_Creature.attacking
 Oracle:Whenever you cast a colorless creature spell, manifest the top card of your library. (Put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)\nWhenever you attack with creatures with total power 6 or greater, you may turn a face-down creature you control face up.

--- a/forge-gui/res/cardsfolder/u/unyaro_griffin.txt
+++ b/forge-gui/res/cardsfolder/u/unyaro_griffin.txt
@@ -3,5 +3,5 @@ ManaCost:3 W
 Types:Creature Griffin
 PT:2/2
 K:Flying
-A:AB$ Counter | Cost$ Sac<1/CARDNAME> | TargetType$ Spell | TgtPrompt$ Select target Red Instant or Sorcery spell | ValidTgts$ Instant.Red,Sorcery.Red | SpellDescription$ Counter target red instant or sorcery spell.
+A:AB$ Counter | Cost$ Sac<1/CARDNAME> | TargetType$ Spell | TgtPrompt$ Select target red instant or sorcery spell | ValidTgts$ Instant.Red,Sorcery.Red | SpellDescription$ Counter target red instant or sorcery spell.
 Oracle:Flying\nSacrifice Unyaro Griffin: Counter target red instant or sorcery spell.

--- a/forge-gui/res/cardsfolder/u/urgent_necropsy.txt
+++ b/forge-gui/res/cardsfolder/u/urgent_necropsy.txt
@@ -3,7 +3,7 @@ ManaCost:2 B G
 Types:Instant
 A:SP$ Pump | Cost$ CollectEvidence<X> 2 B G | ValidTgts$ Artifact | TargetMin$ 0 | TargetMax$ 1 | SubAbility$ DBCreature | TgtPrompt$ Select up to one target artifact | SpellDescription$ Destroy up to one target artifact, up to one target creature, up to one target enchantment, and up to one target planeswalker.
 SVar:DBCreature:DB$ Pump | ValidTgts$ Creature | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target creature | SubAbility$ DBEnchantment
-SVar:DBEnchantment:DB$ Pump | SubAbility$ DBDestroyAll | ValidTgts$ Enchantment | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target Enchantment
+SVar:DBEnchantment:DB$ Pump | SubAbility$ DBDestroyAll | ValidTgts$ Enchantment | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target enchantment
 SVar:DBDestroyAll:DB$ Destroy | Defined$ Targeted
 SVar:X:AllTargeted$SumCMC
 DeckHints:Ability$Graveyard|Mill|Discard|Dredge

--- a/forge-gui/res/cardsfolder/v/vampire_sovereign.txt
+++ b/forge-gui/res/cardsfolder/v/vampire_sovereign.txt
@@ -4,6 +4,6 @@ Types:Creature Vampire Noble
 PT:3/4
 K:Flying
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigBite | TriggerDescription$ When CARDNAME enters, target opponent loses 3 life and you gain 3 life.
-SVar:TrigBite:DB$ LoseLife | ValidTgts$ Opponent | TgtPrompt$ Select an opponent | LifeAmount$ 3 | SubAbility$ DBGainLife | SpellDescription$ Target opponent loses 3 life and you gain 3 life.
+SVar:TrigBite:DB$ LoseLife | ValidTgts$ Opponent | LifeAmount$ 3 | SubAbility$ DBGainLife | SpellDescription$ Target opponent loses 3 life and you gain 3 life.
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ 3
 Oracle:Flying\nWhen Vampire Sovereign enters, target opponent loses 3 life and you gain 3 life.

--- a/forge-gui/res/cardsfolder/v/vhal_eager_scholar.txt
+++ b/forge-gui/res/cardsfolder/v/vhal_eager_scholar.txt
@@ -86,7 +86,7 @@ PT:4/4
 T:Mode$ Specializes | ValidCard$ Card.Self | Execute$ TrigRemoveCounters | TriggerDescription$ When this creature specializes, remove all study counters from it. Seek two creature cards with mana value less than or equal to the number of study counters removed this way. Put one of them onto the battlefield and shuffle the other into your library.
 SVar:TrigRemoveCounters:DB$ RemoveCounter | CounterType$ STUDY | CounterNum$ All | RememberRemoved$ True | SubAbility$ DBSeek
 SVar:DBSeek:DB$ Seek | Type$ Card.Creature+cmcLEX | Num$ 2 | RememberFound$ True | SubAbility$ DBBattlefield
-SVar:DBBattlefield:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | SelectPrompt$ Select one to put onto the battlefield | ChangeType$ Card.IsRemembered | ForgetChanged$ True | SubAbility$ DBShuffle
+SVar:DBBattlefield:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | SelectPrompt$ Select a card seeked this way to put onto the battlefield | ChangeType$ Card.IsRemembered | ForgetChanged$ True | SubAbility$ DBShuffle
 SVar:DBShuffle:DB$ ChangeZone | Origin$ Hand | Destination$ Library | Shuffle$ True | Defined$ RememberedCard | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Count$RememberedSize

--- a/forge-gui/res/cardsfolder/w/waterfront_bouncer.txt
+++ b/forge-gui/res/cardsfolder/w/waterfront_bouncer.txt
@@ -2,6 +2,6 @@ Name:Waterfront Bouncer
 ManaCost:1 U
 Types:Creature Merfolk Spellshaper
 PT:1/1
-A:AB$ ChangeZone | Cost$ U T Discard<1/Card> | ValidTgts$ Creature | TgtPrompt$ Select target Creature | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return target creature to its owner's hand.
+A:AB$ ChangeZone | Cost$ U T Discard<1/Card> | ValidTgts$ Creature | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return target creature to its owner's hand.
 AI:RemoveDeck:All
 Oracle:{U}, {T}, Discard a card: Return target creature to its owner's hand.

--- a/forge-gui/res/cardsfolder/w/welcome_to_jurassic_park.txt
+++ b/forge-gui/res/cardsfolder/w/welcome_to_jurassic_park.txt
@@ -2,7 +2,7 @@ Name:Welcome to . . .
 ManaCost:1 G G
 Types:Enchantment Saga
 K:Chapter:3:DBAnimateAll,DBToken,DBWrath
-SVar:DBAnimateAll:DB$ Animate | ValidTgts$ Artifact.nonCreature+OppCtrl | TgtPrompt$ Select target noncreature Artifact | TargetMin$ 0 | TargetMax$ OneEach | TargetsForEachPlayer$ True | Defined$ Targeted | Power$ 0 | Toughness$ 4 | Types$ Creature,Artifact,Wall | Keywords$ Defender | Duration$ AsLongAsControl | SpellDescription$ For each opponent, up to one target noncreature artifact they control becomes a 0/4 Wall artifact creature with defender for as long as you control this Saga.
+SVar:DBAnimateAll:DB$ Animate | ValidTgts$ Artifact.nonCreature+OppCtrl | TgtPrompt$ Select target noncreature artifact | TargetMin$ 0 | TargetMax$ OneEach | TargetsForEachPlayer$ True | Defined$ Targeted | Power$ 0 | Toughness$ 4 | Types$ Creature,Artifact,Wall | Keywords$ Defender | Duration$ AsLongAsControl | SpellDescription$ For each opponent, up to one target noncreature artifact they control becomes a 0/4 Wall artifact creature with defender for as long as you control this Saga.
 SVar:OneEach:PlayerCountOpponents$Amount
 SVar:DBToken:DB$ Token | TokenOwner$ You | TokenScript$ g_3_3_dinosaur_trample | PumpKeywords$ Haste | SpellDescription$ Create a 3/3 green Dinosaur creature token with trample. It gains haste until end of turn.
 SVar:DBWrath:DB$ DestroyAll | ValidCards$ Creature.Wall | SubAbility$ DBTransform | SpellDescription$ Destroy all Walls. Exile this Saga, then return it to the battlefield transformed under your control.

--- a/forge-gui/res/cardsfolder/w/wellgabber_apothecary.txt
+++ b/forge-gui/res/cardsfolder/w/wellgabber_apothecary.txt
@@ -2,6 +2,6 @@ Name:Wellgabber Apothecary
 ManaCost:4 W
 Types:Creature Merfolk Cleric
 PT:2/3
-A:SP$ Effect | Cost$ 1 W | ValidTgts$ Creature.Merfolk+tapped,Creature.Kithkin+tapped | TgtPrompt$ Select tapped Merfolk or Kithkin creature | ReplacementEffects$ RPrevent | RememberObjects$ Targeted | ExileOnMoved$ Battlefield | SpellDescription$ Prevent all damage that would be dealt to target tapped Merfolk or Kithkin creature this turn.
+A:SP$ Effect | Cost$ 1 W | ValidTgts$ Creature.Merfolk+tapped,Creature.Kithkin+tapped | TgtPrompt$ Select target tapped Merfolk or Kithkin creature | ReplacementEffects$ RPrevent | RememberObjects$ Targeted | ExileOnMoved$ Battlefield | SpellDescription$ Prevent all damage that would be dealt to target tapped Merfolk or Kithkin creature this turn.
 SVar:RPrevent:Event$ DamageDone | Prevent$ True | ValidTarget$ Card.IsRemembered | Description$ Prevent all damage that would be dealt to that creature this turn.
 Oracle:{1}{W}: Prevent all damage that would be dealt to target tapped Merfolk or Kithkin creature this turn.

--- a/forge-gui/res/cardsfolder/w/which_of_you_burns_brightest.txt
+++ b/forge-gui/res/cardsfolder/w/which_of_you_burns_brightest.txt
@@ -2,7 +2,7 @@ Name:Which of You Burns Brightest?
 ManaCost:no cost
 Types:Scheme
 T:Mode$ SetInMotion | ValidCard$ Card.Self | Execute$ DarkEffect | TriggerZones$ Command | OptionalDecider$ You | TriggerDescription$ When you set this scheme in motion, you may pay {X}. If you do, this scheme deals X damage to target opponent or planeswalker and each creature that player or that planeswalker's controller controls.
-SVar:DarkEffect:AB$ DealDamage | Cost$ X | ValidTgts$ Opponent,Planeswalker | TgtPrompt$ Select an opponent or planeswalker | NumDmg$ X | SubAbility$ DmgAll | DamageMap$ True
+SVar:DarkEffect:AB$ DealDamage | Cost$ X | ValidTgts$ Opponent,Planeswalker | TgtPrompt$ Select target opponent or planeswalker | NumDmg$ X | SubAbility$ DmgAll | DamageMap$ True
 SVar:DmgAll:DB$ DamageAll | NumDmg$ X | ValidCards$ Creature.ControlledBy TargetedOrController | SubAbility$ DBDamageResolve
 SVar:DBDamageResolve:DB$ DamageResolve
 SVar:X:Count$xPaid

--- a/forge-gui/res/cardsfolder/w/windborne_charge.txt
+++ b/forge-gui/res/cardsfolder/w/windborne_charge.txt
@@ -1,5 +1,5 @@
 Name:Windborne Charge
 ManaCost:2 W W
 Types:Sorcery
-A:SP$ Pump | TargetMin$ 2 | TargetMax$ 2 | KW$ Flying | NumAtt$ +2 | NumDef$ +2 | ValidTgts$ Creature | TgtPrompt$ Select target Creature | SpellDescription$ Two target creatures you control each get +2/+2 and gain flying until end of turn.
+A:SP$ Pump | TargetMin$ 2 | TargetMax$ 2 | KW$ Flying | NumAtt$ +2 | NumDef$ +2 | ValidTgts$ Creature | TgtPrompt$ Select two target creatures | SpellDescription$ Two target creatures you control each get +2/+2 and gain flying until end of turn.
 Oracle:Two target creatures you control each get +2/+2 and gain flying until end of turn.

--- a/forge-gui/res/cardsfolder/w/withering_boon.txt
+++ b/forge-gui/res/cardsfolder/w/withering_boon.txt
@@ -1,5 +1,5 @@
 Name:Withering Boon
 ManaCost:1 B
 Types:Instant
-A:SP$ Counter | Cost$ 1 B PayLife<3> | TargetType$ Spell | TgtPrompt$ Select target Creature spell | ValidTgts$ Creature | SpellDescription$ Counter target creature spell.
+A:SP$ Counter | Cost$ 1 B PayLife<3> | TargetType$ Spell | TgtPrompt$ Select target creature spell | ValidTgts$ Creature | SpellDescription$ Counter target creature spell.
 Oracle:As an additional cost to cast this spell, pay 3 life.\nCounter target creature spell.

--- a/forge-gui/res/cardsfolder/w/wizards_lightning.txt
+++ b/forge-gui/res/cardsfolder/w/wizards_lightning.txt
@@ -2,6 +2,6 @@ Name:Wizard's Lightning
 ManaCost:2 R
 Types:Instant
 S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 2 | EffectZone$ All | IsPresent$ Wizard.YouCtrl | Description$ This spell costs {2} less to cast if you control a Wizard.
-A:SP$ DealDamage | ValidTgts$ Any | TgtPrompt$ Select target | NumDmg$ 3 | SpellDescription$ CARDNAME deals 3 damage to any target.
+A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ 3 | SpellDescription$ CARDNAME deals 3 damage to any target.
 DeckNeeds:Type$Wizard
 Oracle:This spell costs {2} less to cast if you control a Wizard.\nWizard's Lightning deals 3 damage to any target.

--- a/forge-gui/res/cardsfolder/w/workshop_elders.txt
+++ b/forge-gui/res/cardsfolder/w/workshop_elders.txt
@@ -5,7 +5,7 @@ PT:4/4
 S:Mode$ Continuous | Affected$ Creature.Artifact+YouCtrl | AddKeyword$ Flying | Description$ Artifact creatures you control have flying.
 SVar:PlayMain1:TRUE
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigAnimate | TriggerDescription$ At the beginning of combat on your turn, you may have target noncreature artifact you control becomes a 0/0 artifact creature. If you do, put four +1/+1 counters on it.
-SVar:TrigAnimate:DB$ Animate | ValidTgts$ Artifact.nonCreature+YouCtrl | TgtPrompt$ Select noncreature artifact | Power$ 0 | Toughness$ 0 | Types$ Artifact,Creature | Duration$ Permanent | SubAbility$ DBPutCounter
+SVar:TrigAnimate:DB$ Animate | ValidTgts$ Artifact.nonCreature+YouCtrl | TgtPrompt$ Select target noncreature artifact | Power$ 0 | Toughness$ 0 | Types$ Artifact,Creature | Duration$ Permanent | SubAbility$ DBPutCounter
 SVar:DBPutCounter:DB$ PutCounter | Defined$ Targeted | CounterType$ P1P1 | CounterNum$ 4
 DeckHas:Ability$Counters
 Oracle:Artifact creatures you control have flying.\nAt the beginning of combat on your turn, you may have target noncreature artifact you control become a 0/0 artifact creature. If you do, put four +1/+1 counters on it.


### PR DESCRIPTION
Dealing with typos and other lapses. Also chipping away at the work for `TgtPrompt$` while I was at it. Notable fixes:
- Updated the Oracle text for [Suppression Ray // Orderly Plaza](https://scryfall.com/card/mh3/260/suppression-ray-orderly-plaza), as the sorcery face fell afoul of the same loophole as [Wheel of Potential](https://scryfall.com/card/mh3/144/wheel-of-potential). I'm assuming this one also works as intended and not as printed. 