### PR TITLE
Fix AI proliferate to consider mana cost vs value

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/CountersProliferateAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CountersProliferateAi.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import forge.ai.*;
 import forge.game.GameEntity;
 import forge.game.card.*;
+import forge.game.player.GameLossReason;
 import forge.game.player.Player;
 import forge.game.spellability.SpellAbility;
 import forge.game.zone.ZoneType;
@@ -58,6 +59,11 @@ public class CountersProliferateAi extends SpellAbilityAi {
         boolean opponentPoison = false;
 
         for (final Player o : ai.getOpponents()) {
+            // Lethal poison - proliferating would win the game
+            if (o.getPoisonCounters() >= 9 && o.canReceiveCounters(CounterEnumType.POISON)
+                    && !o.cantLoseCheck(GameLossReason.Poisoned)) {
+                return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+            }
             opponentPoison |= o.getPoisonCounters() > 0 && o.canReceiveCounters(CounterEnumType.POISON);
             hperms.addAll(CardLists.filter(o.getCardsIn(ZoneType.Battlefield), crd -> {
                 if (!crd.hasCounters()) {

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/CountersProliferateAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/CountersProliferateAiTest.java
@@ -97,4 +97,32 @@ public class CountersProliferateAiTest extends AITest {
         assertEquals("AI should not activate proliferate when value below cost",
                 AiPlayDecision.CantPlayAi, decision);
     }
+
+    @Test
+    public void testProliferate_lethalPoison_aiActivates() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+        ai.setTeam(0);
+        opponent.setTeam(1);
+
+        // Add Karn's Bastion and enough lands
+        Card karnsBastion = addCard("Karn's Bastion", ai);
+        addCards("Wastes", 4, ai);
+
+        // Opponent has 9 poison counters - proliferating would win the game
+        opponent.setPoisonCounters(9, null);
+
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN2, ai);
+        game.getAction().checkStateEffects(true);
+
+        SpellAbility proliferateSA = findSAWithPrefix(karnsBastion, "{4}, {T}: Proliferate");
+        assertNotNull(proliferateSA);
+
+        // AI should always activate when it can win by poison
+        SpellAbilityAi aiLogic = SpellApiToAi.Converter.get(ApiType.Proliferate);
+        AiPlayDecision decision = aiLogic.canPlayWithSubs(ai, proliferateSA).decision();
+        assertEquals("AI should activate proliferate for lethal poison",
+                AiPlayDecision.WillPlay, decision);
+    }
 }


### PR DESCRIPTION
AI now calculates the total value of proliferating based on what's on the battlefield (planeswalkers worth 3, creatures with positive counters worth 1, opponent poison worth 2, etc.) and only activates proliferate if the value meets or exceeds the mana cost. This prevents the AI from wasting mana on low-value proliferates like spending 4 mana on Karn's Bastion just to add one +1/+1 counter.

Closes https://github.com/Card-Forge/forge/issues/9479