### PR TITLE
Don't search library while opponent controls Ob Nixilis, Unshackled (#8346)

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
@@ -22,7 +22,10 @@ import forge.game.player.PlayerActionConfirmMode;
 import forge.game.spellability.AbilitySub;
 import forge.game.spellability.SpellAbility;
 import forge.game.spellability.TargetRestrictions;
+import forge.game.staticability.StaticAbility;
 import forge.game.staticability.StaticAbilityMustTarget;
+import forge.game.trigger.Trigger;
+import forge.game.trigger.TriggerType;
 import forge.game.zone.ZoneType;
 import forge.util.Aggregates;
 import forge.util.MyRandom;
@@ -346,7 +349,28 @@ public class ChangeZoneAi extends SpellAbilityAi {
                     return true;
                 });
             }
-            // TODO: prevent ai searching its own library when Ob Nixilis, Unshackled is in play
+
+            // Searching own library
+            if (p == ai && origin != null && origin.size() == 1 && origin.get(0).equals(ZoneType.Library)) {
+                for (final Player op : ai.getOpponents()) {
+                    for (Card c : op.getCardsIn(ZoneType.Battlefield)) {
+                        // Ob Nixilis, Unshackled
+                        for (Trigger trigger : c.getTriggers()) {
+                            if (TriggerType.SearchedLibrary.equals(trigger.getMode())
+                                && "TrigSac".equals(trigger.getParam("Execute"))) {
+                                    return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
+                            }
+                        }
+                        // Opposition Agent
+                        for (StaticAbility stAb : c.getStaticAbilities()) {
+                            if ("You".equals(stAb.getParam("ControlOpponentsSearchingLibrary"))) {
+                                return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
+                            }
+                        }
+                    }
+                }
+            }
+
             if (origin != null && origin.size() == 1 && origin.get(0).isKnown()) {
                 // FIXME: make this properly interact with several origin zones
                 list = CardLists.getValidCards(list, type, source.getController(), source, sa);


### PR DESCRIPTION
Fixes #8346.

Test result from game log (why is that most recent on top?):

```
Resolve stack: Imprint — Whenever a nontoken creature dies, you may exile that card. If you do, return each other card exiled with Mimic Vat to its owner's graveyard. [Zone Changer: Ob Nixilis, Unshackled (404)]
Resolve stack: Evolving Wilds (14) - Sedar searches their library for a Land.Basic card, puts it onto the battlefield tapped, then shuffles.
Resolve stack: Evolving Wilds (221) - Veldahar searches their library for a Land.Basic card, puts it onto the battlefield tapped, then shuffles.
Add to stack: Veldahar activated Evolving Wilds (221)
Add to stack: Sedar activated Evolving Wilds (14)
Add to stack: Veldahar triggered Mimic Vat (227)
Resolve stack: Murder (43) - Destroy Ob Nixilis, Unshackled (404).
Add to stack: Sedar cast Murder (43) targeting [Ob Nixilis, Unshackled (404)]
```

