### PR TITLE
Bump tag when building daily snapshots

### DIFF
--- a/.github/workflows/snapshot-both-pc-android.yml
+++ b/.github/workflows/snapshot-both-pc-android.yml
@@ -22,7 +22,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -111,6 +111,13 @@ jobs:
           ls
         env:
           GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Bump Snapshot Tag
+        run: |
+          git fetch origin tag "daily-snapshots"
+          git fetch origin master
+          git tag -f daily-snapshots origin/master
+          git push origin -f daily-snapshots
 
       - name: Upload snapshot to GitHub Prerelease
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
An attempt to fix the daily snapshots being buried halfway down the releases page. The release date seems to be tied to the date of the tag's commit, so I think updating it will bump the release up the list.

 I admittedly haven't tested this, since I'd have to hack up the script and plug in a lot of config data to run it in my own fork. But the commands for updating the tag seem to work when I tried them locally. Can revert and refire if the build fails.