### PR TITLE
Non-alchemy sets cleanup

### DIFF
--- a/forge-gui/res/blockdata/blocks.txt
+++ b/forge-gui/res/blockdata/blocks.txt
@@ -32,11 +32,11 @@ Ravnica, 3/6/RAV, RAV GPT DIS
 Coldsnap, 3/6/9ED, CSP  
 Time Spiral, 3/6/TSP, TSP PLC FUT
 Tenth Edition, 3/6/10E, 10E  
-Masters Edition, 3/6/MED, MED
+Masters Edition, 3/6/ME1, ME1
 Lorwyn, 3/6/LRW, LRW MOR 
 Shadowmoor, 3/6/SHM, SHM EVE 
 Shards of Alara, 3/6/ALA, ALA CFX ARB
-Masters Edition II, 3/6/MED, ME2
+Masters Edition II, 3/6/ME2, ME2
 Magic 2010, 3/6/M10, M10  
 Masters Edition III, 3/6/ME3, ME3
 Zendikar, 3/6/ZEN, ZEN WWK 

--- a/forge-gui/res/cube/MTGO Vintage Cube 2025-04.dck
+++ b/forge-gui/res/cube/MTGO Vintage Cube 2025-04.dck
@@ -21,7 +21,7 @@ name=MTGO Vintage Cube 2025-04
 1 Adeline, Resplendent Cathar|MID
 1 Clarion Conqueror|TDM
 1 Elite Spellbinder|SLC
-1 Enduring Innocence|PDSK
+1 Enduring Innocence|DSK
 1 Flickerwisp|2X2
 1 Loran of the Third Path|BRO
 1 Monastery Mentor|FRF
@@ -147,7 +147,7 @@ name=MTGO Vintage Cube 2025-04
 1 Barrowgoyf|M3C
 1 Preacher of the Schism|LCI
 1 Qarsi Revenant|TDM
-1 Sedgemoor Witch|PSTX
+1 Sedgemoor Witch|STX
 1 Grief|MH2
 1 Sheoldred, the Apocalypse|DMU
 1 Harvester of Misery|BIG
@@ -227,7 +227,7 @@ name=MTGO Vintage Cube 2025-04
 1 Headliner Scarlett|CLU
 1 Pyrogoyf|M3C
 1 Rampaging Raptor|MOM
-1 Bonehoard Dracosaur|PLCI
+1 Bonehoard Dracosaur|LCI
 1 Fury|SPG
 1 Glorybringer|AKH
 1 Goldspan Dragon|KHM
@@ -324,7 +324,7 @@ name=MTGO Vintage Cube 2025-04
 1 Emrakul, the Aeons Torn|2X2
 1 Triplicate Titan|C21
 1 Ulamog, the Infinite Gyre|MM2
-1 Karn, Scion of Urza|MED
+1 Karn, Scion of Urza|MPS_RNA
 1 The Aetherspark|DFT
 1 Ugin, Eye of the Storms|TDM
 1 Black Lotus|2ED
@@ -459,7 +459,7 @@ name=MTGO Vintage Cube 2025-04
 1 Watery Grave|GTC
 1 Badlands|3ED
 1 Blackcleave Cliffs|ZNE
-1 Blazemire Verge|PDSK
+1 Blazemire Verge|DSK
 1 Blood Crypt|RNA
 1 Raucous Theater|MKM
 1 Commercial District|MKM
@@ -484,7 +484,7 @@ name=MTGO Vintage Cube 2025-04
 1 Volcanic Island|3ED
 1 Bayou|3ED
 1 Blooming Marsh|SLD
-1 Overgrown Tomb|PGRN
+1 Overgrown Tomb|GRN
 1 Underground Mortuary|MKM
 1 Wastewood Verge|DFT
 1 Inspiring Vantage|SLD
@@ -513,7 +513,7 @@ name=MTGO Vintage Cube 2025-04
 1 Arid Mesa|MM3
 1 Bloodstained Mire|ONS
 1 Boseiju, Who Endures|NEO
-1 City of Traitors|WC99
+1 City of Traitors|EXO
 1 Dark Depths|2XM
 1 Fabled Passage|SLD
 1 Field of the Dead|M20

