### PR TITLE
LandTraitChanges: add extra for SpellAbility by Type Change (Layer 4)

### DIFF
--- a/forge-core/src/main/java/forge/card/MagicColor.java
+++ b/forge-core/src/main/java/forge/card/MagicColor.java
@@ -195,7 +195,6 @@ public final class MagicColor {
         public String getShortName() {
             return shortName;
         }
-
         public String getBasicLandType() {
             return basicLandType;
         }

--- a/forge-game/src/main/java/forge/game/StaticEffect.java
+++ b/forge-game/src/main/java/forge/game/StaticEffect.java
@@ -265,8 +265,8 @@ public class StaticEffect {
             if (layers.contains(StaticAbilityLayer.ABILITIES)) {
                 // remove keywords
                 boolean abilitiesChanged = false;
-                if (hasParam("AddKeyword") || hasParam("RemoveKeyword") || hasParam("RemoveLandTypes")
-                        || hasParam("ShareRememberedKeywords") || hasParam("RemoveAllAbilities")) {
+                if (hasParam("AddKeyword") || hasParam("RemoveKeyword")
+                        || hasParam("ShareRememberedKeywords") || hasParam("RemoveAllAbilities") || hasParam("RemoveNonManaAbilities")) {
                     abilitiesChanged |= affectedCard.removeChangedCardKeywords(getTimestamp(), ability.getId(), false);
                 }
 
@@ -274,8 +274,8 @@ public class StaticEffect {
                 if (hasParam("AddAbility") || hasParam("GainsAbilitiesOf")
                         || hasParam("GainsAbilitiesOfDefined") || hasParam("GainsTriggerAbsOf")
                         || hasParam("AddTrigger") || hasParam("AddStaticAbility")
-                        || hasParam("AddReplacementEffect") || hasParam("RemoveAllAbilities")
-                        || hasParam("RemoveLandTypes")) {
+                        || hasParam("AddReplacementEffect") || hasParam("RemoveAllAbilities") || hasParam("RemoveNonManaAbilities")
+                        ) {
                     abilitiesChanged |= affectedCard.removeChangedCardTraits(getTimestamp(), ability.getId());
                 }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/AnimateEffectBase.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/AnimateEffectBase.java
@@ -20,6 +20,7 @@ package forge.game.ability.effects;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import com.google.common.collect.Lists;
 
@@ -29,6 +30,7 @@ import forge.card.ColorSet;
 import forge.card.RemoveType;
 import forge.card.mana.ManaCost;
 import forge.card.mana.ManaCostParser;
+import forge.game.CardTraitBase;
 import forge.game.Game;
 import forge.game.ability.AbilityFactory;
 import forge.game.ability.AbilityUtils;
@@ -74,8 +76,12 @@ public abstract class AnimateEffectBase extends SpellAbilityEffect {
         if (sa.hasParam("RemoveEnchantmentTypes"))
             remove.add(RemoveType.EnchantmentTypes);
 
-        boolean removeNonManaAbilities = sa.hasParam("RemoveNonManaAbilities");
-        boolean removeAll = sa.hasParam("RemoveAllAbilities");
+        Predicate<CardTraitBase> removeAbilities = null;
+        if (sa.hasParam("RemoveAllAbilities")) {
+            removeAbilities = e -> true;
+        } else if (sa.hasParam("RemoveNonManaAbilities")) {
+            removeAbilities = Predicate.not(CardTraitBase::isManaAbility);
+        }
 
         if (sa.hasParam("RememberAnimated")) {
             source.addRemembered(c);
@@ -106,11 +112,11 @@ public abstract class AnimateEffectBase extends SpellAbilityEffect {
             c.addChangedCardTypes(addType, removeType, addAllCreatureTypes, remove, timestamp, 0, true, false);
         }
 
-        if (!keywords.isEmpty() || !removeKeywords.isEmpty() || removeAll) {
+        if (!keywords.isEmpty() || !removeKeywords.isEmpty() || removeAbilities != null) {
             if (perpetual) {
-                c.addPerpetual(new PerpetualKeywords(timestamp, keywords, removeKeywords, removeAll));
+                c.addPerpetual(new PerpetualKeywords(timestamp, keywords, removeKeywords, removeAbilities != null));
             }
-            c.addChangedCardKeywords(keywords, removeKeywords, removeAll, timestamp, null);
+            c.addChangedCardKeywords(keywords, removeKeywords, removeAbilities != null, timestamp, null);
         }
 
         // do this after changing types in case it wasn't a creature before
@@ -213,11 +219,11 @@ public abstract class AnimateEffectBase extends SpellAbilityEffect {
         }
 
         // after unanimate to add RevertCost
-        if (removeAll || removeNonManaAbilities
+        if (removeAbilities != null
                 || !addedAbilities.isEmpty() || !removedAbilities.isEmpty() || !addedTriggers.isEmpty()
                 || !addedReplacements.isEmpty() || !addedStaticAbilities.isEmpty()) {
             CardTraitChanges changes = c.addChangedCardTraits(addedAbilities, removedAbilities, addedTriggers, addedReplacements,
-                addedStaticAbilities, removeAll, removeNonManaAbilities, timestamp, 0);
+                addedStaticAbilities, removeAbilities, timestamp, 0);
             if (perpetual) {
                 c.addPerpetual(new PerpetualAbilities(timestamp, changes));
             }

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -350,8 +350,6 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
 
     private String overlayText = null;
 
-    private SpellAbility[] basicLandAbilities = new SpellAbility[MagicColor.WUBRG.length];
-
     private int planeswalkerAbilityActivated;
     private boolean planeswalkerActivationLimitUsed;
 
@@ -3451,7 +3449,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
                 continue;
             }
             // while Adventure and Omen are part of Secondary
-            if ((sa.isAdventure() || sa.isOmen()) && !getCurrentStateName().equals(sa.getCardState())) {
+            if ((sa.isAdventure() || sa.isOmen()) && !getCurrentStateName().equals(sa.getCardStateName())) {
                 continue;
             }
             if (!(sa instanceof SpellPermanent && sa.isBasicSpell())) {
@@ -3461,30 +3459,15 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
         return true;
     }
 
-    public void updateSpellAbilities(List<SpellAbility> list, CardState state, Boolean mana) {
-        for (final CardTraitChanges ck : getChangedCardTraitsList(state)) {
-            if (ck.isRemoveNonMana()) {
-                // List only has nonMana
-                if (null == mana) {
-                    list.removeIf(Predicate.not(SpellAbility::isManaAbility));
-                } else if (false == mana) {
-                    list.clear();
-                }
-            } else if (ck.isRemoveAll()) {
-                list.clear();
-            }
-            list.removeAll(ck.getRemovedAbilities());
-            for (SpellAbility sa : ck.getAbilities()) {
-                if (mana == null || mana == sa.isManaAbility()) {
-                    list.add(sa);
-                }
-            }
+    public void updateSpellAbilities(List<SpellAbility> list, CardState state) {
+        for (final ICardTraitChanges ck : getChangedCardTraitsList(state)) {
+            ck.applySpellAbility(list);
         }
 
         // add Facedown abilities from Original state but only if this state is face down
         // need CardStateView#getState or might crash in StackOverflow
         if (isInPlay()) {
-            if ((null == mana || false == mana) && isFaceDown() && state.getStateName() == CardStateName.FaceDown) {
+            if (isFaceDown() && state.getStateName() == CardStateName.FaceDown) {
                 for (SpellAbility sa : getState(CardStateName.Original).getNonManaAbilities()) {
                     if (sa.isTurnFaceUp()) {
                         list.add(sa);
@@ -3493,44 +3476,12 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
             }
         } else if (hasState(CardStateName.Secondary) && state.getStateName() == CardStateName.Original) {
             // Adventure and Omen may only be cast not from Battlefield
-            for (SpellAbility sa : getState(CardStateName.Secondary).getSpellAbilities()) {
-                if (mana == null || mana == sa.isManaAbility()) {
-                    list.add(sa);
-                }
-            }
+            list.addAll(getState(CardStateName.Secondary).getSpellAbilities());
         }
 
         // keywords should already been cleanup by layers
         for (KeywordInterface kw : getUnhiddenKeywords(state)) {
-            for (SpellAbility sa : kw.getAbilities()) {
-                if (mana == null || mana == sa.isManaAbility()) {
-                    list.add(sa);
-                }
-            }
-        }
-    }
-
-    private void updateBasicLandAbilities(List<SpellAbility> list, CardState state) {
-        final CardTypeView type = state.getTypeWithChanges();
-
-        if (!type.isLand()) {
-            // no land, do nothing there
-            return;
-        }
-
-        for (int i = 0; i < MagicColor.WUBRG.length; i++ ) {
-            byte c = MagicColor.WUBRG[i];
-            if (type.hasSubtype(MagicColor.Constant.BASIC_LANDS.get(i))) {
-                SpellAbility sa = basicLandAbilities[i];
-
-                // no Ability for this type yet, make a new one
-                if (sa == null) {
-                    sa = CardFactory.buildBasicLandAbility(state, c);
-                    basicLandAbilities[i] = sa;
-                }
-
-                list.add(sa);
-            }
+            list.addAll(kw.getAbilities());
         }
     }
 
@@ -4981,7 +4932,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     public final void addChangedCardTraitsByText(Collection<SpellAbility> spells,
             Collection<Trigger> trigger, Collection<ReplacementEffect> replacements, Collection<StaticAbility> statics, long timestamp, long staticId) {
         changedCardTraitsByText.put(timestamp, staticId, new CardTraitChanges(
-            spells, null, trigger, replacements, statics, true, false
+            spells, null, trigger, replacements, statics, e -> true
         ));
 
         // setting card traits via text, does overwrite any other word change effects?
@@ -4992,14 +4943,14 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
 
     public final CardTraitChanges addChangedCardTraits(Collection<SpellAbility> spells, Collection<SpellAbility> removedAbilities,
             Collection<Trigger> trigger, Collection<ReplacementEffect> replacements, Collection<StaticAbility> statics,
-            boolean removeAll, boolean removeNonMana, long timestamp, long staticId) {
-        return addChangedCardTraits(spells, removedAbilities, trigger, replacements, statics, removeAll, removeNonMana, timestamp, staticId, true);
+            Predicate<CardTraitBase> remove, long timestamp, long staticId) {
+        return addChangedCardTraits(spells, removedAbilities, trigger, replacements, statics, remove, timestamp, staticId, true);
     }
     public final CardTraitChanges addChangedCardTraits(Collection<SpellAbility> spells, Collection<SpellAbility> removedAbilities,
             Collection<Trigger> trigger, Collection<ReplacementEffect> replacements, Collection<StaticAbility> statics,
-            boolean removeAll, boolean removeNonMana, long timestamp, long staticId, boolean updateView) {
+            Predicate<CardTraitBase> remove, long timestamp, long staticId, boolean updateView) {
         CardTraitChanges result = new CardTraitChanges(
-            spells, removedAbilities, trigger, replacements, statics, removeAll, removeNonMana
+            spells, removedAbilities, trigger, replacements, statics, remove
         );
         changedCardTraits.put(timestamp, staticId, result);
         if (updateView) {
@@ -5020,13 +4971,10 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
         return changedCardTraitsByText.remove(timestamp, staticId) != null;
     }
 
-    public Iterable<CardTraitChanges> getChangedCardTraitsList(CardState state) {
-        List<SpellAbility> landManaAbilities = Lists.newArrayList();
-        this.updateBasicLandAbilities(landManaAbilities, state);
-
-        return Iterables.concat(
+    public Iterable<ICardTraitChanges> getChangedCardTraitsList(CardState state) {
+        return Iterables.<ICardTraitChanges>concat(
             changedCardTraitsByText.values(), // Layer 3
-            ImmutableList.of(new CardTraitChanges(landManaAbilities, null, null, null, null, hasRemoveIntrinsic(), false)), // Layer 4
+            ImmutableList.of(state.getLandTraitChanges()), // Layer 4
             changedCardTraits.values() // Layer 6
         );
     }
@@ -7149,11 +7097,8 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     }
 
     public void updateStaticAbilities(List<StaticAbility> list, CardState state) {
-        for (final CardTraitChanges ck : getChangedCardTraitsList(state)) {
-            if (ck.isRemoveAll()) {
-                list.clear();
-            }
-            list.addAll(ck.getStaticAbilities());
+        for (final ICardTraitChanges ck : getChangedCardTraitsList(state)) {
+            ck.applyStaticAbility(list);
         }
 
         // keywords are already sorted by Layer
@@ -7191,11 +7136,8 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     }
 
     public void updateTriggers(List<Trigger> list, CardState state) {
-        for (final CardTraitChanges ck : getChangedCardTraitsList(state)) {
-            if (ck.isRemoveAll()) {
-                list.clear();
-            }
-            list.addAll(ck.getTriggers());
+        for (final ICardTraitChanges ck : getChangedCardTraitsList(state)) {
+            ck.applyTrigger(list);
         }
 
         // Keywords are already sorted by Layer
@@ -7214,11 +7156,8 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     }
 
     public void updateReplacementEffects(List<ReplacementEffect> list, CardState state) {
-        for (final CardTraitChanges ck : getChangedCardTraitsList(state)) {
-            if (ck.isRemoveAll()) {
-                list.clear();
-            }
-            list.addAll(ck.getReplacements());
+        for (final ICardTraitChanges ck : getChangedCardTraitsList(state)) {
+            ck.applyReplacementEffect(list);
         }
 
         // Keywords are already sorted by Layer

--- a/forge-game/src/main/java/forge/game/card/CardFactory.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactory.java
@@ -290,15 +290,6 @@ public class CardFactory {
         }
     }
 
-    public static SpellAbility buildBasicLandAbility(final CardState state, byte color) {
-        String strcolor = MagicColor.toShortString(color);
-        String abString  = "AB$ Mana | Cost$ T | Produced$ " + strcolor +
-                " | Secondary$ True | SpellDescription$ Add {" + strcolor + "}.";
-        SpellAbility sa = AbilityFactory.getAbility(abString, state);
-        sa.setIntrinsic(true); // always intrinsic
-        return sa;
-    }
-
     private static Card readCard(final IPaperCard paperCard, int cardId, Game game) {
         final Card card = new Card(cardId, paperCard, game);
         CardRules rules = paperCard.getRules();

--- a/forge-game/src/main/java/forge/game/card/CardState.java
+++ b/forge-game/src/main/java/forge/game/card/CardState.java
@@ -51,11 +51,11 @@ import io.sentry.Sentry;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 public class CardState implements GameObject, IHasSVars, ITranslatable {
     private String name = "";
@@ -103,6 +103,8 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
 
     private SpellAbility manifestUp;
     private SpellAbility cloakUp;
+
+    private LandTraitChanges landTraitChanges = new LandTraitChanges(this);
 
     public CardState(Card card, CardStateName name) {
         this(card.getView().createAlternateState(name), card);
@@ -396,59 +398,41 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
 
     public final FCollectionView<SpellAbility> getSpellAbilities() {
         FCollection<SpellAbility> newCol = new FCollection<>();
-        updateSpellAbilities(newCol, null);
+        updateSpellAbilities(newCol);
         newCol.addAll(abilities);
-        card.updateSpellAbilities(newCol, this, null);
+        card.updateSpellAbilities(newCol, this);
         return newCol;
     }
     public final FCollectionView<SpellAbility> getManaAbilities() {
         FCollection<SpellAbility> newCol = new FCollection<>();
-        updateSpellAbilities(newCol, true);
-        // stream().toList() causes crash on Android 8-13, use Collectors.toList()
-        newCol.addAll(abilities.stream().filter(SpellAbility::isManaAbility).collect(Collectors.toList()));
-        card.updateSpellAbilities(newCol, this, true);
+        updateSpellAbilities(newCol);
+        newCol.addAll(abilities);
+        card.updateSpellAbilities(newCol, this);
+        newCol.removeIf(Predicate.not(SpellAbility::isManaAbility));
         return newCol;
     }
     public final FCollectionView<SpellAbility> getNonManaAbilities() {
         FCollection<SpellAbility> newCol = new FCollection<>();
-        updateSpellAbilities(newCol, false);
-        // stream().toList() causes crash on Android 8-13, use Collectors.toList()
-        newCol.addAll(abilities.stream().filter(Predicate.not(SpellAbility::isManaAbility)).collect(Collectors.toList()));
-        card.updateSpellAbilities(newCol, this, false);
+        updateSpellAbilities(newCol);
+        newCol.addAll(abilities);
+        card.updateSpellAbilities(newCol, this);
+        newCol.removeIf(SpellAbility::isManaAbility);
         return newCol;
     }
 
-    protected final void updateSpellAbilities(FCollection<SpellAbility> newCol, Boolean mana) {
+    protected final void updateSpellAbilities(FCollection<SpellAbility> newCol) {
         // add Split to Original
         if (getStateName().equals(CardStateName.Original)) {
             if (getCard().hasState(CardStateName.LeftSplit)) {
                 CardState leftState = getCard().getState(CardStateName.LeftSplit);
-                Collection<SpellAbility> leftAbilities = leftState.abilities;
-                if (null != mana) {
-                    leftAbilities = leftAbilities.stream()
-                            .filter(mana ? SpellAbility::isManaAbility : Predicate.not(SpellAbility::isManaAbility))
-                            // stream().toList() causes crash on Android 8-13, use Collectors.toList()
-                            .collect(Collectors.toList());
-                }
-                newCol.addAll(leftAbilities);
-                leftState.updateSpellAbilities(newCol, mana);
+                newCol.addAll(leftState.abilities);
+                leftState.updateSpellAbilities(newCol);
             }
             if (getCard().hasState(CardStateName.RightSplit)) {
                 CardState rightState = getCard().getState(CardStateName.RightSplit);
-                Collection<SpellAbility> rightAbilities = rightState.abilities;
-                if (null != mana) {
-                    rightAbilities = rightAbilities.stream()
-                            .filter(mana ? SpellAbility::isManaAbility : Predicate.not(SpellAbility::isManaAbility))
-                            // stream().toList() causes crash on Android 8-13, use Collectors.toList()
-                            .collect(Collectors.toList());
-                }
-                newCol.addAll(rightAbilities);
-                rightState.updateSpellAbilities(newCol, mana);
+                newCol.addAll(rightState.abilities);
+                rightState.updateSpellAbilities(newCol);
             }
-        }
-
-        if (null != mana && true == mana) {
-            return;
         }
 
         // SpellPermanent only for Original State
@@ -494,6 +478,58 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
                 permanentAbility = new SpellPermanent(card, this);
             }
             newCol.add(permanentAbility);
+        }
+    }
+
+    public LandTraitChanges getLandTraitChanges() { return this.landTraitChanges; }
+
+    record LandTraitChanges(CardState state, Map<MagicColor.Color, SpellAbility> map) implements ICardTraitChanges
+    {
+        LandTraitChanges(CardState state) {
+            this(state, Maps.newEnumMap(MagicColor.Color.class));
+        }
+
+        public List<SpellAbility> applySpellAbility(List<SpellAbility> list) {
+            if (state.getCard().hasRemoveIntrinsic()) {
+                list.clear();
+            }
+            CardTypeView type = state.getTypeWithChanges();
+            if (!type.isLand()) {
+                return list;
+            }
+            for (MagicColor.Color c : MagicColor.Color.values()) {
+               if (c.getBasicLandType() == null) {
+                   continue;
+               }
+               if (type.hasSubtype(c.getBasicLandType())) {
+                   list.add(map.computeIfAbsent(c, a -> {
+                       String abString  = "AB$ Mana | Cost$ T | Produced$ " + a.getShortName() +
+                               " | Secondary$ True | SpellDescription$ Add " + a.getSymbol() + ".";
+                       SpellAbility sa = AbilityFactory.getAbility(abString, state);
+                       sa.setIntrinsic(true); // always intrinsic
+                       return sa;
+                   }));
+               }
+            }
+            return list;
+        }
+        public List<Trigger> applyTrigger(List<Trigger> list) {
+            if (state.getCard().hasRemoveIntrinsic()) {
+                list.clear();
+            }
+            return list;
+        }
+        public List<ReplacementEffect> applyReplacementEffect(List<ReplacementEffect> list) {
+            if (state.getCard().hasRemoveIntrinsic()) {
+                list.clear();
+            }
+            return list;
+        }
+        public List<StaticAbility> applyStaticAbility(List<StaticAbility> list) {
+            if (state.getCard().hasRemoveIntrinsic()) {
+                list.clear();
+            }
+            return list;
         }
     }
 

--- a/forge-game/src/main/java/forge/game/card/CardTraitChanges.java
+++ b/forge-game/src/main/java/forge/game/card/CardTraitChanges.java
@@ -1,6 +1,6 @@
 package forge.game.card;
 
-import com.google.common.collect.Lists;
+import forge.game.CardTraitBase;
 import forge.game.replacement.ReplacementEffect;
 import forge.game.spellability.SpellAbility;
 import forge.game.staticability.StaticAbility;
@@ -8,133 +8,109 @@ import forge.game.trigger.Trigger;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
-public class CardTraitChanges implements Cloneable {
-
-    private List<Trigger> triggers = Lists.newArrayList();
-    private List<ReplacementEffect> replacements = Lists.newArrayList();
-    private List<SpellAbility> abilities = Lists.newArrayList();
-    private List<StaticAbility> staticAbilities = Lists.newArrayList();
-
-    private List<SpellAbility> removedAbilities = Lists.newArrayList();
-
-    private boolean removeAll = false;
-    private boolean removeNonMana = false;
-
-    public CardTraitChanges(Collection<SpellAbility> spells, Collection<SpellAbility> removedAbilities,
-            Collection<Trigger> trigger, Collection<ReplacementEffect> res, Collection<StaticAbility> st,
-            boolean removeAll, boolean removeNonMana) {
-        if (spells != null) {
-            this.abilities.addAll(spells);
-        }
-        if (removedAbilities != null) {
-            this.removedAbilities.addAll(removedAbilities);
-        }
-        if (trigger != null) {
-            this.triggers.addAll(trigger);
-        }
-        if (res != null) {
-            this.replacements.addAll(res);
-        }
-        if (st != null) {
-            this.staticAbilities.addAll(st);
-        }
-
-        this.removeAll |= removeAll;
-        this.removeNonMana |= removeNonMana;
-    }
-
-    /**
-     * @return the triggers
-     */
-    public Collection<Trigger> getTriggers() {
-        return triggers;
-    }
-    /**
-     * @return the replacements
-     */
-    public Collection<ReplacementEffect> getReplacements() {
-        return replacements;
-    }
+public record CardTraitChanges(
+        Collection<SpellAbility> abilities,
+        Collection<SpellAbility> removedAbilities,
+        Collection<Trigger> triggers,
+        Collection<ReplacementEffect> replacements,
+        Collection<StaticAbility> staticAbilities,
+        Predicate<CardTraitBase> remove
+        ) implements ICardTraitChanges {
 
     /**
      * @return the abilities
      */
     public Collection<SpellAbility> getAbilities() {
-        return abilities;
+        return Objects.requireNonNullElse(abilities, List.of());
     }
 
     /**
      * @return the abilities
      */
     public Collection<SpellAbility> getRemovedAbilities() {
-        return removedAbilities;
+        return Objects.requireNonNullElse(removedAbilities, List.of());
+    }
+
+    /**
+     * @return the triggers
+     */
+    public Collection<Trigger> getTriggers() {
+        return Objects.requireNonNullElse(triggers, List.of());
+    }
+    /**
+     * @return the replacements
+     */
+    public Collection<ReplacementEffect> getReplacements() {
+        return Objects.requireNonNullElse(replacements, List.of());
     }
 
     /**
      * @return the staticAbilities
      */
     public Collection<StaticAbility> getStaticAbilities() {
-        return staticAbilities;
-    }
-
-    public boolean isRemoveAll() {
-        return removeAll;
-    }
-
-    public boolean isRemoveNonMana() {
-        return removeNonMana;
+        return Objects.requireNonNullElse(staticAbilities, List.of());
     }
 
     public CardTraitChanges copy(Card host, boolean lki) {
-        try {
-            CardTraitChanges result = (CardTraitChanges) super.clone();
-
-            result.abilities = Lists.newArrayList();
-            for (SpellAbility sa : this.abilities) {
-                result.abilities.add(sa.copy(host, lki));
-            }
-            result.removedAbilities = Lists.newArrayList();
-            for (SpellAbility sa : this.removedAbilities) {
-                result.removedAbilities.add(sa.copy(host, lki));
-            }
-
-            result.triggers = Lists.newArrayList();
-            for (Trigger tr : this.triggers) {
-                result.triggers.add(tr.copy(host, lki));
-            }
-
-            result.replacements = Lists.newArrayList();
-            for (ReplacementEffect re : this.replacements) {
-                result.replacements.add(re.copy(host, lki));
-            }
-
-            result.staticAbilities = Lists.newArrayList();
-            for (StaticAbility sa : this.staticAbilities) {
-                result.staticAbilities.add(sa.copy(host, lki));
-            }
-
-            return result;
-        } catch (final Exception ex) {
-            throw new RuntimeException("CardTraitChanges : clone() error", ex);
-        }
+        return new CardTraitChanges(
+                this.getAbilities().stream().map(sa -> sa.copy(host, lki)).collect(Collectors.toList()),
+                this.getRemovedAbilities().stream().map(sa -> sa.copy(host, lki)).collect(Collectors.toList()),
+                this.getTriggers().stream().map(tr -> tr.copy(host, lki)).collect(Collectors.toList()),
+                this.getReplacements().stream().map(re -> re.copy(host, lki)).collect(Collectors.toList()),
+                this.getStaticAbilities().stream().map(st -> st.copy(host, lki)).collect(Collectors.toList()),
+                remove
+            );
     }
 
     public void changeText() {
-        for (SpellAbility sa : this.abilities) {
+        for (SpellAbility sa : this.getAbilities()) {
             sa.changeText();
         }
 
-        for (Trigger tr : this.triggers) {
+        for (Trigger tr : this.getTriggers()) {
             tr.changeText();
         }
 
-        for (ReplacementEffect re : this.replacements) {
+        for (ReplacementEffect re : this.getReplacements()) {
             re.changeText();
         }
 
-        for (StaticAbility sa : this.staticAbilities) {
+        for (StaticAbility sa : this.getStaticAbilities()) {
             sa.changeText();
         }
+    }
+
+    public List<SpellAbility> applySpellAbility(List<SpellAbility> list) {
+        if (remove != null) {
+            list.removeIf(remove);
+        }
+        list.removeAll(getRemovedAbilities());
+        list.addAll(getAbilities());
+        return list;
+    }
+    public List<Trigger> applyTrigger(List<Trigger> list) {
+        if (remove != null) {
+            list.removeIf(remove);
+        }
+        list.addAll(getTriggers());
+        return list;
+    }
+    public List<ReplacementEffect> applyReplacementEffect(List<ReplacementEffect> list) {
+        if (remove != null) {
+            list.removeIf(remove);
+        }
+        list.addAll(getReplacements());
+        return list;
+    }
+    public List<StaticAbility> applyStaticAbility(List<StaticAbility> list) {
+        if (remove != null) {
+            list.removeIf(remove);
+        }
+        list.addAll(getStaticAbilities());
+        return list;
     }
 }

--- a/forge-game/src/main/java/forge/game/card/ICardTraitChanges.java
+++ b/forge-game/src/main/java/forge/game/card/ICardTraitChanges.java
@@ -1,0 +1,17 @@
+package forge.game.card;
+
+import java.util.List;
+
+import forge.game.replacement.ReplacementEffect;
+import forge.game.spellability.SpellAbility;
+import forge.game.staticability.StaticAbility;
+import forge.game.trigger.Trigger;
+
+public interface ICardTraitChanges {
+    default List<SpellAbility> applySpellAbility(List<SpellAbility> list) { return list;}
+    default List<Trigger> applyTrigger(List<Trigger> list) { return list;}
+    default List<ReplacementEffect> applyReplacementEffect(List<ReplacementEffect> list) { return list;}
+    default List<StaticAbility> applyStaticAbility(List<StaticAbility> list) { return list;}
+    
+    default void changeText() {}
+}

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -996,7 +996,7 @@ public class Player extends GameEntity implements Comparable<Player> {
         KeywordsChange cks = new KeywordsChange(kws, removeKeywords, false);
         if (!cks.getAbilities().isEmpty() || !cks.getTriggers().isEmpty() || !cks.getReplacements().isEmpty() || !cks.getStaticAbilities().isEmpty()) {
             getKeywordCard().addChangedCardTraits(
-                cks.getAbilities(), null, cks.getTriggers(), cks.getReplacements(), cks.getStaticAbilities(), false, false, timestamp, staticId);
+                cks.getAbilities(), null, cks.getTriggers(), cks.getReplacements(), cks.getStaticAbilities(), null, timestamp, staticId);
         }
         changedKeywords.put(timestamp, staticId, cks);
         updateKeywords();

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbility.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbility.java
@@ -158,7 +158,7 @@ public class StaticAbility extends CardTraitBase implements IIdentifiable, Clone
             layers.add(StaticAbilityLayer.COLOR);
         }
 
-        if (hasParam("RemoveAllAbilities") || hasParam("GainsAbilitiesOf")
+        if (hasParam("RemoveAllAbilities") || hasParam("RemoveNonManaAbilities") || hasParam("GainsAbilitiesOf")
                 || hasParam("GainsAbilitiesOfDefined") || hasParam("GainsTriggerAbsOf")
                 || hasParam("AddKeyword") || hasParam("AddAbility")
                 || hasParam("AddTrigger") || hasParam("AddReplacementEffect")

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import forge.GameCommand;
 import forge.card.*;
+import forge.game.CardTraitBase;
 import forge.game.Game;
 import forge.game.StaticEffect;
 import forge.game.ability.AbilityUtils;
@@ -44,6 +45,7 @@ import forge.util.TextUtil;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 
@@ -124,8 +126,7 @@ public final class StaticAbilityContinuous {
         ColorSet addColors = null;
         String[] addTriggers = null;
         String[] addStatics = null;
-        boolean removeAllAbilities = false;
-        boolean removeNonMana = false;
+        Predicate<CardTraitBase> removeAbilities = null;
         boolean addAllCreatureTypes = false;
         Set<RemoveType> remove = EnumSet.noneOf(RemoveType.class);
 
@@ -325,10 +326,9 @@ public final class StaticAbilityContinuous {
 
         if (layer == StaticAbilityLayer.ABILITIES) {
             if (params.containsKey("RemoveAllAbilities")) {
-                removeAllAbilities = true;
-                if (params.containsKey("ExceptManaAbilities")) {
-                    removeNonMana = true;
-                }
+                removeAbilities = e -> true;
+            } else if (params.containsKey("RemoveNonManaAbilities")) {
+                removeAbilities = Predicate.not(CardTraitBase::isManaAbility);
             }
 
             if (params.containsKey("AddAbility")) {
@@ -704,7 +704,7 @@ public final class StaticAbilityContinuous {
             }
 
             // add keywords
-            if ((addKeywords != null && !addKeywords.isEmpty()) || removeKeywords != null || removeAllAbilities) {
+            if ((addKeywords != null && !addKeywords.isEmpty()) || removeKeywords != null || removeAbilities != null) {
                 List<String> newKeywords = null;
                 if (addKeywords != null) {
                     newKeywords = Lists.newArrayList(addKeywords);
@@ -742,7 +742,7 @@ public final class StaticAbilityContinuous {
                 }
 
                 affectedCard.addChangedCardKeywords(newKeywords, removeKeywords,
-                        removeAllAbilities, se.getTimestamp(), stAb, false);
+                        removeAbilities != null, se.getTimestamp(), stAb, false);
                 affectedCard.updateKeywordsCache();
             }
 
@@ -850,10 +850,9 @@ public final class StaticAbilityContinuous {
                 }
 
                 if (!addedAbilities.isEmpty() || !addedTrigger.isEmpty() || addReplacements != null || addStatics != null
-                    || removeAllAbilities) {
+                    || removeAbilities != null) {
                     affectedCard.addChangedCardTraits(
-                        addedAbilities, null, addedTrigger, addedReplacementEffects, addedStaticAbility, removeAllAbilities, removeNonMana,
-                        se.getTimestamp(), stAb.getId(), false
+                        addedAbilities, null, addedTrigger, addedReplacementEffects, addedStaticAbility, removeAbilities, se.getTimestamp(), stAb.getId(), false
                     );
                 }
 
@@ -968,7 +967,7 @@ public final class StaticAbilityContinuous {
         addIgnore.setIntrinsic(false);
         addIgnore.setApi(ApiType.InternalIgnoreEffect);
         addIgnore.setDescription(cost + " Ignore the effect until end of turn.");
-        sourceCard.addChangedCardTraits(ImmutableList.of(addIgnore), null, null, null, null, false, false, sourceCard.getLayerTimestamp(), stAb.getId());
+        sourceCard.addChangedCardTraits(ImmutableList.of(addIgnore), null, null, null, null, null, sourceCard.getLayerTimestamp(), stAb.getId());
 
         final GameCommand removeIgnore = new GameCommand() {
             private static final long serialVersionUID = -5415775215053216360L;

--- a/forge-gui-desktop/src/test/java/forge/gamesimulationtests/ReplacementHandlerTest.java
+++ b/forge-gui-desktop/src/test/java/forge/gamesimulationtests/ReplacementHandlerTest.java
@@ -68,11 +68,11 @@ public class ReplacementHandlerTest extends SimulationTest {
         CardTraitChanges changes = new CardTraitChanges(
             null, null, null,
             Lists.newArrayList(re),
-            null, false, false
+            null, null
         );
         creature.addPerpetual(new PerpetualAbilities(timestamp, changes));
         creature.addChangedCardTraits(null, null, null,
-            Lists.newArrayList(re), null, false, false, timestamp, 0);
+            Lists.newArrayList(re), null, null, timestamp, 0);
 
         // Now move the card from hand to battlefield
         // This should NOT cause a StackOverflowError

--- a/forge-gui/res/cardsfolder/b/blood_sun.txt
+++ b/forge-gui/res/cardsfolder/b/blood_sun.txt
@@ -3,7 +3,7 @@ ManaCost:2 R
 Types:Enchantment
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ DBDraw | TriggerDescription$ When CARDNAME enters, draw a card.
 SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1
-S:Mode$ Continuous | Affected$ Land | RemoveAllAbilities$ True | ExceptManaAbilities$ True | Description$ All lands lose all abilities except mana abilities.
+S:Mode$ Continuous | Affected$ Land | RemoveNonManaAbilities$ True | Description$ All lands lose all abilities except mana abilities.
 SVar:NonStackingEffect:True
 AI:RemoveDeck:Random
 Oracle:When Blood Sun enters, draw a card.\nAll lands lose all abilities except mana abilities.


### PR DESCRIPTION
Closes #9532, #9583

Uses an extra class for CardTraitChanges by Type Change (Layer 4)

it also uses new `CardTraitBase::isManaAbility` for "remove non mana abilities"
(so it should keep the triggered ones)

for the new LandTraitChanges in CardState, i use #9570 to have the SpellAbilities in an Enum Map
(that somewhat fixes that the BasicLand Ability might be on the wrong state for a DFC?)