### PR TITLE
Update carrionette.txt

### DIFF
--- a/forge-gui/res/cardsfolder/c/carrionette.txt
+++ b/forge-gui/res/cardsfolder/c/carrionette.txt
@@ -2,5 +2,5 @@ Name:Carrionette
 ManaCost:1 B
 Types:Creature Skeleton
 PT:1/1
-A:AB$ ChangeZone | Cost$ 2 B B | ValidTgts$ Creature | TgtPrompt$ Select target creature | ThisDefinedAndTgts$ Self | Origin$ Battlefield,Graveyard | Destination$ Exile | UnlessCost$ 2 | UnlessPayer$ TargetedController | ActivationZone$ Graveyard | SpellDescription$ Exile CARDNAME and target creature unless that creature's controller pays {2}. Activate only if CARDNAME is in your graveyard.
+A:AB$ ChangeZone | Cost$ 2 B B | ValidTgts$ Creature.inZoneBattlefield | TgtPrompt$ Select target creature | ThisDefinedAndTgts$ Self | Origin$ Battlefield,Graveyard | Destination$ Exile | UnlessCost$ 2 | UnlessPayer$ TargetedController | ActivationZone$ Graveyard | SpellDescription$ Exile CARDNAME and target creature unless that creature's controller pays {2}. Activate only if CARDNAME is in your graveyard.
 Oracle:{2}{B}{B}: Exile Carrionette and target creature unless that creature's controller pays {2}. Activate only if Carrionette is in your graveyard.


### PR DESCRIPTION
It came to my attention that [Carrionette](https://scryfall.com/card/tmp/111/carrionette)'s activated ability was able to target creature cards in graveyards. something it shouldn't do per rules text. The targeting is herein restricted to correct this behavior.

![carrionette](https://github.com/user-attachments/assets/79209e65-418f-4282-a9e9-f5eda860a707)
