### PR TITLE
Corrected Traumatic Prank's mana cost.

### DIFF
--- a/forge-gui/res/cardsfolder/t/traumatic_prank.txt
+++ b/forge-gui/res/cardsfolder/t/traumatic_prank.txt
@@ -1,5 +1,5 @@
 Name:Traumatic Prank
-ManaCost:3 R
+ManaCost:2 R
 Types:Sorcery
 A:SP$ GainControl | ValidTgts$ Creature | LoseControl$ EOT | Untap$ True | SubAbility$ DBAnimate | StackDescription$ REP target creature_{c:Targeted} | SpellDescription$ Gain control of target creature until end of turn. Untap that creature.
 SVar:DBAnimate:DB$ Animate | Defined$ Targeted | Keywords$ Haste | staticAbilities$ CantBlock | Triggers$ PingUpkeep | Duration$ Perpetual | StackDescription$ SpellDescription | SpellDescription$ It perpetually gains haste, "This creature can't block," and "At the beginning of your upkeep, this creature deals 1 damage to you."


### PR DESCRIPTION
It was previously 3R. You can see the actual cost and effects here: https://scryfall.com/card/ysnc/12/traumatic-prank