### PR TITLE
Cleanup: DBCleanup

### DIFF
--- a/forge-gui/res/cardsfolder/a/aberrant_researcher_perfected_form.txt
+++ b/forge-gui/res/cardsfolder/a/aberrant_researcher_perfected_form.txt
@@ -5,8 +5,8 @@ PT:3/2
 K:Flying
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigMill | TriggerDescription$ At the beginning of your upkeep, mill a card. If an instant or sorcery card was milled this way, transform CARDNAME.
 SVar:TrigMill:DB$ Mill | Defined$ You | RememberMilled$ True | SubAbility$ DBTransform
-SVar:DBTransform:DB$ SetState | Defined$ Self | ConditionDefined$ Remembered | ConditionPresent$ Card.Instant,Card.Sorcery | SubAbility$ Cleanup | Mode$ Transform
-SVar:Cleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBTransform:DB$ SetState | Defined$ Self | ConditionDefined$ Remembered | ConditionPresent$ Card.Instant,Card.Sorcery | SubAbility$ DBCleanup | Mode$ Transform
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 DeckHints:Ability$Delirium & Type$Instant|Sorcery
 AlternateMode:DoubleFaced
 Oracle:Flying\nAt the beginning of your upkeep, mill a card. If an instant or sorcery card was milled this way, transform Aberrant Researcher.

--- a/forge-gui/res/cardsfolder/a/ancient_vendetta.txt
+++ b/forge-gui/res/cardsfolder/a/ancient_vendetta.txt
@@ -1,10 +1,10 @@
 Name:Ancient Vendetta
 ManaCost:3 B
 Types:Sorcery
-A:SP$ NameCard | Defined$ You | SubAbility$ ExileYard | SpellDescription$ Choose a card name. Search target opponent's graveyard, hand, and library for up to four cards with that name and exile them. That player shuffles.
-SVar:ExileYard:DB$ ChangeZone | ValidTgts$ Opponent | ChangeType$ Card.NamedCard | Origin$ Graveyard | DefinedPlayer$ Targeted | Chooser$ You | Destination$ Exile | ChangeNum$ Y | Hidden$ True | RememberChanged$ True | SubAbility$ ExileHand
-SVar:ExileHand:DB$ ChangeZone | Origin$ Hand | Destination$ Exile | DefinedPlayer$ Targeted | ChangeType$ Card.NamedCard | ChangeNum$ Y | Chooser$ You | SubAbility$ ExileLib | RememberChanged$ True
-SVar:ExileLib:DB$ ChangeZone | Origin$ Library | Destination$ Exile | DefinedPlayer$ Targeted | ChangeType$ Card.NamedCard | ChangeNum$ Y | Chooser$ You | Shuffle$ True
+A:SP$ NameCard | Defined$ You | SubAbility$ ExileYard | StackDescription$ REP Choose a_{p:You} chooses a & Search target opponent's_{p:You} searches {p:Targeted}'s & and exile_and exiles & That player_{p:Targeted} | SpellDescription$ Choose a card name. Search target opponent's graveyard, hand, and library for up to four cards with that name and exile them. That player shuffles.
+SVar:ExileYard:DB$ ChangeZone | ValidTgts$ Opponent | ChangeType$ Card.NamedCard | Origin$ Graveyard | DefinedPlayer$ Targeted | Chooser$ You | Destination$ Exile | ChangeNum$ Y | Hidden$ True | RememberChanged$ True | SubAbility$ ExileHand | StackDescription$ None
+SVar:ExileHand:DB$ ChangeZone | Origin$ Hand | Destination$ Exile | DefinedPlayer$ Targeted | ChangeType$ Card.NamedCard | ChangeNum$ Y | Chooser$ You | SubAbility$ ExileLib | RememberChanged$ True | StackDescription$ None
+SVar:ExileLib:DB$ ChangeZone | Origin$ Library | Destination$ Exile | DefinedPlayer$ Targeted | ChangeType$ Card.NamedCard | ChangeNum$ Y | Chooser$ You | Shuffle$ True | SubAbility$ DBCleanup | StackDescription$ None
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Remembered$Amount
 SVar:Y:SVar$X/NMinus.4

