### PR TITLE
Amplify: remove type from keyword

### DIFF
--- a/forge-core/src/main/java/forge/card/CardType.java
+++ b/forge-core/src/main/java/forge/card/CardType.java
@@ -312,7 +312,7 @@ public final class CardType implements Comparable<CardType>, CardTypeView {
 
     @Override
     public Set<String> getCreatureTypes() {
-        final Set<String> creatureTypes = Sets.newHashSet();
+        final Set<String> creatureTypes = Sets.newLinkedHashSet();
         if (!isCreature() && !isKindred()) {
             return creatureTypes;
         }
@@ -327,7 +327,7 @@ public final class CardType implements Comparable<CardType>, CardTypeView {
 
     @Override
     public Set<String> getLandTypes() {
-        final Set<String> landTypes = Sets.newHashSet();
+        final Set<String> landTypes = Sets.newLinkedHashSet();
         if (isLand()) {
             for (final String t : subtypes) {
                 if (isALandType(t)) {

--- a/forge-core/src/main/java/forge/util/Lang.java
+++ b/forge-core/src/main/java/forge/util/Lang.java
@@ -220,7 +220,7 @@ public abstract class Lang {
         return name.split(" ")[0];
     }
 
-    public String buildValidDesc(List<String> valid, boolean multiple) {
+    public String buildValidDesc(Collection<String> valid, boolean multiple) {
         return joinHomogenous(valid.stream().map(s -> formatValidDesc(s)).collect(Collectors.toList()), null, multiple ? "and/or" : "or");
     }
 

--- a/forge-game/src/main/java/forge/game/keyword/Amplify.java
+++ b/forge-game/src/main/java/forge/game/keyword/Amplify.java
@@ -1,0 +1,12 @@
+package forge.game.keyword;
+
+import forge.util.Lang;
+
+public class Amplify extends KeywordWithAmount {
+
+    @Override
+    protected String formatReminderText(String reminderText) {
+        String type = Lang.getInstance().buildValidDesc(getHostCard().getType().getCreatureTypes(), true);
+        return String.format(reminderText, amount, type);
+    }
+}

--- a/forge-game/src/main/java/forge/game/keyword/Keyword.java
+++ b/forge-game/src/main/java/forge/game/keyword/Keyword.java
@@ -14,7 +14,7 @@ public enum Keyword {
     AFFLICT("Afflict", KeywordWithAmount.class, false, "Whenever this creature becomes blocked, defending player loses %d life."),
     AFTERLIFE("Afterlife", KeywordWithAmount.class, false, "When this creature dies, create {%1$d:1/1 white and black Spirit creature token} with flying."),
     AFTERMATH("Aftermath", SimpleKeyword.class, false, "Cast this spell only from your graveyard. Then exile it."),
-    AMPLIFY("Amplify", KeywordWithAmountAndType.class, false, "As this creature enters, put {%d:+1/+1 counter} on it for each %s card you reveal in your hand."),
+    AMPLIFY("Amplify", Amplify.class, false, "As this creature enters, put {%d:+1/+1 counter} on it for each %s card you reveal in your hand."),
     ANNIHILATOR("Annihilator", KeywordWithAmount.class, false, "Whenever this creature attacks, defending player sacrifices {%d:permanent}."),
     ASCEND("Ascend", SimpleKeyword.class, true, "If you control ten or more permanents, you get the city's blessing for the rest of the game."),
     ASSIST("Assist", SimpleKeyword.class, true, "Another player can pay up to %s of this spell's cost."),

--- a/forge-gui/res/cardsfolder/a/aven_warhawk.txt
+++ b/forge-gui/res/cardsfolder/a/aven_warhawk.txt
@@ -2,6 +2,6 @@ Name:Aven Warhawk
 ManaCost:4 W
 Types:Creature Bird Soldier
 PT:2/2
-K:Amplify:1:Bird,Soldier
+K:Amplify:1
 K:Flying
 Oracle:Amplify 1 (As this creature enters, put a +1/+1 counter on it for each Bird and/or Soldier card you reveal in your hand.)\nFlying

--- a/forge-gui/res/cardsfolder/c/canopy_crawler.txt
+++ b/forge-gui/res/cardsfolder/c/canopy_crawler.txt
@@ -2,7 +2,7 @@ Name:Canopy Crawler
 ManaCost:3 G
 Types:Creature Beast
 PT:2/2
-K:Amplify:1:Beast
+K:Amplify:1
 A:AB$ Pump | Cost$ T | ValidTgts$ Creature | NumAtt$ +X | NumDef$ +X | SpellDescription$ Target creature gets +1/+1 until end of turn for each +1/+1 counter on CARDNAME.
 SVar:X:Count$CardCounters.P1P1
 Oracle:Amplify 1 (As this creature enters, put a +1/+1 counter on it for each Beast card you reveal in your hand.)\n{T}: Target creature gets +1/+1 until end of turn for each +1/+1 counter on Canopy Crawler.

--- a/forge-gui/res/cardsfolder/d/daru_stinger.txt
+++ b/forge-gui/res/cardsfolder/d/daru_stinger.txt
@@ -2,7 +2,7 @@ Name:Daru Stinger
 ManaCost:3 W
 Types:Creature Soldier
 PT:1/1
-K:Amplify:1:Soldier
+K:Amplify:1
 A:AB$ DealDamage | Cost$ T | ValidTgts$ Creature.attacking,Creature.blocking | TgtPrompt$ Select target attacking or blocking creature | NumDmg$ X | SpellDescription$ CARDNAME deals damage equal to the number of +1/+1 counters on it to target attacking or blocking creature.
 SVar:X:Count$CardCounters.P1P1
 Oracle:Amplify 1 (As this creature enters, put a +1/+1 counter on it for each Soldier card you reveal in your hand.)\n{T}: Daru Stinger deals damage equal to the number of +1/+1 counters on it to target attacking or blocking creature.

--- a/forge-gui/res/cardsfolder/e/embalmed_brawler.txt
+++ b/forge-gui/res/cardsfolder/e/embalmed_brawler.txt
@@ -2,7 +2,7 @@ Name:Embalmed Brawler
 ManaCost:2 B
 Types:Creature Zombie
 PT:2/2
-K:Amplify:1:Zombie
+K:Amplify:1
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigLoseLife | TriggerDescription$ Whenever CARDNAME attacks or blocks, you lose 1 life for each +1/+1 counter on it.
 T:Mode$ Blocks | ValidCard$ Card.Self | Execute$ TrigLoseLife | Secondary$ True | TriggerDescription$ Whenever CARDNAME attacks or blocks, you lose 1 life for each +1/+1 counter on it.
 SVar:TrigLoseLife:DB$ LoseLife | Defined$ You | LifeAmount$ X

--- a/forge-gui/res/cardsfolder/f/feral_throwback.txt
+++ b/forge-gui/res/cardsfolder/f/feral_throwback.txt
@@ -2,6 +2,6 @@ Name:Feral Throwback
 ManaCost:4 G G
 Types:Creature Beast
 PT:3/3
-K:Amplify:2:Beast
+K:Amplify:2
 K:Provoke
 Oracle:Amplify 2 (As this creature enters, put two +1/+1 counters on it for each Beast card you reveal in your hand.)\nProvoke (Whenever this creature attacks, you may have target creature defending player controls untap and block it if able.)

--- a/forge-gui/res/cardsfolder/g/ghastly_remains.txt
+++ b/forge-gui/res/cardsfolder/g/ghastly_remains.txt
@@ -2,7 +2,7 @@ Name:Ghastly Remains
 ManaCost:B B B
 Types:Creature Zombie
 PT:0/0
-K:Amplify:1:Zombie
+K:Amplify:1
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | IsPresent$ Card.StrictlySelf | PresentZone$ Graveyard | PresentPlayer$ You | TriggerZones$ Graveyard | OptionalDecider$ You | Execute$ TrigReturn | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard, you may pay {B}{B}{B}. If you do, return CARDNAME to your hand.
 SVar:TrigReturn:AB$ ChangeZone | Cost$ B B B | Defined$ Self | Origin$ Graveyard | Destination$ Hand
 SVar:NeedsToPlayVar:X GE2

--- a/forge-gui/res/cardsfolder/g/glowering_rogon.txt
+++ b/forge-gui/res/cardsfolder/g/glowering_rogon.txt
@@ -2,5 +2,5 @@ Name:Glowering Rogon
 ManaCost:5 G
 Types:Creature Beast
 PT:4/4
-K:Amplify:1:Beast
+K:Amplify:1
 Oracle:Amplify 1 (As this creature enters, put a +1/+1 counter on it for each Beast card you reveal in your hand.)

--- a/forge-gui/res/cardsfolder/k/kilnmouth_dragon.txt
+++ b/forge-gui/res/cardsfolder/k/kilnmouth_dragon.txt
@@ -2,7 +2,7 @@ Name:Kilnmouth Dragon
 ManaCost:5 R R
 Types:Creature Dragon
 PT:5/5
-K:Amplify:3:Dragon
+K:Amplify:3
 K:Flying
 A:AB$ DealDamage | Cost$ T | ValidTgts$ Any | NumDmg$ X | SpellDescription$ CARDNAME deals damage equal to the number of +1/+1 counters on it to any target.
 SVar:X:Count$CardCounters.P1P1

--- a/forge-gui/res/cardsfolder/z/zombie_brute.txt
+++ b/forge-gui/res/cardsfolder/z/zombie_brute.txt
@@ -2,6 +2,6 @@ Name:Zombie Brute
 ManaCost:6 B
 Types:Creature Zombie
 PT:5/4
-K:Amplify:1:Zombie
+K:Amplify:1
 K:Trample
 Oracle:Amplify 1 (As this creature enters, put a +1/+1 counter on it for each Zombie card you reveal in your hand.)\nTrample


### PR DESCRIPTION
part of #9453 to clean up some keywords

the Types from the Reminder Text can be get by the HostCard

Also `KeywordWithAmountAndType` might be removed later, after some Devour changes