### PR TITLE
Make FCollection's set field transient to skip redundant serialization

### DIFF
--- a/forge-core/src/main/java/forge/util/collect/FCollection.java
+++ b/forge-core/src/main/java/forge/util/collect/FCollection.java
@@ -1,5 +1,7 @@
 package forge.util.collect;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.util.*;
 import java.util.function.Predicate;
@@ -34,12 +36,20 @@ public class FCollection<T> implements List<T>, /*Set<T>,*/ FCollectionView<T>, 
     /**
      * The {@link Set} representation of this collection.
      */
-    private final Set<T> set = new HashSet<>();
+    private transient Set<T> set = new HashSet<>();
 
     /**
      * The {@link List} representation of this collection.
      */
     private final List<T> list = new ArrayList<>();
+
+    /**
+     * Rebuild the transient set from the list after deserialization.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        set = new HashSet<>(list);
+    }
 
     /**
      * Create an empty {@link FCollection}.


### PR DESCRIPTION
## Summary

- Makes `FCollection`'s internal `HashSet` field `transient`, skipping it during Java serialization
- Adds `readObject()` to rebuild the set from the list after deserialization
- Removes `final` from the set field (required because field initializers don't run during Java deserialization — the field is `null` after `defaultReadObject()` and must be reassigned in `readObject()`)

## Context

Discussed with @tool4ever based on the investigation in [copyChangedProps.md](https://github.com/MostCromulent/forge/blob/NetworkPlay/dev/.documentation/copyChangedProps.md) (change #3 + RE 3 feedback).

`FCollection` is a hybrid list+set data structure that is serialized on every network `setGameView` call. The set duplicates all list element references — since Java serialization shares object references within a single `writeObject` call, these are back-references (~5 bytes each) rather than full copies, but it's still pure waste across dozens of collections per GameView.

The list is the source of truth for element order and indexed access. Rebuilding the set from the list in `readObject()` is equivalent to serializing it, but also guarantees correct HashMap bucket placement — eliminating a class of structural HashMap corruption observed during network play testing where deserialized entries end up in wrong buckets due to circular object graph references.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)