### PR TITLE
Adventure Console "give card" Updates

### DIFF
--- a/forge-core/src/main/java/forge/StaticData.java
+++ b/forge-core/src/main/java/forge/StaticData.java
@@ -249,6 +249,15 @@ public class StaticData {
     }
 
     /**
+     * Retrieve a PaperCard by looking at all available card databases for any matching print.
+     * @param cardName The name of the card
+     * @return PaperCard instance found in one of the available CardDb databases, or <code>null</code> if not found.
+     */
+    public PaperCard fetchCard(final String cardName) {
+        return fetchCard(cardName, null, null);
+    }
+
+    /**
      * Retrieve a PaperCard by looking at all available card databases;
      * @param cardName The name of the card
      * @param setCode The card Edition code

--- a/forge-core/src/main/java/forge/card/CardDb.java
+++ b/forge-core/src/main/java/forge/card/CardDb.java
@@ -138,8 +138,6 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
 
         public static String compose(String cardName, String setCode, String collectorNumber) {
             String requestInfo = compose(cardName, setCode);
-            if(collectorNumber == null || collectorNumber.isEmpty())
-                return requestInfo;
             // CollectorNumber will be wrapped in square brackets
             collectorNumber = preprocessCollectorNumber(collectorNumber);
             return requestInfo + NameSetSeparator + collectorNumber;

--- a/forge-core/src/main/java/forge/card/CardDb.java
+++ b/forge-core/src/main/java/forge/card/CardDb.java
@@ -138,6 +138,8 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
 
         public static String compose(String cardName, String setCode, String collectorNumber) {
             String requestInfo = compose(cardName, setCode);
+            if(collectorNumber == null || collectorNumber.isEmpty())
+                return requestInfo;
             // CollectorNumber will be wrapped in square brackets
             collectorNumber = preprocessCollectorNumber(collectorNumber);
             return requestInfo + NameSetSeparator + collectorNumber;

--- a/forge-core/src/main/java/forge/card/CardEdition.java
+++ b/forge-core/src/main/java/forge/card/CardEdition.java
@@ -417,6 +417,17 @@ public final class CardEdition implements Comparable<CardEdition> {
         return this.cardsInSetLookupMap.get(cardName);
     }
 
+    public CardInSet getCardFromCollectorNumber(String collectorNumber) {
+        if(collectorNumber == null || collectorNumber.isEmpty())
+            return null;
+        for(CardInSet c : this.cardsInSet) {
+            //Could build a map for this one too if it's used for more than one-offs.
+            if (c.collectorNumber.equalsIgnoreCase(collectorNumber))
+                return c;
+        }
+        return null;
+    }
+
     public boolean isRebalanced(String cardName) {
         for (CardInSet cis : getRebalancedCards()) {
             if (cis.name.equals(cardName)) {

--- a/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
+++ b/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
@@ -654,8 +654,12 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
     }
 
     public void addCard(PaperCard card) {
-        cards.add(card);
-        newCards.add(card);
+        addCard(card, 1);
+    }
+
+    public void addCard(PaperCard card, int amount) {
+        cards.add(card, amount);
+        newCards.add(card, amount);
     }
 
     public void addReward(Reward reward) {


### PR DESCRIPTION
Adds support for an amount parameter to the `give card` and `give nosell card` commands, after the card name (e.g. `give card "Lotus Petal" 3`.)

Adds a `give print` command, which adds a card given a set code and collector number instead of a card name. It also supports the amount parameter. e.g. `give print SLD 7010 4` will give you four copies of the Spongebob Secret Lair Counterspell.

Also makes it possible for the `give card` command to fetch cards in the variant DB, (though the deck editor still doesn't yet support them properly).