### PR TITLE
Cleanup: NumAtt$ & NumDef$, part 1

### DIFF
--- a/forge-gui/res/cardsfolder/a/abyssal_nocturnus.txt
+++ b/forge-gui/res/cardsfolder/a/abyssal_nocturnus.txt
@@ -3,5 +3,5 @@ ManaCost:1 B B
 Types:Creature Horror
 PT:2/2
 T:Mode$ Discarded | ValidCard$ Card.OppOwn | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever an opponent discards a card, CARDNAME gets +2/+2 and gains fear until end of turn. (It can't be blocked except by artifact creatures and/or black creatures.)
-SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ 2 | NumDef$ 2 | KW$ Fear
+SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +2 | NumDef$ +2 | KW$ Fear
 Oracle:Whenever an opponent discards a card, Abyssal Nocturnus gets +2/+2 and gains fear until end of turn. (It can't be blocked except by artifact creatures and/or black creatures.)

--- a/forge-gui/res/cardsfolder/a/accelerated_mutation.txt
+++ b/forge-gui/res/cardsfolder/a/accelerated_mutation.txt
@@ -1,6 +1,6 @@
 Name:Accelerated Mutation
 ManaCost:3 G G
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ X | NumDef$ X | SpellDescription$ Target creature gets +X/+X until end of turn, where X is the highest mana value among permanents you control.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | NumDef$ +X | SpellDescription$ Target creature gets +X/+X until end of turn, where X is the highest mana value among permanents you control.
 SVar:X:Count$Valid Permanent.YouCtrl$GreatestCMC
 Oracle:Target creature gets +X/+X until end of turn, where X is the highest mana value among permanents you control.

--- a/forge-gui/res/cardsfolder/a/accident_prone_apprentice_amphibian_accident.txt
+++ b/forge-gui/res/cardsfolder/a/accident_prone_apprentice_amphibian_accident.txt
@@ -3,7 +3,7 @@ ManaCost:1 R
 Types:Creature Otter Wizard
 PT:1/1
 T:Mode$ SpellCast | ValidCard$ Card.nonCreature | ValidActivatingPlayer$ You | TriggerZones$ Battlefield,Exile | Execute$ TrigPump | TriggerDescription$ Whenever you cast a noncreature spell, CARDNAME perpetually gets +1/+1. This ability also triggers if CARDNAME is in exile.
-SVar:TrigPump:DB$ Pump | PumpZone$ Battlefield,Exile | NumAtt$ 1 | NumDef$ 1 | Duration$ Perpetual
+SVar:TrigPump:DB$ Pump | PumpZone$ Battlefield,Exile | NumAtt$ +1 | NumDef$ +1 | Duration$ Perpetual
 AlternateMode:Adventure
 Oracle:Whenever you cast a noncreature spell, Accident-Prone Apprentice perpetually gets +1/+1. This ability also triggers if Accident-Prone Apprentice is in exile.
 

--- a/forge-gui/res/cardsfolder/a/acrobatic_leap.txt
+++ b/forge-gui/res/cardsfolder/a/acrobatic_leap.txt
@@ -1,6 +1,6 @@
 Name:Acrobatic Leap
 ManaCost:W
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | NumAtt$ 1 | NumDef$ 3 | KW$ Flying | SubAbility$ DBUntap | SpellDescription$ Target creature gets +1/+3 and gains flying until end of turn. Untap it.
+A:SP$ Pump | ValidTgts$ Creature | NumAtt$ +1 | NumDef$ +3 | KW$ Flying | SubAbility$ DBUntap | SpellDescription$ Target creature gets +1/+3 and gains flying until end of turn. Untap it.
 SVar:DBUntap:DB$ Untap | Defined$ Targeted
 Oracle:Target creature gets +1/+3 and gains flying until end of turn. Untap it.

--- a/forge-gui/res/cardsfolder/a/adaptive_sporesinger.txt
+++ b/forge-gui/res/cardsfolder/a/adaptive_sporesinger.txt
@@ -5,7 +5,7 @@ PT:2/2
 K:Vigilance
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigCharm | TriggerDescription$ When CARDNAME enters, ABILITY
 SVar:TrigCharm:DB$ Charm | Choices$ DBPump,DBProliferate
-SVar:DBPump:DB$ Pump | NumAtt$ 2 | NumDef$ 2 | ValidTgts$ Creature | KW$ Vigilance | SpellDescription$ Target creature gets +2/+2 and gains vigilance until end of turn.
+SVar:DBPump:DB$ Pump | NumAtt$ +2 | NumDef$ +2 | ValidTgts$ Creature | KW$ Vigilance | SpellDescription$ Target creature gets +2/+2 and gains vigilance until end of turn.
 SVar:DBProliferate:DB$ Proliferate | SpellDescription$ Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)
 DeckHas:Ability$Proliferate
 Oracle:Vigilance\nWhen Adaptive Sporesinger enters, choose one —\n• Target creature gets +2/+2 and gains vigilance until end of turn.\n• Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)

--- a/forge-gui/res/cardsfolder/a/adventuring_gear.txt
+++ b/forge-gui/res/cardsfolder/a/adventuring_gear.txt
@@ -3,6 +3,6 @@ ManaCost:1
 Types:Artifact Equipment
 K:Equip:1
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Landfall — Whenever a land you control enters, equipped creature gets +2/+2 until end of turn.
-SVar:TrigPump:DB$ Pump | Defined$ Equipped | NumAtt$ 2 | NumDef$ 2
+SVar:TrigPump:DB$ Pump | Defined$ Equipped | NumAtt$ +2 | NumDef$ +2
 SVar:BuffedBy:Land
 Oracle:Landfall — Whenever a land you control enters, equipped creature gets +2/+2 until end of turn.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)

--- a/forge-gui/res/cardsfolder/a/aegis_of_the_heavens.txt
+++ b/forge-gui/res/cardsfolder/a/aegis_of_the_heavens.txt
@@ -1,5 +1,5 @@
 Name:Aegis of the Heavens
 ManaCost:1 W
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ 1 | NumDef$ 7 | SpellDescription$ Target creature gets +1/+7 until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +1 | NumDef$ +7 | SpellDescription$ Target creature gets +1/+7 until end of turn.
 Oracle:Target creature gets +1/+7 until end of turn.

--- a/forge-gui/res/cardsfolder/a/aegis_of_the_meek.txt
+++ b/forge-gui/res/cardsfolder/a/aegis_of_the_meek.txt
@@ -1,5 +1,5 @@
 Name:Aegis of the Meek
 ManaCost:3
 Types:Artifact
-A:AB$ Pump | Cost$ 1 T | NumAtt$ 1 | NumDef$ 2 | ValidTgts$ Creature.powerEQ1+toughnessEQ1 | TgtPrompt$ Select target 1/1 creature | SpellDescription$ Target 1/1 creature gets +1/+2 until end of turn.
+A:AB$ Pump | Cost$ 1 T | NumAtt$ +1 | NumDef$ +2 | ValidTgts$ Creature.powerEQ1+toughnessEQ1 | TgtPrompt$ Select target 1/1 creature | SpellDescription$ Target 1/1 creature gets +1/+2 until end of turn.
 Oracle:{1}, {T}: Target 1/1 creature gets +1/+2 until end of turn.

--- a/forge-gui/res/cardsfolder/a/aerial_maneuver.txt
+++ b/forge-gui/res/cardsfolder/a/aerial_maneuver.txt
@@ -1,5 +1,5 @@
 Name:Aerial Maneuver
 ManaCost:1 W
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ 1 | NumDef$ 1 | KW$ Flying & First Strike | SpellDescription$ Target creature gets +1/+1 and gains flying and first strike until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +1 | NumDef$ +1 | KW$ Flying & First Strike | SpellDescription$ Target creature gets +1/+1 and gains flying and first strike until end of turn.
 Oracle:Target creature gets +1/+1 and gains flying and first strike until end of turn.

--- a/forge-gui/res/cardsfolder/a/aetherflame_wall.txt
+++ b/forge-gui/res/cardsfolder/a/aetherflame_wall.txt
@@ -3,6 +3,6 @@ ManaCost:1 R
 Types:Creature Wall
 PT:0/4
 K:Defender
-A:AB$ Pump | Cost$ R | Defined$ Self | NumAtt$ 1 | SpellDescription$ CARDNAME gets +1/+0 until end of turn.
+A:AB$ Pump | Cost$ R | Defined$ Self | NumAtt$ +1 | SpellDescription$ CARDNAME gets +1/+0 until end of turn.
 K:CARDNAME can block creatures with shadow as though they didn't have shadow.
 Oracle:Defender\nAetherflame Wall can block creatures with shadow as though they didn't have shadow.\n{R}: Aetherflame Wall gets +1/+0 until end of turn.

--- a/forge-gui/res/cardsfolder/a/aethershield_artificer.txt
+++ b/forge-gui/res/cardsfolder/a/aethershield_artificer.txt
@@ -3,5 +3,5 @@ ManaCost:3 W
 Types:Creature Dwarf Artificer
 PT:3/3
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ At the beginning of combat on your turn, target artifact creature you control gets +2/+2 and gains indestructible until end of turn.
-SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.Artifact+YouCtrl | TgtPrompt$ Select target artifact creature you control | NumAtt$ 2 | NumDef$ 2 | KW$ Indestructible
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.Artifact+YouCtrl | TgtPrompt$ Select target artifact creature you control | NumAtt$ +2 | NumDef$ +2 | KW$ Indestructible
 Oracle:At the beginning of combat on your turn, target artifact creature you control gets +2/+2 and gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it.)

