### PR TITLE
Fix Advancing Audio Tracks

### DIFF
--- a/forge-gui-mobile/src/forge/sound/AudioMusic.java
+++ b/forge-gui-mobile/src/forge/sound/AudioMusic.java
@@ -32,8 +32,7 @@ public class AudioMusic implements IAudioMusic {
             //sometimes cause a paused audio track to rapidly advance its position to the end (silently)
             //and then fire a completion listener. Setting the position manually right before pausing
             //seems to prevent this.
-            float pauseTimestamp = music.getPosition();
-            music.setPosition(pauseTimestamp);
+            music.setPosition(music.getPosition());
             music.pause();
         }
     }


### PR DESCRIPTION
There appears to be a bug between LibGDX and OpenAL Soft 1.23.1, which can under certain circumstances cause a paused audio track to quickly advance its position instead of staying where it is.

When I first encountered this when working on #9216, it just seemed to mean that when I resumed a track that I'd paused, it'd sometimes resume at some random point in the middle. Instead of digging into this I just marked the `pauseTimestamp` of the paused track and restored it when resuming. 

This fixed the wrong-resume-time issue, but then I realized it was also firing the completion listener, which meant a paused track could still trigger `changeBackgroundTrack` after a few seconds. I tried to fix this by checking if the song is actually playing when it supposedly reached the end in #9244, but I neglected to check that a song should actually register as `isPlaying` under those circumstances, and consequently broke ordinary playlist advancement.

Decided to dig into it a lot more this time. I still don't know exactly what's going on under the hood, or which underlying library I should report this issue to. But I'll document my observations as they pertain to Forge for future reference:

* In LibGDX's [`OpenALMusic.update()`](https://github.com/libgdx/libgdx/blob/f5861db5b94f9ccd22ffce7ae7f8dc5851d6afe5/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALMusic.java#L234-L257), when the issue happens, `alGetSourcei(sourceID, AL_BUFFERS_PROCESSED)` is always returning 3. In other words, it's continually reporting "I've played all the audio data you've given me" even though the track is paused and it shouldn't report that it's played anything. 
* This causes LibGDX to advance the track and write 3 more buffers of audio data which OpenAL Soft promptly ignores and then reports "yep, processed all 3 of those". It's rapidly advancing because it always writes all 3 buffers each update whereas it normally writes 0 or 1 each update.
* It happened on both Linux and Windows. I think the OpenAL Soft library ships with LibGDX or LWJGL so I think this would affect any non-Android device.
* It doesn't happen with every music change, but it regularly happened to the overworld track while entering towns and other interiors. Not vice versa or when passing between overworld regions.
* Absent any other differences in music handling between overworld to town and vice versa, my hypothesis is that the brief hang due to the auto-save when entering towns factors into the issue.
* Logging the music's position, pausing, then setting the paused track's position to the saved position causes the issue to happen every time any track is paused.
* Setting the unpaused track's position to its current position immediately before pausing seemed to prevent the bug in all cases.

That was around the point I gave up trying to understand it. I've cleaned up the other solutions I'd put in place in favor of a hack that I can't explain, but seems to resolve everything. On devices unaffected by this issue, the workaround should be completely vestigial.