### PR TITLE
Update nantuko_slicer.txt

### DIFF
--- a/forge-gui/res/cardsfolder/n/nantuko_slicer.txt
+++ b/forge-gui/res/cardsfolder/n/nantuko_slicer.txt
@@ -5,9 +5,10 @@ PT:3/2
 K:Kicker:B
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChangeZone | TriggerDescription$ When CARDNAME enters, return target card from your graveyard to your hand. If this spell was kicked, conjure a duplicate of target card in an opponent's graveyard into your hand. It perpetually gains "You may spend mana as though it were mana of any color to cast this spell."
 SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Card.YouOwn | TgtPrompt$ Select target card in your graveyard | SubAbility$ DBConjure
-SVar:DBConjure:DB$ MakeCard | Condition$ Kicked | Conjure$ True | TgtPrompt$ Select target card in an opponent's graveyard | ValidTgts$ Card.OppOwn | TgtZone$ Graveyard | DefinedName$ ThisTargetedCard | Zone$ Hand | RememberMade$ True | SubAbility$ DBAnimate
+SVar:DBConjure:DB$ MakeCard | Conjure$ True | TgtPrompt$ Select target card in an opponent's graveyard | ValidTgts$ Card.OppOwn | TargetMin$ Y | TargetMax$ Y | TgtZone$ Graveyard | DefinedName$ ThisTargetedCard | Zone$ Hand | RememberMade$ True | SubAbility$ DBAnimate
 SVar:DBAnimate:DB$ Animate | Defined$ Remembered | staticAbilities$ SpendAnyMana | Duration$ Perpetual | SubAbility$ DBCleanup
 SVar:SpendAnyMana:Mode$ ManaConvert | EffectZone$ Stack | ValidPlayer$ You | ValidCard$ Card.Self | ValidSA$ Spell | ManaConversion$ AnyType->AnyColor | Description$ You may spend mana as though it were mana of any color to cast this spell.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:Y:Count$Kicked.1.0
 DeckHas:Ability$Graveyard
 Oracle:Kicker{B}\nWhen Nantuko Slicer enters, return target card from your graveyard to your hand. If this spell was kicked, conjure a duplicate of target card in an opponent's graveyard into your hand. It perpetually gains "You may spend mana as though it were mana of any color to cast this spell."


### PR DESCRIPTION
Following up on https://github.com/Card-Forge/forge/pull/7413 , with an assist from **ShadesRealm** over on Discord, I finally hared into a good solution for this card's conjuring issue. 
Pulled the targeting amount restriction for Jilt's kicked effect (<https://github.com/Card-Forge/forge/blob/master/forge-gui/res/cardsfolder/j/jilt.txt>). I was intrigued enough to test a version of Jilt with only `Condition$ Kicked`: it works. However I opted to remove that parameter in Nantuko Slicer since it does nothing here. In any case, tested to satisfaction.