### PR TITLE
Old Border Shandalar: Add enableGeneticAI config option, remove Standard/Constructed modes

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/data/ConfigData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/ConfigData.java
@@ -29,4 +29,5 @@ public class ConfigData {
     public String[] restrictedEvents;
     public String[] allowedEvents;
     public String[] allowedJumpstart;
+    public boolean enableGeneticAI = true;
 }

--- a/forge-gui-mobile/src/forge/adventure/scene/DuelScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/DuelScene.java
@@ -421,17 +421,23 @@ public class DuelScene extends ForgeScene {
                 this.AIExtras = aiCards;
                 deck = deckProxy.getDeck();
             } else if (this.arenaBattleChallenge) {
-                deck = Aggregates.random(DeckProxy.getAllGeneticAIDecks()).getDeck();
+                if (Config.instance().getConfigData().enableGeneticAI) {
+                    deck = Aggregates.random(DeckProxy.getAllGeneticAIDecks()).getDeck();
+                } else {
+                    deck = currentEnemy.generateDeck(Current.player().isFantasyMode(), false);
+                }
             } else if (this.eventData != null) {
                 deck = eventData.nextOpponent.getDeck();
             } else {
-                deck = currentEnemy.copyPlayerDeck ? this.playerDeck : currentEnemy.generateDeck(Current.player().isFantasyMode(), Current.player().isUsingCustomDeck() || Current.player().isHardorInsaneDifficulty());
+                boolean useGeneticAI = Config.instance().getConfigData().enableGeneticAI && (Current.player().isUsingCustomDeck() || Current.player().isHardorInsaneDifficulty());
+                deck = currentEnemy.copyPlayerDeck ? this.playerDeck : currentEnemy.generateDeck(Current.player().isFantasyMode(), useGeneticAI);
             }
             if (deck == null) {
                 isDeckMissing = true;
-                isDeckMissingMsg = "Deck for " + currentEnemy.getName() + " is missing! " + (this.eventData == null ? "Genetic AI deck will be used." : "Player deck will be used.");
+                boolean canUseGeneticAI = Config.instance().getConfigData().enableGeneticAI;
+                isDeckMissingMsg = "Deck for " + currentEnemy.getName() + " is missing! " + (this.eventData == null ? (canUseGeneticAI ? "Genetic AI deck will be used." : "Player deck will be used.") : "Player deck will be used.");
                 System.err.println(isDeckMissingMsg);
-                deck = this.eventData == null ? Aggregates.random(DeckProxy.getAllGeneticAIDecks()).getDeck() : this.playerDeck;
+                deck = this.eventData == null && canUseGeneticAI ? Aggregates.random(DeckProxy.getAllGeneticAIDecks()).getDeck() : this.playerDeck;
             }
             RegisteredPlayer aiPlayer = RegisteredPlayer.forVariants(playerCount, appliedVariants, deck, null, false, null, null);
 

--- a/forge-gui/res/adventure/Shandalar Old Border/config.json
+++ b/forge-gui/res/adventure/Shandalar Old Border/config.json
@@ -123,6 +123,7 @@
     "O90P", "PALP", "PELP", "PGRU", "UGL"
   ],
   "allowedJumpstart": [],
