### PR TITLE
fix null pointer on refresh during last draft pick

### DIFF
--- a/forge-gui-mobile/src/forge/deck/FDeckEditor.java
+++ b/forge-gui-mobile/src/forge/deck/FDeckEditor.java
@@ -1997,7 +1997,9 @@ public class FDeckEditor extends TabPageScreen<FDeckEditor> {
         @Override
         public void refresh() {
             BoosterDraft draft = parentScreen.getDraft();
-            if (draft == null) { return; }
+            if (draft == null || !draft.hasNextChoice()) {
+                return;
+            }
 
             CardPool pool = draft.nextChoice();
             int packNumber = draft.getCurrentBoosterIndex() + 1;


### PR DESCRIPTION
Got several reports of drafts crashing at the very last pick because of a null pointer to the pool.  I couldn't replicate this myself but a refresh is being scheduled and then activated on the last pick, resulting in `draft.nextChoice()` returning null, and then finally `ImagePool.addAll()` throwing a null pointer exception.