--- a/forge-gui/res/editions/30th Anniversary Celebration Tokyo.txt
+++ b/forge-gui/res/editions/30th Anniversary Celebration Tokyo.txt
@@ -4,6 +4,7 @@ Date=2023-09-01
 Name=30th Anniversary Celebration Tokyo
 Type=Promo
 ScryfallCode=P30T
+CardLang=ja
 
 [cards]
 1 R Destroy Evil @Naoki Saito

--- a/forge-gui/res/editions/Amonkhet Invocations.txt
+++ b/forge-gui/res/editions/Amonkhet Invocations.txt
@@ -1,9 +1,10 @@
 [metadata]
-Code=MPS_AKH
+Code=MP2
+Code2=MPS_AKH
 Date=2017-04-28
-Name=Masterpiece Series - Amonkhet
+Name=Amonkhet Invocations
 Type=Collector_Edition
-ScryfallCode=mp2
+ScryfallCode=MP2
 
 #Bonus cards for AKH Amonkhet
 [cards]

--- a/forge-gui/res/editions/Commander Collection Black.txt
+++ b/forge-gui/res/editions/Commander Collection Black.txt
@@ -4,6 +4,7 @@ Date=2022-01-28
 Name=Commander Collection Black
 Type=Collector_Edition
 ScryfallCode=CC2
+TokensCode=CC2
 
 [cards]
 1 M Liliana, Heretical Healer @Bastien L. Deharme
@@ -16,5 +17,5 @@ ScryfallCode=CC2
 8 R Command Tower @Julian Kok Joon Wen
 
 [tokens]
-b_1_1_snake_deathtouch
+9 b_1_1_snake_deathtouch @Caroline Gariba & Xavier Ribeiro
 b_2_2_zombie

--- a/forge-gui/res/editions/DCI Promos.txt
+++ b/forge-gui/res/editions/DCI Promos.txt
@@ -56,6 +56,7 @@ ScryfallCode=DCI
 48 R Staggershock @Raymond Swanland
 49 R Deathless Angel @Johann Bodin
 50 R Fling @Daren Bader
+50† R Fling @Daren Bader
 51 R Sylvan Ranger @Ciruelo
 52 C Liliana's Specter @Jaime Jones
 53 R Mitotic Slime @Ron Spencer

--- a/forge-gui/res/editions/Dominaria United Promos.txt
+++ b/forge-gui/res/editions/Dominaria United Promos.txt
@@ -1,0 +1,9 @@
+[metadata]
+Code=PDMU
+Date=2022-09-09
+Name=Dominaria United Promos
+Type=Promo
+ScryfallCode=PDMU
+
+[cards]
+1★ R Llanowar Elves @Chris Rahn

--- a/forge-gui/res/editions/Eighth Edition Promos.txt
+++ b/forge-gui/res/editions/Eighth Edition Promos.txt
@@ -7,3 +7,6 @@ ScryfallCode=P8ED
 
 [cards]
 216★ R Rukh Egg @Mark Zug
+
+[tokens]
+r_4_4_bird_flying

--- a/forge-gui/res/editions/Eternal Weekend.txt
+++ b/forge-gui/res/editions/Eternal Weekend.txt
@@ -12,3 +12,5 @@ ScryfallCode=PEWK
 2023b R Dragon's Rage Channeler @Patrik Hell
 2024a M Tinker @Jason Rainville
 2024b R Crop Rotation @Samuele Bandini
+2025a R Tendrils of Agony @Chuck Lukacs
+2025b M Trinisphere @Steven Belledin

--- a/forge-gui/res/editions/Final Fantasy Regional Promos.txt
+++ b/forge-gui/res/editions/Final Fantasy Regional Promos.txt
@@ -4,6 +4,7 @@ Date=2025-06-13
 Name=Final Fantasy Regional Promos
 Type=Promo
 ScryfallCode=RFIN
+CardLang=ja
 
 [cards]
 J1 R Force of Negation @Ittoku

--- a/forge-gui/res/editions/Game Day Promos.txt
+++ b/forge-gui/res/editions/Game Day Promos.txt
@@ -15,3 +15,7 @@ ScryfallCode=GDY
 7 R Recruitment Officer @Zoltan Boros
 8 R Braids, Arisen Nightmare @Anastasia Balakchina
 9 M Surge Engine @Volkan Baǵa
