### PR TITLE
Cleanup: Delayed cantrips

### DIFF
--- a/forge-gui/res/cardsfolder/a/aleatory.txt
+++ b/forge-gui/res/cardsfolder/a/aleatory.txt
@@ -2,9 +2,10 @@ Name:Aleatory
 ManaCost:1 R
 Types:Instant
 Text:Cast CARDNAME only during combat after blockers are declared.
-A:SP$ FlipACoin | ValidTgts$ Creature | WinSubAbility$ AleatoryPump | LoseSubAbility$ DelTrigSlowtrip | ActivationPhases$ Declare Blockers->EndCombat | ActivationAfterBlockers$ True | SpellDescription$ Flip a coin. If you win the flip, target creature gets +1/+1 until end of turn. Draw a card at the beginning of the next turn's upkeep.
+A:SP$ FlipACoin | ValidTgts$ Creature | WinSubAbility$ AleatoryPump | LoseSubAbility$ DelTrigSlowtrip | ActivationPhases$ Declare Blockers->EndCombat | ActivationAfterBlockers$ True | SubAbility$ DBNoop | SpellDescription$ Flip a coin. If you win the flip, target creature gets +1/+1 until end of turn.
 SVar:AleatoryPump:DB$ Pump | Defined$ Targeted | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DelTrigSlowtrip
 SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | Defined$ You
+SVar:DrawSlowtrip:DB$ Draw
+SVar:DBNoop:DB$ Pump | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
 AI:RemoveDeck:All
 Oracle:Cast this spell only during combat after blockers are declared.\nFlip a coin. If you win the flip, target creature gets +1/+1 until end of turn.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/a/arcane_denial.txt
+++ b/forge-gui/res/cardsfolder/a/arcane_denial.txt
@@ -1,10 +1,10 @@
 Name:Arcane Denial
 ManaCost:1 U
 Types:Instant
-A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | RememberTargets$ True | ValidTgts$ Card | SubAbility$ DelTrigSlowtrip | SpellDescription$ Counter target spell. Its controller may draw up to two cards at the beginning of the next turn's upkeep. You draw a card at the beginning of the next turn's upkeep.
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | SubAbility$ DelTrigDrawTwo | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | Defined$ You
-SVar:DelTrigDrawTwo:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | RememberObjects$ RememberedController | Execute$ DrawTwo | TriggerDescription$ Draw up to two cards. | SubAbility$ DBCleanup
+A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | RememberTargets$ True | ValidTgts$ Card | SubAbility$ DelTrigDrawTwo | SpellDescription$ Counter target spell.
+SVar:DelTrigDrawTwo:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | RememberObjects$ RememberedController | Execute$ DrawTwo | SubAbility$ DelTrigSlowtrip | TriggerDescription$ The controller of the spell countered by CARDNAME draws up to two cards. | StackDescription$ REP Its controller_{p:TargetedController} | SpellDescription$ Its controller may draw up to two cards at the beginning of the next turn's upkeep.
 SVar:DrawTwo:DB$ Draw | NumCards$ 2 | Defined$ DelayTriggerRemembered | Upto$ True | AILogic$ OptionalDraw
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | SubAbility$ DBCleanup | TriggerDescription$ Draw a card. | StackDescription$ REP You draw_{p:You} draws | SpellDescription$ You draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Counter target spell. Its controller may draw up to two cards at the beginning of the next turn's upkeep.\nYou draw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/a/astrolabe.txt
+++ b/forge-gui/res/cardsfolder/a/astrolabe.txt
@@ -1,8 +1,8 @@
 Name:Astrolabe
 ManaCost:3
 Types:Artifact
-A:AB$ Mana | Cost$ 1 T Sac<1/CARDNAME> | Produced$ Any | Amount$ 2 | SubAbility$ DelTrigSlowtrip | SpellDescription$ Add two mana of any one color. Draw a card at the beginning of the next turn's upkeep.
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card at the beginning of the next turn's upkeep.
-SVar:DrawSlowtrip:DB$ Draw | Defined$ You
+A:AB$ Mana | Cost$ 1 T Sac<1/CARDNAME> | Produced$ Any | Amount$ 2 | SubAbility$ DelTrigSlowtrip | SpellDescription$ Add two mana of any one color.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$  Draw a card. | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 AI:RemoveDeck:All
 Oracle:{1}, {T}, Sacrifice Astrolabe: Add two mana of any one color. Draw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/b/balduvian_rage.txt
+++ b/forge-gui/res/cardsfolder/b/balduvian_rage.txt
@@ -1,8 +1,8 @@
 Name:Balduvian Rage
 ManaCost:X R
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature.attacking | TgtPrompt$ Select target attacking creature | NumAtt$ +X | SpellDescription$ Target attacking creature gets +X/+0 until end of turn. Draw a card at the beginning of the next turn's upkeep. | SubAbility$ DelTrigSlowtrip
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ Pump | ValidTgts$ Creature.attacking | TgtPrompt$ Select target attacking creature | NumAtt$ +X | SubAbility$ DelTrigSlowtrip | SpellDescription$ Target attacking creature gets +X/+0 until end of turn.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 SVar:X:Count$xPaid
 Oracle:Target attacking creature gets +X/+0 until end of turn.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/b/barbed_sextant.txt
+++ b/forge-gui/res/cardsfolder/b/barbed_sextant.txt
@@ -1,8 +1,8 @@
 Name:Barbed Sextant
 ManaCost:1
 Types:Artifact
-A:AB$ Mana | Cost$ 1 T Sac<1/CARDNAME> | Produced$ Any | SubAbility$ DelTrigSlowtrip | SpellDescription$ Add one mana of any color. Draw a card at the beginning of the next turn's upkeep.
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:AB$ Mana | Cost$ 1 T Sac<1/CARDNAME> | Produced$ Any | SubAbility$ DelTrigSlowtrip | SpellDescription$ Add one mana of any color.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 AI:RemoveDeck:All
 Oracle:{1}, {T}, Sacrifice Barbed Sextant: Add one mana of any color. Draw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/b/bestial_fury.txt
