### PR TITLE
Fix for refundPayment when multiple costs

### DIFF
--- a/forge-game/src/main/java/forge/game/cost/CostPayment.java
+++ b/forge-game/src/main/java/forge/game/cost/CostPayment.java
@@ -123,8 +123,10 @@ public class CostPayment extends ManaConversionMatrix {
     public final void refundPayment() {
         Card sourceCard = this.ability.getHostCard();
         for (final CostPart part : this.paidCostParts) {
-            if (part.isUndoable()) {
-                part.refund(sourceCard);
+            part.refund(sourceCard);
+            // Clear lists to prevent accumulation across multiple cancelled activations
+            if (part instanceof CostPartWithList) {
+                ((CostPartWithList) part).resetLists();
             }
         }
 


### PR DESCRIPTION
In cards like [Champion of the Weird](http://scryfall.com/card/ecl/95/champion-of-the-weird) with multiple costs, the player might start paying some costs but then it might cancel others (e.g., Bligh 2, cancel Pay 1 life). In this scenario, Blight 2 is not refunded because Blight 2 is not an undoable cost.

I don't think rolling back an ability should care about undoable costs, since we are just trying to reset the game to a state previous to ability being used.
