### PR TITLE
Oracle update: Affinity

### DIFF
--- a/forge-gui/res/cardsfolder/a/angelic_observer.txt
+++ b/forge-gui/res/cardsfolder/a/angelic_observer.txt
@@ -2,8 +2,7 @@ Name:Angelic Observer
 ManaCost:5 W
 Types:Creature Angel Advisor
 PT:3/3
+K:Affinity:Citizen
 K:Flying
-S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {1} less to cast for each Citizen you control.
-SVar:X:Count$TypeYouCtrl.Citizen
 DeckHints:Type$Citizen
-Oracle:This spell costs {1} less to cast for each Citizen you control.\nFlying
+Oracle:Affinity for Citizens (This spell costs {1} less to cast for each Citizen you control.)\nFlying

--- a/forge-gui/res/cardsfolder/a/argivian_phalanx.txt
+++ b/forge-gui/res/cardsfolder/a/argivian_phalanx.txt
@@ -2,7 +2,6 @@ Name:Argivian Phalanx
 ManaCost:5 W
 Types:Creature Human Kor Soldier
 PT:4/4
+K:Affinity:Creature
 K:Vigilance
-S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {1} less to cast for each creature you control.
-SVar:X:Count$Valid Creature.YouCtrl
-Oracle:This spell costs {1} less to cast for each creature you control.\nVigilance
+Oracle:Affinity for creatures (This spell costs {1} less to cast for each creature you control.)\nVigilance

--- a/forge-gui/res/cardsfolder/b/brine_giant.txt
+++ b/forge-gui/res/cardsfolder/b/brine_giant.txt
@@ -2,7 +2,6 @@ Name:Brine Giant
 ManaCost:6 U
 Types:Creature Giant
 PT:5/6
-S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {1} less to cast for each enchantment you control.
-SVar:X:Count$Valid Enchantment.YouCtrl
+K:Affinity:Enchantment
 DeckHints:Type$Enchantment
-Oracle:This spell costs {1} less to cast for each enchantment you control.
+Oracle:Affinity for enchantments (This spell costs {1} less to cast for each enchantment you control.)

--- a/forge-gui/res/cardsfolder/e/emry_lurker_of_the_loch.txt
+++ b/forge-gui/res/cardsfolder/e/emry_lurker_of_the_loch.txt
@@ -2,12 +2,11 @@ Name:Emry, Lurker of the Loch
 ManaCost:2 U
 Types:Legendary Creature Merfolk Wizard
 PT:1/2
-S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {1} less to cast for each artifact you control.
-SVar:X:Count$Valid Artifact.YouCtrl
+K:Affinity:Artifact
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigMill | TriggerDescription$ When CARDNAME enters, mill four cards.
 SVar:TrigMill:DB$ Mill | NumCards$ 4 | Defined$ You
 A:AB$ Effect | Cost$ T | TgtZone$ Graveyard | ValidTgts$ Artifact.YouOwn | TgtPrompt$ Select target artifact card in your graveyard | SpellDescription$ Choose target artifact card in your graveyard. You may cast that card this turn. | RememberObjects$ Targeted | StaticAbilities$ STPlay | ExileOnMoved$ Graveyard
 SVar:STPlay:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsRemembered+nonLand | AffectedZone$ Graveyard | Description$ You may cast that card this turn.
 DeckHas:Ability$Graveyard
 DeckNeeds:Type$Artifact
-Oracle:This spell costs {1} less to cast for each artifact you control.\nWhen Emry, Lurker of the Loch enters, mill four cards.\n{T}: Choose target artifact card in your graveyard. You may cast that card this turn. (You still pay its costs. Timing rules still apply.)
+Oracle:Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nWhen Emry, Lurker of the Loch enters, mill four cards.\n{T}: Choose target artifact card in your graveyard. You may cast that card this turn. (You still pay its costs. Timing rules still apply.)

