### PR TITLE
Cleanup: Targeted effects that grant flashback

### DIFF
--- a/forge-gui/res/cardsfolder/a/archmages_newt.txt
+++ b/forge-gui/res/cardsfolder/a/archmages_newt.txt
@@ -4,8 +4,8 @@ Types:Creature Salamander Mount
 PT:2/2
 K:Saddle:3
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigBranch | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. That card gains flashback {0} until end of turn instead if CARDNAME is saddled. (You may cast that card from your graveyard for its flashback cost. Then exile it.)
-SVar:TrigBranch:DB$ Branch | ValidTgts$ Instant.YouCtrl,Sorcery.YouCtrl | TgtZone$ Graveyard | TgtPrompt$ Select target instant or sorcery card in your graveyard | BranchConditionSVar$ Count$Valid Card.Self+IsSaddled | TrueSubAbility$ TrigRearrangeSaddled | FalseSubAbility$ TrigRearrangeUnsaddled
-SVar:TrigRearrangeSaddled:DB$ Pump | Defined$ Targeted | KW$ Flashback:0 | PumpZone$ Graveyard | AILogic$ ReplaySpell
-SVar:TrigRearrangeUnsaddled:DB$ Pump | Defined$ Targeted | KW$ Flashback | PumpZone$ Graveyard | AILogic$ ReplaySpell
+SVar:TrigBranch:DB$ Branch | ValidTgts$ Instant.YouCtrl,Sorcery.YouCtrl | TgtZone$ Graveyard | TgtPrompt$ Select target instant or sorcery card in your graveyard | BranchConditionSVar$ Count$Valid Card.Self+IsSaddled | TrueSubAbility$ TrigFlashbackSaddled | FalseSubAbility$ TrigFlashbackUnsaddled
+SVar:TrigFlashbackSaddled:DB$ Pump | Defined$ Targeted | KW$ Flashback:0 | PumpZone$ Graveyard | AILogic$ ReplaySpell
+SVar:TrigFlashbackUnsaddled:DB$ Pump | Defined$ Targeted | KW$ Flashback:CardManaCost | PumpZone$ Graveyard | AILogic$ ReplaySpell
 DeckHints:Ability$Graveyard & Type$Instant|Sorcery
 Oracle:Whenever Archmage's Newt deals combat damage to a player, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. That card gains flashback {0} until end of turn instead if Archmage's Newt is saddled. (You may cast that card from your graveyard for its flashback cost. Then exile it.)\nSaddle 3

--- a/forge-gui/res/cardsfolder/d/dralnu_lich_lord.txt
+++ b/forge-gui/res/cardsfolder/d/dralnu_lich_lord.txt
@@ -5,6 +5,6 @@ PT:3/3
 R:Event$ DamageDone | ActiveZones$ Battlefield | ValidTarget$ Card.Self | ReplaceWith$ Sac | Description$ If damage would be dealt to CARDNAME, sacrifice that many permanents instead.
 SVar:Sac:DB$ Sacrifice | Defined$ You | SacValid$ Permanent | SacMessage$ Permanent | Amount$ X
 SVar:X:ReplaceCount$DamageAmount
-A:AB$ Pump | Cost$ T | ValidTgts$ Instant.YouCtrl,Sorcery.YouCtrl | KW$ Flashback | TgtZone$ Graveyard | PumpZone$ Graveyard | SpellDescription$ Target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)
+A:AB$ Pump | Cost$ T | ValidTgts$ Instant.YouCtrl,Sorcery.YouCtrl | KW$ Flashback:CardManaCost | TgtZone$ Graveyard | PumpZone$ Graveyard | AILogic$ ReplaySpell | SpellDescription$ Target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)
 AI:RemoveDeck:All
 Oracle:If damage would be dealt to Dralnu, Lich Lord, sacrifice that many permanents instead.\n{T}: Target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)

--- a/forge-gui/res/cardsfolder/k/katilda_and_lier.txt
+++ b/forge-gui/res/cardsfolder/k/katilda_and_lier.txt
@@ -3,7 +3,7 @@ ManaCost:G W U
 Types:Legendary Creature Human
 PT:3/3
 T:Mode$ SpellCast | ValidCard$ Human | ValidActivatingPlayer$ You | Execute$ TrigFlashback | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a Human spell, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)
-SVar:TrigFlashback:DB$ Pump | ValidTgts$ Instant.YouOwn,Sorcery.YouOwn | TgtZone$ Graveyard | TgtPrompt$ Select target instant or sorcery card in your graveyard | KW$ Flashback | PumpZone$ Graveyard | AILogic$ ReplaySpell
+SVar:TrigFlashback:DB$ Pump | ValidTgts$ Instant.YouOwn,Sorcery.YouOwn | TgtZone$ Graveyard | TgtPrompt$ Select target instant or sorcery card in your graveyard | KW$ Flashback:CardManaCost | PumpZone$ Graveyard | AILogic$ ReplaySpell
 DeckHas:Ability$Graveyard & Keyword$Flashback
 DeckHints:Ability$Graveyard|Mill & Type$Instant|Sorcery
 DeckNeeds:Type$Human

