### PR TITLE
Update decoy_gambit.txt

### DIFF
--- a/forge-gui/res/cardsfolder/d/decoy_gambit.txt
+++ b/forge-gui/res/cardsfolder/d/decoy_gambit.txt
@@ -1,8 +1,13 @@
 Name:Decoy Gambit
 ManaCost:2 U
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Choose up to one target creature each opponent controls | TargetMin$ 0 | TargetMax$ OneEach | TargetsForEachPlayer$ True | SubAbility$ DBRepeat | SpellDescription$ For each opponent, choose up to one target creature that player controls, then return that creature to its owner's hand unless its controller has you draw a card.
-SVar:DBRepeat:DB$ RepeatEach | DefinedCards$ Targeted | RepeatSubAbility$ DBReturn
-SVar:DBReturn:DB$ ChangeZone | Defined$ Remembered | Origin$ Battlefield | Destination$ Hand | UnlessCost$ Draw<1/Player.Activator> | UnlessPayer$ RememberedController
+A:SP$ Pump | ValidTgts$ Creature.OppCtrl | TgtPrompt$ For each opponent, choose up to one target creature that player controls | TargetMin$ 0 | TargetMax$ OneEach | TargetsForEachPlayer$ True | RememberPumped$ True | SubAbility$ DBChoice | StackDescription$ SpellDescription | SpellDescription$ For each opponent, choose up to one target creature that player controls, then return that creature to its owner's hand unless its controller has you draw a card.
+SVar:DBChoice:DB$ GenericChoice | Choices$ Diversion,Intelligence | Defined$ TargetedController | TempRemember$ Chooser | SubAbility$ DBDraw | AILogic$ Random | ShowChoice$ ExceptSelf | StackDescription$ None
+SVar:Diversion:DB$ Pump | Defined$ Remembered | NoteCards$ Self | NoteCardsFor$ Diversion | SpellDescription$ Return targeted creature you control to its owner's hand.
+SVar:Intelligence:DB$ Pump | Defined$ Remembered | NoteCards$ Self | NoteCardsFor$ Intelligence | SpellDescription$ CARDNAME's controller draws a card.
+SVar:DBDraw:DB$ Draw | NumCards$ X | SubAbility$ DBBounce | StackDescription$ None
+SVar:DBBounce:DB$ ChangeZoneAll | Origin$ Battlefield | Destination$ Hand | ChangeType$ Card.IsRemembered+ControlledBy Player.NotedForDiversion | SubAbility$ DBClearNoted | StackDescription$ None
+SVar:DBClearNoted:DB$ Pump | Defined$ Player | ClearNotedCardsFor$ Diversion,Intelligence | StackDescription$ None
+SVar:X:PlayerCountPropertyOpponents$HasPropertyNotedForIntelligence
 SVar:OneEach:PlayerCountOpponents$Amount
 Oracle:For each opponent, choose up to one target creature that player controls, then return that creature to its owner's hand unless its controller has you draw a card.

--- a/forge-gui/res/cardsfolder/d/decoy_gambit.txt
+++ b/forge-gui/res/cardsfolder/d/decoy_gambit.txt
@@ -1,12 +1,12 @@
 Name:Decoy Gambit
 ManaCost:2 U
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature.OppCtrl | TgtPrompt$ For each opponent, choose up to one target creature that player controls | TargetMin$ 0 | TargetMax$ OneEach | TargetsForEachPlayer$ True | RememberPumped$ True | SubAbility$ DBChoice | StackDescription$ SpellDescription | SpellDescription$ For each opponent, choose up to one target creature that player controls, then return that creature to its owner's hand unless its controller has you draw a card.
+A:SP$ Pump | ValidTgts$ Creature.OppCtrl | TgtPrompt$ For each opponent, choose up to one target creature that player controls | TargetMin$ 0 | TargetMax$ OneEach | TargetsForEachPlayer$ True | SubAbility$ DBChoice | StackDescription$ SpellDescription | SpellDescription$ For each opponent, choose up to one target creature that player controls, then return that creature to its owner's hand unless its controller has you draw a card.
 SVar:DBChoice:DB$ GenericChoice | Choices$ Diversion,Intelligence | Defined$ TargetedController | TempRemember$ Chooser | SubAbility$ DBDraw | AILogic$ Random | ShowChoice$ ExceptSelf | StackDescription$ None
 SVar:Diversion:DB$ Pump | Defined$ Remembered | NoteCards$ Self | NoteCardsFor$ Diversion | SpellDescription$ Return targeted creature you control to its owner's hand.
 SVar:Intelligence:DB$ Pump | Defined$ Remembered | NoteCards$ Self | NoteCardsFor$ Intelligence | SpellDescription$ CARDNAME's controller draws a card.
 SVar:DBDraw:DB$ Draw | NumCards$ X | SubAbility$ DBBounce | StackDescription$ None
-SVar:DBBounce:DB$ ChangeZoneAll | Origin$ Battlefield | Destination$ Hand | ChangeType$ Card.IsRemembered+ControlledBy Player.NotedForDiversion | SubAbility$ DBClearNoted | StackDescription$ None
+SVar:DBBounce:DB$ ChangeZoneAll | Origin$ Battlefield | Destination$ Hand | ChangeType$ Card.targetedBy+ControlledBy Player.NotedForDiversion | SubAbility$ DBClearNoted | StackDescription$ None
 SVar:DBClearNoted:DB$ Pump | Defined$ Player | ClearNotedCardsFor$ Diversion,Intelligence | StackDescription$ None
 SVar:X:PlayerCountPropertyOpponents$HasPropertyNotedForIntelligence
 SVar:OneEach:PlayerCountOpponents$Amount


### PR DESCRIPTION
Took a while to get there but here it is, [Decoy Gambit](https://scryfall.com/card/c20/32/decoy-gambit) reworked to comply with the rulings, mostly lifted from the work I did for [Step Between Worlds](https://scryfall.com/card/otj/70/step-between-worlds) with an assist from [Disorienting Choice](https://scryfall.com/card/dsc/32/disorienting-choice). Closes https://github.com/Card-Forge/forge/issues/1602 .