+
+[tokens]
+u_x_x_illusion
+g_4_4_rhino_warrior

--- a/forge-gui/res/editions/Happy Holidays.txt
+++ b/forge-gui/res/editions/Happy Holidays.txt
@@ -5,16 +5,19 @@ Name=Happy Holidays
 Type=Funny
 Border=Silver
 ScryfallCode=HHO
+TokensCode=HHO
 
 [cards]
 6 R Fruitcake Elemental @Darrell Riche
 7 R Gifts Given @Jason Chan
+7† R Gifts Given @Jason Chan
 8 R Evil Presents @Paul Bonner
 9 R Season's Beatings @Kev Walker
 10 R Snow Mercy @rk post
 11 R Yule Ooze @Steve Prescott
 12 R Naughty // Nice @Greg Staples
 13 R Stocking Tiger @Terese Nielsen
+13† R Stocking Tiger @Terese Nielsen
 14 M Mishra's Toy Workshop @Jung Park
 15 M Goblin Sleigh Ride @Mark Zug
 16 M Thopter Pie Network @Victor Adame Minguez
@@ -28,4 +31,4 @@ ScryfallCode=HHO
 24 M Eggnogger's 'Stache @Arif Wijaya
 
 [tokens]
-c_a_treasure_sac
+21★ c_a_treasure_sac @Rachta Lin

--- a/forge-gui/res/editions/Japan Standard Cup.txt
+++ b/forge-gui/res/editions/Japan Standard Cup.txt
@@ -4,6 +4,7 @@ Date=2025-02-09
 Name=Japan Standard Cup
 Type=Promo
 ScryfallCode=PJSC
+CardLang=ja
 
 [cards]
 2025-1 R Tishana's Tidebinder @Hagiya Kaoru

--- a/forge-gui/res/editions/Magic Player Rewards 2003.txt
+++ b/forge-gui/res/editions/Magic Player Rewards 2003.txt
@@ -4,13 +4,15 @@ Date=2003-01-01
 Name=Magic Player Rewards 2003
 Type=Promo
 ScryfallCode=P03
+TokensCode=P03
 
 [cards]
 1 R Voidmage Prodigy @Christopher Moeller
 
 [tokens]
-g_1_1_insect
-c_1_1_sliver
-g_2_2_bear
-r_1_1_goblin
-b_x_x_demon_flying
+2 g_1_1_insect @Anthony S. Waters
+3 c_1_1_sliver @Tony Szczudlo
+4 g_2_2_bear @Glen Angus
+5 r_1_1_goblin @Darrell Riche
+6 b_x_x_demon_flying @Pete Venters
+7 r_4_4_bird_flying @Edward P. Beard, Jr.

--- a/forge-gui/res/editions/Magic x Duel Masters Promos.txt
+++ b/forge-gui/res/editions/Magic x Duel Masters Promos.txt
@@ -4,6 +4,7 @@ Date=2023-09-08
 Name=Magic x Duel Masters Promos
 Type=Promo
 ScryfallCode=PMDA
+CardLang=ja
 
 [cards]
 1 R Nicol Bolas @Toshiaki Takayama

--- a/forge-gui/res/editions/Masters Edition.txt
+++ b/forge-gui/res/editions/Masters Edition.txt
@@ -1,8 +1,8 @@
 [metadata]
-Code=MED
+Code=ME1
+Code2=MED
 Date=2007-09-10
 Name=Masters Edition
-Code2=MED
 Type=Online
 BoosterCovers=1
 Booster=10 Common, 3 Uncommon, 1 Rare, 1 BasicLand

--- a/forge-gui/res/editions/Mythic Edition - Guilds of Ravnica.txt
+++ b/forge-gui/res/editions/Mythic Edition - Guilds of Ravnica.txt
@@ -3,7 +3,7 @@ Code=MPS_GRN
 Date=2018-10-05
 Name=Mythic Edition - Guilds of Ravnica
 Type=Collector_Edition
-ScryfallCode=med
+ScryfallCode=MED
 
 [cards]
 GR1 M Elspeth, Knight-Errant @Zack Stella
@@ -19,3 +19,10 @@ GR8 M Vraska, Golgari Queen @Livia Prima
 G1 w_1_1_soldier @Goran Josic
 G2 b_2_2_zombie @Anna Steinbauer
 G3 c_1_1_a_construct_defender @Victor Adame Minguez
