### PR TITLE
Cleanup: 2025-07-25

### DIFF
--- a/forge-gui/res/cardsfolder/a/abzan_falconer.txt
+++ b/forge-gui/res/cardsfolder/a/abzan_falconer.txt
@@ -3,7 +3,7 @@ ManaCost:2 W
 Types:Creature Human Soldier
 PT:2/3
 K:Outlast:W
-S:Mode$ Continuous | Affected$ Creature.YouCtrl+counters_GE1_P1P1 | AddKeyword$ Flying | Description$ Each creature you control wth a +1/+1 counter on it has flying.
+S:Mode$ Continuous | Affected$ Creature.YouCtrl+counters_GE1_P1P1 | AddKeyword$ Flying | Description$ Each creature you control with a +1/+1 counter on it has flying.
 SVar:PlayMain1:TRUE
 DeckHas:Ability$Counters
 DeckHints:Ability$Counters

--- a/forge-gui/res/cardsfolder/a/akroma_vision_of_ixidor.txt
+++ b/forge-gui/res/cardsfolder/a/akroma_vision_of_ixidor.txt
@@ -6,20 +6,20 @@ K:Flying
 K:First Strike
 K:Vigilance
 K:Trample
-T:Mode$ Phase | Phase$ BeginCombat | TriggerZones$ Battlefield | Execute$ Flying | TriggerDescription$ At the beginning of each combat, until end of turn, each other creature you control gets +1/+1 if it has flying, +1/+1 if it has first strike, and so on for double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, protection, reach, trample, vigilance, and partner.
-SVar:Flying:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withFlying | NumAtt$ +1 | NumDef$ +1 | SubAbility$ FirstStrike
-SVar:FirstStrike:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withFirst Strike | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DoubleStrike
-SVar:DoubleStrike:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withDouble Strike | NumAtt$ +1 | NumDef$ +1 | SubAbility$ Deathtouch
-SVar:Deathtouch:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withDeathtouch | NumAtt$ +1 | NumDef$ +1 | SubAbility$ Haste
-SVar:Haste:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withHaste | NumAtt$ +1 | NumDef$ +1 | SubAbility$ Hexproof
-SVar:Hexproof:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withHexproof | NumAtt$ +1 | NumDef$ +1 | SubAbility$ Indestructible
-SVar:Indestructible:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withIndestructible | NumAtt$ +1 | NumDef$ +1 | SubAbility$ Lifelink
-SVar:Lifelink:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withLifelink | NumAtt$ +1 | NumDef$ +1 | SubAbility$ Menace
-SVar:Menace:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withMenace | NumAtt$ +1 | NumDef$ +1 | SubAbility$ Protection
-SVar:Protection:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withProtection | NumAtt$ +1 | NumDef$ +1 | SubAbility$ Reach
-SVar:Reach:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withReach | NumAtt$ +1 | NumDef$ +1 | SubAbility$ Trample
-SVar:Trample:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withTrample | NumAtt$ +1 | NumDef$ +1 | SubAbility$ Vigilance
-SVar:Vigilance:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withVigilance | NumAtt$ +1 | NumDef$ +1 | SubAbility$ Partner
-SVar:Partner:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withPartner | NumAtt$ +1 | NumDef$ +1
+T:Mode$ Phase | Phase$ BeginCombat | TriggerZones$ Battlefield | Execute$ TrigFlying | TriggerDescription$ At the beginning of each combat, until end of turn, each other creature you control gets +1/+1 if it has flying, +1/+1 if it has first strike, and so on for double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, protection, reach, trample, vigilance, and partner.
+SVar:TrigFlying:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withFlying | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DBFirstStrike
+SVar:DBFirstStrike:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withFirst Strike | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DBDoubleStrike
+SVar:DBDoubleStrike:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withDouble Strike | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DBDeathtouch
+SVar:DBDeathtouch:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withDeathtouch | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DBHaste
+SVar:DBHaste:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withHaste | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DBHexproof
+SVar:DBHexproof:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withHexproof | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DBIndestructible
+SVar:DBIndestructible:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withIndestructible | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DBLifelink
+SVar:DBLifelink:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withLifelink | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DBMenace
+SVar:DBMenace:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withMenace | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DBProtection
+SVar:DBProtection:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withProtection | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DBReach
+SVar:DBReach:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withReach | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DBTrample
+SVar:DBTrample:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withTrample | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DBVigilance
+SVar:DBVigilance:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withVigilance | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DBPartner
+SVar:DBPartner:DB$ PumpAll | ValidCards$ Creature.Other+YouCtrl+withPartner | NumAtt$ +1 | NumDef$ +1
 K:Partner
 Oracle:Flying, first strike, vigilance, trample\nAt the beginning of each combat, until end of turn, each other creature you control gets +1/+1 if it has flying, +1/+1 if it has first strike, and so on for double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, protection, reach, trample, vigilance, and partner.\nPartner

