### PR TITLE
Cleanup: Draft effect, pass 1

### DIFF
--- a/forge-gui/res/cardsfolder/a/arms_scavenger.txt
+++ b/forge-gui/res/cardsfolder/a/arms_scavenger.txt
@@ -3,7 +3,8 @@ ManaCost:1 R
 Types:Creature Human Warrior
 PT:2/2
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDraft | TriggerDescription$ At the beginning of your upkeep, draft a card from CARDNAME's spellbook, then exile it. Until end of turn, you may play that card.
-SVar:TrigDraft:DB$ Draft | Spellbook$ Boots of Speed,Cliffhaven Kitesail,Colossus Hammer,Dueling Rapier,Spare Dagger,Tormentor's Helm,Goldvein Pick,Jousting Lance,Mask of Immolation,Mirror Shield,Relic Axe,Rogue's Gloves,Scavenged Blade,Shield of the Realm,Ceremonial Knife | Zone$ Exile | RememberDrafted$ True | SubAbility$ DBEffect
+SVar:TrigDraft:DB$ Draft | Spellbook$ Boots of Speed,Cliffhaven Kitesail,Colossus Hammer,Dueling Rapier,Spare Dagger,Tormentor's Helm,Goldvein Pick,Jousting Lance,Mask of Immolation,Mirror Shield,Relic Axe,Rogue's Gloves,Scavenged Blade,Shield of the Realm,Ceremonial Knife | RememberDrafted$ True | SubAbility$ DBExile
+SVar:DBExile:DB$ ChangeZone | Origin$ Hand | Destination$ Exile | Defined$ Remembered | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ Play | ExileOnMoved$ Exile | SubAbility$ DBCleanup
 SVar:Play:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsRemembered | AffectedZone$ Exile | Description$ Until the end of turn, you may play that card.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/b/brood_astronomer.txt
+++ b/forge-gui/res/cardsfolder/b/brood_astronomer.txt
@@ -3,7 +3,9 @@ ManaCost:1 G
 Types:Creature Insect Scientist
 PT:2/2
 T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigDraft | TriggerDescription$ When this creature enters, you may sacrifice a land. If you do, draft a card from the Planets spellbook and put it onto the battlefield tapped.
-SVar:TrigDraft:AB$ Draft | Cost$ Sac<1/Land> | SpellbookName$ Planets | Spellbook$ Adagia; Windswept Bastion,Evendo; Waking Haven,Kavaron; Memorial World,Susur Secundi; Void Altar,Uthros; Titanic Godcore | Zone$ Battlefield | Tapped$ True
+SVar:TrigDraft:AB$ Draft | Cost$ Sac<1/Land> | SpellbookName$ Planets | Spellbook$ Adagia; Windswept Bastion,Evendo; Waking Haven,Kavaron; Memorial World,Susur Secundi; Void Altar,Uthros; Titanic Godcore | RememberDrafted$ True | SubAbility$ DBPut
+SVar:DBPut:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | Defined$ Remembered | Tapped$ True | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 A:AB$ Mana | Cost$ T | Produced$ Any | Amount$ X | SpellDescription$ Add one mana of any color. If you control a Planet with twelve or more charge counters on it, add three mana of any one color instead.
 SVar:X:Count$Compare Y GE1.3.1
 SVar:Y:Count$Valid Planet.YouCtrl+counters_GE12_CHARGE

--- a/forge-gui/res/cardsfolder/c/celestial_vault.txt
+++ b/forge-gui/res/cardsfolder/c/celestial_vault.txt
@@ -1,7 +1,8 @@
 Name:Celestial Vault
 ManaCost:1 W
 Types:Artifact
