### PR TITLE
Update summon_primal_odin.txt

### DIFF
--- a/forge-gui/res/cardsfolder/s/summon_primal_odin.txt
+++ b/forge-gui/res/cardsfolder/s/summon_primal_odin.txt
@@ -4,9 +4,10 @@ Types:Enchantment Creature Saga Knight
 PT:5/3
 K:Chapter:3:DBDestroy,DBPump,DBDraw
 SVar:DBDestroy:DB$ Destroy | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | SpellDescription$ Gungnir — Destroy target creature an opponent controls.
-SVar:DBPump:DB$ Animate | Defined$ Self | Triggers$ CombatTrig | Duration$ Permanent | SpellDescription$ Zantetsuken — This creature gains "Whenever this creature deals combat damage to a player, that player loses the game."
+SVar:DBPump:DB$ Animate | Defined$ Self | Triggers$ CombatTrig | sVars$ OdinMustBeBlocked | Duration$ Permanent | SpellDescription$ Zantetsuken — This creature gains "Whenever this creature deals combat damage to a player, that player loses the game."
 SVar:CombatTrig:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigTheyLose | TriggerDescription$ Whenever this creature deals combat damage to a player, that player loses the game.
 SVar:TrigTheyLose:DB$ LosesGame | Defined$ TriggeredTarget
+SVar:OdinMustBeBlocked:SVar:MustBeBlocked:True
 SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 2 | SubAbility$ DBLoseLife | SpellDescription$ Hall of Sorrow — Draw two cards. Each player loses 2 life.
 SVar:DBLoseLife:DB$ LoseLife | LifeAmount$ 2 | Defined$ Player
 Oracle:(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI — Gungnir — Destroy target creature an opponent controls.\nII — Zantetsuken — This creature gains "Whenever this creature deals combat damage to a player, that player loses the game."\nIII — Hall of Sorrow — Draw two cards. Each player loses 2 life.


### PR DESCRIPTION
Confirmed a report that [Summon: Primal Odin](https://github.com/Card-Forge/forge/blob/master/forge-gui/res/cardsfolder/s/summon_primal_odin.txt) wasn't being chump blocked when not blocking would result in a loss for the defending player. 
Applied a working fix largely based on [Kheru Lich Lord](https://github.com/Card-Forge/forge/blob/master/forge-gui/res/cardsfolder/k/kheru_lich_lord.txt), swapping out `MustAttack:True` with `MustBeBlocked:True`.