--- a/forge-gui/res/cardsfolder/c/chaos_terminator_lord.txt
+++ b/forge-gui/res/cardsfolder/c/chaos_terminator_lord.txt
@@ -5,5 +5,5 @@ PT:3/3
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Lord of Chaos — At the beginning of combat on your turn, another target creature you control gains double strike until end of turn.
 SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.Other+YouCtrl | TgtPrompt$ Select another target creature you control | KW$ Double Strike
 SVar:PlayMain1:TRUE
-DeckHas:Keyword$DoubleStrike
+DeckHas:Keyword$Double Strike
 Oracle:Lord of Chaos — At the beginning of combat on your turn, another target creature you control gains double strike until end of turn.

--- a/forge-gui/res/cardsfolder/c/conversion.txt
+++ b/forge-gui/res/cardsfolder/c/conversion.txt
@@ -1,7 +1,7 @@
 Name:Conversion
 ManaCost:2 W W
 Types:Enchantment
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUpkeep | TriggerDescription$ At the beginning of your upkeep, sacrifice CARDNAME unless youpay {W}{W}.
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUpkeep | TriggerDescription$ At the beginning of your upkeep, sacrifice CARDNAME unless you pay {W}{W}.
 SVar:TrigUpkeep:DB$ Sacrifice | UnlessPayer$ You | UnlessCost$ W W
 S:Mode$ Continuous | Affected$ Mountain | AddType$ Plains | RemoveLandTypes$ True | Description$ All Mountains are Plains.
 AI:RemoveDeck:Random

--- a/forge-gui/res/cardsfolder/d/deathleaper_terror_weapon.txt
+++ b/forge-gui/res/cardsfolder/d/deathleaper_terror_weapon.txt
@@ -5,5 +5,5 @@ PT:3/3
 K:Flash
 K:Haste
 S:Mode$ Continuous | Affected$ Creature.YouCtrl+ThisTurnEntered | AddKeyword$ Double Strike | Description$ Flesh Hooks — Creatures you control that entered this turn have double strike.
-DeckHas:Keyword$DoubleStrike
+DeckHas:Keyword$Double Strike
 Oracle:Flash\nHaste\nFlesh Hooks — Creatures you control that entered this turn have double strike.

--- a/forge-gui/res/cardsfolder/d/djeru_and_hazoret.txt
+++ b/forge-gui/res/cardsfolder/d/djeru_and_hazoret.txt
@@ -12,4 +12,4 @@ SVar:X:Count$ValidHand Card.YouOwn
 SVar:PlayMain1:TRUE
 SVar:HasAttackEffect:TRUE
 DeckNeeds:Type$Legendary
-Oracle:As long as you have one or fewer cards in hand, Dieru and Hazoret has vigilance and haste.\nWhenever Djeru and Hazoret attacks, look at the top six cards of your library. You may exile a legendary creature card from among them. Put the rest on the bottom of your library in a random order. Until end of turn, you may cast the exiled card without paying its mana cost.
+Oracle:As long as you have one or fewer cards in hand, Djeru and Hazoret has vigilance and haste.\nWhenever Djeru and Hazoret attacks, look at the top six cards of your library. You may exile a legendary creature card from among them. Put the rest on the bottom of your library in a random order. Until end of turn, you may cast the exiled card without paying its mana cost.

--- a/forge-gui/res/cardsfolder/e/emberstrike_duo.txt
+++ b/forge-gui/res/cardsfolder/e/emberstrike_duo.txt
@@ -2,9 +2,9 @@ Name:Emberstrike Duo
 ManaCost:1 BR
 Types:Creature Elemental Warrior Shaman
 PT:1/1
-T:Mode$ SpellCast | ValidCard$ Card.Black | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPump11 | TriggerDescription$ Whenever you cast a black spell, CARDNAME gets +1/+1 until end of turn.
-T:Mode$ SpellCast | ValidCard$ Card.Red | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPumpFirstStrike | TriggerDescription$ Whenever you cast a red spell, CARDNAME gains first strike until end of turn.
-SVar:TrigPump11:DB$ Pump | NumAtt$ +1 | NumDef$ +1 | Defined$ Self
-SVar:TrigPumpFirstStrike:DB$ Pump | KW$ First Strike | Defined$ Self
+T:Mode$ SpellCast | ValidCard$ Card.Black | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPumpP1P1 | TriggerDescription$ Whenever you cast a black spell, CARDNAME gets +1/+1 until end of turn.
+T:Mode$ SpellCast | ValidCard$ Card.Red | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigFirstStrike | TriggerDescription$ Whenever you cast a red spell, CARDNAME gains first strike until end of turn.
+SVar:TrigPumpP1P1:DB$ Pump | NumAtt$ +1 | NumDef$ +1 | Defined$ Self
+SVar:TrigFirstStrike:DB$ Pump | KW$ First Strike | Defined$ Self
 SVar:BuffedBy:Card.Black,Card.Red
 Oracle:Whenever you cast a black spell, Emberstrike Duo gets +1/+1 until end of turn.\nWhenever you cast a red spell, Emberstrike Duo gains first strike until end of turn.

