### PR TITLE
Cleanup: Updating to Count$Valid, pass 4

### DIFF
--- a/forge-gui/res/cardsfolder/a/accumulated_knowledge.txt
+++ b/forge-gui/res/cardsfolder/a/accumulated_knowledge.txt
@@ -3,6 +3,6 @@ ManaCost:1 U
 Types:Instant
 A:SP$ Draw | Defined$ You | SubAbility$ DBDraw | SpellDescription$ Draw a card, then draw cards equal to the number of cards named Accumulated Knowledge in all graveyards.
 SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ X
-SVar:X:Count$NamedInAllYards.Accumulated Knowledge
+SVar:X:Count$ValidGraveyard Card.namedAccumulated Knowledge
 DeckNeeds:Name$Accumulated Knowledge
 Oracle:Draw a card, then draw cards equal to the number of cards named Accumulated Knowledge in all graveyards.

--- a/forge-gui/res/cardsfolder/a/avenger_of_zendikar.txt
+++ b/forge-gui/res/cardsfolder/a/avenger_of_zendikar.txt
@@ -4,7 +4,7 @@ Types:Creature Elemental
 PT:5/5
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a 0/1 green Plant creature token for each land you control.
 SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ g_0_1_plant | TokenOwner$ You
-SVar:X:Count$NumTypeYouCtrl.Land
+SVar:X:Count$Valid Land.YouCtrl
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigPutCounterAll | OptionalDecider$ You | TriggerDescription$ Landfall — Whenever a land you control enters, you may put a +1/+1 counter on each Plant creature you control.
 SVar:TrigPutCounterAll:DB$ PutCounterAll | ValidCards$ Creature.Plant+YouCtrl | CounterType$ P1P1 | CounterNum$ 1 | AILogic$ Always
 SVar:BuffedBy:Land

--- a/forge-gui/res/cardsfolder/b/bargaining_table.txt
+++ b/forge-gui/res/cardsfolder/b/bargaining_table.txt
@@ -2,6 +2,6 @@ Name:Bargaining Table
 ManaCost:5
 Types:Artifact
 A:AB$ Draw | Cost$ X T | NumCards$ 1 | AnnounceType$ Opponent | SpellDescription$ Draw a card. X is the number of cards in an opponent's hand.
-SVar:X:Count$InChosenHand
+SVar:X:Count$ValidHand Card.ChosenCtrl
 AI:RemoveDeck:All
 Oracle:{X}, {T}: Draw a card. X is the number of cards in an opponent's hand.

--- a/forge-gui/res/cardsfolder/b/black_vise.txt
+++ b/forge-gui/res/cardsfolder/b/black_vise.txt
@@ -5,5 +5,5 @@ K:ETBReplacement:Other:ChooseP
 SVar:ChooseP:DB$ ChoosePlayer | Defined$ You | Choices$ Player.Opponent | ChoiceTitle$ Choose an opponent | AILogic$ MostCardsInHand | SpellDescription$ As CARDNAME enters, choose an opponent.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player.Chosen | TriggerZones$ Battlefield | Execute$ TrigDamage | TriggerDescription$ At the beginning of the chosen player's upkeep, CARDNAME deals X damage to that player, where X is the number of cards in their hand minus 4.
 SVar:TrigDamage:DB$ DealDamage | Defined$ ChosenPlayer | NumDmg$ X
-SVar:X:Count$InChosenHand/Minus.4
+SVar:X:Count$ValidHand Card.ChosenCtrl/Minus.4
 Oracle:As Black Vise enters, choose an opponent.\nAt the beginning of the chosen player's upkeep, Black Vise deals X damage to that player, where X is the number of cards in their hand minus 4.

--- a/forge-gui/res/cardsfolder/b/bulwark.txt
+++ b/forge-gui/res/cardsfolder/b/bulwark.txt
@@ -4,7 +4,7 @@ Types:Enchantment
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ PsychicSlap | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, CARDNAME deals X damage to target opponent, where X is the number of cards in your hand minus the number of cards in that player's hand.
 SVar:PsychicSlap:DB$ DealDamage | ValidTgts$ Opponent | NumDmg$ X
 SVar:A:Count$ValidHand Card.YouOwn
-SVar:B:Count$InTargetedHand
+SVar:B:Count$ValidHand Card.TargetedPlayerOwn
 SVar:X:SVar$A/Minus.B
 AI:RemoveDeck:All
 Oracle:At the beginning of your upkeep, Bulwark deals X damage to target opponent, where X is the number of cards in your hand minus the number of cards in that player's hand.

