### PR TITLE
CardState: Refactor LandAbility/Aura/PermSpell

### DIFF
--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -2790,15 +2790,9 @@ public class GameAction {
             return false;
         }
 
-        SpellAbility aura = new SpellAbility.EmptySa(ApiType.Attach, source);
-        if (source.hasSVar("AttachAITgts")) {
-            aura.putParam("AITgts", source.getSVar("AttachAITgts"));
-        }
-        if (source.hasSVar("AttachAILogic")) {
-            aura.putParam("AILogic", source.getSVar("AttachAILogic"));
-        }
-        if (source.hasSVar("AttachAIValid")) {
-            aura.putParam("AIValid", source.getSVar("AttachAIValid"));
+        SpellAbility aura = source.getCurrentState().getAuraSpell();
+        if (aura == null) {
+            return false;
         }
 
         Set<ZoneType> zones = EnumSet.noneOf(ZoneType.class);

--- a/forge-game/src/main/java/forge/game/ability/AbilityFactory.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityFactory.java
@@ -209,15 +209,6 @@ public final class AbilityFactory {
             }
         }
 
-        else if (api == ApiType.PermanentCreature || api == ApiType.PermanentNoncreature) {
-            // If API is a permanent type, and creating AF Spell
-            // Clear out the auto created SpellPermanent spell
-            if (type == AbilityRecordType.Spell
-                    && !mapParams.containsKey("SubAbility") && !mapParams.containsKey("NonBasicSpell")) {
-                hostCard.clearFirstSpell();
-            }
-        }
-
         if (abCost == null) {
             abCost = parseAbilityCost(state, mapParams, type);
         }

--- a/forge-game/src/main/java/forge/game/ability/AbilityFactory.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityFactory.java
@@ -494,8 +494,9 @@ public final class AbilityFactory {
         AbilityRecordType leftType = AbilityRecordType.getRecordType(leftMap);
         ApiType leftApi = leftType.getApiTypeOf(leftMap);
         leftMap.put("StackDescription", leftMap.get("SpellDescription"));
-        leftMap.put("SpellDescription", "Fuse (you may cast both halves of this card from your hand).");
+        leftMap.put("SpellDescription", "Fuse (You may cast one or both halves of this card from your hand.)");
         leftMap.put("ActivationZone", "Hand");
+        leftMap.put("Secondary", "True");
 
         CardState rightState = card.getState(CardStateName.RightSplit);
         SpellAbility rightAbility = rightState.getFirstAbility();

--- a/forge-game/src/main/java/forge/game/ability/AbilityFactory.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityFactory.java
@@ -511,8 +511,10 @@ public final class AbilityFactory {
         totalCost.add(parseAbilityCost(rightState, rightMap, rightType));
 
         final SpellAbility left = getAbility(leftType, leftApi, leftMap, totalCost, leftState, leftState);
+        left.setOriginalAbility(leftAbility);
         left.setCardState(card.getState(CardStateName.Original));
         final AbilitySub right = (AbilitySub) getAbility(AbilityRecordType.SubAbility, rightApi, rightMap, null, rightState, rightState);
+        right.setOriginalAbility(rightAbility);
         left.appendSubAbility(right);
         return left;
     }

--- a/forge-game/src/main/java/forge/game/ability/effects/PermanentCreatureEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PermanentCreatureEffect.java
@@ -15,8 +15,8 @@ public class PermanentCreatureEffect extends PermanentEffect {
     public String getStackDescription(final SpellAbility sa) {
         final CardState source = sa.getCardState();
         final StringBuilder sb = new StringBuilder();
-        sb.append(CardTranslation.getTranslatedName(source.getName())).append(" - ").append(Localizer.getInstance().getMessage("lblCreature")).append(" ").append(source.getBasePower());
-        sb.append(" / ").append(source.getBaseToughness());
+        sb.append(CardTranslation.getTranslatedName(source.getName())).append(" - ").append(Localizer.getInstance().getMessage("lblCreature")).append(" ").append(source.getBasePowerString());
+        sb.append(" / ").append(source.getBaseToughnessString());
         return sb.toString();
     }
 }

--- a/forge-game/src/main/java/forge/game/ability/effects/PermanentCreatureEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PermanentCreatureEffect.java
@@ -1,6 +1,6 @@
 package forge.game.ability.effects;
 
-import forge.game.card.Card;
+import forge.game.card.CardState;
 import forge.game.spellability.SpellAbility;
 import forge.util.CardTranslation;
 import forge.util.Localizer;
@@ -13,10 +13,10 @@ public class PermanentCreatureEffect extends PermanentEffect {
 
     @Override
     public String getStackDescription(final SpellAbility sa) {
-        final Card sourceCard = sa.getHostCard();
+        final CardState source = sa.getCardState();
         final StringBuilder sb = new StringBuilder();
-        sb.append(CardTranslation.getTranslatedName(sourceCard.getName())).append(" - ").append(Localizer.getInstance().getMessage("lblCreature")).append(" ").append(sourceCard.getNetPower());
-        sb.append(" / ").append(sourceCard.getNetToughness());
+        sb.append(CardTranslation.getTranslatedName(source.getName())).append(" - ").append(Localizer.getInstance().getMessage("lblCreature")).append(" ").append(source.getBasePower());
+        sb.append(" / ").append(source.getBaseToughness());
         return sb.toString();
     }
 }

--- a/forge-game/src/main/java/forge/game/ability/effects/PermanentNoncreatureEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PermanentNoncreatureEffect.java
@@ -1,6 +1,5 @@
 package forge.game.ability.effects;
 
-import forge.game.card.Card;
 import forge.game.spellability.SpellAbility;
 import forge.util.CardTranslation;
 
@@ -12,8 +11,7 @@ public class PermanentNoncreatureEffect extends PermanentEffect {
 
     @Override
     public String getStackDescription(final SpellAbility sa) {
-        final Card sourceCard = sa.getHostCard();
         //CardView toString return translated name,don't need call CardTranslation.getTranslatedName in this.
-        return CardTranslation.getTranslatedName(sourceCard.getName());
+        return CardTranslation.getTranslatedName(sa.getCardState().getName());
     }
 }

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -5382,6 +5382,14 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
 
         // Layer 1
         keywords.insertAll(state.getIntrinsicKeywords());
+        if (state.getStateName().equals(CardStateName.Original)) {
+            if (hasState(CardStateName.LeftSplit)) {
+                keywords.insertAll(getState(CardStateName.LeftSplit).getIntrinsicKeywords());
+            }
+            if (hasState(CardStateName.RightSplit)) {
+                keywords.insertAll(getState(CardStateName.RightSplit).getIntrinsicKeywords());
+            }
+        }
 
         keywords.applyChanges(getChangedCardKeywordsList());
 

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -2981,7 +2981,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
             }
         }
 
