### PR TITLE
Add vertical scrollbar to combat panel

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/screens/match/views/VCombat.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/views/VCombat.java
@@ -22,10 +22,13 @@ import forge.gui.framework.DragTab;
 import forge.gui.framework.EDocID;
 import forge.gui.framework.IVDoc;
 import forge.screens.match.controllers.CCombat;
+import forge.toolbox.FScrollPane;
 import forge.toolbox.FSkin;
 import forge.toolbox.FSkin.SkinnedTextArea;
 import forge.util.Localizer;
 import net.miginfocom.swing.MigLayout;
+
+import javax.swing.ScrollPaneConstants;
 
 /** 
  * Assembles Swing components of combat report.
@@ -39,6 +42,8 @@ public class VCombat implements IVDoc<CCombat> {
     private final DragTab tab = new DragTab(Localizer.getInstance().getMessage("lblCombatTab"));
 
     private final SkinnedTextArea tar = new SkinnedTextArea();
+    private final FScrollPane scroller = new FScrollPane(tar, false,
+            ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED, ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
 
     private final CCombat controller;
     public VCombat(final CCombat controller) {
@@ -59,7 +64,7 @@ public class VCombat implements IVDoc<CCombat> {
     public void populate() {
         parentCell.getBody().removeAll();
         parentCell.getBody().setLayout(new MigLayout("insets 0, gap 0, wrap"));
-        parentCell.getBody().add(tar, "w 95%!, gapleft 3%, gaptop 1%, h 95%");
+        parentCell.getBody().add(scroller, "w 95%!, gapleft 3%, gaptop 1%, h 95%");
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
<img width="50%" alt="Untitled" src="https://github.com/user-attachments/assets/0ebc1a41-b614-4b91-95cb-defc1aa27b95" />


## Summary
- The combat panel (`VCombat`) previously had no scrollbar — when combat information exceeded the panel height, content was clipped and not visible
- Wrapped the `SkinnedTextArea` in an `FScrollPane` with `VERTICAL_SCROLLBAR_AS_NEEDED`, matching the pattern used by other match panels (`VPrompt`, `VAntes`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)