### PR TITLE
Fix Profane Transfusion

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/LifeExchangeEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/LifeExchangeEffect.java
@@ -70,6 +70,9 @@ public class LifeExchangeEffect extends SpellAbilityEffect {
                 lossMap.put(p1, lost);
                 final Map<AbilityKey, Object> runParams = AbilityKey.mapFromPIMap(lossMap);
                 source.getGame().getTriggerHandler().runTrigger(TriggerType.LifeLostAll, runParams, false);
+                if (sa.hasParam("RememberOwnLoss") && p1.equals(sa.getActivatingPlayer())) {
+                    source.addRemembered(lost);
+                }
             }
         }
         if (sa.hasParam("RememberDifference")) {

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -455,7 +455,6 @@ public class Player extends GameEntity implements Comparable<Player> {
             return false;
         }
 
-        // Run any applicable replacement effects.
         final Map<AbilityKey, Object> repParams = AbilityKey.mapFromAffected(this);
         repParams.put(AbilityKey.LifeGained, lifeGain);
         repParams.put(AbilityKey.SourceSA, sa);
@@ -521,7 +520,7 @@ public class Player extends GameEntity implements Comparable<Player> {
             return 0;
         }
         int oldLife = life;
-        // Run applicable replacement effects
+
         final Map<AbilityKey, Object> repParams = AbilityKey.mapFromAffected(this);
         repParams.put(AbilityKey.Amount, toLose);
         repParams.put(AbilityKey.IsDamage, damage);
@@ -554,7 +553,6 @@ public class Player extends GameEntity implements Comparable<Player> {
         }
 
         boolean firstLost = lifeLostThisTurn == 0;
-
         lifeLostThisTurn += toLose;
 
         final Map<AbilityKey, Object> runParams = AbilityKey.mapFromPlayer(this);


### PR DESCRIPTION
>  Use the difference between the life totals after the exchange to determine the size of the Horror token. Because replacement effects can modify the life gain and life loss, this number may be different from what it was before the exchange.