### PR TITLE
Remove Quest items on NG+

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
+++ b/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
@@ -1027,6 +1027,17 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
         return true;
     }
 
+    public void removeAllQuestItems(){
+        for (String s : inventoryItems) {
+            ItemData data = ItemData.getItem(s);
+            if(data != null){
+                if(data.questItem){
+                    removeItem(data.name);
+                }
+            }
+        }
+    }
+
     public boolean addBooster(Deck booster) {
         if (booster == null || booster.isEmpty())
             return false;

--- a/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
+++ b/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
@@ -1030,10 +1030,8 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
     public void removeAllQuestItems(){
         for (String s : inventoryItems) {
             ItemData data = ItemData.getItem(s);
-            if(data != null){
-                if(data.questItem){
-                    removeItem(data.name);
-                }
+            if(data != null && data.questItem){
+                removeItem(data.name);
             }
         }
     }

--- a/forge-gui-mobile/src/forge/adventure/scene/SaveLoadScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/SaveLoadScene.java
@@ -253,6 +253,7 @@ public class SaveLoadScene extends UIScene {
                                 Current.player().getQuests().clear();
                                 Current.player().resetQuestFlags();
                                 Current.player().setCharacterFlag("newGamePlus", 1);
+                                Current.player().removeAllQuestItems();
                                 AdventurePlayer.current().addQuest("28");
                                 WorldSave.getCurrentSave().clearBookmarks();
                                 WorldStage.getInstance().enterSpawnPOI();

--- a/forge-gui/res/adventure/common/world/items.json
+++ b/forge-gui/res/adventure/common/world/items.json
@@ -146,17 +146,20 @@
   {
     "name": "Landscape Sketchbook - Mirage",
     "description": "A leather bound notebook containing sketches of tropical locations",
-    "iconName": "LandscapeSketchbook"
+    "iconName": "LandscapeSketchbook",
+    "questItem": true
   },
   {
     "name": "Landscape Sketchbook - Urza's Saga",
     "description": "A leather bound notebook containing many different angles of the same terrain features",
-    "iconName": "LandscapeSketchbook"
+    "iconName": "LandscapeSketchbook",
+    "questItem": true
   },
   {
     "name": "Landscape Sketchbook - Coldsnap",
     "description": "A leather bound notebook containing sketches of frost covered vistas",
-    "iconName": "LandscapeSketchbook"
+    "iconName": "LandscapeSketchbook",
+    "questItem": true
   },
   {
     "name": "Chandra's Tome",
@@ -1188,7 +1191,6 @@
     "description": "Teleports you to the plains",
     "commandOnUse": "teleport to poi \"Plains Capital\"",
     "iconName": "WhiteRune",
-    "questItem": true,
     "shardsNeeded": 1,
     "cost": 100
   },
@@ -1202,7 +1204,6 @@
     "description": "Teleports you to the swamp",
     "commandOnUse": "teleport to poi \"Swamp Capital\"",
     "iconName": "BlackRune",
-    "questItem": true,
     "shardsNeeded": 1,
     "cost": 100
   },
@@ -1216,7 +1217,6 @@
     "description": "Teleports you to the island",
     "commandOnUse": "teleport to poi \"Island Capital\"",
     "iconName": "BlueRune",
-    "questItem": true,
     "shardsNeeded": 1,
     "cost": 100
   },
@@ -1230,7 +1230,6 @@
     "description": "Teleports you to the mountain",
     "commandOnUse": "teleport to poi \"Mountain Capital\"",
     "iconName": "RedRune",
-    "questItem": true,
     "shardsNeeded": 1,
     "cost": 100
   },
@@ -1244,7 +1243,6 @@
     "description": "Teleports you to the forest",
     "commandOnUse": "teleport to poi \"Forest Capital\"",
     "iconName": "GreenRune",
-    "questItem": true,
     "shardsNeeded": 1,
     "cost": 100
   },


### PR DESCRIPTION
This removes quest items from a NG+ run in adventure mode. It might not remove all when a file has multiple NG+'s already, but multiple resets will remove all of the items. I decided to remove the quest item tag from the teleport runes, since they are not added by a quest but can be bought in the store instead. Keeping them seems a good move for NG+.