### PR TITLE
[Adventure] Fix for beating castles before getting there in main quest

### DIFF
--- a/forge-gui/res/adventure/Shandalar/world/quests.json
+++ b/forge-gui/res/adventure/Shandalar/world/quests.json
@@ -6899,7 +6899,7 @@
 {
 	"id": 28,
 	"isTemplate": true,
-	"name": "Welcome to Shandalar",
+	"name": "Entering Shandalar",
 	"description": "Learn about your surroundings.",
 	"offerDialog": {},
 	"prologue": {
@@ -6914,6 +6914,7 @@
 							{
 								"removeItem": "",
 								"setColorIdentity": "",
+								"activateMapObject": 78,
 								"advanceQuestFlag": "",
 								"advanceMapFlag": "",
 								"setQuestFlag": {
@@ -7037,12 +7038,12 @@
 						"action": [
 							{
 								"removeItem": "",
-								"activateMapObject": 78,
 								"setColorIdentity": "",
 								"advanceQuestFlag": "",
 								"advanceMapFlag": "",
-								"setMapFlag": {
-									"key": ""
+								"setCharacterFlag": {
+									"key": "noQuest",
+									"val": "1"
 								},
 								"issueQuest": "",
 								"POIReference": ""
@@ -11278,7 +11279,7 @@
 									"setMapFlag": {
 										"key": ""
 									},
-									"issueQuest": "52",
+									"issueQuest": "30",
 									"POIReference": ""
 								}
 							]

--- a/forge-gui/res/adventure/Shandalar/world/quests.json
+++ b/forge-gui/res/adventure/Shandalar/world/quests.json
@@ -11278,7 +11278,7 @@
 									"setMapFlag": {
 										"key": ""
 									},
-									"issueQuest": "30",
+									"issueQuest": "52",
 									"POIReference": ""
 								}
 							]

--- a/forge-gui/res/adventure/Shandalar/world/quests.json
+++ b/forge-gui/res/adventure/Shandalar/world/quests.json
@@ -6906,14 +6906,123 @@
 		"text": "Darkness and silence surrounds you. A vague sense of falling slows second by second.",
 		"options": [
 			{
-				"name": "Where am I? What am I? What is going on?",
+				"name": "Where am I? What am I? What is going on? (Tutorial and main quest)",
 				"text": "A flash of light brighter than anything you remember precedes a fall to a stone floor. This is almost as jarring as realizing that you actually don't remember much of anything at all.",
 				"options": [
 					{
-						"name": "(Continue)",
+						"action": [
+							{
+								"removeItem": "",
+								"setColorIdentity": "",
+								"advanceQuestFlag": "",
+								"advanceMapFlag": "",
+								"setQuestFlag": {
+									"key": "exploreShand1",
+									"val": 1
+								},
+								"setMapFlag": {
+									"key": ""
+								},
+								"issueQuest": "53",
+								"POIReference": ""
+							}
+						],
+						"name": "Let's talk to the mage over there.",
 						"text": "A quiet crackling sound draws your eyes to the flickering light of a fire within the cave you now occupy. A hooded figure stands by the fire, facing you as if expecting your arrival."
 					}
 				]
+			},
+			{
+				"action": [
+					{
+						"removeItem": "",
+						"setColorIdentity": "",
+						"advanceQuestFlag": "",
+						"advanceMapFlag": "",
+						"setQuestFlag": {
+							"key": "shandWalkers1",
+							"val": 1
+						},
+						"setMapFlag": {
+							"key": ""
+						},
+						"issueQuest": "",
+						"POIReference": ""
+					}
+				],
+				"name": "I want to find the planeswalkers (Future release)",
+				"text": "Well, shouting \"Planeswalkers, where are you?\" into the wastes won't do much. Travel to the nearest settlement and ask around for information.",
+				"options": [
+					{
+						"action": [
+							{
+								"removeItem": "",
+								"setColorIdentity": "",
+								"advanceQuestFlag": "",
+								"advanceMapFlag": "",
+								"setQuestFlag": {
+									"key": ""
+								},
+								"setMapFlag": {
+									"key": ""
+								},
+								"issueQuest": "29",
+								"POIReference": ""
+							}
+						],
+						"name": "(Continue)",
+						"text": "New Quest: A Chat with the Locals - Objective: Travel to any town in the wasteland.",
+						"options": [
+							{
+								"name": "(Dismiss)"
+							}
+						]
+					}
+				],
+				"isDisabled": true
+			},
+			{
+				"action": [
+					{
+						"removeItem": "",
+						"setColorIdentity": "",
+						"advanceQuestFlag": "",
+						"advanceMapFlag": "",
+						"setQuestFlag": {
+							"key": "shandRep1",
+							"val": 1
+						},
+						"setMapFlag": {
+							"key": ""
+						},
+						"issueQuest": "",
+						"POIReference": ""
+					}
+				],
+				"name": "I want to make a name for myself (Future release)",
+				"text": "Then let's go impress some people. But first, you need some impressive spells. Build your collection to begin your quest.",
+				"options": [
+					{
+						"action": [
+							{
+								"removeItem": "",
+								"setColorIdentity": "",
+								"advanceQuestFlag": "",
+								"advanceMapFlag": "",
+								"setQuestFlag": {
+									"key": ""
+								},
+								"setMapFlag": {
+									"key": ""
+								},
+								"issueQuest": "31",
+								"POIReference": ""
+							}
+						],
+						"name": "(Dismiss)"
+					}
+				],
+				"isDisabled": true
 			},
 			{
 				"condition": [
@@ -6932,10 +7041,6 @@
 								"setColorIdentity": "",
 								"advanceQuestFlag": "",
 								"advanceMapFlag": "",
-								"setQuestFlag": {
-									"key": "mainQuest",
-									"val": 1
-								},
 								"setMapFlag": {
 									"key": ""
 								},
@@ -6959,163 +7064,6 @@
 			}
 		]
 	},
-	"stages": [
-		{
-			"id": 1,
-			"name": "Talk to the nearby mage",
-			"description": "There's not a lot to do in here other than talk to him, and any information is more than you have right now.",
-			"mapFlag": "mainQuest",
-			"mapFlagValue": 1,
-			"objective": "QuestFlag",
-			"prologue": {},
-			"epilogue": {},
-			"POIToken": ""
-		},
-		{
-			"id": 2,
-			"name": "Exit the cave",
-			"description": "The portal is open and you can leave now.",
-			"anyPOI": true,
-			"mapFlag": "",
-			"mapFlagValue": 1,
-			"objective": "Leave",
-			"prerequisiteIDs": [ 1 ],
-			"prologue": {},
-			"epilogue": {
-				"text": "So, you have a quest of sorts now: Find and free the planeswalkers. But is that really what you want to do? Despite the fog covering your memory, you are certain that you are powerful enough to take care of yourself.",
-				"options": [
-					{
-						"action": [
-							{
-								"removeItem": "",
-								"setColorIdentity": "",
-								"advanceQuestFlag": "",
-								"advanceMapFlag": "",
-								"setQuestFlag": {
-									"key": "shandWalkers1",
-									"val": 1
-								},
-								"setMapFlag": {
-									"key": ""
-								},
-								"issueQuest": "",
-								"POIReference": ""
-							}
-						],
-						"name": "I want to find the planeswalkers (Future release)",
-						"text": "Well, shouting \"Planeswalkers, where are you?\" into the wastes won't do much. Travel to the nearest settlement and ask around for information.",
-						"options": [
-							{
-								"action": [
-									{
-										"removeItem": "",
-										"setColorIdentity": "",
-										"advanceQuestFlag": "",
-										"advanceMapFlag": "",
-										"setQuestFlag": {
-											"key": ""
-										},
-										"setMapFlag": {
-											"key": ""
-										},
-										"issueQuest": "29",
-										"POIReference": ""
-									}
-								],
-								"name": "(Continue)",
-								"text": "New Quest: A Chat with the Locals - Objective: Travel to any town in the wasteland.",
-								"options": [
-									{
-										"name": "(Dismiss)"
-									}
-								]
-							}
-						],
-						"isDisabled": true
-					},
-					{
-						"action": [
-							{
-								"removeItem": "",
-								"setColorIdentity": "",
-								"advanceQuestFlag": "",
-								"advanceMapFlag": "",
-								"setQuestFlag": {
-									"key": "exploreShand1",
-									"val": 1
-								},
-								"setMapFlag": {
-									"key": ""
-								},
-								"issueQuest": "30",
-								"POIReference": ""
-							}
-						],
-						"name": "I want to explore Shandalar ((Has a brief tutorial))"
-					},
-					{
-						"action": [
-							{
-								"removeItem": "",
-								"setColorIdentity": "",
-								"advanceQuestFlag": "",
-								"advanceMapFlag": "",
-								"setQuestFlag": {
-									"key": "shandRep1",
-									"val": 1
-								},
-								"setMapFlag": {
-									"key": ""
-								},
-								"issueQuest": "",
-								"POIReference": ""
-							}
-						],
-						"name": "I want to make a name for myself (Future release)",
-						"text": "Then let's go impress some people. But first, you need some impressive spells. Build your collection to begin your quest.",
-						"options": [
-							{
-								"action": [
-									{
-										"removeItem": "",
-										"setColorIdentity": "",
-										"advanceQuestFlag": "",
-										"advanceMapFlag": "",
-										"setQuestFlag": {
-											"key": ""
-										},
-										"setMapFlag": {
-											"key": ""
-										},
-										"issueQuest": "31",
-										"POIReference": ""
-									}
-								],
-								"name": "(Dismiss)"
-							}
-						],
-						"isDisabled": true
-					},
-					{
-						"action": [
-							{
-								"removeItem": "",
-								"setColorIdentity": "",
-								"advanceQuestFlag": "",
-								"advanceMapFlag": "",
-								"setMapFlag": {
-									"key": ""
-								},
-								"POIReference": ""
-							}
-						],
-						"name": "I want to do my own thing (Disables main quest)"
-					}
-				]
-			},
-			"POIToken": ""
-		}
-	],
 	"storyQuest": true
 },
 {
@@ -7359,7 +7307,7 @@
 												"setMapFlag": {
 													"key": ""
 												},
-												"issueQuest": "43",
+												"issueQuest": "52",
 												"POIReference": ""
 											}
 										],
@@ -11279,5 +11227,67 @@
 		}
 	],
 	"storyQuest": true
