### PR TITLE
Log version and system info at desktop startup

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/view/Main.java
+++ b/forge-gui-desktop/src/main/java/forge/view/Main.java
@@ -58,6 +58,7 @@ public final class Main {
 
         //install our error handler
         ExceptionHandler.registerErrorHandling();
+        GuiBase.logHWInfo();
 
         // Start splash screen first, then data models, then controller.
         if (args.length == 0) {

--- a/forge-gui-mobile/src/forge/Forge.java
+++ b/forge-gui-mobile/src/forge/Forge.java
@@ -170,8 +170,8 @@ public class Forge implements ApplicationListener {
     public void create() {
         //install our error handler
         ExceptionHandler.registerErrorHandling();
-        //init hwInfo to log
-        System.out.println(GuiBase.getHWInfo());
+        //log version and system info
+        GuiBase.logHWInfo();
         // closeSplashScreen() is called early on non-Windows OS so it will not crash, LWJGL3 bug on AWT Splash.
         if (OperatingSystem.isWindows())
             getDeviceAdapter().closeSplashScreen();

--- a/forge-gui/src/main/java/forge/gui/GuiBase.java
+++ b/forge-gui/src/main/java/forge/gui/GuiBase.java
@@ -4,6 +4,7 @@ import forge.util.HWInfo;
 import forge.gui.interfaces.IGuiBase;
 import forge.gui.interfaces.IGuiGame;
 import forge.localinstance.properties.ForgePreferences;
+import org.tinylog.Logger;
 
 public class GuiBase {
     private static IGuiBase guiInterface;
@@ -42,17 +43,33 @@ public class GuiBase {
         downloadsDir = dir;
     }
     public static String getHWInfo() {
+        Runtime runtime = Runtime.getRuntime();
+        StringBuilder sb = new StringBuilder();
+        sb.append("##########################################\n");
+        sb.append("APP: Forge v.").append(getInterface().getCurrentVersion());
         if (hwInfo != null) {
-            return "##########################################\n" +
-                    "APP: Forge v." + getInterface().getCurrentVersion() +
-                    "\nDEV: " + hwInfo.device().getName() + (hwInfo.getChipset() ?
-                    "\nSOC: " + hwInfo.device().getChipset() :
-                    "\nCPU: " + hwInfo.device().getCpuDescription()) +
-                    "\nRAM: " + deviceRAM + " MB" +
-                    "\nOS: " + hwInfo.os().getRawDescription() +
-                    "\n##########################################";
+            sb.append("\nDEV: ").append(hwInfo.device().getName());
+            sb.append(hwInfo.getChipset()
+                    ? "\nSOC: " + hwInfo.device().getChipset()
+                    : "\nCPU: " + hwInfo.device().getCpuDescription());
+            sb.append("\nRAM: ").append(deviceRAM).append(" MB");
+            sb.append("\nOS: ").append(hwInfo.os().getRawDescription());
+        } else {
+            sb.append("\nJava: ").append(System.getProperty("java.version"))
+                    .append(" (").append(System.getProperty("java.vendor")).append(")");
+            sb.append("\nOS: ").append(System.getProperty("os.name"))
+                    .append(" ").append(System.getProperty("os.version"))
+                    .append(" ").append(System.getProperty("os.arch"));
+            sb.append("\nRAM: ").append(runtime.maxMemory() / 1024 / 1024)
+                    .append(" MB max, ").append(runtime.availableProcessors()).append(" CPUs");
         }
-        return "";
+        sb.append("\n##########################################");
+        return sb.toString();
+    }
+    public static void logHWInfo() {
+        for (String line : getHWInfo().split("\n")) {
+            Logger.info(line);
+        }
     }
     public static String getDownloadsDir() {
         return downloadsDir;


### PR DESCRIPTION
Mobile already logs hardware and version info at startup via `GuiBase.getHWInfo()`, but desktop never called it — `getHWInfo()` returned an empty string when `hwInfo` was null (desktop has no Android hardware detection).

This adds a desktop fallback to `getHWInfo()` that reports Java version, OS, and memory, and calls it from `Main.java` at startup — matching mobile's behavior.

Both entry points now route through `Logger.info()` (tinylog) instead of `System.out.println()` for timestamped, formatted output in `forge.log`:

```
05:48:09 INFO: ##########################################
05:48:09 INFO: APP: Forge v.2.0.11-SNAPSHOT
05:48:09 INFO: Java: 25.0.1 (Oracle Corporation)
05:48:09 INFO: OS: Windows 11 10.0 amd64
05:48:09 INFO: RAM: 4096 MB max, 20 CPUs
05:48:09 INFO: ##########################################
```

3 files, +29/-11.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)