### PR TITLE
fix: move CHANGES.txt generation to target directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,9 @@ forge-gui-mobile-dev/testAssets
 
 forge-gui/res/cardsfolder/*.bat
 
+# Generated changelog file
+forge-gui/release-files/CHANGES.txt
+
 forge-gui/res/PerSetTrackingResults
 forge-gui/res/decks
 forge-gui/res/layouts

--- a/forge-gui-android/pom.xml
+++ b/forge-gui-android/pom.xml
@@ -486,7 +486,7 @@
                                             <fileset dir="${basedir}/../forge-gui/release-files/" includes="CONTRIBUTORS.txt" />
                                             <fileset dir="${basedir}/../forge-gui/release-files/" includes="INSTALLATION.txt" />
                                             <fileset dir="${basedir}/../forge-gui/release-files/" includes="ISSUES.txt" />
-                                            <fileset dir="${basedir}/../forge-gui/release-files/" includes="CHANGES.txt" />
+                                            <fileset dir="${basedir}/../forge-gui-desktop/target/" includes="CHANGES.txt" />
                                             <fileset dir="${basedir}/../forge-gui/release-files/" includes="GAMEPAD_README.txt" />
                                             <fileset dir="${basedir}/../forge-gui/" includes="MANUAL.txt" />
                                             <fileset dir="${basedir}/../forge-gui-mobile-dev/" includes="sentry.properties" />

--- a/forge-gui-desktop/pom.xml
+++ b/forge-gui-desktop/pom.xml
@@ -35,7 +35,6 @@
                             <goal>timestamp-property</goal>
                         </goals>
                         <configuration>
-                            <!-- generate MonthDate code to month.date property -->
                             <name>month.date</name>
                             <pattern>MM.dd</pattern>
                         </configuration>
@@ -47,7 +46,6 @@
                             <goal>regex-property</goal>
                         </goals>
                         <configuration>
-                            <!-- generate versionName from revision property to snapshot-version property  -->
                             <name>snapshot-version</name>
                             <value>${revision}</value>
                             <regex>-SNAPSHOT</regex>
@@ -189,7 +187,7 @@
   java.base/java.nio
   java.base/java.math
   java.base/java.util.concurrent
-  java.base/java.net                                     
+  java.base/java.net
 ]]>
                             </Add-Opens>
                             <Main-Class>forge.view.Main</Main-Class>
@@ -208,6 +206,46 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.gmaven</groupId>
+                <artifactId>groovy-maven-plugin</artifactId>
+                <version>2.1.1</version>
+                <executions>
+                    <execution>
+                        <id>get-changelog-from-tag</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>execute</goal>
+                        </goals>
+                        <configuration>
+                            <source>
+<![CDATA[
+try {
+    def isOnTag = "git describe --exact-match --tags HEAD".execute().waitFor() == 0
+    def tagList = "git tag --sort=-version:refname".execute().text.split("\n")
+        .findAll { it.startsWith("forge-") }
+
+    def tag = "HEAD"
+    if (isOnTag && tagList.size() > 1) {
+        tag = tagList[1]
+    } else if (!isOnTag && tagList.size() > 0) {
+        tag = tagList[0]
+    }
+
+    project.properties['changelog.from.tag'] = tag
+    println "Using changelog from tag: ${tag}"
+} catch (Exception e) {
+    project.properties['changelog.from.tag'] = "HEAD"
+    println "Using changelog from tag: HEAD (fallback)"
+}
+]]>
+                            </source>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>se.bjurr.gitchangelog</groupId>
                 <artifactId>git-changelog-maven-plugin</artifactId>
@@ -220,9 +258,9 @@
                             <goal>git-changelog</goal>
                         </goals>
                         <configuration>
-                            <!-- TODO: insert placeholder for latest version tag -->
-                            <fromRef>forge-1.6.65</fromRef>
-                            <file>../forge-gui/release-files/CHANGES.txt</file>
+                            <!-- Generate changelog from the appropriate tag -->
+                            <fromRef>refs/tags/${changelog.from.tag}</fromRef>
+                            <file>${project.build.directory}/CHANGES.txt</file>
                             <templateContent>
 <![CDATA[
 {{#tags}}
@@ -488,7 +526,7 @@
                                         <mkdir dir="${project.build.directory}/${project.build.finalName}-osx" />
                                         <copy todir="${project.build.directory}/${project.build.finalName}-osx">
                                             <fileset dir="${basedir}/../forge-gui/" includes="LICENSE.txt" />
-                                            <fileset dir="${basedir}/../forge-gui/release-files/" includes="CHANGES.txt" />
+                                            <fileset dir="${basedir}/../forge-gui-desktop/target/" includes="CHANGES.txt" />
                                             <fileset dir="${basedir}/../forge-gui/release-files/" includes="CONTRIBUTORS.txt" />
                                             <fileset dir="${basedir}/../forge-gui/release-files/" includes="ISSUES.txt" />
                                             <fileset dir="${basedir}/../forge-gui/release-files/" includes="INSTALLATION.txt" />

--- a/forge-gui/release-files/CHANGES.txt
+++ b/forge-gui/release-files/CHANGES.txt
@@ -1,2 +1,0 @@
-- Bug fixes -
-As always, this release of Forge features an assortment of bug fixes and improvements based on user feedback during the previous release run.

--- a/forge-installer/pom.xml
+++ b/forge-installer/pom.xml
@@ -171,7 +171,7 @@
                                             <fileset dir="${basedir}/../forge-gui/release-files/" includes="INSTALLATION.txt" />
                                             <fileset dir="${basedir}/../forge-gui/release-files/" includes="GAMEPAD_README.txt" />
                                             <fileset dir="${basedir}/../forge-gui/release-files/" includes="ISSUES.txt" />
-                                            <fileset dir="${basedir}/../forge-gui/release-files/" includes="CHANGES.txt" />
+                                            <fileset dir="${basedir}/../forge-gui-desktop/target/" includes="CHANGES.txt" />
                                             <fileset dir="${basedir}/../forge-gui/">
                                                 <include name="res/**" />
                                                 <exclude name="res/cardsfolder/**" />

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,6 @@
                         <allowTimestampedSnapshots>true</allowTimestampedSnapshots>
                         <checkModificationExcludes>
                           <checkModificationExclude>.mvn/local-settings.xml</checkModificationExclude>
-                          <checkModificationExclude>forge-gui/release-files/CHANGES.txt</checkModificationExclude>
                         </checkModificationExcludes>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
- Generate CHANGES.txt in forge-gui-desktop/target/ instead of source tree
- Update installer to copy from target directory for all build profiles
- Add CHANGES.txt to .gitignore since it's generated
- Remove hardcoded fromRef to use latest tag automatically
- Remove maven-release-plugin exclusion for untracked file

Fixes issue where CHANGES.txt appeared as modified after every build.

--

While working on #8378, I keep seeing changes to `forge-gui/release-files/CHANGES.txt`, and within that file it looked like it included a lot more changes than I expected (all the way back to 2011).  It likely shouldn't be in the codebase at all, so I removed it, and set the generated location to be in the target directory.  Further, the release related scripts that use this file were adjusted to refer to the new location.

As far as reducing the changes in this file to the latest tag, I did try to include the case where the changes are being generated from a new tag (where the current revision is tagged).  In this case, the changes will be generated from the previous tag.