### PR TITLE
Fix CHANGES.txt generation - TAKE 2!

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -27,12 +27,15 @@ jobs:
       - uses: actions/checkout@v4
       - name: Fetch history for changelog
         run: |
-          TAG_SHA=$(gh api repos/${{ github.repository }}/tags \
-            --jq '[.[] | select(.name | startswith("forge-"))][0].commit.sha')
-          if [ -n "$TAG_SHA" ]; then
+          TAG=$(gh api repos/${{ github.repository }}/tags \
+            --jq '[.[] | select(.name | startswith("forge-"))][0]')
+          TAG_SHA=$(echo "$TAG" | jq -r '.commit.sha')
+          TAG_NAME=$(echo "$TAG" | jq -r '.name')
+          if [ -n "$TAG_SHA" ] && [ "$TAG_SHA" != "null" ]; then
             TAG_DATE=$(gh api "repos/${{ github.repository }}/commits/$TAG_SHA" \
               --jq '.commit.committer.date')
-            git fetch --shallow-since="$TAG_DATE"
+            git fetch --shallow-since="$TAG_DATE" origin master
+            git fetch origin tag "$TAG_NAME"
           fi
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/snapshot-both-pc-android.yml
+++ b/.github/workflows/snapshot-both-pc-android.yml
@@ -25,12 +25,15 @@ jobs:
       - uses: actions/checkout@v6
       - name: Fetch history for changelog
         run: |
-          TAG_SHA=$(gh api repos/${{ github.repository }}/tags \
-            --jq '[.[] | select(.name | startswith("forge-"))][0].commit.sha')
-          if [ -n "$TAG_SHA" ]; then
+          TAG=$(gh api repos/${{ github.repository }}/tags \
+            --jq '[.[] | select(.name | startswith("forge-"))][0]')
+          TAG_SHA=$(echo "$TAG" | jq -r '.commit.sha')
+          TAG_NAME=$(echo "$TAG" | jq -r '.name')
+          if [ -n "$TAG_SHA" ] && [ "$TAG_SHA" != "null" ]; then
             TAG_DATE=$(gh api "repos/${{ github.repository }}/commits/$TAG_SHA" \
               --jq '.commit.committer.date')
-            git fetch --shallow-since="$TAG_DATE"
+            git fetch --shallow-since="$TAG_DATE" origin master
+            git fetch origin tag "$TAG_NAME"
           fi
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/snapshots-android.yml
+++ b/.github/workflows/snapshots-android.yml
@@ -27,12 +27,15 @@ jobs:
       - uses: actions/checkout@v4
       - name: Fetch history for changelog
         run: |
-          TAG_SHA=$(gh api repos/${{ github.repository }}/tags \
-            --jq '[.[] | select(.name | startswith("forge-"))][0].commit.sha')
-          if [ -n "$TAG_SHA" ]; then
+          TAG=$(gh api repos/${{ github.repository }}/tags \
+            --jq '[.[] | select(.name | startswith("forge-"))][0]')
+          TAG_SHA=$(echo "$TAG" | jq -r '.commit.sha')
+          TAG_NAME=$(echo "$TAG" | jq -r '.name')
+          if [ -n "$TAG_SHA" ] && [ "$TAG_SHA" != "null" ]; then
             TAG_DATE=$(gh api "repos/${{ github.repository }}/commits/$TAG_SHA" \
               --jq '.commit.committer.date')
-            git fetch --shallow-since="$TAG_DATE"
+            git fetch --shallow-since="$TAG_DATE" origin master
+            git fetch origin tag "$TAG_NAME"
           fi
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/snapshots-pc.yml
+++ b/.github/workflows/snapshots-pc.yml
@@ -22,12 +22,15 @@ jobs:
       - uses: actions/checkout@v4
       - name: Fetch history for changelog
         run: |
-          TAG_SHA=$(gh api repos/${{ github.repository }}/tags \
-            --jq '[.[] | select(.name | startswith("forge-"))][0].commit.sha')
-          if [ -n "$TAG_SHA" ]; then
+          TAG=$(gh api repos/${{ github.repository }}/tags \
+            --jq '[.[] | select(.name | startswith("forge-"))][0]')
+          TAG_SHA=$(echo "$TAG" | jq -r '.commit.sha')
+          TAG_NAME=$(echo "$TAG" | jq -r '.name')
+          if [ -n "$TAG_SHA" ] && [ "$TAG_SHA" != "null" ]; then
             TAG_DATE=$(gh api "repos/${{ github.repository }}/commits/$TAG_SHA" \
               --jq '.commit.committer.date')
-            git fetch --shallow-since="$TAG_DATE"
+            git fetch --shallow-since="$TAG_DATE" origin master
+            git fetch origin tag "$TAG_NAME"
           fi
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
Follow-up to #9938, which is still producing CHANGES.txt with only 1 commit in history on most recent snapshot

## Root Cause Analysis
The `actions/checkout` step creates a depth-1 clone. The changelog step then ran `git fetch --shallow-since=DATE` with no refspec, which fetched all remote branch refs and tag objects (~90 seconds) but did **not** deepen the master branch commit graph. The tag commit existed locally as a detached object but was not an ancestor of HEAD - so the git-changelog plugin only saw the single HEAD commit.

## Fix
Two changes to `git fetch`:
1. `git fetch --shallow-since=DATE origin master` - specifying the remote and branch actually deepens the master history
2. `git fetch origin tag TAG_NAME` - fetches only the one needed tag

This is also faster than before (targeted fetch vs fetching all branches and tags).

## Testing

GitHub Actions workflow cannot be replicated locally with precision. This is a known testing limitation.

 However:

- [x] Reproduced locally by simulating the GitHub Actions shallow clone sequence (depth-1 checkout -> fetch ->Maven package)
- [x] Verified fix: CHANGES.txt went from 1 commit to 927 lines (123 commits since forge-2.0.10)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)