### PR TITLE
Fix music volume resetting after window minimize/restore

### DIFF
--- a/forge-gui/src/main/java/forge/sound/SoundSystem.java
+++ b/forge-gui/src/main/java/forge/sound/SoundSystem.java
@@ -300,6 +300,7 @@ public class SoundSystem {
     public void resume() {
         shouldPlayMusic = true;
         updatePlayPause();
+        refreshVolume();
     }
 
     private void updatePlayPause() {


### PR DESCRIPTION
## Summary
- Fixes music volume reverting to default when the game window is minimized and restored, even though the slider shows the correct position
- The pause/resume cycle creates a new `VolumeAudioDevice` with default volume (1.0), discarding the user's setting. Adding `refreshVolume()` after `updatePlayPause()` in `SoundSystem.resume()` reapplies the saved preference.

Bug report: https://github.com/Card-Forge/forge/pull/9742#issuecomment-3907664507

## Test plan
- [ ] Set music volume to a low level via the Audio slider
- [ ] Minimize and restore the game window
- [ ] Verify volume remains at the user-set level without needing to touch the slider

🤖 Generated with [Claude Code](https://claude.com/claude-code)