### PR TITLE
Fixing mistaken references to defending player in triggered abilities

### DIFF
--- a/forge-gui/res/cardsfolder/b/baneblade_scoundrel_baneclaw_marauder.txt
+++ b/forge-gui/res/cardsfolder/b/baneblade_scoundrel_baneclaw_marauder.txt
@@ -3,7 +3,7 @@ ManaCost:3 B
 Types:Creature Human Rogue Werewolf
 PT:4/3
 T:Mode$ AttackerBlocked | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME becomes blocked, each creature blocking it gets -1/-1 until end of turn.
-SVar:TrigPump:DB$ PumpAll | ValidCards$ Creature.blockingSource+DefenderCtrl | NumAtt$ -1 | NumDef$ -1
+SVar:TrigPump:DB$ PumpAll | ValidCards$ Creature.blockingSource | NumAtt$ -1 | NumDef$ -1
 K:Daybound
 AlternateMode:DoubleFaced
 Oracle:Whenever Baneblade Scoundrel becomes blocked, each creature blocking it gets -1/-1 until end of turn.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)
@@ -16,8 +16,8 @@ Colors:black
 Types:Creature Werewolf
 PT:5/4
 T:Mode$ AttackerBlocked | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME becomes blocked, each creature blocking it gets -1/-1 until end of turn.
-SVar:TrigPump:DB$ PumpAll | ValidCards$ Creature.blockingSource+DefenderCtrl | NumAtt$ -1 | NumDef$ -1
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.blockingSource+DefenderCtrl | Execute$ TrigLoseLife | TriggerZones$ Battlefield | TriggerDescription$ Whenever a creature blocking CARDNAME dies, that creature's controller loses 1 life.
+SVar:TrigPump:DB$ PumpAll | ValidCards$ Creature.blockingSource | NumAtt$ -1 | NumDef$ -1
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.blockingSource | Execute$ TrigLoseLife | TriggerZones$ Battlefield | TriggerDescription$ Whenever a creature blocking CARDNAME dies, that creature's controller loses 1 life.
 SVar:TrigLoseLife:DB$ LoseLife | Defined$ TriggeredCardController | LifeAmount$ 1
 K:Nightbound
 Oracle:Whenever Baneclaw Marauder becomes blocked, each creature blocking it gets -1/-1 until end of turn.\nWhenever a creature blocking Baneclaw Marauder dies, that creature's controller loses 1 life.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)

--- a/forge-gui/res/cardsfolder/b/blizzard_specter.txt
+++ b/forge-gui/res/cardsfolder/b/blizzard_specter.txt
@@ -5,6 +5,6 @@ PT:2/3
 K:Flying
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigCharm | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, ABILITY
 SVar:TrigCharm:DB$ Charm | Choices$ DBBounce,DBDiscard
-SVar:DBBounce:DB$ ChangeZone | Origin$ Battlefield | Destination$ Hand | Hidden$ True | ChangeType$ Permanent.DefenderCtrl | ChangeNum$ 1 | Chooser$ TriggeredTarget | Mandatory$ True | SpellDescription$ That player returns a permanent they control to its owner's hand.
+SVar:DBBounce:DB$ ChangeZone | Origin$ Battlefield | Destination$ Hand | Hidden$ True | ChangeType$ Permanent.ControlledBy TriggeredTarget | ChangeNum$ 1 | Chooser$ TriggeredTarget | Mandatory$ True | SpellDescription$ That player returns a permanent they control to its owner's hand.
 SVar:DBDiscard:DB$ Discard | Defined$ TriggeredTarget | NumCards$ 1 | Mode$ TgtChoose | SpellDescription$ That player discards a card.
 Oracle:Flying\nWhenever Blizzard Specter deals combat damage to a player, choose one —\n• That player returns a permanent they control to its owner's hand.\n• That player discards a card.

--- a/forge-gui/res/cardsfolder/f/froghemoth.txt
+++ b/forge-gui/res/cardsfolder/f/froghemoth.txt
@@ -5,7 +5,7 @@ PT:4/4
 K:Trample
 K:Haste
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigExile | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, exile up to that many target cards from their graveyard. Put a +1/+1 counter on CARDNAME for each creature card exiled this way. You gain 1 life for each noncreature card exiled this way.
-SVar:TrigExile:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | ChangeType$ Card.DefenderCtrl | ChangeNum$ X | Hidden$ True | RememberChanged$ True | SubAbility$ DBPutCounter
+SVar:TrigExile:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | ChangeType$ Card.OwnedBy TriggeredTarget | ChangeNum$ X | Hidden$ True | RememberChanged$ True | SubAbility$ DBPutCounter
 SVar:DBPutCounter:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ Y | SubAbility$ DBGainLife
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ Z | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/g/grenzo_havoc_raiser.txt
+++ b/forge-gui/res/cardsfolder/g/grenzo_havoc_raiser.txt
@@ -5,7 +5,7 @@ PT:2/2
 T:Mode$ DamageDone | ValidSource$ Creature.YouCtrl | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigCharm | TriggerZones$ Battlefield | TriggerDescription$ Whenever a creature you control deals combat damage to a player, ABILITY
 SVar:TrigCharm:DB$ Charm | Choices$ DBGoad,DBExile
 SVar:DBGoad:DB$ Goad | ValidTgts$ Creature | TargetsWithDefinedController$ TriggeredTarget | TgtPrompt$ Select target creature damaged player controls | SpellDescription$ Goad target creature that player controls.