-}
+},
+	{
+		"id": 53,
+		"isTemplate": true,
+		"name": "Welcome to Shandalar",
+		"description": "Learn about your surroundings.",
+		"offerDialog": {},
+		"prologue": {},
+		"epilogue": {},
+		"failureDialog": {},
+		"declinedDialog": {},
+		"stages": [
+			{
+				"id": 1,
+				"name": "Talk to the nearby mage",
+				"description": "There's not a lot to do in here other than talk to him, and any information is more than you have right now.",
+				"mapFlag": "mainQuest",
+				"mapFlagValue": 1,
+				"objective": "QuestFlag",
+				"prologue": {},
+				"epilogue": {},
+				"POIToken": ""
+			},
+			{
+				"id": 2,
+				"name": "Exit the cave",
+				"description": "The portal is open and you can leave now.",
+				"anyPOI": true,
+				"mapFlag": "",
+				"mapFlagValue": 1,
+				"objective": "Leave",
+				"prerequisiteIDs": [ 1 ],
+				"prologue": {},
+				"epilogue": {
+					"text": "You find yourself stranded on an unknown plane. It's time to get your bearings.",
+					"options": [
+						{
+							"name": "(Continue)",
+							"action": [
+								{
+									"removeItem": "",
+									"setColorIdentity": "",
+									"advanceQuestFlag": "",
+									"advanceMapFlag": "",
+									"setQuestFlag": {
+										"key": "shandRep1",
+										"val": 1
+									},
+									"setMapFlag": {
+										"key": ""
+									},
+									"issueQuest": "30",
+									"POIReference": ""
+								}
+							]
+						}
+					]
+				},
+				"POIToken": ""
+			}
+		],
+		"storyQuest": true
+	}
 ]

