### PR TITLE
Tidying trigger-granting Slivers

### DIFF
--- a/forge-gui/res/cardsfolder/c/constricting_sliver.txt
+++ b/forge-gui/res/cardsfolder/c/constricting_sliver.txt
@@ -2,8 +2,8 @@ Name:Constricting Sliver
 ManaCost:5 W
 Types:Creature Sliver
 PT:3/3
-S:Mode$ Continuous | Affected$ Creature.Sliver+YouCtrl | AddTrigger$ ConstrictingTrig | AddSVar$ ConstrictingSliverExile | Description$ Sliver creatures you control have "When this creature enters, you may exile target creature an opponent controls until this creature leaves the battlefield."
-SVar:ConstrictingTrig:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | OptionalDecider$ You | ValidCard$ Card.Self | Execute$ ConstrictingSliverExile | TriggerDescription$ When CARDNAME enters, you may exile target creature an opponent controls until CARDNAME leaves the battlefield.
-SVar:ConstrictingSliverExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | ConditionPresent$ Card.Self | Duration$ UntilHostLeavesPlay
+S:Mode$ Continuous | Affected$ Creature.Sliver+YouCtrl | AddTrigger$ ConstrictingTrig | Description$ Sliver creatures you control have "When this creature enters, you may exile target creature an opponent controls until this creature leaves the battlefield."
+SVar:ConstrictingTrig:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | OptionalDecider$ You | ValidCard$ Card.Self | Execute$ ConstrictingExile | TriggerDescription$ When CARDNAME enters, you may exile target creature an opponent controls until CARDNAME leaves the battlefield.
+SVar:ConstrictingExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | ConditionPresent$ Card.Self | Duration$ UntilHostLeavesPlay
 SVar:PlayMain1:TRUE
 Oracle:Sliver creatures you control have "When this creature enters, you may exile target creature an opponent controls until this creature leaves the battlefield."

--- a/forge-gui/res/cardsfolder/d/dementia_sliver.txt
+++ b/forge-gui/res/cardsfolder/d/dementia_sliver.txt
@@ -2,7 +2,7 @@ Name:Dementia Sliver
 ManaCost:3 U B
 Types:Creature Sliver
 PT:3/3
-S:Mode$ Continuous | Affected$ Sliver | AddAbility$ ABDementiaNameCard | AddSVar$ DBDementiaReveal & DBDementiaDiscard | Description$ All Slivers have "{T}: Choose a card name. Target opponent reveals a card at random from their hand. If that card has the chosen name, that player discards it. Activate only during your turn."
+S:Mode$ Continuous | Affected$ Sliver | AddAbility$ ABDementiaNameCard | Description$ All Slivers have "{T}: Choose a card name. Target opponent reveals a card at random from their hand. If that card has the chosen name, that player discards it. Activate only during your turn."
 SVar:ABDementiaNameCard:AB$ NameCard | Cost$ T | Defined$ You | SubAbility$ DBDementiaReveal | SpellDescription$ Choose a card name. Target opponent reveals a card at random from their hand. If that card has the chosen name, that player discards it. Activate only during your turn.
 SVar:DBDementiaReveal:DB$ Reveal | ValidTgts$ Opponent | TgtPrompt$ Select target opponent | Random$ True | PlayerTurn$ True | RememberRevealed$ True | SubAbility$ DBDementiaDiscard
 SVar:DBDementiaDiscard:DB$ Discard | DiscardValid$ Card.NamedCard+IsRemembered | Mode$ TgtChoose | Defined$ Targeted | SubAbility$ DBCleanup

--- a/forge-gui/res/cardsfolder/f/frenetic_sliver.txt
+++ b/forge-gui/res/cardsfolder/f/frenetic_sliver.txt
@@ -2,8 +2,8 @@ Name:Frenetic Sliver
 ManaCost:1 U R
 Types:Creature Sliver
 PT:2/2
