### PR TITLE
YTDM: 4 more cards

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/desert_cenote.txt
+++ b/forge-gui/res/cardsfolder/upcoming/desert_cenote.txt
@@ -1,0 +1,11 @@
+Name:Desert Cenote
+ManaCost:no cost
+Types:Land Desert
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplaceWith$ LandTapped | ReplacementResult$ Updated | Description$ If you were the starting player, this land enters tapped.
+SVar:LandTapped:DB$ Tap | Defined$ Self | ETB$ True | ConditionCheckSVar$ X | ConditionSVarCompare$ LT1
+SVar:X:Count$StartingPlayer.0.1
+K:ETBReplacement:Other:ChooseColors
+SVar:ChooseColors:DB$ ChooseColor | Defined$ You | TwoColors$ True | UpTo$ True | ColorsFrom$ Card.inZoneHand+YouOwn | AILogic$ MostProminentInComputerDeck | SpellDescription$ As this land enters, choose up to two colors from among cards in your hand.
+A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
+A:AB$ Mana | Cost$ T | Produced$ Combo Chosen | SpellDescription$ Add one mana of a chosen color.
+Oracle:If you were the starting player, this land enters tapped.\nAs this land enters, choose up to two colors from among cards in your hand.\n{T}: Add {C}.\n{T}: Add one mana of a chosen color.

--- a/forge-gui/res/cardsfolder/upcoming/dragonweave_tapestry.txt
+++ b/forge-gui/res/cardsfolder/upcoming/dragonweave_tapestry.txt
@@ -1,0 +1,10 @@
+Name:Dragonweave Tapestry
+ManaCost:4
+Types:Artifact
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigConjure | TriggerDescription$ When this artifact enters, conjure Dragonweave Tapestry’s spellbook into your library twice, then shuffle.
+SVar:TrigConjure:DB$ MakeCard | Conjure$ True | Names$ Disruptive Stormbrood,Purging Stormbrood,Runescale Stormbrood,Twinmaw Stormbrood,Whirlwing Stormbrood | Zone$ Library | Shuffle$ False | SubAbility$ DBConjure
+SVar:DBConjure:DB$ MakeCard | Conjure$ True | Names$ Disruptive Stormbrood,Purging Stormbrood,Runescale Stormbrood,Twinmaw Stormbrood,Whirlwing Stormbrood | Zone$ Library
+T:Mode$ SpellCast | ValidCard$ Dragon,Omen | ValidActivatingPlayer$ You | Execute$ TrigDraw | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a Dragon or Omen spell, draw a card.
+SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1
+A:AB$ Mana | Cost$ T | Produced$ Any | SpellDescription$ Add one mana of any color.
+Oracle:When this artifact enters, conjure Dragonweave Tapestry’s spellbook into your library twice, then shuffle.\nWhenever you cast a Dragon or Omen spell, draw a card.\n{T}: Add one mana of any color.

--- a/forge-gui/res/cardsfolder/upcoming/territorial_strike.txt
+++ b/forge-gui/res/cardsfolder/upcoming/territorial_strike.txt
@@ -1,0 +1,7 @@
+Name:Territorial Strike
+ManaCost:1 B G
+Types:Sorcery
+S:Mode$ OptionalCost | EffectZone$ All | ValidCard$ Card.Self | ValidSA$ Spell | Cost$ Behold<1/Creature.Dragon> | Description$ As an additional cost to cast this spell, you may behold a Dragon. (You may choose a Dragon you control or reveal a Dragon card from your hand.)
+A:SP$ Destroy | ValidTgts$ Permanent.nonLand | TgtPrompt$ Select target nonland permanent | SubAbility$ DBPump | SpellDescription$ Destroy target nonland permanent.
+SVar:DBPump:DB$ Pump | Defined$ Beheld | NumAtt$ +2 | NumDef$ +2 | Duration$ Perpetual
+Oracle:As an additional cost to cast this spell, you may behold a Dragon creature.\nDestroy target nonland permanent. If a Dragon creature was beheld, it perpetually gets +2/+2.

