### PR TITLE
PowerUp: add Param and Cost Reduction

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/AbilityFactory.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityFactory.java
@@ -236,6 +236,9 @@ public final class AbilityFactory {
         if (spellAbility.isExhaust()) {
             spellAbility.putParam("PrecostDesc", "Exhaust — ");
         }
+        if (spellAbility.isPowerUp()) {
+            spellAbility.putParam("PrecostDesc", "Power-Up — ");
+        }
 
         if (mapParams.containsKey("Named")) {
             spellAbility.setName(mapParams.get("Named"));

--- a/forge-game/src/main/java/forge/game/cost/CostAdjustment.java
+++ b/forge-game/src/main/java/forge/game/cost/CostAdjustment.java
@@ -225,6 +225,10 @@ public class CostAdjustment {
                 sumGeneric += num;
             }
         }
+        if (sa.isPowerUp() && originalCard.enteredThisTurn()) {
+            // TODO handle hybrid ManaCost
+            cost.subtractManaCost(originalCard.getManaCost());
+        }
 
         while (!reduceAbilities.isEmpty()) {
             StaticAbility choice = activator.getController().chooseSingleStaticAbility(Localizer.getInstance().getMessage("lblChooseCostReduction"), reduceAbilities);

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
@@ -595,6 +595,9 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
     public boolean isExhaust() {
         return this.hasParam("Exhaust");
     }
+    public boolean isPowerUp() {
+        return this.hasParam("PowerUp");
+    }
 
     public boolean isNinjutsu() {
         return this.isKeyword(Keyword.NINJUTSU);

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbilityRestriction.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbilityRestriction.java
@@ -542,6 +542,10 @@ public class SpellAbilityRestriction extends SpellAbilityVariables {
             if (sa.getActivationsThisGame() > 0 && !StaticAbilityExhaust.anyWithExhaust(activator)) {
                 return false;
             }
+        } else if (sa.isPowerUp()) {
+            if (sa.getActivationsThisGame() > 0) {
+                return false;
+            }
         }
 
         // Rule 605.3c about Mana Abilities


### PR DESCRIPTION
Closes #9309 

it should work for most cases.



What doesn't work yet is if something with Hybrid or Phyrexian ManaCost would gain the PowerUp ability.

> 118.7e If a cost is reduced by an amount of mana represented by a hybrid mana symbol, **the player paying that cost chooses one half of that symbol** at the time the cost reduction is applied (see rule 601.2f). If a colored half is chosen, the cost is reduced by one mana of that color. If a generic half is chosen, the cost is reduced by an amount of generic mana equal to that half’s number.
> 
> 118.7f If a cost is reduced by an amount of mana represented by a Phyrexian mana symbol, the cost is reduced by one mana of that symbol’s color.
> 
> 118.7g If a cost is reduced by an amount of mana represented by one or more snow mana symbols, the cost is reduced by that much generic mana.

The "the player paying that cost chooses one half of that symbol" needs to be handled via PlayerController


Also, this function should be refactored too:
https://github.com/Card-Forge/forge/blob/31bd11ef34c02cb29f9144e60fc6148a7e50b3be/forge-game/src/main/java/forge/game/mana/ManaCostBeingPaid.java#L275