### PR TITLE
Add "Copy Collection to Clipboard" button to adventure mode deck editor

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/scene/AdventureDeckEditor.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/AdventureDeckEditor.java
@@ -577,6 +577,9 @@ public class AdventureDeckEditor extends TabPageScreen<AdventureDeckEditor> {
                     @Override
                     protected void buildMenu() {
                         addItem(new FMenuItem(Forge.getLocalizer().getMessage("btnCopyToClipboard"), Forge.hdbuttons ? FSkinImage.HDEXPORT : FSkinImage.BLANK, e1 -> FDeckViewer.copyDeckToClipboard(getDeck())));
+                        addItem(new FMenuItem(Forge.getLocalizer().getMessage("btnCopyCollectionToClipboard"), Forge.hdbuttons ? FSkinImage.HDEXPORT : FSkinImage.BLANK, e1 -> {
+                            FDeckViewer.copyCollectionToClipboard(AdventurePlayer.current().getCards());
+                        }));
                         if (allowsAddBasic()) {
                             FMenuItem addBasic = new FMenuItem(Forge.getLocalizer().getMessage("lblAddBasicLands"), FSkinImage.LANDLOGO, e1 -> launchBasicLandDialog());
                             addItem(addBasic);

--- a/forge-gui-mobile/src/forge/deck/FDeckViewer.java
+++ b/forge-gui-mobile/src/forge/deck/FDeckViewer.java
@@ -16,7 +16,6 @@ import forge.menu.FPopupMenu;
 import forge.screens.FScreen;
 import forge.screens.match.MatchController;
 import forge.toolbox.FOptionPane;
-import forge.util.ItemPool;
 
 public class FDeckViewer extends FScreen {
     private static FDeckViewer deckViewer;

--- a/forge-gui-mobile/src/forge/deck/FDeckViewer.java
+++ b/forge-gui-mobile/src/forge/deck/FDeckViewer.java
@@ -73,14 +73,14 @@ public class FDeckViewer extends FScreen {
         FOptionPane.showMessageDialog(Forge.getLocalizer().getMessage("lblDeckListCopiedClipboard", deck.getName()));
     }
 
-    public static void copyCollectionToClipboard(ItemPool<PaperCard> pool) {
+    public static void copyCollectionToClipboard(CardPool pool) {
         final String nl = System.lineSeparator();
         final StringBuilder collectionList = new StringBuilder();
         Set<String> accounted = new HashSet<>();
         for (final Entry<PaperCard, Integer> entry : pool) {
             String cardName = entry.getKey().getCardName();
             if (!accounted.contains(cardName)) {
-                collectionList.append(entry.getValue()).append(" ").append(cardName).append(nl);
+                collectionList.append(pool.countByName(cardName)).append(" ").append(cardName).append(nl);
                 accounted.add(cardName);
             }
         }

--- a/forge-gui-mobile/src/forge/deck/FDeckViewer.java
+++ b/forge-gui-mobile/src/forge/deck/FDeckViewer.java
@@ -16,6 +16,7 @@ import forge.menu.FPopupMenu;
 import forge.screens.FScreen;
 import forge.screens.match.MatchController;
 import forge.toolbox.FOptionPane;
+import forge.util.ItemPool;
 
 public class FDeckViewer extends FScreen {
     private static FDeckViewer deckViewer;
@@ -70,6 +71,21 @@ public class FDeckViewer extends FScreen {
 
         Forge.getClipboard().setContents(deckList.toString());
         FOptionPane.showMessageDialog(Forge.getLocalizer().getMessage("lblDeckListCopiedClipboard", deck.getName()));
+    }
+
+    public static void copyCollectionToClipboard(ItemPool<PaperCard> pool) {
+        final String nl = System.lineSeparator();
+        final StringBuilder collectionList = new StringBuilder();
+        java.util.Set<String> accounted = new java.util.HashSet<>();
+        for (final java.util.Map.Entry<PaperCard, Integer> entry : pool) {
+            String cardName = entry.getKey().getCardName();
+            if (!accounted.contains(cardName)) {
+                collectionList.append(entry.getValue()).append(" ").append(cardName).append(nl);
+                accounted.add(cardName);
+            }
+        }
+        Forge.getClipboard().setContents(collectionList.toString());
+        FOptionPane.showMessageDialog(Forge.getLocalizer().getMessage("lblCollectionCopiedClipboard"));
     }
 
     private final Deck deck;

--- a/forge-gui-mobile/src/forge/deck/FDeckViewer.java
+++ b/forge-gui-mobile/src/forge/deck/FDeckViewer.java
@@ -76,8 +76,8 @@ public class FDeckViewer extends FScreen {
     public static void copyCollectionToClipboard(ItemPool<PaperCard> pool) {
         final String nl = System.lineSeparator();
         final StringBuilder collectionList = new StringBuilder();
-        java.util.Set<String> accounted = new java.util.HashSet<>();
-        for (final java.util.Map.Entry<PaperCard, Integer> entry : pool) {
+        Set<String> accounted = new HashSet<>();
+        for (final Entry<PaperCard, Integer> entry : pool) {
             String cardName = entry.getKey().getCardName();
             if (!accounted.contains(cardName)) {
                 collectionList.append(entry.getValue()).append(" ").append(cardName).append(nl);

--- a/forge-gui/res/languages/de-DE.properties
+++ b/forge-gui/res/languages/de-DE.properties
@@ -52,6 +52,7 @@ btnResetJavaFutureCompatibilityWarnings=Java-Kompatibilitätswarnung zurücksetz
 btnClearImageCache=Leere Bildspeicher
 btnTokenPreviewer=Spielstein-Vorschau
 btnCopyToClipboard=In Zwischenablage kopieren
+btnCopyCollectionToClipboard=Kartensammlung in Zwischenablage kopieren
 cbpAutoUpdater=Auto-Updater
 cbpServerUPnPOption=Server UPnP
 nlAutoUpdater=Wähle aus welcher Quelle Forge aktualisiert wird
@@ -1251,6 +1252,7 @@ lblNoKnownCardsOnClipboard=Keine Karten in der Zwischenablage gefunden.\n\nKopie
 #FDeckViewer.java
 lblChangeSection=Wechsle Bereich
 lblDeckListCopiedClipboard=Deckliste von "{0}" in Zwischenablage kopiert.
+lblCollectionCopiedClipboard=Kartensammlung in Zwischenablage kopiert.
 #FSideboardDialog.java
 lblUpdateMainFromSideboard=Aktuallisiere %s aus dem Sideboard
 #FVanguardChooser.java

--- a/forge-gui/res/languages/en-US.properties
+++ b/forge-gui/res/languages/en-US.properties
@@ -52,6 +52,7 @@ btnResetJavaFutureCompatibilityWarnings=Reset Java Compatibility Warnings
 btnClearImageCache=Clear Image Cache
 btnTokenPreviewer=Token Previewer
 btnCopyToClipboard=Copy to Clipboard
+btnCopyCollectionToClipboard=Copy Collection to Clipboard
 cbpAutoUpdater=Auto updater
 cbpServerUPnPOption=Server UPnP
 nlAutoUpdater=Select the release channel to use for updating Forge
@@ -1268,6 +1269,7 @@ lblNoKnownCardsOnClipboard=No known cards found on clipboard.\n\nCopy the deckli
 #FDeckViewer.java
 lblChangeSection=Change Section
 lblDeckListCopiedClipboard=Deck list for ''{0}'' copied to clipboard.
+lblCollectionCopiedClipboard=Card collection copied to clipboard.
 #FSideboardDialog.java
 lblUpdateMainFromSideboard=Update main deck from sideboard (%s)
 #FVanguardChooser.java

--- a/forge-gui/res/languages/es-ES.properties
+++ b/forge-gui/res/languages/es-ES.properties
@@ -52,6 +52,7 @@ btnResetJavaFutureCompatibilityWarnings=Restablecer las advertencias de compatib
 btnClearImageCache=Limpiar caché de imágenes
 btnTokenPreviewer=Previsualizador de fichas (tokens)
 btnCopyToClipboard=Copiar al portapapeles
+btnCopyCollectionToClipboard=Copiar colección al portapapeles
 cbpAutoUpdater=Actualizar Forge
 cbpServerUPnPOption=Server UPnP
 nlAutoUpdater=Selecciona la versión a utilizar para actualizar Forge
@@ -1258,6 +1259,7 @@ lblNoKnownCardsOnClipboard=No se han encontrado cartas conocidas en el portapape
 #FDeckViewer.java
 lblChangeSection=Cambiar sección
 lblDeckListCopiedClipboard=Lista de mazo para ''{0}'' copiada al portapapeles.
+lblCollectionCopiedClipboard=Colección de cartas copiada al portapapeles.
 #FSideboardDialog.java
 lblUpdateMainFromSideboard=Actualiza el mazo principal desde el banquillo de %s
 #FVanguardChooser.java

--- a/forge-gui/res/languages/fr-FR.properties
+++ b/forge-gui/res/languages/fr-FR.properties
@@ -52,6 +52,7 @@ btnResetJavaFutureCompatibilityWarnings=Réinitialiser les avertissements de com
 btnClearImageCache=Effacer le cache des images
 btnTokenPreviewer=Aperçu des jetons
 btnCopyToClipboard=Copier dans le presse-papiers
+btnCopyCollectionToClipboard=Copier la collection dans le presse-papiers
 cbpAutoUpdater=Mise à jour automatique
 cbpServerUPnPOption=Server UPnP
 nlAutoUpdater=Sélectionnez le canal de publication à utiliser pour mettre à jour Forge
@@ -1252,6 +1253,7 @@ lblNoKnownCardsOnClipboard=Aucune carte connue trouvée dans le presse-papiers.\
 #FDeckViewer.java
 lblChangeSection=Changer de section
 lblDeckListCopiedClipboard=Liste des decks pour '{0}' copiée dans le presse-papiers.
+lblCollectionCopiedClipboard=Collection de cartes copiée dans le presse-papiers.
 #FSideboardDialog.java
 lblUpdateMainFromSideboard=Mettre à jour le deck principal depuis la réserve%s
 #FVanguardChooser.java

--- a/forge-gui/res/languages/it-IT.properties
+++ b/forge-gui/res/languages/it-IT.properties
@@ -51,6 +51,7 @@ btnResetJavaFutureCompatibilityWarnings=Ripristina avvisi di compatibilità Java
 btnClearImageCache=Cancella cache immagini
 btnTokenPreviewer=Visualizzatore di pedine
 btnCopyToClipboard=Copia negli appunti
+btnCopyCollectionToClipboard=Copia collezione negli appunti
 cbpAutoUpdater=Auto updater
 cbpServerUPnPOption=Server UPnP
 nlAutoUpdater=Seleziona il canale di distribuzione da usare per aggiornare Forge
@@ -1249,6 +1250,7 @@ lblNoKnownCardsOnClipboard=Nessuna carta nota trovata negli appunti. \n \nCopia 
 #FDeckViewer.java
 lblChangeSection=Cambia sezione
 lblDeckListCopiedClipboard=Lista del mazzo per ' {0}' copiato negli appunti.
+lblCollectionCopiedClipboard=Collezione di carte copiata negli appunti.
 #FSideboardDialog.java
 lblUpdateMainFromSideboard=Aggiorna il mazzo dalla sideboard %s
 #FVanguardChooser.java

--- a/forge-gui/res/languages/ja-JP.properties
+++ b/forge-gui/res/languages/ja-JP.properties
@@ -52,6 +52,7 @@ btnResetJavaFutureCompatibilityWarnings=Java 互換性の警告をリセット
 btnClearImageCache=画像キャッシュのクリア
 btnTokenPreviewer=トークンを見る
 btnCopyToClipboard=クリップボードにコピー
+btnCopyCollectionToClipboard=コレクションをクリップボードにコピー
 cbpAutoUpdater=自動アップデート
 cbpServerUPnPOptions=Server UPnP
 nlAutoUpdater=Forge を更新する時に使用するリリースチャネルを選択
@@ -1251,6 +1252,7 @@ lblNoKnownCardsOnClipboard=クリップボードに既知のカードが見つ�
 #FDeckViewer.java
 lblChangeSection=選択変更
 lblDeckListCopiedClipboard=クリップボードにコピーされた ''{0}'' のデッキリスト。
+lblCollectionCopiedClipboard=カードコレクションがクリップボードにコピーされました。
 #FSideboardDialog.java
 lblUpdateMainFromSideboard=メインデッキをサイドボード%sから更新
 #FVanguardChooser.java

--- a/forge-gui/res/languages/pt-BR.properties
+++ b/forge-gui/res/languages/pt-BR.properties
@@ -53,6 +53,7 @@ btnResetJavaFutureCompatibilityWarnings=Redefinir Avisos de Compatibilidade Java
 btnClearImageCache=Limpar Cache de Imagens
 btnTokenPreviewer=Pré-visualizador de Ficha
 btnCopyToClipboard=Copiar para Área de Transferência
+btnCopyCollectionToClipboard=Copiar coleção para a área de transferência
 cbpAutoUpdater=Atualização automática
 cbpServerUPnPOption=Server UPnP
 nlAutoUpdater=Selecione o canal de lançamento para atualizar o Forge
@@ -1279,6 +1280,7 @@ Copie a lista do deck para a área de transferência e reabra este diálogo.
 #FDeckViewer.java
 lblChangeSection=Alterar Seção
 lblDeckListCopiedClipboard=Lista de deck de ''{0}'' copiada para área de transferência.
+lblCollectionCopiedClipboard=Coleção de cartas copiada para a área de transferência.
 #FSideboardDialog.java
 lblUpdateMainFromSideboard=Atualizar o deck principal a partir da reserva%s
 #FVanguardChooser.java

--- a/forge-gui/res/languages/zh-CN.properties
+++ b/forge-gui/res/languages/zh-CN.properties
@@ -52,6 +52,7 @@ btnResetJavaFutureCompatibilityWarnings=重置Java兼容性警告
 btnClearImageCache=清除图片缓存
 btnTokenPreviewer=衍生物预览器
 btnCopyToClipboard=复制到剪切板
+btnCopyCollectionToClipboard=复制收藏到剪贴板
 cbpSelectLanguage=语言
 cbpAutoUpdater=自动更新 
 cbpServerUPnPOption=Server UPnP
@@ -1255,6 +1256,7 @@ lblNoKnownCardsOnClipboard=在剪切板找不到已知的卡牌。\n\n将套牌�
 #FDeckViewer.java
 lblChangeSection=切换部分
 lblDeckListCopiedClipboard=套牌列表''{0}''已经复制到剪切板
+lblCollectionCopiedClipboard=卡牌收藏已复制到剪贴板。
 #FSideboardDialog.java
 lblUpdateMainFromSideboard=为%s进行换备
 #FVanguardChooser.java


### PR DESCRIPTION
Adds new button to the adventure mode deck editor that enables users to copy full collection to clipboard.

This is useful when using external tools and websites for deck building.

PR includes translations for all supported languages.

![Screenshot 2025-06-07 at 5 51 12 PM](https://github.com/user-attachments/assets/70cbb0ca-856b-4c0c-8436-c7375b300eca)
