### PR TITLE
Add Server URL dialog button, copy internal/external URL buttons

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/screens/home/online/VSubmenuOnlineLobby.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/online/VSubmenuOnlineLobby.java
@@ -5,6 +5,7 @@ import javax.swing.JPanel;
 import forge.deckchooser.FDeckChooser;
 import forge.gamemodes.match.GameLobby;
 import forge.gamemodes.net.IOnlineLobby;
+import forge.gamemodes.net.NetConnectUtil;
 import forge.gamemodes.net.client.FGameClient;
 import forge.gamemodes.net.server.FServerManager;
 import forge.gui.FNetOverlay;
@@ -82,7 +83,14 @@ public enum VSubmenuOnlineLobby implements IVSubmenu<CSubmenuOnlineLobby>, IOnli
         lobby.getLblTitle().setText(Localizer.getInstance().getMessage("lblOnlineLobbyTitle"));
         pnlTitle.removeAll();
         pnlTitle.setOpaque(false);
-        pnlTitle.add(lobby.getLblTitle(), "w 95%, h 40px!, gap 0 0 15px 15px, span 2");
+        final boolean hosting = FServerManager.getInstance().isHosting();
+        pnlTitle.add(lobby.getLblTitle(), "w 95%, h 40px!, gap 0 0 15px 15px, span " + (hosting ? "3" : "2"));
+        if (hosting) {
+            FButton btnServerUrl = new FButton(Localizer.getInstance().getMessage("lblServerURL"));
+            btnServerUrl.setFont(FSkin.getRelativeFont(14));
+            pnlTitle.add(btnServerUrl, "w 150!, h 35!, gap 10 10 0 0, align right");
+            btnServerUrl.addActionListener(e -> NetConnectUtil.copyHostedServerUrl());
+        }
         pnlTitle.add(btnStop, "gap 10 10 0 0, align right");
         container.add(pnlTitle,"w 80%, gap 0 0 0 0, al right, pushx");
 

--- a/forge-gui/res/languages/en-US.properties
+++ b/forge-gui/res/languages/en-US.properties
@@ -3065,9 +3065,11 @@ lblConnectingToServer=Connecting to server...
 #NetConnectUtil.java
 lblOnlineMultiplayerDest=This feature is under active development.\nYou are likely to find bugs.\n\n - = * H E R E   B E   E L D R A Z I * = -\n\nEnter the URL of the server to join.\nLeave blank to host your own server.
 lblHostingPortOnN=Hosting on port {0}.
-lblShareURLToMakePlayerJoinServer=Share the following URL with anyone who wishes to join your server. It has been copied to your clipboard for convenience.\n\n{0}\n\nFor internal games, use the following URL: {1}
-lblForgeUnableDetermineYourExternalIP=Forge was unable to determine your external IP!\n\n{0}
+lblShareURLToMakePlayerJoinServer=Share a URL below with anyone who wishes to join your server.\nThe external URL has been copied to your clipboard.\n\nExternal URL (for players outside your network):\n{0}\n\nLocal URL (for players on your network):\n{1}
+lblForgeUnableDetermineYourExternalIP=Forge was unable to determine your external IP.\nThe local URL has been copied to your clipboard.\n\nLocal URL (for players on your network):\n{0}
 lblServerURL=Server URL
+lblCopyExternalURL=Copy External URL
+lblCopyLocalURL=Copy Local URL
 lblYourConnectionToHostWasInterrupted=Your connection to the host ({0}) was interrupted.
 lblConnectedIPPort=Connected to {0}:{1}
 #FServerManager.java

--- a/forge-gui/src/main/java/forge/gamemodes/net/NetConnectUtil.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/NetConnectUtil.java
@@ -24,6 +24,8 @@ import forge.util.Localizer;
 import forge.util.URLValidator;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.List;
