### PR TITLE
Update darigaaz_shivan_champion.txt

### DIFF
--- a/forge-gui/res/cardsfolder/d/darigaaz_shivan_champion.txt
+++ b/forge-gui/res/cardsfolder/d/darigaaz_shivan_champion.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature Dragon
 PT:5/5
 K:Flying
 T:Mode$ Phase | Phase$ End of Turn | Execute$ TrigDraft | ValidPlayer$ You | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your end step, conjure a random card from CARDNAME's spellbook into exile face down with three egg counters on it. It gains "At the beginning of your upkeep, if this card is exiled, remove an egg counter from it. Then if it has no egg counters on it, put it onto the battlefield."
-SVar:TrigDraft:DB$ MakeCard | Conjure$ True | AtRandom$ True | Spellbook$ Shivan Dragon,Moonveil Regent,Terror of the Peaks,Leyline Tyrant,Immersturm Predator,Manaform Hellkite,Bone Dragon,Demanding Dragon,Skarrgan Hellkite,Thunderbreak Regent,Black Dragon,Skyship Stalker,Red Dragon | WithCounters$ EGG | WithCountersAmount$ 3 | Zone$ Exile | FaceDown$ True | RememberMade$ True | SubAbility$ DBAnimate
+SVar:TrigDraft:DB$ MakeCard | Conjure$ True | AtRandom$ True | Spellbook$ Shivan Dragon,Moonveil Regent,Terror of the Peaks,Leyline Tyrant,Immersturm Predator,Manaform Hellkite,Bone Dragon,Demanding Dragon,Skarrgan Hellkite,Thunderbreak Regent,Black Dragon,Skyship Stalker,Red Dragon | WithCounter$ EGG | WithCounterNum$ 3 | Zone$ Exile | FaceDown$ True | RememberMade$ True | SubAbility$ DBAnimate
 SVar:DBAnimate:DB$ Animate | Defined$ Remembered | Duration$ Permanent | Triggers$ TrigRemoveEgg | SubAbility$ DBCleanup
 SVar:TrigRemoveEgg:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Exile | Execute$ DBRemoveCounter | TriggerDescription$ At the beginning of your upkeep, if this card is exiled, remove an egg counter from it. Then if it has no egg counters on it, put it onto the battlefield.
 SVar:DBRemoveCounter:DB$ RemoveCounter | CounterType$ EGG | SubAbility$ DBReturn


### PR DESCRIPTION
Not sure why the parameter nomenclature for a fairly consistent game action, putting a card in a zone with counters on it, differs between these effects:
- [`MakeCardEffect`](https://github.com/Card-Forge/forge/blob/2d20ce07e3ec70b615e9b3ea039ba888c68d3188/forge-game/src/main/java/forge/game/ability/effects/MakeCardEffect.java#L180): `WithCounter`,`WithCounterNum` 
- [`DigEffect`](https://github.com/Card-Forge/forge/blob/2d20ce07e3ec70b615e9b3ea039ba888c68d3188/forge-game/src/main/java/forge/game/ability/effects/DigEffect.java#L397): `WithCounters`, `WithCountersAmount`
- [`ChangeZoneEffect`](https://github.com/Card-Forge/forge/blob/2d20ce07e3ec70b615e9b3ea039ba888c68d3188/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java#L600): `WithCountersType`, `WithCountersAmount`

In any case. I'm proposing herein to resolve the confounding issue with [Darigaaz, Shivan Champion](https://scryfall.com/card/ydmu/22/darigaaz-shivan-champion), where no egg counters are put on the cards conjured into exile (which reportedly makes it into a very aggressive card) by using the parameter nomenclature as it is for `MakeCardEffect` (it had been using that of `DigEffect` previously). This fix was tested to satisfaction.