### PR TITLE
Cleanup: draft rankings

### DIFF
--- a/forge-gui/res/draft/rankings/10e.rnk
+++ b/forge-gui/res/draft/rankings/10e.rnk
@@ -18,7 +18,7 @@
 #17|Ascendant Evincar|R|10E
 #18|Royal Assassin|R|10E
 #19|Cone of Flame|U|10E
-#20|Siege Gang Commander|R|10E
+#20|Siege-Gang Commander|R|10E
 #21|Verdant Force|R|10E
 #22|Icy Manipulator|U|10E
 #23|Arcanis the Omnipotent|R|10E
@@ -40,13 +40,13 @@
 #39|Dragon Roost|R|10E
 #40|Grave Pact|R|10E
 #41|Seedborn Muse|R|10E
-#42|Cho Manno, Revolutionary|R|10E
+#42|Cho-Manno, Revolutionary|R|10E
 #43|Reya Dawnbringer|R|10E
 #44|Clone|R|10E
 #45|Nightmare|R|10E
-#46|Paladin en Vec|R|10E
+#46|Paladin en-Vec|R|10E
 #47|Chimeric Staff|R|10E
-#48|Molimo, Maro Sorcerer|R|10E
+#48|Molimo, Maro-Sorcerer|R|10E
 #49|Tidings|U|10E
 #50|Orcish Artillery|U|10E
 #51|Might of Oaks|R|10E

--- a/forge-gui/res/draft/rankings/2ed.rnk
+++ b/forge-gui/res/draft/rankings/2ed.rnk
@@ -98,7 +98,7 @@
 #97|Volcanic Eruption|R|2ED
 #98|Hurricane|U|2ED
 #99|Lich|R|2ED
-#100|Will o' the Wisp|R|2ED
+#100|Will-o'-the-Wisp|R|2ED
 #101|Uthden Troll|U|2ED
 #102|Pestilence|C|2ED
 #103|White Knight|U|2ED

--- a/forge-gui/res/draft/rankings/30a.rnk
+++ b/forge-gui/res/draft/rankings/30a.rnk
@@ -49,7 +49,7 @@
 #48|Phantom Monster|U|30A
 #49|Red Elemental Blast|C|30A
 #50|Roc of Kher Ridges|R|30A
-#51|Circle of Protection Red|C|30A
+#51|Circle of Protection: Red|C|30A
 #52|Savannah Lions|R|30A
 #53|Clone|U|30A
 #54|Royal Assassin|R|30A
@@ -88,9 +88,9 @@
 #87|Tundra|R|30A
 #88|Underground Sea|R|30A
 #89|Volcanic Island|R|30A
-#90|Circle of Protection Black|C|30A
-#91|Circle of Protection Green|C|30A
-#92|Circle of Protection White|C|30A
+#90|Circle of Protection: Black|C|30A
+#91|Circle of Protection: Green|C|30A
+#92|Circle of Protection: White|C|30A
 #93|Pirate Ship|R|30A
 #94|Power Sink|C|30A
 #95|Sinkhole|C|30A
@@ -109,7 +109,7 @@
 #108|Elvish Archers|R|30A
 #109|Hurricane|U|30A
 #110|Armageddon|R|30A
-#111|Circle of Protection Blue|C|30A
+#111|Circle of Protection: Blue|C|30A
 #112|Disenchant|C|30A
 #113|Red Ward|U|30A
 #114|Resurrection|U|30A

--- a/forge-gui/res/draft/rankings/3ed.rnk
+++ b/forge-gui/res/draft/rankings/3ed.rnk
@@ -64,7 +64,7 @@
 #63|Earth Elemental|U|3ED
 #64|Hurricane|U|3ED
 #65|Dragon Whelp|U|3ED
-#66|Will o' the Wisp|R|3ED
+#66|Will-o'-the-Wisp|R|3ED
 #67|Llanowar Elves|C|3ED
 #68|Primal Clay|R|3ED
 #69|Demonic Tutor|U|3ED
@@ -200,7 +200,7 @@
 #199|Spell Blast|C|3ED
 #200|Dingus Egg|R|3ED
 #201|Crumble|U|3ED
-#202|El-Hajjaj|R|3ED
+#202|El-Hajjâj|R|3ED
 #203|Savannah|R|3ED
 #204|Red Elemental Blast|C|3ED
 #205|Orcish Oriflamme|U|3ED

--- a/forge-gui/res/draft/rankings/4ed.rnk
+++ b/forge-gui/res/draft/rankings/4ed.rnk
@@ -99,7 +99,7 @@
 #98|Zombie Master|R|4ED
 #99|Paralyze|C|4ED
 #100|Savannah Lions|R|4ED
-#101|Will o' the Wisp|R|4ED
+#101|Will-o'-the-Wisp|R|4ED
 #102|Channel|U|4ED
 #103|Fellwar Stone|U|4ED
 #104|Clay Statue|C|4ED
@@ -133,7 +133,7 @@
 #132|Ironroot Treefolk|C|4ED
 #133|The Rack|U|4ED
 #134|Nevinyrral's Disk|R|4ED
-#135|Junun Efreet|U|4ED
+#135|Junún Efreet|U|4ED
 #136|Spirit Shackle|U|4ED
 #137|Living Artifact|R|4ED
 #138|Mana Vault|R|4ED
@@ -314,7 +314,7 @@
 #313|Sleight of Mind|R|4ED
 #314|Circle of Protection: Blue|C|4ED
 #315|Warp Artifact|R|4ED
-#316|El-Hajjaj|R|4ED
+#316|El-Hajjâj|R|4ED
 #317|Gloom|U|4ED
 #318|Wall of Wood|C|4ED
 #319|Psychic Venom|C|4ED

--- a/forge-gui/res/draft/rankings/5dn.rnk
+++ b/forge-gui/res/draft/rankings/5dn.rnk
@@ -12,7 +12,7 @@
 #11|Tornado Elemental|R|5DN
 #12|Magma Jet|U|5DN
 #13|Helm of Kaldra|R|5DN
-#14|Tel Jilad Justice|U|5DN
+#14|Tel-Jilad Justice|U|5DN
 #15|Beacon of Creation|R|5DN
 #16|Summoning Station|R|5DN
 #17|Engineered Explosives|R|5DN
@@ -92,7 +92,7 @@
 #91|Tyrranax|C|5DN
 #92|Grinding Station|U|5DN
 #93|Composite Golem|U|5DN
-#94|Iron Barb Hellion|U|5DN
+#94|Iron-Barb Hellion|U|5DN
 #95|Horned Helm|C|5DN
 #96|Baton of Courage|C|5DN
 #97|Rain of Rust|C|5DN
@@ -116,9 +116,9 @@
 #115|Sawtooth Thresher|C|5DN
 #116|Beacon of Tomorrows|R|5DN
 #117|Steelshaper's Gift|U|5DN
-#118|Krark Clan Engineers|U|5DN
+#118|Krark-Clan Engineers|U|5DN
 #119|Shattered Dreams|U|5DN
-#120|Krark Clan Ogre|C|5DN
+#120|Krark-Clan Ogre|C|5DN
 #121|Dross Crocodile|C|5DN
 #122|Avarice Totem|U|5DN
 #123|Chimeric Coils|U|5DN
@@ -127,14 +127,14 @@
 #126|Nim Grotesque|U|5DN
 #127|Fold into Aether|U|5DN
 #128|Plunge into Darkness|R|5DN
-#129|Tel Jilad Lifebreather|C|5DN
+#129|Tel-Jilad Lifebreather|C|5DN
 #130|All Suns' Dawn|R|5DN
 #131|Sparring Collar|C|5DN
 #132|Neurok Stealthsuit|C|5DN
 #133|Roar of Reclamation|R|5DN
 #134|Channel the Suns|U|5DN
 #135|Door to Nothingness|R|5DN
-#136|Krark Clan Ironworks|U|5DN
+#136|Krark-Clan Ironworks|U|5DN
 #137|Skullcage|U|5DN
 #138|Crucible of Worlds|R|5DN
 #139|Artificer's Intuition|R|5DN

--- a/forge-gui/res/draft/rankings/5ed.rnk
+++ b/forge-gui/res/draft/rankings/5ed.rnk
@@ -67,7 +67,7 @@
 #66|Castle|U|5ED
 #67|Remove Soul|C|5ED
 #68|Colossus of Sardia|R|5ED
-#69|Evil Eye of Orms by Gore|U|5ED
+#69|Evil Eye of Orms-by-Gore|U|5ED
 #70|Serra Paladin|U|5ED
 #71|Mana Vault|R|5ED
 #72|Lord of the Pit|R|5ED
@@ -263,7 +263,7 @@
 #262|Nature's Lore|C|5ED
 #263|Disenchant|C|5ED
 #264|Goblin Hero|C|5ED
-#265|Ghazban Ogre|C|5ED
+#265|Ghazbán Ogre|C|5ED
 #266|Initiates of the Ebon Hand|C|5ED
 #267|Pikemen|C|5ED
 #268|Mind Warp|U|5ED
@@ -322,7 +322,7 @@
 #321|Howling Mine|R|5ED
 #322|Lure|U|5ED
 #323|Soul Net|U|5ED
-#324|Dandan|C|5ED
+#324|Dandân|C|5ED
 #325|Flight|C|5ED
 #326|Stream of Life|C|5ED
 #327|Ankh of Mishra|R|5ED

--- a/forge-gui/res/draft/rankings/6ed.rnk
+++ b/forge-gui/res/draft/rankings/6ed.rnk
@@ -112,7 +112,7 @@
 #111|Strands of Night|U|6ED
 #112|Dwarven Ruins|U|6ED
 #113|Reprisal|U|6ED
-#114|Evil Eye of Orms by Gore|U|6ED
+#114|Evil Eye of Orms-by-Gore|U|6ED
 #115|Thicket Basilisk|U|6ED
 #116|Wall of Air|U|6ED
 #117|Jayemdae Tome|R|6ED

--- a/forge-gui/res/draft/rankings/9ed.rnk
+++ b/forge-gui/res/draft/rankings/9ed.rnk
@@ -17,7 +17,7 @@
 #16|Might of Oaks|R|9ED
 #17|Blaze|U|9ED
 #18|Shard Phoenix|R|9ED
-#19|Paladin en Vec|R|9ED
+#19|Paladin en-Vec|R|9ED
 #20|Force of Nature|R|9ED
 #21|Nekrataal|U|9ED
 #22|Thundermare|R|9ED
@@ -84,7 +84,7 @@
 #83|Threaten|U|9ED
 #84|Master Decoy|C|9ED
 #85|Gluttonous Zombie|U|9ED
-#86|Will o' the Wisp|R|9ED
+#86|Will-o'-the-Wisp|R|9ED
 #87|Thought Courier|U|9ED
 #88|Phantom Warrior|U|9ED
 #89|Leonin Skyhunter|U|9ED
@@ -225,7 +225,7 @@
 #224|Creeping Mold|U|9ED
 #225|Venerable Monk|C|9ED
 #226|Cowardice|R|9ED
-#227|Ur Golem's Eye|U|9ED
+#227|Ur-Golem's Eye|U|9ED
 #228|Suntail Hawk|C|9ED
 #229|Annex|U|9ED
 #230|Gift of Estates|U|9ED

--- a/forge-gui/res/draft/rankings/a25.rnk
+++ b/forge-gui/res/draft/rankings/a25.rnk
@@ -162,7 +162,7 @@
 #161|Balduvian Horde|C|A25
 #162|Mogg Flunkies|C|A25
 #163|Skirk Commando|C|A25
-#164|Uncaged fury|C|A25
+#164|Uncaged Fury|C|A25
 #165|Ancient Stirrings|U|A25
 #166|Giant Growth|C|A25
 #167|Sai of the Shinobi|U|A25

--- a/forge-gui/res/draft/rankings/ala.rnk
+++ b/forge-gui/res/draft/rankings/ala.rnk
@@ -10,7 +10,7 @@
 #9|Sharding Sphinx|R|ALA
 #10|Stoic Angel|R|ALA
 #11|Feral Hydra|R|ALA
-#12|Elspeth, Knight Errant|M|ALA
+#12|Elspeth, Knight-Errant|M|ALA
 #13|Sarkhan Vol|M|ALA
 #14|Cruel Ultimatum|R|ALA
 #15|Ajani Vengeant|M|ALA
@@ -38,7 +38,7 @@
 #37|Resounding Thunder|C|ALA
 #38|Ranger of Eos|R|ALA
 #39|Kresh the Bloodbraided|M|ALA
-#40|Knight Captain of Eos|R|ALA
+#40|Knight-Captain of Eos|R|ALA
 #41|Sprouting Thrinax|U|ALA
 #42|Titanic Ultimatum|R|ALA
 #43|Godsire|M|ALA
@@ -83,7 +83,7 @@
 #82|Tidehollow Sculler|U|ALA
 #83|Prince of Thralls|M|ALA
 #84|Resounding Silence|C|ALA
-#85|Fire Field Ogre|U|ALA
+#85|Fire-Field Ogre|U|ALA
 #86|Bloodpyre Elemental|C|ALA
 #87|Soul's Fire|C|ALA
 #88|Knight of the Skyward Eye|C|ALA
@@ -120,8 +120,8 @@
 #119|Jund Panorama|C|ALA
 #120|Blister Beetle|C|ALA
 #121|Cloudheath Drake|C|ALA
-#122|Rip Clan Crasher|C|ALA
-#123|Thunder Thrash Elder|U|ALA
+#122|Rip-Clan Crasher|C|ALA
+#123|Thunder-Thrash Elder|U|ALA
 #124|Goblin Deathraiders|C|ALA
 #125|Carrion Thrash|C|ALA
 #126|Jhessian Infiltrator|U|ALA
@@ -141,7 +141,7 @@
 #140|Punish Ignorance|R|ALA
 #141|Excommunicate|C|ALA
 #142|Gift of the Gargantuan|C|ALA
-#143|Sighted Caste Sorcerer|C|ALA
+#143|Sighted-Caste Sorcerer|C|ALA
 #144|Welkin Guide|C|ALA
 #145|Ridge Rannet|C|ALA
 #146|Cylian Elf|C|ALA
@@ -155,7 +155,7 @@
 #154|Angelic Benediction|U|ALA
 #155|Rockcaster Platoon|U|ALA
 #156|Obelisk of Grixis|C|ALA
-#157|Thorn Thrash Viashino|C|ALA
+#157|Thorn-Thrash Viashino|C|ALA
 #158|Naturalize|C|ALA
 #159|Obelisk of Esper|C|ALA
 #160|Etherium Sculptor|C|ALA

--- a/forge-gui/res/draft/rankings/all.rnk
+++ b/forge-gui/res/draft/rankings/all.rnk
@@ -19,7 +19,7 @@
 #18|Misfortune|R|ALL
 #19|Contagion|U|ALL
 #20|Ritual of the Machine|R|ALL
-#21|Lim-Dul's Paladin|U|ALL
+#21|Lim-Dûl's Paladin|U|ALL
 #22|Ivory Gargoyle|R|ALL
 #23|Phyrexian War Beast|C|ALL
 #24|Yavimaya Ancients|C|ALL
@@ -60,7 +60,7 @@
 #59|Deadly Insect|U|ALL
 #60|Surge of Strength|U|ALL
 #61|Soldevi Digger|R|ALL
-#62|Lim-Dul's High Guard|C|ALL
+#62|Lim-Dûl's High Guard|C|ALL
 #63|Splintering Wind|R|ALL
 #64|Diminishing Returns|R|ALL
 #65|Varchild's War-Riders|R|ALL
@@ -86,7 +86,7 @@
 #85|Pillage|U|ALL
 #86|Whip Vine|C|ALL
 #87|Bestial Fury|C|ALL
-#88|Lim-Dul's Vault|U|ALL
+#88|Lim-Dûl's Vault|U|ALL
 #89|Fevered Strength|C|ALL
 #90|Soldier of Fortune|U|ALL
 #91|Mishra's Groundbreaker|U|ALL

--- a/forge-gui/res/draft/rankings/arb.rnk
+++ b/forge-gui/res/draft/rankings/arb.rnk
@@ -51,7 +51,7 @@
 #50|Bant Sureblade|C|ARB
 #51|Necromancer's Covenant|R|ARB
 #52|Rhox Brute|C|ARB
-#53|Sewn Eye Drake|C|ARB
+#53|Sewn-Eye Drake|C|ARB
 #54|Grixis Grimblade|C|ARB
 #55|Jund Hackblade|C|ARB
 #56|Naya Hushblade|C|ARB
@@ -91,7 +91,7 @@
 #90|Arsenal Thresher|C|ARB
 #91|Predatory Advantage|R|ARB
 #92|Jhessian Zombies|C|ARB
-#93|Singe Mind Ogre|C|ARB
+#93|Singe-Mind Ogre|C|ARB
 #94|Naya Sojourners|C|ARB
 #95|Captured Sunlight|C|ARB
 #96|Sigiled Behemoth|C|ARB

--- a/forge-gui/res/draft/rankings/arn.rnk
+++ b/forge-gui/res/draft/rankings/arn.rnk
@@ -1,15 +1,15 @@
 //Rank|Name|Rarity|Set
-#1|Juzam Djinn|U|ARN
+#1|Juzám Djinn|U|ARN
 #2|Library of Alexandria|U|ARN
 #3|Ali from Cairo|U|ARN
 #4|Serendib Efreet|U|ARN
 #5|Oubliette|C|ARN
-#6|Ifh-Biff Efreet|U|ARN
+#6|Ifh-Bíff Efreet|U|ARN
 #7|Sorceress Queen|U|ARN
 #8|Serendib Djinn|U|ARN
 #9|Erhnam Djinn|U|ARN
 #10|Aladdin's Ring|U|ARN
-#11|Khabal Ghoul|U|ARN
+#11|Khabál Ghoul|U|ARN
 #12|Old Man of the Sea|U|ARN
 #13|Kird Ape|C|ARN
 #14|Erg Raiders|C|ARN
@@ -26,12 +26,12 @@
 #25|City of Brass|U|ARN
 #26|Desert|C|ARN
 #27|Flying Men|C|ARN
-#28|Junun Efreet|U|ARN
+#28|Junún Efreet|U|ARN
 #29|Jihad|U|ARN
 #30|Unstable Mutation|C|ARN
 #31|Moorish Cavalry|C|ARN
 #32|Drop of Honey|U|ARN
-#33|Ring of Ma'ruf|U|ARN
+#33|Ring of Ma'rûf|U|ARN
 #34|Brass Man|U|ARN
 #35|Aladdin|U|ARN
 #36|Island Fish Jasconius|U|ARN
@@ -41,7 +41,7 @@
 #40|Oasis|U|ARN
 #41|Bottle of Suleiman|U|ARN
 #42|Guardian Beast|U|ARN
-#43|El-Hajjaj|U|ARN
+#43|El-Hajjâj|U|ARN
 #44|Hasran Ogress|C|ARN
 #45|Shahrazad|U|ARN
 #46|Cyclone|U|ARN
@@ -52,7 +52,7 @@
 #51|Stone-Throwing Devils|C|ARN
 #52|Desert Nomads|C|ARN
 #53|Bird Maiden|C|ARN
-#54|Ghazban Ogre|C|ARN
+#54|Ghazbán Ogre|C|ARN
 #55|Wyluli Wolf|C|ARN
 #56|Elephant Graveyard|U|ARN
 #57|Giant Tortoise|C|ARN
@@ -71,7 +71,7 @@
 #70|Merchant Ship|U|ARN
 #71|Magnetic Mountain|U|ARN
 #72|Hurr Jackal|C|ARN
-#73|Dandan|C|ARN
+#73|Dandân|C|ARN
 #74|Camel|C|ARN
 #75|Metamorphosis|C|ARN
 #76|Fishliver Oil|C|ARN

--- a/forge-gui/res/draft/rankings/avr.rnk
+++ b/forge-gui/res/draft/rankings/avr.rnk
@@ -1,15 +1,15 @@
 //Rank|Name|Rarity|Set
-#1|Tamiyo the Moon Sage|M|AVR
+#1|Tamiyo, the Moon Sage|M|AVR
 #2|Bonfire of the Damned|M|AVR
 #3|Entreat the Angels|M|AVR
-#4|Sigarda Host of Herons|M|AVR
-#5|Gisela Blade of Goldnight|M|AVR
-#6|Avacyn Angel of Hope|M|AVR
-#7|Bruna Light of Alabaster|M|AVR
+#4|Sigarda, Host of Herons|M|AVR
+#5|Gisela, Blade of Goldnight|M|AVR
+#6|Avacyn, Angel of Hope|M|AVR
+#7|Bruna, Light of Alabaster|M|AVR
 #8|Griselbrand|M|AVR
 #9|Craterhoof Behemoth|M|AVR
 #10|Temporal Mastery|M|AVR
-#11|Tibalt the Fiend Blooded|M|AVR
+#11|Tibalt, the Fiend-Blooded|M|AVR
 #12|Misthollow Griffin|M|AVR
 #13|Malignus|M|AVR
 #14|Wolfir Silverheart|R|AVR
@@ -30,11 +30,11 @@
 #29|Deadeye Navigator|R|AVR
 #30|Riders of Gavony|R|AVR
 #31|Dark Impostor|R|AVR
-#32|Angel of Glorys Rise|R|AVR
-#33|Cathars Crusade|R|AVR
+#32|Angel of Glory's Rise|R|AVR
+#33|Cathars' Crusade|R|AVR
 #34|Demonlord of Ashmouth|R|AVR
 #35|Archwing Dragon|R|AVR
-#36|Druids Familiar|U|AVR
+#36|Druid's Familiar|U|AVR
 #37|Spirit Away|R|AVR
 #38|Wolfir Avenger|U|AVR
 #39|Lone Revenant|R|AVR
@@ -75,7 +75,7 @@
 #74|Demonic Taskmaster|U|AVR
 #75|Gloomwidow|U|AVR
 #76|Trusted Forcemage|C|AVR
-#77|Slayers Stronghold|R|AVR
+#77|Slayers' Stronghold|R|AVR
 #78|Nephalia Smuggler|U|AVR
 #79|Archangel|U|AVR
 #80|Pillar of Flame|C|AVR
@@ -90,7 +90,7 @@
 #89|Gloom Surgeon|R|AVR
 #90|Angelic Armaments|U|AVR
 #91|Wild Defiance|R|AVR
-#92|Angels Tomb|U|AVR
+#92|Angel's Tomb|U|AVR
 #93|Maalfeld Twins|U|AVR
 #94|Stern Mentor|U|AVR
 #95|Holy Justiciar|U|AVR
@@ -102,7 +102,7 @@
 #101|Righteous Blow|C|AVR
 #102|Nightshade Peddler|C|AVR
 #103|Riot Ringleader|C|AVR
-#104|Conjurers Closet|R|AVR
+#104|Conjurer's Closet|R|AVR
 #105|Yew Spirit|U|AVR
 #106|Scrapskin Drake|C|AVR
 #107|Marrow Bats|U|AVR
@@ -116,18 +116,18 @@
 #115|Gallows at Willow Hill|R|AVR
 #116|Desolate Lighthouse|R|AVR
 #117|Bone Splinters|C|AVR
-#118|Alchemists Refuge|R|AVR
+#118|Alchemist's Refuge|R|AVR
 #119|Vessel of Endless Rest|U|AVR
 #120|Gang of Devils|U|AVR
 #121|Heirs of Stromkirk|C|AVR
 #122|Elgaud Shieldmate|C|AVR
-#123|Tormentors Trident|U|AVR
+#123|Tormentor's Trident|U|AVR
 #124|Peel from Reality|C|AVR
-#125|Treacherous Pit Dweller|R|AVR
+#125|Treacherous Pit-Dweller|R|AVR
 #126|Butcher Ghoul|C|AVR
 #127|Undead Executioner|C|AVR
 #128|Nettle Swine|C|AVR
-#129|Descendants Path|R|AVR
+#129|Descendants' Path|R|AVR
 #130|Moonlight Geist|C|AVR
 #131|Joint Assault|C|AVR
 #132|Amass the Components|C|AVR
@@ -137,13 +137,13 @@
 #136|Abundant Growth|C|AVR
 #137|Lunar Mystic|R|AVR
 #138|Crippling Chill|C|AVR
-#139|Druids Repository|R|AVR
+#139|Druids' Repository|R|AVR
 #140|Corpse Traders|U|AVR
 #141|Primal Surge|M|AVR
 #142|Pathbreaker Wurm|C|AVR
 #143|Geist Trappers|C|AVR
 #144|Defang|C|AVR
-#145|Alchemists Apprentice|C|AVR
+#145|Alchemist's Apprentice|C|AVR
 #146|Devout Chaplain|U|AVR
 #147|Searchlight Geist|C|AVR
 #148|Farbog Explorer|C|AVR
@@ -189,7 +189,7 @@
 #188|Narstad Scrapper|C|AVR
 #189|Natural End|C|AVR
 #190|Essence Harvest|C|AVR
-#191|Predators Gambit|C|AVR
+#191|Predator's Gambit|C|AVR
 #192|Mental Agony|C|AVR
 #193|Lair Delve|C|AVR
 #194|Uncanny Speed|C|AVR
@@ -203,12 +203,12 @@
 #202|Cursebreak|C|AVR
 #203|Leap of Faith|C|AVR
 #204|Hunted Ghoul|C|AVR
-#205|Commanders Authority|U|AVR
+#205|Commander's Authority|U|AVR
 #206|Appetite for Brains|U|AVR
 #207|Raging Poltergeist|C|AVR
 #208|Dreadwaters|C|AVR
 #209|Demolish|C|AVR
-#210|Vanguards Shield|C|AVR
+#210|Vanguard's Shield|C|AVR
 #211|Banners Raised|C|AVR
 #212|Descent into Madness|M|AVR
 #213|Seraph Sanctuary|C|AVR
@@ -216,14 +216,14 @@
 #215|Scroll of Griselbrand|C|AVR
 #216|Ghostly Touch|U|AVR
 #217|Outwit|C|AVR
-#218|Angels Mercy|C|AVR
+#218|Angel's Mercy|C|AVR
 #219|Grounded|C|AVR
 #220|Battle Hymn|C|AVR
 #221|Malicious Intent|C|AVR
 #222|Triumph of Cruelty|U|AVR
 #223|Rain of Thorns|U|AVR
 #224|Otherworld Atlas|R|AVR
-#225|Builders Blessing|U|AVR
+#225|Builder's Blessing|U|AVR
 #226|Bower Passage|U|AVR
 #227|Rite of Ruin|R|AVR
 #228|Second Guess|U|AVR

--- a/forge-gui/res/draft/rankings/bng.rnk
+++ b/forge-gui/res/draft/rankings/bng.rnk
@@ -1,12 +1,12 @@
 //Rank|Name|Rarity|Set
-#1|Brimaz King of Oreskos|M|BNG
-#2|Kiora the Crashing Wave|M|BNG
-#3|Xenagos God of Revels|M|BNG
-#4|Phenax God of Deception|M|BNG
-#5|Mogis God of Slaughter|M|BNG
-#6|Flame Wreathed Phoenix|M|BNG
-#7|Ephara God of the Polis|M|BNG
-#8|Karametra God of Harvests|M|BNG
+#1|Brimaz, King of Oreskos|M|BNG
+#2|Kiora, the Crashing Wave|M|BNG
+#3|Xenagos, God of Revels|M|BNG
+#4|Phenax, God of Deception|M|BNG
+#5|Mogis, God of Slaughter|M|BNG
+#6|Flame-Wreathed Phoenix|M|BNG
+#7|Ephara, God of the Polis|M|BNG
+#8|Karametra, God of Harvests|M|BNG
 #9|Chromanticore|M|BNG
 #10|Champion of Stray Souls|M|BNG
 #11|Eidolon of Countless Battles|R|BNG
@@ -20,7 +20,7 @@
 #19|Felhide Spiritbinder|R|BNG
 #20|Fate Unraveler|R|BNG
 #21|Fated Intervention|R|BNG
