### PR TITLE
Protean War Engine fix

### DIFF
--- a/forge-gui/res/cardsfolder/p/protean_war_engine.txt
+++ b/forge-gui/res/cardsfolder/p/protean_war_engine.txt
@@ -3,10 +3,10 @@ ManaCost:R W
 Types:Artifact Vehicle
 PT:0/4
 K:ETBReplacement:Other:DBDraft
-SVar:DBDraft:DB$ Draft | TriggerZones$ Battlefield | Spellbook$ Serra Angel,Resplendent Angel,Steel-Plume Marshal, Duelcraft Trainer,Falconer Adept,Seraph of Dawn,Star-Crowned Stag,Benalish Marshal,Blade Historian,Captivating Crew,Manaform Hellkite,Serra Paragon,Moonveil Regent,Skyship Stalker,Ogre Battledriver | Zone$ Exile | RememberDrafted$ True | SpellDescription$ As CARDNAME enters, draft a card from CARDNAME's spellbook and exile it.
+SVar:DBDraft:DB$ Draft | TriggerZones$ Battlefield | Spellbook$ Serra Angel,Resplendent Angel,Steel-Plume Marshal,Duelcraft Trainer,Falconer Adept,Seraph of Dawn,Star-Crowned Stag,Benalish Marshal,Blade Historian,Captivating Crew,Manaform Hellkite,Serra Paragon,Moonveil Regent,Skyship Stalker,Ogre Battledriver | Zone$ Exile | SpellDescription$ As CARDNAME enters, draft a card from CARDNAME's spellbook and exile it.
 T:Mode$ BecomesCrewed | ValidVehicle$ Card.Self | Execute$ TrigClone | TriggerDescription$ Whenever CARDNAME becomes crewed, until end of turn, it becomes a copy of the exiled card, except it's a Vehicle artifact in addition to its other types.
-SVar:TrigClone:DB$ Clone | Cost$ 3 | Defined$ Remembered | CloneTarget$ Self | AddTypes$ Vehicle | Duration$ UntilEndOfTurn
+SVar:TrigClone:DB$ Clone | Defined$ ExiledWith | CloneTarget$ Self | AddTypes$ Vehicle & Artifact | Duration$ UntilEndOfTurn
 K:Crew:3
 SVar:HasAttackingEffect:TRUE
 DeckHas:Type$Angel|Bird|Dragon|Elk|Human|Ogre|Cleric|Knight|Pirate|Soldier|Warrior & Ability$LifeGain|Token & Keyword$Double Strike|Haste|First Strike|Flying
-Oracle:As Protean War Engine enters, draft a card from Protean War Engine's spellbook and exile it.\nWhenever Protean War Engine becomes crewed, until end of turn, it becomes a copy of the exiled card, except it's a Vehicle artifact in addition to its other types.
+Oracle:As Protean War Engine enters, draft a card from Protean War Engine's spellbook and exile it.\nWhenever Protean War Engine becomes crewed, until end of turn, it becomes a copy of the exiled card, except it's a Vehicle artifact in addition to its other types.\nCrew 3


### PR DESCRIPTION
A few fixes:
- Protean War Engine was crashing the game inconsistently on resolution due to an extraneous space in the `Spellbook$` list. Removed it, managed to exile and clone the affected card to satisfactory results.
- Took the liberty of shortening the referential chain for the `Clone` effect's `Defined$` as I believe is preferred: `Remembered` to `ExiledWith`. An extraneous `Cost$` parameter was also removed.
- The cloning effect wasn't granting the Vehicle type to the cloned card. This is now working as expected.
- "Crew 3" was missing from the `Oracle:` line.