### PR TITLE
Tidying DBCleanup

### DIFF
--- a/forge-gui/res/cardsfolder/c/cranial_extraction.txt
+++ b/forge-gui/res/cardsfolder/c/cranial_extraction.txt
@@ -7,5 +7,5 @@ SVar:ExileHand:DB$ ChangeZone | Origin$ Hand | Destination$ Exile | DefinedPlaye
 SVar:ExileLib:DB$ ChangeZone | Origin$ Library | Destination$ Exile | DefinedPlayer$ Targeted | ChangeType$ Card.NamedCard | ChangeNum$ NumInLib | Chooser$ You | Shuffle$ True | SubAbility$ DBCleanup | StackDescription$ None
 SVar:NumInLib:TargetedPlayer$CardsInLibrary
 SVar:NumInHand:TargetedPlayer$CardsInHand
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBCleanup:DB$ Cleanup | ClearNamedCard$ True
 Oracle:Choose a nonland card name. Search target player's graveyard, hand, and library for all cards with that name and exile them. Then that player shuffles.

--- a/forge-gui/res/cardsfolder/k/kheru_dreadmaw.txt
+++ b/forge-gui/res/cardsfolder/k/kheru_dreadmaw.txt
@@ -3,7 +3,6 @@ ManaCost:4 B
 Types:Creature Zombie Crocodile
 PT:4/4
 K:Defender
-A:AB$ GainLife | Cost$ 1 G Sac<1/Creature.Other/another creature> | LifeAmount$ X | SubAbility$ DBCleanup | SpellDescription$ You gain life equal to the sacrificed creature's toughness.
+A:AB$ GainLife | Cost$ 1 G Sac<1/Creature.Other/another creature> | LifeAmount$ X | SpellDescription$ You gain life equal to the sacrificed creature's toughness.
 SVar:X:Sacrificed$CardToughness
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Defender\n{1}{G}, Sacrifice another creature: You gain life equal to the sacrificed creature's toughness.

--- a/forge-gui/res/cardsfolder/l/lolth_spider_queen.txt
+++ b/forge-gui/res/cardsfolder/l/lolth_spider_queen.txt
@@ -9,8 +9,7 @@ SVar:DBLoseLife1:DB$ LoseLife | LifeAmount$ 1
 A:AB$ Token | Cost$ SubCounter<3/LOYALTY> | TokenAmount$ 2 | TokenScript$ b_2_1_spider_menace_reach | TokenOwner$ You | Planeswalker$ True | SpellDescription$ Create two 2/1 black Spider creature tokens with menace and reach.
 A:AB$ Effect | Cost$ SubCounter<8/LOYALTY> | Name$ Emblem — Lolth, Spider Queen | Triggers$ TrigLoseLife | Planeswalker$ True | Ultimate$ True | Duration$ Permanent | AILogic$ Main1 | SpellDescription$ You get an emblem with "Whenever an opponent is dealt combat damage by one or more creatures you control, if that player lost less than 8 life this turn, they lose life equal to the difference."
 SVar:TrigLoseLife:Mode$ DamageDoneOnce | ValidSource$ Creature.YouCtrl | ValidTarget$ Player | CombatDamage$ True | CheckSVar$ X | SVarCompare$ LT8 | Execute$ LoseLife | TriggerZones$ Command | TriggerDescription$ Whenever an opponent is dealt combat damage by one or more creatures you control, if that player lost less than 8 life this turn, they lose life equal to the difference.
-SVar:LoseLife:DB$ LoseLife | Defined$ TriggeredTarget | LifeAmount$ Y | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:LoseLife:DB$ LoseLife | Defined$ TriggeredTarget | LifeAmount$ Y
 SVar:X:TriggeredTarget$LifeLostThisTurn
 SVar:Y:SVar$X/NMinus.8
 Oracle:Whenever a creature you control dies, put a loyalty counter on Lolth, Spider Queen.\n[0]: You draw a card and you lose 1 life.\n[-3]: Create two 2/1 black Spider creature tokens with menace and reach.\n[-8]: You get an emblem with "Whenever an opponent is dealt combat damage by one or more creatures you control, if that player lost less than 8 life this turn, they lose life equal to the difference."

--- a/forge-gui/res/cardsfolder/m/martyrs_bond.txt
+++ b/forge-gui/res/cardsfolder/m/martyrs_bond.txt
@@ -1,8 +1,6 @@
 Name:Martyr's Bond
 ManaCost:4 W W
 Types:Enchantment
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Permanent.nonLand+YouCtrl+Other | Execute$ TrigMartyrsSacrifice | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME or another nonland permanent you control is put into a graveyard from the battlefield, each opponent sacrifices a permanent that shares a card type with it.
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigMartyrsSacrifice | Secondary$ True | TriggerDescription$ Whenever CARDNAME or another nonland permanent you control is put into a graveyard from the battlefield, each opponent sacrifices a permanent that shares a card type with it.
-SVar:TrigMartyrsSacrifice:DB$ Sacrifice | Amount$ 1 | SacValid$ TriggeredCard.sharesCardTypeWith | Defined$ TriggeredCardOpponent | SacMessage$ permanent that shares type with it | SubAbility$ DBMartyrsCleanup
-SVar:DBMartyrsCleanup:DB$ Cleanup | ClearRemembered$ True
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self,Permanent.nonLand+YouCtrl+Other | Execute$ TrigMartyrsSacrifice | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME or another nonland permanent you control is put into a graveyard from the battlefield, each opponent sacrifices a permanent that shares a card type with it.
+SVar:TrigMartyrsSacrifice:DB$ Sacrifice | Amount$ 1 | SacValid$ TriggeredCard.sharesCardTypeWith | Defined$ TriggeredCardOpponent | SacMessage$ permanent that shares type with it
 Oracle:Whenever Martyr's Bond or another nonland permanent you control is put into a graveyard from the battlefield, each opponent sacrifices a permanent that shares a card type with it.

