### PR TITLE
Fix batching for network game events to reduce redundant GameView serialization

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/net/server/NetGuiGame.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/NetGuiGame.java
@@ -299,6 +299,14 @@ public class NetGuiGame extends AbstractGuiGame {
     }
 
     @Override
+    public void handleGameEvents(List<GameEvent> events) {
+        updateGameView();
+        for (GameEvent event : events) {
+            send(ProtocolMethod.handleGameEvent, event);
+        }
+    }
+
+    @Override
     public boolean isNetGame() { return true; }
 
     @Override

--- a/forge-gui/src/main/java/forge/gui/control/GameEventForwarder.java
+++ b/forge-gui/src/main/java/forge/gui/control/GameEventForwarder.java
@@ -2,12 +2,39 @@ package forge.gui.control;
 
 import com.google.common.eventbus.Subscribe;
 import forge.game.event.GameEvent;
+import forge.gui.GuiBase;
 import forge.gui.interfaces.IGuiGame;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class GameEventForwarder {
     private final IGuiGame gui;
+    private final List<GameEvent> pendingEvents = new ArrayList<>();
+    private volatile boolean flushQueued = false;
+
     public GameEventForwarder(IGuiGame gui) { this.gui = gui; }
 
     @Subscribe
-    public void receiveGameEvent(GameEvent ev) { gui.handleGameEvent(ev); }
+    public void receiveGameEvent(GameEvent ev) {
+        synchronized (pendingEvents) {
+            pendingEvents.add(ev);
+        }
+        if (!flushQueued) {
+            flushQueued = true;
+            GuiBase.getInterface().invokeInEdtLater(this::flush);
+        }
+    }
+
+    private void flush() {
+        flushQueued = false;
+        List<GameEvent> batch;
+        synchronized (pendingEvents) {
+            batch = new ArrayList<>(pendingEvents);
+            pendingEvents.clear();
+        }
+        if (!batch.isEmpty()) {
+            gui.handleGameEvents(batch);
+        }
+    }
 }

--- a/forge-gui/src/main/java/forge/gui/interfaces/IGuiGame.java
+++ b/forge-gui/src/main/java/forge/gui/interfaces/IGuiGame.java
@@ -83,6 +83,11 @@ public interface IGuiGame {
     void handleLandPlayed(CardView land);
 
     void handleGameEvent(GameEvent event);
+    default void handleGameEvents(List<GameEvent> events) {
+        for (GameEvent event : events) {
+            handleGameEvent(event);
+        }
+    }
 
     Iterable<PlayerZoneUpdate> tempShowZones(PlayerView controller, Iterable<PlayerZoneUpdate> zonesToUpdate);
 


### PR DESCRIPTION
@tool4ever: issue with GameEvent refactor discovered while investigating user reports of recent increased network lag, and AI solution below:

---
## Summary

PR #9760 (GameEvent refactor) changed how game events reach remote clients. Previously, the server's `FControlGameEventHandler` batched events into coalesced UI updates and `NetGuiGame` sent ~3-5 protocol messages per game action. After the refactor, a `GameEventForwarder` sends every individual `GameEvent` immediately via `NetGuiGame.handleGameEvent()`, which calls `updateGameView()` + `send(handleGameEvent, event)` per event.

`updateGameView()` serializes and sends the **complete `GameView`** over the network every time it's called. A single game action that fires N events now generates 2N network messages (N full GameView serializations + N event messages) instead of the ~4-6 messages it sent before.

There are ~200 `fireEvent` call sites across the game engine, and events frequently fire in bursts — for example, combat resolution, stack processing, or phase transitions can fire 10+ events in rapid succession. That means 10+ redundant full GameView serializations for a single game action.

This also affects the delta sync branch (NetworkPlay/main), though the cost is much smaller there — `updateGameView()` only sends changed properties and skips entirely when nothing has changed, so redundant calls are cheap rather than expensive. Still, batching eliminates unnecessary delta-sync comparisons and empty-check overhead.

## Fix

- **Batch events in `GameEventForwarder`** using EDT coalescing (the same `invokeInEdtLater` gate pattern used by `FControlGameEventHandler` before the refactor). Events that fire in rapid succession are collected and flushed as a single batch.
- **Add `handleGameEvents(List<GameEvent>)` to `IGuiGame`** with a default implementation that delegates to `handleGameEvent` one-by-one — no impact on local play, desktop GUI, or mobile.
- **Override in `NetGuiGame`** to call `updateGameView()` once, then send each event individually. This reuses the existing `ProtocolMethod.handleGameEvent` protocol method, so no client-side changes are needed.

For a game action firing 10 events, network messages drop from 20 (10 full GameView + 10 event) to 11 (1 GameView + 10 event). The full GameView serialization is the dominant cost, so this eliminates the main source of redundant network traffic.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)