### PR TITLE
build: add macOS app bundle support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,41 @@ Join the **Forge community** on [Discord](https://discord.gg/HcPJNyD66a)!
 3. **User Data Management:** Previous players’ data is preserved during upgrades.
 4. **Java Requirement:** Ensure you have **Java 17 or later** installed.
 
+**Platform-specific launchers:**
+- **macOS:** `Forge.app`, `Forge Adventure.app`, and `Adventure Editor.app`
+- **Windows:** `forge.exe` and `forge-adventure.exe`
+- **Linux:** `forge.sh` and `forge-adventure.sh`
+- **Cross-platform:** JAR files
+
 ### 📱 Android Installation
 - _(Note: **Android 11** is the minimum requirements with at least **6GB RAM** to run smoothly. You need to enable **"Install unknown apps"** for Forge to initialize and update itself)_
 - Download the **APK** from the [Snapshot Build](https://github.com/Card-Forge/forge/releases/tag/daily-snapshots). On the first launch, Forge will automatically download all necessary assets.
+
+## 🔨 Building from Source
+
+To build Forge for all platforms:
+
+```bash
+git clone https://github.com/Card-Forge/forge.git
+cd forge
+mvn clean package -DskipTests
+```
+
+**Platform-specific builds:**
+- **All platforms:** `mvn clean package -DskipTests` (default)
+- **Windows/Linux:** `mvn clean package -Pwindows-linux -DskipTests`
+- **MacOS app bundles:** `mvn clean package -Pmacos -DskipTests`
+- **Force DMG creation:** `mvn clean package -Pmacos-dmg -DskipTests` (only available on MacOS)
+
+**Requirements:**
+- Java 17 or later
+- Maven 3.6+
+- Git
+
+**Output locations:**
+- Desktop apps: `forge-gui-desktop/target/`
+- Adventure mode: `forge-gui-mobile-dev/target/`
+- Installers: `forge-installer/target/`
 
 ---
 

--- a/adventure-editor/src/main/config/adventure-editor.command
+++ b/adventure-editor/src/main/config/adventure-editor.command
@@ -1,3 +1,0 @@
-#!/bin/sh
-cd $(dirname "${0}")
-java -Xmx4096m -Dfile.encoding=UTF-8 -jar $project.build.finalName$

--- a/forge-gui-desktop/src/main/config/forge.command
+++ b/forge-gui-desktop/src/main/config/forge.command
@@ -1,3 +1,0 @@
-#!/bin/sh
-cd $(dirname "${0}")
-java $mandatory.java.args$ -jar $project.build.finalName$

--- a/forge-gui-desktop/src/main/java/forge/view/FView.java
+++ b/forge-gui-desktop/src/main/java/forge/view/FView.java
@@ -103,6 +103,12 @@ public enum FView {
 		frmDocument.setMinimumSize(new Dimension(800, 600));
 		frmDocument.setLocationRelativeTo(null);
 		frmDocument.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+		frmDocument.addWindowListener(new java.awt.event.WindowAdapter() {
+			@Override
+			public void windowClosing(java.awt.event.WindowEvent e) {
+				System.exit(0);
+			}
+		});
 		frmDocument.setIconImage(FSkin.getIcon(FSkinProp.ICO_FAVICON));
 
 		// Frame components

--- a/forge-gui-mobile-dev/src/main/config/forge-adventure.command
+++ b/forge-gui-mobile-dev/src/main/config/forge-adventure.command
@@ -1,3 +1,0 @@
-#!/bin/sh
-cd $(dirname "${0}")
-java -Xmx4096m $mandatory.java.args$ -jar $project.build.finalName$

--- a/forge-gui/release-files/INSTALLATION.txt
+++ b/forge-gui/release-files/INSTALLATION.txt
@@ -7,7 +7,7 @@ Some people use the Windows application 7zip. This utility can be found at http:
 Once the Forge archive has been decompressed you should then be able to launch Forge by using the included launcher. Launching Forge by double clicking on the forge jar file in the past caused a java heap space error. Forge's memory requirements have increased over time and the launchers increase the java heap space available to Forge. Currently you can launch Forge by double clicking on the forge jar file without a java heap space error but this is likely to change as we add in more sounds, icons, etc.
 
 - Mac OS -
-We DO NOT provide a separate macOS builds of desktop and mobile (backported). Instead, please run Forge using the forge.command or forge-adventure.command files.
+We provide native macOS application bundles (Forge.app and Forge Adventure.app) that can be launched directly by double-clicking. Java 17 or later is still required to be installed separately. We do NOT provide iOS mobile builds.
 
 
 - Online Multiplayer -

--- a/forge-installer/README-macOS.md
+++ b/forge-installer/README-macOS.md
@@ -1,0 +1,50 @@
+# macOS App Bundle Build
+
+This directory contains the configuration to build a native macOS application bundle (.app) for Forge.
+
+## Building
+
+From the project root:
+```bash
+mvn clean package -Pmacos -DskipTests
+```
+
+## Output
+
+The build creates:
+- `target/Forge.app` - Native macOS application bundle (main game)
+- `target/Forge Adventure.app` - Native macOS application bundle (adventure mode)
+- `target/forge-installer-*.dmg` - Disk image for distribution (contains both apps, only created on macOS)
+
+## App Bundle Structure
+
+```
+Forge.app/
+├── Contents/
+│   ├── Info.plist          # App metadata
+│   ├── MacOS/
+│   │   └── forge           # Launcher script
+│   └── Resources/          # Application resources
+│       ├── forge-gui-desktop-*.jar
+│       ├── res/            # Game resources
+│       └── *.txt           # Documentation files
+```
+
+## Requirements
+
+- macOS 10.9 (Mavericks) or later
+- Java 17 or later (bundled JRE not included)
+- Maven 3.6+
+
+## Installation
+
+Users can:
+1. Mount the DMG file
+2. Drag Forge.app to Applications folder
+3. Launch from Applications or Launchpad
+
+## Notes
+
+- The app bundles are created on any OS and require Java to be installed on the target system
+- Icon conversion from PNG to ICNS happens automatically if available
+- DMG creation only works on macOS (requires `hdiutil` command) but is optional - the .app bundles are always created

--- a/forge-installer/pom.xml
+++ b/forge-installer/pom.xml
@@ -92,6 +92,12 @@
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>forge</groupId>
+            <artifactId>adventure-editor</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>
@@ -161,7 +167,7 @@
                                         <mkdir dir="${project.build.directory}/${project.build.finalName}" />
                                         <copy todir="${project.build.directory}/${project.build.finalName}">
                                             <fileset dir="${project.build.directory}/../../forge-gui-desktop/target" includes="forge.sh" />
-                                            <fileset dir="${project.build.directory}/../../forge-gui-desktop/target" includes="forge.command" />
+
                                             <fileset dir="${project.build.directory}/../../forge-gui-desktop/target" includes="forge.cmd" />
                                             <fileset dir="${basedir}/../forge-gui/" includes="forge.profile.properties.example" />
                                             <fileset dir="${basedir}/" includes="sentry.properties" />
@@ -181,12 +187,12 @@
                                             <fileset dir="${project.build.directory}/../../adventure-editor/tools" includes="gdx-particle-editor.jar" />
                                             <fileset dir="${project.build.directory}/../../adventure-editor/target" includes="adventure-editor.exe" />
                                             <fileset dir="${project.build.directory}/../../adventure-editor/target" includes="adventure-editor.sh" />
-                                            <fileset dir="${project.build.directory}/../../adventure-editor/target" includes="adventure-editor.command" />
+
                                             <fileset dir="${project.build.directory}/../../adventure-editor/target" includes="adventure-editor.cmd" />
                                             <fileset dir="${project.build.directory}/../../adventure-editor/target" includes="adventure-editor-jar-with-dependencies.jar" />
                                             <fileset dir="${project.build.directory}/../../forge-gui-mobile-dev/target" includes="forge-adventure.exe" />
                                             <fileset dir="${project.build.directory}/../../forge-gui-mobile-dev/target" includes="forge-adventure.sh" />
-                                            <fileset dir="${project.build.directory}/../../forge-gui-mobile-dev/target" includes="forge-adventure.command" />
+
                                             <fileset dir="${project.build.directory}/../../forge-gui-mobile-dev/target" includes="forge-adventure.cmd" />
                                             <fileset dir="${project.build.directory}/../../forge-gui-mobile-dev/target" includes="forge-gui-mobile-dev-${project.version}-jar-with-dependencies.jar" />
                                             <fileset dir="${project.build.directory}/../../forge-gui-mobile-dev/target/classes" includes="build.txt" />
@@ -206,28 +212,28 @@
                                         <chmod file="${project.build.directory}/${project.build.finalName}/forge-adventure.exe" perm="a+rx" />
                                         <chmod file="${project.build.directory}/${project.build.finalName}/adventure-editor.exe" perm="a+rx" />
                                         <copy todir="${basedir}/target">
-                                            <fileset dir="${project.build.directory}/../../forge-gui-desktop/target" includes="forge.sh,forge.command" />
-                                            <fileset dir="${project.build.directory}/../../forge-gui-mobile-dev/target" includes="forge-adventure.sh,forge-adventure.command" />
-                                            <fileset dir="${project.build.directory}/../../adventure-editor/target" includes="adventure-editor.sh,adventure-editor.command" />
+                                            <fileset dir="${project.build.directory}/../../forge-gui-desktop/target" includes="forge.sh" />
+                                            <fileset dir="${project.build.directory}/../../forge-gui-mobile-dev/target" includes="forge-adventure.sh" />
+                                            <fileset dir="${project.build.directory}/../../adventure-editor/target" includes="adventure-editor.sh" />
                                         </copy>
                                         <chmod file="${basedir}/target/forge.sh" perm="a+rx" />
-                                        <chmod file="${basedir}/target/forge.command" perm="a+rx" />
+
                                         <chmod file="${basedir}/target/forge-adventure.sh" perm="a+rx" />
-                                        <chmod file="${basedir}/target/forge-adventure.command" perm="a+rx" />
+
                                         <chmod file="${basedir}/target/adventure-editor.sh" perm="a+rx" />
-                                        <chmod file="${basedir}/target/adventure-editor.command" perm="a+rx" />
+
                                         <tar destfile="${basedir}/target/${project.build.finalName}.tar.bz2" compression="bzip2">
                                             <tarfileset filemode="755" dir="${project.build.directory}/${project.build.finalName}">
                                                 <include name="forge.sh" />
-                                                <include name="forge.command" />
+
                                                 <include name="forge.cmd" />
                                                 <include name="forge.exe" />
                                                 <include name="forge-adventure.sh" />
-                                                <include name="forge-adventure.command" />
+
                                                 <include name="forge-adventure.cmd" />
                                                 <include name="forge-adventure.exe" />
                                                 <include name="adventure-editor.sh" />
-                                                <include name="adventure-editor.command" />
+
                                                 <include name="adventure-editor.cmd" />
                                                 <include name="adventure-editor.exe" />
                                                 <exclude name="**/*.xcf" />
@@ -235,15 +241,15 @@
                                             <tarfileset dir="${project.build.directory}/${project.build.finalName}">
                                                 <include name="**" />
                                                 <exclude name="forge.sh" />
-                                                <exclude name="forge.command" />
+
                                                 <exclude name="forge.cmd" />
                                                 <exclude name="forge.exe" />
                                                 <exclude name="forge-adventure.sh" />
-                                                <exclude name="forge-adventure.command" />
+
                                                 <exclude name="forge-adventure.cmd" />
                                                 <exclude name="forge-adventure.exe" />
                                                 <exclude name="adventure-editor.sh" />
-                                                <exclude name="adventure-editor.command" />
+
                                                 <exclude name="adventure-editor.cmd" />
                                                 <exclude name="adventure-editor.exe" />
                                                 <exclude name="**/*.xcf" />
@@ -325,5 +331,232 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>macos</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <macos.generateDmg>false</macos.generateDmg>
+                <macos.generateInstaller>false</macos.generateInstaller>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.github.fvarrui</groupId>
+                        <artifactId>javapackager</artifactId>
+                        <version>1.7.6</version>
+                        <executions>
+                            <execution>
+                                <id>forge-app</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                                <configuration>
+                                    <mainClass>forge.view.Main</mainClass>
+                                    <name>Forge</name>
+                                    <displayName>Forge</displayName>
+                                    <description>Magic: The Gathering Rules Engine</description>
+                                    <url>https://www.cardforge.org/</url>
+                                    <organizationName>CardForge</organizationName>
+                                    <organizationUrl>https://www.cardforge.org/</organizationUrl>
+                                    <bundleJre>false</bundleJre>
+                                    <generateInstaller>${macos.generateInstaller}</generateInstaller>
+                                    <platform>mac</platform>
+                                    <createZipball>false</createZipball>
+                                    <runnableJar>${project.build.directory}/../../forge-gui-desktop/target/forge-gui-desktop-${project.version}-jar-with-dependencies.jar</runnableJar>
+                                    <macConfig>
+                                        <icnsFile>${basedir}/../forge-gui/src/main/config/Forge.icns</icnsFile>
+                                        <generateDmg>${macos.generateDmg}</generateDmg>
+                                    </macConfig>
+                                    <additionalResources>
+                                        <additionalResource>${basedir}/../forge-gui/res</additionalResource>
+                                        <additionalResource>${basedir}/../forge-gui/LICENSE.txt</additionalResource>
+                                        <additionalResource>${basedir}/../forge-gui/MANUAL.txt</additionalResource>
+                                        <additionalResource>${basedir}/../forge-gui/release-files</additionalResource>
+                                    </additionalResources>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>forge-adventure-app</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                                <configuration>
+                                    <mainClass>forge.app.Main</mainClass>
+                                    <name>Forge Adventure</name>
+                                    <displayName>Forge Adventure</displayName>
+                                    <description>Magic: The Gathering Adventure Mode</description>
+                                    <url>https://www.cardforge.org/</url>
+                                    <organizationName>CardForge</organizationName>
+                                    <organizationUrl>https://www.cardforge.org/</organizationUrl>
+                                    <bundleJre>false</bundleJre>
+                                    <generateInstaller>${macos.generateInstaller}</generateInstaller>
+                                    <platform>mac</platform>
+                                    <createZipball>false</createZipball>
+                                    <runnableJar>${project.build.directory}/../../forge-gui-mobile-dev/target/forge-gui-mobile-dev-${project.version}-jar-with-dependencies.jar</runnableJar>
+                                    <macConfig>
+                                        <icnsFile>${basedir}/../forge-gui/src/main/config/Forge.icns</icnsFile>
+                                        <generateDmg>${macos.generateDmg}</generateDmg>
+                                    </macConfig>
+                                    <additionalResources>
+                                        <additionalResource>${basedir}/../forge-gui/res</additionalResource>
+                                        <additionalResource>${basedir}/../forge-gui/LICENSE.txt</additionalResource>
+                                        <additionalResource>${basedir}/../forge-gui/MANUAL.txt</additionalResource>
+                                        <additionalResource>${basedir}/../forge-gui/release-files</additionalResource>
+                                    </additionalResources>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>adventure-editor-app</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                                <configuration>
+                                    <mainClass>forge.adventure.Main</mainClass>
+                                    <name>Adventure Editor</name>
+                                    <displayName>Adventure Editor</displayName>
+                                    <description>Magic: The Gathering Adventure Editor</description>
+                                    <url>https://www.cardforge.org/</url>
+                                    <organizationName>CardForge</organizationName>
+                                    <organizationUrl>https://www.cardforge.org/</organizationUrl>
+                                    <bundleJre>false</bundleJre>
+                                    <generateInstaller>${macos.generateInstaller}</generateInstaller>
+                                    <platform>mac</platform>
+                                    <createZipball>false</createZipball>
+                                    <runnableJar>${project.build.directory}/../../adventure-editor/target/adventure-editor-jar-with-dependencies.jar</runnableJar>
+                                    <macConfig>
+                                        <icnsFile>${basedir}/../forge-gui/src/main/config/Forge.icns</icnsFile>
+                                        <generateDmg>${macos.generateDmg}</generateDmg>
+                                    </macConfig>
+                                    <additionalResources>
+                                        <additionalResource>${basedir}/../adventure-editor/tools</additionalResource>
+                                    </additionalResources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <executions>
+                            <execution>
+                                <id>prepare-cardsfolder</id>
+                                <phase>package</phase>
+                                <configuration>
+                                    <target>
+                                        <mkdir dir="${project.build.directory}/Forge/res/cardsfolder" />
+                                        <zip destfile="${project.build.directory}/Forge/res/cardsfolder/cardsfolder.zip"
+                                             basedir="${basedir}/../forge-gui/res/cardsfolder" level="1" />
+                                        <mkdir dir="${project.build.directory}/Forge Adventure/res/cardsfolder" />
+                                        <zip destfile="${project.build.directory}/Forge Adventure/res/cardsfolder/cardsfolder.zip"
+                                             basedir="${basedir}/../forge-gui/res/cardsfolder" level="1" />
+                                        <mkdir dir="${project.build.directory}/Adventure Editor/tools" />
+                                        <copy todir="${project.build.directory}/Adventure Editor/tools">
+                                            <fileset dir="${basedir}/../adventure-editor/tools" includes="**/*" />
+                                        </copy>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>macos-on-mac</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                </os>
+            </activation>
+            <properties>
+                <macos.generateDmg>true</macos.generateDmg>
+                <macos.generateInstaller>true</macos.generateInstaller>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <executions>
+                            <execution>
+                                <id>prepare-cardsfolder</id>
+                                <phase>package</phase>
+                                <configuration>
+                                    <target>
+                                        <mkdir dir="${project.build.directory}/Forge/res/cardsfolder" />
+                                        <zip destfile="${project.build.directory}/Forge/res/cardsfolder/cardsfolder.zip"
+                                             basedir="${basedir}/../forge-gui/res/cardsfolder" level="1" />
+                                        <mkdir dir="${project.build.directory}/Forge Adventure/res/cardsfolder" />
+                                        <zip destfile="${project.build.directory}/Forge Adventure/res/cardsfolder/cardsfolder.zip"
+                                             basedir="${basedir}/../forge-gui/res/cardsfolder" level="1" />
+                                        <mkdir dir="${project.build.directory}/Adventure Editor/tools" />
+                                        <copy todir="${project.build.directory}/Adventure Editor/tools">
+                                            <fileset dir="${basedir}/../adventure-editor/tools" includes="**/*" />
+                                        </copy>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>3.6.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-macos-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>attach-artifact</goal>
+                                </goals>
+                                <configuration>
+                                    <artifacts>
+                                        <artifact>
+                                            <file>${project.build.directory}/Forge.dmg</file>
+                                            <type>dmg</type>
+                                            <classifier>forge</classifier>
+                                            <optional>true</optional>
+                                        </artifact>
+                                        <artifact>
+                                            <file>${project.build.directory}/Forge Adventure.dmg</file>
+                                            <type>dmg</type>
+                                            <classifier>forge-adventure</classifier>
+                                            <optional>true</optional>
+                                        </artifact>
+                                        <artifact>
+                                            <file>${project.build.directory}/Adventure Editor.dmg</file>
+                                            <type>dmg</type>
+                                            <classifier>adventure-editor</classifier>
+                                            <optional>true</optional>
+                                        </artifact>
+                                    </artifacts>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>macos-dmg</id>
+            <properties>
+                <macos.generateDmg>true</macos.generateDmg>
+                <macos.generateInstaller>true</macos.generateInstaller>
+            </properties>
+        </profile>
+
     </profiles>
 </project>

--- a/forge-installer/src/main/resources/macos/Info-adventure.plist
+++ b/forge-installer/src/main/resources/macos/Info-adventure.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleDisplayName</key>
+    <string>Forge Adventure</string>
+    <key>CFBundleExecutable</key>
+    <string>forge-adventure</string>
+    <key>CFBundleIdentifier</key>
+    <string>forge.mtg.adventure</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>Forge Adventure</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${project.version}</string>
+    <key>CFBundleVersion</key>
+    <string>${project.version}</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>10.9</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSSupportsAutomaticGraphicsSwitching</key>
+    <true/>
+    <key>CFBundleIconFile</key>
+    <string>forge-adventure.icns</string>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.games</string>
+    <key>NSHumanReadableCopyright</key>
+    <string>Copyright © 2024 Forge Community. All rights reserved.</string>
+</dict>
+</plist>

--- a/forge-installer/src/main/resources/macos/Info.plist
+++ b/forge-installer/src/main/resources/macos/Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleDisplayName</key>
+    <string>Forge</string>
+    <key>CFBundleExecutable</key>
+    <string>forge</string>
+    <key>CFBundleIdentifier</key>
+    <string>forge.mtg.forge</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>Forge</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${project.version}</string>
+    <key>CFBundleVersion</key>
+    <string>${project.version}</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>10.9</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSSupportsAutomaticGraphicsSwitching</key>
+    <true/>
+    <key>CFBundleIconFile</key>
+    <string>forge.icns</string>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.games</string>
+    <key>NSHumanReadableCopyright</key>
+    <string>Copyright © 2024 Forge Community. All rights reserved.</string>
+</dict>
+</plist>

--- a/forge-installer/src/main/resources/macos/forge
+++ b/forge-installer/src/main/resources/macos/forge
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "$(dirname "$0")/../Resources"
+java -Xdock:icon="forge.icns" -jar $project.build.finalName$-jar-with-dependencies.jar

--- a/forge-installer/src/main/resources/macos/forge-adventure
+++ b/forge-installer/src/main/resources/macos/forge-adventure
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "$(dirname "$0")/../Resources"
+java -Xdock:icon="forge-adventure.icns" -jar $project.build.finalName$-jar-with-dependencies.jar


### PR DESCRIPTION
- Add native macOS .app bundles for Forge and Forge Adventure
- Create macOS Maven profile with Info.plist and launcher scripts
- Generate optional DMG for distribution (macOS only)
- Remove redundant .command scripts in favor of native app bundles
- Update README with comprehensive build instructions

----

It looks like there was some previous work or attempt to build MacOS app files.  I am not clear on why those are not working.  I was able to build these and run both on my Mac OS system, so maybe that is good enough to switch to.  

Please let me know if there is anything that I need to do to adjust them.