### PR TITLE
AddPower & AddToughness: Removing redundancy

### DIFF
--- a/forge-gui/res/cardsfolder/b/battleground_geist.txt
+++ b/forge-gui/res/cardsfolder/b/battleground_geist.txt
@@ -3,6 +3,6 @@ ManaCost:4 U
 Types:Creature Spirit
 PT:3/3
 K:Flying
-S:Mode$ Continuous | Affected$ Creature.Spirit+Other+YouCtrl | AddPower$ 1 | AddToughness$ 0 | Description$ Other Spirit creatures you control get +1/+0.
+S:Mode$ Continuous | Affected$ Creature.Spirit+Other+YouCtrl | AddPower$ 1 | Description$ Other Spirit creatures you control get +1/+0.
 SVar:PlayMain1:TRUE
 Oracle:Flying\nOther Spirit creatures you control get +1/+0.

--- a/forge-gui/res/cardsfolder/c/captains_hook.txt
+++ b/forge-gui/res/cardsfolder/c/captains_hook.txt
@@ -2,7 +2,7 @@ Name:Captain's Hook
 ManaCost:3
 Types:Artifact Equipment
 K:Equip:1
-S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 2 | AddToughness$ 0 | AddType$ Pirate | AddKeyword$ Menace | Description$ Equipped creature gets +2/+0, has menace, and is a Pirate in addition to its other creature types.
+S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 2 | AddType$ Pirate | AddKeyword$ Menace | Description$ Equipped creature gets +2/+0, has menace, and is a Pirate in addition to its other creature types.
 T:Mode$ Unattach | ValidAttachment$ Card.Self | ValidObject$ Permanent | Execute$ TrigDestroy | TriggerDescription$ Whenever CARDNAME becomes unattached from a permanent, destroy that permanent.
 SVar:TrigDestroy:DB$ Destroy | Defined$ TriggeredObjectLKICopy
 Oracle:Equipped creature gets +2/+0, has menace, and is a Pirate in addition to its other creature types.\nWhenever Captain's Hook becomes unattached from a permanent, destroy that permanent.\nEquip {1}

--- a/forge-gui/res/cardsfolder/d/dwarfhold_champion.txt
+++ b/forge-gui/res/cardsfolder/d/dwarfhold_champion.txt
@@ -2,6 +2,6 @@ Name:Dwarfhold Champion
 ManaCost:1 W
 Types:Creature Dwarf Warrior
 PT:3/1
-S:Mode$ Continuous | Affected$ Card.Self+equipped | AddPower$ 0 | AddToughness$ 2 | Description$ As long as CARDNAME is equipped, it gets +0/+2.
+S:Mode$ Continuous | Affected$ Card.Self+equipped | AddToughness$ 2 | Description$ As long as CARDNAME is equipped, it gets +0/+2.
 SVar:EquipMe:Once
 Oracle:As long as Dwarfhold Champion is equipped, it gets +0/+2.

--- a/forge-gui/res/cardsfolder/d/dwindle.txt
+++ b/forge-gui/res/cardsfolder/d/dwindle.txt
@@ -3,7 +3,7 @@ ManaCost:2 U
 Types:Enchantment Aura
 K:Enchant creature
 A:SP$ Attach | ValidTgts$ Creature | IsCurse$ True
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ -6 | AddToughness$ -0 | Description$ Enchanted creature gets -6/-0.
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ -6 | Description$ Enchanted creature gets -6/-0.
 T:Mode$ AttackerBlockedByCreature | ValidCard$ Creature | ValidBlocker$ Creature.EnchantedBy | TriggerZones$ Battlefield | Execute$ TrigDestroy | TriggerDescription$ When enchanted creature blocks, destroy it.
 SVar:TrigDestroy:DB$ Destroy | Defined$ TriggeredBlockerLKICopy
 Oracle:Enchant creature\nEnchanted creature gets -6/-0.\nWhen enchanted creature blocks, destroy it. (The attacking creature remains blocked.)

--- a/forge-gui/res/cardsfolder/f/full_moons_rise.txt
+++ b/forge-gui/res/cardsfolder/f/full_moons_rise.txt
@@ -1,7 +1,7 @@
 Name:Full Moon's Rise
 ManaCost:1 G
 Types:Enchantment
-S:Mode$ Continuous | Affected$ Creature.Werewolf+YouCtrl | AddPower$ 1 | AddToughness$ 0 | AddKeyword$ Trample | Description$ Werewolf creatures you control get +1/+0 and have trample.
+S:Mode$ Continuous | Affected$ Creature.Werewolf+YouCtrl | AddPower$ 1 | AddKeyword$ Trample | Description$ Werewolf creatures you control get +1/+0 and have trample.
 A:AB$ Regenerate | Cost$ Sac<1/CARDNAME> | Defined$ Valid Creature.Werewolf+YouCtrl | SpellDescription$ Regenerate all Werewolf creatures you control.
 AI:RemoveDeck:Random
 Oracle:Werewolf creatures you control get +1/+0 and have trample.\nSacrifice Full Moon's Rise: Regenerate all Werewolf creatures you control.

