### PR TITLE
Fix several UX issues with menu navigation and dialog boxes

### DIFF
--- a/forge-gui-mobile/src/forge/Forge.java
+++ b/forge-gui-mobile/src/forge/Forge.java
@@ -1235,7 +1235,15 @@ public class Forge implements ApplicationListener {
             if (keyInputAdapter != null) {
                 return keyInputAdapter.keyUp(keyCode);
             }
-            return false;
+            // if no active key input adapter, give current screen or overlay a chance to handle key
+            FContainer container = FOverlay.getTopOverlay();
+            if (container == null) {
+                container = currentScreen;
+                if (container == null) {
+                    return false;
+                }
+            }
+            return container.keyUp(keyCode);
         }
 
         @Override

--- a/forge-gui-mobile/src/forge/Forge.java
+++ b/forge-gui-mobile/src/forge/Forge.java
@@ -274,6 +274,14 @@ public class Forge implements ApplicationListener {
         return false;
     }
 
+    public static boolean hasExternalInput() {
+        return hasGamepad() || hasKeyboard();
+    }
+
+    public static boolean hasKeyboard() {
+        return !GuiBase.isAndroid();
+    }
+
     public static InputProcessor getInputProcessor() {
         return inputProcessor;
     }

--- a/forge-gui-mobile/src/forge/adventure/scene/AdventureDeckEditor.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/AdventureDeckEditor.java
@@ -1612,5 +1612,13 @@ public class AdventureDeckEditor extends TabPageScreen<AdventureDeckEditor> {
         }
         return true;
     }
+
+    @Override
+    public boolean keyUp(int keyCode) {
+        if (keyCode == Input.Keys.ESCAPE) {
+            return this.tabHeader.btnBack.trigger();
+        }
+        return super.keyUp(keyCode);
+    }
 }
 

--- a/forge-gui-mobile/src/forge/adventure/scene/MenuScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/MenuScene.java
@@ -308,7 +308,7 @@ public class MenuScene extends UIScene {
         }
         dialog.show(stage, Actions.show());
         dialog.setPosition((stage.getWidth() - dialog.getWidth()) / 2, (stage.getHeight() - dialog.getHeight()) / 2);
-        if (Forge.hasGamepad() && !dialogButtonMap.isEmpty())
+        if (Forge.hasExternalInput() && !dialogButtonMap.isEmpty())
             stage.setKeyboardFocus(dialogButtonMap.first());
     }
 

--- a/forge-gui-mobile/src/forge/adventure/scene/RewardScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/RewardScene.java
@@ -83,6 +83,10 @@ public class RewardScene extends UIScene {
         detailButton.setVisible(false);
         doneButton = ui.findActor("done");
         restockButton = ui.findActor("restock");
+
+        if (type != Type.Shop) {
+            doneButton.setText("[+OK]");
+        }
     }
 
     @Override
