### PR TITLE
CantUntap Third Step

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
@@ -897,6 +897,8 @@ public abstract class SpellAbilityEffect {
             } else {
                 game.getUpkeep().addUntilEnd(controller, until);
             }
+        } else if ("UntilTheEndOfYourNextUntap".equals(duration)) {
+            game.getUntap().addUntilEnd(controller, until);
         } else if ("UntilNextEndStep".equals(duration)) {
             game.getEndOfTurn().addAt(until);
         } else if ("UntilYourNextEndStep".equals(duration)) {

--- a/forge-game/src/main/java/forge/game/ability/effects/AnimateEffectBase.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/AnimateEffectBase.java
@@ -252,9 +252,7 @@ public abstract class AnimateEffectBase extends SpellAbilityEffect {
         }
 
         if (!"Permanent".equals(duration) && !perpetual) {
-            if ("UntilControllerNextUntap".equals(duration)) {
-                game.getUntap().addUntil(c.getController(), unanimate);
-            } else if ("UntilAnimatedFaceup".equals(duration)) {
+            if ("UntilAnimatedFaceup".equals(duration)) {
                 c.addFaceupCommand(unanimate);
             } else {
                 addUntilCommand(sa, unanimate);

--- a/forge-game/src/main/java/forge/game/phase/PhaseHandler.java
+++ b/forge-game/src/main/java/forge/game/phase/PhaseHandler.java
@@ -481,6 +481,9 @@ public class PhaseHandler implements java.io.Serializable {
                 game.getUpkeep().registerUntilEndCommand(playerTurn);
                 break;
 
+            case UNTAP:
+                game.getUntap().executeUntilEndOfPhase(playerTurn);
+
             case COMBAT_END:
                 GameEventCombatEnded eventEndCombat = null;
                 if (inCombat()) {

--- a/forge-game/src/main/java/forge/game/phase/Untap.java
+++ b/forge-game/src/main/java/forge/game/phase/Untap.java
@@ -164,7 +164,7 @@ public class Untap extends Phase {
         for (final Card c : active.getCardsIn(ZoneType.Battlefield)) {
             c.removeHiddenExtrinsicKeyword("This card doesn't untap during your next untap step.");
         }
-        
+
         // remove exerted flags from all things in play
         // even if they are not creatures
         for (final Card c : game.getCardsIn(ZoneType.Battlefield)) {

--- a/forge-gui/res/cardsfolder/a/arbalest_elite.txt
+++ b/forge-gui/res/cardsfolder/a/arbalest_elite.txt
@@ -3,5 +3,8 @@ ManaCost:2 W W
 Types:Creature Human Archer
 PT:2/3
 A:AB$ DealDamage | Cost$ 2 W T | ValidTgts$ Creature.attacking,Creature.blocking | TgtPrompt$ Select target attacking or blocking creature | NumDmg$ 3 | SubAbility$ DBStayTapped | SpellDescription$ CARDNAME deals 3 damage to target attacking or blocking creature. CARDNAME doesn't untap during your next untap step.
-SVar:DBStayTapped:DB$ Pump | KW$ HIDDEN This card doesn't untap during your next untap step. | Defined$ Self | Duration$ Permanent
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
+SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
+SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{2}{W}, {T}: Arbalest Elite deals 3 damage to target attacking or blocking creature. Arbalest Elite doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/a/arbalest_elite.txt
+++ b/forge-gui/res/cardsfolder/a/arbalest_elite.txt
@@ -3,8 +3,6 @@ ManaCost:2 W W
 Types:Creature Human Archer
 PT:2/3
 A:AB$ DealDamage | Cost$ 2 W T | ValidTgts$ Creature.attacking,Creature.blocking | TgtPrompt$ Select target attacking or blocking creature | NumDmg$ 3 | SubAbility$ DBStayTapped | SpellDescription$ CARDNAME deals 3 damage to target attacking or blocking creature. CARDNAME doesn't untap during your next untap step.
-SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ UntilTheEndOfYourNextUntap
 SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
-SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
-SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{2}{W}, {T}: Arbalest Elite deals 3 damage to target attacking or blocking creature. Arbalest Elite doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/b/bontus_last_reckoning.txt
+++ b/forge-gui/res/cardsfolder/b/bontus_last_reckoning.txt
@@ -2,8 +2,6 @@ Name:Bontu's Last Reckoning
 ManaCost:1 B B
 Types:Sorcery
 A:SP$ DestroyAll | ValidCards$ Creature | SubAbility$ DBNoUntap | SpellDescription$ Destroy all creatures.
-SVar:DBNoUntap:DB$ Effect | StaticAbilities$ DontUntap | Triggers$ RemoveEffect | Duration$ Permanent | SpellDescription$ Lands you control don't untap during your next untap step.
-SVar:DontUntap:Mode$ Continuous | AffectedZone$ Battlefield | Affected$ Land.YouCtrl | AddHiddenKeyword$ This card doesn't untap during your next untap step.
-SVar:RemoveEffect:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | TriggerZones$ Command | Static$ True | Execute$ ExileEffect
-SVar:ExileEffect:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
+SVar:DBNoUntap:DB$ Effect | ReplacementEffects$ DontUntap | Duration$ UntilTheEndOfYourNextUntap | SpellDescription$ Lands you control don't untap during your next untap step.
+SVar:DontUntap:Event$ Untap | ValidCard$ Land.YouCtrl | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ Lands you control don't untap during your next untap step.
 Oracle:Destroy all creatures. Lands you control don't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/c/cinder_marsh.txt
+++ b/forge-gui/res/cardsfolder/c/cinder_marsh.txt
@@ -3,8 +3,6 @@ ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ T | Produced$ Combo B R | SubAbility$ DBStayTapped | SpellDescription$ Add {B} or {R}. CARDNAME doesn't untap during your next untap step.
-SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ UntilTheEndOfYourNextUntap
 SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
-SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
-SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{T}: Add {C}.\n{T}: Add {B} or {R}. Cinder Marsh doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/c/cinder_marsh.txt
+++ b/forge-gui/res/cardsfolder/c/cinder_marsh.txt
@@ -3,5 +3,8 @@ ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ T | Produced$ Combo B R | SubAbility$ DBStayTapped | SpellDescription$ Add {B} or {R}. CARDNAME doesn't untap during your next untap step.
-SVar:DBStayTapped:DB$ Pump | KW$ HIDDEN This card doesn't untap during your next untap step. | Defined$ Self | Duration$ Permanent
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
+SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
+SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{T}: Add {C}.\n{T}: Add {B} or {R}. Cinder Marsh doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/c/cloudcrest_lake.txt
+++ b/forge-gui/res/cardsfolder/c/cloudcrest_lake.txt
@@ -3,5 +3,8 @@ ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ T | Produced$ Combo W U | SubAbility$ DBStayTapped | SpellDescription$ Add {W} or {U}. CARDNAME doesn't untap during your next untap step.
-SVar:DBStayTapped:DB$ Pump | KW$ HIDDEN This card doesn't untap during your next untap step. | Defined$ Self | Duration$ Permanent
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
+SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
+SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{T}: Add {C}.\n{T}: Add {W} or {U}. Cloudcrest Lake doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/c/cloudcrest_lake.txt
+++ b/forge-gui/res/cardsfolder/c/cloudcrest_lake.txt
@@ -3,8 +3,6 @@ ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ T | Produced$ Combo W U | SubAbility$ DBStayTapped | SpellDescription$ Add {W} or {U}. CARDNAME doesn't untap during your next untap step.
-SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ UntilTheEndOfYourNextUntap
 SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
-SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
-SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{T}: Add {C}.\n{T}: Add {W} or {U}. Cloudcrest Lake doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/d/deep_spawn.txt
+++ b/forge-gui/res/cardsfolder/d/deep_spawn.txt
@@ -6,9 +6,7 @@ K:Trample
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUpkeep | TriggerDescription$ At the beginning of your upkeep, sacrifice CARDNAME unless you mill two cards.
 SVar:TrigUpkeep:DB$ Sacrifice | UnlessPayer$ You | UnlessCost$ Mill<2>
 A:AB$ Pump | Cost$ U | Defined$ Self | KW$ Shroud | SubAbility$ DBStayTapped | SpellDescription$ CARDNAME gains shroud until end of turn and doesn't untap during your next untap step. Tap CARDNAME. (A permanent with shroud can't be the target of spells or abilities.)
-SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent | SubAbility$ DBTap
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ UntilTheEndOfYourNextUntap | SubAbility$ DBTap
 SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
-SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
-SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 SVar:DBTap:DB$ Tap | Defined$ Self
 Oracle:Trample\nAt the beginning of your upkeep, sacrifice Deep Spawn unless you mill two cards.\n{U}: Deep Spawn gains shroud until end of turn and doesn't untap during your next untap step. Tap Deep Spawn. (A creature with shroud can't be the target of spells or abilities.)

--- a/forge-gui/res/cardsfolder/d/deep_spawn.txt
+++ b/forge-gui/res/cardsfolder/d/deep_spawn.txt
@@ -5,7 +5,10 @@ PT:6/6
 K:Trample
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUpkeep | TriggerDescription$ At the beginning of your upkeep, sacrifice CARDNAME unless you mill two cards.
 SVar:TrigUpkeep:DB$ Sacrifice | UnlessPayer$ You | UnlessCost$ Mill<2>
-A:AB$ Pump | Cost$ U | Defined$ Self | KW$ Shroud | SubAbility$ DBPump | SpellDescription$ CARDNAME gains shroud until end of turn and doesn't untap during your next untap step. Tap CARDNAME. (A permanent with shroud can't be the target of spells or abilities.)
-SVar:DBPump:DB$ Pump | Defined$ Self | KW$ HIDDEN This card doesn't untap during your next untap step. | Duration$ Permanent | SubAbility$ DBTap
+A:AB$ Pump | Cost$ U | Defined$ Self | KW$ Shroud | SubAbility$ DBStayTapped | SpellDescription$ CARDNAME gains shroud until end of turn and doesn't untap during your next untap step. Tap CARDNAME. (A permanent with shroud can't be the target of spells or abilities.)
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent | SubAbility$ DBTap
+SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
+SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
+SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 SVar:DBTap:DB$ Tap | Defined$ Self
 Oracle:Trample\nAt the beginning of your upkeep, sacrifice Deep Spawn unless you mill two cards.\n{U}: Deep Spawn gains shroud until end of turn and doesn't untap during your next untap step. Tap Deep Spawn. (A creature with shroud can't be the target of spells or abilities.)

--- a/forge-gui/res/cardsfolder/h/hazorets_undying_fury.txt
+++ b/forge-gui/res/cardsfolder/h/hazorets_undying_fury.txt
@@ -4,9 +4,7 @@ Types:Sorcery
 A:SP$ Shuffle | Defined$ You | SubAbility$ DBExile | SpellDescription$ Shuffle your library, then exile the top four cards. You may cast any number of spells with mana value 5 or less from among them without paying their mana costs. Lands you control don't untap during your next untap step.
 SVar:DBExile:DB$ Dig | Defined$ You | DigNum$ 4 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBPlay
 SVar:DBPlay:DB$ Play | Valid$ Card.nonLand+IsRemembered+YouOwn+cmcLE5 | ValidZone$ Exile | ValidSA$ Spell | Controller$ You | WithoutManaCost$ True | Optional$ True | Amount$ All | SubAbility$ DBNoUntap
-SVar:DBNoUntap:DB$ Effect | StaticAbilities$ DontUntap | Triggers$ RemoveEffect | Duration$ Permanent | SubAbility$ DBCleanup | SpellDescription$ Lands you control don't untap during your next untap step.
-SVar:DontUntap:Mode$ Continuous | AffectedZone$ Battlefield | Affected$ Land.YouCtrl | AddHiddenKeyword$ This card doesn't untap during your next untap step.
-SVar:RemoveEffect:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | TriggerZones$ Command | Static$ True | Execute$ ExileEffect
-SVar:ExileEffect:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
+SVar:DBNoUntap:DB$ Effect | ReplacementEffects$ DontUntap | Duration$ UntilTheEndOfYourNextUntap | SubAbility$ DBCleanup
+SVar:DontUntap:Event$ Untap | ValidCard$ Land.YouCtrl | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ Lands you control don't untap during your next untap step.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Shuffle your library, then exile the top four cards. You may cast any number of spells with mana value 5 or less from among them without paying their mana costs. Lands you control don't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/h/homarid_warrior.txt
+++ b/forge-gui/res/cardsfolder/h/homarid_warrior.txt
@@ -2,7 +2,10 @@ Name:Homarid Warrior
 ManaCost:4 U
 Types:Creature Homarid Warrior
 PT:3/3
-A:AB$ Pump | Cost$ U | Defined$ Self | KW$ Shroud | SubAbility$ DBPumpNoUntap | SpellDescription$ CARDNAME gains shroud until end of turn and doesn't untap during your next untap step. Tap CARDNAME. (A permanent with shroud can't be the target of spells or abilities.)
-SVar:DBPumpNoUntap:DB$ Pump | Defined$ Self | KW$ HIDDEN This card doesn't untap during your next untap step. | Duration$ Permanent | SubAbility$ DBTap
+A:AB$ Pump | Cost$ U | Defined$ Self | KW$ Shroud | SubAbility$ DBStayTapped | SpellDescription$ CARDNAME gains shroud until end of turn and doesn't untap during your next untap step. Tap CARDNAME. (A permanent with shroud can't be the target of spells or abilities.)
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent | SubAbility$ DBTap
+SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
+SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
+SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 SVar:DBTap:DB$ Tap | Defined$ Self
 Oracle:{U}: Homarid Warrior gains shroud until end of turn and doesn't untap during your next untap step. Tap Homarid Warrior. (A creature with shroud can't be the target of spells or abilities.)

