### PR TITLE
Adventure: preserve card edition in variant rewards

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/util/CardUtil.java
+++ b/forge-gui-mobile/src/forge/adventure/util/CardUtil.java
@@ -317,8 +317,8 @@ public class CardUtil {
                 PaperCard candidate = pool.get(r.nextInt(pool.size()));
                 if (candidate != null) {
                     if (allCardVariants) {
-                        // Get a random set variant
-                        PaperCard finalCandidate = CardUtil.getCardByName(candidate.getCardName());
+                        // Get a random variant, preserving edition when specified
+                        PaperCard finalCandidate = CardUtil.getCardByNameAndEdition(candidate.getCardName(), candidate.getEdition());
                         result.add(finalCandidate);
                     } else {
                         result.add(candidate);


### PR DESCRIPTION
- When "Use All Card Variants" is enabled, card rewards (dungeon loot, enemy deck drops, deck-sourced rewards) now preserve the original edition instead of randomizing across all editions
- Previously, `generateCards()` called `getCardByName()` which discarded the candidate's edition and returned a random printing from any set
- Now calls `getCardByNameAndEdition()` which keeps the card in its original edition while still allowing art variant randomization within that edition
- Falls back to random edition if the specified edition is restricted or not found in the database
- Affects all three call sites of `CardUtil.generateCards()`:
  - `RewardData.java:246` - card rewards from a specific deck file (`sourceDeck`)
  - `RewardData.java:251` - random card drops from the global pool (filtered by edition/rarity/color)
  - `RewardData.java:332` - enemy deck card rewards (`deckCard` type)