### PR TITLE
Fix build on JDK 21+

### DIFF
--- a/forge-installer/pom.xml
+++ b/forge-installer/pom.xml
@@ -101,7 +101,7 @@
                     <plugin>
                         <groupId>org.codehaus.izpack</groupId>
                         <artifactId>izpack-maven-plugin</artifactId>
-                        <version>5.2.3</version>
+                        <version>5.2.4</version>
                         <executions>
                             <execution>
                                 <phase>post-integration-test</phase>


### PR DESCRIPTION
This bumps `izpack-maven-plugin`.

Tested with JDK 25.

Similar fix for another project:
https://github.com/lsc-project/lsc/pull/385

Original Error message:
`[ERROR] Failed to execute goal
org.codehaus.izpack:izpack-maven-plugin:5.2.3:izpack (standard-installer) on project forge-installer: Execution standard-installer of goal org.codehaus.izpack:izpack-maven-plugin:5.2.3:izpack failed: java.lang.ArrayIndexOutOfBoundsException: Index 70131 out of bounds for length 22674 -> [Help 1]`