### PR TITLE
Adventure - Fix for 'Fetch' objectives

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/data/AdventureQuestStage.java
+++ b/forge-gui-mobile/src/forge/adventure/data/AdventureQuestStage.java
@@ -330,7 +330,7 @@ public class AdventureQuestStage implements Serializable {
                         status = ++progress1 >= count1 ? COMPLETE : status;
                 }
                 else if (event.type == AdventureQuestEventType.USEITEM) {
-                    if ((itemNames.isEmpty()) || itemNames.contains(event.item.name))
+                    if ((itemNames.isEmpty()) || (event.item != null && itemNames.contains(event.item.name)))
                         status = ++progress3 >= count3 ? COMPLETE : status;
                 }
                 break;

--- a/forge-gui-mobile/src/forge/adventure/data/AdventureQuestStage.java
+++ b/forge-gui-mobile/src/forge/adventure/data/AdventureQuestStage.java
@@ -325,9 +325,14 @@ public class AdventureQuestStage implements Serializable {
                 }
                 break;
             case Fetch:
-                status = event.type == AdventureQuestEventType.RECEIVEITEM
-                        && (itemNames.isEmpty()) || (event.item != null && itemNames.contains(event.item.name))
-                        && ++progress1 >= count1 ? COMPLETE : status;
+                if (event.type == AdventureQuestEventType.RECEIVEITEM) {
+                    if ((itemNames.isEmpty()) || (event.item != null && itemNames.contains(event.item.name)))
+                        status = ++progress1 >= count1 ? COMPLETE : status;
+                }
+                else if (event.type == AdventureQuestEventType.USEITEM) {
+                    if ((itemNames.isEmpty()) || itemNames.contains(event.item.name))
+                        status = ++progress3 >= count3 ? COMPLETE : status;
+                }
                 break;
             case Hunt:
                 if (event.type == AdventureQuestEventType.DESPAWN) {

--- a/forge-gui/res/adventure/common/world/items.json
+++ b/forge-gui/res/adventure/common/world/items.json
@@ -141,7 +141,16 @@
     "name": "Landscape Sketchbook",
     "description": "A leather bound notebook containing sketches of various landscapes across Shandalar",
     "iconName": "LandscapeSketchbook",
-    "questItem": true
+    "questItem": true,
+    "usableInPoi": true,
+    "dialogOnUse": {
+      "text": "You found this sketchbook at the dig site.",
+      "options": [
+        {
+          "name": "You can't quite make heads nor tails of the sketches inside, but you better hold onto it..."
+        }
+      ]
+    }
   },
   {
     "name": "Landscape Sketchbook - Mirage",
@@ -173,7 +182,6 @@
     }
   },
   {
-
     "name": "Phoenix Charm",
     "description": "Draft a Phoenix card, or conjure one to be cast with mana of any color.",
     "equipmentSlot": "Neck",


### PR DESCRIPTION
If a user Receives an item specified in a 'Fetch' objective before the objective has started, it was impossible for them to finish the quest. Now, as long as they are in the PointofInterest where the item was found, they can enter their inventory and Use the item instead. This will prevent main quest softlocks.

I tested this on the only 'Fetch' objective in the game so far, stage 2 of The Dig Site.
I acquired the item before beginning the quest. I completed the quests up until that objective, entered the PoI and used enter.
![image](https://github.com/user-attachments/assets/6b8e7a7d-b8b7-4fef-bc81-c7f614f6dce1)


I also deleted an empty line.

This is my first time using Github, IDEs, and contributing! Let me know your comments.