--- a/forge-gui/res/cardsfolder/g/gate_colossus.txt
+++ b/forge-gui/res/cardsfolder/g/gate_colossus.txt
@@ -2,10 +2,9 @@ Name:Gate Colossus
 ManaCost:8
 Types:Artifact Creature Construct
 PT:8/8
-S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {1} less to cast for each Gate you control.
-SVar:X:Count$Valid Gate.YouCtrl
+K:Affinity:Gate
 S:Mode$ CantBlockBy | ValidAttacker$ Creature.Self | ValidBlocker$ Creature.powerLE2 | Description$ CARDNAME can't be blocked by creatures with power 2 or less.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Gate.YouCtrl | OptionalDecider$ You | TriggerZones$ Graveyard | Execute$ TrigChange | TriggerDescription$ Whenever a Gate you control enters, you may put CARDNAME from your graveyard on top of your library.
 SVar:TrigChange:DB$ ChangeZone | Origin$ Graveyard | Destination$ Library | Defined$ Self
 DeckNeeds:Type$Gate
-Oracle:This spell costs {1} less to cast for each Gate you control.\nGate Colossus can't be blocked by creatures with power 2 or less.\nWhenever a Gate you control enters, you may put Gate Colossus from your graveyard on top of your library.
+Oracle:Affinity for Gates (This spell costs {1} less to cast for each Gate you control.)\nGate Colossus can't be blocked by creatures with power 2 or less.\nWhenever a Gate you control enters, you may put Gate Colossus from your graveyard on top of your library.

--- a/forge-gui/res/cardsfolder/g/gearseeker_serpent.txt
+++ b/forge-gui/res/cardsfolder/g/gearseeker_serpent.txt
@@ -2,9 +2,8 @@ Name:Gearseeker Serpent
 ManaCost:5 U U
 Types:Creature Serpent
 PT:5/6
-S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {1} less to cast for each artifact you control.
+K:Affinity:Artifact
 A:AB$ Effect | Cost$ 5 U | RememberObjects$ Self | ExileOnMoved$ Battlefield | StaticAbilities$ Unblockable | SpellDescription$ CARDNAME can't be blocked this turn.
 SVar:Unblockable:Mode$ CantBlockBy | ValidAttacker$ Card.IsRemembered | Description$ EFFECTSOURCE can't be blocked this turn.
-SVar:X:Count$Valid Artifact.YouCtrl
 DeckHints:Type$Artifact
-Oracle:This spell costs {1} less to cast for each artifact you control.\n{5}{U}: Gearseeker Serpent can't be blocked this turn.
+Oracle:Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\n{5}{U}: Gearseeker Serpent can't be blocked this turn.

--- a/forge-gui/res/cardsfolder/h/hellspur_brute.txt
+++ b/forge-gui/res/cardsfolder/h/hellspur_brute.txt
@@ -2,7 +2,7 @@ Name:Hellspur Brute
 ManaCost:4 R
 Types:Creature Minotaur Mercenary
 PT:5/4
-K:Affinity:Card.Outlaw:outlaw
+K:Affinity:Permanent.Outlaw:outlaw
 K:Trample
 DeckHints:Type$Assassin|Mercenary|Pirate|Rogue|Warlock
 Oracle:Affinity for outlaws (This spell costs {1} less to cast for each Assassin, Mercenary, Pirate, Rogue, and/or Warlock you control.)\nTrample

--- a/forge-gui/res/cardsfolder/i/icebreaker_kraken.txt
+++ b/forge-gui/res/cardsfolder/i/icebreaker_kraken.txt
@@ -2,13 +2,12 @@ Name:Icebreaker Kraken
 ManaCost:10 U U
 Types:Snow Creature Kraken
 PT:8/8
