### PR TITLE
removed getDirectSVars

### DIFF
--- a/forge-game/src/main/java/forge/game/CardTraitBase.java
+++ b/forge-game/src/main/java/forge/game/CardTraitBase.java
@@ -607,7 +607,7 @@ public abstract class CardTraitBase extends GameObject implements IHasCardView, 
     }
 
     @Override
-    public final void setSVar(final String name, final String value) {
+    public void setSVar(final String name, final String value) {
         sVars.put(name, value);
     }
 
@@ -620,11 +620,6 @@ public abstract class CardTraitBase extends GameObject implements IHasCardView, 
         }
         res.putAll(sVars);
         return res;
-    }
-
-    @Override
-    public Map<String, String> getDirectSVars() {
-        return sVars;
     }
 
     @Override

--- a/forge-game/src/main/java/forge/game/IHasSVars.java
+++ b/forge-game/src/main/java/forge/game/IHasSVars.java
@@ -15,7 +15,6 @@ public interface IHasSVars {
     //public Set<String> getSVars();
 
     public Map<String, String> getSVars();
-    public Map<String, String> getDirectSVars();
 
     public void removeSVar(final String var);
 }

--- a/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
@@ -1786,11 +1786,10 @@ public class AbilityUtils {
                 }
                 // Count$NumTimesChoseMode
                 if (sq[0].startsWith("NumTimesChoseMode")) {
-                    SpellAbility sub = sa.getRootAbility();
                     int amount = 0;
-                    while (sub != null) {
-                        if (sub.getDirectSVars().containsKey("CharmOrder")) amount++;
-                        sub = sub.getSubAbility();
+                    SpellAbility tail = sa.getTailAbility();
+                    if (tail.hasSVar("CharmOrder")) {
+                        amount = tail.getSVarInt("CharmOrder");
                     }
                     return doXMath(amount, expr, c, ctb);
                 }

--- a/forge-game/src/main/java/forge/game/ability/effects/CharmEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CharmEffect.java
@@ -45,7 +45,7 @@ public class CharmEffect extends SpellAbilityEffect {
             choices.removeAll(toRemove);
         }
 
-        int indx = 0;
+        int indx = 1;
         // set CharmOrder
         for (AbilitySub sub : choices) {
             sub.setSVar("CharmOrder", Integer.toString(indx));

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -2017,11 +2017,6 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
         return currentState.getSVars();
     }
 
-    @Override
-    public Map<String, String> getDirectSVars() {
-        return ImmutableMap.of();
-    }
-
     public final void setSVars(final Map<String, String> newSVars) {
         currentState.setSVars(newSVars);
     }

--- a/forge-game/src/main/java/forge/game/card/CardState.java
+++ b/forge-game/src/main/java/forge/game/card/CardState.java
@@ -570,11 +570,6 @@ public class CardState extends GameObject implements IHasSVars, ITranslatable {
     }
 
     @Override
-    public Map<String, String> getDirectSVars() {
-        return sVars;
-    }
-
-    @Override
     public final String getSVar(final String var) {
         if (sVars.containsKey(var)) {
             return sVars.get(var);

--- a/forge-game/src/main/java/forge/game/cost/CostAdjustment.java
+++ b/forge-game/src/main/java/forge/game/cost/CostAdjustment.java
@@ -128,14 +128,10 @@ public class CostAdjustment {
         } else if (st.hasParam("Amount")) {
             String amount = st.getParam("Amount");
             if ("Escalate".equals(amount)) {
-                SpellAbility sub = sa;
-                while (sub != null) {
-                    if (sub.getDirectSVars().containsKey("CharmOrder")) {
-                        count++;
-                    }
-                    sub = sub.getSubAbility();
+                SpellAbility tail = sa.getTailAbility();
+                if (tail.hasSVar("CharmOrder")) {
+                    count = tail.getSVarInt("CharmOrder") - 1;
                 }
-                --count;
             } else if ("Strive".equals(amount)) {
                 for (TargetChoices tc : sa.getAllTargetChoices()) {
                     count += tc.size();

--- a/forge-game/src/main/java/forge/game/keyword/KeywordInstance.java
+++ b/forge-game/src/main/java/forge/game/keyword/KeywordInstance.java
@@ -411,11 +411,6 @@ public abstract class KeywordInstance<T extends KeywordInstance<?>> implements K
     }
 
     @Override
-    public Map<String, String> getDirectSVars() {
-        return null;
-    }
-
-    @Override
     public void setSVars(Map<String, String> newSVars) {
     }
 

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
@@ -1180,11 +1180,7 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
         view.updateDescription(this);
     }
     public void appendSubAbility(final AbilitySub toAdd) {
-        SpellAbility tailend = this;
-        while (tailend.getSubAbility() != null) {
-            tailend = tailend.getSubAbility();
-        }
-        tailend.setSubAbility(toAdd);
+        getTailAbility().setSubAbility(toAdd);
     }
 
     public boolean isBasicSpell() {
@@ -1641,6 +1637,13 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
             parent = parent.getParent();
         }
         return parent;
+    }
+    public SpellAbility getTailAbility() {
+        SpellAbility tailend = this;
+        while (tailend.getSubAbility() != null) {
+            tailend = tailend.getSubAbility();
+        }
+        return tailend;
     }
 
     public SpellAbility getParent() {

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbilityStackInstance.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbilityStackInstance.java
@@ -31,7 +31,6 @@ import forge.game.card.CardView;
 import forge.game.card.IHasCardView;
 import forge.game.player.Player;
 import forge.game.trigger.TriggerType;
-import forge.game.trigger.WrappedAbility;
 import forge.util.TextUtil;
 
 /**
@@ -75,10 +74,9 @@ public class SpellAbilityStackInstance implements IIdentifiable, IHasCardView {
 
         subInstance = ability.getSubAbility() == null ? null : new SpellAbilityStackInstance(ability.getSubAbility());
 
-        final Map<String, String> sVars = (ability.isWrapper() ? ((WrappedAbility) ability).getWrappedAbility() : ability).getDirectSVars();
-        if (ApiType.SetState == sa.getApi() && !sVars.containsKey("StoredTransform")) {
+        if (ApiType.SetState == sa.getApi() && !ability.hasSVar("StoredTransform")) {
             // Record current state of Transformation if the ability might change state
-            sVars.put("StoredTransform", String.valueOf(ability.getHostCard().getTransformedTimestamp()));
+            ability.setSVar("StoredTransform", String.valueOf(ability.getHostCard().getTransformedTimestamp()));
         }
 
         if (sa.getApi() == ApiType.Charm && sa.hasParam("ChoiceRestriction")) {

--- a/forge-game/src/main/java/forge/game/trigger/WrappedAbility.java
+++ b/forge-game/src/main/java/forge/game/trigger/WrappedAbility.java
@@ -297,6 +297,11 @@ public class WrappedAbility extends Ability {
     }
 
     @Override
+    public void setSVar(final String name, final String value) {
+        sa.setSVar(name, value);
+    }
+
+    @Override
     public Map<String, String> getSVars() {
         return sa.getSVars();
     }


### PR DESCRIPTION
I removed `getDirectSVars` and did some cleanup

one other thing i would like to remove is in createEffect, the call for `eff.setSVars(sa.getSVars());`

This is the reason why this still exist:
```java

    @Override
    public Map<String, String> getSVars() {
        Map<String, String> res = Maps.newHashMap();
        // TODO reverse the order
        for (IHasSVars s : getSVarFallback()) {
            res.putAll(s.getSVars());
        }
        res.putAll(sVars);
        return res;
    }
```

so what if Effect just uses `effectSourceAbility` instead? Or is the problem in case the Svars get cleaned up?