### PR TITLE
Add User Guide link to online multiplayer connect dialog

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/toolbox/FOptionPane.java
+++ b/forge-gui-desktop/src/main/java/forge/toolbox/FOptionPane.java
@@ -1,6 +1,7 @@
 package forge.toolbox;
 
 import java.awt.Component;
+import java.awt.Desktop;
 import java.awt.Dimension;
 import java.awt.FontMetrics;
 import java.awt.event.KeyAdapter;
@@ -10,6 +11,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
 
 import javax.swing.*;
+import javax.swing.event.HyperlinkEvent;
 import javax.swing.text.StyleConstants;
 
 import com.google.common.collect.ImmutableList;
@@ -198,8 +200,18 @@ public class FOptionPane extends FDialog {
             prompt = new FTextPane();
             prompt.setContentType("text/html");
             prompt.putClientProperty(JEditorPane.HONOR_DISPLAY_PROPERTIES, Boolean.TRUE);
+            final java.awt.Color textColor = FSkin.getColor(FSkin.Colors.CLR_TEXT).getColor();
+            final String hex = String.format("#%02x%02x%02x", textColor.getRed(), textColor.getGreen(), textColor.getBlue());
+            ((javax.swing.text.html.HTMLEditorKit) prompt.getEditorKit()).getStyleSheet()
+                    .addRule("a { color: " + hex + "; }");
             prompt.setText(FSkin.encodeSymbols(message, false));
             prompt.setFont(FSkin.getFont(14));
+            prompt.addHyperlinkListener(e -> {
+                if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
+                    try { Desktop.getDesktop().browse(e.getURL().toURI()); }
+                    catch (final Exception ex) { ex.printStackTrace(); }
+                }
+            });
             if(centeredLabel != null)
                 prompt.setTextAlignment(StyleConstants.ALIGN_CENTER);
             final Dimension parentSize = JOptionPane.getRootFrame().getSize();

--- a/forge-gui/res/languages/en-US.properties
+++ b/forge-gui/res/languages/en-US.properties
@@ -3052,7 +3052,7 @@ lblUnableStartServerPortAlreadyUse=Unable to start server, port already in use!
 lblStartingServer=Starting server...
 lblConnectingToServer=Connecting to server...
 #NetConnectUtil.java
-lblOnlineMultiplayerDest=This feature is under active development.\nYou are likely to find bugs.\n\n - = * H E R E   B E   E L D R A Z I * = -\n\nEnter the URL of the server to join.\nLeave blank to host your own server.
+lblOnlineMultiplayerDest=This feature is under active development.\nYou are likely to find bugs.\n\n - = * H E R E   B E   E L D R A Z I * = -\n\nEnter the URL of the server to join.\nLeave blank to host your own server.\n\nSee the <a href="https://github.com/Card-Forge/forge/wiki/network-play">User Guide</a> for network configuration help.
 lblHostingPortOnN=Hosting on port {0}.
 lblShareURLToMakePlayerJoinServer=Share the following URL with anyone who wishes to join your server. It has been copied to your clipboard for convenience.\n\n{0}\n\nFor internal games, use the following URL: {1}
 lblForgeUnableDetermineYourExternalIP=Forge was unable to determine your external IP!\n\n{0}


### PR DESCRIPTION
Many of the network issues reported in the Discord could be avoided if people read the user guide re: port forwarding etc. I have had to link people to the user guide several times just today.

<img width="40%" alt="Screenshot 2026-02-18 073500" src="https://github.com/user-attachments/assets/ca3f4587-be27-40e9-90fe-eb754e9e51d9" />

## Summary
- Adds a clickable "User Guide" hyperlink to the Network Play wiki page in the "Here Be Eldrazi" online multiplayer connection dialog
- Adds theme-aware hyperlink support to `FOptionPane` so link colors match the active skin (uses `CLR_TEXT` via CSS stylesheet rule)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)