### PR TITLE
(Bug Fix) Add heartbeat-based network disconnect detection

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/gui/FNetOverlay.java
+++ b/forge-gui-desktop/src/main/java/forge/gui/FNetOverlay.java
@@ -20,6 +20,7 @@ import forge.Singletons;
 import forge.gamemodes.net.ChatMessage;
 import forge.gamemodes.net.IOnlineChatInterface;
 import forge.gamemodes.net.IRemote;
+import forge.gamemodes.net.client.FGameClient;
 import forge.gamemodes.net.event.MessageEvent;
 import forge.gui.framework.SDisplayUtil;
 import forge.localinstance.properties.ForgePreferences;
@@ -101,6 +102,12 @@ public enum FNetOverlay implements IOnlineChatInterface {
         }
 
         if (remote != null) {
+            if ("/simulatedisconnect".equalsIgnoreCase(message.trim()) && remote instanceof FGameClient) {
+                System.out.println("[FNetOverlay] /simulatedisconnect intercepted, remote=" + remote.getClass().getSimpleName());
+                addMessage(ChatMessage.createSystemMessage("Simulating disconnect: all network writes suspended."));
+                ((FGameClient) remote).simulateDisconnect();
+                return;
+            }
             remote.send(new MessageEvent(prefs.getPref(FPref.PLAYER_NAME), message));
         }
     };

--- a/forge-gui/src/main/java/forge/gamemodes/net/event/HeartbeatEvent.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/event/HeartbeatEvent.java
@@ -1,0 +1,16 @@
+package forge.gamemodes.net.event;
+
+import forge.gamemodes.net.server.RemoteClient;
+
+public final class HeartbeatEvent implements NetEvent {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void updateForClient(final RemoteClient client) {
+    }
+
+    @Override
+    public String toString() {
+        return "Heartbeat";
+    }
+}


### PR DESCRIPTION
Addresses capability gap in reconnect function - thanks to _Chairbender_ for thorough bug report on Discord channel:

(Note although _Chairbender_ suggested the same solution in their bug report, Claude AI has investigated this and independently came to the same conclusion it was the best way to address the issue).

---

## Summary

When a client crashes, loses connectivity, or is force-closed during a network game, the server can have no way to detect it. The TCP connection remains open — a clean shutdown would send a FIN packet and a protocol error would trigger a RST, but a crash or network loss produces neither. The client just goes silent, and from the server's perspective it's indistinguishable from a slow player. TCP keepalive defaults are far too slow (often 2+ hours), so the game hangs indefinitely waiting for input that will never come, with no indication to the host or other players that anything went wrong.

This adds a heartbeat mechanism:
- Client sends a lightweight heartbeat every 15s if it hasn't sent any other network traffic in that time
- Server closes the connection if it receives no data at all (no heartbeats, game events, or chat messages) for 45s
- Timeout is announced in chat so all players know what happened
- Timeouts are configurable via `-Dforge.net.heartbeatInterval` and `-Dforge.net.heartbeatTimeout`

Also adds `/simulatedisconnect` as a client chat command for debug testing — it silently stops all network writes while keeping TCP open, artificially replicating a client crash.

## Testing

Manually tested. After typing `/simulatedisconnect`:
- Client chat shows confirmation message
- Server detects timeout and announces it in chat
- Existing reconnection flow (AI takeover, reconnect timer) activates normally

---
  🤖 Generated with [Claude Code](https://claude.com/claude-code)