-S:Mode$ Continuous | Affected$ Sliver | AddAbility$ Frenetic | AddSVar$ DBExile & DelTrig & MoveBack & DBSacSelf | Description$ All Slivers have "{0}: If this permanent is on the battlefield, flip a coin. If you win the flip, exile this permanent and return it to the battlefield under its owner's control at the beginning of the next end step. If you lose the flip, sacrifice it."
-SVar:Frenetic:AB$ FlipACoin | Cost$ 0 | ConditionPresent$ Card.Self | ConditionCompare$ EQ1 | WinSubAbility$ DBExile | LoseSubAbility$ DBSacSelf | SpellDescription$ If this permanent is on the battlefield, flip a coin. If you win the flip, exile this permanent and return it to the battlefield under its owner's control at the beginning of the next end step. If you lose the flip, sacrifice it.
+S:Mode$ Continuous | Affected$ Sliver | AddAbility$ ABFrenetic | Description$ All Slivers have "{0}: If this permanent is on the battlefield, flip a coin. If you win the flip, exile this permanent and return it to the battlefield under its owner's control at the beginning of the next end step. If you lose the flip, sacrifice it."
+SVar:ABFrenetic:AB$ FlipACoin | Cost$ 0 | ConditionPresent$ Card.Self | ConditionCompare$ EQ1 | WinSubAbility$ DBExile | LoseSubAbility$ DBSacSelf | SpellDescription$ If this permanent is on the battlefield, flip a coin. If you win the flip, exile this permanent and return it to the battlefield under its owner's control at the beginning of the next end step. If you lose the flip, sacrifice it.
 SVar:DBExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | Defined$ Self | RememberChanged$ True | SubAbility$ DelTrig
 SVar:DelTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ MoveBack | RememberObjects$ RememberedLKI | SubAbility$ DBCleanup | TriggerDescription$ Return CARDNAME to the battlefield under its owner's control at the beginning of the next end step.
 SVar:MoveBack:DB$ ChangeZone | Origin$ Exile | Destination$ Battlefield | Defined$ DelayTriggerRememberedLKI

--- a/forge-gui/res/cardsfolder/f/frenzy_sliver.txt
+++ b/forge-gui/res/cardsfolder/f/frenzy_sliver.txt
@@ -2,8 +2,8 @@ Name:Frenzy Sliver
 ManaCost:1 B
 Types:Creature Sliver
 PT:1/1