--- a/forge-gui/res/cardsfolder/d/display_of_power.txt
+++ b/forge-gui/res/cardsfolder/d/display_of_power.txt
@@ -3,6 +3,6 @@ ManaCost:1 R R
 Types:Instant
 S:Mode$ CantBeCopied | ValidCard$ Card.Self | EffectZone$ Stack | Description$ This spell can't be copied.
 A:SP$ CopySpellAbility | ValidTgts$ Instant,Sorcery | TargetMin$ 0 | TargetMax$ X | TgtPrompt$ Select any number of target instant and sorcery spells | TargetType$ Spell | MayChooseTarget$ True | SpellDescription$ Copy any number of target instant and/or sorcery spells. You may choose new targets for the copies.
-SVar:X:Count$SpellsOnStack
+SVar:X:Count$ValidStack Card
 DeckHints:Type$Instant|Sorcery
 Oracle:This spell can't be copied.\nCopy any number of target instant and/or sorcery spells. You may choose new targets for the copies.

--- a/forge-gui/res/cardsfolder/e/entropic_specter.txt
+++ b/forge-gui/res/cardsfolder/e/entropic_specter.txt
@@ -6,7 +6,7 @@ K:Flying
 K:ETBReplacement:Other:ChooseP
 SVar:ChooseP:DB$ ChoosePlayer | Defined$ You | Choices$ Player.Opponent | AILogic$ Curse | SpellDescription$ As CARDNAME enters, choose an opponent.
 S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of cards in the chosen player's hand.
-SVar:X:Count$InChosenHand
+SVar:X:Count$ValidHand Card.ChosenCtrl
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigDiscard | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME deals damage to a player, that player discards a card.
 SVar:TrigDiscard:DB$ Discard | Defined$ TriggeredTarget | NumCards$ 1 | Mode$ TgtChoose
 Oracle:Flying\nAs Entropic Specter enters, choose an opponent.\nEntropic Specter's power and toughness are each equal to the number of cards in the chosen player's hand.\nWhenever Entropic Specter deals damage to a player, that player discards a card.

--- a/forge-gui/res/cardsfolder/e/evil_comes_to_fruition.txt
+++ b/forge-gui/res/cardsfolder/e/evil_comes_to_fruition.txt
@@ -4,5 +4,4 @@ Types:Scheme
 T:Mode$ SetInMotion | ValidCard$ Card.Self | Execute$ NewEvil | TriggerZones$ Command | TriggerDescription$ When you set this scheme in motion, create seven 0/1 green Plant creature tokens. If you control ten or more lands, create seven 3/3 green Elemental creature tokens instead.
 SVar:NewEvil:DB$ Token | TokenAmount$ 7 | TokenScript$ g_0_1_plant | TokenOwner$ You | ConditionPresent$ Land.YouCtrl | ConditionCompare$ LT10 | SubAbility$ MatureEvil
 SVar:MatureEvil:DB$ Token | TokenAmount$ 7 | TokenScript$ g_3_3_elemental | TokenOwner$ You | ConditionPresent$ Land.YouCtrl | ConditionCompare$ GE10
-SVar:X:Count$NumTypeYouCtrl.Land
 Oracle:When you set this scheme in motion, create seven 0/1 green Plant creature tokens. If you control ten or more lands, create seven 3/3 green Elemental creature tokens instead.

--- a/forge-gui/res/cardsfolder/f/feast_of_flesh.txt
+++ b/forge-gui/res/cardsfolder/f/feast_of_flesh.txt
@@ -3,6 +3,6 @@ ManaCost:B
 Types:Sorcery
 A:SP$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ X | SubAbility$ DBGainLife | SpellDescription$ CARDNAME deals X damage to target creature and you gain X life, where X is 1 plus the number of cards named Feast of Flesh in all graveyards.
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ X
-SVar:X:Count$NamedInAllYards.Feast of Flesh/Plus.1
+SVar:X:Count$ValidGraveyard Card.namedFeast of Flesh/Plus.1
 DeckHints:Name$Feast of Flesh
 Oracle:Feast of Flesh deals X damage to target creature and you gain X life, where X is 1 plus the number of cards named Feast of Flesh in all graveyards.