-#22|Hunters Prowess|R|BNG
+#22|Hunter's Prowess|R|BNG
 #23|Tromokratis|R|BNG
 #24|Hero of Leina Tower|R|BNG
 #25|Scourge of Skola Vale|R|BNG
@@ -51,18 +51,18 @@
 #50|Temple of Enlightenment|R|BNG
 #51|Archetype of Aggression|U|BNG
 #52|Fated Infatuation|R|BNG
-#53|Epharas Enlightenment|U|BNG
+#53|Ephara's Enlightenment|U|BNG
 #54|Everflame Eidolon|U|BNG
-#55|Satyr Nyx Smith|U|BNG
+#55|Satyr Nyx-Smith|U|BNG
 #56|Satyr Firedancer|R|BNG
-#57|Kioras Follower|U|BNG
+#57|Kiora's Follower|U|BNG
 #58|Glimpse the Sun God|U|BNG
 #59|Perplexing Chimera|R|BNG
 #60|Siren of the Silent Song|U|BNG
 #61|Thunder Brute|U|BNG
 #62|Fated Return|R|BNG
 #63|Flitterstep Eidolon|U|BNG
-#64|Pheres Band Raiders|U|BNG
+#64|Pheres-Band Raiders|U|BNG
 #65|Bolt of Keranos|C|BNG
 #66|Temple of Plenty|R|BNG
 #67|Temple of Malice|R|BNG
@@ -72,25 +72,25 @@
 #71|Nessian Demolok|U|BNG
 #72|Forlorn Pseudamma|U|BNG
 #73|Graverobber Spider|U|BNG
-#74|Oracles Insight|U|BNG
-#75|God Favored General|U|BNG
+#74|Oracle's Insight|U|BNG
+#75|God-Favored General|U|BNG
 #76|Noble Quarry|U|BNG
 #77|Asphyxiate|C|BNG
 #78|Vortex Elemental|U|BNG
 #79|Archetype of Finality|U|BNG
-#80|Acolytes Reward|U|BNG
+#80|Acolyte's Reward|U|BNG
 #81|Ragemonger|U|BNG
 #82|Retraction Helix|C|BNG
 #83|Nyxborn Triton|C|BNG
 #84|Nyxborn Wolf|C|BNG
-#85|Pheres Band Tromper|C|BNG
+#85|Pheres-Band Tromper|C|BNG
 #86|Mischief and Mayhem|U|BNG
 #87|Swordwise Centaur|C|BNG
 #88|Nyxborn Shieldmate|C|BNG
 #89|Chorus of the Tides|C|BNG
 #90|Setessan Oathsworn|C|BNG
 #91|Kragma Butcher|C|BNG
-#92|Ashioks Adept|U|BNG
+#92|Ashiok's Adept|U|BNG
 #93|Springleaf Drum|U|BNG
 #94|Oreskos Sun Guide|C|BNG
 #95|Sudden Storm|C|BNG
@@ -106,10 +106,10 @@
 #105|Snake of the Golden Grove|C|BNG
 #106|Nyxborn Rollicker|C|BNG
 #107|Black Oak of Odunos|U|BNG
-#108|Mortals Resolve|C|BNG
+#108|Mortal's Resolve|C|BNG
 #109|Nyxborn Eidolon|C|BNG
 #110|Pharagax Giant|C|BNG
-#111|Gorgons Head|U|BNG
+#111|Gorgon's Head|U|BNG
 #112|Stratus Walk|C|BNG
 #113|Peregrination|U|BNG
 #114|Archetype of Endurance|U|BNG
@@ -117,9 +117,9 @@
 #116|Weight of the Underworld|C|BNG
 #117|Fearsome Temper|C|BNG
 #118|Kraken of the Straits|U|BNG
-#119|Mortals Ardor|C|BNG
+#119|Mortal's Ardor|C|BNG
 #120|Nullify|C|BNG
-#121|Sphinxs Disciple|C|BNG
+#121|Sphinx's Disciple|C|BNG
 #122|Revoke Existence|C|BNG
 #123|Eternity Snare|U|BNG
 #124|Crypsis|C|BNG
@@ -127,14 +127,14 @@
 #126|Thunderous Might|U|BNG
 #127|Dawn to Dusk|U|BNG
 #128|Aspect of Hydra|C|BNG
-#129|Karametras Favor|C|BNG
+#129|Karametra's Favor|C|BNG
 #130|Unravel the Aether|U|BNG
 #131|Pillar of War|U|BNG
 #132|Astral Cornucopia|R|BNG
 #133|Impetuous Sunchaser|C|BNG
 #134|Siren Song Lyre|U|BNG
 #135|Necrobite|C|BNG
-#136|Cyclops of One Eyed Pass|C|BNG
+#136|Cyclops of One-Eyed Pass|C|BNG
 #137|Floodtide Serpent|C|BNG
 #138|Reckless Reveler|C|BNG
 #139|Mindreaver|R|BNG
@@ -147,7 +147,7 @@
 #146|Grisly Transformation|C|BNG
 #147|Lightning Volley|U|BNG
 #148|Eye Gouge|C|BNG
-#149|Thassas Rebuff|U|BNG
+#149|Thassa's Rebuff|U|BNG
 #150|Scouring Sands|C|BNG
 #151|Hold at Bay|C|BNG
 #152|Great Hart|C|BNG
@@ -156,11 +156,11 @@
 #155|Forsaken Drifters|C|BNG
 #156|Sunbond|U|BNG
 #157|Skyreaping|U|BNG
-#158|Epharas Radiance|C|BNG
+#158|Ephara's Radiance|C|BNG
 #159|Evanescent Intellect|C|BNG
 #160|Epiphany Storm|C|BNG
 #161|Culling Mark|C|BNG
 #162|Sanguimancy|U|BNG
 #163|Plea for Guidance|R|BNG
 #164|Whims of the Fates|R|BNG
-#165|Heroes Podium|R|BNG
+#165|Heroes' Podium|R|BNG

--- a/forge-gui/res/draft/rankings/bok.rnk
+++ b/forge-gui/res/draft/rankings/bok.rnk
@@ -1,6 +1,6 @@
 //Rank|Name|Rarity|Set
 #1|Umezawa's Jitte|R|BOK
-#2|Ink Eyes, Servant of Oni|R|BOK
+#2|Ink-Eyes, Servant of Oni|R|BOK
 #3|Final Judgment|R|BOK
 #4|Patron of the Kitsune|R|BOK
 #5|Iwamori of the Open Fist|R|BOK
@@ -13,7 +13,7 @@
 #12|Higure, the Still Wind|R|BOK
 #13|Sickening Shoal|R|BOK
 #14|Jetting Glasskite|U|BOK
-#15|Kira, Great Glass Spinner|R|BOK
+#15|Kira, Great Glass-Spinner|R|BOK
 #16|Torrent of Stone|C|BOK
 #17|Eradicate|U|BOK
 #18|Isao, Enlightened Bushi|R|BOK
@@ -28,13 +28,13 @@
 #27|Hired Muscle|U|BOK
 #28|Ogre Marauder|U|BOK
 #29|Toshiro Umezawa|R|BOK
-#30|Opal Eye, Konda's Yojimbo|R|BOK
+#30|Opal-Eye, Konda's Yojimbo|R|BOK
 #31|Genju of the Fields|U|BOK
 #32|Genju of the Cedars|U|BOK
 #33|Budoka Pupil|U|BOK
-#34|Forked Branch Garami|U|BOK
+#34|Forked-Branch Garami|U|BOK
 #35|Unchecked Growth|U|BOK
-#36|Okiba Gang Shinobi|C|BOK
+#36|Okiba-Gang Shinobi|C|BOK
 #37|Faithful Squire|U|BOK
 #38|Ronin Warclub|U|BOK
 #39|Genju of the Falls|U|BOK
@@ -43,11 +43,11 @@
 #42|Shimmering Glasskite|C|BOK
 #43|Patron of the Orochi|R|BOK
 #44|Scourge of Numai|U|BOK
-#45|Neko Te|R|BOK
+#45|Neko-Te|R|BOK
 #46|Takenuma Bleeder|C|BOK
 #47|Gnarled Mass|C|BOK
 #48|Terashi's Verdict|U|BOK
-#49|Ishi Ishi, Akki Crackshot|R|BOK
+#49|Ishi-Ishi, Akki Crackshot|R|BOK
 #50|Callow Jushi|U|BOK
 #51|Hokori, Dust Drinker|R|BOK
 #52|Ogre Recluse|U|BOK
@@ -57,7 +57,7 @@
 #56|Kentaro, the Smiling Cat|R|BOK
 #57|Indebted Samurai|U|BOK
 #58|Tallowisp|U|BOK
-#59|Split Tail Miko|C|BOK
+#59|Split-Tail Miko|C|BOK
 #60|Shirei, Shizo's Caretaker|R|BOK
 #61|Ronin Cliffrider|U|BOK
 #62|Moonlit Strider|C|BOK
@@ -66,17 +66,17 @@
 #65|Soratami Mindsweeper|U|BOK
 #66|Threads of Disloyalty|R|BOK
 #67|Genju of the Fens|U|BOK
-#68|Matsu Tribe Sniper|C|BOK
+#68|Matsu-Tribe Sniper|C|BOK
 #69|Mistblade Shinobi|C|BOK
 #70|Minamo Sightbender|U|BOK
 #71|Skullsnatcher|C|BOK
 #72|First Volley|C|BOK
 #73|Blademane Baku|C|BOK
-#74|Sakura Tribe Springcaller|C|BOK
+#74|Sakura-Tribe Springcaller|C|BOK
 #75|Frost Ogre|C|BOK
 #76|Hero's Demise|R|BOK
 #77|Child of Thorns|C|BOK
-#78|Hundred Talon Strike|C|BOK
+#78|Hundred-Talon Strike|C|BOK
 #79|Scaled Hulk|C|BOK
 #80|Blinding Powder|U|BOK
 #81|Baku Altar|R|BOK
@@ -101,10 +101,10 @@
 #100|Flames of the Blood Hand|U|BOK
 #101|Skullmane Baku|C|BOK
 #102|Teardrop Kami|C|BOK
-#103|Nezumi Shadow Watcher|U|BOK
+#103|Nezumi Shadow-Watcher|U|BOK
 #104|Kodama of the Center Tree|R|BOK
 #105|Stir the Grave|C|BOK
-#106|Empty Shrine Kannushi|U|BOK
+#106|Empty-Shrine Kannushi|U|BOK
 #107|Shinka Gatekeeper|C|BOK
 #108|Roar of Jukai|C|BOK
 #109|Veil of Secrecy|C|BOK
@@ -147,7 +147,7 @@
 #146|Uproot|C|BOK
 #147|Quash|U|BOK
 #148|Takeno's Cavalry|C|BOK
-#149|Akki Blizzard Herder|C|BOK
+#149|Akki Blizzard-Herder|C|BOK
 #150|Clash of Realities|R|BOK
 #151|Sway of the Stars|R|BOK
 #152|Crack the Earth|C|BOK

--- a/forge-gui/res/draft/rankings/c13.rnk
+++ b/forge-gui/res/draft/rankings/c13.rnk
@@ -82,7 +82,7 @@
 #81|Selesnya Guildgate|C|C13
 #82|Darksteel Mutation|U|C13
 #83|Crawlspace|R|C13
-#84|Lim-Dul's Vault|U|C13
+#84|Lim-Dûl's Vault|U|C13
 #85|Vampire Nighthawk|U|C13
 #86|Temple Bell|R|C13
 #87|Jwar Isle Refuge|U|C13

--- a/forge-gui/res/draft/rankings/cfx.rnk
+++ b/forge-gui/res/draft/rankings/cfx.rnk
@@ -22,7 +22,7 @@
 #21|Nicol Bolas, Planeswalker|M|CFX
 #22|Thornling|M|CFX
 #23|Apocalypse Hydra|M|CFX
-#24|Mirror Sigil Sergeant|M|CFX
+#24|Mirror-Sigil Sergeant|M|CFX
 #25|Paleoloth|R|CFX
 #26|Master Transmuter|R|CFX
 #27|Malfegor|M|CFX
@@ -56,7 +56,7 @@
 #55|Viashino Slaughtermaster|U|CFX
 #56|Aven Squire|C|CFX
 #57|Vagrant Plowbeasts|U|CFX
-#58|Nacatl Hunt Pride|U|CFX
+#58|Nacatl Hunt-Pride|U|CFX
 #59|Matca Rioters|C|CFX
 #60|Ancient Ziggurat|U|CFX
 #61|Hellspark Elemental|U|CFX
@@ -130,7 +130,7 @@
 #129|Wandering Goblins|C|CFX
 #130|Mana Cylix|C|CFX
 #131|Rotting Rats|C|CFX
-#132|Scornful Aether Lich|U|CFX
+#132|Scornful Aether-Lich|U|CFX
 #133|Bone Saw|C|CFX
 #134|Constricting Tendrils|C|CFX
 #135|Infectious Horror|C|CFX

--- a/forge-gui/res/draft/rankings/chk.rnk
+++ b/forge-gui/res/draft/rankings/chk.rnk
@@ -12,8 +12,8 @@
 #11|Kodama of the North Tree|R|CHK
 #12|Kodama of the South Tree|R|CHK
 #13|Kiku, Night's Flower|R|CHK
-#14|Eight and a Half Tails|R|CHK
-#15|Kiki Jiki, Mirror Breaker|R|CHK
+#14|Eight-and-a-Half-Tails|R|CHK
+#15|Kiki-Jiki, Mirror Breaker|R|CHK
 #16|Hideous Laughter|U|CHK
 #17|Honden of Infinite Rage|U|CHK
 #18|Seshiro the Anointed|R|CHK
@@ -25,7 +25,7 @@
 #24|Yamabushi's Flame|C|CHK
 #25|Sosuke, Son of Seshiro|U|CHK
 #26|Hanabi Blast|U|CHK
-#27|Long Forgotten Gohei|R|CHK
+#27|Long-Forgotten Gohei|R|CHK
 #28|Nezumi Shortfang|R|CHK
 #29|Strength of Cedars|U|CHK
 #30|Thief of Hope|U|CHK
@@ -50,9 +50,9 @@
 #49|Isamaru, Hound of Konda|R|CHK
 #50|Myojin of Cleansing Fire|R|CHK
 #51|Honden of Cleansing Fire|U|CHK
-#52|No Dachi|U|CHK
+#52|No-Dachi|U|CHK
 #53|Jushi Apprentice|R|CHK
-#54|Kashi Tribe Reaver|U|CHK
+#54|Kashi-Tribe Reaver|U|CHK
 #55|He Who Hungers|R|CHK
 #56|Ghostly Prison|U|CHK
 #57|Samurai of the Pale Curtain|U|CHK
@@ -62,12 +62,12 @@
 #61|Frostwielder|C|CHK
 #62|Blood Rites|U|CHK
 #63|Ronin Houndmaster|C|CHK
-#64|Sensei Golden Tail|R|CHK
+#64|Sensei Golden-Tail|R|CHK
 #65|Painwracker Oni|U|CHK
 #66|Takeno, Samurai General|R|CHK
 #67|Mothrider Samurai|C|CHK
 #68|Innocence Kami|U|CHK
-#69|Sakura Tribe Elder|C|CHK
+#69|Sakura-Tribe Elder|C|CHK
 #70|Kodama's Might|C|CHK
 #71|Kodama's Reach|C|CHK
 #72|Scuttling Death|C|CHK
@@ -77,14 +77,14 @@
 #76|Konda, Lord of Eiganjo|R|CHK
 #77|Honden of Life's Web|U|CHK
 #78|Orochi Hatchery|R|CHK
-#79|Marrow Gnawer|R|CHK
+#79|Marrow-Gnawer|R|CHK
 #80|Mystic Restraints|C|CHK
 #81|Soratami Rainshaper|C|CHK
-#82|Soratami Mirror Mage|U|CHK
+#82|Soratami Mirror-Mage|U|CHK
 #83|Honden of Night's Reach|U|CHK
 #84|Devouring Greed|C|CHK
 #85|Order of the Sacred Bell|C|CHK
-#86|Kusari Gama|R|CHK
+#86|Kusari-Gama|R|CHK
 #87|Wicked Akuba|C|CHK
 #88|Kami of Fire's Roar|C|CHK
 #89|Soilshaper|U|CHK
@@ -121,19 +121,19 @@
 #120|River Kaijin|C|CHK
 #121|Samurai Enforcers|U|CHK
 #122|Tenza, Godo's Maul|U|CHK
-#123|Zo Zu the Punisher|R|CHK
+#123|Zo-Zu the Punisher|R|CHK
 #124|Kitsune Diviner|C|CHK
 #125|Orochi Eggwatcher|U|CHK
 #126|Soratami Cloudskater|C|CHK
-#127|Floating Dream Zubera|C|CHK
+#127|Floating-Dream Zubera|C|CHK
 #128|Sachi, Daughter of Seshiro|U|CHK
 #129|Iname, Life Aspect|R|CHK
 #130|Initiate of Blood|U|CHK
-#131|Hundred Talon Kami|C|CHK
-#132|Ashen Skin Zubera|C|CHK
+#131|Hundred-Talon Kami|C|CHK
+#132|Ashen-Skin Zubera|C|CHK
 #133|Kami of the Palace Fields|U|CHK
 #134|Journeyer's Kite|R|CHK
-#135|Matsu Tribe Decoy|C|CHK
+#135|Matsu-Tribe Decoy|C|CHK
 #136|Dampen Thought|U|CHK
 #137|Serpent Skin|C|CHK
 #138|Lantern Kami|C|CHK
@@ -147,7 +147,7 @@
 #146|Soulless Revival|C|CHK
 #147|Night of Souls' Betrayal|R|CHK
 #148|Waking Nightmare|C|CHK
-#149|Dripping Tongue Zubera|C|CHK
+#149|Dripping-Tongue Zubera|C|CHK
 #150|Counsel of the Soratami|C|CHK
 #151|Callous Deceiver|C|CHK
 #152|Guardian of Solitude|U|CHK
@@ -157,7 +157,7 @@
 #156|Reach Through Mists|C|CHK
 #157|Kami of the Painted Road|C|CHK
 #158|Hinder|U|CHK
-#159|Nine Ringed Bo|U|CHK
+#159|Nine-Ringed Bo|U|CHK
 #160|Gifts Ungiven|R|CHK
 #161|Jade Idol|U|CHK
 #162|Uncontrollable Anger|C|CHK
@@ -181,7 +181,7 @@
 #180|Soulblast|R|CHK
 #181|Sokenzan Bruiser|C|CHK
 #182|Call to Glory|C|CHK
-#183|Ben Ben, Akki Hermit|R|CHK
+#183|Ben-Ben, Akki Hermit|R|CHK
 #184|Okina, Temple to the Grandfathers|R|CHK
 #185|Distress|C|CHK
 #186|Myojin of Night's Reach|R|CHK
@@ -190,13 +190,13 @@
 #189|Cranial Extraction|R|CHK
 #190|Orochi Leafcaller|C|CHK
 #191|Ethereal Haze|C|CHK
-#192|Silent Chant Zubera|C|CHK
+#192|Silent-Chant Zubera|C|CHK
 #193|Myojin of Life's Web|R|CHK
 #194|Lava Spike|C|CHK
 #195|Shinka, the Bloodsoaked Keep|R|CHK
 #196|Gale Force|U|CHK
 #197|Commune with Nature|C|CHK
-#198|Lantern Lit Graveyard|U|CHK
+#198|Lantern-Lit Graveyard|U|CHK
 #199|Dosan the Falling Leaf|R|CHK
 #200|Lure|U|CHK
 #201|Wear Away|C|CHK
@@ -213,16 +213,16 @@
 #212|Azusa, Lost but Seeking|R|CHK
 #213|Akki Avalanchers|C|CHK
 #214|Konda's Banner|R|CHK
-#215|Kashi Tribe Warriors|C|CHK
+#215|Kashi-Tribe Warriors|C|CHK
 #216|Thoughtbind|C|CHK
 #217|Reverse the Sands|R|CHK
 #218|Myojin of Infinite Rage|R|CHK
 #219|Vine Kami|C|CHK
 #220|Student of Elements|U|CHK
-#221|Thousand legged Kami|U|CHK
+#221|Thousand-legged Kami|U|CHK
 #222|Kitsune Mystic|R|CHK
 #223|Unearthly Blizzard|C|CHK
-#224|Nezumi Bone Reader|U|CHK
+#224|Nezumi Bone-Reader|U|CHK
 #225|Myojin of Seeing Winds|R|CHK
 #226|Tranquil Garden|U|CHK
 #227|Oni Possession|U|CHK
@@ -245,7 +245,7 @@
 #244|Midnight Covenant|C|CHK
 #245|Hisoka's Guard|C|CHK
 #246|Shisato, Whispering Hunter|R|CHK
-#247|Honor Worn Shaku|U|CHK
+#247|Honor-Worn Shaku|U|CHK
 #248|Lifted by Clouds|C|CHK
 #249|Wandering Ones|C|CHK
 #250|Glimpse of Nature|R|CHK
@@ -271,7 +271,7 @@
 #270|Part the Veil|R|CHK
 #271|Numai Outcast|U|CHK
 #272|Hall of the Bandit Lord|R|CHK
-#273|Hair Strung Koto|R|CHK
+#273|Hair-Strung Koto|R|CHK
 #274|Horizon Seed|U|CHK
 #275|Ore Gorger|U|CHK
 #276|Nature's Will|R|CHK

--- a/forge-gui/res/draft/rankings/chr.rnk
+++ b/forge-gui/res/draft/rankings/chr.rnk
@@ -7,7 +7,7 @@
 #6|The Wretched|U|CHR
 #7|Sol'kanar the Swamp King|U|CHR
 #8|Rubinia Soulsinger|U|CHR
-#9|Palladia Mors|U|CHR
+#9|Palladia-Mors|U|CHR
 #10|Bronze Horse|U|CHR
 #11|Gauntlets of Chaos|U|CHR
 #12|Nicol Bolas|U|CHR
@@ -46,7 +46,7 @@
 #45|Axelrod Gunnarson|U|CHR
 #46|War Elephant|C|CHR
 #47|Shimian Night Stalker|U|CHR
-#48|Ghazban Ogre|C|CHR
+#48|Ghazbán Ogre|C|CHR
 #49|The Fallen|U|CHR
 #50|Marhault Elsdragon|C|CHR
 #51|Abu Ja'far|U|CHR
@@ -87,7 +87,7 @@
 #86|Fountain of Youth|C|CHR
 #87|Keepers of the Faith|C|CHR
 #88|Concordant Crossroads|U|CHR
-#89|Dandan|C|CHR
+#89|Dandân|C|CHR
 #90|Divine Offering|C|CHR
 #91|Shield Wall|U|CHR
 #92|Tormod's Crypt|C|CHR

--- a/forge-gui/res/draft/rankings/clb.rnk
+++ b/forge-gui/res/draft/rankings/clb.rnk
@@ -8,7 +8,7 @@
 #7|Ancient Bronze Dragon|M|CLB
 #8|Miirym, Sentinel Wyrm|R|CLB
 #9|Tasha, the Witch Queen|M|CLB
-#10|Minsc and Boo, Timeless Heroes|M|CLB
+#10|Minsc & Boo, Timeless Heroes|M|CLB
 #11|Elminster|M|CLB
 #12|Tomb of Horrors Adventurer|R|CLB
 #13|Blood Money|M|CLB

--- a/forge-gui/res/draft/rankings/com.rnk
+++ b/forge-gui/res/draft/rankings/com.rnk
@@ -284,7 +284,7 @@
 #283|Monk Realist|C|COM
 #284|Oni of Wild Places|U|COM
 #285|Ruhan of the Fomori|M|COM
-#286|Jotun Grunt|U|COM
+#286|Jötun Grunt|U|COM
 #287|Murmurs from Beyond|C|COM
 #288|Court Hussar|U|COM
 #289|Cleansing Beam|U|COM

--- a/forge-gui/res/draft/rankings/csp.rnk
+++ b/forge-gui/res/draft/rankings/csp.rnk
@@ -20,7 +20,7 @@
 #19|Surging Flame|C|CSP
 #20|Lightning Serpent|R|CSP
 #21|Blizzard Specter|U|CSP
-#22|Jotun Owl Keeper|U|CSP
+#22|Jötun Owl Keeper|U|CSP
 #23|Phyrexian Ironfoot|U|CSP
 #24|Garza Zol, Plague Queen|R|CSP
 #25|Arctic Nishoba|U|CSP
@@ -71,13 +71,13 @@
 #70|Deepfire Elemental|U|CSP
 #71|Dark Depths|R|CSP
 #72|Kjeldoran Outrider|C|CSP
-#73|Snow Covered Forest|C|CSP
-#74|Snow Covered Island|C|CSP
+#73|Snow-Covered Forest|C|CSP
+#74|Snow-Covered Island|C|CSP
 #75|Ronom Unicorn|C|CSP
 #76|Bull Aurochs|C|CSP
-#77|Snow Covered Mountain|C|CSP
-#78|Snow Covered Plains|C|CSP
-#79|Snow Covered Swamp|C|CSP
+#77|Snow-Covered Mountain|C|CSP
+#78|Snow-Covered Plains|C|CSP
+#79|Snow-Covered Swamp|C|CSP
 #80|Lovisa Coldeyes|R|CSP
 #81|Kjeldoran War Cry|C|CSP
 #82|Frozen Solid|C|CSP
@@ -106,7 +106,7 @@
 #105|Swift Maneuver|C|CSP
 #106|Balduvian Warlord|U|CSP
 #107|Drelnoch|C|CSP
-#108|Jotun Grunt|U|CSP
+#108|Jötun Grunt|U|CSP
 #109|Surging Dementia|C|CSP
 #110|Steam Spitter|U|CSP
 #111|Balduvian Rage|U|CSP

--- a/forge-gui/res/draft/rankings/dgm.rnk
+++ b/forge-gui/res/draft/rankings/dgm.rnk
@@ -9,15 +9,15 @@
 #8|Deadbridge Chant|M|DGM
 #9|Aetherling|R|DGM
 #10|Advent of the Wurm|R|DGM
-#11|Tajic Blade of the Legion|R|DGM
+#11|Tajic, Blade of the Legion|R|DGM
 #12|Scion of Vitu-Ghazi|R|DGM
-#13|Exava Rakdos Blood Witch|R|DGM
+#13|Exava, Rakdos Blood Witch|R|DGM
 #14|Lavinia of the Tenth|R|DGM
 #15|Pontiff of Blight|R|DGM
-#16|Ruric Thar the Unbowed|R|DGM
-#17|Varolz the Scar-Striped|R|DGM
-#18|Mirko Vosk Mind Drinker|R|DGM
-#19|Teysa Envoy of Ghosts|R|DGM
+#16|Ruric Thar, the Unbowed|R|DGM
+#17|Varolz, the Scar-Striped|R|DGM
+#18|Mirko Vosk, Mind Drinker|R|DGM
+#19|Teysa, Envoy of Ghosts|R|DGM
 #20|Sire of Insanity|R|DGM
 #21|Warleader's Helix|U|DGM
 #22|Council of the Absolute|M|DGM
@@ -40,7 +40,7 @@
 #39|Dragonshift|R|DGM
 #40|Krasis Incubation|U|DGM
 #41|Haunter of Nightveil|U|DGM
-#42|Melek Izzet Paragon|R|DGM
+#42|Melek, Izzet Paragon|R|DGM
 #43|Jelenn Sphinx|U|DGM
 #44|Zhur-Taa Ancient|R|DGM
 #45|Gruul War Chant|U|DGM

--- a/forge-gui/res/draft/rankings/dis.rnk
+++ b/forge-gui/res/draft/rankings/dis.rnk
@@ -7,7 +7,7 @@
 #6|Rakdos Guildmage|U|DIS
 #7|Azorius Guildmage|U|DIS
 #8|Pride of the Clouds|R|DIS
