### PR TITLE
FIN: The Masamune

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/the_masamune.txt
+++ b/forge-gui/res/cardsfolder/upcoming/the_masamune.txt
@@ -1,0 +1,8 @@
+Name:The Masamune
+ManaCost:3
+Types:Legendary Artifact Equipment
+K:Equip:2
+S:Mode$ Continuous | Affected$ Creature.EquippedBy+attacking | AddKeyword$ First Strike & MustBeBlockedBy Creature | Description$ As long as equipped creature is attacking, it has first strike and must be blocked if able.
+S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddStaticAbility$ Masarmonioon | Description$ Equipped creature has "If a creature dying causes a triggered ability of this creature or an emblem you own to trigger, that ability triggers an additional time."
+SVar:Masarmonioon:Mode$ Panharmonicon | ValidMode$ ChangesZone,ChangesZoneAll | ValidCard$ Card.Self,Emblem.YouOwn | ValidCause$ Creature | Origin$ Battlefield | Destination$ Graveyard | Description$ If a creature dying causes a triggered ability of this creature or an emblem you own to trigger, that ability triggers an additional time.
+Oracle:As long as equipped creature is attacking, it has first strike and must be blocked if able.\nEquipped creature has "If a creature dying causes a triggered ability of this creature or an emblem you own to trigger, that ability triggers an additional time."\nEquip {2}


### PR DESCRIPTION
Tested to some extent:
- [The Masamune](https://www.reddit.com/r/magicTCG/comments/1kxap3u/fin_the_masamune_geek_culture/)
=> While the trigger doubling works for the equipped creature, it seems that `ValidCard` doesn't recognize emblems as, well... valid trigger sources, so those triggers aren't doubled as the script currently stands. I looked over [`StaticAbilityPanharmonicon.java`](https://github.com/Card-Forge/forge/blob/master/forge-game/src/main/java/forge/game/staticability/StaticAbilityPanharmonicon.java) and the state off affairs for `ValidCard`, `ValidSource` and even `ValidTgts` to end up with little idea as to how to proceed on the Java front.