### PR TITLE
Fix some crashes from the new editor

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/scene/AdventureDeckEditor.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/AdventureDeckEditor.java
@@ -671,7 +671,7 @@ public class AdventureDeckEditor extends FDeckEditor {
     }
 
     public AdventureDeckEditor(Deck deckToPreview) {
-        super(new DeckPreviewConfig(deckToPreview), deckToPreview.getName());
+        super(new DeckPreviewConfig(deckToPreview), deckToPreview);
     }
 
     @Override

--- a/forge-gui-mobile/src/forge/adventure/scene/DuelScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/DuelScene.java
@@ -413,12 +413,12 @@ public class DuelScene extends ForgeScene {
         if (missingCards > 0) //Replace unknown cards for a Wastes.
             mainSection.add(PLACEHOLDER_MAIN, missingCards);
 
-        if(!attractions.isEmpty()) {
+        if(attractions != null && !attractions.isEmpty()) {
             int missingAttractions = 10 - attractions.countAll(); //TODO: These shouldn't be hard coded but DeckFormat's gonna need some reorganizing to fetch this dynamically
             if(missingAttractions > 0)
                 attractions.add(PLACEHOLDER_ATTRACTION, missingAttractions);
         }
-        if(!contraptions.isEmpty()) {
+        if(contraptions != null && !contraptions.isEmpty()) {
             int missingContraptions = 15 - contraptions.countAll();
             if(missingContraptions > 0)
                 contraptions.add(PLACEHOLDER_CONTRAPTION, missingContraptions);

--- a/forge-gui-mobile/src/forge/adventure/scene/DuelScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/DuelScene.java
@@ -425,13 +425,15 @@ public class DuelScene extends ForgeScene {
         }
     }
 
-    private static void removeExcessCopies(CardPool mainSection, DeckFormat format) {
-        for(Map.Entry<PaperCard, Integer> e : mainSection) {
+    private static void removeExcessCopies(CardPool section, DeckFormat format) {
+        if(section == null)
+            return;
+        for(Map.Entry<PaperCard, Integer> e : section) {
             PaperCard card = e.getKey();
             int amount = e.getValue();
             int limit = format.getMaxCardCopies(card);
             if(amount > limit)
-                mainSection.remove(card, amount - limit);
+                section.remove(card, amount - limit);
         }
     }
 

--- a/forge-gui-mobile/src/forge/adventure/util/AdventureEventController.java
+++ b/forge-gui-mobile/src/forge/adventure/util/AdventureEventController.java
@@ -100,7 +100,7 @@ public class AdventureEventController implements Serializable {
         AdventureEventData e;
 
         // TODO After a certain amount of wins, stop offering jump start events
-        if (random.nextInt(10) <= 2) {
+        if (random.nextInt(10) <= 100) {
             e = new AdventureEventData(eventSeed, EventFormat.Jumpstart);
         } else {
             e = new AdventureEventData(eventSeed, EventFormat.Draft);

--- a/forge-gui-mobile/src/forge/adventure/util/AdventureEventController.java
+++ b/forge-gui-mobile/src/forge/adventure/util/AdventureEventController.java
@@ -100,7 +100,7 @@ public class AdventureEventController implements Serializable {
         AdventureEventData e;
 
         // TODO After a certain amount of wins, stop offering jump start events
-        if (random.nextInt(10) <= 100) {
+        if (random.nextInt(10) <= 2) {
             e = new AdventureEventData(eventSeed, EventFormat.Jumpstart);
         } else {
             e = new AdventureEventData(eventSeed, EventFormat.Draft);


### PR DESCRIPTION
Fixes crash when previewing Jumpstart decks. Plugged in the wrong overload here when removing the back button callbacks.

Fixes an NPE when fighting an enemy without all possible extra sections. This one's probably worth refiring snapshots over.