### PR TITLE
Cleanup 2026-01-15

### DIFF
--- a/forge-gui/res/cardsfolder/a/aang_at_the_crossroads_aang_destined_savior.txt
+++ b/forge-gui/res/cardsfolder/a/aang_at_the_crossroads_aang_destined_savior.txt
@@ -6,7 +6,7 @@ K:Flying
 T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigDig | TriggerDescription$ When NICKNAME enters, look at the top five cards of your library. You may put a creature card with mana value 4 or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.
 SVar:TrigDig:DB$ Dig | DigNum$ 5 | ChangeNum$ 1 | ChangeValid$ Creature.cmcLE4 | Optional$ True | DestinationZone$ Battlefield | DestinationZone2$ Library | LibraryPosition$ -1 | RestRandomOrder$ True
 T:Mode$ ChangesZone | ValidCard$ Creature.Other+YouCtrl | Origin$ Battlefield | Destination$ Any | Execute$ TrigDelayTransform | TriggerZones$ Battlefield | TriggerDescription$ When another creature you control leaves the battlefield, transform NICKNAME at the beginning of the next upkeep.
-SVar:TrigDelayTransform:DB$ DelayedTrigger | Mode$ Phase | Phase$ Upkeep | Execute$ TrigTransform | TriggerDescription$ CARDNAME — Transform him at the beginning of the next upkeep
+SVar:TrigDelayTransform:DB$ DelayedTrigger | Mode$ Phase | Phase$ Upkeep | Execute$ TrigTransform | TriggerDescription$ Transform NICKNAME.
 SVar:TrigTransform:DB$ SetState | Defined$ Self | Mode$ Transform
 AlternateMode:DoubleFaced
 Oracle:Flying\nWhen Aang enters, look at the top five cards of your library. You may put a creature card with mana value 4 or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.\nWhen another creature you control leaves the battlefield, transform Aang at the beginning of the next upkeep.

--- a/forge-gui/res/cardsfolder/a/amarant_coral.txt
+++ b/forge-gui/res/cardsfolder/a/amarant_coral.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature Human Monk
 PT:5/4
 K:Trample
 S:Mode$ MustAttack | ValidCreature$ Card.Self | Description$ CARDNAME attacks each combat if able.
-T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Opponent | CombatDamage$ True | Execute$ TrigDmg | TriggerDescription$ No Mercy - Whenever CARDNAME deals combat damage to an opponent, it deals that much damage to each other opponent
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Opponent | CombatDamage$ True | Execute$ TrigDmg | TriggerDescription$ No Mercy — Whenever CARDNAME deals combat damage to an opponent, it deals that much damage to each other opponent
 SVar:TrigDmg:DB$ DamageAll | ValidPlayers$ OppNonTriggeredTarget | NumDmg$ X
 SVar:X:TriggerCount$DamageAmount
-Oracle:Trample\nAmarant Coral attacks each combat if able.\nNo Mercy - Whenever Amarant Coral deals combat damage to an opponent, it deals that much damage to each other opponent.
+Oracle:Trample\nAmarant Coral attacks each combat if able.\nNo Mercy — Whenever Amarant Coral deals combat damage to an opponent, it deals that much damage to each other opponent.

--- a/forge-gui/res/cardsfolder/a/archangel_avacyn_avacyn_the_purifier.txt
+++ b/forge-gui/res/cardsfolder/a/archangel_avacyn_avacyn_the_purifier.txt
@@ -8,7 +8,7 @@ K:Vigilance
 T:Mode$ ChangesZone | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPumpAll | TriggerDescription$ When CARDNAME enters, creatures you control gain indestructible until end of turn.
 SVar:TrigPumpAll:DB$ PumpAll | ValidCards$ Creature.YouCtrl | KW$ Indestructible
 T:Mode$ ChangesZone | ValidCard$ Creature.nonAngel+YouCtrl | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigDelayTransform | TriggerZones$ Battlefield | TriggerDescription$ When a non-Angel creature you control dies, transform CARDNAME at the beginning of the next upkeep.
-SVar:TrigDelayTransform:DB$ DelayedTrigger | Mode$ Phase | Phase$ Upkeep | Execute$ TrigTransform | TriggerDescription$ CARDNAME — Transform it at the beginning of the next end step.
+SVar:TrigDelayTransform:DB$ DelayedTrigger | Mode$ Phase | Phase$ Upkeep | Execute$ TrigTransform | TriggerDescription$ Transform CARDNAME.
 SVar:TrigTransform:DB$ SetState | Defined$ Self | Mode$ Transform
 AlternateMode:DoubleFaced
 Oracle:Flash\nFlying, vigilance\nWhen Archangel Avacyn enters, creatures you control gain indestructible until end of turn.\nWhen a non-Angel creature you control dies, transform Archangel Avacyn at the beginning of the next upkeep.

