### PR TITLE
Add all preconstructed decks for old border era

### DIFF
--- a/forge-gui/res/quest/precons/Aerodoom.dck
+++ b/forge-gui/res/quest/precons/Aerodoom.dck
@@ -1,0 +1,58 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Aerodoom
+Description=A blue-black control deck from Beatdown. Survive early with removal, then dominate the skies with Drakes, Djinns, and Elementals.
+Deck Type=constructed
+Set=BTD
+Image=aerodoom.jpg
+[main]
+4 Island|TMP|1
+4 Island|TMP|2
+3 Island|TMP|3
+4 Swamp|TMP|1
+4 Swamp|TMP|2
+3 Swamp|TMP|3
+1 Ebon Stronghold|FEM
+1 Polluted Mire|USG
+1 Remote Isle|USG
+1 Svyelunite Temple|FEM
+1 Air Elemental|4ED
+1 Blizzard Elemental|UDS
+1 Clockwork Avian|4ED
+1 Cloud Djinn|WTH
+1 Cloud Elemental|VIS
+1 Fallen Angel|LEG
+1 Feral Shadow|MIR
+1 Fog Elemental|WTH
+1 Giant Crab|TMP
+1 Gravedigger|TMP
+1 Hollow Dogs|USG
+1 Killer Whale|EXO
+1 Leviathan|DRK
+1 Mahamoti Djinn|4ED
+1 Sengir Vampire|4ED
+1 Skittering Horror|UDS
+1 Skittering Skirge|USG
+1 Snapping Drake|S99
+1 Tar Pit Warrior|VIS
+1 Vigilant Drake|ULG
+1 Wayward Soul|EXO
+1 Bone Harvest|MIR
+1 Brainstorm|ICE
+1 Counterspell|4ED
+1 Dark Ritual|4ED
+1 Diabolic Edict|TMP
+1 Impulse|VIS
+1 Power Sink|4ED
+1 Terror|4ED
+1 Tolarian Winds|USG
+1 Coercion|VIS
+1 Death Stroke|STH
+1 Diabolic Vision|ICE
+1 Drain Life|4ED
+1 Gaseous Form|TMP
+[sideboard]

--- a/forge-gui/res/quest/precons/Air Forces.dck
+++ b/forge-gui/res/quest/precons/Air Forces.dck
@@ -1,0 +1,41 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Air Forces
+Description=Air Forces takes to the skies. Blue-white flying creatures dominate.
+Deck Type=constructed
+Set=WTH
+Image=air_forces.jpg
+[main]
+5 Island|MIR|1
+5 Island|MIR|2
+4 Island|MIR|3
+4 Plains|MIR|1
+3 Plains|MIR|2
+3 Plains|MIR|3
+1 Alabaster Dragon|WTH
+3 Benalish Knight|WTH
+1 Cloud Djinn|WTH
+1 Fog Elemental|WTH
+2 Heavy Ballista|WTH
+1 Man-o'-War|VIS
+2 Mistmoon Griffin|WTH
+3 Ophidian|WTH
+1 Sage Owl|WTH
+3 Serrated Biskelion|WTH
+1 Suq'Ata Firewalker|MIR
+3 Vodalian Illusionist|WTH
+1 Waterspout Djinn|VIS
+1 Abduction|WTH
+2 Empyrial Armor|WTH
+2 Pacifism|MIR
+1 Debt of Loyalty|WTH
+1 Disrupt|WTH
+1 Dissipate|MIR
+2 Impulse|VIS
+2 Memory Lapse|MIR
+1 Power Sink|MIR
+[sideboard]

--- a/forge-gui/res/quest/precons/Air Razers.dck
+++ b/forge-gui/res/quest/precons/Air Razers.dck
@@ -20,8 +20,12 @@ Image=air_razers.jpg
 2 Shower of Coals|ODY
 1 Scalpelexis|JUD
 1 Concentrate|ODY
-12 Island|ODY
-12 Mountain|ODY
+4 Island|ODY|1
+4 Island|ODY|2
+4 Island|ODY|3
+4 Mountain|ODY|1
+4 Mountain|ODY|2
+4 Mountain|ODY|3
 2 Aven Fisher|ODY
 2 Fiery Temper|TOR
 1 Wonder|JUD

--- a/forge-gui/res/quest/precons/Armada.dck
+++ b/forge-gui/res/quest/precons/Armada.dck
@@ -21,7 +21,9 @@ Image=armada.jpg
 2 Longbow Archer|7ED
 1 Master Healer|7ED
 2 Pacifism|7ED
-15 Plains|7ED
+5 Plains|7ED|1
+5 Plains|7ED|2
+5 Plains|7ED|3
 1 Razorfoot Griffin|7ED
 2 Samite Healer|7ED
 1 Serra Advocate|7ED

--- a/forge-gui/res/quest/precons/Assassin.dck
+++ b/forge-gui/res/quest/precons/Assassin.dck
@@ -11,7 +11,9 @@ Set=UDS
 Image=assassin.jpg
 [main]
 1 Mantis Engine|UDS
-16 Swamp|6ED
+6 Swamp|6ED|1
+5 Swamp|6ED|2
+5 Swamp|6ED|3
 1 Body Snatcher|UDS
 1 Bone Shredder|ULG
 2 Disease Carriers|UDS

--- a/forge-gui/res/quest/precons/Bait & Switch.dck
+++ b/forge-gui/res/quest/precons/Bait & Switch.dck
@@ -1,0 +1,43 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Bait & Switch
+Description=Bait & Switch uses morph creatures to deceive opponents. Flip your creatures at the perfect moment.
+Deck Type=constructed
+Set=ONS
+Image=bait_and_switch.jpg
+[main]
+4 Island|ONS|1
+4 Island|ONS|2
+3 Island|ONS|3
+3 Swamp|ONS|1
+3 Swamp|ONS|2
+3 Swamp|ONS|3
+2 Barren Moor|ONS
+2 Lonely Sandbar|ONS
+2 Boneknitter|ONS
+2 Cabal Slaver|ONS
+1 Fallen Cleric|ONS
+1 Frightshroud Courier|ONS
+4 Imagecrafter|ONS
+1 Information Dealer|ONS
+1 Ghosthelm Courier|ONS
+3 Mistform Dreamer|ONS
+1 Mistform Mutant|ONS
+2 Mistform Shrieker|ONS
+2 Mistform Stalker|ONS
+4 Mistform Wall|ONS
+1 Feeding Frenzy|ONS
+1 Ixidor's Will|ONS
+1 Mage's Guile|ONS
+1 Misery Charm|ONS
+1 Smother|ONS
+3 Swat|ONS
+1 Trickery Charm|ONS
+1 Endemic Plague|ONS
+1 Peer Pressure|ONS
+1 Crown of Suspicion|ONS
+[sideboard]

--- a/forge-gui/res/quest/precons/Barrage.dck
+++ b/forge-gui/res/quest/precons/Barrage.dck
@@ -1,0 +1,47 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Barrage
+Description=Barrage unleashes a relentless assault. Green creatures and red burn combine for explosive damage.
+Deck Type=constructed
+Set=PLS
+Image=barrage.jpg
+[main]
+4 Mountain|INV|1
+4 Mountain|INV|2
+3 Mountain|INV|3
+4 Forest|INV|1
+4 Forest|INV|2
+4 Forest|INV|3
+2 Alpha Kavu|PLS
+1 Amphibious Kavu|PLS
+1 Caldera Kavu|PLS
+2 Flametongue Kavu|PLS
+1 Gaea's Herald|PLS
+2 Horned Kavu|PLS
+1 Kavu Recluse|PLS
+1 Llanowar Elite|INV
+2 Mogg Jailer|PLS
+1 Mogg Sentry|PLS
+2 Nomadic Elf|INV
+1 Root Greevil|PLS
+1 Serpentine Kavu|INV
+2 Sparkcaster|PLS
+1 Thornscape Apprentice|INV
+3 Thornscape Familiar|PLS
+1 Thunderscape Apprentice|INV
+1 Thunderscape Battlemage|PLS
+1 Thunderscape Familiar|PLS
+2 Fertile Ground|USG
+1 Fires of Yavimaya|INV
+1 Assault // Battery|INV
+1 Explosive Growth|INV
+1 Magma Burst|PLS
+1 Scorching Lava|INV
+1 Simoon|VIS
+1 Singe|PLS
+1 Implode|PLS
+[sideboard]

--- a/forge-gui/res/quest/precons/Battle Surge.dck
+++ b/forge-gui/res/quest/precons/Battle Surge.dck
@@ -17,12 +17,16 @@ Image=battle_surge.jpg
 2 Goblin Berserker|UDS
 1 Goblin Marshal|UDS
 2 Goblin War Buggy|USG
-9 Island|6ED
+3 Island|6ED|1
+3 Island|6ED|2
+3 Island|6ED|3
 1 Jagged Lightning|USG
 2 Keldon Champion|UDS
 3 Kingfisher|UDS
 1 Mark of Fury|UDS
-14 Mountain|6ED
+5 Mountain|6ED|1
+5 Mountain|6ED|2
+4 Mountain|6ED|3
 1 Parch|ULG
 1 Raven Familiar|ULG
 2 Thieving Magpie|UDS
@@ -32,5 +36,5 @@ Image=battle_surge.jpg
 2 Viashino Cutthroat|ULG
 3 Viashino Sandscout|ULG
 4 Wild Colos|UDS
-1 AEther Sting|UDS
+1 Aether Sting|UDS
 [sideboard]

--- a/forge-gui/res/quest/precons/Blinding Fury.dck
+++ b/forge-gui/res/quest/precons/Blinding Fury.dck
@@ -1,0 +1,29 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Blinding Fury
+Description=Blinding Fury harnesses white creature abilities. Expanded gameplay with this white theme deck.
+Deck Type=constructed
+Set=S99
+Image=blinding_fury.jpg
+[main]
+6 Plains|S99|1
+6 Plains|S99|2
+5 Plains|S99|3
+1 Archangel|S99
+1 Angel of Light|S99
+2 Charging Paladin|S99
+3 Foot Soldiers|S99
+3 Knight Errant|S99
+3 Venerable Monk|S99
+2 Wild Griffin|S99
+1 Armageddon|S99
+2 Angelic Blessing|S99
+1 Breath of Life|S99
+1 False Peace|S99
+2 Path of Peace|S99
+1 Vengeance|S99
+[sideboard]

--- a/forge-gui/res/quest/precons/Blowout.dck
+++ b/forge-gui/res/quest/precons/Blowout.dck
@@ -1,0 +1,46 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Blowout
+Description=Blowout explodes with red-black aggression. Burn spells and aggressive creatures end games fast.
+Deck Type=constructed
+Set=INV
+Image=blowout.jpg
+[main]
+4 Swamp|INV|1
+4 Swamp|INV|2
+4 Swamp|INV|3
+4 Mountain|INV|1
+3 Mountain|INV|2
+3 Mountain|INV|3
+2 Urborg Volcano|INV
+1 Cinder Shade|INV
+1 Firescreamer|INV
+1 Halam Djinn|INV
+1 Hate Weaver|INV
+2 Hooded Kavu|INV
+2 Kavu Aggressor|INV
+1 Phyrexian Delver|INV
+1 Phyrexian Reaper|INV
+1 Phyrexian Slayer|INV
+4 Ravenous Rats|INV
+2 Shivan Zombie|INV
+2 Thunderscape Apprentice|INV
+1 Trench Wurm|INV
+2 Vicious Kavu|INV
+1 Maniacal Rage|INV
+1 Mourning|INV
+1 Smoldering Tar|INV
+1 Agonizing Demise|INV
+1 Annihilate|INV
+1 Zap|INV
+2 Addle|INV
+1 Breath of Darigaaz|INV
+1 Ghitu Fire|INV
+1 Hypnotic Cloud|INV
+2 Scorching Lava|INV
+1 Soul Burn|INV
+[sideboard]

--- a/forge-gui/res/quest/precons/Bomber.dck
+++ b/forge-gui/res/quest/precons/Bomber.dck
@@ -22,7 +22,9 @@ Image=bomber.jpg
 1 Glacial Wall|7ED
 1 Horned Turtle|7ED
 1 Inspiration|7ED
-17 Island|7ED
+6 Island|7ED|1
+6 Island|7ED|2
+5 Island|7ED|3
 1 Merfolk Looter|7ED
 1 Merfolk of the Pearl Trident|7ED
 1 Prodigal Sorcerer|7ED

--- a/forge-gui/res/quest/precons/Breakdown.dck
+++ b/forge-gui/res/quest/precons/Breakdown.dck
@@ -1,0 +1,40 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Breakdown
+Description=Breakdown combines blue control with green creatures. Counter threats and overwhelm with efficient beaters.
+Deck Type=constructed
+Set=NMS
+Image=breakdown.jpg
+[main]
+4 Island|MMQ
+3 Island|MMQ
+3 Island|MMQ
+4 Forest|MMQ
+3 Forest|MMQ
+3 Forest|MMQ
+2 Hickory Woodlot|MMQ
+2 Saprazzan Skerry|MMQ
+2 Blastoderm|NMS
+4 Cloudskate|NMS
+2 Rusting Golem|NMS
+1 Skyshroud Behemoth|NMS
+4 Skyshroud Ridgeback|NMS
+2 Stronghold Zeppelin|NMS
+1 Vine Trellis|MMQ
+3 Waterfront Bouncer|MMQ
+2 Woodripper|NMS
+1 Dehydration|MMQ
+1 False Demise|ALL
+1 Seal of Strength|NMS
+1 War Tax|MMQ
+1 Seal of Removal|NMS
+4 Accumulated Knowledge|NMS
+2 Ensnare|NMS
+2 Revive|MMQ
+1 Parallax Inhibitor|NMS
+1 Puffer Extract|MMQ
+[sideboard]

--- a/forge-gui/res/quest/precons/Burial.dck
+++ b/forge-gui/res/quest/precons/Burial.dck
@@ -1,0 +1,43 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Burial
+Description=Burial brings creatures back from the dead. Graveyard recursion in three colors.
+Deck Type=constructed
+Set=APC
+Image=burial.jpg
+[main]
+1 Plains|INV|1
+1 Plains|INV|2
+1 Plains|INV|3
+4 Swamp|INV|1
+3 Swamp|INV|2
+3 Swamp|INV|3
+2 Forest|INV|1
+2 Forest|INV|2
+1 Forest|INV|3
+3 Elfhame Palace|INV
+3 Grave Defiler|APC
+4 Llanowar Dead|APC
+3 Maggot Carrier|PLS
+2 Mournful Zombie|APC
+1 Phyrexian Gargantua|APC
+2 Phyrexian Reaper|INV
+4 Putrid Warrior|APC
+2 Quagmire Druid|APC
+2 Zombie Boa|APC
+1 Foul Presence|APC
+1 Phyrexian Arena|APC
+1 Soul Link|APC
+1 Annihilate|INV
+2 Consume Strength|APC
+3 Strength of Night|APC
+1 Wax // Wane|INV
+2 Dead Ringers|APC
+1 Death Grasp|APC
+2 Chromatic Sphere|INV
+1 Tigereye Cameo|INV
+[sideboard]

--- a/forge-gui/res/quest/precons/Burning Sky.dck
+++ b/forge-gui/res/quest/precons/Burning Sky.dck
@@ -1,0 +1,42 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Burning Sky
+Description=Burning Sky combines blue tempo with red burn. Counter and burn your way to victory.
+Deck Type=constructed
+Set=MIR
+Image=burning_sky.jpg
+[main]
+4 Island|MIR|1
+4 Island|MIR|2
+4 Island|MIR|3
+4 Mountain|MIR|1
+4 Mountain|MIR|2
+4 Mountain|MIR|3
+2 Azimaet Drake|MIR
+3 Bay Falcon|MIR
+1 Burning Palm Efreet|MIR
+1 Dream Fighter|MIR
+2 Flame Elemental|MIR
+1 Harmattan Efreet|MIR
+1 Mist Dragon|MIR
+3 Pyric Salamander|MIR
+1 Subterranean Spirit|MIR
+1 Suq'Ata Firewalker|MIR
+2 Talruum Minotaur|MIR
+3 Teferi's Drake|MIR
+1 Vaporous Djinn|MIR
+2 Wildfire Emissary|MIR
+2 Boomerang|MIR
+1 Dissipate|MIR
+1 Incinerate|MIR
+2 Meddle|MIR
+1 Mystical Tutor|MIR
+1 Power Sink|MIR
+2 Dream Cache|MIR
+1 Goblin Scouts|MIR
+1 Kaervek's Torch|MIR
+[sideboard]

