### PR TITLE
Update cards with Static CantAttack or CantBlock

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/AttachAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/AttachAi.java
@@ -834,7 +834,27 @@ public class AttachAi extends SpellAbilityAi {
         int totPower = 0;
         final List<String> keywords = new ArrayList<>();
 
+        boolean cantAttack = false;
+        boolean cantBlock = false;
+
         for (final StaticAbility stAbility : attachSource.getStaticAbilities()) {
+            if (stAbility.checkMode(StaticAbilityMode.CantAttack)) {
+                String valid = stAbility.getParam("ValidCard");
+                if (valid.contains(stCheck) || valid.contains("AttachedBy")) {
+                    cantAttack = true;
+                }
+            } else if (stAbility.checkMode(StaticAbilityMode.CantBlock)) {
+                String valid = stAbility.getParam("ValidCard");
+                if (valid.contains(stCheck) || valid.contains("AttachedBy")) {
+                    cantBlock = true;
+                }
+            } else if (stAbility.checkMode(StaticAbilityMode.CantBlockBy)) {
+                String valid = stAbility.getParam("ValidBlocker");
+                if (valid.contains(stCheck) || valid.contains("AttachedBy")) {
+                    cantBlock = true;
+                }
+            }
+
             if (!stAbility.checkMode(StaticAbilityMode.Continuous)) {
                 continue;
             }
@@ -886,6 +906,12 @@ public class AttachAi extends SpellAbilityAi {
             prefList = CardLists.filter(prefList, c -> containsUsefulCurseKeyword(keywords, c, sa));
         } else if (totPower < 0) {
             prefList = CardLists.filter(prefList, c -> c.getNetPower() > 0 && ComputerUtilCombat.canAttackNextTurn(c));
+        }
+
+        if (cantAttack) {
+            prefList = CardLists.filter(prefList, c -> c.isCreature() && ComputerUtilCombat.canAttackNextTurn(c));
+        } else if (cantBlock) { // TODO better can block filter?
+            prefList = CardLists.filter(prefList, c -> c.isCreature() && !ComputerUtilCard.isUselessCreature(ai, c));
         }
 
         //some auras aren't useful in multiples

--- a/forge-gui/res/cardsfolder/a/akron_legionnaire.txt
+++ b/forge-gui/res/cardsfolder/a/akron_legionnaire.txt
@@ -2,7 +2,7 @@ Name:Akron Legionnaire
 ManaCost:6 W W
 Types:Creature Giant Soldier
 PT:8/4
-S:Mode$ Continuous | Affected$ Creature.YouCtrl+nonArtifact+notnamedAkron Legionnaire | AddHiddenKeyword$ CARDNAME can't attack. | Description$ Except for creatures named Akron Legionnaire and artifact creatures, creatures you control can't attack.
+S:Mode$ CantAttack | ValidCard$ Creature.YouCtrl+nonArtifact+notnamedAkron Legionnaire | Description$ Except for creatures named Akron Legionnaire and artifact creatures, creatures you control can't attack.
 DeckHints:Type$Artifact
 DeckNeeds:Name$Akron Legionnaire
 Oracle:Except for creatures named Akron Legionnaire and artifact creatures, creatures you control can't attack.

--- a/forge-gui/res/cardsfolder/a/arachnus_web.txt
+++ b/forge-gui/res/cardsfolder/a/arachnus_web.txt
@@ -4,7 +4,9 @@ Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAITgts:Creature.powerLT4
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. & CARDNAME's activated abilities can't be activated. | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBeActivated | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
 T:Mode$ Phase | Phase$ End of Turn | TriggerZones$ Battlefield | IsPresent$ Creature.EnchantedBy+powerGE4 | Execute$ TrigDestroy | TriggerDescription$ At the beginning of the end step, if enchanted creature's power is 4 or greater, destroy CARDNAME.
 SVar:TrigDestroy:DB$ Destroy | Defined$ Self
 DeckHints:Name$Arachnus Spinner

--- a/forge-gui/res/cardsfolder/a/arachnus_web.txt
+++ b/forge-gui/res/cardsfolder/a/arachnus_web.txt
@@ -4,9 +4,7 @@ Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAITgts:Creature.powerLT4
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBeActivated | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack,CantBlock,CantBeActivated | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
 T:Mode$ Phase | Phase$ End of Turn | TriggerZones$ Battlefield | IsPresent$ Creature.EnchantedBy+powerGE4 | Execute$ TrigDestroy | TriggerDescription$ At the beginning of the end step, if enchanted creature's power is 4 or greater, destroy CARDNAME.
 SVar:TrigDestroy:DB$ Destroy | Defined$ Self
 DeckHints:Name$Arachnus Spinner

--- a/forge-gui/res/cardsfolder/a/arrest.txt
+++ b/forge-gui/res/cardsfolder/a/arrest.txt
@@ -3,5 +3,7 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. & CARDNAME's activated abilities can't be activated. | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBeActivated | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
 Oracle:Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/a/arrest.txt
+++ b/forge-gui/res/cardsfolder/a/arrest.txt
@@ -3,7 +3,5 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBeActivated | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack,CantBlock,CantBeActivated | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
 Oracle:Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/b/bedlam.txt
+++ b/forge-gui/res/cardsfolder/b/bedlam.txt
@@ -1,7 +1,7 @@
 Name:Bedlam
 ManaCost:2 R R
 Types:Enchantment
-S:Mode$ Continuous | Affected$ Creature | AddHiddenKeyword$ CARDNAME can't block. | Description$ Creatures can't block.
+S:Mode$ CantBlock | ValidCard$ Creature | Description$ Creatures can't block.
 SVar:NonStackingEffect:True
 AI:RemoveDeck:Random
 Oracle:Creatures can't block.

--- a/forge-gui/res/cardsfolder/b/blind_spot_giant.txt
+++ b/forge-gui/res/cardsfolder/b/blind_spot_giant.txt
@@ -2,7 +2,8 @@ Name:Blind-Spot Giant
 ManaCost:2 R
 Types:Creature Giant Warrior
 PT:4/3
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack or block. | IsPresent$ Giant.Other+YouCtrl | PresentCompare$ EQ0 | Description$ CARDNAME can't attack or block unless you control another Giant.
+S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Giant.Other+YouCtrl | PresentCompare$ EQ0 | Description$ CARDNAME can't attack or block unless you control another Giant.
+S:Mode$ CantBlock | ValidCard$ Card.Self | IsPresent$ Giant.Other+YouCtrl | PresentCompare$ EQ0 | Secondary$ True | Description$ CARDNAME can't attack or block unless you control another Giant.
 SVar:BuffedBy:Giant
 AI:RemoveDeck:Random
 Oracle:Blind-Spot Giant can't attack or block unless you control another Giant.

--- a/forge-gui/res/cardsfolder/b/blind_spot_giant.txt
+++ b/forge-gui/res/cardsfolder/b/blind_spot_giant.txt
@@ -2,8 +2,7 @@ Name:Blind-Spot Giant
 ManaCost:2 R
 Types:Creature Giant Warrior
 PT:4/3
-S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Giant.Other+YouCtrl | PresentCompare$ EQ0 | Description$ CARDNAME can't attack or block unless you control another Giant.
-S:Mode$ CantBlock | ValidCard$ Card.Self | IsPresent$ Giant.Other+YouCtrl | PresentCompare$ EQ0 | Secondary$ True | Description$ CARDNAME can't attack or block unless you control another Giant.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Card.Self | IsPresent$ Giant.Other+YouCtrl | PresentCompare$ EQ0 | Description$ CARDNAME can't attack or block unless you control another Giant.
 SVar:BuffedBy:Giant
 AI:RemoveDeck:Random
 Oracle:Blind-Spot Giant can't attack or block unless you control another Giant.

--- a/forge-gui/res/cardsfolder/b/bloodcrazed_goblin.txt
+++ b/forge-gui/res/cardsfolder/b/bloodcrazed_goblin.txt
@@ -2,6 +2,6 @@ Name:Bloodcrazed Goblin
 ManaCost:R
 Types:Creature Goblin Berserker
 PT:2/2
-S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ CARDNAME can't attack. | CheckSVar$ X | SVarCompare$ LT1 | Description$ CARDNAME can't attack unless an opponent has been dealt damage this turn.
+S:Mode$ CantAttack | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ LT1 | Description$ CARDNAME can't attack unless an opponent has been dealt damage this turn.
 SVar:X:PlayerCountPropertyYou$DamageToOppsThisTurn
 Oracle:Bloodcrazed Goblin can't attack unless an opponent has been dealt damage this turn.

--- a/forge-gui/res/cardsfolder/b/bonds_of_faith.txt
+++ b/forge-gui/res/cardsfolder/b/bonds_of_faith.txt
@@ -5,5 +5,6 @@ K:Enchant:Creature
 SVar:AttachAILogic:SpecificCard
 SVar:AttachAIValid:Human
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy+Human | AddPower$ 2 | AddToughness$ 2 | Description$ Enchanted creature gets +2/+2 as long as it's a Human.
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy+nonHuman | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Otherwise, it can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy+nonHuman | Description$ Otherwise, it can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy+nonHuman | Secondary$ True | Description$ Otherwise, it can't attack or block.
 Oracle:Enchant creature\nEnchanted creature gets +2/+2 as long as it's a Human. Otherwise, it can't attack or block.

--- a/forge-gui/res/cardsfolder/b/bonds_of_faith.txt
+++ b/forge-gui/res/cardsfolder/b/bonds_of_faith.txt
@@ -5,6 +5,5 @@ K:Enchant:Creature
 SVar:AttachAILogic:SpecificCard
 SVar:AttachAIValid:Human
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy+Human | AddPower$ 2 | AddToughness$ 2 | Description$ Enchanted creature gets +2/+2 as long as it's a Human.
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy+nonHuman | Description$ Otherwise, it can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy+nonHuman | Secondary$ True | Description$ Otherwise, it can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy+nonHuman | Description$ Otherwise, it can't attack or block.
 Oracle:Enchant creature\nEnchanted creature gets +2/+2 as long as it's a Human. Otherwise, it can't attack or block.

--- a/forge-gui/res/cardsfolder/b/bontu_the_glorified.txt
+++ b/forge-gui/res/cardsfolder/b/bontu_the_glorified.txt
@@ -4,7 +4,8 @@ Types:Legendary Creature God
 PT:4/6
 K:Menace
 K:Indestructible
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack or block. | CheckSVar$ X | SVarCompare$ EQ0 | Description$ CARDNAME can't attack or block unless a creature died under your control this turn.
+S:Mode$ CantAttack | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ EQ0 | Description$ NICKNAME can't attack or block unless a creature died under your control this turn.
+S:Mode$ CantBlock | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ EQ0 | Secondary$ True | Description$ NICKNAME can't attack or block unless a creature died under your control this turn.
 A:AB$ Scry | Cost$ 1 B Sac<1/Creature.Other/another creature> | ScryNum$ 1 | SubAbility$ DBLoseLife | SpellDescription$ Scry 1. Each opponent loses 1 life and you gain 1 life.
 SVar:DBLoseLife:DB$ LoseLife | Defined$ Player.Opponent | LifeAmount$ 1 | SubAbility$ DBGainLife
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1

--- a/forge-gui/res/cardsfolder/b/bontu_the_glorified.txt
+++ b/forge-gui/res/cardsfolder/b/bontu_the_glorified.txt
@@ -4,8 +4,7 @@ Types:Legendary Creature God
 PT:4/6
 K:Menace
 K:Indestructible
-S:Mode$ CantAttack | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ EQ0 | Description$ NICKNAME can't attack or block unless a creature died under your control this turn.
-S:Mode$ CantBlock | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ EQ0 | Secondary$ True | Description$ NICKNAME can't attack or block unless a creature died under your control this turn.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ EQ0 | Description$ NICKNAME can't attack or block unless a creature died under your control this turn.
 A:AB$ Scry | Cost$ 1 B Sac<1/Creature.Other/another creature> | ScryNum$ 1 | SubAbility$ DBLoseLife | SpellDescription$ Scry 1. Each opponent loses 1 life and you gain 1 life.
 SVar:DBLoseLife:DB$ LoseLife | Defined$ Player.Opponent | LifeAmount$ 1 | SubAbility$ DBGainLife
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1

--- a/forge-gui/res/cardsfolder/b/bothersome_quasit.txt
+++ b/forge-gui/res/cardsfolder/b/bothersome_quasit.txt
@@ -3,7 +3,7 @@ ManaCost:2 R
 Types:Creature Demon
 PT:3/2
 K:Menace
-S:Mode$ Continuous | Affected$ Creature.IsGoaded+OppCtrl | AddHiddenKeyword$ CARDNAME can't block. | Description$ Goaded creatures your opponents control can't block.
+S:Mode$ CantBlock | ValidCard$ Creature.IsGoaded+OppCtrl | Description$ Goaded creatures your opponents control can't block.
 T:Mode$ SpellCast | ValidCard$ Card.nonCreature | ValidActivatingPlayer$ You | Execute$ DBGoad | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a noncreature spell, goad target creature an opponent controls.
 SVar:DBGoad:DB$ Goad | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls
 SVar:BuffedBy:Card.nonCreature

--- a/forge-gui/res/cardsfolder/b/bound_by_moonsilver.txt
+++ b/forge-gui/res/cardsfolder/b/bound_by_moonsilver.txt
@@ -3,9 +3,7 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block, or transform.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block, or transform.
-S:Mode$ CantTransform | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't transform.
+S:Mode$ CantAttack,CantBlock,CantTransform | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block, or transform.
 A:AB$ Attach | Cost$ Sac<1/Permanent.Other/another permanent> | ValidTgts$ Creature | TgtPrompt$ Select target creature | AILogic$ Curse | SorcerySpeed$ True | ActivationLimit$ 1 | SpellDescription$ Attach CARDNAME to target creature. Activate only as a sorcery and only once each turn.
 SVar:AIPreference:SacCost$Card.token,Permanent.nonLand+cmcLE2,Land.Basic
 Oracle:Enchant creature\nEnchanted creature can't attack, block, or transform.\nSacrifice another permanent: Attach Bound by Moonsilver to target creature. Activate only as a sorcery and only once each turn.

--- a/forge-gui/res/cardsfolder/b/bound_by_moonsilver.txt
+++ b/forge-gui/res/cardsfolder/b/bound_by_moonsilver.txt
@@ -3,7 +3,8 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Enchanted creature can't attack, block, or transform.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block, or transform.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block, or transform.
 S:Mode$ CantTransform | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't transform.
 A:AB$ Attach | Cost$ Sac<1/Permanent.Other/another permanent> | ValidTgts$ Creature | TgtPrompt$ Select target creature | AILogic$ Curse | SorcerySpeed$ True | ActivationLimit$ 1 | SpellDescription$ Attach CARDNAME to target creature. Activate only as a sorcery and only once each turn.
 SVar:AIPreference:SacCost$Card.token,Permanent.nonLand+cmcLE2,Land.Basic

--- a/forge-gui/res/cardsfolder/b/bound_in_gold.txt
+++ b/forge-gui/res/cardsfolder/b/bound_in_gold.txt
@@ -3,8 +3,5 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Permanent
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted permanent can't attack, block, or crew Vehicles, and its activated abilities can't be activated unless they're mana abilities.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack, block, or crew Vehicles, and its activated abilities can't be activated unless they're mana abilities.
-S:Mode$ CantCrew | ValidCard$ Permanent.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't crew Vehicles.
-S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated.nonManaAbility | Secondary$ True | Description$ Enchanted permanent's activated abilities can't be activated unless they're mana abilities.
+S:Mode$ CantAttack,CantBlock,CantCrew,CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated.nonManaAbility | Description$ Enchanted permanent can't attack, block, or crew Vehicles, and its activated abilities can't be activated unless they're mana abilities.
 Oracle:Enchant permanent\nEnchanted permanent can't attack, block, or crew Vehicles, and its activated abilities can't be activated unless they're mana abilities.

--- a/forge-gui/res/cardsfolder/b/bound_in_gold.txt
+++ b/forge-gui/res/cardsfolder/b/bound_in_gold.txt
@@ -3,7 +3,8 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Permanent
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Permanent.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Enchanted permanent can't attack, block, or crew Vehicles, and its activated abilities can't be activated unless they're mana abilities.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted permanent can't attack, block, or crew Vehicles, and its activated abilities can't be activated unless they're mana abilities.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack, block, or crew Vehicles, and its activated abilities can't be activated unless they're mana abilities.
 S:Mode$ CantCrew | ValidCard$ Permanent.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't crew Vehicles.
-S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated.nonManaAbility
+S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated.nonManaAbility | Secondary$ True | Description$ Enchanted permanent's activated abilities can't be activated unless they're mana abilities.
 Oracle:Enchant permanent\nEnchanted permanent can't attack, block, or crew Vehicles, and its activated abilities can't be activated unless they're mana abilities.

--- a/forge-gui/res/cardsfolder/b/bound_in_silence.txt
+++ b/forge-gui/res/cardsfolder/b/bound_in_silence.txt
@@ -3,5 +3,6 @@ ManaCost:2 W
 Types:Kindred Enchantment Rebel Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
 Oracle:Enchant creature\nEnchanted creature can't attack or block.

--- a/forge-gui/res/cardsfolder/b/bound_in_silence.txt
+++ b/forge-gui/res/cardsfolder/b/bound_in_silence.txt
@@ -3,6 +3,5 @@ ManaCost:2 W
 Types:Kindred Enchantment Rebel Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
 Oracle:Enchant creature\nEnchanted creature can't attack or block.

--- a/forge-gui/res/cardsfolder/b/branded_brawlers.txt
+++ b/forge-gui/res/cardsfolder/b/branded_brawlers.txt
@@ -3,5 +3,5 @@ ManaCost:R
 Types:Creature Human Soldier
 PT:2/2
 S:Mode$ CantAttack | ValidCard$ Card.Self | IfDefenderControls$ Land.untapped | Description$ CARDNAME can't attack if defending player controls an untapped land.
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't block. | IsPresent$ Land.YouCtrl+untapped | Description$ CARDNAME can't block if you control an untapped land.
+S:Mode$ CantBlock | ValidCard$ Card.Self | IsPresent$ Land.YouCtrl+untapped | Description$ CARDNAME can't block if you control an untapped land.
 Oracle:Branded Brawlers can't attack if defending player controls an untapped land.\nBranded Brawlers can't block if you control an untapped land.

--- a/forge-gui/res/cardsfolder/c/cage_of_hands.txt
+++ b/forge-gui/res/cardsfolder/c/cage_of_hands.txt
@@ -3,6 +3,7 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
 A:AB$ ChangeZone | Cost$ 1 W | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return CARDNAME to its owner's hand.
 Oracle:Enchant creature\nEnchanted creature can't attack or block.\n{1}{W}: Return Cage of Hands to its owner's hand.

--- a/forge-gui/res/cardsfolder/c/cage_of_hands.txt
+++ b/forge-gui/res/cardsfolder/c/cage_of_hands.txt
@@ -3,7 +3,6 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
 A:AB$ ChangeZone | Cost$ 1 W | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return CARDNAME to its owner's hand.
 Oracle:Enchant creature\nEnchanted creature can't attack or block.\n{1}{W}: Return Cage of Hands to its owner's hand.

--- a/forge-gui/res/cardsfolder/c/cagemail.txt
+++ b/forge-gui/res/cardsfolder/c/cagemail.txt
@@ -3,6 +3,7 @@ ManaCost:1 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 2 | AddToughness$ 2 | AddHiddenKeyword$ CARDNAME can't attack. | Description$ Enchanted creature gets +2/+2 and can't attack.
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 2 | AddToughness$ 2 | Description$ Enchanted creature gets +2/+2 and can't attack.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature gets +2/+2 and can't attack.
 AI:RemoveDeck:All
 Oracle:Enchant creature\nEnchanted creature gets +2/+2 and can't attack.

--- a/forge-gui/res/cardsfolder/c/calming_licid.txt
+++ b/forge-gui/res/cardsfolder/c/calming_licid.txt
@@ -4,6 +4,6 @@ Types:Creature Licid
 PT:2/2
 A:AB$ Animate | Cost$ W T | Defined$ Self | RemoveThisAbility$ True | Duration$ Permanent | RevertCost$ W | Keywords$ Enchant:Creature | Types$ Enchantment,Aura | RemoveCardTypes$ True | RemoveEnchantmentTypes$ True | SubAbility$ DBAttach | SpellDescription$ CARDNAME loses this ability and becomes an Aura enchantment with enchant creature. Attach it to target creature. You may pay {W} to end this effect.
 SVar:DBAttach:DB$ Attach | ValidTgts$ Creature | AILogic$ Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack. | Description$ Enchanted creature can't attack.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack.
 AI:RemoveDeck:All
 Oracle:{W}, {T}: Calming Licid loses this ability and becomes an Aura enchantment with enchant creature. Attach it to target creature. You may pay {W} to end this effect.\nEnchanted creature can't attack.

--- a/forge-gui/res/cardsfolder/c/captured_by_lagacs.txt
+++ b/forge-gui/res/cardsfolder/c/captured_by_lagacs.txt
@@ -3,8 +3,7 @@ ManaCost:1 G W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPut | TriggerDescription$ When CARDNAME enters, support 2. (Put a +1/+1 counter on each of up to two target creatures.)
 SVar:TrigPut:DB$ PutCounter | ValidTgts$ Creature | TgtPrompt$ Select up to two target creatures | TargetMin$ 0 | TargetMax$ 2 | CounterType$ P1P1 | CounterNum$ 1
 Oracle:Enchant creature\nEnchanted creature can't attack or block.\nWhen Captured by Lagacs enters, support 2. (Put a +1/+1 counter on each of up to two target creatures.)

--- a/forge-gui/res/cardsfolder/c/captured_by_lagacs.txt
+++ b/forge-gui/res/cardsfolder/c/captured_by_lagacs.txt
@@ -3,7 +3,8 @@ ManaCost:1 G W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPut | TriggerDescription$ When CARDNAME enters, support 2. (Put a +1/+1 counter on each of up to two target creatures.)
 SVar:TrigPut:DB$ PutCounter | ValidTgts$ Creature | TgtPrompt$ Select up to two target creatures | TargetMin$ 0 | TargetMax$ 2 | CounterType$ P1P1 | CounterNum$ 1
 Oracle:Enchant creature\nEnchanted creature can't attack or block.\nWhen Captured by Lagacs enters, support 2. (Put a +1/+1 counter on each of up to two target creatures.)

--- a/forge-gui/res/cardsfolder/c/captured_by_the_consulate.txt
+++ b/forge-gui/res/cardsfolder/c/captured_by_the_consulate.txt
@@ -3,7 +3,7 @@ ManaCost:3 W
 Types:Enchantment Aura
 K:Enchant:Creature.YouDontCtrl:creature you don't control
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack. | Description$ Enchanted creature can't attack.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack.
 T:Mode$ SpellCast | ValidSA$ Spell.singleTarget | ValidActivatingPlayer$ Opponent | TriggerZones$ Battlefield | OrderDuplicates$ True | Execute$ TrigChangeTarget | TriggerDescription$ Whenever an opponent casts a spell, if it has a single target, change the target to enchanted creature if able.
 SVar:TrigChangeTarget:DB$ ChangeTargets | TargetType$ Spell | Defined$ TriggeredStackInstance | DefinedMagnet$ Enchanted
 Oracle:Enchant creature you don't control\nEnchanted creature can't attack.\nWhenever an opponent casts a spell, if it has a single target, change the target to enchanted creature if able.

--- a/forge-gui/res/cardsfolder/c/cast_into_darkness.txt
+++ b/forge-gui/res/cardsfolder/c/cast_into_darkness.txt
@@ -3,5 +3,6 @@ ManaCost:1 B
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ -2 | AddHiddenKeyword$ CARDNAME can't block. | Description$ Enchanted creature gets -2/-0 and can't block.
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ -2 | Description$ Enchanted creature gets -2/-0 and can't block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature gets -2/-0 and can't block.
 Oracle:Enchant creature\nEnchanted creature gets -2/-0 and can't block.

--- a/forge-gui/res/cardsfolder/c/caught_in_the_brights.txt
+++ b/forge-gui/res/cardsfolder/c/caught_in_the_brights.txt
@@ -3,7 +3,8 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
 T:Mode$ Attacks | ValidCard$ Vehicle.YouCtrl | Execute$ TrigExile | TriggerZones$ Battlefield | TriggerDescription$ When a Vehicle you control attacks, exile enchanted creature.
 SVar:TrigExile:DB$ ChangeZone | Defined$ Enchanted | Origin$ Battlefield | Destination$ Exile
 Oracle:Enchant creature\nEnchanted creature can't attack or block.\nWhen a Vehicle you control attacks, exile enchanted creature.

--- a/forge-gui/res/cardsfolder/c/caught_in_the_brights.txt
+++ b/forge-gui/res/cardsfolder/c/caught_in_the_brights.txt
@@ -3,8 +3,7 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
 T:Mode$ Attacks | ValidCard$ Vehicle.YouCtrl | Execute$ TrigExile | TriggerZones$ Battlefield | TriggerDescription$ When a Vehicle you control attacks, exile enchanted creature.
 SVar:TrigExile:DB$ ChangeZone | Defined$ Enchanted | Origin$ Battlefield | Destination$ Exile
 Oracle:Enchant creature\nEnchanted creature can't attack or block.\nWhen a Vehicle you control attacks, exile enchanted creature.

--- a/forge-gui/res/cardsfolder/c/cessation.txt
+++ b/forge-gui/res/cardsfolder/c/cessation.txt
@@ -3,7 +3,7 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack. | Description$ Enchanted creature can't attack.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack.
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigChangeZone | TriggerDescription$ When CARDNAME is put into a graveyard from the battlefield, return CARDNAME to its owner's hand.
 SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | Defined$ TriggeredNewCardLKICopy
 SVar:SacMe:2

--- a/forge-gui/res/cardsfolder/c/childhood_horror.txt
+++ b/forge-gui/res/cardsfolder/c/childhood_horror.txt
@@ -4,5 +4,5 @@ Types:Creature Horror
 PT:2/2
 K:Flying
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 2 | AddToughness$ 2 | Condition$ Threshold | Description$ Threshold — As long as seven or more cards are in your graveyard, CARDNAME gets +2/+2 and can't block.
-S:Mode$ CantBlock | ValidCard$ Card.Self | AddKeyword$ CARDNAME can't block. | Condition$ Threshold | Secondary$ True | Description$ Enchanted Threshold — As long as seven or more cards are in your graveyard, CARDNAME gets +2/+2 and can't block.
+S:Mode$ CantBlock | ValidCard$ Card.Self | Condition$ Threshold | Secondary$ True | Description$ Enchanted Threshold — As long as seven or more cards are in your graveyard, CARDNAME gets +2/+2 and can't block.
 Oracle:Flying\nThreshold — As long as seven or more cards are in your graveyard, Childhood Horror gets +2/+2 and can't block.

--- a/forge-gui/res/cardsfolder/c/childhood_horror.txt
+++ b/forge-gui/res/cardsfolder/c/childhood_horror.txt
@@ -3,5 +3,6 @@ ManaCost:3 B
 Types:Creature Horror
 PT:2/2
 K:Flying
-S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 2 | AddToughness$ 2 | AddKeyword$ CARDNAME can't block. | Condition$ Threshold | Description$ Threshold — As long as seven or more cards are in your graveyard, CARDNAME gets +2/+2 and can't block.
+S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 2 | AddToughness$ 2 | Condition$ Threshold | Description$ Threshold — As long as seven or more cards are in your graveyard, CARDNAME gets +2/+2 and can't block.
+S:Mode$ CantBlock | ValidCard$ Card.Self | AddKeyword$ CARDNAME can't block. | Condition$ Threshold | Secondary$ True | Description$ Enchanted Threshold — As long as seven or more cards are in your graveyard, CARDNAME gets +2/+2 and can't block.
 Oracle:Flying\nThreshold — As long as seven or more cards are in your graveyard, Childhood Horror gets +2/+2 and can't block.

--- a/forge-gui/res/cardsfolder/c/choking_restraints.txt
+++ b/forge-gui/res/cardsfolder/c/choking_restraints.txt
@@ -3,8 +3,7 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
 A:AB$ ChangeZone | Cost$ 3 W W Sac<1/CARDNAME> | Defined$ Enchanted | Origin$ Battlefield | Destination$ Exile | SpellDescription$ Exile enchanted creature.
 SVar:NonStackingAttachEffect:True
 Oracle:Enchant creature\nEnchanted creature can't attack or block.\n{3}{W}{W}, Sacrifice Choking Restraints: Exile enchanted creature.

--- a/forge-gui/res/cardsfolder/c/choking_restraints.txt
+++ b/forge-gui/res/cardsfolder/c/choking_restraints.txt
@@ -3,7 +3,8 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
 A:AB$ ChangeZone | Cost$ 3 W W Sac<1/CARDNAME> | Defined$ Enchanted | Origin$ Battlefield | Destination$ Exile | SpellDescription$ Exile enchanted creature.
 SVar:NonStackingAttachEffect:True
 Oracle:Enchant creature\nEnchanted creature can't attack or block.\n{3}{W}{W}, Sacrifice Choking Restraints: Exile enchanted creature.

--- a/forge-gui/res/cardsfolder/c/clawing_torment.txt
+++ b/forge-gui/res/cardsfolder/c/clawing_torment.txt
@@ -4,7 +4,8 @@ Types:Enchantment Aura
 K:Enchant:Creature,Artifact:artifact or creature
 SVar:AttachAITgts:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ -1 | AddToughness$ -1 | AddHiddenKeyword$ CARDNAME can't block. | Description$ As long as enchanted permanent is a creature, it gets -1/-1 and can't block.
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ -1 | AddToughness$ -1 | Description$ As long as enchanted permanent is a creature, it gets -1/-1 and can't block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ As long as enchanted permanent is a creature, it gets -1/-1 and can't block.
 S:Mode$ Continuous | Affected$ Card.EnchantedBy | AddTrigger$ TriggerTorment | AddSVar$ TrigLoseLife | Description$ Enchanted permanent has "At the beginning of your upkeep, you lose 1 life."
 SVar:TriggerTorment:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ TrigLoseLife | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, you lose 1 life.
 SVar:TrigLoseLife:DB$ LoseLife | Defined$ You | LifeAmount$ 1

--- a/forge-gui/res/cardsfolder/c/compulsory_rest.txt
+++ b/forge-gui/res/cardsfolder/c/compulsory_rest.txt
@@ -3,8 +3,7 @@ ManaCost:1 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddAbility$ ABGainLife | Description$ Enchanted creature has "{2}, Sacrifice this creature: You gain 2 life."
 SVar:ABGainLife:AB$ GainLife | Cost$ 2 Sac<1/CARDNAME> | LifeAmount$ 2 | Defined$ You | SpellDescription$ You gain 2 life.
 Oracle:Enchant creature\nEnchanted creature can't attack or block.\nEnchanted creature has "{2}, Sacrifice this creature: You gain 2 life."

--- a/forge-gui/res/cardsfolder/c/compulsory_rest.txt
+++ b/forge-gui/res/cardsfolder/c/compulsory_rest.txt
@@ -3,7 +3,8 @@ ManaCost:1 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddAbility$ ABGainLife | Description$ Enchanted creature has "{2}, Sacrifice this creature: You gain 2 life."
 SVar:ABGainLife:AB$ GainLife | Cost$ 2 Sac<1/CARDNAME> | LifeAmount$ 2 | Defined$ You | SpellDescription$ You gain 2 life.
 Oracle:Enchant creature\nEnchanted creature can't attack or block.\nEnchanted creature has "{2}, Sacrifice this creature: You gain 2 life."

--- a/forge-gui/res/cardsfolder/c/convulsing_licid.txt
+++ b/forge-gui/res/cardsfolder/c/convulsing_licid.txt
@@ -4,6 +4,6 @@ Types:Creature Licid
 PT:2/2
 A:AB$ Animate | Cost$ R T | Defined$ Self | RemoveThisAbility$ True | Duration$ Permanent | RevertCost$ R | Keywords$ Enchant:Creature | Types$ Enchantment,Aura | RemoveCardTypes$ True | RemoveEnchantmentTypes$ True | SubAbility$ DBAttach | SpellDescription$ CARDNAME loses this ability and becomes an Aura enchantment with enchant creature. Attach it to target creature. You may pay {R} to end this effect.
 SVar:DBAttach:DB$ Attach | ValidTgts$ Creature | AILogic$ Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't block. | Description$ Enchanted creature can't block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't block.
 AI:RemoveDeck:All
 Oracle:{R}, {T}: Convulsing Licid loses this ability and becomes an Aura enchantment with enchant creature. Attach it to target creature. You may pay {R} to end this effect.\nEnchanted creature can't block.

--- a/forge-gui/res/cardsfolder/c/cooped_up.txt
+++ b/forge-gui/res/cardsfolder/c/cooped_up.txt
@@ -3,7 +3,6 @@ ManaCost:1 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
 A:AB$ ChangeZone | Cost$ 2 W | Defined$ Enchanted | Origin$ Battlefield | Destination$ Exile | SpellDescription$ Exile enchanted creature.
 Oracle:Enchant creature\nEnchanted creature can't attack or block.\n{2}{W}: Exile enchanted creature.

--- a/forge-gui/res/cardsfolder/c/cooped_up.txt
+++ b/forge-gui/res/cardsfolder/c/cooped_up.txt
@@ -3,6 +3,7 @@ ManaCost:1 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
 A:AB$ ChangeZone | Cost$ 2 W | Defined$ Enchanted | Origin$ Battlefield | Destination$ Exile | SpellDescription$ Exile enchanted creature.
 Oracle:Enchant creature\nEnchanted creature can't attack or block.\n{2}{W}: Exile enchanted creature.

--- a/forge-gui/res/cardsfolder/c/copper_carapace.txt
+++ b/forge-gui/res/cardsfolder/c/copper_carapace.txt
@@ -2,6 +2,7 @@ Name:Copper Carapace
 ManaCost:1
 Types:Artifact Equipment
 K:Equip:3
-S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 2 | AddToughness$ 2 | AddHiddenKeyword$ CARDNAME can't block. | Description$ Equipped creature gets +2/+2 and can't block.
+S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 2 | AddToughness$ 2 | Description$ Equipped creature gets +2/+2 and can't block.
+S:Mode$ CantBlock | ValidCard$ Creature.EquippedBy | Secondary$ True | Description$ Equipped creature gets +2/+2 and can't block.
 AI:RemoveDeck:Random
 Oracle:Equipped creature gets +2/+2 and can't block.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)

--- a/forge-gui/res/cardsfolder/c/crippling_blight.txt
+++ b/forge-gui/res/cardsfolder/c/crippling_blight.txt
@@ -3,5 +3,6 @@ ManaCost:B
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ -1 | AddToughness$ -1 | AddHiddenKeyword$ CARDNAME can't block. | Description$ Enchanted creature gets -1/-1 and can't block.
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ -1 | AddToughness$ -1 | Description$ Enchanted creature gets -1/-1 and can't block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature gets -1/-1 and can't block.
 Oracle:Enchant creature\nEnchanted creature gets -1/-1 and can't block.

--- a/forge-gui/res/cardsfolder/c/crystallization.txt
+++ b/forge-gui/res/cardsfolder/c/crystallization.txt
@@ -3,7 +3,8 @@ ManaCost:GU W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
 T:Mode$ BecomesTarget | ValidTarget$ Card.AttachedBy | TriggerZones$ Battlefield | Execute$ TrigExile | TriggerDescription$ When enchanted creature becomes the target of a spell or ability, exile that creature.
 SVar:TrigExile:DB$ ChangeZone | Defined$ TriggeredTargetLKICopy | Origin$ Battlefield | Destination$ Exile
 Oracle:Enchant creature\nEnchanted creature can't attack or block.\nWhen enchanted creature becomes the target of a spell or ability, exile that creature.

--- a/forge-gui/res/cardsfolder/c/crystallization.txt
+++ b/forge-gui/res/cardsfolder/c/crystallization.txt
@@ -3,8 +3,7 @@ ManaCost:GU W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
 T:Mode$ BecomesTarget | ValidTarget$ Card.AttachedBy | TriggerZones$ Battlefield | Execute$ TrigExile | TriggerDescription$ When enchanted creature becomes the target of a spell or ability, exile that creature.
 SVar:TrigExile:DB$ ChangeZone | Defined$ TriggeredTargetLKICopy | Origin$ Battlefield | Destination$ Exile
 Oracle:Enchant creature\nEnchanted creature can't attack or block.\nWhen enchanted creature becomes the target of a spell or ability, exile that creature.

--- a/forge-gui/res/cardsfolder/d/deadlock_trap.txt
+++ b/forge-gui/res/cardsfolder/d/deadlock_trap.txt
@@ -6,5 +6,6 @@ SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigEnergy | TriggerDescription$ When CARDNAME enters, you get {E}{E} (two energy counters).
 SVar:TrigEnergy:DB$ PutCounter | Defined$ You | CounterType$ ENERGY | CounterNum$ 2
 A:AB$ Tap | Cost$ T PayEnergy<1> | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | SubAbility$ DBPump | SpellDescription$ Tap target creature or planeswalker. Its activated abilities can't be activated this turn.
-SVar:DBPump:DB$ Pump | Defined$ ParentTarget | KW$ HIDDEN CARDNAME's activated abilities can't be activated.
+SVar:DBPump:DB$ Effect | RememberObjects$ ParentTarget | StaticAbilities$ DBCantBeActivated | ForgetOnMoved$ Battlefield
+SVar:DBCantBeActivated:Mode$ CantBeActivated | ValidCard$ Card.IsRemembered | Description$ Remembered activated abilities can't be activated.
 Oracle:Deadlock Trap enters tapped.\nWhen Deadlock Trap enters, you get {E}{E} (two energy counters).\n{T}, Pay {E}: Tap target creature or planeswalker. Its activated abilities can't be activated this turn.

--- a/forge-gui/res/cardsfolder/d/deep_sea_terror.txt
+++ b/forge-gui/res/cardsfolder/d/deep_sea_terror.txt
@@ -2,7 +2,7 @@ Name:Deep-Sea Terror
 ManaCost:4 U U
 Types:Creature Serpent
 PT:6/6
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack. | CheckSVar$ X | SVarCompare$ LT7 | Description$ CARDNAME can't attack unless there are seven or more cards in your graveyard.
+S:Mode$ CantAttack | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ LT7 | Description$ CARDNAME can't attack unless there are seven or more cards in your graveyard.
 SVar:X:Count$ValidGraveyard Card.YouOwn
 SVar:BuffedBy:Instant,Sorcery
 Oracle:Deep-Sea Terror can't attack unless there are seven or more cards in your graveyard.

--- a/forge-gui/res/cardsfolder/d/demonic_torment.txt
+++ b/forge-gui/res/cardsfolder/d/demonic_torment.txt
@@ -3,6 +3,6 @@ ManaCost:2 B
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack. | Description$ Enchanted creature can't attack.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack.
 R:Event$ DamageDone | Prevent$ True | IsCombat$ True | ValidSource$ Creature.EnchantedBy | Description$ Prevent all combat damage that would be dealt by enchanted creature.
 Oracle:Enchant creature\nEnchanted creature can't attack.\nPrevent all combat damage that would be dealt by enchanted creature.

--- a/forge-gui/res/cardsfolder/d/demotion.txt
+++ b/forge-gui/res/cardsfolder/d/demotion.txt
@@ -3,5 +3,6 @@ ManaCost:W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't block. & CARDNAME's activated abilities can't be activated. | Description$ Enchanted creature can't block, and its activated abilities can't be activated.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't block, and its activated abilities can't be activated.
+S:Mode$ CantBeActivated | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't block, and its activated abilities can't be activated.
 Oracle:Enchant creature\nEnchanted creature can't block, and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/d/deserts_hold.txt
+++ b/forge-gui/res/cardsfolder/d/deserts_hold.txt
@@ -5,8 +5,6 @@ K:Enchant:Creature
 SVar:AttachAILogic:Curse
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Desert$ True | Execute$ TrigGainLife | TriggerDescription$ When CARDNAME enters, if you control a Desert or there is a Desert card in your graveyard, you gain 3 life.
 SVar:TrigGainLife:DB$ GainLife | LifeAmount$ 3
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBeActivated | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack,CantBlock,CantBeActivated | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
 DeckHints:Type$Desert
 Oracle:Enchant creature\nWhen Desert's Hold enters, if you control a Desert or there is a Desert card in your graveyard, you gain 3 life.\nEnchanted creature can't attack or block, and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/d/deserts_hold.txt
+++ b/forge-gui/res/cardsfolder/d/deserts_hold.txt
@@ -5,6 +5,8 @@ K:Enchant:Creature
 SVar:AttachAILogic:Curse
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Desert$ True | Execute$ TrigGainLife | TriggerDescription$ When CARDNAME enters, if you control a Desert or there is a Desert card in your graveyard, you gain 3 life.
 SVar:TrigGainLife:DB$ GainLife | LifeAmount$ 3
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. & CARDNAME's activated abilities can't be activated. | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBeActivated | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
 DeckHints:Type$Desert
 Oracle:Enchant creature\nWhen Desert's Hold enters, if you control a Desert or there is a Desert card in your graveyard, you gain 3 life.\nEnchanted creature can't attack or block, and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/d/desperate_castaways.txt
+++ b/forge-gui/res/cardsfolder/d/desperate_castaways.txt
@@ -2,7 +2,7 @@ Name:Desperate Castaways
 ManaCost:1 B
 Types:Creature Human Pirate
 PT:2/3
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack. | IsPresent$ Artifact.YouCtrl | PresentCompare$ EQ0 | Description$ CARDNAME can't attack unless you control an artifact.
+S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Artifact.YouCtrl | PresentCompare$ EQ0 | Description$ CARDNAME can't attack unless you control an artifact.
 SVar:BuffedBy:Artifact
 DeckHints:Type$Artifact
 Oracle:Desperate Castaways can't attack unless you control an artifact.

--- a/forge-gui/res/cardsfolder/d/detained_by_legionnaires.txt
+++ b/forge-gui/res/cardsfolder/d/detained_by_legionnaires.txt
@@ -3,5 +3,6 @@ ManaCost:1 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
 Oracle:Enchant creature\nEnchanted creature can't attack or block.

--- a/forge-gui/res/cardsfolder/d/detained_by_legionnaires.txt
+++ b/forge-gui/res/cardsfolder/d/detained_by_legionnaires.txt
@@ -3,6 +3,5 @@ ManaCost:1 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
 Oracle:Enchant creature\nEnchanted creature can't attack or block.

--- a/forge-gui/res/cardsfolder/d/detention_vortex.txt
+++ b/forge-gui/res/cardsfolder/d/detention_vortex.txt
@@ -3,6 +3,8 @@ ManaCost:W
 Types:Enchantment Aura
 K:Enchant:Permanent.nonLand:nonland permanent
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Permanent.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. & CARDNAME's activated abilities can't be activated. | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack | ValidCard$ Card.EnchantedBy | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated.
+S:Mode$ CantBlock | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
 A:AB$ Destroy | Cost$ 3 | Defined$ Self | Activator$ Player.Opponent | SorcerySpeed$ True | SpellDescription$ Destroy CARDNAME. Only your opponents may activate this ability and only as a sorcery.
 Oracle:Enchant nonland permanent\nEnchanted permanent can't attack or block, and its activated abilities can't be activated.\n{3}: Destroy Detention Vortex. Only your opponents may activate this ability and only as a sorcery.

--- a/forge-gui/res/cardsfolder/d/detention_vortex.txt
+++ b/forge-gui/res/cardsfolder/d/detention_vortex.txt
@@ -3,8 +3,6 @@ ManaCost:W
 Types:Enchantment Aura
 K:Enchant:Permanent.nonLand:nonland permanent
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Card.EnchantedBy | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated.
-S:Mode$ CantBlock | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack,CantBlock,CantBeActivated | ValidCard$ Card.EnchantedBy | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated.
 A:AB$ Destroy | Cost$ 3 | Defined$ Self | Activator$ Player.Opponent | SorcerySpeed$ True | SpellDescription$ Destroy CARDNAME. Only your opponents may activate this ability and only as a sorcery.
 Oracle:Enchant nonland permanent\nEnchanted permanent can't attack or block, and its activated abilities can't be activated.\n{3}: Destroy Detention Vortex. Only your opponents may activate this ability and only as a sorcery.

--- a/forge-gui/res/cardsfolder/d/dog_umbra.txt
+++ b/forge-gui/res/cardsfolder/d/dog_umbra.txt
@@ -3,7 +3,6 @@ ManaCost:1 W
 Types:Enchantment Aura
 K:Flash
 K:Enchant:Creature
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy+ControlledBy Player.Other | Description$ As long as another player controls enchanted creature, it can't attack or block. Otherwise, CARDNAME has umbra armor. (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy+ControlledBy Player.Other | Secondary$ True | Description$ As long as another player controls enchanted creature, it can't attack or block. Otherwise, CARDNAME has umbra armor. (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy+ControlledBy Player.Other | Description$ As long as another player controls enchanted creature, it can't attack or block. Otherwise, CARDNAME has umbra armor. (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)
 S:Mode$ Continuous | Affected$ Card.Self | IsPresent$ Creature.YouCtrl+EnchantedBy | AddKeyword$ Umbra armor | Secondary$ True | Description$ As long as another player controls enchanted creature, it can't attack or block. Otherwise, CARDNAME has umbra armor. (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)
 Oracle:Flash\nEnchant creature\nAs long as another player controls enchanted creature, it can't attack or block. Otherwise, Dog Umbra has umbra armor. (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)

--- a/forge-gui/res/cardsfolder/d/dog_umbra.txt
+++ b/forge-gui/res/cardsfolder/d/dog_umbra.txt
@@ -3,6 +3,7 @@ ManaCost:1 W
 Types:Enchantment Aura
 K:Flash
 K:Enchant:Creature
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy+ControlledBy Player.Other | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ As long as another player controls enchanted creature, it can't attack or block. Otherwise, CARDNAME has umbra armor. (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy+ControlledBy Player.Other | Description$ As long as another player controls enchanted creature, it can't attack or block. Otherwise, CARDNAME has umbra armor. (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy+ControlledBy Player.Other | Secondary$ True | Description$ As long as another player controls enchanted creature, it can't attack or block. Otherwise, CARDNAME has umbra armor. (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)
 S:Mode$ Continuous | Affected$ Card.Self | IsPresent$ Creature.YouCtrl+EnchantedBy | AddKeyword$ Umbra armor | Secondary$ True | Description$ As long as another player controls enchanted creature, it can't attack or block. Otherwise, CARDNAME has umbra armor. (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)
 Oracle:Flash\nEnchant creature\nAs long as another player controls enchanted creature, it can't attack or block. Otherwise, Dog Umbra has umbra armor. (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)

--- a/forge-gui/res/cardsfolder/d/doomed_artisan.txt
+++ b/forge-gui/res/cardsfolder/d/doomed_artisan.txt
@@ -2,8 +2,7 @@ Name:Doomed Artisan
 ManaCost:2 W
 Types:Creature Human Artificer
 PT:1/1
-S:Mode$ CantAttack | ValidCard$ Sculpture.YouCtrl | Description$ Sculptures you control can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Sculpture.YouCtrl | Secondary$ True | Description$ Sculptures you control can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Sculpture.YouCtrl | Description$ Sculptures you control can't attack or block.
 AI:RemoveDeck:Random
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ At the beginning of your end step, create a colorless Sculpture artifact creature token with "This creature's power and toughness are each equal to the number of Sculptures you control."
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ c_x_x_a_sculpture_total_sculptures | TokenOwner$ You

--- a/forge-gui/res/cardsfolder/d/doomed_artisan.txt
+++ b/forge-gui/res/cardsfolder/d/doomed_artisan.txt
@@ -2,7 +2,8 @@ Name:Doomed Artisan
 ManaCost:2 W
 Types:Creature Human Artificer
 PT:1/1
-S:Mode$ Continuous | Affected$ Sculpture.YouCtrl | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Sculptures you control can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Sculpture.YouCtrl | Description$ Sculptures you control can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Sculpture.YouCtrl | Secondary$ True | Description$ Sculptures you control can't attack or block.
 AI:RemoveDeck:Random
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ At the beginning of your end step, create a colorless Sculpture artifact creature token with "This creature's power and toughness are each equal to the number of Sculptures you control."
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ c_x_x_a_sculpture_total_sculptures | TokenOwner$ You

--- a/forge-gui/res/cardsfolder/d/dovin_baan.txt
+++ b/forge-gui/res/cardsfolder/d/dovin_baan.txt
@@ -2,7 +2,9 @@ Name:Dovin Baan
 ManaCost:2 W U
 Types:Legendary Planeswalker Dovin
 Loyalty:3
-A:AB$ Pump | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | NumAtt$ -3 | IsCurse$ True | Duration$ UntilYourNextTurn | TargetMin$ 0 | TargetMax$ 1 | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ HIDDEN CARDNAME's activated abilities can't be activated. | SpellDescription$ Until your next turn, up to one target creature gets -3/-0 and its activated abilities can't be activated.
+A:AB$ Pump | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | NumAtt$ -3 | IsCurse$ True | Duration$ UntilYourNextTurn | TargetMin$ 0 | TargetMax$ 1 | ValidTgts$ Creature | TgtPrompt$ Select target creature | SubAbility$ DBEffect | SpellDescription$ Until your next turn, up to one target creature gets -3/-0 and its activated abilities can't be activated.
+SVar:DBEffect:DB$ Effect | RememberObjects$ ParentTarget | StaticAbilities$ DBCantBeActivated | ForgetOnMoved$ Battlefield | IsCurse$ True | Duration$ UntilYourNextTurn
+SVar:DBCantBeActivated:Mode$ CantBeActivated | ValidCard$ Card.IsRemembered | Description$ Remembered activated abilities can't be activated.
 A:AB$ GainLife | Cost$ SubCounter<1/LOYALTY> | Planeswalker$ True | Defined$ You | LifeAmount$ 2 | SubAbility$ DBDraw | SpellDescription$ You gain 2 life and draw a card.
 SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1
 A:AB$ Effect | Cost$ SubCounter<7/LOYALTY> | Name$ Emblem — Dovin Baan | Image$ Emblem_dovin_baan | StaticAbilities$ STDovin | Planeswalker$ True | Ultimate$ True | Stackable$ False | Duration$ Permanent | AILogic$ Always | SpellDescription$ You get an emblem with "Your opponents can't untap more than two permanents during their untap steps."

--- a/forge-gui/res/cardsfolder/d/dreadful_apathy.txt
+++ b/forge-gui/res/cardsfolder/d/dreadful_apathy.txt
@@ -3,8 +3,7 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
 A:AB$ ChangeZone | Cost$ 2 W | Defined$ Enchanted | Origin$ Battlefield | Destination$ Exile | SpellDescription$ Exile enchanted creature.
 SVar:NonStackingAttachEffect:True
 Oracle:Enchant creature\nEnchanted creature can't attack or block.\n{2}{W}: Exile enchanted creature.

--- a/forge-gui/res/cardsfolder/d/dreadful_apathy.txt
+++ b/forge-gui/res/cardsfolder/d/dreadful_apathy.txt
@@ -3,7 +3,8 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
 A:AB$ ChangeZone | Cost$ 2 W | Defined$ Enchanted | Origin$ Battlefield | Destination$ Exile | SpellDescription$ Exile enchanted creature.
 SVar:NonStackingAttachEffect:True
 Oracle:Enchant creature\nEnchanted creature can't attack or block.\n{2}{W}: Exile enchanted creature.

--- a/forge-gui/res/cardsfolder/e/edifice_of_authority.txt
+++ b/forge-gui/res/cardsfolder/e/edifice_of_authority.txt
@@ -3,6 +3,9 @@ ManaCost:3
 Types:Artifact
 A:AB$ Pump | Cost$ 1 T | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ HIDDEN CARDNAME can't attack. | SubAbility$ DBPutCounter | IsCurse$ True | SpellDescription$ Target creature can't attack this turn. Put a brick counter on CARDNAME.
 SVar:DBPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ BRICK | CounterNum$ 1
-A:AB$ Pump | Cost$ 1 T | ValidTgts$ Creature | TgtPrompt$ Select target creature | Duration$ UntilYourNextTurn | KW$ HIDDEN CARDNAME can't attack or block. & HIDDEN CARDNAME's activated abilities can't be activated. | CheckSVar$ X | SVarCompare$ GE3 | IsCurse$ True | SpellDescription$ Until your next turn, target creature can't attack or block and its activated abilities can't be activated. Activate only if there are three or more brick counters on CARDNAME.
+A:AB$ Effect | Cost$ 1 T | ValidTgts$ Creature | TgtPrompt$ Select target creature | RememberObjects$ Targeted | StaticAbilities$ DBCantAttack,DBCantBlockBy,DBCantBeActivated | ForgetOnMoved$ Battlefield | IsCurse$ True | Duration$ UntilYourNextTurn | CheckSVar$ X | SVarCompare$ GE3 | SpellDescription$ Until your next turn, target creature can't attack or block and its activated abilities can't be activated. Activate only if there are three or more brick counters on CARDNAME.
+SVar:DBCantAttack:Mode$ CantAttack | ValidCard$ Card.IsRemembered | Description$ Remembered can't attack or block.
+SVar:DBCantBlockBy:Mode$ CantBlockBy | ValidBlocker$ Card.IsRemembered | Secondary$ True | Description$ Remembered can't attack or block.
+SVar:DBCantBeActivated:Mode$ CantBeActivated | ValidCard$ Card.IsRemembered | Description$ Remembered activated abilities can't be activated.
 SVar:X:Count$CardCounters.BRICK
 Oracle:{1}, {T}: Target creature can't attack this turn. Put a brick counter on Edifice of Authority.\n{1}, {T}: Until your next turn, target creature can't attack or block and its activated abilities can't be activated. Activate only if there are three or more brick counters on Edifice of Authority.

--- a/forge-gui/res/cardsfolder/e/ethrimik_imagined_fiend.txt
+++ b/forge-gui/res/cardsfolder/e/ethrimik_imagined_fiend.txt
@@ -5,6 +5,5 @@ PT:5/5
 T:Mode$ ChangesZone | ValidCard$ Card.Self | Destination$ Battlefield | Origin$ Any | Execute$ TrigManifest | TriggerDescription$ When NICKNAME enters, manifest dread.
 SVar:TrigManifest:DB$ ManifestDread
 S:Mode$ Continuous | Affected$ Creature.Other+YouCtrl | AddPower$ 1 | AddToughness$ 1 | Description$ Other creatures you control get +1/+1.
-S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Creature.Other+YouCtrl | Description$ As long as you control another creature, NICKNAME can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Card.Self | IsPresent$ Creature.Other+YouCtrl | Secondary$ True | Description$ As long as you control another creature, NICKNAME can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Card.Self | IsPresent$ Creature.Other+YouCtrl | Description$ As long as you control another creature, NICKNAME can't attack or block.
 Oracle:When Ethrimik enters, manifest dread.\nOther creatures you control get +1/+1.\nAs long as you control another creature, Ethrimik can't attack or block.

--- a/forge-gui/res/cardsfolder/e/ethrimik_imagined_fiend.txt
+++ b/forge-gui/res/cardsfolder/e/ethrimik_imagined_fiend.txt
@@ -5,5 +5,6 @@ PT:5/5
 T:Mode$ ChangesZone | ValidCard$ Card.Self | Destination$ Battlefield | Origin$ Any | Execute$ TrigManifest | TriggerDescription$ When NICKNAME enters, manifest dread.
 SVar:TrigManifest:DB$ ManifestDread
 S:Mode$ Continuous | Affected$ Creature.Other+YouCtrl | AddPower$ 1 | AddToughness$ 1 | Description$ Other creatures you control get +1/+1.
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack or block. | IsPresent$ Creature.Other+YouCtrl | PresentCompare$ GE1 | Description$ As long as you control another creature, NICKNAME can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Creature.Other+YouCtrl | Description$ As long as you control another creature, NICKNAME can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Card.Self | IsPresent$ Creature.Other+YouCtrl | Secondary$ True | Description$ As long as you control another creature, NICKNAME can't attack or block.
 Oracle:When Ethrimik enters, manifest dread.\nOther creatures you control get +1/+1.\nAs long as you control another creature, Ethrimik can't attack or block.

--- a/forge-gui/res/cardsfolder/f/faiths_fetters.txt
+++ b/forge-gui/res/cardsfolder/f/faiths_fetters.txt
@@ -6,8 +6,6 @@ SVar:AttachAITgts:Creature
 SVar:AttachAILogic:Curse
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigGainLife | TriggerDescription$ When CARDNAME enters, you gain 4 life.
 SVar:TrigGainLife:DB$ GainLife | LifeAmount$ 4
-S:Mode$ CantAttack | ValidCard$ Card.EnchantedBy | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.
-S:Mode$ CantBlock | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.
-S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated.nonManaAbility | Secondary$ True | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.
+S:Mode$ CantAttack,CantBlock,CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated.nonManaAbility | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.
 DeckHas:Ability$LifeGain
 Oracle:Enchant permanent\nWhen Faith's Fetters enters, you gain 4 life.\nEnchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.

--- a/forge-gui/res/cardsfolder/f/faiths_fetters.txt
+++ b/forge-gui/res/cardsfolder/f/faiths_fetters.txt
@@ -6,7 +6,8 @@ SVar:AttachAITgts:Creature
 SVar:AttachAILogic:Curse
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigGainLife | TriggerDescription$ When CARDNAME enters, you gain 4 life.
 SVar:TrigGainLife:DB$ GainLife | LifeAmount$ 4
-S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated.nonManaAbility | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Card.EnchantedBy | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.
+S:Mode$ CantBlock | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.
+S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated.nonManaAbility | Secondary$ True | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.
 DeckHas:Ability$LifeGain
 Oracle:Enchant permanent\nWhen Faith's Fetters enters, you gain 4 life.\nEnchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.

--- a/forge-gui/res/cardsfolder/f/felhide_brawler.txt
+++ b/forge-gui/res/cardsfolder/f/felhide_brawler.txt
@@ -2,5 +2,5 @@ Name:Felhide Brawler
 ManaCost:1 B
 Types:Creature Minotaur
 PT:2/2
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't block. | IsPresent$ Minotaur.Other+YouCtrl | PresentCompare$ EQ0 | Description$ CARDNAME can't block unless you control another Minotaur.
+S:Mode$ CantBlock | ValidCard$ Card.Self | IsPresent$ Minotaur.Other+YouCtrl | PresentCompare$ EQ0 | Description$ CARDNAME can't block unless you control another Minotaur.
 Oracle:Felhide Brawler can't block unless you control another Minotaur.

--- a/forge-gui/res/cardsfolder/f/flowering_lumberknot.txt
+++ b/forge-gui/res/cardsfolder/f/flowering_lumberknot.txt
@@ -2,7 +2,6 @@ Name:Flowering Lumberknot
 ManaCost:3 G
 Types:Creature Treefolk
 PT:5/5
-S:Mode$ CantAttack | ValidCard$ Creature.Self | IsPresent$ Creature.PairedWith+withSoulbond | PresentCompare$ EQ0 | Description$ CARDNAME can't attack or block unless it's paired with a creature with soulbond.
-S:Mode$ CantBlock | ValidCard$ Creature.Self | IsPresent$ Creature.PairedWith+withSoulbond | PresentCompare$ EQ0 | Secondary$ True | Description$ CARDNAME can't attack or block unless it's paired with a creature with soulbond.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.Self | IsPresent$ Creature.PairedWith+withSoulbond | PresentCompare$ EQ0 | Description$ CARDNAME can't attack or block unless it's paired with a creature with soulbond.
 AI:RemoveDeck:Random
 Oracle:Flowering Lumberknot can't attack or block unless it's paired with a creature with soulbond.

--- a/forge-gui/res/cardsfolder/f/flowering_lumberknot.txt
+++ b/forge-gui/res/cardsfolder/f/flowering_lumberknot.txt
@@ -2,6 +2,7 @@ Name:Flowering Lumberknot
 ManaCost:3 G
 Types:Creature Treefolk
 PT:5/5
-S:Mode$ Continuous | Affected$ Creature.Self | IsPresent$ Creature.PairedWith+withSoulbond | PresentCompare$ EQ0 | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ CARDNAME can't attack or block unless it's paired with a creature with soulbond.
+S:Mode$ CantAttack | ValidCard$ Creature.Self | IsPresent$ Creature.PairedWith+withSoulbond | PresentCompare$ EQ0 | Description$ CARDNAME can't attack or block unless it's paired with a creature with soulbond.
+S:Mode$ CantBlock | ValidCard$ Creature.Self | IsPresent$ Creature.PairedWith+withSoulbond | PresentCompare$ EQ0 | Secondary$ True | Description$ CARDNAME can't attack or block unless it's paired with a creature with soulbond.
 AI:RemoveDeck:Random
 Oracle:Flowering Lumberknot can't attack or block unless it's paired with a creature with soulbond.

--- a/forge-gui/res/cardsfolder/f/fog_on_the_barrow_downs.txt
+++ b/forge-gui/res/cardsfolder/f/fog_on_the_barrow_downs.txt
@@ -3,5 +3,7 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | AddType$ Spirit | RemoveCreatureTypes$ True | Description$ Enchanted creature is a Spirit and can't attack or block. (It loses all other creature types.)
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature is a Spirit and can't attack or block. (It loses all other creature types.)
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature is a Spirit and can't attack or block. (It loses all other creature types.)
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddType$ Spirit | RemoveCreatureTypes$ True | Secondary$ True | Description$ Enchanted creature is a Spirit and can't attack or block. (It loses all other creature types.)
 Oracle:Enchant creature\nEnchanted creature is a Spirit and can't attack or block. (It loses all other creature types.)

--- a/forge-gui/res/cardsfolder/f/fog_on_the_barrow_downs.txt
+++ b/forge-gui/res/cardsfolder/f/fog_on_the_barrow_downs.txt
@@ -3,7 +3,6 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature is a Spirit and can't attack or block. (It loses all other creature types.)
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature is a Spirit and can't attack or block. (It loses all other creature types.)
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature is a Spirit and can't attack or block. (It loses all other creature types.)
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddType$ Spirit | RemoveCreatureTypes$ True | Secondary$ True | Description$ Enchanted creature is a Spirit and can't attack or block. (It loses all other creature types.)
 Oracle:Enchant creature\nEnchanted creature is a Spirit and can't attack or block. (It loses all other creature types.)

--- a/forge-gui/res/cardsfolder/f/forced_worship.txt
+++ b/forge-gui/res/cardsfolder/f/forced_worship.txt
@@ -3,6 +3,6 @@ ManaCost:1 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack. | Description$ Enchanted creature can't attack.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack.
 A:AB$ ChangeZone | Cost$ 2 W | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return CARDNAME to its owner's hand.
 Oracle:Enchant creature\nEnchanted creature can't attack.\n{2}{W}: Return Forced Worship to its owner's hand.

--- a/forge-gui/res/cardsfolder/f/frenetic_raptor.txt
+++ b/forge-gui/res/cardsfolder/f/frenetic_raptor.txt
@@ -2,5 +2,5 @@ Name:Frenetic Raptor
 ManaCost:5 R
 Types:Creature Dinosaur Beast
 PT:6/6
-S:Mode$ Continuous | Affected$ Creature.Beast | AddHiddenKeyword$ CARDNAME can't block. | Description$ Beasts can't block.
+S:Mode$ CantBlock | ValidCard$ Creature.Beast | Description$ Beasts can't block.
 Oracle:Beasts can't block.

--- a/forge-gui/res/cardsfolder/g/gadrak_the_crown_scourge.txt
+++ b/forge-gui/res/cardsfolder/g/gadrak_the_crown_scourge.txt
@@ -3,7 +3,7 @@ ManaCost:2 R
 Types:Legendary Creature Dragon
 PT:5/4
 K:Flying
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack. | IsPresent$ Artifact.YouCtrl | PresentCompare$ LE3 | Description$ CARDNAME can't attack unless you control four or more artifacts.
+S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Artifact.YouCtrl | PresentCompare$ LE3 | Description$ CARDNAME can't attack unless you control four or more artifacts.
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ At the beginning of your end step, create a Treasure token for each nontoken creature that died this turn.
 SVar:TrigToken:DB$ Token | TokenAmount$ Y | TokenScript$ c_a_treasure_sac | TokenOwner$ You
 SVar:Y:Count$ThisTurnEntered_Graveyard_from_Battlefield_Creature.!token

--- a/forge-gui/res/cardsfolder/g/gelid_shackles.txt
+++ b/forge-gui/res/cardsfolder/g/gelid_shackles.txt
@@ -3,7 +3,8 @@ ManaCost:W
 Types:Snow Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't block. & CARDNAME's activated abilities can't be activated. | Description$ Enchanted creature can't block and its activated abilities can't be activated.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't block, and its activated abilities can't be activated.
+S:Mode$ CantBeActivated | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't block, and its activated abilities can't be activated.
 A:AB$ Pump | Cost$ S | Defined$ Enchanted | KW$ Defender | IsCurse$ True | SpellDescription$ Enchanted creature gains defender until end of turn.
 # AI can now use snow mana to pay for activated abilities.
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/g/giant_turtle.txt
+++ b/forge-gui/res/cardsfolder/g/giant_turtle.txt
@@ -2,5 +2,5 @@ Name:Giant Turtle
 ManaCost:1 G G
 Types:Creature Turtle
 PT:2/4
-S:Mode$ Continuous | Affected$ Card.Self+attackedLastTurn | AddHiddenKeyword$ CARDNAME can't attack. | Description$ CARDNAME can't attack if it attacked during your last turn.
+S:Mode$ CantAttack | ValidCard$ Card.Self+attackedLastTurn | Description$ CARDNAME can't attack if it attacked during your last turn.
 Oracle:Giant Turtle can't attack if it attacked during your last turn.

--- a/forge-gui/res/cardsfolder/g/glacial_crasher.txt
+++ b/forge-gui/res/cardsfolder/g/glacial_crasher.txt
@@ -3,7 +3,7 @@ ManaCost:4 U U
 Types:Creature Elemental
 PT:5/5
 K:Trample
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack. | IsPresent$ Mountain | PresentCompare$ EQ0 | Description$ CARDNAME can't attack unless there is a Mountain on the battlefield.
+S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Mountain | PresentCompare$ EQ0 | Description$ CARDNAME can't attack unless there is a Mountain on the battlefield.
 SVar:BuffedBy:Mountain
 AI:RemoveDeck:Random
 DeckNeeds:Color$Red

--- a/forge-gui/res/cardsfolder/g/goblin_cohort.txt
+++ b/forge-gui/res/cardsfolder/g/goblin_cohort.txt
@@ -2,7 +2,7 @@ Name:Goblin Cohort
 ManaCost:R
 Types:Creature Goblin Warrior
 PT:2/2
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack. | CheckSVar$ X | SVarCompare$ EQ0 | Description$ CARDNAME can't attack unless you've cast a creature spell this turn.
+S:Mode$ CantAttack | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ EQ0 | Description$ CARDNAME can't attack unless you've cast a creature spell this turn.
 SVar:X:Count$ThisTurnCast_Creature.YouCtrl
 SVar:BuffedBy:Creature
 Oracle:Goblin Cohort can't attack unless you've cast a creature spell this turn.

--- a/forge-gui/res/cardsfolder/g/goblin_goon.txt
+++ b/forge-gui/res/cardsfolder/g/goblin_goon.txt
@@ -3,7 +3,7 @@ ManaCost:3 R
 Types:Creature Goblin Mutant
 PT:6/6
 S:Mode$ CantAttack | ValidCard$ Card.Self | UnlessDefender$ hasFewerCreaturesInPlayThanYou | Description$ CARDNAME can't attack unless you control more creatures than defending player.
-S:Mode$ Continuous | Affected$ Card.Self | Condition$ NotPlayerTurn | AddHiddenKeyword$ CARDNAME can't block. | CheckSVar$ Y | SVarCompare$ GEX | Description$ CARDNAME can't block unless you control more creatures than attacking player.
+S:Mode$ CantBlock | ValidCard$ Card.Self | Condition$ NotPlayerTurn | CheckSVar$ Y | SVarCompare$ GEX | Description$ CARDNAME can't block unless you control more creatures than attacking player.
 SVar:X:Count$Valid Creature.YouCtrl
 SVar:Y:Count$Valid Creature.ActivePlayerCtrl
 SVar:BuffedBy:Creature

--- a/forge-gui/res/cardsfolder/g/gwafa_hazid_profiteer.txt
+++ b/forge-gui/res/cardsfolder/g/gwafa_hazid_profiteer.txt
@@ -4,6 +4,5 @@ Types:Legendary Creature Human Rogue
 PT:2/2
 A:AB$ PutCounter | Cost$ W U T | ValidTgts$ Creature.YouDontCtrl | TgtPrompt$ Select target creature you don't control. | CounterType$ BRIBERY | CounterNum$ 1 | SubAbility$ DBDraw | SpellDescription$ Put a bribery counter on target creature you don't control. Its controller draws a card.
 SVar:DBDraw:DB$ Draw | Defined$ TargetedController | NumCards$ 1
-S:Mode$ CantAttack | ValidCard$ Creature.counters_GE1_BRIBERY | Description$ Creatures with bribery counters on them can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.counters_GE1_BRIBERY | Secondary$ True | Description$ Creatures with bribery counters on them can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.counters_GE1_BRIBERY | Description$ Creatures with bribery counters on them can't attack or block.
 Oracle:{W}{U}, {T}: Put a bribery counter on target creature you don't control. Its controller draws a card.\nCreatures with bribery counters on them can't attack or block.

--- a/forge-gui/res/cardsfolder/g/gwafa_hazid_profiteer.txt
+++ b/forge-gui/res/cardsfolder/g/gwafa_hazid_profiteer.txt
@@ -2,7 +2,8 @@ Name:Gwafa Hazid, Profiteer
 ManaCost:1 W U
 Types:Legendary Creature Human Rogue
 PT:2/2
-S:Mode$ Continuous | Affected$ Creature.counters_GE1_BRIBERY | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Creatures with bribery counters on them can't attack or block.
 A:AB$ PutCounter | Cost$ W U T | ValidTgts$ Creature.YouDontCtrl | TgtPrompt$ Select target creature you don't control. | CounterType$ BRIBERY | CounterNum$ 1 | SubAbility$ DBDraw | SpellDescription$ Put a bribery counter on target creature you don't control. Its controller draws a card.
 SVar:DBDraw:DB$ Draw | Defined$ TargetedController | NumCards$ 1
+S:Mode$ CantAttack | ValidCard$ Creature.counters_GE1_BRIBERY | Description$ Creatures with bribery counters on them can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.counters_GE1_BRIBERY | Secondary$ True | Description$ Creatures with bribery counters on them can't attack or block.
 Oracle:{W}{U}, {T}: Put a bribery counter on target creature you don't control. Its controller draws a card.\nCreatures with bribery counters on them can't attack or block.

--- a/forge-gui/res/cardsfolder/h/harbor_serpent.txt
+++ b/forge-gui/res/cardsfolder/h/harbor_serpent.txt
@@ -3,6 +3,6 @@ ManaCost:4 U U
 Types:Creature Serpent
 PT:5/5
 K:Landwalk:Island
-S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ CARDNAME can't attack. | IsPresent$ Island | PresentCompare$ LT5 | Description$ CARDNAME can't attack unless there are five or more Islands on the battlefield.
+S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Island | PresentCompare$ LT5 | Description$ CARDNAME can't attack unless there are five or more Islands on the battlefield.
 SVar:BuffedBy:Island
 Oracle:Islandwalk (This creature can't be blocked as long as defending player controls an Island.)\nHarbor Serpent can't attack unless there are five or more Islands on the battlefield.

--- a/forge-gui/res/cardsfolder/h/hazoret_godseeker.txt
+++ b/forge-gui/res/cardsfolder/h/hazoret_godseeker.txt
@@ -7,6 +7,5 @@ K:Haste
 K:Start your engines
 A:AB$ Effect | Cost$ 1 T | ValidTgts$ Creature.powerLE2 | TgtPrompt$ Select target creature with power 2 or less | RememberObjects$ Targeted | ExileOnMoved$ Battlefield | StaticAbilities$ Unblockable | AILogic$ Pump | StackDescription$ {c:Targeted} can't be blocked this turn. | SpellDescription$ Target creature with power 2 or less can't be blocked this turn.
 SVar:Unblockable:Mode$ CantBlockBy | ValidAttacker$ Card.IsRemembered | Description$ This creature can't be blocked this turn.
-S:Mode$ CantAttack | ValidCard$ Card.Self | CheckSVar$ PlayerCountPropertyYou$HasPropertyMaxSpeed | SVarCompare$ NE1 | Description$ NICKNAME can't attack or block unless you have max speed.
-S:Mode$ CantBlock | ValidCard$ Card.Self | CheckSVar$ PlayerCountPropertyYou$HasPropertyMaxSpeed | SVarCompare$ NE1 | Secondary$ True | Description$ NICKNAME can't attack or block unless you have max speed.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Card.Self | CheckSVar$ PlayerCountPropertyYou$HasPropertyMaxSpeed | SVarCompare$ NE1 | Description$ NICKNAME can't attack or block unless you have max speed.
 Oracle:Indestructible, haste\nStart your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{1}, {T}: Target creature with power 2 or less can't be blocked this turn.\nHazoret can't attack or block unless you have max speed.

--- a/forge-gui/res/cardsfolder/h/hazoret_godseeker.txt
+++ b/forge-gui/res/cardsfolder/h/hazoret_godseeker.txt
@@ -7,5 +7,6 @@ K:Haste
 K:Start your engines
 A:AB$ Effect | Cost$ 1 T | ValidTgts$ Creature.powerLE2 | TgtPrompt$ Select target creature with power 2 or less | RememberObjects$ Targeted | ExileOnMoved$ Battlefield | StaticAbilities$ Unblockable | AILogic$ Pump | StackDescription$ {c:Targeted} can't be blocked this turn. | SpellDescription$ Target creature with power 2 or less can't be blocked this turn.
 SVar:Unblockable:Mode$ CantBlockBy | ValidAttacker$ Card.IsRemembered | Description$ This creature can't be blocked this turn.
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack or block. | CheckSVar$ PlayerCountPropertyYou$HasPropertyMaxSpeed | SVarCompare$ NE1 | Description$ NICKNAME can't attack or block unless you have max speed.
+S:Mode$ CantAttack | ValidCard$ Card.Self | CheckSVar$ PlayerCountPropertyYou$HasPropertyMaxSpeed | SVarCompare$ NE1 | Description$ NICKNAME can't attack or block unless you have max speed.
+S:Mode$ CantBlock | ValidCard$ Card.Self | CheckSVar$ PlayerCountPropertyYou$HasPropertyMaxSpeed | SVarCompare$ NE1 | Secondary$ True | Description$ NICKNAME can't attack or block unless you have max speed.
 Oracle:Indestructible, haste\nStart your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{1}, {T}: Target creature with power 2 or less can't be blocked this turn.\nHazoret can't attack or block unless you have max speed.

--- a/forge-gui/res/cardsfolder/h/hazoret_the_fervent.txt
+++ b/forge-gui/res/cardsfolder/h/hazoret_the_fervent.txt
@@ -4,8 +4,7 @@ Types:Legendary Creature God
 PT:5/4
 K:Indestructible
 K:Haste
-S:Mode$ CantAttack | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ GE2 | Description$ NICKNAME can't attack or block unless you have one or fewer cards in hand.
-S:Mode$ CantBlock | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ GE2 | Secondary$ True | Description$ NICKNAME can't attack or block unless you have one or fewer cards in hand.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ GE2 | Description$ NICKNAME can't attack or block unless you have one or fewer cards in hand.
 SVar:X:Count$ValidHand Card.YouOwn
 A:AB$ DealDamage | Cost$ 2 R Discard<1/Card> | NumDmg$ 2 | Defined$ Player.Opponent | SpellDescription$ CARDNAME deals 2 damage to each opponent.
 Oracle:Indestructible, haste\nHazoret the Fervent can't attack or block unless you have one or fewer cards in hand.\n{2}{R}, Discard a card: Hazoret deals 2 damage to each opponent.

--- a/forge-gui/res/cardsfolder/h/hazoret_the_fervent.txt
+++ b/forge-gui/res/cardsfolder/h/hazoret_the_fervent.txt
@@ -4,7 +4,8 @@ Types:Legendary Creature God
 PT:5/4
 K:Indestructible
 K:Haste
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack or block. | CheckSVar$ X | SVarCompare$ GE2 | Description$ CARDNAME can't attack or block unless you have one or fewer cards in hand.
+S:Mode$ CantAttack | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ GE2 | Description$ NICKNAME can't attack or block unless you have one or fewer cards in hand.
+S:Mode$ CantBlock | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ GE2 | Secondary$ True | Description$ NICKNAME can't attack or block unless you have one or fewer cards in hand.
 SVar:X:Count$ValidHand Card.YouOwn
 A:AB$ DealDamage | Cost$ 2 R Discard<1/Card> | NumDmg$ 2 | Defined$ Player.Opponent | SpellDescription$ CARDNAME deals 2 damage to each opponent.
 Oracle:Indestructible, haste\nHazoret the Fervent can't attack or block unless you have one or fewer cards in hand.\n{2}{R}, Discard a card: Hazoret deals 2 damage to each opponent.

--- a/forge-gui/res/cardsfolder/h/hedron_fields_of_agadeem.txt
+++ b/forge-gui/res/cardsfolder/h/hedron_fields_of_agadeem.txt
@@ -1,7 +1,8 @@
 Name:Hedron Fields of Agadeem
 ManaCost:no cost
 Types:Plane Zendikar
-S:Mode$ Continuous | EffectZone$ Command | Affected$ Creature.powerGE7 | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Creatures with power 7 or greater can't attack or block.
+S:Mode$ CantAttack | EffectZone$ Command | ValidCard$ Creature.powerGE7 | Description$ Creatures with power 7 or greater can't attack or block.
+S:Mode$ CantBlockBy | EffectZone$ Command | ValidBlocker$ Creature.powerGE7 | Secondary$ True | Description$ Creatures with power 7 or greater can't attack or block.
 T:Mode$ ChaosEnsues | TriggerZones$ Command | Execute$ RolledChaos | TriggerDescription$ Whenever chaos ensues, create a 7/7 colorless Eldrazi creature token with annihilator 1. (Whenever it attacks, defending player sacrifices a permanent.)
 SVar:RolledChaos:DB$ Token | TokenScript$ c_7_7_eldrazi_annihilator
 SVar:AIRollPlanarDieParams:Mode$ Always | LowPriority$ True | MaxRollsPerTurn$ 9

--- a/forge-gui/res/cardsfolder/h/heliods_punishment.txt
+++ b/forge-gui/res/cardsfolder/h/heliods_punishment.txt
@@ -4,7 +4,9 @@ Types:Enchantment Aura
 K:Enchant:Creature
 K:etbCounter:TASK:4
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | RemoveAllAbilities$ True | AddAbility$ ABRemoveCounter | AddSVar$ DBHeliodsPunishment | Description$ Enchanted creature can't attack or block. It loses all abilities and has "{T}: Remove a task counter from CARDNAME. Then if it has no task counters on it, destroy CARDNAME."
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | RemoveAllAbilities$ True | AddAbility$ ABRemoveCounter | AddSVar$ DBHeliodsPunishment | Description$ It loses all abilities and has "{T}: Remove a task counter from CARDNAME. Then if it has no task counters on it, destroy CARDNAME."
 SVar:ABRemoveCounter:AB$ RemoveCounter | Cost$ T | CounterType$ TASK | CounterNum$ 1 | AILogic$ Always | Defined$ OriginalHost | StackDescription$ Remove a task counter from {c:OriginalHost}. Then if it has no task counters on it, destroy {c:OriginalHost}. | SpellDescription$ Remove a task counter from ORIGINALHOST. Then if it has no task counters on it, destroy ORIGINALHOST. | SubAbility$ DBHeliodsPunishment
 SVar:DBHeliodsPunishment:DB$ Destroy | Defined$ OriginalHost | ConditionDefined$ OriginalHost | ConditionPresent$ Card.counters_EQ0_TASK | StackDescription$ None
 DeckHas:Ability$Counters

--- a/forge-gui/res/cardsfolder/h/heliods_punishment.txt
+++ b/forge-gui/res/cardsfolder/h/heliods_punishment.txt
@@ -4,8 +4,7 @@ Types:Enchantment Aura
 K:Enchant:Creature
 K:etbCounter:TASK:4
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | RemoveAllAbilities$ True | AddAbility$ ABRemoveCounter | AddSVar$ DBHeliodsPunishment | Description$ It loses all abilities and has "{T}: Remove a task counter from CARDNAME. Then if it has no task counters on it, destroy CARDNAME."
 SVar:ABRemoveCounter:AB$ RemoveCounter | Cost$ T | CounterType$ TASK | CounterNum$ 1 | AILogic$ Always | Defined$ OriginalHost | StackDescription$ Remove a task counter from {c:OriginalHost}. Then if it has no task counters on it, destroy {c:OriginalHost}. | SpellDescription$ Remove a task counter from ORIGINALHOST. Then if it has no task counters on it, destroy ORIGINALHOST. | SubAbility$ DBHeliodsPunishment
 SVar:DBHeliodsPunishment:DB$ Destroy | Defined$ OriginalHost | ConditionDefined$ OriginalHost | ConditionPresent$ Card.counters_EQ0_TASK | StackDescription$ None

--- a/forge-gui/res/cardsfolder/h/hobble.txt
+++ b/forge-gui/res/cardsfolder/h/hobble.txt
@@ -3,8 +3,8 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack. | Description$ Enchanted creature can't attack.
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy+Black | AddHiddenKeyword$ CARDNAME can't block. | Description$ Enchanted creature can't block if it's black.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ When CARDNAME enters, draw a card.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy+Black | Description$ Enchanted creature can't block if it's black.
 Oracle:Enchant creature\nWhen Hobble enters, draw a card.\nEnchanted creature can't attack.\nEnchanted creature can't block if it's black.

--- a/forge-gui/res/cardsfolder/h/hold_for_ransom.txt
+++ b/forge-gui/res/cardsfolder/h/hold_for_ransom.txt
@@ -3,7 +3,9 @@ ManaCost:1 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | AddAbility$ PayRansom | Description$ Enchanted creature can't attack or block and has "{7}: CARDNAME's controller sacrifices it and draws a card. Activate only as a sorcery."
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and has "{7}: CARDNAME's controller sacrifices it and draws a card. Activate only as a sorcery."
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and has "{7}: CARDNAME's controller sacrifices it and draws a card. Activate only as a sorcery."
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddAbility$ PayRansom | Secondary$ True | Description$ Enchanted creature can't attack or block and has "{7}: CARDNAME's controller sacrifices it and draws a card. Activate only as a sorcery."
 SVar:PayRansom:AB$ SacrificeAll | Cost$ 7 | Defined$ OriginalHost | Controller$ OriginalHostController | SubAbility$ DBDraw | SorcerySpeed$ True | AILogic$ Always | SpellDescription$ ORIGINALHOST's controller sacrifices it and draws a card. Activate only as a sorcery.
 SVar:DBDraw:DB$ Draw | Defined$ OriginalHostController
 Oracle:Enchant creature\nEnchanted creature can't attack or block and has "{7}: Hold for Ransom's controller sacrifices it and draws a card. Activate only as a sorcery."

--- a/forge-gui/res/cardsfolder/h/hold_for_ransom.txt
+++ b/forge-gui/res/cardsfolder/h/hold_for_ransom.txt
@@ -3,8 +3,7 @@ ManaCost:1 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and has "{7}: CARDNAME's controller sacrifices it and draws a card. Activate only as a sorcery."
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and has "{7}: CARDNAME's controller sacrifices it and draws a card. Activate only as a sorcery."
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and has "{7}: CARDNAME's controller sacrifices it and draws a card. Activate only as a sorcery."
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddAbility$ PayRansom | Secondary$ True | Description$ Enchanted creature can't attack or block and has "{7}: CARDNAME's controller sacrifices it and draws a card. Activate only as a sorcery."
 SVar:PayRansom:AB$ SacrificeAll | Cost$ 7 | Defined$ OriginalHost | Controller$ OriginalHostController | SubAbility$ DBDraw | SorcerySpeed$ True | AILogic$ Always | SpellDescription$ ORIGINALHOST's controller sacrifices it and draws a card. Activate only as a sorcery.
 SVar:DBDraw:DB$ Draw | Defined$ OriginalHostController

--- a/forge-gui/res/cardsfolder/h/howlpack_wolf.txt
+++ b/forge-gui/res/cardsfolder/h/howlpack_wolf.txt
@@ -2,7 +2,7 @@ Name:Howlpack Wolf
 ManaCost:2 R
 Types:Creature Wolf
 PT:3/3
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't block. | IsPresent$ Wolf.Other+YouCtrl,Werewolf.Other+YouCtrl | PresentCompare$ EQ0 | Description$ CARDNAME can't block unless you control another Wolf or Werewolf.
+S:Mode$ CantBlock | ValidCard$ Card.Self | IsPresent$ Wolf.Other+YouCtrl,Werewolf.Other+YouCtrl | PresentCompare$ EQ0 | Description$ CARDNAME can't block unless you control another Wolf or Werewolf.
 SVar:BuffedBy:Wolf,Werewolf
 AI:RemoveDeck:Random
 DeckHints:Type$Wolf|Werewolf

--- a/forge-gui/res/cardsfolder/i/ice_cage.txt
+++ b/forge-gui/res/cardsfolder/i/ice_cage.txt
@@ -3,9 +3,7 @@ ManaCost:1 U
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBeActivated | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack,CantBlock,CantBeActivated | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
 T:Mode$ BecomesTarget | ValidTarget$ Card.AttachedBy | TriggerZones$ Battlefield | Execute$ TrigDestroy | TriggerDescription$ When enchanted creature becomes the target of a spell or ability, destroy CARDNAME.
 SVar:TrigDestroy:DB$ Destroy | Defined$ Self
 Oracle:Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.\nWhen enchanted creature becomes the target of a spell or ability, destroy Ice Cage.

--- a/forge-gui/res/cardsfolder/i/ice_cage.txt
+++ b/forge-gui/res/cardsfolder/i/ice_cage.txt
@@ -3,7 +3,9 @@ ManaCost:1 U
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. & CARDNAME's activated abilities can't be activated. | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBeActivated | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
 T:Mode$ BecomesTarget | ValidTarget$ Card.AttachedBy | TriggerZones$ Battlefield | Execute$ TrigDestroy | TriggerDescription$ When enchanted creature becomes the target of a spell or ability, destroy CARDNAME.
 SVar:TrigDestroy:DB$ Destroy | Defined$ Self
 Oracle:Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.\nWhen enchanted creature becomes the target of a spell or ability, destroy Ice Cage.

--- a/forge-gui/res/cardsfolder/i/intercessors_arrest.txt
+++ b/forge-gui/res/cardsfolder/i/intercessors_arrest.txt
@@ -3,8 +3,5 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Permanent
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Card.EnchantedBy | Description$ Enchanted permanent can't attack, block, or crew Vehicles. Its activated abilities can't be activated unless they're mana abilities.
-S:Mode$ CantBlock | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack, block, or crew Vehicles. Its activated abilities can't be activated unless they're mana abilities.
-S:Mode$ CantCrew | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack, block, or crew Vehicles. Its activated abilities can't be activated unless they're mana abilities.
-S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated.nonManaAbility | Secondary$ True | Description$ Enchanted permanent can't attack, block, or crew Vehicles. Its activated abilities can't be activated unless they're mana abilities.
+S:Mode$ CantAttack,CantBlock,CantCrew,CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated.nonManaAbility | Description$ Enchanted permanent can't attack, block, or crew Vehicles. Its activated abilities can't be activated unless they're mana abilities.
 Oracle:Enchant permanent\nEnchanted permanent can't attack, block, or crew Vehicles. Its activated abilities can't be activated unless they're mana abilities.

--- a/forge-gui/res/cardsfolder/i/intercessors_arrest.txt
+++ b/forge-gui/res/cardsfolder/i/intercessors_arrest.txt
@@ -3,7 +3,8 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Permanent
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Permanent.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Enchanted permanent can't attack, block, or crew Vehicles. Its activated abilities can't be activated unless they're mana abilities.
-S:Mode$ CantCrew | ValidCard$ Permanent.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't crew Vehicles.
-S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated.nonManaAbility
+S:Mode$ CantAttack | ValidCard$ Card.EnchantedBy | Description$ Enchanted permanent can't attack, block, or crew Vehicles. Its activated abilities can't be activated unless they're mana abilities.
+S:Mode$ CantBlock | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack, block, or crew Vehicles. Its activated abilities can't be activated unless they're mana abilities.
+S:Mode$ CantCrew | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack, block, or crew Vehicles. Its activated abilities can't be activated unless they're mana abilities.
+S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated.nonManaAbility | Secondary$ True | Description$ Enchanted permanent can't attack, block, or crew Vehicles. Its activated abilities can't be activated unless they're mana abilities.
 Oracle:Enchant permanent\nEnchanted permanent can't attack, block, or crew Vehicles. Its activated abilities can't be activated unless they're mana abilities.

--- a/forge-gui/res/cardsfolder/k/katabatic_winds.txt
+++ b/forge-gui/res/cardsfolder/k/katabatic_winds.txt
@@ -2,8 +2,6 @@ Name:Katabatic Winds
 ManaCost:2 G
 Types:Enchantment
 K:Phasing
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Creatures with flying can't attack or block, and their activated abilities with {T} in their costs can't be activated.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Creatures with flying can't attack or block, and their activated abilities with {T} in their costs can't be activated.
-S:Mode$ CantBeActivated | ValidCard$ Creature.withFlying | ValidSA$ Activated.hasTapCost | AffectedZone$ Battlefield | Secondary$ True | Description$ Creatures with flying can't attack or block, and their activated abilities with {T} in their costs can't be activated.
+S:Mode$ CantAttack,CantBlock,CantBeActivated | ValidCard$ Creature.withFlying | ValidSA$ Activated.hasTapCost | AffectedZone$ Battlefield | Description$ Creatures with flying can't attack or block, and their activated abilities with {T} in their costs can't be activated.
 AI:RemoveDeck:Random
 Oracle:Phasing (This phases in or out before you untap during each of your untap steps. While it's phased out, it's treated as though it doesn't exist.)\nCreatures with flying can't attack or block, and their activated abilities with {T} in their costs can't be activated.

--- a/forge-gui/res/cardsfolder/k/katabatic_winds.txt
+++ b/forge-gui/res/cardsfolder/k/katabatic_winds.txt
@@ -2,7 +2,8 @@ Name:Katabatic Winds
 ManaCost:2 G
 Types:Enchantment
 K:Phasing
-S:Mode$ Continuous | Affected$ Creature.withFlying | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Creatures with flying can't attack or block, and their activated abilities with {T} in their costs can't be activated.
-S:Mode$ CantBeActivated | ValidCard$ Creature.withFlying | ValidSA$ Activated.hasTapCost | AffectedZone$ Battlefield
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Creatures with flying can't attack or block, and their activated abilities with {T} in their costs can't be activated.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Creatures with flying can't attack or block, and their activated abilities with {T} in their costs can't be activated.
+S:Mode$ CantBeActivated | ValidCard$ Creature.withFlying | ValidSA$ Activated.hasTapCost | AffectedZone$ Battlefield | Secondary$ True | Description$ Creatures with flying can't attack or block, and their activated abilities with {T} in their costs can't be activated.
 AI:RemoveDeck:Random
 Oracle:Phasing (This phases in or out before you untap during each of your untap steps. While it's phased out, it's treated as though it doesn't exist.)\nCreatures with flying can't attack or block, and their activated abilities with {T} in their costs can't be activated.

--- a/forge-gui/res/cardsfolder/k/kefnet_the_mindful.txt
+++ b/forge-gui/res/cardsfolder/k/kefnet_the_mindful.txt
@@ -4,8 +4,7 @@ Types:Legendary Creature God
 PT:5/5
 K:Flying
 K:Indestructible
-S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Card.YouOwn | PresentZone$ Hand | PresentCompare$ LE6 | Description$ NICKNAME can't attack or block unless you have seven or more cards in hand.
-S:Mode$ CantBlock | ValidCard$ Card.Self | IsPresent$ Card.YouOwn | PresentZone$ Hand | PresentCompare$ LE6 | Secondary$ True | Description$ NICKNAME can't attack or block unless you have seven or more cards in hand.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Card.Self | IsPresent$ Card.YouOwn | PresentZone$ Hand | PresentCompare$ LE6 | Description$ NICKNAME can't attack or block unless you have seven or more cards in hand.
 SVar:X:Count$ValidHand Card.YouOwn
 A:AB$ Draw | Cost$ 3 U | NumCards$ 1 | Defined$ You | SubAbility$ DBChooseCard | SpellDescription$ Draw a card, then you may return a land you control to its owner's hand.
 SVar:DBChooseCard:DB$ ChooseCard | Choices$ Land.YouCtrl | ChoiceZone$ Battlefield | Amount$ 1 | SubAbility$ DBChangeZone

--- a/forge-gui/res/cardsfolder/k/kefnet_the_mindful.txt
+++ b/forge-gui/res/cardsfolder/k/kefnet_the_mindful.txt
@@ -4,7 +4,8 @@ Types:Legendary Creature God
 PT:5/5
 K:Flying
 K:Indestructible
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack or block. | CheckSVar$ X | SVarCompare$ LE6 | Description$ CARDNAME can't attack or block unless you have seven or more cards in hand.
+S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Card.YouOwn | PresentZone$ Hand | PresentCompare$ LE6 | Description$ NICKNAME can't attack or block unless you have seven or more cards in hand.
+S:Mode$ CantBlock | ValidCard$ Card.Self | IsPresent$ Card.YouOwn | PresentZone$ Hand | PresentCompare$ LE6 | Secondary$ True | Description$ NICKNAME can't attack or block unless you have seven or more cards in hand.
 SVar:X:Count$ValidHand Card.YouOwn
 A:AB$ Draw | Cost$ 3 U | NumCards$ 1 | Defined$ You | SubAbility$ DBChooseCard | SpellDescription$ Draw a card, then you may return a land you control to its owner's hand.
 SVar:DBChooseCard:DB$ ChooseCard | Choices$ Land.YouCtrl | ChoiceZone$ Battlefield | Amount$ 1 | SubAbility$ DBChangeZone

--- a/forge-gui/res/cardsfolder/k/ketramose_the_new_dawn.txt
+++ b/forge-gui/res/cardsfolder/k/ketramose_the_new_dawn.txt
@@ -5,8 +5,7 @@ PT:4/4
 K:Menace
 K:Lifelink
 K:Indestructible
-S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Card | PresentZone$ Exile | PresentCompare$ LT7 | Description$ NICKNAME can't attack or block unless there are seven or more cards in exile.
-S:Mode$ CantBlock | ValidCard$ Card.Self | IsPresent$ Card | PresentZone$ Exile | PresentCompare$ LT7 | Secondary$ True | Description$ NICKNAME can't attack or block unless there are seven or more cards in exile.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Card.Self | IsPresent$ Card | PresentZone$ Exile | PresentCompare$ LT7 | Description$ NICKNAME can't attack or block unless there are seven or more cards in exile.
 T:Mode$ ChangesZoneAll | ValidCards$ Card.!token | Origin$ Battlefield,Graveyard | Destination$ Exile | TriggerZones$ Battlefield | PlayerTurn$ True | Execute$ TrigDraw | TriggerDescription$ Whenever one or more cards are put into exile from graveyards and/or the battlefield during your turn, you draw a card and lose 1 life.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1 | SubAbility$ DBLoseLife
 SVar:DBLoseLife:DB$ LoseLife | Defined$ You | LifeAmount$ 1

--- a/forge-gui/res/cardsfolder/k/ketramose_the_new_dawn.txt
+++ b/forge-gui/res/cardsfolder/k/ketramose_the_new_dawn.txt
@@ -5,7 +5,8 @@ PT:4/4
 K:Menace
 K:Lifelink
 K:Indestructible
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack or block. | IsPresent$ Card | PresentZone$ Exile | PresentCompare$ LT7 | Description$ NICKNAME can't attack or block unless there are seven or more cards in exile.
+S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Card | PresentZone$ Exile | PresentCompare$ LT7 | Description$ NICKNAME can't attack or block unless there are seven or more cards in exile.
+S:Mode$ CantBlock | ValidCard$ Card.Self | IsPresent$ Card | PresentZone$ Exile | PresentCompare$ LT7 | Secondary$ True | Description$ NICKNAME can't attack or block unless there are seven or more cards in exile.
 T:Mode$ ChangesZoneAll | ValidCards$ Card.!token | Origin$ Battlefield,Graveyard | Destination$ Exile | TriggerZones$ Battlefield | PlayerTurn$ True | Execute$ TrigDraw | TriggerDescription$ Whenever one or more cards are put into exile from graveyards and/or the battlefield during your turn, you draw a card and lose 1 life.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1 | SubAbility$ DBLoseLife
 SVar:DBLoseLife:DB$ LoseLife | Defined$ You | LifeAmount$ 1

--- a/forge-gui/res/cardsfolder/k/kirtars_desire.txt
+++ b/forge-gui/res/cardsfolder/k/kirtars_desire.txt
@@ -3,6 +3,6 @@ ManaCost:W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack. | Description$ Enchanted creature can't attack.
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't block. | Condition$ Threshold | Description$ Threshold — Enchanted creature can't block as long as seven or more cards are in your graveyard.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Condition$ Threshold | Description$ Threshold — Enchanted creature can't block as long as seven or more cards are in your graveyard.
 Oracle:Enchant creature\nEnchanted creature can't attack.\nThreshold — Enchanted creature can't block as long as seven or more cards are in your graveyard.

--- a/forge-gui/res/cardsfolder/k/kithkin_armor.txt
+++ b/forge-gui/res/cardsfolder/k/kithkin_armor.txt
@@ -4,14 +4,11 @@ Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Pump
 S:Mode$ CantBlockBy | ValidAttacker$ Creature.EnchantedBy | ValidBlocker$ Creature.powerGE3 | Description$ Enchanted creature can't be blocked by creatures with power 3 or greater.
-T:Mode$ Attached | ValidSource$ Card.Self | ValidTarget$ Creature | TriggerZones$ Battlefield | Execute$ TrigImprint | Static$ True
-SVar:TrigImprint:DB$ Cleanup | ClearImprinted$ True | SubAbility$ ImprintNew
-SVar:ImprintNew:DB$ Pump | ImprintCards$ Enchanted
 A:AB$ ChooseSource | Cost$ Sac<1/CARDNAME> | Choices$ Card,Emblem | AILogic$ NeedsPrevention | SubAbility$ DBEffect | SpellDescription$ The next time a source of your choice would deal damage to enchanted creature this turn, prevent that damage.
-SVar:DBEffect:DB$ Effect | ReplacementEffects$ RPreventNextFromSource | ImprintCards$ Imprinted | SubAbility$ DBCleanup | ConditionDefined$ ChosenCard | ConditionPresent$ Card,Emblem
+SVar:DBEffect:DB$ Effect | ReplacementEffects$ RPreventNextFromSource | ImprintCards$ AttachedBy Sacrificed | SubAbility$ DBCleanup | ConditionDefined$ ChosenCard | ConditionPresent$ Card,Emblem
 SVar:RPreventNextFromSource:Event$ DamageDone | ValidSource$ Card.ChosenCardStrict,Emblem.ChosenCard | ValidTarget$ Card.IsImprinted | ReplaceWith$ ExileEffect | PreventionEffect$ True | Description$ The next time the chosen source deals damage to enchanted creature, prevent that damage.
 SVar:ExileEffect:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
-SVar:DBCleanup:DB$ Cleanup | ClearImprinted$ True | ClearChosenCard$ True
+SVar:DBCleanup:DB$ Cleanup | ClearChosenCard$ True
 AI:RemoveDeck:All
 SVar:NonStackingAttachEffect:True
 Oracle:Enchant creature\nEnchanted creature can't be blocked by creatures with power 3 or greater.\nSacrifice Kithkin Armor: The next time a source of your choice would deal damage to enchanted creature this turn, prevent that damage.

--- a/forge-gui/res/cardsfolder/k/koma_cosmos_serpent.txt
+++ b/forge-gui/res/cardsfolder/k/koma_cosmos_serpent.txt
@@ -7,7 +7,8 @@ T:Mode$ Phase | Phase$ Upkeep | TriggerZones$ Battlefield | Execute$ TrigToken |
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ komas_coil | TokenOwner$ You
 A:AB$ Charm | Cost$ Sac<1/Serpent.Other/another Serpent> | Choices$ DBTap,DBPump
 SVar:DBTap:DB$ Tap | ValidTgts$ Permanent | TgtPrompt$ Select target permanent | SubAbility$ DBConstrict | StackDescription$ Tap {c:Targeted}. Its activated abilities can't be activated this turn. | SpellDescription$ Tap target permanent. Its activated abilities can't be activated this turn.
-SVar:DBConstrict:DB$ Pump | Defined$ ParentTarget | KW$ HIDDEN CARDNAME's activated abilities can't be activated. | StackDescription$ None
+SVar:DBConstrict:DB$ Effect | RememberObjects$ ParentTarget | StaticAbilities$ DBCantBeActivated | ForgetOnMoved$ Battlefield
+SVar:DBCantBeActivated:Mode$ CantBeActivated | ValidCard$ Card.IsRemembered | Description$ Remembered activated abilities can't be activated.
 SVar:DBPump:DB$ Pump | Defined$ Self | KW$ Indestructible | SpellDescription$ CARDNAME gains indestructible until end of turn.
 DeckHas:Ability$Token|Sacrifice
 Oracle:This spell can't be countered.\nAt the beginning of each upkeep, create a 3/3 blue Serpent creature token named Koma's Coil.\nSacrifice another Serpent: Choose one —\n• Tap target permanent. Its activated abilities can't be activated this turn.\n• Koma, Cosmos Serpent gains indestructible until end of turn.

--- a/forge-gui/res/cardsfolder/k/krasis_incubation.txt
+++ b/forge-gui/res/cardsfolder/k/krasis_incubation.txt
@@ -3,11 +3,10 @@ ManaCost:2 G U
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. & CARDNAME's activated abilities can't be activated. | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
-T:Mode$ Attached | ValidSource$ Card.Self | ValidTarget$ Creature | TriggerZones$ Battlefield | Execute$ TrigRemember | Static$ True
-SVar:TrigRemember:DB$ Cleanup | ClearRemembered$ True | SubAbility$ RememberNew
-SVar:RememberNew:DB$ Pump | RememberObjects$ Enchanted
-A:AB$ PutCounter | Cost$ 1 G U Return<1/CARDNAME> | Defined$ Remembered | CounterType$ P1P1 | CounterNum$ 2 | SpellDescription$ Put two +1/+1 counters on enchanted creature.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBeActivated | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+A:AB$ PutCounter | Cost$ 1 G U Return<1/CARDNAME> | Defined$ AttachedBy Returned | CounterType$ P1P1 | CounterNum$ 2 | SpellDescription$ Put two +1/+1 counters on enchanted creature.
 AI:RemoveDeck:All
 DeckHas:Ability$Counters
 Oracle:Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.\n{1}{G}{U}, Return Krasis Incubation to its owner's hand: Put two +1/+1 counters on enchanted creature.

--- a/forge-gui/res/cardsfolder/k/krasis_incubation.txt
+++ b/forge-gui/res/cardsfolder/k/krasis_incubation.txt
@@ -3,9 +3,7 @@ ManaCost:2 G U
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBeActivated | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack,CantBlock,CantBeActivated | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
 A:AB$ PutCounter | Cost$ 1 G U Return<1/CARDNAME> | Defined$ AttachedBy Returned | CounterType$ P1P1 | CounterNum$ 2 | SpellDescription$ Put two +1/+1 counters on enchanted creature.
 AI:RemoveDeck:All
 DeckHas:Ability$Counters

--- a/forge-gui/res/cardsfolder/k/kulrath_knight.txt
+++ b/forge-gui/res/cardsfolder/k/kulrath_knight.txt
@@ -4,6 +4,5 @@ Types:Creature Elemental Knight
 PT:3/3
 K:Flying
 K:Wither
-S:Mode$ CantAttack | ValidCard$ Creature.OppCtrl+HasCounters | Description$ Creatures your opponents control with counters on them can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.OppCtrl+HasCounters | Secondary$ True | Description$ Creatures your opponents control with counters on them can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.OppCtrl+HasCounters | Description$ Creatures your opponents control with counters on them can't attack or block.
 Oracle:Flying\nWither (This deals damage to creatures in the form of -1/-1 counters.)\nCreatures your opponents control with counters on them can't attack or block.

--- a/forge-gui/res/cardsfolder/k/kulrath_knight.txt
+++ b/forge-gui/res/cardsfolder/k/kulrath_knight.txt
@@ -4,5 +4,6 @@ Types:Creature Elemental Knight
 PT:3/3
 K:Flying
 K:Wither
-S:Mode$ Continuous | Affected$ Creature.OppCtrl+HasCounters | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Creatures your opponents control with counters on them can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Creature.OppCtrl+HasCounters | Description$ Creatures your opponents control with counters on them can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.OppCtrl+HasCounters | Secondary$ True | Description$ Creatures your opponents control with counters on them can't attack or block.
 Oracle:Flying\nWither (This deals damage to creatures in the form of -1/-1 counters.)\nCreatures your opponents control with counters on them can't attack or block.

--- a/forge-gui/res/cardsfolder/l/lambholt_pacifist_lambholt_butcher.txt
+++ b/forge-gui/res/cardsfolder/l/lambholt_pacifist_lambholt_butcher.txt
@@ -2,7 +2,7 @@ Name:Lambholt Pacifist
 ManaCost:1 G
 Types:Creature Human Shaman Werewolf
 PT:3/3
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack. | IsPresent$ Creature.YouCtrl+powerGE4 | PresentCompare$ EQ0 | Description$ CARDNAME can't attack unless you control a creature with power 4 or greater.
+S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Creature.YouCtrl+powerGE4 | PresentCompare$ EQ0 | Description$ CARDNAME can't attack unless you control a creature with power 4 or greater.
 T:Mode$ Phase | Phase$ Upkeep | WerewolfTransformCondition$ True | TriggerZones$ Battlefield | Execute$ TrigTransform | TriggerDescription$ At the beginning of each upkeep, if no spells were cast last turn, transform CARDNAME.
 SVar:TrigTransform:DB$ SetState | Defined$ Self | Mode$ Transform
 AlternateMode:DoubleFaced

--- a/forge-gui/res/cardsfolder/l/lawmages_binding.txt
+++ b/forge-gui/res/cardsfolder/l/lawmages_binding.txt
@@ -4,5 +4,7 @@ Types:Enchantment Aura
 K:Flash
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. & CARDNAME's activated abilities can't be activated. | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBeActivated | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
 Oracle:Flash\nEnchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/l/lawmages_binding.txt
+++ b/forge-gui/res/cardsfolder/l/lawmages_binding.txt
@@ -4,7 +4,5 @@ Types:Enchantment Aura
 K:Flash
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBeActivated | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack,CantBlock,CantBeActivated | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
 Oracle:Flash\nEnchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/l/light_of_day.txt
+++ b/forge-gui/res/cardsfolder/l/light_of_day.txt
@@ -1,8 +1,7 @@
 Name:Light of Day
 ManaCost:3 W
 Types:Enchantment
-S:Mode$ CantAttack | ValidCard$ Creature.Black | Description$ Black creatures can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.Black | Secondary$ True | Description$ Black creatures can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.Black | Description$ Black creatures can't attack or block.
 SVar:NonStackingEffect:True
 AI:RemoveDeck:Random
 Oracle:Black creatures can't attack or block.

--- a/forge-gui/res/cardsfolder/l/light_of_day.txt
+++ b/forge-gui/res/cardsfolder/l/light_of_day.txt
@@ -1,7 +1,8 @@
 Name:Light of Day
 ManaCost:3 W
 Types:Enchantment
-S:Mode$ Continuous | Affected$ Creature.Black | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Black creatures can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Creature.Black | Description$ Black creatures can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.Black | Secondary$ True | Description$ Black creatures can't attack or block.
 SVar:NonStackingEffect:True
 AI:RemoveDeck:Random
 Oracle:Black creatures can't attack or block.

--- a/forge-gui/res/cardsfolder/l/lovestruck_beast_hearts_desire.txt
+++ b/forge-gui/res/cardsfolder/l/lovestruck_beast_hearts_desire.txt
@@ -2,7 +2,7 @@ Name:Lovestruck Beast
 ManaCost:2 G
 Types:Creature Beast Noble
 PT:5/5
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack. | IsPresent$ Creature.YouCtrl+powerEQ1+toughnessEQ1 | PresentCompare$ EQ0 | Description$ CARDNAME can't attack unless you control a 1/1 creature.
+S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Creature.YouCtrl+powerEQ1+toughnessEQ1 | PresentCompare$ EQ0 | Description$ CARDNAME can't attack unless you control a 1/1 creature.
 AlternateMode:Adventure
 Oracle:Lovestruck Beast can't attack unless you control a 1/1 creature.
 

--- a/forge-gui/res/cardsfolder/l/luminous_bonds.txt
+++ b/forge-gui/res/cardsfolder/l/luminous_bonds.txt
@@ -3,6 +3,5 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
 Oracle:Enchant creature\nEnchanted creature can't attack or block.

--- a/forge-gui/res/cardsfolder/l/luminous_bonds.txt
+++ b/forge-gui/res/cardsfolder/l/luminous_bonds.txt
@@ -3,5 +3,6 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
 Oracle:Enchant creature\nEnchanted creature can't attack or block.

--- a/forge-gui/res/cardsfolder/l/lupine_prototype.txt
+++ b/forge-gui/res/cardsfolder/l/lupine_prototype.txt
@@ -2,7 +2,8 @@ Name:Lupine Prototype
 ManaCost:2
 Types:Artifact Creature Wolf Construct
 PT:5/5
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack or block. | CheckSVar$ X | SVarCompare$ GE1 | Description$ CARDNAME can't attack or block unless a player has no cards in hand.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | CheckSVar$ X | SVarCompare$ GE1 | Description$ CARDNAME can't attack or block unless a player has no cards in hand.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | CheckSVar$ X | SVarCompare$ GE1 | Secondary$ True | Description$ CARDNAME can't attack or block unless a player has no cards in hand.
 SVar:X:PlayerCountPlayers$LowestValidHand Card.YouOwn
 AI:RemoveDeck:Random
 Oracle:Lupine Prototype can't attack or block unless a player has no cards in hand.

--- a/forge-gui/res/cardsfolder/l/lupine_prototype.txt
+++ b/forge-gui/res/cardsfolder/l/lupine_prototype.txt
@@ -2,8 +2,7 @@ Name:Lupine Prototype
 ManaCost:2
 Types:Artifact Creature Wolf Construct
 PT:5/5
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | CheckSVar$ X | SVarCompare$ GE1 | Description$ CARDNAME can't attack or block unless a player has no cards in hand.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | CheckSVar$ X | SVarCompare$ GE1 | Secondary$ True | Description$ CARDNAME can't attack or block unless a player has no cards in hand.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy | CheckSVar$ X | SVarCompare$ GE1 | Description$ CARDNAME can't attack or block unless a player has no cards in hand.
 SVar:X:PlayerCountPlayers$LowestValidHand Card.YouOwn
 AI:RemoveDeck:Random
 Oracle:Lupine Prototype can't attack or block unless a player has no cards in hand.

--- a/forge-gui/res/cardsfolder/m/magistrates_veto.txt
+++ b/forge-gui/res/cardsfolder/m/magistrates_veto.txt
@@ -1,7 +1,7 @@
 Name:Magistrate's Veto
 ManaCost:2 R
 Types:Enchantment
-S:Mode$ Continuous | Affected$ Creature.White,Creature.Blue | AddHiddenKeyword$ CARDNAME can't block. | Description$ White creatures and blue creatures can't block.
+S:Mode$ CantBlock | ValidCard$ Creature.White,Creature.Blue | Description$ White creatures and blue creatures can't block.
 SVar:NonStackingEffect:True
 AI:RemoveDeck:Random
 Oracle:White creatures and blue creatures can't block.

--- a/forge-gui/res/cardsfolder/m/manacles_of_decay.txt
+++ b/forge-gui/res/cardsfolder/m/manacles_of_decay.txt
@@ -3,7 +3,7 @@ ManaCost:1 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack. | Description$ Enchanted creature can't attack.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack.
 A:AB$ Pump | Cost$ B | Defined$ Enchanted | NumAtt$ -1 | NumDef$ -1 | IsCurse$ True | SpellDescription$ Enchanted creature gets -1/-1 until end of turn.
 A:AB$ Pump | Cost$ R | Defined$ Enchanted | KW$ HIDDEN CARDNAME can't block. | IsCurse$ True | SpellDescription$ Enchanted creature can't block this turn.
 SVar:NonStackingAttachEffect:True

--- a/forge-gui/res/cardsfolder/m/maniacal_rage.txt
+++ b/forge-gui/res/cardsfolder/m/maniacal_rage.txt
@@ -3,6 +3,7 @@ ManaCost:1 R
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Pump
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 2 | AddToughness$ 2 | AddHiddenKeyword$ CARDNAME can't block. | Description$ Enchanted creature gets +2/+2 and can't block.
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 2 | AddToughness$ 2 | Description$ Enchanted creature gets +2/+2 and can't block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature gets +2/+2 and can't block.
 AI:RemoveDeck:Random
 Oracle:Enchant creature\nEnchanted creature gets +2/+2 and can't block.

--- a/forge-gui/res/cardsfolder/m/marauding_boneslasher.txt
+++ b/forge-gui/res/cardsfolder/m/marauding_boneslasher.txt
@@ -2,5 +2,5 @@ Name:Marauding Boneslasher
 ManaCost:2 B
 Types:Creature Zombie Minotaur
 PT:3/3
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't block. | IsPresent$ Zombie.Other+YouCtrl | PresentCompare$ EQ0 | Description$ CARDNAME can't block unless you control another Zombie.
+S:Mode$ CantBlock | ValidCard$ Card.Self | IsPresent$ Zombie.Other+YouCtrl | PresentCompare$ EQ0 | Description$ CARDNAME can't block unless you control another Zombie.
 Oracle:Marauding Boneslasher can't block unless you control another Zombie.

--- a/forge-gui/res/cardsfolder/m/mindless_null.txt
+++ b/forge-gui/res/cardsfolder/m/mindless_null.txt
@@ -2,5 +2,5 @@ Name:Mindless Null
 ManaCost:2 B
 Types:Creature Zombie
 PT:2/2
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't block. | IsPresent$ Vampire.YouCtrl | PresentCompare$ EQ0 | Description$ CARDNAME can't block unless you control a Vampire.
+S:Mode$ CantBlock | ValidCard$ Card.Self | IsPresent$ Vampire.YouCtrl | PresentCompare$ EQ0 | Description$ CARDNAME can't block unless you control a Vampire.
 Oracle:Mindless Null can't block unless you control a Vampire.

--- a/forge-gui/res/cardsfolder/m/mishras_domination.txt
+++ b/forge-gui/res/cardsfolder/m/mishras_domination.txt
@@ -3,5 +3,5 @@ ManaCost:1 R
 Types:Enchantment Aura
 K:Enchant:Creature
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 2 | AddToughness$ 2 | IsPresent$ Card.EnchantedBy+YouCtrl | Description$ As long as you control enchanted creature, it gets +2/+2. Otherwise, it can't block.
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't block. | IsPresent$ Card.EnchantedBy+YouDontCtrl | Secondary$ True | Description$ As long as you control enchanted creature, it gets +2/+2. Otherwise, it can't block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | IsPresent$ Card.EnchantedBy+YouDontCtrl | Secondary$ True | Description$ As long as you control enchanted creature, it gets +2/+2. Otherwise, it can't block.
 Oracle:Enchant creature\nAs long as you control enchanted creature, it gets +2/+2. Otherwise, it can't block.

--- a/forge-gui/res/cardsfolder/m/mogg_conscripts.txt
+++ b/forge-gui/res/cardsfolder/m/mogg_conscripts.txt
@@ -2,7 +2,7 @@ Name:Mogg Conscripts
 ManaCost:R
 Types:Creature Goblin
 PT:2/2
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack. | CheckSVar$ X | SVarCompare$ EQ0 | Description$ CARDNAME can't attack unless you've cast a creature spell this turn.
+S:Mode$ CantAttack | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ EQ0 | Description$ CARDNAME can't attack unless you've cast a creature spell this turn.
 SVar:X:Count$ThisTurnCast_Creature.YouCtrl
 SVar:BuffedBy:Creature
 Oracle:Mogg Conscripts can't attack unless you've cast a creature spell this turn.

--- a/forge-gui/res/cardsfolder/m/mogg_toady.txt
+++ b/forge-gui/res/cardsfolder/m/mogg_toady.txt
@@ -3,7 +3,7 @@ ManaCost:1 R
 Types:Creature Goblin
 PT:2/2
 S:Mode$ CantAttack | ValidCard$ Card.Self | UnlessDefender$ hasFewerCreaturesInPlayThanYou | Description$ CARDNAME can't attack unless you control more creatures than defending player.
-S:Mode$ Continuous | Affected$ Card.Self | Condition$ NotPlayerTurn | AddHiddenKeyword$ CARDNAME can't block. | CheckSVar$ Y | SVarCompare$ GEX | Description$ CARDNAME can't block unless you control more creatures than attacking player.
+S:Mode$ CantBlock | ValidCard$ Card.Self | Condition$ NotPlayerTurn | CheckSVar$ Y | SVarCompare$ GEX | Description$ CARDNAME can't block unless you control more creatures than attacking player.
 SVar:X:Count$Valid Creature.YouCtrl
 SVar:Y:Count$Valid Creature.ActivePlayerCtrl
 SVar:BuffedBy:Creature

--- a/forge-gui/res/cardsfolder/m/monstrous_hound.txt
+++ b/forge-gui/res/cardsfolder/m/monstrous_hound.txt
@@ -3,7 +3,7 @@ ManaCost:3 R
 Types:Creature Dog
 PT:4/4
 S:Mode$ CantAttack | ValidCard$ Card.Self | UnlessDefender$ hasFewerLandsInPlayThanYou | Description$ CARDNAME can't attack unless you control more lands than defending player.
-S:Mode$ Continuous | Affected$ Card.Self | Condition$ NotPlayerTurn | AddHiddenKeyword$ CARDNAME can't block. | CheckSVar$ Y | SVarCompare$ GEX | Description$ CARDNAME can't block unless you control more lands than attacking player.
+S:Mode$ CantBlock | ValidCard$ Card.Self | Condition$ NotPlayerTurn | CheckSVar$ Y | SVarCompare$ GEX | Description$ CARDNAME can't block unless you control more lands than attacking player.
 SVar:X:Count$Valid Land.YouCtrl
 SVar:Y:Count$Valid Land.ActivePlayerCtrl
 SVar:BuffedBy:Land

--- a/forge-gui/res/cardsfolder/n/nahiris_binding.txt
+++ b/forge-gui/res/cardsfolder/n/nahiris_binding.txt
@@ -3,7 +3,5 @@ ManaCost:1 W W
 Types:Enchantment Aura
 K:Enchant:Creature,Planeswalker:creature or planeswalker
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Card.EnchantedBy | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated.
-S:Mode$ CantBlock | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack,CantBlock,CantBeActivated | ValidCard$ Card.EnchantedBy | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated.
 Oracle:Enchant creature or planeswalker\nEnchanted permanent can't attack or block, and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/n/nahiris_binding.txt
+++ b/forge-gui/res/cardsfolder/n/nahiris_binding.txt
@@ -3,5 +3,7 @@ ManaCost:1 W W
 Types:Enchantment Aura
 K:Enchant:Creature,Planeswalker:creature or planeswalker
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Card.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. & CARDNAME's activated abilities can't be activated. | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated.
+S:Mode$ CantAttack | ValidCard$ Card.EnchantedBy | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated.
+S:Mode$ CantBlock | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
 Oracle:Enchant creature or planeswalker\nEnchanted permanent can't attack or block, and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/o/oketra_the_true.txt
+++ b/forge-gui/res/cardsfolder/o/oketra_the_true.txt
@@ -4,7 +4,8 @@ Types:Legendary Creature God
 PT:3/6
 K:Double Strike
 K:Indestructible
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack or block. | IsPresent$ Creature.Other+YouCtrl | PresentCompare$ LE2 | Description$ CARDNAME can't attack or block unless you control at least three other creatures.
+S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Creature.Other+YouCtrl | PresentCompare$ LE2 | Description$ NICKNAME can't attack or block unless you control at least three other creatures.
+S:Mode$ CantBlock | ValidCard$ Card.Self | IsPresent$ Creature.Other+YouCtrl | PresentCompare$ LE2 | Secondary$ True | Description$ NICKNAME can't attack or block unless you control at least three other creatures.
 A:AB$ Token | Cost$ 3 W | TokenAmount$ 1 | TokenScript$ w_1_1_warrior_vigilance | TokenOwner$ You | SpellDescription$ Create a 1/1 white Warrior creature token with vigilance.
 DeckHas:Ability$Token
 Oracle:Double strike, indestructible\nOketra the True can't attack or block unless you control at least three other creatures.\n{3}{W}: Create a 1/1 white Warrior creature token with vigilance.

--- a/forge-gui/res/cardsfolder/o/oketra_the_true.txt
+++ b/forge-gui/res/cardsfolder/o/oketra_the_true.txt
@@ -4,8 +4,7 @@ Types:Legendary Creature God
 PT:3/6
 K:Double Strike
 K:Indestructible
-S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Creature.Other+YouCtrl | PresentCompare$ LE2 | Description$ NICKNAME can't attack or block unless you control at least three other creatures.
-S:Mode$ CantBlock | ValidCard$ Card.Self | IsPresent$ Creature.Other+YouCtrl | PresentCompare$ LE2 | Secondary$ True | Description$ NICKNAME can't attack or block unless you control at least three other creatures.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Card.Self | IsPresent$ Creature.Other+YouCtrl | PresentCompare$ LE2 | Description$ NICKNAME can't attack or block unless you control at least three other creatures.
 A:AB$ Token | Cost$ 3 W | TokenAmount$ 1 | TokenScript$ w_1_1_warrior_vigilance | TokenOwner$ You | SpellDescription$ Create a 1/1 white Warrior creature token with vigilance.
 DeckHas:Ability$Token
 Oracle:Double strike, indestructible\nOketra the True can't attack or block unless you control at least three other creatures.\n{3}{W}: Create a 1/1 white Warrior creature token with vigilance.

--- a/forge-gui/res/cardsfolder/o/olog_hai_crusher.txt
+++ b/forge-gui/res/cardsfolder/o/olog_hai_crusher.txt
@@ -3,6 +3,6 @@ ManaCost:3 R
 Types:Creature Troll Soldier
 PT:4/4
 K:Trample
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't block. | IsPresent$ Goblin.YouCtrl,Orc.YouCtrl | PresentCompare$ EQ0 | Description$ CARDNAME can't block unless you control a Goblin or Orc.
+S:Mode$ CantBlock | ValidCard$ Card.Self | IsPresent$ Goblin.YouCtrl,Orc.YouCtrl | PresentCompare$ EQ0 | Description$ CARDNAME can't block unless you control a Goblin or Orc.
 DeckHints:Type$Goblin|Orc
 Oracle:Trample\nOlog-hai Crusher can't block unless you control a Goblin or Orc.

--- a/forge-gui/res/cardsfolder/o/one_thousand_lashes.txt
+++ b/forge-gui/res/cardsfolder/o/one_thousand_lashes.txt
@@ -3,7 +3,9 @@ ManaCost:2 W B
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. & CARDNAME's activated abilities can't be activated. | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBeActivated | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player.EnchantedController | TriggerZones$ Battlefield | Execute$ TrigLoseLife | TriggerDescription$ At the beginning of the upkeep of enchanted creature's controller, that player loses 1 life.
 SVar:TrigLoseLife:DB$ LoseLife | Defined$ TriggeredPlayer | LifeAmount$ 1
 Oracle:Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.\nAt the beginning of the upkeep of enchanted creature's controller, that player loses 1 life.

--- a/forge-gui/res/cardsfolder/o/one_thousand_lashes.txt
+++ b/forge-gui/res/cardsfolder/o/one_thousand_lashes.txt
@@ -3,9 +3,7 @@ ManaCost:2 W B
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBeActivated | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack,CantBlock,CantBeActivated | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player.EnchantedController | TriggerZones$ Battlefield | Execute$ TrigLoseLife | TriggerDescription$ At the beginning of the upkeep of enchanted creature's controller, that player loses 1 life.
 SVar:TrigLoseLife:DB$ LoseLife | Defined$ TriggeredPlayer | LifeAmount$ 1
 Oracle:Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.\nAt the beginning of the upkeep of enchanted creature's controller, that player loses 1 life.

--- a/forge-gui/res/cardsfolder/p/pacifism.txt
+++ b/forge-gui/res/cardsfolder/p/pacifism.txt
@@ -3,5 +3,6 @@ ManaCost:1 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
 Oracle:Enchant creature\nEnchanted creature can't attack or block.

--- a/forge-gui/res/cardsfolder/p/pacifism.txt
+++ b/forge-gui/res/cardsfolder/p/pacifism.txt
@@ -3,6 +3,5 @@ ManaCost:1 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
 Oracle:Enchant creature\nEnchanted creature can't attack or block.

--- a/forge-gui/res/cardsfolder/p/paper_tiger.txt
+++ b/forge-gui/res/cardsfolder/p/paper_tiger.txt
@@ -2,6 +2,5 @@ Name:Paper Tiger
 ManaCost:4
 Types:Artifact Creature Cat
 PT:4/3
-S:Mode$ CantAttack | ValidCard$ Creature.namedRock Lobster | Description$ Creatures named Rock Lobster can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.namedRock Lobster | Secondary$ True | Description$ Creatures named Rock Lobster can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.namedRock Lobster | Description$ Creatures named Rock Lobster can't attack or block.
 Oracle:Creatures named Rock Lobster can't attack or block.

--- a/forge-gui/res/cardsfolder/p/paper_tiger.txt
+++ b/forge-gui/res/cardsfolder/p/paper_tiger.txt
@@ -2,5 +2,6 @@ Name:Paper Tiger
 ManaCost:4
 Types:Artifact Creature Cat
 PT:4/3
-S:Mode$ Continuous | Affected$ Creature.namedRock Lobster | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Creatures named Rock Lobster can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Creature.namedRock Lobster | Description$ Creatures named Rock Lobster can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.namedRock Lobster | Secondary$ True | Description$ Creatures named Rock Lobster can't attack or block.
 Oracle:Creatures named Rock Lobster can't attack or block.

--- a/forge-gui/res/cardsfolder/p/patchwork_beastie.txt
+++ b/forge-gui/res/cardsfolder/p/patchwork_beastie.txt
@@ -2,7 +2,8 @@ Name:Patchwork Beastie
 ManaCost:G
 Types:Artifact Creature Beast
 PT:3/3
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack or block. | CheckSVar$ X | Description$ Delirium — CARDNAME can't attack or block unless there are four or more card types among cards in your graveyard.
+S:Mode$ CantAttack | ValidCard$ Card.Self | CheckSVar$ X | Description$ Delirium — CARDNAME can't attack or block unless there are four or more card types among cards in your graveyard.
+S:Mode$ CantBlock | ValidCard$ Card.Self | CheckSVar$ X | Secondary$ True | Description$ Delirium — CARDNAME can't attack or block unless there are four or more card types among cards in your graveyard.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ TrigMill | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, you may mill a card. (You may put the top card of your library into your graveyard.)
 SVar:TrigMill:DB$ Mill | NumCards$ 1 | Defined$ You | Optional$ True
 SVar:X:Count$Delirium.0.1

--- a/forge-gui/res/cardsfolder/p/patchwork_beastie.txt
+++ b/forge-gui/res/cardsfolder/p/patchwork_beastie.txt
@@ -2,8 +2,7 @@ Name:Patchwork Beastie
 ManaCost:G
 Types:Artifact Creature Beast
 PT:3/3
-S:Mode$ CantAttack | ValidCard$ Card.Self | CheckSVar$ X | Description$ Delirium — CARDNAME can't attack or block unless there are four or more card types among cards in your graveyard.
-S:Mode$ CantBlock | ValidCard$ Card.Self | CheckSVar$ X | Secondary$ True | Description$ Delirium — CARDNAME can't attack or block unless there are four or more card types among cards in your graveyard.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Card.Self | CheckSVar$ X | Description$ Delirium — CARDNAME can't attack or block unless there are four or more card types among cards in your graveyard.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ TrigMill | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, you may mill a card. (You may put the top card of your library into your graveyard.)
 SVar:TrigMill:DB$ Mill | NumCards$ 1 | Defined$ You | Optional$ True
 SVar:X:Count$Delirium.0.1

--- a/forge-gui/res/cardsfolder/p/petrify.txt
+++ b/forge-gui/res/cardsfolder/p/petrify.txt
@@ -2,7 +2,5 @@ Name:Petrify
 ManaCost:1 W
 Types:Enchantment Aura
 K:Enchant:Artifact,Creature:artifact or creature
-S:Mode$ CantAttack | ValidCard$ Card.EnchantedBy | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated.
-S:Mode$ CantBlock | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated.
-S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated | Secondary$ True | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated.
+S:Mode$ CantAttack,CantBlock,CantBeActivated | ValidCard$ Card.EnchantedBy | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated.
 Oracle:Enchant artifact or creature\nEnchanted permanent can't attack or block, and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/p/petrify.txt
+++ b/forge-gui/res/cardsfolder/p/petrify.txt
@@ -2,6 +2,7 @@ Name:Petrify
 ManaCost:1 W
 Types:Enchantment Aura
 K:Enchant:Artifact,Creature:artifact or creature
-S:Mode$ Continuous | Affected$ Permanent.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated.
-S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated
+S:Mode$ CantAttack | ValidCard$ Card.EnchantedBy | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated.
+S:Mode$ CantBlock | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated.
+S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated | Secondary$ True | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated.
 Oracle:Enchant artifact or creature\nEnchanted permanent can't attack or block, and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/p/pillory_of_the_sleepless.txt
+++ b/forge-gui/res/cardsfolder/p/pillory_of_the_sleepless.txt
@@ -3,7 +3,9 @@ ManaCost:1 W B
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | AddTrigger$ TriggerTheSleepless | AddSVar$ PilloryLoseLife | Description$ Enchanted creature can't attack or block. Enchanted creature has "At the beginning of your upkeep, you lose 1 life."
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddTrigger$ TriggerTheSleepless | AddSVar$ PilloryLoseLife | Description$ Enchanted creature can't attack or block. Enchanted creature has "At the beginning of your upkeep, you lose 1 life."
 SVar:TriggerTheSleepless:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ PilloryLoseLife | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, you lose 1 life.
 SVar:PilloryLoseLife:DB$ LoseLife | Defined$ You | LifeAmount$ 1
 Oracle:Enchant creature\nEnchanted creature can't attack or block.\nEnchanted creature has "At the beginning of your upkeep, you lose 1 life."

--- a/forge-gui/res/cardsfolder/p/pillory_of_the_sleepless.txt
+++ b/forge-gui/res/cardsfolder/p/pillory_of_the_sleepless.txt
@@ -3,8 +3,7 @@ ManaCost:1 W B
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddTrigger$ TriggerTheSleepless | AddSVar$ PilloryLoseLife | Description$ Enchanted creature can't attack or block. Enchanted creature has "At the beginning of your upkeep, you lose 1 life."
 SVar:TriggerTheSleepless:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ PilloryLoseLife | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, you lose 1 life.
 SVar:PilloryLoseLife:DB$ LoseLife | Defined$ You | LifeAmount$ 1

--- a/forge-gui/res/cardsfolder/p/pious_interdiction.txt
+++ b/forge-gui/res/cardsfolder/p/pious_interdiction.txt
@@ -5,6 +5,5 @@ K:Enchant:Creature
 SVar:AttachAILogic:Curse
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigGainLife | TriggerDescription$ When CARDNAME enters, you gain 2 life.
 SVar:TrigGainLife:DB$ GainLife | LifeAmount$ 2
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
 Oracle:Enchant creature\nWhen Pious Interdiction enters, you gain 2 life.\nEnchanted creature can't attack or block.

--- a/forge-gui/res/cardsfolder/p/pious_interdiction.txt
+++ b/forge-gui/res/cardsfolder/p/pious_interdiction.txt
@@ -5,5 +5,6 @@ K:Enchant:Creature
 SVar:AttachAILogic:Curse
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigGainLife | TriggerDescription$ When CARDNAME enters, you gain 2 life.
 SVar:TrigGainLife:DB$ GainLife | LifeAmount$ 2
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
 Oracle:Enchant creature\nWhen Pious Interdiction enters, you gain 2 life.\nEnchanted creature can't attack or block.

--- a/forge-gui/res/cardsfolder/p/planar_disruption.txt
+++ b/forge-gui/res/cardsfolder/p/planar_disruption.txt
@@ -3,7 +3,5 @@ ManaCost:1 W
 Types:Enchantment Aura
 K:Enchant:Artifact,Creature,Planeswalker:artifact, creature, or planeswalker
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Card.EnchantedBy | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated.
-S:Mode$ CantBlock | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated.
-S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated | Secondary$ True | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated.
+S:Mode$ CantAttack,CantBlock,CantBeActivated | ValidCard$ Card.EnchantedBy | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated.
 Oracle:Enchant artifact, creature, or planeswalker\nEnchanted permanent can't attack or block, and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/p/planar_disruption.txt
+++ b/forge-gui/res/cardsfolder/p/planar_disruption.txt
@@ -3,6 +3,7 @@ ManaCost:1 W
 Types:Enchantment Aura
 K:Enchant:Artifact,Creature,Planeswalker:artifact, creature, or planeswalker
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Permanent.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated.
-S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated
+S:Mode$ CantAttack | ValidCard$ Card.EnchantedBy | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated.
+S:Mode$ CantBlock | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated.
+S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated | Secondary$ True | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated.
 Oracle:Enchant artifact, creature, or planeswalker\nEnchanted permanent can't attack or block, and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/p/prison_sentence.txt
+++ b/forge-gui/res/cardsfolder/p/prison_sentence.txt
@@ -5,5 +5,7 @@ K:Enchant:Creature
 SVar:AttachAILogic:Curse
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2.
 SVar:TrigScry:DB$ Scry | ScryNum$ 2
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. & CARDNAME's activated abilities can't be activated. | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBeActivated | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
 Oracle:Enchant creature\nWhen Prison Sentence enters, scry 2.\nEnchanted creature can't attack or block, and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/p/prison_sentence.txt
+++ b/forge-gui/res/cardsfolder/p/prison_sentence.txt
@@ -5,7 +5,5 @@ K:Enchant:Creature
 SVar:AttachAILogic:Curse
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2.
 SVar:TrigScry:DB$ Scry | ScryNum$ 2
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBeActivated | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack,CantBlock,CantBeActivated | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
 Oracle:Enchant creature\nWhen Prison Sentence enters, scry 2.\nEnchanted creature can't attack or block, and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/p/prison_term.txt
+++ b/forge-gui/res/cardsfolder/p/prison_term.txt
@@ -3,7 +3,9 @@ ManaCost:1 W W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. & CARDNAME's activated abilities can't be activated. | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBeActivated | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.OppCtrl | TriggerZones$ Battlefield | Execute$ TrigAttach | OptionalDecider$ You | TriggerDescription$ Whenever a creature an opponent controls enters, you may attach CARDNAME to that creature.
 SVar:TrigAttach:DB$ Attach | Defined$ TriggeredCardLKICopy
 Oracle:Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.\nWhenever a creature an opponent controls enters, you may attach Prison Term to that creature.

--- a/forge-gui/res/cardsfolder/p/prison_term.txt
+++ b/forge-gui/res/cardsfolder/p/prison_term.txt
@@ -3,9 +3,7 @@ ManaCost:1 W W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBeActivated | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack,CantBlock,CantBeActivated | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.OppCtrl | TriggerZones$ Battlefield | Execute$ TrigAttach | OptionalDecider$ You | TriggerDescription$ Whenever a creature an opponent controls enters, you may attach CARDNAME to that creature.
 SVar:TrigAttach:DB$ Attach | Defined$ TriggeredCardLKICopy
 Oracle:Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.\nWhenever a creature an opponent controls enters, you may attach Prison Term to that creature.

--- a/forge-gui/res/cardsfolder/p/putrid_imp.txt
+++ b/forge-gui/res/cardsfolder/p/putrid_imp.txt
@@ -3,6 +3,7 @@ ManaCost:B
 Types:Creature Zombie Imp
 PT:1/1
 A:AB$ Pump | Cost$ Discard<1/Card> | Defined$ Self | KW$ Flying | SpellDescription$ CARDNAME gains flying until end of turn.
-S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 1 | AddToughness$ 1 | AddHiddenKeyword$ CARDNAME can't block. | Condition$ Threshold | Description$ Threshold — As long as seven or more cards are in your graveyard, CARDNAME gets +1/+1 and can't block.
+S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 1 | AddToughness$ 1 | Condition$ Threshold | Description$ Threshold — As long as seven or more cards are in your graveyard, CARDNAME gets +1/+1 and can't block.
+S:Mode$ CantBlock | ValidCard$ Card.Self | Condition$ Threshold | Secondary$ True | Description$ Threshold — As long as seven or more cards are in your graveyard, CARDNAME gets +1/+1 and can't block..
 AI:RemoveDeck:All
 Oracle:Discard a card: Putrid Imp gains flying until end of turn.\nThreshold — As long as seven or more cards are in your graveyard, Putrid Imp gets +1/+1 and can't block.

--- a/forge-gui/res/cardsfolder/r/razorjaw_oni.txt
+++ b/forge-gui/res/cardsfolder/r/razorjaw_oni.txt
@@ -2,6 +2,6 @@ Name:Razorjaw Oni
 ManaCost:3 B
 Types:Creature Demon Spirit
 PT:4/5
-S:Mode$ Continuous | Affected$ Creature.Black | AddHiddenKeyword$ CARDNAME can't block. | Description$ Black creatures can't block.
+S:Mode$ CantBlock | ValidCard$ Creature.Black | Description$ Black creatures can't block.
 AI:RemoveDeck:Random
 Oracle:Black creatures can't block.

--- a/forge-gui/res/cardsfolder/r/realmbreakers_grasp.txt
+++ b/forge-gui/res/cardsfolder/r/realmbreakers_grasp.txt
@@ -3,7 +3,5 @@ ManaCost:1 W
 Types:Enchantment Aura
 K:Enchant:Artifact,Creature:artifact or creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Card.EnchantedBy | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.
-S:Mode$ CantBlock | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.
-S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated.nonManaAbility | Secondary$ True | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.
+S:Mode$ CantAttack,CantBlock,CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated.nonManaAbility | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.
 Oracle:Enchant artifact or creature\nEnchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.

--- a/forge-gui/res/cardsfolder/r/realmbreakers_grasp.txt
+++ b/forge-gui/res/cardsfolder/r/realmbreakers_grasp.txt
@@ -3,6 +3,7 @@ ManaCost:1 W
 Types:Enchantment Aura
 K:Enchant:Artifact,Creature:artifact or creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Permanent.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.
-S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated.nonManaAbility
+S:Mode$ CantAttack | ValidCard$ Card.EnchantedBy | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.
+S:Mode$ CantBlock | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.
+S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated.nonManaAbility | Secondary$ True | Description$ Enchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.
 Oracle:Enchant artifact or creature\nEnchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.

--- a/forge-gui/res/cardsfolder/r/recumbent_bliss.txt
+++ b/forge-gui/res/cardsfolder/r/recumbent_bliss.txt
@@ -3,8 +3,7 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigGainLife | TriggerDescription$ At the beginning of your upkeep, you may gain 1 life.
 SVar:TrigGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1
 Oracle:Enchant creature\nEnchanted creature can't attack or block.\nAt the beginning of your upkeep, you may gain 1 life.

--- a/forge-gui/res/cardsfolder/r/recumbent_bliss.txt
+++ b/forge-gui/res/cardsfolder/r/recumbent_bliss.txt
@@ -3,7 +3,8 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ TrigGainLife | TriggerDescription$ At the beginning of your upkeep, you may gain 1 life.
 SVar:TrigGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1
 Oracle:Enchant creature\nEnchanted creature can't attack or block.\nAt the beginning of your upkeep, you may gain 1 life.

--- a/forge-gui/res/cardsfolder/r/relic_golem.txt
+++ b/forge-gui/res/cardsfolder/r/relic_golem.txt
@@ -2,7 +2,8 @@ Name:Relic Golem
 ManaCost:3
 Types:Artifact Creature Golem
 PT:6/6
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack or block. | CheckSVar$ X | SVarCompare$ LT8 | Description$ CARDNAME can't attack or block unless an opponent has eight or more cards in their graveyard.
+S:Mode$ CantAttack | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ LT8 | Description$ CARDNAME can't attack or block unless an opponent has eight or more cards in their graveyard.
+S:Mode$ CantBlock | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ LT8 | Secondary$ True | Description$ CARDNAME can't attack or block unless an opponent has eight or more cards in their graveyard.
 SVar:X:PlayerCountOpponents$HighestCardsInGraveyard
 A:AB$ Mill | Cost$ 2 T | NumCards$ 2 | ValidTgts$ Player | TgtPrompt$ Choose a player | SpellDescription$ Target player mills two cards. (They put the top two cards of their library into their graveyard.)
 DeckHas:Ability$Mill

--- a/forge-gui/res/cardsfolder/r/relic_golem.txt
+++ b/forge-gui/res/cardsfolder/r/relic_golem.txt
@@ -2,8 +2,7 @@ Name:Relic Golem
 ManaCost:3
 Types:Artifact Creature Golem
 PT:6/6
-S:Mode$ CantAttack | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ LT8 | Description$ CARDNAME can't attack or block unless an opponent has eight or more cards in their graveyard.
-S:Mode$ CantBlock | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ LT8 | Secondary$ True | Description$ CARDNAME can't attack or block unless an opponent has eight or more cards in their graveyard.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ LT8 | Description$ CARDNAME can't attack or block unless an opponent has eight or more cards in their graveyard.
 SVar:X:PlayerCountOpponents$HighestCardsInGraveyard
 A:AB$ Mill | Cost$ 2 T | NumCards$ 2 | ValidTgts$ Player | TgtPrompt$ Choose a player | SpellDescription$ Target player mills two cards. (They put the top two cards of their library into their graveyard.)
 DeckHas:Ability$Mill

--- a/forge-gui/res/cardsfolder/r/revoke_privileges.txt
+++ b/forge-gui/res/cardsfolder/r/revoke_privileges.txt
@@ -3,6 +3,7 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Enchanted creature can't attack, block, or crew Vehicles.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block, or crew Vehicles.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block, or crew Vehicles.
 S:Mode$ CantCrew | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't crew Vehicles.
 Oracle:Enchant creature\nEnchanted creature can't attack, block, or crew Vehicles.

--- a/forge-gui/res/cardsfolder/r/revoke_privileges.txt
+++ b/forge-gui/res/cardsfolder/r/revoke_privileges.txt
@@ -3,7 +3,5 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block, or crew Vehicles.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block, or crew Vehicles.
-S:Mode$ CantCrew | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't crew Vehicles.
+S:Mode$ CantAttack,CantBlock,CantCrew | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block, or crew Vehicles.
 Oracle:Enchant creature\nEnchanted creature can't attack, block, or crew Vehicles.

--- a/forge-gui/res/cardsfolder/r/rhonas_the_indomitable.txt
+++ b/forge-gui/res/cardsfolder/r/rhonas_the_indomitable.txt
@@ -4,6 +4,7 @@ Types:Legendary Creature God
 PT:5/5
 K:Deathtouch
 K:Indestructible
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack or block. | IsPresent$ Creature.Other+YouCtrl+powerGE4 | PresentCompare$ EQ0 | Description$ CARDNAME can't attack or block unless you control another creature with power 4 or greater.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | IsPresent$ Creature.Other+YouCtrl+powerGE4 | PresentCompare$ EQ0 | Description$ NICKNAME can't attack or block unless you control another creature with power 4 or greater.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | IsPresent$ Creature.Other+YouCtrl+powerGE4 | PresentCompare$ EQ0 | Secondary$ True | Description$ NICKNAME can't attack or block unless you control another creature with power 4 or greater.
 A:AB$ Pump | Cost$ 2 G | ValidTgts$ Creature.Other | TgtPrompt$ Select target creature | NumAtt$ +2 | KW$ Trample | SpellDescription$ Another target creature gets +2/+0 and gains trample until end of turn.
 Oracle:Deathtouch, indestructible\nRhonas the Indomitable can't attack or block unless you control another creature with power 4 or greater.\n{2}{G}: Another target creature gets +2/+0 and gains trample until end of turn.

--- a/forge-gui/res/cardsfolder/r/rhonas_the_indomitable.txt
+++ b/forge-gui/res/cardsfolder/r/rhonas_the_indomitable.txt
@@ -4,7 +4,6 @@ Types:Legendary Creature God
 PT:5/5
 K:Deathtouch
 K:Indestructible
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | IsPresent$ Creature.Other+YouCtrl+powerGE4 | PresentCompare$ EQ0 | Description$ NICKNAME can't attack or block unless you control another creature with power 4 or greater.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | IsPresent$ Creature.Other+YouCtrl+powerGE4 | PresentCompare$ EQ0 | Secondary$ True | Description$ NICKNAME can't attack or block unless you control another creature with power 4 or greater.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy | IsPresent$ Creature.Other+YouCtrl+powerGE4 | PresentCompare$ EQ0 | Description$ NICKNAME can't attack or block unless you control another creature with power 4 or greater.
 A:AB$ Pump | Cost$ 2 G | ValidTgts$ Creature.Other | TgtPrompt$ Select target creature | NumAtt$ +2 | KW$ Trample | SpellDescription$ Another target creature gets +2/+0 and gains trample until end of turn.
 Oracle:Deathtouch, indestructible\nRhonas the Indomitable can't attack or block unless you control another creature with power 4 or greater.\n{2}{G}: Another target creature gets +2/+0 and gains trample until end of turn.

--- a/forge-gui/res/cardsfolder/r/river_serpent.txt
+++ b/forge-gui/res/cardsfolder/r/river_serpent.txt
@@ -2,7 +2,7 @@ Name:River Serpent
 ManaCost:5 U
 Types:Creature Serpent
 PT:5/5
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack. | CheckSVar$ X | SVarCompare$ LE4 | Description$ CARDNAME can't attack unless there are five or more cards in your graveyard.
+S:Mode$ CantAttack | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ LE4 | Description$ CARDNAME can't attack unless there are five or more cards in your graveyard.
 K:Cycling:U
 SVar:X:Count$ValidGraveyard Card.YouOwn
 SVar:BuffedBy:Instant,Sorcery

--- a/forge-gui/res/cardsfolder/r/rock_lobster.txt
+++ b/forge-gui/res/cardsfolder/r/rock_lobster.txt
@@ -2,5 +2,6 @@ Name:Rock Lobster
 ManaCost:4
 Types:Artifact Creature Lobster
 PT:4/3
-S:Mode$ Continuous | Affected$ Creature.namedScissors Lizard | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Creatures named Scissors Lizard can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Creature.namedScissors Lizard | Description$ Creatures named Scissors Lizard can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.namedScissors Lizard | Secondary$ True | Description$ Creatures named Scissors Lizard can't attack or block.
 Oracle:Creatures named Scissors Lizard can't attack or block.

--- a/forge-gui/res/cardsfolder/r/rock_lobster.txt
+++ b/forge-gui/res/cardsfolder/r/rock_lobster.txt
@@ -2,6 +2,5 @@ Name:Rock Lobster
 ManaCost:4
 Types:Artifact Creature Lobster
 PT:4/3
-S:Mode$ CantAttack | ValidCard$ Creature.namedScissors Lizard | Description$ Creatures named Scissors Lizard can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.namedScissors Lizard | Secondary$ True | Description$ Creatures named Scissors Lizard can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.namedScissors Lizard | Description$ Creatures named Scissors Lizard can't attack or block.
 Oracle:Creatures named Scissors Lizard can't attack or block.

--- a/forge-gui/res/cardsfolder/s/sab_sunen_luxa_embodied.txt
+++ b/forge-gui/res/cardsfolder/s/sab_sunen_luxa_embodied.txt
@@ -5,7 +5,8 @@ PT:6/6
 K:Reach
 K:Trample
 K:Indestructible
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack or block. | CheckSVar$ X | SVarCompare$ EQ1 | Description$ NICKNAME can't attack or block unless it has an even number of counters on it. (Zero is even.)
+S:Mode$ CantAttack | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ EQ1 | Description$ NICKNAME can't attack or block unless it has an even number of counters on it. (Zero is even.)
+S:Mode$ CantBlock | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ EQ1 | Secondary$ True | Description$ NICKNAME can't attack or block unless it has an even number of counters on it. (Zero is even.)
 T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ At the beginning of your first main phase, put a +1/+1 counter on NICKNAME. Then if it has an odd number of counters on it, draw two cards.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw | NumCards$ 2 | ConditionCheckSVar$ X | ConditionSVarCompare$ EQ1

--- a/forge-gui/res/cardsfolder/s/sab_sunen_luxa_embodied.txt
+++ b/forge-gui/res/cardsfolder/s/sab_sunen_luxa_embodied.txt
@@ -5,8 +5,7 @@ PT:6/6
 K:Reach
 K:Trample
 K:Indestructible
-S:Mode$ CantAttack | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ EQ1 | Description$ NICKNAME can't attack or block unless it has an even number of counters on it. (Zero is even.)
-S:Mode$ CantBlock | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ EQ1 | Secondary$ True | Description$ NICKNAME can't attack or block unless it has an even number of counters on it. (Zero is even.)
+S:Mode$ CantAttack,CantBlock | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ EQ1 | Description$ NICKNAME can't attack or block unless it has an even number of counters on it. (Zero is even.)
 T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ At the beginning of your first main phase, put a +1/+1 counter on NICKNAME. Then if it has an odd number of counters on it, draw two cards.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw | NumCards$ 2 | ConditionCheckSVar$ X | ConditionSVarCompare$ EQ1

--- a/forge-gui/res/cardsfolder/s/scissors_lizard.txt
+++ b/forge-gui/res/cardsfolder/s/scissors_lizard.txt
@@ -2,5 +2,6 @@ Name:Scissors Lizard
 ManaCost:4
 Types:Artifact Creature Lizard
 PT:4/3
-S:Mode$ Continuous | Affected$ Creature.namedPaper Tiger | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Creatures named Paper Tiger can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Creature.namedPaper Tiger | Description$ Creatures named Paper Tiger can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.namedPaper Tiger | Secondary$ True | Description$ Creatures named Paper Tiger can't attack or block.
 Oracle:Creatures named Paper Tiger can't attack or block.

--- a/forge-gui/res/cardsfolder/s/scissors_lizard.txt
+++ b/forge-gui/res/cardsfolder/s/scissors_lizard.txt
@@ -2,6 +2,5 @@ Name:Scissors Lizard
 ManaCost:4
 Types:Artifact Creature Lizard
 PT:4/3
-S:Mode$ CantAttack | ValidCard$ Creature.namedPaper Tiger | Description$ Creatures named Paper Tiger can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.namedPaper Tiger | Secondary$ True | Description$ Creatures named Paper Tiger can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.namedPaper Tiger | Description$ Creatures named Paper Tiger can't attack or block.
 Oracle:Creatures named Paper Tiger can't attack or block.

--- a/forge-gui/res/cardsfolder/s/seatower_imprisonment.txt
+++ b/forge-gui/res/cardsfolder/s/seatower_imprisonment.txt
@@ -5,5 +5,7 @@ K:Enchant:Creature.YouDontCtrl,Planeswalker.YouDontCtrl:creature or planeswalker
 SVar:AttachAILogic:Curse
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigConjure | TriggerDescription$ When CARDNAME enters, conjure a card named Soldiers of the Watch onto the battlefield.
 SVar:TrigConjure:DB$ MakeCard | Conjure$ True | Name$ Soldiers of the Watch | Zone$ Battlefield
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. & CARDNAME's activated abilities can't be activated. | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack | ValidCard$ Card.EnchantedBy | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBlock | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
 Oracle:Enchant creature or planeswalker you don't control\nWhen Seatower Imprisonment enters, conjure a card named Soldiers of the Watch onto the battlefield.\nEnchanted permanent can't attack or block and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/s/seatower_imprisonment.txt
+++ b/forge-gui/res/cardsfolder/s/seatower_imprisonment.txt
@@ -5,7 +5,5 @@ K:Enchant:Creature.YouDontCtrl,Planeswalker.YouDontCtrl:creature or planeswalker
 SVar:AttachAILogic:Curse
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigConjure | TriggerDescription$ When CARDNAME enters, conjure a card named Soldiers of the Watch onto the battlefield.
 SVar:TrigConjure:DB$ MakeCard | Conjure$ True | Name$ Soldiers of the Watch | Zone$ Battlefield
-S:Mode$ CantAttack | ValidCard$ Card.EnchantedBy | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBlock | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack,CantBlock,CantBeActivated | ValidCard$ Card.EnchantedBy | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
 Oracle:Enchant creature or planeswalker you don't control\nWhen Seatower Imprisonment enters, conjure a card named Soldiers of the Watch onto the battlefield.\nEnchanted permanent can't attack or block and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/s/serra_bestiary.txt
+++ b/forge-gui/res/cardsfolder/s/serra_bestiary.txt
@@ -5,7 +5,5 @@ K:Enchant:Creature
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUpkeep | TriggerDescription$ At the beginning of your upkeep, sacrifice CARDNAME unless you pay {W}{W}.
 SVar:TrigUpkeep:DB$ Sacrifice | UnlessPayer$ You | UnlessCost$ W W
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block, and its activated abilities with {T} in their costs can't be activated.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block, and its activated abilities with {T} in their costs can't be activated.
-S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated.hasTapCost | Secondary$ True | Description$ Enchanted creature can't attack or block, and its activated abilities with {T} in their costs can't be activated.
+S:Mode$ CantAttack,CantBlock,CantBeActivated | ValidCard$ Creature.EnchantedBy | ValidSA$ Activated.hasTapCost | Description$ Enchanted creature can't attack or block, and its activated abilities with {T} in their costs can't be activated.
 Oracle:Enchant creature\nAt the beginning of your upkeep, sacrifice Serra Bestiary unless you pay {W}{W}.\nEnchanted creature can't attack or block, and its activated abilities with {T} in their costs can't be activated.

--- a/forge-gui/res/cardsfolder/s/serra_bestiary.txt
+++ b/forge-gui/res/cardsfolder/s/serra_bestiary.txt
@@ -5,6 +5,7 @@ K:Enchant:Creature
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUpkeep | TriggerDescription$ At the beginning of your upkeep, sacrifice CARDNAME unless you pay {W}{W}.
 SVar:TrigUpkeep:DB$ Sacrifice | UnlessPayer$ You | UnlessCost$ W W
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Enchanted creature can't attack or block, and its activated abilities with {T} in their costs can't be activated.
-S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated.hasTapCost
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block, and its activated abilities with {T} in their costs can't be activated.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block, and its activated abilities with {T} in their costs can't be activated.
+S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | ValidSA$ Activated.hasTapCost | Secondary$ True | Description$ Enchanted creature can't attack or block, and its activated abilities with {T} in their costs can't be activated.
 Oracle:Enchant creature\nAt the beginning of your upkeep, sacrifice Serra Bestiary unless you pay {W}{W}.\nEnchanted creature can't attack or block, and its activated abilities with {T} in their costs can't be activated.

--- a/forge-gui/res/cardsfolder/s/shauku_endbringer.txt
+++ b/forge-gui/res/cardsfolder/s/shauku_endbringer.txt
@@ -3,7 +3,7 @@ ManaCost:5 B B
 Types:Legendary Creature Vampire
 PT:5/5
 K:Flying
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack. | IsPresent$ Creature | PresentCompare$ GT1 | Description$ CARDNAME can't attack if another creature is on the battlefield.
+S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Creature | PresentCompare$ GT1 | Description$ CARDNAME can't attack if another creature is on the battlefield.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigLoseLife | TriggerDescription$ At the beginning of your upkeep, you lose 3 life.
 A:AB$ ChangeZone | Cost$ T | ValidTgts$ Creature | Origin$ Battlefield | Destination$ Exile | TgtPrompt$ Select target creature | SubAbility$ DBCounter | SpellDescription$ Exile target creature and put a +1/+1 counter on NICKNAME.
 SVar:TrigLoseLife:DB$ LoseLife | Defined$ You | LifeAmount$ 3

--- a/forge-gui/res/cardsfolder/s/sigardas_imprisonment.txt
+++ b/forge-gui/res/cardsfolder/s/sigardas_imprisonment.txt
@@ -3,8 +3,7 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
 A:AB$ ChangeZone | Cost$ 4 W | Defined$ Enchanted | Origin$ Battlefield | Destination$ Exile | SubAbility$ DBToken | SpellDescription$ Exile enchanted creature.
 SVar:DBToken:DB$ Token | TokenScript$ c_a_blood_draw | SpellDescription$ Create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
 SVar:NonStackingAttachEffect:True

--- a/forge-gui/res/cardsfolder/s/sigardas_imprisonment.txt
+++ b/forge-gui/res/cardsfolder/s/sigardas_imprisonment.txt
@@ -3,7 +3,8 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
 A:AB$ ChangeZone | Cost$ 4 W | Defined$ Enchanted | Origin$ Battlefield | Destination$ Exile | SubAbility$ DBToken | SpellDescription$ Exile enchanted creature.
 SVar:DBToken:DB$ Token | TokenScript$ c_a_blood_draw | SpellDescription$ Create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
 SVar:NonStackingAttachEffect:True

--- a/forge-gui/res/cardsfolder/s/silburlind_snapper.txt
+++ b/forge-gui/res/cardsfolder/s/silburlind_snapper.txt
@@ -2,7 +2,7 @@ Name:Silburlind Snapper
 ManaCost:5 U
 Types:Creature Turtle
 PT:6/6
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack. | CheckSVar$ X | SVarCompare$ EQ0 | Description$ CARDNAME can't attack unless you've cast a noncreature spell this turn.
+S:Mode$ CantAttack | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ EQ0 | Description$ CARDNAME can't attack unless you've cast a noncreature spell this turn.
 SVar:X:Count$ThisTurnCast_Card.nonCreature+YouCtrl
 SVar:BuffedBy:Card.nonCreature+nonLand
 Oracle:Silburlind Snapper can't attack unless you've cast a noncreature spell this turn.

--- a/forge-gui/res/cardsfolder/s/sluggishness.txt
+++ b/forge-gui/res/cardsfolder/s/sluggishness.txt
@@ -3,7 +3,7 @@ ManaCost:1 R
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't block. | Description$ Enchanted creature can't block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't block.
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigChangeZone | TriggerDescription$ When CARDNAME is put into a graveyard from the battlefield, return CARDNAME to its owner's hand.
 SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | Defined$ TriggeredNewCardLKICopy
 SVar:SacMe:2

--- a/forge-gui/res/cardsfolder/s/slumbering_dragon.txt
+++ b/forge-gui/res/cardsfolder/s/slumbering_dragon.txt
@@ -3,7 +3,8 @@ ManaCost:R
 Types:Creature Dragon
 PT:3/3
 K:Flying
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack or block. | CheckSVar$ X | SVarCompare$ LT5 | Description$ CARDNAME can't attack or block unless it has five or more +1/+1 counters on it.
+S:Mode$ CantAttack | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ LT5 | Description$ CARDNAME can't attack or block unless it has five or more +1/+1 counters on it.
+S:Mode$ CantBlock | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ LT5 | Secondary$ True | Description$ CARDNAME can't attack or block unless it has five or more +1/+1 counters on it.
 T:Mode$ Attacks | ValidCard$ Creature | Attacked$ You,Planeswalker.YouCtrl | TriggerZones$ Battlefield | Execute$ DragonWake | TriggerDescription$ Whenever a creature attacks you or a planeswalker you control, put a +1/+1 counter on CARDNAME.
 SVar:DragonWake:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
 SVar:X:Count$CardCounters.P1P1

--- a/forge-gui/res/cardsfolder/s/slumbering_dragon.txt
+++ b/forge-gui/res/cardsfolder/s/slumbering_dragon.txt
@@ -3,8 +3,7 @@ ManaCost:R
 Types:Creature Dragon
 PT:3/3
 K:Flying
-S:Mode$ CantAttack | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ LT5 | Description$ CARDNAME can't attack or block unless it has five or more +1/+1 counters on it.
-S:Mode$ CantBlock | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ LT5 | Secondary$ True | Description$ CARDNAME can't attack or block unless it has five or more +1/+1 counters on it.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ LT5 | Description$ CARDNAME can't attack or block unless it has five or more +1/+1 counters on it.
 T:Mode$ Attacks | ValidCard$ Creature | Attacked$ You,Planeswalker.YouCtrl | TriggerZones$ Battlefield | Execute$ DragonWake | TriggerDescription$ Whenever a creature attacks you or a planeswalker you control, put a +1/+1 counter on CARDNAME.
 SVar:DragonWake:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
 SVar:X:Count$CardCounters.P1P1

--- a/forge-gui/res/cardsfolder/s/song_of_serenity.txt
+++ b/forge-gui/res/cardsfolder/s/song_of_serenity.txt
@@ -1,7 +1,8 @@
 Name:Song of Serenity
 ManaCost:1 G
 Types:Enchantment
-S:Mode$ Continuous | Affected$ Creature.enchanted | AddHiddenKeyword$ CARDNAME can't attack or block. | Description$ Creatures that are enchanted can't attack or block.
+S:Mode$ CantAttack | ValidCard$ Creature.enchanted | Description$ Creatures that are enchanted can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.enchanted | Secondary$ True | Description$ Creatures that are enchanted can't attack or block.
 SVar:NonStackingEffect:True
 AI:RemoveDeck:Random
 Oracle:Creatures that are enchanted can't attack or block.

--- a/forge-gui/res/cardsfolder/s/song_of_serenity.txt
+++ b/forge-gui/res/cardsfolder/s/song_of_serenity.txt
@@ -1,8 +1,7 @@
 Name:Song of Serenity
 ManaCost:1 G
 Types:Enchantment
-S:Mode$ CantAttack | ValidCard$ Creature.enchanted | Description$ Creatures that are enchanted can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.enchanted | Secondary$ True | Description$ Creatures that are enchanted can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.enchanted | Description$ Creatures that are enchanted can't attack or block.
 SVar:NonStackingEffect:True
 AI:RemoveDeck:Random
 Oracle:Creatures that are enchanted can't attack or block.

--- a/forge-gui/res/cardsfolder/s/stasis_cocoon.txt
+++ b/forge-gui/res/cardsfolder/s/stasis_cocoon.txt
@@ -4,6 +4,7 @@ Types:Enchantment Aura
 K:Enchant:Artifact
 SVar:AttachAITgts:Creature,Card.hasAbility Activated
 SVar:AttachAILogic:Curse
+S:Mode$ CantAttack | ValidCard$ Card.EnchantedBy | Description$ Enchanted artifact can't attack or block, and its activated abilities can't be activated.
+S:Mode$ CantBlock | ValidCard$ Card.EnchantedBy | Secondary$ True | Enchanted artifact can't attack or block, and its activated abilities can't be activated.
 S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | Description$ Enchanted artifact can't attack or block, and its activated abilities can't be activated.
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block.
 Oracle:Enchant artifact\nEnchanted artifact can't attack or block, and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/s/stasis_cocoon.txt
+++ b/forge-gui/res/cardsfolder/s/stasis_cocoon.txt
@@ -4,7 +4,5 @@ Types:Enchantment Aura
 K:Enchant:Artifact
 SVar:AttachAITgts:Creature,Card.hasAbility Activated
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Card.EnchantedBy | Description$ Enchanted artifact can't attack or block, and its activated abilities can't be activated.
-S:Mode$ CantBlock | ValidCard$ Card.EnchantedBy | Secondary$ True | Enchanted artifact can't attack or block, and its activated abilities can't be activated.
-S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | Description$ Enchanted artifact can't attack or block, and its activated abilities can't be activated.
+S:Mode$ CantAttack,CantBlock,CantBeActivated | ValidCard$ Card.EnchantedBy | Description$ Enchanted artifact can't attack or block, and its activated abilities can't be activated.
 Oracle:Enchant artifact\nEnchanted artifact can't attack or block, and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/s/steelclad_serpent.txt
+++ b/forge-gui/res/cardsfolder/s/steelclad_serpent.txt
@@ -2,6 +2,6 @@ Name:Steelclad Serpent
 ManaCost:5 U
 Types:Artifact Creature Serpent
 PT:4/5
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack. | IsPresent$ Artifact.YouCtrl+Other | PresentCompare$ EQ0 | Description$ CARDNAME can't attack unless you control another artifact.
+S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Artifact.YouCtrl+Other | PresentCompare$ EQ0 | Description$ CARDNAME can't attack unless you control another artifact.
 AI:RemoveDeck:Random
 Oracle:Steelclad Serpent can't attack unless you control another artifact.

--- a/forge-gui/res/cardsfolder/s/suppression_bonds.txt
+++ b/forge-gui/res/cardsfolder/s/suppression_bonds.txt
@@ -3,7 +3,5 @@ ManaCost:3 W
 Types:Enchantment Aura
 K:Enchant:Permanent.nonLand:nonland permanent
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Card.EnchantedBy | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBlock | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack,CantBlock,CantBeActivated | ValidCard$ Card.EnchantedBy | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
 Oracle:Enchant nonland permanent\nEnchanted permanent can't attack or block, and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/s/suppression_bonds.txt
+++ b/forge-gui/res/cardsfolder/s/suppression_bonds.txt
@@ -3,5 +3,7 @@ ManaCost:3 W
 Types:Enchantment Aura
 K:Enchant:Permanent.nonLand:nonland permanent
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Permanent.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. & CARDNAME's activated abilities can't be activated. | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack | ValidCard$ Card.EnchantedBy | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBlock | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent can't attack or block and its activated abilities can't be activated.
 Oracle:Enchant nonland permanent\nEnchanted permanent can't attack or block, and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/t/tazeem.txt
+++ b/forge-gui/res/cardsfolder/t/tazeem.txt
@@ -1,7 +1,7 @@
 Name:Tazeem
 ManaCost:no cost
 Types:Plane Zendikar
-S:Mode$ Continuous | Affected$ Creature | EffectZone$ Command | AddHiddenKeyword$ CARDNAME can't block. | Description$ Creatures can't block.
+S:Mode$ CantBlock | ValidCard$ Creature | EffectZone$ Command | Description$ Creatures can't block.
 T:Mode$ ChaosEnsues | TriggerZones$ Command | Execute$ RolledChaos | TriggerDescription$ Whenever chaos ensues, draw a card for each land you control.
 SVar:RolledChaos:DB$ Draw | NumCards$ Y | Defined$ You
 SVar:Y:Count$Valid Land.YouCtrl

--- a/forge-gui/res/cardsfolder/t/the_ancient_one.txt
+++ b/forge-gui/res/cardsfolder/t/the_ancient_one.txt
@@ -2,7 +2,8 @@ Name:The Ancient One
 ManaCost:U B
 Types:Legendary Creature Spirit God
 PT:8/8
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack or block. | IsPresent$ Permanent.YouOwn | PresentZone$ Graveyard | PresentCompare$ LE7 | Description$ Descend 8 — CARDNAME can't attack or block unless there are eight or more permanent cards in your graveyard.
+S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Permanent.YouOwn | PresentZone$ Graveyard | PresentCompare$ LE7 | Description$ Descend 8 — CARDNAME can't attack or block unless there are eight or more permanent cards in your graveyard.
+S:Mode$ CantBlock | ValidCard$ Card.Self | IsPresent$ Permanent.YouOwn | PresentZone$ Graveyard | PresentCompare$ LE7 | Secondary$ True | Description$ Descend 8 — CARDNAME can't attack or block unless there are eight or more permanent cards in your graveyard.
 A:AB$ Draw | Cost$ 2 U B | SubAbility$ DBDiscard | SpellDescription$ Draw a card, then discard a card. When you discard a card this way, target player mills cards equal to its mana value.
 SVar:DBDiscard:DB$ Discard | Defined$ You | Mode$ TgtChoose | NumCards$ 1 | RememberDiscarded$ True | SubAbility$ DBImmediateTrig | StackDescription$ then discard a card.
 SVar:DBImmediateTrig:DB$ ImmediateTrigger | ConditionDefined$ Remembered | ConditionPresent$ Card | Execute$ TrigMill | RememberObjects$ Remembered | SubAbility$ DBCleanup | TriggerDescription$ When you discard a card this way, target player mills cards equal to its mana value.

--- a/forge-gui/res/cardsfolder/t/the_ancient_one.txt
+++ b/forge-gui/res/cardsfolder/t/the_ancient_one.txt
@@ -2,8 +2,7 @@ Name:The Ancient One
 ManaCost:U B
 Types:Legendary Creature Spirit God
 PT:8/8
-S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Permanent.YouOwn | PresentZone$ Graveyard | PresentCompare$ LE7 | Description$ Descend 8 — CARDNAME can't attack or block unless there are eight or more permanent cards in your graveyard.
-S:Mode$ CantBlock | ValidCard$ Card.Self | IsPresent$ Permanent.YouOwn | PresentZone$ Graveyard | PresentCompare$ LE7 | Secondary$ True | Description$ Descend 8 — CARDNAME can't attack or block unless there are eight or more permanent cards in your graveyard.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Card.Self | IsPresent$ Permanent.YouOwn | PresentZone$ Graveyard | PresentCompare$ LE7 | Description$ Descend 8 — CARDNAME can't attack or block unless there are eight or more permanent cards in your graveyard.
 A:AB$ Draw | Cost$ 2 U B | SubAbility$ DBDiscard | SpellDescription$ Draw a card, then discard a card. When you discard a card this way, target player mills cards equal to its mana value.
 SVar:DBDiscard:DB$ Discard | Defined$ You | Mode$ TgtChoose | NumCards$ 1 | RememberDiscarded$ True | SubAbility$ DBImmediateTrig | StackDescription$ then discard a card.
 SVar:DBImmediateTrig:DB$ ImmediateTrigger | ConditionDefined$ Remembered | ConditionPresent$ Card | Execute$ TrigMill | RememberObjects$ Remembered | SubAbility$ DBCleanup | TriggerDescription$ When you discard a card this way, target player mills cards equal to its mana value.

--- a/forge-gui/res/cardsfolder/t/topiary_stomper.txt
+++ b/forge-gui/res/cardsfolder/t/topiary_stomper.txt
@@ -5,6 +5,7 @@ PT:4/4
 K:Vigilance
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSearch | TriggerDescription$ When CARDNAME enters, search your library for a basic land card, put it onto the battlefield tapped, then shuffle.
 SVar:TrigSearch:DB$ ChangeZone | Origin$ Library | Destination$ Battlefield | ChangeType$ Land.Basic | ChangeNum$ 1 | Tapped$ True
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack or block. | IsPresent$ Land.YouCtrl | PresentCompare$ LT7 | Description$ CARDNAME can't attack or block unless you control seven or more lands.
+S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Land.YouCtrl | PresentCompare$ LT7 | Description$ CARDNAME can't attack or block unless you control seven or more lands.
+S:Mode$ CantBlock | ValidCard$ Card.Self | IsPresent$ Land.YouCtrl | PresentCompare$ LT7 | Secondary$ True | Description$ CARDNAME can't attack or block unless you control seven or more lands.
 SVar:BuffedBy:Land
 Oracle:Vigilance\nWhen Topiary Stomper enters, search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nTopiary Stomper can't attack or block unless you control seven or more lands.

--- a/forge-gui/res/cardsfolder/t/topiary_stomper.txt
+++ b/forge-gui/res/cardsfolder/t/topiary_stomper.txt
@@ -5,7 +5,6 @@ PT:4/4
 K:Vigilance
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSearch | TriggerDescription$ When CARDNAME enters, search your library for a basic land card, put it onto the battlefield tapped, then shuffle.
 SVar:TrigSearch:DB$ ChangeZone | Origin$ Library | Destination$ Battlefield | ChangeType$ Land.Basic | ChangeNum$ 1 | Tapped$ True
-S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Land.YouCtrl | PresentCompare$ LT7 | Description$ CARDNAME can't attack or block unless you control seven or more lands.
-S:Mode$ CantBlock | ValidCard$ Card.Self | IsPresent$ Land.YouCtrl | PresentCompare$ LT7 | Secondary$ True | Description$ CARDNAME can't attack or block unless you control seven or more lands.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Card.Self | IsPresent$ Land.YouCtrl | PresentCompare$ LT7 | Description$ CARDNAME can't attack or block unless you control seven or more lands.
 SVar:BuffedBy:Land
 Oracle:Vigilance\nWhen Topiary Stomper enters, search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nTopiary Stomper can't attack or block unless you control seven or more lands.

--- a/forge-gui/res/cardsfolder/t/training_drone.txt
+++ b/forge-gui/res/cardsfolder/t/training_drone.txt
@@ -2,8 +2,7 @@ Name:Training Drone
 ManaCost:3
 Types:Artifact Creature Drone
 PT:4/4
-S:Mode$ CantAttack | ValidCard$ Card.Self+unequipped | Description$ CARDNAME can't attack or block unless it's equipped.
-S:Mode$ CantBlock | ValidCard$ Card.Self+unequipped | Secondary$ True | Description$ CARDNAME can't attack or block unless it's equipped.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Card.Self+unequipped | Description$ CARDNAME can't attack or block unless it's equipped.
 SVar:BuffedBy:Artifact.Equipment
 SVar:EquipMe:Once
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/t/training_drone.txt
+++ b/forge-gui/res/cardsfolder/t/training_drone.txt
@@ -2,7 +2,7 @@ Name:Training Drone
 ManaCost:3
 Types:Artifact Creature Drone
 PT:4/4
-S:Mode$ CantAttack,CantBlock | ValidCard$ Card.Self+unequipped | Description$ CARDNAME can't attack or block unless it's equipped.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Card.Self+!equipped | Description$ CARDNAME can't attack or block unless it's equipped.
 SVar:BuffedBy:Artifact.Equipment
 SVar:EquipMe:Once
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/t/training_drone.txt
+++ b/forge-gui/res/cardsfolder/t/training_drone.txt
@@ -2,7 +2,8 @@ Name:Training Drone
 ManaCost:3
 Types:Artifact Creature Drone
 PT:4/4
-S:Mode$ Continuous | Affected$ Card.Self+unequipped | AddHiddenKeyword$ CARDNAME can't attack. & CARDNAME can't block. | Description$ CARDNAME can't attack or block unless it's equipped.
+S:Mode$ CantAttack | ValidCard$ Card.Self+unequipped | Description$ CARDNAME can't attack or block unless it's equipped.
+S:Mode$ CantBlock | ValidCard$ Card.Self+unequipped | Secondary$ True | Description$ CARDNAME can't attack or block unless it's equipped.
 SVar:BuffedBy:Artifact.Equipment
 SVar:EquipMe:Once
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/t/trapped_in_the_tower.txt
+++ b/forge-gui/res/cardsfolder/t/trapped_in_the_tower.txt
@@ -3,5 +3,7 @@ ManaCost:1 W
 Types:Enchantment Aura
 K:Enchant:Creature.withoutFlying:creature without flying
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. & CARDNAME's activated abilities can't be activated. | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantBeActivated | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
 Oracle:Enchant creature without flying\nEnchanted creature can't attack or block, and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/t/trapped_in_the_tower.txt
+++ b/forge-gui/res/cardsfolder/t/trapped_in_the_tower.txt
@@ -3,7 +3,5 @@ ManaCost:1 W
 Types:Enchantment Aura
 K:Enchant:Creature.withoutFlying:creature without flying
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
-S:Mode$ CantBeActivated | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
+S:Mode$ CantAttack,CantBlock,CantBeActivated | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
 Oracle:Enchant creature without flying\nEnchanted creature can't attack or block, and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/u/undying_rage.txt
+++ b/forge-gui/res/cardsfolder/u/undying_rage.txt
@@ -3,7 +3,8 @@ ManaCost:2 R
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Pump
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 2 | AddToughness$ 2 | AddHiddenKeyword$ CARDNAME can't block. | Description$ Enchanted creature gets +2/+2 and can't block.
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 2 | AddToughness$ 2 | Description$ Enchanted creature gets +2/+2 and can't block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature gets +2/+2 and can't block.
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigChangeZone | TriggerDescription$ When CARDNAME is put into a graveyard from the battlefield, return CARDNAME to its owner's hand.
 SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | Defined$ TriggeredNewCardLKICopy
 SVar:SacMe:2

--- a/forge-gui/res/cardsfolder/u/utopia_vow.txt
+++ b/forge-gui/res/cardsfolder/u/utopia_vow.txt
@@ -3,7 +3,9 @@ ManaCost:1 G
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack or block. | AddAbility$ AnyMana | Description$ Enchanted creature can't attack or block. Enchanted creature has "{T}: Add one mana of any color."
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddAbility$ AnyMana | Description$ Enchanted creature has "{T}: Add one mana of any color."
 SVar:AnyMana:AB$ Mana | Cost$ T | Produced$ Any | SpellDescription$ Add one mana of any color.
 SVar:NonStackingAttachEffect:True
 # TODO: For AI, this acts as a curse spell to lock the opponent's creature while giving the opponent mana advantage (similar to Path to Exile). Could probably be improved to be used on own useless creatures instead when possible.

--- a/forge-gui/res/cardsfolder/u/utopia_vow.txt
+++ b/forge-gui/res/cardsfolder/u/utopia_vow.txt
@@ -3,8 +3,7 @@ ManaCost:1 G
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
-S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Secondary$ True | Description$ Enchanted creature can't attack or block.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddAbility$ AnyMana | Description$ Enchanted creature has "{T}: Add one mana of any color."
 SVar:AnyMana:AB$ Mana | Cost$ T | Produced$ Any | SpellDescription$ Add one mana of any color.
 SVar:NonStackingAttachEffect:True

--- a/forge-gui/res/cardsfolder/v/vantress_gargoyle.txt
+++ b/forge-gui/res/cardsfolder/v/vantress_gargoyle.txt
@@ -4,7 +4,7 @@ Types:Artifact Creature Gargoyle
 PT:5/4
 K:Flying
 S:Mode$ CantAttack | ValidCard$ Card.Self | UnlessDefender$ HasCardsInGraveyard_Card_GE7 | Description$ CARDNAME can't attack unless defending player has seven or more cards in their graveyard.
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't block. | CheckSVar$ X | SVarCompare$ LT4 | Description$ CARDNAME can't block unless you have four or more cards in hand.
+S:Mode$ CantBlock | ValidCard$ Card.Self | CheckSVar$ X | SVarCompare$ LT4 | Description$ CARDNAME can't block unless you have four or more cards in hand.
 SVar:X:Count$ValidHand Card.YouOwn
 A:AB$ Mill | Cost$ T | NumCards$ 1 | Defined$ Player | SpellDescription$ Each player mills a card.
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/v/veteran_brawlers.txt
+++ b/forge-gui/res/cardsfolder/v/veteran_brawlers.txt
@@ -3,5 +3,5 @@ ManaCost:1 R
 Types:Creature Human Soldier
 PT:4/4
 S:Mode$ CantAttack | ValidCard$ Card.Self | IfDefenderControls$ Land.untapped | Description$ CARDNAME can't attack if defending player controls an untapped land.
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't block. | IsPresent$ Land.YouCtrl+untapped | Description$ CARDNAME can't block if you control an untapped land.
+S:Mode$ CantBlock | ValidCard$ Card.Self | IsPresent$ Land.YouCtrl+untapped | Description$ CARDNAME can't block if you control an untapped land.
 Oracle:Veteran Brawlers can't attack if defending player controls an untapped land.\nVeteran Brawlers can't block if you control an untapped land.

--- a/forge-gui/res/cardsfolder/v/visions_of_brutality.txt
+++ b/forge-gui/res/cardsfolder/v/visions_of_brutality.txt
@@ -4,7 +4,7 @@ Types:Enchantment Aura
 K:Devoid
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't block. | Description$ Enchanted creature can't block.
+S:Mode$ CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't block.
 T:Mode$ DamageDealtOnce | ValidSource$ Card.AttachedBy | Execute$ TrigLoseLife | TriggerZones$ Battlefield | TriggerDescription$ Whenever enchanted creature deals damage, its controller loses that much life.
 SVar:TrigLoseLife:DB$ LoseLife | Defined$ TriggeredSourceController | LifeAmount$ X
 SVar:X:TriggerCount$DamageAmount

--- a/forge-gui/res/cardsfolder/w/war_falcon.txt
+++ b/forge-gui/res/cardsfolder/w/war_falcon.txt
@@ -3,7 +3,7 @@ ManaCost:W
 Types:Creature Bird
 PT:2/1
 K:Flying
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack. | IsPresent$ Knight.YouCtrl,Soldier.YouCtrl | PresentCompare$ EQ0 | Description$ CARDNAME can't attack unless you control a Knight or Soldier.
+S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Knight.YouCtrl,Soldier.YouCtrl | PresentCompare$ EQ0 | Description$ CARDNAME can't attack unless you control a Knight or Soldier.
 SVar:BuffedBy:Knight,Soldier
 DeckNeeds:Type$Knight|Soldier
 Oracle:Flying\nWar Falcon can't attack unless you control a Knight or a Soldier.

--- a/forge-gui/res/cardsfolder/w/warden_of_the_chained.txt
+++ b/forge-gui/res/cardsfolder/w/warden_of_the_chained.txt
@@ -3,5 +3,5 @@ ManaCost:1 R G
 Types:Creature Minotaur Warrior
 PT:4/4
 K:Trample
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack. | IsPresent$ Creature.powerGE4+YouCtrl+Other | PresentCompare$ EQ0 | Description$ CARDNAME can't attack unless you control another creature with power 4 or greater.
+S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Creature.powerGE4+YouCtrl+Other | PresentCompare$ EQ0 | Description$ CARDNAME can't attack unless you control another creature with power 4 or greater.
 Oracle:Trample\nWarden of the Chained can't attack unless you control another creature with power 4 or greater.

--- a/forge-gui/res/cardsfolder/w/wayward_swordtooth.txt
+++ b/forge-gui/res/cardsfolder/w/wayward_swordtooth.txt
@@ -4,6 +4,7 @@ Types:Creature Dinosaur
 PT:5/5
 K:Ascend
 S:Mode$ Continuous | Affected$ You | AdjustLandPlays$ 1 | Description$ You may play an additional land on each of your turns.
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack or block. | CheckSVar$ X | SVarCompare$ EQ0 | Description$ CARDNAME can't attack or block unless you have the city's blessing.
-SVar:X:Count$Blessing.1.0
+S:Mode$ CantAttack | ValidCard$ Card.Self | CheckSVar$ X | Description$ CARDNAME can't attack or block unless you have the city's blessing.
+S:Mode$ CantBlock | ValidCard$ Card.Self | CheckSVar$ X | Secondary$ True | Description$ CARDNAME can't attack or block unless you have the city's blessing.
+SVar:X:Count$Blessing.0.1
 Oracle:Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nYou may play an additional land on each of your turns.\nWayward Swordtooth can't attack or block unless you have the city's blessing.

--- a/forge-gui/res/cardsfolder/w/wayward_swordtooth.txt
+++ b/forge-gui/res/cardsfolder/w/wayward_swordtooth.txt
@@ -4,7 +4,6 @@ Types:Creature Dinosaur
 PT:5/5
 K:Ascend
 S:Mode$ Continuous | Affected$ You | AdjustLandPlays$ 1 | Description$ You may play an additional land on each of your turns.
-S:Mode$ CantAttack | ValidCard$ Card.Self | CheckSVar$ X | Description$ CARDNAME can't attack or block unless you have the city's blessing.
-S:Mode$ CantBlock | ValidCard$ Card.Self | CheckSVar$ X | Secondary$ True | Description$ CARDNAME can't attack or block unless you have the city's blessing.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Card.Self | CheckSVar$ X | Description$ CARDNAME can't attack or block unless you have the city's blessing.
 SVar:X:Count$Blessing.0.1
 Oracle:Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nYou may play an additional land on each of your turns.\nWayward Swordtooth can't attack or block unless you have the city's blessing.

--- a/forge-gui/res/cardsfolder/w/weight_of_conscience.txt
+++ b/forge-gui/res/cardsfolder/w/weight_of_conscience.txt
@@ -3,7 +3,7 @@ ManaCost:1 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddHiddenKeyword$ CARDNAME can't attack. | Description$ Enchanted creature can't attack.
+S:Mode$ CantAttack | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack.
 A:AB$ ChangeZone | Cost$ tapXType<2/Creature.sharesCreatureTypeWith/creatures that share a creature type> | Defined$ Enchanted | Origin$ Battlefield | Destination$ Exile | SpellDescription$ Exile enchanted creature.
 SVar:NonStackingAttachEffect:True
 Oracle:Enchant creature\nEnchanted creature can't attack.\nTap two untapped creatures you control that share a creature type: Exile enchanted creature.

--- a/forge-gui/res/cardsfolder/w/wirecat.txt
+++ b/forge-gui/res/cardsfolder/w/wirecat.txt
@@ -2,5 +2,6 @@ Name:Wirecat
 ManaCost:4
 Types:Artifact Creature Cat
 PT:4/3
-S:Mode$ Continuous | Affected$ Card.Self | AddHiddenKeyword$ CARDNAME can't attack or block. | IsPresent$ Enchantment | Description$ CARDNAME can't attack or block if an enchantment is on the battlefield.
+S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Enchantment | Description$ CARDNAME can't attack or block if an enchantment is on the battlefield.
+S:Mode$ CantBlock | ValidCard$ Card.Self | IsPresent$ Enchantment | Secondary$ True | Description$ CARDNAME can't attack or block if an enchantment is on the battlefield.
 Oracle:Wirecat can't attack or block if an enchantment is on the battlefield.

--- a/forge-gui/res/cardsfolder/w/wirecat.txt
+++ b/forge-gui/res/cardsfolder/w/wirecat.txt
@@ -2,6 +2,5 @@ Name:Wirecat
 ManaCost:4
 Types:Artifact Creature Cat
 PT:4/3
-S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Enchantment | Description$ CARDNAME can't attack or block if an enchantment is on the battlefield.
-S:Mode$ CantBlock | ValidCard$ Card.Self | IsPresent$ Enchantment | Secondary$ True | Description$ CARDNAME can't attack or block if an enchantment is on the battlefield.
+S:Mode$ CantAttack,CantBlock | ValidCard$ Card.Self | IsPresent$ Enchantment | Description$ CARDNAME can't attack or block if an enchantment is on the battlefield.
 Oracle:Wirecat can't attack or block if an enchantment is on the battlefield.


### PR DESCRIPTION
Part of #3307

Removed `K:CARDNAME can't block.`

and updated "S:Mode"  Statics that did add `CARDNAME can't attack or block.` & `CARDNAME's activated abilities can't be activated.`

i didn't updated Cards yet that does this via Pump/Animate/Effect


`Volrath's Curse` and `Lost in Thought` are still tricky