### PR TITLE
GameAction: cleanup Static giving Abilities to the Stack

### DIFF
--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -205,6 +205,7 @@ public class GameAction {
             copied.setGameTimestamp(c.getGameTimestamp());
 
             if (zoneTo.is(ZoneType.Stack)) {
+                copied.setCastFrom(zoneFrom);
                 // try not to copy changed stats when moving to stack
 
                 // copy exiled properties when adding to stack
@@ -452,7 +453,7 @@ public class GameAction {
                 if (c.getCastSA() != null && !c.getCastSA().isIntrinsic() && c.getKeywords().contains(c.getCastSA().getKeyword())) {
                     KeywordInterface ki = c.getCastSA().getKeyword();
                     ki.setHostCard(copied);
-                    copied.addChangedCardKeywordsInternal(ImmutableList.of(ki), null, false, copied.getGameTimestamp(), null, true);
+                    copied.addChangedCardKeywordsInternal(ImmutableList.of(ki), null, false, copied.getGameTimestamp(), ki.getStatic(), true);
                 }
                 // TODO hot fix for non-intrinsic offspring
                 Multimap<StaticAbility, KeywordInterface> addKw = MultimapBuilder.hashKeys().arrayListValues().build();
@@ -566,7 +567,8 @@ public class GameAction {
         // 400.7g try adding keyword back into card if it doesn't already have it
         if (zoneTo.is(ZoneType.Stack) && cause != null && cause.isSpell() && !cause.isIntrinsic() && c.equals(cause.getHostCard())) {
             if (cause.getKeyword() != null && !copied.getKeywords().contains(cause.getKeyword())) {
-                copied.addChangedCardKeywordsInternal(ImmutableList.of(cause.getKeyword()), null, false, game.getNextTimestamp(), null, true);
+                KeywordInterface kw = cause.getKeyword();
+                copied.addChangedCardKeywordsInternal(ImmutableList.of(cause.getKeyword()), null, false, copied.getGameTimestamp(), kw.getStatic(), true);
             }
         }
 


### PR DESCRIPTION
still WIP

This fixes the problem with Herigast adding doubled Emerge to Spells on the Stack

(castFrom wasn't set, so wasCast was false when Line567 was checked)

Normal cases already works,
but what now got broken is if Herigast got sacrificed, especially for Emerge Cost.
Because it is still on the field when Line565 is checked.
So the Keyword i still there for Line567
then Herigast gets sacrificed later by some Human code (i want to clean up for later MR)
at this place i need to pinpoint, the castSa Keyword needs to be added again