### PR TITLE
Fix crash copying adventure decks with full slots

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
+++ b/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
@@ -1419,6 +1419,7 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
      */
     public int copyDeck() {
         for (int i = 0; i < MAX_DECK_COUNT; i++) {
+            if (i >= getDeckCount()) addDeck();
             if (isEmptyDeck(i)) {
                 decks.set(i, (Deck) deck.copyTo(deck.getName() + " (" + Forge.getLocalizer().getMessage("lblCopy") + ")"));
                 return i;

--- a/forge-gui-mobile/src/forge/adventure/scene/DeckSelectScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/DeckSelectScene.java
@@ -83,7 +83,7 @@ public class DeckSelectScene extends UIScene {
 
     private void layoutDeckButtons() {
         for (int i = 0; i < AdventurePlayer.current().getDeckCount(); i++)
-            addDeckButton(Forge.getLocalizer().getMessage("lblDeck") + ": " + (i + 1), i);
+            addDeckButton(i);
     }
 
     private void addDeck(){
@@ -144,6 +144,7 @@ public class DeckSelectScene extends UIScene {
     }
 
     private void updateDeckButton(int index) {
+        if (!buttons.containsKey(index)) addDeckButton(index);
         buttons.get(index).setText(Current.player().getDeck(index).getName());
         buttons.get(index).getTextraLabel().layout();
         buttons.get(index).layout();
@@ -177,8 +178,9 @@ public class DeckSelectScene extends UIScene {
         }
     }
 
-    private TextraButton addDeckButton(String name, int i) {
+    private TextraButton addDeckButton(int i) {
         TextraButton button = Controls.newTextButton("-");
+        String name = Forge.getLocalizer().getMessage("lblDeck") + ": " + (i + 1);
         button.addListener(new ClickListener() {
             @Override
             public void clicked(InputEvent event, float x, float y) {


### PR DESCRIPTION
Fixes #8582.

Did our best to keep this one short and sweet.