### PR TITLE
Adventure and Omen as ReplacementEffect in CardState

### DIFF
--- a/forge-game/src/main/java/forge/game/card/CardFactory.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactory.java
@@ -281,13 +281,6 @@ public class CardFactory {
             } else if (state != CardStateName.Original) {
                 CardFactoryUtil.setupKeywordedAbilities(card);
             }
-            if (state == CardStateName.Secondary) {
-                if (card.getState(state).getType().hasSubtype("Adventure")) {
-                    CardFactoryUtil.setupAdventureAbility(card);
-                } else if (card.getState(state).getType().hasSubtype("Omen")) {
-                    CardFactoryUtil.setupOmenAbility(card);
-                }
-            }
         }
 
         card.setState(CardStateName.Original, false);

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -4152,16 +4152,7 @@ public class CardFactoryUtil {
         card.addTrigger(defeatedTrigger);
     }
 
-    public static void setupAdventureAbility(Card card) {
-        if (!card.getType().hasSubtype("Adventure")) {
-            return;
-        }
-        SpellAbility sa = card.getFirstSpellAbility();
-        if (sa == null) {
-            return;
-        }
-        sa.setCardState(card.getCurrentState());
-
+    public static ReplacementEffect setupAdventureAbility(CardState card) {
         StringBuilder sb = new StringBuilder();
         sb.append("Event$ Moved | ValidCard$ Card.Self | Origin$ Stack | ExcludeDestination$ Exile ");
         sb.append("| ValidStackSa$ Spell.Adventure | Fizzle$ False | Secondary$ True | Description$ Adventure");
@@ -4176,30 +4167,33 @@ public class CardFactoryUtil {
         AbilitySub saEffect = (AbilitySub)AbilityFactory.getAbility(abEffect, card);
 
         StringBuilder sbPlay = new StringBuilder();
-        sbPlay.append("Mode$ Continuous | MayPlay$ True | EffectZone$ Command | Affected$ Card.IsRemembered+nonAdventure");
+        sbPlay.append("Mode$ Continuous | MayPlay$ True | EffectZone$ Command | Affected$ Card.IsRemembered+!Adventure");
         sbPlay.append(" | AffectedZone$ Exile | Description$ You may cast the card.");
         saEffect.setSVar("Play", sbPlay.toString());
 
         saExile.setSubAbility(saEffect);
 
-        ReplacementEffect re = ReplacementHandler.parseReplacement(repeffstr, card, true);
+        ReplacementEffect re = ReplacementHandler.parseReplacement(repeffstr, card.getCard(), true);
 
         re.setOverridingAbility(saExile);
-        card.addReplacementEffect(re);
+        return re;
     }
-    public static void setupOmenAbility(Card card) {
-        if (!card.getType().hasSubtype("Omen")) {
-            return;
-        }
-        SpellAbility sa = card.getFirstSpellAbility();
-        if (sa == null) {
-            return;
-        }
-        sa.setCardState(card.getCurrentState());
 
-        String abEffect = "DB$ ChangeZone | Defined$ Self | Origin$ Stack | Destination$ Library | Shuffle$ True | StackDescription$ None";
-        AbilitySub saEffect = (AbilitySub)AbilityFactory.getAbility(abEffect, card);
-        sa.appendSubAbility(saEffect);
+    public static ReplacementEffect setupOmenAbility(CardState card) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Event$ Moved | ValidCard$ Card.Self | Origin$ Stack ");
+        sb.append("| ValidStackSa$ Spell.Omen | Fizzle$ False | Secondary$ True | Description$ Omen");
+
+        String repeffstr = sb.toString();
+
+        String abShuffle = "DB$ ChangeZone | Defined$ Self | Origin$ Stack | Destination$ Library | Shuffle$ True | StackDescription$ None";
+        AbilitySub saShuffle = (AbilitySub)AbilityFactory.getAbility(abShuffle, card);
+
+        ReplacementEffect re = ReplacementHandler.parseReplacement(repeffstr, card.getCard(), true);
+
+        re.setOverridingAbility(saShuffle);
+
+        return re;
     }
 
     public static void setFaceDownState(Card c, SpellAbility sa) {

--- a/forge-game/src/main/java/forge/game/card/CardState.java
+++ b/forge-game/src/main/java/forge/game/card/CardState.java
@@ -84,8 +84,9 @@ public class CardState extends GameObject implements IHasSVars, ITranslatable {
 
     private ReplacementEffect loyaltyRep;
     private ReplacementEffect defenseRep;
-    private ReplacementEffect battleTypeRep;
     private ReplacementEffect sagaRep;
+    private ReplacementEffect adventureRep;
+    private ReplacementEffect omenRep;
 
     private SpellAbility manifestUp;
     private SpellAbility cloakUp;
@@ -513,19 +514,25 @@ public class CardState extends GameObject implements IHasSVars, ITranslatable {
             }
             result.add(defenseRep);
 
-            if (battleTypeRep == null) {
-                if(type.hasSubtype("Siege")) {
-                    // battleTypeRep; // - Choose a player to protect it
-                }
-            }
-            //result.add(battleTypeRep);
-
+            // TODO add Siege "Choose a player to protect it"
         }
         if (type.hasSubtype("Saga") && !hasKeyword(Keyword.READ_AHEAD)) {
             if (sagaRep == null) {
                 sagaRep = CardFactoryUtil.makeEtbCounter("etbCounter:LORE:1", this, true);
             }
             result.add(sagaRep);
+        }
+        if (type.hasSubtype("Adventure")) {
+            if (this.adventureRep == null) {
+                adventureRep = CardFactoryUtil.setupAdventureAbility(this);
+            }
+            result.add(adventureRep);
+        }
+        if (type.hasSubtype("Omen")) {
+            if (this.omenRep == null) {
+                omenRep = CardFactoryUtil.setupOmenAbility(this);
+            }
+            result.add(omenRep);
         }
 
         card.updateReplacementEffects(result, this);
@@ -686,6 +693,12 @@ public class CardState extends GameObject implements IHasSVars, ITranslatable {
             }
             if (source.sagaRep != null) {
                 sagaRep = source.sagaRep.copy(card, true);
+            }
+            if (source.adventureRep != null) {
+                adventureRep = source.adventureRep.copy(card, true);
+            }
+            if (source.omenRep != null) {
+                omenRep = source.omenRep.copy(card, true);
             }
         }
     }


### PR DESCRIPTION
This Updates Omen into an ReplacementEffect and moves both of them into Card State depending on the Type

(assuming something could mess with Spell Subtypes)