### PR TITLE
Delegate rendering of cards in deck viewer to piles all the time

### DIFF
--- a/forge-gui-mobile/src/forge/itemmanager/views/ImageView.java
+++ b/forge-gui-mobile/src/forge/itemmanager/views/ImageView.java
@@ -869,33 +869,18 @@ public class ImageView<T extends InventoryItem> extends ItemView<T> {
                 if (isCollapsed) {
                     return;
                 }
-
-                float visibleLeft = getScrollLeft();
-                float visibleRight = visibleLeft + getWidth();
-                for (Pile pile : piles) {
-                    if (pile.getRight() < visibleLeft) {
-                        continue;
-                    }
-                    if (pile.getLeft() >= visibleRight) {
-                        break;
-                    }
-                    pile.draw(g);
-                }
-                return;
             }
 
-            final float visibleTop = getScrollValue();
-            final float visibleBottom = visibleTop + getScroller().getHeight();
-            for (ItemInfo itemInfo : items) {
-                if (itemInfo == null)
-                    continue;
-                if (itemInfo.getBottom() < visibleTop) {
+            float visibleLeft = getScrollLeft();
+            float visibleRight = visibleLeft + getWidth();
+            for (Pile pile : piles) {
+                if (pile.getRight() < visibleLeft) {
                     continue;
                 }
-                if (itemInfo.getTop() >= visibleBottom) {
+                if (pile.getLeft() >= visibleRight) {
                     break;
                 }
-                itemInfo.draw(g);
+                pile.draw(g);
             }
         }
 


### PR DESCRIPTION
See the thread "Mobile deck editor doesn't show cards unless you scroll" on the discord server