--- a/forge-gui/res/cardsfolder/e/emerald_dragonfly.txt
+++ b/forge-gui/res/cardsfolder/e/emerald_dragonfly.txt
@@ -4,5 +4,5 @@ Types:Creature Insect
 PT:1/1
 K:Flying
 A:AB$ Pump | Cost$ G G | Defined$ Self | KW$ First Strike | SpellDescription$ CARDNAME gains first strike until end of turn.
-DeckHas:Keyword$FirstStrike
+DeckHas:Keyword$First Strike
 Oracle:Flying\n{G}{G}: Emerald Dragonfly gains first strike until end of turn.

--- a/forge-gui/res/cardsfolder/f/fallaji_chaindancer.txt
+++ b/forge-gui/res/cardsfolder/f/fallaji_chaindancer.txt
@@ -3,5 +3,5 @@ ManaCost:3 R
 Types:Creature Human Soldier
 PT:2/4
 A:AB$ Pump | Cost$ 2 | Defined$ Self | KW$ Double Strike | SpellDescription$ CARDNAME gains double strike until end of turn.
-DeckHas:Keyword$DoubleStrike
+DeckHas:Keyword$Double Strike
 Oracle:{2}: Fallaji Chaindancer gains double strike until end of turn.

--- a/forge-gui/res/cardsfolder/g/gorilla_pack.txt
+++ b/forge-gui/res/cardsfolder/g/gorilla_pack.txt
@@ -2,7 +2,7 @@ Name:Gorilla Pack
 ManaCost:2 G
 Types:Creature Ape
 PT:3/3
-S:Mode$ CantAttack | ValidCard$ Card.Self | UUnlessDefender$ controlsForest | Description$ CARDNAME can't attack unless defending player controls a Forest.
+S:Mode$ CantAttack | ValidCard$ Card.Self | UnlessDefender$ controlsForest | Description$ CARDNAME can't attack unless defending player controls a Forest.
 T:Mode$ Always | TriggerZones$ Battlefield | IsPresent$ Forest.YouCtrl | PresentCompare$ EQ0 | Execute$ TrigSac | TriggerDescription$ When you control no Forests, sacrifice CARDNAME.
 SVar:TrigSac:DB$ Sacrifice
 SVar:NeedsToPlay:Forest.YouCtrl

--- a/forge-gui/res/cardsfolder/h/haunted_hellride.txt
+++ b/forge-gui/res/cardsfolder/h/haunted_hellride.txt
@@ -3,7 +3,7 @@ ManaCost:1 U B
 Types:Artifact Vehicle
 PT:3/3
 T:Mode$ AttackersDeclared | AttackingPlayer$ You | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever you attack, target creature you control gets +1/+0 and gains deathtouch until end of turn. Untap it.
-SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | NumAtt$ +1 | KW$ Deathtouch | SubABility$ DBUntap
+SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | NumAtt$ +1 | KW$ Deathtouch | SubAbility$ DBUntap
 SVar:DBUntap:DB$ Untap | Defined$ Targeted
 K:Crew:1
 SVar:PlayMain1:TRUE

--- a/forge-gui/res/cardsfolder/j/jon_irenicus_shattered_one.txt
+++ b/forge-gui/res/cardsfolder/j/jon_irenicus_shattered_one.txt
@@ -9,7 +9,7 @@ SVar:DBPutCounters:DB$ PutCounter | Defined$ TargetedCard | CounterType$ P1P1 | 
 SVar:DBTap:DB$ Tap | Defined$ Targeted | SubAbility$ DBGoad
 SVar:DBGoad:DB$ Goad | Defined$ Targeted | Duration$ Permanent | SubAbility$ DBDisableSacing
 SVar:DBDisableSacing:DB$ Animate | Defined$ Targeted | staticAbilities$ SCantSac | Duration$ Permanent
-SVar:SCantSac:Mode$ CantSacrifice | ValidCard$ Card.Self | Description$ This creature cannot be sacrificed.
+SVar:SCantSac:Mode$ CantSacrifice | ValidCard$ Card.Self | Description$ This creature can't be sacrificed.
 T:Mode$ Attacks | ValidCard$ Creature.YouDontCtrl+YouOwn | TriggerZones$ Battlefield | Execute$ DrawACard | TriggerDescription$ Whenever a creature you own but don't control attacks, you draw a card.
 SVar:DrawACard:DB$ Draw | Defined$ You | NumCards$ 1
 Oracle:At the beginning of your end step, target opponent gains control of up to one target creature you control. Put two +1/+1 counters on it and tap it. It's goaded for the rest of the game and it gains "This creature can't be sacrificed." (It attacks each combat if able and attacks a player other than you if able.)\nWhenever a creature you own but don't control attacks, you draw a card.

