### PR TITLE
Fix addShards action in MapDialog using wrong methods

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/util/MapDialog.java
+++ b/forge-gui-mobile/src/forge/adventure/util/MapDialog.java
@@ -333,8 +333,8 @@ public class MapDialog {
                 else Current.player().takeGold(-E.addGold);
             }
             if (E.addShards != 0) { //Gives (positive or negative) mana shards to the player.
-                if (E.addShards > 0) Current.player().giveGold(E.addShards);
-                else Current.player().takeGold(-E.addShards);
+                if (E.addShards > 0) Current.player().addShards(E.addShards);
+                else Current.player().takeShards(-E.addShards);
             }
             if (E.addMapReputation != 0) {
                 if (E.POIReference != null && !E.POIReference.isEmpty()) {


### PR DESCRIPTION
## Summary
- Fixed copy-paste bug where `addShards` action handler was calling `giveGold()`/`takeGold()` instead of `addShards()`/`takeShards()`
- Dialogs using `addShards` were incorrectly modifying player gold instead of mana shards

## Details
The addShards block in MapDialog.java was a copy of the addGold block where the method calls were never updated. The correct implementation already exists in MenuScene.java (lines 75-77).

**Before (incorrect):**
```java
if (E.addShards != 0) {
    if (E.addShards > 0) Current.player().giveGold(E.addShards);
    else Current.player().takeGold(-E.addShards);
}
```

**After (correct):**
```java
if (E.addShards != 0) {
    if (E.addShards > 0) Current.player().addShards(E.addShards);
    else Current.player().takeShards(-E.addShards);
}
```
