### PR TITLE
Fix NPE in VMatchUI.populate when cellWithHands is null

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/screens/match/VMatchUI.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/VMatchUI.java
@@ -204,16 +204,26 @@ public class VMatchUI implements IVTopLevelUI {
 
         // Determine (an) existing hand panel
         DragCell cellWithHands = null;
+        DragCell cellWithHandsFallback = null;
         for (final EDocID handId : EDocID.Hands) {
-            cellWithHands = handId.getDoc().getParentCell();
-            if (cellWithHands != null && cellWithHands.isShowing()) {
-                break;
+            final DragCell c = handId.getDoc().getParentCell();
+            if (c != null) {
+                if (cellWithHandsFallback == null) {
+                    cellWithHandsFallback = c;
+                }
+                if (c.isShowing()) {
+                    cellWithHands = c;
+                    break;
+                }
             }
-            cellWithHands = null;
         }
         if (cellWithHands == null) {
-            // Default to a cell we know exists
             cellWithHands = EDocID.REPORT_LOG.getDoc().getParentCell();
+        }
+        // Last resort: use any hand cell even if not yet showing (e.g. during
+        // initial game load before Swing has realized the components).
+        if (cellWithHands == null) {
+            cellWithHands = cellWithHandsFallback;
         }
         for (int iHandId = 0; iHandId < EDocID.Hands.length; iHandId++) {
             final EDocID handId = EDocID.Hands[iHandId];
@@ -237,11 +247,13 @@ public class VMatchUI implements IVTopLevelUI {
                 if (parentCell == null || !parentCell.isShowing()) {
                     final EDocID fieldDoc = EDocID.Fields[iHandId];
                     DragCell fieldCell = fieldDoc.getDoc().getParentCell();
-                    if (fieldCell != null && fieldCell.isShowing()) {
+                    if (fieldCell != null && (fieldCell.isShowing() || cellWithHands == null)) {
                         fieldCell.addDoc(myVHand);
                         continue;
                     }
-                    cellWithHands.addDoc(myVHand);
+                    if (cellWithHands != null) {
+                        cellWithHands.addDoc(myVHand);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fixes the crash on game start reported by smokeweedle on Discord, caused by a null `cellWithHands` in `VMatchUI.populate()`.

#9637 added `isShowing()` checks to the hand discovery loop so that after a layout refresh, hands wouldn't get placed into stale cells that existed in memory but were no longer part of the visible layout. However, these same checks can also reject perfectly valid cells during initial game load — before Swing has fully realized the components, or when the user's saved layout is missing expected panels like REPORT_LOG. When every cell fails the `isShowing()` check and all fallbacks return null, the game crashes with:

```
java.lang.NullPointerException: Cannot invoke "forge.gui.framework.DragCell.addDoc(forge.gui.framework.IVDoc)" because "cellWithHands" is null
    at forge.screens.match.VMatchUI.populate(VMatchUI.java:244)
```

The fix adds a last-resort fallback that remembers any existing hand cell even if not yet showing. If every fallback still somehow returns null, the hand placement is skipped rather than crashing — the hand panel will appear on the next layout refresh or repopulate call.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)