### PR TITLE
Support for non-Siege Battles

### DIFF
--- a/forge-core/src/main/java/forge/card/CardType.java
+++ b/forge-core/src/main/java/forge/card/CardType.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * <p>
@@ -313,6 +314,12 @@ public final class CardType implements Comparable<CardType>, CardTypeView {
             }
         }
         return landTypes;
+    }
+
+    public Set<String> getBattleTypes() {
+        if(!isBattle())
+            return Set.of();
+        return subtypes.stream().filter(CardType::isABattleType).collect(Collectors.toSet());
     }
 
     @Override

--- a/forge-core/src/main/java/forge/card/CardTypeView.java
+++ b/forge-core/src/main/java/forge/card/CardTypeView.java
@@ -16,6 +16,7 @@ public interface CardTypeView extends Iterable<String>, Serializable {
 
     Set<String> getCreatureTypes();
     Set<String> getLandTypes();
+    Set<String> getBattleTypes();
 
     boolean hasStringType(String t);
     boolean hasType(CoreType type);

--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -1654,10 +1654,27 @@ public class GameAction {
         if (!c.isBattle()) {
             return checkAgain;
         }
-        if (((c.getProtectingPlayer() == null || !c.getProtectingPlayer().isInGame()) &&
+        Player battleController = c.getController();
+        Player battleProtector = c.getProtectingPlayer();
+        /*
+         704.5w If a battle has no player in the game designated as its protector and no attacking creatures are currently
+         attacking that battle, that battle’s controller chooses an appropriate player to be its protector based on its
+         battle type. If no player can be chosen this way, the battle is put into its owner’s graveyard.
+
+         704.5x If a Siege’s controller is also its designated protector, that player chooses an opponent to become its
+         protector. If no player can be chosen this way, the battle is put into its owner’s graveyard.
+         */
+        if (((battleProtector == null || !battleProtector.isInGame()) &&
                 (game.getCombat() == null || game.getCombat().getAttackersOf(c).isEmpty())) ||
-                (c.getType().hasStringType("Siege") && c.getController().equals(c.getProtectingPlayer()))) {
-            Player newProtector = c.getController().getController().chooseSingleEntityForEffect(c.getController().getOpponents(), new SpellAbility.EmptySa(ApiType.ChoosePlayer, c), "Choose an opponent to protect this battle", null);
+                (c.getType().hasStringType("Siege") && battleController.equals(battleProtector))) {
+            Player newProtector;
+            if (c.getType().getBattleTypes().contains("Siege"))
+                newProtector = battleController.getController().chooseSingleEntityForEffect(battleController.getOpponents(), new SpellAbility.EmptySa(ApiType.ChoosePlayer, c), "Choose an opponent to protect this battle", null);
+            else {
+                // Fall back to the controller. Technically should fall back to null per the above rules, but no official
+                // cards should use this branch. For now this better supports custom cards. May need to revise this later.
+                newProtector = battleController;
+            }
             // seems unlikely unless range of influence gets implemented
             if (newProtector == null) {
                 removeList.add(c);

--- a/forge-game/src/main/java/forge/game/card/CardFactory.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactory.java
@@ -18,7 +18,6 @@
 package forge.game.card;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import forge.ImageKeys;
 import forge.StaticData;

--- a/forge-game/src/main/java/forge/game/card/CardFactory.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactory.java
@@ -308,19 +308,6 @@ public class CardFactory {
             CardFactoryUtil.setupSiegeAbilities(card);
         }
         else if (card.getType().getBattleTypes().isEmpty()) {
-            if (!Iterables.isEmpty(card.getType().getSubtypes())) {
-                //Custom battle type? Or wizards printed a Battle Artifact or something.
-                for (ReplacementEffect re : card.getReplacementEffects()) {
-                    //Do a rough search to see if there's anything that looks like a protector assignment ability in place.
-                    //Iterate over replacement effects, then recurse through their overriding abilities and sub-abilities
-                    SpellAbility sub = re.getOverridingAbility();
-                    while(sub != null) {
-                        if(sub.hasParam("Protect"))
-                            return; //Has the Protect$ Parameter. No need to add one then. Probably.
-                        sub = sub.getSubAbility();
-                    }
-                }
-            }
             //Battles with no battle type enter protected by their controller.
             String abProtector = "DB$ ChoosePlayer | Choices$ You | Protect$ True | DontNotify$ True";
             String reText = "Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated"

--- a/forge-game/src/main/java/forge/game/card/CardFactory.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactory.java
@@ -307,10 +307,13 @@ public class CardFactory {
             CardFactoryUtil.setupSiegeAbilities(card);
         }
         else if (card.getType().getBattleTypes().isEmpty()) {
+            //Probably a custom card? Check if it already has an RE for designating a protector.
+            if(card.getReplacementEffects().stream().anyMatch((re) -> re.hasParam("BattleProtector")))
+                return;
             //Battles with no battle type enter protected by their controller.
             String abProtector = "DB$ ChoosePlayer | Choices$ You | Protect$ True | DontNotify$ True";
             String reText = "Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated"
-                    + " | Description$ (As this Battle enters, its controller becomes its protector.)";
+                    + " | BattleProtector$ True | Description$ (As this Battle enters, its controller becomes its protector.)";
             ReplacementEffect re = ReplacementHandler.parseReplacement(reText, card, true);
             re.setOverridingAbility(AbilityFactory.getAbility(abProtector, card));
             card.addReplacementEffect(re);

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -4124,7 +4124,7 @@ public class CardFactoryUtil {
 
     public static void setupSiegeAbilities(Card card) {
         StringBuilder chooseSB = new StringBuilder();
-        chooseSB.append("Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated");
+        chooseSB.append("Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | BattleProtector$ True");
         chooseSB.append(" | Description$ (As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)");
         String chooseProtector = "DB$ ChoosePlayer | Defined$ You | Choices$ Opponent | Protect$ True | ChoiceTitle$ Choose an opponent to protect this battle";
 

--- a/forge-game/src/main/java/forge/game/combat/CombatUtil.java
+++ b/forge-game/src/main/java/forge/game/combat/CombatUtil.java
@@ -71,7 +71,7 @@ public class CombatUtil {
         final Game game = playerWhoAttacks.getGame();
         final CardCollection battles = CardLists.filter(game.getCardsIn(ZoneType.Battlefield), CardPredicates.BATTLES);
         for (Card battle : battles) {
-            if (battle.getType().hasSubtype("Siege") && battle.getProtectingPlayer().isOpponentOf(playerWhoAttacks)) {
+            if (battle.getProtectingPlayer().isOpponentOf(playerWhoAttacks)) {
                 defenders.add(battle);
             }
         }


### PR DESCRIPTION
Not currently used by any official cards but the rules define their behavior to an extent and it was requested to support some custom cards. This doesn't fully support custom types - the engine won't even acknowledge unknown subtypes, much less handle their intrinsic abilities or state based actions. But this does enable various designs that are protected by their controllers.