--- a/forge-gui/res/cardsfolder/g/gallows_warden.txt
+++ b/forge-gui/res/cardsfolder/g/gallows_warden.txt
@@ -3,5 +3,5 @@ ManaCost:4 W
 Types:Creature Spirit
 PT:3/3
 K:Flying
-S:Mode$ Continuous | Affected$ Creature.Spirit+Other+YouCtrl | AddPower$ 0 | AddToughness$ 1 | Description$ Other Spirit creatures you control get +0/+1.
+S:Mode$ Continuous | Affected$ Creature.Spirit+Other+YouCtrl | AddToughness$ 1 | Description$ Other Spirit creatures you control get +0/+1.
 Oracle:Flying\nOther Spirit creatures you control get +0/+1.

--- a/forge-gui/res/cardsfolder/g/gearsmith_prodigy.txt
+++ b/forge-gui/res/cardsfolder/g/gearsmith_prodigy.txt
@@ -2,7 +2,7 @@ Name:Gearsmith Prodigy
 ManaCost:U
 Types:Creature Human Artificer
 PT:1/2
-S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 1 | AddToughness$ 0 | IsPresent$ Artifact.YouCtrl | Description$ CARDNAME gets +1/+0 as long as you control an artifact.
+S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 1 | IsPresent$ Artifact.YouCtrl | Description$ CARDNAME gets +1/+0 as long as you control an artifact.
 SVar:BuffedBy:Artifact
 DeckHints:Type$Artifact
 Oracle:Gearsmith Prodigy gets +1/+0 as long as you control an artifact.

--- a/forge-gui/res/cardsfolder/g/goldwardens_helm.txt
+++ b/forge-gui/res/cardsfolder/g/goldwardens_helm.txt
@@ -2,7 +2,7 @@ Name:Goldwarden's Helm
 ManaCost:2 W
 Types:Artifact Equipment
 K:For Mirrodin
-S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 0 | AddToughness$ 1 | Description$ Equipped creature gets +0/+1
+S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddToughness$ 1 | Description$ Equipped creature gets +0/+1
 K:Equip:1 W
 DeckHas:Type$Rebel & Ability$Token & Color$Red
 Oracle:For Mirrodin! (When this Equipment enters, create a 2/2 red Rebel creature token, then attach this to it.)\nEquipped creature gets +0/+1.\nEquip {1}{W} ({1}{W}: Attach to target creature you control. Equip only as a sorcery.)

--- a/forge-gui/res/cardsfolder/g/gryffs_boon.txt
+++ b/forge-gui/res/cardsfolder/g/gryffs_boon.txt
@@ -3,7 +3,7 @@ ManaCost:W
 Types:Enchantment Aura
 K:Enchant creature
 A:SP$ Attach | ValidTgts$ Creature | AILogic$ Pump
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | AddToughness$ 0 | AddKeyword$ Flying | Description$ Enchanted creature gets +1/+0 and has flying.
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | AddKeyword$ Flying | Description$ Enchanted creature gets +1/+0 and has flying.
 A:AB$ Pump | Cost$ 3 W | ActivationZone$ Graveyard | ValidTgts$ Creature | SorcerySpeed$ True | TgtPrompt$ Choose a creature | SubAbility$ DBChange | SpellDescription$ Return CARDNAME from your graveyard to the battlefield attached to target creature. Activate only any time you could cast a sorcery. | StackDescription$ SpellDescription
 SVar:DBChange:DB$ ChangeZone | Defined$ Self | Origin$ Graveyard | Destination$ Battlefield | AttachedTo$ ParentTarget | SpellDescription$ | StackDescription$ SpellDescription
 Oracle:Enchant creature\nEnchanted creature gets +1/+0 and has flying.\n{3}{W}: Return Gryff's Boon from your graveyard to the battlefield attached to target creature. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/h/hardy_veteran.txt
+++ b/forge-gui/res/cardsfolder/h/hardy_veteran.txt
@@ -2,5 +2,5 @@ Name:Hardy Veteran
 ManaCost:1 G
 Types:Creature Human Warrior
 PT:2/2
-S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 0 | AddToughness$ 2 | Condition$ PlayerTurn | Description$ During your turn, CARDNAME gets +0/+2.
+S:Mode$ Continuous | Affected$ Card.Self | AddToughness$ 2 | Condition$ PlayerTurn | Description$ During your turn, CARDNAME gets +0/+2.
 Oracle:During your turn, Hardy Veteran gets +0/+2.

--- a/forge-gui/res/cardsfolder/h/hexgold_hoverwings.txt
+++ b/forge-gui/res/cardsfolder/h/hexgold_hoverwings.txt
@@ -3,7 +3,7 @@ ManaCost:3 W
 Types:Artifact Equipment
 K:For Mirrodin
 S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddKeyword$ Flying | Description$ Equipped creature has flying.
