### PR TITLE
Card cleanup: 2026-02-05, incidental

### DIFF
--- a/forge-gui/res/cardsfolder/c/cait_cage_brawler.txt
+++ b/forge-gui/res/cardsfolder/c/cait_cage_brawler.txt
@@ -8,6 +8,6 @@ SVar:TrigDraw:DB$ Draw | Defined$ You & TriggeredDefendingPlayer | NumCards$ 1 |
 SVar:DBDiscard:DB$ Discard | Mode$ TgtChoose | Defined$ TriggeredDefendingPlayer & You | RememberDiscarded$ True | SubAbility$ DBPutCounter
 SVar:DBPutCounter:DB$ PutCounter | ConditionDefined$ Remembered | ConditionPresent$ Card.greatestRememberedCMC+YouOwn | CounterType$ P1P1 | CounterNum$ 2 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-SVar:HasAttackEffect:True
+SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Discard|Counters
 Oracle:During your turn, Cait, Cage Brawler has indestructible.\nWhenever Cait attacks, you and defending player each draw a card, then discard a card. Put two +1/+1 counters on Cait if you discarded the card with the highest mana value among those cards or tied for highest.

--- a/forge-gui/res/cardsfolder/d/doc_ocks_henchmen.txt
+++ b/forge-gui/res/cardsfolder/d/doc_ocks_henchmen.txt
@@ -6,6 +6,6 @@ PT:2/1
 K:Flash
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigConnive | TriggerZones$ Battlefield | TriggerDescription$ Whenever this creature attacks, it connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)
 SVar:TrigConnive:DB$ Connive
-SVar:HasAttackEffect:True
+SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Counters|Discard
 Oracle:Flash\nWhenever this creature attacks, it connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)

--- a/forge-gui/res/cardsfolder/f/furtive_courier.txt
+++ b/forge-gui/res/cardsfolder/f/furtive_courier.txt
@@ -7,7 +7,7 @@ SVar:SaccedThisTurn:PlayerCountPropertyYou$SacrificedThisTurn Artifact
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ Whenever CARDNAME attacks, draw a card, then discard a card.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1 | SubAbility$ DBDiscard
 SVar:DBDiscard:DB$ Discard | Defined$ You | NumCards$ 1 | Mode$ TgtChoose
-SVar:HasAttackEffect:True
+SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Sacrifice|Discard
 DeckHints:Type$Artifact|Clue|Map|Treasure|Food
 Oracle:Furtive Courier can't be blocked as long as you've sacrificed an artifact this turn.\nWhenever Furtive Courier attacks, draw a card, then discard a card.

--- a/forge-gui/res/cardsfolder/m/midnight_crusader_shuttle.txt
+++ b/forge-gui/res/cardsfolder/m/midnight_crusader_shuttle.txt
@@ -10,6 +10,6 @@ SVar:DBTap:DB$ Tap | Defined$ Remembered | ConditionDefined$ Remembered | Condit
 SVar:DBSetAttacking:DB$ ChangeCombatants | Defined$ Remembered | ConditionDefined$ Remembered | ConditionPresent$ Card.YouCtrl | Attacking$ RememberedPlayer | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 K:Crew:2
-SVar:HasAttackEffect:True
+SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Sacrifice
 Oracle:Midnight Entity — Whenever Midnight Crusader Shuttle attacks, defending player faces a villainous choice — That player sacrifices a creature, or you gain control of a creature of your choice that player controls until end of turn. If you gain control of a creature this way, tap it, and it's attacking that player.\nCrew 2

--- a/forge-gui/res/cardsfolder/m/motivated_pony.txt
+++ b/forge-gui/res/cardsfolder/m/motivated_pony.txt
@@ -9,6 +9,6 @@ SVar:TrigPump:DB$ PumpAll | ValidCards$ Creature.attacking | NumAtt$ +1 | NumDef
 SVar:DBUntapAll:DB$ UntapAll | ValidCards$ Creature.attacking | ConditionCheckSVar$ Food | SubAbility$ DBPump
 SVar:DBPump:DB$ PumpAll | ValidCards$ Creature.attacking | NumAtt$ +2 | ConditionCheckSVar$ Food | NumDef$ +2
 SVar:Food:Count$ThisTurnEntered_Battlefield_Food.YouCtrl
-SVar:HasAttackEffect:True
+SVar:HasAttackEffect:TRUE
 DeckHints:Type$Food
 Oracle:Whenever Motivated Pony attacks, attacking creatures get +1/+1 until end of turn. If a Food entered under your control this turn, untap those creatures and they get an additional +2/+2 until end of turn.

