### PR TITLE
[Adventure] further cleanup of the restricted cards

### DIFF
--- a/forge-gui/res/adventure/common/config.json
+++ b/forge-gui/res/adventure/common/config.json
@@ -84,7 +84,8 @@
     "PPC1",
     "UND",
     "PUST",
-    "DA1"
+    "DA1",
+    "UST"
   ],
   "difficulties": [
     {

--- a/forge-gui/res/adventure/common/config.json
+++ b/forge-gui/res/adventure/common/config.json
@@ -59,7 +59,15 @@
     "The Heron Moon",
     "Gobland",
     "Fetching Garden",
-    "Mox Poison"
+    "Mox Poison",
+    "Wisedrafter's Will",
+    "New Master of Arms",
+    "Halving Season",
+    "Questing Cosplayer",
+    "Teferi, Druid of Argoth",
+    "Anax and Cymede & Kynaios and Tiro",
+    "Call from the Grave"
+    
   ],
   "restrictedEditions": [
     "HTR",

--- a/forge-gui/res/adventure/common/config.json
+++ b/forge-gui/res/adventure/common/config.json
@@ -49,7 +49,17 @@
     "Mishra's Workshop",
     "Yawgmoth's Bargain",
     "Gaea's Cradle",
-    "Commander's Sphere"
+    "Commander's Sphere",
+    "Drake Stone",
+    "Wrenn and One",
+    "Under-Construction Skyscraper",
+    "Temur Elevator",
+    "Slumbering Waterways",
+    "Omenpath to Naya",
+    "The Heron Moon",
+    "Gobland",
+    "Fetching Garden",
+    "Mox Poison"
   ],
   "restrictedEditions": [
     "HTR",
@@ -58,7 +68,6 @@
     "HTR19",
     "HTR20",
     "PCEL",
-    "DS0",
     "HHO",
     "CMB1",
     "UST",
@@ -67,13 +76,6 @@
     "PPC1",
     "UND",
     "PUST",
-    "UEPHI23",
-    "UEMIN23",
-    "UELAS23",
-    "UEIND23",
-    "UEBAR23",
-    "MB2",
-    "UNF",
     "DA1"
   ],
   "difficulties": [

--- a/forge-gui/res/adventure/common/config.json
+++ b/forge-gui/res/adventure/common/config.json
@@ -85,7 +85,8 @@
     "UND",
     "PUST",
     "DA1",
-    "UST"
+    "UST",
+    "UNF"
   ],
   "difficulties": [
     {

--- a/forge-gui/res/adventure/common/decks/standard/eldrazilarge.dck
+++ b/forge-gui/res/adventure/common/decks/standard/eldrazilarge.dck
@@ -15,17 +15,16 @@ Name=eldrazilarge
 3 Eye of Ugin|J20|1
 4 Fellwar Stone|C15|1
 2 Flayer of Loyalties|CMM|1
-1 It That Betrays|CMM|1
+2 It That Betrays|CMM|1
 1 Kozilek, Butcher of Truth|UMA|1
 4 Matter Reshaper|OGW|1
 1 Not of This World|CMM|1
 4 Reality Smasher|SLD|1
 1 Rise of the Eldrazi|CMM|1
-2 Sol Ring|CM2|1
 4 Thought-Knot Seer|PLIST|1
 4 Thran Dynamo|MB1|1
 1 Ulamog, the Ceaseless Hunger|CMM|1
-1 Ulamog, the Infinite Gyre|2X2|2
+2 Ulamog, the Infinite Gyre|2X2|2
 2 Void Winnower|BFZ|1
 23 Wastes|SLD|1
 [Sideboard]

--- a/forge-gui/res/adventure/common/world/enemies.json
+++ b/forge-gui/res/adventure/common/world/enemies.json
@@ -12193,9 +12193,9 @@
 		},
 		{
 			"type": "card",
-			"probability": 0.5,
+			"probability": 0.3,
 			"count": 1,
-			"cardName": "Elder Gargaroth"
+			"cardName": "Gaea's Cradle"
 		},
 		{
 			"type": "card",


### PR DESCRIPTION
By adding MB2 to the restricted list all the non-convention cards become banned as well. This way fixes that. 

The restricted list also contained non existent sets which I have removed. 