### PR TITLE
[proposal] establish import style consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,14 @@
 # Ignore IDEA config files
 
-*.idea
+*.idea/*
 *.iml
 *.tmp
 .metadata
 .recommenders
 
+# Except project codeStyle
+!.idea/codeStyles/
+!.idea/codeStyles/Project.xml
 
 # Ignore Eclipse config files
 

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,26 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <JavaCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+        <value>
+          <package name="java.awt" withSubpackages="true" static="false" />
+          <package name="javax.swing" withSubpackages="true" static="false" />
+          <package name="forge.itemmanger.filters" withSubpackages="true" static="false" />
+        </value>
+      </option>
+      <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+          <package name="" withSubpackages="true" static="false" module="true" />
+          <package name="forge" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="java" withSubpackages="true" static="false" />
+          <package name="javax" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="" withSubpackages="true" static="true" />
+        </value>
+      </option>
+    </JavaCodeStyleSettings>
+  </code_scheme>
+</component>


### PR DESCRIPTION
I've noticed a lot of inconsistency in imports across our source files. How about we tighten this up a bit?

To be clear, this configuration does not enforce anything. It just enables an option in IntelliJ IDEA to choose "Project" from the "Scheme" menu in the Code Style -> Java settings, and indirectly documents to contributors how to organize imports when editing project files.

By carving out a `.gitignore` exception for `.idea/codeStyle/Project.xml`, we can put a stake in the ground to start to formalize the project recommendations for this, at least for IDEA. This configuration file could also be a foothold for establishing other project code style standards, although there is a better editor-agnostic way of doing this for many of those (c.f. [EditorConfig](https://editorconfig.org/)). That said, there are quite a few IDEA-specific settings we could include in this file to help establish project style standards.

IDEA can automatically sort imports for us, too. It looks like we are often using the following ordering (but this is one of the areas of significant inconsistency):

- `import forge.*`
- blank line
- `import java.*`
- `import javax.*`
- blank line
- other packages
- blank line
- static imports

This is what I set as the initial ordering in the configuration file.

An open question is whether we want to allow wild card imports, and if so when. I've included some statistics about our current usage of wild card imports below. I prefer no wild cards, myself, and I'm happy to discuss why, but I'm more interested in establishing consistency here than evangelizing.

```
# Files using java.util without wild card
rg -l 'import java.util.[^*]' | wc -l
> 1325

# Files using java.util with wild card
rg -l 'import java.util.\*' | wc -l
> 153

# Files using javax.swing without wild card
rg -l 'import javax.swing.[^*]' | wc -l
> 269

# Files using javax.swing with wild card
rg -l 'import javax.swing.\*' | wc -l
> 54

# Files using java.awt without wild card
rg -l 'import java.awt.[^*]' | wc -l
> 217

# Files using java.awt with wild card
rg -l 'import java.awt.\*' | wc -l
> 38

# Files using wild card imports that are not one of the packages above.
rg -l --pcre2 'import (?!java.util)(?!java.awt)(?!javax.swing).*.\*'
> 271

# And here are what those packages are, and the frequency of their use:
rg --no-filename -N --pcre2 'import (?!java.util)(?!java.awt)(?!javax.swing).*.\*' | sort | uniq -c | sort -nr

 100 import forge.game.card.*;
  53 import forge.util.*;
  45 import forge.ai.*;
  21 import java.io.*;
  20 import forge.game.*;
  20 import forge.card.*;
  18 import com.google.common.collect.*;
  12 import forge.adventure.util.*;
  11 import forge.game.spellability.*;
  11 import forge.game.cost.*;
  10 import forge.toolbox.*;
  10 import com.badlogic.gdx.scenes.scene2d.ui.*;
   9 import forge.game.event.*;
   8 import forge.game.player.*;
   7 import forge.item.*;
   7 import forge.adventure.data.*;
   6 import forge.assets.*;
   5 import forge.screens.deckeditor.views.*;
   5 import forge.deck.*;
   5 import com.badlogic.gdx.graphics.g2d.*;
   3 import static forge.adventure.util.AdventureQuestController.QuestStatus.*;
   3 import java.net.*;
   3 import forge.screens.home.gauntlet.*;
   3 import forge.itemmanager.*;
   3 import com.badlogic.gdx.utils.*;
   2 import io.netty.channel.*;
   2 import forge.itemmanager.filters.*;
   2 import forge.game.staticability.*;
   2 import forge.game.keyword.*;
   2 import forge.adventure.scene.*;
   2 import com.badlogic.gdx.physics.box2d.*;
   2  * import org.jdesktop.swinghelper.buttonpanel.*;
   1 import static org.testng.Assert.*;
   1 import static forge.deck.DeckRecognizer.TokenType.*;
   1 import static forge.adventure.util.AdventureQuestController.ObjectiveTypes.*;
   1 import static forge.adventure.util.AdventureEventController.EventStatus.*;
   1 import static com.badlogic.gdx.graphics.g2d.Batch.*;
   1 import org.w3c.dom.*;
   1 import javax.xml.stream.*;
   1 import forge.util.lang.*;
   1 import forge.sound.*;
   1 import forge.screens.deckeditor.controllers.*;
   1 import forge.localinstance.achievements.*;
   1 import forge.gui.events.*;
   1 import forge.gamesimulationtests.util.playeractions.*;
   1 import forge.gamemodes.quest.data.*;
   1 import forge.gamemodes.net.event.*;
   1 import forge.gamemodes.match.input.*;
   1 import forge.game.replacement.*;
   1 import forge.game.mana.*;
   1 import forge.game.ability.effects.*;
   1 import forge.deck.generation.*;
   1 import forge.ai.ability.*;
   1 import forge.adventure.character.*;
   1 import com.badlogic.gdx.graphics.*;
   1 import com.badlogic.gdx.ai.steer.behaviors.*;
   1 import com.badlogic.gdx.*;
   1 import android.widget.*;
   1 import android.view.*;
   1 import android.text.*;
```