### PR TITLE
Fix CHANGES.txt generation in snapshot and release builds

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -24,7 +24,18 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - name: Fetch history for changelog
+        run: |
+          TAG_SHA=$(gh api repos/${{ github.repository }}/tags \
+            --jq '[.[] | select(.name | startswith("forge-"))][0].commit.sha')
+          if [ -n "$TAG_SHA" ]; then
+            TAG_DATE=$(gh api "repos/${{ github.repository }}/commits/$TAG_SHA" \
+              --jq '.commit.committer.date')
+            git fetch --shallow-since="$TAG_DATE"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/snapshot-both-pc-android.yml
+++ b/.github/workflows/snapshot-both-pc-android.yml
@@ -23,6 +23,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      - name: Fetch history for changelog
+        run: |
+          TAG_SHA=$(gh api repos/${{ github.repository }}/tags \
+            --jq '[.[] | select(.name | startswith("forge-"))][0].commit.sha')
+          if [ -n "$TAG_SHA" ]; then
+            TAG_DATE=$(gh api "repos/${{ github.repository }}/commits/$TAG_SHA" \
+              --jq '.commit.committer.date')
+            git fetch --shallow-since="$TAG_DATE"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/snapshots-android.yml
+++ b/.github/workflows/snapshots-android.yml
@@ -24,7 +24,18 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - name: Fetch history for changelog
+        run: |
+          TAG_SHA=$(gh api repos/${{ github.repository }}/tags \
+            --jq '[.[] | select(.name | startswith("forge-"))][0].commit.sha')
+          if [ -n "$TAG_SHA" ]; then
+            TAG_DATE=$(gh api "repos/${{ github.repository }}/commits/$TAG_SHA" \
+              --jq '.commit.committer.date')
+            git fetch --shallow-since="$TAG_DATE"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/snapshots-pc.yml
+++ b/.github/workflows/snapshots-pc.yml
@@ -19,7 +19,18 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - name: Fetch history for changelog
+        run: |
+          TAG_SHA=$(gh api repos/${{ github.repository }}/tags \
+            --jq '[.[] | select(.name | startswith("forge-"))][0].commit.sha')
+          if [ -n "$TAG_SHA" ]; then
+            TAG_DATE=$(gh api "repos/${{ github.repository }}/commits/$TAG_SHA" \
+              --jq '.commit.committer.date')
+            git fetch --shallow-since="$TAG_DATE"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/forge-gui-desktop/pom.xml
+++ b/forge-gui-desktop/pom.xml
@@ -224,20 +224,26 @@
 try {
     def isOnTag = "git describe --exact-match --tags HEAD".execute().waitFor() == 0
     def tagList = "git tag --sort=-version:refname".execute().text.split("\n")
+        .collect { it.trim() }
         .findAll { it.startsWith("forge-") }
 
-    def tag = "HEAD"
+    def tag = ""
     if (isOnTag && tagList.size() > 1) {
         tag = tagList[1]
     } else if (!isOnTag && tagList.size() > 0) {
         tag = tagList[0]
     }
 
-    project.properties['changelog.from.tag'] = tag
-    println "Using changelog from tag: ${tag}"
+    if (tag.isEmpty()) {
+        println "WARNING: No forge- tags found. CHANGES.txt will be empty."
+        project.properties['changelog.from.tag'] = 'HEAD'
+    } else {
+        project.properties['changelog.from.tag'] = tag
+        println "Using changelog from tag: ${tag}"
+    }
 } catch (Exception e) {
-    project.properties['changelog.from.tag'] = "HEAD"
-    println "Using changelog from tag: HEAD (fallback)"
+    println "WARNING: Could not determine changelog tag: ${e.message}"
+    project.properties['changelog.from.tag'] = 'HEAD'
 }
 ]]>
                             </source>
