### PR TITLE
Fix Android tinylog logging provider stripped by ProGuard

### DIFF
--- a/forge-gui-android/proguard.cfg
+++ b/forge-gui-android/proguard.cfg
@@ -65,9 +65,10 @@
 -dontwarn org.tinylog.**
 -dontwarn dalvik.system.VMStack
 -dontwarn sun.reflect.Reflection
--keepnames interface org.tinylog.**
--keepnames class * implements org.tinylog.**
--keepclassmembers class * implements org.tinylog.** { <init>(...); }
+# tinylog uses ServiceLoader to find its implementation at runtime;
+# -keepnames only prevents renaming but still allows ProGuard to strip
+# classes it considers unused, which removes the logging provider.
+-keep class org.tinylog.** { *; }
 
 -keep class forge.** { *; }
 -keep class com.thoughtworks.xstream.** { *; }


### PR DESCRIPTION
## Summary

Fixes tinylog's logging implementation being stripped from Android APKs by ProGuard, causing this warning at startup and silent loss of all logging:

```
LOGGER WARN: No logging framework implementation found in classpath. Add tinylog-impl.jar for outputting log entries.
```

(Reported by a user on Discord running Forge on tablet/phone)

## Change

`tinylog-impl` is already a dependency of `forge-core` and correctly resolved in the build. The problem is ProGuard stripping it from the final APK. The existing rules used `-keepnames`, which only prevents renaming but still allows ProGuard to remove classes it considers unused. Since tinylog loads its `LoggingProvider` via Java's `ServiceLoader` (no direct code references), ProGuard treats it as dead code.

Changed to `-keep class org.tinylog.** { *; }` — the same pattern already used for other ServiceLoader-dependent libraries in the same file (Sentry, Netty logging).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)