### PR TITLE
FIC: 4 cards

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/cloud_ex_soldier.txt
+++ b/forge-gui/res/cardsfolder/upcoming/cloud_ex_soldier.txt
@@ -1,0 +1,18 @@
+Name:Cloud, Ex-SOLDIER
+ManaCost:2 R G W
+Types:Legendary Creature Human Soldier Mercenary
+PT:4/4
+K:Haste
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | TriggerZones$ Battlefield | Execute$ TrigAttach | TriggerDescription$ Whenever NICKNAME enters, attach up to one target Equipment you control to it.
+SVar:TrigAttach:DB$ Attach | Defined$ Self | Object$ Targeted | ValidTgts$ Equipment.YouCtrl | TgtPrompt$ Select up to one target Equipment you control | TargetMin$ 0 | TargetMax$ 1
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ Whenever NICKNAME attacks, draw a card for each equipped attacking creature you control. Then if NICKNAME has power 7 or greater, create two Treasure tokens.
+SVar:TrigDraw:DB$ Draw | NumCards$ X | SubAbility$ DBTreasure
+SVar:DBTreasure:DB$ Token | ConditionDefined$ Self | ConditionPresent$ Creature.powerGE7 | TokenAmount$ 2 | TokenScript$ c_a_treasure_sac
+SVar:X:Count$Valid Creature.attacking+equipped
+S:Mode$ Continuous | Affected$ Creature.YouCtrl+withoutDefender | AddSVar$ EqMe | Secondary$ True
+SVar:EqMe:SVar:EquipMe:Once
+SVar:HasAttackEffect:TRUE
+SVar:EquipMe:Once
+DeckHas:Ability$Token
+DeckNeeds:Type$Equipment
+Oracle:Haste\nWhen Cloud enters, attach up to one target Equipment you control to it.\nWhenever Cloud attacks, draw a card for each equipped attacking creature you control. Then if Cloud has power 7 or greater, create two Treasure tokens.

--- a/forge-gui/res/cardsfolder/upcoming/cloud_ex_soldier.txt
+++ b/forge-gui/res/cardsfolder/upcoming/cloud_ex_soldier.txt
@@ -9,7 +9,7 @@ T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$
 SVar:TrigDraw:DB$ Draw | NumCards$ X | SubAbility$ DBTreasure
 SVar:DBTreasure:DB$ Token | ConditionDefined$ Self | ConditionPresent$ Creature.powerGE7 | TokenAmount$ 2 | TokenScript$ c_a_treasure_sac
 SVar:X:Count$Valid Creature.attacking+equipped
-S:Mode$ Continuous | Affected$ Creature.YouCtrl+withoutDefender | AddSVar$ EqMe | Secondary$ True
+S:Mode$ Continuous | Affected$ Creature.Other+YouCtrl+withoutDefender | AddSVar$ EqMe | Secondary$ True
 SVar:EqMe:SVar:EquipMe:Once
 SVar:HasAttackEffect:TRUE
 SVar:EquipMe:Once

--- a/forge-gui/res/cardsfolder/upcoming/terra_herald_of_hope.txt
+++ b/forge-gui/res/cardsfolder/upcoming/terra_herald_of_hope.txt
@@ -1,0 +1,13 @@
+Name:Terra, Herald of Hope
+ManaCost:R W B
+Types:Legendary Creature Human Wizard Warrior
+PT:3/3
+T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigMill | TriggerDescription$ Trance — At the beginning of combat on your turn, mill two cards. NICKNAME gains flying until end of turn.
+SVar:TrigMill:DB$ Mill | NumCards$ 2 | Defined$ You | SubAbility$ DBPump
+SVar:DBPump:DB$ Pump | Defined$ Self | KW$ Flying
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigPayCost | CombatDamage$ True | TriggerDescription$ Whenever NICKNAME deals combat damage to a player, you may pay {2}. When you do, return target creature card with power 3 or less from your graveyard to the battlefield tapped.
+SVar:TrigPayCost:AB$ ImmediateTrigger | Cost$ 2 | Execute$ TrigChange | TriggerDescription$ When you do, return target creature card with power 3 or less from your graveyard to the battlefield tapped.
+SVar:TrigChange:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | ValidTgts$ Creature.YouOwn+powerLE3 | Tapped$ True | TgtPrompt$ Select target creature card with power 3 or less in your graveyard
+DeckHas:Ability$Mill|Graveyard
+DeckHints:Ability$Mill|Discard|Sacrifice
+Oracle:Trance — At the beginning of combat on your turn, mill two cards. Terra gains flying until end of turn.\nWhenever Terra deals combat damage to a player, you may pay {2}. When you do, return target creature card with power 3 or less from your graveyard to the battlefield tapped.

