### PR TITLE
Feature: Added support for custom number of players for smaller cubes

### DIFF
--- a/forge-gui/res/cube/The Original Recipe Twobert.dck
+++ b/forge-gui/res/cube/The Original Recipe Twobert.dck
@@ -1,0 +1,183 @@
+[metadata]
+name=The Original Recipe Twobert
+[Main]
+1 Giver of Runes|MH1
+1 Student of Warfare|ROE
+1 Thraben Inspector|SOI
+1 Adanto Vanguard|XLN
+1 Lion Sash|NEO
+1 Luminarch Aspirant|ZNR
+1 Rhys, the Evermore|ECL
+1 Selfless Spirit|EMN
+1 Tithe Taker|RNA
+1 Blade Splicer|NPH
+1 Elite Spellbinder|STX
+1 Skyclave Apparition|ZNR
+1 Restoration Angel|AVR
+1 Gideon, Ally of Zendikar|BFZ
+1 The Wandering Emperor|NEO
+1 Gideon Jura|ROE
+1 Elspeth, Sun's Champion|THS
+1 Path to Exile|CON
+1 Swords to Plowshares|LEA
+1 Reprieve|LTR
+1 Ossification|ONE
+1 Sheltered by Ghosts|DSK
+1 Virtue of Loyalty|WOE
+1 Jace, Vryn's Prodigy|ORI
+1 Malcolm, Alluring Scoundrel|LCI
+1 Phantasmal Image|M12
+1 Snapcaster Mage|ISD
+1 Brazen Borrower|ELD
+1 Glen Elendra Guardian|ECL
+1 Tishana's Tidebinder|LCI
+1 Vendilion Clique|MOR
+1 Phyrexian Metamorph|NPH
+1 Sower of Temptation|LRW
+1 Mulldrifter|LRW
+1 Horned Loch-Whale|WOE
+1 Jace, the Mind Sculptor|WWK
+1 Consider|MID
+1 Fading Hope|MID
+1 Occult Epiphany|VOC
+1 Spell Pierce|ZEN
+1 Counterspell|LEA
+1 Mana Leak|STH
+1 Miscalculation|ULG
+1 Psionic Blast|TSB
+1 Ponder|LRW
+1 Preordain|M11
+1 Evolved Sleeper|DMU
+1 Knight of the Ebon Legion|M20
+1 Caustic Bronco|OTJ
+1 Dark Confidant|RAV
+1 Deep-Cavern Bat|LCI
+1 Misery's Shadow|BRO
+1 Scrapheap Scrounger|KLD
+1 Tenacious Underdog|SNC
+1 Murderous Rider|ELD
+1 Qarsi Revenant|TDM
+1 Ravenous Chupacabra|RIX
+1 Harvester of Misery|BIG
+1 Shriekmaw|LRW
+1 Grave Titan|M11
+1 Liliana of the Veil|ISD
+1 Sorin the Mirthless|VOW
+1 Fatal Push|AER
+1 Bitter Triumph|LCI
+1 Sheoldred's Edict|ONE
+1 Fell the Profane|MH3
+1 Bloodchief's Thirst|ZNR
+1 Inquisition of Kozilek|ROE
+1 Thoughtseize|LRW
+1 Greasewrench Goblin|DFT
+1 Grim Lavamancer|TOR
+1 Kellan, Planar Trailblazer|FDN
+1 Bloodthirsty Adversary|MID
+1 Draconautics Engineer|DFT
+1 Earthshaker Khenra|HOU
+1 Inti, Seneschal of the Sun|LCI
+1 Kari Zev, Skyship Raider|AER
+1 Bonecrusher Giant|ELD
+1 Seasoned Pyromancer|MH1
+1 Pia and Kiran Nalaar|ORI
+1 Pyrogoyf|M3C
+1 Glorybringer|AKH
+1 Nova Hellkite|EOE
+1 Overlord of the Boilerbilges|DSK
+1 Chandra, Torch of Defiance|KLD
+1 Burst Lightning|ZEN
+1 Lightning Bolt|LEA
+1 Chain Lightning|LEG
+1 Flame Slash|ROE
+1 Light Up the Night|MID
+1 Obliterating Bolt|BRO
+1 Fable of the Mirror-Breaker|NEO
+1 Birds of Paradise|LEA
+1 Elvish Mystic|M14
+1 Hexdrinker|MH1
+1 Bristly Bill, Spine Sower|OTJ
+1 Den Protector|DTK
+1 Scavenging Ooze|CMD
+1 Scythecat Cub|J25
+1 Tarmogoyf|FUT
+1 Courser of Kruphix|BNG
+1 Mutable Explorer|ECL
+1 Nissa, Vastwood Seer|ORI
+1 Sentinel of the Nameless City|LCI
+1 Tireless Tracker|SOI
+1 Polukranos, World Eater|THS
+1 Questing Beast|ELD
+1 Thragtusk|M13
+1 Whisperwood Elemental|FRF
+1 Primeval Titan|M11
+1 Hornet Queen|CMD
+1 Nissa, Voice of Zendikar|OGW
+1 Garruk Wildspeaker|LRW
+1 Nissa, Who Shakes the World|WAR
+1 Primal Might|M21
+1 Walking Ballista|AER
+1 No More Lies|MKM
+1 Supreme Verdict|RTR
+1 Teferi, Hero of Dominaria|DOM
+1 Baleful Strix|C13
+1 Ertai Resurrected|DMU
+1 Silumgar's Command|DTK
+1 Bloodtithe Harvester|VOW
+1 Dreadbore|RTR
+1 Kolaghan's Command|DTK
+1 Mawloc|40K
+1 Bloodbraid Elf|ARB
+1 Vibrance|ECL
+1 Figure of Fable|ECL
+1 Voice of Resurgence|DGM
+1 Kitchen Finks|SHM
+1 Damn|MH2
+1 Tidehollow Sculler|ALA
+1 Lingering Souls|DKA
+1 Izzet Charm|RTR
+1 Electrolyze|GPT
+1 Roaring Furnace // Steaming Sauna|DSK
+1 Mosswood Dreadknight|WOE
+1 Glissa Sunslayer|ONE
+1 Maelstrom Pulse|ARB
+1 Figure of Destiny|EVE
+1 Heartflame Duelist|WOE
+1 Ajani Vengeant|ALA
+1 Growth Spiral|RNA
+1 Hydroid Krasis|RNA
+1 Kiora, the Crashing Wave|BNG
+1 Celestial Colonnade|WWK
+1 Hallowed Fountain|DIS
+1 Seachrome Coast|SOM
+1 Creeping Tar Pit|WWK
+1 Darkslick Shores|SOM
+1 Watery Grave|RAV
+1 Blackcleave Cliffs|SOM
+1 Blood Crypt|DIS
+1 Restless Vents|LCI
+1 Copperline Gorge|SOM
+1 Raging Ravine|WWK
+1 Stomping Ground|GPT
+1 Razorverge Thicket|SOM
+1 Stirring Wildwood|WWK
+1 Temple Garden|RAV
+1 Concealed Courtyard|KLD
+1 Godless Shrine|GPT
+1 Shambling Vent|BFZ
+1 Spirebluff Canal|KLD
+1 Steam Vents|GPT
+1 Wandering Fumarole|OGW
+1 Blooming Marsh|KLD
+1 Overgrown Tomb|RAV
+1 Restless Cottage|WOE
+1 Inspiring Vantage|KLD
+1 Restless Bivouac|WOE
+1 Sacred Foundry|RAV
+1 Botanical Sanctum|KLD
+1 Breeding Pool|DIS
+1 Lumbering Falls|BFZ
+1 Mana Confluence|JOU
+1 Mishra's Factory|ATQ
+1 Multiversal Passage|SPM
+1 Prismatic Vista|MH1