--- a/forge-gui/res/cardsfolder/a/ashling_rekindled_ashling_rimebound.txt
+++ b/forge-gui/res/cardsfolder/a/ashling_rekindled_ashling_rimebound.txt
@@ -18,7 +18,7 @@ ManaCost:no cost
 Colors:blue
 Types:Legendary Creature Elemental Wizard
 PT:1/3
-T:Mode$ Transformed | ValidCard$ Card.Self | Execute$ TrigMana | TriggerDescription$Whenever this creature transforms into CARDNAME and at the beginning of your first main phase, add two mana of any one color. Spend this mana only to cast spells with mana value 4 or greater.
+T:Mode$ Transformed | ValidCard$ Card.Self | Execute$ TrigMana | TriggerDescription$ Whenever this creature transforms into CARDNAME and at the beginning of your first main phase, add two mana of any one color. Spend this mana only to cast spells with mana value 4 or greater.
 T:Mode$ Phase | Phase$ Main1 | Secondary$ True | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigMana | TriggerDescription$ Whenever this creature transforms into CARDNAME and at the beginning of your first main phase, add two mana of any one color. Spend this mana only to cast spells with mana value 4 or greater.
 SVar:TrigMana:DB$ Mana | Produced$ Any | Amount$ 2 | RestrictValid$ Spell.cmcGE4
 T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigTransform | TriggerDescription$ At the beginning of your first main phase, you may pay {R}. If you do, transform NICKNAME.

--- a/forge-gui/res/cardsfolder/e/ellie_brick_master.txt
+++ b/forge-gui/res/cardsfolder/e/ellie_brick_master.txt
@@ -3,7 +3,7 @@ ManaCost:1 R
 Types:Legendary Creature Human Survivor
 PT:2/1
 K:Partner:Survivors
-T:Mode$ AttackersDeclaredOneTarget | AttackedTarget$ Opponent | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Distract the Horde - Whenever a player attacks one of your opponents, that attacking player creates a tapped 1/1 black Fungus Zombie creature token named Cordyceps Infected that's attacking that opponent.
+T:Mode$ AttackersDeclaredOneTarget | AttackedTarget$ Opponent | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Distract the Horde — Whenever a player attacks one of your opponents, that attacking player creates a tapped 1/1 black Fungus Zombie creature token named Cordyceps Infected that's attacking that opponent.
 SVar:TrigToken:DB$ Token | TokenScript$ cordyceps_infected | TokenOwner$ TriggeredAttackingPlayer | TokenTapped$ True | TokenAttacking$ TriggeredAttackedTarget
 DeckHas:Ability$Token & Type$Zombie|Fungus
-Oracle:Distract the Horde - Whenever a player attacks one of your opponents, that attacking player creates a tapped 1/1 black Fungus Zombie creature token named Cordyceps Infected that's attacking that opponent.\nPartner—Survivors (You can have two commanders if both have this ability.)
+Oracle:Distract the Horde — Whenever a player attacks one of your opponents, that attacking player creates a tapped 1/1 black Fungus Zombie creature token named Cordyceps Infected that's attacking that opponent.\nPartner—Survivors (You can have two commanders if both have this ability.)

--- a/forge-gui/res/cardsfolder/g/goblin_polka_band.txt
+++ b/forge-gui/res/cardsfolder/g/goblin_polka_band.txt
@@ -2,8 +2,9 @@ Name:Goblin Polka Band
 ManaCost:R R
 Types:Creature Goblin
 PT:1/1