+++ b/forge-gui/res/cardsfolder/b/bestial_fury.txt
@@ -6,6 +6,6 @@ SVar:AttachAILogic:Pump
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ DelTrigSlowtrip | TriggerDescription$ When CARDNAME enters, draw a card at the beginning of the next turn's upkeep.
 T:Mode$ AttackerBlocked | ValidCard$ Card.AttachedBy | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever enchanted creature becomes blocked, it gets +4/+0 and gains trample until end of turn.
 SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+SVar:DrawSlowtrip:DB$ Draw
 SVar:TrigPump:DB$ Pump | Defined$ TriggeredAttackerLKICopy | NumAtt$ +4 | KW$ Trample
 Oracle:Enchant creature\nWhen Bestial Fury enters, draw a card at the beginning of the next turn's upkeep.\nWhenever enchanted creature becomes blocked, it gets +4/+0 and gains trample until end of turn.

--- a/forge-gui/res/cardsfolder/b/blessed_wine.txt
+++ b/forge-gui/res/cardsfolder/b/blessed_wine.txt
@@ -1,7 +1,7 @@
 Name:Blessed Wine
 ManaCost:1 W
 Types:Instant
-A:SP$ GainLife | LifeAmount$ 1 | SpellDescription$ You gain 1 life. Draw a card at the beginning of next turn's upkeep. | SubAbility$ DelTrigSlowtrip
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ GainLife | LifeAmount$ 1 | SubAbility$ DelTrigSlowtrip | SpellDescription$ You gain 1 life.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:You gain 1 life.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/b/bone_harvest.txt
+++ b/forge-gui/res/cardsfolder/b/bone_harvest.txt
@@ -1,8 +1,8 @@
 Name:Bone Harvest
 ManaCost:2 B
 Types:Instant
-A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Library | TargetMin$ 0 | TargetMax$ X | TgtPrompt$ Choose target creature card in your graveyard | ValidTgts$ Creature.YouCtrl | SpellDescription$ Put any number of target creature cards from your graveyard on top of your library. Draw a card at the beginning of next turn's upkeep. | SubAbility$ DelTrigSlowtrip
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Library | TargetMin$ 0 | TargetMax$ X | TgtPrompt$ Select any number of target creature cards in your graveyard | ValidTgts$ Creature.YouCtrl | SubAbility$ DelTrigSlowtrip | SpellDescription$ Put any number of target creature cards from your graveyard on top of your library.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 SVar:X:Count$ValidGraveyard Creature.YouOwn
 Oracle:Put any number of target creature cards from your graveyard on top of your library.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/b/burnout.txt
+++ b/forge-gui/res/cardsfolder/b/burnout.txt
@@ -1,8 +1,8 @@
 Name:Burnout
 ManaCost:1 R
 Types:Instant
-A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Instant | AITgts$ Card.Blue | ConditionDefined$ Targeted | ConditionPresent$ Spell.Blue | SpellDescription$ Counter target instant spell if it's blue. Draw a card at the beginning of the next turn's upkeep. | SubAbility$ DelTrigSlowtrip
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Instant | AITgts$ Card.Blue | ConditionDefined$ Targeted | ConditionPresent$ Spell.Blue | SubAbility$ DelTrigSlowtrip | SpellDescription$ Counter target instant spell if it's blue.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 AI:RemoveDeck:Random
 Oracle:Counter target instant spell if it's blue.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/c/carrier_pigeons.txt
+++ b/forge-gui/res/cardsfolder/c/carrier_pigeons.txt
@@ -5,5 +5,5 @@ PT:1/1
 K:Flying
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ DelTrigSlowtrip | TriggerDescription$ When CARDNAME enters, draw a card at the beginning of the next turn's upkeep.
 SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:Flying\nWhen Carrier Pigeons enters, draw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/c/clairvoyance.txt
+++ b/forge-gui/res/cardsfolder/c/clairvoyance.txt
@@ -1,8 +1,8 @@
 Name:Clairvoyance
 ManaCost:U
 Types:Instant
-A:SP$ RevealHand | ValidTgts$ Player | TgtPrompt$ Select target player | Look$ True | SubAbility$ DelTrigSlowtrip | SpellDescription$ Look at target player's hand. Draw a card at the beginning of next turn's upkeep.
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ RevealHand | ValidTgts$ Player | Look$ True | SubAbility$ DelTrigSlowtrip | SpellDescription$ Look at target player's hand.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 AI:RemoveDeck:All
 Oracle:Look at target player's hand.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/d/dazzling_beauty.txt
+++ b/forge-gui/res/cardsfolder/d/dazzling_beauty.txt
@@ -2,7 +2,7 @@ Name:Dazzling Beauty
 ManaCost:2 W
 Types:Instant
 Text:Cast this spell only during the declare blockers step.
