### PR TITLE
Add options to set the user/cache dirs

### DIFF
--- a/docs/User-Guide.md
+++ b/docs/User-Guide.md
@@ -106,6 +106,9 @@ If you are using the Mac OS X version of Forge then you will find the forge.prof
 /Contents/Resources/Java/
 and you will find the file.
 
+The userDir's location may be changed by setting the environment variable "FORGE_USER_DIR" to the desired path. Likewise, the cache dir can be changed using the
+"FORGE_CACHE_DIR" environment variable.
+
 ## Import Data
 If you have a directory full of deck files, you can use the Import Data dialog to copy or move them to the appropriate directory. The dialog gives you a full listing of all file copy/move operations, so you can see what will happen before you click 'Start Import'.
 


### PR DESCRIPTION
This adds two new environment variables, `FORGE_USER_DIR` and `FORGE_CACHE_DIR` for overriding the default locations for user data.

For example, forge can be ran using:

```bash
FORGE_USER_DIR="$HOME/.local/state/forge" FORGE_CACHE_DIR="/tmp/forge" forge
```

To use alternate directories.

There should be no change in behaviour when neither of these vars are set.