### PR TITLE
Fix card name parsing in getCardByName for allCardVariants mode

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/data/RewardData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/RewardData.java
@@ -6,6 +6,7 @@ import forge.ImageKeys;
 import forge.StaticData;
 import forge.adventure.util.*;
 import forge.adventure.world.WorldSave;
+import forge.card.CardDb;
 import forge.card.CardEdition;
 import forge.deck.Deck;
 import forge.item.PaperCard;
@@ -181,8 +182,15 @@ public class RewardData implements Serializable {
                     HashSet<PaperCard> pool = new HashSet<>();
                     for (RewardData r : cardUnion) {
                         if (r.cardName != null && !r.cardName.isEmpty() ) {
-                            PaperCard pc = allCardVariants ? CardUtil.getCardByName(r.cardName)
-                                : StaticData.instance().getCommonCards().getCard(r.cardName);
+                            PaperCard pc;
+                            if (allCardVariants) {
+                                CardDb.CardRequest req = CardDb.CardRequest.fromString(r.cardName);
+                                pc = (req.edition != null)
+                                    ? CardUtil.getCardByNameAndEdition(req.cardName, req.edition)
+                                    : CardUtil.getCardByName(req.cardName);
+                            } else {
+                                pc = StaticData.instance().getCommonCards().getCard(r.cardName);
+                            }
                             if (pc != null)
                                 pool.add(pc);
                         } else if (r.sourceDeck != null && !r.sourceDeck.isEmpty() ) {
@@ -214,10 +222,13 @@ public class RewardData implements Serializable {
                 case "randomCard":
                     if (cardName != null && !cardName.isEmpty()) {
                         if (allCardVariants) {
-                            PaperCard card = CardUtil.getCardByName(cardName);
+                            CardDb.CardRequest request = CardDb.CardRequest.fromString(cardName);
+                            PaperCard card = (request.edition != null)
+                                ? CardUtil.getCardByNameAndEdition(request.cardName, request.edition)
+                                : CardUtil.getCardByName(request.cardName);
                             if (card != null) {
                                 for (int i = 0; i < count + addedCount; i++) {
-                                    PaperCard finalCard = CardUtil.getCardByNameAndEdition(cardName, card.getEdition());
+                                    PaperCard finalCard = CardUtil.getCardByNameAndEdition(request.cardName, card.getEdition());
                                     if (finalCard != null)
                                         ret.add(new Reward(finalCard, isNoSell));
                                 }

--- a/forge-gui-mobile/src/forge/adventure/util/CardUtil.java
+++ b/forge-gui-mobile/src/forge/adventure/util/CardUtil.java
@@ -770,16 +770,6 @@ public class CardUtil {
     }
 
     public static PaperCard getCardByName(String cardName) {
-        // Parse edition suffix if present (e.g., "Card Name|SET" -> name "Card Name", edition "SET")
-        // getAllCards() expects just the card name, unlike getCard() which parses the full format.
-        String lookupName = cardName;
-        String requestedEdition = null;
-        int separatorIndex = cardName.indexOf(CardDb.NameSetSeparator);
-        if (separatorIndex >= 0) {
-            lookupName = cardName.substring(0, separatorIndex);
-            requestedEdition = cardName.substring(separatorIndex + 1);
-        }
-
         List<PaperCard> validCards;
         // Faster to ask the CardDB for a card name than it is to search the pool.
         if (Config.instance().getSettingData().useAllCardVariants) {
@@ -795,36 +785,18 @@ public class CardUtil {
             if (Config.instance().getSettingData().excludeAlchemyVariants) {
                 combined_predicate = editionFilter.and(PaperCardPredicates.IS_REBALANCED.negate());
             }
-            validCards = FModel.getMagicDb().getCommonCards().getAllCards(lookupName, combined_predicate);
+            validCards = FModel.getMagicDb().getCommonCards().getAllCards(cardName, combined_predicate);
         } else {
-            validCards = FModel.getMagicDb().getCommonCards().getUniqueCardsNoAlt(lookupName);
+            validCards = FModel.getMagicDb().getCommonCards().getUniqueCardsNoAlt(cardName);
         }
         if (validCards.isEmpty()) {
             return getReplacement(cardName, "Wastes");
-        }
-
-        // If a specific edition was requested, prefer cards from that edition.
-        if (requestedEdition != null) {
-            String editionToMatch = requestedEdition;
-            List<PaperCard> editionCards = validCards.stream()
-                    .filter(card -> card.getEdition().equals(editionToMatch))
-                    .collect(Collectors.toList());
-            if (!editionCards.isEmpty()) {
-                return editionCards.get(Current.world().getRandom().nextInt(editionCards.size()));
-            }
         }
 
         return validCards.get(Current.world().getRandom().nextInt(validCards.size()));
     }
 
     public static PaperCard getCardByNameAndEdition(String cardName, String edition) {
-        // Parse card name for DB lookup (getAllCards expects name without "|SET" suffix).
-        String lookupName = cardName;
-        int separatorIndex = cardName.indexOf(CardDb.NameSetSeparator);
-        if (separatorIndex >= 0) {
-            lookupName = cardName.substring(0, separatorIndex);
-        }
-
         ConfigData configData = Config.instance().getConfigData();
         if (configData.allowedEditions != null && configData.allowedEditions.length > 0) {
             if (!Arrays.asList(configData.allowedEditions).contains(edition)) {
@@ -836,8 +808,8 @@ public class CardUtil {
             }
         }
         List<PaperCard> cardPool = Config.instance().getSettingData().useAllCardVariants
-                ? FModel.getMagicDb().getCommonCards().getAllCards(lookupName)
-                : FModel.getMagicDb().getCommonCards().getUniqueCardsNoAlt(lookupName);
+                ? FModel.getMagicDb().getCommonCards().getAllCards(cardName)
+                : FModel.getMagicDb().getCommonCards().getUniqueCardsNoAlt(cardName);
         List<PaperCard> validCards = cardPool.stream()
                 .filter(input -> input.getEdition().equals(edition)).collect(Collectors.toList());
 


### PR DESCRIPTION
## Summary

Follow-up fix for #9798. When `useAllCardVariants` is enabled, `getCardByName()` and `getCardByNameAndEdition()` receive card names in `"Name|SET"` format (e.g., `"Verdeloth the Ancient|INV"`) from reward/shop JSON data. However, unlike `CardDb.getCard()` which parses this format via `CardRequest.fromString()`, `CardDb.getAllCards()` does a direct map lookup by card name — so `"Verdeloth the Ancient|INV"` matches nothing, and every card reward silently falls back to Wastes.

**Changes:**
- Parse the `|SET` suffix in `getCardByName()` before passing to `getAllCards()`/`getUniqueCardsNoAlt()`
- When an edition is specified, prefer cards from that edition (falling back to any allowed printing if unavailable)
- Same name parsing in `getCardByNameAndEdition()` for its `getAllCards()` lookup

**Not affected:** Callers passing plain card names (from `PaperCard.getCardName()`, land generation, SpellSmith) — no `|` separator means no parsing occurs, identical behavior to before.