--- a/forge-gui/res/quest/precons/Call of the Kor.dck
+++ b/forge-gui/res/quest/precons/Call of the Kor.dck
@@ -1,0 +1,41 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Call of the Kor
+Description=The en-Kor nomads have mastered the art of redirecting damage. Call of the Kor assembles these warriors to protect each other while striking at foes.
+Deck Type=constructed
+Set=STH
+Image=call_of_the_kor.jpg
+[main]
+5 Plains|TMP|1
+4 Plains|TMP|2
+4 Plains|TMP|3
+4 Swamp|TMP|1
+4 Swamp|TMP|2
+3 Swamp|TMP|3
+3 Nomads en-Kor|STH
+1 Shaman en-Kor|STH
+2 Warrior en-Kor|STH
+1 Soltari Champion|STH
+2 Knight of Dawn|TMP
+1 Cloudchaser Eagle|TMP
+4 Spirit en-Kor|STH
+2 Lancers en-Kor|STH
+1 Skeleton Scavengers|STH
+1 Darkling Stalker|TMP
+2 Gravedigger|TMP
+1 Screeching Harpy|TMP
+3 Endless Scream|TMP
+2 Enfeeblement|MIR
+1 Flickering Ward|TMP
+1 Dark Banishing|TMP
+1 Disenchant|TMP
+1 Smite|STH
+1 Temper|STH
+1 Death Stroke|STH
+2 Evincar's Justice|TMP
+2 Lab Rats|STH
+[sideboard]

--- a/forge-gui/res/quest/precons/Celestial Assault.dck
+++ b/forge-gui/res/quest/precons/Celestial Assault.dck
@@ -1,0 +1,44 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Celestial Assault
+Description=Celestial Assault brings soldiers and angels to war. Blue-white tribal aggression.
+Deck Type=constructed
+Set=ONS
+Image=celestial_assault.jpg
+[main]
+5 Plains|ONS|1
+4 Plains|ONS|2
+4 Plains|ONS|3
+4 Island|ONS|1
+3 Island|ONS|2
+3 Island|ONS|3
+1 Seaside Haven|ONS
+2 Ascending Aven|ONS
+2 Daru Cavalier|ONS
+2 Dive Bomber|ONS
+1 Gustcloak Harrier|ONS
+2 Gustcloak Runner|ONS
+1 Gustcloak Savior|ONS
+1 Gustcloak Sentinel|ONS
+1 Gustcloak Skirmisher|ONS
+2 Ironfist Crusher|ONS
+1 Pearlspear Courier|ONS
+2 Screaming Seahawk|ONS
+1 Akroma's Blessing|ONS
+1 Defensive Maneuvers|ONS
+2 Inspirit|ONS
+2 Mage's Guile|ONS
+1 Meddle|ONS
+1 Oblation|ONS
+2 Piety Charm|ONS
+1 Sunfire Balm|ONS
+2 Unified Strike|ONS
+2 Airborne Aid|ONS
+1 Essence Fracture|ONS
+1 Dispersing Orb|ONS
+2 Sandskin|ONS
+[sideboard]

--- a/forge-gui/res/quest/precons/Chargoyf.dck
+++ b/forge-gui/res/quest/precons/Chargoyf.dck
@@ -1,0 +1,44 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Chargoyf
+Description=A red-green deck from Battle Royale featuring the mighty Lhurgoyf. Aggressive creatures and burn combine for a powerful assault.
+Deck Type=constructed
+Set=BRB
+Image=chargoyf.jpg
+[main]
+4 Forest|TMP|1
+3 Forest|TMP|2
+3 Forest|TMP|3
+2 Mountain|TMP|1
+2 Mountain|TMP|2
+2 Mountain|TMP|3
+1 Mogg Hollows|TMP
+1 Slippery Karst|USG
+1 Gorilla Warrior|USG
+1 Lhurgoyf|ICE
+1 Llanowar Elves|4ED
+1 Pincher Beetles|TMP
+1 Plated Rootwalla|EXO
+1 Raging Goblin|EXO
+1 River Boa|VIS
+1 Scryb Sprites|4ED
+1 Seeker of Skybreak|TMP
+1 Skyshroud Elite|EXO
+1 Spike Feeder|STH
+1 Spike Weaver|EXO
+1 Trumpeting Armodon|TMP
+1 Uthden Troll|4ED
+1 Village Elder|MIR
+1 Wildfire Emissary|MIR
+1 Shower of Sparks|USG
+1 Symbiosis|USG
+1 Arc Lightning|USG
+1 Steam Blast|USG
+1 Tranquility|TMP
+1 Broken Fall|TMP
+1 Maniacal Rage|EXO
+[sideboard]

--- a/forge-gui/res/quest/precons/Cinder Heart.dck
+++ b/forge-gui/res/quest/precons/Cinder Heart.dck
@@ -1,0 +1,44 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Cinder Heart
+Description=A black-red deck from Battle Royale focused on reanimation and board control. Pestilence and powerful creatures dominate.
+Deck Type=constructed
+Set=BRB
+Image=cinder_heart.jpg
+[main]
+3 Mountain|TMP|1
+3 Mountain|TMP|2
+3 Mountain|TMP|3
+2 Swamp|TMP|1
+2 Swamp|TMP|2
+2 Swamp|TMP|3
+1 Cinder Marsh|TMP
+1 Polluted Mire|USG
+1 Abyssal Specter|ICE
+1 Cackling Fiend|USG
+1 Crazed Skirge|USG
+1 Fire Ants|USG
+1 Lightning Elemental|TMP
+1 Nekrataal|VIS
+1 Phyrexian Ghoul|USG
+1 Sengir Vampire|4ED
+1 Sewer Rats|MIR
+1 Wall of Heat|LEG
+1 Dark Ritual|ICE
+1 Heat Ray|USG
+1 Terror|4ED
+1 Exhume|USG
+1 Living Death|TMP
+1 Reanimate|TMP
+1 Rolling Thunder|TMP
+1 Syphon Soul|LEG
+1 Unnerve|USG
+1 Pestilence|USG
+1 Sadistic Glee|TMP
+1 Subversion|ULG
+1 Weakness|4ED
+[sideboard]

--- a/forge-gui/res/quest/precons/Comeback.dck
+++ b/forge-gui/res/quest/precons/Comeback.dck
@@ -1,0 +1,52 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Comeback
+Description=Comeback recovers from any situation. Card advantage and resilient threats grind out victories.
+Deck Type=constructed
+Set=PLS
+Image=comeback.jpg
+[main]
+2 Plains|INV|1
+1 Plains|INV|2
+1 Plains|INV|3
+3 Island|INV|1
+2 Island|INV|2
+2 Island|INV|3
+2 Swamp|INV|1
+2 Swamp|INV|2
+2 Swamp|INV|3
+1 Ancient Spring|INV
+1 Coastal Tower|INV
+2 Dromar's Cavern|PLS
+1 Salt Marsh|INV
+1 Terminal Moraine|PLS
+1 Arctic Merfolk|PLS
+3 Cavern Harpy|PLS
+1 Faerie Squadron|INV
+1 Galina's Knight|INV
+1 Guard Dogs|PLS
+1 Honorable Scout|PLS
+2 Hunting Drake|PLS
+2 Marsh Crocodile|PLS
+1 Nightscape Familiar|PLS
+2 Phyrexian Bloodstock|PLS
+2 Ravenous Rats|PO2
+1 Sawtooth Loon|PLS
+2 Silver Drake|PLS
+1 Stormscape Apprentice|INV
+1 Stormscape Battlemage|PLS
+3 Stormscape Familiar|PLS
+3 Tidal Visionary|INV
+1 Vodalian Merchant|INV
+1 Waterspout Elemental|PLS
+1 Planeswalker's Scorn|PLS
+2 Sisay's Ingenuity|PLS
+1 Confound|PLS
+1 Dromar's Charm|PLS
+1 Slay|PLS
+1 Mana Cylix|PLS
+[sideboard]

--- a/forge-gui/res/quest/precons/Crusher.dck
+++ b/forge-gui/res/quest/precons/Crusher.dck
@@ -18,7 +18,9 @@ Image=crusher.jpg
 3 Drifting Meadow|USG
 1 Elvish Herder|USG
 1 Erase|ULG
-17 Forest|USG
+6 Forest|USG|1
+6 Forest|USG|2
+5 Forest|USG|3
 1 Gaea's Bounty|USG
 1 Gaea's Embrace|USG
 1 Gang of Elk|ULG
@@ -26,7 +28,9 @@ Image=crusher.jpg
 1 Lone Wolf|ULG
 2 Mother of Runes|ULG
 2 Pacifism|USG
-4 Plains|USG
+2 Plains|USG|1
+1 Plains|USG|2
+1 Plains|USG|3
 1 Radiant's Judgment|ULG
 1 Rancor|ULG
 1 Silk Net|ULG

--- a/forge-gui/res/quest/precons/Dark Alliance.dck
+++ b/forge-gui/res/quest/precons/Dark Alliance.dck
@@ -1,0 +1,57 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Dark Alliance
+Description=A black-red aggressive deck from Anthologies. Goblins swarm the battlefield while Hypnotic Specter disrupts opponent's plans.
+Deck Type=constructed
+Set=ATH
+Image=dark_alliance.jpg
+[main]
+4 Mountain|4ED|1
+4 Mountain|4ED|2
+4 Mountain|4ED|3
+4 Swamp|4ED|1
+3 Swamp|4ED|2
+3 Swamp|4ED|3
+1 Polluted Mire|USG
+1 Smoldering Crater|USG
+1 Strip Mine|4ED
+1 Aesthir Glider|ALL
+1 Black Knight|4ED
+1 Cuombajj Witches|ARN
+1 Goblin Balloon Brigade|4ED
+1 Goblin Digging Team|DRK
+1 Goblin Hero|DRK
+1 Goblin King|4ED
+1 Goblin Matron|USG
+1 Goblin Mutant|ICE
+1 Goblin Recruiter|VIS
+1 Goblin Snowman|ICE
+1 Goblin Tinkerer|MIR
+1 Goblin Vandal|WTH
+1 Hypnotic Specter|4ED
+1 Ihsan's Shade|HML
+1 Knight of Stromgald|ICE
+1 Lady Orca|LEG
+1 Mogg Fanatic|TMP
+1 Mogg Flunkies|STH
+1 Mogg Raider|TMP
+1 Raging Goblin|EXO
+1 Uthden Troll|4ED
+1 Volcanic Dragon|MIR
+1 Lightning Bolt|4ED
+1 Pyrokinesis|ALL
+1 Terror|4ED
+1 Fireball|4ED
+1 Goblin Grenade|FEM
+1 Goblin Offensive|USG
+1 Hymn to Tourach|FEM
+1 Pyrotechnics|4ED
+1 Nevinyrral's Disk|4ED
+1 Feast of the Unicorn|HML
+1 Goblin Warrens|FEM
+1 Unholy Strength|4ED
+[sideboard]

--- a/forge-gui/res/quest/precons/Dead and Alive.dck
+++ b/forge-gui/res/quest/precons/Dead and Alive.dck
@@ -1,0 +1,38 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Dead and Alive
+Description=Dead and Alive blurs the line. Black reanimation and graveyard themes.
+Deck Type=constructed
+Set=WTH
+Image=dead_and_alive.jpg
+[main]
+8 Swamp|MIR|1
+8 Swamp|MIR|2
+8 Swamp|MIR|3
+1 Barrow Ghoul|WTH
+1 Circling Vultures|WTH
+3 Crypt Rats|VIS
+2 Fallen Askari|VIS
+2 Fledgling Djinn|WTH
+1 Hidden Horror|WTH
+1 Mischievous Poltergeist|WTH
+1 Morinfen|WTH
+3 Necratog|WTH
+2 Nekrataal|VIS
+2 Sewer Rats|MIR
+2 Shadow Rider|WTH
+1 Skulking Ghost|MIR
+1 Zombie Scavengers|WTH
+1 Infernal Tribute|WTH
+2 Necromancy|VIS
+1 Strands of Night|WTH
+1 Shattered Crypt|WTH
+2 Spinning Darkness|WTH
+2 Buried Alive|WTH
+2 Dark Banishing|MIR
+2 Drain Life|MIR
+[sideboard]

--- a/forge-gui/res/quest/precons/Deadly Instinct.dck
+++ b/forge-gui/res/quest/precons/Deadly Instinct.dck
@@ -1,0 +1,29 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Deadly Instinct
+Description=Deadly Instinct embraces dark power. Black creature abilities and removal.
+Deck Type=constructed
+Set=S99
+Image=deadly_instinct.jpg
+[main]
+6 Swamp|S99|1
+6 Swamp|S99|2
+5 Swamp|S99|3
+1 Dakmor Lancer|S99
+2 Dakmor Scorpion|S99
+2 Feral Shadow|S99
+2 Gravedigger|S99
+2 Hollow Dogs|S99
+2 Ravenous Rats|S99
+2 Serpent Warrior|S99
+1 Ancient Craving|S99
+2 Chorus of Woe|S99
+1 Dakmor Plague|S99
+3 Hand of Death|S99
+2 Mind Rot|S99
+1 Soul Feast|S99
+[sideboard]

--- a/forge-gui/res/quest/precons/Decay.dck
+++ b/forge-gui/res/quest/precons/Decay.dck
@@ -13,7 +13,9 @@ Image=decay.jpg
 1 Bog Imp|7ED
 2 Drudge Skeletons|7ED
 1 Fallen Angel|7ED
-16 Swamp|7ED
+6 Swamp|7ED|1
+5 Swamp|7ED|2
+5 Swamp|7ED|3
 1 Ostracize|7ED
 2 Gravedigger|7ED
 1 Looming Shade|7ED

--- a/forge-gui/res/quest/precons/Deep Freeze.dck
+++ b/forge-gui/res/quest/precons/Deep Freeze.dck
@@ -34,6 +34,10 @@ Image=deep_freeze.jpg
 2 Repentance|TMP
 2 Soltari Lancer|TMP
 1 Sky Spirit|TMP
-13 Island|TMP
-11 Plains|TMP
+5 Island|TMP|1
+4 Island|TMP|2
+4 Island|TMP|3
+4 Plains|TMP|1
+4 Plains|TMP|2
+3 Plains|TMP|3
 [sideboard]

--- a/forge-gui/res/quest/precons/Deepwood Menace.dck
+++ b/forge-gui/res/quest/precons/Deepwood Menace.dck
@@ -1,0 +1,38 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Deepwood Menace
+Description=Deepwood Menace unleashes the dangers of the Deepwood. Aggressive creatures and combat tricks crush unprepared opponents.
+Deck Type=constructed
+Set=MMQ
+Image=deepwood_menace.jpg
+[main]
+5 Mountain|MMQ|1
+4 Mountain|MMQ|2
+4 Mountain|MMQ|3
+4 Forest|MMQ|1
+4 Forest|MMQ|2
+3 Forest|MMQ|3
+1 Battle Squadron|MMQ
+2 Cinder Elemental|MMQ
+2 Deepwood Drummer|MMQ
+2 Deepwood Tantiv|MMQ
+3 Deepwood Wolverine|MMQ
+3 Horned Troll|MMQ
+2 Kris Mage|MMQ
+2 Saber Ants|MMQ
+2 Shock Troops|MMQ
+2 Squallmonger|MMQ
+3 Vine Trellis|MMQ
+1 Tiger Claws|MMQ
+1 Lunge|MMQ
+1 Natural Affinity|MMQ
+3 Thunderclap|MMQ
+2 Desert Twister|MMQ
+2 Revive|MMQ
+1 Tranquility|MMQ
+1 Volcanic Wind|MMQ
+[sideboard]

--- a/forge-gui/res/quest/precons/Defenders of the Cause.dck
+++ b/forge-gui/res/quest/precons/Defenders of the Cause.dck
@@ -1,0 +1,58 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Defenders of the Cause
+Description=A green-white control deck from Anthologies. Establish ground stalemates while winning through aerial superiority with Serra Angel.
+Deck Type=constructed
+Set=ATH
+Image=defenders_of_the_cause.jpg
+[main]
+4 Plains|4ED|1
+4 Plains|4ED|2
+3 Plains|4ED|3
+4 Forest|4ED|1
+3 Forest|4ED|2
+3 Forest|4ED|3
+1 Brushland|ICE
+1 Drifting Meadow|USG
+1 Pendelhaven|LEG
+1 Slippery Karst|USG
+1 Armored Pegasus|TMP
+1 Benalish Knight|WTH
+1 Canopy Spider|TMP
+1 Carnivorous Plant|DRK
+1 Combat Medic|FEM
+1 Erhnam Djinn|CHR
+1 Freewind Falcon|VIS
+1 Giant Spider|4ED
+1 Gorilla Chieftain|ALL
+1 Icatian Javelineers|FEM
+1 Infantry Veteran|VIS
+1 Llanowar Elves|4ED
+1 Mirri, Cat Warrior|EXO
+1 Order of the White Shield|ICE
+1 Pegasus Charger|USG
+1 Ranger en-Vec|TMP
+1 Samite Healer|4ED
+1 Scavenger Folk|DRK
+1 Serra Angel|4ED
+1 Spectral Bears|HML
+1 White Knight|4ED
+1 Woolly Spider|ICE
+1 Youthful Knight|STH
+1 Disenchant|4ED
+1 Giant Growth|4ED
+1 Swords to Plowshares|4ED
+1 Warrior's Honor|VIS
+1 Armageddon|4ED
+1 Hurricane|4ED
+1 Overrun|TMP
+1 Pegasus Stampede|EXO
+1 Jalum Tome|CHR
+1 Serrated Arrows|HML
+1 Pacifism|TMP
+1 Sacred Mesa|MIR
+[sideboard]

