### PR TITLE
Add new card filters

### DIFF
--- a/forge-core/src/main/java/forge/card/CardRulesPredicates.java
+++ b/forge-core/src/main/java/forge/card/CardRulesPredicates.java
@@ -197,6 +197,31 @@ public final class CardRulesPredicates {
     }
 
     /**
+     * @return a Predicate that matches cards that are vanilla.
+     */
+    public static Predicate<CardRules> isVanilla() {
+        return card -> {
+            if (!(card.getType().isCreature() || card.getType().isLand()) ||
+                card.getSplitType() != CardSplitType.None ||
+                card.hasFunctionalVariants()) {
+                return false;
+            }
+
+            ICardFace mainPart = card.getMainPart();
+
+            boolean hasAny =
+                mainPart.getKeywords().iterator().hasNext() ||
+                mainPart.getAbilities().iterator().hasNext() ||
+                mainPart.getStaticAbilities().iterator().hasNext() ||
+                mainPart.getTriggers().iterator().hasNext() ||
+                (mainPart.getDraftActions() != null && mainPart.getDraftActions().iterator().hasNext()) ||
+                mainPart.getReplacements().iterator().hasNext();
+
+            return !hasAny;
+        };
+    }
+
+    /**
      * Checks for color.
      *
      * @param thatColor

--- a/forge-gui/src/main/java/forge/itemmanager/AdvancedSearchParser.java
+++ b/forge-gui/src/main/java/forge/itemmanager/AdvancedSearchParser.java
@@ -326,6 +326,10 @@ public abstract class AdvancedSearchParser {
                         case "transform":
                             predicate = CardRulesPredicates.isSplitType(CardSplitType.Transform);
                             break;
+
+                        case "vanilla":
+                            predicate = CardRulesPredicates.isVanilla();
+                            break;
                     }
                 }
                 break;

--- a/forge-gui/src/main/java/forge/itemmanager/AdvancedSearchParser.java
+++ b/forge-gui/src/main/java/forge/itemmanager/AdvancedSearchParser.java
@@ -330,6 +330,10 @@ public abstract class AdvancedSearchParser {
                         case "vanilla":
                             predicate = CardRulesPredicates.isVanilla();
                             break;
+
+                        case "custom":
+                            predicate = card -> card.isCustom();
+                            break;
                     }
                 }
                 break;


### PR DESCRIPTION
Added `is:vanilla` to return vanilla creatures and lands, and `is:custom` for custom cards.