### PR TITLE
add Preload Custom Drafts

### DIFF
--- a/forge-gui-mobile/src/forge/Forge.java
+++ b/forge-gui-mobile/src/forge/Forge.java
@@ -283,7 +283,8 @@ public class Forge implements ApplicationListener {
 
     private void preloadBoosterDrafts() {
         //preloading of custom drafts
-        BoosterDraft.initializeCustomDrafts();
+        if (getForgePreferences().getPrefBoolean(FPref.PRELOAD_CUSTOM_DRAFTS))
+            BoosterDraft.initializeCustomDrafts();
     }
 
     public static void openHomeScreen(int index, FScreen lastMatch) {

--- a/forge-gui-mobile/src/forge/screens/settings/SettingsPage.java
+++ b/forge-gui-mobile/src/forge/screens/settings/SettingsPage.java
@@ -393,6 +393,10 @@ public class SettingsPage extends TabPage<SettingsScreen> {
                         Forge.getLocalizer().getMessage("cbLoadArchivedFormats"),
                         Forge.getLocalizer().getMessage("nlLoadArchivedFormats")),
                 3);
+        lstSettings.addItem(new BooleanSetting(FPref.PRELOAD_CUSTOM_DRAFTS,
+                        Forge.getLocalizer().getMessage("cbPreloadCustomDrafts"),
+                        Forge.getLocalizer().getMessage("nlPreloadCustomDrafts")),
+                3);
         lstSettings.addItem(new BooleanSetting(FPref.UI_LOAD_UNKNOWN_CARDS,
                                     Forge.getLocalizer().getMessage("lblEnableUnknownCards"),
                                     Forge.getLocalizer().getMessage("nlEnableUnknownCards")) {

--- a/forge-gui/res/languages/de-DE.properties
+++ b/forge-gui/res/languages/de-DE.properties
@@ -3537,3 +3537,5 @@ lblPlsSelectActions=Bitte wählen Sie Optionen zum Ausführen der Aktion aus
 lblBackupMsg=Sichern von Dateien
 lblRestoreMsg=Wiederherstellen von Dateien
 lblSuccess=Erfolg
+cbPreloadCustomDrafts=Benutzerdefinierte Entwürfe vorladen
+nlPreloadCustomDrafts=Wenn aktiviert, werden die benutzerdefinierten Entwurfsdateien beim Start vorab geladen (Forge benötigt beim Parsen von Entwurfsdateien eine längere Startzeit).

--- a/forge-gui/res/languages/en-US.properties
+++ b/forge-gui/res/languages/en-US.properties
@@ -3284,3 +3284,5 @@ lblPlsSelectActions=Please select options to perform action
 lblBackupMsg=Backing up files
 lblRestoreMsg=Restoring files
 lblSuccess=Success
+cbPreloadCustomDrafts=Preload Custom Drafts
+nlPreloadCustomDrafts=If enabled, the custom drafts files are preloaded on startup (Forge will have longer startup time when parsing drafts files).

--- a/forge-gui/res/languages/es-ES.properties
+++ b/forge-gui/res/languages/es-ES.properties
@@ -3541,3 +3541,5 @@ lblPlsSelectActions=Seleccione las opciones para realizar la acción
 lblBackupMsg=Realizar copias de seguridad de archivos
 lblRestoreMsg=Restaurando archivos
 lblSuccess=Éxito
+cbPreloadCustomDrafts=Precargar borradores personalizados
+nlPreloadCustomDrafts=Si está habilitado, los archivos de borradores personalizados se precargan al inicio (Forge tendrá un tiempo de inicio más largo al analizar los archivos de borradores).

--- a/forge-gui/res/languages/fr-FR.properties
+++ b/forge-gui/res/languages/fr-FR.properties
@@ -3542,3 +3542,5 @@ lblPlsSelectActions=Veuillez sélectionner les options pour effectuer l'action
 lblBackupMsg=Sauvegarde des fichiers
 lblRestoreMsg=Restauration de fichiers
 lblSuccess=Succès
+cbPreloadCustomDrafts=Précharger les brouillons personnalisés
+nlPreloadCustomDrafts=Si cette option est activée, les fichiers de brouillons personnalisés sont préchargés au démarrage (Forge aura un temps de démarrage plus long lors de l'analyse des fichiers de brouillons).

--- a/forge-gui/res/languages/it-IT.properties
+++ b/forge-gui/res/languages/it-IT.properties
@@ -3540,3 +3540,5 @@ lblPlsSelectActions=Seleziona le opzioni per eseguire l'azione
 lblBackupMsg=Backup dei file
 lblRestoreMsg=Ripristino dei file
 lblSuccess=Successo
+cbPreloadCustomDrafts=Precarica bozze personalizzate
+nlPreloadCustomDrafts=Se abilitato, i file delle bozze personalizzate vengono precaricati all'avvio (Forge avrà tempi di avvio più lunghi durante l'analisi dei file delle bozze).

--- a/forge-gui/res/languages/ja-JP.properties
+++ b/forge-gui/res/languages/ja-JP.properties
@@ -3536,3 +3536,5 @@ lblPlsSelectActions=アクションを実行するにはオプションを選択
 lblBackupMsg=ファイルのバックアップ
 lblRestoreMsg=ファイルの復元
 lblSuccess=成功
+cbPreloadCustomDrafts=カスタムドラフトをプリロードする
+nlPreloadCustomDrafts=有効にすると、起動時にカスタム ドラフト ファイルがプリロードされます (ドラフト ファイルを解析するときに Forge の起動時間が長くなります)。

--- a/forge-gui/res/languages/pt-BR.properties
+++ b/forge-gui/res/languages/pt-BR.properties
@@ -3626,3 +3626,5 @@ lblPlsSelectActions=Selecione as opções para executar a ação
 lblBackupMsg=Fazendo backup de arquivos
 lblRestoreMsg=Restaurando arquivos
 lblSuccess=Sucesso
+cbPreloadCustomDrafts=Pré-carregar rascunhos personalizados
+nlPreloadCustomDrafts=Se habilitado, os arquivos de rascunhos personalizados serão pré-carregados na inicialização (o Forge terá um tempo de inicialização maior ao analisar arquivos de rascunhos).

--- a/forge-gui/res/languages/zh-CN.properties
+++ b/forge-gui/res/languages/zh-CN.properties
@@ -3527,3 +3527,5 @@ lblPlsSelectActions=请选择要执行操作的选项
 lblBackupMsg=备份文件
 lblRestoreMsg=恢复文件
 lblSuccess=成功
+cbPreloadCustomDrafts=预加载自定义草稿
+nlPreloadCustomDrafts=如果启用，自定义草稿文件将在启动时预加载（Forge 在解析草稿文件时会有更长的启动时间）。

--- a/forge-gui/src/main/java/forge/localinstance/properties/ForgePreferences.java
+++ b/forge-gui/src/main/java/forge/localinstance/properties/ForgePreferences.java
@@ -217,6 +217,7 @@ public class ForgePreferences extends PreferencesStore<ForgePreferences.FPref> {
 
         LOAD_CARD_SCRIPTS_LAZILY ("false"),
         LOAD_ARCHIVED_FORMATS ("false"),
+        PRELOAD_CUSTOM_DRAFTS ("false"),
 
         DECK_DEFAULT_CARD_LIMIT ("4"),
         DECKGEN_SINGLETONS ("false"),


### PR DESCRIPTION
Should fix longer startup time on mobile version instead of forcing to load custom drafts file at startup.