### PR TITLE
Fix Scryfall image fallback skipping requested card's own edition

### DIFF
--- a/forge-gui-mobile/src/forge/util/LibGDXImageFetcher.java
+++ b/forge-gui-mobile/src/forge/util/LibGDXImageFetcher.java
@@ -2,7 +2,10 @@ package forge.util;
 
 import com.badlogic.gdx.files.FileHandle;
 import forge.Forge;
+import forge.adventure.data.ConfigData;
+import forge.adventure.util.Config;
 import forge.gui.GuiBase;
+import forge.item.PaperCard;
 import forge.localinstance.properties.ForgeConstants;
 import io.sentry.Sentry;
 
@@ -12,10 +15,25 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 public class LibGDXImageFetcher extends ImageFetcher {
+    @Override
+    protected boolean shouldTryScryfallSetLookupCandidate(PaperCard requestedCard, PaperCard candidate) {
+        if (!Forge.isMobileAdventureMode) {
+            return true;
+        }
+
+        ConfigData configData = Config.instance().getConfigData();
+        if (configData == null || configData.allowedEditions == null || configData.allowedEditions.length == 0) {
+            return true;
+        }
+
+        return Arrays.asList(configData.allowedEditions).contains(candidate.getEdition());
+    }
+
     @Override
     protected Runnable getDownloadTask(String[] downloadUrls, String destPath, Runnable notifyObservers) {
         return new LibGDXDownloadTask(downloadUrls, destPath, notifyObservers);

--- a/forge-gui/src/main/java/forge/util/ImageFetcher.java
+++ b/forge-gui/src/main/java/forge/util/ImageFetcher.java
@@ -43,42 +43,47 @@ public abstract class ImageFetcher {
         CardEdition edition = data.getEditions().get(c.getEdition());
         if (edition == null) // Edition does not exist - some error occurred with card data
             return null;
+
         if (hasSetLookup) {
+            // Always try the requested print first. The old fallback skipped it
+            // entirely and went straight to alternate prints, which can fetch
+            // the wrong frame.
+            addScryfallUrl(c, face, useArtCrop, downloadUrls);
+
             List<PaperCard> clones = StaticData.instance().getCommonCards().getAllCards(c.getName());
             for (PaperCard pc : clones) {
-                if (clones.size() > 1) { // Clones only
-                    if (!c.getEdition().equalsIgnoreCase(pc.getEdition())) {
-                        CardEdition ed = data.getEditions().get(pc.getEdition());
-                        if (ed != null) {
-                            String setCode = ed.getScryfallCode();
-                            String langCode = ed.getCardsLangCode();
-                            downloadUrls.add(ForgeConstants.URL_PIC_SCRYFALL_DOWNLOAD + ImageUtil.getScryfallDownloadUrl(pc, face, setCode, langCode, useArtCrop));
-                        }
-                    }
-                } else {// original from set
-                    CardEdition ed = data.getEditions().get(pc.getEdition());
-                    if (ed != null) {
-                        String setCode = ed.getScryfallCode();
-                        String langCode = ed.getCardsLangCode();
-                        downloadUrls.add(ForgeConstants.URL_PIC_SCRYFALL_DOWNLOAD + ImageUtil.getScryfallDownloadUrl(pc, face, setCode, langCode, useArtCrop));
-                    }
+                if (c.getEdition().equalsIgnoreCase(pc.getEdition())) {
+                    continue;
                 }
+                if (!shouldTryScryfallSetLookupCandidate(c, pc)) {
+                    continue;
+                }
+                addScryfallUrl(pc, face, useArtCrop, downloadUrls);
             }
         } else {
+            addScryfallUrl(c, face, useArtCrop, downloadUrls);
             String setCode = edition.getScryfallCode();
-            String langCode = edition.getCardsLangCode();
-            String primaryUrl = ImageUtil.getScryfallDownloadUrl(c, face, setCode, langCode, useArtCrop);
-            downloadUrls.add(ForgeConstants.URL_PIC_SCRYFALL_DOWNLOAD + primaryUrl);
-
-            // It seems like the scryfall lookup might be better if we didn't include the language code at all?
             downloadUrls.add(ForgeConstants.URL_PIC_SCRYFALL_DOWNLOAD + ImageUtil.getScryfallDownloadUrl(c, face, setCode, "", useArtCrop));
-
-            String alternateUrl = ImageUtil.getScryfallDownloadUrl(c, face, setCode, langCode, useArtCrop);
-            if (!alternateUrl.equals(primaryUrl)) {
-                downloadUrls.add(ForgeConstants.URL_PIC_SCRYFALL_DOWNLOAD + alternateUrl);
-            }
         }
         return null;
+    }
+
+    private void addScryfallUrl(PaperCard card, String face, boolean useArtCrop, ArrayList<String> downloadUrls) {
+        CardEdition edition = StaticData.instance().getEditions().get(card.getEdition());
+        if (edition == null) {
+            return;
+        }
+
+        String setCode = edition.getScryfallCode();
+        String langCode = edition.getCardsLangCode();
+        String primaryUrl = ForgeConstants.URL_PIC_SCRYFALL_DOWNLOAD + ImageUtil.getScryfallDownloadUrl(card, face, setCode, langCode, useArtCrop);
+        if (!downloadUrls.contains(primaryUrl)) {
+            downloadUrls.add(primaryUrl);
+        }
+    }
+
+    protected boolean shouldTryScryfallSetLookupCandidate(PaperCard requestedCard, PaperCard candidate) {
+        return true;
     }
 
     public static String getPlanechaseFilename(final String cardName) {


### PR DESCRIPTION
- The set-lookup fallback path skipped the requested card's own print and only tried alternate editions, which were not filtered by allowedEditions, resulting in wrong-frame art (e.g. 9ED art for an S00 card)
- Always try the requested card's Scryfall URL first before falling back to other prints
- In Adventure mode, filter fallback candidates through allowedEditions when configured