--- a/forge-gui/res/draft/Adam Styborkski's Pauper Cube.draft
+++ b/forge-gui/res/draft/Adam Styborkski's Pauper Cube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Amaz Peasant Cube.draft
+++ b/forge-gui/res/draft/Amaz Peasant Cube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Ben's Cube.draft
+++ b/forge-gui/res/draft/Ben's Cube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Bun Magic Cube.draft
+++ b/forge-gui/res/draft/Bun Magic Cube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Caleb Gannon's Powered Synergy Cube.draft
+++ b/forge-gui/res/draft/Caleb Gannon's Powered Synergy Cube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Card Kingdom Starter Cube v3.draft
+++ b/forge-gui/res/draft/Card Kingdom Starter Cube v3.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Cube Tutor 360 Pauper.draft
+++ b/forge-gui/res/draft/Cube Tutor 360 Pauper.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Cube Tutor 720.draft
+++ b/forge-gui/res/draft/Cube Tutor 720.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Cultic.draft
+++ b/forge-gui/res/draft/Cultic.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Dekkaru Cube.draft
+++ b/forge-gui/res/draft/Dekkaru Cube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Elliot Raff's Khans Expanded Cube (MTGO).draft
+++ b/forge-gui/res/draft/Elliot Raff's Khans Expanded Cube (MTGO).draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Eric Klug's Pro Tour Cube.draft
+++ b/forge-gui/res/draft/Eric Klug's Pro Tour Cube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Frontier.draft
+++ b/forge-gui/res/draft/Frontier.draft
@@ -4,4 +4,5 @@ Singleton:True
 LandSetCode:BFZ
                 
 Booster: 15 Any  