-#9|Cytoplast Root Kin|R|DIS
+#9|Cytoplast Root-Kin|R|DIS
 #10|Twinstrike|U|DIS
 #11|Seal of Doom|C|DIS
 #12|Cytoplast Manipulator|R|DIS
@@ -55,7 +55,7 @@
 #54|Paladin of Prahv|U|DIS
 #55|Blood Crypt|R|DIS
 #56|Momir Vig, Simic Visionary|R|DIS
-#57|Azorius First Wing|C|DIS
+#57|Azorius First-Wing|C|DIS
 #58|Demon's Jester|C|DIS
 #59|Rise Fall|U|DIS
 #60|Kindle the Carnage|U|DIS
@@ -70,7 +70,7 @@
 #69|Plaxmanta|U|DIS
 #70|Squealing Devil|U|DIS
 #71|Loaming Shaman|R|DIS
-#72|Flaring Flame Kin|U|DIS
+#72|Flaring Flame-Kin|U|DIS
 #73|Aquastrand Spider|C|DIS
 #74|Cytoshape|R|DIS
 #75|Pure Simple|U|DIS
@@ -103,7 +103,7 @@
 #102|Beacon Hawk|C|DIS
 #103|Soulsworn Jury|C|DIS
 #104|Trial Error|U|DIS
-#105|Flame Kin War Scout|U|DIS
+#105|Flame-Kin War Scout|U|DIS
 #106|Enemy of the Guildpact|C|DIS
 #107|Utopia Sprawl|C|DIS
 #108|Muse Vessel|R|DIS
@@ -132,7 +132,7 @@
 #131|Novijen, Heart of Progress|U|DIS
 #132|Flash Foliage|U|DIS
 #133|Walking Archive|R|DIS
-#134|Kill Suit Cultist|C|DIS
+#134|Kill-Suit Cultist|C|DIS
 #135|Ghost Quarter|U|DIS
 #136|Taste for Mayhem|C|DIS
 #137|Vesper Ghoul|C|DIS

--- a/forge-gui/res/draft/rankings/dka.rnk
+++ b/forge-gui/res/draft/rankings/dka.rnk
@@ -153,7 +153,7 @@
 #152|Lost in the Woods|R|DKA
 #153|Curse of Echoes|R|DKA
 #154|Shattered Perception|U|DKA
-#155|Seance|R|DKA
+#155|Séance|R|DKA
 #156|Curse of Thirst|U|DKA
 #157|Curse of Exhaustion|U|DKA
 #158|Altar of the Lost|U|DKA

--- a/forge-gui/res/draft/rankings/dmu.rnk
+++ b/forge-gui/res/draft/rankings/dmu.rnk
@@ -98,7 +98,7 @@
 #97|Essence Scatter|C|DMU
 #98|Destroy Evil|C|DMU
 #99|Radha, Coalition Warlord|U|DMU
-#100|Tura Kennerud, Skyknight|U|DMU
+#100|Tura Kennerüd, Skyknight|U|DMU
 #101|Argivian Cavalier|C|DMU
 #102|Runic Shot|U|DMU
 #103|Shalai's Acolyte|U|DMU

--- a/forge-gui/res/draft/rankings/dsk.rnk
+++ b/forge-gui/res/draft/rankings/dsk.rnk
@@ -64,7 +64,7 @@
 #63|Drag to the Roots|U|DSK
 #64|Fear of Burning Alive|U|DSK
 #65|Inquisitive Glimmer|U|DSK
-#66|Painter's Studio Defeated Gallery|U|DSK
+#66|Painter's Studio Defaced Gallery|U|DSK
 #67|Piggy Bank|U|DSK
 #68|Damnation|M|SPG
 #69|Glassworks Shattered Yard|C|DSK

--- a/forge-gui/res/draft/rankings/dst.rnk
+++ b/forge-gui/res/draft/rankings/dst.rnk
@@ -76,13 +76,13 @@
 #75|Grimclaw Bats|C|DST
 #76|Screams from Within|U|DST
 #77|Quicksilver Behemoth|C|DST
-#78|Tel Jilad Outrider|C|DST
+#78|Tel-Jilad Outrider|C|DST
 #79|Oxidda Golem|C|DST
-#80|Tel Jilad Wolf|C|DST
+#80|Tel-Jilad Wolf|C|DST
 #81|Whispersilk Cloak|C|DST
 #82|Tangle Spider|C|DST
 #83|Arcbound Hybrid|C|DST
-#84|Death Mask Duplicant|U|DST
+#84|Death-Mask Duplicant|U|DST
 #85|Dross Golem|C|DST
 #86|Echoing Truth|C|DST
 #87|Arcbound Fiend|U|DST
@@ -104,13 +104,13 @@
 #103|Eater of Days|R|DST
 #104|Synod Artificer|R|DST
 #105|Voltaic Construct|U|DST
-#106|Drill Skimmer|C|DST
+#106|Drill-Skimmer|C|DST
 #107|Darksteel Pendant|C|DST
 #108|Arcbound Lancer|U|DST
 #109|Neurok Transmuter|U|DST
 #110|Mycosynth Lattice|R|DST
 #111|Carry Away|U|DST
-#112|Krark Clan Stoker|C|DST
+#112|Krark-Clan Stoker|C|DST
 #113|Pteron Ghost|C|DST
 #114|Shriveling Rot|R|DST
 #115|Reshape|R|DST
@@ -118,7 +118,7 @@
 #117|Genesis Chamber|U|DST
 #118|Spincrusher|U|DST
 #119|Reap and Sow|C|DST
-#120|Ur Golems Eye|C|DST
+#120|Ur-Golem's Eye|C|DST
 #121|Serum Powder|R|DST
 #122|Second Sight|U|DST
 #123|Scavenging Scarab|C|DST

--- a/forge-gui/res/draft/rankings/dtk.rnk
+++ b/forge-gui/res/draft/rankings/dtk.rnk
@@ -14,18 +14,18 @@
 #13|Descent of the Dragons|M|DTK
 #14|Risen Executioner|M|DTK
 #15|Thunderbreak Regent|R|DTK
-#16|Sidisi Undead Vizier|R|DTK
+#16|Sidisi, Undead Vizier|R|DTK
 #17|Icefall Regent|R|DTK
 #18|Sunscorch Regent|R|DTK
-#19|Surrak the Hunt Caller|R|DTK
+#19|Surrak, the Hunt Caller|R|DTK
 #20|Necromaster Dragon|R|DTK
-#21|Anafenza Kin Tree Spirit|R|DTK
+#21|Anafenza, Kin-Tree Spirit|R|DTK
 #22|Deathbringer Regent|R|DTK
 #23|Boltwing Marauder|R|DTK
 #24|Secure the Wastes|R|DTK
 #25|Hidden Dragonslayer|R|DTK
 #26|Den Protector|R|DTK
-#27|Foe Razer Regent|R|DTK
+#27|Foe-Razer Regent|R|DTK
 #28|Arashin Foremost|R|DTK
 #29|Silumgar Assassin|R|DTK
 #30|Harbinger of the Hunt|R|DTK
@@ -37,7 +37,7 @@
 #36|Silumgar's Command|R|DTK
 #37|Pitiless Horde|R|DTK
 #38|Kolaghan's Command|R|DTK
-#39|Blood Chin Fanatic|R|DTK
+#39|Blood-Chin Fanatic|R|DTK
 #40|Crater Elemental|R|DTK
 #41|Arashin Sovereign|R|DTK
 #42|Ire Shaman|R|DTK
@@ -68,7 +68,7 @@
 #67|Mirror Mockery|R|DTK
 #68|Pacifism|C|DTK
 #69|Swift Warkite|U|DTK
-#70|Foul Tongue Invocation|U|DTK
+#70|Foul-Tongue Invocation|U|DTK
 #71|Volcanic Vision|R|DTK
 #72|Ambuscade Shaman|U|DTK
 #73|Aven Sunstriker|U|DTK
@@ -78,7 +78,7 @@
 #77|Warbringer|U|DTK
 #78|Enduring Scalelord|U|DTK
 #79|Silkwrap|U|DTK
-#80|Blood Chin Rager|U|DTK
+#80|Blood-Chin Rager|U|DTK
 #81|Qal Sisma Behemoth|U|DTK
 #82|Sarkhan's Rage|C|DTK
 #83|Salt Road Ambushers|U|DTK
@@ -96,9 +96,9 @@
 #95|Belltoll Dragon|U|DTK
 #96|Kolaghan Forerunners|U|DTK
 #97|Vulturous Aven|C|DTK
-#98|Acid Spewer Dragon|U|DTK
+#98|Acid-Spewer Dragon|U|DTK
 #99|Haven of the Spirit Dragon|R|DTK
-#100|Silumgar Spell Eater|U|DTK
+#100|Silumgar Spell-Eater|U|DTK
 #101|Ainok Survivalist|U|DTK
 #102|Hand of Silumgar|C|DTK
 #103|Gudul Lurker|U|DTK
@@ -132,14 +132,14 @@
 #131|Dragon Fodder|C|DTK
 #132|Defeat|C|DTK
 #133|Kolaghan Aspirant|C|DTK
-#134|Dragon Scarred Bear|C|DTK
+#134|Dragon-Scarred Bear|C|DTK
 #135|Anticipate|C|DTK
 #136|Press the Advantage|U|DTK
 #137|Lurking Arynx|U|DTK
 #138|Coat with Venom|C|DTK
 #139|Glade Watcher|C|DTK
 #140|Evolving Wilds|C|DTK
-#141|Guardian Shield Bearer|C|DTK
+#141|Guardian Shield-Bearer|C|DTK
 #142|Butcher's Glee|C|DTK
 #143|Dromoka Warrior|C|DTK
 #144|Living Lore|R|DTK
@@ -180,7 +180,7 @@
 #179|Sight Beyond Sight|U|DTK
 #180|Kolaghan Stormsinger|C|DTK
 #181|Graceblade Artisan|U|DTK
-#182|Self Inflicted Wound|U|DTK
+#182|Self-Inflicted Wound|U|DTK
 #183|Sandstorm Charger|C|DTK
 #184|Orator of Ojutai|U|DTK
 #185|Updraft Elemental|C|DTK
@@ -231,7 +231,7 @@
 #230|Naturalize|C|DTK
 #231|Dragon's Eye Sentry|C|DTK
 #232|Fate Forgotten|C|DTK
-#233|Foul Tongue Shriek|C|DTK
+#233|Foul-Tongue Shriek|C|DTK
 #234|Ancient Carp|C|DTK
 #235|Shape the Sands|C|DTK
 #236|Revealing Wind|C|DTK

--- a/forge-gui/res/draft/rankings/ema.rnk
+++ b/forge-gui/res/draft/rankings/ema.rnk
@@ -101,7 +101,7 @@
 #100|Firebolt|C|EMA
 #101|Wonder|U|EMA
 #102|Ichorid|R|EMA
-#103|Man-o-War|C|EMA
+#103|Man-o'-War|C|EMA
 #104|Gamble|R|EMA
 #105|Llanowar Elves|C|EMA
 #106|Prodigal Sorcerer|U|EMA

--- a/forge-gui/res/draft/rankings/eve.rnk
+++ b/forge-gui/res/draft/rankings/eve.rnk
@@ -44,7 +44,7 @@
 #43|Crag Puca|U|EVE
 #44|Noxious Hatchling|U|EVE
 #45|Shrewd Hatchling|U|EVE
-#46|Cold Eyed Selkie|R|EVE
+#46|Cold-Eyed Selkie|R|EVE
 #47|Canker Abomination|U|EVE
 #48|Flickerwisp|U|EVE
 #49|Primalcrux|R|EVE
@@ -63,7 +63,7 @@
 #62|Regal Force|R|EVE
 #63|Soul Reap|C|EVE
 #64|Wistful Selkie|U|EVE
-#65|Gwyllion Hedge Mage|U|EVE
+#65|Gwyllion Hedge-Mage|U|EVE
 #66|Rendclaw Trow|C|EVE
 #67|Needle Specter|R|EVE
 #68|Bloom Tender|R|EVE
@@ -78,13 +78,13 @@
 #77|Desecrator Hag|C|EVE
 #78|Riverfall Mimic|C|EVE
 #79|Harvest Gwyllion|C|EVE
-#80|Hag Hedge Mage|U|EVE
+#80|Hag Hedge-Mage|U|EVE
 #81|Inundate|R|EVE
-#82|Noggle Hedge Mage|U|EVE
-#83|Duergar Hedge Mage|U|EVE
+#82|Noggle Hedge-Mage|U|EVE
+#83|Duergar Hedge-Mage|U|EVE
 #84|Loyal Gyrfalcon|U|EVE
-#85|Selkie Hedge Mage|U|EVE
-#86|Duergar Mine Captain|U|EVE
+#85|Selkie Hedge-Mage|U|EVE
+#86|Duergar Mine-Captain|U|EVE
 #87|Shorecrasher Mimic|C|EVE
 #88|Nucklavee|U|EVE
 #89|Cinder Pyromancer|C|EVE
@@ -126,7 +126,7 @@
 #125|Flooded Grove|R|EVE
 #126|Noggle Ransacker|U|EVE
 #127|Banishing Knack|C|EVE
-#128|Duergar Cave Guard|U|EVE
+#128|Duergar Cave-Guard|U|EVE
 #129|Twilight Mire|R|EVE
 #130|Inside Out|C|EVE
 #131|Nip Gwyllion|C|EVE

--- a/forge-gui/res/draft/rankings/exp.rnk
+++ b/forge-gui/res/draft/rankings/exp.rnk
@@ -36,7 +36,7 @@
 #1|Strip Mine|M|EXP
 #1|Graven Cairns|M|EXP
 #1|Rugged Prairie|M|EXP
-#1|Fire Lit Thicket|M|EXP
+#1|Fire-Lit Thicket|M|EXP
 #1|Flooded Grove|M|EXP
 #1|Tectonic Edge|M|EXP
 #1|Wooded Bastion|M|EXP

--- a/forge-gui/res/draft/rankings/frf.rnk
+++ b/forge-gui/res/draft/rankings/frf.rnk
@@ -1,5 +1,5 @@
 //Rank|Name|Rarity|Set
-#1|Ugin the Spirit Dragon|M|FRF
+#1|Ugin, the Spirit Dragon|M|FRF
 #2|Shaman of the Great Hunt|M|FRF
 #3|Brutal Hordechief|M|FRF
 #4|Monastery Mentor|M|FRF
@@ -7,26 +7,26 @@
 #6|Whisperwood Elemental|M|FRF
 #7|Warden of the First Tree|M|FRF
 #8|Soulfire Grand Master|M|FRF
-#9|Dromoka the Eternal|R|FRF
+#9|Dromoka, the Eternal|R|FRF
 #10|Citadel Siege|R|FRF
-#11|Tasigur the Golden Fang|R|FRF
-#12|Kolaghan the Storm's Fury|R|FRF
+#11|Tasigur, the Golden Fang|R|FRF
+#12|Kolaghan, the Storm's Fury|R|FRF
 #13|Archfiend of Depravity|R|FRF
-#14|Silumgar the Drifting Death|R|FRF
+#14|Silumgar, the Drifting Death|R|FRF
 #15|Crux of Fate|R|FRF
 #16|Palace Siege|R|FRF
 #17|Ghastly Conscription|M|FRF
 #18|Dragonscale General|R|FRF
 #19|Mardu Strike Leader|R|FRF
-#20|Alesha Who Smiles at Death|R|FRF
-#21|Ojutai Soul of Winter|R|FRF
+#20|Alesha, Who Smiles at Death|R|FRF
+#21|Ojutai, Soul of Winter|R|FRF
 #22|Daghatar the Adamant|R|FRF
 #23|Yasova Dragonclaw|R|FRF
-#24|Shu Yun the Silent Tempest|R|FRF
-#25|Atarka World Render|R|FRF
+#24|Shu Yun, the Silent Tempest|R|FRF
+#25|Atarka, World Render|R|FRF
 #26|Flamewake Phoenix|R|FRF
 #27|Temur War Shaman|R|FRF
-#28|Sage Eye Avengers|R|FRF
+#28|Sage-Eye Avengers|R|FRF
 #29|Outpost Siege|R|FRF
 #30|Sandsteppe Mastodon|R|FRF
 #31|Temporal Trespass|M|FRF
@@ -65,7 +65,7 @@
 #64|Vaultbreaker|U|FRF
 #65|Marang River Prowler|U|FRF
 #66|Mindscour Dragon|U|FRF
-#67|Mardu Woe Reaper|U|FRF
+#67|Mardu Woe-Reaper|U|FRF
 #68|Douse in Gloom|C|FRF
 #69|Aven Surveyor|C|FRF
 #70|Frost Walker|U|FRF
@@ -74,7 +74,7 @@
 #73|Wandering Champion|U|FRF
 #74|Hunt the Weak|C|FRF
 #75|Gurmag Angler|C|FRF
-#76|Abzan Kin Guard|U|FRF
+#76|Abzan Kin-Guard|U|FRF
 #77|Reality Shift|U|FRF
 #78|Honor's Reward|U|FRF
 #79|Sultai Emissary|C|FRF
@@ -100,7 +100,7 @@
 #99|Cached Defenses|U|FRF
 #100|Hooded Assassin|C|FRF
 #101|Jeskai Barricade|U|FRF
-#102|Lotus Eye Mystics|U|FRF
+#102|Lotus-Eye Mystics|U|FRF
 #103|Channel Harm|U|FRF
 #104|Soul Summons|C|FRF
 #105|Hungering Yeti|U|FRF
@@ -117,7 +117,7 @@
 #116|Fearsome Awakening|U|FRF
 #117|Harsh Sustenance|C|FRF
 #118|Tranquil Cove|L|FRF
-#119|Wind Scarred Crag|L|FRF
+#119|Wind-Scarred Crag|L|FRF
 #120|Collateral Damage|C|FRF
 #121|Feral Krushok|C|FRF
 #122|Arashin Cleric|C|FRF
@@ -146,7 +146,7 @@
 #145|Refocus|C|FRF
 #146|Ethereal Ambush|C|FRF
 #147|Ancestral Vengeance|C|FRF
-#148|Great Horn Krushok|C|FRF
+#148|Great-Horn Krushok|C|FRF
 #149|Sudden Reclamation|U|FRF
 #150|Diplomacy of the Wastes|U|FRF
 #151|Grave Strength|U|FRF

--- a/forge-gui/res/draft/rankings/fut.rnk
+++ b/forge-gui/res/draft/rankings/fut.rnk
@@ -25,17 +25,17 @@
 #24|Ichor Slick|C|FUT
 #25|Quagnoth|R|FUT
 #26|Bound in Silence|U|FUT
-#27|Nacatl War Pride|U|FUT
+#27|Nacatl War-Pride|U|FUT
 #28|Coalition Relic|R|FUT
 #29|Arc Blade|U|FUT
 #30|Judge Unworthy|C|FUT
-#31|Infiltrator il Kor|C|FUT
+#31|Infiltrator il-Kor|C|FUT
 #32|Magus of the Abyss|R|FUT
 #33|Magus of the Future|R|FUT
 #34|Epochrasite|R|FUT
 #35|Sporoloth Ancient|C|FUT
 #36|Spin into Myth|U|FUT
-#37|Whip Spine Drake|C|FUT
+#37|Whip-Spine Drake|C|FUT
 #38|Riddle of Lightning|C|FUT
 #39|Knight of Sursi|C|FUT
 #40|Centaur Omenreader|U|FUT
@@ -46,7 +46,7 @@
 #45|Foresee|C|FUT
 #46|Nessian Courser|C|FUT
 #47|Thornweald Archer|C|FUT
-#48|Spirit en Dal|U|FUT
+#48|Spirit en-Dal|U|FUT
 #49|Edge of Autumn|C|FUT
 #50|Kavu Primarch|C|FUT
 #51|Bonded Fetch|U|FUT
@@ -73,7 +73,7 @@
 #72|Graven Cairns|R|FUT
 #73|Skizzik Surger|U|FUT
 #74|Nimbus Maze|R|FUT
-#75|Shivan Sand Mage|U|FUT
+#75|Shivan Sand-Mage|U|FUT
 #76|Grove of the Burnwillows|R|FUT
 #77|Summoner's Pact|R|FUT
 #78|Sword of the Meek|U|FUT
@@ -114,7 +114,7 @@
 #113|Storm Entity|U|FUT
 #114|Blind Phantasm|C|FUT
 #115|Ramosian Revivalist|U|FUT
-#116|Char Rumbler|U|FUT
+#116|Char-Rumbler|U|FUT
 #117|Shah of Naar Isle|R|FUT
 #118|Cyclical Evolution|U|FUT
 #119|Witch's Mist|U|FUT
@@ -123,7 +123,7 @@
 #122|New Benalia|U|FUT
 #123|Shapeshifter's Marrow|R|FUT
 #124|Virulent Sliver|C|FUT
-#125|Augur il Vec|C|FUT
+#125|Augur il-Vec|C|FUT
 #126|Bloodshot Trainee|U|FUT
 #127|Petrified Plating|C|FUT
 #128|Muraganda Petroglyphs|R|FUT
@@ -159,11 +159,11 @@
 #158|Bitter Ordeal|R|FUT
 #159|Veilstone Amulet|R|FUT
 #160|Darksteel Garrison|R|FUT
-#161|Cutthroat il Dal|C|FUT
+#161|Cutthroat il-Dal|C|FUT
 #162|Quiet Disrepair|C|FUT
 #163|Arcanum Wings|U|FUT
 #164|Gift of Granite|C|FUT
-#165|Samite Censer Bearer|C|FUT
+#165|Samite Censer-Bearer|C|FUT
 #166|Pyromancer's Swath|R|FUT
 #167|Oblivion Crown|C|FUT
 #168|Emblem of the Warmind|U|FUT

--- a/forge-gui/res/draft/rankings/gpt.rnk
+++ b/forge-gui/res/draft/rankings/gpt.rnk
@@ -9,7 +9,7 @@
 #8|Ghost Council of Orzhova|R|GPT
 #9|Mortify|U|GPT
 #10|Rumbling Slum|R|GPT
-#11|Burning Tree Shaman|R|GPT
+#11|Burning-Tree Shaman|R|GPT
 #12|Electrolyze|U|GPT
 #13|Skarrgan Firebird|R|GPT
 #14|Giant Solifuge|R|GPT
@@ -43,7 +43,7 @@
 #42|Exhumer Thrull|U|GPT
 #43|Izzet Guildmage|U|GPT
 #44|Silhana Starfletcher|C|GPT
-#45|Ghor Clan Savage|C|GPT
+#45|Ghor-Clan Savage|C|GPT
 #46|Wildsize|C|GPT
 #47|Mourning Thrull|C|GPT
 #48|Stomping Ground|R|GPT
@@ -80,8 +80,8 @@
 #79|Shadow Lance|U|GPT
 #80|Thunderheads|U|GPT
 #81|Bloodscale Prowler|C|GPT
-#82|Scab Clan Mauler|C|GPT
-#83|Petrified Wood Kin|R|GPT
+#82|Scab-Clan Mauler|C|GPT
+#83|Petrified Wood-Kin|R|GPT
 #84|Sanguine Praetor|R|GPT
 #85|Ghostway|R|GPT
 #86|Absolver Thrull|C|GPT
@@ -95,7 +95,7 @@
 #94|Goblin Flectomancer|U|GPT
 #95|Withstand|C|GPT
 #96|Wild Cantor|C|GPT
-#97|Burning Tree Bloodscale|C|GPT
+#97|Burning-Tree Bloodscale|C|GPT
 #98|To Arms!|U|GPT
 #99|Infiltrator's Magemark|C|GPT
 #100|Castigate|C|GPT
@@ -107,35 +107,35 @@
 #106|Storm Herd|R|GPT
 #107|Feral Animist|U|GPT
 #108|Necromancer's Magemark|C|GPT
-#109|Ghor Clan Bloodscale|U|GPT
+#109|Ghor-Clan Bloodscale|U|GPT
 #110|Leap of Flame|C|GPT
 #111|Vertigo Spawn|U|GPT
-#112|Witch Maw Nephilim|R|GPT
+#112|Witch-Maw Nephilim|R|GPT
 #113|Gruul Nodorog|C|GPT
 #114|Battering Wurm|U|GPT
 #115|Abyssal Nocturnus|R|GPT
 #116|Guardian's Magemark|C|GPT
 #117|Runeboggle|C|GPT
-#118|Glint Eye Nephilim|R|GPT
+#118|Glint-Eye Nephilim|R|GPT
 #119|Hissing Miasma|U|GPT
 #120|Fencer's Magemark|C|GPT
 #121|Skyrider Trainee|C|GPT
 #122|Wreak Havoc|U|GPT
 #123|Frazzle|U|GPT
-#124|Dune Brood Nephilim|R|GPT
+#124|Dune-Brood Nephilim|R|GPT
 #125|Gigadrowse|C|GPT
 #126|Parallectric Feedback|R|GPT
 #127|Leyline of Lightning|R|GPT
-#128|Rabble Rouser|U|GPT
-#129|Skarrgan Pit Skulk|C|GPT
+#128|Rabble-Rouser|U|GPT
+#129|Skarrgan Pit-Skulk|C|GPT
 #130|Restless Bones|C|GPT
 #131|Beastmaster's Magemark|C|GPT
 #132|Stitch in Time|R|GPT
-#133|Ink Treader Nephilim|R|GPT
+#133|Ink-Treader Nephilim|R|GPT
 #134|Siege of Towers|R|GPT
 #135|Lionheart Maverick|C|GPT
 #136|Poisonbelly Ogre|C|GPT
-#137|Yore Tiller Nephilim|R|GPT
+#137|Yore-Tiller Nephilim|R|GPT
 #138|Crystal Seer|C|GPT
 #139|Predatory Focus|U|GPT
 #140|Cry of Contrition|C|GPT

--- a/forge-gui/res/draft/rankings/gtc.rnk
+++ b/forge-gui/res/draft/rankings/gtc.rnk
@@ -1,9 +1,9 @@
 //Rank|Name|Rarity|Set
-#1|Gideon Champion of Justice|M|GTC
-#2|Aurelias Fury|M|GTC
+#1|Gideon, Champion of Justice|M|GTC
+#2|Aurelia's Fury|M|GTC
 #3|Domri Rade|M|GTC
-#4|Obzedat Ghost Council|M|GTC
-#5|Aurelia the Warleader|M|GTC
+#4|Obzedat, Ghost Council|M|GTC
+#5|Aurelia, the Warleader|M|GTC
 #6|Master Biomancer|M|GTC
 #7|Deathpact Angel|M|GTC
 #8|Duskmantle Seer|M|GTC
@@ -11,7 +11,7 @@
 #10|Prime Speaker Zegana|M|GTC
 #11|Giant Adephage|M|GTC
 #12|Lord of the Void|M|GTC
-#13|Lazav Dimir Mastermind|M|GTC
+#13|Lazav, Dimir Mastermind|M|GTC
 #14|Borborygmos Enraged|M|GTC
 #15|Boros Reckoner|R|GTC
 #16|Angelic Skirmisher|R|GTC
@@ -73,7 +73,7 @@
 #72|Cinder Elemental|U|GTC
 #73|Godless Shrine|R|GTC
 #74|Zameck Guildmage|U|GTC
-#75|Kingpins Pet|C|GTC
+#75|Kingpin's Pet|C|GTC
 #76|Syndic of Tithes|C|GTC
 #77|Stomping Ground|R|GTC
 #78|Sacred Foundry|R|GTC
@@ -121,10 +121,10 @@
 #120|Vizkopa Confessor|U|GTC
 #121|Ordruun Veteran|U|GTC
 #122|Simic Fluxmage|U|GTC
-#123|Five Alarm Fire|R|GTC
+#123|Five-Alarm Fire|R|GTC
 #124|Boros Guildgate|C|GTC
 #125|Orzhov Guildgate|C|GTC
