### PR TITLE
CardEdition: have Token look for other Sets too

### DIFF
--- a/forge-core/src/main/java/forge/card/CardEdition.java
+++ b/forge-core/src/main/java/forge/card/CardEdition.java
@@ -310,6 +310,7 @@ public final class CardEdition implements Comparable<CardEdition> {
     private String code2;
     private String scryfallCode;
     private String tokensCode;
+    private String tokenFallbackCode;
     private String cardsLanguage;
     private Type   type;
     private String name;
@@ -480,6 +481,16 @@ public final class CardEdition implements Comparable<CardEdition> {
     public boolean isModern() { return getDate().after(parseDate("2003-07-27")); } //8ED and above are modern except some promo cards and others
 
     public Multimap<String, TokenInSet> getTokens() { return tokenMap; }
+
+    public String getTokenSet(String token) {
+        if (tokenMap.containsKey(token)) {
+            return this.getCode();
+        }
+        if (this.tokenFallbackCode != null) {
+            return StaticData.instance().getCardEdition(this.tokenFallbackCode).getTokenSet(token);
+        }
+        return null;
+    }
 
     @Override
     public int compareTo(final CardEdition o) {
@@ -718,6 +729,7 @@ public final class CardEdition implements Comparable<CardEdition> {
             res.code2 = metadata.get("code2", res.code);
             res.scryfallCode = metadata.get("ScryfallCode", res.code);
             res.tokensCode = metadata.get("TokensCode", "T" + res.scryfallCode);
+            res.tokenFallbackCode = metadata.get("TokenFallbackCode");
             res.cardsLanguage = metadata.get("CardLang", "en");
             res.boosterArts = metadata.getInt("BoosterCovers", 1);
 

--- a/forge-game/src/main/java/forge/game/card/token/TokenInfo.java
+++ b/forge-game/src/main/java/forge/game/card/token/TokenInfo.java
@@ -286,6 +286,7 @@ public class TokenInfo {
             editionHost = sa.getKeyword().getStatic().getHostCard();
         }
         String edition = ObjectUtils.firstNonNull(editionHost, host).getSetCode();
+        edition = ObjectUtils.firstNonNull(StaticData.instance().getCardEdition(edition).getTokenSet(script), edition);
         PaperToken token = StaticData.instance().getAllTokens().getToken(script, edition);
 
         if (token == null) {

--- a/forge-gui/res/editions/Born of the Gods.txt
+++ b/forge-gui/res/editions/Born of the Gods.txt
@@ -8,6 +8,7 @@ Booster=10 Common, 3 Uncommon, 1 RareMythic, 1 BasicLand THS
 FatPack=9
 FatPackExtraSlots=80 BasicLands THS
 ScryfallCode=BNG
+TokenFallbackCode=THS
 
 [cards]
 1 U Acolyte's Reward @Slawomir Maniak
@@ -188,3 +189,6 @@ ScryfallCode=BNG
 8 g_3_3_e_centaur @Ryan Barger
 9 g_2_2_wolf @Raoul Vitale
 10 c_a_gold_sac @Richard Wright
+
+[other]
+11 emblem_kiora_the_crashing_wave @Scott M. Fischer

--- a/forge-gui/res/editions/Breaking News.txt
+++ b/forge-gui/res/editions/Breaking News.txt
@@ -88,8 +88,8 @@ ScryfallCode=OTP
 80 M Mindslaver @Gossip Goblin
 
 [tokens]
-1 rw_2_1_human_cleric_lifelink_haste @Unknown
-2 rw_1_2_human_rogue_haste_damage @Unknown
-3 rw_3_1_human_warrior_trample_haste @Unknown
+1 rw_2_1_human_cleric_lifelink_haste @Suzanne Helmigh
+2 rw_1_2_human_rogue_haste_damage @Suzanne Helmigh
+3 rw_3_1_human_warrior_trample_haste @Suzanne Helmigh
 4 bg_1_1_pest_lifegain @Ilse Gort
 5 c_a_food_sac @Lucas Graciano

--- a/forge-gui/res/editions/Commander 2014.txt
+++ b/forge-gui/res/editions/Commander 2014.txt
@@ -359,7 +359,7 @@ ScryfallCode=C14
 11 u_x_x_zombie @Dave Kendall
 12 b_x_x_demon_flying @Pete Venters
 13 b_5_5_demon_flying @Kev Walker
-14 b_0_0_phyrexian_germ @Unknown
+14 b_0_0_phyrexian_germ @Igor Kieryluk
 15 b_x_x_horror @Jason Felix
 16 b_2_2_zombie @Lucas Graciano
 17 r_1_1_goblin @Dave Kendall
@@ -379,3 +379,8 @@ ScryfallCode=C14
 31 tuktuk_the_returned @Franz Vohwinkel
 32 c_3_3_a_phyrexian_wurm_deathtouch @Raymond Swanland
 33 c_3_3_a_phyrexian_wurm_lifelink @Raymond Swanland
+
+[other]
+34 emblem_teferi_temporal_archmage @Tyler Jacobson
+35 emblem_ob_nixilis_of_the_black_oath @Daarken
+36 Emblem_daretti_scrap_savant @Dan Murayama Scott

--- a/forge-gui/res/editions/Commander 2015.txt
+++ b/forge-gui/res/editions/Commander 2015.txt
@@ -357,13 +357,13 @@ ScryfallCode=C15
 4 w_2_2_knight_first_strike @Matt Stewart
 5 w_2_2_knight_vigilance @Matt Stewart
 6 u_2_2_drake_flying @Svetlin Velinov
-7 b_0_0_phyrexian_germ @Unknown
+7 b_0_0_phyrexian_germ @Igor Kieryluk
 8 b_2_2_zombie @Lucas Graciano
 9 r_5_5_dragon_flying @Jim Pavelec
 10 r_3_1_elemental_shaman_haste @Jim Pavelec
 11 lightning_rager @Svetlin Velinov
 12 g_2_2_bear @Heather Hudson
-13 g_4_4_phyrexian_beast @Unknown
+13 g_4_4_phyrexian_beast @Svetlin Velinov
 14 g_3_3_elephant @Lars Grant-West
 15 g_3_3_frog_lizard @Jack Wang
 16 g_1_1_saproling @Brad Rigney
@@ -371,7 +371,7 @@ ScryfallCode=C15
 18 g_1_2_spider_reach @Daniel Ljunggren
 19 g_2_2_wolf @David Palumbo
 20 ur_5_5_elemental_flying @Randy Gallegos
-21 gu_1_1_snake @Unknown
+21 gu_1_1_snake @Christopher Moeller
 22 wb_1_1_spirit_flying @Cliff Childs
 23 wb_x_x_e_spirit_experience @Adam Paquette
 24 c_a_gold_sac @Richard Wright

--- a/forge-gui/res/editions/Conflux.txt
+++ b/forge-gui/res/editions/Conflux.txt
@@ -10,6 +10,7 @@ Booster=10 Common, 3 Uncommon, 1 RareMythic, 1 BasicLand ALA
 FatPack=8
 FatPackExtraSlots=40 BasicLands ALA
 ScryfallCode=CON
+TokenFallbackCode=ALA
 
 [cards]
 1 U Aerie Mystics @Mark Zug
@@ -159,8 +160,5 @@ ScryfallCode=CON
 145 U Unstable Frontier @John Avon
 
 [tokens]
-0 w_1_1_soldier @Unknown
-0 b_2_2_zombie @Unknown
-0 g_1_1_saproling @Unknown
 1 w_4_4_angel_flying @Cyril Van Der Haegen
 2 r_3_1_elemental_haste @Vance Kovacs

--- a/forge-gui/res/editions/Dark Ascension.txt
+++ b/forge-gui/res/editions/Dark Ascension.txt
@@ -10,6 +10,7 @@ FatPack=9
 FatPackExtraSlots=70 BasicLands ISD
 ChaosDraftThemes=GRAVEYARD_MATTERS
 ScryfallCode=DKA
+TokenFallbackCode=ISD
 
 [cards]
 1 M Archangel's Light @Volkan Baǵa
@@ -172,10 +173,8 @@ ScryfallCode=DKA
 158 R Vault of the Archangel @John Avon
 
 [tokens]
-0 w_1_1_spirit_flying @Unknown
-0 b_2_2_zombie @Unknown
-0 b_2_2_zombie @Unknown
-0 b_2_2_zombie @Unknown
-0 g_2_2_wolf @Unknown
 1 w_1_1_human @John Stanko
 2 b_1_1_vampire_lifelink @Peter Mohrbacher
+
+[other]
+3 emblem_sorin_lord_of_innistrad @Michael Komarck

--- a/forge-gui/res/editions/Dominaria United Commander.txt
+++ b/forge-gui/res/editions/Dominaria United Commander.txt
@@ -248,21 +248,9 @@ ScryfallCode=DMC
 240 R Tyrite Sanctum @Volkan Baǵa
 
 [tokens]
-0 all_3_3_kavu_trample @Unknown
-0 b_1_1_insect_flying @Unknown
-0 b_2_2_zombie @Unknown
-0 c_a_treasure_sac @Unknown
-0 g_2_2_cat_warrior_forestwalk @Unknown
-0 g_3_3_badger @Unknown
-0 g_4_4_wurm @Unknown
-0 kobolds_of_kher_keep @Unknown
-0 rgw_1_1_sand_warrior @Unknown
-0 stangg_twin @Unknown
-0 u_1_1_merfolk @Unknown
-0 w_4_4_angel_flying_vigilance @Unknown
 1 w_2_2_griffin_flying @John Tedrick
 2 w_1_1_human @Bram Sels
-3 w_2_2_knight_pro_red @Dan Murayama Scott
+3 w_2_2_knight_vigilance @Dan Murayama Scott
 4 w_1_1_warrior_vigilance @Magali Villeneuve
 5 b_2_2_zombie_knight_menace @Even Amundsen
 6 ragavan @Daniel Ljunggren
@@ -271,4 +259,4 @@ ScryfallCode=DMC
 9 g_3_3_elephant @Lars Grant-West
 10 g_0_0_hydra @Simon Dominic
 11 g_1_1_snake @Lars Grant-West
-12 w_2_2_knight_vigilance @Dan Murayama Scott
+12 all_3_3_kavu_trample @Victor Adame Minguez

--- a/forge-gui/res/editions/Double Masters.txt
+++ b/forge-gui/res/editions/Double Masters.txt
@@ -739,16 +739,16 @@ ScryfallCode=2XM
 1 Dark Depths+|2XM
 
 [tokens]
-0 u_2_1_a_phyrexian_myr @Unknown
 1 c_0_1_eldrazi_spawn_sac @Aleksi Briclot
 2 c_1_1_shapeshifter_changeling @Steve Prescott
 3 w_4_4_angel_flying @Magali Villeneuve
 4 w_2_2_cat @Jesper Ejsing
 5 w_1_1_human_soldier @Deruchenko Alexander
 6 w_1_1_soldier @Jakub Kasper
+7 u_2_1_a_phyrexian_myr @Daarken
 8 u_1_1_a_thopter_flying @Andrew Murray
 9 b_5_5_demon_flying @Sidharth Chaturvedi
-10 b_0_0_phyrexian_germ @Unknown
+10 b_0_0_phyrexian_germ @Igor Kieryluk
 11 marit_lage @Stephan Martiniere
 12 g_3_3_ape @Lars Grant-West
 13 g_3_3_beast @Jason Felix
@@ -769,3 +769,6 @@ ScryfallCode=2XM
 28 tuktuk_the_returned @Franz Vohwinkel
 29 c_3_3_a_phyrexian_wurm_deathtouch @Raymond Swanland
 30 c_3_3_a_phyrexian_wurm_lifelink @Raymond Swanland
+
+[other]
+31 copy @David Palumbo

--- a/forge-gui/res/editions/Dragon's Maze.txt
+++ b/forge-gui/res/editions/Dragon's Maze.txt
@@ -10,6 +10,7 @@ FatPack=9
 FatPackExtraSlots=80 BasicLands RTR
 ChaosDraftThemes=RAVNICA
 ScryfallCode=DGM
+TokenFallbackCode=GTC
 
 [cards]
 1 C Boros Mastiff @Kev Walker
@@ -193,14 +194,4 @@ ScryfallCode=DGM
 1 Maze's End|DGM
 
 [tokens]
-0 w_1_1_bird_flying @Unknown
-0 w_2_2_knight_vigilance @Unknown
-0 w_2_2_knight_vigilance @Unknown
-0 g_3_3_centaur @Unknown
-0 g_3_3_centaur @Unknown
-0 g_4_4_rhino_trample @Unknown
-0 g_5_5_wurm_trample @Unknown
-0 rw_1_1_soldier_haste @Unknown
-0 rw_1_1_soldier_haste @Unknown
-0 wb_1_1_spirit_flying @Unknown
 1 gw_x_x_elemental_total_creatures @Mark Winters

--- a/forge-gui/res/editions/Duel Decks Elspeth vs. Tezzeret.txt
+++ b/forge-gui/res/editions/Duel Decks Elspeth vs. Tezzeret.txt
@@ -87,5 +87,4 @@ ScryfallCode=DDF
 79 L Island @Chippy
 
 [tokens]
-0 c_1_1_a_pentavite_flying @Unknown
 1 w_1_1_soldier @Paolo Parente

--- a/forge-gui/res/editions/Duel Decks Elves vs. Inventors.txt
+++ b/forge-gui/res/editions/Duel Decks Elves vs. Inventors.txt
@@ -84,7 +84,6 @@ ScryfallCode=DDU
 76 L Mountain @Eytan Zana
 
 [tokens]
-0 c_1_1_a_phyrexian_myr @Unknown
 1 g_1_1_elf_warrior @William O'Connor
 2 c_1_1_a_myr @Ryan Pancoast
 3 c_1_1_a_thopter_flying @Svetlin Velinov

--- a/forge-gui/res/editions/Duel Decks Garruk vs. Liliana.txt
+++ b/forge-gui/res/editions/Duel Decks Garruk vs. Liliana.txt
@@ -71,7 +71,6 @@ ScryfallCode=DDD
 63 L Swamp @Richard Wright
 
 [tokens]
-0 b_1_1_bat_flying @Unknown
 T1 g_3_3_beast @John Donahue
 T2 g_4_4_beast @Steve Prescott
 T3 g_3_3_elephant @Arnie Swekel

--- a/forge-gui/res/editions/Duel Decks Izzet vs. Golgari.txt
+++ b/forge-gui/res/editions/Duel Decks Izzet vs. Golgari.txt
@@ -98,6 +98,4 @@ ScryfallCode=DDJ
 90 L Forest @Richard Wright
 
 [tokens]
-0 u_3_3_weird_defender_flying @Unknown
-0 b_2_2_zombie @Unknown
 1 g_1_1_saproling @Brad Rigney

--- a/forge-gui/res/editions/Duel Decks Jace vs. Vraska.txt
+++ b/forge-gui/res/editions/Duel Decks Jace vs. Vraska.txt
@@ -96,5 +96,4 @@ ScryfallCode=DDM
 88 L Forest @Richard Wright
 
 [tokens]
-0 u_2_2_illusion @Unknown
 1 b_1_1_assassin_lose_con @Svetlin Velinov

--- a/forge-gui/res/editions/Duel Decks Knights vs. Dragons.txt
+++ b/forge-gui/res/editions/Duel Decks Knights vs. Dragons.txt
@@ -89,5 +89,4 @@ ScryfallCode=DDG
 81 L Mountain @Matt Cavotta
 
 [tokens]
-0 w_2_2_griffin_flying @Unknown
 1 r_1_1_goblin @Brandon Kitkouski

--- a/forge-gui/res/editions/Duel Decks Phyrexia vs. the Coalition.txt
+++ b/forge-gui/res/editions/Duel Decks Phyrexia vs. the Coalition.txt
@@ -79,6 +79,6 @@ ScryfallCode=DDE
 71 L Forest @Alan Pollack
 
 [tokens]
-0 b_x_x_phyrexian_minion @Unknown
 1 hornet @Ron Spencer
+2 b_x_x_phyrexian_minion @Dave Kendall
 3 g_1_1_saproling @Warren Mahy

--- a/forge-gui/res/editions/Duel Decks Sorin vs. Tibalt.txt
+++ b/forge-gui/res/editions/Duel Decks Sorin vs. Tibalt.txt
@@ -88,5 +88,4 @@ ScryfallCode=DDK
 80 L Swamp @Jung Park
 
 [tokens]
-0 b_1_1_vampire_lifelink @Unknown
 1 w_1_1_spirit_flying @Ryan Yee

--- a/forge-gui/res/editions/Eldritch Moon.txt
+++ b/forge-gui/res/editions/Eldritch Moon.txt
@@ -12,6 +12,7 @@ ChanceReplaceCommonWith=.125F dfc:RareMythic
 TreatAsSmallSet=true
 ChaosDraftThemes=GRAVEYARD_MATTERS
 ScryfallCode=EMN
+TokenFallbackCode=SOI
 
 [cards]
 1 U Abundant Maw @Greg Staples
@@ -221,16 +222,15 @@ ScryfallCode=EMN
 205 U Nephalia Academy @Adam Paquette
 
 [tokens]
-0 w_1_1_human_soldier @Unknown
-0 w_1_1_spirit_flying @Unknown
-0 r_1_1_devil_burn @Unknown
-0 g_1_1_insect @Unknown
-0 g_2_2_wolf @Unknown
 1 c_3_2_eldrazi_horror @Jason Felix
 2 u_1_1_human_wizard @Nils Hamm
 3 b_2_2_zombie @Tomasz Jedruszek
-3 b_2_2_zombie @Tomasz Jedruszek
-3 b_2_2_zombie @Tomasz Jedruszek
+4 b_2_2_zombie @Seb McKinnon
+5 b_2_2_zombie @Anna Steinbauer
 6 b_x_x_zombie @Daarken
 7 r_1_1_human @Kieran Yanner
 8 g_1_2_spider_reach @Christine Choi
+
+[other]
+9 emblem_liliana_the_last_hope @Anna Steinbauer
+10 emblem_tamiyo_field_researcher @Tianhua X

--- a/forge-gui/res/editions/Eventide.txt
+++ b/forge-gui/res/editions/Eventide.txt
@@ -10,6 +10,7 @@ Booster=11 Common, 3 Uncommon, 1 Rare
 FatPack=8
 FatPackExtraSlots=40 BasicLands SHM
 ScryfallCode=EVE
+TokenFallbackCode=SHM
 
 [cards]
 1 R Archon of Justice @Jason Chan
@@ -194,8 +195,6 @@ ScryfallCode=EVE
 180 R Twilight Mire @Rob Alexander
 
 [tokens]
-0 w_1_1_kithkin_soldier @Unknown
-0 g_2_2_wolf @Unknown
 1 w_0_1_goat @Terese Nielsen
 2 u_1_1_bird_flying @Heather Hudson
 3 g_3_3_beast @William O'Connor

--- a/forge-gui/res/editions/Game Night 2019.txt
+++ b/forge-gui/res/editions/Game Night 2019.txt
@@ -73,9 +73,6 @@ ScryfallCode=GN2
 64 L Forest @Dimitar Marinski
 
 [tokens]
-0 w_1_1_soldier @Unknown
-0 b_2_2_zombie @Unknown
-0 g_2_2_wolf @Unknown
 1 r_2_2_dragon_flying_firebreathing @Lars Grant-West
 2 r_5_5_dragon_flying @Alex Konstad
 3 g_3_3_dinosaur_trample @Filip Burburan

--- a/forge-gui/res/editions/Gatecrash.txt
+++ b/forge-gui/res/editions/Gatecrash.txt
@@ -10,6 +10,7 @@ FatPack=9
 FatPackExtraSlots=80 BasicLands RTR
 ChaosDraftThemes=RAVNICA
 ScryfallCode=GTC
+TokenFallbackCode=RTR
 
 [cards]
 1 C Aerial Maneuver @Scott Chou
@@ -263,11 +264,6 @@ ScryfallCode=GTC
 249 R Watery Grave @Raymond Swanland
 
 [tokens]
-0 w_2_2_knight_vigilance @Unknown
-0 w_2_2_knight_vigilance @Unknown
-0 w_1_1_soldier @Unknown
-0 g_x_x_ooze @Unknown
-0 rw_1_1_soldier_haste @Unknown
 1 w_4_4_angel_flying @Steve Argyle
 2 b_1_1_rat @Nils Hamm
 3 g_3_3_frog_lizard @Jack Wang
@@ -275,3 +271,6 @@ ScryfallCode=GTC
 5 ub_1_1_horror_flying @Adam Paquette
 6 rw_1_1_soldier_haste @David Palumbo
 7 wb_1_1_spirit_flying @Cliff Childs
+
+[other]
+8 emblem_domri_rade @Tyler Jacobson

--- a/forge-gui/res/editions/Guilds of Ravnica Guild Kit.txt
+++ b/forge-gui/res/editions/Guilds of Ravnica Guild Kit.txt
@@ -5,6 +5,7 @@ Name=Guilds of Ravnica Guild Kit
 Code2=GK1
 Type=Boxed_Set
 ScryfallCode=GK1
+TokenFallbackCode=GRN
 
 [cards]
 1 R Etrata, the Silencer @Igor Kieryluk
@@ -136,16 +137,16 @@ ScryfallCode=GK1
 127 L Forest @Alayna Danner
 
 [tokens]
-0 gw_2_2_elf_knight_vigilance @Unknown
-0 ub_1_1_horror_flying @Unknown
-0 bg_1_1_insect @Unknown
-0 g_3_3_centaur @Unknown
-2 w_1_1_soldier_lifelink @Unknown
-3 u_3_3_weird_defender_flying @Unknown
-4 r_1_1_goblin @Unknown
-6 rw_1_1_soldier_haste @Unknown
-5 g_1_1_saproling @Unknown
-8 g_1_1_saproling @Unknown
-9 g_5_5_wurm_trample @Unknown
-10 gw_8_8_elemental_vigilance @Unknown
-11 voja @Unknown
+2 ub_1_1_horror_flying @Adam Paquette
+3 u_3_3_weird_defender_flying @Hideaki Takamura
+4 r_1_1_goblin @Karl Kopinski
+5 g_1_1_saproling @Raoul Vitale
+6 rw_1_1_soldier_haste @David Palumbo
+7 g_3_3_centaur @Slawomir Maniak
+8 g_1_1_saproling @Brad Rigney
+9 g_5_5_wurm_trample @Anthony Palumbo
+10 gw_8_8_elemental_vigilance @Yeong-Hao Han
+11 voja @Richard Sardinha
+
+[other]
+1 copy @Clint Cearley

--- a/forge-gui/res/editions/Hour of Devastation.txt
+++ b/forge-gui/res/editions/Hour of Devastation.txt
@@ -13,6 +13,7 @@ AdditionalSetUnlockedInQuest=MPS_AKH
 TreatAsSmallSet=true
 ChaosDraftThemes=GRAVEYARD_MATTERS
 ScryfallCode=HOU
+TokenFallbackCode=AKH
 
 [cards]
 1 C Act of Heroism @Magali Villeneuve
@@ -228,20 +229,17 @@ ScryfallCode=HOU
 209 C Cinder Barrens @Titus Lunter
 
 [tokens]
-0 w_1_1_cat_lifelink @Unknown
-0 w_1_1_warrior_vigilance @Unknown
-0 b_2_2_zombie @Unknown
 10 w_5_5_horse @Lucas Graciano
 11 g_5_4_snake @Winona Nelson
 12 ur_1_1_insect_flying_haste @Lius Lasahido
 
 [other]
-eternalize_adorned_pouncer
-eternalize_champion_of_wits
-eternalize_dreamstealer
-eternalize_earthshaker_khenra
-eternalize_proven_combatant
-eternalize_resilient_khenra
-eternalize_sinuous_striker
-eternalize_steadfast_sentinel
-eternalize_sunscourge_champion
+1 eternalize_adorned_pouncer @Slawomir Maniak
+2 eternalize_champion_of_wits @Even Amundsen
+3 eternalize_dreamstealer @Yongjae Choi
+4 eternalize_earthshaker_khenra @Jason A. Engle
+5 eternalize_proven_combatant @Clint Cearley
+6 eternalize_resilient_khenra @Svetlin Velinov
+7 eternalize_sinuous_striker @Svetlin Velinov
+8 eternalize_steadfast_sentinel @ Karl Kopinski
+9 eternalize_sunscourge_champion @Josu Hernaiz

--- a/forge-gui/res/editions/Innistrad Crimson Vow Commander.txt
+++ b/forge-gui/res/editions/Innistrad Crimson Vow Commander.txt
@@ -196,11 +196,6 @@ ScryfallCode=VOC
 188 U Unclaimed Territory @Dimitar Marinski
 
 [tokens]
-0 c_a_blood_draw @Unknown
-0 c_a_treasure_sac @Unknown
-0 g_2_2_wolf @Unknown
-0 w_1_1_spirit_flying @Unknown
-0 wb_1_1_vampire_lifelink @Unknown
 1 c_1_1_spirit @Daniel Ljunggren
 2 w_4_4_angel_flying @Magali Villeneuve
 3 w_3_3_spirit_flying @Matt Thompson

--- a/forge-gui/res/editions/Innistrad Crimson Vow.txt
+++ b/forge-gui/res/editions/Innistrad Crimson Vow.txt
@@ -463,7 +463,13 @@ A248 U A-Skull Skaab @Nicholas Gregory
 12 g_3_1_boar @Nicholas Gregory
 13 g_1_1_insect @Joe Slucher
 14 g_2_2_wolf @Andrea Radeck
-15 gw_1_1_human_soldier_training @Unknown
+15 gw_1_1_human_soldier_training @Campbell White
 16 wb_1_1_vampire_lifelink @Zoltan Boros
 17 c_a_blood_draw @Miranda Meeks
 18 c_a_treasure_sac @Josu Hernaiz
+
+[other]
+19 copy @Brian Valeza
+20 emblem_chandra_dressed_to_kill @Viktor Titov
+21 day @Johan Grenier
+21 night @Johan Grenier

--- a/forge-gui/res/editions/Innistrad Midnight Hunt Commander.txt
+++ b/forge-gui/res/editions/Innistrad Midnight Hunt Commander.txt
@@ -195,13 +195,6 @@ ScryfallCode=MIC
 187 U Unclaimed Territory @Dimitar Marinski
 
 [tokens]
-0 c_a_clue_draw @Unknown
-0 c_a_treasure_sac @Unknown
-0 g_1_2_spider_reach @Unknown
-0 g_2_2_wolf @Unknown
-0 g_4_4_beast @Unknown
-0 w_1_1_spirit_flying @Unknown
-0 b_2_2_zombie_decayed
 1 c_0_1_eldrazi_spawn_sac @Aleksi Briclot
 2 w_1_1_human_soldier @Deruchenko Alexander
 3 w_2_2_knight_vigilance @Matt Stewart

--- a/forge-gui/res/editions/Innistrad Midnight Hunt.txt
+++ b/forge-gui/res/editions/Innistrad Midnight Hunt.txt
@@ -436,10 +436,16 @@ A218 U A-Devoted Grafkeeper @Raoul Vitale
 7 r_x_x_elemental_trample_grave_exile @Deruchenko Alexander
 8 g_4_4_beast @Piotr Foksowicz
 9 g_3_3_insect @Nicholas Gregory
-10 g_x_y_ooze_types_graveyard @Unknown
+10 g_x_y_ooze_types_graveyard @Izzy
 11 g_1_2_spider_reach @Slawomir Maniak
 12 g_x_x_treefolk_reach_total_lands @Yeong-Hao Han
 13 g_2_2_wolf @Andrea Radeck
 14 br_3_1_vampire_trample_lifelink_haste @Bastien L. Deharme
 15 ub_x_x_zombie_menace @Ravenna Tran
 16 c_a_clue_draw @Campbell White
+
+[other]
+17 emblem_teferi_who_slows_the_sunset @Heonhwa Choe
+18 emblem_wrenn_and_seven @Heonhwa Choe
+19 day @Johan Grenier
+19 night @Johan Grenier

--- a/forge-gui/res/editions/Innistrad Remastered.txt
+++ b/forge-gui/res/editions/Innistrad Remastered.txt
@@ -561,6 +561,13 @@ Replace=.04 Mythic:fromSheet("INR cards")
 17 g_x_x_treefolk_reach_total_lands @Yeong-Hao Han
 18 g_2_2_wolf @David Palumbo
 19 wb_1_1_human_cleric @Min Yum
-20 gw_1_1_human_soldier_training @Unknown
+20 gw_1_1_human_soldier_training @Campbell White
 21 c_a_blood_draw @Miranda Meeks
 22 c_a_clue_draw @John Avon
+
+[other]
+23 emblem_arlinn_embraced_by_the_moon @Winona Nelson
+24 emblem_chandra_dressed_to_kill @Viktor Titov
+25 emblem_jace_unraveler_of_secrets @Tyler Jacobson
+26 emblem_tamiyo_field_researcher @Kieran Yanner
+27 emblem_wrenn_and_seven @Heonhwa Choe

--- a/forge-gui/res/editions/Journey into Nyx.txt
+++ b/forge-gui/res/editions/Journey into Nyx.txt
@@ -8,6 +8,7 @@ Booster=10 Common, 3 Uncommon, 1 RareMythic, 1 BasicLand THS
 FatPack=9
 FatPackExtraSlots=80 BasicLands THS
 ScryfallCode=JOU
+TokenFallbackCode=BNG
 
 [cards]
 1 R Aegis of the Gods @Yefim Kligerman
@@ -177,13 +178,6 @@ ScryfallCode=JOU
 165 R Temple of Malady @James Paick
 
 [tokens]
-0 c_a_gold_sac @Unknown
-0 rg_2_2_satyr_haste @Unknown
-0 u_2_2_e_bird_flying @Unknown
-0 w_1_1_soldier @Unknown
-0 w_1_1_soldier @Unknown
-0 w_1_1_soldier @Unknown
-0 r_2_3_minotaur_haste @Craig J Spearing
 1 u_4_4_sphinx_flying @Jesper Ejsing
 2 b_x_x_zombie @Zack Stella
 3 r_2_3_minotaur_haste @Craig J Spearing

--- a/forge-gui/res/editions/Kaldheim Commander.txt
+++ b/forge-gui/res/editions/Kaldheim Commander.txt
@@ -127,9 +127,6 @@ ScryfallCode=KHC
 119 C Tranquil Cove @John Avon
 
 [tokens]
-0 g_1_1_elf_warrior @Unknown
-0 r_5_5_dragon_flying @Unknown
-0 w_1_1_spirit_flying @Unknown
 1 w_1_1_bird_flying @Howard Lyon
 2 w_1_1_kithkin_soldier @Randy Gallegos
 3 w_1_1_pegasus_flying @Greg Hildebrandt

--- a/forge-gui/res/editions/Kaldheim.txt
+++ b/forge-gui/res/editions/Kaldheim.txt
@@ -485,7 +485,7 @@ A387 U A-Thornmantle Striker @Magali Villeneuve
 4 w_1_1_spirit_flying @Anastasia Ovchinnikova
 5 u_1_1_bird_flying @Jason A. Engle
 6 u_4_4_giant_wizard @Andrew Mar
-7 komas_coil @Unknown
+7 komas_coil @Simon Dominic
 8 u_2_2_shapeshifter_changeling @Filip Burburan
 9 b_2_2_zombie_berserker @Igor Kieryluk
 10 r_2_3_demon_berserker_menace @Grzegorz Rutkowski
@@ -498,3 +498,9 @@ A387 U A-Thornmantle Striker @Magali Villeneuve
 17 icy_manalith @Andrew Mar
 18 replicated_ring @Olena Richards
 19 c_a_treasure_sac @Olena Richards
+
+[other]
+20 emblem_kaya_the_inexorable @Tyler Jacobson
+21 emblem_tibalt_cosmic_impostor @Yongjae Choi
+22 emblem_tyvar_kell @Chris Rallis
+23 foretell

--- a/forge-gui/res/editions/Kamigawa Neon Dynasty.txt
+++ b/forge-gui/res/editions/Kamigawa Neon Dynasty.txt
@@ -606,5 +606,9 @@ A242 U A-Circuit Mender @Hector Ortiz
 13 keimi @Milivoj Ćeran
 14 mechtitan @Victor Adame Minguez
 15 c_1_1_a_construct @Sean Murray
-16 tamiyos_notebook @Unknown
+16 tamiyos_notebook @Randy Vargas
 17 c_a_treasure_sac @Yeong-Hao Han
+
+[other]
+18 emblem_kaito_shizuki @Yongjae Choi
+19 emblem_tezzeret_betrayer_of_flesh @Bryan Sola

--- a/forge-gui/res/editions/Magic Origins.txt
+++ b/forge-gui/res/editions/Magic Origins.txt
@@ -310,8 +310,13 @@ ScryfallCode=ORI
 4 b_5_5_demon_flying @Kev Walker
 5 b_2_2_zombie @Lucas Graciano
 6 r_1_1_goblin @Brandon Kitkouski
-7 ashaya_the_awoken_world @Unknown
+7 ashaya_the_awoken_world @Raymond Swanland
 8 g_2_2_elemental @Marco Nelor
 9 g_1_1_elf_warrior @William O'Connor
 10 c_1_1_a_thopter_flying @Adam Paquette
 11 c_1_1_a_thopter_flying @Adam Paquette
+
+[other]
+12 emblem_jace_telepath_unbound @Jaime Jones
+13 emblem_liliana_defiant_necromancer @Karla Ortiz
+14 emblem_chandra_roaring_flame @Eric Deschamps

--- a/forge-gui/res/editions/March of the Machine.txt
+++ b/forge-gui/res/editions/March of the Machine.txt
@@ -513,11 +513,18 @@ ScryfallCode=MOM
 8 g_1_1_phyrexian_saproling @Maxime Minard
 9 ur_1_1_elemental @Ryan Valle
 10 wu_2_2_knight_vigilance @Ernanda Souza
-11 gw_3_3_phyrexian_hydra_lifelink @Unknown
-12 gw_3_3_phyrexian_hydra_reach @Unknown
-13 rw_3_2_spirit @Unknown
+11 gw_3_3_phyrexian_hydra_lifelink @Néstor Ossandón Leal
+12 gw_3_3_phyrexian_hydra_reach @Néstor Ossandón Leal
+13 rw_3_2_spirit @Michael Walsh
 14 wb_1_1_spirit_flying @Bruno Biazotto
-15 rw_3_2_warrior_symbiotic_attack @Unknown
+15 rw_3_2_warrior_symbiotic_attack @Viko Menezes
+16 incubator_c_0_0_a_phyrexian @Johann Bodin
+17 incubator_c_0_0_a_phyrexian @Johann Bodin
+18 incubator_c_0_0_a_phyrexian @Johann Bodin
 19 c_1_1_a_thopter_flying @David Astruga
 20 c_a_treasure_sac @David Astruga
 21 c_a_treasure_sac @David Astruga
+
+[other]
+22 emblem_teferi_akosa_of_zhalfir @Chris Rallis
+23 emblem_wrenn_and_realmbreaker @Cristi Balanescu

--- a/forge-gui/res/editions/Mirrodin Besieged.txt
+++ b/forge-gui/res/editions/Mirrodin Besieged.txt
@@ -10,6 +10,7 @@ FatPack=9
 FatPackExtraSlots=40 BasicLands
 ChaosDraftThemes=MIRRODIN
 ScryfallCode=MBS
+TokenFallbackCode=SOM
 
 [cards]
 1 U Accorder Paladin @Kekai Kotaki
@@ -169,12 +170,8 @@ ScryfallCode=MBS
 155 L Forest @Mark Tedin
 
 [tokens]
-0 w_2_2_cat @Unknown
-0 w_1_1_soldier @Unknown
-0 c_1_1_a_myr @Unknown
-0 c_1_1_a_phyrexian_myr @Unknown
-1 b_0_0_phyrexian_germ @Unknown
-2 b_2_2_phyrexian_zombie @Unknown
+1 b_0_0_phyrexian_germ @Igor Kieryluk
+2 b_2_2_phyrexian_zombie @Dave Kendall
 3 c_9_9_a_golem @Svetlin Velinov
 4 c_x_x_a_phyrexian_horror @Scott Chou
 5 c_1_1_a_thopter_flying @Volkan Baǵa

--- a/forge-gui/res/editions/Modern Event Deck.txt
+++ b/forge-gui/res/editions/Modern Event Deck.txt
@@ -35,6 +35,9 @@ ScryfallCode=MD1
 26 U Ghost Quarter @Peter Mohrbacher
 
 [tokens]
-0 c_1_1_a_phyrexian_myr @Unknown
 1 w_1_1_soldier @Goran Josic
 2 w_1_1_spirit_flying @Kev Walker
+3 c_1_1_a_phyrexian_myr @Matt Stewart
+
+[other]
+4 emblem_elspeth_knight_errant @Volkan Baǵa

--- a/forge-gui/res/editions/Modern Horizons 3 Commander.txt
+++ b/forge-gui/res/editions/Modern Horizons 3 Commander.txt
@@ -406,7 +406,6 @@ ScryfallCode=M3C
 411 R Rishkar's Expertise @Magali Villeneuve
 
 [tokens]
-0 rgw_1_1_sand_warrior @Unknown
 1 c_10_10_eldrazi @Jack Wang
 2 c_4_4_eldrazi_angel_flying_vigilance @Nino Is
 3 c_1_1_eldrazi_scion_sac @Izzy
@@ -428,6 +427,12 @@ ScryfallCode=M3C
 19 g_1_1_forest_dryad @Donato Giancola
 20 g_x_x_hydra @Simon Dominic
 21 g_1_1_saproling @Trevor Claxton
+23 rgw_1_1_sand_warrior @Piotr Foksowicz
 24 c_6_12_a_construct_trample @Jung Park
 25 c_1_1_a_myr @Ryan Pancoast
 26 c_1_1_a_thopter_flying @Adam Paquette
+
+[other]
+22 tarmogoyf @Camille Alquier
+27 emblem_garruk_apex_predator @Tyler Jacobson
+28 emblem_vivien_reid @Anna Steinbauer

--- a/forge-gui/res/editions/Modern Horizons.txt
+++ b/forge-gui/res/editions/Modern Horizons.txt
@@ -270,7 +270,6 @@ ScryfallCode=MH1
 255 R Flusterstorm @Chris Rallis
 
 [tokens]
-0 c_3_3_a_phyrexian_golem @Unknown
 1 c_2_2_shapeshifter_changeling @Johann Bodin
 2 w_4_4_angel_flying_vigilance @Winona Nelson
 3 w_1_1_bird_flying @James Ryman
@@ -288,4 +287,9 @@ ScryfallCode=MH1
 15 g_1_1_squirrel @Daniel Ljunggren
 16 wb_1_1_spirit_flying @Josh Hass
 17 c_0_0_a_construct_total_artifacts @Victor Adame Minguez
+18 c_3_3_a_phyrexian_golem @Volkan Baǵa
 19 c_1_1_a_myr @Ryan Pancoast
+
+[other]
+20 emblem_serra_the_benevolent @Magali Villeneuve
+21 emblem_wrenn_and_six @Chase Stone

--- a/forge-gui/res/editions/Modern Masters 2015.txt
+++ b/forge-gui/res/editions/Modern Masters 2015.txt
@@ -262,13 +262,13 @@ ScryfallCode=MM2
 249 U Simic Growth Chamber @John Avon
 
 [tokens]
-0 b_0_0_phyrexian_germ @Unknown
 1 c_0_1_eldrazi_spawn_sac @Aleksi Briclot
 2 c_0_1_eldrazi_spawn_sac @Aleksi Briclot
 3 c_0_1_eldrazi_spawn_sac @Aleksi Briclot
 4 w_1_1_soldier @Greg Staples
 5 w_1_1_spirit_flying @Mike Sass
 6 b_1_1_faerie_rogue_flying @Dave Allsop
+7 b_0_0_phyrexian_germ @Igor Kieryluk
 8 b_1_1_thrull @Mark Tedin
 9 g_3_3_elephant @Lars Grant-West
 10 g_1_1_insect @Ron Spencer

--- a/forge-gui/res/editions/Modern Masters 2017.txt
+++ b/forge-gui/res/editions/Modern Masters 2017.txt
@@ -262,9 +262,6 @@ ScryfallCode=MM3
 249 R Verdant Catacombs @Vance Kovacs
 
 [tokens]
-0 gw_x_x_elemental_total_creatures @Unknown
-0 rw_1_1_soldier_haste @Unknown
-0 c_3_3_a_phyrexian_golem @Unknown
 1 w_4_4_angel_flying @Anthony Palumbo
 2 w_1_1_bird_flying @James Ryman
 3 w_1_1_soldier @Magali Villeneuve
@@ -281,5 +278,11 @@ ScryfallCode=MM3
 13 g_x_x_ooze @Marco Nelor
 14 g_1_1_saproling @Brad Rigney
 15 g_5_5_wurm_trample @Anthony Palumbo
+16 gw_x_x_elemental_total_creatures @Mark Winters
 17 rg_4_4_giant_warrior_haste @Trevor Hairsine
 18 rg_1_1_goblin_warrior @Dave Allsop
+19 rw_1_1_soldier_haste @David Palumbo
+20 c_3_3_a_phyrexian_golem @Volkan Baǵa
+
+[other]
+21 emblem_domri_rade @Tyler Jacobson

--- a/forge-gui/res/editions/Morningtide.txt
+++ b/forge-gui/res/editions/Morningtide.txt
@@ -9,6 +9,7 @@ Booster=11 Common, 3 Uncommon, 1 Rare
 FatPack=6
 FatPackExtraSlots=40 BasicLands LRW
 ScryfallCode=MOR
+TokenFallbackCode=LRW
 
 [cards]
 1 C Ballyrush Banneret @Ralph Horsley
@@ -163,12 +164,6 @@ ScryfallCode=MOR
 150 R Rustic Clachan @Fred Fields
 
 [tokens]
-0 w_1_1_kithkin_soldier @Unknown
-0 u_1_1_merfolk_wizard @Unknown
-0 b_1_1_goblin_rogue @Unknown
-0 g_4_4_elemental @Unknown
-0 g_1_1_elf_warrior @Unknown
-0 g_2_2_wolf @Unknown
 1 w_5_5_giant_warrior @Steve Ellis
 2 b_1_1_faerie_rogue_flying @Jim Nelson
 3 g_2_5_treefolk_shaman @Richard Sardinha

--- a/forge-gui/res/editions/Mythic Edition - Ravnica Allegiance.txt
+++ b/forge-gui/res/editions/Mythic Edition - Ravnica Allegiance.txt
@@ -16,5 +16,4 @@ RA7 M Domri, Chaos Bringer @Jason Rainville
 RA8 M Kaya, Orzhov Usurper @Chris Rallis
 
 [tokens]
-0 rg_4_4_beast_trample @Unknown
 R1 c_0_0_a_construct_total_artifacts @Victor Adame Minguez

--- a/forge-gui/res/editions/New Phyrexia.txt
+++ b/forge-gui/res/editions/New Phyrexia.txt
@@ -10,6 +10,7 @@ FatPack=9
 FatPackExtraSlots=40 BasicLands
 ChaosDraftThemes=MIRRODIN
 ScryfallCode=NPH
+TokenFallbackCode=MBS
 
 [cards]
 1 M Karn Liberated @Jason Chan
@@ -189,9 +190,7 @@ ScryfallCode=NPH
 175 L Forest @Mark Tedin
 
 [tokens]
-0 b_0_0_phyrexian_germ @Unknown
-0 r_1_1_phyrexian_goblin_haste @Unknown
-0 g_1_1_phyrexian_insect_infect @Unknown
-0 c_3_3_a_phyrexian_golem @Unknown
-0 c_1_1_a_phyrexian_myr @Unknown
 1 g_3_3_beast @Dave Allsop
+2 r_1_1_phyrexian_goblin_haste @Jaime Jones
+3 c_3_3_a_phyrexian_golem @Volkan Baǵa
+4 c_1_1_a_phyrexian_myr @Matt Stewart

--- a/forge-gui/res/editions/Oath of the Gatewatch.txt
+++ b/forge-gui/res/editions/Oath of the Gatewatch.txt
@@ -11,6 +11,7 @@ FatPackExtraSlots=66 BasicLands BFZ, 14 name("Wastes")
 AdditionalSheetForFoils=fromSheet("EXP special slot")
 AdditionalSetUnlockedInQuest=EXP
 ScryfallCode=OGW
+TokenFallbackCode=BFZ
 
 [cards]
 1 R Deceiver of Form @Viktor Titov
@@ -201,9 +202,6 @@ ScryfallCode=OGW
 184a C Wastes @Raymond Swanland
 
 [tokens]
-0 w_2_2_knight_ally @Unknown
-0 w_1_1_kor_ally @Unknown
-0 u_8_8_octopus @Unknown
 1 c_1_1_eldrazi_scion_sac @Izzy
 2 c_1_1_eldrazi_scion_sac @Izzy
 3 c_1_1_eldrazi_scion_sac @Izzy

--- a/forge-gui/res/editions/Outlaws of Thunder Junction Commander.txt
+++ b/forge-gui/res/editions/Outlaws of Thunder Junction Commander.txt
@@ -350,7 +350,6 @@ ScryfallCode=OTC
 342 R Yavimaya Coast @Jesper Ejsing
 
 [tokens]
-0 rgw_1_1_sand_warrior @Unknown
 1 c_10_10_eldrazi @Jack Wang
 2 c_1_1_eldrazi_scion_sac @Izzy
 3 w_4_4_angel_flying @Magali Villeneuve
@@ -373,7 +372,12 @@ ScryfallCode=OTC
 20 g_4_2_plant_warrior_reach @Xabi Gaztelua
 21 rg_5_5_elemental @Brad Rigney
 22 wb_2_1_inkling_flying @Scott Murphy
+23 rgw_1_1_sand_warrior @Piotr Foksowicz
 24 c_a_blood_draw @Miranda Meeks
 25 c_a_food_sac @Lucas Graciano
 26 c_1_1_a_soldier @Kev Walker
 27 c_1_1_a_thopter_flying @Svetlin Velinov
+
+[other]
+28 manifest @Jason A. Engle
+29 monarch @Volkan Baǵa

--- a/forge-gui/res/editions/Phyrexia All Will Be One Commander.txt
+++ b/forge-gui/res/editions/Phyrexia All Will Be One Commander.txt
@@ -182,9 +182,9 @@ ScryfallCode=ONC
 174 R Windbrisk Heights @Omar Rayyan
 
 [tokens]
-0 rw_1_1_soldier_haste @Unknown
 1 c_10_10_eldrazi @Jack Wang
-3 w_4_4_angel_flying @Volkan Baǵa
+2 w_4_4_angel_flying @Magali Villeneuve
+3 w_4_4_angel_flying_vigilance @Volkan Baǵa
 4 w_1_1_bird_flying @Howard Lyon
 5 w_1_1_human @Ben Maier
 6 w_1_1_human_soldier @Deruchenko Alexander
@@ -198,9 +198,12 @@ ScryfallCode=ONC
 14 g_3_3_elephant @Lars Grant-West
 15 g_1_1_phyrexian_insect_infect @Adrian Smith
 16 g_x_x_phyrexian_wurm_trample_toxic @Nicholas Gregory
-17 w_4_4_angel_flying_vigilance @Volkan Baǵa
+17 rw_1_1_soldier_haste @David Palumbo
 18 c_x_x_a_golem_haste @José Parodi
 19 c_1_1_a_myr @Ryan Pancoast
 20 c_x_x_a_phyrexian_horror @Scott Chou
 21 c_1_1_a_thopter_flying @Richard Wright
 23 b_0_0_phyrexian_germ @Igor Kieryluk
+
+[other]
+22 monarch @Volkan Baǵa

--- a/forge-gui/res/editions/Planechase Anthology.txt
+++ b/forge-gui/res/editions/Planechase Anthology.txt
@@ -251,13 +251,13 @@ OPCA85 C Windriddle Palaces @Kekai Kotaki
 OPCA86 C The Zephyr Maze @rk post
 
 [tokens]
-0 b_0_0_phyrexian_germ @Unknown
 1 c_7_7_eldrazi_annihilator @Vincent Proce
 2 c_0_1_eldrazi_spawn_sac @Aleksi Briclot
 3 c_0_1_eldrazi_spawn_sac @Aleksi Briclot
 4 c_0_1_eldrazi_spawn_sac @Aleksi Briclot
 5 w_4_4_angel_flying @Cyril Van Der Haegen
 6 w_0_1_goat @Terese Nielsen
+7 b_0_0_phyrexian_germ @Igor Kieryluk
 8 b_2_4_spider_reach @Lars Grant-West
 9 b_2_2_zombie @Dave Kendall
 10 r_5_5_dragon_flying @Jim Pavelec

--- a/forge-gui/res/editions/Ravnica Allegiance Guild Kit.txt
+++ b/forge-gui/res/editions/Ravnica Allegiance Guild Kit.txt
@@ -4,6 +4,7 @@ Date=2019-02-15
 Name=Ravnica Allegiance Guild Kit
 Type=Boxed_Set
 ScryfallCode=GK2
+TokenFallbackCode=RNA
 
 [cards]
 1 M Isperia, Supreme Judge @Lucas Graciano
@@ -141,7 +142,6 @@ ScryfallCode=GK2
 133 L Forest @Yeong-Hao Han
 
 [tokens]
-0 g_3_3_frog_lizard @Unknown
 1 wu_1_1_bird_flying @Shishizaru
 2 w_1_1_spirit_flying @Dave Allsop
 3 b_1_1_bat_flying @Wayne Reynolds

--- a/forge-gui/res/editions/Ravnica Remastered.txt
+++ b/forge-gui/res/editions/Ravnica Remastered.txt
@@ -513,10 +513,9 @@ ScryfallCode=RVR
 1 Chromatic Lantern|RVR
 
 [tokens]
-0 gw_2_2_elf_knight_vigilance @Unknown
-0 rw_1_1_soldier_haste @Unknown
 1 w_1_1_bird_flying @James Ryman
-3 w_4_4_angel_flying @Grzegorz Rutkowski
+2 w_4_4_angel_flying @Steve Argyle
+3 w_4_4_angel_flying_vigilance @Grzegorz Rutkowski
 4 w_1_1_spirit_flying @Dave Allsop
 5 u_1_1_bird_illusion_flying @James Paick
 6 b_2_2_zombie @Simon Dominic
@@ -528,7 +527,11 @@ ScryfallCode=RVR
 12 g_1_1_saproling @Dana Knutson
 13 g_6_6_wurm @Mitch Cotie
 14 rg_4_4_beast_trample @Winona Nelson
-15 w_4_4_angel_flying_vigilance @Grzegorz Rutkowski
+15 gw_2_2_elf_knight_vigilance @Hristo D. Chukov
+16 rw_1_1_soldier_haste @David Palumbo
 17 wu_4_4_sphinx_flying_vigilance @Scott Murphy
 18 wb_1_1_spirit_flying @Cliff Childs
 19 voja @Richard Sardinha
+
+[other]
+20 emblem_domri_rade @Tyler Jacobson

--- a/forge-gui/res/editions/Rise of the Eldrazi.txt
+++ b/forge-gui/res/editions/Rise of the Eldrazi.txt
@@ -9,6 +9,7 @@ Booster=10 Common, 3 Uncommon, 1 RareMythic, 1 BasicLand
 FatPack=8
 FatPackExtraSlots=40 BasicLands
 ScryfallCode=ROE
+TokenFallbackCode=WWK
 
 [cards]
 1 M All Is Dust @Jason Felix
@@ -261,9 +262,6 @@ ScryfallCode=ROE
 248 L Forest @Jung Park
 
 [tokens]
-0 w_1_1_kor_soldier @Unknown
-0 r_5_5_dragon_flying @Unknown
-0 g_3_3_elephant @Unknown
 1a c_0_1_eldrazi_spawn_sac @Aleksi Briclot
 1a c_0_1_eldrazi_spawn_sac @Aleksi Briclot
 1a c_0_1_eldrazi_spawn_sac @Aleksi Briclot

--- a/forge-gui/res/editions/Rivals of Ixalan.txt
+++ b/forge-gui/res/editions/Rivals of Ixalan.txt
@@ -10,6 +10,7 @@ FatPack=10
 FatPackExtraSlots=80 BasicLands
 TreatAsSmallSet=true
 ScryfallCode=RIX
+TokenFallbackCode=XLN
 
 [cards]
 1 U Baffling End @Mathias Kollros
@@ -233,15 +234,11 @@ ScryfallCode=RIX
 1 Forest|RIX
 
 [tokens]
-0 w_1_1_vampire_lifelink @Unknown
-0 u_1_1_merfolk_hexproof @Unknown
-0 g_3_3_dinosaur_trample @Unknown
-0 c_a_treasure_sac @Unknown
-0 c_a_treasure_sac @Unknown
-0 c_a_treasure_sac @Unknown
-0 c_a_treasure_sac @Unknown
-0 c_a_treasure_sac @Unknown
 1 r_0_1_elemental_rekindling_phoenix @Jason Rainville
 2 r_1_1_elemental @Lius Lasahido
 3 g_1_1_saproling @Joseph Meehan
 4 c_4_4_a_golem @Svetlin Velinov
+
+[other]
+5 emblem_huatli_radiant_champion @Chris Rahn
+6 blessing @Yeong-Hao Han

--- a/forge-gui/res/editions/Scars of Mirrodin.txt
+++ b/forge-gui/res/editions/Scars of Mirrodin.txt
@@ -263,12 +263,12 @@ ScryfallCode=SOM
 249 L Forest @Mark Tedin
 
 [tokens]
-0 g_1_1_phyrexian_insect_infect @Unknown
-0 c_3_3_a_phyrexian_wurm_deathtouch @Unknown
-0 c_3_3_a_phyrexian_wurm_lifelink @Unknown
 1 w_2_2_cat @Scott Chou
 2 w_1_1_soldier @Goran Josic
 3 r_1_1_goblin @Goran Josic
+4 g_1_1_phyrexian_insect_infect @Adrian Smith
 5 g_2_2_wolf @Chris Rahn
 6 c_3_3_a_golem @Nic Klein
 7 c_1_1_a_myr @Ryan Pancoast
+8 c_3_3_a_phyrexian_wurm_deathtouch @Raymond Swanland
+9 c_3_3_a_phyrexian_wurm_lifelink @Raymond Swanland

--- a/forge-gui/res/editions/Shadowmoor.txt
+++ b/forge-gui/res/editions/Shadowmoor.txt
@@ -314,7 +314,6 @@ ScryfallCode=SHM
 301 L Forest @Steve Prescott
 
 [tokens]
-0 gw_1_1_elf_warrior @Unknown
 1 w_1_1_kithkin_soldier @Randy Gallegos
 2 w_1_1_spirit_flying @Jeremy Enecio
 3 b_1_1_rat @Carl Critchlow
@@ -326,3 +325,4 @@ ScryfallCode=SHM
 9 br_5_5_elemental @Dave Dorman
 10 rg_4_4_giant_warrior_haste @Trevor Hairsine
 11 rg_1_1_goblin_warrior @Dave Allsop
+12 gw_1_1_elf_warrior @Carl Frank

--- a/forge-gui/res/editions/Shards of Alara.txt
+++ b/forge-gui/res/editions/Shards of Alara.txt
@@ -265,7 +265,6 @@ ScryfallCode=ALA
 250 M Rafiq of the Many @Meel Tamphanon
 
 [tokens]
-0 rgw_8_8_beast @Unknown
 1 w_1_1_soldier @Alan Pollack
 2 u_0_1_a_homunculus @Howard Lyon
 3 u_1_1_a_thopter_flying @Andrew Murray
@@ -276,3 +275,4 @@ ScryfallCode=ALA
 8 r_1_1_goblin_haste @Brandon Kitkouski
 8 g_x_x_ooze @Anthony S. Waters
 9 g_1_1_saproling @Trevor Claxton
+10 rgw_8_8_beast @Paolo Parente

--- a/forge-gui/res/editions/Streets of New Capenna Commander.txt
+++ b/forge-gui/res/editions/Streets of New Capenna Commander.txt
@@ -455,7 +455,6 @@ ScryfallCode=NCC
 447 R Windbrisk Heights @Omar Rayyan
 
 [tokens]
-0 rw_1_1_soldier_haste @Unknown
 1 c_10_10_eldrazi @Jack Wang
 2 c_0_1_eldrazi_spawn_sac @Aleksi Briclot
 4 w_2_2_cat_beast @Bayard Wu
@@ -486,6 +485,7 @@ ScryfallCode=NCC
 30 g_x_x_treefolk @Filip Burburan
 31 g_5_5_wurm @Slawomir Maniak
 32 ur_5_5_elemental_flying @Randy Gallegos
+33 rw_1_1_soldier_haste @David Palumbo
 34 c_a_clue_draw @Randy Vargas
 35 c_a_food_sac @Steve Prescott
 36 c_1_1_a_thopter_flying @Richard Wright

--- a/forge-gui/res/editions/Streets of New Capenna.txt
+++ b/forge-gui/res/editions/Streets of New Capenna.txt
@@ -564,7 +564,6 @@ A242 C A-Paragon of Modernity @Volkan Baǵa
 1 Forest|SNC|4
 
 [tokens]
-0 gw_1_1_citizen @Unknown
 2 w_3_3_angel_flying @Julia Metzger
 3 w_2_2_spirit_flying @Miranda Meeks
 4 u_1_1_fish_unblockable @Stella Spente
@@ -575,8 +574,12 @@ A242 C A-Paragon of Modernity @Volkan Baǵa
 9 g_2_2_cat_haste @David Gaillet
 10 g_3_1_dog_vigilance @David Gaillet
 11 g_4_4_rhino_warrior @Zoltan Boros
+12 gw_1_1_citizen @Maria Poliakova
 13 c_a_treasure_sac @Nadia Hurianova
 14 c_a_treasure_sac @Nadia Hurianova
 15 c_a_treasure_sac @Nadia Hurianova
 16 c_a_treasure_sac @Nadia Hurianova
 17 c_a_treasure_sac @Nadia Hurianova
+
+[other]
+1 copy @David Palumbo

--- a/forge-gui/res/editions/Strixhaven School of Mages.txt
+++ b/forge-gui/res/editions/Strixhaven School of Mages.txt
@@ -443,10 +443,14 @@ A258 U A-Spell Satchel @YW Tang
 2 Spirit Summoning
 
 [tokens]
-0 gu_0_0_fractal @Unknown
-0 rw_3_2_spirit @Unknown
 1 br_3_6_avatar_haste_bolt @Bryan Sola
 2 ur_4_4_elemental @Alayna Danner
+3 gu_0_0_fractal @Andreas Zafiratos
 4 wb_2_1_inkling_flying @Scott Murphy
 5 bg_1_1_pest_lifegain @Ilse Gort
+6 rw_3_2_spirit @David Rapoza
 7 c_a_treasure_sac @Andrew Mar
+
+[other]
+8 emblem_lukka_wayward_bonder @Kieran Yanner
+9 emblem_rowan_scholar_of_sparks @Magali Villeneuve

--- a/forge-gui/res/editions/The Lost Caverns of Ixalan.txt
+++ b/forge-gui/res/editions/The Lost Caverns of Ixalan.txt
@@ -473,7 +473,6 @@ A150 U A-Geological Appraiser @Alix Branwyn
 5 Promising Vein|LCI
 
 [tokens]
-0 rw_3_2_spirit @Unknown
 2 w_4_4_angel_flying_vigilance @Zoltan Boros
 3 w_x_x_a_gnome_soldier_total_artifacts_creatures @Steve Ellis
 4 w_1_1_vampire_lifelink @Bruno Biazotto
@@ -486,7 +485,11 @@ A150 U A-Geological Appraiser @Alix Branwyn
 11 g_0_1_dinosaur_egg @Muhammad Firdaus
 12 g_x_x_fungus_dinosaur @Dave Kendall
 13 wu_4_4_a_golem @Racrufi
+14 rw_3_2_spirit @Milivoj Ćeran
 15 wb_4_3_vampire_demon_flying @Nino Vecia
 16 c_1_1_a_gnome @Racrufi
 17 c_a_map_sac_explore @Francesca Baerald
 18 c_a_treasure_sac @Wero Gallo
+
+[other]
+1 copy @Henry Peters

--- a/forge-gui/res/editions/Theros.txt
+++ b/forge-gui/res/editions/Theros.txt
@@ -261,14 +261,16 @@ ScryfallCode=THS
 249 L Forest @Raoul Vitale
 
 [tokens]
-0 c_3_3_e_a_golem @Unknown
 1 w_2_1_e_cleric @Johann Bodin
 2 w_1_1_soldier @Seb McKinnon
-2 w_1_1_soldier @Seb McKinnon
-2 w_1_1_soldier @Seb McKinnon
+3 w_1_1_soldier @Svetlin Velinov
 4 u_2_2_bird_flying @Peter Mohrbacher
 5 u_1_0_elemental @Karl Kopinski
 6 b_1_1_harpy_flying @Nils Hamm
 7 r_1_1_soldier_haste @Johann Bodin
 8 g_2_2_boar @James Ryman
 9 rg_2_2_satyr_haste @Johann Bodin
+10 c_3_3_e_a_golem @Yeong-Hao Han
+
+[others]
+11 emblem_elspeth_suns_champion @Eric Deschamps

--- a/forge-gui/res/editions/Throne of Eldraine.txt
+++ b/forge-gui/res/editions/Throne of Eldraine.txt
@@ -428,9 +428,6 @@ A81 U A-Cauldron Familiar @Milivoj Ćeran
 A125 R A-Fires of Invention @Stanton Feng
 
 [tokens]
-0 rw_2_1_human_cleric_lifelink_haste @Unknown
-0 rw_1_2_human_rogue_haste_damage @Unknown
-0 rw_3_1_human_warrior_trample_haste @Unknown
 1 w_0_1_goat @Forrest Imel
 2 w_1_1_human @Ben Maier
 3 w_2_2_knight_vigilance @Dan Murayama Scott
@@ -441,8 +438,15 @@ A125 R A-Fires of Invention @Stanton Feng
 8 g_2_2_bear @Forrest Imel
 9 g_1_1_boar_food @Stacie Pitt
 10 g_7_7_giant @YW Tang
+11 rw_2_1_human_cleric_lifelink_haste @Suzanne Helmigh
+12 rw_1_2_human_rogue_haste_damage @Suzanne Helmigh
+13 rw_3_1_human_warrior_trample_haste @Suzanne Helmigh
 14 bg_2_2_wolf_garruk @David Gaillet
 15 c_a_food_sac @Steven Belledin
 16 c_a_food_sac @Steven Belledin
 17 c_a_food_sac @Steven Belledin
 18 c_a_food_sac @Steven Belledin
+
+[other]
+19 emblem_garruk_cursed_huntsman @Eric Deschamps
+20 adventure @Adam Paquette

--- a/forge-gui/res/editions/Time Spiral Remastered.txt
+++ b/forge-gui/res/editions/Time Spiral Remastered.txt
@@ -425,7 +425,6 @@ ScryfallCode=TSR
 411 R Lotus Bloom @Christopher Rush
 
 [tokens]
-0 c_2_2_a_assembly_worker @Unknown
 1 w_2_2_griffin_flying @Jim Nelson
 2 w_1_1_soldier @Alex Horley-Orlandelli
 3 cloud_sprite @Mark Zug
@@ -439,4 +438,5 @@ ScryfallCode=TSR
 11 g_6_1_insect_shroud @E. M. Gist
 12 llanowar_elves @Paolo Parente
 13 g_1_1_saproling @Warren Mahy
+14 c_2_2_a_assembly_worker @Mark Tedin
 15 metallic_sliver @Carl Critchlow

--- a/forge-gui/res/editions/Unglued.txt
+++ b/forge-gui/res/editions/Unglued.txt
@@ -100,9 +100,6 @@ ScryfallCode=UGL
 88 L Forest @Terese Nielsen
 
 [tokens]
-0 rabid_sheep @Unknown
-0 r_4_4_giant_chicken @Unknown
-0 g_0_1_sheep @Unknown
 1 w_1_1_pegasus_flying @Mark Zug
 2 w_1_1_soldier @Daren Bader
 3 b_2_2_zombie @Christopher Rush

--- a/forge-gui/res/editions/Unstable.txt
+++ b/forge-gui/res/editions/Unstable.txt
@@ -277,40 +277,23 @@ ScryfallCode=UST
 216 L Forest @John Avon
 
 [tokens]
-0 w_2_2_cat @Unknown
-0 w_1_1_spirit_flying @Unknown
-0 w_1_1_spirit_flying @Unknown
-0 w_4_4_angel_flying @Unknown
-0 w_4_4_angel_flying @Unknown
-0 w_1_1_soldier @Unknown
-0 u_8_8_octopus @Unknown
-0 u_1_1_a_thopter_flying @Unknown
-0 u_1_1_a_thopter_flying @Unknown
-0 b_1_1_assassin_lose_con @Unknown
-0 b_3_3_beast_deathtouch @Unknown
-0 b_5_5_demon_flying @Unknown
-0 b_2_2_vampire_flying @Unknown
-0 b_2_2_vampire_flying @Unknown
-0 b_2_2_zombie @Unknown
-0 b_2_2_zombie @Unknown
-0 r_1_1_elemental @Unknown
-0 r_1_1_elemental @Unknown
-0 g_3_3_beast @Unknown
-0 g_3_3_beast @Unknown
-0 g_1_1_saproling @Unknown
-0 g_1_1_saproling @Unknown
-0 g_6_6_wurm @Unknown
-0 gw_x_x_elemental_total_creatures @Unknown
-0 gw_x_x_elemental_total_creatures @Unknown
-0 c_a_clue_draw @Unknown
-0 c_a_clue_draw @Unknown
+1 w_4_4_angel_flying @Magali Villeneuve
 2 w_0_1_goat @Carl Critchlow
+3 w_1_1_spirit_flying @Jason A. Engle
 4 u_1_1_faerie_spy_flying_haste_draw @Dmitry Burmak
 5 storm_crow @McLean Kendree
+6 u_1_1_a_thopter_flying @Andrew Murray
 7 b_2_2_rogue_menace @Emrah Elmasli
+8 b_2_2_vampire_flying @Svetlin Velinov
+9 b_2_2_zombie @Craig J Spearing
 10 r_1_1_brainiac @Matt Dixon
+11 r_1_1_elemental @Winona Nelson
 12 r_1_1_goblin @Dave Allsop
+13 g_3_3_beast @John Donahue
+14 g_1_1_saproling @Brad Rigney
 15 g_1_1_squirrel @John Thacker
 16 c_4_4_dragon_flying @Autumn Rain Turkel
+17 gw_x_x_elemental_total_creatures @Mark Winters
+18 c_a_clue_draw @John Avon
 19 c_x_x_a_construct @Matt Gaser
 20 c_1_1_a_gnome @Dmitry Burmak

--- a/forge-gui/res/editions/War of the Spark.txt
+++ b/forge-gui/res/editions/War of the Spark.txt
@@ -335,8 +335,6 @@ ScryfallCode=WAR
 A221 R A-Teferi, Time Raveler @Chris Rallis
 
 [tokens]
-0 all_2_2_citizen @Unknown
-0 voja_friend_to_elves @Unknown
 1 c_2_2_spirit @Johann Bodin
 2 w_4_4_angel_flying_vigilance @Volkan Baǵa
 3 w_2_2_soldier_vigilance @Johan Grenier
@@ -345,11 +343,16 @@ A221 R A-Teferi, Time Raveler @Chris Rallis
 6 b_1_1_assassin_deathtouch_pwdestroy @Zezhou Chen
 7 b_2_2_zombie @Simon Dominic
 8 b_0_0_zombie_army @Tomasz Jedruszek
-8 b_0_0_zombie_army @Tomasz Jedruszek
-8 b_0_0_zombie_army @Tomasz Jedruszek
+9 b_0_0_zombie_army @Tomasz Jedruszek
+10 b_0_0_zombie_army @Tomasz Jedruszek
 11 b_4_4_zombie_warrior_vigilance @Mike Bierek
 12 r_1_1_devil_burn @Kev Walker
 13 r_4_4_dragon_flying @Kieran Yanner
 14 r_1_1_goblin @Mark Behm
 15 g_2_2_wolf @Lars Grant-West
+16 all_2_2_citizen @Winona Nelson
+17 voja_friend_to_elves @Chris Seaman
 18 c_1_1_a_servo @Victor Adame Minguez
+
+[other]
+19 emblem_nissa_who_shakes_the_world @Chris Rallis

--- a/forge-gui/res/editions/Worldwake.txt
+++ b/forge-gui/res/editions/Worldwake.txt
@@ -9,6 +9,7 @@ Booster=10 Common, 3 Uncommon, 1 RareMythic, 1 BasicLand ZEN
 FatPack=8
 FatPackExtraSlots=40 BasicLands ZEN
 ScryfallCode=WWK
+TokenFallbackCode=ZEN
 
 [cards]
 1 M Admonition Angel @Steve Argyle
@@ -158,8 +159,6 @@ ScryfallCode=WWK
 145 U Tectonic Edge @Vincent Proce
 
 [tokens]
-0 g_1_1_snake @Unknown
-0 g_2_2_wolf @Unknown
 1 w_1_1_soldier_ally @Kekai Kotaki
 2 r_5_5_dragon_flying @Raymond Swanland
 3 r_3_3_ogre @Paul Bonner

--- a/forge-gui/res/editions/Zendikar Rising Commander.txt
+++ b/forge-gui/res/editions/Zendikar Rising Commander.txt
@@ -150,11 +150,10 @@ ScryfallCode=ZNC
 142 C Terramorphic Expanse @Dan Murayama Scott
 
 [tokens]
-0 b_0_0_phyrexian_germ @Unknown
-0 ub_1_1_faerie_rogue_flying @Unknown
 1 w_1_1_bird_flying @Howard Lyon
 2 w_1_1_kor_ally @Jeremy Wilson
 3 b_1_1_faerie_rogue_flying @Dave Allsop
+4 b_0_0_phyrexian_germ @Igor Kieryluk
 5 b_1_1_goblin_rogue @Dave Kendall
 6 b_1_1_rat @Mike Bierek
 7 g_4_4_beast @Steve Prescott


### PR DESCRIPTION
Adds a way to define fallbacks to other editions.

So HOU `Pride Sovereign` makes AKH cat tokens