### PR TITLE
Rename Adventure arena function from 'loose' to 'lose'

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/scene/ArenaScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/ArenaScene.java
@@ -103,14 +103,14 @@ public class ArenaScene extends UIScene implements IAfterMatch {
                     "\n" + Forge.getLocalizer().getMessage("lblConcedeCurrentGame"),
                     Forge.getLocalizer().getMessage("lblYes"),
                     Forge.getLocalizer().getMessage("lblNo"), () -> {
-                        this.loose();
+                        this.lose();
                         removeDialog();
                     }, this::removeDialog);
         }
         showDialog(concedeDialog);
     }
 
-    private void loose() {
+    private void lose() {
         doneButton.setText("[%80][+Exit]");
         doneButton.layout();
         startButton.setDisabled(true);
@@ -185,7 +185,7 @@ public class ArenaScene extends UIScene implements IAfterMatch {
             markLostFighter(fighters.get(fighters.size - 1).actor);
             moveFighter(fighters.get(fighters.size - 2).actor, true);
             winners.add(fighters.get(fighters.size - 2));
-            loose();
+            lose();
         }
 
         fighters = winners;


### PR DESCRIPTION
The function to handle losses in the Adventure Mode arenas had a function called 'loose' instead of 'lose', I've just fixed that.