### PR TITLE
TDC: 4 cards

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/transcendent_dragon.txt
+++ b/forge-gui/res/cardsfolder/upcoming/transcendent_dragon.txt
@@ -1,0 +1,11 @@
+Name:Transcendent Dragon
+ManaCost:4 U U
+Types:Creature Dragon
+PT:4/3
+K:Flash
+K:Flying
+T:Mode$ ChangesZone | ValidCard$ Card.wasCastByYou+Self | Destination$ Battlefield | Execute$ TrigCounter | TriggerDescription$ When this creature enters, if you cast it, counter target spell. If that spell is countered to this way, exile it instead of putting it into its owner's graveyard, then you may cast it without paying its mana cost.
+SVar:TrigCounter:DB$ Counter | TargetType$ Spell | ValidTgts$ Card | TgtPrompt$ Select target spell | RememberCountered$ True | Destination$ Exile | SubAbility$ DBPlay
+SVar:DBPlay:DB$ Play | Valid$ Card.nonLand+IsRemembered | ValidSA$ Spell | ValidZone$ Exile | WithoutManaCost$ True | Controller$ You | Optional$ True | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:Flash\nFlying\nWhen this creature enters, if you cast it, counter target spell. If that spell is countered to this way, exile it instead of putting it into its owner's graveyard, then you may cast it without paying its mana cost.

--- a/forge-gui/res/cardsfolder/upcoming/transcendent_dragon.txt
+++ b/forge-gui/res/cardsfolder/upcoming/transcendent_dragon.txt
@@ -4,8 +4,8 @@ Types:Creature Dragon
 PT:4/3
 K:Flash
 K:Flying
-T:Mode$ ChangesZone | ValidCard$ Card.wasCastByYou+Self | Destination$ Battlefield | Execute$ TrigCounter | TriggerDescription$ When this creature enters, if you cast it, counter target spell. If that spell is countered to this way, exile it instead of putting it into its owner's graveyard, then you may cast it without paying its mana cost.
+T:Mode$ ChangesZone | ValidCard$ Card.wasCastByYou+Self | Destination$ Battlefield | Execute$ TrigCounter | TriggerDescription$ When this creature enters, if you cast it, counter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard, then you may cast it without paying its mana cost.
 SVar:TrigCounter:DB$ Counter | TargetType$ Spell | ValidTgts$ Card | TgtPrompt$ Select target spell | RememberCountered$ True | Destination$ Exile | SubAbility$ DBPlay
 SVar:DBPlay:DB$ Play | Valid$ Card.nonLand+IsRemembered | ValidSA$ Spell | ValidZone$ Exile | WithoutManaCost$ True | Controller$ You | Optional$ True | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-Oracle:Flash\nFlying\nWhen this creature enters, if you cast it, counter target spell. If that spell is countered to this way, exile it instead of putting it into its owner's graveyard, then you may cast it without paying its mana cost.
+Oracle:Flash\nFlying\nWhen this creature enters, if you cast it, counter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard, then you may cast it without paying its mana cost.

--- a/forge-gui/res/cardsfolder/upcoming/transforming_flourish.txt
+++ b/forge-gui/res/cardsfolder/upcoming/transforming_flourish.txt
@@ -1,0 +1,9 @@
+Name:Transforming Flourish
+ManaCost:2 R
+Types:Instant
+K:Demonstrate
+A:SP$ Destroy | ValidTgts$ Artifact.YouDontCtrl,Creature.YouDontCtrl | SubAbility$ DBDig | RememberDestroyed$ True | TgtPrompt$ Select target artifact or creature you don't control | SpellDescription$ Destroy target artifact or creature you don't control. If that permanent is destroyed this way, its controller exiles cards from the top of their library until they exile a nonland card, then they may cast that card without paying its mana cost.
+SVar:DBDig:DB$ DigUntil | Defined$ TargetedController | ConditionDefined$ Remembered | ConditionPresent$ Card | ConditionCompare$ GE1 | Valid$ Card.nonLand | FoundDestination$ Exile | RevealedDestination$ Exile | RememberFound$ True | ForgetOtherRemembered$ True | SubAbility$ DBPlay
+SVar:DBPlay:DB$ Play | Controller$ TargetedController | Defined$ Remembered | ValidZone$ Exile | WithoutManaCost$ True | ValidSA$ Spell | Optional$ True | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:Demonstrate (When you cast this spell, you may copy it. If you do, choose an opponent to also copy it. Players may choose new targets for their copies.)\nDestroy target artifact or creature you don't control. If that permanent is destroyed this way, its controller exiles cards from the top of their library until they exile a nonland card, then they may cast that card without paying its mana cost.