+
+[other]
+G4 emblem_elspeth_knight_errant @Zack Stella
+G5 emblem_liliana_the_last_hope @Kieran Yanner
+G6 emblem_ral_izzet_viceroy @Daniel Ljunggren
+G7 emblem_teferi_hero_of_dominaria @Yongjae Choi
+G8 emblem_vraska_golgari_queen @Livia Prima

--- a/forge-gui/res/editions/Mythic Edition - Ravnica Allegiance.txt
+++ b/forge-gui/res/editions/Mythic Edition - Ravnica Allegiance.txt
@@ -3,7 +3,7 @@ Code=MPS_RNA
 Date=2018-10-05
 Name=Mythic Edition - Ravnica Allegiance
 Type=Collector_Edition
-ScryfallCode=med
+ScryfallCode=MED
 
 [cards]
 RA1 M Karn, Scion of Urza @Adam Paquette
@@ -17,3 +17,8 @@ RA8 M Kaya, Orzhov Usurper @Chris Rallis
 
 [tokens]
 R1 c_0_0_a_construct_total_artifacts @Victor Adame Minguez
+
+[other]
+R2 emblem_dack_fayden @Jason Rainville
+R3 emblem_domri_chaos_bringer @Jason Rainville
+R4 emblem_jaya_ballard @Kieran Yanner

--- a/forge-gui/res/editions/Mythic Edition - War of the Spark.txt
+++ b/forge-gui/res/editions/Mythic Edition - War of the Spark.txt
@@ -3,7 +3,7 @@ Code=MPS_WAR
 Date=2018-10-05
 Name=Mythic Edition - War of the Spark
 Type=Collector_Edition
-ScryfallCode=med
+ScryfallCode=MED
 
 [cards]
 WS1 M Ugin, the Spirit Dragon @Chris Rahn
@@ -18,3 +18,6 @@ WS8 M Sarkhan Unbroken @Eric Deschamps
 [tokens]
 W1 b_3_3_beast_deathtouch @Dave Kendall
 W2 r_4_4_dragon_flying @Raymond Swanland
+
+[other]
+W3 emblem_garruk_apex_predator @Victor Adame Minguez

--- a/forge-gui/res/editions/Rivals of Ixalan Promos.txt
+++ b/forge-gui/res/editions/Rivals of Ixalan Promos.txt
@@ -8,6 +8,10 @@ ScryfallCode=PRIX
 [cards]
 53 U Silvergill Adept @Slawomir Maniak
 94 R Brass's Bounty @Dimitar Marinski
+100★ Etali, Primal Storm @Raymond Swanland
 130 R Ghalta, Primal Hunger @Johann Bodin
 177 R Captain's Hook @Kev Walker
 186 C Evolving Wilds @Daniel Ljunggren
+
+[tokens]
+c_a_treasure_sac

--- a/forge-gui/res/editions/Secret Lair Showdown.txt
+++ b/forge-gui/res/editions/Secret Lair Showdown.txt
@@ -38,6 +38,8 @@ ScryfallCode=SLP
 30 M Living End @Nathan Jurevicius
 31 R Plains @John Avon
 32 R Island @John Avon
+33 R Swamp @John Avon
+34 R Mountain @John Avon
 36 M Karn Liberated @Kieran Yanner
 37 R Lightning Bolt @Peach Momoko
 38 R Questing Druid @Jordan Speer
@@ -45,3 +47,5 @@ ScryfallCode=SLP
 40 R Prosperous Innkeeper @Brett Stenson
 41 R Fauna Shaman @Nature Nurture
 42 M Garruk Wildspeaker @Merwan Chabane
+43 R Shoot the Sheriff @Dan Black
+44 R Laughing Jasper Flint @Ed Repka

--- a/forge-gui/res/editions/Theros Beyond Death Promos.txt
+++ b/forge-gui/res/editions/Theros Beyond Death Promos.txt
@@ -1,0 +1,9 @@
+[metadata]
+Code=PTHB
+Date=2020-01-24
+Name=Theros: Beyond Death Promos
+Type=Promo
+ScryfallCode=PTHB
+
+[cards]
+235★ R Nyx Lotus @Raoul Vitale

