### PR TITLE
Fix fullscreen window not responding after focus loss in WSL

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/view/FFrame.java
+++ b/forge-gui-desktop/src/main/java/forge/view/FFrame.java
@@ -59,6 +59,9 @@ public class FFrame extends SkinnedFrame implements ITitleBarOwner {
         this.addWindowListener(new WindowAdapter() {
             @Override
             public void windowActivated(final WindowEvent e) {
+                if (minimized) {
+                    setMinimized(false); //ensure window is restored when activated (fixes focus issues in some environments like WSL)
+                }
                 resume(); //resume music when main frame regains focus
             }
 


### PR DESCRIPTION
When running in fullscreen mode under WSL, the window would become unresponsive after losing and regaining focus. This was caused by the windowStateListener not reliably firing state change events in WSL's X11 environment, leaving the window in a minimized state.

Now windowActivated explicitly restores the window if it's still marked as minimized, ensuring proper restoration regardless of whether the state change event fires.
