### PR TITLE
Fixing Chimeric Mass and Svogthos

### DIFF
--- a/forge-gui/res/cardsfolder/c/chimeric_mass.txt
+++ b/forge-gui/res/cardsfolder/c/chimeric_mass.txt
@@ -4,7 +4,7 @@ Types:Artifact
 K:etbCounter:CHARGE:X
 SVar:X:Count$xPaid
 A:AB$ Animate | Cost$ 1 | Defined$ Self | Types$ Artifact,Creature,Construct | RemoveCreatureTypes$ True | staticAbilities$ Static | SpellDescription$ Until end of turn, CARDNAME becomes a Construct artifact creature with "This creature's power and toughness are each equal to the number of charge counters on it."
-SVar:Static:Mode$ Continuous | EffectZone$ Battlefield | SetPower$ Y | SetToughness$ Y | Description$ This creature's power and toughness are each equal to the number of charge counters on it.
+SVar:Static:Mode$ Continuous | Affected$ Card.Self | EffectZone$ Battlefield | SetPower$ Y | SetToughness$ Y | Description$ This creature's power and toughness are each equal to the number of charge counters on it.
 SVar:Y:Count$CardCounters.CHARGE
 SVar:NeedsToPlayVar:Z GE4
 SVar:Z:Count$Valid Land.YouCtrl+inZoneBattlefield+untapped

--- a/forge-gui/res/cardsfolder/s/svogthos_the_restless_tomb.txt
+++ b/forge-gui/res/cardsfolder/s/svogthos_the_restless_tomb.txt
@@ -3,7 +3,7 @@ ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Animate | Cost$ 3 B G | Defined$ Self | Types$ Creature,Zombie,Plant | Colors$ Black,Green | OverwriteColors$ True | staticAbilities$ Static | SpellDescription$ Until end of turn, CARDNAME becomes a black and green Plant Zombie creature with "This creature's power and toughness are each equal to the number of creature cards in your graveyard." It's still a land.
-SVar:Static:Mode$ Continuous | EffectZone$ Battlefield | SetPower$ X | SetToughness$ X | Description$ This creature's power and toughness are each equal to the number of creature cards in your graveyard.
+SVar:Static:Mode$ Continuous | Affected$ Card.Self | EffectZone$ Battlefield | SetPower$ X | SetToughness$ X | Description$ This creature's power and toughness are each equal to the number of creature cards in your graveyard.
 SVar:X:Count$TypeInYourYard.Creature
 AI:RemoveDeck:All
 Oracle:{T}: Add {C}.\n{3}{B}{G}: Until end of turn, Svogthos, the Restless Tomb becomes a black and green Plant Zombie creature with "This creature's power and toughness are each equal to the number of creature cards in your graveyard." It's still a land.


### PR DESCRIPTION
As reported, the static ability granted by these cards' animating effects was applying the power/toughness setting to the whole board instead of just to the card itself. 
As these aren't characteristic-defining abilities (self-granted), I opted to be explicit to what these static abilities applied to, with the cards now working as expected.