--- a/forge-gui/res/cardsfolder/a/agent_of_shauku.txt
+++ b/forge-gui/res/cardsfolder/a/agent_of_shauku.txt
@@ -2,6 +2,6 @@ Name:Agent of Shauku
 ManaCost:1 B
 Types:Creature Human Mercenary
 PT:1/1
-A:AB$ Pump | Cost$ 1 B Sac<1/Land> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ 2 | SpellDescription$ Target creature gets +2/+0 until end of turn.
+A:AB$ Pump | Cost$ 1 B Sac<1/Land> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +2 | SpellDescription$ Target creature gets +2/+0 until end of turn.
 AI:RemoveDeck:All
 Oracle:{1}{B}, Sacrifice a land: Target creature gets +2/+0 until end of turn.

--- a/forge-gui/res/cardsfolder/a/aggressive_urge.txt
+++ b/forge-gui/res/cardsfolder/a/aggressive_urge.txt
@@ -1,6 +1,6 @@
 Name:Aggressive Urge
 ManaCost:1 G
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ 1 | NumDef$ 1 | SpellDescription$ Target creature gets +1/+1 until end of turn. | SubAbility$ DBDraw
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +1 | NumDef$ +1 | SpellDescription$ Target creature gets +1/+1 until end of turn. | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw | SpellDescription$ Draw a card.
 Oracle:Target creature gets +1/+1 until end of turn.\nDraw a card.

--- a/forge-gui/res/cardsfolder/a/agrus_kos_wojek_veteran.txt
+++ b/forge-gui/res/cardsfolder/a/agrus_kos_wojek_veteran.txt
@@ -3,6 +3,6 @@ ManaCost:3 R W
 Types:Legendary Creature Human Soldier
 PT:3/3
 T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, attacking red creatures get +2/+0 and attacking white creatures get +0/+2 until end of turn.
-SVar:TrigPump:DB$ PumpAll | ValidCards$ Creature.attacking+Red | NumAtt$ 2 | SubAbility$ DBPump
-SVar:DBPump:DB$ PumpAll | ValidCards$ Creature.attacking+White | NumDef$ 2
+SVar:TrigPump:DB$ PumpAll | ValidCards$ Creature.attacking+Red | NumAtt$ +2 | SubAbility$ DBPump
+SVar:DBPump:DB$ PumpAll | ValidCards$ Creature.attacking+White | NumDef$ +2
 Oracle:Whenever Agrus Kos, Wojek Veteran attacks, attacking red creatures get +2/+0 and attacking white creatures get +0/+2 until end of turn.

--- a/forge-gui/res/cardsfolder/a/akki_avalanchers.txt
+++ b/forge-gui/res/cardsfolder/a/akki_avalanchers.txt
@@ -2,6 +2,6 @@ Name:Akki Avalanchers
 ManaCost:R
 Types:Creature Goblin Warrior
 PT:1/1
-A:AB$ Pump | Cost$ Sac<1/Land> | Defined$ Self | NumAtt$ 2 | ActivationLimit$ 1 | SpellDescription$ CARDNAME gets +2/+0 until end of turn. Activate only once each turn.
+A:AB$ Pump | Cost$ Sac<1/Land> | Defined$ Self | NumAtt$ +2 | ActivationLimit$ 1 | SpellDescription$ CARDNAME gets +2/+0 until end of turn. Activate only once each turn.
 AI:RemoveDeck:All
 Oracle:Sacrifice a land: Akki Avalanchers gets +2/+0 until end of turn. Activate only once each turn.

--- a/forge-gui/res/cardsfolder/a/akki_raider.txt
+++ b/forge-gui/res/cardsfolder/a/akki_raider.txt
@@ -3,5 +3,5 @@ ManaCost:1 R
 Types:Creature Goblin Warrior
 PT:2/1
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Land | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever a land is put into a graveyard from the battlefield, CARDNAME gets +1/+0 until end of turn.
-SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ 1
+SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +1
 Oracle:Whenever a land is put into a graveyard from the battlefield, Akki Raider gets +1/+0 until end of turn.

--- a/forge-gui/res/cardsfolder/a/akoum_battlesinger.txt
+++ b/forge-gui/res/cardsfolder/a/akoum_battlesinger.txt
@@ -4,6 +4,6 @@ Types:Creature Human Berserker Ally
 PT:1/1
 K:Haste
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self,Ally.Other+YouCtrl | OptionalDecider$ You | Execute$ TrigPumpAll | TriggerDescription$ Whenever CARDNAME or another Ally you control enters, you may have Ally creatures you control get +1/+0 until end of turn.
-SVar:TrigPumpAll:DB$ PumpAll | ValidCards$ Creature.Ally+YouCtrl | NumAtt$ 1
+SVar:TrigPumpAll:DB$ PumpAll | ValidCards$ Creature.Ally+YouCtrl | NumAtt$ +1
 SVar:BuffedBy:Ally
 Oracle:Haste\nWhenever Akoum Battlesinger or another Ally you control enters, you may have Ally creatures you control get +1/+0 until end of turn.

--- a/forge-gui/res/cardsfolder/a/akoum_hellhound.txt
+++ b/forge-gui/res/cardsfolder/a/akoum_hellhound.txt
@@ -3,6 +3,6 @@ ManaCost:R
 Types:Creature Elemental Dog
 PT:0/1
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Landfall — Whenever a land you control enters, CARDNAME gets +2/+2 until end of turn.
-SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ 2 | NumDef$ 2
+SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +2 | NumDef$ +2
 SVar:BuffedBy:Land
 Oracle:Landfall — Whenever a land you control enters, Akoum Hellhound gets +2/+2 until end of turn.

--- a/forge-gui/res/cardsfolder/a/akroan_hoplite.txt
+++ b/forge-gui/res/cardsfolder/a/akroan_hoplite.txt
@@ -3,6 +3,6 @@ ManaCost:R W
 Types:Creature Human Soldier
 PT:1/2
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, it gets +X/+0 until end of turn, where X is the number of attacking creatures you control.
-SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ X
+SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +X
 SVar:X:Count$Valid Creature.YouCtrl+attacking
 Oracle:Whenever Akroan Hoplite attacks, it gets +X/+0 until end of turn, where X is the number of attacking creatures you control.

--- a/forge-gui/res/cardsfolder/a/akroma_angel_of_fury.txt
+++ b/forge-gui/res/cardsfolder/a/akroma_angel_of_fury.txt
@@ -6,7 +6,7 @@ K:Flying
 K:Trample
 K:Protection from white
 K:Protection from blue
-A:AB$ Pump | Cost$ R | Defined$ Self | NumAtt$ 1 | SpellDescription$ CARDNAME gets +1/+0 until end of turn.
+A:AB$ Pump | Cost$ R | Defined$ Self | NumAtt$ +1 | SpellDescription$ CARDNAME gets +1/+0 until end of turn.
 K:Morph:3 R R R
 R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 Oracle:This spell can't be countered.\nFlying, trample, protection from white and from blue\n{R}: Akroma, Angel of Fury gets +1/+0 until end of turn.\nMorph {3}{R}{R}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)

--- a/forge-gui/res/cardsfolder/a/alaborn_veteran.txt
+++ b/forge-gui/res/cardsfolder/a/alaborn_veteran.txt
@@ -2,5 +2,5 @@ Name:Alaborn Veteran
 ManaCost:2 W
 Types:Creature Human Knight
 PT:2/2
-A:AB$ Pump | Cost$ T | NumAtt$ 2 | NumDef$ 2 | ValidTgts$ Creature | TgtPrompt$ Select target creature | PlayerTurn$ True | ActivationPhases$ Upkeep->BeginCombat | ActivationFirstCombat$ True | SpellDescription$ Target creature gets +2/+2 until end of turn. Activate only during your turn, before attackers are declared.
+A:AB$ Pump | Cost$ T | NumAtt$ +2 | NumDef$ +2 | ValidTgts$ Creature | TgtPrompt$ Select target creature | PlayerTurn$ True | ActivationPhases$ Upkeep->BeginCombat | ActivationFirstCombat$ True | SpellDescription$ Target creature gets +2/+2 until end of turn. Activate only during your turn, before attackers are declared.
 Oracle:{T}: Target creature gets +2/+2 until end of turn. Activate only during your turn, before attackers are declared.

--- a/forge-gui/res/cardsfolder/a/alandra_sky_dreamer.txt
+++ b/forge-gui/res/cardsfolder/a/alandra_sky_dreamer.txt
@@ -5,7 +5,7 @@ PT:2/4
 T:Mode$ Drawn | ValidCard$ Card.YouCtrl | Number$ 2 | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever you draw your second card each turn, create a 2/2 blue Drake creature token with flying.
 SVar:TrigToken:DB$ Token | TokenScript$ u_2_2_drake_flying
 T:Mode$ Drawn | ValidCard$ Card.YouCtrl | Number$ 5 | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever you draw your fifth card each turn, CARDNAME and Drakes you control get +X/+X until end of turn, where X is the number of cards in your hand.