-A:AB$ Draft | Cost$ W T | Spellbook$ Angel of Destiny,Resplendent Angel,Angel of Vitality,Righteous Valkyrie,Angel of Invention,Angel of Sanctions,Valkyrie Harbinger,Emancipation Angel,Youthful Valkyrie,Resplendent Marshal,Enduring Angel,Sigardian Savior,Serra Angel,Stalwart Valkyrie,Segovian Angel | Zone$ Exile | ExileFaceDown$ True | RememberDrafted$ True | SpellDescription$ Draft a card from CARDNAME's spellbook and exile it face down.
+A:AB$ Draft | Cost$ W T | Spellbook$ Angel of Destiny,Resplendent Angel,Angel of Vitality,Righteous Valkyrie,Angel of Invention,Angel of Sanctions,Valkyrie Harbinger,Emancipation Angel,Youthful Valkyrie,Resplendent Marshal,Enduring Angel,Sigardian Savior,Serra Angel,Stalwart Valkyrie,Segovian Angel | RememberDrafted$ True | SubAbility$ DBExile | StackDescription$ REP Draft_{p:You} drafts & exile_they exile | SpellDescription$ Draft a card from CARDNAME's spellbook and exile it face down.
+SVar:DBExile:DB$ ChangeZone | Origin$ Hand | Destination$ Exile | ExileFaceDown$ True | Defined$ Remembered | StackDescription$ None
 A:AB$ ChangeZoneAll | Cost$ 1 Sac<1/CARDNAME> | Origin$ Exile | Destination$ Hand | ChangeType$ Card.IsRemembered+ExiledWithSource | SpellDescription$ Put each card exiled with CARDNAME into your hand.
 T:Mode$ ChangesZone | Origin$ Exile | Destination$ Any | Static$ True | ValidCard$ Card.IsRemembered+ExiledWithSource | Execute$ DBForget
 SVar:DBForget:DB$ Pump | ForgetObjects$ TriggeredCard

--- a/forge-gui/res/cardsfolder/d/dragon_typhoon.txt
+++ b/forge-gui/res/cardsfolder/d/dragon_typhoon.txt
@@ -2,7 +2,9 @@ Name:Dragon Typhoon
 ManaCost:4 R R
 Types:Kindred Enchantment Dragon
 T:Mode$ SpellCast | ValidCard$ Card.Dragon,Card.nonCreature | ValidActivatingPlayer$ You | Execute$ TrigDraft | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a Dragon or noncreature spell, draft a card from CARDNAME's spellbook and put it onto the battlefield.
-SVar:TrigDraft:DB$ Draft | Spellbook$ Boltwing Marauder,Caldera Pyremaw,Magmatic Hellkite,Neriv; Heart of the Storm,Stormscale Scion,Thunderbreak Regent,Thundermane Dragon | Zone$ Battlefield
+SVar:TrigDraft:DB$ Draft | Spellbook$ Boltwing Marauder,Caldera Pyremaw,Magmatic Hellkite,Neriv; Heart of the Storm,Stormscale Scion,Thunderbreak Regent,Thundermane Dragon | RememberDrafted$ True | SubAbility$ DBPut
+SVar:DBPut:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | Defined$ Remembered | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 A:AB$ Token | PrecostDesc$ Channel — | Cost$ 2 R R Discard<1/CARDNAME> | ActivationZone$ Hand | TokenScript$ r_4_4_dragon_flying | SpellDescription$ Create a 4/4 red Dragon creature token with flying.
 DeckHas:Type$Dragon
 DeckHints:Type$Dragon

--- a/forge-gui/res/cardsfolder/g/garruk_wrath_of_the_wilds.txt
+++ b/forge-gui/res/cardsfolder/g/garruk_wrath_of_the_wilds.txt
@@ -4,10 +4,12 @@ Types:Legendary Planeswalker Garruk
 Loyalty:4
 A:AB$ ChooseCard | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | ChoiceZone$ Hand | Choices$ Card.Creature+YouOwn | ChoiceTitle$ Choose a creature card in your hand | Mandatory$ True | SubAbility$ DBPump | StackDescription$ SpellDescription | SpellDescription$ Choose a creature card in your hand. It perpetually gets +1/+1 and perpetually gains "This spell costs {1} less to cast."
 SVar:DBPump:DB$ Pump | PumpZone$ Hand | Defined$ ChosenCard | NumAtt$ +1 | NumDef$ +1 | Duration$ Perpetual | SubAbility$ DBAnimate
