### PR TITLE
Old Border Shandalar: Fix Dungeon Master quest stuck on out-of-order boss kills

### DIFF
--- a/forge-gui/res/adventure/Shandalar Old Border/maps/map/fort/fort_blue_4_clouds.tmx
+++ b/forge-gui/res/adventure/Shandalar Old Border/maps/map/fort/fort_blue_4_clouds.tmx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="30" height="30" tilewidth="16" tileheight="16" infinite="0" nextlayerid="11" nextobjectid="67">
+<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="30" height="30" tilewidth="16" tileheight="16" infinite="0" nextlayerid="11" nextobjectid="68">
  <editorsettings>
   <export target="wastetown..tmx" format="tmx" />
  </editorsettings>
@@ -228,5 +228,10 @@
     <property name="enemy" value="The Astral Visionary" />
     <property name="threatRange" type="int" value="100" />
    <property name="speedModifier" type="float" value="20" /></properties>
-  </object></objectgroup>
+  </object>  <object id="67" template="../../../../../../common/maps/obj/dialog.tx" type="dialog" gid="11530" x="182" y="425.5" width="60" height="40">
+   <properties>
+    <property name="dialog">[{"condition":[{"item":"Astral Visionary's Trophy"}],"text":"","options":[],"action":[{"removeItem":"Astral Visionary's Trophy"},{"addItem":"Astral Visionary's Trophy"}]}]</property>
+   </properties>
+  </object>
+ </objectgroup>
 </map>

--- a/forge-gui/res/adventure/Shandalar Old Border/maps/map/fort/fort_white_2_humans.tmx
+++ b/forge-gui/res/adventure/Shandalar Old Border/maps/map/fort/fort_white_2_humans.tmx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="35" height="25" tilewidth="16" tileheight="16" infinite="0" nextlayerid="10" nextobjectid="79">
+<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="35" height="25" tilewidth="16" tileheight="16" infinite="0" nextlayerid="10" nextobjectid="80">
  <editorsettings>
   <export target="wastetown..tmx" format="tmx" />
  </editorsettings>
@@ -257,5 +257,10 @@
     <property name="enemy" value="The Sainted One" />
     <property name="threatRange" type="int" value="100" />
    <property name="speedModifier" type="float" value="20" /></properties>
-  </object></objectgroup>
+  </object>  <object id="79" template="../../../../../../common/maps/obj/dialog.tx" type="dialog" gid="11530" x="160.6" y="409.7" width="60" height="40">
+   <properties>
+    <property name="dialog">[{"condition":[{"item":"Sainted One's Trophy"}],"text":"","options":[],"action":[{"removeItem":"Sainted One's Trophy"},{"addItem":"Sainted One's Trophy"}]}]</property>
+   </properties>
+  </object>
+ </objectgroup>
 </map>

--- a/forge-gui/res/adventure/Shandalar Old Border/maps/map/graveyard_crypt/graveyard_4.tmx
+++ b/forge-gui/res/adventure/Shandalar Old Border/maps/map/graveyard_crypt/graveyard_4.tmx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="34" height="25" tilewidth="16" tileheight="16" infinite="0" nextlayerid="11" nextobjectid="94">
+<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="34" height="25" tilewidth="16" tileheight="16" infinite="0" nextlayerid="11" nextobjectid="96">
  <editorsettings>
   <export target="wastetown..tmx" format="tmx" />
  </editorsettings>
@@ -247,6 +247,16 @@
         ]
     }
 ]</property>
+   </properties>
+  </object>
+   <object id="94" template="../../../../../../common/maps/obj/dialog.tx" type="dialog" gid="11530" x="397" y="409.5" width="60" height="40">
+   <properties>
+    <property name="dialog">[{"condition":[{"item":"Lichlord's Trophy"}],"text":"","options":[],"action":[{"removeItem":"Lichlord's Trophy"},{"addItem":"Lichlord's Trophy"}]}]</property>
+   </properties>
+  </object>
+  <object id="95" template="../../../../../../common/maps/obj/dialog.tx" type="dialog" gid="11530" x="236" y="36" width="60" height="40">
+   <properties>
+    <property name="dialog">[{"condition":[{"item":"Lichlord's Trophy"}],"text":"","options":[],"action":[{"removeItem":"Lichlord's Trophy"},{"addItem":"Lichlord's Trophy"}]}]</property>
    </properties>
   </object>
  </objectgroup>

