### PR TITLE
Fix meld + Add advanced search for split types

### DIFF
--- a/forge-core/src/main/java/forge/card/CardRulesPredicates.java
+++ b/forge-core/src/main/java/forge/card/CardRulesPredicates.java
@@ -190,6 +190,13 @@ public final class CardRulesPredicates {
     }
 
     /**
+     * @return a Predicate that matches cards that are of the split type.
+     */
+    public static Predicate<CardRules> isSplitType(final CardSplitType type) {
+        return card -> card.getSplitType().equals(type);
+    }
+
+    /**
      * Checks for color.
      *
      * @param thatColor

--- a/forge-core/src/main/java/forge/util/ImageUtil.java
+++ b/forge-core/src/main/java/forge/util/ImageUtil.java
@@ -231,6 +231,7 @@ public class ImageUtil {
         }
         String versionParam = useArtCrop ? "art_crop" : "normal";
         String faceParam = "";
+
         if (cp.getRules().getSplitType() == CardSplitType.Meld) {
             if (face.equals("back")) {
                 PaperCard meldBasePc = cp.getMeldBaseCard();
@@ -239,16 +240,18 @@ public class ImageUtil {
 
                 if (cardCollectorNumber.endsWith("a")) {
                     cardCollectorNumber = cardCollectorNumber.substring(0, cardCollectorNumber.length() - 1);
-                    collectorNumberSuffix = "b";
                 } else if (cardCollectorNumber.endsWith("as")) {
                     cardCollectorNumber = cardCollectorNumber.substring(0, cardCollectorNumber.length() - 2);
-                    collectorNumberSuffix = "bs";
+                    collectorNumberSuffix = "s";
                 } else if (cardCollectorNumber.endsWith("ap")) {
                     cardCollectorNumber = cardCollectorNumber.substring(0, cardCollectorNumber.length() - 2);
-                    collectorNumberSuffix = "bp";
+                    collectorNumberSuffix = "p";
+                } else if (cp.getCollectorNumber().endsWith("a")) {
+                    // SIR
+                    cardCollectorNumber = cp.getCollectorNumber().substring(0, cp.getCollectorNumber().length() - 1);
                 }
 
-                cardCollectorNumber += collectorNumberSuffix;
+                cardCollectorNumber += "b" + collectorNumberSuffix;
             }
 
             faceParam = "&face=front";
@@ -256,18 +259,6 @@ public class ImageUtil {
             faceParam = (face.equals("back") && cp.getRules().getSplitType() != CardSplitType.Flip
                     ? "&face=back"
                     : "&face=front");
-        } else if (cp.getRules().getSplitType() == CardSplitType.Meld
-                    && !cardCollectorNumber.endsWith("a")
-                    && !cardCollectorNumber.endsWith("b")) {
-
-                // Only the bottom half of a meld card shares a collector number.
-                // Hanweir Garrison EMN already has a appended.
-                // Exception: The front facing card doesn't use a in FIN
-                if (face.equals("back")) {
-                    cardCollectorNumber += "b";
-                } else if (!editionCode.equals("fin")) {
-                    cardCollectorNumber += "a";
-                }
         }
 
         return String.format("%s/%s/%s?format=image&version=%s%s", editionCode, encodeUtf8(cardCollectorNumber),

--- a/forge-core/src/main/java/forge/util/ImageUtil.java
+++ b/forge-core/src/main/java/forge/util/ImageUtil.java
@@ -239,15 +239,16 @@ public class ImageUtil {
 
                 if (cardCollectorNumber.endsWith("a")) {
                     cardCollectorNumber = cardCollectorNumber.substring(0, cardCollectorNumber.length() - 1);
+                    collectorNumberSuffix = "b";
                 } else if (cardCollectorNumber.endsWith("as")) {
                     cardCollectorNumber = cardCollectorNumber.substring(0, cardCollectorNumber.length() - 2);
-                    collectorNumberSuffix = "s";
+                    collectorNumberSuffix = "bs";
                 } else if (cardCollectorNumber.endsWith("ap")) {
                     cardCollectorNumber = cardCollectorNumber.substring(0, cardCollectorNumber.length() - 2);
-                    collectorNumberSuffix = "p";
+                    collectorNumberSuffix = "bp";
                 }
 
-                cardCollectorNumber += "b" + collectorNumberSuffix;
+                cardCollectorNumber += collectorNumberSuffix;
             }
 
             faceParam = "&face=front";

--- a/forge-gui/res/editions/Shadows over Innistrad Remastered.txt
+++ b/forge-gui/res/editions/Shadows over Innistrad Remastered.txt
@@ -170,7 +170,7 @@ ScryfallCode=SIR
 158 C Gatstaf Arsonists @Greg Staples
 159 U Geier Reach Bandit @Slawomir Maniak
 160 M Goldnight Castigator @Zack Stella
-161 R Hanweir Garrison @Vincent Proce
+161a R Hanweir Garrison @Vincent Proce
 162 C Howlpack Wolf @Svetlin Velinov
 163 C Incendiary Flow @Raymond Swanland
 164 C Insatiable Gorgers @Nils Hamm

--- a/forge-gui/src/main/java/forge/itemmanager/AdvancedSearchParser.java
+++ b/forge-gui/src/main/java/forge/itemmanager/AdvancedSearchParser.java
@@ -329,6 +329,7 @@ public abstract class AdvancedSearchParser {
                     }
                 }
                 break;
+        }
 
         if (predicate == null) {
             return null;

--- a/forge-gui/src/main/java/forge/itemmanager/AdvancedSearchParser.java
+++ b/forge-gui/src/main/java/forge/itemmanager/AdvancedSearchParser.java
@@ -2,6 +2,7 @@ package forge.itemmanager;
 
 import forge.card.CardRules;
 import forge.card.CardRulesPredicates;
+import forge.card.CardSplitType;
 import forge.card.CardRulesPredicates.LeafNumber;
 import forge.card.MagicColor;
 import forge.item.PaperCard;
@@ -302,7 +303,32 @@ public abstract class AdvancedSearchParser {
                         break;
                 }
                 break;
-        }
+
+            case "is":
+                if (opUsed.equals(":")) {
+                    switch(valueStr) {
+                        case "meld":
+                            predicate = CardRulesPredicates.isSplitType(CardSplitType.Meld);
+                            break;
+                        
+                        case "flip":
+                            predicate = CardRulesPredicates.isSplitType(CardSplitType.Flip);
+                            break;
+
+                        case "split":
+                            predicate = CardRulesPredicates.isSplitType(CardSplitType.Split);
+                            break;
+
+                        case "modal":
+                            predicate = CardRulesPredicates.isSplitType(CardSplitType.Modal);
+                            break;
+
+                        case "transform":
+                            predicate = CardRulesPredicates.isSplitType(CardSplitType.Transform);
+                            break;
+                    }
+                }
+                break;
 
         if (predicate == null) {
             return null;


### PR DESCRIPTION
* Meld image fetching should be fixed. Tested with FIN, SIR, EMN and BRO.
* Added advanced search for split cards. (`is:meld`, `is:flip`, etc.)