--- a/forge-gui/res/cardsfolder/h/homarid_warrior.txt
+++ b/forge-gui/res/cardsfolder/h/homarid_warrior.txt
@@ -3,9 +3,7 @@ ManaCost:4 U
 Types:Creature Homarid Warrior
 PT:3/3
 A:AB$ Pump | Cost$ U | Defined$ Self | KW$ Shroud | SubAbility$ DBStayTapped | SpellDescription$ CARDNAME gains shroud until end of turn and doesn't untap during your next untap step. Tap CARDNAME. (A permanent with shroud can't be the target of spells or abilities.)
-SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent | SubAbility$ DBTap
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ UntilTheEndOfYourNextUntap | SubAbility$ DBTap
 SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
-SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
-SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 SVar:DBTap:DB$ Tap | Defined$ Self
 Oracle:{U}: Homarid Warrior gains shroud until end of turn and doesn't untap during your next untap step. Tap Homarid Warrior. (A creature with shroud can't be the target of spells or abilities.)

--- a/forge-gui/res/cardsfolder/k/kefnets_last_word.txt
+++ b/forge-gui/res/cardsfolder/k/kefnets_last_word.txt
@@ -2,8 +2,6 @@ Name:Kefnet's Last Word
 ManaCost:2 U U
 Types:Sorcery
 A:SP$ GainControl | ValidTgts$ Artifact,Creature,Enchantment | TgtPrompt$ Select target artifact, creature, or enchantment | SubAbility$ DBNoUntap | SpellDescription$ Gain control of target artifact, creature or enchantment.