--- a/forge-gui/res/adventure/Shandalar/world/quests.json
+++ b/forge-gui/res/adventure/Shandalar/world/quests.json
@@ -7095,6 +7095,21 @@
 							}
 						],
 						"isDisabled": true
+					},
+					{
+						"action": [
+							{
+								"removeItem": "",
+								"setColorIdentity": "",
+								"advanceQuestFlag": "",
+								"advanceMapFlag": "",
+								"setMapFlag": {
+									"key": ""
+								},
+								"POIReference": ""
+							}
+						],
+						"name": "I want to do my own thing (Disables main quest)"
 					}
 				]
 			},

--- a/forge-gui/res/adventure/common/maps/map/main_story/castles/black_castle.tmx
+++ b/forge-gui/res/adventure/common/maps/map/main_story/castles/black_castle.tmx
@@ -105,7 +105,11 @@
                 		}
                 	},
                     {
-                        &quot;checkQuestFlag&quot;: &quot;Ch1BlackCastleComplete&quot;
+                        &quot;checkQuestFlag&quot;: &quot;Ch1BlackCastleComplete&quot;,
+                        &quot;not&quot;: true
+                    },
+                    {
+                        &quot;checkQuestFlag&quot;: &quot;mainQuest&quot;
                     }
                 	],
                 		&quot;text&quot;: &quot;With a gust of black wind, the door scatters into thousands of pieces. You are now free to pass.&quot;,