--- a/forge-gui/res/cardsfolder/l/lance.txt
+++ b/forge-gui/res/cardsfolder/l/lance.txt
@@ -4,5 +4,5 @@ Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Pump
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddKeyword$ First Strike | Description$ Enchanted creature has first strike.
-DeckHas:Keyword$FirstStrike
+DeckHas:Keyword$First Strike
 Oracle:Enchant creature\nEnchanted creature has first strike.

--- a/forge-gui/res/cardsfolder/m/mardu_charm.txt
+++ b/forge-gui/res/cardsfolder/m/mardu_charm.txt
@@ -1,10 +1,10 @@
 Name:Mardu Charm
 ManaCost:R W B
 Types:Instant
-A:SP$ Charm | Choices$ DealDmg,Warrior,DBDiscard | CharmNum$ 1
-SVar:DealDmg:DB$ DealDamage | ValidTgts$ Creature | NumDmg$ 4 | SpellDescription$ CARDNAME deals 4 damage to target creature.
-SVar:Warrior:DB$ Token | TokenAmount$ 2 | TokenScript$ w_1_1_warrior | TokenOwner$ You | RememberTokens$ True | SubAbility$ DBPumpFirstStrike | SpellDescription$ Create two 1/1 white Warrior creature tokens. They gain first strike until end of turn.
-SVar:DBPumpFirstStrike:DB$ PumpAll | ValidCards$ Creature.IsRemembered | KW$ First Strike | SubAbility$ DBCleanUp
+A:SP$ Charm | Choices$ DBDealDmg,DBWarrior,DBDiscard | CharmNum$ 1
+SVar:DBDealDmg:DB$ DealDamage | ValidTgts$ Creature | NumDmg$ 4 | SpellDescription$ CARDNAME deals 4 damage to target creature.
+SVar:DBWarrior:DB$ Token | TokenAmount$ 2 | TokenScript$ w_1_1_warrior | TokenOwner$ You | RememberTokens$ True | SubAbility$ DBFirstStrike | SpellDescription$ Create two 1/1 white Warrior creature tokens. They gain first strike until end of turn.
+SVar:DBFirstStrike:DB$ PumpAll | ValidCards$ Creature.IsRemembered | KW$ First Strike | SubAbility$ DBCleanUp
 SVar:DBCleanUp:DB$ Cleanup | ClearRemembered$ True
 SVar:DBDiscard:DB$ Discard | ValidTgts$ Opponent | Mode$ RevealYouChoose | DiscardValid$ Card.nonCreature+nonLand | DiscardValidDesc$ noncreature, nonland | SpellDescription$ Target opponent reveals their hand. You choose a noncreature, nonland card from it. That player discards that card.
 Oracle:Choose one —\n• Mardu Charm deals 4 damage to target creature.\n• Create two 1/1 white Warrior creature tokens. They gain first strike until end of turn.\n• Target opponent reveals their hand. You choose a noncreature, nonland card from it. That player discards that card.

--- a/forge-gui/res/cardsfolder/m/marton_stromgald.txt
+++ b/forge-gui/res/cardsfolder/m/marton_stromgald.txt
@@ -5,7 +5,7 @@ PT:1/1
 T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPumpAttack | TriggerDescription$ Whenever CARDNAME attacks, other attacking creatures get +1/+1 until end of turn for each attacking creature other than CARDNAME.
 SVar:TrigPumpAttack:DB$ PumpAll | ValidCards$ Creature.attacking+Other | NumAtt$ +X | NumDef$ +X
 SVar:X:Count$Valid Creature.attacking+Other
-T:Mode$ Blocks | ValidCard$ Card.Self | Triggerzones$ Battlefield | Execute$ TrigPumpBlock | TriggerDescription$ Whenever CARDNAME blocks, other blocking creatures get +1/+1 until end of turn for each blocking creature other than CARDNAME.
+T:Mode$ Blocks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPumpBlock | TriggerDescription$ Whenever CARDNAME blocks, other blocking creatures get +1/+1 until end of turn for each blocking creature other than CARDNAME.
 SVar:TrigPumpBlock:DB$ PumpAll | ValidCards$ Creature.blocking+Other | NumAtt$ +Y | NumDef$ +Y
 SVar:Y:Count$Valid Creature.blocking+Other
 Oracle:Whenever Márton Stromgald attacks, other attacking creatures get +1/+1 until end of turn for each attacking creature other than Márton Stromgald.\nWhenever Márton Stromgald blocks, other blocking creatures get +1/+1 until end of turn for each blocking creature other than Márton Stromgald.

