### PR TITLE
Sanguine Brushstroke: disambiguating between Arena and Mystery Booster versions

### DIFF
--- a/forge-gui/res/cardsfolder/rebalanced/a-sanguine_brushstroke.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-sanguine_brushstroke.txt
@@ -1,0 +1,10 @@
+Name:A-Sanguine Brushstroke
+ManaCost:1 B B
+Types:Enchantment
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a Blood token and conjure a card named Blood Artist onto the battlefield.
+SVar:TrigToken:DB$ Token | TokenScript$ c_a_blood_draw | SubAbility$ DBMakeCard
+SVar:DBMakeCard:DB$ MakeCard | Conjure$ True | Name$ A-Blood Artist | Zone$ Battlefield
+T:Mode$ Sacrificed | ValidCard$ Blood.token+YouCtrl | Execute$ TrigLoseLife | TriggerZones$ Battlefield | TriggerDescription$ Whenever you sacrifice a Blood token, each opponent loses 1 life.
+SVar:TrigLoseLife:DB$ LoseLife | Defined$ Player.Opponent | LifeAmount$ 1
+DeckHas:Ability$Token|Sacrifice|LifeGain & Type$Blood
+Oracle:When Sanguine Brushstroke enters, create a Blood token and conjure a card named Blood Artist onto the battlefield.\nWhenever you sacrifice a Blood token, each opponent loses 1 life.

--- a/forge-gui/res/cardsfolder/s/sanguine_brushstroke.txt
+++ b/forge-gui/res/cardsfolder/s/sanguine_brushstroke.txt
@@ -3,8 +3,9 @@ ManaCost:1 B B
 Types:Enchantment
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a Blood token and conjure a card named Blood Artist onto the battlefield.
 SVar:TrigToken:DB$ Token | TokenScript$ c_a_blood_draw | SubAbility$ DBMakeCard
-SVar:DBMakeCard:DB$ MakeCard | Conjure$ True | Name$ A-Blood Artist | Zone$ Battlefield
-T:Mode$ Sacrificed | ValidCard$ Blood.token+YouCtrl | Execute$ TrigLoseLife | TriggerZones$ Battlefield | TriggerDescription$ Whenever you sacrifice a Blood token, each opponent loses 1 life.
-SVar:TrigLoseLife:DB$ LoseLife | Defined$ Player.Opponent | LifeAmount$ 1
+SVar:DBMakeCard:DB$ MakeCard | Conjure$ True | Name$ Blood Artist | Zone$ Battlefield
+T:Mode$ Sacrificed | ValidCard$ Blood.token+YouCtrl | Execute$ TrigLoseLife | TriggerZones$ Battlefield | TriggerDescription$ Whenever you sacrifice a Blood token, each opponent loses 1 life and you gain 1 life.
+SVar:TrigLoseLife:DB$ LoseLife | Defined$ Player.Opponent | LifeAmount$ 1 | SubAbility$ DBGainLife
+SVar:DBGainLife:DB$ GainLife | LifeAmount$ 1
 DeckHas:Ability$Token|Sacrifice|LifeGain & Type$Blood
-Oracle:When Sanguine Brushstroke enters, create a Blood token and conjure a card named Blood Artist onto the battlefield.\nWhenever you sacrifice a Blood token, each opponent loses 1 life.
+Oracle:When Sanguine Brushstroke enters, create a Blood token and conjure a card named Blood Artist onto the battlefield.\nWhenever you sacrifice a Blood token, each opponent loses 1 life and you gain 1 life..


### PR DESCRIPTION
- [**Arena**](https://scryfall.com/card/ymid/32/sanguine-brushstroke): Script as currently exists in Forge moved to the rebalanced folder and given the requisite name prefix as that's what happened with it according to the MTG Wiki [Rebalanced card](https://mtg.wiki/page/Rebalanced_card) article.
- [**Mystery Booster**](https://scryfall.com/card/mb2/260/sanguine-brushstroke): Adapted the existing script, reinstating the life gain on the sacrifice triggered ability, and per the stated intent of the card's rulings, the enters triggered ability now conjures the paper version of Blood Artist, as the Arena one isn't listed on Gatherer.