### PR TITLE
Resolve absolute path for sound files

### DIFF
--- a/forge-gui-mobile/src/forge/sound/AudioClip.java
+++ b/forge-gui-mobile/src/forge/sound/AudioClip.java
@@ -35,7 +35,7 @@ public class AudioClip implements IAudioClip {
 
     public static AudioClip createClip(File file) {
         if(file == null) return null;
-        FileHandle fileHandle = new FileHandle(file);
+        FileHandle fileHandle = Gdx.files.absolute(file.getPath());
         if(!fileHandle.exists()) return null;
         return new AudioClip(fileHandle);
     }


### PR DESCRIPTION
Wasn't able to verify this, but this seems like the likely cause of missing sounds on Android. 