--- a/forge-gui/res/cardsfolder/f/flame_burst.txt
+++ b/forge-gui/res/cardsfolder/f/flame_burst.txt
@@ -2,7 +2,7 @@ Name:Flame Burst
 ManaCost:1 R
 Types:Instant
 A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to any target, where X is 2 plus the number of cards named Flame Burst in all graveyards.
-SVar:X:Count$NamedInAllYards.Flame Burst/Plus.Y
+SVar:X:Count$ValidGraveyard Card.namedFlame Burst/Plus.Y
 SVar:Y:Count$ValidGraveyard Card.hasKeywordCARDNAME count as Flame Burst./Plus.2
 DeckHints:Name$Flame Burst|Pardic Firecat
 Oracle:Flame Burst deals X damage to any target, where X is 2 plus the number of cards named Flame Burst in all graveyards.

--- a/forge-gui/res/cardsfolder/g/gaeas_avenger.txt
+++ b/forge-gui/res/cardsfolder/g/gaeas_avenger.txt
@@ -3,5 +3,5 @@ ManaCost:1 G G
 Types:Creature Treefolk
 PT:1+*/1+*
 S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to 1 plus the number of artifacts your opponents control.
-SVar:X:Count$NumTypeOppCtrl.Artifact/Plus.1
+SVar:X:Count$Valid Artifact.OppCtrl/Plus.1
 Oracle:Gaea's Avenger's power and toughness are each equal to 1 plus the number of artifacts your opponents control.

--- a/forge-gui/res/cardsfolder/i/irradiate.txt
+++ b/forge-gui/res/cardsfolder/i/irradiate.txt
@@ -2,6 +2,6 @@ Name:Irradiate
 ManaCost:3 B
 Types:Instant
 A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ -X | NumDef$ -X | IsCurse$ True | SpellDescription$ Target creature gets -1/-1 until end of turn for each artifact you control.
-SVar:X:Count$NumTypeYouCtrl.Artifact
+SVar:X:Count$Valid Artifact.YouCtrl
 AI:RemoveDeck:Random
 Oracle:Target creature gets -1/-1 until end of turn for each artifact you control.

--- a/forge-gui/res/cardsfolder/j/jon_irenicus_the_exile.txt
+++ b/forge-gui/res/cardsfolder/j/jon_irenicus_the_exile.txt
@@ -7,6 +7,6 @@ SVar:TrigBranch:DB$ Branch | ValidTgts$ Opponent | BranchConditionSVar$ X | Bran
 SVar:Draw:DB$ Draw
 SVar:Mill:DB$ Mill | Defined$ Opponent | NumCards$ 5
 SVar:X:Count$ValidLibrary Card.YouOwn
-SVar:Y:Count$InTargetedLibrary
+SVar:Y:Count$ValidLibrary Card.TargetedPlayerOwn
 DeckHas:Ability$Mill
 Oracle:At the beginning of your end step, draw a card if your library has more cards in it than target opponent's library. Otherwise, each opponent mills five cards.

--- a/forge-gui/res/cardsfolder/k/kindle.txt
+++ b/forge-gui/res/cardsfolder/k/kindle.txt
@@ -2,6 +2,6 @@ Name:Kindle
 ManaCost:1 R
 Types:Instant
 A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to any target, where X is 2 plus the number of cards named Kindle in all graveyards.
-SVar:X:Count$NamedInAllYards.Kindle/Plus.2
+SVar:X:Count$ValidGraveyard Card.namedKindle/Plus.2
 DeckHints:Name$Kindle
 Oracle:Kindle deals X damage to any target, where X is 2 plus the number of cards named Kindle in all graveyards.

--- a/forge-gui/res/cardsfolder/k/kjeldoran_war_cry.txt
+++ b/forge-gui/res/cardsfolder/k/kjeldoran_war_cry.txt
@@ -2,6 +2,6 @@ Name:Kjeldoran War Cry
 ManaCost:1 W
 Types:Instant
 A:SP$ PumpAll | ValidCards$ Creature.YouCtrl | NumAtt$ +X | NumDef$ +X | SpellDescription$ Creatures you control get +X/+X until end of turn, where X is 1 plus the number of cards named Kjeldoran War Cry in all graveyards.
-SVar:X:Count$NamedInAllYards.Kjeldoran War Cry/Plus.1
+SVar:X:Count$ValidGraveyard Card.namedKjeldoran War Cry/Plus.1
 DeckHints:Name$Kjeldoran War Cry
 Oracle:Creatures you control get +X/+X until end of turn, where X is 1 plus the number of cards named Kjeldoran War Cry in all graveyards.

