### PR TITLE
Fix Distended Mindbender

### DIFF
--- a/forge-gui/res/cardsfolder/d/distended_mindbender.txt
+++ b/forge-gui/res/cardsfolder/d/distended_mindbender.txt
@@ -7,6 +7,6 @@ T:Mode$ SpellCast | ValidCard$ Card.Self | Execute$ TrigReveal | TriggerDescript
 SVar:TrigReveal:DB$ RevealHand | ValidTgts$ Opponent | RememberRevealed$ True | SubAbility$ DBChoose
 SVar:DBChoose:DB$ ChooseCard | Defined$ You | Choices$ Card.IsRemembered+cmcLE3+nonLand | ChoiceZone$ Hand | Amount$ 1 | Mandatory$ True | ChoiceTitle$ Choose a nonland card with mana value 3 or less | ForgetChosen$ True | SubAbility$ DBChoose2
 SVar:DBChoose2:DB$ ChooseCard | Defined$ You | Choices$ Card.IsRemembered+cmcGE4 | ChoiceZone$ Hand | Amount$ 1 | Mandatory$ True | ChoiceTitle$ Choose a card with mana value 4 or greater | ForgetChosen$ True | SubAbility$ DBDiscard
-SVar:DBDiscard:DB$ Discard | Mode$ Defined | DefinedCards$ ValidHand Card.IsNotRemembered | Defined$ Targeted | SubAbility$ DBCleanup
+SVar:DBDiscard:DB$ Discard | Mode$ Defined | DefinedCards$ ValidHand Card.IsNotRemembered+OwnedBy Targeted | Defined$ Targeted | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Emerge {5}{B}{B} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's mana value.)\nWhen you cast this spell, target opponent reveals their hand. You choose from it a nonland card with mana value 3 or less and a card with mana value 4 or greater. That player discards those cards.

--- a/forge-gui/res/cardsfolder/m/monomania.txt
+++ b/forge-gui/res/cardsfolder/m/monomania.txt
@@ -2,5 +2,5 @@ Name:Monomania
 ManaCost:3 B B
 Types:Sorcery
 A:SP$ ChooseCard | ValidTgts$ Player | Mandatory$ True | Choices$ Card | SubAbility$ DBDiscard | AILogic$ AtLeast2 | TargetControls$ True | ChoiceZone$ Hand | StackDescription$ SpellDescription | SpellDescription$ Target player chooses a card in their hand and discards the rest.
-SVar:DBDiscard:DB$ Discard | Defined$ Targeted | Mode$ Defined | DefinedCards$ ValidHand Card.!ChosenCard
+SVar:DBDiscard:DB$ Discard | Defined$ Targeted | Mode$ Defined | DefinedCards$ ValidHand Card.!ChosenCard+OwnedBy Targeted
 Oracle:Target player chooses a card in their hand and discards the rest.


### PR DESCRIPTION
It only looks big because I was able to remove the ugly
`if ((mode.equals("RevealTgtChoose") && firstTarget != null) || !sa.usesTargeting() || p.canBeTargetedBy(sa))`
wrapping everything.

Closes #7380