--- a/forge-gui/res/cardsfolder/p/press_the_enemy.txt
+++ b/forge-gui/res/cardsfolder/p/press_the_enemy.txt
@@ -2,8 +2,7 @@ Name:Press the Enemy
 ManaCost:2 U U
 Types:Instant
 A:SP$ ChangeZone | ValidTgts$ Permanent.nonLand+OppCtrl,Card.inZoneStack+OppCtrl | TgtZone$ Stack,Battlefield | Origin$ Battlefield,Stack | Destination$ Hand | SubAbility$ DBMayPlay | SpellDescription$ Return target spell or nonland permanent an opponent controls to its owner's hand.
-SVar:DBMayPlay:DB$ Play | Valid$ Card.YouOwn | ValidZone$ Hand | ValidSA$ Instant.cmcLEZ,Sorcery.cmcLEZ | WithoutManaCost$ True | Optional$ True | SubAbility$ DBCleanup | SpellDescription$ You may cast an instant or sorcery spell with equal or lesser mana value from your hand without paying its mana cost.
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBMayPlay:DB$ Play | Valid$ Card.YouOwn | ValidZone$ Hand | ValidSA$ Instant.cmcLEZ,Sorcery.cmcLEZ | WithoutManaCost$ True | Optional$ True | SpellDescription$ You may cast an instant or sorcery spell with equal or lesser mana value from your hand without paying its mana cost.
 SVar:X:SpellTargeted$CardManaCostLKI
 SVar:Y:Targeted$CardManaCostLKI
 SVar:Z:SVar$X/Plus.Y

--- a/forge-gui/res/cardsfolder/s/sirens_call.txt
+++ b/forge-gui/res/cardsfolder/s/sirens_call.txt
@@ -1,11 +1,10 @@
 Name:Siren's Call
 ManaCost:U
 Types:Instant
-A:SP$ Effect | StaticAbilities$ MustAttack | ActivationPhases$ Upkeep->BeginCombat | ActivationFirstCombat$ True | OpponentTurn$ True | SpellDescription$ Cast this spell only during an opponent's turn, before attackers are declared. Creatures the active player controls attack this turn if able. At the beginning of the next end step, destroy all non-Wall creatures that player controls that didn't attack this turn. Ignore this effect for each creature the player didn't control continuously since the beginning of the turn. | SubAbility$ DestroyPacifist
+A:SP$ Effect | StaticAbilities$ MustAttack | ActivationPhases$ Upkeep->BeginCombat | ActivationFirstCombat$ True | OpponentTurn$ True | SpellDescription$ Cast this spell only during an opponent's turn, before attackers are declared.,,,,,,Creatures the active player controls attack this turn if able.,,,,,,At the beginning of the next end step, destroy all non-Wall creatures that player controls that didn't attack this turn. Ignore this effect for each creature the player didn't control continuously since the beginning of the turn. | SubAbility$ DestroyPacifist
 SVar:MustAttack:Mode$ MustAttack | AffectedZone$ Battlefield | ValidCreature$ Creature.ActivePlayerCtrl | Description$ Creatures the active player controls attack this turn if able.
-SVar:DestroyPacifist:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ TrigDestroy | TriggerDescription$ At the beginning of the next end step, destroy all non-Wall creatures that player controls that didn't attack this turn.
-SVar:TrigDestroy:DB$ DestroyAll | ValidCards$ Creature.ActivePlayerCtrl+!attackedThisTurn+nonWall+!firstTurnControlled | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DestroyPacifist:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ TrigDestroy | StackDescription$ None | TriggerDescription$ At the beginning of the next end step, destroy all non-Wall creatures that player controls that didn't attack this turn.
+SVar:TrigDestroy:DB$ DestroyAll | ValidCards$ Creature.ActivePlayerCtrl+!attackedThisTurn+nonWall+!firstTurnControlled
 AI:RemoveDeck:All
 AI:RemoveDeck:Random
 Oracle:Cast this spell only during an opponent's turn, before attackers are declared.\nCreatures the active player controls attack this turn if able.\nAt the beginning of the next end step, destroy all non-Wall creatures that player controls that didn't attack this turn. Ignore this effect for each creature the player didn't control continuously since the beginning of the turn.

