### PR TITLE
Cleanup 2025-09-23

### DIFF
--- a/forge-gui/res/cardsfolder/a/avatar_aang_aang_master_of_elements.txt
+++ b/forge-gui/res/cardsfolder/a/avatar_aang_aang_master_of_elements.txt
@@ -7,7 +7,7 @@ K:Firebending:2
 T:Mode$ ElementalBend | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ Whenever you waterbend, earthbend, firebend, or airbend, draw a card. Then if you've done all four this turn, transform CARDNAME.
 SVar:TrigDraw:DB$ Draw | SubAbility$ DBTransform
 SVar:DBTransform:DB$ SetState | Defined$ Self | Mode$ Transform | ConditionCheckSVar$ X
-X:Count$AllFourBend.1.0
+SVar:X:Count$AllFourBend.1.0
 Oracle:Flying, firebending 2\nWhenever you waterbend, earthbend, firebend, or airbend, draw a card. Then if you've done all four this turn, transform Avatar Aang.
 
 ALTERNATE

--- a/forge-gui/res/cardsfolder/b/bagel_and_schmear.txt
+++ b/forge-gui/res/cardsfolder/b/bagel_and_schmear.txt
@@ -1,8 +1,8 @@
 Name:Bagel and Schmear
 ManaCost:1
 Types:Artifact Food
-A:AB$ PutCounter | PreCostDesc$ Share — | Cost$ W T Sac<1/CARDNAME> | TargetMin$ 0 | TargetMax$ 1 | ValidTgts$ Creature | TgtPrompt$ Select target creature | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBDraw | SorcerySpeed$ True | SpellDescription$ Put a +1/+1 counter on up to one target creature. Draw a card. Activate only as a sorcery.
-A:AB$ GainLife | PreCostDesc$ Nosh — | Cost$ 2 T Sac<1/CARDNAME> | LifeAmount$ 3 | SubAbility$ DBDraw | SpellDescription$ You gain 3 life and draw a card.
+A:AB$ PutCounter | PrecostDesc$ Share — | Cost$ W T Sac<1/CARDNAME> | TargetMin$ 0 | TargetMax$ 1 | ValidTgts$ Creature | TgtPrompt$ Select target creature | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBDraw | SorcerySpeed$ True | SpellDescription$ Put a +1/+1 counter on up to one target creature. Draw a card. Activate only as a sorcery.
+A:AB$ GainLife | PrecostDesc$ Nosh — | Cost$ 2 T Sac<1/CARDNAME> | LifeAmount$ 3 | SubAbility$ DBDraw | SpellDescription$ You gain 3 life and draw a card.
 SVar:DBDraw:DB$ Draw
 DeckHas:Ability$LifeGain|Sacrifice|Counters
 Oracle:Share — {W}, {T}, Sacrifice this artifact: Put a +1/+1 counter on up to one target creature. Draw a card. Activate only as a sorcery.\nNosh — {2}, {T}, Sacrifice this artifact: You gain 3 life and draw a card.

--- a/forge-gui/res/cardsfolder/b/ballad_of_the_black_flag.txt
+++ b/forge-gui/res/cardsfolder/b/ballad_of_the_black_flag.txt
@@ -5,6 +5,6 @@ K:Chapter:4:DBMill,DBMill,DBMill,DBCostReduction
 SVar:DBMill:DB$ Mill | NumCards$ 3 | Defined$ You | Imprint$ True | SubAbility$ DBChangeZone
 SVar:DBChangeZone:DB$ ChangeZone | Origin$ Graveyard,Exile | Destination$ Hand | ChangeType$ Card.Historic+YouOwn+IsImprinted | Hidden$ True | Optional$ True | SubAbility$ DBCleanup | SpellDescription$ Mill three cards. You may put a historic card from among them into your hand. (Artifacts, legendaries, and Sagas are historic.)
 SVar:DBCleanup:DB$ Cleanup | ClearImprinted$ True