--- a/forge-gui/res/quest/precons/Devastation.dck
+++ b/forge-gui/res/quest/precons/Devastation.dck
@@ -1,0 +1,43 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Devastation
+Description=Devastation unleashes primal fury. Green beasts and red burn devastate all opposition.
+Deck Type=constructed
+Set=ONS
+Image=devastation.jpg
+[main]
+3 Mountain|ONS|1
+3 Mountain|ONS|2
+3 Mountain|ONS|3
+5 Forest|ONS|1
+4 Forest|ONS|2
+4 Forest|ONS|3
+2 Forgotten Cave|ONS
+2 Tranquil Thicket|ONS
+2 Barkhide Mauler|ONS
+1 Battering Craghorn|ONS
+1 Charging Slateback|ONS
+3 Elvish Pioneer|ONS
+1 Krosan Groundshaker|ONS
+1 Shaleskin Bruiser|ONS
+1 Snapping Thragg|ONS
+3 Snarling Undorak|ONS
+1 Tephraderm|ONS
+1 Towering Baloth|ONS
+1 Venomspout Brackus|ONS
+3 Wirewood Elf|ONS
+3 Wirewood Savage|ONS
+2 Chain of Plasma|ONS
+1 Naturalize|ONS
+1 Primal Boost|ONS
+1 Solar Blast|ONS
+1 Erratic Explosion|ONS
+3 Explosive Vegetation|ONS
+1 Thunder of Hooves|ONS
+1 Aether Charge|ONS
+1 Cryptic Gateway|ONS
+[sideboard]

--- a/forge-gui/res/quest/precons/Dismissal.dck
+++ b/forge-gui/res/quest/precons/Dismissal.dck
@@ -1,0 +1,49 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Dismissal
+Description=Dismissal bounces and destroys threats while evasive creatures deal damage. Classic blue-black control.
+Deck Type=constructed
+Set=INV
+Image=dismissal.jpg
+[main]
+4 Island|INV|1
+4 Island|INV|2
+3 Island|INV|3
+3 Swamp|INV|1
+3 Swamp|INV|2
+3 Swamp|INV|3
+2 Salt Marsh|INV
+1 Sulfur Vent|INV
+2 Dream Thrush|INV
+1 Duskwalker|INV
+2 Faerie Squadron|INV
+1 Hate Weaver|INV
+1 Metathran Zombie|INV
+1 Nightscape Apprentice|INV
+1 Phyrexian Infiltrator|INV
+3 Ravenous Rats|INV
+1 Slinking Serpent|INV
+1 Stalking Assassin|INV
+1 Tidal Visionary|INV
+2 Urborg Drake|INV
+1 Urborg Emissary|INV
+1 Vodalian Hypnotist|INV
+2 Vodalian Serpent|INV
+1 Vodalian Zombie|INV
+1 Cursed Flesh|INV
+1 Seer's Vision|INV
+1 Agonizing Demise|INV
+1 Disrupt|INV
+1 Opt|INV
+1 Prohibit|INV
+3 Recoil|INV
+1 Repulse|INV
+1 Spite // Malice|INV
+1 Lobotomy|INV
+2 Probe|INV
+1 Drake-Skull Cameo|INV
+[sideboard]

--- a/forge-gui/res/quest/precons/Disrupter.dck
+++ b/forge-gui/res/quest/precons/Disrupter.dck
@@ -38,7 +38,11 @@ Image=disrupter.jpg
 1 Gerrard's Irregulars|MMQ
 1 Ogre Taskmaster|MMQ
 1 Subterranean Hangar|MMQ
-12 Swamp|MMQ
-8 Mountain|MMQ
+4 Swamp|MMQ|1
+4 Swamp|MMQ|2
+4 Swamp|MMQ|3
+3 Mountain|MMQ|1
+3 Mountain|MMQ|2
+2 Mountain|MMQ|3
 1 Undertaker|MMQ
 [sideboard]

--- a/forge-gui/res/quest/precons/Distress.dck
+++ b/forge-gui/res/quest/precons/Distress.dck
@@ -1,0 +1,48 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Distress
+Description=Distress grinds opponents down with removal and life drain. Inevitability through attrition.
+Deck Type=constructed
+Set=PCY
+Image=distress.jpg
+[main]
+3 Plains|MMQ|1
+3 Plains|MMQ|2
+3 Plains|MMQ|3
+4 Swamp|MMQ|1
+4 Swamp|MMQ|2
+3 Swamp|MMQ|3
+1 Peat Bog|MMQ
+1 Agent of Shauku|PCY
+1 Avatar of Woe|PCY
+1 Ballista Squad|MMQ
+1 Belbe's Percher|NMS
+1 Chilling Apparition|PCY
+1 Death Charmer|PCY
+2 Fresh Volunteers|MMQ
+3 Glittering Lion|PCY
+2 Glittering Lynx|PCY
+1 Nakaya Shade|PCY
+1 Plague Fiend|PCY
+1 Shield Dancer|PCY
+2 Skulking Fugitive|MMQ
+1 Spineless Thug|NMS
+1 Maggot Therapy|MMQ
+1 Seal of Cleansing|NMS
+1 Seal of Doom|NMS
+1 Afterlife|MIR
+1 Angelic Favor|NMS
+2 Dark Ritual|LEA
+1 Disenchant|LEA
+2 Excise|PCY
+1 Steal Strength|PCY
+1 Snuff Out|MMQ
+3 Despoil|PCY
+2 Rain of Tears|POR
+2 Rhystic Syphon|PCY
+1 Rhystic Tutor|PCY
+[sideboard]

--- a/forge-gui/res/quest/precons/Domain.dck
+++ b/forge-gui/res/quest/precons/Domain.dck
@@ -25,15 +25,25 @@ Image=domain.jpg
 1 Treva's Charm|PLS
 2 Stratadon|PLS
 2 Exotic Disease|PLS
-3 Island|INV
+1 Island|INV|1
+1 Island|INV|2
+1 Island|INV|3
 2 Terminal Moraine|PLS
 1 Kavu Recluse|PLS
 3 Samite Pilgrim|PLS
 1 Quirion Dryad|PLS
-3 Plains|INV
-3 Swamp|INV
-3 Mountain|INV
-8 Forest|INV
+1 Plains|INV|1
+1 Plains|INV|2
+1 Plains|INV|3
+1 Swamp|INV|1
+1 Swamp|INV|2
+1 Swamp|INV|3
+1 Mountain|INV|1
+1 Mountain|INV|2
+1 Mountain|INV|3
+3 Forest|INV|1
+3 Forest|INV|2
+2 Forest|INV|3
 2 Quirion Explorer|PLS
 2 Allied Strategies|PLS
 1 Primal Growth|PLS

--- a/forge-gui/res/quest/precons/Dominator.dck
+++ b/forge-gui/res/quest/precons/Dominator.dck
@@ -1,0 +1,34 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Dominator
+Description=The Dominator deck establishes complete control over the game. Counter spells, bounce permanents, and dominate the board with evasive creatures.
+Deck Type=constructed
+Set=EXO
+Image=dominator.jpg
+[main]
+9 Island|TMP|1
+9 Island|TMP|2
+8 Island|TMP|3
+2 Cloud Spirit|STH
+4 Thalakos Scout|EXO
+1 Dominating Licid|EXO
+2 Mirozel|EXO
+2 Wayward Soul|EXO
+2 Killer Whale|EXO
+1 Erratic Portal|EXO
+1 Equilibrium|EXO
+1 Legacy's Allure|TMP
+1 Propaganda|TMP
+1 Treasure Trove|EXO
+2 Capsize|TMP
+4 Counterspell|TMP
+2 Forbid|EXO
+3 Mana Leak|STH
+2 Mind Games|STH
+2 Fade Away|EXO
+1 Time Ebb|TMP
+[sideboard]

--- a/forge-gui/res/quest/precons/Elvish Rage.dck
+++ b/forge-gui/res/quest/precons/Elvish Rage.dck
@@ -24,7 +24,9 @@ Image=elvish_rage.jpg
 1 Bloodline Shaman|ONS
 1 Elvish Warrior|ONS
 2 Elven Riders|ONS
-25 Forest|ONS
+9 Forest|ONS|1
+8 Forest|ONS|2
+8 Forest|ONS|3
 3 Patron of the Wild|LGN
 2 Gempalm Strider|LGN
 1 Elvish Soultiller|LGN

--- a/forge-gui/res/quest/precons/Enchanter.dck
+++ b/forge-gui/res/quest/precons/Enchanter.dck
@@ -1,0 +1,48 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Enchanter
+Description=The Enchanter deck weaves powerful auras onto creatures. Transform humble beings into unstoppable forces.
+Deck Type=constructed
+Set=UDS
+Image=enchanter.jpg
+[main]
+5 Island|USG|1
+4 Island|USG|2
+4 Island|USG|3
+3 Plains|USG|1
+2 Plains|USG|2
+2 Plains|USG|3
+2 Drifting Meadow|USG
+2 Remote Isle|USG
+3 Fledgling Osprey|UDS
+1 Horseshoe Crab|USG
+3 Metathran Elite|UDS
+1 Monk Realist|USG
+1 Mother of Runes|ULG
+1 Rayne, Academy Chancellor|UDS
+2 Thieving Magpie|UDS
+1 Thran Golem|UDS
+2 Thornwind Faeries|ULG
+2 Tormented Angel|UDS
+1 Vigilant Drake|ULG
+1 Wall of Glare|UDS
+1 Disenchant|TMP
+1 Humble|USG
+2 Miscalculation|ULG
+1 Opportunity|ULG
+1 Quash|UDS
+1 Radiant's Judgment|ULG
+1 Archery Training|UDS
+2 Brilliant Halo|USG
+1 Capashen Standard|UDS
+1 Confiscate|USG
+1 Hermetic Study|USG
+1 Mask of Law and Grace|UDS
+1 Private Research|UDS
+1 Sigil of Sleep|UDS
+1 Zephid's Embrace|USG
+[sideboard]

--- a/forge-gui/res/quest/precons/Eruption.dck
+++ b/forge-gui/res/quest/precons/Eruption.dck
@@ -1,0 +1,45 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Eruption
+Description=Eruption explodes with aggressive creatures and direct damage. Fast and furious, this deck ends games quickly.
+Deck Type=constructed
+Set=NMS
+Image=eruption.jpg
+[main]
+4 Plains|MMQ
+3 Plains|MMQ
+3 Plains|MMQ
+5 Mountain|MMQ
+5 Mountain|MMQ
+4 Mountain|MMQ
+2 Alabaster Wall|MMQ
+1 Arc Mage|NMS
+2 Chieftain en-Dal|NMS
+1 Crenellated Wall|MMQ
+1 Defender en-Vec|NMS
+2 Flowstone Crusher|NMS
+1 Flowstone Overseer|NMS
+1 Kris Mage|MMQ
+3 Laccolith Grunt|NMS
+2 Laccolith Warrior|NMS
+2 Laccolith Whelp|NMS
+1 Oracle's Attendants|NMS
+2 Trap Runner|MMQ
+1 Flaming Sword|MMQ
+1 Inviolability|MMQ
+1 Seal of Cleansing|NMS
+3 Seal of Fire|NMS
+1 Disenchant|LEA
+1 Downhill Charge|NMS
+1 Ramosian Rally|MMQ
+1 Sivvi's Ruse|NMS
+1 Thunderclap|MMQ
+1 Volcanic Wind|MMQ
+1 Belbe's Armor|NMS
+1 Flowstone Armor|NMS
+1 Iron Lance|MMQ
+[sideboard]

--- a/forge-gui/res/quest/precons/Fiendish Nature.dck
+++ b/forge-gui/res/quest/precons/Fiendish Nature.dck
@@ -17,8 +17,12 @@ Image=fiendish_nature.jpg
 1 Polluted Mire|USG
 2 Expunge|USG
 1 Winding Wurm|USG
-6 Swamp|6ED
-13 Forest|6ED
+2 Swamp|6ED|1
+2 Swamp|6ED|2
+2 Swamp|6ED|3
+5 Forest|6ED|1
+4 Forest|6ED|2
+4 Forest|6ED|3
 1 No Rest for the Wicked|USG
 1 Diabolic Servitude|USG
 1 Victimize|USG

--- a/forge-gui/res/quest/precons/Fiery Fury.dck
+++ b/forge-gui/res/quest/precons/Fiery Fury.dck
@@ -1,0 +1,35 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Fiery Fury
+Description=Fiery Fury burns everything. Mono-red burn and aggressive creatures.
+Deck Type=constructed
+Set=WTH
+Image=fiery_fury.jpg
+[main]
+8 Mountain|MIR|1
+8 Mountain|MIR|2
+7 Mountain|MIR|3
+1 Crystal Vein|MIR
+3 Bloodrock Cyclops|WTH
+3 Goblin Vandal|WTH
+1 Hulking Cyclops|VIS
+3 Lava Hounds|WTH
+2 Roc Hatchling|WTH
+1 Suq'Ata Lancer|VIS
+2 Talruum Minotaur|MIR
+2 Viashino Sandstalker|VIS
+1 Wildfire Emissary|MIR
+2 Fireblast|VIS
+1 Firestorm|WTH
+3 Incinerate|MIR
+1 Thunderbolt|WTH
+2 Spitting Earth|MIR
+3 Cone of Flame|WTH
+2 Kaervek's Torch|MIR
+1 Heart of Bogardan|WTH
+3 Mind Stone|WTH
+[sideboard]

--- a/forge-gui/res/quest/precons/Finkel.dck
+++ b/forge-gui/res/quest/precons/Finkel.dck
@@ -1,0 +1,40 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Finkel
+Description=Jon Finkel's black-red deck from Deckmasters 2001. Necropotence powers this aggressive deck designed by one of Magic's greatest players.
+Deck Type=constructed
+Set=DKM
+Image=finkel.jpg
+[main]
+4 Mountain|ICE|1
+4 Mountain|ICE|2
+4 Mountain|ICE|3
+4 Swamp|ICE|1
+4 Swamp|ICE|2
+4 Swamp|ICE|3
+1 Sulfurous Springs|ICE
+1 Underground River|ICE
+2 Abyssal Specter|ICE
+1 Balduvian Horde|ALL
+2 Foul Familiar|ICE
+2 Goblin Mutant|ICE
+2 Lim-Dûl's High Guard|ALL
+2 Orcish Cannoneers|ICE
+2 Phantasmal Fiend|ALL
+2 Phyrexian War Beast|ALL
+2 Storm Shaman|ALL
+2 Contagion|ALL
+2 Dark Banishing|ICE
+2 Dark Ritual|ICE
+2 Guerrilla Tactics|ALL
+2 Incinerate|ICE
+2 Lava Burst|ICE
+2 Pyroclasm|ICE
+2 Soul Burn|ICE
+2 Icy Manipulator|ICE
+1 Necropotence|ICE
+[sideboard]

--- a/forge-gui/res/quest/precons/Garfield.dck
+++ b/forge-gui/res/quest/precons/Garfield.dck
@@ -1,0 +1,43 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Garfield
+Description=Richard Garfield's red-green deck from Deckmasters 2001. Efficient creatures and burn spells in a classic design by Magic's creator.
+Deck Type=constructed
+Set=DKM
+Image=garfield.jpg
+[main]
+4 Forest|ICE|1
+4 Forest|ICE|2
+4 Forest|ICE|3
+4 Mountain|ICE|1
+4 Mountain|ICE|2
+4 Mountain|ICE|3
+1 Karplusan Forest|ICE
+2 Balduvian Bears|ICE
+1 Elvish Bard|ALL
+1 Folk of the Pines|ICE
+2 Fyndhorn Elves|ICE
+2 Giant Trap Door Spider|ICE
+1 Lhurgoyf|ICE
+2 Phyrexian War Beast|ALL
+2 Storm Shaman|ALL
+2 Walking Wall|ICE
+2 Woolly Spider|ICE
+2 Yavimaya Ancients|ALL
+2 Yavimaya Ants|ALL
+1 Bounty of the Hunt|ALL
+2 Death Spark|ALL
+2 Giant Growth|ICE
+2 Incinerate|ICE
+1 Shatter|ICE
+1 Hurricane|ICE
+1 Jokulhaups|ICE
+2 Lava Burst|ICE
+1 Pillage|ALL
+2 Barbed Sextant|ICE
+1 Elkin Bottle|ICE
+[sideboard]

