### PR TITLE
CardView: rework BasicLand Watermark Properties

### DIFF
--- a/forge-game/src/main/java/forge/game/card/CardFactory.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactory.java
@@ -408,8 +408,7 @@ public class CardFactory {
 
         c.setAttractionLights(face.getAttractionLights());
 
-        if (c.getId() > 0) // Set FactoryAbilities if not for view
-            CardFactoryUtil.addAbilityFactoryAbilities(c, face.getAbilities());
+        CardFactoryUtil.addAbilityFactoryAbilities(c, face.getAbilities());
     }
 
     public static void copySpellAbility(SpellAbility from, SpellAbility to, final Card host, final Player p, final boolean lki, final boolean keepTextChanges) {

--- a/forge-game/src/main/java/forge/game/card/CardView.java
+++ b/forge-game/src/main/java/forge/game/card/CardView.java
@@ -1643,29 +1643,8 @@ public class CardView extends GameEntityView {
         public boolean origProduceAnyMana() {
             return get(TrackableProperty.OrigProduceAnyMana);
         }
-        public boolean origProduceManaR() {
-            return get(TrackableProperty.OrigProduceManaR);
-        }
-        public boolean origProduceManaG() {
-            return get(TrackableProperty.OrigProduceManaG);
-        }
-        public boolean origProduceManaB() {
-            return get(TrackableProperty.OrigProduceManaB);
-        }
-        public boolean origProduceManaU() {
-            return get(TrackableProperty.OrigProduceManaU);
-        }
-        public boolean origProduceManaW() {
-            return get(TrackableProperty.OrigProduceManaW);
-        }
-        public boolean origProduceManaC() {
-            return get(TrackableProperty.OrigProduceManaC);
-        }
-        public int origCanProduceColoredMana() {
-            return get(TrackableProperty.CountOrigProduceColoredMana);
-        }
-        public int countBasicLandTypes() {
-            return get(TrackableProperty.CountBasicLandTypes);
+        public ColorSet origProduceMana() {
+            return get(TrackableProperty.OrigProduceMana);
         }
 
         public String getAbilityText() {
@@ -1719,20 +1698,15 @@ public class CardView extends GameEntityView {
         }
         void updateManaColorBG(CardState state) {
             boolean anyMana = false;
-            boolean rMana = false;
-            boolean gMana = false;
-            boolean bMana = false;
-            boolean uMana = false;
-            boolean wMana = false;
             boolean cMana = false;
-            int count = 0;
-            int basicLandTypes = 0;
+            byte colors = 0;
             for (SpellAbility sa : state.getManaAbilities()) {
                 if (sa == null)
                     continue;
                 for (AbilityManaPart mp : sa.getAllManaParts()) {
                     if (mp.isAnyMana()) {
                         anyMana = true;
+                        continue;
                     }
 
                     String[] colorsProduced = mp.mana(sa).split(" ");
@@ -1741,62 +1715,28 @@ public class CardView extends GameEntityView {
                     for (final String s : colorsProduced) {
                         switch (s.toUpperCase()) {
                             case "R":
-                                if (!rMana) {
-                                    count += 1;
-                                    rMana = true;
-                                }
+                                colors |= MagicColor.RED;
                                 break;
                             case "G":
-                                if (!gMana) {
-                                    count += 1;
-                                    gMana = true;
-                                }
+                                colors |= MagicColor.GREEN;
                                 break;
                             case "B":
-                                if (!bMana) {
-                                    count += 1;
-                                    bMana = true;
-                                }
+                                colors |= MagicColor.BLACK;
                                 break;
                             case "U":
-                                if (!uMana) {
-                                    count += 1;
-                                    uMana = true;
-                                }
+                                colors |= MagicColor.BLUE;
                                 break;
                             case "W":
-                                if (!wMana) {
-                                    count += 1;
-                                    wMana = true;
-                                }
+                                colors |= MagicColor.WHITE;
                                 break;
                             case "C":
-                                if (!cMana) {
-                                    cMana = true;
-                                }
+                                cMana = true;
                                 break;
                         }
                     }
                 }
             }
-            if (isForest())
-                basicLandTypes += 1;
-            if (isMountain())
-                basicLandTypes += 1;
-            if (isSwamp())
-                basicLandTypes += 1;
-            if (isPlains())
-                basicLandTypes += 1;
-            if (isIsland())
-                basicLandTypes += 1;
-            set(TrackableProperty.CountBasicLandTypes, basicLandTypes);
-            set(TrackableProperty.OrigProduceManaR, rMana);
-            set(TrackableProperty.OrigProduceManaG, gMana);
-            set(TrackableProperty.OrigProduceManaB, bMana);
-            set(TrackableProperty.OrigProduceManaU, uMana);
-            set(TrackableProperty.OrigProduceManaW, wMana);
-            set(TrackableProperty.OrigProduceManaC, cMana);
-            set(TrackableProperty.CountOrigProduceColoredMana, count);
+            set(TrackableProperty.OrigProduceMana, colors > 0 ? ColorSet.fromMask(colors) : cMana ? ColorSet.C : null);
             set(TrackableProperty.OrigProduceAnyMana, anyMana);
         }
 
@@ -1821,21 +1761,6 @@ public class CardView extends GameEntityView {
 
         public boolean isBattle() {
             return getType().isBattle();
-        }
-        public boolean isMountain() {
-            return getType().hasSubtype("Mountain");
-        }
-        public boolean isPlains() {
-            return getType().hasSubtype("Plains");
-        }
-        public boolean isSwamp() {
-            return getType().hasSubtype("Swamp");
-        }
-        public boolean isForest() {
-            return getType().hasSubtype("Forest");
-        }
-        public boolean isIsland() {
-            return getType().hasSubtype("Island");
         }
         public boolean isVehicle() {
             return getType().hasSubtype("Vehicle");

--- a/forge-game/src/main/java/forge/trackable/TrackableProperty.java
+++ b/forge-game/src/main/java/forge/trackable/TrackableProperty.java
@@ -144,16 +144,8 @@ public enum TrackableProperty {
     ChangedTypes(TrackableTypes.StringMapType),
 
     //check produce mana for BG
-    OrigProduceManaR(TrackableTypes.BooleanType),
-    OrigProduceManaG(TrackableTypes.BooleanType),
-    OrigProduceManaB(TrackableTypes.BooleanType),
-    OrigProduceManaU(TrackableTypes.BooleanType),
-    OrigProduceManaW(TrackableTypes.BooleanType),
-    OrigProduceManaC(TrackableTypes.BooleanType),
+    OrigProduceMana(TrackableTypes.ColorSetType),
     OrigProduceAnyMana(TrackableTypes.BooleanType),
-    CountOrigProduceColoredMana(TrackableTypes.IntegerType),
-    //number of basic landtypes
-    CountBasicLandTypes(TrackableTypes.IntegerType),
 
     KeywordKey(TrackableTypes.StringType),
     HasAnnihilator(TrackableTypes.BooleanType),

--- a/forge-gui-desktop/src/main/java/forge/toolbox/CardFaceSymbols.java
+++ b/forge-gui-desktop/src/main/java/forge/toolbox/CardFaceSymbols.java
@@ -27,7 +27,6 @@ public class CardFaceSymbols {
     /** Constant <code>manaImages</code>. */
     private static final Map<String, SkinImage> MANA_IMAGES = new HashMap<>();
     private static final Map<String, SkinImage> DECK_COLORSET = new HashMap<>();
-    private static final Map<String, SkinImage> WATERMARKS = new HashMap<>();
 
     private static final int manaImageSize = 13;
 
@@ -37,13 +36,6 @@ public class CardFaceSymbols {
      * </p>
      */
     public static void loadImages() {
-        WATERMARKS.put("C", FSkin.getImage(FSkinProp.IMG_WATERMARK_C));
-        WATERMARKS.put("R", FSkin.getImage(FSkinProp.IMG_WATERMARK_R));
-        WATERMARKS.put("G", FSkin.getImage(FSkinProp.IMG_WATERMARK_G));
-        WATERMARKS.put("B", FSkin.getImage(FSkinProp.IMG_WATERMARK_B));
-        WATERMARKS.put("U", FSkin.getImage(FSkinProp.IMG_WATERMARK_U));
-        WATERMARKS.put("W", FSkin.getImage(FSkinProp.IMG_WATERMARK_W));
-
         DECK_COLORSET.put("C", FSkin.getImage(FSkinProp.IMG_MANA_COLORLESS));
         DECK_COLORSET.put("R", FSkin.getImage(FSkinProp.IMG_MANA_R));
         DECK_COLORSET.put("G", FSkin.getImage(FSkinProp.IMG_MANA_G));
@@ -283,12 +275,15 @@ public class CardFaceSymbols {
         FSkin.drawImage(g, MANA_IMAGES.get(imageName).resize(imageSize, imageSize),
             x, y, x + size, y + size, 0, 0, imageSize, imageSize);
     }
-    public static void drawWatermark(final String imageName, final Graphics g, final int x, final int y, final int size) {
+    public static void drawWatermark(final FSkinProp skinProp, final Graphics g, final int x, final int y, final int size) {
+        if (skinProp == null) {
+            return;
+        }
         // Obtain screen DPI scale
         float screenScale = GuiBase.getInterface().getScreenScale();
         int imageSize = Math.round(size * screenScale);
 
-        FSkin.drawImage(g, WATERMARKS.get(imageName).resize(imageSize, imageSize),
+        FSkin.drawImage(g, FSkin.getImage(skinProp).resize(imageSize, imageSize),
             x, y, x + size, y + size, 0, 0, imageSize, imageSize);
     }
     public static void drawAbilitySymbol(final String imageName, final Graphics g, final int x, final int y, final int w, final int h) {

--- a/forge-gui-mobile/src/forge/assets/FSkin.java
+++ b/forge-gui-mobile/src/forge/assets/FSkin.java
@@ -10,6 +10,7 @@ import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.utils.Array;
 import forge.Forge;
 import forge.card.CardFaceSymbols;
+import forge.card.MagicColor;
 import forge.gui.FThreads;
 import forge.gui.GuiBase;
 import forge.localinstance.properties.ForgeConstants;
@@ -380,6 +381,12 @@ public class FSkin {
                 }
             }
             for (FSkinProp prop : FSkinProp.MANA_IMG.values()) {
+                FSkinImageImpl image = new FSkinImageImpl(prop);
+                image.load(preferredIcons);
+                FSkin.getImages().put(prop, image);
+            }
+            for (MagicColor.Color c : MagicColor.Color.values()) {
+                FSkinProp prop = FSkinProp.watermarkFromColor(c);
                 FSkinImageImpl image = new FSkinImageImpl(prop);
                 image.load(preferredIcons);
                 FSkin.getImages().put(prop, image);

--- a/forge-gui-mobile/src/forge/assets/FSkinImage.java
+++ b/forge-gui-mobile/src/forge/assets/FSkinImage.java
@@ -56,14 +56,6 @@ public enum FSkinImage implements FSkinImageInterface {
     SET_MYTHIC     (FSkinProp.IMG_SETLOGO_MYTHIC),
     SET_SPECIAL    (FSkinProp.IMG_SETLOGO_SPECIAL),
 
-    //Watermarks
-    WATERMARK_G    (FSkinProp.IMG_WATERMARK_G),
-    WATERMARK_R    (FSkinProp.IMG_WATERMARK_R),
-    WATERMARK_B    (FSkinProp.IMG_WATERMARK_B),
-    WATERMARK_U    (FSkinProp.IMG_WATERMARK_U),
-    WATERMARK_W    (FSkinProp.IMG_WATERMARK_W),
-    WATERMARK_C    (FSkinProp.IMG_WATERMARK_C),
-
     //draft ranks
     DRAFTRANK_D (FSkinProp.IMG_DRAFTRANK_D),
     DRAFTRANK_C (FSkinProp.IMG_DRAFTRANK_C),

--- a/forge-gui/src/main/java/forge/gui/card/CardDetailUtil.java
+++ b/forge-gui/src/main/java/forge/gui/card/CardDetailUtil.java
@@ -99,22 +99,9 @@ public class CardDetailUtil {
             }
             else { //for 3 colors or fewer, return all colors in shard order
                 for (MagicColor.Color shard : cardColors.getOrderedColors()) {
-                    switch (shard.getColorMask()) {
-                    case MagicColor.WHITE:
-                        borderColors.add(DetailColors.WHITE);
-                        break;
-                    case MagicColor.BLUE:
-                        borderColors.add(DetailColors.BLUE);
-                        break;
-                    case MagicColor.BLACK:
-                        borderColors.add(DetailColors.BLACK);
-                        break;
-                    case MagicColor.RED:
-                        borderColors.add(DetailColors.RED);
-                        break;
-                    case MagicColor.GREEN:
-                        borderColors.add(DetailColors.GREEN);
-                        break;
+                    DetailColors colors = getColor(shard);
+                    if (colors != null) {
+                        borderColors.add(colors);
                     }
                 }
             }
@@ -124,6 +111,16 @@ public class CardDetailUtil {
             borderColors.add(DetailColors.UNKNOWN);
         }
         return borderColors;
+    }
+    public static DetailColors getColor(MagicColor.Color shard) {
+        return switch (shard) {
+            case WHITE -> DetailColors.WHITE;
+            case BLUE -> DetailColors.BLUE;
+            case BLACK -> DetailColors.BLACK;
+            case RED -> DetailColors.RED;
+            case GREEN -> DetailColors.GREEN;
+            default -> null;
+        };
     }
 
     public static String getCurrentColors(final CardStateView c) {

--- a/forge-gui/src/main/java/forge/localinstance/skin/FSkinProp.java
+++ b/forge-gui/src/main/java/forge/localinstance/skin/FSkinProp.java
@@ -768,6 +768,17 @@ public enum FSkinProp {
         };
     }
 
+    public static FSkinProp watermarkFromColor(MagicColor.Color color) {
+        return switch (color) {
+            case WHITE -> IMG_WATERMARK_W;
+            case BLUE -> IMG_WATERMARK_U;
+            case BLACK -> IMG_WATERMARK_B;
+            case RED -> IMG_WATERMARK_R;
+            case GREEN -> IMG_WATERMARK_G;
+            case COLORLESS -> IMG_WATERMARK_C;
+        };
+    }
+
     public enum PropType {
         BACKGROUND(null),
         COLOR(null),


### PR DESCRIPTION
Part of #8682 

i noticed that the check for `addAbilityFactoryAbilities` was messing with getCardForUI, where `getManaAbilities` was empty.
so it failed for `Wastes`, somehow

(we need to refactor getCardForUI in the future anyway)