### PR TITLE
Fix deck editor filter.

### DIFF
--- a/forge-core/src/main/java/forge/item/PaperCard.java
+++ b/forge-core/src/main/java/forge/item/PaperCard.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.io.*;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A lightweight version of a card that matches real-world cards, to use outside of games (eg. inventory, decks, trade).
@@ -347,7 +348,9 @@ public class PaperCard implements Comparable<IPaperCard>, InventoryItemFromSet, 
                 return Set.of(this.name);
             else {
                 String translatedName = CardTranslation.getTranslatedName(this.name);
-                return Set.of(this.name, translatedName, StringUtils.stripAccents(translatedName));
+                return Stream.of(this.name, translatedName, StringUtils.stripAccents(translatedName))
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toSet());
             }
         }
         Set<String> names = new HashSet<>();


### PR DESCRIPTION
Closes #9330

StringUtils.stripAccents() may return the original input when no accents exist, and in some cases the translated name is the same as the original card name(e.g. V.A.T.S.). Both cases can cause Set.of() to throw an IllegalArgumentException.