-#126|Executioners Swing|C|GTC
+#126|Executioner's Swing|C|GTC
 #127|Warmind Infantry|C|GTC
 #128|Miming Slime|U|GTC
 #129|Balustrade Spy|C|GTC
@@ -159,16 +159,16 @@
 #158|Act of Treason|C|GTC
 #159|Gridlock|U|GTC
 #160|Hellraiser Goblin|U|GTC
-#161|Deaths Approach|C|GTC
+#161|Death's Approach|C|GTC
 #162|Gateway Shade|U|GTC
 #163|Massive Raid|C|GTC
 #164|Psychic Strike|C|GTC
-#165|Sages Row Denizen|C|GTC
+#165|Sage's Row Denizen|C|GTC
 #166|Ruination Wurm|C|GTC
 #167|Verdant Haven|C|GTC
 #168|Keymaster Rogue|C|GTC
 #169|Smog Elemental|U|GTC
-#170|Debtors Pulpit|U|GTC
+#170|Debtor's Pulpit|U|GTC
 #171|Orzhov Keyrune|U|GTC
 #172|Dutiful Thrull|C|GTC
 #173|Beckon Apparition|C|GTC
@@ -227,12 +227,12 @@
 #226|Scatter Arc|C|GTC
 #227|Furious Resistance|C|GTC
 #228|Voidwalk|U|GTC
-#229|Thespians Stage|R|GTC
+#229|Thespian's Stage|R|GTC
 #230|Guildscorn Ward|C|GTC
 #231|Skyblinder Staff|C|GTC
 #232|Contaminated Ground|C|GTC
 #233|Alpha Authority|U|GTC
-#234|Predators Rapport|C|GTC
+#234|Predator's Rapport|C|GTC
 #235|Skygames|C|GTC
 #236|Structural Collapse|C|GTC
 #237|Tin Street Market|C|GTC
@@ -243,7 +243,7 @@
 #242|Crackling Perimeter|U|GTC
 #243|Hindervines|U|GTC
 #244|Mental Vapors|U|GTC
-#245|Illusionists Bracers|R|GTC
+#245|Illusionist's Bracers|R|GTC
 #246|Illness in the Ranks|U|GTC
 #247|Dying Wish|U|GTC
 #248|Serene Remembrance|U|GTC

--- a/forge-gui/res/draft/rankings/hbg.rnk
+++ b/forge-gui/res/draft/rankings/hbg.rnk
@@ -37,7 +37,7 @@
 #36|Grim Hireling|R|HBG
 #37|Uthgardt Fury|R|HBG
 #38|Earthquake Dragon|R|HBG
-#39|Rasaad, Monk of Selune|U|HBG
+#39|Rasaad, Monk of Selûne|U|HBG
 #40|Gale, Conduit of the Arcane|M|HBG
 #41|Imoen, Trickster Friend|R|HBG
 #42|Shadowheart, Sharran Cleric|R|HBG

--- a/forge-gui/res/draft/rankings/ice.rnk
+++ b/forge-gui/res/draft/rankings/ice.rnk
@@ -11,7 +11,7 @@
 #10|Chaos Moon|R|ICE
 #11|Formation|R|ICE
 #12|Swords to Plowshares|U|ICE
-#13|Marton Stromgald|R|ICE
+#13|Márton Stromgald|R|ICE
 #14|Johtull Wurm|U|ICE
 #15|Time Bomb|R|ICE
 #16|Minion of Leshrac|R|ICE
@@ -118,7 +118,7 @@
 #117|Barbed Sextant|C|ICE
 #118|Giant Trap Door Spider|U|ICE
 #119|Wings of Aesthir|U|ICE
-#120|Lim-Dul's Cohort|C|ICE
+#120|Lim-Dûl's Cohort|C|ICE
 #121|Melee|U|ICE
 #122|Baton of Morale|U|ICE
 #123|Thunder Wall|U|ICE
@@ -149,9 +149,9 @@
 #148|Vertigo|U|ICE
 #149|Wall of Lava|U|ICE
 #150|Jester's Mask|R|ICE
-#151|Legions of Lim-Dul|C|ICE
+#151|Legions of Lim-Dûl|C|ICE
 #152|Flare|C|ICE
-#153|Oath of Lim-Dul|R|ICE
+#153|Oath of Lim-Dûl|R|ICE
 #154|Diabolic Vision|U|ICE
 #155|Sulfurous Springs|R|ICE
 #156|Fyndhorn Pollen|R|ICE
@@ -159,7 +159,7 @@
 #158|Lost Order of Jarkeld|R|ICE
 #159|Bone Shaman|C|ICE
 #160|Gravebind|R|ICE
-#161|Lim-Dul's Hex|U|ICE
+#161|Lim-Dûl's Hex|U|ICE
 #162|Hipparion|U|ICE
 #163|Juniper Order Druid|C|ICE
 #164|Aurochs|C|ICE

--- a/forge-gui/res/draft/rankings/iko.rnk
+++ b/forge-gui/res/draft/rankings/iko.rnk
@@ -21,7 +21,7 @@
 #20|Keruga, the Macrosage|R|IKO
 #21|Crystalline Giant|R|IKO
 #22|Yorion, Sky Nomad|R|IKO
-#23|Lurrus of the Dream Den|R|IKO
+#23|Lurrus of the Dream-Den|R|IKO
 #24|Cubwarden|R|IKO
 #25|Everquill Phoenix|R|IKO
 #26|Voracious Greatshark|R|IKO

--- a/forge-gui/res/draft/rankings/isd.rnk
+++ b/forge-gui/res/draft/rankings/isd.rnk
@@ -6,17 +6,17 @@
 #5|Angelic Overseer|M|ISD
 #6|Reaper from the Abyss|M|ISD
 #7|Geist of Saint Traft|M|ISD
-#8|Grimgrin, Corpse Born|M|ISD
+#8|Grimgrin, Corpse-Born|M|ISD
 #9|Balefire Dragon|M|ISD
 #10|Skaab Ruinator|M|ISD
 #11|Essence of the Wild|M|ISD
 #12|Army of the Damned|M|ISD
 #13|Grimoire of the Dead|M|ISD
 #14|Tree of Redemption|M|ISD
-#15|Mirror Mad Phantasm|M|ISD
+#15|Mirror-Mad Phantasm|M|ISD
 #16|Devil's Play|R|ISD
 #17|Bloodgift Demon|R|ISD
-#18|Geist Honored Monk|R|ISD
+#18|Geist-Honored Monk|R|ISD
 #19|Sever the Bloodline|R|ISD
 #20|Angel of Flight Alabaster|R|ISD
 #21|Manor Gargoyle|R|ISD
@@ -104,7 +104,7 @@
 #103|Geistflame|C|ISD
 #104|Hamlet Captain|U|ISD
 #105|Runechanter's Pike|R|ISD
-#106|Silver Inlaid Dagger|U|ISD
+#106|Silver-Inlaid Dagger|U|ISD
 #107|Cloistered Youth|U|ISD
 #108|Silent Departure|C|ISD
 #109|Blazing Torch|C|ISD
@@ -153,8 +153,8 @@
 #152|Village Ironsmith|C|ISD
 #153|Orchard Spirit|C|ISD
 #154|Bloodcrazed Neonate|C|ISD
-#155|One Eyed Scarecrow|C|ISD
-#156|Village Bell Ringer|C|ISD
+#155|One-Eyed Scarecrow|C|ISD
+#156|Village Bell-Ringer|C|ISD
 #157|Walking Corpse|C|ISD
 #158|Unruly Mob|C|ISD
 #159|Stitcher's Apprentice|C|ISD

--- a/forge-gui/res/draft/rankings/jou.rnk
+++ b/forge-gui/res/draft/rankings/jou.rnk
@@ -1,27 +1,27 @@
 //Rank|Name|Rarity|Set
-#1|Pharika God of Affliction|M|JOU
-#2|Ajani Mentor of Heroes|M|JOU
+#1|Pharika, God of Affliction|M|JOU
+#2|Ajani, Mentor of Heroes|M|JOU
 #3|Godsend|M|JOU
-#4|Iroas God of Victory|M|JOU
-#5|Keranos God of Storms|M|JOU
+#4|Iroas, God of Victory|M|JOU
+#5|Keranos, God of Storms|M|JOU
 #6|Prophetic Flamespeaker|M|JOU
-#7|Athreos God of Passage|M|JOU
+#7|Athreos, God of Passage|M|JOU
 #8|Sage of Hours|M|JOU
-#9|Kruphix God of Horizons|M|JOU
+#9|Kruphix, God of Horizons|M|JOU
 #10|Dictate of Heliod|R|JOU
 #11|Dawnbringer Charioteers|R|JOU
 #12|Silence the Believers|R|JOU
-#13|King Macar the Gold Cursed|R|JOU
+#13|King Macar, the Gold-Cursed|R|JOU
 #14|Master of the Feast|R|JOU
 #15|Hypnotic Siren|R|JOU
 #16|Setessan Tactics|R|JOU
 #17|Hydra Broodmaster|R|JOU
-#18|Heroes Bane|R|JOU
+#18|Heroes' Bane|R|JOU
 #19|Dictate of Erebos|R|JOU
 #20|Doomwake Giant|R|JOU
 #21|Eidolon of Blossoms|R|JOU
 #22|Spawn of Thraxes|R|JOU
-#23|Pheres Band Warchief|R|JOU
+#23|Pheres-Band Warchief|R|JOU
 #24|Battlefield Thaumaturge|R|JOU
 #25|Harness by Force|R|JOU
 #26|Extinguish All Hope|R|JOU
@@ -53,7 +53,7 @@
 #52|Crystalline Nautilus|U|JOU
 #53|Riddle of Lightning|U|JOU
 #54|Revel of the Fallen God|R|JOU
-#55|Nyx Fleece Ram|U|JOU
+#55|Nyx-Fleece Ram|U|JOU
 #56|Gnarled Scarhide|U|JOU
 #57|Underworld Coinsmith|U|JOU
 #58|Brain Maggot|U|JOU
@@ -62,11 +62,11 @@
 #61|Nyx Weaver|U|JOU
 #62|Spiteful Blow|U|JOU
 #63|Phalanx Formation|U|JOU
-#64|Mogiss Warhound|U|JOU
+#64|Mogis's Warhound|U|JOU
 #65|Dictate of the Twin Gods|R|JOU
 #66|Bassara Tower Archer|U|JOU
 #67|Nightmarish End|U|JOU
-#68|War Wing Siren|C|JOU
+#68|War-Wing Siren|C|JOU
 #69|Wildfire Cerberus|U|JOU
 #70|Spirespine|U|JOU
 #71|Skybind|R|JOU
@@ -83,7 +83,7 @@
 #82|Cloaked Siren|C|JOU
 #83|Dakra Mystic|U|JOU
 #84|Grim Guardian|C|JOU
-#85|Supply Line Cranes|C|JOU
+#85|Supply-Line Cranes|C|JOU
 #86|Stormchaser Chimera|U|JOU
 #87|Chariot of Victory|U|JOU
 #88|Feast of Dreams|C|JOU
@@ -92,28 +92,28 @@
 #91|Desperate Stand|U|JOU
 #92|Disciple of Deceit|U|JOU
 #93|Hubris|C|JOU
-#94|Ajanis Presence|C|JOU
+#94|Ajani's Presence|C|JOU
 #95|Goldenhide Ox|U|JOU
-#96|Pharikas Chosen|C|JOU
-#97|Lagonna Band Trailblazer|C|JOU
+#96|Pharika's Chosen|C|JOU
+#97|Lagonna-Band Trailblazer|C|JOU
 #98|Oreskos Swiftclaw|C|JOU
 #99|Quarry Colossus|U|JOU
 #100|Oakheart Dryads|C|JOU
 #101|Harvestguard Alseids|C|JOU
 #102|Bladetusk Boar|C|JOU
 #103|Sigiled Skink|C|JOU
-#104|Pheres Band Thunderhoof|C|JOU
+#104|Pheres-Band Thunderhoof|C|JOU
 #105|Satyr Hoplite|C|JOU
 #106|Armory of Iroas|U|JOU
 #107|Ravenous Leucrocota|C|JOU
 #108|Starfall|C|JOU
-#109|Gold Forged Sentinel|U|JOU
+#109|Gold-Forged Sentinel|U|JOU
 #110|Eagle of the Watch|C|JOU
 #111|Strength from the Fallen|U|JOU
 #112|Eidolon of Rhetoric|U|JOU
 #113|Nyx Infusion|C|JOU
 #114|Oppressive Rays|C|JOU
-#115|Kioras Dismissal|U|JOU
+#115|Kiora's Dismissal|U|JOU
 #116|Akroan Mastiff|C|JOU
 #117|Interpret the Signs|U|JOU
 #118|Renowned Weaver|C|JOU
@@ -123,7 +123,7 @@
 #122|Font of Fortunes|C|JOU
 #123|Armament of Nyx|C|JOU
 #124|Ritual of the Returned|U|JOU
-#125|Thassas Ire|U|JOU
+#125|Thassa's Ire|U|JOU
 #126|Spite of Mogis|U|JOU
 #127|Reviving Melody|U|JOU
 #128|Font of Fertility|C|JOU
@@ -140,10 +140,10 @@
 #139|Rouse the Mob|C|JOU
 #140|Tormented Thoughts|U|JOU
 #141|Blinding Flare|U|JOU
-#142|Natures Panoply|C|JOU
+#142|Nature's Panoply|C|JOU
 #143|Pensive Minotaur|C|JOU
 #144|Cruel Feeding|C|JOU
-#145|Thassas Devourer|C|JOU
+#145|Thassa's Devourer|C|JOU
 #146|Cast into Darkness|C|JOU
 #147|Market Festival|C|JOU
 #148|Triton Shorestalker|C|JOU
@@ -153,14 +153,14 @@
 #152|Lightning Diadem|C|JOU
 #153|Gluttonous Cyclops|C|JOU
 #154|Knowledge and Power|U|JOU
-#155|Flamespeakers Will|C|JOU
+#155|Flamespeaker's Will|C|JOU
 #156|Rotted Hulk|C|JOU
 #157|Font of Ire|C|JOU
-#158|Kruphixs Insight|C|JOU
+#158|Kruphix's Insight|C|JOU
 #159|Pull from the Deep|U|JOU
 #160|Dictate of Karametra|R|JOU
 #161|Rollick of Abandon|U|JOU
 #162|Font of Vigor|C|JOU
 #163|Godhunter Octopus|C|JOU
 #164|Desecration Plague|C|JOU
-#165|Deserters Quarters|U|JOU
+#165|Deserter's Quarters|U|JOU

--- a/forge-gui/res/draft/rankings/ktk.rnk
+++ b/forge-gui/res/draft/rankings/ktk.rnk
@@ -1,24 +1,24 @@
 //Rank|Name|Rarity|Set
-#1|Sarkhan the Dragonspeaker|M|KTK
+#1|Sarkhan, the Dragonspeaker|M|KTK
 #2|Wingmate Roc|M|KTK
-#3|Sorin Solemn Visitor|M|KTK
+#3|Sorin, Solemn Visitor|M|KTK
 #4|Ashcloud Phoenix|M|KTK
 #5|Hooded Hydra|M|KTK
 #6|Zurgo Helmsmasher|M|KTK
 #7|Surrak Dragonclaw|M|KTK
-#8|Anafenza the Foremost|M|KTK
+#8|Anafenza, the Foremost|M|KTK
 #9|Clever Impersonator|M|KTK
 #10|Pearl Lake Ancient|M|KTK
-#11|Sidisi Brood Tyrant|M|KTK
+#11|Sidisi, Brood Tyrant|M|KTK
 #12|See the Unwritten|M|KTK
-#13|Narset Enlightened Master|M|KTK
+#13|Narset, Enlightened Master|M|KTK
 #14|High Sentinels of Arashin|R|KTK
 #15|Sagu Mauler|R|KTK
 #16|Empty the Pits|M|KTK
 #17|Siege Rhino|R|KTK
 #18|Herald of Anafenza|R|KTK
 #19|Crater's Claws|R|KTK
-#20|Dragon Style Twins|R|KTK
+#20|Dragon-Style Twins|R|KTK
 #21|End Hostilities|R|KTK
 #22|Master of Pearls|R|KTK
 #23|Utter End|R|KTK
@@ -52,7 +52,7 @@
 #51|Mardu Ascendancy|R|KTK
 #52|Bellowing Saddlebrute|U|KTK
 #53|Trail of Mystery|R|KTK
-#54|Mardu Heart Piercer|U|KTK
+#54|Mardu Heart-Piercer|U|KTK
 #55|Heir of the Wilds|U|KTK
 #56|Windswept Heath|R|KTK
 #57|Icefeather Aven|U|KTK
@@ -72,7 +72,7 @@
 #71|Mistfire Weaver|U|KTK
 #72|Tuskguard Captain|U|KTK
 #73|Meandering Towershell|R|KTK
-#74|Mer Ek Nightblade|U|KTK
+#74|Mer-Ek Nightblade|U|KTK
 #75|Ruthless Ripper|U|KTK
 #76|Deflecting Palm|R|KTK
 #77|Mardu Charm|U|KTK
@@ -85,7 +85,7 @@
 #84|Hordeling Outburst|U|KTK
 #85|Riverwheel Aerialists|U|KTK
 #86|Winterflame|U|KTK
-#87|War Name Aspirant|U|KTK
+#87|War-Name Aspirant|U|KTK
 #88|Incremental Growth|U|KTK
 #89|Watcher of the Roost|U|KTK
 #90|Jeskai Charm|U|KTK
@@ -94,7 +94,7 @@
 #93|Rakshasa Vizier|R|KTK
 #94|Sandsteppe Citadel|U|KTK
 #95|Sultai Charm|U|KTK
-#96|Kin Tree Invocation|U|KTK
+#96|Kin-Tree Invocation|U|KTK
 #97|Nomad Outpost|U|KTK
 #98|Bear's Companion|U|KTK
 #99|Monastery Swiftspear|U|KTK
@@ -103,7 +103,7 @@
 #102|Mystic Monastery|U|KTK
 #103|Frontier Bivouac|U|KTK
 #104|Temur Charm|U|KTK
-#105|Ainok Bond Kin|C|KTK
+#105|Ainok Bond-Kin|C|KTK
 #106|Swarm of Bloodflies|U|KTK
 #107|Sultai Ascendancy|R|KTK
 #108|Jeskai Elder|U|KTK
@@ -141,7 +141,7 @@
 #140|Bring Low|C|KTK
 #141|Hooting Mandrills|C|KTK
 #142|Gurmag Swiftwing|U|KTK
-#143|Wind Scarred Crag|C|KTK
+#143|Wind-Scarred Crag|C|KTK
 #144|Alpine Grizzly|C|KTK
 #145|Force Away|C|KTK
 #146|Ponyback Brigade|C|KTK
@@ -174,7 +174,7 @@
 #173|Despise|U|KTK
 #174|Tranquil Cove|C|KTK
 #175|Rite of the Serpent|C|KTK
-#176|Krumar Bond Kin|C|KTK
+#176|Krumar Bond-Kin|C|KTK
 #177|Rugged Highlands|C|KTK
 #178|Salt Road Patrol|C|KTK
 #179|Rush of Battle|C|KTK
@@ -186,7 +186,7 @@
 #185|Summit Prowler|C|KTK
 #186|Bitter Revelation|C|KTK
 #187|Monastery Flock|C|KTK
-#188|Sage Eye Harrier|C|KTK
+#188|Sage-Eye Harrier|C|KTK
 #189|Smoke Teller|C|KTK
 #190|Trumpet Blast|C|KTK
 #191|Canyon Lurkers|C|KTK
@@ -195,7 +195,7 @@
 #194|Sidisi's Pet|C|KTK
 #195|Act of Treason|C|KTK
 #196|Roar of Challenge|U|KTK
-#197|Kin Tree Warden|C|KTK
+#197|Kin-Tree Warden|C|KTK
 #198|Scaldkin|C|KTK
 #199|Shambling Attendants|C|KTK
 #200|War Behemoth|C|KTK
@@ -244,7 +244,7 @@
 #243|Lens of Clarity|C|KTK
 #244|Briber's Purse|U|KTK
 #245|Altar of the Brood|R|KTK
-#246|Heart Piercer Bow|U|KTK
+#246|Heart-Piercer Bow|U|KTK
 #247|Tomb of the Spirit Dragon|U|KTK
 #248|Cranial Archive|U|KTK
 #249|Ugin's Nexus|M|KTK

--- a/forge-gui/res/draft/rankings/lci.rnk
+++ b/forge-gui/res/draft/rankings/lci.rnk
@@ -221,7 +221,7 @@
 #220|Ancestral Reminiscence|C|LCI
 #221|Thousand Moons Crackshot|C|LCI
 #222|Didact Echo|C|LCI
-#223|Bartolome del Presidio|U|LCI
+#223|Bartolomé del Presidio|U|LCI
 #224|Amalia Benavides Aguirre|R|LCI
 #225|Hurl into History|U|LCI
 #226|Runaway Boulder|C|LCI

--- a/forge-gui/res/draft/rankings/lea.rnk
+++ b/forge-gui/res/draft/rankings/lea.rnk
@@ -47,7 +47,7 @@
 #46|Winter Orb|R|LEA
 #47|Volcanic Island|R|LEA
 #48|Two-Headed Giant of Foriys|R|LEA
-#49|Will o' the Wisp|R|LEA
+#49|Will-o'-the-Wisp|R|LEA
 #50|Granite Gargoyle|R|LEA
 #51|Lord of the Pit|R|LEA
 #52|Birds of Paradise|R|LEA

--- a/forge-gui/res/draft/rankings/leb.rnk
+++ b/forge-gui/res/draft/rankings/leb.rnk
@@ -109,7 +109,7 @@
 #108|Regrowth|U|LEB
 #109|Craw Wurm|C|LEB
 #110|Pestilence|C|LEB
-#111|Will o' the Wisp|R|LEB
+#111|Will-o'-the-Wisp|R|LEB
 #112|Water Elemental|U|LEB
 #113|Braingeyser|R|LEB
 #114|Gaea's Liege|R|LEB

--- a/forge-gui/res/draft/rankings/leg.rnk
+++ b/forge-gui/res/draft/rankings/leg.rnk
@@ -13,7 +13,7 @@
 #12|Sylvan Library|U|LEG
 #13|Tor Wauki|U|LEG
 #14|Lesser Werewolf|U|LEG
-#15|Evil Eye of Orms by Gore|U|LEG
+#15|Evil Eye of Orms-by-Gore|U|LEG
 #16|Sunastian Falconer|U|LEG
 #17|Hazezon Tamar|R|LEG
 #18|Beasts of Bogardan|U|LEG

--- a/forge-gui/res/draft/rankings/lrw.rnk
+++ b/forge-gui/res/draft/rankings/lrw.rnk
@@ -19,7 +19,7 @@
 #18|Mistbind Clique|R|LRW
 #19|Cryptic Command|R|LRW
 #20|Cloudthresher|R|LRW
-#21|Nath of the Gilt Leaf|R|LRW
+#21|Nath of the Gilt-Leaf|R|LRW
 #22|Wydwen, the Biting Gale|R|LRW
 #23|Purity|R|LRW
 #24|Cairn Wanderer|R|LRW
@@ -80,7 +80,7 @@
 #79|Avian Changeling|C|LRW
 #80|Hoofprints of the Stag|R|LRW
 #81|Ghostly Changeling|U|LRW
-#82|Jagged Scar Archers|U|LRW
+#82|Jagged-Scar Archers|U|LRW
 #83|Fallowsage|U|LRW
 #84|Hamletback Goliath|R|LRW
 #85|Aethersnipe|C|LRW
@@ -120,7 +120,7 @@
 #119|Flamekin Harbinger|U|LRW
 #120|Smokebraider|C|LRW
 #121|Kinsbaile Balloonist|C|LRW
-#122|Gilt Leaf Ambush|C|LRW
+#122|Gilt-Leaf Ambush|C|LRW
 #123|Treefolk Harbinger|U|LRW
 #124|Wanderwine Prophets|R|LRW
 #125|Arbiter of Knollridge|R|LRW
@@ -129,7 +129,7 @@
 #128|Vivid Creek|U|LRW
 #129|Battlewand Oak|C|LRW
 #130|Hornet Harasser|C|LRW
-#131|Inner Flame Igniter|U|LRW
+#131|Inner-Flame Igniter|U|LRW
 #132|Ethereal Whiskergill|U|LRW
 #133|Vivid Grove|U|LRW
 #134|Whirlpool Whelm|C|LRW
@@ -137,24 +137,24 @@
 #136|Vivid Meadow|U|LRW
 #137|Kithkin Greatheart|C|LRW
 #138|Spellstutter Sprite|C|LRW
-#139|Blind Spot Giant|C|LRW
+#139|Blind-Spot Giant|C|LRW
 #140|Consuming Bonfire|C|LRW
 #141|Amoeboid Changeling|C|LRW
 #142|Stinkdrinker Daredevil|C|LRW
 #143|Vivid Crag|U|LRW
 #144|Skeletal Changeling|C|LRW
-#145|Gilt Leaf Palace|R|LRW
+#145|Gilt-Leaf Palace|R|LRW
 #146|Wanderwine Hub|R|LRW
 #147|Fertile Ground|C|LRW
 #148|Wings of Velis Vel|C|LRW
 #149|Nath's Elite|C|LRW
-#150|Fire Belly Changeling|C|LRW
+#150|Fire-Belly Changeling|C|LRW
 #151|Windbrisk Heights|R|LRW
 #152|Knucklebone Witch|R|LRW
 #153|Judge of Currents|C|LRW
 #154|Forced Fruition|R|LRW
 #155|Glen Elendra Pranksters|U|LRW
-#156|Inner Flame Acolyte|C|LRW
+#156|Inner-Flame Acolyte|C|LRW
 #157|Shimmering Grotto|C|LRW
 #158|Ponder|C|LRW
 #159|Wanderer's Twig|C|LRW
@@ -178,17 +178,17 @@
 #177|Ancient Amphitheater|R|LRW
 #178|Ceaseless Searblades|U|LRW
 #179|Inkfathom Divers|C|LRW
-#180|Adder Staff Boggart|C|LRW
+#180|Adder-Staff Boggart|C|LRW
 #181|Flamekin Bladewhirl|U|LRW
 #182|Horde of Notions|R|LRW
 #183|Soulbright Flamekin|C|LRW
 #184|Surge of Thoughtweft|C|LRW
-#185|Bog Strider Ash|C|LRW
+#185|Bog-Strider Ash|C|LRW
 #186|Goatnapper|U|LRW
 #187|Footbottom Feast|C|LRW
 #188|Elvish Promenade|U|LRW
 #189|Hillcomber Giant|C|LRW
-#190|Boggart Sprite Chaser|C|LRW
+#190|Boggart Sprite-Chaser|C|LRW
 #191|Faerie Trickery|C|LRW
 #192|Blades of Velis Vel|C|LRW
 #193|Hearthcage Giant|U|LRW
@@ -202,17 +202,17 @@
 #201|Familiar's Ruse|U|LRW
 #202|Mournwhelk|C|LRW
 #203|Crush Underfoot|U|LRW
-#204|Burrenton Forge Tender|U|LRW
+#204|Burrenton Forge-Tender|U|LRW
 #205|Guardian of Cloverdell|U|LRW
 #206|Shelldock Isle|R|LRW
 #207|Mosswort Bridge|R|LRW
 #208|Kithkin Healer|C|LRW
 #209|Spiderwig Boggart|C|LRW
 #210|Lys Alana Scarblade|U|LRW
-#211|Hurly Burly|C|LRW
+#211|Hurly-Burly|C|LRW
 #212|Nightshade Stinger|C|LRW
 #213|Oakgnarl Warrior|C|LRW
-#214|Gilt Leaf Seer|C|LRW
+#214|Gilt-Leaf Seer|C|LRW
 #215|Ego Erasure|U|LRW
 #216|Tideshaper Mystic|C|LRW
 #217|Oaken Brawler|C|LRW
