### PR TITLE
Fix cards in decks reverting to first art in set after game is restarted

### DIFF
--- a/forge-core/src/main/java/forge/card/CardDb.java
+++ b/forge-core/src/main/java/forge/card/CardDb.java
@@ -636,6 +636,13 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
         return tryGetCard(request);
     }
 
+    @Override
+    public PaperCard getCard(final String cardName, String setCode, String collectorNumber, Map<String, String> flags) {
+        String reqInfo = CardRequest.compose(cardName, setCode, collectorNumber, flags);
+        CardRequest request = CardRequest.fromString(reqInfo);
+        return tryGetCard(request);
+    }
+
     private PaperCard tryGetCard(CardRequest request) {
         // Before doing anything, check that a non-null request has been provided
         if (request == null)

--- a/forge-core/src/main/java/forge/card/ICardDatabase.java
+++ b/forge-core/src/main/java/forge/card/ICardDatabase.java
@@ -50,6 +50,7 @@ public interface ICardDatabase extends Iterable<PaperCard> {
     // [NEW Methods] Including the card CollectorNumber as criterion for DB lookup
     PaperCard getCard(String cardName, String edition, String collectorNumber);
     PaperCard getCard(String cardName, String edition, int artIndex, Map<String, String> flags);
+    PaperCard getCard(String cardName, String edition, String collectorNumber, Map<String, String> flags);
 
     // 2. Card Lookup from a single Expansion Set
     PaperCard getCardFromSet(String cardName, CardEdition edition, boolean isFoil);  // NOT yet used, included for API symmetry


### PR DESCRIPTION
Resolves [this debacle.](https://discord.com/channels/267367946135928833/1363076100502323333/1363076100502323333) 

This was a pretty big oversight during my testing. I had verified that decks retain the correct print when the deck was saved then re-opened, but I didn't realize the loading from file was done for most decks when Forge first starts, causing me to miss that the prints had changed then. Sincerest apologies to those affected.