--- a/forge-gui/res/cardsfolder/n/naktamun_shines_again.txt
+++ b/forge-gui/res/cardsfolder/n/naktamun_shines_again.txt
@@ -5,5 +5,5 @@ K:Chapter:3:TrigPumpP1,TrigSeek,TrigPumpFly
 SVar:TrigPumpP1:DB$ PumpAll | ValidCards$ Creature.YouOwn+!token+cmcLE2 | PumpZone$ All | Duration$ Perpetual | NumAtt$ +1 | SpellDescription$ All creature cards you own with mana value 2 or less perpetually get +1/+0.
 SVar:TrigSeek:DB$ Seek | Type$ Creature.cmcLE2 | RememberFound$ True | SubAbility$ DBPut | SpellDescription$ Seek a creature with mana value 2 or less and put it onto the battlefield.
 SVar:DBPut:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | Defined$ Remembered
-SVar:TrigPumpFly:DB$ PumpAll | ValidCards$ Creature.YouCtrl+cmcLE2 | KW$ Flying | SpellDescription$ Creatures you controll with mana value 2 or less gain flying until end of turn.
+SVar:TrigPumpFly:DB$ PumpAll | ValidCards$ Creature.YouCtrl+cmcLE2 | KW$ Flying | SpellDescription$ Creatures you control with mana value 2 or less gain flying until end of turn.
 Oracle:(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI — All creature cards you own with mana value 2 or less perpetually get +1/+0.\nII — Seek a creature with mana value 2 or less and put it onto the battlefield.\nIII — Creatures you control with mana value 2 or less gain flying until end of turn.

--- a/forge-gui/res/cardsfolder/p/primeval_bounty.txt
+++ b/forge-gui/res/cardsfolder/p/primeval_bounty.txt
@@ -8,4 +8,4 @@ SVar:TrigPutCounter:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ 3 | ValidTg
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigGainLife | TriggerDescription$ Landfall — Whenever a land you control enters, you gain 3 life.
 SVar:TrigGainLife:DB$ GainLife | LifeAmount$ 3
 SVar:BuffedBy:nonCreature
-Oracle:Whenever you cast a creature spell, create a 3/3 green Beast creature token.\nWhenever you cast a noncreature spell, put three +1/+1 counters on target creature you control.\nLandfall — nWhenever a land you control enters, you gain 3 life.
+Oracle:Whenever you cast a creature spell, create a 3/3 green Beast creature token.\nWhenever you cast a noncreature spell, put three +1/+1 counters on target creature you control.\nLandfall — Whenever a land you control enters, you gain 3 life.

--- a/forge-gui/res/cardsfolder/r/restless_spire.txt
+++ b/forge-gui/res/cardsfolder/r/restless_spire.txt
@@ -4,8 +4,8 @@ Types:Land
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 A:AB$ Mana | Cost$ T | Produced$ Combo U R | SpellDescription$ Add {U} or {R}.
-A:AB$ Animate | Cost$ U R | Defined$ Self | Power$ 2 | Toughness$ 1 | staticAbilities$ FirstStrikeStatic | Types$ Creature,Elemental | Colors$ Blue,Red | OverwriteColors$ True | SpellDescription$ Until end of turn, CARDNAME becomes a 2/1 blue and red Elemental creature with "During your turn, this creature has first strike." It's still a land.
-SVar:FirstStrikeStatic:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ First Strike | Condition$ PlayerTurn | Description$ During your turn, CARDNAME has first strike.
+A:AB$ Animate | Cost$ U R | Defined$ Self | Power$ 2 | Toughness$ 1 | staticAbilities$ STFirstStrike | Types$ Creature,Elemental | Colors$ Blue,Red | OverwriteColors$ True | SpellDescription$ Until end of turn, CARDNAME becomes a 2/1 blue and red Elemental creature with "During your turn, this creature has first strike." It's still a land.
+SVar:STFirstStrike:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ First Strike | Condition$ PlayerTurn | Description$ During your turn, CARDNAME has first strike.
 T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigScry | TriggerDescription$ Whenever CARDNAME attacks, scry 1.
 SVar:TrigScry:DB$ Scry | ScryNum$ 1
 SVar:HasAttackEffect:TRUE

--- a/forge-gui/res/cardsfolder/rebalanced/a-ancestral_katana.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-ancestral_katana.txt
@@ -4,8 +4,8 @@ Types:Artifact Equipment
 T:Mode$ Attacks | ValidCard$ Samurai.YouCtrl,Warrior.YouCtrl | Alone$ True | TriggerZones$ Battlefield | Execute$ TrigImmediateTrig | TriggerDescription$ Whenever a Samurai or Warrior you control attacks alone, you may pay {1}. When you do, attach CARDNAME to it.
 SVar:TrigImmediateTrig:AB$ ImmediateTrigger | Cost$ 1 | Execute$ TrigAttach | RememberObjects$ TriggeredAttackerLKICopy | TriggerDescription$ When you do, attach CARDNAME to it.
 SVar:TrigAttach:DB$ Attach | Defined$ DelayTriggerRememberedLKI
-S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 2 | AddToughness$ 2 | AddStaticAbility$ FirstStrike | Description$ Equipped creature gets +2/+2 and has "This creature has first strike as long as it's attacking."
-SVar:FirstStrike:Mode$ Continuous | Affected$ Card.Self+attacking | AddKeyword$ First Strike | Description$ This creature has first strike as long as it's attacking.
+S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 2 | AddToughness$ 2 | AddStaticAbility$ STFirstStrike | Description$ Equipped creature gets +2/+2 and has "This creature has first strike as long as it's attacking."
+SVar:STFirstStrike:Mode$ Continuous | Affected$ Card.Self+attacking | AddKeyword$ First Strike | Description$ This creature has first strike as long as it's attacking.
 K:Equip:2
 DeckHints:Type$Samurai|Warrior
 Oracle:Whenever a Samurai or Warrior you control attacks alone, you may pay {1}. When you do, attach Ancestral Katana to it.\nEquipped creature gets +2/+2 and has "This creature has first strike as long as it's attacking."\nEquip {2}

--- a/forge-gui/res/cardsfolder/s/sarevok_the_usurper.txt
+++ b/forge-gui/res/cardsfolder/s/sarevok_the_usurper.txt
@@ -20,7 +20,7 @@ K:First Strike
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ At the beginning of combat on your turn, target creature you control gains first strike and gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard.
 SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | NumAtt$ +X | KW$ First Strike
 SVar:X:Count$ValidGraveyard Creature.YouOwn
-DeckHas:Ability$Graveyard & Keyword$FirstStrike
+DeckHas:Ability$Graveyard & Keyword$First Strike
 Oracle:First strike\nAt the beginning of combat on your turn, target creature you control gains first strike and gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard.
 
 SPECIALIZE:BLUE

--- a/forge-gui/res/cardsfolder/s/sidequest_card_collection_magicked_card.txt
+++ b/forge-gui/res/cardsfolder/s/sidequest_card_collection_magicked_card.txt
@@ -19,4 +19,4 @@ Types:Artifact Vehicle
 PT:4/4
 K:Flying
 K:Crew:1
-Oracle:Flying\nCrew 1 (Tap any number of creatured you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)
+Oracle:Flying\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)

