### PR TITLE
Alchemy sets boosters added

### DIFF
--- a/forge-gui/res/editions/Alchemy Aetherdrift.txt
+++ b/forge-gui/res/editions/Alchemy Aetherdrift.txt
@@ -3,6 +3,7 @@ Code=YDFT
 Date=2025-03-04
 Name=Alchemy: Aetherdrift
 Type=Online
+Booster=1 UncommonRareMythic,8 Common:fromsheet("DFT cards"), 3 Uncommon:fromSheet("DFT cards"), 1 UncommonRareMythic:fromSheet("DFT cards"), 1 RareMythic:fromSheet("DFT cards"), 1 BasicLand:fromSheet("DFT cards")
 ScryfallCode=YDFT
 
 [cards]

--- a/forge-gui/res/editions/Alchemy Bloomburrow.txt
+++ b/forge-gui/res/editions/Alchemy Bloomburrow.txt
@@ -3,6 +3,7 @@ Code=YBLB
 Date=2024-08-20
 Name=Alchemy: Bloomburrow
 Type=Online
+Booster=1 UncommonRareMythic,8 Common:fromsheet("BLB cards"), 3 Uncommon:fromSheet("BLB cards"), 1 UncommonRareMythic:fromSheet("BLB cards"), 1 RareMythic:fromSheet("BLB cards"), 1 BasicLand:fromSheet("BLB cards")
 ScryfallCode=YBLB
 
 [cards]

--- a/forge-gui/res/editions/Alchemy Duskmourn.txt
+++ b/forge-gui/res/editions/Alchemy Duskmourn.txt
@@ -3,6 +3,7 @@ Code=YDSK
 Date=2024-10-15
 Name=Alchemy: Duskmourn
 Type=Online
+Booster=1 UncommonRareMythic,8 Common:fromsheet("DSK cards"), 3 Uncommon:fromSheet("DSK cards"), 1 UncommonRareMythic:fromSheet("DSK cards"), 1 RareMythic:fromSheet("DSK cards"), 1 BasicLand:fromSheet("DSK cards")
 ScryfallCode=YDSK
 
 [cards]

--- a/forge-gui/res/editions/Alchemy Innistrad.txt
+++ b/forge-gui/res/editions/Alchemy Innistrad.txt
@@ -4,6 +4,7 @@ Date=2021-12-09
 Name=Alchemy: Innistrad
 Alias=Y22
 Type=Online
+Booster=1 UncommonRareMythic,8 Common:fromsheet("MID cards"), 3 Uncommon:fromSheet("MID cards"), 1 UncommonRareMythic:fromSheet("MID cards"), 1 RareMythic:fromSheet("MID cards"), 1 BasicLand:fromSheet("MID cards")
 ScryfallCode=YMID
 
 [cards]

--- a/forge-gui/res/editions/Alchemy Karlov Manor.txt
+++ b/forge-gui/res/editions/Alchemy Karlov Manor.txt
@@ -3,6 +3,7 @@ Code=YMKM
 Date=2024-03-05
 Name=Alchemy: Karlov Manor
 Type=Online
+Booster=1 UncommonRareMythic,8 Common:fromsheet("MKM cards"), 3 Uncommon:fromSheet("MKM cards"), 1 UncommonRareMythic:fromSheet("MKM cards"), 1 RareMythic:fromSheet("MKM cards"), 1 BasicLand:fromSheet("MKM cards")
 ScryfallCode=YMKM
 
 [cards]

--- a/forge-gui/res/editions/Alchemy Thunder Junction.txt
+++ b/forge-gui/res/editions/Alchemy Thunder Junction.txt
@@ -3,6 +3,7 @@ Code=YOTJ
 Date=2024-05-07
 Name=Alchemy: Thunder Junction
 Type=Online
+Booster=1 UncommonRareMythic,8 Common:fromsheet("OTJ cards"), 3 Uncommon:fromSheet("OTJ cards"), 1 UncommonRareMythic:fromSheet("OTJ cards"), 1 RareMythic:fromSheet("OTJ cards"), 1 BasicLand:fromSheet("OTJ cards")
 ScryfallCode=YOTJ
 
 [cards]


### PR DESCRIPTION
Alchemy Aetherdrift (YDFT),
Alchemy Bloomburrow (YBLB),
Alchemy: Duskmourn (YDSK),
Alchemy: Innistrad (YMID),
Alchemy: Murders at Karlov Manor (YMKM),
Alchemy: Outlaws of Thunder Junction (YOTJ)