--- a/forge-gui/res/cardsfolder/b/blue_dragon.txt
+++ b/forge-gui/res/cardsfolder/b/blue_dragon.txt
@@ -7,6 +7,5 @@ T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.S
 SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Choose target creature an opponent controls (-3/-0) | NumAtt$ -3 | Duration$ UntilYourNextTurn | SubAbility$ DBPump
 SVar:DBPump:DB$ Pump | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Choose up to one other target creature an opponent controls (-2/-0) | TargetMin$ 0 | TargetMax$ 1 | NumAtt$ -2 | TargetUnique$ True | Duration$ UntilYourNextTurn | SubAbility$ DBPump2
 SVar:DBPump2:DB$ Pump | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Choose up to one other target creature an opponent controls (-1/-0) | TargetMin$ 0 | TargetMax$ 1 | NumAtt$ -1 | TargetUnique$ True | Duration$ UntilYourNextTurn
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:PlayMain1:TRUE
 Oracle:Flying\nLightning Breath — When Blue Dragon enters, until your next turn, target creature an opponent controls gets -3/-0, up to one other target creature gets -2/-0, and up to one other target creature gets -1/-0.

--- a/forge-gui/res/cardsfolder/b/breath_of_fury.txt
+++ b/forge-gui/res/cardsfolder/b/breath_of_fury.txt
@@ -7,7 +7,7 @@ T:Mode$ DamageDone | ValidSource$ Card.AttachedBy | ValidTarget$ Player | Combat
 SVar:TrigSacrifice:DB$ SacrificeAll | ValidCards$ Card.EnchantedBy | SubAbility$ StillFurious
 SVar:StillFurious:DB$ Attach | Object$ Self | Choices$ Creature.YouCtrl | ChoiceTitle$ Choose a creature you control to attach Breath of Fury to | RememberAttached$ True | SubAbility$ CatchBreath
 SVar:CatchBreath:DB$ UntapAll | ValidCards$ Creature.YouCtrl | SubAbility$ TheFuryContinues | ConditionDefined$ Remembered | ConditionPresent$ Card
-SVar:TheFuryContinues:DB$ AddPhase | ExtraPhase$ Combat | AfterPhase$ EndCombat | ConditionDefined$ Remembered | ConditionPresent$ Card | SubAbility$ Cleanup
-SVar:Cleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:TheFuryContinues:DB$ AddPhase | ExtraPhase$ Combat | AfterPhase$ EndCombat | ConditionDefined$ Remembered | ConditionPresent$ Card | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 AI:RemoveDeck:All
 Oracle:Enchant creature you control\nWhen enchanted creature deals combat damage to a player, sacrifice it and attach Breath of Fury to a creature you control. If you do, untap all creatures you control and after this phase, there is an additional combat phase.

--- a/forge-gui/res/cardsfolder/b/breyas_apprentice.txt
+++ b/forge-gui/res/cardsfolder/b/breyas_apprentice.txt
@@ -6,7 +6,7 @@ T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.S
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ c_1_1_a_thopter_flying | TokenOwner$ You
 A:AB$ Charm | Cost$ T Sac<1/Artifact> | Choices$ DBImpulse,DBPump | Defined$ You
 SVar:DBImpulse:DB$ Dig | Defined$ You | DigNum$ 1 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBEffect | SpellDescription$ Exile the top card of your library. Until the end of your next turn, you may play that card.
-SVar:DBEffect:DB$ Effect | StaticAbilities$ StaticMayPlay | Duration$ UntilTheEndOfYourNextTurn | RememberObjects$ Remembered | ForgetOnMoved$ Exile
+SVar:DBEffect:DB$ Effect | StaticAbilities$ StaticMayPlay | Duration$ UntilTheEndOfYourNextTurn | RememberObjects$ Remembered | ForgetOnMoved$ Exile | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:StaticMayPlay:Mode$ Continuous | Affected$ Card.IsRemembered | AffectedZone$ Exile | MayPlay$ True | Description$ Until the end of your next turn, you may play that card.
 SVar:DBPump:DB$ Pump | ValidTgts$ Creature | NumAtt$ +2 | TgtPrompt$ Select target creature. | SpellDescription$ Target creature gets +2/+0 until end of turn.

