### PR TITLE
Fix AI not sacrificing to avoid lethal life loss

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtil.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtil.java
@@ -835,8 +835,8 @@ public class ComputerUtil {
                 while (sub != null) {
                     if (sub.getApi() == ApiType.LoseLife) {
                         String defined = sub.getParamOrDefault("Defined", "");
-                        // Check if this targets opponents who didn't sacrifice (e.g., OppNonRememberedController)
-                        if (defined.contains("OppNon") || defined.contains("Opponent")) {
+                        // Check if this targets the AI (e.g., OppNonRememberedController, TriggeredPlayer)
+                        if (defined.contains("OppNon") || defined.contains("Opponent") || defined.contains("TriggeredPlayer")) {
                             int lifeAmount = AbilityUtils.calculateAmount(host, sub.getParamOrDefault("LifeAmount", "0"), sub);
                             if (lifeAmount >= ai.getLife()) {
                                 wouldDieFromNotSacrificing = true;

--- a/forge-gui-desktop/src/test/java/forge/ai/sacrifice/AiSacrificeDecisionTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/sacrifice/AiSacrificeDecisionTest.java
@@ -93,4 +93,44 @@ public class AiSacrificeDecisionTest extends AITest {
         // Opponent should have 8 life (lost 2 from not sacrificing)
         AssertJUnit.assertEquals("Opponent should have lost 2 life from not sacrificing", 8, opponent.getLife());
     }
+
+
+    @Test
+    public void testAiSacrificesToPillarTombsToAvoidLethalLifeLoss() {
+        Game game = initAndCreateGame();
+
+        Player p = game.getPlayers().get(1);
+        p.setTeam(0);
+
+        Player opponent = game.getPlayers().get(0);
+        opponent.setTeam(1);
+        opponent.setLife(4, null);
+
+        // Player 1 controls Pillar Tombs of Aku
+        addCard("Pillar Tombs of Aku", p);
+
+        // Opponent controls a creature they can sacrifice
+        Card bear = addCard("Runeclaw Bear", opponent);
+
+        // Fill libraries to prevent draw-death
+        for (int i = 0; i < 10; i++) {
+            addCardToZone("Plains", p, ZoneType.Library);
+            addCardToZone("Plains", opponent, ZoneType.Library);
+        }
+
+        // Play two turns - first ends Player 1's turn, second plays through opponent's upkeep
+        // where Pillar Tombs triggers and the AI must decide whether to sacrifice
+        this.playUntilNextTurn(game);
+        this.playUntilNextTurn(game);
+
+        // The game should NOT be over - AI should have sacrificed to survive
+        AssertJUnit.assertFalse("Game should not be over - AI should have sacrificed to survive", game.isGameOver());
+
+        // Bear should be in graveyard (sacrificed)
+        AssertJUnit.assertTrue("Runeclaw Bear should be in graveyard after being sacrificed",
+                opponent.getZone(ZoneType.Graveyard).contains(bear));
+
+        // Opponent should still have 4 life (didn't lose life because they sacrificed)
+        AssertJUnit.assertEquals("Opponent should still have 4 life after sacrificing", 4, opponent.getLife());
+    }
 }


### PR DESCRIPTION
As a simple workaround, always sacrifice if doing the opposite would result in lethal life loss.

This closes https://github.com/Card-Forge/forge/issues/9530

You can test with the following state:

```txt
turn=1
activeplayer=p0
activephase=MAIN1
p0life=20
p0landsplayed=0
p0landsplayedlastturn=0
p0numringtemptedyou=0
p0speed=0
p0hand=
p0library=Plains|Set:EOE|Art:1;Plains|Set:EOE|Art:1;Plains|Set:EOE|Art:1
p0graveyard=The Crystal's Chosen|Set:FF|Art:1
p0battlefield=Fandaniel, Telophoroi Ascian|Set:FIC|Art:2
p0exile=
p0command=
p0sideboard=
p1life=1
p1landsplayed=0
p1landsplayedlastturn=0
p1numringtemptedyou=0
p1speed=0
p1hand=
p1library=Plains|Set:EOE|Art:1;Plains|Set:EOE|Art:1;Plains|Set:EOE|Art:1
p1graveyard=
p1battlefield=Adelbert Steiner|Set:FIN|Art:2;
p1exile=
p1command=
p1sideboard=

```