-SVar:TrigPump:DB$ PumpAll | ValidCards$ Card.Self,Drake.YouCtrl | NumAtt$ X | NumDef$ X
+SVar:TrigPump:DB$ PumpAll | ValidCards$ Card.Self,Drake.YouCtrl | NumAtt$ +X | NumDef$ +X
 SVar:X:Count$InYourHand
 AI:RemoveDeck:Random
 DeckHas:Ability$Token & Type$Drake

--- a/forge-gui/res/cardsfolder/a/alarum.txt
+++ b/forge-gui/res/cardsfolder/a/alarum.txt
@@ -1,6 +1,6 @@
 Name:Alarum
 ManaCost:1 W
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature.notattacking | TgtPrompt$ Select target nonattacking creature | NumAtt$ 1 | NumDef$ 3 | SubAbility$ DBUntap | SpellDescription$ Untap target nonattacking creature. It gets +1/+3 until end of turn.
+A:SP$ Pump | ValidTgts$ Creature.notattacking | TgtPrompt$ Select target nonattacking creature | NumAtt$ +1 | NumDef$ +3 | SubAbility$ DBUntap | SpellDescription$ Untap target nonattacking creature. It gets +1/+3 until end of turn.
 SVar:DBUntap:DB$ Untap | Defined$ Targeted
 Oracle:Untap target nonattacking creature. It gets +1/+3 until end of turn.

--- a/forge-gui/res/cardsfolder/a/albiorix_goose_tyrant_wild_goose_chase.txt
+++ b/forge-gui/res/cardsfolder/a/albiorix_goose_tyrant_wild_goose_chase.txt
@@ -6,7 +6,7 @@ K:Flying
 K:Trample
 K:Ward:1
 T:Mode$ Sacrificed | ValidPlayer$ You | ValidCard$ Card.token | TriggerZones$ Battlefield,Exile | Execute$ TrigPump | TriggerDescription$ Whenever you sacrifice a token, NICKNAME perpetually gets +1/+1. This ability also triggers if NICKNAME is in exile.
-SVar:TrigPump:DB$ Pump | PumpZone$ Battlefield,Exile | NumAtt$ 1 | NumDef$ 1 | Duration$ Perpetual
+SVar:TrigPump:DB$ Pump | PumpZone$ Battlefield,Exile | NumAtt$ +1 | NumDef$ +1 | Duration$ Perpetual
 DeckHas:Ability$Discard|Token & Type$Food
 DeckHints:Ability$Token & Type$Treasure|Food|Clue
 AlternateMode:Adventure

--- a/forge-gui/res/cardsfolder/a/aleatory.txt
+++ b/forge-gui/res/cardsfolder/a/aleatory.txt
@@ -3,7 +3,7 @@ ManaCost:1 R
 Types:Instant
 Text:Cast CARDNAME only during combat after blockers are declared.
 A:SP$ FlipACoin | ValidTgts$ Creature | WinSubAbility$ AleatoryPump | LoseSubAbility$ DelTrigSlowtrip | ActivationPhases$ Declare Blockers->EndCombat | ActivationAfterBlockers$ True | SpellDescription$ Flip a coin. If you win the flip, target creature gets +1/+1 until end of turn. Draw a card at the beginning of the next turn's upkeep.
-SVar:AleatoryPump:DB$ Pump | Defined$ Targeted | NumAtt$ 1 | NumDef$ 1 | SubAbility$ DelTrigSlowtrip
+SVar:AleatoryPump:DB$ Pump | Defined$ Targeted | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DelTrigSlowtrip
 SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
 SVar:DrawSlowtrip:DB$ Draw | Defined$ You
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/a/alibans_tower.txt
+++ b/forge-gui/res/cardsfolder/a/alibans_tower.txt
@@ -1,5 +1,5 @@
 Name:Aliban's Tower
 ManaCost:1 R
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature.blocking | TgtPrompt$ Select target blocking creature | NumAtt$ 3 | NumDef$ 1 | SpellDescription$ Target blocking creature gets +3/+1 until end of turn.
+A:SP$ Pump | ValidTgts$ Creature.blocking | TgtPrompt$ Select target blocking creature | NumAtt$ +3 | NumDef$ +1 | SpellDescription$ Target blocking creature gets +3/+1 until end of turn.
 Oracle:Target blocking creature gets +3/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/a/alistair_the_brigadier.txt
+++ b/forge-gui/res/cardsfolder/a/alistair_the_brigadier.txt
@@ -5,7 +5,7 @@ PT:3/3
 T:Mode$ SpellCast | ValidCard$ Card.Historic | ValidActivatingPlayer$ You | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a historic spell, create a 1/1 white Soldier creature token. (Artifacts, legendaries, and Sagas are historic.)
 SVar:TrigToken:DB$ Token | TokenScript$ w_1_1_soldier
 T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPumpAll | TriggerDescription$ Whenever NICKNAME attacks, you may pay {8}. If you do, creatures you control get +X/+X until end of turn, where X is the number of historic permanents you control.
-SVar:TrigPumpAll:AB$ PumpAll | Cost$ 8 | ValidCards$ Creature.YouCtrl | NumAtt$ X | NumDef$ X
+SVar:TrigPumpAll:AB$ PumpAll | Cost$ 8 | ValidCards$ Creature.YouCtrl | NumAtt$ +X | NumDef$ +X
 SVar:X:Count$Valid Permanent.YouCtrl+Historic
 SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Token

--- a/forge-gui/res/cardsfolder/a/allied_assault.txt
+++ b/forge-gui/res/cardsfolder/a/allied_assault.txt
@@ -1,7 +1,7 @@
 Name:Allied Assault
 ManaCost:2 W
 Types:Instant
-A:SP$ Pump | TargetMin$ 0 | TargetMax$ 2 | NumAtt$ X | NumDef$ X | ValidTgts$ Creature | TgtPrompt$ Select up to two target creatures | SpellDescription$ Up to two target creatures each get +X/+X until end of turn, where X is the number of creatures in your party.
+A:SP$ Pump | TargetMin$ 0 | TargetMax$ 2 | NumAtt$ +X | NumDef$ +X | ValidTgts$ Creature | TgtPrompt$ Select up to two target creatures | SpellDescription$ Up to two target creatures each get +X/+X until end of turn, where X is the number of creatures in your party.
 SVar:X:Count$Party
 DeckHas:Ability$Party
 DeckHints:Type$Cleric|Rogue|Warrior|Wizard

--- a/forge-gui/res/cardsfolder/a/aloe_alchemist.txt
+++ b/forge-gui/res/cardsfolder/a/aloe_alchemist.txt
@@ -4,6 +4,6 @@ Types:Creature Plant Warlock
 PT:3/2
 K:Trample
 T:Mode$ BecomesPlotted | ValidCard$ Card.Self | TriggerZones$ Exile | Execute$ TrigPump | TriggerDescription$ When CARDNAME becomes plotted, target creature gets +3/+2 and gains trample until end of turn.
-SVar:TrigPump:DB$ Pump | ValidTgts$ Creature | NumAtt$ 3 | NumDef$ 2 | KW$ Trample
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature | NumAtt$ +3 | NumDef$ +2 | KW$ Trample
 K:Plot:1 G
 Oracle:Trample\nWhen Aloe Alchemist becomes plotted, target creature gets +3/+2 and gains trample until end of turn.\nPlot {1}{G} (You may pay {1}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)

--- a/forge-gui/res/cardsfolder/a/alpine_houndmaster.txt
+++ b/forge-gui/res/cardsfolder/a/alpine_houndmaster.txt
@@ -6,6 +6,6 @@ T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.S
 SVar:TrigSearch:DB$ ChangeZone | Origin$ Library | Destination$ Hand | DifferentNames$ True | ChangeType$ Card.namedAlpine Watchdog,Card.namedIgneous Cur | ChangeNum$ 2 | ShuffleNonMandatory$ True
 DeckHints:Name$Alpine Watchdog|Igneous Cur
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, it gets +X/+0 until end of turn, where X is the number of other attacking creatures.
-SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ X
+SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +X
 SVar:X:Count$Valid Creature.attacking+Other
 Oracle:When Alpine Houndmaster enters, you may search your library for a card named Alpine Watchdog and/or a card named Igneous Cur, reveal them, put them into your hand, then shuffle.\nWhenever Alpine Houndmaster attacks, it gets +X/+0 until end of turn, where X is the number of other attacking creatures.

--- a/forge-gui/res/cardsfolder/a/ambergris_citadel_agent.txt
+++ b/forge-gui/res/cardsfolder/a/ambergris_citadel_agent.txt
@@ -21,7 +21,7 @@ Types:Legendary Creature Dwarf Cleric
 PT:4/3
 K:Haste
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME attacks, you may discard your hand and draw two cards. If you do, other creatures you control get +X/+X until end of turn, where X is the number of cards you've discarded this turn.
-SVar:TrigPump:AB$ PumpAll | Cost$ Discard<1/Hand> Draw<2/You> | ValidCards$ Creature.Other+YouCtrl | NumAtt$ X | NumDef$ X
+SVar:TrigPump:AB$ PumpAll | Cost$ Discard<1/Hand> Draw<2/You> | ValidCards$ Creature.Other+YouCtrl | NumAtt$ +X | NumDef$ +X
 SVar:X:PlayerCountPropertyYou$CardsDiscardedThisTurn
 SVar:HasAttackEffect:TRUE
 Oracle:Haste\nWhenever Ambergris, Agent of Law attacks, you may discard your hand and draw two cards. If you do, other creatures you control get +X/+X until end of turn, where X is the number of cards you've discarded this turn.

