### PR TITLE
Fix running checks twice for permanent spells

### DIFF
--- a/forge-ai/src/main/java/forge/ai/SpellAbilityAi.java
+++ b/forge-ai/src/main/java/forge/ai/SpellAbilityAi.java
@@ -65,7 +65,6 @@ public abstract class SpellAbilityAi {
 
     protected AiAbilityDecision canPlayWithoutRestrict(final Player ai, final SpellAbility sa) {
         final Card source = sa.getHostCard();
-        final Cost cost = sa.getPayCosts();
 
         if (sa.hasParam("AILogic")) {
             final String logic = sa.getParam("AILogic");
@@ -89,6 +88,7 @@ public abstract class SpellAbilityAi {
         }
 
         // needs to be after API logic because needs to check possible X Cost
+        final Cost cost = sa.getPayCosts();
         if (cost != null && !willPayCosts(ai, sa, cost, source)) {
             return new AiAbilityDecision(0, AiPlayDecision.CostNotAcceptable);
         }

--- a/forge-ai/src/main/java/forge/ai/ability/LifeLoseAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/LifeLoseAi.java
@@ -14,10 +14,7 @@ import forge.game.player.Player;
 import forge.game.player.PlayerCollection;
 import forge.game.player.PlayerPredicates;
 import forge.game.spellability.SpellAbility;
-import forge.util.collect.FCollection;
 import forge.util.collect.FCollectionView;
-
-import java.util.List;
 
 public class LifeLoseAi extends SpellAbilityAi {
 
@@ -163,17 +160,18 @@ public class LifeLoseAi extends SpellAbilityAi {
      * forge.game.spellability.SpellAbility, boolean)
      */
     @Override
-    protected AiAbilityDecision doTriggerNoCost(final Player ai, final SpellAbility sa,
-                                                final boolean mandatory) {
-        if (sa.usesTargeting()) {
-            if (!doTgt(ai, sa, mandatory)) {
-                return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
-            }
+    protected AiAbilityDecision doTriggerNoCost(final Player ai, final SpellAbility sa, final boolean mandatory) {
+        if (sa.usesTargeting() && !doTgt(ai, sa, mandatory)) {
+            return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
+        }
+
+        if (mandatory) {
+            return new AiAbilityDecision(50, AiPlayDecision.MandatoryPlay);
         }
 
         final Card source = sa.getHostCard();
         final String amountStr = sa.getParam("LifeAmount");
-        int amount = 0;
+        int amount;
         if (amountStr.equals("X") && sa.getSVar(amountStr).equals("Count$xPaid")) {
             // Set PayX here to maximum value.
             final int xPay = ComputerUtilCost.getMaxXValue(sa, ai, true);
@@ -183,25 +181,15 @@ public class LifeLoseAi extends SpellAbilityAi {
             amount = AbilityUtils.calculateAmount(source, amountStr, sa);
         }
 
-        final List<Player> tgtPlayers = sa.usesTargeting() && !sa.hasParam("Defined")
-                ? new FCollection<>(sa.getTargets().getTargetPlayers())
-                : AbilityUtils.getDefinedPlayers(source, sa.getParam("Defined"), sa);
-
-        // For cards like Foul Imp, ETB you lose life
-        if (mandatory) {
-            return new AiAbilityDecision(50, AiPlayDecision.MandatoryPlay);
-        }
-
-        if (!tgtPlayers.contains(ai) || amount <= 0 || amount + 3 <= ai.getLife()) {
+        // For cards like Foul Imp: ETB you lose life
+        if (!getPlayers(ai, sa).contains(ai) || amount <= 0 || amount + 3 <= ai.getLife()) {
             return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
-        } else {
-            return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
         }
+        return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
     }
 
     @Override
-    public boolean willPayUnlessCost(Player payer, SpellAbility sa, Cost cost, boolean alreadyPaid,
-                                     FCollectionView<Player> payers) {
+    public boolean willPayUnlessCost(Player payer, SpellAbility sa, Cost cost, boolean alreadyPaid, FCollectionView<Player> payers) {
         if (!payer.canLoseLife() || payer.cantLoseForZeroOrLessLife()) {
             return false;
         }

--- a/forge-ai/src/main/java/forge/ai/ability/PermanentAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PermanentAi.java
@@ -316,6 +316,9 @@ public class PermanentAi extends SpellAbilityAi {
 
     @Override
     protected AiAbilityDecision doTriggerNoCost(Player ai, SpellAbility sa, boolean mandatory) {
+        if (mandatory) {
+            return new AiAbilityDecision(50, AiPlayDecision.MandatoryPlay);
+        }
         if (!sa.metConditions()) {
             return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
         }
@@ -324,20 +327,12 @@ public class PermanentAi extends SpellAbilityAi {
             return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
         }
         final Cost cost = sa.getPayCosts();
-        final Card source = sa.getHostCard();
-        if (cost != null && !willPayCosts(ai, sa, cost, source)) {
+        if (cost != null && !willPayCosts(ai, sa, cost, sa.getHostCard())) {
             return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
         }
         if (!checkPhaseRestrictions(ai, sa, ai.getGame().getPhaseHandler())) {
             return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
         }
-        AiAbilityDecision decision = checkApiLogic(ai, sa);
-        if (decision.willingToPlay()) {
-            return decision;
-        } else if (mandatory) {
-            return new AiAbilityDecision(50, AiPlayDecision.MandatoryPlay);
-        } else {
-            return decision;
-        }
+        return checkApiLogic(ai, sa);
      }
 }

--- a/forge-ai/src/main/java/forge/ai/ability/PermanentNoncreatureAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PermanentNoncreatureAi.java
@@ -35,14 +35,14 @@ public class PermanentNoncreatureAi extends PermanentAi {
 
         // Check for valid targets before casting
         if (host.hasSVar("OblivionRing")) {
+            // TODO: only the "may" case wouldn't fail checkETBEffects - replace with NeedsToPlay SVar?
             SpellAbility effectExile = AbilityFactory.getAbility(host.getSVar("TrigExile"), host);
             final ZoneType origin = ZoneType.listValueOf(effectExile.getParamOrDefault("Origin", "Battlefield")).get(0);
             effectExile.setActivatingPlayer(ai);
             CardCollection targets = CardLists.getTargetableCards(game.getCardsIn(origin), effectExile);
-            if (sourceName.equals("Suspension Field") 
+            if (sourceName.equals("Suspension Field")
                     || sourceName.equals("Detention Sphere")) {
                 // existing "exile until leaves" enchantments only target opponent's permanents
-                // TODO: consider replacing the condition with host.hasSVar("OblivionRing")
                 targets = CardLists.filterControlledBy(targets, ai.getOpponents());
             }
             if (targets.isEmpty()) {

--- a/forge-gui/res/cardsfolder/c/chained_to_the_rocks.txt
+++ b/forge-gui/res/cardsfolder/c/chained_to_the_rocks.txt
@@ -6,5 +6,4 @@ SVar:AttachAILogic:Pump
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ When CARDNAME enters, exile target creature an opponent controls until CARDNAME leaves the battlefield.
 SVar:TrigExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | Duration$ UntilHostLeavesPlay
 SVar:PlayMain1:TRUE
-SVar:NeedsToPlay:Creature.OppCtrl
 Oracle:Enchant Mountain you control\nWhen Chained to the Rocks enters, exile target creature an opponent controls until Chained to the Rocks leaves the battlefield. (That creature returns under its owner's control.)


### PR DESCRIPTION
roughly 10 years ago some refactoring lead to the chain `canPlaySa -> canPlayFromEffectAI -> doTrigger` running expensive functions (`checkApiLogic`, `willPayCosts` etc.) a second time.