### PR TITLE
Update getCommander method to enable subfolders

### DIFF
--- a/forge-gui/src/main/java/forge/model/CardCollections.java
+++ b/forge-gui/src/main/java/forge/model/CardCollections.java
@@ -111,7 +111,8 @@ public class CardCollections {
     public IStorage<Deck> getCommander() {
         if (commander == null) {
             commander = new StorageImmediatelySerialized<>("Commander decks",
-                    new DeckStorage(new File(ForgeConstants.DECK_COMMANDER_DIR), ForgeConstants.DECK_BASE_DIR));
+                    new DeckStorage(new File(ForgeConstants.DECK_COMMANDER_DIR), ForgeConstants.DECK_BASE_DIR),
+                    true);
         }
         return commander;
     }


### PR DESCRIPTION
_I am not a developer, but Forge is amazing, and I wanted to try to contribute. It was super fun to look at the history of these files going back 13 years ago when support for subfolders was added for Constructed decks. There appears to be an optional boolean flag to search subfolders. To fix this issue I will be submitting only a request to change the function for commander decks, but this could be added to other items in CardCollections.java._

This resolves #7811

Aug 19, 2013 **StorageImmediatelySerialized** was extended to support subfolders with a boolean. See **Commit ada5fa5**.
During this commit the boolean was added into **CardCollections**, but only with the "Constructed Decks".
For this issue I have added the same adjustment to the function that loads the Commander Decks.




 