### PR TITLE
Bundle of Assorted Fixes

### DIFF
--- a/forge-core/src/main/java/forge/deck/DeckRecognizer.java
+++ b/forge-core/src/main/java/forge/deck/DeckRecognizer.java
@@ -472,7 +472,8 @@ public class DeckRecognizer {
             "side", "sideboard", "sb",
             "main", "card", "mainboard",
             "avatar", "commander", "schemes",
-            "conspiracy", "planes", "deck", "dungeon"};
+            "conspiracy", "planes", "deck", "dungeon",
+            "attractions", "contraptions"};
 
     private static CharSequence[] allCardTypes(){
         List<String> cardTypesList = new ArrayList<>();
@@ -670,6 +671,9 @@ public class DeckRecognizer {
                     // ok so the card has been found - let's see if there's any restriction on the set
                     return checkAndSetCardToken(pc, edition, cardCount, deckSecFromCardLine,
                                                 currentDeckSection, true);
+                // On the off chance we accidentally interpreted part of the card's name as a set code, e.g. "Tyrranax Rex"
+                if (data.isMTGCard(cardName + " " + setCode))
+                    continue;
                 // UNKNOWN card as in the Counterspell|FEM case
                 return Token.UnknownCard(cardName, setCode, cardCount);
             }

--- a/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
@@ -3704,6 +3704,10 @@ public class AbilityUtils {
             return doXMath(amount, m, source, ctb);
         }
 
+        if (value.equals("AttractionsVisitedThisTurn")) {
+            return doXMath(player.getAttractionsVisitedThisTurn(), m, source, ctb);
+        }
+
         if (value.startsWith("PlaneswalkedToThisTurn")) {
             int found = 0;
             String name = value.split(" ")[1];

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -3764,6 +3764,8 @@ public class CardFactoryUtil {
                 desc = "Basic land";
             } else if (type.equals("Land.Artifact")) {
                 desc = "Artifact land";
+            } else if (type.startsWith("Card.with")) {
+                desc = type.substring(9);
             }
 
             sb.append(" Discard<1/CARDNAME> | ActivationZone$ Hand | PrecostDesc$ ").append(desc).append("cycling ");
@@ -3784,17 +3786,20 @@ public class CardFactoryUtil {
         if (keyword.startsWith("Affinity")) {
             final String[] k = keyword.split(":");
             final String t = k[1];
-            String d = "";
-            if (k.length > 2) {
-                final StringBuilder s = new StringBuilder();
-                s.append(k[2]).append("s");
-                d = s.toString();
-            }
 
-            String desc = "Artifact".equals(t) ? "artifacts" : CardType.getPluralType(t);
-            if (!d.isEmpty()) {
-                desc = d;
+            String desc;
+            if(k.length > 2) {
+                String typeText = k[2];
+                if(typeText.contains(" with "))
+                    desc = typeText.substring(typeText.indexOf(" with ") + 6);
+                else
+                    desc = typeText + "s";
             }
+            else if ("Artifact".equals(t))
+                desc = "artifacts";
+            else
+                desc = CardType.getPluralType(t);
+
             StringBuilder sb = new StringBuilder();
             sb.append("Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ AffinityX | EffectZone$ All");
             sb.append("| Description$ Affinity for ").append(desc);

--- a/forge-game/src/main/java/forge/game/keyword/KeywordWithCostAndType.java
+++ b/forge-game/src/main/java/forge/game/keyword/KeywordWithCostAndType.java
@@ -26,6 +26,8 @@ public class KeywordWithCostAndType extends KeywordInstance<KeywordWithCostAndTy
                     n[i] = "basic land";
                 } else if (n[i].equals("Land.Artifact")) {
                     n[i] = "artifact land";
+                } else if (n[i].startsWith("Card.with")) {
+                    n[i] = n[i].substring(9);
                 }
             }
 

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -112,6 +112,7 @@ public class Player extends GameEntity implements Comparable<Player> {
     private int expentThisTurn;
     private int numLibrarySearchedOwn; //The number of times this player has searched his library
     private int venturedThisTurn;
+    private int attractionsVisitedThisTurn;
     private int descended;
     private int numRingTemptedYou;
     private int devotionMod;
@@ -2589,6 +2590,7 @@ public class Player extends GameEntity implements Comparable<Player> {
         setCommitedCrimeThisTurn(0);
         diceRollsThisTurn = Lists.newArrayList();
         setExpentThisTurn(0);
+        attractionsVisitedThisTurn = 0;
 
         damageReceivedThisTurn.clear();
         planeswalkedToThisTurn.clear();
@@ -4008,11 +4010,16 @@ public class Player extends GameEntity implements Comparable<Player> {
     public void visitAttractions(int light) {
         CardCollection attractions = CardLists.filter(getCardsIn(ZoneType.Battlefield), CardPredicates.isAttractionWithLight(light));
         for (Card c : attractions) {
+            if(!c.wasVisitedThisTurn())
+                this.attractionsVisitedThisTurn++;
             c.visitAttraction(this);
         }
     }
     public void rollToVisitAttractions() {
         this.visitAttractions(RollDiceEffect.rollDiceForPlayerToVisitAttractions(this));
+    }
+    public int getAttractionsVisitedThisTurn() {
+        return this.attractionsVisitedThisTurn;
     }
 
     public int getCrankCounter() {

--- a/forge-gui/res/cardsfolder/b/black_hole.txt
+++ b/forge-gui/res/cardsfolder/b/black_hole.txt
@@ -2,5 +2,5 @@ Name:Black Hole
 ManaCost:3 B
 Types:Sorcery
 A:SP$ Destroy | ValidTgts$ Creature | TgtPrompt$ Select target creature and up to X other target creatures, where X is the number of Attractions you're visited this turn | TargetMin$ 1 | TargetMax$ X | SpellDescription$ Destroy target creature and up to X other target creatures, where X is the number of Attractions you've visited this turn.
-SVar:X:Count$Valid Attraction.VisitedThisTurn/Plus.1
+SVar:X:PlayerCountPropertyYou$AttractionsVisitedThisTurn/Plus.1
 Oracle:Destroy target creature and up to X other target creatures, where X is the number of Attractions you've visited this turn.

--- a/forge-gui/res/cardsfolder/s/soul_swindler.txt
+++ b/forge-gui/res/cardsfolder/s/soul_swindler.txt
@@ -5,5 +5,5 @@ PT:5/3
 S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Indestructible | CheckSVar$ X | Description$ As long as you've visited an Attraction this turn, CARDNAME has indestructible. (Damage and effects that say "destroy" don't destroy it.)
 T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigOpenAttraction | TriggerDescription$ When CARDNAME enters the battlefield, open an Attraction.
 SVar:TrigOpenAttraction:DB$ OpenAttraction
-SVar:X:Count$Valid Attraction.VisitedThisTurn
+SVar:X:PlayerCountPropertyYou$AttractionsVisitedThisTurn
 Oracle:As long as you've visited an Attraction this turn, Soul Swindler has indestructible. (Damage and effects that say "destroy" don't destroy it.)\nWhen Soul Swindler enters the battlefield, open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)

--- a/forge-gui/res/cardsfolder/s/squirrel_squatters.txt
+++ b/forge-gui/res/cardsfolder/s/squirrel_squatters.txt
@@ -6,6 +6,6 @@ T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefi
 SVar:TrigOpenAttraction:DB$ OpenAttraction
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ Whenever CARDNAME attacks, create a 1/1 green Squirrel creature token that's tapped and attacking for each Attraction you've visited this turn.
 SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ g_1_1_squirrel | TokenOwner$ You | TokenTapped$ True | TokenAttacking$ True
-SVar:X:Count$Valid Attraction.VisitedThisTurn
+SVar:X:PlayerCountPropertyYou$AttractionsVisitedThisTurn
 SVar:HasAttackEffect:TRUE
 Oracle:When Squirrel Squatters enters, open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)\nWhenever Squirrel Squatters attacks, create a 1/1 green Squirrel creature token that's tapped and attacking for each Attraction you've visited this turn.

--- a/forge-gui/res/cardsfolder/s/storybook_ride.txt
+++ b/forge-gui/res/cardsfolder/s/storybook_ride.txt
@@ -8,7 +8,7 @@ SVar:EffSModeContinuous:Mode$ Continuous | Affected$ Card.IsRemembered | MayPlay
 SVar:DBDelayTrig:DB$ DelayedTrigger | Mode$ Phase | RememberObjects$ Remembered | ConditionDefined$ Remembered | ConditionPresent$ Card | ConditionZone$ Exile | Phase$ End Of Turn | Execute$ TrigChangeAll | SubAbility$ DBCleanup | TriggerDescription$ At the beginning of the next end step, if any of those cards remain exiled, put them on the bottom of your library in any order.
 SVar:TrigChangeAll:DB$ ChangeZone | Defined$ DelayTriggerRememberedLKI | Origin$ Exile | Destination$ Library | LibraryPosition$ 0
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-SVar:X:Count$Valid Attraction.VisitedThisTurn
+SVar:X:PlayerCountPropertyYou$AttractionsVisitedThisTurn
 Oracle:Visit — Exile the top X cards of your library, where X is the number of Attractions you've visited this turn (including this one). You may play those cards this turn. At the beginning of the next end step, if any of those cards remain exiled, put them on the bottom of your library in any order.
 
 # --- VARIANTS ---

--- a/forge-gui/src/main/java/forge/util/OperatingSystem.java
+++ b/forge-gui/src/main/java/forge/util/OperatingSystem.java
@@ -1,9 +1,5 @@
 package forge.util;
 
-import forge.gui.FThreads;
-
-import java.awt.event.KeyEvent;
-
 public class OperatingSystem {
     private static String os = System.getProperty("os.name").toLowerCase();
 
@@ -24,10 +20,16 @@ public class OperatingSystem {
     }
 
     //utility for preventing system from sleeping
-    private static boolean preventSleep;
-    private static java.util.concurrent.ScheduledFuture<?> delayedKeepAwakeTask;
+    //private static boolean preventSleep;
+    //private static java.util.concurrent.ScheduledFuture<?> delayedKeepAwakeTask;
 
     public static void preventSystemSleep(boolean preventSleep0) {
+        //Disabling this for now. Mashing a key every 30 seconds has become a problematic solution for preventing sleep
+        //on modern devices which sometimes do handle keys like "F15".
+        //We could possibly implement the mouse-movement based solution here as an alternative: https://stackoverflow.com/a/53419439
+        //It's possible though that we don't actually need it. Supposedly modern OSes can use network traffic as
+        //an indication that the computer shouldn't put the CPU to sleep.
+        /*
         if (preventSleep == preventSleep0) { return; }
         preventSleep = preventSleep0;
 
@@ -38,9 +40,10 @@ public class OperatingSystem {
 
         if (preventSleep) { //ensure task scheduled from EDT thread
             FThreads.invokeInEdtNowOrLater(keepSystemAwake);
-        }
+        }*/
     }
 
+    /*
     private static Runnable keepSystemAwake = new Runnable() {
         @Override
         public void run() {
@@ -63,4 +66,5 @@ public class OperatingSystem {
             }
         }
     };
+     */
 }


### PR DESCRIPTION
Small handful of minor fixes and changes.

* Fix importing when the last few letters of the card name are also a set code. Closes #5941.
* Add text formatting support for "[Keyword]cycling" and "Affinity for [Keyword]". Not really perfect since the reminder text for the former still comes out as "for a [keyword] card" instead of "for a card with [keyword]", but the text formatting there hooks into several other keywords so this seems acceptable for now. Unblocks #7003.
* "Number of attractions you visited this turn" now counts attractions that have left the battlefield or have stopped being Attractions, per rule 608.2i. Doesn't close any issues because it's a niche rule in an edge case scenario involving multiple cards from a pool that are almost never used... but it's been bugging me so here it is. 
* Remove the wake lock code for desktop. Java does not offer any proper API for this functionality, so it worked by simulating a key press of "F15" every 30 seconds or so. It was written with the assumption that the F15 key would typically never have any effect, but that assumption has not held up. We could replace it with a different solution that simulates a mouse jitter, but I'd like to try removing it completely first. Desktop OSes like Windows are a bit less strict about sleep conditions than Android, and it's possible the network traffic will be enough to keep the CPU awake. If anyone objects, or if we encounter any issues caused by this in the future, I don't mind implementing an alternative. Closes #4678 and properly closes #3485.