--- a/forge-gui/res/cardsfolder/p/protean_war_engine.txt
+++ b/forge-gui/res/cardsfolder/p/protean_war_engine.txt
@@ -9,6 +9,6 @@ SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 T:Mode$ BecomesCrewed | ValidCard$ Card.Self | Execute$ TrigClone | TriggerDescription$ Whenever CARDNAME becomes crewed, until end of turn, it becomes a copy of the exiled card, except it's a Vehicle artifact in addition to its other types.
 SVar:TrigClone:DB$ Clone | Defined$ ExiledWith | CloneTarget$ Self | AddTypes$ Vehicle & Artifact | Duration$ UntilEndOfTurn
 K:Crew:3
-SVar:HasAttackingEffect:TRUE
+SVar:HasAttackEffect:TRUE
 DeckHas:Type$Angel|Bird|Dragon|Elk|Human|Ogre|Cleric|Knight|Pirate|Soldier|Warrior & Ability$LifeGain|Token & Keyword$Double Strike|Haste|First Strike|Flying
 Oracle:As Protean War Engine enters, draft a card from Protean War Engine's spellbook and exile it.\nWhenever Protean War Engine becomes crewed, until end of turn, it becomes a copy of the exiled card, except it's a Vehicle artifact in addition to its other types.\nCrew 3

--- a/forge-gui/res/cardsfolder/s/scurrilous_sentry.txt
+++ b/forge-gui/res/cardsfolder/s/scurrilous_sentry.txt
@@ -6,6 +6,6 @@ K:Menace
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigConnive | TriggerDescription$ Whenever CARDNAME enters or attacks, it connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigConnive | TriggerZones$ Battlefield | Secondary$ True | TriggerDescription$ Whenever CARDNAME enters or attacks, it connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)
 SVar:TrigConnive:DB$ Connive
-SVar:HasAttackEffect:True
+SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Counters|Discard
 Oracle:Menace\nWhenever Scurrilous Sentry enters or attacks, it connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)

--- a/forge-gui/res/cardsfolder/t/the_seventh_doctor.txt
+++ b/forge-gui/res/cardsfolder/t/the_seventh_doctor.txt
@@ -10,6 +10,6 @@ SVar:GuessNotGreaterArtifacts:DB$ Play | Controller$ You | Defined$ ChosenCard |
 SVar:DBInvestigate:DB$ Investigate | ConditionDefined$ Remembered | ConditionPresent$ Card | ConditionCompare$ EQ0 | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearChosenCard$ True
 SVar:X:Count$Valid Artifact.YouCtrl
-SVar:HasAttackEffect:True
+SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Token & Type$Clue|Artifact
 Oracle:When The Seventh Doctor attacks, choose a card in your hand. Defending player guesses whether that card's mana value is greater than the number of artifacts you control. If they guessed wrong, you may cast it without paying its mana cost. If you don't cast a spell this way, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")

--- a/forge-gui/res/cardsfolder/t/thunderhawk_gunship.txt
+++ b/forge-gui/res/cardsfolder/t/thunderhawk_gunship.txt
@@ -8,6 +8,6 @@ SVar:TrigToken:DB$ Token | TokenScript$ w_2_2_astartes_warrior_vigilance | Token
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, attacking creatures you control gain flying until end of turn.
 SVar:TrigPump:DB$ PumpAll | ValidCards$ Creature.attacking+YouCtrl | KW$ Flying
 K:Crew:2
-SVar:HasAttackingEffect:TRUE
+SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Token & Type$Astartes|Warrior & Keyword$Vigilance
 Oracle:Flying\nWhen Thunderhawk Gunship enters, create two 2/2 white Astartes Warrior creature tokens with vigilance.\nWhenever Thunderhawk Gunship attacks, attacking creatures you control gain flying until end of turn.\nCrew 2

--- a/forge-gui/res/cardsfolder/w/witch_king_bringer_of_ruin.txt
+++ b/forge-gui/res/cardsfolder/w/witch_king_bringer_of_ruin.txt
@@ -5,6 +5,6 @@ PT:5/3
 K:Flying
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigSac | TriggerDescription$ Whenever CARDNAME attacks, defending player sacrifices a creature with the least power among creatures they control.
 SVar:TrigSac:DB$ Sacrifice | Defined$ TriggeredDefendingPlayer | SacValid$ Creature.leastPowerControlledByTriggeredDefendingPlayer
-SVar:HasAttackEffect:True
+SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Sacrifice
 Oracle:Flying\nWhenever Witch-king, Bringer of Ruin attacks, defending player sacrifices a creature with the least power among creatures they control.


### PR DESCRIPTION
As pointed out elsewhere, the `HasAttackEffect:` flag explicitly requires `TRUE` as an argument ( [Line 1357 of AiAttackController.java](https://github.com/Card-Forge/forge/blob/15442cdc55db928bb5a2fea5205666b9abc1d68c/forge-ai/src/main/java/forge/ai/AiAttackController.java#L1357) for reference ). Also corrected a flag variant unattested in Java.