### PR TITLE
How to suplex a train

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/phantom_train.txt
+++ b/forge-gui/res/cardsfolder/upcoming/phantom_train.txt
@@ -1,0 +1,9 @@
+Name:Phantom Train
+ManaCost:3 B
+Types:Artifact Vehicle
+PT:4/4
+K:Trample
+A:AB$ PutCounter | Cost$ Sac<1/Artifact.Other;Creature.Other/another artifact or creature> | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBAnimate | SpellDescription$ Put a +1/+1 counter on this Vehicle. It becomes a Spirit artifact creature in addition to its other types until end of turn.
+SVar:DBAnimate:DB$ Animate | Defined$ Self | Types$ Artifact,Creature,Spirit
+DeckHas:Ability$Sacrifice|Counters
+Oracle:Trample\nSacrifice another artifact or creature: Put a +1/+1 counter on this Vehicle. It becomes a Spirit artifact creature in addition to its other types until end of turn.

--- a/forge-gui/res/cardsfolder/upcoming/poison_the_waters.txt
+++ b/forge-gui/res/cardsfolder/upcoming/poison_the_waters.txt
@@ -1,0 +1,7 @@
+Name:Poison the Waters
+ManaCost:1 B
+Types:Sorcery
+A:SP$ Charm | Choices$ DBPumpAll,DBDiscard | CharmNum$ 1
+SVar:DBPumpAll:DB$ PumpAll | ValidCards$ Creature | NumAtt$ -1 | NumDef$ -1 | IsCurse$ True | SpellDescription$ All creatures get -1/-1 until end of turn.
+SVar:DBDiscard:DB$ Discard | ValidTgts$ Player | Mode$ RevealYouChoose | DiscardValid$ Artifact,Creature | SpellDescription$ Target player reveals their hand. You choose an artifact or creature card from it. That player discards that card.
+Oracle:Choose one —\n• All creatures get -1/-1 until end of turn.\n• Target player reveals their hand. You choose an artifact or creature card from it. That player discards that card.

--- a/forge-gui/res/cardsfolder/upcoming/suplex.txt
+++ b/forge-gui/res/cardsfolder/upcoming/suplex.txt
@@ -1,0 +1,7 @@
+Name:Suplex
+ManaCost:1 R
+Types:Sorcery
+A:SP$ Charm | CharmNum$ 1 | Choices$ DBDealDamage,DBExile
+SVar:DBDealDamage:DB$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 3 | ReplaceDyingDefined$ Targeted | SpellDescription$ CARDNAME deals 3 damage to target creature. If that creature would die this turn, exile it instead.
+SVar:DBExile:DB$ ChangeZone | ValidTgts$ Artifact | TgtPrompt$ Select target artifact | Origin$ Battlefield | Destination$ Exile | SpellDescription$ Exile target artifact.
+Oracle:Choose one —\n• Suplex deals 3 damage to target creature. If that creature would die this turn, exile it instead.\n• Exile target artifact.


### PR DESCRIPTION
There's something strange with Phantom Train's ability where its P/T display doesn't update properly after getting the counter -- maybe because the counter is gained before animating?