### PR TITLE
Removed token image fetch attempt from old server

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/util/SwingImageFetcher.java
+++ b/forge-gui-desktop/src/main/java/forge/util/SwingImageFetcher.java
@@ -29,7 +29,7 @@ public class SwingImageFetcher extends ImageFetcher {
         }
 
         private boolean doFetch(String urlToDownload) throws IOException {
-            if (disableHostedDownload && urlToDownload.startsWith(ForgeConstants.URL_CARDFORGE) && !urlToDownload.contains("tokens")) {
+            if (disableHostedDownload && urlToDownload.startsWith(ForgeConstants.URL_CARDFORGE)) {
                 // Don't try to download card images from cardforge servers
                 return false;
             }

--- a/forge-gui-mobile/src/forge/util/LibGDXImageFetcher.java
+++ b/forge-gui-mobile/src/forge/util/LibGDXImageFetcher.java
@@ -30,7 +30,7 @@ public class LibGDXImageFetcher extends ImageFetcher {
         }
 
         private boolean doFetch(String urlToDownload) throws IOException {
-            if (disableHostedDownload && urlToDownload.startsWith(ForgeConstants.URL_CARDFORGE) && !urlToDownload.contains("tokens")) {
+            if (disableHostedDownload && urlToDownload.startsWith(ForgeConstants.URL_CARDFORGE)) {
                 // Don't try to download card images from cardforge servers
                 return false;
             }


### PR DESCRIPTION
Every token image not on cache attempts to fetch from https://downloads.cardforge.org and fails.