-SVar:DBNoUntap:DB$ Effect | StaticAbilities$ DontUntap | Triggers$ RemoveEffect | Duration$ Permanent | SpellDescription$ Lands you control don't untap during your next untap step.
-SVar:DontUntap:Mode$ Continuous | AffectedZone$ Battlefield | Affected$ Land.YouCtrl | AddHiddenKeyword$ This card doesn't untap during your next untap step.
-SVar:RemoveEffect:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | TriggerZones$ Command | Static$ True | Execute$ ExileEffect
-SVar:ExileEffect:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
+SVar:DBNoUntap:DB$ Effect | ReplacementEffects$ DontUntap | Duration$ UntilTheEndOfYourNextUntap | SpellDescription$ Lands you control don't untap during your next untap step.
+SVar:DontUntap:Event$ Untap | ValidCard$ Land.YouCtrl | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ Lands you control don't untap during your next untap step.
 Oracle:Gain control of target artifact, creature, or enchantment. Lands you control don't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/l/lantern_lit_graveyard.txt
+++ b/forge-gui/res/cardsfolder/l/lantern_lit_graveyard.txt
@@ -3,8 +3,6 @@ ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ T | Produced$ Combo B R | SubAbility$ DBStayTapped | SpellDescription$ Add {B} or {R}. CARDNAME doesn't untap during your next untap step.
-SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap| RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ UntilTheEndOfYourNextUntap
 SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
-SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
-SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{T}: Add {C}.\n{T}: Add {B} or {R}. Lantern-Lit Graveyard doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/l/lantern_lit_graveyard.txt
+++ b/forge-gui/res/cardsfolder/l/lantern_lit_graveyard.txt
@@ -3,5 +3,8 @@ ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ T | Produced$ Combo B R | SubAbility$ DBStayTapped | SpellDescription$ Add {B} or {R}. CARDNAME doesn't untap during your next untap step.
-SVar:DBStayTapped:DB$ Pump | KW$ HIDDEN This card doesn't untap during your next untap step. | Defined$ Self | Duration$ Permanent
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
+SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
+SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{T}: Add {C}.\n{T}: Add {B} or {R}. Lantern-Lit Graveyard doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/m/mogg_hollows.txt
+++ b/forge-gui/res/cardsfolder/m/mogg_hollows.txt
@@ -3,8 +3,6 @@ ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ T | Produced$ Combo R G | SpellDescription$ Add {R} or {G}. CARDNAME doesn't untap during your next untap step. | SubAbility$ DBStayTapped
-SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ UntilTheEndOfYourNextUntap
 SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
-SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
-SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{T}: Add {C}.\n{T}: Add {R} or {G}. Mogg Hollows doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/m/mogg_hollows.txt
+++ b/forge-gui/res/cardsfolder/m/mogg_hollows.txt
@@ -2,6 +2,9 @@ Name:Mogg Hollows
 ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
-A:AB$ Mana | Cost$ T | Produced$ Combo R G | SpellDescription$ Add {R} or {G}. CARDNAME doesn't untap during your next untap step. | SubAbility$ DBPump
-SVar:DBPump:DB$ Pump | KW$ HIDDEN This card doesn't untap during your next untap step. | Defined$ Self | Duration$ Permanent
+A:AB$ Mana | Cost$ T | Produced$ Combo R G | SpellDescription$ Add {R} or {G}. CARDNAME doesn't untap during your next untap step. | SubAbility$ DBStayTapped
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
+SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
+SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{T}: Add {C}.\n{T}: Add {R} or {G}. Mogg Hollows doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/o/oketras_last_mercy.txt
+++ b/forge-gui/res/cardsfolder/o/oketras_last_mercy.txt
@@ -2,9 +2,7 @@ Name:Oketra's Last Mercy
 ManaCost:1 W W
 Types:Sorcery
 A:SP$ SetLife | Defined$ You | LifeAmount$ X | SubAbility$ DBNoUntap | SpellDescription$ Your life total becomes equal to your starting life total.