--- a/forge-gui/res/cardsfolder/upcoming/voracious_bibliophile.txt
+++ b/forge-gui/res/cardsfolder/upcoming/voracious_bibliophile.txt
@@ -6,5 +6,5 @@ K:Flying
 K:Vigilance
 T:Mode$ SpellCast | ValidSA$ Spell.numTargets GE1 | ValidActivatingPlayer$ You | Execute$ TrigDraw | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a spell with one or more targets, draw that many cards.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ X
-SVar:X:TriggerObjectsSpellAbilityTargets$Valid Any
+SVar:X:TriggeredSpellAbility>TargetedObjects$Amount
 Oracle:Flying, vigilance\nWhenever you cast a spell with one or more targets, draw that many cards.

--- a/forge-gui/res/cardsfolder/upcoming/voracious_bibliophile.txt
+++ b/forge-gui/res/cardsfolder/upcoming/voracious_bibliophile.txt
@@ -1,0 +1,10 @@
+Name:Voracious Bibliophile
+ManaCost:3 U
+Types:Creature Dragon
+PT:3/3
+K:Flying
+K:Vigilance
+T:Mode$ SpellCast | ValidSA$ Spell.numTargets GE1 | ValidActivatingPlayer$ You | Execute$ TrigDraw | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a spell with one or more targets, draw that many cards.
+SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ X
+SVar:X:TriggerObjectsSpellAbilityTargets$Valid Any
+Oracle:Flying, vigilance\nWhenever you cast a spell with one or more targets, draw that many cards.

--- a/forge-gui/res/cardsfolder/upcoming/will_of_the_jeskai.txt
+++ b/forge-gui/res/cardsfolder/upcoming/will_of_the_jeskai.txt
@@ -1,0 +1,8 @@
+Name:Will of the Jeskai
+ManaCost:3 R
+Types:Sorcery
+A:SP$ Charm | MinCharmNum$ 1 | CharmNum$ Count$Compare Y GE1.2.1 | Choices$ DBWheel,DBFlames | AdditionalDescription$ . If you control a commander as you cast this spell, you may choose both instead.
+SVar:DBWheel:DB$ Draw | UnlessCost$ Discard<1/Hand> | UnlessPayer$ Player | UnlessSwitched$ True | NumCards$ 5 | SpellDescription$ Each player may discard their hand and draw five cards.
+SVar:DBFlames:DB$ PumpAll | ValidCards$ Instant.YouCtrl,Sorcery.YouCtrl | KW$ Flashback | PumpZone$ Graveyard | SpellDescription$ Each instant and sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.
+SVar:Y:Count$Valid Card.IsCommander+YouCtrl
+Oracle:Choose one. If you control a commander as you cast this spell, you may choose both instead.\n• Each player may discard their hand and draw five cards.\n• Each instant and sorcery card your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.

--- a/forge-gui/res/cardsfolder/upcoming/will_of_the_jeskai.txt
+++ b/forge-gui/res/cardsfolder/upcoming/will_of_the_jeskai.txt
@@ -5,4 +5,4 @@ A:SP$ Charm | MinCharmNum$ 1 | CharmNum$ Count$Compare Y GE1.2.1 | Choices$ DBWh
 SVar:DBWheel:DB$ Draw | UnlessCost$ Discard<1/Hand> | UnlessPayer$ Player | UnlessSwitched$ True | NumCards$ 5 | SpellDescription$ Each player may discard their hand and draw five cards.
 SVar:DBFlames:DB$ PumpAll | ValidCards$ Instant.YouCtrl,Sorcery.YouCtrl | KW$ Flashback | PumpZone$ Graveyard | SpellDescription$ Each instant and sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.
 SVar:Y:Count$Valid Card.IsCommander+YouCtrl
-Oracle:Choose one. If you control a commander as you cast this spell, you may choose both instead.\n• Each player may discard their hand and draw five cards.\n• Each instant and sorcery card your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.
+Oracle:Choose one. If you control a commander as you cast this spell, you may choose both instead.\n• Each player may discard their hand and draw five cards.\n• Each instant and sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.


### PR DESCRIPTION
Tested to satisfaction:
- Transcendent Dragon
- Transforming Flourish
- Will of the Jeskai

Needing support:
- Voracious Bibliophile: The trigger works as far as the condition goes. For the resulting draw effect, I got as far as lifting the `SVar:X:TriggerObjectsSpellAbilityTargets$` line from [Arcee, Acrobatic Coupe](https://github.com/Card-Forge/forge/blob/master/forge-gui/res/cardsfolder/a/arcee_sharpshooter_arcee_acrobatic_coupe.txt) but the results are as follows on casting a [Donate](https://scryfall.com/card/uds/31/donate) (2 distinct targets) for the variations that seemed relevant:
• `TriggerObjectsSpellAbilityTargets$Amount`: draw 1 card
• `TriggerObjectsSpellAbilityTargets$Valid Any`: no card draw
Either option would be fine to implement: unfortunately my aptitude for Java doesn't stretch that far yet.