### PR TITLE
Deck importer improvements - Commander detection heuristic / misc fixes

### DIFF
--- a/forge-core/src/main/java/forge/deck/DeckRecognizer.java
+++ b/forge-core/src/main/java/forge/deck/DeckRecognizer.java
@@ -490,8 +490,6 @@ public class DeckRecognizer {
             "avatar", "commander", "companion", "schemes",
             "conspiracy", "planes", "deck", "dungeon",
             "attractions", "contraptions"};
-    private static final CharSequence[] IGNORABLE_SECTION_NAMES = {
-            "maybeboard", "maybe", "considering", "tokens"};
 
     private static CharSequence[] allCardTypes(){
         List<String> cardTypesList = new ArrayList<>();
@@ -524,7 +522,6 @@ public class DeckRecognizer {
     public List<Token> parseCardList(String[] cardList) {
         List<Token> tokens = new ArrayList<>();
         DeckSection referenceDeckSectionInParsing = null;  // default
-        boolean inIgnoredSection = false;
 
         for (String line : cardList) {
             Token token = this.recognizeLine(line, referenceDeckSectionInParsing);
@@ -532,23 +529,6 @@ public class DeckRecognizer {
                 continue;
 
             TokenType tokenType = token.getType();
-
-            // A valid deck section header resets the ignored-section flag
-            if (tokenType == TokenType.DECK_SECTION_NAME) {
-                inIgnoredSection = false;
-            }
-
-            // Detect ignorable section headers (Maybeboard, Tokens, etc.)
-            if (!inIgnoredSection && tokenType == TokenType.UNKNOWN_TEXT
-                    && isIgnorableSection(line.trim())) {
-                inIgnoredSection = true;
-            }
-
-            // While in an ignored section, suppress all tokens as comments
-            if (inIgnoredSection) {
-                tokens.add(new Token(TokenType.COMMENT, 0, line.trim()));
-                continue;
-            }
 
             if (!token.isTokenForDeck() && (tokenType != TokenType.DECK_SECTION_NAME) ||
                     (tokenType == TokenType.LIMITED_CARD && !this.includeBannedAndRestricted)) {
@@ -936,12 +916,6 @@ public class DeckRecognizer {
         return StringUtils.equalsAnyIgnoreCase(nonCardToken, DECK_SECTION_NAMES);
     }
 
-    public static boolean isIgnorableSection(final String lineAsIs) {
-        String nonCardToken = nonCardTokenMatch(lineAsIs);
-        if (nonCardToken == null)
-            return false;
-        return StringUtils.equalsAnyIgnoreCase(nonCardToken, IGNORABLE_SECTION_NAMES);
-    }
 
     private static String nonCardTokenMatch(final String lineAsIs){
         if (lineAsIs == null)

--- a/forge-core/src/main/java/forge/deck/DeckRecognizer.java
+++ b/forge-core/src/main/java/forge/deck/DeckRecognizer.java
@@ -529,7 +529,6 @@ public class DeckRecognizer {
                 continue;
 
             TokenType tokenType = token.getType();
-
             if (!token.isTokenForDeck() && (tokenType != TokenType.DECK_SECTION_NAME) ||
                     (tokenType == TokenType.LIMITED_CARD && !this.includeBannedAndRestricted)) {
                 // Just bluntly add the token to the list and proceed.
@@ -915,7 +914,6 @@ public class DeckRecognizer {
             return false;
         return StringUtils.equalsAnyIgnoreCase(nonCardToken, DECK_SECTION_NAMES);
     }
-
 
     private static String nonCardTokenMatch(final String lineAsIs){
         if (lineAsIs == null)

--- a/forge-core/src/main/java/forge/deck/DeckRecognizer.java
+++ b/forge-core/src/main/java/forge/deck/DeckRecognizer.java
@@ -159,7 +159,8 @@ public class DeckRecognizer {
         public static Token DeckSection(final String sectionName0, List<DeckSection> allowedDeckSections){
             String sectionName = sectionName0.toLowerCase().trim();
             DeckSection matchedSection = null;
-            if (sectionName.equals("side") || sectionName.contains("sideboard") || sectionName.equals("sb"))
+            if (sectionName.equals("side") || sectionName.contains("sideboard") || sectionName.equals("sb")
+                    || sectionName.equals("companion"))
                 matchedSection = DeckSection.Sideboard;
             else if (sectionName.equals("main") || sectionName.contains("card")
                     || sectionName.equals("mainboard") || sectionName.equals("deck"))
@@ -406,7 +407,7 @@ public class DeckRecognizer {
     // Core Matching Patterns (initialised in Constructor)
     public static final String REGRP_DECKNAME = "deckName";
     public static final String REX_DECK_NAME =
-            String.format("^(\\/\\/\\s*)?(?<pre>(deck|name(\\s)?))(\\:|=)\\s*(?<%s>([a-zA-Z0-9',\\/\\-\\s\\)\\]\\(\\[\\#]+))\\s*(.*)$",
+            String.format("^(\\/\\/\\s*)?(?<pre>(deck|name(\\s)?))(\\:|=|\\s+)\\s*(?<%s>([a-zA-Z0-9',\\/\\-\\s\\)\\]\\(\\[\\#!]+))\\s*(.*)$",
                     REGRP_DECKNAME);
     public static final Pattern DECK_NAME_PATTERN = Pattern.compile(REX_DECK_NAME, Pattern.CASE_INSENSITIVE);
 
@@ -433,7 +434,7 @@ public class DeckRecognizer {
     public static final String REGRP_CARD = "cardname";
     public static final String REGRP_CARDNO = "count";
 
-    public static final String REX_CARD_NAME = String.format("(\\[)?(?<%s>[a-zA-Z0-9à-ÿÀ-Ÿ&',\\.:!\\+\\\"\\/\\-\\s]+)(\\])?", REGRP_CARD);
+    public static final String REX_CARD_NAME = String.format("(\\[)?(?<%s>[a-zA-Z0-9à-ÿÀ-Ÿ&',\\.:!\\?\\+\\\"\\/\\-\\s]+)(\\])?", REGRP_CARD);
     public static final String REX_SET_CODE = String.format("(?<%s>[a-zA-Z0-9_]{2,7})", REGRP_SET);
     public static final String REX_COLL_NUMBER = String.format("(?<%s>\\*?[0-9A-Z]+(?:\\S[0-9A-Z]*)?)", REGRP_COLLNR);
     public static final String REX_CARD_COUNT = String.format("(?<%s>[\\d]{1,2})(?<mult>x)?", REGRP_CARDNO);
@@ -486,9 +487,11 @@ public class DeckRecognizer {
     private static final CharSequence[] DECK_SECTION_NAMES = {
             "side", "sideboard", "sb",
             "main", "card", "mainboard",
-            "avatar", "commander", "schemes",
+            "avatar", "commander", "companion", "schemes",
             "conspiracy", "planes", "deck", "dungeon",
             "attractions", "contraptions"};
+    private static final CharSequence[] IGNORABLE_SECTION_NAMES = {
+            "maybeboard", "maybe", "considering", "tokens"};
 
     private static CharSequence[] allCardTypes(){
         List<String> cardTypesList = new ArrayList<>();
@@ -521,13 +524,32 @@ public class DeckRecognizer {
     public List<Token> parseCardList(String[] cardList) {
         List<Token> tokens = new ArrayList<>();
         DeckSection referenceDeckSectionInParsing = null;  // default
-        
+        boolean inIgnoredSection = false;
+
         for (String line : cardList) {
             Token token = this.recognizeLine(line, referenceDeckSectionInParsing);
             if (token == null)
                 continue;
 
             TokenType tokenType = token.getType();
+
+            // A valid deck section header resets the ignored-section flag
+            if (tokenType == TokenType.DECK_SECTION_NAME) {
+                inIgnoredSection = false;
+            }
+
+            // Detect ignorable section headers (Maybeboard, Tokens, etc.)
+            if (!inIgnoredSection && tokenType == TokenType.UNKNOWN_TEXT
+                    && isIgnorableSection(line.trim())) {
+                inIgnoredSection = true;
+            }
+
+            // While in an ignored section, suppress all tokens as comments
+            if (inIgnoredSection) {
+                tokens.add(new Token(TokenType.COMMENT, 0, line.trim()));
+                continue;
+            }
+
             if (!token.isTokenForDeck() && (tokenType != TokenType.DECK_SECTION_NAME) ||
                     (tokenType == TokenType.LIMITED_CARD && !this.includeBannedAndRestricted)) {
                 // Just bluntly add the token to the list and proceed.
@@ -601,6 +623,12 @@ public class DeckRecognizer {
             line = SEARCH_SINGLE_SLASH.matcher(line).replaceFirst(" // ");
         if (line.startsWith(ASTERISK))  // Markdown lists (tappedout md export)
             line = line.substring(2);
+        // Moxfield foil/etched markers
+        if (line.endsWith("*F*")) {
+            line = line.substring(0, line.length() - 3).trim() + " (F)";
+        } else if (line.endsWith("*E*")) {
+            line = line.substring(0, line.length() - 3).trim();
+        }
 
         // == Patches to Corner Cases
         // FIX Commander in Deckstats export
@@ -906,6 +934,13 @@ public class DeckRecognizer {
         if (nonCardToken == null)
             return false;
         return StringUtils.equalsAnyIgnoreCase(nonCardToken, DECK_SECTION_NAMES);
+    }
+
+    public static boolean isIgnorableSection(final String lineAsIs) {
+        String nonCardToken = nonCardTokenMatch(lineAsIs);
+        if (nonCardToken == null)
+            return false;
+        return StringUtils.equalsAnyIgnoreCase(nonCardToken, IGNORABLE_SECTION_NAMES);
     }
 
     private static String nonCardTokenMatch(final String lineAsIs){

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/DeckImport.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/DeckImport.java
@@ -40,7 +40,9 @@ import forge.game.GameType;
 import forge.gui.CardPicturePanel;
 import forge.item.PaperCard;
 import forge.screens.deckeditor.controllers.CDeckEditor;
+import forge.screens.deckeditor.controllers.CEditorConstructed;
 import forge.screens.deckeditor.controllers.CStatisticsImporter;
+import forge.screens.match.controllers.CDetailPicture;
 import forge.screens.deckeditor.views.VStatisticsImporter;
 import forge.toolbox.*;
 import forge.util.Localizer;
@@ -210,6 +212,10 @@ public class DeckImport<TModel extends DeckBase> extends FDialog {
             .getMessage("lblUseFormatFilter"), false);
     private final FComboBox<GameFormat> formatDropdown = new FComboBox<>();
 
+    private JPanel optionsPanel;
+    private JPanel closedOptsPanel;
+    private boolean formatAutoSelected = false;
+
     private final DeckImportController controller;
     private final CDeckEditor<TModel> host;
 
@@ -301,7 +307,7 @@ public class DeckImport<TModel extends DeckBase> extends FDialog {
 
         // == A. (Closed) Option Panel
         // This component will be used as a Placeholder panel to simulate Show/Hide animation
-        JPanel closedOptsPanel = new JPanel(new MigLayout("insets 10, gap 5, left, w 100%"));
+        this.closedOptsPanel = new JPanel(new MigLayout("insets 10, gap 5, left, w 100%"));
         closedOptsPanel.setVisible(true);
         closedOptsPanel.setOpaque(false);
         final TitledBorder showOptsBorder = new TitledBorder(BorderFactory.createEtchedBorder(),
@@ -311,7 +317,7 @@ public class DeckImport<TModel extends DeckBase> extends FDialog {
         closedOptsPanel.add(new JSeparator(JSeparator.HORIZONTAL), "w 100%, hidemode 2");
 
         // == B. (Actual) Options Panel
-        JPanel optionsPanel = new JPanel(new MigLayout("insets 10, gap 5, left, h 150!"));
+        this.optionsPanel = new JPanel(new MigLayout("insets 10, gap 5, left, h 150!"));
         final TitledBorder border = new TitledBorder(BorderFactory.createEtchedBorder(),
                 String.format("\u25BC %s", Localizer.getInstance().getMessage("lblHideOptions")));
         border.setTitleColor(foreColor.getColor());
@@ -522,7 +528,16 @@ public class DeckImport<TModel extends DeckBase> extends FDialog {
                 else
                     deck.setName(currentDeckName);
             }
-            host.getDeckController().loadDeck(deck, controller.getImportBehavior() != DeckImportController.ImportBehavior.MERGE);
+            // If the imported deck has a Commander section but the current editor doesn't support it,
+            // switch to a Commander editor before loading
+            if (deck.has(DeckSection.Commander) && !host.isSectionImportable(DeckSection.Commander)) {
+                CDetailPicture cDetailPicture = CDeckEditorUI.SINGLETON_INSTANCE.getCDetailPicture();
+                CEditorConstructed commanderEditor = new CEditorConstructed(cDetailPicture, GameType.Commander);
+                CDeckEditorUI.SINGLETON_INSTANCE.setEditorController(commanderEditor);
+                commanderEditor.getDeckController().loadDeck(deck, true);
+            } else {
+                host.getDeckController().loadDeck(deck, controller.getImportBehavior() != DeckImportController.ImportBehavior.MERGE);
+            }
             processWindowEvent(new WindowEvent(DeckImport.this, WindowEvent.WINDOW_CLOSING));
         });
 
@@ -662,6 +677,36 @@ public class DeckImport<TModel extends DeckBase> extends FDialog {
             tokens = controller.optimiseCardArtInTokens();
         displayTokens(tokens);
         updateSummaries(tokens);
+
+        // Auto-select Commander format when detected (once per detection — resets when input changes)
+        if (controller.wasCommanderAutoDetected() && controller.hasNoDefaultGameFormat()
+                && !formatAutoSelected) {
+            formatAutoSelected = true;
+            selectCommanderFormat();
+        } else if (!controller.wasCommanderAutoDetected()) {
+            formatAutoSelected = false;
+        }
+    }
+
+    private void selectCommanderFormat() {
+        // Find "Commander" in the format dropdown and select it
+        for (int i = 0; i < formatDropdown.getItemCount(); i++) {
+            GameFormat format = formatDropdown.getItemAt(i);
+            if (format != null && "Commander".equalsIgnoreCase(format.getName())) {
+                formatDropdown.setSelectedIndex(i);
+                break;
+            }
+        }
+        // Enable the format checkbox and dropdown
+        formatSelectionCheck.setSelected(true);
+        formatDropdown.setEnabled(true);
+        // Apply the format to the controller
+        GameFormat selected = formatDropdown.getSelectedItem();
+        if (selected != null)
+            controller.setCurrentGameFormat(selected);
+        // Expand the options panel so the user can see the selection
+        optionsPanel.setVisible(true);
+        closedOptsPanel.setVisible(false);
     }
 
     private void displayTokens(final List<DeckRecognizer.Token> tokens) {

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/DeckImport.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/DeckImport.java
@@ -528,9 +528,12 @@ public class DeckImport<TModel extends DeckBase> extends FDialog {
                 else
                     deck.setName(currentDeckName);
             }
-            // If the imported deck has a Commander section but the current editor doesn't support it,
-            // switch to a Commander editor before loading
-            if (deck.has(DeckSection.Commander) && !host.isSectionImportable(DeckSection.Commander)) {
+            // If the user's format dropdown indicates Commander and the current editor
+            // doesn't support it, switch to a Commander editor before loading.
+            // The format dropdown is auto-set by commander detection (and the options panel
+            // expanded to make it visible), so the user can override before accepting.
+            if (deck.has(DeckSection.Commander) && !host.isSectionImportable(DeckSection.Commander)
+                    && isCommanderFormatSelected()) {
                 CDetailPicture cDetailPicture = CDeckEditorUI.SINGLETON_INSTANCE.getCDetailPicture();
                 CEditorConstructed commanderEditor = new CEditorConstructed(cDetailPicture, GameType.Commander);
                 CDeckEditorUI.SINGLETON_INSTANCE.setEditorController(commanderEditor);
@@ -707,6 +710,13 @@ public class DeckImport<TModel extends DeckBase> extends FDialog {
         // Expand the options panel so the user can see the selection
         optionsPanel.setVisible(true);
         closedOptsPanel.setVisible(false);
+    }
+
+    private boolean isCommanderFormatSelected() {
+        if (!formatSelectionCheck.isSelected())
+            return false;
+        GameFormat selected = formatDropdown.getSelectedItem();
+        return selected != null && "Commander".equalsIgnoreCase(selected.getName());
     }
 
     private void displayTokens(final List<DeckRecognizer.Token> tokens) {

--- a/forge-gui/src/main/java/forge/deck/DeckImportController.java
+++ b/forge-gui/src/main/java/forge/deck/DeckImportController.java
@@ -245,9 +245,11 @@ public class DeckImportController {
         if (!inputContainsCommanderSection(input) && looksLikeCommanderDeck()) {
             if (!this.allowedSections.contains(DeckSection.Commander))
                 this.allowedSections.add(DeckSection.Commander);
-            commanderAutoDetected = true;
-            // Use blank-line separator to identify commander(s)
-            identifyCommanderFromBlankLineSeparator(input);
+            // Use blank-line separator to identify commander(s).
+            // Only flag as auto-detected if a valid commander was actually found,
+            // to avoid false positives on other 100-singleton formats (Canadian Highlander, etc.)
+            if (identifyCommanderFromBlankLineSeparator(input))
+                commanderAutoDetected = true;
         }
 
         if (this.currentGameFormatAllowsCommander()) {
@@ -413,7 +415,7 @@ public class DeckImportController {
      * cards appearing after the last blank line in the input. Only assigns if the trailing card(s)
      * are valid commander candidates (legendary creatures, eligible planeswalkers, etc.).
      */
-    private void identifyCommanderFromBlankLineSeparator(String input) {
+    private boolean identifyCommanderFromBlankLineSeparator(String input) {
         String[] lines = input.split("\n");
         // Find cards after the last blank line
         List<String> trailingCardNames = new ArrayList<>();
@@ -426,7 +428,7 @@ public class DeckImportController {
             trailingCardNames.add(0, lines[i].trim());
         }
         if (!foundBlank || trailingCardNames.isEmpty() || trailingCardNames.size() > 2)
-            return;
+            return false;
 
         // Undo any premature Commander auto-assignments from the recognizer.
         // (The recognizer auto-assigns the first legendary creature to Commander
@@ -466,7 +468,9 @@ public class DeckImportController {
             tokens.add(insertAt, Token.DeckSection(DeckSection.Commander.name(), this.allowedSections));
             for (int i = 0; i < commanderTokens.size(); i++)
                 tokens.add(insertAt + 1 + i, commanderTokens.get(i));
+            return true;
         }
+        return false;
     }
 
     public List<Token> optimiseCardArtInTokens(){

--- a/forge-gui/src/main/java/forge/deck/DeckImportController.java
+++ b/forge-gui/src/main/java/forge/deck/DeckImportController.java
@@ -50,6 +50,7 @@ public class DeckImportController {
     private GameFormat currentGameFormat;
     private GameType currentGameType;
     private final List<DeckSection> allowedSections = new ArrayList<>();
+    private boolean commanderAutoDetected = false;
     private ItemPool<PaperCard> playerInventory;
     /**
      * If a free card is missing from a player's inventory (e.g. a basic land), it gets run through this function, which
@@ -113,6 +114,10 @@ public class DeckImportController {
 
     public boolean hasNoDefaultGameFormat(){
         return this.currentGameFormat == null;
+    }
+
+    public boolean wasCommanderAutoDetected() {
+        return commanderAutoDetected;
     }
 
     public String getCurrentGameFormatName(){
@@ -197,6 +202,15 @@ public class DeckImportController {
     public List<Token> parseInput(String input) {
         tokens.clear();
         cardsInTokens.clear();
+        commanderAutoDetected = false;
+
+        // 5a: Auto-detect Commander format from explicit section headers in input
+        if (!this.allowedSections.contains(DeckSection.Commander)
+                && inputContainsCommanderSection(input)) {
+            this.allowedSections.add(DeckSection.Commander);
+            commanderAutoDetected = true;
+        }
+
         DeckRecognizer recognizer = new DeckRecognizer();
         // Set Art Preference first thing
         recognizer.setArtPreference(this.artPreference);
@@ -223,6 +237,18 @@ public class DeckImportController {
         List<Token> parsedTokens = recognizer.parseCardList(lines);
         if (parsedTokens != null)
             tokens.addAll(parsedTokens);
+
+        // 5b: Heuristic Commander detection for headerless formats (e.g. Moxfield MTGO/Plain Text)
+        // Run when no explicit Commander header exists in the input and the deck looks like Commander.
+        // Note: the recognizer may auto-assign the first legendary creature to Commander section
+        // (DeckRecognizer line 806), so we check for headers rather than section emptiness.
+        if (!inputContainsCommanderSection(input) && looksLikeCommanderDeck()) {
+            if (!this.allowedSections.contains(DeckSection.Commander))
+                this.allowedSections.add(DeckSection.Commander);
+            commanderAutoDetected = true;
+            // Use blank-line separator to identify commander(s)
+            identifyCommanderFromBlankLineSeparator(input);
+        }
 
         if (this.currentGameFormatAllowsCommander()) {
             List<Pair<Integer, Token>> commanderTokens = getTokensInSection(DeckSection.Commander);
@@ -345,6 +371,102 @@ public class DeckImportController {
 
     public boolean currentGameFormatAllowsCommander(){
         return this.allowedSections.contains(DeckSection.Commander) || this.currentGameType == GameType.PlanarConquest;
+    }
+
+    /**
+     * Pre-scan input text for explicit Commander section headers (e.g. from Arena/Moxfield MTGA exports).
+     */
+    private static boolean inputContainsCommanderSection(String input) {
+        for (String line : input.split("\n")) {
+            String trimmed = line.trim().replaceAll("^[/#*]+\\s*", "")
+                    .replaceAll("[:\\s]+$", "").toLowerCase();
+            if (trimmed.equals("commander"))
+                return true;
+            if (line.trim().startsWith("CM:"))
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * Heuristic: detect Commander format from parsed tokens.
+     * Returns true if total card count is 98-102 and all non-basic-land cards are singletons.
+     */
+    private boolean looksLikeCommanderDeck() {
+        int totalCards = 0;
+        boolean allSingletons = true;
+        for (Token token : tokens) {
+            if (!token.isCardToken())
+                continue;
+            totalCards += token.getQuantity();
+            if (token.getQuantity() > 1) {
+                PaperCard card = token.getCard();
+                if (card == null || !card.getRules().getType().isBasicLand())
+                    allSingletons = false;
+            }
+        }
+        return totalCards >= 98 && totalCards <= 102 && allSingletons;
+    }
+
+    /**
+     * For headerless Commander formats (Moxfield MTGO/Plain Text), identify commander(s) from
+     * cards appearing after the last blank line in the input. Only assigns if the trailing card(s)
+     * are valid commander candidates (legendary creatures, eligible planeswalkers, etc.).
+     */
+    private void identifyCommanderFromBlankLineSeparator(String input) {
+        String[] lines = input.split("\n");
+        // Find cards after the last blank line
+        List<String> trailingCardNames = new ArrayList<>();
+        boolean foundBlank = false;
+        for (int i = lines.length - 1; i >= 0; i--) {
+            if (lines[i].trim().isEmpty()) {
+                foundBlank = true;
+                break;
+            }
+            trailingCardNames.add(0, lines[i].trim());
+        }
+        if (!foundBlank || trailingCardNames.isEmpty() || trailingCardNames.size() > 2)
+            return;
+
+        // Undo any premature Commander auto-assignments from the recognizer.
+        // (The recognizer auto-assigns the first legendary creature to Commander
+        // when no section headers are present — move those back to Main first.)
+        for (Token token : tokens) {
+            if (token.isCardToken() && token.getTokenSection() == DeckSection.Commander) {
+                token.resetTokenSection(DeckSection.Main);
+            }
+        }
+
+        // Match trailing card names to tokens, assign to Commander section,
+        // and move them in the token list under a new Commander section header
+        List<Token> commanderTokens = new ArrayList<>();
+        for (Token token : tokens) {
+            if (!token.isCardToken())
+                continue;
+            PaperCard card = token.getCard();
+            if (card == null)
+                continue;
+            for (String trailingLine : trailingCardNames) {
+                if (trailingLine.contains(card.getName()) && DeckSection.Commander.validate(card)) {
+                    token.resetTokenSection(DeckSection.Commander);
+                    commanderTokens.add(token);
+                    break;
+                }
+            }
+        }
+
+        // Move matched commander tokens to a new Commander section at the top of the list
+        if (!commanderTokens.isEmpty()) {
+            for (Token ct : commanderTokens)
+                tokens.remove(ct);
+            // Insert after deck name (index 0) if present, otherwise at the very start
+            int insertAt = 0;
+            if (!tokens.isEmpty() && tokens.get(0).getType() == TokenType.DECK_NAME)
+                insertAt = 1;
+            tokens.add(insertAt, Token.DeckSection(DeckSection.Commander.name(), this.allowedSections));
+            for (int i = 0; i < commanderTokens.size(); i++)
+                tokens.add(insertAt + 1 + i, commanderTokens.get(i));
+        }
     }
 
     public List<Token> optimiseCardArtInTokens(){

--- a/forge-gui/src/main/java/forge/deck/DeckImportController.java
+++ b/forge-gui/src/main/java/forge/deck/DeckImportController.java
@@ -204,7 +204,7 @@ public class DeckImportController {
         cardsInTokens.clear();
         commanderAutoDetected = false;
 
-        // 5a: Auto-detect Commander format from explicit section headers in input
+        // Auto-detect Commander format from explicit section headers in input
         if (!this.allowedSections.contains(DeckSection.Commander)
                 && inputContainsCommanderSection(input)) {
             this.allowedSections.add(DeckSection.Commander);
@@ -238,7 +238,7 @@ public class DeckImportController {
         if (parsedTokens != null)
             tokens.addAll(parsedTokens);
 
-        // 5b: Heuristic Commander detection for headerless formats (e.g. Moxfield MTGO/Plain Text)
+        // Heuristic Commander detection for headerless formats (e.g. Moxfield MTGO/Plain Text)
         // Run when no explicit Commander header exists in the input and the deck looks like Commander.
         // Note: the recognizer may auto-assign the first legendary creature to Commander section
         // (DeckRecognizer line 806), so we check for headers rather than section emptiness.

--- a/forge-gui/src/main/java/forge/deck/DeckImportController.java
+++ b/forge-gui/src/main/java/forge/deck/DeckImportController.java
@@ -240,8 +240,8 @@ public class DeckImportController {
 
         // Heuristic Commander detection for headerless formats (e.g. Moxfield MTGO/Plain Text)
         // Run when no explicit Commander header exists in the input and the deck looks like Commander.
-        // Note: the recognizer may auto-assign the first legendary creature to Commander section
-        // (DeckRecognizer line 806), so we check for headers rather than section emptiness.
+        // Note: the recognizer auto-assigns the first legendary creature to Commander section
+        // when Commander is allowed, so we check for headers rather than section emptiness.
         if (!inputContainsCommanderSection(input) && looksLikeCommanderDeck()) {
             if (!this.allowedSections.contains(DeckSection.Commander))
                 this.allowedSections.add(DeckSection.Commander);


### PR DESCRIPTION
## Summary

Several improvements to the deck importer:

1. **Commander detection heuristics:** Two-tier heuristic for automatically detecting and assigning to Commander format. 
   - When Commander is auto-detected, the options panel is expanded and the format dropdown is automatically enabled and set to Commander so the detection is visible and the **user can choose to override it**. 
   - When accepting a deck with Commander format from a non-Commander editor, automatically switch to the Commander editor.
   - Auto-detect criteria:
        - Explicit headers  (`Commander`, `//Commander`, `CM:`) - auto-detect as Commander
        - Headerless heuristic (98-102 singleton cards + blank-line separator) - identify commander from cards after the last blank line (common Commander export format in plain text e.g. Moxfield), validated with `DeckSection.Commander.validate()`. The blank-line heuristic guards against false positives on other 100-card singleton formats (e.g. Canadian Highlander) by requiring the trailing card(s) to be valid commander candidates (legendary creatures, eligible planeswalkers).


3. **Companion section**: Map `Companion` header to Sideboard (Forge auto-detects companions at game start). Without this, companion cards fall into the preceding section (typically Commander), creating a bogus second commander.

4. **Card name regex**: Added `?` to support cards like `Continue?`

5. **Foil/etched markers**: Strip Moxfield `*F*`/`*E*` suffixes so cards are recognized

6.  **Deck name with space separator**: Accept `Name Turtle Power!` format

## Known limitations

- **Mobile**: The shared controller correctly identifies commanders and builds the deck with a Commander section, but the mobile import dialog (`FDeckImportDialog`) does not have format selection UI or editor switching. Commander cards are silently dropped when importing into a Constructed editor on mobile. This is a pre-existing limitation, not a regression.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
