### PR TITLE
fix: do not steal keyboard focus when "Visually Alert on Receipt of Priority" is enabled

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/gui/framework/SDisplayUtil.java
+++ b/forge-gui-desktop/src/main/java/forge/gui/framework/SDisplayUtil.java
@@ -18,6 +18,7 @@ import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 
 import forge.gui.FThreads;
+import forge.toolbox.FButton;
 import forge.view.FFrame;
 
 /**
@@ -103,9 +104,8 @@ public class SDisplayUtil {
             if (dc != null) {
                 dc.setSelected(tab0);
             }
-            // set focus back to previous owner, if any
-            // if (null != c  &&  c instanceof FButton) {  //pfps UGLY but maybe necessary (probably not)
-            if (null != c) {
+            // To prevent stealing keyboard focus, set focus back to previous owner, but only if it was a button.
+            if (c instanceof FButton) {
                 c.requestFocusInWindow();
             }
         };


### PR DESCRIPTION
When the "Visually Alert on Receipt of Priority" feature is enabled, the `showTab()` call at the beginning of `forge.gui.framework.SDisplayUtil.remind()` steals focus from the primary button whenever anything goes on the stack.

This change, previously suggested by pfps as probably not necessary, is indeed necessary after all to prevent that focus stealing by restoring focus to the previous owner only if the owner was an `FButton`.

fixes https://github.com/Card-Forge/forge/issues/7660