### PR TITLE
Adventure: Show ante results popup after battle

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/scene/DuelScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/DuelScene.java
@@ -7,6 +7,9 @@ import com.google.common.collect.ImmutableList;
 import forge.Forge;
 import forge.Graphics;
 import forge.LobbyPlayer;
+import forge.card.CardRenderer;
+import forge.card.CardRenderer.CardStackPosition;
+import forge.card.CardZoom;
 import forge.adventure.character.EnemySprite;
 import forge.adventure.character.PlayerSprite;
 import forge.adventure.data.*;
@@ -20,6 +23,7 @@ import forge.adventure.util.Current;
 import forge.assets.FBufferedImage;
 import forge.assets.FSkin;
 import forge.deck.*;
+import forge.game.card.CardView;
 import forge.game.GameRules;
 import forge.game.GameType;
 import forge.game.player.Player;
@@ -41,6 +45,8 @@ import forge.screens.TransitionScreen;
 import forge.screens.match.MatchController;
 import forge.sound.MusicPlaylist;
 import forge.sound.SoundSystem;
+import forge.toolbox.FCardPanel;
+import forge.toolbox.FDisplayObject;
 import forge.toolbox.FOptionPane;
 import forge.trackable.TrackableCollection;
 import forge.util.Aggregates;
