### PR TITLE
Puppeteer Clique (and similar effects) fix

### DIFF
--- a/forge-gui/res/cardsfolder/h/harried_dronesmith.txt
+++ b/forge-gui/res/cardsfolder/h/harried_dronesmith.txt
@@ -3,6 +3,6 @@ ManaCost:3 R
 Types:Creature Human Artificer
 PT:2/3
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of combat on your turn, create a 1/1 colorless Thopter artifact creature token with flying. It gains haste until end of turn. Sacrifice it at the beginning of your next end step.
-SVar:TrigToken:DB$ Token | TokenScript$ c_1_1_a_thopter_flying | PumpKeywords$ Haste | PumpDuration$ EOT | AtEOT$ Sacrifice
+SVar:TrigToken:DB$ Token | TokenScript$ c_1_1_a_thopter_flying | PumpKeywords$ Haste | PumpDuration$ EOT | AtEOT$ YourSacrifice
 DeckHas:Ability$Token|Sacrifice & Type$Artifact|Thopter
 Oracle:At the beginning of combat on your turn, create a 1/1 colorless Thopter artifact creature token with flying. It gains haste until end of turn. Sacrifice it at the beginning of your next end step.

--- a/forge-gui/res/cardsfolder/k/kheru_lich_lord.txt
+++ b/forge-gui/res/cardsfolder/k/kheru_lich_lord.txt
@@ -4,7 +4,7 @@ Types:Creature Zombie Wizard
 PT:4/4
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigChangZone | TriggerDescription$ At the beginning of your upkeep, you may pay {2}{B}. If you do, return a creature card at random from your graveyard to the battlefield. It gains flying, trample, and haste. Exile that card at the beginning of your next end step. If it would leave the battlefield, exile it instead of putting it anywhere else.
 SVar:TrigChangZone:AB$ ChangeZone | Cost$ 2 B | ChangeType$ Creature.YouCtrl | Origin$ Graveyard | Destination$ Battlefield | Hidden$ True | Mandatory$ True | AtRandom$ True | RememberChanged$ True | SubAbility$ DBUnearthed
-SVar:DBUnearthed:DB$ Animate | Defined$ Remembered | Keywords$ Flying & Trample & Haste | LeaveBattlefield$ Exile | sVars$ KheruMustAttack | Duration$ Permanent | SubAbility$ DBCleanup | AtEOT$ Exile | StackDescription$ It gains flying, trample, and haste. Exile that card at the beginning of your next end step. If it would leave the battlefield, exile it instead of putting it anywhere else.
+SVar:DBUnearthed:DB$ Animate | Defined$ Remembered | Keywords$ Flying & Trample & Haste | LeaveBattlefield$ Exile | sVars$ KheruMustAttack | Duration$ Permanent | SubAbility$ DBCleanup | AtEOT$ YourExile | StackDescription$ It gains flying, trample, and haste. Exile that card at the beginning of your next end step. If it would leave the battlefield, exile it instead of putting it anywhere else.
 SVar:KheruMustAttack:SVar:MustAttack:True
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/p/puppeteer_clique.txt
+++ b/forge-gui/res/cardsfolder/p/puppeteer_clique.txt
@@ -6,7 +6,7 @@ K:Flying
 K:Persist
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChangeZone | TriggerDescription$ When CARDNAME enters, put target creature card from an opponent's graveyard onto the battlefield under your control. It gains haste. At the beginning of your next end step, exile it.
 SVar:TrigChangeZone:DB$ ChangeZone | ValidTgts$ Creature.OppOwn | TgtPrompt$ Select target creature from an opponent's graveyard | RememberChanged$ True | Origin$ Graveyard | Destination$ Battlefield | GainControl$ True | SubAbility$ DBPump
-SVar:DBPump:DB$ Animate | Keywords$ Haste | Defined$ Remembered | Duration$ Permanent | AtEOT$ Exile | SubAbility$ DBCleanup
+SVar:DBPump:DB$ Animate | Keywords$ Haste | Defined$ Remembered | Duration$ Permanent | AtEOT$ YourExile | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:PlayMain1:ALWAYS
 Oracle:Flying\nWhen Puppeteer Clique enters, put target creature card from an opponent's graveyard onto the battlefield under your control. It gains haste. At the beginning of your next end step, exile it.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)


### PR DESCRIPTION
Working on [Come Back Wrong](https://scryfall.com/card/dsk/86/come-back-wrong), I noticed the sacrifice trigger was written as "sacrifice it at the beginning of **your** next end step" which would allow the returned creature to survive for two turns if the sorcery was flashed in during an opponent's turn via [Vedalken Orrery](https://scryfall.com/card/2x2/317/vedalken-orrery). 
This had me look it up to find a few effects needed to have `Your` prefixed to the sacrifice/exile trigger's `AtEOT$` argument. Took a while to get around to translating these observations into edits: this is a functional change for Puppeteer Clique and Kheru Lich Lord, but admittedly perfunctory for Harried Dronesmith. In any case these were tested to satisfaction, working as expected. 