@@ -226,7 +226,7 @@
 #225|Black Poplar Shaman|C|LRW
 #226|Merrow Commerce|U|LRW
 #227|Sentry Oak|U|LRW
-#228|Quill Slinger Boggart|C|LRW
+#228|Quill-Slinger Boggart|C|LRW
 #229|Lairwatch Giant|C|LRW
 #230|Boggart Birth Rite|C|LRW
 #231|Ringskipper|C|LRW
@@ -239,11 +239,11 @@
 #238|Flamekin Brawler|C|LRW
 #239|Faultgrinder|C|LRW
 #240|Lace with Moonglove|C|LRW
-#241|Thousand Year Elixir|R|LRW
+#241|Thousand-Year Elixir|R|LRW
 #242|Facevaulter|C|LRW
 #243|Rootgrapple|C|LRW
 #244|Nath's Buffoon|C|LRW
-#245|Warren Scourge Elf|C|LRW
+#245|Warren-Scourge Elf|C|LRW
 #246|Needle Drop|C|LRW
 #247|Ingot Chewer|C|LRW
 #248|Scarred Vinebreeder|C|LRW

--- a/forge-gui/res/draft/rankings/ltr.rnk
+++ b/forge-gui/res/draft/rankings/ltr.rnk
@@ -1,21 +1,21 @@
 //Rank|Name|Rarity|Set
-#1|Witch-King of Angmar|M|LTR
+#1|Witch-king of Angmar|M|LTR
 #2|Horn of Gondor|R|LTR
 #3|Faramir, Prince of Ithilien|R|LTR
-#4|Anduril, Flame of the West|M|LTR
+#4|Andúril, Flame of the West|M|LTR
 #5|Spiteful Banditry|M|LTR
 #6|Orcish Bowmasters|R|LTR
 #7|Sauron, the Dark Lord|M|LTR
 #8|Arwen, Mortal Queen|M|LTR
-#9|Eomer, Marshal of Rohan|R|LTR
+#9|Éomer, Marshal of Rohan|R|LTR
 #10|Rangers of Ithilien|R|LTR
 #11|Aragorn, the Uniter|M|LTR
 #12|Shelob, Child of Ungoliant|R|LTR
 #13|Boromir, Warden of the Tower|R|LTR
 #14|Gandalf the Grey|R|LTR
 #15|Frodo, Sauron's Bane|R|LTR
-#16|Eowyn, Fearless Knight|R|LTR
-#17|Nazgul|U|LTR
+#16|Éowyn, Fearless Knight|R|LTR
+#17|Nazgûl|U|LTR
 #18|Samwise Gamgee|R|LTR
 #19|Call of the Ring|R|LTR
 #20|King of the Oathbreakers|R|LTR
@@ -32,17 +32,17 @@
 #31|Bitter Downfall|U|LTR
 #32|Fear, Fire, Foes!|U|LTR
 #33|Flowering of the White Tree|R|LTR
-#34|Theoden, King of Rohan|U|LTR
+#34|Théoden, King of Rohan|U|LTR
 #35|Gandalf's Sanction|U|LTR
 #36|Sauron's Ransom|R|LTR
 #37|Rosie Cotton of South Lane|U|LTR
-#38|Mauhur, Uruk-hai Captain|U|LTR
+#38|Mauhúr, Uruk-hai Captain|U|LTR
 #39|Bilbo, Retired Burglar|U|LTR
 #40|Fiery Inscription|U|LTR
 #41|The Mouth of Sauron|U|LTR
-#42|Smeagol, Helpful Guide|R|LTR
+#42|Sméagol, Helpful Guide|R|LTR
 #43|Denethor, Ruling Steward|U|LTR
-#44|Eomer of the Riddermark|U|LTR
+#44|Éomer of the Riddermark|U|LTR
 #45|Saruman of Many Colors|M|LTR
 #46|Gothmog, Morgul Lieutenant|U|LTR
 #47|Pippin, Guard of the Citadel|R|LTR
@@ -52,7 +52,7 @@
 #51|Shadowfax, Lord of Horses|U|LTR
 #52|Book of Mazarbul|U|LTR
 #53|March from the Black Gate|U|LTR
-#54|Palantir of Orthanc|M|LTR
+#54|Palantír of Orthanc|M|LTR
 #55|Shadow Summoning|U|LTR
 #56|Old Man Willow|U|LTR
 #57|Rally at the Hornburg|C|LTR
@@ -60,7 +60,7 @@
 #59|Aragorn, Company Leader|R|LTR
 #60|Ranger's Firebrand|U|LTR
 #61|The Torment of Gollum|C|LTR
-#62|Grishnakh, Brash Instigator|U|LTR
+#62|Grishnákh, Brash Instigator|U|LTR
 #63|Prince Imrahil the Fair|U|LTR
 #64|Smite the Deathless|C|LTR
 #65|Dunland Crebain|C|LTR
@@ -75,7 +75,7 @@
 #74|Generous Ent|C|LTR
 #75|Many Partings|C|LTR
 #76|Minas Tirith|R|LTR
-#77|Barad-dur|R|LTR
+#77|Barad-dûr|R|LTR
 #78|Goblin Fireleaper|U|LTR
 #79|Swarming of Moria|C|LTR
 #80|Saruman's Trickery|U|LTR
@@ -84,21 +84,21 @@
 #83|Merry, Esquire of Rohan|R|LTR
 #84|Delighted Halfling|R|LTR
 #85|Stern Scolding|U|LTR
-#86|Eowyn, Lady of Rohan|U|LTR
+#86|Éowyn, Lady of Rohan|U|LTR
 #87|Scroll of Isildur|R|LTR
 #88|Shire Shirriff|U|LTR
 #89|Erkenbrand, Lord of Westfold|U|LTR
 #90|Horses of the Bruinen|U|LTR
 #91|Birthday Escape|C|LTR
-#92|Soothing of Smeagol|C|LTR
+#92|Soothing of Sméagol|C|LTR
 #93|Glorious Gale|C|LTR
 #94|Haunt of the Dead Marshes|C|LTR
 #95|Mordor Muster|C|LTR
 #96|Improvised Club|C|LTR
 #97|Stew the Coneys|U|LTR
 #98|Wose Pathfinder|C|LTR
-#99|Gloin, Dwarf Emissary|R|LTR
-#100|Troll of Khazad-dum|C|LTR
+#99|Glóin, Dwarf Emissary|R|LTR
+#100|Troll of Khazad-dûm|C|LTR
 #101|Phial of Galadriel|R|LTR
 #102|Battle-Scarred Goblin|C|LTR
 #103|Fall of Cair Andros|R|LTR
@@ -129,11 +129,11 @@
 #128|Took Reaper|C|LTR
 #129|The Battle of Bywater|R|LTR
 #130|Warbeast of Gorgoroth|C|LTR
-#131|Arwen Undomiel|U|LTR
+#131|Arwen Undómiel|U|LTR
 #132|Eagles of the North|C|LTR
 #133|Lembas|C|LTR
 #134|Pelargir Survivor|C|LTR
-#135|Lorien Revealed|C|LTR
+#135|Lórien Revealed|C|LTR
 #136|Isolation at Orthanc|C|LTR
 #137|Deceive the Messenger|C|LTR
 #138|Haradrim Spearmaster|C|LTR
@@ -142,13 +142,13 @@
 #141|Westfold Rider|C|LTR
 #142|Legolas, Master Archer|R|LTR
 #143|Quickbeam, Upstart Ent|U|LTR
-#144|Grima Wormtongue|U|LTR
+#144|Gríma Wormtongue|U|LTR
 #145|Mirrormere Guardian|C|LTR
 #146|Doors of Durin|R|LTR
 #147|Mordor Trebuchet|C|LTR
 #148|Eastfarthing Farmer|C|LTR
-#149|Dunedain Blade|C|LTR
-#150|Ugluk of the White Hand|U|LTR
+#149|Dúnedain Blade|C|LTR
+#150|Uglúk of the White Hand|U|LTR
 #151|Shire Terrace|C|LTR
 #152|Treason of Isengard|C|LTR
 #153|Lobelia Sackville-Baggins|R|LTR
@@ -157,13 +157,13 @@
 #156|Moria Marauder|R|LTR
 #157|Grond, the Gatebreaker|U|LTR
 #158|Legolas, Counter of Kills|U|LTR
-#159|Rise of the Witch-King|U|LTR
+#159|Rise of the Witch-king|U|LTR
 #160|Barrow-Blade|U|LTR
 #161|Meneldor, Swift Savior|U|LTR
 #162|Shagrat, Loot Bearer|R|LTR
 #163|Elrond, Lord of Rivendell|U|LTR
 #164|Lost to Legend|U|LTR
-#165|Dunedain Rangers|U|LTR
+#165|Dúnedain Rangers|U|LTR
 #166|Celeborn the Wise|U|LTR
 #167|Elrond, Master of Healing|R|LTR
 #168|Glamdring|M|LTR
@@ -188,7 +188,7 @@
 #187|Nasty End|C|LTR
 #188|Bombadil's Song|C|LTR
 #189|Wizard's Rockets|C|LTR
-#190|Tale of Tinuviel|U|LTR
+#190|Tale of Tinúviel|U|LTR
 #191|Morgul-Knife Wound|C|LTR
 #192|Gwaihir the Windlord|U|LTR
 #193|Gimli's Fury|C|LTR
@@ -196,7 +196,7 @@
 #195|Slip On the Ring|C|LTR
 #196|Surrounded by Orcs|C|LTR
 #197|Breaking of the Fellowship|C|LTR
-#198|Galadriel of Lothlorien|R|LTR
+#198|Galadriel of Lothlórien|R|LTR
 #199|Lash of the Balrog|C|LTR
 #200|Stalwarts of Osgiliath|C|LTR
 #201|Soldier of the Grey Host|C|LTR
@@ -245,7 +245,7 @@
 #244|The Grey Havens|U|LTR
 #245|Captain of Umbar|C|LTR
 #246|Elven Farsight|C|LTR
-#247|Lothlorien Lookout|C|LTR
+#247|Lothlórien Lookout|C|LTR
 #248|Forge Anew|R|LTR
 #249|Long List of the Ents|U|LTR
 #250|You Cannot Pass!|U|LTR

--- a/forge-gui/res/draft/rankings/m10.rnk
+++ b/forge-gui/res/draft/rankings/m10.rnk
@@ -1,7 +1,7 @@
 //Rank|Name|Rarity|Set
 #1|Captain of the Watch|R|M10
 #2|Shivan Dragon|R|M10
-#3|Siege Gang Commander|R|M10
+#3|Siege-Gang Commander|R|M10
 #4|Earthquake|R|M10
 #5|Ant Queen|R|M10
 #6|Djinn of Wishes|R|M10

--- a/forge-gui/res/draft/rankings/m12.rnk
+++ b/forge-gui/res/draft/rankings/m12.rnk
@@ -22,7 +22,7 @@
 #21|Royal Assassin|R|M12
 #22|Solemn Simulacrum|R|M12
 #23|Djinn of Wishes|R|M12
-#24|Rune Scarred Demon|R|M12
+#24|Rune-Scarred Demon|R|M12
 #25|Sphinx of Uthuun|R|M12
 #26|Pentavus|R|M12
 #27|Grim Lavamancer|R|M12

--- a/forge-gui/res/draft/rankings/m13.rnk
+++ b/forge-gui/res/draft/rankings/m13.rnk
@@ -1,24 +1,24 @@
 //Rank|Name|Rarity|Set
-#1|Ajani Caller of the Pride|M|M13
-#2|Garruk Primal Hunter|M|M13
-#3|Jace Memory Adept|M|M13
+#1|Ajani, Caller of the Pride|M|M13
+#2|Garruk, Primal Hunter|M|M13
+#3|Jace, Memory Adept|M|M13
 #4|Thundermaw Hellkite|M|M13
 #5|Sublime Archangel|M|M13
 #6|Liliana of the Dark Realms|M|M13
 #7|Primordial Hydra|M|M13
-#8|Chandra the Firebrand|M|M13
-#9|Akromas Memorial|M|M13
+#8|Chandra, the Firebrand|M|M13
+#9|Akroma's Memorial|M|M13
 #10|Elderscale Wurm|M|M13
-#11|Nicol Bolas Planeswalker|M|M13
+#11|Nicol Bolas, Planeswalker|M|M13
 #12|Vampire Nocturnus|M|M13
 #13|Serra Avatar|M|M13
-#14|Nefarox Overlord of Grixis|R|M13
+#14|Nefarox, Overlord of Grixis|R|M13
 #15|Thragtusk|R|M13
-#16|Odric Master Tactician|R|M13
+#16|Odric, Master Tactician|R|M13
 #17|Captain of the Watch|R|M13
-#18|Talrand Sky Summoner|R|M13
-#19|Krenko Mob Boss|R|M13
-#20|Yeva Natures Herald|R|M13
+#18|Talrand, Sky Summoner|R|M13
+#19|Krenko, Mob Boss|R|M13
+#20|Yeva, Nature's Herald|R|M13
 #21|Staff of Nin|R|M13
 #22|Xathrid Gorgon|R|M13
 #23|Silklash Spider|R|M13
@@ -35,7 +35,7 @@
 #34|Disciple of Bolas|R|M13
 #35|Magmaquake|R|M13
 #36|Flames of the Firebrand|U|M13
-#37|Talrands Invocation|U|M13
+#37|Talrand's Invocation|U|M13
 #38|Intrepid Hero|R|M13
 #39|Shimian Specter|R|M13
 #40|Sands of Delirium|R|M13
@@ -45,7 +45,7 @@
 #44|Knight of Glory|U|M13
 #45|Cathedral of War|R|M13
 #46|Volcanic Geyser|U|M13
-#47|Garruks Packleader|U|M13
+#47|Garruk's Packleader|U|M13
 #48|Public Execution|U|M13
 #49|Acidic Slime|U|M13
 #50|Murder|C|M13
@@ -80,7 +80,7 @@
 #79|Sentinel Spider|C|M13
 #80|Attended Knight|C|M13
 #81|Mwonvuli Beast Tracker|U|M13
-#82|Jaces Phantasm|U|M13
+#82|Jace's Phantasm|U|M13
 #83|Prized Elephant|U|M13
 #84|Chronomaton|U|M13
 #85|Bloodhunter Bat|C|M13
@@ -99,7 +99,7 @@
 #98|Hellion Crucible|R|M13
 #99|Evolving Wilds|C|M13
 #100|Mindclaw Shaman|U|M13
-#101|Duty Bound Dead|C|M13
+#101|Duty-Bound Dead|C|M13
 #102|Servant of Nefarox|C|M13
 #103|Arbor Elf|C|M13
 #104|Giant Scorpion|C|M13
@@ -113,25 +113,25 @@
 #112|Timberpack Wolf|C|M13
 #113|Primal Huntbeast|C|M13
 #114|Turn to Slag|C|M13
-#115|Faiths Reward|R|M13
+#115|Faith's Reward|R|M13
 #116|Primal Clay|U|M13
 #117|Welkin Tern|C|M13
 #118|Mark of Mutiny|U|M13
 #119|Mogg Flunkies|C|M13
 #120|Faerie Invaders|C|M13
 #121|Omniscience|M|M13
-#122|Captains Call|C|M13
+#122|Captain's Call|C|M13
 #123|Wind Drake|C|M13
 #124|Guardians of Akrasa|C|M13
-#125|Ajanis Sunstriker|C|M13
+#125|Ajani's Sunstriker|C|M13
 #126|Archaeomancer|C|M13
 #127|Phylactery Lich|R|M13
 #128|Ring of Thune|U|M13
-#129|Krenkos Command|C|M13
+#129|Krenko's Command|C|M13
 #130|Essence Scatter|C|M13
 #131|Unsummon|C|M13
 #132|Farseek|C|M13
-#133|Yevas Forcemage|C|M13
+#133|Yeva's Forcemage|C|M13
 #134|Spelltwine|R|M13
 #135|Kitesail|U|M13
 #136|Goblin Arsonist|C|M13
@@ -140,7 +140,7 @@
 #139|Ravenous Rats|C|M13
 #140|Diabolic Revelation|R|M13
 #141|Divination|C|M13
-#142|Lilianas Shade|C|M13
+#142|Liliana's Shade|C|M13
 #143|Encrust|C|M13
 #144|Titanic Growth|C|M13
 #145|Scroll Thief|C|M13
@@ -150,7 +150,7 @@
 #149|War Falcon|C|M13
 #150|Rewind|U|M13
 #151|Crippling Blight|C|M13
-#152|Chandras Fury|C|M13
+#152|Chandra's Fury|C|M13
 #153|Torch Fiend|U|M13
 #154|Ring of Evos Isle|U|M13
 #155|Battleflight Eagle|C|M13
@@ -190,7 +190,7 @@
 #189|Downpour|C|M13
 #190|Vile Rebirth|C|M13
 #191|Divine Favor|C|M13
-#192|Rangers Path|C|M13
+#192|Ranger's Path|C|M13
 #193|Courtly Provocateur|U|M13
 #194|Trumpet Blast|C|M13
 #195|Glorious Charge|C|M13
@@ -205,7 +205,7 @@
 #204|Disentomb|C|M13
 #205|Wall of Fire|C|M13
 #206|Wild Guess|C|M13
-#207|Serpents Gift|C|M13
+#207|Serpent's Gift|C|M13
 #208|Rain of Blades|U|M13
 #209|Revive|U|M13
 #210|Cleaver Riot|U|M13
@@ -216,15 +216,15 @@
 #215|Hydrosurge|C|M13
 #216|Smelt|C|M13
 #217|Craterize|C|M13
-#218|Angels Mercy|C|M13
+#218|Angel's Mercy|C|M13
 #219|Gem of Becoming|U|M13
 #220|Bountiful Harvest|C|M13
 #221|Ground Seal|R|M13
 #222|Boundless Realms|R|M13
 #223|Touch of the Eternal|R|M13
 #224|Reliquary Tower|U|M13
-#225|Wits End|R|M13
-#226|Tormods Crypt|U|M13
+#225|Wit's End|R|M13
+#226|Tormod's Crypt|U|M13
 #227|Door to Nothingness|R|M13
 #228|Battle of Wits|R|M13
 #229|Clock of Omens|U|M13

--- a/forge-gui/res/draft/rankings/m14.rnk
+++ b/forge-gui/res/draft/rankings/m14.rnk
@@ -1,10 +1,10 @@
 //Rank|Name|Rarity|Set
-#1|Ajani Caller of the Pride|M|M14
-#2|Jace Memory Adept|M|M14
+#1|Ajani, Caller of the Pride|M|M14
+#2|Jace, Memory Adept|M|M14
 #3|Archangel of Thune|M|M14
 #4|Kalonian Hydra|M|M14
-#5|Chandra Pyromaster|M|M14
-#6|Garruk Caller of Beasts|M|M14
+#5|Chandra, Pyromaster|M|M14
+#6|Garruk, Caller of Beasts|M|M14
 #7|Liliana of the Dark Realms|M|M14
 #8|Shadowborn Demon|M|M14
 #9|Primeval Bounty|M|M14

--- a/forge-gui/res/draft/rankings/m15.rnk
+++ b/forge-gui/res/draft/rankings/m15.rnk
@@ -3,11 +3,11 @@
 #2|Soul of New Phyrexia|M|M15
 #3|Soul of Shandalar|M|M15
 #4|Soul of Theros|M|M15
-#5|Chandra Pyromaster|M|M15
-#6|Garruk Apex Predator|M|M15
-#7|Nissa Worldwaker|M|M15
+#5|Chandra, Pyromaster|M|M15
+#6|Garruk, Apex Predator|M|M15
+#7|Nissa, Worldwaker|M|M15
 #8|Soul of Zendikar|M|M15
-#9|Jace the Living Guildpact|M|M15
+#9|Jace, the Living Guildpact|M|M15
 #10|Soul of Innistrad|M|M15
 #11|Soul of Ravnica|M|M15
 #12|Liliana Vess|M|M15
@@ -15,11 +15,11 @@
 #14|Sliver Hivelord|M|M15
 #15|Scuttling Doom Engine|R|M15
 #16|Indulgent Tormentor|R|M15
-#17|Avacyn Guardian Angel|R|M15
+#17|Avacyn, Guardian Angel|R|M15
 #18|Spectra Ward|R|M15
 #19|Hornet Queen|R|M15
 #20|Master of Predicaments|R|M15
-#21|Ob Nixilis Unshackled|R|M15
+#21|Ob Nixilis, Unshackled|R|M15
 #22|Siege Dragon|R|M15
 #23|Hoarding Dragon|R|M15
 #24|Resolute Archangel|R|M15
@@ -27,13 +27,13 @@
 #26|Kalonian Twingrove|R|M15
 #27|Genesis Hydra|R|M15
 #28|Chasm Skulker|R|M15
-#29|Polymorphists Jest|R|M15
+#29|Polymorphist's Jest|R|M15
 #30|Goblin Rabblemaster|R|M15
 #31|Spirit Bonds|R|M15
 #32|Burning Anger|R|M15
 #33|Aetherspouts|R|M15
 #34|Hornet Nest|R|M15
-#35|Yisan the Wanderer Bard|R|M15
+#35|Yisan, the Wanderer Bard|R|M15
 #36|Chord of Calling|R|M15
 #37|Phytotitan|R|M15
 #38|Preeminent Captain|R|M15
@@ -47,11 +47,11 @@
 #46|Illusory Angel|U|M15
 #47|Stormtide Leviathan|R|M15
 #48|Heat Ray|U|M15
-#49|Urborg Tomb of Yawgmoth|R|M15
-#50|Kurkesh Onakke Ancient|R|M15
+#49|Urborg, Tomb of Yawgmoth|R|M15
+#50|Kurkesh, Onakke Ancient|R|M15
 #51|Necrogen Scudder|U|M15
 #52|Waste Not|R|M15
-#53|Jalira Master Polymorphist|R|M15
+#53|Jalira, Master Polymorphist|R|M15
 #54|Return to the Ranks|R|M15
 #55|Mass Calcify|R|M15
 #56|Ancient Silverback|U|M15
@@ -61,7 +61,7 @@
 #60|Obelisk of Urd|R|M15
 #61|Quickling|U|M15
 #62|Ulcerate|U|M15
-#63|In Garruks Wake|R|M15
+#63|In Garruk's Wake|R|M15
 #64|Mercurial Pretender|R|M15
 #65|Paragon of Open Graves|U|M15
 #66|Paragon of Fierce Defiance|U|M15
@@ -72,12 +72,12 @@
 #71|Sliver Hive|R|M15
 #72|Xathrid Slyblade|U|M15
 #73|Nightfire Giant|U|M15
-#74|Ajanis Pridemate|U|M15
+#74|Ajani's Pridemate|U|M15
 #75|Shield of the Avatar|R|M15
 #76|Turn to Frog|U|M15
 #77|Paragon of Eternal Wilds|U|M15
-#78|Jaces Ingenuity|U|M15
-#79|Lifes Legacy|R|M15
+#78|Jace's Ingenuity|U|M15
+#79|Life's Legacy|R|M15
 #80|Juggernaut|U|M15
 #81|Grindclock|R|M15
 #82|Brood Keeper|U|M15
@@ -87,7 +87,7 @@
 #86|Yavimaya Coast|R|M15
 #87|Shivan Reef|R|M15
 #88|Phyrexian Revoker|R|M15
-#89|Necromancers Stockpile|R|M15
+#89|Necromancer's Stockpile|R|M15
 #90|Feral Incarnation|U|M15
 #91|Reclamation Sage|U|M15
 #92|Roaring Primadox|U|M15
@@ -125,16 +125,16 @@
 #124|Oreskos Swiftclaw|C|M15
 #125|Warden of the Beyond|U|M15
 #126|Dissipate|U|M15
-#127|Rogues Gloves|U|M15
+#127|Rogue's Gloves|U|M15
 #128|Child of Night|C|M15
-#129|Nissas Expedition|U|M15
-#130|Krenkos Enforcer|C|M15
+#129|Nissa's Expedition|U|M15
+#130|Krenko's Enforcer|C|M15
 #131|Belligerent Sliver|U|M15
 #132|Sungrace Pegasus|C|M15
 #133|Accursed Spirit|C|M15
 #134|Carrion Crow|C|M15
 #135|Caustic Tar|U|M15
-#136|Brawlers Plate|U|M15
+#136|Brawler's Plate|U|M15
 #137|The Chain Veil|M|M15
 #138|Shaman of Spring|C|M15
 #139|Typhoid Rats|C|M15
@@ -156,14 +156,14 @@
 #155|Divination|C|M15
 #156|Darksteel Citadel|U|M15
 #157|Invasive Species|C|M15
-#158|Heliods Pilgrim|C|M15
+#158|Heliod's Pilgrim|C|M15
 #159|Void Snare|C|M15
 #160|Sign in Blood|C|M15
 #161|Nimbus of the Isles|C|M15
 #162|Charging Rhino|C|M15
 #163|Wall of Limbs|U|M15
 #164|Aeronaut Tinkerer|C|M15
-#165|Will Forged Golem|C|M15
+#165|Will-Forged Golem|C|M15
 #166|Titanic Growth|C|M15
 #167|Scrapyard Mongrel|C|M15
 #168|Midnight Guard|C|M15
@@ -178,7 +178,7 @@
 #177|Shadowcloak Vampire|C|M15
 #178|Oppressive Rays|C|M15
 #179|Marked by Honor|C|M15
-#180|Tyrants Machine|C|M15
+#180|Tyrant's Machine|C|M15
 #181|Hot Soup|U|M15
 #182|Torch Fiend|C|M15
 #183|Thundering Giant|C|M15
@@ -188,7 +188,7 @@
 #187|Blastfire Bolt|C|M15
 #188|Undergrowth Scavenger|C|M15
 #189|Rummaging Goblin|C|M15
-#190|Crowds Favor|C|M15
+#190|Crowd's Favor|C|M15
 #191|Rotfeaster Maggot|C|M15
 #192|Leeching Sliver|U|M15
 #193|Foundry Street Denizen|C|M15
@@ -197,24 +197,24 @@
 #196|Ephemeral Shields|C|M15
 #197|Satyr Wayfinder|C|M15
 #198|Research Assistant|C|M15
-#199|Necromancers Assistant|C|M15
+#199|Necromancer's Assistant|C|M15
 #200|Sanctified Charge|C|M15
 #201|Mind Rot|C|M15
-#202|Witchs Familiar|C|M15
+#202|Witch's Familiar|C|M15
 #203|Lava Axe|C|M15
 #204|Eternal Thirst|C|M15
 #205|Crippling Blight|C|M15
 #206|Zof Shade|C|M15
 #207|Hammerhand|C|M15
-#208|Carnivorous Moss Beast|C|M15
+#208|Carnivorous Moss-Beast|C|M15
 #209|Soulmender|C|M15
 #210|Divine Favor|C|M15
 #211|Plummet|C|M15
-#212|Rangers Guile|C|M15
+#212|Ranger's Guile|C|M15
 #213|Negate|C|M15
 #214|Unmake the Graves|C|M15
 #215|Festergloom|C|M15
-#216|Miners Bane|C|M15
+#216|Miner's Bane|C|M15
 #217|Mind Sculpt|C|M15
 #218|Glacial Crasher|C|M15
 #219|Radiant Fountain|C|M15
@@ -226,7 +226,7 @@
 #225|Statute of Denial|C|M15
 #226|Solemn Offering|C|M15
 #227|Naturalize|C|M15
-#228|Hunters Ambush|C|M15
+#228|Hunter's Ambush|C|M15
 #229|Vineweft|C|M15
 #230|Invisibility|C|M15
 #231|Diffusion Sliver|U|M15
@@ -241,7 +241,7 @@
 #240|Stain the Mind|R|M15
 #241|Back to Nature|U|M15
 #242|Aggressive Mining|R|M15
