### PR TITLE
Escape closed bracket character

### DIFF
--- a/forge-core/src/main/java/forge/card/CardEdition.java
+++ b/forge-core/src/main/java/forge/card/CardEdition.java
@@ -620,7 +620,7 @@ public final class CardEdition implements Comparable<CardEdition> {
                     * extra parameters - grouping #9
                 */
                 // Collector numbers now should allow hyphens for Planeswalker Championship Promos
-                "(^(.?[0-9A-Z-]+\\S*[A-Z]*)\\s)?(([SCURML])\\s)?([^@$]+)( @([^$]*))?( \\$\\{(.+)})?$"
+                "(^(.?[0-9A-Z-]+\\S*[A-Z]*)\\s)?(([SCURML])\\s)?([^@$]+)( @([^$]*))?( \\$\\{(.+)\\})?$"
                 //"(?:^(?<cnum>.?[0-9A-Z-]+\\S*[A-Z]*)\\s)?(?:(?<rarity>[SCURML])\\s)?(?<name>[^@$]*)(?: @(?<artist>[^$]*))?(?: \\$\\{(?<params>.+)})?$"
         );
 


### PR DESCRIPTION
I *think* this might be what's breaking Android? Digging up docs for old versions is a pain, but apparently for at least some versions, escaping these is necessary. Can't even test on desktop from here, let alone Android. 