### PR TITLE
Add new duplicate cards directory to deal with duplicate test cards and implement correct Fast // Furious card in UNK

### DIFF
--- a/forge-gui/res/cardsfolder/duplicate/t-fast_t-furious.txt
+++ b/forge-gui/res/cardsfolder/duplicate/t-fast_t-furious.txt
@@ -1,0 +1,17 @@
+Name:T-Fast
+ManaCost:1 R
+Types:Instant
+K:Fuse
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ Haste | SubAbility$ DBUnblockable | SpellDescription$ Target creature gains haste until end of turn. It can’t be blocked this turn except by Vehicles or by creatures with haste.
+SVar:DBUnblockable:DB$ Effect | RememberObjects$ Targeted | ExileOnMoved$ Battlefield | StaticAbilities$ Unblockable
+SVar:Unblockable:Mode$ CantBlockBy | ValidAttacker$ Card.IsRemembered | ValidBlocker$ Creature.withoutHaste+nonVehicle | Description$ This creature can’t be blocked this turn except by Vehicles or by creatures with haste.
+AlternateMode:Split
+Oracle:Target creature gains haste until end of turn. It can’t be blocked this turn except by Vehicles or by creatures with haste.\nFuse (You may cast one or both halves of this card from your hand.)
+
+ALTERNATE
+
+Name:T-Furious
+ManaCost:2 R
+Types:Instant
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature to get +3/+0 | NumAtt$ +3 | SpellDescription$ Target creature gets +3/+0 until end of turn.
+Oracle:Target creature gets +3/+0 until end of turn.\nFuse (You may cast one or both halves of this card from your hand.)

--- a/forge-gui/res/editions/Unknown Event.txt
+++ b/forge-gui/res/editions/Unknown Event.txt
@@ -396,7 +396,7 @@ PLA014 C The Food Court @
 RB14 R Another Night in Vegas @
 UU14a U Tax Draw @
 UU14b U Tax Sweeper @
-CR15a C Fast // Furious @
+CR15a C T-Fast // T-Furious @
 PLA015 C High Noon At Thunder Junction @
 RR15 R Force of Rowan @
 RW15 R Crux of Mirrodin @

--- a/forge-gui/res/editions/Unstable.txt
+++ b/forge-gui/res/editions/Unstable.txt
@@ -128,7 +128,6 @@ ScryfallCode=UST
 90 C Just Desserts @Zoltan Boros
 91 C Painiac @McLean Kendree
 92 U Party Crasher @Mike Burns
-93 R Steamflogger Boss @Warren Mahy
 94 R Steamflogger of the Month @Warren Mahy
 95 U Steamflogger Temp @Jeff Miracola
 96 U Steamfloggery @Emrah Elmasli
@@ -275,6 +274,9 @@ ScryfallCode=UST
 214 L Swamp @John Avon
 215 L Mountain @John Avon
 216 L Forest @John Avon
+
+[eternal]
+93 R Steamflogger Boss @Warren Mahy
 
 [tokens]
 1 w_4_4_angel_flying @Magali Villeneuve


### PR DESCRIPTION
The purpose of this PR is to introduce a new duplicate cards folder to the cardsfolder directory for managing cards with duplicate names (none of which are tournament legal, but are still real cards).

The folder will include mostly test cards as they are implemented, such as:

**Red Herring** in Mystery Booster [CMB1](https://scryfall.com/card/cmb1/62/red-herring) (homonymous with [MKM](https://scryfall.com/card/mkm/142/red-herring)).
**Pick your Poison** in Mystery Booster [CMB1](https://scryfall.com/card/cmb1/97/pick-your-poison) (homonymous with [MKM](https://scryfall.com/card/mkm/170/pick-your-poison))
**Unquenchable Fury** in [Battle the Horde](https://scryfall.com/card/tbth/10/unquenchable-fury) (homonymous with [Neon Dynasty](https://scryfall.com/card/nec/23/unquenchable-fury))
**Fast // Furious** in [Unknown Event](https://scryfall.com/card/unk/CR15a/fast-furious) (homonymous with [Modern Horizons 2 - MH2](https://scryfall.com/card/mh2/123/fast-furious))

The last card, Fast // Furious, is the only one present in forge currently, however it was actually the MH2 card in functionality, both making it incorrect, and also causing the MH2 card to not load if one disabled non-legal cards in the settings (see issue link below).

My proposal is to adopt a similar naming convention to that of rebalanced alchemy cards by prepending T- to the card name. I have added the correct "Fast // Furious" playtest card under the name "T-Fast // T-Furious", since cards are loaded once no matter how many sets they appear in. This way, disabling non-legal cards doesn't prevent the loading of the tournament legal Fast // Furious.

Sidenote: also moved Steamflogger Boss to the eternal section of UST setlist so as to fix the issue linked below.

Fixes: #8495 