### PR TITLE
Cleanup: Updating to Count$Valid, pass 3 

### DIFF
--- a/forge-gui/res/cardsfolder/a/accessories_to_murder.txt
+++ b/forge-gui/res/cardsfolder/a/accessories_to_murder.txt
@@ -3,5 +3,5 @@ ManaCost:no cost
 Types:Artifact Contraption
 T:Mode$ CrankContraption | ValidCard$ Card.Self | Execute$ TrigCrank | TriggerDescription$ Whenever you crank CARDNAME, target creature gets +X/+0 until end of turn, where X is the number of creatures you control.
 SVar:TrigCrank:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X
-SVar:X:Count$TypeYouCtrl.Creature
+SVar:X:Count$Valid Creature.YouCtrl
 Oracle:Whenever you crank Accessories to Murder, target creature gets +X/+0 until end of turn, where X is the number of creatures you control.

--- a/forge-gui/res/cardsfolder/a/aetherwind_basker.txt
+++ b/forge-gui/res/cardsfolder/a/aetherwind_basker.txt
@@ -6,7 +6,7 @@ K:Trample
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigEnergy | TriggerDescription$ Whenever CARDNAME enters or attacks, you get {E} (an energy counter) for each creature you control.
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigEnergy | Secondary$ True | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME enters or attacks, you get {E} (an energy counter) for each creature you control.
 SVar:TrigEnergy:DB$ PutCounter | Defined$ You | CounterType$ ENERGY | CounterNum$ X
-SVar:X:Count$TypeYouCtrl.Creature
+SVar:X:Count$Valid Creature.YouCtrl
 A:AB$ Pump | Cost$ PayEnergy<1> | Defined$ Self | NumAtt$ +1 | NumDef$ +1 | SpellDescription$ CARDNAME gets +1/+1 until end of turn.
 SVar:HasAttackEffect:TRUE
 Oracle:Trample\nWhenever Aetherwind Basker enters or attacks, you get {E} (an energy counter) for each creature you control.\nPay {E}: Aetherwind Basker gets +1/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/a/airborne_aid.txt
+++ b/forge-gui/res/cardsfolder/a/airborne_aid.txt
@@ -2,6 +2,6 @@ Name:Airborne Aid
 ManaCost:3 U
 Types:Sorcery
 A:SP$ Draw | NumCards$ X | SpellDescription$ Draw a card for each Bird on the battlefield.
-SVar:X:Count$TypeOnBattlefield.Bird
+SVar:X:Count$Valid Bird
 AI:RemoveDeck:Random
 Oracle:Draw a card for each Bird on the battlefield.

--- a/forge-gui/res/cardsfolder/a/alive_well.txt
+++ b/forge-gui/res/cardsfolder/a/alive_well.txt
@@ -13,5 +13,5 @@ Name:Well
 ManaCost:W
 Types:Sorcery
 A:SP$ GainLife | LifeAmount$ X | SpellDescription$ You gain 2 life for each creature you control.
-SVar:X:Count$TypeYouCtrl.Creature/Times.2
+SVar:X:Count$Valid Creature.YouCtrl/Times.2
 Oracle:You gain 2 life for each creature you control.\nFuse (You may cast one or both halves of this card from your hand.)

--- a/forge-gui/res/cardsfolder/a/ancient_brass_dragon.txt
+++ b/forge-gui/res/cardsfolder/a/ancient_brass_dragon.txt
@@ -8,6 +8,6 @@ SVar:TrigRoll:DB$ RollDice | ResultSVar$ Result | Sides$ 20 | SubAbility$ DBImme
 SVar:DBImmediateTrigger:DB$ ImmediateTrigger | Execute$ TrigChangeZone | RememberSVarAmount$ Result | TriggerDescription$ When you do, put any number of target creature cards with total mana value X or less from graveyards onto the battlefield under your control, where X is the result.
 SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | TargetMin$ 0 | TargetMax$ Y | ValidTgts$ Creature | TgtPrompt$ Select any number of target creature cards with total mana value X or less from graveyards | MaxTotalTargetCMC$ X | GainControl$ True
 SVar:X:Count$TriggerRememberAmount
-SVar:Y:Count$TypeInAllYards.Creature
+SVar:Y:Count$ValidGraveyard Creature
 DeckHas:Ability$Graveyard
 Oracle:Flying\nWhenever Ancient Brass Dragon deals combat damage to a player, roll a d20. When you do, put any number of target creature cards with total mana value X or less from graveyards onto the battlefield under your control, where X is the result.

--- a/forge-gui/res/cardsfolder/a/appeal_authority.txt
+++ b/forge-gui/res/cardsfolder/a/appeal_authority.txt
@@ -2,7 +2,7 @@ Name:Appeal
 ManaCost:G
 Types:Sorcery
 A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | NumDef$ +X | KW$ Trample | SpellDescription$ Until end of turn, target creature gains trample and gets +X/+X, where X is the number of creatures you control.
-SVar:X:Count$TypeYouCtrl.Creature
+SVar:X:Count$Valid Creature.YouCtrl
 AlternateMode:Split
 Oracle:Until end of turn, target creature gains trample and gets +X/+X, where X is the number of creatures you control.
 

--- a/forge-gui/res/cardsfolder/a/armored_ascension.txt
+++ b/forge-gui/res/cardsfolder/a/armored_ascension.txt
@@ -4,6 +4,6 @@ Types:Enchantment Aura
 K:Enchant creature
 A:SP$ Attach | ValidTgts$ Creature | AILogic$ Pump
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ X | AddToughness$ X | AddKeyword$ Flying | Description$ Enchanted creature gets +1/+1 for each Plains you control and has flying.
-SVar:X:Count$TypeYouCtrl.Plains
+SVar:X:Count$Valid Plains.YouCtrl
 SVar:BuffedBy:Plains
 Oracle:Enchant creature\nEnchanted creature gets +1/+1 for each Plains you control and has flying.

--- a/forge-gui/res/cardsfolder/a/aspect_of_wolf.txt
+++ b/forge-gui/res/cardsfolder/a/aspect_of_wolf.txt
@@ -4,7 +4,7 @@ Types:Enchantment Aura
 K:Enchant creature
 A:SP$ Attach | ValidTgts$ Creature | AILogic$ Pump
 S:Mode$ Continuous | Affected$ Card.AttachedBy | AddPower$ X | AddToughness$ Y | Description$ Enchanted creature gets +X/+Y, where X is half the number of Forests you control, rounded down, and Y is half the number of Forests you control, rounded up.
-SVar:X:Count$TypeYouCtrl.Forest/HalfDown
+SVar:X:Count$Valid Forest.YouCtrl/HalfDown
 SVar:Y:Count$Valid Forest.YouCtrl/HalfUp
 SVar:BuffedBy:Forest
 Oracle:Enchant creature\nEnchanted creature gets +X/+Y, where X is half the number of Forests you control, rounded down, and Y is half the number of Forests you control, rounded up.

--- a/forge-gui/res/cardsfolder/a/avacyn_and_griselbrand.txt
+++ b/forge-gui/res/cardsfolder/a/avacyn_and_griselbrand.txt
@@ -7,5 +7,5 @@ K:Vigilance
 K:Lifelink
 A:AB$ PumpAll | Cost$ PayLife<8> | ValidCards$ Creature.YouCtrl | KW$ Indestructible | SubAbility$ DBDraw | SpellDescription$ Each creature you control gains indestructible until end of turn. Then, draw a card for each creature you control.
 SVar:DBDraw:DB$ Draw | NumCards$ X
-SVar:X:Count$TypeYouCtrl.Creature
+SVar:X:Count$Valid Creature.YouCtrl
 Oracle:Flying, vigilance, lifelink\nPay 8 life: Each creature you control gains indestructible until end of turn. Then, draw a card for each creature you control.

--- a/forge-gui/res/cardsfolder/a/avatar_of_woe.txt
+++ b/forge-gui/res/cardsfolder/a/avatar_of_woe.txt
@@ -5,5 +5,5 @@ PT:6/5
 K:Fear
 A:AB$ Destroy | Cost$ T | ValidTgts$ Creature | TgtPrompt$ Select target creature | NoRegen$ True | SpellDescription$ Destroy target creature. It can't be regenerated.
 S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 6 | EffectZone$ All | CheckSVar$ X | SVarCompare$ GT9 | Description$ If there are ten or more creature cards total in all graveyards, CARDNAME costs {6} less to cast.
