### PR TITLE
Flatten CIFriendly lines earlier in the build process

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,7 @@
                 <executions>
                     <execution>
                         <id>flatten</id>
-                        <phase>deploy</phase>
+                        <phase>process-resources</phase>
                         <goals>
                             <goal>flatten</goal>
                         </goals>


### PR DESCRIPTION
* Before this change, the parent maven package for forge is not given the correct value:

```
❯ ls ../maven_cache/forge/forge
'${revision}'   maven-metadata-local.xml
```

  This affects how other java packages find forge inside the maven cache. This comes up when a developer creates an ancillary java package that integrates with forge, but isn't meant to be added to forge proper with a PR for instance. The developer sees errors like this:

  ``` [ERROR] Failed to execute goal on project ForgeGuiDesktopHelper: Could not resolve dependencies for project com.krafczyk.forge:ForgeGuiDesktopHelper:jar:1.0-SNAPSHOT: Failed to collect dependencies at forge:forge-gui:jar:2.0.06-SNAPSHOT: Failed to read artifact descriptor for forge:forge-gui:jar:2.0.06-SNAPSHOT: Could not find artifact forge:forge:pom:${revision} in central (https://repo.maven.apache.org/maven2) -> [Help 1] ```