--- a/forge-gui/res/cardsfolder/s/skullwinder.txt
+++ b/forge-gui/res/cardsfolder/s/skullwinder.txt
@@ -4,8 +4,8 @@ Types:Creature Snake
 PT:1/3
 K:Deathtouch
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChangeZone | TriggerDescription$ When CARDNAME enters, return target card from your graveyard to your hand, then choose an opponent. That player returns a card from their graveyard to their hand.
-SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Card.YouCtrl | SubAbility$ ChooseP
+SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Card.YouCtrl | TgtPrompt$ Select target card in your graveyard | SubAbility$ ChooseP
 SVar:ChooseP:DB$ ChoosePlayer | Defined$ You | Choices$ Player.Opponent | SubAbility$ DBChangeZone
-SVar:DBChangeZone:DB$ ChangeZone | Hidden$ True | Mandatory$ True | ChangeType$ Card.ChosenCtrl | Chooser$ ChosenPlayer | ChangeNum$ 1 | Origin$ Graveyard | Destination$ Hand | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBChangeZone:DB$ ChangeZone | Hidden$ True | Mandatory$ True | ChangeType$ Card.ChosenCtrl | SelectPrompt$ Select a card in your graveyard | Chooser$ ChosenPlayer | ChangeNum$ 1 | Origin$ Graveyard | Destination$ Hand | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearChosenPlayer$ True
 Oracle:Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhen Skullwinder enters, return target card from your graveyard to your hand, then choose an opponent. That player returns a card from their graveyard to their hand.

--- a/forge-gui/res/cardsfolder/s/sudden_salvation.txt
+++ b/forge-gui/res/cardsfolder/s/sudden_salvation.txt
@@ -1,7 +1,7 @@
 Name:Sudden Salvation
 ManaCost:2 W W
 Types:Instant
-A:SP$ ChangeZone | ValidTgts$ Permanent.ThisTurnEnteredFrom_Battlefield | TgtPrompt$ Select up to three target permanent cards in graveyards that were put there from the battlefield this turn | TargetMin$ 0 | TargetMax$ 3 | Origin$ Graveyard | Destination$ Battlefield | Tapped$ True | SubAbility$ DBDraw | SpellDescription$ Choose up to three target permanent cards in graveyards that were put there from the battlefield this turn. Return them to the battlefield tapped under their owners' control. You draw a card for each opponent who controls one or more of those permanents.
+A:SP$ ChangeZone | ValidTgts$ Permanent.ThisTurnEnteredFrom_Battlefield | TgtPrompt$ Select up to three target permanent cards in graveyards that were put there from the battlefield this turn | TargetMin$ 0 | TargetMax$ 3 | Origin$ Graveyard | Destination$ Battlefield | Tapped$ True | RememberChanged$ True | SubAbility$ DBDraw | SpellDescription$ Choose up to three target permanent cards in graveyards that were put there from the battlefield this turn. Return them to the battlefield tapped under their owners' control. You draw a card for each opponent who controls one or more of those permanents.
 SVar:DBDraw:DB$ Draw | NumCards$ X | Defined$ You | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:PlayerCountOpponents$HasPropertycontrolsPermanent.IsRemembered

--- a/forge-gui/res/cardsfolder/u/undercity_scavenger.txt
+++ b/forge-gui/res/cardsfolder/u/undercity_scavenger.txt
@@ -4,8 +4,7 @@ Types:Creature Ogre Warrior
 PT:3/3
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPutCounter | TriggerDescription$ When CARDNAME enters, you may sacrifice another creature. If you do, put two +1/+1 counters on CARDNAME, then scry 2.
 SVar:TrigPutCounter:AB$ PutCounter | Cost$ Sac<1/Creature.Other/another creature> | Defined$ Self | CounterType$ P1P1 | CounterNum$ 2 | SubAbility$ DBScry
-SVar:DBScry:DB$ Scry | ScryNum$ 2 | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:DBScry:DB$ Scry | ScryNum$ 2
 SVar:AIPreference:SacCost$Creature.token,Creature.cmcLE3
 DeckHas:Ability$Counters
 Oracle:When Undercity Scavenger enters, you may sacrifice another creature. If you do, put two +1/+1 counters on Undercity Scavenger, then scry 2.


### PR DESCRIPTION
Generally removing where a `ClearRemembered$` is unnecessary, but adjusting where needed as well. Also some incidental cleanup, namely [Martyr's Bond](https://scryfall.com/card/cmd/19/martyrs-bond) (joining split trigger conditions), [Siren's Call](https://scryfall.com/card/4ed/101/sirens-call), and [Skullwinder](https://scryfall.com/card/otc/207/skullwinder) (improving readability of both in several game UI subdivisions). 
On the latter, I'll note that the game engine confoundingly labels a prompt revealing a card in my hand with my AI opponent's name, when I'm affected by the second part of their Skullwinder's ETB.

<img width="1519" height="997" alt="skullwinder" src="https://github.com/user-attachments/assets/d8385b9b-b473-4079-8698-fc8b1dc29e7e" />
