### PR TITLE
Old Border Shandalar: Minor item fixes

### DIFF
--- a/forge-gui/res/adventure/Shandalar Old Border/world/items.json
+++ b/forge-gui/res/adventure/Shandalar Old Border/world/items.json
@@ -538,12 +538,13 @@
     }
   },
   {
-    "name": "Jeweled Amulet",
-    "description": "Store one mana for later use.",
+    "name": "Jeweled Necklace",
+    "description": "-2 Max Life. Store one mana for later use.",
     "equipmentSlot": "Neck",
     "iconName": "JeweledNecklace",
     "cost": 9000,
     "effect": {
+      "lifeModifier": -2,
       "startBattleWithCard": [
         "Jeweled Amulet|ICE"
       ]
@@ -1655,11 +1656,12 @@
     "equipmentSlot": "Right",
     "iconName": "WombatTamersWhip",
     "effect": {
+      "lifeModifier": -2,
       "startBattleWithCard": [
         "Rabid Wombat|LEG"
       ]
     },
-    "description": "A 0/1 vigilance that gets +2/+2 for each Aura on it."
+    "description": "-2 Max Life. A 0/1 vigilance that gets +2/+2 for each Aura on it."
   },
   {
     "name": "Molten Gauntlet",
@@ -1896,11 +1898,12 @@
     "equipmentSlot": "Right",
     "iconName": "ScytheOfYawgmoth",
     "effect": {
+      "lifeModifier": -8,
       "startBattleWithCard": [
         "Order of Yawgmoth|USG"
       ]
     },
-    "description": "A 2/2 fear creature. Opponent discards when it deals damage.",
+    "description": "-8 Max Life. A 2/2 fear creature. Opponent discards when it deals damage.",
     "cost": 12000
   },
   {
@@ -2058,12 +2061,12 @@
     "equipmentSlot": "Neck",
     "iconName": "RhysticAmulet",
     "effect": {
-      "lifeModifier": -3,
+      "lifeModifier": -6,
       "startBattleWithCard": [
         "Rhystic Cave|PCY"
       ]
     },
-    "description": "-3 life. Tap for any color unless an opponent pays 1."
+    "description": "-6 Max Life. Tap for any color unless an opponent pays 1."
   },
   {
     "name": "Shoes of Sorrow",
@@ -2105,11 +2108,12 @@
     "equipmentSlot": "Neck",
     "iconName": "CrownOfTheVale",
     "effect": {
+      "lifeModifier": -4,
       "startBattleWithCard": [
         "Rainbow Vale|FEM"
       ]
     },
-    "description": "Tap for any color. Gives itself to your opponent."
+    "description": "-4 Max Life. Tap for any color. Gives itself to your opponent."
   },
   {
     "name": "Tasty Tome",
@@ -2746,12 +2750,12 @@
   },
   {
     "name": "Krampus's Horns",
-    "description": "Start with Charcoal Diamond in play. -1 starting hand, -2 life.",
+    "description": "Start with Charcoal Diamond in play. -1 starting hand, -6 Max Life.",
     "equipmentSlot": "Neck",
     "iconName": "KrampussHorns",
     "effect": {
       "changeStartCards": -1,
-      "lifeModifier": -2,
+      "lifeModifier": -6,
       "startBattleWithCard": [
         "Charcoal Diamond|MIR"
       ]


### PR DESCRIPTION
- Jeweled Necklace (previously Jeweled Amulet): -2 Max Life, renamed to match existing arena reward reference in forest_capital.tmx
- Crown of the Vale: -4 Max Life
- Rhystic Amulet: -3 to -6 Max Life
- Krampus's Horns: -2 to -6 Max Life
- Scythe of Yawgmoth: -8 Max Life
- Wombat Tamer's Whip: -2 Max Life