### PR TITLE
FIC: another 5 cards

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/lifestreams_blessing.txt
+++ b/forge-gui/res/cardsfolder/upcoming/lifestreams_blessing.txt
@@ -1,0 +1,10 @@
+Name:Lifestream's Blessing
+ManaCost:4 G G
+Types:Instant
+K:Foretell:4 G
+A:SP$ Draw | NumCards$ X | SubAbility$ DBGainLife | SpellDescription$ Draw X cards, where X is the greatest power among creatures you controlled as you cast this spell. If this spell was cast from exile, you gain twice X life.
+SVar:DBGainLife:DB$ GainLife | LifeAmount$ Y | Defined$ You
+SVar:X:Count$LastStateBattlefieldWithFallback Creature.YouCtrl$GreatestPower
+SVar:Y:SVar$X/Times.Z
+SVar:Z:Count$wasCastFromExile.2.0
+Oracle:Draw X cards, where X is the greatest power among creatures you controlled as you cast this spell. If this spell was cast from exile, you gain twice X life.\nForetell {4}{G} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)

--- a/forge-gui/res/cardsfolder/upcoming/professor_hojo.txt
+++ b/forge-gui/res/cardsfolder/upcoming/professor_hojo.txt
@@ -1,0 +1,9 @@
+Name:Professor Hojo
+ManaCost:1 G
+Types:Legendary Creature Human Scientist
+PT:2/2
+S:Mode$ ReduceCost | ValidCard$ Card | ValidSpell$ Activated.YouCtrl | Type$ Ability | Activator$ You | Amount$ 2 | CheckSVar$ X | SVarCompare$ LE1 | Description$ The first activated ability of an artifact you activate each turn costs {2} less to activate.
+SVar:X:Count$ThisTurnActivated_Activated.YouCtrl
+T:Mode$ BecomesTargetOnce | ValidTarget$ Creature.YouCtrl+inZoneBattlefield | ValidSource$ Activated | TriggerZones$ Battlefield | Execute$ TrigDraw | ActivationLimit$ 1 | TriggerDescription$ Whenever one or more creatures you control become the target of an activated ability, draw a card. This ability triggers only once each turn.
+SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1
+Oracle:The first activated ability you activate during your turn that targets a creature you control costs {2} less to activate.\nWhenever one or more creatures you control become the target of an activated ability, draw a card. This ability triggers only once each turn.

--- a/forge-gui/res/cardsfolder/upcoming/red_xiii_proud_warrior.txt
+++ b/forge-gui/res/cardsfolder/upcoming/red_xiii_proud_warrior.txt
@@ -1,0 +1,10 @@
+Name:Red XIII, Proud Warrior
+ManaCost:1 R G
+Types:Legendary Creature Beast Warrior
+PT:3/3
+K:Vigilance
+K:Trample
+S:Mode$ Continuous | Affected$ Creature.Other+modified+YouCtrl | AddKeyword$ Vigilance & Trample | Description$ Other modified creatures you control have vigilance and trample. (Equipment, Auras you control, and counters are modifications.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChangeZone | TriggerDescription$ Cosmo Memory — When NICKNAME enters, return target Aura or Equipment card from your graveyard to your hand.
+SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Aura.YouCtrl,Equipment.YouCtrl | TgtPrompt$ Select target Aura or Equipment card in your graveyard
+Oracle:Vigilance, trample\nOther modified creatures you control have vigilance and trample. (Equipment, Auras you control, and counters are modifications.)\nCosmo Memory — When Red XIII enters, return target Aura or Equipment card from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/upcoming/soldier_military_program.txt
+++ b/forge-gui/res/cardsfolder/upcoming/soldier_military_program.txt
@@ -1,0 +1,9 @@
+Name:SOLDIER Military Program
+ManaCost:2 W
+Types:Enchantment
+T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | Execute$ TrigCharm | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of combat on your turn, ABILITY
+SVar:TrigCharm:DB$ Charm | Choices$ DBToken,DBPutCounters | MinCharmNum$ 1 | CharmNum$ Count$Compare Y GE1.2.1 | AdditionalDescription$ . If you control a commander, you may choose both instead.
+SVar:DBToken:DB$ Token | TokenAmount$ 1 | TokenOwner$ You | TokenScript$ w_1_1_soldier | SpellDescription$ Create a 1/1 white Soldier creature token.
+SVar:DBPutCounters:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ 1 | ChoiceAmount$ 2 | MinChoiceAmount$ 0 | Choices$ Soldier.YouCtrl | ChoiceTitle$ Choose up to two Soldiers you control | SpellDescription$ Put a +1/+1 counter on each of up to two Soldiers you control.
+SVar:Y:Count$Valid Card.IsCommander+YouCtrl
+Oracle:At the beginning of combat on your turn, choose one. If you control a commander, you may choose both instead.\n• Create a 1/1 white Soldier creature token.\n• Put a +1/+1 counter on each of up to two Soldiers you control.

--- a/forge-gui/res/cardsfolder/upcoming/summoning_materia.txt
+++ b/forge-gui/res/cardsfolder/upcoming/summoning_materia.txt
@@ -1,0 +1,9 @@
+Name:Summoning Materia
+ManaCost:2 G
+Types:Artifact Equipment
+K:Equip:2
+S:Mode$ Continuous | Affected$ Card.TopLibrary+YouCtrl | AffectedZone$ Library | MayLookAt$ You | Description$ You may look at the top card of your library any time.
+S:Mode$ Continuous | IsPresent$ Card.Self+AttachedTo Creature | Affected$ Card.Creature+nonLand+TopLibrary+YouCtrl | AffectedZone$ Library | MayPlay$ True | Description$ As long as this Equipment is attached to a creature, you may cast creature spells from the top of your library.
+S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 2 | AddToughness$ 2 | AddKeyword$ Vigilance | AddAbility$ ABMana | Description$ Equipped creature gets +2/+2 and has vigilance and "{T}: Add {G}.
+SVar:ABMana:AB$ Mana | Cost$ T | Produced$ G | SpellDescription$ Add {G}.
+Oracle:You may look at the top card of your library any time.\nAs long as this Equipment is attached to a creature, you may cast creature spells from the top of your library.\nEquipped creature gets +2/+2 and has vigilance and "{T}: Add {G}."\nEquip {2}


### PR DESCRIPTION
- [Lifestream's Blessing](https://scryfall.com/card/fic/67/lifestreams-blessing):
=> I assume `Count$LastStateBattlefieldWithFallback Creature.YouCtrl$GreatestPower` is what's expected based on the pattern for `Valid`. Currently though, that `SVar` is only counting the amount of creatures the spell's caster controlled, instead of determining the greatest power among them. Fairly stumped as to resolving this on the Java side of things.
- [Professor Hojo](https://scryfall.com/card/fic/69/professor-hojo): Tested to satisfaction.
- [Red XIII, Proud Warrior](https://scryfall.com/card/fic/91/red-xiii-proud-warrior): Tested to satisfaction.
- [SOLDIER Military Program](https://scryfall.com/card/fic/25/soldier-military-program): Tested to satisfaction.
- [Summoning Materia](https://scryfall.com/card/fic/72/summoning-materia): Tested to satisfaction.