### PR TITLE
CloneAi: fix Mandatory Trigger

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/CloneAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CloneAi.java
@@ -81,7 +81,7 @@ public class CloneAi extends SpellAbilityAi {
         boolean chance = true;
 
         if (sa.usesTargeting()) {
-            chance = cloneTgtAI(sa);
+            chance = cloneTgtAI(sa, false);
         }
 
         return chance ? new AiAbilityDecision(100, AiPlayDecision.WillPlay)


### PR DESCRIPTION
This should fix `Silent Hallcreeper` ignoring the last trigger

* we probably should be able to remove the AI logic like `CloneAttacker`
