### PR TITLE
Better Games In Match Selection

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/gui/SwingPrefBinders.java
+++ b/forge-gui-desktop/src/main/java/forge/gui/SwingPrefBinders.java
@@ -1,0 +1,26 @@
+package forge.gui;
+
+import javax.swing.*;
+import java.awt.event.ItemEvent;
+import forge.localinstance.properties.ForgePreferences;
+import forge.model.FPrefsBinder;
+
+public class SwingPrefBinders {
+  public static final class ComboBox extends FPrefsBinder<JComboBox<String>, String> {
+    public ComboBox(ForgePreferences.FPref key, JComboBox<String> box) {
+      super(
+        key,
+        box,
+        b -> (String) b.getSelectedItem(),
+        (b, s) -> b.setSelectedItem(s),
+        s -> s,
+        s -> s);
+
+      box.addItemListener(e -> {
+        if (e.getStateChange() == ItemEvent.SELECTED) {
+          this.save();
+        }
+      });
+    }
+  }
+}

--- a/forge-gui-desktop/src/main/java/forge/screens/home/CLobby.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/CLobby.java
@@ -1,8 +1,11 @@
 package forge.screens.home;
 
+import java.awt.event.ItemEvent;
+
 import java.util.Arrays;
 import java.util.Vector;
 
+import javax.swing.*;
 import javax.swing.SwingUtilities;
 
 import com.google.common.collect.Iterables;
@@ -54,6 +57,7 @@ public class CLobby {
             // General updates when switching back to this view
             view.getBtnStart().requestFocusInWindow();
         });
+        syncGamesInMatchFromPrefs();
     }
 
     public void initialize() {
@@ -72,5 +76,34 @@ public class CLobby {
         // Pre-select checkboxes
         view.getCbSingletons().setSelected(prefs.getPrefBoolean(FPref.DECKGEN_SINGLETONS));
         view.getCbArtifacts().setSelected(prefs.getPrefBoolean(FPref.DECKGEN_ARTIFACTS));
+
+        view.getGamesInMatch().addItemListener(e -> {
+          if (e.getStateChange() == ItemEvent.SELECTED) {
+            updateGamesInMatchPrefs();
+          }
+        });
+    }
+
+    /** Saves the number of games in match select to preferences. */
+    private void updateGamesInMatchPrefs() {
+        final ForgePreferences prefs = FModel.getPreferences();
+        final JComboBox<String> gamesInMatch = view.getGamesInMatch();
+        final String selectedItem = (String) gamesInMatch.getSelectedItem();
+        if (selectedItem != null && !selectedItem.isEmpty()) {
+            prefs.setPref(FPref.UI_MATCHES_PER_GAME, selectedItem);
+            prefs.save();
+        }
+    }
+
+    /** Saves Games in match selection **/
+    private void syncGamesInMatchFromPrefs() {
+        final ForgePreferences prefs = FModel.getPreferences();
+        final JComboBox<String> gamesInMatch = view.getGamesInMatch();
+        final String defaultGamesInMatch = prefs.getPref(FPref.UI_MATCHES_PER_GAME);
+        if (defaultGamesInMatch == null || defaultGamesInMatch.isEmpty()) {
+            gamesInMatch.setSelectedItem("3");
+        } else {
+            gamesInMatch.setSelectedItem(defaultGamesInMatch);
+        }
     }
 }

--- a/forge-gui-desktop/src/main/java/forge/screens/home/CLobby.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/CLobby.java
@@ -1,11 +1,8 @@
 package forge.screens.home;
 
-import java.awt.event.ItemEvent;
-
 import java.util.Arrays;
 import java.util.Vector;
 
-import javax.swing.*;
 import javax.swing.SwingUtilities;
 
 import com.google.common.collect.Iterables;
@@ -57,7 +54,7 @@ public class CLobby {
             // General updates when switching back to this view
             view.getBtnStart().requestFocusInWindow();
         });
-        syncGamesInMatchFromPrefs();
+        view.getGamesInMatchBinder().load();
     }
 
     public void initialize() {
@@ -76,34 +73,5 @@ public class CLobby {
         // Pre-select checkboxes
         view.getCbSingletons().setSelected(prefs.getPrefBoolean(FPref.DECKGEN_SINGLETONS));
         view.getCbArtifacts().setSelected(prefs.getPrefBoolean(FPref.DECKGEN_ARTIFACTS));
-
-        view.getGamesInMatch().addItemListener(e -> {
-          if (e.getStateChange() == ItemEvent.SELECTED) {
-            updateGamesInMatchPrefs();
-          }
-        });
-    }
-
-    /** Saves the number of games in match select to preferences. */
-    private void updateGamesInMatchPrefs() {
-        final ForgePreferences prefs = FModel.getPreferences();
-        final JComboBox<String> gamesInMatch = view.getGamesInMatch();
-        final String selectedItem = (String) gamesInMatch.getSelectedItem();
-        if (selectedItem != null && !selectedItem.isEmpty()) {
-            prefs.setPref(FPref.UI_MATCHES_PER_GAME, selectedItem);
-            prefs.save();
-        }
-    }
-
-    /** Saves Games in match selection **/
-    private void syncGamesInMatchFromPrefs() {
-        final ForgePreferences prefs = FModel.getPreferences();
-        final JComboBox<String> gamesInMatch = view.getGamesInMatch();
-        final String defaultGamesInMatch = prefs.getPref(FPref.UI_MATCHES_PER_GAME);
-        if (defaultGamesInMatch == null || defaultGamesInMatch.isEmpty()) {
-            gamesInMatch.setSelectedItem("3");
-        } else {
-            gamesInMatch.setSelectedItem(defaultGamesInMatch);
-        }
     }
 }

