### PR TITLE
Refactor "Unique Cards Only" Setting for Mobile Editor

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/scene/AdventureDeckEditor.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/AdventureDeckEditor.java
@@ -59,7 +59,7 @@ public class AdventureDeckEditor extends FDeckEditor {
         }
 
         @Override
-        public ItemPool<PaperCard> getCardPool(boolean wantUnique) {
+        public ItemPool<PaperCard> getCardPool() {
             return Current.player().getCards();
         }
 
@@ -116,7 +116,7 @@ public class AdventureDeckEditor extends FDeckEditor {
 
         @Override public boolean usePlayerInventory() { return false; }
         @Override public boolean isLimited() { return true; }
-        @Override public ItemPool<PaperCard> getCardPool(boolean wantUnique) { return deckToPreview.getAllCardsInASinglePool(true, true); }
+        @Override public ItemPool<PaperCard> getCardPool() { return deckToPreview.getAllCardsInASinglePool(true, true); }
         @Override public boolean allowsCardReplacement() { return false; }
 
         @Override

--- a/forge-gui-mobile/src/forge/deck/FDeckEditor.java
+++ b/forge-gui-mobile/src/forge/deck/FDeckEditor.java
@@ -65,8 +65,8 @@ public class FDeckEditor extends TabPageScreen<FDeckEditor> {
             return gameType == null ? null : gameType.getDeckFormat();
         }
 
-        public ItemPool<PaperCard> getCardPool(boolean wantUnique) {
-            return wantUnique ? FModel.getUniqueCardsNoAlt() : FModel.getAllCardsNoAlt();
+        public ItemPool<PaperCard> getCardPool() {
+            return FModel.getAllCardsNoAlt();
         }
         protected Predicate<PaperCard> getCardFilter() { return null; }
 
@@ -171,10 +171,10 @@ public class FDeckEditor extends TabPageScreen<FDeckEditor> {
         @Override public boolean hasCommander() { return deckFormat.hasCommander(); }
 
         @Override
-        public ItemPool<PaperCard> getCardPool(boolean wantUnique) {
+        public ItemPool<PaperCard> getCardPool() {
             if(this.itemPoolSupplier != null)
                 return itemPoolSupplier.get();
-            return super.getCardPool(wantUnique);
+            return super.getCardPool();
         }
 
         @Override
@@ -1723,7 +1723,7 @@ public class FDeckEditor extends TabPageScreen<FDeckEditor> {
 
             //Clone the pool to ensure we don't mutate it by adding to or removing from this page.
             //Can override this if that behavior is desired.
-            ItemPool<PaperCard> cardPool = CardPool.createFrom(parentScreen.getEditorConfig().getCardPool(cardManager.getWantUnique()), PaperCard.class);
+            ItemPool<PaperCard> cardPool = CardPool.createFrom(parentScreen.getEditorConfig().getCardPool(), PaperCard.class);
 
             if(editorConfig.usePlayerInventory() && currentDeck != null) {
                 //Remove any items from the pool that are in the deck.
@@ -1896,8 +1896,8 @@ public class FDeckEditor extends TabPageScreen<FDeckEditor> {
                 menu.addItem(new FCheckBoxMenuItem(Forge.getLocalizer().getMessage("lblUniqueCardsOnly"), cardManager.getWantUnique(), e -> {
                     boolean wantUnique = !cardManager.getWantUnique();
                     cardManager.setWantUnique(wantUnique);
-                    refresh();
                     cardManager.getConfig().setUniqueCardsOnly(wantUnique);
+                    cardManager.refresh();
                 }));
             }
         }

--- a/forge-gui-mobile/src/forge/deck/FDeckImportDialog.java
+++ b/forge-gui-mobile/src/forge/deck/FDeckImportDialog.java
@@ -76,7 +76,7 @@ public class FDeckImportDialog extends FDialog {
         boolean replacingDeck = !currentDeck.isEmpty() || usingInventory;
         this.currentDeck = currentDeck;
         this.editorConfig = editorConfig;
-        ItemPool<PaperCard> cardPool = editorConfig.getCardPool(false);
+        ItemPool<PaperCard> cardPool = editorConfig.getCardPool();
         controller = new DeckImportController(dateTimeCheck, monthDropdown, yearDropdown, replacingDeck);
         String contents = Forge.getClipboard().getContents();
         if (contents == null)

--- a/forge-gui-mobile/src/forge/itemmanager/CardManager.java
+++ b/forge-gui-mobile/src/forge/itemmanager/CardManager.java
@@ -1,10 +1,18 @@
 package forge.itemmanager;
 
+import java.util.*;
 import java.util.Map.Entry;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multimaps;
 import forge.Graphics;
+import forge.StaticData;
 import forge.assets.FSkinColor;
 import forge.assets.FSkinFont;
+import forge.card.CardEdition;
 import forge.card.CardRenderer;
 import forge.card.CardZoom;
 import forge.item.PaperCard;
@@ -58,6 +66,77 @@ public class CardManager extends ItemManager<PaperCard> {
 
     public static AdvancedSearchFilter<PaperCard> createAdvancedSearchFilter(final ItemManager<? super PaperCard> itemManager) {
         return new AdvancedSearchFilter<>(itemManager);
+    }
+
+    @Override
+    protected Iterable<Entry<PaperCard, Integer>> getUnique(Iterable<Entry<PaperCard, Integer>> items) {
+        //TO-maybe-DO: Share logic between this and identical method in desktop.
+        ListMultimap<String, Entry<PaperCard, Integer>> entriesByName = Multimaps.newListMultimap(
+                new TreeMap<>(String.CASE_INSENSITIVE_ORDER), Lists::newArrayList);
+        for (Entry<PaperCard, Integer> item : items) {
+            final String cardName = item.getKey().getName();
+            entriesByName.put(cardName, item);
+        }
+
+        // Now we're ready to go on with retrieving cards to be returned
+        Map<PaperCard, Integer> cardsMap = new HashMap<>();
+        for (String cardName : entriesByName.keySet()) {
+            List<Entry<PaperCard, Integer>> entries = entriesByName.get(cardName);
+
+            ListMultimap<CardEdition, Entry<PaperCard, Integer>> entriesByEdition = Multimaps.newListMultimap(new HashMap<>(), Lists::newArrayList);
+            for (Entry<PaperCard, Integer> entry : entries) {
+                CardEdition ed = StaticData.instance().getCardEdition(entry.getKey().getEdition());
+                if (ed != null)
+                    entriesByEdition.put(ed, entry);
+            }
+            if (entriesByEdition.isEmpty())
+                continue;  // skip card
+
+            // Try to retain only those editions accepted by the current Card Art Preference Policy
+            Predicate<CardEdition> editionPredicate = ed -> StaticData.instance().getCardArtPreference().accept(ed);
+            List<CardEdition> acceptedEditions = entriesByEdition.keySet().stream().filter(editionPredicate).collect(Collectors.toList());
+
+            // If policy too strict, fall back to getting all editions.
+            if (acceptedEditions.isEmpty())
+                // Policy is too strict for current PaperCard in Entry. Remove any filter
+                acceptedEditions.addAll(entriesByEdition.keySet());
+
+            Entry<PaperCard, Integer> cardEntry = getCardEntryToAdd(entriesByEdition, acceptedEditions);
+            if (cardEntry != null)
+                cardsMap.put(cardEntry.getKey(), cardEntry.getValue());
+        }
+        return cardsMap.entrySet();
+    }
+
+    // Select the Card Art Entry to add, based on current Card Art Preference Order.
+    // This method will prefer the entry currently having an image. If that's not the case,
+    private Entry<PaperCard, Integer> getCardEntryToAdd(ListMultimap<CardEdition, Entry<PaperCard, Integer>> entriesByEdition,
+                                                        List<CardEdition> acceptedEditions) {
+        // Use standard sort + index, for better performance!
+        Collections.sort(acceptedEditions);
+        if (StaticData.instance().cardArtPreferenceIsLatest())
+            Collections.reverse(acceptedEditions);
+        Iterator<CardEdition> editionIterator = acceptedEditions.iterator();
+        Entry<PaperCard, Integer> candidateEntry = null;
+        Entry<PaperCard, Integer> firstCandidateEntryFound = null;
+        while (editionIterator.hasNext() && candidateEntry == null){
+            CardEdition cardEdition = editionIterator.next();
+            // These are now the entries to add to Cards Map
+            List<Entry<PaperCard, Integer>> cardEntries = entriesByEdition.get(cardEdition);
+            Iterator<Entry<PaperCard, Integer>> entriesIterator = cardEntries.iterator();
+            candidateEntry = entriesIterator.hasNext() ? entriesIterator.next() : null;
+            if (candidateEntry != null && firstCandidateEntryFound == null)
+                firstCandidateEntryFound = candidateEntry;  // save reference to the first candidate entry found!
+            while ((candidateEntry == null || !candidateEntry.getKey().hasImage()) && entriesIterator.hasNext()) {
+                candidateEntry = entriesIterator.next();
+                if (firstCandidateEntryFound == null)
+                    firstCandidateEntryFound = candidateEntry;
+            }
+
+            if (candidateEntry != null && !candidateEntry.getKey().hasImage())
+                candidateEntry = null;  // resetting for next edition
+        }
+        return candidateEntry != null ? candidateEntry : firstCandidateEntryFound;
     }
 
     @Override


### PR DESCRIPTION
Previously, when this option was set, the deck editor would handle it by fetching an abridged card pool from `FModel` and passing that off to the item manager. This caused problems with the "add additional copies" and "replace variant" options on cards already in the deck, since if "Unique Cards" was toggled on in the catalog page, it could only see the unique-only pool.

This fixes that by moving all the unique-filtering logic over to the same place where `ItemManager` applies its other filters, no longer actually reducing the card pool. The logic for doing so was transplanted directly from the desktop version - 

https://github.com/Card-Forge/forge/blob/ba4ee98c3bdd19189f58e22751a969cf894cd494/forge-gui-desktop/src/main/java/forge/itemmanager/ItemManager.java#L997-L1021

https://github.com/Card-Forge/forge/blob/ba4ee98c3bdd19189f58e22751a969cf894cd494/forge-gui-desktop/src/main/java/forge/itemmanager/CardManager.java#L57-L124

Not a perfect solution, but it seems to work, and parity between the two UI is nice when it's possible. Ideally desktop and mobile could inherit these methods from some parent interface, but that feels like a bigger project.