### PR TITLE
Draft rankings for unranked cards

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/limited/CardRanker.java
+++ b/forge-gui/src/main/java/forge/gamemodes/limited/CardRanker.java
@@ -7,6 +7,7 @@ import forge.card.ColorSet;
 import forge.card.DeckHints;
 import forge.card.MagicColor;
 import forge.item.PaperCard;
+import forge.model.FModel;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.ArrayList;
@@ -150,6 +151,15 @@ public class CardRanker {
                 }
             } else {
                 rkg = DraftRankCache.getRanking(card.getName(), card.getEdition());
+                if(rkg == null){
+                    List<PaperCard> cardList = FModel.getMagicDb().getCommonCards().getAllCards(card.getName());
+                    for(PaperCard currentCard : cardList){
+                        rkg = DraftRankCache.getRanking(currentCard.getName(), currentCard.getEdition());
+                        if(rkg != null){
+                            break;
+                        }
+                    }
+                }
             }
 
             // Convert to a score from 0-100 where higher is better.


### PR DESCRIPTION
If the card in this set doesn't have a rating, checks other sets if that same card does have a rating.

Very relevant for drafting with a random selection of all cards in the game, for example. 