### PR TITLE
Fix negative gold payouts from selling cards.

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
+++ b/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
@@ -1022,7 +1022,7 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
         int earned = performSale(card, amountToSell);
 
         if(earned > 0)
-            takeGold(earned);
+            giveGold(earned);
         return amountToSell;
     }
 
@@ -1036,7 +1036,7 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
             profit += AdventurePlayer.current().performSale(cardToSell, 1);
             cards.remove(cardToSell);
         }
-        takeGold(profit); //do this as one transaction so as not to get multiple copies of sound effect
+        giveGold(profit); //do this as one transaction so as not to get multiple copies of sound effect
     }
 
     /**


### PR DESCRIPTION
Originally switched from `addGold` so the sound would play, but used `takeGold` instead of `giveGold`.