### PR TITLE
Alchemy Rebalancing for March 4, 2025

### DIFF
--- a/forge-gui/res/cardsfolder/b/buxton_decorated_host.txt
+++ b/forge-gui/res/cardsfolder/b/buxton_decorated_host.txt
@@ -1,5 +1,5 @@
 Name:Buxton, Decorated Host
-ManaCost:3 G W
+ManaCost:3 G G W
 Types:Legendary Creature Rabbit Noble
 PT:4/4
 K:Convoke

--- a/forge-gui/res/cardsfolder/c/chittering_illuminator.txt
+++ b/forge-gui/res/cardsfolder/c/chittering_illuminator.txt
@@ -1,7 +1,7 @@
 Name:Chittering Illuminator
-ManaCost:1 G G
+ManaCost:G G
 Types:Enchantment Creature Squirrel Glimmer
-PT:3/3
+PT:2/2
 S:Mode$ Continuous | Affected$ Card.Self+TopLibrary | AffectedZone$ Library | EffectZone$ All | MayPlay$ True | MayLookAt$ You | Description$ As long as CARDNAME is at the top of your library, you may look at it any time and you may cast it.
 S:Mode$ Continuous | Affected$ Creature.TopLibrary+YouCtrl+nonLand | AffectedZone$ Library | EffectZone$ Battlefield | MayPlay$ True | MayLookAt$ You | Description$ As long as the top card of your library is a creature card, you may look at it any time and you may cast it.
 Oracle:As long as Chittering Illuminator is at the top of your library, you may look at it any time and you may cast it.\nAs long as the top card of your library is a creature card, you may look at it any time and you may cast it.

--- a/forge-gui/res/cardsfolder/d/dazzling_flameweaver.txt
+++ b/forge-gui/res/cardsfolder/d/dazzling_flameweaver.txt
@@ -6,7 +6,7 @@ K:Menace
 K:Ward:PayLife<3>
 T:Mode$ DamageDoneOnce | ValidSource$ Creature.YouCtrl | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigConjure | TriggerZones$ Battlefield | TriggerDescription$ Whenever one or more creatures you control deal combat damage to a player, conjure a random card from CARDNAME's spellbook into exile. You may play that card until the end of your next turn.
 SVar:TrigConjure:DB$ MakeCard | Conjure$ True | AtRandom$ True | Spellbook$ Blade Juggler,Body Count,Dead Revels,Drill Bit,Hackrobat,Light Up the Stage,Rafter Demon,Rix Maadi Reveler,Skewer the Critics,Spawn of Mayhem,Spikewheel Acrobat | RememberMade$ True | SubAbility$ DBEffect | Zone$ Exile
-SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ STPlay | SubAbility$ DBCleanup | ExileOnMoved$ Exile | Duration$ UntilTheEndOfYourNextTurn
+SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ STPlay | SubAbility$ DBCleanup | ForgetOnMoved$ Exile | Duration$ UntilTheEndOfYourNextTurn
 SVar:STPlay:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsRemembered | AffectedZone$ Exile | Description$ You may play the exiled card until the end of your next turn.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Menace\nWard — Pay 3 life.\nWhenever one or more creatures you control deal combat damage to a player, conjure a random card from Dazzling Flameweaver's spellbook into exile. You may play that card until the end of your next turn.

--- a/forge-gui/res/cardsfolder/d/dazzling_flameweaver.txt
+++ b/forge-gui/res/cardsfolder/d/dazzling_flameweaver.txt
@@ -4,9 +4,9 @@ Types:Creature Lizard Warlock
 PT:4/4
 K:Menace
 K:Ward:PayLife<3>
-T:Mode$ DamageDoneOnce | ValidSource$ Creature.YouCtrl | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigConjure | TriggerZones$ Battlefield | TriggerDescription$ Whenever one or more creatures you control deal combat damage to a player, conjure a random card from CARDNAME's spellbook into exile. You may play that card this turn.
+T:Mode$ DamageDoneOnce | ValidSource$ Creature.YouCtrl | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigConjure | TriggerZones$ Battlefield | TriggerDescription$ Whenever one or more creatures you control deal combat damage to a player, conjure a random card from CARDNAME's spellbook into exile. You may play that card until the end of your next turn.
 SVar:TrigConjure:DB$ MakeCard | Conjure$ True | AtRandom$ True | Spellbook$ Blade Juggler,Body Count,Dead Revels,Drill Bit,Hackrobat,Light Up the Stage,Rafter Demon,Rix Maadi Reveler,Skewer the Critics,Spawn of Mayhem,Spikewheel Acrobat | RememberMade$ True | SubAbility$ DBEffect | Zone$ Exile
-SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ Play | SubAbility$ DBCleanup | ExileOnMoved$ Exile
-SVar:Play:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsRemembered | AffectedZone$ Exile | Description$ You may play the exiled card this turn.
+SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ STPlay | SubAbility$ DBCleanup | ExileOnMoved$ Exile | Duration$ UntilTheEndOfYourNextTurn
+SVar:STPlay:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsRemembered | AffectedZone$ Exile | Description$ You may play the exiled card until the end of your next turn.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-Oracle:Menace\nWard — Pay 3 life.\nWhenever one or more creatures you control deal combat damage to a player, conjure a random card from Dazzling Flameweaver's spellbook into exile. You may play that card this turn.
+Oracle:Menace\nWard — Pay 3 life.\nWhenever one or more creatures you control deal combat damage to a player, conjure a random card from Dazzling Flameweaver's spellbook into exile. You may play that card until the end of your next turn.