--- a/forge-gui/res/cardsfolder/s/skanos_dragon_vassal.txt
+++ b/forge-gui/res/cardsfolder/s/skanos_dragon_vassal.txt
@@ -63,7 +63,7 @@ T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ Tr
 SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.attacking+Other | TgtPrompt$ Select another target attacking creature | NumAtt$ +X | KW$ First Strike
 SVar:X:Count$CardPower
 SVar:HasAttackEffect:TRUE
-DeckHas:Keyword$FirstStrike
+DeckHas:Keyword$First Strike
 Oracle:First strike\nWhenever Skanos, Red Dragon Vassal attacks, another target attacking creature gains first strike and gets +X/+0 until end of turn, where X is Skanos's power.
 
 SPECIALIZE:GREEN

--- a/forge-gui/res/cardsfolder/s/skorpekh_destroyer.txt
+++ b/forge-gui/res/cardsfolder/s/skorpekh_destroyer.txt
@@ -5,6 +5,6 @@ PT:4/2
 K:Deathtouch
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Artifact.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Hyperphase Threshers — Whenever an artifact you control enters, CARDNAME gains first strike until end of turn.
 SVar:TrigPump:DB$ Pump | Defined$ Self | KW$ First Strike
-DeckHas:Keyword$FirstStrike
+DeckHas:Keyword$First Strike
 DeckHints:Type$Artifact
 Oracle:Deathtouch\nHyperphase Threshers — Whenever an artifact you control enters, Skorpekh Destroyer gains first strike until end of turn.

--- a/forge-gui/res/cardsfolder/s/skyserpent_seeker.txt
+++ b/forge-gui/res/cardsfolder/s/skyserpent_seeker.txt
@@ -4,7 +4,7 @@ Types:Creature Snake
 PT:1/1
 K:Flying
 K:Deathtouch
-A:AB$ DigUntil | Cost$ 4 | Valid$ Land | ValidDescription$ land | Amount$ 2 | FoundDestination$ Battlefield | Tapped$ True | RevealedDestination$ Library | RevealedLibraryPosition$ -1 | RevealRandomOrder$ True | Exhaust$ True | SubABility$ DBPutCounter | SpellDescription$ Reveal cards from the top of your library until you reveal two land cards. Put those land cards onto the battlefield tapped and the rest on the bottom of your library in a random order. Put a +1/+1 counter on this creature. (Activate each exhaust ability only once.)
+A:AB$ DigUntil | Cost$ 4 | Valid$ Land | ValidDescription$ land | Amount$ 2 | FoundDestination$ Battlefield | Tapped$ True | RevealedDestination$ Library | RevealedLibraryPosition$ -1 | RevealRandomOrder$ True | Exhaust$ True | SubAbility$ DBPutCounter | SpellDescription$ Reveal cards from the top of your library until you reveal two land cards. Put those land cards onto the battlefield tapped and the rest on the bottom of your library in a random order. Put a +1/+1 counter on this creature. (Activate each exhaust ability only once.)
 SVar:DBPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
 DeckHas:Ability$Counters
 Oracle:Flying, deathtouch\nExhaust — {4}: Reveal cards from the top of your library until you reveal two land cards. Put those land cards onto the battlefield tapped and the rest on the bottom of your library in a random order. Put a +1/+1 counter on this creature. (Activate each exhaust ability only once.)

