### PR TITLE
Cant untap first step

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/ControlGainEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ControlGainEffect.java
@@ -166,7 +166,7 @@ public class ControlGainEffect extends SpellAbilityEffect {
             tgtC.addTempController(newController, tStamp);
 
             if (bUntap) {
-                if (tgtC.untap(true)) untapped.add(tgtC);
+                if (tgtC.untap()) untapped.add(tgtC);
             }
 
             if (keywords != null) {

--- a/forge-game/src/main/java/forge/game/ability/effects/TapOrUntapAllEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/TapOrUntapAllEffect.java
@@ -84,7 +84,7 @@ public class TapOrUntapAllEffect extends SpellAbilityEffect {
             if (toTap) {
                 if (gameCard.tap(true, sa, activator)) tapped.add(gameCard);
             } else {
-                if (gameCard.untap(true)) untapped.add(gameCard);
+                if (gameCard.untap()) untapped.add(gameCard);
             }
         }
         if (!tapped.isEmpty()) {

--- a/forge-game/src/main/java/forge/game/ability/effects/TapOrUntapEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/TapOrUntapEffect.java
@@ -65,7 +65,7 @@ public class TapOrUntapEffect extends SpellAbilityEffect {
                     !gameCard.getController().equals(tapper));
             if (tap) {
                 if (gameCard.tap(true, sa, tapper)) tapped.add(gameCard);
-            } else if (gameCard.untap(true)) {
+            } else if (gameCard.untap()) {
                 untapMap.computeIfAbsent(tapper, i -> new CardCollection()).add(gameCard);
             }
         }

--- a/forge-game/src/main/java/forge/game/ability/effects/UntapAllEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/UntapAllEffect.java
@@ -44,7 +44,7 @@ public class UntapAllEffect extends SpellAbilityEffect {
             if (sa.hasParam("ControllerUntaps")) {
                 untapper = c.getController();
             }
-            if (c.untap(true))  {
+            if (c.untap())  {
                 untapMap.computeIfAbsent(untapper, i -> new CardCollection()).add(c);
                 if (sa.hasParam("RememberUntapped")) card.addRemembered(c);
 

--- a/forge-game/src/main/java/forge/game/ability/effects/UntapEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/UntapEffect.java
@@ -66,7 +66,7 @@ public class UntapEffect extends SpellAbilityEffect {
                     if (gameCard == null || !tgtC.equalsWithGameTimestamp(gameCard)) {
                         continue;
                     }
-                    if (gameCard.untap(true)) untapped.add(gameCard);
+                    if (gameCard.untap()) untapped.add(gameCard);
                 }
                 if (etb) {
                     // do not fire triggers
@@ -114,7 +114,7 @@ public class UntapEffect extends SpellAbilityEffect {
             final CardCollectionView selected = p.getController().chooseCardsForEffect(list, sa, Localizer.getInstance().getMessage("lblSelectCardToUntap"), mandatory ? num : 0, num, !mandatory, null);
             if (selected != null) {
                 for (final Card c : selected) {
-                    if (c.untap(true)) untapped.add(c);
+                    if (c.untap()) untapped.add(c);
                 }
             }
             if (!untapped.isEmpty()) {

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -4916,13 +4916,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
         if (phase != null && isExertedBy(phase)) {
             return false;
         }
-
-        final Map<AbilityKey, Object> repParams = AbilityKey.mapFromAffected(this);
-        if (phase != null) {
-            repParams.put(AbilityKey.Phase, phase);
-        }
-
-        return !getGame().getReplacementHandler().cantHappenCheck(ReplacementType.Untap, repParams);
+        return !getGame().getReplacementHandler().cantHappenCheck(ReplacementType.Untap, AbilityKey.mapFromAffected(this));
     }
 
     public final boolean untap() {
@@ -4934,12 +4928,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
             return false;
         }
 
-        final Map<AbilityKey, Object> repParams = AbilityKey.mapFromAffected(this);
-        if (phase != null) {
-            repParams.put(AbilityKey.Phase, phase);
-        }
-
-        if (getGame().getReplacementHandler().run(ReplacementType.Untap, repParams) != ReplacementResult.NotReplaced) {
+        if (getGame().getReplacementHandler().run(ReplacementType.Untap, AbilityKey.mapFromAffected(this)) != ReplacementResult.NotReplaced) {
             return false;
         }
 

--- a/forge-game/src/main/java/forge/game/cost/CostUntap.java
+++ b/forge-game/src/main/java/forge/game/cost/CostUntap.java
@@ -87,7 +87,7 @@ public class CostUntap extends CostPart {
     @Override
     public boolean payAsDecided(Player ai, PaymentDecision decision, SpellAbility ability, final boolean effect) {
         final Card c = ability.getHostCard();
-        if (c.untap(true)) {
+        if (c.untap()) {
             final Map<AbilityKey, Object> runParams = AbilityKey.newMap();
             final Map<Player, CardCollection> map = Maps.newHashMap();
             map.put(ai, new CardCollection(c));

--- a/forge-game/src/main/java/forge/game/cost/CostUntapType.java
+++ b/forge-game/src/main/java/forge/game/cost/CostUntapType.java
@@ -94,7 +94,7 @@ public class CostUntapType extends CostPartWithList {
 
     @Override
     protected Card doPayment(Player payer, SpellAbility ability, Card targetCard, final boolean effect) {
-        targetCard.untap(true);
+        targetCard.untap();
         return targetCard;
     }
 
@@ -107,7 +107,7 @@ public class CostUntapType extends CostPartWithList {
     protected CardCollectionView doListPayment(Player payer, SpellAbility ability, CardCollectionView targetCards, final boolean effect) {
         CardCollection untapped = new CardCollection();
         for (Card c : targetCards) {
-            if (c.untap(true)) untapped.add(c);
+            if (c.untap()) untapped.add(c);
         }
         if (!untapped.isEmpty()) {
             final Map<AbilityKey, Object> runParams = AbilityKey.newMap();

--- a/forge-game/src/main/java/forge/game/phase/Untap.java
+++ b/forge-game/src/main/java/forge/game/phase/Untap.java
@@ -168,9 +168,6 @@ public class Untap extends Phase {
 
         cardsWithKW.addAll(cardsWithKW2);
         for (final Card cardWithKW : cardsWithKW) {
-            if (!cardWithKW.canUntap(player)) {
-                continue;
-            }
             if (cardWithKW.untap(player)) {
                 untapMap.computeIfAbsent(cardWithKW.getController(),
                         i -> new CardCollection()).add(cardWithKW);

--- a/forge-game/src/main/java/forge/game/phase/Untap.java
+++ b/forge-game/src/main/java/forge/game/phase/Untap.java
@@ -98,7 +98,7 @@ public class Untap extends Phase {
         //exerted need current player turn
         final Player playerTurn = c.getGame().getPhaseHandler().getPlayerTurn();
 
-        return !c.isExertedBy(playerTurn);
+        return c.canUntap(playerTurn);
     }
 
     public static final Predicate<Card> CANUNTAP = Untap::canUntap;
@@ -152,7 +152,7 @@ public class Untap extends Phase {
         });
 
         for (final Card c : list) {
-            if (optionalUntap(c)) {
+            if (optionalUntap(c, player)) {
                 untapMap.computeIfAbsent(player, i -> new CardCollection()).add(c);
             }
         }
@@ -168,10 +168,10 @@ public class Untap extends Phase {
 
         cardsWithKW.addAll(cardsWithKW2);
         for (final Card cardWithKW : cardsWithKW) {
-            if (cardWithKW.isExertedBy(player)) {
+            if (!cardWithKW.canUntap(player)) {
                 continue;
             }
-            if (cardWithKW.untap(true)) {
+            if (cardWithKW.untap(player)) {
                 untapMap.computeIfAbsent(cardWithKW.getController(),
                         i -> new CardCollection()).add(cardWithKW);
             }
@@ -203,7 +203,7 @@ public class Untap extends Phase {
             }
         }
         for (Card c : restrictUntapped) {
-            if (optionalUntap(c)) {
+            if (optionalUntap(c, player)) {
                 untapMap.computeIfAbsent(player, i -> new CardCollection()).add(c);
             }
         }
@@ -228,7 +228,7 @@ public class Untap extends Phase {
         game.getTriggerHandler().runTrigger(TriggerType.UntapAll, runParams, false);
     }
 
-    private static boolean optionalUntap(final Card c) {
+    private static boolean optionalUntap(final Card c, Player phase) {
         boolean untap = true;
 
         if (c.hasKeyword("You may choose not to untap CARDNAME during your untap step.") && c.isTapped()) {
@@ -247,7 +247,7 @@ public class Untap extends Phase {
             untap = c.getController().getController().chooseBinary(new SpellAbility.EmptySa(c, c.getController()), prompt.toString(), BinaryChoiceType.UntapOrLeaveTapped, defaultChoice);
         }
         if (untap) {
-            if (!c.untap(true)) untap = false;
+            if (!c.untap(phase)) untap = false;
         }
         return untap;
     }

--- a/forge-game/src/main/java/forge/game/replacement/ReplaceUntap.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplaceUntap.java
@@ -47,9 +47,6 @@ public class ReplaceUntap extends ReplacementEffect {
         if (!matchesValidParam("ValidCard", runParams.get(AbilityKey.Affected))) {
             return false;
         }
-        if (!matchesValidParam("UntapStep", runParams.get(AbilityKey.Phase))) {
-            return false;
-        }
         return true;
     }
 

--- a/forge-game/src/main/java/forge/game/replacement/ReplaceUntap.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplaceUntap.java
@@ -21,8 +21,6 @@ import java.util.Map;
 
 import forge.game.ability.AbilityKey;
 import forge.game.card.Card;
-import forge.game.phase.PhaseType;
-import forge.game.player.Player;
 import forge.game.spellability.SpellAbility;
 
 /** 
@@ -49,21 +47,9 @@ public class ReplaceUntap extends ReplacementEffect {
         if (!matchesValidParam("ValidCard", runParams.get(AbilityKey.Affected))) {
             return false;
         }
-        if (hasParam("UntapStep")) {
-            final Object o = runParams.get(AbilityKey.Affected);
-            //normally should not happen, but protect from possible crash.
-            if (!(o instanceof Card)) {
-                return false;
-            }
-
-            final Card card = (Card) o;
-            // all replace untap with untapStep does have "your untap step"
-            final Player player = card.getController();
-            if (!player.getGame().getPhaseHandler().is(PhaseType.UNTAP, player)) {
-                return false;
-            }
+        if (!matchesValidParam("UntapStep", runParams.get(AbilityKey.Phase))) {
+            return false;
         }
-
         return true;
     }
 

--- a/forge-gui/res/cardsfolder/a/altar_golem.txt
+++ b/forge-gui/res/cardsfolder/a/altar_golem.txt
@@ -3,7 +3,7 @@ ManaCost:7
 Types:Artifact Creature Golem
 PT:*/*
 K:Trample
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creatures on the battlefield.
 SVar:X:Count$Valid Creature
 A:AB$ Untap | Cost$ tapXType<5/Creature> | SpellDescription$ Untap this creature.

--- a/forge-gui/res/cardsfolder/a/altar_golem.txt
+++ b/forge-gui/res/cardsfolder/a/altar_golem.txt
@@ -3,11 +3,11 @@ ManaCost:7
 Types:Artifact Creature Golem
 PT:*/*
 K:Trample
-K:CARDNAME doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creatures on the battlefield.
 SVar:X:Count$Valid Creature
-A:AB$ Untap | Cost$ tapXType<5/Creature> | SpellDescription$ Untap CARDNAME.
+A:AB$ Untap | Cost$ tapXType<5/Creature> | SpellDescription$ Untap this creature.
 SVar:BuffedBy:Creature
 AI:RemoveDeck:Random
 SVar:NoZeroToughnessAI:True
-Oracle:Trample\nAltar Golem's power and toughness are each equal to the number of creatures on the battlefield.\nAltar Golem doesn't untap during your untap step.\nTap five untapped creatures you control: Untap Altar Golem.
+Oracle:Trample\nAltar Golem's power and toughness are each equal to the number of creatures on the battlefield.\nThis creature doesn't untap during your untap step.\nTap five untapped creatures you control: Untap this creature.

--- a/forge-gui/res/cardsfolder/b/basalt_monolith.txt
+++ b/forge-gui/res/cardsfolder/b/basalt_monolith.txt
@@ -1,8 +1,8 @@
 Name:Basalt Monolith
 ManaCost:3
 Types:Artifact
-K:CARDNAME doesn't untap during your untap step.
-A:AB$ Untap | Cost$ 3 | AILogic$ EOT | AIManaPref$ NotSameCard | SpellDescription$ Untap CARDNAME.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This artifact doesn't untap during your untap step.
 A:AB$ Mana | Cost$ T | Produced$ C | Amount$ 3 | SpellDescription$ Add {C}{C}{C}.
+A:AB$ Untap | Cost$ 3 | AILogic$ EOT | AIManaPref$ NotSameCard | SpellDescription$ Untap this artifact.
 AI:RemoveDeck:Random
-Oracle:Basalt Monolith doesn't untap during your untap step.\n{T}: Add {C}{C}{C}.\n{3}: Untap Basalt Monolith.
+Oracle:This artifact doesn't untap during your untap step.\n{T}: Add {C}{C}{C}.\n{3}: Untap this artifact.

--- a/forge-gui/res/cardsfolder/b/basalt_monolith.txt
+++ b/forge-gui/res/cardsfolder/b/basalt_monolith.txt
@@ -1,7 +1,7 @@
 Name:Basalt Monolith
 ManaCost:3
 Types:Artifact
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This artifact doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This artifact doesn't untap during your untap step.
 A:AB$ Mana | Cost$ T | Produced$ C | Amount$ 3 | SpellDescription$ Add {C}{C}{C}.
 A:AB$ Untap | Cost$ 3 | AILogic$ EOT | AIManaPref$ NotSameCard | SpellDescription$ Untap this artifact.
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/b/battered_golem.txt
+++ b/forge-gui/res/cardsfolder/b/battered_golem.txt
@@ -2,7 +2,7 @@ Name:Battered Golem
 ManaCost:3
 Types:Artifact Creature Golem
 PT:3/2
-K:CARDNAME doesn't untap during your untap step.
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Artifact | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigUntap | TriggerDescription$ Whenever an artifact enters, you may untap CARDNAME.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Artifact | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigUntap | TriggerDescription$ Whenever an artifact enters, you may untap this creature.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
-Oracle:Battered Golem doesn't untap during your untap step.\nWhenever an artifact enters, you may untap Battered Golem.
+Oracle:This creature doesn't untap during your untap step.\nWhenever an artifact enters, you may untap this creature.

--- a/forge-gui/res/cardsfolder/b/battered_golem.txt
+++ b/forge-gui/res/cardsfolder/b/battered_golem.txt
@@ -2,7 +2,7 @@ Name:Battered Golem
 ManaCost:3
 Types:Artifact Creature Golem
 PT:3/2
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Artifact | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigUntap | TriggerDescription$ Whenever an artifact enters, you may untap this creature.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
 Oracle:This creature doesn't untap during your untap step.\nWhenever an artifact enters, you may untap this creature.

--- a/forge-gui/res/cardsfolder/b/bewitching_leechcraft.txt
+++ b/forge-gui/res/cardsfolder/b/bewitching_leechcraft.txt
@@ -6,7 +6,7 @@ A:SP$ Attach | ValidTgts$ Creature | AILogic$ Curse
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigTap | TriggerDescription$ When CARDNAME enters, tap enchanted creature.
 SVar:TrigTap:DB$ Tap | Defined$ Enchanted
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddReplacementEffect$ DBUntap | Description$ Enchanted creature has "If this creature would untap during your untap step, remove a +1/+1 counter from it instead. If you do, untap it." (Otherwise, it doesn't untap.)
-SVar:DBUntap:Event$ Untap | ActiveZones$ Battlefield | ValidCard$ Card.Self | ReplaceWith$ RepRemoveCounter | UntapStep$ True | Description$ If this creature would untap during your untap step, remove a +1/+1 counter from it instead. If you do, untap it. (Otherwise, it doesn't untap.)
+SVar:DBUntap:Event$ Untap | ActiveZones$ Battlefield | ValidCard$ Card.Self | ReplaceWith$ RepRemoveCounter | UntapStep$ You | Description$ If this creature would untap during your untap step, remove a +1/+1 counter from it instead. If you do, untap it. (Otherwise, it doesn't untap.)
 SVar:RepRemoveCounter:DB$ RemoveCounter | Defined$ ReplacedCard | CounterType$ P1P1 | CounterNum$ 1 | RememberRemoved$ True | SubAbility$ Untap
 SVar:Untap:DB$ Untap | Defined$ Self | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/b/bewitching_leechcraft.txt
+++ b/forge-gui/res/cardsfolder/b/bewitching_leechcraft.txt
@@ -3,7 +3,7 @@ ManaCost:1 U
 Types:Enchantment Aura
 K:Enchant creature
 A:SP$ Attach | ValidTgts$ Creature | AILogic$ Curse
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigTap | TriggerDescription$ When CARDNAME enters, tap enchanted creature.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigTap | TriggerDescription$ When this Aura enters, tap enchanted creature.
 SVar:TrigTap:DB$ Tap | Defined$ Enchanted
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddReplacementEffect$ DBUntap | Description$ Enchanted creature has "If this creature would untap during your untap step, remove a +1/+1 counter from it instead. If you do, untap it." (Otherwise, it doesn't untap.)
 SVar:DBUntap:Event$ Untap | ActiveZones$ Battlefield | ValidCard$ Card.Self | ReplaceWith$ RepRemoveCounter | UntapStep$ You | Description$ If this creature would untap during your untap step, remove a +1/+1 counter from it instead. If you do, untap it. (Otherwise, it doesn't untap.)
@@ -11,4 +11,4 @@ SVar:RepRemoveCounter:DB$ RemoveCounter | Defined$ ReplacedCard | CounterType$ P
 SVar:Untap:DB$ Untap | Defined$ Self | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Count$RememberedSize
-Oracle:Enchant creature\nWhen Bewitching Leechcraft enters, tap enchanted creature.\nEnchanted creature has "If this creature would untap during your untap step, remove a +1/+1 counter from it instead. If you do, untap it." (Otherwise, it doesn't untap.)
+Oracle:Enchant creature\nWhen this Aura enters, tap enchanted creature.\nEnchanted creature has "If this creature would untap during your untap step, remove a +1/+1 counter from it instead. If you do, untap it." (Otherwise, it doesn't untap.)

--- a/forge-gui/res/cardsfolder/b/bewitching_leechcraft.txt
+++ b/forge-gui/res/cardsfolder/b/bewitching_leechcraft.txt
@@ -6,7 +6,7 @@ A:SP$ Attach | ValidTgts$ Creature | AILogic$ Curse
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigTap | TriggerDescription$ When this Aura enters, tap enchanted creature.
 SVar:TrigTap:DB$ Tap | Defined$ Enchanted
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddReplacementEffect$ DBUntap | Description$ Enchanted creature has "If this creature would untap during your untap step, remove a +1/+1 counter from it instead. If you do, untap it." (Otherwise, it doesn't untap.)
-SVar:DBUntap:Event$ Untap | ActiveZones$ Battlefield | ValidCard$ Card.Self | ReplaceWith$ RepRemoveCounter | UntapStep$ You | Description$ If this creature would untap during your untap step, remove a +1/+1 counter from it instead. If you do, untap it. (Otherwise, it doesn't untap.)
+SVar:DBUntap:Event$ Untap | ActiveZones$ Battlefield | ValidCard$ Card.Self | ReplaceWith$ RepRemoveCounter | ActivePhases$ Untap | PlayerTurn$ You | Description$ If this creature would untap during your untap step, remove a +1/+1 counter from it instead. If you do, untap it. (Otherwise, it doesn't untap.)
 SVar:RepRemoveCounter:DB$ RemoveCounter | Defined$ ReplacedCard | CounterType$ P1P1 | CounterNum$ 1 | RememberRemoved$ True | SubAbility$ Untap
 SVar:Untap:DB$ Untap | Defined$ Self | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/b/black_carriage.txt
+++ b/forge-gui/res/cardsfolder/b/black_carriage.txt
@@ -3,7 +3,7 @@ ManaCost:3 B B
 Types:Creature Horse
 PT:4/4
 K:Trample
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 A:AB$ Untap | Cost$ Sac<1/Creature> | ActivationPhases$ Upkeep | PlayerTurn$ True | SpellDescription$ Untap this creature. Activate only during your upkeep.
 AI:RemoveDeck:All
 Oracle:Trample\nThis creature doesn't untap during your untap step.\nSacrifice a creature: Untap this creature. Activate only during your upkeep.

--- a/forge-gui/res/cardsfolder/b/black_carriage.txt
+++ b/forge-gui/res/cardsfolder/b/black_carriage.txt
@@ -3,7 +3,7 @@ ManaCost:3 B B
 Types:Creature Horse
 PT:4/4
 K:Trample
-K:CARDNAME doesn't untap during your untap step.
-A:AB$ Untap | Cost$ Sac<1/Creature> | ActivationPhases$ Upkeep | PlayerTurn$ True | SpellDescription$ Untap CARDNAME. Activate only during your upkeep.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+A:AB$ Untap | Cost$ Sac<1/Creature> | ActivationPhases$ Upkeep | PlayerTurn$ True | SpellDescription$ Untap this creature. Activate only during your upkeep.
 AI:RemoveDeck:All
-Oracle:Trample\nBlack Carriage doesn't untap during your untap step.\nSacrifice a creature: Untap Black Carriage. Activate only during your upkeep.
+Oracle:Trample\nThis creature doesn't untap during your untap step.\nSacrifice a creature: Untap this creature. Activate only during your upkeep.

--- a/forge-gui/res/cardsfolder/b/brass_gnat.txt
+++ b/forge-gui/res/cardsfolder/b/brass_gnat.txt
@@ -3,7 +3,7 @@ ManaCost:1
 Types:Artifact Creature Insect
 PT:1/1
 K:Flying
-K:CARDNAME doesn't untap during your untap step.
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | OptionalDecider$ You | Execute$ TrigUntap | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, you may pay {1}. If you do, untap CARDNAME.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | OptionalDecider$ You | Execute$ TrigUntap | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, you may pay {1}. If you do, untap this creature.
 SVar:TrigUntap:AB$ Untap | Cost$ 1 | Defined$ Self
-Oracle:Flying\nBrass Gnat doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {1}. If you do, untap Brass Gnat.
+Oracle:Flying\nThis creature doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {1}. If you do, untap this creature.

--- a/forge-gui/res/cardsfolder/b/brass_gnat.txt
+++ b/forge-gui/res/cardsfolder/b/brass_gnat.txt
@@ -3,7 +3,7 @@ ManaCost:1
 Types:Artifact Creature Insect
 PT:1/1
 K:Flying
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | OptionalDecider$ You | Execute$ TrigUntap | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, you may pay {1}. If you do, untap this creature.
 SVar:TrigUntap:AB$ Untap | Cost$ 1 | Defined$ Self
 Oracle:Flying\nThis creature doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {1}. If you do, untap this creature.

--- a/forge-gui/res/cardsfolder/b/brass_man.txt
+++ b/forge-gui/res/cardsfolder/b/brass_man.txt
@@ -2,7 +2,7 @@ Name:Brass Man
 ManaCost:1
 Types:Artifact Creature Construct
 PT:1/3
-K:CARDNAME doesn't untap during your untap step.
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | OptionalDecider$ You | Execute$ TrigUntap | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, you may pay {1}. If you do, untap CARDNAME.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | OptionalDecider$ You | Execute$ TrigUntap | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, you may pay {1}. If you do, untap this creature.
 SVar:TrigUntap:AB$ Untap | Cost$ 1 | Defined$ Self
-Oracle:Brass Man doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {1}. If you do, untap Brass Man.
+Oracle:This creature doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {1}. If you do, untap this creature.

--- a/forge-gui/res/cardsfolder/b/brass_man.txt
+++ b/forge-gui/res/cardsfolder/b/brass_man.txt
@@ -2,7 +2,7 @@ Name:Brass Man
 ManaCost:1
 Types:Artifact Creature Construct
 PT:1/3
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | OptionalDecider$ You | Execute$ TrigUntap | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, you may pay {1}. If you do, untap this creature.
 SVar:TrigUntap:AB$ Untap | Cost$ 1 | Defined$ Self
 Oracle:This creature doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {1}. If you do, untap this creature.

--- a/forge-gui/res/cardsfolder/c/chained_brute.txt
+++ b/forge-gui/res/cardsfolder/c/chained_brute.txt
@@ -2,7 +2,7 @@ Name:Chained Brute
 ManaCost:1 R
 Types:Creature Devil
 PT:4/3
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 A:AB$ Untap | Cost$ 1 Sac<1/Creature.Other/another creature> | PlayerTurn$ True | SpellDescription$ Untap this creature. Activate only during your turn.
 SVar:AIPreference:SacCost$Creature.token+powerLE2+toughnessLE2,Creature.cmcLE2+powerLE1+toughnessLE2+inZoneBattlefield
 DeckHas:Ability$Sacrifice

--- a/forge-gui/res/cardsfolder/c/chained_brute.txt
+++ b/forge-gui/res/cardsfolder/c/chained_brute.txt
@@ -2,8 +2,8 @@ Name:Chained Brute
 ManaCost:1 R
 Types:Creature Devil
 PT:4/3
-K:CARDNAME doesn't untap during your untap step.
-A:AB$ Untap | Cost$ 1 Sac<1/Creature.Other/another creature> | PlayerTurn$ True | SpellDescription$ Untap CARDNAME. Activate only during your turn.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+A:AB$ Untap | Cost$ 1 Sac<1/Creature.Other/another creature> | PlayerTurn$ True | SpellDescription$ Untap this creature. Activate only during your turn.
 SVar:AIPreference:SacCost$Creature.token+powerLE2+toughnessLE2,Creature.cmcLE2+powerLE1+toughnessLE2+inZoneBattlefield
 DeckHas:Ability$Sacrifice
-Oracle:Chained Brute doesn't untap during your untap step.\n{1}, Sacrifice another creature: Untap Chained Brute. Activate only during your turn.
+Oracle:This creature doesn't untap during your untap step.\n{1}, Sacrifice another creature: Untap this creature. Activate only during your turn.

--- a/forge-gui/res/cardsfolder/c/colossus_of_sardia.txt
+++ b/forge-gui/res/cardsfolder/c/colossus_of_sardia.txt
@@ -3,6 +3,6 @@ ManaCost:9
 Types:Artifact Creature Golem
 PT:9/9
 K:Trample
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 A:AB$ Untap | Cost$ 9 | ActivationPhases$ Upkeep | PlayerTurn$ True | SpellDescription$ Untap this creature. Activate only during your upkeep.
 Oracle:Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nThis creature doesn't untap during your untap step.\n{9}: Untap this creature. Activate only during your upkeep.

--- a/forge-gui/res/cardsfolder/c/colossus_of_sardia.txt
+++ b/forge-gui/res/cardsfolder/c/colossus_of_sardia.txt
@@ -3,6 +3,6 @@ ManaCost:9
 Types:Artifact Creature Golem
 PT:9/9
 K:Trample
-K:CARDNAME doesn't untap during your untap step.
-A:AB$ Untap | Cost$ 9 | ActivationPhases$ Upkeep | PlayerTurn$ True | SpellDescription$ Untap CARDNAME. Activate only during your upkeep.
-Oracle:Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nColossus of Sardia doesn't untap during your untap step.\n{9}: Untap Colossus of Sardia. Activate only during your upkeep.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+A:AB$ Untap | Cost$ 9 | ActivationPhases$ Upkeep | PlayerTurn$ True | SpellDescription$ Untap this creature. Activate only during your upkeep.
+Oracle:Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nThis creature doesn't untap during your untap step.\n{9}: Untap this creature. Activate only during your upkeep.

--- a/forge-gui/res/cardsfolder/d/deep_slumber_titan.txt
+++ b/forge-gui/res/cardsfolder/d/deep_slumber_titan.txt
@@ -8,4 +8,4 @@ R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Des
 T:Mode$ DamageDoneOnce | ValidTarget$ Card.Self | Execute$ TrigUntap | TriggerDescription$ Whenever this creature is dealt damage, untap it.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
 AI:RemoveDeck:Random
-Oracle:This creature enters tapped.\nDeep-Slumber Titan doesn't untap during your untap step.\nWhenever this creature is dealt damage, untap it.
+Oracle:This creature enters tapped.\nThis creature doesn't untap during your untap step.\nWhenever this creature is dealt damage, untap it.

--- a/forge-gui/res/cardsfolder/d/deep_slumber_titan.txt
+++ b/forge-gui/res/cardsfolder/d/deep_slumber_titan.txt
@@ -4,7 +4,7 @@ Types:Creature Giant Warrior
 PT:7/7
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ This creature enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 T:Mode$ DamageDoneOnce | ValidTarget$ Card.Self | Execute$ TrigUntap | TriggerDescription$ Whenever this creature is dealt damage, untap it.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/d/deep_slumber_titan.txt
+++ b/forge-gui/res/cardsfolder/d/deep_slumber_titan.txt
@@ -2,10 +2,10 @@ Name:Deep-Slumber Titan
 ManaCost:2 R R
 Types:Creature Giant Warrior
 PT:7/7
-R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ This creature enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
-K:CARDNAME doesn't untap during your untap step.
-T:Mode$ DamageDoneOnce | ValidTarget$ Card.Self | Execute$ TrigUntap | TriggerDescription$ Whenever CARDNAME is dealt damage, untap it.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+T:Mode$ DamageDoneOnce | ValidTarget$ Card.Self | Execute$ TrigUntap | TriggerDescription$ Whenever this creature is dealt damage, untap it.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
 AI:RemoveDeck:Random
-Oracle:Deep-Slumber Titan enters tapped.\nDeep-Slumber Titan doesn't untap during your untap step.\nWhenever Deep-Slumber Titan is dealt damage, untap it.
+Oracle:This creature enters tapped.\nDeep-Slumber Titan doesn't untap during your untap step.\nWhenever this creature is dealt damage, untap it.

--- a/forge-gui/res/cardsfolder/d/depth_charge_colossus.txt
+++ b/forge-gui/res/cardsfolder/d/depth_charge_colossus.txt
@@ -3,7 +3,7 @@ ManaCost:9
 Types:Artifact Creature Dreadnought
 PT:9/9
 K:Prototype:4 U U:6:6
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 A:AB$ Untap | Cost$ 3 | SpellDescription$ Untap this creature.
 DeckHints:Color$Blue
 Oracle:Prototype {4}{U}{U} — 6/6 (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\nThis creature doesn't untap during your untap step.\n{3}: Untap this creature.

--- a/forge-gui/res/cardsfolder/d/depth_charge_colossus.txt
+++ b/forge-gui/res/cardsfolder/d/depth_charge_colossus.txt
@@ -3,7 +3,7 @@ ManaCost:9
 Types:Artifact Creature Dreadnought
 PT:9/9
 K:Prototype:4 U U:6:6
-K:CARDNAME doesn't untap during your untap step.
-A:AB$ Untap | Cost$ 3 | SpellDescription$ Untap CARDNAME.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+A:AB$ Untap | Cost$ 3 | SpellDescription$ Untap this creature.
 DeckHints:Color$Blue
-Oracle:Prototype {4}{U}{U} — 6/6 (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\nDepth Charge Colossus doesn't untap during your untap step.\n{3}: Untap Depth Charge Colossus.
+Oracle:Prototype {4}{U}{U} — 6/6 (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\nThis creature doesn't untap during your untap step.\n{3}: Untap this creature.

--- a/forge-gui/res/cardsfolder/d/dormant_gomazoa.txt
+++ b/forge-gui/res/cardsfolder/d/dormant_gomazoa.txt
@@ -5,7 +5,7 @@ PT:5/5
 K:Flying
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ This creature enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 T:Mode$ BecomesTarget | ValidTarget$ You | ValidSource$ Spell | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigUntap | TriggerDescription$ Whenever you become the target of a spell, you may untap this creature.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
 Oracle:Flying\nThis creature enters tapped.\nThis creature doesn't untap during your untap step.\nWhenever you become the target of a spell, you may untap this creature.

--- a/forge-gui/res/cardsfolder/d/dormant_gomazoa.txt
+++ b/forge-gui/res/cardsfolder/d/dormant_gomazoa.txt
@@ -3,9 +3,9 @@ ManaCost:1 U U
 Types:Creature Jellyfish
 PT:5/5
 K:Flying
-R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ This creature enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
-K:CARDNAME doesn't untap during your untap step.
-T:Mode$ BecomesTarget | ValidTarget$ You | ValidSource$ Spell | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigUntap | TriggerDescription$ Whenever you become the target of a spell, you may untap CARDNAME.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+T:Mode$ BecomesTarget | ValidTarget$ You | ValidSource$ Spell | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigUntap | TriggerDescription$ Whenever you become the target of a spell, you may untap this creature.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
-Oracle:Flying\nDormant Gomazoa enters tapped.\nDormant Gomazoa doesn't untap during your untap step.\nWhenever you become the target of a spell, you may untap Dormant Gomazoa.
+Oracle:Flying\nThis creature enters tapped.\nThis creature doesn't untap during your untap step.\nWhenever you become the target of a spell, you may untap this creature.

--- a/forge-gui/res/cardsfolder/d/dwarven_patrol.txt
+++ b/forge-gui/res/cardsfolder/d/dwarven_patrol.txt
@@ -2,7 +2,7 @@ Name:Dwarven Patrol
 ManaCost:2 R
 Types:Creature Dwarf
 PT:4/2
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 T:Mode$ SpellCast | ValidCard$ Card.nonRed | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ Whenever you cast a nonred spell, untap this creature.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/d/dwarven_patrol.txt
+++ b/forge-gui/res/cardsfolder/d/dwarven_patrol.txt
@@ -2,8 +2,8 @@ Name:Dwarven Patrol
 ManaCost:2 R
 Types:Creature Dwarf
 PT:4/2
-K:CARDNAME doesn't untap during your untap step.
-T:Mode$ SpellCast | ValidCard$ Card.nonRed | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ Whenever you cast a nonred spell, untap CARDNAME.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+T:Mode$ SpellCast | ValidCard$ Card.nonRed | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ Whenever you cast a nonred spell, untap this creature.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
 AI:RemoveDeck:Random
-Oracle:Dwarven Patrol doesn't untap during your untap step.\nWhenever you cast a nonred spell, untap Dwarven Patrol.
+Oracle:This creature doesn't untap during your untap step.\nWhenever you cast a nonred spell, untap this creature.

--- a/forge-gui/res/cardsfolder/e/edge_of_malacol.txt
+++ b/forge-gui/res/cardsfolder/e/edge_of_malacol.txt
@@ -1,7 +1,7 @@
 Name:Edge of Malacol
 ManaCost:no cost
 Types:Plane Belenon
-R:Event$ Untap | ActiveZones$ Command | ValidCard$ Creature.YouCtrl | ReplaceWith$ RepPutCounter | UntapStep$ True | Description$ If a creature you control would untap during your untap step, put two +1/+1 counters on it instead.
+R:Event$ Untap | ActiveZones$ Command | ValidCard$ Creature.YouCtrl | ReplaceWith$ RepPutCounter | UntapStep$ You | Description$ If a creature you control would untap during your untap step, put two +1/+1 counters on it instead.
 SVar:RepPutCounter:DB$ PutCounter | Defined$ ReplacedCard | CounterType$ P1P1 | CounterNum$ 2
 T:Mode$ ChaosEnsues | TriggerZones$ Command | Execute$ RolledChaos | TriggerDescription$ Whenever chaos ensues, untap each creature you control.
 SVar:RolledChaos:DB$ UntapAll | ValidCards$ Creature.YouCtrl

--- a/forge-gui/res/cardsfolder/e/edge_of_malacol.txt
+++ b/forge-gui/res/cardsfolder/e/edge_of_malacol.txt
@@ -1,7 +1,7 @@
 Name:Edge of Malacol
 ManaCost:no cost
 Types:Plane Belenon
-R:Event$ Untap | ActiveZones$ Command | ValidCard$ Creature.YouCtrl | ReplaceWith$ RepPutCounter | UntapStep$ You | Description$ If a creature you control would untap during your untap step, put two +1/+1 counters on it instead.
+R:Event$ Untap | ActiveZones$ Command | ValidCard$ Creature.YouCtrl | ReplaceWith$ RepPutCounter | ActivePhases$ Untap | PlayerTurn$ You | Description$ If a creature you control would untap during your untap step, put two +1/+1 counters on it instead.
 SVar:RepPutCounter:DB$ PutCounter | Defined$ ReplacedCard | CounterType$ P1P1 | CounterNum$ 2
 T:Mode$ ChaosEnsues | TriggerZones$ Command | Execute$ RolledChaos | TriggerDescription$ Whenever chaos ensues, untap each creature you control.
 SVar:RolledChaos:DB$ UntapAll | ValidCards$ Creature.YouCtrl

--- a/forge-gui/res/cardsfolder/e/elaborate_firecannon.txt
+++ b/forge-gui/res/cardsfolder/e/elaborate_firecannon.txt
@@ -1,8 +1,8 @@
 Name:Elaborate Firecannon
 ManaCost:2
 Types:Artifact
-K:CARDNAME doesn't untap during your untap step.
-A:AB$ DealDamage | Cost$ 4 T | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ CARDNAME deals 2 damage to any target.
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ At the beginning of your upkeep, you may discard a card. If you do, untap CARDNAME.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This artifact doesn't untap during your untap step.
+A:AB$ DealDamage | Cost$ 4 T | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ This artifact deals 2 damage to any target.
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ At the beginning of your upkeep, you may discard a card. If you do, untap this artifact.
 SVar:TrigUntap:AB$ Untap | Cost$ Discard<1/Card> | Defined$ Self
-Oracle:Elaborate Firecannon doesn't untap during your untap step.\n{4}, {T}: Elaborate Firecannon deals 2 damage to any target.\nAt the beginning of your upkeep, you may discard a card. If you do, untap Elaborate Firecannon.
+Oracle:This artifact doesn't untap during your untap step.\n{4}, {T}: This artifact deals 2 damage to any target.\nAt the beginning of your upkeep, you may discard a card. If you do, untap this artifact.

--- a/forge-gui/res/cardsfolder/e/elaborate_firecannon.txt
+++ b/forge-gui/res/cardsfolder/e/elaborate_firecannon.txt
@@ -1,7 +1,7 @@
 Name:Elaborate Firecannon
 ManaCost:2
 Types:Artifact
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This artifact doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This artifact doesn't untap during your untap step.
 A:AB$ DealDamage | Cost$ 4 T | ValidTgts$ Any | NumDmg$ 2 | SpellDescription$ This artifact deals 2 damage to any target.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ At the beginning of your upkeep, you may discard a card. If you do, untap this artifact.
 SVar:TrigUntap:AB$ Untap | Cost$ Discard<1/Card> | Defined$ Self

--- a/forge-gui/res/cardsfolder/f/famished_paladin.txt
+++ b/forge-gui/res/cardsfolder/f/famished_paladin.txt
@@ -2,7 +2,7 @@ Name:Famished Paladin
 ManaCost:1 W
 Types:Creature Vampire Knight
 PT:3/3
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 T:Mode$ LifeGained | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ Whenever you gain life, untap this creature.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/f/famished_paladin.txt
+++ b/forge-gui/res/cardsfolder/f/famished_paladin.txt
@@ -2,8 +2,8 @@ Name:Famished Paladin
 ManaCost:1 W
 Types:Creature Vampire Knight
 PT:3/3
-K:CARDNAME doesn't untap during your untap step.
-T:Mode$ LifeGained | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ Whenever you gain life, untap CARDNAME.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+T:Mode$ LifeGained | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ Whenever you gain life, untap this creature.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
 AI:RemoveDeck:Random
-Oracle:Famished Paladin doesn't untap during your untap step.\nWhenever you gain life, untap Famished Paladin.
+Oracle:This creature doesn't untap during your untap step.\nWhenever you gain life, untap this creature.

--- a/forge-gui/res/cardsfolder/f/farmstead_gleaner.txt
+++ b/forge-gui/res/cardsfolder/f/farmstead_gleaner.txt
@@ -2,7 +2,7 @@ Name:Farmstead Gleaner
 ManaCost:3
 Types:Artifact Creature Scarecrow
 PT:2/2
-K:CARDNAME doesn't untap during your untap step.
-A:AB$ PutCounter | Cost$ 2 Q | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on CARDNAME.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+A:AB$ PutCounter | Cost$ 2 Q | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on this creature.
 DeckHas:Ability$Counters
-Oracle:Farmstead Gleaner doesn't untap during your untap step.\n{2}, {Q}: Put a +1/+1 counter on Farmstead Gleaner. ({Q} is the untap symbol.)
+Oracle:This creature doesn't untap during your untap step.\n{2}, {Q}: Put a +1/+1 counter on this creature. ({Q} is the untap symbol.)

--- a/forge-gui/res/cardsfolder/f/farmstead_gleaner.txt
+++ b/forge-gui/res/cardsfolder/f/farmstead_gleaner.txt
@@ -2,7 +2,7 @@ Name:Farmstead Gleaner
 ManaCost:3
 Types:Artifact Creature Scarecrow
 PT:2/2
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 A:AB$ PutCounter | Cost$ 2 Q | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on this creature.
 DeckHas:Ability$Counters
 Oracle:This creature doesn't untap during your untap step.\n{2}, {Q}: Put a +1/+1 counter on this creature. ({Q} is the untap symbol.)

--- a/forge-gui/res/cardsfolder/f/forsaken_city.txt
+++ b/forge-gui/res/cardsfolder/f/forsaken_city.txt
@@ -1,7 +1,7 @@
 Name:Forsaken City
 ManaCost:no cost
 Types:Land
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This land doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This land doesn't untap during your untap step.
 A:AB$ Mana | Cost$ T | Produced$ Any | SpellDescription$ Add one mana of any color.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ At the beginning of your upkeep, you may exile a card from your hand. If you do, untap this land.
 SVar:TrigUntap:AB$ Untap | Cost$ ExileFromHand<1/Card> | Defined$ Self

--- a/forge-gui/res/cardsfolder/f/forsaken_city.txt
+++ b/forge-gui/res/cardsfolder/f/forsaken_city.txt
@@ -1,9 +1,9 @@
 Name:Forsaken City
 ManaCost:no cost
 Types:Land
-K:CARDNAME doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This land doesn't untap during your untap step.
 A:AB$ Mana | Cost$ T | Produced$ Any | SpellDescription$ Add one mana of any color.
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ At the beginning of your upkeep, you may exile a card from your hand. If you do, untap CARDNAME.
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ At the beginning of your upkeep, you may exile a card from your hand. If you do, untap this land.
 SVar:TrigUntap:AB$ Untap | Cost$ ExileFromHand<1/Card> | Defined$ Self
 AI:RemoveDeck:All
-Oracle:Forsaken City doesn't untap during your untap step.\nAt the beginning of your upkeep, you may exile a card from your hand. If you do, untap Forsaken City.\n{T}: Add one mana of any color.
+Oracle:This land doesn't untap during your untap step.\nAt the beginning of your upkeep, you may exile a card from your hand. If you do, untap this land.\n{T}: Add one mana of any color.

--- a/forge-gui/res/cardsfolder/f/freyalises_winds.txt
+++ b/forge-gui/res/cardsfolder/f/freyalises_winds.txt
@@ -3,7 +3,7 @@ ManaCost:2 G G
 Types:Enchantment
 T:Mode$ Taps | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Whenever a permanent becomes tapped, put a wind counter on it.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ TriggeredCardLKICopy | CounterType$ WIND | CounterNum$ 1
-R:Event$ Untap | ActiveZones$ Battlefield | ValidCard$ Permanent.counters_GE1_WIND | ReplaceWith$ RepRemoveCounter | UntapStep$ Player | Description$ If a permanent with a wind counter on it would untap during its controller's untap step, remove all wind counters from it instead.
+R:Event$ Untap | ActiveZones$ Battlefield | ValidCard$ Permanent.counters_GE1_WIND+ActivePlayerCtrl | ReplaceWith$ RepRemoveCounter | ActivePhases$ Untap | Description$ If a permanent with a wind counter on it would untap during its controller's untap step, remove all wind counters from it instead.
 SVar:RepRemoveCounter:DB$ RemoveCounter | Defined$ ReplacedCard | CounterType$ WIND | CounterNum$ All
 AI:RemoveDeck:Random
 Oracle:Whenever a permanent becomes tapped, put a wind counter on it.\nIf a permanent with a wind counter on it would untap during its controller's untap step, remove all wind counters from it instead.

--- a/forge-gui/res/cardsfolder/f/freyalises_winds.txt
+++ b/forge-gui/res/cardsfolder/f/freyalises_winds.txt
@@ -3,7 +3,7 @@ ManaCost:2 G G
 Types:Enchantment
 T:Mode$ Taps | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Whenever a permanent becomes tapped, put a wind counter on it.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ TriggeredCardLKICopy | CounterType$ WIND | CounterNum$ 1
-R:Event$ Untap | ActiveZones$ Battlefield | ValidCard$ Permanent.counters_GE1_WIND | ReplaceWith$ RepRemoveCounter | UntapStep$ True | Description$ If a permanent with a wind counter on it would untap during its controller's untap step, remove all wind counters from it instead.
+R:Event$ Untap | ActiveZones$ Battlefield | ValidCard$ Permanent.counters_GE1_WIND | ReplaceWith$ RepRemoveCounter | UntapStep$ Player | Description$ If a permanent with a wind counter on it would untap during its controller's untap step, remove all wind counters from it instead.
 SVar:RepRemoveCounter:DB$ RemoveCounter | Defined$ ReplacedCard | CounterType$ WIND | CounterNum$ All
 AI:RemoveDeck:Random
 Oracle:Whenever a permanent becomes tapped, put a wind counter on it.\nIf a permanent with a wind counter on it would untap during its controller's untap step, remove all wind counters from it instead.

--- a/forge-gui/res/cardsfolder/g/galvanic_juggernaut.txt
+++ b/forge-gui/res/cardsfolder/g/galvanic_juggernaut.txt
@@ -2,8 +2,8 @@ Name:Galvanic Juggernaut
 ManaCost:4
 Types:Artifact Creature Juggernaut
 PT:5/5
-S:Mode$ MustAttack | ValidCreature$ Card.Self | Description$ CARDNAME attacks each combat if able.
-K:CARDNAME doesn't untap during your untap step.
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.Other | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ Whenever another creature dies, untap CARDNAME.
+S:Mode$ MustAttack | ValidCreature$ Card.Self | Description$ This creature attacks each combat if able.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.Other | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ Whenever another creature dies, untap this creature.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
-Oracle:Galvanic Juggernaut attacks each combat if able.\nGalvanic Juggernaut doesn't untap during your untap step.\nWhenever another creature dies, untap Galvanic Juggernaut.
+Oracle:This creature attacks each combat if able.\nThis creature doesn't untap during your untap step.\nWhenever another creature dies, untap this creature.

--- a/forge-gui/res/cardsfolder/g/galvanic_juggernaut.txt
+++ b/forge-gui/res/cardsfolder/g/galvanic_juggernaut.txt
@@ -3,7 +3,7 @@ ManaCost:4
 Types:Artifact Creature Juggernaut
 PT:5/5
 S:Mode$ MustAttack | ValidCreature$ Card.Self | Description$ This creature attacks each combat if able.
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.Other | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ Whenever another creature dies, untap this creature.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
 Oracle:This creature attacks each combat if able.\nThis creature doesn't untap during your untap step.\nWhenever another creature dies, untap this creature.

--- a/forge-gui/res/cardsfolder/g/goblin_dirigible.txt
+++ b/forge-gui/res/cardsfolder/g/goblin_dirigible.txt
@@ -3,7 +3,7 @@ ManaCost:6
 Types:Artifact Creature Construct
 PT:4/4
 K:Flying
-K:CARDNAME doesn't untap during your untap step.
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigUntap | TriggerDescription$ At the beginning of your upkeep, you may pay {4}. If you do, untap CARDNAME.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigUntap | TriggerDescription$ At the beginning of your upkeep, you may pay {4}. If you do, untap this creature.
 SVar:TrigUntap:AB$ Untap | Cost$ 4 | Defined$ Self
-Oracle:Flying\nGoblin Dirigible doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {4}. If you do, untap Goblin Dirigible.
+Oracle:Flying\nThis creature doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {4}. If you do, untap this creature.

--- a/forge-gui/res/cardsfolder/g/goblin_dirigible.txt
+++ b/forge-gui/res/cardsfolder/g/goblin_dirigible.txt
@@ -3,7 +3,7 @@ ManaCost:6
 Types:Artifact Creature Construct
 PT:4/4
 K:Flying
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigUntap | TriggerDescription$ At the beginning of your upkeep, you may pay {4}. If you do, untap this creature.
 SVar:TrigUntap:AB$ Untap | Cost$ 4 | Defined$ Self
 Oracle:Flying\nThis creature doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {4}. If you do, untap this creature.

--- a/forge-gui/res/cardsfolder/g/goblin_sharpshooter.txt
+++ b/forge-gui/res/cardsfolder/g/goblin_sharpshooter.txt
@@ -2,7 +2,7 @@ Name:Goblin Sharpshooter
 ManaCost:2 R
 Types:Creature Goblin
 PT:1/1
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ Whenever a creature dies, untap this creature.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
 A:AB$ DealDamage | Cost$ T | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ This creature deals 1 damage to any target.

--- a/forge-gui/res/cardsfolder/g/goblin_sharpshooter.txt
+++ b/forge-gui/res/cardsfolder/g/goblin_sharpshooter.txt
@@ -2,9 +2,9 @@ Name:Goblin Sharpshooter
 ManaCost:2 R
 Types:Creature Goblin
 PT:1/1
-A:AB$ DealDamage | Cost$ T | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to any target.
-K:CARDNAME doesn't untap during your untap step.
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ Whenever a creature dies, untap CARDNAME.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ Whenever a creature dies, untap this creature.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
+A:AB$ DealDamage | Cost$ T | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ This creature deals 1 damage to any target.
 SVar:NonCombatPriority:1
-Oracle:Goblin Sharpshooter doesn't untap during your untap step.\nWhenever a creature dies, untap Goblin Sharpshooter.\n{T}: Goblin Sharpshooter deals 1 damage to any target.
+Oracle:This creature doesn't untap during your untap step.\nWhenever a creature dies, untap this creature.\n{T}: This creature deals 1 damage to any target.

--- a/forge-gui/res/cardsfolder/g/goblin_war_wagon.txt
+++ b/forge-gui/res/cardsfolder/g/goblin_war_wagon.txt
@@ -2,7 +2,7 @@ Name:Goblin War Wagon
 ManaCost:4
 Types:Artifact Creature Juggernaut
 PT:3/3
-K:CARDNAME doesn't untap during your untap step.
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigUntap | TriggerDescription$ At the beginning of your upkeep, you may pay {2}. If you do, untap CARDNAME.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigUntap | TriggerDescription$ At the beginning of your upkeep, you may pay {2}. If you do, untap this creature.
 SVar:TrigUntap:AB$ Untap | Cost$ 2 | Defined$ Self
-Oracle:Goblin War Wagon doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {2}. If you do, untap Goblin War Wagon.
+Oracle:This creature doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {2}. If you do, untap this creature.

--- a/forge-gui/res/cardsfolder/g/goblin_war_wagon.txt
+++ b/forge-gui/res/cardsfolder/g/goblin_war_wagon.txt
@@ -2,7 +2,7 @@ Name:Goblin War Wagon
 ManaCost:4
 Types:Artifact Creature Juggernaut
 PT:3/3
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigUntap | TriggerDescription$ At the beginning of your upkeep, you may pay {2}. If you do, untap this creature.
 SVar:TrigUntap:AB$ Untap | Cost$ 2 | Defined$ Self
 Oracle:This creature doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {2}. If you do, untap this creature.

--- a/forge-gui/res/cardsfolder/g/grim_monolith.txt
+++ b/forge-gui/res/cardsfolder/g/grim_monolith.txt
@@ -1,7 +1,7 @@
 Name:Grim Monolith
 ManaCost:2
 Types:Artifact
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This artifact doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This artifact doesn't untap during your untap step.
 A:AB$ Mana | Cost$ T | Produced$ C | Amount$ 3 | SpellDescription$ Add {C}{C}{C}.
 A:AB$ Untap | Cost$ 4 | AILogic$ EOT | SpellDescription$ Untap this artifact.
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/g/grim_monolith.txt
+++ b/forge-gui/res/cardsfolder/g/grim_monolith.txt
@@ -1,8 +1,8 @@
 Name:Grim Monolith
 ManaCost:2
 Types:Artifact
-K:CARDNAME doesn't untap during your untap step.
-A:AB$ Untap | Cost$ 4 | AILogic$ EOT | SpellDescription$ Untap CARDNAME.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This artifact doesn't untap during your untap step.
 A:AB$ Mana | Cost$ T | Produced$ C | Amount$ 3 | SpellDescription$ Add {C}{C}{C}.
+A:AB$ Untap | Cost$ 4 | AILogic$ EOT | SpellDescription$ Untap this artifact.
 AI:RemoveDeck:Random
-Oracle:Grim Monolith doesn't untap during your untap step.\n{T}: Add {C}{C}{C}.\n{4}: Untap Grim Monolith.
+Oracle:This artifact doesn't untap during your untap step.\n{T}: Add {C}{C}{C}.\n{4}: Untap this artifact.

--- a/forge-gui/res/cardsfolder/g/grimgrin_corpse_born.txt
+++ b/forge-gui/res/cardsfolder/g/grimgrin_corpse_born.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature Zombie Warrior
 PT:5/5
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ NICKNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ NICKNAME doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ NICKNAME doesn't untap during your untap step.
 A:AB$ Untap | Cost$ Sac<1/Creature.Other/another creature> | SubAbility$ DBPutCounter | SpellDescription$ Untap NICKNAME and put a +1/+1 counter on it.
 SVar:DBPutCounter:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ 1
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigDestroy | TriggerDescription$ Whenever NICKNAME attacks, destroy target creature defending player controls, then put a +1/+1 counter on NICKNAME.

--- a/forge-gui/res/cardsfolder/g/grimgrin_corpse_born.txt
+++ b/forge-gui/res/cardsfolder/g/grimgrin_corpse_born.txt
@@ -2,9 +2,9 @@ Name:Grimgrin, Corpse-Born
 ManaCost:3 U B
 Types:Legendary Creature Zombie Warrior
 PT:5/5
-R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ NICKNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
-K:CARDNAME doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ NICKNAME doesn't untap during your untap step.
 A:AB$ Untap | Cost$ Sac<1/Creature.Other/another creature> | SubAbility$ DBPutCounter | SpellDescription$ Untap NICKNAME and put a +1/+1 counter on it.
 SVar:DBPutCounter:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ 1
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigDestroy | TriggerDescription$ Whenever NICKNAME attacks, destroy target creature defending player controls, then put a +1/+1 counter on NICKNAME.
@@ -12,4 +12,4 @@ SVar:TrigDestroy:DB$ Destroy | ValidTgts$ Creature.ControlledBy TriggeredDefendi
 SVar:DBPutCounter:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ 1
 AI:RemoveDeck:Random
 SVar:HasAttackEffect:TRUE
-Oracle:Grimgrin, Corpse-Born enters tapped and doesn't untap during your untap step.\nSacrifice another creature: Untap Grimgrin and put a +1/+1 counter on it.\nWhenever Grimgrin attacks, destroy target creature defending player controls, then put a +1/+1 counter on Grimgrin.
+Oracle:Grimgrin enters tapped and doesn't untap during your untap step.\nSacrifice another creature: Untap Grimgrin and put a +1/+1 counter on it.\nWhenever Grimgrin attacks, destroy target creature defending player controls, then put a +1/+1 counter on Grimgrin.

--- a/forge-gui/res/cardsfolder/i/island_fish_jasconius.txt
+++ b/forge-gui/res/cardsfolder/i/island_fish_jasconius.txt
@@ -3,7 +3,7 @@ ManaCost:4 U U U
 Types:Creature Fish
 PT:6/8
 S:Mode$ CantAttack | ValidCard$ Card.Self | UnlessDefenderControls$ Island | Description$ This creature can't attack unless defending player controls an Island.
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 T:Mode$ Always | TriggerZones$ Battlefield | IsPresent$ Island.YouCtrl | PresentCompare$ EQ0 | Execute$ TrigSac | TriggerDescription$ When you control no Islands, sacrifice this creature.
 SVar:TrigSac:DB$ Sacrifice
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigUntap | TriggerDescription$ At the beginning of your upkeep, you may pay {U}{U}{U}. If you do, untap this creature.

--- a/forge-gui/res/cardsfolder/i/island_fish_jasconius.txt
+++ b/forge-gui/res/cardsfolder/i/island_fish_jasconius.txt
@@ -2,12 +2,12 @@ Name:Island Fish Jasconius
 ManaCost:4 U U U
 Types:Creature Fish
 PT:6/8
-S:Mode$ CantAttack | ValidCard$ Card.Self | UnlessDefenderControls$ Island | Description$ CARDNAME can't attack unless defending player controls an Island.
-K:CARDNAME doesn't untap during your untap step.
-T:Mode$ Always | TriggerZones$ Battlefield | IsPresent$ Island.YouCtrl | PresentCompare$ EQ0 | Execute$ TrigSac | TriggerDescription$ When you control no Islands, sacrifice CARDNAME.
+S:Mode$ CantAttack | ValidCard$ Card.Self | UnlessDefenderControls$ Island | Description$ This creature can't attack unless defending player controls an Island.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+T:Mode$ Always | TriggerZones$ Battlefield | IsPresent$ Island.YouCtrl | PresentCompare$ EQ0 | Execute$ TrigSac | TriggerDescription$ When you control no Islands, sacrifice this creature.
 SVar:TrigSac:DB$ Sacrifice
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigUntap | TriggerDescription$ At the beginning of your upkeep, you may pay {U}{U}{U}. If you do, untap CARDNAME.
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigUntap | TriggerDescription$ At the beginning of your upkeep, you may pay {U}{U}{U}. If you do, untap this creature.
 SVar:TrigUntap:AB$ Untap | Cost$ U U U | Defined$ Self
 SVar:NeedsToPlay:Island.YouCtrl
 DeckHas:Ability$Sacrifice
-Oracle:Island Fish Jasconius doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {U}{U}{U}. If you do, untap Island Fish Jasconius.\nIsland Fish Jasconius can't attack unless defending player controls an Island.\nWhen you control no Islands, sacrifice Island Fish Jasconius.
+Oracle:This creature doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {U}{U}{U}. If you do, untap this creature.\nThis creature can't attack unless defending player controls an Island.\nWhen you control no Islands, sacrifice this creature.

--- a/forge-gui/res/cardsfolder/j/jasconian_isle.txt
+++ b/forge-gui/res/cardsfolder/j/jasconian_isle.txt
@@ -5,7 +5,7 @@ Types:Land Creature Island Fish
 PT:3/4
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ CARDNAME doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ CARDNAME doesn't untap during your untap step.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ At the beginning of your upkeep, you may pay {U}{U}. If you do, untap CARDNAME.
 SVar:TrigUntap:AB$ Untap | Cost$ U U | Defined$ Self
 Oracle:(Jasconian Isle isn't a spell, it's affected by summoning sickness, it's blue, and it has "{T}: Add {U}.")\nJasconian Isle enters tapped.\nJasconian Isle doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {U}{U}. If you do, untap Jasconian Isle.

--- a/forge-gui/res/cardsfolder/j/jasconian_isle.txt
+++ b/forge-gui/res/cardsfolder/j/jasconian_isle.txt
@@ -5,7 +5,7 @@ Types:Land Creature Island Fish
 PT:3/4
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
-K:CARDNAME doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ CARDNAME doesn't untap during your untap step.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ At the beginning of your upkeep, you may pay {U}{U}. If you do, untap CARDNAME.
 SVar:TrigUntap:AB$ Untap | Cost$ U U | Defined$ Self
 Oracle:(Jasconian Isle isn't a spell, it's affected by summoning sickness, it's blue, and it has "{T}: Add {U}.")\nJasconian Isle enters tapped.\nJasconian Isle doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {U}{U}. If you do, untap Jasconian Isle.

--- a/forge-gui/res/cardsfolder/j/jokulmorder.txt
+++ b/forge-gui/res/cardsfolder/j/jokulmorder.txt
@@ -12,4 +12,4 @@ T:Mode$ LandPlayed | ValidCard$ Island.YouCtrl | Execute$ TrigUntap | TriggerZon
 SVar:TrigUntap:DB$ Untap | Defined$ Self
 SVar:NeedsToPlayVar:Y GE5
 SVar:Y:Count$Valid Land.YouCtrl
-Oracle:Trample\nJokulmorder enters tapped.\nWhen Jokulmorder enters, sacrifice it unless you sacrifice five lands.\nJokulmorder doesn't untap during your untap step.\nWhenever you play an Island, you may untap Jokulmorder.
+Oracle:Trample\nThis creature enters tapped.\nWhen this creature enters, sacrifice it unless you sacrifice five lands.\nThis creature doesn't untap during your untap step.\nWhenever you play an Island, you may untap this creature.

--- a/forge-gui/res/cardsfolder/j/jokulmorder.txt
+++ b/forge-gui/res/cardsfolder/j/jokulmorder.txt
@@ -7,7 +7,7 @@ R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementRe
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSacUnless | TriggerDescription$ When this creature enters, sacrifice it unless you sacrifice five lands.
 SVar:TrigSacUnless:DB$ Sacrifice | UnlessCost$ Sac<5/Land> | UnlessPayer$ You
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 T:Mode$ LandPlayed | ValidCard$ Island.YouCtrl | Execute$ TrigUntap | TriggerZones$ Battlefield | OptionalDecider$ You | TriggerDescription$ Whenever you play an Island, you may untap this creature.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
 SVar:NeedsToPlayVar:Y GE5

--- a/forge-gui/res/cardsfolder/j/jokulmorder.txt
+++ b/forge-gui/res/cardsfolder/j/jokulmorder.txt
@@ -3,12 +3,12 @@ ManaCost:4 U U U
 Types:Creature Leviathan
 PT:12/12
 K:Trample
-R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ This creature enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSacUnless | TriggerDescription$ When CARDNAME enters, sacrifice it unless you sacrifice five lands.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSacUnless | TriggerDescription$ When this creature enters, sacrifice it unless you sacrifice five lands.
 SVar:TrigSacUnless:DB$ Sacrifice | UnlessCost$ Sac<5/Land> | UnlessPayer$ You
-K:CARDNAME doesn't untap during your untap step.
-T:Mode$ LandPlayed | ValidCard$ Island.YouCtrl | Execute$ TrigUntap | TriggerZones$ Battlefield | OptionalDecider$ You | TriggerDescription$ Whenever you play an Island, you may untap CARDNAME.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+T:Mode$ LandPlayed | ValidCard$ Island.YouCtrl | Execute$ TrigUntap | TriggerZones$ Battlefield | OptionalDecider$ You | TriggerDescription$ Whenever you play an Island, you may untap this creature.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
 SVar:NeedsToPlayVar:Y GE5
 SVar:Y:Count$Valid Land.YouCtrl

--- a/forge-gui/res/cardsfolder/l/leviathan.txt
+++ b/forge-gui/res/cardsfolder/l/leviathan.txt
@@ -3,13 +3,13 @@ ManaCost:5 U U U U
 Types:Creature Leviathan
 PT:10/10
 K:Trample
-R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ This creature enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
-K:CARDNAME doesn't untap during your untap step.
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | OptionalDecider$ You | Execute$ TrigUntap | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, you may sacrifice two Islands. If you do, untap CARDNAME.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | OptionalDecider$ You | Execute$ TrigUntap | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, you may sacrifice two Islands. If you do, untap this creature.
 SVar:TrigUntap:AB$ Untap | Cost$ Sac<2/Island>
-S:Mode$ CantAttackUnless | ValidCard$ Creature.Self | Cost$ Sac<2/Island> | Description$ CARDNAME can't attack unless you sacrifice two islands. (This cost is paid as attackers are declared.)
+S:Mode$ CantAttackUnless | ValidCard$ Creature.Self | Cost$ Sac<2/Island> | Description$ This creature can't attack unless you sacrifice two islands. (This cost is paid as attackers are declared.)
 SVar:NeedsToPlayVar:Y GE4
 SVar:Y:Count$Valid Island.YouCtrl
 AI:RemoveDeck:All
-Oracle:Trample\nLeviathan enters tapped and doesn't untap during your untap step.\nAt the beginning of your upkeep, you may sacrifice two Islands. If you do, untap Leviathan.\nLeviathan can't attack unless you sacrifice two Islands. (This cost is paid as attackers are declared.)
+Oracle:Trample\nThis creature enters tapped and doesn't untap during your untap step.\nAt the beginning of your upkeep, you may sacrifice two Islands. If you do, untap this creature.\nThis creature can't attack unless you sacrifice two Islands. (This cost is paid as attackers are declared.)

--- a/forge-gui/res/cardsfolder/l/leviathan.txt
+++ b/forge-gui/res/cardsfolder/l/leviathan.txt
@@ -5,7 +5,7 @@ PT:10/10
 K:Trample
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ This creature enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | OptionalDecider$ You | Execute$ TrigUntap | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, you may sacrifice two Islands. If you do, untap this creature.
 SVar:TrigUntap:AB$ Untap | Cost$ Sac<2/Island>
 S:Mode$ CantAttackUnless | ValidCard$ Creature.Self | Cost$ Sac<2/Island> | Description$ This creature can't attack unless you sacrifice two islands. (This cost is paid as attackers are declared.)

--- a/forge-gui/res/cardsfolder/l/lurking_roper.txt
+++ b/forge-gui/res/cardsfolder/l/lurking_roper.txt
@@ -2,7 +2,7 @@ Name:Lurking Roper
 ManaCost:2 G
 Types:Creature Horror
 PT:4/5
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 T:Mode$ LifeGained | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ Whenever you gain life, untap this creature.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/l/lurking_roper.txt
+++ b/forge-gui/res/cardsfolder/l/lurking_roper.txt
@@ -2,9 +2,9 @@ Name:Lurking Roper
 ManaCost:2 G
 Types:Creature Horror
 PT:4/5
-K:CARDNAME doesn't untap during your untap step.
-T:Mode$ LifeGained | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ Whenever you gain life, untap CARDNAME.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+T:Mode$ LifeGained | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ Whenever you gain life, untap this creature.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
 AI:RemoveDeck:Random
 DeckNeeds:Ability$LifeGain
-Oracle:Lurking Roper doesn't untap during your untap step.\nWhenever you gain life, untap Lurking Roper.
+Oracle:This creature doesn't untap during your untap step.\nWhenever you gain life, untap this creature.

--- a/forge-gui/res/cardsfolder/m/mage_ring_responder.txt
+++ b/forge-gui/res/cardsfolder/m/mage_ring_responder.txt
@@ -2,7 +2,7 @@ Name:Mage-Ring Responder
 ManaCost:7
 Types:Artifact Creature Golem
 PT:7/7
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 A:AB$ Untap | Cost$ 7 | SpellDescription$ Untap this creature.
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ Whenever this creature attacks, it deals 7 damage to target creature defending player controls.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Creature.DefenderCtrl | TgtPrompt$ Select target creature defending player controls | NumDmg$ 7

--- a/forge-gui/res/cardsfolder/m/mage_ring_responder.txt
+++ b/forge-gui/res/cardsfolder/m/mage_ring_responder.txt
@@ -2,8 +2,8 @@ Name:Mage-Ring Responder
 ManaCost:7
 Types:Artifact Creature Golem
 PT:7/7
-K:CARDNAME doesn't untap during your untap step.
-A:AB$ Untap | Cost$ 7 | SpellDescription$ Untap CARDNAME.
-T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ Whenever CARDNAME attacks, it deals 7 damage to target creature defending player controls.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+A:AB$ Untap | Cost$ 7 | SpellDescription$ Untap this creature.
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ Whenever this creature attacks, it deals 7 damage to target creature defending player controls.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Creature.DefenderCtrl | TgtPrompt$ Select target creature defending player controls | NumDmg$ 7
-Oracle:Mage-Ring Responder doesn't untap during your untap step.\n{7}: Untap Mage-Ring Responder.\nWhenever Mage-Ring Responder attacks, it deals 7 damage to target creature defending player controls.
+Oracle:This creature doesn't untap during your untap step.\n{7}: Untap this creature.\nWhenever this creature attacks, it deals 7 damage to target creature defending player controls.

--- a/forge-gui/res/cardsfolder/m/mana_vault.txt
+++ b/forge-gui/res/cardsfolder/m/mana_vault.txt
@@ -1,12 +1,12 @@
 Name:Mana Vault
 ManaCost:1
 Types:Artifact
-A:AB$ Mana | Cost$ T | Produced$ C | Amount$ 3 | SpellDescription$ Add {C}{C}{C}.
-K:CARDNAME doesn't untap during your untap step.
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigUntap | TriggerDescription$ At the beginning of your upkeep, you may pay {4}. If you do, untap CARDNAME.
-T:Mode$ Phase | Phase$ Draw | ValidPlayer$ You | PresentDefined$ Self | IsPresent$ Card.tapped | Execute$ TrigDamage | TriggerDescription$ At the beginning of your draw step, if CARDNAME is tapped, it deals 1 damage to you.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This artifact doesn't untap during your untap step.
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigUntap | TriggerDescription$ At the beginning of your upkeep, you may pay {4}. If you do, untap this artifact.
 SVar:TrigUntap:AB$ Untap | Cost$ 4 | Defined$ Self
+T:Mode$ Phase | Phase$ Draw | ValidPlayer$ You | PresentDefined$ Self | IsPresent$ Card.tapped | Execute$ TrigDamage | TriggerDescription$ At the beginning of your draw step, if this artifact is tapped, it deals 1 damage to you.
 SVar:TrigDamage:DB$ DealDamage | Defined$ You | NumDmg$ 1
+A:AB$ Mana | Cost$ T | Produced$ C | Amount$ 3 | SpellDescription$ Add {C}{C}{C}.
 SVar:UntapMe:True
 AI:RemoveDeck:Random
-Oracle:Mana Vault doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {4}. If you do, untap Mana Vault.\nAt the beginning of your draw step, if Mana Vault is tapped, it deals 1 damage to you.\n{T}: Add {C}{C}{C}.
+Oracle:This artifact doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {4}. If you do, untap this artifact.\nAt the beginning of your draw step, if this artifact is tapped, it deals 1 damage to you.\n{T}: Add {C}{C}{C}.

--- a/forge-gui/res/cardsfolder/m/mana_vault.txt
+++ b/forge-gui/res/cardsfolder/m/mana_vault.txt
@@ -1,7 +1,7 @@
 Name:Mana Vault
 ManaCost:1
 Types:Artifact
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This artifact doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This artifact doesn't untap during your untap step.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigUntap | TriggerDescription$ At the beginning of your upkeep, you may pay {4}. If you do, untap this artifact.
 SVar:TrigUntap:AB$ Untap | Cost$ 4 | Defined$ Self
 T:Mode$ Phase | Phase$ Draw | ValidPlayer$ You | PresentDefined$ Self | IsPresent$ Card.tapped | Execute$ TrigDamage | TriggerDescription$ At the beginning of your draw step, if this artifact is tapped, it deals 1 damage to you.

--- a/forge-gui/res/cardsfolder/m/marjhan.txt
+++ b/forge-gui/res/cardsfolder/m/marjhan.txt
@@ -2,7 +2,7 @@ Name:Marjhan
 ManaCost:5 U U
 Types:Creature Serpent
 PT:8/8
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 S:Mode$ CantAttack | ValidCard$ Card.Self | UnlessDefenderControls$ Island | Description$ This creature can't attack unless defending player controls an Island.
 T:Mode$ Always | TriggerZones$ Battlefield | IsPresent$ Island.YouCtrl | PresentCompare$ EQ0 | Execute$ TrigSac | TriggerDescription$ When you control no Islands, sacrifice this creature.
 SVar:TrigSac:DB$ Sacrifice

--- a/forge-gui/res/cardsfolder/m/marjhan.txt
+++ b/forge-gui/res/cardsfolder/m/marjhan.txt
@@ -2,13 +2,13 @@ Name:Marjhan
 ManaCost:5 U U
 Types:Creature Serpent
 PT:8/8
-K:CARDNAME doesn't untap during your untap step.
-S:Mode$ CantAttack | ValidCard$ Card.Self | UnlessDefenderControls$ Island | Description$ CARDNAME can't attack unless defending player controls an Island.
-T:Mode$ Always | TriggerZones$ Battlefield | IsPresent$ Island.YouCtrl | PresentCompare$ EQ0 | Execute$ TrigSac | TriggerDescription$ When you control no Islands, sacrifice CARDNAME.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+S:Mode$ CantAttack | ValidCard$ Card.Self | UnlessDefenderControls$ Island | Description$ This creature can't attack unless defending player controls an Island.
+T:Mode$ Always | TriggerZones$ Battlefield | IsPresent$ Island.YouCtrl | PresentCompare$ EQ0 | Execute$ TrigSac | TriggerDescription$ When you control no Islands, sacrifice this creature.
 SVar:TrigSac:DB$ Sacrifice
-A:AB$ Untap | Cost$ U U Sac<1/Creature> | ActivationPhases$ Upkeep | PlayerTurn$ True | SpellDescription$ Untap CARDNAME. Activate only during your upkeep.
-A:AB$ DealDamage | Cost$ U U | NumDmg$ 1 | ValidTgts$ Creature.attacking+withoutFlying | TgtPrompt$ Select target attacking creature without flying | SubAbility$ DBPump | SpellDescription$ CARDNAME gets -1/-0 until end of turn and deals 1 damage to target attacking creature without flying.
+A:AB$ Untap | Cost$ U U Sac<1/Creature> | ActivationPhases$ Upkeep | PlayerTurn$ True | SpellDescription$ Untap this creature. Activate only during your upkeep.
+A:AB$ DealDamage | Cost$ U U | NumDmg$ 1 | ValidTgts$ Creature.attacking+withoutFlying | TgtPrompt$ Select target attacking creature without flying | SubAbility$ DBPump | SpellDescription$ This creature gets -1/-0 until end of turn and deals 1 damage to target attacking creature without flying.
 SVar:DBPump:DB$ Pump | NumAtt$ -1 | Defined$ Self
 SVar:NeedsToPlay:Island.YouCtrl
 AI:RemoveDeck:Random
-Oracle:Marjhan doesn't untap during your untap step.\n{U}{U}, Sacrifice a creature: Untap Marjhan. Activate only during your upkeep.\nMarjhan can't attack unless defending player controls an Island.\n{U}{U}: Marjhan gets -1/-0 until end of turn and deals 1 damage to target attacking creature without flying.\nWhen you control no Islands, sacrifice Marjhan.
+Oracle:This creature doesn't untap during your untap step.\n{U}{U}, Sacrifice a creature: Untap this creature. Activate only during your upkeep.\nThis creature can't attack unless defending player controls an Island.\n{U}{U}: This creature gets -1/-0 until end of turn and deals 1 damage to target attacking creature without flying.\nWhen you control no Islands, sacrifice this creature.

--- a/forge-gui/res/cardsfolder/m/merieke_ri_berit.txt
+++ b/forge-gui/res/cardsfolder/m/merieke_ri_berit.txt
@@ -2,7 +2,7 @@ Name:Merieke Ri Berit
 ManaCost:W U B
 Types:Legendary Creature Human
 PT:1/1
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ CARDNAME doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ CARDNAME doesn't untap during your untap step.
 A:AB$ GainControl | Cost$ T | ValidTgts$ Creature | TgtPrompt$ Select target creature | LoseControl$ LeavesPlay,LoseControl | SubAbility$ DBEffect | SpellDescription$ Gain control of target creature for as long as you control CARDNAME. When CARDNAME leaves the battlefield or becomes untapped, destroy that creature. It can't be regenerated.
 SVar:DBEffect:DB$ Effect | RememberObjects$ ParentTarget | ForgetOnMoved$ Battlefield | Triggers$ LeavesPlay,Untap | Duration$ UntilHostLeavesPlay
 SVar:LeavesPlay:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | ValidCard$ Card.EffectSource | Execute$ DBDestroy | TriggerDescription$ When EFFECTSOURCE leaves the battlefield, or becomes untapped, destroy that creature. It can't be regenerated.

--- a/forge-gui/res/cardsfolder/m/merieke_ri_berit.txt
+++ b/forge-gui/res/cardsfolder/m/merieke_ri_berit.txt
@@ -2,7 +2,7 @@ Name:Merieke Ri Berit
 ManaCost:W U B
 Types:Legendary Creature Human
 PT:1/1
-K:CARDNAME doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ CARDNAME doesn't untap during your untap step.
 A:AB$ GainControl | Cost$ T | ValidTgts$ Creature | TgtPrompt$ Select target creature | LoseControl$ LeavesPlay,LoseControl | SubAbility$ DBEffect | SpellDescription$ Gain control of target creature for as long as you control CARDNAME. When CARDNAME leaves the battlefield or becomes untapped, destroy that creature. It can't be regenerated.
 SVar:DBEffect:DB$ Effect | RememberObjects$ ParentTarget | ForgetOnMoved$ Battlefield | Triggers$ LeavesPlay,Untap | Duration$ UntilHostLeavesPlay
 SVar:LeavesPlay:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | ValidCard$ Card.EffectSource | Execute$ DBDestroy | TriggerDescription$ When EFFECTSOURCE leaves the battlefield, or becomes untapped, destroy that creature. It can't be regenerated.

--- a/forge-gui/res/cardsfolder/n/nettle_sentinel.txt
+++ b/forge-gui/res/cardsfolder/n/nettle_sentinel.txt
@@ -2,7 +2,7 @@ Name:Nettle Sentinel
 ManaCost:G
 Types:Creature Elf Warrior
 PT:2/2
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 T:Mode$ SpellCast | ValidCard$ Card.Green | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigUntap | TriggerDescription$ Whenever you cast a green spell, you may untap this creature.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
 Oracle:This creature doesn't untap during your untap step.\nWhenever you cast a green spell, you may untap this creature.

--- a/forge-gui/res/cardsfolder/n/nettle_sentinel.txt
+++ b/forge-gui/res/cardsfolder/n/nettle_sentinel.txt
@@ -2,7 +2,7 @@ Name:Nettle Sentinel
 ManaCost:G
 Types:Creature Elf Warrior
 PT:2/2
-K:CARDNAME doesn't untap during your untap step.
-T:Mode$ SpellCast | ValidCard$ Card.Green | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigUntap | TriggerDescription$ Whenever you cast a green spell, you may untap CARDNAME.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+T:Mode$ SpellCast | ValidCard$ Card.Green | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigUntap | TriggerDescription$ Whenever you cast a green spell, you may untap this creature.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
-Oracle:Nettle Sentinel doesn't untap during your untap step.\nWhenever you cast a green spell, you may untap Nettle Sentinel.
+Oracle:This creature doesn't untap during your untap step.\nWhenever you cast a green spell, you may untap this creature.

--- a/forge-gui/res/cardsfolder/p/phyrexian_colossus.txt
+++ b/forge-gui/res/cardsfolder/p/phyrexian_colossus.txt
@@ -2,7 +2,7 @@ Name:Phyrexian Colossus
 ManaCost:7
 Types:Artifact Creature Phyrexian Golem
 PT:8/8
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 A:AB$ Untap | Cost$ PayLife<8> | SpellDescription$ Untap this creature.
 S:Mode$ MinMaxBlocker | ValidCard$ Creature.Self | Min$ 3 | Description$ This creature can't be blocked except by three or more creatures.
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/p/phyrexian_colossus.txt
+++ b/forge-gui/res/cardsfolder/p/phyrexian_colossus.txt
@@ -2,8 +2,8 @@ Name:Phyrexian Colossus
 ManaCost:7
 Types:Artifact Creature Phyrexian Golem
 PT:8/8
-K:CARDNAME doesn't untap during your untap step.
-A:AB$ Untap | Cost$ PayLife<8> | SpellDescription$ Untap CARDNAME.
-S:Mode$ MinMaxBlocker | ValidCard$ Creature.Self | Min$ 3 | Description$ CARDNAME can't be blocked except by three or more creatures.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+A:AB$ Untap | Cost$ PayLife<8> | SpellDescription$ Untap this creature.
+S:Mode$ MinMaxBlocker | ValidCard$ Creature.Self | Min$ 3 | Description$ This creature can't be blocked except by three or more creatures.
 AI:RemoveDeck:All
-Oracle:Phyrexian Colossus doesn't untap during your untap step.\nPay 8 life: Untap Phyrexian Colossus.\nPhyrexian Colossus can't be blocked except by three or more creatures.
+Oracle:This creature doesn't untap during your untap step.\nPay 8 life: Untap this creature.\nThis creature can't be blocked except by three or more creatures.

--- a/forge-gui/res/cardsfolder/p/phyrexian_ironfoot.txt
+++ b/forge-gui/res/cardsfolder/p/phyrexian_ironfoot.txt
@@ -2,8 +2,8 @@ Name:Phyrexian Ironfoot
 ManaCost:3
 Types:Snow Artifact Creature Phyrexian Construct
 PT:3/4
-K:CARDNAME doesn't untap during your untap step.
-A:AB$ Untap | Cost$ 1 S | SpellDescription$ Untap CARDNAME.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+A:AB$ Untap | Cost$ 1 S | SpellDescription$ Untap this creature.
 # AI can now use snow mana to pay for activated abilities.
 AI:RemoveDeck:Random
-Oracle:Phyrexian Ironfoot doesn't untap during your untap step.\n{1}{S}: Untap Phyrexian Ironfoot. ({S} can be paid with one mana from a snow source.)
+Oracle:This creature doesn't untap during your untap step.\n{1}{S}: Untap this creature. ({S} can be paid with one mana from a snow source.)

--- a/forge-gui/res/cardsfolder/p/phyrexian_ironfoot.txt
+++ b/forge-gui/res/cardsfolder/p/phyrexian_ironfoot.txt
@@ -2,7 +2,7 @@ Name:Phyrexian Ironfoot
 ManaCost:3
 Types:Snow Artifact Creature Phyrexian Construct
 PT:3/4
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 A:AB$ Untap | Cost$ 1 S | SpellDescription$ Untap this creature.
 # AI can now use snow mana to pay for activated abilities.
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/s/slumbering_cerberus.txt
+++ b/forge-gui/res/cardsfolder/s/slumbering_cerberus.txt
@@ -2,7 +2,7 @@ Name:Slumbering Cerberus
 ManaCost:1 R
 Types:Creature Dog
 PT:4/2
-K:CARDNAME doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 T:Mode$ Phase | Phase$ End of Turn | CheckSVar$ X | SVarCompare$ GE1 | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ Morbid — At the beginning of each end step, if a creature died this turn, untap this creature.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
 SVar:X:Count$ThisTurnEntered_Graveyard_from_Battlefield_Creature

--- a/forge-gui/res/cardsfolder/s/slumbering_cerberus.txt
+++ b/forge-gui/res/cardsfolder/s/slumbering_cerberus.txt
@@ -2,7 +2,7 @@ Name:Slumbering Cerberus
 ManaCost:1 R
 Types:Creature Dog
 PT:4/2
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 T:Mode$ Phase | Phase$ End of Turn | CheckSVar$ X | SVarCompare$ GE1 | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ Morbid — At the beginning of each end step, if a creature died this turn, untap this creature.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
 SVar:X:Count$ThisTurnEntered_Graveyard_from_Battlefield_Creature

--- a/forge-gui/res/cardsfolder/s/soldevi_golem.txt
+++ b/forge-gui/res/cardsfolder/s/soldevi_golem.txt
@@ -2,9 +2,9 @@ Name:Soldevi Golem
 ManaCost:4
 Types:Artifact Creature Golem
 PT:5/3
-K:CARDNAME doesn't untap during your untap step.
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | OptionalDecider$ You | Execute$ TrigUntap | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, you may untap target tapped creature an opponent controls. If you do, untap CARDNAME.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | OptionalDecider$ You | Execute$ TrigUntap | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, you may untap target tapped creature an opponent controls. If you do, untap this creature.
 SVar:TrigUntap:DB$ Untap | ValidTgts$ Creature.OppCtrl+tapped | TgtPrompt$ Select target tapped creature an opponent controls | SubAbility$ DBUntap
 SVar:DBUntap:DB$ Untap | Defined$ Self
 AI:RemoveDeck:All
-Oracle:Soldevi Golem doesn't untap during your untap step.\nAt the beginning of your upkeep, you may untap target tapped creature an opponent controls. If you do, untap Soldevi Golem.
+Oracle:This creature doesn't untap during your untap step.\nAt the beginning of your upkeep, you may untap target tapped creature an opponent controls. If you do, untap this creature.

--- a/forge-gui/res/cardsfolder/s/soldevi_golem.txt
+++ b/forge-gui/res/cardsfolder/s/soldevi_golem.txt
@@ -2,7 +2,7 @@ Name:Soldevi Golem
 ManaCost:4
 Types:Artifact Creature Golem
 PT:5/3
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | OptionalDecider$ You | Execute$ TrigUntap | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, you may untap target tapped creature an opponent controls. If you do, untap this creature.
 SVar:TrigUntap:DB$ Untap | ValidTgts$ Creature.OppCtrl+tapped | TgtPrompt$ Select target tapped creature an opponent controls | SubAbility$ DBUntap
 SVar:DBUntap:DB$ Untap | Defined$ Self

--- a/forge-gui/res/cardsfolder/s/sunstrike_legionnaire.txt
+++ b/forge-gui/res/cardsfolder/s/sunstrike_legionnaire.txt
@@ -2,8 +2,8 @@ Name:Sunstrike Legionnaire
 ManaCost:1 W
 Types:Creature Human Soldier
 PT:1/2
-K:CARDNAME doesn't untap during your untap step.
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.Other | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ Whenever another creature enters, untap CARDNAME.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.Other | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ Whenever another creature enters, untap this creature.
 A:AB$ Tap | Cost$ T | ValidTgts$ Creature.cmcLE3 | TgtPrompt$ Select target creature with mana value 3 or less | SpellDescription$ Tap target creature with mana value 3 or less.
 SVar:TrigUntap:DB$ Untap | Defined$ Self
-Oracle:Sunstrike Legionnaire doesn't untap during your untap step.\nWhenever another creature enters, untap Sunstrike Legionnaire.\n{T}: Tap target creature with mana value 3 or less.
+Oracle:This creature doesn't untap during your untap step.\nWhenever another creature enters, untap this creature.\n{T}: Tap target creature with mana value 3 or less.

--- a/forge-gui/res/cardsfolder/s/sunstrike_legionnaire.txt
+++ b/forge-gui/res/cardsfolder/s/sunstrike_legionnaire.txt
@@ -2,7 +2,7 @@ Name:Sunstrike Legionnaire
 ManaCost:1 W
 Types:Creature Human Soldier
 PT:1/2
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ This creature doesn't untap during your untap step.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.Other | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ Whenever another creature enters, untap this creature.
 A:AB$ Tap | Cost$ T | ValidTgts$ Creature.cmcLE3 | TgtPrompt$ Select target creature with mana value 3 or less | SpellDescription$ Tap target creature with mana value 3 or less.
 SVar:TrigUntap:DB$ Untap | Defined$ Self

--- a/forge-gui/res/cardsfolder/t/time_vault.txt
+++ b/forge-gui/res/cardsfolder/t/time_vault.txt
@@ -3,7 +3,7 @@ ManaCost:2
 Types:Artifact
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ CARDNAME doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ CARDNAME doesn't untap during your untap step.
 R:Event$ BeginTurn | ActiveZones$ Battlefield | ValidPlayer$ You | IsPresent$ Card.Self+tapped | Optional$ True | ReplaceWith$ DBUntap | Description$ If you would begin your turn while CARDNAME is tapped, you may skip that turn instead. If you do, untap CARDNAME.
 SVar:DBUntap:DB$ Untap | Defined$ Self | AILogic$ Never
 A:AB$ AddTurn | Cost$ T | NumTurns$ 1 | SpellDescription$ Take an extra turn after this one.

--- a/forge-gui/res/cardsfolder/t/time_vault.txt
+++ b/forge-gui/res/cardsfolder/t/time_vault.txt
@@ -3,7 +3,7 @@ ManaCost:2
 Types:Artifact
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
-K:CARDNAME doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ CARDNAME doesn't untap during your untap step.
 R:Event$ BeginTurn | ActiveZones$ Battlefield | ValidPlayer$ You | IsPresent$ Card.Self+tapped | Optional$ True | ReplaceWith$ DBUntap | Description$ If you would begin your turn while CARDNAME is tapped, you may skip that turn instead. If you do, untap CARDNAME.
 SVar:DBUntap:DB$ Untap | Defined$ Self | AILogic$ Never
 A:AB$ AddTurn | Cost$ T | NumTurns$ 1 | SpellDescription$ Take an extra turn after this one.

--- a/forge-gui/res/cardsfolder/t/traxos_scourge_of_kroog.txt
+++ b/forge-gui/res/cardsfolder/t/traxos_scourge_of_kroog.txt
@@ -5,7 +5,7 @@ PT:7/7
 K:Trample
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ NICKNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
-R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ NICKNAME doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | ActivePhases$ Untap | PlayerTurn$ You | Layer$ CantHappen | Description$ NICKNAME doesn't untap during your untap step.
 T:Mode$ SpellCast | ValidCard$ Card.Historic | ValidActivatingPlayer$ You | Execute$ TrigUntap | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a historic spell, untap NICKNAME. (Artifacts, legendaries, and Sagas are historic.)
 SVar:TrigUntap:DB$ Untap | Defined$ Self
 SVar:BuffedBy:Card.Historic

--- a/forge-gui/res/cardsfolder/t/traxos_scourge_of_kroog.txt
+++ b/forge-gui/res/cardsfolder/t/traxos_scourge_of_kroog.txt
@@ -3,10 +3,10 @@ ManaCost:4
 Types:Legendary Artifact Creature Construct
 PT:7/7
 K:Trample
-R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ NICKNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
-K:CARDNAME doesn't untap during your untap step.
+R:Event$ Untap | ValidCard$ Card.Self | UntapStep$ You | Layer$ CantHappen | Description$ NICKNAME doesn't untap during your untap step.
 T:Mode$ SpellCast | ValidCard$ Card.Historic | ValidActivatingPlayer$ You | Execute$ TrigUntap | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a historic spell, untap NICKNAME. (Artifacts, legendaries, and Sagas are historic.)
 SVar:TrigUntap:DB$ Untap | Defined$ Self
 SVar:BuffedBy:Card.Historic
-Oracle:Trample\nTraxos, Scourge of Kroog enters tapped and doesn't untap during your untap step.\nWhenever you cast a historic spell, untap Traxos. (Artifacts, legendaries, and Sagas are historic.)
+Oracle:Trample\nTraxos enters tapped and doesn't untap during your untap step.\nWhenever you cast a historic spell, untap Traxos. (Artifacts, legendaries, and Sagas are historic.)

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -2735,7 +2735,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
                 if (!inp.hasCancelled()) {
                     CardCollection untapped = new CardCollection();
                     for (final Card c : inp.getSelected()) {
-                        if (c.untap(true)) untapped.add(c);
+                        if (c.untap()) untapped.add(c);
                     }
                     if (!untapped.isEmpty()) {
                         final Map<AbilityKey, Object> runParams = AbilityKey.newMap();


### PR DESCRIPTION
part of #6011 

This is the first batch of creatures and other cards that does have intrinsic `K:CARDNAME doesn't untap during your untap step.`

i might extend this MR to static abilities adding it.
But for this, i need to update the ReplacmentEffect for `its controllers untap step`