-SVar:DBCostReduction:DB$ Effect | StaticAbilities$ ReduceSPcost
-SVar:ReduceSPcost:Mode$ ReduceCost | ValidCard$ Card.Historic | Type$ Spell | Activator$ You | Amount$ 2 | Description$ Historic spells you cast this turn cost {2} less to cast.
+SVar:DBCostReduction:DB$ Effect | StaticAbilities$ ReduceSPCost
+SVar:ReduceSPCost:Mode$ ReduceCost | ValidCard$ Card.Historic | Type$ Spell | Activator$ You | Amount$ 2 | Description$ Historic spells you cast this turn cost {2} less to cast.
 Oracle:(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI, II, III — Mill three cards. You may put a historic card from among them into your hand. (Artifacts, legendaries, and Sagas are historic.)\nIV — Historic spells you cast this turn cost {2} less to cast.

--- a/forge-gui/res/cardsfolder/b/bloodpyre_elemental.txt
+++ b/forge-gui/res/cardsfolder/b/bloodpyre_elemental.txt
@@ -2,6 +2,6 @@ Name:Bloodpyre Elemental
 ManaCost:4 R
 Types:Creature Elemental
 PT:4/1
-A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 4 | SorcerySpeed$ True | SpellDescription$ It deals 4 damage to target creature. Activate only any time you could cast a sorcery.
+A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 4 | SorcerySpeed$ True | SpellDescription$ It deals 4 damage to target creature. Activate only as a sorcery.
 DeckHas:Ability$Sacrifice
 Oracle:Sacrifice Bloodpyre Elemental: It deals 4 damage to target creature. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/b/bound_determined.txt
+++ b/forge-gui/res/cardsfolder/b/bound_determined.txt
@@ -15,7 +15,7 @@ ALTERNATE
 Name:Determined
 ManaCost:G U
 Types:Instant
-A:SP$ Effect | ReplacementEffects$ CantbeCountered | SubAbility$ DBDraw | SpellDescription$ Other spells you control can't be countered this turn. Draw a card.
-SVar:CantbeCountered:Event$ Counter | ValidSA$ Spell.YouCtrl | Layer$ CantHappen | Description$ Other spells you control can't be countered this turn.
+A:SP$ Effect | ReplacementEffects$ CantBeCountered | SubAbility$ DBDraw | SpellDescription$ Other spells you control can't be countered this turn. Draw a card.
+SVar:CantBeCountered:Event$ Counter | ValidSA$ Spell.YouCtrl | Layer$ CantHappen | Description$ Other spells you control can't be countered this turn.
 SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1
 Oracle:Other spells you control can't be countered this turn.\nDraw a card.

--- a/forge-gui/res/cardsfolder/c/cloakwood_swarmkeeper.txt
+++ b/forge-gui/res/cardsfolder/c/cloakwood_swarmkeeper.txt
@@ -2,8 +2,8 @@ Name:Cloakwood Swarmkeeper
 ManaCost:G
 Types:Creature Elf Ranger
 PT:1/1
-T:Mode$ ChangesZoneAll | ValidCards$ Card.token+YouCtrl | Destination$ Battlefield | TriggerZones$ Battlefield | Execute$ TrigPutcounter | TriggerDescription$ Gathered Swarm — Whenever one or more tokens you control enter, put a +1/+1 counter on CARDNAME.
-SVar:TrigPutcounter:DB$ PutCounter | CounterType$ P1P1 | Defined$ Self | CounterNum$ 1
+T:Mode$ ChangesZoneAll | ValidCards$ Card.token+YouCtrl | Destination$ Battlefield | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Gathered Swarm — Whenever one or more tokens you control enter, put a +1/+1 counter on CARDNAME.
+SVar:TrigPutCounter:DB$ PutCounter | CounterType$ P1P1 | Defined$ Self | CounterNum$ 1
 DeckHints:Ability$Token
 DeckHas:Ability$Counters
 Oracle:Gathered Swarm — Whenever one or more tokens you control enter, put a +1/+1 counter on Cloakwood Swarmkeeper.

--- a/forge-gui/res/cardsfolder/c/corpse_traders.txt
+++ b/forge-gui/res/cardsfolder/c/corpse_traders.txt
@@ -2,6 +2,6 @@ Name:Corpse Traders
 ManaCost:3 B
 Types:Creature Human Rogue
 PT:3/3
-A:AB$ Discard | Cost$ 2 B Sac<1/Creature> | ValidTgts$ Player | Mode$ RevealYouChoose | NumCards$ 1 | SorcerySpeed$ True | SpellDescription$ Target player reveals their hand. You choose a card from it. That player discards that card. Activate only any time you could cast a sorcery.
+A:AB$ Discard | Cost$ 2 B Sac<1/Creature> | ValidTgts$ Player | Mode$ RevealYouChoose | NumCards$ 1 | SorcerySpeed$ True | SpellDescription$ Target player reveals their hand. You choose a card from it. That player discards that card. Activate only as a sorcery.
 AI:RemoveDeck:All
 Oracle:{2}{B}, Sacrifice a creature: Target opponent reveals their hand. You choose a card from it. That player discards that card. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/d/daily_bugle_building.txt
+++ b/forge-gui/res/cardsfolder/d/daily_bugle_building.txt
@@ -3,6 +3,6 @@ ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ 1 T | Produced$ Any | Amount$ 1 | SpellDescription$ Add one mana of any color.
-A:AB$ Pump | PreCostDesc$ Smear Campaign — | Cost$ 1 T | ValidTgts$ Creature.Legendary | TgtPrompt$ Select target legendary creature | KW$ Menace | SorcerySpeed$ True | SpellDescription$ Target legendary creature gains menace until end of turn. Activate only as a sorcery.
+A:AB$ Pump | PrecostDesc$ Smear Campaign — | Cost$ 1 T | ValidTgts$ Creature.Legendary | TgtPrompt$ Select target legendary creature | KW$ Menace | SorcerySpeed$ True | SpellDescription$ Target legendary creature gains menace until end of turn. Activate only as a sorcery.
 DeckHints:Type$Legendary
 Oracle:{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\nSmear Campaign — {1}, {T}: Target legendary creature gains menace until end of turn. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/d/draining_whelk.txt
+++ b/forge-gui/res/cardsfolder/d/draining_whelk.txt
@@ -5,8 +5,8 @@ PT:1/1
 K:Flash
 K:Flying
 T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigCounter | TriggerDescription$ When CARDNAME enters, counter target spell. Put X +1/+1 counters on CARDNAME, where X is that spell's mana value.
-SVar:TrigCounter:DB$ Counter | TargetType$ Spell | ValidTgts$ Card | TgtPrompt$ Select target spell | RememberCounteredCMC$ True | SubAbility$ DBPutcounter
-SVar:DBPutcounter:DB$ PutCounter | CounterType$ P1P1 | Defined$ Self | CounterNum$ X | SubAbility$ DBCleanup
+SVar:TrigCounter:DB$ Counter | TargetType$ Spell | ValidTgts$ Card | TgtPrompt$ Select target spell | RememberCounteredCMC$ True | SubAbility$ DBPutCounter
+SVar:DBPutCounter:DB$ PutCounter | CounterType$ P1P1 | Defined$ Self | CounterNum$ X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Count$RememberedNumber
 Oracle:Flash\nFlying\nWhen Draining Whelk enters, counter target spell. Put X +1/+1 counters on Draining Whelk, where X is that spell's mana value.

--- a/forge-gui/res/cardsfolder/e/eliminate_the_impossible.txt
+++ b/forge-gui/res/cardsfolder/e/eliminate_the_impossible.txt
@@ -2,7 +2,7 @@ Name:Eliminate the Impossible
 ManaCost:1 U
 Types:Instant
 A:SP$ Investigate | SubAbility$ DBDebuff | SpellDescription$ Investigate. Creatures your opponents control get -2/-0 until end of turn. If any of them are suspected, they're no longer suspected. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
-SVar:DBDebuff:DB$ PumpAll | ValidCards$ Creature.OppCtrl | NumAtt$ -2 | SubAbility$ DBAlterAtribute
-SVar:DBAlterAtribute:DB$ AlterAttribute | Defined$ Valid Creature.OppCtrl+IsSuspected | Attributes$ Suspected | Activate$ False
+SVar:DBDebuff:DB$ PumpAll | ValidCards$ Creature.OppCtrl | NumAtt$ -2 | SubAbility$ DBAlterAttribute
+SVar:DBAlterAttribute:DB$ AlterAttribute | Defined$ Valid Creature.OppCtrl+IsSuspected | Attributes$ Suspected | Activate$ False
 DeckHas:Ability$Token & Type$Artifact|Clue
 Oracle:Investigate. Creatures your opponents control get -2/-0 until end of turn. If any of them are suspected, they're no longer suspected. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")

--- a/forge-gui/res/cardsfolder/e/eye_for_an_eye.txt
+++ b/forge-gui/res/cardsfolder/e/eye_for_an_eye.txt
@@ -4,8 +4,8 @@ Types:Instant
 A:SP$ ChooseSource | Choices$ Card,Emblem | AILogic$ NeedsPrevention | SubAbility$ DBEffect | SpellDescription$ The next time a source of your choice would deal damage to you this turn, instead that source deals that much damage to you and CARDNAME deals that much damage to that source's controller.
 SVar:DBEffect:DB$ Effect | ReplacementEffects$ SelflessDamage | ImprintCards$ Self | ConditionDefined$ ChosenCard | ConditionPresent$ Card,Emblem | ConditionCompare$ GE1
 SVar:SelflessDamage:Event$ DamageDone | ValidTarget$ You | ValidSource$ Card.ChosenCardStrict,Emblem.ChosenCard | ReplaceWith$ SelflessDmg | Description$ The next time a source of your choice would deal damage to you this turn, instead that source deals that much damage to you and this card deals that much damage to that source's controller.
-SVar:SelflessDmg:DB$ ReplaceEffect | VarName$ Affected | VarValue$ You | VarType$ Player | SubAbility$ EyeforEye
-SVar:EyeforEye:DB$ DealDamage | Defined$ ReplacedSourceController | DamageSource$ EffectSource | NumDmg$ X | SubAbility$ ExileEffect
+SVar:SelflessDmg:DB$ ReplaceEffect | VarName$ Affected | VarValue$ You | VarType$ Player | SubAbility$ EyeForEye
+SVar:EyeForEye:DB$ DealDamage | Defined$ ReplacedSourceController | DamageSource$ EffectSource | NumDmg$ X | SubAbility$ ExileEffect
 SVar:ExileEffect:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 SVar:X:ReplaceCount$DamageAmount
 Oracle:The next time a source of your choice would deal damage to you this turn, instead that source deals that much damage to you and Eye for an Eye deals that much damage to that source's controller.

--- a/forge-gui/res/cardsfolder/f/flaxen_intruder_welcome_home.txt
+++ b/forge-gui/res/cardsfolder/f/flaxen_intruder_welcome_home.txt
@@ -2,8 +2,8 @@ Name:Flaxen Intruder
 ManaCost:G
 Types:Creature Human Berserker
 PT:1/2
-T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ Trigtrig | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, you may sacrifice it. When you do, destroy target artifact or enchantment.
-SVar:Trigtrig:AB$ ImmediateTrigger | Cost$ Sac<1/CARDNAME> | Execute$ TrigDestroy | TriggerDescription$ When you do, destroy target artifact or enchantment.
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigTrig | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, you may sacrifice it. When you do, destroy target artifact or enchantment.
+SVar:TrigTrig:AB$ ImmediateTrigger | Cost$ Sac<1/CARDNAME> | Execute$ TrigDestroy | TriggerDescription$ When you do, destroy target artifact or enchantment.
 SVar:TrigDestroy:DB$ Destroy | ValidTgts$ Artifact,Enchantment | TgtPrompt$ Select target artifact or enchantment
 AlternateMode:Adventure
 Oracle:Whenever Flaxen Intruder deals combat damage to a player, you may sacrifice it. When you do, destroy target artifact or enchantment.

--- a/forge-gui/res/cardsfolder/f/frankensteins_monster.txt
+++ b/forge-gui/res/cardsfolder/f/frankensteins_monster.txt
@@ -4,8 +4,8 @@ Types:Creature Zombie
 PT:0/1
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplaceWith$ ExileCreature | Description$ As CARDNAME enters, exile X creature cards from your graveyard. If you can't, put CARDNAME into its owner's graveyard instead of onto the battlefield. For each creature card exiled this way, CARDNAME enters with a +2/+0, +1/+1, or +0/+2 counter on it.
 SVar:ExileCreature:DB$ ChooseCard | ETB$ True | Choices$ Creature.YouOwn+NotDefinedReplacedSimultaneousETB | ChoiceZone$ Graveyard | Amount$ X | Mandatory$ True | ConditionCheckSVar$ CheckYard | ConditionSVarCompare$ GEX | SubAbility$ DBExile
-SVar:DBExile:DB$ ChangeZone | Defined$ ChosenCard | Origin$ Graveyard | Destination$ Exile | RememberChanged$ True | SubAbility$ Movetoyard
-SVar:Movetoyard:DB$ ChangeZone | Hidden$ True | Origin$ All | Destination$ Graveyard | Defined$ Self | ConditionCheckSVar$ CheckExiled | ConditionSVarCompare$ LTX | Imprint$ True | ETB$ True | SubAbility$ DBChooseCounter
+SVar:DBExile:DB$ ChangeZone | Defined$ ChosenCard | Origin$ Graveyard | Destination$ Exile | RememberChanged$ True | SubAbility$ MoveToYard
+SVar:MoveToYard:DB$ ChangeZone | Hidden$ True | Origin$ All | Destination$ Graveyard | Defined$ Self | ConditionCheckSVar$ CheckExiled | ConditionSVarCompare$ LTX | Imprint$ True | ETB$ True | SubAbility$ DBChooseCounter
 SVar:DBChooseCounter:DB$ PutCounter | CounterTypes$ P2P0,P1P1,P0P2 | CounterNum$ X | SplitAmount$ True | ETB$ True | ConditionDefined$ Imprinted | ConditionPresent$ Card | ConditionCompare$ EQ0 | SubAbility$ DBUpdate
 SVar:DBUpdate:DB$ ReplaceEffect | ConditionDefined$ Imprinted | ConditionPresent$ Card | ConditionCompare$ EQ0 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearImprinted$ True

--- a/forge-gui/res/cardsfolder/g/gryffs_boon.txt
+++ b/forge-gui/res/cardsfolder/g/gryffs_boon.txt
@@ -4,6 +4,6 @@ Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Pump
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | AddKeyword$ Flying | Description$ Enchanted creature gets +1/+0 and has flying.
-A:AB$ Pump | Cost$ 3 W | ActivationZone$ Graveyard | ValidTgts$ Creature | SorcerySpeed$ True | TgtPrompt$ Choose a creature | SubAbility$ DBChange | SpellDescription$ Return CARDNAME from your graveyard to the battlefield attached to target creature. Activate only any time you could cast a sorcery. | StackDescription$ SpellDescription
-SVar:DBChange:DB$ ChangeZone | Defined$ Self | Origin$ Graveyard | Destination$ Battlefield | AttachedTo$ ParentTarget | SpellDescription$ | StackDescription$ SpellDescription
+A:AB$ Pump | Cost$ 3 W | ActivationZone$ Graveyard | ValidTgts$ Creature | SorcerySpeed$ True | TgtPrompt$ Choose a creature | SubAbility$ DBChange | StackDescription$ REP Return_{p:You} returns & from your_from their & to target creature. Activate only as a sorcery._to {c:Targeted}. | SpellDescription$ Return CARDNAME from your graveyard to the battlefield attached to target creature. Activate only as a sorcery.
+SVar:DBChange:DB$ ChangeZone | Defined$ Self | Origin$ Graveyard | Destination$ Battlefield | AttachedTo$ ParentTarget | StackDescription$ None
 Oracle:Enchant creature\nEnchanted creature gets +1/+0 and has flying.\n{3}{W}: Return Gryff's Boon from your graveyard to the battlefield attached to target creature. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/i/ignoble_soldier.txt
+++ b/forge-gui/res/cardsfolder/i/ignoble_soldier.txt
@@ -2,8 +2,8 @@ Name:Ignoble Soldier
 ManaCost:2 W
 Types:Creature Human Soldier
 PT:3/1
-T:Mode$ AttackerBlocked | ValidCard$ Card.Self | Execute$ TrigNodamage | TriggerDescription$ Whenever CARDNAME becomes blocked, prevent all combat damage that would be dealt by it this turn.
-SVar:TrigNodamage:DB$ Effect | ReplacementEffects$ RPrevent | RememberObjects$ TriggeredAttackerLKICopy | ExileOnMoved$ Battlefield
+T:Mode$ AttackerBlocked | ValidCard$ Card.Self | Execute$ TrigNoDamage | TriggerDescription$ Whenever CARDNAME becomes blocked, prevent all combat damage that would be dealt by it this turn.
+SVar:TrigNoDamage:DB$ Effect | ReplacementEffects$ RPrevent | RememberObjects$ TriggeredAttackerLKICopy | ExileOnMoved$ Battlefield
 SVar:RPrevent:Event$ DamageDone | Prevent$ True | IsCombat$ True | ValidSource$ Card.IsRemembered | Description$ Prevent all combat damage that would be dealt by it this turn.
 SVar:MustBeBlocked:True
 Oracle:Whenever Ignoble Soldier becomes blocked, prevent all combat damage that would be dealt by it this turn.

--- a/forge-gui/res/cardsfolder/i/immersturm_skullcairn.txt
+++ b/forge-gui/res/cardsfolder/i/immersturm_skullcairn.txt
@@ -4,7 +4,7 @@ Types:Land
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 A:AB$ Mana | Cost$ T | Produced$ B | SpellDescription$ Add {B}.
-A:AB$ DealDamage | Cost$ 1 B R R T Sac<1/CARDNAME> | ValidTgts$ Player | TgtPrompt$ Select target player | NumDmg$ 3 | SubAbility$ DBDiscard | SorcerySpeed$ True | SpellDescription$ It deals 3 damage to target player. That player discards a card. Activate only any time you could cast a sorcery.
+A:AB$ DealDamage | Cost$ 1 B R R T Sac<1/CARDNAME> | ValidTgts$ Player | TgtPrompt$ Select target player | NumDmg$ 3 | SubAbility$ DBDiscard | SorcerySpeed$ True | SpellDescription$ It deals 3 damage to target player. That player discards a card. Activate only as a sorcery.
 SVar:DBDiscard:DB$ Discard | Defined$ TargetedPlayer | NumCards$ 1 | Mode$ TgtChoose
 DeckHas:Ability$Sacrifice
 Oracle:Immersturm Skullcairn enters tapped.\n{T}: Add {B}.\n{1}{B}{R}{R}, {T}, Sacrifice Immersturm Skullcairn: It deals 3 damage to target player. That player discards a card. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/i/izzet_steam_maze.txt
+++ b/forge-gui/res/cardsfolder/i/izzet_steam_maze.txt
@@ -4,7 +4,7 @@ Types:Plane Ravnica
 T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ Player | Execute$ TrigCopy | TriggerZones$ Command | TriggerDescription$ Whenever a player casts an instant or sorcery spell, that player copies it. The player may choose new targets for the copy.
 SVar:TrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | Controller$ TriggeredActivator | MayChooseTarget$ True
 T:Mode$ ChaosEnsues | TriggerZones$ Command | Execute$ RolledChaos | TriggerDescription$ Whenever chaos ensues, instant and sorcery spells you cast this turn cost {3} less to cast.
-SVar:RolledChaos:DB$ Effect | StaticAbilities$ ReduceSPcost
-SVar:ReduceSPcost:Mode$ ReduceCost | ValidCard$ Instant,Sorcery | Type$ Spell | Activator$ You | Amount$ 3 | Description$ Instant and sorcery spells you cast this turn cost {3} less to cast.
+SVar:RolledChaos:DB$ Effect | StaticAbilities$ ReduceSPCost
+SVar:ReduceSPCost:Mode$ ReduceCost | ValidCard$ Instant,Sorcery | Type$ Spell | Activator$ You | Amount$ 3 | Description$ Instant and sorcery spells you cast this turn cost {3} less to cast.
 SVar:AIRollPlanarDieParams:Mode$ Always | RollInMain1$ True
 Oracle:Whenever a player casts an instant or sorcery spell, that player copies it. The player may choose new targets for the copy.\nWhenever chaos ensues, instant and sorcery spells you cast this turn cost {3} less to cast.

--- a/forge-gui/res/cardsfolder/l/luminescent_rain.txt
+++ b/forge-gui/res/cardsfolder/l/luminescent_rain.txt
@@ -1,8 +1,8 @@
 Name:Luminescent Rain
 ManaCost:2 G
 Types:Instant
-A:SP$ ChooseType | Defined$ You | Type$ Creature | AILogic$ MostProminentComputerControls | SubAbility$ DBGainlife | SpellDescription$ Choose a creature type. You gain 2 life for each permanent you control of that type.
-SVar:DBGainlife:DB$ Gainlife | LifeAmount$ X | StackDescription$ You gain 2 life for each permanent you control of that type.
+A:SP$ ChooseType | Defined$ You | Type$ Creature | AILogic$ MostProminentComputerControls | SubAbility$ DBGainLife | SpellDescription$ Choose a creature type. You gain 2 life for each permanent you control of that type.
+SVar:DBGainLife:DB$ GainLife | LifeAmount$ X | StackDescription$ You gain 2 life for each permanent you control of that type.
 SVar:X:Count$Valid Permanent.ChosenType+YouCtrl/Times.2
 SVar:NeedsToPlay:Creature
 Oracle:Choose a creature type. You gain 2 life for each permanent you control of that type.

--- a/forge-gui/res/cardsfolder/m/march_toward_perfection.txt
+++ b/forge-gui/res/cardsfolder/m/march_toward_perfection.txt
@@ -7,6 +7,6 @@ SVar:ReplEffAddCounter:DB$ Effect | ReplacementEffects$ ETBAddCounter | Remember
 SVar:ETBAddCounter:Event$ Moved | Origin$ Stack | Destination$ Battlefield | ValidCard$ Card.IsRemembered | ReplaceWith$ ETBAddExtraCounter | ReplacementResult$ Updated
 SVar:ETBAddExtraCounter:DB$ PutCounter | ETB$ True | Defined$ ReplacedCard | CounterTypes$ P1P1,Deathtouch | CounterNum$ 1
 SVar:DBDraft:DB$ Draft | Spellbook$ Entomber Exarch,Phyrexian Fleshgorger,Phyrexian Gargantua,Phyrexian Obliterator,Phyrexian Rager,Phyrexian Revoker,Toxic Abomination,Vault Skirge,Scrapwork Rager,Bilious Skulldweller,Archfiend of the Dross,Myr Convert,Zenith Chronicler,Soulless Jailer,Diminished Returner | SpellDescription$ Draft a card from CARDNAME's spellbook.
-DeckHas:Ability$Counters|Lifegain|Graveyard & Type$Phyrexian|Horror|Imp|Zombie|Insect|Demon|Insect
+DeckHas:Ability$Counters|LifeGain|Graveyard & Type$Phyrexian|Horror|Imp|Zombie|Insect|Demon|Insect
 DeckNeeds:Type$Phyrexian
 Oracle:You get a boon with "When you cast your next Phyrexian creature spell, that creature enters with an additional +1/+1 counter and deathtouch counter on it."\nDraft a card from March Toward Perfection's spellbook.

--- a/forge-gui/res/cardsfolder/m/mindwhip_sliver.txt
+++ b/forge-gui/res/cardsfolder/m/mindwhip_sliver.txt
@@ -3,5 +3,5 @@ ManaCost:2 B
 Types:Creature Sliver
 PT:2/2
 S:Mode$ Continuous | Affected$ Sliver | AddAbility$ Discard | Description$ All Slivers have "{2}, Sacrifice this permanent: Target player discards a card at random. Activate only as a sorcery."
-SVar:Discard:AB$ Discard | Cost$ 2 Sac<1/CARDNAME> | ValidTgts$ Player | TgtPrompt$ Select target player | NumCards$ 1 | Mode$ Random | SpellDescription$ Target player discards a card at random. Activate only any time you could cast a sorcery.
+SVar:Discard:AB$ Discard | Cost$ 2 Sac<1/CARDNAME> | ValidTgts$ Player | TgtPrompt$ Select target player | NumCards$ 1 | Mode$ Random | SpellDescription$ Target player discards a card at random. Activate only as a sorcery.
 Oracle:All Slivers have "{2}, Sacrifice this permanent: Target player discards a card at random. Activate only as a sorcery."

--- a/forge-gui/res/cardsfolder/m/molten_collapse.txt
+++ b/forge-gui/res/cardsfolder/m/molten_collapse.txt
@@ -1,9 +1,9 @@
 Name:Molten Collapse
 ManaCost:B R
 Types:Sorcery
-A:SP$ Charm | MinCharmNum$ 1 | CharmNum$ Count$Compare Y GE1.2.1 | Choices$ DBDestroy,DBDsestroynoncreatue | AdditionalDescription$ . If you descended this turn, you may choose both instead. (You descended if a permanent card was put into your graveyard from anywhere.)
+A:SP$ Charm | MinCharmNum$ 1 | CharmNum$ Count$Compare Y GE1.2.1 | Choices$ DBDestroy,DBDestroyNonCreature | AdditionalDescription$ . If you descended this turn, you may choose both instead. (You descended if a permanent card was put into your graveyard from anywhere.)
 SVar:DBDestroy:DB$ Destroy | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | SpellDescription$ Destroy target creature or planeswalker.
-SVar:DBDsestroynoncreatue:DB$ Destroy | ValidTgts$ Permanent.nonCreature+nonLand+cmcLE1 | TgtPrompt$ Select target noncreature, nonland permanent with mana value 1 or less | SpellDescription$ Destroy target noncreature, nonland permanent with mana value 1 or less.
+SVar:DBDestroyNonCreature:DB$ Destroy | ValidTgts$ Permanent.nonCreature+nonLand+cmcLE1 | TgtPrompt$ Select target noncreature, nonland permanent with mana value 1 or less | SpellDescription$ Destroy target noncreature, nonland permanent with mana value 1 or less.
 SVar:Y:Count$YouDescendedThisTurn
 DeckHints:Ability$Mill|Graveyard|Dredge|Sacrifice
 Oracle:Choose one. If you descended this turn, you may choose both instead. (You descended if a permanent card was put into your graveyard from anywhere.)\n• Destroy target creature or planeswalker.\n• Destroy target noncreature, nonland permanent with mana value 1 or less.

--- a/forge-gui/res/cardsfolder/o/ob_nixilis_of_the_black_oath.txt
+++ b/forge-gui/res/cardsfolder/o/ob_nixilis_of_the_black_oath.txt
@@ -6,8 +6,8 @@ Text:CARDNAME can be your commander.
 A:AB$ LoseLife | Cost$ AddCounter<2/LOYALTY> | Planeswalker$ True | Defined$ Player.Opponent | LifeAmount$ 1 | SubAbility$ DBGainLife | SpellDescription$ Each opponent loses 1 life. You gain life equal to the life lost this way. | StackDescription$ SpellDescription
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ AFLifeLost | StackDescription$ None
 SVar:AFLifeLost:Number$0
-A:AB$ Token | Cost$ SubCounter<2/LOYALTY> | Planeswalker$ True | TokenAmount$ 1 | TokenScript$ b_5_5_demon_flying | TokenOwner$ You | SubAbility$ DBLoselife | SpellDescription$ Create a 5/5 black Demon creature token with flying. You lose 2 life.
-SVar:DBLoselife:DB$ LoseLife | LifeAmount$ 2
+A:AB$ Token | Cost$ SubCounter<2/LOYALTY> | Planeswalker$ True | TokenAmount$ 1 | TokenScript$ b_5_5_demon_flying | TokenOwner$ You | SubAbility$ DBLoseLife | SpellDescription$ Create a 5/5 black Demon creature token with flying. You lose 2 life.
+SVar:DBLoseLife:DB$ LoseLife | LifeAmount$ 2
 A:AB$ Effect | Cost$ SubCounter<8/LOYALTY> | Planeswalker$ True | Ultimate$ True | Name$ Emblem — Ob Nixilis of the Black Oath | Image$ emblem_ob_nixilis_of_the_black_oath | Stackable$ False | Abilities$ ObGainLife | Duration$ Permanent | SpellDescription$ You get an emblem with "{1}{B}, Sacrifice a creature: You gain X life and draw X cards, where X is the sacrificed creature's power."
 SVar:ObGainLife:AB$ GainLife | Cost$ 1 B Sac<1/Creature> | ActivationZone$ Command | LifeAmount$ X | SubAbility$ DBDraw | SpellDescription$ You gain X life and draw X cards, where X is the sacrificed creature's power.
 SVar:DBDraw:DB$ Draw | NumCards$ X

--- a/forge-gui/res/cardsfolder/p/perish_the_thought.txt
+++ b/forge-gui/res/cardsfolder/p/perish_the_thought.txt
@@ -1,6 +1,6 @@
 Name:Perish the Thought
 ManaCost:2 B
 Types:Sorcery
-A:SP$ RevealHand | Defined$ Targeted | ValidTgts$ Opponent | SubAbility$ ShuffleCardtoLib | StackDescription$ SpellDescription | SpellDescription$ Target opponent reveals their hand.
-SVar:ShuffleCardtoLib:DB$ ChangeZone | Origin$ Hand | Destination$ Library | DefinedPlayer$ Targeted | Chooser$ You | ChangeType$ Card | ChangeNum$ 1 | IsCurse$ True | Shuffle$ True | Mandatory$ True | AlreadyRevealed$ True | StackDescription$ SpellDescription | SpellDescription$ You choose a card from it. That player shuffles that card into their library.
+A:SP$ RevealHand | Defined$ Targeted | ValidTgts$ Opponent | SubAbility$ ShuffleCardToLib | StackDescription$ SpellDescription | SpellDescription$ Target opponent reveals their hand.
+SVar:ShuffleCardToLib:DB$ ChangeZone | Origin$ Hand | Destination$ Library | DefinedPlayer$ Targeted | Chooser$ You | ChangeType$ Card | ChangeNum$ 1 | IsCurse$ True | Shuffle$ True | Mandatory$ True | AlreadyRevealed$ True | StackDescription$ SpellDescription | SpellDescription$ You choose a card from it. That player shuffles that card into their library.
 Oracle:Target opponent reveals their hand. You choose a card from it. That player shuffles that card into their library.

--- a/forge-gui/res/cardsfolder/p/pilfering_imp.txt
+++ b/forge-gui/res/cardsfolder/p/pilfering_imp.txt
@@ -3,5 +3,5 @@ ManaCost:B
 Types:Creature Imp
 PT:1/1
 K:Flying
-A:AB$ Discard | Cost$ 1 B T Sac<1/CARDNAME> | ValidTgts$ Player | Mode$ RevealYouChoose | DiscardValid$ Card.nonLand | NumCards$ 1 | SorcerySpeed$ True | SpellDescription$ Target player reveals their hand. You choose a nonland card from it. That player discards that card. Activate only any time you could cast a sorcery.
+A:AB$ Discard | Cost$ 1 B T Sac<1/CARDNAME> | ValidTgts$ Player | Mode$ RevealYouChoose | DiscardValid$ Card.nonLand | NumCards$ 1 | SorcerySpeed$ True | SpellDescription$ Target player reveals their hand. You choose a nonland card from it. That player discards that card. Activate only as a sorcery.
 Oracle:Flying\n{1}{B}, {T}, Sacrifice Pilfering Imp: Target opponent reveals their hand. You choose a nonland card from it. That player discards that card. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/r/rakshasa_vizier.txt
+++ b/forge-gui/res/cardsfolder/r/rakshasa_vizier.txt
@@ -2,7 +2,7 @@ Name:Rakshasa Vizier
 ManaCost:2 B G U
 Types:Creature Demon
 PT:4/4
-T:Mode$ ChangesZoneAll | ValidCards$ Card.YouOwn | Origin$ Graveyard | Destination$ Exile | TriggerZones$ Battlefield | Execute$ TrigPutcounter | TriggerDescription$ Whenever one or more cards are put into exile from your graveyard, put that many +1/+1 counters on CARDNAME.
-SVar:TrigPutcounter:DB$ PutCounter | CounterType$ P1P1 | Defined$ Self | CounterNum$ X
+T:Mode$ ChangesZoneAll | ValidCards$ Card.YouOwn | Origin$ Graveyard | Destination$ Exile | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Whenever one or more cards are put into exile from your graveyard, put that many +1/+1 counters on CARDNAME.
+SVar:TrigPutCounter:DB$ PutCounter | CounterType$ P1P1 | Defined$ Self | CounterNum$ X
 SVar:X:TriggerCount$Amount
 Oracle:Whenever one or more cards are put into exile from your graveyard, put that many +1/+1 counters on Rakshasa Vizier.

--- a/forge-gui/res/cardsfolder/rebalanced/a-zar_ojanen_scion_of_efrava.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-zar_ojanen_scion_of_efrava.txt
@@ -2,9 +2,9 @@ Name:A-Zar Ojanen, Scion of Efrava
 ManaCost:3 G W
 Types:Legendary Creature Cat Warrior
 PT:4/4
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPutcounter | TriggerDescription$ Domain — Whenever CARDNAME enters or becomes tapped, put a +1/+1 counter on each creature you control with toughness less than the number of basic land types among lands you control.
-T:Mode$ Taps | ValidCard$ Card.Self | Execute$ TrigPutcounter | TriggerZones$ Battlefield | TriggerDescription$ Domain — Whenever CARDNAME enters or becomes tapped, put a +1/+1 counter on each creature you control with toughness less than the number of basic land types among lands you control.
-SVar:TrigPutcounter:DB$ PutCounterAll | ValidCards$ Creature.YouCtrl+toughnessLTX | CounterType$ P1P1 | CounterNum$ 1
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPutCounter | TriggerDescription$ Domain — Whenever CARDNAME enters or becomes tapped, put a +1/+1 counter on each creature you control with toughness less than the number of basic land types among lands you control.
+T:Mode$ Taps | ValidCard$ Card.Self | Execute$ TrigPutCounter | TriggerZones$ Battlefield | TriggerDescription$ Domain — Whenever CARDNAME enters or becomes tapped, put a +1/+1 counter on each creature you control with toughness less than the number of basic land types among lands you control.
+SVar:TrigPutCounter:DB$ PutCounterAll | ValidCards$ Creature.YouCtrl+toughnessLTX | CounterType$ P1P1 | CounterNum$ 1
 SVar:X:Count$Domain
 DeckHas:Ability$Counters
 Oracle:Domain — Whenever Zar Ojanen, Scion of Efrava enters or becomes tapped, put a +1/+1 counter on each creature you control with toughness less than the number of basic land types among lands you control.

--- a/forge-gui/res/cardsfolder/s/shimatsu_the_bloodcloaked.txt
+++ b/forge-gui/res/cardsfolder/s/shimatsu_the_bloodcloaked.txt
@@ -3,8 +3,8 @@ ManaCost:3 R
 Types:Legendary Creature Demon Spirit
 PT:0/0
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplaceWith$ TrigSac | ReplacementResult$ Updated | Description$ As CARDNAME enters, sacrifice any number of permanents. NICKNAME enters with that many +1/+1 counters on it.
-SVar:TrigSac:DB$ Sacrifice | Amount$ SacX | SacValid$ Permanent | Defined$ You | RememberSacrificed$ True | Optional$ True | SubAbility$ DBPutcounter
-SVar:DBPutcounter:DB$ PutCounter | ETB$ True | CounterType$ P1P1 | Defined$ Self | CounterNum$ X | SubAbility$ DBCleanup
+SVar:TrigSac:DB$ Sacrifice | Amount$ SacX | SacValid$ Permanent | Defined$ You | RememberSacrificed$ True | Optional$ True | SubAbility$ DBPutCounter
+SVar:DBPutCounter:DB$ PutCounter | ETB$ True | CounterType$ P1P1 | Defined$ Self | CounterNum$ X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:SacX:Count$Valid Permanent.YouCtrl
 SVar:X:Remembered$Amount

--- a/forge-gui/res/cardsfolder/s/skygames.txt
+++ b/forge-gui/res/cardsfolder/s/skygames.txt
@@ -4,6 +4,6 @@ Types:Enchantment Aura
 K:Enchant:Land
 SVar:AttachAILogic:Pump
 S:Mode$ Continuous | Affected$ Card.EnchantedBy | AddAbility$ DPTapCreature | Description$ Enchanted land has "{T}: Target creature gains flying until end of turn. Activate only as a sorcery."
-SVar:DPTapCreature:AB$ Pump | Cost$ T | ValidTgts$ Creature | TgtPrompt$ Choose target creature. | KW$ Flying | SorcerySpeed$ True | SpellDescription$ Target creature gains flying until end of turn. Activate only any time you could cast a sorcery.
+SVar:DPTapCreature:AB$ Pump | Cost$ T | ValidTgts$ Creature | TgtPrompt$ Choose target creature. | KW$ Flying | SorcerySpeed$ True | SpellDescription$ Target creature gains flying until end of turn. Activate only as a sorcery.
 SVar:NonStackingAttachEffect:True
 Oracle:Enchant land\nEnchanted land has "{T}: Target creature gains flying until end of turn. Activate only as a sorcery."

--- a/forge-gui/res/cardsfolder/s/smoldering_tar.txt
+++ b/forge-gui/res/cardsfolder/s/smoldering_tar.txt
@@ -3,6 +3,6 @@ ManaCost:2 B R
 Types:Enchantment
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigLoseLife | TriggerDescription$ At the beginning of your upkeep, target player loses 1 life.
 SVar:TrigLoseLife:DB$ LoseLife | ValidTgts$ Player | TgtPrompt$ Select a player | LifeAmount$ 1
-A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 4 | SorcerySpeed$ True | SpellDescription$ It deals 4 damage to target creature. Activate only any time you could cast a sorcery.
+A:AB$ DealDamage | Cost$ Sac<1/CARDNAME> | ValidTgts$ Creature | TgtPrompt$ Select target creature | NumDmg$ 4 | SorcerySpeed$ True | SpellDescription$ It deals 4 damage to target creature. Activate only as a sorcery.
 DeckHas:Ability$Sacrifice
 Oracle:At the beginning of your upkeep, target player loses 1 life.\nSacrifice Smoldering Tar: It deals 4 damage to target creature. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/s/squees_revenge.txt
+++ b/forge-gui/res/cardsfolder/s/squees_revenge.txt
@@ -6,8 +6,8 @@ A:SP$ ChooseNumber | SubAbility$ RepeatFlip | SpellDescription$ Choose a number.
 SVar:RepeatFlip:DB$ Repeat | RepeatSubAbility$ FlipAgain | ConditionCheckSVar$ TimesToFlip | ConditionSVarCompare$ GT0 | RepeatCheckSVar$ FlipsDone | RepeatSVarCompare$ LTTimesToFlip | SubAbility$ DrawIfWin
 SVar:FlipAgain:DB$ FlipACoin | WinSubAbility$ IncrementFlips | LoseSubAbility$ IncrementLoss
 SVar:IncrementFlips:DB$ StoreSVar | SVar$ FlipsDone | Type$ CountSVar | Expression$ FlipsDone/Plus.1
-SVar:IncrementLoss:DB$ StoreSVar | SVar$ Loss | Type$ CountSVar | Expression$ Loss/Plus.1 | SubAbility$ SetFilpsDone
-SVar:SetFilpsDone:DB$ StoreSVar | SVar$ FlipsDone | Type$ CountSVar | Expression$ TimesToFlip
+SVar:IncrementLoss:DB$ StoreSVar | SVar$ Loss | Type$ CountSVar | Expression$ Loss/Plus.1 | SubAbility$ SetFlipsDone
+SVar:SetFlipsDone:DB$ StoreSVar | SVar$ FlipsDone | Type$ CountSVar | Expression$ TimesToFlip
 # Draw cards
 SVar:DrawIfWin:DB$ Draw | Defined$ You | NumCards$ CardsToDraw | ConditionCheckSVar$ Loss | ConditionSVarCompare$ EQ0
 SVar:TimesToFlip:Count$ChosenNumber

--- a/forge-gui/res/cardsfolder/s/stalking_yeti.txt
+++ b/forge-gui/res/cardsfolder/s/stalking_yeti.txt
@@ -5,7 +5,7 @@ PT:3/3
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | IsPresent$ Card.StrictlySelf | Execute$ TrigDamage | TriggerDescription$ When CARDNAME enters, if it's on the battlefield, it deals damage equal to its power to target creature an opponent controls and that creature deals damage equal to its power to CARDNAME.
 SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | NumDmg$ X | SubAbility$ DBDamage
 SVar:DBDamage:DB$ DealDamage | Defined$ Self | DamageSource$ Targeted | NumDmg$ Y
-A:AB$ ChangeZone | Cost$ 2 S | Origin$ Battlefield | Destination$ Hand | SorcerySpeed$ True | SpellDescription$ Return CARDNAME to its owner's hand. Activate only any time you could cast a sorcery.
+A:AB$ ChangeZone | Cost$ 2 S | Origin$ Battlefield | Destination$ Hand | SorcerySpeed$ True | SpellDescription$ Return CARDNAME to its owner's hand. Activate only as a sorcery.
 SVar:X:Count$CardPower
 SVar:Y:Targeted$CardPower
 AI:RemoveDeck:All

--- a/forge-gui/res/cardsfolder/s/startled_awake_persistent_nightmare.txt
+++ b/forge-gui/res/cardsfolder/s/startled_awake_persistent_nightmare.txt
@@ -2,7 +2,7 @@ Name:Startled Awake
 ManaCost:2 U U
 Types:Sorcery
 A:SP$ Mill | NumCards$ 13 | ValidTgts$ Opponent | TgtPrompt$ Choose an opponent | SpellDescription$ Target opponent mills thirteen cards.
-A:AB$ ChangeZone | Cost$ 3 U U | Origin$ Graveyard | Destination$ Battlefield | Transformed$ True | ActivationZone$ Graveyard | SorcerySpeed$ True | SpellDescription$ Return CARDNAME from your graveyard onto the battlefield transformed. Activate only any time you could cast a sorcery.
+A:AB$ ChangeZone | Cost$ 3 U U | Origin$ Graveyard | Destination$ Battlefield | Transformed$ True | ActivationZone$ Graveyard | SorcerySpeed$ True | SpellDescription$ Return CARDNAME from your graveyard onto the battlefield transformed. Activate only as a sorcery.
 AlternateMode:DoubleFaced
 Oracle:Target opponent mills thirteen cards.\n{3}{U}{U}: Put Startled Awake from your graveyard onto the battlefield transformed. Activate only as a sorcery.
 

--- a/forge-gui/res/cardsfolder/s/stonebinders_familiar.txt
+++ b/forge-gui/res/cardsfolder/s/stonebinders_familiar.txt
@@ -2,7 +2,7 @@ Name:Stonebinder's Familiar
 ManaCost:W
 Types:Creature Spirit Dog
 PT:1/1
-T:Mode$ ChangesZoneAll | ValidCards$ Card.!token+!copiedSpell | Destination$ Exile | TriggerZones$ Battlefield | Execute$ TrigPutcounter | PlayerTurn$ True | ActivationLimit$ 1 | TriggerDescription$ Whenever one or more cards are put into exile during your turn, put a +1/+1 counter on CARDNAME. This ability triggers only once each turn.
-SVar:TrigPutcounter:DB$ PutCounter | CounterType$ P1P1 | Defined$ Self | CounterNum$ 1
+T:Mode$ ChangesZoneAll | ValidCards$ Card.!token+!copiedSpell | Destination$ Exile | TriggerZones$ Battlefield | Execute$ TrigPutCounter | PlayerTurn$ True | ActivationLimit$ 1 | TriggerDescription$ Whenever one or more cards are put into exile during your turn, put a +1/+1 counter on CARDNAME. This ability triggers only once each turn.
+SVar:TrigPutCounter:DB$ PutCounter | CounterType$ P1P1 | Defined$ Self | CounterNum$ 1
 DeckHas:Ability$Counters
 Oracle:Whenever one or more cards are put into exile during your turn, put a +1/+1 counter on Stonebinder's Familiar. This ability triggers only once each turn.

--- a/forge-gui/res/cardsfolder/s/surtland_frostpyre.txt
+++ b/forge-gui/res/cardsfolder/s/surtland_frostpyre.txt
@@ -4,6 +4,6 @@ Types:Land
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 A:AB$ Mana | Cost$ T | Produced$ R | SpellDescription$ Add {R}.
-A:AB$ Scry | Cost$ 2 U U R T Sac<1/CARDNAME> | ScryNum$ 2 | SubAbility$ DBDamageAll | SorcerySpeed$ True | SpellDescription$ Scry 2. CARDNAME deals 2 damage to each creature. Activate only any time you could cast a sorcery.
+A:AB$ Scry | Cost$ 2 U U R T Sac<1/CARDNAME> | ScryNum$ 2 | SubAbility$ DBDamageAll | SorcerySpeed$ True | SpellDescription$ Scry 2. CARDNAME deals 2 damage to each creature. Activate only as a sorcery.
 SVar:DBDamageAll:DB$ DamageAll | ValidCards$ Creature | NumDmg$ 2
 Oracle:Surtland Frostpyre enters tapped.\n{T}: Add {R}.\n{2}{U}{U}{R}, {T}, Sacrifice Surtland Frostpyre: Scry 2. Surtland Frostpyre deals 2 damage to each creature. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/t/tahngarths_glare.txt
+++ b/forge-gui/res/cardsfolder/t/tahngarths_glare.txt
@@ -1,6 +1,6 @@
 Name:Tahngarth's Glare
 ManaCost:R
 Types:Sorcery
-A:SP$ RearrangeTopOfLibrary | ValidTgts$ Opponent | NumCards$ 3 | SubAbility$ DBRearange | SpellDescription$ Look at the top three cards of target opponent's library, then put them back in any order. That player looks at the top three cards of your library, then puts them back in any order.
-SVar:DBRearange:DB$ RearrangeTopOfLibrary | Defined$ You | RearrangePlayer$ Targeted | NumCards$ 3
+A:SP$ RearrangeTopOfLibrary | ValidTgts$ Opponent | NumCards$ 3 | SubAbility$ DBRearrange | SpellDescription$ Look at the top three cards of target opponent's library, then put them back in any order. That player looks at the top three cards of your library, then puts them back in any order.
+SVar:DBRearrange:DB$ RearrangeTopOfLibrary | Defined$ You | RearrangePlayer$ Targeted | NumCards$ 3
 Oracle:Look at the top three cards of target opponent's library, then put them back in any order. That player looks at the top three cards of your library, then puts them back in any order.

--- a/forge-gui/res/cardsfolder/t/the_soul_stone.txt
+++ b/forge-gui/res/cardsfolder/t/the_soul_stone.txt
@@ -5,7 +5,7 @@ K:Indestructible
 A:AB$ Mana | Cost$ T | Produced$ B | SpellDescription$ Add {B}.
 A:AB$ AlterAttribute | Cost$ 6 B Exile<1/Creature> | Defined$ Self | Attributes$ Harnessed | StackDescription$ SpellDescription | SpellDescription$ Harness CARDNAME. (Once harnessed, its ∞ ability is active.)
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | IsPresent$ Card.Self+harnessed | TriggerZones$ Battlefield | Execute$ TrigReturn | TriggerDescription$ ∞ — At the beginning of your upkeep, return target creature card from your graveyard to the battlefield.
-SVar:TrigReturn:DB$ Changezone | ValidTgts$ Creature.YouOwn | Origin$ Graveyard | Destination$ Battlefield
+SVar:TrigReturn:DB$ ChangeZone | ValidTgts$ Creature.YouOwn | Origin$ Graveyard | Destination$ Battlefield
 SVar:PlayMain1:TRUE
 DeckHints:Ability$Graveyard
 Oracle:Indestructible\n{T}: Add {B}.\n{6}{B}, {T}, Exile a creature you control: Harness The Soul Stone. (Once harnessed, its ∞ ability is active.)\n∞ — At the beginning of your upkeep, return target creature card from your graveyard to the battlefield.

--- a/forge-gui/res/cardsfolder/t/titania_voice_of_gaea_titania_gaea_incarnate.txt
+++ b/forge-gui/res/cardsfolder/t/titania_voice_of_gaea_titania_gaea_incarnate.txt
@@ -3,8 +3,8 @@ ManaCost:1 G G
 Types:Legendary Creature Elemental
 PT:3/4
 K:Reach
-T:Mode$ ChangesZoneAll | ValidCards$ Land.YouOwn+!token | Origin$ Any | Destination$ Graveyard | TriggerZones$ Battlefield | Execute$ TrigLifegain | TriggerDescription$ Whenever one or more land cards are put into your graveyard from anywhere, you gain 2 life.
-SVar:TrigLifegain:DB$ GainLife | LifeAmount$ 2
+T:Mode$ ChangesZoneAll | ValidCards$ Land.YouOwn+!token | Origin$ Any | Destination$ Graveyard | TriggerZones$ Battlefield | Execute$ TrigGainLife | TriggerDescription$ Whenever one or more land cards are put into your graveyard from anywhere, you gain 2 life.
+SVar:TrigGainLife:DB$ GainLife | LifeAmount$ 2
 T:Mode$ Phase | Phase$ Upkeep | CheckSVar$ X | SVarCompare$ GE4 | IsPresent$ Card.Self+YouCtrl+YouOwn | IsPresent2$ Land.YouCtrl+YouOwn+namedArgoth; Sanctum of Nature | ValidPlayer$ You | Execute$ Meld | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, if there are four or more land cards in your graveyard and you both own and control CARDNAME and a land named Argoth, Sanctum of Nature, exile them, then meld them into Titania, Gaea Incarnate.
 SVar:Meld:DB$ Meld | Name$ Titania, Gaea Incarnate | Primary$ Titania, Voice of Gaea | Secondary$ Argoth, Sanctum of Nature | SecondaryType$ Land
 SVar:X:Count$ValidGraveyard Land.YouOwn

--- a/forge-gui/res/cardsfolder/t/transmogrifying_wand.txt
+++ b/forge-gui/res/cardsfolder/t/transmogrifying_wand.txt
@@ -3,5 +3,5 @@ ManaCost:3
 Types:Artifact
 K:etbCounter:CHARGE:3
 A:AB$ Destroy | Cost$ 1 T SubCounter<1/CHARGE> | ValidTgts$ Creature | AITgts$ BetterThanEvalRating.130 | TgtPrompt$ Select target creature | SorcerySpeed$ True | SubAbility$ OxToken | SpellDescription$ Destroy target creature.
-SVar:OxToken:DB$ Token | TokenAmount$ 1 | TokenScript$ w_2_4_ox | TokenOwner$ TargetedController | SpellDescription$ Its controller creates a 2/4 white Ox creature token. Activate only any time you could cast a sorcery.
+SVar:OxToken:DB$ Token | TokenAmount$ 1 | TokenScript$ w_2_4_ox | TokenOwner$ TargetedController | SpellDescription$ Its controller creates a 2/4 white Ox creature token. Activate only as a sorcery.
 Oracle:Transmogrifying Wand enters with three charge counters on it.\n{1}, {T}, Remove a charge counter from Transmogrifying Wand: Destroy target creature. Its controller creates a 2/4 white Ox creature token. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/t/trap_essence.txt
+++ b/forge-gui/res/cardsfolder/t/trap_essence.txt
@@ -1,7 +1,7 @@
 Name:Trap Essence
 ManaCost:G U R
 Types:Instant
-A:SP$ Counter | TargetType$ Spell | ValidTgts$ Card.Creature | TgtPrompt$ Select target creature spell | SpellDescription$ Counter target creature spell. Put two +1/+1 counters on up to one target creature. | SubAbility$ DBPutcounter
-SVar:DBPutcounter:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ 2 | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target creature | ValidTgts$ Creature
+A:SP$ Counter | TargetType$ Spell | ValidTgts$ Card.Creature | TgtPrompt$ Select target creature spell | SpellDescription$ Counter target creature spell. Put two +1/+1 counters on up to one target creature. | SubAbility$ DBPutCounter
+SVar:DBPutCounter:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ 2 | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target creature | ValidTgts$ Creature
 DeckHas:Ability$Counters
 Oracle:Counter target creature spell. Put two +1/+1 counters on up to one target creature.

--- a/forge-gui/res/cardsfolder/t/trickery_charm.txt
+++ b/forge-gui/res/cardsfolder/t/trickery_charm.txt
@@ -1,10 +1,10 @@
 Name:Trickery Charm
 ManaCost:U
 Types:Instant
-A:SP$ Charm | Choices$ DBPump,DBChooseType,DBRearrage
+A:SP$ Charm | Choices$ DBPump,DBChooseType,DBRearrange
 SVar:DBPump:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature | KW$ Flying | SpellDescription$ Target creature gains flying until end of turn.
 SVar:DBChooseType:DB$ ChooseType | Type$ Creature | Defined$ You | SubAbility$ DBAnimate | SpellDescription$ Target creature becomes the creature type of your choice until end of turn.
 SVar:DBAnimate:DB$ Animate | ValidTgts$ Creature | TgtPrompt$ Select target creature | Types$ ChosenType | RemoveCreatureTypes$ True
-SVar:DBRearrage:DB$ RearrangeTopOfLibrary | Defined$ You | NumCards$ 4 | SpellDescription$ Look at the top four cards of your library, then put them back in any order.
+SVar:DBRearrange:DB$ RearrangeTopOfLibrary | Defined$ You | NumCards$ 4 | SpellDescription$ Look at the top four cards of your library, then put them back in any order.
 AI:RemoveDeck:All
 Oracle:Choose one —\n• Target creature gains flying until end of turn.\n• Target creature becomes the creature type of your choice until end of turn.\n• Look at the top four cards of your library, then put them back in any order.

--- a/forge-gui/res/cardsfolder/u/undercity_necrolisk.txt
+++ b/forge-gui/res/cardsfolder/u/undercity_necrolisk.txt
@@ -2,6 +2,6 @@ Name:Undercity Necrolisk
 ManaCost:3 B
 Types:Creature Zombie Lizard
 PT:3/3
-A:AB$ PutCounter | Cost$ 1 Sac<1/Creature.Other/another creature> | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBPump | SorcerySpeed$ True | SpellDescription$ Put a +1/+1 counter on CARDNAME. It gains menace until end of turn. Activate only any time you could cast a sorcery.
+A:AB$ PutCounter | Cost$ 1 Sac<1/Creature.Other/another creature> | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBPump | SorcerySpeed$ True | SpellDescription$ Put a +1/+1 counter on CARDNAME. It gains menace until end of turn. Activate only as a sorcery.
 SVar:DBPump:DB$ Pump | KW$ Menace | Defined$ Self
 Oracle:{1}, Sacrifice another creature: Put a +1/+1 counter on Undercity Necrolisk. It gains menace until end of turn. Activate only as a sorcery. (It can't be blocked except by two or more creatures.)

--- a/forge-gui/res/cardsfolder/u/urza_academy_headmaster.txt
+++ b/forge-gui/res/cardsfolder/u/urza_academy_headmaster.txt
@@ -58,8 +58,8 @@ SVar:DBChangeLands11M:DB$ ChangeZoneAll | ChangeType$ Card.Land+IsRemembered | O
 SVar:DBChangeRest11M:DB$ ChangeZoneAll | ChangeType$ Card.IsRemembered | Origin$ Library | Destination$ Graveyard | ForgetChanged$ True
 SVar:Tutor12M:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Card | ChangeNum$ 1 | Mandatory$ True | SpellDescription$ Search your library for a card and put that card into your hand. Then shuffle your library.
 SVar:Sacrifice13M:DB$ Sacrifice | ValidTgts$ Player | Amount$ 2 | SacValid$ Creature | SpellDescription$ Target player sacrifices two creatures.
-SVar:Token14M:DB$ Token | TokenScript$ b_5_5_demon_flying | SubAbility$ DBLoselife14M | SpellDescription$ Create a 5/5 black Demon creature token with flying. You lose 2 life.
-SVar:DBLoselife14M:DB$ LoseLife | LifeAmount$ 2
+SVar:Token14M:DB$ Token | TokenScript$ b_5_5_demon_flying | SubAbility$ DBLoseLife14M | SpellDescription$ Create a 5/5 black Demon creature token with flying. You lose 2 life.
+SVar:DBLoseLife14M:DB$ LoseLife | LifeAmount$ 2
 SVar:Token15M:DB$ Token | TokenScript$ c_4_4_dragon_flying | SpellDescription$ Create a 4/4 gold Dragon creature token with flying.
 SVar:SetLife16M:DB$ SetLife | ValidTgts$ Player | TgtPrompt$ Select target player | LifeAmount$ 10 | SpellDescription$ Target player's life total becomes 10.
 SVar:Destroy17M:DB$ Destroy | ValidTgts$ Permanent.nonLand | TgtPrompt$ Select target nonland permanent | SpellDescription$ Destroy target nonland permanent.

--- a/forge-gui/res/cardsfolder/v/ventifact_bottle.txt
+++ b/forge-gui/res/cardsfolder/v/ventifact_bottle.txt
@@ -1,7 +1,7 @@
 Name:Ventifact Bottle
 ManaCost:3
 Types:Artifact
-A:AB$ PutCounter | Cost$ X 1 T | CounterType$ CHARGE | CounterNum$ X | SorcerySpeed$ True | SpellDescription$ Put X charge counters on CARDNAME. Activate only any time you could cast a sorcery.
+A:AB$ PutCounter | Cost$ X 1 T | CounterType$ CHARGE | CounterNum$ X | SorcerySpeed$ True | SpellDescription$ Put X charge counters on CARDNAME. Activate only as a sorcery.
 T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigGetMana | CheckSVar$ Y | SVarCompare$ GE1 | TriggerDescription$ At the beginning of your first main phase, if CARDNAME has a charge counter on it, tap it and remove all charge counters from it. Add {C} for each charge counter removed this way.
 SVar:TrigGetMana:DB$ Mana | Produced$ C | Amount$ Y | SubAbility$ TrigRemove
 SVar:TrigRemove:DB$ RemoveCounter | CounterType$ CHARGE | CounterNum$ Y | SubAbility$ DBTap

--- a/forge-gui/res/cardsfolder/w/woodland_champion.txt
+++ b/forge-gui/res/cardsfolder/w/woodland_champion.txt
@@ -2,8 +2,8 @@ Name:Woodland Champion
 ManaCost:1 G
 Types:Creature Elf Scout
 PT:2/2
-T:Mode$ ChangesZoneAll | ValidCards$ Card.token+YouCtrl | Destination$ Battlefield | TriggerZones$ Battlefield | Execute$ TrigPutcounter | TriggerDescription$ Whenever one or more tokens you control enter, put that many +1/+1 counters on CARDNAME.
-SVar:TrigPutcounter:DB$ PutCounter | CounterType$ P1P1 | Defined$ Self | CounterNum$ X
+T:Mode$ ChangesZoneAll | ValidCards$ Card.token+YouCtrl | Destination$ Battlefield | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Whenever one or more tokens you control enter, put that many +1/+1 counters on CARDNAME.
+SVar:TrigPutCounter:DB$ PutCounter | CounterType$ P1P1 | Defined$ Self | CounterNum$ X
 SVar:X:TriggerCount$Amount
 DeckHints:Ability$Token
 DeckHas:Ability$Counters

--- a/forge-gui/res/cardsfolder/z/zar_ojanen_scion_of_efrava.txt
+++ b/forge-gui/res/cardsfolder/z/zar_ojanen_scion_of_efrava.txt
@@ -2,8 +2,8 @@ Name:Zar Ojanen, Scion of Efrava
 ManaCost:3 G W
 Types:Legendary Creature Cat Warrior
 PT:4/4
-T:Mode$ Taps | ValidCard$ Card.Self | Execute$ TrigPutcounter | TriggerZones$ Battlefield | TriggerDescription$ Domain — Whenever CARDNAME becomes tapped, put a +1/+1 counter on each creature you control with toughness less than the number of basic land types among lands you control.
-SVar:TrigPutcounter:DB$ PutCounterAll | ValidCards$ Creature.YouCtrl+toughnessLTX | CounterType$ P1P1 | CounterNum$ 1
+T:Mode$ Taps | ValidCard$ Card.Self | Execute$ TrigPutCounter | TriggerZones$ Battlefield | TriggerDescription$ Domain — Whenever CARDNAME becomes tapped, put a +1/+1 counter on each creature you control with toughness less than the number of basic land types among lands you control.
+SVar:TrigPutCounter:DB$ PutCounterAll | ValidCards$ Creature.YouCtrl+toughnessLTX | CounterType$ P1P1 | CounterNum$ 1
 SVar:X:Count$Domain
 DeckHas:Ability$Counters
 Oracle:Domain — Whenever Zar Ojanen, Scion of Efrava becomes tapped, put a +1/+1 counter on each creature you control with toughness less than the number of basic land types among lands you control.

--- a/forge-gui/res/tokenscripts/g_x_x_treefolk_warrior_total_forests.txt
+++ b/forge-gui/res/tokenscripts/g_x_x_treefolk_warrior_total_forests.txt
@@ -3,7 +3,7 @@ ManaCost:no cost
 Colors:green
 Types:Creature Treefolk Warrior
 PT:*/*
-S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of Forests you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ This creature's power and toughness are each equal to the number of Forests you control.
 SVar:X:Count$Valid Forest.YouCtrl
 SVar:BuffedBy:Forest
-Oracle:CARDNAMEs power and toughness are each equal to the number of Forests you control.
+Oracle:This creature's power and toughness are each equal to the number of Forests you control.


### PR DESCRIPTION
Dealing with:
- Orthography, mostly capitalization: some instances with likely functional relevance (parameters) but chiefly standardizing arguments to ease future cleanups.
- Oracle update to description lines, namely "Activate only any time you could cast a sorcery" → "Activate only as a sorcery".
- A few misplaced snippets of code (Avatar Aang, Gryff's Boon).