### PR TITLE
AdvancedSearch: fix ColorEvaluator using getTranslatedName

### DIFF
--- a/forge-gui/src/main/java/forge/itemmanager/AdvancedSearch.java
+++ b/forge-gui/src/main/java/forge/itemmanager/AdvancedSearch.java
@@ -1354,7 +1354,7 @@ public class AdvancedSearch {
 
     private static abstract class ColorEvaluator<T extends InventoryItem> extends CustomListEvaluator<T, MagicColor.Color> {
         public ColorEvaluator() {
-            super(Arrays.asList(MagicColor.Color.values()), MagicColor.Color::getSymbol);
+            super(Arrays.asList(MagicColor.Color.values()), MagicColor.Color::getSymbol, MagicColor.Color::getTranslatedName);
         }
 
         @Override


### PR DESCRIPTION
this fixes the Name in the Advanced Filter ("white" instead of "WHITE") and also enables the Icons