-S:Mode$ Continuous | Affected$ Creature.Sliver | AddTrigger$ TrigFrenzy | AddSVar$ FrenzyPump | Description$ All Sliver creatures have frenzy 1. (Whenever a Sliver attacks and isn't blocked, it gets +1/+0 until end of turn.)
-SVar:TrigFrenzy:Mode$ AttackerUnblocked | ValidCard$ Card.Self | Execute$ FrenzyPump | TriggerZones$ Battlefield | TriggerDescription$ Frenzy 1 (Whenever CARDNAME attacks and isn't blocked, it gets +1/+0 until end of turn.)
+S:Mode$ Continuous | Affected$ Creature.Sliver | AddTrigger$ FrenzyTrig | Description$ All Sliver creatures have frenzy 1. (Whenever a Sliver attacks and isn't blocked, it gets +1/+0 until end of turn.)
+SVar:FrenzyTrig:Mode$ AttackerUnblocked | ValidCard$ Card.Self | Execute$ FrenzyPump | TriggerZones$ Battlefield | TriggerDescription$ Frenzy 1 (Whenever CARDNAME attacks and isn't blocked, it gets +1/+0 until end of turn.)
 SVar:FrenzyPump:DB$ Pump | NumAtt$ +1 | Defined$ TriggeredAttacker
 SVar:PlayMain1:TRUE
 Oracle:All Sliver creatures have frenzy 1. (Whenever a Sliver attacks and isn't blocked, it gets +1/+0 until end of turn.)

--- a/forge-gui/res/cardsfolder/f/fungus_sliver.txt
+++ b/forge-gui/res/cardsfolder/f/fungus_sliver.txt
@@ -2,9 +2,9 @@ Name:Fungus Sliver
 ManaCost:3 G
 Types:Creature Fungus Sliver
 PT:2/2
-S:Mode$ Continuous | Affected$ Creature.Sliver | AddTrigger$ OnDmg | AddSVar$ FungusSliverCounters | Description$ All Sliver creatures have "Whenever this creature is dealt damage, put a +1/+1 counter on it." (It must survive the damage to get the counter.)
-SVar:OnDmg:Mode$ DamageDoneOnce | ValidTarget$ Card.Self | Execute$ FungusSliverCounters | TriggerDescription$ Whenever CARDNAME is dealt damage, put a +1/+1 counter on it.
-SVar:FungusSliverCounters:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
+S:Mode$ Continuous | Affected$ Creature.Sliver | AddTrigger$ FungusDmgTrig | Description$ All Sliver creatures have "Whenever this creature is dealt damage, put a +1/+1 counter on it." (It must survive the damage to get the counter.)
+SVar:FungusDmgTrig:Mode$ DamageDoneOnce | ValidTarget$ Card.Self | Execute$ FungusCounters | TriggerDescription$ Whenever CARDNAME is dealt damage, put a +1/+1 counter on it.
+SVar:FungusCounters:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
 SVar:PlayMain1:TRUE
 SVar:HasCombatEffect:TRUE
 Oracle:All Sliver creatures have "Whenever this creature is dealt damage, put a +1/+1 counter on it." (It must survive the damage to get the counter.)

--- a/forge-gui/res/cardsfolder/h/harmonic_sliver.txt
+++ b/forge-gui/res/cardsfolder/h/harmonic_sliver.txt
@@ -2,7 +2,7 @@ Name:Harmonic Sliver
 ManaCost:1 G W
 Types:Creature Sliver
 PT:1/1
-S:Mode$ Continuous | Affected$ Sliver | AddTrigger$ HarmonicETB | AddSVar$ HarmonicDestroy | Description$ All Slivers have "When this permanent enters, destroy target artifact or enchantment."
+S:Mode$ Continuous | Affected$ Sliver | AddTrigger$ HarmonicETB | Description$ All Slivers have "When this permanent enters, destroy target artifact or enchantment."
 SVar:HarmonicETB:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ HarmonicDestroy | TriggerDescription$ When this permanent enters, destroy target artifact or enchantment.
 SVar:HarmonicDestroy:DB$ Destroy | ValidTgts$ Artifact,Enchantment | TgtPrompt$ Select target artifact or enchantment.
 SVar:BuffedBy:Sliver

--- a/forge-gui/res/cardsfolder/h/harmonic_sliver.txt
+++ b/forge-gui/res/cardsfolder/h/harmonic_sliver.txt
@@ -2,9 +2,8 @@ Name:Harmonic Sliver
 ManaCost:1 G W
 Types:Creature Sliver
 PT:1/1
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Sliver.Self | TriggerZones$ Battlefield | Execute$ HarmonicDestroy | TriggerDescription$ When this permanent enters, destroy target artifact or enchantment.
-S:Mode$ Continuous | Affected$ Sliver.Other | EffectZone$ Battlefield | AffectedZone$ All | AddTrigger$ HarmonicETB | AddSVar$ HarmonicDestroy | Description$ All Slivers have "When this permanent enters, destroy target artifact or enchantment."
-SVar:HarmonicETB:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Sliver.Self | TriggerZones$ Battlefield | Execute$ HarmonicDestroy | TriggerDescription$ When this permanent enters, destroy target artifact or enchantment.
+S:Mode$ Continuous | Affected$ Sliver | AddTrigger$ HarmonicETB | AddSVar$ HarmonicDestroy | Description$ All Slivers have "When this permanent enters, destroy target artifact or enchantment."
+SVar:HarmonicETB:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ HarmonicDestroy | TriggerDescription$ When this permanent enters, destroy target artifact or enchantment.
 SVar:HarmonicDestroy:DB$ Destroy | ValidTgts$ Artifact,Enchantment | TgtPrompt$ Select target artifact or enchantment.
 SVar:BuffedBy:Sliver
 Oracle:All Slivers have "When this permanent enters, destroy target artifact or enchantment."

--- a/forge-gui/res/cardsfolder/l/lavabelly_sliver.txt
+++ b/forge-gui/res/cardsfolder/l/lavabelly_sliver.txt
@@ -2,9 +2,9 @@ Name:Lavabelly Sliver
 ManaCost:1 R W
 Types:Creature Sliver
 PT:2/2
-S:Mode$ Continuous | Affected$ Creature.Sliver+YouCtrl | AddTrigger$ ChangesZone | AddSVar$ LavabellyTrigDamage & LavabellyGainLife | Description$ Sliver creatures you control have "When this creature enters, it deals 1 damage to target player or planeswalker and you gain 1 life."
-SVar:ChangesZone:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ LavabellyTrigDamage | TriggerDescription$ When this creature enters, it deals 1 damage to target player or planeswalker and you gain 1 life.
-SVar:LavabellyTrigDamage:DB$ DealDamage | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker to damage | NumDmg$ 1 | SubAbility$ LavabellyGainLife
+S:Mode$ Continuous | Affected$ Creature.Sliver+YouCtrl | AddTrigger$ LavabellyETB | Description$ Sliver creatures you control have "When this creature enters, it deals 1 damage to target player or planeswalker and you gain 1 life."
+SVar:LavabellyETB:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ LavabellyTrigDmg | TriggerDescription$ When this creature enters, it deals 1 damage to target player or planeswalker and you gain 1 life.
+SVar:LavabellyTrigDmg:DB$ DealDamage | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker to damage | NumDmg$ 1 | SubAbility$ LavabellyGainLife
 SVar:LavabellyGainLife:DB$ GainLife | LifeAmount$ 1 | Defined$ You
 DeckHas:Ability$LifeGain
 Oracle:Sliver creatures you control have "When this creature enters, it deals 1 damage to target player or planeswalker and you gain 1 life."

--- a/forge-gui/res/cardsfolder/m/magma_sliver.txt
+++ b/forge-gui/res/cardsfolder/m/magma_sliver.txt
@@ -2,8 +2,8 @@ Name:Magma Sliver
 ManaCost:3 R
 Types:Creature Sliver
 PT:3/3
-S:Mode$ Continuous | Affected$ Sliver | AddAbility$ Pump | AddSVar$ SliversOnFieldX | Description$ All Slivers have "{T}: Target Sliver creature gets +X/+0 until end of turn, where X is the number of Slivers on the battlefield."
-SVar:Pump:AB$ Pump | Cost$ T | ValidTgts$ Creature.Sliver | TgtPrompt$ Select target Sliver creature | NumAtt$ +SliversOnFieldX | SpellDescription$ Target Sliver creature gets +X/+0 until end of turn, where X is the number of Slivers on the battlefield.
+S:Mode$ Continuous | Affected$ Sliver | AddAbility$ ABMagma | Description$ All Slivers have "{T}: Target Sliver creature gets +X/+0 until end of turn, where X is the number of Slivers on the battlefield."
+SVar:ABMagma:AB$ Pump | Cost$ T | ValidTgts$ Creature.Sliver | TgtPrompt$ Select target Sliver creature | NumAtt$ +SliversOnFieldX | SpellDescription$ Target Sliver creature gets +X/+0 until end of turn, where X is the number of Slivers on the battlefield.
 SVar:SliversOnFieldX:Count$Valid Sliver
 SVar:PlayMain1:TRUE
 SVar:BuffedBy:Sliver

--- a/forge-gui/res/cardsfolder/m/mesmeric_sliver.txt
+++ b/forge-gui/res/cardsfolder/m/mesmeric_sliver.txt
@@ -2,9 +2,9 @@ Name:Mesmeric Sliver
 ManaCost:3 U
 Types:Creature Sliver
 PT:2/2
-S:Mode$ Continuous | Affected$ Sliver | EffectZone$ Battlefield | AddTrigger$ MesmericETB | AddSVar$ MesmFateseal & DBDig & DBCleanupChosen | Description$ All Slivers have "When this permanent enters, you may fateseal 1." (To fateseal 1, its controller looks at the top card of an opponent's library, then they may put that card on the bottom of that library.)
-SVar:MesmericETB:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ MesmFateseal | TriggerDescription$ When CARDNAME enters, you may fateseal 1.
-SVar:MesmFateseal:DB$ ChoosePlayer | Defined$ You | Choices$ Player.Opponent | AILogic$ Curse | SubAbility$ DBDig
+S:Mode$ Continuous | Affected$ Sliver | EffectZone$ Battlefield | AddTrigger$ MesmericETB | Description$ All Slivers have "When this permanent enters, you may fateseal 1." (To fateseal 1, its controller looks at the top card of an opponent's library, then they may put that card on the bottom of that library.)
+SVar:MesmericETB:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | TriggerZones$ Battlefield | OptionalDecider$ You | Execute$ MesmericFateseal | TriggerDescription$ When CARDNAME enters, you may fateseal 1.
+SVar:MesmericFateseal:DB$ ChoosePlayer | Defined$ You | Choices$ Player.Opponent | AILogic$ Curse | SubAbility$ DBDig
 SVar:DBDig:DB$ Dig | Defined$ ChosenPlayer | DigNum$ 1 | AnyNumber$ True | DestinationZone$ Library | LibraryPosition$ -1 | LibraryPosition2$ 0 | SubAbility$ DBCleanupChosen
 SVar:DBCleanupChosen:DB$ Cleanup | ClearChosenPlayer$ True
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/m/mistform_sliver.txt
+++ b/forge-gui/res/cardsfolder/m/mistform_sliver.txt
@@ -2,8 +2,8 @@ Name:Mistform Sliver
 ManaCost:1 U
 Types:Creature Illusion Sliver
 PT:1/1
-S:Mode$ Continuous | Affected$ Sliver | AddAbility$ ABChooseType | AddSVar$ DBAnimate | Description$ All Slivers have "{1}: This permanent becomes the creature type of your choice in addition to its other types until end of turn."
-SVar:ABChooseType:AB$ ChooseType | Cost$ 1 | Type$ Creature | SubAbility$ DBAnimate | SpellDescription$ This permanent becomes the creature type of your choice in addition to its other types until end of turn.
+S:Mode$ Continuous | Affected$ Sliver | AddAbility$ ABMistformCT | Description$ All Slivers have "{1}: This permanent becomes the creature type of your choice in addition to its other types until end of turn."
+SVar:ABMistformCT:AB$ ChooseType | Cost$ 1 | Type$ Creature | SubAbility$ DBAnimate | SpellDescription$ This permanent becomes the creature type of your choice in addition to its other types until end of turn.
 SVar:DBAnimate:DB$ Animate | Types$ ChosenType
 AI:RemoveDeck:All
 Oracle:All Slivers have "{1}: This permanent becomes the creature type of your choice in addition to its other types until end of turn."

--- a/forge-gui/res/cardsfolder/o/opaline_sliver.txt
+++ b/forge-gui/res/cardsfolder/o/opaline_sliver.txt
@@ -2,8 +2,8 @@ Name:Opaline Sliver
 ManaCost:1 W U
 Types:Creature Sliver
 PT:2/2
-S:Mode$ Continuous | Affected$ Sliver | AddTrigger$ TrigTargetSpell | AddSVar$ OpalineTrigDraw | Description$ All Slivers have "Whenever this permanent becomes the target of a spell an opponent controls, you may draw a card."
-SVar:TrigTargetSpell:Mode$ BecomesTarget | ValidTarget$ Card.Self | ValidSource$ Spell.OppCtrl | Execute$ OpalineTrigDraw | OptionalDecider$ You | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME becomes the target of a spell an opponent controls, you may draw a card.
+S:Mode$ Continuous | Affected$ Sliver | AddTrigger$ OpalineTgtTrig | Description$ All Slivers have "Whenever this permanent becomes the target of a spell an opponent controls, you may draw a card."
+SVar:OpalineTgtTrig:Mode$ BecomesTarget | ValidTarget$ Card.Self | ValidSource$ Spell.OppCtrl | Execute$ OpalineTrigDraw | OptionalDecider$ You | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME becomes the target of a spell an opponent controls, you may draw a card.
 SVar:OpalineTrigDraw:DB$ Draw | NumCards$ 1 | Defined$ You
 SVar:PlayMain1:TRUE
 Oracle:All Slivers have "Whenever this permanent becomes the target of a spell an opponent controls, you may draw a card."

--- a/forge-gui/res/cardsfolder/p/plague_sliver.txt
+++ b/forge-gui/res/cardsfolder/p/plague_sliver.txt
@@ -2,7 +2,7 @@ Name:Plague Sliver
 ManaCost:2 B B
 Types:Creature Sliver
 PT:5/5
-S:Mode$ Continuous | Affected$ Sliver | AddTrigger$ TrigPhase | AddSVar$ PlagueTrigDamage | Description$ All Slivers have "At the beginning of your upkeep, this permanent deals 1 damage to you."
-SVar:TrigPhase:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ PlagueTrigDamage | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, CARDNAME deals 1 damage to you.
-SVar:PlagueTrigDamage:DB$ DealDamage | NumDmg$ 1 | Defined$ You
+S:Mode$ Continuous | Affected$ Sliver | AddTrigger$ PlaguePhaseTrig | Description$ All Slivers have "At the beginning of your upkeep, this permanent deals 1 damage to you."
+SVar:PlaguePhaseTrig:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ PlagueTrigDmg | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, CARDNAME deals 1 damage to you.
+SVar:PlagueTrigDmg:DB$ DealDamage | NumDmg$ 1 | Defined$ You
 Oracle:All Slivers have "At the beginning of your upkeep, this permanent deals 1 damage to you."

--- a/forge-gui/res/cardsfolder/p/psionic_sliver.txt
+++ b/forge-gui/res/cardsfolder/p/psionic_sliver.txt
@@ -2,7 +2,7 @@ Name:Psionic Sliver
 ManaCost:4 U
 Types:Creature Sliver
 PT:2/2
-S:Mode$ Continuous | Affected$ Sliver | AddAbility$ DamageOther | AddSVar$ DBDamageSelf | Description$ All Sliver creatures have "{T}: This creature deals 2 damage to any target and 3 damage to itself."
-SVar:DamageOther:AB$ DealDamage | Cost$ T | ValidTgts$ Any | NumDmg$ 2 | SubAbility$ DBDamageSelf | SpellDescription$ This creature deals 2 damage to any target and 3 damage to itself.
+S:Mode$ Continuous | Affected$ Sliver | AddAbility$ ABDamageOther | Description$ All Sliver creatures have "{T}: This creature deals 2 damage to any target and 3 damage to itself."
+SVar:ABDamageOther:AB$ DealDamage | Cost$ T | ValidTgts$ Any | NumDmg$ 2 | SubAbility$ DBDamageSelf | SpellDescription$ This creature deals 2 damage to any target and 3 damage to itself.
 SVar:DBDamageSelf:DB$ DealDamage | NumDmg$ 3 | Defined$ Self
 Oracle:All Sliver creatures have "{T}: This creature deals 2 damage to any target and 3 damage to itself."

--- a/forge-gui/res/cardsfolder/p/pulmonic_sliver.txt
+++ b/forge-gui/res/cardsfolder/p/pulmonic_sliver.txt
@@ -3,8 +3,8 @@ ManaCost:3 W W
 Types:Creature Sliver
 PT:3/3
 S:Mode$ Continuous | Affected$ Creature.Sliver | AddKeyword$ Flying | Description$ All Sliver creatures have flying.
-S:Mode$ Continuous | Affected$ Card.Sliver | AddReplacementEffect$ PulmonicMoveToLibrary | AddSVar$ PulmonicSliverRep | Description$ All Slivers have "If this permanent would be put into a graveyard, you may put it on top of its owner's library instead."
-SVar:PulmonicMoveToLibrary:Event$ Moved | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | ReplaceWith$ PulmonicSliverRep | Optional$ True | Description$ If CARDNAME would die, you may put it on the top of its owner's library instead.
-SVar:PulmonicSliverRep:DB$ ChangeZone | Hidden$ True | Origin$ All | Destination$ Library | LibraryPosition$ 0 | Defined$ ReplacedCard
+S:Mode$ Continuous | Affected$ Card.Sliver | AddReplacementEffect$ PulmonicMoveToLibrary | Description$ All Slivers have "If this permanent would be put into a graveyard, you may put it on top of its owner's library instead."
+SVar:PulmonicMoveToLibrary:Event$ Moved | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | ReplaceWith$ PulmonicRep | Optional$ True | Description$ If CARDNAME would die, you may put it on the top of its owner's library instead.
+SVar:PulmonicRep:DB$ ChangeZone | Hidden$ True | Origin$ All | Destination$ Library | LibraryPosition$ 0 | Defined$ ReplacedCard
 SVar:PlayMain1:TRUE
 Oracle:All Sliver creatures have flying.\nAll Slivers have "If this permanent would be put into a graveyard, you may put it on top of its owner's library instead."

--- a/forge-gui/res/cardsfolder/r/regal_sliver.txt
+++ b/forge-gui/res/cardsfolder/r/regal_sliver.txt
@@ -3,7 +3,7 @@ ManaCost:3 W
 Types:Creature Sliver
 PT:3/3
 S:Mode$ Continuous | Affected$ Creature.Sliver+YouCtrl | AddTrigger$ ETBTrig | Description$ Sliver creatures you control have "When this creature enters, Slivers you control get +1/+1 until end of turn if you're the monarch. Otherwise, you become the monarch."
-SVar:ETBTrig:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Sliver.Self | TriggerZones$ Battlefield | Execute$ TrigPumpAll | TriggerDescription$ When this creature enters, Slivers you control get +1/+1 until end of turn if you're the monarch. Otherwise, you become the monarch.
+SVar:ETBTrig:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPumpAll | TriggerDescription$ When this creature enters, Slivers you control get +1/+1 until end of turn if you're the monarch. Otherwise, you become the monarch.
 SVar:TrigPumpAll:DB$ PumpAll | ValidCards$ Sliver.YouCtrl | NumAtt$ +1 | NumDef$ +1 | ConditionCheckSVar$ X | ConditionSVarCompare$ EQ1 | SubAbility$ DBMonarch
 SVar:DBMonarch:DB$ BecomeMonarch | Defined$ You | ConditionCheckSVar$ X | ConditionSVarCompare$ EQ0
 SVar:X:Count$Monarch.1.0

--- a/forge-gui/res/cardsfolder/s/sliv_mizzet_hivemind.txt
+++ b/forge-gui/res/cardsfolder/s/sliv_mizzet_hivemind.txt
@@ -2,7 +2,7 @@ Name:Sliv-Mizzet, Hivemind
 ManaCost:2 U U R R
 Types:Legendary Creature Dragon Sliver
 PT:4/4
-S:Mode$ Continuous | Affected$ Permanent.Sliver+YouCtrl | AddKeyword$ Flying | AddTrigger$ PingTrig | AddSVar$ TrigDealDamage | AddAbility$ Draw | Description$ Slivers you control have flying and "Whenever you draw a card, this creature deals 1 damage to any target" and "{T}: Draw a card."
+S:Mode$ Continuous | Affected$ Permanent.Sliver+YouCtrl | AddKeyword$ Flying | AddTrigger$ PingTrig | AddAbility$ Draw | Description$ Slivers you control have flying and "Whenever you draw a card, this creature deals 1 damage to any target" and "{T}: Draw a card."
 SVar:PingTrig:Mode$ Drawn | ValidCard$ Card.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigDealDamage | TriggerDescription$ Whenever you draw a card, CARDNAME deals 1 damage to any target.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Any | NumDmg$ 1
 SVar:Draw:AB$ Draw | Cost$ T | Defined$ You | NumCards$ 1 | SpellDescription$ Draw a card.

--- a/forge-gui/res/cardsfolder/s/spiteful_sliver.txt
+++ b/forge-gui/res/cardsfolder/s/spiteful_sliver.txt
@@ -2,8 +2,8 @@ Name:Spiteful Sliver
 ManaCost:2 R
 Types:Creature Sliver
 PT:2/2
-S:Mode$ Continuous | Affected$ Creature.Sliver+YouCtrl | AddTrigger$ SpitefulSliverTrigger | AddSVar$ SpitefulSliverDamage & SpitefulSliverX | Description$ Sliver creatures you control have "Whenever this creature is dealt damage, it deals that much damage to target player or planeswalker."
-SVar:SpitefulSliverTrigger:Mode$ DamageDoneOnce | Execute$ SpitefulSliverDamage | ValidTarget$ Card.Self | TriggerZones$ Battlefield | TriggerDescription$ Whenever this creature is dealt damage, it deals that much damage to target player or planeswalker.
-SVar:SpitefulSliverDamage:DB$ DealDamage | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | NumDmg$ SpitefulSliverX
-SVar:SpitefulSliverX:TriggerCount$DamageAmount
+S:Mode$ Continuous | Affected$ Creature.Sliver+YouCtrl | AddTrigger$ SpitefulTrig | Description$ Sliver creatures you control have "Whenever this creature is dealt damage, it deals that much damage to target player or planeswalker."
+SVar:SpitefulTrig:Mode$ DamageDoneOnce | Execute$ SpitefulDmg | ValidTarget$ Card.Self | TriggerZones$ Battlefield | TriggerDescription$ Whenever this creature is dealt damage, it deals that much damage to target player or planeswalker.
+SVar:SpitefulDmg:DB$ DealDamage | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | NumDmg$ SpitefulX
+SVar:SpitefulX:TriggerCount$DamageAmount
 Oracle:Sliver creatures you control have "Whenever this creature is dealt damage, it deals that much damage to target player or planeswalker."

--- a/forge-gui/res/cardsfolder/t/taunting_sliver.txt
+++ b/forge-gui/res/cardsfolder/t/taunting_sliver.txt
@@ -3,7 +3,7 @@ ManaCost:3 U
 Types:Creature Sliver
 PT:3/3
 S:Mode$ Continuous | Affected$ Creature.Sliver+YouCtrl | AddTrigger$ ETBTrig | Description$ Sliver creatures you control have "When this creature enters, goad target creature an opponent controls." (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)
-SVar:ETBTrig:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Sliver.Self | TriggerZones$ Battlefield | Execute$ TrigGoad | TriggerDescription$ When this creature enters, goad target creature an opponent controls. (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)
+SVar:ETBTrig:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigGoad | TriggerDescription$ When this creature enters, goad target creature an opponent controls. (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)
 SVar:TrigGoad:DB$ Goad | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Target creature an opponent controls
 SVar:PlayMain1:TRUE
 SVar:BuffedBy:Sliver

--- a/forge-gui/res/cardsfolder/t/tempered_sliver.txt
+++ b/forge-gui/res/cardsfolder/t/tempered_sliver.txt
@@ -2,9 +2,9 @@ Name:Tempered Sliver
 ManaCost:2 G
 Types:Creature Sliver
 PT:2/2
-S:Mode$ Continuous | Affected$ Creature.Sliver+YouCtrl | AddTrigger$ DamageDone | AddSVar$ TemperedSliverPutCounter | Description$ Sliver creatures you control have "Whenever this creature deals combat damage to a player, put a +1/+1 counter on it."
-SVar:DamageDone:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TemperedSliverPutCounter | TriggerZones$ Battlefield | TriggerDescription$ Whenever this creature deals combat damage to a player, put a +1/+1 counter on it.
-SVar:TemperedSliverPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
+S:Mode$ Continuous | Affected$ Creature.Sliver+YouCtrl | AddTrigger$ TemperedDmgTrig | Description$ Sliver creatures you control have "Whenever this creature deals combat damage to a player, put a +1/+1 counter on it."
+SVar:TemperedDmgTrig:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TemperedCounters | TriggerZones$ Battlefield | TriggerDescription$ Whenever this creature deals combat damage to a player, put a +1/+1 counter on it.
+SVar:TemperedCounters:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
 SVar:PlayMain1:TRUE
 SVar:BuffedBy:Sliver
 DeckHas:Ability$Counters

--- a/forge-gui/res/cardsfolder/t/thorncaster_sliver.txt
+++ b/forge-gui/res/cardsfolder/t/thorncaster_sliver.txt
@@ -2,8 +2,8 @@ Name:Thorncaster Sliver
 ManaCost:4 R
 Types:Creature Sliver
 PT:2/2
-S:Mode$ Continuous | Affected$ Creature.Sliver+YouCtrl | AddTrigger$ SliverThornAttack | AddSVar$ ThorncasterSliverDamage & HasAttackEffect | Description$ Sliver creatures you control have "Whenever this creature attacks, it deals 1 damage to any target."
-SVar:SliverThornAttack:Mode$ Attacks | ValidCard$ Card.Self | Execute$ ThorncasterSliverDamage | TriggerDescription$ Whenever this creature attacks, it deals 1 damage to any target.
-SVar:ThorncasterSliverDamage:DB$ DealDamage | ValidTgts$ Any | TgtPrompt$ Select any target to damage | NumDmg$ 1
-SVar:HasAttackEffect:TRUE
+S:Mode$ Continuous | Affected$ Creature.Sliver+YouCtrl | AddTrigger$ ThorncasterAttackTrig | AddSVar$ AE | Description$ Sliver creatures you control have "Whenever this creature attacks, it deals 1 damage to any target."
+SVar:ThorncasterAttackTrig:Mode$ Attacks | ValidCard$ Card.Self | Execute$ ThorncasterDmg | TriggerDescription$ Whenever this creature attacks, it deals 1 damage to any target.
+SVar:ThorncasterDmg:DB$ DealDamage | ValidTgts$ Any | TgtPrompt$ Select any target to damage | NumDmg$ 1
+SVar:AE:SVar:HasAttackEffect:TRUE
 Oracle:Sliver creatures you control have "Whenever this creature attacks, it deals 1 damage to any target."

--- a/forge-gui/res/cardsfolder/v/vampiric_sliver.txt
+++ b/forge-gui/res/cardsfolder/v/vampiric_sliver.txt
@@ -2,8 +2,8 @@ Name:Vampiric Sliver
 ManaCost:3 B
 Types:Creature Sliver
 PT:3/3
-S:Mode$ Continuous | Affected$ Creature.Sliver | AddTrigger$ VampiricSliverTrig | AddSVar$ VampiricSliverCounters | Description$ All Sliver creatures have "Whenever a creature dealt damage by this creature this turn dies, put a +1/+1 counter on this creature."
-SVar:VampiricSliverTrig:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.DamagedBy | TriggerZones$ Battlefield | Execute$ VampiricSliverCounters | TriggerDescription$ Whenever a creature dealt damage by CARDNAME this turn dies, put a +1/+1 counter on CARDNAME.
-SVar:VampiricSliverCounters:DB$ PutCounter | Defined$ Self | CounterNum$ 1 | CounterType$ P1P1
+S:Mode$ Continuous | Affected$ Creature.Sliver | AddTrigger$ VampiricTrig | Description$ All Sliver creatures have "Whenever a creature dealt damage by this creature this turn dies, put a +1/+1 counter on this creature."
+SVar:VampiricTrig:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.DamagedBy | TriggerZones$ Battlefield | Execute$ VampiricCounters | TriggerDescription$ Whenever a creature dealt damage by CARDNAME this turn dies, put a +1/+1 counter on CARDNAME.
+SVar:VampiricCounters:DB$ PutCounter | Defined$ Self | CounterNum$ 1 | CounterType$ P1P1
 SVar:PlayMain1:TRUE
 Oracle:All Sliver creatures have "Whenever a creature dealt damage by this creature this turn dies, put a +1/+1 counter on this creature."


### PR DESCRIPTION
I came across [Harmonic Sliver](https://github.com/Card-Forge/forge/blob/master/forge-gui/res/cardsfolder/h/harmonic_sliver.txt) with a trigger condition for itself and another for the other Slivers, something that I interpret as a remainder from an earlier state of the game engine. Tidied it according to [Constricting Sliver](https://github.com/Card-Forge/forge/blob/master/forge-gui/res/cardsfolder/c/constricting_sliver.txt), tested the new script version and it works as expected. 
Also, took the opportunity to standardize the `Sliver.Self` flourish in this and other cards.

As requested, removed `AddSVar$` from other trigger and ability-granting Silvers where it was found to be redundant. Salient cards were tested to confirm this removal didn't affect their function.