-NumPacks:3
+NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Guillaume Matignon's Jenny's-Johnny's Cube.draft
+++ b/forge-gui/res/draft/Guillaume Matignon's Jenny's-Johnny's Cube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Hypercube (383 cards).draft
+++ b/forge-gui/res/draft/Hypercube (383 cards).draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Jim Davis's Cube.draft
+++ b/forge-gui/res/draft/Jim Davis's Cube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Jospeh Vasoli's Peasant Cube.draft
+++ b/forge-gui/res/draft/Jospeh Vasoli's Peasant Cube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/LSVCube.draft
+++ b/forge-gui/res/draft/LSVCube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Legendary Cube April 2016.draft
+++ b/forge-gui/res/draft/Legendary Cube April 2016.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Legendary Cube.draft
+++ b/forge-gui/res/draft/Legendary Cube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTG Arena Chromatic Cube June 24.draft
+++ b/forge-gui/res/draft/MTG Arena Chromatic Cube June 24.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGA Cube 2020 April.draft
+++ b/forge-gui/res/draft/MTGA Cube 2020 April.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGACube.draft
+++ b/forge-gui/res/draft/MTGACube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Core Cube 2018 (540 cards).draft
+++ b/forge-gui/res/draft/MTGO Core Cube 2018 (540 cards).draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Cube 2014-03.draft
+++ b/forge-gui/res/draft/MTGO Cube 2014-03.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Grixis Cube (540 Cards).draft
+++ b/forge-gui/res/draft/MTGO Grixis Cube (540 Cards).draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Grixis Cube 2019-09 (540 Cards).draft
+++ b/forge-gui/res/draft/MTGO Grixis Cube 2019-09 (540 Cards).draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Khans Expanded Cube.draft
+++ b/forge-gui/res/draft/MTGO Khans Expanded Cube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Legacy Cube 2015-03.draft
+++ b/forge-gui/res/draft/MTGO Legacy Cube 2015-03.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Legacy Cube 2015-09.draft
+++ b/forge-gui/res/draft/MTGO Legacy Cube 2015-09.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Legacy Cube 2016-01.draft
+++ b/forge-gui/res/draft/MTGO Legacy Cube 2016-01.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Legacy Cube 2016-09.draft
+++ b/forge-gui/res/draft/MTGO Legacy Cube 2016-09.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Legacy Cube 2017-01.draft
+++ b/forge-gui/res/draft/MTGO Legacy Cube 2017-01.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Legacy Cube 2017-04.draft
+++ b/forge-gui/res/draft/MTGO Legacy Cube 2017-04.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Legacy Cube 2018-02.draft
+++ b/forge-gui/res/draft/MTGO Legacy Cube 2018-02.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Legacy Cube 2019-07.draft
+++ b/forge-gui/res/draft/MTGO Legacy Cube 2019-07.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Legacy Cube 2021-05.draft
+++ b/forge-gui/res/draft/MTGO Legacy Cube 2021-05.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Legacy Cube 2021-08.draft
+++ b/forge-gui/res/draft/MTGO Legacy Cube 2021-08.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Legacy Cube.draft
+++ b/forge-gui/res/draft/MTGO Legacy Cube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2013.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2013.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2014.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2014.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2015.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2015.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2016-06.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2016-06.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2016-11.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2016-11.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2016.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2016.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2017-06.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2017-06.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2017-12.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2017-12.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2017.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2017.draft
@@ -3,5 +3,6 @@ DeckFile:MTGO Vintage Cube 2017
 Singleton:True
 LandSetCode:RTR
 