--- a/forge-gui/res/cardsfolder/e/ethrimik_imagined_fiend.txt
+++ b/forge-gui/res/cardsfolder/e/ethrimik_imagined_fiend.txt
@@ -2,8 +2,8 @@ Name:Ethrimik, Imagined Fiend
 ManaCost:2 W W
 Types:Legendary Creature Illusion Beast
 PT:5/5
-T:Mode$ ChangesZone | ValidCard$ Card.Self | Destination$ Battlefield | Origin$ Any | IsPresent$ Creature.Other+YouCtrl | PresentCompare$ EQ0 | Execute$ TrigManifest | TriggerDescription$ When NICKNAME enters, if you control no other creatures, manifest dread.
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Destination$ Battlefield | Origin$ Any | Execute$ TrigManifest | TriggerDescription$ When NICKNAME enters, manifest dread.
 SVar:TrigManifest:DB$ ManifestDread
 S:Mode$ Continuous | Affected$ Creature.Other+YouCtrl | AddPower$ 1 | AddToughness$ 1 | Description$ Other creatures you control get +1/+1.
 S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack or block. | IsPresent$ Creature.Other+YouCtrl | PresentCompare$ GE1 | Description$ As long as you control another creature, NICKNAME can't attack or block.
-Oracle:When Ethrimik enters, if you control no other creatures, manifest dread.\nOther creatures you control get +1/+1.\nAs long as you control another creature, Ethrimik can't attack or block.
+Oracle:When Ethrimik enters, manifest dread.\nOther creatures you control get +1/+1.\nAs long as you control another creature, Ethrimik can't attack or block.

--- a/forge-gui/res/cardsfolder/g/golden_sidekick.txt
+++ b/forge-gui/res/cardsfolder/g/golden_sidekick.txt
@@ -1,7 +1,7 @@
 Name:Golden Sidekick
 ManaCost:W B
 Types:Enchantment Creature Bat Glimmer
-PT:2/2
+PT:1/3
 K:Flying
 K:Lifelink
 T:Mode$ LifeGained | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigChoose | TriggerDescription$ Whenever you gain life, a random creature card in your hand perpetually gets +X/+X, where X is the amount of life you gained.

--- a/forge-gui/res/cardsfolder/i/impetuous_lootmonger.txt
+++ b/forge-gui/res/cardsfolder/i/impetuous_lootmonger.txt
@@ -6,7 +6,7 @@ K:First Strike
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDiscard | TriggerDescription$ When CARDNAME enters, discard a card, then heist target opponent's library.
 SVar:TrigDiscard:DB$ Discard | NumCards$ 1 | Mode$ TgtChoose | SubAbility$ DBHeist
 SVar:DBHeist:DB$ Heist | ValidTgts$ Opponent
-T:Mode$ SpellCast | ValidCard$ Card.YouDontOwn | ValidActivatingPlayer$ You | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a spell you don't own, create a Treasure token.
-SVar:TrigToken:DB$ Token | TokenScript$ c_a_treasure_sac
+T:Mode$ SpellCast | ValidCard$ Card.YouDontOwn | ValidActivatingPlayer$ You | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a spell you don't own, create a tapped Treasure token.
+SVar:TrigToken:DB$ Token | TokenTapped$ True | TokenScript$ c_a_treasure_sac
 DeckHas:Ability$Discard|Token|Sacrifice & Type$Artifact|Treasure
-Oracle:First strike\nWhen Impetuous Lootmonger enters, discard a card, then heist target opponent's library.\nWhenever you cast a spell you don't own, create a Treasure token.
+Oracle:First strike\nWhen Impetuous Lootmonger enters, discard a card, then heist target opponent's library.\nWhenever you cast a spell you don't own, create a tapped Treasure token.

--- a/forge-gui/res/cardsfolder/w/wingbright_thief.txt
+++ b/forge-gui/res/cardsfolder/w/wingbright_thief.txt
@@ -1,7 +1,7 @@
 Name:Wingbright Thief
-ManaCost:1 W U
+ManaCost:W U
 Types:Enchantment Creature Bird Glimmer
-PT:2/3
+PT:2/2
 K:Flying
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigReveal | TriggerDescription$ When CARDNAME enters, target opponent reveals each nonland card in their hand. You choose one of them. That card perpetually gains "When you cast this spell, each opponent draws a card and gains 3 life."
 SVar:TrigReveal:DB$ Reveal | ValidTgts$ Opponent | RevealAllValid$ Card.nonLand+TargetedPlayerOwn | SubAbility$ DBChooseCard | RememberRevealed$ True


### PR DESCRIPTION
Source: https://magic.wizards.com/en/news/mtg-arena/announcements-march-3-2025#rebalances

Alchemy only - no new script needed:
- [x] Buxton, Decorated Host
- [x] Chittering Illuminator
- [x] Dazzling Flameweaver
- [x] Ethrimik, Imagined Fiend
- [x] Golden Sidekick
- [x] Impetuous Lootmonger
- [x] Wingbright Thief