### PR TITLE
Fix: Correctly locate LDAModelGenerator in forge-lda structure

### DIFF
--- a/forge-lda/src/forge/lda/LDAModelGenerator.java
+++ b/forge-lda/src/forge/lda/LDAModelGenerator.java
@@ -30,7 +30,7 @@ import static forge.lda.lda.inference.InferenceMethod.CGS;
 /**
  * Created by maustin on 09/05/2017.
  */
-public final class LDAModelGenetrator {
+public final class LDAModelGenerator {
 
     public static final String SUPPORTED_LDA_FORMATS = "Historic|Modern|Pioneer|Standard|Legacy|Vintage|Pauper";
     public static Map<String, Map<String,List<List<Pair<String, Double>>>>> ldaPools = new HashMap<>();


### PR DESCRIPTION
Moves LDAModelGenerator.java to the correct package structure and fixes the typo in filename.