### PR TITLE
Fixing Ravenous Harpy, Reaper of Flight Moonsilver

### DIFF
--- a/forge-gui/res/cardsfolder/r/ravenous_harpy.txt
+++ b/forge-gui/res/cardsfolder/r/ravenous_harpy.txt
@@ -3,6 +3,6 @@ ManaCost:2 B
 Types:Creature Harpy
 PT:1/2
 K:Flying
-A:AB$ PutCounter | Cost$ 1 Sac<1/Creature> | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on CARDNAME.
+A:AB$ PutCounter | Cost$ 1 Sac<1/Creature.Other/another creature> | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1 | SpellDescription$ Put a +1/+1 counter on CARDNAME.
 DeckHas:Ability$Counters
 Oracle:Flying\n{1}, Sacrifice another creature: Put a +1/+1 counter on Ravenous Harpy.

--- a/forge-gui/res/cardsfolder/r/reaper_of_flight_moonsilver.txt
+++ b/forge-gui/res/cardsfolder/r/reaper_of_flight_moonsilver.txt
@@ -3,7 +3,7 @@ ManaCost:3 W W
 Types:Creature Angel
 PT:3/3
 K:Flying
-A:AB$ Pump | Cost$ Sac<1/Creature> | NumAtt$ +2 | NumDef$ +1 | AILogic$ Aristocrat | Activation$ Delirium | PrecostDesc$ Delirium — | SpellDescription$ CARDNAME gets +2/+1 until end of turn. Activate only if there are four or more card types among cards in your graveyard.
+A:AB$ Pump | Cost$ Sac<1/Creature.Other/another creature> | NumAtt$ +2 | NumDef$ +1 | AILogic$ Aristocrat | Activation$ Delirium | PrecostDesc$ Delirium — | SpellDescription$ CARDNAME gets +2/+1 until end of turn. Activate only if there are four or more card types among cards in your graveyard.
 SVar:AIPreference:SacCost$Creature.Other
 DeckHints:Ability$Graveyard|Discard
 DeckHas:Ability$Delirium


### PR DESCRIPTION
On a report that Ravenous Harpy was able to sacrifice itself to its own activated ability when its rules text instructs otherwise, it was found the script lacked the required cost restriction. While I was at it, I searched the card scripts and found another instance of this lapse.