### PR TITLE
Add python specific entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,7 @@ forge-gui/tools/PerSetTrackingResults
 *.tiled-session
 /forge-gui/res/adventure/*.tiled-project
 /forge-gui/res/adventure/*.tiled-session
+
+# Ignore python temporaries
+__pycache__
+*.pyc


### PR DESCRIPTION
Forge has some python tools. This adds python temporaries to the .gitignore. *.pyc files and __pycache__ should never be checked in.