### PR TITLE
Card: remove one of addChangedCardTypes functions

### DIFF
--- a/forge-core/src/main/java/forge/card/CardChangedType.java
+++ b/forge-core/src/main/java/forge/card/CardChangedType.java
@@ -19,41 +19,7 @@ package forge.card;
 
 import java.util.Set;
 
-/**
- * <p>
- * CardType class.
- * </p>
- * 
- * @author Forge
- * @version $Id: CardType.java 24393 2014-01-21 06:27:36Z Max mtg $
- */
-public class CardChangedType {
-
-    // takes care of individual card types
-    private final CardType addType;
-    private final CardType removeType;
-    private final boolean addAllCreatureTypes;
-    private final Set<RemoveType> remove;
-
-    public CardChangedType(final CardType addType0, final CardType removeType0, final boolean addAllCreatureTypes0,
-            final Set<RemoveType> remove0) {
-        addType = addType0;
-        removeType = removeType0;
-        addAllCreatureTypes = addAllCreatureTypes0;
-        remove = remove0;
-    }
-
-    public final CardType getAddType() {
-        return addType;
-    }
-
-    public final CardType getRemoveType() {
-        return removeType;
-    }
-
-    public final boolean isAddAllCreatureTypes() {
-        return addAllCreatureTypes;
-    }
+public record CardChangedType(CardType addType, CardType removeType, boolean addAllCreatureTypes, Set<RemoveType> remove) {
 
     public final boolean isRemoveSuperTypes() {
         return remove.contains(RemoveType.SuperTypes);

--- a/forge-core/src/main/java/forge/card/CardType.java
+++ b/forge-core/src/main/java/forge/card/CardType.java
@@ -631,21 +631,21 @@ public final class CardType implements Comparable<CardType>, CardTypeView {
                     newType.subtypes.removeIf(Predicates.IS_ENCHANTMENT_TYPE);
                 }
             }
-            if (ct.getRemoveType() != null) {
-                newType.removeAll(ct.getRemoveType());
+            if (ct.removeType() != null) {
+                newType.removeAll(ct.removeType());
             }
-            if (ct.getAddType() != null) {
-                newType.addAll(ct.getAddType());
-                if (ct.getAddType().hasAllCreatureTypes()) {
+            if (ct.addType() != null) {
+                newType.addAll(ct.addType());
+                if (ct.addType().hasAllCreatureTypes()) {
                     newType.allCreatureTypes = true;
                 }
             }
-            if (ct.isAddAllCreatureTypes()) {
+            if (ct.addAllCreatureTypes()) {
                 newType.allCreatureTypes = true;
             }
             // remove specific creature types from all creature types
-            if (ct.getRemoveType() != null && newType.allCreatureTypes) {
-                newType.excludedCreatureSubtypes.addAll(Lists.newArrayList(IterableUtil.filter(ct.getRemoveType(), Predicates.IS_CREATURE_TYPE)));
+            if (ct.removeType() != null && newType.allCreatureTypes) {
+                newType.excludedCreatureSubtypes.addAll(Lists.newArrayList(IterableUtil.filter(ct.removeType(), Predicates.IS_CREATURE_TYPE)));
             }
         }
         // sanisfy subtypes

--- a/forge-game/src/main/java/forge/game/ability/effects/EarthbendEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/EarthbendEffect.java
@@ -1,9 +1,10 @@
 package forge.game.ability.effects;
 
-import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Map;
 
+import forge.card.CardType;
 import forge.card.RemoveType;
 import forge.game.Game;
 import forge.game.GameEntityCounterTable;
@@ -58,8 +59,8 @@ public class EarthbendEffect extends SpellAbilityEffect {
         // Earthbend should only target one land
         for (Card c : getTargetCards(sa)) {
             c.addNewPT(0, 0, ts, 0);
-            c.addChangedCardTypes(Arrays.asList("Creature"), null, false, EnumSet.noneOf(RemoveType.class), ts, 0, true, false);
-            c.addChangedCardKeywords(Arrays.asList("Haste"), null, false, ts, null);
+            c.addChangedCardTypes(new CardType(List.of("Creature"), true), null, false, EnumSet.noneOf(RemoveType.class), ts, 0, true, false);
+            c.addChangedCardKeywords(List.of("Haste"), null, false, ts, null);
 
             GameEntityCounterTable table = new GameEntityCounterTable();
             c.addCounter(CounterEnumType.P1P1, num, pl, table);

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -4318,22 +4318,6 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
         }
     }
 
-    public final void addChangedCardTypes(final Iterable<String> types, final Iterable<String> removeTypes, final boolean addAllCreatureTypes,
-            final Set<RemoveType> remove,
-            final long timestamp, final long staticId, final boolean updateView, final boolean cda) {
-        CardType addType = null;
-        CardType removeType = null;
-        if (types != null) {
-            addType = new CardType(types, true);
-        }
-
-        if (removeTypes != null) {
-            removeType = new CardType(removeTypes, true);
-        }
-
-        addChangedCardTypes(addType, removeType, addAllCreatureTypes, remove, timestamp, staticId, updateView, cda);
-    }
-
     public final void removeChangedCardTypes(final long timestamp, final long staticId) {
         removeChangedCardTypes(timestamp, staticId, true);
     }

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
@@ -851,7 +851,7 @@ public final class StaticAbilityContinuous {
 
             // add Types
             if ((addTypes != null && !addTypes.isEmpty()) || (removeTypes != null && !removeTypes.isEmpty()) || addAllCreatureTypes || !remove.isEmpty()) {
-                affectedCard.addChangedCardTypes(addTypes, removeTypes, addAllCreatureTypes, remove,
+                affectedCard.addChangedCardTypes(addTypes != null ? new CardType(addTypes, true) : null, removeTypes != null ? new CardType(removeTypes, true) : null, addAllCreatureTypes, remove,
                         se.getTimestamp(), stAb.getId(), false, stAb.isCharacteristicDefining());
             }
 


### PR DESCRIPTION
Part for #7011

that makes all effects use the same addChangedCardTypes function
and turned CardChangedType into a record