-        if (this.getRules() != null && state.getView().getState().equals(CardStateName.Original)) {
+        if (this.getRules() != null && state.getStateName().equals(CardStateName.Original)) {
             // try to look which what card this card can be meld to
             // only show this info if this card does not has the meld Effect itself
 
@@ -3474,10 +3474,6 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
         return max_produced;
     }
 
-    public final void clearFirstSpell() {
-        currentState.clearFirstSpell();
-    }
-
     public final SpellAbility getFirstSpellAbility() {
         return Iterables.getFirst(currentState.getNonManaAbilities(), null);
     }
@@ -3497,18 +3493,6 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     public final void addSpellAbility(final SpellAbility a, final boolean updateView) {
         a.setHostCard(this);
         if (currentState.addSpellAbility(a) && updateView) {
-            currentState.getView().updateAbilityText(this, currentState);
-        }
-    }
-
-    @Deprecated
-    public final void removeSpellAbility(final SpellAbility a) {
-        removeSpellAbility(a, true);
-    }
-
-    @Deprecated
-    public final void removeSpellAbility(final SpellAbility a, final boolean updateView) {
-        if (currentState.removeSpellAbility(a) && updateView) {
             currentState.getView().updateAbilityText(this, currentState);
         }
     }
@@ -3584,7 +3568,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
         // add Facedown abilities from Original state but only if this state is face down
         // need CardStateView#getState or might crash in StackOverflow
         if (isInPlay()) {
-            if ((null == mana || false == mana) && isFaceDown() && state.getView().getState() == CardStateName.FaceDown) {
+            if ((null == mana || false == mana) && isFaceDown() && state.getStateName() == CardStateName.FaceDown) {
                 for (SpellAbility sa : getState(CardStateName.Original).getNonManaAbilities()) {
                     if (sa.isTurnFaceUp()) {
                         list.add(sa);
@@ -3593,7 +3577,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
             }
         } else {
             // Adventure and Omen may only be cast not from Battlefield
-            if (hasState(CardStateName.Secondary) && state.getView().getState() == CardStateName.Original) {
+            if (hasState(CardStateName.Secondary) && state.getStateName() == CardStateName.Original) {
                 for (SpellAbility sa : getState(CardStateName.Secondary).getSpellAbilities()) {
                     if (mana == null || mana == sa.isManaAbility()) {
                         list.add(sa);
@@ -7224,10 +7208,6 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
         return !StaticAbilityCantExile.cantExile(this, source, effect);
     }
 
-    public final void setStaticAbilities(final List<StaticAbility> a) {
-        currentState.setStaticAbilities(a);
-    }
-
     public final FCollectionView<StaticAbility> getStaticAbilities() {
         return currentState.getStaticAbilities();
     }
@@ -7242,11 +7222,6 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     public final StaticAbility addStaticAbility(final StaticAbility stAb) {
         currentState.addStaticAbility(stAb);
         return stAb;
-    }
-
-    @Deprecated
-    public final void removeStaticAbility(StaticAbility stAb) {
-        currentState.removeStaticAbility(stAb);
     }
 
     public void updateStaticAbilities(List<StaticAbility> list, CardState state) {
@@ -7299,11 +7274,6 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     public ReplacementEffect addReplacementEffect(final ReplacementEffect replacementEffect) {
         currentState.addReplacementEffect(replacementEffect);
         return replacementEffect;
-    }
-
-    @Deprecated
-    public void removeReplacementEffect(ReplacementEffect replacementEffect) {
-        currentState.removeReplacementEffect(replacementEffect);
     }
 
     public void updateReplacementEffects(List<ReplacementEffect> list, CardState state) {

--- a/forge-game/src/main/java/forge/game/card/CardFactory.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactory.java
@@ -254,15 +254,7 @@ public class CardFactory {
 
             // ******************************************************************
             // ************** Link to different CardFactories *******************
-            if (state == CardStateName.LeftSplit || state == CardStateName.RightSplit) {
-                for (final SpellAbility sa : card.getSpellAbilities()) {
-                    sa.setCardState(card.getState(state));
-                }
-                CardFactoryUtil.setupKeywordedAbilities(card);
-                final CardState original = card.getState(CardStateName.Original);
-                original.addIntrinsicKeywords(card.getCurrentState().getIntrinsicKeywords()); // Copy 'Fuse' to original side
-                original.getSVars().putAll(card.getCurrentState().getSVars()); // Unfortunately need to copy these to (Effect looks for sVars on execute)
-            } else if (state != CardStateName.Original) {
+            if (state != CardStateName.Original) {
                 CardFactoryUtil.setupKeywordedAbilities(card);
             }
         }

--- a/forge-game/src/main/java/forge/game/card/CardFactory.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactory.java
@@ -260,23 +260,7 @@ public class CardFactory {
                 }
                 CardFactoryUtil.setupKeywordedAbilities(card);
                 final CardState original = card.getState(CardStateName.Original);
-                original.addNonManaAbilities(card.getCurrentState().getNonManaAbilities());
                 original.addIntrinsicKeywords(card.getCurrentState().getIntrinsicKeywords()); // Copy 'Fuse' to original side
-                for (Trigger t : card.getCurrentState().getTriggers()) {
-                    if (t.isIntrinsic()) {
-                        original.addTrigger(t);
-                    }
-                }
-                for (StaticAbility st : card.getCurrentState().getStaticAbilities()) {
-                    if (st.isIntrinsic()) {
-                        original.addStaticAbility(st);
-                    }
-                }
-                for (ReplacementEffect re : card.getCurrentState().getReplacementEffects()) {
-                    if (re.isIntrinsic()) {
-                        original.addReplacementEffect(re);
-                    }
-                }
                 original.getSVars().putAll(card.getCurrentState().getSVars()); // Unfortunately need to copy these to (Effect looks for sVars on execute)
             } else if (state != CardStateName.Original) {
                 CardFactoryUtil.setupKeywordedAbilities(card);
@@ -441,54 +425,6 @@ public class CardFactory {
         }
 
         c.setAttractionLights(face.getAttractionLights());
-
-        // SpellPermanent only for Original State
-        if (c.getCurrentStateName() == CardStateName.Original ||
-                c.getCurrentStateName() == CardStateName.LeftSplit ||
-                c.getCurrentStateName() == CardStateName.RightSplit ||
-                c.getCurrentStateName() == CardStateName.Modal ||
-                c.getCurrentStateName().toString().startsWith("Specialize")) {
-            if (c.isLand()) {
-                SpellAbility sa = new LandAbility(c);
-                sa.setCardState(c.getCurrentState());
-                c.addSpellAbility(sa);
-            } else if (c.isAura()) {
-                String desc = "";
-                String extra = "";
-                for (KeywordInterface ki : c.getKeywords(Keyword.ENCHANT)) {
-                    String o = ki.getOriginal();
-                    String m[] = o.split(":");
-                    if (m.length > 2) {
-                        desc = m[2];
-                    } else {
-                        desc = m[1];
-                        if (CardType.isACardType(desc) || "Permanent".equals(desc) || "Player".equals(desc) || "Opponent".equals(desc)) {
-                            desc = desc.toLowerCase();
-                        }
-                    }
-                    break;
-                }
-                if (c.hasSVar("AttachAITgts")) {
-                    extra += " | AITgts$ " + c.getSVar("AttachAITgts");
-                }
-                if (c.hasSVar("AttachAILogic")) {
-                    extra += " | AILogic$ " + c.getSVar("AttachAILogic");
-                }
-                if (c.hasSVar("AttachAIValid")) { // TODO combine with AttachAITgts
-                    extra += " | AIValid$ " + c.getSVar("AttachAIValid");
-                }
-                String st = "SP$ Attach | ValidTgts$ Card.CanBeEnchantedBy,Player.CanBeEnchantedBy | TgtZone$ Battlefield,Graveyard | TgtPrompt$ Select target " + desc + extra;
-                SpellAbility sa = AbilityFactory.getAbility(st, c);
-                sa.setIntrinsic(true);
-                sa.setCardState(c.getCurrentState());
-                c.addSpellAbility(sa);
-            } else if (c.isPermanent()) {
-                // this is the "default" spell for permanents like creatures and artifacts
-                SpellAbility sa = new SpellPermanent(c);
-                sa.setCardState(c.getCurrentState());
-                c.addSpellAbility(sa);
-            }
-        }
 
         CardFactoryUtil.addAbilityFactoryAbilities(c, face.getAbilities());
     }

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -3207,7 +3207,6 @@ public class CardFactoryUtil {
             inst.addSpellAbility(newSA);
         } else if (keyword.startsWith("Fuse") && card.getStateName().equals(CardStateName.Original)) {
             final SpellAbility sa = AbilityFactory.buildFusedAbility(card.getCard());
-            card.addSpellAbility(sa);
             inst.addSpellAbility(sa);
         } else if (keyword.startsWith("Haunt")) {
             if (!host.isCreature() && intrinsic) {

--- a/forge-game/src/main/java/forge/game/card/CardState.java
+++ b/forge-game/src/main/java/forge/game/card/CardState.java
@@ -443,7 +443,6 @@ public class CardState extends GameObject implements IHasSVars, ITranslatable {
 
             if (permanentAbility == null) {
                 permanentAbility = new SpellPermanent(card, this);
-                permanentAbility.setCardState(this);
             }
             newCol.add(permanentAbility);
         }
@@ -472,7 +471,6 @@ public class CardState extends GameObject implements IHasSVars, ITranslatable {
         } else {
             if (permanentAbility == null) {
                 permanentAbility = new SpellPermanent(card, this);
-                permanentAbility.setCardState(this);
             }
             return permanentAbility;
         }
@@ -511,7 +509,6 @@ public class CardState extends GameObject implements IHasSVars, ITranslatable {
             String st = "SP$ Attach | ValidTgts$ Card.CanBeEnchantedBy,Player.CanBeEnchantedBy | TgtZone$ Battlefield,Graveyard | TgtPrompt$ Select target " + desc + extra;
             auraAbility = AbilityFactory.getAbility(st, this);
             auraAbility.setIntrinsic(true);
-            auraAbility.setCardState(this);
         }
         return this.auraAbility;
     }

--- a/forge-game/src/main/java/forge/game/card/CardState.java
+++ b/forge-game/src/main/java/forge/game/card/CardState.java
@@ -419,6 +419,11 @@ public class CardState extends GameObject implements IHasSVars, ITranslatable {
         default:
             return;
         }
+        // if card has left or right split, disable intrinsic Spell for original
+        if (getStateName().equals(CardStateName.Original) && (getCard().hasState(CardStateName.LeftSplit) || getCard().hasState(CardStateName.RightSplit))) {
+            return;
+        }
+
         CardTypeView type = getTypeWithChanges();
         if (type.isLand()) {
             if (landAbility == null) {

--- a/forge-game/src/main/java/forge/game/card/CardView.java
+++ b/forge-game/src/main/java/forge/game/card/CardView.java
@@ -1068,6 +1068,7 @@ public class CardView extends GameEntityView {
         if (isSplitCard) {
             set(TrackableProperty.LeftSplitState, c.getState(CardStateName.LeftSplit).getView());
             set(TrackableProperty.RightSplitState, c.getState(CardStateName.RightSplit).getView());
+
             // need to update ability text
             getLeftSplitState().updateAbilityText(c, c.getState(CardStateName.LeftSplit));
             getRightSplitState().updateAbilityText(c, c.getState(CardStateName.RightSplit));

--- a/forge-game/src/main/java/forge/game/card/CardView.java
+++ b/forge-game/src/main/java/forge/game/card/CardView.java
@@ -1068,6 +1068,9 @@ public class CardView extends GameEntityView {
         if (isSplitCard) {
             set(TrackableProperty.LeftSplitState, c.getState(CardStateName.LeftSplit).getView());
             set(TrackableProperty.RightSplitState, c.getState(CardStateName.RightSplit).getView());
+            // need to update ability text
+            getLeftSplitState().updateAbilityText(c, c.getState(CardStateName.LeftSplit));
+            getRightSplitState().updateAbilityText(c, c.getState(CardStateName.RightSplit));
         }
 
         CardStateView currentStateView = currentState.getView();

--- a/forge-game/src/main/java/forge/game/spellability/LandAbility.java
+++ b/forge-game/src/main/java/forge/game/spellability/LandAbility.java
@@ -79,7 +79,7 @@ public class LandAbility extends AbilityStatic {
         StringBuilder sb = new StringBuilder(StringUtils.capitalize(localizer.getMessage("lblPlayLand")));
 
         if (getHostCard().isModal()) {
-            sb.append(" (").append(CardTranslation.getTranslatedName(getHostCard().getName(ObjectUtils.firstNonNull(getCardStateName(), CardStateName.Original)))).append(")");
+            sb.append(" (").append(CardTranslation.getTranslatedName(getCardState().getName())).append(")");
         }
 
         StaticAbility sta = getMayPlay();

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
@@ -1655,6 +1655,12 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
     @Override
     protected List<IHasSVars> getSVarFallback(final String name) {
         List<IHasSVars> result = Lists.newArrayList();
+        if (isKeyword(Keyword.FUSE)) {
+            SpellAbility original = this.getOriginalAbility();
+            if (original != null) {
+                result.add(original);
+            }
+        }
         if (getParent() != null) {
             result.add(getParent());
         }

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
@@ -1009,6 +1009,9 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
         if (stackDescription.equals(text) && !text.isEmpty()) {
             return getHostCard().getName() + " - " + text;
         }
+        if (stackDescription.isEmpty()) {
+            return "";
+        }
         return TextUtil.fastReplace(stackDescription, "CARDNAME", getHostCard().getName());
     }
     public void setStackDescription(final String s) {
@@ -1101,7 +1104,7 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
                 sb.append(" ");
             }
             String desc = node.getDescription();
-            if (node.getHostCard() != null) {
+            if (node.getHostCard() != null && !desc.isEmpty()) {
                 ITranslatable nameSource = getHostName(node);
                 desc = CardTranslation.translateMultipleDescriptionText(desc, nameSource);
                 String translatedName = CardTranslation.getTranslatedName(nameSource);

--- a/forge-game/src/main/java/forge/game/spellability/SpellPermanent.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellPermanent.java
@@ -55,6 +55,8 @@ public class SpellPermanent extends SpellApiBased {
         super(cardstate.getType().isCreature() ? ApiType.PermanentCreature : ApiType.PermanentNoncreature, sourceCard,
                 cost, null, Maps.newHashMap());
 
+        setCardState(cardstate);
+
         // reset StackDescription for something with Text
         this.setStackDescription("");
         this.setDescription(this.getStackDescription());


### PR DESCRIPTION
Closes #7677 

Also:
- Fixes Disturb Auras need to target
- Changed the need for `clearFirstSpell`, the Only use for `NonBasicSpell` is Cleave make an extra PR for this
- Make Original CardState load LeftSplit/RightSplit CardStates too
