### PR TITLE
Fix path separator causing a regex syntax error on Windows

### DIFF
--- a/forge-gui/src/main/java/forge/sound/SoundSystem.java
+++ b/forge-gui/src/main/java/forge/sound/SoundSystem.java
@@ -340,9 +340,9 @@ public class SoundSystem {
         List<String> out = new ArrayList<>(5);
         if (adventureDirectory != null) {
             //Check user folders for matching music folder. Last path part should be the plane name.
-            String[] pathParts = adventureDirectory.split(ForgeConstants.PATH_SEPARATOR);
+            String directoryName = new File(adventureDirectory).getName();
             for(String path : SOUND_RESOURCE_PATHS) {
-                out.add(path + subPath + pathParts[pathParts.length - 1] + ForgeConstants.PATH_SEPARATOR);
+                out.add(path + subPath + directoryName + ForgeConstants.PATH_SEPARATOR);
             }
             out.add(adventureDirectory + subPath);
             out.add(ForgeConstants.ADVENTURE_COMMON_DIR + subPath);


### PR DESCRIPTION
Thanks Microsoft.

This whole method could probably be rewritten to use File objects instead of frankenstening together path segments but that's something for another time.