### PR TITLE
Fix arena item rewards always yielding the same item

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/data/RewardData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/RewardData.java
@@ -257,7 +257,7 @@ public class RewardData implements Serializable {
                 case "item":
                     if(itemNames!=null) {
                         for (int i = 0; i < count + addedCount; i++) {
-                            String itemName = itemNames[WorldSave.getCurrentSave().getWorld().getRandom().nextInt(itemNames.length)];
+                            String itemName = itemNames[rewardRandom.nextInt(itemNames.length)];
                             ItemData itemData = ItemListData.getItem(itemName);
                             if (itemData != null)
                                 ret.add(new Reward(itemData));
@@ -297,7 +297,7 @@ public class RewardData implements Serializable {
                         allEditions.removeIf(q -> q.getDate().getYear()+1900 < startDate || q.getDate().getYear()+1900 > endDate);
                         for (int i = 0; i < count + addedCount; i++) {
                             ret.add(new Reward(AdventureEventController.instance().generateBooster(
-                                allEditions.get(WorldSave.getCurrentSave().getWorld().getRandom().nextInt(allEditions.size())).getCode())));
+                                allEditions.get(rewardRandom.nextInt(allEditions.size())).getCode())));
                         }
                     } else {
                         for (int i = 0; i < count + addedCount; i++) {
@@ -309,7 +309,7 @@ public class RewardData implements Serializable {
                 case "landSketchbookShop":
                     Array<ItemData> sketchbookItems = ItemListData.getSketchBooks();
                     for (int i = 0; i < count + addedCount; i++) {
-                        ItemData item = sketchbookItems.get(WorldSave.getCurrentSave().getWorld().getRandom().nextInt(sketchbookItems.size));
+                        ItemData item = sketchbookItems.get(rewardRandom.nextInt(sketchbookItems.size));
                         if (item != null)
                             ret.add(new Reward(item));
                     }


### PR DESCRIPTION
- Three reward branches in `RewardData.generate()` (`item`, `cardPackShop`, `landSketchbookShop`) bypassed the local `rewardRandom` and called `WorldSave.getWorld().getRandom()` directly
- For arena loot where `useSeedlessRandom=true`, this used the deterministic world RNG (re-seeded on every map load) instead of a fresh `Random` instance
- Capital arena item rewards resolved to the same item on every visit because the world random reached the same state each time
- Replace all three direct world-random calls with `rewardRandom`, matching every other branch in the method
- No behavioral change for shops (`useSeedlessRandom=false`), where `rewardRandom` already references the world random

(Bug reported by @CrystalCreation on 21.2.26 in the Old Border channel)