### PR TITLE
Adventure: fix concede shortcut not working due to event dispatch thread

### DIFF
--- a/forge-gui-mobile/src/forge/screens/match/MatchScreen.java
+++ b/forge-gui-mobile/src/forge/screens/match/MatchScreen.java
@@ -1,5 +1,8 @@
 package forge.screens.match;
 
+import static forge.Forge.getLocalizer;
+
+import forge.toolbox.FOptionPane;
 import java.util.*;
 import java.util.Map.Entry;
 
@@ -651,7 +654,7 @@ public class MatchScreen extends FScreen {
                 break;
             case Keys.Q: //concede game on Ctrl+Q
                 if (KeyInputAdapter.isCtrlKeyDown()) {
-                    MatchController.instance.concede();
+                    confirmUserConcedes();
                     return true;
                 }
                 break;
@@ -1175,6 +1178,22 @@ public class MatchScreen extends FScreen {
                 return !MatchController.instance.getGameView().getPlanarPlayer().getCurrentPlaneName().isEmpty();
             }
         return false;
+    }
+
+    private void confirmUserConcedes() {
+        final Callback<Boolean> callback = new Callback<>() {
+            @Override
+            public void run(Boolean result) {
+                if (result) {
+                    getGameController().concede();
+                }
+            }
+        };
+
+        FOptionPane.showConfirmDialog(getLocalizer().getMessage("lblConcedeCurrentGame"),
+            getLocalizer().getMessage("lblConcedeTitle"),
+            getLocalizer().getMessage("lblConcede"),
+            getLocalizer().getMessage("lblCancel"), callback);
     }
 
     @Override


### PR DESCRIPTION
Usage of MatchController#concede() confirms an user input using WaitCallback, which results in an IllegalStateException due to EDT validations [here](https://github.com/Card-Forge/forge/blob/master/forge-gui/src/main/java/forge/util/WaitCallback.java#L22) and [here](https://github.com/Card-Forge/forge/blob/master/forge-gui/src/main/java/forge/gui/FThreads.java#L22).

```java
EDT > java.lang.IllegalStateException: forge.util.WaitCallback.invokeAndWait may not be accessed from the event dispatch thread.
	at forge.gui.FThreads.assertExecutedByEdt(FThreads.java:22)
	at forge.util.WaitCallback.invokeAndWait(WaitCallback.java:22)
	at forge.GuiMobile.showOptionDialog(GuiMobile.java:174)
	at forge.gui.util.SOptionPane.showOptionDialog(SOptionPane.java:67)
	at forge.gui.util.SOptionPane.showConfirmDialog(SOptionPane.java:58)
	at forge.gui.util.SOptionPane.showConfirmDialog(SOptionPane.java:53)
	at forge.screens.match.MatchController.showConfirmDialog(MatchController.java:638)
	at forge.gamemodes.match.AbstractGuiGame.showConfirmDialog(AbstractGuiGame.java:826)
	at forge.gamemodes.match.AbstractGuiGame.concede(AbstractGuiGame.java:365)
	at forge.screens.match.MatchScreen.keyDown(MatchScreen.java:654)
	at forge.Forge$MainInputProcessor.keyDown(Forge.java:1224)
	at com.badlogic.gdx.InputEventQueue.drain(InputEventQueue.java:58)
	at com.badlogic.gdx.backends.lwjgl3.DefaultLwjgl3Input.update(DefaultLwjgl3Input.java:190)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Window.update(Lwjgl3Window.java:409)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.loop(Lwjgl3Application.java:181)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.<init>(Lwjgl3Application.java:153)
	at forge.app.GameLauncher.<init>(GameLauncher.java:51)
	at forge.app.Main.main(Main.java:29)
```

This exception resulted in the application being closed.

This PR fixes this, no longer using the MatchController to concede.