-SVar:DBAnimate:DB$ Animate | Defined$ ChosenCard | staticAbilities$ ReduceCost | Duration$ Perpetual | SubAbility$ DBCleanup | StackDescription$ None
+SVar:DBAnimate:DB$ Animate | Defined$ ChosenCard | staticAbilities$ ReduceCost | Duration$ Perpetual | SubAbility$ DBCleanup1 | StackDescription$ None
 SVar:ReduceCost:Mode$ ReduceCost | ValidCard$ Card.Self | Type$ Spell | Amount$ 1 | EffectZone$ All | Description$ This spell costs {1} less to cast.
-SVar:DBCleanup:DB$ Cleanup | ClearChosenCard$ True
-A:AB$ Draft | Cost$ SubCounter<1/LOYALTY> | Planeswalker$ True | Spellbook$ Mosscoat Goriak,Sylvan Brushstrider,Murasa Rootgrazer,Dire Wolf Prowler,Ferocious Pup,Pestilent Wolf,Garruk's Uprising,Dawntreader Elk,Nessian Hornbeetle,Territorial Scythecat,Trufflesnout,Wary Okapi,Scurrid Colony,Barkhide Troll,Underdark Basilisk | Zone$ Battlefield | SpellDescription$ Draft a card from CARDNAME's spellbook and put it onto the battlefield.
+SVar:DBCleanup1:DB$ Cleanup | ClearChosenCard$ True
+A:AB$ Draft | Cost$ SubCounter<1/LOYALTY> | Planeswalker$ True | Spellbook$ Mosscoat Goriak,Sylvan Brushstrider,Murasa Rootgrazer,Dire Wolf Prowler,Ferocious Pup,Pestilent Wolf,Garruk's Uprising,Dawntreader Elk,Nessian Hornbeetle,Territorial Scythecat,Trufflesnout,Wary Okapi,Scurrid Colony,Barkhide Troll,Underdark Basilisk | RememberDrafted$ True | SubAbility$ DBPut | StackDescription$ REP Draft_{p:You} drafts & and put_and they put | SpellDescription$ Draft a card from CARDNAME's spellbook and put it onto the battlefield.
+SVar:DBPut:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | Defined$ Remembered | SubAbility$ DBCleanup2 | StackDescription$ None
+SVar:DBCleanup2:DB$ Cleanup | ClearRemembered$ True
 A:AB$ PumpAll | Cost$ SubCounter<6/LOYALTY> | Planeswalker$ True | Ultimate$ True | ValidCards$ Creature.YouCtrl | NumAtt$ +3 | NumDef$ +3 | KW$ Trample | SpellDescription$ Until end of turn, creatures you control get +3/+3 and gain trample.
 DeckHas:Type$Troll|Elk|Wolf|Beast|Insect|Squirrel|Boar|Basilisk|Antelope & Ability$Sacrifice|Counters|LifeGain
 Oracle:[+1]: Choose a creature card in your hand. It perpetually gets +1/+1 and perpetually gains "This spell costs {1} less to cast."\n[-1]: Draft a card from Garruk, Wrath of the Wild's spellbook and put it onto the battlefield.\n[-6]: Until end of turn, creatures you control get +3/+3 and gain trample.

--- a/forge-gui/res/cardsfolder/g/glimmer_hoarder.txt
+++ b/forge-gui/res/cardsfolder/g/glimmer_hoarder.txt
@@ -4,6 +4,7 @@ Types:Creature Human Survivor
 PT:2/2
 T:Mode$ Phase | Phase$ Main | PhaseCount$ 2 | ValidPlayer$ You | PresentDefined$ Self | IsPresent$ Card.tapped | TriggerZones$ Battlefield | Execute$ TrigLoseLife | TriggerDescription$ Survival — At the beginning of your second main phase, if CARDNAME is tapped, you lose 1 life and draft a card from CARDNAME's spellbook. That card perpetually becomes an enchantment in addition to its other types.
 SVar:TrigLoseLife:DB$ LoseLife | LifeAmount$ 1 | SubAbility$ DBDraft
