### PR TITLE
Fix host chat messages appearing twice

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/net/NetConnectUtil.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/NetConnectUtil.java
@@ -89,7 +89,6 @@ public class NetConnectUtil {
                     if (server.handleCommand(message.getMessage())) {
                         return;
                     }
-                    chatInterface.addMessage(new ChatMessage(message.getSource(), message.getMessage()));
                     server.broadcast(event);
                 }
             }


### PR DESCRIPTION
Fixes issue reported in Discord network play channel.

## Summary
- Remove redundant `addMessage()` call in host's chat send path
- `broadcast()` already echoes the message back to the host's lobby listener, so the direct add was a duplicate

## Test plan
- Host a server, send chat messages, verify each appears only once