--- a/forge-gui/res/adventure/Shandalar Old Border/maps/map/grove/grove_7_snake.tmx
+++ b/forge-gui/res/adventure/Shandalar Old Border/maps/map/grove/grove_7_snake.tmx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="40" height="50" tilewidth="16" tileheight="16" infinite="0" nextlayerid="11" nextobjectid="101">
+<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="40" height="50" tilewidth="16" tileheight="16" infinite="0" nextlayerid="11" nextobjectid="102">
  <editorsettings>
   <export target="wastetown..tmx" format="tmx" />
  </editorsettings>
@@ -239,5 +239,10 @@
 ]</property>
    </properties>
   </object>
- <object id="100" template="../../../../../../common/maps/obj/enemy.tx" x="250" y="150"><properties><property name="enemy" value="Dracur of Shandalar" /><property name="threatRange" type="int" value="100" /><property name="effect">{"startBattleWithCard": ["City of Brass|ARN"]}</property></properties></object></objectgroup>
+ <object id="100" template="../../../../../../common/maps/obj/enemy.tx" x="250" y="150"><properties><property name="enemy" value="Dracur of Shandalar" /><property name="threatRange" type="int" value="100" /><property name="effect">{"startBattleWithCard": ["City of Brass|ARN"]}</property></properties></object>  <object id="101" template="../../../../../../common/maps/obj/dialog.tx" type="dialog" gid="11530" x="260.5" y="808.5" width="60" height="40">
+   <properties>
+    <property name="dialog">[{"condition":[{"item":"Dragon Lord's Trophy"}],"text":"","options":[],"action":[{"removeItem":"Dragon Lord's Trophy"},{"addItem":"Dragon Lord's Trophy"}]}]</property>
+   </properties>
+  </object>
+ </objectgroup>
 </map>

--- a/forge-gui/res/adventure/Shandalar Old Border/maps/map/grove/grove_8_hydra.tmx
+++ b/forge-gui/res/adventure/Shandalar Old Border/maps/map/grove/grove_8_hydra.tmx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="60" height="30" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="124">
+<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="60" height="30" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="125">
  <editorsettings>
   <export target="wastetown..tmx" format="tmx" />
  </editorsettings>
@@ -259,6 +259,11 @@
         ]
     }
 ]</property>
+   </properties>
+  </object>
+   <object id="124" template="../../../../../../common/maps/obj/dialog.tx" type="dialog" gid="11530" x="468.8" y="488.7" width="60" height="40">
+   <properties>
+    <property name="dialog">[{"condition":[{"item":"Hydra's Trophy"}],"text":"","options":[],"action":[{"removeItem":"Hydra's Trophy"},{"addItem":"Hydra's Trophy"}]}]</property>
    </properties>
   </object>
  </objectgroup>

--- a/forge-gui/res/adventure/Shandalar Old Border/maps/map/grove/grove_9_eldrazi.tmx
+++ b/forge-gui/res/adventure/Shandalar Old Border/maps/map/grove/grove_9_eldrazi.tmx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="37" height="33" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="118">
+<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="37" height="33" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="119">
  <editorsettings>
   <export target="wastetown..tmx" format="tmx" />
  </editorsettings>
@@ -228,5 +228,10 @@
 ]</property>
    </properties>
   </object>
- <object id="117" template="../../../../../../common/maps/obj/enemy.tx" x="250" y="150"><properties><property name="enemy" value="Prismat of Shandalar" /><property name="threatRange" type="int" value="100" /><property name="effect">{"startBattleWithCard": ["City of Brass|ARN"]}</property></properties></object></objectgroup>
+ <object id="117" template="../../../../../../common/maps/obj/enemy.tx" x="250" y="150"><properties><property name="enemy" value="Prismat of Shandalar" /><property name="threatRange" type="int" value="100" /><property name="effect">{"startBattleWithCard": ["City of Brass|ARN"]}</property></properties></object>  <object id="118" template="../../../../../../common/maps/obj/dialog.tx" type="dialog" gid="11530" x="220" y="537.5" width="60" height="40">
+   <properties>
+    <property name="dialog">[{"condition":[{"item":"Great Druid's Trophy"}],"text":"","options":[],"action":[{"removeItem":"Great Druid's Trophy"},{"addItem":"Great Druid's Trophy"}]}]</property>
+   </properties>
+  </object>
+ </objectgroup>
 </map>

