### PR TITLE
Fix Android tinylog "No logging framework" warning - TAKE 2!

### DIFF
--- a/forge-gui-android/src/forge/app/Main.java
+++ b/forge-gui-android/src/forge/app/Main.java
@@ -162,6 +162,9 @@ public class Main extends AndroidApplication {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        // Register tinylog provider explicitly — the android-maven-plugin strips
+        // META-INF/services/ from dependency JARs, so ServiceLoader discovery fails.
+        org.tinylog.configuration.Configuration.set("provider", "org.tinylog.core.TinylogLoggingProvider");
         try {
             PackageInfo pInfo = getContext().getPackageManager().getPackageInfo(getContext().getPackageName(), 0);
             versionString = pInfo.versionName;


### PR DESCRIPTION
@tool4ever 

## Summary

Fixes the "No logging framework implementation found in classpath" warning that persists on Android even after #9958.

## Root cause

#9958 changed the ProGuard rules from `-keepnames` to `-keep class org.tinylog.** { *; }`, which correctly prevents ProGuard from stripping tinylog's classes. However, the warning persists because the problem is one layer earlier in the build pipeline.

tinylog discovers its logging implementation via Java's `ServiceLoader` mechanism, which reads `META-INF/services/org.tinylog.provider.LoggingProvider` from the `tinylog-impl.jar`. This resource file tells tinylog which class to instantiate (`org.tinylog.core.TinylogLoggingProvider`).

The Android build pipeline is:

1. The android-maven-plugin **unpacks** all dependency JARs to merge their classes
2. During unpacking, it **strips the `META-INF/` directory** ΓÇö this is standard Android convention since `META-INF/` contains JAR signing info and manifests that aren't relevant in an APK
3. The stripped classes go through ProGuard ΓåÆ D8 ΓåÆ DEX ΓåÆ APK
4. At runtime, `ServiceLoader` looks for `META-INF/services/org.tinylog.provider.LoggingProvider` but the file was removed in step 2

So the tinylog classes are present (ProGuard keeps them), but the service discovery file that tells tinylog *which* class to load is gone. No ProGuard rule can preserve a resource file that was already stripped before ProGuard runs.

This doesn't affect desktop because the standard JVM reads `META-INF/services/` directly from intact JARs on the classpath.

## Fix

tinylog's `ProviderRegistry` checks `Configuration.get("provider")` before falling back to `ServiceLoader` discovery. If a provider is named in the configuration, it instantiates it directly via reflection - no `META-INF/services` file needed.

This PR adds a single `Configuration.set("provider", "org.tinylog.core.TinylogLoggingProvider")` call at the top of `Main.onCreate()`, before any logging occurs, bypassing `ServiceLoader` entirely. The existing ProGuard `-keep` rule from #9958 is still needed to prevent the classes themselves from being stripped.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)