-Booster:15 Any
-NumPacks:3
+Booster: 15 Any
+NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2018-06.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2018-06.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2018-12.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2018-12.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2019 Summer.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2019 Summer.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2019-06.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2019-06.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2019-12.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2019-12.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2020-04.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2020-04.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2020-07.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2020-07.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2020-12.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2020-12.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2021-07.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2021-07.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2022-02.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2022-02.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2023-05.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2023-05.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2023-08.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2023-08.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2023-10.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2023-10.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2024-02.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2024-02.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2024-06.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2024-06.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2025-04.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2025-04.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/MTGO Vintage Cube 2025-12.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2025-12.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Modern Cube 2017.draft
+++ b/forge-gui/res/draft/Modern Cube 2017.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Mono Blue Cube.draft
+++ b/forge-gui/res/draft/Mono Blue Cube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Old School 93-94 (540 Cards, Cube Cobra).draft
+++ b/forge-gui/res/draft/Old School 93-94 (540 Cards, Cube Cobra).draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Old School 93-94 Craig Wescoe's Cube (Cube Cobra).draft
+++ b/forge-gui/res/draft/Old School 93-94 Craig Wescoe's Cube (Cube Cobra).draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Old School 93-94 Magic Full Set 878 Card Cube.draft
+++ b/forge-gui/res/draft/Old School 93-94 Magic Full Set 878 Card Cube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Old School 93-94 Magic Powered 360 Card Cube.draft
+++ b/forge-gui/res/draft/Old School 93-94 Magic Powered 360 Card Cube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Old School 93-94 Magic Unpowered 400 Card Cube.draft
+++ b/forge-gui/res/draft/Old School 93-94 Magic Unpowered 400 Card Cube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Old School 93-95 (360 Cards, Cube Cobra).draft
+++ b/forge-gui/res/draft/Old School 93-95 (360 Cards, Cube Cobra).draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Old School 98 (350 Cards, Cube Cobra).draft
+++ b/forge-gui/res/draft/Old School 98 (350 Cards, Cube Cobra).draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Old School Alpha, Beta and 4 Horsemen (360 Cards, Cube Cobra).draft
+++ b/forge-gui/res/draft/Old School Alpha, Beta and 4 Horsemen (360 Cards, Cube Cobra).draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Old School Classically Trained - The First Five (Cube Cobra).draft
+++ b/forge-gui/res/draft/Old School Classically Trained - The First Five (Cube Cobra).draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Pioneer Cube.draft
+++ b/forge-gui/res/draft/Pioneer Cube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Regular Cube.draft
+++ b/forge-gui/res/draft/Regular Cube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Ryan Overturf's Grixis Cube (MTGO).draft
+++ b/forge-gui/res/draft/Ryan Overturf's Grixis Cube (MTGO).draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/SCG Con Cube 2018 December.draft
+++ b/forge-gui/res/draft/SCG Con Cube 2018 December.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Sam Black's No Search Cube.draft
+++ b/forge-gui/res/draft/Sam Black's No Search Cube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/The Arena Cube.draft
+++ b/forge-gui/res/draft/The Arena Cube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/The Modern Cube.draft
+++ b/forge-gui/res/draft/The Modern Cube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/The Original Recipe Twobert.draft
+++ b/forge-gui/res/draft/The Original Recipe Twobert.draft
@@ -1,0 +1,7 @@
+Name:The Original Recipe Twobert
+DeckFile:The Original Recipe Twobert
+Singleton:True
+
+Booster: 9 Any
+NumPacks: 5
+NumPlayers: 4