--- a/forge-gui/res/quest/precons/Gatecrasher.dck
+++ b/forge-gui/res/quest/precons/Gatecrasher.dck
@@ -1,0 +1,40 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Gatecrasher
+Description=Gatecrasher smashes through defenses. Green-red aggression breaks down doors.
+Deck Type=constructed
+Set=WTH
+Image=gatecrasher.jpg
+[main]
+3 Mountain|MIR|1
+2 Mountain|MIR|2
+2 Mountain|MIR|3
+5 Forest|MIR|1
+5 Forest|MIR|2
+5 Forest|MIR|3
+1 Aboroth|WTH
+3 Arctic Wolves|WTH
+1 Bogardan Firefiend|WTH
+2 Granger Guildmage|MIR
+1 Llanowar Behemoth|WTH
+3 Llanowar Sentinel|WTH
+1 Maraxus of Keld|WTH
+2 Redwood Treefolk|WTH
+2 Stampeding Wildebeests|VIS
+2 Striped Bears|WTH
+2 Uktabi Efreet|WTH
+1 Uktabi Orangutan|VIS
+3 Wall of Roots|MIR
+2 Fire Whip|WTH
+2 Incinerate|ICE
+2 Cone of Flame|WTH
+1 Creeping Mold|VIS
+1 Kaervek's Torch|MIR
+3 Rampant Growth|MIR
+1 Savage Twister|MIR
+2 Dragon Mask|VIS
+[sideboard]

--- a/forge-gui/res/quest/precons/Goblin Assault.dck
+++ b/forge-gui/res/quest/precons/Goblin Assault.dck
@@ -1,0 +1,28 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Goblin Assault
+Description=Goblin Assault brings the heat. Red direct damage and fast creatures.
+Deck Type=constructed
+Set=S99
+Image=goblin_assault.jpg
+[main]
+6 Mountain|S99|1
+6 Mountain|S99|2
+5 Mountain|S99|3
+3 Goblin Chariot|S99
+2 Goblin General|S99
+2 Goblin Glider|S99
+2 Hulking Goblin|S99
+3 Raging Goblin|S99
+1 Volcanic Dragon|S99
+1 Jagged Lightning|S99
+2 Lava Axe|S99
+1 Relentless Assault|S99
+2 Scorching Spear|S99
+1 Spitting Earth|S99
+3 Volcanic Hammer|S99
+[sideboard]

--- a/forge-gui/res/quest/precons/Goblin Fire.dck
+++ b/forge-gui/res/quest/precons/Goblin Fire.dck
@@ -1,0 +1,29 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Goblin Fire
+Description=Goblin Fire unleashes destruction. Red goblins and burn spells.
+Deck Type=constructed
+Set=PO2
+Image=goblin_fire.jpg
+[main]
+5 Mountain|PO2
+5 Mountain|PO2
+5 Mountain|PO2
+2 Goblin Cavaliers|PO2
+2 Goblin Firestarter|PO2
+1 Goblin General|PO2
+2 Goblin Glider|PO2
+2 Goblin Matron|PO2
+2 Goblin Piker|PO2
+2 Goblin Raider|PO2
+3 Raging Goblin|PO2
+2 Blaze|PO2
+2 Goblin War Strike|PO2
+1 Relentless Assault|PO2
+3 Volcanic Hammer|PO2
+1 Wildfire|PO2
+[sideboard]

--- a/forge-gui/res/quest/precons/Goblin Mob.dck
+++ b/forge-gui/res/quest/precons/Goblin Mob.dck
@@ -1,0 +1,41 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Goblin Mob
+Description=Goblin Mob swarms with aggressive goblins. Red goblin tribal at its finest.
+Deck Type=constructed
+Set=SCG
+Image=goblin_mob.jpg
+[main]
+7 Mountain|ONS|1
+7 Mountain|ONS|2
+6 Mountain|ONS|3
+2 Forgotten Cave|ONS
+2 Goblin Burrows|ONS
+1 Flamestick Courier|ONS
+1 Gempalm Incinerator|LGN
+3 Goblin Brigand|SCG
+2 Goblin Grappler|LGN
+1 Goblin Psychopath|SCG
+2 Goblin Sky Raider|ONS
+2 Goblin Sledder|ONS
+2 Goblin Taskmaster|ONS
+1 Goblin Warchief|SCG
+1 Nosy Goblin|ONS
+1 Reckless One|ONS
+3 Rock Jockey|SCG
+1 Siege-Gang Commander|SCG
+2 Skirk Commando|ONS
+1 Skirk Drill Sergeant|LGN
+2 Skirk Marauder|LGN
+2 Skirk Volcanist|SCG
+1 Sparksmith|ONS
+2 Carbonize|SCG
+1 Enrage|SCG
+2 Goblin War Strike|SCG
+1 Wave of Indifference|ONS
+1 Sulfuric Vortex|SCG
+[sideboard]

--- a/forge-gui/res/quest/precons/Grave Danger.dck
+++ b/forge-gui/res/quest/precons/Grave Danger.dck
@@ -25,14 +25,18 @@ Image=grave_danger.jpg
 2 Compulsion|TOR
 2 Crypt Creeper|ODY
 1 False Memories|TOR
-11 Island|ODY
+4 Island|ODY|1
+4 Island|ODY|2
+3 Island|ODY|3
 1 Morgue Theft|ODY
 2 Obsessive Search|TOR
 4 Organ Grinder|TOR
 1 Painbringer|ODY
 2 Psychatog|ODY
 1 Skywing Aven|TOR
-11 Swamp|ODY
+4 Swamp|ODY|1
+4 Swamp|ODY|2
+3 Swamp|ODY|3
 2 Tainted Isle|TOR
 1 Zombie Assassin|ODY
 [sideboard]

--- a/forge-gui/res/quest/precons/Ground Pounder.dck
+++ b/forge-gui/res/quest/precons/Ground Pounder.dck
@@ -1,0 +1,58 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Ground Pounder
+Description=A red-green beatdown deck from Beatdown. Features the biggest, baddest creatures including Shivan Dragon and Force of Nature.
+Deck Type=constructed
+Set=BTD
+Image=ground_pounder.jpg
+[main]
+4 Forest|TMP|1
+4 Forest|TMP|2
+3 Forest|TMP|3
+4 Mountain|TMP|1
+4 Mountain|TMP|2
+3 Mountain|TMP|3
+1 Dwarven Ruins|FEM
+1 Havenwood Battleground|FEM
+1 Slippery Karst|USG
+1 Smoldering Crater|USG
+1 Balduvian Horde|ALL
+1 Ball Lightning|4ED
+1 Bloodrock Cyclops|WTH
+1 Clockwork Beast|4ED
+1 Crash of Rhinos|MIR
+1 Crashing Boars|EXO
+1 Deadly Insect|ALL
+1 Erhnam Djinn|CHR
+1 Force of Nature|4ED
+1 Hulking Cyclops|VIS
+1 Kird Ape|ARN
+1 Llanowar Elves|4ED
+1 Lowland Giant|TMP
+1 Plated Spider|UDS
+1 Quirion Elves|MIR
+1 Raging Goblin|EXO
+1 Scaled Wurm|ICE
+1 Segmented Wurm|TMP
+1 Shambling Strider|ICE
+1 Shivan Dragon|4ED
+1 Talruum Minotaur|MIR
+1 Thundering Giant|USG
+1 Viashino Warrior|MIR
+1 Woolly Spider|ICE
+1 Yavimaya Wurm|ULG
+1 Fog|4ED
+1 Giant Growth|4ED
+1 Lightning Bolt|4ED
+1 Shock|STH
+1 Sonic Burst|EXO
+1 Thunderbolt|WTH
+1 Fireball|4ED
+1 Lava Axe|ULG
+1 Rampant Growth|MIR
+1 Wild Growth|4ED
+[sideboard]

--- a/forge-gui/res/quest/precons/Groundbreaker.dck
+++ b/forge-gui/res/quest/precons/Groundbreaker.dck
@@ -18,7 +18,9 @@ Image=groundbreaker.jpg
 1 Evincar's Justice|TMP
 3 Flowstone Flood|EXO
 1 Monstrous Hound|EXO
-12 Mountain|TMP
+4 Mountain|TMP|1
+4 Mountain|TMP|2
+4 Mountain|TMP|3
 1 Nausea|EXO
 1 Necrologia|EXO
 3 Rain of Tears|TMP
@@ -26,7 +28,9 @@ Image=groundbreaker.jpg
 1 Searing Touch|TMP
 3 Shock|STH
 4 Stone Rain|TMP
-12 Swamp|TMP
+4 Swamp|TMP|1
+4 Swamp|TMP|2
+4 Swamp|TMP|3
 1 Thopter Squadron|EXO
 2 Thrull Surgeon|EXO
 2 Vampire Hounds|EXO

--- a/forge-gui/res/quest/precons/Heavy Duty.dck
+++ b/forge-gui/res/quest/precons/Heavy Duty.dck
@@ -1,0 +1,45 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Heavy Duty
+Description=Heavy Duty deploys efficient green-white creatures. Solid bodies and combat tricks win through quality.
+Deck Type=constructed
+Set=INV
+Image=heavy_duty.jpg
+[main]
+4 Plains|INV|1
+4 Plains|INV|2
+3 Plains|INV|3
+4 Forest|INV|1
+4 Forest|INV|2
+3 Forest|INV|3
+2 Elfhame Palace|INV
+2 Angel of Mercy|INV
+1 Ardent Soldier|INV
+1 Benalish Emissary|INV
+1 Benalish Lancer|INV
+1 Benalish Trapper|INV
+1 Capashen Unicorn|INV
+2 Charging Troll|INV
+1 Crimson Acolyte|INV
+2 Kavu Chameleon|INV
+1 Kavu Climber|INV
+2 Llanowar Cavalry|INV
+1 Llanowar Elite|INV
+2 Llanowar Knight|INV
+1 Noble Panther|INV
+1 Obsidian Acolyte|INV
+1 Pincer Spider|INV
+2 Rampant Elephant|INV
+2 Razorfoot Griffin|INV
+1 Rooting Kavu|INV
+1 Thicket Elemental|INV
+1 Treefolk Healer|INV
+2 Armadillo Cloak|INV
+2 Shackles|INV
+2 Explosive Growth|INV
+2 Wax // Wane|INV
+[sideboard]

--- a/forge-gui/res/quest/precons/Impaler.dck
+++ b/forge-gui/res/quest/precons/Impaler.dck
@@ -1,0 +1,28 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Impaler
+Description=Impaler commands nature's might. Green's biggest, baddest creatures.
+Deck Type=constructed
+Set=S99
+Image=impaler.jpg
+[main]
+6 Forest|S99|1
+6 Forest|S99|2
+5 Forest|S99|3
+2 Bull Hippo|S99
+3 Durkwood Boars|S99
+3 Grizzly Bears|S99
+2 Lone Wolf|S99
+3 Norwood Archers|S99
+1 Pride of Lions|S99
+1 Thorn Elemental|S99
+2 Wild Ox|S99
+2 Monstrous Growth|S99
+2 Nature's Lore|S99
+1 Renewing Touch|S99
+1 Whirlwind|S99
+[sideboard]

--- a/forge-gui/res/quest/precons/Infestation.dck
+++ b/forge-gui/res/quest/precons/Infestation.dck
@@ -20,7 +20,9 @@ Image=infestation.jpg
 1 Goblin Matron|7ED
 2 Goblin Raider|7ED
 1 Lightning Blast|7ED
-16 Mountain|7ED
+6 Mountain|7ED|1
+5 Mountain|7ED|2
+5 Mountain|7ED|3
 1 Patagia Golem|7ED
 2 Pillage|7ED
 2 Raging Goblin|7ED

--- a/forge-gui/res/quest/precons/Insanity.dck
+++ b/forge-gui/res/quest/precons/Insanity.dck
@@ -1,0 +1,39 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Insanity
+Description=Insanity embraces madness. Discard for value and deploy threats that love the graveyard.
+Deck Type=constructed
+Set=TOR
+Image=insanity.jpg
+[main]
+4 Swamp|ODY|1
+4 Swamp|ODY|2
+4 Swamp|ODY|3
+4 Forest|ODY|1
+3 Forest|ODY|2
+3 Forest|ODY|3
+2 Tainted Wood|TOR
+1 Anurid Scavenger|TOR
+2 Arrogant Wurm|TOR
+3 Basking Rootwalla|TOR
+2 Boneshard Slasher|TOR
+2 Carrion Rats|TOR
+2 Centaur Veteran|TOR
+1 Grotesque Hybrid|TOR
+2 Krosan Archer|ODY
+2 Krosan Constrictor|TOR
+1 Nantuko Blightcutter|TOR
+1 Nantuko Cultivator|TOR
+3 Putrid Imp|TOR
+3 Wild Mongrel|ODY
+2 Muscle Burst|ODY
+2 Sylvan Might|ODY
+2 Waste Away|TOR
+2 Acorn Harvest|TOR
+1 Narcissism|TOR
+2 Strength of Lunacy|TOR
+[sideboard]

--- a/forge-gui/res/quest/precons/Inundation.dck
+++ b/forge-gui/res/quest/precons/Inundation.dck
@@ -1,0 +1,37 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Inundation
+Description=Inundation floods the board with white creatures. Threshold unlocks even greater power.
+Deck Type=constructed
+Set=JUD
+Image=inundation.jpg
+[main]
+7 Plains|ODY|1
+7 Plains|ODY|2
+6 Plains|ODY|3
+2 Aven Cloudchaser|ODY
+2 Beloved Chaplain|ODY
+3 Benevolent Bodyguard|JUD
+1 Commander Eesha|JUD
+1 Dedicated Martyr|ODY
+3 Militant Monk|TOR
+2 Mystic Penitent|ODY
+2 Nomad Decoy|ODY
+3 Patrol Hound|ODY
+1 Selfless Exorcist|JUD
+1 Shieldmage Advocate|JUD
+2 Spurnmage Advocate|JUD
+4 Suntail Hawk|JUD
+1 Tireless Tribe|ODY
+1 Valor|JUD
+1 Embolden|ODY
+3 Guided Strike|JUD
+1 Prismatic Strands|JUD
+2 Shelter|ODY
+2 Battle Screech|JUD
+2 Unquestioned Authority|JUD
+[sideboard]

--- a/forge-gui/res/quest/precons/Ivory Doom.dck
+++ b/forge-gui/res/quest/precons/Ivory Doom.dck
@@ -1,0 +1,42 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Ivory Doom
+Description=Ivory Doom combines clerics with dark magic. White-black tribal control.
+Deck Type=constructed
+Set=ONS
+Image=ivory_doom.jpg
+[main]
+3 Plains|ONS|1
+3 Plains|ONS|2
+2 Plains|ONS|3
+3 Swamp|ONS|1
+3 Swamp|ONS|2
+2 Swamp|ONS|3
+4 Barren Moor|ONS
+4 Secluded Steppe|ONS
+1 Starlit Sanctum|ONS
+1 Aven Soulgazer|ONS
+2 Battlefield Medic|ONS
+2 Cabal Archon|ONS
+1 Cabal Executioner|ONS
+3 Daru Healer|ONS
+1 Daunting Defender|ONS
+2 Disciple of Grace|ONS
+4 Disciple of Malice|ONS
+2 Doubtless One|ONS
+3 Foothill Guide|ONS
+1 Gangrenous Goliath|ONS
+1 Headhunter|ONS
+1 Akroma's Blessing|ONS
+1 Death Pulse|ONS
+2 Smother|ONS
+2 Swat|ONS
+2 Profane Prayers|ONS
+1 Astral Slide|ONS
+2 Pacifism|ONS
+1 Sigil of the New Dawn|ONS
+[sideboard]

--- a/forge-gui/res/quest/precons/Jungle Jam.dck
+++ b/forge-gui/res/quest/precons/Jungle Jam.dck
@@ -1,0 +1,43 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Jungle Jam
+Description=Jungle Jam deploys Jamuraan creatures. Green-white beatdown from the wilds.
+Deck Type=constructed
+Set=MIR
+Image=jungle_jam.jpg
+[main]
+4 Plains|MIR|1
+3 Plains|MIR|2
+3 Plains|MIR|3
+1 Mountain|MIR|1
+4 Forest|MIR|1
+3 Forest|MIR|2
+3 Forest|MIR|3
+1 Grasslands|MIR
+1 Mountain Valley|MIR
+1 Benevolent Unicorn|MIR
+2 Ekundu Griffin|MIR
+2 Foratog|MIR
+3 Gibbering Hyenas|MIR
+3 Jolrael's Centaur|MIR
+2 Mtenda Griffin|MIR
+2 Nettletooth Djinn|MIR
+3 Quirion Elves|MIR
+1 Sawback Manticore|MIR
+2 Teremko Griffin|MIR
+2 Unyaro Griffin|MIR
+1 Zuberi, Golden Feather|MIR
+2 Armor of Thorns|MIR
+2 Pacifism|MIR
+1 Ritual of Steel|MIR
+1 Afterlife|MIR
+1 Disenchant|MIR
+1 Ivory Charm|MIR
+1 Vitalizing Cascade|MIR
+1 Worldly Tutor|MIR
+3 Rampant Growth|MIR
+[sideboard]

