### PR TITLE
Fix mobile deck editor selecting wrong cards under certain conditions

### DIFF
--- a/forge-gui-mobile/src/forge/itemmanager/ItemManager.java
+++ b/forge-gui-mobile/src/forge/itemmanager/ItemManager.java
@@ -1003,6 +1003,8 @@ public abstract class ItemManager<T extends InventoryItem> extends FContainer im
     private class ContextMenu extends FDropDownMenu {
         @Override
         protected void buildMenu() {
+            if (getSelectedItem() == null)
+                return;
             contextMenuBuilder.buildMenu(this, getSelectedItem());
         }
 

--- a/forge-gui-mobile/src/forge/itemmanager/views/ImageView.java
+++ b/forge-gui-mobile/src/forge/itemmanager/views/ImageView.java
@@ -601,7 +601,7 @@ public class ImageView<T extends InventoryItem> extends ItemView<T> {
 
         for (int i = groups.get().size() - 1; i >= 0; i--) {
             Group group = groups.get().get(i);
-            if (!group.isCollapsed) {
+            if (!group.isCollapsed && !group.items.isEmpty()) {
                 for (int j = group.piles.size() - 1; j >= 0; j--) {
                     float relX = x + group.getScrollLeft() - group.getLeft();
                     float relY = y + getScrollValue();


### PR DESCRIPTION
I'm not sure I fully grasp the scope of this issue, but apparently if the mobile deck editor is in ImageView mode, `groupBy` is set to something non-null, `pileBy` is null, and you change your search filters in a way that causes a group that had cards in it to become empty, the group will be emptied of items but it won't clear the piles within that group. They won't be visible, but `getItemAtPoint` can still see them, which can cause it to return an item that was previously filtered out. That item that should no longer exist later gets referred to by its outdated index, then that wrong index gets used to look up a real item that actually is visible in the list. 

End result: you click one card and the menu opens for a different card, or for a null card and you get problems. The recent addition of `card.hasNoSellValue` in the Adventure editor's `buildMenu` method turned this bug into an immediate NPE, but I suspect the underlying issue has been there much longer. 

This PR changes `getItemAtPoint` to ignore empty groups and their ghost piles, and blocks off the NPE by preventing `buildMenu` from being called without a valid card selected.