### PR TITLE
Fixing The Mindskinner and cards with similar effects

### DIFF
--- a/forge-gui/res/cardsfolder/a/angel_of_suffering.txt
+++ b/forge-gui/res/cardsfolder/a/angel_of_suffering.txt
@@ -3,7 +3,7 @@ ManaCost:3 B B
 Types:Creature Nightmare Angel
 PT:5/3
 K:Flying
-R:Event$ DamageDone | ActiveZones$ Battlefield | ValidTarget$ You | ReplaceWith$ DoubleMill | PreventionEffect$ True | Description$ If damage would be dealt to you, prevent that damage and mill twice that many cards.
+R:Event$ DamageDone | ActiveZones$ Battlefield | ValidTarget$ You | ReplaceWith$ DoubleMill | AlwaysReplace$ True | PreventionEffect$ True | Description$ If damage would be dealt to you, prevent that damage and mill twice that many cards.
 SVar:DoubleMill:DB$ Mill | Defined$ ReplacedTarget | NumCards$ X
 SVar:X:ReplaceCount$DamageAmount/Twice
 DeckHas:Ability$Mill

--- a/forge-gui/res/cardsfolder/t/the_mindskinner.txt
+++ b/forge-gui/res/cardsfolder/t/the_mindskinner.txt
@@ -3,7 +3,7 @@ ManaCost:U U U
 Types:Legendary Enchantment Creature Nightmare
 PT:10/1
 S:Mode$ CantBlockBy | ValidAttacker$ Creature.Self | Description$ CARDNAME can't be blocked.
-R:Event$ DamageDone | ActiveZones$ Battlefield | ValidSource$ Card.YouCtrl,Emblem.YouCtrl | ValidTarget$ Opponent | ReplaceWith$ Mill | PreventionEffect$ True | ExecuteMode$ PerSource | Description$ If a source you control would deal damage to an opponent, prevent that damage and each opponent mills that many cards.
+R:Event$ DamageDone | ActiveZones$ Battlefield | ValidSource$ Card.YouCtrl,Emblem.YouCtrl | ValidTarget$ Opponent | ReplaceWith$ Mill | AlwaysReplace$ True | PreventionEffect$ True | ExecuteMode$ PerSource | Description$ If a source you control would deal damage to an opponent, prevent that damage and each opponent mills that many cards.
 SVar:Mill:DB$ Mill | Defined$ Opponent | NumCards$ X
 SVar:X:ReplaceCount$DamageAmount
 Oracle:The Mindskinner can't be blocked.\nIf a source you control would deal damage to an opponent, prevent that damage and each opponent mills that many cards.

--- a/forge-gui/res/cardsfolder/w/weeping_angel.txt
+++ b/forge-gui/res/cardsfolder/w/weeping_angel.txt
@@ -5,7 +5,7 @@ PT:2/2
 K:Flash
 K:First Strike
 K:Vigilance
-R:Event$ DamageDone | ActiveZones$ Battlefield | ValidSource$ Card.Self | ValidTarget$ Creature | IsCombat$ True | ReplaceWith$ ShuffleCreature | PreventionEffect$ True | Description$ If CARDNAME would deal combat damage to a creature, prevent that damage and that creature's owner shuffles it into their library.
+R:Event$ DamageDone | ActiveZones$ Battlefield | ValidSource$ Card.Self | ValidTarget$ Creature | IsCombat$ True | ReplaceWith$ ShuffleCreature | AlwaysReplace$ True | PreventionEffect$ True | Description$ If CARDNAME would deal combat damage to a creature, prevent that damage and that creature's owner shuffles it into their library.
 SVar:ShuffleCreature:DB$ ChangeZone | Defined$ ReplacedTarget | Origin$ Battlefield | Destination$ Library | Shuffle$ True
 T:Mode$ SpellCast | ValidCard$ Creature | ValidActivatingPlayer$ Opponent | TriggerZones$ Battlefield | Execute$ TrigAnimate | TriggerDescription$ Whenever an opponent casts a creature spell, CARDNAME isn't a creature until end of turn.
 SVar:TrigAnimate:DB$ Animate | RemoveTypes$ Creature


### PR DESCRIPTION
It came to my attention that [The Mindskinner](https://scryfall.com/card/dsk/66/the-mindskinner)'s damage prevention effect wasn't interacting properly with [Questing Beast](https://scryfall.com/card/eld/171/questing-beast)'s "damage can't be prevented" effect: the damage **wasn't** prevented while the milling **didn't** happen. 
Per [CR 615.12](https://mtg.wiki/page/Prevention_effect#Rules) and the last ruling on [Angel of Suffering](https://scryfall.com/card/snc/67/angel-of-suffering), the damage **is** prevented and the milling **should** still happen. To resolve this, an `AlwaysReplace$ True` flag was added to the `R:` lines of three cards that were missing it.