### PR TITLE
Cleanup: Optional wheel update

### DIFF
--- a/forge-gui/res/cardsfolder/i/imposing_grandeur.txt
+++ b/forge-gui/res/cardsfolder/i/imposing_grandeur.txt
@@ -1,8 +1,13 @@
 Name:Imposing Grandeur
 ManaCost:4 R
 Types:Sorcery
-A:SP$ RepeatEach | RepeatPlayers$ Player | RepeatSubAbility$ DBDraw | SpellDescription$ Each player may discard their hand and draw cards equal to the greatest mana value of a commander they own on the battlefield or in the command zone.
-SVar:DBDraw:DB$ Draw | UnlessCost$ Discard<1/Hand> | UnlessPayer$ Remembered | UnlessSwitched$ True | Defined$ Remembered | NumCards$ X
+A:SP$ GenericChoice | TempRemember$ Chooser | ShowChoice$ ExceptSelf | Defined$ Player | Choices$ Discard,No | SubAbility$ DBGrandWheel | StackDescription$ REP Each player may_{p:Player} may each & they own_that player owns | SpellDescription$ Each player may discard their hand and draw cards equal to the greatest mana value of a commander they own on the battlefield or in the command zone.
+SVar:Discard:DB$ Pump | Defined$ Remembered | NoteCards$ Self | NoteCardsFor$ Discard | SpellDescription$ I will discard my hand.
+SVar:No:DB$ Pump | SpellDescription$ I will NOT discard my hand.
+SVar:DBGrandWheel:DB$ RepeatEach | RepeatPlayers$ Player.NotedForDiscard | RepeatSubAbility$ DBWheelDiscard | SubAbility$ DBClearNotes
+SVar:DBWheelDiscard:DB$ Discard | Mode$ Hand | Defined$ Player.IsRemembered | SubAbility$ DBWheelDraw
+SVar:DBWheelDraw:DB$ Draw | NumCards$ X | Defined$ Player.IsRemembered
+SVar:DBClearNotes:DB$ Pump | Defined$ Player | ClearNotedCardsFor$ Discard | StackDescription$ None
 SVar:X:Count$ValidBattlefield,Command Card.IsCommander+RememberedPlayerOwn$GreatestCMC
 AI:RemoveDeck:NonCommander
 DeckHas:Ability$Discard

--- a/forge-gui/res/cardsfolder/r/ruin_grinder.txt
+++ b/forge-gui/res/cardsfolder/r/ruin_grinder.txt
@@ -5,8 +5,8 @@ PT:7/4
 K:Menace
 T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigChoose | TriggerDescription$ When CARDNAME dies, each player may discard their hand and draw seven cards.
 SVar:TrigChoose:DB$ GenericChoice | TempRemember$ Chooser | ShowChoice$ ExceptSelf | Defined$ Player | Choices$ Discard,No | SubAbility$ DBDiscard
-SVar:Discard:DB$ Pump | Defined$ Remembered | NoteCards$ Self | NoteCardsFor$ Discard | SpellDescription$ Discard a card.
-SVar:No:DB$ Pump | SpellDescription$ Do not discard a card.
+SVar:Discard:DB$ Pump | Defined$ Remembered | NoteCards$ Self | NoteCardsFor$ Discard | SpellDescription$ I will discard my hand.
+SVar:No:DB$ Pump | SpellDescription$ I will NOT discard my hand.
 SVar:DBDiscard:DB$ Discard | Mode$ Hand | Defined$ Player.NotedForDiscard | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw | Defined$ Player.NotedForDiscard | NumCards$ 7 | SubAbility$ DBClearNotes
 SVar:DBClearNotes:DB$ Pump | Defined$ Player | ClearNotedCardsFor$ Discard

--- a/forge-gui/res/cardsfolder/s/sail_into_the_west.txt
+++ b/forge-gui/res/cardsfolder/s/sail_into_the_west.txt
@@ -1,13 +1,17 @@
 Name:Sail into the West
 ManaCost:2 G U
 Types:Instant
-A:SP$ Vote | Defined$ Player | VoteType$ Return,Embark | VoteReturn$ DBChangeZone | VoteEmbark$ DBWheel | Tied$ DBWheel | SpellDescription$ Will of the council — Starting with you, each player votes for return or embark. If return gets more votes, each player returns up to two cards from their graveyard to their hand, then you exile CARDNAME. If embark gets more votes or the vote is tied, each player may discard their hand and draw seven cards.
+A:SP$ Vote | Defined$ Player | VoteType$ Return,Embark | VoteReturn$ DBChangeZone | VoteEmbark$ DBWheel | Tied$ DBWheel | StackDescription$ REP you, each player votes_{p:You}, {p:Player} each vote & each player returns_{p:Player} each return & each player may_{p:Player} may each | SpellDescription$ Will of the council — Starting with you, each player votes for return or embark. If return gets more votes, each player returns up to two cards from their graveyard to their hand, then you exile CARDNAME. If embark gets more votes or the vote is tied, each player may discard their hand and draw seven cards.
 SVar:DBChangeZone:DB$ RepeatEach | RepeatPlayers$ Player | RepeatSubAbility$ DBChoose | SubAbility$ DBChangeZoneAll | SpellDescription$ If return gets more votes, each player returns up to two cards from their graveyard to their hand, then you exile CARDNAME.
 SVar:DBChoose:DB$ ChooseCard | Choices$ Card.RememberedPlayerCtrl | ChoiceZone$ Graveyard | Defined$ Player.IsRemembered | MinAmount$ 0 | Amount$ 2 | ChoiceTitle$ Select up to two cards from your graveyard | RememberChosen$ True
 SVar:DBChangeZoneAll:DB$ ChangeZoneAll | ChangeType$ Card.IsRemembered | Origin$ Graveyard | Destination$ Hand | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearChosenCard$ True | SubAbility$ ExileSelf
 SVar:ExileSelf:DB$ ChangeZone | Origin$ Stack | Destination$ Exile
