### PR TITLE
Update shiko_and_narset_unified.txt

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/shiko_and_narset_unified.txt
+++ b/forge-gui/res/cardsfolder/upcoming/shiko_and_narset_unified.txt
@@ -6,7 +6,7 @@ K:Flying
 K:Vigilance
 T:Mode$ SpellCast | ValidCard$ Card.YouCtrl | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigCopy | ActivatorThisTurnCast$ EQ2 | TriggerDescription$ Flurry — Whenever you cast your second spell each turn, copy that spell if it targets a permanent or player, and you may choose new targets for the copy. If you don't copy a spell this way, draw a card.
 SVar:TrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | ConditionDefined$ TriggeredSpellAbility | ConditionPresent$ Spell.IsTargeting Valid Permanent,Spell.IsTargeting Player | RememberCopies$ True | MayChooseTarget$ True | SubAbility$ DBDraw
-SVar:DBDraw:DB$ Draw | ConditionDefined$ Remembered | ConditionPresent$ Card | ConditionCompare$ EQ0 | SubAbility$ DBCleanup
+SVar:DBDraw:DB$ Draw | ConditionDefined$ Remembered | ConditionPresent$ Spell | ConditionCompare$ EQ0 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:BuffedBy:Card
 Oracle:Flying, vigilance\nFlurry — Whenever you cast your second spell each turn, copy that spell if it targets a permanent or player, and you may choose new targets for the copy. If you don't copy a spell this way, draw a card.


### PR DESCRIPTION
As reported, the triggered ability was drawing you a card regardless of whether you copied a spell. Turns out `Card` wasn't the right argument for `ConditionPresent$` in this circumstance as what's remembered by `RememberCopies$` is a spell.