### PR TITLE
Update nantuko_slicer.txt

### DIFF
--- a/forge-gui/res/cardsfolder/n/nantuko_slicer.txt
+++ b/forge-gui/res/cardsfolder/n/nantuko_slicer.txt
@@ -4,8 +4,8 @@ Types:Creature Insect
 PT:3/2
 K:Kicker:B
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChangeZone | TriggerDescription$ When CARDNAME enters, return target card from your graveyard to your hand. If this spell was kicked, conjure a duplicate of target card in an opponent's graveyard into your hand. It perpetually gains "You may spend mana as though it were mana of any color to cast this spell."
-SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Card.YouOwn | TgtPrompt$ Select target card from your graveyard | SubAbility$ DBConjure
-SVar:DBConjure:DB$ MakeCard | Condition$ Kicked | Conjure$ True | TgtPrompt$ Select target creature card in an opponent's graveyard | ValidTgts$ Creature.OppOwn | TgtZone$ Graveyard | DefinedName$ ThisTargetedCard | Zone$ Hand | RememberMade$ True | SubAbility$ DBAnimate
+SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Card.YouOwn | TgtPrompt$ Select target card in your graveyard | SubAbility$ DBConjure
+SVar:DBConjure:DB$ MakeCard | Condition$ Kicked | Conjure$ True | TgtPrompt$ Select target card in an opponent's graveyard | ValidTgts$ Card.OppOwn | TgtZone$ Graveyard | DefinedName$ ThisTargetedCard | Zone$ Hand | RememberMade$ True | SubAbility$ DBAnimate
 SVar:DBAnimate:DB$ Animate | Defined$ Remembered | staticAbilities$ SpendAnyMana | Duration$ Perpetual | SubAbility$ DBCleanup
 SVar:SpendAnyMana:Mode$ ManaConvert | EffectZone$ Stack | ValidPlayer$ You | ValidCard$ Card.Self | ValidSA$ Spell | ManaConversion$ AnyType->AnyColor | Description$ You may spend mana as though it were mana of any color to cast this spell.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True


### PR DESCRIPTION
Fixed an unduly restrictive targeting requirement on the kicked part of the enters trigger for [Nantuko Slicer](https://scryfall.com/card/ydmu/17/nantuko-slicer). 
However, regarding the report that a duplicate of the selected card in an opponent's graveyard **isn't** being conjured in your hand, I've got nothing. Hared off every which reasonable way as the scripts go. The likely source for that part of the script, [Bind to Secrecy](https://scryfall.com/card/ysnc/19/bind-to-secrecy), works fine. It also works with `ThisTargetedCard` as the argument for the `DefinedName$` parameter on the `MakeCard` line. Splitting the targeting part out to an upstream `Pump` line, on the erstwhile assumption that might be an issue, got me nowhere as well.