### PR TITLE
YEOE: 4 cards, batch 3

### DIFF
--- a/forge-game/src/main/java/forge/game/trigger/TriggerType.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerType.java
@@ -139,6 +139,7 @@ public enum TriggerType {
     SpellCast(TriggerSpellAbilityCastOrCopy.class),
     SpellCastOrCopy(TriggerSpellAbilityCastOrCopy.class),
     SpellCopy(TriggerSpellAbilityCastOrCopy.class),
+    Stationed(TriggerCrewedSaddled.class),
     Surveil(TriggerSurveil.class),
     TakesInitiative(TriggerTakesInitiative.class),
     TapAll(TriggerTapAll.class),

--- a/forge-game/src/main/java/forge/game/zone/MagicStack.java
+++ b/forge-game/src/main/java/forge/game/zone/MagicStack.java
@@ -453,6 +453,16 @@ public class MagicStack /* extends MyObservable */ implements Iterable<SpellAbil
                     }
                 }
             }
+            if (sp.isKeyword(Keyword.STATION) && (sp.getHostCard().getType().hasSubtype("Spacecraft") || (sp.getHostCard().getType().hasSubtype("Planet")))) {
+                Iterable<Card> crews = sp.getPaidList("Tapped", true);
+                if (crews != null) {
+                    for (Card c : crews) {
+                        Map<AbilityKey, Object> stationParams = AbilityKey.mapFromCard(sp.getHostCard());
+                        stationParams.put(AbilityKey.Crew, c);
+                        game.getTriggerHandler().runTrigger(TriggerType.Stationed, stationParams, false);
+                    }
+                }
+            }
         } else {
             // Run Copy triggers
             if (sp.isSpell()) {

--- a/forge-gui/res/cardsfolder/upcoming/monoist_gravliner.txt
+++ b/forge-gui/res/cardsfolder/upcoming/monoist_gravliner.txt
@@ -1,0 +1,9 @@
+Name:Monoist Gravliner
+ManaCost:1 B
+Types:Artifact Spacecraft
+PT:2/3
+K:Station:6
+T:Mode$ Stationed | ValidCard$ Card.Self | ValidCrew$ Creature | Execute$ TrigPump | TriggerZones$ Battlefield | TriggerDescription$ Whenever a creature stations this Spacecraft, that creature perpetually gains deathtouch and lifelink.
+SVar:TrigPump:DB$ Pump | Defined$ Valid Creature.TriggeredCrew | KW$ Deathtouch & Lifelink | Duration$ Perpetual
+S:Mode$ Continuous | Affected$ Card.Self+counters_GE6_CHARGE | AddType$ Creature | AddKeyword$ Flying & Deathtouch & Lifelink | Description$ STATION 6+ Flying, deathtouch, lifelink
+Oracle:Whenever a creature stations this Spacecraft, that creature perpetually gains deathtouch and lifelink.\nStation\nSTATION 6+\nFlying, deathtouch, lifelink

--- a/forge-gui/res/cardsfolder/upcoming/spirited_simulacrum.txt
+++ b/forge-gui/res/cardsfolder/upcoming/spirited_simulacrum.txt
@@ -1,0 +1,12 @@
+Name:Spirited Simulacrum
+ManaCost:4
+Types:Artifact Creature Robot
+PT:2/1
+K:Warp:4
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSeekLand | TriggerDescription$ When this creature enters, seek a land card and put it onto the battlefield tapped.
+SVar:TrigSeekLand:DB$ Seek | Type$ Card.Land | RememberFound$ True | SubAbility$ DBPut
+SVar:DBPut:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | Defined$ Remembered | Tapped$ True | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | ValidCard$ Card.Self | Execute$ TrigSeekNonLand | TriggerDescription$ When this creature leaves the battlefield, seek a nonland card.
+SVar:TrigSeekNonLand:DB$ Seek | Type$ Card.nonLand
+Oracle:When this creature enters, seek a land card and put it onto the battlefield tapped.\nWhen this creature leaves the battlefield, seek a nonland card.\nWarp {4}

--- a/forge-gui/res/cardsfolder/upcoming/squadron_carrier.txt
+++ b/forge-gui/res/cardsfolder/upcoming/squadron_carrier.txt
@@ -1,0 +1,10 @@
+Name:Squadron Carrier
+ManaCost:2 W
+Types:Artifact Spacecraft
+PT:4/4
+K:Station:10
+S:Mode$ Continuous | Affected$ Spacecraft.YouCtrl | AddAbility$ ABConjureExh | Description$ Spacecraft you control have "Exhaust — {W}: Conjure a card named Starfighter Pilot onto the battlefield."
+SVar:ABConjureExh:AB$ MakeCard | Cost$ W | Conjure$ True | Name$ Starfighter Pilot | Zone$ Battlefield | Exhaust$ True | SpellDescription$ Conjure a card named Starfighter Pilot onto the battlefield.
+S:Mode$ Continuous | Affected$ Card.Self+counters_GE10_CHARGE | AddType$ Creature | AddStaticAbility$ CarrierStatic | Description$ STATION 10+ Creatures you control have flying.
+SVar:CarrierStatic:Mode$ Continuous | Affected$ Creature.YouCtrl | AddKeyword$ Flying | Description$ Creatures you control have flying.
+Oracle:Spacecraft you control have "Exhaust — {W}: Conjure a card named Starfighter Pilot onto the battlefield."\nStation\nSTATION 10+\nCreatures you control have flying.

--- a/forge-gui/res/cardsfolder/upcoming/thought_partition.txt
+++ b/forge-gui/res/cardsfolder/upcoming/thought_partition.txt
@@ -3,6 +3,6 @@ ManaCost:W
 Types:Sorcery
 A:SP$ Reveal | ValidTgts$ Opponent | RevealAllValid$ Card.nonLand+TargetedPlayerCtrl | RememberRevealed$ True | SubAbility$ DBChooseCard | StackDescription$ REP Target opponent_{p:Targeted} & You may_{p:You} may & If you_If they | SpellDescription$ Target opponent reveals all nonland cards in their hand. You may choose one of those cards. If you do, it perpetually becomes white and its mana cost perpetually becomes {5}.
 SVar:DBChooseCard:DB$ ChooseCard | Defined$ You | ChoiceZone$ Hand | Choices$ Card.IsRemembered | ChoiceTitle$ Choose a card that was revealed in targeted player's hand | SubAbility$ DBAnimate | StackDescription$ None
-SVar:DBAnimate:DB$ Animate | Defined$ ChosenCard | Colors$ White | OverwriteColors$ True | Duration$ Perpetual | SubAbility$ DBCleanup | StackDescription$ None
+SVar:DBAnimate:DB$ Animate | Defined$ ChosenCard | Colors$ White | OverwriteColors$ True | ManaCost$ 5 | Duration$ Perpetual | SubAbility$ DBCleanup | StackDescription$ None
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Target opponent reveals all nonland cards in their hand. You may choose one of those cards. If you do, it perpetually becomes white and its mana cost perpetually becomes {5}.

--- a/forge-gui/res/cardsfolder/upcoming/thought_partition.txt
+++ b/forge-gui/res/cardsfolder/upcoming/thought_partition.txt
@@ -1,0 +1,8 @@
+Name:Thought Partition
+ManaCost:W
+Types:Sorcery
+A:SP$ Reveal | ValidTgts$ Opponent | RevealAllValid$ Card.nonLand+TargetedPlayerCtrl | RememberRevealed$ True | SubAbility$ DBChooseCard | StackDescription$ REP Target opponent_{p:Targeted} & You may_{p:You} may & If you_If they | SpellDescription$ Target opponent reveals all nonland cards in their hand. You may choose one of those cards. If you do, it perpetually becomes white and its mana cost perpetually becomes {5}.
+SVar:DBChooseCard:DB$ ChooseCard | Defined$ You | ChoiceZone$ Hand | Choices$ Card.IsRemembered | ChoiceTitle$ Choose a card that was revealed in targeted player's hand | SubAbility$ DBAnimate | StackDescription$ None
+SVar:DBAnimate:DB$ Animate | Defined$ ChosenCard | Colors$ White | OverwriteColors$ True | Duration$ Perpetual | SubAbility$ DBCleanup | StackDescription$ None
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:Target opponent reveals all nonland cards in their hand. You may choose one of those cards. If you do, it perpetually becomes white and its mana cost perpetually becomes {5}.


### PR DESCRIPTION
Tested card scripts for:
- [Monoist Gravliner](https://scryfall.com/card/yeoe/11/monoist-gravliner) with functional trigger support
- [Spirited Simulacrum](https://scryfall.com/card/yeoe/30/spirited-simulacrum)
- [Squadron Carrier](https://scryfall.com/card/yeoe/2/squadron-carrier)

Needing engine update:
- [Thought Partition](https://scryfall.com/card/yeoe/4/thought-partition)
 => ~~The effect sequence works as far as changing the chosen card's color to white. Couldn't figure out how to change the mana cost on my own.~~ Functional engine support provided by https://github.com/Card-Forge/forge/pull/8504