### PR TITLE
Fix Elturel Survivors not played (#8920)

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiAttackController.java
+++ b/forge-ai/src/main/java/forge/ai/AiAttackController.java
@@ -1102,7 +1102,8 @@ public class AiAttackController {
         for (final Card pCard : myList) {
             // if the creature can attack then it's a potential attacker this
             // turn, assume summoning sickness creatures will be able to
-            if (ComputerUtilCombat.canAttackNextTurn(pCard) && pCard.getNetCombatDamage() > 0) {
+            // TODO: Account for triggered power boosts.
+            if (ComputerUtilCombat.canAttackNextTurn(pCard) && (pCard.getNetCombatDamage() > 0 || "TRUE".equals(pCard.getSVar("HasAttackEffect")))) {
                 candidateAttackers.add(pCard);
                 candidateUnblockedDamage += ComputerUtilCombat.damageIfUnblocked(pCard, defendingOpponent, null, false);
                 computerForces++;

--- a/forge-gui/res/cardsfolder/e/elturel_survivors.txt
+++ b/forge-gui/res/cardsfolder/e/elturel_survivors.txt
@@ -6,7 +6,6 @@ K:Trample
 K:Myriad
 S:Mode$ Continuous | Affected$ Creature.Self+attacking | AddPower$ X | Description$ As long as CARDNAME is attacking, it gets +X/+0, where X is the number of lands defending player controls.
 SVar:X:Count$Valid Land.DefenderCtrl
-AI:RemoveDeck:All
 SVar:BuffedBy:Land.OppCtrl
 SVar:HasAttackEffect:TRUE
 Oracle:Trample, myriad\nAs long as Elturel Survivors is attacking, it gets +X/+0, where X is the number of lands defending player controls.


### PR DESCRIPTION
Closes #8920.

Checks for attack effect, not just power > 0.