--- a/forge-gui/res/adventure/Shandalar Old Border/maps/map/jacetower/jacehold.tmx
+++ b/forge-gui/res/adventure/Shandalar Old Border/maps/map/jacetower/jacehold.tmx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="39" height="17" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="103">
+<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="39" height="17" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="104">
  <editorsettings>
   <export target="wastetown..tmx" format="tmx" />
  </editorsettings>
@@ -402,6 +402,11 @@
         ]
     }
 ]</property>
+   </properties>
+  </object>
+   <object id="103" template="../../../../../../common/maps/obj/dialog.tx" type="dialog" gid="11530" x="298.7" y="278.3" width="60" height="40">
+   <properties>
+    <property name="dialog">[{"condition":[{"item":"Arcanis's Trophy"}],"text":"","options":[],"action":[{"removeItem":"Arcanis's Trophy"},{"addItem":"Arcanis's Trophy"}]}]</property>
    </properties>
   </object>
  </objectgroup>

--- a/forge-gui/res/adventure/Shandalar Old Border/maps/map/magetower/magetower_10_crawlspace.tmx
+++ b/forge-gui/res/adventure/Shandalar Old Border/maps/map/magetower/magetower_10_crawlspace.tmx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="30" height="17" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="60">
+<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="30" height="17" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="61">
  <editorsettings>
   <export target="wastetown..tmx" format="tmx" />
  </editorsettings>
@@ -187,6 +187,11 @@
         ]
     }
 ]</property>
+   </properties>
+  </object>
+   <object id="60" template="../../../../../../common/maps/obj/dialog.tx" type="dialog" gid="11530" x="81.5" y="281" width="60" height="40">
+   <properties>
+    <property name="dialog">[{"condition":[{"item":"Time Walker's Trophy"}],"text":"","options":[],"action":[{"removeItem":"Time Walker's Trophy"},{"addItem":"Time Walker's Trophy"}]}]</property>
    </properties>
   </object>
  </objectgroup>

--- a/forge-gui/res/adventure/Shandalar Old Border/maps/map/minibosses/kiora_island.tmx
+++ b/forge-gui/res/adventure/Shandalar Old Border/maps/map/minibosses/kiora_island.tmx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="60" height="50" tilewidth="16" tileheight="16" infinite="0" nextlayerid="14" nextobjectid="121">
+<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="60" height="50" tilewidth="16" tileheight="16" infinite="0" nextlayerid="14" nextobjectid="122">
  <editorsettings>
   <export format="tmx" />
  </editorsettings>
@@ -324,6 +324,11 @@
         ]
     }
 ]</property>
+   </properties>
+  </object>
+   <object id="121" template="../../../../../../common/maps/obj/dialog.tx" type="dialog" gid="11530" x="356" y="808.7" width="60" height="40">
+   <properties>
+    <property name="dialog">[{"condition":[{"item":"Empress Galina's Trophy"}],"text":"","options":[],"action":[{"removeItem":"Empress Galina's Trophy"},{"addItem":"Empress Galina's Trophy"}]}]</property>
    </properties>
   </object>
  </objectgroup>

--- a/forge-gui/res/adventure/Shandalar Old Border/maps/map/minibosses/slimefoot_boss.tmx
+++ b/forge-gui/res/adventure/Shandalar Old Border/maps/map/minibosses/slimefoot_boss.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="50" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="95">
+<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="50" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="96">
  <editorsettings>
   <export target="wastetown..tmx" format="tmx" />
  </editorsettings>
@@ -203,6 +203,11 @@
         ]
     }
 ]</property>
+   </properties>
+  </object>
+   <object id="95" template="../../../../../../common/maps/obj/dialog.tx" type="dialog" gid="11530" x="248" y="648" width="60" height="40">
+   <properties>
+    <property name="dialog">[{"condition":[{"item":"Thallid Lord's Trophy"}],"text":"","options":[],"action":[{"removeItem":"Thallid Lord's Trophy"},{"addItem":"Thallid Lord's Trophy"}]}]</property>
    </properties>
   </object>
  </objectgroup>

