### PR TITLE
Details Labels and Zooming on Adventure World Map

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/pointofintrest/PointOfInterestChanges.java
+++ b/forge-gui-mobile/src/forge/adventure/pointofintrest/PointOfInterestChanges.java
@@ -20,6 +20,7 @@ public class PointOfInterestChanges implements SaveFileContent  {
     //private final java.util.Map<Integer, Float> shopModifiers = new HashMap<>();
     private final java.util.Map<Integer, Integer> reputation = new HashMap<>();
     private Boolean isBookmarked;
+    private Boolean isVisited;
 
     public static class Map extends HashMap<String,PointOfInterestChanges> implements SaveFileContent {
         @Override
@@ -67,6 +68,7 @@ public class PointOfInterestChanges implements SaveFileContent  {
             reputation.putAll((java.util.Map<Integer, Integer>) data.readObject("reputation"));
         }
         isBookmarked = (Boolean) data.readObject("isBookmarked");
+        isVisited = (Boolean) data.readObject("isVisited");
     }
 
     @Override
@@ -78,6 +80,7 @@ public class PointOfInterestChanges implements SaveFileContent  {
         data.storeObject("shopSeeds", shopSeeds);
         data.storeObject("reputation", reputation);
         data.storeObject("isBookmarked", isBookmarked);
+        data.storeObject("isVisited", isVisited);
         return data;
     }
 
@@ -176,5 +179,13 @@ public class PointOfInterestChanges implements SaveFileContent  {
     public void clearDeletedObjects() {
         // reset map when assigning as a quest target that needs enemies
         deletedObjects.clear();
+    }
+    public boolean isVisited() {
+        if (isVisited ==null)
+            return false;
+        return isVisited;
+    }
+    public void visit() {
+        isVisited = true;
     }
 }

--- a/forge-gui-mobile/src/forge/adventure/scene/MapViewScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/MapViewScene.java
@@ -2,7 +2,10 @@ package forge.adventure.scene;
 
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.math.Vector2;
-import com.badlogic.gdx.scenes.scene2d.*;
+import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.scenes.scene2d.Group;
+import com.badlogic.gdx.scenes.scene2d.InputEvent;
+import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
 import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;

--- a/forge-gui-mobile/src/forge/adventure/scene/MapViewScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/MapViewScene.java
@@ -2,17 +2,19 @@ package forge.adventure.scene;
 
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.math.Vector2;
-import com.badlogic.gdx.scenes.scene2d.Actor;
-import com.badlogic.gdx.scenes.scene2d.Group;
+import com.badlogic.gdx.scenes.scene2d.*;
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
 import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
+import com.badlogic.gdx.utils.SnapshotArray;
 import com.github.tommyettinger.textra.TextraButton;
 import com.github.tommyettinger.textra.TypingLabel;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import forge.Forge;
+import forge.adventure.data.AdventureEventData;
 import forge.adventure.data.AdventureQuestData;
+import forge.adventure.player.AdventurePlayer;
 import forge.adventure.pointofintrest.PointOfInterest;
 import forge.adventure.stage.GameHUD;
 import forge.adventure.stage.WorldStage;
@@ -37,6 +39,9 @@ public class MapViewScene extends UIScene {
     private int index = -1;
     private float avatarX = 0, avatarY = 0;
     private Set<Vector2> positions;
+    private final List<TypingLabel> details;
+    private final float maxZoom = 1.2f;
+    private final float minZoom = 0.25f;
     private Set<PointOfInterest> bookmark;
 
     public static MapViewScene instance() {
@@ -49,7 +54,25 @@ public class MapViewScene extends UIScene {
         super(Forge.isLandscapeMode() ? "ui/map.json" : "ui/map_portrait.json");
         ui.onButtonPress("done", this::done);
         ui.onButtonPress("quest", this::scroll);
-        scroll = ui.findActor("map");
+        //TODO:Add Translations for buttons
+        ui.onButtonPress("details", this::details);
+        ui.onButtonPress("events", this::events);
+        ui.onButtonPress("reputation", this::reputation);
+        ui.onButtonPress("names", this::names);
+        ui.onButtonPress("zoomIn", this::zoomIn);
+        ui.onButtonPress("zoomOut", this::zoomOut);
+        scroll = new ScrollPane(null,Controls.getSkin()) {
+            @Override
+            public void addScrollListener() {
+                return;
+            }
+        };
+        scroll.setName("map");
+        scroll.setActor(Controls.newTextraLabel(""));
+        scroll.setWidth(ui.findActor("map").getWidth());
+        scroll.setHeight(ui.findActor("map").getHeight());
+        ui.addActor(scroll);
+        scroll.setZIndex(1);
         labels = Lists.newArrayList();
         positions = Sets.newHashSet();
         bookmark = Sets.newHashSet();
@@ -60,16 +83,53 @@ public class MapViewScene extends UIScene {
         img.setPosition(0, 0);
         table.addActor(img);
         table.addActor(miniMapPlayer);
+        miniMapPlayer.setZIndex(2);
+        details = Lists.newArrayList();
+        ui.addListener(new InputListener() {
+            public boolean scrolled(InputEvent event, float x, float y, float scrollAmountX, float scrollAmountY) {
+                event.cancel();
+                scroll.setScrollbarsVisible(true);
+                if (scrollAmountY > 0) {
+                    zoomOut();
+                    return true;
+                } else if (scrollAmountY < 0) {
+                    zoomIn();
+                    return true;
+                }
+                return false;
+            }
+        });
+        stage.setScrollFocus(ui);
+
+    }
+
+    public void test() {
+        img.setPosition((scroll.getScrollPercentX()*2334 +233)*0.1f + 0.9f*img.getX(),(2544-scroll.getScrollPercentY()*2544 +128)*0.1f + 0.9f*img.getY());
+        img.setScale(img.getScaleX()*0.9f);
+        miniMapPlayer.setPosition((scroll.getScrollPercentX()*2334 +233)*0.1f + 0.9f*miniMapPlayer.getX(),(2544-scroll.getScrollPercentY()*2544 +128)*0.1f + 0.9f*miniMapPlayer.getY());
+        miniMapPlayer.setScale(miniMapPlayer.getScaleX()*0.9f);
+        for(Actor actor : table.getChildren()) {
+            if (actor instanceof TypingLabel) {
+                actor.setPosition((scroll.getScrollPercentX() * 2334 + 233) * 0.1f + 0.9f * actor.getX(), (2544 - scroll.getScrollPercentY() * 2544 + 128) * 0.1f + 0.9f * actor.getY());
+            }
+        }
     }
 
     public boolean done() {
         GameHUD.getInstance().getTouchpad().setVisible(false);
-        for (Actor a : table.getChildren()) {
-            if (a instanceof TypingLabel)
-                a.remove();
+        SnapshotArray<Actor> allActors = table.getChildren();
+        for (int i = 0; i < allActors.size; i++) {
+            if (allActors.get(i) instanceof TypingLabel) {
+                allActors.get(i).remove();
+                i--;
+            }
         }
         labels.clear();
         positions.clear();
+        details.clear();
+        miniMapPlayer.setScale(1);
+        img.setScale(1);
+        img.setPosition(0,0);
         index = -1;
         Forge.switchToLast();
         return true;
@@ -99,6 +159,134 @@ public class MapViewScene extends UIScene {
             scroll.scrollTo(label.getX(), label.getY(), miniMapPlayer.getWidth(), miniMapPlayer.getHeight(), true, true);
         }
         return true;
+    }
+
+
+    public void details() {
+        TextraButton detailsButton = ui.findActor("details");
+        if (detailsButton != null) {
+            detailsButton.setVisible(false);
+            detailsButton.setDisabled(true);
+        }
+        TextraButton eventButton = ui.findActor("events");
+        if (eventButton != null) {
+            eventButton.setVisible(true);
+            eventButton.setDisabled(false);
+        }
+        List<PointOfInterest> allPois = Current.world().getAllPointOfInterest();
+        for (PointOfInterest poi : allPois) {
+            for (AdventureEventData data : AdventurePlayer.current().getEvents()) {
+                if (data.sourceID.equals(poi.getID())) {
+                    TypingLabel label = Controls.newTypingLabel("[%?BLACKEN] " + data.getCardBlock());
+                    table.addActor(label);
+                    details.add(label);
+                    label.setPosition(img.getScaleX()*(getMapX(poi.getPosition().x) - label.getWidth() / 2) + img.getX(), img.getScaleY()*(getMapY(poi.getPosition().y) - label.getHeight() / 2) + img.getY());
+                    label.skipToTheEnd();
+                }
+            }
+        }
+    }
+
+    public void events() {
+        TextraButton eventsButton = ui.findActor("events");
+        if (eventsButton != null) {
+            eventsButton.setVisible(false);
+            eventsButton.setDisabled(true);
+        }
+        TextraButton repButton = ui.findActor("reputation");
+        if (repButton != null) {
+            repButton.setVisible(true);
+            repButton.setDisabled(false);
+        }
+        for (TypingLabel detail : details) {
+            table.removeActor(detail);
+        }
+        List<PointOfInterest> allPois = Current.world().getAllPointOfInterest();
+        details.clear();
+        for (PointOfInterest poi : allPois) {
+            int rep = WorldSave.getCurrentSave().getPointOfInterestChanges(poi.getID()).getMapReputation();
+            if (rep != 0) {
+                TypingLabel label = Controls.newTypingLabel("[%?BLACKEN] " + rep);
+                table.addActor(label);
+                details.add(label);
+                label.setPosition(img.getScaleX()*(getMapX(poi.getPosition().x) - label.getWidth() / 2) + img.getX(), img.getScaleY()*(getMapY(poi.getPosition().y) - label.getHeight() / 2) + img.getY());
+                label.skipToTheEnd();
+            }
+        }
+    }
+
+    public void reputation() {
+        TextraButton repButton = ui.findActor("reputation");
+        if (repButton != null) {
+            repButton.setVisible(false);
+            repButton.setDisabled(true);
+        }
+        TextraButton namesButton = ui.findActor("names");
+        if (namesButton != null) {
+            namesButton.setVisible(true);
+            namesButton.setDisabled(false);
+        }
+        for (TypingLabel detail : details) {
+            table.removeActor(detail);
+        }
+        details.clear();
+        List<PointOfInterest> allPois = Current.world().getAllPointOfInterest();
+        for (PointOfInterest poi : allPois) {
+            if (WorldSave.getCurrentSave().getPointOfInterestChanges(poi.getID()).isVisited()) {
+                if ("cave".equalsIgnoreCase(poi.getData().type) || "dungeon".equalsIgnoreCase(poi.getData().type) || "castle".equalsIgnoreCase(poi.getData().type)) {
+                    TypingLabel label = Controls.newTypingLabel("[%?BLACKEN] " + poi.getDisplayName());
+                    table.addActor(label);
+                    details.add(label);
+                    label.setPosition(img.getScaleX()*(getMapX(poi.getPosition().x) - label.getWidth() / 2) + img.getX(), img.getScaleY()*(getMapY(poi.getPosition().y) - label.getHeight() / 2) + img.getY());
+                    label.skipToTheEnd();
+                }
+            }
+        }
+    }
+
+    public void names() {
+        TextraButton namesButton = ui.findActor("names");
+        if (namesButton != null) {
+            namesButton.setVisible(false);
+            namesButton.setDisabled(true);
+        }
+        TextraButton detailsButton = ui.findActor("details");
+        if (detailsButton != null) {
+            detailsButton.setVisible(true);
+            detailsButton.setDisabled(false);
+        }
+        for (TypingLabel detail : details) {
+            table.removeActor(detail);
+        }
+        details.clear();
+
+    }
+
+    public void zoomOut() {
+        if (img.getScaleX()*0.9f > minZoom) {
+            img.setPosition((scroll.getScrollX() + scroll.getWidth()/2) * 0.1f + 0.9f * img.getX(), (scroll.getMaxY() - scroll.getScrollY() + scroll.getHeight()/2) * 0.1f + 0.9f * img.getY());
+            img.setScale(img.getScaleX() * 0.9f);
+            miniMapPlayer.setPosition((scroll.getScrollX() + scroll.getWidth()/2) * 0.1f + 0.9f * miniMapPlayer.getX(), (scroll.getMaxY() - scroll.getScrollY() + scroll.getHeight()/2) * 0.1f + 0.9f * miniMapPlayer.getY());
+            miniMapPlayer.setScale(miniMapPlayer.getScaleX() * 0.9f);
+            for (Actor actor : table.getChildren()) {
+                if (actor instanceof TypingLabel) {
+                    actor.setPosition((scroll.getScrollX() + scroll.getWidth()/2) * 0.1f + 0.9f * actor.getX(), (scroll.getMaxY() - scroll.getScrollY() + scroll.getHeight()/2) * 0.1f + 0.9f * actor.getY());
+                }
+            }
+        }
+    }
+    public void zoomIn() {
+        if (img.getScaleX()*1.1f < maxZoom) {
+            img.setPosition(-(scroll.getScrollX() + scroll.getWidth()/2) * 0.1f + 1.1f * img.getX(), -(scroll.getMaxY() - scroll.getScrollY() + scroll.getHeight()/2) * 0.1f + 1.1f * img.getY());
+            img.setScale(img.getScaleX() * 1.1f);
+            miniMapPlayer.setPosition(-(scroll.getScrollX() + scroll.getWidth()/2) * 0.1f + 1.1f * miniMapPlayer.getX(), -(scroll.getMaxY() - scroll.getScrollY() + scroll.getHeight()/2) * 0.1f + 1.1f * miniMapPlayer.getY());
+            miniMapPlayer.setScale(miniMapPlayer.getScaleX() * 1.1f);
+            for (Actor actor : table.getChildren()) {
+                if (actor instanceof TypingLabel) {
+                    actor.setPosition(-(scroll.getScrollX() + scroll.getWidth()/2) * 0.1f + 1.1f * actor.getX(), -(scroll.getMaxY() - scroll.getScrollY() + scroll.getHeight()/2) * 0.1f + 1.1f * actor.getY());
+                }
+            }
+        }
     }
 
     @Override
@@ -134,6 +322,37 @@ public class MapViewScene extends UIScene {
             table.addActor(label);
             label.setPosition(getMapX(poi.getPosition().x) - label.getWidth() / 2, getMapY(poi.getPosition().y) - label.getHeight() / 2);
             label.skipToTheEnd();
+        }
+
+        TextraButton detailsButton = ui.findActor("details");
+        if (detailsButton != null) {
+            detailsButton.setVisible(true);
+            detailsButton.setDisabled(false);
+        }
+        TextraButton eventButton = ui.findActor("events");
+        if (eventButton != null) {
+            eventButton.setVisible(false);
+            eventButton.setDisabled(true);
+        }
+        TextraButton repButton = ui.findActor("reputation");
+        if (repButton != null) {
+            repButton.setVisible(false);
+            repButton.setDisabled(true);
+        }
+        TextraButton namesButton = ui.findActor("names");
+        if (namesButton != null) {
+            namesButton.setVisible(false);
+            namesButton.setDisabled(true);
+        }
+        TextraButton zoomInButton = ui.findActor("zoomIn");
+        if (zoomInButton != null) {
+            zoomInButton.setVisible(true);
+            zoomInButton.setDisabled(false);
+        }
+        TextraButton zoomOutButton = ui.findActor("zoomOut");
+        if (zoomOutButton != null) {
+            zoomOutButton.setVisible(true);
+            zoomOutButton.setDisabled(false);
         }
         TextraButton questButton = ui.findActor("quest");
         if (questButton != null) {

--- a/forge-gui-mobile/src/forge/adventure/stage/WorldStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/WorldStage.java
@@ -216,6 +216,7 @@ public class WorldStage extends GameStage implements SaveFileContent {
                     WorldSave.getCurrentSave().autoSave();
                     loadPOI(point.getPointOfInterest());
                     point.getMapSprite().checkOut();
+                    WorldSave.getCurrentSave().getPointOfInterestChanges(point.getPointOfInterest().getID()).visit();
                     return true;
                 } else {
                     if (point == collidingPoint) {
@@ -365,7 +366,7 @@ public class WorldStage extends GameStage implements SaveFileContent {
         super.draw();
         if (WorldSave.getCurrentSave().getPlayer().hasAnnounceFantasy()) {
             MapStage.getInstance().showDeckAwardDialog("{BLINK=WHITE;RED}Chaos Mode!{ENDBLINK}\n" +
-                    "Enemy will use Preconstructed or Random Generated Decks. Genetic AI Decks will be available to some enemies on Hard difficulty.",
+                            "Enemy will use Preconstructed or Random Generated Decks. Genetic AI Decks will be available to some enemies on Hard difficulty.",
                     WorldSave.getCurrentSave().getPlayer().getSelectedDeck());
             WorldSave.getCurrentSave().getPlayer().clearAnnounceFantasy();
         } else if (WorldSave.getCurrentSave().getPlayer().hasAnnounceCustom()) {

--- a/forge-gui/res/adventure/common/ui/map.json
+++ b/forge-gui/res/adventure/common/ui/map.json
@@ -2,10 +2,10 @@
   "width": 480,
   "height": 270,
   "yDown": true,
-  "elements": [      
+  "elements": [
     {
       "type": "Scroll",
-      "name": "map",    
+      "name": "map",
       "width": 480,
       "height": 270
     },
@@ -28,6 +28,60 @@
       "height": 20,
       "x": 415,
       "y": 245
-    }  
+    },
+    {
+      "type": "TextButton",
+      "name": "details",
+      "text": "[%80] Details",
+      "width": 60,
+      "height": 20,
+      "x": 210,
+      "y": 245
+    },
+    {
+      "type": "TextButton",
+      "name": "events",
+      "text": "[%80] Events",
+      "width": 60,
+      "height": 20,
+      "x": 210,
+      "y": 245
+    },
+    {
+      "type": "TextButton",
+      "name": "reputation",
+      "text": "[%80] Reputation",
+      "width": 60,
+      "height": 20,
+      "x": 210,
+      "y": 245
+    },
+    {
+      "type": "TextButton",
+      "name": "names",
+      "text": "[%80] Names",
+      "width": 60,
+      "height": 20,
+      "x": 210,
+      "y": 245
+    },
+    {
+      "type": "TextButton",
+      "name": "zoomIn",
+      "text": "[%80]+",
+      "width": 20,
+      "height": 20,
+      "x": 5,
+      "y": 5
+    },
+    {
+      "type": "TextButton",
+      "name": "zoomOut",
+      "text": "[%80]-",
+      "width": 20,
+      "height": 20,
+      "x": 455,
+      "y": 5
+    }
   ]
 }

--- a/forge-gui/res/adventure/common/ui/map_portrait.json
+++ b/forge-gui/res/adventure/common/ui/map_portrait.json
@@ -26,6 +26,60 @@
       "height": 20,
       "x": 205,
       "y": 455
-    }  
+    },
+    {
+      "type": "TextButton",
+      "name": "details",
+      "text": "[%80] Details",
+      "width": 60,
+      "height": 20,
+      "x": 105,
+      "y": 245
+    },
+    {
+      "type": "TextButton",
+      "name": "events",
+      "text": "[%80] Events",
+      "width": 60,
+      "height": 20,
+      "x": 105,
+      "y": 245
+    },
+    {
+      "type": "TextButton",
+      "name": "reputation",
+      "text": "[%80] Reputation",
+      "width": 60,
+      "height": 20,
+      "x": 105,
+      "y": 245
+    },
+    {
+      "type": "TextButton",
+      "name": "names",
+      "text": "[%80] Names",
+      "width": 60,
+      "height": 20,
+      "x": 105,
+      "y": 245
+    },
+    {
+      "type": "TextButton",
+      "name": "zoomIn",
+      "text": "[%80]+",
+      "width": 20,
+      "height": 20,
+      "x": 5,
+      "y": 5
+    },
+    {
+      "type": "TextButton",
+      "name": "zoomOut",
+      "text": "[%80]-",
+      "width": 20,
+      "height": 20,
+      "x": 245,
+      "y": 5
+    }
   ]
 }


### PR DESCRIPTION
Multiple Buttons which cycle Visibility when being pressed:
Details -> Events: Display Drafts/Jumpstarts at Inns
Events -> Reputation: Remove Labels. Display Town Reputation if != 0
Reputation -> Names: Remove Labels. Display Names of visited Dungeons (visited is saved in PointOfInterestChanges)
Names -> Details: Remove Labels

Zooming by creating a new ScrollPane without a ScrollListener and then attaching a new Input Listener which activates the Zoom methods
WorldMap image gets scaled and moved to maintain viewing position
Labels and MiniMapPlayer get moved as well
