### PR TITLE
Update gale_conduit_of_the_arcane.txt

### DIFF
--- a/forge-gui/res/cardsfolder/g/gale_conduit_of_the_arcane.txt
+++ b/forge-gui/res/cardsfolder/g/gale_conduit_of_the_arcane.txt
@@ -53,8 +53,8 @@ Types:Legendary Creature Human Wizard
 PT:4/5
 T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ DBEffect | TriggerDescription$ Whenever you cast an instant or sorcery spell, CARDNAME perpetually gains "Creatures you control get +1/+0."
 SVar:DBEffect:DB$ Effect | StaticAbilities$ PerpetualPump | Name$ Gale, Storm Conduit's Perpetual Effect | Duration$ Permanent
-SVar:PerpetualPump:Mode$ Continuous | Affected$ Card.Self | AddStaticAbility$ Pump | AffectedZone$ All | Description$ CARDNAME perpetually gains "Creatures you control get +1/+0."
-SVar:Pump:Mode$ Continuous | Affected$ Creature.YouCtrl | AddPower$ 1 | AffectedZone$ Battlefield
+SVar:PerpetualPump:Mode$ Continuous | Affected$ Card.EffectSource | AddStaticAbility$ P1Pump | AffectedZone$ All | Description$ EFFECTSOURCE perpetually gains "Creatures you control get +1/+0."
+SVar:P1Pump:Mode$ Continuous | Affected$ Creature.YouCtrl | AddPower$ 1 | Description$ Creatures you control get +1/+0.
 SVar:BuffedBy:Creature
 DeckHints:Type$Instant|Sorcery
 Oracle:Whenever you cast an instant or sorcery spell, Gale, Storm Conduit perpetually gains "Creatures you control get +1/+0."


### PR DESCRIPTION
Reproduced a report that the triggered ability on the [Gale, Storm Conduit](https://scryfall.com/card/hbg/6r/gale-storm-conduit) face didn't confer the stated bonus on 2.0.02-SNAPSHOT-01.17. 
Got it working on that version of Forge, and did my best to splice in the relevant edits: removing spurious parameters, adjusting arguments out of self-reference and adding a `Description$` where it was needed.