--- a/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
@@ -189,10 +189,14 @@ public class VLobby implements ILobbyView {
                 }
             });
         }
+        String defaultGamesInMatch = FModel.getPreferences().getPref(FPref.UI_MATCHES_PER_GAME);
+        if (defaultGamesInMatch == null || defaultGamesInMatch.isEmpty()) {
+            defaultGamesInMatch = "3";
+        }
         gamesInMatchFrame.add(newLabel(localizer.getMessage("lblGamesInMatch")), "w 150px!, h 30px!");
         gamesInMatchFrame.add(gamesInMatch, "w 50px!, h 30px!");
         gamesInMatchFrame.setOpaque(false);
-        gamesInMatch.setSelectedItem("3");
+        gamesInMatch.setSelectedItem(defaultGamesInMatch);
         pnlStart.add(gamesInMatchFrame);
     }
 

--- a/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
@@ -74,7 +74,7 @@ public class VLobby implements ILobbyView {
 
     private final StartButton btnStart  = new StartButton();
     private final JPanel pnlStart = new JPanel(new MigLayout("insets 0, gap 0, wrap 2"));
-    private final JComboBox gamesInMatch = new JComboBox(new String[] {"1","3","5"});
+    private final JComboBox<String> gamesInMatch = new JComboBox<String>(new String[] {"1","3","5"});
     private final JPanel gamesInMatchFrame = new JPanel(new MigLayout("insets 0, gap 0, wrap 2"));
     private final JPanel constructedFrame = new JPanel(new MigLayout("insets 0, gap 0, wrap 2")); // Main content frame
 
@@ -182,9 +182,6 @@ public class VLobby implements ILobbyView {
             btnStart.addActionListener(arg0 -> {
                 Runnable startGame = lobby.startGame();
                 if (startGame != null) {
-                    if (!gamesInMatch.getSelectedItem().equals(FPref.UI_MATCHES_PER_GAME)) {
-                        FModel.getPreferences().setPref(FPref.UI_MATCHES_PER_GAME, (String) gamesInMatch.getSelectedItem());
-                    }
                     startGame.run();
                 }
             });
@@ -193,10 +190,11 @@ public class VLobby implements ILobbyView {
         if (defaultGamesInMatch == null || defaultGamesInMatch.isEmpty()) {
             defaultGamesInMatch = "3";
         }
+
         gamesInMatchFrame.add(newLabel(localizer.getMessage("lblGamesInMatch")), "w 150px!, h 30px!");
         gamesInMatchFrame.add(gamesInMatch, "w 50px!, h 30px!");
         gamesInMatchFrame.setOpaque(false);
-        gamesInMatch.setSelectedItem(defaultGamesInMatch);
+
         pnlStart.add(gamesInMatchFrame);
     }
 
@@ -857,6 +855,11 @@ public class VLobby implements ILobbyView {
     /** Return the Vanguard avatars not flagged RemoveDeck:All or RemoveDeck:Random. */
     public List<PaperCard> getNonRandomAiAvatars() {
         return nonRandomAiAvatars;
+    }
+
+    /** Return the gamesInMatch */
+    public JComboBox<String> getGamesInMatch() {
+      return gamesInMatch;
     }
 
     /** Populate vanguard lists. */

--- a/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
@@ -34,6 +34,7 @@ import forge.gamemodes.match.LobbySlotType;
 import forge.gamemodes.net.event.UpdateLobbyPlayerEvent;
 import forge.gui.CardDetailPanel;
 import forge.gui.GuiBase;
+import forge.gui.SwingPrefBinders;
 import forge.gui.interfaces.ILobbyView;
 import forge.gui.util.SOptionPane;
 import forge.interfaces.IPlayerChangeListener;
@@ -75,6 +76,8 @@ public class VLobby implements ILobbyView {
     private final StartButton btnStart  = new StartButton();
     private final JPanel pnlStart = new JPanel(new MigLayout("insets 0, gap 0, wrap 2"));
     private final JComboBox<String> gamesInMatch = new JComboBox<String>(new String[] {"1","3","5"});
+    private final SwingPrefBinders.ComboBox gamesInMatchBinder =
+      new SwingPrefBinders.ComboBox(FPref.UI_MATCHES_PER_GAME, gamesInMatch);
     private final JPanel gamesInMatchFrame = new JPanel(new MigLayout("insets 0, gap 0, wrap 2"));
     private final JPanel constructedFrame = new JPanel(new MigLayout("insets 0, gap 0, wrap 2")); // Main content frame
 
@@ -857,9 +860,9 @@ public class VLobby implements ILobbyView {
         return nonRandomAiAvatars;
     }
 
-    /** Return the gamesInMatch */
-    public JComboBox<String> getGamesInMatch() {
-      return gamesInMatch;
+    /** Return the gamesInMatchBinder */
+    public SwingPrefBinders.ComboBox getGamesInMatchBinder() {
+      return gamesInMatchBinder;
     }
 
     /** Populate vanguard lists. */

--- a/forge-gui-desktop/src/main/java/forge/screens/home/sanctioned/CSubmenuDraft.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/sanctioned/CSubmenuDraft.java
@@ -18,7 +18,6 @@ import forge.gui.UiCommand;
 import forge.gui.framework.FScreen;
 import forge.gui.framework.ICDoc;
 import forge.itemmanager.ItemManagerConfig;
-import forge.localinstance.properties.ForgePreferences;
 import forge.localinstance.properties.ForgePreferences.FPref;
 import forge.model.FModel;
 import forge.player.GamePlayerUtil;
@@ -73,8 +72,6 @@ public enum CSubmenuDraft implements ICDoc {
 
         view.getRadAll().addActionListener(radioAction);
         view.getRadMultiple().addActionListener(radioAction);
-
-        view.getGamesInMatch().addItemListener(e -> updateGamesInMatchPrefs());
     }
 
     /* (non-Javadoc)
@@ -101,7 +98,7 @@ public enum CSubmenuDraft implements ICDoc {
             }
         });
 
-        syncGamesInMatchFromPrefs();
+        view.getGamesInMatchBinder().load();
     }
 
     private void startGame(final GameType gameType) {
@@ -109,15 +106,10 @@ public enum CSubmenuDraft implements ICDoc {
         final VSubmenuDraft view = VSubmenuDraft.SINGLETON_INSTANCE;
         final boolean gauntlet = view.isGauntlet();
         final DeckProxy humanDeck = view.getLstDecks().getSelectedItem();
-        final String gamesInMatch = view.getGamesInMatch().getSelectedItem().toString();
 
         if (humanDeck == null) {
             FOptionPane.showErrorDialog(localizer.getMessage("lblNoDeckSelected"), localizer.getMessage("lblNoDeck"));
             return;
-        }
-
-        if (!gamesInMatch.equals(FPref.UI_MATCHES_PER_GAME)) {
-            FModel.getPreferences().setPref(FPref.UI_MATCHES_PER_GAME, gamesInMatch);
         }
 
         if (FModel.getPreferences().getPrefBoolean(FPref.ENFORCE_DECK_LEGALITY)) {
@@ -256,28 +248,4 @@ public enum CSubmenuDraft implements ICDoc {
             combo.addItem("5");
         }
     }
-
-    /** Saves the number of games in match select to preferences. */
-    private void updateGamesInMatchPrefs() {
-      final ForgePreferences prefs = FModel.getPreferences();
-      final JComboBox<String> gamesInMatch = VSubmenuDraft.SINGLETON_INSTANCE.getGamesInMatch();
-      final String selectedItem = (String) gamesInMatch.getSelectedItem();
-      if (selectedItem != null && !selectedItem.isEmpty()) {
-          prefs.setPref(FPref.UI_MATCHES_PER_GAME, selectedItem);
-          prefs.save();
-      }
-    }
-
-    /** Saves Games in match selection **/
-    private void syncGamesInMatchFromPrefs() {
-      final ForgePreferences prefs = FModel.getPreferences();
-      final JComboBox<String> gamesInMatch = VSubmenuDraft.SINGLETON_INSTANCE.getGamesInMatch();
-      final String defaultGamesInMatch = prefs.getPref(FPref.UI_MATCHES_PER_GAME);
-      if (defaultGamesInMatch == null || defaultGamesInMatch.isEmpty()) {
-          gamesInMatch.setSelectedItem("3");
-      } else {
-          gamesInMatch.setSelectedItem(defaultGamesInMatch);
-      }
-    }
-
 }

--- a/forge-gui-desktop/src/main/java/forge/screens/home/sanctioned/VSubmenuDraft.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/sanctioned/VSubmenuDraft.java
@@ -13,6 +13,7 @@ import forge.game.GameType;
 import forge.gui.framework.DragCell;
 import forge.gui.framework.DragTab;
 import forge.gui.framework.EDocID;
+import forge.gui.SwingPrefBinders;
 import forge.itemmanager.DeckManager;
 import forge.itemmanager.ItemManagerContainer;
 import forge.screens.deckeditor.CDeckEditorUI;
@@ -60,6 +61,8 @@ public enum VSubmenuDraft implements IVSubmenu<CSubmenuDraft> {
     private final JComboBox<String> cbOpponent = new JComboBox<>();
 
     private final JComboBox<String> gamesInMatch = new JComboBox<String>(new String[] {"1","3","5"});
+    private final SwingPrefBinders.ComboBox gamesInMatchBinder =
+        new SwingPrefBinders.ComboBox(FPref.UI_MATCHES_PER_GAME, gamesInMatch);
     private final JPanel gamesInMatchFrame = new JPanel(new MigLayout("insets 0, gap 0, wrap 2"));
 
     private final JLabel lblInfo = new FLabel.Builder()
@@ -113,7 +116,6 @@ public enum VSubmenuDraft implements IVSubmenu<CSubmenuDraft> {
         gamesInMatchFrame.add(lblGamesInMatch, "w 150px!, h 30px!");
         gamesInMatchFrame.add(gamesInMatch, "w 50px!, h 30px!");
         gamesInMatchFrame.setOpaque(false);
-        gamesInMatch.setSelectedItem(defaultGamesInMatch);
         pnlStart.add(gamesInMatchFrame, "cell 1 0, alignx center, aligny top");
 
         pnlStart.add(btnStart, "cell 1 2, alignx center, aligny bottom");
@@ -169,7 +171,7 @@ public enum VSubmenuDraft implements IVSubmenu<CSubmenuDraft> {
     public JRadioButton getRadSingle() { return radSingle; }
     public JRadioButton getRadMultiple() { return radMultiple; }
     public JRadioButton getRadAll() { return radAll; }
-    public JComboBox<String> getGamesInMatch() { return gamesInMatch; }
+    public SwingPrefBinders.ComboBox getGamesInMatchBinder() { return gamesInMatchBinder; }
 
     //========== Overridden from IVDoc
 

--- a/forge-gui-desktop/src/main/java/forge/screens/home/sanctioned/VSubmenuDraft.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/sanctioned/VSubmenuDraft.java
@@ -26,6 +26,8 @@ import forge.toolbox.FLabel;
 import forge.toolbox.FRadioButton;
 import forge.toolbox.FSkin;
 import forge.toolbox.JXButtonPanel;
+import forge.localinstance.properties.ForgePreferences.FPref;
+import forge.model.FModel;
 import forge.util.Localizer;
 import net.miginfocom.swing.MigLayout;
 
@@ -57,6 +59,9 @@ public enum VSubmenuDraft implements IVSubmenu<CSubmenuDraft> {
 
     private final JComboBox<String> cbOpponent = new JComboBox<>();
 
+    private final JComboBox gamesInMatch = new JComboBox(new String[] {"1","3","5"});
+    private final JPanel gamesInMatchFrame = new JPanel(new MigLayout("insets 0, gap 0, wrap 2"));
+
     private final JLabel lblInfo = new FLabel.Builder()
         .fontAlign(SwingConstants.LEFT).fontSize(16).fontStyle(Font.BOLD)
         .text(localizer.getMessage("lblBuildorselectadeck")).build();
@@ -71,6 +76,10 @@ public enum VSubmenuDraft implements IVSubmenu<CSubmenuDraft> {
 
     private final FLabel lblDir3 = new FLabel.Builder()
         .text(localizer.getMessage("lblDraftText3"))
+        .fontSize(12).build();
+
+    private final FLabel lblGamesInMatch = new FLabel.Builder()
+        .text(localizer.getMessage("lblGamesInMatch"))
         .fontSize(12).build();
 
     private final FLabel btnBuildDeck = new FLabel.ButtonBuilder().text(localizer.getMessage("lblNewBoosterDraftGame")).fontSize(16).build();
@@ -91,10 +100,23 @@ public enum VSubmenuDraft implements IVSubmenu<CSubmenuDraft> {
         radSingle.setSelected(true);
         grpPanel.add(cbOpponent, "w 200px!, h 30px!");
 
-        pnlStart.setLayout(new MigLayout("insets 0, gap 0, wrap 2"));
+        pnlStart.setLayout(new MigLayout("insets 0, gap 0",
+                                         "[grow][pref!]",
+                                         "[pref!][grow,fill][pref!]"));
         pnlStart.setOpaque(false);
-        pnlStart.add(grpPanel, "gapright 20");
-        pnlStart.add(btnStart);
+        pnlStart.add(grpPanel, "cell 0 0 1 3, growy, gapright 20");
+
+        String defaultGamesInMatch = FModel.getPreferences().getPref(FPref.UI_MATCHES_PER_GAME);
+        if (defaultGamesInMatch == null || defaultGamesInMatch.isEmpty()) {
+            defaultGamesInMatch = "3";
+        }
+        gamesInMatchFrame.add(lblGamesInMatch, "w 150px!, h 30px!");
+        gamesInMatchFrame.add(gamesInMatch, "w 50px!, h 30px!");
+        gamesInMatchFrame.setOpaque(false);
+        gamesInMatch.setSelectedItem(defaultGamesInMatch);
+        pnlStart.add(gamesInMatchFrame, "cell 1 0, alignx center, aligny top");
+
+        pnlStart.add(btnStart, "cell 1 2, alignx center, aligny bottom");
     }
 
     /* (non-Javadoc)

--- a/forge-gui-desktop/src/main/java/forge/screens/home/sanctioned/VSubmenuDraft.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/sanctioned/VSubmenuDraft.java
@@ -59,7 +59,7 @@ public enum VSubmenuDraft implements IVSubmenu<CSubmenuDraft> {
 
     private final JComboBox<String> cbOpponent = new JComboBox<>();
 
-    private final JComboBox gamesInMatch = new JComboBox(new String[] {"1","3","5"});
+    private final JComboBox<String> gamesInMatch = new JComboBox<String>(new String[] {"1","3","5"});
     private final JPanel gamesInMatchFrame = new JPanel(new MigLayout("insets 0, gap 0, wrap 2"));
 
     private final JLabel lblInfo = new FLabel.Builder()
@@ -169,6 +169,7 @@ public enum VSubmenuDraft implements IVSubmenu<CSubmenuDraft> {
     public JRadioButton getRadSingle() { return radSingle; }
     public JRadioButton getRadMultiple() { return radMultiple; }
     public JRadioButton getRadAll() { return radAll; }
+    public JComboBox<String> getGamesInMatch() { return gamesInMatch; }
 
     //========== Overridden from IVDoc
 

--- a/forge-gui-mobile/src/forge/screens/constructed/LobbyScreen.java
+++ b/forge-gui-mobile/src/forge/screens/constructed/LobbyScreen.java
@@ -51,6 +51,7 @@ import forge.toolbox.FScrollPane;
 import forge.util.MyRandom;
 import forge.util.TextUtil;
 import forge.util.Utils;
+import forge.util.GuiPrefBinders;
 
 public abstract class LobbyScreen extends LaunchScreen implements ILobbyView {
     private static final ForgePreferences prefs = FModel.getPreferences();
@@ -72,6 +73,8 @@ public abstract class LobbyScreen extends LaunchScreen implements ILobbyView {
     // Max games in a match frame and variables
     private final FLabel lblGamesInMatch = new FLabel.Builder().text(Forge.getLocalizer().getMessage("lblMatch") + ":").font(VARIANTS_FONT).build();
     private final FComboBox<String> cbGamesInMatch = new FComboBox<>();
+    private final GuiPrefBinders.ComboBox cbGamesInMatchBinder =
+        new GuiPrefBinders.ComboBox(FPref.UI_MATCHES_PER_GAME, cbGamesInMatch);
 
     private final List<PlayerPanel> playerPanels = new ArrayList<>(MAX_PLAYERS);
     private final FScrollPane playersScroll = new FScrollPane() {
@@ -133,8 +136,6 @@ public abstract class LobbyScreen extends LaunchScreen implements ILobbyView {
         cbGamesInMatch.addItem("1");
         cbGamesInMatch.addItem("3");
         cbGamesInMatch.addItem("5");
-        cbGamesInMatch.setSelectedItem(FModel.getPreferences().getPref((FPref.UI_MATCHES_PER_GAME)));
-        cbGamesInMatch.setChangedHandler(event -> FModel.getPreferences().setPref(FPref.UI_MATCHES_PER_GAME, cbGamesInMatch.getSelectedItem()));
 
         add(lblVariants);
         add(cbVariants);
@@ -590,7 +591,7 @@ public abstract class LobbyScreen extends LaunchScreen implements ILobbyView {
 
     @Override
     public void onActivate() {
-        cbGamesInMatch.setSelectedItem(FModel.getPreferences().getPref(FPref.UI_MATCHES_PER_GAME));
+        cbGamesInMatchBinder.load();
     }
 
     @Override

--- a/forge-gui-mobile/src/forge/screens/constructed/LobbyScreen.java
+++ b/forge-gui-mobile/src/forge/screens/constructed/LobbyScreen.java
@@ -589,6 +589,11 @@ public abstract class LobbyScreen extends LaunchScreen implements ILobbyView {
     }
 
     @Override
+    public void onActivate() {
+        cbGamesInMatch.setSelectedItem(FModel.getPreferences().getPref(FPref.UI_MATCHES_PER_GAME));
+    }
+
+    @Override
     public void update(final boolean fullUpdate) {
         int playerCount = lobby.getNumberOfSlots();
 

--- a/forge-gui-mobile/src/forge/screens/limited/LoadDraftScreen.java
+++ b/forge-gui-mobile/src/forge/screens/limited/LoadDraftScreen.java
@@ -20,6 +20,7 @@ import forge.gamemodes.match.HostedMatch;
 import forge.gui.FThreads;
 import forge.gui.GuiBase;
 import forge.gui.util.SGuiChoose;
+import forge.util.GuiPrefBinders;
 import forge.itemmanager.DeckManager;
 import forge.itemmanager.ItemManagerConfig;
 import forge.itemmanager.filters.ItemFilter;
@@ -48,6 +49,8 @@ public class LoadDraftScreen extends LaunchScreen {
     // Max games in a match frame and variables
     private final FLabel lblGamesInMatch = add(new FLabel.Builder().text(Forge.getLocalizer().getMessage("lblMatch") + ":").font(GAME_MODE_FONT).build());
     private final FComboBox<String> cbGamesInMatch = add(new FComboBox<>());
+    private final GuiPrefBinders.ComboBox cbGamesInMatchBinder = new GuiPrefBinders.ComboBox(
+        FPref.UI_MATCHES_PER_GAME, cbGamesInMatch);
 
     public LoadDraftScreen() {
         super(null, LoadGameMenu.getMenu());
@@ -63,15 +66,13 @@ public class LoadDraftScreen extends LaunchScreen {
         cbGamesInMatch.addItem("1");
         cbGamesInMatch.addItem("3");
         cbGamesInMatch.addItem("5");
-        cbGamesInMatch.setSelectedItem(FModel.getPreferences().getPref((FPref.UI_MATCHES_PER_GAME)));
-        cbGamesInMatch.setChangedHandler(event -> FModel.getPreferences().setPref(FPref.UI_MATCHES_PER_GAME, cbGamesInMatch.getSelectedItem()));
     }
 
     @Override
     public void onActivate() {
         lstDecks.setPool(DeckProxy.getAllDraftDecks());
         lstDecks.setSelectedString(DeckPreferences.getDraftDeck());
-        cbGamesInMatch.setSelectedItem(FModel.getPreferences().getPref(FPref.UI_MATCHES_PER_GAME));
+        cbGamesInMatchBinder.load();
     }
 
     private void editSelectedDeck() {
@@ -169,12 +170,6 @@ public class LoadDraftScreen extends LaunchScreen {
                 }));
             }
         });
-    }
-
-    @Override
-    public void update(final boolean fullUpdate) {
-        // Update games in match
-        cbGamesInMatch.setSelectedItem(FModel.getPreferences().getPref(FPref.UI_MATCHES_PER_GAME));
     }
 
     private boolean checkDeckLegality(DeckProxy humanDeck) {

--- a/forge-gui-mobile/src/forge/screens/limited/LoadDraftScreen.java
+++ b/forge-gui-mobile/src/forge/screens/limited/LoadDraftScreen.java
@@ -32,6 +32,7 @@ import forge.screens.home.LoadGameMenu;
 import forge.toolbox.FComboBox;
 import forge.toolbox.FLabel;
 import forge.toolbox.FOptionPane;
+import forge.util.Utils;
 
 public class LoadDraftScreen extends LaunchScreen {
     private final DeckManager lstDecks = add(new DeckManager(GameType.Draft));
@@ -44,6 +45,10 @@ public class LoadDraftScreen extends LaunchScreen {
     private final FLabel lblMode = add(new FLabel.Builder().text(Forge.getLocalizer().getMessage("lblMode")).font(GAME_MODE_FONT).build());
     private final FComboBox<String> cbMode = add(new FComboBox<>());
 
+    // Max games in a match frame and variables
+    private final FLabel lblGamesInMatch = add(new FLabel.Builder().text(Forge.getLocalizer().getMessage("lblMatch") + ":").font(GAME_MODE_FONT).build());
+    private final FComboBox<String> cbGamesInMatch = add(new FComboBox<>());
+
     public LoadDraftScreen() {
         super(null, LoadGameMenu.getMenu());
 
@@ -53,12 +58,20 @@ public class LoadDraftScreen extends LaunchScreen {
 
         lstDecks.setup(ItemManagerConfig.DRAFT_DECKS);
         lstDecks.setItemActivateHandler(event -> editSelectedDeck());
+
+        cbGamesInMatch.setFont(GAME_MODE_FONT);
+        cbGamesInMatch.addItem("1");
+        cbGamesInMatch.addItem("3");
+        cbGamesInMatch.addItem("5");
+        cbGamesInMatch.setSelectedItem(FModel.getPreferences().getPref((FPref.UI_MATCHES_PER_GAME)));
+        cbGamesInMatch.setChangedHandler(event -> FModel.getPreferences().setPref(FPref.UI_MATCHES_PER_GAME, cbGamesInMatch.getSelectedItem()));
     }
 
     @Override
     public void onActivate() {
         lstDecks.setPool(DeckProxy.getAllDraftDecks());
         lstDecks.setSelectedString(DeckPreferences.getDraftDeck());
+        cbGamesInMatch.setSelectedItem(FModel.getPreferences().getPref(FPref.UI_MATCHES_PER_GAME));
     }
 
     private void editSelectedDeck() {
@@ -78,8 +91,16 @@ public class LoadDraftScreen extends LaunchScreen {
         float listHeight = height - labelHeight - y - FDeckChooser.PADDING;
         float comboBoxHeight = cbMode.getHeight();
 
-        lblMode.setBounds(x, y, lblMode.getAutoSizeBounds().width + FDeckChooser.PADDING / 2, comboBoxHeight);
-        cbMode.setBounds(x + lblMode.getWidth(), y, w - lblMode.getWidth(), comboBoxHeight);
+        float x2 = x;
+        float w1 = lblMode.getAutoSizeBounds().width;
+        float w2 = lblGamesInMatch.getAutoSizeBounds().width;
+        lblMode.setBounds(x2, y, w1 + FDeckChooser.PADDING / 2, comboBoxHeight);
+        x2 += lblMode.getWidth();
+        cbMode.setBounds(x2, y, w - x2 - w2 - Utils.AVG_FINGER_WIDTH, comboBoxHeight);
+        x2 += cbMode.getWidth();
+        lblGamesInMatch.setBounds(x2, y, w2 + FDeckChooser.PADDING / 2, comboBoxHeight);
+        x2 += lblGamesInMatch.getWidth();
+        cbGamesInMatch.setBounds(x2, y, Utils.AVG_FINGER_WIDTH, comboBoxHeight);
         y += comboBoxHeight + FDeckChooser.PADDING;
         lstDecks.setBounds(x, y, w, listHeight);
         y += listHeight + FDeckChooser.PADDING;
@@ -148,6 +169,12 @@ public class LoadDraftScreen extends LaunchScreen {
                 }));
             }
         });
+    }
+
+    @Override
+    public void update(final boolean fullUpdate) {
+        // Update games in match
+        cbGamesInMatch.setSelectedItem(FModel.getPreferences().getPref(FPref.UI_MATCHES_PER_GAME));
     }
 
     private boolean checkDeckLegality(DeckProxy humanDeck) {

--- a/forge-gui-mobile/src/forge/screens/limited/LoadSealedScreen.java
+++ b/forge-gui-mobile/src/forge/screens/limited/LoadSealedScreen.java
@@ -32,6 +32,7 @@ import forge.screens.home.LoadGameMenu;
 import forge.toolbox.FComboBox;
 import forge.toolbox.FLabel;
 import forge.toolbox.FOptionPane;
+import forge.util.Utils;
 
 public class LoadSealedScreen extends LaunchScreen {
     private final DeckManager lstDecks = add(new DeckManager(GameType.Draft));
@@ -44,6 +45,10 @@ public class LoadSealedScreen extends LaunchScreen {
     private final FLabel lblMode = add(new FLabel.Builder().text(Forge.getLocalizer().getMessage("lblMode")).font(GAME_MODE_FONT).build());
     private final FComboBox<String> cbMode = add(new FComboBox<>());
 
+    // Max games in a match frame and variables
+    private final FLabel lblGamesInMatch = add(new FLabel.Builder().text(Forge.getLocalizer().getMessage("lblMatch") + ":").font(GAME_MODE_FONT).build());
+    private final FComboBox<String> cbGamesInMatch = add(new FComboBox<>());
+
     public LoadSealedScreen() {
         super(null, LoadGameMenu.getMenu());
 
@@ -53,12 +58,20 @@ public class LoadSealedScreen extends LaunchScreen {
 
         lstDecks.setup(ItemManagerConfig.SEALED_DECKS);
         lstDecks.setItemActivateHandler(event -> editSelectedDeck());
+
+        cbGamesInMatch.setFont(GAME_MODE_FONT);
+        cbGamesInMatch.addItem("1");
+        cbGamesInMatch.addItem("3");
+        cbGamesInMatch.addItem("5");
+        cbGamesInMatch.setSelectedItem(FModel.getPreferences().getPref((FPref.UI_MATCHES_PER_GAME)));
+        cbGamesInMatch.setChangedHandler(event -> FModel.getPreferences().setPref(FPref.UI_MATCHES_PER_GAME, cbGamesInMatch.getSelectedItem()));
     }
 
     @Override
     public void onActivate() {
         lstDecks.setPool(DeckProxy.getAllSealedDecks());
         lstDecks.setSelectedString(DeckPreferences.getSealedDeck());
+        cbGamesInMatch.setSelectedItem(FModel.getPreferences().getPref(FPref.UI_MATCHES_PER_GAME));
     }
 
     private void editSelectedDeck() {
@@ -78,8 +91,16 @@ public class LoadSealedScreen extends LaunchScreen {
         float listHeight = height - labelHeight - y - FDeckChooser.PADDING;
         float comboBoxHeight = cbMode.getHeight();
 
-        lblMode.setBounds(x, y, lblMode.getAutoSizeBounds().width + FDeckChooser.PADDING / 2, comboBoxHeight);
-        cbMode.setBounds(x + lblMode.getWidth(), y, w - lblMode.getWidth(), comboBoxHeight);
+        float x2 = x;
+        float w1 = lblMode.getAutoSizeBounds().width;
+        float w2 = lblGamesInMatch.getAutoSizeBounds().width;
+        lblMode.setBounds(x2, y, w1 + FDeckChooser.PADDING / 2, comboBoxHeight);
+        x2 += lblMode.getWidth();
+        cbMode.setBounds(x2, y, w - x2 - w2 - Utils.AVG_FINGER_WIDTH, comboBoxHeight);
+        x2 += cbMode.getWidth();
+        lblGamesInMatch.setBounds(x2, y, w2 + FDeckChooser.PADDING / 2, comboBoxHeight);
+        x2 += lblGamesInMatch.getWidth();
+        cbGamesInMatch.setBounds(x2, y, Utils.AVG_FINGER_WIDTH, comboBoxHeight);
         y += comboBoxHeight + FDeckChooser.PADDING;
         lstDecks.setBounds(x, y, w, listHeight);
         y += listHeight + FDeckChooser.PADDING;

--- a/forge-gui-mobile/src/forge/screens/limited/LoadSealedScreen.java
+++ b/forge-gui-mobile/src/forge/screens/limited/LoadSealedScreen.java
@@ -20,6 +20,7 @@ import forge.gamemodes.match.HostedMatch;
 import forge.gui.FThreads;
 import forge.gui.GuiBase;
 import forge.gui.util.SGuiChoose;
+import forge.util.GuiPrefBinders;
 import forge.itemmanager.DeckManager;
 import forge.itemmanager.ItemManagerConfig;
 import forge.itemmanager.filters.ItemFilter;
@@ -48,6 +49,8 @@ public class LoadSealedScreen extends LaunchScreen {
     // Max games in a match frame and variables
     private final FLabel lblGamesInMatch = add(new FLabel.Builder().text(Forge.getLocalizer().getMessage("lblMatch") + ":").font(GAME_MODE_FONT).build());
     private final FComboBox<String> cbGamesInMatch = add(new FComboBox<>());
+    private final GuiPrefBinders.ComboBox cbGamesInMatchBinder = new GuiPrefBinders.ComboBox(
+        FPref.UI_MATCHES_PER_GAME, cbGamesInMatch);
 
     public LoadSealedScreen() {
         super(null, LoadGameMenu.getMenu());
@@ -63,15 +66,13 @@ public class LoadSealedScreen extends LaunchScreen {
         cbGamesInMatch.addItem("1");
         cbGamesInMatch.addItem("3");
         cbGamesInMatch.addItem("5");
-        cbGamesInMatch.setSelectedItem(FModel.getPreferences().getPref((FPref.UI_MATCHES_PER_GAME)));
-        cbGamesInMatch.setChangedHandler(event -> FModel.getPreferences().setPref(FPref.UI_MATCHES_PER_GAME, cbGamesInMatch.getSelectedItem()));
     }
 
     @Override
     public void onActivate() {
         lstDecks.setPool(DeckProxy.getAllSealedDecks());
         lstDecks.setSelectedString(DeckPreferences.getSealedDeck());
-        cbGamesInMatch.setSelectedItem(FModel.getPreferences().getPref(FPref.UI_MATCHES_PER_GAME));
+        cbGamesInMatchBinder.load();
     }
 
     private void editSelectedDeck() {

--- a/forge-gui-mobile/src/forge/util/GuiPrefBinders.java
+++ b/forge-gui-mobile/src/forge/util/GuiPrefBinders.java
@@ -1,0 +1,23 @@
+package forge.util;
+
+import forge.toolbox.FComboBox;
+import forge.localinstance.properties.ForgePreferences;
+import forge.model.FPrefsBinder;
+
+public class GuiPrefBinders {
+  public static final class ComboBox extends FPrefsBinder<FComboBox<String>, String> {
+    public ComboBox(ForgePreferences.FPref key, FComboBox<String> box) {
+      super(
+        key,
+        box,
+        b -> (String) b.getSelectedItem(),
+        (b, s) -> b.setSelectedItem(s),
+        s -> s,
+        s -> s);
+
+      box.setChangedHandler(e -> {
+          this.save();
+      });
+    }
+  }
+}

--- a/forge-gui/src/main/java/forge/model/FPrefsBinder.java
+++ b/forge-gui/src/main/java/forge/model/FPrefsBinder.java
@@ -1,0 +1,56 @@
+package forge.model;
+
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import forge.localinstance.properties.ForgePreferences;
+
+/**
+ * Binds any GUI component to a Forge preference key
+ */
+
+public class FPrefsBinder<C, V> implements ModelBinder<ForgePreferences.FPref, C, V> {
+  private final ForgePreferences.FPref prefKey;
+  private final C component;
+
+  /** Extracts a value from the component */
+  private final Function<C, V> extractor;
+
+  /** Pushes a value back into the component */
+  private final BiConsumer<C, V> applier;
+
+  /** conversions between pref store value and component value */
+  private final Function<V, String> toString;
+  private final Function<String, V> fromString;
+
+  public FPrefsBinder(ForgePreferences.FPref prefKey,
+                    C component,
+                    Function<C, V> extractor,
+                    BiConsumer<C, V> applier,
+                    Function<V, String> toString,
+                    Function<String, V> fromString) {
+    this.prefKey = prefKey;
+    this.component = component;
+    this.extractor = extractor;
+    this.applier = applier;
+    this.toString = toString;
+    this.fromString = fromString;
+  }
+
+  public void load() {
+    ForgePreferences prefs = FModel.getPreferences();
+    String prefValue = prefs.getPref(prefKey);
+    if (prefValue != null) {
+      V value = fromString.apply(prefValue);
+      applier.accept(component, value);
+    }
+  }
+
+  public void save() {
+    ForgePreferences prefs = FModel.getPreferences();
+    V value = extractor.apply(component);
+    String prefValue = toString.apply(value);
+    prefs.setPref(prefKey, prefValue);
+    prefs.save();
+  }
+}

--- a/forge-gui/src/main/java/forge/model/ModelBinder.java
+++ b/forge-gui/src/main/java/forge/model/ModelBinder.java
@@ -1,0 +1,10 @@
+package forge.model;
+
+/**
+ * Binds any GUI component to a Forge preference key
+ */
+
+public interface ModelBinder<K, C, V> {
+  public void load();
+  public void save();
+}


### PR DESCRIPTION
The number of games in a match is handled by the `FPref.UI_MATCHES_PER_GAME` preference value. This is only modifiable with a combobox on the new constructed game pages.

This preference value also affects other game modes such as booster draft and sealed draft. The player then sees no obvious way to change the number of games in the match on these pages.

This PR does the following:
* Adds a ModelBinder interface for linking GUI elements to model values more directly
* Adds a series of Binder specializations for existing GUI frameworks (desktop and mobile)
* Adds a 'Best Of' combo box to the Booster Draft and Sealed Draft pages for both desktop and mobile
* Adds binders so changes to the combo box are propagated to the saved preferences.

UI changes have been tested with desktop builds, and the changes work.

ModelBinder and its helpers also provide a path for expansion to other UI elements in the future.