-SVar:DBDraft:DB$ Draft | Defined$ You | Spellbook$ Angel of Suffering,Aphemia; the Cacophony,Balemurk Leech,Chitinous Crawler,Defiler of Flesh,Gravebreaker Lamia,Mindwrack Harpy,Puppet Raiser,Starving Revenant | RememberDrafted$ True | Zone$ Hand | SubAbility$ DBAnimate
-SVar:DBAnimate:DB$ Animate | Defined$ Remembered | Types$ Enchantment | Duration$ Perpetual
+SVar:DBDraft:DB$ Draft | Defined$ You | Spellbook$ Angel of Suffering,Aphemia; the Cacophony,Balemurk Leech,Chitinous Crawler,Defiler of Flesh,Gravebreaker Lamia,Mindwrack Harpy,Puppet Raiser,Starving Revenant | RememberDrafted$ True | SubAbility$ DBAnimate
+SVar:DBAnimate:DB$ Animate | Defined$ Remembered | Types$ Enchantment | Duration$ Perpetual | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Survival — At the beginning of your second main phase, if Glimmer Hoarder is tapped, you lose 1 life and draft a card from Glimmer Hoarder's spellbook. That card perpetually becomes an enchantment in addition to its other types.

--- a/forge-gui/res/cardsfolder/k/kaylas_kindling.txt
+++ b/forge-gui/res/cardsfolder/k/kaylas_kindling.txt
@@ -4,7 +4,8 @@ Types:Enchantment
 T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigDamage | TriggerDescription$ When CARDNAME enters, it deals 2 damage to any target.
 SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Any | NumDmg$ 2
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigDraft | TriggerDescription$ At the beginning of your upkeep, draft a card from CARDNAME's spellbook and exile it. Until end of turn, you may cast that card.
-SVar:TrigDraft:DB$ Draft | Spellbook$ Abrade,Cleansing Wildfire,Terror of the Peaks,Explosive Singularity,Guttersnipe,Seasoned Pyromancer,Unexpected Windfall,Banefire,Lightning Bolt,Dualcaster Mage,Electrodominance,Crackle with Power,Volcanic Fallout,Young Pyromancer,Siege-Gang Commander | Zone$ Exile | RememberDrafted$ True | SubAbility$ DBEffect
+SVar:TrigDraft:DB$ Draft | Spellbook$ Abrade,Cleansing Wildfire,Terror of the Peaks,Explosive Singularity,Guttersnipe,Seasoned Pyromancer,Unexpected Windfall,Banefire,Lightning Bolt,Dualcaster Mage,Electrodominance,Crackle with Power,Volcanic Fallout,Young Pyromancer,Siege-Gang Commander | RememberDrafted$ True | SubAbility$ DBExile
+SVar:DBExile:DB$ ChangeZone | Origin$ Hand | Destination$ Exile | Defined$ Remembered | SubAbility$ DBEffect
 SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ Play | ExileOnMoved$ Exile | SubAbility$ DBCleanup
 SVar:Play:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsRemembered | AffectedZone$ Exile | Description$ Until the end of turn, you may play that card.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/l/loose_in_the_park.txt
+++ b/forge-gui/res/cardsfolder/l/loose_in_the_park.txt
@@ -5,8 +5,10 @@ K:Enchant:Land
 SVar:AttachAILogic:Pump
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ FreeCard | TriggerDescription$ When CARDNAME enters, draw a card, then draft a card from CARDNAME's spellbook and exile it.
 SVar:FreeCard:DB$ Draw | Defined$ You | NumCards$ 1 | SubAbility$ TrigDraft
