### PR TITLE
Remove the need of CounterEnumType.values

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/CountersAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CountersAi.java
@@ -17,7 +17,6 @@
  */
 package forge.ai.ability;
 
-import com.google.common.collect.Iterables;
 import forge.ai.ComputerUtilCard;
 import forge.ai.SpellAbilityAi;
 import forge.game.card.*;


### PR DESCRIPTION
Remove the need of `CounterEnumType.values`
Also Check for corner case where type somehow is "Any" and it would return null

See: https://github.com/Card-Forge/forge/issues/10076#issuecomment-4098661902