### PR TITLE
Old Border Shandalar: Fix Gorilla Chief sprite

### DIFF
--- a/forge-gui/res/adventure/Shandalar Old Border/world/enemies.json
+++ b/forge-gui/res/adventure/Shandalar Old Border/world/enemies.json
@@ -36004,7 +36004,7 @@
   },
   {
     "name": "Gorilla Chief",
-    "sprite": "sprites/enemy/beast/elephant.atlas",
+    "sprite": "sprites/enemy/beast/gorilla.atlas",
     "deck": [
       "decks/miniboss/shandalar97_gorilla_chief.dck"
     ],


### PR DESCRIPTION
- Gorilla Chief was incorrectly using the elephant sprite (elephant.atlas)
- Changed to gorilla sprite (gorilla.atlas) to match the enemy type