+  "enableGeneticAI": false,
   "difficulties": [
     {
       "name": "Easy",
@@ -136,20 +137,6 @@
       "rewardMaxFactor": 1.5,
       "sellFactor": 0.6,
       "shardSellRatio": 0.95,
-      "starterDecks": {
-        "W": "decks/starter/precon/USG - Sleeper.dck",
-        "U": "decks/starter/precon/UDS - Enchanter.dck",
-        "B": "decks/starter/precon/STH - Migraine.dck",
-        "R": "decks/starter/precon/UDS - Battle Surge.dck",
-        "G": "decks/starter/precon/UDS - Fiendish Nature.dck"
-      },
-      "constructedStarterDecks": {
-        "W": "decks/starter/precon/ULG - Radiant's Revenge.dck",
-        "U": "decks/starter/precon/EXO - Dominator.dck",
-        "B": "decks/starter/precon/EXO - Groundbreaker.dck",
-        "R": "decks/starter/precon/EXO - White Heat.dck",
-        "G": "decks/starter/precon/TMP - The Swarm.dck"
-      },
       "pileDecks": {
         "W": "decks/starter/pile_white_e.json",
         "B": "decks/starter/pile_black_e.json",
@@ -181,20 +168,6 @@
       "lifeLoss": 0.2,
       "sellFactor": 0.5,
       "shardSellRatio": 0.8,
-      "starterDecks": {
-        "W": "decks/starter/precon/TMP - Deep Freeze.dck",
-        "U": "decks/starter/precon/TMP - The Slivers.dck",
-        "B": "decks/starter/precon/UDS - Assassin.dck",
-        "R": "decks/starter/precon/ULG - Phyrexian Assault.dck",
-        "G": "decks/starter/precon/ULG - Time Drain.dck"
-      },
-      "constructedStarterDecks": {
-        "W": "decks/starter/precon/STH - Call of the Kor.dck",
-        "U": "decks/starter/precon/EXO - Widowmaker.dck",
-        "B": "decks/starter/precon/USG - The Plague.dck",
-        "R": "decks/starter/precon/TMP - The Flames of Rath.dck",
-        "G": "decks/starter/precon/ULG - Crusher.dck"
-      },
       "pileDecks": {
         "W": "decks/starter/pile_white_n.json",
         "B": "decks/starter/pile_black_n.json",
@@ -224,20 +197,6 @@
       "lifeLoss": 0.3,
       "sellFactor": 0.25,
       "shardSellRatio": 0.6,
-      "starterDecks": {
-        "W": "decks/starter/precon/VIS - Legion of Glory.dck",
-        "U": "decks/starter/precon/MIR - Burning Sky.dck",
-        "B": "decks/starter/precon/MIR - Night Terrors.dck",
-        "R": "decks/starter/precon/VIS - Wild-Eyed Frenzy.dck",
-        "G": "decks/starter/precon/MIR - Jungle Jam.dck"
-      },
-      "constructedStarterDecks": {
-        "W": "decks/starter/precon/WTH - Air Forces.dck",
-        "U": "decks/starter/precon/VIS - Unnatural Forces.dck",
-        "B": "decks/starter/precon/WTH - Dead and Alive.dck",
-        "R": "decks/starter/precon/WTH - Fiery Fury.dck",
-        "G": "decks/starter/precon/VIS - Savage Stompdown.dck"
-      },
       "pileDecks": {
         "W": "decks/starter/pile_white_h.json",
         "B": "decks/starter/pile_black_h.json",
@@ -267,20 +226,6 @@
       "lifeLoss": 0.3,
       "sellFactor": 0.05,
       "shardSellRatio": 0.3,
-      "starterDecks": {
-        "W": "decks/starter/precon/S99 - Blinding Fury.dck",
-        "U": "decks/starter/precon/7ED - Bomber.dck",
-        "B": "decks/starter/precon/7ED - Decay.dck",
-        "R": "decks/starter/precon/7ED - Infestation.dck",
-        "G": "decks/starter/precon/7ED - Way Wild.dck"
-      },
-      "constructedStarterDecks": {
-        "W": "decks/starter/precon/7ED - Armada.dck",
-        "U": "decks/starter/precon/S99 - Time Curse.dck",
-        "B": "decks/starter/precon/S99 - Deadly Instinct.dck",
-        "R": "decks/starter/precon/S99 - Goblin Assault.dck",
-        "G": "decks/starter/precon/S99 - Impaler.dck"
-      },
       "pileDecks": {
         "W": "decks/starter/pile_white_h.json",
         "B": "decks/starter/pile_black_h.json",


### PR DESCRIPTION
- Add `enableGeneticAI` boolean to `ConfigData` (defaults `true` for backward compatibility)
- Check the flag in `DuelScene` for arena battles, Hard/Insane enemies, and missing deck fallback
- Set `enableGeneticAI: false` in Old Border Shandalar config.json to prevent modern card decks from replacing curated old-border enemy decks on higher difficulties
- Remove `starterDecks` and `constructedStarterDecks` from Old Border difficulties (replaced by the new Precon starter mode)

On Hard+ difficulty, genetic AI and LDA deck generation would give enemies Modern/Legacy/Standard competitive decks with 2020+ cards, completely breaking the old-border-only experience. Arena battles were also hardcoded to always use genetic AI decks regardless of difficulty. This adds a per-world config option so realm modders can opt out.