### PR TITLE
Fixing Firion

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
@@ -356,6 +356,7 @@ public abstract class SpellAbilityEffect {
         boolean intrinsic = sa.isIntrinsic();
         boolean your = location.startsWith("Your");
         boolean combat = location.endsWith("Combat");
+        boolean upkeep = location.endsWith("Upkeep");
 
         String desc = sa.getParamOrDefault("AtEOTDesc", "");
 
@@ -364,6 +365,9 @@ public abstract class SpellAbilityEffect {
         }
         if (combat) {
             location = location.substring(0, location.length() - "Combat".length());
+        }
+        if (upkeep) {
+            location = location.substring(0, location.length() - "Upkeep".length());
         }
 
         if (desc.isEmpty()) {
@@ -389,14 +393,18 @@ public abstract class SpellAbilityEffect {
             } else {
                 sb.append("beginning of ");
                 sb.append(your ? "your" : "the");
+            if (upkeep) {
+                sb.append(" next upkeep.");
+            } else {
                 sb.append(" next end step.");
+            }
             }
             desc = sb.toString();
         }
 
         StringBuilder delTrig = new StringBuilder();
         delTrig.append("Mode$ Phase | Phase$ ");
-        delTrig.append(combat ? "EndCombat "  : "End Of Turn ");
+        delTrig.append(combat ? "EndCombat " : upkeep ? "Upkeep" : "End Of Turn ");
 
         if (your) {
             delTrig.append("| ValidPlayer$ You ");

--- a/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
@@ -393,11 +393,11 @@ public abstract class SpellAbilityEffect {
             } else {
                 sb.append("beginning of ");
                 sb.append(your ? "your" : "the");
-            if (upkeep) {
-                sb.append(" next upkeep.");
-            } else {
-                sb.append(" next end step.");
-            }
+                if (upkeep) {
+                    sb.append(" next upkeep.");
+                } else {
+                    sb.append(" next end step.");
+                }
             }
             desc = sb.toString();
         }

--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneAllEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneAllEffect.java
@@ -186,6 +186,10 @@ public class ChangeZoneAllEffect extends SpellAbilityEffect {
 
         triggerList.triggerChangesZoneAll(game, sa);
 
+        if (sa.hasParam("AtEOT") && !triggerList.isEmpty()) {
+            registerDelayedTrigger(sa, sa.getParam("AtEOT"), triggerList.allCards());
+        }
+
         changeZoneUntilCommand(triggerList, sa);
 
         // CR 701.20d If an effect would cause a player to shuffle a set of objects into a library,

--- a/forge-gui/res/cardsfolder/f/force_of_rage.txt
+++ b/forge-gui/res/cardsfolder/f/force_of_rage.txt
@@ -2,9 +2,6 @@ Name:Force of Rage
 ManaCost:1 R R
 Types:Instant
 S:Mode$ AlternativeCost | ValidSA$ Spell.Self | EffectZone$ All | Cost$ ExileFromHand<1/Card.Red+Other> | Condition$ NotPlayerTurn | Description$ If it's not your turn, you may exile a red card from your hand rather than pay this spell's mana cost.
-A:SP$ Token | TokenAmount$ 2 | TokenScript$ r_3_1_elemental_trample_haste | TokenOwner$ You | SubAbility$ DelayedSac | RememberTokens$ True | SpellDescription$ Create two 3/1 red Elemental creature tokens with trample and haste. Sacrifice those tokens at the beginning of your next upkeep.
-SVar:DelayedSac:DB$ DelayedTrigger | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ DBSacToken | RememberObjects$ Remembered | SubAbility$ DBCleanup | TriggerDescription$ Sacrifice those tokens at the beginning of your next upkeep.
-SVar:DBSacToken:DB$ SacrificeAll | Defined$ DelayTriggerRememberedLKI | Controller$ You
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+A:SP$ Token | TokenAmount$ 2 | TokenScript$ r_3_1_elemental_trample_haste | TokenOwner$ You | AtEOT$ YourSacrificeUpkeep | SpellDescription$ Create two 3/1 red Elemental creature tokens with trample and haste. Sacrifice those tokens at the beginning of your next upkeep.
 DeckHas:Ability$Token
 Oracle:If it's not your turn, you may exile a red card from your hand rather than pay this spell's mana cost.\nCreate two 3/1 red Elemental creature tokens with trample and haste. Sacrifice those tokens at the beginning of your next upkeep.

--- a/forge-gui/res/cardsfolder/r/rally_the_ancestors.txt
+++ b/forge-gui/res/cardsfolder/r/rally_the_ancestors.txt
@@ -1,11 +1,8 @@
 Name:Rally the Ancestors
 ManaCost:X W W
 Types:Instant
-A:SP$ ChangeZoneAll | Origin$ Graveyard | Destination$ Battlefield | ChangeType$ Creature.YouOwn+cmcLEX | RememberChanged$ True | SubAbility$ DBDelTrig | SpellDescription$ Return each creature card with mana value X or less from your graveyard to the battlefield. Exile those creatures at the beginning of your next upkeep. Exile CARDNAME.
-SVar:DBDelTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ TrigExile | RememberObjects$ RememberedLKI | SubAbility$ ExileSelf | TriggerDescription$ Exile those creatures at the beginning of your next upkeep.
-SVar:TrigExile:DB$ ChangeZone | Defined$ DelayTriggerRememberedLKI | Origin$ Battlefield | Destination$ Exile
-SVar:ExileSelf:DB$ ChangeZone | Origin$ Stack | Destination$ Exile | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+A:SP$ ChangeZoneAll | Origin$ Graveyard | Destination$ Battlefield | ChangeType$ Creature.YouOwn+cmcLEX | AtEOT$ YourExileUpkeep | SubAbility$ ExileSelf | SpellDescription$ Return each creature card with mana value X or less from your graveyard to the battlefield. Exile those creatures at the beginning of your next upkeep. Exile CARDNAME.
+SVar:ExileSelf:DB$ ChangeZone | Origin$ Stack | Destination$ Exile
 SVar:X:Count$xPaid
 AI:RemoveDeck:All
 Oracle:Return each creature card with mana value X or less from your graveyard to the battlefield. Exile those creatures at the beginning of your next upkeep. Exile Rally the Ancestors.

--- a/forge-gui/res/cardsfolder/upcoming/firion_wild_rose_warrior.txt
+++ b/forge-gui/res/cardsfolder/upcoming/firion_wild_rose_warrior.txt
@@ -4,11 +4,8 @@ Types:Legendary Creature Human Rebel Warrior
 PT:3/3
 S:Mode$ Continuous | Affected$ Creature.YouCtrl+equipped | AddKeyword$ Haste | Description$ Equipped creatures you control have haste.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Equipment.YouCtrl+!token+Other | TriggerZones$ Battlefield | Execute$ TrigCopy | TriggerDescription$ Whenever a nontoken Equipment you control enters, create a token that's a copy of it, except it has "This Equipment's equip abilities cost {2} less to activate." Sacrifice that token at the beginning of the next upkeep.
-SVar:TrigCopy:DB$ CopyPermanent | Defined$ TriggeredCardLKICopy | AddStaticAbilities$ EquipReduce | RememberTokens$ True | SubAbility$ TrigDelay
+SVar:TrigCopy:DB$ CopyPermanent | Defined$ TriggeredCardLKICopy | AddStaticAbilities$ EquipReduce | AtEOT$ SacrificeUpkeep
 SVar:EquipReduce:Mode$ ReduceCost | ValidCard$ Card.Self | ValidSpell$ Activated.Equip | Amount$ 2 | Description$ This Equipment's equip abilities cost {2} less to activate.
-SVar:TrigDelay:DB$ DelayedTrigger | Mode$ Phase | Phase$ Upkeep | RememberObjects$ RememberedLKI | Execute$ TrigSac | SubAbility$ DBCleanup | TriggerDescription$ Sacrifice that token at the beginning of the next upkeep.
-SVar:TrigSac:DB$ Sacrifice | Defined$ DelayTriggerRememberedLKI
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 DeckHas:Ability$Token
 DeckNeeds:Type$Equipment
 Oracle:Equipped creatures you control have haste.\nWhenever a nontoken Equipment you control enters, create a token that's a copy of it, except it has "This Equipment's equip abilities cost {2} less to activate." Sacrifice that token at the beginning of the next upkeep.


### PR DESCRIPTION
The delayed trigger set up by [Firion, Wild Rose Warrior](https://scryfall.com/card/fin/137/firion-wild-rose-warrior)'s triggered ability was sacrificing the creature instead of the created token. I opted to implement `AtEOT$ SacrificeUpkeep` to resolve this. The script now works as expected.

As requested, propagated these changes to:
- [Force of Rage](https://scryfall.com/card/mh1/124/force-of-rage): tested to satisfaction
- [Rally the Ancestors](https://scryfall.com/card/frf/22/rally-the-ancestors) along with general support for `AtEOT$` in `ChangeZoneAll` lines, mirroring the existing support `ChangeZone` lines have: tested to satisfaction.