--- a/forge-gui/res/adventure/common/maps/map/main_story/castles/black_castle.tmx
+++ b/forge-gui/res/adventure/common/maps/map/main_story/castles/black_castle.tmx
@@ -67,7 +67,7 @@
     <property name="dialog">[
 	{
 		&quot;name&quot;: &quot;&quot;,
-		&quot;text&quot;: &quot;You enter the gate.&quot;,
+		&quot;text&quot;: &quot;You come upon the gate.&quot;,
 		&quot;loctext&quot;: &quot;&quot;,
 		&quot;action&quot;: [
 			{ &quot;advanceMapFlag&quot;: &quot;intro&quot; }
@@ -84,11 +84,32 @@
 								&quot;op&quot;: &quot;&gt;=&quot;,
 								&quot;val&quot;: 4
 							}
-						}
+						},
+						{
+                            &quot;checkQuestFlag&quot;: &quot;mainQuest&quot;
+                        }
 					],
 					&quot;text&quot;: &quot;With a gust of black wind, the door scatters into thousands of pieces. You are now free to pass.&quot;,
 					&quot;options&quot;: [ { &quot;name&quot;: &quot;(continue)&quot; } ]
 				},
+				{
+                	&quot;name&quot;: &quot;Griselbrand, I've done as you asked ! It's time to end this !&quot;,
+                	&quot;action&quot;: [ { &quot;deleteMapObject&quot;: 55 } ],
+                	&quot;condition&quot;: [
+                	{
+                		&quot;getMapFlag&quot;: {
+                	    	&quot;key&quot;: &quot;enemiesDefeated&quot;,
+                			&quot;op&quot;: &quot;&gt;=&quot;,
+                			&quot;val&quot;: 4
+                		}
+                	},
+                    {
+                        &quot;checkQuestFlag&quot;: &quot;Ch1BlackCastleComplete&quot;
+                    }
+                	],
+                		&quot;text&quot;: &quot;With a gust of black wind, the door scatters into thousands of pieces. You are now free to pass.&quot;,
+                		&quot;options&quot;: [ { &quot;name&quot;: &quot;(continue)&quot; } ]
+                },
 				{
 					&quot;name&quot;: &quot;You knock on the door&quot;,
 					&quot;condition&quot;: [ { &quot;checkMapFlag&quot;: &quot;intro&quot; } ],

--- a/forge-gui/res/adventure/common/maps/map/main_story/castles/black_castle.tmx
+++ b/forge-gui/res/adventure/common/maps/map/main_story/castles/black_castle.tmx
@@ -86,7 +86,8 @@
 							}
 						},
 						{
-                            &quot;checkQuestFlag&quot;: &quot;mainQuest&quot;
+                            &quot;checkQuestFlag&quot;: &quot;mainQuest&quot;,
+                            &quot;not&quot;: true
                         }
 					],
 					&quot;text&quot;: &quot;With a gust of black wind, the door scatters into thousands of pieces. You are now free to pass.&quot;,

--- a/forge-gui/res/adventure/common/maps/map/main_story/castles/blue_castle.tmx
+++ b/forge-gui/res/adventure/common/maps/map/main_story/castles/blue_castle.tmx
@@ -118,7 +118,11 @@
                 			}
                 		},
                 		{
-                             &quot;checkQuestFlag&quot;: &quot;Ch1BlueCastleComplete&quot;
+                             &quot;checkQuestFlag&quot;: &quot;Ch1BlueCastleComplete&quot;,
+                             &quot;not&quot;: true
+                        },
+                        {
+                             &quot;checkQuestFlag&quot;: &quot;mainQuest&quot;
                         }
                 	],
                 		&quot;text&quot;: &quot;Suddently, the gate dissapears right in front of your eyes, You are now free to pass.&quot;,

