### PR TITLE
CardFactoryUtil: unkeyword Adapt

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/CountersMoveAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CountersMoveAi.java
@@ -319,7 +319,7 @@ public class CountersMoveAi extends SpellAbilityAi {
                     // try to remove P1P1 from undying or evolve
                     if (cType != null && cType.is(CounterEnumType.P1P1)) {
                         if (card.hasKeyword(Keyword.UNDYING) || card.hasKeyword(Keyword.EVOLVE)
-                                || card.hasKeyword(Keyword.ADAPT)) {
+                                || card.getNonManaAbilities().anyMatch(ab -> ab.hasParam("Adapt"))) {
                             return true;
                         }
                     }

--- a/forge-ai/src/main/java/forge/ai/ability/CountersRemoveAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CountersRemoveAi.java
@@ -298,7 +298,7 @@ public class CountersRemoveAi extends SpellAbilityAi {
         if (mandatory) {
             if (type.equals("P1P1")) {
                 // Try to target creatures with Adapt or similar
-                CardCollection adaptCreats = CardLists.filter(list, CardPredicates.hasKeyword(Keyword.ADAPT));
+                CardCollection adaptCreats = CardLists.filter(list, c -> c.getNonManaAbilities().anyMatch(ab -> ab.hasParam("Adapt")));
                 if (!adaptCreats.isEmpty()) {
                     sa.getTargets().add(ComputerUtilCard.getWorstAI(adaptCreats));
                     return new AiAbilityDecision(100, AiPlayDecision.WillPlay);

--- a/forge-game/src/main/java/forge/game/ability/AbilityFactory.java
+++ b/forge-game/src/main/java/forge/game/ability/AbilityFactory.java
@@ -221,29 +221,6 @@ public final class AbilityFactory {
             spellAbility.setCardState(state);
         }
 
-        if (mapParams.containsKey("Forecast")) {
-            spellAbility.putParam("ActivationZone", "Hand");
-            spellAbility.putParam("ActivationLimit", "1");
-            spellAbility.putParam("ActivationPhases", "Upkeep");
-            spellAbility.putParam("PlayerTurn", "True");
-            spellAbility.putParam("PrecostDesc", "Forecast — ");
-        }
-        if (spellAbility.isBoast()) {
-            spellAbility.putParam("PresentDefined", "Self");
-            spellAbility.putParam("IsPresent", "Card.attackedThisTurn");
-            spellAbility.putParam("PrecostDesc", "Boast — ");
-        }
-        if (spellAbility.isExhaust()) {
-            spellAbility.putParam("PrecostDesc", "Exhaust — ");
-        }
-        if (spellAbility.isPowerUp()) {
-            spellAbility.putParam("PrecostDesc", "Power-Up — ");
-        }
-
-        if (mapParams.containsKey("Named")) {
-            spellAbility.setName(mapParams.get("Named"));
-        }
-
         // *********************************************
         // set universal properties of the SpellAbility
 
@@ -296,7 +273,7 @@ public final class AbilityFactory {
         if (spellAbility instanceof SpellApiBased && hostCard.isPermanent()) {
             String desc = mapParams.getOrDefault("SpellDescription", spellAbility.getHostCard().getName());
             spellAbility.setDescription(desc);
-        } else if (mapParams.containsKey("SpellDescription")) {
+        } else if (spellAbility.hasParam("SpellDescription")) {
             spellAbility.rebuiltDescription();
         } else if (api == ApiType.Charm) {
             spellAbility.setDescription(CharmEffect.makeFormatedDescription(spellAbility));

--- a/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
@@ -49,7 +49,30 @@ public abstract class SpellAbilityEffect {
         return sa.getDescription();
     }
 
-    public void buildSpellAbility(final SpellAbility sa) {}
+    public void buildSpellAbility(final SpellAbility sa) {
+        if (sa.hasParam("Forecast")) {
+            sa.putParam("ActivationZone", "Hand");
+            sa.putParam("ActivationLimit", "1");
+            sa.putParam("ActivationPhases", "Upkeep");
+            sa.putParam("PlayerTurn", "True");
+            sa.putParam("PrecostDesc", "Forecast — ");
+        }
+        if (sa.isBoast()) {
+            sa.putParam("PresentDefined", "Self");
+            sa.putParam("IsPresent", "Card.attackedThisTurn");
+            sa.putParam("PrecostDesc", "Boast — ");
+        }
+        if (sa.isExhaust()) {
+            sa.putParam("PrecostDesc", "Exhaust — ");
+        }
+        if (sa.isPowerUp()) {
+            sa.putParam("PrecostDesc", "Power-Up — ");
+        }
+
+        if (sa.hasParam("Named")) {
+            sa.setName(sa.getParam("Named"));
+        }
+    }
 
     /**
      * Returns this effect description with needed prelude and epilogue.

--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeTargetsEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeTargetsEffect.java
@@ -30,6 +30,7 @@ public class ChangeTargetsEffect extends SpellAbilityEffect {
 
     @Override
     public void buildSpellAbility(SpellAbility sa) {
+        super.buildSpellAbility(sa);
         if (sa.usesTargeting()) {
             sa.getTargetRestrictions().setZone(ZoneType.Stack);
         }

--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneAllEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneAllEffect.java
@@ -25,6 +25,7 @@ public class ChangeZoneAllEffect extends SpellAbilityEffect {
 
     @Override
     public void buildSpellAbility(SpellAbility sa) {
+        super.buildSpellAbility(sa);
         AbilityFactory.adjustChangeZoneTarget(sa.getMapParams(), sa);
     }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
@@ -38,6 +38,7 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
 
     @Override
     public void buildSpellAbility(SpellAbility sa) {
+        super.buildSpellAbility(sa);
         AbilityFactory.adjustChangeZoneTarget(sa.getMapParams(), sa);
     }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/ControlSpellEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ControlSpellEffect.java
@@ -16,6 +16,7 @@ public class ControlSpellEffect extends SpellAbilityEffect {
 
     @Override
     public void buildSpellAbility(SpellAbility sa) {
+        super.buildSpellAbility(sa);
         if (sa.usesTargeting()) {
             sa.getTargetRestrictions().setZone(ZoneType.Stack);
         }

--- a/forge-game/src/main/java/forge/game/ability/effects/CopySpellAbilityEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CopySpellAbilityEffect.java
@@ -25,6 +25,7 @@ import java.util.Map;
 public class CopySpellAbilityEffect extends SpellAbilityEffect {
     @Override
     public void buildSpellAbility(SpellAbility sa) {
+        super.buildSpellAbility(sa);
         if (sa.usesTargeting()) {
             sa.getTargetRestrictions().setZone(ZoneType.Stack);
         }

--- a/forge-game/src/main/java/forge/game/ability/effects/CounterEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CounterEffect.java
@@ -23,6 +23,7 @@ import java.util.Map;
 public class CounterEffect extends SpellAbilityEffect {
     @Override
     public void buildSpellAbility(SpellAbility sa) {
+        super.buildSpellAbility(sa);
         if (sa.usesTargeting()) {
             sa.getTargetRestrictions().setZone(ZoneType.Stack);
         }

--- a/forge-game/src/main/java/forge/game/ability/effects/CountersPutEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CountersPutEffect.java
@@ -738,4 +738,16 @@ public class CountersPutEffect extends SpellAbilityEffect {
         }
         return randomLog.toString();
     }
+
+    @Override
+    public void buildSpellAbility(SpellAbility sa) {
+        super.buildSpellAbility(sa);
+        if (sa.hasParam("Adapt")) {
+            sa.putParam("CounterType", "P1P1");
+            sa.putParam("StackDescription", "SpellDescription");
+            if (!sa.hasParam("SpellDescription")) {
+                sa.putParam("SpellDescription", "Adapt " + sa.getParam("CounterNum"));
+            }
+        }
+    }
 }

--- a/forge-game/src/main/java/forge/game/ability/effects/EarthbendEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/EarthbendEffect.java
@@ -38,6 +38,7 @@ public class EarthbendEffect extends SpellAbilityEffect {
 
     @Override
     public void buildSpellAbility(final SpellAbility sa) {
+        super.buildSpellAbility(sa);
         TargetRestrictions abTgt = new TargetRestrictions(Map.of("ValidTgtsDesc", "land you control", "ValidTgts", "Land.YouCtrl"));
         sa.setTargetRestrictions(abTgt);
     }

--- a/forge-game/src/main/java/forge/game/ability/effects/ManaEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ManaEffect.java
@@ -31,6 +31,7 @@ public class ManaEffect extends SpellAbilityEffect {
 
     @Override
     public void buildSpellAbility(SpellAbility sa) {
+        super.buildSpellAbility(sa);
         sa.setManaPart(new AbilityManaPart(sa, sa.getMapParams()));
         if (sa.getParent() == null) {
             sa.setUndoable(true); // will try at least

--- a/forge-game/src/main/java/forge/game/ability/effects/ManaReflectedEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ManaReflectedEffect.java
@@ -19,6 +19,7 @@ public class ManaReflectedEffect extends SpellAbilityEffect {
 
     @Override
     public void buildSpellAbility(SpellAbility sa) {
+        super.buildSpellAbility(sa);
         sa.setManaPart(new AbilityManaPart(sa, sa.getMapParams()));
         if (sa.getParent() == null) {
             sa.setUndoable(true); // will try at least

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -2711,7 +2711,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
                         || keyword.equals("For Mirrodin") || keyword.equals("Job select") || keyword.startsWith("Craft")
                         || keyword.startsWith("Landwalk") || keyword.startsWith("Visit") || keyword.startsWith("Mobilize")
                         || keyword.startsWith("Station") || keyword.startsWith("Warp") || keyword.startsWith("Devour")
-                        || keyword.startsWith("Affinity") || keyword.startsWith("Adapt")) {
+                        || keyword.startsWith("Affinity")) {
                     // keyword parsing takes care of adding a proper description
                 } else if (keyword.equals("Read ahead")) {
                     sb.append(Localizer.getInstance().getMessage("lblReadAhead")).append(" (").append(Localizer.getInstance().getMessage("lblReadAheadDesc"));

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -2663,27 +2663,7 @@ public class CardFactoryUtil {
     public static void addSpellAbility(final KeywordInterface inst, final CardState card, final boolean intrinsic) {
         String keyword = inst.getOriginal();
         Card host = card.getCard();
-        if (keyword.startsWith("Adapt")) {
-            final String[] k = keyword.split(":");
-            final String magnitude = k[1];
-            final String manacost = k[2];
-            final String reduceCost = k.length > 3 ? k[3] : null;
-
-            String desc = "Adapt " + magnitude;
-
-            String effect = "AB$ PutCounter | Cost$ " + manacost + " | Adapt$ True | CounterNum$ " + magnitude
-                    + " | CounterType$ P1P1 | StackDescription$ SpellDescription";
-
-            if (reduceCost != null) {
-                effect += "| ReduceCost$ " + reduceCost;
-                desc += ". This ability costs {1} less to activate for each " + k[4] + ".";
-            }
-            effect += "| SpellDescription$ " + desc + " (" + inst.getReminderText() + ")";
-
-            final SpellAbility sa = AbilityFactory.getAbility(effect, card);
-            sa.setIntrinsic(intrinsic);
-            inst.addSpellAbility(sa);
-        } else if (keyword.equals("Aftermath") && card.getStateName().equals(CardStateName.RightSplit)) {
+        if (keyword.equals("Aftermath") && card.getStateName().equals(CardStateName.RightSplit)) {
             // Aftermath does modify existing SA, and does not add new one
 
             // only target RightSplit of it

--- a/forge-game/src/main/java/forge/game/keyword/Keyword.java
+++ b/forge-game/src/main/java/forge/game/keyword/Keyword.java
@@ -9,7 +9,6 @@ import java.util.*;
 public enum Keyword {
     UNDEFINED("", SimpleKeyword.class, false, ""),
     ABSORB("Absorb", KeywordWithAmount.class, false, "If a source would deal damage to this creature, prevent %d of that damage."),
-    ADAPT("Adapt", KeywordWithCostAndAmount.class, false, "If this creature has no +1/+1 counters on it, put {%2$d:+1/+1 counter} on it."),
     AFFINITY("Affinity", KeywordWithType.class, false, "This spell costs {1} less to cast for each %s you control."),
     AFFLICT("Afflict", KeywordWithAmount.class, false, "Whenever this creature becomes blocked, defending player loses %d life."),
     AFTERLIFE("Afterlife", KeywordWithAmount.class, false, "When this creature dies, create {%1$d:1/1 white and black Spirit creature token} with flying."),

--- a/forge-gui/res/cardsfolder/a/aeromunculus.txt
+++ b/forge-gui/res/cardsfolder/a/aeromunculus.txt
@@ -3,6 +3,6 @@ ManaCost:1 G U
 Types:Creature Homunculus Mutant
 PT:2/3
 K:Flying
-K:Adapt:1:2 G U
+A:AB$ PutCounter | Cost$ 2 G U | Adapt$ True | CounterNum$ 1
 DeckHas:Ability$Counters
 Oracle:Flying\n{2}{G}{U}: Adapt 1. (If this creature has no +1/+1 counters on it, put a +1/+1 counter on it.)

--- a/forge-gui/res/cardsfolder/b/basking_broodscale.txt
+++ b/forge-gui/res/cardsfolder/b/basking_broodscale.txt
@@ -3,7 +3,7 @@ ManaCost:1 G
 Types:Creature Eldrazi Lizard
 PT:2/2
 K:Devoid
-K:Adapt:1:1 G
+A:AB$ PutCounter | Cost$ 1 G | Adapt$ True | CounterNum$ 1
 T:Mode$ CounterAddedOnce | ValidCard$ Card.Self | TriggerZones$ Battlefield | OptionalDecider$ You | CounterType$ P1P1 | Execute$ TrigToken | TriggerDescription$ Whenever one or more +1/+1 counters are put on CARDNAME, you may create a 0/1 colorless Eldrazi Spawn creature token with "Sacrifice this creature: Add {C}."
 SVar:TrigToken:DB$ Token | TokenScript$ c_0_1_eldrazi_spawn_sac | TokenOwner$ You
 DeckHas:Ability$Counters|Token & Type$Spawn

--- a/forge-gui/res/cardsfolder/b/benthic_biomancer.txt
+++ b/forge-gui/res/cardsfolder/b/benthic_biomancer.txt
@@ -2,7 +2,7 @@ Name:Benthic Biomancer
 ManaCost:U
 Types:Creature Merfolk Wizard Mutant
 PT:1/1
-K:Adapt:1:1 U
+A:AB$ PutCounter | Cost$ 1 U | Adapt$ True | CounterNum$ 1
 T:Mode$ CounterAddedOnce | ValidCard$ Card.Self | TriggerZones$ Battlefield | CounterType$ P1P1 | Execute$ TrigDraw | TriggerDescription$ Whenever one or more +1/+1 counters are put on CARDNAME, draw a card, then discard a card.
 SVar:TrigDraw:DB$ Draw | SubAbility$ DBDiscard
 SVar:DBDiscard:DB$ Discard | Defined$ You | NumCards$ 1 | Mode$ TgtChoose

--- a/forge-gui/res/cardsfolder/c/cursed_wombat.txt
+++ b/forge-gui/res/cardsfolder/c/cursed_wombat.txt
@@ -2,7 +2,7 @@ Name:Cursed Wombat
 ManaCost:B G
 Types:Creature Nightmare Wombat
 PT:2/3
-K:Adapt:2:2 B G
+A:AB$ PutCounter | Cost$ 2 B G | Adapt$ True | CounterNum$ 2
 S:Mode$ Continuous | Affected$ Permanent.YouCtrl | AddTrigger$ CountersAdded | Description$ Permanents you control have "Whenever one or more +1/+1 counters are put on this permanent, put an additional +1/+1 counter on it. This ability triggers only once each turn."
 SVar:CountersAdded:Mode$ CounterAddedOnce | CounterType$ P1P1 | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPutCounter | ActivationLimit$ 1 | TriggerDescription$ Whenever one or more +1/+1 counters are put on this permanent, put an additional +1/+1 counter on it. This ability triggers only once each turn.
 SVar:TrigPutCounter:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ 1

--- a/forge-gui/res/cardsfolder/d/dreamdrinker_vampire.txt
+++ b/forge-gui/res/cardsfolder/d/dreamdrinker_vampire.txt
@@ -3,7 +3,7 @@ ManaCost:1 B
 Types:Creature Vampire
 PT:2/1
 K:Lifelink
-K:Adapt:1:1 B
+A:AB$ PutCounter | Cost$ 1 B | Adapt$ True | CounterNum$ 1
 T:Mode$ CounterAddedOnce | ValidCard$ Card.Self | TriggerZones$ Battlefield | CounterType$ P1P1 | Execute$ TrigPump | TriggerDescription$ Whenever one or more +1/+1 counters are put on CARDNAME, it gains menace until end of turn.
 SVar:TrigPump:DB$ Pump | Defined$ Self | KW$ Menace
 DeckHas:Ability$Counters|LifeGain

--- a/forge-gui/res/cardsfolder/e/emperor_of_bones.txt
+++ b/forge-gui/res/cardsfolder/e/emperor_of_bones.txt
@@ -4,7 +4,7 @@ Types:Creature Skeleton Noble
 PT:2/2
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | Execute$ TrigExile | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of combat on your turn, exile up to one target card from a graveyard.
 SVar:TrigExile:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | TargetMin$ 0 | TargetMax$ 1 | ValidTgts$ Card | TgtPrompt$ Select up to one target card from a graveyard
-K:Adapt:2:1 B
+A:AB$ PutCounter | Cost$ 1 B | Adapt$ True | CounterNum$ 2
 T:Mode$ CounterAddedOnce | ValidCard$ Card.Self | TriggerZones$ Battlefield | CounterType$ P1P1 | Execute$ TrigChangeZone | TriggerDescription$ Whenever one or more +1/+1 counters are put on CARDNAME, put a creature card exiled with CARDNAME onto the battlefield under your control with a finality counter on it. It gains haste. Sacrifice it at the beginning of the next end step.
 SVar:TrigChangeZone:DB$ ChangeZone | ChangeType$ Creature.ExiledWithSource | GainControl$ True | Origin$ Exile | Hidden$ True | Mandatory$ True | RememberChanged$ True | Destination$ Battlefield | WithCountersType$ FINALITY | SubAbility$ DBPump
 SVar:DBPump:DB$ Pump | Defined$ Remembered | KW$ Haste | AtEOT$ Sacrifice | SubAbility$ DBCleanup

--- a/forge-gui/res/cardsfolder/e/etherium_pteramander.txt
+++ b/forge-gui/res/cardsfolder/e/etherium_pteramander.txt
@@ -4,6 +4,6 @@ Types:Artifact Creature Salamander Drake
 PT:1/1
 K:Flying
 S:Mode$ CantBlockBy | ValidAttacker$ Creature.withoutFlying | ValidBlocker$ Creature.Self | Description$ CARDNAME can block only creatures with flying.
-K:Adapt:4:6 B:X:other artifact you control
+A:AB$ PutCounter | Cost$ 6 B | Adapt$ True | CounterNum$ 4 | ReduceCost$ X | SpellDescription$ Adapt 4. This ability costs {1} less to activate for each other artifact you control. (If this creature has no +1/+1 counters on it, put four +1/+1 counters on it.)
 SVar:X:Count$Valid Artifact.YouCtrl+Other
-Oracle:Flying\n{6}{B}: Adapt 4. This ability costs {1} less to activate for each other artifact you control. (If this creature has no +1/+1 counters on it, put four +1/+1 counters on it.)
+Oracle:Flying\nThis creature can block only creatures with flying.\n{6}{B}: Adapt 4. This ability costs {1} less to activate for each other artifact you control. (If this creature has no +1/+1 counters on it, put four +1/+1 counters on it.)

--- a/forge-gui/res/cardsfolder/e/evolution_witness.txt
+++ b/forge-gui/res/cardsfolder/e/evolution_witness.txt
@@ -2,7 +2,7 @@ Name:Evolution Witness
 ManaCost:2 G
 Types:Creature Elf Shaman Mutant
 PT:2/1
-K:Adapt:2:1 G
+A:AB$ PutCounter | Cost$ 1 G | Adapt$ True | CounterNum$ 2
 T:Mode$ CounterAddedOnce | ValidCard$ Card.Self | TriggerZones$ Battlefield | CounterType$ P1P1 | Execute$ TrigChangeZone | TriggerDescription$ Whenever one or more +1/+1 counters are put on CARDNAME, return target permanent card from your graveyard to your hand.
 SVar:TrigChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Permanent.YouCtrl | TgtPrompt$ Select target permanent card from your graveyard
 DeckHas:Ability$Counters|Graveyard

--- a/forge-gui/res/cardsfolder/e/expanding_ooze.txt
+++ b/forge-gui/res/cardsfolder/e/expanding_ooze.txt
@@ -2,7 +2,7 @@ Name:Expanding Ooze
 ManaCost:1 B G
 Types:Creature Ooze
 PT:3/3
-K:Adapt:1:B G
+A:AB$ PutCounter | Cost$ B G | Adapt$ True | CounterNum$ 1
 T:Mode$ Attacks | ValidCard$ Creature.Self | Execute$ TrigPutCounter | TriggerDescription$ Whenever CARDNAME attacks, put a +1/+1 counter on target modified creature you control. (Equipment, Auras you control, and counters are modifications.)
 SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Creature.modified+YouCtrl | TgtPrompt$ Select target modified creature you control | CounterType$ P1P1 | CounterNum$ 1
 SVar:HasAttackEffect:TRUE

--- a/forge-gui/res/cardsfolder/f/fetid_gargantua.txt
+++ b/forge-gui/res/cardsfolder/f/fetid_gargantua.txt
@@ -2,7 +2,7 @@ Name:Fetid Gargantua
 ManaCost:4 B
 Types:Creature Horror
 PT:4/4
-K:Adapt:2:2 B
+A:AB$ PutCounter | Cost$ 2 B | Adapt$ True | CounterNum$ 2
 T:Mode$ CounterAddedOnce | ValidCard$ Card.Self | TriggerZones$ Battlefield | CounterType$ P1P1 | Execute$ TrigLoseLife | TriggerDescription$ Whenever one or more +1/+1 counters are put on CARDNAME, you may draw two cards. If you do, lose 2 life.
 SVar:TrigLoseLife:AB$ LoseLife | Cost$ Draw<2/You> | LifeAmount$ 2
 Oracle:{2}{B}: Adapt 2. (If this creature has no +1/+1 counters on it, put two +1/+1 counters on it.)\nWhenever one or more +1/+1 counters are put on Fetid Gargantua, you may draw two cards. If you do, lose 2 life.

--- a/forge-gui/res/cardsfolder/g/growth_chamber_guardian.txt
+++ b/forge-gui/res/cardsfolder/g/growth_chamber_guardian.txt
@@ -2,7 +2,7 @@ Name:Growth-Chamber Guardian
 ManaCost:1 G
 Types:Creature Elf Crab Warrior
 PT:2/2
-K:Adapt:2:2 G
+A:AB$ PutCounter | Cost$ 2 G | Adapt$ True | CounterNum$ 2
 T:Mode$ CounterAddedOnce | ValidCard$ Card.Self | TriggerZones$ Battlefield | CounterType$ P1P1 | Execute$ TrigSearch | OptionalDecider$ You | TriggerDescription$ Whenever one or more +1/+1 counters are put on CARDNAME, you may search your library for a card named Growth-Chamber Guardian, reveal it, put it into your hand, then shuffle.
 SVar:TrigSearch:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Card.namedGrowth-Chamber Guardian | ChangeNum$ 1 | ShuffleNonMandatory$ True
 DeckHints:Name$Growth-Chamber Guardian

--- a/forge-gui/res/cardsfolder/h/hydra_trainer.txt
+++ b/forge-gui/res/cardsfolder/h/hydra_trainer.txt
@@ -5,5 +5,5 @@ PT:1/1
 S:Mode$ OptionalAttackCost | ValidCard$ Card.Self | Trigger$ TrigPump | Cost$ Exert<1/CARDNAME> | Description$ You may exert CARDNAME as it attacks. When you do, target creature gets +X/+X until end of turn, where X is the number of counters on permanents you control. (An exerted creature won't untap during your next untap step.)
 SVar:TrigPump:DB$ Pump | ValidTgts$ Creature | NumAtt$ +X | NumDef$ +X | SpellDescription$ When you do, target creature gets +X/+X until end of turn, where X is the number of counters on permanents you control. (An exerted creature won't untap during your next untap step.)
 SVar:X:Count$Valid Permanent.YouCtrl$CardCounters.ALL
-K:Adapt:2:2 G
+A:AB$ PutCounter | Cost$ 2 G | Adapt$ True | CounterNum$ 2
 Oracle:You may exert Hydra Trainer as it attacks. When you do, target creature gets +X/+X until end of turn, where X is the number of counters on permanents you control. (An exerted creature won't untap during your next untap step.)\n{2}{G}: Adapt 2. (If this creature has no +1/+1 counters on it, put two +1/+1 counters on it.)

--- a/forge-gui/res/cardsfolder/i/incubation_druid.txt
+++ b/forge-gui/res/cardsfolder/i/incubation_druid.txt
@@ -2,7 +2,7 @@ Name:Incubation Druid
 ManaCost:1 G
 Types:Creature Elf Druid
 PT:0/2
-K:Adapt:3:3 G G
+A:AB$ PutCounter | Cost$ 3 G G | Adapt$ True | CounterNum$ 3
 A:AB$ ManaReflected | Cost$ T | ColorOrType$ Type | Valid$ Land.YouCtrl | Amount$ IncubationAmount | ReflectProperty$ Produce | SpellDescription$ Add one mana of any type that a land you control could produce. If CARDNAME has a +1/+1 counter on it, add three mana of that type instead.
 SVar:Y:Count$Valid Card.Self+counters_GE1_P1P1
 SVar:IncubationAmount:Count$Compare Y GE1.3.1

--- a/forge-gui/res/cardsfolder/j/jetfire_ingenious_scientist_jetfire_air_guardian.txt
+++ b/forge-gui/res/cardsfolder/j/jetfire_ingenious_scientist_jetfire_air_guardian.txt
@@ -22,6 +22,6 @@ PT:3/4
 K:Living metal
 K:Flying
 A:AB$ SetState | Cost$ U U U | Mode$ Transform | SubAbility$ DBAdapt | StackDescription$ Convert NICKNAME, | SpellDescription$ Convert NICKNAME, then adapt 3. (If it has no +1/+1 counters on it, put three +1/+1 counters on it.)
-SVar:DBAdapt:DB$ PutCounter | Adapt$ True | CounterNum$ 3 | CounterType$ P1P1 | StackDescription$ then adapt 3.
+SVar:DBAdapt:DB$ PutCounter | Adapt$ True | CounterNum$ 3 | StackDescription$ then adapt 3.
 DeckHas:Ability$Counters
 Oracle:Living metal (During your turn, this Vehicle is also a creature.)\nFlying\n{U}{U}{U}: Convert Jetfire, then adapt 3. (If it has no +1/+1 counters on it, put three +1/+1 counters on it.)

--- a/forge-gui/res/cardsfolder/k/knighted_myr.txt
+++ b/forge-gui/res/cardsfolder/k/knighted_myr.txt
@@ -2,7 +2,7 @@ Name:Knighted Myr
 ManaCost:2 W
 Types:Artifact Creature Myr Knight
 PT:2/2
-K:Adapt:1:2 W
+A:AB$ PutCounter | Cost$ 2 W | Adapt$ True | CounterNum$ 1
 T:Mode$ CounterAddedOnce | ValidCard$ Card.Self | CounterType$ P1P1 | Execute$ TrigPump | TriggerDescription$ Whenever one or more +1/+1 counters are put on CARDNAME, it gains double strike until end of turn.
 SVar:TrigPump:DB$ Pump | KW$ Double Strike
 DeckHas:Ability$Counters

--- a/forge-gui/res/cardsfolder/p/pteramander.txt
+++ b/forge-gui/res/cardsfolder/p/pteramander.txt
@@ -3,7 +3,7 @@ ManaCost:U
 Types:Creature Salamander Drake
 PT:1/1
 K:Flying
-K:Adapt:4:7 U:X:instant and sorcery card in your graveyard
+A:AB$ PutCounter | Cost$ 7 U | Adapt$ True | CounterNum$ 4 | ReduceCost$ X | SpellDescription$ Adapt 4. This ability costs {1} less to activate for each instant and sorcery card in your graveyard. (If this creature has no +1/+1 counters on it, put four +1/+1 counters on it.)
 SVar:X:Count$ValidGraveyard Instant.YouOwn,Sorcery.YouOwn
 DeckHas:Ability$Counters
 Oracle:Flying\n{7}{U}: Adapt 4. This ability costs {1} less to activate for each instant and sorcery card in your graveyard. (If this creature has no +1/+1 counters on it, put four +1/+1 counters on it.)

--- a/forge-gui/res/cardsfolder/s/sauroform_hybrid.txt
+++ b/forge-gui/res/cardsfolder/s/sauroform_hybrid.txt
@@ -2,6 +2,6 @@ Name:Sauroform Hybrid
 ManaCost:1 G
 Types:Creature Human Lizard Warrior
 PT:2/2
-K:Adapt:4:4 G G
+A:AB$ PutCounter | Cost$ 4 G G | Adapt$ True | CounterNum$ 4
 DeckHas:Ability$Counters
 Oracle:{4}{G}{G}: Adapt 4. (If this creature has no +1/+1 counters on it, put four +1/+1 counters on it.)

--- a/forge-gui/res/cardsfolder/s/scuttlegator.txt
+++ b/forge-gui/res/cardsfolder/s/scuttlegator.txt
@@ -3,7 +3,7 @@ ManaCost:4 GU GU
 Types:Creature Crab Turtle Crocodile
 PT:6/6
 K:Defender
-K:Adapt:3:6 GU GU
+A:AB$ PutCounter | Cost$ 6 GU GU | Adapt$ True | CounterNum$ 3
 S:Mode$ CanAttackDefender | ValidCard$ Card.Self+counters_GE1_P1P1 | Description$ As long as CARDNAME has a +1/+1 counter on it, it can attack as though it didn't have defender.
 DeckHas:Ability$Counters
 Oracle:Defender\n{6}{G/U}{G/U}: Adapt 3. (If this creature has no +1/+1 counters on it, put three +1/+1 counters on it.)\nAs long as Scuttlegator has a +1/+1 counter on it, it can attack as though it didn't have defender.

--- a/forge-gui/res/cardsfolder/s/sharktocrab.txt
+++ b/forge-gui/res/cardsfolder/s/sharktocrab.txt
@@ -2,7 +2,7 @@ Name:Sharktocrab
 ManaCost:2 G U
 Types:Creature Shark Octopus Crab
 PT:4/4
-K:Adapt:1:2 G U
+A:AB$ PutCounter | Cost$ 2 G U | Adapt$ True | CounterNum$ 1
 T:Mode$ CounterAddedOnce | ValidCard$ Card.Self | TriggerZones$ Battlefield | CounterType$ P1P1 | Execute$ TrigTap | TriggerDescription$ Whenever one or more +1/+1 counters are put on CARDNAME, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.
 SVar:TrigTap:DB$ Tap | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Choose target creature an opponent controls. | SubAbility$ DBPump
 SVar:DBPump:DB$ Pump | Defined$ Targeted | KW$ HIDDEN This card doesn't untap during your next untap step. | Duration$ Permanent

--- a/forge-gui/res/cardsfolder/s/skatewing_spy.txt
+++ b/forge-gui/res/cardsfolder/s/skatewing_spy.txt
@@ -2,7 +2,7 @@ Name:Skatewing Spy
 ManaCost:3 U
 Types:Creature Vedalken Rogue Mutant
 PT:2/3
-K:Adapt:2:5 U
+A:AB$ PutCounter | Cost$ 5 U | Adapt$ True | CounterNum$ 2
 DeckHas:Ability$Counters
 S:Mode$ Continuous | Affected$ Creature.YouCtrl+counters_GE1_P1P1 | AddKeyword$ Flying | Description$ Each creature you control with a +1/+1 counter on it has flying.
 DeckHints:Ability$Counters

--- a/forge-gui/res/cardsfolder/s/skitter_eel.txt
+++ b/forge-gui/res/cardsfolder/s/skitter_eel.txt
@@ -2,6 +2,6 @@ Name:Skitter Eel
 ManaCost:3 U
 Types:Creature Fish Crab
 PT:3/3
-K:Adapt:2:2 U
+A:AB$ PutCounter | Cost$ 2 U | Adapt$ True | CounterNum$ 2
 DeckHas:Ability$Counters
 Oracle:{2}{U}: Adapt 2. (If this creature has no +1/+1 counters on it, put two +1/+1 counters on it.)

--- a/forge-gui/res/cardsfolder/t/temperamental_oozewagg.txt
+++ b/forge-gui/res/cardsfolder/t/temperamental_oozewagg.txt
@@ -2,6 +2,6 @@ Name:Temperamental Oozewagg
 ManaCost:3 G
 Types:Creature Ooze Brushwagg
 PT:4/4
-K:Adapt:2:2 G
+A:AB$ PutCounter | Cost$ 2 G | Adapt$ True | CounterNum$ 2
 S:Mode$ Continuous | Affected$ Creature.modified+YouCtrl | AddKeyword$ Trample | Description$ Modified creatures you control have trample. (Equipment, Auras you control, and counters are modifications.)
 Oracle:{2}{G}: Adapt 2. (If this creature has no +1/+1 counters on it, put two +1/+1 counters on it.)\nModified creatures you control have trample. (Equipment, Auras you control, and counters are modifications.)

--- a/forge-gui/res/cardsfolder/t/trollbred_guardian.txt
+++ b/forge-gui/res/cardsfolder/t/trollbred_guardian.txt
@@ -2,7 +2,7 @@ Name:Trollbred Guardian
 ManaCost:4 G
 Types:Creature Troll Frog Warrior
 PT:5/5
-K:Adapt:2:2 G
+A:AB$ PutCounter | Cost$ 2 G | Adapt$ True | CounterNum$ 2
 S:Mode$ Continuous | Affected$ Creature.YouCtrl+counters_GE1_P1P1 | AddKeyword$ Trample | Description$ Each creature you control with a +1/+1 counter on it has trample.
 DeckHas:Ability$Counters
 DeckHints:Ability$Counters

--- a/forge-gui/res/cardsfolder/u/unruly_krasis.txt
+++ b/forge-gui/res/cardsfolder/u/unruly_krasis.txt
@@ -6,7 +6,7 @@ K:Trample
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigAnimate | OptionalDecider$ You | TriggerDescription$ Whenever CARDNAME attacks, you may have the base power and toughness of another target creature you control become X/X until end of turn, where X is CARDNAME's power.
 SVar:TrigAnimate:DB$ Animate | ValidTgts$ Creature.Other+YouCtrl | TgtPrompt$ Select another target creature you control | Power$ X | Toughness$ X
 SVar:X:Count$CardPower
-K:Adapt:3:3 G U
+A:AB$ PutCounter | Cost$ 3 G U | Adapt$ True | CounterNum$ 3
 SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Counters
 Oracle:Trample\nWhenever Unruly Krasis attacks, you may have the base power and toughness of another target creature you control become X/X until end of turn, where X is Unruly Krasis's power.\n{3}{G}{U}: Adapt 3. (If this creature has no +1/+1 counters on it, put three +1/+1 counters on it.)

--- a/forge-gui/res/cardsfolder/z/zegana_utopian_speaker.txt
+++ b/forge-gui/res/cardsfolder/z/zegana_utopian_speaker.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature Merfolk Wizard
 PT:4/4
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | IsPresent$ Creature.Other+YouCtrl+counters_GE1_P1P1 | Execute$ TrigDraw | TriggerDescription$ When CARDNAME enters, if you control another creature with a +1/+1 counter on it, draw a card.
 SVar:TrigDraw:DB$ Draw
-K:Adapt:4:4 G U
+A:AB$ PutCounter | Cost$ 4 G U | Adapt$ True | CounterNum$ 4
 S:Mode$ Continuous | Affected$ Creature.YouCtrl+counters_GE1_P1P1 | AddKeyword$ Trample | Description$ Each creature you control with a +1/+1 counter on it has trample.
 DeckHas:Ability$Counters
 DeckHints:Ability$Counters


### PR DESCRIPTION
This turns Adapt Keyword back into an activated Ability with special Param (that already existed in the code)

i also moved some Param shenanigans from the AbilityFactory into the SpellAbilityEffect helper

that place can also create SpellDescription if needed (works for basic ones, not Charm Effects)