### PR TITLE
Fix Commander's Sphere (#9249)

### DIFF
--- a/forge-gui/res/cardsfolder/c/commanders_sphere.txt
+++ b/forge-gui/res/cardsfolder/c/commanders_sphere.txt
@@ -3,5 +3,5 @@ ManaCost:3
 Types:Artifact
 A:AB$ Mana | Cost$ T | Produced$ Combo ColorIdentity | SpellDescription$ Add one mana of any color in your commander's color identity.
 A:AB$ Draw | Cost$ Sac<1/CARDNAME> | NumCards$ 1 | SpellDescription$ Draw a card.
-AI:RemoveDeck:All
+AI:RemoveDeck:NonCommander
 Oracle:{T}: Add one mana of any color in your commander's color identity.\nSacrifice Commander's Sphere: Draw a card.


### PR DESCRIPTION
Fixes #9249.

It's used for mana just like Arcane Signet, and also sacced when cards are more important:
```
Turn 36 (Peter)
Stinkweed Imp (240) : [Peter's Hand] -> [Peter's Graveyard]
Family's Favor (98) : [Giselle's Battlefield] -> [Giselle's Graveyard]
Peter sacrificed Commander's Sphere (200)
Commander's Sphere (200) : [Peter's Battlefield] -> [Peter's Graveyard]
Peter activated Sacrifice Commander's Sphere: Draw a card. phase UPKEEP
```