### PR TITLE
YDFT: 12 cards

### DIFF
--- a/forge-game/src/main/java/forge/game/ForgeScript.java
+++ b/forge-game/src/main/java/forge/game/ForgeScript.java
@@ -129,6 +129,13 @@ public class ForgeScript {
                 }
             }
             return false;
+        } else if (property.equals("hasActivatedAbilityWithExhaust")) {
+            for (final SpellAbility sa : cardState.getSpellAbilities()) {
+                if (sa.isActivatedAbility() && sa.hasParam("Exhaust")) {
+                    return true;
+                }
+            }
+            return false;
         } else if (property.equals("hasActivatedAbility")) {
             for (final SpellAbility sa : cardState.getSpellAbilities()) {
                 if (sa.isActivatedAbility()) {

--- a/forge-game/src/main/java/forge/game/ability/effects/ChooseCardNameEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChooseCardNameEffect.java
@@ -112,8 +112,7 @@ public class ChooseCardNameEffect extends SpellAbilityEffect {
                 }
                 if (randomChoice) {
                     chosen = StaticData.instance().getCommonCards().streamAllFaces()
-                            .filter(cpp).collect(StreamUtil.random()).get()
-                            .getName();
+                            .filter(cpp).collect(StreamUtil.random()).map(ICardFace::getName).orElse("");
                 } else {
                     chosen = p.getController().chooseCardName(sa, cpp, valid, message);
                 }

--- a/forge-gui/res/cardsfolder/a/agent_of_masks.txt
+++ b/forge-gui/res/cardsfolder/a/agent_of_masks.txt
@@ -7,4 +7,5 @@ SVar:TrigDrain:DB$ LoseLife | Defined$ Player.Opponent | LifeAmount$ 1 | SubAbil
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ AFLifeLost
 SVar:AFLifeLost:Number$0
 # AFLifeLost will be set by LoseLife
+DeckHas:Ability$LifeGain
 Oracle:At the beginning of your upkeep, each opponent loses 1 life. You gain life equal to the life lost this way.

--- a/forge-gui/res/cardsfolder/b/banquet_guests.txt
+++ b/forge-gui/res/cardsfolder/b/banquet_guests.txt
@@ -10,4 +10,4 @@ SVar:Y:SVar$X/Twice
 A:AB$ Pump | Cost$ 2 Sac<1/Food> | Defined$ Self | KW$ Indestructible | SpellDescription$ CARDNAME gains indestructible until end of turn.
 DeckHints:Type$Food
 DeckHas:Ability$Counters|Sacrifice
-Oracle:Affinity for Food (This spell costs {1} less to cast for each Food you control.)\nTrample\nBanquet Guests enters with twice X +1/+1 counters on it.\n{2}, Sacrifice a Food: Banquet Guests gains indestructible until end of turn.
+Oracle:Affinity for Foods (This spell costs {1} less to cast for each Food you control.)\nTrample\nBanquet Guests enters with twice X +1/+1 counters on it.\n{2}, Sacrifice a Food: Banquet Guests gains indestructible until end of turn.

--- a/forge-gui/res/cardsfolder/b/blood_artist.txt
+++ b/forge-gui/res/cardsfolder/b/blood_artist.txt
@@ -5,4 +5,5 @@ PT:0/1
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self,Creature.Other | TriggerZones$ Battlefield | Execute$ TrigLoseLife | TriggerDescription$ Whenever CARDNAME or another creature dies, target player loses 1 life and you gain 1 life.
 SVar:TrigLoseLife:DB$ LoseLife | ValidTgts$ Player | TgtPrompt$ Choose a player to lose life | LifeAmount$ 1 | SubAbility$ DBGainLife
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1
+DeckHas:Ability$LifeGain
 Oracle:Whenever Blood Artist or another creature dies, target player loses 1 life and you gain 1 life.

--- a/forge-gui/res/cardsfolder/e/euru_acorn_scrounger.txt
+++ b/forge-gui/res/cardsfolder/e/euru_acorn_scrounger.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature Squirrel Soldier
 PT:3/3
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigImmediateTrig | TriggerDescription$ When CARDNAME enters, you may forage. When you do, conjure a card named Chitterspitter onto the battlefield.
 SVar:TrigImmediateTrig:AB$ ImmediateTrigger | Cost$ Forage | Execute$ TrigConjure | SpellDescription$ When you do, conjure a card named Chitterspitter onto the battlefield.
-SVar:TrigConjure:DB$ MakeCard | Name$ Chitterspitter | TokenCard$ True | Zone$ Battlefield
+SVar:TrigConjure:DB$ MakeCard | Name$ Chitterspitter | Conjure$ True | Zone$ Battlefield
 T:Mode$ DamageDoneOnce | ValidSource$ Squirrel.YouCtrl | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigPutCounterAll | TriggerZones$ Battlefield | TriggerDescription$ Whenever one or more Squirrels you control deal combat damage to a player, you may sacrifice a token. If you do, put an acorn counter on each permanent you control named Chitterspitter.
 SVar:TrigPutCounterAll:AB$ PutCounterAll | Cost$ Sac<1/Permanent.token/token> | ValidCards$ Permanent.YouCtrl+namedChitterspitter | CounterType$ ACORN | CounterNum$ 1
 Oracle:When Euru, Acorn Scrounger enters, you may forage. When you do, conjure a card named Chitterspitter onto the battlefield.\nWhenever one or more Squirrels you control deal combat damage to a player, you may sacrifice a token. If you do, put an acorn counter on each permanent you control named Chitterspitter.

--- a/forge-gui/res/cardsfolder/f/fallaji_antiquarian.txt
+++ b/forge-gui/res/cardsfolder/f/fallaji_antiquarian.txt
@@ -5,7 +5,7 @@ PT:2/4
 K:Haste
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigConjure | TriggerDescription$ When CARDNAME enters, conjure a duplicate of another target nontoken creature or artifact you control into your graveyard. The duplicate perpetually gains unearth {1}{R}.
 SVar:TrigConjure:DB$ MakeCard | Conjure$ True | TgtPrompt$ Select another target nontoken creature or artifact you control | DefinedName$ Targeted | ValidTgts$ Creature.YouCtrl+Other+!token,Artifact.YouCtrl+Other+!token | Zone$ Graveyard | RememberMade$ True | SubAbility$ DBPump
-SVar:DBPump:DB$ Pump | Defined$ Remembered | PumpZone$ Graveyard | KW$ Unearth:2 R | Duration$ Perpetual | SubAbility$ DBCleanup
+SVar:DBPump:DB$ Pump | Defined$ Remembered | PumpZone$ Graveyard | KW$ Unearth:1 R | Duration$ Perpetual | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 DeckHas:Ability$Graveyard
 DeckHints:Type$Artifact

--- a/forge-gui/res/cardsfolder/f/fear_of_change.txt
+++ b/forge-gui/res/cardsfolder/f/fear_of_change.txt
@@ -6,7 +6,7 @@ T:Mode$ ChangesZone | ValidCard$ Card.Self | Destination$ Battlefield | Execute$
 T:Mode$ ChangesZone | ValidCard$ Card.Self | Destination$ Graveyard | Execute$ TrigExile | Secondary$ True | TriggerDescription$ When this creatures enters or dies, exile another creature you control. If you do, conjure a duplicate of a random creature card with mana value X onto the battlefield, where X is 2 plus the exiled creature's mana value.
 SVar:TrigExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ChangeType$ Creature.YouCtrl+Other | Hidden$ True | ChangeNum$ 1 | RememberChanged$ True | SelectPrompt$ Select another creature you control | SubAbility$ DBNameCard
 SVar:DBNameCard:DB$ NameCard | AtRandom$ True | ValidCards$ Creature.cmcEQX | ConditionDefined$ Remembered | ConditionPresent$ Card | ConditionCompare$ EQ1 | SubAbility$ DBConjure
-SVar:DBConjure:DB$ MakeCard | Name$ ChosenName | Conjure$ True | AtRandom$ True | Zone$ Battlefield | SubAbility$ DBCleanup
+SVar:DBConjure:DB$ MakeCard | Name$ ChosenName | Conjure$ True | Zone$ Battlefield | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Remembered$CardManaCost/Plus.2
 Oracle:When this creatures enters or dies, exile another creature you control. If you do, conjure a duplicate of a random creature card with mana value X onto the battlefield, where X is 2 plus the exiled creature's mana value.

--- a/forge-gui/res/cardsfolder/q/quicksilver_lapidary.txt
+++ b/forge-gui/res/cardsfolder/q/quicksilver_lapidary.txt
@@ -3,7 +3,7 @@ ManaCost:U R
 Types:Creature Phyrexian Artificer
 PT:1/1
 T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigConjure | TriggerDescription$ When CARDNAME enters, conjure a card named Mox Opal into your hand.
-SVar:TrigConjure:DB$ MakeCard | Name$ Mox Opal | Zone$ Hand
+SVar:TrigConjure:DB$ MakeCard | Name$ Mox Opal | Conjure$ True | Zone$ Hand
 DeckHas:Type$Artifact
 DeckHints:Type$Artifact
 Oracle:When Quicksilver Lapidary enters, conjure a card named Mox Opal into your hand.

--- a/forge-gui/res/cardsfolder/rebalanced/a-blood_artist.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-blood_artist.txt
@@ -5,4 +5,5 @@ PT:0/1
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self,Creature.Other | TriggerZones$ Battlefield | Execute$ TrigLoseLife | TriggerDescription$ Whenever CARDNAME or another creature dies, target opponent loses 1 life and you gain 1 life.
 SVar:TrigLoseLife:DB$ LoseLife | ValidTgts$ Opponent | TgtPrompt$ Choose an opponent to lose life | LifeAmount$ 1 | SubAbility$ DBGainLife
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1
+DeckHas:Ability$LifeGain
 Oracle:Whenever Blood Artist or another creature dies, target opponent loses 1 life and you gain 1 life.

--- a/forge-gui/res/cardsfolder/u/underworld_sentinel.txt
+++ b/forge-gui/res/cardsfolder/u/underworld_sentinel.txt
@@ -5,5 +5,5 @@ PT:4/5
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigExile | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME attacks, exile target creature card from your graveyard.
 SVar:TrigExile:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | TgtPrompt$ Choose target creature card in your graveyard | ValidTgts$ Creature.YouCtrl
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigReturn | TriggerDescription$ When CARDNAME dies, put all cards exiled with it onto the battlefield.
-SVar:TrigReturn:DB$ ChangeZoneAll | ChangeType$ Card.ExiledWithSource | Origin$ Exile | Destination$ Battlefield
+SVar:TrigReturn:DB$ ChangeZoneAll | ChangeType$ Card.ExiledWithSource | Origin$ Exile | Destination$ Battlefield | GainControl$ True
 Oracle:Whenever Underworld Sentinel attacks, exile target creature card from your graveyard.\nWhen Underworld Sentinel dies, put all cards exiled with it onto the battlefield.

--- a/forge-gui/res/cardsfolder/upcoming/fuel_tank_feaster.txt
+++ b/forge-gui/res/cardsfolder/upcoming/fuel_tank_feaster.txt
@@ -1,0 +1,12 @@
+Name:Fuel Tank Feaster
+ManaCost:1 G
+Types:Creature Ooze Druid
+PT:1/3
+T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigRandom | TriggerDescription$ At the beginning of your first main phase, a random creature card with the greatest mana value among creature cards in your hand perpetually gains "This spell costs {1} less to cast."
+SVar:TrigRandom:DB$ ChooseCard | Defined$ You | Choices$ Creature.YouOwn+cmcEQX | ChoiceZone$ Hand | AtRandom$ True | Amount$ 1 | SubAbility$ DBAnimate
+SVar:DBAnimate:DB$ Animate | Defined$ ChosenCard | staticAbilities$ ReduceCost | Duration$ Perpetual | SubAbility$ DBCleanup
+SVar:ReduceCost:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 1 | EffectZone$ All | Description$ This spell costs {1} less to cast.
+SVar:DBCleanup:DB$ Cleanup | ClearChosenCard$ True
+SVar:X:Count$ValidHand Creature.YouOwn$GreatestCMC
+A:AB$ Mana | Cost$ T | Produced$ Any | Amount$ 1 | SpellDescription$ Add one mana of any color.
+Oracle:At the beginning of your first main phase, a random creature card with the greatest mana value among creature cards in your hand perpetually gains "This spell costs {1} less to cast."\n{T}: Add one mana of any color.

--- a/forge-gui/res/cardsfolder/upcoming/great_fang_chroniclers.txt
+++ b/forge-gui/res/cardsfolder/upcoming/great_fang_chroniclers.txt
@@ -1,0 +1,8 @@
+Name:Great Fang Chroniclers
+ManaCost:1 G
+Types:Creature Ape Druid
+PT:2/2
+K:Double team
+A:AB$ Animate | Cost$ 3 G | Defined$ Self | Duration$ Permanent | RemoveThisAbility$ True | SorcerySpeed$ True | SubAbility$ DBMakeCard | SpellDescription$ Conjure a card named Muraganda Petroglyphs onto the battlefield, then this creature loses this ability. Activate only as a sorcery.
+SVar:DBMakeCard:DB$ MakeCard | Conjure$ True | Name$ Muraganda Petroglyphs | Zone$ Battlefield
+Oracle:Double team\n{3}{G}: Conjure a card named Muraganda Petroglyphs onto the battlefield, then this creature loses this ability. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/upcoming/highway_reaver.txt
+++ b/forge-gui/res/cardsfolder/upcoming/highway_reaver.txt
@@ -1,0 +1,13 @@
+Name:Highway Reaver
+ManaCost:2 B R
+Types:Creature Scorpion Dragon
+PT:4/4
+K:Flying
+K:Start your engines
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigAnimate | TriggerDescription$ Whenever this creature enters or attacks, target creature card in your graveyard without unearth perpetually gains unearth. The unearth cost is equal to its mana cost.
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigAnimate | TriggerZones$ Battlefield | Secondary$ True | TriggerDescription$ Whenever this creature enters or attacks, target creature card in your graveyard without unearth perpetually gains unearth. The unearth cost is equal to its mana cost.
+SVar:TrigAnimate:DB$ Animate | ValidTgts$ Creature.YouCtrl+withoutUnearth | TgtPrompt$ Select target creature card in your graveyard without unearth | TgtZone$ Graveyard | Keywords$ Unearth:CardManaCost | Duration$ Perpetual
+S:Mode$ Continuous | Affected$ Card.Self | Condition$ MaxSpeed | AddStaticAbility$ FreebieReaving | AddSVar$ ReavingX | Description$ Max speed — You may pay {0} rather than pay the unearth cost of the first unearth ability you activate each turn.
+SVar:FreebieReaving:Mode$ AlternativeCost | ValidSA$ Activated.Unearth | ValidPlayer$ You | Cost$ 0 | CheckSVar$ ReavingX | SVarCompare$ LT1 | AffectedZone$ Graveyard | EffectZone$ Graveyard | Secondary$ True | Description$ Max speed — You may pay {0} rather than pay the unearth cost of the first unearth ability you activate each turn.
+SVar:ReavingX:Count$ThisTurnActivated_Activated.Unearth+YouCtrl
+Oracle:Flying\nStart your engines!\nWhenever this creature enters or attacks, target creature card in your graveyard without unearth perpetually gains unearth. The unearth cost is equal to its mana cost.\nMax speed — You may pay {0} rather than pay the unearth cost of the first unearth ability you activate each turn.

--- a/forge-gui/res/cardsfolder/upcoming/kari_zev_crew_of_two.txt
+++ b/forge-gui/res/cardsfolder/upcoming/kari_zev_crew_of_two.txt
@@ -1,0 +1,12 @@
+Name:Kari Zev, Crew of Two
+ManaCost:2 R R
+Types:Legendary Creature Human Pirate
+PT:3/3
+K:Menace
+K:Haste
+T:Mode$ Attacks | ValidCard$ Card.Self | IsPresent$ Monkey.Legendary+YouCtrl | PresentCompare$ EQ0 | NoResolvingCheck$ True | TriggerZones$ Battlefield | Execute$ TrigConjure | TriggerDescription$ Whenever NICKNAME attacks while you don't control a legendary Monkey, conjure a card named Ragavan, Nimble Pilferer onto the battlefield tapped and attacking. At the beginning of the next end step, if that card is on the battlefield, return it to its owner's hand.
+SVar:TrigConjure:DB$ MakeCard | Conjure$ True | Name$ Ragavan, Nimble Pilferer | Zone$ Battlefield | Tapped$ True | Attacking$ True | RememberMade$ True | SubAbility$ DBDelayTrig
+SVar:DBDelayTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ TrigReturn | ConditionDefined$ RememberedLKI | ConditionPresent$ Card | ConditionZone$ Battlefield | RememberObjects$ RememberedLKI | SubAbility$ DBCleanup | TriggerDescription$ At the beginning of the next end step, if that card is on the battlefield, return it to its owner's hand.
+SVar:TrigReturn:DB$ ChangeZone | Defined$ DelayTriggerRememberedLKI | Origin$ Battlefield | Destination$ Hand
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:Menace, haste\nWhenever Kari Zev attacks while you don't control a legendary Monkey, conjure a card named Ragavan, Nimble Pilferer onto the battlefield tapped and attacking. At the beginning of the next end step, if that card is on the battlefield, return it to its owner's hand.

--- a/forge-gui/res/cardsfolder/upcoming/kari_zev_crew_of_two.txt
+++ b/forge-gui/res/cardsfolder/upcoming/kari_zev_crew_of_two.txt
@@ -5,7 +5,8 @@ PT:3/3
 K:Menace
 K:Haste
 T:Mode$ Attacks | ValidCard$ Card.Self | IsPresent$ Monkey.Legendary+YouCtrl | PresentCompare$ EQ0 | NoResolvingCheck$ True | TriggerZones$ Battlefield | Execute$ TrigConjure | TriggerDescription$ Whenever NICKNAME attacks while you don't control a legendary Monkey, conjure a card named Ragavan, Nimble Pilferer onto the battlefield tapped and attacking. At the beginning of the next end step, if that card is on the battlefield, return it to its owner's hand.
-SVar:TrigConjure:DB$ MakeCard | Conjure$ True | Name$ Ragavan, Nimble Pilferer | Zone$ Battlefield | Tapped$ True | Attacking$ True | RememberMade$ True | SubAbility$ DBDelayTrig
+SVar:TrigConjure:DB$ MakeCard | Conjure$ True | Name$ Ragavan, Nimble Pilferer | Zone$ Battlefield | Tapped$ True | RememberMade$ True | SubAbility$ DBSetAttacking
+SVar:DBSetAttacking:DB$ ChangeCombatants | Defined$ Remembered | ConditionDefined$ Remembered | ConditionPresent$ Card.YouCtrl | Attacking$ True | SubAbility$ DBDelayTrig
 SVar:DBDelayTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ TrigReturn | ConditionDefined$ RememberedLKI | ConditionPresent$ Card | ConditionZone$ Battlefield | RememberObjects$ RememberedLKI | SubAbility$ DBCleanup | TriggerDescription$ At the beginning of the next end step, if that card is on the battlefield, return it to its owner's hand.
 SVar:TrigReturn:DB$ ChangeZone | Defined$ DelayTriggerRememberedLKI | Origin$ Battlefield | Destination$ Hand
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/upcoming/masterpiece_vault.txt
+++ b/forge-gui/res/cardsfolder/upcoming/masterpiece_vault.txt
@@ -1,0 +1,10 @@
+Name:Masterpiece Vault
+ManaCost:3
+Types:Artifact
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigDraft | TriggerDescription$ When this artifact is put into a graveyard from the battlefield, draft a card from CARDNAME's spellbook and put it onto the battlefield. When an Equipment enters this way, attach it to up to one target creature you control.
+SVar:TrigDraft:DB$ Draft | Spellbook$ Champion's Helm,Lightning Greaves,Sword of Body and Mind,Sword of Feast and Famine,Sword of Fire and Ice,Sword of Light and Shadow,Sword of War and Peace | Zone$ Battlefield | RememberDrafted$ True | SubAbility$ MoveToPlay
+SVar:MoveToPlay:DB$ ChangeZone | Hidden$ True | Origin$ All | Destination$ Battlefield | Defined$ Remembered | ConditionDefined$ Remembered | ConditionPresent$ Card.Equipment | SubAbility$ DBTrigger
+SVar:DBTrigger:DB$ ImmediateTrigger | Execute$ TrigAttach | TriggerDescription$ When an Equipment enters this way, attach it to up to one target creature you control.
+SVar:TrigAttach:DB$ Attach | ValidTgts$ Creature.YouCtrl | Object$ Remembered | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target creature you control
+A:AB$ Sacrifice | Cost$ 5 | SpellDescription$ Sacrifice this artifact.
+Oracle:When this artifact is put into a graveyard from the battlefield, draft a card from Masterpiece Vault's spellbook and put it onto the battlefield. When an Equipment enters this way, attach it to up to one target creature you control.\n{5}: Sacrifice this artifact.

--- a/forge-gui/res/cardsfolder/upcoming/ornate_imitations.txt
+++ b/forge-gui/res/cardsfolder/upcoming/ornate_imitations.txt
@@ -1,0 +1,11 @@
+Name:Ornate Imitations
+ManaCost:X G U
+Types:Sorcery
+A:SP$ Repeat | Cost$ XMin1 X G U | RepeatSubAbility$ DBNameCard | MaxRepeat$ X | StackDescription$ REP . X can't be 0._. | SpellDescription$ For each number between 1 and X, conjure a duplicate of a random creature card with that mana value onto the battlefield. X can't be 0.
+SVar:DBNameCard:DB$ NameCard | AtRandom$ True | ValidCards$ Creature.cmcEQM | SubAbility$ DBConjure
+SVar:DBConjure:DB$ MakeCard | Name$ ChosenName | Conjure$ True | Zone$ Battlefield | SubAbility$ DBClearNamed
+SVar:DBClearNamed:DB$ Cleanup | ClearNamedCard$ True | SubAbility$ DBStore
+SVar:DBStore:DB$ StoreSVar | SVar$ M | Type$ CountSVar | Expression$ M/Plus.1
+SVar:M:Number$1
+SVar:X:Count$xPaid
+Oracle:For each number between 1 and X, conjure a duplicate of a random creature card with that mana value onto the battlefield. X can't be 0.

--- a/forge-gui/res/cardsfolder/upcoming/quickbeast_amulet.txt
+++ b/forge-gui/res/cardsfolder/upcoming/quickbeast_amulet.txt
@@ -1,0 +1,11 @@
+Name:Quickbeast Amulet
+ManaCost:G W
+Types:Artifact Equipment
+K:Starting intensity:0
+S:Mode$ Continuous | Affected$ Card.EquippedBy | AddPower$ X | AddToughness$ X | Description$ Equipped creature gets +X/+X, where X is this Equipment's intensity.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigIntensify | TriggerDescription$ Whenever a creature you control enters, this Equipment intensifies by X, where X is that creature's power.
+SVar:TrigIntensify:DB$ Intensify | Amount$ Y
+SVar:Y:TriggeredCard$CardPower
+SVar:X:Count$Intensity
+K:Equip:2
+Oracle:Starting intensity 0\nEquipped creature gets +X/+X, where X is this Equipment's intensity.\nWhenever a creature you control enters, this Equipment intensifies by X, where X is that creature's power.\nEquip {2}

--- a/forge-gui/res/cardsfolder/upcoming/rising_chicane.txt
+++ b/forge-gui/res/cardsfolder/upcoming/rising_chicane.txt
@@ -1,0 +1,13 @@
+Name:Rising Chicane
+ManaCost:no cost
+Types:Artifact Land
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplaceWith$ LandTapped | ReplacementResult$ Updated | Description$ If you were the starting player, this land enters tapped.
+SVar:LandTapped:DB$ Tap | Defined$ Self | ETB$ True | ConditionCheckSVar$ X | ConditionSVarCompare$ LT1
+SVar:X:Count$StartingPlayer.0.1
+K:Start your engines
+A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
+DeckHas:Ability$Mana.Colorless
+S:Mode$ Continuous | Affected$ Card.Self | Condition$ MaxSpeed | AddTrigger$ PhaseTrig | Description$ Max speed — At the beginning of combat on your turn, this land becomes a 2/2 Construct creature in addition to its other types until end of turn.
+SVar:PhaseTrig:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigAnimate | Secondary$ True | TriggerDescription$ Max speed — At the beginning of combat on your turn, this land becomes a 2/2 Construct creature in addition to its other types until end of turn.
+SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 2 | Toughness$ 2 | Types$ Creature,Construct
+Oracle:If you were the starting player, this land enters tapped.\nStart your engines!\n{T}: Add {C}.\nMax speed — At the beginning of combat on your turn, this land becomes a 2/2 Construct creature in addition to its other types until end of turn.

--- a/forge-gui/res/cardsfolder/upcoming/routeway_moose.txt
+++ b/forge-gui/res/cardsfolder/upcoming/routeway_moose.txt
@@ -1,0 +1,10 @@
+Name:Routeway Moose
+ManaCost:1 G
+Types:Creature Elk Mount
+PT:3/3
+T:Mode$ Attacks | ValidCard$ Card.Self+IsSaddled | TriggerZones$ Battlefield | Execute$ TrigSeek | TriggerDescription$ Whenever this creature attacks while saddled, seek a land card and put it onto the battlefield tapped.
+SVar:TrigSeek:DB$ Seek | Type$ Land | RememberFound$ True | SubAbility$ DBPut
+SVar:DBPut:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | Defined$ Remembered | Tapped$ True | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+K:Saddle:2
+Oracle:Whenever this creature attacks while saddled, seek a land card and put it onto the battlefield tapped.\nSaddle 2

--- a/forge-gui/res/cardsfolder/upcoming/sala_deck_boss.txt
+++ b/forge-gui/res/cardsfolder/upcoming/sala_deck_boss.txt
@@ -6,4 +6,3 @@ S:Mode$ Continuous | Affected$ Creature.YouCtrl+hasActivatedAbilityWithExhaust |
 T:Mode$ AbilityCast | ValidActivatingPlayer$ You | ValidSA$ Activated.Exhaust+nonManaAbility | TriggerZones$ Battlefield | Execute$ TrigCopy | TriggerDescription$ Whenever you activate an exhaust ability that isn't a mana ability, copy it. You may choose new targets for the copy.
 SVar:TrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | MayChooseTarget$ True
 Oracle:Each creature you control with an exhaust ability has haste.\nWhenever you activate an exhaust ability that isn't a mana ability, copy it. You may choose new targets for the copy.
- 

--- a/forge-gui/res/cardsfolder/upcoming/sala_deck_boss.txt
+++ b/forge-gui/res/cardsfolder/upcoming/sala_deck_boss.txt
@@ -1,0 +1,9 @@
+Name:Sala, Deck Boss
+ManaCost:1 U R
+Types:Legendary Creature Squid Pirate
+PT:3/3
+S:Mode$ Continuous | Affected$ Creature.YouCtrl+hasActivatedAbilityWithExhaust | AddKeyword$ Haste | Description$ Each creature you control with an exhaust ability has haste.
+T:Mode$ AbilityCast | ValidActivatingPlayer$ You | ValidSA$ Activated.Exhaust+nonManaAbility | TriggerZones$ Battlefield | Execute$ TrigCopy | TriggerDescription$ Whenever you activate an exhaust ability that isn't a mana ability, copy it. You may choose new targets for the copy.
+SVar:TrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | MayChooseTarget$ True
+Oracle:Each creature you control with an exhaust ability has haste.\nWhenever you activate an exhaust ability that isn't a mana ability, copy it. You may choose new targets for the copy.
+ 

--- a/forge-gui/res/cardsfolder/upcoming/terrors_of_the_track.txt
+++ b/forge-gui/res/cardsfolder/upcoming/terrors_of_the_track.txt
@@ -1,0 +1,11 @@
+Name:Terrors of the Track
+ManaCost:1 B
+Types:Creature Dinosaur
+PT:2/1
+K:Flying
+K:Double team
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self,Creature.Other | TriggerZones$ Battlefield | Execute$ TrigLoseLife | ActivationLimit$ 1 | TriggerDescription$ Whenever this creature or another creature dies, each opponent loses 1 life and you gain 1 life.
+SVar:TrigLoseLife:DB$ LoseLife | Defined$ Player.Opponent | LifeAmount$ 1 | SubAbility$ DBGainLife
+SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1
+DeckHas:Ability$LifeGain
+Oracle:Flying\nDouble team\nWhenever this creature or another creature dies, each opponent loses 1 life and you gain 1 life. This ability triggers only once each turn.

--- a/forge-gui/res/cardsfolder/upcoming/wish_good_luck.txt
+++ b/forge-gui/res/cardsfolder/upcoming/wish_good_luck.txt
@@ -1,0 +1,8 @@
+Name:Wish Good Luck
+ManaCost:R G
+Types:Sorcery
+A:SP$ Token | TokenAmount$ 1 | TokenScript$ c_a_food_sac | TokenOwner$ You | SubAbility$ DBTreasure | SpellDescription$ Create a Food token.
+SVar:DBTreasure:DB$ Token | TokenScript$ c_a_treasure_sac | TokenTapped$ True | SubAbility$ DBVehicle | SpellDescription$ Create a tapped Treasure token.
+SVar:DBVehicle:DB$ Token | TokenAmount$ 1 | TokenScript$ c_3_2_a_vehicle_crew_1 | TokenOwner$ You | SpellDescription$ Create a 3/2 colorless Vehicle artifact token with crew 1.
+DeckHas:Ability$Token
+Oracle:Create a Food token.\nCreate a tapped Treasure token.\nCreate a 3/2 colorless Vehicle artifact token with crew 1.


### PR DESCRIPTION
As revealed recently:
- [**Terrors of the Track**](https://www.reddit.com/r/MagicArena/comments/1iytumc/ydft_sala_deck_boss_terrors_of_the_track/): tested to satisfaction
- [**Sala, Deck Boss**](https://www.reddit.com/r/MagicArena/comments/1iytumc/ydft_sala_deck_boss_terrors_of_the_track/) and support: tested to satisfaction
- [**Wish Good Luck**](https://x.com/MTG_Arena/status/1895203378969325799): tested to satisfaction
- [**Kari Zev, Crew of Two**](https://www.reddit.com/r/MagicArena/comments/1izvhhr/ydft_kari_zev_crew_of_two/): ~~In a working state except for the conjured Ragavan, Nimble Pilferer entering tapped and attacking. The latter only enters tapped. Needs support from someone more knowlegeable than me: I attempted to address this to no avail.~~ Addressed. Tested to satisfaction.
- [**Ornate Imitations**](https://www.reddit.com/r/MagicArena/comments/1j0cvw7/ydft_ornate_imitations/): ~~In a working state, except, as reported on Discord, an X larger than 13 results in a crash as there's currently no creature with mana value 14. Crash log appended for convenience.~~ Addressed. Tested to satisfaction.
~~[2025-03-01-00_ornate.txt](https://github.com/user-attachments/files/19038009/2025-03-01-00_ornate.txt)~~
- [**Quickbeast Amulet**](https://www.reddit.com/r/MagicArena/comments/1j0cwev/ydft_quickbeast_amulet/): tested to satisfaction
- [**Masterpiece Vault**](https://www.reddit.com/r/MagicArena/comments/1j0cy7g/ydft_masterpiece_vault/): tested to satisfaction
- [**Rising Chicane**](https://www.reddit.com/r/MagicArena/comments/1j0cyox/ydft_rising_chicane/): tested to satisfaction
- [**Routeway Moose**](https://www.reddit.com/r/MagicArena/comments/1j0cujw/ydft_routeway_moose/): tested to satisfaction
- [**Fuel Tank Feaster**](https://www.reddit.com/r/MagicArena/comments/1j0cu4j/ydft_fuel_tank_feaster/): tested to satisfaction
- [**Great Fang Chroniclers**](https://www.reddit.com/r/MagicArena/comments/1j0cuzq/ydft_great_fang_chroniclers/): I think this would be the target structure for the activated ability based on what I gleaned from existing scripts. The problem is that the `RemoveThisAbility` flag doesn't work, not even for the licids I lifted it from. I tried using a static ability to grant the activated ability, which would then be turned off by activating the activated ability but that doesn't display properly and the Muraganda Petroglyphs effect still sees the existing static as an ability. There's `LosePerpetual`, but that isn't what the card reads, and my ability to parse Java falls short of being able to adapt it to this effect.
- [**Highway Reaver**](https://www.reddit.com/r/MagicArena/comments/1j0cvf9/ydft_highway_reaver/): While I believe this is roughly the target structure, once more addressing the issues feels too involved for my limited know-how with Java. Which are:
• Like for the encore ability provided by [Wire Surgeons](https://scryfall.com/card/brc/10/wire-surgeons), the animated card's mana cost should be displayed as the unearth cost. It isn't. Instead the mana cost for Unearth is given as {C} throughout which leads me to believe the game engine is reading the one capital 'C' in `CardManaCost` and moving on.
• The unearth freebie static ability isn't being applied like [Bruenor Battlehammer](https://scryfall.com/card/afr/219/bruenor-battlehammer)'s effect applies to equip costs, I imagine because the game engine hasn't been expanded that far. 

Incidental fixes
- Adding relevant tags to a few source scripts for Terrors.
- Was made aware of a straggler for the affinity update, [Banquet Guests](https://scryfall.com/card/ltc/47/banquet-guests).
- A few cards were missing a `Conjure` flag.
- Removed a redundant `AtRandom` flag from [Fear of Change](https://scryfall.com/card/ydsk/21/fear-of-change).
- The unearth cost granted by [Fallaji Antiquarian](https://scryfall.com/card/ybro/8/fallaji-antiquarian) was one mana too expensive.
- Per rulings on [Underworld Sentinel](https://scryfall.com/card/thb/293/underworld-sentinel), it was missing a `GainControl$ True` flag.