### PR TITLE
Fix Multiple Replacement Effects not working correctly

### DIFF
--- a/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
@@ -234,6 +234,7 @@ public class ReplacementHandler {
         // if its updated, try to call event again
         if (res == ReplacementResult.Updated) {
             Map<AbilityKey, Object> params = AbilityKey.newMap(runParams);
+            params.remove(AbilityKey.ReplacementResult);
 
             if (params.containsKey(AbilityKey.EffectOnly)) {
                 params.put(AbilityKey.EffectOnly, true);


### PR DESCRIPTION
fixes if one Updated applies first (Double Lifegain), and then gets replaced by a normal one (Lose Life Instead)