### PR TITLE
Add ECL to Lorwyn quest world

### DIFF
--- a/forge-gui/res/quest/world/worlds.txt
+++ b/forge-gui/res/quest/world/worlds.txt
@@ -7,7 +7,7 @@ Name:Evolving Wilds
 Name:Amonkhet|Dir:Amonkhet|Sets:AKH, HOU, AKR
 Name:Jamuraa|Dir:jamuraa|Sets:5ED, ARN, MIR, VIS, WTH
 Name:Kamigawa|Dir:2004 Kamigawa|Sets:CHK, BOK, SOK
-Name:Lorwyn|Dir:lorwyn|Sets:SHM, EVE, LRW, MOR, 10E
+Name:Lorwyn|Dir:lorwyn|Sets:SHM, EVE, LRW, MOR, 10E, ECL
 Name:Mirrodin|Dir:mirrodin|Sets:MRD, DST, 5DN, SOM, MBS, NPH
 Name:Ravnica|Dir:ravnica|Sets:RAV, GPT, DIS, RTR, GTC, DGM
 Name:Shandalar|Dir:shandalar|Sets:2ED, ARN, ATQ, 3ED, LEG, DRK, 4ED|Banned:Chaos Orb; Falling Star


### PR DESCRIPTION
Someone tried to start Lorwyn in Quest Commander subformat and couldn't get a commander. This would expand the reward pool for regular Lorwyn players, allow for more Lorwyn commanders, and if I understand the files correctly leave the original classic fights and challenges intact (just expand their reward possibilities, maybe).

Side note: I only intended to change line 10, and I'm not familiar with how to do public PRs. 70% of the reason I opened this was to try to do a tiny PR and get a feel for it. I have more substantial ones in mind for the future, potentially. And this one was done in the GH GUI, and I wonder if that's what changed line 40 (EOF difference?).
