### PR TITLE
Fix creating token with Endure 0

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/EndureEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/EndureEffect.java
@@ -53,6 +53,10 @@ public class EndureEffect extends TokenEffectBase {
         String num = sa.getParamOrDefault("Num", "1");
         int amount = AbilityUtils.calculateAmount(host, num, sa);
 
+        if (amount < 1) {
+            return;
+        }
+
         GameEntityCounterTable table = new GameEntityCounterTable();
         TokenCreateTable tokenTable = new TokenCreateTable();
         for (final Card c : GameActionUtil.orderCardsByTheirOwners(game, getTargetCards(sa), ZoneType.Battlefield, sa)) {


### PR DESCRIPTION
> If a permanent is instructed to endure 0, nothing happens. No counters are put on that permanent and no tokens are created.