--- a/forge-gui/res/cardsfolder/c/calix_destinys_hand.txt
+++ b/forge-gui/res/cardsfolder/c/calix_destinys_hand.txt
@@ -4,8 +4,8 @@ Types:Legendary Planeswalker Calix
 Loyalty:4
 A:AB$ Dig | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | DigNum$ 4 | ChangeNum$ 1 | Optional$ True | ForceRevealToController$ True | ChangeValid$ Enchantment | RestRandomOrder$ True | SpellDescription$ Look at the top four cards of your library. You may reveal an enchantment card from among them and put that card into your hand. Put the rest on the bottom of your library in a random order.
 A:AB$ ChangeZone | Cost$ SubCounter<3/LOYALTY> | Planeswalker$ True | ValidTgts$ Creature.YouDontCtrl,Enchantment.YouDontCtrl | TgtPrompt$ Select target creature or enchantment you don't control | Origin$ Battlefield | Destination$ Exile | RememberChanged$ True | SubAbility$ DBEffect | SpellDescription$ Exile target creature or enchantment you don't control until target enchantment you control leaves the battlefield.
-SVar:DBEffect:DB$ Effect | ValidTgts$ Enchantment.YouCtrl | TgtPrompt$ Select target enchantment you control | Triggers$ ComeBack | RememberObjects$ Remembered | ImprintCards$ ThisTargetedCard | ConditionPresent$ Card.Self | Duration$ Permanent | ForgetOnMoved$ Exile | SubAbility$ Cleanup
-SVar:Cleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBEffect:DB$ Effect | ValidTgts$ Enchantment.YouCtrl | TgtPrompt$ Select target enchantment you control | Triggers$ ComeBack | RememberObjects$ Remembered | ImprintCards$ ThisTargetedCard | ConditionPresent$ Card.Self | Duration$ Permanent | ForgetOnMoved$ Exile | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:ComeBack:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | ValidCard$ Card.IsImprinted | Execute$ TrigReturn | TriggerZones$ Command | TriggerController$ TriggeredCardController | Static$ True | TriggerDescription$ Target is exiled until target enchantment you control leaves the battlefield.
 SVar:TrigReturn:DB$ ChangeZone | Origin$ Exile | Destination$ Battlefield | Defined$ Remembered | SubAbility$ ExileSelf
 SVar:ExileSelf:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self

--- a/forge-gui/res/cardsfolder/c/corrosive_ooze.txt
+++ b/forge-gui/res/cardsfolder/c/corrosive_ooze.txt
@@ -7,6 +7,6 @@ T:Mode$ AttackerBlockedByCreature | ValidCard$ Card.Self | ValidBlocker$ Creatur
 SVar:DelTrigAttacker:DB$ DelayedTrigger | Mode$ Phase | Phase$ EndCombat | ValidPlayer$ Player | Execute$ TrigRem | RememberObjects$ TriggeredAttackerLKICopy | TriggerDescription$ Destroy all Equipment attached to blocked creature at end of combat.
 SVar:DelTrigBlocker:DB$ DelayedTrigger | Mode$ Phase | Phase$ EndCombat | ValidPlayer$ Player | Execute$ TrigRem | RememberObjects$ TriggeredBlockerLKICopy | TriggerDescription$ Destroy all Equipment attached to blocking creature at end of combat.
 SVar:TrigRem:DB$ Pump | RememberObjects$ DelayTriggerRememberedLKI | SubAbility$ TrigDestroy
-SVar:TrigDestroy:DB$ DestroyAll | ValidCards$ Remembered.Equipment+Attached | SpellDescription$ Destroy all Equipment attached to that creature. | SubAbility$ Cleanup
-SVar:Cleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:TrigDestroy:DB$ DestroyAll | ValidCards$ Remembered.Equipment+Attached | SpellDescription$ Destroy all Equipment attached to that creature. | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Whenever Corrosive Ooze blocks or becomes blocked by an equipped creature, destroy all Equipment attached to that creature at end of combat.

--- a/forge-gui/res/cardsfolder/f/frenetic_sliver.txt
+++ b/forge-gui/res/cardsfolder/f/frenetic_sliver.txt
@@ -7,7 +7,7 @@ SVar:Frenetic:AB$ FlipACoin | Cost$ 0 | ConditionPresent$ Card.Self | ConditionC
 SVar:DBExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | Defined$ Self | RememberChanged$ True | SubAbility$ DelTrig
 SVar:DelTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ MoveBack | RememberObjects$ RememberedLKI | SubAbility$ DBCleanup | TriggerDescription$ Return CARDNAME to the battlefield under its owner's control at the beginning of the next end step.
 SVar:MoveBack:DB$ ChangeZone | Origin$ Exile | Destination$ Battlefield | Defined$ DelayTriggerRememberedLKI
