### PR TITLE
Shandalar Old Border: Fix item reward names for Santa and Pharaoh enemies

### DIFF
--- a/forge-gui/res/adventure/Shandalar Old Border/world/enemies.json
+++ b/forge-gui/res/adventure/Shandalar Old Border/world/enemies.json
@@ -20816,7 +20816,7 @@
         "type": "item",
         "probability": 1,
         "count": 1,
-        "itemName": "Ring of Ma'r\u00fbf"
+        "itemName": "Djinn's Silks"
       }
     ],
     "questTags": [
@@ -37292,7 +37292,7 @@
         "type": "item",
         "probability": 1,
         "count": 1,
-        "itemName": "Christmas Gift"
+        "itemName": "Santa's Hat"
       },
       {
         "type": "card",


### PR DESCRIPTION
## Summary
- Santa was rewarding non-existent "Christmas Gift" instead of "Santa's Hat"
- Pharaoh was rewarding non-existent "Ring of Ma'rûf" instead of "Djinn's Silks"

Both bugs followed the same pattern: using either the icon name or underlying card name instead of the actual item name defined in items.json.