### PR TITLE
Fix UntilHostLeavesPlay corner case

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
@@ -767,7 +767,11 @@ public abstract class SpellAbilityEffect {
         return combatChanged;
     }
 
-    protected static GameCommand untilHostLeavesPlayCommand(final CardZoneTable triggerList, final SpellAbility sa) {
+    protected static void changeZoneUntilCommand(final CardZoneTable triggerList, final SpellAbility sa) {
+        if (!sa.hasParam("Duration")) {
+            return;
+        }
+
         final Card hostCard = sa.getHostCard();
         final Game game = hostCard.getGame();
         hostCard.addUntilLeavesBattlefield(triggerList.allCards());
@@ -782,7 +786,7 @@ public abstract class SpellAbilityEffect {
             lki = null;
         }
 
-        return new GameCommand() {
+        GameCommand gc = new GameCommand() {
 
             private static final long serialVersionUID = 1L;
 
@@ -837,6 +841,13 @@ public abstract class SpellAbilityEffect {
             }
 
         };
+
+        // corner case can lead to host exiling itself during the effect
+        if (sa.getParam("Duration").contains("UntilHostLeavesPlay") && !hostCard.isInPlay()) {
+            gc.run();
+        } else {
+            addUntilCommand(sa, gc);
+        }
     }
 
     protected static void discard(SpellAbility sa, final boolean effect, Map<Player, CardCollectionView> discardedMap, Map<AbilityKey, Object> params) {

--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneAllEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneAllEffect.java
@@ -186,9 +186,7 @@ public class ChangeZoneAllEffect extends SpellAbilityEffect {
 
         triggerList.triggerChangesZoneAll(game, sa);
 
-        if (sa.hasParam("Duration")) {
-            addUntilCommand(sa, untilHostLeavesPlayCommand(triggerList, sa));
-        }
+        changeZoneUntilCommand(triggerList, sa);
 
         // CR 701.20d If an effect would cause a player to shuffle a set of objects into a library,
         // that library is shuffled even if there are no objects in that set. 

--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
@@ -832,9 +832,8 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
         if (sa.hasParam("AtEOT") && !triggerList.isEmpty()) {
             registerDelayedTrigger(sa, sa.getParam("AtEOT"), triggerList.allCards());
         }
-        if ("UntilHostLeavesPlay".equals(sa.getParam("Duration"))) {
-            addUntilCommand(sa, untilHostLeavesPlayCommand(triggerList, sa));
-        }
+
+        changeZoneUntilCommand(triggerList, sa);
 
         // might set after card is moved again if something has changed
         if (destination.equals(ZoneType.Exile)) {
@@ -1475,9 +1474,7 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
         }
         triggerList.triggerChangesZoneAll(game, sa);
 
-        if ("UntilHostLeavesPlay".equals(sa.getParam("Duration"))) {
-            addUntilCommand(sa, untilHostLeavesPlayCommand(triggerList, sa));
-        }
+        changeZoneUntilCommand(triggerList, sa);
     }
 
     private void handleCastWhileSearching(final CardCollection fetchList, final Player decider) {


### PR DESCRIPTION
> In some very rare situations, Aligned Hedron Network may enter the battlefield as a creature with power 5 or greater. If this happens, Aligned Hedron Network will exile itself along with other creatures with power 5 or greater. Those cards will immediately return to the battlefield. If this causes a loop with Aligned Hedron Network continually exiling and returning itself, the game will be a draw unless a player breaks the loop somehow.