### PR TITLE
Try to use current set when creating a card from an effect

### DIFF
--- a/forge-core/src/main/java/forge/StaticData.java
+++ b/forge-core/src/main/java/forge/StaticData.java
@@ -790,7 +790,7 @@ public class StaticData {
 
             Map<String, Pair<Boolean, Integer>> cardCount = new HashMap<>();
             List<CompletableFuture<?>> futures = new ArrayList<>();
-            for (CardEdition.EditionEntry c : e.getAllCardsInSet()) {
+            for (CardEdition.EditionEntry c : e.getObtainableCards()) {
                 if (cardCount.containsKey(c.name())) {
                     cardCount.put(c.name(), Pair.of(c.collectorNumber() != null && c.collectorNumber().startsWith("F"), cardCount.get(c.name()).getRight() + 1));
                 } else {

--- a/forge-core/src/main/java/forge/card/CardDb.java
+++ b/forge-core/src/main/java/forge/card/CardDb.java
@@ -659,7 +659,8 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
             if(cardFromSet != null && request.flags != null)
                 cardFromSet = cardFromSet.copyWithFlags(request.flags);
 
-            return cardFromSet;
+            if (cardFromSet != null)
+                return cardFromSet;
         }
 
         // 2. Card lookup in edition with specified filter didn't work.

--- a/forge-core/src/main/java/forge/card/CardEdition.java
+++ b/forge-core/src/main/java/forge/card/CardEdition.java
@@ -42,7 +42,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-
 /**
  * <p>
  * CardSet class.
@@ -384,6 +383,15 @@ public final class CardEdition implements Comparable<CardEdition> {
     public List<EditionEntry> getCards() { return cardMap.get(EditionSectionWithCollectorNumbers.CARDS.getName()); }
     public List<EditionEntry> getRebalancedCards() { return cardMap.get(EditionSectionWithCollectorNumbers.REBALANCED.getName()); }
     public List<EditionEntry> getFunnyEternalCards() { return cardMap.get(EditionSectionWithCollectorNumbers.ETERNAL.getName()); }
+    public List<EditionEntry> getObtainableCards() { 
+        List<EditionEntry> allCards = new ArrayList<>(getAllCardsInSet());
+        List<EditionEntry> conjuredCards = cardMap.get(EditionSectionWithCollectorNumbers.CONJURED.getName());
+        if (conjuredCards != null) {
+            allCards.removeAll(conjuredCards);
+        }
+
+        return allCards; 
+    }
     public List<EditionEntry> getAllCardsInSet() {
         return cardsInSet;
     }

--- a/forge-game/src/main/java/forge/game/GameFormat.java
+++ b/forge-game/src/main/java/forge/game/GameFormat.java
@@ -226,7 +226,7 @@ public class GameFormat implements Comparable<GameFormat> {
         for (String setCode : allowedSetCodes_ro) {
             CardEdition edition = StaticData.instance().getEditions().get(setCode);
             if (edition != null) {
-                for (EditionEntry card : edition.getAllCardsInSet()) {
+                for (EditionEntry card : edition.getObtainableCards()) {
                     if (!bannedCardNames_ro.contains(card.name())) {
                         PaperCard pc = commonCards.getCard(card.name(), setCode, card.collectorNumber());
                         if (pc != null) {

--- a/forge-game/src/main/java/forge/game/ability/effects/MakeCardEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/MakeCardEffect.java
@@ -152,11 +152,8 @@ public class MakeCardEffect extends SpellAbilityEffect {
                             pc = Iterables.getLast(IterableUtil.filter(pack, PaperCardPredicates.name(name)));
                         } else {
                             // Try to get the card in the sa host's current edition
-                            pc = StaticData.instance().getCommonCards().getCard(name, sa.getHostCard() != null ? sa.getHostCard().getSetCode() : CardEdition.UNKNOWN_CODE);
-
-                            if (pc == null) {
-                                pc = StaticData.instance().getCommonCards().getCard(name);
-                            }
+                            String editionCode = sa.getHostCard() != null ? sa.getHostCard().getSetCode() : CardEdition.UNKNOWN_CODE;
+                            pc = StaticData.instance().getCommonCards().getCard(name, editionCode);
                         }
                         Card card = Card.fromPaperCard(pc, player);
 

--- a/forge-game/src/main/java/forge/game/ability/effects/MakeCardEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/MakeCardEffect.java
@@ -3,6 +3,7 @@ package forge.game.ability.effects;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import forge.StaticData;
+import forge.card.CardEdition;
 import forge.card.ICardFace;
 import forge.game.Game;
 import forge.game.GameEntityCounterTable;
@@ -150,7 +151,12 @@ public class MakeCardEffect extends SpellAbilityEffect {
                         if (pack != null) {
                             pc = Iterables.getLast(IterableUtil.filter(pack, PaperCardPredicates.name(name)));
                         } else {
-                            pc = StaticData.instance().getCommonCards().getUniqueByName(name);
+                            // Try to get the card in the sa host's current edition
+                            pc = StaticData.instance().getCommonCards().getCard(name, sa.getHostCard() != null ? sa.getHostCard().getSetCode() : CardEdition.UNKNOWN_CODE);
+
+                            if (pc == null) {
+                                pc = StaticData.instance().getCommonCards().getCard(name);
+                            }
                         }
                         Card card = Card.fromPaperCard(pc, player);
 
@@ -183,7 +189,7 @@ public class MakeCardEffect extends SpellAbilityEffect {
                         Card cc;
                         if (c.getZone().getZoneType().equals(ZoneType.None)) cc = c;
                         else { // make another copy
-                            PaperCard next = StaticData.instance().getCommonCards().getUniqueByName(c.getName());
+                            PaperCard next = StaticData.instance().getCommonCards().getCard(c.getName(), c.getSetCode());
                             cc = Card.fromPaperCard(next, player);
                             game.getAction().moveTo(ZoneType.None, cc, sa, moveParams);
                         }

--- a/forge-gui-mobile/src/forge/adventure/data/RewardData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/RewardData.java
@@ -241,7 +241,7 @@ public class RewardData implements Serializable {
                         for(String restrictedCard: configData.restrictedCards)
                         {
                             allEditions.removeIf(
-                                    cardEdition -> cardEdition.getAllCardsInSet().stream().anyMatch(
+                                    cardEdition -> cardEdition.getObtainableCards().stream().anyMatch(
                                             o -> o.name().equals(restrictedCard))
                             );
                         }

--- a/forge-gui/res/editions/Alchemy Dominaria.txt
+++ b/forge-gui/res/editions/Alchemy Dominaria.txt
@@ -37,3 +37,14 @@ ScryfallCode=YDMU
 28 R Tiana, Angelic Mechanic @Joseph Weston
 29 R Vodalian Tide Mage @Brian Valeza
 30 R Coalition Construct @Artur Treffner
+
+[conjured]
+32 M Ancestral Recall @Ryan Pancoast
+33 M Time Walk @Chris Rahn
+34 M Timetwister @Matt Stewart
+35 M Black Lotus @Chris Rahn
+36 M Mox Emerald @Volkan Baǵa
+37 M Mox Jet @Volkan Baǵa
+38 M Mox Pearl @Volkan Baǵa
+39 M Mox Ruby @Volkan Baǵa
+40 M Mox Sapphire @Volkan Baǵa

--- a/forge-gui/res/editions/Alchemy Horizons Baldur's Gate.txt
+++ b/forge-gui/res/editions/Alchemy Horizons Baldur's Gate.txt
@@ -339,4 +339,21 @@ A262 U A-Navigation Orb @Robin Olausson
 45g R Hag of Scoured Thoughts @Konstantin Porubov
 45h R Hag of Syphoned Breath @Konstantin Porubov
 45i R Hag of Twisted Visions @Konstantin Porubov
-
+902 U Archipelagore @Svetlin Velinov
+903 U Junk Winder @Campbell White
+904 C Moat Piranhas @Rudy Siswanto
+905 C Mystic Skyfish @Alayna Danner
+906 R Nadir Kraken @Dan Murayama Scott
+907 R Nezahal, Primal Tide @Sam Burley
+908 U Pouncing Shoreshark @Dan Murayama Scott
+909 R Pursued Whale @Jonathan Kuo
+910 C Riptide Turtle @Brian Valeza
+911 U Ruin Crab @Simon Dominic
+912 R Sea-Dasher Octopus @Chris Seaman
+913 U Sigiled Starfish @Nils Hamm
+914 C Spined Megalodon @Daniel Ljunggren
+915 U Stinging Lionfish @Christopher Burdett
+916 R Voracious Greatshark @Mathias Kollros
+926 R Lightning Bolt @Irina Nordsol
+927 C Naturalize @Tim Hildebrandt
+928 C Plummet @Alix Branwyn

--- a/forge-gui/res/editions/Jumpstart Historic Horizons.txt
+++ b/forge-gui/res/editions/Jumpstart Historic Horizons.txt
@@ -383,3 +383,21 @@ ScryfallCode=J21
 [rebalanced]
 A438 U A-Dragon's Rage Channeler @Martina Fackova
 A529 C A-Unholy Heat @Kari Christensen
+
+[conjured]
+777 C Light of Hope @Kimonas Theodossiou
+778 U Stormfront Pegasus @rk post
+779 U Swords to Plowshares @Sam Wolfe Connelly
+780 C Force Spike @Nelson DeCastro
+781 C Kraken Hatchling @Jason Felix
+782 C Ponder @Dan Murayama Scott
+783 C Dark Ritual @Clint Langley
+784 C Duress @Steven Belledin
+785 U Reassembling Skeleton @Austin Hsu
+786 C Assault Strobe @Kev Walker
+787 C Lightning Bolt @Christopher Moeller
+788 R Shivan Dragon @Donato Giancola
+789 C Fog @Jaime Jones
+790 C Giant Growth @Matt Cavotta
+791 R Regal Force @Brandon Kitkouski
+792 R Tropical Island @Franz Vohwinkel

--- a/forge-gui/src/main/java/forge/gamemodes/planarconquest/ConquestPlane.java
+++ b/forge-gui/src/main/java/forge/gamemodes/planarconquest/ConquestPlane.java
@@ -193,7 +193,7 @@ public class ConquestPlane {
             if (edition == null)
                 continue;
 
-            for (EditionEntry card : edition.getAllCardsInSet()) {
+            for (EditionEntry card : edition.getObtainableCards()) {
                 if (bannedCardSet == null || !bannedCardSet.contains(card.name())) {
                     addCard(commonCards.getCard(card.name(), setCode));
                 }

--- a/forge-gui/src/main/java/forge/gamemodes/quest/BoosterUtils.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/BoosterUtils.java
@@ -199,7 +199,6 @@ public final class BoosterUtils {
         }
 
         return output;
-
     }
 
     private static List<Predicate<CardRules>> getColorFilters(final StartingPoolPreferences userPrefs, final List<PaperCard> cardPool) {
@@ -241,7 +240,6 @@ public final class BoosterUtils {
         }
 
         return colorFilters;
-
     }
 
     private static void populateRandomFilters(final List<Predicate<CardRules>> colorFilters) {

--- a/forge-gui/src/main/java/forge/gamemodes/quest/QuestEventDraft.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/QuestEventDraft.java
@@ -445,7 +445,7 @@ public class QuestEventDraft implements IQuestEvent {
         final List<String> cardNames = new ArrayList<>();
 
         for (final CardEdition edition : getAllEditions()) {
-            for (final EditionEntry card : edition.getAllCardsInSet()) {
+            for (final EditionEntry card : edition.getObtainableCards()) {
                 if (card.rarity() == CardRarity.Rare || card.rarity() == CardRarity.MythicRare) {
                     final PaperCard cardToAdd = FModel.getMagicDb().getCommonCards().getCard(card.name(), edition.getCode());
                     if (cardToAdd != null && !cardNames.contains(cardToAdd.getName())) {
@@ -471,7 +471,7 @@ public class QuestEventDraft implements IQuestEvent {
         final List<EditionEntry> cardsInEdition = new ArrayList<>();
         final List<String> cardNames = new ArrayList<>();
 
-        for (final EditionEntry card : randomEdition.getAllCardsInSet()) {
+        for (final EditionEntry card : randomEdition.getObtainableCards()) {
             if (card.rarity() == CardRarity.Rare || card.rarity() == CardRarity.MythicRare) {
                 if (!cardNames.contains(card.name())) {
                     cardsInEdition.add(card);

--- a/forge-gui/src/main/java/forge/gamemodes/quest/QuestUtilCards.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/QuestUtilCards.java
@@ -505,7 +505,7 @@ public final class QuestUtilCards {
     }
 
     /**
-     * Generate boosters in shop.
+     * Generate singles in shop.
      *
      * @param quantity the count
      */
@@ -550,7 +550,7 @@ public final class QuestUtilCards {
     }
 
     /**
-     * Generate precons in shop.
+     * Generate tournament packs in shop.
      *
      * @param count
      *            the count
@@ -565,7 +565,7 @@ public final class QuestUtilCards {
     }
 
     /**
-     * Generate precons in shop.
+     * Generate fat packs in shop.
      *
      * @param count
      *            the count


### PR DESCRIPTION
Fixes #7445 

* Try to use current set when creating a card from an effect
* Removed conjured-only cards from shops/rewards (Might need more testing)
* Fix CardDb fallback