### PR TITLE
Update vorpal_sword.txt

### DIFF
--- a/forge-gui/res/cardsfolder/v/vorpal_sword.txt
+++ b/forge-gui/res/cardsfolder/v/vorpal_sword.txt
@@ -3,9 +3,9 @@ ManaCost:B
 Types:Artifact Equipment
 K:Equip:B B
 S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 2 | AddKeyword$ Deathtouch | Description$ Equipped creature gets +2/+0 and has deathtouch.
-A:AB$ Animate | Cost$ 5 B B B | Defined$ Self | Triggers$ TrigDamageDone | SubAbility$ DBAddSVar | SpellDescription$ Until end of turn, CARDNAME gains "Whenever equipped creature deals combat damage to a player, that player loses the game."
-SVar:DBAddSVar:DB$ Animate | Defined$ Equipped | sVars$ MustBeBlocked
-SVar:MustBeBlocked:True
+A:AB$ Animate | Cost$ 5 B B B | Defined$ Self | Triggers$ TrigDamageDone | staticAbilities$ EquippedMustBeBlocked | SpellDescription$ Until end of turn, CARDNAME gains "Whenever equipped creature deals combat damage to a player, that player loses the game."
+SVar:EquippedMustBeBlocked:Mode$ Continuous | Affected$ Creature.EquippedBy | AddSVar$ VorpalSwordCE
+SVar:VorpalSwordCE:SVar:MustBeBlocked:True
 SVar:TrigDamageDone:Mode$ DamageDone | ValidSource$ Creature.EquippedBy | ValidTarget$ Player | CombatDamage$ True | Execute$ DBLose | TriggerDescription$ Whenever equipped creature deals combat damage to a player, that player loses the game.
 SVar:DBLose:DB$ LosesGame | Defined$ TriggeredTarget
 Oracle:Equipped creature gets +2/+0 and has deathtouch.\n{5}{B}{B}{B}: Until end of turn, Vorpal Sword gains "Whenever equipped creature deals combat damage to a player, that player loses the game."\nEquip {B}{B}


### PR DESCRIPTION
As is, the AI flag enforcing chump blocking (as done for Summon: Primal Odin), is granted through an Animate effect to the equipped creature when the Equipment's ability is activated. This will result in non-optimal AI behavior with lines of play involving multiple combat phases ([Aggravated Assault](https://scryfall.com/card/ons/185/aggravated-assault), etc.), equip cost discounts or infinite mana to re-equip the Sword onto further creatures as happenstance may require. That issue is addressed herein following precedent in cards of the [Sword of X and Y cycle](https://github.com/Card-Forge/forge/blob/a31c0358a48bf34df52429709ec2374faf5828b8/forge-gui/res/cardsfolder/s/sword_of_fire_and_ice.txt).

However since the activated ability works at instant speed, and thus a human player can activate it after blockers are declared, a finer control regarding AI behavior is desirable, namely available mana being accounted for. I take it `MustBeBlocked:AttackingPlayerConservative` isn't too relevant?