-S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ CARDNAME costs {1} less to cast for each snow land you control.
+K:Affinity:Land.Snow:snow land
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ DBEffect | TriggerDescription$ When CARDNAME enters, artifacts and creatures target opponent controls don't untap during that player's next untap step.
 A:AB$ ChangeZone | Cost$ Return<3/Land.Snow> | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return CARDNAME to its owner's hand.
 SVar:DBEffect:DB$ Effect | StaticAbilities$ DontUntap | Triggers$ RemoveEffect | Duration$ Permanent | ValidTgts$ Opponent | RememberObjects$ Targeted | SpellDescription$ During that player's next untap step, artifacts and creatures they control don't untap.
 SVar:DontUntap:Mode$ Continuous | AffectedZone$ Battlefield | Affected$ Artifact.RememberedPlayerCtrl,Creature.RememberedPlayerCtrl | AddHiddenKeyword$ This card doesn't untap during your next untap step. | Description$ Artifacts and creatures target opponent controls don't untap during their next untap step.
 SVar:RemoveEffect:Mode$ Phase | Phase$ Untap | ValidPlayer$ Player.IsRemembered | TriggerZones$ Command | Static$ True | Execute$ ExileEffect
 SVar:ExileEffect:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
-SVar:X:Count$Valid Land.Snow+YouCtrl
 DeckHints:Type$Snow
-Oracle:This spell costs {1} less to cast for each snow land you control.\nWhen Icebreaker Kraken enters, artifacts and creatures target opponent controls don't untap during that player's next untap step.\nReturn three snow lands you control to their owner's hand: Return Icebreaker Kraken to its owner's hand.
+Oracle:Affinity for snow lands (This spell costs {1} less to cast for each snow land you control.)\nWhen Icebreaker Kraken enters, artifacts and creatures target opponent controls don't untap during that player's next untap step.\nReturn three snow lands you control to their owner's hand: Return Icebreaker Kraken to its owner's hand.

--- a/forge-gui/res/cardsfolder/m/millicent_restless_revenant.txt
+++ b/forge-gui/res/cardsfolder/m/millicent_restless_revenant.txt
@@ -9,4 +9,4 @@ T:Mode$ DamageDone | ValidSource$ Card.Self,Spirit.Other+nonToken+YouCtrl | Vali
 SVar:TrigToken:DB$ Token | TokenScript$ w_1_1_spirit_flying
 DeckHints:Type$Spirit & Keyword$Disturb
 DeckHas:Ability$Token
-Oracle:Oracle:Affinity for Spirits (This spell costs {1} less to cast for each Spirit you control.)\nFlying\nWhenever Millicent, Restless Revenant or another nontoken Spirit you control dies or deals combat damage to a player, create a 1/1 white Spirit creature token with flying.
+Oracle:Affinity for Spirits (This spell costs {1} less to cast for each Spirit you control.)\nFlying\nWhenever Millicent, Restless Revenant or another nontoken Spirit you control dies or deals combat damage to a player, create a 1/1 white Spirit creature token with flying.

--- a/forge-gui/res/cardsfolder/m/millicent_restless_revenant.txt
+++ b/forge-gui/res/cardsfolder/m/millicent_restless_revenant.txt
@@ -2,12 +2,11 @@ Name:Millicent, Restless Revenant
 ManaCost:5 W U
 Types:Legendary Creature Spirit Soldier
 PT:4/4
+K:Affinity:Spirit
 K:Flying
-S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {1} less to cast for each Spirit you control.
-SVar:X:Count$TypeYouCtrl.Spirit
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self,Spirit.Other+nonToken+YouCtrl | Execute$ TrigToken | TriggerDescription$ Whenever CARDNAME or another nontoken Spirit you control dies or deals combat damage to a player, create a 1/1 white Spirit creature token with flying.
 T:Mode$ DamageDone | ValidSource$ Card.Self,Spirit.Other+nonToken+YouCtrl | ValidTarget$ Player | Execute$ TrigToken | TriggerZones$ Battlefield | CombatDamage$ True | Secondary$ True | TriggerDescription$ Whenever CARDNAME or another nontoken Spirit you control dies or deals combat damage to a player, create a 1/1 white Spirit creature token with flying.
 SVar:TrigToken:DB$ Token | TokenScript$ w_1_1_spirit_flying
 DeckHints:Type$Spirit & Keyword$Disturb
 DeckHas:Ability$Token