-SVar:Cleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:DBSacSelf:DB$ Sacrifice
 SVar:PlayMain1:TRUE
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/g/grave_peril.txt
+++ b/forge-gui/res/cardsfolder/g/grave_peril.txt
@@ -3,7 +3,6 @@ ManaCost:1 B
 Types:Enchantment
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.nonBlack | TriggerZones$ Battlefield | Execute$ TrigSac | TriggerDescription$ When a nonblack creature enters, sacrifice CARDNAME. If you do, destroy that creature.
 SVar:TrigSac:AB$ Destroy | Defined$ TriggeredCardLKICopy | Cost$ Mandatory Sac<1/CARDNAME>
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:NonStackingEffect:True
 AI:RemoveDeck:Random
 Oracle:When a nonblack creature enters, sacrifice Grave Peril. If you do, destroy that creature.

--- a/forge-gui/res/cardsfolder/g/grimoire_thief.txt
+++ b/forge-gui/res/cardsfolder/g/grimoire_thief.txt
@@ -3,10 +3,10 @@ ManaCost:U U
 Types:Creature Merfolk Rogue
 PT:2/2
 T:Mode$ Taps | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ Whenever CARDNAME becomes tapped, exile the top three cards of target opponent's library face down.
-SVar:TrigExile:DB$ Dig | ValidTgts$ Opponent | DigNum$ 3 | ChangeNum$ All | DestinationZone$ Exile | ExileFaceDown$ True | RememberChanged$ True
+SVar:TrigExile:DB$ Dig | ValidTgts$ Opponent | DigNum$ 3 | ChangeNum$ All | DestinationZone$ Exile | ExileFaceDown$ True
 S:Mode$ Continuous | Affected$ Card.ExiledWithSource | AffectedZone$ Exile | MayLookAt$ You | Description$ You may look at cards exiled with CARDNAME.
 A:AB$ SetState | Cost$ U Sac<1/CARDNAME> | Defined$ ExiledWithSource | Mode$ TurnFaceUp | SubAbility$ DBCounter | SpellDescription$ Turn all cards exiled with CARDNAME face up. Counter all spells with those names.
-SVar:DBCounter:DB$ Counter | Defined$ ValidStack Spell.sharesNameWith ExiledWithSource | SubAbility$ DBCleanup
+SVar:DBCounter:DB$ Counter | Defined$ ValidStack Spell.sharesNameWith ExiledWithSource
 AI:RemoveDeck:All
 AI:RemoveDeck:Random
 Oracle:Whenever Grimoire Thief becomes tapped, exile the top three cards of target opponent's library face down.\nYou may look at cards exiled with Grimoire Thief.\n{U}, Sacrifice Grimoire Thief: Turn all cards exiled with Grimoire Thief face up. Counter all spells with those names.

--- a/forge-gui/res/cardsfolder/k/king_narfis_betrayal.txt
+++ b/forge-gui/res/cardsfolder/k/king_narfis_betrayal.txt
@@ -5,9 +5,9 @@ K:Chapter:3:DBMill,DBEffect,DBEffect
 SVar:DBMill:DB$ Mill | NumCards$ 4 | Defined$ Player | SubAbility$ DBRepeatEach | SpellDescription$ Each player mills four cards. Then you may exile a creature or planeswalker card from each graveyard.
 SVar:DBRepeatEach:DB$ RepeatEach | Optional$ True | OptionPrompt$ Do you want to exile a creature or planeswalker card from each graveyard? | RepeatPlayers$ Player | RepeatSubAbility$ DBChooseCard | SubAbility$ DBExile
 SVar:DBChooseCard:DB$ ChooseCard | Defined$ You | Choices$ Creature.RememberedPlayerCtrl,Planeswalker.RememberedPlayerCtrl | ChoiceZone$ Graveyard | ChoiceTitle$ Choose a creature or planeswalker card in a graveyard | Mandatory$ True | RememberChosen$ True
