### PR TITLE
Re-adding item to New Game+ Adventure

### DIFF
--- a/forge-gui/res/adventure/Shandalar/world/quests.json
+++ b/forge-gui/res/adventure/Shandalar/world/quests.json
@@ -7038,6 +7038,7 @@
 						"action": [
 							{
 								"removeItem": "",
+								"addItem": "Colorless rune",
 								"setColorIdentity": "",
 								"advanceQuestFlag": "",
 								"advanceMapFlag": "",


### PR DESCRIPTION
When I put in the code to delete quest items on a new game+ I forgot to re-add the colorless rune that lets you teleport to the center of the map in case you start without the main quest (you get it as part of the main quest). This fixes that.