### PR TITLE
Fix Android tinylog logging by shipping META-INF/services descriptors

### DIFF
--- a/forge-gui-android/pom.xml
+++ b/forge-gui-android/pom.xml
@@ -88,6 +88,12 @@
                 <filtering>true</filtering>
                 <targetPath>assets</targetPath>
             </resource>
+            <!-- tinylog + SLF4J service descriptors: the android-maven-plugin strips
+                 META-INF/ from dependency JARs during unpack, so we ship our own copies
+                 so tinylog's ServiceLoader can discover its providers at runtime. -->
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
         </resources>
         <!-- append generated snapshot-version property -->
         <finalName>forge-android-${snapshot-version}</finalName>

--- a/forge-gui-android/src/main/resources/META-INF/services/org.slf4j.spi.SLF4JServiceProvider
+++ b/forge-gui-android/src/main/resources/META-INF/services/org.slf4j.spi.SLF4JServiceProvider
@@ -1,0 +1,1 @@
+org.tinylog.slf4j.TinylogSlf4jServiceProvider

--- a/forge-gui-android/src/main/resources/META-INF/services/org.tinylog.configuration.ConfigurationLoader
+++ b/forge-gui-android/src/main/resources/META-INF/services/org.tinylog.configuration.ConfigurationLoader
@@ -1,0 +1,1 @@
+org.tinylog.configuration.PropertiesConfigurationLoader

--- a/forge-gui-android/src/main/resources/META-INF/services/org.tinylog.converters.FileConverter
+++ b/forge-gui-android/src/main/resources/META-INF/services/org.tinylog.converters.FileConverter
@@ -1,0 +1,1 @@
+org.tinylog.converters.GzipFileConverter

--- a/forge-gui-android/src/main/resources/META-INF/services/org.tinylog.policies.Policy
+++ b/forge-gui-android/src/main/resources/META-INF/services/org.tinylog.policies.Policy
@@ -1,0 +1,5 @@
+org.tinylog.policies.DailyPolicy
+org.tinylog.policies.DynamicPolicy
+org.tinylog.policies.MonthlyPolicy
+org.tinylog.policies.StartupPolicy
+org.tinylog.policies.SizePolicy

--- a/forge-gui-android/src/main/resources/META-INF/services/org.tinylog.provider.LoggingProvider
+++ b/forge-gui-android/src/main/resources/META-INF/services/org.tinylog.provider.LoggingProvider
@@ -1,0 +1,1 @@
+org.tinylog.core.TinylogLoggingProvider

--- a/forge-gui-android/src/main/resources/META-INF/services/org.tinylog.throwable.ThrowableFilter
+++ b/forge-gui-android/src/main/resources/META-INF/services/org.tinylog.throwable.ThrowableFilter
@@ -1,0 +1,4 @@
+org.tinylog.throwable.DropCauseThrowableFilter
+org.tinylog.throwable.KeepThrowableFilter
+org.tinylog.throwable.StripThrowableFilter
+org.tinylog.throwable.UnpackThrowableFilter

--- a/forge-gui-android/src/main/resources/META-INF/services/org.tinylog.writers.Writer
+++ b/forge-gui-android/src/main/resources/META-INF/services/org.tinylog.writers.Writer
@@ -1,0 +1,8 @@
+org.tinylog.writers.ConsoleWriter
+org.tinylog.writers.FileWriter
+org.tinylog.writers.JdbcWriter
+org.tinylog.writers.LogcatWriter
+org.tinylog.writers.RollingFileWriter
+org.tinylog.writers.SharedFileWriter
+org.tinylog.writers.JsonWriter
+org.tinylog.writers.SyslogWriter


### PR DESCRIPTION
@tool4ever as discussed.

----

### Problem

Since the tinylog migration, all logging on Android is silently disabled. The `forge.log` shows:
```
LOGGER WARN: No logging framework implementation found in classpath. Add tinylog-impl.jar for outputting log entries.
```
All `Logger.info()` / `Logger.warn()` calls become no-ops — no crash, just complete loss of logging.

### Root Cause

tinylog uses a custom `org.tinylog.configuration.ServiceLoader` that discovers implementations by reading `META-INF/services/` files from the classpath. The android-maven-plugin strips `META-INF/` directories from dependency JARs during the unpack step. Without the service descriptor files, tinylog's ServiceLoader sets its classloader to `null`, and subsequent `Class.forName(className, false, null)` calls fail on Android because the bootstrap classloader cannot find app classes.

<!-- -->#9976 (`-keep class org.slf4j.** { *; }` and removing `Configuration.set()`) was necessary but insufficient — ProGuard preserves class files but cannot restore resource files that were already stripped before it runs.

### Fix

Ship the `META-INF/services/` descriptor files directly in the Android module (`forge-gui-android/src/main/resources/`) and add a `<resource>` entry to the POM so the android-maven-plugin includes them in the APK. Contents are copied verbatim from the tinylog 2.7.0 and slf4j-tinylog 2.7.0 JARs.

7 service files added:
- `org.tinylog.provider.LoggingProvider`
- `org.tinylog.configuration.ConfigurationLoader`
- `org.tinylog.writers.Writer`
- `org.slf4j.spi.SLF4JServiceProvider`
- `org.tinylog.policies.Policy`
- `org.tinylog.converters.FileConverter`
- `org.tinylog.throwable.ThrowableFilter`

### Testing

Built APK locally (JDK 17, android-maven-plugin 4.6.2, build-tools 35.0.0) and tested on an Android 15 (API 35) x86_64 emulator.

**Baseline (current master, no fix)** — `forge.log` output:
```
Error handling registered!
LOGGER WARN: No logging framework implementation found in classpath. Add tinylog-impl.jar for outputting log entries.
```

**With fix** — `forge.log` output:
```
Error handling registered!
20:37:56 [INFO ] GuiBase: ##########################################
20:37:56 [INFO ] GuiBase: APP: Forge v.2.0.12-SNAPSHOT-03.03
20:37:56 [INFO ] GuiBase: DEV: Google - sdk_gphone64_x86_64
20:37:56 [INFO ] GuiBase: RAM: 1972 MB
20:37:56 [INFO ] GuiBase: OS: Android 15 (Vanilla Ice Cream)
20:37:56 [INFO ] GuiBase: ##########################################
```

The tinylog format string from `tinylog.properties` is applied correctly, confirming both `LoggingProvider` and `ConfigurationLoader` services are discovered.

Build output also confirms the files are packaged into the APK:
```
[INFO] Adding resource ...META-INF/services/org.tinylog.provider.LoggingProvider
[INFO] Adding resource ...META-INF/services/org.tinylog.configuration.ConfigurationLoader
[INFO] Adding resource ...META-INF/services/org.tinylog.writers.Writer
...
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)