### PR TITLE
Update ISSUES.txt URL from git.cardforge.com to github.com

### DIFF
--- a/forge-gui/release-files/ISSUES.txt
+++ b/forge-gui/release-files/ISSUES.txt
@@ -1,3 +1,3 @@
-Known issues are here: https://git.cardforge.org/core-developers/forge/issues
+Known issues are here: https://github.com/Card-Forge/forge/issues
 
 Feel free to report your own there if you have any.


### PR DESCRIPTION
I'm a new player, installed and was looking through files. This git.cardforge.org URL no longer works, and I assume we want to use the GitHub issues list here. 