### PR TITLE
Cleanup: EffectZone$ All, part 1

### DIFF
--- a/forge-gui/res/cardsfolder/a/abominable_treefolk.txt
+++ b/forge-gui/res/cardsfolder/a/abominable_treefolk.txt
@@ -3,7 +3,7 @@ ManaCost:2 G U
 Types:Snow Creature Treefolk
 PT:*/*
 K:Trample
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of snow permanents you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of snow permanents you control.
 SVar:X:Count$Valid Permanent.Snow+YouCtrl
 SVar:BuffedBy:Permanent.Snow
 SVar:NoZeroToughnessAI:True

--- a/forge-gui/res/cardsfolder/a/abomination_of_llanowar.txt
+++ b/forge-gui/res/cardsfolder/a/abomination_of_llanowar.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature Elf Horror
 PT:*/*
 K:Vigilance
 K:Menace
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of Elves you control plus the number of Elf cards in your graveyard.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of Elves you control plus the number of Elf cards in your graveyard.
 SVar:X:Count$Valid Elf.YouCtrl/Plus.Y
 SVar:Y:Count$TypeInYourYard.Elf
 SVar:NeedsToPlayVar:X GE1

--- a/forge-gui/res/cardsfolder/a/adamaro_first_to_desire.txt
+++ b/forge-gui/res/cardsfolder/a/adamaro_first_to_desire.txt
@@ -2,7 +2,7 @@ Name:Adamaro, First to Desire
 ManaCost:1 R R
 Types:Legendary Creature Spirit
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of cards in the hand of the opponent with the most cards in hand.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of cards in the hand of the opponent with the most cards in hand.
 SVar:X:PlayerCountOpponents$HighestCardsInHand
 SVar:AntiBuffedBy:Card
 Oracle:Adamaro, First to Desire's power and toughness are each equal to the number of cards in the hand of the opponent with the most cards in hand.

--- a/forge-gui/res/cardsfolder/a/adeline_resplendent_cathar.txt
+++ b/forge-gui/res/cardsfolder/a/adeline_resplendent_cathar.txt
@@ -3,7 +3,7 @@ ManaCost:1 W W
 Types:Legendary Creature Human Knight
 PT:*/4
 K:Vigilance
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of creatures you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of creatures you control.
 SVar:X:Count$Valid Creature.YouCtrl
 T:Mode$ AttackersDeclared | AttackingPlayer$ You | Execute$ DBRepeat | TriggerZones$ Battlefield | TriggerDescription$ Whenever you attack, for each opponent, create a 1/1 white Human creature token that's tapped and attacking that player or a planeswalker they control.
 SVar:DBRepeat:DB$ RepeatEach | RepeatPlayers$ Opponent | ChangeZoneTable$ True | RepeatSubAbility$ DBToken

--- a/forge-gui/res/cardsfolder/a/aeon_chronicler.txt
+++ b/forge-gui/res/cardsfolder/a/aeon_chronicler.txt
@@ -2,7 +2,7 @@ Name:Aeon Chronicler
 ManaCost:3 U U
 Types:Creature Avatar
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ Y | SetToughness$ Y | Description$ CARDNAME's power and toughness are each equal to the number of cards in your hand.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ Y | SetToughness$ Y | Description$ CARDNAME's power and toughness are each equal to the number of cards in your hand.
 K:Suspend:X:XMin1 X 3 U
 T:Mode$ CounterRemoved | ValidCard$ Card.Self | TriggerZones$ Exile | CounterType$ TIME | Execute$ TrigDraw | TriggerDescription$ Whenever a time counter is removed from CARDNAME while it's exiled, draw a card.
 SVar:TrigDraw:DB$ Draw | Defined$ You

--- a/forge-gui/res/cardsfolder/a/allosaurus_rider.txt
+++ b/forge-gui/res/cardsfolder/a/allosaurus_rider.txt
@@ -2,7 +2,7 @@ Name:Allosaurus Rider
 ManaCost:5 G G
 Types:Creature Elf Warrior
 PT:1+*/1+*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to 1 plus the number of lands you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to 1 plus the number of lands you control.
 SVar:X:Count$Valid Land.YouCtrl/Plus.1
 S:Mode$ AlternativeCost | ValidSA$ Spell.Self | EffectZone$ All | Cost$ ExileFromHand<2/Card.Green> | Description$ You may exile two green cards from your hand rather than pay this spell's mana cost.
 Oracle:You may exile two green cards from your hand rather than pay this spell's mana cost.\nAllosaurus Rider's power and toughness are each equal to 1 plus the number of lands you control.

--- a/forge-gui/res/cardsfolder/a/altar_golem.txt
+++ b/forge-gui/res/cardsfolder/a/altar_golem.txt
@@ -4,7 +4,7 @@ Types:Artifact Creature Golem
 PT:*/*
 K:Trample
 K:CARDNAME doesn't untap during your untap step.
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creatures on the battlefield.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creatures on the battlefield.
 SVar:X:Count$Valid Creature
 A:AB$ Untap | Cost$ tapXType<5/Creature> | SpellDescription$ Untap CARDNAME.
 SVar:BuffedBy:Creature

--- a/forge-gui/res/cardsfolder/a/altar_of_the_wretched_wretched_bonemass.txt
+++ b/forge-gui/res/cardsfolder/a/altar_of_the_wretched_wretched_bonemass.txt
@@ -21,7 +21,7 @@ ManaCost:no cost
 Colors:black
 Types:Creature Skeleton Horror
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the total power of the exiled cards used to craft it.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the total power of the exiled cards used to craft it.
 SVar:X:ExiledWith$CardPower
 S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self | SharedKeywordsZone$ Exile | SharedRestrictions$ Card.ExiledWithSource | AddKeyword$ Flying & First Strike & Double Strike & Deathtouch & Haste & Hexproof & Indestructible & Lifelink & Menace & Protection & Reach & Trample & Vigilance | Description$ CARDNAME has flying as long as an exiled card used to craft it has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, protection, reach, trample, and vigilance.
 Oracle:Wretched Bonemass's power and toughness are each equal to the total power of the exiled cards used to craft it.\nWretched Bonemass has flying as long as an exiled card used to craft it has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, protection, reach, trample, and vigilance.

--- a/forge-gui/res/cardsfolder/a/an_havva_constable.txt
+++ b/forge-gui/res/cardsfolder/a/an_havva_constable.txt
@@ -2,6 +2,6 @@ Name:An-Havva Constable
 ManaCost:1 G G
 Types:Creature Human
 PT:2/1+*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetToughness$ X | Description$ CARDNAME's toughness is equal to 1 plus the number of green creatures on the battlefield.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetToughness$ X | Description$ CARDNAME's toughness is equal to 1 plus the number of green creatures on the battlefield.
 SVar:X:Count$Valid Creature.Green/Plus.1
 Oracle:An-Havva Constable's toughness is equal to 1 plus the number of green creatures on the battlefield.

--- a/forge-gui/res/cardsfolder/a/anax_hardened_in_the_forge.txt
+++ b/forge-gui/res/cardsfolder/a/anax_hardened_in_the_forge.txt
@@ -2,7 +2,7 @@ Name:Anax, Hardened in the Forge
 ManaCost:1 R R
 Types:Legendary Enchantment Creature Demigod
 PT:*/3
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | Description$ NICKNAME's power is equal to your devotion to red.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | Description$ NICKNAME's power is equal to your devotion to red.
 SVar:X:Count$Devotion.Red
 SVar:BuffedBy:Permanent.Red
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self,Creature.Other+nonToken+YouCtrl | Execute$ TrigToken | TriggerDescription$ Whenever NICKNAME or another nontoken creature you control dies, create a 1/1 red Satyr creature token with "This creature can't block." If the creature had power 4 or greater, create two of those tokens instead.

--- a/forge-gui/res/cardsfolder/a/ancient_ooze.txt
+++ b/forge-gui/res/cardsfolder/a/ancient_ooze.txt
@@ -2,7 +2,7 @@ Name:Ancient Ooze
 ManaCost:5 G G
 Types:Creature Ooze
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the total mana value of other creatures you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the total mana value of other creatures you control.
 SVar:X:Count$Valid Creature.Other+YouCtrl$SumCMC
 SVar:NeedsToPlayVar:X GE4
 Oracle:Ancient Ooze's power and toughness are each equal to the total mana value of other creatures you control.

