### PR TITLE
Image Key URLs for speed and max_speed; Functional variant tweak

### DIFF
--- a/forge-core/src/main/java/forge/card/CardFace.java
+++ b/forge-core/src/main/java/forge/card/CardFace.java
@@ -222,7 +222,7 @@ final class CardFace implements ICardFace, Cloneable {
                 else variant.replacements.addAll(0, this.replacements);
 
                 if(variant.variables == null) variant.variables = this.variables;
-                else variant.variables.putAll(this.variables);
+                else this.variables.forEach((k, v) -> variant.variables.putIfAbsent(k, v));
 
                 if(variant.nonAbilityText == null) variant.nonAbilityText = this.nonAbilityText;
                 if(variant.draftActions == null) variant.draftActions = this.draftActions;

--- a/forge-gui/res/lists/token-images.txt
+++ b/forge-gui/res/lists/token-images.txt
@@ -2499,6 +2499,8 @@ night_mid.jpg https://downloads.cardforge.org/images/tokens/night_mid.jpg
 radiation.jpg https://downloads.cardforge.org/images/tokens/radiation.jpg
 sprockets.jpg https://downloads.cardforge.org/images/tokens/sprockets.jpg
 the_ring.jpg https://downloads.cardforge.org/images/tokens/the_ring.jpg
+speed.jpg https://downloads.cardforge.org/images/tokens/speed.jpg
+max_speed.jpg https://downloads.cardforge.org/images/tokens/max_speed.jpg
 
 #Pets
 


### PR DESCRIPTION
Adds image key URLs for speed and max_speed; forgot those would be needed for them to download. Still needs the [speed tracker images](https://scryfall.com/card/tdft/14/start-your-engines!-max-speed) uploaded at some point. 

Also lets functional variants overwrite SVars in the base script by using the same name.