-SVar:TrigDraft:DB$ Draft | TriggerZones$ Battlefield | Spellbook$ Bristling Boar,Enraged Ceratok,Exuberant Wolfbear,Gaea's Protector,Master Symmetrist,Ornery Dilophosaur,Overgrown Armasaur,Predatory Wurm,Prized Unicorn,Sabertooth Mauler,Spike-Tailed Ceratops,Spore Crawler,Thrashing Brontodon,Wardscale Crocodile,World Shaper | Zone$ Exile | RememberDrafted$ True
-A:AB$ Clone | Cost$ 3 | Defined$ Remembered | CloneTarget$ Enchanted | PumpKeywords$ Haste | AddTypes$ Land | Duration$ UntilEndOfTurn | SpellDescription$ Enchanted land becomes a copy of the exiled card until end of turn and gains haste. It's still a land.
+SVar:TrigDraft:DB$ Draft | TriggerZones$ Battlefield | Spellbook$ Bristling Boar,Enraged Ceratok,Exuberant Wolfbear,Gaea's Protector,Master Symmetrist,Ornery Dilophosaur,Overgrown Armasaur,Predatory Wurm,Prized Unicorn,Sabertooth Mauler,Spike-Tailed Ceratops,Spore Crawler,Thrashing Brontodon,Wardscale Crocodile,World Shaper | RememberDrafted$ True | SubAbility$ DBExile
+SVar:DBExile:DB$ ChangeZone | Origin$ Hand | Destination$ Exile | Defined$ Remembered | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+A:AB$ Clone | Cost$ 3 | Defined$ ExiledWith | CloneTarget$ Enchanted | PumpKeywords$ Haste | AddTypes$ Land | Duration$ UntilEndOfTurn | SpellDescription$ Enchanted land becomes a copy of the exiled card until end of turn and gains haste. It's still a land.
 SVar:NonStackingAttachEffect:True
 DeckHas:Type$Boar|Rhino|Wolf|Bear|Elemental|Warrior|Rhino|Druid|Dinosaur|Wurm|Unicorn|Cat|Fungus|Crocodile|Merfolk|Shaman|Saproling & Ability$Mill|Graveyard|Sacrifice|Counters|Token
 DeckHints:Type$Human|Garruk

--- a/forge-gui/res/cardsfolder/m/masterpiece_vault.txt
+++ b/forge-gui/res/cardsfolder/m/masterpiece_vault.txt
@@ -2,8 +2,8 @@ Name:Masterpiece Vault
 ManaCost:3
 Types:Artifact
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigDraft | TriggerDescription$ When this artifact is put into a graveyard from the battlefield, draft a card from CARDNAME's spellbook and put it onto the battlefield. When an Equipment enters this way, attach it to up to one target creature you control.
-SVar:TrigDraft:DB$ Draft | Spellbook$ Champion's Helm,Lightning Greaves,Sword of Body and Mind,Sword of Feast and Famine,Sword of Fire and Ice,Sword of Light and Shadow,Sword of War and Peace | Zone$ Battlefield | RememberDrafted$ True | SubAbility$ MoveToPlay
-SVar:MoveToPlay:DB$ ChangeZone | Hidden$ True | Origin$ All | Destination$ Battlefield | Defined$ Remembered | ConditionDefined$ Remembered | ConditionPresent$ Card.Equipment | SubAbility$ DBTrigger
+SVar:TrigDraft:DB$ Draft | Spellbook$ Champion's Helm,Lightning Greaves,Sword of Body and Mind,Sword of Feast and Famine,Sword of Fire and Ice,Sword of Light and Shadow,Sword of War and Peace | RememberDrafted$ True | SubAbility$ DBPut
+SVar:DBPut:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | Defined$ Remembered | ConditionDefined$ Remembered | ConditionPresent$ Card.Equipment | SubAbility$ DBTrigger
 SVar:DBTrigger:DB$ ImmediateTrigger | Execute$ TrigAttach | TriggerDescription$ When an Equipment enters this way, attach it to up to one target creature you control.
 SVar:TrigAttach:DB$ Attach | ValidTgts$ Creature.YouCtrl | Object$ Remembered | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target creature you control
 A:AB$ Sacrifice | Cost$ 5 | SpellDescription$ Sacrifice this artifact.

--- a/forge-gui/res/cardsfolder/p/protean_war_engine.txt
+++ b/forge-gui/res/cardsfolder/p/protean_war_engine.txt
@@ -3,7 +3,9 @@ ManaCost:R W
 Types:Artifact Vehicle
 PT:0/4
 K:ETBReplacement:Other:DBDraft