-Oracle:This spell costs {1} less to cast for each Spirit you control.\nFlying\nWhenever Millicent, Restless Revenant or another nontoken Spirit you control dies or deals combat damage to a player, create a 1/1 white Spirit creature token with flying.
+Oracle:Oracle:Affinity for Spirits (This spell costs {1} less to cast for each Spirit you control.)\nFlying\nWhenever Millicent, Restless Revenant or another nontoken Spirit you control dies or deals combat damage to a player, create a 1/1 white Spirit creature token with flying.

--- a/forge-gui/res/cardsfolder/n/nahiri_forged_in_fury.txt
+++ b/forge-gui/res/cardsfolder/n/nahiri_forged_in_fury.txt
@@ -2,7 +2,7 @@ Name:Nahiri, Forged in Fury
 ManaCost:4 R W
 Types:Legendary Creature Kor Artificer
 PT:5/4
-K:Affinity:Artifact.Equipment:equipment
+K:Affinity:Equipment
 T:Mode$ Attacks | ValidCard$ Creature.equipped+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigExile | TriggerDescription$ Whenever an equipped creature you control attacks, exile the top card of your library. You may play that card this turn. You may cast Equipment spells this way without paying their mana costs.
 SVar:TrigExile:DB$ Dig | Defined$ You | DigNum$ 1 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | StaticAbilities$ STPlay,STPlay2 | RememberObjects$ Remembered | ForgetOnMoved$ Exile | SubAbility$ DBCleanup
@@ -10,4 +10,4 @@ SVar:STPlay:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsRemembered | Aff
 SVar:STPlay2:Mode$ Continuous | MayPlay$ True | MayPlayWithoutManaCost$ True | Affected$ Equipment.IsRemembered | ValidAfterStack$ Spell.Equipment | AffectedZone$ Exile | Description$ You may cast Equipment spells this way without paying their mana costs.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 DeckNeeds:Type$Equipment
-Oracle:Affinity for Equipment\nWhenever an equipped creature you control attacks, exile the top card of your library. You may play that card this turn. You may cast Equipment spells this way without paying their mana costs.
+Oracle:Affinity for Equipment (This spell costs {1} less to cast for each Equipment you control.)\nWhenever an equipped creature you control attacks, exile the top card of your library. You may play that card this turn. You may cast Equipment spells this way without paying their mana costs.

--- a/forge-gui/res/cardsfolder/o/oxidda_finisher.txt
+++ b/forge-gui/res/cardsfolder/o/oxidda_finisher.txt
@@ -2,6 +2,6 @@ Name:Oxidda Finisher
 ManaCost:5 R R
 Types:Creature Ogre Rebel
 PT:7/5
-K:Affinity:Artifact.Equipment:equipment
+K:Affinity:Equipment
 K:Trample
-Oracle:Affinity for Equipment (This spell costs {1} less to cast for each equipment you control.)\nTrample
+Oracle:Affinity for Equipment (This spell costs {1} less to cast for each Equipment you control.)\nTrample

--- a/forge-gui/res/cardsfolder/p/polliwallop.txt
+++ b/forge-gui/res/cardsfolder/p/polliwallop.txt
@@ -1,9 +1,8 @@
 Name:Polliwallop
 ManaCost:3 G
 Types:Instant
-S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {1} less to cast for each Frog you control.
+K:Affinity:Frog
 A:SP$ Pump | ValidTgts$ Creature.YouCtrl | AILogic$ PowerDmg | TgtPrompt$ Select target creature you control | SubAbility$ SoulsDamage | StackDescription$ None | SpellDescription$ Target creature you control deals damage equal to twice its power to target creature you don't control.
 SVar:SoulsDamage:DB$ DealDamage | ValidTgts$ Creature.YouDontCtrl | AILogic$ PowerDmg | TgtPrompt$ Select target creature you don't control | NumDmg$ Y | DamageSource$ ParentTarget
-SVar:X:Count$Valid Frog.YouCtrl
 SVar:Y:ParentTargeted$CardPower/Twice