--- a/forge-gui/res/cardsfolder/r/recoup.txt
+++ b/forge-gui/res/cardsfolder/r/recoup.txt
@@ -2,5 +2,5 @@ Name:Recoup
 ManaCost:1 R
 Types:Sorcery
 K:Flashback:3 R
-A:SP$ Pump | ValidTgts$ Sorcery.YouCtrl.Other | TgtZone$ Graveyard | TgtPrompt$ Select target sorcery card | KW$ Flashback | PumpZone$ Graveyard | SpellDescription$ Target sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (Mana cost includes color.)
+A:SP$ Pump | ValidTgts$ Sorcery.YouCtrl.Other | TgtZone$ Graveyard | TgtPrompt$ Select target sorcery card | KW$ Flashback:CardManaCost | PumpZone$ Graveyard | AILogic$ ReplaySpell | SpellDescription$ Target sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (Mana cost includes color.)
 Oracle:Target sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (Mana cost includes color.)\nFlashback {3}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)

--- a/forge-gui/res/cardsfolder/s/sapphire_collector.txt
+++ b/forge-gui/res/cardsfolder/s/sapphire_collector.txt
@@ -5,7 +5,7 @@ PT:3/3
 K:Prowess
 T:Mode$ SpellCast | ValidCard$ Card.YouCtrl+nonCreature | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigConjure | GameActivationLimit$ 1 | ActivatorThisTurnCast$ EQ2 | TriggerDescription$ When you cast your second noncreature spell in a turn, conjure a card named Mox Sapphire into your hand. This ability triggers only once.
 SVar:TrigConjure:DB$ MakeCard | Conjure$ True | Name$ Mox Sapphire | Zone$ Hand
-A:AB$ Pump | Cost$ 2 U | ValidTgts$ Instant.YouCtrl,Sorcery.YouCtrl | TgtZone$ Graveyard | TgtPrompt$ Select target instant or sorcery card | KW$ Flashback | PumpZone$ Graveyard | AILogic$ ReplaySpell | SpellDescription$ Target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.
+A:AB$ Pump | Cost$ 2 U | ValidTgts$ Instant.YouCtrl,Sorcery.YouCtrl | TgtZone$ Graveyard | TgtPrompt$ Select target instant or sorcery card | KW$ Flashback:CardManaCost | PumpZone$ Graveyard | AILogic$ ReplaySpell | SpellDescription$ Target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.
 DeckHas:Type$Artifact & Ability$Graveyard
 DeckHints:Ability$Graveyard & Type$Instant|Sorcery
 Oracle:Prowess\nWhen you cast your second noncreature spell in a turn, conjure a card named Mox Sapphire into your hand. This ability triggers only once.\n{2}{U}: Target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.

--- a/forge-gui/res/cardsfolder/s/slickshot_lockpicker.txt
+++ b/forge-gui/res/cardsfolder/s/slickshot_lockpicker.txt
@@ -3,6 +3,6 @@ ManaCost:2 U
 Types:Creature Human Rogue
 PT:2/3
 K:Plot:2 U
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigRearrange | TriggerDescription$ When CARDNAME enters, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)
-SVar:TrigRearrange:DB$ Pump | ValidTgts$ Instant.YouCtrl,Sorcery.YouCtrl | TgtZone$ Graveyard | TgtPrompt$ Select target instant or sorcery card | KW$ Flashback | PumpZone$ Graveyard | AILogic$ ReplaySpell
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigFlashback | TriggerDescription$ When CARDNAME enters, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)
+SVar:TrigFlashback:DB$ Pump | ValidTgts$ Instant.YouCtrl,Sorcery.YouCtrl | TgtZone$ Graveyard | TgtPrompt$ Select target instant or sorcery card | KW$ Flashback:CardManaCost | PumpZone$ Graveyard | AILogic$ ReplaySpell
 Oracle:When Slickshot Lockpicker enters, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)\nPlot {2}{U} (You may pay {2}{U} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)

--- a/forge-gui/res/cardsfolder/s/snapcaster_mage.txt
+++ b/forge-gui/res/cardsfolder/s/snapcaster_mage.txt
@@ -3,6 +3,6 @@ ManaCost:1 U
 Types:Creature Human Wizard
 PT:2/1
 K:Flash
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigRearrange | TriggerDescription$ When CARDNAME enters, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)
-SVar:TrigRearrange:DB$ Pump | ValidTgts$ Instant.YouCtrl,Sorcery.YouCtrl | TgtZone$ Graveyard | TgtPrompt$ Select target instant or sorcery card | KW$ Flashback | PumpZone$ Graveyard | AILogic$ ReplaySpell
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigFlashback | TriggerDescription$ When CARDNAME enters, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)
+SVar:TrigFlashback:DB$ Pump | ValidTgts$ Instant.YouCtrl,Sorcery.YouCtrl | TgtZone$ Graveyard | TgtPrompt$ Select target instant or sorcery card | KW$ Flashback:CardManaCost | PumpZone$ Graveyard | AILogic$ ReplaySpell
 Oracle:Flash\nWhen Snapcaster Mage enters, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)

