### PR TITLE
StaticAbility InfectDamage for Phyrexian Unlife

### DIFF
--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -681,8 +681,7 @@ public class Player extends GameEntity implements Comparable<Player> {
             return 0;
         }
 
-        boolean infect = source.hasKeyword(Keyword.INFECT)
-                || hasKeyword("All damage is dealt to you as though its source had infect.");
+        boolean infect = source.hasKeyword(Keyword.INFECT) || StaticAbilityInfectDamage.isInfectDamage(this);
 
         int poisonCounters = 0;
         if (infect) {

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityInfectDamage.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityInfectDamage.java
@@ -1,0 +1,33 @@
+package forge.game.staticability;
+
+import forge.game.Game;
+import forge.game.card.Card;
+import forge.game.player.Player;
+import forge.game.zone.ZoneType;
+
+public class StaticAbilityInfectDamage {
+
+    static String MODE = "InfectDamage";
+
+    static public boolean isInfectDamage(Player target) {
+        final Game game = target.getGame();
+        for (final Card ca : game.getCardsIn(ZoneType.STATIC_ABILITIES_SOURCE_ZONES)) {
+            for (final StaticAbility stAb : ca.getStaticAbilities()) {
+                if (!stAb.checkConditions(MODE)) {
+                    continue;
+                }
+                if (applyInfectDamageAbility(stAb, target)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    static public boolean applyInfectDamageAbility(StaticAbility stAb, Player target) {
+        if (!stAb.matchesValidParam("ValidTarget", target)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/forge-gui/res/cardsfolder/p/phyrexian_unlife.txt
+++ b/forge-gui/res/cardsfolder/p/phyrexian_unlife.txt
@@ -2,7 +2,7 @@ Name:Phyrexian Unlife
 ManaCost:2 W
 Types:Enchantment
 R:Event$ GameLoss | ActiveZones$ Battlefield | ValidPlayer$ You | ValidLoseReason$ LifeReachedZero | Layer$ CantHappen | Description$ You don't lose the game for having 0 or less life.
-S:Mode$ Continuous | CheckSVar$ UnlifeCondition | SVarCompare$ LE0 | Affected$ You | AddKeyword$ All damage is dealt to you as though its source had infect. | Description$ As long as you have 0 or less life, all damage is dealt to you as though its source had infect.
+S:Mode$ InfectDamage | ValidTarget$ You | CheckSVar$ UnlifeCondition | SVarCompare$ LE0 | Description$ As long as you have 0 or less life, all damage is dealt to you as though its source had infect.
 SVar:UnlifeCondition:Count$YourLifeTotal
 SVar:NonStackingEffect:True
 Oracle:You don't lose the game for having 0 or less life.\nAs long as you have 0 or less life, all damage is dealt to you as though its source had infect. (Damage is dealt to you in the form of poison counters.)


### PR DESCRIPTION
Changes _Phyrexian Unlife_ into a Static Ability

or should this new class be merged with StaticAbilityWitherDamage? (WitherDamage uses Source, this uses Target)