### PR TITLE
Fix NPE deserializing old decks

### DIFF
--- a/forge-core/src/main/java/forge/deck/Deck.java
+++ b/forge-core/src/main/java/forge/deck/Deck.java
@@ -28,6 +28,8 @@ import forge.item.PaperCard;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.util.*;
 import java.util.Map.Entry;
 
@@ -215,7 +217,9 @@ public class Deck extends DeckBase implements Iterable<Entry<DeckSection, CardPo
         }
         result.setAiHints(StringUtils.join(aiHints, " | "));
         result.setDraftNotes(draftNotes);
-        tags.addAll(result.getTags());
+        //noinspection ConstantValue
+        if(tags != null) //Can happen deserializing old Decks.
+            result.tags.addAll(this.tags);
     }
 
     /*
@@ -622,6 +626,14 @@ public class Deck extends DeckBase implements Iterable<Entry<DeckSection, CardPo
 
     @Override
     public Deck getHumanDeck() {
+        return this;
+    }
+
+    @Serial
+    private Object readResolve() throws ObjectStreamException {
+        //If we deserialized an old deck that doesn't have tags, fix it here.
+        if(this.tags == null)
+            return new Deck(this);
         return this;
     }
 


### PR DESCRIPTION
Apparently very old decks that were serialized for storage didn't have a `tags` field, even though it's effectively non-null these days. Added a `readResolve` method to account for that. But we *really* should move away from using Java serialization for anything. It easily breaks assumptions in ways that's difficult to account for.

Also reverses `tags.addAll(result.getTags());` to `result.tags.addAll(this.tags);`, because that seems more like the intended behavior for the `cloneFieldsTo` method.