-Oracle:This spell costs {1} less to cast for each Frog you control.\nTarget creature you control deals damage equal to twice its power to target creature you don't control.
+Oracle:Affinity for Frogs (This spell costs {1} less to cast for each Frog you control.)\nTarget creature you control deals damage equal to twice its power to target creature you don't control.

--- a/forge-gui/res/cardsfolder/r/reality_heist.txt
+++ b/forge-gui/res/cardsfolder/r/reality_heist.txt
@@ -1,8 +1,7 @@
 Name:Reality Heist
 ManaCost:5 U U
 Types:Instant
-S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {1} less to cast for each artifact you control.
-SVar:X:Count$Valid Artifact.YouCtrl
+K:Affinity:Artifact
 A:SP$ Dig | Defined$ You | DigNum$ 7 | ChangeNum$ 2 | Optional$ True | ForceRevealToController$ True | ChangeValid$ Artifact | RestRandomOrder$ True | SpellDescription$ Look at the top seven cards of your library. You may reveal up to two artifact cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order.
 DeckNeeds:Type$Artifact
-Oracle:This spell costs {1} less to cast for each artifact you control.\nLook at the top seven cards of your library. You may reveal up to two artifact cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order.
+Oracle:Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nLook at the top seven cards of your library. You may reveal up to two artifact cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order.

--- a/forge-gui/res/cardsfolder/r/riders_of_the_mark.txt
+++ b/forge-gui/res/cardsfolder/r/riders_of_the_mark.txt
@@ -2,10 +2,9 @@ Name:Riders of the Mark
 ManaCost:6 R
 Types:Creature Human Knight
 PT:7/4
+K:Affinity:Human
 K:Trample
 K:Haste
-S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {1} less to cast for each Human you control.
-SVar:X:Count$TypeYouCtrl.Human
 T:Mode$ Phase | TriggerZones$ Battlefield | Phase$ End of Turn | ValidPlayer$ You | IsPresent$ Card.Self+attackedThisTurn | Execute$ TrigChangeZone | TriggerDescription$ At the beginning of your end step, if CARDNAME attacked this turn, return it to its owner's hand. If you do, create a number of 1/1 white Human Soldier creature tokens equal to its toughness.
 SVar:TrigChangeZone:DB$ ChangeZone | Defined$ Self | Origin$ Battlefield | Destination$ Hand | RememberChanged$ True | SubAbility$ DBToken
 SVar:DBToken:DB$ Token | TokenScript$ w_1_1_human_soldier | TokenOwner$ You | TokenAmount$ Y | ConditionDefined$ Remembered | ConditionPresent$ Card | SubAbility$ DBCleanup
@@ -13,4 +12,4 @@ SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:Y:RememberedLKI$CardToughness
 DeckHints:Type$Human
 DeckHas:Ability$Token & Type$Soldier
-Oracle:This spell costs {1} less to cast for each Human you control.\nTrample, haste\nAt the beginning of your end step, if Riders of the Mark attacked this turn, return it to its owner's hand. If you do, create a number of 1/1 white Human Soldier creature tokens equal to its toughness.
+Oracle:Affinity for Humans (This spell costs {1} less to cast for each Human you control.)\nTrample, haste\nAt the beginning of your end step, if Riders of the Mark attacked this turn, return it to its owner's hand. If you do, create a number of 1/1 white Human Soldier creature tokens equal to its toughness.

--- a/forge-gui/res/cardsfolder/s/saheeli_the_gifted.txt
+++ b/forge-gui/res/cardsfolder/s/saheeli_the_gifted.txt
@@ -3,11 +3,10 @@ ManaCost:2 U R
 Types:Legendary Planeswalker Saheeli
 Loyalty:4
 A:AB$ Token | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | TokenAmount$ 1 | TokenScript$ c_1_1_a_servo | TokenOwner$ You | SpellDescription$ Create a 1/1 colorless Servo artifact creature token.
