### PR TITLE
Update the forge.sh script to be more usable

### DIFF
--- a/forge-gui-desktop/src/main/config/forge.sh
+++ b/forge-gui-desktop/src/main/config/forge.sh
@@ -1,3 +1,27 @@
 #!/bin/sh
+set -euo pipefail
+
 cd $(dirname "${0}")
-java $mandatory.java.args$ -jar $project.build.finalName$ "$@"
+
+if [ ! -e res ]; then
+  ln -s ../../forge-gui/res res
+fi;
+
+JAVA_EXE="java"
+if [ -n "${JAVA_HOME:-}" ]; then
+  JAVA_EXE="${JAVA_HOME}/bin/java"
+fi
+
+# The user can specify an alternate project jar in the first argument
+if [ -n "${1:-}" ]; then
+  if [ -e "$1" ]; then
+    project_jar="$1"
+  else
+    echo "Error: Specified project jar '$1' does not exist." >&2
+    exit 1
+  fi
+else
+  project_jar="$project.build.finalName$"
+fi
+
+${JAVA_EXE} $mandatory.java.args$ -jar ${project_jar} "$@"


### PR DESCRIPTION
As a developer when I build forge with a `mvn install` command, I don't want to go through a whole rigamarole to package the jars before running. I try to run directly out of the `forge-gui-desktop/target` directory for instance. These changes make that easier as the developer can now directly run `bash forge-gui-desktop/target/forge.sh` after running the `install` target and run the built forge. It sets up a link to `forge-gui/res` so it can find it's resources and it checks if `JAVA_HOME` is set, and if so uses the appropriate `java` executable.

It's possible people have a different use pattern in mind. Let me know if I've got it wrong. Otherwise, I'm just trying to share how I do it now.