### PR TITLE
YECL: Limitless Rekindling

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/limitless_rekindling.txt
+++ b/forge-gui/res/cardsfolder/upcoming/limitless_rekindling.txt
@@ -1,0 +1,10 @@
+Name:Limitless Rekindling
+ManaCost:3 R R
+Types:Kindred Sorcery Elemental
+K:Storm
+A:SP$ NameCard | AtRandom$ True | ValidCards$ Instant.setECL,Sorcery.setECL | SubAbility$ DBConjure | StackDescription$ REP Conjure_{p:You} conjures & you may_{p:You} may | SpellDescription$ Conjure a random instant or sorcery card from the Lorwyn Eclipsed expansion into exile. Until end of turn, you may cast that card without paying its mana cost.
+SVar:DBConjure:DB$  MakeCard | Name$ ChosenName | Conjure$ True | Zone$ Exile | RememberMade$ True | SubAbility$ DBEffect
+SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ STPlay | SubAbility$ DBCleanup | ForgetOnMoved$ Exile
+SVar:STPlay:Mode$ Continuous | MayPlay$ True | MayPlayWithoutManaCost$ True | Affected$ Card.IsRemembered+nonLand | AffectedZone$ Exile | Description$ Until end of turn, you may cast the exiled card without paying its mana cost.
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:Conjure a random instant or sorcery card from the Lorwyn Eclipsed expansion into exile. Until end of turn, you may cast that card without paying its mana cost.\nStorm


### PR DESCRIPTION
[As revealed recently](https://www.reddit.com/r/MagicAlchemy/comments/1qoxa32/limitless_rekindling/).
Needs support that feels beyond my current expertise. Tested with `ValidCards$ Instant` to determine that the resolution process does work as expected. 
As far as I can determine `ValidCards$` in the context of  `NameCard` lines doesn't parse comma splits or set codes. Looking into the code of `ChooseCardNameEffect.java` (lines [36-39](https://github.com/Card-Forge/forge/blob/a57b4631adc9abb26358341ca4c5c8937e758b87/forge-game/src/main/java/forge/game/ability/effects/ChooseCardNameEffect.java#L36) and [96-109](https://github.com/Card-Forge/forge/blob/a57b4631adc9abb26358341ca4c5c8937e758b87/forge-game/src/main/java/forge/game/ability/effects/ChooseCardNameEffect.java#L96) ) and comparing with `SacrificeAllEffect.java` (lines [45-52](https://github.com/Card-Forge/forge/blob/a57b4631adc9abb26358341ca4c5c8937e758b87/forge-game/src/main/java/forge/game/ability/effects/SacrificeAllEffect.java#L45); which  is an effect that can parse commas and set codes in `ValidCards$` ) I clearly notice these classes handle `ValidCards$` in ways that seem difficult to reconcile. Still, I followed the latter effect's lead in laying out the putative script herein.