### PR TITLE
Fix for red castle

### DIFF
--- a/forge-gui/res/adventure/common/maps/map/main_story/castles/red_castle_f1.tmx
+++ b/forge-gui/res/adventure/common/maps/map/main_story/castles/red_castle_f1.tmx
@@ -64,6 +64,32 @@
     <property name="threatRange" type="int" value="50"/>
    </properties>
   </object>
+  <object id="56" template="../../../obj/enemy.tx" x="193.477" y="293.735" width="32" height="32">
+     <properties>
+      <property name="defeatDialog">[{
+     &quot;condition&quot;: [{&quot;checkQuestFlag&quot;: &quot;Ch1CastlesComplete&quot;, &quot;not&quot;:true}],
+     &quot;text&quot;: &quot;As you land your final blow against Lathliss, you feel a significant pulse of mana. But with the immediate threat removed, you can now see clearly that the locked room at the north end of the chamber does not hold any prisoners.&quot;,
+     &quot;options&quot;: [{
+        &quot;name&quot;: &quot;(Continue)&quot;,
+        &quot;action&quot;: [{&quot;setQuestFlag&quot;: {&quot;key&quot;:&quot;Ch1RedCastleComplete&quot;, &quot;val&quot;: 1} }, {&quot;deleteMapObject&quot;: -1}, {&quot;advanceQuestFlag&quot;: &quot;Ch1CastlesComplete&quot;}]
+     }]
+  },
+  {
+     &quot;condition&quot;: [{&quot;checkQuestFlag&quot;: &quot;Ch1CastlesComplete&quot;}],
+     &quot;text&quot;: &quot;As you land your final blow against Lathliss, you feel a another pulse of mana. But just as before, the locked room behind your fallen foe does not hold any prisoners.&quot;,
+     &quot;options&quot;: [{
+        &quot;name&quot;: &quot;(Continue)&quot;,
+        &quot;action&quot;: [{&quot;setQuestFlag&quot;: {&quot;key&quot;:&quot;Ch1RedCastleComplete&quot;, &quot;val&quot;: 1} }, {&quot;deleteMapObject&quot;: -1}, {&quot;advanceQuestFlag&quot;: &quot;Ch1CastlesComplete&quot;}]
+     }]
+  }]</property>
+      <property name="effect" value="{ &quot;startBattleWithCardInCommandZone&quot;: [ &quot;Lathliss' Presence (Hard Mode)&quot;]}"/>
+        <property name="enemy" value="Lathliss"/>
+        <property name="spawn.Easy" type="bool" value="false"/>
+        <property name="spawn.Hard" type="bool" value="true"/>
+        <property name="spawn.Normal" type="bool" value="false"/>
+        <property name="threatRange" type="int" value="50"/>
+       </properties>
+    </object>
   <object id="54" template="../../../obj/scroll.tx" x="210" y="74">
    <properties>
     <property name="reward" value="[ { &quot;type&quot;: &quot;card&quot;, &quot;cardName&quot;: &quot;Mox Ruby&quot;, &quot;count&quot;: 1 }, {&quot;type&quot;: &quot;item&quot;, &quot;count&quot;: 1, &quot;itemName&quot;: &quot;Strange Key&quot;} ]"/>
@@ -103,16 +129,6 @@
 		]
 	}
 ]</property>
-   </properties>
-  </object>
-  <object id="56" template="../../../obj/enemy.tx" x="193.047" y="293.131" width="32" height="32">
-   <properties>
-    <property name="effect" value="{ &quot;startBattleWithCardInCommandZone&quot;: [ &quot;Lathliss' Presence (Hard Mode)&quot;]}"/>
-    <property name="enemy" value="Lathliss"/>
-    <property name="spawn.Easy" type="bool" value="false"/>
-    <property name="spawn.Hard" type="bool" value="true"/>
-    <property name="spawn.Normal" type="bool" value="false"/>
-    <property name="threatRange" type="int" value="50"/>
    </properties>
   </object>
  </objectgroup>


### PR DESCRIPTION
Hard mode didn't have the defeat dialogue because it spawned a different version of Lathliss without the defeat code.

(I had to duplicate the defeat code, which means that it is a little more error-prone to maintain, but hopefully that won't actually come up too much)