--- a/forge-gui/res/adventure/Shandalar Old Border/maps/map/minibosses/slobad_factory.tmx
+++ b/forge-gui/res/adventure/Shandalar Old Border/maps/map/minibosses/slobad_factory.tmx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="50" height="27" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="99">
+<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="50" height="27" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="100">
  <editorsettings>
   <export target="wastetown..tmx" format="tmx" />
  </editorsettings>
@@ -164,6 +164,11 @@
         ]
     }
 ]</property>
+   </properties>
+  </object>
+  <object id="99" template="../../../../../../common/maps/obj/dialog.tx" type="dialog" gid="11530" x="372" y="440" width="60" height="40">
+   <properties>
+    <property name="dialog">[{"condition":[{"item":"Squee's Trophy"}],"text":"","options":[],"action":[{"removeItem":"Squee's Trophy"},{"addItem":"Squee's Trophy"}]}]</property>
    </properties>
   </object>
  </objectgroup>

--- a/forge-gui/res/adventure/Shandalar Old Border/maps/map/minibosses/teferi.tmx
+++ b/forge-gui/res/adventure/Shandalar Old Border/maps/map/minibosses/teferi.tmx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="60" height="50" tilewidth="16" tileheight="16" infinite="0" nextlayerid="13" nextobjectid="120">
+<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="60" height="50" tilewidth="16" tileheight="16" infinite="0" nextlayerid="13" nextobjectid="121">
  <editorsettings>
   <export target="wastetown..tmx" format="tmx" />
  </editorsettings>
@@ -391,6 +391,11 @@
         ]
     }
 ]</property>
+   </properties>
+  </object>
+   <object id="120" template="../../../../../../common/maps/obj/dialog.tx" type="dialog" gid="11530" x="310" y="810.8" width="60" height="40">
+   <properties>
+    <property name="dialog">[{"condition":[{"item":"Teferi's Trophy"}],"text":"","options":[],"action":[{"removeItem":"Teferi's Trophy"},{"addItem":"Teferi's Trophy"}]}]</property>
    </properties>
   </object>
  </objectgroup>

--- a/forge-gui/res/adventure/Shandalar Old Border/maps/map/minibosses/xira.tmx
+++ b/forge-gui/res/adventure/Shandalar Old Border/maps/map/minibosses/xira.tmx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<map version="1.10" tiledversion="1.10.2" orientation="orthogonal" renderorder="right-down" width="40" height="26" tilewidth="16" tileheight="16" infinite="0" nextlayerid="12" nextobjectid="105">
+<map version="1.10" tiledversion="1.10.2" orientation="orthogonal" renderorder="right-down" width="40" height="26" tilewidth="16" tileheight="16" infinite="0" nextlayerid="12" nextobjectid="106">
  <editorsettings>
   <export target="wastetown..tmx" format="tmx" />
  </editorsettings>
@@ -256,6 +256,11 @@
         ]
     }
 ]</property>
+   </properties>
+  </object>
+   <object id="105" template="../../../../../../common/maps/obj/dialog.tx" type="dialog" gid="11530" x="381.5" y="426.5" width="60" height="40">
+   <properties>
+    <property name="dialog">[{"condition":[{"item":"Xira's Trophy"}],"text":"","options":[],"action":[{"removeItem":"Xira's Trophy"},{"addItem":"Xira's Trophy"}]}]</property>
    </properties>
   </object>
  </objectgroup>

--- a/forge-gui/res/adventure/Shandalar Old Border/maps/map/tibalt/tibalt.tmx
+++ b/forge-gui/res/adventure/Shandalar Old Border/maps/map/tibalt/tibalt.tmx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="65" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="25" nextobjectid="247">
+<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="65" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="25" nextobjectid="250">
  <editorsettings>
   <export format="tmx" />
  </editorsettings>
@@ -346,6 +346,21 @@
         ]
     }
 ]</property>
