### PR TITLE
Adventure Mode cleanup: February 2025 pass

### DIFF
--- a/forge-gui/res/adventure/Amonkhet/world/shops.json
+++ b/forge-gui/res/adventure/Amonkhet/world/shops.json
@@ -465,7 +465,7 @@
     }]
 },{                                      
 "name":"White6",                  
-"description":"Strict dogma",
+"description":"Strict Dogma",
 "spriteAtlas":"maps/tileset/buildings.atlas",   
 "sprite":"RotatingShop",
 "overlaySprite":"Overlay6White",

--- a/forge-gui/res/adventure/Shandalar/world/quests.json
+++ b/forge-gui/res/adventure/Shandalar/world/quests.json
@@ -9071,7 +9071,7 @@
 		"plains_town_tribal",
 		"swamp_town_generic",
 		"swamp_town_identity",
-		"swamo_town_tribal",
+		"swamp_town_tribal",
 		"waste_town_generic",
 		"waste_town_identity",
 		"waste_town_tribal"
@@ -9811,7 +9811,7 @@
 	"offerDialog": {},
 	"prologue": {},
 	"epilogue": {
-		"text": "A slight whistle alerts you to Acirxes' presence. You're not entirely sure if he has impeccible timing or if he watched you complete your most recent job, but it appears that Sir Donovan has more work for you.",
+		"text": "A slight whistle alerts you to Acirxes' presence. You're not entirely sure if he has impeccable timing or if he watched you complete your most recent job, but it appears that Sir Donovan has more work for you.",
 		"options": [
 			{
 				"action": [

--- a/forge-gui/res/adventure/Shandalar/world/shops.json
+++ b/forge-gui/res/adventure/Shandalar/world/shops.json
@@ -500,7 +500,7 @@
     }]
 },{                                      
 "name":"White6",                  
-"description":"Strict dogma",
+"description":"Strict Dogma",
 "spriteAtlas":"maps/tileset/buildings.atlas",   
 "sprite":"RotatingShop",
 "overlaySprite":"Overlay6White",
@@ -982,7 +982,7 @@
     }]
 },{                                    
 "name":"Creature2Eldrazi",
-"description": "Eldritch Emissaries",
+"description":"Eldritch Emissaries",
 "spriteAtlas":"maps/tileset/buildings.atlas",   
 "sprite":"CreatureShop",
 "overlaySprite":"Overlay2Colorless",
@@ -2231,7 +2231,7 @@
 	}]
 },{
   "name":"Sliver4Green",
-  "description":"Venemous Hive",
+  "description":"Venomous Hive",
   "spriteAtlas":"maps/tileset/buildings.atlas",
   "sprite":"SliverShop",
   "overlaySprite":"Overlay4Green",

--- a/forge-gui/res/adventure/common/decks/boss/emrakul.dck
+++ b/forge-gui/res/adventure/common/decks/boss/emrakul.dck
@@ -1,22 +1,21 @@
 [metadata]
 Name=Emrakul
 [Main]
-4 Black Lotus  
-4 Crystal Vein  
-4 Eldrazi Temple  
-3 Emrakul, the Aeons Torn  
+4 Black Lotus
+4 Crystal Vein
+4 Eldrazi Temple
+3 Emrakul, the Aeons Torn
 3 Emrakul, the Promised End 
-4 Expedition Map  
-2 Eye of Ugin  
+4 Expedition Map
+2 Eye of Ugin
 4 Mana Vault
-2 Kozilek, Butcher of Truth  
-2 Kozilek, the Great Distortion  
-4 Mana Crypt  
-4 Sol Ring  
-4 Titan's Presence   
+2 Kozilek, Butcher of Truth
+2 Kozilek, the Great Distortion
+4 Mana Crypt
+4 Sol Ring
+4 Titan's Presence 
 2 Ulamog, the Ceaseless Hunger 
-2 Ulamog, the Infinite Gyre  
-4 Urza's Mine  
-4 Urza's Power Plant  
-4 Urza's Tower 
- 
+2 Ulamog, the Infinite Gyre
+4 Urza's Mine
+4 Urza's Power Plant
+4 Urza's Tower

--- a/forge-gui/res/adventure/common/decks/boss/lorthos.dck
+++ b/forge-gui/res/adventure/common/decks/boss/lorthos.dck
@@ -26,6 +26,6 @@ Name=Lorthos
 2 Show and Tell|CN2|1
 4 Spawning Kraken|C21|1
 4 Stormtide Leviathan|CMR|1
-4 Whelming Wave|JMP|1 
+4 Whelming Wave|JMP|1
 
 

--- a/forge-gui/res/adventure/common/decks/standard/banditarcher_damage.dck
+++ b/forge-gui/res/adventure/common/decks/standard/banditarcher_damage.dck
@@ -2,7 +2,7 @@
 Name=Hellboy 2
 [main]
 5 Swamp
-7 Mountain 
+7 Mountain
 3 Blackcleave Cliffs
 3 Dragonskull Summit
 1 Blood Crypt

--- a/forge-gui/res/adventure/common/decks/standard/bluewizard_apprentice_2.dck
+++ b/forge-gui/res/adventure/common/decks/standard/bluewizard_apprentice_2.dck
@@ -1,5 +1,5 @@
 [metadata]
-Name=Adventure -  Blue Apprentice 2
+Name=Adventure - Blue Apprentice 2
 [Main]
 4 Accumulated Knowledge|NMS|1
 2 Arcane Investigator|AFR|1

--- a/forge-gui/res/adventure/common/decks/standard/not in use/goblins.dck
+++ b/forge-gui/res/adventure/common/decks/standard/not in use/goblins.dck
@@ -1,6 +1,6 @@
 [metadata]
 Name=Goblins
-Title=Goblins 
+Title=Goblins
 [main]
 2 Gauntlet of Might|LEA
 2 Giant Strength|4ED

--- a/forge-gui/res/adventure/common/decks/standard/not in use/golem.dck
+++ b/forge-gui/res/adventure/common/decks/standard/not in use/golem.dck
@@ -11,10 +11,10 @@ Deck Type=constructed
 4 Crystal Golem|MIR
 4 Alloy Golem
 20 Wastes
-4 Igneous Golem|MIR 
+4 Igneous Golem|MIR
 4 Lead Golem|MIR
 4 Battered Golem
 4 Matopi Golem|VIS
-4 Patagia Golem|MIR 
+4 Patagia Golem|MIR
 4 Quicksand|VIS
-4 Sand Golem|MIR 
+4 Sand Golem|MIR

--- a/forge-gui/res/adventure/common/world/enemies.json
+++ b/forge-gui/res/adventure/common/world/enemies.json
@@ -6874,7 +6874,7 @@
 			"probability": 1,
 			"count": 3,
 			"rarity": [
-				"uncomon",
+				"uncommon",
 				"common"
 			],
 			"cardTypes": [
@@ -20929,7 +20929,7 @@
 			"count": 3,
 			"addMaxCount": 6,
 			"rarity": [
-				"uncomon",
+				"uncommon",
 				"common"
 			]
 		},
@@ -20946,7 +20946,7 @@
 			"probability": 1,
 			"count": 3,
 			"rarity": [
-				"uncomon",
+				"uncommon",
 				"common"
 			],
 			"cardTypes": [
@@ -23699,7 +23699,7 @@
 			"probability": 1,
 			"count": 3,
 			"rarity": [
-				"uncomon",
+				"uncommon",
 				"common"
 			],
 			"cardTypes": [
@@ -24664,7 +24664,7 @@
 			"probability": 1,
 			"count": 3,
 			"rarity": [
-				"uncomon",
+				"uncommon",
 				"common"
 			],
 			"cardTypes": [
@@ -25552,7 +25552,7 @@
 			"probability": 1,
 			"count": 3,
 			"rarity": [
-				"uncomon",
+				"uncommon",
 				"common"
 			],
 			"cardTypes": [
@@ -27452,7 +27452,7 @@
 	]
 },
 {
-	"name": "Vulcano Dragon",
+	"name": "Volcano Dragon",
 	"nameOverride": "",
 	"sprite": "sprites/enemy/dragon/dragonlarge.atlas",
 	"deck": [


### PR DESCRIPTION
Generally dealing with clear typos. 
I am left wondering about `\common\world\sprites\map_sprites.json` and the trailing whitespace on a lot of the lines, though.