-SVar:DBDraft:DB$ Draft | TriggerZones$ Battlefield | Spellbook$ Serra Angel,Resplendent Angel,Steel-Plume Marshal,Duelcraft Trainer,Falconer Adept,Seraph of Dawn,Star-Crowned Stag,Benalish Marshal,Blade Historian,Captivating Crew,Manaform Hellkite,Serra Paragon,Moonveil Regent,Skyship Stalker,Ogre Battledriver | Zone$ Exile | SpellDescription$ As CARDNAME enters, draft a card from CARDNAME's spellbook and exile it.
+SVar:DBDraft:DB$ Draft | TriggerZones$ Battlefield | Spellbook$ Serra Angel,Resplendent Angel,Steel-Plume Marshal,Duelcraft Trainer,Falconer Adept,Seraph of Dawn,Star-Crowned Stag,Benalish Marshal,Blade Historian,Captivating Crew,Manaform Hellkite,Serra Paragon,Moonveil Regent,Skyship Stalker,Ogre Battledriver | RememberDrafted$ True | SubAbility$ DBExile | SpellDescription$ As CARDNAME enters, draft a card from CARDNAME's spellbook and exile it.
+SVar:DBExile:DB$ ChangeZone | Origin$ Hand | Destination$ Exile | Defined$ Remembered | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 T:Mode$ BecomesCrewed | ValidCard$ Card.Self | Execute$ TrigClone | TriggerDescription$ Whenever CARDNAME becomes crewed, until end of turn, it becomes a copy of the exiled card, except it's a Vehicle artifact in addition to its other types.
 SVar:TrigClone:DB$ Clone | Defined$ ExiledWith | CloneTarget$ Self | AddTypes$ Vehicle & Artifact | Duration$ UntilEndOfTurn
 K:Crew:3

--- a/forge-gui/res/cardsfolder/r/razor_demon.txt
+++ b/forge-gui/res/cardsfolder/r/razor_demon.txt
@@ -6,7 +6,7 @@ K:Flying
 K:Ward:Discard<1/Card>
 T:Mode$ SpellCast | ValidCard$ Card.Self | Execute$ TrigChooseTgt | TriggerDescription$ When you cast this spell, target opponent drafts a card from CARDNAME's spellbook. They may cast that card without paying its mana cost.
 SVar:TrigChooseTgt:DB$ Pump | ValidTgts$ Opponent | IsCurse$ True | SubAbility$ DBDraft
-SVar:DBDraft:DB$ Draft | Defined$ Targeted | Spellbook$ Demonic Bargain,Ever After,Demonic Pact | RememberDrafted$ True | Zone$ Hand | SubAbility$ DBPlay
+SVar:DBDraft:DB$ Draft | Defined$ Targeted | Spellbook$ Demonic Bargain,Ever After,Demonic Pact | RememberDrafted$ True | SubAbility$ DBPlay
 SVar:DBPlay:DB$ Play | Controller$ Targeted | Defined$ Remembered | WithoutManaCost$ True | Optional$ True | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:When you cast this spell, target opponent drafts a card from Razor Demon's spellbook. They may cast that card without paying its mana cost.\nFlying\nWard-Discard a card.

--- a/forge-gui/res/cardsfolder/t/the_hourglass_coven.txt
+++ b/forge-gui/res/cardsfolder/t/the_hourglass_coven.txt
@@ -3,7 +3,9 @@ ManaCost:4 B B
 Types:Legendary Creature Hag Warlock
 PT:3/3
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDraft | TriggerDescription$ When CARDNAME enters, draft a card from CARDNAME's spellbook twice, then put those cards onto the battlefield.
-SVar:TrigDraft:DB$ Draft | DraftNum$ 2 | Spellbook$ Hag of Syphoned Breath,Hag of Dark Duress,Hag of Ceaseless Torment,Hag of Inner Weakness,Hag of Death's Legion,Hag of Scoured Thoughts,Hag of Twisted Visions,Hag of Mage's Doom,Hag of Noxious Nightmares | Zone$ Battlefield
+SVar:TrigDraft:DB$ Draft | DraftNum$ 2 | Spellbook$ Hag of Syphoned Breath,Hag of Dark Duress,Hag of Ceaseless Torment,Hag of Inner Weakness,Hag of Death's Legion,Hag of Scoured Thoughts,Hag of Twisted Visions,Hag of Mage's Doom,Hag of Noxious Nightmares | RememberDrafted$ True | SubAbility$ DBPut
+SVar:DBPut:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | Defined$ Remembered | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 S:Mode$ Continuous | Affected$ Warlock.Other+YouCtrl | AddPower$ 1 | AddToughness$ 1 | Description$ Other Warlocks you control get +1/+1.
 SVar:PlayMain1:TRUE
 DeckHints:Type$Warlock

