### PR TITLE
MagicStack: check for StackEntries in addAllTriggeredAbilities

### DIFF
--- a/forge-game/src/main/java/forge/game/zone/MagicStack.java
+++ b/forge-game/src/main/java/forge/game/zone/MagicStack.java
@@ -854,6 +854,9 @@ public class MagicStack /* extends MyObservable */ implements Iterable<SpellAbil
             // caused by DevTools before first turn
             return false;
         }
+        if (!hasSimultaneousStackEntries()) {
+            return false;
+        }
 
         if (!playerTurn.isInGame()) {
             playerTurn = game.getNextPlayerAfter(playerTurn);


### PR DESCRIPTION
No need to call `getPlayersInTurnOrder` and `chooseOrderOfSimultaneousStackEntry`
if `simultaneousStackEntryList` is empty