--- a/forge-gui/res/quest/precons/Legion of Glory.dck
+++ b/forge-gui/res/quest/precons/Legion of Glory.dck
@@ -1,0 +1,38 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Legion of Glory
+Description=Legion of Glory marches to war. White weenie with flanking knights.
+Deck Type=constructed
+Set=VIS
+Image=legion_of_glory.jpg
+[main]
+8 Plains|MIR|1
+8 Plains|MIR|2
+7 Plains|MIR|3
+3 Femeref Scouts|MIR
+2 Femeref Healer|MIR
+3 Infantry Veteran|VIS
+2 Jamuraan Lion|VIS
+2 Knight of Valor|VIS
+1 Longbow Archer|VIS
+1 Resistance Fighter|VIS
+2 Vigilant Martyr|MIR
+2 Zhalfirin Commander|MIR
+1 Zhalfirin Crusader|VIS
+2 Favorable Destiny|MIR
+2 Pacifism|MIR
+2 Sun Clasp|VIS
+1 Ward of Lights|MIR
+1 Afterlife|MIR
+1 Hope Charm|VIS
+2 Miraculous Recovery|VIS
+2 Remedy|VIS
+1 Warrior's Honor|VIS
+1 Blinding Light|MIR
+1 Retribution of the Meek|VIS
+2 Magma Mine|VIS
+[sideboard]

--- a/forge-gui/res/quest/precons/Liftoff.dck
+++ b/forge-gui/res/quest/precons/Liftoff.dck
@@ -1,0 +1,45 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Liftoff
+Description=Liftoff takes to the skies with flying creatures. Blue-white tempo with evasive threats.
+Deck Type=constructed
+Set=ODY
+Image=liftoff.jpg
+[main]
+4 Plains|ODY|1
+3 Plains|ODY|2
+3 Plains|ODY|3
+3 Island|ODY|1
+3 Island|ODY|2
+3 Island|ODY|3
+1 Abandoned Outpost|ODY
+1 Seafloor Debris|ODY
+1 Angelic Wall|ODY
+2 Aven Windreader|ODY
+1 Beloved Chaplain|ODY
+2 Blessed Orator|ODY
+2 Cephalid Broker|ODY
+2 Cephalid Looter|ODY
+1 Cephalid Retainer|ODY
+2 Cephalid Scout|ODY
+1 Mystic Crusader|ODY
+1 Mystic Penitent|ODY
+2 Mystic Visionary|ODY
+3 Mystic Zealot|ODY
+1 Nomad Decoy|ODY
+1 Pilgrim of Justice|ODY
+1 Puppeteer|ODY
+1 Embolden|ODY
+2 Kirtar's Desire|ODY
+2 Millikin|ODY
+1 Peek|ODY
+1 Second Thoughts|ODY
+1 Shelter|ODY
+1 Skycloud Egg|ODY
+2 Syncopate|ODY
+2 Think Tank|ODY
+[sideboard]

--- a/forge-gui/res/quest/precons/Martial Law.dck
+++ b/forge-gui/res/quest/precons/Martial Law.dck
@@ -1,0 +1,29 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Martial Law
+Description=Martial Law enforces order. White soldiers and griffins maintain peace.
+Deck Type=constructed
+Set=PO2
+Image=martial_law.jpg
+[main]
+5 Plains|PO2
+5 Plains|PO2
+5 Plains|PO2
+2 Alaborn Cavalier|PO2
+2 Alaborn Grenadier|PO2
+3 Alaborn Trooper|PO2
+1 Alaborn Veteran|PO2
+1 Angel of Fury|PO2
+2 Armored Griffin|PO2
+2 Temple Acolyte|PO2
+2 Volunteer Militia|PO2
+3 Wild Griffin|PO2
+1 Armageddon|PO2
+2 Path of Peace|PO2
+2 Righteous Charge|PO2
+2 Vengeance|PO2
+[sideboard]

--- a/forge-gui/res/quest/precons/Max Attax.dck
+++ b/forge-gui/res/quest/precons/Max Attax.dck
@@ -1,0 +1,41 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Max Attax
+Description=Max Attax goes all-in on massive creatures. Green-black fatties end games decisively.
+Deck Type=constructed
+Set=SCG
+Image=max_attax.jpg
+[main]
+2 Swamp|ONS|1
+2 Swamp|ONS|2
+2 Swamp|ONS|3
+5 Forest|ONS|1
+5 Forest|ONS|2
+4 Forest|ONS|3
+2 Barren Moor|ONS
+2 Temple of the False God|SCG
+2 Tranquil Thicket|ONS
+2 Elvish Aberration|SCG
+3 Fierce Empath|SCG
+1 Gluttonous Zombie|ONS
+3 Krosan Drover|SCG
+2 Kurgadon|SCG
+1 Root Elemental|SCG
+2 Spitting Gourna|ONS
+2 Symbiotic Beast|ONS
+2 Titanic Bulvox|SCG
+1 Treespring Lorian|ONS
+1 Venomspout Brackus|ONS
+2 Wirewood Guardian|SCG
+3 Accelerated Mutation|SCG
+2 Chill Haunting|SCG
+1 Smother|ONS
+2 Sprouting Vines|SCG
+1 Final Punishment|SCG
+2 Dragon Fangs|SCG
+1 Dragon Shadow|SCG
+[sideboard]

--- a/forge-gui/res/quest/precons/Migraine.dck
+++ b/forge-gui/res/quest/precons/Migraine.dck
@@ -28,5 +28,7 @@ Image=migraine.jpg
 2 Pit Imp|TMP
 1 Portcullis|STH
 1 Rabid Rats|STH
-24 Swamp|TMP
+8 Swamp|TMP|1
+8 Swamp|TMP|2
+8 Swamp|TMP|3
 [sideboard]

--- a/forge-gui/res/quest/precons/Morph Mayhem.dck
+++ b/forge-gui/res/quest/precons/Morph Mayhem.dck
@@ -1,0 +1,45 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Morph Mayhem
+Description=Morph Mayhem hides threats face-down. Flip creatures at opportune moments for maximum impact.
+Deck Type=constructed
+Set=LGN
+Image=morph_mayhem.jpg
+[main]
+4 Plains|ONS|1
+4 Plains|ONS|2
+3 Plains|ONS|3
+4 Island|ONS|1
+4 Island|ONS|2
+3 Island|ONS|3
+2 Lonely Sandbar|ONS
+2 Secluded Steppe|ONS
+2 Ascending Aven|ONS
+1 Aven Redeemer|LGN
+1 Chromeshell Crab|LGN
+1 Daru Mender|LGN
+1 Daru Lancer|ONS
+2 Deftblade Elite|LGN
+2 Echo Tracer|LGN
+4 Glory Seeker|ONS
+1 Imagecrafter|ONS
+1 Ironfist Crusher|ONS
+1 Liege of the Axe|LGN
+1 Master of the Veil|LGN
+1 Mistform Mutant|ONS
+1 Swooping Talon|LGN
+2 Voidmage Apprentice|LGN
+1 Wall of Deceit|LGN
+1 Weaver of Lies|LGN
+1 Whipcorder|ONS
+2 Willbender|LGN
+2 Wingbeat Warrior|LGN
+1 Akroma's Blessing|ONS
+1 Discombobulate|ONS
+1 Improvised Armor|ONS
+2 Pacifism|MIR
+[sideboard]

--- a/forge-gui/res/quest/precons/Nature's Assault.dck
+++ b/forge-gui/res/quest/precons/Nature's Assault.dck
@@ -1,0 +1,29 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Nature's Assault
+Description=Nature's Assault summons the wild. Green creatures and natural magic.
+Deck Type=constructed
+Set=PO2
+Image=natures_assault.jpg
+[main]
+5 Forest|PO2
+5 Forest|PO2
+5 Forest|PO2
+3 Bear Cub|PO2
+2 Golden Bear|PO2
+2 Ironhoof Ox|PO2
+2 Norwood Archers|PO2
+3 Norwood Ranger|PO2
+2 Norwood Riders|PO2
+2 River Bear|PO2
+1 Sylvan Basilisk|PO2
+2 Wild Ox|PO2
+1 Alluring Scent|PO2
+1 Hurricane|PO2
+2 Monstrous Growth|PO2
+2 Natural Spring|PO2
+[sideboard]

--- a/forge-gui/res/quest/precons/Night Terrors.dck
+++ b/forge-gui/res/quest/precons/Night Terrors.dck
@@ -1,0 +1,39 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Night Terrors
+Description=Night Terrors brings darkness to Jamuraa. Black control with discard and removal.
+Deck Type=constructed
+Set=MIR
+Image=night_terrors.jpg
+[main]
+8 Swamp|MIR|1
+7 Swamp|MIR|2
+7 Swamp|MIR|3
+1 Blighted Shaman|MIR
+3 Breathstealer|MIR
+2 Dread Specter|MIR
+3 Feral Shadow|MIR
+1 Fetid Horror|MIR
+1 Gravebane Zombie|MIR
+1 Ravenous Vampire|MIR
+2 Restless Dead|MIR
+2 Skulking Ghost|MIR
+1 Spirit of the Night|MIR
+3 Urborg Panther|MIR
+2 Wall of Corpses|MIR
+2 Bone Harvest|MIR
+2 Dark Banishing|MIR
+1 Nocturnal Raid|MIR
+1 Shallow Grave|MIR
+1 Soulshriek|MIR
+1 Withering Boon|MIR
+1 Drain Life|MIR
+1 Kaervek's Hex|MIR
+2 Stupor|MIR
+3 Charcoal Diamond|MIR
+1 Phyrexian Vault|MIR
+[sideboard]

--- a/forge-gui/res/quest/precons/Nightstalkers.dck
+++ b/forge-gui/res/quest/precons/Nightstalkers.dck
@@ -1,0 +1,29 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Nightstalkers
+Description=Nightstalkers lurk in shadows. Black discard and creature destruction.
+Deck Type=constructed
+Set=PO2
+Image=nightstalkers.jpg
+[main]
+5 Swamp|PO2
+5 Swamp|PO2
+5 Swamp|PO2
+2 Abyssal Nightstalker|PO2
+2 Brutal Nightstalker|PO2
+2 Dakmor Bat|PO2
+3 Lurking Nightstalker|PO2
+1 Nightstalker Engine|PO2
+2 Predatory Nightstalker|PO2
+3 Prowling Nightstalker|PO2
+2 Raiding Nightstalker|PO2
+1 Ancient Craving|PO2
+2 Cruel Edict|PO2
+2 Hand of Death|PO2
+2 Mind Rot|PO2
+1 Return of the Nightstalkers|PO2
+[sideboard]

--- a/forge-gui/res/quest/precons/One-Two Punch.dck
+++ b/forge-gui/res/quest/precons/One-Two Punch.dck
@@ -1,0 +1,41 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=One-Two Punch
+Description=One-Two Punch delivers a devastating combination. Green creatures and red burn finish games fast.
+Deck Type=constructed
+Set=ODY
+Image=one-two_punch.jpg
+[main]
+4 Mountain|ODY|1
+3 Mountain|ODY|2
+3 Mountain|ODY|3
+5 Forest|ODY|1
+5 Forest|ODY|2
+5 Forest|ODY|3
+3 Chatter of the Squirrel|ODY
+2 Druid Lyrist|ODY
+3 Elephant Ambush|ODY
+1 Gorilla Titan|ODY
+1 Krosan Archer|ODY
+2 Leaf Dancer|ODY
+1 Nantuko Mentor|ODY
+1 Rabid Elephant|ODY
+2 Beast Attack|ODY
+2 Deep Reconnaissance|ODY
+1 Earth Rift|ODY
+2 Engulfing Flames|ODY
+1 Firebolt|ODY
+1 Howling Gale|ODY
+1 Moment's Peace|ODY
+1 Reckless Charge|ODY
+1 Refresh|ODY
+2 Roar of the Wurm|ODY
+2 Scorching Missile|ODY
+1 Seize the Day|ODY
+2 Sylvan Might|ODY
+1 Volcanic Spray|ODY
+[sideboard]

--- a/forge-gui/res/quest/precons/Painflow.dck
+++ b/forge-gui/res/quest/precons/Painflow.dck
@@ -1,0 +1,37 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Painflow
+Description=Painflow deploys threshold creatures. Fill your graveyard to unlock their full power.
+Deck Type=constructed
+Set=JUD
+Image=painflow.jpg
+[main]
+7 Forest|ODY|1
+7 Forest|ODY|2
+6 Forest|ODY|3
+1 Anurid Barkripper|JUD
+2 Anurid Swarmsnapper|JUD
+2 Battlefield Scrounger|JUD
+2 Brawn|JUD
+3 Diligent Farmhand|ODY
+4 Giant Warthog|JUD
+1 Krosan Archer|ODY
+2 Krosan Wayfarer|JUD
+2 Nantuko Elder|ODY
+2 Nantuko Tracer|JUD
+2 Rabid Elephant|ODY
+1 Thriss, Nantuko Primus|JUD
+2 Tunneler Wurm|JUD
+3 Werebear|ODY
+2 Moment's Peace|ODY
+2 Sudden Strength|JUD
+1 Crush of Wurms|JUD
+2 Deep Reconnaissance|ODY
+1 Grizzly Fate|JUD
+2 Roar of the Wurm|ODY
+1 Seton's Desire|ODY
+[sideboard]

--- a/forge-gui/res/quest/precons/Pandemonium.dck
+++ b/forge-gui/res/quest/precons/Pandemonium.dck
@@ -1,0 +1,50 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Pandemonium
+Description=Pandemonium brings chaos to the battlefield. Five-color madness with powerful multicolored spells.
+Deck Type=constructed
+Set=APC
+Image=pandemonium.jpg
+[main]
+1 Plains|INV|1
+1 Plains|INV|2
+1 Plains|INV|3
+1 Island|INV|1
+1 Island|INV|2
+1 Island|INV|3
+1 Swamp|INV|1
+1 Swamp|INV|2
+1 Swamp|INV|3
+1 Mountain|INV|1
+1 Mountain|INV|2
+4 Forest|INV|1
+4 Forest|INV|2
+4 Forest|INV|3
+1 Emblazoned Golem|APC
+1 Helionaut|APC
+1 Nomadic Elf|INV
+3 Penumbra Bobcat|APC
+2 Penumbra Kavu|APC
+1 Penumbra Wurm|APC
+2 Quirion Elves|MIR
+1 Quirion Trailblazer|INV
+1 Stratadon|PLS
+2 Urborg Elf|APC
+1 Wayfaring Giant|INV
+2 Exotic Curse|INV
+2 Fertile Ground|USG
+1 Captain's Maneuver|APC
+2 Evasive Action|APC
+3 Harrow|TMP
+1 Order // Chaos|APC
+2 Allied Strategies|PLS
+1 Gaea's Balance|APC
+1 Last Stand|APC
+3 Lay of the Land|APC
+1 Life // Death|APC
+2 Tribal Flames|INV
+[sideboard]

--- a/forge-gui/res/quest/precons/Phyrexian Assault.dck
+++ b/forge-gui/res/quest/precons/Phyrexian Assault.dck
@@ -26,7 +26,9 @@ Image=phyrexian_assault.jpg
 1 Heat Ray|USG
 1 Looming Shade|USG
 1 Molten Hydra|ULG
-10 Mountain|USG
+4 Mountain|USG|1
+3 Mountain|USG|2
+3 Mountain|USG|3
 1 Phyrexian Broodlings|ULG
 2 Phyrexian Debaser|ULG
 2 Phyrexian Defiler|ULG
@@ -36,7 +38,9 @@ Image=phyrexian_assault.jpg
 1 Polluted Mire|USG
 1 Smoldering Crater|USG
 1 Spawning Pool|ULG
-12 Swamp|USG
+4 Swamp|USG|1
+4 Swamp|USG|2
+4 Swamp|USG|3
 1 Tethered Skirge|ULG
 1 Treacherous Link|ULG
 1 Viashino Cutthroat|ULG

--- a/forge-gui/res/quest/precons/Pressure Cooker.dck
+++ b/forge-gui/res/quest/precons/Pressure Cooker.dck
@@ -1,0 +1,45 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Pressure Cooker
+Description=Pressure Cooker builds up to an explosive finish. Red-black aggression with sacrifice themes.
+Deck Type=constructed
+Set=ODY
+Image=pressure_cooker.jpg
+[main]
+4 Swamp|ODY|1
+4 Swamp|ODY|2
+3 Swamp|ODY|3
+3 Mountain|ODY|1
+3 Mountain|ODY|2
+3 Mountain|ODY|3
+1 Bog Wreckage|ODY
+2 Cabal Pit|ODY
+1 Ravaged Highlands|ODY
+2 Barbarian Lunatic|ODY
+1 Braids, Cabal Minion|ODY
+2 Chainflinger|ODY
+2 Childhood Horror|ODY
+1 Crypt Creeper|ODY
+1 Dwarven Strike Force|ODY
+1 Face of Fear|ODY
+2 Famished Ghoul|ODY
+1 Frightcrawler|ODY
+1 Halberdier|ODY
+3 Pardic Firecat|ODY
+1 Repentant Vampire|ODY
+2 Engulfing Flames|ODY
+1 Firebolt|ODY
+3 Flame Burst|ODY
+2 Ghastly Demise|ODY
+1 Innocent Blood|ODY
+1 Liquid Fire|ODY
+2 Morbid Hunger|ODY
+1 Morgue Theft|ODY
+1 Reckless Charge|ODY
+2 Shadowblood Egg|ODY
+1 Thermal Blast|ODY
+[sideboard]

