### PR TITLE
fix incorrect resource name (deathknightidle.png)

### DIFF
--- a/forge-gui/res/adventure/common/sprites/enemy/undead/deathknightidle.atlas
+++ b/forge-gui/res/adventure/common/sprites/enemy/undead/deathknightidle.atlas
@@ -1,4 +1,4 @@
-Deathknightidle.png
+deathknightidle.png
 size: 80,16
 format: RGBA8888
 filter: Nearest,Nearest


### PR DESCRIPTION
small fix to incorrect resource name, when loading a page with an idle deathknight the following exception will be thrown on repeat and the screen will not load:

```
com.badlogic.gdx.utils.GdxRuntimeException: com.badlogic.gdx.utils.GdxRuntimeException: Couldn't load dependencies of asset: ../forge-gui/res/adventure/common/sprites/enemy/undead/Deathknightidle.png
  at com.badlogic.gdx.assets.AssetManager.handleTaskError(AssetManager.java:648)
  at com.badlogic.gdx.assets.AssetManager.update(AssetManager.java:426)
  at com.badlogic.gdx.assets.AssetManager.finishLoadingAsset(AssetManager.java:483)
  at forge.assets.Assets$MemoryTrackingAssetManager.finishLoadingAsset(Assets.java:559)
  at forge.adventure.util.Config.getAtlas(Config.java:267)
  at forge.adventure.util.Config.getAnimatedSprites(Config.java:311)
  at forge.adventure.character.CharacterSprite.load(CharacterSprite.java:60)
  at forge.adventure.character.CharacterSprite.<init>(CharacterSprite.java:35)
  at forge.adventure.character.EnemySprite.<init>(EnemySprite.java:95)
  at forge.adventure.stage.MapStage.loadObjects(MapStage.java:491)
  at forge.adventure.stage.MapStage.loadMap(MapStage.java:270)
  at forge.adventure.stage.PointOfInterestMapRenderer.loadMap(PointOfInterestMapRenderer.java:35)
  at forge.adventure.scene.TileMapScene.load(TileMapScene.java:140)
  at forge.adventure.scene.TileMapScene.act(TileMapScene.java:62)
  at forge.Forge.render(Forge.java:920)
  at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Window.update(Lwjgl3Window.java:435)
  at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.loop(Lwjgl3Application.java:181)
  at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.<init>(Lwjgl3Application.java:153)
  at forge.app.GameLauncher.<init>(GameLauncher.java:51)
  at forge.app.Main.main(Main.java:30)
Caused by: com.badlogic.gdx.utils.GdxRuntimeException: Couldn't load dependencies of asset: ../forge-gui/res/adventure/common/sprites/enemy/undead/Deathknightidle.png
  at com.badlogic.gdx.assets.AssetLoadingTask.handleAsyncLoader(AssetLoadingTask.java:119)
  at com.badlogic.gdx.assets.AssetLoadingTask.update(AssetLoadingTask.java:91)
  at com.badlogic.gdx.assets.AssetManager.updateTask(AssetManager.java:575)
  at com.badlogic.gdx.assets.AssetManager.update(AssetManager.java:424)
  ... 18 more
Caused by: com.badlogic.gdx.utils.GdxRuntimeException: com.badlogic.gdx.utils.GdxRuntimeException: Couldn't load file: ../forge-gui/res/adventure/common/sprites/enemy/undead/Deathknightidle.png
  at com.badlogic.gdx.utils.async.AsyncResult.get(AsyncResult.java:46)
  at com.badlogic.gdx.assets.AssetLoadingTask.handleAsyncLoader(AssetLoadingTask.java:117)
  ... 21 more
Caused by: com.badlogic.gdx.utils.GdxRuntimeException: Couldn't load file: ../forge-gui/res/adventure/common/sprites/enemy/undead/Deathknightidle.png
  at com.badlogic.gdx.graphics.Pixmap.<init>(Pixmap.java:190)
  at com.badlogic.gdx.graphics.TextureData$Factory.loadFromFile(TextureData.java:101)
  at com.badlogic.gdx.assets.loaders.TextureLoader.loadAsync(TextureLoader.java:62)
  at com.badlogic.gdx.assets.loaders.TextureLoader.loadAsync(TextureLoader.java:35)
  at com.badlogic.gdx.assets.AssetLoadingTask.call(AssetLoadingTask.java:71)
  at com.badlogic.gdx.assets.AssetLoadingTask.call(AssetLoadingTask.java:35)
  at com.badlogic.gdx.utils.async.AsyncExecutor$2.call(AsyncExecutor.java:64)
  at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
  at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
  at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
  at java.base/java.lang.Thread.run(Thread.java:1575)
```