### PR TITLE
Cleanup 2026-01-17

### DIFF
--- a/forge-gui/res/cardsfolder/b/black_market.txt
+++ b/forge-gui/res/cardsfolder/b/black_market.txt
@@ -4,6 +4,6 @@ Types:Enchantment
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Whenever a creature dies, put a charge counter on CARDNAME.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ CHARGE | CounterNum$ 1
 T:Mode$ Phase | Phase$ Main1 | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigGetMana | TriggerDescription$ At the beginning of your first main phase, add {B} for each charge counter on CARDNAME.
-SVar:TrigGetMana:DB$ Mana | Produced$ B | Amount$ X | SpellDescription$ Add {X}{B}
+SVar:TrigGetMana:DB$ Mana | Produced$ B | Amount$ X
 SVar:X:Count$CardCounters.CHARGE
 Oracle:Whenever a creature dies, put a charge counter on Black Market.\nAt the beginning of your first main phase, add {B} for each charge counter on Black Market.

--- a/forge-gui/res/cardsfolder/f/flash_photography.txt
+++ b/forge-gui/res/cardsfolder/f/flash_photography.txt
@@ -5,4 +5,4 @@ K:Flashback:4 U U
 S:Mode$ CastWithFlash | ValidCard$ Card.Self | ValidSA$ Spell.IsTargeting Valid Permanent.YouCtrl | EffectZone$ All | Caster$ You | Description$ You may cast this spell as though it had flash if it targets a permanent you control.
 A:SP$ CopyPermanent | ValidTgts$ Permanent | StackDescription$ SpellDescription | SpellDescription$ Create a token that's a copy of target permanent.
 DeckHas:Ability$Token
-Oracle:You may cast this spell as though it had flash if it targets a permanent you control.\nCreate a token that's a copy of target permanent.\nFlashback {4}{U)}U)
+Oracle:You may cast this spell as though it had flash if it targets a permanent you control.\nCreate a token that's a copy of target permanent.\nFlashback {4}{U}{U}

--- a/forge-gui/res/cardsfolder/g/glamorous_outlaw.txt
+++ b/forge-gui/res/cardsfolder/g/glamorous_outlaw.txt
@@ -7,7 +7,7 @@ SVar:TrigDealDamage:DB$ DealDamage | NumDmg$ 2 | Defined$ Opponent | SubAbility$
 SVar:DBScry:DB$ Scry | ScryNum$ 2
 A:AB$ Effect | Cost$ 2 ExileFromHand<1/CARDNAME> | ActivationZone$ Hand | ValidTgts$ Land | RememberObjects$ Targeted,Self | StaticAbilities$ Land,MayPlay | Triggers$ Cast | ImprintCards$ Self | Duration$ Permanent | ForgetOnMoved$ Exile | SpellDescription$ Target land gains "{T}: Add {U}, {B}, or {R}" until CARDNAME is cast from exile. You may cast CARDNAME for as long as it remains exiled.
 SVar:Land:Mode$ Continuous | AffectedZone$ Battlefield | Affected$ Card.IsRemembered+IsNotImprinted | AddAbility$ Mana | Description$ Target land gains "{T}: Add {U}, {B}, or {R}" until EFFECTSOURCE is cast from exile. You may cast EFFECTSOURCE for as long as it remains exiled.
-SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo U B R | Amount$ 1 | SpellDescription$ Add {U}, {B}, or {R}
+SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo U B R | Amount$ 1 | SpellDescription$ Add {U}, {B}, or {R}.
 SVar:MayPlay:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsImprinted+IsRemembered | AffectedZone$ Exile | Secondary$ True | Description$ You may cast EFFECTSOURCE for as long as it remains exiled.
 SVar:Cast:Mode$ SpellCast | ValidCard$ Card.IsImprinted+IsRemembered+wasCastFromExile | Execute$ ExileSelf | Static$ True
 SVar:ExileSelf:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self