+
 import static forge.util.URLValidator.parseURL;
 
 public class NetConnectUtil {
@@ -106,6 +108,7 @@ public class NetConnectUtil {
     }
 
     public static void copyHostedServerUrl() {
+        final Localizer localizer = Localizer.getInstance();
         String internalAddress = FServerManager.getLocalAddress();
         String externalAddress = FServerManager.getExternalAddress();
         String internalUrl = internalAddress + ":" + FModel.getNetPreferences().getPrefInt(ForgeNetPreferences.FNetPref.NET_PORT);
@@ -114,16 +117,42 @@ public class NetConnectUtil {
             externalUrl = externalAddress + ":" + FModel.getNetPreferences().getPrefInt(ForgeNetPreferences.FNetPref.NET_PORT);
             GuiBase.getInterface().copyToClipboard(externalUrl);
         } else {
-            GuiBase.getInterface().copyToClipboard(internalAddress);
+            GuiBase.getInterface().copyToClipboard(internalUrl);
         }
 
-        String message = "";
+        String message;
+        String title = localizer.getMessage("lblServerURL");
+        List<String> options;
+        int closeIndex;
+        int localCopyIndex;
+
         if (externalUrl != null) {
-            message = Localizer.getInstance().getMessage("lblShareURLToMakePlayerJoinServer", externalUrl, internalUrl);
+            message = localizer.getMessage("lblShareURLToMakePlayerJoinServer", externalUrl, internalUrl);
+            options = List.of(
+                    localizer.getMessage("lblCopyExternalURL"),
+                    localizer.getMessage("lblCopyLocalURL"),
+                    localizer.getMessage("lblClose"));
+            closeIndex = 2;
+            localCopyIndex = 1;
         } else {
-            message = Localizer.getInstance().getMessage("lblForgeUnableDetermineYourExternalIP", message + internalUrl);
+            message = localizer.getMessage("lblForgeUnableDetermineYourExternalIP", internalUrl);
+            options = List.of(
+                    localizer.getMessage("lblCopyLocalURL"),
+                    localizer.getMessage("lblClose"));
+            closeIndex = 1;
+            localCopyIndex = 0;
         }
-        SOptionPane.showMessageDialog(message, Localizer.getInstance().getMessage("lblServerURL"), SOptionPane.INFORMATION_ICON);
+
+        while (true) {
+            int result = SOptionPane.showOptionDialog(message, title, SOptionPane.INFORMATION_ICON, options, closeIndex);
+            if (externalUrl != null && result == 0) {
+                GuiBase.getInterface().copyToClipboard(externalUrl);
+            } else if (result == localCopyIndex) {
+                GuiBase.getInterface().copyToClipboard(internalUrl);
+            } else {
+                break;
+            }
+        }
     }
 
     public static ChatMessage join(final String url, final IOnlineLobby onlineLobby, final IOnlineChatInterface chatInterface) {


### PR DESCRIPTION
It seems currently there's no way to get the Server URL screen back once you close it, and you can't choose whether to copy the internal or external URL. This addresses both issues.

--

<img width="1196" height="476" alt="Screenshot 2026-02-20 134616" src="https://github.com/user-attachments/assets/d2ce6bfe-dd70-4351-a02b-0ee070cf9f23" />
<img width="748" height="320" alt="Screenshot 2026-02-20 134554" src="https://github.com/user-attachments/assets/672ac79b-098b-42d6-b5b4-f5b5ab5a1267" />

## Summary
- New host-only "Server URL" button in the desktop lobby title bar to re-open dialog after its closed.
- Server URL dialog now has dedicated "Copy External URL" / "Copy Local URL" buttons instead of a single OK
- Fixed local-only fallback copying just the IP instead of the full URL with port

## Test plan
- Host a server, verify dialog shows with labeled URLs and copy buttons
- Click each copy button, verify clipboard contents and dialog re-shows
- Click Close, verify dialog dismisses
- Verify "Server URL" button appears in lobby (host only, not for clients)
- Click "Server URL" button, verify dialog re-appears