### PR TITLE
Fix collector number regex

### DIFF
--- a/forge-core/src/main/java/forge/deck/DeckRecognizer.java
+++ b/forge-core/src/main/java/forge/deck/DeckRecognizer.java
@@ -435,7 +435,7 @@ public class DeckRecognizer {
 
     public static final String REX_CARD_NAME = String.format("(\\[)?(?<%s>[a-zA-Z0-9à-ÿÀ-Ÿ&',\\.:!\\+\\\"\\/\\-\\s]+)(\\])?", REGRP_CARD);
     public static final String REX_SET_CODE = String.format("(?<%s>[a-zA-Z0-9_]{2,7})", REGRP_SET);
-    public static final String REX_COLL_NUMBER = String.format("(?<%s>\\*?[0-9A-Z]+\\S?[A-Z]*)", REGRP_COLLNR);
+    public static final String REX_COLL_NUMBER = String.format("(?<%s>\\*?[0-9A-Z]+(?:\\S[0-9A-Z]*)?)", REGRP_COLLNR);
     public static final String REX_CARD_COUNT = String.format("(?<%s>[\\d]{1,2})(?<mult>x)?", REGRP_CARDNO);
     // EXTRA
     public static final String REGRP_FOIL_GFISH = "foil";


### PR DESCRIPTION
Tested with

```text
COMMANDER:
Elesh Norn
[Main]
1 Archaeomancer's Map|PLST|C21-
1 Arid Mesa|MM3|229
1 Castle Ardenvale|ELD|238
1 Catastrophe|PLST|USG-6
1 Cemetery Protector|VOW|6
1 Citanul Flute|USG|289
1 Cloudshift|PLST|A25-7
1 Cosmic Intervention|KHC|3
1 Crucible of Worlds|M19|229
1 Mana Crypt|PLST|EMA-225
1 Marsh Flats|MM3|239
1 Mentor of the Meek|SCD|28
1 Mistveil Plains|UMA|247
1 Moon-Blessed Cleric|AFR|26
1 Myriad Landscape|C19|261
1 Nykthos, Shrine to Nyx|PPRO|2022-3
1 Ondu Inversion // Ondu Skyruins|ZNR|30
1 Path to Exile|PLST|E02-3
1 Plains|UND|87
1 Prowling Felidar|ZNR|34
1 Recruiter of the Guard|PLST|CN2-22
1 Retreat to Emeria|PLST|BFZ-44
1 Roadside Reliquary|NEO|272
1 Ruin Ghost|WWK|19
1 Sandstone Bridge|BFZ|243
1 Second Sunrise|PLST|MRD-20
1 Seer's Sundial|CM2|214
1 Sejiri Steppe|WWK|142
1 Settle the Wreckage|PXLN|34p
1 Sevinne's Reclamation|C19|5
1 Wayfarer's Bauble|SCD|287
1 Weathered Wayfarer|PLST|ONS-59
1 Winds of Abandon|MH1|37
1 Windswept Heath|KTK|248
1 Zuran Orb|MH2|300
```

https://discord.com/channels/267367946135928833/267367946135928833/1455249797375332412