### PR TITLE
Fix AI targeting for Comet, Stellar Pup damage ability

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/DamageDealAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DamageDealAi.java
@@ -1202,7 +1202,8 @@ public class DamageDealAi extends DamageAiBase {
         // Separate options into creatures and players
         List<Card> oppCreatures = CardLists.filterControlledBy(
                 IterableUtil.filter(options, Card.class), ai.getOpponents());
-        List<Player> oppPlayers = ai.getOpponents().filter(options::contains);
+        Iterable<Player> optionPlayers = IterableUtil.filter(options, Player.class);
+        List<Player> oppPlayers = ai.getOpponents().filter(p -> IterableUtil.any(optionPlayers, p::equals));
 
         // First priority: kill opponent creatures
         if (!oppCreatures.isEmpty()) {
@@ -1235,14 +1236,21 @@ public class DamageDealAi extends DamageAiBase {
             return null;
         }
 
-        // Mandatory: target own worst creature or self
+        // Mandatory: target teammate's worst creature before own
+        List<Card> alliedCreatures = CardLists.filterControlledBy(
+                IterableUtil.filter(options, Card.class), ai.getAllies());
+        if (!alliedCreatures.isEmpty()) {
+            return (T) ComputerUtilCard.getWorstCreatureAI(alliedCreatures);
+        }
+
+        // Mandatory: target own worst creature
         List<Card> ownCreatures = CardLists.filterControlledBy(
                 IterableUtil.filter(options, Card.class), ai);
         if (!ownCreatures.isEmpty()) {
             return (T) ComputerUtilCard.getWorstCreatureAI(ownCreatures);
         }
 
-        if (options.contains(ai)) {
+        if (IterableUtil.any(optionPlayers, ai::equals)) {
             return (T) ai;
         }
 


### PR DESCRIPTION
When using Comet, Stellar Pup and rolling a 4 or 5, the AI was targeting its own creatures instead of the opponent. This was because the default chooseSingleEntity implementation in SpellAbilityAi doesn't consider ownership when choosing between cards and players.

Added chooseSingleEntity override in DamageDealAi that properly handles target selection for damage abilities:
1. First priority: kill opponent creatures (if damage is sufficient)
2. Second priority: target opponent player (if shouldTgtP returns true)
3. Third priority: target opponent's best creature (even if can't kill)
4. Fourth priority: target opponent player
5. Mandatory fallback: target own worst creature or self

Also added unit tests for the new behavior.

This closes https://github.com/Card-Forge/forge/issues/9511

You can test this with the following state and letting the AI play:

```text
turn=1
activeplayer=p1
activephase=MAIN1
p0life=20
p0landsplayed=0
p0landsplayedlastturn=0
p0numringtemptedyou=0
p0speed=0
p0hand=
p0library=Plains|Set:UNF|Art:1;Plains|Set:UNF|Art:1;Plains|Set:UNF|Art:1;Plains|Set:UNF|Art:1;Plains|Set:UNF|Art:1
p0graveyard=
p0battlefield=
p0exile=
p0command=
p0sideboard=
p1life=20
p1landsplayed=0
p1landsplayedlastturn=0
p1numringtemptedyou=0
p1speed=0
p1hand=Comet, Stellar Pup|Set:UNF|Art:1
p1library=Plains|Set:UNF|Art:1;Plains|Set:UNF|Art:1;Plains|Set:UNF|Art:1;Plains|Set:UNF|Art:1;Plains|Set:UNF|Art:1
p1graveyard=
p1battlefield=Pixie Guide|Set:AFR|Art:1;Mountain|Set:UNF|Art:1;Mountain|Set:UNF|Art:1;Plains|Set:UNF|Art:1;Plains|Set:UNF|Art:1
p1exile=
p1command=
p1sideboard=

```