-SVar:DBExile:DB$ ChangeZoneAll | Origin$ Graveyard | Destination$ Exile | ChangeType$ Card.IsRemembered
+SVar:DBExile:DB$ ChangeZoneAll | Origin$ Graveyard | Destination$ Exile | ChangeType$ Card.IsRemembered | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearChosenCard$ True
-SVar:DBEffect:DB$ Effect | StaticAbilities$ PlayExile | SpellDescription$ Until end of turn, you may cast spells from among cards exiled with CARDNAME, and you may spend mana as though it were mana of any color to cast those spells.
+SVar:DBEffect:DB$ Effect | StaticAbilities$ PlayExile | RememberObjects$ ValidExile Card.ExiledWithSource+nonLand | ForgetOnMoved$ Exile | SpellDescription$ Until end of turn, you may cast spells from among cards exiled with CARDNAME, and you may spend mana as though it were mana of any color to cast those spells.
 SVar:PlayExile:Mode$ Continuous | MayPlayIgnoreType$ True | MayPlayIgnoreColor$ True | MayPlay$ True | Affected$ Card.ExiledWithEffectSource+nonLand | AffectedZone$ Exile | Description$ Until end of turn, you may cast spells from among cards exiled with EFFECTSOURCE, and you may spend mana as though it were mana of any color to cast those spells.
 DeckHas:Ability$Mill
 Oracle:(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI — Each player mills four cards. Then you may exile a creature or planeswalker card from each graveyard.\nII, III — Until end of turn, you may cast spells from among cards exiled with King Narfi's Betrayal, and you may spend mana as though it were mana of any color to cast those spells.

--- a/forge-gui/res/cardsfolder/l/light_up_the_stage.txt
+++ b/forge-gui/res/cardsfolder/l/light_up_the_stage.txt
@@ -3,7 +3,7 @@ ManaCost:2 R
 Types:Sorcery
 K:Spectacle:R
 A:SP$ Dig | Defined$ You | DigNum$ 2 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBEffect | SpellDescription$ Exile the top two cards of your library. Until the end of your next turn, you may play those cards.
-SVar:DBEffect:DB$ Effect | StaticAbilities$ StaticMayPlay | Duration$ UntilTheEndOfYourNextTurn | RememberObjects$ Remembered | ForgetOnMoved$ Exile
+SVar:DBEffect:DB$ Effect | StaticAbilities$ StaticMayPlay | Duration$ UntilTheEndOfYourNextTurn | RememberObjects$ Remembered | ForgetOnMoved$ Exile | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:StaticMayPlay:Mode$ Continuous | Affected$ Card.IsRemembered | AffectedZone$ Exile | MayPlay$ True | Description$ Until the end of your next turn, you may play those cards.
 Oracle:Spectacle {R} (You may cast this spell for its spectacle cost rather than its mana cost if an opponent lost life this turn.)\nExile the top two cards of your library. Until the end of your next turn, you may play those cards.

--- a/forge-gui/res/cardsfolder/l/lolth_spider_queen.txt
+++ b/forge-gui/res/cardsfolder/l/lolth_spider_queen.txt
@@ -9,8 +9,8 @@ SVar:DBLoseLife1:DB$ LoseLife | LifeAmount$ 1
 A:AB$ Token | Cost$ SubCounter<3/LOYALTY> | TokenAmount$ 2 | TokenScript$ b_2_1_spider_menace_reach | TokenOwner$ You | Planeswalker$ True | SpellDescription$ Create two 2/1 black Spider creature tokens with menace and reach.
 A:AB$ Effect | Cost$ SubCounter<8/LOYALTY> | Name$ Emblem — Lolth, Spider Queen | Triggers$ TrigLoseLife | Planeswalker$ True | Ultimate$ True | Duration$ Permanent | AILogic$ Main1 | SpellDescription$ You get an emblem with "Whenever an opponent is dealt combat damage by one or more creatures you control, if that player lost less than 8 life this turn, they lose life equal to the difference."
 SVar:TrigLoseLife:Mode$ DamageDoneOnce | ValidSource$ Creature.YouCtrl | ValidTarget$ Player | CombatDamage$ True | CheckSVar$ X | SVarCompare$ LT8 | Execute$ LoseLife | TriggerZones$ Command | TriggerDescription$ Whenever an opponent is dealt combat damage by one or more creatures you control, if that player lost less than 8 life this turn, they lose life equal to the difference.
-SVar:LoseLife:DB$ LoseLife | Defined$ TriggeredTarget | LifeAmount$ Y | SubAbility$ Cleanup
-SVar:Cleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:LoseLife:DB$ LoseLife | Defined$ TriggeredTarget | LifeAmount$ Y | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:TriggeredTarget$LifeLostThisTurn
 SVar:Y:SVar$X/NMinus.8
 Oracle:Whenever a creature you control dies, put a loyalty counter on Lolth, Spider Queen.\n[0]: You draw a card and you lose 1 life.\n[-3]: Create two 2/1 black Spider creature tokens with menace and reach.\n[-8]: You get an emblem with "Whenever an opponent is dealt combat damage by one or more creatures you control, if that player lost less than 8 life this turn, they lose life equal to the difference."

--- a/forge-gui/res/cardsfolder/m/metathran_aerostat.txt
+++ b/forge-gui/res/cardsfolder/m/metathran_aerostat.txt
@@ -4,8 +4,8 @@ Types:Creature Metathran
 PT:2/2
 K:Flying
 A:AB$ ChangeZone | Cost$ X U | Origin$ Hand | Destination$ Battlefield | ChangeType$ Creature.cmcEQX | ChangeNum$ 1 | RememberChanged$ True | SubAbility$ DBReturn | SpellDescription$ You may put a creature card with mana value X from your hand onto the battlefield. If you do, return CARDNAME to its owner's hand.
-SVar:DBReturn:DB$ ChangeZone | Origin$ Battlefield | Destination$ Hand | Defined$ Self | ConditionDefined$ Remembered | ConditionPresent$ Creature | ConditionCompare$ EQ1 | SubAbility$ Cleanup
+SVar:DBReturn:DB$ ChangeZone | Origin$ Battlefield | Destination$ Hand | Defined$ Self | ConditionDefined$ Remembered | ConditionPresent$ Creature | ConditionCompare$ EQ1 | SubAbility$ DBCleanup
 SVar:X:Count$xPaid
-SVar:Cleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 AI:RemoveDeck:Random
 Oracle:Flying\n{X}{U}: You may put a creature card with mana value X from your hand onto the battlefield. If you do, return Metathran Aerostat to its owner's hand.

--- a/forge-gui/res/cardsfolder/m/mysterious_stranger.txt
+++ b/forge-gui/res/cardsfolder/m/mysterious_stranger.txt
@@ -6,7 +6,7 @@ K:Flash
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigChangeZone | TriggerDescription$ When CARDNAME enters, for each graveyard with an instant or sorcery card in it, exile target instant or sorcery card from that graveyard. If two or more cards are exiled this way, choose one of them at random and copy it. You may cast the copy without paying its mana cost.
 SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | ValidTgts$ Instant,Sorcery | TgtPrompt$ For each player, select a target instant or sorcery card from their graveyard. | TargetMin$ OneEach | TargetMax$ OneEach | TargetsWithDifferentControllers$ True | RememberChanged$ True | SubAbility$ ChooseRandom
 SVar:ChooseRandom:DB$ ChooseCard | Choices$ Card.IsRemembered | ChoiceZone$ Exile | Defined$ You | Amount$ 1 | AtRandom$ True | ConditionCheckSVar$ CountExiled | ConditionSVarCompare$ GE2 | SubAbility$ DBPlay
-SVar:DBPlay:DB$ Play | Valid$ Card.ChosenCard | ValidSA$ Spell | ValidZone$ Exile | WithoutManaCost$ True | Optional$ True | CopyCard$ True
+SVar:DBPlay:DB$ Play | Valid$ Card.ChosenCard | ValidSA$ Spell | ValidZone$ Exile | WithoutManaCost$ True | Optional$ True | CopyCard$ True | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearChosenCard$ True
 SVar:OneEach:PlayerCountPlayers$Amount
 SVar:CountExiled:Count$ValidExile Card.IsRemembered

--- a/forge-gui/res/cardsfolder/r/recall.txt
+++ b/forge-gui/res/cardsfolder/r/recall.txt
@@ -3,8 +3,8 @@ ManaCost:X X U
 Types:Sorcery
 A:SP$ Discard | Defined$ You | Mode$ TgtChoose | NumCards$ X | RememberDiscarded$ True | SubAbility$ DBChangeZone | SpellDescription$ Discard X cards, then return a card from your graveyard to your hand for each card discarded this way. Exile CARDNAME.
 SVar:DBChangeZone:DB$ ChangeZone | Hidden$ True | Mandatory$ True | ChangeType$ Card.YouOwn | ChangeNum$ Y | Origin$ Graveyard | Destination$ Hand | SubAbility$ DBExile
-SVar:DBExile:DB$ ChangeZone | Origin$ Stack | Destination$ Exile | SubAbility$ Cleanup
-SVar:Cleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBExile:DB$ ChangeZone | Origin$ Stack | Destination$ Exile | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Count$xPaid
 SVar:Y:Remembered$Amount
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/r/rofelloss_gift.txt
+++ b/forge-gui/res/cardsfolder/r/rofelloss_gift.txt
@@ -2,8 +2,8 @@ Name:Rofellos's Gift
 ManaCost:G
 Types:Sorcery
 A:SP$ Reveal | RevealValid$ Card.Green+YouCtrl | AnyNumber$ True | RememberRevealed$ True | SubAbility$ DBChangeZone | SpellDescription$ Reveal any number of green cards in your hand. Return an enchantment card from your graveyard to your hand for each card revealed this way.
-SVar:DBChangeZone:DB$ ChangeZone | Hidden$ True | Mandatory$ True | ChangeType$ Card.Enchantment+YouOwn | ChangeNum$ X | Origin$ Graveyard | Destination$ Hand | SubAbility$ Cleanup
-SVar:Cleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBChangeZone:DB$ ChangeZone | Hidden$ True | Mandatory$ True | ChangeType$ Card.Enchantment+YouOwn | ChangeNum$ X | Origin$ Graveyard | Destination$ Hand | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Remembered$Amount
 AI:RemoveDeck:All
 Oracle:Reveal any number of green cards in your hand. Return an enchantment card from your graveyard to your hand for each card revealed this way.

--- a/forge-gui/res/cardsfolder/r/ruthless_knave.txt
+++ b/forge-gui/res/cardsfolder/r/ruthless_knave.txt
@@ -4,6 +4,5 @@ Types:Creature Orc Pirate
 PT:3/2
 A:AB$ Token | Cost$ 2 B Sac<1/Creature> | TokenAmount$ 2 | TokenScript$ c_a_treasure_sac | TokenOwner$ You | SpellDescription$ Create two Treasure tokens.
 A:AB$ Draw | Cost$ Sac<3/Treasure> | NumCards$ 1 | SpellDescription$ Draw a card.
-SVar:DBDiscard:DB$ Discard | Defined$ You | Mode$ TgtChoose | DiscardValid$ Card.IsRemembered | NumCards$ 1 | SubAbility$ DBCleanup
-DeckHas:Ability$Token
+DeckHas:Ability$Sacrifice|Token
 Oracle:{2}{B}, Sacrifice a creature: Create two Treasure tokens. (They're artifacts with "{T}, Sacrifice this artifact: Add one mana of any color.")\nSacrifice three Treasures: Draw a card.

--- a/forge-gui/res/cardsfolder/s/skullwinder.txt
+++ b/forge-gui/res/cardsfolder/s/skullwinder.txt
@@ -6,6 +6,6 @@ K:Deathtouch
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChangeZone | TriggerDescription$ When CARDNAME enters, return target card from your graveyard to your hand, then choose an opponent. That player returns a card from their graveyard to their hand.
 SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Card.YouCtrl | SubAbility$ ChooseP
 SVar:ChooseP:DB$ ChoosePlayer | Defined$ You | Choices$ Player.Opponent | SubAbility$ DBChangeZone
-SVar:DBChangeZone:DB$ ChangeZone | Hidden$ True | Mandatory$ True | ChangeType$ Card.ChosenCtrl | Chooser$ ChosenPlayer | ChangeNum$ 1 | Origin$ Graveyard | Destination$ Hand | SubAbility$ Cleanup
-SVar:Cleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBChangeZone:DB$ ChangeZone | Hidden$ True | Mandatory$ True | ChangeType$ Card.ChosenCtrl | Chooser$ ChosenPlayer | ChangeNum$ 1 | Origin$ Graveyard | Destination$ Hand | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhen Skullwinder enters, return target card from your graveyard to your hand, then choose an opponent. That player returns a card from their graveyard to their hand.

--- a/forge-gui/res/cardsfolder/t/talent_of_the_telepath.txt
+++ b/forge-gui/res/cardsfolder/t/talent_of_the_telepath.txt
@@ -3,7 +3,7 @@ ManaCost:2 U U
 Types:Sorcery
 A:SP$ PeekAndReveal | ValidTgts$ Opponent | Reveal$ True | NoPeek$ True | PeekAmount$ 7 | RememberRevealed$ True | SubAbility$ TelepathCast | SpellDescription$ Target opponent reveals the top seven cards of their library. You may cast an instant or sorcery spell from among them without paying its mana cost. Then that player puts the rest into their graveyard. Spell mastery — If there are two or more instant and/or sorcery cards in your graveyard, you may cast up to two instant and/or sorcery spells from among the revealed cards instead of one.
 SVar:TelepathCast:DB$ Play | ValidZone$ Library | Valid$ Card.IsRemembered | ValidSA$ Instant,Sorcery | Controller$ You | WithoutManaCost$ True | Optional$ True | Amount$ X | SubAbility$ DBChangeZone
-SVar:DBChangeZone:DB$ ChangeZone | Origin$ Library | Destination$ Graveyard | Defined$ Remembered
+SVar:DBChangeZone:DB$ ChangeZone | Origin$ Library | Destination$ Graveyard | Defined$ Remembered | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Count$Compare Y GE2.2.1
 SVar:Y:Count$ValidGraveyard Instant.YouOwn,Sorcery.YouOwn

--- a/forge-gui/res/cardsfolder/t/temur_sabertooth.txt
+++ b/forge-gui/res/cardsfolder/t/temur_sabertooth.txt
@@ -3,6 +3,6 @@ ManaCost:2 G G
 Types:Creature Cat
 PT:4/3
 A:AB$ ChangeZone | Cost$ 1 G | Origin$ Battlefield | Destination$ Hand | Hidden$ True | ChangeType$ Creature.YouCtrl+Other | ChangeNum$ 1 | RememberChanged$ True | SubAbility$ DBPump | SpellDescription$ You may return another creature you control to its owner's hand. If you do, CARDNAME gains indestructible until end of turn. | StackDescription$ SpellDescription
-SVar:DBPump:DB$ Pump | ConditionDefined$ Remembered | ConditionPresent$ Card | ConditionCompare$ EQ1 | Defined$ Self | KW$ Indestructible | SubAbility$ Cleanup | StackDescription$ None
-SVar:Cleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBPump:DB$ Pump | ConditionDefined$ Remembered | ConditionPresent$ Card | ConditionCompare$ EQ1 | Defined$ Self | KW$ Indestructible | SubAbility$ DBCleanup | StackDescription$ None
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:{1}{G}: You may return another creature you control to its owner's hand. If you do, Temur Sabertooth gains indestructible until end of turn.

--- a/forge-gui/res/cardsfolder/v/volatile_stormdrake.txt
+++ b/forge-gui/res/cardsfolder/v/volatile_stormdrake.txt
@@ -7,8 +7,8 @@ K:Hexproof:Activated,Triggered:activated and triggered abilities
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExchange | TriggerDescription$ When CARDNAME enters, exchange control of CARDNAME and target creature an opponent controls. If you do, you get {E}{E}{E}{E}, then sacrifice that creature unless you pay an amount of {E} equal to its mana value.
 SVar:TrigExchange:DB$ ExchangeControl | Defined$ Self | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | RememberExchanged$ True | SubAbility$ Energy
 SVar:Energy:DB$ PutCounter | ConditionDefined$ Remembered | ConditionPresent$ Card | Defined$ You | CounterType$ ENERGY | CounterNum$ 4 | SubAbility$ Sacrifice
-SVar:Sacrifice:DB$ SacrificeAll | ConditionDefined$ Remembered | ConditionPresent$ Card | Defined$ Targeted | UnlessCost$ PayEnergy<N> | UnlessPayer$ You | SubAbility$ Cleanup
-SVar:Cleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:Sacrifice:DB$ SacrificeAll | ConditionDefined$ Remembered | ConditionPresent$ Card | Defined$ Targeted | UnlessCost$ PayEnergy<N> | UnlessPayer$ You | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:N:Targeted$CardManaCost
 DeckHas:Ability$Sacrifice
 Oracle:Flying, hexproof from activated and triggered abilities\nWhen Volatile Stormdrake enters, exchange control of Volatile Stormdrake and target creature an opponent controls. If you do, you get {E}{E}{E}{E}, then sacrifice that creature unless you pay an amount of {E} equal to its mana value.


### PR DESCRIPTION
Tidying `DBCleanup` lines, testing when appropriate to confirm functionality:
- some standardization
- removing where irrelevant
- establishing links with upstream lines where missing and relevant

Notable incidental fixes:
- Ancient Vendetta: Updated so Prompt and Stack read a bit better for its effect.
- King Narfi's Betrayal: Thought it best to have the exiled cards be remembered by the command zone effect so that information is accessible after the last chapter resolves. Also the effect wasn't exiling itself  after the last of the exiled cards was cast.