### PR TITLE
Update giott_king_of_the_dwarves.txt

### DIFF
--- a/forge-gui/res/cardsfolder/g/giott_king_of_the_dwarves.txt
+++ b/forge-gui/res/cardsfolder/g/giott_king_of_the_dwarves.txt
@@ -3,6 +3,7 @@ ManaCost:R W
 Types:Legendary Creature Dwarf Noble
 PT:1/1
 K:Double Strike
-T:Mode$ ChangesZone | ValidCard$ Card.Self,Dwarf.YouCtrl,Equipment.YouCtrl | Origin$ Any | Destination$ Battlefield | Execute$ TrigDraw | TriggerZones$ Battlefield | TriggerDescription$ Whenever NICKNAME or another Dwarf you control enters and whenever an Equipment you control enters, you may discard a card. If you do, draw a card.
+T:Mode$ ChangesZone | ValidCard$ Card.Self,Dwarf.YouCtrl | Origin$ Any | Destination$ Battlefield | Execute$ TrigDraw | TriggerZones$ Battlefield | TriggerDescription$ Whenever NICKNAME or another Dwarf you control enters and whenever an Equipment you control enters, you may discard a card. If you do, draw a card.
+T:Mode$ ChangesZone | ValidCard$ Equipment.YouCtrl | Origin$ Any | Destination$ Battlefield | Execute$ TrigDraw | TriggerZones$ Battlefield | Secondary$ True | TriggerDescription$ Whenever NICKNAME or another Dwarf you control enters and whenever an Equipment you control enters, you may discard a card. If you do, draw a card.
 SVar:TrigDraw:AB$ Draw | Cost$ Discard<1/Card> | NumCards$ 1
 Oracle:Double strike\nWhenever Giott or another Dwarf you control enters and whenever an Equipment you control enters, you may discard a card. If you do, draw a card.

--- a/forge-gui/res/cardsfolder/g/giott_king_of_the_dwarves.txt
+++ b/forge-gui/res/cardsfolder/g/giott_king_of_the_dwarves.txt
@@ -3,7 +3,7 @@ ManaCost:R W
 Types:Legendary Creature Dwarf Noble
 PT:1/1
 K:Double Strike
-T:Mode$ ChangesZone | ValidCard$ Card.Self,Dwarf.YouCtrl | Origin$ Any | Destination$ Battlefield | Execute$ TrigDraw | TriggerZones$ Battlefield | TriggerDescription$ Whenever NICKNAME or another Dwarf you control enters and whenever an Equipment you control enters, you may discard a card. If you do, draw a card.
+T:Mode$ ChangesZone | ValidCard$ Card.Self,Dwarf.Other+YouCtrl | Origin$ Any | Destination$ Battlefield | Execute$ TrigDraw | TriggerZones$ Battlefield | TriggerDescription$ Whenever NICKNAME or another Dwarf you control enters and whenever an Equipment you control enters, you may discard a card. If you do, draw a card.
 T:Mode$ ChangesZone | ValidCard$ Equipment.YouCtrl | Origin$ Any | Destination$ Battlefield | Execute$ TrigDraw | TriggerZones$ Battlefield | Secondary$ True | TriggerDescription$ Whenever NICKNAME or another Dwarf you control enters and whenever an Equipment you control enters, you may discard a card. If you do, draw a card.
 SVar:TrigDraw:AB$ Draw | Cost$ Discard<1/Card> | NumCards$ 1
 Oracle:Double strike\nWhenever Giott or another Dwarf you control enters and whenever an Equipment you control enters, you may discard a card. If you do, draw a card.


### PR DESCRIPTION
The way this card is worded, if something that is both Dwarf and Equipment enters (perhaps with Conspiracy + creature with Reconfigure), Giott should trigger twice.