-A:AB$ Effect | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | StaticAbilities$ HBReduceCost | Triggers$ TrigCastSpell | SpellDescription$ The next spell you cast this turn costs {1} less to cast for each artifact you control as you cast it.
-SVar:HBReduceCost:Mode$ ReduceCost | Type$ Spell | ValidCard$ Card | Activator$ You | Amount$ X | Description$ The next spell you cast this turn costs {1} less to cast for each artifact you control as you cast it.
+A:AB$ Effect | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | StaticAbilities$ GrantAffinity | Triggers$ TrigCastSpell | SpellDescription$ The next spell you cast this turn has affinity for artifacts. (It costs {1} less to cast for each artifact you control as you cast it.)
+SVar:GrantAffinity:Mode$ Continuous | Affected$ Card.YouCtrl | AffectedZone$ Stack | AddKeyword$ Affinity:Artifact | Description$ The next spell you cast this turn has affinity for artifacts. (It costs {1} less to cast for each artifact you control as you cast it.)
 SVar:TrigCastSpell:Mode$ SpellCast | ValidActivatingPlayer$ You | TriggerZones$ Command | Execute$ RemoveEffect | Static$ True
 SVar:RemoveEffect:DB$ ChangeZone | Origin$ Command | Destination$ Exile
-SVar:X:Count$Valid Artifact.YouCtrl
 A:AB$ CopyPermanent | Cost$ SubCounter<7/LOYALTY> | Planeswalker$ True | Ultimate$ True | Defined$ Valid Artifact.YouCtrl | PumpKeywords$ Haste | AtEOT$ Exile | AILogic$ DuplicatePerms | SpellDescription$ For each artifact you control, create a token that's a copy of it. Those tokens gain haste. Exile those tokens at the beginning of the next end step.
 K:CARDNAME can be your commander.
-Oracle:[+1]: Create a 1/1 colorless Servo artifact creature token.\n[+1]: The next spell you cast this turn costs {1} less to cast for each artifact you control as you cast it.\n[-7]: For each artifact you control, create a token that's a copy of it. Those tokens gain haste. Exile those tokens at the beginning of the next end step.\nSaheeli, the Gifted can be your commander.
+Oracle:[+1]: Create a 1/1 colorless Servo artifact creature token.\n[+1]: The next spell you cast this turn has affinity for artifacts. (It costs {1} less to cast for each artifact you control as you cast it.)\n[-7]: For each artifact you control, create a token that's a copy of it. Those tokens gain haste. Exile those tokens at the beginning of the next end step.\nSaheeli, the Gifted can be your commander.

--- a/forge-gui/res/cardsfolder/s/scales_of_shale.txt
+++ b/forge-gui/res/cardsfolder/s/scales_of_shale.txt
@@ -1,8 +1,7 @@
 Name:Scales of Shale
 ManaCost:2 B
 Types:Instant
-S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {1} less to cast for each Lizard you control.
-SVar:X:Count$Valid Lizard.YouCtrl
+K:Affinity:Lizard
 A:SP$ Pump | ValidTgts$ Creature | NumAtt$ +2 | KW$ Lifelink & Indestructible | SpellDescription$ Target creature gets +2/+0 and gains lifelink and indestructible until end of turn.
 DeckHints:Type$Lizard
-Oracle:This spell costs {1} less to cast for each Lizard you control.\nTarget creature gets +2/+0 and gains lifelink and indestructible until end of turn.
+Oracle:Affinity for Lizards (This spell costs {1} less to cast for each Lizard you control.)\nTarget creature gets +2/+0 and gains lifelink and indestructible until end of turn.

--- a/forge-gui/res/cardsfolder/s/sky_blessed_samurai.txt
+++ b/forge-gui/res/cardsfolder/s/sky_blessed_samurai.txt
@@ -2,8 +2,7 @@ Name:Sky-Blessed Samurai
 ManaCost:6 W
 Types:Enchantment Creature Human Samurai
 PT:4/4
-S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {1} less to cast for each enchantment you control.
-SVar:X:Count$Valid Enchantment.YouCtrl
+K:Affinity:Enchantment
 K:Flying
 DeckHints:Type$Enchantment