-S:Mode$ Continuous | Affected$ Creature.YouCtrl+equipped | AddPower$ 1 | AddToughness$ 0 | Description$ Creatures you control that are equipped get +1/+0.
+S:Mode$ Continuous | Affected$ Creature.YouCtrl+equipped | AddPower$ 1 | Description$ Creatures you control that are equipped get +1/+0.
 K:Equip:2 W
 DeckHints:Type$Equipment
 DeckHas:Type$Rebel & Ability$Token & Color$Red

--- a/forge-gui/res/cardsfolder/m/molting_snakeskin.txt
+++ b/forge-gui/res/cardsfolder/m/molting_snakeskin.txt
@@ -3,6 +3,6 @@ ManaCost:B
 Types:Enchantment Aura
 K:Enchant creature
 A:SP$ Attach | ValidTgts$ Creature | AILogic$ Pump
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 2 | AddToughness$ 0 | AddAbility$ Regenerate | Description$ Enchanted creature gets +2/+0 and has "{2}{B}: Regenerate this creature."
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 2 | AddAbility$ Regenerate | Description$ Enchanted creature gets +2/+0 and has "{2}{B}: Regenerate this creature."
 SVar:Regenerate:AB$ Regenerate | Cost$ 2 B | SpellDescription$ Regenerate this creature.
 Oracle:Enchant creature\nEnchanted creature gets +2/+0 and has "{2}{B}: Regenerate this creature."

--- a/forge-gui/res/cardsfolder/o/one_eyed_scarecrow.txt
+++ b/forge-gui/res/cardsfolder/o/one_eyed_scarecrow.txt
@@ -3,5 +3,5 @@ ManaCost:3
 Types:Artifact Creature Scarecrow
 PT:2/3
 K:Defender
-S:Mode$ Continuous | Affected$ Creature.withFlying+OppCtrl | AddPower$ -1 | AddToughness$ 0 | Description$ Creatures with flying your opponents control get -1/-0.
+S:Mode$ Continuous | Affected$ Creature.withFlying+OppCtrl | AddPower$ -1 | Description$ Creatures with flying your opponents control get -1/-0.
 Oracle:Defender\nCreatures with flying your opponents control get -1/-0.

--- a/forge-gui/res/cardsfolder/rebalanced/a-dwarfhold_champion.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-dwarfhold_champion.txt
@@ -3,6 +3,6 @@ ManaCost:1 W
 Types:Creature Dwarf Warrior
 PT:3/1
 K:Ward:1
-S:Mode$ Continuous | Affected$ Card.Self+equipped | AddPower$ 0 | AddToughness$ 2 | Description$ As long as CARDNAME is equipped, it gets +0/+2.
+S:Mode$ Continuous | Affected$ Card.Self+equipped | AddToughness$ 2 | Description$ As long as CARDNAME is equipped, it gets +0/+2.
 SVar:EquipMe:Once
 Oracle:Ward {1}\nAs long as Dwarfhold Champion is equipped, it gets +0/+2.

--- a/forge-gui/res/cardsfolder/s/sporeback_wolf.txt
+++ b/forge-gui/res/cardsfolder/s/sporeback_wolf.txt
@@ -2,5 +2,5 @@ Name:Sporeback Wolf
 ManaCost:1 G
 Types:Creature Wolf
 PT:2/2
-S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 0 | AddToughness$ 2 | Condition$ PlayerTurn | Description$ During your turn, CARDNAME gets +0/+2.
+S:Mode$ Continuous | Affected$ Card.Self | AddToughness$ 2 | Condition$ PlayerTurn | Description$ During your turn, CARDNAME gets +0/+2.
 Oracle:During your turn, Sporeback Wolf gets +0/+2.

--- a/forge-gui/res/tokenscripts/icingdeath_frost_tongue.txt
+++ b/forge-gui/res/tokenscripts/icingdeath_frost_tongue.txt
@@ -2,7 +2,7 @@ Name:Icingdeath, Frost Tongue
 ManaCost:no cost
 Colors:white
 Types:Legendary Artifact Equipment
-S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 2 | AddToughness$ 0 | Description$ Equipped creature gets +2/+0.
+S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 2 | Description$ Equipped creature gets +2/+0.
 T:Mode$ Attacks | ValidCard$ Card.AttachedBy | Execute$ TrigTap | TriggerDescription$ Whenever equipped creature attacks, tap target creature defending player controls.
 SVar:TrigTap:DB$ Tap | ValidTgts$ Creature.ControlledBy TriggeredDefendingPlayer | TgtPrompt$ Select target creature defending player controls
 K:Equip:2


### PR DESCRIPTION
As a followup to https://github.com/Card-Forge/forge/pull/6878 , this PR removes redundant instances of `AddPower$ 0` and `AddToughness$ 0`.