### PR TITLE
Fix Puzzle Possibility Storm - Foundations #01

### DIFF
--- a/forge-gui/res/puzzle/PS_FDN1.pzl
+++ b/forge-gui/res/puzzle/PS_FDN1.pzl
@@ -15,5 +15,5 @@ p0library=Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Op
 p0graveyard=Electroduplicate
 p0battlefield=Stormsplitter;Fear of Missing Out;Ghired, Mirror of the Wilds;Mountain;Mountain;Mountain;Forgotten Monument;Forgotten Monument;Forgotten Monument
 p1life=27
-p0library=Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt
+p1library=Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt;Opt
 p1battlefield=Tomik, Wielder of Law;Soul Warden;Soul Warden


### PR DESCRIPTION
Fix : Puzzle (Possibility Storm - Foundations #01). Opponent library is empty.