--- a/forge-gui/res/adventure/common/maps/map/main_story/castles/blue_castle.tmx
+++ b/forge-gui/res/adventure/common/maps/map/main_story/castles/blue_castle.tmx
@@ -80,7 +80,7 @@
     <property name="dialog">[
 	{
 		&quot;name&quot;: &quot;&quot;,
-		&quot;text&quot;: &quot;You enter the gate.&quot;,
+		&quot;text&quot;: &quot;You come upon a gate.&quot;,
 		&quot;loctext&quot;: &quot;&quot;,
 		&quot;action&quot;: [
 			{ &quot;advanceMapFlag&quot;: &quot;intro&quot; }
@@ -97,11 +97,32 @@
 								&quot;op&quot;: &quot;&gt;=&quot;,
 								&quot;val&quot;: 4
 							}
-						}
+						},
+						{
+                            &quot;checkQuestFlag&quot;: &quot;mainQuest&quot;
+                        }
 					],
 					&quot;text&quot;: &quot;Suddently, the gate dissapears right in front of your eyes, You are now free to pass.&quot;,
 					&quot;options&quot;: [ { &quot;name&quot;: &quot;(continue)&quot; } ]
 				},
+				{
+                	&quot;name&quot;: &quot;Lorthos, I've done as you asked ! It's time to end this !&quot;,
+                	&quot;action&quot;: [ { &quot;deleteMapObject&quot;: 55 } ],
+                	&quot;condition&quot;: [
+                		{
+                			&quot;getMapFlag&quot;: {
+                				&quot;key&quot;: &quot;enemiesDefeated&quot;,
+                				&quot;op&quot;: &quot;&gt;=&quot;,
+                				&quot;val&quot;: 4
+                			}
+                		},
+                		{
+                             &quot;checkQuestFlag&quot;: &quot;Ch1BlueCastleComplete&quot;
+                        }
+                	],
+                		&quot;text&quot;: &quot;Suddently, the gate dissapears right in front of your eyes, You are now free to pass.&quot;,
+                		&quot;options&quot;: [ { &quot;name&quot;: &quot;(continue)&quot; } ]
+                },
 				{
 					&quot;name&quot;: &quot;You knock on the door&quot;,
 					&quot;condition&quot;: [ { &quot;checkMapFlag&quot;: &quot;intro&quot; } ],

--- a/forge-gui/res/adventure/common/maps/map/main_story/castles/blue_castle.tmx
+++ b/forge-gui/res/adventure/common/maps/map/main_story/castles/blue_castle.tmx
@@ -99,7 +99,8 @@
 							}
 						},
 						{
-                            &quot;checkQuestFlag&quot;: &quot;mainQuest&quot;
+                            &quot;checkQuestFlag&quot;: &quot;mainQuest&quot;,
+                            &quot;not&quot;: true
                         }
 					],
 					&quot;text&quot;: &quot;Suddently, the gate dissapears right in front of your eyes, You are now free to pass.&quot;,

--- a/forge-gui/res/adventure/common/maps/map/main_story/castles/green_castle.tmx
+++ b/forge-gui/res/adventure/common/maps/map/main_story/castles/green_castle.tmx
@@ -111,7 +111,11 @@
                 			}
                 		},
                 		{
-                               &quot;checkQuestFlag&quot;: &quot;Ch1GreenCastleComplete&quot;
+                               &quot;checkQuestFlag&quot;: &quot;Ch1GreenCastleComplete&quot;,
+                               &quot;not&quot;: true
+                        },
+                        {
+                            &quot;checkQuestFlag&quot;: &quot;mainQuest&quot;
                         }
                 	],
                 	&quot;text&quot;: &quot;With an extremely loud roar, the gate burst open, leaving only ashes in your path. You are now free to pass.&quot;,

