### PR TITLE
Fix AI helps opponent create an army (#8901)

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiAttackController.java
+++ b/forge-ai/src/main/java/forge/ai/AiAttackController.java
@@ -974,6 +974,16 @@ public class AiAttackController {
             return aiAggression;
         }
 
+        // Only do decisive attacks against token-generating players
+        if (!bAssault && defender instanceof Player) {
+            Player opponent = (Player)defender;
+            if (CardLists.count(ai.getCardsIn(ZoneType.Battlefield), CardPredicates.nameEquals("Rabble Rousing"))
+                - CardLists.count(opponent.getCardsIn(ZoneType.Battlefield), CardPredicates.nameEquals("Darien, King of Kjeldor"))
+                - CardLists.count(opponent.getCardsIn(ZoneType.Battlefield), CardPredicates.nameEquals("Kazuul, Tyrant of the Cliffs")) < 0) {
+                    return aiAggression;
+                }
+        }
+
         if (bAssault && defender == defendingOpponent) { // in case we are forced to attack someone else
             if (LOG_AI_ATTACKS)
                 System.out.println("Assault");


### PR DESCRIPTION
Only decisively attack a player who generates tokens on being attacked or damaged.

<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/9b9e36d1-0cf5-46bd-989f-f39478efa09b" />
Now Darien & Kazuul mostly just delay the inevitable instead of turning the tide.