--- a/forge-gui/res/cardsfolder/a/ambush_commander.txt
+++ b/forge-gui/res/cardsfolder/a/ambush_commander.txt
@@ -3,5 +3,5 @@ ManaCost:3 G G
 Types:Creature Elf
 PT:2/2
 S:Mode$ Continuous | Affected$ Forest.YouCtrl | SetPower$ 1 | SetToughness$ 1 | AddType$ Creature & Elf | SetColor$ Green | Description$ Forests you control are 1/1 green Elf creatures that are still lands.
-A:AB$ Pump | Cost$ 1 G Sac<1/Elf> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ 3 | NumDef$ 3 | SpellDescription$ Target creature gets +3/+3 until end of turn.
+A:AB$ Pump | Cost$ 1 G Sac<1/Elf> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +3 | NumDef$ +3 | SpellDescription$ Target creature gets +3/+3 until end of turn.
 Oracle:Forests you control are 1/1 green Elf creatures that are still lands.\n{1}{G}, Sacrifice an Elf: Target creature gets +3/+3 until end of turn.

--- a/forge-gui/res/cardsfolder/a/ambush_paratrooper.txt
+++ b/forge-gui/res/cardsfolder/a/ambush_paratrooper.txt
@@ -4,5 +4,5 @@ Types:Creature Human Soldier
 PT:1/2
 K:Flash
 K:Flying
-A:AB$ PumpAll | Cost$ 5 | ValidCards$ Creature.YouCtrl | NumAtt$ 1 | NumDef$ 1 | SpellDescription$ Creatures you control get +1/+1 until end of turn.
+A:AB$ PumpAll | Cost$ 5 | ValidCards$ Creature.YouCtrl | NumAtt$ +1 | NumDef$ +1 | SpellDescription$ Creatures you control get +1/+1 until end of turn.
 Oracle:Flash\nFlying\n{5}: Creatures you control get +1/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/a/amphibious_kavu.txt
+++ b/forge-gui/res/cardsfolder/a/amphibious_kavu.txt
@@ -4,5 +4,5 @@ Types:Creature Kavu
 PT:2/2
 T:Mode$ Blocks | ValidCard$ Card.Self | ValidBlocked$ Creature.Blue,Creature.Black | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME blocks or becomes blocked by one or more blue and/or black creatures, CARDNAME gets +3/+3 until end of turn.
 T:Mode$ AttackerBlocked | ValidCard$ Card.Self | ValidBlocker$ Creature.Blue,Creature.Black | Execute$ TrigPump | Secondary$ True | TriggerDescription$ Whenever CARDNAME blocks or becomes blocked by one or more blue and/or black creatures, CARDNAME gets +3/+3 until end of turn.
-SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ 3 | NumDef$ 3
+SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +3 | NumDef$ +3
 Oracle:Whenever Amphibious Kavu blocks or becomes blocked by one or more blue and/or black creatures, Amphibious Kavu gets +3/+3 until end of turn.

--- a/forge-gui/res/cardsfolder/a/ana_sanctuary.txt
+++ b/forge-gui/res/cardsfolder/a/ana_sanctuary.txt
@@ -2,7 +2,7 @@ Name:Ana Sanctuary
 ManaCost:2 G
 Types:Enchantment
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | IsPresent$ Permanent.YouCtrl+Blue,Permanent.YouCtrl+Black | Execute$ TrigPump | TriggerDescription$ At the beginning of your upkeep, if you control a blue or black permanent, target creature gets +1/+1 until end of turn. If you control a blue permanent and a black permanent, that creature gets +5/+5 until end of turn instead.
-SVar:TrigPump:DB$ Pump | ValidTgts$ Creature | NumAtt$ P | NumDef$ P
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature | NumAtt$ +P | NumDef$ +P
 SVar:Y:Count$Valid Permanent.Blue+YouCtrl/LimitMax.1
 SVar:Z:Count$Valid Permanent.Black+YouCtrl/LimitMax.1
 SVar:X:SVar$Y/Plus.Z

--- a/forge-gui/res/cardsfolder/a/anaba_ancestor.txt
+++ b/forge-gui/res/cardsfolder/a/anaba_ancestor.txt
@@ -2,6 +2,6 @@ Name:Anaba Ancestor
 ManaCost:1 R
 Types:Creature Minotaur Spirit
 PT:1/1
-A:AB$ Pump | Cost$ T | NumAtt$ 1 | NumDef$ 1 | ValidTgts$ Creature.Minotaur+Other | TgtPrompt$ Select another target Minotaur creature | SpellDescription$ Another target Minotaur creature gets +1/+1 until end of turn.
+A:AB$ Pump | Cost$ T | NumAtt$ +1 | NumDef$ +1 | ValidTgts$ Creature.Minotaur+Other | TgtPrompt$ Select another target Minotaur creature | SpellDescription$ Another target Minotaur creature gets +1/+1 until end of turn.
 AI:RemoveDeck:All
 Oracle:{T}: Another target Minotaur creature gets +1/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/a/andradite_leech.txt
+++ b/forge-gui/res/cardsfolder/a/andradite_leech.txt
@@ -2,6 +2,6 @@ Name:Andradite Leech
 ManaCost:2 B
 Types:Creature Leech
 PT:2/2
-A:AB$ Pump | Cost$ B | Defined$ Self | NumAtt$ 1 | NumDef$ 1 | SpellDescription$ CARDNAME gets +1/+1 until end of turn.
+A:AB$ Pump | Cost$ B | Defined$ Self | NumAtt$ +1 | NumDef$ +1 | SpellDescription$ CARDNAME gets +1/+1 until end of turn.
 S:Mode$ RaiseCost | ValidCard$ Card.Black | Activator$ You | Type$ Spell | Cost$ B | Description$ Black spells you cast cost {B} more to cast.
 Oracle:Black spells you cast cost {B} more to cast.\n{B}: Andradite Leech gets +1/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/a/angel_of_the_dawn.txt
+++ b/forge-gui/res/cardsfolder/a/angel_of_the_dawn.txt
@@ -4,6 +4,6 @@ Types:Creature Angel
 PT:3/3
 K:Flying
 T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigPumpAll | TriggerDescription$ When CARDNAME enters, creatures you control get +1/+1 and gain vigilance until end of turn.
-SVar:TrigPumpAll:DB$ PumpAll | ValidCards$ Creature.YouCtrl | NumAtt$ 1 | NumDef$ 1 | KW$ Vigilance
+SVar:TrigPumpAll:DB$ PumpAll | ValidCards$ Creature.YouCtrl | NumAtt$ +1 | NumDef$ +1 | KW$ Vigilance
 Oracle:Flying\nWhen Angel of the Dawn enters, creatures you control get +1/+1 and gain vigilance until end of turn.
 SVar:PlayMain1:TRUE

--- a/forge-gui/res/cardsfolder/a/angel_of_unity.txt
+++ b/forge-gui/res/cardsfolder/a/angel_of_unity.txt
@@ -7,7 +7,7 @@ K:Lifelink
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChoose | TriggerDescription$ Whenever CARDNAME enters or you cast a party spell, choose a party creature card in your hand. It perpetually gets +1/+1. (A party card or spell is a Cleric, Rogue, Warrior, or Wizard.)
 T:Mode$ SpellCast | ValidCard$ Card.Party | ValidActivatingPlayer$ You | Execute$ TrigChoose | TriggerZones$ Battlefield | Secondary$ True | TriggerDescription$ Whenever CARDNAME enters or you cast a party spell, choose a party creature card in your hand. It perpetually gets +1/+1. (A party card or spell is a Cleric, Rogue, Warrior, or Wizard.)
 SVar:TrigChoose:DB$ ChooseCard | ChoiceZone$ Hand | Choices$ Creature.Party+YouOwn | ChoiceTitle$ Choose a party creature card in your hand | Amount$ 1 | SubAbility$ DBPump
-SVar:DBPump:DB$ Pump | Defined$ ChosenCard | PumpZone$ Hand | NumAtt$ 1 | NumDef$ 1 | Duration$ Perpetual | SubAbility$ DBCleanup
+SVar:DBPump:DB$ Pump | Defined$ ChosenCard | PumpZone$ Hand | NumAtt$ +1 | NumDef$ +1 | Duration$ Perpetual | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearChosenCard$ True
 SVar:BuffedBy:Cleric,Rogue,Warrior,Wizard
 DeckHas:Ability$Party|LifeGain

--- a/forge-gui/res/cardsfolder/a/angelfire_crusader.txt
+++ b/forge-gui/res/cardsfolder/a/angelfire_crusader.txt
@@ -2,5 +2,5 @@ Name:Angelfire Crusader
 ManaCost:3 W
 Types:Creature Human Soldier Knight
 PT:2/3
-A:AB$ Pump | Cost$ R | Defined$ Self | NumAtt$ 1 | SpellDescription$ CARDNAME gets +1/+0 until end of turn.
+A:AB$ Pump | Cost$ R | Defined$ Self | NumAtt$ +1 | SpellDescription$ CARDNAME gets +1/+0 until end of turn.
 Oracle:{R}: Angelfire Crusader gets +1/+0 until end of turn.

