### PR TITLE
Fixing Ultima, Origin of Oblivion

### DIFF
--- a/forge-gui/res/cardsfolder/u/ultima_origin_of_oblivion.txt
+++ b/forge-gui/res/cardsfolder/u/ultima_origin_of_oblivion.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature God
 PT:4/4
 K:Flying
 T:Mode$ Attacks | ValidCard$ Creature.Self | Execute$ TrigPutCounter | TriggerDescription$ Whenever NICKNAME attacks, put a blight counter on target land. For as long as that land has a blight counter on it, it loses all land types and abilities and has "{T}: Add {C}."
-SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Land | CounterType$ BLIGHT | CounterNum$ 1 | AITgts$ Land.YouCtrl+Basic+notnamedWastes+counters_LT1_BLIGHT | SubAbility$ DBEffect
+SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Land | CounterType$ BLIGHT | CounterNum$ 1 | AITgts$ Land.YouCtrl+Basic+notnamedWastes+notnamedSnow-Covered Wastes+counters_LT1_BLIGHT | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | RememberObjects$ Targeted | StaticAbilities$ BlightStatic | ForgetOnMoved$ Battlefield | ForgetCounter$ BLIGHT | Duration$ Permanent
 SVar:BlightStatic:Mode$ Continuous | Affected$ Card.IsRemembered | RemoveLandTypes$ True | RemoveAllAbilities$ True | AddAbility$ ColorlessMana | Description$ For as long as that land has a blight counter on it, it loses all land types and abilities and has "{T}: Add {C}."
 SVar:ColorlessMana:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.

--- a/forge-gui/res/cardsfolder/u/ultima_origin_of_oblivion.txt
+++ b/forge-gui/res/cardsfolder/u/ultima_origin_of_oblivion.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature God
 PT:4/4
 K:Flying
 T:Mode$ Attacks | ValidCard$ Creature.Self | Execute$ TrigPutCounter | TriggerDescription$ Whenever NICKNAME attacks, put a blight counter on target land. For as long as that land has a blight counter on it, it loses all land types and abilities and has "{T}: Add {C}."
-SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Land | CounterType$ BLIGHT | CounterNum$ 1 | SubAbility$ DBEffect
+SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Land | CounterType$ BLIGHT | CounterNum$ 1 | IsCurse$ True | AITgts$ Land.counters_LT1_BLIGHT | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | RememberObjects$ Targeted | StaticAbilities$ BlightStatic | ForgetOnMoved$ Battlefield | ForgetCounter$ BLIGHT | Duration$ Permanent
 SVar:BlightStatic:Mode$ Continuous | Affected$ Card.IsRemembered | RemoveLandTypes$ True | RemoveAllAbilities$ True | AddAbility$ ColorlessMana | Description$ For as long as that land has a blight counter on it, it loses all land types and abilities and has "{T}: Add {C}."
 SVar:ColorlessMana:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.

--- a/forge-gui/res/cardsfolder/u/ultima_origin_of_oblivion.txt
+++ b/forge-gui/res/cardsfolder/u/ultima_origin_of_oblivion.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature God
 PT:4/4
 K:Flying
 T:Mode$ Attacks | ValidCard$ Creature.Self | Execute$ TrigPutCounter | TriggerDescription$ Whenever NICKNAME attacks, put a blight counter on target land. For as long as that land has a blight counter on it, it loses all land types and abilities and has "{T}: Add {C}."
-SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Land | CounterType$ BLIGHT | CounterNum$ 1 | AITgts$ Land.YouCtrl+Basic+counters_LT1_BLIGHT | SubAbility$ DBEffect
+SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Land | CounterType$ BLIGHT | CounterNum$ 1 | AITgts$ Land.YouCtrl+Basic+notnamedWastes+counters_LT1_BLIGHT | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | RememberObjects$ Targeted | StaticAbilities$ BlightStatic | ForgetOnMoved$ Battlefield | ForgetCounter$ BLIGHT | Duration$ Permanent
 SVar:BlightStatic:Mode$ Continuous | Affected$ Card.IsRemembered | RemoveLandTypes$ True | RemoveAllAbilities$ True | AddAbility$ ColorlessMana | Description$ For as long as that land has a blight counter on it, it loses all land types and abilities and has "{T}: Add {C}."
 SVar:ColorlessMana:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.