-A:SP$ BecomesBlocked | ValidTgts$ Creature.attacking+unblocked | TgtPrompt$ Select target unblocked attacking creature | SubAbility$ DelTrigSlowtrip | ActivationPhases$ Declare Blockers | SpellDescription$ Target unblocked attacking creature becomes blocked. (This spell works on creatures that can't be blocked.) Draw a card at the beginning of the next turn's upkeep.
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ BecomesBlocked | ValidTgts$ Creature.attacking+unblocked | TgtPrompt$ Select target unblocked attacking creature | ActivationPhases$ Declare Blockers | SubAbility$ DelTrigSlowtrip | SpellDescription$ Target unblocked attacking creature becomes blocked. (This spell works on creatures that can't be blocked.)
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:Cast this spell only during the declare blockers step.\nTarget unblocked attacking creature becomes blocked. (This spell works on creatures that can't be blocked.)\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/e/enervate.txt
+++ b/forge-gui/res/cardsfolder/e/enervate.txt
@@ -1,8 +1,8 @@
 Name:Enervate
 ManaCost:1 U
 Types:Instant
-A:SP$ Tap | TgtPrompt$ Choose target artifact, creature or land | ValidTgts$ Artifact,Creature,Land | SpellDescription$ Tap target artifact, creature or land. Draw a card at the beginning of next turn's upkeep. | SubAbility$ DelTrigSlowtrip
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ Tap | TgtPrompt$ Choose target artifact, creature or land | ValidTgts$ Artifact,Creature,Land | SubAbility$ DelTrigSlowtrip | SpellDescription$ Tap target artifact, creature or land.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 AI:RemoveDeck:All
 Oracle:Tap target artifact, creature, or land.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/f/feral_instinct.txt
+++ b/forge-gui/res/cardsfolder/f/feral_instinct.txt
@@ -1,7 +1,7 @@
 Name:Feral Instinct
 ManaCost:1 G
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +1 | NumDef$ +1 | SpellDescription$ Target creature gets +1/+1 until end of turn. Draw a card at the beginning of the next turn's upkeep. | SubAbility$ DelTrigSlowtrip
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ Pump | ValidTgts$ Creature | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DelTrigSlowtrip | SpellDescription$ Target creature gets +1/+1 until end of turn.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:Target creature gets +1/+1 until end of turn.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/f/fevered_strength.txt
+++ b/forge-gui/res/cardsfolder/f/fevered_strength.txt
@@ -1,7 +1,7 @@
 Name:Fevered Strength
 ManaCost:2 B
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumAtt$ +2 | SpellDescription$ Target creature gets +2/+0 until end of turn. Draw a card at the beginning of the next turn's upkeep. | SubAbility$ DelTrigSlowtrip
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ Pump | ValidTgts$ Creature | NumAtt$ +2 | SubAbility$ DelTrigSlowtrip | SpellDescription$ Target creature gets +2/+0 until end of turn.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:Target creature gets +2/+0 until end of turn.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/f/flare.txt
+++ b/forge-gui/res/cardsfolder/f/flare.txt
@@ -1,7 +1,7 @@
 Name:Flare
 ManaCost:2 R
 Types:Instant
-A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to any target. Draw a card at the beginning of the next turn's upkeep. | SubAbility$ DelTrigSlowtrip
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ 1 | SubAbility$ DelTrigSlowtrip | SpellDescription$ CARDNAME deals 1 damage to any target.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:Flare deals 1 damage to any target.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/f/force_void.txt
+++ b/forge-gui/res/cardsfolder/f/force_void.txt
@@ -1,7 +1,7 @@
 Name:Force Void
 ManaCost:2 U
 Types:Instant
-A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | UnlessCost$ 1 | SpellDescription$ Counter target spell unless its controller pays {1}. Draw a card at the beginning of the next turn's upkeep. | SubAbility$ DelTrigSlowtrip
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | UnlessCost$ 1 | SubAbility$ DelTrigSlowtrip | SpellDescription$ Counter target spell unless its controller pays {1}.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:Counter target spell unless its controller pays {1}.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/f/foreshadow.txt
+++ b/forge-gui/res/cardsfolder/f/foreshadow.txt
@@ -1,10 +1,10 @@
 Name:Foreshadow
 ManaCost:1 U
 Types:Instant
-A:SP$ NameCard | SubAbility$ DBMill | SpellDescription$ Choose a card name, then target opponent mills a card. If a card with the chosen name was milled this way, you draw a card. Draw a card at the beginning of the next turn's upkeep.
+A:SP$ NameCard | SubAbility$ DBMill | SpellDescription$ Choose a card name, then target opponent mills a card. If a card with the chosen name was milled this way, you draw a card.
 SVar:DBMill:DB$ Mill | ValidTgts$ Opponent | NumCards$ 1 | RememberMilled$ True | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw | ConditionDefined$ Remembered | ConditionPresent$ Card.NamedCard | SubAbility$ DelTrigSlowtrip
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | SubAbility$ DBCleanup | TriggerDescription$ Draw a card.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | SubAbility$ DBCleanup | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
 SVar:DrawSlowtrip:DB$ Draw
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearNamedCard$ True
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/f/foresight.txt
+++ b/forge-gui/res/cardsfolder/f/foresight.txt
@@ -1,9 +1,9 @@
 Name:Foresight
 ManaCost:1 U
 Types:Sorcery
-A:SP$ ChangeZone | Origin$ Library | Destination$ Exile | ChangeType$ Card | ChangeNum$ 3 | Mandatory$ True | SpellDescription$ Search your library for three cards, exile them, then shuffle. Draw a card at the beginning of the next turn's upkeep. | SubAbility$ DelTrigSlowtrip
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ ChangeZone | Origin$ Library | Destination$ Exile | ChangeType$ Card | ChangeNum$ 3 | Mandatory$ True | SubAbility$ DelTrigSlowtrip | SpellDescription$ Search your library for three cards, exile them, then shuffle.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 AI:RemoveDeck:All
 AI:RemoveDeck:Random
 Oracle:Search your library for three cards, exile them, then shuffle.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/f/formation.txt
+++ b/forge-gui/res/cardsfolder/f/formation.txt
@@ -1,7 +1,7 @@
 Name:Formation
 ManaCost:1 W
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ Banding | SubAbility$ DelTrigSlowtrip | SpellDescription$ Target creature gains banding until end of turn. Draw a card at the beginning of the next turn's upkeep.
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ Pump | ValidTgts$ Creature | KW$ Banding | SubAbility$ DelTrigSlowtrip | SpellDescription$ Target creature gains banding until end of turn.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:Target creature gains banding until end of turn. (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding a player controls are blocking or being blocked by a creature, that player divides that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/f/foxfire.txt
+++ b/forge-gui/res/cardsfolder/f/foxfire.txt
@@ -4,8 +4,8 @@ Types:Instant
 A:SP$ Untap | ValidTgts$ Creature.attacking | TgtPrompt$ Select target attacking creature | SubAbility$ DBPump | SpellDescription$ Untap target attacking creature.
 SVar:DBPump:DB$ Effect | ReplacementEffects$ RPrevent1,RPrevent2 | RememberObjects$ Targeted | ExileOnMoved$ Battlefield | SubAbility$ DelTrigSlowtrip | SpellDescription$ Prevent all combat damage that would be dealt to and dealt by that creature this turn.
 SVar:RPrevent1:Event$ DamageDone | Prevent$ True | IsCombat$ True | ValidSource$ Card.IsRemembered | Description$ Prevent all combat damage that would be dealt to and dealt by that creature this turn.
-SVar:RPrevent2:Event$ DamageDone | Prevent$ True | IsCombat$ True | ValidTarget$ Card.IsRemembered | Description$ Prevent all combat damage that would be dealt to and dealt by that creature this turn. | Secondary$ True
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+SVar:RPrevent2:Event$ DamageDone | Prevent$ True | IsCombat$ True | ValidTarget$ Card.IsRemembered | Secondary$ True | Description$ Prevent all combat damage that would be dealt to and dealt by that creature this turn.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 AI:RemoveDeck:All
 Oracle:Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/g/gorilla_war_cry.txt
+++ b/forge-gui/res/cardsfolder/g/gorilla_war_cry.txt
@@ -2,6 +2,6 @@ Name:Gorilla War Cry
 ManaCost:1 R
 Types:Instant
 A:SP$ PumpAll | ValidCards$ Creature | KW$ Menace | ActivationPhases$ BeginCombat->Declare Attackers | SubAbility$ DelTrigSlowtrip | SpellDescription$ All creatures gain menace until end of turn.
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:Cast this spell only during combat before blockers are declared.\nAll creatures gain menace until end of turn. (They can't be blocked except by two or more creatures.)\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/g/gravebind.txt
+++ b/forge-gui/res/cardsfolder/g/gravebind.txt
@@ -1,10 +1,10 @@
 Name:Gravebind
 ManaCost:B
 Types:Instant
-A:SP$ Effect | ValidTgts$ Creature | TgtPrompt$ Select target creature | RememberObjects$ Targeted | ForgetOnMoved$ Battlefield | StaticAbilities$ NoRegen | IsCurse$ True | SubAbility$ DelTrigSlowtrip | AILogic$ CantRegenerate | SpellDescription$ Target creature can't be regenerated this turn. Draw a card at the beginning of the next turn's upkeep.
+A:SP$ Effect | ValidTgts$ Creature | RememberObjects$ Targeted | ForgetOnMoved$ Battlefield | StaticAbilities$ NoRegen | IsCurse$ True | AILogic$ CantRegenerate | SubAbility$ DelTrigSlowtrip | SpellDescription$ Target creature can't be regenerated this turn.
 SVar:NoRegen:Mode$ CantRegenerate | ValidCard$ Card.IsRemembered | Description$ Creature can't be regenerated this turn.
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 AI:RemoveDeck:All
 AI:RemoveDeck:Random
 Oracle:Target creature can't be regenerated this turn.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/h/headstone.txt
+++ b/forge-gui/res/cardsfolder/h/headstone.txt
@@ -1,7 +1,7 @@
 Name:Headstone
 ManaCost:1 B
 Types:Instant
-A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Exile | TgtPrompt$ Choose target card in a graveyard | ValidTgts$ Card | SpellDescription$ Exile target card from a graveyard. Draw a card at the beginning of the next turn's upkeep. | SubAbility$ DelTrigSlowtrip
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Exile | TgtPrompt$ Choose target card in a graveyard | ValidTgts$ Card | SubAbility$ DelTrigSlowtrip | SpellDescription$ Exile target card from a graveyard.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:Exile target card from a graveyard.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/h/heal.txt
+++ b/forge-gui/res/cardsfolder/h/heal.txt
@@ -1,7 +1,7 @@
 Name:Heal
 ManaCost:W
 Types:Instant
-A:SP$ PreventDamage | ValidTgts$ Any | Amount$ 1 | SubAbility$ DelTrigSlowtrip | SpellDescription$ Prevent the next 1 damage that would be dealt to any target this turn. Draw a card at the beginning of the next turn's upkeep.
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ PreventDamage | ValidTgts$ Any | Amount$ 1 | SubAbility$ DelTrigSlowtrip | SpellDescription$ Prevent the next 1 damage that would be dealt to any target this turn.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:Prevent the next 1 damage that would be dealt to any target this turn.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/i/infuse.txt
+++ b/forge-gui/res/cardsfolder/i/infuse.txt
@@ -1,7 +1,7 @@
 Name:Infuse
 ManaCost:2 U
 Types:Instant
-A:SP$ Untap | TgtPrompt$ Choose target artifact, creature or land | ValidTgts$ Artifact,Creature,Land | SpellDescription$ Untap target artifact, creature or land. Draw a card at the beginning of the next turn's upkeep. | SubAbility$ DelTrigSlowtrip
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ Untap | TgtPrompt$ Choose target artifact, creature or land | ValidTgts$ Artifact,Creature,Land | SubAbility$ DelTrigSlowtrip | SpellDescription$ Untap target artifact, creature or land.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:Untap target artifact, creature, or land.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/j/jinx.txt
+++ b/forge-gui/res/cardsfolder/j/jinx.txt
@@ -1,9 +1,9 @@
 Name:Jinx
 ManaCost:1 U
 Types:Instant
-A:SP$ ChooseType | Defined$ You | Type$ Basic Land | SubAbility$ DBAnimate | SpellDescription$ Target land becomes the basic land type of your choice until end of turn. Draw a card at the beginning of the next turn's upkeep.
-SVar:DBAnimate:DB$ Animate | ValidTgts$ Land | TgtPrompt$ Select target land | Types$ ChosenType | RemoveLandTypes$ True | SubAbility$ DelTrigSlowtrip
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ ChooseType | Defined$ You | Type$ Basic Land | SubAbility$ DBAnimate | SpellDescription$ Target land becomes the basic land type of your choice until end of turn.
+SVar:DBAnimate:DB$ Animate | ValidTgts$ Land | Types$ ChosenType | RemoveLandTypes$ True | SubAbility$ DelTrigSlowtrip
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 AI:RemoveDeck:All
 Oracle:Target land becomes the basic land type of your choice until end of turn.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/j/jolt.txt
+++ b/forge-gui/res/cardsfolder/j/jolt.txt
@@ -1,8 +1,8 @@
 Name:Jolt
 ManaCost:2 U
 Types:Instant
-A:SP$ TapOrUntap | ValidTgts$ Artifact,Creature,Land | TgtPrompt$ Select target artifact, creature, or land | SubAbility$ DelTrigSlowtrip | SpellDescription$ You may tap or untap target artifact, creature, or land. Draw a card at the beginning of the next turn's upkeep.
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ TapOrUntap | ValidTgts$ Artifact,Creature,Land | TgtPrompt$ Select target artifact, creature, or land | SubAbility$ DelTrigSlowtrip | SpellDescription$ You may tap or untap target artifact, creature, or land.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 AI:RemoveDeck:All
 Oracle:You may tap or untap target artifact, creature, or land.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/k/krovikan_fetish.txt
+++ b/forge-gui/res/cardsfolder/k/krovikan_fetish.txt
@@ -6,5 +6,5 @@ SVar:AttachAILogic:Pump
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | AddToughness$ 1 | Description$ Enchanted creature gets +1/+1.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ DelTrigSlowtrip | TriggerDescription$ When CARDNAME enters, draw a card at the beginning of the next turn's upkeep.
 SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:Enchant creature\nWhen Krovikan Fetish enters, draw a card at the beginning of the next turn's upkeep.\nEnchanted creature gets +1/+1.

--- a/forge-gui/res/cardsfolder/k/krovikan_plague.txt
+++ b/forge-gui/res/cardsfolder/k/krovikan_plague.txt
@@ -5,7 +5,7 @@ K:Enchant:Creature.nonWall+YouCtrl:non-Wall creature you control
 SVar:AttachAILogic:Pump
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ DelTrigSlowtrip | TriggerDescription$ When CARDNAME enters, draw a card at the beginning of the next turn's upkeep.
 SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+SVar:DrawSlowtrip:DB$ Draw
 A:AB$ DealDamage | Cost$ tapXType<1/Creature.EnchantedBy/Enchanted Creature> | ValidTgts$ Any | NumDmg$ 1 | SubAbility$ DBPutCounter | CostDesc$ Tap enchanted creature: | SpellDescription$ CARDNAME deals 1 damage to any target. Put a -0/-1 counter on enchanted creature. Activate only if enchanted creature is untapped.
 SVar:DBPutCounter:DB$ PutCounter | Defined$ Enchanted | CounterType$ M0M1 | CounterNum$ 1
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/l/lightning_blow.txt
+++ b/forge-gui/res/cardsfolder/l/lightning_blow.txt
@@ -1,7 +1,7 @@
 Name:Lightning Blow
 ManaCost:1 W
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ First Strike | SpellDescription$ Target creature gains first strike until end of turn. Draw a card at the beginning of the next turn's upkeep. | SubAbility$ DelTrigSlowtrip
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ Pump | ValidTgts$ Creature | KW$ First Strike | SubAbility$ DelTrigSlowtrip | SpellDescription$ Target creature gains first strike until end of turn.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:Target creature gains first strike until end of turn.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/m/mind_ravel.txt
+++ b/forge-gui/res/cardsfolder/m/mind_ravel.txt
@@ -1,7 +1,7 @@
 Name:Mind Ravel
 ManaCost:2 B
 Types:Sorcery
-A:SP$ Discard | ValidTgts$ Player | NumCards$ 1 | Mode$ TgtChoose | SubAbility$ DelTrigSlowtrip | SpellDescription$ Target player discards a card. Draw a card at the beginning of the next turn's upkeep.
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ Discard | ValidTgts$ Player | NumCards$ 1 | Mode$ TgtChoose | SubAbility$ DelTrigSlowtrip | SpellDescription$ Target player discards a card.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:Target player discards a card.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/m/mishras_bauble.txt
+++ b/forge-gui/res/cardsfolder/m/mishras_bauble.txt
@@ -1,8 +1,8 @@
 Name:Mishra's Bauble
 ManaCost:0
 Types:Artifact
-A:AB$ PeekAndReveal | Cost$ T Sac<1/CARDNAME> | ValidTgts$ Player | TgtPrompt$ Select target player | NoReveal$ True | SubAbility$ DelTrigSlowtrip | SpellDescription$ Look at the top card of target player's library.
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | StackDescription$ SpellDescription | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:AB$ PeekAndReveal | Cost$ T Sac<1/CARDNAME> | ValidTgts$ Player | NoReveal$ True | SubAbility$ DelTrigSlowtrip | SpellDescription$ Look at the top card of target player's library.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 AI:RemoveDeck:All
 Oracle:{T}, Sacrifice Mishra's Bauble: Look at the top card of target player's library. Draw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/m/mystic_melting.txt
+++ b/forge-gui/res/cardsfolder/m/mystic_melting.txt
@@ -1,7 +1,7 @@
 Name:Mystic Melting
 ManaCost:3 G
 Types:Instant
-A:SP$ Destroy | ValidTgts$ Artifact,Enchantment | TgtPrompt$ Select target artifact or enchantment | SpellDescription$ Destroy target artifact or enchantment. | SubAbility$ DelTrigSlowtrip
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ Destroy | ValidTgts$ Artifact,Enchantment | TgtPrompt$ Select target artifact or enchantment | SubAbility$ DelTrigSlowtrip | SpellDescription$ Destroy target artifact or enchantment.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:Destroy target artifact or enchantment.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/p/panic.txt
+++ b/forge-gui/res/cardsfolder/p/panic.txt
@@ -2,7 +2,7 @@ Name:Panic
 ManaCost:R
 Types:Instant
 Text:Cast this spell only during combat before blockers are declared.
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ HIDDEN CARDNAME can't block. | ActivationPhases$ BeginCombat->Declare Attackers | IsCurse$ True | SpellDescription$ Target creature can't block this turn. Draw a card at the beginning of the next turn's upkeep. | SubAbility$ DelTrigSlowtrip
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ Pump | ValidTgts$ Creature | KW$ HIDDEN CARDNAME can't block. | ActivationPhases$ BeginCombat->Declare Attackers | IsCurse$ True | SubAbility$ DelTrigSlowtrip | SpellDescription$ Target creature can't block this turn.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:Cast this spell only during combat before blockers are declared.\nTarget creature can't block this turn.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/p/portent.txt
+++ b/forge-gui/res/cardsfolder/p/portent.txt
@@ -1,7 +1,7 @@
 Name:Portent
 ManaCost:U
 Types:Sorcery
-A:SP$ RearrangeTopOfLibrary | ValidTgts$ Player | TgtPrompt$ Choose target player. | NumCards$ 3 | MayShuffle$ True | SubAbility$ DelTrigSlowtrip | SpellDescription$ Look at the top three cards of target player's library, then put them back in any order. You may have that player shuffle. Draw a card at the beginning of the next turn's upkeep.
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ RearrangeTopOfLibrary | ValidTgts$ Player | NumCards$ 3 | MayShuffle$ True | SubAbility$ DelTrigSlowtrip | SpellDescription$ Look at the top three cards of target player's library, then put them back in any order. You may have that player shuffle.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:Look at the top three cards of target player's library, then put them back in any order. You may have that player shuffle.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/p/prophecy.txt
+++ b/forge-gui/res/cardsfolder/p/prophecy.txt
@@ -1,10 +1,10 @@
 Name:Prophecy
 ManaCost:W
 Types:Sorcery
-A:SP$ PeekAndReveal | ValidTgts$ Opponent | NoPeek$ True | RememberRevealed$ True | SubAbility$ DBGainLife | SpellDescription$ Reveal the top card of target opponent's library. If it's a land, you gain 1 life. Then that player shuffles. Draw a card at the beginning of the next turn's upkeep.
+A:SP$ PeekAndReveal | ValidTgts$ Opponent | NoPeek$ True | RememberRevealed$ True | SubAbility$ DBGainLife | SpellDescription$ Reveal the top card of target opponent's library. If it's a land, you gain 1 life. Then that player shuffles.
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ 1 | ConditionDefined$ Remembered | ConditionPresent$ Card.Land | ConditionCompare$ GE1 | SubAbility$ DBShuffle
 SVar:DBShuffle:DB$ Shuffle | Defined$ ParentTarget | SubAbility$ DelTrigSlowtrip
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
 SVar:DrawSlowtrip:DB$ Draw
 DeckHas:Ability$LifeGain
 Oracle:Reveal the top card of target opponent's library. If it's a land, you gain 1 life. Then that player shuffles.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/p/pyknite.txt
+++ b/forge-gui/res/cardsfolder/p/pyknite.txt
@@ -4,5 +4,5 @@ Types:Creature Ouphe
 PT:1/1
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ DelTrigSlowtrip | TriggerDescription$ When CARDNAME enters, draw a card at the beginning of the next turn's upkeep.
 SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:When Pyknite enters, draw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/r/ray_of_erasure.txt
+++ b/forge-gui/res/cardsfolder/r/ray_of_erasure.txt
@@ -1,7 +1,7 @@
 Name:Ray of Erasure
 ManaCost:U
 Types:Instant
-A:SP$ Mill | NumCards$ 1 | ValidTgts$ Player | TgtPrompt$ Choose a player | SpellDescription$ Target player mills a card. Draw a card at the beginning of the next turn's upkeep. | SubAbility$ DelTrigSlowtrip
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ Mill | NumCards$ 1 | ValidTgts$ Player | SubAbility$ DelTrigSlowtrip | SpellDescription$ Target player mills a card.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:Target player mills a card.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/r/renewal.txt
+++ b/forge-gui/res/cardsfolder/r/renewal.txt
@@ -1,8 +1,8 @@
 Name:Renewal
 ManaCost:2 G
 Types:Sorcery
-A:SP$ ChangeZone | Cost$ 2 G Sac<1/Land> | Origin$ Library | Destination$ Battlefield | ChangeType$ Land.Basic | ChangeNum$ 1 | SpellDescription$ Search your library for a basic land card, put that card onto the battlefield, then shuffle. Draw a card at the beginning of the next turn's upkeep. | SubAbility$ DelTrigSlowtrip
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ ChangeZone | Cost$ 2 G Sac<1/Land> | Origin$ Library | Destination$ Battlefield | ChangeType$ Land.Basic | ChangeNum$ 1 | SubAbility$ DelTrigSlowtrip | SpellDescription$ Search your library for a basic land card, put that card onto the battlefield, then shuffle.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 DeckHas:Ability$Sacrifice
 Oracle:As an additional cost to cast this spell, sacrifice a land.\nSearch your library for a basic land card, put that card onto the battlefield, then shuffle.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/r/ritual_of_steel.txt
+++ b/forge-gui/res/cardsfolder/r/ritual_of_steel.txt
@@ -6,5 +6,5 @@ SVar:AttachAILogic:Pump
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddToughness$ 2 | Description$ Enchanted creature gets +0/+2.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ DelTrigSlowtrip | TriggerDescription$ When CARDNAME enters, draw a card at the beginning of the next turn's upkeep.
 SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:Enchant creature\nWhen Ritual of Steel enters, draw a card at the beginning of the next turn's upkeep.\nEnchanted creature gets +0/+2.

--- a/forge-gui/res/cardsfolder/s/scarab_of_the_unseen.txt
+++ b/forge-gui/res/cardsfolder/s/scarab_of_the_unseen.txt
@@ -1,9 +1,9 @@
 Name:Scarab of the Unseen
 ManaCost:2
 Types:Artifact
-A:AB$ ChangeZoneAll | Cost$ T Sac<1/CARDNAME> | Origin$ Battlefield | Destination$ Hand | ValidTgts$ Permanent.YouOwn | TgtPrompt$ Select target permanent you own | ChangeType$ Aura.AttachedTo Targeted | UseAllOriginZones$ True | SubAbility$ DelTrigSlowtrip | SpellDescription$ Return all Auras attached to target permanent you own to their owners' hands. Draw a card at the beginning of the next turn's upkeep.
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:AB$ ChangeZoneAll | Cost$ T Sac<1/CARDNAME> | Origin$ Battlefield | Destination$ Hand | ValidTgts$ Permanent.YouOwn | TgtPrompt$ Select target permanent you own | ChangeType$ Aura.AttachedTo Targeted | UseAllOriginZones$ True | SubAbility$ DelTrigSlowtrip | SpellDescription$ Return all Auras attached to target permanent you own to their owners' hands.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 AI:RemoveDeck:Random
 AI:RemoveDeck:All
 Oracle:{T}, Sacrifice Scarab of the Unseen: Return all Auras attached to target permanent you own to their owners' hands. Draw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/s/solfatara.txt
+++ b/forge-gui/res/cardsfolder/s/solfatara.txt
@@ -1,8 +1,8 @@
 Name:Solfatara
 ManaCost:2 R
 Types:Instant
-A:SP$ Effect | ValidTgts$ Player | StaticAbilities$ STCantPlayLand | RememberObjects$ Targeted | AILogic$ BeginningOfOppTurn | SubAbility$ DelTrigSlowtrip | SpellDescription$ Target player can't play lands this turn. Draw a card at the beginning of the next turn's upkeep.
+A:SP$ Effect | ValidTgts$ Player | StaticAbilities$ STCantPlayLand | RememberObjects$ Targeted | AILogic$ BeginningOfOppTurn | SubAbility$ DelTrigSlowtrip | SpellDescription$ Target player can't play lands this turn.
 SVar:STCantPlayLand:Mode$ CantPlayLand | Player$ Player.IsRemembered | Description$ Target player can't play lands this turn.
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:Target player can't play lands this turn.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/s/soul_rend.txt
+++ b/forge-gui/res/cardsfolder/s/soul_rend.txt
@@ -1,8 +1,8 @@
 Name:Soul Rend
 ManaCost:1 B
 Types:Instant
-A:SP$ Destroy | ValidTgts$ Creature | AITgts$ Card.White | TgtPrompt$ Select target creature | ConditionDefined$ Targeted | ConditionPresent$ Creature.White | ConditionCompare$ EQ1 | NoRegen$ True | SubAbility$ DelTrigSlowtrip | SpellDescription$ Destroy target creature if it's white. A creature destroyed this way can't be regenerated. Draw a card at the beginning of the next turn's upkeep.
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ Destroy | ValidTgts$ Creature | AITgts$ Card.White | ConditionDefined$ Targeted | ConditionPresent$ Creature.White | ConditionCompare$ EQ1 | NoRegen$ True | SubAbility$ DelTrigSlowtrip | SpellDescription$ Destroy target creature if it's white. A creature destroyed this way can't be regenerated.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 AI:RemoveDeck:Random
 Oracle:Destroy target creature if it's white. A creature destroyed this way can't be regenerated.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/s/suffocation.txt
+++ b/forge-gui/res/cardsfolder/s/suffocation.txt
@@ -2,8 +2,8 @@ Name:Suffocation
 ManaCost:1 U
 Types:Instant
 Text:Cast this spell only if you were dealt damage this turn by a red instant or sorcery spell.
-T:Mode$ DamageDone | ValidSource$ Sorcery.Red,Instant.Red | ValidTarget$ You | Execute$ TrigClear | Static$ True
-SVar:TrigClear:DB$ Cleanup | ClearRemembered$ True | SubAbility$ TrigRemember
+T:Mode$ DamageDone | ValidSource$ Sorcery.Red,Instant.Red | ValidTarget$ You | Execute$ TrigClearRem | Static$ True
+SVar:TrigClearRem:DB$ Cleanup | ClearRemembered$ True | SubAbility$ TrigRemember
 SVar:TrigRemember:DB$ Pump | RememberObjects$ TriggeredSourceController
 T:Mode$ Phase | Phase$ Cleanup | Execute$ TrigReset | Static$ True
 SVar:TrigReset:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/s/suffocation.txt
+++ b/forge-gui/res/cardsfolder/s/suffocation.txt
@@ -2,14 +2,14 @@ Name:Suffocation
 ManaCost:1 U
 Types:Instant
 Text:Cast this spell only if you were dealt damage this turn by a red instant or sorcery spell.
-T:Mode$ DamageDone | ValidSource$ Sorcery.Red,Instant.Red | ValidTarget$ You | Execute$ TrigClearRem | Static$ True
-SVar:TrigClearRem:DB$ Cleanup | ClearRemembered$ True | SubAbility$ TrigRemember
+T:Mode$ DamageDone | ValidSource$ Sorcery.Red,Instant.Red | ValidTarget$ You | Execute$ TrigClear | Static$ True
+SVar:TrigClear:DB$ Cleanup | ClearRemembered$ True | SubAbility$ TrigRemember
 SVar:TrigRemember:DB$ Pump | RememberObjects$ TriggeredSourceController
 T:Mode$ Phase | Phase$ Cleanup | Execute$ TrigReset | Static$ True
 SVar:TrigReset:DB$ Cleanup | ClearRemembered$ True
-A:SP$ DealDamage | Defined$ Remembered | NumDmg$ 4 | CheckSVar$ X | SVarCompare$ EQ1 | SubAbility$ DelTrigSlowtrip | SpellDescription$ CARDNAME deals 4 damage to the controller of the last red instant or sorcery spell that dealt damage to you this turn. Draw a card at the beginning of the next turn's upkeep.
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ DealDamage | Defined$ Remembered | NumDmg$ 4 | CheckSVar$ X | SVarCompare$ EQ1 | SubAbility$ DelTrigSlowtrip | SpellDescription$ CARDNAME deals 4 damage to the controller of the last red instant or sorcery spell that dealt damage to you this turn.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 SVar:X:Count$RememberedSize
 AI:RemoveDeck:Random
 Oracle:Cast this spell only if you were dealt damage this turn by a red instant or sorcery spell.\nSuffocation deals 4 damage to the controller of the last red instant or sorcery spell that dealt damage to you this turn.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/s/swift_maneuver.txt
+++ b/forge-gui/res/cardsfolder/s/swift_maneuver.txt
@@ -1,7 +1,7 @@
 Name:Swift Maneuver
 ManaCost:1 W
 Types:Instant
-A:SP$ PreventDamage | ValidTgts$ Any | Amount$ 2 | SubAbility$ DelTrigSlowtrip | SpellDescription$ Prevent the next 2 damage that would be dealt to any target this turn. Draw a card at the beginning of the next turn's upkeep.
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ PreventDamage | ValidTgts$ Any | Amount$ 2 | SubAbility$ DelTrigSlowtrip | SpellDescription$ Prevent the next 2 damage that would be dealt to any target this turn.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:Prevent the next 2 damage that would be dealt to any target this turn.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/t/telimtors_edict.txt
+++ b/forge-gui/res/cardsfolder/t/telimtors_edict.txt
@@ -1,8 +1,8 @@
 Name:Telim'Tor's Edict
 ManaCost:R
 Types:Instant
-A:SP$ ChangeZone | ValidTgts$ Permanent.YouCtrl,Permanent.YouOwn | TgtPrompt$ Select target permanent you own or control | Origin$ Battlefield | Destination$ Exile | SpellDescription$ Exile target permanent you own or control. Draw a card at the beginning of the next turn's upkeep. | SubAbility$ DelTrigSlowtrip
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ ChangeZone | ValidTgts$ Permanent.YouCtrl,Permanent.YouOwn | TgtPrompt$ Select target permanent you own or control | Origin$ Battlefield | Destination$ Exile | SubAbility$ DelTrigSlowtrip | SpellDescription$ Exile target permanent you own or control.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 AI:RemoveDeck:All
 Oracle:Exile target permanent you own or control.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/t/thermal_flux.txt
+++ b/forge-gui/res/cardsfolder/t/thermal_flux.txt
@@ -1,10 +1,11 @@
 Name:Thermal Flux
 ManaCost:U
 Types:Instant
-A:SP$ Charm | Choices$ ChooseFreeze,ChooseThaw | Defined$ You
-SVar:ChooseFreeze:DB$ Animate | ValidTgts$ Permanent.nonSnow | TgtPrompt$ Select target nonsnow permanent | Types$ Snow | SubAbility$ DelTrigSlowtrip | SpellDescription$ Target nonsnow permanent becomes snow until end of turn. Draw a card at the beginning of the next turn's upkeep.
-SVar:ChooseThaw:DB$ Animate | ValidTgts$ Permanent.Snow | TgtPrompt$ Select target snow permanent | RemoveTypes$ Snow | SubAbility$ DelTrigSlowtrip | SpellDescription$ Target snow permanent isn't snow until end of turn. Draw a card at the beginning of the next turn's upkeep.
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ Charm | Choices$ ChooseFreeze,ChooseThaw | Defined$ You | SubAbility$ DBNoop
+SVar:ChooseFreeze:DB$ Animate | ValidTgts$ Permanent.nonSnow | TgtPrompt$ Select target nonsnow permanent | Types$ Snow | SubAbility$ DelTrigSlowtrip | SpellDescription$ Target nonsnow permanent becomes snow until end of turn.
+SVar:ChooseThaw:DB$ Animate | ValidTgts$ Permanent.Snow | TgtPrompt$ Select target snow permanent | RemoveTypes$ Snow | SubAbility$ DelTrigSlowtrip | SpellDescription$ Target snow permanent isn't snow until end of turn.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | StackDescription$ {p:You} draws a card at the beginning of the next turn's upkeep. | TriggerDescription$ Draw a card.
+SVar:DrawSlowtrip:DB$ Draw
+SVar:DBNoop:DB$ Pump | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
 AI:RemoveDeck:All
 Oracle:Choose one —\n• Target nonsnow permanent becomes snow until end of turn.\n• Target snow permanent isn't snow until end of turn.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/t/touch_of_death.txt
+++ b/forge-gui/res/cardsfolder/t/touch_of_death.txt
@@ -1,8 +1,8 @@
 Name:Touch of Death
 ManaCost:2 B
 Types:Sorcery
-A:SP$ DealDamage | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to target player or planeswalker. You gain 1 life. Draw a card at the beginning of the next turn's upkeep. | SubAbility$ DBGainLife
+A:SP$ DealDamage | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | NumDmg$ 1 | SubAbility$ DBGainLife | SpellDescription$ CARDNAME deals 1 damage to target player or planeswalker. You gain 1 life.
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ 1 | SubAbility$ DelTrigSlowtrip
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:Touch of Death deals 1 damage to target player or planeswalker. You gain 1 life.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/t/touch_of_vitae.txt
+++ b/forge-gui/res/cardsfolder/t/touch_of_vitae.txt
@@ -1,10 +1,10 @@
 Name:Touch of Vitae
 ManaCost:2 G
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ Haste | SubAbility$ DBAnimate | SpellDescription$ Until end of turn, target creature gains haste and "{0}: Untap this creature. Activate only once." Draw a card at the beginning of the next turn's upkeep.
+A:SP$ Pump | ValidTgts$ Creature | KW$ Haste | SubAbility$ DBAnimate | SpellDescription$ Until end of turn, target creature gains haste and "{0}: Untap this creature. Activate only once."
 SVar:DBAnimate:DB$ Animate | Defined$ Targeted | Abilities$ ABUntap | SubAbility$ DelTrigSlowtrip
 SVar:ABUntap:AB$ Untap | Cost$ 0 | Defined$ Self | GameActivationLimit$ 1 | SpellDescription$ Untap this creature. Activate only once.
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 AI:RemoveDeck:All
 Oracle:Until end of turn, target creature gains haste and "{0}: Untap this creature. Activate only once."\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/u/updraft.txt
+++ b/forge-gui/res/cardsfolder/u/updraft.txt
@@ -1,7 +1,7 @@
 Name:Updraft
 ManaCost:1 U
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ Flying | SpellDescription$ Target creature gains flying until end of turn. Draw a card at the beginning of the next turn's upkeep. | SubAbility$ DelTrigSlowtrip
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:SP$ Pump | ValidTgts$ Creature | KW$ Flying | SubAbility$ DelTrigSlowtrip | SpellDescription$ Target creature gains flying until end of turn.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 Oracle:Target creature gains flying until end of turn.\nDraw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/u/urzas_bauble.txt
+++ b/forge-gui/res/cardsfolder/u/urzas_bauble.txt
@@ -1,8 +1,8 @@
 Name:Urza's Bauble
 ManaCost:0
 Types:Artifact
-A:AB$ Reveal | Cost$ T Sac<1/CARDNAME> | ValidTgts$ Player | TgtPrompt$ Select target player | Random$ True | SubAbility$ DelTrigSlowtrip | SpellDescription$ Look at a card at random in target player's hand. You draw a card at the beginning of the next turn's upkeep.
-SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+A:AB$ Reveal | Cost$ T Sac<1/CARDNAME> | ValidTgts$ Player | Random$ True | SubAbility$ DelTrigSlowtrip | SpellDescription$ Look at a card at random in target player's hand.
+SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card. | StackDescription$ REP Draw_{p:You} draws | SpellDescription$ Draw a card at the beginning of the next turn's upkeep.
+SVar:DrawSlowtrip:DB$ Draw
 AI:RemoveDeck:All
 Oracle:{T}, Sacrifice Urza's Bauble: Look at a card at random in target player's hand. You draw a card at the beginning of the next turn's upkeep.

--- a/forge-gui/res/cardsfolder/v/vampirism.txt
+++ b/forge-gui/res/cardsfolder/v/vampirism.txt
@@ -5,7 +5,7 @@ K:Enchant:Creature
 SVar:AttachAILogic:Pump
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ DelTrigSlowtrip | TriggerDescription$ When CARDNAME enters, draw a card at the beginning of the next turn's upkeep.
 SVar:DelTrigSlowtrip:DB$ DelayedTrigger | NextTurn$ True | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player | Execute$ DrawSlowtrip | TriggerDescription$ Draw a card.
-SVar:DrawSlowtrip:DB$ Draw | NumCards$ 1 | Defined$ You
+SVar:DrawSlowtrip:DB$ Draw
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ X | AddToughness$ X | Description$ Enchanted creature gets +1/+1 for each other creature you control.
 S:Mode$ Continuous | Affected$ Creature.YouCtrl+Other | AddPower$ -1 | AddToughness$ -1 | Description$ Other creatures you control get -1/-1.
 SVar:X:Count$Valid Creature.YouCtrl


### PR DESCRIPTION
Updated and tested this set of cards so the corresponding Prompt and Stack text reads a bit better. Also trimmed redundant parameters such as those for the `Draw` lines and `TgtPrompt` where automatic text handles it well.
Some scripts like Arcane Denial and Thermal Flux required a bit more attention, but I believe I was successful in updating them, with the latter benefiting from the template provided by Blood on the Snow and similar tricks on other cards. The only outstanding item in this PR is [Aleatory](https://scryfall.com/card/mir/155/aleatory):
- The `Text`: line has no trailing space/new line character on the Card Detail
![aleatory_2](https://github.com/user-attachments/assets/fa863c41-d0d1-453e-a336-0b41dba46d2b)

- The Stack item for the spell shows no text other than that from the `Text:` line
![aleatory](https://github.com/user-attachments/assets/d9550964-bddd-4943-9cbe-a5b24867d428)

These issues were confirmed for [Chaotic Strike](https://scryfall.com/card/inv/140/chaotic-strike) as well. In any case, I tailored my update for Aleatory on the understanding that, at least for me, these don't seem particularly easy to fix on short notice. 




