### PR TITLE
Fix network game race condition from event batching

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/match/HostedMatch.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/HostedMatch.java
@@ -226,7 +226,9 @@ public class HostedMatch {
                 gui.setOriginalGameController(p.getView(), humanController);
 
                 if (gui instanceof forge.gamemodes.net.server.NetGuiGame) {
-                    game.subscribeToEvents(new forge.gui.control.GameEventForwarder(gui));
+                    forge.gui.control.GameEventForwarder forwarder = new forge.gui.control.GameEventForwarder(gui);
+                    ((forge.gamemodes.net.server.NetGuiGame) gui).setForwarder(forwarder);
+                    game.subscribeToEvents(forwarder);
                 } else {
                     game.subscribeToEvents(new FControlGameEventHandler(humanController));
                 }


### PR DESCRIPTION
@tool4ever 

---

The batching commit (742c7ba3) introduced a race condition for network games. Events were queued and flushed on the Swing EDT, leaving the game thread free to modify `FCollection`/`EnumMap` objects while Netty serialized them on the I/O thread -causing `ArrayIndexOutOfBoundsException` in `EnumMap.writeObject()`.

This fix flushes events on the game thread instead of EDT, so the game thread blocks during serialization. Batching is preserved via time (50ms) and size (50 event) thresholds. A pre-send flush in `NetGuiGame` guarantees events reach the client before any interactive prompt.

3 files changed, no engine modifications.

Tested in local network play (host + remote client) - previously had repeated `ArrayIndexOutOfBoundsException` during serialization, now no errors following fix.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)