--- a/forge-gui/res/editions/URL Convention Promos.txt
+++ b/forge-gui/res/editions/URL Convention Promos.txt
@@ -16,3 +16,7 @@ ScryfallCode=PURL
 23 R Kor Skyfisher @Dan Murayama Scott
 34★ U Shepherd of the Lost @Kekai Kotaki
 445 M Ral, Monsoon Mage @Borja Pindado
+2025-1 Hylda of the Icy Crown @Yakotakos
+
+[tokens]
+wu_4_4_elemental

--- a/forge-gui/res/editions/Year of the Dragon 2024.txt
+++ b/forge-gui/res/editions/Year of the Dragon 2024.txt
@@ -4,6 +4,7 @@ Date=2024-02-08
 Name=Year of the Dragon 2024
 Type=Promo
 ScryfallCode=PL24
+TokensCode=PL24
 
 [cards]
 1 R Dragonlord's Servant @Song Qijin
@@ -14,4 +15,4 @@ ScryfallCode=PL24
 7 R Dragon Tempest @TSWCK
 
 [tokens]
-r_4_4_dragon_flying
+3 r_4_4_dragon_flying @Song Qijin

--- a/forge-gui/res/editions/Year of the Ox 2021.txt
+++ b/forge-gui/res/editions/Year of the Ox 2021.txt
@@ -4,13 +4,14 @@ Date=2021-01-25
 Name=Year of the Ox 2021
 Type=Promo
 ScryfallCode=PL21
+TokensCode=PL21
 
 [cards]
 1 M Moraug, Fury of Akoum @Rudy Siswanto
 1★ R Sethron, Hurloon General @Fiona Hsieh
 2 M Ox of Agonas @Lie Setiawan
-3★ M Angrath, the Flame-Chained @Song Qijin
+3 M Angrath, the Flame-Chained @Song Qijin
 4 R Tahngarth, First Mate @Song Qijin
 
 [tokens]
-r_2_3_minotaur
+2★ r_2_3_minotaur @Fiona Hsieh

--- a/forge-gui/res/editions/Year of the Rabbit 2023.txt
+++ b/forge-gui/res/editions/Year of the Rabbit 2023.txt
@@ -4,6 +4,7 @@ Date=2023-02-10
 Name=Year of the Rabbit 2023
 Type=Promo
 ScryfallCode=PL23
+TokensCode=PL23
 
 [cards]
 1 R Rabbit Battery @TSWCK
@@ -13,4 +14,4 @@ ScryfallCode=PL23
 6 R Arcbound Ravager @Walleystation
 
 [tokens]
-c_a_food_sac
+2 c_a_food_sac @TSWCK

--- a/forge-gui/res/editions/Year of the Snake 2025.txt
+++ b/forge-gui/res/editions/Year of the Snake 2025.txt
@@ -4,6 +4,7 @@ Date=2025-02-14
 Name=Year of the Snake 2025
 Type=Promo
 ScryfallCode=PL25
+TokensCode=PL25
 
 [cards]
 1 M Xyris, the Writhing Storm @Song Qijin
@@ -13,4 +14,4 @@ ScryfallCode=PL25
 6 L Forest @Ray
 
 [tokens]
-g_1_1_snake
+2 g_1_1_snake @Song Qijin

--- a/forge-gui/res/editions/Zendikar Promos.txt
+++ b/forge-gui/res/editions/Zendikar Promos.txt
@@ -6,6 +6,11 @@ Type=Promo
 ScryfallCode=PZEN
 
 [cards]
+A5 R Terra Stomper @Goran Josic
 9★ R Day of Judgment @Kev Walker
 178★ M Rampaging Baloths @Eric Deschamps
+221★ R Oran-Rief, the Vastwood @Mike Bierek
 228★ R Valakut, the Molten Pinnacle @James Paick
+
+[tokens]
+g_4_4_beast


### PR DESCRIPTION
* Added missing cards.
* Changed Master Edition from MED to ME1 to reflect Scryfall's ID.
* Changed Masterpiece Series - Amonkhet from MPS_AKH to MP2 to reflect Scryfall's ID, as well as the set's name.
* Replaced 'unsupported' cards by their non-promo equivalent so they don't popup at every launch.