### PR TITLE
Fix audit finding unimplemented funny cards

### DIFF
--- a/forge-core/src/main/java/forge/StaticData.java
+++ b/forge-core/src/main/java/forge/StaticData.java
@@ -776,7 +776,7 @@ public class StaticData {
         Queue<String> TOKEN_Q = new ConcurrentLinkedQueue<>();
         boolean nifHeader = false;
         boolean cniHeader = false;
-        final Pattern funnyCardCollectorNumberPattern = Pattern.compile("^F\\d+");
+        final Pattern funnyCardCollectorNumberPattern = Pattern.compile("^F★?\\d+★?");
         for (CardEdition e : editions) {
             if (CardEdition.Type.FUNNY.equals(e.getType()))
                 continue;


### PR DESCRIPTION
Enables the audit to ignore unimplemented funny cards when the collector number contains a ★

Example in P30M edition:
F1★ R Richard Garfield, Ph.D.

<img width="255" height="108" alt="java_L1m6JJIWLD" src="https://github.com/user-attachments/assets/47188818-e10d-4660-a6dc-5a4b416947ac" />
