### PR TITLE
Fix cardPackShop ignoring explicit editions filter

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/data/RewardData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/RewardData.java
@@ -285,18 +285,17 @@ public class RewardData implements Serializable {
                             .forEach(allEditions::add);
                         ConfigData configData = Config.instance().getConfigData();
 
-                        for (String restricted : configData.restrictedEditions) {
-                            allEditions.removeIf(q -> q.getCode().equals(restricted));
-                        }
-                        for (String restrictedCard : configData.restrictedCards) {
-                            allEditions.removeIf(cardEdition -> cardEdition.getObtainableCards().stream().anyMatch(
-                                o -> o.name().equals(restrictedCard)));
-                        }
-
                         if (this.editions != null && this.editions.length > 0) {
                             Set<String> allowed = new HashSet<>(Arrays.asList(this.editions));
                             allEditions.removeIf(q -> !allowed.contains(q.getCode()));
                         } else {
+                            for (String restricted : configData.restrictedEditions) {
+                                allEditions.removeIf(q -> q.getCode().equals(restricted));
+                            }
+                            for (String restrictedCard : configData.restrictedCards) {
+                                allEditions.removeIf(cardEdition -> cardEdition.getObtainableCards().stream().anyMatch(
+                                    o -> o.name().equals(restrictedCard)));
+                            }
                             endDate = endDate == 0 ? 9999 : endDate;
                             allEditions.removeIf(q -> q.getDate().getYear()+1900 < startDate || q.getDate().getYear()+1900 > endDate);
                         }


### PR DESCRIPTION
The `restrictedCards` filter removes entire editions containing any restricted card. This runs before the editions filter, so explicitly requesting a specific edition via the editions array has no effect if that edition contains a restricted card.

Moves the explicit editions check before the restricted filters, and only applies `restrictedEditions`/`restrictedCards` when no specific editions are requested. The date range path is unaffected.