### PR TITLE
Consider more cards playable in main1 (#8589)

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtil.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtil.java
@@ -1141,56 +1141,274 @@ public class ComputerUtil {
     public static boolean castPermanentInMain1(final Player ai, final SpellAbility sa) {
         final Card card = sa.getHostCard();
         final CardState cardState = card.isFaceDown() ? card.getState(CardStateName.Original) : card.getCurrentState();
+        final CardCollection myCreatures = ai.getCreaturesInPlay();
 
+        // 2909+ cards match `ManaCost:no cost`
+        // trigger/boost boardstate while you can
+        if (card.getManaCost().isZero()) return true;
+
+        // 1432+ cards match `PlayMain1`
+        // manually chosen, e.g. Bello, Bard of the Brambles
         if (card.hasSVar("PlayMain1")) {
-            if (card.getSVar("PlayMain1").equals("ALWAYS") || sa.getPayCosts().hasNoManaCost()) {
+            if (Set.of("ALWAYS", "TRUE", "True").contains(card.getSVar("PlayMain1")) || sa.getPayCosts().hasNoManaCost()) {
                 return true;
             } else if (card.getSVar("PlayMain1").equals("OPPONENTCREATURES")) {
                 // Only play these main1 when the opponent has creatures (stealing and giving them haste)
                 if (!ai.getOpponents().getCreaturesInPlay().isEmpty()) {
                     return true;
                 }
-            } else if (!card.getController().getCreaturesInPlay().isEmpty()) {
+            } else if (!myCreatures.isEmpty()) {
                 return true;
             }
         }
 
-        // cast Backup creatures in main 1 to pump attackers
-        if (cardState.hasKeyword(Keyword.BACKUP)) {
-            for (Card potentialAtkr: ai.getCreaturesInPlay()) {
-                if (ComputerUtilCard.doesCreatureAttackAI(ai, potentialAtkr)) {
-                    return true;
-                }
-            }
-        }
-
-        // if AI has no speed, play start your engines on Main1
-        if (ai.noSpeed() && cardState.hasKeyword(Keyword.START_YOUR_ENGINES)) {
-            return true;
-        }
-
-        // cast Blitz in main 1 if the creature attacks
-        if (sa.isBlitz() && ComputerUtilCard.doesSpecifiedCreatureAttackAI(ai, card)) {
-            return true;
-        }
-
+        // What not to cast in main1
+        // 51+ cards match `RaidTest`
+        // Raid is better after combat
         // try not to cast Raid creatures in main 1 if an attack is likely
         if ("Count$AttackersDeclared".equals(card.getSVar("RaidTest")) && !cardState.hasKeyword(Keyword.HASTE)) {
-            for (Card potentialAtkr: ai.getCreaturesInPlay()) {
+            for (Card potentialAtkr: myCreatures) {
                 if (ComputerUtilCard.doesCreatureAttackAI(ai, potentialAtkr)) {
                     return false;
                 }
             }
         }
 
-        if (card.getManaCost().isZero()) {
+        // Activated abilities
+        for (SpellAbility nma : cardState.getNonManaAbilities()) {
+            final Cost cost = nma.getPayCosts();
+            if (cost.hasSpecificCostType(CostTap.class) && card.isAbilitySick()) continue;
+
+            // 1761+ cards match `A:AB\$.*Cost\$[^|]*Sac`
+            // sac as combat trick
+            // A Killer Among Us etc
+            // if (cost.hasSpecificCostType(CostSacrifice.class)) {
+            //     return true;
+            // }
+
+            // 244+ cards match `A:AB\$[^|]*(PumpAll|PutCounterAll)`
+            // Jazal Goldmane etc
+            if (myCreatures.size() >= 1
+                && nma.getApi() != null && Set.of(
+                    ApiType.PumpAll,
+                    ApiType.PutCounterAll
+                    ).contains(nma.getApi())) {
+                if (card.isCreature()) {
+                    final String nmaCost = nma.getParam("Cost");
+                    if (nmaCost == null || !nmaCost.contains("T")) {
+                        return true;
+                    }
+                    continue;
+                }
+            }
+
+            // 8+ cards match `A:AB.*?BeforeCombat`
+            // Apprentice Necromancer only gets here if it has haste.
+            // Arms Race already has SVar:PlayMain1:ALWAYS
+            // Cogwork Assembler cost is steep.
+            // Kiki-Jiki, Mirror Breaker etc.
+            if ("BeforeCombat".equals(nma.getParam("AILogic"))) {
+                return true;
+            }
+        }  // activated abilities
+
+        if (myCreatures.size() >= 1) {
+            // Static abilities
+            for (StaticAbility sta : cardState.getStaticAbilities()) {
+                final Set<StaticAbilityMode> mode = sta.getMode();
+
+                // 1138+ cards match `S:Mode\$ Continuous.*?Affected\$[^|]*?YouCtrl`
+                // Saryth, the Viper's Fang etc
+                if (mode.contains(StaticAbilityMode.Continuous)) {
+                    final String affected = sta.getParam("Affected");
+                    if (affected != null && affected.contains("YouCtrl")) {
+                        return true;
+                    }
+                }
+
+                // 32+ cards match `S:Mode\$ Panharmonicon`
+                // double triggers
+                if (mode.contains(StaticAbilityMode.Panharmonicon)) {
+                    return true;
+                }
+
+                String validCard = sta.getParam("ValidCard");
+                if (validCard == null) validCard = "";
+                // 26+ cards match `S:Mode\$ CantBlock.*ValidCard\$(?![^|]*(You|Self))`
+                // Bedlam; Heat Wave etc
+                if (mode.contains(StaticAbilityMode.CantBlock) || mode.contains(StaticAbilityMode.CantBlockUnless)) {
+                    if (!validCard.contains("You") && !validCard.contains("Self")) return true;
+                }
+
+                // 21+ card match `S:Mode\$ CombatDamageToughness(?!.*Self)`
+                // Ancient Lumberknot; Belligerent Brontodon etc
+                if (mode.contains(StaticAbilityMode.CombatDamageToughness)) {
+                    if (validCard.contains("Self")) continue;
+                    int moreT = 0;
+                    for (Card c : myCreatures) {
+                        if (!c.hasSickness()) moreT += c.getNetToughness() - c.getNetPower();
+                    }
+                    if (moreT > 0) return true;
+                }
+
+                // 18+ cards match `S:Mode\$ CantGainLife.*ValidPlayer\$[^|]*(?!You)`
+                // Archfiend of Despair etc
+                if (mode.contains(StaticAbilityMode.CantGainLife)) {
+                    final String validPlayer = sta.getParam("ValidPlayer");
+                    if (validPlayer != null && validPlayer.contains("You")) continue;
+                    for (Player p : ai.getOpponents()) {
+                        for (Card c : p.getCreaturesInPlay()) {
+                            if (c.hasKeyword(Keyword.LIFELINK) && !c.isTapped()) return true;
+                        }
+                    }
+                }
+
+                // 17+ cards match `S:Mode\$ CantBlockBy.*ValidAttacker\$[^|]*You`
+                // Bower Passage etc
+                if (mode.contains(StaticAbilityMode.CantBlockBy)) {
+                    final String validAttacker = sta.getParam("ValidAttacker");
+                    if (validAttacker != null && validAttacker.contains("You")) return true;
+                }
+
+                // 11+ card match `S:Mode\$ CantPreventDamage.*(?!Card.Self)`
+                // Everlasting Torment etc
+                if (mode.contains(StaticAbilityMode.CantPreventDamage)) {
+                    final String validSource = sta.getParam("ValidSource");
+                    if (!"Card.Self".equals(validSource)) return true;
+                }
+
+                // 8+ cards match `S:Mode\$ CantBeActivated.*Activator\$[^|]*(?!You)`
+                // Drana and Linvala; City of Solitude etc
+                if (mode.contains(StaticAbilityMode.CantBeActivated)) {
+                    final String activator = sta.getParam("Activator");
+                    if ("Opponent".equals(activator) || "Player.NonActive".equals(activator)) return true;
+                }
+
+                // 5+ cards match `S:Mode\$ NoCleanupDamage`
+                // Patient Zero etc
+                if (mode.contains(StaticAbilityMode.NoCleanupDamage)) {
+                    if (!"Card.Self".equals(validCard)) return true;
+                }
+
+                // 4+ cards match `S:Mode\$ CanAttackDefender.*ValidCard\$[^|]*You`
+                // Guardians of Oboro etc
+                if (mode.contains(StaticAbilityMode.CanAttackDefender)) {
+                    if (!validCard.contains("You")) continue;
+                    for (Card c : myCreatures) {
+                        if (c.hasKeyword(Keyword.DEFENDER) && !c.hasSickness()) return true;
+                    }
+                }
+
+                // 3+ cards match `S:Mode\$ IgnoreHexproof`
+                // Glaring Spotlight etc
+                if (mode.contains(StaticAbilityMode.IgnoreHexproof)) {
+                    return true;
+                }
+
+                // Everlasting Torment
+                if (mode.contains(StaticAbilityMode.WitherDamage)) {
+                    return true;
+                }
+            }  // static abilities
+
+            // 34+ cards match `K:Exalted`
+            if (cardState.hasKeyword(Keyword.EXALTED)) {
+                return true;
+            }
+
+            // 26+ cards match `K:Backup`
+            // cast Backup creatures in main 1 to pump attackers
+            if (cardState.hasKeyword(Keyword.BACKUP)) {
+                for (Card potentialAtkr: myCreatures) {
+                    if (ComputerUtilCard.doesCreatureAttackAI(ai, potentialAtkr)) {
+                        return true;
+                    }
+                }
+            }
+        } // boosts other creature
+
+        // Triggered abilities
+        for (Trigger trigger : cardState.getTriggers()) {
+            if (!"Battlefield".equals(trigger.getParam("TriggerZones"))) continue;
+
+            // 303+ cards match `Phase\$ BeginCombat.*?ValidPlayer\$(?![^|]*Opponent)`
+            // Odric, Lunarch Marshal etc. Ouroboroid is useful alone
+            final String phase = trigger.getParam("Phase");
+            if ("BeginCombat".equals(phase)) {
+                String validPlayer = trigger.getParam("ValidPlayer");
+                if (validPlayer == null || !validPlayer.contains("Opponent")) {
+                    return true;
+                }
+            }
+
+            if (myCreatures.size() < 1) continue;
+
+            final TriggerType mode = trigger.getMode();
+            if (mode != null) {
+                // 658+ cards match `Mode\$ ChangesZone.*?ValidCards?\$[^|]*Creature.*?TriggerZones\$ Battlefield`
+                // death triggers
+                // Al Bhed Salvagers; Dennick, Pious Apparition etc
+                if ("Graveyard".equals(trigger.getParam("Destination"))
+                    && Set.of("Any", "Battlefield").contains(trigger.getParamOrDefault("Origin", ""))
+                    && ((mode == TriggerType.ChangesZone && trigger.getParamOrDefault("ValidCard", "").contains("Creature") || trigger.getParamOrDefault("ValidCard", "").contains("Permanent"))
+                    || (mode == TriggerType.ChangesZoneAll && trigger.getParamOrDefault("ValidCards", "").contains("Creature") || trigger.getParamOrDefault("ValidCards", "").contains("Permanent")))) {
+                    return true;
+                }
+    
+                // 333+ cards match `T:Mode\$[^|]*Attacker(Blocked|BlockedOnce|sDeclared|sDecalaredOnceTarget|s) `
+                // Cunning Evasion; Big Spender; Adeline, Resplendent Cathar; Breena, the Demagogue; Shared Animosity etc
+                if (Set.of(TriggerType.AttackerBlocked, TriggerType.AttackerBlockedOnce, TriggerType.AttackersDeclared, TriggerType.AttackersDeclaredOneTarget, TriggerType.Attacks).contains(mode)) {
+                    return true;
+                }
+
+                // 217+ cards match `T:Mode\$ Damage.*YouCtrl`
+                // Breeches, Brazen Plunderer; Five-Alarm Fire; Aragorn, Hornburg Hero; Automated Assembly Line etc
+                if (Set.of(TriggerType.DamageAll, TriggerType.DamageDealtOnce, TriggerType.DamageDone, TriggerType.DamageDoneOnce).contains(mode)) {
+                    if (trigger.getParamOrDefault("ValidSource", "").contains("YouCtrl")) return true;
+                }
+            }
+        } // triggered abilities
+
+        // 46+ cards match `K:Start your engines`
+        // if AI has no speed, play start your engines on Main1
+        if (ai.noSpeed() && cardState.hasKeyword(Keyword.START_YOUR_ENGINES)) {
             return true;
         }
 
-        if (cardState.hasKeyword(Keyword.EXALTED) || cardState.hasKeyword(Keyword.EXTORT)) {
+        // 17+ cards match `K:Extort`
+        // benefit from other spells this turn
+        if (cardState.hasKeyword(Keyword.EXTORT)) {
             return true;
         }
 
+        // Slower checks
+
+        // 626+ cards match `Types:.*Equipment`
+        // cast equipment in Main1 when there are creatures to equip and no other unequipped equipment
+        // TODO: Necropouncer and Samurai's Katana create a token and give it haste, but would that attack?
+        if (card.isEquipment() && myCreatures.size() > 0) {
+            boolean playNow = false;
+            for (Card c : card.getController().getCardsIn(ZoneType.Battlefield)) {
+                if (c.isEquipment() && !c.isEquipping()) {
+                    playNow = false;
+                    break;
+                }
+                if (!playNow && c.isCreature() && ComputerUtilCombat.canAttackNextTurn(c) && c.canBeAttached(card, null)) {
+                    playNow = true;
+                }
+            }
+            if (playNow) {
+                return true;
+            }
+        }
+
+        // 19+ cards match `K:Blitz`
+        // cast Blitz in main 1 if the creature attacks
+        if (sa.isBlitz() && ComputerUtilCard.doesSpecifiedCreatureAttackAI(ai, card)) {
+            return true;
+        }
+
+        // 13+ card match `K:Riot`
         if (cardState.hasKeyword(Keyword.RIOT) && SpecialAiLogic.preferHasteForRiot(sa, ai)) {
             // Planning to choose Haste for Riot, so do this in Main 1
             return true;
@@ -1213,26 +1431,10 @@ public class ComputerUtil {
             }
         }
 
+        // slower than the if above
         if (card.isCreature() && !cardState.hasKeyword(Keyword.DEFENDER)
                 && (cardState.hasKeyword(Keyword.HASTE) || hasACardGivingHaste(ai, true) || sa.isDash())) {
             return true;
-        }
-
-        //cast equipment in Main1 when there are creatures to equip and no other unequipped equipment
-        if (card.isEquipment()) {
-            boolean playNow = false;
-            for (Card c : card.getController().getCardsIn(ZoneType.Battlefield)) {
-                if (c.isEquipment() && !c.isEquipping()) {
-                    playNow = false;
-                    break;
-                }
-                if (!playNow && c.isCreature() && ComputerUtilCombat.canAttackNextTurn(c) && c.canBeAttached(card, null)) {
-                    playNow = true;
-                }
-            }
-            if (playNow) {
-                return true;
-            }
         }
 
         // get all cards the computer controls with BuffedBy
@@ -1297,12 +1499,17 @@ public class ComputerUtil {
 
     public static boolean castSpellInMain1(final Player ai, final SpellAbility sa) {
         final Card source = sa.getHostCard();
-        final SpellAbility sub = sa.getSubAbility();
-
-        if (source != null && "ALWAYS".equals(source.getSVar("PlayMain1"))) {
+        if (source != null && Set.of("ALWAYS", "TRUE", "True").contains(source.getSVar("PlayMain1"))) {
             return true;
         }
 
+        // 5+ cards match `A:SP.*BeforeCombat`
+        // Footsteps of the Goryo etc
+        if ("BeforeCombat".equals(sa.getParam("AILogic"))) {
+            return true;
+        }
+
+        final SpellAbility sub = sa.getSubAbility();
         if (sub != null) {
             final ApiType api = sub.getApi();
             if (ApiType.Encode == api && !ai.getCreaturesInPlay().isEmpty()) {
@@ -1329,7 +1536,7 @@ public class ComputerUtil {
             if (ApiType.PermanentNoncreature.equals(sa.getApi()) && buffedCard.hasKeyword(Keyword.PROWESS)) {
                 return true;
             }
-            //Fill the graveyard for Threshold
+            // Fill the graveyard for Threshold
             if (checkThreshold) {
                 for (StaticAbility stAb : buffedCard.getStaticAbilities()) {
                     if ("Threshold".equals(stAb.getParam("Condition"))) {
@@ -1366,7 +1573,7 @@ public class ComputerUtil {
 
         int activations = sa.getActivationsThisTurn();
 
-        //10 activations should still be acceptable
+        // 10 activations should still be acceptable
         if (activations < 10) {
             return false;
         }

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilAbility.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilAbility.java
@@ -360,6 +360,7 @@ public class ComputerUtilAbility {
                 if (source.isInPlay() && source.hasSVar("EndOfTurnLeavePlay")) {
                     p += 1;
                 }
+                // avoid cards AI is bad at
                 if (ComputerUtilCard.isCardRemAIDeck(sa.getOriginalHost() != null ? sa.getOriginalHost() : source)) {
                     p -= 10;
                 }
@@ -391,7 +392,15 @@ public class ComputerUtilAbility {
                     }
                     final TriggerType mode = trig.getMode();
                     // benefit from Magecraft abilities
-                    if ((mode == TriggerType.SpellCast || mode == TriggerType.SpellCastOrCopy) && "You".equals(sa.getParam("ValidActivatingPlayer"))) {
+                    if ((mode == TriggerType.SpellCast || mode == TriggerType.SpellCastOrCopy) && "You".equals(trig.getParam("ValidActivatingPlayer"))) {
+                        p += 1;
+                    }
+                    // ETB triggers
+                    // Weapons Manufactoring before Breya, Etherium Shaper etc.
+                    // 528+ cards match `Mode\$ ChangesZone.*?Destination\$ Battlefield.*?ValidCard.*?YouCtrl.*?TriggerZones\$ Battlefield`
+                    if ("Battlefield".equals(trig.getParam("Destination"))
+                        && ((mode == TriggerType.ChangesZone && trig.getParamOrDefault("ValidCard", "").contains("YouCtrl"))
+                        || (mode == TriggerType.ChangesZoneAll && trig.getParamOrDefault("ValidCards", "").contains("YouCtrl")))) {
                         p += 1;
                     }
                 }
@@ -400,6 +409,11 @@ public class ComputerUtilAbility {
                     final Set<StaticAbilityMode> mode = sta.getMode();
                     // reduce cost to enable more plays
                     if (mode.contains(StaticAbilityMode.ReduceCost) && "You".equals(sta.getParam("Activator"))) {
+                        p += 1;
+                    }
+                    // double triggers
+                    // 32+ cards match `S:Mode\$ Panharmonicon`
+                    if (mode.contains(StaticAbilityMode.Panharmonicon)) {
                         p += 1;
                     }
                 }


### PR DESCRIPTION
Fixes #8589. My Naya deck win rate improved by at least 50% when AI played it against its unpatched self.

I moved 0-mana, Exalted, and Extort checks before the RaidTest check as i don't think they reduce the number of blockers. The checks after RaidTest probably apply to cards that share that property with e.g. Blitz. I'm too tired to check atm.