### PR TITLE
Flowstone Blade not used as removal (#7817)

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
@@ -1321,7 +1321,21 @@ public class ComputerUtilCard {
         }
 
         if (c.getNetToughness() + toughness <= 0) {
-            return false;
+            // Use Flowstone Blade etc. as removal
+            return c.getController().isOpponentOf(ai);
+        }
+
+        // If the ability is repeatable, check if multiple activations can kill the creature
+        if (toughness < 0 && sa.isAbility() && c.getController().isOpponentOf(ai)) {
+            int timesNeeded = (int)Math.ceil((double)c.getNetToughness() / (double) -toughness);
+            Cost cost = sa.getPayCosts();
+            Cost totalCost = cost.copy();
+            for (int time = timesNeeded; time > 1; --time) totalCost.add(cost);
+            // Always true so gets stuck on creatures larger than mana pool
+            // boolean canPay = totalCost.canPay(sa, ai, false);
+            // This is the one that calls the private canPayManaCost() with test=true
+            boolean canPay = ComputerUtilMana.canPayManaCost(totalCost, sa, ai, 0, false);
+            return canPay;
         }
 
         if (sa.getHostCard().equals(c) && ComputerUtilCost.isSacrificeSelfCost(sa.getPayCosts())) {

--- a/forge-ai/src/main/java/forge/ai/ability/PumpAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PumpAi.java
@@ -315,10 +315,14 @@ public class PumpAi extends PumpAiBase {
 
                     return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
                 }
+
+                // Pump can have negative effects as well.
+                if (ComputerUtilCard.shouldPumpCard(ai, sa, card, defense, attack, keywords, false)) {
+                    return new AiAbilityDecision(50, AiPlayDecision.WillPlay);
+                }
+
                 if (!card.getController().isOpponentOf(ai)) {
-                    if (ComputerUtilCard.shouldPumpCard(ai, sa, card, defense, attack, keywords, false)) {
-                        return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
-                    } else if (containsUsefulKeyword(ai, keywords, card, sa, attack)) {
+                    if (containsUsefulKeyword(ai, keywords, card, sa, attack)) {
                         if (game.getPhaseHandler().is(PhaseType.MAIN1) && isSorcerySpeed(sa, ai) ||
                                 game.getPhaseHandler().is(PhaseType.COMBAT_DECLARE_ATTACKERS, ai) ||
                                 game.getPhaseHandler().is(PhaseType.COMBAT_BEGIN, ai)) {

--- a/forge-gui/res/cardsfolder/f/flowstone_blade.txt
+++ b/forge-gui/res/cardsfolder/f/flowstone_blade.txt
@@ -2,9 +2,7 @@ Name:Flowstone Blade
 ManaCost:R
 Types:Enchantment Aura
 K:Enchant:Creature
-# TODO: The AI can only use this as a form of buff. Maybe teach the AI to also use it to kill opposing creatures?
-SVar:AttachAITgts:Creature.toughnessGE2
-SVar:AttachAILogic:Pump
+SVar:AttachAILogic:Curse
 A:AB$ Pump | Cost$ R | Defined$ Enchanted | NumAtt$ +1 | NumDef$ -1 | SpellDescription$ Enchanted creature gets +1/-1 until end of turn.
 SVar:NonStackingAttachEffect:True
 Oracle:Enchant creature\n{R}: Enchanted creature gets +1/-1 until end of turn.


### PR DESCRIPTION
Firebreathing is a better buff, so use the rare negative toughness pump of Flowstone Blade etc. as removal for indestructible and other problematic creatures.

Fixes #7817 