--- a/forge-gui/res/cardsfolder/t/tibalt_wicked_tormentor.txt
+++ b/forge-gui/res/cardsfolder/t/tibalt_wicked_tormentor.txt
@@ -2,9 +2,10 @@ Name:Tibalt, Wicked Tormentor
 ManaCost:3 R R
 Types:Legendary Planeswalker Tibalt
 Loyalty:3
-A:AB$ Mana | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | Produced$ R | Amount$ 2 | SubAbility$ DBDraft | SpellDescription$ Add {R}{R}.
-SVar:DBDraft:DB$ Draft | Spellbook$ Chained Brute,Charmbreaker Devils,Festival Crasher,Forge Devil,Frenzied Devils,Havoc Jester,Hellrider,Hobblefiend,Pitchburn Devils,Sin Prodder,Spiteful Prankster,Tibalt's Rager,Torch Fiend,Brimstone Vandal,Devil's Play | Zone$ Exile | RememberDrafted$ True | SubAbility$ DBEffect | SpellDescription$ Draft a card from CARDNAME's spellbook, then exile it.
-SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ Play | ExileOnMoved$ Exile | SubAbility$ DBCleanup | SpellDescription$ Until end of turn, you may cast that card.
+A:AB$ Mana | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | Produced$ R | Amount$ 2 | SubAbility$ DBDraft | StackDescription$ REP Add_{p:You} adds & Draft_{p:You} drafts & then exile_then they exile & you may_{p:You} may | SpellDescription$ Add {R}{R}. Draft a card from CARDNAME's spellbook, then exile it. Until end of turn, you may cast that card.
+SVar:DBDraft:DB$ Draft | Spellbook$ Chained Brute,Charmbreaker Devils,Festival Crasher,Forge Devil,Frenzied Devils,Havoc Jester,Hellrider,Hobblefiend,Pitchburn Devils,Sin Prodder,Spiteful Prankster,Tibalt's Rager,Torch Fiend,Brimstone Vandal,Devil's Play | RememberDrafted$ True | SubAbility$ DBExile | StackDescription$ None
+SVar:DBExile:DB$ ChangeZone | Origin$ Hand | Destination$ Exile | Defined$ Remembered | SubAbility$ DBEffect | StackDescription$ None
+SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | StaticAbilities$ Play | ExileOnMoved$ Exile | SubAbility$ DBCleanup | StackDescription$ None
 SVar:Play:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsRemembered | AffectedZone$ Exile | Description$ Until the end of turn, you may cast that card.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 A:AB$ DealDamage | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ 4 | UnlessCost$ DamageYou<4> | UnlessPayer$ TargetedController | UnlessResolveSubs$ WhenPaid | SubAbility$ DBDiscardDraw | StackDescription$ CARDNAME deals 4 damage to {c:Targeted} unless {p:TargetedController} has NICKNAME deal 4 damage to them. | SpellDescription$ CARDNAME deals 4 damage to target creature or planeswalker unless its controller has NICKNAME deal 4 damage to them.


### PR DESCRIPTION
[As discussed here](https://github.com/Card-Forge/forge/pull/9668#discussion_r2759449271), it was noticed that `Draft` effect lines with the `Zone$` parameter weren't putting the card in hand before putting it in the zone stated in the parameter, when the ability is described in such a way and [gameplay footage](https://youtu.be/vENppwSISIw?t=151) shows the drafted cards going to the hand before going anywhere else. This situation, among other things, has effects that exile drafted cards not trigger [Ranar the Ever-Watchful](https://scryfall.com/card/khc/2/ranar-the-ever-watchful). 
In the interest of having things working as expected, and that seek and draft follow the same pattern for ease of scripting, herein I removed the `Zone$` parameter from the `Draft` lines and added relevant `ChangeZone` lines. Cards were tested to satisfaction and some germane issues were resolved at the same time, mostly regarding Stack messages.
Admittedly my Java expertise isn't sufficient to confidently edit `DraftEffect.java` to remove the code this PR proposes to obsolete.