--- a/forge-gui/res/cardsfolder/a/angelic_blessing.txt
+++ b/forge-gui/res/cardsfolder/a/angelic_blessing.txt
@@ -1,5 +1,5 @@
 Name:Angelic Blessing
 ManaCost:2 W
 Types:Sorcery
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ 3 | NumDef$ 3 | KW$ Flying | SpellDescription$ Target creature gets +3/+3 and gains flying until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +3 | NumDef$ +3 | KW$ Flying | SpellDescription$ Target creature gets +3/+3 and gains flying until end of turn.
 Oracle:Target creature gets +3/+3 and gains flying until end of turn. (It can't be blocked except by creatures with flying or reach.)

--- a/forge-gui/res/cardsfolder/a/angelic_captain.txt
+++ b/forge-gui/res/cardsfolder/a/angelic_captain.txt
@@ -4,7 +4,7 @@ Types:Creature Angel Ally
 PT:4/3
 K:Flying
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, it gets +1/+1 until end of turn for each other attacking Ally.
-SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ X | NumDef$ X
+SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +X | NumDef$ +X
 SVar:X:Count$Valid Ally.attacking+Other
 DeckHints:Type$Ally
 Oracle:Flying\nWhenever Angelic Captain attacks, it gets +1/+1 until end of turn for each other attacking Ally.

--- a/forge-gui/res/cardsfolder/a/angelic_page.txt
+++ b/forge-gui/res/cardsfolder/a/angelic_page.txt
@@ -3,5 +3,5 @@ ManaCost:1 W
 Types:Creature Angel Spirit
 PT:1/1
 K:Flying
-A:AB$ Pump | Cost$ T | NumAtt$ 1 | NumDef$ 1 | ValidTgts$ Creature.attacking,Creature.blocking | TgtPrompt$ Select target attacking or blocking creature | SpellDescription$ Target attacking or blocking creature gets +1/+1 until end of turn.
+A:AB$ Pump | Cost$ T | NumAtt$ +1 | NumDef$ +1 | ValidTgts$ Creature.attacking,Creature.blocking | TgtPrompt$ Select target attacking or blocking creature | SpellDescription$ Target attacking or blocking creature gets +1/+1 until end of turn.
 Oracle:Flying\n{T}: Target attacking or blocking creature gets +1/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/a/angelic_protector.txt
+++ b/forge-gui/res/cardsfolder/a/angelic_protector.txt
@@ -4,5 +4,5 @@ Types:Creature Angel
 PT:2/2
 K:Flying
 T:Mode$ BecomesTarget | ValidTarget$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME becomes the target of a spell or ability, it gets +0/+3 until end of turn.
-SVar:TrigPump:DB$ Pump | Defined$ Self | NumDef$ 3
+SVar:TrigPump:DB$ Pump | Defined$ Self | NumDef$ +3
 Oracle:Flying\nWhenever Angelic Protector becomes the target of a spell or ability, Angelic Protector gets +0/+3 until end of turn.

--- a/forge-gui/res/cardsfolder/a/anointed_deacon.txt
+++ b/forge-gui/res/cardsfolder/a/anointed_deacon.txt
@@ -3,6 +3,6 @@ ManaCost:4 B
 Types:Creature Vampire Cleric
 PT:3/3
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigPump | TriggerDescription$ At the beginning of combat on your turn, you may have target Vampire get +2/+0 until end of turn.
-SVar:TrigPump:DB$ Pump | ValidTgts$ Vampire | TgtPrompt$ Select target Vampire | NumAtt$ 2
+SVar:TrigPump:DB$ Pump | ValidTgts$ Vampire | TgtPrompt$ Select target Vampire | NumAtt$ +2
 SVar:PlayMain1:TRUE
 Oracle:At the beginning of combat on your turn, you may have target Vampire get +2/+0 until end of turn.

--- a/forge-gui/res/cardsfolder/a/anointer_of_champions.txt
+++ b/forge-gui/res/cardsfolder/a/anointer_of_champions.txt
@@ -2,5 +2,5 @@ Name:Anointer of Champions
 ManaCost:W
 Types:Creature Human Cleric
 PT:1/1
-A:AB$ Pump | Cost$ T | NumAtt$ 1 | NumDef$ 1 | ValidTgts$ Creature.attacking | TgtPrompt$ Select target attacking creature | SpellDescription$ Target attacking creature gets +1/+1 until end of turn.
+A:AB$ Pump | Cost$ T | NumAtt$ +1 | NumDef$ +1 | ValidTgts$ Creature.attacking | TgtPrompt$ Select target attacking creature | SpellDescription$ Target attacking creature gets +1/+1 until end of turn.
 Oracle:{T}: Target attacking creature gets +1/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/a/anthem_of_rakdos.txt
+++ b/forge-gui/res/cardsfolder/a/anthem_of_rakdos.txt
@@ -2,7 +2,7 @@ Name:Anthem of Rakdos
 ManaCost:2 B R R
 Types:Enchantment
 T:Mode$ Attacks | ValidCard$ Creature.YouCtrl | TriggerZones$ Battlefield | Execute$ AnthemPump | TriggerDescription$ Whenever a creature you control attacks, it gets +2/+0 until end of turn and CARDNAME deals 1 damage to you.
-SVar:AnthemPump:DB$ Pump | Defined$ TriggeredAttackerLKICopy | NumAtt$ 2 | SubAbility$ RakdosBurn
+SVar:AnthemPump:DB$ Pump | Defined$ TriggeredAttackerLKICopy | NumAtt$ +2 | SubAbility$ RakdosBurn
 SVar:RakdosBurn:DB$ DealDamage | Defined$ You | NumDmg$ 1
 R:Event$ DamageDone | ActiveZones$ Battlefield | ValidSource$ Card.YouCtrl,Emblem.YouCtrl | ValidTarget$ Permanent,Player | Hellbent$ True | ReplaceWith$ DmgTwice | Description$ Hellbent — As long as you have no cards in hand, if a source you control would deal damage to a permanent or player, it deals double that damage to that permanent or player instead.
 SVar:DmgTwice:DB$ ReplaceEffect | VarName$ DamageAmount | VarValue$ X

--- a/forge-gui/res/cardsfolder/a/aquatic_alchemist_bubble_up.txt
+++ b/forge-gui/res/cardsfolder/a/aquatic_alchemist_bubble_up.txt
@@ -3,7 +3,7 @@ ManaCost:1 U
 Types:Creature Elemental
 PT:1/3
 T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | ActivatorThisTurnCast$ EQ1 | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast your first instant or sorcery spell each turn, CARDNAME gets +2/+0 until end of turn.
-SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ 2
+SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +2
 DeckHas:Ability$Graveyard
 DeckHints:Type$Instant|Sorcery
 AlternateMode:Adventure

--- a/forge-gui/res/cardsfolder/a/arahbo_roar_of_the_world.txt
+++ b/forge-gui/res/cardsfolder/a/arahbo_roar_of_the_world.txt
@@ -4,9 +4,9 @@ Types:Legendary Creature Cat Avatar
 PT:5/5
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | IsPresent$ Card.StrictlySelf | PresentZone$ Battlefield | Execute$ TrigPump1 | TriggerDescription$ Eminence — At the beginning of combat on your turn, if CARDNAME is in the command zone or on the battlefield, another target Cat you control gets +3/+3 until end of turn.
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Command | IsPresent$ Card.StrictlySelf | PresentZone$ Command | Execute$ TrigPump1 | Secondary$ True
-SVar:TrigPump1:DB$ Pump | ValidTgts$ Creature.Cat+YouCtrl+Other | TgtPrompt$ Select another target Cat you control | NumAtt$ 3 | NumDef$ 3
+SVar:TrigPump1:DB$ Pump | ValidTgts$ Creature.Cat+YouCtrl+Other | TgtPrompt$ Select another target Cat you control | NumAtt$ +3 | NumDef$ +3
 T:Mode$ Attacks | ValidCard$ Creature.Cat+Other+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigPump2 | TriggerDescription$ Whenever another Cat you control attacks, you may pay {1}{G}{W}. If you do, it gains trample and gets +X/+X until end of turn, where X is its power.
-SVar:TrigPump2:AB$ Pump | Cost$ 1 G W | Defined$ TriggeredAttackerLKICopy | KW$ Trample | NumAtt$ X | NumDef$ X
+SVar:TrigPump2:AB$ Pump | Cost$ 1 G W | Defined$ TriggeredAttackerLKICopy | KW$ Trample | NumAtt$ +X | NumDef$ +X
 SVar:X:TriggeredAttacker$CardPower
 SVar:BuffedBy:Cat
 SVar:PlayMain1:TRUE

--- a/forge-gui/res/cardsfolder/a/arborea_pegasus.txt
+++ b/forge-gui/res/cardsfolder/a/arborea_pegasus.txt
@@ -4,6 +4,6 @@ Types:Creature Pegasus
 PT:2/3
 K:Flying
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ When CARDNAME enters, target creature gets +1/+1 and gains flying until end of turn.
-SVar:TrigPump:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ 1 | NumDef$ 1 | KW$ Flying
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +1 | NumDef$ +1 | KW$ Flying
 SVar:PlayMain1:TRUE
 Oracle:Flying\nWhen Arborea Pegasus enters, target creature gets +1/+1 and gains flying until end of turn.

--- a/forge-gui/res/cardsfolder/a/arcane_archery.txt
+++ b/forge-gui/res/cardsfolder/a/arcane_archery.txt
@@ -1,7 +1,7 @@
 Name:Arcane Archery
 ManaCost:2 G
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | NumAtt$ 3 | NumDef$ 3 | KW$ Reach & Trample | SubAbility$ DBBoon | SpellDescription$ Target creature gets +3/+3 and gains reach and trample until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | NumAtt$ +3 | NumDef$ +3 | KW$ Reach & Trample | SubAbility$ DBBoon | SpellDescription$ Target creature gets +3/+3 and gains reach and trample until end of turn.
 SVar:DBBoon:DB$ Effect | Boon$ True | Duration$ Permanent | Triggers$ SpellCast | StackDescription$ SpellDescription | SpellDescription$ ,,,,,,You get a boon with "When you cast your next creature spell, that creature enters with an additional +1/+1 counter, reach counter, and trample counter on it."
 SVar:SpellCast:Mode$ SpellCast | ValidCard$ Creature | ValidActivatingPlayer$ You | TriggerZones$ Command | Execute$ ReplEffAddCounter | TriggerDescription$ When you cast your next creature spell, that creature enters with an additional +1/+1 counter, reach counter, and trample counter on it.
 SVar:ReplEffAddCounter:DB$ Effect | ReplacementEffects$ ETBAddCounter | RememberObjects$ TriggeredCard

--- a/forge-gui/res/cardsfolder/a/arm_the_cathars.txt
+++ b/forge-gui/res/cardsfolder/a/arm_the_cathars.txt
@@ -1,8 +1,8 @@
 Name:Arm the Cathars
 ManaCost:1 W W
 Types:Sorcery
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature (+3/+3) | NumAtt$ 3 | NumDef$ 3 | KW$ Vigilance | SubAbility$ DBPump | StackDescription$ Until end of turn, {c:ThisTargetedCard} gets +3/+3, | SpellDescription$ Until end of turn, target creature gets +3/+3,
-SVar:DBPump:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select up to one other target creature (+2/+2) | TargetMin$ 0 | TargetMax$ 1 | NumAtt$ 2 | NumDef$ 2 | KW$ Vigilance | TargetUnique$ True | SubAbility$ DBPump2 | StackDescription$ SpellDescription | SpellDescription$ up to one other target creature gets +2/+2,
-SVar:DBPump2:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select up to one other target creature (+1/+1) | TargetMin$ 0 | TargetMax$ 1 | NumAtt$ 1 | NumDef$ 1 | KW$ Vigilance | TargetUnique$ True | SubAbility$ DBPump3 | StackDescription$ SpellDescription | SpellDescription$ and up to one other target creature gets +1/+1.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature (+3/+3) | NumAtt$ +3 | NumDef$ +3 | KW$ Vigilance | SubAbility$ DBPump | StackDescription$ Until end of turn, {c:ThisTargetedCard} gets +3/+3, | SpellDescription$ Until end of turn, target creature gets +3/+3,
+SVar:DBPump:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select up to one other target creature (+2/+2) | TargetMin$ 0 | TargetMax$ 1 | NumAtt$ +2 | NumDef$ +2 | KW$ Vigilance | TargetUnique$ True | SubAbility$ DBPump2 | StackDescription$ SpellDescription | SpellDescription$ up to one other target creature gets +2/+2,
+SVar:DBPump2:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select up to one other target creature (+1/+1) | TargetMin$ 0 | TargetMax$ 1 | NumAtt$ +1 | NumDef$ +1 | KW$ Vigilance | TargetUnique$ True | SubAbility$ DBPump3 | StackDescription$ SpellDescription | SpellDescription$ and up to one other target creature gets +1/+1.
 SVar:DBPump3:DB$ Pump | Defined$ Targeted | KW$ Vigilance | StackDescription$ SpellDescription | SpellDescription$ Those creatures gain vigilance until end of turn.
 Oracle:Until end of turn, target creature gets +3/+3, up to one other target creature gets +2/+2, and up to one other target creature gets +1/+1. Those creatures gain vigilance until end of turn.

--- a/forge-gui/res/cardsfolder/a/arming_gala.txt
+++ b/forge-gui/res/cardsfolder/a/arming_gala.txt
@@ -2,5 +2,5 @@ Name:Arming Gala
 ManaCost:3 G W
 Types:Enchantment
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPerpetualP1P1 | TriggerDescription$ At the beginning of your end step, creatures you control and creature cards in your hand, library, and graveyard perpetually get +1/+1.
-SVar:TrigPerpetualP1P1:DB$ PumpAll | ValidCards$ Creature.YouCtrl | PumpZone$ Battlefield,Hand,Library,Graveyard | NumAtt$ 1 | NumDef$ 1 | Duration$ Perpetual
+SVar:TrigPerpetualP1P1:DB$ PumpAll | ValidCards$ Creature.YouCtrl | PumpZone$ Battlefield,Hand,Library,Graveyard | NumAtt$ +1 | NumDef$ +1 | Duration$ Perpetual
 Oracle:At the beginning of your end step, creatures you control and creature cards in your hand, library, and graveyard perpetually get +1/+1.

--- a/forge-gui/res/cardsfolder/a/armored_armadillo.txt
+++ b/forge-gui/res/cardsfolder/a/armored_armadillo.txt
@@ -3,6 +3,6 @@ ManaCost:W
 Types:Creature Armadillo
 PT:0/4
 K:Ward:1
-A:AB$ Pump | Cost$ 3 W | NumAtt$ X | SpellDescription$ CARDNAME gets +X/+0 until end of turn, where X is its toughness.
+A:AB$ Pump | Cost$ 3 W | NumAtt$ +X | SpellDescription$ CARDNAME gets +X/+0 until end of turn, where X is its toughness.
 SVar:X:Count$CardToughness
 Oracle:Ward {1} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)\n{3}{W}: Armored Armadillo gets +X/+0 until end of turn, where X is its toughness.