--- a/forge-gui/res/cardsfolder/l/life_burst.txt
+++ b/forge-gui/res/cardsfolder/l/life_burst.txt
@@ -3,6 +3,6 @@ ManaCost:1 W
 Types:Instant
 A:SP$ GainLife | LifeAmount$ 4 | ValidTgts$ Player | TgtPrompt$ Select target player | SubAbility$ DBGainLife | SpellDescription$ Target player gains 4 life, then gains 4 life for each card named Life Burst in each graveyard.
 SVar:DBGainLife:DB$ GainLife | Defined$ Targeted | LifeAmount$ X
-SVar:X:Count$NamedInAllYards.Life Burst/Times.4
+SVar:X:Count$ValidGraveyard Card.namedLife Burst/Times.4
 DeckHints:Name$Life Burst
 Oracle:Target player gains 4 life, then gains 4 life for each card named Life Burst in each graveyard.

--- a/forge-gui/res/cardsfolder/l/liu_bei_lord_of_shu.txt
+++ b/forge-gui/res/cardsfolder/l/liu_bei_lord_of_shu.txt
@@ -4,8 +4,8 @@ Types:Legendary Creature Human Soldier
 PT:2/4
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 2 | AddToughness$ 2 | CheckSVar$ Z | Description$ CARDNAME gets +2/+2 as long as you control a permanent named Guan Yu, Sainted Warrior or a permanent named Zhang Fei, Fierce Warrior.
 K:Horsemanship
