### PR TITLE
Additional Discard Cost to RaiseCost

### DIFF
--- a/forge-gui/res/cardsfolder/b/big_score.txt
+++ b/forge-gui/res/cardsfolder/b/big_score.txt
@@ -1,7 +1,8 @@
 Name:Big Score
 ManaCost:3 R
 Types:Instant
-A:SP$ Draw | Cost$ 3 R Discard<1/Card/card> | CostDesc$ As an additional cost to cast this spell, discard a card. | NumCards$ 2 | Defined$ You | SubAbility$ DBToken | StackDescription$ SpellDescription | SpellDescription$ Draw two cards and create two Treasure tokens. (They're artifacts with "{T}, Sacrifice this artifact: Add one mana of any color.")
+S:Mode$ RaiseCost | ValidCard$ Card.Self | Activator$ You | Type$ Spell | Cost$ Discard<1/Card> | EffectZone$ All | Description$ As an additional cost to cast this spell, discard a card.
+A:SP$ Draw | NumCards$ 2 | Defined$ You | SubAbility$ DBToken | StackDescription$ SpellDescription | SpellDescription$ Draw two cards and create two Treasure tokens. (They're artifacts with "{T}, Sacrifice this artifact: Add one mana of any color.")
 SVar:DBToken:DB$ Token | TokenOwner$ You | TokenAmount$ 2 | TokenScript$ c_a_treasure_sac
 DeckHas:Ability$Discard|Sacrifice|Token & Type$Treasure|Artifact
 Oracle:As an additional cost to cast this spell, discard a card.\nDraw two cards and create two Treasure tokens. (They're artifacts with "{T}, Sacrifice this artifact: Add one mana of any color.")

--- a/forge-gui/res/cardsfolder/c/cathartic_reunion.txt
+++ b/forge-gui/res/cardsfolder/c/cathartic_reunion.txt
@@ -1,7 +1,8 @@
 Name:Cathartic Reunion
 ManaCost:1 R
 Types:Sorcery
-A:SP$ Draw | Cost$ 1 R Discard<2/Card/cards> | CostDesc$ As an additional cost to cast this spell, discard two cards. | NumCards$ 3 | Defined$ You | SpellDescription$ Draw three cards.
+S:Mode$ RaiseCost | ValidCard$ Card.Self | Activator$ You | Type$ Spell | Cost$ Discard<2/Card/cards> | EffectZone$ All | Description$ As an additional cost to cast this spell, discard two cards.
+A:SP$ Draw | NumCards$ 3 | Defined$ You | SpellDescription$ Draw three cards.
 DeckHas:Ability$Discard
 DeckHints:Keyword$Madness & Ability$Delirium
 Oracle:As an additional cost to cast this spell, discard two cards.\nDraw three cards.

--- a/forge-gui/res/cardsfolder/g/grab_the_prize.txt
+++ b/forge-gui/res/cardsfolder/g/grab_the_prize.txt
@@ -1,7 +1,8 @@
 Name:Grab the Prize
 ManaCost:1 R
 Types:Sorcery
-A:SP$ Draw | Cost$ 1 R Discard<1/Card> | CostDesc$ As an additional cost to cast this spell, discard a card. | NumCards$ 2 | SubAbility$ DBDealDamage | SpellDescription$ Draw two cards. If the discarded card wasn't a land card, CARDNAME deals 2 damage to each opponent.
+S:Mode$ RaiseCost | ValidCard$ Card.Self | Activator$ You | Type$ Spell | Cost$ Discard<1/Card> | EffectZone$ All | Description$ As an additional cost to cast this spell, discard a card.
+A:SP$ Draw | NumCards$ 2 | SubAbility$ DBDealDamage | SpellDescription$ Draw two cards. If the discarded card wasn't a land card, CARDNAME deals 2 damage to each opponent.
 SVar:DBDealDamage:DB$ DamageAll | ValidPlayers$ Player.Opponent | NumDmg$ X
 SVar:X:Discarded$Valid Card.nonLand/Times.2
 DeckHas:Ability$Discard

--- a/forge-gui/res/cardsfolder/h/honor_the_god_pharaoh.txt
+++ b/forge-gui/res/cardsfolder/h/honor_the_god_pharaoh.txt
@@ -1,7 +1,8 @@
 Name:Honor the God-Pharaoh
 ManaCost:2 R
 Types:Sorcery
-A:SP$ Draw | Cost$ 2 R Discard<1/Card> | CostDesc$ As an additional cost to cast this spell, discard a card. | NumCards$ 2 | Defined$ You | SubAbility$ DBAmass | SpellDescription$ Draw two cards. Amass Zombies 1. (Put a +1/+1 counter on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)
+S:Mode$ RaiseCost | ValidCard$ Card.Self | Activator$ You | Type$ Spell | Cost$ Discard<1/Card> | EffectZone$ All | Description$ As an additional cost to cast this spell, discard a card.
+A:SP$ Draw | NumCards$ 2 | Defined$ You | SubAbility$ DBAmass | SpellDescription$ Draw two cards. Amass Zombies 1. (Put a +1/+1 counter on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)
 SVar:DBAmass:DB$ Amass | Type$ Zombie | Num$ 1
 DeckHas:Ability$Discard|Amass|Counters|Token
 DeckHints:Keyword$Madness & Ability$Delirium|Amass & Type$Zombie

--- a/forge-gui/res/cardsfolder/m/magmatic_insight.txt
+++ b/forge-gui/res/cardsfolder/m/magmatic_insight.txt
@@ -1,6 +1,7 @@
 Name:Magmatic Insight
 ManaCost:R
 Types:Sorcery
-A:SP$ Draw | Cost$ R Discard<1/Land/land card> | CostDesc$ As an additional cost to cast this spell, discard a land card. | NumCards$ 2 | Defined$ You | SpellDescription$ Draw two cards.
+S:Mode$ RaiseCost | ValidCard$ Card.Self | Activator$ You | Type$ Spell | Cost$ Discard<1/Land/land card> | EffectZone$ All | Description$ As an additional cost to cast this spell, discard a land card.
+A:SP$ Draw | NumCards$ 2 | Defined$ You | SpellDescription$ Draw two cards.
 AI:RemoveDeck:All
 Oracle:As an additional cost to cast this spell, discard a land card.\nDraw two cards.

--- a/forge-gui/res/cardsfolder/p/pirates_pillage.txt
+++ b/forge-gui/res/cardsfolder/p/pirates_pillage.txt
@@ -1,7 +1,8 @@
 Name:Pirate's Pillage
 ManaCost:3 R
 Types:Sorcery
-A:SP$ Draw | Cost$ 3 R Discard<1/Card/card> | CostDesc$ As an additional cost to cast this spell, discard a card. | NumCards$ 2 | Defined$ You | SubAbility$ DBToken | SpellDescription$ Draw two cards and create two Treasure tokens. (They're artifacts with "{T}, Sacrifice this artifact: Add one mana of any color.")
+S:Mode$ RaiseCost | ValidCard$ Card.Self | Activator$ You | Type$ Spell | Cost$ Discard<1/Card> | EffectZone$ All | Description$ As an additional cost to cast this spell, discard a card.
+A:SP$ Draw | NumCards$ 2 | Defined$ You | SubAbility$ DBToken | SpellDescription$ Draw two cards and create two Treasure tokens. (They're artifacts with "{T}, Sacrifice this artifact: Add one mana of any color.")
 SVar:DBToken:DB$ Token | TokenAmount$ 2 | TokenScript$ c_a_treasure_sac | TokenOwner$ You
 DeckHas:Ability$Discard
 DeckHints:Keyword$Madness & Ability$Delirium

--- a/forge-gui/res/cardsfolder/s/sazacaps_brew.txt
+++ b/forge-gui/res/cardsfolder/s/sazacaps_brew.txt
@@ -3,7 +3,8 @@ ManaCost:1 R
 Types:Instant
 K:Gift
 SVar:GiftAbility:DB$ Token | TokenAmount$ 1 | TokenScript$ u_1_1_fish | TokenTapped$ True | TokenOwner$ Promised | LockTokenScript$ True | GiftDescription$ a tapped Fish
-A:SP$ Draw | Cost$ 1 R Discard<1/Card> | CostDesc$ As an additional cost to cast this spell, discard a card. | NumCards$ 2 | ValidTgts$ Player | TgtPrompt$ Select target player | SubAbility$ DBPump | SpellDescription$ Target player draws two cards. If the gift was promised, target creature you control gets +2/+0 until end of turn.
+S:Mode$ RaiseCost | ValidCard$ Card.Self | Activator$ You | Type$ Spell | Cost$ Discard<1/Card> | EffectZone$ All | Description$ As an additional cost to cast this spell, discard a card.
+A:SP$ Draw | NumCards$ 2 | ValidTgts$ Player | TgtPrompt$ Select target player | SubAbility$ DBPump | SpellDescription$ Target player draws two cards. If the gift was promised, target creature you control gets +2/+0 until end of turn.
 SVar:DBPump:DB$ Pump | ValidTgts$ Creature.YouCtrl | TargetMin$ X | TargetMax$ X | TgtPrompt$ Select target creature you control | NumAtt$ +2
 SVar:X:Count$PromisedGift.1.0
 DeckHas:Ability$Discard

--- a/forge-gui/res/cardsfolder/s/seize_the_spoils.txt
+++ b/forge-gui/res/cardsfolder/s/seize_the_spoils.txt
@@ -1,7 +1,8 @@
 Name:Seize the Spoils
 ManaCost:2 R
 Types:Sorcery
-A:SP$ Draw | Cost$ 2 R Discard<1/Card/card> | CostDesc$ As an additional cost to cast this spell, discard a card. | NumCards$ 2 | Defined$ You | SubAbility$ DBToken | SpellDescription$ Draw two cards and create a Treasure token. | StackDescription$ SpellDescription
+S:Mode$ RaiseCost | ValidCard$ Card.Self | Activator$ You | Type$ Spell | Cost$ Discard<1/Card> | EffectZone$ All | Description$ As an additional cost to cast this spell, discard a card.
+A:SP$ Draw | NumCards$ 2 | Defined$ You | SubAbility$ DBToken | SpellDescription$ Draw two cards and create a Treasure token. | StackDescription$ SpellDescription
 SVar:DBToken:DB$ Token | TokenAmount$ 1 | TokenScript$ c_a_treasure_sac | TokenOwner$ You
 DeckHas:Ability$Discard|Token
 DeckHints:Keyword$Madness & Ability$Delirium

--- a/forge-gui/res/cardsfolder/s/surge_of_strength.txt
+++ b/forge-gui/res/cardsfolder/s/surge_of_strength.txt
@@ -1,7 +1,8 @@
 Name:Surge of Strength
 ManaCost:R G
 Types:Instant
-A:SP$ Pump | Cost$ R G Discard<1/Card.Green;Card.Red> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | KW$ Trample | CostDesc$ As an additional cost to cast this spell, discard a red or green card. | SpellDescription$ Target creature gains trample and gets +X/+0 until end of turn, where X is that creature's mana value.
+S:Mode$ RaiseCost | ValidCard$ Card.Self | Activator$ You | Type$ Spell | Cost$ Discard<1/Card.Green;Card.Red> | EffectZone$ All | Description$ As an additional cost to cast this spell, discard a red or green card.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | KW$ Trample | SpellDescription$ Target creature gains trample and gets +X/+0 until end of turn, where X is that creature's mana value.
 SVar:X:Targeted$CardManaCost
 AI:RemoveDeck:All
 Oracle:As an additional cost to cast this spell, discard a red or green card.\nTarget creature gains trample and gets +X/+0 until end of turn, where X is that creature's mana value.

--- a/forge-gui/res/cardsfolder/t/tormenting_voice.txt
+++ b/forge-gui/res/cardsfolder/t/tormenting_voice.txt
@@ -1,7 +1,8 @@
 Name:Tormenting Voice
 ManaCost:1 R
 Types:Sorcery
-A:SP$ Draw | Cost$ 1 R Discard<1/Card> | CostDesc$ As an additional cost to cast this spell, discard a card. | NumCards$ 2 | Defined$ You | SpellDescription$ Draw two cards.
+S:Mode$ RaiseCost | ValidCard$ Card.Self | Activator$ You | Type$ Spell | Cost$ Discard<1/Card> | EffectZone$ All | Description$ As an additional cost to cast this spell, discard a card.
+A:SP$ Draw | NumCards$ 2 | Defined$ You | SpellDescription$ Draw two cards.
 DeckHas:Ability$Discard
 DeckHints:Keyword$Madness & Ability$Delirium
 Oracle:As an additional cost to cast this spell, discard a card.\nDraw two cards.

--- a/forge-gui/res/cardsfolder/u/unexpected_windfall.txt
+++ b/forge-gui/res/cardsfolder/u/unexpected_windfall.txt
@@ -1,7 +1,8 @@
 Name:Unexpected Windfall
 ManaCost:2 R R
 Types:Instant
-A:SP$ Draw | Cost$ 2 R R Discard<1/Card/card> | CostDesc$ As an additional cost to cast this spell, discard a card. | NumCards$ 2 | Defined$ You | SubAbility$ DBToken | SpellDescription$ Draw two cards and create two Treasure tokens. | StackDescription$ SpellDescription
+S:Mode$ RaiseCost | ValidCard$ Card.Self | Activator$ You | Type$ Spell | Cost$ Discard<1/Card> | EffectZone$ All | Description$ As an additional cost to cast this spell, discard a card.
+A:SP$ Draw | NumCards$ 2 | Defined$ You | SubAbility$ DBToken | SpellDescription$ Draw two cards and create two Treasure tokens. | StackDescription$ SpellDescription
 SVar:DBToken:DB$ Token | TokenAmount$ 2 | TokenScript$ c_a_treasure_sac | TokenOwner$ You
 DeckHints:Keyword$Madness & Ability$Delirium
 DeckHas:Ability$Token|Discard

--- a/forge-gui/res/cardsfolder/w/wild_guess.txt
+++ b/forge-gui/res/cardsfolder/w/wild_guess.txt
@@ -1,6 +1,7 @@
 Name:Wild Guess
 ManaCost:R R
 Types:Sorcery
-A:SP$ Draw | Cost$ R R Discard<1/Card/card> | CostDesc$ As an additional cost to cast this spell, discard a card. | NumCards$ 2 | Defined$ You | SpellDescription$ Draw two cards.
+S:Mode$ RaiseCost | ValidCard$ Card.Self | Activator$ You | Type$ Spell | Cost$ Discard<1/Card> | EffectZone$ All | Description$ As an additional cost to cast this spell, discard a card.
+A:SP$ Draw | NumCards$ 2 | Defined$ You | SpellDescription$ Draw two cards.
 AI:RemoveDeck:All
 Oracle:As an additional cost to cast this spell, discard a card.\nDraw two cards.


### PR DESCRIPTION
part of #2472

- [ ] Check AI if it still understands that these have a discard cost. Probably need an update
- [ ] Need to update the ones that does `As an additional cost to cast this spell, discard X cards.`
- [ ] Maybe remove `AlternateAdditionalCost` if possible