### PR TITLE
Planar controller/owner fix

### DIFF
--- a/forge-game/src/main/java/forge/game/Game.java
+++ b/forge-game/src/main/java/forge/game/Game.java
@@ -856,12 +856,14 @@ public class Game {
             }
         }
 
-        for (Card c : getActivePlanes()) {
-            if (c.getController().equals(p)) {
-                planarControllerLost = true;
-            }
-            if (c.getOwner().equals(p)) {
-                planarOwnerLost = true;
+        if (getActivePlanes() != null) {
+            for (Card c : getActivePlanes()) {
+                if (c.getController().equals(p)) {
+                    planarControllerLost = true;
+                }
+                if (c.getOwner().equals(p)) {
+                    planarOwnerLost = true;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes issue where any player losing in a Planechase game was causing the behaviors meant for when the planar controller and for when the planar owners lose, regardless of whether that player actually controlled or owned any active planes at the time, because it was counting the controlled/owned _inactive_ planes in the planar deck.