### PR TITLE
Fix AI removing creature from combat when checking Endure AI during an attack

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/EndureAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/EndureAi.java
@@ -51,7 +51,7 @@ public class EndureAi extends SpellAbilityAi {
 
         // need a copy for one with extra +1/+1 counter boost,
         // without causing triggers to run
-        final Card copy = CardCopyService.getLKICopy(source);
+        final Card copy = CardCopyService.copyStats(source, ai, true);
         copy.setCounters(CounterEnumType.P1P1, copy.getCounters(CounterEnumType.P1P1) + amount);
         copy.setZone(source.getZone());
 

--- a/forge-gui/res/lists/altwin-achievements.txt
+++ b/forge-gui/res/lists/altwin-achievements.txt
@@ -5,6 +5,7 @@ Azor's Elocutors|The Filibuster|Talk might be cheap, but it can buy you victory!
 Barren Glory|The Clean Slate|When you have nothing, you can lose nothing... so you can win everything!
 Battle of Wits|The Great Library|So many answers, so little time to look through them...
 Biovisionary|The Clique|And now my... I mean our plan is complete!
+Call the Spirit Dragons|The Final Call|The call... is coming from inside the dragonstorm!
 Chance Encounter|The Accident|This victory was brought to you by a series of fortunate events.
 Chance for Glory|The Big-Time|Sorry, you used it up.
 Coalition Victory|The Teamwork|Let's all be friends!

--- a/forge-gui/res/lists/planeswalker-achievements.txt
+++ b/forge-gui/res/lists/planeswalker-achievements.txt
@@ -211,6 +211,7 @@ The Royal Scions|Kenrith Twins' Ultimate Combo|You hit them, I'll tell you where
 Tibalt, Cosmic Impostor|Tibalt's Heist|Who says crime doesn't pay?
 Tibalt, the Fiend-Blooded|Tibalt's Treason|My side is the winning side!
 Tyvar Kell|Tyvar's Charge|To arms! To arms! And remember -- look fabulous!
+Ugin, Eye of the Storms|Ugin's Dragonstorm|The skies seem gray today... too gray.
 Ugin, the Spirit Dragon|Ugin's Anti-Ultimatum|A ragtag band of misfits, brought from the future...
 Urza, Planeswalker|Urza's Ruinous Blast|Thousands of years... of this?
 Venser, the Sojourner|Venser's Oblivion|Let's just clean this up a bit...


### PR DESCRIPTION
Fixes #7368.
The exact reason for this behavior is unknown, but copying the card with getLKICopy and then passing it to canBeBlockedProfitably removes the original from combat. Could it be that they are linked by ID? Using copyStats and assigning a new ID seems to do the job (the bug doesn't happen anymore), if a LKI copy would be preferred here, we need to test if getting a LKI copy and assigning a new ID would do the trick (not sure if there's a method for that, getLKICopy doesn't support it inherently).