### PR TITLE
Fix Quest crashes

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/quest/BoosterUtils.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/BoosterUtils.java
@@ -99,7 +99,10 @@ public final class BoosterUtils {
 
         if (userPrefs != null && userPrefs.getPoolType() == StartingPoolPreferences.PoolType.BOOSTERS) {
 
-            for (InventoryItem inventoryItem : generateRandomBoosterPacks(userPrefs.getNumberOfBoosters(), formatStartingPool.editionLegalPredicate)) {
+            Predicate<CardEdition> editionLegalPredicate = formatStartingPool == null
+                    ? cardEdition -> true
+                    : formatStartingPool.editionLegalPredicate;
+            for (InventoryItem inventoryItem : generateRandomBoosterPacks(userPrefs.getNumberOfBoosters(), editionLegalPredicate)) {
                 cards.addAll(((BoosterPack) inventoryItem).getCards());
             }
 

--- a/forge-gui/src/main/java/forge/gamemodes/quest/QuestEventDraft.java
+++ b/forge-gui/src/main/java/forge/gamemodes/quest/QuestEventDraft.java
@@ -62,7 +62,6 @@ import forge.util.storage.IStorage;
 public class QuestEventDraft implements IQuestEvent {
 
     public static class QuestDraftPrizes {
-
         public int credits;
         public List<BoosterPack> boosterPacks;
         public List<PaperCard> individualCards;
@@ -85,7 +84,6 @@ public class QuestEventDraft implements IQuestEvent {
         public void addSelectedCard(final PaperCard card) {
             FModel.getQuest().getCards().addSingleCard(card, 1);
         }
-
     }
 
     public static final String UNDETERMINED = "quest_draft_undetermined_place";
@@ -233,7 +231,6 @@ public class QuestEventDraft implements IQuestEvent {
     }
 
     public void setWinner(final String playerName) {
-
         if (QuestDraftUtils.TOURNAMENT_TOGGLE) {
             TournamentPairing pairing = bracket.getNextPairing();
             for(TournamentPlayer player : pairing.getPairedPlayers()) {
@@ -290,7 +287,6 @@ public class QuestEventDraft implements IQuestEvent {
      * Generates the prizes for the player and saves them to the current quest.
      */
     public QuestDraftPrizes collectPrizes() {
-
         final int place = getPlayerPlacement();
         int prizePool = entryFee * 9;
 
@@ -345,11 +341,9 @@ public class QuestEventDraft implements IQuestEvent {
         }
 
         return null;
-
     }
 
     private QuestDraftPrizes generateFirstPlacePrizes(final int prizePool) {
-
         int credits = 2 * (prizePool / 3); //First place gets 2/3 the total prize pool
         final List<PaperCard> cards = new ArrayList<>();
         final List<BoosterPack> boosters = new ArrayList<>();
@@ -366,11 +360,9 @@ public class QuestEventDraft implements IQuestEvent {
         awardSelectedRare(prizes);
 
         return prizes;
-
     }
 
     private QuestDraftPrizes generateSecondPlacePrizes(final int prizePool) {
-
         int credits = prizePool / 3; //Second place gets 1/3 the total prize pool
         final List<PaperCard> cards = new ArrayList<>();
         final List<BoosterPack> boosters = new ArrayList<>();
@@ -388,11 +380,9 @@ public class QuestEventDraft implements IQuestEvent {
         awardSelectedRare(prizes);
 
         return prizes;
-
     }
 
     private QuestDraftPrizes generateThirdPlacePrizes() {
-
         final int credits = 0;
         final List<PaperCard> cards = new ArrayList<>();
 
@@ -407,11 +397,9 @@ public class QuestEventDraft implements IQuestEvent {
         prizes.individualCards = cards;
 
         return prizes;
-
     }
 
     private QuestDraftPrizes generateFourthPlacePrizes() {
-
         final int credits = 0;
         final List<PaperCard> cards = new ArrayList<>();
 
@@ -440,7 +428,6 @@ public class QuestEventDraft implements IQuestEvent {
     }
 
     private void awardSelectedRare(final QuestDraftPrizes prizes) {
-
         final List<PaperCard> possibleCards = new ArrayList<>();
         final List<String> cardNames = new ArrayList<>();
 
@@ -466,7 +453,6 @@ public class QuestEventDraft implements IQuestEvent {
     }
 
     private PaperCard getPromoCard() {
-
         final CardEdition randomEdition = getRandomEdition();
         final List<EditionEntry> cardsInEdition = new ArrayList<>();
         final List<String> cardNames = new ArrayList<>();
@@ -478,6 +464,11 @@ public class QuestEventDraft implements IQuestEvent {
                     cardNames.add(card.name());
                 }
             }
+        }
+
+        // For sets such as MB1 that only have cards from PLST.
+        if (cardsInEdition.isEmpty()) {
+            return FModel.getQuest().getCards().addRandomRare();
         }
 
         EditionEntry randomCard;
@@ -495,7 +486,6 @@ public class QuestEventDraft implements IQuestEvent {
         }
 
         return promo;
-
     }
 
     private CardEdition getRandomEdition() {
@@ -506,7 +496,6 @@ public class QuestEventDraft implements IQuestEvent {
         }
 
         return editions.get((int) (MyRandom.getRandom().nextDouble() * editions.size()));
-
     }
 
     private Set<CardEdition> getAllEditions() {
@@ -517,7 +506,6 @@ public class QuestEventDraft implements IQuestEvent {
         }
 
         return editions;
-
     }
 
     private static int getBoosterPrice(final BoosterPack booster) {
@@ -528,11 +516,9 @@ public class QuestEventDraft implements IQuestEvent {
         value = MAP_PRICES.getOrDefault(boosterName, 395);
 
         return value;
-
     }
 
     public boolean playerHasMatchesLeft() {
-
         if (QuestDraftUtils.TOURNAMENT_TOGGLE) {
             return !bracket.isTournamentOver() && bracket.isPlayerRemaining(-1);
         }
@@ -585,7 +571,6 @@ public class QuestEventDraft implements IQuestEvent {
         }
 
         return nextMatchIndex != -1 && standings[nextMatchIndex].equals(UNDETERMINED);
-
     }
 
     public int getPlayerPlacement() {
@@ -622,11 +607,9 @@ public class QuestEventDraft implements IQuestEvent {
         }
 
         return -1;
-
     }
 
     public String getPlacementString() {
-
         final int place = getPlayerPlacement();
 
         String output;
@@ -650,7 +633,6 @@ public class QuestEventDraft implements IQuestEvent {
         }
 
         return output;
-
     }
 
     public boolean canEnter() {
@@ -683,7 +665,6 @@ public class QuestEventDraft implements IQuestEvent {
     }
 
     public static class QuestDraftFormat implements Comparable<QuestDraftFormat> {
-
         private CardEdition edition;
         private CardBlock block;
 
@@ -746,11 +727,9 @@ public class QuestEventDraft implements IQuestEvent {
         public int compareTo(final QuestDraftFormat other) {
             return toString().compareToIgnoreCase(other.toString());
         }
-
     }
 
     private static List<CardEdition> getAllowedSets(final QuestController quest) {
-
         final List<CardEdition> allowedQuestSets = new ArrayList<>();
 
         if (quest.getFormat() != null) {
@@ -771,11 +750,9 @@ public class QuestEventDraft implements IQuestEvent {
         }
 
         return allowedQuestSets;
-
     }
 
     private static List<CardBlock> getBlocks() {
-
         final List<CardBlock> blocks = new ArrayList<>();
         final IStorage<CardBlock> storage = FModel.getBlocks();
 
@@ -786,11 +763,9 @@ public class QuestEventDraft implements IQuestEvent {
         }
 
         return blocks;
-
     }
 
     public static List<QuestDraftFormat> getAvailableFormats(final QuestController quest) {
-
         final List<CardEdition> allowedQuestSets = getAllowedSets(quest);
         final List<QuestDraftFormat> possibleFormats = new ArrayList<>();
         final List<CardBlock> blocks = getBlocks();
@@ -812,7 +787,6 @@ public class QuestEventDraft implements IQuestEvent {
                 if (blockAllowed) {
                     possibleFormats.add(new QuestDraftFormat(block));
                 } 
-
             }
 
             for (CardEdition allowedQuestSet : allowedQuestSets) {
@@ -840,7 +814,6 @@ public class QuestEventDraft implements IQuestEvent {
 
         Collections.sort(possibleFormats);
         return possibleFormats;
-
     }
 
     /**
@@ -849,7 +822,6 @@ public class QuestEventDraft implements IQuestEvent {
      * @return The created draft or null in the event no draft could be created.
      */
     public static QuestEventDraft getRandomDraftOrNull(final QuestController quest) {
-
         final List<QuestDraftFormat> possibleFormats = getAvailableFormats(quest);
 
         if (possibleFormats.isEmpty()) {
@@ -858,7 +830,6 @@ public class QuestEventDraft implements IQuestEvent {
 
         Collections.shuffle(possibleFormats);
         return getDraftOrNull(quest, possibleFormats.get(0));
-
     }
 
     /**
@@ -866,7 +837,6 @@ public class QuestEventDraft implements IQuestEvent {
      * @return The created draft or null in the event no draft could be created.
      */
     public static QuestEventDraft getDraftOrNull(final QuestController quest, final QuestDraftFormat format) {
-
         final QuestEventDraft event = new QuestEventDraft(format.getName());
 
         if (format.isSet()) {
@@ -936,13 +906,11 @@ public class QuestEventDraft implements IQuestEvent {
             event.aiIcons[i] = icon;
             usedNames.add(event.aiNames[i]);
             usedIcons.add(icon);
-
         }
 
         event.bracket = createBracketFromStandings(event.standings, event.aiNames, event.aiIcons);
 
         return event;
-
     }
 
     private static int calculateEntryFee(final String[] boosters) {
@@ -960,7 +928,6 @@ public class QuestEventDraft implements IQuestEvent {
         }
 
         return (int) (entryFee * 1.5);
-
     }
 
     private static Set<String> getSetCombos(final QuestController quest, final CardBlock block) {
@@ -1041,7 +1008,6 @@ public class QuestEventDraft implements IQuestEvent {
         }
 
         return possibleCombinations;
-
     }
 
     public static TournamentBracket createBracketFromStandings(String[] standings, String[] aiNames, int[] aiIcons) {


### PR DESCRIPTION
* Fix a crash when you start a Quest using boosters in an Unsanctioned pool.
* Fix a crash when getting rewards for a draft.