### PR TITLE
Fix CardRequest for unflavored name not preferring unflavored prints

### DIFF
--- a/forge-core/src/main/java/forge/card/CardDb.java
+++ b/forge-core/src/main/java/forge/card/CardDb.java
@@ -389,6 +389,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
             String normalizedFlavorName = cr.getDisplayNameForVariant(variantName);
             if(!flavorNameMappings.containsKey(normalizedFlavorName)) {
                 flavorNameMappings.put(normalizedFlavorName, variantName);
+                flavorNameMappings.put(cr.getName(), IPaperCard.NO_FUNCTIONAL_VARIANT);
                 rulesByName.put(normalizedFlavorName, cr);
                 cacheFlavorName(cr.getMainPart().getFunctionalVariant(variantName));
                 if(cr.getOtherPart() != null)


### PR DESCRIPTION
Fixes an issue where supplying a flavor name via edition entry wouldn't register the unflavored name in `flavorNameMappings`. When a card has printings with a flavor name, `tryToGetCardFromEditions` will jump through some extra hoops to try and supply a printing that's either flavored or unflavored in accordance with the name in the card request. It uses this map to quickly determine if it needs to do that. With this, a CardRequest for Lightning Bolt should no longer be able to return the Thrum of the Vestige print.

Unblocks #9019.