### PR TITLE
Card cleanup: 2026-02-21, incidental

### DIFF
--- a/forge-gui/res/cardsfolder/a/adventurers_guildhouse.txt
+++ b/forge-gui/res/cardsfolder/a/adventurers_guildhouse.txt
@@ -3,5 +3,6 @@ ManaCost:no cost
 Types:Land
 S:Mode$ Continuous | Affected$ Creature.Green+Legendary+YouCtrl | AddKeyword$ Bands with other:Creature.Legendary:legendary creatures | Description$ Green legendary creatures you control have "bands with other legendary creatures." (Any legendary creatures can attack in a band as long as at least one has "bands with other legendary creatures." Bands are blocked as a group. If at least two legendary creatures you control, one of which has "bands with other legendary creatures," are blocking or being blocked by the same creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)
 SVar:NonStackingEffect:True
+DeckHas:Keyword$Bands with other
 DeckNeeds:Color$Green & Type$Legendary
 Oracle:Green legendary creatures you control have "bands with other legendary creatures." (Any legendary creatures can attack in a band as long as at least one has "bands with other legendary creatures." Bands are blocked as a group. If at least two legendary creatures you control, one of which has "bands with other legendary creatures," are blocking or being blocked by the same creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)

--- a/forge-gui/res/cardsfolder/c/cathedral_of_serra.txt
+++ b/forge-gui/res/cardsfolder/c/cathedral_of_serra.txt
@@ -3,6 +3,6 @@ ManaCost:no cost
 Types:Land
 S:Mode$ Continuous | Affected$ Creature.White+Legendary+YouCtrl | AddKeyword$ Bands with other:Creature.Legendary:legendary creatures | Description$ White legendary creatures you control have "bands with other legendary creatures." (Any legendary creatures can attack in a band as long as at least one has "bands with other legendary creatures." Bands are blocked as a group. If at least two legendary creatures you control, one of which has "bands with other legendary creatures," are blocking or being blocked by the same creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)
 SVar:NonStackingEffect:True
-DeckHas:Keyword$BandsWithOther
+DeckHas:Keyword$Bands with other
 DeckNeeds:Type$Legendary & Color$White
 Oracle:White legendary creatures you control have "bands with other legendary creatures." (Any legendary creatures can attack in a band as long as at least one has "bands with other legendary creatures." Bands are blocked as a group. If at least two legendary creatures you control, one of which has "bands with other legendary creatures," are blocking or being blocked by the same creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)

--- a/forge-gui/res/cardsfolder/m/mountain_stronghold.txt
+++ b/forge-gui/res/cardsfolder/m/mountain_stronghold.txt
@@ -2,5 +2,7 @@ Name:Mountain Stronghold
 ManaCost:no cost
 Types:Land
 S:Mode$ Continuous | Affected$ Creature.Red+Legendary+YouCtrl | AddKeyword$ Bands with other:Creature.Legendary:legendary creatures | Description$ Red legendary creatures you control have "bands with other legendary creatures." (Any legendary creatures can attack in a band as long as at least one has "bands with other legendary creatures." Bands are blocked as a group. If at least two legendary creatures you control, one of which has "bands with other legendary creatures," are blocking or being blocked by the same creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)
+SVar:NonStackingEffect:True
+DeckHas:Keyword$Bands with other
 DeckNeeds:Color$Red & Type$Legendary
 Oracle:Red legendary creatures you control have "bands with other legendary creatures." (Any legendary creatures can attack in a band as long as at least one has "bands with other legendary creatures." Bands are blocked as a group. If at least two legendary creatures you control, one of which has "bands with other legendary creatures," are blocking or being blocked by the same creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)

--- a/forge-gui/res/cardsfolder/s/seafarers_quay.txt
+++ b/forge-gui/res/cardsfolder/s/seafarers_quay.txt
@@ -2,5 +2,7 @@ Name:Seafarer's Quay
 ManaCost:no cost
 Types:Land
 S:Mode$ Continuous | Affected$ Creature.Blue+Legendary+YouCtrl | AddKeyword$ Bands with other:Creature.Legendary:legendary creatures | Description$ Blue legendary creatures you control have "bands with other legendary creatures." (Any legendary creatures can attack in a band as long as at least one has "bands with other legendary creatures." Bands are blocked as a group. If at least two legendary creatures you control, one of which has "bands with other legendary creatures," are blocking or being blocked by the same creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)
