### PR TITLE
Update Shorikai, Genesis Engine Oracle Text

### DIFF
--- a/forge-gui/res/cardsfolder/s/shorikai_genesis_engine.txt
+++ b/forge-gui/res/cardsfolder/s/shorikai_genesis_engine.txt
@@ -6,7 +6,6 @@ A:AB$ Draw | Cost$ 1 T | NumCards$ 2 | SubAbility$ DBDiscard | SpellDescription$
 SVar:DBDiscard:DB$ Discard | Defined$ You | NumCards$ 1 | Mode$ TgtChoose | SubAbility$ DBToken | SpellDescription$ then discard a card.
 SVar:DBToken:DB$ Token | TokenScript$ c_1_1_pilot_crewbuff | SpellDescription$ Create a 1/1 colorless Pilot creature token with "This creature crews Vehicles as though its power were 2 greater."
 K:Crew:8
-K:CARDNAME can be your commander.
 DeckHas:Ability$Discard|Token & Type$Pilot
 DeckHints:Type$Vehicle
-Oracle:{1}, {T}: Draw two cards, then discard a card. Create a 1/1 colorless Pilot creature token with "This creature crews Vehicles as though its power were 2 greater."\nCrew 8 (Tap any number of creatures you control with total power 8 or more: This Vehicle becomes an artifact creature until end of turn.)\nShorikai, Genesis Engine can be your commander.
+Oracle:{1}, {T}: Draw two cards, then discard a card. Create a 1/1 colorless Pilot creature token with "This creature crews Vehicles as though its power were 2 greater."\nCrew 8 (Tap any number of creatures you control with total power 8 or more: This Vehicle becomes an artifact creature until end of turn.)


### PR DESCRIPTION
Since the EOE change where Vehicles and Spacecrafts can be commanders, the part of Shorikai at the bottom became redundant and was removed. Update it to match its current Oracle text.

Also removed the keyword that makes it a commander since I think it's redundant with the current changes already implemented.