-SVar:X:Count$NamedYouCtrl.Guan Yu, Sainted Warrior
-SVar:Y:Count$NamedYouCtrl.Zhang Fei, Fierce Warrior
+SVar:X:Count$Valid Permanent.namedGuan Yu; Sainted Warrior+YouCtrl
+SVar:Y:Count$Valid Permanent.namedZhang Fei; Fierce Warrior+YouCtrl
 SVar:Z:SVar$X/Plus.Y
 DeckHints:Name$Guan Yu, Sainted Warrior|Zhang Fei, Fierce Warrior
 Oracle:Horsemanship (This creature can't be blocked except by creatures with horsemanship.)\nLiu Bei, Lord of Shu gets +2/+2 as long as you control a permanent named Guan Yu, Sainted Warrior or a permanent named Zhang Fei, Fierce Warrior.

--- a/forge-gui/res/cardsfolder/m/mind_burst.txt
+++ b/forge-gui/res/cardsfolder/m/mind_burst.txt
@@ -2,6 +2,6 @@ Name:Mind Burst
 ManaCost:1 B
 Types:Sorcery
 A:SP$ Discard | ValidTgts$ Player | NumCards$ X | Mode$ TgtChoose | SpellDescription$ Target player discards X cards, where X is one plus the number of cards named Mind Burst in all graveyards.
-SVar:X:Count$NamedInAllYards.Mind Burst/Plus.1
+SVar:X:Count$ValidGraveyard Card.namedMind Burst/Plus.1
 DeckHints:Name$Mind Burst
 Oracle:Target player discards X cards, where X is one plus the number of cards named Mind Burst in all graveyards.

--- a/forge-gui/res/cardsfolder/m/mindbreak_trap.txt
+++ b/forge-gui/res/cardsfolder/m/mindbreak_trap.txt
@@ -4,6 +4,6 @@ Types:Instant Trap
 S:Mode$ AlternativeCost | ValidSA$ Spell.Self | EffectZone$ All | Cost$ 0 | CheckSVar$ OppCastThisTurn | Description$ If an opponent cast three or more spells this turn, you may pay {0} rather than pay this spell's mana cost.
 A:SP$ ChangeZone | TargetType$ Spell | ValidTgts$ Card | TgtZone$ Stack | Origin$ Stack | Destination$ Exile | TargetMin$ 0 | TargetMax$ MaxTgts | StackDescription$ SpellDescription | SpellDescription$ Exile any number of target spells.
 SVar:OppCastThisTurn:PlayerCountOpponents$ConditionGE3 SpellsCastThisTurn
-SVar:MaxTgts:Count$SpellsOnStack
+SVar:MaxTgts:Count$ValidStack Card
 AI:RemoveDeck:All
 Oracle:If an opponent cast three or more spells this turn, you may pay {0} rather than pay this spell's mana cost.\nExile any number of target spells.

--- a/forge-gui/res/cardsfolder/m/muscle_burst.txt
+++ b/forge-gui/res/cardsfolder/m/muscle_burst.txt
@@ -2,7 +2,7 @@ Name:Muscle Burst
 ManaCost:1 G
 Types:Instant
 A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +X | NumDef$ +X | SpellDescription$ Target creature gets +X/+X until end of turn, where X is 3 plus the number of cards named Muscle Burst in all graveyards.
-SVar:X:Count$NamedInAllYards.Muscle Burst/Plus.Y
+SVar:X:Count$ValidGraveyard Card.namedMuscle Burst/Plus.Y
 SVar:Y:Count$ValidGraveyard Card.hasKeywordCARDNAME count as Muscle Burst./Plus.3
 DeckHints:Name$Diligent Farmhand|Muscle Burst
 Oracle:Target creature gets +X/+X until end of turn, where X is 3 plus the number of cards named Muscle Burst in all graveyards.

--- a/forge-gui/res/cardsfolder/n/nicol_bolas_the_ravager_nicol_bolas_the_arisen.txt
+++ b/forge-gui/res/cardsfolder/n/nicol_bolas_the_ravager_nicol_bolas_the_arisen.txt
@@ -22,5 +22,5 @@ A:AB$ Draw | Cost$ AddCounter<2/LOYALTY> | Planeswalker$ True | NumCards$ 2 | Sp
 A:AB$ DealDamage | Cost$ SubCounter<3/LOYALTY> | Planeswalker$ True | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ 10 | SpellDescription$ CARDNAME deals 10 damage to target creature or planeswalker.
 A:AB$ ChangeZone | Cost$ SubCounter<4/LOYALTY> | Planeswalker$ True | Origin$ Graveyard | Destination$ Battlefield | GainControl$ True | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker card in a graveyard | SpellDescription$ Put target creature or planeswalker card from a graveyard onto the battlefield under your control.
 A:AB$ Dig | Cost$ SubCounter<12/LOYALTY> | Planeswalker$ True | Ultimate$ True | DigNum$ X | ChangeNum$ All | DestinationZone$ Exile | ValidTgts$ Player | TgtPrompt$ Select target player | SpellDescription$ Exile all but the bottom card of target player's library.
-SVar:X:Count$InTargetedLibrary.Card/Minus.1
+SVar:X:Count$ValidLibrary Card.TargetedPlayerOwn/Minus.1
 Oracle:[+2]: Draw two cards.\n[-3]: Nicol Bolas, the Arisen deals 10 damage to target creature or planeswalker.\n[-4]: Put target creature or planeswalker card from a graveyard onto the battlefield under your control.\n[-12]: Exile all but the bottom card of target player's library.

--- a/forge-gui/res/cardsfolder/n/nyxathid.txt
+++ b/forge-gui/res/cardsfolder/n/nyxathid.txt
@@ -5,7 +5,7 @@ PT:7/7
 K:ETBReplacement:Other:ChooseP
 SVar:ChooseP:DB$ ChoosePlayer | Defined$ You | Choices$ Player.Opponent | AILogic$ Curse | SpellDescription$ As CARDNAME enters, choose an opponent.
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ -X | AddToughness$ -X | Description$ CARDNAME gets -1/-1 for each card in the chosen player's hand.
-SVar:X:Count$InChosenHand
+SVar:X:Count$ValidHand Card.ChosenCtrl
 SVar:NeedsToPlayVar:Z GE1
 SVar:Z:PlayerCountPropertyOpponents$HasPropertyHasCardsInHand_Card_LE5
 Oracle:As Nyxathid enters, choose an opponent.\nNyxathid gets -1/-1 for each card in the chosen player's hand.

--- a/forge-gui/res/cardsfolder/p/pulse_of_the_dross.txt
+++ b/forge-gui/res/cardsfolder/p/pulse_of_the_dross.txt
@@ -3,6 +3,6 @@ ManaCost:1 B B
 Types:Sorcery
 A:SP$ Discard | ValidTgts$ Player | TgtPrompt$ Select target player | Mode$ RevealYouChoose | RevealNumber$ 3 | NumCards$ 1 | SubAbility$ ReturnDross | SpellDescription$ Target player reveals three cards from their hand and you choose one of them. That player discards that card. Then if that player has more cards in hand than you, return CARDNAME to its owner's hand.
 SVar:ReturnDross:DB$ ChangeZone | ConditionCheckSVar$ X | ConditionSVarCompare$ GTY | Defined$ Parent | Origin$ Stack | Destination$ Hand
-SVar:X:Count$InTargetedHand
+SVar:X:Count$ValidHand Card.TargetedPlayerOwn
 SVar:Y:Count$ValidHand Card.YouOwn
 Oracle:Target player reveals three cards from their hand and you choose one of them. That player discards that card. Then if that player has more cards in hand than you, return Pulse of the Dross to its owner's hand.

--- a/forge-gui/res/cardsfolder/r/rite_of_flame.txt
+++ b/forge-gui/res/cardsfolder/r/rite_of_flame.txt
@@ -3,6 +3,6 @@ ManaCost:R
 Types:Sorcery
 A:SP$ Mana | Produced$ R | Amount$ 2 | AILogic$ ManaRitual | AINoRecursiveCheck$ True | SubAbility$ SubMana | SpellDescription$ Add {R}{R}, then add {R} for each card named Rite of Flame in each graveyard.
 SVar:SubMana:DB$ Mana | Produced$ R | Amount$ X
-SVar:X:Count$NamedInAllYards.Rite of Flame
+SVar:X:Count$ValidGraveyard Card.namedRite of Flame
 DeckHints:Name$Rite of Flame
 Oracle:Add {R}{R}, then add {R} for each card named Rite of Flame in each graveyard.

--- a/forge-gui/res/cardsfolder/r/rune_snag.txt
+++ b/forge-gui/res/cardsfolder/r/rune_snag.txt
@@ -2,7 +2,7 @@ Name:Rune Snag
 ManaCost:1 U
 Types:Instant
 A:SP$ Counter | TargetType$ Spell | ValidTgts$ Card | TgtPrompt$ Select target spell | UnlessCost$ Z | UnlessPayer$ TargetedController | SpellDescription$ Counter target spell unless its controller pays {2} plus an additional {2} for each card named Rune Snag in each graveyard.
-SVar:Y:Count$NamedInAllYards.Rune Snag/Times.2
+SVar:Y:Count$ValidGraveyard Card.namedRune Snag/Times.2
 SVar:Z:Number$2/Plus.Y
 DeckHints:Name$Rune Snag
 Oracle:Counter target spell unless its controller pays {2} plus an additional {2} for each card named Rune Snag in each graveyard.

--- a/forge-gui/res/cardsfolder/s/sandstone_oracle.txt
+++ b/forge-gui/res/cardsfolder/s/sandstone_oracle.txt
@@ -7,5 +7,5 @@ T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.S
 SVar:TrigChooseOpp:DB$ ChoosePlayer | Defined$ You | Choices$ Player.Opponent | AILogic$ MostCardsInHand | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw | NumCards$ X | Defined$ You | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1
 SVar:Y:Count$ValidHand Card.YouOwn
-SVar:X:Count$InChosenHand/Minus.Y
+SVar:X:Count$ValidHand Card.ChosenCtrl/Minus.Y
 Oracle:Flying\nWhen Sandstone Oracle enters, choose an opponent. If that player has more cards in hand than you, draw cards equal to the difference.

--- a/forge-gui/res/cardsfolder/s/search_warrant.txt
+++ b/forge-gui/res/cardsfolder/s/search_warrant.txt
@@ -3,6 +3,6 @@ ManaCost:W U
 Types:Sorcery
 A:SP$ RevealHand | ValidTgts$ Player | TgtPrompt$ Select target player | SubAbility$ DBGainLife | SpellDescription$ Target player reveals their hand. You gain life equal to the number of cards in that player's hand.
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ X
-SVar:X:Count$InTargetedHand
+SVar:X:Count$ValidHand Card.TargetedPlayerOwn
 AI:RemoveDeck:All
 Oracle:Target player reveals their hand. You gain life equal to the number of cards in that player's hand.

--- a/forge-gui/res/cardsfolder/s/sewer_nemesis.txt
+++ b/forge-gui/res/cardsfolder/s/sewer_nemesis.txt
@@ -5,7 +5,7 @@ PT:*/*
 K:ETBReplacement:Other:ChooseP
 SVar:ChooseP:DB$ ChoosePlayer | Defined$ You | Choices$ Player | AILogic$ Curse | SpellDescription$ As CARDNAME enters, choose a player.
 S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of cards in the chosen player's graveyard.
-SVar:X:Count$InChosenYard
+SVar:X:Count$ValidGraveyard Card.ChosenCtrl
 T:Mode$ SpellCast | ValidCard$ Card | ValidActivatingPlayer$ Player.Chosen | Execute$ TrigMill | TriggerZones$ Battlefield | TriggerDescription$ Whenever the chosen player casts a spell, that player mills a card.
 SVar:TrigMill:DB$ Mill | Defined$ TriggeredPlayer | NumCards$ 1
 SVar:NeedsToPlayVar:Y GE1

--- a/forge-gui/res/cardsfolder/s/slithermuse.txt
+++ b/forge-gui/res/cardsfolder/s/slithermuse.txt
@@ -7,5 +7,5 @@ T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Battlefield | Destination$ 
 SVar:TrigChooseOpp:DB$ ChoosePlayer | Defined$ You | Choices$ Player.Opponent | AILogic$ MostCardsInHand | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw | NumCards$ X | ConditionPresent$ Card.ChosenCtrl | ConditionCompare$ GTY | ConditionZone$ Hand
 SVar:Y:Count$ValidHand Card.YouOwn
-SVar:X:Count$InChosenHand/Minus.Y
+SVar:X:Count$ValidHand Card.ChosenCtrl/Minus.Y
 Oracle:When Slithermuse leaves the battlefield, choose an opponent. If that player has more cards in hand than you, draw cards equal to the difference.\nEvoke {3}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters.)

--- a/forge-gui/res/cardsfolder/t/tales_of_the_ancestors.txt
+++ b/forge-gui/res/cardsfolder/t/tales_of_the_ancestors.txt
@@ -4,7 +4,7 @@ Types:Sorcery
 A:SP$ RepeatEach | RepeatPlayers$ Player.HasCardsInHand_Card_LTX | RepeatSubAbility$ DBDraw | SpellDescription$ Each player with fewer cards in hand than the player with the most cards in hand draws cards equal to the difference.
 SVar:DBDraw:DB$ Draw | Defined$ Player.IsRemembered | NumCards$ Z
 SVar:X:PlayerCountPlayers$HighestCardsInHand
-SVar:Y:Count$InRememberedHand
+SVar:Y:Count$ValidHand Card.RememberedPlayerCtrl
 SVar:Z:SVar$X/Minus.Y
 K:Foretell:1 U
 Oracle:Each player with fewer cards in hand than the player with the most cards in hand draws cards equal to the difference.\nForetell {1}{U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)

--- a/forge-gui/res/cardsfolder/t/the_rack.txt
+++ b/forge-gui/res/cardsfolder/t/the_rack.txt
@@ -5,5 +5,5 @@ K:ETBReplacement:Other:ChooseP
 SVar:ChooseP:DB$ ChoosePlayer | Defined$ You | Choices$ Player.Opponent | AILogic$ Curse | AILogic$ MostCardsInHand | SpellDescription$ As CARDNAME enters, choose an opponent.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player.Chosen | TriggerZones$ Battlefield | Execute$ TrigDamage | TriggerDescription$ At the beginning of the chosen player's upkeep, CARDNAME deals X damage to that player, where X is 3 minus the number of cards in their hand.
 SVar:TrigDamage:DB$ DealDamage | Defined$ ChosenPlayer | NumDmg$ X
-SVar:X:Count$InChosenHand/NMinus.3
+SVar:X:Count$ValidHand Card.ChosenCtrl/NMinus.3
 Oracle:As The Rack enters, choose an opponent.\nAt the beginning of the chosen player's upkeep, The Rack deals X damage to that player, where X is 3 minus the number of cards in their hand.


### PR DESCRIPTION
Following up on https://github.com/Card-Forge/forge/pull/7342 : rounding up the last remaining, relevant items.

Deprecated counting expressions updated in this pass:
- `Count$InChosenHand`
- `Count$InChosenYard`
- `Count$InRememberedHand`
- `Count$InTargetedHand`
- `Count$InTargetedLibrary`
- `Count$NamedInAllYards`
- `Count$NamedYouCtrl`
- `Count$NumTypeOppCtrl`
- `Count$NumTypeYouCtrl`
- `Count$SpellsOnStack`

Incidentally removed an orphaned counting expression line from [Evil Comes to Fruition](https://scryfall.com/card/oarc/12%E2%98%85/evil-comes-to-fruition).