### PR TITLE
Adventure: added support for dynamic deck count

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
+++ b/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
@@ -459,6 +459,8 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
         boolean hasDynamicDeckCount = data.containsKey("deckCount");
         if (hasDynamicDeckCount) {
             int dynamicDeckCount = data.readInt("deckCount");
+            // in case the save had previously saved more decks than the current version allows (in case of the max being lowered)
+            dynamicDeckCount = Math.min(MAX_DECK_COUNT, dynamicDeckCount);
             for (int i = 0; i < dynamicDeckCount; i++){
                 // the first x elements are pre-created
                 if (i < MIN_DECK_COUNT) {

--- a/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
+++ b/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
@@ -35,7 +35,9 @@ import java.util.*;
  * Class that represents the player (not the player sprite)
  */
 public class AdventurePlayer implements Serializable, SaveFileContent {
-    public static final int NUMBER_OF_DECKS = 10;
+    public static final int MIN_DECK_COUNT = 10;
+    // this is a purely arbitrary limit, could be higher or lower; just meant as some sort of reasonable limit for the user
+    public static final int MAX_DECK_COUNT = 50;
     // Player profile data.
     private String name;
     private int heroRace;
@@ -45,7 +47,7 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
 
     // Deck data
     private Deck deck;
-    private final Deck[] decks = new Deck[NUMBER_OF_DECKS];
+    private final ArrayList<Deck> decks = new ArrayList<Deck>(MIN_DECK_COUNT);
     private int selectedDeckIndex = 0;
     private final DifficultyData difficultyData = new DifficultyData();
 
@@ -91,9 +93,13 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
         return statistic;
     }
 
+    public int getDeckCount() { return decks.size(); }
+
     private void clearDecks() {
-        for (int i = 0; i < NUMBER_OF_DECKS; i++) decks[i] = new Deck(Forge.getLocalizer().getMessage("lblEmptyDeck"));
-        deck = decks[0];
+        decks.clear();
+        for (int i = 0; i < MIN_DECK_COUNT; i++)
+            decks.add(new Deck(Forge.getLocalizer().getMessage("lblEmptyDeck")));
+        deck = decks.get(0);
         selectedDeckIndex = 0;
     }
 
@@ -140,7 +146,7 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
         announceCustom = usingCustomDeck = isUsingCustomDeck;
 
         deck = startingDeck;
-        decks[0] = deck;
+        decks.set(0, deck);
 
         cards.addAllFlat(deck.getAllCardsInASinglePool().toFlatList());
 
@@ -173,9 +179,9 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
     }
 
     public void setSelectedDeckSlot(int slot) {
-        if (slot >= 0 && slot < NUMBER_OF_DECKS) {
+        if (slot >= 0 && slot < getDeckCount()) {
             selectedDeckIndex = slot;
-            deck = decks[selectedDeckIndex];
+            deck = decks.get(selectedDeckIndex);
             setColorIdentity(DeckProxy.getColorIdentity(deck));
         }
     }
@@ -214,7 +220,7 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
     }
 
     public Deck getDeck(int index) {
-        return decks[index];
+        return decks.get(index);
     }
 
     public CardPool getCards() {
@@ -448,17 +454,42 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
             }
         }
 
-        for (int i = 0; i < NUMBER_OF_DECKS; i++) {
-            if (!data.containsKey("deck_name_" + i)) {
-                if (i == 0) decks[i] = deck;
-                else decks[i] = new Deck(Forge.getLocalizer().getMessage("lblEmptyDeck"));
-                continue;
+        // load decks
+        // check if this save has dynamic deck count, use set-count load if not
+        boolean hasDynamicDeckCount = data.containsKey("deckCount");
+        if (hasDynamicDeckCount) {
+            int dynamicDeckCount = data.readInt("deckCount");
+            for (int i = 0; i < dynamicDeckCount; i++){
+                // the first x elements are pre-created
+                if (i < MIN_DECK_COUNT) {
+                    decks.set(i, new Deck(data.readString("deck_name_" + i)));
+                }
+                else {
+                    decks.add(new Deck(data.readString("deck_name_" + i)));
+                }
+                decks.get(i).getMain().addAll(CardPool.fromCardList(Lists.newArrayList((String[]) data.readObject("deck_" + i))));
+                if (data.containsKey("sideBoardCards_" + i))
+                    decks.get(i).getOrCreate(DeckSection.Sideboard).addAll(CardPool.fromCardList(Lists.newArrayList((String[]) data.readObject("sideBoardCards_" + i))));
             }
-            decks[i] = new Deck(data.readString("deck_name_" + i));
-            decks[i].getMain().addAll(CardPool.fromCardList(Lists.newArrayList((String[]) data.readObject("deck_" + i))));
-            if (data.containsKey("sideBoardCards_" + i))
-                decks[i].getOrCreate(DeckSection.Sideboard).addAll(CardPool.fromCardList(Lists.newArrayList((String[]) data.readObject("sideBoardCards_" + i))));
+            // in case we allow removing decks from the deck selection GUI, populate up to the minimum
+            for (int i = dynamicDeckCount++; i < MIN_DECK_COUNT; i++) {
+                decks.set(i, new Deck(Forge.getLocalizer().getMessage("lblEmptyDeck")));
+            }
+        // legacy load
+        } else {
+            for (int i = 0; i < MIN_DECK_COUNT; i++) {
+                if (!data.containsKey("deck_name_" + i)) {
+                    if (i == 0) decks.set(i, deck);
+                    else decks.set(i, new Deck(Forge.getLocalizer().getMessage("lblEmptyDeck")));
+                    continue;
+                }
+                decks.set(i, new Deck(data.readString("deck_name_" + i)));
+                decks.get(i).getMain().addAll(CardPool.fromCardList(Lists.newArrayList((String[]) data.readObject("deck_" + i))));
+                if (data.containsKey("sideBoardCards_" + i))
+                    decks.get(i).getOrCreate(DeckSection.Sideboard).addAll(CardPool.fromCardList(Lists.newArrayList((String[]) data.readObject("sideBoardCards_" + i))));
+            }
         }
+
         setSelectedDeckSlot(data.readInt("selectedDeckIndex"));
         cards.addAll(CardPool.fromCardList(Lists.newArrayList((String[]) data.readObject("cards"))));
 
@@ -602,11 +633,14 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
         data.storeObject("deckCards", deck.getMain().toCardList("\n").split("\n"));
         if (deck.get(DeckSection.Sideboard) != null)
             data.storeObject("sideBoardCards", deck.get(DeckSection.Sideboard).toCardList("\n").split("\n"));
-        for (int i = 0; i < NUMBER_OF_DECKS; i++) {
-            data.store("deck_name_" + i, decks[i].getName());
-            data.storeObject("deck_" + i, decks[i].getMain().toCardList("\n").split("\n"));
-            if (decks[i].get(DeckSection.Sideboard) != null)
-                data.storeObject("sideBoardCards_" + i, decks[i].get(DeckSection.Sideboard).toCardList("\n").split("\n"));
+
+        // save decks dynamically
+        data.store("deckCount", getDeckCount());
+        for (int i = 0; i < getDeckCount(); i++) {
+            data.store("deck_name_" + i, decks.get(i).getName());
+            data.storeObject("deck_" + i, decks.get(i).getMain().toCardList("\n").split("\n"));
+            if (decks.get(i).get(DeckSection.Sideboard) != null)
+                data.storeObject("sideBoardCards_" + i, decks.get(i).get(DeckSection.Sideboard).toCardList("\n").split("\n"));
         }
         data.store("selectedDeckIndex", selectedDeckIndex);
         data.storeObject("cards", cards.toCardList("\n").split("\n"));
@@ -933,7 +967,7 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
 
     public void renameDeck(String text) {
         deck = (Deck) deck.copyTo(text);
-        decks[selectedDeckIndex] = deck;
+        decks.set(selectedDeckIndex, deck);
     }
 
     public int cardSellPrice(PaperCard card) {
@@ -1182,10 +1216,23 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
     }
 
     /**
-     * Deletes a deck by replacing the current selected deck with a new deck
+     * Clears a deck by replacing the current selected deck with a new deck
      */
-    public void deleteDeck() {
-        deck = decks[selectedDeckIndex] = new Deck(Forge.getLocalizer().getMessage("lblEmptyDeck"));
+    public void clearDeck() {
+        deck = decks.set(selectedDeckIndex, new Deck(Forge.getLocalizer().getMessage("lblEmptyDeck")));
+    }
+
+    /**
+     * Actually removes the deck from the list of decks.
+     */
+    public void deleteDeck(){
+        int oldIndex = selectedDeckIndex;
+        this.setSelectedDeckSlot(0);
+        decks.remove(oldIndex);
+    }
+
+    public void addDeck(){
+        decks.add(new Deck(Forge.getLocalizer().getMessage("lblEmptyDeck")));
     }
 
     /**
@@ -1194,9 +1241,9 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
      * @return int - index of new copy slot, or -1 if no slot was available
      */
     public int copyDeck() {
-        for (int i = 0; i < decks.length; i++) {
+        for (int i = 0; i < MAX_DECK_COUNT; i++) {
             if (isEmptyDeck(i)) {
-                decks[i] = (Deck) deck.copyTo(deck.getName() + " (" + Forge.getLocalizer().getMessage("lblCopy") + ")");
+                decks.set(i, (Deck) deck.copyTo(deck.getName() + " (" + Forge.getLocalizer().getMessage("lblCopy") + ")"));
                 return i;
             }
         }
@@ -1205,7 +1252,7 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
     }
 
     public boolean isEmptyDeck(int deckIndex) {
-        return decks[deckIndex].isEmpty() && decks[deckIndex].getName().equals(Forge.getLocalizer().getMessage("lblEmptyDeck"));
+        return decks.get(deckIndex).isEmpty() && decks.get(deckIndex).getName().equals(Forge.getLocalizer().getMessage("lblEmptyDeck"));
     }
 
     public void removeEvent(AdventureEventData completedEvent) {
@@ -1227,8 +1274,8 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
 
         // 2. Count max cards across all decks in excess of unsellable
         Map<PaperCard, Integer> maxCardCounts = new HashMap<>();
-        for (int i = 0; i < NUMBER_OF_DECKS; i++) {
-            for (final Map.Entry<PaperCard, Integer> cp : decks[i].getAllCardsInASinglePool()) {
+        for (int i = 0; i < getDeckCount(); i++) {
+            for (final Map.Entry<PaperCard, Integer> cp : decks.get(i).getAllCardsInASinglePool()) {
                 int count = cp.getValue();
                 if (count > maxCardCounts.getOrDefault(cp.getKey(), 0)) {
                     maxCardCounts.put(cp.getKey(), cp.getValue());

--- a/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
+++ b/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
@@ -37,7 +37,7 @@ import java.util.*;
 public class AdventurePlayer implements Serializable, SaveFileContent {
     public static final int MIN_DECK_COUNT = 10;
     // this is a purely arbitrary limit, could be higher or lower; just meant as some sort of reasonable limit for the user
-    public static final int MAX_DECK_COUNT = 50;
+    public static final int MAX_DECK_COUNT = 20;
     // Player profile data.
     private String name;
     private int heroRace;

--- a/forge-gui-mobile/src/forge/adventure/scene/AdventureDeckEditor.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/AdventureDeckEditor.java
@@ -389,7 +389,7 @@ public class AdventureDeckEditor extends TabPageScreen<AdventureDeckEditor> {
     @Override
     public void onActivate() {
         decksUsingMyCards = new ItemPool<>(InventoryItem.class);
-        for (int i = 0; i < AdventurePlayer.NUMBER_OF_DECKS; i++) {
+        for (int i = 0; i < AdventurePlayer.current().getDeckCount(); i++) {
             final Deck deck = AdventurePlayer.current().getDeck(i);
             CardPool main = deck.getMain();
             for (final Map.Entry<PaperCard, Integer> e : main) {

--- a/forge-gui-mobile/src/forge/adventure/scene/DeckSelectScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/DeckSelectScene.java
@@ -16,11 +16,12 @@ import forge.adventure.util.Current;
 
 public class DeckSelectScene extends UIScene {
     private final IntMap<TextraButton> buttons = new IntMap<>();
+    private final IntMap<Label> labels = new IntMap<>();
     Color defColor;
     TextField textInput;
     Table layout;
     TextraLabel header;
-    TextraButton back, edit, rename;
+    TextraButton back, edit, rename, add;
     int currentSlot = 0;
     ScrollPane scrollPane;
     Dialog renameDialog;
@@ -45,13 +46,13 @@ public class DeckSelectScene extends UIScene {
         root.add(header).colspan(2);
         root.row();
         root.add(scrollPane).expand().width(window.getWidth() - 20);
-        for (int i = 0; i < AdventurePlayer.NUMBER_OF_DECKS; i++)
-            addDeckSlot(Forge.getLocalizer().getMessage("lblDeck") + ": " + (i + 1), i);
+        this.layoutDeckButtons();
 
         textInput = Controls.newTextField("");
         back = ui.findActor("return");
         edit = ui.findActor("edit");
         rename = ui.findActor("rename");
+        add = ui.findActor("add");
         ui.onButtonPress("return", DeckSelectScene.this::back);
         ui.onButtonPress("edit", DeckSelectScene.this::edit);
         ui.onButtonPress("rename", () -> {
@@ -59,9 +60,42 @@ public class DeckSelectScene extends UIScene {
             showRenameDialog();
         });
         ui.onButtonPress("copy", DeckSelectScene.this::copy);
-        ui.onButtonPress("delete", DeckSelectScene.this::maybeDelete);
+        ui.onButtonPress("delete", DeckSelectScene.this::promptDelete);
+        ui.onButtonPress("add", DeckSelectScene.this::addDeck);
         defColor = ui.findActor("return").getColor();
         window.add(root);
+    }
+
+    private void refreshDeckButtons(){
+        clearDeckButtons();
+        layoutDeckButtons();
+    }
+
+    private void clearDeckButtons(){
+        int count = AdventurePlayer.current().getDeckCount();
+        for (int i = count; i >= 0; i--){
+            clearDeckButton(i);
+        }
+        layout.clearChildren();
+        buttons.clear();
+        labels.clear();
+    }
+
+    private void layoutDeckButtons() {
+        for (int i = 0; i < AdventurePlayer.current().getDeckCount(); i++)
+            addDeckButton(Forge.getLocalizer().getMessage("lblDeck") + ": " + (i + 1), i);
+    }
+
+    private void addDeck(){
+        if (Current.player().getDeckCount() >= AdventurePlayer.MAX_DECK_COUNT){
+            showDialog(createGenericDialog(Forge.getLocalizer().getMessage("lblAddDeck"), Forge.getLocalizer().getMessage("lblMaxDeckCountReached"),
+                    Forge.getLocalizer().getMessage("lblOK"), null, this::removeDialog, null));
+            return;
+        }
+
+        Current.player().addDeck();
+        refreshDeckButtons();
+        select(Current.player().getSelectedDeckIndex());
     }
 
     private void copy() {
@@ -79,17 +113,32 @@ public class DeckSelectScene extends UIScene {
         }
     }
 
-    private void maybeDelete() {
-        if (Current.player().isEmptyDeck(currentSlot)) return;
+    private void promptDelete() {
         Dialog deleteDialog = createGenericDialog(Forge.getLocalizer().getMessage("lblDelete"), Forge.getLocalizer().getMessage("lblAreYouSureProceedDelete"),
             Forge.getLocalizer().getMessage("lblOK"),
-            Forge.getLocalizer().getMessage("lblAbort"), this::delete, this::removeDialog);
+            Forge.getLocalizer().getMessage("lblAbort"), this::clearOrDelete, this::removeDialog);
 
         showDialog(deleteDialog);
     }
 
-    private void delete() {
-        Current.player().deleteDeck();
+    /**
+     * Clears or deletes the currently selected deck.
+     */
+    private void clearOrDelete(){
+        if (currentSlot >= AdventurePlayer.MIN_DECK_COUNT){
+            Current.player().deleteDeck();
+        }
+        else {
+            Current.player().clearDeck();
+        }
+
+        refreshDeckButtons();
+        select(0);
+        removeDialog();
+    }
+
+    private void clear() {
+        Current.player().clearDeck();
         updateDeckButton(currentSlot);
         removeDialog();
     }
@@ -117,7 +166,18 @@ public class DeckSelectScene extends UIScene {
         showDialog(renameDialog);
     }
 
-    private TextraButton addDeckSlot(String name, int i) {
+    /**
+     * Not sure if this is strictly necessary in Java but wouldn't want to leak before clearing the layout table.
+     */
+    private void clearDeckButton(int i){
+        if (buttons.containsKey(i)) {
+            TextraButton button = buttons.remove(i);
+            button.clearListeners();
+            button.clearActions();
+        }
+    }
+
+    private TextraButton addDeckButton(String name, int i) {
         TextraButton button = Controls.newTextButton("-");
         button.addListener(new ClickListener() {
             @Override
@@ -131,9 +191,12 @@ public class DeckSelectScene extends UIScene {
             }
         });
 
+        button.setText(Current.player().getDeck(i).getName());
+        Label label = Controls.newLabel(name);
         layout.add(Controls.newLabel(name)).pad(2);
         layout.add(button).fill(true, false).expand(true, false).align(Align.left).expandX().pad(2);
         buttons.put(i, button);
+        labels.put(i, label);
         addToSelectable(new Selectable(button));
         layout.row();
         return button;
@@ -158,13 +221,7 @@ public class DeckSelectScene extends UIScene {
 
     @Override
     public void enter() {
-        for (int i = 0; i < AdventurePlayer.NUMBER_OF_DECKS; i++) {
-            if (buttons.containsKey(i)) {
-                buttons.get(i).setText(Current.player().getDeck(i).getName());
-                buttons.get(i).getTextraLabel().layout();
-                buttons.get(i).layout();
-            }
-        }
+        refreshDeckButtons();
         GameHUD.getInstance().switchAudio();
         select(Current.player().getSelectedDeckIndex());
         performTouch(scrollPane); //can use mouse wheel if available to scroll after selection
@@ -175,9 +232,7 @@ public class DeckSelectScene extends UIScene {
     private void rename() {
         String text = textInput.getText();
         Current.player().renameDeck(text);
-        buttons.get(currentSlot).setText(Current.player().getDeck(currentSlot).getName());
-        buttons.get(currentSlot).getTextraLabel().layout();
-        buttons.get(currentSlot).layout();
+        updateDeckButton(currentSlot);
     }
 
     private void edit() {

--- a/forge-gui-mobile/src/forge/adventure/util/Controls.java
+++ b/forge-gui-mobile/src/forge/adventure/util/Controls.java
@@ -249,6 +249,27 @@ public class Controls {
         return ret;
     }
 
+    static public SelectBox<Integer> newComboBox(Integer[] text, int item, Function<Object, Void> func) {
+        SelectBox<Integer> ret = newComboBox();
+        ret.getStyle().listStyle.selection.setTopHeight(4);
+        ret.setItems(text);
+        ret.addListener(new ChangeListener() {
+            @Override
+            public void changed(ChangeEvent event, Actor actor) {
+                try {
+                    func.apply(((SelectBox) actor).getSelected());
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+        func.apply(item);
+        ret.getList().setAlignment(Align.center);
+        ret.setSelected(item);
+        ret.setAlignment(Align.right);
+        return ret;
+    }
+
     static public TextField newTextField(String text) {
         return new TextField(text, getSkin());
     }

--- a/forge-gui/res/adventure/common/ui/deck_selector.json
+++ b/forge-gui/res/adventure/common/ui/deck_selector.json
@@ -34,7 +34,7 @@
       "width": 100,
       "height": 30,
       "x": 365,
-      "y": 60
+      "y": 50
     },
     {
       "type": "TextButton",
@@ -44,7 +44,7 @@
       "width": 100,
       "height": 30,
       "x": 365,
-      "y": 110
+      "y": 90
     },
     {
       "type": "TextButton",
@@ -53,12 +53,21 @@
       "width": 100,
       "height": 30,
       "x": 365,
-      "y": 160
+      "y": 130
     },
     {
       "type": "TextButton",
       "name": "delete",
       "text": "tr(lblDelete)",
+      "width": 100,
+      "height": 30,
+      "x": 365,
+      "y": 170
+    },
+    {
+      "type": "TextButton",
+      "name": "add",
+      "text": "tr(lblAddDeck)",
       "width": 100,
       "height": 30,
       "x": 365,

--- a/forge-gui/res/adventure/common/ui/deck_selector_portrait.json
+++ b/forge-gui/res/adventure/common/ui/deck_selector_portrait.json
@@ -15,33 +15,42 @@
       "x": 4,
       "y": 4,
       "width": 262,
-      "height": 414
+      "height": 384
+    },
+    {
+      "type": "TextButton",
+      "name": "add",
+      "text": "tr(lblAddDeck)",
+      "width": 130,
+      "height": 30,
+      "x": 4,
+      "y": 388
     },
     {
       "type": "TextButton",
       "name": "delete",
       "text": "tr(lblDelete)",
-      "width": 86,
+      "width": 130,
+      "height": 30,
+      "x": 136,
+      "y": 388
+    },
+    {
+      "type": "TextButton",
+      "name": "copy",
+      "text": "tr(lblCopy)",
+      "width": 130,
       "height": 30,
       "x": 4,
       "y": 418
     },
     {
       "type": "TextButton",
-      "name": "copy",
-      "text": "tr(lblCopy)",
-      "width": 86,
-      "height": 30,
-      "x": 92,
-      "y": 418
-    },
-    {
-      "type": "TextButton",
       "name": "rename",
       "text": "tr(lblRename)",
-      "width": 86,
+      "width": 130,
       "height": 30,
-      "x": 180,
+      "x": 136,
       "y": 418
     },
     {

--- a/forge-gui/res/languages/de-DE.properties
+++ b/forge-gui/res/languages/de-DE.properties
@@ -3517,3 +3517,5 @@ lblNonSellable=Kein Verkauf
 lblPromptAutoSell=Aufforderung zum Autoverkauf
 cbAITimeout=AI Time-out
 nlAITimeout=Zeitüberschreitung in Sekunden für AI, wenn die zu spielenden Zauber berechnet und Angreifer deklariert werden
+lblAddDeck=Hinzufügen
+lblMaxDeckCountReached=Sie haben bereits die maximale Anzahl an Kartendecks erstellt

--- a/forge-gui/res/languages/en-US.properties
+++ b/forge-gui/res/languages/en-US.properties
@@ -3264,3 +3264,5 @@ lblNonSellable=No-Sell
 lblPromptAutoSell=Prompt for auto sell
 cbAITimeout=AI Timeout
 nlAITimeout=Time-out in seconds for AI when computing for spells to play and declaring attackers
+lblAddDeck=Add
+lblMaxDeckCountReached=You've already created the maximum amount of decks

--- a/forge-gui/res/languages/es-ES.properties
+++ b/forge-gui/res/languages/es-ES.properties
@@ -3521,3 +3521,5 @@ lblNonSellable=Sin venta
 lblPromptAutoSell=Solicitar venta automática
 cbAITimeout=AI Se acabó el tiempo
 nlAITimeout=Tiempo de espera en segundos para AI al calcular los hechizos a jugar y declarar atacantes
+lblAddDeck=Añadir
+lblMaxDeckCountReached=Ya has creado la cantidad máxima de mazos

--- a/forge-gui/res/languages/fr-FR.properties
+++ b/forge-gui/res/languages/fr-FR.properties
@@ -3522,3 +3522,5 @@ lblNonSellable=Pas de vente
 lblPromptAutoSell=Invite pour la vente automatique
 cbAITimeout=AI Temps mort
 nlAITimeout=Délai d'attente en secondes pour AI lors du calcul des sorts à jouer et de la déclaration des attaquants
+lblAddDeck=Ajouter
+lblMaxDeckCountReached=Vous avez déjà créé le montant maximum

--- a/forge-gui/res/languages/it-IT.properties
+++ b/forge-gui/res/languages/it-IT.properties
@@ -3520,3 +3520,5 @@ lblNonSellable=Nessuna vendita
 lblPromptAutoSell=Richiesta di vendita auto
 cbAITimeout=AI Tempo scaduto
 nlAITimeout=Timeout in secondi per AI durante il calcolo degli incantesimi da giocare e la dichiarazione degli attaccanti
+lblAddDeck=Aggiungere
+lblMaxDeckCountReached=Hai già creato il numero massimo di mazzi

--- a/forge-gui/res/languages/ja-JP.properties
+++ b/forge-gui/res/languages/ja-JP.properties
@@ -3516,3 +3516,5 @@ lblNonSellable=売りません
 lblPromptAutoSell=自動車販売のプロンプト
 cbAITimeout=AI タイムアウト
 nlAITimeout=プレイする呪文を計算し、攻撃者を宣言するときの AI のタイムアウト (秒単位)
+lblAddDeck=追加
+lblMaxDeckCountReached=すでに最大額を作成しました

--- a/forge-gui/res/languages/pt-BR.properties
+++ b/forge-gui/res/languages/pt-BR.properties
@@ -3606,3 +3606,5 @@ lblNonSellable=Não vender
 lblPromptAutoSell=Solicitação de venda automática
 cbAITimeout=AI Tempo esgotado
 nlAITimeout=Tempo limite em segundos para AI ao calcular feitiços para jogar e declarar atacantes
+lblAddDeck=Adicionar
+lblMaxDeckCountReached=Você já criou a quantidade máxima de decks

--- a/forge-gui/res/languages/zh-CN.properties
+++ b/forge-gui/res/languages/zh-CN.properties
@@ -3507,3 +3507,5 @@ lblNonSellable=不卖
 lblPromptAutoSell=提示汽车出售
 cbAITimeout=AI 暂停
 nlAITimeout=计算要播放的咒语并宣布攻击者时，AI 超时（以秒为单位）
+lblAddDeck=添加
+lblMaxDeckCountReached=你已经创建了最大数量的卡牌组


### PR DESCRIPTION
When playing Adventure for a while, it's possible to run out of deck slots when trying different builds. Currently the deck count is statically set to 10 due to the underlying structure of the data (array) and storage solution (trying to see if the user has deck of an index stored, for each index up till 10).

This MR replaces the underlying structure (with an ArrayList) and the save load mechanism to allow dynamic deck counts. I've extended the adventure deck editor scene/UI to support adding and deleting decks. The player is always bound to have at least 10 decks (trying to delete below the minimum limit just clears that deck, as was the case before). The save/load checks whether the deck count is saved and if so, loads decks up till the count, otherwise proceeds with the legacy load.

I've also added a utility method for an integer-selecting combo box - didn't really need it in the end but might come in handy for someone else later on.