--- a/forge-gui/res/quest/precons/Pulverize.dck
+++ b/forge-gui/res/quest/precons/Pulverize.dck
@@ -1,0 +1,40 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Pulverize
+Description=Pulverize combines storm magic with burn. Build up spell count for devastating finishes.
+Deck Type=constructed
+Set=SCG
+Image=pulverize.jpg
+[main]
+4 Island|ONS|1
+4 Island|ONS|2
+4 Island|ONS|3
+4 Mountain|ONS|1
+4 Mountain|ONS|2
+4 Mountain|ONS|3
+1 Aven Fateshaper|ONS
+1 Bloodstoke Howler|LGN
+3 Chartooth Cougar|SCG
+1 Frenetic Raptor|LGN
+2 Goblin Machinist|ONS
+1 Macetail Hystrodon|LGN
+1 Mischievous Quanar|SCG
+2 Mistform Warchief|SCG
+3 Scornful Egotist|SCG
+2 Shoreline Ranger|SCG
+1 Skittish Valesk|ONS
+1 Thundercloud Elemental|SCG
+2 Carbonize|SCG
+2 Dispersal Shield|SCG
+2 Erratic Explosion|ONS
+2 Rush of Knowledge|SCG
+1 Slice and Dice|ONS
+3 Torrent of Fire|SCG
+2 Dragon Breath|SCG
+1 Parallel Thoughts|SCG
+2 Pyrostatic Pillar|SCG
+[sideboard]

--- a/forge-gui/res/quest/precons/Pummel.dck
+++ b/forge-gui/res/quest/precons/Pummel.dck
@@ -18,7 +18,9 @@ Image=pummel.jpg
 2 Hickory Woodlot|MMQ
 2 Hunted Wumpus|MMQ
 1 Lumbering Satyr|MMQ
-20 Forest|MMQ
+7 Forest|MMQ|1
+7 Forest|MMQ|2
+6 Forest|MMQ|3
 1 Stampede Driver|NMS
 2 Blastoderm|NMS
 1 Treetop Bracers|NMS

--- a/forge-gui/res/quest/precons/Radiant's Revenge.dck
+++ b/forge-gui/res/quest/precons/Radiant's Revenge.dck
@@ -16,7 +16,9 @@ Image=radiants_revenge.jpg
 1 Drifting Meadow|USG
 1 Erase|ULG
 1 Fog Bank|USG
-12 Island|USG
+4 Island|USG|1
+4 Island|USG|2
+4 Island|USG|3
 2 Miscalculation|ULG
 1 Mobile Fort|USG
 1 Mother of Runes|ULG
@@ -24,7 +26,9 @@ Image=radiants_revenge.jpg
 2 Opportunity|ULG
 1 Pacifism|USG
 2 Path of Peace|USG
-11 Plains|USG
+4 Plains|USG|1
+4 Plains|USG|2
+3 Plains|USG|3
 1 Power Sink|USG
 1 Radiant's Dragoons|ULG
 3 Radiant's Judgment|ULG

--- a/forge-gui/res/quest/precons/Rebel's Call.dck
+++ b/forge-gui/res/quest/precons/Rebel's Call.dck
@@ -1,0 +1,38 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Rebel's Call
+Description=Rebel's Call assembles an army of Rebels. Search your deck for the right soldier at the right time.
+Deck Type=constructed
+Set=MMQ
+Image=rebels_call.jpg
+[main]
+7 Plains|MMQ|1
+7 Plains|MMQ|2
+6 Plains|MMQ|3
+1 Fountain of Cho|MMQ
+2 Ballista Squad|MMQ
+2 Charm Peddler|MMQ
+1 Cho-Manno, Revolutionary|MMQ
+2 Devout Witness|MMQ
+2 Jhovall Rider|MMQ
+2 Nightwind Glider|MMQ
+2 Pious Warrior|MMQ
+2 Ramosian Captain|MMQ
+2 Ramosian Commander|MMQ
+2 Ramosian Lieutenant|MMQ
+3 Ramosian Sergeant|MMQ
+1 Ramosian Sky Marshal|MMQ
+2 Steadfast Guard|MMQ
+2 Task Force|MMQ
+2 Thermal Glider|MMQ
+2 Arrest|MMQ
+2 Cho-Manno's Blessing|MMQ
+1 Moonlit Wake|MMQ
+1 Afterlife|MMQ
+2 Disenchant|MMQ
+2 Ramosian Rally|MMQ
+[sideboard]

--- a/forge-gui/res/quest/precons/Ride Like the Wind.dck
+++ b/forge-gui/res/quest/precons/Ride Like the Wind.dck
@@ -1,0 +1,39 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Ride Like the Wind
+Description=Ride Like the Wind charges with flanking knights. Red-white aggression at its fastest.
+Deck Type=constructed
+Set=MIR
+Image=ride_like_the_wind.jpg
+[main]
+4 Plains|MIR|1
+4 Plains|MIR|2
+4 Plains|MIR|3
+4 Mountain|MIR|1
+4 Mountain|MIR|2
+4 Mountain|MIR|3
+2 Blistering Barrier|MIR
+1 Crimson Roc|MIR
+3 Burning Shield Askari|MIR
+3 Femeref Knight|MIR
+1 Iron Tusk Elephant|MIR
+1 Melesse Spirit|MIR
+3 Mtenda Herder|MIR
+3 Searing Spear Askari|MIR
+1 Sidar Jabari|MIR
+1 Telim'Tor|MIR
+1 Vigilant Martyr|MIR
+2 Zhalfirin Commander|MIR
+3 Zhalfirin Knight|MIR
+1 Agility|MIR
+2 Favorable Destiny|MIR
+1 Alarum|MIR
+2 Aleatory|MIR
+1 Shadowbane|MIR
+2 Spitting Earth|MIR
+2 Telim'Tor's Darts|MIR
+[sideboard]

--- a/forge-gui/res/quest/precons/Sacrilege.dck
+++ b/forge-gui/res/quest/precons/Sacrilege.dck
@@ -1,0 +1,41 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Sacrilege
+Description=Sacrilege profits from death. White-black sacrifice themes generate value from dying creatures.
+Deck Type=constructed
+Set=TOR
+Image=sacrilege.jpg
+[main]
+4 Plains|ODY|1
+3 Plains|ODY|2
+3 Plains|ODY|3
+4 Swamp|ODY|1
+4 Swamp|ODY|2
+4 Swamp|ODY|3
+2 Tainted Field|TOR
+1 Angel of Retribution|TOR
+1 Auramancer|ODY
+1 Aven Cloudchaser|ODY
+2 Cabal Surgeon|TOR
+1 Carrion Wurm|TOR
+1 Crypt Creeper|ODY
+4 Gravedigger|POR
+1 Grotesque Hybrid|TOR
+1 Ichorid|TOR
+3 Mystic Familiar|TOR
+3 Putrid Imp|TOR
+1 Stern Judge|TOR
+3 Teroh's Faithful|TOR
+1 Teroh's Vanguard|TOR
+1 Whispering Shade|ODY
+3 Buried Alive|WTH
+4 Crippling Fatigue|TOR
+1 Zombify|ODY
+1 Hypochondria|TOR
+1 Malevolent Awakening|ODY
+1 Strength of Isolation|TOR
+[sideboard]

--- a/forge-gui/res/quest/precons/Savage Stompdown.dck
+++ b/forge-gui/res/quest/precons/Savage Stompdown.dck
@@ -1,0 +1,41 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Savage Stompdown
+Description=Savage Stompdown crushes opponents. Green creatures and red burn in harmony.
+Deck Type=constructed
+Set=VIS
+Image=savage_stompdown.jpg
+[main]
+4 Forest|MIR|1
+4 Forest|MIR|2
+4 Forest|MIR|3
+4 Mountain|MIR|1
+4 Mountain|MIR|2
+4 Mountain|MIR|3
+1 Bull Elephant|VIS
+1 Crash of Rhinos|MIR
+3 Ekundu Cyclops|MIR
+2 Giant Caterpillar|VIS
+1 Granger Guildmage|MIR
+2 Hulking Cyclops|VIS
+2 Jungle Troll|MIR
+1 King Cheetah|VIS
+2 Kyscu Drake|VIS
+1 Locust Swarm|MIR
+2 Quirion Elves|MIR
+3 Raging Gorilla|VIS
+2 Spitting Drake|VIS
+1 Viashivan Dragon|VIS
+1 Emerald Charm|VIS
+3 Feral Instinct|VIS
+1 Hearth Charm|VIS
+2 Rock Slide|VIS
+1 Volcanic Geyser|MIR
+1 Creeping Mold|VIS
+1 Natural Order|VIS
+2 Unyaro Bee Sting|MIR
+[sideboard]

--- a/forge-gui/res/quest/precons/Scout.dck
+++ b/forge-gui/res/quest/precons/Scout.dck
@@ -1,0 +1,56 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Scout
+Description=Scout explores all angles of attack. Three-color aggression with versatile threats.
+Deck Type=constructed
+Set=PLS
+Image=scout.jpg
+[main]
+1 Plains|INV|1
+1 Plains|INV|2
+1 Plains|INV|3
+1 Mountain|INV|1
+1 Mountain|INV|2
+4 Forest|INV|1
+4 Forest|INV|2
+3 Forest|INV|3
+1 Elfhame Palace|INV
+1 Geothermal Crevice|INV
+1 Irrigation Ditch|INV
+2 Rith's Grove|PLS
+1 Shivan Oasis|INV
+1 Amphibious Kavu|PLS
+1 Ancient Kavu|INV
+1 Aurora Griffin|PLS
+1 Fleetfoot Panther|PLS
+1 Horned Kavu|PLS
+1 Mirrorwood Treefolk|PLS
+1 Nomadic Elf|INV
+1 Quirion Elves|MIR
+2 Quirion Explorer|PLS
+1 Radiant Kavu|PLS
+1 Rampant Elephant|INV
+1 Slingshot Goblin|PLS
+1 Steel Leaf Paladin|PLS
+3 Stone Kavu|PLS
+2 Sunscape Battlemage|PLS
+2 Thunderscape Battlemage|PLS
+1 Thornscape Apprentice|INV
+2 Thornscape Battlemage|PLS
+1 Thornscape Familiar|PLS
+1 Viashino Grappler|INV
+1 Armadillo Cloak|INV
+2 Fertile Ground|USG
+1 Eladamri's Call|PLS
+2 Gerrard's Command|PLS
+1 Harrow|TMP
+1 Magma Burst|PLS
+1 Pollen Remedy|PLS
+1 Rith's Charm|PLS
+1 Singe|PLS
+1 Zap|INV
+[sideboard]

--- a/forge-gui/res/quest/precons/Shu Kingdom.dck
+++ b/forge-gui/res/quest/precons/Shu Kingdom.dck
@@ -1,0 +1,29 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Shu Kingdom
+Description=A white deck from Portal Three Kingdoms featuring the noble Liu Bei and his legendary oath-brothers. Horsemanship creatures evade blockers.
+Deck Type=constructed
+Set=PTK
+Image=shu_kingdom.jpg
+[main]
+5 Plains|PTK|1
+5 Plains|PTK|2
+5 Plains|PTK|3
+2 Flanking Troops|PTK
+1 Guan Yu, Sainted Warrior|PTK
+1 Kongming, "Sleeping Dragon"|PTK
+1 Liu Bei, Lord of Shu|PTK
+3 Shu Cavalry|PTK
+2 Shu Farmer|PTK
+3 Shu Foot Soldiers|PTK
+2 Shu General|PTK
+2 Shu Grain Caravan|PTK
+2 Volunteer Militia|PTK
+2 Misfortune's Gain|PTK
+2 Vengeance|PTK
+2 Virtuous Charge|PTK
+[sideboard]

--- a/forge-gui/res/quest/precons/Sleeper.dck
+++ b/forge-gui/res/quest/precons/Sleeper.dck
@@ -28,7 +28,9 @@ Image=sleeper.jpg
 1 Opal Titan|USG
 2 Pacifism|USG
 3 Pegasus Charger|USG
-18 Plains|USG
+6 Plains|USG|1
+6 Plains|USG|2
+6 Plains|USG|3
 1 Sanctum Custodian|USG
 1 Serra's Embrace|USG
 2 Songstitcher|USG

--- a/forge-gui/res/quest/precons/Slither.dck
+++ b/forge-gui/res/quest/precons/Slither.dck
@@ -1,0 +1,41 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Slither
+Description=Slither combines green's creatures with red's aggression. Fast, efficient, and deadly.
+Deck Type=constructed
+Set=PCY
+Image=slither.jpg
+[main]
+5 Mountain|MMQ|1
+5 Mountain|MMQ|2
+4 Mountain|MMQ|3
+4 Forest|MMQ|1
+3 Forest|MMQ|2
+3 Forest|MMQ|3
+3 Keldon Berserker|PCY
+1 Latulla, Keldon Overseer|PCY
+1 Mungha Wurm|PCY
+2 Scoria Cat|PCY
+4 Silt Crawler|PCY
+4 Spur Grappler|PCY
+2 Squallmonger|MMQ
+1 Stampede Driver|NMS
+2 Vine Trellis|MMQ
+1 Vintara Snapper|PCY
+1 Zerapa Minotaur|PCY
+1 Barbed Field|PCY
+1 Citadel of Pain|PCY
+1 Kyren Negotiations|MMQ
+2 Seal of Fire|NMS
+1 War Cadence|MMQ
+2 Invigorate|MMQ
+2 Rhystic Lightning|PCY
+1 Desert Twister|3ED
+1 Flameshot|PCY
+1 Reverent Silence|NMS
+1 Chimeric Idol|PCY
+[sideboard]

--- a/forge-gui/res/quest/precons/Sliver Shivers.dck
+++ b/forge-gui/res/quest/precons/Sliver Shivers.dck
@@ -10,9 +10,15 @@ Deck Type=constructed
 Set=LGN
 Image=sliver_shivers.jpg
 [main]
-7 Forest|ONS
-5 Island|ONS
-9 Plains|ONS
+3 Forest|ONS|1
+2 Forest|ONS|2
+2 Forest|ONS|3
+2 Island|ONS|1
+2 Island|ONS|2
+1 Island|ONS|3
+3 Plains|ONS|1
+3 Plains|ONS|2
+3 Plains|ONS|3
 1 Brood Sliver|LGN
 1 Essence Sliver|LGN
 3 Mistform Dreamer|ONS

--- a/forge-gui/res/quest/precons/Special Delivery.dck
+++ b/forge-gui/res/quest/precons/Special Delivery.dck
@@ -1,0 +1,46 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Special Delivery
+Description=Special Delivery brings the biggest creatures to the battlefield fast. Ramp into massive threats and deliver the beatdown.
+Deck Type=constructed
+Set=USG
+Image=special_delivery.jpg
+[main]
+4 Mountain|USG|1
+4 Mountain|USG|2
+3 Mountain|USG|3
+4 Forest|USG|1
+3 Forest|USG|2
+3 Forest|USG|3
+2 Slippery Karst|USG
+2 Smoldering Crater|USG
+2 Acridian|USG
+1 Anaconda|USG
+1 Argothian Wurm|USG
+1 Bull Hippo|USG
+2 Cradle Guard|USG
+2 Goblin Patrol|USG
+2 Goblin War Buggy|USG
+1 Pouncing Jaguar|USG
+2 Shivan Raptor|USG
+2 Thundering Giant|USG
+3 Wild Dogs|USG
+1 Heat Ray|USG
+1 Scrap|USG
+1 Shower of Sparks|USG
+1 Symbiosis|USG
+3 Arc Lightning|USG
+1 Hush|USG
+1 Jagged Lightning|USG
+1 Wildfire|USG
+1 Fiery Mantle|USG
+1 Hidden Ancients|USG
+1 Hidden Spider|USG
+1 Shiv's Embrace|USG
+1 Torch Song|USG
+1 Thran Turbine|USG
+[sideboard]

--- a/forge-gui/res/quest/precons/Spectral Slam.dck
+++ b/forge-gui/res/quest/precons/Spectral Slam.dck
@@ -16,7 +16,9 @@ Image=spectral_slam.jpg
 2 Elephant Guide|JUD
 1 Exoskeletal Armor|JUD
 1 Forcemage Advocate|JUD
-12 Forest|ODY
+4 Forest|ODY|1
+4 Forest|ODY|2
+4 Forest|ODY|3
 1 Guided Strike|JUD
 2 Hallowed Healer|ODY
 2 Ironshell Beetle|JUD
@@ -29,7 +31,9 @@ Image=spectral_slam.jpg
 1 Phantom Nantuko|JUD
 4 Phantom Nomad|JUD
 3 Phantom Tiger|JUD
