### PR TITLE
fixes AI for Glistening deluge #6378

### DIFF
--- a/forge-gui/res/cardsfolder/g/glistening_deluge.txt
+++ b/forge-gui/res/cardsfolder/g/glistening_deluge.txt
@@ -1,6 +1,6 @@
 Name:Glistening Deluge
 ManaCost:1 B B
 Types:Sorcery
-A:SP$ PumpAll | ValidCards$ Creature | NumAtt$ -1 | NumDef$ -1 | SubAbility$ DBDebuff | SpellDescription$ All creatures get -1/-1 until end of turn. Creatures that are green and/or white get an additional -2/-2 until end of turn.
+A:SP$ PumpAll | IsCurse$ True | ValidCards$ Creature | NumAtt$ -1 | NumDef$ -1 | SubAbility$ DBDebuff | SpellDescription$ All creatures get -1/-1 until end of turn. Creatures that are green and/or white get an additional -2/-2 until end of turn.
 SVar:DBDebuff:DB$ PumpAll | ValidCards$ Creature.White,Creature.Green | NumAtt$ -2 | NumDef$ -2
 Oracle:All creatures get -1/-1 until end of turn. Creatures that are green and/or white get an additional -2/-2 until end of turn.


### PR DESCRIPTION
Checked with following game state:

```
turn=1
activeplayer=p1
activephase=MAIN1
p0life=20
p0landsplayed=0
p0landsplayedlastturn=0
p0numringtemptedyou=0
p0speed=0
p0manapool=W W G G
p0hand=
p0library=Forest|Set:LEA|Art:1
p0graveyard=
p0battlefield=Birds of Paradise|Set:LEA|Art:1;Champion of Rhonas|Set:AKH|Art:1;Birds of Paradise|Set:LEA|Art:1;Birds of Paradise|Set:LEA|Art:1|Tapped;Birds of Paradise|Set:LEA|Art:1|Tapped;Forest|Set:LEA|Art:1|Tapped;Forest|Set:LEA|Art:1|Tapped
p0exile=
p0command=
p0sideboard=
p1life=2
p1landsplayed=0
p1landsplayedlastturn=0
p1numringtemptedyou=0
p1speed=0
p1hand=Glistening Deluge|Set:MOM|Art:1
p1library=Swamp|Set:LEA|Art:1
p1graveyard=
p1battlefield=Swamp|Set:LEA|Art:1;Swamp|Set:LEA|Art:1;Swamp|Set:LEA|Art:1
p1exile=
p1command=
p1sideboard=
```

AI will cast Glistening deluge in MAIN2