### PR TITLE
Cleanup: Count$TypeInYour[Zone].[Type]

### DIFF
--- a/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 import forge.GameCommand;
+import forge.card.CardStateName;
 import forge.card.ColorSet;
 import forge.card.MagicColor;
 import forge.card.mana.ManaAtom;
@@ -744,10 +745,10 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
     }
 
     public boolean isAdventure() {
-        return getCardState().getType().hasSubtype("Adventure");
+        return getCardStateName() == CardStateName.Secondary && getCardState().getType().hasSubtype("Adventure");
     }
     public boolean isOmen() {
-        return getCardState().getType().hasSubtype("Omen");
+        return getCardStateName() == CardStateName.Secondary && getCardState().getType().hasSubtype("Omen");
     }
 
     public final boolean isCurse() {

--- a/forge-gui/res/adventure/Shandalar/world/quests.json
+++ b/forge-gui/res/adventure/Shandalar/world/quests.json
@@ -11218,7 +11218,6 @@
 			"name": "Rescue the Red Captive",
 			"description": "Free the wizard being held captive inside the Red Castle.",
 			"mapFlag": "Ch1RedCastleComplete",
-			"mapFlagValue": 1,
 			"POITags": [
 				"BiomeRed",
 				"Chapter1Boss"

--- a/forge-gui/res/adventure/common/maps/map/towns/waste_town_generic.tmx
+++ b/forge-gui/res/adventure/common/maps/map/towns/waste_town_generic.tmx
@@ -99,7 +99,7 @@
   <object id="47" template="../../obj/inn.tx" x="150" y="273"/>
   <object id="48" template="../../obj/shop.tx" x="104" y="272">
    <properties>
-    <property name="commonShopList" value="cardPackShop"/>
+    <property name="commonShopList" value="Equipment"/>
     <property name="noRestock" type="bool" value="true"/>
    </properties>
   </object>

--- a/forge-gui/res/cardsfolder/a/abomination_of_llanowar.txt
+++ b/forge-gui/res/cardsfolder/a/abomination_of_llanowar.txt
@@ -6,7 +6,7 @@ K:Vigilance
 K:Menace
 S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of Elves you control plus the number of Elf cards in your graveyard.
 SVar:X:Count$Valid Elf.YouCtrl/Plus.Y
-SVar:Y:Count$TypeInYourYard.Elf
+SVar:Y:Count$ValidGraveyard Elf.YouOwn
 SVar:NeedsToPlayVar:X GE1
 SVar:BuffedBy:Elf
 DeckNeeds:Type$Elf

--- a/forge-gui/res/cardsfolder/a/armix_filigree_thrasher.txt
+++ b/forge-gui/res/cardsfolder/a/armix_filigree_thrasher.txt
@@ -7,7 +7,7 @@ SVar:TrigDiscard:DB$ Discard | Defined$ You | Mode$ TgtChoose | RememberDiscarde
 SVar:DBImmediateTriggerCheck:DB$ ImmediateTrigger | Execute$ TrigPump | ConditionDefined$ Remembered | ConditionPresent$ Card | ConditionCompare$ GE1 | TriggerDescription$ When you do, target creature defending player controls gets -X/-X until end of turn, where X is the number of artifacts you control plus the number of artifact cards in your graveyard.
 SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.DefenderCtrl | TgtPrompt$ Select target creature defending player controls | NumAtt$ -X | NumDef$ -X | IsCurse$ True | SubAbility$ DBCleanup
 SVar:X:Count$Valid Artifact.YouCtrl/Plus.Y
-SVar:Y:Count$TypeInYourYard.Artifact
+SVar:Y:Count$ValidGraveyard Artifact.YouOwn
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 K:Partner
 SVar:HasAttackEffect:TRUE

--- a/forge-gui/res/cardsfolder/b/barrow_ghoul.txt
+++ b/forge-gui/res/cardsfolder/b/barrow_ghoul.txt
@@ -5,6 +5,6 @@ PT:4/4
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUpkeep | TriggerDescription$ At the beginning of your upkeep, sacrifice CARDNAME unless you exile the top creature card of your graveyard.
 SVar:TrigUpkeep:DB$ Sacrifice | UnlessPayer$ You | UnlessCost$ ExileFromGrave<1/Card.TopGraveyardCreature>
 SVar:NeedsToPlayVar:Y GE2
-SVar:Y:Count$TypeInYourYard.Creature
+SVar:Y:Count$ValidGraveyard Creature.YouOwn
 SVar:NeedsOrderedGraveyard:TRUE
 Oracle:At the beginning of your upkeep, sacrifice Barrow Ghoul unless you exile the top creature card of your graveyard.

--- a/forge-gui/res/cardsfolder/b/battlefield_butcher.txt
+++ b/forge-gui/res/cardsfolder/b/battlefield_butcher.txt
@@ -3,6 +3,6 @@ ManaCost:2 B
 Types:Creature Human Soldier
 PT:1/4
 A:AB$ LoseLife | Cost$ 5 T | ReduceCost$ X | Defined$ Opponent | LifeAmount$ 2 | SpellDescription$ Each opponent loses 2 life. This ability costs {1} less to activate for each creature card in your graveyard.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 DeckHints:Ability$Graveyard|Mill|Dredge
 Oracle:{5}, {T}: Each opponent loses 2 life. This ability costs {1} less to activate for each creature card in your graveyard.

--- a/forge-gui/res/cardsfolder/b/bladewing_deathless_tyrant.txt
+++ b/forge-gui/res/cardsfolder/b/bladewing_deathless_tyrant.txt
@@ -6,7 +6,7 @@ K:Flying
 K:Haste
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player,Planeswalker | CombatDamage$ True | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME deals combat damage to a player or planeswalker, for each creature card in your graveyard, create a 2/2 black Zombie Knight creature token with menace.
 SVar:TrigToken:DB$ Token | TokenScript$ b_2_2_zombie_knight_menace | TokenAmount$ X | TokenOwner$ You
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 DeckHas:Ability$Token & Type$Zombie|Knight
 DeckHints:Ability$Graveyard
 Oracle:Flying, haste\nWhenever Bladewing, Deathless Tyrant deals combat damage to a player or planeswalker, for each creature card in your graveyard, create a 2/2 black Zombie Knight creature token with menace.

--- a/forge-gui/res/cardsfolder/b/bloodsworn_squire_bloodsworn_knight.txt
+++ b/forge-gui/res/cardsfolder/b/bloodsworn_squire_bloodsworn_knight.txt
@@ -19,7 +19,7 @@ Colors:black
 Types:Creature Vampire Knight
 PT:*/*
 S:Mode$ Continuous | Affected$ Card.Self | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creature cards in your graveyard.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 A:AB$ Pump | Cost$ 1 B Discard<1/Card> | Defined$ Self | KW$ Indestructible | SubAbility$ DBTap | SpellDescription$ CARDNAME gains indestructible until end of turn.
 SVar:DBTap:DB$ Tap | Defined$ Self | StackDescription$ SpellDescription | SpellDescription$ Tap it.
 SVar:AIPreference:DiscardCost$Creature

--- a/forge-gui/res/cardsfolder/b/blossoming_wreath.txt
+++ b/forge-gui/res/cardsfolder/b/blossoming_wreath.txt
@@ -2,5 +2,5 @@ Name:Blossoming Wreath
 ManaCost:G
 Types:Instant
 A:SP$ GainLife | LifeAmount$ X | SpellDescription$ You gain life equal to the number of creature cards in your graveyard.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:You gain life equal to the number of creature cards in your graveyard.

--- a/forge-gui/res/cardsfolder/b/body_snatcher.txt
+++ b/forge-gui/res/cardsfolder/b/body_snatcher.txt
@@ -8,5 +8,5 @@ T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Battlefield | Destination$ 
 SVar:TrigBodySnatcherExileMe:DB$ ChangeZone | Defined$ TriggeredNewCardLKICopy | Origin$ Graveyard | Destination$ Exile | SubAbility$ DBBodySnatcherReturnCreature
 SVar:DBBodySnatcherReturnCreature:DB$ ChangeZone | ValidTgts$ Creature | TargetsWithDefinedController$ TriggeredCardController | TgtPrompt$ Select target creature from your graveyard | Origin$ Graveyard | Destination$ Battlefield
 SVar:NeedsToPlayVar:Y GE2
-SVar:Y:Count$TypeInYourHand.Creature
+SVar:Y:Count$ValidHand Creature.YouOwn
 Oracle:When Body Snatcher enters, exile it unless you discard a creature card.\nWhen Body Snatcher dies, exile Body Snatcher and return target creature card from your graveyard to the battlefield.

--- a/forge-gui/res/cardsfolder/b/bone_harvest.txt
+++ b/forge-gui/res/cardsfolder/b/bone_harvest.txt
@@ -4,5 +4,5 @@ Types:Instant
 A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Library | TargetMin$ 0 | TargetMax$ X | TgtPrompt$ Choose target creature card in your graveyard | ValidTgts$ Creature.YouCtrl | SpellDescription$ Put any number of target creature cards from your graveyard on top of your library. Draw a card at the beginning of next turn's upkeep. | SubAbility$ DelTrigSlowtrip
 SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
 SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:Put any number of target creature cards from your graveyard on top of your library.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/b/boneyard_wurm.txt
+++ b/forge-gui/res/cardsfolder/b/boneyard_wurm.txt
@@ -3,6 +3,6 @@ ManaCost:1 G
 Types:Creature Wurm
 PT:*/*
 S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creature cards in your graveyard.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 SVar:NeedsToPlayVar:X GE1
 Oracle:Boneyard Wurm's power and toughness are each equal to the number of creature cards in your graveyard.

--- a/forge-gui/res/cardsfolder/c/cavalier_of_flame.txt
+++ b/forge-gui/res/cardsfolder/c/cavalier_of_flame.txt
@@ -10,5 +10,5 @@ SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:Y:Remembered$Amount
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigDamageAll | TriggerDescription$ When CARDNAME dies, it deals X damage to each opponent and each planeswalker they control, where X is the number of land cards in your graveyard.
 SVar:TrigDamageAll:DB$ DamageAll | ValidPlayers$ Player.Opponent | ValidCards$ Planeswalker.OppCtrl | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to each opponent and each planeswalker they control, where X is the number of land cards in your graveyard.
-SVar:X:Count$TypeInYourYard.Land
+SVar:X:Count$ValidGraveyard Land.YouOwn
 Oracle:{1}{R}: Creatures you control get +1/+0 and gain haste until end of turn.\nWhen Cavalier of Flame enters, discard any number of cards, then draw that many cards.\nWhen Cavalier of Flame dies, it deals X damage to each opponent and each planeswalker they control, where X is the number of land cards in your graveyard.

--- a/forge-gui/res/cardsfolder/c/criminal_past.txt
+++ b/forge-gui/res/cardsfolder/c/criminal_past.txt
@@ -3,7 +3,7 @@ ManaCost:2 B
 Types:Legendary Enchantment Background
 S:Mode$ Continuous | Affected$ Creature.IsCommander+YouOwn | AddKeyword$ Menace | AddStaticAbility$ PowerGrave | Description$ Commander creatures you own have menace and "This creature gets +X/+0, where X is the number of creature cards in your graveyard." (A creature with menace can't be blocked except by two or more creatures.)
 SVar:PowerGrave:Mode$ Continuous | Affected$ Card.Self | AddPower$ X | This creature gets +X/+0, where X is the number of creature cards in your graveyard.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 AI:RemoveDeck:NonCommander
 DeckHas:Ability$Graveyard
 DeckHints:Ability$Discard|Mill|Sacrifice

--- a/forge-gui/res/cardsfolder/d/death_denied.txt
+++ b/forge-gui/res/cardsfolder/d/death_denied.txt
@@ -3,5 +3,5 @@ ManaCost:X B B
 Types:Instant Arcane
 A:SP$ ChangeZone | TargetMin$ X | TargetMax$ X | ValidTgts$ Creature.YouOwn | TgtPrompt$ Select X target creatures in your graveyard | Origin$ Graveyard | Destination$ Hand | SpellDescription$ Return X target creature cards from your graveyard to your hand.
 SVar:X:Count$xPaid
-SVar:MaxTgts:Count$TypeInYourYard.Creature
+SVar:MaxTgts:Count$ValidGraveyard Creature.YouOwn
 Oracle:Return X target creature cards from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/d/deathbloom_ritualist.txt
+++ b/forge-gui/res/cardsfolder/d/deathbloom_ritualist.txt
@@ -3,6 +3,6 @@ ManaCost:3 B G
 Types:Creature Elf Warlock
 PT:3/5
 A:AB$ Mana | Cost$ T | Produced$ Any | Amount$ X | SpellDescription$ Add X mana of any one color, where X is the number of creature cards in your graveyard.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 DeckHints:Ability$Mill|Dredge|Graveyard
 Oracle:{T}: Add X mana of any one color, where X is the number of creature cards in your graveyard.

--- a/forge-gui/res/cardsfolder/d/diabolic_servitude.txt
+++ b/forge-gui/res/cardsfolder/d/diabolic_servitude.txt
@@ -14,5 +14,5 @@ T:Mode$ ChangesZone | ValidCard$ Card.IsRemembered | Origin$ Battlefield | Desti
 T:Mode$ ChangesZone | ValidCard$ Card.IsRemembered | Origin$ Battlefield | Destination$ Hand | Execute$ DBCleanup | Static$ True | Secondary$ True | TriggerDescription$ Forget remembered card if it goes into Hand.
 T:Mode$ ChangesZone | ValidCard$ Card.IsRemembered | Origin$ Battlefield | Destination$ Library | Execute$ DBCleanup | Static$ True | Secondary$ True | TriggerDescription$ Forget remembered card if it goes into Library.
 SVar:NeedsToPlayVar:Y GE1
-SVar:Y:Count$TypeInYourYard.Creature
+SVar:Y:Count$ValidGraveyard Creature.YouOwn
 Oracle:When Diabolic Servitude enters, return target creature card from your graveyard to the battlefield.\nWhen the creature put onto the battlefield with Diabolic Servitude dies, exile it and return Diabolic Servitude to its owner's hand.\nWhen Diabolic Servitude leaves the battlefield, exile the creature put onto the battlefield with Diabolic Servitude.

--- a/forge-gui/res/cardsfolder/e/elvish_eulogist.txt
+++ b/forge-gui/res/cardsfolder/e/elvish_eulogist.txt
@@ -3,5 +3,5 @@ ManaCost:G
 Types:Creature Elf Shaman
 PT:1/1
 A:AB$ GainLife | Cost$ Sac<1/CARDNAME> | LifeAmount$ X | SpellDescription$ You gain 1 life for each Elf card in your graveyard.
-SVar:X:Count$TypeInYourYard.Elf
+SVar:X:Count$ValidGraveyard Elf.YouOwn
 Oracle:Sacrifice Elvish Eulogist: You gain 1 life for each Elf card in your graveyard.

--- a/forge-gui/res/cardsfolder/e/endless_horizons.txt
+++ b/forge-gui/res/cardsfolder/e/endless_horizons.txt
@@ -5,6 +5,6 @@ T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefi
 SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Library | Destination$ Exile | ChangeType$ Plains | ChangeNum$ X | RememberChanged$ True
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ TrigRetrieve | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, you may put a card you own exiled with CARDNAME into your hand.
 SVar:TrigRetrieve:DB$ ChangeZone | ChangeType$ Card.IsRemembered+YouOwn | ChangeNum$ 1 | Origin$ Exile | Destination$ Hand | Hidden$ True
-SVar:X:Count$TypeInYourLibrary.Plains
+SVar:X:Count$ValidLibrary Plains.YouCtrl
 AI:RemoveDeck:All
 Oracle:When Endless Horizons enters, search your library for any number of Plains cards, exile them, then shuffle.\nAt the beginning of your upkeep, you may put a card you own exiled with Endless Horizons into your hand.

--- a/forge-gui/res/cardsfolder/e/exhume.txt
+++ b/forge-gui/res/cardsfolder/e/exhume.txt
@@ -3,6 +3,6 @@ ManaCost:1 B
 Types:Sorcery
 A:SP$ RepeatEach | RepeatSubAbility$ DBChangeZone | RepeatPlayers$ Player | SpellDescription$ Each player puts a creature card from their graveyard onto the battlefield.
 SVar:DBChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | ChangeType$ Creature.RememberedPlayerCtrl | DefinedPlayer$ Player.IsRemembered | Chooser$ Player.IsRemembered | ChangeNum$ 1 | Hidden$ True | Mandatory$ True
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 SVar:NeedsToPlayVar:X GE1
 Oracle:Each player puts a creature card from their graveyard onto the battlefield.

--- a/forge-gui/res/cardsfolder/f/fallow_wurm.txt
+++ b/forge-gui/res/cardsfolder/f/fallow_wurm.txt
@@ -5,5 +5,5 @@ PT:4/4
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ DBSacSelf | TriggerDescription$ When CARDNAME enters, sacrifice it unless you discard a land card.
 SVar:DBSacSelf:DB$ Sacrifice | UnlessCost$ Discard<1/Land> | UnlessPayer$ You
 SVar:NeedsToPlayVar:Y GE1
-SVar:Y:Count$TypeInYourHand.Land
+SVar:Y:Count$ValidHand Land.YouOwn
 Oracle:When Fallow Wurm enters, sacrifice it unless you discard a land card.

--- a/forge-gui/res/cardsfolder/f/fiend_artisan.txt
+++ b/forge-gui/res/cardsfolder/f/fiend_artisan.txt
@@ -4,7 +4,7 @@ Types:Creature Nightmare
 PT:1/1
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ Y | AddToughness$ Y | Description$ CARDNAME gets +1/+1 for each creature card in your graveyard.
 A:AB$ ChangeZone | Cost$ X BG T Sac<1/Creature.Other/another creature> | Origin$ Library | Destination$ Battlefield | ChangeType$ Creature.cmcLEX | ChangeNum$ 1 | SorcerySpeed$ True | StackDescription$ SpellDescription | SpellDescription$ Search your library for a creature card with mana value X or less, put it onto the battlefield, then shuffle. Activate only as a sorcery.
-SVar:Y:Count$TypeInYourYard.Creature
+SVar:Y:Count$ValidGraveyard Creature.YouOwn
 SVar:X:Count$xPaid
 AI:RemoveDeck:All
 DeckHints:Ability$Graveyard

--- a/forge-gui/res/cardsfolder/f/footbottom_feast.txt
+++ b/forge-gui/res/cardsfolder/f/footbottom_feast.txt
@@ -3,6 +3,6 @@ ManaCost:2 B
 Types:Instant
 A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Library | TargetMin$ 0 | TargetMax$ X | TgtPrompt$ Choose target creature card in your graveyard | ValidTgts$ Creature.YouCtrl | SpellDescription$ Put any number of target creature cards from your graveyard on top of your library. | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | SpellDescription$ Draw a card.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 AI:RemoveDeck:All
 Oracle:Put any number of target creature cards from your graveyard on top of your library.\nDraw a card.

--- a/forge-gui/res/cardsfolder/f/forever_young.txt
+++ b/forge-gui/res/cardsfolder/f/forever_young.txt
@@ -3,5 +3,5 @@ ManaCost:1 B
 Types:Sorcery
 A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Library | TargetMin$ 0 | TargetMax$ X | TgtPrompt$ Choose target creature card in your graveyard | ValidTgts$ Creature.YouOwn | SpellDescription$ Put any number of target creature cards from your graveyard on top of your library. Draw a card. | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | Defined$ You
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:Put any number of target creature cards from your graveyard on top of your library.\nDraw a card.

--- a/forge-gui/res/cardsfolder/f/formless_genesis.txt
+++ b/forge-gui/res/cardsfolder/f/formless_genesis.txt
@@ -4,6 +4,6 @@ Types:Kindred Sorcery Shapeshifter
 K:Changeling
 A:SP$ Token | TokenAmount$ 1 | TokenScript$ c_x_x_shapeshifter_changeling_deathtouch | TokenOwner$ You | TokenPower$ X | TokenToughness$ X | SpellDescription$ Create an X/X colorless Shapeshifter creature token with changeling and deathtouch, where X is the number of land cards in your graveyard.
 K:Retrace
-SVar:X:Count$TypeInYourYard.Land
+SVar:X:Count$ValidGraveyard Land.YouOwn
 DeckHas:Ability$Token
 Oracle:Changeling (This card is every creature type.)\nCreate an X/X colorless Shapeshifter creature token with changeling and deathtouch, where X is the number of land cards in your graveyard.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)

--- a/forge-gui/res/cardsfolder/f/frantic_salvage.txt
+++ b/forge-gui/res/cardsfolder/f/frantic_salvage.txt
@@ -3,7 +3,7 @@ ManaCost:3 W
 Types:Instant
 A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Library | TargetMin$ 0 | TargetMax$ X | TgtPrompt$ Choose target artifact card in your graveyard | ValidTgts$ Artifact.YouCtrl | SubAbility$ DBDraw | SpellDescription$ Put any number of target artifact cards from your graveyard on top of your library.
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | SpellDescription$ Draw a card.
-SVar:X:Count$TypeInYourYard.Artifact
+SVar:X:Count$ValidGraveyard Artifact.YouOwn
 AI:RemoveDeck:All
 AI:RemoveDeck:Random
 Oracle:Put any number of target artifact cards from your graveyard on top of your library.\nDraw a card.

--- a/forge-gui/res/cardsfolder/g/garruk_relentless_garruk_the_veil_cursed.txt
+++ b/forge-gui/res/cardsfolder/g/garruk_relentless_garruk_the_veil_cursed.txt
@@ -21,5 +21,5 @@ Loyalty:3
 A:AB$ Token | Cost$ AddCounter<1/LOYALTY> | TokenAmount$ 1 | TokenScript$ b_1_1_wolf_deathtouch | TokenOwner$ You | Planeswalker$ True | SpellDescription$ Create a 1/1 black Wolf creature token with deathtouch.
 A:AB$ ChangeZone | Cost$ SubCounter<1/LOYALTY> | UnlessCost$ Sac<1/Creature> | UnlessSwitched$ True | UnlessPayer$ You | Origin$ Library | Destination$ Hand | ChangeType$ Creature | ChangeNum$ 1 | Planeswalker$ True | SpellDescription$ Sacrifice a creature. If you do, search your library for a creature card, reveal it, put it into your hand, then shuffle.
 A:AB$ PumpAll | Cost$ SubCounter<3/LOYALTY> | ValidCards$ Creature.YouCtrl | KW$ Trample | NumAtt$ +X | NumDef$ +X | Planeswalker$ True | Ultimate$ True | SpellDescription$ Creatures you control gain trample and get +X/+X until end of turn, where X is the number of creature cards in your graveyard.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:[+1]: Create a 1/1 black Wolf creature token with deathtouch.\n[-1]: Sacrifice a creature. If you do, search your library for a creature card, reveal it, put it into your hand, then shuffle.\n[-3]: Creatures you control gain trample and get +X/+X until end of turn, where X is the number of creature cards in your graveyard.

--- a/forge-gui/res/cardsfolder/g/ghastly_remains.txt
+++ b/forge-gui/res/cardsfolder/g/ghastly_remains.txt
@@ -6,7 +6,7 @@ K:Amplify:1:Zombie
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | IsPresent$ Card.StrictlySelf | PresentZone$ Graveyard | PresentPlayer$ You | TriggerZones$ Graveyard | OptionalDecider$ You | Execute$ TrigReturn | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard, you may pay {B}{B}{B}. If you do, return CARDNAME to your hand.
 SVar:TrigReturn:AB$ ChangeZone | Cost$ B B B | Defined$ Self | Origin$ Graveyard | Destination$ Hand
 SVar:NeedsToPlayVar:X GE2
-SVar:X:Count$TypeInYourHand.Zombie
+SVar:X:Count$ValidHand Zombie.YouOwn
 SVar:SacMe:2
 SVar:DiscardMe:2
 Oracle:Amplify 1 (As this creature enters, put a +1/+1 counter on it for each Zombie card you reveal in your hand.)\nAt the beginning of your upkeep, if Ghastly Remains is in your graveyard, you may pay {B}{B}{B}. If you do, return Ghastly Remains to your hand.

--- a/forge-gui/res/cardsfolder/g/ghouls_feast.txt
+++ b/forge-gui/res/cardsfolder/g/ghouls_feast.txt
@@ -2,5 +2,5 @@ Name:Ghoul's Feast
 ManaCost:1 B
 Types:Instant
 A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | SpellDescription$ Target creature gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:Target creature gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard.

--- a/forge-gui/res/cardsfolder/g/ghoultree.txt
+++ b/forge-gui/res/cardsfolder/g/ghoultree.txt
@@ -3,5 +3,5 @@ ManaCost:7 G
 Types:Creature Zombie Treefolk
 PT:10/10
 S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {1} less to cast for each creature card in your graveyard.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:This spell costs {1} less to cast for each creature card in your graveyard.

--- a/forge-gui/res/cardsfolder/g/gnarlroot_pallbearer.txt
+++ b/forge-gui/res/cardsfolder/g/gnarlroot_pallbearer.txt
@@ -5,6 +5,6 @@ PT:5/5
 K:Trample
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ When CARDNAME enters, target creature gets +X/+X until end of turn, where X is the number of creature cards in your graveyard.
 SVar:TrigPump:DB$ Pump | ValidTgts$ Creature | NumAtt$ +X | NumDef$ +X
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 DeckHints:Ability$Graveyard|Mill|Dredge|Discard
 Oracle:Trample\nWhen Gnarlroot Pallbearer enters, target creature gets +X/+X until end of turn, where X is the number of creature cards in your graveyard.

--- a/forge-gui/res/cardsfolder/g/gnaw_to_the_bone.txt
+++ b/forge-gui/res/cardsfolder/g/gnaw_to_the_bone.txt
@@ -3,5 +3,5 @@ ManaCost:2 G
 Types:Instant
 K:Flashback:2 G
 A:SP$ GainLife | Defined$ You | LifeAmount$ X | SpellDescription$ You gain 2 life for each creature card in your graveyard.
-SVar:X:Count$TypeInYourYard.Creature/Times.2
+SVar:X:Count$ValidGraveyard Creature.YouOwn/Times.2
 Oracle:You gain 2 life for each creature card in your graveyard.\nFlashback {2}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)

--- a/forge-gui/res/cardsfolder/g/graveblade_marauder.txt
+++ b/forge-gui/res/cardsfolder/g/graveblade_marauder.txt
@@ -5,5 +5,5 @@ PT:1/4
 K:Deathtouch
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigLoseLife | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, that player loses life equal to the number of creature cards in your graveyard.
 SVar:TrigLoseLife:DB$ LoseLife | Defined$ TriggeredTarget | LifeAmount$ X
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhenever Graveblade Marauder deals combat damage to a player, that player loses life equal to the number of creature cards in your graveyard.

--- a/forge-gui/res/cardsfolder/g/gravepurge.txt
+++ b/forge-gui/res/cardsfolder/g/gravepurge.txt
@@ -3,6 +3,6 @@ ManaCost:2 B
 Types:Instant
 A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Library | TargetMin$ 0 | TargetMax$ X | TgtPrompt$ Choose target creature card in your graveyard | ValidTgts$ Creature.YouCtrl | SubAbility$ DBDraw | SpellDescription$ Put any number of target creature cards from your graveyard on top of your library.
 SVar:DBDraw:DB$ Draw | NumCards$ 1 | SpellDescription$ Draw a card.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 AI:RemoveDeck:All
 Oracle:Put any number of target creature cards from your graveyard on top of your library.\nDraw a card.

--- a/forge-gui/res/cardsfolder/g/graverobber_spider.txt
+++ b/forge-gui/res/cardsfolder/g/graverobber_spider.txt
@@ -4,6 +4,6 @@ Types:Creature Spider
 PT:2/4
 K:Reach
 A:AB$ Pump | Cost$ 3 B | Defined$ Self | NumAtt$ +X | NumDef$ +X | ActivationLimit$ 1 | SpellDescription$ CARDNAME gets +X/+X until end of turn, where X is the number of creature cards in your graveyard. Activate only once each turn.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 DeckHints:Ability$Graveyard
 Oracle:Reach\n{3}{B}: Graverobber Spider gets +X/+X until end of turn, where X is the number of creature cards in your graveyard. Activate only once each turn.

--- a/forge-gui/res/cardsfolder/g/grim_flowering.txt
+++ b/forge-gui/res/cardsfolder/g/grim_flowering.txt
@@ -2,5 +2,5 @@ Name:Grim Flowering
 ManaCost:5 G
 Types:Sorcery
 A:SP$ Draw | NumCards$ X | SpellDescription$ Draw a card for each creature card in your graveyard.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:Draw a card for each creature card in your graveyard.

--- a/forge-gui/res/cardsfolder/g/grist_the_hunger_tide.txt
+++ b/forge-gui/res/cardsfolder/g/grist_the_hunger_tide.txt
@@ -13,7 +13,7 @@ SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 A:AB$ ImmediateTrigger | Cost$ SubCounter<2/LOYALTY> | Planeswalker$ True | Execute$ TrigDestroy | UnlessCost$ Sac<1/Creature> | UnlessPayer$ You | UnlessSwitched$ True | AILogic$ WeakerCreature | SpellDescription$ You may sacrifice a creature. When you do, destroy target creature or planeswalker.
 SVar:TrigDestroy:DB$ Destroy | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker
 A:AB$ LoseLife | Cost$ SubCounter<5/LOYALTY> | LifeAmount$ X | Defined$ Player.Opponent | Planeswalker$ True | Ultimate$ True | SpellDescription$ Each opponent loses life equal to the number of creature cards in your graveyard.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 DeckHas:Ability$Token|Mill
 DeckHints:Type$Insect
 Oracle:As long as Grist, the Hunger Tide isn't on the battlefield, it's a 1/1 Insect creature in addition to its other types.\n[+1]: Create a 1/1 black and green Insect creature token, then mill a card. If an Insect card was milled this way, put a loyalty counter on Grist and repeat this process.\n[-2]: You may sacrifice a creature. When you do, destroy target creature or planeswalker.\n[-5]: Each opponent loses life equal to the number of creature cards in your graveyard.

--- a/forge-gui/res/cardsfolder/h/hallowed_spiritkeeper.txt
+++ b/forge-gui/res/cardsfolder/h/hallowed_spiritkeeper.txt
@@ -5,6 +5,6 @@ PT:3/2
 K:Vigilance
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME dies, create X 1/1 white Spirit creature tokens with flying, where X is the number of creature cards in your graveyard.
 SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ w_1_1_spirit_flying | TokenOwner$ You
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 DeckHas:Ability$Token
 Oracle:Vigilance\nWhen Hallowed Spiritkeeper dies, create X 1/1 white Spirit creature tokens with flying, where X is the number of creature cards in your graveyard.

--- a/forge-gui/res/cardsfolder/h/harvest_wurm.txt
+++ b/forge-gui/res/cardsfolder/h/harvest_wurm.txt
@@ -8,5 +8,5 @@ SVar:DBSac:DB$ Sacrifice | SubAbility$ DBCleanup | ConditionCheckSVar$ X | Condi
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Remembered$Amount
 SVar:NeedsToPlayVar:Y GE1
-SVar:Y:Count$TypeInYourYard.Basic
+SVar:Y:Count$ValidGraveyard Land.Basic+YouOwn
 Oracle:When Harvest Wurm enters, sacrifice it unless you return a basic land card from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/h/hatchery_spider.txt
+++ b/forge-gui/res/cardsfolder/h/hatchery_spider.txt
@@ -5,5 +5,5 @@ PT:5/7
 K:Reach
 T:Mode$ SpellCast | ValidCard$ Card.Self | Execute$ TrigDig | TriggerDescription$ Undergrowth — When you cast this spell, reveal the top X cards of your library, where X is the number of creature cards in your graveyard. You may put a green permanent card with mana value X or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.
 SVar:TrigDig:DB$ Dig | DigNum$ X | Reveal$ True | ChangeNum$ 1 | ChangeValid$ Permanent.Green+cmcLEX | DestinationZone$ Battlefield | AILogic$ AtOppEOT | Optional$ True | RestRandomOrder$ True
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:Reach\nUndergrowth — When you cast this spell, reveal the top X cards of your library, where X is the number of creature cards in your graveyard. You may put a green permanent card with mana value X or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.

--- a/forge-gui/res/cardsfolder/h/hidden_horror.txt
+++ b/forge-gui/res/cardsfolder/h/hidden_horror.txt
@@ -5,5 +5,5 @@ PT:4/4
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ DBSacSelf | TriggerDescription$ When CARDNAME enters, sacrifice it unless you discard a creature card.
 SVar:DBSacSelf:DB$ Sacrifice | UnlessCost$ Discard<1/Creature> | UnlessPayer$ You
 SVar:NeedsToPlayVar:Y GE2
-SVar:Y:Count$TypeInYourHand.Creature
+SVar:Y:Count$ValidHand Creature.YouOwn
 Oracle:When Hidden Horror enters, sacrifice it unless you discard a creature card.

--- a/forge-gui/res/cardsfolder/i/iname_death_aspect.txt
+++ b/forge-gui/res/cardsfolder/i/iname_death_aspect.txt
@@ -4,6 +4,6 @@ Types:Legendary Creature Spirit
 PT:4/4
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChangeZone | OptionalDecider$ You | TriggerDescription$ When CARDNAME enters, you may search your library for any number of Spirit cards, put them into your graveyard, then shuffle.
 SVar:TrigChangeZone:DB$ ChangeZone | ChangeType$ Spirit.YouCtrl | Origin$ Library | Destination$ Graveyard | ChangeNum$ X | ShuffleNonMandatory$ True
-SVar:X:Count$TypeInYourLibrary.Spirit
+SVar:X:Count$ValidLibrary Spirit.YouCtrl
 AI:RemoveDeck:All
 Oracle:When Iname, Death Aspect enters, you may search your library for any number of Spirit cards, put them into your graveyard, then shuffle.

--- a/forge-gui/res/cardsfolder/i/ire_of_kaminari.txt
+++ b/forge-gui/res/cardsfolder/i/ire_of_kaminari.txt
@@ -2,7 +2,7 @@ Name:Ire of Kaminari
 ManaCost:3 R
 Types:Instant Arcane
 A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ X | SpellDescription$ CARDNAME deals damage to any target equal to the number of Arcane cards in your graveyard.
-SVar:X:Count$TypeInYourYard.Arcane
+SVar:X:Count$ValidGraveyard Arcane.YouOwn
 AI:RemoveDeck:Random
 DeckHints:Type$Arcane
 Oracle:Ire of Kaminari deals damage to any target equal to the number of Arcane cards in your graveyard.

--- a/forge-gui/res/cardsfolder/i/izoni_thousand_eyed.txt
+++ b/forge-gui/res/cardsfolder/i/izoni_thousand_eyed.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature Elf Shaman
 PT:2/3
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ Undergrowth — When CARDNAME enters, create a 1/1 black and green Insect creature token for each creature card in your graveyard.
 SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenOwner$ You | TokenScript$ bg_1_1_insect
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 A:AB$ GainLife | Cost$ B G Sac<1/Creature.Other/another creature> | Defined$ You | LifeAmount$ 1 | SubAbility$ DBDraw | SpellDescription$ You gain 1 life and draw a card.
 SVar:DBDraw:DB$ Draw | NumCards$ 1
 DeckHas:Ability$Token|LifeGain

--- a/forge-gui/res/cardsfolder/j/jarad_golgari_lich_lord.txt
+++ b/forge-gui/res/cardsfolder/j/jarad_golgari_lich_lord.txt
@@ -5,6 +5,6 @@ PT:2/2
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ X | AddToughness$ X | Description$ CARDNAME gets +1/+1 for each creature card in your graveyard.
 A:AB$ LoseLife | Cost$ 1 B G Sac<1/Creature.Other/another creature> | Defined$ Player.Opponent | LifeAmount$ LichLeech | SpellDescription$ Each opponent loses life equal to the sacrificed creature's power.
 A:AB$ ChangeZone | Cost$ Sac<1/Swamp> Sac<1/Forest> | Origin$ Graveyard | Destination$ Hand | ActivationZone$ Graveyard | SpellDescription$ Return CARDNAME from your graveyard to your hand.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 SVar:LichLeech:Sacrificed$CardPower
 Oracle:Jarad, Golgari Lich Lord gets +1/+1 for each creature card in your graveyard.\n{1}{B}{G}, Sacrifice another creature: Each opponent loses life equal to the sacrificed creature's power.\nSacrifice a Swamp and a Forest: Return Jarad from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/k/keeper_of_the_dead.txt
+++ b/forge-gui/res/cardsfolder/k/keeper_of_the_dead.txt
@@ -5,5 +5,5 @@ PT:1/2
 A:AB$ Pump | Cost$ B T | ValidTgts$ Opponent | TgtPrompt$ Choose target opponent with at least two fewer creature cards in their graveyard than you | CheckSVar$ X | SVarCompare$ GEY | SubAbility$ DeadKeepersDestroy | StackDescription$ None | SpellDescription$ Choose target opponent who had at least two fewer creature cards in their graveyard than you did as you activated this ability. Destroy target nonblack creature that player controls.
 SVar:DeadKeepersDestroy:DB$ Destroy | ValidTgts$ Creature.nonBlack+TargetedPlayerCtrl | TgtPrompt$ Select target nonblack creature targeted player controls
 SVar:X:Count$ValidGraveyard Creature.YouOwn/Minus.2
-SVar:Y:Count$TypeInOppYard.Creature
+SVar:Y:Count$ValidGraveyard Creature.OppOwn
 Oracle:{B}, {T}: Choose target opponent who had at least two fewer creature cards in their graveyard than you did as you activated this ability. Destroy target nonblack creature that player controls.

--- a/forge-gui/res/cardsfolder/k/keeper_of_the_dead.txt
+++ b/forge-gui/res/cardsfolder/k/keeper_of_the_dead.txt
@@ -4,6 +4,6 @@ Types:Creature Human Wizard
 PT:1/2
 A:AB$ Pump | Cost$ B T | ValidTgts$ Opponent | TgtPrompt$ Choose target opponent with at least two fewer creature cards in their graveyard than you | CheckSVar$ X | SVarCompare$ GEY | SubAbility$ DeadKeepersDestroy | StackDescription$ None | SpellDescription$ Choose target opponent who had at least two fewer creature cards in their graveyard than you did as you activated this ability. Destroy target nonblack creature that player controls.
 SVar:DeadKeepersDestroy:DB$ Destroy | ValidTgts$ Creature.nonBlack+TargetedPlayerCtrl | TgtPrompt$ Select target nonblack creature targeted player controls
-SVar:X:Count$TypeInYourYard.Creature/Minus.2
+SVar:X:Count$ValidGraveyard Creature.YouOwn/Minus.2
 SVar:Y:Count$TypeInOppYard.Creature
 Oracle:{B}, {T}: Choose target opponent who had at least two fewer creature cards in their graveyard than you did as you activated this ability. Destroy target nonblack creature that player controls.

--- a/forge-gui/res/cardsfolder/k/kessig_cagebreakers.txt
+++ b/forge-gui/res/cardsfolder/k/kessig_cagebreakers.txt
@@ -4,6 +4,6 @@ Types:Creature Human Rogue
 PT:3/4
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ Whenever CARDNAME attacks, create a 2/2 green Wolf creature token that's tapped and attacking for each creature card in your graveyard.
 SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ g_2_2_wolf | TokenOwner$ You | TokenTapped$ True | TokenAttacking$ True
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 SVar:HasAttackEffect:TRUE
 Oracle:Whenever Kessig Cagebreakers attacks, create a 2/2 green Wolf creature token that's tapped and attacking for each creature card in your graveyard.

--- a/forge-gui/res/cardsfolder/k/knight_of_the_reliquary.txt
+++ b/forge-gui/res/cardsfolder/k/knight_of_the_reliquary.txt
@@ -4,5 +4,5 @@ Types:Creature Human Knight
 PT:2/2
 A:AB$ ChangeZone | Cost$ T Sac<1/Forest;Plains/Forest or Plains> | Origin$ Library | Destination$ Battlefield | ChangeType$ Land | ChangeNum$ 1 | SpellDescription$ Search your library for a land card, put it onto the battlefield, then shuffle.
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ X | AddToughness$ X | Description$ CARDNAME gets +1/+1 for each land card in your graveyard.
-SVar:X:Count$TypeInYourYard.Land
+SVar:X:Count$ValidGraveyard Land.YouOwn
 Oracle:Knight of the Reliquary gets +1/+1 for each land card in your graveyard.\n{T}, Sacrifice a Forest or Plains: Search your library for a land card, put it onto the battlefield, then shuffle.

--- a/forge-gui/res/cardsfolder/k/kraul_foragers.txt
+++ b/forge-gui/res/cardsfolder/k/kraul_foragers.txt
@@ -4,5 +4,5 @@ Types:Creature Insect Scout
 PT:4/4
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigGainLife | TriggerDescription$ Undergrowth — When CARDNAME enters, you gain 1 life for each creature card in your graveyard.
 SVar:TrigGainLife:DB$ GainLife | Defined$ You | LifeAmount$ X
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:Undergrowth — When Kraul Foragers enters, you gain 1 life for each creature card in your graveyard.

--- a/forge-gui/res/cardsfolder/k/kraul_harpooner.txt
+++ b/forge-gui/res/cardsfolder/k/kraul_harpooner.txt
@@ -6,5 +6,5 @@ K:Reach
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ Undergrowth — When CARDNAME enters, choose up to one target creature with flying you don't control. CARDNAME gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard, then you may have CARDNAME fight that creature.
 SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +X | SubAbility$ DBFight
 SVar:DBFight:DB$ Fight | Defined$ Self | ValidTgts$ Creature.withFlying+YouDontCtrl | TgtPrompt$ Select target creature with flying you don't control | TargetMin$ 0 | TargetMax$ 1 | Optional$ True
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:Reach\nUndergrowth — When Kraul Harpooner enters, choose up to one target creature with flying you don't control. Kraul Harpooner gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard, then you may have Kraul Harpooner fight that creature.

--- a/forge-gui/res/cardsfolder/k/kroxa_and_kunoros.txt
+++ b/forge-gui/res/cardsfolder/k/kroxa_and_kunoros.txt
@@ -11,7 +11,7 @@ SVar:TrigImmediateTrig:AB$ ImmediateTrigger | Cost$ ExileFromGrave<5/Card> | Exe
 SVar:TrigReturn:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | ValidTgts$ Creature.YouOwn | TgtPrompt$ Select target creature to return from your graveyard
 SVar:NeedsToPlayVar:Z EQ6
 SVar:X:Count$InYourYard/LimitMax.6
-SVar:Y:Count$TypeInYourYard.Creature/LimitMax.1
+SVar:Y:Count$ValidGraveyard Creature.YouOwn/LimitMax.1
 SVar:Z:SVar$X/Times.Y
 DeckHas:Ability$Graveyard|LifeGain
 DeckHints:Ability$Discard

--- a/forge-gui/res/cardsfolder/l/land_grant.txt
+++ b/forge-gui/res/cardsfolder/l/land_grant.txt
@@ -2,6 +2,6 @@ Name:Land Grant
 ManaCost:1 G
 Types:Sorcery
 S:Mode$ AlternativeCost | ValidSA$ Spell | ValidCard$ Card.Self | ValidPlayer$ You | Cost$ Reveal<1/Hand> | EffectZone$ All | CheckSVar$ X | SVarCompare$ EQ0 | Description$ If you have no land cards in hand, you may reveal your hand rather than pay this spell's mana cost.
-SVar:X:Count$TypeInYourHand.Land
+SVar:X:Count$ValidHand Land.YouOwn
 A:SP$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Forest | ChangeNum$ 1 | SpellDescription$ Search your library for a Forest card, reveal that card, put it into your hand, then shuffle.
 Oracle:If you have no land cards in hand, you may reveal your hand rather than pay this spell's mana cost.\nSearch your library for a Forest card, reveal that card, put it into your hand, then shuffle.

--- a/forge-gui/res/cardsfolder/l/lilianas_elite.txt
+++ b/forge-gui/res/cardsfolder/l/lilianas_elite.txt
@@ -3,6 +3,6 @@ ManaCost:2 B
 Types:Creature Zombie
 PT:1/1
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ X | AddToughness$ X | Description$ CARDNAME gets +1/+1 for each creature card in your graveyard.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 DeckHints:Ability$Graveyard
 Oracle:Liliana's Elite gets +1/+1 for each creature card in your graveyard.

--- a/forge-gui/res/cardsfolder/l/lotleth_giant.txt
+++ b/forge-gui/res/cardsfolder/l/lotleth_giant.txt
@@ -4,5 +4,5 @@ Types:Creature Zombie Giant
 PT:6/5
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ Undergrowth — When CARDNAME enters, it deals 1 damage to target opponent for each creature card in your graveyard.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Opponent | TgtPrompt$ Select target opponent | NumDmg$ X
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:Undergrowth — When Lotleth Giant enters, it deals 1 damage to target opponent for each creature card in your graveyard.

--- a/forge-gui/res/cardsfolder/m/mana_severance.txt
+++ b/forge-gui/res/cardsfolder/m/mana_severance.txt
@@ -2,6 +2,6 @@ Name:Mana Severance
 ManaCost:1 U
 Types:Sorcery
 A:SP$ ChangeZone | Origin$ Library | Destination$ Exile | ChangeType$ Land | ChangeNum$ XFetch | SpellDescription$ Search your library for any number of land cards, exile them, then shuffle.
-SVar:XFetch:Count$TypeInYourLibrary.Land
+SVar:XFetch:Count$ValidLibrary Land.YouCtrl
 AI:RemoveDeck:All
 Oracle:Search your library for any number of land cards, exile them, then shuffle.

--- a/forge-gui/res/cardsfolder/m/mausoleum_secrets.txt
+++ b/forge-gui/res/cardsfolder/m/mausoleum_secrets.txt
@@ -2,6 +2,6 @@ Name:Mausoleum Secrets
 ManaCost:1 B
 Types:Instant
 A:SP$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Card.Black+cmcLEX | ChangeTypeDesc$ black card with mana value less than or equal to the number of creature cards in their graveyard | ChangeNum$ 1 | SpellDescription$ Undergrowth — Search your library for a black card with mana value less than or equal to the number of creature cards in your graveyard, reveal it, put it into your hand, then shuffle.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 AI:RemoveDeck:Random
 Oracle:Undergrowth — Search your library for a black card with mana value less than or equal to the number of creature cards in your graveyard, reveal it, put it into your hand, then shuffle.

--- a/forge-gui/res/cardsfolder/m/mercenary_knight.txt
+++ b/forge-gui/res/cardsfolder/m/mercenary_knight.txt
@@ -5,5 +5,5 @@ PT:4/4
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ DBSacSelf | TriggerDescription$ When CARDNAME enters, sacrifice it unless you discard a creature card.
 SVar:DBSacSelf:DB$ Sacrifice | UnlessCost$ Discard<1/Creature> | UnlessPayer$ You
 SVar:NeedsToPlayVar:Y GE2
-SVar:Y:Count$TypeInYourHand.Creature
+SVar:Y:Count$ValidHand Creature.YouOwn
 Oracle:When Mercenary Knight enters, sacrifice it unless you discard a creature card.

--- a/forge-gui/res/cardsfolder/m/molderhulk.txt
+++ b/forge-gui/res/cardsfolder/m/molderhulk.txt
@@ -5,5 +5,5 @@ PT:6/6
 S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ Undergrowth — This spell costs {1} less to cast for each creature card in your graveyard.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChangeZone | TriggerDescription$ When CARDNAME enters, return target land card from your graveyard to the battlefield.
 SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | ValidTgts$ Land.YouCtrl | TgtPrompt$ Select target land card from your graveyard
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:Undergrowth — This spell costs {1} less to cast for each creature card in your graveyard.\nWhen Molderhulk enters, return target land card from your graveyard to the battlefield.

--- a/forge-gui/res/cardsfolder/m/moodmark_painter.txt
+++ b/forge-gui/res/cardsfolder/m/moodmark_painter.txt
@@ -4,6 +4,6 @@ Types:Creature Human Shaman
 PT:2/3
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ When CARDNAME enters, target creature gains menace and gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard. (It can't blocked except by two or more creatures.)
 SVar:TrigPump:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | KW$ Menace
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 SVar:PlayMain1:TRUE
 Oracle:Undergrowth — When Moodmark Painter enters, target creature gains menace and gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard. (It can't be blocked except by two or more creatures.)

--- a/forge-gui/res/cardsfolder/m/multani_yavimayas_avatar.txt
+++ b/forge-gui/res/cardsfolder/m/multani_yavimayas_avatar.txt
@@ -6,7 +6,7 @@ K:Reach
 K:Trample
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ X | AddToughness$ X | Description$ CARDNAME gets +1/+1 for each land you control and each land card in your graveyard.
 SVar:X:Count$Valid Land.YouCtrl/Plus.Y
-SVar:Y:Count$TypeInYourYard.Land
+SVar:Y:Count$ValidGraveyard Land.YouOwn
 A:AB$ ChangeZone | Cost$ 1 G Return<2/Land> | Origin$ Graveyard | Destination$ Hand | ActivationZone$ Graveyard | SpellDescription$ Return CARDNAME from your graveyard to your hand.
 SVar:DiscardMe:1
 Oracle:Reach, trample\nMultani, Yavimaya's Avatar gets +1/+1 for each land you control and each land card in your graveyard.\n{1}{G}, Return two lands you control to their owner's hand: Return Multani from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/n/nantuko_cultivator.txt
+++ b/forge-gui/res/cardsfolder/n/nantuko_cultivator.txt
@@ -7,7 +7,7 @@ SVar:TrigNantukoDiscardLand:DB$ Discard | DiscardValid$ Land | NumCards$ Nantuko
 SVar:DBNantukoPutCounter:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ NantukoY | SubAbility$ DBNantukoDraw
 SVar:DBNantukoDraw:DB$ Draw | NumCards$ NantukoY | SubAbility$ DBNantukoCleanup
 SVar:DBNantukoCleanup:DB$ Cleanup | ClearRemembered$ True
-SVar:NantukoX:Count$TypeInYourHand.Land
+SVar:NantukoX:Count$ValidHand Land.YouOwn
 SVar:NantukoY:Remembered$Amount
 AI:RemoveDeck:All
 DeckHas:Ability$Counters

--- a/forge-gui/res/cardsfolder/n/necromancy.txt
+++ b/forge-gui/res/cardsfolder/n/necromancy.txt
@@ -12,5 +12,5 @@ SVar:TrigSacrifice:DB$ SacrificeAll | Defined$ DelayTriggerRememberedLKI
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | ValidCard$ Card.Self | Execute$ DBCleanup | Static$ True
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:NeedsToPlayVar:Y GE1
-SVar:Y:Count$TypeInYourYard.Creature
+SVar:Y:Count$ValidGraveyard Creature.YouOwn
 Oracle:You may cast Necromancy as though it had flash. If you cast it any time a sorcery couldn't have been cast, the controller of the permanent it becomes sacrifices it at the beginning of the next cleanup step.\nWhen Necromancy enters, if it's on the battlefield, it becomes an Aura with "enchant creature put onto the battlefield with Necromancy." Put target creature card from a graveyard onto the battlefield under your control and attach Necromancy to it. When Necromancy leaves the battlefield, that creature's controller sacrifices it.

--- a/forge-gui/res/cardsfolder/n/necrotic_wound.txt
+++ b/forge-gui/res/cardsfolder/n/necrotic_wound.txt
@@ -2,5 +2,5 @@ Name:Necrotic Wound
 ManaCost:B
 Types:Instant
 A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ -X | NumDef$ -X | ReplaceDyingDefined$ Targeted | IsCurse$ True | SpellDescription$ Target creature gets -X/-X until end of turn, where X is the number of creature cards in your graveyard. If that creature would die this turn, exile it instead.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:Undergrowth — Target creature gets -X/-X until end of turn, where X is the number of creature cards in your graveyard. If that creature would die this turn, exile it instead.

--- a/forge-gui/res/cardsfolder/n/nightstalker_engine.txt
+++ b/forge-gui/res/cardsfolder/n/nightstalker_engine.txt
@@ -3,5 +3,5 @@ ManaCost:4 B
 Types:Creature Nightstalker
 PT:*/3
 S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of creature cards in your graveyard.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:Nightstalker Engine's power is equal to the number of creature cards in your graveyard.

--- a/forge-gui/res/cardsfolder/n/nissa_revane.txt
+++ b/forge-gui/res/cardsfolder/n/nissa_revane.txt
@@ -6,7 +6,7 @@ A:AB$ ChangeZone | Cost$ AddCounter<1/LOYALTY> | Origin$ Library | Destination$ 
 A:AB$ GainLife | Cost$ AddCounter<1/LOYALTY> | LifeAmount$ XLife | Planeswalker$ True | SpellDescription$ You gain 2 life for each Elf you control.
 A:AB$ ChangeZone | Cost$ SubCounter<7/LOYALTY> | Origin$ Library | Destination$ Battlefield | ChangeType$ Creature.Elf | ChangeNum$ XFetch | Planeswalker$ True | Ultimate$ True | StackDescription$ SpellDescription | SpellDescription$ Search your library for any number of Elf creature cards, put them onto the battlefield, then shuffle.
 SVar:XLife:Count$TypeYouCtrl.Elf/Times.2
-SVar:XFetch:Count$TypeInYourLibrary.Elf
+SVar:XFetch:Count$ValidLibrary Creature.Elf+YouCtrl
 AI:RemoveDeck:Random
 DeckHints:Type$Elf & Name$Nissa's Chosen
 Oracle:[+1]: Search your library for a card named Nissa's Chosen, put it onto the battlefield, then shuffle.\n[+1]: You gain 2 life for each Elf you control.\n[-7]: Search your library for any number of Elf creature cards, put them onto the battlefield, then shuffle.

--- a/forge-gui/res/cardsfolder/n/nissa_who_shakes_the_world.txt
+++ b/forge-gui/res/cardsfolder/n/nissa_who_shakes_the_world.txt
@@ -10,6 +10,6 @@ SVar:DBAnimate:DB$ Animate | Defined$ Targeted | Power$ 0 | Toughness$ 0 | Types
 A:AB$ Effect | Cost$ SubCounter<8/LOYALTY> | Name$ Emblem — Nissa, Who Shakes the World | Image$ emblem_nissa_who_shakes_the_world | Duration$ Permanent | Stackable$ False | Planeswalker$ True | Ultimate$ True | StaticAbilities$ STIndestructible | SubAbility$ DBChangeZone | SpellDescription$ You get an emblem with "Lands you control have indestructible." Search your library for any number of Forest cards, put them onto the battlefield tapped, then shuffle.
 SVar:STIndestructible:Mode$ Continuous | Affected$ Land.YouCtrl | AffectedZone$ Battlefield | AddKeyword$ Indestructible | Description$ Lands you control have indestructible.
 SVar:DBChangeZone:DB$ ChangeZone | Origin$ Library | Destination$ Battlefield | ChangeType$ Forest | ChangeNum$ XFetch | Tapped$ True | StackDescription$ Search your library for any number of Forest cards, put them onto the battlefield tapped, then shuffle.
-SVar:XFetch:Count$TypeInYourLibrary.Forest
+SVar:XFetch:Count$ValidLibrary Forest.YouCtrl
 DeckHas:Ability$Counters
 Oracle:Whenever you tap a Forest for mana, add an additional {G}.\n[+1]: Put three +1/+1 counters on up to one target noncreature land you control. Untap it. It becomes a 0/0 Elemental creature with vigilance and haste that's still a land.\n[-8]: You get an emblem with "Lands you control have indestructible." Search your library for any number of Forest cards, put them onto the battlefield tapped, then shuffle.

--- a/forge-gui/res/cardsfolder/o/old_stickfingers.txt
+++ b/forge-gui/res/cardsfolder/o/old_stickfingers.txt
@@ -6,6 +6,6 @@ T:Mode$ SpellCast | ValidCard$ Card.Self | Execute$ TrigDigUntil | TriggerDescri
 SVar:TrigDigUntil:DB$ DigUntil | Amount$ X | Valid$ Creature | FoundDestination$ Graveyard | RevealedDestination$ Library | RevealedLibraryPosition$ -1 | RevealRandomOrder$ True
 SVar:X:Count$xPaid
 S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ Y | SetToughness$ Y | Description$ CARDNAME's power and toughness are each equal to the number of creature cards in your graveyard.
-SVar:Y:Count$TypeInYourYard.Creature
+SVar:Y:Count$ValidGraveyard Creature.YouOwn
 DeckHas:Ability$Graveyard
 Oracle:When you cast this spell, reveal cards from the top of your library until you reveal X creature cards. Put all the creature cards revealed this way into your graveyard and the rest on the bottom of your library in a random order.\nOld Stickfingers's power and toughness are each equal to the number of creature cards in your graveyard.

--- a/forge-gui/res/cardsfolder/o/ore_scale_guardian.txt
+++ b/forge-gui/res/cardsfolder/o/ore_scale_guardian.txt
@@ -3,7 +3,7 @@ ManaCost:5 R R
 Types:Creature Dragon
 PT:4/4
 S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {1} less to cast for each land card in your graveyard.
-SVar:X:Count$TypeInYourYard.Land
+SVar:X:Count$ValidGraveyard Land.YouOwn
 K:Flying
 K:Haste
 Oracle:This spell costs {1} less to cast for each land card in your graveyard.\nFlying, haste

--- a/forge-gui/res/cardsfolder/o/ossuary_rats.txt
+++ b/forge-gui/res/cardsfolder/o/ossuary_rats.txt
@@ -4,6 +4,6 @@ Types:Creature Rat
 PT:3/2
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When CARDNAME enters, it deals X damage to target creature or planeswalker an opponent controls, where X is the number of creature cards in your graveyard.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Creature.OppCtrl,Planeswalker.OppCtrl | TgtPrompt$ Select target creature or planeswalker an opponent controls | NumDmg$ X
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 DeckHints:Ability$Graveyard|Mill
 Oracle:When Ossuary Rats enters, it deals X damage to target creature or planeswalker an opponent controls, where X is the number of creature cards in your graveyard.

--- a/forge-gui/res/cardsfolder/p/pipers_melody.txt
+++ b/forge-gui/res/cardsfolder/p/pipers_melody.txt
@@ -2,5 +2,5 @@ Name:Piper's Melody
 ManaCost:G
 Types:Sorcery
 A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Library | TargetMin$ 0 | TargetMax$ X | Shuffle$ True | TgtPrompt$ Choose target creature card in your graveyard | ValidTgts$ Creature.YouCtrl | SpellDescription$ Shuffle any number of target creature cards from your graveyard into your library.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:Shuffle any number of target creature cards from your graveyard into your library.

--- a/forge-gui/res/cardsfolder/p/prophet_of_the_scarab.txt
+++ b/forge-gui/res/cardsfolder/p/prophet_of_the_scarab.txt
@@ -6,5 +6,5 @@ K:Vigilance
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ When this creature enters, draw cards equal to the number of Zombies you control or the number of Zombie cards in your graveyard, whichever is greater.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ X
 SVar:X:Count$Valid Zombie.YouCtrl/LimitMin.Y
-SVar:Y:Count$TypeInYourYard.Zombie
+SVar:Y:Count$ValidGraveyard Zombie.YouOwn
 Oracle:Vigilance\nWhen this creature enters, draw cards equal to the number of Zombies you control or the number of Zombie cards in your graveyard, whichever is greater.

--- a/forge-gui/res/cardsfolder/r/realmbreaker_the_invasion_tree.txt
+++ b/forge-gui/res/cardsfolder/r/realmbreaker_the_invasion_tree.txt
@@ -8,7 +8,7 @@ SVar:ReplaceLeaves:Event$ Moved | ActiveZones$ Battlefield | Origin$ Battlefield
 SVar:Exile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | Defined$ ReplacedCard
 A:AB$ ChangeZone | Cost$ 10 T Sac<1/CARDNAME> | Origin$ Library | Destination$ Battlefield | ChangeType$ Praetor | ChangeNum$ XFetch | StackDescription$ {p:You} searches their library for any number of Praetor cards, puts them onto the battlefield, then shuffles. | SpellDescription$ Search your library for any number of Praetor cards, put them onto the battlefield, then shuffle.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-SVar:XFetch:Count$TypeInYourLibrary.Praetor
+SVar:XFetch:Count$ValidLibrary Praetor.YouCtrl
 DeckHas:Ability$Mill|Sacrifice
 DeckHints:Type$Praetor
 Oracle:{2}, {T}: Target opponent mills three cards. Put a land card from their graveyard onto the battlefield tapped under your control. It gains "If this land would leave the battlefield, exile it instead of putting it anywhere else."\n{10}, {T}, Sacrifice Realmbreaker, the Invasion Tree: Search your library for any number of Praetor cards, put them onto the battlefield, then shuffle.

--- a/forge-gui/res/cardsfolder/r/renewing_touch.txt
+++ b/forge-gui/res/cardsfolder/r/renewing_touch.txt
@@ -2,5 +2,5 @@ Name:Renewing Touch
 ManaCost:G
 Types:Sorcery
 A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Library | TargetMin$ 0 | TargetMax$ X | Shuffle$ True | TgtPrompt$ Choose target creature card in your graveyard | ValidTgts$ Creature.YouCtrl | AILogic$ AtOppEOT | SpellDescription$ Shuffle any number of target creature cards from your graveyard into your library.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:Shuffle any number of target creature cards from your graveyard into your library.

--- a/forge-gui/res/cardsfolder/r/revenant.txt
+++ b/forge-gui/res/cardsfolder/r/revenant.txt
@@ -4,7 +4,7 @@ Types:Creature Spirit
 PT:*/*
 K:Flying
 S:Mode$ Continuous | Affected$ Card.Self | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creature cards in your graveyard.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 AI:RemoveDeck:Random
 SVar:NeedsToPlayVar:X GE3
 Oracle:Flying\nRevenant's power and toughness are each equal to the number of creature cards in your graveyard.

--- a/forge-gui/res/cardsfolder/r/revenge_of_the_rats.txt
+++ b/forge-gui/res/cardsfolder/r/revenge_of_the_rats.txt
@@ -3,5 +3,5 @@ ManaCost:2 B B
 Types:Sorcery
 K:Flashback:2 B B
 A:SP$ Token | TokenAmount$ X | TokenScript$ b_1_1_rat | TokenOwner$ You | TokenTapped$ True | SpellDescription$ Create a tapped 1/1 black Rat creature token for each creature card in your graveyard.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:Create a tapped 1/1 black Rat creature token for each creature card in your graveyard.\nFlashback {2}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)

--- a/forge-gui/res/cardsfolder/r/rhizome_lurcher.txt
+++ b/forge-gui/res/cardsfolder/r/rhizome_lurcher.txt
@@ -3,7 +3,7 @@ ManaCost:2 B G
 Types:Creature Fungus Zombie
 PT:2/2
 K:etbCounter:P1P1:X:no Condition:Undergrowth — CARDNAME enters with a number of +1/+1 counters on it equal to the number of creature cards in your graveyard.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 SVar:NeedsToPlayVar:X GE1
 DeckHas:Ability$Counters
 Oracle:Undergrowth — Rhizome Lurcher enters with a number of +1/+1 counters on it equal to the number of creature cards in your graveyard.

--- a/forge-gui/res/cardsfolder/r/ruination_rioter.txt
+++ b/forge-gui/res/cardsfolder/r/ruination_rioter.txt
@@ -4,5 +4,5 @@ Types:Creature Human Berserker
 PT:2/2
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigDamage | OptionalDecider$ You | TriggerDescription$ When CARDNAME dies, you may have it deal damage to any target equal to the number of land cards in your graveyard.
 SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Any | NumDmg$ X
-SVar:X:Count$TypeInYourYard.Land
+SVar:X:Count$ValidGraveyard Land.YouOwn
 Oracle:When Ruination Rioter dies, you may have it deal damage to any target equal to the number of land cards in your graveyard.

--- a/forge-gui/res/cardsfolder/r/rumbleweed.txt
+++ b/forge-gui/res/cardsfolder/r/rumbleweed.txt
@@ -3,7 +3,7 @@ ManaCost:10 G
 Types:Creature Plant Elemental
 PT:8/8
 S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {1} less to cast for each land card in your graveyard.
-SVar:X:Count$TypeInYourYard.Land
+SVar:X:Count$ValidGraveyard Land.YouOwn
 K:Vigilance
 K:Reach
 K:Trample

--- a/forge-gui/res/cardsfolder/r/runechanters_pike.txt
+++ b/forge-gui/res/cardsfolder/r/runechanters_pike.txt
@@ -3,6 +3,6 @@ ManaCost:2
 Types:Artifact Equipment
 K:Equip:2
 S:Mode$ Continuous | Affected$ Card.EquippedBy | AddPower$ X | AddKeyword$ First Strike | Description$ Equipped creature has first strike and gets +X/+0 where X is the number of instant and sorcery cards in your graveyard.
-SVar:X:Count$TypeInYourYard.Instant/Plus.Y
-SVar:Y:Count$TypeInYourYard.Sorcery
+SVar:X:Count$ValidGraveyard Instant.YouOwn/Plus.Y
+SVar:Y:Count$ValidGraveyard Sorcery.YouOwn
 Oracle:Equipped creature has first strike and gets +X/+0, where X is the number of instant and sorcery cards in your graveyard.\nEquip {2}

--- a/forge-gui/res/cardsfolder/rebalanced/a-uurg_spawn_of_turg.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-uurg_spawn_of_turg.txt
@@ -6,7 +6,7 @@ S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | Description$ C
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigSurveil | TriggerDescription$ At the beginning of your upkeep, surveil 2.
 SVar:TrigSurveil:DB$ Surveil | Amount$ 2
 A:AB$ GainLife | Cost$ 1 Sac<1/Land> | LifeAmount$ 2 | SpellDescription$ You gain 2 life.
-SVar:X:Count$TypeInYourYard.Land
+SVar:X:Count$ValidGraveyard Land.YouOwn
 DeckHas:Ability$LifeGain|Graveyard|Sacrifice
 DeckHints:Ability$Graveyard
 Oracle:Uurg, Spawn of Turg's power is equal to the number of land cards in your graveyard.\nAt the beginning of your upkeep, surveil 2.\n{1}, Sacrifice a land: You gain 2 life.

--- a/forge-gui/res/cardsfolder/s/salvage_slasher.txt
+++ b/forge-gui/res/cardsfolder/s/salvage_slasher.txt
@@ -3,5 +3,5 @@ ManaCost:1 B
 Types:Artifact Creature Human Rogue
 PT:1/1
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ X | Description$ CARDNAME gets +1/+0 for each artifact card in your graveyard.
-SVar:X:Count$TypeInYourYard.Artifact
+SVar:X:Count$ValidGraveyard Artifact.YouOwn
 Oracle:Salvage Slasher gets +1/+0 for each artifact card in your graveyard.

--- a/forge-gui/res/cardsfolder/s/sarevok_the_usurper.txt
+++ b/forge-gui/res/cardsfolder/s/sarevok_the_usurper.txt
@@ -5,7 +5,7 @@ PT:3/3
 K:Specialize:3
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ At the beginning of combat on your turn, target creature you control gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard.
 SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | NumAtt$ +X
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 DeckHas:Ability$Graveyard
 AlternateMode:Specialize
 Oracle:Specialize {3}\nAt the beginning of combat on your turn, target creature you control gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard.
@@ -19,7 +19,7 @@ PT:4/4
 K:First Strike
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ At the beginning of combat on your turn, target creature you control gains first strike and gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard.
 SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | NumAtt$ +X | KW$ First Strike
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 DeckHas:Ability$Graveyard & Keyword$FirstStrike
 Oracle:First strike\nAt the beginning of combat on your turn, target creature you control gains first strike and gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard.
 
@@ -50,7 +50,7 @@ SVar:DBConjure:DB$ MakeCard | Conjure$ True | DefinedName$ Remembered | Zone$ Gr
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ At the beginning of combat on your turn, target creature you control gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard.
 SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | NumAtt$ +X
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 DeckHas:Ability$Graveyard
 Oracle:When this creature specializes, seek a creature card and put it into your graveyard, then conjure two duplicates of it into your graveyard.\nAt the beginning of combat on your turn, target creature you control gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard.
 
@@ -63,7 +63,7 @@ PT:4/4
 K:Menace
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ At the beginning of combat on your turn, target creature you control gains menace and gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard.
 SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | NumAtt$ +X | KW$ Menace
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 DeckHas:Ability$Graveyard & Keyword$Menace
 Oracle:Menace\nAt the beginning of combat on your turn, target creature you control gains menace and gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard.
 
@@ -76,6 +76,6 @@ PT:4/4
 K:Trample
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ At the beginning of combat on your turn, target creature you control gains trample and gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard.
 SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | NumAtt$ +X | KW$ Trample
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 DeckHas:Ability$Graveyard & Keyword$Trample
 Oracle:Trample\nAt the beginning of combat on your turn, target creature you control gains trample and gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard.

--- a/forge-gui/res/cardsfolder/s/sarkhan_unbroken.txt
+++ b/forge-gui/res/cardsfolder/s/sarkhan_unbroken.txt
@@ -6,5 +6,5 @@ A:AB$ Draw | Cost$ AddCounter<1/LOYALTY> | Defined$ You | SubAbility$ DBMana | P
 SVar:DBMana:DB$ Mana | Produced$ Any
 A:AB$ Token | Cost$ SubCounter<2/LOYALTY> | TokenAmount$ 1 | TokenScript$ r_4_4_dragon_flying | TokenOwner$ You | Planeswalker$ True | SpellDescription$ Create a 4/4 red Dragon creature token with flying.
 A:AB$ ChangeZone | Cost$ SubCounter<8/LOYALTY> | Origin$ Library | Destination$ Battlefield | ChangeType$ Creature.Dragon | ChangeNum$ XFetch | Planeswalker$ True | Ultimate$ True | StackDescription$ SpellDescription | SpellDescription$ Search your library for any number of Dragon creature cards, put them onto the battlefield, then shuffle.
-SVar:XFetch:Count$TypeInYourLibrary.Dragon
+SVar:XFetch:Count$ValidLibrary Creature.Dragon+YouCtrl
 Oracle:[+1]: Draw a card, then add one mana of any color.\n[-2]: Create a 4/4 red Dragon creature token with flying.\n[-8]: Search your library for any number of Dragon creature cards, put them onto the battlefield, then shuffle.

--- a/forge-gui/res/cardsfolder/s/scrapyard_salvo.txt
+++ b/forge-gui/res/cardsfolder/s/scrapyard_salvo.txt
@@ -2,6 +2,6 @@ Name:Scrapyard Salvo
 ManaCost:1 R R
 Types:Sorcery
 A:SP$ DealDamage | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | NumDmg$ X | SpellDescription$ CARDNAME deals damage to target player or planeswalker equal to the number of artifact cards in your graveyard.
-SVar:X:Count$TypeInYourYard.Artifact
+SVar:X:Count$ValidGraveyard Artifact.YouOwn
 AI:RemoveDeck:Random
 Oracle:Scrapyard Salvo deals damage to target player or planeswalker equal to the number of artifact cards in your graveyard.

--- a/forge-gui/res/cardsfolder/s/season_of_loss.txt
+++ b/forge-gui/res/cardsfolder/s/season_of_loss.txt
@@ -6,5 +6,5 @@ SVar:DBSacrifice:DB$ Sacrifice | Pawprint$ 1 | Defined$ Player | SacValid$ Creat
 SVar:DBDraw:DB$ Draw | Pawprint$ 2 | Defined$ You | NumCards$ Y | SpellDescription$ Draw a card for each creature you controlled that died this turn.
 SVar:Y:Count$ThisTurnEntered_Graveyard_from_Battlefield_Creature.YouCtrl
 SVar:DBLoseLife:DB$ LoseLife | Pawprint$ 3 | Defined$ Player.Opponent | LifeAmount$ X | SpellDescription$ Each opponent loses X life, where X is the number of creature cards in your graveyard.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:Choose up to five {P} worth of modes. You may choose the same mode more than once.\n{P} — Each player sacrifices a creature.\n{P}{P} — Draw a card for each creature you controlled that died this turn.\n{P}{P}{P} — Each opponent loses X life, where X is the number of creature cards in your graveyard.

--- a/forge-gui/res/cardsfolder/s/seed_guardian.txt
+++ b/forge-gui/res/cardsfolder/s/seed_guardian.txt
@@ -5,6 +5,6 @@ PT:3/4
 K:Reach
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME dies, create an X/X green Elemental creature token, where X is the number of creature cards in your graveyard.
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ g_x_x_elemental | TokenOwner$ TriggeredCardController | TokenPower$ X | TokenToughness$ X
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 SVar:SacMe:1
 Oracle:Reach\nWhen Seed Guardian dies, create an X/X green Elemental creature token, where X is the number of creature cards in your graveyard.

--- a/forge-gui/res/cardsfolder/s/skyfisher_spider.txt
+++ b/forge-gui/res/cardsfolder/s/skyfisher_spider.txt
@@ -9,7 +9,7 @@ SVar:TrigDestroy:DB$ Destroy | ValidTgts$ Permanent.nonLand | TgtPrompt$ Select 
 T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigGainLife | OptionalDecider$ TriggeredCardController | TriggerDescription$ When CARDNAME dies, you may gain 1 life for each creature card in your graveyard. If you do, exile CARDNAME from your graveyard.
 SVar:TrigGainLife:DB$ GainLife | LifeAmount$ X | SubAbility$ TrigExile
 SVar:TrigExile:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | Defined$ TriggeredNewCardLKICopy
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 DeckHints:Ability$Graveyard|Mill|Dredge|Sacrifice
 DeckHas:Ability$Sacrifice|LifeGain|Graveyard
 Oracle:Reach\nWhen Skyfisher Spider enters, you may sacrifice another creature. When you do, destroy target nonland permanent.\nWhen Skyfisher Spider dies, you may gain 1 life for each creature card in your graveyard. If you do, exile Skyfisher Spider from your graveyard.

--- a/forge-gui/res/cardsfolder/s/songs_of_the_damned.txt
+++ b/forge-gui/res/cardsfolder/s/songs_of_the_damned.txt
@@ -2,5 +2,5 @@ Name:Songs of the Damned
 ManaCost:B
 Types:Instant
 A:SP$ Mana | Produced$ B | Amount$ X | AILogic$ ManaRitual | AINoRecursiveCheck$ True | SpellDescription$ Add {B} for each creature card in your graveyard.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:Add {B} for each creature card in your graveyard.

--- a/forge-gui/res/cardsfolder/s/soulshriek.txt
+++ b/forge-gui/res/cardsfolder/s/soulshriek.txt
@@ -2,5 +2,5 @@ Name:Soulshriek
 ManaCost:B
 Types:Instant
 A:SP$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | NumAtt$ +X | AILogic$ Berserk | AtEOT$ Sacrifice | SpellDescription$ Target creature you control gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard. Sacrifice that creature at the beginning of the next end step.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:Target creature you control gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard. Sacrifice that creature at the beginning of the next end step.

--- a/forge-gui/res/cardsfolder/s/spider_spawning.txt
+++ b/forge-gui/res/cardsfolder/s/spider_spawning.txt
@@ -3,5 +3,5 @@ ManaCost:4 G
 Types:Sorcery
 K:Flashback:6 B
 A:SP$ Token | TokenAmount$ X | TokenScript$ g_1_2_spider_reach | TokenOwner$ You | SpellDescription$ Create a 1/2 green Spider creature token with reach for each creature card in your graveyard.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:Create a 1/2 green Spider creature token with reach for each creature card in your graveyard.\nFlashback {6}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)

--- a/forge-gui/res/cardsfolder/s/splinterfright.txt
+++ b/forge-gui/res/cardsfolder/s/splinterfright.txt
@@ -6,7 +6,7 @@ K:Trample
 S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creature cards in your graveyard.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigMill | TriggerDescription$ At the beginning of your upkeep, mill two cards.
 SVar:TrigMill:DB$ Mill | Defined$ You | NumCards$ 2
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 SVar:NeedsToPlayVar:X GE1
 DeckHas:Ability$Graveyard
 Oracle:Trample\nSplinterfright's power and toughness are each equal to the number of creature cards in your graveyard.\nAt the beginning of your upkeep, mill two cards.

--- a/forge-gui/res/cardsfolder/s/storm_of_souls.txt
+++ b/forge-gui/res/cardsfolder/s/storm_of_souls.txt
@@ -4,7 +4,7 @@ Types:Sorcery
 A:SP$ ChangeZoneAll | ChangeType$ Creature.YouOwn | Origin$ Graveyard | Destination$ Battlefield | StaticEffect$ Animate | SubAbility$ DBExile | SpellDescription$ Return all creature cards from your graveyard to the battlefield. Each of them is a 1/1 Spirit with flying in addition to its other types.
 SVar:Animate:Mode$ Continuous | Affected$ Card.IsRemembered | SetPower$ 1 | SetToughness$ 1 | AddType$ Spirit | AddKeyword$ Flying
 SVar:DBExile:DB$ ChangeZone | Origin$ Stack | Destination$ Exile | SpellDescription$ Exile CARDNAME.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 SVar:NeedsToPlayVar:X GE4
 DeckHas:Ability$Graveyard & Type$Spirit
 Oracle:Return all creature cards from your graveyard to the battlefield. Each of them is a 1/1 Spirit with flying in addition to its other types. Exile Storm of Souls.

--- a/forge-gui/res/cardsfolder/s/strength_from_the_fallen.txt
+++ b/forge-gui/res/cardsfolder/s/strength_from_the_fallen.txt
@@ -3,7 +3,7 @@ ManaCost:1 G
 Types:Enchantment
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self,Enchantment.Other+YouCtrl | Execute$ TrigPump | TriggerDescription$ Constellation — Whenever CARDNAME or another enchantment you control enters, target creature gets +X/+X until end of turn, where X is the number of creature cards in your graveyard.
 SVar:TrigPump:DB$ Pump | ValidTgts$ Creature | NumAtt$ +X | NumDef$ +X
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 SVar:PlayMain1:TRUE
 SVar:BuffedBy:Enchantment
 Oracle:Constellation — Whenever Strength from the Fallen or another enchantment you control enters, target creature gets +X/+X until end of turn, where X is the number of creature cards in your graveyard.

--- a/forge-gui/res/cardsfolder/s/strongarm_tactics.txt
+++ b/forge-gui/res/cardsfolder/s/strongarm_tactics.txt
@@ -8,5 +8,5 @@ SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Remembered$Valid Creature.RememberedPlayerCtrl
 AI:RemoveDeck:All
 SVar:NeedsToPlayVar:Z GE1
-SVar:Z:Count$TypeInYourHand.Creature
+SVar:Z:Count$ValidHand Creature.YouOwn
 Oracle:Each player discards a card. Then each player who didn't discard a creature card this way loses 4 life.

--- a/forge-gui/res/cardsfolder/s/stubborn_burrowfiend.txt
+++ b/forge-gui/res/cardsfolder/s/stubborn_burrowfiend.txt
@@ -4,7 +4,7 @@ Types:Creature Badger Beast Mount
 PT:2/2
 T:Mode$ BecomesSaddled | ValidSaddled$ Card.Self | FirstTimeSaddled$ True | TriggerZones$ Battlefield | Execute$ TrigMill | TriggerDescription$ Whenever CARDNAME becomes saddled for the first time each turn, mill two cards, then CARDNAME gets +X/+X until end of turn, where X is the number of creature cards in your graveyard.
 SVar:TrigMill:DB$ Mill | NumCards$ 2 | SubAbility$ DBPump
-SVar:DBPump:DB$ Pump | NumAtt$ +Count$TypeInYourYard.Creature | NumDef$ +Count$TypeInYourYard.Creature
+SVar:DBPump:DB$ Pump | NumAtt$ +Count$ValidGraveyard Creature.YouOwn | NumDef$ +Count$ValidGraveyard Creature.YouOwn
 K:Saddle:2
 DeckHas:Ability$Mill
 DeckHints:Ability$Sacrifice|Mill|Dredge|Discard

--- a/forge-gui/res/cardsfolder/s/sunflare_shaman.txt
+++ b/forge-gui/res/cardsfolder/s/sunflare_shaman.txt
@@ -5,6 +5,6 @@ PT:2/1
 A:AB$ DealDamage | Cost$ 1 R T | ValidTgts$ Any | NumDmg$ X | DamageMap$ True | SubAbility$ DBDealDamage | SpellDescription$ CARDNAME deals X damage to any target and X damage to itself, where X is the number of Elemental cards in your graveyard.
 SVar:DBDealDamage:DB$ DealDamage | NumDmg$ X | Defined$ Self | SubAbility$ DBDamageResolve
 SVar:DBDamageResolve:DB$ DamageResolve
-SVar:X:Count$TypeInYourYard.Elemental
+SVar:X:Count$ValidGraveyard Elemental.YouOwn
 AI:RemoveDeck:Random
 Oracle:{1}{R}, {T}: Sunflare Shaman deals X damage to any target and X damage to itself, where X is the number of Elemental cards in your graveyard.

--- a/forge-gui/res/cardsfolder/s/sutured_ghoul.txt
+++ b/forge-gui/res/cardsfolder/s/sutured_ghoul.txt
@@ -11,6 +11,6 @@ SVar:DBCleanup:DB$ Cleanup | ClearChosenCard$ True
 S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self | SetPower$ TotalPower | SetToughness$ TotalToughness | Description$ CARDNAME's power is equal to the total power of the exiled cards and its toughness is equal to their total toughness.
 SVar:TotalPower:Remembered$CardPower
 SVar:TotalToughness:Remembered$CardToughness
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 AI:RemoveDeck:Random
 Oracle:Trample\nAs Sutured Ghoul enters, exile any number of creature cards from your graveyard.\nSutured Ghoul's power is equal to the total power of the exiled cards and its toughness is equal to their total toughness.

--- a/forge-gui/res/cardsfolder/s/svogthos_the_restless_tomb.txt
+++ b/forge-gui/res/cardsfolder/s/svogthos_the_restless_tomb.txt
@@ -4,6 +4,6 @@ Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Animate | Cost$ 3 B G | Defined$ Self | Types$ Creature,Zombie,Plant | Colors$ Black,Green | OverwriteColors$ True | staticAbilities$ Static | SpellDescription$ Until end of turn, CARDNAME becomes a black and green Plant Zombie creature with "This creature's power and toughness are each equal to the number of creature cards in your graveyard." It's still a land.
 SVar:Static:Mode$ Continuous | Affected$ Card.Self | EffectZone$ Battlefield | SetPower$ X | SetToughness$ X | Description$ This creature's power and toughness are each equal to the number of creature cards in your graveyard.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 AI:RemoveDeck:All
 Oracle:{T}: Add {C}.\n{3}{B}{G}: Until end of turn, Svogthos, the Restless Tomb becomes a black and green Plant Zombie creature with "This creature's power and toughness are each equal to the number of creature cards in your graveyard." It's still a land.

--- a/forge-gui/res/cardsfolder/t/tempt_with_immortality.txt
+++ b/forge-gui/res/cardsfolder/t/tempt_with_immortality.txt
@@ -8,5 +8,5 @@ SVar:DBReturn:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | Ch
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Remembered$Amount
 SVar:NeedsToPlayVar:Y GE2
-SVar:Y:Count$TypeInYourYard.Creature
+SVar:Y:Count$ValidGraveyard Creature.YouOwn
 Oracle:Tempting offer — Return a creature card from your graveyard to the battlefield. Each opponent may return a creature card from their graveyard to the battlefield. For each opponent who does, return a creature card from your graveyard to the battlefield.

--- a/forge-gui/res/cardsfolder/t/the_cauldron_of_eternity.txt
+++ b/forge-gui/res/cardsfolder/t/the_cauldron_of_eternity.txt
@@ -2,7 +2,7 @@ Name:The Cauldron of Eternity
 ManaCost:10 B B
 Types:Legendary Artifact
 S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ CARDNAME costs {2} less for each creature card in your graveyard.
-SVar:X:Count$TypeInYourYard.Creature/Twice
+SVar:X:Count$ValidGraveyard Creature.YouOwn/Twice
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigChange | TriggerDescription$ Whenever a creature you control dies, put it on the bottom of its owner's library.
 SVar:TrigChange:DB$ ChangeZone | Defined$ TriggeredNewCardLKICopy | Origin$ Graveyard | Destination$ Library | LibraryPosition$ -1
 SVar:BuffedBy:Creature

--- a/forge-gui/res/cardsfolder/t/the_world_tree.txt
+++ b/forge-gui/res/cardsfolder/t/the_world_tree.txt
@@ -7,6 +7,6 @@ A:AB$ Mana | Cost$ T | Produced$ G | SpellDescription$ Add {G}.
 S:Mode$ Continuous | Affected$ Land.YouCtrl | AddAbility$ AnyMana | IsPresent$ Land.YouCtrl | PresentCompare$ GE6 | Description$ As long as you control six or more lands, lands you control have "{T}: Add one mana of any color."
 SVar:AnyMana:AB$ Mana | Cost$ T | Produced$ Any | Amount$ 1 | SpellDescription$ Add one mana of any color.
 A:AB$ ChangeZone | Cost$ W W U U B B R R G G T Sac<1/CARDNAME> | Origin$ Library | Destination$ Battlefield | ChangeType$ God | ChangeNum$ XFetch | StackDescription$ SpellDescription | SpellDescription$ Search your library for any number of God cards, put them onto the battlefield, then shuffle.
-SVar:XFetch:Count$TypeInYourLibrary.God
+SVar:XFetch:Count$ValidLibrary God.YouCtrl
 DeckHints:Type$God
 Oracle:The World Tree enters tapped.\n{T}: Add {G}.\nAs long as you control six or more lands, lands you control have "{T}: Add one mana of any color."\n{W}{W}{U}{U}{B}{B}{R}{R}{G}{G}, {T}, Sacrifice The World Tree: Search your library for any number of God cards, put them onto the battlefield, then shuffle.

--- a/forge-gui/res/cardsfolder/t/thundering_wurm.txt
+++ b/forge-gui/res/cardsfolder/t/thundering_wurm.txt
@@ -5,7 +5,7 @@ PT:4/4
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ DBSacSelf | TriggerDescription$ When CARDNAME enters, sacrifice it unless you discard a land card.
 SVar:DBSacSelf:DB$ Sacrifice | UnlessCost$ Discard<1/Land> | UnlessPayer$ You
 SVar:NeedsToPlayVar:Y GE1
-SVar:Y:Count$TypeInYourHand.Land
+SVar:Y:Count$ValidHand Land.YouOwn
 SVar:PlayMain1:TRUE
 SVar:PlayBeforeLandDrop:TRUE
 Oracle:When Thundering Wurm enters, sacrifice it unless you discard a land card.

--- a/forge-gui/res/cardsfolder/t/titania_voice_of_gaea_titania_gaea_incarnate.txt
+++ b/forge-gui/res/cardsfolder/t/titania_voice_of_gaea_titania_gaea_incarnate.txt
@@ -7,7 +7,7 @@ T:Mode$ ChangesZoneAll | ValidCards$ Land.YouOwn+!token | Origin$ Any | Destinat
 SVar:TrigLifegain:DB$ GainLife | LifeAmount$ 2
 T:Mode$ Phase | Phase$ Upkeep | CheckSVar$ X | SVarCompare$ GE4 | IsPresent$ Card.Self+YouOwn | IsPresent2$ Land.YouCtrl+YouOwn+namedArgoth; Sanctum of Nature | ValidPlayer$ You | Execute$ Meld | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, if there are four or more land cards in your graveyard and you both own and control CARDNAME and a land named Argoth, Sanctum of Nature, exile them, then meld them into Titania, Gaea Incarnate.
 SVar:Meld:DB$ Meld | Name$ Titania, Gaea Incarnate | Primary$ Titania, Voice of Gaea | Secondary$ Argoth, Sanctum of Nature | SecondaryType$ Land
-SVar:X:Count$TypeInYourYard.Land
+SVar:X:Count$ValidGraveyard Land.YouOwn
 DeckHas:Ability$Graveyard|Counters|LifeGain
 DeckHints:Ability$Discard|Mill|Graveyard|Dredge & Name$Argoth, Sanctum of Nature
 MeldPair:Argoth, Sanctum of Nature

--- a/forge-gui/res/cardsfolder/t/tocasia_dig_site_mentor.txt
+++ b/forge-gui/res/cardsfolder/t/tocasia_dig_site_mentor.txt
@@ -5,6 +5,6 @@ PT:4/3
 S:Mode$ Continuous | Affected$ Creature.YouCtrl | AddAbility$ Surveil | AddKeyword$ Vigilance | Description$ Creatures you control have vigilance and "{T}: Surveil 1." (To surveil 1, look at the top card of your library You may put that card into your graveyard.)
 SVar:Surveil:AB$ Surveil | Cost$ T | Amount$ 1 | SpellDescription$ Surveil 1. (To surveil 1, look at the top card of your library. You may put that card into your graveyard.)
 A:AB$ ChangeZone | Cost$ 2 G G W W U U ExileFromGrave<1/CARDNAME> | Origin$ Graveyard | Destination$ Battlefield | TargetMin$ 0 | TargetMax$ X | ValidTgts$ Artifact.YouOwn | TgtPrompt$ Select any number of target artifact cards with total mana value 10 or less | MaxTotalTargetCMC$ 10 | ActivationZone$ Graveyard | SorcerySpeed$ True | SpellDescription$ Return any number of target artifact cards with total mana value 10 or less from your graveyard to the battlefield. Activate only as a sorcery.
-SVar:X:Count$TypeInYourYard.Artifact
+SVar:X:Count$ValidGraveyard Artifact.YouOwn
 DeckHas:Ability$Graveyard|Surveil & Keyword$Vigilance
 Oracle:Creatures you control have vigilance and "{T}: Surveil 1." (To surveil 1, look at the top card of your library. You may put that card into your graveyard.)\n{2}{G}{G}{W}{W}{U}{U}, Exile Tocasia, Digsite Mentor from your graveyard: Return any number of target artifact cards with total mana value 10 or less from your graveyard to the battlefield. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/t/trench_gorger.txt
+++ b/forge-gui/res/cardsfolder/t/trench_gorger.txt
@@ -7,7 +7,7 @@ T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefi
 SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Library | Destination$ Exile | ChangeType$ Land | ChangeNum$ X | RememberChanged$ True | SubAbility$ TrenchAnimate | ShuffleNonMandatory$ True
 SVar:TrenchAnimate:DB$ Animate | Power$ Y | Toughness$ Y | Duration$ Permanent | SubAbility$ DBCleanUp
 SVar:DBCleanUp:DB$ Cleanup | ClearRemembered$ True
-SVar:X:Count$TypeInYourLibrary.Land
+SVar:X:Count$ValidLibrary Land.YouCtrl
 SVar:Y:Remembered$Amount
 AI:RemoveDeck:All
 Oracle:Trample\nWhen Trench Gorger enters, you may search your library for any number of land cards, exile them, then shuffle. If you do, Trench Gorger has base power and base toughness each equal to the number of cards exiled this way.

--- a/forge-gui/res/cardsfolder/u/urborg_lhurgoyf.txt
+++ b/forge-gui/res/cardsfolder/u/urborg_lhurgoyf.txt
@@ -6,7 +6,7 @@ K:Kicker:U:B
 K:ETBReplacement:Other:TrigMill
 SVar:TrigMill:DB$ Mill | NumCards$ Z | Defined$ You | SpellDescription$ As CARDNAME enters, mill three cards for each time it was kicked.
 S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ Y | Description$ CARDNAME's power is equal to the number of creature cards in your graveyard and its toughness is equal to that number plus 1.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 SVar:Y:SVar$X/Plus.1
 SVar:Z:Count$TimesKicked/Times.3
 Oracle:Kicker {U} and/or {B} (You may pay an additional {U} and/or {B} as you cast this spell.)\nAs Urborg Lhurgoyf enters, mill three cards for each time it was kicked.\nUrborg Lhurgoyf's power is equal to the number of creature cards in your graveyard and its toughness is equal to that number plus 1.

--- a/forge-gui/res/cardsfolder/u/uurg_spawn_of_turg.txt
+++ b/forge-gui/res/cardsfolder/u/uurg_spawn_of_turg.txt
@@ -6,7 +6,7 @@ S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | Description$ C
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigSurveil | TriggerDescription$ At the beginning of your upkeep, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)
 SVar:TrigSurveil:DB$ Surveil | Amount$ 1
 A:AB$ GainLife | Cost$ B G Sac<1/Land> | LifeAmount$ 2 | SpellDescription$ You gain 2 life.
-SVar:X:Count$TypeInYourYard.Land
+SVar:X:Count$ValidGraveyard Land.YouOwn
 DeckHas:Ability$LifeGain|Graveyard|Sacrifice
 DeckHints:Ability$Graveyard
 Oracle:Uurg, Spawn of Turg's power is equal to the number of land cards in your graveyard.\nAt the beginning of your upkeep, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)\n{B}{G}, Sacrifice a land: You gain 2 life.

--- a/forge-gui/res/cardsfolder/v/vigorspore_wurm.txt
+++ b/forge-gui/res/cardsfolder/v/vigorspore_wurm.txt
@@ -5,6 +5,6 @@ PT:6/4
 S:Mode$ MinMaxBlocker | ValidCard$ Card.Self | Max$ 1 | Description$ CARDNAME can't be blocked by more than one creature.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ Undergrowth — When CARDNAME enters, target creature gains vigilance and gets +X/+X until end of turn, where X is the number of creature cards in your graveyard.
 SVar:TrigPump:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | NumDef$ +X | KW$ Vigilance
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 SVar:PlayMain1:TRUE
 Oracle:Undergrowth — When Vigorspore Wurm enters, target creature gains vigilance and gets +X/+X until end of turn, where X is the number of creature cards in your graveyard.\nVigorspore Wurm can't be blocked by more than one creature.

--- a/forge-gui/res/cardsfolder/v/vilespawn_spider.txt
+++ b/forge-gui/res/cardsfolder/v/vilespawn_spider.txt
@@ -6,7 +6,7 @@ K:Reach
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigMill | TriggerDescription$ At the beginning of your upkeep, mill a card. (Put the top card of your library into your graveyard.)
 SVar:TrigMill:DB$ Mill | Defined$ You | NumCards$ 1
 A:AB$ Token | Cost$ 2 G U T Sac<1/CARDNAME> | TokenScript$ g_1_1_insect | TokenAmount$ X | SorcerySpeed$ True | AICheckSVar$ X | AISVarCompare$ GE4 | StackDescription$ {p:You} creates a 1/1 green Insect creature token for each creature card in their graveyard. | SpellDescription$ Create a 1/1 green Insect creature token for each creature card in your graveyard. Activate only as a sorcery.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 DeckHas:Ability$Mill|Token|Sacrifice
 DeckHints:Ability$Discard
 Oracle:Reach\nAt the beginning of your upkeep, mill a card. (Put the top card of your library into your graveyard.)\n{2}{G}{U}, {T}, Sacrifice Vilespawn Spider: Create a 1/1 green Insect creature token for each creature card in your graveyard. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/w/wall_of_tombstones.txt
+++ b/forge-gui/res/cardsfolder/w/wall_of_tombstones.txt
@@ -5,5 +5,5 @@ PT:0/1
 K:Defender
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigTough | TriggerDescription$ At the beginning of your upkeep, change CARDNAME's base toughness to 1 plus the number of creature cards in your graveyard. (This effect lasts indefinitely.)
 SVar:TrigTough:DB$ Animate | Toughness$ X | Duration$ Permanent
-SVar:X:Count$TypeInYourYard.Creature/Plus.1
+SVar:X:Count$ValidGraveyard Creature.YouOwn/Plus.1
 Oracle:Defender (This creature can't attack.)\nAt the beginning of your upkeep, change Wall of Tombstones's base toughness to 1 plus the number of creature cards in your graveyard. (This effect lasts indefinitely.)

--- a/forge-gui/res/cardsfolder/w/wight_of_the_reliquary.txt
+++ b/forge-gui/res/cardsfolder/w/wight_of_the_reliquary.txt
@@ -5,5 +5,5 @@ PT:2/2
 K:Vigilance
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ X | AddToughness$ X | Description$ CARDNAME gets +1/+1 for each creature card in your graveyard.
 A:AB$ ChangeZone | Cost$ T Sac<1/Creature.Other/another creature> | Origin$ Library | Destination$ Battlefield | Tapped$ True | ChangeType$ Land | ChangeNum$ 1 | SpellDescription$ Search your library for a land card, put it onto the battlefield tapped, then shuffle.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:Vigilance\nWight of the Reliquary gets +1/+1 for each creature card in your graveyard.\n{T}, Sacrifice another creature: Search your library for a land card, put it onto the battlefield tapped, then shuffle.

--- a/forge-gui/res/cardsfolder/w/worm_harvest.txt
+++ b/forge-gui/res/cardsfolder/w/worm_harvest.txt
@@ -3,7 +3,7 @@ ManaCost:2 BG BG BG
 Types:Sorcery
 K:Retrace
 A:SP$ Token | TokenAmount$ X | TokenScript$ bg_1_1_worm | TokenOwner$ You | SpellDescription$ Create a 1/1 black and green Worm creature token for each land card in your graveyard.
-SVar:X:Count$TypeInYourYard.Land
+SVar:X:Count$ValidGraveyard Land.YouOwn
 SVar:NeedsToPlayVar:Z GE2
 SVar:Z:Count$ValidGraveyard Land.YouOwn
 Oracle:Create a 1/1 black and green Worm creature token for each land card in your graveyard.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)

--- a/forge-gui/res/cardsfolder/w/wreath_of_geists.txt
+++ b/forge-gui/res/cardsfolder/w/wreath_of_geists.txt
@@ -4,5 +4,5 @@ Types:Enchantment Aura
 K:Enchant creature
 A:SP$ Attach | ValidTgts$ Creature | AILogic$ Pump
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ X | AddToughness$ X | Description$ Enchanted creature gets +X/+X, where X is the number of creature cards in your graveyard.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:Enchant creature\nEnchanted creature gets +X/+X, where X is the number of creature cards in your graveyard.

--- a/forge-gui/res/cardsfolder/w/writhing_necromass.txt
+++ b/forge-gui/res/cardsfolder/w/writhing_necromass.txt
@@ -4,5 +4,5 @@ Types:Creature Zombie Giant
 PT:5/5
 K:Deathtouch
 S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {1} less to cast for each creature card in your graveyard.
-SVar:X:Count$TypeInYourYard.Creature
+SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:This spell costs {1} less to cast for each creature card in your graveyard.\nDeathtouch

--- a/forge-gui/res/cardsfolder/y/young_necromancer.txt
+++ b/forge-gui/res/cardsfolder/y/young_necromancer.txt
@@ -7,7 +7,7 @@ SVar:TrigImmediateTrig:AB$ ImmediateTrigger | Cost$ ExileFromGrave<2/card> | Exe
 SVar:TrigReturn:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | ValidTgts$ Creature.YouOwn | TgtPrompt$ Select target creature to return from your graveyard
 SVar:NeedsToPlayVar:Z EQ3
 SVar:X:Count$InYourYard/LimitMax.3
-SVar:Y:Count$TypeInYourYard.Creature/LimitMax.1
+SVar:Y:Count$ValidGraveyard Creature.YouOwn/LimitMax.1
 SVar:Z:SVar$X/Times.Y
 DeckHas:Ability$Graveyard
 DeckHints:Ability$Discard

--- a/forge-gui/res/cardsfolder/y/yuma_proud_protector.txt
+++ b/forge-gui/res/cardsfolder/y/yuma_proud_protector.txt
@@ -2,7 +2,7 @@ Name:Yuma, Proud Protector
 ManaCost:5 R G W
 Types:Legendary Creature Human Ranger
 PT:6/6
-S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ Count$TypeInYourYard.Land | EffectZone$ All | Description$ This spell costs {1} less to cast for each land card in your graveyard.
+S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ Count$ValidGraveyard Land.YouOwn | EffectZone$ All | Description$ This spell costs {1} less to cast for each land card in your graveyard.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ Whenever CARDNAME enters or attacks, you may sacrifice a land. If you do, draw a card.
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigDraw | Secondary$ True | TriggerDescription$ Whenever CARDNAME enters or attacks, you may sacrifice a land. If you do, draw a card.
 SVar:TrigDraw:AB$ Draw | Cost$ Sac<1/Land>

--- a/forge-gui/res/quest/commanderprecons/Abzan Armor [TDC] [2025].dck
+++ b/forge-gui/res/quest/commanderprecons/Abzan Armor [TDC] [2025].dck
@@ -77,7 +77,7 @@ Name=Abzan Armor [TDC] [2025]
 1 Twilight Mire|TDC|1
 1 Woodland Cemetery|TDC|1
 1 Command Tower|TDC|1
-1 Evolving Wilds|TDC|1
+1 Evolving Wilds|TDM|1
 1 Sandsteppe Citadel|TDM|1
 1 Access Tunnel|TDC|1
 1 Bojuka Bog|TDC|1

--- a/forge-gui/res/quest/commanderprecons/Jeskai Striker [TDC] [2025].dck
+++ b/forge-gui/res/quest/commanderprecons/Jeskai Striker [TDC] [2025].dck
@@ -82,7 +82,7 @@ Name=Jeskai Striker [TDC] [2025]
 1 Temple of Epiphany|TDC|1
 1 Temple of Triumph|TDC|1
 1 Command Tower|TDC|1
-1 Evolving Wilds|TDC|1
+1 Evolving Wilds|TDM|1
 1 Mystic Monastery|TDM|1
 1 Ash Barrens|TDC|1
 1 Path of Ancestry|TDC|1

--- a/forge-gui/res/tokenscripts/g_x_x_elephant_resurgence.txt
+++ b/forge-gui/res/tokenscripts/g_x_x_elephant_resurgence.txt
@@ -4,5 +4,5 @@ Colors:green
 Types:Creature Elephant
 PT:*/*
 S:Mode$ Continuous | SetPower$ ResurgenceX | SetToughness$ ResurgenceX | EffectZone$ Battlefield | CharacteristicDefining$ True | Description$ CARDNAME's power and toughness are each equal to the number of creature cards in its controller's graveyard.
-SVar:ResurgenceX:Count$TypeInYourYard.Creature
+SVar:ResurgenceX:Count$ValidGraveyard Creature.YouOwn
 Oracle:This creature's power and toughness are each equal to the number of creature cards in its controller's graveyard.


### PR DESCRIPTION
As discussed, `Count$TypeInYour[Zone]` , a fairly inflexible counting expression, has been deprecated in favor of `Count$Valid[Zone] [Type]`, a more flexible one, which allows scripts to hew closer to the text of the cards. A sample of standard and corner cases was tested to satisfaction.

Also cleaning up the single instance of `Count$TypeInOpp[Zone]` on Keeper of the Dead.