@@ -159,18 +163,15 @@ public class RewardScene extends UIScene {
     boolean done(boolean skipShowLoot) {
         GameHUD.getInstance().getTouchpad().setVisible(false);
         if (!skipShowLoot) {
-            doneButton.setText("[+OK]");
             showLootOrDone();
             return true;
         }
         if (type != null) {
             switch (type) {
                 case Shop:
-                    doneButton.setText("[+OK]");
                     break;
                 case QuestReward:
                 case Loot:
-                    doneButton.setText("[+OK]");
                     break;
             }
         }
@@ -217,7 +218,6 @@ public class RewardScene extends UIScene {
     @Override
     public void enter() {
         autoSell = false;
-        doneButton.setText("[+OK]");
         updateDetailButton();
         super.enter();
     }
@@ -406,7 +406,6 @@ public class RewardScene extends UIScene {
 
         switch (type) {
             case Shop:
-                doneButton.setText("[+OK]");
                 String shopName = shopActor.getDescription();
                 if ((shopName != null && !shopName.isEmpty())) {
                     headerLabel.setVisible(true);
@@ -425,7 +424,6 @@ public class RewardScene extends UIScene {
                 headerLabel.setVisible(false);
                 headerLabel.setText("");
                 restockButton.setVisible(false);
-                doneButton.setText("[+OK]");
                 break;
             case Loot:
                 headerLabel.skipToTheEnd();
@@ -433,11 +431,9 @@ public class RewardScene extends UIScene {
                 headerLabel.setVisible(true);
                 headerLabel.setText("[%?SHINY][;]\u2610 " + Forge.getLocalizer().getMessage("lblAll"));
                 restockButton.setVisible(false);
-                doneButton.setText("[+OK]");
                 break;
             case RewardChoice:
                 restockButton.setVisible(false);
-                doneButton.setText("[+OK]");
                 headerLabel.setVisible(remainingSelections > 0);
                 headerLabel.setText(Forge.getLocalizer().getMessage("lblSelectRewards", remainingSelections));
                 doneButton.setDisabled(remainingSelections > 0);

--- a/forge-gui-mobile/src/forge/adventure/scene/RewardScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/RewardScene.java
@@ -83,10 +83,6 @@ public class RewardScene extends UIScene {
         detailButton.setVisible(false);
         doneButton = ui.findActor("done");
         restockButton = ui.findActor("restock");
-
-        if (type != Type.Shop) {
-            doneButton.setText("[+OK]");
-        }
     }
 
     @Override
@@ -342,6 +338,8 @@ public class RewardScene extends UIScene {
             this.shopActor = shopActor;
             this.changes = shopActor.getMapStage().getChanges();
             addToSelectable(restockButton);
+        } else {
+            doneButton.setText("[+OK]");
         }
         for (Actor actor : new Array.ArrayIterator<>(generated)) {
             actor.remove();

--- a/forge-gui-mobile/src/forge/adventure/scene/UIScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/UIScene.java
@@ -340,16 +340,15 @@ public class UIScene extends Scene {
     }
 
     public boolean keyPressed(int keycode) {
+        ui.pressDown(keycode);
+    
         Selectable selection = getSelected();
-
         if (KeyBinding.Use.isPressed(keycode)) {
             if (selection != null) {
                 selection.onPressDown(this);
-                return true;
             }
         }
 
-        ui.pressDown(keycode);
         if (stage.getKeyboardFocus() instanceof SelectBox) {
             SelectBox box = (SelectBox) stage.getKeyboardFocus();
             if (box.getScrollPane().hasParent()) {

--- a/forge-gui-mobile/src/forge/adventure/stage/GameHUD.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/GameHUD.java
@@ -794,6 +794,12 @@ public class GameHUD extends Stage {
     @Override
     public boolean keyUp(int keycode) {
         ui.pressUp(keycode);
+    
+        Button pressedButton = ui.buttonPressed(keycode);
+        if (pressedButton != null) {
+            pressedButton.fire(eventTouchUp);
+        }
+
         return super.keyUp(keycode);
     }
 
@@ -816,7 +822,7 @@ public class GameHUD extends Stage {
             return true;
         Button pressedButton = ui.buttonPressed(keycode);
         if (pressedButton != null) {
-            performTouch(pressedButton);
+            pressedButton.fire(eventTouchDown);
         }
         return super.keyDown(keycode);
     }

--- a/forge-gui-mobile/src/forge/adventure/stage/GameHUD.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/GameHUD.java
@@ -813,9 +813,10 @@ public class GameHUD extends Stage {
             toggleConsole();
             return true;
         }
-        if (keycode == Input.Keys.BACK) {
+        if (KeyBinding.Back.isPressed(keycode)) {
             if (console.isVisible()) {
                 toggleConsole();
+                return true;
             }
         }
         if (console.isVisible())

--- a/forge-gui-mobile/src/forge/adventure/stage/GameHUD.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/GameHUD.java
@@ -884,7 +884,7 @@ public class GameHUD extends Stage {
         dialogOnlyInput = true;
         gameStage.hudIsShowingDialog(true);
         MapStage.getInstance().hudIsShowingDialog(true);
-        if (Forge.hasGamepad() && !dialogButtonMap.isEmpty())
+        if (Forge.hasExternalInput() && !dialogButtonMap.isEmpty())
             this.setKeyboardFocus(dialogButtonMap.first());
     }
 

--- a/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
@@ -577,9 +577,6 @@ public abstract class GameStage extends Stage {
             if (!player.isMoving())
                 stop();
         }
-        if (KeyBinding.Menu.isPressed(keycode)) {
-            openMenu();
-        }
         return false;
     }
 

--- a/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
@@ -110,7 +110,7 @@ public abstract class GameStage extends Stage {
         dialog.setPosition((dialogStage.getWidth() - dialog.getWidth()) / 2, (dialogStage.getHeight() - dialog.getHeight()) / 2);
         dialogOnlyInput = true;
 
-        if (Forge.hasGamepad() && !dialogButtonMap.isEmpty())
+        if (Forge.hasExternalInput() && !dialogButtonMap.isEmpty())
             dialogStage.setKeyboardFocus(dialogButtonMap.first());
     }
 

--- a/forge-gui-mobile/src/forge/adventure/stage/MapStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/MapStage.java
@@ -1132,8 +1132,10 @@ public class MapStage extends GameStage {
         dialog.show(dialogStage, Actions.show());
         dialog.setPosition((dialogStage.getWidth() - dialog.getWidth()) / 2, (dialogStage.getHeight() - dialog.getHeight()) / 2);
         dialogOnlyInput = true;
-        if (Forge.hasGamepad() && !dialogButtonMap.isEmpty())
+
+        if (Forge.hasExternalInput() && !dialogButtonMap.isEmpty()) {
             dialogStage.setKeyboardFocus(dialogButtonMap.first());
+        }
     }
 
 

--- a/forge-gui-mobile/src/forge/toolbox/FDisplayObject.java
+++ b/forge-gui-mobile/src/forge/toolbox/FDisplayObject.java
@@ -190,4 +190,8 @@ public abstract class FDisplayObject {
     public boolean keyDown(int keyCode) {
         return false;
     }
+
+    public boolean keyUp(int keyCode) {
+        return false;
+    }
 }

--- a/forge-gui/res/adventure/common/ui/items.json
+++ b/forge-gui/res/adventure/common/ui/items.json
@@ -37,10 +37,10 @@
     {
       "type": "TextButton",
       "name": "done",
-      "text": "[+OK]",
+      "text": "Back",
       "width": 48,
       "height": 30,
-      "binding": "Use",
+      "binding": "Back",
       "x": 420,
       "y": 120
     }  ,


### PR DESCRIPTION
This PR contains a number of UX improvements and bug fixes for menu navigation in Adventure Mode

The majority of these fixes are related to keybindings that only work when using game pads or Android devices, and do not have keyboard support.

* Change keybinding to exit the shop and other rewards screens from Use to Back. This is consistent with all other menus that let you press ESC to go back. It also prevents accidental purchase of cards when attempting to exit shop.
* Fix enter key not working to save game in save menu
* Fix enter key not working to load game in load menu
* Add support for ESC key to go back from deck editor screen
* Fix main menu flickering issue when opened
* Fix issue where main menu opens and closes with a single key press
* Enable ESC (Back KeyBinding) to dismiss console
* Fix autofocus in dialogs on desktop (with keyboard). This allows you to press enter to dismiss single option dialogs.

This resolves most of the issues listed here: https://github.com/Card-Forge/forge/issues/6823