--- a/forge-gui/res/cardsfolder/upcoming/xho_cai_flickering_talon.txt
+++ b/forge-gui/res/cardsfolder/upcoming/xho_cai_flickering_talon.txt
@@ -1,0 +1,17 @@
+Name:Xho Cai, Flickering Talon
+ManaCost:U R W
+Types:Legendary Creature Bird Monk
+PT:2/3
+K:Flying
+K:Vigilance
+K:Haste
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigEffect | TriggerDescription$ When NICKNAME enters, the next noncreature spell you cast costs {1} less to cast.
+SVar:TrigEffect:DB$ Effect | StaticAbilities$ ReduceCost | Triggers$ TrigCastSpell
+SVar:ReduceCost:Mode$ ReduceCost | Type$ Spell | ValidCard$ Card.nonCreature | Activator$ You | Amount$ 1 | Description$ The next noncreature spell you cast costs {1} less to cast.
+SVar:TrigCastSpell:Mode$ SpellCast | ValidCard$ Card.nonCreature | ValidActivatingPlayer$ You | TriggerZones$ Command | Execute$ RemoveEffect | Static$ True
+SVar:RemoveEffect:DB$ ChangeZone | Origin$ Command | Destination$ Exile
+T:Mode$ SpellCast | ValidCard$ Card.YouCtrl | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigExile | ActivatorThisTurnCast$ EQ2 | TriggerDescription$ Flurry — Whenever you cast your second spell each turn, exile up to one target creature you control, then return it to the battlefield under its owner’s control.
+SVar:TrigExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | RememberChanged$ True | ValidTgts$ Creature.YouCtrl | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target creature you control | SubAbility$ DBReturn
+SVar:DBReturn:DB$ ChangeZone | Defined$ Remembered | Origin$ All | Destination$ Battlefield | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:Flying, vigilance, haste\nWhen Xho Cai enters, the next noncreature spell you cast costs {1} less to cast.\nFlurry — Whenever you cast your second spell each turn, exile up to one target creature you control, then return it to the battlefield under its owner’s control.


### PR DESCRIPTION
- [Desert Cenote](https://scryfall.com/card/ytdm/30/desert-cenote): 
=> The second enters replacement effect is my notion of what it should look like based on existing patterns across `ChooseColor`, `ChooseType` and `Choose Card` effects. Unfortunately, `UpTo$ True` doesn't work in this context as far as I could test. Implementing `ColorsFrom$` (or a variation thereof) is beyond my limited Java expertise. 
=> Tested the second mana ability with a less limited version of the second replacement effect: unfortunately it only produces mana of the first chosen color.
- [Dragonweave Tapestry](https://scryfall.com/card/ytdm/29/dragonweave-tapestry):
=> Tested against a [Cosi's Trickster](https://scryfall.com/card/zen/45/cosis-trickster) on the opponent's side: Neither `NoShuffle$ True` or `Shuffle$ False` on the first `MakeCard` line prevent the Merfolk's ability from triggering twice. 
=> An attempt to splice [line 1040 of `ChangeZoneEffect.java`](https://github.com/Card-Forge/forge/blob/9054e01273f63f11c26deb03afa6361c18038bed/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java#L1040) into [line 222 of  `MakeCardEffect.java`](https://github.com/Card-Forge/forge/blob/9054e01273f63f11c26deb03afa6361c18038bed/forge-game/src/main/java/forge/game/ability/effects/MakeCardEffect.java#L222) as follows proved unsuccessful in resolving this issue.
```            if (zone.equals(ZoneType.Library) && (!sa.hasParam("LibraryPosition") || !sa.hasParam("NoShuffle") || "True".equals(sa.getParam("Shuffle")))) {```
- [Territorial Strike](https://scryfall.com/card/ytdm/27/territorial-strike):
=> My notion of what it should look like based on the existing patterns of additional costs linked with spell abilities as realized in [Fling](https://scryfall.com/card/jmp/320/fling) and [Calamity of the Titans](https://scryfall.com/card/cmm/713/calamity-of-the-titans). Wholly untested.
- [Xho Cai, Flickering Talon](https://scryfall.com/card/ytdm/28/xho-cai-flickering-talon): Tested to satisfaction.