### PR TITLE
Make ListChooser search accent/diacritic/punctuation-insensitive

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/gui/ListChooser.java
+++ b/forge-gui-desktop/src/main/java/forge/gui/ListChooser.java
@@ -191,7 +191,7 @@ public class ListChooser<T> {
     }
 
     private void applyFilter(final FTextField searchField) {
-        final String text = StringUtils.stripAccents(searchField.getText().toLowerCase());
+        final String text = normalize(searchField.getText());
         lstChoices.clearSelection();
 
         if (text.isEmpty()) {
@@ -200,7 +200,7 @@ public class ListChooser<T> {
             final List<T> startsWith = new ArrayList<>();
             final List<T> contains = new ArrayList<>();
             for (final T item : allItems) {
-                final String name = StringUtils.stripAccents(getDisplayText(item).toLowerCase());
+                final String name = normalize(getDisplayText(item));
                 if (name.startsWith(text)) {
                     startsWith.add(item);
                 } else if (name.contains(text)) {
@@ -217,6 +217,10 @@ public class ListChooser<T> {
         if (!displayedItems.isEmpty() && maxChoices > 0) {
             lstChoices.setSelectedIndex(0);
         }
+    }
+
+    private static String normalize(final String s) {
+        return StringUtils.stripAccents(s.toLowerCase()).replaceAll("[^a-z0-9 ]", "");
     }
 
     private String getDisplayText(final T value) {

--- a/forge-gui-mobile/src/forge/toolbox/ListChooser.java
+++ b/forge-gui-mobile/src/forge/toolbox/ListChooser.java
@@ -160,9 +160,9 @@ public class ListChooser<T> extends FContainer {
 
         List<Predicate<? super T>> predicates = new ArrayList<>();
 
-        final String pattern = StringUtils.stripAccents(txtSearch.getText().toLowerCase());
+        final String pattern = normalize(txtSearch.getText());
         if (!pattern.isEmpty()) {
-            predicates.add(input -> StringUtils.stripAccents(lstChoices.getChoiceText(input).toLowerCase()).contains(pattern));
+            predicates.add(input -> normalize(lstChoices.getChoiceText(input)).contains(pattern));
         }
         if (advancedSearchFilter != null && !advancedSearchFilter.isEmpty()) {
             predicates.add((Predicate<? super T>)advancedSearchFilter.getPredicate());
@@ -179,6 +179,10 @@ public class ListChooser<T> extends FContainer {
             lstChoices.addSelectedIndex(0);
         }
         lstChoices.setScrollTop(0);
+    }
+
+    private static String normalize(final String s) {
+        return StringUtils.stripAccents(s.toLowerCase()).replaceAll("[^a-z0-9 ]", "");
     }
 
     private void updateHeight() {


### PR DESCRIPTION

<img width="409" height="355" alt="Screenshot 2026-03-01 060921" src="https://github.com/user-attachments/assets/e35a488e-6908-4810-b273-9a5acfec1548" /><img width="405" height="353" alt="Screenshot 2026-03-01 060845" src="https://github.com/user-attachments/assets/ca116f46-a2de-4f9c-9927-6715b5df2559" />


## Summary
- Fixes #9947 — the "Name a card" dialog (and other ListChooser-based dialogs) now matches accented/diacritic characters when searching with plain ASCII letters
- Searching "Eowyn" now finds "Éowyn", "Palantir" finds "Palantír of Orthanc", etc.
- Applies to both desktop and mobile ListChooser implementations
- Uses `StringUtils.stripAccents()` (Apache Commons Lang), consistent with existing usage in `CardDb`, `PaperCard`, `CardRulesPredicates`, and `ImageUtil`

**EDIT:** Now also strips punctuation for comparison purposes so "laezel" now matches "Lae'zel, Githyanki Warrior"

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)