-SVar:DBNoUntap:DB$ Effect | StaticAbilities$ DontUntap | Triggers$ RemoveEffect | Duration$ Permanent | SpellDescription$ Lands you control don't untap during your next untap step.
-SVar:DontUntap:Mode$ Continuous | AffectedZone$ Battlefield | Affected$ Land.YouCtrl | AddHiddenKeyword$ This card doesn't untap during your next untap step.
-SVar:RemoveEffect:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | TriggerZones$ Command | Static$ True | Execute$ ExileEffect
-SVar:ExileEffect:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
+SVar:DBNoUntap:DB$ Effect | ReplacementEffects$ DontUntap | Duration$ UntilTheEndOfYourNextUntap | SpellDescription$ Lands you control don't untap during your next untap step.
+SVar:DontUntap:Event$ Untap | ValidCard$ Land.YouCtrl | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ Lands you control don't untap during your next untap step.
 SVar:X:Count$YourStartingLife
 Oracle:Your life total becomes equal to your starting life total. Lands you control don't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/o/orcish_farmer.txt
+++ b/forge-gui/res/cardsfolder/o/orcish_farmer.txt
@@ -2,6 +2,9 @@ Name:Orcish Farmer
 ManaCost:1 R R
 Types:Creature Orc
 PT:2/2
-A:AB$ Animate | Cost$ T | ValidTgts$ Land | TgtPrompt$ Select target land | Types$ Swamp | RemoveLandTypes$ True | Duration$ UntilControllerNextUntap | SpellDescription$ Target land becomes a Swamp until its controller's next untap step.
+A:AB$ Effect | Cost$ T | ValidTgts$ Land | Duration$ Permanent | ExileOnMoved$ Battlefield | RememberObjects$ Targeted | StaticAbilities$ Animate | Triggers$ ExileEff
+SVar:Animate:Mode$ Continuous | Affected$ Card.IsRemembered | AddType$ Swamp | RemoveLandTypes$ True | Description$ Target land becomes a Swamp until its controller's next untap step.
+SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ Player.controlsCard.IsRemembered | Execute$ Exile | Static$ True
+SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 AI:RemoveDeck:All
 Oracle:{T}: Target land becomes a Swamp until its controller's next untap step.

--- a/forge-gui/res/cardsfolder/p/pinecrest_ridge.txt
+++ b/forge-gui/res/cardsfolder/p/pinecrest_ridge.txt
@@ -3,8 +3,6 @@ ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ T | Produced$ Combo R G | SubAbility$ DBStayTapped | SpellDescription$ Add {R} or {G}. CARDNAME doesn't untap during your next untap step.
-SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ UntilTheEndOfYourNextUntap
 SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
-SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
-SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{T}: Add {C}.\n{T}: Add {R} or {G}. Pinecrest Ridge doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/p/pinecrest_ridge.txt
+++ b/forge-gui/res/cardsfolder/p/pinecrest_ridge.txt
@@ -3,5 +3,8 @@ ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ T | Produced$ Combo R G | SubAbility$ DBStayTapped | SpellDescription$ Add {R} or {G}. CARDNAME doesn't untap during your next untap step.
-SVar:DBStayTapped:DB$ Pump | KW$ HIDDEN This card doesn't untap during your next untap step. | Defined$ Self | Duration$ Permanent
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
+SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
+SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{T}: Add {C}.\n{T}: Add {R} or {G}. Pinecrest Ridge doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/r/reveka_wizard_savant.txt
+++ b/forge-gui/res/cardsfolder/r/reveka_wizard_savant.txt
@@ -2,6 +2,9 @@ Name:Reveka, Wizard Savant
 ManaCost:2 U U
 Types:Legendary Creature Dwarf Wizard
 PT:0/1
-A:AB$ DealDamage | Cost$ T | NumDmg$ 2 | ValidTgts$ Any | TgtPrompt$ Select target creature or player | SubAbility$ DBPump | SpellDescription$ CARDNAME deals 2 damage to any target and doesn't untap during your next untap step.
-SVar:DBPump:DB$ Pump | KW$ HIDDEN This card doesn't untap during your next untap step. | Defined$ Self | Duration$ Permanent
+A:AB$ DealDamage | Cost$ T | NumDmg$ 2 | ValidTgts$ Any | TgtPrompt$ Select target creature or player | SubAbility$ DBStayTapped | SpellDescription$ CARDNAME deals 2 damage to any target and doesn't untap during your next untap step.
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
+SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
+SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{T}: Reveka, Wizard Savant deals 2 damage to any target and doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/r/reveka_wizard_savant.txt
+++ b/forge-gui/res/cardsfolder/r/reveka_wizard_savant.txt
@@ -3,8 +3,6 @@ ManaCost:2 U U
 Types:Legendary Creature Dwarf Wizard
 PT:0/1
 A:AB$ DealDamage | Cost$ T | NumDmg$ 2 | ValidTgts$ Any | TgtPrompt$ Select target creature or player | SubAbility$ DBStayTapped | SpellDescription$ CARDNAME deals 2 damage to any target and doesn't untap during your next untap step.
-SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ UntilTheEndOfYourNextUntap
 SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
-SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
-SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{T}: Reveka, Wizard Savant deals 2 damage to any target and doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/r/rhonass_last_stand.txt
+++ b/forge-gui/res/cardsfolder/r/rhonass_last_stand.txt
@@ -2,9 +2,7 @@ Name:Rhonas's Last Stand
 ManaCost:G G
 Types:Sorcery
 A:SP$ Token | TokenAmount$ 1 | TokenScript$ g_5_4_snake | TokenOwner$ You | SubAbility$ DBNoUntap | SpellDescription$ Create a 5/4 green Snake creature token.
-SVar:DBNoUntap:DB$ Effect | StaticAbilities$ DontUntap | Triggers$ RemoveEffect | Duration$ Permanent | SpellDescription$ Lands you control don't untap during your next untap step.
-SVar:DontUntap:Mode$ Continuous | AffectedZone$ Battlefield | Affected$ Land.YouCtrl | AddHiddenKeyword$ This card doesn't untap during your next untap step.
-SVar:RemoveEffect:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | TriggerZones$ Command | Static$ True | Execute$ ExileEffect
-SVar:ExileEffect:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
+SVar:DBNoUntap:DB$ Effect | ReplacementEffects$ DontUntap | Duration$ UntilTheEndOfYourNextUntap | SpellDescription$ Lands you control don't untap during your next untap step.
+SVar:DontUntap:Event$ Untap | ValidCard$ Land.YouCtrl | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ Lands you control don't untap during your next untap step.
 DeckHas:Ability$Token
 Oracle:Create a 5/4 green Snake creature token. Lands you control don't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/r/rootwater_depths.txt
+++ b/forge-gui/res/cardsfolder/r/rootwater_depths.txt
@@ -3,8 +3,6 @@ ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ T | Produced$ Combo U B | SpellDescription$ Add {U} or {B}. CARDNAME doesn't untap during your next untap step. | SubAbility$ DBStayTapped
-SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ UntilTheEndOfYourNextUntap
 SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
-SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
-SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{T}: Add {C}.\n{T}: Add {U} or {B}. Rootwater Depths doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/r/rootwater_depths.txt
+++ b/forge-gui/res/cardsfolder/r/rootwater_depths.txt
@@ -2,6 +2,9 @@ Name:Rootwater Depths
 ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
-A:AB$ Mana | Cost$ T | Produced$ Combo U B | SpellDescription$ Add {U} or {B}. CARDNAME doesn't untap during your next untap step. | SubAbility$ DBPump
-SVar:DBPump:DB$ Pump | KW$ HIDDEN This card doesn't untap during your next untap step. | Defined$ Self | Duration$ Permanent
+A:AB$ Mana | Cost$ T | Produced$ Combo U B | SpellDescription$ Add {U} or {B}. CARDNAME doesn't untap during your next untap step. | SubAbility$ DBStayTapped
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
+SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
+SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{T}: Add {C}.\n{T}: Add {U} or {B}. Rootwater Depths doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/s/samite_alchemist.txt
+++ b/forge-gui/res/cardsfolder/s/samite_alchemist.txt
@@ -4,8 +4,6 @@ Types:Creature Human Cleric
 PT:0/2
 A:AB$ PreventDamage | Cost$ W W T | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | Amount$ 4 | SubAbility$ DBTap | SpellDescription$ Prevent the next 4 damage that would be dealt this turn to target creature you control. Tap that creature. It doesn't untap during your next untap step.
 SVar:DBTap:DB$ Tap | Defined$ Targeted | SubAbility$ DBStayTapped
-SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Targeted | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | RememberObjects$ Targeted | ExileOnMoved$ Battlefield | Duration$ UntilTheEndOfYourNextUntap
 SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ It doesn't untap during your next untap step.
-SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
-SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{W}{W}, {T}: Prevent the next 4 damage that would be dealt this turn to target creature you control. Tap that creature. It doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/s/samite_alchemist.txt
+++ b/forge-gui/res/cardsfolder/s/samite_alchemist.txt
@@ -4,5 +4,8 @@ Types:Creature Human Cleric
 PT:0/2
 A:AB$ PreventDamage | Cost$ W W T | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | Amount$ 4 | SubAbility$ DBTap | SpellDescription$ Prevent the next 4 damage that would be dealt this turn to target creature you control. Tap that creature. It doesn't untap during your next untap step.
 SVar:DBTap:DB$ Tap | Defined$ Targeted | SubAbility$ DBStayTapped