--- a/forge-gui/res/adventure/common/maps/map/main_story/castles/green_castle.tmx
+++ b/forge-gui/res/adventure/common/maps/map/main_story/castles/green_castle.tmx
@@ -73,7 +73,7 @@
     <property name="dialog">[
 	{
 		&quot;name&quot;: &quot;&quot;,
-		&quot;text&quot;: &quot;You enter the gate.&quot;,
+		&quot;text&quot;: &quot;You come upon a gate.&quot;,
 		&quot;loctext&quot;: &quot;&quot;,
 		&quot;action&quot;: [
 			{ &quot;advanceMapFlag&quot;: &quot;intro&quot; }
@@ -90,11 +90,32 @@
 								&quot;op&quot;: &quot;&gt;=&quot;,
 								&quot;val&quot;: 4
 							}
-						}
+						},
+						{
+                             &quot;checkQuestFlag&quot;: &quot;mainQuest&quot;
+                        }
 					],
 					&quot;text&quot;: &quot;With an extremely loud roar, the gate burst open, leaving only ashes in your path. You are now free to pass.&quot;,
 					&quot;options&quot;: [ { &quot;name&quot;: &quot;(continue)&quot; } ]
 				},
+				{
+                	&quot;name&quot;: &quot;Ghalta, I've done as you asked ! It's time to end this !&quot;,
+                	&quot;action&quot;: [ { &quot;deleteMapObject&quot;: 55 } ],
+                	&quot;condition&quot;: [
+                		{
+                			&quot;getMapFlag&quot;: {
+                				&quot;key&quot;: &quot;enemiesDefeated&quot;,
+                				&quot;op&quot;: &quot;&gt;=&quot;,
+                				&quot;val&quot;: 4
+                			}
+                		},
+                		{
+                               &quot;checkQuestFlag&quot;: &quot;Ch1GreenCastleComplete&quot;
+                        }
+                	],
+                	&quot;text&quot;: &quot;With an extremely loud roar, the gate burst open, leaving only ashes in your path. You are now free to pass.&quot;,
+                	&quot;options&quot;: [ { &quot;name&quot;: &quot;(continue)&quot; } ]
+                },
 				{
 					&quot;name&quot;: &quot;You knock on the door&quot;,
 					&quot;condition&quot;: [ { &quot;checkMapFlag&quot;: &quot;intro&quot; } ],

--- a/forge-gui/res/adventure/common/maps/map/main_story/castles/green_castle.tmx
+++ b/forge-gui/res/adventure/common/maps/map/main_story/castles/green_castle.tmx
@@ -92,7 +92,8 @@
 							}
 						},
 						{
-                             &quot;checkQuestFlag&quot;: &quot;mainQuest&quot;
+                            &quot;checkQuestFlag&quot;: &quot;mainQuest&quot;,
+                            &quot;not&quot;: true
                         }
 					],
 					&quot;text&quot;: &quot;With an extremely loud roar, the gate burst open, leaving only ashes in your path. You are now free to pass.&quot;,

--- a/forge-gui/res/adventure/common/maps/map/main_story/castles/red_castle.tmx
+++ b/forge-gui/res/adventure/common/maps/map/main_story/castles/red_castle.tmx
@@ -111,7 +111,11 @@
                 			}
                 		},
                 		{
-                            &quot;checkQuestFlag&quot;: &quot;Ch1RedCastleComplete&quot;
+                            &quot;checkQuestFlag&quot;: &quot;Ch1RedCastleComplete&quot;,
+                            &quot;not&quot;: true
+                        },
+                        {
+                            &quot;checkQuestFlag&quot;: &quot;mainQuest&quot;
                         }
                 	],
                 	&quot;text&quot;: &quot;With a gust of red flames, the door burns away, leaving only ashes in your path. You are now free to pass.&quot;,

--- a/forge-gui/res/adventure/common/maps/map/main_story/castles/red_castle.tmx
+++ b/forge-gui/res/adventure/common/maps/map/main_story/castles/red_castle.tmx
@@ -73,7 +73,7 @@
     <property name="dialog">[
 	{
 		&quot;name&quot;: &quot;&quot;,
-		&quot;text&quot;: &quot;You enter the gate.&quot;,
+		&quot;text&quot;: &quot;You come upon a gate.&quot;,
 		&quot;loctext&quot;: &quot;&quot;,
 		&quot;action&quot;: [
 			{ &quot;advanceMapFlag&quot;: &quot;intro&quot; }
@@ -90,11 +90,32 @@
 								&quot;op&quot;: &quot;&gt;=&quot;,
 								&quot;val&quot;: 4
 							}
-						}
+						},
+						{
+                            &quot;checkQuestFlag&quot;: &quot;mainQuest&quot;
+                        }
 					],
 					&quot;text&quot;: &quot;With a gust of red flames, the door burns away, leaving only ashes in your path. You are now free to pass.&quot;,
 					&quot;options&quot;: [ { &quot;name&quot;: &quot;(continue)&quot; } ]
 				},