--- a/forge-gui/res/cardsfolder/upcoming/tidus_yunas_guardian.txt
+++ b/forge-gui/res/cardsfolder/upcoming/tidus_yunas_guardian.txt
@@ -1,0 +1,12 @@
+Name:Tidus, Yuna's Guardian
+ManaCost:G W U
+Types:Legendary Creature Human Warrior
+PT:3/3
+T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigMoveCounter | TriggerDescription$ At the beginning of combat on your turn, you may move a counter from target creature you control onto a second target creature you control.
+SVar:TrigMoveCounter:DB$ MoveCounter | ValidTgts$ Creature.YouCtrl | TargetMin$ 2 | TargetMax$ 2 | TgtPrompt$ Select two target creatures you control | CounterType$ Any
+T:Mode$ DamageDoneOnce | CombatDamage$ True | ValidSource$ Creature.YouCtrl+HasCounters | TriggerZones$ Battlefield | ValidTarget$ Player | ResolvedLimit$ 1 | OptionalDecider$ You | Execute$ TrigDraw | TriggerDescription$ Cheer — Whenever one or more creatures you control with counters on them deal combat damage to a player, you may draw a card and proliferate. Do this only once each turn.
+SVar:TrigDraw:DB$ Draw | SubAbility$ DBProliferate
+SVar:DBProliferate:DB$ Proliferate
+DeckHas:Ability$Proliferate
+DeckHints:Ability$Counters
+Oracle:At the beginning of combat on your turn, you may move a counter from target creature you control onto a second target creature you control.\nCheer — Whenever one or more creatures you control with counters on them deal combat damage to a player, you may draw a card and proliferate. Do this only once each turn.

--- a/forge-gui/res/cardsfolder/upcoming/yshtola_nights_blessed.txt
+++ b/forge-gui/res/cardsfolder/upcoming/yshtola_nights_blessed.txt
@@ -1,0 +1,14 @@
+Name:Y'shtola, Night's Blessed
+ManaCost:1 W U B
+Types:Legendary Creature Cat Warlock
+PT:2/4
+K:Vigilance
+T:Mode$ Phase | Phase$ End of Turn | TriggerZones$ Battlefield | CheckSVar$ X | SVarCompare$ GE4 | Execute$ TrigDraw | TriggerDescription$ At the beginning of your end step, if a player lost 4 or more life this turn, you draw a card.
+SVar:TrigDraw:DB$ Draw
+SVar:X:PlayerCountDefinedRegistered$HighestLifeLostThisTurn
+T:Mode$ SpellCast | ValidCard$ Card.nonCreature+cmcGE3 | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDealDamage | TriggerDescription$ Whenever you cast a noncreature spell with mana value 3 or greater, NICKNAME deals 2 damage to each opponent and you gain 2 life.
+SVar:TrigDealDamage:DB$ DamageAll | ValidPlayers$ Opponent | NumDmg$ 2 | SubAbility$ DBGainLife
+SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 2
+SVar:BuffedBy:Card.nonCreature+cmcGE3
+DeckHas:Ability$LifeGain
+Oracle:Vigilance\nAt the beginning of each end step, if a player lost 4 or more life this turn, you draw a card.\nWhenever you cast a noncreature spell with mana value 3 or greater, Y'shtola deals 2 damage to each opponent and you gain 2 life.

--- a/forge-gui/res/cardsfolder/upcoming/yshtola_nights_blessed.txt
+++ b/forge-gui/res/cardsfolder/upcoming/yshtola_nights_blessed.txt
@@ -3,7 +3,7 @@ ManaCost:1 W U B
 Types:Legendary Creature Cat Warlock
 PT:2/4
 K:Vigilance
-T:Mode$ Phase | Phase$ End of Turn | TriggerZones$ Battlefield | CheckSVar$ X | SVarCompare$ GE4 | Execute$ TrigDraw | TriggerDescription$ At the beginning of your end step, if a player lost 4 or more life this turn, you draw a card.
+T:Mode$ Phase | Phase$ End of Turn | TriggerZones$ Battlefield | CheckSVar$ X | SVarCompare$ GE4 | Execute$ TrigDraw | TriggerDescription$ At the beginning of each end step, if a player lost 4 or more life this turn, you draw a card.
 SVar:TrigDraw:DB$ Draw
 SVar:X:PlayerCountDefinedRegistered$HighestLifeLostThisTurn
 T:Mode$ SpellCast | ValidCard$ Card.nonCreature+cmcGE3 | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDealDamage | TriggerDescription$ Whenever you cast a noncreature spell with mana value 3 or greater, NICKNAME deals 2 damage to each opponent and you gain 2 life.


### PR DESCRIPTION
Scripts for the commanders of the relevant Final Fantasy supplement [as revealed on IGN](https://www.ign.com/articles/magic-the-gathering-final-fantasy-commander-deck-reveal-spoilers), all tested to satisfaction:
- Cloud, Ex-SOLDIER
- Terra, Herald of Hope
- Tidus, Yuna's Guardian
- Y'shtola, Night's Blessed

Based on [Brass Knuckles](https://github.com/Card-Forge/forge/blob/master/forge-gui/res/cardsfolder/b/brass_knuckles.txt), it felt opportune to add a hidden static ability to Cloud so the AI knows to equip its creatures. I restricted it to nondefenders, though I'm unsure if there should be a power cutoff.