### PR TITLE
FIN: 4 Job select cards and support

### DIFF
--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -2737,7 +2737,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
                         || keyword.startsWith("Encore") || keyword.startsWith("Mutate") || keyword.startsWith("Dungeon")
                         || keyword.startsWith("Class") || keyword.startsWith("Blitz")
                         || keyword.startsWith("Specialize") || keyword.equals("Ravenous")
-                        || keyword.equals("For Mirrodin") || keyword.startsWith("Craft")
+                        || keyword.equals("For Mirrodin") || keyword.equals("Job select") || keyword.startsWith("Craft")
                         || keyword.startsWith("Landwalk") || keyword.startsWith("Visit")) {
                     // keyword parsing takes care of adding a proper description
                 } else if (keyword.equals("Read ahead")) {

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -1409,6 +1409,29 @@ public class CardFactoryUtil {
             parsedEndTrig.setOverridingAbility(AbilityFactory.getAbility(remove, card));
 
             inst.addTrigger(parsedEndTrig);
+        } else if (keyword.equals("Job select")) {
+            final StringBuilder sbTrig = new StringBuilder();
+            sbTrig.append("Mode$ ChangesZone | Destination$ Battlefield | ");
+            sbTrig.append("ValidCard$ Card.Self | TriggerDescription$ ");
+            sbTrig.append("Job select (").append(inst.getReminderText()).append(")");
+
+            final String sbHero = "DB$ Token | TokenScript$ c_1_1_hero | TokenOwner$ You | RememberTokens$ True";
+            final SpellAbility saHero= AbilityFactory.getAbility(sbHero, card);
+
+            final String sbAttach = "DB$ Attach | Defined$ Remembered";
+            final AbilitySub saAttach = (AbilitySub) AbilityFactory.getAbility(sbAttach, card);
+            saHero.setSubAbility(saAttach);
+
+            final String sbClear = "DB$ Cleanup | ClearRemembered$ True";
+            final AbilitySub saClear = (AbilitySub) AbilityFactory.getAbility(sbClear, card);
+            saAttach.setSubAbility(saClear);
+
+            final Trigger etbTrigger = TriggerHandler.parseTrigger(sbTrig.toString(), card, intrinsic);
+
+            etbTrigger.setOverridingAbility(saHero);
+
+            saHero.setIntrinsic(intrinsic);
+            inst.addTrigger(etbTrigger);
         } else if (keyword.equals("Living Weapon")) {
             final StringBuilder sbTrig = new StringBuilder();
             sbTrig.append("Mode$ ChangesZone | Destination$ Battlefield | ");

--- a/forge-game/src/main/java/forge/game/keyword/Keyword.java
+++ b/forge-game/src/main/java/forge/game/keyword/Keyword.java
@@ -110,6 +110,7 @@ public enum Keyword {
     INGEST("Ingest", SimpleKeyword.class, false, "Whenever this creature deals combat damage to a player, that player exiles the top card of their library."),
     INTIMIDATE("Intimidate", SimpleKeyword.class, true, "This creature can't be blocked except by artifact creatures and/or creatures that share a color with it."),
     KICKER("Kicker", Kicker.class, false, "You may pay an additional %s as you cast this spell."),
+    JOB_SELECT("Job select", SimpleKeyword.class, false, "When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it."),
     JUMP_START("Jump-start", SimpleKeyword.class, false, "You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card."),
     LANDWALK("Landwalk", KeywordWithType.class, true, "This creature is unblockable as long as defending player controls {1:%s}."),
     LEVEL_UP("Level up", KeywordWithCost.class, false, "%s: Put a level counter on this. Level up only as a sorcery."),

--- a/forge-gui/res/cardsfolder/upcoming/black_mages_rod.txt
+++ b/forge-gui/res/cardsfolder/upcoming/black_mages_rod.txt
@@ -1,0 +1,9 @@
+Name:Black Mage's Rod
+ManaCost:1 B
+Types:Artifact Equipment
+K:Job select
+S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 1 | AddType$ Wizard | AddTrigger$ TrigSpellCast | Description$ Equipped creature gets +1/+0, has "Whenever you cast a noncreature spell, this creature deals 1 damage to each opponent," and is a Wizard in addition to its other types.
+SVar:TrigSpellCast:Mode$ SpellCast | ValidCard$ Card.nonCreature | ValidActivatingPlayer$ You | Execute$ TrigDamage | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a noncreature spell, this creature deals 1 damage to each opponent.
+SVar:TrigDamage:DB$ DealDamage | Defined$ Player.Opponent | NumDmg$ 1
+K:Equip:3
+Oracle:Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\nEquipped creature gets +1/+0, has "Whenever you cast a noncreature spell, this creature deals 1 damage to each opponent," and is a Wizard in addition to its other types.\nEquip {3}

--- a/forge-gui/res/cardsfolder/upcoming/dragoons_lance.txt
+++ b/forge-gui/res/cardsfolder/upcoming/dragoons_lance.txt
@@ -1,0 +1,8 @@
+Name:Dragoon's Lance
+ManaCost:1 W
+Types:Artifact Equipment
+K:Job select
+S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 1 | AddType$ Knight | Description$ Equipped creature gets +1/+0 and is a Knight in addition to its other types.
+S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddKeyword$ Flying | Condition$ PlayerTurn | Description$ During your turn, equipped creature has flying.
+K:Equip:4
+Oracle:Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\nEquipped creature gets +1/+0 and is a Knight in addition to its other types.\nDuring your turn, equipped creature has flying.\nGae Bolg — Equip {4}

--- a/forge-gui/res/cardsfolder/upcoming/summoners_grimoire.txt
+++ b/forge-gui/res/cardsfolder/upcoming/summoners_grimoire.txt
@@ -1,0 +1,12 @@
+Name:Summoner's Grimoire
+ManaCost:3 G
+Types:Artifact Equipment
+K:Job select
+S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddType$ Shaman | AddTrigger$ TrigAttack | Description$ Equipped creature is a Shaman in addition to its other types and has "Whenever this creature attacks, you may put a creature card from your hand onto the battlefield. If that card is an enchantment card, it enters tapped and attacking."
+SVar:TrigAttack:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigChoose | TriggerZones$ Battlefield | OptionalDecider$ You | TriggerDescription$ Whenever this creature attacks, you may put a creature card from your hand onto the battlefield. If that card is an enchantment card, it enters tapped and attacking.
+SVar:TrigChoose:DB$ ChooseCard | Mandatory$ True | ChoiceZone$ Hand | Choices$ Creature.YouOwn | ChoiceTitle$ Choose a creature card in your hand | SubAbility$ DBChangeOne
+SVar:DBChangeOne:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | Defined$ ChosenCard | ConditionDefined$ ChosenCard | ConditionPresent$ Card.Enchantment | Tapped$ True | Attacking$ True | SubAbility$ DBChangeTwo
+SVar:DBChangeTwo:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | Defined$ ChosenCard | ConditionDefined$ ChosenCard | ConditionPresent$ Card.nonEnchantment | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearChosenCard$ True
+K:Equip:3
+Oracle:Job select\nEquipped creature is a Shaman in addition to its other types and has "Whenever this creature attacks, you may put a creature card from your hand onto the battlefield. If that card is an enchantment card, it enters tapped and attacking."\nAbraxas — Equip {3}

--- a/forge-gui/res/cardsfolder/upcoming/white_mages_staff.txt
+++ b/forge-gui/res/cardsfolder/upcoming/white_mages_staff.txt
@@ -1,0 +1,9 @@
+Name:White Mage's Staff
+ManaCost:1 W
+Types:Artifact Equipment
+K:Job select
+K:Equip:3
+S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 1 | AddToughness$ 1 | AddTrigger$ TrigAttack | AddType$ Cleric | Description$ Equipped creature gets +1/+1, has "Whenever this creature attacks, you gain 1 life," and is a Cleric in addition to its its other types.
+SVar:TrigAttack:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigGainLife | TriggerDescription$ Whenever this creature attacks, you gain 1 life.
+SVar:TrigGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1
+Oracle:Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\nEquipped creature gets +1/+1, has "Whenever this creature attacks, you gain 1 life," and is a Cleric in addition to its its other types.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery)


### PR DESCRIPTION
As revealed recently; tested to satisfaction:
- [Black Mage's Rod](https://scryfall.com/card/fin/90/black-mages-rod)
- [Dragoon's Lance](https://scryfall.com/card/fin/17/dragoons-lance)
- [Summoner's Grimoire](https://scryfall.com/card/fin/205/summoners-grimoire)
- [White Mage's Staff](https://scryfall.com/card/fin/42/white-mages-staff)

The only issue is that I'm not sure how to implement the flavor words for the equip abilities of Dragoon's Lance and Summoner's Grimoire so they display on the in-game Card Detail. However, as that's fundamentally a cosmetic issue, I'll leave it to be resolved at a latter date.