### PR TITLE
Old Border Shandalar: Diamond Mine and Riddles Lair reward booster packs instead of loose cards

### DIFF
--- a/forge-gui/res/adventure/Shandalar Old Border/maps/map/lair/ancient_diamond_mine.tmx
+++ b/forge-gui/res/adventure/Shandalar Old Border/maps/map/lair/ancient_diamond_mine.tmx
@@ -46,14 +46,12 @@
         "condition": [
           { "hasGold": 10000 }
         ],
-        "text": "The crystals shimmer and absorb your gold. In exchange, ancient spells materialize before you - cards from the Beta era of magic!",
+        "text": "The crystals shimmer and absorb your gold. In exchange, a sealed pack from the dawn of magic materializes before you!",
         "action": [
           {
             "addGold": -10000,
             "grantRewards": [
-              { "type": "randomCard", "sourceDeck": "decks/custom_lists/LEB_List.dck", "rarity": ["R"], "count": 1 },
-              { "type": "randomCard", "sourceDeck": "decks/custom_lists/LEB_List.dck", "rarity": ["U"], "count": 3 },
-              { "type": "randomCard", "sourceDeck": "decks/custom_lists/LEB_List.dck", "rarity": ["C"], "count": 11 }
+              { "type": "cardPackShop", "count": 1, "editions": ["LEB"] }
             ]
           }
         ]
@@ -70,14 +68,12 @@
         "condition": [
           { "hasShards": 400 }
         ],
-        "text": "The crystals shimmer and absorb your mana shards. In exchange, ancient spells materialize before you - cards from the Beta era of magic!",
+        "text": "The crystals shimmer and absorb your mana shards. In exchange, a sealed pack from the dawn of magic materializes before you!",
         "action": [
           {
             "addShards": -400,
             "grantRewards": [
-              { "type": "randomCard", "sourceDeck": "decks/custom_lists/LEB_List.dck", "rarity": ["R"], "count": 1 },
-              { "type": "randomCard", "sourceDeck": "decks/custom_lists/LEB_List.dck", "rarity": ["U"], "count": 3 },
-              { "type": "randomCard", "sourceDeck": "decks/custom_lists/LEB_List.dck", "rarity": ["C"], "count": 11 }
+              { "type": "cardPackShop", "count": 1, "editions": ["LEB"] }
             ]
           }
         ]

--- a/forge-gui/res/adventure/Shandalar Old Border/maps/map/lair/riddles_lair.tmx
+++ b/forge-gui/res/adventure/Shandalar Old Border/maps/map/lair/riddles_lair.tmx
@@ -104,8 +104,7 @@
                                 "addGold": 8000,
                                 "addShards": 250,
                                 "grantRewards": [
-                                  { "type": "randomCard", "sourceDeck": "decks/custom_lists/3ED_List.dck", "rarity": ["R"], "count": 3 },
-                                  { "type": "randomCard", "sourceDeck": "decks/custom_lists/2ED_List.dck", "rarity": ["R"], "count": 1 }
+                                  { "type": "cardPackShop", "count": 1, "editions": ["2ED"] }
                                 ]
                               }
                             ]


### PR DESCRIPTION
- Diamond Mine now rewards a sealed Beta (LEB) booster pack instead of individual cards at fixed rarities
- Riddles Lair now rewards a sealed Unlimited (2ED) booster pack instead of individual rares from 3ED/2ED
- Uses the existing cardPackShop reward type for proper pack-opening experience