--- a/forge-gui/res/cardsfolder/a/angry_mob.txt
+++ b/forge-gui/res/cardsfolder/a/angry_mob.txt
@@ -3,9 +3,9 @@ ManaCost:2 W W
 Types:Creature Human
 PT:2+*/2+*
 K:Trample
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Condition$ PlayerTurn | Description$ As long as it's your turn, CARDNAME's power and toughness are each equal to 2 plus the number of Swamps your opponents control. As long as it's not your turn, CARDNAME's power and toughness are each 2.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Condition$ PlayerTurn | Description$ As long as it's your turn, CARDNAME's power and toughness are each equal to 2 plus the number of Swamps your opponents control. As long as it's not your turn, CARDNAME's power and toughness are each 2.
 SVar:X:Count$Valid Swamp.OppCtrl/Plus.2
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ 2 | SetToughness$ 2 | Condition$ NotPlayerTurn
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ 2 | SetToughness$ 2 | Condition$ NotPlayerTurn
 AI:RemoveDeck:Random
 DeckHints:Name$Urborg, Tomb of Yawgmoth & Keyword$Swampwalk
 Oracle:Trample\nAs long as it's your turn, Angry Mob's power and toughness are each equal to 2 plus the number of Swamps your opponents control. As long as it's not your turn, Angry Mob's power and toughness are each 2.

--- a/forge-gui/res/cardsfolder/a/apocalypse_demon.txt
+++ b/forge-gui/res/cardsfolder/a/apocalypse_demon.txt
@@ -3,7 +3,7 @@ ManaCost:4 B B
 Types:Creature Demon
 PT:*/*
 K:Flying
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of cards in your graveyard.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of cards in your graveyard.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigTap | TriggerDescription$ At the beginning of your upkeep, tap CARDNAME unless you sacrifice another creature.
 SVar:TrigTap:DB$ Tap | UnlessCost$ Sac<1/Creature.Other/another creature> | UnlessPayer$ You | Defined$ Self
 SVar:X:Count$InYourYard

--- a/forge-gui/res/cardsfolder/a/archpriest_of_iona.txt
+++ b/forge-gui/res/cardsfolder/a/archpriest_of_iona.txt
@@ -2,7 +2,7 @@ Name:Archpriest of Iona
 ManaCost:W
 Types:Creature Human Cleric
 PT:*/2
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of creatures in your party.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of creatures in your party.
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | CheckSVar$ X | SVarCompare$ EQ4 | Execute$ TrigPump | TriggerDescription$ At the beginning of combat on your turn, if you have a full party, target creature gets +1/+1 and gains flying until end of turn.
 SVar:TrigPump:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +1 | NumDef$ +1 | KW$ Flying
 SVar:X:Count$Party

