### PR TITLE
Update Libgdx to 1.13.5 (fixes Steam Deck mobile backport crash)

### DIFF
--- a/forge-gui-android/pom.xml
+++ b/forge-gui-android/pom.xml
@@ -141,7 +141,7 @@
         <dependency>
             <groupId>com.badlogicgames.gdx</groupId>
             <artifactId>gdx-backend-android</artifactId>
-            <version>1.13.0</version>
+            <version>1.13.5</version>
             <scope>system</scope>
             <systemPath>${pom.basedir}/libs/gdx-backend-android.jar</systemPath>
         </dependency>

--- a/forge-gui-ios/pom.xml
+++ b/forge-gui-ios/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.badlogicgames.gdx</groupId>
             <artifactId>gdx-backend-robovm</artifactId>
-            <version>1.13.0</version>
+            <version>1.13.5</version>
         </dependency>
     </dependencies>
 </project>

--- a/forge-gui-mobile-dev/pom.xml
+++ b/forge-gui-mobile-dev/pom.xml
@@ -202,18 +202,18 @@
         <dependency>
             <groupId>com.badlogicgames.gdx</groupId>
             <artifactId>gdx-backend-lwjgl3</artifactId>
-            <version>1.13.0</version>
+            <version>1.13.5</version>
         </dependency>
         <dependency>
             <groupId>com.badlogicgames.gdx</groupId>
             <artifactId>gdx-platform</artifactId>
-            <version>1.13.0</version>
+            <version>1.13.5</version>
             <classifier>natives-desktop</classifier>
         </dependency>
         <dependency>
             <groupId>com.badlogicgames.gdx</groupId>
             <artifactId>gdx-freetype-platform</artifactId>
-            <version>1.13.0</version>
+            <version>1.13.5</version>
             <classifier>natives-desktop</classifier>
         </dependency>
         <!-- https://mvnrepository.com/artifact/commons-cli/commons-cli -->
@@ -236,7 +236,7 @@
         <dependency>
             <groupId>com.badlogicgames.gdx</groupId>
             <artifactId>gdx-box2d-platform</artifactId>
-            <version>1.13.0</version>
+            <version>1.13.5</version>
             <classifier>natives-desktop</classifier>
         </dependency>
     </dependencies>

--- a/forge-gui-mobile/pom.xml
+++ b/forge-gui-mobile/pom.xml
@@ -75,12 +75,12 @@
         <dependency>
             <groupId>com.badlogicgames.gdx</groupId>
             <artifactId>gdx</artifactId>
-            <version>1.13.0</version>
+            <version>1.13.5</version>
         </dependency>
         <dependency>
             <groupId>com.badlogicgames.gdx</groupId>
             <artifactId>gdx-freetype</artifactId>
-            <version>1.13.0</version>
+            <version>1.13.5</version>
         </dependency>
         <dependency>
             <groupId>com.github.raeleus.TenPatch</groupId>
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>com.badlogicgames.gdx</groupId>
             <artifactId>gdx-box2d</artifactId>
-            <version>1.13.0</version>
+            <version>1.13.5</version>
         </dependency>
         <dependency>
             <groupId>com.badlogicgames.gdx</groupId>


### PR DESCRIPTION
Updates Libgdx dependency from 1.13.0 to the point release 1.13.5, which fixes mobile backport crashing on Steam Deck during any match (when trying to visualize cards).

This works on my Linux desktop without any issue as well.
Could use some testing on Android, perhaps, since I don't have a working Android build setup anymore.