### PR TITLE
Allow nonbasic lands like Towns in Planar Conquest common filter of the Aether

### DIFF
--- a/forge-gui-mobile/src/forge/screens/planarconquest/ConquestAEtherScreen.java
+++ b/forge-gui-mobile/src/forge/screens/planarconquest/ConquestAEtherScreen.java
@@ -123,6 +123,7 @@ public class ConquestAEtherScreen extends FScreen {
             } else if (card.getRarity() == CardRarity.BasicLand
                     && !card.isVeryBasicLand()
                     && selectedRarity == CardRarity.Common
+                    && btnCMCFilter.selectedOption == ConquestUtil.CMCFilter.CMC_LOW
                     && card.getRules().getColorIdentity().hasNoColorsExcept(commander.getCard().getRules().getColorIdentity())) {
                 filteredPool.add(card);
             }


### PR DESCRIPTION
Currently, Planar Conquest allows some lands, but not all lands when pulling from the Aether with the Common filter. In particular, dual color Towns in Final Fantasy set are not allowed, but other Towns are allowed. The problem is that the towns have the "L" rarity (identified as BasicLand in Forge), but are not really basic lands. Therefore, a separate check is needed to include these cards in the Aether reward pool if the Common filter is selected - if they correspond to the Commander's color identity, CMC 0+ is selected in the filter, and the cards are Lands (L rarity) but not real Basic Lands, allow them through.
