### PR TITLE
YEOE: 7 cards

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/DraftEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DraftEffect.java
@@ -73,6 +73,11 @@ import java.util.*;
              }
 
              Card made = game.getAction().moveTo(zone, c, sa, moveParams);
+             if (zone.equals(ZoneType.Battlefield)) {
+                 if (sa.hasParam("Tapped")) {
+                     made.setTapped(true);
+                 }
+             }
              if (zone.equals(ZoneType.Exile)) {
                  handleExiledWith(made, sa);
                  if (sa.hasParam("ExileFaceDown")) {

--- a/forge-gui/res/cardsfolder/upcoming/brood_astronomer.txt
+++ b/forge-gui/res/cardsfolder/upcoming/brood_astronomer.txt
@@ -1,0 +1,10 @@
+Name:Brood Astronomer
+ManaCost:1 G
+Types:Creature Insect Scientist
+PT:2/2
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigDraft | TriggerDescription$ When this creature enters, you may sacrifice a land. If you do, draft a card from the Planets spellbook and put it onto the battlefield tapped.
+SVar:TrigDraft:AB$ Draft | Cost$ Sac<1/Land> | SpellbookName$ Planets | Spellbook$ Adagia; Windswept Bastion,Evendo; Waking Haven,Kavaron; Memorial World,Susur Secundi; Void Altar,Uthros; Titanic Godcore | Zone$ Battlefield | Tapped$ True
+A:AB$ Mana | Cost$ T | Produced$ Any | Amount$ X | SpellDescription$ Add one mana of any color. If you control a Planet with twelve or more charge counters on it, add three mana of any one color instead.
+SVar:X:Count$Compare Y GE1.3.1
+SVar:Y:Count$Valid Planet.YouCtrl+counters_GE12_CHARGE
+Oracle:When this creature enters, you may sacrifice a land. If you do, draft a card from the Planets spellbook and put it onto the battlefield tapped.\n{T}: Add one mana of any color. If you control a Planet with twelve or more charge counters on it, add three mana of any one color instead.

--- a/forge-gui/res/cardsfolder/upcoming/eumidian_lifeseed.txt
+++ b/forge-gui/res/cardsfolder/upcoming/eumidian_lifeseed.txt
@@ -1,0 +1,7 @@
+Name:Eumidian Lifeseed
+ManaCost:G
+Types:Artifact
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigDraft | TriggerDescription$ When this artifact enters, draft a card from CARDNAME’s spellbook.
+SVar:TrigDraft:DB$ Draft | Spellbook$ Adagia; Windswept Bastion,Blast Zone,Cascading Cataracts,Contested War Zone,Deserted Temple,Dust Bowl,Kavaron; Memorial World,Mutavault,Nesting Grounds,Plaza of Heroes,Sunken Citadel,Susur Secundi; Void Altar,Terrain Generator,Uthros; Titanic Godcore
+A:AB$ Mana | Cost$ T | Produced$ Any | Amount$ 1 | RestrictValid$ Activated.Land | SpellDescription$ Add one mana of any color. Spend this mana only to activate abilities of land sources.
+Oracle:When this artifact enters, draft a card from Eumidian Lifeseed’s spellbook.\n{T}: Add one mana of any color. Spend this mana only to activate abilities of land sources.

--- a/forge-gui/res/cardsfolder/upcoming/mutable_pupa.txt
+++ b/forge-gui/res/cardsfolder/upcoming/mutable_pupa.txt
@@ -1,0 +1,8 @@
+Name:Mutable Pupa
+ManaCost:G
+Types:Creature Insect
+PT:1/1
+K:Evolve
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.Other+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever another creature you control enters, this creature perpetually gains flying if that creature has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.
+SVar:TrigPump:DB$ Pump | Defined$ Self | KW$ First Strike & Flying & Deathtouch & Double Strike & Haste & Hexproof & Indestructible & Lifelink & Menace & Reach & Trample & Vigilance | SharedKeywordsZone$ Battlefield | SharedRestrictions$ Card.TriggeredCard | Duration$ Perpetual
+Oracle:Evolve\nWhenever another creature you control enters, this creature perpetually gains flying if that creature has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.

--- a/forge-gui/res/cardsfolder/upcoming/network_marauder.txt
+++ b/forge-gui/res/cardsfolder/upcoming/network_marauder.txt
@@ -1,0 +1,8 @@
+Name:Network Marauder
+ManaCost:2 U
+Types:Artifact Creature Robot Pirate
+PT:1/2
+K:Warp:1 U
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self,Artifact.YouCtrl+cmcGE3 | Execute$ TrigPump | TriggerDescription$ When this creature enters and whenever another artifact you control with mana value 3 or greater enters, all artifact creature cards and Spacecraft cards you own perpetually get +1/+0.
+SVar:TrigPump:DB$ PumpAll | ValidCards$ Artifact.Creature+YouOwn+!token,Spacecraft.YouOwn+!token | PumpZone$ All | NumAtt$ +1 | Duration$ Perpetual
+Oracle:When this creature enters and whenever another artifact you control with mana value 3 or greater enters, all artifact creature cards and Spacecraft cards you own perpetually get +1/+0.\nWarp {1}{U}

--- a/forge-gui/res/cardsfolder/upcoming/prototype_x_8.txt
+++ b/forge-gui/res/cardsfolder/upcoming/prototype_x_8.txt
@@ -1,0 +1,12 @@
+Name:Prototype X-8
+ManaCost:6 U B
+Types:Legendary Artifact Creature Robot Octopus
+PT:8/8
+S:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ X | EffectZone$ All | Description$ This spell costs {1} less to cast for each creature card in your graveyard.
+SVar:X:Count$ValidGraveyard Creature.YouOwn
+T:Mode$ ChangesZone | Destination$ Battlefield | ValidCard$ Creature.wasCastByYou+YouCtrl+Other | Execute$ TrigSac | TriggerZones$ Battlefield | TriggerDescription$ Whenever another creature you control enters, if you cast it, sacrifice it. Conjure a duplicate of it onto the battlefield. The duplicate perpetually becomes a Robot artifact in addition to its other types.
+SVar:TrigSac:DB$ SacrificeAll | Defined$ TriggeredCardLKICopy | SubAbility$ DBConjure
+SVar:DBConjure:DB$ MakeCard | Conjure$ True | DefinedName$ TriggeredCardLKICopy | Zone$ Battlefield | RememberMade$ True | SubAbility$ DBAnimate
+SVar:DBAnimate:DB$ Animate | Defined$ Remembered | Types$ Artifact,Robot | Duration$ Perpetual | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:This spell costs {1} less to cast for each creature card in your graveyard.\nWhenever another creature you control enters, if you cast it, sacrifice it. Conjure a duplicate of it onto the battlefield. The duplicate perpetually becomes a Robot artifact in addition to its other types.

--- a/forge-gui/res/cardsfolder/upcoming/sliver_weftwinder.txt
+++ b/forge-gui/res/cardsfolder/upcoming/sliver_weftwinder.txt
@@ -1,0 +1,11 @@
+Name:Sliver Weftwinder
+ManaCost:W U B R G
+Types:Legendary Creature Sliver
+PT:6/6
+K:Warp:3
+S:Mode$ Continuous | Affected$ Sliver.YouOwn | AffectedZone$ Hand | AddKeyword$ Warp:3 | Description$ Sliver cards in your hand have warp {3}.
+S:Mode$ Continuous | Affected$ Creature.Sliver+YouCtrl | AddTrigger$ WeftwinderTrig | Description$ Sliver creatures you control have “When this creature enters, conjure a random card from the Slivers spellbook into the top ten cards of your library at random, then draw a card.”
+SVar:WeftwinderTrig:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ WeftwinderConjure | TriggerDescription$ When this creature enters, conjure a random card from the Slivers spellbook into the top ten cards of your library at random, then draw a card.
+SVar:WeftwinderConjure:DB$ MakeCard | Conjure$ True | AtRandom$ True | Zone$ Library | LibraryPosition$ Count$Random.0.10 | SpellbookName$ Slivers | Spellbook$ Belligerent Sliver,Bladeback Sliver,Blur Sliver,Bonescythe Sliver,Cleaving Sliver,Cloudshredder Sliver,Diffusion Sliver,Dregscape Sliver,Enduring Sliver,First Sliver's Chosen,Hollowhead Sliver,Lancer Sliver,Lavabelly Sliver,Leeching Sliver,Manaweft Sliver,Predatory Sliver,Scuttling Sliver,Sentinel Sliver,Sliver Hivelord,Spiteful Sliver,Steelform Sliver,Striking Sliver,Tempered Sliver,The First Sliver | SubAbility$ WeftwinderDraw
+SVar:WeftwinderDraw:DB$ Draw
+Oracle:Sliver cards in your hand have warp {3}.\nSliver creatures you control have “When this creature enters, conjure a random card from the Slivers spellbook into the top ten cards of your library at random, then draw a card.”\nWarp {3}

--- a/forge-gui/res/cardsfolder/upcoming/volatile_orbit.txt
+++ b/forge-gui/res/cardsfolder/upcoming/volatile_orbit.txt
@@ -1,0 +1,7 @@
+Name:Volatile Orbit
+ManaCost:R G
+Types:Enchantment
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDamage | IsPresent$ Planet.YouCtrl | TriggerDescription$ When this enchantment enters, if you control a Planet, this enchantment deals 4 damage to any target.
+SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Any | NumDmg$ 4
+A:AB$ MakeCard | Cost$ 1 R G Sac<1/CARDNAME/this enchantment> | Conjure$ True | SorcerySpeed$ True | SpellbookName$ Planets | Spellbook$ Adagia; Windswept Bastion,Evendo; Waking Haven,Kavaron; Memorial World,Susur Secundi; Void Altar,Uthros; Titanic Godcore | Zone$ Battlefield | Tapped$ True | WithCounter$ CHARGE | WithCounterNum$ 8 | SpellDescription$ Conjure a card of your choice from the Planets spellbook onto the battlefield tapped with eight charge counters on it. Activate only as a sorcery.
+Oracle:When this enchantment enters, if you control a Planet, this enchantment deals 4 damage to any target.\n{1}{R}{G}, Sacrifice this enchantment: Conjure a card of your choice from the Planets spellbook onto the battlefield tapped with eight charge counters on it. Activate only as a sorcery.


### PR DESCRIPTION
Tested card scripts for:
- [Brood Astronomer](https://scryfall.com/card/yeoe/18/brood-astronomer) and support for the `Tapped` flag in `DraftEffect.java`
- [Eumidian Lifeseed](https://scryfall.com/card/yeoe/19/eumidian-lifeseed)
- [Mutable Pupa](https://scryfall.com/card/yeoe/20/mutable-pupa)
=> Works for the most part except for the case where the creature that triggered the second triggered ability leaves the battlefield before the trigger resolves: the Pupa gets none of that creature's abilities. Tried a variety of LKI options to no avail.
- [Network Marauder](https://scryfall.com/card/yeoe/8/network-marauder)
- [Prototype X-8](https://scryfall.com/card/yeoe/24/prototype-x-8)
- [Sliver Weftwinder](https://scryfall.com/card/yeoe/25/sliver-weftwinder)
- [Volatile Orbit](https://scryfall.com/card/yeoe/27/volatile-orbit)