@@ -97,6 +103,8 @@ public class DuelScene extends ForgeScene {
         if (eventData != null)
             eventData.nextOpponent = null;
         boolean winner = false;
+        List<PaperCard> anteWonCards = Collections.emptyList();
+        List<PaperCard> anteLostCards = Collections.emptyList();
         try {
             winner = humanPlayer == hostedMatch.getGame().getMatch().getWinner();
 
@@ -134,6 +142,8 @@ public class DuelScene extends ForgeScene {
                         Current.player().removeLostCardFromPools(card);
                     }
                 }
+                anteWonCards = new ArrayList<>(anteResult.wonCards);
+                anteLostCards = new ArrayList<>(anteResult.lostCards);
             }
         } catch (Exception e) {
             e.printStackTrace();
@@ -142,27 +152,45 @@ public class DuelScene extends ForgeScene {
         String insult = enemy.getBossInsult();
         boolean showMessages = enemy.getData().boss || (enemy.getData().copyPlayerDeck && Current.player().isUsingCustomDeck());
         Current.player().clearBlessing();
-        if ((chaosBattle || showMessages) && !winner) {
-            final FBufferedImage fb = getFBEnemyAvatar();
-            callbackExit = true;
-            boolean finalWinner = winner;
-            if (insult != null){
-            bossDialogue = createFOption((insult), enemyName, fb, () -> {afterGameEnd(enemyName, finalWinner);
-                        exitDuelScene();
-                        fb.dispose();
-                    });
-            }
-            else {
-            	bossDialogue = createFOption(Forge.getLocalizer().getMessage("AdvBossInsult" + Aggregates.randomInt(1, 44)), enemyName, fb, () ->
-            	{afterGameEnd(enemyName, finalWinner);
-                            exitDuelScene();
-                            fb.dispose();
-            	});
-            }
-            FThreads.invokeInEdtNowOrLater(() -> bossDialogue.show());
+
+        boolean finalWinner = winner;
+        boolean isBossLoss = (chaosBattle || showMessages) && !finalWinner;
+        boolean hasAnteResults = !anteWonCards.isEmpty() || !anteLostCards.isEmpty();
+
+        // No popups needed, preserve original behavior
+        if (!hasAnteResults && !isBossLoss) {
+            afterGameEnd(enemyName, finalWinner);
+            return;
         }
-            else {
-            afterGameEnd(enemyName, winner);
+
+        // Build popup chain: ante results -> boss dialogue -> exit
+        callbackExit = true;
+        Runnable exitChain = () -> {
+            afterGameEnd(enemyName, finalWinner);
+            exitDuelScene();
+        };
+
+        Runnable afterAnte;
+        if (isBossLoss) {
+            afterAnte = () -> {
+                final FBufferedImage fb = getFBEnemyAvatar();
+                String bossInsultMsg = insult != null ? insult
+                        : Forge.getLocalizer().getMessage("AdvBossInsult" + Aggregates.randomInt(1, 44));
+                bossDialogue = createFOption(bossInsultMsg,
+                        enemyName, fb, () -> {
+                            exitChain.run();
+                            fb.dispose();
+                        });
+                FThreads.invokeInEdtNowOrLater(() -> bossDialogue.show());
+            };
+        } else {
+            afterAnte = exitChain;
+        }
+
+        if (hasAnteResults) {
+            showAnteResults(anteWonCards, anteLostCards, afterAnte);
+        } else {
+            afterAnte.run();
         }
     }
 
@@ -195,6 +223,66 @@ public class DuelScene extends ForgeScene {
             if (runnable != null)
                 runnable.run();
         });
+    }
+
+    private void showAnteResults(List<PaperCard> wonCards, List<PaperCard> lostCards, Runnable onDone) {
+        // Show won cards one at a time, then lost cards, then continue
+        showAnteCardsSequentially(wonCards, 0, true, () ->
+            showAnteCardsSequentially(lostCards, 0, false, onDone));
+    }
+
+    private void showAnteCardsSequentially(List<PaperCard> cards, int index, boolean won, Runnable onDone) {
+        if (index >= cards.size()) {
+            onDone.run();
+            return;
+        }
+        PaperCard card = cards.get(index);
+        Runnable next = () -> showAnteCardsSequentially(cards, index + 1, won, onDone);
+        showAnteCardPopup(won ? "Card Gained" : "Card Lost", card, won, next);
+    }
+
+    private void showAnteCardPopup(String title, PaperCard card, boolean won, Runnable onDone) {
+        CardView cardView = CardView.getCardForUi(card);
+
+        FDisplayObject cardDisplay = new FDisplayObject() {
+            @Override
+            public boolean tap(float x, float y, int count) {
+                CardZoom.show(cardView);
+                return true;
+            }
+            @Override
+            public boolean longPress(float x, float y) {
+                CardZoom.show(cardView);
+                return true;
+            }
+            @Override
+            public void draw(Graphics g) {
+                float h = getHeight();
+                float w = h / FCardPanel.ASPECT_RATIO;
+                float xPos = (getWidth() - w) / 2;
+                CardRenderer.drawCard(g, cardView, xPos, 0, w, h, CardStackPosition.Top, true);
+            }
+        };
+        cardDisplay.setHeight(Forge.getScreenHeight() / 3);
+
+        String message = card.getName();
+        List<String> buttons;
+        if (won && eventData == null) {
+            int sellPrice = Current.player().cardSellPrice(card);
+            buttons = sellPrice > 0
+                    ? ImmutableList.of(Forge.getLocalizer().getMessage("lblOK"), "Auto-Sell (" + sellPrice + " gold)")
+                    : ImmutableList.of(Forge.getLocalizer().getMessage("lblOK"));
+        } else {
+            buttons = ImmutableList.of(Forge.getLocalizer().getMessage("lblOK"));
+        }
+
+        FOptionPane popup = new FOptionPane(message, null, title, null, cardDisplay, buttons, 0, result -> {
+            if (won && result == 1) {
+                Current.player().autoSellCards.add(card);
+            }
+            if (onDone != null) onDone.run();
+        });
+        FThreads.invokeInEdtNowOrLater(popup::show);
     }
 
     void addEffects(RegisteredPlayer player, Array<EffectData> effects) {


### PR DESCRIPTION
- After a game with ante enabled, a popup now shows each card won or lost, with the full card image rendered and tappable to zoom
- Won cards include an "Auto-Sell" button showing the gold value, which marks the card for auto-sell (same behavior as the reward scene toggle)
- Supports multiple cards from ownership-change effects (Bronze Tablet, Darkpact, etc.) by showing one popup per card sequentially
- Refactored the post-game popup chain (ante results -> boss dialogue -> exit) for clearer control flow

Works well in testing so far.