-12 Plains|ODY
+4 Plains|ODY|1
+4 Plains|ODY|2
+4 Plains|ODY|3
 2 Second Thoughts|ODY
 2 Seton's Desire|ODY
 1 Spirit Flare|TOR

--- a/forge-gui/res/quest/precons/Spectrum.dck
+++ b/forge-gui/res/quest/precons/Spectrum.dck
@@ -1,0 +1,46 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Spectrum
+Description=Spectrum harnesses all five colors of magic. Domain cards grow stronger with each basic land type you control.
+Deck Type=constructed
+Set=INV
+Image=spectrum.jpg
+[main]
+1 Plains|INV|1
+1 Plains|INV|2
+1 Island|INV|1
+1 Island|INV|2
+1 Swamp|INV|1
+1 Swamp|INV|2
+1 Mountain|INV|1
+1 Mountain|INV|2
+5 Forest|INV|1
+5 Forest|INV|2
+4 Forest|INV|3
+1 Halam Djinn|INV
+2 Kavu Climber|INV
+1 Nomadic Elf|INV
+2 Quirion Trailblazer|INV
+1 Sabertooth Nishoba|INV
+1 Serpentine Kavu|INV
+3 Thornscape Apprentice|INV
+2 Voracious Cobra|INV
+1 Wayfaring Giant|INV
+2 Yavimaya Barbarian|INV
+2 Zanam Djinn|INV
+3 Fertile Ground|INV
+1 Fires of Yavimaya|INV
+2 Assault // Battery|INV
+2 Exclude|INV
+3 Harrow|INV
+1 Spite // Malice|INV
+2 Wax // Wane|INV
+1 Global Ruin|INV
+1 Ordered Migration|INV
+2 Probe|INV
+2 Tribal Flames|INV
+[sideboard]

--- a/forge-gui/res/quest/precons/Spellweaver.dck
+++ b/forge-gui/res/quest/precons/Spellweaver.dck
@@ -1,0 +1,29 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Spellweaver
+Description=Spellweaver controls the battlefield. Blue magic and card advantage.
+Deck Type=constructed
+Set=PO2
+Image=spellweaver.jpg
+[main]
+5 Island|PO2
+5 Island|PO2
+5 Island|PO2
+2 Air Elemental|PO2
+2 Apprentice Sorcerer|PO2
+2 Talas Air Ship|PO2
+2 Talas Explorer|PO2
+3 Talas Merchant|PO2
+1 Talas Researcher|PO2
+3 Talas Scout|PO2
+1 Talas Warrior|PO2
+1 Exhaustion|PO2
+2 False Summoning|PO2
+2 Mystic Denial|PO2
+2 Time Ebb|PO2
+2 Touch of Brilliance|PO2
+[sideboard]

--- a/forge-gui/res/quest/precons/Spirit Gale.dck
+++ b/forge-gui/res/quest/precons/Spirit Gale.dck
@@ -1,0 +1,44 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Spirit Gale
+Description=A white-blue control deck from Battle Royale. Flying creatures, counterspells, and Wrath of God make for a powerful combination.
+Deck Type=constructed
+Set=BRB
+Image=spirit_gale.jpg
+[main]
+3 Island|TMP|1
+3 Island|TMP|2
+3 Island|TMP|3
+2 Plains|TMP|1
+2 Plains|TMP|2
+2 Plains|TMP|3
+1 Remote Isle|USG
+1 Thalakos Lowlands|TMP
+1 Air Elemental|4ED
+1 Azure Drake|CHR
+1 Blinking Spirit|ICE
+1 Disruptive Student|USG
+1 Infantry Veteran|VIS
+1 Man-o'-War|VIS
+1 Manta Riders|TMP
+1 Prodigal Sorcerer|4ED
+1 Songstitcher|USG
+1 Soul Warden|EXO
+1 Wind Drake|TMP
+1 Counterspell|4ED
+1 Curfew|USG
+1 Disenchant|4ED
+1 Healing Salve|4ED
+1 Mana Leak|STH
+1 Opportunity|ULG
+1 Ray of Command|ICE
+1 Swords to Plowshares|ICE
+1 Windfall|USG
+1 Wrath of God|4ED
+1 Control Magic|4ED
+1 Flood|DRK
+[sideboard]

--- a/forge-gui/res/quest/precons/Storm Surge.dck
+++ b/forge-gui/res/quest/precons/Storm Surge.dck
@@ -1,0 +1,45 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Storm Surge
+Description=Storm Surge rides the wave of spells. Blue-white storm with protective magic.
+Deck Type=constructed
+Set=SCG
+Image=storm_surge.jpg
+[main]
+5 Plains|ONS|1
+5 Plains|ONS|2
+4 Plains|ONS|3
+2 Island|ONS|1
+2 Island|ONS|2
+2 Island|ONS|3
+2 Lonely Sandbar|ONS
+2 Secluded Steppe|ONS
+1 Ageless Sentinels|SCG
+2 Aven Farseer|SCG
+2 Aven Liberator|SCG
+1 Coast Watcher|SCG
+1 Daru Mender|LGN
+1 Deftblade Elite|LGN
+1 Echo Tracer|LGN
+3 Frontline Strategist|SCG
+1 Noble Templar|SCG
+1 Shoreline Ranger|SCG
+2 Silver Knight|SCG
+1 Whipcorder|ONS
+1 White Knight|LEA
+1 Willbender|LGN
+2 Zealous Inquisitor|SCG
+3 Astral Steel|SCG
+1 Chain of Vapor|ONS
+2 Hindering Touch|SCG
+1 Rain of Blades|SCG
+2 Reward the Faithful|SCG
+1 Spy Network|ONS
+3 Wing Shards|SCG
+1 Mind's Desire|SCG
+1 Temporal Fissure|SCG
+[sideboard]

--- a/forge-gui/res/quest/precons/Swoop.dck
+++ b/forge-gui/res/quest/precons/Swoop.dck
@@ -1,0 +1,44 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Swoop
+Description=Swoop attacks from above with flying creatures. Blue-green tempo with evasive threats.
+Deck Type=constructed
+Set=APC
+Image=swoop.jpg
+[main]
+3 Island|INV|1
+3 Island|INV|2
+3 Island|INV|3
+5 Forest|INV|1
+4 Forest|INV|2
+4 Forest|INV|3
+2 Ana Disciple|APC
+2 Coastal Drake|APC
+3 Gaea's Skyfolk|APC
+2 Glade Gnarr|APC
+2 Jungle Barrier|APC
+2 Kavu Chameleon|INV
+2 Living Airship|APC
+1 Mystic Snake|APC
+1 Pincer Spider|INV
+1 Rainbow Crow|INV
+1 Rooting Kavu|INV
+1 Tidal Visionary|INV
+2 Urborg Elf|APC
+2 Ceta Sanctuary|APC
+1 Fertile Ground|USG
+1 Yavimaya's Embrace|APC
+1 Confound|PLS
+1 Jaded Response|APC
+1 Repulse|INV
+1 Rushing River|PLS
+2 Aether Mutation|APC
+1 Lay of the Land|APC
+2 Temporal Spring|APC
+1 Wash Out|INV
+2 Chromatic Sphere|INV
+[sideboard]

--- a/forge-gui/res/quest/precons/The Deluge.dck
+++ b/forge-gui/res/quest/precons/The Deluge.dck
@@ -1,0 +1,44 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=The Deluge
+Description=A green-white deck from Battle Royale featuring big creatures and Land Tax. Spike creatures grow your army to overwhelm opponents.
+Deck Type=constructed
+Set=BRB
+Image=the_deluge.jpg
+[main]
+2 Forest|TMP|1
+2 Forest|TMP|2
+2 Forest|TMP|3
+3 Plains|TMP|1
+3 Plains|TMP|2
+2 Plains|TMP|3
+1 Drifting Meadow|USG
+1 Vec Townships|TMP
+1 Advance Scout|TMP
+1 Angelic Page|USG
+1 Argothian Elder|USG
+1 Armored Pegasus|TMP
+1 Dirtcowl Wurm|TMP
+1 Elvish Lyrist|USG
+1 Master Decoy|TMP
+1 Sanctum Custodian|USG
+1 Sanctum Guardian|USG
+1 Scaled Wurm|ICE
+1 Seasoned Marshal|USG
+1 Soltari Foot Soldier|TMP
+1 Spike Colony|STH
+1 Spike Worker|STH
+1 Giant Growth|ICE
+1 Sandstorm|MIR
+1 Catastrophe|USG
+1 Hurricane|ICE
+1 Fecundity|USG
+1 Fertile Ground|USG
+1 Land Tax|LEG
+1 Pacifism|TMP
+1 Sun Clasp|VIS
+[sideboard]

--- a/forge-gui/res/quest/precons/The Flames of Rath.dck
+++ b/forge-gui/res/quest/precons/The Flames of Rath.dck
@@ -1,0 +1,41 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=The Flames of Rath
+Description=The Flames of Rath deck harnesses the power of fire and fury. With Furnace of Rath doubling all damage, burn your opponents to cinders.
+Deck Type=constructed
+Set=TMP
+Image=the_flames_of_rath.jpg
+[main]
+2 Plains|TMP|1
+2 Plains|TMP|2
+1 Plains|TMP|3
+7 Mountain|TMP|1
+6 Mountain|TMP|2
+6 Mountain|TMP|3
+1 Maze of Shadows|TMP
+1 Coiled Tinviper|TMP
+1 Firefly|TMP
+3 Fireslinger|TMP
+1 Flowstone Giant|TMP
+1 Flowstone Salamander|TMP
+2 Lightning Elemental|TMP
+1 Magmasaur|TMP
+4 Mogg Fanatic|TMP
+1 Sandstone Warrior|TMP
+1 Soltari Guerrillas|TMP
+2 Wild Wurm|TMP
+1 Furnace of Rath|TMP
+1 Goblin Bombardment|TMP
+1 Tahngarth's Rage|TMP
+1 Blood Frenzy|TMP
+2 Disenchant|TMP
+4 Kindle|TMP
+3 Lightning Blast|TMP
+1 Searing Touch|TMP
+2 Rolling Thunder|TMP
+1 Squee's Toy|TMP
+[sideboard]

--- a/forge-gui/res/quest/precons/The Plague.dck
+++ b/forge-gui/res/quest/precons/The Plague.dck
@@ -1,0 +1,41 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=The Plague
+Description=The Plague deck weaponizes Pestilence to sweep the board repeatedly while your creatures survive the onslaught.
+Deck Type=constructed
+Set=USG
+Image=the_plague.jpg
+[main]
+3 Plains|USG|1
+2 Plains|USG|2
+2 Plains|USG|3
+4 Swamp|USG|1
+4 Swamp|USG|2
+4 Swamp|USG|3
+3 Drifting Meadow|USG
+2 Polluted Mire|USG
+1 Blood Vassal|USG
+3 Disciple of Grace|USG
+1 Flesh Reaver|USG
+1 Sanctum Guardian|USG
+1 Silent Attendant|USG
+3 Unworthy Dead|USG
+3 Voice of Grace|USG
+3 Wall of Junk|USG
+2 Disenchant|USG
+2 Expunge|USG
+2 Humble|USG
+1 Befoul|USG
+1 Corrupt|USG
+1 Opal Acrolith|USG
+1 Pariah|USG
+4 Pestilence|USG
+2 Rune of Protection: Black|USG
+1 Sicken|USG
+1 Worship|USG
+2 Urza's Armor|USG
+[sideboard]

--- a/forge-gui/res/quest/precons/The Slivers.dck
+++ b/forge-gui/res/quest/precons/The Slivers.dck
@@ -1,0 +1,39 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=The Slivers
+Description=The Slivers are a hive-minded race of creatures that share abilities. Build your swarm and watch as each Sliver makes all others more powerful.
+Deck Type=constructed
+Set=TMP
+Image=the_slivers.jpg
+[main]
+5 Island|TMP|1
+4 Island|TMP|2
+4 Island|TMP|3
+4 Swamp|TMP|1
+4 Swamp|TMP|2
+3 Swamp|TMP|3
+1 Rootwater Depths|TMP
+4 Clot Sliver|TMP
+4 Metallic Sliver|TMP
+1 Mindwhip Sliver|TMP
+3 Mnemonic Sliver|TMP
+4 Winged Sliver|TMP
+1 Fevered Convulsions|TMP
+2 Counterspell|TMP
+2 Dark Banishing|TMP
+2 Diabolic Edict|TMP
+1 Dismiss|TMP
+1 Ertai's Meddling|TMP
+2 Power Sink|TMP
+1 Spell Blast|TMP
+1 Whispers of the Muse|TMP
+2 Dream Cache|TMP
+1 Evincar's Justice|TMP
+1 Extinction|TMP
+1 Lobotomy|TMP
+1 Essence Bottle|TMP
+[sideboard]

--- a/forge-gui/res/quest/precons/The Sparkler.dck
+++ b/forge-gui/res/quest/precons/The Sparkler.dck
@@ -1,0 +1,41 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=The Sparkler
+Description=The Sparkler combines blue control magic with red direct damage. Counter threats and burn your opponents with lightning and fire.
+Deck Type=constructed
+Set=STH
+Image=the_sparkler.jpg
+[main]
+5 Island|TMP|1
+5 Island|TMP|2
+4 Island|TMP|3
+5 Mountain|TMP|1
+4 Mountain|TMP|2
+4 Mountain|TMP|3
+1 Wall of Tears|STH
+1 Mogg Fanatic|TMP
+1 Wall of Razors|STH
+1 Contempt|STH
+2 Flowstone Blade|STH
+1 Intruder Alarm|STH
+2 Propaganda|TMP
+2 Capsize|TMP
+1 Counterspell|LEA
+1 Evacuation|STH
+3 Lightning Blast|TMP
+3 Mana Leak|STH
+1 Mind Games|STH
+2 Power Sink|LEA
+1 Reins of Power|STH
+1 Searing Touch|TMP
+1 Shatter|LEA
+2 Shock|STH
+2 Spell Blast|LEA
+1 Whispers of the Muse|TMP
+1 Ransack|STH
+2 Fanning the Flames|STH
+[sideboard]

--- a/forge-gui/res/quest/precons/The Spikes.dck
+++ b/forge-gui/res/quest/precons/The Spikes.dck
@@ -14,12 +14,16 @@ Image=the_spikes.jpg
 1 Canopy Spider|TMP
 1 Elven Rite|STH
 1 Fanning the Flames|STH
-12 Forest|TMP
+4 Forest|TMP|1
+4 Forest|TMP|2
+4 Forest|TMP|3
 2 Heartstone|STH
 1 Hermit Druid|STH
 4 Kindle|TMP
 1 Lowland Basilisk|STH
-9 Mountain|TMP
+3 Mountain|TMP|1
+3 Mountain|TMP|2
+3 Mountain|TMP|3
 2 Pincher Beetles|TMP
 2 Rampant Growth|TMP
 2 Shock|STH

--- a/forge-gui/res/quest/precons/The Swarm.dck
+++ b/forge-gui/res/quest/precons/The Swarm.dck
@@ -14,7 +14,9 @@ Image=the_swarm.jpg
 1 Disenchant|TMP
 1 Elven Warhounds|TMP
 1 Elvish Fury|TMP
-14 Forest|TMP
+5 Forest|TMP|1
+5 Forest|TMP|2
+4 Forest|TMP|3
 1 Krakilin|TMP
 3 Master Decoy|TMP
 4 Muscle Sliver|TMP
@@ -22,7 +24,9 @@ Image=the_swarm.jpg
 2 Overrun|TMP
 3 Pacifism|TMP
 3 Pincher Beetles|TMP
-7 Plains|TMP
+3 Plains|TMP|1
+2 Plains|TMP|2
+2 Plains|TMP|3
 2 Ranger en-Vec|TMP
 1 Recycle|TMP
 3 Rootwalla|TMP

--- a/forge-gui/res/quest/precons/Tidal Mastery.dck
+++ b/forge-gui/res/quest/precons/Tidal Mastery.dck
@@ -1,0 +1,43 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Tidal Mastery
+Description=Tidal Mastery commands the seas. Blue-white control with powerful flying creatures dominates the battlefield.
+Deck Type=constructed
+Set=MMQ
+Image=tidal_mastery.jpg
+[main]
+4 Plains|MMQ|1
+3 Plains|MMQ|2
+3 Plains|MMQ|3
+6 Island|MMQ|1
+5 Island|MMQ|2
+5 Island|MMQ|3
+2 Alabaster Wall|MMQ
+1 Ballista Squad|MMQ
+1 Cho-Arrim Legate|MMQ
+1 Cloud Sprite|MMQ
+2 Crossbow Infantry|MMQ
+2 Darting Merfolk|MMQ
+1 Devout Witness|MMQ
+1 Diplomatic Escort|MMQ
+2 Drake Hatchling|MMQ
+1 Overtaker|MMQ
+2 Saprazzan Legate|MMQ
+3 Stinging Barrier|MMQ
+1 Coastal Piracy|MMQ
+1 Customs Depot|MMQ
+1 Noble Purpose|MMQ
+1 Story Circle|MMQ
+1 War Tax|MMQ
+2 Afterlife|MMQ
+2 Counterspell|MMQ
+2 Disenchant|MMQ
+1 Ramosian Rally|MMQ
+1 Thwart|MMQ
+1 Kyren Archive|MMQ
+1 Puffer Extract|MMQ
+[sideboard]

