### PR TITLE
use strongly typed configuration; put Game behind an interface

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiAttackController.java
+++ b/forge-ai/src/main/java/forge/ai/AiAttackController.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import forge.ai.ability.AnimateAi;
 import forge.game.GameEntity;
+import forge.game.GameOptions;
 import forge.game.ability.AbilityUtils;
 import forge.game.ability.ApiType;
 import forge.game.ability.effects.ProtectEffect;
@@ -96,8 +97,8 @@ public class AiAttackController {
         myList = ai.getCreaturesInPlay();
         this.nextTurn = nextTurn;
         refreshCombatants(defendingOpponent);
-        this.timeOut = ai.getGame().getAITimeout();
-        this.canUseTimeout = ai.getGame().canUseTimeout();
+        this.timeOut = ai.getGame().configuration().get(GameOptions.AI_TIMEOUT);
+        this.canUseTimeout = ai.getGame().configuration().get(GameOptions.AI_CAN_USE_TIMEOUT);
     } // overloaded constructor to evaluate attackers that should attack next turn
 
     public AiAttackController(final Player ai, Card attacker) {
@@ -111,8 +112,8 @@ public class AiAttackController {
             attackers.add(attacker);
         }
         this.blockers = getPossibleBlockers(oppList, this.attackers, this.nextTurn);
-        this.timeOut = ai.getGame().getAITimeout();
-        this.canUseTimeout = ai.getGame().canUseTimeout();
+        this.timeOut = ai.getGame().configuration().get(GameOptions.AI_TIMEOUT);
+        this.canUseTimeout = ai.getGame().configuration().get(GameOptions.AI_CAN_USE_TIMEOUT);
     } // overloaded constructor to evaluate single specified attacker
 
     private void refreshCombatants(GameEntity defender) {

--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -1791,7 +1791,7 @@ public class AiController {
 
         // instead of computing all available concurrently just add a simple timeout depending on the user prefs
         try {
-            return future.get(game.getAITimeout(), TimeUnit.SECONDS);
+            return future.get(game.configuration().get(GameOptions.AI_TIMEOUT), TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             future.cancel(true);
             return null;

--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -1147,7 +1147,7 @@ public class PlayerControllerAi extends PlayerController {
     public String chooseProtectionType(String string, SpellAbility sa, List<String> choices) {
         String choice = choices.get(0);
         SpellAbility hostsa = null;     //for Protect sub-ability
-        if (getGame().stack.size() > 1) {
+        if (getGame().stack().size() > 1) {
             for (SpellAbilityStackInstance si : getGame().getStack()) {
                 SpellAbility spell = si.getSpellAbility();
                 if (sa != spell && sa.getHostCard() != spell.getHostCard()) {
@@ -1161,8 +1161,8 @@ public class PlayerControllerAi extends PlayerController {
         }
         final Combat combat = getGame().getCombat();
         if (combat != null) {
-            if (getGame().stack.size() == 1) {
-                SpellAbility topstack = getGame().stack.peekAbility();
+            if (getGame().stack().size() == 1) {
+                SpellAbility topstack = getGame().stack().peekAbility();
                 if (topstack.getSubAbility() == sa) {
                     hostsa = topstack;
                 }

--- a/forge-ai/src/main/java/forge/ai/simulation/GameCopier.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameCopier.java
@@ -50,7 +50,7 @@ public class GameCopier {
 
     public GameCopier(Game origGame) {
         this.origGame = origGame;
-        if (origGame.EXPERIMENTAL_RESTORE_SNAPSHOT) {
+        if (origGame.configuration().get(GameOptions.EXPERIMENTAL_RESTORE_SNAPSHOT)) {
             this.snapshot = new GameSnapshot(origGame);
         }
     }
@@ -67,7 +67,7 @@ public class GameCopier {
         return makeCopy(null, null);
     }
     public Game makeCopy(PhaseType advanceToPhase, Player aiPlayer) {
-        if (origGame.EXPERIMENTAL_RESTORE_SNAPSHOT) {
+        if (origGame.configuration().get(GameOptions.EXPERIMENTAL_RESTORE_SNAPSHOT)) {
             // How do we advance to phase when using restores?
             return snapshot.makeCopy();
         }
@@ -80,7 +80,7 @@ public class GameCopier {
 
         GameRules currentRules = origGame.getRules();
         Match newMatch = new Match(currentRules, newPlayers, origGame.getView().getTitle());
-        Game newGame = new Game(newPlayers, currentRules, newMatch);
+        Game newGame = new GameImpl(newPlayers, currentRules, newMatch);
         newGame.dangerouslySetTimestamp(origGame.getTimestamp());
 
         for (int i = 0; i < origGame.getPlayers().size(); i++) {
@@ -214,9 +214,7 @@ public class GameCopier {
     }
 
     private void copyGameState(Game newGame, Player aiPlayer) {
-        newGame.EXPERIMENTAL_RESTORE_SNAPSHOT = origGame.EXPERIMENTAL_RESTORE_SNAPSHOT;
-        newGame.AI_TIMEOUT = origGame.AI_TIMEOUT;
-        newGame.AI_CAN_USE_TIMEOUT = origGame.AI_CAN_USE_TIMEOUT;
+        newGame.setConfiguration(origGame.configuration());
         newGame.setAge(origGame.getAge());
 
         // TODO countersAddedThisTurn
@@ -475,7 +473,7 @@ public class GameCopier {
     }
 
     public GameObject find(GameObject o) {
-        if (origGame.EXPERIMENTAL_RESTORE_SNAPSHOT) {
+        if (origGame.configuration().get(GameOptions.EXPERIMENTAL_RESTORE_SNAPSHOT)) {
             return snapshot.find(o);
         }
 
@@ -497,7 +495,7 @@ public class GameCopier {
         return result;
     }
     public GameObject reverseFind(GameObject o) {
-        if (origGame.EXPERIMENTAL_RESTORE_SNAPSHOT) {
+        if (origGame.configuration().get(GameOptions.EXPERIMENTAL_RESTORE_SNAPSHOT)) {
             return snapshot.reverseFind(o);
         }
 

--- a/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
@@ -4,6 +4,7 @@ import forge.ai.AiDeckStatistics;
 import forge.ai.CreatureEvaluator;
 import forge.card.mana.ManaAtom;
 import forge.game.Game;
+import forge.game.GameOptions;
 import forge.game.card.Card;
 import forge.game.card.CounterEnumType;
 import forge.game.cost.CostSacrifice;
@@ -53,7 +54,7 @@ public class GameStateEvaluator {
         Game gameCopy;
         GameCopier copier = new GameCopier(evalGame);
 
-        if (evalGame.EXPERIMENTAL_RESTORE_SNAPSHOT) {
+        if (evalGame.configuration().get(GameOptions.EXPERIMENTAL_RESTORE_SNAPSHOT)) {
             gameCopy = copier.makeCopy();
         } else {
             gameCopy = copier.makeCopy(null, aiPlayer);

--- a/forge-ai/src/main/java/forge/ai/simulation/SpellAbilityPicker.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/SpellAbilityPicker.java
@@ -25,7 +25,7 @@ public class SpellAbilityPicker {
     private Game game;
     private Player player;
     private Score bestScore;
-    private boolean printOutput = false;
+    private boolean printOutput = true;
     private SpellAbilityChoicesIterator interceptor;
 
     private Plan plan;

--- a/forge-game/src/main/java/forge/game/Game.java
+++ b/forge-game/src/main/java/forge/game/Game.java
@@ -1,1388 +1,163 @@
-/*
- * Forge: Play Magic: the Gathering.
- * Copyright (C) 2011  Forge Team
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
 package forge.game;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Sets;
-import com.google.common.collect.Table;
-import com.google.common.eventbus.EventBus;
+import com.google.common.collect.*;
 import forge.GameCommand;
-import forge.card.CardRarity;
-import forge.card.CardStateName;
-import forge.game.ability.AbilityKey;
 import forge.game.card.*;
 import forge.game.combat.Combat;
+import forge.game.config.Configuration;
 import forge.game.event.Event;
-import forge.game.event.GameEventDayTimeChanged;
-import forge.game.event.GameEventGameOutcome;
 import forge.game.phase.Phase;
 import forge.game.phase.PhaseHandler;
-import forge.game.phase.PhaseType;
 import forge.game.phase.Untap;
 import forge.game.player.*;
 import forge.game.replacement.ReplacementHandler;
 import forge.game.spellability.SpellAbility;
-import forge.game.spellability.SpellAbilityStackInstance;
-import forge.game.staticability.StaticAbilityCantChangeDayTime;
 import forge.game.trigger.TriggerHandler;
-import forge.game.trigger.TriggerType;
 import forge.game.zone.CostPaymentStack;
 import forge.game.zone.MagicStack;
 import forge.game.zone.Zone;
 import forge.game.zone.ZoneType;
 import forge.trackable.Tracker;
-import forge.util.*;
-import forge.util.collect.FCollection;
-import org.apache.commons.lang3.ObjectUtils;
+import forge.util.Visitor;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.*;
-import java.util.function.Predicate;
 
-/**
- * Represents the state of a <i>single game</i>, a new instance is created for each game.
- */
-public class Game {
-
-    private static int maxId = 0;
-    private static int nextId() { return ++maxId; }
-
-    /** The ID. */
-    private int id;
-    private final GameRules rules;
-    private final PlayerCollection allPlayers = new PlayerCollection();
-    private final PlayerCollection ingamePlayers = new PlayerCollection();
-    private final PlayerCollection lostPlayers = new PlayerCollection();
-
-    private List<Card> activePlanes = null;
-
-    public final Phase cleanup;
-    public final Phase endOfCombat;
-    public final Phase endOfTurn;
-    public final Untap untap;
-    public final Phase upkeep;
-    // to execute commands for "current" phase each time state based action is checked
-    public final List<GameCommand> sbaCheckedCommandList;
-    public final MagicStack stack;
-    public final CostPaymentStack costPaymentStack = new CostPaymentStack();
-    private final PhaseHandler phaseHandler;
-    private final StaticEffects staticEffects = new StaticEffects();
-    private final TriggerHandler triggerHandler = new TriggerHandler(this);
-    private final ReplacementHandler replacementHandler = new ReplacementHandler(this);
-    private final EventBus events = new EventBus("game events");
-    private final GameLog gameLog = new GameLog();
-
-    private final Zone stackZone = new Zone(ZoneType.Stack, this);
-    public int AI_TIMEOUT = 5;
-    public boolean AI_CAN_USE_TIMEOUT = true;
-
-    public boolean EXPERIMENTAL_RESTORE_SNAPSHOT = false;
-    // While this is false here, its really set by the Match/Preferences
-
-    // If this merges with LKI In the future, it will need to change forms
-    private GameSnapshot previousGameState = null;
-    private CardCollection lastStateBattlefield = new CardCollection();
-    private CardCollection lastStateGraveyard = new CardCollection();
-
-    private CardZoneTable untilHostLeavesPlayTriggerList = new CardZoneTable();
-
-    private Table<CounterType, Player, List<Pair<Card, Integer>>> countersAddedThisTurn = HashBasedTable.create();
-    private Multimap<CounterType, Pair<GameEntity, Integer>> countersRemovedThisTurn = ArrayListMultimap.create();
-
-    private List<Card> leftBattlefieldThisTurn = Lists.newArrayList();
-    private List<Card> leftGraveyardThisTurn = Lists.newArrayList();
-
-    private FCollection<CardDamageHistory> globalDamageHistory = new FCollection<>();
-    private IdentityHashMap<Pair<Integer, Boolean>, Pair<Card, GameEntity>> damageThisTurnLKI = new IdentityHashMap<>();
-
-    private Map<Player, Card> topLibsCast = Maps.newHashMap();
-    private Map<Card, Integer> facedownWhileCasting = Maps.newHashMap();
-
-    private Player initiative;
-    private Player monarch;
-    private Player monarchBeginTurn;
-    private Player startingPlayer;
-
-    private Direction turnOrder = Direction.getDefaultDirection();
-
-    private Boolean daytime = null;
-
-    private int numPiledGuessedSA;
-
-    private long timestamp = 0;
-    public final GameAction action;
-    private final Match match;
-    private GameStage age = GameStage.BeforeMulligan;
-    private GameOutcome outcome;
-    private final Game maingame;
-
-    private final GameView view;
-    private final Tracker tracker = new Tracker();
-
-    /**
-     * Gets the id.
-     *
-     * @return the id
-     */
-    public int getId() {
-        return this.id;
-    }
-
-    public Player getStartingPlayer() {
-        return startingPlayer;
-    }
-    public void setStartingPlayer(final Player p) {
-        startingPlayer = p;
-    }
-
-    public Player getMonarch() {
-        return monarch;
-    }
-    public void setMonarch(final Player p) {
-        monarch = p;
-    }
-
-    public Player getMonarchBeginTurn() {
-        return monarchBeginTurn;
-    }
-    public void setMonarchBeginTurn(Player monarchBeginTurn) {
-        this.monarchBeginTurn = monarchBeginTurn;
-    }
-
-    public Player getHasInitiative() {
-        return initiative;
-    }
-    public void setHasInitiative(final Player p) {
-        initiative = p;
-    }
-
-    public CardZoneTable getUntilHostLeavesPlayTriggerList() {
-        return untilHostLeavesPlayTriggerList;
-    }
-
-    public CardCollectionView getLastStateBattlefield() {
-        return lastStateBattlefield;
-    }
-    public CardCollectionView getLastStateGraveyard() {
-        return lastStateGraveyard;
-    }
-
-    public void stashGameState() {
-        // Take a snapshot of the current state to restore to previous state
-        if (EXPERIMENTAL_RESTORE_SNAPSHOT) {
-            previousGameState = new GameSnapshot(this);
-            previousGameState.makeCopy();
-        }
-    }
-
-    public boolean restoreGameState() {
-        // Restore game state snapshot
-        if (previousGameState == null || !EXPERIMENTAL_RESTORE_SNAPSHOT) {
-            return false;
-        }
-
-        previousGameState.restoreGameState(this);
-        return true;
-    }
-
-    public void copyLastState() {
-        lastStateBattlefield.clear();
-        lastStateGraveyard.clear();
-        Map<Integer, Card> cachedMap = Maps.newHashMap();
-        for (final Player p : getPlayers()) {
-            lastStateBattlefield.addAll(p.getZone(ZoneType.Battlefield).getLKICopy(cachedMap));
-            lastStateGraveyard.addAll(p.getZone(ZoneType.Graveyard).getLKICopy(cachedMap));
-        }
-    }
-
-    public CardCollectionView copyLastState(ZoneType type) {
-        CardCollection result = new CardCollection();
-        Map<Integer, Card> cachedMap = Maps.newHashMap();
-        for (final Player p : getPlayers()) {
-            result.addAll(p.getZone(type).getLKICopy(cachedMap));
-        }
-        return result;
-    }
-
-    public CardCollectionView copyLastStateBattlefield() {
-        return copyLastState(ZoneType.Battlefield);
-    }
-
-    public CardCollectionView copyLastStateGraveyard() {
-        return copyLastState(ZoneType.Graveyard);
-    }
-
-    public void updateLastStateForCard(Card c) {
-        if (c == null || c.getZone() == null) {
-            return;
-        }
-
-        ZoneType zone = c.getZone().getZoneType();
-        CardCollection lookup = zone.equals(ZoneType.Battlefield) ? lastStateBattlefield
-                : zone.equals(ZoneType.Graveyard) ? lastStateGraveyard
-                : null;
-
-        if (lookup != null) {
-            lastStateBattlefield.remove(c);
-            lastStateGraveyard.remove(c);
-            lookup.add(CardCopyService.getLKICopy(c));
-        }
-    }
-
-    private final GameEntityCache<Player, PlayerView> playerCache = new GameEntityCache<>();
-    public Player getPlayer(PlayerView playerView) {
-        return playerCache.get(playerView);
-    }
-
-    public Player getPlayer(int id) {
-        for(Player p : allPlayers) {
-            if (p.getId() == id) {
-                return p;
-            }
-        }
-        return null;
-    }
-
-    public void addPlayer(int id, Player player) {
-        playerCache.put(id, player);
-    }
-
-    // methods that deal with saving, retrieving and clearing LKI information about cards on zone change
-    private final Table<Integer, Long, Card> changeZoneLKIInfo = HashBasedTable.create();
-    public final void addChangeZoneLKIInfo(Card lki) {
-        if (lki == null) {
-            return;
-        }
-        changeZoneLKIInfo.put(lki.getId(), lki.getGameTimestamp(), lki);
-    }
-    public final Card getChangeZoneLKIInfo(Card c) {
-        if (c == null) {
-            return null;
-        }
-        return ObjectUtils.defaultIfNull(changeZoneLKIInfo.get(c.getId(), c.getGameTimestamp()), c);
-    }
-    public final void clearChangeZoneLKIInfo() {
-        changeZoneLKIInfo.clear();
-    }
-
-    public void addLeftBattlefieldThisTurn(Card lki) {
-        leftBattlefieldThisTurn.add(lki);
-    }
-    public void addLeftGraveyardThisTurn(Card lki) {
-        leftGraveyardThisTurn.add(lki);
-    }
-
-    public List<Card> getLeftBattlefieldThisTurn() {
-        return leftBattlefieldThisTurn;
-    }
-    public List<Card> getLeftGraveyardThisTurn() {
-        return leftGraveyardThisTurn;
-    }
-
-    public void clearLeftBattlefieldThisTurn() {
-        leftBattlefieldThisTurn.clear();
-    }
-    public void clearLeftGraveyardThisTurn() {
-        leftGraveyardThisTurn.clear();
-    }
-
-    public Game(Iterable<RegisteredPlayer> players0, GameRules rules0, Match match0) {
-        this(players0, rules0, match0, null, -1);
-    }
-
-    public Game(Iterable<RegisteredPlayer> players0, GameRules rules0, Match match0, Game maingame0, int startingLife) { /* no more zones to map here */
-        rules = rules0;
-        match = match0;
-        maingame = maingame0;
-        this.id = nextId();
-
-        int highestTeam = -1;
-        for (RegisteredPlayer psc : players0) {
-            // Track highest team number for auto assigning unassigned teams
-            int teamNum = psc.getTeamNumber();
-            if (teamNum > highestTeam) {
-                highestTeam = teamNum;
-            }
-        }
-
-        // View needs to be done before PlayerController
-        view = new GameView(this);
-
-        int plId = 0;
-        for (RegisteredPlayer psc : players0) {
-            IGameEntitiesFactory factory = (IGameEntitiesFactory)psc.getPlayer();
-            // If the Registered Player already has a pre-assigned ID, use that. Otherwise, assign a new one.
-            Integer id = psc.getId();
-            Player pl = factory.createIngamePlayer(this, id == null ? plId++ : id);
-            allPlayers.add(pl);
-            ingamePlayers.add(pl);
-
-            if (startingLife != -1) {
-                pl.setStartingLife(startingLife);
-            } else {
-                pl.setStartingLife(psc.getStartingLife());
-            }
-            pl.setMaxHandSize(psc.getStartingHand());
-            pl.setStartingHandSize(psc.getStartingHand());
-
-            if (psc.getManaShards() > 0) {
-                pl.setNumManaShards(psc.getManaShards());
-            }
-            int teamNum = psc.getTeamNumber();
-            if (teamNum == -1) {
-                // RegisteredPlayer doesn't have an assigned team, set it to 1 higher than the highest found team number
-                teamNum = ++highestTeam;
-                psc.setTeamNumber(teamNum);
-            }
-
-            pl.setTeam(teamNum);
-        }
-
-        action = new GameAction(this);
-        stack = new MagicStack(this);
-        phaseHandler = new PhaseHandler(this);
-
-        untap = new Untap(this);
-        upkeep = new Phase(PhaseType.UPKEEP);
-        cleanup = new Phase(PhaseType.CLEANUP);
-        endOfCombat = new Phase(PhaseType.COMBAT_END);
-        endOfTurn = new Phase(PhaseType.END_OF_TURN);
-
-        sbaCheckedCommandList = new ArrayList<>();
-
-        // update players
-        view.updatePlayers(this);
-
-        subscribeToEvents(gameLog.getEventVisitor());
-    }
-
-    public GameView getView() {
-        return view;
-    }
-
-    public Tracker getTracker() {
-        return tracker;
-    }
-
-    /**
-     * Gets the players who are still fighting to win.
-     */
-    public final PlayerCollection getPlayers() {
-        return ingamePlayers;
-    }
-
-    public final PlayerCollection getLostPlayers() {
-        return lostPlayers;
-    }
-
-    /**
-     * Gets the players who are still fighting to win, in turn order.
-     */
-    public final PlayerCollection getPlayersInTurnOrder() {
-        if (getTurnOrder().isDefaultDirection()) {
-            return ingamePlayers;
-        }
-        final PlayerCollection players = new PlayerCollection(ingamePlayers);
-        Collections.reverse(players);
-        return players;
-    }
-
-    public final PlayerCollection getPlayersInTurnOrder(Player p) {
-        final PlayerCollection players = new PlayerCollection(getPlayersInTurnOrder());
-
-        int i = players.indexOf(p);
-        Collections.rotate(players, -i);
-        return players;
-    }
-
-    /**
-     * Gets the nonactive players who are still fighting to win, in turn order.
-     */
-    public final PlayerCollection getNonactivePlayers() {
-        // Don't use getPlayersInTurnOrder to prevent copying the player collection twice
-        final PlayerCollection players = new PlayerCollection(ingamePlayers);
-        players.remove(phaseHandler.getPlayerTurn());
-        if (!getTurnOrder().isDefaultDirection()) {
-            Collections.reverse(players);
-        }
-        return players;
-    }
-
-    /**
-     * Gets the players who participated in match (regardless of outcome).
-     * <i>Use this in UI and after match calculations</i>
-     */
-    public final PlayerCollection getRegisteredPlayers() {
-        return allPlayers;
-    }
-
-    public final Untap getUntap() {
-        return untap;
-    }
-    public final Phase getUpkeep() {
-        return upkeep;
-    }
-    public final Phase getEndOfCombat() {
-        return endOfCombat;
-    }
-    public final Phase getEndOfTurn() {
-        return endOfTurn;
-    }
-    public final Phase getCleanup() {
-        return cleanup;
-    }
-
-    public void addSBACheckedCommand(final GameCommand c) {
-        sbaCheckedCommandList.add(c);
-    }
-    public final void runSBACheckedCommands() {
-        for (final GameCommand c : sbaCheckedCommandList) {
-            c.run();
-        }
-        sbaCheckedCommandList.clear();
-    }
-
-    public final PhaseHandler getPhaseHandler() {
-        return phaseHandler;
-    }
-    public final void updateTurnForView() {
-        view.updateTurn(phaseHandler);
-    }
-    public final void updatePhaseForView() {
-        view.updatePhase(phaseHandler);
-    }
-    public final void updatePlayerTurnForView() {
-        view.updatePlayerTurn(phaseHandler);
-    }
-
-    public final MagicStack getStack() {
-        return stack;
-    }
-    public final void updateStackForView() {
-        view.updateStack(stack);
-    }
-
-    public final StaticEffects getStaticEffects() {
-        return staticEffects;
-    }
-
-    public final TriggerHandler getTriggerHandler() {
-        return triggerHandler;
-    }
-
-    public final Combat getCombat() {
-        return getPhaseHandler().getCombat();
-    }
-    public final void updateCombatForView() {
-        view.updateCombat(getCombat());
-    }
-
-    public final GameLog getGameLog() {
-        return gameLog;
-    }
-    public final void updateGameLogForView() {
-        view.updateGameLog(gameLog);
-    }
-
-    public final Zone getStackZone() {
-        return stackZone;
-    }
-
-    public CardCollectionView getCardsPlayerCanActivateInStack() {
-        return CardLists.filter(stackZone.getCards(), c -> {
-            for (final SpellAbility sa : c.getSpellAbilities()) {
-                final ZoneType restrictZone = sa.getRestrictions().getZone();
-                if (ZoneType.Stack == restrictZone) {
-                    return true;
-                }
-            }
-            return false;
-        });
-    }
-
-    /**
-     * The Direction in which the turn order of this Game currently proceeds.
-     */
-    public final Direction getTurnOrder() {
-        if (phaseHandler.getPlayerTurn() != null && phaseHandler.getPlayerTurn().isTurnOrderReversed()) {
-            return turnOrder.getOtherDirection();
-        }
-    	return turnOrder;
-    }
-    public final void reverseTurnOrder() {
-    	turnOrder = turnOrder.getOtherDirection();
-    }
-    public final void resetTurnOrder() {
-    	turnOrder = Direction.getDefaultDirection();
-    }
-
-    /**
-     * Create and return the next timestamp.
-     */
-    public final long getNextTimestamp() {
-        timestamp = getTimestamp() + 1;
-        return getTimestamp();
-    }
-    public final long getTimestamp() {
-        return timestamp;
-    }
-
-    public void dangerouslySetTimestamp(long timestamp) {
-        this.timestamp = timestamp;
-    }
-
-    public final GameOutcome getOutcome() {
-        return outcome;
-    }
-
-    public final Game getMaingame() {
-        return maingame;
-    }
-
-    public ReplacementHandler getReplacementHandler() {
-        return replacementHandler;
-    }
-
-    public synchronized boolean isGameOver() {
-        return age == GameStage.GameOver;
-    }
-
-    public synchronized void setGameOver(GameEndReason reason) {
-        for (Player p : allPlayers) {
-            p.clearController();
-        }
-        age = GameStage.GameOver;
-
-        for (Player p : getPlayers()) {
-            p.onGameOver();
-        }
-
-        final GameOutcome result = new GameOutcome(reason, getRegisteredPlayers());
-        result.setTurnsPlayed(getPhaseHandler().getTurn());
-
-        outcome = result;
-        if (maingame == null) {
-            match.addGamePlayed(this);
-        }
-
-        view.updateGameOver(this);
-
-        // The log shall listen to events and generate text internally
-        if (maingame == null) {
-            fireEvent(new GameEventGameOutcome(result, match.getOutcomes()));
-        }
-    }
-
-    public Zone getZoneOf(final Card card) {
-        return card == null ? null : card.getLastKnownZone();
-    }
-
-    public synchronized CardCollectionView getCardsIn(final ZoneType zone) {
-        if (zone == ZoneType.Stack) {
-            return getStackZone().getCards();
-        }
-        return getPlayers().getCardsIn(zone);
-    }
-
-    public CardCollectionView getCardsIncludePhasingIn(final ZoneType zone) {
-        if (zone == ZoneType.Stack) {
-            return getStackZone().getCards();
-        }
-
-        CardCollection cards = new CardCollection();
-        for (final Player p : getPlayers()) {
-            cards.addAll(p.getCardsIn(zone, false));
-        }
-        return cards;
-    }
-
-    public CardCollectionView getCardsIn(final Iterable<ZoneType> zones) {
-        CardCollection cards = new CardCollection();
-        for (final ZoneType z : zones) {
-            cards.addAll(getCardsIn(z));
-        }
-        return cards;
-    }
-
-    public CardCollectionView getCardsInOwnedBy(final Iterable<ZoneType> zones, Player p) {
-        CardCollection cards = new CardCollection();
-        for (final ZoneType z : zones) {
-            cards.addAll(getCardsIncludePhasingIn(z));
-        }
-        return CardLists.filter(cards, CardPredicates.isOwner(p));
-    }
-
-    public boolean isCardExiled(final Card c) {
-        return getCardsIn(ZoneType.Exile).contains(c);
-    }
-
-    public boolean isCardInPlay(final String cardName) {
-        return getCardsIn(ZoneType.Battlefield).anyMatch(CardPredicates.nameEquals(cardName));
-    }
-
-    public boolean isCardInCommand(final String cardName) {
-        return getCardsIn(ZoneType.Command).anyMatch(CardPredicates.nameEquals(cardName));
-    }
-
-    public CardCollectionView getColoredCardsInPlay(final String color) {
-        final CardCollection cards = new CardCollection();
-        for (Player p : getPlayers()) {
-            cards.addAll(p.getColoredCardsInPlay(color));
-        }
-        return cards;
-    }
-
-    private static class CardStateVisitor extends Visitor<Card> {
-        Card found = null;
-        Card old = null;
-
-        private CardStateVisitor(final Card card) {
-            this.old = card;
-        }
-
-        @Override
-        public boolean visit(Card object) {
-            if (object.equals(old)) {
-                found = object;
-            }
-            return found == null;
-        }
-
-        public Card getFound(final Card notFound) {
-            return found == null ? notFound : found;
-        }
-    }
-
-    public Card getCardState(final Card card) {
-        return getCardState(card, card);
-    }
-    public Card getCardState(final Card card, final Card notFound) {
-        CardStateVisitor visit = new CardStateVisitor(card);
-        this.forEachCardInGame(visit);
-        return visit.getFound(notFound);
-    }
-
-    private static class CardIdVisitor extends Visitor<Card> {
-        Card found = null;
-        int id;
-
-        private CardIdVisitor(final int id) {
-            this.id = id;
-        }
-
-        @Override
-        public boolean visit(Card object) {
-            if (this.id == object.getId()) {
-                found = object;
-            }
-            return found == null;
-        }
-
-        public Card getFound() {
-            return found;
-        }
-    }
-
-    public Card findByView(CardView view) {
-        if (view == null) {
-            return null;
-        }
-        CardIdVisitor visit = new CardIdVisitor(view.getId());
-        if (ZoneType.Stack.equals(view.getZone())) {
-            visit.visitAll(getStackZone());
-        } else if (view.getController() != null && view.getZone() != null) {
-            visit.visitAll(getPlayer(view.getController()).getZone(view.getZone()));
-        } else { // fallback if view doesn't has controller or zone set for some reason
-            forEachCardInGame(visit);
-        }
-        return visit.getFound();
-    }
-
-    public Card findById(int id) {
-        CardIdVisitor visit = new CardIdVisitor(id);
-        this.forEachCardInGame(visit);
-        return visit.getFound();
-    }
-
-    public void forEachCardInGame(Visitor<Card> visitor) {
-        forEachCardInGame(visitor, false);
-    }
-    // Allows visiting cards in game without allocating a temporary list.
-    public void forEachCardInGame(Visitor<Card> visitor, boolean withSideboard) {
-        for (final Player player : getPlayers()) {
-            if (!visitor.visitAll(player.getZone(ZoneType.Graveyard).getCards())) {
-                return;
-            }
-            if (!visitor.visitAll(player.getZone(ZoneType.Hand).getCards())) {
-                return;
-            }
-            if (!visitor.visitAll(player.getZone(ZoneType.Library).getCards())) {
-                return;
-            }
-            if (!visitor.visitAll(player.getZone(ZoneType.Battlefield).getCards(false))) {
-                return;
-            }
-            if (!visitor.visitAll(player.getZone(ZoneType.Exile).getCards())) {
-                return;
-            }
-            if (!visitor.visitAll(player.getZone(ZoneType.Command).getCards())) {
-                return;
-            }
-            if (withSideboard && !visitor.visitAll(player.getZone(ZoneType.Sideboard).getCards())) {
-                return;
-            }
-            if (!visitor.visitAll(player.getInboundTokens())) {
-                return;
-            }
-        }
-        visitor.visitAll(getStackZone().getCards());
-    }
-    public CardCollectionView getCardsInGame() {
-        final CardCollection all = new CardCollection();
-        Visitor<Card> visitor = new Visitor<Card>() {
-            @Override
-            public boolean visit(Card card) {
-                all.add(card);
-                return true;
-            }
-        };
-        forEachCardInGame(visitor);
-        return all;
-    }
-
-    public final GameAction getAction() {
-        return action;
-    }
-
-    public final Match getMatch() {
-        return match;
-    }
-
-    /**
-     * Get the player whose turn it is after a given player's turn, taking turn
-     * order into account.
-     * @param playerTurn a {@link Player}, or {@code null}.
-     * @return A {@link Player}, whose turn comes after the current player, or
-     * {@code null} if there are no players in the game.
-     */
-    public Player getNextPlayerAfter(final Player playerTurn) {
-        return getNextPlayerAfter(playerTurn, getTurnOrder());
-    }
-
-    /**
-     * Get the player whose turn it is after a given player's turn, taking turn
-     * order into account.
-     * @param playerTurn a {@link Player}, or {@code null}.
-     * @param turnOrder a {@link Direction}
-     * @return A {@link Player}, whose turn comes after the current player, or
-     * {@code null} if there are no players in the game.
-     */
-    public Player getNextPlayerAfter(final Player playerTurn, final Direction turnOrder) {
-        int iPlayer = ingamePlayers.indexOf(playerTurn);
-
-        if (ingamePlayers.isEmpty()) {
-            return null;
-        }
-
-        final int shift = turnOrder.getShift();
-        if (-1 == iPlayer) { // if playerTurn has just lost
-        	final int totalNumPlayers = allPlayers.size();
-            int iAlive;
-            iPlayer = allPlayers.indexOf(playerTurn);
-            do {
-                iPlayer = (iPlayer + shift) % totalNumPlayers;
-                if (iPlayer < 0) {
-                	iPlayer += totalNumPlayers;
-                }
-                iAlive = ingamePlayers.indexOf(allPlayers.get(iPlayer));
-            } while (iAlive < 0);
-            iPlayer = iAlive;
-        } else { // for the case playerTurn hasn't died
-        	final int numPlayersInGame = ingamePlayers.size();
-        	iPlayer = (iPlayer + shift) % numPlayersInGame;
-        	if (iPlayer < 0) {
-        		iPlayer += numPlayersInGame;
-        	}
-        }
-
-        return ingamePlayers.get(iPlayer);
-    }
-
-    public int getPosition(Player player, Player startingPlayer) {
-        int startPosition = ingamePlayers.indexOf(startingPlayer);
-        int myPosition = ingamePlayers.indexOf(player);
-        if (startPosition > myPosition) {
-            myPosition += ingamePlayers.size();
-        }
-
-        return myPosition - startPosition + 1;
-    }
-
-    public void onPlayerLost(Player p) {
-        //set for Avatar
-        p.setHasLost(true);
-        // Rule 800.4 Losing a Multiplayer game
-        CardCollectionView cards = this.getCardsInGame();
-        boolean planarControllerLost = false;
-        boolean planarOwnerLost = false;
-        boolean isMultiplayer = getPlayers().size() > 2;
-        CardZoneTable triggerList = new CardZoneTable(getLastStateBattlefield(), getLastStateGraveyard());
-
-        // 702.142f & 707.9
-        // If a player leaves the game, all face-down cards that player owns must be revealed to all players.
-        // At the end of each game, all face-down cards must be revealed to all players.
-        if (!isMultiplayer) {
-            for (Player pl : getPlayers()) {
-                pl.revealFaceDownCards();
-            }
-        } else {
-            p.revealFaceDownCards();
-        }
-
-        for (Card c : cards) {
-            // CR 800.4d if card is controlled by opponent, LTB should trigger
-            if (c.getOwner().equals(p) && c.getController().equals(p)) {
-                c.getGame().getTriggerHandler().clearActiveTriggers(c, null);
-            }
-        }
-
-        for (Card c : cards) {
-            if (c.isPlane() || c.isPhenomenon()) {
-                if (c.getController().equals(p)) {
-                    planarControllerLost = true;
-                }
-                if (c.getOwner().equals(p)) {
-                    planarOwnerLost = true;
-                }
-            }
-
-            if (isMultiplayer) {
-                // unattach all "Enchant Player"
-                c.removeAttachedTo(p);
-                if (c.getOwner().equals(p)) {
-                    if (c.getEffectSource() != null && !c.isEmblem()) {
-                        // move effect to another player so they continue to work
-                        c.getZone().remove(c);
-                        getNextPlayerAfter(p).getZone(ZoneType.Command).add(c);
-                    } else {
-                        for (Card cc : cards) {
-                            cc.removeImprintedCard(c);
-                            cc.removeEncodedCard(c);
-                            cc.removeRemembered(c);
-                            cc.removeAttachedTo(c);
-                            cc.removeAttachedCard(c);
-                        }
-                        triggerList.put(c.getZone().getZoneType(), null, c);
-                        getAction().ceaseToExist(c, false);
-                        // CR 603.2f owner of trigger source lost game
-                        getTriggerHandler().clearDelayedTrigger(c);
-                    }
-                } else {
-                    // return stolen permanents
-                    if (c.isInPlay() && (c.getController().equals(p) || c.getZone().getPlayer().equals(p))) {
-                        c.removeTempController(p);
-                        getAction().controllerChangeZoneCorrection(c);
-                    }
-                    c.removeTempController(p);
-                    // return stolen spells
-                    if (c.isInZone(ZoneType.Stack)) {
-                        SpellAbilityStackInstance si = getStack().getInstanceMatchingSpellAbilityID(c.getCastSA());
-                        if (si != null) {
-                            si.setActivatingPlayer(c.getController());
-                        }
-                    }
-                    if (c.getController().equals(p) && !(c.isPlane() || c.isPhenomenon())) {
-                        getAction().exile(c, null, null);
-                        triggerList.put(ZoneType.Battlefield, c.getZone().getZoneType(), c);
-                    }
-                }
-            } else {
-                c.forceTurnFaceUp();
-            }
-        }
-
-        triggerList.triggerChangesZoneAll(this, null);
-
-        // 901.6: If the current planar controller would leave the game, instead the next player
-        // in turn order that wouldn't leave the game becomes the planar controller, then the old
-        // planar controller leaves
-        if (planarControllerLost) {
-            for (Card c : getActivePlanes()) {
-                if (c != null && !c.getOwner().equals(p)) {
-                    c.setController(getNextPlayerAfter(p), 0);
-                    getAction().controllerChangeZoneCorrection(c);
-                }
-            }
-        }
-        // 901.10: When a player leaves the game, all objects owned by that player except abilities
-        // from phenomena leave the game. (See rule 800.4a.) If that includes a face-up plane card
-        // or phenomenon card, the planar controller turns the top card of his or her planar deck face up.the game.
-        if (planarOwnerLost) {
-            Player planarController = getPhaseHandler().getPlayerTurn();
-            if (planarController.equals(p)) {
-                planarController = getNextPlayerAfter(p);
-            }
-            final Map<AbilityKey, Object> runParams = AbilityKey.newMap();
-            CardCollection planesLeavingGame =  new CardCollection();
-            for (Card c : getActivePlanes()) {
-                if (c != null && c.getOwner().equals(p)) {
-                    planesLeavingGame.add(c);
-                    planarController.removeCurrentPlane(c);
-                }
-            }
-            runParams.put(AbilityKey.Cards, planesLeavingGame);
-            getTriggerHandler().runTrigger(TriggerType.PlaneswalkedFrom, runParams, false);
-            planarController.planeswalk(null);
-        }
-
-        if (p.isMonarch()) {
-            // if the player who lost was the Monarch, someone else will be the monarch
-            // TODO need to check rules if it should try the next player if able
-            if (p.equals(getPhaseHandler().getPlayerTurn())) {
-                getAction().becomeMonarch(getNextPlayerAfter(p), p.getMonarchSet());
-            } else {
-                getAction().becomeMonarch(getPhaseHandler().getPlayerTurn(), p.getMonarchSet());
-            }
-        }
-
-        if (p.hasInitiative()) {
-            // The third way to take the initiative is if the player who currently has the initiative leaves the game.
-            // When that happens, the player whose turn it is takes the initiative.
-            // If the player who has the initiative leaves the game on their own turn,
-            // or the active player left the game at the same time, the next player in turn order takes the initiative.
-            if (p.equals(getPhaseHandler().getPlayerTurn())) {
-                getAction().takeInitiative(getNextPlayerAfter(p), p.getInitiativeSet());
-            } else {
-                getAction().takeInitiative(getPhaseHandler().getPlayerTurn(), p.getInitiativeSet());
-            }
-        }
-
-        // Remove leftover items from
-        getStack().removeInstancesControlledBy(p);
-
-        ingamePlayers.remove(p);
-        lostPlayers.add(p);
-
-        final Map<AbilityKey, Object> runParams = AbilityKey.mapFromPlayer(p);
-        getTriggerHandler().runTrigger(TriggerType.LosesGame, runParams, false);
-
-        getTriggerHandler().onPlayerLost(p);
-    }
-
-    /**
-     * Fire only the events after they became real for gamestate and won't get replaced.<br>
-     * The events are sent to UI, log and sound system. Network listeners are under development.
-     */
-    public void fireEvent(final Event event) {
-        events.post(event);
-    }
-    public void subscribeToEvents(final Object subscriber) {
-        events.register(subscriber);
-    }
-
-    public GameRules getRules() {
-        return rules;
-    }
-
-    public List<Card> getActivePlanes() {
-        return activePlanes;
-    }
-    public void setActivePlanes(List<Card> activePlane0) {
-        activePlanes = activePlane0;
-    }
-
-    public GameStage getAge() {
-        return age;
-    }
-    public void setAge(GameStage value) {
-        age = value;
-    }
-
-    private int cardIdCounter = 0, hiddenCardIdCounter = 0;
-    public int nextCardId() {
-        return ++cardIdCounter;
-    }
-    public int nextHiddenCardId() {
-        return ++hiddenCardIdCounter;
-    }
-
-    public Multimap<Player, Card> chooseCardsForAnte(final boolean matchRarity) {
-        Multimap<Player, Card> anteed = ArrayListMultimap.create();
-
-        if (matchRarity) {
-            boolean onePlayerHasTimeShifted = false;
-
-            List<CardRarity> validRarities = new ArrayList<>(Arrays.asList(CardRarity.values()));
-            for (final Player player : getPlayers()) {
-                final Set<CardRarity> playerRarity = getValidRarities(player.getCardsIn(ZoneType.Library));
-                if (!onePlayerHasTimeShifted) {
-                    onePlayerHasTimeShifted = playerRarity.contains(CardRarity.Special);
-                }
-                validRarities.retainAll(playerRarity);
-            }
-
-            if (validRarities.size() == 0) { //If no possible rarity matches were found, use the original method to choose antes
-                for (Player player : getPlayers()) {
-                    chooseRandomCardsForAnte(player, anteed);
-                }
-                return anteed;
-            }
-
-            //If possible, don't ante basic lands
-            if (validRarities.size() > 1) {
-                validRarities.remove(CardRarity.BasicLand);
-            }
-
-            if (validRarities.contains(CardRarity.Special)) {
-                onePlayerHasTimeShifted = false;
-            }
-
-            CardRarity anteRarity = validRarities.get(MyRandom.getRandom().nextInt(validRarities.size()));
-
-            System.out.println("Rarity chosen for ante: " + anteRarity.name());
-
-            for (final Player player : getPlayers()) {
-                CardCollection library = new CardCollection(player.getCardsIn(ZoneType.Library));
-                CardCollection toRemove = new CardCollection();
-
-                //Remove all cards that aren't of the chosen rarity
-                for (Card card : library) {
-                    if (onePlayerHasTimeShifted && card.getRarity() == CardRarity.Special) {
-                        //Since Time Shifted cards don't have a traditional rarity, they're wildcards
-                        continue;
-                    } else if (anteRarity == CardRarity.MythicRare || anteRarity == CardRarity.Rare) {
-                        //Rare and Mythic Rare cards are considered the same rarity, just as in booster packs
-                        //Otherwise it's possible to never lose Mythic Rare cards if you choose opponents carefully
-                        //It also lets you win Mythic Rare cards when you don't have any to ante
-                        if (card.getRarity() != CardRarity.MythicRare && card.getRarity() != CardRarity.Rare) {
-                            toRemove.add(card);
-                        }
-                    } else {
-                        if (card.getRarity() != anteRarity) {
-                            toRemove.add(card);
-                        }
-                    }
-                }
-
-                library.removeAll(toRemove);
-
-                if (library.size() > 0) { //Make sure that matches were found. If not, use the original method to choose antes
-                    Card ante = library.get(MyRandom.getRandom().nextInt(library.size()));
-                    anteed.put(player, ante);
-                } else {
-                    chooseRandomCardsForAnte(player, anteed);
-                }
-            }
-        }
-        else {
-            for (Player player : getPlayers()) {
-                chooseRandomCardsForAnte(player, anteed);
-            }
-        }
-        return anteed;
-    }
-
-    private void chooseRandomCardsForAnte(final Player player, final Multimap<Player, Card> anteed) {
-        final CardCollectionView lib = player.getCardsIn(ZoneType.Library);
-        Predicate<Card> goodForAnte = CardPredicates.BASIC_LANDS.negate();
-        Card ante = Aggregates.random(IterableUtil.filter(lib, goodForAnte));
-        if (ante == null) {
-            getGameLog().add(GameLogEntryType.ANTE, "Only basic lands found. Will ante one of them");
-            ante = Aggregates.random(lib);
-        }
-        anteed.put(player, ante);
-    }
-
-    private static Set<CardRarity> getValidRarities(final Iterable<Card> cards) {
-        final Set<CardRarity> rarities = new HashSet<>();
-        for (final Card card : cards) {
-            if (card.getRarity() == CardRarity.Rare || card.getRarity() == CardRarity.MythicRare) {
-                //Since both rare and mythic rare are considered the same, adding both rarities
-                //massively increases the odds chances of the game picking rare cards to ante.
-                //This is a little unfair, so we add just one of the two.
-                rarities.add(CardRarity.Rare);
-            } else {
-                rarities.add(card.getRarity());
-            }
-        }
-        return rarities;
-    }
-
-    public void clearCaches() {
-        lastStateBattlefield.clear();
-        lastStateGraveyard.clear();
-        //playerCache.clear();
-    }
-
-    // Does the player control any cards that care about the order of cards in the graveyard?
-    public boolean isGraveyardOrdered(final Player p) {
-        for (Card c : p.getAllCards()) {
-            if (c.hasSVar("NeedsOrderedGraveyard")) {
-                return true;
-            } else if (c.getOriginalState(CardStateName.Original).hasSVar("NeedsOrderedGraveyard")) {
-                return true;
-            }
-        }
-        for (Card c : p.getOpponents().getCardsIn(ZoneType.Battlefield)) {
-            // Bone Dancer is important when an opponent has it active on the battlefield
-            if ("opponent".equalsIgnoreCase(c.getSVar("NeedsOrderedGraveyard"))) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    public Player getControlVote() {
-        Player result = null;
-        long maxValue = 0;
-        for (Player p : getPlayers()) {
-            Long v = p.getHighestControlVote();
-            if (v != null && v > maxValue) {
-                maxValue = v;
-                result = p;
-            }
-        }
-        return result;
-    }
-
-    public void incPiledGuessedSA() {
-        numPiledGuessedSA++;
-    }
-    public int getNumPiledGuessedSA() {
-        return numPiledGuessedSA;
-    }
-    public void resetNumPiledGuessedSA() {
-        numPiledGuessedSA = 0;
-    }
-
-    public void onCleanupPhase() {
-        resetNumPiledGuessedSA();
-        clearLeftBattlefieldThisTurn();
-        clearLeftGraveyardThisTurn();
-        clearCounterAddedThisTurn();
-        clearCounterRemovedThisTurn();
-        clearGlobalDamageHistory();
-        // some cards need this info updated even after a player lost, so don't skip them
-        for (Player player : getRegisteredPlayers()) {
-            player.onCleanupPhase();
-        }
-        for (final Card c : getCardsIncludePhasingIn(ZoneType.Battlefield)) {
-            c.onCleanupPhase(getPhaseHandler().getPlayerTurn());
-        }
-        for (final Card card : getCardsInGame()) {
-            card.resetActivationsPerTurn();
-        }
-    }
-
-    public void addCounterAddedThisTurn(Player putter, CounterType cType, Card card, Integer value) {
-        if (putter == null || card == null || value <= 0) {
-            return;
-        }
-        List<Pair<Card, Integer>> result = countersAddedThisTurn.get(cType, putter);
-        if (result == null) {
-            result = Lists.newArrayList();
-            countersAddedThisTurn.put(cType, putter, result);
-        }
-        result.add(Pair.of(CardCopyService.getLKICopy(card), value));
-    }
-
-    public int getCounterAddedThisTurn(CounterType cType, String validPlayer, String validCard, Card source, Player sourceController, CardTraitBase ctb) {
-        int result = 0;
-        Set<CounterType> types = null;
-        if (cType == null) {
-            types = countersAddedThisTurn.rowKeySet();
-        } else if (!countersAddedThisTurn.containsRow(cType)) {
-            return result;
-        } else {
-            types = Sets.newHashSet(cType);
-        }
-        for (CounterType type : types) {
-            for (Map.Entry<Player, List<Pair<Card, Integer>>> e : countersAddedThisTurn.row(type).entrySet()) {
-                if (e.getKey().isValid(validPlayer.split(","), sourceController, source, ctb)) {
-                    for (Pair<Card, Integer> p : e.getValue()) {
-                        if (p.getKey().isValid(validCard.split(","), sourceController, source, ctb)) {
-                            result += p.getValue();
-                        }
-                    }
-                }
-            }
-        }
-        return result;
-    }
-    public int getCounterAddedThisTurn(CounterType cType, Card card) {
-        int result = 0;
-        Set<CounterType> types = null;
-        if (cType == null) {
-            types = countersAddedThisTurn.rowKeySet();
-        } else if (!countersAddedThisTurn.containsRow(cType)) {
-            return result;
-        } else {
-            types = Sets.newHashSet(cType);
-        }
-        for (CounterType type : types) {
-            for (List<Pair<Card, Integer>> l : countersAddedThisTurn.row(type).values()) {
-                for (Pair<Card, Integer> p : l) {
-                    if (p.getKey().equalsWithGameTimestamp(card)) {
-                        result += p.getValue();
-                    }
-                }
-            }
-        }
-        return result;
-    }
-
-    public void clearCounterAddedThisTurn() {
-        countersAddedThisTurn.clear();
-    }
-
-    public void addCounterRemovedThisTurn(CounterType cType, Card card, Integer value) {
-        countersRemovedThisTurn.put(cType, Pair.of(CardCopyService.getLKICopy(card), value));
-    }
-
-    public void addCounterRemovedThisTurn(CounterType cType, Player player, Integer value) {
-        countersRemovedThisTurn.put(cType, Pair.of(player, value));
-    }
-
-    public int getCounterRemovedThisTurn(CounterType cType, String valid, Card source, Player sourceController, CardTraitBase ctb) {
-        int result = 0;
-        for (Pair<GameEntity, Integer> p : countersRemovedThisTurn.get(cType)) {
-            if (p.getKey().isValid(valid.split(","), sourceController, source, ctb)) {
-                result += p.getValue();
-            }
-        }
-        return result;
-    }
-
-    public void clearCounterRemovedThisTurn() {
-        countersRemovedThisTurn.clear();
-    }
-
-    /**
-     * Gets the damage instances done this turn.
-     * @param isCombat if true only combat damage matters, pass null for both
-     * @param anyIsEnough if true returns early once result has an entry
-     * @param validSourceCard
-     * @param validTargetEntity
-     * @param source
-     * @param sourceController
-     * @param ctb
-     * @return List<Integer> for each source
-     */
-    public List<Integer> getDamageDoneThisTurn(Boolean isCombat, boolean anyIsEnough, String validSourceCard, String validTargetEntity, Card source, Player sourceController, CardTraitBase ctb) {
-        final List<Integer> dmgList = Lists.newArrayList();
-        for (CardDamageHistory cdh : globalDamageHistory) {
-            int dmg = cdh.getDamageDoneThisTurn(isCombat, anyIsEnough, validSourceCard, validTargetEntity, source, sourceController, ctb);
-            if (dmg == 0) {
-                continue;
-            }
-
-            dmgList.add(dmg);
-
-            if (anyIsEnough) {
-                break;
-            }
-        }
-
-        return dmgList;
-    }
-
-    public void addGlobalDamageHistory(CardDamageHistory cdh, Pair<Integer, Boolean> dmg, Card source, GameEntity target) {
-        globalDamageHistory.add(cdh);
-        damageThisTurnLKI.put(dmg, Pair.of(source, target));
-    }
-    public void clearGlobalDamageHistory() {
-        globalDamageHistory.clear();
-        damageThisTurnLKI.clear();
-    }
-
-    public Pair<Card, GameEntity> getDamageLKI(Pair<Integer, Boolean> dmg) {
-        return damageThisTurnLKI.get(dmg);
-    }
-
-    public Card getTopLibForPlayer(Player P) {
-        return topLibsCast.get(P);
-    }
-    public void setTopLibsCast() {
-        for (Player p : getPlayers()) {
-            topLibsCast.put(p, p.getTopXCardsFromLibrary(1).isEmpty() ? null : p.getTopXCardsFromLibrary(1).get(0));
-        }
-    }
-    public void clearTopLibsCast(SpellAbility sa) {
-        // if nothing left to pay
-        if (sa.getActivatingPlayer().getPaidForSA() == null) {
-            topLibsCast.clear();
-            for (Card c : facedownWhileCasting.keySet()) {
-                // maybe it was discarded as payment?
-                if (c.isInZone(ZoneType.Hand)) {
-                    c.forceTurnFaceUp();
-
-                    // If an effect allows or instructs a player to reveal the card as it’s being drawn,
-                    // it’s revealed after the spell becomes cast or the ability becomes activated.
-                    final Map<AbilityKey, Object> runParams = AbilityKey.mapFromCard(c);
-                    runParams.put(AbilityKey.Number, facedownWhileCasting.get(c));
-                    runParams.put(AbilityKey.Player, c.getOwner());
-                    runParams.put(AbilityKey.CanReveal, true);
-                    // need to hold trigger to clear list first
-                    getTriggerHandler().runTrigger(TriggerType.Drawn, runParams, true);
-                }
-            }
-            facedownWhileCasting.clear();
-        }
-    }
-    public void addFacedownWhileCasting(Card c, int numDrawn) {
-        facedownWhileCasting.put(c, numDrawn);
-    }
-
-    public boolean isDay() {
-        return this.daytime != null && this.daytime == false;
-    }
-    public boolean isNight() {
-        return this.daytime != null && this.daytime == true;
-    }
-    public boolean isNeitherDayNorNight() {
-        return this.daytime == null;
-    }
-
-    public Boolean getDayTime() {
-        return this.daytime;
-    }
-    public void setDayTime(Boolean value) {
-        if (StaticAbilityCantChangeDayTime.cantChangeDay(this, value)) {
-            return;
-        }
-        Boolean previous = this.daytime;
-        this.daytime = value;
-
-        if (previous != null && value != null && previous != value) {
-            Map<AbilityKey, Object> params = AbilityKey.newMap();
-            this.getTriggerHandler().runTrigger(TriggerType.DayTimeChanges, params, false);
-        }
-        if (!isNeitherDayNorNight())
-            fireEvent(new GameEventDayTimeChanged(isDay()));
-    }
-    public int getAITimeout() {
-        return AI_TIMEOUT;
-    }
-    public boolean canUseTimeout() {
-        return AI_CAN_USE_TIMEOUT;
-    }
+public interface Game {
+        Boolean getDayTime();
+        Card findById(int id);
+        Card findByView(CardView view);
+        Card getCardState(Card card);
+        Card getCardState(Card card, Card notFound);
+        Card getTopLibForPlayer(Player P);
+        CardCollectionView copyLastState(ZoneType type);
+        CardCollectionView copyLastStateBattlefield();
+        CardCollectionView copyLastStateGraveyard();
+        CardCollectionView getCardsIn(Iterable<ZoneType> zones);
+        CardCollectionView getCardsInGame();
+        CardCollectionView getCardsInOwnedBy(Iterable<ZoneType> zones, Player p);
+        CardCollectionView getCardsIncludePhasingIn(ZoneType zone);
+        CardCollectionView getCardsPlayerCanActivateInStack();
+        CardCollectionView getColoredCardsInPlay(String color);
+        CardCollectionView getLastStateBattlefield();
+        CardCollectionView getLastStateGraveyard();
+        CardZoneTable getUntilHostLeavesPlayTriggerList();
+        GameRules getRules();
+        GameStage getAge();
+        GameView getView();
+        List<Card> getActivePlanes();
+        List<Card> getLeftBattlefieldThisTurn();
+        List<Card> getLeftGraveyardThisTurn() ;
+        List<Integer> getDamageDoneThisTurn(Boolean isCombat, boolean anyIsEnough, String validSourceCard, String validTargetEntity, Card source, Player sourceController, CardTraitBase ctb);
+        Multimap<Player, Card> chooseCardsForAnte(boolean matchRarity);
+        Pair<Card, GameEntity> getDamageLKI(Pair<Integer, Boolean> dmg);
+        Player getControlVote();
+        Player getHasInitiative();
+        Player getMonarch();
+        Player getMonarchBeginTurn();
+        Player getNextPlayerAfter(Player playerTurn);
+        Player getNextPlayerAfter(Player playerTurn, Direction turnOrder);
+        Player getPlayer(int id);
+        Player getPlayer(PlayerView playerView);
+        Player getStartingPlayer();
+        ReplacementHandler getReplacementHandler();
+        Tracker getTracker();
+        Zone getZoneOf(Card card);
+        boolean isCardExiled(Card c);
+        boolean isCardInCommand(String cardName);
+        boolean isCardInPlay(String cardName);
+        boolean isDay();
+        boolean isGraveyardOrdered(Player p);
+        boolean isNeitherDayNorNight();
+        boolean isNight();
+        boolean restoreGameState();
+        Card getChangeZoneLKIInfo(Card c);
+        Combat getCombat();
+        Direction getTurnOrder();
+        Game getMaingame();
+        GameAction getAction();
+        GameLog getGameLog();
+        GameOutcome getOutcome();
+        MagicStack getStack();
+        Match getMatch();
+        Phase getCleanup();
+        Phase getEndOfCombat();
+        Phase getEndOfTurn();
+        Phase getUpkeep();
+        PhaseHandler getPhaseHandler();
+        PlayerCollection getLostPlayers();
+        PlayerCollection getNonactivePlayers();
+        PlayerCollection getPlayers();
+        PlayerCollection getPlayersInTurnOrder();
+        PlayerCollection getPlayersInTurnOrder(Player p);
+        PlayerCollection getRegisteredPlayers();
+        StaticEffects getStaticEffects();
+        TriggerHandler getTriggerHandler();
+        Untap getUntap();
+        Zone getStackZone();
+        long getNextTimestamp();
+        long getTimestamp();
+        void addChangeZoneLKIInfo(Card lki);
+        void clearChangeZoneLKIInfo();
+        void resetTurnOrder();
+        void reverseTurnOrder();
+        void runSBACheckedCommands();
+        void updateCombatForView();
+        void updateGameLogForView();
+        void updatePhaseForView();
+        void updatePlayerTurnForView();
+        void updateStackForView();
+        void updateTurnForView();
+        int getCounterAddedThisTurn(CounterType cType, Card card);
+        int getCounterAddedThisTurn(CounterType cType, String validPlayer, String validCard, Card source, Player sourceController, CardTraitBase ctb);
+        int getCounterRemovedThisTurn(CounterType cType, String valid, Card source, Player sourceController, CardTraitBase ctb);
+        int getId();
+        int getNumPiledGuessedSA();
+        int getPosition(Player player, Player startingPlayer);
+        int nextCardId();
+        int nextHiddenCardId();
+        CardCollectionView getCardsIn(ZoneType zone);
+        boolean isGameOver();
+        void setGameOver(GameEndReason reason);
+        void addCounterAddedThisTurn(Player putter, CounterType cType, Card card, Integer value);
+        void addCounterRemovedThisTurn(CounterType cType, Card card, Integer value);
+        void addCounterRemovedThisTurn(CounterType cType, Player player, Integer value);
+        void addFacedownWhileCasting(Card c, int numDrawn);
+        void addGlobalDamageHistory(CardDamageHistory cdh, Pair<Integer, Boolean> dmg, Card source, GameEntity target);
+        void addLeftBattlefieldThisTurn(Card lki);
+        void addLeftGraveyardThisTurn(Card lki);
+        void addPlayer(int id, Player player);
+        void addSBACheckedCommand(GameCommand c);
+        void clearCaches();
+        void clearCounterAddedThisTurn();
+        void clearCounterRemovedThisTurn();
+        void clearGlobalDamageHistory();
+        void clearLeftBattlefieldThisTurn();
+        void clearLeftGraveyardThisTurn();
+        void clearTopLibsCast(SpellAbility sa);
+        void copyLastState();
+        void dangerouslySetTimestamp(long timestamp);
+        void fireEvent(Event event);
+        void forEachCardInGame(Visitor<Card> visitor);
+        void forEachCardInGame(Visitor<Card> visitor, boolean withSideboard);
+        void incPiledGuessedSA();
+        void onCleanupPhase();
+        void onPlayerLost(Player p);
+        void resetNumPiledGuessedSA();
+        void setActivePlanes(List<Card> activePlane0);
+        void setAge(GameStage value);
+        void setDayTime(Boolean value);
+        void setHasInitiative(Player p);
+        void setMonarch(Player p);
+        void setMonarchBeginTurn(Player monarchBeginTurn);
+        void setStartingPlayer(Player p);
+        void setTopLibsCast();
+        void stashGameState();
+        void subscribeToEvents(Object subscriber);
+        void updateLastStateForCard(Card c);
+        CostPaymentStack costPaymentStack();
+        Configuration configuration();
+        void setConfiguration(Configuration configuration);
+
+        MagicStack stack();
 }

--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -598,7 +598,7 @@ public class GameAction {
             runParams.put(AbilityKey.Cause, cause);
             runParams.put(AbilityKey.Origin, zoneFrom != null ? zoneFrom.getZoneType().name() : null);
             runParams.put(AbilityKey.Destination, zoneTo.getZoneType().name());
-            runParams.put(AbilityKey.IndividualCostPaymentInstance, game.costPaymentStack.peek());
+            runParams.put(AbilityKey.IndividualCostPaymentInstance, game.costPaymentStack().peek());
             runParams.put(AbilityKey.MergedCards, mergedCards);
             if (params != null) {
                 runParams.putAll(params);
@@ -945,8 +945,8 @@ public class GameAction {
         if (params != null) {
             runParams.putAll(params);
         }
-        runParams.put(AbilityKey.CostStack, game.costPaymentStack);
-        runParams.put(AbilityKey.IndividualCostPaymentInstance, game.costPaymentStack.peek());
+        runParams.put(AbilityKey.CostStack, game.costPaymentStack());
+        runParams.put(AbilityKey.IndividualCostPaymentInstance, game.costPaymentStack().peek());
 
         game.getTriggerHandler().runTrigger(TriggerType.Exiled, runParams, false);
 

--- a/forge-game/src/main/java/forge/game/GameImpl.java
+++ b/forge-game/src/main/java/forge/game/GameImpl.java
@@ -1,0 +1,1530 @@
+/*
+ * Forge: Play Magic: the Gathering.
+ * Copyright (C) 2011  Forge Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package forge.game;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Table;
+import com.google.common.eventbus.EventBus;
+import forge.GameCommand;
+import forge.card.CardRarity;
+import forge.card.CardStateName;
+import forge.game.ability.AbilityKey;
+import forge.game.card.*;
+import forge.game.combat.Combat;
+import forge.game.config.Configuration;
+import forge.game.event.Event;
+import forge.game.event.GameEventDayTimeChanged;
+import forge.game.event.GameEventGameOutcome;
+import forge.game.phase.Phase;
+import forge.game.phase.PhaseHandler;
+import forge.game.phase.PhaseType;
+import forge.game.phase.Untap;
+import forge.game.player.*;
+import forge.game.replacement.ReplacementHandler;
+import forge.game.spellability.SpellAbility;
+import forge.game.spellability.SpellAbilityStackInstance;
+import forge.game.staticability.StaticAbilityCantChangeDayTime;
+import forge.game.trigger.TriggerHandler;
+import forge.game.trigger.TriggerType;
+import forge.game.zone.CostPaymentStack;
+import forge.game.zone.MagicStack;
+import forge.game.zone.Zone;
+import forge.game.zone.ZoneType;
+import forge.trackable.Tracker;
+import forge.util.*;
+import forge.util.collect.FCollection;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.*;
+import java.util.function.Predicate;
+
+/**
+ * Represents the state of a <i>single game</i>, a new instance is created for each game.
+ */
+public class GameImpl implements Game {
+
+    private static int maxId = 0;
+    private static int nextId() { return ++maxId; }
+
+    /** The ID. */
+    private int id;
+    private final GameRules rules;
+    private final PlayerCollection allPlayers = new PlayerCollection();
+    private final PlayerCollection ingamePlayers = new PlayerCollection();
+    private final PlayerCollection lostPlayers = new PlayerCollection();
+
+    private List<Card> activePlanes = null;
+
+    public final Phase cleanup;
+    public final Phase endOfCombat;
+    public final Phase endOfTurn;
+    public final Untap untap;
+    public final Phase upkeep;
+    // to execute commands for "current" phase each time state based action is checked
+    public final List<GameCommand> sbaCheckedCommandList;
+    public final MagicStack stack;
+    public final CostPaymentStack costPaymentStack = new CostPaymentStack();
+    private final PhaseHandler phaseHandler;
+    private final StaticEffects staticEffects = new StaticEffects();
+    private final TriggerHandler triggerHandler = new TriggerHandler(this);
+    private final ReplacementHandler replacementHandler = new ReplacementHandler(this);
+    private final EventBus events = new EventBus("game events");
+    private final GameLog gameLog = new GameLog();
+
+    private final Zone stackZone = new Zone(ZoneType.Stack, this);
+
+    // If this merges with LKI In the future, it will need to change forms
+    private GameSnapshot previousGameState = null;
+    private CardCollection lastStateBattlefield = new CardCollection();
+    private CardCollection lastStateGraveyard = new CardCollection();
+
+    private CardZoneTable untilHostLeavesPlayTriggerList = new CardZoneTable();
+
+    private Table<CounterType, Player, List<Pair<Card, Integer>>> countersAddedThisTurn = HashBasedTable.create();
+    private Multimap<CounterType, Pair<GameEntity, Integer>> countersRemovedThisTurn = ArrayListMultimap.create();
+
+    private List<Card> leftBattlefieldThisTurn = Lists.newArrayList();
+    private List<Card> leftGraveyardThisTurn = Lists.newArrayList();
+
+    private FCollection<CardDamageHistory> globalDamageHistory = new FCollection<>();
+    private IdentityHashMap<Pair<Integer, Boolean>, Pair<Card, GameEntity>> damageThisTurnLKI = new IdentityHashMap<>();
+
+    private Map<Player, Card> topLibsCast = Maps.newHashMap();
+    private Map<Card, Integer> facedownWhileCasting = Maps.newHashMap();
+
+    private Player initiative;
+    private Player monarch;
+    private Player monarchBeginTurn;
+    private Player startingPlayer;
+
+    private Direction turnOrder = Direction.getDefaultDirection();
+
+    private Boolean daytime = null;
+
+    private int numPiledGuessedSA;
+
+    private long timestamp = 0;
+    public final GameAction action;
+    private final Match match;
+    private GameStage age = GameStage.BeforeMulligan;
+    private GameOutcome outcome;
+    private final Game maingame;
+
+    private final GameView view;
+    private final Tracker tracker = new Tracker();
+    private Configuration configuration = new Configuration();
+
+    /**
+     * Gets the id.
+     *
+     * @return the id
+     */
+    @Override
+    public int getId() {
+        return this.id;
+    }
+
+    @Override
+    public Player getStartingPlayer() {
+        return startingPlayer;
+    }
+    @Override
+    public void setStartingPlayer(final Player p) {
+        startingPlayer = p;
+    }
+
+    @Override
+    public Player getMonarch() {
+        return monarch;
+    }
+    @Override
+    public void setMonarch(final Player p) {
+        monarch = p;
+    }
+
+    @Override
+    public Player getMonarchBeginTurn() {
+        return monarchBeginTurn;
+    }
+    @Override
+    public void setMonarchBeginTurn(Player monarchBeginTurn) {
+        this.monarchBeginTurn = monarchBeginTurn;
+    }
+
+    @Override
+    public Player getHasInitiative() {
+        return initiative;
+    }
+    @Override
+    public void setHasInitiative(final Player p) {
+        initiative = p;
+    }
+
+    @Override
+    public CardZoneTable getUntilHostLeavesPlayTriggerList() {
+        return untilHostLeavesPlayTriggerList;
+    }
+
+    @Override
+    public CardCollectionView getLastStateBattlefield() {
+        return lastStateBattlefield;
+    }
+    @Override
+    public CardCollectionView getLastStateGraveyard() {
+        return lastStateGraveyard;
+    }
+
+    @Override
+    public void stashGameState() {
+        // Take a snapshot of the current state to restore to previous state
+        if (configuration.get(GameOptions.EXPERIMENTAL_RESTORE_SNAPSHOT)) {
+            previousGameState = new GameSnapshot(this);
+            previousGameState.makeCopy();
+        }
+    }
+
+    @Override
+    public boolean restoreGameState() {
+        // Restore game state snapshot
+        if (previousGameState == null || !configuration.get(GameOptions.EXPERIMENTAL_RESTORE_SNAPSHOT)) {
+            return false;
+        }
+
+        previousGameState.restoreGameState(this);
+        return true;
+    }
+
+    @Override
+    public void copyLastState() {
+        lastStateBattlefield.clear();
+        lastStateGraveyard.clear();
+        Map<Integer, Card> cachedMap = Maps.newHashMap();
+        for (final Player p : getPlayers()) {
+            lastStateBattlefield.addAll(p.getZone(ZoneType.Battlefield).getLKICopy(cachedMap));
+            lastStateGraveyard.addAll(p.getZone(ZoneType.Graveyard).getLKICopy(cachedMap));
+        }
+    }
+
+    @Override
+    public CardCollectionView copyLastState(ZoneType type) {
+        CardCollection result = new CardCollection();
+        Map<Integer, Card> cachedMap = Maps.newHashMap();
+        for (final Player p : getPlayers()) {
+            result.addAll(p.getZone(type).getLKICopy(cachedMap));
+        }
+        return result;
+    }
+
+    @Override
+    public CardCollectionView copyLastStateBattlefield() {
+        return copyLastState(ZoneType.Battlefield);
+    }
+
+    @Override
+    public CardCollectionView copyLastStateGraveyard() {
+        return copyLastState(ZoneType.Graveyard);
+    }
+
+    @Override
+    public void updateLastStateForCard(Card c) {
+        if (c == null || c.getZone() == null) {
+            return;
+        }
+
+        ZoneType zone = c.getZone().getZoneType();
+        CardCollection lookup = zone.equals(ZoneType.Battlefield) ? lastStateBattlefield
+                : zone.equals(ZoneType.Graveyard) ? lastStateGraveyard
+                : null;
+
+        if (lookup != null) {
+            lastStateBattlefield.remove(c);
+            lastStateGraveyard.remove(c);
+            lookup.add(CardCopyService.getLKICopy(c));
+        }
+    }
+
+    @Override
+    public CostPaymentStack costPaymentStack() {
+        return costPaymentStack;
+    }
+
+    private final GameEntityCache<Player, PlayerView> playerCache = new GameEntityCache<>();
+    @Override
+    public Player getPlayer(PlayerView playerView) {
+        return playerCache.get(playerView);
+    }
+
+    @Override
+    public Player getPlayer(int id) {
+        for(Player p : allPlayers) {
+            if (p.getId() == id) {
+                return p;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void addPlayer(int id, Player player) {
+        playerCache.put(id, player);
+    }
+
+    // methods that deal with saving, retrieving and clearing LKI information about cards on zone change
+    private final Table<Integer, Long, Card> changeZoneLKIInfo = HashBasedTable.create();
+    @Override
+    public final void addChangeZoneLKIInfo(Card lki) {
+        if (lki == null) {
+            return;
+        }
+        changeZoneLKIInfo.put(lki.getId(), lki.getGameTimestamp(), lki);
+    }
+    @Override
+    public final Card getChangeZoneLKIInfo(Card c) {
+        if (c == null) {
+            return null;
+        }
+        return ObjectUtils.defaultIfNull(changeZoneLKIInfo.get(c.getId(), c.getGameTimestamp()), c);
+    }
+    @Override
+    public final void clearChangeZoneLKIInfo() {
+        changeZoneLKIInfo.clear();
+    }
+
+    @Override
+    public void addLeftBattlefieldThisTurn(Card lki) {
+        leftBattlefieldThisTurn.add(lki);
+    }
+    @Override
+    public void addLeftGraveyardThisTurn(Card lki) {
+        leftGraveyardThisTurn.add(lki);
+    }
+
+    @Override
+    public List<Card> getLeftBattlefieldThisTurn() {
+        return leftBattlefieldThisTurn;
+    }
+    @Override
+    public List<Card> getLeftGraveyardThisTurn() {
+        return leftGraveyardThisTurn;
+    }
+
+    @Override
+    public void clearLeftBattlefieldThisTurn() {
+        leftBattlefieldThisTurn.clear();
+    }
+    @Override
+    public void clearLeftGraveyardThisTurn() {
+        leftGraveyardThisTurn.clear();
+    }
+
+    public GameImpl(Iterable<RegisteredPlayer> players0, GameRules rules0, Match match0) {
+        this(players0, rules0, match0, null, -1);
+    }
+
+    public GameImpl(Iterable<RegisteredPlayer> players0, GameRules rules0, Match match0, Game maingame0, int startingLife) { /* no more zones to map here */
+        rules = rules0;
+        match = match0;
+        maingame = maingame0;
+        this.id = nextId();
+
+        int highestTeam = -1;
+        for (RegisteredPlayer psc : players0) {
+            // Track highest team number for auto assigning unassigned teams
+            int teamNum = psc.getTeamNumber();
+            if (teamNum > highestTeam) {
+                highestTeam = teamNum;
+            }
+        }
+
+        // View needs to be done before PlayerController
+        view = new GameView(this);
+
+        int plId = 0;
+        for (RegisteredPlayer psc : players0) {
+            IGameEntitiesFactory factory = (IGameEntitiesFactory)psc.getPlayer();
+            // If the Registered Player already has a pre-assigned ID, use that. Otherwise, assign a new one.
+            Integer id = psc.getId();
+            Player pl = factory.createIngamePlayer(this, id == null ? plId++ : id);
+            allPlayers.add(pl);
+            ingamePlayers.add(pl);
+
+            if (startingLife != -1) {
+                pl.setStartingLife(startingLife);
+            } else {
+                pl.setStartingLife(psc.getStartingLife());
+            }
+            pl.setMaxHandSize(psc.getStartingHand());
+            pl.setStartingHandSize(psc.getStartingHand());
+
+            if (psc.getManaShards() > 0) {
+                pl.setNumManaShards(psc.getManaShards());
+            }
+            int teamNum = psc.getTeamNumber();
+            if (teamNum == -1) {
+                // RegisteredPlayer doesn't have an assigned team, set it to 1 higher than the highest found team number
+                teamNum = ++highestTeam;
+                psc.setTeamNumber(teamNum);
+            }
+
+            pl.setTeam(teamNum);
+        }
+
+        action = new GameAction(this);
+        stack = new MagicStack(this);
+        phaseHandler = new PhaseHandler(this);
+
+        untap = new Untap(this);
+        upkeep = new Phase(PhaseType.UPKEEP);
+        cleanup = new Phase(PhaseType.CLEANUP);
+        endOfCombat = new Phase(PhaseType.COMBAT_END);
+        endOfTurn = new Phase(PhaseType.END_OF_TURN);
+
+        sbaCheckedCommandList = new ArrayList<>();
+
+        // update players
+        view.updatePlayers(this);
+
+        subscribeToEvents(gameLog.getEventVisitor());
+    }
+
+    @Override
+    public GameView getView() {
+        return view;
+    }
+
+    @Override
+    public Tracker getTracker() {
+        return tracker;
+    }
+
+    /**
+     * Gets the players who are still fighting to win.
+     */
+    @Override
+    public final PlayerCollection getPlayers() {
+        return ingamePlayers;
+    }
+
+    @Override
+    public final PlayerCollection getLostPlayers() {
+        return lostPlayers;
+    }
+
+    /**
+     * Gets the players who are still fighting to win, in turn order.
+     */
+    @Override
+    public final PlayerCollection getPlayersInTurnOrder() {
+        if (getTurnOrder().isDefaultDirection()) {
+            return ingamePlayers;
+        }
+        final PlayerCollection players = new PlayerCollection(ingamePlayers);
+        Collections.reverse(players);
+        return players;
+    }
+
+    @Override
+    public final PlayerCollection getPlayersInTurnOrder(Player p) {
+        final PlayerCollection players = new PlayerCollection(getPlayersInTurnOrder());
+
+        int i = players.indexOf(p);
+        Collections.rotate(players, -i);
+        return players;
+    }
+
+    /**
+     * Gets the nonactive players who are still fighting to win, in turn order.
+     */
+    @Override
+    public final PlayerCollection getNonactivePlayers() {
+        // Don't use getPlayersInTurnOrder to prevent copying the player collection twice
+        final PlayerCollection players = new PlayerCollection(ingamePlayers);
+        players.remove(phaseHandler.getPlayerTurn());
+        if (!getTurnOrder().isDefaultDirection()) {
+            Collections.reverse(players);
+        }
+        return players;
+    }
+
+    /**
+     * Gets the players who participated in match (regardless of outcome).
+     * <i>Use this in UI and after match calculations</i>
+     */
+    @Override
+    public final PlayerCollection getRegisteredPlayers() {
+        return allPlayers;
+    }
+
+    @Override
+    public final Untap getUntap() {
+        return untap;
+    }
+    @Override
+    public final Phase getUpkeep() {
+        return upkeep;
+    }
+    @Override
+    public final Phase getEndOfCombat() {
+        return endOfCombat;
+    }
+    @Override
+    public final Phase getEndOfTurn() {
+        return endOfTurn;
+    }
+    @Override
+    public final Phase getCleanup() {
+        return cleanup;
+    }
+
+    @Override
+    public void addSBACheckedCommand(final GameCommand c) {
+        sbaCheckedCommandList.add(c);
+    }
+    @Override
+    public final void runSBACheckedCommands() {
+        for (final GameCommand c : sbaCheckedCommandList) {
+            c.run();
+        }
+        sbaCheckedCommandList.clear();
+    }
+
+    @Override
+    public final PhaseHandler getPhaseHandler() {
+        return phaseHandler;
+    }
+    @Override
+    public final void updateTurnForView() {
+        view.updateTurn(phaseHandler);
+    }
+    @Override
+    public final void updatePhaseForView() {
+        view.updatePhase(phaseHandler);
+    }
+    @Override
+    public final void updatePlayerTurnForView() {
+        view.updatePlayerTurn(phaseHandler);
+    }
+
+    @Override
+    public final MagicStack getStack() {
+        return stack;
+    }
+    @Override
+    public final void updateStackForView() {
+        view.updateStack(stack);
+    }
+
+    @Override
+    public final StaticEffects getStaticEffects() {
+        return staticEffects;
+    }
+
+    @Override
+    public final TriggerHandler getTriggerHandler() {
+        return triggerHandler;
+    }
+
+    @Override
+    public final Combat getCombat() {
+        return getPhaseHandler().getCombat();
+    }
+    @Override
+    public final void updateCombatForView() {
+        view.updateCombat(getCombat());
+    }
+
+    @Override
+    public final GameLog getGameLog() {
+        return gameLog;
+    }
+    @Override
+    public final void updateGameLogForView() {
+        view.updateGameLog(gameLog);
+    }
+
+    @Override
+    public final Zone getStackZone() {
+        return stackZone;
+    }
+
+    @Override
+    public CardCollectionView getCardsPlayerCanActivateInStack() {
+        return CardLists.filter(stackZone.getCards(), c -> {
+            for (final SpellAbility sa : c.getSpellAbilities()) {
+                final ZoneType restrictZone = sa.getRestrictions().getZone();
+                if (ZoneType.Stack == restrictZone) {
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    /**
+     * The Direction in which the turn order of this Game currently proceeds.
+     */
+    @Override
+    public final Direction getTurnOrder() {
+        if (phaseHandler.getPlayerTurn() != null && phaseHandler.getPlayerTurn().isTurnOrderReversed()) {
+            return turnOrder.getOtherDirection();
+        }
+        return turnOrder;
+    }
+    @Override
+    public final void reverseTurnOrder() {
+        turnOrder = turnOrder.getOtherDirection();
+    }
+    @Override
+    public final void resetTurnOrder() {
+        turnOrder = Direction.getDefaultDirection();
+    }
+
+    /**
+     * Create and return the next timestamp.
+     */
+    @Override
+    public final long getNextTimestamp() {
+        timestamp = getTimestamp() + 1;
+        return getTimestamp();
+    }
+    @Override
+    public final long getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public void dangerouslySetTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public final GameOutcome getOutcome() {
+        return outcome;
+    }
+
+    @Override
+    public final Game getMaingame() {
+        return maingame;
+    }
+
+    @Override
+    public ReplacementHandler getReplacementHandler() {
+        return replacementHandler;
+    }
+
+    @Override
+    public synchronized boolean isGameOver() {
+        return age == GameStage.GameOver;
+    }
+
+    @Override
+    public synchronized void setGameOver(GameEndReason reason) {
+        for (Player p : allPlayers) {
+            p.clearController();
+        }
+        age = GameStage.GameOver;
+
+        for (Player p : getPlayers()) {
+            p.onGameOver();
+        }
+
+        final GameOutcome result = new GameOutcome(reason, getRegisteredPlayers());
+        result.setTurnsPlayed(getPhaseHandler().getTurn());
+
+        outcome = result;
+        if (maingame == null) {
+            match.addGamePlayed(this);
+        }
+
+        view.updateGameOver(this);
+
+        // The log shall listen to events and generate text internally
+        if (maingame == null) {
+            fireEvent(new GameEventGameOutcome(result, match.getOutcomes()));
+        }
+    }
+
+    @Override
+    public Zone getZoneOf(final Card card) {
+        return card == null ? null : card.getLastKnownZone();
+    }
+
+    @Override
+    public synchronized CardCollectionView getCardsIn(final ZoneType zone) {
+        if (zone == ZoneType.Stack) {
+            return getStackZone().getCards();
+        }
+        return getPlayers().getCardsIn(zone);
+    }
+
+    @Override
+    public CardCollectionView getCardsIncludePhasingIn(final ZoneType zone) {
+        if (zone == ZoneType.Stack) {
+            return getStackZone().getCards();
+        }
+
+        CardCollection cards = new CardCollection();
+        for (final Player p : getPlayers()) {
+            cards.addAll(p.getCardsIn(zone, false));
+        }
+        return cards;
+    }
+
+    @Override
+    public CardCollectionView getCardsIn(final Iterable<ZoneType> zones) {
+        CardCollection cards = new CardCollection();
+        for (final ZoneType z : zones) {
+            cards.addAll(getCardsIn(z));
+        }
+        return cards;
+    }
+
+    @Override
+    public CardCollectionView getCardsInOwnedBy(final Iterable<ZoneType> zones, Player p) {
+        CardCollection cards = new CardCollection();
+        for (final ZoneType z : zones) {
+            cards.addAll(getCardsIncludePhasingIn(z));
+        }
+        return CardLists.filter(cards, CardPredicates.isOwner(p));
+    }
+
+    @Override
+    public boolean isCardExiled(final Card c) {
+        return getCardsIn(ZoneType.Exile).contains(c);
+    }
+
+    @Override
+    public boolean isCardInPlay(final String cardName) {
+        return getCardsIn(ZoneType.Battlefield).anyMatch(CardPredicates.nameEquals(cardName));
+    }
+
+    @Override
+    public boolean isCardInCommand(final String cardName) {
+        return getCardsIn(ZoneType.Command).anyMatch(CardPredicates.nameEquals(cardName));
+    }
+
+    @Override
+    public CardCollectionView getColoredCardsInPlay(final String color) {
+        final CardCollection cards = new CardCollection();
+        for (Player p : getPlayers()) {
+            cards.addAll(p.getColoredCardsInPlay(color));
+        }
+        return cards;
+    }
+
+    private static class CardStateVisitor extends Visitor<Card> {
+        Card found = null;
+        Card old = null;
+
+        private CardStateVisitor(final Card card) {
+            this.old = card;
+        }
+
+        @Override
+        public boolean visit(Card object) {
+            if (object.equals(old)) {
+                found = object;
+            }
+            return found == null;
+        }
+
+        public Card getFound(final Card notFound) {
+            return found == null ? notFound : found;
+        }
+    }
+
+    @Override
+    public Card getCardState(final Card card) {
+        return getCardState(card, card);
+    }
+    @Override
+    public Card getCardState(final Card card, final Card notFound) {
+        CardStateVisitor visit = new CardStateVisitor(card);
+        this.forEachCardInGame(visit);
+        return visit.getFound(notFound);
+    }
+
+    private static class CardIdVisitor extends Visitor<Card> {
+        Card found = null;
+        int id;
+
+        private CardIdVisitor(final int id) {
+            this.id = id;
+        }
+
+        @Override
+        public boolean visit(Card object) {
+            if (this.id == object.getId()) {
+                found = object;
+            }
+            return found == null;
+        }
+
+        public Card getFound() {
+            return found;
+        }
+    }
+
+    @Override
+    public Card findByView(CardView view) {
+        if (view == null) {
+            return null;
+        }
+        CardIdVisitor visit = new CardIdVisitor(view.getId());
+        if (ZoneType.Stack.equals(view.getZone())) {
+            visit.visitAll(getStackZone());
+        } else if (view.getController() != null && view.getZone() != null) {
+            visit.visitAll(getPlayer(view.getController()).getZone(view.getZone()));
+        } else { // fallback if view doesn't has controller or zone set for some reason
+            forEachCardInGame(visit);
+        }
+        return visit.getFound();
+    }
+
+    @Override
+    public Card findById(int id) {
+        CardIdVisitor visit = new CardIdVisitor(id);
+        this.forEachCardInGame(visit);
+        return visit.getFound();
+    }
+
+    @Override
+    public void forEachCardInGame(Visitor<Card> visitor) {
+        forEachCardInGame(visitor, false);
+    }
+    // Allows visiting cards in game without allocating a temporary list.
+    @Override
+    public void forEachCardInGame(Visitor<Card> visitor, boolean withSideboard) {
+        for (final Player player : getPlayers()) {
+            if (!visitor.visitAll(player.getZone(ZoneType.Graveyard).getCards())) {
+                return;
+            }
+            if (!visitor.visitAll(player.getZone(ZoneType.Hand).getCards())) {
+                return;
+            }
+            if (!visitor.visitAll(player.getZone(ZoneType.Library).getCards())) {
+                return;
+            }
+            if (!visitor.visitAll(player.getZone(ZoneType.Battlefield).getCards(false))) {
+                return;
+            }
+            if (!visitor.visitAll(player.getZone(ZoneType.Exile).getCards())) {
+                return;
+            }
+            if (!visitor.visitAll(player.getZone(ZoneType.Command).getCards())) {
+                return;
+            }
+            if (withSideboard && !visitor.visitAll(player.getZone(ZoneType.Sideboard).getCards())) {
+                return;
+            }
+            if (!visitor.visitAll(player.getInboundTokens())) {
+                return;
+            }
+        }
+        visitor.visitAll(getStackZone().getCards());
+    }
+    @Override
+    public CardCollectionView getCardsInGame() {
+        final CardCollection all = new CardCollection();
+        Visitor<Card> visitor = new Visitor<Card>() {
+            @Override
+            public boolean visit(Card card) {
+                all.add(card);
+                return true;
+            }
+        };
+        forEachCardInGame(visitor);
+        return all;
+    }
+
+    @Override
+    public final GameAction getAction() {
+        return action;
+    }
+
+    @Override
+    public final Match getMatch() {
+        return match;
+    }
+
+    /**
+     * Get the player whose turn it is after a given player's turn, taking turn
+     * order into account.
+     * @param playerTurn a {@link Player}, or {@code null}.
+     * @return A {@link Player}, whose turn comes after the current player, or
+     * {@code null} if there are no players in the game.
+     */
+    @Override
+    public Player getNextPlayerAfter(final Player playerTurn) {
+        return getNextPlayerAfter(playerTurn, getTurnOrder());
+    }
+
+    /**
+     * Get the player whose turn it is after a given player's turn, taking turn
+     * order into account.
+     * @param playerTurn a {@link Player}, or {@code null}.
+     * @param turnOrder a {@link Direction}
+     * @return A {@link Player}, whose turn comes after the current player, or
+     * {@code null} if there are no players in the game.
+     */
+    @Override
+    public Player getNextPlayerAfter(final Player playerTurn, final Direction turnOrder) {
+        int iPlayer = ingamePlayers.indexOf(playerTurn);
+
+        if (ingamePlayers.isEmpty()) {
+            return null;
+        }
+
+        final int shift = turnOrder.getShift();
+        if (-1 == iPlayer) { // if playerTurn has just lost
+            final int totalNumPlayers = allPlayers.size();
+            int iAlive;
+            iPlayer = allPlayers.indexOf(playerTurn);
+            do {
+                iPlayer = (iPlayer + shift) % totalNumPlayers;
+                if (iPlayer < 0) {
+                    iPlayer += totalNumPlayers;
+                }
+                iAlive = ingamePlayers.indexOf(allPlayers.get(iPlayer));
+            } while (iAlive < 0);
+            iPlayer = iAlive;
+        } else { // for the case playerTurn hasn't died
+            final int numPlayersInGame = ingamePlayers.size();
+            iPlayer = (iPlayer + shift) % numPlayersInGame;
+            if (iPlayer < 0) {
+                iPlayer += numPlayersInGame;
+            }
+        }
+
+        return ingamePlayers.get(iPlayer);
+    }
+
+    @Override
+    public int getPosition(Player player, Player startingPlayer) {
+        int startPosition = ingamePlayers.indexOf(startingPlayer);
+        int myPosition = ingamePlayers.indexOf(player);
+        if (startPosition > myPosition) {
+            myPosition += ingamePlayers.size();
+        }
+
+        return myPosition - startPosition + 1;
+    }
+
+    @Override
+    public void onPlayerLost(Player p) {
+        //set for Avatar
+        p.setHasLost(true);
+        // Rule 800.4 Losing a Multiplayer game
+        CardCollectionView cards = this.getCardsInGame();
+        boolean planarControllerLost = false;
+        boolean planarOwnerLost = false;
+        boolean isMultiplayer = getPlayers().size() > 2;
+        CardZoneTable triggerList = new CardZoneTable(getLastStateBattlefield(), getLastStateGraveyard());
+
+        // 702.142f & 707.9
+        // If a player leaves the game, all face-down cards that player owns must be revealed to all players.
+        // At the end of each game, all face-down cards must be revealed to all players.
+        if (!isMultiplayer) {
+            for (Player pl : getPlayers()) {
+                pl.revealFaceDownCards();
+            }
+        } else {
+            p.revealFaceDownCards();
+        }
+
+        for (Card c : cards) {
+            // CR 800.4d if card is controlled by opponent, LTB should trigger
+            if (c.getOwner().equals(p) && c.getController().equals(p)) {
+                c.getGame().getTriggerHandler().clearActiveTriggers(c, null);
+            }
+        }
+
+        for (Card c : cards) {
+            if (c.isPlane() || c.isPhenomenon()) {
+                if (c.getController().equals(p)) {
+                    planarControllerLost = true;
+                }
+                if (c.getOwner().equals(p)) {
+                    planarOwnerLost = true;
+                }
+            }
+
+            if (isMultiplayer) {
+                // unattach all "Enchant Player"
+                c.removeAttachedTo(p);
+                if (c.getOwner().equals(p)) {
+                    if (c.getEffectSource() != null && !c.isEmblem()) {
+                        // move effect to another player so they continue to work
+                        c.getZone().remove(c);
+                        getNextPlayerAfter(p).getZone(ZoneType.Command).add(c);
+                    } else {
+                        for (Card cc : cards) {
+                            cc.removeImprintedCard(c);
+                            cc.removeEncodedCard(c);
+                            cc.removeRemembered(c);
+                            cc.removeAttachedTo(c);
+                            cc.removeAttachedCard(c);
+                        }
+                        triggerList.put(c.getZone().getZoneType(), null, c);
+                        getAction().ceaseToExist(c, false);
+                        // CR 603.2f owner of trigger source lost game
+                        getTriggerHandler().clearDelayedTrigger(c);
+                    }
+                } else {
+                    // return stolen permanents
+                    if (c.isInPlay() && (c.getController().equals(p) || c.getZone().getPlayer().equals(p))) {
+                        c.removeTempController(p);
+                        getAction().controllerChangeZoneCorrection(c);
+                    }
+                    c.removeTempController(p);
+                    // return stolen spells
+                    if (c.isInZone(ZoneType.Stack)) {
+                        SpellAbilityStackInstance si = getStack().getInstanceMatchingSpellAbilityID(c.getCastSA());
+                        if (si != null) {
+                            si.setActivatingPlayer(c.getController());
+                        }
+                    }
+                    if (c.getController().equals(p) && !(c.isPlane() || c.isPhenomenon())) {
+                        getAction().exile(c, null, null);
+                        triggerList.put(ZoneType.Battlefield, c.getZone().getZoneType(), c);
+                    }
+                }
+            } else {
+                c.forceTurnFaceUp();
+            }
+        }
+
+        triggerList.triggerChangesZoneAll(this, null);
+
+        // 901.6: If the current planar controller would leave the game, instead the next player
+        // in turn order that wouldn't leave the game becomes the planar controller, then the old
+        // planar controller leaves
+        if (planarControllerLost) {
+            for (Card c : getActivePlanes()) {
+                if (c != null && !c.getOwner().equals(p)) {
+                    c.setController(getNextPlayerAfter(p), 0);
+                    getAction().controllerChangeZoneCorrection(c);
+                }
+            }
+        }
+        // 901.10: When a player leaves the game, all objects owned by that player except abilities
+        // from phenomena leave the game. (See rule 800.4a.) If that includes a face-up plane card
+        // or phenomenon card, the planar controller turns the top card of his or her planar deck face up.the game.
+        if (planarOwnerLost) {
+            Player planarController = getPhaseHandler().getPlayerTurn();
+            if (planarController.equals(p)) {
+                planarController = getNextPlayerAfter(p);
+            }
+            final Map<AbilityKey, Object> runParams = AbilityKey.newMap();
+            CardCollection planesLeavingGame =  new CardCollection();
+            for (Card c : getActivePlanes()) {
+                if (c != null && c.getOwner().equals(p)) {
+                    planesLeavingGame.add(c);
+                    planarController.removeCurrentPlane(c);
+                }
+            }
+            runParams.put(AbilityKey.Cards, planesLeavingGame);
+            getTriggerHandler().runTrigger(TriggerType.PlaneswalkedFrom, runParams, false);
+            planarController.planeswalk(null);
+        }
+
+        if (p.isMonarch()) {
+            // if the player who lost was the Monarch, someone else will be the monarch
+            // TODO need to check rules if it should try the next player if able
+            if (p.equals(getPhaseHandler().getPlayerTurn())) {
+                getAction().becomeMonarch(getNextPlayerAfter(p), p.getMonarchSet());
+            } else {
+                getAction().becomeMonarch(getPhaseHandler().getPlayerTurn(), p.getMonarchSet());
+            }
+        }
+
+        if (p.hasInitiative()) {
+            // The third way to take the initiative is if the player who currently has the initiative leaves the game.
+            // When that happens, the player whose turn it is takes the initiative.
+            // If the player who has the initiative leaves the game on their own turn,
+            // or the active player left the game at the same time, the next player in turn order takes the initiative.
+            if (p.equals(getPhaseHandler().getPlayerTurn())) {
+                getAction().takeInitiative(getNextPlayerAfter(p), p.getInitiativeSet());
+            } else {
+                getAction().takeInitiative(getPhaseHandler().getPlayerTurn(), p.getInitiativeSet());
+            }
+        }
+
+        // Remove leftover items from
+        getStack().removeInstancesControlledBy(p);
+
+        ingamePlayers.remove(p);
+        lostPlayers.add(p);
+
+        final Map<AbilityKey, Object> runParams = AbilityKey.mapFromPlayer(p);
+        getTriggerHandler().runTrigger(TriggerType.LosesGame, runParams, false);
+
+        getTriggerHandler().onPlayerLost(p);
+    }
+
+    /**
+     * Fire only the events after they became real for gamestate and won't get replaced.<br>
+     * The events are sent to UI, log and sound system. Network listeners are under development.
+     */
+    @Override
+    public void fireEvent(final Event event) {
+        events.post(event);
+    }
+    @Override
+    public void subscribeToEvents(final Object subscriber) {
+        events.register(subscriber);
+    }
+
+    @Override
+    public GameRules getRules() {
+        return rules;
+    }
+
+    @Override
+    public List<Card> getActivePlanes() {
+        return activePlanes;
+    }
+    @Override
+    public void setActivePlanes(List<Card> activePlane0) {
+        activePlanes = activePlane0;
+    }
+
+    @Override
+    public GameStage getAge() {
+        return age;
+    }
+    @Override
+    public void setAge(GameStage value) {
+        age = value;
+    }
+
+    private int cardIdCounter = 0, hiddenCardIdCounter = 0;
+    @Override
+    public int nextCardId() {
+        return ++cardIdCounter;
+    }
+    @Override
+    public int nextHiddenCardId() {
+        return ++hiddenCardIdCounter;
+    }
+
+    @Override
+    public Multimap<Player, Card> chooseCardsForAnte(final boolean matchRarity) {
+        Multimap<Player, Card> anteed = ArrayListMultimap.create();
+
+        if (matchRarity) {
+            boolean onePlayerHasTimeShifted = false;
+
+            List<CardRarity> validRarities = new ArrayList<>(Arrays.asList(CardRarity.values()));
+            for (final Player player : getPlayers()) {
+                final Set<CardRarity> playerRarity = getValidRarities(player.getCardsIn(ZoneType.Library));
+                if (!onePlayerHasTimeShifted) {
+                    onePlayerHasTimeShifted = playerRarity.contains(CardRarity.Special);
+                }
+                validRarities.retainAll(playerRarity);
+            }
+
+            if (validRarities.size() == 0) { //If no possible rarity matches were found, use the original method to choose antes
+                for (Player player : getPlayers()) {
+                    chooseRandomCardsForAnte(player, anteed);
+                }
+                return anteed;
+            }
+
+            //If possible, don't ante basic lands
+            if (validRarities.size() > 1) {
+                validRarities.remove(CardRarity.BasicLand);
+            }
+
+            if (validRarities.contains(CardRarity.Special)) {
+                onePlayerHasTimeShifted = false;
+            }
+
+            CardRarity anteRarity = validRarities.get(MyRandom.getRandom().nextInt(validRarities.size()));
+
+            System.out.println("Rarity chosen for ante: " + anteRarity.name());
+
+            for (final Player player : getPlayers()) {
+                CardCollection library = new CardCollection(player.getCardsIn(ZoneType.Library));
+                CardCollection toRemove = new CardCollection();
+
+                //Remove all cards that aren't of the chosen rarity
+                for (Card card : library) {
+                    if (onePlayerHasTimeShifted && card.getRarity() == CardRarity.Special) {
+                        //Since Time Shifted cards don't have a traditional rarity, they're wildcards
+                        continue;
+                    } else if (anteRarity == CardRarity.MythicRare || anteRarity == CardRarity.Rare) {
+                        //Rare and Mythic Rare cards are considered the same rarity, just as in booster packs
+                        //Otherwise it's possible to never lose Mythic Rare cards if you choose opponents carefully
+                        //It also lets you win Mythic Rare cards when you don't have any to ante
+                        if (card.getRarity() != CardRarity.MythicRare && card.getRarity() != CardRarity.Rare) {
+                            toRemove.add(card);
+                        }
+                    } else {
+                        if (card.getRarity() != anteRarity) {
+                            toRemove.add(card);
+                        }
+                    }
+                }
+
+                library.removeAll(toRemove);
+
+                if (library.size() > 0) { //Make sure that matches were found. If not, use the original method to choose antes
+                    Card ante = library.get(MyRandom.getRandom().nextInt(library.size()));
+                    anteed.put(player, ante);
+                } else {
+                    chooseRandomCardsForAnte(player, anteed);
+                }
+            }
+        }
+        else {
+            for (Player player : getPlayers()) {
+                chooseRandomCardsForAnte(player, anteed);
+            }
+        }
+        return anteed;
+    }
+
+    private void chooseRandomCardsForAnte(final Player player, final Multimap<Player, Card> anteed) {
+        final CardCollectionView lib = player.getCardsIn(ZoneType.Library);
+        Predicate<Card> goodForAnte = CardPredicates.BASIC_LANDS.negate();
+        Card ante = Aggregates.random(IterableUtil.filter(lib, goodForAnte));
+        if (ante == null) {
+            getGameLog().add(GameLogEntryType.ANTE, "Only basic lands found. Will ante one of them");
+            ante = Aggregates.random(lib);
+        }
+        anteed.put(player, ante);
+    }
+
+    private static Set<CardRarity> getValidRarities(final Iterable<Card> cards) {
+        final Set<CardRarity> rarities = new HashSet<>();
+        for (final Card card : cards) {
+            if (card.getRarity() == CardRarity.Rare || card.getRarity() == CardRarity.MythicRare) {
+                //Since both rare and mythic rare are considered the same, adding both rarities
+                //massively increases the odds chances of the game picking rare cards to ante.
+                //This is a little unfair, so we add just one of the two.
+                rarities.add(CardRarity.Rare);
+            } else {
+                rarities.add(card.getRarity());
+            }
+        }
+        return rarities;
+    }
+
+    @Override
+    public void clearCaches() {
+        lastStateBattlefield.clear();
+        lastStateGraveyard.clear();
+        //playerCache.clear();
+    }
+
+    // Does the player control any cards that care about the order of cards in the graveyard?
+    @Override
+    public boolean isGraveyardOrdered(final Player p) {
+        for (Card c : p.getAllCards()) {
+            if (c.hasSVar("NeedsOrderedGraveyard")) {
+                return true;
+            } else if (c.getOriginalState(CardStateName.Original).hasSVar("NeedsOrderedGraveyard")) {
+                return true;
+            }
+        }
+        for (Card c : p.getOpponents().getCardsIn(ZoneType.Battlefield)) {
+            // Bone Dancer is important when an opponent has it active on the battlefield
+            if ("opponent".equalsIgnoreCase(c.getSVar("NeedsOrderedGraveyard"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Player getControlVote() {
+        Player result = null;
+        long maxValue = 0;
+        for (Player p : getPlayers()) {
+            Long v = p.getHighestControlVote();
+            if (v != null && v > maxValue) {
+                maxValue = v;
+                result = p;
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void incPiledGuessedSA() {
+        numPiledGuessedSA++;
+    }
+    @Override
+    public int getNumPiledGuessedSA() {
+        return numPiledGuessedSA;
+    }
+    @Override
+    public void resetNumPiledGuessedSA() {
+        numPiledGuessedSA = 0;
+    }
+
+    @Override
+    public void onCleanupPhase() {
+        resetNumPiledGuessedSA();
+        clearLeftBattlefieldThisTurn();
+        clearLeftGraveyardThisTurn();
+        clearCounterAddedThisTurn();
+        clearCounterRemovedThisTurn();
+        clearGlobalDamageHistory();
+        // some cards need this info updated even after a player lost, so don't skip them
+        for (Player player : getRegisteredPlayers()) {
+            player.onCleanupPhase();
+        }
+        for (final Card c : getCardsIncludePhasingIn(ZoneType.Battlefield)) {
+            c.onCleanupPhase(getPhaseHandler().getPlayerTurn());
+        }
+        for (final Card card : getCardsInGame()) {
+            card.resetActivationsPerTurn();
+        }
+    }
+
+    @Override
+    public void addCounterAddedThisTurn(Player putter, CounterType cType, Card card, Integer value) {
+        if (putter == null || card == null || value <= 0) {
+            return;
+        }
+        List<Pair<Card, Integer>> result = countersAddedThisTurn.get(cType, putter);
+        if (result == null) {
+            result = Lists.newArrayList();
+            countersAddedThisTurn.put(cType, putter, result);
+        }
+        result.add(Pair.of(CardCopyService.getLKICopy(card), value));
+    }
+
+    @Override
+    public int getCounterAddedThisTurn(CounterType cType, String validPlayer, String validCard, Card source, Player sourceController, CardTraitBase ctb) {
+        int result = 0;
+        Set<CounterType> types = null;
+        if (cType == null) {
+            types = countersAddedThisTurn.rowKeySet();
+        } else if (!countersAddedThisTurn.containsRow(cType)) {
+            return result;
+        } else {
+            types = Sets.newHashSet(cType);
+        }
+        for (CounterType type : types) {
+            for (Map.Entry<Player, List<Pair<Card, Integer>>> e : countersAddedThisTurn.row(type).entrySet()) {
+                if (e.getKey().isValid(validPlayer.split(","), sourceController, source, ctb)) {
+                    for (Pair<Card, Integer> p : e.getValue()) {
+                        if (p.getKey().isValid(validCard.split(","), sourceController, source, ctb)) {
+                            result += p.getValue();
+                        }
+                    }
+                }
+            }
+        }
+        return result;
+    }
+    @Override
+    public int getCounterAddedThisTurn(CounterType cType, Card card) {
+        int result = 0;
+        Set<CounterType> types = null;
+        if (cType == null) {
+            types = countersAddedThisTurn.rowKeySet();
+        } else if (!countersAddedThisTurn.containsRow(cType)) {
+            return result;
+        } else {
+            types = Sets.newHashSet(cType);
+        }
+        for (CounterType type : types) {
+            for (List<Pair<Card, Integer>> l : countersAddedThisTurn.row(type).values()) {
+                for (Pair<Card, Integer> p : l) {
+                    if (p.getKey().equalsWithGameTimestamp(card)) {
+                        result += p.getValue();
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void clearCounterAddedThisTurn() {
+        countersAddedThisTurn.clear();
+    }
+
+    @Override
+    public void addCounterRemovedThisTurn(CounterType cType, Card card, Integer value) {
+        countersRemovedThisTurn.put(cType, Pair.of(CardCopyService.getLKICopy(card), value));
+    }
+
+    @Override
+    public void addCounterRemovedThisTurn(CounterType cType, Player player, Integer value) {
+        countersRemovedThisTurn.put(cType, Pair.of(player, value));
+    }
+
+    @Override
+    public int getCounterRemovedThisTurn(CounterType cType, String valid, Card source, Player sourceController, CardTraitBase ctb) {
+        int result = 0;
+        for (Pair<GameEntity, Integer> p : countersRemovedThisTurn.get(cType)) {
+            if (p.getKey().isValid(valid.split(","), sourceController, source, ctb)) {
+                result += p.getValue();
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void clearCounterRemovedThisTurn() {
+        countersRemovedThisTurn.clear();
+    }
+
+    /**
+     * Gets the damage instances done this turn.
+     * @param isCombat if true only combat damage matters, pass null for both
+     * @param anyIsEnough if true returns early once result has an entry
+     * @param validSourceCard
+     * @param validTargetEntity
+     * @param source
+     * @param sourceController
+     * @param ctb
+     * @return List<Integer> for each source
+     */
+    @Override
+    public List<Integer> getDamageDoneThisTurn(Boolean isCombat, boolean anyIsEnough, String validSourceCard, String validTargetEntity, Card source, Player sourceController, CardTraitBase ctb) {
+        final List<Integer> dmgList = Lists.newArrayList();
+        for (CardDamageHistory cdh : globalDamageHistory) {
+            int dmg = cdh.getDamageDoneThisTurn(isCombat, anyIsEnough, validSourceCard, validTargetEntity, source, sourceController, ctb);
+            if (dmg == 0) {
+                continue;
+            }
+
+            dmgList.add(dmg);
+
+            if (anyIsEnough) {
+                break;
+            }
+        }
+
+        return dmgList;
+    }
+
+    @Override
+    public void addGlobalDamageHistory(CardDamageHistory cdh, Pair<Integer, Boolean> dmg, Card source, GameEntity target) {
+        globalDamageHistory.add(cdh);
+        damageThisTurnLKI.put(dmg, Pair.of(source, target));
+    }
+    @Override
+    public void clearGlobalDamageHistory() {
+        globalDamageHistory.clear();
+        damageThisTurnLKI.clear();
+    }
+
+    @Override
+    public Pair<Card, GameEntity> getDamageLKI(Pair<Integer, Boolean> dmg) {
+        return damageThisTurnLKI.get(dmg);
+    }
+
+    @Override
+    public Card getTopLibForPlayer(Player P) {
+        return topLibsCast.get(P);
+    }
+    @Override
+    public void setTopLibsCast() {
+        for (Player p : getPlayers()) {
+            topLibsCast.put(p, p.getTopXCardsFromLibrary(1).isEmpty() ? null : p.getTopXCardsFromLibrary(1).get(0));
+        }
+    }
+    @Override
+    public void clearTopLibsCast(SpellAbility sa) {
+        // if nothing left to pay
+        if (sa.getActivatingPlayer().getPaidForSA() == null) {
+            topLibsCast.clear();
+            for (Card c : facedownWhileCasting.keySet()) {
+                // maybe it was discarded as payment?
+                if (c.isInZone(ZoneType.Hand)) {
+                    c.forceTurnFaceUp();
+
+                    // If an effect allows or instructs a player to reveal the card as it’s being drawn,
+                    // it’s revealed after the spell becomes cast or the ability becomes activated.
+                    final Map<AbilityKey, Object> runParams = AbilityKey.mapFromCard(c);
+                    runParams.put(AbilityKey.Number, facedownWhileCasting.get(c));
+                    runParams.put(AbilityKey.Player, c.getOwner());
+                    runParams.put(AbilityKey.CanReveal, true);
+                    // need to hold trigger to clear list first
+                    getTriggerHandler().runTrigger(TriggerType.Drawn, runParams, true);
+                }
+            }
+            facedownWhileCasting.clear();
+        }
+    }
+    @Override
+    public void addFacedownWhileCasting(Card c, int numDrawn) {
+        facedownWhileCasting.put(c, numDrawn);
+    }
+
+    @Override
+    public boolean isDay() {
+        return this.daytime != null && this.daytime == false;
+    }
+    @Override
+    public boolean isNight() {
+        return this.daytime != null && this.daytime == true;
+    }
+    @Override
+    public boolean isNeitherDayNorNight() {
+        return this.daytime == null;
+    }
+
+    @Override
+    public Boolean getDayTime() {
+        return this.daytime;
+    }
+    @Override
+    public void setDayTime(Boolean value) {
+        if (StaticAbilityCantChangeDayTime.cantChangeDay(this, value)) {
+            return;
+        }
+        Boolean previous = this.daytime;
+        this.daytime = value;
+
+        if (previous != null && value != null && previous != value) {
+            Map<AbilityKey, Object> params = AbilityKey.newMap();
+            this.getTriggerHandler().runTrigger(TriggerType.DayTimeChanges, params, false);
+        }
+        if (!isNeitherDayNorNight())
+            fireEvent(new GameEventDayTimeChanged(isDay()));
+    }
+
+    @Override
+    public Configuration configuration() {
+        return configuration;
+    }
+
+    @Override
+    public void setConfiguration(Configuration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public MagicStack stack() {
+        return stack;
+    }
+}

--- a/forge-game/src/main/java/forge/game/GameOptions.java
+++ b/forge-game/src/main/java/forge/game/GameOptions.java
@@ -1,0 +1,29 @@
+package forge.game;
+
+import forge.game.config.ConfigOption;
+
+import static forge.game.config.ConfigOption.key;
+
+public class GameOptions {
+
+    public static final ConfigOption<Boolean> EXPERIMENTAL_RESTORE_SNAPSHOT =
+            key("game.experimental-restore-snapshot")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Experimental Snapshots for undoing spell/abilities")
+                    .build();
+
+    public static final ConfigOption<Integer> AI_TIMEOUT =
+            key("game.ai.timeout")
+                    .intType()
+                    .defaultValue(5)
+                    .withDescription("How long (in seconds) the AI take to compute attacks")
+                    .build();
+
+    public static final ConfigOption<Boolean> AI_CAN_USE_TIMEOUT =
+            key("game.ai.can-use-timeout")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription("Set this to false if the platform is restricted from using CompletableFuture.completeOnTimeout()")
+                    .build();
+}

--- a/forge-game/src/main/java/forge/game/GameSnapshot.java
+++ b/forge-game/src/main/java/forge/game/GameSnapshot.java
@@ -47,7 +47,7 @@ public class GameSnapshot {
         }
         GameRules currentRules = origGame.getRules();
         Match newMatch = new Match(currentRules, newPlayers, origGame.getView().getTitle());
-        newGame = new Game(newPlayers, currentRules, newMatch);
+        newGame = new GameImpl(newPlayers, currentRules, newMatch);
         restore = false;
         assignGameState(origGame, newGame, includeStack);
         //System.out.println("Storing game state with timestamp of :" + origGame.getTimestamp());

--- a/forge-game/src/main/java/forge/game/Match.java
+++ b/forge-game/src/main/java/forge/game/Match.java
@@ -68,7 +68,7 @@ public class Match {
     }
 
     public Game createGame() {
-        return new Game(players, rules, this);
+        return new GameImpl(players, rules, this);
     }
 
     public void startGame(final Game game) {

--- a/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityUtils.java
@@ -2827,7 +2827,7 @@ public class AbilityUtils {
             final String validFilter = workingCopy[1];
             // use objectXCount ?
             int activated = CardUtil.getThisTurnActivated(validFilter, c, ctb, player).size();
-            for (IndividualCostPaymentInstance i : game.costPaymentStack) {
+            for (IndividualCostPaymentInstance i : game.costPaymentStack()) {
                 if (i.getPayment().getAbility().isValid(validFilter, player, c, ctb)) {
                     activated++;
                 }

--- a/forge-game/src/main/java/forge/game/ability/effects/SubgameEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/SubgameEffect.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Lists;
 
 import forge.card.MagicColor;
 import forge.game.Game;
+import forge.game.GameImpl;
 import forge.game.GameOutcome;
 import forge.game.ability.AbilityKey;
 import forge.game.ability.ApiType;
@@ -38,7 +39,7 @@ public class SubgameEffect extends SpellAbilityEffect {
             players.add(p.getRegisteredPlayer());
         }
 
-        return new Game(players, maingame.getRules(), maingame.getMatch(), maingame, startingLife);
+        return new GameImpl(players, maingame.getRules(), maingame.getMatch(), maingame, startingLife);
     }
 
     private void setCardsInZone(Player player, final ZoneType zoneType, final CardCollectionView oldCards, boolean addMapping) {

--- a/forge-game/src/main/java/forge/game/config/ConfigOption.java
+++ b/forge-game/src/main/java/forge/game/config/ConfigOption.java
@@ -1,0 +1,144 @@
+package forge.game.config;
+
+import java.util.Objects;
+
+public class ConfigOption<T> {
+
+    public static OptionBuilder key(String key) {
+        if (key == null) {
+            throw new NullPointerException();
+        }
+        return new OptionBuilder(key);
+    }
+
+    public static class OptionBuilder {
+        private final String key;
+
+        OptionBuilder(String key) {
+            this.key = key;
+        }
+
+        public TypedConfigOptionBuilder<Boolean> booleanType() {
+            return new TypedConfigOptionBuilder<>(key, Boolean.class);
+        }
+
+        public TypedConfigOptionBuilder<Integer> intType() {
+            return new TypedConfigOptionBuilder<>(key, Integer.class);
+        }
+
+        public TypedConfigOptionBuilder<Long> longType() {
+            return new TypedConfigOptionBuilder<>(key, Long.class);
+        }
+
+        public TypedConfigOptionBuilder<Float> floatType() {
+            return new TypedConfigOptionBuilder<>(key, Float.class);
+        }
+
+        public TypedConfigOptionBuilder<Double> doubleType() {
+            return new TypedConfigOptionBuilder<>(key, Double.class);
+        }
+
+        public TypedConfigOptionBuilder<String> stringType() {
+            return new TypedConfigOptionBuilder<>(key, String.class);
+        }
+
+        public <T extends Enum<T>> TypedConfigOptionBuilder<T> enumType(Class<T> enumClass) {
+            return new TypedConfigOptionBuilder<>(key, enumClass);
+        }
+    }
+
+    public static class TypedConfigOptionBuilder<T> {
+        private final String key;
+        private final Class<T> clazz;
+        private T defaultValue;
+        private String description;
+
+        TypedConfigOptionBuilder(String key, Class<T> clazz) {
+            this.key = key;
+            this.clazz = clazz;
+        }
+
+        public ListConfigOptionBuilder<T> asList() {
+            return new ListConfigOptionBuilder<>(key, clazz);
+        }
+
+        public TypedConfigOptionBuilder<T> defaultValue(T value) {
+            this.defaultValue = value;
+            return this;
+        }
+
+        public TypedConfigOptionBuilder<T> withDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public ConfigOption<T> build() {
+            return new ConfigOption<>(this);
+        }
+    }
+
+    public static class ListConfigOptionBuilder<E> {
+        private final String key;
+        private final Class<E> clazz;
+
+        ListConfigOptionBuilder(String key, Class<E> clazz) {
+            this.key = key;
+            this.clazz = clazz;
+        }
+    }
+
+    private final String key;
+    private final T defaultValue;
+    private final String description;
+    private final Class<?> clazz;
+
+    public ConfigOption(TypedConfigOptionBuilder<T> builder) {
+        this.key = builder.key;
+        this.description = builder.description;
+        this.defaultValue = builder.defaultValue;
+        this.clazz = builder.clazz;
+    }
+    ConfigOption(String key, String description, T defaultValue, Class<?> clazz) {
+        this.key = key;
+        this.description = description;
+        this.defaultValue = defaultValue;
+        this.clazz = clazz;
+    }
+
+    public String key() {
+        return key;
+    }
+
+    public boolean hasDefaultValue() {
+        return defaultValue != null;
+    }
+
+    public T defaultValue() {
+        return defaultValue;
+    }
+
+    public String description() {
+        return description;
+    }
+
+    Class<?> getClazz() {
+        return clazz;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        ConfigOption<?> that = (ConfigOption<?>) o;
+        return Objects.equals(key, that.key) && Objects.equals(defaultValue, that.defaultValue) && Objects.equals(description, that.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, defaultValue, description);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Key: '%s' , default: %s", key, defaultValue);
+    }
+}

--- a/forge-game/src/main/java/forge/game/config/Configuration.java
+++ b/forge-game/src/main/java/forge/game/config/Configuration.java
@@ -1,0 +1,170 @@
+package forge.game.config;
+
+import java.util.*;
+
+public class Configuration {
+
+    private final HashMap<String, Object> confData;
+
+    public Configuration() {
+        this.confData = new HashMap<>();
+    }
+
+    public <T> Configuration set(ConfigOption<T> option, T value) {
+        setValueInternal(option.key(), value);
+        return this;
+    }
+
+    public <T> T get(ConfigOption<T> option) {
+        return getOptional(option).orElseGet(option::defaultValue);
+    }
+
+    public <T> T get(ConfigOption<T> configOption, T overrideDefault) {
+        return getOptional(configOption).orElse(overrideDefault);
+    }
+
+    public <T> Optional<T> getOptional(ConfigOption<T> option) {
+        Optional<Object> rawValue = getRawValueFromOption(option);
+        Class<?> clazz = option.getClazz();
+        return rawValue.map(v -> convertValue(v, clazz));
+    }
+
+    private <T> Optional<Object> getRawValueFromOption(ConfigOption<T> option) {
+        if (this.confData.containsKey(option.key())) {
+            return Optional.of(confData.get(option.key()));
+        }
+        return Optional.empty();
+    }
+
+    private <T> void setValueInternal(String key, T value) {
+        if (key == null) {
+            throw new NullPointerException("Key must not be null.");
+        }
+        if (value == null) {
+            throw new NullPointerException("Value must not be null.");
+        }
+
+        synchronized (this.confData) {
+            this.confData.put(key, value);
+        }
+    }
+
+    private <T> T convertValue(Object rawValue, Class<?> clazz) {
+        if (Integer.class.equals(clazz)) {
+            return (T) convertToInt(rawValue);
+        } else if (Long.class.equals(clazz)) {
+            return (T) convertToLong(rawValue);
+        } else if (Boolean.class.equals(clazz)) {
+            return (T) convertToBoolean(rawValue);
+        } else if (Float.class.equals(clazz)) {
+            return (T) convertToFloat(rawValue);
+        } else if (Double.class.equals(clazz)) {
+            return (T) convertToDouble(rawValue);
+        } else if (String.class.equals(clazz)) {
+            return (T) convertToString(rawValue);
+        } else if (clazz.isEnum()) {
+            return (T) convertToEnum(rawValue, (Class<? extends Enum<?>>) clazz);
+        }
+
+        throw new IllegalArgumentException("Unsupported type: " + clazz);
+    }
+
+    private Integer convertToInt(Object o) {
+        if (o.getClass() == Integer.class) {
+            return (Integer) o;
+        } else if (o.getClass() == Long.class) {
+            long value = (Long) o;
+            if (value <= Integer.MAX_VALUE && value >= Integer.MIN_VALUE) {
+                return (int) value;
+            } else {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Configuration value %s overflows/underflows the integer type.",
+                                value));
+            }
+        }
+
+        return Integer.parseInt(o.toString());
+    }
+
+    private Long convertToLong(Object o) {
+        if (o.getClass() == Long.class) {
+            return (Long) o;
+        } else if (o.getClass() == Integer.class) {
+            return ((Integer) o).longValue();
+        }
+
+        return Long.parseLong(o.toString());
+    }
+
+    private Boolean convertToBoolean(Object o) {
+        if (o.getClass() == Boolean.class) {
+            return (Boolean) o;
+        }
+
+        return switch (o.toString().toUpperCase()) {
+            case "TRUE" -> true;
+            case "FALSE" -> false;
+            default -> throw new IllegalArgumentException(
+                    String.format(
+                            "Unrecognized option for boolean: %s. Expected either true or false(case insensitive)",
+                            o));
+        };
+    }
+
+    private Float convertToFloat(Object o) {
+        if (o.getClass() == Float.class) {
+            return (Float) o;
+        } else if (o.getClass() == Double.class) {
+            double value = ((Double) o);
+            if (value == 0.0
+                    || (value >= Float.MIN_VALUE && value <= Float.MAX_VALUE)
+                    || (value >= -Float.MAX_VALUE && value <= -Float.MIN_VALUE)) {
+                return (float) value;
+            } else {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Configuration value %s overflows/underflows the float type.",
+                                value));
+            }
+        }
+
+        return Float.parseFloat(o.toString());
+    }
+
+    static Double convertToDouble(Object o) {
+        if (o.getClass() == Double.class) {
+            return (Double) o;
+        } else if (o.getClass() == Float.class) {
+            return ((Float) o).doubleValue();
+        }
+
+        return Double.parseDouble(o.toString());
+    }
+
+    static String convertToString(Object o) {
+        if (o.getClass() == String.class) {
+            return (String) o;
+        }
+
+        return o.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <E extends Enum<?>> E convertToEnum(Object o, Class<E> clazz) {
+        if (o.getClass().equals(clazz)) {
+            return (E) o;
+        }
+
+        return Arrays.stream(clazz.getEnumConstants())
+                .filter(e -> e.toString().toUpperCase(Locale.ROOT).equals(o.toString().toUpperCase(Locale.ROOT)))
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        String.format("Could not parse value for enum %s. Expected one of: [%s]",
+                                clazz,
+                                Arrays.toString(clazz.getEnumConstants())
+                        )
+                ));
+    }
+
+}

--- a/forge-game/src/main/java/forge/game/cost/CostPayment.java
+++ b/forge-game/src/main/java/forge/game/cost/CostPayment.java
@@ -144,7 +144,7 @@ public class CostPayment extends ManaConversionMatrix {
 
         for (final CostPart part : costParts) {
             // Wrap the cost and push onto the cost stack
-            game.costPaymentStack.push(part, this);
+            game.costPaymentStack().push(part, this);
 
             PaymentDecision pd = part.accept(decisionMaker);
 
@@ -154,11 +154,11 @@ public class CostPayment extends ManaConversionMatrix {
             }
 
             if (pd == null || !part.payAsDecided(decisionMaker.getPlayer(), pd, ability, decisionMaker.isEffect())) {
-                game.costPaymentStack.pop(); // cost is resolved
+                game.costPaymentStack().pop(); // cost is resolved
                 return false;
             }
             this.paidCostParts.add(part);
-            game.costPaymentStack.pop(); // cost is resolved
+            game.costPaymentStack().pop(); // cost is resolved
         }
 
         // this clears lists used for undo. 
@@ -191,22 +191,22 @@ public class CostPayment extends ManaConversionMatrix {
             if (null == decision) return false;
 
             // wrap the payment and push onto the cost stack
-            game.costPaymentStack.push(part, this);
+            game.costPaymentStack().push(part, this);
             if (decisionMaker.paysRightAfterDecision() && !part.payAsDecided(decisionMaker.getPlayer(), decision, ability, decisionMaker.isEffect())) {
-                game.costPaymentStack.pop(); // cost is resolved
+                game.costPaymentStack().pop(); // cost is resolved
                 return false;
             }
 
-            game.costPaymentStack.pop(); // cost is either paid or deferred
+            game.costPaymentStack().pop(); // cost is either paid or deferred
             decisions.put(part, decision);
         }
 
         for (final CostPart part : parts) {
             // wrap the payment and push onto the cost stack
-            game.costPaymentStack.push(part, this);
+            game.costPaymentStack().push(part, this);
 
             if (!part.payAsDecided(decisionMaker.getPlayer(), decisions.get(part), this.ability, decisionMaker.isEffect())) {
-                game.costPaymentStack.pop(); // cost is resolved
+                game.costPaymentStack().pop(); // cost is resolved
                 return false;
             }
             // abilities care what was used to pay for them
@@ -214,7 +214,7 @@ public class CostPayment extends ManaConversionMatrix {
                 ((CostPartWithList) part).resetLists();
             }
 
-            game.costPaymentStack.pop(); // cost is resolved
+            game.costPaymentStack().pop(); // cost is resolved
         }
         return true;
     }

--- a/forge-game/src/main/java/forge/game/phase/PhaseHandler.java
+++ b/forge-game/src/main/java/forge/game/phase/PhaseHandler.java
@@ -1070,7 +1070,7 @@ public class PhaseHandler implements java.io.Serializable {
                             // 117.3c If a player has priority when they cast a spell, activate an ability, [play a land]
                             // that player receives priority afterward.
                             pFirstPriority = pPlayerPriority; // all opponents have to pass before stack is allowed to resolve
-                        } else if (game.EXPERIMENTAL_RESTORE_SNAPSHOT) {
+                        } else if (game.configuration().get(GameOptions.EXPERIMENTAL_RESTORE_SNAPSHOT)) {
                             rollback = true;
                         }
 

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -2335,8 +2335,8 @@ public class Player extends GameEntity implements Comparable<Player> {
         // use a copy that preserves last known information about the card (e.g. for Savra, Queen of the Golgari + Painter's Servant)
         runParams.put(AbilityKey.Card, cpy);
         runParams.put(AbilityKey.Cause, source);
-        runParams.put(AbilityKey.CostStack, game.costPaymentStack);
-        runParams.put(AbilityKey.IndividualCostPaymentInstance, game.costPaymentStack.peek());
+        runParams.put(AbilityKey.CostStack, game.costPaymentStack());
+        runParams.put(AbilityKey.IndividualCostPaymentInstance, game.costPaymentStack().peek());
         game.getTriggerHandler().runTrigger(TriggerType.Sacrificed, runParams, false);
     }
 

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbilityRestriction.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbilityRestriction.java
@@ -546,7 +546,7 @@ public class SpellAbilityRestriction extends SpellAbilityVariables {
 
         // Rule 605.3c about Mana Abilities
         if (sa.isManaAbility()) {
-            for (IndividualCostPaymentInstance i : game.costPaymentStack) {
+            for (IndividualCostPaymentInstance i : game.costPaymentStack()) {
                 if (i.getPayment().getAbility().equals(sa)) {
                     return false;
                 }
@@ -611,7 +611,7 @@ public class SpellAbilityRestriction extends SpellAbilityVariables {
         }
 
         // Special check for Lion's Eye Diamond
-        if (sa.isManaAbility() && c.getGame().costPaymentStack.peek() != null && isInstantSpeed()) {
+        if (sa.isManaAbility() && c.getGame().costPaymentStack().peek() != null && isInstantSpeed()) {
             return false;
         }
 

--- a/forge-game/src/main/java/forge/game/zone/MagicStack.java
+++ b/forge-game/src/main/java/forge/game/zone/MagicStack.java
@@ -285,7 +285,7 @@ public class MagicStack /* extends MyObservable */ implements Iterable<SpellAbil
             sp.resetOnceResolved();
 
             // parts are paid sequentially, so collect directly or some trigger might get lost
-            if (game.costPaymentStack.peek() != null) {
+            if (game.costPaymentStack().peek() != null) {
                 game.getTriggerHandler().collectTriggerForWaiting();
             }
             return;

--- a/forge-game/src/test/java/forge/game/config/ConfigurationTest.java
+++ b/forge-game/src/test/java/forge/game/config/ConfigurationTest.java
@@ -1,0 +1,103 @@
+package forge.game.config;
+
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+import static forge.game.config.ConfigOption.key;
+
+public class ConfigurationTest {
+
+    @Test
+    public void testConfiguration() {
+
+        enum TestEnum {
+            FOO, BAR, BAT
+        }
+
+        ConfigOption<Boolean> BOOLEAN_CONFIG_TEST =
+                key("test.boolean-value")
+                        .booleanType()
+                        .defaultValue(true)
+                        .withDescription("a test for boolean value")
+                        .build();
+
+        ConfigOption<Integer> INT_CONFIG_TEST =
+                key("test.integer-value")
+                        .intType()
+                        .defaultValue(Integer.MAX_VALUE)
+                        .withDescription("a test for integers")
+                        .build();
+
+        ConfigOption<Long> LONG_CONFIG_TEST =
+                key("test.long-value")
+                        .longType()
+                        .defaultValue(Long.MAX_VALUE)
+                        .withDescription("a test for longs")
+                        .build();
+
+        ConfigOption<Float> FLOAT_CONFIG_TEST =
+                key("test.float-value")
+                        .floatType()
+                        .defaultValue(Float.MAX_VALUE)
+                        .withDescription("a test for integers")
+                        .build();
+
+        ConfigOption<Double> DOUBLE_CONFIG_TEST =
+                key("test.double-value")
+                        .doubleType()
+                        .defaultValue(Double.MAX_VALUE)
+                        .withDescription("a test for integers")
+                        .build();
+
+        ConfigOption<String> STRING_CONFIG_TEST =
+                key("test.string-value")
+                        .stringType()
+                        .defaultValue("A String Value")
+                        .withDescription("a test for Strings")
+                        .build();
+
+        ConfigOption<TestEnum> ENUM_CONFIG_TEST =
+                key("test.enum-value")
+                        .enumType(TestEnum.class)
+                        .defaultValue(TestEnum.FOO)
+                        .withDescription("a test for enums")
+                        .build();
+
+        final Configuration config = new Configuration();
+
+        // Check default values
+        AssertJUnit.assertSame(Boolean.TRUE, config.get(BOOLEAN_CONFIG_TEST));
+        AssertJUnit.assertEquals(Integer.MAX_VALUE, (int) config.get(INT_CONFIG_TEST));
+        AssertJUnit.assertEquals(Long.MAX_VALUE, (long) config.get(LONG_CONFIG_TEST));
+        AssertJUnit.assertEquals(Float.MAX_VALUE, config.get(FLOAT_CONFIG_TEST));
+        AssertJUnit.assertEquals(Double.MAX_VALUE, config.get(DOUBLE_CONFIG_TEST));
+        AssertJUnit.assertEquals("A String Value", config.get(STRING_CONFIG_TEST));
+        AssertJUnit.assertEquals(TestEnum.FOO, config.get(ENUM_CONFIG_TEST));
+
+        // Check overrides
+        AssertJUnit.assertSame(Boolean.FALSE, config.get(BOOLEAN_CONFIG_TEST, false));
+        AssertJUnit.assertEquals(666, (int) config.get(INT_CONFIG_TEST, 666));
+        AssertJUnit.assertEquals(1_000_000_000L, (long) config.get(LONG_CONFIG_TEST, 1_000_000_000L));
+        AssertJUnit.assertEquals(6.02e23f, config.get(FLOAT_CONFIG_TEST, 6.02e23f));
+        AssertJUnit.assertEquals(3.141592653589793, config.get(DOUBLE_CONFIG_TEST, 3.141592653589793));
+        AssertJUnit.assertEquals("A Different Value", config.get(STRING_CONFIG_TEST, "A Different Value"));
+        AssertJUnit.assertEquals(TestEnum.BAR, config.get(ENUM_CONFIG_TEST, TestEnum.BAR));
+
+        config.set(BOOLEAN_CONFIG_TEST, Boolean.FALSE);
+        config.set(INT_CONFIG_TEST, 666);
+        config.set(LONG_CONFIG_TEST, 1_000_000_000L);
+        config.set(FLOAT_CONFIG_TEST, 6.02e23f);
+        config.set(DOUBLE_CONFIG_TEST, 3.141592653589793);
+        config.set(STRING_CONFIG_TEST, "A Different Value");
+        config.set(ENUM_CONFIG_TEST, TestEnum.BAR);
+
+        // Check set values
+        AssertJUnit.assertSame(Boolean.FALSE, config.get(BOOLEAN_CONFIG_TEST));
+        AssertJUnit.assertEquals(666, (int) config.get(INT_CONFIG_TEST));
+        AssertJUnit.assertEquals(1_000_000_000L, (long) config.get(LONG_CONFIG_TEST));
+        AssertJUnit.assertEquals(6.02e23f, config.get(FLOAT_CONFIG_TEST));
+        AssertJUnit.assertEquals(3.141592653589793, config.get(DOUBLE_CONFIG_TEST));
+        AssertJUnit.assertEquals("A Different Value", config.get(STRING_CONFIG_TEST));
+        AssertJUnit.assertEquals(TestEnum.BAR, config.get(ENUM_CONFIG_TEST));
+    }
+}

--- a/forge-gui-desktop/src/test/java/forge/ai/simulation/SimulationTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/simulation/SimulationTest.java
@@ -13,11 +13,7 @@ import forge.ai.AIOption;
 import forge.ai.LobbyPlayerAi;
 import forge.ai.simulation.GameStateEvaluator.Score;
 import forge.deck.Deck;
-import forge.game.Game;
-import forge.game.GameRules;
-import forge.game.GameStage;
-import forge.game.GameType;
-import forge.game.Match;
+import forge.game.*;
 import forge.game.card.Card;
 import forge.game.card.CardCollectionView;
 import forge.game.card.CardFactory;
@@ -44,11 +40,11 @@ public class SimulationTest {
         players.add(new RegisteredPlayer(d1).setPlayer(new LobbyPlayerAi("p1", options)));
         GameRules rules = new GameRules(GameType.Constructed);
         Match match = new Match(rules, players, "Test");
-        Game game = new Game(players, rules, match);
+        Game game = new GameImpl(players, rules, match);
         game.setAge(GameStage.Play);
-        game.EXPERIMENTAL_RESTORE_SNAPSHOT = false;
-        game.AI_TIMEOUT = FModel.getPreferences().getPrefInt(FPref.MATCH_AI_TIMEOUT);
-        game.AI_CAN_USE_TIMEOUT = true; //Only Android is restricted according to API Level
+        game.configuration().set(GameOptions.EXPERIMENTAL_RESTORE_SNAPSHOT, false);
+        game.configuration().set(GameOptions.AI_TIMEOUT, FModel.getPreferences().getPrefInt(FPref.MATCH_AI_TIMEOUT));
+        game.configuration().set(GameOptions.AI_CAN_USE_TIMEOUT, true); //Only Android is restricted according to API Level
 
         return game;
     }

--- a/forge-gui/src/main/java/forge/gamemodes/match/HostedMatch.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/HostedMatch.java
@@ -153,11 +153,11 @@ public class HostedMatch {
         SoundSystem.instance.setBackgroundMusic(this.matchPlaylist == null ? MusicPlaylist.MATCH : this.matchPlaylist);
 
         game = match.createGame();
-        game.EXPERIMENTAL_RESTORE_SNAPSHOT = FModel.getPreferences().getPrefBoolean(FPref.MATCH_EXPERIMENTAL_RESTORE);
-        game.AI_TIMEOUT = FModel.getPreferences().getPrefInt(FPref.MATCH_AI_TIMEOUT);
+        game.configuration().set(GameOptions.EXPERIMENTAL_RESTORE_SNAPSHOT, FModel.getPreferences().getPrefBoolean(FPref.MATCH_EXPERIMENTAL_RESTORE));
+        game.configuration().set(GameOptions.AI_TIMEOUT, FModel.getPreferences().getPrefInt(FPref.MATCH_AI_TIMEOUT));
         // Android API 31 and above can use completeOnTimeout -> CompletableFuture:
         //https://developer.android.com/reference/java/util/concurrent/CompletableFuture#completeOnTimeout(T,%20long,%20java.util.concurrent.TimeUnit)
-        game.AI_CAN_USE_TIMEOUT = !GuiBase.isAndroid() || GuiBase.getAndroidAPILevel() > 30;
+        game.configuration().set(GameOptions.AI_CAN_USE_TIMEOUT, !GuiBase.isAndroid() || GuiBase.getAndroidAPILevel() > 30);
 
         StaticData.instance().setSourceImageForClone(FModel.getPreferences().getPrefBoolean(FPref.UI_CLONE_MODE_SOURCE));
 

--- a/forge-gui/src/main/java/forge/player/HumanCostDecision.java
+++ b/forge-gui/src/main/java/forge/player/HumanCostDecision.java
@@ -671,7 +671,7 @@ public class HumanCostDecision extends CostDecisionMakerBase {
         // for costs declared mandatory, this is only reachable with a valid amount
         if (player.canPayLife(c, isEffect(), ability) && confirmAction(cost, message)) {
             //force mandatory if paylife is paid.. todo add check if all can be paid
-            if (!player.getGame().EXPERIMENTAL_RESTORE_SNAPSHOT) {
+            if (!player.getGame().configuration().get(GameOptions.EXPERIMENTAL_RESTORE_SNAPSHOT)) {
                 // If we can restore the game state, don't force the SA to be mandatory
                 mandatory = true;
             }

--- a/forge-gui/src/main/java/forge/player/HumanPlay.java
+++ b/forge-gui/src/main/java/forge/player/HumanPlay.java
@@ -3,10 +3,7 @@ package forge.player;
 import com.google.common.collect.Iterables;
 import forge.card.CardStateName;
 import forge.card.mana.ManaCost;
-import forge.game.Game;
-import forge.game.GameActionUtil;
-import forge.game.GameEntityView;
-import forge.game.GameEntityViewMap;
+import forge.game.*;
 import forge.game.ability.AbilityKey;
 import forge.game.ability.AbilityUtils;
 import forge.game.card.*;
@@ -90,7 +87,7 @@ public class HumanPlay {
 
         final HumanPlaySpellAbility req = new HumanPlaySpellAbility(controller, sa);
         if (!req.playAbility(true, false, false)) {
-            if (!controller.getGame().EXPERIMENTAL_RESTORE_SNAPSHOT) {
+            if (!controller.getGame().configuration().get(GameOptions.EXPERIMENTAL_RESTORE_SNAPSHOT)) {
                 Card rollback = p.getGame().getCardState(source);
                 if (castFaceDown) {
                     rollback.setFaceDown(false);

--- a/forge-gui/src/main/java/forge/player/HumanPlaySpellAbility.java
+++ b/forge-gui/src/main/java/forge/player/HumanPlaySpellAbility.java
@@ -22,6 +22,7 @@ import forge.card.CardType;
 import forge.game.Game;
 import forge.game.GameActionUtil;
 import forge.game.GameObject;
+import forge.game.GameOptions;
 import forge.game.ability.AbilityUtils;
 import forge.game.ability.ApiType;
 import forge.game.ability.effects.CharmEffect;
@@ -169,7 +170,7 @@ public class HumanPlaySpellAbility {
 
             if (ability.isTrigger()) {
                 // Only roll back triggers if they were not paid for
-                if (game.EXPERIMENTAL_RESTORE_SNAPSHOT && preCostRequisites) {
+                if (game.configuration().get(GameOptions.EXPERIMENTAL_RESTORE_SNAPSHOT) && preCostRequisites) {
                     GameActionUtil.rollbackAbility(ability, fromZone, zonePosition, payment, c);
                 } else {
                     // If precost requsities failed, then there probably isn't anything to refund during experimental

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -592,7 +592,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
 
             cost.decreaseGenericMana(willPay);
             return true;
-        } else if (sa.getHostCard().getGame().EXPERIMENTAL_RESTORE_SNAPSHOT) {
+        } else if (sa.getHostCard().getGame().configuration().get(GameOptions.EXPERIMENTAL_RESTORE_SNAPSHOT)) {
             // Let's roll it back!
             return false;
         } else {
@@ -2365,7 +2365,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
     }
 
     public boolean canUndoLastAction() {
-        if (!getGame().stack.canUndo(player)) {
+        if (!getGame().stack().canUndo(player)) {
             return false;
         }
         final Player priorityPlayer = getGame().getPhaseHandler().getPriorityPlayer();


### PR DESCRIPTION
We've been loving the game and have been very impressed with the AI controller.  Looking to get more involved and possibly make some more substantial suggestions.  But before that happens I thought it might be best to do some small refactoring and throw some of the major parts of the implementation behind an interface.

While moving Game behind an interface, I had to move certain public fields into a configuration object.  Borrowed the style from some of my favorite open source projects.  This is not necessarily tied to the refactor of Game and we can separate them.  Might also be useful to replace other parts of the code where we have settings with the Configuration object.