### PR TITLE
Cleanup: "During your turn" Oracle update, living metal 

### DIFF
--- a/forge-game/src/main/java/forge/game/keyword/Keyword.java
+++ b/forge-game/src/main/java/forge/game/keyword/Keyword.java
@@ -114,7 +114,7 @@ public enum Keyword {
     LANDWALK("Landwalk", KeywordWithType.class, true, "This creature is unblockable as long as defending player controls {1:%s}."),
     LEVEL_UP("Level up", KeywordWithCost.class, false, "%s: Put a level counter on this. Level up only as a sorcery."),
     LIFELINK("Lifelink", SimpleKeyword.class, true, "Damage dealt by this creature also causes its controller to gain that much life."),
-    LIVING_METAL("Living metal", SimpleKeyword.class, true, "As long as it's your turn, this Vehicle is also a creature."),
+    LIVING_METAL("Living metal", SimpleKeyword.class, true, "During your turn, this Vehicle is also a creature."),
     LIVING_WEAPON("Living Weapon", SimpleKeyword.class, true, "When this Equipment enters, create a 0/0 black Phyrexian Germ creature token, then attach this to it."),
     MADNESS("Madness", KeywordWithCost.class, false, "If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard."),
     MELEE("Melee", SimpleKeyword.class, false, "Whenever this creature attacks, it gets +1/+1 until end of turn for each opponent you attacked this combat."),

--- a/forge-gui/res/cardsfolder/a/arcee_sharpshooter_arcee_acrobatic_coupe.txt
+++ b/forge-gui/res/cardsfolder/a/arcee_sharpshooter_arcee_acrobatic_coupe.txt
@@ -24,4 +24,4 @@ SVar:TrigPutCounters:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ X | SubAbi
 SVar:DBConvert:DB$ SetState | Mode$ Transform
 SVar:X:TriggerObjectsSpellAbilityTargets$Valid Creature.YouCtrl,Vehicle.YouCtrl
 DeckHas:Ability$Counters
-Oracle:Living metal (As long as it's your turn, this Vehicle is also a creature.)\nWhenever you cast a spell that targets one or more creatures or Vehicles you control, put that many +1/+1 counters on Arcee. Convert Arcee.
+Oracle:Living metal (During your turn, this Vehicle is also a creature.)\nWhenever you cast a spell that targets one or more creatures or Vehicles you control, put that many +1/+1 counters on Arcee. Convert Arcee.

--- a/forge-gui/res/cardsfolder/b/blitzwing_cruel_tormentor_blitzwing_adaptive_assailant.txt
+++ b/forge-gui/res/cardsfolder/b/blitzwing_cruel_tormentor_blitzwing_adaptive_assailant.txt
@@ -26,4 +26,4 @@ T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage
 SVar:TrigConvert:DB$ SetState | Mode$ Transform
 SVar:HasAttackEffect:TRUE
 DeckHas:Keyword$Flying|Indestructible
-Oracle:Living metal (As long as it's your turn, this Vehicle is also a creature.)\nAt the beginning of combat on your turn, choose flying or indestructible at random. Blitzwing gains that ability until end of turn.\nWhenever Blitzwing deals combat damage to a player, convert it.
+Oracle:Living metal (During your turn, this Vehicle is also a creature.)\nAt the beginning of combat on your turn, choose flying or indestructible at random. Blitzwing gains that ability until end of turn.\nWhenever Blitzwing deals combat damage to a player, convert it.

--- a/forge-gui/res/cardsfolder/c/cyclonus_the_saboteur_cyclonus_cybertronian_fighter.txt
+++ b/forge-gui/res/cardsfolder/c/cyclonus_the_saboteur_cyclonus_cybertronian_fighter.txt
@@ -26,4 +26,4 @@ SVar:TrigConvert:DB$ SetState | Mode$ Transform | SubAbility$ ExtraBeginningPhas
 SVar:ExtraBeginningPhase:DB$ AddPhase | ExtraPhase$ Beginning | ConditionDefined$ Remembered | ConditionPresent$ Card.Self | ConditionCompare$ GE1 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:HasAttackEffect:TRUE
-Oracle:Living metal (As long as it's your turn, this Vehicle is also a creature.)\nFlying\nWhenever Cyclonus deals combat damage to a player, convert it. If you do, there is an additional beginning phase after this phase. (The beginning phase includes the untap, upkeep, and draw steps.)
+Oracle:Living metal (During your turn, this Vehicle is also a creature.)\nFlying\nWhenever Cyclonus deals combat damage to a player, convert it. If you do, there is an additional beginning phase after this phase. (The beginning phase includes the untap, upkeep, and draw steps.)

--- a/forge-gui/res/cardsfolder/f/flamewar_brash_veteran_flamewar_streetwise_operative.txt
+++ b/forge-gui/res/cardsfolder/f/flamewar_brash_veteran_flamewar_streetwise_operative.txt
@@ -26,4 +26,4 @@ SVar:TrigDig:DB$ Dig | DigNum$ X | ChangeNum$ All | DestinationZone$ Exile | Exi
 SVar:DBConvert:DB$ SetState | Mode$ Transform
 SVar:X:TriggerCount$DamageAmount
 SVar:HasAttackEffect:TRUE
-Oracle:Living metal (As long as it's your turn, this Vehicle is also a creature.)\nMenace, deathtouch\nWhenever Flamewar deals combat damage to a player, exile that many cards from the top of your library face down. Put an intel counter on each of them. Convert Flamewar.
+Oracle:Living metal (During your turn, this Vehicle is also a creature.)\nMenace, deathtouch\nWhenever Flamewar deals combat damage to a player, exile that many cards from the top of your library face down. Put an intel counter on each of them. Convert Flamewar.

--- a/forge-gui/res/cardsfolder/g/goldbug_humanitys_ally_goldbug_scrappy_scout.txt
+++ b/forge-gui/res/cardsfolder/g/goldbug_humanitys_ally_goldbug_scrappy_scout.txt
@@ -24,4 +24,4 @@ T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | IsPresent$ 
 SVar:TrigDraw:DB$ Draw | SubAbility$ DBConvert
 SVar:DBConvert:DB$ SetState | Mode$ Transform
 DeckNeeds:Type$Human
-Oracle:Living metal (As long as it's your turn, this Vehicle is also a creature.)\nHuman spells you control can't be countered\nWhenever Goldbug and at least one Human attack, draw a card and convert Goldbug.
+Oracle:Living metal (During your turn, this Vehicle is also a creature.)\nHuman spells you control can't be countered\nWhenever Goldbug and at least one Human attack, draw a card and convert Goldbug.

--- a/forge-gui/res/cardsfolder/j/jetfire_ingenious_scientist_jetfire_air_guardian.txt
+++ b/forge-gui/res/cardsfolder/j/jetfire_ingenious_scientist_jetfire_air_guardian.txt
@@ -24,4 +24,4 @@ K:Flying
 A:AB$ SetState | Cost$ U U U | Mode$ Transform | SubAbility$ DBAdapt | StackDescription$ Convert NICKNAME, | SpellDescription$ Convert NICKNAME, then adapt 3. (If it has no +1/+1 counters on it, put three +1/+1 counters on it.)
 SVar:DBAdapt:DB$ PutCounter | Adapt$ True | CounterNum$ 3 | CounterType$ P1P1 | StackDescription$ then adapt 3.
 DeckHas:Ability$Counters
-Oracle:Living metal (As long as it's your turn, this Vehicle is also a creature.)\nFlying\n{U}{U}{U}: Convert Jetfire, then adapt 3. (If it has no +1/+1 counters on it, put three +1/+1 counters on it.)
+Oracle:Living metal (During your turn, this Vehicle is also a creature.)\nFlying\n{U}{U}{U}: Convert Jetfire, then adapt 3. (If it has no +1/+1 counters on it, put three +1/+1 counters on it.)

--- a/forge-gui/res/cardsfolder/m/megatron_tyrant_megatron_destructive_force.txt
+++ b/forge-gui/res/cardsfolder/m/megatron_tyrant_megatron_destructive_force.txt
@@ -28,4 +28,4 @@ SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:TriggerRemembered$CardManaCost
 SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Sacrifice
-Oracle:Living metal (As long as it's your turn, this Vehicle is also a creature.)\nWhenever Megatron attacks, you may sacrifice another artifact. When you do, Megatron deals damage equal to the sacrificed artifact's mana value to target creature. If excess damage would be dealt to that creature this way, instead that damage is dealt to that creature's controller and you convert Megatron.
+Oracle:Living metal (During your turn, this Vehicle is also a creature.)\nWhenever Megatron attacks, you may sacrifice another artifact. When you do, Megatron deals damage equal to the sacrificed artifact's mana value to target creature. If excess damage would be dealt to that creature this way, instead that damage is dealt to that creature's controller and you convert Megatron.

--- a/forge-gui/res/cardsfolder/o/optimus_prime_hero_optimus_prime_autobot_leader.txt
+++ b/forge-gui/res/cardsfolder/o/optimus_prime_hero_optimus_prime_autobot_leader.txt
@@ -26,4 +26,4 @@ SVar:DBPump:DB$ Pump | Defined$ Remembered | KW$ Trample | SubAbility$ DBDelayed
 SVar:DBDelayedTrigger:DB$ DelayedTrigger | Mode$ DamageDone | RememberObjects$ Remembered | ValidSource$ Card.IsTriggerRemembered | ValidTarget$ Player | CombatDamage$ True | ThisTurn$ True | Execute$ TrigConvert | TriggerDescription$ When that creature deals combat damage to a player this turn, convert NICKNAME.
 SVar:TrigConvert:DB$ SetState | Mode$ Transform | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-Oracle:Living metal (As long as it's your turn, this Vehicle is also a creature.)\nTrample\nWhenever you attack, bolster 2. The chosen creature gains trample until end of turn. When that creature deals combat damage to a player this turn, convert Optimus Prime.
+Oracle:Living metal (During your turn, this Vehicle is also a creature.)\nTrample\nWhenever you attack, bolster 2. The chosen creature gains trample until end of turn. When that creature deals combat damage to a player this turn, convert Optimus Prime.

--- a/forge-gui/res/cardsfolder/p/prowl_stoic_strategist_prowl_pursuit_vehicle.txt
+++ b/forge-gui/res/cardsfolder/p/prowl_stoic_strategist_prowl_pursuit_vehicle.txt
@@ -27,4 +27,4 @@ SVar:TrigCounter:DB$ PutCounter | CounterType$ P1P1 | SubAbility$ DBConvert
 SVar:DBConvert:DB$ SetState | Mode$ Transform | ConditionCheckSVar$ TrigAmount | ConditionSVarCompare$ EQ2
 SVar:TrigAmount:Count$ResolvedThisTurn
 DeckHas:Ability$Counters
-Oracle:Living metal (As long as it's your turn, this Vehicle is also a creature.)\nWhenever another creature or Vehicle you control enters, put a +1/+1 counter on Prowl. If this is the second time this ability has resolved this turn, convert Prowl.
+Oracle:Living metal (During your turn, this Vehicle is also a creature.)\nWhenever another creature or Vehicle you control enters, put a +1/+1 counter on Prowl. If this is the second time this ability has resolved this turn, convert Prowl.

--- a/forge-gui/res/cardsfolder/r/ratchet_field_medic_ratchet_rescue_racer.txt
+++ b/forge-gui/res/cardsfolder/r/ratchet_field_medic_ratchet_rescue_racer.txt
@@ -27,4 +27,4 @@ T:Mode$ ChangesZoneAll | ValidCards$ Artifact.YouCtrl+!token | Origin$ Battlefie
 SVar:TrigConvert:DB$ SetState | Mode$ Transform
 DeckHas:Ability$LifeGain
 DeckHints:Type$Artifact
-Oracle:Living metal (As long as it's your turn, this Vehicle is also a creature.)\nLifelink\nWhenever one or more nontoken artifacts you control are put into a graveyard from the battlefield, convert Ratchet. This ability triggers only once each turn.
+Oracle:Living metal (During your turn, this Vehicle is also a creature.)\nLifelink\nWhenever one or more nontoken artifacts you control are put into a graveyard from the battlefield, convert Ratchet. This ability triggers only once each turn.

--- a/forge-gui/res/cardsfolder/s/slicer_hired_muscle_slicer_high_speed_antagonist.txt
+++ b/forge-gui/res/cardsfolder/s/slicer_hired_muscle_slicer_high_speed_antagonist.txt
@@ -28,4 +28,4 @@ K:Haste
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | TriggerZones$ Battlefield | CombatDamage$ True | Execute$ TrigDelTrig | TriggerDescription$ Whenever NICKNAME deals combat damage to a player, convert it at end of combat.
 SVar:TrigDelTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ EndCombat | ValidPlayer$ Player | Execute$ TrigConvert | TriggerDescription$ Convert NICKNAME at end of combat.
 SVar:TrigConvert:DB$ SetState | Mode$ Transform
-Oracle:Living metal (As long as it's your turn, this Vehicle is also a creature.)\nFirst strike, haste\nWhenever Slicer deals combat damage to a player, convert it at end of combat.
+Oracle:Living metal (During your turn, this Vehicle is also a creature.)\nFirst strike, haste\nWhenever Slicer deals combat damage to a player, convert it at end of combat.

--- a/forge-gui/res/cardsfolder/s/starscream_power_hungry_starscream_seeker_leader.txt
+++ b/forge-gui/res/cardsfolder/s/starscream_power_hungry_starscream_seeker_leader.txt
@@ -27,4 +27,4 @@ SVar:TrigMonarch:DB$ BecomeMonarch | Defined$ TriggeredTarget
 T:Mode$ BecomeMonarch | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigConvert | TriggerDescription$ Whenever you become the monarch, convert NICKNAME.
 SVar:TrigConvert:DB$ SetState | Mode$ Transform
 SVar:Monarch:PlayerCountPlayers$HasPropertyisMonarch
-Oracle:Living metal (As long as it's your turn, this Vehicle is also a creature.)\nFlying, menace, haste\nWhenever Starscream deals combat damage to a player, if there is no monarch, that player becomes the monarch.\nWhenever you become the monarch, convert Starscream.
+Oracle:Living metal (During your turn, this Vehicle is also a creature.)\nFlying, menace, haste\nWhenever Starscream deals combat damage to a player, if there is no monarch, that player becomes the monarch.\nWhenever you become the monarch, convert Starscream.

--- a/forge-gui/res/cardsfolder/u/ultra_magnus_tactician_ultra_magnus_armored_carrier.txt
+++ b/forge-gui/res/cardsfolder/u/ultra_magnus_tactician_ultra_magnus_armored_carrier.txt
@@ -27,4 +27,4 @@ SVar:TrigPump:DB$ PumpAll | ValidCards$ Creature.attacking+YouCtrl | KW$ Indestr
 SVar:DBConvert:DB$ SetState | Mode$ Transform | ConditionCheckSVar$ FormidableTest | ConditionSVarCompare$ GE8
 SVar:FormidableTest:Count$SumPower_Creature.attacking+YouCtrl
 SVar:HasAttackEffect:TRUE
-Oracle:Living metal (As long as it's your turn, this Vehicle is also a creature.)\nHaste\nFormidable — Whenever Ultra Magnus attacks, attacking creatures you control gain indestructible until end of turn. If those creatures have total power 8 or greater, convert Ultra Magnus.
+Oracle:Living metal (During your turn, this Vehicle is also a creature.)\nHaste\nFormidable — Whenever Ultra Magnus attacks, attacking creatures you control gain indestructible until end of turn. If those creatures have total power 8 or greater, convert Ultra Magnus.


### PR DESCRIPTION
Following up on https://github.com/Card-Forge/forge/pull/7005 , I noticed the Transformers (BOT) cards, like [Arcee, Sharpshooter // Arcee, Acrobatic Coupe](https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=587886&printed=false), had the reminder text for the living metal keyword on their Vehicle backside also updated, with "As long as it's your turn" replaced by "During your turn". Both `Oracle:` lines in scripts and `Keyword.java` were addressed in this pass.