### PR TITLE
Card cleanup: 2026-02-22, incidental

### DIFF
--- a/forge-gui/res/cardsfolder/d/drivnod_carnage_dominus.txt
+++ b/forge-gui/res/cardsfolder/d/drivnod_carnage_dominus.txt
@@ -3,6 +3,6 @@ ManaCost:3 B B
 Types:Legendary Creature Phyrexian Horror
 PT:8/3
 S:Mode$ Panharmonicon | ValidMode$ ChangesZone,ChangesZoneAll | ValidCard$ Permanent.YouCtrl | ValidCause$ Creature | Origin$ Battlefield | Destination$ Graveyard | Description$ If a creature dying causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.
-A:AB$ PutCounter | Cost$ PB PB ExileFromGrave<3/Creature> | Defined$ Self | CounterType$ Indestructible | CounterNum$ 1 | SpellDescription$ Put an indestructible counter on CARDNAME.
+A:AB$ PutCounter | Cost$ BP BP ExileFromGrave<3/Creature> | Defined$ Self | CounterType$ Indestructible | CounterNum$ 1 | SpellDescription$ Put an indestructible counter on CARDNAME.
 DeckHas:Ability$Counters
 Oracle:If a creature dying causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\n{B/P}{B/P}, Exile three creature cards from your graveyard: Put an indestructible counter on Drivnod, Carnage Dominus. ({B/P} can be paid with either {B} or 2 life.)

--- a/forge-gui/res/cardsfolder/e/electros_bolt.txt
+++ b/forge-gui/res/cardsfolder/e/electros_bolt.txt
@@ -5,4 +5,3 @@ Types:Sorcery
 A:SP$ DealDamage | ValidTgts$ Creature | NumDmg$ 4 | SpellDescription$ CARDNAME deals 4 damage to target creature.
 K:Mayhem:1 R
 Oracle:Electro's Bolt deals 4 damage to target creature.\nMayhem {1}{R} (You may cast this card from your graveyard for {1}{R} if you discarded it this turn. Timing rules still apply.)
-

--- a/forge-gui/res/cardsfolder/o/omnath_locus_of_all.txt
+++ b/forge-gui/res/cardsfolder/o/omnath_locus_of_all.txt
@@ -1,5 +1,5 @@
 Name:Omnath, Locus of All
-ManaCost:W U PB R G
+ManaCost:W U BP R G
 Types:Legendary Creature Phyrexian Elemental
 PT:4/4
 R:Event$ LoseMana | ValidPlayer$ You | ReplacementResult$ Replaced | ReplaceWith$ ConvertMana | ActiveZones$ Battlefield | Description$ If you would lose unspent mana, that mana becomes black instead.

--- a/forge-gui/res/cardsfolder/p/phyrexian_chimney_imp.txt
+++ b/forge-gui/res/cardsfolder/p/phyrexian_chimney_imp.txt
@@ -1,5 +1,5 @@
 Name:Phyrexian Chimney Imp
-ManaCost:4 PB
+ManaCost:4 BP
 Types:Creature Phyrexian Imp
 PT:2/3
 K:Flying

--- a/forge-gui/res/cardsfolder/r/rhinos_rampage.txt
+++ b/forge-gui/res/cardsfolder/r/rhinos_rampage.txt
@@ -1,5 +1,5 @@
 Name:Rhino's Rampage
-ManaCost:GR
+ManaCost:RG
 Types:Sorcery
 A:SP$ Pump | ValidTgts$ Creature.YouCtrl | AILogic$ Fight | TgtPrompt$ Select target creature you control | SubAbility$ DBFight | NumAtt$ +1 | SpellDescription$ Target creature you control gets +1/+0 until end of turn. It fights target creature an opponent controls.
 SVar:DBFight:DB$ Fight | Defined$ ParentTarget | ValidTgts$ Creature.OppCtrl | ExcessSVar$ Excess | ExcessSVarCondition$ Creature.targetedBy+OppCtrl | SubAbility$ DBImmediateTrig | TgtPrompt$ Select target creature an opponent controls.

--- a/forge-gui/res/cardsfolder/s/shaman_of_the_great_hunt.txt
+++ b/forge-gui/res/cardsfolder/s/shaman_of_the_great_hunt.txt
@@ -5,6 +5,6 @@ PT:4/2
 K:Haste
 T:Mode$ DamageDone | ValidSource$ Creature.YouCtrl | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigPutCounter | TriggerZones$ Battlefield | TriggerDescription$ Whenever a creature you control deals combat damage to a player, put a +1/+1 counter on it.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ TriggeredSourceLKICopy | CounterType$ P1P1 | CounterNum$ 1
-A:AB$ Draw | Cost$ 2 UG UG | NumCards$ X | PrecostDesc$ Ferocious — | SpellDescription$ Draw a card for each creature with power 4 or greater you control.
+A:AB$ Draw | Cost$ 2 GU GU | NumCards$ X | PrecostDesc$ Ferocious — | SpellDescription$ Draw a card for each creature with power 4 or greater you control.
 SVar:X:Count$Valid Creature.powerGE4+YouCtrl
 Oracle:Haste\nWhenever a creature you control deals combat damage to a player, put a +1/+1 counter on it.\nFerocious — {2}{G/U}{G/U}: Draw a card for each creature you control with power 4 or greater.

--- a/forge-gui/res/cardsfolder/upcoming/level_up.txt
+++ b/forge-gui/res/cardsfolder/upcoming/level_up.txt
@@ -8,5 +8,5 @@ SVar:TrigPutCounter:DB$ PutCounter | Defined$ Enchanted | CounterType$ P1P1 | Co
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddTrigger$ AttackTrig | Description$ Enchanted creature has "Whenever this creature attacks, double the number of +1/+1 counters on it. Then if it has power 10 or greater, draw a card."
 SVar:AttackTrig:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigDouble | TriggerDescription$ Whenever this creature attacks, double the number of +1/+1 counters on it. Then if it has power 10 or greater, draw a card.
 SVar:TrigDouble:DB$ MultiplyCounter | Defined$ TriggeredSourceLKICopy | CounterType$ P1P1 | SubAbility$ DBDraw
-SVar:DBDraw:DB$ Draw |  ConditionCheckSVar$ TriggeredAttacker$CardPower | ConditionSVarCompare$ GE10
+SVar:DBDraw:DB$ Draw | ConditionCheckSVar$ TriggeredAttacker$CardPower | ConditionSVarCompare$ GE10
 Oracle:Enchant creature\nWhen this Aura enters, put a +1/+1 counter on enchanted creature.\nEnchanted creature has "Whenever this creature attacks, double the number of +1/+1 counters on it. Then if it has power 10 or greater, draw a card."


### PR DESCRIPTION
Dealing with a few instances of extraneous whitespace and standardizing the order of components for hybrid mana with reference to the most common variant in scripts, Scryfall and the symbols themselves where relevant. 