### PR TITLE
Resolving the land shop issue in Shandalar Old World.

### DIFF
--- a/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Black.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Black.dck
@@ -1,0 +1,46 @@
+[metadata]
+Name=Land Shop - Black Commons
+[Avatar]
+
+[Main]
+
+1 Swamp|LEA|1
+1 Swamp|LEB|1
+1 Swamp|2ED|1
+1 Swamp|3ED|1
+1 Swamp|4ED|1
+1 Swamp|ICE|1
+1 Snow-Covered Swamp|ICE|1
+1 Swamp|MIR|1
+1 Swamp|MIR|2
+1 Swamp|5ED|1
+1 Swamp|5ED|2
+1 Swamp|POR|1
+1 Swamp|POR|2
+1 Swamp|TMP|1
+1 Swamp|TMP|2
+1 Swamp|PO2|1
+1 Swamp|USG|1
+1 Swamp|USG|2
+1 Swamp|6ED|1
+1 Swamp|6ED|2
+1 Swamp|PTK|1
+1 Swamp|S99|1
+1 Swamp|S99|2
+1 Swamp|MMQ|2
+1 Swamp|MMQ|1
+1 Swamp|BRB|1
+1 Swamp|BRB|2
+1 Swamp|BTD|1
+1 Swamp|INV|1
+1 Swamp|INV|2
+1 Swamp|7ED|1
+1 Swamp|7ED|2
+1 Swamp|ODY|1
+1 Swamp|ODY|2
+1 Swamp|ONS|1
+1 Swamp|ONS|2
+
+[Sideboard]
+
+

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Black_R.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Black_R.dck
@@ -1,0 +1,40 @@
+[metadata]
+Name=Land Shop - Black Rares
+[Avatar]
+
+[Main]
+
+1 Swamp|LEB|3
+1 Swamp|2ED|3
+1 Swamp|3ED|3
+1 Swamp|4ED|3
+1 Swamp|ICE|3
+1 Swamp|MIR|4
+1 Swamp|5ED|4
+1 Swamp|POR|4
+1 Swamp|TMP|4
+1 Swamp|PO2|3
+1 Swamp|PALP|1
+1 Swamp|PALP|2
+1 Swamp|PALP|3
+1 Swamp|USG|4
+1 Swamp|6ED|4
+1 Swamp|PTK|3
+1 Swamp|S99|4
+1 Swamp|PGRU|1
+1 Swamp|MMQ|4
+1 Swamp|BRB|5
+1 Swamp|PELP|1
+1 Swamp|PELP|2
+1 Swamp|PELP|3
+1 Swamp|BTD|3
+1 Swamp|INV|4
+1 Swamp|7ED|4
+1 Swamp|ODY|4
+1 Swamp|ONS|4
+
+
+[Sideboard]
+
+
+

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Black_S.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Black_S.dck
@@ -1,0 +1,9 @@
+[metadata]
+Name=Land Shop - Black Snow-Covered
+[Avatar]
+
+[Main]
+
+1 Snow-Covered Swamp|ICE|1
+
+[Sideboard]

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Black_U.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Black_U.dck
@@ -1,0 +1,35 @@
+[metadata]
+Name=Land Shop - Black Uncommons
+[Avatar]
+
+[Main]
+
+1 Swamp|LEA|2
+1 Swamp|LEB|2
+1 Swamp|2ED|2
+1 Swamp|3ED|2
+1 Swamp|4ED|2
+1 Swamp|ICE|2
+1 Swamp|MIR|3
+1 Swamp|5ED|3
+1 Swamp|POR|3
+1 Swamp|TMP|3
+1 Swamp|PO2|2
+1 Swamp|USG|3
+1 Swamp|6ED|3
+1 Swamp|PTK|2
+1 Swamp|S99|3
+1 Swamp|MMQ|3
+1 Swamp|BRB|3
+1 Swamp|BRB|4
+1 Swamp|BTD|2
+1 Swamp|INV|3
+1 Swamp|7ED|3
+1 Swamp|ODY|3
+1 Swamp|ONS|3
+
+
+
+[Sideboard]
+
+

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Blue.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Blue.dck
@@ -1,0 +1,46 @@
+[metadata]
+Name=Land Shop - Blue Commons
+[Avatar]
+
+[Main]
+
+1 Island|LEA|1
+1 Island|LEB|1
+1 Island|2ED|1
+1 Island|3ED|1
+1 Island|4ED|1
+1 Island|ICE|1
+1 Snow-Covered Island|ICE|1
+1 Island|MIR|1
+1 Island|MIR|2
+1 Island|5ED|1
+1 Island|5ED|2
+1 Island|POR|1
+1 Island|POR|2
+1 Island|TMP|1
+1 Island|TMP|2
+1 Island|PO2|1
+1 Island|USG|1
+1 Island|USG|2
+1 Island|6ED|1
+1 Island|6ED|2
+1 Island|PTK|1
+1 Island|S99|1
+1 Island|S99|2
+1 Island|MMQ|2
+1 Island|MMQ|1
+1 Island|BRB|1
+1 Island|BRB|2
+1 Island|BTD|1
+1 Island|INV|1
+1 Island|INV|2
+1 Island|7ED|1
+1 Island|7ED|2
+1 Island|ODY|1
+1 Island|ODY|2
+1 Island|ONS|1
+1 Island|ONS|2
+
+[Sideboard]
+
+

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Blue_R.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Blue_R.dck
@@ -1,0 +1,40 @@
+[metadata]
+Name=Land Shop - Blue Rares
+[Avatar]
+
+[Main]
+
+1 Island|LEB|3
+1 Island|2ED|3
+1 Island|3ED|3
+1 Island|4ED|3
+1 Island|ICE|3
+1 Island|MIR|4
+1 Island|5ED|4
+1 Island|POR|4
+1 Island|TMP|4
+1 Island|PO2|3
+1 Island|PALP|1
+1 Island|PALP|2
+1 Island|PALP|3
+1 Island|USG|4
+1 Island|6ED|4
+1 Island|PTK|3
+1 Island|S99|4
+1 Island|PGRU|1
+1 Island|MMQ|4
+1 Island|BRB|5
+1 Island|PELP|1
+1 Island|PELP|2
+1 Island|PELP|3
+1 Island|BTD|3
+1 Island|INV|4
+1 Island|7ED|4
+1 Island|ODY|4
+1 Island|ONS|4
+
+
+[Sideboard]
+
+
+

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Blue_S.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Blue_S.dck
@@ -1,0 +1,9 @@
+[metadata]
+Name=Land Shop - Blue Snow-Covered
+[Avatar]
+
+[Main]
+
+1 Snow-Covered Island|ICE|1
+
+[Sideboard]

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Blue_U.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Blue_U.dck
@@ -1,0 +1,35 @@
+[metadata]
+Name=Land Shop - Blue Uncommons
+[Avatar]
+
+[Main]
+
+1 Island|LEA|2
+1 Island|LEB|2
+1 Island|2ED|2
+1 Island|3ED|2
+1 Island|4ED|2
+1 Island|ICE|2
+1 Island|MIR|3
+1 Island|5ED|3
+1 Island|POR|3
+1 Island|TMP|3
+1 Island|PO2|2
+1 Island|USG|3
+1 Island|6ED|3
+1 Island|PTK|2
+1 Island|S99|3
+1 Island|MMQ|3
+1 Island|BRB|3
+1 Island|BRB|4
+1 Island|BTD|2
+1 Island|INV|3
+1 Island|7ED|3
+1 Island|ODY|3
+1 Island|ONS|3
+
+
+
+[Sideboard]
+
+

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Green.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Green.dck
@@ -1,0 +1,46 @@
+[metadata]
+Name=Land Shop - Green Commons
+[Avatar]
+
+[Main]
+
+1 Forest|LEA|1
+1 Forest|LEB|1
+1 Forest|2ED|1
+1 Forest|3ED|1
+1 Forest|4ED|1
+1 Forest|ICE|1
+1 Snow-Covered Forest|ICE|1
+1 Forest|MIR|1
+1 Forest|MIR|2
+1 Forest|5ED|1
+1 Forest|5ED|2
+1 Forest|POR|1
+1 Forest|POR|2
+1 Forest|TMP|1
+1 Forest|TMP|2
+1 Forest|PO2|1
+1 Forest|USG|1
+1 Forest|USG|2
+1 Forest|6ED|1
+1 Forest|6ED|2
+1 Forest|PTK|1
+1 Forest|S99|1
+1 Forest|S99|2
+1 Forest|MMQ|2
+1 Forest|MMQ|1
+1 Forest|BRB|1
+1 Forest|BRB|2
+1 Forest|BTD|1
+1 Forest|INV|1
+1 Forest|INV|2
+1 Forest|7ED|1
+1 Forest|7ED|2
+1 Forest|ODY|1
+1 Forest|ODY|2
+1 Forest|ONS|1
+1 Forest|ONS|2
+
+[Sideboard]
+
+

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Green_R.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Green_R.dck
@@ -1,0 +1,40 @@
+[metadata]
+Name=Land Shop - Green Rares
+[Avatar]
+
+[Main]
+
+1 Forest|LEB|3
+1 Forest|2ED|3
+1 Forest|3ED|3
+1 Forest|4ED|3
+1 Forest|ICE|3
+1 Forest|MIR|4
+1 Forest|5ED|4
+1 Forest|POR|4
+1 Forest|TMP|4
+1 Forest|PO2|3
+1 Forest|PALP|1
+1 Forest|PALP|2
+1 Forest|PALP|3
+1 Forest|USG|4
+1 Forest|6ED|4
+1 Forest|PTK|3
+1 Forest|S99|4
+1 Forest|PGRU|1
+1 Forest|MMQ|4
+1 Forest|BRB|5
+1 Forest|PELP|1
+1 Forest|PELP|2
+1 Forest|PELP|3
+1 Forest|BTD|3
+1 Forest|INV|4
+1 Forest|7ED|4
+1 Forest|ODY|4
+1 Forest|ONS|4
+
+
+[Sideboard]
+
+
+

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Green_S.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Green_S.dck
@@ -1,0 +1,9 @@
+[metadata]
+Name=Land Shop - Green Snow-Covered
+[Avatar]
+
+[Main]
+
+1 Snow-Covered Forest|ICE|1
+
+[Sideboard]

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Green_U.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Green_U.dck
@@ -1,0 +1,35 @@
+[metadata]
+Name=Land Shop - Green Uncommons
+[Avatar]
+
+[Main]
+
+1 Forest|LEA|2
+1 Forest|LEB|2
+1 Forest|2ED|2
+1 Forest|3ED|2
+1 Forest|4ED|2
+1 Forest|ICE|2
+1 Forest|MIR|3
+1 Forest|5ED|3
+1 Forest|POR|3
+1 Forest|TMP|3
+1 Forest|PO2|2
+1 Forest|USG|3
+1 Forest|6ED|3
+1 Forest|PTK|2
+1 Forest|S99|3
+1 Forest|MMQ|3
+1 Forest|BRB|3
+1 Forest|BRB|4
+1 Forest|BTD|2
+1 Forest|INV|3
+1 Forest|7ED|3
+1 Forest|ODY|3
+1 Forest|ONS|3
+
+
+
+[Sideboard]
+
+

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Red.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Red.dck
@@ -1,0 +1,46 @@
+[metadata]
+Name=Land Shop - Red Commons
+[Avatar]
+
+[Main]
+
+1 Mountain|LEA|1
+1 Mountain|LEB|1
+1 Mountain|2ED|1
+1 Mountain|3ED|1
+1 Mountain|4ED|1
+1 Mountain|ICE|1
+1 Snow-Covered Mountain|ICE|1
+1 Mountain|MIR|1
+1 Mountain|MIR|2
+1 Mountain|5ED|1
+1 Mountain|5ED|2
+1 Mountain|POR|1
+1 Mountain|POR|2
+1 Mountain|TMP|1
+1 Mountain|TMP|2
+1 Mountain|PO2|1
+1 Mountain|USG|1
+1 Mountain|USG|2
+1 Mountain|6ED|1
+1 Mountain|6ED|2
+1 Mountain|PTK|1
+1 Mountain|S99|1
+1 Mountain|S99|2
+1 Mountain|MMQ|2
+1 Mountain|MMQ|1
+1 Mountain|BRB|1
+1 Mountain|BRB|2
+1 Mountain|BTD|1
+1 Mountain|INV|1
+1 Mountain|INV|2
+1 Mountain|7ED|1
+1 Mountain|7ED|2
+1 Mountain|ODY|1
+1 Mountain|ODY|2
+1 Mountain|ONS|1
+1 Mountain|ONS|2
+
+[Sideboard]
+
+

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Red_R.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Red_R.dck
@@ -1,0 +1,40 @@
+[metadata]
+Name=Land Shop - Red Rares
+[Avatar]
+
+[Main]
+
+1 Mountain|LEB|3
+1 Mountain|2ED|3
+1 Mountain|3ED|3
+1 Mountain|4ED|3
+1 Mountain|ICE|3
+1 Mountain|MIR|4
+1 Mountain|5ED|4
+1 Mountain|POR|4
+1 Mountain|TMP|4
+1 Mountain|PO2|3
+1 Mountain|PALP|1
+1 Mountain|PALP|2
+1 Mountain|PALP|3
+1 Mountain|USG|4
+1 Mountain|6ED|4
+1 Mountain|PTK|3
+1 Mountain|S99|4
+1 Mountain|PGRU|1
+1 Mountain|MMQ|4
+1 Mountain|BRB|5
+1 Mountain|PELP|1
+1 Mountain|PELP|2
+1 Mountain|PELP|3
+1 Mountain|BTD|3
+1 Mountain|INV|4
+1 Mountain|7ED|4
+1 Mountain|ODY|4
+1 Mountain|ONS|4
+
+
+[Sideboard]
+
+
+

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Red_S.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Red_S.dck
@@ -1,0 +1,9 @@
+[metadata]
+Name=Land Shop - Red Snow-Covered
+[Avatar]
+
+[Main]
+
+1 Snow-Covered Mountain|ICE|1
+
+[Sideboard]

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Red_U.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_Red_U.dck
@@ -1,0 +1,35 @@
+[metadata]
+Name=Land Shop - Red Uncommons
+[Avatar]
+
+[Main]
+
+1 Mountain|LEA|2
+1 Mountain|LEB|2
+1 Mountain|2ED|2
+1 Mountain|3ED|2
+1 Mountain|4ED|2
+1 Mountain|ICE|2
+1 Mountain|MIR|3
+1 Mountain|5ED|3
+1 Mountain|POR|3
+1 Mountain|TMP|3
+1 Mountain|PO2|2
+1 Mountain|USG|3
+1 Mountain|6ED|3
+1 Mountain|PTK|2
+1 Mountain|S99|3
+1 Mountain|MMQ|3
+1 Mountain|BRB|3
+1 Mountain|BRB|4
+1 Mountain|BTD|2
+1 Mountain|INV|3
+1 Mountain|7ED|3
+1 Mountain|ODY|3
+1 Mountain|ONS|3
+
+
+
+[Sideboard]
+
+

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_White.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_White.dck
@@ -1,0 +1,46 @@
+[metadata]
+Name=Land Shop - White Commons
+[Avatar]
+
+[Main]
+
+1 Plains|LEA|1
+1 Plains|LEB|1
+1 Plains|2ED|1
+1 Plains|3ED|1
+1 Plains|4ED|1
+1 Plains|ICE|1
+1 Snow-Covered Plains|ICE|1
+1 Plains|MIR|1
+1 Plains|MIR|2
+1 Plains|5ED|1
+1 Plains|5ED|2
+1 Plains|POR|1
+1 Plains|POR|2
+1 Plains|TMP|1
+1 Plains|TMP|2
+1 Plains|PO2|1
+1 Plains|USG|1
+1 Plains|USG|2
+1 Plains|6ED|1
+1 Plains|6ED|2
+1 Plains|PTK|1
+1 Plains|S99|1
+1 Plains|S99|2
+1 Plains|MMQ|2
+1 Plains|MMQ|1
+1 Plains|BRB|1
+1 Plains|BRB|2
+1 Plains|BTD|1
+1 Plains|INV|1
+1 Plains|INV|2
+1 Plains|7ED|1
+1 Plains|7ED|2
+1 Plains|ODY|1
+1 Plains|ODY|2
+1 Plains|ONS|1
+1 Plains|ONS|2
+
+[Sideboard]
+
+

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_White_R.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_White_R.dck
@@ -1,0 +1,40 @@
+[metadata]
+Name=Land Shop - White Rares
+[Avatar]
+
+[Main]
+
+1 Plains|LEB|3
+1 Plains|2ED|3
+1 Plains|3ED|3
+1 Plains|4ED|3
+1 Plains|ICE|3
+1 Plains|MIR|4
+1 Plains|5ED|4
+1 Plains|POR|4
+1 Plains|TMP|4
+1 Plains|PO2|3
+1 Plains|PALP|1
+1 Plains|PALP|2
+1 Plains|PALP|3
+1 Plains|USG|4
+1 Plains|6ED|4
+1 Plains|PTK|3
+1 Plains|S99|4
+1 Plains|PGRU|1
+1 Plains|MMQ|4
+1 Plains|BRB|5
+1 Plains|PELP|1
+1 Plains|PELP|2
+1 Plains|PELP|3
+1 Plains|BTD|3
+1 Plains|INV|4
+1 Plains|7ED|4
+1 Plains|ODY|4
+1 Plains|ONS|4
+
+
+[Sideboard]
+
+
+

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_White_S.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_White_S.dck
@@ -1,0 +1,9 @@
+[metadata]
+Name=Land Shop - White Snow-Covered
+[Avatar]
+
+[Main]
+
+1 Snow-Covered Plains|ICE|1
+
+[Sideboard]

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_White_U.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/shops/landShop_White_U.dck
@@ -1,0 +1,35 @@
+[metadata]
+Name=Land Shop - White Uncommons
+[Avatar]
+
+[Main]
+
+1 Plains|LEA|2
+1 Plains|LEB|2
+1 Plains|2ED|2
+1 Plains|3ED|2
+1 Plains|4ED|2
+1 Plains|ICE|2
+1 Plains|MIR|3
+1 Plains|5ED|3
+1 Plains|POR|3
+1 Plains|TMP|3
+1 Plains|PO2|2
+1 Plains|USG|3
+1 Plains|6ED|3
+1 Plains|PTK|2
+1 Plains|S99|3
+1 Plains|MMQ|3
+1 Plains|BRB|3
+1 Plains|BRB|4
+1 Plains|BTD|2
+1 Plains|INV|3
+1 Plains|7ED|3
+1 Plains|ODY|3
+1 Plains|ONS|3
+
+
+
+[Sideboard]
+
+

