### PR TITLE
CI: add install step (WIP)

### DIFF
--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         java: [ '17' ]
-    name: Test with Java ${{ matrix.Java }}
+    name: Test Android (Java ${{ matrix.Java }})
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test-build-and-install-desktop.yml
+++ b/.github/workflows/test-build-and-install-desktop.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         java: ['17', '21']
-    name: Test with Java ${{ matrix.Java }}
+    name: Test, build, and install Desktop (Java ${{ matrix.Java }})
     steps:
       - uses: actions/checkout@v3
 
@@ -27,3 +27,7 @@ jobs:
           export DISPLAY=":1"
           Xvfb :1 -screen 0 800x600x8 &
           mvn -U -B clean test
+
+      - name: Install (windows-linux)
+        run:
+          mvn -U -B clean -P windows-linux install


### PR DESCRIPTION
* Add install step to CI pipeline

Due to this missing step,
https://github.com/Card-Forge/forge/pull/8534

was passing even before having merged
https://github.com/Card-Forge/forge/pull/8533
(on which it dependend)

* Use more descriptive names in test scripts