--- a/forge-gui/res/cardsfolder/g/glorious_sunrise.txt
+++ b/forge-gui/res/cardsfolder/g/glorious_sunrise.txt
@@ -5,7 +5,7 @@ T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | Execute$ TrigCharm | Tri
 SVar:TrigCharm:DB$ Charm | Choices$ PumpAll,Animate,Draw,Gain
 SVar:PumpAll:DB$ PumpAll | ValidCards$ Creature.YouCtrl | KW$ Trample | NumAtt$ +1 | NumDef$ +1 | SpellDescription$ Creatures you control get +1/+1 and gain trample until end of turn.
 SVar:Animate:DB$ Animate | ValidTgts$ Land | Abilities$ ThreeG | SpellDescription$ Target land gains "{T}: Add {G}{G}{G}" until end of turn.
-SVar:ThreeG:AB$ Mana | Cost$ T | Produced$ G | Amount$ 3 | SpellDescription$ Add {G}{G}{G}
+SVar:ThreeG:AB$ Mana | Cost$ T | Produced$ G | Amount$ 3 | SpellDescription$ Add {G}{G}{G}.
 SVar:Draw:DB$ Draw | Defined$ You | NumCards$ 1 | ConditionPresent$ Creature.YouCtrl+powerGE3 | SpellDescription$ Draw a card if you control a creature with power 3 or greater.
 SVar:Gain:DB$ GainLife | LifeAmount$ 3 | SpellDescription$ You gain 3 life.
 DeckHas:Ability$LifeGain

