### PR TITLE
DA1: Updating Phila, Introducing Delphia

### DIFF
--- a/forge-gui/res/cardsfolder/d/delphia_undecided.txt
+++ b/forge-gui/res/cardsfolder/d/delphia_undecided.txt
@@ -1,0 +1,19 @@
+Name:Delphia, Undecided
+ManaCost:W U B R G
+Types:Legendary Creature Elephant
+PT:6/6
+# Developer's note: The Phyrexians won that event. However, in the interest of fun, Forge has the three possible versions of the card implemented.
+SVar:WhoWon:Number$1
+S:Mode$ ReduceCost | ValidCard$ Card.setMRD,Card.setDST,Card.set5DN,Card.setSOM | Type$ Spell | Activator$ You | Amount$ 3 | CheckSVar$ WhoWon | SVarCompare$ EQ2 | Description$ Spells you cast cost {3} less to cast if they were originally printed in the following expansions or associated commander decks, depending on who won the Unknown event on February 18th, 2023:,,,Mirran Victory — Mirrodin, Darksteel, Fifth Dawn, and Scars of Mirrodin.,,,Phyrexian Victory — Mirrodin Besieged, New Phyrexia, All Will be One, and March of the Machine.
+S:Mode$ ReduceCost | ValidCard$ Card.setMBS,Card.setNPH,Card.setONE,Card.setONC,Card.setMOM,Card.setMOC | Type$ Spell | Activator$ You | Amount$ 3 | CheckSVar$ WhoWon | SVarCompare$ EQ1 | Secondary$ True
+Oracle:(Variant: The Phyrexians won the event.)\nSpells you cast cost {3} less to cast if they were originally printed in the following expansions or associated commander decks, depending on who won the Unknown event on February 18th, 2023:\nMirran Victory — Mirrodin, Darksteel, Fifth Dawn, and Scars of Mirrodin.\nPhyrexian Victory — Mirrodin Besieged, New Phyrexia, All Will be One, and March of the Machine.
+
+# --- VARIANT: MirranWin ---
+
+Variant:MirranWin:SVar:WhoWon:Number$2
+Variant:MirranWin:Oracle:(Variant: The Mirrans won the event.)\nSpells you cast cost {3} less to cast if they were originally printed in the following expansions or associated commander decks, depending on who won the Unknown event on February 18th, 2023:\nMirran Victory — Mirrodin, Darksteel, Fifth Dawn, and Scars of Mirrodin.\nPhyrexian Victory — Mirrodin Besieged, New Phyrexia, All Will be One, and March of the Machine.
+
+# --- VARIANT: Unknown ---
+
+Variant:Unknown:SVar:WhoWon:Number$0
+Variant:Unknown:Oracle:(Variant: The outcome of the event isn't yet known.)\nSpells you cast cost {3} less to cast if they were originally printed in the following expansions or associated commander decks, depending on who won the Unknown event on February 18th, 2023:\nMirran Victory — Mirrodin, Darksteel, Fifth Dawn, and Scars of Mirrodin.\nPhyrexian Victory — Mirrodin Besieged, New Phyrexia, All Will be One, and March of the Machine.

--- a/forge-gui/res/cardsfolder/p/phila_unsealed.txt
+++ b/forge-gui/res/cardsfolder/p/phila_unsealed.txt
@@ -1,7 +1,22 @@
 Name:Phila, Unsealed
 ManaCost:4
-Types:Legendary Artifact Creature Rebel Golem
+Types:Legendary Artifact Creature Golem
 PT:4/4
-S:Mode$ CantPutCounter | ValidPlayer$ You | CounterType$ POISON | Description$ You can't get poison counters.
-A:AB$ ChangeZone | Cost$ W U B R G | ValidTgts$ Artifact | TgtPrompt$ Select target artifact | Origin$ Battlefield | Destination$ Exile | SpellDescription$ Exile target artifact.
-Oracle:You can't get poison counters.\n{W}{U}{B}{R}{G}: Exile target artifact.
+# Developer's note: The Mirrans won that event. However, in the interest of fun, Forge has the three possible versions of the card implemented.
+SVar:WhoWon:Number$1
+S:Mode$ Continuous | Affected$ Card.Self | AddType$ Rebel | AddStaticAbility$ NoCountersOnYou | AddAbility$ ABExile | CheckSVar$ WhoWon | SVarCompare$ EQ1 | Description$ If the Mirrans won the Unknown event on February 17th, 2023, CARDNAME is also a Rebel with "You can’t get poison counters," and has "{W}{U}{B}{R}{G}: Exile target artifact."
+SVar:NoCountersOnYou:Mode$ CantPutCounter | ValidPlayer$ You | CounterType$ POISON | Description$ You can't get poison counters.
+SVar:ABExile:AB$ ChangeZone | Cost$ W U B R G | ValidTgts$ Artifact | Origin$ Battlefield | Destination$ Exile | SpellDescription$ Exile target artifact.
+S:Mode$ Continuous | Affected$ Card.Self | AddType$ Phyrexian | AddStaticAbility$ PhyresisPump | CheckSVar$ WhoWon | SVarCompare$ EQ2 | Description$ If the Phyrexians won that event, NICKNAME is also a Phyrexian with "Other Phyrexians you control get +1/+1 and have toxic 1."
+SVar:PhyresisPump:Mode$ Continuous | Affected$ Phyrexian.YouCtrl+Other | AddPower$ 1 | AddToughness$ 1 | AddKeyword$ Toxic:1 | Description$ Other Phyrexians you control get +1/+1 and have toxic 1.
+Oracle:(Variant: The Mirrans won the event.)\nIf the Mirrans won the Unknown event on February 17th, 2023, Phila, Unsealed is also a Rebel with "You can’t get poison counters," and has "{W}{U}{B}{R}{G}: Exile target artifact."\nIf the Phyrexians won that event, Phila is also a Phyrexian with "Other Phyrexians you control get +1/+1 and gain Toxic 1."
+
+# --- VARIANT: PhyrexianWin ---
+
+Variant:PhyrexianWin:SVar:WhoWon:Number$2
+Variant:PhyrexianWin:Oracle:(Variant: The Phyrexians won the event.)\nIf the Mirrans won the Unknown event on February 17th, 2023, Phila, Unsealed is also a Rebel with "You can’t get poison counters," and has "{W}{U}{B}{R}{G}: Exile target artifact."\nIf the Phyrexians won that event, Phila is also a Phyrexian with "Other Phyrexians you control get +1/+1 and gain Toxic 1."
+
+# --- VARIANT: Unknown ---
+
+Variant:Unknown:SVar:WhoWon:Number$0
+Variant:Unknown:Oracle:(Variant: The outcome of the event isn't yet known.)\nIf the Mirrans won the Unknown event on February 17th, 2023, Phila, Unsealed is also a Rebel with "You can’t get poison counters," and has "{W}{U}{B}{R}{G}: Exile target artifact."\nIf the Phyrexians won that event, Phila is also a Phyrexian with "Other Phyrexians you control get +1/+1 and gain Toxic 1."

--- a/forge-gui/res/editions/Unknown Event.txt
+++ b/forge-gui/res/editions/Unknown Event.txt
@@ -47,7 +47,9 @@ CG02b C That's No Moonmist @
 CR02 C Fear of Going 0-2 Drop @
 CW02 C Unclaimed Cat @
 MW02 M You, Magic Playtester @
-MZ02 M Delphia, Undecided @
+MZ02a M Delphia, Undecided @
+MZ02b M Delphia, Undecided @ $MirranWin
+MZ02c M Delphia, Undecided @ $Unknown
 PLA002 C Pin Trading @
 RA02a R Goblin Savant @
 RA02b R Huge Truck @
@@ -358,8 +360,10 @@ PLA019 C Shrinking Plane @
 PLA020 C Windmill Farm @
 PLA023 C Royal Booster @
 PLA024 C Bicycle Rack @
-RZ24 R The Dogronmaster @
-MA30 M Phila, Unsealed @
+RZ24 R The Dogronmaster @ 
+MA30a M Phila, Unsealed @
+MA30b M Phila, Unsealed @ $PhyrexianWin
+MA30c M Phila, Unsealed @ $Unknown
 RA31 R The Rebellious Intelligence @
 RZ34 R The Duke of Midrange @
 RW35 R The Asker of More Mana @

--- a/forge-gui/res/editions/Unknown Event.txt
+++ b/forge-gui/res/editions/Unknown Event.txt
@@ -47,7 +47,7 @@ CG02b C That's No Moonmist @
 CR02 C Fear of Going 0-2 Drop @
 CW02 C Unclaimed Cat @
 MW02 M You, Magic Playtester @
-MZ02a M Delphia, Undecided @
+MZ02 M Delphia, Undecided @
 MZ02b M Delphia, Undecided @ $MirranWin
 MZ02c M Delphia, Undecided @ $Unknown
 PLA002 C Pin Trading @
@@ -361,7 +361,7 @@ PLA020 C Windmill Farm @
 PLA023 C Royal Booster @
 PLA024 C Bicycle Rack @
 RZ24 R The Dogronmaster @ 
-MA30a M Phila, Unsealed @
+MA30 M Phila, Unsealed @
 MA30b M Phila, Unsealed @ $PhyrexianWin
 MA30c M Phila, Unsealed @ $Unknown
 RA31 R The Rebellious Intelligence @


### PR DESCRIPTION
Couldn't help feel that our implementation of [Phila, Unsealed](https://scryfall.com/card/da1/MA30/phila-unsealed) could hew a bit closer to the card as written, while allowing access to the possible versions of the card (like the Arena buffs/debuffs). So I iterated the script structure until arriving at a hopefully reasonable way of doing so, with support from this [fix to functional variants](https://github.com/Card-Forge/forge/pull/7019). While I was at it, I did [Delphia, Undecided](https://scryfall.com/card/da1/MZ02/delphia-undecided) as well, since it's a conceptually similar card. Except for some issues with card display outside of games, shared with other functional variant scripts, these work as expected.