### PR TITLE
Fix Blessing applying too late for triggers

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
@@ -1362,10 +1362,8 @@ public class AbilityUtils {
         }
 
         // do blessing there before condition checks
-        if (source.hasKeyword(Keyword.ASCEND)) {
-            if (controller.getZone(ZoneType.Battlefield).size() >= 10) {
-                controller.setBlessing(true);
-            }
+        if (source.hasKeyword(Keyword.ASCEND) && controller.getZone(ZoneType.Battlefield).size() >= 10) {
+            controller.setBlessing(true);
         }
 
         if (source.hasKeyword(Keyword.GIFT) && sa.isGiftPromised()) {

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -3686,6 +3686,9 @@ public class Player extends GameEntity implements Comparable<Player> {
             blessingEffect.updateStateForView();
 
             com.add(blessingEffect);
+
+            // 702.131d. After a player gets the city's blessing, continuous effects are reapplied
+            game.getAction().checkStaticAbilities();
         } else {
             com.remove(blessingEffect);
             blessingEffect = null;


### PR DESCRIPTION
> Some cards get power, toughness, and/or abilities once you have the city’s blessing. If another card has an ability that triggers when creatures with certain characteristics enter the battlefield (such as Mentor of the Meek or Elemental Bond do), use the entering permanent’s characteristics after you have the city’s blessing to determine whether those abilities trigger. This is true even if the entering permanent is your tenth permanent.

E.g.  _Godtracker of Jund_ should trigger when _Dusk Charger_ ETB