@@ -259,25 +265,11 @@ try {
                         </goals>
                         <configuration>
                             <!-- Generate changelog from the appropriate tag -->
-                            <fromRef>refs/tags/${changelog.from.tag}</fromRef>
+                            <fromRef>${changelog.from.tag}</fromRef>
                             <file>${project.build.directory}/CHANGES.txt</file>
                             <templateContent>
 <![CDATA[
 {{#tags}}
-## {{name}}
- {{#issues}}
-  {{#hasIssue}}
-   {{#hasLink}}
-### {{name}} [{{issue}}]({{link}}) {{title}} {{#hasIssueType}} *{{issueType}}* {{/hasIssueType}} {{#hasLabels}} {{#labels}} *{{.}}* {{/labels}} {{/hasLabels}}
-   {{/hasLink}}
-   {{^hasLink}}
-### {{name}} {{issue}} {{title}} {{#hasIssueType}} *{{issueType}}* {{/hasIssueType}} {{#hasLabels}} {{#labels}} *{{.}}* {{/labels}} {{/hasLabels}}
-   {{/hasLink}}
-  {{/hasIssue}}
-  {{^hasIssue}}
-### {{name}}
-  {{/hasIssue}}
-
   {{#commits}}
 **{{{messageTitle}}}**
 
@@ -288,8 +280,6 @@ try {
 [{{hash}}](https://github.com/{{ownerName}}/{{repoName}}/commit/{{hash}}) {{authorName}} *{{commitTime}}*
 
   {{/commits}}
-
- {{/issues}}
 {{/tags}}
 ]]>
                             </templateContent>


### PR DESCRIPTION
@tool4ever as discussed:

---

## Problem

Before PR #8410, CHANGES.txt was a committed file in the source tree — CI shallow clones always had it regardless of whether the changelog plugin could regenerate it. PR #8410 deleted that file, moved the output to `target/`, and added a Groovy script to dynamically find the latest `forge-*` tag. The motivation was to stop CHANGES.txt showing up as a modified file in `git status` after every local build.

This worked in development because local clones have full git history and all tags available. It broke in snapshot and release builds because CI workflows use shallow clones (`fetch-depth: 1`) — they download only the latest commit for speed, not the full history. The Groovy script finds no `forge-*` tags in the shallow clone and falls back to `fromRef=refs/tags/HEAD`, an invalid git ref. The changelog plugin either errors or produces a single-entry changelog containing only the HEAD commit, instead of the full list of changes since the last release.

Additionally:

1. **The Mustache template produces noisy output.** Every commit gets wrapped in `### No issue` headers because Forge doesn't configure issue tracker integration. The Java parser (`TextUtil.getFormattedChangelog`) already strips these, but they clutter the raw file shipped in Mac DMGs.

2. **Windows compatibility.** `git tag` output can contain `\r` on Windows, causing tag name matching to fail silently.

3. **Deprecated actions.** Three workflows still use `actions/checkout@v3` (Node 16 EOL).

## Changes

### CI: fetch just enough history for changelog generation (4 workflow files)

Instead of switching to `fetch-depth: 0` (which downloads the full 1 GB+ repo history), the workflows use the GitHub API to find the latest `forge-*` tag's commit date, then deepen the shallow clone to just that date with `git fetch --shallow-since`. This adds ~4 MB and ~2 seconds to each build.

- `snapshot-both-pc-android.yml` — add changelog fetch step
- `snapshots-pc.yml` — upgrade checkout v3→v4, add changelog fetch step
- `maven-publish.yml` — upgrade checkout v3→v4, add changelog fetch step
- `snapshots-android.yml` — upgrade checkout v3→v4, add changelog fetch step (android assets include CHANGES.txt from the desktop build)

### Groovy script hardening (`forge-gui-desktop/pom.xml`)

- Add `.trim()` to tag names to strip `\r` on Windows
- Log a warning when no tags are found instead of silently falling back
- Drop `refs/tags/` prefix from `fromRef` — bare tag names resolve correctly, and the `HEAD` fallback no longer produces the invalid ref `refs/tags/HEAD`

### Simplify Mustache template (`forge-gui-desktop/pom.xml`)

Remove `## {{name}}` tag headers, `### No issue` headers, and `hasIssue`/`hasLink` grouping. These were stripped by `TextUtil.getFormattedChangelog` anyway and added noise to the raw file.

## Testing done

Simulated CI by creating a shallow clone (`git clone --depth 1`), then ran the GitHub API + `git fetch --shallow-since` approach. The clone grew from 228 MB to 232 MB (+4 MB) in 1.6 seconds, the `forge-2.0.10` tag was fetched automatically, and `mvn -pl forge-gui-desktop -am package -DskipTests` generated an 838-line CHANGES.txt with correct content — no `##`/`###` headers, proper commit entries with title, body, and timestamps. Also verified the Java parser (`TextUtil.getFormattedChangelog`) correctly extracts 20 non-merge entries from the output.

Not tested in a live GitHub Actions run — the `--shallow-since` fetch was verified with the `file://` protocol locally. If it behaves differently over HTTPS in CI, the Groovy script falls back gracefully (empty CHANGES.txt, no build failure).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)