### PR TITLE
Fix Manifest Dread vs. Grafdigger's Cage

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtil.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtil.java
@@ -1408,9 +1408,7 @@ public class ComputerUtil {
             }
         }
         for (final CostPart part : abCost.getCostParts()) {
-            if (part instanceof CostSacrifice) {
-                final CostSacrifice sac = (CostSacrifice) part;
-
+            if (part instanceof CostSacrifice sac) {
                 final String type = sac.getType();
 
                 if (type.equals("CARDNAME")) {
@@ -1776,9 +1774,7 @@ public class ComputerUtil {
                 noRegen = true;
             }
             for (final Object o : objects) {
-                if (o instanceof Card) {
-                    final Card c = (Card) o;
-
+                if (o instanceof Card c) {
                     // indestructible
                     if (c.hasKeyword(Keyword.INDESTRUCTIBLE)) {
                         continue;
@@ -1842,9 +1838,7 @@ public class ComputerUtil {
                     if (ComputerUtilCombat.predictDamageTo(c, dmg, source, false) >= ComputerUtilCombat.getDamageToKill(c, false)) {
                         threatened.add(c);
                     }
-                } else if (o instanceof Player) {
-                    final Player p = (Player) o;
-
+                } else if (o instanceof Player p) {
                     if (source.hasKeyword(Keyword.INFECT)) {
                         if (p.canReceiveCounters(CounterEnumType.POISON) && ComputerUtilCombat.predictDamageTo(p, dmg, source, false) >= 10 - p.getPoisonCounters()) {
                             threatened.add(p);
@@ -1862,8 +1856,7 @@ public class ComputerUtil {
                 || saviourApi == null)) {
             final int dmg = -AbilityUtils.calculateAmount(source, topStack.getParam("NumDef"), topStack);
             for (final Object o : objects) {
-                if (o instanceof Card) {
-                    final Card c = (Card) o;
+                if (o instanceof Card c) {
                     final boolean canRemove = (c.getNetToughness() <= dmg)
                             || (!c.hasKeyword(Keyword.INDESTRUCTIBLE) && c.getShieldCount() == 0 && dmg >= ComputerUtilCombat.getDamageToKill(c, false));
                     if (!canRemove) {
@@ -1909,9 +1902,7 @@ public class ComputerUtil {
                         || saviourApi == ApiType.Protection || saviourApi == null
                         || saviorWithSubsApi == ApiType.Pump || saviorWithSubsApi == ApiType.PumpAll)) {
             for (final Object o : objects) {
-                if (o instanceof Card) {
-                    final Card c = (Card) o;
-                    // indestructible
+                if (o instanceof Card c) {
                     if (c.hasKeyword(Keyword.INDESTRUCTIBLE)) {
                         continue;
                     }
@@ -1960,8 +1951,7 @@ public class ComputerUtil {
                 && topStack.hasParam("Destination")
                 && topStack.getParam("Destination").equals("Exile")) {
             for (final Object o : objects) {
-                if (o instanceof Card) {
-                    final Card c = (Card) o;
+                if (o instanceof Card c) {
                     // give Shroud to targeted creatures
                     if ((saviourApi == ApiType.Pump || saviourApi == ApiType.PumpAll) && (!topStack.usesTargeting() || !grantShroud)) {
                         continue;
@@ -1988,8 +1978,7 @@ public class ComputerUtil {
                 && (saviourApi == ApiType.ChangeZone || saviourApi == ApiType.Pump || saviourApi == ApiType.PumpAll
                 || saviourApi == ApiType.Protection || saviourApi == null)) {
             for (final Object o : objects) {
-                if (o instanceof Card) {
-                    final Card c = (Card) o;
+                if (o instanceof Card c) {
                     // give Shroud to targeted creatures
                     if ((saviourApi == ApiType.Pump || saviourApi == ApiType.PumpAll) && (!topStack.usesTargeting() || !grantShroud)) {
                         continue;
@@ -2011,8 +2000,7 @@ public class ComputerUtil {
             boolean enableCurseAuraRemoval = aic != null ? aic.getBooleanProperty(AiProps.ACTIVELY_DESTROY_IMMEDIATELY_UNBLOCKABLE) : false;
             if (enableCurseAuraRemoval) {
                 for (final Object o : objects) {
-                    if (o instanceof Card) {
-                        final Card c = (Card) o;
+                    if (o instanceof Card c) {
                         // give Shroud to targeted creatures
                         if ((saviourApi == ApiType.Pump || saviourApi == ApiType.PumpAll) && (!topStack.usesTargeting() || !grantShroud)) {
                             continue;

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
@@ -77,7 +77,6 @@ public class ComputerUtilCost {
         final AiCostDecision decision = new AiCostDecision(sa.getActivatingPlayer(), sa, false);
         for (final CostPart part : cost.getCostParts()) {
             if (part instanceof CostRemoveCounter remCounter) {
-
                 final CounterType type = remCounter.counter;
                 if (!part.payCostFromSource()) {
                     if (type.is(CounterEnumType.P1P1)) {
@@ -105,7 +104,6 @@ public class ComputerUtilCost {
                     return false;
                 }
             } else if (part instanceof CostRemoveAnyCounter remCounter) {
-
                 PaymentDecision pay = decision.visit(remCounter);
                 return pay != null;
             }
@@ -131,7 +129,6 @@ public class ComputerUtilCost {
 
         for (final CostPart part : cost.getCostParts()) {
             if (part instanceof CostDiscard disc) {
-
                 final String type = disc.getType();
                 final CardCollection typeList;
                 int num;
@@ -216,7 +213,6 @@ public class ComputerUtilCost {
         }
         for (final CostPart part : cost.getCostParts()) {
             if (part instanceof CostPayLife payLife) {
-
                 int amount = payLife.getAbilityAmount(sourceAbility);
 
                 // check if there's override for the remainingLife threshold

--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -1032,7 +1032,8 @@ public class GameAction {
                 lki = CardCopyService.getLKICopy(c);
             }
             game.addChangeZoneLKIInfo(lki);
-            if (lki.isInPlay()) {
+            // CR 702.26k
+            if (lki.isInPlay() && !lki.isPhasedOut()) {
                 if (game.getCombat() != null) {
                     game.getCombat().saveLKI(lki);
                     game.getCombat().removeFromCombat(c);
@@ -2678,8 +2679,8 @@ public class GameAction {
         if (isCombat) {
             for (Map.Entry<GameEntity, Map<Card, Integer>> et : damageMap.columnMap().entrySet()) {
                 final GameEntity ge = et.getKey();
-                if (ge instanceof Card) {
-                    ((Card) ge).clearAssignedDamage();
+                if (ge instanceof Card c) {
+                    c.clearAssignedDamage();
                 }
             }
         }
@@ -2699,8 +2700,7 @@ public class GameAction {
                     continue;
                 }
 
-                if (e.getKey() instanceof Card && !lethalDamage.containsKey(e.getKey())) {
-                    Card c = (Card) e.getKey();
+                if (e.getKey() instanceof Card c && !lethalDamage.containsKey(c)) {
                     lethalDamage.put(c, c.getExcessDamageValue(false));
                 }
 

--- a/forge-game/src/main/java/forge/game/GameLogFormatter.java
+++ b/forge-game/src/main/java/forge/game/GameLogFormatter.java
@@ -273,8 +273,7 @@ public class GameLogFormatter extends IGameEventVisitor.Base<GameLogEntry> {
             }
 
             String controllerName;
-            if (defender instanceof Card) {
-                Card c = ((Card)defender);
+            if (defender instanceof Card c) {
                 controllerName = c.isBattle() ? c.getProtectingPlayer().getName() : c.getController().getName();
             } else {
                 controllerName = defender.getName();

--- a/forge-game/src/main/java/forge/game/ability/effects/ControlSpellEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ControlSpellEffect.java
@@ -63,8 +63,7 @@ public class ControlSpellEffect extends SpellAbilityEffect {
                 // Expand this area as it becomes needed
                 // Use "DefinedExchange" to Reference Object that is Exchanging the other direction
                 GameObject obj = Iterables.getFirst(getDefinedOrTargeted(sa, "DefinedExchange"), null);
-                if (obj instanceof Card) {
-                    Card c = (Card)obj;
+                if (obj instanceof Card c) {
                     if (!c.isInPlay() || si == null) {
                         // Exchanging object isn't available, continue
                         continue;

--- a/forge-game/src/main/java/forge/game/ability/effects/CountersPutEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CountersPutEffect.java
@@ -252,8 +252,7 @@ public class CountersPutEffect extends SpellAbilityEffect {
         if (sa.hasParam("DividedRandomly")) {
             CardCollection targets = new CardCollection();
             for (final GameEntity obj : tgtObjects) { // check if each target is still OK
-                if (obj instanceof Card) {
-                    Card tgtCard = (Card) obj;
+                if (obj instanceof Card tgtCard) {
                     Card gameCard = game.getCardState(tgtCard, null);
                     if (gameCard == null || !tgtCard.equalsWithGameTimestamp(gameCard)) {
                         tgtObjects.remove(obj);
@@ -284,8 +283,7 @@ public class CountersPutEffect extends SpellAbilityEffect {
             for (final GameEntity obj : tgtObjects) {
                 // check if the object is still in game or if it was moved
                 Card gameCard = null;
-                if (obj instanceof Card) {
-                    Card tgtCard = (Card) obj;
+                if (obj instanceof Card tgtCard) {
                     gameCard = game.getCardState(tgtCard, null);
                     // gameCard is LKI in that case, the card is not in game anymore
                     // or the timestamp did change
@@ -572,9 +570,8 @@ public class CountersPutEffect extends SpellAbilityEffect {
                     if (sa.isDividedAsYouChoose() && !sa.usesTargeting()) {
                         counterRemain = counterRemain - counterAmount;
                     }
-                } else if (obj instanceof Player) {
+                } else if (obj instanceof Player pl) {
                     // Add Counters to players!
-                    Player pl = (Player) obj;
                     pl.addCounter(counterType, counterAmount, placer, table);
                 }
             }

--- a/forge-game/src/main/java/forge/game/ability/effects/CountersRemoveEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CountersRemoveEffect.java
@@ -248,8 +248,7 @@ public class CountersRemoveEffect extends SpellAbilityEffect {
             if (chosenAmount > 0) {
                 removed += chosenAmount;
                 entity.subtractCounter(chosenType, chosenAmount, activator);
-                if (entity instanceof Card) {
-                    Card gameCard = (Card) entity;
+                if (entity instanceof Card gameCard) {
                     game.updateLastStateForCard(gameCard);
                 }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/DamageDealEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DamageDealEffect.java
@@ -252,16 +252,14 @@ public class DamageDealEffect extends DamageBaseEffect {
                         continue;
                     }
                 }
-                if (o instanceof Card) {
-                    final Card c = (Card) o;
+                if (o instanceof Card c) {
                     final Card gc = game.getCardState(c, null);
                     if (gc == null || !c.equalsWithGameTimestamp(gc) || !gc.isInPlay() || gc.isPhasedOut()) {
                         // timestamp different or not in play
                         continue;
                     }
                     internalDamageDeal(sa, sourceLKI, gc, dmg, damageMap);
-                } else if (o instanceof Player) {
-                    final Player p = (Player) o;
+                } else if (o instanceof Player p) {
                     damageMap.put(sourceLKI, p, dmg);
                 }
             }

--- a/forge-game/src/main/java/forge/game/ability/effects/DamageEachEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DamageEachEffect.java
@@ -95,8 +95,7 @@ public class DamageEachEffect extends DamageBaseEffect {
             }
         } else for (GameEntity ge : getTargetEntities(sa)) {
             // check before checking sources
-            if (ge instanceof Card) {
-                final Card c = (Card) ge;
+            if (ge instanceof Card c) {
                 if (!c.isInPlay() || c.isPhasedOut()) {
                     continue;
                 }

--- a/forge-game/src/main/java/forge/game/ability/effects/DamagePreventEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DamagePreventEffect.java
@@ -47,8 +47,7 @@ public class DamagePreventEffect extends SpellAbilityEffect {
             }
 
             final Object o = tgts.get(i);
-            if (o instanceof Card) {
-                final Card tgtC = (Card) o;
+            if (o instanceof Card tgtC) {
                 if (tgtC.isFaceDown()) {
                     sb.append("Morph");
                 } else {
@@ -104,8 +103,7 @@ public class DamagePreventEffect extends SpellAbilityEffect {
 
         for (final GameEntity o : tgts) {
             numDam = sa.usesTargeting() && sa.isDividedAsYouChoose() ? sa.getDividedValue(o) : numDam;
-            if (o instanceof Card) {
-                final Card c = (Card) o;
+            if (o instanceof Card c) {
                 if (c.isInPlay()) {
                     addPreventNextDamage(sa, o, numDam);
                 }

--- a/forge-game/src/main/java/forge/game/ability/effects/UnattachAllEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/UnattachAllEffect.java
@@ -32,8 +32,7 @@ public class UnattachAllEffect extends SpellAbilityEffect {
 
         // If Cast Targets will be checked on the Stack
         for (GameEntity ge : getTargetEntities(sa)) {
-            if (ge instanceof Card) {
-                Card gc = (Card) ge;
+            if (ge instanceof Card gc) {
                 // check if the object is still in game or if it was moved
                 Card gameCard = game.getCardState(gc, null);
                 // gameCard is LKI in that case, the card is not in game anymore

--- a/forge-game/src/main/java/forge/game/combat/Combat.java
+++ b/forge-game/src/main/java/forge/game/combat/Combat.java
@@ -648,8 +648,7 @@ public class Combat {
                     missingCombatants.add(c);
                 }
             }
-            if (ee.getKey() instanceof Card) {
-                Card c = (Card) ee.getKey();
+            if (ee.getKey() instanceof Card c) {
                 if (!c.isBattle() && !c.isPlaneswalker()) {
                     missingCombatants.add(c);
                 }

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
@@ -1535,8 +1535,7 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
                 }
             }
 
-            if (entity instanceof GameEntity) {
-                GameEntity e = (GameEntity)entity;
+            if (entity instanceof GameEntity e) {
                 if (!e.isValid(tr.getValidTgts(), getActivatingPlayer(), getHostCard(), this)) {
                     return false;
                 }
@@ -1545,8 +1544,7 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
                 }
             }
 
-            if (entity instanceof Card) {
-                final Card c = (Card) entity;
+            if (entity instanceof Card c) {
                 if (c.getZone() != null && !tr.getZone().contains(c.getZone().getZoneType())) {
                     return false;
                 }

--- a/forge-game/src/main/java/forge/game/spellability/TargetChoices.java
+++ b/forge-game/src/main/java/forge/game/spellability/TargetChoices.java
@@ -72,8 +72,7 @@ public class TargetChoices extends ForwardingList<GameObject> implements Cloneab
 
     public final boolean add(final GameObject o) {
         if (o instanceof Player || o instanceof Card || o instanceof SpellAbility) {
-            if (o instanceof Card) {
-                Card c = (Card) o;
+            if (o instanceof Card c) {
                 cardControllers.put(c, c.getController());
             }
             return super.add(o);

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityMustAttack.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityMustAttack.java
@@ -30,13 +30,11 @@ public class StaticAbilityMustAttack {
                     if (stAb.hasParam("MustAttack")) {
                         List<GameEntity> def = AbilityUtils.getDefinedEntities(stAb.getHostCard(), stAb.getParam("MustAttack"), stAb);
                         for (GameEntity e : def) {
-                            if (e instanceof Player) {
-                                Player attackPl = (Player) e;
+                            if (e instanceof Player attackPl) {
                                 if (!game.getPhaseHandler().isPlayerTurn(attackPl)) { // CR 506.2
                                     entityList.add(e);
                                 }
-                            } else if (e instanceof Card) {
-                                Card attackPW = (Card) e;
+                            } else if (e instanceof Card attackPW) {
                                 if (!game.getPhaseHandler().isPlayerTurn(attackPW.getController())) { // CR 506.2
                                     entityList.add(e);
                                 }

--- a/forge-game/src/main/java/forge/game/trigger/TriggerDamageDone.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerDamageDone.java
@@ -113,8 +113,7 @@ public class TriggerDamageDone extends Trigger {
             final Object target = runParams.get(AbilityKey.DamageTarget);
             final Card source = (Card) runParams.get(AbilityKey.DamageSource);
 
-            if (target instanceof Player) {
-                final Player trigTgt = (Player) target;
+            if (target instanceof Player trigTgt) {
                 if (!Expressions.compare(trigTgt.getAssignedDamage(null, source), operator, operand)) {
                     return false;
                 }

--- a/forge-game/src/main/java/forge/game/trigger/TriggerManifestDread.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerManifestDread.java
@@ -22,7 +22,7 @@ public class TriggerManifestDread extends Trigger {
 
     @Override
     public void setTriggeringObjects(SpellAbility sa, Map<AbilityKey, Object> runParams) {
-        sa.setTriggeringObject(AbilityKey.NewCard, runParams.get(AbilityKey.Card));
+        sa.setTriggeringObject(AbilityKey.Cards, runParams.get(AbilityKey.Cards));
 
     }
 

--- a/forge-game/src/main/java/forge/game/trigger/WrappedAbility.java
+++ b/forge-game/src/main/java/forge/game/trigger/WrappedAbility.java
@@ -585,7 +585,7 @@ public class WrappedAbility extends Ability {
             }
         }
 
-        timestampCheck();
+        //timestampCheck();
 
         getActivatingPlayer().getController().playSpellAbilityNoStack(sa, false);
     }

--- a/forge-gui/res/cardsfolder/p/paranormal_analyst.txt
+++ b/forge-gui/res/cardsfolder/p/paranormal_analyst.txt
@@ -3,5 +3,5 @@ ManaCost:1 U
 Types:Creature Human Detective
 PT:1/3
 T:Mode$ ManifestDread | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigReturn | TriggerDescription$ Whenever you manifest dread, put a card you put into your graveyard this way into your hand.
-SVar:TrigReturn:DB$ ChangeZone | Defined$ TriggeredNewCardLKICopy | Origin$ Graveyard | Destination$ Hand
+SVar:TrigReturn:DB$ ChangeZone | ChooseFromDefined$ TriggeredCards | ChangeNum$ 1 | Mandatory$ True | Hidden$ True | Origin$ Graveyard | Destination$ Hand
 Oracle:Whenever you manifest dread, put a card you put into your graveyard this way into your hand.


### PR DESCRIPTION
> 701.60a “Manifest dread” means “Look at the top two cards of your library. Manifest one of them,
then put the cards you looked at that were not manifested this way into your graveyard.”

Also commented out `timestampCheck()` as the final step before removing it completely.