### PR TITLE
FightAI NPE prevention

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/FightAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/FightAi.java
@@ -149,7 +149,11 @@ public class FightAi extends SpellAbilityAi {
         }
         //assumes the triggered card belongs to the ai
         if (sa.hasParam("Defined")) {
-            Card aiCreature = AbilityUtils.getDefinedCards(source, sa.getParam("Defined"), sa).get(0);
+            CardCollection definedCards = AbilityUtils.getDefinedCards(source, sa.getParam("Defined"), sa);
+            if (definedCards.isEmpty()) {
+                return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
+            }
+            Card aiCreature = definedCards.get(0);
             for (Card humanCreature : humCreatures) {
                 if (canKill(aiCreature, humanCreature, 0)
                         && ComputerUtilCard.evaluateCreature(humanCreature) > ComputerUtilCard.evaluateCreature(aiCreature)) {


### PR DESCRIPTION
For some reason, had this crash twice recently (in FightAi.java on line 152, an OutOfBounds exception). Not sure what card exactly triggered it, I was playing with decks that only have FIN and FIC cards in them, there was nothing on the battlefield that had a fight ability though.

This is a safety check, not sure if there's a better fix that would be more appropriate.