### PR TITLE
Adventure:  Made auto-sell buttons semi-transparent unless selected, fixed transparency issues, increased card flip speed

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/scene/RewardScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/RewardScene.java
@@ -252,7 +252,7 @@ public class RewardScene extends UIScene {
                             reward.flip();
                         }
                     }, delay);
-                    delay += 0.15f;
+                    delay += 0.12f;
                 }
             }
         } else {
@@ -428,10 +428,10 @@ public class RewardScene extends UIScene {
                 doneButton.setText("[+OK]");
                 break;
             case Loot:
-                headerLabel.skipToTheEnd();
                 headerLabel.setPosition(restockButton.getX(), restockButton.getY());
                 headerLabel.setVisible(true);
                 headerLabel.setText("[%?SHINY][;]\u2610 " + Forge.getLocalizer().getMessage("lblAll"));
+                headerLabel.skipToTheEnd();
                 restockButton.setVisible(false);
                 doneButton.setText("[+OK]");
                 break;

--- a/forge-gui-mobile/src/forge/adventure/util/Controls.java
+++ b/forge-gui-mobile/src/forge/adventure/util/Controls.java
@@ -48,6 +48,12 @@ public class Controls {
             this.setWidth(this.layout.getWidth() + (this.style != null && this.style.background != null ? this.style.background.getLeftWidth() + this.style.background.getRightWidth() : 0.0F));
             layout();
         }
+
+        @Override
+        public void draw(Batch batch, float parentAlpha) {
+            batch.setColor(1f, 1f, 1f, 1f); // Set color before drawing each actor, per libGDX docs
+            super.draw(batch, parentAlpha);
+        }
     }
 
     static class TextButtonFix extends TextraButton {

--- a/forge-gui-mobile/src/forge/adventure/util/RewardActor.java
+++ b/forge-gui-mobile/src/forge/adventure/util/RewardActor.java
@@ -14,6 +14,7 @@ import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Group;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
+import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.Tooltip;
@@ -222,6 +223,7 @@ public class RewardActor extends Actor implements Disposable, ImageFetcher.Callb
         reward.setAutoSell(!reward.isAutoSell());
         String c = reward.isAutoSell() ? "[%85][GREEN]" : "[%85][GRAY]";
         autoSell.setText(c + "\uFF04");
+        autoSell.getColor().a = reward.isAutoSell() ? 1f : 0.7f;
     }
 
     public RewardActor(Reward reward, boolean flippable, RewardScene.Type type, boolean showOverlay) {
@@ -237,6 +239,17 @@ public class RewardActor extends Actor implements Disposable, ImageFetcher.Callb
             case Card: {
                 if (!reward.isNoSell) {
                     autoSell = Controls.newTextButton("[%85][GRAY]\uFF04");
+                    autoSell.getColor().a = 0.7f; // semi-transparent by default
+                    autoSell.addListener(new InputListener() {
+                        @Override
+                        public void enter(InputEvent event, float x, float y, int pointer, Actor fromActor) {
+                            if (!reward.isAutoSell()) autoSell.getColor().a = 1f;
+                        }
+                        @Override
+                        public void exit(InputEvent event, float x, float y, int pointer, Actor toActor) {
+                            if (!reward.isAutoSell()) autoSell.getColor().a = 0.7f;
+                        }
+                    });
                     float scale = autoSell.getWidth();
                     autoSell.setSize(scale, scale * 1.2f);
                     autoSell.addListener(new ClickListener() {
@@ -848,7 +861,7 @@ public class RewardActor extends Actor implements Disposable, ImageFetcher.Callb
         super.act(delta);
         if (clicked) {
             if (flipProcess < 1)
-                flipProcess += delta * 2.4;
+                flipProcess += delta * 4;
             else
                 flipProcess = 1;
 
@@ -1113,6 +1126,12 @@ public class RewardActor extends Actor implements Disposable, ImageFetcher.Callb
 
         public TextraLabel getStoredLabel() {
             return cLabel;
+        }
+
+        @Override
+        public void draw(Batch batch, float parentAlpha) {
+            batch.setColor(1f, 1f, 1f, 1f); // Set color before drawing each actor, per libGDX docs
+            super.draw(batch, parentAlpha);
         }
     }
 


### PR DESCRIPTION
This PR:
1. Makes the autoSell buttons on card rewards semi-transparent unless auto-sell is enabled or being moused-over.
The intent is basically to both look a little nicer, and make text under it a little readable to see all the rules text without having to hover-over. 
3. Fixes some transparency issues that then became apparent. The transparency set for an Actor being drawn in a batch was not reset before drawing the next Actor in a batch, causing other things to be transparent that shouldn't be. Libgdx documentation says to set the batch color between drawing Actors, so I overrode two draw() methods affecting the rewards screen to do this.
See: https://libgdx.com/wiki/graphics/2d/scene2d/scene2d#drawing
4. Increased the card rewards' flip speed to better match the sound effect (and be a little more snappy).
5. Slightly decreased the time between cards flipping when the button is clicked to flip all of them to make the whole process faster.

![autosell screenshot](https://github.com/user-attachments/assets/b77384df-55f6-4208-ac91-f79c9a4632da)
