### PR TITLE
Fix AI freeze when declaring attackers with unpayable attack costs

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -1324,6 +1324,10 @@ public class AiController {
         // Check if we can reinforce with Banding creatures
         aiAtk.reinforceWithBanding(combat);
 
+        // Per CR 508.1d, the decision to pay attack costs (e.g. Propaganda)
+        // is made at declaration time. Remove attackers the AI can't pay for.
+        removeUnpayableAttackers(combat);
+
         // if invalid: just try an attack declaration that we know to be legal
         if (!CombatUtil.validateAttackers(combat)) {
             combat.clearAttackers();
@@ -1340,6 +1344,22 @@ public class AiController {
         for (final Card element : combat.getAttackers()) {
             // tapping of attackers happens after Propaganda is paid for
             Logger.debug("Computer just assigned " + element.getName() + " as an attacker.");
+        }
+    }
+
+    private void removeUnpayableAttackers(Combat combat) {
+        for (Card attacker : new ArrayList<>(combat.getAttackers())) {
+            Cost attackCost = CombatUtil.getAttackCost(game, attacker, combat.getDefenderByAttacker(attacker));
+            if (attackCost == null) {
+                continue;
+            }
+            SpellAbility fakeSA = new SpellAbility.EmptySa(attacker, attacker.getController());
+            fakeSA.setCardState(attacker.getCurrentState());
+            fakeSA.setPayCosts(attackCost);
+            fakeSA.setSVar("X", "0");
+            if (!ComputerUtilCost.canPayCost(attackCost, fakeSA, player, true)) {
+                combat.removeFromCombat(attacker);
+            }
         }
     }
 


### PR DESCRIPTION
- AI would freeze in an infinite loop when declaring attackers that have attack tax costs (e.g. Propaganda) they cannot pay, forcing the player to concede
- The bug required interdependent attackers like two Mogg Flunkies (which can only attack if another creature also attacks): the AI would declare both, `PhaseHandler` would remove one for not paying the tax, the remaining one alone would fail validation, and the loop would restart with the AI making the same decision
- Reproduced by destroying the AI's lands at the beginning of combat while Propaganda was in play
- Fix: check attack cost payability at declaration time in `AiController`, before the attackers reach `PhaseHandler's` payment loop. This aligns with CR 508.1d which says the decision to pay attack costs is made during attacker declaration, not as a separate step afterward