--- a/forge-gui/res/quest/precons/Time Curse.dck
+++ b/forge-gui/res/quest/precons/Time Curse.dck
@@ -1,0 +1,28 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Time Curse
+Description=Time Curse controls the flow of time. Blue spell-denial and tempo.
+Deck Type=constructed
+Set=S99
+Image=time_curse.jpg
+[main]
+6 Island|S99|1
+6 Island|S99|2
+5 Island|S99|3
+2 Air Elemental|S99
+3 Ingenious Thief|S99
+2 Giant Octopus|S99
+3 Wind Drake|S99
+2 Counterspell|S99
+2 Extinguish|S99
+3 Remove Soul|S99
+1 Exhaustion|S99
+1 Ransack|S99
+1 Time Warp|S99
+2 Touch of Brilliance|S99
+1 Undo|S99
+[sideboard]

--- a/forge-gui/res/quest/precons/Time Drain.dck
+++ b/forge-gui/res/quest/precons/Time Drain.dck
@@ -11,8 +11,12 @@ Set=ULG
 Image=time_drain.jpg
 [main]
 1 Thran War Machine|ULG
-8 Forest|USG
-11 Island|USG
+3 Forest|USG|1
+3 Forest|USG|2
+2 Forest|USG|3
+4 Island|USG|1
+4 Island|USG|2
+3 Island|USG|3
 2 Acridian|USG
 1 Anthroplasm|ULG
 1 Archivist|ULG

--- a/forge-gui/res/quest/precons/Tombstone.dck
+++ b/forge-gui/res/quest/precons/Tombstone.dck
@@ -27,9 +27,15 @@ Image=tombstone.jpg
 1 Rescind|USG
 1 Sandbar Merfolk|USG
 1 Expunge|USG
-3 Plains|USG
-9 Island|USG
-9 Swamp|USG
+1 Plains|USG|1
+1 Plains|USG|2
+1 Plains|USG|3
+3 Island|USG|1
+3 Island|USG|2
+3 Island|USG|3
+3 Swamp|USG|1
+3 Swamp|USG|2
+3 Swamp|USG|3
 1 Wizard Mentor|USG
 3 Sandbar Serpent|USG
 2 Catalog|USG

--- a/forge-gui/res/quest/precons/Trounce-O-Matic.dck
+++ b/forge-gui/res/quest/precons/Trounce-O-Matic.dck
@@ -15,8 +15,12 @@ Image=trounce-o-matic.jpg
 2 Crashing Centaur|ODY
 1 Deluge|ODY
 2 Diligent Farmhand|ODY
-13 Forest|ODY
-9 Island|ODY
+5 Forest|ODY|1
+4 Forest|ODY|2
+4 Forest|ODY|3
+3 Island|ODY|1
+3 Island|ODY|2
+3 Island|ODY|3
 1 Ivy Elemental|ODY
 2 Krosan Avenger|ODY
 2 Metamorphic Wurm|ODY

--- a/forge-gui/res/quest/precons/Turnaround.dck
+++ b/forge-gui/res/quest/precons/Turnaround.dck
@@ -1,0 +1,44 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Turnaround
+Description=Turnaround reverses your opponent's momentum. Blue-white control stabilizes the board and takes over.
+Deck Type=constructed
+Set=PCY
+Image=turnaround.jpg
+[main]
+5 Plains|MMQ|1
+5 Plains|MMQ|2
+4 Plains|MMQ|3
+4 Island|MMQ|1
+3 Island|MMQ|2
+3 Island|MMQ|3
+1 Chieftain en-Dal|NMS
+1 Crossbow Infantry|MMQ
+1 Defiant Vanguard|NMS
+2 Diving Griffin|PCY
+2 Glittering Lion|PCY
+1 Mageta the Lion|PCY
+2 Mine Bearer|PCY
+1 Reveille Squad|PCY
+3 Ribbon Snake|PCY
+3 Shield Dancer|PCY
+3 Spiketail Hatchling|PCY
+1 Stronghold Machinist|NMS
+1 Sword Dancer|PCY
+2 Trap Runner|MMQ
+2 Waterfront Bouncer|MMQ
+1 Heightened Awareness|PCY
+1 Rhystic Circle|PCY
+1 Rhystic Study|PCY
+1 Seal of Cleansing|NMS
+1 Daze|NMS
+1 Disenchant|LEA
+1 Foil|PCY
+1 Rethink|PCY
+1 Rhystic Shield|PCY
+1 Topple|NMS
+[sideboard]

--- a/forge-gui/res/quest/precons/Unnatural Forces.dck
+++ b/forge-gui/res/quest/precons/Unnatural Forces.dck
@@ -1,0 +1,42 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Unnatural Forces
+Description=Unnatural Forces wields strange magic. Blue-black control with unusual threats.
+Deck Type=constructed
+Set=VIS
+Image=unnatural_forces.jpg
+[main]
+4 Island|MIR|1
+4 Island|MIR|2
+4 Island|MIR|3
+4 Swamp|MIR|1
+4 Swamp|MIR|2
+4 Swamp|MIR|3
+2 Brood of Cockroaches|VIS
+1 Coral Fighters|MIR
+2 Fetid Horror|MIR
+2 Kukemssa Serpent|MIR
+2 Man-o'-War|VIS
+1 Necrosavant|VIS
+1 Nekrataal|VIS
+2 Restless Dead|MIR
+1 Shrieking Drake|VIS
+2 Waterspout Djinn|VIS
+1 Zombie Mob|MIR
+2 Enfeeblement|MIR
+1 Flooded Shoreline|VIS
+2 Necromancy|VIS
+1 Boomerang|MIR
+2 Ether Well|MIR
+1 Funeral Charm|VIS
+2 Impulse|VIS
+2 Inspiration|VIS
+1 Ray of Command|MIR
+1 Vision Charm|VIS
+2 Coercion|VIS
+2 Sealed Fate|MIR
+[sideboard]

--- a/forge-gui/res/quest/precons/Waking Nightmares.dck
+++ b/forge-gui/res/quest/precons/Waking Nightmares.dck
@@ -1,0 +1,41 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Waking Nightmares
+Description=Waking Nightmares brings terror to opponents. Black's nightmares combine with red's fury.
+Deck Type=constructed
+Set=TOR
+Image=waking_nightmares.jpg
+[main]
+4 Swamp|ODY|1
+4 Swamp|ODY|2
+4 Swamp|ODY|3
+3 Mountain|ODY|1
+3 Mountain|ODY|2
+3 Mountain|ODY|3
+2 Tainted Peak|TOR
+3 Barbarian Outcast|TOR
+1 Chainer, Dementia Master|TOR
+1 Enslaved Dwarf|TOR
+3 Faceless Butcher|TOR
+1 Gravegouger|TOR
+3 Mesmeric Fiend|TOR
+2 Pardic Collaborator|TOR
+1 Petradon|TOR
+3 Petravark|TOR
+1 Slithery Stalker|TOR
+3 Soul Scourge|TOR
+2 Flame Burst|ODY
+1 Flaming Gambit|TOR
+2 Temporary Insanity|TOR
+2 Firebolt|ODY
+2 Rancid Earth|TOR
+1 Caustic Tar|ODY
+1 Demolish|ODY
+1 Malevolent Awakening|ODY
+2 Pyromania|TOR
+1 Shade's Form|TOR
+[sideboard]

--- a/forge-gui/res/quest/precons/Way Wild.dck
+++ b/forge-gui/res/quest/precons/Way Wild.dck
@@ -13,7 +13,9 @@ Image=way_wild.jpg
 1 Ancient Silverback|7ED
 1 Blanchwood Armor|7ED
 2 Creeping Mold|7ED
-14 Forest|7ED
+5 Forest|7ED|1
+5 Forest|7ED|2
+4 Forest|7ED|3
 1 Fyndhorn Elder|7ED
 1 Giant Growth|7ED
 2 Giant Spider|7ED

--- a/forge-gui/res/quest/precons/Wei Kingdom.dck
+++ b/forge-gui/res/quest/precons/Wei Kingdom.dck
@@ -1,0 +1,30 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Wei Kingdom
+Description=A black deck from Portal Three Kingdoms ruled by the cunning Cao Cao. Assassins and disruption crush your enemies.
+Deck Type=constructed
+Set=PTK
+Image=wei_kingdom.jpg
+[main]
+5 Swamp|PTK|1
+5 Swamp|PTK|2
+5 Swamp|PTK|3
+1 Cao Cao, Lord of Wei|PTK
+2 Cunning Advisor|PTK
+1 Sima Yi, Wei Field Marshal|PTK
+2 Wei Assassins|PTK
+2 Wei Ambush Force|PTK
+2 Wei Elite Companions|PTK
+2 Wei Infantry|PTK
+2 Wei Scout|PTK
+2 Wei Strike Force|PTK
+2 Return to Battle|PTK
+2 Imperial Edict|PTK
+2 Deception|PTK
+2 Ghostly Visit|PTK
+1 Ambition's Cost|PTK
+[sideboard]

--- a/forge-gui/res/quest/precons/Whirlpool.dck
+++ b/forge-gui/res/quest/precons/Whirlpool.dck
@@ -1,0 +1,43 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Whirlpool
+Description=Whirlpool churns through your deck for answers. Blue-red card selection and burn.
+Deck Type=constructed
+Set=APC
+Image=whirlpool.jpg
+[main]
+4 Island|INV|1
+4 Island|INV|2
+4 Island|INV|3
+4 Mountain|INV|1
+4 Mountain|INV|2
+4 Mountain|INV|3
+2 Bloodfire Dwarf|APC
+2 Bloodfire Kavu|APC
+1 Coastal Drake|APC
+1 Dwarven Patrol|APC
+2 Faerie Squadron|INV
+1 Flametongue Kavu|PLS
+1 Metathran Transport|INV
+2 Minotaur Illusionist|APC
+1 Rainbow Crow|INV
+2 Razorfin Hunter|APC
+2 Whirlpool Drake|APC
+3 Whirlpool Rider|APC
+1 Whirlpool Warrior|APC
+1 Bloodfire Infusion|APC
+2 Quicksilver Dagger|APC
+1 Confound|PLS
+1 Exclude|INV
+1 Fire // Ice|APC
+2 Jilt|APC
+1 Opt|INV
+1 Scorching Lava|INV
+2 Stun|TMP
+1 Suffocating Blast|APC
+2 Chromatic Sphere|INV
+[sideboard]

--- a/forge-gui/res/quest/precons/White Heat.dck
+++ b/forge-gui/res/quest/precons/White Heat.dck
@@ -1,0 +1,39 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=White Heat
+Description=White Heat combines efficient white creatures with red's direct damage. Swarm the board and burn away any resistance.
+Deck Type=constructed
+Set=EXO
+Image=white_heat.jpg
+[main]
+3 Mountain|TMP|1
+3 Mountain|TMP|2
+3 Mountain|TMP|3
+5 Plains|TMP|1
+4 Plains|TMP|2
+4 Plains|TMP|3
+4 Soltari Foot Soldier|TMP
+2 Master Decoy|TMP
+4 Welkin Hawk|EXO
+2 Knight of Dawn|TMP
+1 Paladin en-Vec|EXO
+3 Soltari Visionary|EXO
+1 Wall of Nets|EXO
+1 Goblin Bombardment|TMP
+1 Limited Resources|EXO
+1 Onslaught|EXO
+2 Pegasus Stampede|EXO
+1 Reconnaissance|EXO
+1 Shackles|EXO
+2 Searing Touch|TMP
+1 Shattering Pulse|EXO
+2 Shock|STH
+2 Sonic Burst|EXO
+2 Lightning Blast|TMP
+4 Kindle|TMP
+1 Temper|STH
+[sideboard]

--- a/forge-gui/res/quest/precons/Widowmaker.dck
+++ b/forge-gui/res/quest/precons/Widowmaker.dck
@@ -1,0 +1,39 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Widowmaker
+Description=Widowmaker uses blue-black control to slowly strangle opponents. Card advantage and removal ensure victory through attrition.
+Deck Type=constructed
+Set=EXO
+Image=widowmaker.jpg
+[main]
+5 Island|TMP|1
+5 Island|TMP|2
+4 Island|TMP|3
+4 Swamp|TMP|1
+4 Swamp|TMP|2
+3 Swamp|TMP|3
+3 Manta Riders|TMP
+4 Merfolk Looter|EXO
+1 Keeper of the Mind|EXO
+1 Rootwater Hunter|TMP
+1 Thalakos Scout|EXO
+3 Vampire Hounds|EXO
+2 Mind Maggots|EXO
+1 Skyshroud Vampire|TMP
+1 Mindless Automaton|EXO
+1 Null Brooch|EXO
+1 Oath of Scholars|EXO
+1 Treasure Trove|EXO
+1 Capsize|TMP
+2 Counterspell|TMP
+2 Dark Banishing|TMP
+2 Dark Ritual|TMP
+2 Diabolic Edict|TMP
+2 Forbid|EXO
+2 Mana Leak|STH
+2 Necrologia|EXO
+[sideboard]

--- a/forge-gui/res/quest/precons/Wild-Eyed Frenzy.dck
+++ b/forge-gui/res/quest/precons/Wild-Eyed Frenzy.dck
@@ -1,0 +1,35 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Wild-Eyed Frenzy
+Description=Wild-Eyed Frenzy attacks relentlessly. Mono-red aggression with flanking.
+Deck Type=constructed
+Set=VIS
+Image=wild-eyed_frenzy.jpg
+[main]
+8 Mountain|MIR|1
+8 Mountain|MIR|2
+7 Mountain|MIR|3
+1 Flame Elemental|MIR
+2 Goblin Elite Infantry|MIR
+2 Goblin Recruiter|VIS
+2 Goblin Soothsayer|MIR
+3 Goblin Swine-Rider|VIS
+2 Goblin Tinkerer|MIR
+3 Keeper of Kookus|VIS
+1 Kookus|VIS
+1 Ogre Enforcer|VIS
+2 Talruum Champion|VIS
+2 Talruum Piper|VIS
+1 Viashino Sandstalker|VIS
+2 Mob Mentality|VIS
+3 Chaos Charm|MIR
+2 Fireblast|VIS
+3 Flare|MIR
+2 Goblin Scouts|MIR
+2 Song of Blood|VIS
+1 Unerring Sling|MIR
+[sideboard]

--- a/forge-gui/res/quest/precons/Wu Kingdom.dck
+++ b/forge-gui/res/quest/precons/Wu Kingdom.dck
@@ -1,0 +1,29 @@
+[shop]
+WinsToUnlock=0
+Credits=1200
+MinDifficulty=0
+MaxDifficulty=5
+[metadata]
+Name=Wu Kingdom
+Description=A blue deck from Portal Three Kingdoms led by the wise Sun Quan. Control magic and counterspells protect your horsemanship army.
+Deck Type=constructed
+Set=PTK
+Image=wu_kingdom.jpg
+[main]
+5 Island|PTK|1
+5 Island|PTK|2
+5 Island|PTK|3
+3 Straw Soldiers|PTK
+3 Wu Light Cavalry|PTK
+2 Wu Scout|PTK
+2 Wu Longbowman|PTK
+2 Wu Elite Cavalry|PTK
+1 Lu Xun, Scholar General|PTK
+2 Wu Admiral|PTK
+1 Sun Quan, Lord of Wu|PTK
+2 Extinguish|PTK
+1 Exhaustion|PTK
+2 Preemptive Strike|PTK
+2 Forced Retreat|PTK
+2 Brilliant Plan|PTK
+[sideboard]

--- a/forge-gui/res/quest/precons/Zombies Unleashed.dck
+++ b/forge-gui/res/quest/precons/Zombies Unleashed.dck
@@ -17,7 +17,9 @@ Image=zombies_unleashed.jpg
 2 Frightshroud Courier|ONS
 1 Soulless One|ONS
 1 Festering Goblin|ONS
-23 Swamp|ONS
+8 Swamp|ONS|1
+8 Swamp|ONS|2
+7 Swamp|ONS|3
 2 Barren Moor|ONS
 1 Dirge of Dread|ONS
 1 Feeding Frenzy|ONS


### PR DESCRIPTION
- Adds 72 new preconstructed deck files for old border era sets (pre-Scourge 2003)

This enables adventure worlds with `allowedEditions` filtering (like PR #9399) to have access to all official precon decks from:

- **Theme Decks**: Tempest, Urza's Block, Masques Block, Invasion Block, Odyssey Block, Onslaught Block, Mirage Block
- **Starter Products**: Starter 1999, Portal, Portal Second Age, Portal Three Kingdoms
- **Box Sets**: Anthologies, Battle Royale, Beatdown, Deckmasters 2001