--- a/forge-gui/res/cardsfolder/u/ultima_origin_of_oblivion.txt
+++ b/forge-gui/res/cardsfolder/u/ultima_origin_of_oblivion.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature God
 PT:4/4
 K:Flying
 T:Mode$ Attacks | ValidCard$ Creature.Self | Execute$ TrigPutCounter | TriggerDescription$ Whenever NICKNAME attacks, put a blight counter on target land. For as long as that land has a blight counter on it, it loses all land types and abilities and has "{T}: Add {C}."
-SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Land | CounterType$ BLIGHT | CounterNum$ 1 | IsCurse$ True | AITgts$ Land.counters_LT1_BLIGHT | SubAbility$ DBEffect
+SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Land | CounterType$ BLIGHT | CounterNum$ 1 | AITgts$ Land.YouCtrl+Basic+counters_LT1_BLIGHT | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | RememberObjects$ Targeted | StaticAbilities$ BlightStatic | ForgetOnMoved$ Battlefield | ForgetCounter$ BLIGHT | Duration$ Permanent
 SVar:BlightStatic:Mode$ Continuous | Affected$ Card.IsRemembered | RemoveLandTypes$ True | RemoveAllAbilities$ True | AddAbility$ ColorlessMana | Description$ For as long as that land has a blight counter on it, it loses all land types and abilities and has "{T}: Add {C}."
 SVar:ColorlessMana:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.

--- a/forge-gui/res/cardsfolder/u/ultima_origin_of_oblivion.txt
+++ b/forge-gui/res/cardsfolder/u/ultima_origin_of_oblivion.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature God
 PT:4/4
 K:Flying
 T:Mode$ Attacks | ValidCard$ Creature.Self | Execute$ TrigPutCounter | TriggerDescription$ Whenever NICKNAME attacks, put a blight counter on target land. For as long as that land has a blight counter on it, it loses all land types and abilities and has "{T}: Add {C}."
-SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Land | CounterType$ BLIGHT | CounterNum$ 1 | AITgts$ Land.YouCtrl+Basic+notnamedWastes+notnamedSnow-Covered Wastes+counters_LT1_BLIGHT | SubAbility$ DBEffect
+SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Land | CounterType$ BLIGHT | CounterNum$ 1 | AITgts$ Land.Basic+YouCtrl+!canProduceManaColor Colorless | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | RememberObjects$ Targeted | StaticAbilities$ BlightStatic | ForgetOnMoved$ Battlefield | ForgetCounter$ BLIGHT | Duration$ Permanent
 SVar:BlightStatic:Mode$ Continuous | Affected$ Card.IsRemembered | RemoveLandTypes$ True | RemoveAllAbilities$ True | AddAbility$ ColorlessMana | Description$ For as long as that land has a blight counter on it, it loses all land types and abilities and has "{T}: Add {C}."
 SVar:ColorlessMana:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.


### PR DESCRIPTION
Closes #8257 .

Confirmed AI behavior in bug report (2025-07-19 build):
- AI focuses targeting of attack trigger on own lands probably because the ramping self aspect is likely weighed well above denying other player resources.
- AI does this targeting non-systematically:
-> targeting lands they control that already have blight counters on them.
-> targeting nonbasic lands they control, especially ones with nonmana activated abilities as was reported as the main issue.

Iterating through fixes, some more or less strict, I came upon the argument for `AITgts$` herein which guides the AI into somewhat more strategic behavior. It, admittedly, doesn't completely avoid the nullification of nonbasic lands the AI controls but it does delay that eventuality substantially.

As for attempted fixes, using `IsCurse$ True` flipped the switch, as it were: the AI focused exclusively on the opponent's resources to the detriment of developing their own.
In either case, with or without `IsCurse$`, there was no effect trying to supplement `AITgts$` with an argument extension that would presumably expand behavior to include both targeting the AI's lands and their opponent's.
Thus I decided to keep this edit simple, and address the salient annoying behavior that belies the strategy the AI prefers. I'm however open to input otherwise.