### PR TITLE
Streamline logic so canPlay always before canPay

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
@@ -666,6 +666,7 @@ public class ComputerUtilMana {
             return true;
         }
 
+        int phyLifeToPay = 2;
         boolean purePhyrexian = cost.containsOnlyPhyrexianMana();
         boolean hasConverge = sa.getHostCard().hasConverge();
         ListMultimap<ManaCostShard, SpellAbility> sourcesForShards = getSourcesForShards(cost, sa, ai, test, checkPlayable, hasConverge);
@@ -693,12 +694,11 @@ public class ComputerUtilMana {
             }
 
             if (sourcesForShards == null && !purePhyrexian) {
-                break;    // no mana abilities to use for paying
+                // no mana abilities to use for paying
+                break;
             }
 
             toPay = getNextShardToPay(cost, sourcesForShards);
-
-            boolean lifeInsteadOfBlack = toPay.isBlack() && ai.hasKeyword("PayLifeInsteadOf:B");
 
             Collection<SpellAbility> saList = null;
             if (hasConverge &&
@@ -752,9 +752,14 @@ public class ComputerUtilMana {
             }
 
             if (saPayment == null) {
-                if ((!toPay.isPhyrexian() && !lifeInsteadOfBlack) || !ai.canPayLife(2, false, sa)
-                        || (ai.getLife() <= 2 && !ai.cantLoseForZeroOrLessLife())) {
-                    break; // cannot pay
+                boolean lifeInsteadOfBlack = toPay.isBlack() && ai.hasKeyword("PayLifeInsteadOf:B");
+                if ((!toPay.isPhyrexian() && !lifeInsteadOfBlack) || !ai.canPayLife(phyLifeToPay, false, sa)
+                        || (ai.getLife() <= phyLifeToPay && !ai.cantLoseForZeroOrLessLife())) {
+                    // cannot pay
+                    break;
+                }
+                if (test) {
+                    phyLifeToPay += 2;
                 }
 
                 if (sa.hasParam("AIPhyrexianPayment")) {

--- a/forge-game/src/main/java/forge/game/mana/ManaCostBeingPaid.java
+++ b/forge-game/src/main/java/forge/game/mana/ManaCostBeingPaid.java
@@ -551,10 +551,10 @@ public class ManaCostBeingPaid {
                 // The generic portion of a 2/Colored mana, should be lower priority than generic mana
                 return !ColorSet.fromMask(bill.getColorMask() & paymentColor).isColorless() ? 9 : 1;
             }
-            if (!bill.isPhyrexian()) {
-                return 10;
+            if (bill.isPhyrexian()) {
+                return 8;
             }
-            return 8;
+            return 10;
         }
         return 5;
     }

--- a/forge-gui/src/main/java/forge/gamemodes/match/input/InputPayManaOfCostPayment.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/input/InputPayManaOfCostPayment.java
@@ -47,11 +47,9 @@ public class InputPayManaOfCostPayment extends InputPayMana {
                 if (manaCost.payPhyrexian()) {
                     saPaidFor.setSpendPhyrexianMana(true);
                     this.phyLifeToLose += 2;
-                } else {
-                    if (player.hasKeyword("PayLifeInsteadOf:B") && manaCost.hasAnyKind(ManaAtom.BLACK)) {
-                        manaCost.decreaseShard(ManaCostShard.BLACK, 1);
-                        this.phyLifeToLose += 2;
-                    }
+                } else if (player.hasKeyword("PayLifeInsteadOf:B") && manaCost.hasAnyKind(ManaAtom.BLACK)) {
+                    manaCost.decreaseShard(ManaCostShard.BLACK, 1);
+                    this.phyLifeToLose += 2;
                 }
             }
 


### PR DESCRIPTION
I wouldn't do it if it only simplified the code again since this was changed in 726976f

but performance-wise I'm seeing nothing negative, especially since the extra guards for targeted SA or Ward don't have to be considered now :)

Also cherry-picked fix from #8229