-SVar:DBStayTapped:DB$ Pump | KW$ HIDDEN This card doesn't untap during your next untap step. | Defined$ Targeted | Duration$ Permanent | IsCurse$ True
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Targeted | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ It doesn't untap during your next untap step.
+SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
+SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{W}{W}, {T}: Prevent the next 4 damage that would be dealt this turn to target creature you control. Tap that creature. It doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/s/spectral_bears.txt
+++ b/forge-gui/res/cardsfolder/s/spectral_bears.txt
@@ -3,5 +3,8 @@ ManaCost:1 G
 Types:Creature Bear Spirit
 PT:3/3
 T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ StayTapped | IsPresent$ Permanent.Black+!token+DefenderCtrl | PresentCompare$ EQ0 | TriggerDescription$ Whenever CARDNAME attacks, if defending player controls no black nontoken permanents, it doesn't untap during your next untap step.
-SVar:StayTapped:DB$ Pump | KW$ HIDDEN This card doesn't untap during your next untap step. | Defined$ Self | Duration$ Permanent
+SVar:StayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
+SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
+SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:Whenever Spectral Bears attacks, if defending player controls no black nontoken permanents, it doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/s/spectral_bears.txt
+++ b/forge-gui/res/cardsfolder/s/spectral_bears.txt
@@ -3,8 +3,6 @@ ManaCost:1 G
 Types:Creature Bear Spirit
 PT:3/3
 T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ StayTapped | IsPresent$ Permanent.Black+!token+DefenderCtrl | PresentCompare$ EQ0 | TriggerDescription$ Whenever CARDNAME attacks, if defending player controls no black nontoken permanents, it doesn't untap during your next untap step.
-SVar:StayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:StayTapped:DB$ Effect | ReplacementEffects$ DontUntap | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ UntilTheEndOfYourNextUntap
 SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
-SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
-SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:Whenever Spectral Bears attacks, if defending player controls no black nontoken permanents, it doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/s/spectral_force.txt
+++ b/forge-gui/res/cardsfolder/s/spectral_force.txt
@@ -3,6 +3,9 @@ ManaCost:3 G G
 Types:Creature Elemental Spirit
 PT:8/8
 K:Trample
-T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ StayTapped | IsPresent$ Permanent.Black+!token+DefenderCtrl | PresentCompare$ EQ0 | TriggerDescription$ Whenever CARDNAME attacks, if defending player controls no black nontoken permanents, it doesn't untap during your next untap step.
-SVar:StayTapped:DB$ Pump | KW$ HIDDEN This card doesn't untap during your next untap step. | Defined$ Self | Duration$ Permanent
+T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ StayTapped | IsPresent$ Permanent.Black+DefenderCtrl | PresentCompare$ EQ0 | TriggerDescription$ Whenever CARDNAME attacks, if defending player controls no black nontoken permanents, it doesn't untap during your next untap step.
+SVar:StayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
+SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
+SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:Trample\nWhenever Spectral Force attacks, if defending player controls no black permanents, it doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/s/spectral_force.txt
+++ b/forge-gui/res/cardsfolder/s/spectral_force.txt
@@ -4,8 +4,6 @@ Types:Creature Elemental Spirit
 PT:8/8
 K:Trample
 T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ StayTapped | IsPresent$ Permanent.Black+DefenderCtrl | PresentCompare$ EQ0 | TriggerDescription$ Whenever CARDNAME attacks, if defending player controls no black nontoken permanents, it doesn't untap during your next untap step.
-SVar:StayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:StayTapped:DB$ Effect | ReplacementEffects$ DontUntap | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ UntilTheEndOfYourNextUntap
 SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
-SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
-SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:Trample\nWhenever Spectral Force attacks, if defending player controls no black permanents, it doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/t/thalakos_lowlands.txt
+++ b/forge-gui/res/cardsfolder/t/thalakos_lowlands.txt
@@ -3,5 +3,8 @@ ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ T | Produced$ Combo W U | SubAbility$ DBStayTapped | SpellDescription$ Add {W}. or {U}. CARDNAME doesn't untap during your next untap step.
-SVar:DBStayTapped:DB$ Pump | KW$ HIDDEN This card doesn't untap during your next untap step. | Defined$ Self | Duration$ Permanent
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
+SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
+SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{T}: Add {C}.\n{T}: Add {W} or {U}. Thalakos Lowlands doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/t/thalakos_lowlands.txt
+++ b/forge-gui/res/cardsfolder/t/thalakos_lowlands.txt
@@ -3,8 +3,6 @@ ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ T | Produced$ Combo W U | SubAbility$ DBStayTapped | SpellDescription$ Add {W}. or {U}. CARDNAME doesn't untap during your next untap step.
-SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ UntilTheEndOfYourNextUntap
 SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
-SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
-SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{T}: Add {C}.\n{T}: Add {W} or {U}. Thalakos Lowlands doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/t/tranquil_garden.txt
+++ b/forge-gui/res/cardsfolder/t/tranquil_garden.txt
@@ -3,8 +3,6 @@ ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ T | Produced$ Combo G W | SubAbility$ DBStayTapped | SpellDescription$ Add {G} or {W}. CARDNAME doesn't untap during your next untap step.
-SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ UntilTheEndOfYourNextUntap
 SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
-SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
-SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{T}: Add {C}.\n{T}: Add {G} or {W}. Tranquil Garden doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/t/tranquil_garden.txt
+++ b/forge-gui/res/cardsfolder/t/tranquil_garden.txt
@@ -3,5 +3,8 @@ ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ T | Produced$ Combo G W | SubAbility$ DBStayTapped | SpellDescription$ Add {G} or {W}. CARDNAME doesn't untap during your next untap step.
-SVar:DBStayTapped:DB$ Pump | KW$ HIDDEN This card doesn't untap during your next untap step. | Defined$ Self | Duration$ Permanent
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
+SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
+SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{T}: Add {C}.\n{T}: Add {G} or {W}. Tranquil Garden doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/v/vec_townships.txt
+++ b/forge-gui/res/cardsfolder/v/vec_townships.txt
@@ -3,8 +3,6 @@ ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ T | Produced$ Combo G W | SpellDescription$ Add {G} or {W}. CARDNAME doesn't untap during your next untap step. | SubAbility$ DBStayTapped
-SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ UntilTheEndOfYourNextUntap
 SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
-SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
-SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{T}: Add {C}.\n{T}: Add {G} or {W}. Vec Townships doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/v/vec_townships.txt
+++ b/forge-gui/res/cardsfolder/v/vec_townships.txt
@@ -2,6 +2,9 @@ Name:Vec Townships
 ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
-A:AB$ Mana | Cost$ T | Produced$ Combo G W | SpellDescription$ Add {G} or {W}. CARDNAME doesn't untap during your next untap step. | SubAbility$ DBPump
-SVar:DBPump:DB$ Pump | KW$ HIDDEN This card doesn't untap during your next untap step. | Defined$ Self | Duration$ Permanent
+A:AB$ Mana | Cost$ T | Produced$ Combo G W | SpellDescription$ Add {G} or {W}. CARDNAME doesn't untap during your next untap step. | SubAbility$ DBStayTapped
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
+SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
+SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{T}: Add {C}.\n{T}: Add {G} or {W}. Vec Townships doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/w/waterveil_cavern.txt
+++ b/forge-gui/res/cardsfolder/w/waterveil_cavern.txt
@@ -3,5 +3,8 @@ ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ T | Produced$ Combo U B | SubAbility$ DBStayTapped | SpellDescription$ Add {U} or {B}. CARDNAME doesn't untap during your next untap step.
-SVar:DBStayTapped:DB$ Pump | KW$ HIDDEN This card doesn't untap during your next untap step. | Defined$ Self | Duration$ Permanent
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
+SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
+SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{T}: Add {C}.\n{T}: Add {U} or {B}. Waterveil Cavern doesn't untap during your next untap step.

--- a/forge-gui/res/cardsfolder/w/waterveil_cavern.txt
+++ b/forge-gui/res/cardsfolder/w/waterveil_cavern.txt
@@ -3,8 +3,6 @@ ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ T | Produced$ Combo U B | SubAbility$ DBStayTapped | SpellDescription$ Add {U} or {B}. CARDNAME doesn't untap during your next untap step.
-SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | Triggers$ ExileEff | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ Permanent
+SVar:DBStayTapped:DB$ Effect | ReplacementEffects$ DontUntap | RememberObjects$ Self | ExileOnMoved$ Battlefield | Duration$ UntilTheEndOfYourNextUntap
 SVar:DontUntap:Event$ Untap | ValidCard$ Card.IsRemembered | ValidStepTurnToController$ Player.Activator | Layer$ CantHappen | Description$ EFFECTSOURCE doesn't untap during your next untap step.
-SVar:ExileEff:Mode$ Phase | Phase$ Untap | ValidPlayer$ You | Execute$ Exile | Static$ True
-SVar:Exile:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 Oracle:{T}: Add {C}.\n{T}: Add {U} or {B}. Waterveil Cavern doesn't untap during your next untap step.


### PR DESCRIPTION
Patches `your next`, so remaining usage of the hidden KW should be reduced to only the types `player's|controller's/controllers' next`, making the final refactor a bit easier later.