### PR TITLE
Fix mana refund to go to spell caster, not mana producer

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/ManaAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ManaAi.java
@@ -269,7 +269,7 @@ public class ManaAi extends SpellAbilityAi {
         Mana test = null;
         if (mp.isEmpty()) {
             // TODO use color from ability
-            test = new Mana((byte) ManaAtom.COLORLESS, source, null);
+            test = new Mana((byte) ManaAtom.COLORLESS, source, null, ai);
             mp.addMana(test, false);
         }
         boolean lose = mp.willManaBeLostAtEndOfPhase();

--- a/forge-game/src/main/java/forge/game/GameSnapshot.java
+++ b/forge-game/src/main/java/forge/game/GameSnapshot.java
@@ -191,19 +191,19 @@ public class GameSnapshot {
         Game toGame = toPlayer.getGame();
         toPlayer.getManaPool().resetPool();
         for (Mana m : fromPlayer.getManaPool()) {
-            toPlayer.getManaPool().addMana(copyMana(m, toGame), false);
+            toPlayer.getManaPool().addMana(copyMana(m, toGame, toPlayer), false);
         }
         toPlayer.updateManaForView();
     }
 
-    private Mana copyMana(Mana m, Game toGame) {
+    private Mana copyMana(Mana m, Game toGame, Player toPlayer) {
         Card fromCard = m.getSourceCard();
         Card toCard = findBy(toGame, fromCard);
         // Are we copying over mana abilities properly?
         if (toCard == null) {
             return m;
         }
-        Mana newMana = new Mana(m.getColor(), toCard, m.getManaAbility());
+        Mana newMana = new Mana(m.getColor(), toCard, m.getManaAbility(), toPlayer);
         newMana.getManaAbility().setSourceCard(toCard);
         return newMana;
     }

--- a/forge-game/src/main/java/forge/game/cost/CostAddMana.java
+++ b/forge-game/src/main/java/forge/game/cost/CostAddMana.java
@@ -80,7 +80,7 @@ public class CostAddMana extends CostPart {
         for (int n = 0; n < decision.c; n++) {
             if (StringUtils.isNumeric(type)) {
                 for (int i = Integer.parseInt(type); i > 0; i--) {
-                    manaProduced.add(new Mana((byte)ManaAtom.COLORLESS, source, null));
+                    manaProduced.add(new Mana((byte)ManaAtom.COLORLESS, source, null, ai));
                 }
             } else {
                 byte attemptedMana = ManaAtom.fromName(type);
@@ -91,7 +91,7 @@ public class CostAddMana extends CostPart {
                         attemptedMana = (byte)ManaAtom.COLORLESS;
                     }
                 }*/
-                manaProduced.add(new Mana(attemptedMana, source, null));
+                manaProduced.add(new Mana(attemptedMana, source, null, ai));
             }
         }
         ai.getManaPool().add(manaProduced);

--- a/forge-game/src/main/java/forge/game/mana/Mana.java
+++ b/forge-game/src/main/java/forge/game/mana/Mana.java
@@ -21,6 +21,7 @@ import forge.card.MagicColor;
 import forge.card.mana.ManaAtom;
 import forge.game.card.Card;
 import forge.game.card.CardCopyService;
+import forge.game.player.Player;
 import forge.game.spellability.AbilityManaPart;
 import forge.game.spellability.SpellAbility;
 
@@ -30,7 +31,7 @@ import forge.game.spellability.SpellAbility;
  * This represents a single mana 'globe' floating in a player's pool.
  * </p>
  */
-public record Mana(byte color, Card sourceCard, AbilityManaPart manaAbility) {
+public record Mana(byte color, Card sourceCard, AbilityManaPart manaAbility, Player player) {
 
     @Override
     public int hashCode() {
@@ -80,10 +81,11 @@ public record Mana(byte color, Card sourceCard, AbilityManaPart manaAbility) {
         return mp == mp2 || (mp.getManaRestrictions().equals(mp2.getManaRestrictions()) && mp.getExtraManaRestriction().equals(mp2.getExtraManaRestriction()));
     }
 
-    public Mana(final byte color, final Card sourceCard, final AbilityManaPart manaAbility) {
+    public Mana(final byte color, final Card sourceCard, final AbilityManaPart manaAbility, final Player player) {
         this.color = color;
         this.manaAbility = manaAbility;
         this.sourceCard = sourceCard.isInPlay() ? CardCopyService.getLKICopy(sourceCard) : sourceCard.getGame().getChangeZoneLKIInfo(sourceCard);
+        this.player = player;
     }
 
     @Override
@@ -137,6 +139,10 @@ public record Mana(byte color, Card sourceCard, AbilityManaPart manaAbility) {
 
     public final AbilityManaPart getManaAbility() {
         return this.manaAbility;
+    }
+
+    public final Player getPlayer() {
+        return this.player;
     }
 
     public boolean isColorless() {

--- a/forge-game/src/main/java/forge/game/mana/ManaPool.java
+++ b/forge-game/src/main/java/forge/game/mana/ManaPool.java
@@ -175,7 +175,7 @@ public class ManaPool extends ManaConversionMatrix implements Iterable<Mana> {
         List<Mana> convert = Lists.newArrayList();
         Collection<Mana> cm = floatingMana.get(originalColor);
         for (Mana m : cm) {
-            convert.add(new Mana(toColor, m.getSourceCard(), m.getManaAbility()));
+            convert.add(new Mana(toColor, m.getSourceCard(), m.getManaAbility(), m.getPlayer()));
         }
         cm.clear();
         floatingMana.putAll(toColor, convert);

--- a/forge-game/src/main/java/forge/game/mana/ManaRefundService.java
+++ b/forge-game/src/main/java/forge/game/mana/ManaRefundService.java
@@ -13,21 +13,17 @@ import java.util.List;
 public class ManaRefundService {
 
     private final SpellAbility sa;
-    private final Player activator;
+
     public ManaRefundService(SpellAbility sa) {
         this.sa = sa;
-        this.activator = sa.getActivatingPlayer();
     }
 
     public void refundManaPaid() {
-        PlayerCollection payers = new PlayerCollection(activator);
+        PlayerCollection payers = new PlayerCollection(sa.getActivatingPlayer());
 
         // move non-undoable paying mana back to floating
         for (Mana mana : sa.getPayingMana()) {
-            Player pl = mana.getManaAbility().getSourceSA() ==  null // null means mana likely added by dev cheat
-                ? mana.getManaAbility().getSourceCard().getOwner()
-                : mana.getManaAbility().getSourceSA().getActivatingPlayer();
-
+            Player pl = mana.getPlayer();
             pl.getManaPool().addMana(mana);
             payers.add(pl);
         }
@@ -48,7 +44,7 @@ public class ManaRefundService {
             // Recursively refund abilities that were used.
             ManaRefundService refundService = new ManaRefundService(am);
             refundService.refundManaPaid();
-            activator.getGame().getStack().clearUndoStack(am);
+            sa.getHostCard().getGame().getStack().clearUndoStack(am);
         }
 
         payingAbilities.clear();

--- a/forge-game/src/main/java/forge/game/spellability/AbilityManaPart.java
+++ b/forge-game/src/main/java/forge/game/spellability/AbilityManaPart.java
@@ -181,7 +181,7 @@ public class AbilityManaPart implements java.io.Serializable {
         for (final String c : afterReplace.split(" ")) {
             if (StringUtils.isNumeric(c)) {
                 for (int i = Integer.parseInt(c); i > 0; i--) {
-                    this.lastManaProduced.add(new Mana((byte) ManaAtom.COLORLESS, source, this));
+                    this.lastManaProduced.add(new Mana((byte) ManaAtom.COLORLESS, source, this, player));
                 }
             } else {
                 byte attemptedMana = MagicColor.fromName(c);
@@ -189,7 +189,7 @@ public class AbilityManaPart implements java.io.Serializable {
                     attemptedMana = (byte)ManaAtom.COLORLESS;
                 }
 
-                this.lastManaProduced.add(new Mana(attemptedMana, source, this));
+                this.lastManaProduced.add(new Mana(attemptedMana, source, this, player));
             }
         }
 

--- a/forge-gui-desktop/src/test/java/forge/ai/AIIntegrationTests.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/AIIntegrationTests.java
@@ -99,8 +99,8 @@ public class AIIntegrationTests extends AITest {
         // Setup mana
         Card colorlessMana = createCard("Ash Barrens", p);
         Card greenMana = createCard("Forest", p);
-        p.getManaPool().addMana(new Mana((byte) ManaAtom.COLORLESS, colorlessMana, null));
-        p.getManaPool().addMana(new Mana((byte) ManaAtom.GREEN, greenMana, null));
+        p.getManaPool().addMana(new Mana((byte) ManaAtom.COLORLESS, colorlessMana, null, p));
+        p.getManaPool().addMana(new Mana((byte) ManaAtom.GREEN, greenMana, null, p));
         AssertJUnit.assertEquals(2, p.getManaPool().totalMana());
 
         // Put a non-creature card in opponent's graveyard

--- a/forge-gui-desktop/src/test/java/forge/game/mana/ManaRefundServiceTest.java
+++ b/forge-gui-desktop/src/test/java/forge/game/mana/ManaRefundServiceTest.java
@@ -1,0 +1,37 @@
+package forge.game.mana;
+
+import forge.ai.simulation.SimulationTest;
+import forge.card.mana.ManaAtom;
+import forge.game.Game;
+import forge.game.card.Card;
+import forge.game.player.Player;
+import forge.game.spellability.SpellAbility;
+import forge.game.zone.ZoneType;
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+public class ManaRefundServiceTest extends SimulationTest {
+
+    /**
+     * Tests that mana is refunded to the player stored in the Mana object.
+     */
+    @Test
+    public void testManaRefundsToManaPlayer() {
+        Game game = initAndCreateGame();
+        Player caster = game.getPlayers().get(1);
+        Player manaOwner = game.getPlayers().get(0);
+
+        Card land = addCard("Island", manaOwner);
+        Mana mana = new Mana((byte) ManaAtom.BLUE, land, null, manaOwner);
+
+        Card spell = addCardToZone("Bear Cub", caster, ZoneType.Hand);
+        SpellAbility castSpell = spell.getFirstSpellAbility();
+        castSpell.setActivatingPlayer(caster);
+        castSpell.getPayingMana().add(mana);
+
+        new ManaRefundService(castSpell).refundManaPaid();
+
+        AssertJUnit.assertEquals(1, manaOwner.getManaPool().totalMana());
+        AssertJUnit.assertEquals(0, caster.getManaPool().totalMana());
+    }
+}


### PR DESCRIPTION
Mana from cards like Eladamri's Vineyard that add mana to an opponent's pool was not being refunded correctly when a spell was cancelled. The mana was going back to the card owner instead of the player who was casting the spell.

Closes https://github.com/Card-Forge/forge/issues/9529

Sample state:

```txt
turn=1
activeplayer=p0
activephase=UPKEEP
p0life=20
p0landsplayed=0
p0landsplayedlastturn=0
p0numringtemptedyou=0
p0speed=0
p0hand=Famished Worldsire|Set:EOE|Art:1
p0library=Plains|Set:EOE|Art:1;Plains|Set:EOE|Art:1;Plains|Set:EOE|Art:1
p0graveyard=
p0battlefield=
p0exile=
p0command=
p0sideboard=
p1life=20
p1landsplayed=0
p1landsplayedlastturn=0
p1numringtemptedyou=0
p1speed=0
p1hand=Famished Worldsire|Set:EOE|Art:1
p1library=Plains|Set:EOE|Art:1;Plains|Set:EOE|Art:1;Plains|Set:EOE|Art:1
p1graveyard=
p1battlefield=Eladamri's Vineyard|Set:TMP|Art:1;Magus of the Vineyard|Set:FUT|Art:1
p1exile=
p1command=
p1sideboard=
```

PD: I have added the tests in `forge-gui-desktop` because the test infrastructure is better there.