--- a/forge-gui/res/adventure/Shandalar Old Border/world/shops.json
+++ b/forge-gui/res/adventure/Shandalar Old Border/world/shops.json
@@ -650,11 +650,39 @@
 	"spriteAtlas":"maps/tileset/buildings.atlas",
 	"sprite":"LandShop",
 	   "restockPrice": 1,
-	  "rewards": [
-	       { "count": 5, "cardTypes": ["Land"], "subTypes": ["Swamp"]},
-	       { "count": 1, "cardName": "Snow-Covered Swamp" },
-	       { "count": 2, "cardTypes": ["Land"], "subTypes": ["Swamp"], "rarity": ["C", "U", "R"] }
-	     ]
+		"rewards": [
+			{
+				"count":4,
+				"type":"Union",
+				"cardUnion":[
+					{
+						"sourceDeck":"decks/shops/landShop_Black.dck"
+					}]
+			},
+			{
+				"count":2,
+				"type":"Union",
+				"cardUnion":[
+					{
+						"sourceDeck":"decks/shops/landShop_Black_U.dck"
+					}]
+			},
+			{
+				"count":1,
+				"type":"Union",
+				"cardUnion":[
+					{
+						"sourceDeck":"decks/shops/landShop_Black_R.dck"
+					}]
+			},
+			{
+				"count":1,
+				"type":"Union",
+				"cardUnion":[
+					{
+						"sourceDeck":"decks/shops/landShop_Black_S.dck"
+					}]
+			}]
 	
 	},{                                      
 	"name":"Forest",
@@ -662,11 +690,39 @@
 	"spriteAtlas":"maps/tileset/buildings.atlas",
 	"sprite":"LandShop",
 	   "restockPrice": 1,
-	  "rewards": [
-	       { "count": 5, "cardTypes": ["Land"], "subTypes": ["Forest"]},
-	       { "count": 1, "cardName": "Snow-Covered Forest" },
-	       { "count": 2, "cardTypes": ["Land"], "subTypes": ["Forest"], "rarity": ["C", "U", "R"] }
-	     ]
+	"rewards": [
+		{
+			"count":4,
+			"type":"Union",
+			"cardUnion":[
+				{
+					"sourceDeck":"decks/shops/landShop_Green.dck"
+				}]
+		},
+		{
+			"count":2,
+			"type":"Union",
+			"cardUnion":[
+				{
+					"sourceDeck":"decks/shops/landShop_Green_U.dck"
+				}]
+		},
+		{
+			"count":1,
+			"type":"Union",
+			"cardUnion":[
+				{
+					"sourceDeck":"decks/shops/landShop_Green_R.dck"
+				}]
+		},
+		{
+			"count":1,
+			"type":"Union",
+			"cardUnion":[
+				{
+					"sourceDeck":"decks/shops/landShop_Green_S.dck"
+				}]
+		}]
 	
 	},{                                      
 	"name":"Mountain",   
@@ -674,11 +730,39 @@
 	"spriteAtlas":"maps/tileset/buildings.atlas",
 	"sprite":"LandShop",
 	   "restockPrice": 1,
-	  "rewards": [
-		{ "count": 5, "cardTypes": ["Land"], "subTypes": ["Mountain"]},
-	       { "count": 1, "cardName": "Snow-Covered Mountain" },
-	       { "count": 2, "cardTypes": ["Land"], "subTypes": ["Mountain"], "rarity": ["C", "U", "R"] }
-	     ]
+	"rewards": [
+		{
+			"count":4,
+			"type":"Union",
+			"cardUnion":[
+				{
+					"sourceDeck":"decks/shops/landShop_Red.dck"
+				}]
+		},
+		{
+			"count":2,
+			"type":"Union",
+			"cardUnion":[
+				{
+					"sourceDeck":"decks/shops/landShop_Red_U.dck"
+				}]
+		},
+		{
+			"count":1,
+			"type":"Union",
+			"cardUnion":[
+				{
+					"sourceDeck":"decks/shops/landShop_Red_R.dck"
+				}]
+		},
+		{
+			"count":1,
+			"type":"Union",
+			"cardUnion":[
+				{
+					"sourceDeck":"decks/shops/landShop_Red_S.dck"
+				}]
+		}]
 	
 	},{                                      
 	"name":"Island",                  
@@ -686,11 +770,39 @@
 	"spriteAtlas":"maps/tileset/buildings.atlas",
 	"sprite":"LandShop",
 	   "restockPrice": 1,
-	  "rewards": [
-	       { "count": 5, "cardTypes": ["Land"], "subTypes": ["Island"] },
-	       { "count": 1, "cardName": "Snow-Covered Island" },
-	       { "count": 2, "cardTypes": ["Land"], "subTypes": ["Island"], "rarity": ["C", "U", "R"] }
-	     ]
+	"rewards": [
+		{
+			"count":4,
+			"type":"Union",
+			"cardUnion":[
+				{
+					"sourceDeck":"decks/shops/landShop_Blue.dck"
+				}]
+		},
+		{
+			"count":2,
+			"type":"Union",
+			"cardUnion":[
+				{
+					"sourceDeck":"decks/shops/landShop_Blue_U.dck"
+				}]
+		},
+		{
+			"count":1,
+			"type":"Union",
+			"cardUnion":[
+				{
+					"sourceDeck":"decks/shops/landShop_Blue_R.dck"
+				}]
+		},
+		{
+			"count":1,
+			"type":"Union",
+			"cardUnion":[
+				{
+					"sourceDeck":"decks/shops/landShop_Blue_S.dck"
+				}]
+		}]
 	
 	},{                                      
 	"name":"Plains",                  
@@ -699,10 +811,38 @@
 	"sprite":"LandShop",
 	   "restockPrice": 1,
 	  "rewards": [
-	       { "count": 5, "cardTypes": ["Land"], "subTypes": ["Plains"] },
-	       { "count": 1, "cardName": "Snow-Covered Plains" },
-	       { "count": 2, "cardTypes": ["Land"], "subTypes": ["Plains"], "rarity": ["C", "U", "R"] }
-	     ]
+		  {
+			  "count":4,
+			  "type":"Union",
+			  "cardUnion":[
+				  {
+					  "sourceDeck":"decks/shops/landShop_White.dck"
+				  }]
+		  },
+		  {
+			  "count":2,
+			  "type":"Union",
+			  "cardUnion":[
+				  {
+					  "sourceDeck":"decks/shops/landShop_White_U.dck"
+				  }]
+		  },
+		  {
+			  "count":1,
+			  "type":"Union",
+			  "cardUnion":[
+				  {
+					  "sourceDeck":"decks/shops/landShop_White_R.dck"
+				  }]
+		  },
+		  {
+			  "count":1,
+			  "type":"Union",
+			  "cardUnion":[
+				  {
+					  "sourceDeck":"decks/shops/landShop_White_S.dck"
+				  }]
+		  }]
 	
 	},{                                      
 	"name":"Instant",                  


### PR DESCRIPTION
The land shops were desired to be a bit more mixed and random for Shandalar Old Border while RemusLord was working on it. When they were brought into the main system, the new shop logic he built was reliant on java files not in core forge. Instead of adding entirely new java files for something that was only being used by the one world. I built up a series of shop decks and accessed via it's own shops.json to use them, and Remus approved the final result. This will have zero impact outside Shandalar Old Border.