### PR TITLE
Fix Brutal Cathar trigger timing and add regression canaries(#9484)

### DIFF
--- a/forge-gui-desktop/src/test/java/forge/ai/simulation/GameSimulationTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/simulation/GameSimulationTest.java
@@ -24,16 +24,6 @@ import java.util.List;
 import java.util.Map;
 
 public class GameSimulationTest extends SimulationTest {
-    private int countCreaturesControlledBy(Player p) {
-        int count = 0;
-        for (Card c : p.getCardsIn(ZoneType.Battlefield)) {
-            if (c.isCreature()) {
-                count++;
-            }
-        }
-        return count;
-    }
-
     private Map<AbilityKey, Object> destroyParams(Game game) {
         Map<AbilityKey, Object> params = AbilityKey.newMap();
         params.put(AbilityKey.LastStateBattlefield, game.copyLastStateBattlefield());
@@ -1643,7 +1633,7 @@ public class GameSimulationTest extends SimulationTest {
         Game afterCast = sim.getSimulatedGameState();
 
         Player simOpponent = afterCast.getPlayers().get(0);
-        AssertJUnit.assertEquals(1, countCreaturesControlledBy(simOpponent));
+        AssertJUnit.assertEquals(1, simOpponent.getCreaturesInPlay().size());
     }
 
     @Test


### PR DESCRIPTION
Fixes ChangesZone trigger timing for battlefield-origin events so newly-entered objects don’t retroactively observe older leaves/dies events (Brutal Cathar / Slaughter Specialist case).

  Also adds focused regression canaries in GameSimulationTest for:

  - exile-and-return timing (Brutal Cathar, Fiend Hunter, Banisher Priest),
  - normal simultaneous death observer behavior,
  - command-zone/leave watcher behavior (Oubliette),
  - replacement + leaves-battlefield path (Rest in Peace + Skyclave Apparition),
  - LKI counter-dependent dies behavior (Jotun Owl Keeper).

  No functional changes outside trigger timing guard + tests.