--- a/forge-gui/res/cardsfolder/h/hydro_man_fluid_felon.txt
+++ b/forge-gui/res/cardsfolder/h/hydro_man_fluid_felon.txt
@@ -8,5 +8,5 @@ SVar:TrigPump:DB$ Pump | NumAtt$ +1 | NumDef$ +1 | Defined$ Self
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUntap | TriggerDescription$ At the beginning of your end step, untap NICKNAME. Until your next turn, he becomes a land and gains "{T}: Add {U}." (He's not a creature during that time.)
 SVar:TrigUntap:DB$ Untap | Defined$ Self | SubAbility$ DBAnimate
 SVar:DBAnimate:DB$ Animate | Defined$ Self | Types$ Land | RemoveCardTypes$ True | Abilities$ DBMana | Duration$ UntilYourNextTurn
-SVar:DBMana:AB$ Mana | Cost$ T | Produced$ U | Amount$ 1 | SpellDescription$ Add {U}
+SVar:DBMana:AB$ Mana | Cost$ T | Produced$ U | Amount$ 1 | SpellDescription$ Add {U}.
 Oracle:Whenever you cast a blue spell, if Hydro-Man is a creature, he gets +1/+1 until end of turn.\nAt the beginning of your end step, untap Hydro-Man. Until your next turn, he becomes a land and gains "{T}: Add {U}." (He's not a creature during that time.)

--- a/forge-gui/res/cardsfolder/m/masked_bandits.txt
+++ b/forge-gui/res/cardsfolder/m/masked_bandits.txt
@@ -6,7 +6,7 @@ K:Vigilance
 K:Menace
 A:AB$ Effect | Cost$ 2 ExileFromHand<1/CARDNAME> | ActivationZone$ Hand | ValidTgts$ Land | RememberObjects$ Targeted,Self | StaticAbilities$ Land,MayPlay | Triggers$ Cast | ImprintCards$ Self | Duration$ Permanent | ForgetOnMoved$ Exile | SpellDescription$ Target land gains "{T}: Add {B}, {R}, or {G}" until CARDNAME is cast from exile. You may cast CARDNAME for as long as it remains exiled.
 SVar:Land:Mode$ Continuous | AffectedZone$ Battlefield | Affected$ Card.IsRemembered+IsNotImprinted | AddAbility$ Mana | Description$ Target land gains "{T}: Add {B}, {R}, or {G}" until EFFECTSOURCE is cast from exile. You may cast EFFECTSOURCE for as long as it remains exiled.
-SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo B R G | Amount$ 1 | SpellDescription$ Add {B}, {R}, or {G}
+SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo B R G | Amount$ 1 | SpellDescription$ Add {B}, {R}, or {G}.
 SVar:MayPlay:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsImprinted+IsRemembered | AffectedZone$ Exile | Secondary$ True | Description$ You may cast EFFECTSOURCE for as long as it remains exiled.
 SVar:Cast:Mode$ SpellCast | ValidCard$ Card.IsImprinted+IsRemembered+wasCastFromExile | Execute$ ExileSelf | Static$ True
 SVar:ExileSelf:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self

--- a/forge-gui/res/cardsfolder/m/mogg_assassin.txt
+++ b/forge-gui/res/cardsfolder/m/mogg_assassin.txt
@@ -2,9 +2,9 @@ Name:Mogg Assassin
 ManaCost:2 R
 Types:Creature Goblin Assassin
 PT:2/1
-A:AB$ Pump | Cost$ T | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | RememberObjects$ ThisTargetedCard | IsCurse$ True | SubAbility$ DBPump | StackDescription$ You choose {c:ThisTargetedCard} | SpellDescription$ You choose target creature an opponent controls, and that opponent chooses target creature. Flip a coin. If you win the flip, destroy the creature you chose. If you lose the flip, destroy the creature your opponent chose.
-SVar:DBPump:DB$ Pump | ValidTgts$ Creature | TargetingPlayer$ ParentTargetedController | IsCurse$ True | ImprintCards$ ThisTargetedCard | SubAbility$ DBFlip | StackDescription$ That player chooses {c:ThisTargetedCard}
-SVar:DBFlip:DB$ FlipACoin | WinSubAbility$ DestroyRemembered | LoseSubAbility$ DestroyImprinted | SubAbility$ DBCleanup
+A:AB$ Pump | Cost$ T | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | RememberObjects$ ThisTargetedCard | IsCurse$ True | SubAbility$ DBPump | StackDescription$ {p:You} chooses {c:ThisTargetedCard}, | SpellDescription$ You choose target creature an opponent controls, and that opponent chooses target creature. Flip a coin. If you win the flip, destroy the creature you chose. If you lose the flip, destroy the creature your opponent chose.
+SVar:DBPump:DB$ Pump | ValidTgts$ Creature | TargetingPlayer$ ParentTargetedController | IsCurse$ True | ImprintCards$ ThisTargetedCard | SubAbility$ DBFlip | StackDescription$ and {p:ParentTargetedController} chooses {c:ThisTargetedCard}. {p:You} flips a coin. If {p:You} wins the flip, they destroy {c:ParentTarget}. If {p:You} loses the flip, they destroy {c:ThisTargetedCard}.
+SVar:DBFlip:DB$ FlipACoin | WinSubAbility$ DestroyRemembered | LoseSubAbility$ DestroyImprinted | SubAbility$ DBCleanup | StackDescription$ None
 SVar:DestroyRemembered:DB$ Destroy | Defined$ Remembered
 SVar:DestroyImprinted:DB$ Destroy | Defined$ Imprinted
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearImprinted$ True

--- a/forge-gui/res/cardsfolder/p/plaza_of_heroes.txt
+++ b/forge-gui/res/cardsfolder/p/plaza_of_heroes.txt
@@ -1,7 +1,7 @@
 Name:Plaza of Heroes
 ManaCost:no cost
 Types:Land
-A:AB$ Mana | Cost$ T | Produced$ C | Amount$ 1 | SpellDescription$ Add {C}
+A:AB$ Mana | Cost$ T | Produced$ C | Amount$ 1 | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ T | Produced$ Any | Amount$ 1 | RestrictValid$ Spell.Legendary | SpellDescription$ Add one mana of any color. Spend this mana only to cast a legendary spell.
 A:AB$ ManaReflected | Cost$ T | ColorOrType$ Color | Valid$ Permanent.Legendary+YouCtrl | ReflectProperty$ Is | SpellDescription$ Add one mana of any color among legendary permanents you control.
 A:AB$ Pump | Cost$ 3 T Exile<1/CARDNAME> | ValidTgts$ Creature.Legendary | KW$ Hexproof & Indestructible | SpellDescription$ Target legendary creature gains hexproof and indestructible until end of turn.

--- a/forge-gui/res/cardsfolder/r/rakish_revelers.txt
+++ b/forge-gui/res/cardsfolder/r/rakish_revelers.txt
@@ -6,7 +6,7 @@ T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.S
 SVar:TrigToken:DB$ Token | TokenScript$ gw_1_1_citizen
 A:AB$ Effect | Cost$ 2 ExileFromHand<1/CARDNAME> | ActivationZone$ Hand | ValidTgts$ Land | RememberObjects$ Targeted,Self | StaticAbilities$ Land,MayPlay | Triggers$ Cast | ImprintCards$ Self | Duration$ Permanent | ForgetOnMoved$ Exile | SpellDescription$ Target land gains "{T}: Add {R}, {G}, or {W}" until CARDNAME is cast from exile. You may cast CARDNAME for as long as it remains exiled.
 SVar:Land:Mode$ Continuous | AffectedZone$ Battlefield | Affected$ Card.IsRemembered+IsNotImprinted | AddAbility$ Mana | Description$ Target land gains "{T}: Add {R}, {G}, or {W}" until EFFECTSOURCE is cast from exile. You may cast EFFECTSOURCE for as long as it remains exiled.
-SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo R G W | Amount$ 1 | SpellDescription$ Add {R}, {G}, or {W}
+SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo R G W | Amount$ 1 | SpellDescription$ Add {R}, {G}, or {W}.
 SVar:MayPlay:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsImprinted+IsRemembered | AffectedZone$ Exile | Secondary$ True | Description$ You may cast EFFECTSOURCE for as long as it remains exiled.
 SVar:Cast:Mode$ SpellCast | ValidCard$ Card.IsImprinted+IsRemembered+wasCastFromExile | Execute$ ExileSelf | Static$ True
 SVar:ExileSelf:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self

--- a/forge-gui/res/cardsfolder/rebalanced/a-glamorous_outlaw.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-glamorous_outlaw.txt
@@ -8,7 +8,7 @@ SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 2 | SubAbility$ DBScry
 SVar:DBScry:DB$ Scry | ScryNum$ 2
 A:AB$ Effect | Cost$ 1 ExileFromHand<1/CARDNAME> | ActivationZone$ Hand | ValidTgts$ Land | RememberObjects$ Targeted,Self | StaticAbilities$ Land,MayPlay | Triggers$ Cast | ImprintCards$ Self | Duration$ Permanent | ForgetOnMoved$ Exile | SpellDescription$ Target land gains "{T}: Add {U}, {B}, or {R}" until CARDNAME is cast from exile. You may cast CARDNAME for as long as it remains exiled.
 SVar:Land:Mode$ Continuous | AffectedZone$ Battlefield | Affected$ Card.IsRemembered+IsNotImprinted | AddAbility$ Mana | Description$ Target land gains "{T}: Add {U}, {B}, or {R}" until EFFECTSOURCE is cast from exile. You may cast EFFECTSOURCE for as long as it remains exiled.
-SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo U B R | Amount$ 1 | SpellDescription$ Add {U}, {B}, or {R}
+SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo U B R | Amount$ 1 | SpellDescription$ Add {U}, {B}, or {R}.
 SVar:MayPlay:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsImprinted+IsRemembered | AffectedZone$ Exile | Secondary$ True | Description$ You may cast EFFECTSOURCE for as long as it remains exiled.
 SVar:Cast:Mode$ SpellCast | ValidCard$ Card.IsImprinted+IsRemembered+wasCastFromExile | Execute$ ExileSelf | Static$ True
 SVar:ExileSelf:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self

--- a/forge-gui/res/cardsfolder/rebalanced/a-masked_bandits.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-masked_bandits.txt
@@ -6,7 +6,7 @@ K:Vigilance
 K:Menace
 A:AB$ Effect | Cost$ 1 ExileFromHand<1/CARDNAME> | ActivationZone$ Hand | ValidTgts$ Land | RememberObjects$ Targeted,Self | StaticAbilities$ Land,MayPlay | Triggers$ Cast | ImprintCards$ Self | Duration$ Permanent | ForgetOnMoved$ Exile | SpellDescription$ Target land gains "{T}: Add {B}, {R}, or {G}" until CARDNAME is cast from exile. You may cast CARDNAME for as long as it remains exiled.
 SVar:Land:Mode$ Continuous | AffectedZone$ Battlefield | Affected$ Card.IsRemembered+IsNotImprinted | AddAbility$ Mana | Description$ Target land gains "{T}: Add {B}, {R}, or {G}" until EFFECTSOURCE is cast from exile. You may cast EFFECTSOURCE for as long as it remains exiled.
-SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo B R G | Amount$ 1 | SpellDescription$ Add {B}, {R}, or {G}
+SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo B R G | Amount$ 1 | SpellDescription$ Add {B}, {R}, or {G}.
 SVar:MayPlay:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsImprinted+IsRemembered | AffectedZone$ Exile | Secondary$ True | Description$ You may cast EFFECTSOURCE for as long as it remains exiled.
 SVar:Cast:Mode$ SpellCast | ValidCard$ Card.IsImprinted+IsRemembered+wasCastFromExile | Execute$ ExileSelf | Static$ True
 SVar:ExileSelf:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self

--- a/forge-gui/res/cardsfolder/rebalanced/a-rakish_revelers.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-rakish_revelers.txt
@@ -6,7 +6,7 @@ T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.S
 SVar:TrigToken:DB$ Token | TokenScript$ gw_1_1_citizen
 A:AB$ Effect | Cost$ 1 ExileFromHand<1/CARDNAME> | ActivationZone$ Hand | ValidTgts$ Land | RememberObjects$ Targeted,Self | StaticAbilities$ Land,MayPlay | Triggers$ Cast | ImprintCards$ Self | Duration$ Permanent | ForgetOnMoved$ Exile | SpellDescription$ Target land gains "{T}: Add {R}, {G}, or {W}" until CARDNAME is cast from exile. You may cast CARDNAME for as long as it remains exiled.
 SVar:Land:Mode$ Continuous | AffectedZone$ Battlefield | Affected$ Card.IsRemembered+IsNotImprinted | AddAbility$ Mana | Description$ Target land gains "{T}: Add {R}, {G}, or {W}" until EFFECTSOURCE is cast from exile. You may cast EFFECTSOURCE for as long as it remains exiled.
-SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo R G W | Amount$ 1 | SpellDescription$ Add {R}, {G}, or {W}
+SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo R G W | Amount$ 1 | SpellDescription$ Add {R}, {G}, or {W}.
 SVar:MayPlay:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsImprinted+IsRemembered | AffectedZone$ Exile | Secondary$ True | Description$ You may cast EFFECTSOURCE for as long as it remains exiled.
 SVar:Cast:Mode$ SpellCast | ValidCard$ Card.IsImprinted+IsRemembered+wasCastFromExile | Execute$ ExileSelf | Static$ True
 SVar:ExileSelf:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self

--- a/forge-gui/res/cardsfolder/rebalanced/a-shattered_seraph.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-shattered_seraph.txt
@@ -7,7 +7,7 @@ T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.S
 SVar:TrigGainLife:DB$ GainLife | LifeAmount$ 3
 A:AB$ Effect | Cost$ 1 ExileFromHand<1/CARDNAME> | ActivationZone$ Hand | ValidTgts$ Land | RememberObjects$ Targeted,Self | StaticAbilities$ Land,MayPlay | Triggers$ Cast | ImprintCards$ Self | Duration$ Permanent | ForgetOnMoved$ Exile | SpellDescription$ Target land gains "{T}: Add {W}, {U}, or {B}" until CARDNAME is cast from exile. You may cast CARDNAME for as long as it remains exiled.
 SVar:Land:Mode$ Continuous | AffectedZone$ Battlefield | Affected$ Card.IsRemembered+IsNotImprinted | AddAbility$ Mana | Description$ Target land gains "{T}: Add {W}, {U}, or {B}" until EFFECTSOURCE is cast from exile. You may cast EFFECTSOURCE for as long as it remains exiled.
-SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo W U B | Amount$ 1 | SpellDescription$ Add {W}, {U}, or {B}
+SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo W U B | Amount$ 1 | SpellDescription$ Add {W}, {U}, or {B}.
 SVar:MayPlay:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsImprinted+IsRemembered | AffectedZone$ Exile | Secondary$ True | Description$ You may cast EFFECTSOURCE for as long as it remains exiled.
 SVar:Cast:Mode$ SpellCast | ValidCard$ Card.IsImprinted+IsRemembered+wasCastFromExile | Execute$ ExileSelf | Static$ True
 SVar:ExileSelf:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self

--- a/forge-gui/res/cardsfolder/rebalanced/a-sparas_adjudicators.txt
+++ b/forge-gui/res/cardsfolder/rebalanced/a-sparas_adjudicators.txt
@@ -6,7 +6,7 @@ T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefi
 SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | KW$ HIDDEN CARDNAME can't attack or block. | IsCurse$ True | Duration$ UntilYourNextTurn
 A:AB$ Effect | Cost$ 1 ExileFromHand<1/CARDNAME> | ActivationZone$ Hand | ValidTgts$ Land | RememberObjects$ Targeted,Self | StaticAbilities$ Land,MayPlay | Triggers$ Cast | ImprintCards$ Self | Duration$ Permanent | ForgetOnMoved$ Exile | SpellDescription$ Target land gains "{T}: Add {G}, {W}, or {U}" until CARDNAME is cast from exile. You may cast CARDNAME for as long as it remains exiled.
 SVar:Land:Mode$ Continuous | AffectedZone$ Battlefield | Affected$ Card.IsRemembered+IsNotImprinted | AddAbility$ Mana | Description$ Target land gains "{T}: Add {G}, {W}, or {U}" until EFFECTSOURCE is cast from exile. You may cast EFFECTSOURCE for as long as it remains exiled.
-SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo G W U | Amount$ 1 | SpellDescription$ Add {G}, {W}, or {U}
+SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo G W U | Amount$ 1 | SpellDescription$ Add {G}, {W}, or {U}.
 SVar:MayPlay:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsImprinted+IsRemembered | AffectedZone$ Exile | Secondary$ True | Description$ You may cast EFFECTSOURCE for as long as it remains exiled.
 SVar:Cast:Mode$ SpellCast | ValidCard$ Card.IsImprinted+IsRemembered+wasCastFromExile | Execute$ ExileSelf | Static$ True
 SVar:ExileSelf:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self

--- a/forge-gui/res/cardsfolder/s/shattered_seraph.txt
+++ b/forge-gui/res/cardsfolder/s/shattered_seraph.txt
@@ -7,7 +7,7 @@ T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.S
 SVar:TrigGainLife:DB$ GainLife | LifeAmount$ 3
 A:AB$ Effect | Cost$ 2 ExileFromHand<1/CARDNAME> | ActivationZone$ Hand | ValidTgts$ Land | RememberObjects$ Targeted,Self | StaticAbilities$ Land,MayPlay | Triggers$ Cast | ImprintCards$ Self | Duration$ Permanent | ForgetOnMoved$ Exile | SpellDescription$ Target land gains "{T}: Add {W}, {U}, or {B}" until CARDNAME is cast from exile. You may cast CARDNAME for as long as it remains exiled.
 SVar:Land:Mode$ Continuous | AffectedZone$ Battlefield | Affected$ Card.IsRemembered+IsNotImprinted | AddAbility$ Mana | Description$ Target land gains "{T}: Add {W}, {U}, or {B}" until EFFECTSOURCE is cast from exile. You may cast EFFECTSOURCE for as long as it remains exiled.
-SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo W U B | Amount$ 1 | SpellDescription$ Add {W}, {U}, or {B}
+SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo W U B | Amount$ 1 | SpellDescription$ Add {W}, {U}, or {B}.
 SVar:MayPlay:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsImprinted+IsRemembered | AffectedZone$ Exile | Secondary$ True | Description$ You may cast EFFECTSOURCE for as long as it remains exiled.
 SVar:Cast:Mode$ SpellCast | ValidCard$ Card.IsImprinted+IsRemembered+wasCastFromExile | Execute$ ExileSelf | Static$ True
 SVar:ExileSelf:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self

--- a/forge-gui/res/cardsfolder/s/sparas_adjudicators.txt
+++ b/forge-gui/res/cardsfolder/s/sparas_adjudicators.txt
@@ -6,7 +6,7 @@ T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefi
 SVar:TrigPump:DB$ Pump | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls | KW$ HIDDEN CARDNAME can't attack or block. | IsCurse$ True | Duration$ UntilYourNextTurn
 A:AB$ Effect | Cost$ 2 ExileFromHand<1/CARDNAME> | ActivationZone$ Hand | ValidTgts$ Land | RememberObjects$ Targeted,Self | StaticAbilities$ Land,MayPlay | Triggers$ Cast | ImprintCards$ Self | Duration$ Permanent | ForgetOnMoved$ Exile | SpellDescription$ Target land gains "{T}: Add {G}, {W}, or {U}" until CARDNAME is cast from exile. You may cast CARDNAME for as long as it remains exiled.
 SVar:Land:Mode$ Continuous | AffectedZone$ Battlefield | Affected$ Card.IsRemembered+IsNotImprinted | AddAbility$ Mana | Description$ Target land gains "{T}: Add {G}, {W}, or {U}" until EFFECTSOURCE is cast from exile. You may cast EFFECTSOURCE for as long as it remains exiled.
-SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo G W U | Amount$ 1 | SpellDescription$ Add {G}, {W}, or {U}
+SVar:Mana:AB$ Mana | Cost$ T | Produced$ Combo G W U | Amount$ 1 | SpellDescription$ Add {G}, {W}, or {U}.
 SVar:MayPlay:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsImprinted+IsRemembered | AffectedZone$ Exile | Secondary$ True | Description$ You may cast EFFECTSOURCE for as long as it remains exiled.
 SVar:Cast:Mode$ SpellCast | ValidCard$ Card.IsImprinted+IsRemembered+wasCastFromExile | Execute$ ExileSelf | Static$ True
 SVar:ExileSelf:DB$ ChangeZone | Origin$ Command | Destination$ Exile | Defined$ Self

--- a/forge-gui/res/cardsfolder/t/timeless_lotus.txt
+++ b/forge-gui/res/cardsfolder/t/timeless_lotus.txt
@@ -3,5 +3,5 @@ ManaCost:5
 Types:Legendary Artifact
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
-A:AB$ Mana | Cost$ T | Produced$ W U B R G | SpellDescription$ Add {W}{U}{B}{R}{G}
+A:AB$ Mana | Cost$ T | Produced$ W U B R G | SpellDescription$ Add {W}{U}{B}{R}{G}.
 Oracle:Timeless Lotus enters tapped.\n{T}: Add {W}{U}{B}{R}{G}.


### PR DESCRIPTION
Mostly dealing with missing punctuation and notably:
- Removed the `SpellDescription$` on the `$ Mana` line for Black Market as during testing it patently wasn't displayed.
- Reorganized `StackDescription$` of Mogg Assassin so it reads better on Stack. Tested to satisfaction.