+SVar:NonStackingEffect:True
+DeckHas:Keyword$Bands with other
 DeckNeeds:Type$Legendary & Color$Blue
 Oracle:Blue legendary creatures you control have "bands with other legendary creatures." (Any legendary creatures can attack in a band as long as at least one has "bands with other legendary creatures." Bands are blocked as a group. If at least two legendary creatures you control, one of which has "bands with other legendary creatures," are blocking or being blocked by the same creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)

--- a/forge-gui/res/cardsfolder/t/tibalt_the_chaotic.txt
+++ b/forge-gui/res/cardsfolder/t/tibalt_the_chaotic.txt
@@ -2,7 +2,7 @@ Name:Tibalt the Chaotic
 ManaCost:1 R R
 Types:Legendary Planeswalker Tibalt
 Loyalty:4
-A:AB$ Play | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | AnySupportedCard$ Names:Ignorant Bliss,Crack the Earth,Blazing Volley | RandomCopied$ True | CopyCard$ True | WithoutManaCost$ Trues | SpellDescription$ Cast a copy of one of the following cards chosen at random—Ignorant Bliss, Crack the Earth, Blazing Volley.
+A:AB$ Play | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | AnySupportedCard$ Names:Ignorant Bliss,Crack the Earth,Blazing Volley | RandomCopied$ True | CopyCard$ True | WithoutManaCost$ True | SpellDescription$ Cast a copy of one of the following cards chosen at random—Ignorant Bliss, Crack the Earth, Blazing Volley.
 A:AB$ Play | Cost$ SubCounter<3/LOYALTY> | Planeswalker$ True | AnySupportedCard$ Names:Seething Song,Dance with Devils,Flamebreak | RandomCopied$ True | CopyCard$ True | WithoutManaCost$ True | SpellDescription$ Cast a copy of one of the following cards chosen at random—Seething Song, Dance with Devils, Flamebreak.
 A:AB$ Play | Cost$ SubCounter<6/LOYALTY> | Planeswalker$ True | Ultimate$ True | AnySupportedCard$ Names:Hellion Eruption,Insurrection,Warp World | RandomCopied$ True | CopyCard$ True | WithoutManaCost$ True | SpellDescription$ Cast a copy of one of the following cards chosen at random—Hellion Eruption, Insurrection, Warp World.
 Oracle:[+1]: Cast a copy of one of the following cards chosen at random—Ignorant Bliss, Crack the Earth, Blazing Volley.\n[-3]: Cast a copy of one of the following cards chosen at random—Seething Song, Dance with Devils, Flamebreak.\n[-6]: Cast a copy of one of the following cards chosen at random—Hellion Eruption, Insurrection, Warp World.

--- a/forge-gui/res/cardsfolder/u/unholy_citadel.txt
+++ b/forge-gui/res/cardsfolder/u/unholy_citadel.txt
@@ -3,5 +3,6 @@ ManaCost:no cost
 Types:Land
 S:Mode$ Continuous | Affected$ Creature.Black+Legendary+YouCtrl | AddKeyword$ Bands with other:Creature.Legendary:legendary creatures | Description$ Black legendary creatures you control have "bands with other legendary creatures." (Any legendary creatures can attack in a band as long as at least one has "bands with other legendary creatures." Bands are blocked as a group. If at least two legendary creatures you control, one of which has "bands with other legendary creatures," are blocking or being blocked by the same creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)
 SVar:NonStackingEffect:True
+DeckHas:Keyword$Bands with other
 DeckNeeds:Type$Legendary & Color$Black
 Oracle:Black legendary creatures you control have "bands with other legendary creatures." (Any legendary creatures can attack in a band as long as at least one has "bands with other legendary creatures." Bands are blocked as a group. If at least two legendary creatures you control, one of which has "bands with other legendary creatures," are blocking or being blocked by the same creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)

--- a/forge-gui/res/tokenscripts/wolves_of_the_hunt.txt
+++ b/forge-gui/res/tokenscripts/wolves_of_the_hunt.txt
@@ -3,5 +3,5 @@ ManaCost:no cost
 Colors:green
 Types:Creature Wolf
 PT:1/1
-K:Bands with other:Creature.namedWolves of the Hunt:Creatures named Wolves of the Hunt
+K:Bands with other:Creature.namedWolves of the Hunt:creatures named Wolves of the Hunt
 Oracle:Bands with other creatures named Wolves of the Hunt.


### PR DESCRIPTION
From my notes: some typos and propagating appropriate flags across the Legends "bands with other" land cycle, with attention paid to prior discussion that emphasized the need for `DeckHas`  `Keyword` tags to match how the keyword's spelled out on the script.