### PR TITLE
Fix music continuing to play after closing Forge

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/control/FControl.java
+++ b/forge-gui-desktop/src/main/java/forge/control/FControl.java
@@ -60,6 +60,7 @@ import forge.localinstance.properties.ForgePreferences.FPref;
 import forge.localinstance.skin.FSkinProp;
 import forge.menus.ForgeMenu;
 import forge.model.FModel;
+import forge.sound.SoundSystem;
 import forge.player.GamePlayerUtil;
 import forge.screens.deckeditor.CDeckEditorUI;
 import forge.toolbox.FOptionPane;
@@ -231,6 +232,7 @@ public enum FControl implements KeyEventDispatcher {
         if (!canExitForge(false)) {
             return false;
         }
+        SoundSystem.instance.dispose();
         Singletons.getView().getFrame().setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
         System.exit(0);
         return true;

--- a/forge-gui-desktop/src/main/java/forge/sound/AudioMusic.java
+++ b/forge-gui-desktop/src/main/java/forge/sound/AudioMusic.java
@@ -52,7 +52,7 @@ public class AudioMusic implements IAudioMusic {
                     }
                 }
             });
-            new Thread(() -> {
+            Thread musicThread = new Thread(() -> {
                 try {
                     isPlaying = true;
                     musicPlayer.play();
@@ -62,7 +62,9 @@ public class AudioMusic implements IAudioMusic {
                     valid = false;
                     isPlaying = false;
                 }
-            }, "Audio Music").start();
+            }, "Audio Music");
+            musicThread.setDaemon(true);
+            musicThread.start();
         }
         catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
## Summary

Music continued playing for 5-10 seconds after closing the application. `exitForge()` called `System.exit(0)` without stopping audio first, and shutdown hooks (e.g. Netty graceful shutdown) kept the JVM alive while the music thread was still running.

- Dispose the sound system before `System.exit(0)` so music stops immediately
- Mark the music playback thread as daemon as a safety net

2 files changed.

## Test plan

- [x] Tested locally — music stops immediately on close

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)