-#243|Tormods Crypt|U|M15
+#243|Tormod's Crypt|U|M15
 #244|Crucible of Fire|R|M15
 #245|Staff of the Mind Magus|U|M15
 #246|Staff of the Sun Magus|U|M15

--- a/forge-gui/res/draft/rankings/mbs.rnk
+++ b/forge-gui/res/draft/rankings/mbs.rnk
@@ -29,7 +29,7 @@
 #28|Inkmoth Nexus|R|MBS
 #29|Sangromancer|R|MBS
 #30|Mortarpod|U|MBS
-#31|Flesh Eater Imp|U|MBS
+#31|Flesh-Eater Imp|U|MBS
 #32|Spine of Ish Sah|R|MBS
 #33|Into the Core|U|MBS
 #34|Creeping Corrosion|R|MBS
@@ -42,7 +42,7 @@
 #41|Piston Sledge|U|MBS
 #42|Pierce Strider|U|MBS
 #43|Cryptoplasm|R|MBS
-#44|Leonin Relic Warder|U|MBS
+#44|Leonin Relic-Warder|U|MBS
 #45|Viridian Claw|U|MBS
 #46|Strandwalker|U|MBS
 #47|Skinwing|U|MBS
@@ -84,7 +84,7 @@
 #83|Spin Engine|C|MBS
 #84|Contested War Zone|R|MBS
 #85|Psychosis Crawler|R|MBS
-#86|Gust Skimmer|C|MBS
+#86|Gust-Skimmer|C|MBS
 #87|Steel Sabotage|C|MBS
 #88|Myr Welder|R|MBS
 #89|Rusted Slasher|C|MBS

--- a/forge-gui/res/draft/rankings/me2.rnk
+++ b/forge-gui/res/draft/rankings/me2.rnk
@@ -96,7 +96,7 @@
 #95|Narwhal|U|ME2
 #96|Elvish Hunter|C|ME2
 #97|Imperial Recruiter|R|ME2
-#98|Lim-Dul's High Guard|U|ME2
+#98|Lim-Dûl's High Guard|U|ME2
 #99|Orcish Veteran|C|ME2
 #100|Krovikan Horror|R|ME2
 #101|Elemental Augury|R|ME2

--- a/forge-gui/res/draft/rankings/me4.rnk
+++ b/forge-gui/res/draft/rankings/me4.rnk
@@ -68,7 +68,7 @@
 #67|Horn of Deafening|U|ME4
 #68|Clay Statue|U|ME4
 #69|Detonate|U|ME4
-#70|Junun Efreet|U|ME4
+#70|Junún Efreet|U|ME4
 #71|Savannah|R|ME4
 #72|White Knight|U|ME4
 #73|Gaea's Avenger|U|ME4
@@ -112,7 +112,7 @@
 #111|Symbol of Unsummoning|C|ME4
 #112|Ogre Taskmaster|C|ME4
 #113|Onulet|C|ME4
-#114|Lim-Dul's Cohort|C|ME4
+#114|Lim-Dûl's Cohort|C|ME4
 #115|Obsianus Golem|C|ME4
 #116|Yotian Soldier|C|ME4
 #117|Goblin Cavaliers|C|ME4

--- a/forge-gui/res/draft/rankings/med.rnk
+++ b/forge-gui/res/draft/rankings/med.rnk
@@ -6,14 +6,14 @@
 #5|Lord of Tresserhorn|R|MED
 #6|Feast or Famine|C|MED
 #7|Mirror Universe|R|MED
-#8|Marton Stromgald|R|MED
+#8|Márton Stromgald|R|MED
 #9|Hand of Justice|R|MED
 #10|Autumn Willow|R|MED
-#11|Juzam Djinn|R|MED
+#11|Juzám Djinn|R|MED
 #12|Nevinyrral's Disk|R|MED
 #13|Lightning Bolt|C|MED
 #14|Phelddagrif|R|MED
-#15|Ifh-Biff Efreet|R|MED
+#15|Ifh-Bíff Efreet|R|MED
 #16|Gargantuan Gorilla|R|MED
 #17|Homarid Spawning Bed|U|MED
 #18|Armageddon|R|MED
@@ -21,7 +21,7 @@
 #20|Ball Lightning|R|MED
 #21|Jokulhaups|R|MED
 #22|Polar Kraken|R|MED
-#23|Khabal Ghoul|R|MED
+#23|Khabál Ghoul|R|MED
 #24|Fire Covenant|U|MED
 #25|Icatian Town|U|MED
 #26|Dakkon Blackblade|R|MED
@@ -82,7 +82,7 @@
 #81|Island of Wak-Wak|R|MED
 #82|Winter Orb|R|MED
 #83|Yavimaya Ants|U|MED
-#84|Lim-Dul's Vault|U|MED
+#84|Lim-Dûl's Vault|U|MED
 #85|Ivory Tower|R|MED
 #86|Hecatomb|R|MED
 #87|The Fallen|U|MED
@@ -108,7 +108,7 @@
 #107|Chub Toad|C|MED
 #108|Ankh of Mishra|R|MED
 #109|Nether Shadow|U|MED
-#110|Ghazban Ogre|C|MED
+#110|Ghazbán Ogre|C|MED
 #111|Juxtapose|U|MED
 #112|Thawing Glaciers|R|MED
 #113|Illusionary Wall|C|MED
@@ -122,7 +122,7 @@
 #121|Mana Flare|R|MED
 #122|Cuombajj Witches|C|MED
 #123|Word of Undoing|C|MED
-#124|Ring of Ma'ruf|R|MED
+#124|Ring of Ma'rûf|R|MED
 #125|Goblin Chirurgeon|C|MED
 #126|Telekinesis|C|MED
 #127|Scryb Sprites|C|MED

--- a/forge-gui/res/draft/rankings/mm3.rnk
+++ b/forge-gui/res/draft/rankings/mm3.rnk
@@ -245,6 +245,6 @@
 #244|Blood Moon|R|MM3
 #245|Grafdigger's Cage|R|MM3
 #246|Cavern of Souls|M|MM3
-#247|Seance|R|MM3
+#247|Séance|R|MM3
 #248|Past in Flames|M|MM3
 #249|Pyromancer Ascension|R|MM3

--- a/forge-gui/res/draft/rankings/mma.rnk
+++ b/forge-gui/res/draft/rankings/mma.rnk
@@ -1,19 +1,19 @@
 //Rank|Name|Rarity|Set
 #1|Sword of Fire and Ice|M|MMA
 #2|Sword of Light and Shadow|M|MMA
-#3|Elspeth Knight-Errant|M|MMA
+#3|Elspeth, Knight-Errant|M|MMA
 #4|Kiki-Jiki, Mirror Breaker|M|MMA
-#5|Kokusho the Evening Star|M|MMA
-#6|Keiga the Tide Star|M|MMA
-#7|Yosei the Morning Star|M|MMA
+#5|Kokusho, the Evening Star|M|MMA
+#6|Keiga, the Tide Star|M|MMA
+#7|Yosei, the Morning Star|M|MMA
 #8|Vendilion Clique|M|MMA
 #9|Sarkhan Vol|M|MMA
 #10|Vedalken Shackles|M|MMA
 #11|Tarmogoyf|M|MMA
-#12|Ryusei the Falling Star|M|MMA
+#12|Ryusei, the Falling Star|M|MMA
 #13|Dark Confidant|M|MMA
-#14|Jugan the Rising Star|M|MMA
-#15|Oona Queen of the Fae|R|MMA
+#14|Jugan, the Rising Star|M|MMA
+#15|Oona, Queen of the Fae|R|MMA
 #16|Cryptic Command|R|MMA
 #17|Progenitus|M|MMA
 #18|Meloku the Clouded Mirror|R|MMA
@@ -26,7 +26,7 @@
 #25|Glen Elendra Archmage|R|MMA
 #26|Skeletal Vampire|R|MMA
 #27|Demigod of Revenge|R|MMA
-#28|Kira Great Glass-Spinner|R|MMA
+#28|Kira, Great Glass-Spinner|R|MMA
 #29|Maelstrom Pulse|R|MMA
 #30|Knight of the Reliquary|R|MMA
 #31|Tombstalker|R|MMA
@@ -72,7 +72,7 @@
 #71|Sudden Shock|U|MMA
 #72|Epochrasite|U|MMA
 #73|Feudkiller's Verdict|U|MMA
-#74|Kataki War's Wage|R|MMA
+#74|Kataki, War's Wage|R|MMA
 #75|Manamorphose|U|MMA
 #76|Summoner's Pact|R|MMA
 #77|Rift Bolt|C|MMA
@@ -85,7 +85,7 @@
 #84|Death Cloud|R|MMA
 #85|Bonesplitter|C|MMA
 #86|Glimmervoid|R|MMA
-#87|Squee Goblin Nabob|R|MMA
+#87|Squee, Goblin Nabob|R|MMA
 #88|Chalice of the Void|R|MMA
 #89|Glacial Ray|C|MMA
 #90|Bound in Silence|C|MMA

--- a/forge-gui/res/draft/rankings/mor.rnk
+++ b/forge-gui/res/draft/rankings/mor.rnk
@@ -14,15 +14,15 @@
 #13|Vendilion Clique|R|MOR
 #14|Mutavault|R|MOR
 #15|Violet Pall|C|MOR
-#16|Leaf Crowned Elder|R|MOR
+#16|Leaf-Crowned Elder|R|MOR
 #17|Swell of Courage|U|MOR
-#18|Obsidian Battle Axe|U|MOR
+#18|Obsidian Battle-Axe|U|MOR
 #19|Bramblewood Paragon|U|MOR
 #20|Fendeep Summoner|R|MOR
 #21|Mind Shatter|R|MOR
 #22|Door of Destinies|R|MOR
 #23|Reach of Branches|R|MOR
-#24|Wolf Skull Shaman|U|MOR
+#24|Wolf-Skull Shaman|U|MOR
 #25|Oona's Blackguard|U|MOR
 #26|Hunting Triad|U|MOR
 #27|Nevermaker|U|MOR
@@ -38,7 +38,7 @@
 #37|Burrenton Bombardier|C|MOR
 #38|Weight of Conscience|C|MOR
 #39|Kinsbaile Cavalier|R|MOR
-#40|Game Trail Changeling|C|MOR
+#40|Game-Trail Changeling|C|MOR
 #41|Grimoire Thief|R|MOR
 #42|Vengeful Firebrand|R|MOR
 #43|Cenn's Tactician|U|MOR
@@ -46,7 +46,7 @@
 #45|Weirding Shaman|R|MOR
 #46|Latchkey Faerie|C|MOR
 #47|Stinkdrinker Bandit|U|MOR
-#48|War Spike Changeling|C|MOR
+#48|War-Spike Changeling|C|MOR
 #49|Moonglove Changeling|C|MOR
 #50|Borderland Behemoth|R|MOR
 #51|Sigil Tracer|R|MOR
@@ -78,7 +78,7 @@
 #77|Fencer Clique|C|MOR
 #78|Diviner's Wand|U|MOR
 #79|Order of the Golden Cricket|C|MOR
-#80|Weed Pruner Poplar|C|MOR
+#80|Weed-Pruner Poplar|C|MOR
 #81|Shared Animosity|R|MOR
 #82|Waterspout Weavers|U|MOR
 #83|Walker of the Grove|U|MOR
@@ -90,7 +90,7 @@
 #89|Rustic Clachan|R|MOR
 #90|Elvish Warrior|C|MOR
 #91|Ballyrush Banneret|C|MOR
-#92|Gilt Leaf Archdruid|R|MOR
+#92|Gilt-Leaf Archdruid|R|MOR
 #93|Brighthearth Banneret|C|MOR
 #94|Nightshade Schemers|U|MOR
 #95|Distant Melody|C|MOR
@@ -104,7 +104,7 @@
 #103|Release the Ants|U|MOR
 #104|Ink Dissolver|C|MOR
 #105|Frogtosser Banneret|C|MOR
-#106|Final Sting Faerie|C|MOR
+#106|Final-Sting Faerie|C|MOR
 #107|Knowledge Exploitation|R|MOR
 #108|Noggin Whack|U|MOR
 #109|Maralen of the Mornsong|R|MOR
@@ -132,7 +132,7 @@
 #131|Research the Deep|U|MOR
 #132|Scapeshift|R|MOR
 #133|Lunk Errant|C|MOR
-#134|Burrenton Shield Bearers|C|MOR
+#134|Burrenton Shield-Bearers|C|MOR
 #135|Merrow Witsniper|C|MOR
 #136|Shinewend|C|MOR
 #137|Reins of the Vinesteed|C|MOR

--- a/forge-gui/res/draft/rankings/mrd.rnk
+++ b/forge-gui/res/draft/rankings/mrd.rnk
@@ -4,7 +4,7 @@
 #3|Molder Slug|R|MRD
 #4|Troll Ascetic|R|MRD
 #5|Duplicant|R|MRD
-#6|Arc Slogger|R|MRD
+#6|Arc-Slogger|R|MRD
 #7|Glissa Sunseeker|R|MRD
 #8|Solar Tide|R|MRD
 #9|Bosh, Iron Golem|R|MRD
@@ -94,10 +94,10 @@
 #93|Goblin Replica|C|MRD
 #94|Talisman of Progress|U|MRD
 #95|Seat of the Synod|C|MRD
-#96|Leonin Den Guard|C|MRD
+#96|Leonin Den-Guard|C|MRD
 #97|Slith Firewalker|U|MRD
 #98|Copper Myr|C|MRD
-#99|Taj Nar Swordsmith|U|MRD
+#99|Taj-Nar Swordsmith|U|MRD
 #100|Talisman of Indulgence|U|MRD
 #101|Irradiate|C|MRD
 #102|Leonin Scimitar|C|MRD
@@ -112,7 +112,7 @@
 #111|Bottle Gnomes|U|MRD
 #112|Slith Bloodletter|U|MRD
 #113|Vault of Whispers|C|MRD
-#114|Tel Jilad Archers|C|MRD
+#114|Tel-Jilad Archers|C|MRD
 #115|Talisman of Impulse|U|MRD
 #116|Disciple of the Vault|C|MRD
 #117|Needlebug|U|MRD
@@ -123,7 +123,7 @@
 #122|Fabricate|U|MRD
 #123|Flayed Nim|U|MRD
 #124|Ancient Den|C|MRD
-#125|Tel Jilad Chosen|C|MRD
+#125|Tel-Jilad Chosen|C|MRD
 #126|Goblin Dirigible|U|MRD
 #127|Clockwork Vorrac|U|MRD
 #128|Aether Spellbomb|C|MRD
@@ -139,11 +139,11 @@
 #138|Great Furnace|C|MRD
 #139|Yotian Soldier|C|MRD
 #140|Rust Elemental|U|MRD
-#141|Trolls of Tel Jilad|U|MRD
+#141|Trolls of Tel-Jilad|U|MRD
 #142|Woebearer|U|MRD
 #143|Dragon Blood|U|MRD
 #144|Sun Droplet|U|MRD
-#145|Tel Jilad Exile|C|MRD
+#145|Tel-Jilad Exile|C|MRD
 #146|Fatespinner|R|MRD
 #147|Stalking Stones|U|MRD
 #148|Soldier Replica|C|MRD
@@ -169,11 +169,11 @@
 #168|Myr Incubator|R|MRD
 #169|Lightning Coils|R|MRD
 #170|Necrogen Spellbomb|C|MRD
-#171|Krark Clan Grunt|C|MRD
+#171|Krark-Clan Grunt|C|MRD
 #172|Wail of the Nim|C|MRD
-#173|Tooth of Chiss Goria|C|MRD
+#173|Tooth of Chiss-Goria|C|MRD
 #174|War Elemental|R|MRD
-#175|Golem Skin Gauntlets|U|MRD
+#175|Golem-Skin Gauntlets|U|MRD
 #176|Steel Wall|C|MRD
 #177|Slagwurm Armor|C|MRD
 #178|Neurok Familiar|C|MRD
@@ -187,7 +187,7 @@
 #186|Ornithopter|U|MRD
 #187|Relic Bane|U|MRD
 #188|Wall of Blood|U|MRD
-#189|Scale of Chiss Goria|C|MRD
+#189|Scale of Chiss-Goria|C|MRD
 #190|Elf Replica|C|MRD
 #191|Vermiculos|R|MRD
 #192|Psychic Membrane|U|MRD
@@ -203,7 +203,7 @@
 #202|Worldslayer|R|MRD
 #203|Viridian Joiner|C|MRD
 #204|Tower of Murmurs|R|MRD
-#205|Dead Iron Sledge|U|MRD
+#205|Dead-Iron Sledge|U|MRD
 #206|Extraplanar Lens|R|MRD
 #207|Slith Strider|U|MRD
 #208|Dross Harvester|R|MRD
@@ -232,7 +232,7 @@
 #231|Wanderguard Sentry|C|MRD
 #232|Awe Strike|C|MRD
 #233|Liar's Pendulum|R|MRD
-#234|Krark Clan Shaman|C|MRD
+#234|Krark-Clan Shaman|C|MRD
 #235|Power Conduit|U|MRD
 #236|Vorrac Battlehorns|C|MRD
 #237|Brown Ouphe|C|MRD
@@ -266,7 +266,7 @@
 #265|Necrogen Mists|R|MRD
 #266|Jinxed Choker|R|MRD
 #267|Myr Mindservant|U|MRD
-#268|Tel Jilad Stylus|U|MRD
+#268|Tel-Jilad Stylus|U|MRD
 #269|Disarm|C|MRD
 #270|Rule of Law|R|MRD
 #271|Leveler|R|MRD

--- a/forge-gui/res/draft/rankings/nph.rnk
+++ b/forge-gui/res/draft/rankings/nph.rnk
@@ -20,7 +20,7 @@
 #19|Phyrexian Ingester|R|NPH
 #20|Enslave|U|NPH
 #21|Chancellor of the Annex|R|NPH
-#22|Jin Gitaxias, Core Augur|M|NPH
+#22|Jin-Gitaxias, Core Augur|M|NPH
 #23|Chancellor of the Spires|R|NPH
 #24|Puresteel Paladin|R|NPH
 #25|Spellskite|R|NPH
@@ -98,7 +98,7 @@
 #97|Despise|U|NPH
 #98|Trespassing Souleater|C|NPH
 #99|Mortis Dogs|C|NPH
-#100|Death Hood Cobra|C|NPH
+#100|Death-Hood Cobra|C|NPH
 #101|Shriek Raptor|C|NPH
 #102|Vapor Snag|C|NPH
 #103|Marrow Shards|U|NPH

--- a/forge-gui/res/draft/rankings/po2.rnk
+++ b/forge-gui/res/draft/rankings/po2.rnk
@@ -104,7 +104,7 @@
 #103|False Summoning|C|PO2
 #104|Mind Rot|C|PO2
 #105|Dakmor Scorpion|C|PO2
-#106|Deja Vu|C|PO2
+#106|Déjà Vu|C|PO2
 #107|Extinguish|C|PO2
 #108|Angelic Wall|C|PO2
 #109|Bear Cub|C|PO2

--- a/forge-gui/res/draft/rankings/por.rnk
+++ b/forge-gui/res/draft/rankings/por.rnk
@@ -40,7 +40,7 @@
 #39|Stern Marshal|R|POR
 #40|Armageddon|R|POR
 #41|Mercenary Knight|R|POR
-#42|Man o' War|U|POR
+#42|Man-o'-War|U|POR
 #43|Wall of Swords|U|POR
 #44|Wind Drake|C|POR
 #45|Plant Elemental|U|POR
@@ -136,7 +136,7 @@
 #135|Untamed Wilds|U|POR
 #136|Mind Rot|C|POR
 #137|Moon Sprite|U|POR
-#138|Keen Eyed Archers|C|POR
+#138|Keen-Eyed Archers|C|POR
 #139|Blinding Light|R|POR
 #140|Raging Goblin|C|POR
 #141|Regal Unicorn|C|POR
@@ -145,11 +145,11 @@
 #144|Foot Soldiers|C|POR
 #145|Theft of Dreams|U|POR
 #146|Cloud Pirates|C|POR
-#147|Deep Sea Serpent|U|POR
+#147|Deep-Sea Serpent|U|POR
 #148|Howling Fury|C|POR
 #149|Thing from the Deep|R|POR
 #150|Stone Rain|C|POR
-#151|Deja Vu|C|POR
+#151|Déjà Vu|C|POR
 #152|Sorcerous Sight|C|POR
 #153|Harsh Justice|R|POR
 #154|Knight Errant|C|POR
@@ -177,7 +177,7 @@
 #176|Mountain Goat|U|POR
 #177|Willow Dryad|C|POR
 #178|Mobilize|C|POR
-#179|Fleet Footed Monk|C|POR
+#179|Fleet-Footed Monk|C|POR
 #180|Cruel Fate|R|POR
 #181|Wall of Granite|U|POR
 #182|Devoted Hero|C|POR

--- a/forge-gui/res/draft/rankings/ptk.rnk
+++ b/forge-gui/res/draft/rankings/ptk.rnk
@@ -4,7 +4,7 @@
 #3|Overwhelming Forces|R|PTK
 #4|Sun Quan, Lord of Wu|R|PTK
 #5|Guan Yu, Sainted Warrior|R|PTK
-#6|Lu Bu, Master at Arms|R|PTK
+#6|Lu Bu, Master-at-Arms|R|PTK
 #7|Lu Su, Wu Advisor|R|PTK
 #8|Meng Huo, Barbarian King|R|PTK
 #9|Eightfold Maze|R|PTK
@@ -21,13 +21,13 @@
 #20|Wei Assassins|U|PTK
 #21|Exhaustion|R|PTK
 #22|Cao Cao, Lord of Wei|R|PTK
-#23|Xiahou Dun, the One Eyed|R|PTK
+#23|Xiahou Dun, the One-Eyed|R|PTK
 #24|Ma Chao, Western Warrior|R|PTK
 #25|Capture of Jingzhou|R|PTK
 #26|Diaochan, Artful Beauty|R|PTK
 #27|Hua Tuo, Honored Physician|R|PTK
 #28|Zhang He, Wei General|R|PTK
-#29|Kongming, Sleeping Dragon|R|PTK
+#29|Kongming, "Sleeping Dragon"|R|PTK
 #30|Xun Yu, Wei Advisor|R|PTK
 #31|Lady Sun|R|PTK
 #32|Wolf Pack|R|PTK
@@ -40,7 +40,7 @@
 #39|Lady Zhurong, Warrior Queen|R|PTK
 #40|Ghostly Visit|C|PTK
 #41|Rockslide Ambush|U|PTK
-#42|Guan Yu's 1,000 Li March|R|PTK
+#42|Guan Yu's 1,000-Li March|R|PTK
 #43|Fire Ambush|C|PTK
 #44|Wei Night Raiders|U|PTK
 #45|Zhang Fei, Fierce Warrior|R|PTK
@@ -54,7 +54,7 @@
 #53|Imperial Recruiter|U|PTK
 #54|Cao Ren, Wei Commander|R|PTK
 #55|Lu Meng, Wu General|R|PTK
-#56|Pang Tong, Young Phoenix|R|PTK
+#56|Pang Tong, "Young Phoenix"|R|PTK
 #57|Zhou Yu, Chief Commander|R|PTK
 #58|Sima Yi, Wei Field Marshal|R|PTK
 #59|Zhang Liao, Hero of Hefei|R|PTK
@@ -90,7 +90,7 @@
 #89|Flanking Troops|U|PTK
 #90|Zodiac Ox|U|PTK
 #91|Huang Zhong, Shu General|R|PTK
-#92|Shu Soldier Farmers|U|PTK
+#92|Shu Soldier-Farmers|U|PTK
 #93|Misfortune's Gain|C|PTK
 #94|Desperate Charge|U|PTK
 #95|Zhao Zilong, Tiger General|R|PTK

--- a/forge-gui/res/draft/rankings/rav.rnk
+++ b/forge-gui/res/draft/rankings/rav.rnk
@@ -4,7 +4,7 @@
 #3|Ursapine|R|RAV
 #4|Gleancrawler|R|RAV
 #5|Vulturous Zombie|R|RAV
-#6|Grave Shell Scarab|R|RAV
+#6|Grave-Shell Scarab|R|RAV
 #7|Char|R|RAV
 #8|Firemane Angel|R|RAV
 #9|Hex|R|RAV
@@ -111,15 +111,15 @@
 #110|Gaze of the Gorgon|C|RAV
 #111|Indentured Oaf|U|RAV
 #112|Screeching Griffin|C|RAV
-#113|Vitu Ghazi, the City Tree|U|RAV
+#113|Vitu-Ghazi, the City-Tree|U|RAV
 #114|Remand|U|RAV
 #115|Tidewater Minion|C|RAV
 #116|Telling Time|U|RAV
 #117|Bathe in Light|U|RAV
 #118|Fiery Conclusion|C|RAV
-#119|Golgari Grave Troll|R|RAV
+#119|Golgari Grave-Troll|R|RAV
 #120|Overgrown Tomb|R|RAV
-#121|Flame Kin Zealot|U|RAV
+#121|Flame-Kin Zealot|U|RAV
 #122|Elves of Deep Shadow|C|RAV
 #123|Twisted Justice|U|RAV
 #124|Cloudstone Curio|R|RAV
@@ -136,7 +136,7 @@
 #135|Transluminant|C|RAV
 #136|Selesnya Sagittars|U|RAV
 #137|Boros Garrison|C|RAV
-#138|Root Kin Ally|U|RAV
+#138|Root-Kin Ally|U|RAV
 #139|Clinging Darkness|C|RAV
 #140|Recollect|U|RAV
 #141|Frenzied Goblin|U|RAV
@@ -151,7 +151,7 @@
 #150|Greater Forgeling|U|RAV
 #151|Crown of Convergence|R|RAV
 #152|Psychic Drain|U|RAV
-#153|Guardian of Vitu Ghazi|C|RAV
+#153|Guardian of Vitu-Ghazi|C|RAV
 #154|Sunhome, Fortress of the Legion|U|RAV
 #155|Hunted Troll|R|RAV
 #156|Seeds of Strength|C|RAV
@@ -183,11 +183,11 @@
 #182|Ordruun Commando|C|RAV
 #183|Flickerform|R|RAV
 #184|Three Dreams|R|RAV
-#185|Sell Sword Brute|C|RAV
+#185|Sell-Sword Brute|C|RAV
 #186|Goblin Spelunkers|C|RAV
 #187|Seed Spark|U|RAV
 #188|Grifter's Blade|U|RAV
-#189|Boros Fury Shield|C|RAV
+#189|Boros Fury-Shield|C|RAV
 #190|Sewerdreg|C|RAV
 #191|Rolling Spoil|U|RAV
 #192|Glass Golem|U|RAV
@@ -196,7 +196,7 @@
 #195|Molten Sentry|R|RAV
 #196|Convolute|C|RAV
 #197|Induce Paranoia|C|RAV
-#198|War Torch Goblin|C|RAV
+#198|War-Torch Goblin|C|RAV
 #199|Moonlight Bargain|R|RAV
 #200|Boros Recruit|C|RAV
 #201|Thoughtpicker Witch|C|RAV
@@ -252,7 +252,7 @@
 #251|Shred Memory|C|RAV
 #252|Vindictive Mob|U|RAV
 #253|Dark Heart of the Wood|U|RAV
-#254|Stone Seeder Hierophant|C|RAV
+#254|Stone-Seeder Hierophant|C|RAV
 #255|Cyclopean Snare|U|RAV
 #256|Necromantic Thirst|C|RAV
 #257|Instill Furor|U|RAV
@@ -264,7 +264,7 @@
 #263|Seismic Spike|C|RAV
 #264|Sins of the Past|R|RAV
 #265|Goblin Fire Fiend|C|RAV
-#266|Chant of Vitu Ghazi|U|RAV
+#266|Chant of Vitu-Ghazi|U|RAV
 #267|Wojek Apothecary|U|RAV
 #268|Quickchange|C|RAV
 #269|Breath of Fury|R|RAV

