### PR TITLE
Make canBlock check if the blocker is a creature.

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/TokenAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/TokenAi.java
@@ -202,11 +202,11 @@ public class TokenAi extends SpellAbilityAi {
 
         if (sa.isPwAbility() && alwaysFromPW) {
             return true;
-        } else if (game.getPhaseHandler().is(PhaseType.COMBAT_DECLARE_ATTACKERS)
+        } else if (game.getCombat() != null
                 && game.getPhaseHandler().getPlayerTurn().isOpponentOf(ai)
-                && game.getCombat() != null
                 && !game.getCombat().getAttackers().isEmpty()
-                && alwaysOnOppAttack) {
+                && alwaysOnOppAttack
+                && actualToken.isCreature()) {
             for (Card attacker : game.getCombat().getAttackers()) {
                 if (CombatUtil.canBlock(attacker, actualToken)) {
                     return true;

--- a/forge-game/src/main/java/forge/game/combat/CombatUtil.java
+++ b/forge-game/src/main/java/forge/game/combat/CombatUtil.java
@@ -996,7 +996,7 @@ public class CombatUtil {
      * @return a boolean.
      */
     public static boolean canBlock(final Card attacker, final Card blocker, final boolean nextTurn) {
-        if (attacker == null || blocker == null) {
+        if (attacker == null || blocker == null || !blocker.isCreature()) {
             return false;
         }
 


### PR DESCRIPTION
TokenAi also checks if the spawned token is a creature before running checks.
Fixes e.g. the AI using Fountainport to produce a Treasure token as a potential blocker.