--- a/forge-gui/res/cardsfolder/a/ashaya_soul_of_the_wild.txt
+++ b/forge-gui/res/cardsfolder/a/ashaya_soul_of_the_wild.txt
@@ -2,7 +2,7 @@ Name:Ashaya, Soul of the Wild
 ManaCost:3 G G
 Types:Legendary Creature Elemental
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of lands you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of lands you control.
 S:Mode$ Continuous | Affected$ Creature.nonToken+YouCtrl | AddType$ Forest & Land | Description$ Nontoken creatures you control are Forest lands in addition to their other types. (They're still affected by summoning sickness.)
 SVar:X:Count$Valid Land.YouCtrl
 SVar:Y:Count$Valid Creature.nonToken+YouCtrl

--- a/forge-gui/res/cardsfolder/a/aven_trailblazer.txt
+++ b/forge-gui/res/cardsfolder/a/aven_trailblazer.txt
@@ -3,6 +3,6 @@ ManaCost:2 W
 Types:Creature Bird Soldier
 PT:2/*
 K:Flying
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetToughness$ X | Description$ Domain — CARDNAME's toughness is equal to the number of basic land types among lands you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetToughness$ X | Description$ Domain — CARDNAME's toughness is equal to the number of basic land types among lands you control.
 SVar:X:Count$Domain
 Oracle:Flying\nDomain — Aven Trailblazer's toughness is equal to the number of basic land types among lands you control.

--- a/forge-gui/res/cardsfolder/a/awakened_amalgam.txt
+++ b/forge-gui/res/cardsfolder/a/awakened_amalgam.txt
@@ -2,6 +2,6 @@ Name:Awakened Amalgam
 ManaCost:4
 Types:Artifact Creature Golem
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of differently named lands you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of differently named lands you control.
 SVar:X:Count$DifferentCardNames_Land.YouCtrl+inZoneBattlefield
 Oracle:Awakened Amalgam's power and toughness are each equal to the number of differently named lands you control.

--- a/forge-gui/res/cardsfolder/a/aysen_crusader.txt
+++ b/forge-gui/res/cardsfolder/a/aysen_crusader.txt
@@ -2,6 +2,6 @@ Name:Aysen Crusader
 ManaCost:2 W W
 Types:Creature Human Knight
 PT:2+*/2+*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to 2 plus the number of Soldiers and Warriors you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to 2 plus the number of Soldiers and Warriors you control.
 SVar:X:Count$Valid Soldier.YouCtrl,Warrior.YouCtrl/Plus.2
 Oracle:Aysen Crusader's power and toughness are each equal to 2 plus the number of Soldiers and Warriors you control.

--- a/forge-gui/res/cardsfolder/b/barrowgoyf.txt
+++ b/forge-gui/res/cardsfolder/b/barrowgoyf.txt
@@ -4,7 +4,7 @@ Types:Creature Lhurgoyf
 PT:*/1+*
 K:Deathtouch
 K:Lifelink
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ Y | Description$ CARDNAME's power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ Y | Description$ CARDNAME's power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1.
 SVar:X:Count$ValidGraveyard Card$CardTypes
 SVar:Y:SVar$X/Plus.1
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | OptionalDecider$ You | Execute$ TrigMill | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, you may mill that many cards. If you do, you may put a creature card from among them into your hand.

--- a/forge-gui/res/cardsfolder/b/battle_squadron.txt
+++ b/forge-gui/res/cardsfolder/b/battle_squadron.txt
@@ -3,7 +3,7 @@ ManaCost:3 R R
 Types:Creature Goblin
 PT:*/*
 K:Flying
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creatures you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creatures you control.
 SVar:X:Count$Valid Creature.YouCtrl
 SVar:BuffedBy:Creature
 SVar:NoZeroToughnessAI:True

--- a/forge-gui/res/cardsfolder/b/beanstalk_giant_fertile_footsteps.txt
+++ b/forge-gui/res/cardsfolder/b/beanstalk_giant_fertile_footsteps.txt
@@ -2,7 +2,7 @@ Name:Beanstalk Giant
 ManaCost:6 G
 Types:Creature Giant
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of lands you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of lands you control.
 SVar:X:Count$Valid Land.YouCtrl
 AlternateMode:Adventure
 Oracle:Beanstalk Giant's power and toughness are each equal to the number of lands you control.

--- a/forge-gui/res/cardsfolder/b/beast_of_burden.txt
+++ b/forge-gui/res/cardsfolder/b/beast_of_burden.txt
@@ -2,7 +2,7 @@ Name:Beast of Burden
 ManaCost:6
 Types:Artifact Creature Golem
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creatures on the battlefield.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creatures on the battlefield.
 SVar:X:Count$Valid Creature
 SVar:BuffedBy:Creature
 SVar:NoZeroToughnessAI:True

--- a/forge-gui/res/cardsfolder/b/benalish_commander.txt
+++ b/forge-gui/res/cardsfolder/b/benalish_commander.txt
@@ -2,7 +2,7 @@ Name:Benalish Commander
 ManaCost:3 W
 Types:Creature Human Soldier
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ Y | SetToughness$ Y | Description$ CARDNAME's power and toughness are each equal to the number of Soldiers you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ Y | SetToughness$ Y | Description$ CARDNAME's power and toughness are each equal to the number of Soldiers you control.
 K:Suspend:X:XMin1 X W W
 T:Mode$ CounterRemoved | ValidCard$ Card.Self | TriggerZones$ Exile | CounterType$ TIME | Execute$ TrigToken | TriggerDescription$ Whenever a time counter is removed from CARDNAME while it's exiled, create a 1/1 white Soldier creature token.
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ w_1_1_soldier | TokenOwner$ You

--- a/forge-gui/res/cardsfolder/b/body_of_knowledge.txt
+++ b/forge-gui/res/cardsfolder/b/body_of_knowledge.txt
@@ -2,7 +2,7 @@ Name:Body of Knowledge
 ManaCost:3 U U
 Types:Creature Avatar
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of cards in your hand.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of cards in your hand.
 S:Mode$ Continuous | Affected$ You | SetMaxHandSize$ Unlimited | Description$ You have no maximum hand size.
 T:Mode$ DamageDoneOnce | ValidTarget$ Card.Self | Execute$ TrigDraw | TriggerDescription$ Whenever CARDNAME is dealt damage, draw that many cards.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ Y

--- a/forge-gui/res/cardsfolder/b/boneyard_mycodrax.txt
+++ b/forge-gui/res/cardsfolder/b/boneyard_mycodrax.txt
@@ -2,7 +2,7 @@ Name:Boneyard Mycodrax
 ManaCost:2 B
 Types:Creature Fungus
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of other creature cards in your graveyard.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of other creature cards in your graveyard.
 SVar:X:Count$ValidGraveyard Creature.Other+YouOwn
 K:Scavenge:4 B
 Oracle:Boneyard Mycodrax's power and toughness are each equal to the number of other creature cards in your graveyard.\nScavenge {4}{B} ({4}{B}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)

--- a/forge-gui/res/cardsfolder/b/boneyard_wurm.txt
+++ b/forge-gui/res/cardsfolder/b/boneyard_wurm.txt
@@ -2,7 +2,7 @@ Name:Boneyard Wurm
 ManaCost:1 G
 Types:Creature Wurm
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creature cards in your graveyard.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creature cards in your graveyard.
 SVar:X:Count$TypeInYourYard.Creature
 SVar:NeedsToPlayVar:X GE1
 Oracle:Boneyard Wurm's power and toughness are each equal to the number of creature cards in your graveyard.

--- a/forge-gui/res/cardsfolder/b/braulios_of_pheres_band.txt
+++ b/forge-gui/res/cardsfolder/b/braulios_of_pheres_band.txt
@@ -2,7 +2,7 @@ Name:Braulios of Pheres Band
 ManaCost:3 G G
 Types:Legendary Creature Centaur Scout
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of lands you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of lands you control.
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ Whenever CARDNAME attacks, draw a card, then you may put a land card from your hand onto the battlefield.
 SVar:TrigDraw:DB$ Draw | SubAbility$ DBChangeZone
 SVar:DBChangeZone:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | ChangeType$ Land | ChangeNum$ 1 | Optional$ You

--- a/forge-gui/res/cardsfolder/b/bronze_guardian.txt
+++ b/forge-gui/res/cardsfolder/b/bronze_guardian.txt
@@ -5,7 +5,7 @@ PT:*/5
 K:Double Strike
 K:Ward:2
 S:Mode$ Continuous | Affected$ Artifact.YouCtrl+Other | AddKeyword$ Ward:2 | Description$ Other artifacts you control have ward {2}.
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of artifacts you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of artifacts you control.
 SVar:X:Count$Valid Artifact.YouCtrl
 DeckHints:Type$Artifact
 Oracle:Double strike\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nOther artifacts you control have ward {2}.\nBronze Guardian's power is equal to the number of artifacts you control.

--- a/forge-gui/res/cardsfolder/b/broodstar.txt
+++ b/forge-gui/res/cardsfolder/b/broodstar.txt
@@ -4,7 +4,7 @@ Types:Creature Beast
 PT:*/*
 K:Affinity:Artifact
 K:Flying
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of artifacts you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of artifacts you control.
 SVar:X:Count$Valid Artifact.YouCtrl
 SVar:NeedsToPlayVar:X GE3
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/b/burakos_party_leader.txt
+++ b/forge-gui/res/cardsfolder/b/burakos_party_leader.txt
@@ -3,7 +3,7 @@ ManaCost:3 B
 Types:Legendary Creature Orc
 PT:2/4
 K:Choose a Background
-S:Mode$ Continuous | EffectZone$ All | Affected$ Card.Self | CharacteristicDefining$ True | AddType$ Cleric & Rogue & Warrior & Wizard | Description$ CARDNAME is also a Cleric, Rogue, Warrior, and Wizard.
+S:Mode$ Continuous | Affected$ Card.Self | CharacteristicDefining$ True | AddType$ Cleric & Rogue & Warrior & Wizard | Description$ CARDNAME is also a Cleric, Rogue, Warrior, and Wizard.
 T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigLoseLife | TriggerDescription$ Whenever NICKNAME attacks, defending player loses X life and you create X Treasure tokens, where X is the number of creatures in your party.
 SVar:TrigLoseLife:DB$ LoseLife | Defined$ TriggeredDefendingPlayer | LifeAmount$ X | SubAbility$ DBTreasureTokens
 SVar:DBTreasureTokens:DB$ Token | TokenAmount$ X | TokenScript$ c_a_treasure_sac | TokenOwner$ You

--- a/forge-gui/res/cardsfolder/b/burrowguard_mentor.txt
+++ b/forge-gui/res/cardsfolder/b/burrowguard_mentor.txt
@@ -3,7 +3,7 @@ ManaCost:G W
 Types:Creature Rabbit Soldier
 PT:*/*
 K:Trample
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creatures you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creatures you control.
 SVar:X:Count$Valid Creature.YouCtrl
 SVar:BuffedBy:Creature
 SVar:NoZeroToughnessAI:True

--- a/forge-gui/res/cardsfolder/c/callaphe_beloved_of_the_sea.txt
+++ b/forge-gui/res/cardsfolder/c/callaphe_beloved_of_the_sea.txt
@@ -2,7 +2,7 @@ Name:Callaphe, Beloved of the Sea
 ManaCost:1 U U
 Types:Legendary Enchantment Creature Demigod
 PT:*/3
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | Description$ NICKNAME's power is equal to your devotion to blue.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | Description$ NICKNAME's power is equal to your devotion to blue.
 SVar:X:Count$Devotion.Blue
 SVar:BuffedBy:Permanent.Blue
 S:Mode$ Continuous | Affected$ Creature.YouCtrl,Enchantment.YouCtrl | AddStaticAbility$ RaiseCost | Description$ Creatures and enchantments you control have "Spells your opponents cast that target this permanent cost {1} more to cast."

--- a/forge-gui/res/cardsfolder/c/caller_of_the_hunt.txt
+++ b/forge-gui/res/cardsfolder/c/caller_of_the_hunt.txt
@@ -3,6 +3,6 @@ ManaCost:2 G
 Types:Creature Human
 PT:*/*
 A:SP$ PermanentCreature | Cost$ 2 G ChooseCreatureType<1> | AILogic$ MostProminentOnBattlefield
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creatures of the chosen type on the battlefield.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creatures of the chosen type on the battlefield.
 SVar:X:Count$Valid Creature.ChosenType
 Oracle:As an additional cost to cast this spell, choose a creature type.\nCaller of the Hunt's power and toughness are each equal to the number of creatures of the chosen type on the battlefield.

--- a/forge-gui/res/cardsfolder/c/cantivore.txt
+++ b/forge-gui/res/cardsfolder/c/cantivore.txt
@@ -3,7 +3,7 @@ ManaCost:1 W W
 Types:Creature Lhurgoyf
 PT:*/*
 K:Vigilance
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of enchantment cards in all graveyards.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of enchantment cards in all graveyards.
 SVar:X:Count$TypeInAllYards.Enchantment
 AI:RemoveDeck:Random
 Oracle:Vigilance\nCantivore's power and toughness are each equal to the number of enchantment cards in all graveyards.

--- a/forge-gui/res/cardsfolder/c/cephalopod_sentry.txt
+++ b/forge-gui/res/cardsfolder/c/cephalopod_sentry.txt
@@ -3,7 +3,7 @@ ManaCost:2 W U
 Types:Artifact Creature Phyrexian Squid
 PT:*/5
 K:Flying
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of artifacts you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of artifacts you control.
 SVar:X:Count$Valid Artifact.YouCtrl
 DeckNeeds:Type$Artifact
 Oracle:Flying\nCephalopod Sentry's power is equal to the number of artifacts you control.

--- a/forge-gui/res/cardsfolder/c/chameleon_spirit.txt
+++ b/forge-gui/res/cardsfolder/c/chameleon_spirit.txt
@@ -4,7 +4,7 @@ Types:Creature Illusion Spirit
 PT:*/*
 K:ETBReplacement:Other:ChooseColor
 SVar:ChooseColor:DB$ ChooseColor | Defined$ You | AILogic$ MostProminentHumanControls | SpellDescription$ As CARDNAME enters, choose a color.
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of permanents of the chosen color your opponents control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of permanents of the chosen color your opponents control.
 SVar:X:Count$Valid Permanent.OppCtrl+ChosenColor
 SVar:NeedsToPlay:Permanent.OppCtrl+nonColorless
 Oracle:As Chameleon Spirit enters, choose a color.\nChameleon Spirit's power and toughness are each equal to the number of permanents of the chosen color your opponents control.

--- a/forge-gui/res/cardsfolder/c/chimney_goyf.txt
+++ b/forge-gui/res/cardsfolder/c/chimney_goyf.txt
@@ -3,7 +3,7 @@ ManaCost:4 B
 Types:Creature Lhurgoyf Imp
 PT:*/1+*
 K:Flying
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ Y | Description$ CARDNAME's power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ Y | Description$ CARDNAME's power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1.
 SVar:X:Count$ValidGraveyard Card$CardTypes
 SVar:Y:SVar$X/Plus.1
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigChangeZone | TriggerDescription$ When CARDNAME dies, target opponent puts a card from their hand on top of their library.

--- a/forge-gui/res/cardsfolder/c/clara_oswald.txt
+++ b/forge-gui/res/cardsfolder/c/clara_oswald.txt
@@ -2,7 +2,7 @@ Name:Clara Oswald
 ManaCost:6
 Types:Legendary Creature Human Advisor
 PT:2/6
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | Affected$ Card.Self | SetColor$ ChosenColor | Description$ Impossible Girl — If CARDNAME is your commander, choose a color before the game begins. CARDNAME is the chosen color.
+S:Mode$ Continuous | CharacteristicDefining$ True | Affected$ Card.Self | SetColor$ ChosenColor | Description$ Impossible Girl — If CARDNAME is your commander, choose a color before the game begins. CARDNAME is the chosen color.
 S:Mode$ Panharmonicon | ValidCard$ Doctor.YouCtrl | Description$ If a triggered ability of a Doctor you control triggers, that ability triggers an additional time.
 K:Doctor's companion
 DeckNeeds:Type$Time Lord & Type$Doctor

--- a/forge-gui/res/cardsfolder/c/coalition_construct.txt
+++ b/forge-gui/res/cardsfolder/c/coalition_construct.txt
@@ -4,7 +4,7 @@ Types:Artifact Creature Construct
 PT:2/2
 K:ETBReplacement:Other:ChooseCT
 SVar:ChooseCT:DB$ ChooseType | Type$ Creature | AILogic$ MostProminentInComputerDeck | SpellDescription$ As CARDNAME enters, choose a creature type.
-S:Mode$ Continuous | EffectZone$ All | Affected$ Card.Self | CharacteristicDefining$ True | AddType$ ChosenType | Description$ CARDNAME is the chosen type in addition to its other types.
+S:Mode$ Continuous | Affected$ Card.Self | CharacteristicDefining$ True | AddType$ ChosenType | Description$ CARDNAME is the chosen type in addition to its other types.
 T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigPump | TriggerDescription$ When CARDNAME enters, other creatures you control of the chosen type and creature cards of that type in your hand perpetually get +1/+1.
 SVar:TrigPump:DB$ PumpAll | ValidCards$ Creature.YouCtrl+Other+ChosenType | PumpZone$ Battlefield,Hand | NumAtt$ 1 | NumDef$ 1 | Duration$ Perpetual
 Oracle:As Coalition Construct enters, choose a creature type.\nCoalition Construct is the chosen type in addition to its other types.\nWhen Coalition Construct enters, other creatures you control of the chosen type and creature cards of that type in your hand perpetually get +1/+1.

--- a/forge-gui/res/cardsfolder/c/cognivore.txt
+++ b/forge-gui/res/cardsfolder/c/cognivore.txt
@@ -3,7 +3,7 @@ ManaCost:6 U U
 Types:Creature Lhurgoyf
 PT:*/*
 K:Flying
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of instant cards in all graveyards.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of instant cards in all graveyards.
 SVar:X:Count$TypeInAllYards.Instant
 AI:RemoveDeck:Random
 Oracle:Flying\nCognivore's power and toughness are each equal to the number of instant cards in all graveyards.

--- a/forge-gui/res/cardsfolder/c/coiling_woodworm.txt
+++ b/forge-gui/res/cardsfolder/c/coiling_woodworm.txt
@@ -2,6 +2,6 @@ Name:Coiling Woodworm
 ManaCost:2 G
 Types:Creature Insect Worm
 PT:*/1
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of Forests on the battlefield.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of Forests on the battlefield.
 SVar:X:Count$Valid Forest
 Oracle:Coiling Woodworm's power is equal to the number of Forests on the battlefield.

--- a/forge-gui/res/cardsfolder/c/consuming_aberration.txt
+++ b/forge-gui/res/cardsfolder/c/consuming_aberration.txt
@@ -2,7 +2,7 @@ Name:Consuming Aberration
 ManaCost:3 U B
 Types:Creature Horror
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ ConsumingPT | SetToughness$ ConsumingPT | Description$ CARDNAME's power and toughness are each equal to the number of cards in your opponents' graveyards.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ ConsumingPT | SetToughness$ ConsumingPT | Description$ CARDNAME's power and toughness are each equal to the number of cards in your opponents' graveyards.
 T:Mode$ SpellCast | ValidActivatingPlayer$ You | Execute$ Grind | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a spell, each opponent reveals cards from the top of their library until they reveal a land card, then puts those cards into their graveyard.
 SVar:Grind:DB$ DigUntil | Defined$ Player.Opponent | Amount$ 1 | Valid$ Land | ValidDescription$ land | RevealedDestination$ Graveyard
 SVar:ConsumingPT:Count$ValidGraveyard Card.OppOwn

--- a/forge-gui/res/cardsfolder/c/consuming_blob.txt
+++ b/forge-gui/res/cardsfolder/c/consuming_blob.txt
@@ -2,7 +2,7 @@ Name:Consuming Blob
 ManaCost:3 G G
 Types:Creature Ooze
 PT:*/*+1
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ Y | Description$ CARDNAME's power is equal to the number of creature cards in all graveyards and its toughness is equal to that number plus 1.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ Y | Description$ CARDNAME's power is equal to the number of creature cards in all graveyards and its toughness is equal to that number plus 1.
 SVar:X:Count$ValidGraveyard Card.YouOwn$CardTypes
 SVar:Y:SVar$X/Plus.1
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ At the beginning of your end step, create a green Ooze creature token with "This creature's power is equal to the number of card types among cards in your graveyard and its toughness is equal to that number plus 1."

--- a/forge-gui/res/cardsfolder/c/control_win_condition.txt
+++ b/forge-gui/res/cardsfolder/c/control_win_condition.txt
@@ -4,6 +4,6 @@ Types:Creature Whale
 PT:*/*
 R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 K:Shroud
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of turns you've taken this game. (If this is in your deck, please keep track of your turns. This means you, Mark.)
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of turns you've taken this game. (If this is in your deck, please keep track of your turns. This means you, Mark.)
 SVar:X:Count$YourTurns
 Oracle:This spell can't be countered.\nShroud\nControl Win Condition's power and toughness are each equal to the number of turns you've taken this game. (If this is in your deck, please keep track of your turns. This means you, Mark.)

--- a/forge-gui/res/cardsfolder/c/crackling_drake.txt
+++ b/forge-gui/res/cardsfolder/c/crackling_drake.txt
@@ -3,7 +3,7 @@ ManaCost:U U R R
 Types:Creature Drake
 PT:*/4
 K:Flying
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the total number of instant and sorcery cards you own in exile and in your graveyard.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the total number of instant and sorcery cards you own in exile and in your graveyard.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ When CARDNAME enters, draw a card.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1
 SVar:GraveCount:Count$ValidGraveyard Instant.YouOwn,Sorcery.YouOwn

--- a/forge-gui/res/cardsfolder/c/crowd_of_cinders.txt
+++ b/forge-gui/res/cardsfolder/c/crowd_of_cinders.txt
@@ -3,7 +3,7 @@ ManaCost:3 B
 Types:Creature Elemental
 PT:*/*
 K:Fear
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of black permanents you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of black permanents you control.
 SVar:X:Count$Valid Permanent.Black+YouCtrl
 SVar:BuffedBy:Permanent.Black
 SVar:NoZeroToughnessAI:True

--- a/forge-gui/res/cardsfolder/c/cruel_somnophage_cant_wake_up.txt
+++ b/forge-gui/res/cardsfolder/c/cruel_somnophage_cant_wake_up.txt
@@ -2,7 +2,7 @@ Name:Cruel Somnophage
 ManaCost:1 B
 Types:Creature Nightmare
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creature cards in all graveyards.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creature cards in all graveyards.
 SVar:X:Count$TypeInAllYards.Creature
 DeckHints:Ability$Mill|Discard|Graveyard
 DeckHas:Ability$Mill

--- a/forge-gui/res/cardsfolder/c/crusader_of_odric.txt
+++ b/forge-gui/res/cardsfolder/c/crusader_of_odric.txt
@@ -2,7 +2,7 @@ Name:Crusader of Odric
 ManaCost:2 W
 Types:Creature Human Soldier
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creatures you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creatures you control.
 SVar:X:Count$Valid Creature.YouCtrl
 SVar:BuffedBy:Creature
 SVar:NoZeroToughnessAI:True

--- a/forge-gui/res/cardsfolder/c/cultivator_colossus.txt
+++ b/forge-gui/res/cardsfolder/c/cultivator_colossus.txt
@@ -3,7 +3,7 @@ ManaCost:4 G G G
 Types:Creature Plant Beast
 PT:*/*
 K:Trample
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of lands you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of lands you control.
 SVar:X:Count$Valid Land.YouCtrl
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigRepeat | OptionalDecider$ You | TriggerDescription$ When CARDNAME enters, you may put a land card from your hand onto the battlefield tapped. If you do, draw a card and repeat this process.
 SVar:TrigRepeat:DB$ Repeat | RepeatSubAbility$ DBClear | RepeatDefined$ Remembered | RepeatPresent$ Card | RepeatSVarCompare$ EQ1 | SubAbility$ DBCleanup

--- a/forge-gui/res/cardsfolder/d/dakkon_blackblade.txt
+++ b/forge-gui/res/cardsfolder/d/dakkon_blackblade.txt
@@ -2,7 +2,7 @@ Name:Dakkon Blackblade
 ManaCost:2 W U U B
 Types:Legendary Creature Human Warrior
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of lands you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of lands you control.
 SVar:X:Count$Valid Land.YouCtrl
 SVar:BuffedBy:Land
 Oracle:Dakkon Blackblade's power and toughness are each equal to the number of lands you control.

--- a/forge-gui/res/cardsfolder/d/dakmor_sorceress.txt
+++ b/forge-gui/res/cardsfolder/d/dakmor_sorceress.txt
@@ -2,6 +2,6 @@ Name:Dakmor Sorceress
 ManaCost:5 B
 Types:Creature Human Wizard
 PT:*/4
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of Swamps you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of Swamps you control.
 SVar:X:Count$Valid Swamp.YouCtrl
 Oracle:Dakmor Sorceress's power is equal to the number of Swamps you control.

--- a/forge-gui/res/cardsfolder/d/daretti_rocketeer_engineer.txt
+++ b/forge-gui/res/cardsfolder/d/daretti_rocketeer_engineer.txt
@@ -2,7 +2,7 @@ Name:Daretti, Rocketeer Engineer
 ManaCost:4 R
 Types:Legendary Creature Goblin Artificer
 PT:*/5
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | Description$ NICKNAME's power is equal to the greatest mana value among artifacts you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | Description$ NICKNAME's power is equal to the greatest mana value among artifacts you control.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigReturn | TriggerDescription$ Whenever NICKNAME enters or attacks, choose target artifact card in your graveyard. You may sacrifice an artifact. If you do, return the chosen card to the battlefield.
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigReturn | Secondary$ True | TriggerDescription$ Whenever NICKNAME enters or attacks, choose target artifact card in your graveyard. You may sacrifice an artifact. If you do, return the chosen card to the battlefield.
 SVar:TrigReturn:AB$ ChangeZone | Cost$ Sac<1/Artifact> | Origin$ Graveyard | Destination$ Battlefield | Defined$ Targeted | ValidTgts$ Artifact.YouCtrl | TgtZone$ Graveyard | TgtPrompt$ Select target artifact card in your graveyard

--- a/forge-gui/res/cardsfolder/d/darksteel_hydra.txt
+++ b/forge-gui/res/cardsfolder/d/darksteel_hydra.txt
@@ -4,7 +4,7 @@ Types:Artifact Creature Phyrexian Hydra
 PT:*/*
 K:Indestructible
 K:etbCounter:OIL:X
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ Y | SetToughness$ Y | Description$ CARDNAME's power and toughness are each equal to twice the number of oil counters on it.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ Y | SetToughness$ Y | Description$ CARDNAME's power and toughness are each equal to twice the number of oil counters on it.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigConjure | TriggerDescription$ When CARDNAME enters, conjure a card named Darksteel Ingot and a card named Darksteel Plate into your hand.
 SVar:TrigConjure:DB$ MakeCard | Conjure$ True | Names$ Darksteel Ingot,Darksteel Plate | Zone$ Hand
 SVar:X:Count$xPaid

--- a/forge-gui/res/cardsfolder/d/darksteel_juggernaut.txt
+++ b/forge-gui/res/cardsfolder/d/darksteel_juggernaut.txt
@@ -3,7 +3,7 @@ ManaCost:5
 Types:Artifact Creature Juggernaut
 PT:*/*
 K:Indestructible
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of artifacts you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of artifacts you control.
 SVar:X:Count$Valid Artifact.YouCtrl
 S:Mode$ MustAttack | ValidCreature$ Card.Self | Description$ CARDNAME attacks each combat if able.
 SVar:BuffedBy:Artifact

--- a/forge-gui/res/cardsfolder/d/dauntless_dourbark.txt
+++ b/forge-gui/res/cardsfolder/d/dauntless_dourbark.txt
@@ -2,7 +2,7 @@ Name:Dauntless Dourbark
 ManaCost:3 G
 Types:Creature Treefolk Warrior
 PT:*/*
-S:Mode$ Continuous | Affected$ Card.Self | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of Forests you control plus the number of Treefolk you control.
+S:Mode$ Continuous | Affected$ Card.Self | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of Forests you control plus the number of Treefolk you control.
 S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Trample | IsPresent$ Treefolk.YouCtrl+Other | Description$ CARDNAME has trample as long as you control another Treefolk.
 SVar:X:Count$Valid Treefolk.YouCtrl/Plus.FOREST
 SVar:FOREST:Count$Valid Forest.YouCtrl

--- a/forge-gui/res/cardsfolder/d/dauthi_warlord.txt
+++ b/forge-gui/res/cardsfolder/d/dauthi_warlord.txt
@@ -3,6 +3,6 @@ ManaCost:1 B
 Types:Creature Dauthi Soldier
 PT:*/1
 K:Shadow
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of creatures with shadow on the battlefield.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of creatures with shadow on the battlefield.
 SVar:X:Count$Valid Creature.withShadow
 Oracle:Shadow (This creature can block or be blocked by only creatures with shadow.)\nDauthi Warlord's power is equal to the number of creatures with shadow on the battlefield.

--- a/forge-gui/res/cardsfolder/d/daxos_blessed_by_the_sun.txt
+++ b/forge-gui/res/cardsfolder/d/daxos_blessed_by_the_sun.txt
@@ -2,7 +2,7 @@ Name:Daxos, Blessed by the Sun
 ManaCost:W W
 Types:Legendary Enchantment Creature Demigod
 PT:2/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetToughness$ X | Description$ NICKNAME's toughness is equal to your devotion to white.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetToughness$ X | Description$ NICKNAME's toughness is equal to your devotion to white.
 SVar:X:Count$Devotion.White
 SVar:BuffedBy:Permanent.White
 T:Mode$ ChangesZone | TriggerZones$ Battlefield | ValidCard$ Creature.YouCtrl+Other | Origin$ Any | Destination$ Battlefield | Execute$ TrigGainLife | TriggerDescription$ Whenever another creature you control enters or dies, you gain 1 life.

--- a/forge-gui/res/cardsfolder/d/detritivore.txt
+++ b/forge-gui/res/cardsfolder/d/detritivore.txt
@@ -2,7 +2,7 @@ Name:Detritivore
 ManaCost:2 R R
 Types:Creature Lhurgoyf
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ Y | SetToughness$ Y | Description$ CARDNAME's power and toughness are each equal to the number of nonbasic land cards in your opponents' graveyards.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ Y | SetToughness$ Y | Description$ CARDNAME's power and toughness are each equal to the number of nonbasic land cards in your opponents' graveyards.
 K:Suspend:X:XMin1 X 3 R
 T:Mode$ CounterRemoved | ValidCard$ Card.Self | TriggerZones$ Exile | CounterType$ TIME | Execute$ TrigDestroy | TriggerDescription$ Whenever a time counter is removed from CARDNAME while it's exiled, destroy target nonbasic land.
 SVar:TrigDestroy:DB$ Destroy | ValidTgts$ Land.nonBasic | TgtPrompt$ Select target nonbasic land.

--- a/forge-gui/res/cardsfolder/d/dodgy_jalopy.txt
+++ b/forge-gui/res/cardsfolder/d/dodgy_jalopy.txt
@@ -3,7 +3,7 @@ ManaCost:2 G
 Types:Artifact Vehicle
 PT:*/5
 K:Trample
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the highest mana value among creatures you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the highest mana value among creatures you control.
 SVar:X:Count$Valid Creature.YouCtrl$GreatestCMC
 K:Crew:3
 K:Scavenge:2 G

--- a/forge-gui/res/cardsfolder/d/doubtless_one.txt
+++ b/forge-gui/res/cardsfolder/d/doubtless_one.txt
@@ -2,7 +2,7 @@ Name:Doubtless One
 ManaCost:3 W
 Types:Creature Cleric Avatar
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of Clerics on the battlefield.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of Clerics on the battlefield.
 SVar:X:Count$Valid Cleric
 T:Mode$ DamageDealtOnce | ValidSource$ Card.Self | Execute$ TrigGain | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME deals damage, you gain that much life.
 SVar:TrigGain:DB$ GainLife | Defined$ You | LifeAmount$ Y

--- a/forge-gui/res/cardsfolder/d/drift_of_the_dead.txt
+++ b/forge-gui/res/cardsfolder/d/drift_of_the_dead.txt
@@ -3,7 +3,7 @@ ManaCost:3 B
 Types:Creature Wall
 PT:*/*
 K:Defender
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of snow lands you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of snow lands you control.
 SVar:X:Count$Valid Land.Snow+YouCtrl
 SVar:NeedsToPlayVar:X GE2
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/d/drove_of_elves.txt
+++ b/forge-gui/res/cardsfolder/d/drove_of_elves.txt
@@ -3,7 +3,7 @@ ManaCost:3 G
 Types:Creature Elf
 PT:*/*
 K:Hexproof
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of green permanents you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of green permanents you control.
 SVar:X:Count$Valid Permanent.Green+YouCtrl
 SVar:BuffedBy:Permanent.Green
 SVar:NoZeroToughnessAI:True

--- a/forge-gui/res/cardsfolder/d/duelist_of_the_mind.txt
+++ b/forge-gui/res/cardsfolder/d/duelist_of_the_mind.txt
@@ -4,7 +4,7 @@ Types:Creature Human Advisor
 PT:*/3
 K:Flying
 K:Vigilance
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of cards you've drawn this turn.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of cards you've drawn this turn.
 SVar:X:Count$YouDrewThisTurn
 T:Mode$ CommitCrime | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigLoot | ActivationLimit$ 1 | TriggerDescription$ Whenever you commit a crime, you may draw a card. If you do, discard a card. This ability triggers only once each turn.
 SVar:TrigLoot:AB$ Discard | Defined$ You | Mode$ TgtChoose | Cost$ Draw<1/You>

--- a/forge-gui/res/cardsfolder/d/duggan_private_detective.txt
+++ b/forge-gui/res/cardsfolder/d/duggan_private_detective.txt
@@ -2,7 +2,7 @@ Name:Duggan, Private Detective
 ManaCost:2 G U
 Types:Legendary Creature Human Detective
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ NICKNAME's power and toughness are each equal to the number of cards in your hand.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ NICKNAME's power and toughness are each equal to the number of cards in your hand.
 SVar:X:Count$InYourHand
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ Whenever NICKNAME enters or attacks, investigate.
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigInvestigate | Secondary$ True | TriggerDescription$ Whenever NICKNAME enters or attacks, investigate.

--- a/forge-gui/res/cardsfolder/d/dungrove_elder.txt
+++ b/forge-gui/res/cardsfolder/d/dungrove_elder.txt
@@ -3,7 +3,7 @@ ManaCost:2 G
 Types:Creature Treefolk
 PT:*/*
 K:Hexproof
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of Forests you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of Forests you control.
 SVar:X:Count$Valid Forest.YouCtrl
 SVar:NeedsToPlayVar:X GE2
 SVar:BuffedBy:Forest

--- a/forge-gui/res/cardsfolder/e/eluge_the_shoreless_sea.txt
+++ b/forge-gui/res/cardsfolder/e/eluge_the_shoreless_sea.txt
@@ -2,7 +2,7 @@ Name:Eluge, the Shoreless Sea
 ManaCost:1 U U U
 Types:Legendary Creature Elemental Fish
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ NICKNAME's power and toughness are each equal to the number of Islands you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ NICKNAME's power and toughness are each equal to the number of Islands you control.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPutCounter | TriggerDescription$ Whenever NICKNAME enters or attacks, put a flood counter on target land. It's an Island in addition to its other types for as long as it has a flood counter on it.
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPutCounter | TriggerZones$ Battlefield | Secondary$ True | TriggerDescription$ Whenever NICKNAME enters or attacks, put a flood counter on target land. It's an Island in addition to its other types for as long as it has a flood counter on it.
 SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Land | TgtPrompt$ Select target land | CounterType$ FLOOD | CounterNum$ 1 | SubAbility$ DBEffect

--- a/forge-gui/res/cardsfolder/e/enduring_angel_angelic_enforcer.txt
+++ b/forge-gui/res/cardsfolder/e/enduring_angel_angelic_enforcer.txt
@@ -22,7 +22,7 @@ Types:Creature Angel
 PT:*/*
 K:Flying
 S:Mode$ Continuous | Affected$ You | AddKeyword$ Hexproof | Description$ You have hexproof.
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to your life total.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to your life total.
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigDoubleLife | TriggerDescription$ Whenever CARDNAME attacks, double your life total.
 SVar:TrigDoubleLife:DB$ SetLife | LifeAmount$ Y
 SVar:X:Count$YourLifeTotal

--- a/forge-gui/res/cardsfolder/e/enigma_drake.txt
+++ b/forge-gui/res/cardsfolder/e/enigma_drake.txt
@@ -3,7 +3,7 @@ ManaCost:1 U R
 Types:Creature Drake
 PT:*/4
 K:Flying
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of instant and sorcery cards in your graveyard.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of instant and sorcery cards in your graveyard.
 SVar:X:Count$ValidGraveyard Instant.YouOwn,Sorcery.YouOwn
 DeckHints:Type$Instant|Sorcery
 Oracle:Flying\nEnigma Drake's power is equal to the number of instant and sorcery cards in your graveyard.

--- a/forge-gui/res/cardsfolder/e/entropic_specter.txt
+++ b/forge-gui/res/cardsfolder/e/entropic_specter.txt
@@ -5,7 +5,7 @@ PT:*/*
 K:Flying
 K:ETBReplacement:Other:ChooseP
 SVar:ChooseP:DB$ ChoosePlayer | Defined$ You | Choices$ Player.Opponent | AILogic$ Curse | SpellDescription$ As CARDNAME enters, choose an opponent.
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of cards in the chosen player's hand.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of cards in the chosen player's hand.
 SVar:X:Count$InChosenHand
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigDiscard | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME deals damage to a player, that player discards a card.
 SVar:TrigDiscard:DB$ Discard | Defined$ TriggeredTarget | NumCards$ 1 | Mode$ TgtChoose

--- a/forge-gui/res/cardsfolder/f/faceless_one.txt
+++ b/forge-gui/res/cardsfolder/f/faceless_one.txt
@@ -2,7 +2,7 @@ Name:Faceless One
 ManaCost:5
 Types:Legendary Enchantment Creature Background
 PT:3/3
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | Affected$ Card.Self | SetColor$ ChosenColor | Description$ If CARDNAME is your commander, choose a color before the game begins. CARDNAME is the chosen color.
+S:Mode$ Continuous | CharacteristicDefining$ True | Affected$ Card.Self | SetColor$ ChosenColor | Description$ If CARDNAME is your commander, choose a color before the game begins. CARDNAME is the chosen color.
 K:Choose a Background
 AI:RemoveDeck:NonCommander
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/f/faerie_swarm.txt
+++ b/forge-gui/res/cardsfolder/f/faerie_swarm.txt
@@ -3,7 +3,7 @@ ManaCost:3 U
 Types:Creature Faerie
 PT:*/*
 K:Flying
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of blue permanents you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of blue permanents you control.
 SVar:X:Count$Valid Permanent.Blue+YouCtrl
 SVar:BuffedBy:Permanent.Blue
 SVar:NoZeroToughnessAI:True

--- a/forge-gui/res/cardsfolder/f/filigree_attendant.txt
+++ b/forge-gui/res/cardsfolder/f/filigree_attendant.txt
@@ -3,7 +3,7 @@ ManaCost:2 U U
 Types:Artifact Creature Homunculus
 PT:*/3
 K:Flying
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of artifacts you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of artifacts you control.
 SVar:X:Count$Valid Artifact.YouCtrl
 DeckHints:Type$Artifact
 Oracle:Flying\nFiligree Attendant's power is equal to the number of artifacts you control.

--- a/forge-gui/res/cardsfolder/f/fungal_behemoth.txt
+++ b/forge-gui/res/cardsfolder/f/fungal_behemoth.txt
@@ -2,7 +2,7 @@ Name:Fungal Behemoth
 ManaCost:3 G
 Types:Creature Fungus
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ Y | SetToughness$ Y | Description$ CARDNAME's power and toughness are each equal to the number of +1/+1 counters on creatures you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ Y | SetToughness$ Y | Description$ CARDNAME's power and toughness are each equal to the number of +1/+1 counters on creatures you control.
 K:Suspend:X:XMin1 X G G
 T:Mode$ CounterRemoved | ValidCard$ Card.Self | TriggerZones$ Exile | CounterType$ TIME | Execute$ TrigPut | OptionalDecider$ You | TriggerDescription$ Whenever a time counter is removed from CARDNAME while it's exiled, you may put a +1/+1 counter on target creature.
 SVar:TrigPut:DB$ PutCounter | ValidTgts$ Creature | TgtPrompt$ Select target creature | CounterType$ P1P1 | CounterNum$ 1

--- a/forge-gui/res/cardsfolder/g/gaeas_avenger.txt
+++ b/forge-gui/res/cardsfolder/g/gaeas_avenger.txt
@@ -2,6 +2,6 @@ Name:Gaea's Avenger
 ManaCost:1 G G
 Types:Creature Treefolk
 PT:1+*/1+*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to 1 plus the number of artifacts your opponents control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to 1 plus the number of artifacts your opponents control.
 SVar:X:Count$NumTypeOppCtrl.Artifact/Plus.1
 Oracle:Gaea's Avenger's power and toughness are each equal to 1 plus the number of artifacts your opponents control.

--- a/forge-gui/res/cardsfolder/g/gaeas_liege.txt
+++ b/forge-gui/res/cardsfolder/g/gaeas_liege.txt
@@ -2,9 +2,9 @@ Name:Gaea's Liege
 ManaCost:3 G G G
 Types:Creature Avatar
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | IsPresent$ Card.Self+notattacking | SetPower$ X | SetToughness$ X | Description$ As long as CARDNAME isn't attacking, its power and toughness are each equal to the number of Forests you control. As long as CARDNAME is attacking, its power and toughness are each equal to the number of Forests defending player controls.
+S:Mode$ Continuous | CharacteristicDefining$ True | IsPresent$ Card.Self+notattacking | SetPower$ X | SetToughness$ X | Description$ As long as CARDNAME isn't attacking, its power and toughness are each equal to the number of Forests you control. As long as CARDNAME is attacking, its power and toughness are each equal to the number of Forests defending player controls.
 SVar:X:Count$Valid Forest.YouCtrl
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | IsPresent$ Card.Self+attacking | SetPower$ Y | SetToughness$ Y
+S:Mode$ Continuous | CharacteristicDefining$ True | IsPresent$ Card.Self+attacking | SetPower$ Y | SetToughness$ Y
 SVar:Y:Count$Valid Forest.DefenderCtrl
 A:AB$ Animate | Cost$ T | ValidTgts$ Land | TgtPrompt$ Select target land | Types$ Forest | RemoveLandTypes$ True | Duration$ UntilHostLeavesPlay | SpellDescription$ Target land becomes a Forest until CARDNAME leaves the battlefield.
 SVar:BuffedBy:Forest

--- a/forge-gui/res/cardsfolder/g/geist_honored_monk.txt
+++ b/forge-gui/res/cardsfolder/g/geist_honored_monk.txt
@@ -3,7 +3,7 @@ ManaCost:3 W W
 Types:Creature Human Monk
 PT:*/*
 K:Vigilance
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creatures you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creatures you control.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create two 1/1 white Spirit creature tokens with flying.
 SVar:TrigToken:DB$ Token | TokenAmount$ 2 | TokenScript$ w_1_1_spirit_flying | TokenOwner$ You
 SVar:X:Count$Valid Creature.YouCtrl

--- a/forge-gui/res/cardsfolder/g/ghostfire.txt
+++ b/forge-gui/res/cardsfolder/g/ghostfire.txt
@@ -2,5 +2,5 @@ Name:Ghostfire
 ManaCost:2 R
 Types:Instant
 A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ 3 | SpellDescription$ CARDNAME deals 3 damage to any target.
-S:Mode$ Continuous | EffectZone$ All | Affected$ Card.Self | CharacteristicDefining$ True | SetColor$ Colorless | Description$ CARDNAME is colorless.
+S:Mode$ Continuous | Affected$ Card.Self | CharacteristicDefining$ True | SetColor$ Colorless | Description$ CARDNAME is colorless.
 Oracle:Ghostfire is colorless.\nGhostfire deals 3 damage to any target.

--- a/forge-gui/res/cardsfolder/g/greensleeves_maro_sorcerer.txt
+++ b/forge-gui/res/cardsfolder/g/greensleeves_maro_sorcerer.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature Elemental
 PT:*/*
 K:Protection:Planeswalker
 K:Protection:Wizard
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of lands you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of lands you control.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Landfall — Whenever a land you control enters, create a 3/3 green Badger creature token.
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ g_3_3_badger | TokenOwner$ You
 SVar:X:Count$Valid Land.YouCtrl

--- a/forge-gui/res/cardsfolder/h/hanweir_militia_captain_westvale_cult_leader.txt
+++ b/forge-gui/res/cardsfolder/h/hanweir_militia_captain_westvale_cult_leader.txt
@@ -14,7 +14,7 @@ ManaCost:no cost
 Colors:white
 Types:Creature Human Cleric
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creatures you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creatures you control.
 SVar:X:Count$Valid Creature.YouCtrl
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ At the beginning of your end step, create a 1/1 white and black Human Cleric creature token.
 SVar:TrigToken:DB$ Token | TokenScript$ wb_1_1_human_cleric | TokenOwner$ You | TokenAmount$ 1

--- a/forge-gui/res/cardsfolder/h/haughty_djinn.txt
+++ b/forge-gui/res/cardsfolder/h/haughty_djinn.txt
@@ -3,7 +3,7 @@ ManaCost:1 U U
 Types:Creature Djinn
 PT:*/4
 K:Flying
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of instant and sorcery cards in your graveyard.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of instant and sorcery cards in your graveyard.
 S:Mode$ ReduceCost | ValidCard$ Instant,Sorcery | Type$ Spell | Activator$ You | Amount$ 1 | Description$ Instant and sorcery spells you cast cost {1} less to cast.
 SVar:X:Count$ValidGraveyard Instant.YouOwn,Sorcery.YouOwn
 SVar:BuffedBy:Spell.Instant,Spell.Sorcery

--- a/forge-gui/res/cardsfolder/h/haunting_apparition.txt
+++ b/forge-gui/res/cardsfolder/h/haunting_apparition.txt
@@ -5,6 +5,6 @@ PT:1/2
 K:Flying
 K:ETBReplacement:Other:ChooseP
 SVar:ChooseP:DB$ ChoosePlayer | Defined$ You | Choices$ Player.Opponent | AILogic$ Curse | SpellDescription$ As CARDNAME enters, choose an opponent.
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to 1 plus the number of green creature cards in the chosen player's graveyard.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to 1 plus the number of green creature cards in the chosen player's graveyard.
 SVar:X:Count$ValidGraveyard Creature.Green+ChosenCtrl/Plus.1
 Oracle:Flying\nAs Haunting Apparition enters, choose an opponent.\nHaunting Apparition's power is equal to 1 plus the number of green creature cards in the chosen player's graveyard.

--- a/forge-gui/res/cardsfolder/h/heedless_one.txt
+++ b/forge-gui/res/cardsfolder/h/heedless_one.txt
@@ -3,7 +3,7 @@ ManaCost:3 G
 Types:Creature Elf Avatar
 PT:*/*
 K:Trample
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of Elves on the battlefield.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of Elves on the battlefield.
 SVar:X:Count$Valid Elf
 SVar:BuffedBy:Permanent.Elf
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/h/horde_of_boggarts.txt
+++ b/forge-gui/res/cardsfolder/h/horde_of_boggarts.txt
@@ -3,7 +3,7 @@ ManaCost:3 R
 Types:Creature Goblin
 PT:*/*
 K:Menace
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of red permanents you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of red permanents you control.
 SVar:X:Count$Valid Permanent.Red+YouCtrl
 SVar:BuffedBy:Permanent.Red
 SVar:NoZeroToughnessAI:True

--- a/forge-gui/res/cardsfolder/i/invasion_of_alara_awaken_the_maelstrom.txt
+++ b/forge-gui/res/cardsfolder/i/invasion_of_alara_awaken_the_maelstrom.txt
@@ -16,7 +16,7 @@ ALTERNATE
 Name:Awaken the Maelstrom
 ManaCost:no cost
 Types:Sorcery
-S:Mode$ Continuous | EffectZone$ All | Affected$ Card.Self | CharacteristicDefining$ True | SetColor$ All | Description$ CARDNAME is all colors.
+S:Mode$ Continuous | Affected$ Card.Self | CharacteristicDefining$ True | SetColor$ All | Description$ CARDNAME is all colors.
 A:SP$ Draw | NumCards$ 2 | ValidTgts$ Player | SubAbility$ DBChangeZone | TgtPrompt$ Select target player | SpellDescription$ Target player draws two cards.
 SVar:DBChangeZone:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | SubAbility$ DBCopy | ChangeType$ Artifact | ChangeNum$ 1 | SpellDescription$ You may put an artifact card from your hand onto the battlefield.
 SVar:DBCopy:DB$ CopyPermanent | Choices$ Permanent.YouCtrl | ChoiceTitle$ Choose a permanent you control to copy | SubAbility$ DBCounter | SpellDescription$ Create a token that's a copy of a permanent you control.

--- a/forge-gui/res/cardsfolder/i/invasion_of_kaladesh_aetherwing_golden_scale_flagship.txt
+++ b/forge-gui/res/cardsfolder/i/invasion_of_kaladesh_aetherwing_golden_scale_flagship.txt
@@ -18,6 +18,6 @@ Types:Legendary Artifact Vehicle
 PT:*/4
 K:Flying
 K:Crew:1
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of artifacts you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of artifacts you control.
 SVar:X:Count$Valid Artifact.YouCtrl
 Oracle:Flying\nAetherwing, Golden-Scale Flagship's power is equal to the number of artifacts you control.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)

--- a/forge-gui/res/cardsfolder/i/invasion_of_lorwyn_winnowing_forces.txt
+++ b/forge-gui/res/cardsfolder/i/invasion_of_lorwyn_winnowing_forces.txt
@@ -15,7 +15,7 @@ ManaCost:no cost
 Colors:black,green
 Types:Creature Elf Warrior
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of lands you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of lands you control.
 SVar:X:Count$Valid Land.YouCtrl
 SVar:BuffedBy:Land
 Oracle:Winnowing Forces's power and toughness are each equal to the number of lands you control.

--- a/forge-gui/res/cardsfolder/i/invasion_of_xerex_vertex_paladin.txt
+++ b/forge-gui/res/cardsfolder/i/invasion_of_xerex_vertex_paladin.txt
@@ -14,7 +14,7 @@ ManaCost:no cost
 Colors:white,blue
 Types:Creature Angel Knight
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creatures you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creatures you control.
 SVar:X:Count$Valid Creature.YouCtrl
 K:Flying
 Oracle:Flying\nVertex Paladin's power and toughness are each equal to the number of creatures you control.

--- a/forge-gui/res/cardsfolder/i/ironroot_warlord.txt
+++ b/forge-gui/res/cardsfolder/i/ironroot_warlord.txt
@@ -2,7 +2,7 @@ Name:Ironroot Warlord
 ManaCost:1 G W
 Types:Creature Treefolk Soldier
 PT:*/5
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of creatures you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of creatures you control.
 SVar:X:Count$Valid Creature.YouCtrl
 A:AB$ Token | Cost$ 3 G W | TokenAmount$ 1 | TokenScript$ w_1_1_soldier | TokenOwner$ You | SpellDescription$ Create a 1/1 white Soldier creature token.
 DeckHas:Ability$Token

--- a/forge-gui/res/cardsfolder/i/ixidron.txt
+++ b/forge-gui/res/cardsfolder/i/ixidron.txt
@@ -4,7 +4,7 @@ Types:Creature Illusion
 PT:*/*
 K:ETBReplacement:Other:TrigTurnFaceDown
 SVar:TrigTurnFaceDown:DB$ SetState | Defined$ Valid Creature.nonToken+Other+faceUp | Mode$ TurnFaceDown | SpellDescription$ As CARDNAME enters, turn all other nontoken creatures face down. (They're 2/2 creatures.)
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of face-down creatures on the battlefield.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of face-down creatures on the battlefield.
 SVar:X:Count$Valid Creature.faceDown
 SVar:NeedsToPlay:Creature.OppCtrl+nonToken
 Oracle:As Ixidron enters, turn all other nontoken creatures face down. (They're 2/2 creatures.)\nIxidron's power and toughness are each equal to the number of face-down creatures on the battlefield.

--- a/forge-gui/res/cardsfolder/j/jagged_scar_archers.txt
+++ b/forge-gui/res/cardsfolder/j/jagged_scar_archers.txt
@@ -2,7 +2,7 @@ Name:Jagged-Scar Archers
 ManaCost:1 G G
 Types:Creature Elf Archer
 PT:*/*
-S:Mode$ Continuous | EffectZone$ All | CharacteristicDefining$ True | SetPower$ Y | SetToughness$ Y | Description$ CARDNAME's power and toughness are each equal to the number of Elves you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ Y | SetToughness$ Y | Description$ CARDNAME's power and toughness are each equal to the number of Elves you control.
 SVar:Y:Count$Valid Elf.YouCtrl
 A:AB$ DealDamage | Cost$ T | ValidTgts$ Creature.withFlying | TgtPrompt$ Select target creature with flying | NumDmg$ X | SpellDescription$ CARDNAME deals damage equal to its power to target creature with flying.
 SVar:X:Count$CardPower


### PR DESCRIPTION
As requested on https://github.com/Card-Forge/forge/pull/6861 , removing `EffectZone$ All` on` S:` line static abilities flagged with `CharacteristicDefining$ True`. 
This latter flag was removed from Soulflayer and the `EffectZone$` changed to `Battlefield` per relevant edits on https://github.com/Card-Forge/forge/pull/6872 .