### PR TITLE
Fixing Living Lectern, Embereth Veteran

### DIFF
--- a/forge-gui/res/cardsfolder/e/embereth_veteran.txt
+++ b/forge-gui/res/cardsfolder/e/embereth_veteran.txt
@@ -2,6 +2,6 @@ Name:Embereth Veteran
 ManaCost:R
 Types:Creature Human Knight
 PT:2/1
-A:AB$ Token | Cost$ 1 Sac<1/CARDNAME> | TokenAmount$ 1 | TokenScript$ role_young_hero | AttachedTo$ Targeted | ValidTgts$ Creature.Other | TgtPrompt$ Select another target creature | SpellDescription$ Create a Young Hero Role token attached to another target creature. (If you control another Role on it, put that one into the graveyard. Enchanted creature has "Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it.")
+A:AB$ Token | Cost$ 1 Sac<1/CARDNAME> | TokenAmount$ 1 | TokenScript$ role_young_hero | TokenOwner$ You | AttachedTo$ Targeted | ValidTgts$ Creature.Other | TgtPrompt$ Select another target creature | SpellDescription$ Create a Young Hero Role token attached to another target creature. (If you control another Role on it, put that one into the graveyard. Enchanted creature has "Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it.")
 DeckHas:Ability$Token|Sacrifice & Type$Aura|Enchantment|Role
 Oracle:{1}, Sacrifice Embereth Veteran: Create a Young Hero Role token attached to another target creature. (If you control another Role on it, put that one into the graveyard. Enchanted creature has "Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it.")

--- a/forge-gui/res/cardsfolder/l/living_lectern.txt
+++ b/forge-gui/res/cardsfolder/l/living_lectern.txt
@@ -3,6 +3,6 @@ ManaCost:1 U
 Types:Artifact Creature Construct
 PT:0/4
 A:AB$ Draw | SorcerySpeed$ True | Cost$ 1 Sac<1/CARDNAME> | SubAbility$ DBToken | SpellDescription$ Draw a card. Create a Sorcerer Role token attached to up to one other target creature you control. Activate only as a sorcery. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has "Whenever this creature attacks, scry 1.")
-SVar:DBToken:DB$ Token | TokenAmount$ 1 | TargetMin$ 0 | TargetMax$ 1 | TokenScript$ role_sorcerer | AttachedTo$ Targeted | ValidTgts$ Creature.YouCtrl+Other | TgtPrompt$ Select up to one other target creature you control
+SVar:DBToken:DB$ Token | TokenAmount$ 1 | TokenScript$ role_sorcerer | TokenOwner$ You | AttachedTo$ Targeted | ValidTgts$ Creature.YouCtrl+Other | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one other target creature you control
 DeckHas:Ability$Token|Sacrifice & Type$Aura|Enchantment|Role
 Oracle:{1}, Sacrifice Living Lectern: Draw a card. Create a Sorcerer Role token attached to up to one other target creature you control. Activate only as a sorcery. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has "Whenever this creature attacks, scry 1.")


### PR DESCRIPTION
It came to my attention that [Living Lectern](https://github.com/Card-Forge/forge/blob/master/forge-gui/res/cardsfolder/l/living_lectern.txt)'s activated ability wasn't creating the Role token. Comparing with the working effect on [Betroth the Beast](https://github.com/Card-Forge/forge/blob/master/forge-gui/res/cardsfolder/b/besotted_knight_betroth_the_beast.txt), it was noticeable the `TokenOwner$` parameter was missing. Adding it to the relevant line now results in the token being created as expected. Looking over existing scripts, [Embereth Veteran](https://github.com/Card-Forge/forge/blob/master/forge-gui/res/cardsfolder/e/embereth_veteran.txt)'s corresponding line was found to also lack that parameter and behaved like the uncorrected Lectern. It's been fixed as well.