+				{
+                	&quot;name&quot;: &quot;Lathliss, I've done as you asked ! It's time to end this !&quot;,
+                	&quot;action&quot;: [ { &quot;deleteMapObject&quot;: 55 } ],
+                	&quot;condition&quot;: [
+                		{
+                    		&quot;getMapFlag&quot;: {
+                				&quot;key&quot;: &quot;enemiesDefeated&quot;,
+                				&quot;op&quot;: &quot;&gt;=&quot;,
+                				&quot;val&quot;: 4
+                			}
+                		},
+                		{
+                            &quot;checkQuestFlag&quot;: &quot;Ch1RedCastleComplete&quot;
+                        }
+                	],
+                	&quot;text&quot;: &quot;With a gust of red flames, the door burns away, leaving only ashes in your path. You are now free to pass.&quot;,
+                	&quot;options&quot;: [ { &quot;name&quot;: &quot;(continue)&quot; } ]
+                },
 				{
 					&quot;name&quot;: &quot;You knock on the door&quot;,
 					&quot;condition&quot;: [ { &quot;checkMapFlag&quot;: &quot;intro&quot; } ],

--- a/forge-gui/res/adventure/common/maps/map/main_story/castles/red_castle.tmx
+++ b/forge-gui/res/adventure/common/maps/map/main_story/castles/red_castle.tmx
@@ -92,7 +92,8 @@
 							}
 						},
 						{
-                            &quot;checkQuestFlag&quot;: &quot;mainQuest&quot;
+                            &quot;checkQuestFlag&quot;: &quot;mainQuest&quot;,
+                            &quot;not&quot;: true
                         }
 					],
 					&quot;text&quot;: &quot;With a gust of red flames, the door burns away, leaving only ashes in your path. You are now free to pass.&quot;,

--- a/forge-gui/res/adventure/common/maps/map/main_story/castles/white_castle.tmx
+++ b/forge-gui/res/adventure/common/maps/map/main_story/castles/white_castle.tmx
@@ -111,7 +111,11 @@
                 				}
                 			},
                 			{
-                                &quot;checkQuestFlag&quot;: &quot;Ch1WhiteCastleComplete&quot;
+                                &quot;checkQuestFlag&quot;: &quot;Ch1WhiteCastleComplete&quot;,
+                                &quot;not&quot;: true
+                            },
+                            {
+                                &quot;checkQuestFlag&quot;: &quot;mainQuest&quot;
                             }
                 		],
                 		&quot;text&quot;: &quot;With an extremely loud blast, the gate burst open, leaving only ashes in your path. You are now free to pass.&quot;,

--- a/forge-gui/res/adventure/common/maps/map/main_story/castles/white_castle.tmx
+++ b/forge-gui/res/adventure/common/maps/map/main_story/castles/white_castle.tmx
@@ -92,7 +92,8 @@
 							}
 						},
 						{
-                            &quot;checkQuestFlag&quot;: &quot;mainQuest&quot;
+                            &quot;checkQuestFlag&quot;: &quot;mainQuest&quot;,
+                            &quot;not&quot;: true
                         }
 					],
 					&quot;text&quot;: &quot;With an extremely loud blast, the gate burst open, leaving only ashes in your path. You are now free to pass.&quot;,