-SVar:X:Count$TypeInAllYards.Creature
+SVar:X:Count$ValidGraveyard Creature
 Oracle:If there are ten or more creature cards total in all graveyards, this spell costs {6} less to cast.\nFear (This creature can't be blocked except by artifact creatures and/or black creatures.)\n{T}: Destroy target creature. It can't be regenerated.

--- a/forge-gui/res/cardsfolder/b/bala_ged_thief.txt
+++ b/forge-gui/res/cardsfolder/b/bala_ged_thief.txt
@@ -4,6 +4,6 @@ Types:Creature Human Rogue Ally
 PT:2/2
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self,Ally.Other+YouCtrl | Execute$ DBDiscard | TriggerDescription$ Whenever CARDNAME or another Ally you control enters, target player reveals a number of cards from their hand equal to the number of Allies you control. You choose one of them. That player discards that card.
 SVar:DBDiscard:DB$ Discard | ValidTgts$ Player | NumCards$ 1 | RevealNumber$ X | Mode$ RevealYouChoose | DiscardValid$ Card
-SVar:X:Count$TypeYouCtrl.Ally
+SVar:X:Count$Valid Ally.YouCtrl
 SVar:BuffedBy:Ally
 Oracle:Whenever Bala Ged Thief or another Ally you control enters, target player reveals a number of cards from their hand equal to the number of Allies you control. You choose one of them. That player discards that card.

--- a/forge-gui/res/cardsfolder/b/battlefield_medic.txt
+++ b/forge-gui/res/cardsfolder/b/battlefield_medic.txt
@@ -3,5 +3,5 @@ ManaCost:1 W
 Types:Creature Human Cleric
 PT:1/1
 A:AB$ PreventDamage | Cost$ T | ValidTgts$ Creature | Amount$ X | TgtPrompt$ Select target creature | SpellDescription$ Prevent the next X damage that would be dealt to target creature this turn, where X is the number of Clerics on the battlefield.
-SVar:X:Count$TypeOnBattlefield.Cleric
+SVar:X:Count$Valid Cleric
 Oracle:{T}: Prevent the next X damage that would be dealt to target creature this turn, where X is the number of Clerics on the battlefield.

--- a/forge-gui/res/cardsfolder/b/beacon_of_creation.txt
+++ b/forge-gui/res/cardsfolder/b/beacon_of_creation.txt
@@ -3,5 +3,5 @@ ManaCost:3 G
 Types:Sorcery
 A:SP$ Token | TokenAmount$ X | TokenScript$ g_1_1_insect | TokenOwner$ You | SubAbility$ DBShuffle | SpellDescription$ Create a 1/1 green Insect creature token for each Forest you control. Shuffle CARDNAME into its owner's library.
 SVar:DBShuffle:DB$ ChangeZone | Origin$ Stack | Destination$ Library | Shuffle$ True | Defined$ Parent
-SVar:X:Count$TypeYouCtrl.Forest
+SVar:X:Count$Valid Forest.YouCtrl
 Oracle:Create a 1/1 green Insect creature token for each Forest you control. Shuffle Beacon of Creation into its owner's library.

--- a/forge-gui/res/cardsfolder/b/blanchwood_armor.txt
+++ b/forge-gui/res/cardsfolder/b/blanchwood_armor.txt
@@ -4,6 +4,6 @@ Types:Enchantment Aura
 K:Enchant creature
 A:SP$ Attach | ValidTgts$ Creature | AILogic$ Pump
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ X | AddToughness$ X | Description$ Enchanted creature gets +1/+1 for each Forest you control.
-SVar:X:Count$TypeYouCtrl.Forest
+SVar:X:Count$Valid Forest.YouCtrl
 SVar:BuffedBy:Forest
 Oracle:Enchant creature\nEnchanted creature gets +1/+1 for each Forest you control.

--- a/forge-gui/res/cardsfolder/b/blighted_steppe.txt
+++ b/forge-gui/res/cardsfolder/b/blighted_steppe.txt
@@ -3,7 +3,7 @@ ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ GainLife | Cost$ 3 W T Sac<1/CARDNAME> | Defined$ You | LifeAmount$ X | SpellDescription$ You gain 2 life for each creature you control.
-SVar:X:Count$TypeYouCtrl.Creature/Times.2
+SVar:X:Count$Valid Creature.YouCtrl/Times.2
 DeckHas:Ability$Mana.Colorless
 DeckNeeds:Color$White
 Oracle:{T}: Add {C}.\n{3}{W}, {T}, Sacrifice Blighted Steppe: You gain 2 life for each creature you control.

--- a/forge-gui/res/cardsfolder/b/bonehoard.txt
+++ b/forge-gui/res/cardsfolder/b/bonehoard.txt
@@ -4,7 +4,7 @@ Types:Artifact Equipment
 K:Living Weapon
 K:Equip:2
 S:Mode$ Continuous | Affected$ Card.EquippedBy | AddPower$ X | AddToughness$ X | Description$ Equipped creature gets +X/+X, where X is the number of creature cards in all graveyards.
-SVar:X:Count$TypeInAllYards.Creature
+SVar:X:Count$ValidGraveyard Creature
 SVar:NeedsToPlayVar:X GE1
 DeckHas:Ability$Token
 Oracle:Living weapon (When this Equipment enters, create a 0/0 black Phyrexian Germ creature token, then attach this to it.)\nEquipped creature gets +X/+X, where X is the number of creature cards in all graveyards.\nEquip {2}

--- a/forge-gui/res/cardsfolder/b/bountiful_harvest.txt
+++ b/forge-gui/res/cardsfolder/b/bountiful_harvest.txt
@@ -2,5 +2,5 @@ Name:Bountiful Harvest
 ManaCost:4 G
 Types:Sorcery
 A:SP$ GainLife | LifeAmount$ X | SpellDescription$ You gain 1 life for each land you control.
-SVar:X:Count$TypeYouCtrl.Land
+SVar:X:Count$Valid Land.YouCtrl
 Oracle:You gain 1 life for each land you control.

--- a/forge-gui/res/cardsfolder/b/brasss_bounty.txt
+++ b/forge-gui/res/cardsfolder/b/brasss_bounty.txt
@@ -2,6 +2,6 @@ Name:Brass's Bounty
 ManaCost:6 R
 Types:Sorcery
 A:SP$ Token | TokenAmount$ X | TokenScript$ c_a_treasure_sac | TokenOwner$ You | SpellDescription$ For each land you control, create a Treasure token.
-SVar:X:Count$TypeYouCtrl.Land
+SVar:X:Count$Valid Land.YouCtrl
 DeckHas:Ability$Token
 Oracle:For each land you control, create a Treasure token. (It's an artifact with "{T}, Sacrifice this artifact: Add one mana of any color.")

--- a/forge-gui/res/cardsfolder/b/brightstone_ritual.txt
+++ b/forge-gui/res/cardsfolder/b/brightstone_ritual.txt
@@ -2,6 +2,6 @@ Name:Brightstone Ritual
 ManaCost:R
 Types:Instant
 A:SP$ Mana | Produced$ R | Amount$ X | AILogic$ ManaRitual | AINoRecursiveCheck$ True | SpellDescription$ Add {R} for each Goblin on the battlefield.
-SVar:X:Count$TypeOnBattlefield.Goblin
+SVar:X:Count$Valid Goblin
 AI:RemoveDeck:Random
 Oracle:Add {R} for each Goblin on the battlefield.

--- a/forge-gui/res/cardsfolder/c/camaraderie.txt
+++ b/forge-gui/res/cardsfolder/c/camaraderie.txt
@@ -4,6 +4,6 @@ Types:Sorcery
 A:SP$ GainLife | Defined$ You | LifeAmount$ X | SubAbility$ DBDraw | SpellDescription$ You gain X life and draw X cards, where X is the number of creatures you control.
 SVar:DBDraw:DB$ Draw | NumCards$ X | SubAbility$ DBPumpAll
 SVar:DBPumpAll:DB$ PumpAll | ValidCards$ Creature.YouCtrl | NumAtt$ +1 | NumDef$ +1 | SpellDescription$ Creatures you control get +1/+1 until end of turn.
-SVar:X:Count$TypeYouCtrl.Creature
+SVar:X:Count$Valid Creature.YouCtrl
 SVar:PlayMain1:TRUE
 Oracle:You gain X life and draw X cards, where X is the number of creatures you control. Creatures you control get +1/+1 until end of turn.

--- a/forge-gui/res/cardsfolder/c/cantivore.txt
+++ b/forge-gui/res/cardsfolder/c/cantivore.txt
@@ -4,6 +4,6 @@ Types:Creature Lhurgoyf
 PT:*/*
 K:Vigilance
 S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of enchantment cards in all graveyards.
-SVar:X:Count$TypeInAllYards.Enchantment
+SVar:X:Count$ValidGraveyard Enchantment
 AI:RemoveDeck:Random
 Oracle:Vigilance\nCantivore's power and toughness are each equal to the number of enchantment cards in all graveyards.

--- a/forge-gui/res/cardsfolder/c/chain_reaction.txt
+++ b/forge-gui/res/cardsfolder/c/chain_reaction.txt
@@ -2,5 +2,5 @@ Name:Chain Reaction
 ManaCost:2 R R
 Types:Sorcery
 A:SP$ DamageAll | NumDmg$ X | ValidCards$ Creature | ValidDescription$ each creature. | SpellDescription$ CARDNAME deals X damage to each creature, where X is the number of creatures on the battlefield.
-SVar:X:Count$TypeOnBattlefield.Creature
+SVar:X:Count$Valid Creature
 Oracle:Chain Reaction deals X damage to each creature, where X is the number of creatures on the battlefield.

--- a/forge-gui/res/cardsfolder/c/chandra_gremlin_wrangler.txt
+++ b/forge-gui/res/cardsfolder/c/chandra_gremlin_wrangler.txt
@@ -4,6 +4,6 @@ Types:Legendary Planeswalker Chandra
 Loyalty:3
 A:AB$ Token | Cost$ AddCounter<1/LOYALTY> | TokenAmount$ 1 | TokenScript$ r_2_2_gremlin | TokenOwner$ You | Planeswalker$ True | SpellDescription$ Create a 2/2 red Gremlin creature token.
 A:AB$ DealDamage | Cost$ SubCounter<2/LOYALTY> | Planeswalker$ True | ValidTgts$ Creature,Player | TgtPrompt$ Select target creature or player | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to target creature or player, where X is the number of Gremlins you control.
-SVar:X:Count$TypeYouCtrl.Gremlin
+SVar:X:Count$Valid Gremlin.YouCtrl
 DeckHas:Ability$Token
 Oracle:[+1]: Create a 2/2 red Gremlin creature token.\n[-2]: Chandra, Gremlin Wrangler deals X damage to target creature or player, where X is the number of Gremlins you control.

--- a/forge-gui/res/cardsfolder/c/claws_of_valakut.txt
+++ b/forge-gui/res/cardsfolder/c/claws_of_valakut.txt
@@ -4,6 +4,6 @@ Types:Enchantment Aura
 K:Enchant creature
 A:SP$ Attach | ValidTgts$ Creature | AILogic$ Pump
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ X | AddKeyword$ First Strike | Description$ Enchanted creature gets +1/+0 for each Mountain you control and has first strike.
-SVar:X:Count$TypeYouCtrl.Mountain
+SVar:X:Count$Valid Mountain.YouCtrl
 SVar:BuffedBy:Mountain
 Oracle:Enchant creature\nEnchanted creature gets +1/+0 for each Mountain you control and has first strike.

--- a/forge-gui/res/cardsfolder/c/cognivore.txt
+++ b/forge-gui/res/cardsfolder/c/cognivore.txt
@@ -4,6 +4,6 @@ Types:Creature Lhurgoyf
 PT:*/*
 K:Flying
 S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of instant cards in all graveyards.
-SVar:X:Count$TypeInAllYards.Instant
+SVar:X:Count$ValidGraveyard Instant
 AI:RemoveDeck:Random
 Oracle:Flying\nCognivore's power and toughness are each equal to the number of instant cards in all graveyards.

--- a/forge-gui/res/cardsfolder/c/collective_unconscious.txt
+++ b/forge-gui/res/cardsfolder/c/collective_unconscious.txt
@@ -2,5 +2,5 @@ Name:Collective Unconscious
 ManaCost:4 G G
 Types:Sorcery
 A:SP$ Draw | NumCards$ X | SpellDescription$ Draw a card for each creature you control.
-SVar:X:Count$TypeYouCtrl.Creature
+SVar:X:Count$Valid Creature.YouCtrl
 Oracle:Draw a card for each creature you control.

--- a/forge-gui/res/cardsfolder/c/congregate.txt
+++ b/forge-gui/res/cardsfolder/c/congregate.txt
@@ -2,5 +2,5 @@ Name:Congregate
 ManaCost:3 W
 Types:Instant
 A:SP$ GainLife | LifeAmount$ X | ValidTgts$ Player | TgtPrompt$ Choose a player | SpellDescription$ Target player gains 2 life for each creature on the battlefield.
-SVar:X:Count$TypeOnBattlefield.Creature/Times.2
+SVar:X:Count$Valid Creature/Times.2
 Oracle:Target player gains 2 life for each creature on the battlefield.

--- a/forge-gui/res/cardsfolder/c/consuming_corruption.txt
+++ b/forge-gui/res/cardsfolder/c/consuming_corruption.txt
@@ -3,6 +3,6 @@ ManaCost:B B
 Types:Instant
 A:SP$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ X | SubAbility$ DBGainLife | SpellDescription$ CARDNAME deals X damage to target creature or planeswalker and you gain X life, where X is the number of Swamps you control.
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ X
-SVar:X:Count$TypeYouCtrl.Swamp
+SVar:X:Count$Valid Swamp.YouCtrl
 DeckHas:Ability$LifeGain
 Oracle:Consuming Corruption deals X damage to target creature or planeswalker and you gain X life, where X is the number of Swamps you control.

--- a/forge-gui/res/cardsfolder/c/corrupt.txt
+++ b/forge-gui/res/cardsfolder/c/corrupt.txt
@@ -3,6 +3,6 @@ ManaCost:5 B
 Types:Sorcery
 A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ X | SubAbility$ DBGainLife | SpellDescription$ CARDNAME deals damage to any target equal to the number of Swamps you control. You gain life equal to the damage dealt this way.
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ Y | StackDescription$ You gain life equal to the damage dealt this way.
-SVar:X:Count$TypeYouCtrl.Swamp
+SVar:X:Count$Valid Swamp.YouCtrl
 SVar:Y:Count$TotalDamageDoneByThisTurn
 Oracle:Corrupt deals damage to any target equal to the number of Swamps you control. You gain life equal to the damage dealt this way.

--- a/forge-gui/res/cardsfolder/c/crown_of_skemfar.txt
+++ b/forge-gui/res/cardsfolder/c/crown_of_skemfar.txt
@@ -4,7 +4,7 @@ Types:Enchantment Aura
 K:Enchant creature
 A:SP$ Attach | ValidTgts$ Creature | AILogic$ Pump
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ X | AddToughness$ X | AddKeyword$ Reach | Description$ Enchanted creature gets +1/+1 for each Elf you control and has reach.
-SVar:X:Count$TypeYouCtrl.Elf
+SVar:X:Count$Valid Elf.YouCtrl
 SVar:BuffedBy:Elf
 A:AB$ ChangeZone | Cost$ 2 G | Origin$ Graveyard | Destination$ Hand | ActivationZone$ Graveyard | SpellDescription$ Return CARDNAME from your graveyard to your hand.
 DeckHints:Type$Elf

--- a/forge-gui/res/cardsfolder/c/cruel_somnophage_cant_wake_up.txt
+++ b/forge-gui/res/cardsfolder/c/cruel_somnophage_cant_wake_up.txt
@@ -3,7 +3,7 @@ ManaCost:1 B
 Types:Creature Nightmare
 PT:*/*
 S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creature cards in all graveyards.
-SVar:X:Count$TypeInAllYards.Creature
+SVar:X:Count$ValidGraveyard Creature
 DeckHints:Ability$Mill|Discard|Graveyard
 DeckHas:Ability$Mill
 AlternateMode:Adventure

--- a/forge-gui/res/cardsfolder/d/davriel_soul_broker.txt
+++ b/forge-gui/res/cardsfolder/d/davriel_soul_broker.txt
@@ -40,7 +40,7 @@ SVar:DrawTrig:Mode$ Drawn | ValidCard$ Card.YouCtrl | TriggerZones$ Command | Ex
 SVar:TrigDig:DB$ Dig | Defined$ TriggeredPlayer | DigNum$ 2 | ChangeNum$ All | DestinationZone$ Exile
 SVar:EmblemUpkeepLose:DB$ Effect | Name$ Emblem — Davriel, Soul Broker (Condition 8) | Triggers$ UpkeepLoseTrig | Duration$ Permanent | SpellDescription$ You get an emblem with "At the beginning of your upkeep, you lose 1 life for each creature you control."
 SVar:UpkeepLoseTrig:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ TrigLose | TriggerZones$ Command | TriggerDescription$ At the beginning of your upkeep, you lose 1 life for each creature you control.
-SVar:TrigLose:DB$ LoseLife | Defined$ You | LifeAmount$ Count$TypeYouCtrl.Creature
+SVar:TrigLose:DB$ LoseLife | Defined$ You | LifeAmount$ Count$Valid Creature.YouCtrl
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 A:AB$ Pump | Cost$ SubCounter<3/LOYALTY> | Planeswalker$ True | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | IsCurse$ True | NumAtt$ -3 | NumDef$ -3 | Duration$ Perpetual | StackDescription$ REP Target creature an opponent controls_{c:Targeted} | SpellDescription$ Target creature an opponent controls perpetually gets -3/-3.
 DeckHas:Ability$LifeGain|Graveyard|Sacrifice

--- a/forge-gui/res/cardsfolder/d/defile.txt
+++ b/forge-gui/res/cardsfolder/d/defile.txt
@@ -2,5 +2,5 @@ Name:Defile
 ManaCost:B
 Types:Instant
 A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ -X | NumDef$ -X | IsCurse$ True | SpellDescription$ Target creature gets -1/-1 until end of turn for each Swamp you control.
-SVar:X:Count$TypeYouCtrl.Swamp
+SVar:X:Count$Valid Swamp.YouCtrl
 Oracle:Target creature gets -1/-1 until end of turn for each Swamp you control.

--- a/forge-gui/res/cardsfolder/d/deploy_to_the_front.txt
+++ b/forge-gui/res/cardsfolder/d/deploy_to_the_front.txt
@@ -2,5 +2,5 @@ Name:Deploy to the Front
 ManaCost:5 W W
 Types:Sorcery
 A:SP$ Token | TokenAmount$ X | TokenScript$ w_1_1_soldier | TokenOwner$ You | SpellDescription$ Create X 1/1 white Soldier creature tokens, where X is the number of creatures on the battlefield.
-SVar:X:Count$TypeOnBattlefield.Creature
+SVar:X:Count$Valid Creature
 Oracle:Create X 1/1 white Soldier creature tokens, where X is the number of creatures on the battlefield.

--- a/forge-gui/res/cardsfolder/d/depose_deploy.txt
+++ b/forge-gui/res/cardsfolder/d/depose_deploy.txt
@@ -13,6 +13,6 @@ ManaCost:2 W U
 Types:Instant
 A:SP$ Token | TokenAmount$ 2 | TokenOwner$ You | TokenScript$ c_1_1_a_thopter_flying | SubAbility$ DBGainLife | SpellDescription$ Create two 1/1 colorless Thopter artifact creature tokens with flying, then you gain 1 life for each creature you control.
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ X
-SVar:X:Count$TypeYouCtrl.Creature
+SVar:X:Count$Valid Creature.YouCtrl
 DeckHas:Ability$Token
 Oracle:Create two 1/1 colorless Thopter artifact creature tokens with flying, then you gain 1 life for each creature you control.

--- a/forge-gui/res/cardsfolder/d/downhill_charge.txt
+++ b/forge-gui/res/cardsfolder/d/downhill_charge.txt
@@ -3,5 +3,5 @@ ManaCost:2 R
 Types:Instant
 S:Mode$ AlternativeCost | ValidSA$ Spell.Self | EffectZone$ All | Cost$ Sac<1/Mountain> | Description$ You may sacrifice a Mountain rather than pay this spell's mana cost.
 A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | SpellDescription$ Target creature gets +X/+0 until end of turn, where X is the number of Mountains you control.
-SVar:X:Count$TypeYouCtrl.Mountain
+SVar:X:Count$Valid Mountain.YouCtrl
 Oracle:You may sacrifice a Mountain rather than pay this spell's mana cost.\nTarget creature gets +X/+0 until end of turn, where X is the number of Mountains you control.

--- a/forge-gui/res/cardsfolder/d/drafnas_restoration.txt
+++ b/forge-gui/res/cardsfolder/d/drafnas_restoration.txt
@@ -3,7 +3,7 @@ ManaCost:U
 Types:Sorcery
 A:SP$ Pump | ValidTgts$ Player | SubAbility$ DBChangeZone | IsCurse$ True | SpellDescription$ Put any number of target artifact cards from target player's graveyard on top of their library in any order.
 SVar:DBChangeZone:DB$ ChangeZone | TargetMin$ 0 | TargetMax$ X | TargetsWithDefinedController$ ParentTarget | Origin$ Graveyard | Destination$ Library | TgtPrompt$ Choose target artifact card | ValidTgts$ Artifact | Chooser$ You
-SVar:X:Count$InAllYards
+SVar:X:Count$ValidGraveyard Artifact.OwnedBy TargetedPlayer
 AI:RemoveDeck:All
 DeckHas:Ability$Graveyard
 DeckHints:Ability$Mill

--- a/forge-gui/res/cardsfolder/e/elspeth_tirel.txt
+++ b/forge-gui/res/cardsfolder/e/elspeth_tirel.txt
@@ -5,5 +5,5 @@ Loyalty:4
 A:AB$ GainLife | Cost$ AddCounter<2/LOYALTY> | LifeAmount$ XLife | Planeswalker$ True | SpellDescription$ You gain 1 life for each creature you control.
 A:AB$ Token | Cost$ SubCounter<2/LOYALTY> | TokenAmount$ 3 | TokenScript$ w_1_1_soldier | TokenOwner$ You | Planeswalker$ True | SpellDescription$ Create three 1/1 white Soldier creature tokens.
 A:AB$ DestroyAll | Cost$ SubCounter<5/LOYALTY> | ValidCards$ Permanent.nonLand+!token+StrictlyOther | Planeswalker$ True | Ultimate$ True | SpellDescription$ Destroy all other permanents except for lands and tokens.
-SVar:XLife:Count$TypeYouCtrl.Creature
+SVar:XLife:Count$Valid Creature.YouCtrl
 Oracle:[+2]: You gain 1 life for each creature you control.\n[-2]: Create three 1/1 white Soldier creature tokens.\n[-5]: Destroy all other permanents except for lands and tokens.

--- a/forge-gui/res/cardsfolder/e/eriette_of_the_charmed_apple.txt
+++ b/forge-gui/res/cardsfolder/e/eriette_of_the_charmed_apple.txt
@@ -6,7 +6,7 @@ S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy Aura.YouCtrl | Target$ You,
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDrain | TriggerDescription$ At the beginning of your end step, each opponent loses X life and you gain X life, where X is the number of Auras you control.
 SVar:TrigDrain:DB$ LoseLife | Defined$ Player.Opponent | LifeAmount$ X | SubAbility$ DBGainLife
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ X
-SVar:X:Count$TypeYouCtrl.Aura
+SVar:X:Count$Valid Aura.YouCtrl
 DeckHas:Ability$LifeGain
 DeckNeeds:Type$Aura
 Oracle:Each creature that's enchanted by an Aura you control can't attack you or planeswalkers you control.\nAt the beginning of your end step, each opponent loses X life and you gain X life, where X is the number of Auras you control.

--- a/forge-gui/res/cardsfolder/e/exoskeletal_armor.txt
+++ b/forge-gui/res/cardsfolder/e/exoskeletal_armor.txt
@@ -4,5 +4,5 @@ Types:Enchantment Aura
 K:Enchant creature
 A:SP$ Attach | ValidTgts$ Creature | AILogic$ Pump
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ X | AddToughness$ X | Description$ Enchanted creature gets +X/+X, where X is the number of creature cards in all graveyards.
-SVar:X:Count$TypeInAllYards.Creature
+SVar:X:Count$ValidGraveyard Creature
 Oracle:Enchant creature\nEnchanted creature gets +X/+X, where X is the number of creature cards in all graveyards.

--- a/forge-gui/res/cardsfolder/f/feedback_bolt.txt
+++ b/forge-gui/res/cardsfolder/f/feedback_bolt.txt
@@ -2,6 +2,6 @@ Name:Feedback Bolt
 ManaCost:4 R
 Types:Instant
 A:SP$ DealDamage | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | NumDmg$ X | SpellDescription$ CARDNAME deals damage to target player or planeswalker equal to the number of artifacts you control.
-SVar:X:Count$TypeYouCtrl.Artifact
+SVar:X:Count$Valid Artifact.YouCtrl
 AI:RemoveDeck:Random
 Oracle:Feedback Bolt deals damage to target player or planeswalker equal to the number of artifacts you control.

--- a/forge-gui/res/cardsfolder/f/festival_of_trokin.txt
+++ b/forge-gui/res/cardsfolder/f/festival_of_trokin.txt
@@ -2,5 +2,5 @@ Name:Festival of Trokin
 ManaCost:W
 Types:Sorcery
 A:SP$ GainLife | LifeAmount$ X | SpellDescription$ You gain 2 life for each creature you control.
-SVar:X:Count$TypeYouCtrl.Creature/Times.2
+SVar:X:Count$Valid Creature.YouCtrl/Times.2
 Oracle:You gain 2 life for each creature you control.

--- a/forge-gui/res/cardsfolder/f/fire_dragon.txt
+++ b/forge-gui/res/cardsfolder/f/fire_dragon.txt
@@ -5,6 +5,6 @@ PT:6/6
 K:Flying
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When CARDNAME enters, it deals damage to target creature equal to the number of Mountains you control.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X
-SVar:X:Count$TypeYouCtrl.Mountain
+SVar:X:Count$Valid Mountain.YouCtrl
 SVar:PlayMain1:TRUE
 Oracle:Flying\nWhen Fire Dragon enters, it deals damage to target creature equal to the number of Mountains you control.

--- a/forge-gui/res/cardsfolder/f/flow_of_ideas.txt
+++ b/forge-gui/res/cardsfolder/f/flow_of_ideas.txt
@@ -2,6 +2,6 @@ Name:Flow of Ideas
 ManaCost:5 U
 Types:Sorcery
 A:SP$ Draw | NumCards$ X | SpellDescription$ Draw a card for each Island you control.
-SVar:X:Count$TypeYouCtrl.Island
+SVar:X:Count$Valid Island.YouCtrl
 AI:RemoveDeck:Random
 Oracle:Draw a card for each Island you control.

--- a/forge-gui/res/cardsfolder/f/folk_medicine.txt
+++ b/forge-gui/res/cardsfolder/f/folk_medicine.txt
@@ -3,7 +3,7 @@ ManaCost:2 G
 Types:Instant
 K:Flashback:1 W
 A:SP$ GainLife | LifeAmount$ X | SpellDescription$ You gain 1 life for each creature you control.
-SVar:X:Count$TypeYouCtrl.Creature
+SVar:X:Count$Valid Creature.YouCtrl
 AI:RemoveDeck:Random
 DeckNeeds:Color$White
 Oracle:You gain 1 life for each creature you control.\nFlashback {1}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)

--- a/forge-gui/res/cardsfolder/f/fruition.txt
+++ b/forge-gui/res/cardsfolder/f/fruition.txt
@@ -2,5 +2,5 @@ Name:Fruition
 ManaCost:G
 Types:Sorcery
 A:SP$ GainLife | LifeAmount$ X | SpellDescription$ You gain 1 life for each Forest on the battlefield.
-SVar:X:Count$TypeOnBattlefield.Forest
+SVar:X:Count$Valid Forest
 Oracle:You gain 1 life for each Forest on the battlefield.

--- a/forge-gui/res/cardsfolder/g/glimmerpost.txt
+++ b/forge-gui/res/cardsfolder/g/glimmerpost.txt
@@ -4,5 +4,5 @@ Types:Land Locus
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigGainLife | TriggerDescription$ When CARDNAME enters, you gain 1 life for each Locus on the battlefield.
 SVar:TrigGainLife:DB$ GainLife | LifeAmount$ X
-SVar:X:Count$TypeOnBattlefield.Locus
+SVar:X:Count$Valid Locus
 Oracle:When Glimmerpost enters, you gain 1 life for each Locus on the battlefield.\n{T}: Add {C}.

--- a/forge-gui/res/cardsfolder/g/go_shintai_of_ancient_wars.txt
+++ b/forge-gui/res/cardsfolder/g/go_shintai_of_ancient_wars.txt
@@ -6,6 +6,6 @@ K:First Strike
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigImmediateTrig | TriggerDescription$ At the beginning of your end step, you may pay {1}. When you do, CARDNAME deals X damage to target player or planeswalker, where X is the number of Shrines you control.
 SVar:TrigImmediateTrig:AB$ ImmediateTrigger | Cost$ 1 | Execute$ TrigDealDamage | SpellDescription$ CARDNAME deals X damage to target player or planeswalker, where X is the number of Shrines you control.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | NumDmg$ X
-SVar:X:Count$TypeYouCtrl.Shrine
+SVar:X:Count$Valid Shrine.YouCtrl
 DeckHints:Type$Shrine
 Oracle:First strike\nAt the beginning of your end step, you may pay {1}. When you do, Go-Shintai of Ancient Wars deals X damage to target player or planeswalker, where X is the number of Shrines you control.

--- a/forge-gui/res/cardsfolder/g/go_shintai_of_boundless_vigor.txt
+++ b/forge-gui/res/cardsfolder/g/go_shintai_of_boundless_vigor.txt
@@ -6,7 +6,7 @@ K:Trample
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigImmediateTrig | TriggerDescription$ At the beginning of your end step, you may pay {1}. When you do, put a +1/+1 counter on target Shrine for each Shrine you control.
 SVar:TrigImmediateTrig:AB$ ImmediateTrigger | Cost$ 1 | Execute$ TrigPutCounter | SpellDescription$ Put a +1/+1 counter on target Shrine for each Shrine you control.
 SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Shrine | TgtPrompt$ Select target Shrine | CounterType$ P1P1 | CounterNum$ X
-SVar:X:Count$TypeYouCtrl.Shrine
+SVar:X:Count$Valid Shrine.YouCtrl
 DeckHas:Ability$Counters
 DeckNeeds:Type$Shrine
 Oracle:Trample\nAt the beginning of your end step, you may pay {1}. When you do, put a +1/+1 counter on target Shrine for each Shrine you control.

--- a/forge-gui/res/cardsfolder/g/go_shintai_of_hidden_cruelty.txt
+++ b/forge-gui/res/cardsfolder/g/go_shintai_of_hidden_cruelty.txt
@@ -6,7 +6,7 @@ K:Deathtouch
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigImmediateTrig | TriggerDescription$ At the beginning of your end step, you may pay {1}. When you do, destroy target creature with toughness X or less, where X is the number of Shrines you control.
 SVar:TrigImmediateTrig:AB$ ImmediateTrigger | Cost$ 1 | Execute$ TrigDestroy | SpellDescription$ Destroy target creature with toughness X or less, where X is the number of Shrines you control.
 SVar:TrigDestroy:DB$ Destroy | ValidTgts$ Creature.toughnessLEX | TgtPrompt$ Select target creature with toughness X or less
-SVar:X:Count$TypeYouCtrl.Shrine
+SVar:X:Count$Valid Shrine.YouCtrl
 DeckHas:Ability$Mill
 DeckHints:Type$Shrine
 Oracle:Deathtouch\nAt the beginning of your end step, you may pay {1}. When you do, destroy target creature with toughness X or less, where X is the number of Shrines you control.

--- a/forge-gui/res/cardsfolder/g/go_shintai_of_lost_wisdom.txt
+++ b/forge-gui/res/cardsfolder/g/go_shintai_of_lost_wisdom.txt
@@ -6,7 +6,7 @@ K:Flying
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigImmediateTrig | TriggerDescription$ At the beginning of your end step, you may pay {1}. When you do, target player mills X cards, where X is the number of Shrines you control. (To mill a card, a player puts the top card of their library into their graveyard.)
 SVar:TrigImmediateTrig:AB$ ImmediateTrigger | Cost$ 1 | Execute$ TrigMill | SpellDescription$ Target player mills X cards, where X is the number of Shrines you control.
 SVar:TrigMill:DB$ Mill | ValidTgts$ Player | NumCards$ X | TgtPrompt$ Select target player
-SVar:X:Count$TypeYouCtrl.Shrine
+SVar:X:Count$Valid Shrine.YouCtrl
 DeckHas:Ability$Mill
 DeckHints:Type$Shrine
 Oracle:Flying\nAt the beginning of your end step, you may pay {1}. When you do, target player mills X cards, where X is the number of Shrines you control. (To mill a card, a player puts the top card of their library into their graveyard.)

--- a/forge-gui/res/cardsfolder/g/go_shintai_of_shared_purpose.txt
+++ b/forge-gui/res/cardsfolder/g/go_shintai_of_shared_purpose.txt
@@ -5,7 +5,7 @@ PT:1/3
 K:Vigilance
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ At the beginning of your end step, you may pay {1}. If you do, create a 1/1 colorless Spirit creature token for each Shrine you control.
 SVar:TrigToken:AB$ Token | Cost$ 1 | TokenAmount$ X | TokenScript$ c_1_1_spirit
-SVar:X:Count$TypeYouCtrl.Shrine
+SVar:X:Count$Valid Shrine.YouCtrl
 DeckHas:Ability$Token & Type$Spirit
 DeckHints:Type$Shrine
 Oracle:Vigilance\nAt the beginning of your end step, you may pay {1}. If you do, create a 1/1 colorless Spirit creature token for each Shrine you control.

--- a/forge-gui/res/cardsfolder/g/goblin_war_strike.txt
+++ b/forge-gui/res/cardsfolder/g/goblin_war_strike.txt
@@ -2,6 +2,6 @@ Name:Goblin War Strike
 ManaCost:R
 Types:Sorcery
 A:SP$ DealDamage | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | NumDmg$ X | SpellDescription$ CARDNAME deals damage to target player or planeswalker equal to the number of Goblins you control.
-SVar:X:Count$TypeYouCtrl.Goblin
+SVar:X:Count$Valid Goblin.YouCtrl
 AI:RemoveDeck:Random
 Oracle:Goblin War Strike deals damage to target player or planeswalker equal to the number of Goblins you control.

--- a/forge-gui/res/cardsfolder/g/ground_assault.txt
+++ b/forge-gui/res/cardsfolder/g/ground_assault.txt
@@ -2,5 +2,5 @@ Name:Ground Assault
 ManaCost:R G
 Types:Sorcery
 A:SP$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SpellDescription$ CARDNAME deals damage equal to the number of lands you control to target creature.
-SVar:X:Count$TypeYouCtrl.Land
+SVar:X:Count$Valid Land.YouCtrl
 Oracle:Ground Assault deals damage to target creature equal to the number of lands you control.

--- a/forge-gui/res/cardsfolder/h/harpoon_sniper.txt
+++ b/forge-gui/res/cardsfolder/h/harpoon_sniper.txt
@@ -3,5 +3,5 @@ ManaCost:2 W
 Types:Creature Merfolk Archer
 PT:2/2
 A:AB$ DealDamage | Cost$ W T | ValidTgts$ Creature.attacking,Creature.blocking | TgtPrompt$ Select target attacking or blocking creature | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to target attacking or blocking creature, where X is the number of Merfolk you control.
-SVar:X:Count$TypeYouCtrl.Merfolk
+SVar:X:Count$Valid Merfolk.YouCtrl
 Oracle:{W}, {T}: Harpoon Sniper deals X damage to target attacking or blocking creature, where X is the number of Merfolk you control.

--- a/forge-gui/res/cardsfolder/h/hellkite_igniter.txt
+++ b/forge-gui/res/cardsfolder/h/hellkite_igniter.txt
@@ -5,6 +5,6 @@ PT:5/5
 K:Flying
 K:Haste
 A:AB$ Pump | Cost$ 1 R | Defined$ Self | NumAtt$ +X | SpellDescription$ CARDNAME gets +X/+0 until end of turn, where X is the number of artifacts you control.
-SVar:X:Count$TypeYouCtrl.Artifact
+SVar:X:Count$Valid Artifact.YouCtrl
 DeckHints:Type$Artifact
 Oracle:Flying, haste\n{1}{R}: Hellkite Igniter gets +X/+0 until end of turn, where X is the number of artifacts you control.

--- a/forge-gui/res/cardsfolder/h/honden_of_cleansing_fire.txt
+++ b/forge-gui/res/cardsfolder/h/honden_of_cleansing_fire.txt
@@ -3,6 +3,6 @@ ManaCost:3 W
 Types:Legendary Enchantment Shrine
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigGainLife | TriggerDescription$ At the beginning of your upkeep, you gain 2 life for each Shrine you control.
 SVar:TrigGainLife:DB$ GainLife | Defined$ You | LifeAmount$ X
-SVar:X:Count$TypeYouCtrl.Shrine/Times.2
+SVar:X:Count$Valid Shrine.YouCtrl/Times.2
 DeckHints:Type$Shrine
 Oracle:At the beginning of your upkeep, you gain 2 life for each Shrine you control.

--- a/forge-gui/res/cardsfolder/h/honden_of_infinite_rage.txt
+++ b/forge-gui/res/cardsfolder/h/honden_of_infinite_rage.txt
@@ -3,6 +3,6 @@ ManaCost:2 R
 Types:Legendary Enchantment Shrine
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDamage | TriggerDescription$ At the beginning of your upkeep, CARDNAME deals damage to any target equal to the number of Shrines you control.
 SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Any | NumDmg$ X
-SVar:X:Count$TypeYouCtrl.Shrine
+SVar:X:Count$Valid Shrine.YouCtrl
 DeckHints:Type$Shrine
 Oracle:At the beginning of your upkeep, Honden of Infinite Rage deals damage to any target equal to the number of Shrines you control.

--- a/forge-gui/res/cardsfolder/h/honden_of_lifes_web.txt
+++ b/forge-gui/res/cardsfolder/h/honden_of_lifes_web.txt
@@ -3,6 +3,6 @@ ManaCost:4 G
 Types:Legendary Enchantment Shrine
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ At the beginning of your upkeep, create a 1/1 colorless Spirit creature token for each Shrine you control.
 SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ c_1_1_spirit | TokenOwner$ You
-SVar:X:Count$TypeYouCtrl.Shrine
+SVar:X:Count$Valid Shrine.YouCtrl
 DeckHints:Type$Shrine
 Oracle:At the beginning of your upkeep, create a 1/1 colorless Spirit creature token for each Shrine you control.

--- a/forge-gui/res/cardsfolder/h/honden_of_nights_reach.txt
+++ b/forge-gui/res/cardsfolder/h/honden_of_nights_reach.txt
@@ -3,6 +3,6 @@ ManaCost:3 B
 Types:Legendary Enchantment Shrine
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDiscard | TriggerDescription$ At the beginning of your upkeep, target opponent discards a card for each Shrine you control.
 SVar:TrigDiscard:DB$ Discard | ValidTgts$ Opponent | NumCards$ X | Mode$ TgtChoose
-SVar:X:Count$TypeYouCtrl.Shrine
+SVar:X:Count$Valid Shrine.YouCtrl
 DeckHints:Type$Shrine
 Oracle:At the beginning of your upkeep, target opponent discards a card for each Shrine you control.

--- a/forge-gui/res/cardsfolder/h/honden_of_seeing_winds.txt
+++ b/forge-gui/res/cardsfolder/h/honden_of_seeing_winds.txt
@@ -3,6 +3,6 @@ ManaCost:4 U
 Types:Legendary Enchantment Shrine
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ At the beginning of your upkeep, draw a card for each Shrine you control.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ X
-SVar:X:Count$TypeYouCtrl.Shrine
+SVar:X:Count$Valid Shrine.YouCtrl
 DeckHints:Type$Shrine
 Oracle:At the beginning of your upkeep, draw a card for each Shrine you control.

--- a/forge-gui/res/cardsfolder/h/howl_of_the_night_pack.txt
+++ b/forge-gui/res/cardsfolder/h/howl_of_the_night_pack.txt
@@ -2,5 +2,5 @@ Name:Howl of the Night Pack
 ManaCost:6 G
 Types:Sorcery
 A:SP$ Token | TokenAmount$ X | TokenScript$ g_2_2_wolf | TokenOwner$ You | SpellDescription$ Create a 2/2 green Wolf creature token for each Forest you control.
-SVar:X:Count$TypeYouCtrl.Forest
+SVar:X:Count$Valid Forest.YouCtrl
 Oracle:Create a 2/2 green Wolf creature token for each Forest you control.

--- a/forge-gui/res/cardsfolder/h/hunger_of_the_nim.txt
+++ b/forge-gui/res/cardsfolder/h/hunger_of_the_nim.txt
@@ -2,6 +2,6 @@ Name:Hunger of the Nim
 ManaCost:1 B
 Types:Sorcery
 A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | SpellDescription$ Target creature gets +1/+0 until end of turn for each artifact you control.
-SVar:X:Count$TypeYouCtrl.Artifact
+SVar:X:Count$Valid Artifact.YouCtrl
 AI:RemoveDeck:Random
 Oracle:Target creature gets +1/+0 until end of turn for each artifact you control.

--- a/forge-gui/res/cardsfolder/i/information_dealer.txt
+++ b/forge-gui/res/cardsfolder/i/information_dealer.txt
@@ -3,5 +3,5 @@ ManaCost:1 U
 Types:Creature Human Wizard
 PT:1/1
 A:AB$ RearrangeTopOfLibrary | Cost$ T | Defined$ You | NumCards$ X | SpellDescription$ Look at the top X cards of your library, where X is the number of Wizards on the battlefield, then put them back in any order.
-SVar:X:Count$TypeOnBattlefield.Wizard
+SVar:X:Count$Valid Wizard
 Oracle:{T}: Look at the top X cards of your library, where X is the number of Wizards on the battlefield, then put them back in any order.

--- a/forge-gui/res/cardsfolder/i/invigorating_falls.txt
+++ b/forge-gui/res/cardsfolder/i/invigorating_falls.txt
@@ -2,5 +2,5 @@ Name:Invigorating Falls
 ManaCost:2 G G
 Types:Sorcery
 A:SP$ GainLife | LifeAmount$ X | SpellDescription$ You gain life equal to the number of creature cards in all graveyards.
-SVar:X:Count$TypeInAllYards.Creature
+SVar:X:Count$ValidGraveyard Creature
 Oracle:You gain life equal to the number of creature cards in all graveyards.

--- a/forge-gui/res/cardsfolder/i/ixidors_will.txt
+++ b/forge-gui/res/cardsfolder/i/ixidors_will.txt
@@ -2,6 +2,6 @@ Name:Ixidor's Will
 ManaCost:2 U
 Types:Instant
 A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | UnlessCost$ Y | SpellDescription$ Counter target spell unless its controller pays {2} for each Wizard on the battlefield.
-SVar:Y:Count$TypeYouCtrl.Wizard/Twice
+SVar:Y:Count$Valid Wizard.YouCtrl/Twice
 AI:RemoveDeck:Random
 Oracle:Counter target spell unless its controller pays {2} for each Wizard on the battlefield.

--- a/forge-gui/res/cardsfolder/j/jiang_yanggu.txt
+++ b/forge-gui/res/cardsfolder/j/jiang_yanggu.txt
@@ -5,5 +5,5 @@ Loyalty:4
 A:AB$ Pump | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +2 | NumDef$ +2 | SpellDescription$ Target creature gets +2/+2 until end of turn.
 A:AB$ Token | Cost$ SubCounter<1/LOYALTY> | Planeswalker$ True | TokenAmount$ 1 | TokenScript$ mowu | TokenOwner$ You | SpellDescription$ If you don't control a creature named Mowu, create Mowu, a legendary 3/3 green Dog creature token. | ConditionPresent$ Creature.YouCtrl+namedMowu | ConditionCompare$ EQ0
 A:AB$ Pump | Cost$ SubCounter<5/LOYALTY> | Planeswalker$ True | Ultimate$ True | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | NumDef$ +X | KW$ Trample | SpellDescription$ Until end of turn, target creature gains trample and gets +X/+X, where X is the number of lands you control.
-SVar:X:Count$TypeYouCtrl.Land
+SVar:X:Count$Valid Land.YouCtrl
 Oracle:[+1]: Target creature gets +2/+2 until end of turn.\n[-1]: If you don't control a creature named Mowu, create Mowu, a legendary 3/3 green Dog creature token.\n[-5]: Until end of turn, target creature gains trample and gets +X/+X, where X is the number of lands you control.

--- a/forge-gui/res/cardsfolder/j/joyous_respite.txt
+++ b/forge-gui/res/cardsfolder/j/joyous_respite.txt
@@ -2,5 +2,5 @@ Name:Joyous Respite
 ManaCost:3 G
 Types:Sorcery Arcane
 A:SP$ GainLife | LifeAmount$ X | SpellDescription$ You gain 1 life for each land you control.
-SVar:X:Count$TypeYouCtrl.Land
+SVar:X:Count$Valid Land.YouCtrl
 Oracle:You gain 1 life for each land you control.

--- a/forge-gui/res/cardsfolder/k/kolaghan_forerunners.txt
+++ b/forge-gui/res/cardsfolder/k/kolaghan_forerunners.txt
@@ -5,6 +5,6 @@ PT:*/3
 K:Trample
 K:Dash:2 R
 S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | Description$ CARDNAME's power is equal to the number of creatures you control.
-SVar:X:Count$TypeYouCtrl.Creature
+SVar:X:Count$Valid Creature.YouCtrl
 SVar:BuffedBy:Creature
 Oracle:Trample\nKolaghan Forerunners's power is equal to the number of creatures you control.\nDash {2}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)

--- a/forge-gui/res/cardsfolder/k/kraken_of_the_straits.txt
+++ b/forge-gui/res/cardsfolder/k/kraken_of_the_straits.txt
@@ -3,6 +3,6 @@ ManaCost:5 U U
 Types:Creature Kraken
 PT:6/6
 S:Mode$ CantBlockBy | ValidAttacker$ Creature.Self | ValidBlocker$ Creature.powerLEX | Description$ Creatures with power less than the number of Islands you control can't block CARDNAME.
-SVar:X:Count$TypeYouCtrl.Island
+SVar:X:Count$Valid Island.YouCtrl
 SVar:BuffedBy:Island
 Oracle:Creatures with power less than the number of Islands you control can't block Kraken of the Straits.

--- a/forge-gui/res/cardsfolder/k/krenko_mob_boss.txt
+++ b/forge-gui/res/cardsfolder/k/krenko_mob_boss.txt
@@ -3,6 +3,6 @@ ManaCost:2 R R
 Types:Legendary Creature Goblin Warrior
 PT:3/3
 A:AB$ Token | Cost$ T | TokenAmount$ X | TokenScript$ r_1_1_goblin | TokenOwner$ You | SpellDescription$ Create X 1/1 red Goblin creature tokens, where X is the number of Goblins you control.
-SVar:X:Count$TypeYouCtrl.Goblin
+SVar:X:Count$Valid Goblin.YouCtrl
 DeckHints:Type$Goblin
 Oracle:{T}: Create X 1/1 red Goblin creature tokens, where X is the number of Goblins you control.

--- a/forge-gui/res/cardsfolder/l/landbind_ritual.txt
+++ b/forge-gui/res/cardsfolder/l/landbind_ritual.txt
@@ -2,5 +2,5 @@ Name:Landbind Ritual
 ManaCost:3 W W
 Types:Sorcery
 A:SP$ GainLife | LifeAmount$ X | SpellDescription$ You gain 2 life for each Plains you control.
-SVar:X:Count$TypeYouCtrl.Plains/Times.2
+SVar:X:Count$Valid Plains.YouCtrl/Times.2
 Oracle:You gain 2 life for each Plains you control.

--- a/forge-gui/res/cardsfolder/l/lantern_flare.txt
+++ b/forge-gui/res/cardsfolder/l/lantern_flare.txt
@@ -6,6 +6,6 @@ SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ Y
 A:SP$ DealDamage | Cost$ X R W | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ X | PrecostDesc$ Cleave | SubAbility$ DBGainLifeC | CostDesc$ {X}{R}{W} | NonBasicSpell$ True | SpellDescription$ (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)
 SVar:DBGainLifeC:DB$ GainLife | Defined$ You | LifeAmount$ X
 SVar:X:Count$xPaid
-SVar:Y:Count$TypeYouCtrl.Creature
+SVar:Y:Count$Valid Creature.YouCtrl
 DeckHas:Ability$LifeGain
 Oracle:Cleave {X}{R}{W} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nLantern Flare deals X damage to target creature or planeswalker and you gain X life. [X is the number of creatures you control.]

--- a/forge-gui/res/cardsfolder/l/last_stand.txt
+++ b/forge-gui/res/cardsfolder/l/last_stand.txt
@@ -7,10 +7,10 @@ SVar:DBTokenForest:DB$ Token | TokenAmount$ ForestsYouControl | TokenScript$ g_1
 SVar:DBGainLifePlains:DB$ GainLife | Defined$ You | LifeAmount$ PlainsYouControl | SubAbility$ DBDrawCardIsland
 SVar:DBDrawCardIsland:DB$ Draw | Defined$ You | NumCards$ IslandsYouControl | SubAbility$ DBDiscardJustAsMany
 SVar:DBDiscardJustAsMany:DB$ Discard | Defined$ You | NumCards$ IslandsYouControl | Mode$ TgtChoose
-SVar:SwampsYouControl:Count$TypeYouCtrl.Swamp/Times.2
-SVar:MountainsYouControl:Count$TypeYouCtrl.Mountain
-SVar:ForestsYouControl:Count$TypeYouCtrl.Forest
-SVar:PlainsYouControl:Count$TypeYouCtrl.Plains/Times.2
-SVar:IslandsYouControl:Count$TypeYouCtrl.Island
+SVar:SwampsYouControl:Count$Valid Swamp.YouCtrl/Times.2
+SVar:MountainsYouControl:Count$Valid Mountain.YouCtrl
+SVar:ForestsYouControl:Count$Valid Forest.YouCtrl
+SVar:PlainsYouControl:Count$Valid Plains.YouCtrl/Times.2
+SVar:IslandsYouControl:Count$Valid Island.YouCtrl
 AI:RemoveDeck:Random
 Oracle:Target opponent loses 2 life for each Swamp you control. Last Stand deals damage to target creature equal to the number of Mountains you control. Create a 1/1 green Saproling creature token for each Forest you control. You gain 2 life for each Plains you control. Draw a card for each Island you control, then discard that many cards.

--- a/forge-gui/res/cardsfolder/l/leyline_invocation.txt
+++ b/forge-gui/res/cardsfolder/l/leyline_invocation.txt
@@ -4,7 +4,7 @@ Types:Sorcery
 A:SP$ Token | TokenScript$ gu_0_0_fractal | RememberTokens$ True | SpellDescription$ Create a 0/0 green and blue Fractal creature token. Put X +1/+1 counters on it, where X is the number of lands you control. | SubAbility$ DBCounters
 SVar:DBCounters:DB$ PutCounter | Defined$ Remembered | CounterType$ P1P1 | CounterNum$ X | StackDescription$ None | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-SVar:X:Count$TypeYouCtrl.Land
+SVar:X:Count$Valid Land.YouCtrl
 DeckHas:Ability$Token|Counters
 DeckHints:Type$Instant|Sorcery
 Oracle:Create a 0/0 green and blue Fractal creature token. Put X +1/+1 counters on it, where X is the number of lands you control.

--- a/forge-gui/res/cardsfolder/l/lhurgoyf.txt
+++ b/forge-gui/res/cardsfolder/l/lhurgoyf.txt
@@ -3,6 +3,6 @@ ManaCost:2 G G
 Types:Creature Lhurgoyf
 PT:*/1+*
 S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ Y | Description$ CARDNAME's power is equal to the number of creature cards in all graveyards and its toughness is equal to that number plus 1.
-SVar:X:Count$TypeInAllYards.Creature
-SVar:Y:Count$TypeInAllYards.Creature/Plus.1
+SVar:X:Count$ValidGraveyard Creature
+SVar:Y:Count$ValidGraveyard Creature/Plus.1
 Oracle:Lhurgoyf's power is equal to the number of creature cards in all graveyards and its toughness is equal to that number plus 1.

--- a/forge-gui/res/cardsfolder/l/loaming_shaman.txt
+++ b/forge-gui/res/cardsfolder/l/loaming_shaman.txt
@@ -5,5 +5,5 @@ PT:3/2
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ When CARDNAME enters, target player shuffles any number of target cards from their graveyard into their library.
 SVar:TrigPump:DB$ Pump | ValidTgts$ Player | SubAbility$ DBChangeZone | IsCurse$ True
 SVar:DBChangeZone:DB$ ChangeZone | TargetMin$ 0 | TargetMax$ X | TargetsWithDefinedController$ ParentTarget | Origin$ Graveyard | Destination$ Library | Shuffle$ True | TgtPrompt$ Choose target card | ValidTgts$ Card
-SVar:X:Count$InAllYards
+SVar:X:Count$ValidGraveyard Card.OwnedBy TargetedPlayer
 Oracle:When Loaming Shaman enters, target player shuffles any number of target cards from their graveyard into their library.

--- a/forge-gui/res/cardsfolder/l/lord_of_extinction.txt
+++ b/forge-gui/res/cardsfolder/l/lord_of_extinction.txt
@@ -3,6 +3,6 @@ ManaCost:3 B G
 Types:Creature Elemental
 PT:*/*
 S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of cards in all graveyards.
-SVar:X:Count$InAllYards
+SVar:X:Count$ValidGraveyard Card
 SVar:NeedsToPlayVar:X GE4
 Oracle:Lord of Extinction's power and toughness are each equal to the number of cards in all graveyards.

--- a/forge-gui/res/cardsfolder/m/magnivore.txt
+++ b/forge-gui/res/cardsfolder/m/magnivore.txt
@@ -4,7 +4,7 @@ Types:Creature Lhurgoyf
 PT:*/*
 K:Haste
 S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of sorcery cards in all graveyards.
-SVar:X:Count$TypeInAllYards.Sorcery
+SVar:X:Count$ValidGraveyard Sorcery
 SVar:NeedsToPlayVar:X GE2
 AI:RemoveDeck:Random
 Oracle:Haste (This creature can attack and {T} as soon as it comes under your control.)\nMagnivore's power and toughness are each equal to the number of sorcery cards in all graveyards.

--- a/forge-gui/res/cardsfolder/m/marrow_gnawer.txt
+++ b/forge-gui/res/cardsfolder/m/marrow_gnawer.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature Rat Rogue
 PT:2/3
 S:Mode$ Continuous | Affected$ Rat | AddKeyword$ Fear | Description$ All Rats have fear.
 A:AB$ Token | Cost$ T Sac<1/Rat> | TokenAmount$ X | TokenScript$ b_1_1_rat | TokenOwner$ You | SpellDescription$ Create X 1/1 black Rat creature tokens, where X is the number of Rats you control.
-SVar:X:Count$TypeYouCtrl.Rat
+SVar:X:Count$Valid Rat.YouCtrl
 SVar:AIPreference:SacCost$Creature.Rat+token,Creature.Rat+cmcLE3
 AI:RemoveDeck:Random
 DeckHints:Type$Rat

--- a/forge-gui/res/cardsfolder/m/mass_appeal.txt
+++ b/forge-gui/res/cardsfolder/m/mass_appeal.txt
@@ -2,6 +2,6 @@ Name:Mass Appeal
 ManaCost:2 U
 Types:Sorcery
 A:SP$ Draw | NumCards$ X | SpellDescription$ Draw a card for each Human you control.
-SVar:X:Count$TypeYouCtrl.Human
+SVar:X:Count$Valid Human.YouCtrl
 AI:RemoveDeck:Random
 Oracle:Draw a card for each Human you control.

--- a/forge-gui/res/cardsfolder/m/might_of_the_masses.txt
+++ b/forge-gui/res/cardsfolder/m/might_of_the_masses.txt
@@ -2,5 +2,5 @@ Name:Might of the Masses
 ManaCost:G
 Types:Instant
 A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | NumDef$ +X | SpellDescription$ Target creature gets +1/+1 until end of turn for each creature you control.
-SVar:X:Count$TypeYouCtrl.Creature
+SVar:X:Count$Valid Creature.YouCtrl
 Oracle:Target creature gets +1/+1 until end of turn for each creature you control.

--- a/forge-gui/res/cardsfolder/m/mind_sludge.txt
+++ b/forge-gui/res/cardsfolder/m/mind_sludge.txt
@@ -2,5 +2,5 @@ Name:Mind Sludge
 ManaCost:4 B
 Types:Sorcery
 A:SP$ Discard | ValidTgts$ Player | NumCards$ X | Mode$ TgtChoose | SpellDescription$ Target player discards a card for each Swamp you control.
-SVar:X:Count$TypeYouCtrl.Swamp
+SVar:X:Count$Valid Swamp.YouCtrl
 Oracle:Target player discards a card for each Swamp you control.

--- a/forge-gui/res/cardsfolder/m/minions_murmurs.txt
+++ b/forge-gui/res/cardsfolder/m/minions_murmurs.txt
@@ -3,6 +3,6 @@ ManaCost:2 B B
 Types:Sorcery
 A:SP$ Draw | NumCards$ X | SpellDescription$ You draw X cards and you lose X life, where X is the number of creatures you control. | SubAbility$ DB1
 SVar:DB1:DB$ LoseLife | LifeAmount$ X
-SVar:X:Count$TypeYouCtrl.Creature
+SVar:X:Count$Valid Creature.YouCtrl
 AI:RemoveDeck:All
 Oracle:You draw X cards and you lose X life, where X is the number of creatures you control.

--- a/forge-gui/res/cardsfolder/m/mires_toll.txt
+++ b/forge-gui/res/cardsfolder/m/mires_toll.txt
@@ -2,5 +2,5 @@ Name:Mire's Toll
 ManaCost:B
 Types:Sorcery
 A:SP$ Discard | ValidTgts$ Player | Mode$ RevealYouChoose | RevealNumber$ X | NumCards$ 1 | SpellDescription$ Target player reveals a number of cards from their hand equal to the number of Swamps you control. You choose one of them. That player discards that card.
-SVar:X:Count$TypeYouCtrl.Swamp
+SVar:X:Count$Valid Swamp.YouCtrl
 Oracle:Target player reveals a number of cards from their hand equal to the number of Swamps you control. You choose one of them. That player discards that card.

--- a/forge-gui/res/cardsfolder/m/mob_justice.txt
+++ b/forge-gui/res/cardsfolder/m/mob_justice.txt
@@ -2,5 +2,5 @@ Name:Mob Justice
 ManaCost:1 R
 Types:Sorcery
 A:SP$ DealDamage | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | NumDmg$ X | SpellDescription$ CARDNAME deals damage to target player or planeswalker equal to the number of creatures you control.
-SVar:X:Count$TypeYouCtrl.Creature
+SVar:X:Count$Valid Creature.YouCtrl
 Oracle:Mob Justice deals damage to target player or planeswalker equal to the number of creatures you control.

--- a/forge-gui/res/cardsfolder/m/mortivore.txt
+++ b/forge-gui/res/cardsfolder/m/mortivore.txt
@@ -3,7 +3,7 @@ ManaCost:2 B B
 Types:Creature Lhurgoyf
 PT:*/*
 S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of creature cards in all graveyards.
-SVar:X:Count$TypeInAllYards.Creature
+SVar:X:Count$ValidGraveyard Creature
 A:AB$ Regenerate | Cost$ B | SpellDescription$ Regenerate CARDNAME.
 SVar:NeedsToPlayVar:X GE2
 Oracle:Mortivore's power and toughness are each equal to the number of creature cards in all graveyards.\n{B}: Regenerate Mortivore.

--- a/forge-gui/res/cardsfolder/m/munitions_expert.txt
+++ b/forge-gui/res/cardsfolder/m/munitions_expert.txt
@@ -5,6 +5,6 @@ PT:1/1
 K:Flash
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDamage | OptionalDecider$ You | TriggerDescription$ When CARDNAME enters, you may have it deal damage to target creature or planeswalker equal to the number of Goblins you control.
 SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ X
-SVar:X:Count$TypeYouCtrl.Goblin
+SVar:X:Count$Valid Goblin.YouCtrl
 DeckHints:Type$Goblin
 Oracle:Flash\nWhen Munitions Expert enters, you may have it deal damage to target creature or planeswalker equal to the number of Goblins you control.

--- a/forge-gui/res/cardsfolder/n/necrogoyf.txt
+++ b/forge-gui/res/cardsfolder/n/necrogoyf.txt
@@ -6,6 +6,6 @@ S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | Description$ C
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | TriggerZones$ Battlefield | Execute$ TrigDiscard | TriggerDescription$ At the beginning of each player's upkeep, that player discards a card.
 SVar:TrigDiscard:DB$ Discard | Defined$ TriggeredPlayer | NumCards$ 1 | Mode$ TgtChoose
 K:Madness:1 B B
-SVar:X:Count$TypeInAllYards.Creature
+SVar:X:Count$ValidGraveyard Creature
 DeckHas:Ability$Discard
 Oracle:Necrogoyf's power is equal to the number of creature cards in all graveyards.\nAt the beginning of each player's upkeep, that player discards a card.\nMadness {1}{B}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)

--- a/forge-gui/res/cardsfolder/n/nighthowler.txt
+++ b/forge-gui/res/cardsfolder/n/nighthowler.txt
@@ -4,5 +4,5 @@ Types:Enchantment Creature Horror
 PT:0/0
 K:Bestow:2 B B
 S:Mode$ Continuous | Affected$ Card.Self,Card.EnchantedBy | AddPower$ X | AddToughness$ X | Description$ CARDNAME and enchanted creature each get +X/+X, where X is the number of creature cards in all graveyards.
-SVar:X:Count$TypeInAllYards.Creature
+SVar:X:Count$ValidGraveyard Creature
 Oracle:Bestow {2}{B}{B} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nNighthowler and enchanted creature each get +X/+X, where X is the number of creature cards in all graveyards.

--- a/forge-gui/res/cardsfolder/n/nissa_revane.txt
+++ b/forge-gui/res/cardsfolder/n/nissa_revane.txt
@@ -5,7 +5,7 @@ Loyalty:2
 A:AB$ ChangeZone | Cost$ AddCounter<1/LOYALTY> | Origin$ Library | Destination$ Battlefield | ChangeType$ Permanent.namedNissa's Chosen | ChangeNum$ 1 | Planeswalker$ True | StackDescription$ SpellDescription | SpellDescription$ Search your library for a card named Nissa's Chosen, put it onto the battlefield, then shuffle.
 A:AB$ GainLife | Cost$ AddCounter<1/LOYALTY> | LifeAmount$ XLife | Planeswalker$ True | SpellDescription$ You gain 2 life for each Elf you control.
 A:AB$ ChangeZone | Cost$ SubCounter<7/LOYALTY> | Origin$ Library | Destination$ Battlefield | ChangeType$ Creature.Elf | ChangeNum$ XFetch | Planeswalker$ True | Ultimate$ True | StackDescription$ SpellDescription | SpellDescription$ Search your library for any number of Elf creature cards, put them onto the battlefield, then shuffle.
-SVar:XLife:Count$TypeYouCtrl.Elf/Times.2
+SVar:XLife:Count$Valid Elf.YouCtrl/Times.2
 SVar:XFetch:Count$ValidLibrary Creature.Elf+YouCtrl
 AI:RemoveDeck:Random
 DeckHints:Type$Elf & Name$Nissa's Chosen

--- a/forge-gui/res/cardsfolder/p/peach_garden_oath.txt
+++ b/forge-gui/res/cardsfolder/p/peach_garden_oath.txt
@@ -2,5 +2,5 @@ Name:Peach Garden Oath
 ManaCost:W
 Types:Sorcery
 A:SP$ GainLife | LifeAmount$ X | SpellDescription$ You gain 2 life for each creature you control.
-SVar:X:Count$TypeYouCtrl.Creature/Times.2
+SVar:X:Count$Valid Creature.YouCtrl/Times.2
 Oracle:You gain 2 life for each creature you control.

--- a/forge-gui/res/cardsfolder/p/primal_bellow.txt
+++ b/forge-gui/res/cardsfolder/p/primal_bellow.txt
@@ -2,5 +2,5 @@ Name:Primal Bellow
 ManaCost:G
 Types:Instant
 A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | NumDef$ +X | SpellDescription$ Target creature gets +1/+1 until end of turn for each Forest you control.
-SVar:X:Count$TypeYouCtrl.Forest
+SVar:X:Count$Valid Forest.YouCtrl
 Oracle:Target creature gets +1/+1 until end of turn for each Forest you control.

--- a/forge-gui/res/cardsfolder/p/profane_prayers.txt
+++ b/forge-gui/res/cardsfolder/p/profane_prayers.txt
@@ -3,6 +3,6 @@ ManaCost:2 B B
 Types:Sorcery
 A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ X | SubAbility$ DBGainLife | SpellDescription$ CARDNAME deals X damage to any target and you gain X life, where X is the number of Clerics on the battlefield.
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ X
-SVar:X:Count$TypeOnBattlefield.Cleric
+SVar:X:Count$Valid Cleric
 AI:RemoveDeck:Random
 Oracle:Profane Prayers deals X damage to any target and you gain X life, where X is the number of Clerics on the battlefield.

--- a/forge-gui/res/cardsfolder/r/radha_heart_of_keld.txt
+++ b/forge-gui/res/cardsfolder/r/radha_heart_of_keld.txt
@@ -6,6 +6,6 @@ S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ First Strike | Condition$
 S:Mode$ Continuous | Affected$ Card.TopLibrary+YouCtrl | AffectedZone$ Library | MayLookAt$ You | Description$ You may look at the top card of your library any time, and you may play lands from the top of your library.
 S:Mode$ Continuous | Affected$ Land.TopLibrary+YouCtrl | AffectedZone$ Library | MayPlay$ True | Secondary$ True | Description$ You may look at the top card of your library any time, and you may play lands from the top of your library.
 A:AB$ Pump | Cost$ 4 R G | Defined$ Self | NumAtt$ +X | NumDef$ +X | SpellDescription$ NICKNAME gets +X/+X until end of turn, where X is the number of lands you control.
-SVar:X:Count$TypeYouCtrl.Land
+SVar:X:Count$Valid Land.YouCtrl
 SVar:BuffedBy:Land
 Oracle:During your turn, Radha, Heart of Keld has first strike.\nYou may look at the top card of your library any time, and you may play lands from the top of your library.\n{4}{R}{G}: Radha gets +X/+X until end of turn, where X is the number of lands you control.

--- a/forge-gui/res/cardsfolder/r/reclusive_artificer.txt
+++ b/forge-gui/res/cardsfolder/r/reclusive_artificer.txt
@@ -5,6 +5,6 @@ PT:2/3
 K:Haste
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDamage | OptionalDecider$ You | TriggerDescription$ When CARDNAME enters, you may have it deal damage to target creature equal to the number of artifacts you control.
 SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X
-SVar:X:Count$TypeYouCtrl.Artifact
+SVar:X:Count$Valid Artifact.YouCtrl
 SVar:PlayMain1:TRUE
 Oracle:Haste (This creature can attack and {T} as soon as it comes under your control.)\nWhen Reclusive Artificer enters, you may have it deal damage to target creature equal to the number of artifacts you control.

--- a/forge-gui/res/cardsfolder/r/renewing_dawn.txt
+++ b/forge-gui/res/cardsfolder/r/renewing_dawn.txt
@@ -1,7 +1,7 @@
 Name:Renewing Dawn
 ManaCost:1 W
 Types:Sorcery
-A:SP$ GainLife | LifeAmount$ X | SpellDescription$ You gain 2 life for each Mountain target opponent controls.
-SVar:X:Count$TypeOppCtrl.Mountain/Times.2
+A:SP$ GainLife | ValidTgts$ Opponent | Defined$ You | LifeAmount$ X | SpellDescription$ You gain 2 life for each Mountain target opponent controls.
+SVar:X:Count$Valid Mountain.TargetedPlayerCtrl/Times.2
 AI:RemoveDeck:Random
 Oracle:You gain 2 life for each Mountain target opponent controls.

--- a/forge-gui/res/cardsfolder/r/ribbons_of_the_reikai.txt
+++ b/forge-gui/res/cardsfolder/r/ribbons_of_the_reikai.txt
@@ -2,6 +2,6 @@ Name:Ribbons of the Reikai
 ManaCost:4 U
 Types:Sorcery Arcane
 A:SP$ Draw | NumCards$ X | SpellDescription$ Draw a card for each Spirit you control.
-SVar:X:Count$TypeYouCtrl.Spirit
+SVar:X:Count$Valid Spirit.YouCtrl
 AI:RemoveDeck:Random
 Oracle:Draw a card for each Spirit you control.

--- a/forge-gui/res/cardsfolder/r/rin_and_seri_inseparable.txt
+++ b/forge-gui/res/cardsfolder/r/rin_and_seri_inseparable.txt
@@ -8,7 +8,7 @@ T:Mode$ SpellCast | ValidCard$ Cat | ValidActivatingPlayer$ You | Execute$ TrigD
 SVar:TrigDogToken:DB$ Token | TokenAmount$ 1 | TokenScript$ w_1_1_dog | TokenOwner$ You
 A:AB$ DealDamage | Cost$ R G W T | ValidTgts$ Any | NumDmg$ X | SubAbility$ DBGainLife | SpellDescription$ CARDNAME deals damage to any target equal to the number of Dogs you control. You gain life equal to the number of Cats you control.
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ Y | Defined$ You
-SVar:X:Count$TypeYouCtrl.Dog
-SVar:Y:Count$TypeYouCtrl.Cat
+SVar:X:Count$Valid Dog.YouCtrl
+SVar:Y:Count$Valid Cat.YouCtrl
 DeckHints:Type$Dog|Cat
 Oracle:Whenever you cast a Dog spell, create a 1/1 green Cat creature token.\nWhenever you cast a Cat spell, create a 1/1 white Dog creature token.\n{R}{G}{W}, {T}: Rin and Seri, Inseparable deals damage to any target equal to the number of Dogs you control. You gain life equal to the number of Cats you control.

--- a/forge-gui/res/cardsfolder/r/riptide_director.txt
+++ b/forge-gui/res/cardsfolder/r/riptide_director.txt
@@ -3,7 +3,7 @@ ManaCost:2 U U
 Types:Creature Human Wizard
 PT:2/3
 A:AB$ Draw | Cost$ 2 U U T | NumCards$ X | SpellDescription$ Draw a card for each Wizard you control.
-SVar:X:Count$TypeYouCtrl.Wizard
+SVar:X:Count$Valid Wizard.YouCtrl
 AI:RemoveDeck:Random
 SVar:NonCombatPriority:3
 Oracle:{2}{U}{U}, {T}: Draw a card for each Wizard you control.

--- a/forge-gui/res/cardsfolder/r/road_ruin.txt
+++ b/forge-gui/res/cardsfolder/r/road_ruin.txt
@@ -12,5 +12,5 @@ ManaCost:1 R R
 Types:Sorcery
 K:Aftermath
 A:SP$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SpellDescription$ CARDNAME deals damage to target creature equal to the number of lands you control.
-SVar:X:Count$TypeYouCtrl.Land
+SVar:X:Count$Valid Land.YouCtrl
 Oracle:Aftermath (Cast this spell only from your graveyard. Then exile it.)\nRuin deals damage to target creature equal to the number of lands you control.

--- a/forge-gui/res/cardsfolder/r/rockslide_ambush.txt
+++ b/forge-gui/res/cardsfolder/r/rockslide_ambush.txt
@@ -2,5 +2,5 @@ Name:Rockslide Ambush
 ManaCost:1 R
 Types:Sorcery
 A:SP$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SpellDescription$ CARDNAME deals damage equal to the number of Mountains you control to target creature.
-SVar:X:Count$TypeYouCtrl.Mountain
+SVar:X:Count$Valid Mountain.YouCtrl
 Oracle:Rockslide Ambush deals damage to target creature equal to the number of Mountains you control.

--- a/forge-gui/res/cardsfolder/s/sanctum_of_calm_waters.txt
+++ b/forge-gui/res/cardsfolder/s/sanctum_of_calm_waters.txt
@@ -3,6 +3,6 @@ ManaCost:3 U
 Types:Legendary Enchantment Shrine
 T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ At the beginning of your first main phase, you may draw X cards, where X is the number of Shrines you control. If you do, discard a card.
 SVar:TrigDraw:AB$ Discard | Defined$ You | Mode$ TgtChoose | NumCards$ 1 | Cost$ Draw<X/You>
-SVar:X:Count$TypeYouCtrl.Shrine
+SVar:X:Count$Valid Shrine.YouCtrl
 DeckHints:Type$Shrine
 Oracle:At the beginning of your first main phase, you may draw X cards, where X is the number of Shrines you control. If you do, discard a card.

--- a/forge-gui/res/cardsfolder/s/sanctum_of_fruitful_harvest.txt
+++ b/forge-gui/res/cardsfolder/s/sanctum_of_fruitful_harvest.txt
@@ -3,6 +3,6 @@ ManaCost:2 G
 Types:Legendary Enchantment Shrine
 T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigMana | TriggerDescription$ At the beginning of your first main phase, add X mana of any one color, where X is the number of Shrines you control.
 SVar:TrigMana:DB$ Mana | Produced$ Any | Amount$ X
-SVar:X:Count$TypeYouCtrl.Shrine
+SVar:X:Count$Valid Shrine.YouCtrl
 DeckHints:Type$Shrine
 Oracle:At the beginning of your first main phase, add X mana of any one color, where X is the number of Shrines you control.

--- a/forge-gui/res/cardsfolder/s/sanctum_of_shattered_heights.txt
+++ b/forge-gui/res/cardsfolder/s/sanctum_of_shattered_heights.txt
@@ -2,6 +2,6 @@ Name:Sanctum of Shattered Heights
 ManaCost:2 R
 Types:Legendary Enchantment Shrine
 A:AB$ DealDamage | Cost$ 1 Discard<1/Land;Shrine/land card or Shrine card> | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to target creature or planeswalker, where X is the number of Shrines you control.
-SVar:X:Count$TypeYouCtrl.Shrine
+SVar:X:Count$Valid Shrine.YouCtrl
 DeckHints:Type$Shrine
 Oracle:{1}, Discard a land card or Shrine card: Sanctum of Shattered Heights deals X damage to target creature or planeswalker, where X is the number of Shrines you control.

--- a/forge-gui/res/cardsfolder/s/sanctum_of_stone_fangs.txt
+++ b/forge-gui/res/cardsfolder/s/sanctum_of_stone_fangs.txt
@@ -4,7 +4,7 @@ Types:Legendary Enchantment Shrine
 T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDrain | TriggerDescription$ At the beginning of your first main phase, each opponent loses X life and you gain X life, where X is the number of Shrines you control.
 SVar:TrigDrain:DB$ LoseLife | Defined$ Player.Opponent | LifeAmount$ X | SubAbility$ DBGainLife
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ X
-SVar:X:Count$TypeYouCtrl.Shrine
+SVar:X:Count$Valid Shrine.YouCtrl
 DeckHints:Type$Shrine
 DeckHas:Ability$LifeGain
 Oracle:At the beginning of your first main phase, each opponent loses X life and you gain X life, where X is the number of Shrines you control.

--- a/forge-gui/res/cardsfolder/s/sanctum_of_tranquil_light.txt
+++ b/forge-gui/res/cardsfolder/s/sanctum_of_tranquil_light.txt
@@ -2,6 +2,6 @@ Name:Sanctum of Tranquil Light
 ManaCost:W
 Types:Legendary Enchantment Shrine
 A:AB$ Tap | Cost$ 5 W | ValidTgts$ Creature | TgtPrompt$ Select target creature | ReduceCost$ X | SpellDescription$ Tap target creature. This ability costs {1} less to activate for each Shrine you control.
-SVar:X:Count$TypeYouCtrl.Shrine
+SVar:X:Count$Valid Shrine.YouCtrl
 DeckHints:Type$Shrine
 Oracle:{5}{W}: Tap target creature. This ability costs {1} less to activate for each Shrine you control.

--- a/forge-gui/res/cardsfolder/s/sea_gate_loremaster.txt
+++ b/forge-gui/res/cardsfolder/s/sea_gate_loremaster.txt
@@ -3,6 +3,6 @@ ManaCost:4 U
 Types:Creature Merfolk Wizard Ally
 PT:1/3
 A:AB$ Draw | Cost$ T | NumCards$ X | SpellDescription$ Draw a card for each Ally you control.
-SVar:X:Count$TypeYouCtrl.Ally
+SVar:X:Count$Valid Ally.YouCtrl
 SVar:BuffedBy:Ally
 Oracle:{T}: Draw a card for each Ally you control.

--- a/forge-gui/res/cardsfolder/s/seismic_strike.txt
+++ b/forge-gui/res/cardsfolder/s/seismic_strike.txt
@@ -2,5 +2,5 @@ Name:Seismic Strike
 ManaCost:2 R
 Types:Instant
 A:SP$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SpellDescription$ CARDNAME deals damage to target creature equal to the number of Mountains you control.
-SVar:X:Count$TypeYouCtrl.Mountain
+SVar:X:Count$Valid Mountain.YouCtrl
 Oracle:Seismic Strike deals damage to target creature equal to the number of Mountains you control.

--- a/forge-gui/res/cardsfolder/s/shamanic_revelation.txt
+++ b/forge-gui/res/cardsfolder/s/shamanic_revelation.txt
@@ -2,7 +2,7 @@ Name:Shamanic Revelation
 ManaCost:3 G G
 Types:Sorcery
 A:SP$ Draw | NumCards$ X | SubAbility$ DBGainLife | SpellDescription$ Draw a card for each creature you control. Ferocious — You gain 4 life for each creature you control with power 4 or greater.
-SVar:X:Count$TypeYouCtrl.Creature
+SVar:X:Count$Valid Creature.YouCtrl
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ Y
 SVar:Y:Count$Valid Creature.YouCtrl+powerGE4/Times.4
 Oracle:Draw a card for each creature you control.\nFerocious — You gain 4 life for each creature you control with power 4 or greater.

--- a/forge-gui/res/cardsfolder/s/shepherd_of_rot.txt
+++ b/forge-gui/res/cardsfolder/s/shepherd_of_rot.txt
@@ -3,6 +3,6 @@ ManaCost:1 B
 Types:Creature Zombie Cleric
 PT:1/1
 A:AB$ LoseLife | Cost$ T | Defined$ Player | LifeAmount$ X | SpellDescription$ Each player loses 1 life for each Zombie on the battlefield.
-SVar:X:Count$TypeOnBattlefield.Zombie
+SVar:X:Count$Valid Zombie
 AI:RemoveDeck:Random
 Oracle:{T}: Each player loses 1 life for each Zombie on the battlefield.

--- a/forge-gui/res/cardsfolder/s/skred.txt
+++ b/forge-gui/res/cardsfolder/s/skred.txt
@@ -2,6 +2,6 @@ Name:Skred
 ManaCost:R
 Types:Instant
 A:SP$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SpellDescription$ CARDNAME deals damage to target creature equal to the number of snow permanents you control.
-SVar:X:Count$TypeYouCtrl.Snow
+SVar:X:Count$Valid Snow.YouCtrl
 AI:RemoveDeck:Random
 Oracle:Skred deals damage to target creature equal to the number of snow permanents you control.

--- a/forge-gui/res/cardsfolder/s/slag_fiend.txt
+++ b/forge-gui/res/cardsfolder/s/slag_fiend.txt
@@ -3,7 +3,7 @@ ManaCost:R
 Types:Creature Phyrexian Construct
 PT:*/*
 S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of artifact cards in all graveyards.
-SVar:X:Count$TypeInAllYards.Artifact
+SVar:X:Count$ValidGraveyard Artifact
 AI:RemoveDeck:Random
 SVar:NeedsToPlayVar:X GE1
 Oracle:Slag Fiend's power and toughness are each equal to the number of artifact cards in all graveyards.

--- a/forge-gui/res/cardsfolder/s/slate_of_ancestry.txt
+++ b/forge-gui/res/cardsfolder/s/slate_of_ancestry.txt
@@ -2,6 +2,6 @@ Name:Slate of Ancestry
 ManaCost:4
 Types:Artifact
 A:AB$ Draw | Cost$ 4 T Discard<1/Hand> | NumCards$ X | SpellDescription$ Draw a card for each creature you control.
-SVar:X:Count$TypeYouCtrl.Creature
+SVar:X:Count$Valid Creature.YouCtrl
 AI:RemoveDeck:All
 Oracle:{4}, {T}, Discard your hand: Draw a card for each creature you control.

--- a/forge-gui/res/cardsfolder/s/soulless_one.txt
+++ b/forge-gui/res/cardsfolder/s/soulless_one.txt
@@ -3,8 +3,8 @@ ManaCost:3 B
 Types:Creature Zombie Avatar
 PT:*/*
 S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of Zombies on the battlefield plus the number of Zombie cards in all graveyards.
-SVar:X:Count$TypeOnBattlefield.Zombie/Plus.Y
-SVar:Y:Count$TypeInAllYards.Zombie
+SVar:X:Count$Valid Zombie/Plus.Y
+SVar:Y:Count$ValidGraveyard Zombie
 AI:RemoveDeck:Random
 SVar:NoZeroToughnessAI:True
 Oracle:Soulless One's power and toughness are each equal to the number of Zombies on the battlefield plus the number of Zombie cards in all graveyards.

--- a/forge-gui/res/cardsfolder/s/sparksmith.txt
+++ b/forge-gui/res/cardsfolder/s/sparksmith.txt
@@ -4,6 +4,6 @@ Types:Creature Goblin
 PT:1/1
 A:AB$ DealDamage | Cost$ T | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SubAbility$ DBDealDamage | SpellDescription$ CARDNAME deals X damage to target creature and X damage to you, where X is the number of Goblins on the battlefield.
 SVar:DBDealDamage:DB$ DealDamage | Defined$ You | NumDmg$ X
-SVar:X:Count$TypeOnBattlefield.Goblin
+SVar:X:Count$Valid Goblin
 AI:RemoveDeck:Random
 Oracle:{T}: Sparksmith deals X damage to target creature and X damage to you, where X is the number of Goblins on the battlefield.

--- a/forge-gui/res/cardsfolder/s/spire_barrage.txt
+++ b/forge-gui/res/cardsfolder/s/spire_barrage.txt
@@ -2,5 +2,5 @@ Name:Spire Barrage
 ManaCost:4 R
 Types:Sorcery
 A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ X | SpellDescription$ CARDNAME deals damage to any target equal to the number of Mountains you control.
-SVar:X:Count$TypeYouCtrl.Mountain
+SVar:X:Count$Valid Mountain.YouCtrl
 Oracle:Spire Barrage deals damage to any target equal to the number of Mountains you control.

--- a/forge-gui/res/cardsfolder/s/spitting_earth.txt
+++ b/forge-gui/res/cardsfolder/s/spitting_earth.txt
@@ -2,5 +2,5 @@ Name:Spitting Earth
 ManaCost:1 R
 Types:Sorcery
 A:SP$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SpellDescription$ CARDNAME deals damage to target creature equal to the number of Mountains you control.
-SVar:X:Count$TypeYouCtrl.Mountain
+SVar:X:Count$Valid Mountain.YouCtrl
 Oracle:Spitting Earth deals damage to target creature equal to the number of Mountains you control.

--- a/forge-gui/res/cardsfolder/s/staff_of_titania.txt
+++ b/forge-gui/res/cardsfolder/s/staff_of_titania.txt
@@ -6,6 +6,6 @@ T:Mode$ Attacks | ValidCard$ Creature.EquippedBy | Execute$ TrigToken | TriggerD
 SVar:TrigToken:DB$ Token | TokenScript$ g_1_1_forest_dryad
 K:Equip:3
 SVar:AE:SVar:HasAttackEffect:TRUE
-SVar:X:Count$TypeYouCtrl.Forest
+SVar:X:Count$Valid Forest.YouCtrl
 DeckHas:Ability$Token & Type$Dryad
 Oracle:Equipped creature gets +X/+X, where X is the number of Forests you control. Whenever equipped creature attacks, create a 1/1 green Forest Dryad land creature token. (It's affected by summoning sickness.)\nEquip {3}

--- a/forge-gui/res/cardsfolder/s/stensia_banquet.txt
+++ b/forge-gui/res/cardsfolder/s/stensia_banquet.txt
@@ -3,7 +3,7 @@ ManaCost:2 R
 Types:Sorcery
 A:SP$ DealDamage | ValidTgts$ Opponent,Planeswalker | TgtPrompt$ Select target opponent or planeswalker | NumDmg$ X | SubAbility$ DBDraw | SpellDescription$ CARDNAME deals damage to target opponent or planeswalker equal to the number of Vampires you control. Draw a card.
 SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1
-SVar:X:Count$TypeYouCtrl.Vampire
+SVar:X:Count$Valid Vampire.YouCtrl
 AI:RemoveDeck:Random
 DeckHints:Type$Vampire
 Oracle:Stensia Banquet deals damage to target opponent or planeswalker equal to the number of Vampires you control.\nDraw a card.

--- a/forge-gui/res/cardsfolder/s/strength_of_cedars.txt
+++ b/forge-gui/res/cardsfolder/s/strength_of_cedars.txt
@@ -2,5 +2,5 @@ Name:Strength of Cedars
 ManaCost:4 G
 Types:Instant Arcane
 A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | NumDef$ +X | SpellDescription$ Target creature gets +X/+X until end of turn, where X is the number of lands you control.
-SVar:X:Count$TypeYouCtrl.Land
+SVar:X:Count$Valid Land.YouCtrl
 Oracle:Target creature gets +X/+X until end of turn, where X is the number of lands you control.

--- a/forge-gui/res/cardsfolder/s/struggle_survive.txt
+++ b/forge-gui/res/cardsfolder/s/struggle_survive.txt
@@ -2,7 +2,7 @@ Name:Struggle
 ManaCost:2 R
 Types:Instant
 A:SP$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SpellDescription$ CARDNAME deals damage to target creature equal to the number of lands you control.
-SVar:X:Count$TypeYouCtrl.Land
+SVar:X:Count$Valid Land.YouCtrl
 AlternateMode:Split
 Oracle:Struggle deals damage to target creature equal to the number of lands you control.
 

--- a/forge-gui/res/cardsfolder/t/tendrils_of_corruption.txt
+++ b/forge-gui/res/cardsfolder/t/tendrils_of_corruption.txt
@@ -3,5 +3,5 @@ ManaCost:3 B
 Types:Instant
 A:SP$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SubAbility$ DBGainLife | SpellDescription$ CARDNAME deals X damage to target creature and you gain X life, where X is the number of Swamps you control.
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ X
-SVar:X:Count$TypeYouCtrl.Swamp
+SVar:X:Count$Valid Swamp.YouCtrl
 Oracle:Tendrils of Corruption deals X damage to target creature and you gain X life, where X is the number of Swamps you control.

--- a/forge-gui/res/cardsfolder/t/terravore.txt
+++ b/forge-gui/res/cardsfolder/t/terravore.txt
@@ -4,7 +4,7 @@ Types:Creature Lhurgoyf
 PT:*/*
 K:Trample
 S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of land cards in all graveyards.
-SVar:X:Count$TypeInAllYards.Land
+SVar:X:Count$ValidGraveyard Land
 AI:RemoveDeck:Random
 SVar:NeedsToPlayVar:X GE1
 Oracle:Trample\nTerravore's power and toughness are each equal to the number of land cards in all graveyards.

--- a/forge-gui/res/cardsfolder/t/the_legend_of_arena.txt
+++ b/forge-gui/res/cardsfolder/t/the_legend_of_arena.txt
@@ -6,7 +6,7 @@ K:Chapter:3:DBToken,DBToken,DBSearch
 SVar:DBToken:DB$ Token | TokenAmount$ 1 | TokenScript$ r_2_1_human_wizard | TokenOwner$ You | SubAbility$ DBDiscount | SpellDescription$ Create a 2/1 red Human Wizard creature token.
 SVar:DBDiscount:DB$ Effect | StaticAbilities$ SReduceCost | SpellDescription$ Spells you cast this turn cost {1} less to cast for each Wizard you control.
 SVar:SReduceCost:Mode$ ReduceCost | ValidCard$ Card | Type$ Spell | Activator$ You | Amount$ X | Description$ Spells you cast this turn cost {1} less to cast for each Wizard you control.
-SVar:X:Count$TypeYouCtrl.Wizard
+SVar:X:Count$Valid Wizard.YouCtrl
 SVar:DBSearch:DB$ ChangeZone | Origin$ Library | Destination$ Battlefield | ChangeType$ Planeswalker | ChangeNum$ 1 | RememberChanged$ True | SubAbility$ DBCounter | SpellDescription$ Search your library for a planeswalker card, put it onto the battlefield, then shuffle your library.
 SVar:DBCounter:DB$ PutCounter | Defined$ Remembered | CounterType$ LOYALTY | CounterNum$ X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/t/the_mimeoplasm.txt
+++ b/forge-gui/res/cardsfolder/t/the_mimeoplasm.txt
@@ -11,7 +11,7 @@ SVar:MimeoChooseCopy:DB$ ChooseCard | ConditionCheckSVar$ MimeoNumRemembered | C
 SVar:MimeoAddCounters:DB$ PutCounter | ETB$ True | Defined$ Self | ConditionCheckSVar$ MimeoNumRemembered | ConditionSVarCompare$ EQ1 | CounterType$ P1P1 | CounterNum$ MimeoX | SubAbility$ MimeoCopyChosen
 SVar:MimeoCopyChosen:DB$ Clone | Defined$ ChosenCard | ConditionCheckSVar$ MimeoNumRemembered | ConditionSVarCompare$ EQ1 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearChosenCard$ True
-SVar:MimeoInYard:Count$TypeInAllYards.Creature
+SVar:MimeoInYard:Count$ValidGraveyard Creature
 SVar:MimeoNumRemembered:Remembered$Amount
 SVar:MimeoX:Remembered$CardPower
 SVar:NeedsToPlayVar:MimeoInYard GE2

--- a/forge-gui/res/cardsfolder/t/themberchaud.txt
+++ b/forge-gui/res/cardsfolder/t/themberchaud.txt
@@ -7,6 +7,6 @@ T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.S
 SVar:TrigDamageAllNonFlyers:DB$ DamageAll | NumDmg$ X | ValidCards$ Creature.Other+withoutFlying | ValidPlayers$ Player | ValidDescription$ each other creature without flying and each player
 S:Mode$ OptionalAttackCost | ValidCard$ Card.Self | Trigger$ TrigPump | Cost$ Exert<1/CARDNAME> | Description$ You may exert CARDNAME as it attacks. When you do, he gains flying until end of turn. (An exerted creature won't untap during your next untap step.)
 SVar:TrigPump:DB$ Pump | Defined$ Self | KW$ Flying | SpellDescription$ When you do, he gains flying until end of turn.
-SVar:X:Count$TypeYouCtrl.Mountain
+SVar:X:Count$Valid Mountain.YouCtrl
 DeckHints:Type$Dragon & Keyword$Flying
 Oracle:Trample\nWhen Themberchaud enters, he deals X damage to each other creature without flying and each player, where X is the number of Mountains you control.\nYou may exert Themberchaud as he attacks. When you do, he gains flying until end of turn. (An exerted creature won't untap during your next untap step.)

--- a/forge-gui/res/cardsfolder/t/thieving_sprite.txt
+++ b/forge-gui/res/cardsfolder/t/thieving_sprite.txt
@@ -5,5 +5,5 @@ PT:1/1
 K:Flying
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ DBDiscard | TriggerDescription$ When CARDNAME enters, target player reveals X cards from their hand, where X is the number of Faeries you control. You choose one of those cards. That player discards that card.
 SVar:DBDiscard:DB$ Discard | ValidTgts$ Player | NumCards$ 1 | RevealNumber$ X | Mode$ RevealYouChoose | DiscardValid$ Card
-SVar:X:Count$TypeYouCtrl.Faerie
+SVar:X:Count$Valid Faerie.YouCtrl
 Oracle:Flying\nWhen Thieving Sprite enters, target player reveals X cards from their hand, where X is the number of Faeries you control. You choose one of those cards. That player discards that card.

--- a/forge-gui/res/cardsfolder/t/thunder_of_hooves.txt
+++ b/forge-gui/res/cardsfolder/t/thunder_of_hooves.txt
@@ -2,6 +2,6 @@ Name:Thunder of Hooves
 ManaCost:3 R
 Types:Sorcery
 A:SP$ DamageAll | NumDmg$ X | ValidCards$ Creature.withoutFlying | ValidPlayers$ Player | ValidDescription$ each creature without flying and each player. | SpellDescription$ CARDNAME deals X damage to each creature without flying and each player, where X is the number of Beasts on the battlefield.
-SVar:X:Count$TypeOnBattlefield.Beast
+SVar:X:Count$Valid Beast
 AI:RemoveDeck:Random
 Oracle:Thunder of Hooves deals X damage to each creature without flying and each player, where X is the number of Beasts on the battlefield.

--- a/forge-gui/res/cardsfolder/t/thundercloud_shaman.txt
+++ b/forge-gui/res/cardsfolder/t/thundercloud_shaman.txt
@@ -4,7 +4,7 @@ Types:Creature Giant Shaman
 PT:4/4
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDamageAll | TriggerDescription$ When CARDNAME enters, it deals damage equal to the number of Giants you control to each non-Giant creature.
 SVar:TrigDamageAll:DB$ DamageAll | ValidCards$ Creature.nonGiant | NumDmg$ X | ValidDescription$ each non-Giant creature.
-SVar:X:Count$TypeYouCtrl.Giant
+SVar:X:Count$Valid Giant.YouCtrl
 DeckNeeds:Type$Giant
 SVar:PlayMain1:TRUE
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/t/timberwatch_elf.txt
+++ b/forge-gui/res/cardsfolder/t/timberwatch_elf.txt
@@ -3,5 +3,5 @@ ManaCost:2 G
 Types:Creature Elf
 PT:1/2
 A:AB$ Pump | Cost$ T | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | NumDef$ +X | SpellDescription$ Target creature gets +X/+X until end of turn, where X is the number of Elves on the battlefield.
-SVar:X:Count$TypeOnBattlefield.Elf
+SVar:X:Count$Valid Elf
 Oracle:{T}: Target creature gets +X/+X until end of turn, where X is the number of Elves on the battlefield.

--- a/forge-gui/res/cardsfolder/t/treeguard_duo.txt
+++ b/forge-gui/res/cardsfolder/t/treeguard_duo.txt
@@ -4,6 +4,6 @@ Types:Creature Frog Rabbit
 PT:3/4
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ When CARDNAME enters, until end of turn, target creature you control gains vigilance and gets +X/+X, where X is the number of creatures you control.
 SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | NumAtt$ +X | NumDef$ +X | KW$ Vigilance
-SVar:X:Count$TypeYouCtrl.Creature
+SVar:X:Count$Valid Creature.YouCtrl
 SVar:PlayMain1:TRUE
 Oracle:When Treeguard Duo enters, until end of turn, target creature you control gains vigilance and gets +X/+X, where X is the number of creatures you control.

--- a/forge-gui/res/cardsfolder/t/tuktuk_scrapper.txt
+++ b/forge-gui/res/cardsfolder/t/tuktuk_scrapper.txt
@@ -6,7 +6,7 @@ T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.S
 SVar:TuktukDestroy:DB$ Destroy | ValidTgts$ Artifact | TgtPrompt$ Select target artifact | RememberDestroyed$ True | SubAbility$ TuktukDamage | SpellDescription$ If that artifact is put into a graveyard this way,
 SVar:TuktukDamage:DB$ DealDamage | Defined$ TargetedController | NumDmg$ X | ConditionCheckSVar$ Y | ConditionSVarCompare$ GE1 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-SVar:X:Count$TypeYouCtrl.Ally
+SVar:X:Count$Valid Ally.YouCtrl
 SVar:Y:Remembered$Amount
 DeckHints:Type$Ally
 Oracle:Whenever Tuktuk Scrapper or another Ally you control enters, you may destroy target artifact. If that artifact is put into a graveyard this way, Tuktuk Scrapper deals damage to that artifact's controller equal to the number of Allies you control.

--- a/forge-gui/res/cardsfolder/v/vedalken_shackles.txt
+++ b/forge-gui/res/cardsfolder/v/vedalken_shackles.txt
@@ -3,7 +3,7 @@ ManaCost:3
 Types:Artifact
 K:You may choose not to untap CARDNAME during your untap step.
 A:AB$ GainControl | Cost$ 2 T | ValidTgts$ Creature.powerLEX | TgtPrompt$ Select target creature with power less than or equal to the number of Islands you control | LoseControl$ Untap,LeavesPlay | SpellDescription$ Gain control of target creature with power less than or equal to the number of Islands you control for as long as CARDNAME remains tapped.
-SVar:X:Count$TypeYouCtrl.Island
+SVar:X:Count$Valid Island.YouCtrl
 AI:RemoveDeck:Random
 DeckNeeds:Color$Blue
 Oracle:You may choose not to untap Vedalken Shackles during your untap step.\n{2}, {T}: Gain control of target creature with power less than or equal to the number of Islands you control for as long as Vedalken Shackles remains tapped.

--- a/forge-gui/res/cardsfolder/v/visions_of_glory.txt
+++ b/forge-gui/res/cardsfolder/v/visions_of_glory.txt
@@ -2,7 +2,7 @@ Name:Visions of Glory
 ManaCost:4 W
 Types:Sorcery
 A:SP$ Token | TokenScript$ w_1_1_human | TokenAmount$ Y | SpellDescription$ Create a 1/1 white Human creature token for each creature you control.
-SVar:Y:Count$TypeYouCtrl.Creature
+SVar:Y:Count$Valid Creature.YouCtrl
 K:Flashback:8 W W:ReduceCost$ X:This spell costs {X} less to cast this way, where X is the greatest mana value of a commander you own on the battlefield or in the command zone.
 SVar:X:Count$ValidBattlefield,Command Card.IsCommander+YouOwn$GreatestCMC
 DeckHas:Ability$Token

--- a/forge-gui/res/cardsfolder/v/voldaren_estate.txt
+++ b/forge-gui/res/cardsfolder/v/voldaren_estate.txt
@@ -4,7 +4,7 @@ Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ T PayLife<1> | Produced$ Any | Amount$ 1 | RestrictValid$ Spell.Vampire | SpellDescription$ Add one mana of any color. Spend this mana only to cast a Vampire spell.
 A:AB$ Token | Cost$ 5 T | TokenScript$ c_a_blood_draw | ReduceCost$ X | SpellDescription$ Create a Blood token. This ability costs {1} less to activate for each Vampire you control. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
-SVar:X:Count$TypeYouCtrl.Vampire
+SVar:X:Count$Valid Vampire.YouCtrl
 DeckHas:Ability$Token|Sacrifice & Type$Blood
 DeckNeeds:Type$Vampire
 Oracle:{T}: Add {C}.\n{T}, Pay 1 life: Add one mana of any color. Spend this mana only to cast a Vampire spell.\n{5}, {T}: Create a Blood token. This ability costs {1} less to activate for each Vampire you control. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")

--- a/forge-gui/res/cardsfolder/w/welding_sparks.txt
+++ b/forge-gui/res/cardsfolder/w/welding_sparks.txt
@@ -2,5 +2,5 @@ Name:Welding Sparks
 ManaCost:2 R
 Types:Instant
 A:SP$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to target creature, where X is 3 plus the number of artifacts you control.
-SVar:X:Count$TypeYouCtrl.Artifact/Plus.3
+SVar:X:Count$Valid Artifact.YouCtrl/Plus.3
 Oracle:Welding Sparks deals X damage to target creature, where X is 3 plus the number of artifacts you control.

--- a/forge-gui/res/cardsfolder/w/wellwisher.txt
+++ b/forge-gui/res/cardsfolder/w/wellwisher.txt
@@ -3,6 +3,6 @@ ManaCost:1 G
 Types:Creature Elf
 PT:1/1
 A:AB$ GainLife | Cost$ T | LifeAmount$ X | SpellDescription$ You gain 1 life for each Elf on the battlefield.
-SVar:X:Count$TypeOnBattlefield.Elf
+SVar:X:Count$Valid Elf
 SVar:BuffedBy:Elf
 Oracle:{T}: You gain 1 life for each Elf on the battlefield.

--- a/forge-gui/res/cardsfolder/w/wirewood_pride.txt
+++ b/forge-gui/res/cardsfolder/w/wirewood_pride.txt
@@ -2,5 +2,5 @@ Name:Wirewood Pride
 ManaCost:G
 Types:Instant
 A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | NumDef$ +X | SpellDescription$ Target creature gets +X/+X until end of turn, where X is the number of Elves on the battlefield.
-SVar:X:Count$TypeOnBattlefield.Elf
+SVar:X:Count$Valid Elf
 Oracle:Target creature gets +X/+X until end of turn, where X is the number of Elves on the battlefield.


### PR DESCRIPTION
Following up on the previous passes: https://github.com/Card-Forge/forge/pull/7312 and https://github.com/Card-Forge/forge/pull/7324 .

Deprecated counting expressions updated in this pass:
- `Count$TypeYouCtrl`
- `Count$TypeOppCtrl`
- `Count$TypeInAllYards`
- `Count$InAllYards`
- `Count$TypeOnBattlefield`

Incidentally updated [Renewing Dawn](https://scryfall.com/card/por/23/renewing-dawn) to actually target an opponent per updated Oracle.