--- a/forge-gui/res/draft/rankings/roe.rnk
+++ b/forge-gui/res/draft/rankings/roe.rnk
@@ -45,7 +45,7 @@
 #44|Kabira Vindicator|U|ROE
 #45|Joraga Treespeaker|U|ROE
 #46|Gigantomancer|R|ROE
-#47|Hedron Field Purists|R|ROE
+#47|Hedron-Field Purists|R|ROE
 #48|Training Grounds|R|ROE
 #49|Flame Slash|C|ROE
 #50|Boar Umbra|U|ROE
@@ -120,7 +120,7 @@
 #119|Smite|C|ROE
 #120|Hedron Matrix|R|ROE
 #121|Explosive Revelation|U|ROE
-#122|Battle Rattle Shaman|C|ROE
+#122|Battle-Rattle Shaman|C|ROE
 #123|Surreal Memoir|U|ROE
 #124|Daggerback Basilisk|C|ROE
 #125|Prey's Vengeance|U|ROE
@@ -131,7 +131,7 @@
 #130|Soulsurge Elemental|U|ROE
 #131|Escaped Null|U|ROE
 #132|Snake Umbra|C|ROE
-#133|Totem Guide Hartebeest|C|ROE
+#133|Totem-Guide Hartebeest|C|ROE
 #134|Thought Gorger|R|ROE
 #135|Mnemonic Wall|C|ROE
 #136|Stomper Cub|C|ROE
@@ -154,7 +154,7 @@
 #153|Affa Guard Hound|U|ROE
 #154|Bloodthrone Vampire|C|ROE
 #155|Hyena Umbra|C|ROE
-#156|Kor Line Slinger|C|ROE
+#156|Kor Line-Slinger|C|ROE
 #157|Might of the Masses|C|ROE
 #158|Wrap in Flames|C|ROE
 #159|Akoum Boulderfoot|U|ROE
@@ -163,7 +163,7 @@
 #162|Eel Umbra|C|ROE
 #163|Brood Birthing|C|ROE
 #164|Tajuru Preserver|R|ROE
-#165|Grotag Siege Runner|C|ROE
+#165|Grotag Siege-Runner|C|ROE
 #166|Pennon Blade|U|ROE
 #167|Hand of Emrakul|C|ROE
 #168|Essence Feed|C|ROE
@@ -197,7 +197,7 @@
 #196|Renegade Doppelganger|R|ROE
 #197|Demystify|C|ROE
 #198|Haze Frog|C|ROE
-#199|Stalwart Shield Bearers|C|ROE
+#199|Stalwart Shield-Bearers|C|ROE
 #200|Fleeting Distraction|C|ROE
 #201|Luminous Wake|U|ROE
 #202|Suffer the Past|U|ROE
@@ -215,7 +215,7 @@
 #214|Umbra Mystic|R|ROE
 #215|Irresistible Prey|U|ROE
 #216|Living Destiny|C|ROE
-#217|Sphinx Bone Wand|R|ROE
+#217|Sphinx-Bone Wand|R|ROE
 #218|Realms Uncharted|R|ROE
 #219|Lightmine Field|R|ROE
 #220|Phantasmal Abomination|U|ROE
@@ -226,4 +226,4 @@
 #225|Curse of Wizardry|U|ROE
 #226|Not of This World|U|ROE
 #227|Repay in Kind|R|ROE
-#228|Near Death Experience|R|ROE
+#228|Near-Death Experience|R|ROE

--- a/forge-gui/res/draft/rankings/rtr.rnk
+++ b/forge-gui/res/draft/rankings/rtr.rnk
@@ -1,16 +1,16 @@
 //Rank|Name|Rarity|Set
-#1|Jace Architect of Thought|M|RTR
+#1|Jace, Architect of Thought|M|RTR
 #2|Angel of Serenity|M|RTR
 #3|Vraska the Unseen|M|RTR
-#4|Isperia Supreme Judge|M|RTR
+#4|Isperia, Supreme Judge|M|RTR
 #5|Armada Wurm|M|RTR
-#6|Sphinxs Revelation|M|RTR
-#7|Niv Mizzet Dracogenius|M|RTR
+#6|Sphinx's Revelation|M|RTR
+#7|Niv-Mizzet, Dracogenius|M|RTR
 #8|Necropolis Regent|M|RTR
-#9|Trostani Selesnyas Voice|M|RTR
-#10|Rakdoss Return|M|RTR
-#11|Rakdos Lord of Riots|M|RTR
-#12|Jarad Golgari Lich Lord|M|RTR
+#9|Trostani, Selesnya's Voice|M|RTR
+#10|Rakdos's Return|M|RTR
+#11|Rakdos, Lord of Riots|M|RTR
+#12|Jarad, Golgari Lich Lord|M|RTR
 #13|Utvara Hellkite|M|RTR
 #14|Mizzium Mortars|R|RTR
 #15|Worldspine Wurm|M|RTR
@@ -34,7 +34,7 @@
 #33|Righteous Authority|R|RTR
 #34|Lotleth Troll|R|RTR
 #35|Corpsejack Menace|R|RTR
-#36|Vitu Ghazi Guildmage|U|RTR
+#36|Vitu-Ghazi Guildmage|U|RTR
 #37|Precinct Captain|R|RTR
 #38|Abrupt Decay|R|RTR
 #39|Palisade Giant|R|RTR
@@ -48,7 +48,7 @@
 #47|Ultimate Price|U|RTR
 #48|Bloodfray Giant|U|RTR
 #49|Lyev Skyknight|U|RTR
-#50|Azors Elocutors|R|RTR
+#50|Azor's Elocutors|R|RTR
 #51|Chromatic Lantern|R|RTR
 #52|Underworld Connections|R|RTR
 #53|Growing Ranks|R|RTR
@@ -68,7 +68,7 @@
 #67|Soulsworn Spirit|U|RTR
 #68|Temple Garden|R|RTR
 #69|Annihilating Fire|C|RTR
-#70|Thrill Kill Assassin|U|RTR
+#70|Thrill-Kill Assassin|U|RTR
 #71|Izzet Charm|U|RTR
 #72|Slime Molding|U|RTR
 #73|Auger Spree|C|RTR
@@ -89,14 +89,14 @@
 #88|Slitherhead|U|RTR
 #89|Teleportal|U|RTR
 #90|Explosive Impact|C|RTR
-#91|Judges Familiar|U|RTR
-#92|Assassins Strike|U|RTR
-#93|Gore House Chainwalker|C|RTR
+#91|Judge's Familiar|U|RTR
+#92|Assassin's Strike|U|RTR
+#93|Gore-House Chainwalker|C|RTR
 #94|Thoughtflare|U|RTR
 #95|Slum Reaper|U|RTR
 #96|Azorius Arrester|C|RTR
 #97|Voidwielder|C|RTR
-#98|Trostanis Judgment|C|RTR
+#98|Trostani's Judgment|C|RTR
 #99|Fencing Ace|U|RTR
 #100|Gatecreeper Vine|C|RTR
 #101|Sunspire Griffin|C|RTR
@@ -107,11 +107,11 @@
 #106|Hover Barrier|U|RTR
 #107|Skyline Predator|U|RTR
 #108|Axebane Guardian|C|RTR
-#109|Centaurs Herald|C|RTR
+#109|Centaur's Herald|C|RTR
 #110|Security Blockade|U|RTR
 #111|Knightly Valor|C|RTR
-#112|Rakdos Shred Freak|C|RTR
-#113|Deaths Presence|R|RTR
+#112|Rakdos Shred-Freak|C|RTR
+#113|Death's Presence|R|RTR
 #114|Selesnya Guildgate|C|RTR
 #115|Golgari Charm|U|RTR
 #116|Ogre Jailbreaker|C|RTR
@@ -123,7 +123,7 @@
 #122|Rakdos Guildgate|C|RTR
 #123|Syncopate|U|RTR
 #124|Phantom General|U|RTR
-#125|Rogues Passage|U|RTR
+#125|Rogue's Passage|U|RTR
 #126|Eyes in the Skies|C|RTR
 #127|Golgari Guildgate|C|RTR
 #128|Sluiceway Scorpion|C|RTR
@@ -142,8 +142,8 @@
 #141|Hussar Patrol|C|RTR
 #142|Korozda Monitor|C|RTR
 #143|Rakdos Keyrune|U|RTR
-#144|Jarads Orders|R|RTR
-#145|Coursers Accord|C|RTR
+#144|Jarad's Orders|R|RTR
+#145|Coursers' Accord|C|RTR
 #146|Tower Drake|C|RTR
 #147|Grim Roustabout|C|RTR
 #148|Risen Sanctuary|U|RTR
@@ -164,7 +164,7 @@
 #163|Stealer of Secrets|C|RTR
 #164|Traitorous Instinct|C|RTR
 #165|Rootborn Defenses|C|RTR
-#166|Isperias Skywatch|C|RTR
+#166|Isperia's Skywatch|C|RTR
 #167|Golgari Keyrune|U|RTR
 #168|Soul Tithe|U|RTR
 #169|Doorkeeper|C|RTR
@@ -203,9 +203,9 @@
 #202|Fall of the Gavel|U|RTR
 #203|Seek the Horizon|U|RTR
 #204|Skull Rend|C|RTR
-#205|Druids Deliverance|C|RTR
-#206|Chemisters Trick|C|RTR
-#207|Horncallers Chant|C|RTR
+#205|Druid's Deliverance|C|RTR
+#206|Chemister's Trick|C|RTR
+#207|Horncaller's Chant|C|RTR
 #208|Treasured Find|U|RTR
 #209|Tavern Swindler|U|RTR
 #210|Bellows Lizard|C|RTR
@@ -229,7 +229,7 @@
 #228|Havoc Festival|R|RTR
 #229|Chronic Flooding|C|RTR
 #230|Catacomb Slug|C|RTR
-#231|Heroes Reunion|U|RTR
+#231|Heroes' Reunion|U|RTR
 #232|Aquus Steed|U|RTR
 #233|Psychic Spiral|U|RTR
 #234|Oak Street Innkeeper|U|RTR
@@ -238,7 +238,7 @@
 #237|Urban Burgeoning|C|RTR
 #238|Rest in Peace|R|RTR
 #239|Pithing Needle|R|RTR
-#240|Fireminds Foresight|R|RTR
+#240|Firemind's Foresight|R|RTR
 #241|Vandalblast|U|RTR
 #242|Street Sweeper|U|RTR
 #243|Shrieking Affliction|U|RTR

--- a/forge-gui/res/draft/rankings/s99.rnk
+++ b/forge-gui/res/draft/rankings/s99.rnk
@@ -19,7 +19,7 @@
 #18|Whiptail Wurm|U|S99
 #19|Phantom Warrior|R|S99
 #20|Tidings|U|S99
-#21|Man o' War|U|S99
+#21|Man-o'-War|U|S99
 #22|Angel of Light|U|S99
 #23|Pride of Lions|U|S99
 #24|Gravedigger|U|S99

--- a/forge-gui/res/draft/rankings/shm.rnk
+++ b/forge-gui/res/draft/rankings/shm.rnk
@@ -5,7 +5,7 @@
 #4|Demigod of Revenge|R|SHM
 #5|Godhead of Awe|R|SHM
 #6|Twilight Shepherd|R|SHM
-#7|Wilt Leaf Liege|R|SHM
+#7|Wilt-Leaf Liege|R|SHM
 #8|Boartusk Liege|R|SHM
 #9|Incremental Blight|U|SHM
 #10|Furystoke Giant|R|SHM
@@ -27,14 +27,14 @@
 #26|Biting Tether|U|SHM
 #27|Prison Term|U|SHM
 #28|Puppeteer Clique|R|SHM
-#29|Boggart Ram Gang|U|SHM
+#29|Boggart Ram-Gang|U|SHM
 #30|Jaws of Stone|U|SHM
 #31|Windbrisk Raptor|R|SHM
 #32|Mirrorweave|R|SHM
 #33|Silkbind Faerie|C|SHM
 #34|Knollspine Dragon|R|SHM
 #35|Spectral Procession|U|SHM
-#36|Wilt Leaf Cavaliers|U|SHM
+#36|Wilt-Leaf Cavaliers|U|SHM
 #37|Trip Noose|U|SHM
 #38|Oracle of Nectars|R|SHM
 #39|Mass Calcify|R|SHM
@@ -126,7 +126,7 @@
 #125|Safehold Sentry|C|SHM
 #126|Crabapple Cohort|C|SHM
 #127|Spiteflame Witch|U|SHM
-#128|Rune Cervin Rider|C|SHM
+#128|Rune-Cervin Rider|C|SHM
 #129|Wanderbrine Rootcutters|C|SHM
 #130|Faerie Macabre|C|SHM
 #131|Reflecting Pool|R|SHM
@@ -138,8 +138,8 @@
 #137|Inquisitor's Snare|C|SHM
 #138|Roughshod Mentor|U|SHM
 #139|Horde of Boggarts|U|SHM
-#140|Pili Pala|C|SHM
-#141|Fire Lit Thicket|R|SHM
+#140|Pili-Pala|C|SHM
+#141|Fire-Lit Thicket|R|SHM
 #142|Manamorphose|C|SHM
 #143|Drove of Elves|U|SHM
 #144|Watchwing Scarecrow|C|SHM
@@ -259,7 +259,7 @@
 #258|Goldenglow Moth|C|SHM
 #259|Revelsong Horn|U|SHM
 #260|Fossil Find|U|SHM
-#261|Deep Slumber Titan|R|SHM
+#261|Deep-Slumber Titan|R|SHM
 #262|Bloodshed Fever|C|SHM
 #263|Toil to Renown|C|SHM
 #264|Dramatic Entrance|R|SHM

--- a/forge-gui/res/draft/rankings/sir.rnk
+++ b/forge-gui/res/draft/rankings/sir.rnk
@@ -294,7 +294,7 @@
 #293|Make Mischief|C|SIR
 #294|Mockery of Nature|U|SIR
 #295|Rise from the Tides|U|SIR
-#296|Seance|U|SIS
+#296|Séance|U|SIS
 #297|Traitorous Blood|C|SIS
 #298|Somberwald Sage|U|SIS
 #299|Vessel of Endless Rest|U|SIS

--- a/forge-gui/res/draft/rankings/sok.rnk
+++ b/forge-gui/res/draft/rankings/sok.rnk
@@ -3,7 +3,7 @@
 #2|Infernal Kirin|R|SOK
 #3|Celestial Kirin|R|SOK
 #4|Kagemaro, First to Suffer|R|SOK
-#5|Ghost Lit Raider|U|SOK
+#5|Ghost-Lit Raider|U|SOK
 #6|Jiwari, the Earth Aflame|R|SOK
 #7|Cloudhoof Kirin|R|SOK
 #8|Arashi, the Sky Asunder|R|SOK
@@ -15,7 +15,7 @@
 #14|Bounteous Kirin|R|SOK
 #15|Hail of Arrows|U|SOK
 #16|Hand of Cruelty|U|SOK
-#17|O Naginata|U|SOK
+#17|O-Naginata|U|SOK
 #18|Kami of the Tended Garden|U|SOK
 #19|Akuta, Born of Ash|R|SOK
 #20|Kagemaro's Clutch|C|SOK
@@ -27,8 +27,8 @@
 #26|Spiraling Embers|C|SOK
 #27|Exile into Darkness|U|SOK
 #28|Stampeding Serow|U|SOK
-#29|Manriki Gusari|U|SOK
-#30|Ghost Lit Nourisher|U|SOK
+#29|Manriki-Gusari|U|SOK
+#30|Ghost-Lit Nourisher|U|SOK
 #31|Ayumi, the Last Visitor|R|SOK
 #32|Kiyomaro, First to Stand|R|SOK
 #33|Barrel Down Sokenzan|C|SOK
@@ -39,20 +39,20 @@
 #38|Promise of Bunrei|R|SOK
 #39|Sakashima the Impostor|R|SOK
 #40|Elder Pine of Jukai|C|SOK
-#41|Haru Onna|U|SOK
-#42|Kiri Onna|U|SOK
+#41|Haru-Onna|U|SOK
+#42|Kiri-Onna|U|SOK
 #43|Oni of Wild Places|U|SOK
-#44|Rushing Tide Zubera|U|SOK
+#44|Rushing-Tide Zubera|U|SOK
 #45|Undying Flames|R|SOK
 #46|Shinen of Flight's Wings|C|SOK
 #47|Tomb of Urami|R|SOK
-#48|Eiganjo Free Riders|U|SOK
-#49|Burning Eye Zubera|U|SOK
+#48|Eiganjo Free-Riders|U|SOK
+#49|Burning-Eye Zubera|U|SOK
 #50|Sokenzan Spellblade|C|SOK
 #51|Choice of Damnations|R|SOK
 #52|Maga, Traitor to Mortals|R|SOK
 #53|Adamaro, First to Desire|R|SOK
-#54|Kemuri Onna|U|SOK
+#54|Kemuri-Onna|U|SOK
 #55|Moonwing Moth|C|SOK
 #56|Moonbow Illusionist|C|SOK
 #57|Okina Nightwatch|C|SOK
@@ -62,27 +62,27 @@
 #61|Sekki, Seasons' Guide|R|SOK
 #62|Inner Calm, Outer Strength|C|SOK
 #63|Soratami Cloud Chariot|U|SOK
-#64|Ghost Lit Stalker|U|SOK
+#64|Ghost-Lit Stalker|U|SOK
 #65|Molting Skin|U|SOK
-#66|Raving Oni Slave|C|SOK
+#66|Raving Oni-Slave|C|SOK
 #67|Deathmask Nezumi|C|SOK
-#68|Kashi Tribe Elite|U|SOK
+#68|Kashi-Tribe Elite|U|SOK
 #69|Akki Underling|C|SOK
 #70|Captive Flame|U|SOK
 #71|Kitsune Loreweaver|C|SOK
 #72|Kuro's Taken|C|SOK
-#73|Ghost Lit Redeemer|U|SOK
+#73|Ghost-Lit Redeemer|U|SOK
 #74|Death Denied|C|SOK
-#75|Nikko Onna|U|SOK
+#75|Nikko-Onna|U|SOK
 #76|Nightsoil Kami|C|SOK
 #77|Shinen of Stars' Light|C|SOK
 #78|Kami of Empty Graves|C|SOK
-#79|Ghost Lit Warder|U|SOK
+#79|Ghost-Lit Warder|U|SOK
 #80|Overwhelming Intellect|U|SOK
 #81|Descendant of Masumaro|U|SOK
 #82|Erayo, Soratami Ascendant|R|SOK
 #83|Araba Mothrider|C|SOK
-#84|Yuki Onna|U|SOK
+#84|Yuki-Onna|U|SOK
 #85|Shinen of Fury's Fire|C|SOK
 #86|Freed from the Real|C|SOK
 #87|Pithing Needle|R|SOK
@@ -116,19 +116,19 @@
 #115|Kitsune Dawnblade|C|SOK
 #116|Minamo Scrollkeeper|C|SOK
 #117|Glitterfang|C|SOK
-#118|Sakura Tribe Scout|C|SOK
+#118|Sakura-Tribe Scout|C|SOK
 #119|Oboro, Palace in the Clouds|R|SOK
 #120|Reki, the History of Kamigawa|R|SOK
 #121|Murmurs from Beyond|C|SOK
-#122|Inner Chamber Guard|U|SOK
+#122|Inner-Chamber Guard|U|SOK
 #123|Aether Shockwave|U|SOK
 #124|Fiddlehead Kami|C|SOK
 #125|Locust Miser|U|SOK
 #126|Rending Vines|C|SOK
 #127|Sokenzan Renegade|U|SOK
 #128|Dreamcatcher|C|SOK
-#129|Matsu Tribe Birdstalker|C|SOK
-#130|Rune Tail, Kitsune Ascendant|R|SOK
+#129|Matsu-Tribe Birdstalker|C|SOK
+#130|Rune-Tail, Kitsune Ascendant|R|SOK
 #131|Gaze of Adamaro|U|SOK
 #132|Gnat Miser|C|SOK
 #133|Curtain of Light|C|SOK

--- a/forge-gui/res/draft/rankings/som.rnk
+++ b/forge-gui/res/draft/rankings/som.rnk
@@ -1,7 +1,7 @@
 //Rank|Name|Rarity|Set
 #1|Sword of Body and Mind|M|SOM
 #2|Wurmcoil Engine|M|SOM
-#3|Molten Tail Masticore|M|SOM
+#3|Molten-Tail Masticore|M|SOM
 #4|Skithiryx, the Blight Dragon|M|SOM
 #5|Elspeth Tirel|M|SOM
 #6|Koth of the Hammer|M|SOM
@@ -17,7 +17,7 @@
 #16|Mox Opal|M|SOM
 #17|Contagion Engine|R|SOM
 #18|Sunblast Angel|R|SOM
-#19|Hoard Smelter Dragon|R|SOM
+#19|Hoard-Smelter Dragon|R|SOM
 #20|Carnifex Demon|R|SOM
 #21|Myr Battlesphere|R|SOM
 #22|Precursor Golem|R|SOM
@@ -125,11 +125,11 @@
 #124|Kemba's Skyguard|C|SOM
 #125|Blight Mamba|C|SOM
 #126|Bladed Pinions|C|SOM
-#127|Sky Eel School|C|SOM
+#127|Sky-Eel School|C|SOM
 #128|Bloodshot Trainee|U|SOM
 #129|Strider Harness|C|SOM
 #130|Fume Spitter|C|SOM
-#131|Tel Jilad Fallen|C|SOM
+#131|Tel-Jilad Fallen|C|SOM
 #132|Untamed Might|C|SOM
 #133|Carrion Call|U|SOM
 #134|Instill Infection|C|SOM
@@ -158,7 +158,7 @@
 #157|Vedalken Certarch|C|SOM
 #158|Neurok Invisimancer|C|SOM
 #159|Nihil Spellbomb|C|SOM
-#160|Blade Tribe Berserkers|C|SOM
+#160|Blade-Tribe Berserkers|C|SOM
 #161|Necrogen Censer|C|SOM
 #162|Blackcleave Goblin|C|SOM
 #163|Vector Asp|C|SOM
@@ -172,7 +172,7 @@
 #171|Bonds of Quicksilver|C|SOM
 #172|Grindclock|R|SOM
 #173|Abuna Acolyte|U|SOM
-#174|Tel Jilad Defiance|C|SOM
+#174|Tel-Jilad Defiance|C|SOM
 #175|Flameborn Hellion|C|SOM
 #176|Ferrovore|C|SOM
 #177|Moriok Reaver|C|SOM

--- a/forge-gui/res/draft/rankings/ths.rnk
+++ b/forge-gui/res/draft/rankings/ths.rnk
@@ -1,16 +1,16 @@
 //Rank|Name|Rarity|Set
-#1|Elspeth Sun's Champion|M|THS
+#1|Elspeth, Sun's Champion|M|THS
 #2|Stormbreath Dragon|M|THS
-#3|Thassa God of the Sea|M|THS
-#4|Polukranos World Eater|M|THS
-#5|Ashiok Nightmare Weaver|M|THS
-#6|Purphoros God of the Forge|M|THS
-#7|Heliod God of the Sun|M|THS
-#8|Xenagos the Reveler|M|THS
-#9|Nylea God of the Hunt|M|THS
+#3|Thassa, God of the Sea|M|THS
+#4|Polukranos, World Eater|M|THS
+#5|Ashiok, Nightmare Weaver|M|THS
+#6|Purphoros, God of the Forge|M|THS
+#7|Heliod, God of the Sun|M|THS
+#8|Xenagos, the Reveler|M|THS
+#9|Nylea, God of the Hunt|M|THS
 #10|Hythonia the Cruel|M|THS
 #11|Master of Waves|M|THS
-#12|Erebos God of the Dead|M|THS
+#12|Erebos, God of the Dead|M|THS
 #13|Medomai the Ageless|M|THS
 #14|Underworld Cerberus|M|THS
 #15|Ashen Rider|M|THS
@@ -46,13 +46,13 @@
 #45|Keepsake Gorgon|U|THS
 #46|Reverent Hunter|R|THS
 #47|Sea God's Revenge|U|THS
-#48|Anthousa Setessan Hero|R|THS
+#48|Anthousa, Setessan Hero|R|THS
 #49|Labyrinth Champion|R|THS
 #50|Curse of the Swine|R|THS
 #51|Heliod's Emissary|U|THS
 #52|Rageblood Shaman|R|THS
 #53|Nemesis of Mortals|U|THS
-#54|Nykthos Shrine to Nyx|R|THS
+#54|Nykthos, Shrine to Nyx|R|THS
 #55|Magma Jet|U|THS
 #56|Soldier of the Pantheon|R|THS
 #57|Ordeal of Purphoros|U|THS
@@ -82,7 +82,7 @@
 #81|Gray Merchant of Asphodel|C|THS
 #82|Temple of Deceit|R|THS
 #83|Temple of Mystery|R|THS
-#84|Tymaret the Murder King|R|THS
+#84|Tymaret, the Murder King|R|THS
 #85|Temple of Silence|R|THS
 #86|Temple of Triumph|R|THS
 #87|Ordeal of Erebos|U|THS

--- a/forge-gui/res/draft/rankings/tmp.rnk
+++ b/forge-gui/res/draft/rankings/tmp.rnk
@@ -195,7 +195,7 @@
 #194|Nurturing Licid|U|TMP
 #195|Quickening Licid|U|TMP
 #196|Phyrexian Splicer|U|TMP
-#197|Oracle en-vec|R|TMP
+#197|Oracle en-Vec|R|TMP
 #198|Jet Medallion|R|TMP
 #199|Caldera Lake|R|TMP
 #200|Enraging Licid|U|TMP

--- a/forge-gui/res/draft/rankings/tpr.rnk
+++ b/forge-gui/res/draft/rankings/tpr.rnk
@@ -1,14 +1,14 @@
 //Rank|Name|Rarity|Set
-#1|Legacys Allure|R|TPR
+#1|Legacy's Allure|R|TPR
 #2|Flame Wave|R|TPR
 #3|Living Death|M|TPR
 #4|Soltari Guerrillas|R|TPR
 #5|Rolling Thunder|U|TPR
-#6|Commander Greven il Vec|R|TPR
+#6|Commander Greven il-Vec|R|TPR
 #7|Silver Wyvern|R|TPR
 #8|Rathi Dragon|R|TPR
-#9|Volraths Stronghold|M|TPR
-#10|Vhati il Dal|R|TPR
+#9|Volrath's Stronghold|M|TPR
+#10|Vhati il-Dal|R|TPR
 #11|Ephemeron|R|TPR
 #12|Stronghold Assassin|R|TPR
 #13|Magmasaur|R|TPR
@@ -18,25 +18,25 @@
 #17|Crovax the Cursed|R|TPR
 #18|Kezzerdrix|R|TPR
 #19|Tradewind Rider|R|TPR
-#20|Selenia Dark Angel|R|TPR
+#20|Selenia, Dark Angel|R|TPR
 #21|Pacifism|U|TPR
 #22|Dracoplasm|R|TPR
 #23|Spike Hatcher|R|TPR
 #24|Flowstone Wyvern|U|TPR
 #25|Shard Phoenix|M|TPR
-#26|Evincars Justice|U|TPR
+#26|Evincar's Justice|U|TPR
 #27|Dark Banishing|C|TPR
 #28|Master Decoy|C|TPR
 #29|Exalted Dragon|R|TPR
 #30|Killer Whale|U|TPR
-#31|Mirri Cat Warrior|R|TPR
-#32|Orim Samite Healer|R|TPR
+#31|Mirri, Cat Warrior|R|TPR
+#32|Orim, Samite Healer|R|TPR
 #33|Soltari Champion|U|TPR
 #34|Carnassid|U|TPR
 #35|Ogre Shaman|R|TPR
 #36|Reanimate|U|TPR
 #37|Acidic Sliver|U|TPR