--- a/forge-gui/res/cardsfolder/s/sphinx_of_forgotten_lore.txt
+++ b/forge-gui/res/cardsfolder/s/sphinx_of_forgotten_lore.txt
@@ -4,7 +4,7 @@ Types:Creature Sphinx
 PT:3/3
 K:Flash
 K:Flying
-T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever this creature attacks, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to that card's mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)
-SVar:TrigPump:DB$ Pump | ValidTgts$ Instant.YouOwn,Sorcery.YouOwn | TgtZone$ Graveyard | TgtPrompt$ Select target instant or sorcery card in your graveyard | KW$ Flashback | PumpZone$ Graveyard | AILogic$ ReplaySpell
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigFlashback | TriggerZones$ Battlefield | TriggerDescription$ Whenever this creature attacks, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to that card's mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)
+SVar:TrigFlashback:DB$ Pump | ValidTgts$ Instant.YouOwn,Sorcery.YouOwn | TgtZone$ Graveyard | TgtPrompt$ Select target instant or sorcery card in your graveyard | KW$ Flashback:CardManaCost | PumpZone$ Graveyard | AILogic$ ReplaySpell
 SVar:HasAttackEffect:TRUE
 Oracle:Flash (You may cast this spell any time you could cast an instant.)\nFlying\nWhenever this creature attacks, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to that card's mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)

--- a/forge-gui/res/cardsfolder/t/the_fugitive_doctor.txt
+++ b/forge-gui/res/cardsfolder/t/the_fugitive_doctor.txt
@@ -5,8 +5,8 @@ PT:4/4
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate.
 SVar:TrigInvestigate:DB$ Investigate
 T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigImmediateTrig | OptionalDecider$ You | TriggerDescription$ Whenever CARDNAME attacks, you may sacrifice a Clue. When you do, target instant or sorcery card in your graveyard gains flashback {2}{R}{G} until end of turn. (You may cast that card from your graveyard for its flashback cost. Then exile it.)
-SVar:TrigImmediateTrig:AB$ ImmediateTrigger | Cost$ Sac<1/Clue> | Execute$ TrigRearrange | TriggerDescription$ When you do, target instant or sorcery card in your graveyard gains flashback {2}{R}{G} until end of turn. (You may cast that card from your graveyard for its flashback cost. Then exile it.)
-SVar:TrigRearrange:DB$ Pump | ValidTgts$ Instant.YouCtrl,Sorcery.YouCtrl | TgtZone$ Graveyard | TgtPrompt$ Select target instant or sorcery card | KW$ Flashback:2 R G | PumpZone$ Graveyard | AILogic$ ReplaySpell
+SVar:TrigImmediateTrig:AB$ ImmediateTrigger | Cost$ Sac<1/Clue> | Execute$ TrigFlashback | TriggerDescription$ When you do, target instant or sorcery card in your graveyard gains flashback {2}{R}{G} until end of turn. (You may cast that card from your graveyard for its flashback cost. Then exile it.)
+SVar:TrigFlashback:DB$ Pump | ValidTgts$ Instant.YouCtrl,Sorcery.YouCtrl | TgtZone$ Graveyard | TgtPrompt$ Select target instant or sorcery card | KW$ Flashback:2 R G | PumpZone$ Graveyard | AILogic$ ReplaySpell
 SVar:HasAttackEffect:TRUE
 DeckHints:Ability$Investigate & Type$Instant|Sorcery
 DeckHas:Ability$Investigate|Token|Sacrifice & Type$Artifact|Clue


### PR DESCRIPTION
Prompted by the upcoming [Songcrafter Mage](https://scryfall.com/card/tdm/225/songcrafter-mage) and [earlier discussion](https://github.com/Card-Forge/forge/pull/7118) on [Highway Reaver](https://scryfall.com/card/ydft/22/highway-reaver) regarding the display of costs associated with granted abilities, I experimented a bit with the effects that grant flashback. 
I found that in the case of `Pump` effects, the flashback cost can be displayed, and this is the quality of life update herein. As for the relevant `PumpAll` effects (eg. [Past in Flames](https://scryfall.com/card/mm3/105/past-in-flames)) a similar edit results in the flashback cost somehow being a singular colorless mana. These I left alone.

While I was at it, I standartized relevant `SVar` nomenclature and added a few missing AI flags.