### PR TITLE
update AltZoneLayout VCardDisplayArea for Landscape

### DIFF
--- a/forge-gui-mobile/src/forge/Forge.java
+++ b/forge-gui-mobile/src/forge/Forge.java
@@ -346,9 +346,11 @@ public class Forge implements ApplicationListener {
         GuiBase.setIsAdventureMode(true);
         advStartup = false;
         isMobileAdventureMode = true;
-        //force it for adventure mode if not set to Off
-        if (!"Off".equalsIgnoreCase(FModel.getPreferences().getPref(FPref.UI_ALT_PLAYERZONETABS)))
+        //force it for adventure mode if the prefs is not updated from boolean value to string value
+        if ("true".equalsIgnoreCase(FModel.getPreferences().getPref(FPref.UI_ALT_PLAYERZONETABS)) ||
+            "false".equalsIgnoreCase(FModel.getPreferences().getPref(FPref.UI_ALT_PLAYERZONETABS))) {
             setAltZoneTabMode("Vertical");
+        }
         //pixl cursor for adventure
         setCursor(null, "0");
         if (!GuiBase.isAndroid() || !getDeviceAdapter().getGamepads().isEmpty())

--- a/forge-gui-mobile/src/forge/Forge.java
+++ b/forge-gui-mobile/src/forge/Forge.java
@@ -101,6 +101,7 @@ public class Forge implements ApplicationListener {
     public static boolean allowCardBG = false;
     public static boolean altPlayerLayout = false;
     public static boolean altZoneTabs = false;
+    public static String altZoneTabMode = "Off";
     public static boolean animatedCardTapUntap = false;
     public static String enableUIMask = "Crop";
     public static String selector = "Default";
@@ -222,7 +223,7 @@ public class Forge implements ApplicationListener {
         reversedPrompt = getForgePreferences().getPrefBoolean(FPref.UI_REVERSE_PROMPT_BUTTON);
         autoAIDeckSelection = getForgePreferences().getPrefBoolean(FPref.UI_AUTO_AIDECK_SELECTION);
         altPlayerLayout = getForgePreferences().getPrefBoolean(FPref.UI_ALT_PLAYERINFOLAYOUT);
-        altZoneTabs = getForgePreferences().getPrefBoolean(FPref.UI_ALT_PLAYERZONETABS);
+        setAltZoneTabMode(getForgePreferences().getPref(FPref.UI_ALT_PLAYERZONETABS));
         animatedCardTapUntap = getForgePreferences().getPrefBoolean(FPref.UI_ANIMATED_CARD_TAPUNTAP);
         enableUIMask = getForgePreferences().getPref(FPref.UI_ENABLE_BORDER_MASKING);
         if (getForgePreferences().getPref(FPref.UI_ENABLE_BORDER_MASKING).equals("true")) //override old settings if not updated
@@ -258,6 +259,14 @@ public class Forge implements ApplicationListener {
             };
             //see if app or assets need updating
             FThreads.invokeInBackgroundThread(() -> AssetsDownloader.checkForUpdates(exited, runnable));
+        }
+    }
+    public static void setAltZoneTabMode(String mode) {
+        Forge.altZoneTabMode = mode;
+        switch (Forge.altZoneTabMode) {
+            case "Vertical", "Horizontal" -> Forge.altZoneTabs = true;
+            case "Off" -> Forge.altZoneTabs = false;
+            default -> Forge.altZoneTabs = false;
         }
     }
     public static boolean hasGamepad() {
@@ -337,8 +346,9 @@ public class Forge implements ApplicationListener {
         GuiBase.setIsAdventureMode(true);
         advStartup = false;
         isMobileAdventureMode = true;
-        if (GuiBase.isAndroid()) //force it for adventure mode
-            altZoneTabs = true;
+        //force it for adventure mode if not set to Off
+        if (!"Off".equalsIgnoreCase(FModel.getPreferences().getPref(FPref.UI_ALT_PLAYERZONETABS)))
+            setAltZoneTabMode("Vertical");
         //pixl cursor for adventure
         setCursor(null, "0");
         if (!GuiBase.isAndroid() || !getDeviceAdapter().getGamepads().isEmpty())
@@ -755,7 +765,7 @@ public class Forge implements ApplicationListener {
             isMobileAdventureMode = false;
             GuiBase.setIsAdventureMode(false);
             setCursor(FSkin.getCursor().get(0), "0");
-            altZoneTabs = FModel.getPreferences().getPrefBoolean(FPref.UI_ALT_PLAYERZONETABS);
+            setAltZoneTabMode(FModel.getPreferences().getPref(FPref.UI_ALT_PLAYERZONETABS));
             Gdx.input.setInputProcessor(getInputProcessor());
             clearTransitionScreen();
             openHomeDefault();
@@ -1468,7 +1478,7 @@ public class Forge implements ApplicationListener {
 
             boolean handled;
             if (KeyInputAdapter.isShiftKeyDown()) {
-                handled = pan(mouseMovedX, mouseMovedY, -Utils.AVG_FINGER_WIDTH * amountX, 0, false);
+                handled = pan(mouseMovedX, mouseMovedY, -Utils.AVG_FINGER_WIDTH * amountY, 0, false);
             } else {
                 handled = pan(mouseMovedX, mouseMovedY, 0, -Utils.AVG_FINGER_HEIGHT * amountY, true);
             }

--- a/forge-gui-mobile/src/forge/adventure/scene/SettingsScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/SettingsScene.java
@@ -259,7 +259,7 @@ public class SettingsScene extends UIScene {
 
         if (!GuiBase.isAndroid()) {
             addCheckBox(Forge.getLocalizer().getMessage("lblBattlefieldTextureFiltering"), ForgePreferences.FPref.UI_LIBGDX_TEXTURE_FILTERING);
-            addCheckBox(Forge.getLocalizer().getMessage("lblAltZoneTabs"), ForgePreferences.FPref.UI_ALT_PLAYERZONETABS);
+            //addCheckBox(Forge.getLocalizer().getMessage("lblAltZoneTabs"), ForgePreferences.FPref.UI_ALT_PLAYERZONETABS);
         } else {
             addCheckBox(Forge.getLocalizer().getMessage("lblLandscapeMode") + " (" +
                 Forge.getLocalizer().getMessage("lblRestartRequired") + ")",

--- a/forge-gui-mobile/src/forge/screens/match/MatchController.java
+++ b/forge-gui-mobile/src/forge/screens/match/MatchController.java
@@ -174,10 +174,13 @@ public class MatchController extends AbstractGuiGame {
             final VPlayerPanel playerPanel = new VPlayerPanel(p, isLocal || noHumans, players.size());
             if (isLocal && !init) {
                 playerPanels.add(0, playerPanel); //ensure local player always first among player panels
+                playerPanel.setBottomPlayer(true);
                 init = true;
             }
             else {
                 playerPanels.add(playerPanel);
+                if (playerPanel.equals(playerPanels.get(0)))
+                    playerPanel.setBottomPlayer(true);
             }
         }
         view = new MatchScreen(playerPanels);

--- a/forge-gui-mobile/src/forge/screens/match/views/VCardDisplayArea.java
+++ b/forge-gui-mobile/src/forge/screens/match/views/VCardDisplayArea.java
@@ -53,6 +53,12 @@ public abstract class VCardDisplayArea extends VDisplayArea implements ActivateH
         rotateCards180 = b0;
     }
 
+    private float getCardStackOffset() {
+        if (Forge.altZoneTabs && "Horizontal".equalsIgnoreCase(Forge.altZoneTabMode))
+            return 0.125f;
+        return CARD_STACK_OFFSET;
+    }
+
     protected void refreshCardPanels(Iterable<CardView> model) {
         clear();
 
@@ -78,7 +84,9 @@ public abstract class VCardDisplayArea extends VDisplayArea implements ActivateH
 
     @Override
     public void setVisible(boolean b0) {
-        if (isVisible() == b0) { return; }
+        if (isVisible() == b0) {
+            return;
+        }
         super.setVisible(b0);
         if (b0) { //when zone becomes visible, ensure display area of panels is updated and panels layed out
             for (CardAreaPanel pnl : cardPanels.get()) {
@@ -146,7 +154,7 @@ public abstract class VCardDisplayArea extends VDisplayArea implements ActivateH
                 CardAreaPanel attachedPanel = attachedPanels.get(i);
                 if (attachedPanel != null) {
                     int count = addCards(attachedPanel, x, y, cardWidth, cardHeight);
-                    x += count * cardWidth * CARD_STACK_OFFSET;
+                    x += count * cardWidth * getCardStackOffset();
                     totalCount += count;
                 }
             }
@@ -156,7 +164,7 @@ public abstract class VCardDisplayArea extends VDisplayArea implements ActivateH
         cardPanel.setBounds(x, y, cardWidth, cardHeight);
 
         if (cardPanel.getNextPanelInStack() != null) { //add next panel in stack if needed
-            x += cardWidth * CARD_STACK_OFFSET;
+            x += cardWidth * getCardStackOffset();
             totalCount += addCards(cardPanel.getNextPanelInStack(), x, y, cardWidth, cardHeight);
         }
         return totalCount + 1;
@@ -165,6 +173,7 @@ public abstract class VCardDisplayArea extends VDisplayArea implements ActivateH
     protected float getCardWidth(float cardHeight) {
         return (cardHeight - 2 * FCardPanel.PADDING) / FCardPanel.ASPECT_RATIO + 2 * FCardPanel.PADDING; //ensure aspect ratio maintained after padding applied
     }
+
     protected float getCardHeight(float cardWidth) {
         return (cardWidth - 2 * FCardPanel.PADDING) * FCardPanel.ASPECT_RATIO + 2 * FCardPanel.PADDING; //ensure aspect ratio maintained after padding applied
     }
@@ -181,7 +190,7 @@ public abstract class VCardDisplayArea extends VDisplayArea implements ActivateH
         for (CardAreaPanel cardPanel : new ArrayList<>(cardPanels.get())) {
             if (cardPanel != null) {
                 int count = addCards(cardPanel, x, y, cardWidth, cardHeight);
-                x += cardWidth + (count - 1) * cardWidth * CARD_STACK_OFFSET;
+                x += cardWidth + (count - 1) * cardWidth * getCardStackOffset();
             }
         }
 
@@ -197,7 +206,7 @@ public abstract class VCardDisplayArea extends VDisplayArea implements ActivateH
 
     @Override
     public String getActivateAction(int index) {
-        if(!GuiBase.isNetworkplay()) {
+        if (!GuiBase.isNetworkplay()) {
             //causes lag on netplay client side, also index shouldn't be out of bounds
             if (index >= 0 && index < orderedCards.get().size())
                 return MatchController.instance.getGameController().getActivateDescription(orderedCards.get().get(index));
@@ -266,9 +275,11 @@ public abstract class VCardDisplayArea extends VDisplayArea implements ActivateH
         public CardAreaPanel getAttachedToPanel() {
             return attachedToPanel;
         }
+
         public void setAttachedToPanel(final CardAreaPanel attachedToPanel0) {
             attachedToPanel = attachedToPanel0;
         }
+
         public List<CardAreaPanel> getAttachedPanels() {
             if (attachedPanels == null) {
                 attachedPanels = new ArrayList<>();
@@ -278,15 +289,19 @@ public abstract class VCardDisplayArea extends VDisplayArea implements ActivateH
             }
             return attachedPanels;
         }
+
         public CardAreaPanel getNextPanelInStack() {
             return nextPanelInStack;
         }
+
         public void setNextPanelInStack(CardAreaPanel nextPanelInStack0) {
             nextPanelInStack = nextPanelInStack0;
         }
+
         public CardAreaPanel getPrevPanelInStack() {
             return prevPanelInStack;
         }
+
         public void setPrevPanelInStack(CardAreaPanel prevPanelInStack0) {
             prevPanelInStack = prevPanelInStack0;
         }
@@ -324,8 +339,7 @@ public abstract class VCardDisplayArea extends VDisplayArea implements ActivateH
                     attachedPanels.remove(CardAreaPanel.get(getAttachedto));
                     setAttachedToPanel(null);
                 }
-            }
-            else {
+            } else {
                 setAttachedToPanel(null);
             }
         }
@@ -423,7 +437,9 @@ public abstract class VCardDisplayArea extends VDisplayArea implements ActivateH
         }
 
         public void showZoom() {
-            if (displayArea == null) { return; }
+            if (displayArea == null) {
+                return;
+            }
 
             final List<CardView> cards = displayArea.orderedCards.get();
             CardZoom.show(cards, cards.indexOf(getCard()), displayArea);
@@ -444,10 +460,14 @@ public abstract class VCardDisplayArea extends VDisplayArea implements ActivateH
         }
 
         private List<CardView> getOtherCardsToSelect(boolean selectOtherCardsInStack) {
-            if (!selectOtherCardsInStack) { return null; }
+            if (!selectOtherCardsInStack) {
+                return null;
+            }
 
             //on double-tap select all other cards in stack if any
-            if (prevPanelInStack == null && nextPanelInStack == null) { return null; }
+            if (prevPanelInStack == null && nextPanelInStack == null) {
+                return null;
+            }
 
             List<CardView> cards = new ArrayList<>();
 
@@ -490,7 +510,9 @@ public abstract class VCardDisplayArea extends VDisplayArea implements ActivateH
 
         public Vector2 getTargetingArrowOrigin() {
             //don't show targeting arrow unless in display area that's visible
-            if (displayArea == null || !displayArea.isVisible()) { return null; }
+            if (displayArea == null || !displayArea.isVisible()) {
+                return null;
+            }
 
             return getTargetingArrowOrigin(this, isTapped());
         }
@@ -517,8 +539,7 @@ public abstract class VCardDisplayArea extends VDisplayArea implements ActivateH
                 g.startRotateTransform(x + w / 2, y + h / 2, 180);
                 super.draw(g);
                 g.endTransform();
-            }
-            else {
+            } else {
                 super.draw(g);
             }
         }

--- a/forge-gui-mobile/src/forge/screens/match/views/VField.java
+++ b/forge-gui-mobile/src/forge/screens/match/views/VField.java
@@ -2,6 +2,7 @@ package forge.screens.match.views;
 
 import java.util.*;
 
+import forge.Forge;
 import forge.game.card.CardView;
 import forge.game.card.CardView.CardStateView;
 import forge.game.player.PlayerView;
@@ -33,6 +34,7 @@ public class VField extends FContainer {
     public boolean isFlipped() {
         return flipped;
     }
+
     public void setFlipped(boolean flipped0) {
         flipped = flipped0;
     }
@@ -61,7 +63,9 @@ public class VField extends FContainer {
             clear();
 
             Iterable<CardView> model = player.getBattlefield();
-            if (model == null) { return; }
+            if (model == null) {
+                return;
+            }
 
             for (CardView card : model) {
                 CardAreaPanel cardPanel = CardAreaPanel.get(card);
@@ -84,18 +88,15 @@ public class VField extends FContainer {
                         if (!tryStackCard(card, creatures)) {
                             creatures.add(card);
                         }
-                    }
-                    else if (details.isLand()) {
+                    } else if (details.isLand()) {
                         if (!tryStackCard(card, lands)) {
                             lands.add(card);
                         }
-                    }
-                    else if (details.isArtifact() && (details.isContraption() || details.isAttraction())) {
+                    } else if (details.isArtifact() && (details.isContraption() || details.isAttraction())) {
                         if (contraptions == null)
                             contraptions = new ArrayList<>();
                         contraptions.add(card); //Arrange these later.
-                    }
-                    else {
+                    } else {
                         if (!tryStackCard(card, otherPermanents)) {
                             otherPermanents.add(card);
                         }
@@ -103,7 +104,7 @@ public class VField extends FContainer {
                 }
             }
 
-            if(contraptions != null) {
+            if (contraptions != null) {
                 contraptions = arrangeContraptions(contraptions);
                 otherPermanents.addAll(contraptions);
             }
@@ -111,8 +112,7 @@ public class VField extends FContainer {
             if (creatures.isEmpty()) {
                 row1.refreshCardPanels(otherPermanents);
                 row2.refreshCardPanels(lands);
-            }
-            else {
+            } else {
                 row1.refreshCardPanels(creatures);
                 lands.addAll(otherPermanents);
                 row2.refreshCardPanels(lands);
@@ -173,13 +173,14 @@ public class VField extends FContainer {
         TreeSet<CardView> row = new TreeSet<>((c1, c2) -> {
             //Order is sprocket-less cards, then sprocket 1, sprocket 2, sprocket 3, and finally attractions.
             int sprocket1 = c1.getSprocket(), sprocket2 = c2.getSprocket();
-            if(sprocket1 == 0 && c1.getCurrentState().isAttraction())
+            if (sprocket1 == 0 && c1.getCurrentState().isAttraction())
                 sprocket1 = 4;
-            if(sprocket2 == 0 && c2.getCurrentState().isAttraction())
+            if (sprocket2 == 0 && c2.getCurrentState().isAttraction())
                 sprocket2 = 4;
             return sprocket1 - sprocket2;
         });
-        outer: for (CardView card : contraptions) {
+        outer:
+        for (CardView card : contraptions) {
             if (card.hasCardAttachments()) {
                 row.add(card); //Don't stack contraptions or attractions with attachments.
                 continue;
@@ -187,7 +188,7 @@ public class VField extends FContainer {
             if (card.getCurrentState().isAttraction()) {
                 //Stack attractions with other attractions.
                 for (CardView c : row) {
-                    if(c.getCurrentState().isAttraction() && !c.hasCardAttachments()) {
+                    if (c.getCurrentState().isAttraction() && !c.hasCardAttachments()) {
                         stackOnto(card, c);
                         continue outer;
                     }
@@ -240,13 +241,17 @@ public class VField extends FContainer {
         if (flipped) {
             y1 = cardSize;
             y2 = 0;
-        }
-        else {
+        } else {
             y1 = 0;
             y2 = cardSize;
         }
-        row1.setBounds(0, y1, width-fieldModifier, cardSize);
-        row2.setBounds(0, y2, (width - commandZoneWidth)-fieldModifier, cardSize);
+        if (Forge.altZoneTabs && "Horizontal".equalsIgnoreCase(Forge.altZoneTabMode)) {
+            row1.setBounds(0, y1, width, cardSize);
+            row2.setBounds(0, y2, width, cardSize);
+        } else {
+            row1.setBounds(0, y1, width - fieldModifier, cardSize);
+            row2.setBounds(0, y2, (width - commandZoneWidth) - fieldModifier, cardSize);
+        }
     }
 
     public class FieldRow extends VCardDisplayArea {
@@ -270,13 +275,14 @@ public class VField extends FContainer {
         public void setNextSelected(int val) {
             this.selected++;
             if (this.selected >= this.getChildCount())
-                this.selected = this.getChildCount()-1;
+                this.selected = this.getChildCount() - 1;
             if (this.selectedChild != null)
                 this.selectedChild.setHovered(false);
             this.selectedChild = getChildAt(this.selected);
             this.selectedChild.setHovered(true);
             MatchScreen.setPotentialListener(Arrays.asList(this.selectedChild));
         }
+
         public void selectCurrent() {
             if (this.selectedChild != null) {
                 this.selectedChild.setHovered(true);
@@ -285,6 +291,7 @@ public class VField extends FContainer {
                 this.setNextSelected(1);
             }
         }
+
         public void unselectCurrent() {
             if (this.selectedChild != null) {
                 this.selectedChild.setHovered(false);

--- a/forge-gui-mobile/src/forge/screens/match/views/VManaPool.java
+++ b/forge-gui-mobile/src/forge/screens/match/views/VManaPool.java
@@ -69,7 +69,7 @@ public class VManaPool extends VDisplayArea {
         float x = 0;
         float y = 0;
 
-        if (Forge.isLandscapeMode()) {
+        if (Forge.isLandscapeMode() && !Forge.altZoneTabs) {
             float labelWidth = visibleWidth / 2;
             float labelHeight = visibleHeight / 3;
 
@@ -146,17 +146,19 @@ public class VManaPool extends VDisplayArea {
             if (h > maxImageHeight) {
                 h /= 2;
             }
-            float w = image.getWidth() * h / image.getHeight();
+            float w2 = Forge.altZoneTabs && "Horizontal".equalsIgnoreCase(Forge.altZoneTabMode)
+                ? image.getWidth() * h * 0.7f / image.getHeight() : image.getWidth() * h / image.getHeight();
+            float w =  w2;
             while (w > getWidth()) {
                 h /= 2;
-                w = image.getWidth() * h / image.getHeight();
+                w = w2;
             }
             float x = (getWidth() - w) / 2;
             float y = gapY + (maxImageHeight - h) / 2;
 
             if (isHovered())
                 g.fillRect(FSkinColor.getStandardColor(50, 200, 150).alphaColor(0.3f), 0, 0, getWidth(), getHeight());
-            g.drawImage(image, x, y, w, h);
+            g.drawImage(image, x, y, w, Forge.altZoneTabs && "Horizontal".equalsIgnoreCase(Forge.altZoneTabMode) ? w : h);
 
             x = 0;
             y += h + gapY;

--- a/forge-gui-mobile/src/forge/screens/match/views/VPlayerPanel.java
+++ b/forge-gui-mobile/src/forge/screens/match/views/VPlayerPanel.java
@@ -79,6 +79,7 @@ public class VPlayerPanel extends FContainer {
     private boolean forMultiPlayer = false;
     public int adjustHeight = 1;
     private int selected = 0;
+    private boolean isBottomPlayer = false;
     public VPlayerPanel(PlayerView player0, boolean showHand, int playerCount) {
         player = player0;
         phaseIndicator = add(new VPhaseIndicator());
@@ -114,6 +115,10 @@ public class VPlayerPanel extends FContainer {
 
     public PlayerView getPlayer() {
         return player;
+    }
+
+    public void setBottomPlayer(boolean val) {
+        isBottomPlayer = val;
     }
 
     public void addZoneDisplay(ZoneType zoneType) {
@@ -429,32 +434,51 @@ public class VPlayerPanel extends FContainer {
         }
 
         //account for command zone if needed
+        float commandZoneWidth = 0f;
         int commandZoneCount = commandZone.getCount();
         if (commandZoneCount > 0) {
             float commandZoneHeight = height / 2;
-            float commandZoneWidth = Math.min(commandZoneCount, 2) * commandZone.getCardWidth(commandZoneHeight);
-            commandZone.setBounds(x + fieldWidth - commandZoneWidth, height - commandZoneHeight, commandZoneWidth, commandZoneHeight);
+            float minCommandCards = Forge.altZoneTabs && "Horizontal".equalsIgnoreCase(Forge.altZoneTabMode) ? 5 : 2;
+            commandZoneWidth = Math.min(commandZoneCount, minCommandCards) * commandZone.getCardWidth(commandZoneHeight);
+            float x2 = x + fieldWidth - commandZoneWidth;
+            float y2 = height - commandZoneHeight;
+            if (Forge.altZoneTabs && "Horizontal".equalsIgnoreCase(Forge.altZoneTabMode)) {
+                x2 = width - avatarWidth - commandZoneWidth;
+                y2 = 0;
+            }
+            commandZone.setBounds(x2, y2, commandZoneWidth, commandZoneHeight);
             if (isFlipped()) { //flip across x-axis if needed
                 commandZone.setTop(height - commandZone.getBottom());
             }
 
             field.setCommandZoneWidth(commandZoneWidth + 1); //ensure second row of field accounts for width of command zone and its border
-        }
-        else {
+        } else {
             field.setCommandZoneWidth(0);
         }
-
-        field.setBounds(x, 0, fieldWidth, height);
+        if (Forge.altZoneTabs && "Horizontal".equalsIgnoreCase(Forge.altZoneTabMode)) {
+            field.setBounds(x, 0, width - (avatarWidth / 16f), height);
+            field.getRow1().setWidth(width - (avatarWidth / 16f) - (commandZoneCount > 0 ? commandZoneWidth + 1 : 0));
+            field.getRow2().setWidth(width - (avatarWidth / 16f) - (selectedTab == null ? 0 : width / 2.25f));
+        } else
+            field.setBounds(x, 0, fieldWidth, height);
 
         x = width - displayAreaWidth-avatarWidth;
         for (InfoTab tab : tabs) {
-            tab.setDisplayBounds(x, 0, displayAreaWidth, height);
+            if (Forge.altZoneTabs && "Horizontal".equalsIgnoreCase(Forge.altZoneTabMode)) {
+                float w = (width / 2.25f);
+                float h = height / 2f;
+                tab.setDisplayBounds(width - w - avatarWidth, isBottomPlayer ? h : 0, w, h);
+            } else {
+                tab.setDisplayBounds(x, 0, displayAreaWidth, height);
+            }
         }
 
-        if (!Forge.altZoneTabs)
+        if (!Forge.altZoneTabs) {
             field.setFieldModifier(0);
-        else
-            field.setFieldModifier(avatarWidth/16);
+        } else {
+            if (!"Horizontal".equalsIgnoreCase(Forge.altZoneTabMode))
+                field.setFieldModifier(avatarWidth / 16);
+        }
     }
 
     @Override

--- a/forge-gui-mobile/src/forge/screens/match/views/VZoneDisplay.java
+++ b/forge-gui-mobile/src/forge/screens/match/views/VZoneDisplay.java
@@ -113,7 +113,7 @@ public class VZoneDisplay extends VCardDisplayArea {
     }
 
     protected boolean layoutVerticallyForLandscapeMode() {
-        return true;
+        return !Forge.altZoneTabs || !"Horizontal".equalsIgnoreCase(Forge.altZoneTabMode);
     }
 
     @Override

--- a/forge-gui-mobile/src/forge/screens/settings/SettingsPage.java
+++ b/forge-gui-mobile/src/forge/screens/settings/SettingsPage.java
@@ -274,14 +274,15 @@ public class SettingsPage extends TabPage<SettingsScreen> {
                         MatchController.instance.resetPlayerPanels();
                 }
             }, 1);
-        lstSettings.addItem(new BooleanSetting(FPref.UI_ALT_PLAYERZONETABS,
+        lstSettings.addItem(new CustomSelectSetting(FPref.UI_ALT_PLAYERZONETABS,
             Forge.getLocalizer().getMessage("lblAltZoneTabs"),
-            Forge.getLocalizer().getMessage("nlAltZoneTabs")) {
+            Forge.getLocalizer().getMessage("nlAltZoneTabs"),
+            Lists.newArrayList("Off", "Vertical", "Horizontal")) {
                 @Override
-                public void select() {
-                    super.select();
+                public void valueChanged(String newValue) {
+                    super.valueChanged(newValue);
                     //update
-                    Forge.altZoneTabs = FModel.getPreferences().getPrefBoolean(FPref.UI_ALT_PLAYERZONETABS);
+                    Forge.setAltZoneTabMode(FModel.getPreferences().getPref(FPref.UI_ALT_PLAYERZONETABS));
                     if (MatchController.instance != null)
                         MatchController.instance.resetPlayerPanels();
                 }


### PR DESCRIPTION
Screenshots also enabled Alt Player Layout
<img width="1177" height="158" alt="image" src="https://github.com/user-attachments/assets/f5aa24f0-4548-4024-90b7-dc292f0e3d62" />


- Off (Default Layout)
<img width="1283" height="754" alt="image" src="https://github.com/user-attachments/assets/5be57d43-c46d-4399-9387-38324acb41c2" />


- Vertical (Alt Layout with old Vertical Scroll Card Display Area)
<img width="1284" height="754" alt="image" src="https://github.com/user-attachments/assets/392e8a3f-9b8c-41a9-a671-250f5909df38" />


- Horizontal (Alt Layout with Horizontal Scroll Card Display Area)
<img width="1281" height="755" alt="image" src="https://github.com/user-attachments/assets/4086a994-a33c-4ab3-83f2-2d590ca6ce78" />


- fix mouse scroll to scroll horizontall while ShiftKey is pressed