### PR TITLE
Allow to specify a custom basic land set for default art per world

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/data/ConfigData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/ConfigData.java
@@ -29,5 +29,6 @@ public class ConfigData {
     public String[] restrictedEvents;
     public String[] allowedEvents;
     public String[] allowedJumpstart;
+    public String defaultBasicLandSet = "JMP";
     public boolean enableGeneticAI = true;
 }

--- a/forge-gui-mobile/src/forge/adventure/scene/AdventureDeckEditor.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/AdventureDeckEditor.java
@@ -96,7 +96,6 @@ public class AdventureDeckEditor extends FDeckEditor {
         @Override
         public List<CardEdition> getBasicLandSets(Deck currentDeck) {
             List<CardEdition> unlockedEditions = new ArrayList<>();
-            unlockedEditions.add(FModel.getMagicDb().getEditions().get("JMP"));
 
             // Loop through Landscapes and add them to unlockedEditions
             Map<String, CardEdition> editionsByName = new HashMap<>();
@@ -124,6 +123,13 @@ public class AdventureDeckEditor extends FDeckEditor {
                     unlockedEditions.add(edition);
                 }
             }
+
+            // Add the default edition unless it's already unlocked above
+            String defaultArtSetCode = Config.instance().getConfigData().defaultBasicLandSet;
+            if (!unlockedEditions.contains(FModel.getMagicDb().getEditions().get(defaultArtSetCode))) {
+                unlockedEditions.add(FModel.getMagicDb().getEditions().get(defaultArtSetCode));
+            }
+
             return unlockedEditions;
         }
     }

--- a/forge-gui/res/adventure/Shandalar Old Border/config.json
+++ b/forge-gui/res/adventure/Shandalar Old Border/config.json
@@ -124,6 +124,7 @@
   ],
   "allowedJumpstart": [],
   "enableGeneticAI": false,
+  "defaultBasicLandSet": "7ED",
   "difficulties": [
     {
       "name": "Easy",


### PR DESCRIPTION
Still defaults to JMP unless specified.
Defaults to 7ED for Old Border (may be changed in config.json as needed).