-A:AB$ Tap | Announce$ TgtNum | AnnounceTitle$ any number of creatures to target | Cost$ X 2 T | XColor$ R | CostDesc$ {2}, {T}: | ValidTgts$ Creature.untapped | TargetMin$ TgtNum | TargetMax$ TgtNum | TargetsAtRandom$ True | RememberTapped$ True | AILogic$ GoblinPolkaBand | SubAbility$ GoblinHangover | SpellDescription$ Tap any number of random target creatures. Goblins tapped in this way do not untap during their controllers' next untap phases. This ability costs {R} more to activate for each target.
+Text:[Developer's note: Updated and adapted with reference to subsequent Oracle updates. This updated rules text is displayed in-game.]
+A:AB$ Tap | Announce$ TgtNum | AnnounceTitle$ any number of creatures to target | Cost$ X 2 T | XColor$ R | CostDesc$ {2}, {T}: | ValidTgts$ Creature | TargetMin$ TgtNum | TargetMax$ TgtNum | TargetsAtRandom$ True | RememberTapped$ True | AILogic$ GoblinPolkaBand | SubAbility$ GoblinHangover | SpellDescription$ Tap any number of target creatures chosen at random. Goblins tapped this way do not untap during their controllers' next untap step. This ability costs {R} more to activate for each target.
 SVar:GoblinHangover:DB$ PumpAll | ValidCards$ Goblin.IsRemembered | KW$ HIDDEN This card doesn't untap during your next untap step. | Duration$ Permanent
 SVar:TgtNum:Number$0
 SVar:X:SVar$TgtNum
-Oracle:{2}, {T}: Tap any number of random target creatures. Goblins tapped in this way do not untap during their controllers' next untap phases. This ability costs {R} more to activate for each target.
+Oracle:{2}, {T}, Pay {R} for each target: Tap any number of random target creatures. Goblins tapped in this way do not untap during their controllers' next untap phases.

--- a/forge-gui/res/cardsfolder/j/jin_sakai_ghost_of_tsushima.txt
+++ b/forge-gui/res/cardsfolder/j/jin_sakai_ghost_of_tsushima.txt
@@ -9,4 +9,4 @@ SVar:TrigCharm:DB$ Charm | Choices$ Standoff,Ghost
 SVar:Standoff:DB$ Pump | Defined$ TriggeredAttackers | KW$ Double Strike | SpellDescription$ Standoff — It gains double strike until end of turn.
 SVar:Ghost:DB$ Effect | RememberObjects$ TriggeredAttackers | ExileOnMoved$ Battlefield | StaticAbilities$ Unblockable | SpellDescription$ Ghost — It can't be blocked this turn.
 SVar:Unblockable:Mode$ CantBlockBy | ValidAttacker$ Card.IsRemembered | Description$ EFFECTSOURCE can't be blocked this turn.
-Oracle:Whenever Jin Sakai deals combat damage to a player, draw a card.\nWhenever a creature you control attacks a player, if no other creatures are attacking that player, choose one —-\n• Standoff — It gains double strike until end of turn.\n• Ghost — It can't be blocked this turn.
+Oracle:Whenever Jin Sakai deals combat damage to a player, draw a card.\nWhenever a creature you control attacks a player, if no other creatures are attacking that player, choose one —\n• Standoff — It gains double strike until end of turn.\n• Ghost — It can't be blocked this turn.

--- a/forge-gui/res/cardsfolder/l/lurker_in_the_deep.txt
+++ b/forge-gui/res/cardsfolder/l/lurker_in_the_deep.txt
@@ -10,4 +10,4 @@ T:Mode$ SeekAll | PlayerTurn$ True | ValidPlayer$ You | TriggerZones$ Battlefiel
 SVar:TrigConjure:DB$ MakeCard | DefinedName$ TriggeredCards | RememberMade$ True | Zone$ Hand | Conjure$ True | SubAbility$ DBManifest
 SVar:DBManifest:DB$ Manifest | Defined$ Remembered | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-Oracle:Impending 3-{2}{U}{U}\nWhenever Lurker in the Deep enters or attacks, seek a nonland card.\nWhenever you seek one or more cards during your turn, conjure a duplicate of each of those cards into your hand, then manifest those duplicates.
+Oracle:Impending 3—{2}{U}{U}\nWhenever Lurker in the Deep enters or attacks, seek a nonland card.\nWhenever you seek one or more cards during your turn, conjure a duplicate of each of those cards into your hand, then manifest those duplicates.

--- a/forge-gui/res/cardsfolder/o/oviya_automech_artisan.txt
+++ b/forge-gui/res/cardsfolder/o/oviya_automech_artisan.txt
@@ -6,6 +6,6 @@ S:Mode$ Continuous | Affected$ Creature.attacking Opponent | AddKeyword$ Trample
 A:AB$ ChangeZone | Cost$ G T | Origin$ Hand | Destination$ Battlefield | ChangeType$ Creature,Vehicle | ChangeNum$ 1 | RememberChanged$ True | SubAbility$ DBPutCounter | SpellDescription$ You may put a creature or Vehicle card from your hand onto the battlefield. If you put an artifact onto the battlefield this way, put two +1/+1 counters on it.
 SVar:DBPutCounter:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ 2 | Defined$ Remembered | ConditionDefined$ Remembered | ConditionPresent$ Artifact | ConditionCompare$ GE1 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-DeckHints$:Type$Artifact|Vehicle
+DeckHints:Type$Artifact|Vehicle
 DeckHas:Ability$Counters
 Oracle:Each creature that's attacking one of your opponents has trample.\n{G}, {T}: You may put a creature or Vehicle card from your hand onto the battlefield. If you put an artifact onto the battlefield this way, put two +1/+1 counters on it.

--- a/forge-gui/res/cardsfolder/r/raiding_party.txt
+++ b/forge-gui/res/cardsfolder/r/raiding_party.txt
@@ -2,7 +2,7 @@ Name:Raiding Party
 ManaCost:2 R
 Types:Enchantment
 S:Mode$ CantTarget | ValidTarget$ Card.Self | ValidSource$ Card.White | Description$ CARDNAME can't be the target of white spells or abilities from white sources.
-A:AB$ RepeatEach | Cost$ Sac<1/Orc/Orc> | CostDesc$ Sacrifice an Orc: | RepeatPlayers$ Player | RepeatSubAbility$ DBTap | SubAbility$ DBDestroy | SpellDescription$ Each player may tap any number of untapped white creatures they control. For each creature tapped this way, that player chooses up to two Plains. Then destroy all Plains that weren't chosen this way by any player.
+A:AB$ RepeatEach | Cost$ Sac<1/Orc> | RepeatPlayers$ Player | RepeatSubAbility$ DBTap | SubAbility$ DBDestroy | SpellDescription$ Each player may tap any number of untapped white creatures they control. For each creature tapped this way, that player chooses up to two Plains. Then destroy all Plains that weren't chosen this way by any player.
 SVar:DBTap:DB$ Tap | CardChoices$ Creature.untapped+White+RememberedPlayerCtrl | Tapper$ RememberedPlayer | AnyNumber$ True | ChoiceAmount$ Count$Valid Creature.untapped+White+RememberedPlayerCtrl | RememberTapped$ True | SubAbility$ ChoosePlainsToSave
 SVar:ChoosePlainsToSave:DB$ ChooseCard | Defined$ Remembered | MinAmount$ 0 | Amount$ TappedXTwo | Choices$ Plains | ChoiceTitle$ Choose up to two Plains for each creature tapped | ChoiceZone$ Battlefield | ImprintChosen$ True | AILogic$ OwnCard | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearChosenCard$ True


### PR DESCRIPTION
A few punctuation stragglers and notably:
- Updated the Stack text for the delayed trigger of Aang, at the Crossroads and Archangel Avacyn with reference to my previous work on [Shichifukujin Dragon](https://github.com/Card-Forge/forge/blob/master/forge-gui/res/cardsfolder/s/shichifukujin_dragon.txt) ( https://github.com/Card-Forge/forge/pull/6176 )
- Restored the Oracle text of [Goblin Polka Band](https://scryfall.com/card/past/4/goblin-polka-band) to the original with reference to similar cards I've done like [Mountain Mover](https://github.com/Card-Forge/forge/blob/master/forge-gui/res/cardsfolder/m/mountain_mover.txt) (https://github.com/Card-Forge/forge/pull/5878). Canvassed for relevant up to date Oracle text and made the following changes to the text displayed during a game:
○ Following [Goblin Test Pilot](https://scryfall.com/card/dgm/74/goblin-test-pilot) changed "any number of random target creatures" to "any number of target creatures chosen at random".
○ Following [Harmony of Nature](https://scryfall.com/card/p02/128/harmony-of-nature) dropped the 'in' on "Goblins tapped in this way".
○ Following [Apes of Rath](https://scryfall.com/card/tmp/214/apes-of-rath) updated "next untap phases[sic]" to "next untap step".
○ Noticed the ability itself was only targeting untapped creatures which isn't what's written on the card. Tested the corrected version and it works as expected. In the below screenshot it targeted itself while tapped but only remembered the creatures that were actually tapped for the stun effect.

<img width="795" height="724" alt="goblinpolkaband" src="https://github.com/user-attachments/assets/925eabe9-a70a-417e-8f6b-08e68f562951" />

- Following [Ambush Commander](https://github.com/Card-Forge/forge/blob/master/forge-gui/res/cardsfolder/a/ambush_commander.txt) removed the  `CostDesc$` parameterfrom [Raiding Party](https://github.com/Card-Forge/forge/blob/master/forge-gui/res/cardsfolder/r/raiding_party.txt) as apparently redundant. Tested to satisfaction.



