### PR TITLE
KeywordCollection: Use linkedHashSetValues to prevent duplicates

### DIFF
--- a/forge-game/src/main/java/forge/game/keyword/KeywordCollection.java
+++ b/forge-game/src/main/java/forge/game/keyword/KeywordCollection.java
@@ -15,7 +15,7 @@ public class KeywordCollection implements Iterable<KeywordInterface> {
     private transient KeywordCollectionView view;
     // don't use enumKeys it causes a slow down
     private final Multimap<Keyword, KeywordInterface> map = MultimapBuilder.hashKeys()
-            .arrayListValues().build();
+            .linkedHashSetValues().build();
 
     public KeywordCollection() {
         super();


### PR DESCRIPTION
As mentioned there: https://github.com/Card-Forge/forge/pull/8587#issuecomment-3415238141

KeywordInterfaces should not be duplicates anyway