-Oracle:This spell costs {1} less to cast for each enchantment you control.\nFlying
+Oracle:Oracle:Affinity for enchantments (This spell costs {1} less to cast for each enchantment you control.)\nFlying

--- a/forge-gui/res/cardsfolder/s/sky_blessed_samurai.txt
+++ b/forge-gui/res/cardsfolder/s/sky_blessed_samurai.txt
@@ -5,4 +5,4 @@ PT:4/4
 K:Affinity:Enchantment
 K:Flying
 DeckHints:Type$Enchantment
-Oracle:Oracle:Affinity for enchantments (This spell costs {1} less to cast for each enchantment you control.)\nFlying
+Oracle:Affinity for enchantments (This spell costs {1} less to cast for each enchantment you control.)\nFlying

--- a/forge-gui/res/cardsfolder/t/the_circle_of_loyalty.txt
+++ b/forge-gui/res/cardsfolder/t/the_circle_of_loyalty.txt
@@ -1,8 +1,7 @@
 Name:The Circle of Loyalty
 ManaCost:4 W W
 Types:Legendary Artifact
-S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {1} less to cast for each Knight you control.
-SVar:X:Count$Valid Knight.YouCtrl
+K:Affinity:Knight
 S:Mode$ Continuous | Affected$ Creature.YouCtrl | AddPower$ 1 | AddToughness$ 1 | Description$ Creatures you control get +1/+1.
 T:Mode$ SpellCast | ValidCard$ Card.Legendary | ValidActivatingPlayer$ You | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a legendary spell, create a 2/2 white Knight creature token with vigilance.
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ w_2_2_knight_vigilance | TokenOwner$ You
@@ -11,4 +10,4 @@ SVar:PlayMain1:TRUE
 SVar:BuffedBy:Legendary
 DeckHas:Ability$Token
 DeckHints:Type$Knight|Legendary
-Oracle:This spell costs {1} less to cast for each Knight you control.\nCreatures you control get +1/+1.\nWhenever you cast a legendary spell, create a 2/2 white Knight creature token with vigilance.\n{3}{W}, {T}: Create a 2/2 white Knight creature token with vigilance.
+Oracle:Oracle:Affinity for Knights (This spell costs {1} less to cast for each Knight you control.)\nCreatures you control get +1/+1.\nWhenever you cast a legendary spell, create a 2/2 white Knight creature token with vigilance.\n{3}{W}, {T}: Create a 2/2 white Knight creature token with vigilance.

--- a/forge-gui/res/cardsfolder/t/the_circle_of_loyalty.txt
+++ b/forge-gui/res/cardsfolder/t/the_circle_of_loyalty.txt
@@ -10,4 +10,4 @@ SVar:PlayMain1:TRUE
 SVar:BuffedBy:Legendary
 DeckHas:Ability$Token
 DeckHints:Type$Knight|Legendary
-Oracle:Oracle:Affinity for Knights (This spell costs {1} less to cast for each Knight you control.)\nCreatures you control get +1/+1.\nWhenever you cast a legendary spell, create a 2/2 white Knight creature token with vigilance.\n{3}{W}, {T}: Create a 2/2 white Knight creature token with vigilance.
+Oracle:Affinity for Knights (This spell costs {1} less to cast for each Knight you control.)\nCreatures you control get +1/+1.\nWhenever you cast a legendary spell, create a 2/2 white Knight creature token with vigilance.\n{3}{W}, {T}: Create a 2/2 white Knight creature token with vigilance.


### PR DESCRIPTION
As requested by @Hanmac: updated scripts per Gatherer where explicitly written cost reduction effects were suitably keyworded. I also took the opportunity to clean up some of the existing `K:Affinity` lines.

Notable misses by WotC in this update are [Claws Out](https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=679083&printed=false) and, arguably, [The Legend of Arena](https://scryfall.com/card/ph18/4/the-legend-of-arena), both of which I skipped as well. 