### PR TITLE
Fix SpellSmith not respecting edition filter

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/scene/SpellSmithScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/SpellSmithScene.java
@@ -417,12 +417,11 @@ public class SpellSmithScene extends UIScene {
         lockedPrice = currentPrice;
         PaperCard P = cardPool.get(MyRandom.getRandom().nextInt(cardPool.size())); //Don't use the standard RNG.
         currentReward = null;
-        if (Config.instance().getSettingData().useAllCardVariants) {
-            if (!edition.isEmpty()) {
-                currentReward = new Reward(CardUtil.getCardByNameAndEdition(P.getCardName(), edition));
-            } else {
-                currentReward = new Reward(CardUtil.getCardByName(P.getCardName())); // grab any random variant if no set preference is specified
-            }
+        if (!edition.isEmpty()) {
+            // Always respect edition filter when one is selected
+            currentReward = new Reward(CardUtil.getCardByNameAndEdition(P.getCardName(), edition));
+        } else if (Config.instance().getSettingData().useAllCardVariants) {
+            currentReward = new Reward(CardUtil.getCardByName(P.getCardName())); // grab any random variant if no set preference is specified
         } else {
             currentReward = new Reward(P);
         }

--- a/forge-gui-mobile/src/forge/adventure/util/CardUtil.java
+++ b/forge-gui-mobile/src/forge/adventure/util/CardUtil.java
@@ -784,9 +784,8 @@ public class CardUtil {
     }
 
     public static PaperCard getCardByNameAndEdition(String cardName, String edition) {
-        List<PaperCard> cardPool = Config.instance().getSettingData().useAllCardVariants
-                ? FModel.getMagicDb().getCommonCards().getAllCards(cardName)
-                : FModel.getMagicDb().getCommonCards().getUniqueCardsNoAlt(cardName);
+        // Always search all printings when looking for a specific edition
+        List<PaperCard> cardPool = FModel.getMagicDb().getCommonCards().getAllCards(cardName);
         List<PaperCard> validCards = cardPool.stream()
                 .filter(input -> input.getEdition().equals(edition)).collect(Collectors.toList());
 


### PR DESCRIPTION
- SpellSmith should returns cards from the selected set regardless of the `useAllCardVariants` setting
- Fixed `getCardByNameAndEdition()` to search all printings when looking for a specific edition

When filtering by set in the SpellSmith (e.g., selecting Mirage), the card received was from a random printing instead of the selected set. This happened because:
1. `SpellSmithScene.pullCard()` only used `getCardByNameAndEdition()` when `useAllCardVariants` was TRUE
2. `CardUtil.getCardByNameAndEdition()` only searched unique cards (one per name) when `useAllCardVariants` was FALSE, so it couldn't find the specific edition

Alternatively, we can try to fix the `useAllCardVariants` TRUE scheme for limited edition worlds like Old Border Shandalar.