--- a/forge-gui/res/cardsfolder/a/armorer_guildmage.txt
+++ b/forge-gui/res/cardsfolder/a/armorer_guildmage.txt
@@ -2,6 +2,6 @@ Name:Armorer Guildmage
 ManaCost:R
 Types:Creature Human Wizard
 PT:1/1
-A:AB$ Pump | Cost$ B T | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ 1 | SpellDescription$ Target creature gets +1/+0 until end of turn.
-A:AB$ Pump | Cost$ G T | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDef$ 1 | SpellDescription$ Target creature gets +0/+1 until end of turn.
+A:AB$ Pump | Cost$ B T | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +1 | SpellDescription$ Target creature gets +1/+0 until end of turn.
+A:AB$ Pump | Cost$ G T | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDef$ +1 | SpellDescription$ Target creature gets +0/+1 until end of turn.
 Oracle:{B}, {T}: Target creature gets +1/+0 until end of turn.\n{G}, {T}: Target creature gets +0/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/a/army_of_allah.txt
+++ b/forge-gui/res/cardsfolder/a/army_of_allah.txt
@@ -1,5 +1,5 @@
 Name:Army of Allah
 ManaCost:1 W W
 Types:Instant
-A:SP$ PumpAll | ValidCards$ Creature.attacking | NumAtt$ 2 | SpellDescription$ Attacking creatures get +2/+0 until end of turn.
+A:SP$ PumpAll | ValidCards$ Creature.attacking | NumAtt$ +2 | SpellDescription$ Attacking creatures get +2/+0 until end of turn.
 Oracle:Attacking creatures get +2/+0 until end of turn.

--- a/forge-gui/res/cardsfolder/a/arvad_weatherlight_smuggler.txt
+++ b/forge-gui/res/cardsfolder/a/arvad_weatherlight_smuggler.txt
@@ -5,7 +5,7 @@ PT:1/1
 K:Deathtouch
 K:Lifelink
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield,Graveyard | CheckSVar$ X | Execute$ TrigPump | TriggerDescription$ At the beginning of your end step, if a creature died this turn, CARDNAME perpetually gets +X/+X where X is the number of creatures that died this turn. This ability also triggers if NICKNAME is in your graveyard.
-SVar:TrigPump:DB$ Pump | Defined$ Self | PumpZone$ Battlefield,Graveyard | NumAtt$ X | NumDef$ X | Duration$ Perpetual
+SVar:TrigPump:DB$ Pump | Defined$ Self | PumpZone$ Battlefield,Graveyard | NumAtt$ +X | NumDef$ +X | Duration$ Perpetual
 SVar:X:Count$ThisTurnEntered_Graveyard_from_Battlefield_Creature
 DeckHas:Ability$Graveyard|LifeGain
 DeckHints:Ability$Sacrifice|Graveyard

--- a/forge-gui/res/cardsfolder/a/ashnods_battle_gear.txt
+++ b/forge-gui/res/cardsfolder/a/ashnods_battle_gear.txt
@@ -2,6 +2,6 @@ Name:Ashnod's Battle Gear
 ManaCost:2
 Types:Artifact
 K:You may choose not to untap CARDNAME during your untap step.
-A:AB$ Pump | Cost$ 2 T | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | NumAtt$ 2 | NumDef$ -2 | Duration$ UntilUntaps | AILogic$ ContinuousBonus | SpellDescription$ Target creature you control gets +2/-2 for as long as CARDNAME remains tapped.
+A:AB$ Pump | Cost$ 2 T | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | NumAtt$ +2 | NumDef$ -2 | Duration$ UntilUntaps | AILogic$ ContinuousBonus | SpellDescription$ Target creature you control gets +2/-2 for as long as CARDNAME remains tapped.
 SVar:AIUntapPreference:BetterTgtThanRemembered
 Oracle:You may choose not to untap Ashnod's Battle Gear during your untap step.\n{2}, {T}: Target creature you control gets +2/-2 for as long as Ashnod's Battle Gear remains tapped.

