### PR TITLE
PaperToken: add CollectorNumber and update Downloader

### DIFF
--- a/forge-core/src/main/java/forge/ImageKeys.java
+++ b/forge-core/src/main/java/forge/ImageKeys.java
@@ -103,7 +103,13 @@ public final class ImageKeys {
         final String dir;
         final String filename;
         if (key.startsWith(ImageKeys.TOKEN_PREFIX)) {
-            filename = key.substring(ImageKeys.TOKEN_PREFIX.length());
+            String[] tempdata = key.substring(ImageKeys.TOKEN_PREFIX.length()).split("\\|");
+            String tokenname = tempdata[0] + "_" + tempdata[1];
+            if (tempdata.length > 2) {
+                tokenname += "_" + tempdata[2];
+            }
+            filename = tokenname;
+
             dir = CACHE_TOKEN_PICS_DIR;
         } else if (key.startsWith(ImageKeys.ICON_PREFIX)) {
             filename = key.substring(ImageKeys.ICON_PREFIX.length());
@@ -226,36 +232,27 @@ public final class ImageKeys {
                 }
             }
             if (dir.equals(CACHE_TOKEN_PICS_DIR)) {
-                int index = filename.lastIndexOf('_');
-                if (index != -1) {
-                    String setlessFilename = filename.substring(0, index);
-                    String setCode = filename.substring(index + 1);
-                    // try with upper case set
-                    file = findFile(dir, setlessFilename + "_" + setCode.toUpperCase());
+                String[] tempdata = key.substring(ImageKeys.TOKEN_PREFIX.length()).split("\\|");
+                String setlessFilename = tempdata[0];
+                String setCode = tempdata[1];
+                String collectorNumber = tempdata.length > 2 ? tempdata[2] : "";
+
+                if (!collectorNumber.isEmpty()) {
+                    file = findFile(dir, setlessFilename + "_" + setCode + "_" + collectorNumber);
                     if (file != null) {
                         cachedCards.put(filename, file);
                         return file;
                     }
-                    // try with lower case set
-                    file = findFile(dir, setlessFilename + "_" + setCode.toLowerCase());
-                    if (file != null) {
-                        cachedCards.put(filename, file);
-                        return file;
-                    }
-                    // try without set name
-                    file = findFile(dir, setlessFilename);
-                    if (file != null) {
-                        cachedCards.put(filename, file);
-                        return file;
-                    }
-                    // if there's an art variant try without it
-                    if (setlessFilename.matches(".*[0-9]*$")) {
-                        file = findFile(dir, setlessFilename.replaceAll("[0-9]*$", ""));
-                        if (file != null) {
-                            cachedCards.put(filename, file);
-                            return file;
-                        }
-                    }
+                }
+                file = findFile(dir, setlessFilename + "_" + setCode);
+                if (file != null) {
+                    cachedCards.put(filename, file);
+                    return file;
+                }
+                file = findFile(dir, setlessFilename);
+                if (file != null) {
+                    cachedCards.put(filename, file);
+                    return file;
                 }
             } else if (filename.contains("/")) {
                 String setlessFilename = filename.substring(filename.indexOf('/') + 1);

--- a/forge-core/src/main/java/forge/ImageKeys.java
+++ b/forge-core/src/main/java/forge/ImageKeys.java
@@ -102,8 +102,9 @@ public final class ImageKeys {
 
         final String dir;
         final String filename;
+        String[] tempdata = null;
         if (key.startsWith(ImageKeys.TOKEN_PREFIX)) {
-            String[] tempdata = key.substring(ImageKeys.TOKEN_PREFIX.length()).split("\\|");
+            tempdata = key.substring(ImageKeys.TOKEN_PREFIX.length()).split("\\|");
             String tokenname = tempdata[0] + "_" + tempdata[1];
             if (tempdata.length > 2) {
                 tokenname += "_" + tempdata[2];
@@ -149,6 +150,29 @@ public final class ImageKeys {
             if (file != null) {
                 cachedCards.put(filename, file);
                 return file;
+            }
+            if (dir.equals(CACHE_TOKEN_PICS_DIR)) {
+                String setlessFilename = tempdata[0];
+                String setCode = tempdata[1];
+                String collectorNumber = tempdata.length > 2 ? tempdata[2] : "";
+
+                if (!collectorNumber.isEmpty()) {
+                    file = findFile(dir, setCode + "/" + collectorNumber + "_" + setlessFilename);
+                    if (file != null) {
+                        cachedCards.put(filename, file);
+                        return file;
+                    }
+                }
+                file = findFile(dir, setCode + "/" + setlessFilename);
+                if (file != null) {
+                    cachedCards.put(filename, file);
+                    return file;
+                }
+                file = findFile(dir, setlessFilename);
+                if (file != null) {
+                    cachedCards.put(filename, file);
+                    return file;
+                }
             }
 
             // AE -> Ae and Ae -> AE for older cards with different file names
@@ -231,30 +255,7 @@ public final class ImageKeys {
                     return file;
                 }
             }
-            if (dir.equals(CACHE_TOKEN_PICS_DIR)) {
-                String[] tempdata = key.substring(ImageKeys.TOKEN_PREFIX.length()).split("\\|");
-                String setlessFilename = tempdata[0];
-                String setCode = tempdata[1];
-                String collectorNumber = tempdata.length > 2 ? tempdata[2] : "";
-
-                if (!collectorNumber.isEmpty()) {
-                    file = findFile(dir, setlessFilename + "_" + setCode + "_" + collectorNumber);
-                    if (file != null) {
-                        cachedCards.put(filename, file);
-                        return file;
-                    }
-                }
-                file = findFile(dir, setlessFilename + "_" + setCode);
-                if (file != null) {
-                    cachedCards.put(filename, file);
-                    return file;
-                }
-                file = findFile(dir, setlessFilename);
-                if (file != null) {
-                    cachedCards.put(filename, file);
-                    return file;
-                }
-            } else if (filename.contains("/")) {
+            if (filename.contains("/")) {
                 String setlessFilename = filename.substring(filename.indexOf('/') + 1);
                 file = findFile(dir, setlessFilename);
                 if (file != null) {

--- a/forge-core/src/main/java/forge/StaticData.java
+++ b/forge-core/src/main/java/forge/StaticData.java
@@ -1001,14 +1001,14 @@ public class StaticData {
             if (realSetCode != null) {
                 CardEdition.EditionEntry ee = this.editions.get(realSetCode).findOther(name);
                 if (ee != null) { // TODO add collector Number and new ImageKey format
-                    return ImageKeys.getTokenKey(name + "_" + realSetCode.toLowerCase());
+                    return ImageKeys.getTokenKey(String.format("%s|%s|%s", name, realSetCode, ee.collectorNumber()));
                 }
             }
         }
         for (CardEdition e : this.editions) {
             CardEdition.EditionEntry ee = e.findOther(name);
             if (ee != null) { // TODO add collector Number and new ImageKey format
-                return ImageKeys.getTokenKey(name + "_" + e.getCode().toLowerCase());
+                return ImageKeys.getTokenKey(String.format("%s|%s|%s", name, e.getCode(), ee.collectorNumber()));
             }
         }
         // final fallback

--- a/forge-core/src/main/java/forge/card/CardDb.java
+++ b/forge-core/src/main/java/forge/card/CardDb.java
@@ -1043,7 +1043,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
     public static final Predicate<PaperCard> EDITION_NON_PROMO = paperCard -> {
         String code = paperCard.getEdition();
         CardEdition edition = StaticData.instance().getCardEdition(code);
-        if(edition == null && code.equals("???"))
+        if(edition == null && code.equals(CardEdition.UNKNOWN_CODE))
             return true;
         return edition != null && edition.getType() != Type.PROMO;
     };
@@ -1051,7 +1051,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
     public static final Predicate<PaperCard> EDITION_NON_REPRINT = paperCard -> {
         String code = paperCard.getEdition();
         CardEdition edition = StaticData.instance().getCardEdition(code);
-        if(edition == null && code.equals("???"))
+        if(edition == null && code.equals(CardEdition.UNKNOWN_CODE))
             return true;
         return edition != null && Type.REPRINT_SET_TYPES.contains(edition.getType());
     };

--- a/forge-core/src/main/java/forge/card/CardEdition.java
+++ b/forge-core/src/main/java/forge/card/CardEdition.java
@@ -870,7 +870,7 @@ public final class CardEdition implements Comparable<CardEdition> {
 
         public CardEdition getEditionByCodeOrThrow(final String code) {
             final CardEdition set = this.get(code);
-            if (null == set && code.equals("???")) //Hardcoded set ??? is not with the others, needs special check.
+            if (null == set && code.equals(UNKNOWN_CODE)) //Hardcoded set ??? is not with the others, needs special check.
                 return UNKNOWN;
             if (null == set) {
                 throw new RuntimeException("Edition with code '" + code + "' not found");

--- a/forge-core/src/main/java/forge/item/PaperToken.java
+++ b/forge-core/src/main/java/forge/item/PaperToken.java
@@ -62,29 +62,24 @@ public class PaperToken implements InventoryItemFromSet, IPaperCard {
         this.collectorNumber = collectorNumber;
         this.artist = artist;
 
-        if (edition != null && edition.getTokens().containsKey(imageFileName)) {
-            if (collectorNumber != null && !collectorNumber.isEmpty()) {
-                int idx = 0;
-                // count the one with the same collectorNumber
-                for (CardEdition.TokenInSet t : edition.getTokens().get(imageFileName)) {
-                    ++idx;
-                    if (!t.collectorNumber.equals(collectorNumber)) {
-                        continue;
-                    }
-                    // TODO make better image file names when collector number is known
-                    // for the right index, we need to count the ones with wrong collector number too
-                    this.imageFileName.add(String.format("%s|%s|%s|%d", imageFileName, edition.getCode().toLowerCase(), collectorNumber, idx));
+        if (collectorNumber != null && !collectorNumber.isEmpty() && edition != null && edition.getTokens().containsKey(imageFileName)) {
+            int idx = 0;
+            // count the one with the same collectorNumber
+            for (CardEdition.TokenInSet t : edition.getTokens().get(imageFileName)) {
+                ++idx;
+                if (!t.collectorNumber.equals(collectorNumber)) {
+                    continue;
                 }
-                this.artIndex = this.imageFileName.size();
+                // TODO make better image file names when collector number is known
+                // for the right index, we need to count the ones with wrong collector number too
+                this.imageFileName.add(String.format("%s|%s|%s|%d", imageFileName, edition.getCode().toLowerCase(), collectorNumber, idx));
             }
-        } else if (imageFileName != null) {
-            String formatEdition = null == edition || CardEdition.UNKNOWN == edition ? "" : "_" + edition.getCode().toLowerCase();
-
-            if (null == edition || CardEdition.UNKNOWN == edition) {
-                this.imageFileName.add(imageFileName);
-            }
-            // Fallback for if the Edition doesn't know about the Token
-            this.imageFileName.add(String.format("%s|%s", imageFileName, formatEdition));
+            this.artIndex = this.imageFileName.size();
+        } else if (null == edition || CardEdition.UNKNOWN == edition) {
+            this.imageFileName.add(imageFileName);
+        } else {
+            // Fallback if CollectorNumber is not used
+            this.imageFileName.add(String.format("%s|%s", imageFileName, edition.getCode().toLowerCase()));
         }
     }
 

--- a/forge-core/src/main/java/forge/item/PaperToken.java
+++ b/forge-core/src/main/java/forge/item/PaperToken.java
@@ -72,14 +72,14 @@ public class PaperToken implements InventoryItemFromSet, IPaperCard {
                 }
                 // TODO make better image file names when collector number is known
                 // for the right index, we need to count the ones with wrong collector number too
-                this.imageFileName.add(String.format("%s|%s|%s|%d", imageFileName, edition.getCode().toLowerCase(), collectorNumber, idx));
+                this.imageFileName.add(String.format("%s|%s|%s|%d", imageFileName, edition.getCode(), collectorNumber, idx));
             }
             this.artIndex = this.imageFileName.size();
         } else if (null == edition || CardEdition.UNKNOWN == edition) {
             this.imageFileName.add(imageFileName);
         } else {
             // Fallback if CollectorNumber is not used
-            this.imageFileName.add(String.format("%s|%s", imageFileName, edition.getCode().toLowerCase()));
+            this.imageFileName.add(String.format("%s|%s", imageFileName, edition.getCode()));
         }
     }
 

--- a/forge-core/src/main/java/forge/item/PaperToken.java
+++ b/forge-core/src/main/java/forge/item/PaperToken.java
@@ -11,6 +11,8 @@ import java.util.Locale;
 public class PaperToken implements InventoryItemFromSet, IPaperCard {
     private static final long serialVersionUID = 1L;
     private String name;
+    private String collectorNumber;
+    private String artist;
     private transient CardEdition edition;
     private ArrayList<String> imageFileName = new ArrayList<>();
     private transient CardRules cardRules;
@@ -53,75 +55,36 @@ public class PaperToken implements InventoryItemFromSet, IPaperCard {
         return makeTokenFileName(fileName);
     }
 
-    public static String makeTokenFileName(final CardRules rules, CardEdition edition) {
-        ArrayList<String> build = new ArrayList<>();
-
-        String subtypes = StringUtils.join(rules.getType().getSubtypes(), " ");
-        if (!rules.getName().equals(subtypes)) {
-            return makeTokenFileName(rules.getName());
-        }
-
-        ColorSet colors = rules.getColor();
-
-        if (colors.isColorless()) {
-            build.add("C");
-        } else {
-            String color = "";
-            if (colors.hasWhite()) color += "W";
-            if (colors.hasBlue()) color += "U";
-            if (colors.hasBlack()) color += "B";
-            if (colors.hasRed()) color += "R";
-            if (colors.hasGreen()) color += "G";
-
-            build.add(color);
-        }
-
-        if (rules.getPower() != null && rules.getToughness() != null) {
-            build.add(rules.getPower());
-            build.add(rules.getToughness());
-        }
-
-        String cardTypes = "";
-        if (rules.getType().isArtifact()) cardTypes += "A";
-        if (rules.getType().isEnchantment()) cardTypes += "E";
-
-        if (!cardTypes.isEmpty()) {
-            build.add(cardTypes);
-        }
-
-        build.add(subtypes);
-
-        // Are these keywords sorted?
-        for (String keyword : rules.getMainPart().getKeywords()) {
-            build.add(keyword);
-        }
-
-        if (edition != null) {
-            build.add(edition.getCode());
-        }
-
-        return StringUtils.join(build, "_").replace('*', 'x').toLowerCase();
-    }
-
-    public PaperToken(final CardRules c, CardEdition edition0, String imageFileName) {
+    public PaperToken(final CardRules c, CardEdition edition0, String imageFileName, String collectorNumber, String artist) {
         this.cardRules = c;
         this.name = c.getName();
         this.edition = edition0;
+        this.collectorNumber = collectorNumber;
+        this.artist = artist;
 
         if (edition != null && edition.getTokens().containsKey(imageFileName)) {
-            this.artIndex = edition.getTokens().get(imageFileName).size();
-        }
-
-        if (imageFileName == null) {
-            // This shouldn't really happen. We can just use the normalized name again for the base image name
-            this.imageFileName.add(makeTokenFileName(c, edition0));
-        } else {
+            if (collectorNumber != null && !collectorNumber.isEmpty()) {
+                int idx = 0;
+                // count the one with the same collectorNumber
+                for (CardEdition.TokenInSet t : edition.getTokens().get(imageFileName)) {
+                    ++idx;
+                    if (!t.collectorNumber.equals(collectorNumber)) {
+                        continue;
+                    }
+                    // TODO make better image file names when collector number is known
+                    // for the right index, we need to count the ones with wrong collector number too
+                    this.imageFileName.add(String.format("%s|%s|%s|%d", imageFileName, edition.getCode().toLowerCase(), collectorNumber, idx));
+                }
+                this.artIndex = this.imageFileName.size();
+            }
+        } else if (imageFileName != null) {
             String formatEdition = null == edition || CardEdition.UNKNOWN == edition ? "" : "_" + edition.getCode().toLowerCase();
 
-            this.imageFileName.add(String.format("%s%s", imageFileName, formatEdition));
-            for (int idx = 2; idx <= this.artIndex; idx++) {
-                this.imageFileName.add(String.format("%s%d%s", imageFileName, idx, formatEdition));
+            if (null == edition || CardEdition.UNKNOWN == edition) {
+                this.imageFileName.add(imageFileName);
             }
+            // Fallback for if the Edition doesn't know about the Token
+            this.imageFileName.add(String.format("%s|%s", imageFileName, formatEdition));
         }
     }
 
@@ -137,12 +100,14 @@ public class PaperToken implements InventoryItemFromSet, IPaperCard {
 
     @Override
     public String getEdition() {
-        return edition != null ? edition.getCode() : "???";
+        return edition != null ? edition.getCode() : CardEdition.UNKNOWN_CODE;
     }
 
     @Override
     public String getCollectorNumber() {
-        return IPaperCard.NO_COLLECTOR_NUMBER;
+        if (collectorNumber.isEmpty())
+            return IPaperCard.NO_COLLECTOR_NUMBER;
+        return collectorNumber;
     }
 
     @Override
@@ -177,13 +142,8 @@ public class PaperToken implements InventoryItemFromSet, IPaperCard {
     }
 
     @Override
-    public String getArtist() { /*TODO*/
-        return "";
-    }
-
-    // Unfortunately this is a property of token, cannot move it outside of class
-    public String getImageFilename() {
-        return getImageFilename(1);
+    public String getArtist() {
+        return artist;
     }
 
     public String getImageFilename(int idx) {
@@ -261,11 +221,11 @@ public class PaperToken implements InventoryItemFromSet, IPaperCard {
         if (hasBackFace()) {
             String edCode = edition != null ? "_" + edition.getCode().toLowerCase() : "";
             if (altState) {
-                String name = ImageKeys.TOKEN_PREFIX + cardRules.getOtherPart().getName().toLowerCase().replace(" token", "");
+                String name = ImageKeys.getTokenKey(cardRules.getOtherPart().getName().toLowerCase().replace(" token", ""));
                 name.replace(" ", "_");
                 return name + edCode;
             } else {
-                String name = ImageKeys.TOKEN_PREFIX + cardRules.getMainPart().getName().toLowerCase().replace(" token", "");
+                String name = ImageKeys.getTokenKey(cardRules.getMainPart().getName().toLowerCase().replace(" token", ""));
                 name.replace(" ", "_");
                 return name + edCode;
             }
@@ -275,7 +235,7 @@ public class PaperToken implements InventoryItemFromSet, IPaperCard {
     }
 
     public String getImageKey(int artIndex) {
-        return ImageKeys.TOKEN_PREFIX + imageFileName.get(artIndex).replace(" ", "_");
+        return ImageKeys.getTokenKey(imageFileName.get(artIndex).replace(" ", "_"));
     }
 
     public boolean isRebalanced() {

--- a/forge-core/src/main/java/forge/item/PaperToken.java
+++ b/forge-core/src/main/java/forge/item/PaperToken.java
@@ -213,20 +213,17 @@ public class PaperToken implements InventoryItemFromSet, IPaperCard {
     // InventoryItem
     @Override
     public String getImageKey(boolean altState) {
-        if (hasBackFace()) {
-            String edCode = edition != null ? "_" + edition.getCode().toLowerCase() : "";
-            if (altState) {
-                String name = ImageKeys.getTokenKey(cardRules.getOtherPart().getName().toLowerCase().replace(" token", ""));
-                name.replace(" ", "_");
-                return name + edCode;
+        String suffix = "";
+        if (hasBackFace() && altState) {
+            if (collectorNumber != null && !collectorNumber.isEmpty() && edition != null) {
+                String name = cardRules.getOtherPart().getName().toLowerCase().replace(" token", "").replace(" ", "_");
+                return ImageKeys.getTokenKey(String.format("%s|%s|%s%s", name, edition.getCode(), collectorNumber, ImageKeys.BACKFACE_POSTFIX));
             } else {
-                String name = ImageKeys.getTokenKey(cardRules.getMainPart().getName().toLowerCase().replace(" token", ""));
-                name.replace(" ", "_");
-                return name + edCode;
+                suffix = ImageKeys.BACKFACE_POSTFIX;
             }
         }
         int idx = MyRandom.getRandom().nextInt(artIndex);
-        return getImageKey(idx);
+        return getImageKey(idx) + suffix;
     }
 
     public String getImageKey(int artIndex) {

--- a/forge-core/src/main/java/forge/item/PaperToken.java
+++ b/forge-core/src/main/java/forge/item/PaperToken.java
@@ -65,9 +65,9 @@ public class PaperToken implements InventoryItemFromSet, IPaperCard {
         if (collectorNumber != null && !collectorNumber.isEmpty() && edition != null && edition.getTokens().containsKey(imageFileName)) {
             int idx = 0;
             // count the one with the same collectorNumber
-            for (CardEdition.TokenInSet t : edition.getTokens().get(imageFileName)) {
+            for (CardEdition.EditionEntry t : edition.getTokens().get(imageFileName)) {
                 ++idx;
-                if (!t.collectorNumber.equals(collectorNumber)) {
+                if (!t.collectorNumber().equals(collectorNumber)) {
                     continue;
                 }
                 // TODO make better image file names when collector number is known

--- a/forge-core/src/main/java/forge/token/TokenDb.java
+++ b/forge-core/src/main/java/forge/token/TokenDb.java
@@ -75,6 +75,17 @@ public class TokenDb implements ITokenDatabase {
         return new PaperToken(rulesByName.get(name), edition, name, t.collectorNumber, t.artistName);
     }
 
+    // try all editions to find token
+    protected PaperToken fallbackToken(String name) {
+        for (CardEdition edition : this.editions) {
+            String fullName = String.format("%s_%s", name, edition.getCode().toLowerCase());
+            if (loadTokenFromSet(edition, name)) {
+                return Aggregates.random(allTokenByName.get(fullName));
+            }
+        }
+        return null;
+    }
+
     @Override
     public PaperToken getToken(String tokenName) {
         return getToken(tokenName, CardEdition.UNKNOWN.getCode());
@@ -88,6 +99,10 @@ public class TokenDb implements ITokenDatabase {
         // token exist in Set, return one at random
         if (loadTokenFromSet(realEdition, tokenName)) {
             return Aggregates.random(allTokenByName.get(fullName));
+        }
+        PaperToken fallback = this.fallbackToken(tokenName);
+        if (fallback != null) {
+            return fallback;
         }
 
         if (!extraTokensByName.containsKey(fullName)) {

--- a/forge-core/src/main/java/forge/token/TokenDb.java
+++ b/forge-core/src/main/java/forge/token/TokenDb.java
@@ -1,10 +1,15 @@
 package forge.token;
 
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+
 import forge.card.CardDb;
 import forge.card.CardEdition;
 import forge.card.CardRules;
+import forge.item.IPaperCard;
 import forge.item.PaperToken;
+import forge.util.Aggregates;
 
 import java.util.*;
 import java.util.function.Predicate;
@@ -23,8 +28,8 @@ public class TokenDb implements ITokenDatabase {
 
     // The image names should be the same as the script name + _set
     // If that isn't found, consider falling back to the original token
-
-    private final Map<String, PaperToken> tokensByName = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
+    private final Multimap<String, PaperToken> allTokenByName = HashMultimap.create();
+    private final Map<String, PaperToken> extraTokensByName = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
 
     private final CardEdition.Collection editions;
     private final Map<String, CardRules> rulesByName;
@@ -38,38 +43,64 @@ public class TokenDb implements ITokenDatabase {
         return this.rulesByName.containsKey(rule);
 
     }
-    @Override
-    public PaperToken getToken(String tokenName) {
-        return getToken(tokenName, CardEdition.UNKNOWN.getName());
-    }
 
     public void preloadTokens() {
         for (CardEdition edition : this.editions) {
-            for (String name : edition.getTokens().keySet()) {
-                try {
-                    getToken(name, edition.getCode());
-                } catch(Exception e) {
-                    System.out.println(name + "_" + edition.getCode() + " defined in Edition file, but not defined as a token script.");
+            for (Map.Entry<String, Collection<CardEdition.TokenInSet>> inSet : edition.getTokens().asMap().entrySet()) {
+                String name = inSet.getKey();
+                String fullName = String.format("%s_%s", name, edition.getCode().toLowerCase());
+                for (CardEdition.TokenInSet t : inSet.getValue()) {
+                    allTokenByName.put(fullName, addTokenInSet(edition, name, t));
                 }
             }
         }
     }
 
+    protected boolean loadTokenFromSet(CardEdition edition, String name) {
+        String fullName = String.format("%s_%s", name, edition.getCode().toLowerCase());
+        if (allTokenByName.containsKey(fullName)) {
+            return true;
+        }
+        if (!edition.getTokens().containsKey(name)) {
+            return false;
+        }
+
+        for (CardEdition.TokenInSet t : edition.getTokens().get(name)) {
+            allTokenByName.put(fullName, addTokenInSet(edition, name, t));
+        }
+        return true;
+    }
+
+    protected PaperToken addTokenInSet(CardEdition edition, String name, CardEdition.TokenInSet t) {
+        return new PaperToken(rulesByName.get(name), edition, name, t.collectorNumber, t.artistName);
+    }
+
+    @Override
+    public PaperToken getToken(String tokenName) {
+        return getToken(tokenName, CardEdition.UNKNOWN.getCode());
+    }
+
     @Override
     public PaperToken getToken(String tokenName, String edition) {
-        String fullName = String.format("%s_%s", tokenName, edition.toLowerCase());
+        CardEdition realEdition = editions.getEditionByCodeOrThrow(edition);
+        String fullName = String.format("%s_%s", tokenName, realEdition.getCode().toLowerCase());
 
-        if (!tokensByName.containsKey(fullName)) {
+        // token exist in Set, return one at random
+        if (loadTokenFromSet(realEdition, tokenName)) {
+            return Aggregates.random(allTokenByName.get(fullName));
+        }
+
+        if (!extraTokensByName.containsKey(fullName)) {
             try {
-                PaperToken pt = new PaperToken(rulesByName.get(tokenName), editions.get(edition), tokenName);
-                tokensByName.put(fullName, pt);
+                PaperToken pt = new PaperToken(rulesByName.get(tokenName), realEdition, tokenName, "", IPaperCard.NO_ARTIST_NAME);
+                extraTokensByName.put(fullName, pt);
                 return pt;
             } catch(Exception e) {
                 throw e;
             }
         }
 
-        return tokensByName.get(fullName);
+        return extraTokensByName.get(fullName);
     }
 
     @Override
@@ -119,7 +150,7 @@ public class TokenDb implements ITokenDatabase {
 
     @Override
     public List<PaperToken> getAllTokens() {
-        return new ArrayList<>(tokensByName.values());
+        return new ArrayList<>(allTokenByName.values());
     }
 
     @Override
@@ -139,6 +170,6 @@ public class TokenDb implements ITokenDatabase {
 
     @Override
     public Iterator<PaperToken> iterator() {
-        return tokensByName.values().iterator();
+        return allTokenByName.values().iterator();
     }
 }

--- a/forge-core/src/main/java/forge/token/TokenDb.java
+++ b/forge-core/src/main/java/forge/token/TokenDb.java
@@ -46,10 +46,10 @@ public class TokenDb implements ITokenDatabase {
 
     public void preloadTokens() {
         for (CardEdition edition : this.editions) {
-            for (Map.Entry<String, Collection<CardEdition.TokenInSet>> inSet : edition.getTokens().asMap().entrySet()) {
+            for (Map.Entry<String, Collection<CardEdition.EditionEntry>> inSet : edition.getTokens().asMap().entrySet()) {
                 String name = inSet.getKey();
                 String fullName = String.format("%s_%s", name, edition.getCode().toLowerCase());
-                for (CardEdition.TokenInSet t : inSet.getValue()) {
+                for (CardEdition.EditionEntry t : inSet.getValue()) {
                     allTokenByName.put(fullName, addTokenInSet(edition, name, t));
                 }
             }
@@ -65,14 +65,14 @@ public class TokenDb implements ITokenDatabase {
             return false;
         }
 
-        for (CardEdition.TokenInSet t : edition.getTokens().get(name)) {
+        for (CardEdition.EditionEntry t : edition.getTokens().get(name)) {
             allTokenByName.put(fullName, addTokenInSet(edition, name, t));
         }
         return true;
     }
 
-    protected PaperToken addTokenInSet(CardEdition edition, String name, CardEdition.TokenInSet t) {
-        return new PaperToken(rulesByName.get(name), edition, name, t.collectorNumber, t.artistName);
+    protected PaperToken addTokenInSet(CardEdition edition, String name, CardEdition.EditionEntry t) {
+        return new PaperToken(rulesByName.get(name), edition, name, t.collectorNumber(), t.artistName());
     }
 
     // try all editions to find token

--- a/forge-core/src/main/java/forge/util/ImageUtil.java
+++ b/forge-core/src/main/java/forge/util/ImageUtil.java
@@ -197,9 +197,11 @@ public class ImageUtil {
                 langCode, versionParam, faceParam);
     }
 
-    public static String getScryfallTokenDownloadUrl(String collectorNumber, String setCode, String langCode) {
+    public static String getScryfallTokenDownloadUrl(String collectorNumber, String setCode, String langCode, String faceParam) {
         String versionParam = "normal";
-        String faceParam = "";
+        if (!faceParam.isEmpty()) {
+            faceParam = (faceParam.equals("back") ? "&face=back" : "&face=front");
+        }
         return String.format("%s/%s/%s?format=image&version=%s%s", setCode, collectorNumber,
                 langCode, versionParam, faceParam);
     }

--- a/forge-gui-desktop/src/main/java/forge/util/SwingImageFetcher.java
+++ b/forge-gui-desktop/src/main/java/forge/util/SwingImageFetcher.java
@@ -36,7 +36,7 @@ public class SwingImageFetcher extends ImageFetcher {
 
             String newdespath = urlToDownload.contains(".fullborder.jpg") || urlToDownload.startsWith(ForgeConstants.URL_PIC_SCRYFALL_DOWNLOAD) ?
                     TextUtil.fastReplace(destPath, ".full.jpg", ".fullborder.jpg") : destPath;
-            if (!newdespath.contains(".full") && urlToDownload.startsWith(ForgeConstants.URL_PIC_SCRYFALL_DOWNLOAD))
+            if (!newdespath.contains(".full") && urlToDownload.startsWith(ForgeConstants.URL_PIC_SCRYFALL_DOWNLOAD) && !destPath.startsWith(ForgeConstants.CACHE_TOKEN_PICS_DIR))
                 newdespath = newdespath.replace(".jpg", ".fullborder.jpg"); //fix planes/phenomenon for round border options
             URL url = new URL(urlToDownload);
             System.out.println("Attempting to fetch: " + url);

--- a/forge-gui-mobile/src/forge/util/LibGDXImageFetcher.java
+++ b/forge-gui-mobile/src/forge/util/LibGDXImageFetcher.java
@@ -37,7 +37,7 @@ public class LibGDXImageFetcher extends ImageFetcher {
 
             String newdespath = urlToDownload.contains(".fullborder.") || urlToDownload.startsWith(ForgeConstants.URL_PIC_SCRYFALL_DOWNLOAD) ?
                     TextUtil.fastReplace(destPath, ".full.", ".fullborder.") : destPath;
-            if (!newdespath.contains(".full") && urlToDownload.startsWith(ForgeConstants.URL_PIC_SCRYFALL_DOWNLOAD))
+            if (!newdespath.contains(".full") && urlToDownload.startsWith(ForgeConstants.URL_PIC_SCRYFALL_DOWNLOAD) && !destPath.startsWith(ForgeConstants.CACHE_TOKEN_PICS_DIR))
                 newdespath = newdespath.replace(".jpg", ".fullborder.jpg"); //fix planes/phenomenon for round border options
             URL url = new URL(urlToDownload);
             System.out.println("Attempting to fetch: " + url);

--- a/forge-gui/src/main/java/forge/gamemodes/quest/QuestUtil.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/QuestUtil.java
@@ -156,7 +156,7 @@ public class QuestUtil {
         script.add("Types:" + properties[5].replace(';', ' '));
         script.add("Oracle:"); // tokens don't have texts yet
         final String fileName = PaperToken.makeTokenFileName(properties[1], properties[2], properties[3], properties[4]);
-        return new PaperToken(CardRules.fromScript(script), CardEdition.UNKNOWN, fileName);
+        return new PaperToken(CardRules.fromScript(script), CardEdition.UNKNOWN, fileName, "", IPaperCard.NO_ARTIST_NAME);
     }
 
     /**

--- a/forge-gui/src/main/java/forge/gamemodes/quest/bazaar/QuestPetStats.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/bazaar/QuestPetStats.java
@@ -8,6 +8,7 @@ import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 
 import forge.card.CardEdition;
 import forge.card.CardRules;
+import forge.item.IPaperCard;
 import forge.item.PaperToken;
 import forge.localinstance.properties.ForgeConstants;
 import forge.util.FileUtil;
@@ -59,7 +60,7 @@ public class QuestPetStats {
         if (null == petCard) {
             List<String> cardLines = FileUtil.readFile(new File(ForgeConstants.BAZAAR_DIR, cardFile));
             CardRules rules = CardRules.fromScript(cardLines);
-            petCard = new PaperToken(rules, CardEdition.UNKNOWN, picture);
+            petCard = new PaperToken(rules, CardEdition.UNKNOWN, picture, "", IPaperCard.NO_ARTIST_NAME);
         }
         return petCard;
     }

--- a/forge-gui/src/main/java/forge/gui/download/GuiDownloadPicturesHQ.java
+++ b/forge-gui/src/main/java/forge/gui/download/GuiDownloadPicturesHQ.java
@@ -17,6 +17,7 @@
  */
 package forge.gui.download;
 
+import forge.card.CardEdition;
 import forge.item.PaperCard;
 import forge.localinstance.properties.ForgeConstants;
 import forge.model.FModel;
@@ -93,7 +94,7 @@ public class GuiDownloadPicturesHQ extends GuiDownloadService {
         cardname = cardname.replace(" ", "+");
         cardname = cardname.replace("'", "");
         String scryfallurl = ForgeConstants.URL_PIC_SCRYFALL_DOWNLOAD + "named?fuzzy=" + cardname;
-        if(!setCode.equals("???")) scryfallurl += "&set=" + setCode.toLowerCase();
+        if(!setCode.equals(CardEdition.UNKNOWN_CODE)) scryfallurl += "&set=" + setCode.toLowerCase();
         if(face.equals("back")) scryfallurl += "&face=back";
         scryfallurl += "&format=image";
 

--- a/forge-gui/src/main/java/forge/util/ImageFetcher.java
+++ b/forge-gui/src/main/java/forge/util/ImageFetcher.java
@@ -232,11 +232,12 @@ public abstract class ImageFetcher {
             String tokenName = tempdata[0];
             String setCode = tempdata[1];
 
-            StringBuilder sb = new StringBuilder(tokenName);
-            sb.append("_").append(setCode);
+            StringBuilder sb = new StringBuilder(setCode);
+            sb.append("/");
             if (tempdata.length > 2) {
-                sb.append("_").append(tempdata[2]);
+                sb.append(tempdata[2]).append("_");
             }
+            sb.append(tokenName);
             sb.append(".jpg");
 
             final String filename = sb.toString();

--- a/forge-gui/src/main/java/forge/util/ImageFetcher.java
+++ b/forge-gui/src/main/java/forge/util/ImageFetcher.java
@@ -228,21 +228,29 @@ public abstract class ImageFetcher {
                 this.getScryfallDownloadURL(paperCard, face, useArtCrop, hasSetLookup, filename, downloadUrls);
             }
         } else if (prefix.equals(ImageKeys.TOKEN_PREFIX)) {
-            final String filename = imageKey.substring(2) + ".jpg";
+            String[] tempdata = imageKey.substring(2).split("\\|"); //We want to check the edition first.
+            String tokenName = tempdata[0];
+            String setCode = tempdata[1];
+
+            StringBuilder sb = new StringBuilder(tokenName);
+            sb.append("_").append(setCode);
+            if (tempdata.length > 2) {
+                sb.append("_").append(tempdata[2]);
+            }
+            sb.append(".jpg");
+
+            final String filename = sb.toString();
             if (ImageKeys.missingCards.contains(filename))
                 return;
 
             if (filename.equalsIgnoreCase("null.jpg"))
                 return;
 
-            String[] tempdata = imageKey.substring(2).split("[_](?=[^_]*$)"); //We want to check the edition first.
             if (tempdata.length < 2) {
                 System.err.println("Token image key is malformed: " + imageKey);
                 return;
             }
 
-            String tokenName = tempdata[0];
-            String setCode = tempdata[1];
 
             // Load the paper token from filename + edition
             CardEdition edition = StaticData.instance().getEditions().get(setCode);
@@ -251,7 +259,12 @@ public abstract class ImageFetcher {
             //PaperToken pt = StaticData.instance().getAllTokens().getToken(tokenName, setCode);
             Collection<CardEdition.EditionEntry> allTokens = edition.getTokens().get(tokenName);
 
-            if (!allTokens.isEmpty()) {
+            if (tempdata.length > 2) {
+                String tokenCode = edition.getTokensCode();
+                String langCode = edition.getCardsLangCode();
+                // just assume the CNr from the token image is valid
+                downloadUrls.add(ForgeConstants.URL_PIC_SCRYFALL_DOWNLOAD + ImageUtil.getScryfallTokenDownloadUrl(tempdata[2], tokenCode, langCode));
+            } else if (!allTokens.isEmpty()) {
                 // This loop is going to try to download all the arts until it finds one
                 // This is a bit wrong since it _should_ just be trying to get the one with the appropriate collector number
                 // Since we don't have that for tokens, we'll just take the first one

--- a/forge-gui/src/main/java/forge/util/ImageFetcher.java
+++ b/forge-gui/src/main/java/forge/util/ImageFetcher.java
@@ -129,6 +129,7 @@ public abstract class ImageFetcher {
         boolean useArtCrop = "Crop".equals(FModel.getPreferences().getPref(ForgePreferences.FPref.UI_CARD_ART_FORMAT));
         final String prefix = imageKey.substring(0, 2);
         File destFile = null;
+        String face = "";
         if (prefix.equals(ImageKeys.CARD_PREFIX)) {
             PaperCard paperCard = ImageUtil.getPaperCardFromImageKey(imageKey);
             if (paperCard == null) {
@@ -144,7 +145,6 @@ public abstract class ImageFetcher {
                 return;
             String imagePath = ImageUtil.getImageRelativePath(paperCard, "", true, false);
             final boolean hasSetLookup = ImageKeys.hasSetLookup(imagePath);
-            String face = "";
             if (imageKey.endsWith(ImageKeys.BACKFACE_POSTFIX)) {
                 face = "back";
             } else if (imageKey.endsWith(ImageKeys.SPECFACE_W)) {
@@ -228,7 +228,12 @@ public abstract class ImageFetcher {
                 this.getScryfallDownloadURL(paperCard, face, useArtCrop, hasSetLookup, filename, downloadUrls);
             }
         } else if (prefix.equals(ImageKeys.TOKEN_PREFIX)) {
-            String[] tempdata = imageKey.substring(2).split("\\|"); //We want to check the edition first.
+            String tmp = imageKey;
+            if (tmp.endsWith(ImageKeys.BACKFACE_POSTFIX)) {
+                face = "back";
+                tmp = tmp.substring(0, tmp.length() - ImageKeys.BACKFACE_POSTFIX.length());
+            }
+            String[] tempdata = tmp.substring(2).split("\\|"); //We want to check the edition first.
             String tokenName = tempdata[0];
             String setCode = tempdata[1];
 
@@ -238,6 +243,9 @@ public abstract class ImageFetcher {
                 sb.append(tempdata[2]).append("_");
             }
             sb.append(tokenName);
+            if (tempdata.length <= 2 && !face.isEmpty()) {
+                sb.append("_").append(face);
+            }
             sb.append(".jpg");
 
             final String filename = sb.toString();
@@ -264,7 +272,7 @@ public abstract class ImageFetcher {
                 String tokenCode = edition.getTokensCode();
                 String langCode = edition.getCardsLangCode();
                 // just assume the CNr from the token image is valid
-                downloadUrls.add(ForgeConstants.URL_PIC_SCRYFALL_DOWNLOAD + ImageUtil.getScryfallTokenDownloadUrl(tempdata[2], tokenCode, langCode));
+                downloadUrls.add(ForgeConstants.URL_PIC_SCRYFALL_DOWNLOAD + ImageUtil.getScryfallTokenDownloadUrl(tempdata[2], tokenCode, langCode, face));
             } else if (!allTokens.isEmpty()) {
                 // This loop is going to try to download all the arts until it finds one
                 // This is a bit wrong since it _should_ just be trying to get the one with the appropriate collector number
@@ -282,7 +290,7 @@ public abstract class ImageFetcher {
                         continue;
                     }
 
-                    downloadUrls.add(ForgeConstants.URL_PIC_SCRYFALL_DOWNLOAD + ImageUtil.getScryfallTokenDownloadUrl(tis.collectorNumber(), tokenCode, langCode));
+                    downloadUrls.add(ForgeConstants.URL_PIC_SCRYFALL_DOWNLOAD + ImageUtil.getScryfallTokenDownloadUrl(tis.collectorNumber(), tokenCode, langCode, face));
                 }
             }
 


### PR DESCRIPTION
- Adds CollectorNumber to PaperToken
- Updates Token ImageKey to something more parseable, like with PaperCard
- Updates Downloader to use correct CollectorNumber if possible

This Updates the resulting the filename in the folder be be changed:
from `c_a_clue_draw2_mkm.jpg` with idx = 2
to `c_a_clue_draw_mkm_17.jpg` with nr = 17

Or should the filename to be changed to `mkn/17_c_a_clue_draw.jpg` with set based subfolder and Nr first?