### PR TITLE
Fix exact search

### DIFF
--- a/forge-gui/src/main/java/forge/itemmanager/AdvancedSearchParser.java
+++ b/forge-gui/src/main/java/forge/itemmanager/AdvancedSearchParser.java
@@ -43,7 +43,7 @@ public abstract class AdvancedSearchParser {
         }
 
         String key = token.substring(0, index).trim().toLowerCase();
-        String valueStr = token.substring(index + opUsed.length()).trim().toLowerCase();
+        String valueStr = token.substring(index + opUsed.length()).toLowerCase();
         boolean creatureOnly = false;
 
         Predicate<CardRules> predicate = null;

--- a/forge-gui/src/main/java/forge/itemmanager/SFilterUtil.java
+++ b/forge-gui/src/main/java/forge/itemmanager/SFilterUtil.java
@@ -81,6 +81,7 @@ public class SFilterUtil {
 
             if (ch == '"') {
                 inQuotes = !inQuotes;
+                current.append(ch);
                 continue;
             }
 


### PR DESCRIPTION
Fix for search such as `"Up to two"` or `o:"corrupt "`