--- a/forge-gui/res/cardsfolder/a/ashroot_animist.txt
+++ b/forge-gui/res/cardsfolder/a/ashroot_animist.txt
@@ -4,6 +4,6 @@ Types:Creature Lizard Druid
 PT:4/4
 K:Trample
 T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ When this creature attacks, another target creature you control gains trample and gets +X/+X until end of turn, where X is this creature's power.
-SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.Other+YouCtrl | TgtPrompt$ Select another target creature you control | NumAtt$ X | NumDef$ X | KW$ Trample
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.Other+YouCtrl | TgtPrompt$ Select another target creature you control | NumAtt$ +X | NumDef$ +X | KW$ Trample
 SVar:X:Count$CardPower
 Oracle:Trample\nWhen this creature attacks, another target creature you control gains trample and gets +X/+X until end of turn, where X is this creature's power.

--- a/forge-gui/res/cardsfolder/a/assembly_worker.txt
+++ b/forge-gui/res/cardsfolder/a/assembly_worker.txt
@@ -2,6 +2,6 @@ Name:Assembly-Worker
 ManaCost:3
 Types:Artifact Creature Assembly-Worker
 PT:2/2
-A:AB$ Pump | Cost$ T | ValidTgts$ Creature.Assembly-Worker | TgtPrompt$ Select target Assembly-Worker creature | NumAtt$ 1 | NumDef$ 1 | SpellDescription$ Target Assembly-Worker creature gets +1/+1 until end of turn.
+A:AB$ Pump | Cost$ T | ValidTgts$ Creature.Assembly-Worker | TgtPrompt$ Select target Assembly-Worker creature | NumAtt$ +1 | NumDef$ +1 | SpellDescription$ Target Assembly-Worker creature gets +1/+1 until end of turn.
 DeckHints:Type$Assembly-Worker
 Oracle:{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/a/astral_steel.txt
+++ b/forge-gui/res/cardsfolder/a/astral_steel.txt
@@ -1,6 +1,6 @@
 Name:Astral Steel
 ManaCost:2 W
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ 1 | NumDef$ 2 | SpellDescription$ Target creature gets +1/+2 until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +1 | NumDef$ +2 | SpellDescription$ Target creature gets +1/+2 until end of turn.
 K:Storm
 Oracle:Target creature gets +1/+2 until end of turn.\nStorm (When you cast this spell, copy it for each spell cast before it this turn. You may choose new targets for the copies.)

--- a/forge-gui/res/cardsfolder/a/atog.txt
+++ b/forge-gui/res/cardsfolder/a/atog.txt
@@ -2,7 +2,7 @@ Name:Atog
 ManaCost:1 R
 Types:Creature Atog
 PT:1/2
-A:AB$ Pump | Cost$ Sac<1/Artifact> | Defined$ Self | NumAtt$ 2 | NumDef$ 2 | SpellDescription$ CARDNAME gets +2/+2 until end of turn.
+A:AB$ Pump | Cost$ Sac<1/Artifact> | Defined$ Self | NumAtt$ +2 | NumDef$ +2 | SpellDescription$ CARDNAME gets +2/+2 until end of turn.
 SVar:AIPreference:SacCost$Artifact.token,Artifact.cmcEQ0+nonLegendary+notnamedBlack Lotus,Artifact.cmcEQ1,Artifact.cmcEQ2,Artifact.cmcEQ3
 DeckHas:Ability$Sacrifice
 DeckNeeds:Type$Artifact

--- a/forge-gui/res/cardsfolder/a/atogatog.txt
+++ b/forge-gui/res/cardsfolder/a/atogatog.txt
@@ -2,6 +2,6 @@ Name:Atogatog
 ManaCost:W U B R G
 Types:Legendary Creature Atog
 PT:5/5
-A:AB$ Pump | Cost$ Sac<1/Creature.Atog/Atog creature> | Defined$ Self | NumAtt$ X | NumDef$ X | SpellDescription$ CARDNAME gets +X/+X until end of turn, where X is the sacrificed creature's power.
+A:AB$ Pump | Cost$ Sac<1/Creature.Atog/Atog creature> | Defined$ Self | NumAtt$ +X | NumDef$ +X | SpellDescription$ CARDNAME gets +X/+X until end of turn, where X is the sacrificed creature's power.
 SVar:X:Sacrificed$CardPower
 Oracle:Sacrifice an Atog creature: Atogatog gets +X/+X until end of turn, where X is the sacrificed creature's power.

--- a/forge-gui/res/cardsfolder/a/attack_in_the_box.txt
+++ b/forge-gui/res/cardsfolder/a/attack_in_the_box.txt
@@ -3,5 +3,5 @@ ManaCost:3
 Types:Artifact Creature Toy
 PT:2/4
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPump | OptionalDecider$ You | TriggerDescription$ Whenever CARDNAME attacks, you may have it get +4/+0 until end of turn. If you do, sacrifice it at the beginning of the next end step.
-SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ 4 | AtEOT$ Sacrifice
+SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +4 | AtEOT$ Sacrifice
 Oracle:Whenever Attack-in-the-box attacks, you may have it get +4/+0 until end of turn. If you do, sacrifice it at the beginning of the next end step.

--- a/forge-gui/res/cardsfolder/a/attended_socialite.txt
+++ b/forge-gui/res/cardsfolder/a/attended_socialite.txt
@@ -3,6 +3,6 @@ ManaCost:1 G
 Types:Creature Elf Druid
 PT:2/1
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.Other+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Alliance — Whenever another creature you control enters, CARDNAME gets +1/+1 until end of turn.
-SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ 1 | NumDef$ 1
+SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +1 | NumDef$ +1
 SVar:BuffedBy:Creature
 Oracle:Alliance — Whenever another creature you control enters, Attended Socialite gets +1/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/a/auratog.txt
+++ b/forge-gui/res/cardsfolder/a/auratog.txt
@@ -2,7 +2,7 @@ Name:Auratog
 ManaCost:1 W
 Types:Creature Atog
 PT:1/2
-A:AB$ Pump | Cost$ Sac<1/Enchantment> | Defined$ Self | NumAtt$ 2 | NumDef$ 2 | SpellDescription$ CARDNAME gets +2/+2 until end of turn.
+A:AB$ Pump | Cost$ Sac<1/Enchantment> | Defined$ Self | NumAtt$ +2 | NumDef$ +2 | SpellDescription$ CARDNAME gets +2/+2 until end of turn.
 DeckHints:Type$Enchantment
 DeckHas:Ability$Sacrifice
 Oracle:Sacrifice an enchantment: Auratog gets +2/+2 until end of turn.

--- a/forge-gui/res/cardsfolder/a/aurelia_exemplar_of_justice.txt
+++ b/forge-gui/res/cardsfolder/a/aurelia_exemplar_of_justice.txt
@@ -5,7 +5,7 @@ PT:2/5
 K:Flying
 K:Mentor
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ DBPump | TriggerDescription$ At the beginning of combat on your turn, choose up to one target creature you control. Until end of turn, that creature gets +2/+0, gains trample if it's red, and gains vigilance if it's white.
-SVar:DBPump:DB$ Pump | ValidTgts$ Creature.YouCtrl | NumAtt$ 2 | SubAbility$ DBPump1
+SVar:DBPump:DB$ Pump | ValidTgts$ Creature.YouCtrl | NumAtt$ +2 | SubAbility$ DBPump1
 SVar:DBPump1:DB$ Pump | Defined$ Targeted | KW$ Trample | ConditionDefined$ Targeted | ConditionPresent$ Card.Red | SubAbility$ DBPump2
 SVar:DBPump2:DB$ Pump | Defined$ Targeted | KW$ Vigilance | ConditionDefined$ Targeted | ConditionPresent$ Card.White
 DeckHas:Ability$Counters

--- a/forge-gui/res/cardsfolder/a/auriok_bladewarden.txt
+++ b/forge-gui/res/cardsfolder/a/auriok_bladewarden.txt
@@ -2,6 +2,6 @@ Name:Auriok Bladewarden
 ManaCost:1 W
 Types:Creature Human Soldier
 PT:1/1
-A:AB$ Pump | Cost$ T | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ X | NumDef$ X | SpellDescription$ Target creature gets +X/+X until end of turn, where X is CARDNAME's power.
+A:AB$ Pump | Cost$ T | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | NumDef$ +X | SpellDescription$ Target creature gets +X/+X until end of turn, where X is CARDNAME's power.
 SVar:X:Count$CardPower
 Oracle:{T}: Target creature gets +X/+X until end of turn, where X is Auriok Bladewarden's power.

--- a/forge-gui/res/cardsfolder/a/aurochs.txt
+++ b/forge-gui/res/cardsfolder/a/aurochs.txt
@@ -4,6 +4,6 @@ Types:Creature Aurochs
 PT:2/3
 K:Trample
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, it gets +1/+0 until end of turn for each other attacking Aurochs.
-SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ X
+SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +X
 SVar:X:Count$Valid Aurochs.attacking+Other
 Oracle:Trample\nWhenever Aurochs attacks, it gets +1/+0 until end of turn for each other attacking Aurochs.

--- a/forge-gui/res/cardsfolder/a/aurochs_herd.txt
+++ b/forge-gui/res/cardsfolder/a/aurochs_herd.txt
@@ -6,6 +6,6 @@ K:Trample
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChange | OptionalDecider$ You | TriggerDescription$ When CARDNAME enters, you may search your library for an Aurochs card, reveal it, put it into your hand, then shuffle.
 SVar:TrigChange:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Card.Aurochs | ShuffleNonMandatory$ True
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, it gets +1/+0 until end of turn for each other attacking Aurochs.
-SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ X
+SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +X
 SVar:X:Count$Valid Aurochs.attacking+Other
 Oracle:Trample\nWhen Aurochs Herd enters, you may search your library for an Aurochs card, reveal it, put it into your hand, then shuffle.\nWhenever Aurochs Herd attacks, it gets +1/+0 until end of turn for each other attacking Aurochs.

--- a/forge-gui/res/cardsfolder/a/auspicious_arrival.txt
+++ b/forge-gui/res/cardsfolder/a/auspicious_arrival.txt
@@ -1,7 +1,7 @@
 Name:Auspicious Arrival
 ManaCost:1 W
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | NumAtt$ 2 | NumDef$ 2 | SubAbility$ DBInvestigate | SpellDescription$ Target creature gets +2/+2 until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | NumAtt$ +2 | NumDef$ +2 | SubAbility$ DBInvestigate | SpellDescription$ Target creature gets +2/+2 until end of turn.
 SVar:DBInvestigate:DB$ Investigate | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
 DeckHas:Ability$Investigate|Token & Type$Artifact|Clue
 Oracle:Target creature gets +2/+2 until end of turn. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")

--- a/forge-gui/res/cardsfolder/a/avarax.txt
+++ b/forge-gui/res/cardsfolder/a/avarax.txt
@@ -3,7 +3,7 @@ ManaCost:3 R R
 Types:Creature Beast
 PT:3/3
 K:Haste
-A:AB$ Pump | Cost$ 1 R | Defined$ Self | NumAtt$ 1 | SpellDescription$ CARDNAME gets +1/+0 until end of turn.
+A:AB$ Pump | Cost$ 1 R | Defined$ Self | NumAtt$ +1 | SpellDescription$ CARDNAME gets +1/+0 until end of turn.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | OptionalDecider$ You | Execute$ TrigChange | TriggerDescription$ When CARDNAME enters, you may search your library for a card named Avarax, reveal it, put it into your hand, then shuffle.
 SVar:TrigChange:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Card.namedAvarax | ShuffleNonMandatory$ True
 DeckHints:Name$Avarax

--- a/forge-gui/res/cardsfolder/a/avatar_of_fury.txt
+++ b/forge-gui/res/cardsfolder/a/avatar_of_fury.txt
@@ -3,7 +3,7 @@ ManaCost:6 R R
 Types:Creature Avatar
 PT:6/6
 K:Flying
-A:AB$ Pump | Cost$ R | Defined$ Self | NumAtt$ 1 | SpellDescription$ CARDNAME gets +1/+0 until end of turn.
+A:AB$ Pump | Cost$ R | Defined$ Self | NumAtt$ +1 | SpellDescription$ CARDNAME gets +1/+0 until end of turn.
 S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 6 | EffectZone$ All | CheckSVar$ X | SVarCompare$ GE7 | Description$ If an opponent controls seven or more lands, CARDNAME costs {6} less to cast.
 SVar:X:PlayerCountOpponents$HighestValid Land.YouCtrl
 Oracle:If an opponent controls seven or more lands, this spell costs {6} less to cast.\nFlying\n{R}: Avatar of Fury gets +1/+0 until end of turn.

--- a/forge-gui/res/cardsfolder/a/aven_trooper.txt
+++ b/forge-gui/res/cardsfolder/a/aven_trooper.txt
@@ -3,6 +3,6 @@ ManaCost:3 W
 Types:Creature Bird Soldier
 PT:1/1
 K:Flying
-A:AB$ Pump | Cost$ 2 W Discard<1/Card> | Defined$ Self | NumAtt$ 1 | NumDef$ 2 | SpellDescription$ CARDNAME gets +1/+2 until end of turn.
+A:AB$ Pump | Cost$ 2 W Discard<1/Card> | Defined$ Self | NumAtt$ +1 | NumDef$ +2 | SpellDescription$ CARDNAME gets +1/+2 until end of turn.
 DeckHas:Ability$Discard
 Oracle:Flying\n{2}{W}, Discard a card: Aven Trooper gets +1/+2 until end of turn.

--- a/forge-gui/res/cardsfolder/a/aven_wind_mage.txt
+++ b/forge-gui/res/cardsfolder/a/aven_wind_mage.txt
@@ -4,6 +4,6 @@ Types:Creature Bird Wizard
 PT:2/2
 K:Flying
 T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever you cast an instant or sorcery spell, CARDNAME gets +1/+1 until end of turn.
-SVar:TrigPump:DB$ Pump | Defined$ Self | ValidCard$ Card.Self | NumAtt$ 1 | NumDef$ 1
+SVar:TrigPump:DB$ Pump | Defined$ Self | ValidCard$ Card.Self | NumAtt$ +1 | NumDef$ +1
 DeckHints:Type$Instant|Sorcery
 Oracle:Flying\nWhenever you cast an instant or sorcery spell, Aven Wind Mage gets +1/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/a/avizoa.txt
+++ b/forge-gui/res/cardsfolder/a/avizoa.txt
@@ -3,7 +3,7 @@ ManaCost:3 U
 Types:Creature Jellyfish
 PT:2/2
 K:Flying
-A:AB$ Pump | Cost$ 0 | Defined$ Self | NumAtt$ 2 | NumDef$ 2 | ActivationLimit$ 1 | SubAbility$ DBSkipPhase | SpellDescription$ CARDNAME gets +2/+2 until end of turn. You skip your next untap step. Activate only once each turn.
+A:AB$ Pump | Cost$ 0 | Defined$ Self | NumAtt$ +2 | NumDef$ +2 | ActivationLimit$ 1 | SubAbility$ DBSkipPhase | SpellDescription$ CARDNAME gets +2/+2 until end of turn. You skip your next untap step. Activate only once each turn.
 SVar:DBSkipPhase:DB$ SkipPhase | Defined$ You | Step$ Untap
 AI:RemoveDeck:All
 Oracle:Flying\n{0}: Avizoa gets +2/+2 until end of turn. You skip your next untap step. Activate only once each turn.

--- a/forge-gui/res/cardsfolder/a/azimaet_drake.txt
+++ b/forge-gui/res/cardsfolder/a/azimaet_drake.txt
@@ -3,5 +3,5 @@ ManaCost:2 U
 Types:Creature Drake
 PT:1/3
 K:Flying
-A:AB$ Pump | Cost$ U | Defined$ Self | NumAtt$ 1 | ActivationLimit$ 1 | SpellDescription$ CARDNAME gets +1/+0 until end of turn. Activate only once each turn.
+A:AB$ Pump | Cost$ U | Defined$ Self | NumAtt$ +1 | ActivationLimit$ 1 | SpellDescription$ CARDNAME gets +1/+0 until end of turn. Activate only once each turn.
 Oracle:Flying\n{U}: Azimaet Drake gets +1/+0 until end of turn. Activate only once each turn.

--- a/forge-gui/res/cardsfolder/a/azlask_the_swelling_scourge.txt
+++ b/forge-gui/res/cardsfolder/a/azlask_the_swelling_scourge.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature Eldrazi
 PT:2/2
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self,Creature.Colorless+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigExperience | TriggerDescription$ Whenever CARDNAME or another colorless creature you control dies, you get an experience counter.
 SVar:TrigExperience:DB$ PutCounter | Defined$ You | CounterType$ Experience | CounterNum$ 1
-A:AB$ PumpAll | Cost$ W U B R G | ValidCards$ Creature.YouCtrl | NumAtt$ X | NumDef$ X | SubAbility$ DBPumpAll | SpellDescription$ Creatures you control get +X/+X until end of turn, where X is the number of experience counters you have.
+A:AB$ PumpAll | Cost$ W U B R G | ValidCards$ Creature.YouCtrl | NumAtt$ +X | NumDef$ +X | SubAbility$ DBPumpAll | SpellDescription$ Creatures you control get +X/+X until end of turn, where X is the number of experience counters you have.
 SVar:DBPumpAll:DB$ PumpAll | ValidCards$ Scion.YouCtrl,Spawn.YouCtrl | KW$ Annihilator:1 & Indestructible | SpellDescription$ Scions and Spawns you control gain indestructible and annihilator 1 until end of turn.
 SVar:X:Count$YourCountersExperience
 DeckNeeds:Type$Scion|Spawn


### PR DESCRIPTION
It came to my attention a while ago that the arguments for `NumAtt$` and `NumDef$` were inconsistent on whether or not a positive number was preceded by a plus sign. 
Surveying the situation and discussing it, the easier course of action is to add the plus sign where it's missing. While I was at it I removed redundant `NumAtt$` and `NumDef$` parameters with 0 as the argument. I also took the opportunity to standartize some counting `SVar` names by appending an X, as seems to be the common pattern. Any of the more involved `SVar`s as well as bare counting expressions were tested to satisfaction on their interaction with the added plus sign: all worked as expected.