--- a/forge-gui/res/draft/The Pauper Cube 2023-06.draft
+++ b/forge-gui/res/draft/The Pauper Cube 2023-06.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/The Pauper Cube 2026-02.draft
+++ b/forge-gui/res/draft/The Pauper Cube 2026-02.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/The Peasant Cube 2023 (June).draft
+++ b/forge-gui/res/draft/The Peasant Cube 2023 (June).draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/The Peasant's Toolbox.draft
+++ b/forge-gui/res/draft/The Peasant's Toolbox.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Timothee Simonot's Twisted Color Pie Cube.draft
+++ b/forge-gui/res/draft/Timothee Simonot's Twisted Color Pie Cube.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/Wtwlf123 Powered Cube (540 cards).draft
+++ b/forge-gui/res/draft/Wtwlf123 Powered Cube (540 cards).draft
@@ -3,3 +3,4 @@ DeckFile:Wtwlf123 Powered Cube (540 cards)
 Singleton:True
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/cube_juzamjedi.draft
+++ b/forge-gui/res/draft/cube_juzamjedi.draft
@@ -3,4 +3,5 @@ DeckFile:JuzamjediCube
 LandSetCode:M11
 
 Booster: 5 Rare, 1 Mythic, 5 Common, 5 Uncommon
-NumPacks:3
+NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/cube_skiera.draft
+++ b/forge-gui/res/draft/cube_skiera.draft
@@ -4,4 +4,5 @@ Singleton:True
 LandSetCode:M11
 
 Booster: 16 Any
-NumPacks:3
+NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/res/draft/www.mtgcube.com.draft
+++ b/forge-gui/res/draft/www.mtgcube.com.draft
@@ -4,3 +4,4 @@ Singleton:True
 
 Booster: 15 Any
 NumPacks: 3
+NumPlayers: 8

--- a/forge-gui/src/main/java/forge/gamemodes/limited/BoosterDraft.java
+++ b/forge-gui/src/main/java/forge/gamemodes/limited/BoosterDraft.java
@@ -391,7 +391,19 @@ public class BoosterDraft implements IBoosterDraft {
 
         final SealedTemplate tpl = draft.getSealedProductTemplate();
 
-        // TODO Determine PodSize from custom draft
+        int players = draft.getNumPlayers();
+        final int minPlayers = 2;
+        final int maxPlayers = 8;
+
+        // Check if numPlayers is set in draft file, if not default to 8.
+        if (players == 0) {
+            players = N_PLAYERS;
+        } else {
+            players = Math.max(players, minPlayers);
+            players = Math.min(players, maxPlayers);
+        }
+
+        setPodSize(players);
 
         final UnOpenedProduct toAdd = new UnOpenedProduct(tpl, dPool);
         toAdd.setLimitedPool(draft.isSingleton());

--- a/forge-gui/src/main/java/forge/gamemodes/limited/CustomLimited.java
+++ b/forge-gui/src/main/java/forge/gamemodes/limited/CustomLimited.java
@@ -65,6 +65,8 @@ public class CustomLimited extends DeckBase {
     /** The Num packs. */
     private int numPacks = 3;
 
+    private int numPlayers = 8;
+
     private transient ItemPool<PaperCard> cardPool;
 
     /** The Land set code. */
@@ -116,6 +118,7 @@ public class CustomLimited extends DeckBase {
         cd.landSetCode = data.get("LandSetCode");
         cd.numPacks = data.getInt("NumPacks");
         cd.singleton = data.getBoolean("Singleton");
+        cd.numPlayers = data.getInt("NumPlayers");
         cd.customRankingsFile = data.get("CustomRankings", "rankings_cubecobra.txt");
         final Deck deckCube = cubes.get(data.get("DeckFile"));
         cd.cardPool = deckCube == null ? ItemPool.createFrom(FModel.getMagicDb().getCommonCards().getUniqueCards(), PaperCard.class) : deckCube.getMain();
@@ -140,6 +143,25 @@ public class CustomLimited extends DeckBase {
      */
     public void setNumPacks(final int numPacksIn) {
         this.numPacks = numPacksIn;
+    }
+
+    /**
+     * Gets the num players.
+     * 
+     * @return the numPlayers
+     */
+    public int getNumPlayers() {
+        return this.numPlayers;
+    }
+
+    /**
+     * Sets the num players.
+     * 
+     * @param numPlayersIn
+     *            the numPlayers to set
+     */
+    public void setNumPlayers(final int numPlayersIn) {
+        this.numPlayers = numPlayersIn;
     }
 
     /**


### PR DESCRIPTION
Added support in .draft file to set the NumPlayers for cubes smaller than 360 that can't support that many players.
Added new NumPlayer field to all current cubes to default to 8. Need to find out if there is a place in the documentation that needs to be updated as well.