### PR TITLE
Add version check warning for network play

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/net/client/GameClientHandler.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/client/GameClientHandler.java
@@ -13,6 +13,7 @@ import forge.gamemodes.net.ReplyPool;
 import forge.gamemodes.net.event.LoginEvent;
 import forge.gui.interfaces.IGuiGame;
 import forge.interfaces.ILobbyListener;
+import forge.util.BuildInfo;
 import forge.localinstance.properties.ForgePreferences.FPref;
 import forge.model.FModel;
 import forge.player.LobbyPlayerHuman;
@@ -290,7 +291,7 @@ final class GameClientHandler extends GameProtocolHandler<IGuiGame> {
     @Override
     public void channelActive(final ChannelHandlerContext ctx) {
         // Don't use send() here, as this.channel is not yet set!
-        ctx.channel().writeAndFlush(new LoginEvent(FModel.getPreferences().getPref(FPref.PLAYER_NAME), Integer.parseInt(FModel.getPreferences().getPref(FPref.UI_AVATARS).split(",")[0]), Integer.parseInt(FModel.getPreferences().getPref(FPref.UI_SLEEVES).split(",")[0])));
+        ctx.channel().writeAndFlush(new LoginEvent(FModel.getPreferences().getPref(FPref.PLAYER_NAME), Integer.parseInt(FModel.getPreferences().getPref(FPref.UI_AVATARS).split(",")[0]), Integer.parseInt(FModel.getPreferences().getPref(FPref.UI_SLEEVES).split(",")[0]), BuildInfo.getVersionString()));
     }
 
 }

--- a/forge-gui/src/main/java/forge/gamemodes/net/event/LoginEvent.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/event/LoginEvent.java
@@ -7,10 +7,12 @@ public class LoginEvent implements NetEvent {
 
     private final String username;
     private final int avatarIndex, sleeveIndex;
-    public LoginEvent(final String username, final int avatarIndex, final int sleeveIndex) {
+    private final String version;
+    public LoginEvent(final String username, final int avatarIndex, final int sleeveIndex, final String version) {
         this.username = username;
         this.avatarIndex = avatarIndex;
         this.sleeveIndex = sleeveIndex;
+        this.version = version;
     }
 
     @Override
@@ -27,5 +29,9 @@ public class LoginEvent implements NetEvent {
 
     public int getSleeveIndex() {
         return sleeveIndex;
+    }
+
+    public String getVersion() {
+        return version;
     }
 }

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
@@ -13,6 +13,7 @@ import forge.gui.util.SOptionPane;
 import forge.interfaces.IGameController;
 import forge.interfaces.ILobbyListener;
 import forge.model.FModel;
+import forge.util.BuildInfo;
 import forge.util.IterableUtil;
 import forge.util.Localizer;
 import forge.localinstance.properties.ForgeNetPreferences;
@@ -433,6 +434,20 @@ public final class FServerManager {
                     ctx.close();
                 } else {
                     client.setIndex(index);
+                    // Warn if client version differs from host
+                    final String clientVersion = event.getVersion();
+                    final String hostVersion = BuildInfo.getVersionString();
+                    if (clientVersion == null) {
+                        broadcast(new MessageEvent(String.format(
+                            "Warning: Could not determine %s's Forge version. "
+                            + "Please use the same version as the host to avoid network compatibility issues.",
+                            event.getUsername())));
+                    } else if (!clientVersion.equals(hostVersion)) {
+                        broadcast(new MessageEvent(String.format(
+                            "Warning: %s is using Forge version %s (host: %s). "
+                            + "Please use the same version as the host to avoid network compatibility issues.",
+                            event.getUsername(), clientVersion, hostVersion)));
+                    }
                     broadcast(event);
                     updateLobbyState();
                 }


### PR DESCRIPTION
## Summary

- Client now sends its Forge version to the server as part of the login handshake
- Server compares client version against host version when a player joins
- If versions differ, a chat warning is displayed advising players to use the same version to avoid network compatibility issues

Requested by @tool4ever in #9642 — small standalone PR to give hosts visibility over potential version mismatches before they cause problems.

## Details

Adds a `version` field to `LoginEvent`, populated with `BuildInfo.getVersionString()`. The server checks it in `LobbyInputHandler` after the player is assigned a lobby slot. Three cases:

| Scenario | Result |
|----------|--------|
| Versions match | Silent (no message) |
| Versions differ | Warning: *"PlayerName is using Forge version X (host: Y). Please use the same version as the host to avoid network compatibility issues."* |
| Old client (no version field) | Warning: *"Could not determine PlayerName's Forge version..."* |

Backward compatible — `serialVersionUID` is unchanged, so old clients/servers handle the new field gracefully (defaults to `null`).

**3 files changed, +24 −2 lines.**

## Test plan

- [x] Compile check passes (0 checkstyle violations)
- [x] Manually tested version mismatch warning by hardcoding a fake version on the client
- [x] Simulated CI locally (`mvn -U -B clean test`) — all 13 modules pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)