### PR TITLE
SpellAbility: set CardState inside constructor

### DIFF
--- a/forge-game/src/main/java/forge/game/card/CardState.java
+++ b/forge-game/src/main/java/forge/game/card/CardState.java
@@ -434,15 +434,10 @@ public class CardState extends GameObject implements IHasSVars, ITranslatable {
             return;
         }
 
-        if (getCard().isInPlay()) {
-            return;
-        }
-
         CardTypeView type = getTypeWithChanges();
         if (type.isLand()) {
             if (landAbility == null) {
-                landAbility = new LandAbility(card);
-                landAbility.setCardState(this);
+                landAbility = new LandAbility(card, this);
             }
             newCol.add(landAbility);
         } else if (type.isAura()) {

--- a/forge-game/src/main/java/forge/game/spellability/Ability.java
+++ b/forge-game/src/main/java/forge/game/spellability/Ability.java
@@ -22,6 +22,7 @@ import com.esotericsoftware.minlog.Log;
 import forge.card.mana.ManaCost;
 import forge.game.Game;
 import forge.game.card.Card;
+import forge.game.card.CardState;
 import forge.game.cost.Cost;
 
 /**
@@ -36,6 +37,9 @@ public abstract class Ability extends SpellAbility {
 
     protected Ability(final Card sourceCard, final ManaCost manaCost) {
         this(sourceCard, new Cost(manaCost, true), null);
+    }
+    protected Ability(final Card sourceCard, final ManaCost manaCost, final CardState state) {
+        super(sourceCard, new Cost(manaCost, true), null, state);
     }
     protected Ability(final Card sourceCard, final ManaCost manaCost, SpellAbilityView view0) {
         this(sourceCard, new Cost(manaCost, true), view0);

--- a/forge-game/src/main/java/forge/game/spellability/AbilityStatic.java
+++ b/forge-game/src/main/java/forge/game/spellability/AbilityStatic.java
@@ -19,6 +19,7 @@ package forge.game.spellability;
 
 import forge.card.mana.ManaCost;
 import forge.game.card.Card;
+import forge.game.card.CardState;
 import forge.game.cost.Cost;
 
 /**
@@ -42,6 +43,9 @@ public abstract class AbilityStatic extends Ability implements Cloneable {
      */
     public AbilityStatic(final Card sourceCard, final ManaCost manaCost) {
         super(sourceCard, manaCost);
+    }
+    public AbilityStatic(final Card sourceCard, final ManaCost manaCost, final CardState state) {
+        super(sourceCard, manaCost, state);
     }
 
     public AbilityStatic(final Card sourceCard, final Cost abCost, final TargetRestrictions tgt) {

--- a/forge-game/src/main/java/forge/game/spellability/LandAbility.java
+++ b/forge-game/src/main/java/forge/game/spellability/LandAbility.java
@@ -21,6 +21,7 @@ import forge.card.CardStateName;
 import forge.card.mana.ManaCost;
 import forge.game.card.Card;
 import forge.game.card.CardCopyService;
+import forge.game.card.CardState;
 import forge.game.player.Player;
 import forge.game.staticability.StaticAbility;
 import forge.game.zone.ZoneType;
@@ -31,8 +32,8 @@ import org.apache.commons.lang3.StringUtils;
 
 public class LandAbility extends AbilityStatic {
 
-    public LandAbility(Card sourceCard) {
-        super(sourceCard, ManaCost.NO_COST);
+    public LandAbility(Card sourceCard, CardState state) {
+        super(sourceCard, ManaCost.NO_COST, state);
 
         getRestrictions().setZone(ZoneType.Hand);
     }

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
@@ -195,12 +195,18 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
     }
 
     protected SpellAbility(final Card iSourceCard, final Cost toPay) {
-        this(iSourceCard, toPay, null);
+        this(iSourceCard, toPay, null, null);
     }
     protected SpellAbility(final Card iSourceCard, final Cost toPay, SpellAbilityView view0) {
+        this(iSourceCard, toPay, view0, null);
+    }
+    protected SpellAbility(final Card iSourceCard, final Cost toPay, SpellAbilityView view0, CardState cs) {
         id = nextId();
         hostCard = iSourceCard;
         payCosts = toPay;
+        if (cs != null) {
+            cardState = cs;
+        }
         if (view0 == null) {
             view0 = new SpellAbilityView(this);
         }


### PR DESCRIPTION
Safer approach than  #7780

> Game-0 > java.lang.RuntimeException: Error in Card Scrapshooter with Keyword Gift
	at forge.game.card.Card.keywordsToText(Card.java:2807)
	at forge.game.card.Card.getAbilityText(Card.java:2964)
	at forge.game.card.CardView$CardStateView.updateAbilityText(CardView.java:1630)
	at forge.game.card.CardView$CardStateView.updateKeywords(CardView.java:1665)
	at forge.game.card.CardView.updateState(CardView.java:1096)
	at forge.game.card.Card.updateStateForView(Card.java:462)
	at forge.game.GameAction.changeZone(GameAction.java:549)
	at forge.game.GameAction.moveTo(GameAction.java:792)
	at forge.game.GameAction.moveTo(GameAction.java:749)
	at forge.game.GameAction.moveToPlay(GameAction.java:884)
	at forge.game.ability.effects.PermanentEffect.resolve(PermanentEffect.java:31)
	at forge.game.ability.SpellApiBased.resolve(SpellApiBased.java:51)
	at forge.game.ability.AbilityUtils.resolveApiAbility(AbilityUtils.java:1420)
	at forge.game.ability.AbilityUtils.resolve(AbilityUtils.java:1356)
	at forge.game.zone.MagicStack.resolveStack(MagicStack.java:630)
	at forge.game.phase.PhaseHandler.startFirstTurn(PhaseHandler.java:1134)
	at forge.game.GameAction.startGame(GameAction.java:2338)
	at forge.game.Match.startGame(Match.java:90)
	at forge.gamemodes.match.HostedMatch.lambda$startGame$1(HostedMatch.java:259)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:842)
Caused by: java.lang.NullPointerException: Cannot invoke "forge.game.spellability.SpellAbility.hasAdditionalAbility(String)" because the return value of "forge.game.card.CardState.getFirstSpellAbility()" is null
	at forge.game.card.Card.keywordsToText(Card.java:2653)
	... 21 more