-#38|Paladin en Vec|R|TPR
+#38|Paladin en-Vec|R|TPR
 #39|Lightning Blast|C|TPR
 #40|Coffin Queen|R|TPR
 #41|Fanning the Flames|R|TPR
@@ -50,7 +50,7 @@
 #49|Spitting Hydra|R|TPR
 #50|Cataclysm|M|TPR
 #51|Mawcor|R|TPR
-#52|Gerrards Battle Cry|R|TPR
+#52|Gerrard's Battle Cry|R|TPR
 #53|Kindle|C|TPR
 #54|Recurring Nightmare|M|TPR
 #55|Rootwalla|C|TPR
@@ -64,7 +64,7 @@
 #63|Soltari Trooper|C|TPR
 #64|Skyshroud Vampire|U|TPR
 #65|Dauthi Warlord|U|TPR
-#66|Warrior en Kor|U|TPR
+#66|Warrior en-Kor|U|TPR
 #67|Spike Colony|C|TPR
 #68|Counterspell|U|TPR
 #69|Dismiss|U|TPR
@@ -102,7 +102,7 @@
 #101|Serpent Warrior|C|TPR
 #102|Youthful Knight|C|TPR
 #103|Renegade Warlord|U|TPR
-#104|Spirit en Kor|C|TPR
+#104|Spirit en-Kor|C|TPR
 #105|Spirit Mirror|R|TPR
 #106|Sift|C|TPR
 #107|Legerdemain|U|TPR
@@ -151,7 +151,7 @@
 #150|Skyshroud Elf|C|TPR
 #151|Rampant Growth|C|TPR
 #152|Smite|C|TPR
-#153|Shaman en Kor|R|TPR
+#153|Shaman en-Kor|R|TPR
 #154|Cursed Flesh|C|TPR
 #155|Spike Feeder|U|TPR
 #156|Reality Anchor|C|TPR
@@ -161,7 +161,7 @@
 #160|Sea Monster|C|TPR
 #161|Elven Rite|C|TPR
 #162|Wall of Diffusion|C|TPR
-#163|Deaths Duet|C|TPR
+#163|Death's Duet|C|TPR
 #164|Starke of Rath|M|TPR
 #165|Mnemonic Sliver|C|TPR
 #166|Barbed Sliver|C|TPR
@@ -192,7 +192,7 @@
 #191|Mindless Automaton|R|TPR
 #192|Intuition|R|TPR
 #193|Hermit Druid|U|TPR
-#194|Mage il Vec|U|TPR
+#194|Mage il-Vec|U|TPR
 #195|Stun|C|TPR
 #196|Harrow|C|TPR
 #197|Wall of Souls|U|TPR
@@ -207,8 +207,8 @@
 #206|Gaseous Form|C|TPR
 #207|Spellshock|U|TPR
 #208|Cannibalize|U|TPR
-#209|Volraths Curse|U|TPR
-#210|Nomads en Kor|C|TPR
+#209|Volrath's Curse|U|TPR
+#210|Nomads en-Kor|C|TPR
 #211|Survival of the Fittest|M|TPR
 #212|Patchwork Gnomes|C|TPR
 #213|Emmessi Tome|U|TPR
@@ -219,7 +219,7 @@
 #218|Craven Giant|C|TPR
 #219|Dream Prowler|U|TPR
 #220|Thrull Surgeon|C|TPR
-#221|Volraths Laboratory|R|TPR
+#221|Volrath's Laboratory|R|TPR
 #222|Lab Rats|C|TPR
 #223|Spell Blast|C|TPR
 #224|Conviction|C|TPR

--- a/forge-gui/res/draft/rankings/tsb.rnk
+++ b/forge-gui/res/draft/rankings/tsb.rnk
@@ -2,7 +2,7 @@
 #1|Dummy Card|S|TSB
 #2|Desolation Giant|S|TSB
 #2|Fiery Justice|S|TSB
-#2|Jolrael Empress of Beasts|S|TSB
+#2|Jolrael, Empress of Beasts|S|TSB
 #2|Void|S|TSB
 #3|Faceless Butcher|S|TSB
 #3|Psionic Blast|S|TSB
@@ -10,7 +10,7 @@
 #3|Fiery Temper|S|TSB
 #3|Lightning Angel|S|TSB
 #3|Merieke Ri Berit|S|TSB
-#3|Vhati il Dal|S|TSB
+#3|Vhati il-Dal|S|TSB
 #4|Shadowmage Infiltrator|S|TSB
 #4|Soul Collector|S|TSB
 #4|Assault Battery|S|TSB
@@ -19,13 +19,13 @@
 #4|Ghost Ship|S|TSB
 #4|Verdeloth the Ancient|S|TSB
 #4|Witch Hunter|S|TSB
-#5|Akroma Angel of Wrath|S|TSB
+#5|Akroma, Angel of Wrath|S|TSB
 #5|Cockatrice|S|TSB
 #5|Fire Whip|S|TSB
 #5|Mystic Snake|S|TSB
 #5|Shadow Guildmage|S|TSB
-#5|Teferis Moat|S|TSB
-#5|Solkanar the Swamp King|S|TSB
+#5|Teferi's Moat|S|TSB
+#5|Sol'kanar the Swamp King|S|TSB
 #6|Avatar of Woe|S|TSB
 #6|Mystic Enforcer|S|TSB
 #6|Defiant Vanguard|S|TSB
@@ -59,18 +59,18 @@
 #8|Spitting Slug|S|TSB
 #8|Stormbind|S|TSB
 #8|Stupor|S|TSB
-#8|SuqAta Lancer|S|TSB
+#8|Suq'Ata Lancer|S|TSB
 #8|Wall of Roots|S|TSB
 #9|Nicol Bolas|S|TSB
 #9|Dodecapod|S|TSB
 #9|Moorish Cavalry|S|TSB
 #9|Avalanche Riders|S|TSB
-#9|Evil Eye of Orms by Gore|S|TSB
+#9|Evil Eye of Orms-by-Gore|S|TSB
 #9|Funeral Charm|S|TSB
 #9|Icatian Javelineers|S|TSB
 #9|Mindless Automaton|S|TSB
 #9|Resurrection|S|TSB
-#9|Seragnoth|S|TSB
+#9|Scragnoth|S|TSB
 #9|Sengir Autocrat|S|TSB
 #9|Thallid|S|TSB
 #9|Whispers of the Muse|S|TSB
@@ -83,9 +83,9 @@
 #10|Sacred Mesa|S|TSB
 #10|Pendelhaven|S|TSB
 #10|Conspiracy|S|TSB
-#10|Dandan|S|TSB
-#10|Gaeas Blessing|S|TSB
-#10|Gaeas Liege|S|TSB
+#10|Dandân|S|TSB
+#10|Gaea's Blessing|S|TSB
+#10|Gaea's Liege|S|TSB
 #10|Gemstone Mine|S|TSB
 #10|Hail Storm|S|TSB
 #10|Mirari|S|TSB
@@ -120,5 +120,5 @@
 #13|Consecrate Land|S|TSB
 #13|Dragonstorm|S|TSB
 #13|Enduring Renewal|S|TSB
-#13|Feldons Cane|S|TSB
-#13|Tormods Crypt|S|TSB
+#13|Feldon's Cane|S|TSB
+#13|Tormod's Crypt|S|TSB

--- a/forge-gui/res/draft/rankings/tsp.rnk
+++ b/forge-gui/res/draft/rankings/tsp.rnk
@@ -60,7 +60,7 @@
 #59|Fiery Temper|SR|TSP
 #60|Dragon Whelp|SR|TSP
 #61|Teferi's Moat|SR|TSP
-#62|Deep Sea Kraken|R|TSP
+#62|Deep-Sea Kraken|R|TSP
 #63|Mangara of Corondor|R|TSP
 #64|Ancestral Vision|R|TSP
 #65|Faceless Butcher|SR|TSP
@@ -75,11 +75,11 @@
 #74|Brine Elemental|U|TSP
 #75|Careful Consideration|U|TSP
 #76|Temporal Isolation|C|TSP
-#77|Looter il Kor|C|TSP
+#77|Looter il-Kor|C|TSP
 #78|Twisted Abomination|SR|TSP
 #79|Prodigal Sorcerer|SR|TSP
 #80|Nightshade Assassin|U|TSP
-#81|Outrider en Kor|U|TSP
+#81|Outrider en-Kor|U|TSP
 #82|Celestial Crusader|U|TSP
 #83|Fathom Seer|C|TSP
 #84|Castle Raptors|C|TSP
@@ -96,7 +96,7 @@
 #95|Tribal Flames|SR|TSP
 #96|Crookclaw Transmuter|C|TSP
 #97|Psionic Sliver|R|TSP
-#98|Vhati il Dal|SR|TSP
+#98|Vhati il-Dal|SR|TSP
 #99|Spiketail Drakeling|C|TSP
 #100|Dark Withering|C|TSP
 #101|Weatherseed Totem|U|TSP
@@ -157,14 +157,14 @@
 #156|Fiery Justice|SR|TSP
 #157|Ib Halfheart, Goblin Tactician|R|TSP
 #158|Undertaker|SR|TSP
-#159|Lim Dul the Necromancer|R|TSP
+#159|Lim-Dûl the Necromancer|R|TSP
 #160|Giant Oyster|SR|TSP
-#161|Urborg Syphon Mage|C|TSP
+#161|Urborg Syphon-Mage|C|TSP
 #162|Uthden Troll|SR|TSP
 #163|Candles of Leng|R|TSP
 #164|Cloudchaser Kestrel|C|TSP
-#165|Thick Skinned Goblin|U|TSP
-#166|Trespasser il Vec|C|TSP
+#165|Thick-Skinned Goblin|U|TSP
+#166|Trespasser il-Vec|C|TSP
 #167|Zhalfirin Commander|SR|TSP
 #168|Desert|SR|TSP
 #169|Sol'kanar the Swamp King|SR|TSP
@@ -226,10 +226,10 @@
 #225|Nether Traitor|R|TSP
 #226|Feebleness|C|TSP
 #227|Unstable Mutation|SR|TSP
-#228|Zealot il Vec|C|TSP
+#228|Zealot il-Vec|C|TSP
 #229|Greenseeker|C|TSP
 #230|Pendelhaven|SR|TSP
-#231|Thallid Shell Dweller|C|TSP
+#231|Thallid Shell-Dweller|C|TSP
 #232|Flamecore Elemental|C|TSP
 #233|Dodecapod|SR|TSP
 #234|Flickering Spirit|C|TSP
@@ -273,14 +273,14 @@
 #272|Spitting Slug|SR|TSP
 #273|Savage Thallid|C|TSP
 #274|Viashino Bladescout|C|TSP
-#275|Mwonvuli Acid Moss|C|TSP
+#275|Mwonvuli Acid-Moss|C|TSP
 #276|Saltcrusted Steppe|U|TSP
 #277|D'Avenant Healer|C|TSP
 #278|Jedit's Dragoons|C|TSP
 #279|Evil Eye of Urborg|U|TSP
 #280|Venser's Sliver|C|TSP
 #281|Mirari|SR|TSP
-#282|Two Headed Sliver|C|TSP
+#282|Two-Headed Sliver|C|TSP
 #283|Viscid Lemures|C|TSP
 #284|Sidewinder Sliver|C|TSP
 #285|Smallpox|U|TSP
@@ -296,10 +296,10 @@
 #295|Vesuva|R|TSP
 #296|Cyclopean Giant|C|TSP
 #297|Tectonic Fiend|U|TSP
-#298|Assembly Worker|U|TSP
+#298|Assembly-Worker|U|TSP
 #299|Drudge Reavers|C|TSP
 #300|Aetherflame Wall|C|TSP
-#301|Drifter il Dal|C|TSP
+#301|Drifter il-Dal|C|TSP
 #302|Sage of Epityr|C|TSP
 #303|Spell Burst|U|TSP
 #304|Pentarch Ward|C|TSP
@@ -317,7 +317,7 @@
 #316|Gaze of Justice|C|TSP
 #317|Gustcloak Cavalier|U|TSP
 #318|Gaea's Blessing|SR|TSP
-#319|Evil Eye of Orms by Gore|SR|TSP
+#319|Evil Eye of Orms-by-Gore|SR|TSP
 #320|Gemstone Caverns|R|TSP
 #321|Paradise Plume|U|TSP
 #322|Screeching Sliver|C|TSP
@@ -349,7 +349,7 @@
 #348|Orcish Librarian|SR|TSP
 #349|Gaea's Liege|SR|TSP
 #350|Academy Ruins|R|TSP
-#351|Dandan|SR|TSP
+#351|Dandân|SR|TSP
 #352|Harmonic Sliver|U|TSP
 #353|Krosan Grip|U|TSP
 #354|Traitor's Clutch|C|TSP
@@ -393,7 +393,7 @@
 #392|Volcanic Awakening|U|TSP
 #393|Living End|R|TSP
 #394|Consecrate Land|SR|TSP
-#395|Scion of the Ur Dragon|R|TSP
+#395|Scion of the Ur-Dragon|R|TSP
 #396|Aspect of Mongoose|U|TSP
 #397|Restore Balance|R|TSP
 #398|Paradox Haze|U|TSP

--- a/forge-gui/res/draft/rankings/ugf.rnk
+++ b/forge-gui/res/draft/rankings/ugf.rnk
@@ -1,5 +1,5 @@
 //Rank|Name|Rarity|Set
-#1|Ugin the Spirit Dragon|M|UGF
+#1|Ugin, the Spirit Dragon|M|UGF
 #29|Ghostfire Blade|R|UGF
 #32|Mastery of the Unseen|R|UGF
 #34|Grim Haruspex|R|UGF

--- a/forge-gui/res/draft/rankings/vma.rnk
+++ b/forge-gui/res/draft/rankings/vma.rnk
@@ -2,7 +2,7 @@
 #1|Sol Ring|M|VMA
 #2|Library of Alexandria|M|VMA
 #3|Ancestral Recall|S|VMA
-#4|Jace the Mind Sculptor|M|VMA
+#4|Jace, the Mind Sculptor|M|VMA
 #5|Mana Crypt|M|VMA
 #6|Control Magic|R|VMA
 #7|Visara the Dreadful|R|VMA
@@ -13,40 +13,40 @@
 #12|Rorix Bladewing|R|VMA
 #13|Parallax Wave|R|VMA
 #14|Balance|M|VMA
-#15|Grenzo Dungeon Warden|R|VMA
+#15|Grenzo, Dungeon Warden|R|VMA
 #16|Spiritmonger|R|VMA
 #17|Living Death|R|VMA
 #18|Flametongue Kavu|U|VMA
 #19|Starstorm|R|VMA
 #20|Winds of Rath|R|VMA
-#21|Silvos Rogue Elemental|R|VMA
+#21|Silvos, Rogue Elemental|R|VMA
 #22|Swords to Plowshares|U|VMA
 #23|Battle Screech|C|VMA
 #24|Deranged Hermit|R|VMA
 #25|Ancient Tomb|R|VMA
 #26|Prophetic Bolt|U|VMA
-#27|Councils Judgment|R|VMA
+#27|Council's Judgment|R|VMA
 #28|Dark Hatchling|U|VMA
 #29|Skullclamp|M|VMA
 #30|Mana Drain|M|VMA
 #31|Mana Vault|R|VMA
-#32|Rofellos Llanowar Emissary|R|VMA
+#32|Rofellos, Llanowar Emissary|R|VMA
 #33|Recurring Nightmare|R|VMA
-#34|Nevinyrrals Disk|R|VMA
+#34|Nevinyrral's Disk|R|VMA
 #35|Palinchron|R|VMA
 #36|Crovax the Cursed|R|VMA
 #37|Baleful Strix|R|VMA
-#38|Basandra Battle Seraph|R|VMA
-#39|Kaerveks Torch|U|VMA
+#38|Basandra, Battle Seraph|R|VMA
+#39|Kaervek's Torch|U|VMA
 #40|Yavimaya Hollow|R|VMA
 #41|Serendib Efreet|U|VMA
 #42|Masticore|R|VMA
 #43|Tradewind Rider|R|VMA
-#44|Radiant Archangel|U|VMA
+#44|Radiant, Archangel|U|VMA
 #45|Lightning Dragon|R|VMA
-#46|Edric Spymaster of Trest|R|VMA
+#46|Edric, Spymaster of Trest|R|VMA
 #47|Time Walk|S|VMA
-#48|Laquatuss Champion|R|VMA
+#48|Laquatus's Champion|R|VMA
 #49|Demonic Tutor|R|VMA
 #50|Shivan Wurm|R|VMA
 #51|Sulfuric Vortex|R|VMA
@@ -54,7 +54,7 @@
 #53|Symbiotic Wurm|U|VMA
 #54|Armageddon|M|VMA
 #55|Survival of the Fittest|R|VMA
-#56|Yawgmoths Will|M|VMA
+#56|Yawgmoth's Will|M|VMA
 #57|Lightning Rift|U|VMA
 #58|Sylvan Library|R|VMA
 #59|Mox Pearl|S|VMA
@@ -63,13 +63,13 @@
 #62|Mox Ruby|S|VMA
 #63|Mox Emerald|S|VMA
 #64|Kezzerdrix|U|VMA
-#65|Jareth Leonine Titan|R|VMA
+#65|Jareth, Leonine Titan|R|VMA
 #66|Decree of Justice|R|VMA
-#67|Kongming Sleeping Dragon|R|VMA
-#68|Brago King Eternal|R|VMA
+#67|Kongming, "Sleeping Dragon"|R|VMA
+#68|Brago, King Eternal|R|VMA
 #69|Penumbra Wurm|U|VMA
 #70|Chain Lightning|C|VMA
-#71|Dacks Duplicate|R|VMA
+#71|Dack's Duplicate|R|VMA
 #72|Clickslither|R|VMA
 #73|Zhalfirin Crusader|R|VMA
 #74|Upheaval|M|VMA
@@ -82,7 +82,7 @@
 #81|Crescendo of War|R|VMA
 #82|Dreampod Druid|U|VMA
 #83|Black Lotus|S|VMA
-#84|Man o War|C|VMA
+#84|Man-o'-War|C|VMA
 #85|Beetleback Chief|C|VMA
 #86|Cursed Scroll|R|VMA
 #87|Vampiric Tutor|R|VMA
@@ -106,18 +106,18 @@
 #105|Waterfront Bouncer|U|VMA
 #106|Blastoderm|U|VMA
 #107|Goblin Trenches|U|VMA
-#108|Marchesa the Black Rose|M|VMA
+#108|Marchesa, the Black Rose|M|VMA
 #109|Coercive Portal|M|VMA
 #110|Fact or Fiction|U|VMA
 #111|Erhnam Djinn|U|VMA
-#112|Gaeas Embrace|U|VMA
+#112|Gaea's Embrace|U|VMA
 #113|Phyrexian Defiler|U|VMA
 #114|Gigapede|R|VMA
 #115|Killer Whale|C|VMA
 #116|Chaos Warp|R|VMA
 #117|Memory Jar|M|VMA
 #118|Stroke of Genius|R|VMA
-#119|Gerrards Battle Cry|R|VMA
+#119|Gerrard's Battle Cry|R|VMA
 #120|Keldon Necropolis|R|VMA
 #121|Pillaging Horde|U|VMA
 #122|Tendrils of Agony|U|VMA
@@ -131,10 +131,10 @@
 #130|Goblin Warchief|U|VMA
 #131|Goblin Ringleader|U|VMA
 #132|Hermit Druid|R|VMA
-#133|Su Chi|U|VMA
+#133|Su-Chi|U|VMA
 #134|Flowstone Sculpture|R|VMA
 #135|Predatory Nightstalker|C|VMA
-#136|Selvala Explorer Returned|R|VMA
+#136|Selvala, Explorer Returned|R|VMA
 #137|Counterspell|C|VMA
 #138|Gush|U|VMA
 #139|Necropotence|R|VMA
@@ -145,7 +145,7 @@
 #144|Deep Analysis|C|VMA
 #145|Armadillo Cloak|U|VMA
 #146|Plea for Power|R|VMA
-#147|Pianna Nomad Captain|U|VMA
+#147|Pianna, Nomad Captain|U|VMA
 #148|Smokestack|R|VMA
 #149|Death Grasp|U|VMA
 #150|Deathreap Ritual|U|VMA
@@ -160,10 +160,10 @@
 #159|Plateau|R|VMA
 #160|Scrubland|R|VMA
 #161|Grizzly Fate|U|VMA
-#162|Yawgmoths Bargain|M|VMA
+#162|Yawgmoth's Bargain|M|VMA
 #163|Dack Fayden|M|VMA
 #164|Kindle|C|VMA
-#165|Chainers Edict|C|VMA
+#165|Chainer's Edict|C|VMA
 #166|Power Sink|U|VMA
 #167|Exile|C|VMA
 #168|Fireblast|U|VMA
@@ -184,7 +184,7 @@
 #183|Brindle Shoat|C|VMA
 #184|Sidar Jabari|U|VMA
 #185|Stoic Champion|U|VMA
-#186|Natures Lore|C|VMA
+#186|Nature's Lore|C|VMA
 #187|Rites of Initiation|U|VMA
 #188|Orcish Lumberjack|C|VMA
 #189|Mystic Zealot|U|VMA
@@ -195,7 +195,7 @@
 #194|Nightscape Familiar|C|VMA
 #195|Goblin Piledriver|R|VMA
 #196|Cloud of Faeries|U|VMA
-#197|Deaths Head Buzzard|C|VMA
+#197|Death's-Head Buzzard|C|VMA
 #198|Cruel Bargain|R|VMA
 #199|Shelter|C|VMA
 #200|Goblin Commando|C|VMA
@@ -207,8 +207,8 @@
 #206|Barren Moor|C|VMA
 #207|Turnabout|U|VMA
 #208|High Tide|U|VMA
-#209|Akromas Blessing|U|VMA
-#210|Predator Flagship|R|VMA
+#209|Akroma's Blessing|U|VMA
+#210|Predator, Flagship|R|VMA
 #211|Goblin Matron|C|VMA
 #212|Gamble|R|VMA
 #213|Norwood Priestess|R|VMA
@@ -249,13 +249,13 @@
 #248|Giant Mantis|C|VMA
 #249|Frantic Search|C|VMA
 #250|Paralyze|C|VMA
-#251|Radiants Judgment|C|VMA
+#251|Radiant's Judgment|C|VMA
 #252|Realm Seekers|R|VMA
 #253|Thalakos Drifters|U|VMA
 #254|Breath of Life|U|VMA
 #255|Goblin General|C|VMA
 #256|Aquamoeba|C|VMA
-#257|Minds Desire|R|VMA
+#257|Mind's Desire|R|VMA
 #258|Regrowth|R|VMA
 #259|Flowstone Hellion|U|VMA
 #260|Armor of Thorns|C|VMA
@@ -264,7 +264,7 @@
 #263|Cabal Ritual|U|VMA
 #264|Elvish Aberration|C|VMA
 #265|Benevolent Bodyguard|C|VMA
-#266|Terohs Faithful|C|VMA
+#266|Teroh's Faithful|C|VMA
 #267|Choking Tethers|C|VMA
 #268|Skirge Familiar|C|VMA
 #269|Tangle|C|VMA
@@ -278,15 +278,15 @@
 #277|Provoke|C|VMA
 #278|Hulking Goblin|C|VMA
 #279|Worldgorger Dragon|R|VMA
-#280|Natures Ruin|R|VMA
-#281|Volraths Shapeshifter|R|VMA
+#280|Nature's Ruin|R|VMA
+#281|Volrath's Shapeshifter|R|VMA
 #282|Rescind|C|VMA
 #283|Chartooth Cougar|C|VMA
 #284|Putrid Imp|C|VMA
 #285|Circular Logic|C|VMA
 #286|Claws of Wirewood|U|VMA
 #287|Addle|C|VMA
-#288|Tyrants Choice|C|VMA
+#288|Tyrant's Choice|C|VMA
 #289|Devout Witness|U|VMA
 #290|Mana Prism|C|VMA
 #291|Burning Wish|R|VMA
@@ -302,7 +302,7 @@
 #301|Saproling Burst|R|VMA
 #302|Brilliant Halo|C|VMA
 #303|Fastbond|M|VMA
-#304|Karn Silver Golem|R|VMA
+#304|Karn, Silver Golem|R|VMA
 #305|Flusterstorm|R|VMA
 #306|Astral Slide|U|VMA
 #307|Tribute to the Wild|C|VMA
@@ -316,11 +316,11 @@
 #315|Ichorid|R|VMA
 #316|Bazaar of Baghdad|M|VMA
 #317|Null Rod|R|VMA
-#318|Muzzio Visionary Architect|M|VMA
+#318|Muzzio, Visionary Architect|M|VMA
 #319|Sphere of Resistance|R|VMA
 #320|City in a Bottle|M|VMA
 #321|Ivory Tower|U|VMA
-#322|Lions Eye Diamond|M|VMA
+#322|Lion's Eye Diamond|M|VMA
 #323|Time Vault|M|VMA
-#324|Mishras Workshop|M|VMA
+#324|Mishra's Workshop|M|VMA
 #325|Tolarian Academy|M|VMA

--- a/forge-gui/res/draft/rankings/wth.rnk
+++ b/forge-gui/res/draft/rankings/wth.rnk
@@ -136,7 +136,7 @@
 #135|Thran Forge|U|WTH
 #136|Touchstone|U|WTH
 #137|Disrupt|C|WTH
-#138|Bosium Strip|R|WTH
+#138|Bösium Strip|R|WTH
 #139|Fervor|R|WTH
 #140|Jabari's Banner|U|WTH
 #141|Flux|C|WTH

--- a/forge-gui/res/draft/rankings/zen.rnk
+++ b/forge-gui/res/draft/rankings/zen.rnk
@@ -56,7 +56,7 @@
 #55|Goblin Guide|R|ZEN
 #56|Pitfall Trap|U|ZEN
 #57|Kor Aeronaut|U|ZEN
-#58|Oran Rief Survivalist|C|ZEN
+#58|Oran-Rief Survivalist|C|ZEN
 #59|Kor Hookmaster|C|ZEN
 #60|Arrow Volley Trap|U|ZEN
 #61|Arid Mesa|R|ZEN
@@ -73,7 +73,7 @@
 #72|Scalding Tarn|R|ZEN
 #73|Welkin Tern|C|ZEN
 #74|Torch Slinger|C|ZEN
-#75|Nimana Sell Sword|C|ZEN
+#75|Nimana Sell-Sword|C|ZEN
 #76|Surrakar Marauder|C|ZEN
 #77|Harrow|C|ZEN
 #78|Turntimber Basilisk|U|ZEN
@@ -102,7 +102,7 @@
 #101|Into the Roil|C|ZEN
 #102|Warren Instigator|M|ZEN
 #103|Tuktuk Grunts|C|ZEN
-#104|Oran Rief, the Vastwood|R|ZEN
+#104|Oran-Rief, the Vastwood|R|ZEN
 #105|Shatterskull Giant|C|ZEN
 #106|Gomazoa|U|ZEN
 #107|Mind Sludge|U|ZEN
@@ -123,7 +123,7 @@
 #122|Vines of Vastwood|C|ZEN
 #123|Magma Rift|C|ZEN
 #124|Greenweaver Druid|U|ZEN
-#125|Oran Rief Recluse|C|ZEN
+#125|Oran-Rief Recluse|C|ZEN
 #126|Cliff Threader|C|ZEN
 #127|Kor Cartographer|C|ZEN
 #128|Sky Ruin Drake|C|ZEN


### PR DESCRIPTION
Reportedly, issues with orthography were causing a default ranking of 0 to be displayed for a number of cards across several sets. Names were gleaned from the first line of `\cardsfolder ` scripts and compared with a similar list compiled from the rankings files to single out any issues. 
These issues were chiefly missing hyphens, apostrophes, commas and accents which were addressed to both resolve any issue orthographical differences might cause and to ease similar subsequent cleanup checks.