### PR TITLE
A few auto-sell section fixes

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/scene/AdventureDeckEditor.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/AdventureDeckEditor.java
@@ -471,7 +471,7 @@ public class AdventureDeckEditor extends FDeckEditor {
                 ));
             }
             if(parentScreen instanceof AdventureDeckEditor adventureEditor && adventureEditor.getCatalogPage() != null) {
-                CollectionCatalogPage catalogPage = (CollectionCatalogPage) adventureEditor.getCatalogPage();
+                CatalogPage catalogPage = adventureEditor.getCatalogPage();
                 int autoSellCount = cardManager.getItemCount(card);
                 int amountInCollection = player.getCards().count(card);
                 int safeToSellCount = amountInCollection - player.getCopiesUsedInDecks(card);

--- a/forge-gui-mobile/src/forge/adventure/scene/AdventureDeckEditor.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/AdventureDeckEditor.java
@@ -437,6 +437,7 @@ public class AdventureDeckEditor extends FDeckEditor {
             cardManager.setBtnAdvancedSearchOptions(true);
             cardManager.setCatalogDisplay(true);
             cardManager.setPool(getCardPool(), false); //Need to update this early for the caption.
+            this.updateCaption();
         }
 
         @Override

--- a/forge-gui-mobile/src/forge/deck/FDeckEditor.java
+++ b/forge-gui-mobile/src/forge/deck/FDeckEditor.java
@@ -1793,7 +1793,7 @@ public class FDeckEditor extends TabPageScreen<FDeckEditor> {
             DeckSection destination = DeckSection.matchingSection(card);
             final DeckSectionPage destinationPage = parentScreen.getPageForSection(destination);
 
-            if (!needsCommander() && !canOnlyBePartnerCommander(card)) {
+            if (!needsCommander() && !canOnlyBePartnerCommander(card) && destinationPage != null) {
                 addMoveCardMenuItem(menu, card, this, destinationPage);
                 if (canSideboard(card) && destination != DeckSection.Sideboard) {
                     addMoveCardMenuItem(menu, card, this, parentScreen.getSideboardPage());


### PR DESCRIPTION
Addresses two issues when opening the context menu on a card in the Auto-Sell page while inside a shop. Namely: a ClassCastException that I don't think crashes the game but gets swallowed on some UI thread, and some error outputs for trying to generate an item to move cards to a non-existent destination section. Also ensures the Auto-Sell page's size is updated when it initializes, so it shows before any cards are added to or removed from it.

Doesn't seem urgent enough for yet another refiring of snapshots; nobody's reported these yet as far as I can tell and neither outright crashed the game in my tests.