### PR TITLE
Update consuming_ferocity.txt

### DIFF
--- a/forge-gui/res/cardsfolder/c/consuming_ferocity.txt
+++ b/forge-gui/res/cardsfolder/c/consuming_ferocity.txt
@@ -6,7 +6,7 @@ SVar:AttachAILogic:Curse
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | Description$ Enchanted creature gets +1/+0.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ At the beginning of your upkeep, put a +1/+0 counter on enchanted creature. If that creature has three or more +1/+0 counters on it, it deals damage equal to its power to its controller, then destroy that creature and it can't be regenerated.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Enchanted | CounterType$ P1P0 | CounterNum$ 1 | SubAbility$ DBDmg
-SVar:DBDmg:DB$ DealDamage | Defined$ TriggeredPlayer | DamageSource$ Enchanted | NumDmg$ X | ConditionCheckSVar$ Y | ConditionSVarCompare$ GE3 | SubAbility$ DBDes
+SVar:DBDmg:DB$ DealDamage | Defined$ EnchantedController | DamageSource$ Enchanted | NumDmg$ X | ConditionCheckSVar$ Y | ConditionSVarCompare$ GE3 | SubAbility$ DBDes
 SVar:DBDes:DB$ Destroy | Defined$ Enchanted | NoRegen$ True | ConditionCheckSVar$ Y | ConditionSVarCompare$ GE3
 SVar:Y:Count$Valid Creature.EnchantedBy$CardCounters.P1P0
 SVar:X:Enchanted$CardPower


### PR DESCRIPTION
Closes https://github.com/Card-Forge/forge/issues/8911

[Consuming Ferocity](https://github.com/Card-Forge/forge/blob/master/forge-gui/res/cardsfolder/c/consuming_ferocity.txt)'s trigger was dealing damage to the Aura's controller instead of the creature's controller. The fix herein, replacing `TriggeredPlayer` with `EnchantedController` on the relevant line per [Gremlin Infestation](https://github.com/Card-Forge/forge/blob/master/forge-gui/res/cardsfolder/g/gremlin_infestation.txt), was tested to satisfaction.