-SVar:DBExile:DB$ Dig | Defined$ TriggeredDefendingPlayer | DigNum$ 1 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBEffect | SpellDescription$ Exile the top card of that player's library. Until end of turn, you may cast that card and you may spend mana as though it were mana of any color to cast it.
+SVar:DBExile:DB$ Dig | Defined$ TriggeredTarget | DigNum$ 1 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBEffect | SpellDescription$ Exile the top card of that player's library. Until end of turn, you may cast that card and you may spend mana as though it were mana of any color to cast it.
 SVar:DBEffect:DB$ Effect | StaticAbilities$ STPlay | ExileOnMoved$ Exile | RememberObjects$ Remembered | SubAbility$ DBCleanup
 SVar:STPlay:Mode$ Continuous | MayPlay$ True | MayPlayIgnoreColor$ True | Affected$ Card.IsRemembered+nonLand | AffectedZone$ Exile | Description$ Until end of turn, you may cast that card and you may spend mana as though it were mana of any color to cast it.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/i/ink_eyes_servant_of_oni.txt
+++ b/forge-gui/res/cardsfolder/i/ink_eyes_servant_of_oni.txt
@@ -4,6 +4,6 @@ Types:Legendary Creature Rat Ninja
 PT:5/4
 K:Ninjutsu:3 B B
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigAnimate | OptionalDecider$ You | CombatDamage$ True | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, you may put target creature card from that player's graveyard onto the battlefield under your control.
-SVar:TrigAnimate:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | GainControl$ True | TgtPrompt$ Choose target creature card in an opponent's graveyard | ValidTgts$ Creature.DefenderCtrl | SpellDescription$ Put target creature card from an opponent's graveyard onto the battlefield under your control.
+SVar:TrigAnimate:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | GainControl$ True | TgtPrompt$ Choose target creature card in that player's graveyard | ValidTgts$ Creature | TargetsWithDefinedController$ TriggeredTarget | SpellDescription$ Put target creature card from that player's graveyard onto the battlefield under your control.
 A:AB$ Regenerate | Cost$ 1 B | SpellDescription$ Regenerate CARDNAME.
 Oracle:Ninjutsu {3}{B}{B} ({3}{B}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Ink-Eyes, Servant of Oni deals combat damage to a player, you may put target creature card from that player's graveyard onto the battlefield under your control.\n{1}{B}: Regenerate Ink-Eyes.

--- a/forge-gui/res/cardsfolder/p/plague_wight.txt
+++ b/forge-gui/res/cardsfolder/p/plague_wight.txt
@@ -3,5 +3,5 @@ ManaCost:1 B
 Types:Creature Zombie
 PT:2/1
 T:Mode$ AttackerBlocked | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME becomes blocked, each creature blocking it gets -1/-1 until end of turn.
-SVar:TrigPump:DB$ PumpAll | ValidCards$ Creature.blockingSource+DefenderCtrl | NumAtt$ -1 | NumDef$ -1
+SVar:TrigPump:DB$ PumpAll | ValidCards$ Creature.blockingSource | NumAtt$ -1 | NumDef$ -1
 Oracle:Whenever Plague Wight becomes blocked, each creature blocking it gets -1/-1 until end of turn.

--- a/forge-gui/res/cardsfolder/r/rahilda_wanted_cutthroat_rahilda_feral_outlaw.txt
+++ b/forge-gui/res/cardsfolder/r/rahilda_wanted_cutthroat_rahilda_feral_outlaw.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature Human Werewolf
 PT:2/2
 K:First Strike
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigExile | CombatDamage$ True | TriggerDescription$ When CARDNAME deals combat damage to a player, exile a nonland card from their library at random. During any turn you attacked with a Wolf or Werewolf, you may cast that card and you may spend mana as though it were mana of any color to cast that spell.
-SVar:TrigExile:DB$ ChangeZone | Origin$ Library | Destination$ Exile | DefinedPlayer$ TriggeredDefendingPlayer | ChangeType$ Card.nonLand | ChangeNum$ 1 | Hidden$ True | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | RememberChanged$ True | SubAbility$ DBEffect
+SVar:TrigExile:DB$ ChangeZone | Origin$ Library | Destination$ Exile | DefinedPlayer$ TriggeredTarget | ChangeType$ Card.nonLand | ChangeNum$ 1 | Hidden$ True | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | RememberChanged$ True | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ STPlay | SubAbility$ DBCleanup | ExileOnMoved$ Exile | Duration$ Permanent
 SVar:STPlay:Mode$ Continuous | MayPlay$ True | MayPlayIgnoreColor$ True | Affected$ Card.IsRemembered+nonLand | AffectedZone$ Exile | CheckSVar$ X | Description$ During any turn you attacked with a Wolf or Werewolf, you may cast that card and you may spend mana as though it were mana of any color to cast that spell.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
@@ -23,7 +23,7 @@ Types:Legendary Creature Werewolf
 PT:2/2
 K:Double Strike
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigExile | CombatDamage$ True | TriggerDescription$ When CARDNAME deals combat damage to a player, exile a nonland card from their library at random. During any turn you attacked with a Wolf or Werewolf, you may cast that card and you may spend mana as though it were mana of any color to cast that spell.
-SVar:TrigExile:DB$ ChangeZone | Origin$ Library | Destination$ Exile | DefinedPlayer$ TriggeredDefendingPlayer | ChangeType$ Card.nonLand | ChangeNum$ 1 | Hidden$ True | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | RememberChanged$ True | SubAbility$ DBEffect
+SVar:TrigExile:DB$ ChangeZone | Origin$ Library | Destination$ Exile | DefinedPlayer$ TriggeredTarget | ChangeType$ Card.nonLand | ChangeNum$ 1 | Hidden$ True | AtRandom$ True | NoShuffle$ True | Mandatory$ True | NoLooking$ True | RememberChanged$ True | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ STPlay | SubAbility$ DBCleanup | ExileOnMoved$ Exile | Duration$ Permanent
 SVar:STPlay:Mode$ Continuous | MayPlay$ True | MayPlayIgnoreColor$ True | Affected$ Card.IsRemembered+nonLand | AffectedZone$ Exile | CheckSVar$ X | Description$ During any turn you attacked with a Wolf or Werewolf, you may cast that card and you may spend mana as though it were mana of any color to cast that spell.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/s/scion_of_darkness.txt
+++ b/forge-gui/res/cardsfolder/s/scion_of_darkness.txt
@@ -5,5 +5,5 @@ PT:6/6
 K:Trample
 K:Cycling:3
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigGainControl | CombatDamage$ True | OptionalDecider$ You | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, you may put target creature card from that player's graveyard onto the battlefield under your control.
-SVar:TrigGainControl:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | GainControl$ True | ValidTgts$ Creature.DefenderCtrl | TgtPrompt$ Select target creature in opponent's graveyard
+SVar:TrigGainControl:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | GainControl$ True | ValidTgts$ Creature | TargetsWithDefinedController$ TriggeredTarget | TgtPrompt$ Select target creature in that player's graveyard
 Oracle:Trample\nWhenever Scion of Darkness deals combat damage to a player, you may put target creature card from that player's graveyard onto the battlefield under your control.\nCycling {3} ({3}, Discard this card: Draw a card.)

--- a/forge-gui/res/cardsfolder/s/silent_blade_oni.txt
+++ b/forge-gui/res/cardsfolder/s/silent_blade_oni.txt
@@ -5,5 +5,5 @@ PT:6/5
 K:Ninjutsu:4 U B
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigReveal | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, look at that player's hand. You may cast a spell from among those cards without paying its mana cost.
 SVar:TrigReveal:DB$ RevealHand | Defined$ TriggeredTarget | Look$ True | SubAbility$ TrigPlay
-SVar:TrigPlay:DB$ Play | Valid$ Card.nonLand+DefenderCtrl | ValidZone$ Hand | ValidSA$ Spell | WithoutManaCost$ True | Optional$ True
+SVar:TrigPlay:DB$ Play | Valid$ Card.nonLand+OwnedBy TriggeredTarget | ValidZone$ Hand | ValidSA$ Spell | WithoutManaCost$ True | Optional$ True
 Oracle:Ninjutsu {4}{U}{B} ({4}{U}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Silent-Blade Oni deals combat damage to a player, look at that player's hand. You may cast a spell from among those cards without paying its mana cost.

--- a/forge-gui/res/cardsfolder/s/skullsnatcher.txt
+++ b/forge-gui/res/cardsfolder/s/skullsnatcher.txt
@@ -4,5 +4,5 @@ Types:Creature Rat Ninja
 PT:2/1
 K:Ninjutsu:B
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigExile | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, exile up to two target cards from that player's graveyard.
-SVar:TrigExile:DB$ ChangeZone | ValidTgts$ Card.DefenderCtrl | TgtPrompt$ Select target card | TargetMin$ 0 | TargetMax$ 2 | Origin$ Graveyard | Destination$ Exile | IsCurse$ True
+SVar:TrigExile:DB$ ChangeZone | ValidTgts$ Card | TargetsWithDefinedController$ TriggeredTarget | TgtPrompt$ Select up to two target cards in that player's graveyard | TargetMin$ 0 | TargetMax$ 2 | Origin$ Graveyard | Destination$ Exile | IsCurse$ True
 Oracle:Ninjutsu {B} ({B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Skullsnatcher deals combat damage to a player, exile up to two target cards from that player's graveyard.

--- a/forge-gui/res/cardsfolder/s/sphinx_ambassador.txt
+++ b/forge-gui/res/cardsfolder/s/sphinx_ambassador.txt
@@ -4,10 +4,10 @@ Types:Creature Sphinx
 PT:5/5
 K:Flying
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigSearch | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, search that player's library for a card, then that player chooses a card name. If you searched for a creature card that doesn't have that name, you may put it onto the battlefield under your control. Then that player shuffles.
-SVar:TrigSearch:DB$ ChangeZone | ChangeType$ Card | Origin$ Library | Destination$ Library | DefinedPlayer$ TriggeredDefendingPlayer | Chooser$ You | Shuffle$ False | RememberChanged$ True | SubAbility$ DBName
-SVar:DBName:DB$ NameCard | Defined$ TriggeredDefendingPlayer | SubAbility$ DBChangeZone | AILogic$ BestCreatureInComputerDeck
+SVar:TrigSearch:DB$ ChangeZone | ChangeType$ Card | Origin$ Library | Destination$ Library | DefinedPlayer$ TriggeredTarget | Chooser$ You | Shuffle$ False | RememberChanged$ True | SubAbility$ DBName
+SVar:DBName:DB$ NameCard | Defined$ TriggeredTarget | SubAbility$ DBChangeZone | AILogic$ BestCreatureInComputerDeck
 SVar:DBChangeZone:DB$ ChangeZone | Defined$ Remembered | Origin$ Library | Destination$ Battlefield | GainControl$ True | ConditionDefined$ Remembered | Shuffle$ False | ConditionPresent$ Card.NamedCard | ConditionCompare$ EQ0 | ConditionCheckSVar$ X | ConditionSVarCompare$ EQ1 | Optional$ True | OptionalDecider$ You | SubAbility$ DBShuffle
-SVar:DBShuffle:DB$ Shuffle | Defined$ TriggeredDefendingPlayer | SubAbility$ DBCleanup
+SVar:DBShuffle:DB$ Shuffle | Defined$ TriggeredTarget | SubAbility$ DBCleanup
 SVar:X:Count$ValidLibrary Creature.IsRemembered
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearNamedCard$ True
 Oracle:Flying\nWhenever Sphinx Ambassador deals combat damage to a player, search that player's library for a card, then that player chooses a card name. If you searched for a creature card that doesn't have that name, you may put it onto the battlefield under your control. Then that player shuffles.

--- a/forge-gui/res/cardsfolder/z/zombie_cannibal.txt
+++ b/forge-gui/res/cardsfolder/z/zombie_cannibal.txt
@@ -3,5 +3,5 @@ ManaCost:B
 Types:Creature Zombie
 PT:1/1
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigExile | OptionalDecider$ You | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, you may exile target card from that player's graveyard.
-SVar:TrigExile:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | TgtPrompt$ Choose target card in your opponent's graveyard | ValidTgts$ Card.DefenderCtrl | SpellDescription$ Exile target card from your opponent's graveyard.
+SVar:TrigExile:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | TgtPrompt$ Choose target card in that player's graveyard | ValidTgts$ Card | TargetsWithDefinedController$ TriggeredTarget | SpellDescription$ Exile target card from that player's graveyard.
 Oracle:Whenever Zombie Cannibal deals combat damage to a player, you may exile target card from that player's graveyard.


### PR DESCRIPTION
The first case involves triggers for combat damage dealt to players, where the expected behavior is that combat damage redirected to a non-defending player should also trigger the triggered ability. Addressed with reference to [Aberrant](https://scryfall.com/card/40k/86/aberrant), [Zareth San, the Trickster](https://scryfall.com/card/znr/242/zareth-san-the-trickster) and similar scripts.
The second case has to do with explicitly referencing the defending player in the context of who controls a blocking creature.  Addressed with reference to [Battle-Scarred Goblin](https://scryfall.com/card/ltr/115/battle-scarred-goblin) and similar scripts.
All these edits were tested to satisfaction, especially where it concerns the interaction between combat damage redirection and combat damage triggers. 