-SVar:DBWheel:DB$ RepeatEach | RepeatPlayers$ Player | RepeatSubAbility$ DBDraw | SpellDescription$ If embark gets more votes or the vote is tied, each player may discard their hand and draw seven cards.
-SVar:DBDraw:DB$ Draw | UnlessCost$ Discard<1/Hand> | UnlessPayer$ Remembered | UnlessSwitched$ True | Defined$ Remembered | NumCards$ 7
+SVar:DBWheel:DB$ GenericChoice | TempRemember$ Chooser | ShowChoice$ ExceptSelf | Defined$ Player | Choices$ Discard,No | SubAbility$ DBDiscard | SpellDescription$ If embark gets more votes or the vote is tied, each player may discard their hand and draw seven cards.
+SVar:Discard:DB$ Pump | Defined$ Remembered | NoteCards$ Self | NoteCardsFor$ Discard | SpellDescription$ I will discard my hand.
+SVar:No:DB$ Pump | SpellDescription$ I will NOT discard my hand.
+SVar:DBDiscard:DB$ Discard | Mode$ Hand | Defined$ Player.NotedForDiscard | SubAbility$ DBDraw
+SVar:DBDraw:DB$ Draw | Defined$ Player.NotedForDiscard | NumCards$ 7 | SubAbility$ DBClearNotes
+SVar:DBClearNotes:DB$ Pump | Defined$ Player | ClearNotedCardsFor$ Discard
 DeckHas:Ability$Discard|Graveyard
 Oracle:Will of the council — Starting with you, each player votes for return or embark. If return gets more votes, each player returns up to two cards from their graveyard to their hand, then you exile Sail into the West. If embark gets more votes or the vote is tied, each player may discard their hand and draw seven cards.

--- a/forge-gui/res/cardsfolder/w/will_of_the_jeskai.txt
+++ b/forge-gui/res/cardsfolder/w/will_of_the_jeskai.txt
@@ -2,8 +2,12 @@ Name:Will of the Jeskai
 ManaCost:3 R
 Types:Sorcery
 A:SP$ Charm | MinCharmNum$ 1 | CharmNum$ Count$Compare Y GE1.2.1 | Choices$ DBWheel,DBFlames | AdditionalDescription$ . If you control a commander as you cast this spell, you may choose both instead.
-SVar:DBWheel:DB$ RepeatEach | RepeatPlayers$ Player | RepeatSubAbility$ DBDraw | SpellDescription$ Each player may discard their hand and draw five cards.
-SVar:DBDraw:DB$ Draw | UnlessCost$ Discard<1/Hand> | UnlessPayer$ Remembered | UnlessSwitched$ True | Defined$ Remembered | NumCards$ 5
+SVar:DBWheel:DB$ GenericChoice | TempRemember$ Chooser | ShowChoice$ ExceptSelf | Defined$ Player | Choices$ Discard,No | SubAbility$ DBDiscard | SpellDescription$ Each player may discard their hand and draw five cards.
+SVar:Discard:DB$ Pump | Defined$ Remembered | NoteCards$ Self | NoteCardsFor$ Discard | SpellDescription$ I will discard my hand.
+SVar:No:DB$ Pump | SpellDescription$ I will NOT discard my hand.
+SVar:DBDiscard:DB$ Discard | Mode$ Hand | Defined$ Player.NotedForDiscard | SubAbility$ DBDraw
+SVar:DBDraw:DB$ Draw | Defined$ Player.NotedForDiscard | NumCards$ 5 | SubAbility$ DBClearNotes
+SVar:DBClearNotes:DB$ Pump | Defined$ Player | ClearNotedCardsFor$ Discard | StackDescription$ None
 SVar:DBFlames:DB$ PumpAll | ValidCards$ Instant.YouCtrl,Sorcery.YouCtrl | KW$ Flashback | PumpZone$ Graveyard | SpellDescription$ Each instant and sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.
 SVar:Y:Count$Valid Card.IsCommander+YouCtrl
 DeckHas:Ability$Discard


### PR DESCRIPTION
As discussed [here](https://github.com/Card-Forge/forge/pull/7208#discussion_r2005290115), updating existing optional wheel effects formatted as an `UnlessCost$` by following [Ruin Grinder](https://scryfall.com/card/c21/57/ruin-grinder) instead, to comply with relevant rulings. 
- [Imposing Grandeur](https://scryfall.com/card/voc/24/imposing-grandeur)
- [Sail into the West](https://scryfall.com/card/ltc/68/sail-into-the-west)
- [Will of the Jeskai](https://scryfall.com/card/tdc/40/will-of-the-jeskai)

Also updating: 
- Ruin Grinder so the selectable options more closely reflect its dies effect.
- Adding a `StackDescription$` to Imposing Grandeur and Sail into the West so their Stack items read a bit better.