--- a/forge-gui/res/cardsfolder/s/spitting_slug.txt
+++ b/forge-gui/res/cardsfolder/s/spitting_slug.txt
@@ -7,5 +7,5 @@ T:Mode$ Blocks | ValidCard$ Card.Self | Execute$ PumpSelf | Secondary$ True | Tr
 SVar:PumpSelf:DB$ Pump | Defined$ Self | KW$ First Strike | UnlessCost$ 1 G | UnlessPayer$ You | UnlessSwitched$ True | UnlessResolveSubs$ WhenNotPaid | SubAbility$ PumpOthers
 SVar:PumpOthers:DB$ PumpAll | ValidCards$ Creature.blockingSource,Creature.blockedBySource | KW$ First Strike
 AI:RemoveDeck:All
-DeckHas:Keyword$FirstStrike
+DeckHas:Keyword$First Strike
 Oracle:Whenever Spitting Slug blocks or becomes blocked, you may pay {1}{G}. If you do, Spitting Slug gains first strike until end of turn. Otherwise, each creature blocking or blocked by Spitting Slug gains first strike until end of turn.

--- a/forge-gui/res/cardsfolder/t/thunderous_orator.txt
+++ b/forge-gui/res/cardsfolder/t/thunderous_orator.txt
@@ -3,14 +3,14 @@ ManaCost:1 W
 Types:Creature Kor Wizard
 PT:2/2
 K:Vigilance
-T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ PumpFlying | TriggerDescription$ Whenever CARDNAME attacks, it gains flying until end of turn if you control a creature with flying. The same is true for first strike, double strike, deathtouch, indestructible, lifelink, menace, and trample.
-SVar:PumpFlying:DB$ Pump | Defined$ Self | KW$ Flying | ConditionPresent$ Creature.YouCtrl+withFlying | SubAbility$ PumpFirstStrike
-SVar:PumpFirstStrike:DB$ Pump | Defined$ Self | KW$ First Strike | ConditionPresent$ Creature.YouCtrl+withFirst Strike | SubAbility$ PumpDoubleStrike
-SVar:PumpDoubleStrike:DB$ Pump | Defined$ Self | KW$ Double Strike | ConditionPresent$ Creature.YouCtrl+withDouble Strike | SubAbility$ PumpDeathtouch
-SVar:PumpDeathtouch:DB$ Pump | Defined$ Self | KW$ Deathtouch | ConditionPresent$ Creature.YouCtrl+withDeathtouch | SubAbility$ PumpIndestructible
-SVar:PumpIndestructible:DB$ Pump | Defined$ Self | KW$ Indestructible | ConditionPresent$ Creature.YouCtrl+withIndestructible | SubAbility$ PumpLifelink
-SVar:PumpLifelink:DB$ Pump | Defined$ Self | KW$ Lifelink | ConditionPresent$ Creature.YouCtrl+withLifelink | SubAbility$ PumpMenace
-SVar:PumpMenace:DB$ Pump | Defined$ Self | KW$ Menace | ConditionPresent$ Creature.YouCtrl+withMenace | SubAbility$ PumpTrample
-SVar:PumpTrample:DB$ Pump | Defined$ Self | KW$ Trample | ConditionPresent$ Creature.YouCtrl+withTrample
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigFlying | TriggerDescription$ Whenever CARDNAME attacks, it gains flying until end of turn if you control a creature with flying. The same is true for first strike, double strike, deathtouch, indestructible, lifelink, menace, and trample.
+SVar:TrigFlying:DB$ Pump | Defined$ Self | KW$ Flying | ConditionPresent$ Creature.YouCtrl+withFlying | SubAbility$ DBFirstStrike
+SVar:DBFirstStrike:DB$ Pump | Defined$ Self | KW$ First Strike | ConditionPresent$ Creature.YouCtrl+withFirst Strike | SubAbility$ DBDoubleStrike
+SVar:DBDoubleStrike:DB$ Pump | Defined$ Self | KW$ Double Strike | ConditionPresent$ Creature.YouCtrl+withDouble Strike | SubAbility$ DBDeathtouch
+SVar:DBDeathtouch:DB$ Pump | Defined$ Self | KW$ Deathtouch | ConditionPresent$ Creature.YouCtrl+withDeathtouch | SubAbility$ DBIndestructible
+SVar:DBIndestructible:DB$ Pump | Defined$ Self | KW$ Indestructible | ConditionPresent$ Creature.YouCtrl+withIndestructible | SubAbility$ DBLifelink
+SVar:DBLifelink:DB$ Pump | Defined$ Self | KW$ Lifelink | ConditionPresent$ Creature.YouCtrl+withLifelink | SubAbility$ DBMenace
+SVar:DBMenace:DB$ Pump | Defined$ Self | KW$ Menace | ConditionPresent$ Creature.YouCtrl+withMenace | SubAbility$ DBTrample
+SVar:DBTrample:DB$ Pump | Defined$ Self | KW$ Trample | ConditionPresent$ Creature.YouCtrl+withTrample
 DeckHints:Keyword$Flying|First Strike|Double Strike|Deathtouch|Indestructible|Lifelink|Menace|Trample
 Oracle:Vigilance\nWhenever Thunderous Orator attacks, it gains flying until end of turn if you control a creature with flying. The same is true for first strike, double strike, deathtouch, indestructible, lifelink, menace, and trample.