--- a/forge-gui/res/adventure/common/maps/map/main_story/castles/white_castle.tmx
+++ b/forge-gui/res/adventure/common/maps/map/main_story/castles/white_castle.tmx
@@ -73,7 +73,7 @@
     <property name="dialog">[
 	{
 		&quot;name&quot;: &quot;&quot;,
-		&quot;text&quot;: &quot;You enter the gate.&quot;,
+		&quot;text&quot;: &quot;You come upon a gate.&quot;,
 		&quot;loctext&quot;: &quot;&quot;,
 		&quot;action&quot;: [
 			{ &quot;advanceMapFlag&quot;: &quot;intro&quot; }
@@ -90,11 +90,32 @@
 								&quot;op&quot;: &quot;&gt;=&quot;,
 								&quot;val&quot;: 4
 							}
-						}
+						},
+						{
+                            &quot;checkQuestFlag&quot;: &quot;mainQuest&quot;
+                        }
 					],
 					&quot;text&quot;: &quot;With an extremely loud blast, the gate burst open, leaving only ashes in your path. You are now free to pass.&quot;,
 					&quot;options&quot;: [ { &quot;name&quot;: &quot;(continue)&quot; } ]
 				},
+					{
+                	    &quot;name&quot;: &quot;Akroma, I've done as you asked ! It's time to end this !&quot;,
+                		&quot;action&quot;: [ { &quot;deleteMapObject&quot;: 55 } ],
+                		&quot;condition&quot;: [
+                			{
+                				&quot;getMapFlag&quot;: {
+                					&quot;key&quot;: &quot;enemiesDefeated&quot;,
+                					&quot;op&quot;: &quot;&gt;=&quot;,
+                					&quot;val&quot;: 4
+                				}
+                			},
+                			{
+                                &quot;checkQuestFlag&quot;: &quot;Ch1WhiteCastleComplete&quot;
+                            }
+                		],
+                		&quot;text&quot;: &quot;With an extremely loud blast, the gate burst open, leaving only ashes in your path. You are now free to pass.&quot;,
+                		&quot;options&quot;: [ { &quot;name&quot;: &quot;(continue)&quot; } ]
+                	},
 				{
 					&quot;name&quot;: &quot;You knock on the door&quot;,
 					&quot;condition&quot;: [ { &quot;checkMapFlag&quot;: &quot;intro&quot; } ],

--- a/forge-gui/res/adventure/common/maps/map/main_story/spawn.tmx
+++ b/forge-gui/res/adventure/common/maps/map/main_story/spawn.tmx
@@ -37,7 +37,12 @@
                 &quot;name&quot;: &quot;Why am I here?&quot;,
                 &quot;condition&quot;: [
                     {
-                        &quot;checkQuestFlag&quot;: &quot;exploreShand1&quot;,
+                        &quot;checkQuestFlag&quot;: &quot;mainQuest&quot;,
+                        &quot;not&quot;: true
+                    },
+                    {
+                        &quot;checkCharacterFlag&quot;: &quot;noQuest&quot;,
+                        &quot;not&quot;: true
                     }
                 ],
                 &quot;text&quot;: &quot;This... is Shandalar. A plane where mana is so prevalent and used by all that is sentient. Even the common people use spells daily.&quot;,
@@ -261,8 +266,7 @@
   </object>
   <object id="78" template="../../obj/portal.tx" x="192" y="144">
    <properties>
-    <property name="activeQuestFlag" value="mainQuest"/>
-    <property name="portalState" value="closed"/>
+    <property name="portalState" value="active"/>
     <property name="sprite" value="sprites/portal3.atlas"/>
     <property name="teleport" value=""/>
    </properties>

--- a/forge-gui/res/adventure/common/maps/map/main_story/spawn.tmx
+++ b/forge-gui/res/adventure/common/maps/map/main_story/spawn.tmx
@@ -37,8 +37,7 @@
                 &quot;name&quot;: &quot;Why am I here?&quot;,
                 &quot;condition&quot;: [
                     {
-                        &quot;checkQuestFlag&quot;: &quot;mainQuest&quot;,
-                        &quot;not&quot;: true
+                        &quot;checkQuestFlag&quot;: &quot;exploreShand1&quot;,
                     }
                 ],
                 &quot;text&quot;: &quot;This... is Shandalar. A plane where mana is so prevalent and used by all that is sentient. Even the common people use spells daily.&quot;,


### PR DESCRIPTION
I have changed the gate in the castles to only let people in if they are either at the "enemy is my enemy" part of the main quest or if they are not doing the main quest at all. 
This has required me to change things so that you can actually start without doing the main quest (which is a way lots of people have been playing NG+ anyway). This has made me change up a bunch of logic, since the start of the game was completely interwoven with the main quest. 

Everything I have tested has worked out currently. I hope there aren't any other weird hidden things that might pop up but I don't think anything big could break. 