### PR TITLE
GameEventAttachment: flip oldTarget and newTarget param

### DIFF
--- a/forge-game/src/main/java/forge/game/event/GameEventCardAttachment.java
+++ b/forge-game/src/main/java/forge/game/event/GameEventCardAttachment.java
@@ -3,7 +3,7 @@ package forge.game.event;
 import forge.game.GameEntity;
 import forge.game.card.Card;
 
-public record GameEventCardAttachment(Card equipment, GameEntity newTarget, GameEntity oldEntity) implements GameEvent {
+public record GameEventCardAttachment(Card equipment, GameEntity oldEntity, GameEntity newTarget) implements GameEvent {
 
     @Override
     public <T> T visit(IGameEventVisitor<T> visitor) {


### PR DESCRIPTION
Closes #8672

@CTimmerman the params looked right before, just the one in the Event was wrong?
i checked the four places where this is used?


Hm:
unattachFromEntity does fire GameEventCardAttachment twice
```java
        entity.removeAttachedCard(this);

        // Handle Bestowed Aura part
        unanimateBestow();

        getGame().fireEvent(new GameEventCardAttachment(this, entity, null));

```