--- a/forge-gui/res/cardsfolder/u/unnatural_summons.txt
+++ b/forge-gui/res/cardsfolder/u/unnatural_summons.txt
@@ -4,5 +4,5 @@ Types:Sorcery
 K:Rebound
 S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ If you weren't the starting player, this spell costs {1} less to cast.
 SVar:X:Count$StartingPlayer.0.1
-A:SP$ ManifestDread | SpellDescription$ Maniest dread.
+A:SP$ ManifestDread | SpellDescription$ Manifest dread.
 Oracle:If you weren't the starting player, this spell costs {1} less to cast.\nManifest dread.\nRebound

--- a/forge-gui/res/cardsfolder/w/warzone_duplicator.txt
+++ b/forge-gui/res/cardsfolder/w/warzone_duplicator.txt
@@ -3,7 +3,7 @@ ManaCost:6
 Types:Artifact Creature Construct
 PT:6/6
 K:Prototype:3 U:3:3
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigReturn | TriggerDescription$ When CARDNAME enters, return target creature an opponentcontrols with power less than CARDNAME's power to its owner's hand. If that creature wasn't a token, conjure a duplicate of it into your hand. It perpetually gains "You may spend mana as though it were mana of any color to cast this spell."
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigReturn | TriggerDescription$ When CARDNAME enters, return target creature an opponent controls with power less than CARDNAME's power to its owner's hand. If that creature wasn't a token, conjure a duplicate of it into your hand. It perpetually gains "You may spend mana as though it were mana of any color to cast this spell."
 SVar:TrigReturn:DB$ ChangeZone | ValidTgts$ Creature.OppCtrl+powerLTTriggeredCard$CardPower | Origin$ Battlefield | Destination$ Hand | TgtPrompt$ Select target creature an opponent controls with power less than CARDNAME's power | SubAbility$ DBConjure
 SVar:DBConjure:DB$ MakeCard | Conjure$ True | ConditionDefined$ Targeted | ConditionPresent$ Card.!token | DefinedName$ Targeted | Zone$ Hand | RememberMade$ True | SubAbility$ DBAnimate
 SVar:DBAnimate:DB$ Animate | Defined$ Remembered | staticAbilities$ SpendAnyMana | Duration$ Perpetual | SubAbility$ DBCleanup

--- a/forge-gui/res/cardsfolder/w/wilson_bear_comrade.txt
+++ b/forge-gui/res/cardsfolder/w/wilson_bear_comrade.txt
@@ -74,7 +74,7 @@ A:AB$ Pump | Cost$ 1 R G ExileFromGrave<1/CARDNAME> | ActivationZone$ Graveyard 
 SVar:DBEffect:DB$ Effect | Name$ Wilson, Ardent Bear's Perpetual Effect | StaticAbilities$ PerpetualDoubleStrike | RememberObjects$ Targeted | Duration$ Permanent | SubAbility$ DBCleanup
 SVar:PerpetualDoubleStrike:Mode$ Continuous | Affected$ Card.IsRemembered | AddKeyword$ Double Strike | AffectedZone$ All | Description$ This creature perpetually gains double strike.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-DeckHas:Keyword$DoubleStrike
+DeckHas:Keyword$Double Strike
 Oracle:Double strike, reach, trample\nWard {2}\n{1}{B}{G}, Exile Wilson, Ardent Bear from your graveyard: Target creature you control perpetually gains double strike. Activate only as a sorcery.
 
 SPECIALIZE:GREEN


### PR DESCRIPTION
- Sundry typos, with a few arguably functional ones involving parameter capitalization
- Some `SubAbility$` argument/name standardization to follow existing patterns and ease future cleanup passes.