### PR TITLE
Disable TokenCard flag on drafted cards by default.

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/DraftEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DraftEffect.java
@@ -57,7 +57,8 @@ import java.util.*;
                  // Cardnames that include "," must use ";" instead in Spellbook$ (i.e. Tovolar; Dire Overlord)
                  name = name.replace(";", ",");
                  Card cardOption = Card.fromPaperCard(StaticData.instance().getCommonCards().getUniqueByName(name), player);
-                 cardOption.setTokenCard(true);
+                 if (sa.hasParam("TokenCard"))
+                     cardOption.setTokenCard(true);
                  draftOptions.add(cardOption);
              }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/DraftEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DraftEffect.java
@@ -57,8 +57,7 @@ import java.util.*;
                  // Cardnames that include "," must use ";" instead in Spellbook$ (i.e. Tovolar; Dire Overlord)
                  name = name.replace(";", ",");
                  Card cardOption = Card.fromPaperCard(StaticData.instance().getCommonCards().getUniqueByName(name), player);
-                 if (sa.hasParam("TokenCard"))
-                     cardOption.setTokenCard(sa.hasParam("TokenCard"));
+                 cardOption.setTokenCard(sa.hasParam("TokenCard"));
                  draftOptions.add(cardOption);
              }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/DraftEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DraftEffect.java
@@ -58,7 +58,7 @@ import java.util.*;
                  name = name.replace(";", ",");
                  Card cardOption = Card.fromPaperCard(StaticData.instance().getCommonCards().getUniqueByName(name), player);
                  if (sa.hasParam("TokenCard"))
-                     cardOption.setTokenCard(true);
+                     cardOption.setTokenCard(sa.hasParam("TokenCard"));
                  draftOptions.add(cardOption);
              }
 


### PR DESCRIPTION
Fixes #7165.

Could've just deleted the line entirely since this flag is almost never used, but supporting it via parameter adds parity with `MakeCardEffect`.