### PR TITLE
True-Name Nemesis crashes on "$" Player name

### DIFF
--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
@@ -43,6 +43,7 @@ import forge.util.TextUtil;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
+import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 
 /**
@@ -273,7 +274,7 @@ public final class StaticAbilityContinuous {
                     if (hostCard.hasChosenPlayer()) {
                         Player cp = hostCard.getChosenPlayer();
                         input = input.replaceAll("ChosenPlayerUID", String.valueOf(cp.getId()));
-                        input = input.replaceAll("ChosenPlayerName", cp.getName());
+                        input = input.replaceAll("ChosenPlayerName", Matcher.quoteReplacement(cp.getName()));
                     }
                     if (hostCard.hasNamedCard()) {
                         final String chosenName = hostCard.getNamedCard().replace(",", ";");


### PR DESCRIPTION
Game-0 > java.lang.IllegalArgumentException: Illegal group reference: group index is missing
	at java.base/java.util.regex.Matcher.appendExpandedReplacement(Matcher.java:1029)
	at java.base/java.util.regex.Matcher.appendReplacement(Matcher.java:997)
	at java.base/java.util.regex.Matcher.replaceAll(Matcher.java:1181)
	at java.base/java.lang.String.replaceAll(String.java:2946)
	at forge.game.staticability.StaticAbilityContinuous.lambda$applyContinuousAbility$1(StaticAbilityContinuous.java:276)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at forge.game.staticability.StaticAbilityContinuous.applyContinuousAbility(StaticAbilityContinuous.java:291)
	at forge.game.staticability.StaticAbilityContinuous.applyContinuousAbility(StaticAbilityContinuous.java:71)
	at forge.game.staticability.StaticAbility.applyContinuousAbilityBefore(StaticAbility.java:275)
	at forge.game.GameAction.checkStaticAbilities(GameAction.java:1156)
	at forge.game.GameAction.checkStaticAbilities(GameAction.java:1095)
	at forge.game.GameAction.checkStaticAbilities(GameAction.java:1092)
	at forge.game.GameAction.changeZone(GameAction.java:555)
	at forge.game.GameAction.moveTo(GameAction.java:793)
	at forge.game.GameAction.moveTo(GameAction.java:750)
	at forge.game.GameAction.moveToPlay(GameAction.java:885)
	at forge.game.ability.effects.PermanentEffect.resolve(PermanentEffect.java:31)