+   </properties>
+  </object>
+   <object id="247" template="../../../../../../common/maps/obj/dialog.tx" type="dialog" gid="11530" x="792" y="21.4" width="60" height="40">
+   <properties>
+    <property name="dialog">[{"condition":[{"item":"Specter King's Trophy"}],"text":"","options":[],"action":[{"removeItem":"Specter King's Trophy"},{"addItem":"Specter King's Trophy"}]}]</property>
+   </properties>
+  </object>
+  <object id="248" template="../../../../../../common/maps/obj/dialog.tx" type="dialog" gid="11530" x="663" y="22.4" width="60" height="40">
+   <properties>
+    <property name="dialog">[{"condition":[{"item":"Specter King's Trophy"}],"text":"","options":[],"action":[{"removeItem":"Specter King's Trophy"},{"addItem":"Specter King's Trophy"}]}]</property>
+   </properties>
+  </object>
+  <object id="249" template="../../../../../../common/maps/obj/dialog.tx" type="dialog" gid="11530" x="399" y="641.8" width="60" height="40">
+   <properties>
+    <property name="dialog">[{"condition":[{"item":"Specter King's Trophy"}],"text":"","options":[],"action":[{"removeItem":"Specter King's Trophy"},{"addItem":"Specter King's Trophy"}]}]</property>
    </properties>
   </object>
  </objectgroup>

--- a/forge-gui/res/adventure/Shandalar Old Border/maps/map/vampirecastle/vampirecastle_4.tmx
+++ b/forge-gui/res/adventure/Shandalar Old Border/maps/map/vampirecastle/vampirecastle_4.tmx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="60" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="107">
+<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="60" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="108">
  <editorsettings>
   <export target="wastetown..tmx" format="tmx" />
  </editorsettings>
@@ -355,6 +355,11 @@
         ]
     }
 ]</property>
+   </properties>
+  </object>
+   <object id="107" template="../../../../../../common/maps/obj/dialog.tx" type="dialog" gid="11530" x="8.7" y="325" width="40" height="60">
+   <properties>
+    <property name="dialog">[{"condition":[{"item":"Baron Sengir's Trophy"}],"text":"","options":[],"action":[{"removeItem":"Baron Sengir's Trophy"},{"addItem":"Baron Sengir's Trophy"}]}]</property>
    </properties>
   </object>
  </objectgroup>

--- a/forge-gui/res/adventure/Shandalar Old Border/maps/map/zedruu/zedruu.tmx
+++ b/forge-gui/res/adventure/Shandalar Old Border/maps/map/zedruu/zedruu.tmx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="44" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="33" nextobjectid="267">
+<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="44" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="33" nextobjectid="270">
  <editorsettings>
   <export format="tmx" />
  </editorsettings>
@@ -416,6 +416,21 @@
    <properties>
     <property name="direction" value="down" />
     <property name="teleport" value="../Shandalar Old Border/maps/map/zedruu/zedruu_f4.tmx" />
+   </properties>
+  </object>
+   <object id="267" template="../../../../../../common/maps/obj/dialog.tx" type="dialog" gid="11530" x="41.7" y="76.9" width="60" height="40">
+   <properties>
+    <property name="dialog">[{"condition":[{"item":"Portal Master's Trophy"}],"text":"","options":[],"action":[{"removeItem":"Portal Master's Trophy"},{"addItem":"Portal Master's Trophy"}]}]</property>
+   </properties>
+  </object>
+  <object id="268" template="../../../../../../common/maps/obj/dialog.tx" type="dialog" gid="11530" x="328.8" y="642.8" width="60" height="40">
+   <properties>
+    <property name="dialog">[{"condition":[{"item":"Portal Master's Trophy"}],"text":"","options":[],"action":[{"removeItem":"Portal Master's Trophy"},{"addItem":"Portal Master's Trophy"}]}]</property>
+   </properties>
+  </object>
+  <object id="269" template="../../../../../../common/maps/obj/dialog.tx" type="dialog" gid="11530" x="437.5" y="26.4" width="60" height="40">
+   <properties>
+    <property name="dialog">[{"condition":[{"item":"Portal Master's Trophy"}],"text":"","options":[],"action":[{"removeItem":"Portal Master's Trophy"},{"addItem":"Portal Master's Trophy"}]}]</property>
    </properties>
   </object>
  </objectgroup>


### PR DESCRIPTION
- Fix quest getting permanently stuck when players kill bosses before their quest stage activates
- The Fetch objective only listens for RECEIVEITEM events, so if a boss is killed while a stage is INACTIVE, the trophy pickup event is lost forever
- Add hidden silent dialog triggers at each boss dungeon entry point that re-grant the trophy (removeItem + addItem) when the player already has it, firing a fresh event for the now-active stage to catch
- Covers all 16 boss dungeons with extra triggers for multi-entry maps (Tibalt, Zedruu, Graveyard)