### PR TITLE
DA1: Sojourner's Enforcermite

### DIFF
--- a/forge-gui/res/cardsfolder/s/sojourners_enforcermite.txt
+++ b/forge-gui/res/cardsfolder/s/sojourners_enforcermite.txt
@@ -1,0 +1,8 @@
+Name:Sojourner's Enforcermite
+ManaCost:6
+Types:Artifact Creature Frog Myr Salamander
+PT:6/6
+K:Affinity:Permanent.withAffinity:permanent with affinity
+K:TypeCycling:Card.withAffinity:2
+Oracle:Affinity for Affinity (This card costs {1} less to cast for each permanent you control with affinity.)\nAffinitycycling {2} ({2}, Discard this card: Search your library for a card with affinity, reveal it, put it into your hand, then shuffle.)
+


### PR DESCRIPTION
As far as functionality goes, the script works as expected. The only issue is in-game text display as seen below. 

![image](https://github.com/user-attachments/assets/b9c86ec4-05e9-4e09-90ec-5cac7547f434)

My suggestion would be to have it as: 
> Affinity for permanents with affinity (This card costs {1} less to cast for each permanent you control with affinity.)
> Affinitycycling {2} ({2}, Discard this card: Search your library for a card with affinity, reveal it, put it into your hand, then shuffle.)
