### PR TITLE
Old Border Shandalar: Rebalance boss rewards

### DIFF
--- a/forge-gui/res/adventure/Shandalar Old Border/world/enemies.json
+++ b/forge-gui/res/adventure/Shandalar Old Border/world/enemies.json
@@ -11538,18 +11538,6 @@
         ]
       },
       {
-        "type": "gold",
-        "probability": 0.6,
-        "count": 50,
-        "addMaxCount": 100
-      },
-      {
-        "type": "shards",
-        "probability": 0.35,
-        "count": 2,
-        "addMaxCount": 3
-      },
-      {
         "type": "card",
         "probability": 1,
         "count": 1,
@@ -11566,6 +11554,18 @@
         "probability": 1,
         "count": 1,
         "cardName": "Forest|UGL"
+      },
+      {
+        "type": "gold",
+        "probability": 0.6,
+        "count": 50,
+        "addMaxCount": 100
+      },
+      {
+        "type": "shards",
+        "probability": 0.35,
+        "count": 2,
+        "addMaxCount": 3
       },
       {
         "type": "card",
@@ -12304,14 +12304,14 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
+        "probability": 0.75,
+        "count": 10,
         "addMaxCount": 10
       },
       {
@@ -12322,9 +12322,9 @@
           "Blue",
           "Red"
         ],
-        "probability": 0.3,
+        "probability": 0.15,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -12334,9 +12334,9 @@
           "Blue",
           "Red"
         ],
-        "probability": 0.56,
+        "probability": 0.35,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -12348,7 +12348,7 @@
         ],
         "probability": 0.6,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -12358,9 +12358,9 @@
           "Blue",
           "Red"
         ],
-        "probability": 0.34,
+        "probability": 0.52,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -12370,9 +12370,9 @@
           "Blue",
           "Red"
         ],
-        "probability": 0.16,
+        "probability": 0.27,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -12382,9 +12382,9 @@
           "Blue",
           "Red"
         ],
-        "probability": 0.04,
+        "probability": 0.11,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -12399,8 +12399,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "UB",
@@ -12520,15 +12519,15 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.75,
+        "count": 150,
+        "addMaxCount": 150
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
+        "probability": 0.5,
+        "count": 5,
+        "addMaxCount": 5
       },
       {
         "type": "card",
@@ -12537,9 +12536,9 @@
           "Black",
           "Green"
         ],
-        "probability": 0.175,
+        "probability": 0.0583,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -12548,9 +12547,9 @@
           "Black",
           "Green"
         ],
-        "probability": 0.3267,
+        "probability": 0.14,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -12561,7 +12560,7 @@
         ],
         "probability": 0.35,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -12570,9 +12569,9 @@
           "Black",
           "Green"
         ],
-        "probability": 0.1983,
+        "probability": 0.35,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -12581,9 +12580,9 @@
           "Black",
           "Green"
         ],
-        "probability": 0.0933,
+        "probability": 0.1867,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -12592,27 +12591,27 @@
           "Black",
           "Green"
         ],
-        "probability": 0.0233,
+        "probability": 0.0817,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0417,
+        "probability": 0.0139,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0778,
+        "probability": 0.0333,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -12621,50 +12620,50 @@
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\EG\\Q}\\E",
         "probability": 0.0833,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0472,
+        "probability": 0.0833,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0222,
+        "probability": 0.0444,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0028,
+        "probability": 0.0097,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.0833,
+        "probability": 0.0278,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.1556,
+        "probability": 0.0667,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -12672,31 +12671,31 @@
         "colorType": "Colorless",
         "probability": 0.1667,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0944,
+        "probability": 0.1667,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0444,
+        "probability": 0.0889,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0111,
+        "probability": 0.0389,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -12711,8 +12710,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "GB",
@@ -16026,18 +16024,6 @@
         "itemName": "Eye of Horror"
       },
       {
-        "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
-      },
-      {
-        "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
-      },
-      {
         "type": "card",
         "probability": 1,
         "count": 1,
@@ -16050,14 +16036,26 @@
         "cardName": "Devouring Strossus|INV"
       },
       {
+        "type": "gold",
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
+      },
+      {
+        "type": "shards",
+        "probability": 0.75,
+        "count": 10,
+        "addMaxCount": 10
+      },
+      {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colors": [
           "Black"
         ],
-        "probability": 0.3,
+        "probability": 0.15,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -16065,9 +16063,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.56,
+        "probability": 0.35,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -16077,7 +16075,7 @@
         ],
         "probability": 0.6,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -16085,9 +16083,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.34,
+        "probability": 0.52,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -16095,9 +16093,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.16,
+        "probability": 0.27,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -16105,9 +16103,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.04,
+        "probability": 0.11,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -16122,8 +16120,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "B",
@@ -17535,14 +17532,14 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
+        "probability": 0.75,
+        "count": 10,
         "addMaxCount": 10
       },
       {
@@ -17552,9 +17549,9 @@
           "Blue",
           "Black"
         ],
-        "probability": 0.2286,
+        "probability": 0.1143,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -17563,9 +17560,9 @@
           "Blue",
           "Black"
         ],
-        "probability": 0.4267,
+        "probability": 0.2667,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -17576,7 +17573,7 @@
         ],
         "probability": 0.4571,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -17585,9 +17582,9 @@
           "Blue",
           "Black"
         ],
-        "probability": 0.259,
+        "probability": 0.3962,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -17596,9 +17593,9 @@
           "Blue",
           "Black"
         ],
-        "probability": 0.1219,
+        "probability": 0.2057,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -17607,27 +17604,27 @@
           "Blue",
           "Black"
         ],
-        "probability": 0.0305,
+        "probability": 0.0838,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.0238,
+        "probability": 0.0119,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.0444,
+        "probability": 0.0278,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -17636,50 +17633,50 @@
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
         "probability": 0.0476,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.027,
+        "probability": 0.0413,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.0127,
+        "probability": 0.0214,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.0012,
+        "probability": 0.0033,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.0476,
+        "probability": 0.0238,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.0889,
+        "probability": 0.0556,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -17687,31 +17684,31 @@
         "colorType": "Colorless",
         "probability": 0.0952,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.054,
+        "probability": 0.0825,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0254,
+        "probability": 0.0429,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0063,
+        "probability": 0.0175,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -17726,8 +17723,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "UB",
@@ -18918,15 +18914,15 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.75,
+        "count": 150,
+        "addMaxCount": 150
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
+        "probability": 0.5,
+        "count": 5,
+        "addMaxCount": 5
       },
       {
         "type": "card",
@@ -18934,9 +18930,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.2714,
+        "probability": 0.0905,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -18944,9 +18940,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.5067,
+        "probability": 0.2171,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -18956,7 +18952,7 @@
         ],
         "probability": 0.5429,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -18964,9 +18960,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.3076,
+        "probability": 0.5429,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -18974,9 +18970,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.1448,
+        "probability": 0.2895,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -18984,79 +18980,79 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.0362,
+        "probability": 0.1267,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E",
-        "probability": 0.0048,
+        "probability": 0.0016,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E",
-        "probability": 0.0197,
+        "probability": 0.0081,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E",
-        "probability": 0.0219,
+        "probability": 0.0202,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E",
-        "probability": 0.0108,
+        "probability": 0.019,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E",
-        "probability": 0.0051,
+        "probability": 0.0102,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E",
-        "probability": 0.0003,
+        "probability": 0.0011,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.019,
+        "probability": 0.0063,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.0356,
+        "probability": 0.0152,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -19064,31 +19060,31 @@
         "colorType": "Colorless",
         "probability": 0.0381,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0216,
+        "probability": 0.0381,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0102,
+        "probability": 0.0203,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0025,
+        "probability": 0.0089,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -19103,8 +19099,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "BU",
@@ -25936,14 +25931,14 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
+        "probability": 0.75,
+        "count": 10,
         "addMaxCount": 10
       },
       {
@@ -25953,9 +25948,9 @@
           "Black",
           "Red"
         ],
-        "probability": 0.2182,
+        "probability": 0.1091,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -25964,9 +25959,9 @@
           "Black",
           "Red"
         ],
-        "probability": 0.4073,
+        "probability": 0.2545,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -25977,7 +25972,7 @@
         ],
         "probability": 0.4364,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -25986,9 +25981,9 @@
           "Black",
           "Red"
         ],
-        "probability": 0.2473,
+        "probability": 0.3782,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -25997,9 +25992,9 @@
           "Black",
           "Red"
         ],
-        "probability": 0.1164,
+        "probability": 0.1964,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -26008,27 +26003,27 @@
           "Black",
           "Red"
         ],
-        "probability": 0.0291,
+        "probability": 0.08,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0273,
+        "probability": 0.0136,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0509,
+        "probability": 0.0318,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -26037,50 +26032,50 @@
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
         "probability": 0.0545,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0309,
+        "probability": 0.0473,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0145,
+        "probability": 0.0245,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0014,
+        "probability": 0.0037,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.0545,
+        "probability": 0.0273,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.1018,
+        "probability": 0.0636,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -26088,31 +26083,31 @@
         "colorType": "Colorless",
         "probability": 0.1091,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0618,
+        "probability": 0.0945,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0291,
+        "probability": 0.0491,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0073,
+        "probability": 0.02,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -26127,8 +26122,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "RG",
@@ -27191,18 +27185,6 @@
         "itemName": "Baron Sengir's Trophy"
       },
       {
-        "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
-      },
-      {
-        "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
-      },
-      {
         "type": "card",
         "probability": 0.5,
         "count": 1,
@@ -27219,6 +27201,18 @@
         "probability": 1,
         "count": 1,
         "cardName": "Swamp|PELP"
+      },
+      {
+        "type": "gold",
+        "probability": 1.0,
+        "count": 800,
+        "addMaxCount": 400
+      },
+      {
+        "type": "shards",
+        "probability": 1.0,
+        "count": 20,
+        "addMaxCount": 10
       },
       {
         "type": "card",
@@ -28545,14 +28539,14 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
+        "probability": 0.75,
+        "count": 10,
         "addMaxCount": 10
       },
       {
@@ -28562,9 +28556,9 @@
           "Blue",
           "Black"
         ],
-        "probability": 0.25,
+        "probability": 0.125,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -28573,9 +28567,9 @@
           "Blue",
           "Black"
         ],
-        "probability": 0.4667,
+        "probability": 0.2917,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -28586,7 +28580,7 @@
         ],
         "probability": 0.5,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -28595,9 +28589,9 @@
           "Blue",
           "Black"
         ],
-        "probability": 0.2833,
+        "probability": 0.4333,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -28606,9 +28600,9 @@
           "Blue",
           "Black"
         ],
-        "probability": 0.1333,
+        "probability": 0.225,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -28617,27 +28611,27 @@
           "Blue",
           "Black"
         ],
-        "probability": 0.0333,
+        "probability": 0.0917,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.0167,
+        "probability": 0.0083,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.0311,
+        "probability": 0.0194,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -28646,50 +28640,50 @@
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
         "probability": 0.0333,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.0189,
+        "probability": 0.0289,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.0089,
+        "probability": 0.015,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.0008,
+        "probability": 0.0023,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.0333,
+        "probability": 0.0167,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.0622,
+        "probability": 0.0389,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -28697,31 +28691,31 @@
         "colorType": "Colorless",
         "probability": 0.0667,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0378,
+        "probability": 0.0578,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0178,
+        "probability": 0.03,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0044,
+        "probability": 0.0122,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -28736,8 +28730,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "UG",
@@ -29722,18 +29715,6 @@
         "itemName": "Belt of Worry Beads"
       },
       {
-        "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
-      },
-      {
-        "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
-      },
-      {
         "type": "card",
         "probability": 1,
         "count": 1,
@@ -29756,6 +29737,18 @@
         "probability": 1,
         "count": 1,
         "cardName": "Swamp|PELP|2"
+      },
+      {
+        "type": "gold",
+        "probability": 1.0,
+        "count": 800,
+        "addMaxCount": 400
+      },
+      {
+        "type": "shards",
+        "probability": 1.0,
+        "count": 20,
+        "addMaxCount": 10
       },
       {
         "type": "card",
@@ -37522,18 +37515,6 @@
         "itemName": "Hydra's Trophy"
       },
       {
-        "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
-      },
-      {
-        "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
-      },
-      {
         "type": "card",
         "probability": 1,
         "count": 1,
@@ -37552,15 +37533,27 @@
         "cardName": "Mana Flare|LEA"
       },
       {
+        "type": "gold",
+        "probability": 0.75,
+        "count": 150,
+        "addMaxCount": 150
+      },
+      {
+        "type": "shards",
+        "probability": 0.5,
+        "count": 5,
+        "addMaxCount": 5
+      },
+      {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colors": [
           "Red",
           "Green"
         ],
-        "probability": 0.1364,
+        "probability": 0.0455,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -37569,9 +37562,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.6455,
+        "probability": 0.2636,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -37582,7 +37575,7 @@
         ],
         "probability": 0.5455,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -37591,9 +37584,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.3091,
+        "probability": 0.5455,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -37602,9 +37595,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.1455,
+        "probability": 0.2909,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -37613,79 +37606,79 @@
           "Red",
           "Green"
         ],
-        "probability": 0.0364,
+        "probability": 0.1273,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0091,
+        "probability": 0.003,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0127,
+        "probability": 0.0055,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0224,
+        "probability": 0.02,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0103,
-        "count": 3,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-D.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0048,
-        "count": 3,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-E.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0005,
-        "count": 3,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-S.dck",
-        "colorType": "Colorless",
         "probability": 0.0182,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-D.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
+        "probability": 0.0097,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-E.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
+        "probability": 0.0016,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-S.dck",
+        "colorType": "Colorless",
+        "probability": 0.0061,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.0339,
+        "probability": 0.0145,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -37693,31 +37686,31 @@
         "colorType": "Colorless",
         "probability": 0.0364,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0206,
+        "probability": 0.0364,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0097,
+        "probability": 0.0194,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0024,
+        "probability": 0.0085,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -37732,8 +37725,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "G",
@@ -38615,18 +38607,6 @@
         "itemName": "Arcanis's Trophy"
       },
       {
-        "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
-      },
-      {
-        "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
-      },
-      {
         "type": "card",
         "probability": 0.5,
         "count": 1,
@@ -38643,6 +38623,18 @@
         "probability": 1,
         "count": 1,
         "cardName": "Island|PGRU"
+      },
+      {
+        "type": "gold",
+        "probability": 1.0,
+        "count": 800,
+        "addMaxCount": 400
+      },
+      {
+        "type": "shards",
+        "probability": 1.0,
+        "count": 20,
+        "addMaxCount": 10
       },
       {
         "type": "card",
@@ -39393,18 +39385,6 @@
         "itemName": "Empress Galina's Trophy"
       },
       {
-        "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
-      },
-      {
-        "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
-      },
-      {
         "type": "card",
         "probability": 1,
         "count": 1,
@@ -39429,15 +39409,27 @@
         "cardName": "Island|PALP"
       },
       {
+        "type": "gold",
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
+      },
+      {
+        "type": "shards",
+        "probability": 0.75,
+        "count": 10,
+        "addMaxCount": 10
+      },
+      {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colors": [
           "Blue",
           "Green"
         ],
-        "probability": 0.2368,
+        "probability": 0.1184,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -39446,9 +39438,9 @@
           "Blue",
           "Green"
         ],
-        "probability": 0.4421,
+        "probability": 0.2763,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -39459,7 +39451,7 @@
         ],
         "probability": 0.4737,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -39468,9 +39460,9 @@
           "Blue",
           "Green"
         ],
-        "probability": 0.2684,
+        "probability": 0.4105,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -39479,9 +39471,9 @@
           "Blue",
           "Green"
         ],
-        "probability": 0.1263,
+        "probability": 0.2132,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -39490,79 +39482,79 @@
           "Blue",
           "Green"
         ],
-        "probability": 0.0316,
+        "probability": 0.0868,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0211,
+        "probability": 0.0105,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0246,
+        "probability": 0.0154,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0568,
+        "probability": 0.0513,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0239,
+        "probability": 0.0365,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0112,
+        "probability": 0.0189,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0011,
+        "probability": 0.0029,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.0421,
+        "probability": 0.0211,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.0786,
+        "probability": 0.0491,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -39570,31 +39562,31 @@
         "colorType": "Colorless",
         "probability": 0.0842,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0477,
+        "probability": 0.073,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0225,
+        "probability": 0.0379,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0056,
+        "probability": 0.0154,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -39609,8 +39601,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "UG",
@@ -40742,15 +40733,15 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.75,
+        "count": 150,
+        "addMaxCount": 150
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
+        "probability": 0.5,
+        "count": 5,
+        "addMaxCount": 5
       },
       {
         "type": "card",
@@ -40759,9 +40750,9 @@
           "Black",
           "Red"
         ],
-        "probability": 0.2182,
+        "probability": 0.0727,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -40770,9 +40761,9 @@
           "Black",
           "Red"
         ],
-        "probability": 0.4073,
+        "probability": 0.1745,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -40783,7 +40774,7 @@
         ],
         "probability": 0.4364,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -40792,9 +40783,9 @@
           "Black",
           "Red"
         ],
-        "probability": 0.2473,
+        "probability": 0.4364,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -40803,9 +40794,9 @@
           "Black",
           "Red"
         ],
-        "probability": 0.1164,
+        "probability": 0.2327,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -40814,27 +40805,27 @@
           "Black",
           "Red"
         ],
-        "probability": 0.0291,
+        "probability": 0.1018,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0273,
+        "probability": 0.0091,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0509,
+        "probability": 0.0218,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -40843,50 +40834,50 @@
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
         "probability": 0.0545,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0309,
+        "probability": 0.0545,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0145,
+        "probability": 0.0291,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0014,
+        "probability": 0.0048,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.0545,
+        "probability": 0.0182,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.1018,
+        "probability": 0.0436,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -40894,31 +40885,31 @@
         "colorType": "Colorless",
         "probability": 0.1091,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0618,
+        "probability": 0.1091,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0291,
+        "probability": 0.0582,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0073,
+        "probability": 0.0255,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -40933,8 +40924,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "RB",
@@ -45863,18 +45853,6 @@
     "life": 25,
     "rewards": [
       {
-        "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
-      },
-      {
-        "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
-      },
-      {
         "type": "card",
         "probability": 1,
         "count": 1,
@@ -45893,15 +45871,27 @@
         "cardName": "Synapse Sliver|LGN"
       },
       {
+        "type": "gold",
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
+      },
+      {
+        "type": "shards",
+        "probability": 0.75,
+        "count": 10,
+        "addMaxCount": 10
+      },
+      {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colors": [
           "White",
           "Blue"
         ],
-        "probability": 0.175,
+        "probability": 0.0875,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -45910,9 +45900,9 @@
           "White",
           "Blue"
         ],
-        "probability": 0.3983,
+        "probability": 0.2458,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -45923,7 +45913,7 @@
         ],
         "probability": 0.4,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -45932,9 +45922,9 @@
           "White",
           "Blue"
         ],
-        "probability": 0.2267,
+        "probability": 0.3467,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -45943,9 +45933,9 @@
           "White",
           "Blue"
         ],
-        "probability": 0.1067,
+        "probability": 0.18,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -45954,79 +45944,79 @@
           "White",
           "Blue"
         ],
-        "probability": 0.0267,
+        "probability": 0.0733,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E",
-        "probability": 0.0333,
+        "probability": 0.0167,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E",
-        "probability": 0.0467,
+        "probability": 0.0292,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E",
-        "probability": 0.0822,
+        "probability": 0.0764,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E",
-        "probability": 0.0378,
+        "probability": 0.0578,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E",
-        "probability": 0.0178,
+        "probability": 0.03,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E",
-        "probability": 0.0011,
+        "probability": 0.0031,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.0667,
+        "probability": 0.0333,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.1244,
+        "probability": 0.0778,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -46034,31 +46024,31 @@
         "colorType": "Colorless",
         "probability": 0.1333,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0756,
+        "probability": 0.1156,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0356,
+        "probability": 0.06,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0089,
+        "probability": 0.0244,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -46073,8 +46063,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "BUR",
@@ -47771,61 +47760,61 @@
       {
         "type": "gold",
         "probability": 1.0,
-        "count": 3000,
-        "addMaxCount": 2000
+        "count": 800,
+        "addMaxCount": 400
       },
       {
         "type": "shards",
         "probability": 1.0,
-        "count": 80,
-        "addMaxCount": 40
+        "count": 20,
+        "addMaxCount": 10
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.7,
-        "count": 4,
+        "probability": 0.3,
+        "count": 3,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.6,
-        "count": 4,
+        "probability": 0.56,
+        "count": 3,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
-        "probability": 0.4,
-        "count": 4,
+        "probability": 0.6,
+        "count": 3,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.2,
-        "count": 4,
+        "probability": 0.34,
+        "count": 3,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.08,
-        "count": 4,
+        "probability": 0.16,
+        "count": 3,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.02,
-        "count": 4,
+        "probability": 0.04,
+        "count": 3,
         "addMaxCount": 3
       },
       {
@@ -47841,7 +47830,8 @@
         "rarity": [
           "Rare"
         ],
-        "count": 2
+        "count": 1,
+        "addMaxCount": 1
       }
     ],
     "colors": "C",
@@ -50053,14 +50043,14 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
+        "probability": 0.75,
+        "count": 10,
         "addMaxCount": 10
       },
       {
@@ -50071,9 +50061,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.25,
+        "probability": 0.125,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -50083,9 +50073,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.4667,
+        "probability": 0.2917,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -50097,7 +50087,7 @@
         ],
         "probability": 0.5,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -50107,9 +50097,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.2833,
+        "probability": 0.4333,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -50119,9 +50109,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.1333,
+        "probability": 0.225,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -50131,27 +50121,27 @@
           "Red",
           "Green"
         ],
-        "probability": 0.0333,
+        "probability": 0.0917,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0167,
+        "probability": 0.0083,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0311,
+        "probability": 0.0194,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -50160,50 +50150,50 @@
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
         "probability": 0.0333,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0189,
+        "probability": 0.0289,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0089,
+        "probability": 0.015,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0011,
+        "probability": 0.0031,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.0333,
+        "probability": 0.0167,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.0622,
+        "probability": 0.0389,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -50211,31 +50201,31 @@
         "colorType": "Colorless",
         "probability": 0.0667,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0378,
+        "probability": 0.0578,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0178,
+        "probability": 0.03,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0044,
+        "probability": 0.0122,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -50250,8 +50240,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "GB",
@@ -51892,18 +51881,6 @@
         "itemName": "Djinn's Silks"
       },
       {
-        "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
-      },
-      {
-        "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
-      },
-      {
         "type": "card",
         "probability": 1,
         "count": 1,
@@ -51922,14 +51899,26 @@
         "cardName": "Ali from Cairo|ARN"
       },
       {
+        "type": "gold",
+        "probability": 0.75,
+        "count": 150,
+        "addMaxCount": 150
+      },
+      {
+        "type": "shards",
+        "probability": 0.5,
+        "count": 5,
+        "addMaxCount": 5
+      },
+      {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colors": [
           "Red"
         ],
-        "probability": 0.018,
+        "probability": 0.006,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -51937,9 +51926,9 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.3948,
+        "probability": 0.1572,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -51949,7 +51938,7 @@
         ],
         "probability": 0.288,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -51957,9 +51946,9 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.1632,
+        "probability": 0.288,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -51967,9 +51956,9 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.0768,
+        "probability": 0.1536,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -51977,79 +51966,79 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.0192,
+        "probability": 0.0672,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E",
-        "probability": 0.0325,
+        "probability": 0.0108,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E",
-        "probability": 0.0437,
+        "probability": 0.018,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E",
-        "probability": 0.1769,
+        "probability": 0.1341,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E",
-        "probability": 0.0589,
+        "probability": 0.104,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E",
-        "probability": 0.0277,
+        "probability": 0.0555,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E",
-        "probability": 0.0017,
+        "probability": 0.0061,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.104,
+        "probability": 0.0347,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.1941,
+        "probability": 0.0832,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -52057,31 +52046,31 @@
         "colorType": "Colorless",
         "probability": 0.208,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.1179,
+        "probability": 0.208,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0555,
+        "probability": 0.1109,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0139,
+        "probability": 0.0485,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -52096,8 +52085,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "questTags": [
@@ -55653,22 +55641,22 @@
     "life": 25,
     "rewards": [
       {
-        "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
-      },
-      {
-        "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
-      },
-      {
         "type": "card",
         "probability": 1,
         "count": 1,
         "cardName": "Toxin Sliver|LGN"
+      },
+      {
+        "type": "gold",
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
+      },
+      {
+        "type": "shards",
+        "probability": 0.75,
+        "count": 10,
+        "addMaxCount": 10
       },
       {
         "type": "card",
@@ -55677,9 +55665,9 @@
           "Blue",
           "Black"
         ],
-        "probability": 0.225,
+        "probability": 0.1125,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -55688,9 +55676,9 @@
           "Blue",
           "Black"
         ],
-        "probability": 0.42,
+        "probability": 0.2625,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -55701,7 +55689,7 @@
         ],
         "probability": 0.45,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -55710,9 +55698,9 @@
           "Blue",
           "Black"
         ],
-        "probability": 0.255,
+        "probability": 0.39,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -55721,9 +55709,9 @@
           "Blue",
           "Black"
         ],
-        "probability": 0.12,
+        "probability": 0.2025,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -55732,27 +55720,27 @@
           "Blue",
           "Black"
         ],
-        "probability": 0.03,
+        "probability": 0.0825,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.025,
+        "probability": 0.0125,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.0467,
+        "probability": 0.0292,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -55761,50 +55749,50 @@
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
         "probability": 0.05,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.0283,
+        "probability": 0.0433,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.0133,
+        "probability": 0.0225,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.0012,
+        "probability": 0.0034,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.05,
+        "probability": 0.025,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.0933,
+        "probability": 0.0583,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -55812,31 +55800,31 @@
         "colorType": "Colorless",
         "probability": 0.1,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0567,
+        "probability": 0.0867,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0267,
+        "probability": 0.045,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0067,
+        "probability": 0.0183,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -55851,8 +55839,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "BUR",
@@ -57904,18 +57891,6 @@
         "count": 1
       },
       {
-        "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
-      },
-      {
-        "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
-      },
-      {
         "type": "card",
         "probability": 0.5,
         "count": 1,
@@ -57932,6 +57907,18 @@
         "probability": 0.5,
         "count": 1,
         "cardName": "Sterling Grove|INV"
+      },
+      {
+        "type": "gold",
+        "probability": 1.0,
+        "count": 800,
+        "addMaxCount": 400
+      },
+      {
+        "type": "shards",
+        "probability": 1.0,
+        "count": 20,
+        "addMaxCount": 10
       },
       {
         "type": "card",
@@ -59350,14 +59337,14 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
+        "probability": 0.75,
+        "count": 10,
         "addMaxCount": 10
       },
       {
@@ -59366,9 +59353,9 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.1125,
+        "probability": 0.0562,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -59376,9 +59363,9 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.7475,
+        "probability": 0.4437,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -59388,7 +59375,7 @@
         ],
         "probability": 0.6,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -59396,9 +59383,9 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.34,
+        "probability": 0.52,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -59406,9 +59393,9 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.16,
+        "probability": 0.27,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -59416,9 +59403,9 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.04,
+        "probability": 0.11,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -59433,8 +59420,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "BG",
@@ -59462,6 +59448,12 @@
     "life": 30,
     "rewards": [
       {
+        "type": "card",
+        "probability": 1,
+        "count": 1,
+        "cardName": "Brood Sliver|LGN"
+      },
+      {
         "type": "gold",
         "probability": 0.75,
         "count": 150,
@@ -59472,12 +59464,6 @@
         "probability": 0.5,
         "count": 5,
         "addMaxCount": 5
-      },
-      {
-        "type": "card",
-        "probability": 1,
-        "count": 1,
-        "cardName": "Brood Sliver|LGN"
       },
       {
         "type": "card",
@@ -61158,14 +61144,14 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
+        "probability": 0.75,
+        "count": 10,
         "addMaxCount": 10
       },
       {
@@ -61174,9 +61160,9 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.0341,
+        "probability": 0.017,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -61184,9 +61170,9 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.7477,
+        "probability": 0.4375,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -61196,7 +61182,7 @@
         ],
         "probability": 0.5455,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -61204,9 +61190,9 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.3091,
+        "probability": 0.4727,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -61214,9 +61200,9 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.1455,
+        "probability": 0.2455,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -61224,79 +61210,79 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.0364,
+        "probability": 0.1,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E",
-        "probability": 0.0057,
+        "probability": 0.0028,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E",
-        "probability": 0.0076,
+        "probability": 0.0046,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E",
-        "probability": 0.0309,
+        "probability": 0.0259,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E",
-        "probability": 0.0103,
+        "probability": 0.0158,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E",
-        "probability": 0.0048,
+        "probability": 0.0082,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E",
-        "probability": 0.0003,
+        "probability": 0.0008,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.0182,
+        "probability": 0.0091,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.0339,
+        "probability": 0.0212,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -61304,31 +61290,31 @@
         "colorType": "Colorless",
         "probability": 0.0364,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0206,
+        "probability": 0.0315,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0097,
+        "probability": 0.0164,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0024,
+        "probability": 0.0067,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -61343,8 +61329,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "R",
@@ -61382,18 +61367,6 @@
         "count": 1
       },
       {
-        "type": "gold",
-        "probability": 1.0,
-        "count": 3000,
-        "addMaxCount": 2000
-      },
-      {
-        "type": "shards",
-        "probability": 1.0,
-        "count": 80,
-        "addMaxCount": 40
-      },
-      {
         "type": "card",
         "probability": 1,
         "count": 1,
@@ -61424,6 +61397,18 @@
         "cardName": "Toxin Sliver|LGN"
       },
       {
+        "type": "gold",
+        "probability": 1.0,
+        "count": 800,
+        "addMaxCount": 400
+      },
+      {
+        "type": "shards",
+        "probability": 1.0,
+        "count": 20,
+        "addMaxCount": 10
+      },
+      {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colors": [
@@ -61433,13 +61418,27 @@
           "Red",
           "Green"
         ],
-        "probability": 0.5289,
-        "count": 4,
+        "probability": 0.2267,
+        "count": 3,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
+        "colors": [
+          "White",
+          "Blue",
+          "Black",
+          "Red",
+          "Green"
+        ],
+        "probability": 0.4231,
+        "count": 3,
+        "addMaxCount": 3
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-B.dck",
         "colors": [
           "White",
           "Blue",
@@ -61448,21 +61447,7 @@
           "Green"
         ],
         "probability": 0.4533,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-B.dck",
-        "colors": [
-          "White",
-          "Blue",
-          "Black",
-          "Red",
-          "Green"
-        ],
-        "probability": 0.3022,
-        "count": 4,
+        "count": 3,
         "addMaxCount": 3
       },
       {
@@ -61475,8 +61460,8 @@
           "Red",
           "Green"
         ],
-        "probability": 0.1511,
-        "count": 4,
+        "probability": 0.2569,
+        "count": 3,
         "addMaxCount": 3
       },
       {
@@ -61489,8 +61474,8 @@
           "Red",
           "Green"
         ],
-        "probability": 0.0604,
-        "count": 4,
+        "probability": 0.1209,
+        "count": 3,
         "addMaxCount": 3
       },
       {
@@ -61503,8 +61488,8 @@
           "Red",
           "Green"
         ],
-        "probability": 0.0151,
-        "count": 4,
+        "probability": 0.0302,
+        "count": 3,
         "addMaxCount": 3
       },
       {
@@ -61512,26 +61497,26 @@
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.057,
-        "count": 4,
+        "probability": 0.0244,
+        "count": 3,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
+        "probability": 0.0456,
+        "count": 3,
+        "addMaxCount": 3
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
         "probability": 0.0489,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-B.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0326,
-        "count": 4,
+        "count": 3,
         "addMaxCount": 3
       },
       {
@@ -61539,8 +61524,8 @@
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0163,
-        "count": 4,
+        "probability": 0.0277,
+        "count": 3,
         "addMaxCount": 3
       },
       {
@@ -61548,8 +61533,8 @@
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0065,
-        "count": 4,
+        "probability": 0.013,
+        "count": 3,
         "addMaxCount": 3
       },
       {
@@ -61557,56 +61542,56 @@
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0008,
-        "count": 4,
+        "probability": 0.0016,
+        "count": 3,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.1141,
-        "count": 4,
+        "probability": 0.0489,
+        "count": 3,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.0978,
-        "count": 4,
+        "probability": 0.0913,
+        "count": 3,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
-        "probability": 0.0652,
-        "count": 4,
+        "probability": 0.0978,
+        "count": 3,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0326,
-        "count": 4,
+        "probability": 0.0554,
+        "count": 3,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.013,
-        "count": 4,
+        "probability": 0.0261,
+        "count": 3,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0033,
-        "count": 4,
+        "probability": 0.0065,
+        "count": 3,
         "addMaxCount": 3
       },
       {
@@ -61622,7 +61607,8 @@
         "rarity": [
           "Rare"
         ],
-        "count": 2
+        "count": 1,
+        "addMaxCount": 1
       }
     ],
     "colors": "BGRUW",
@@ -61835,14 +61821,14 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
+        "probability": 0.75,
+        "count": 10,
         "addMaxCount": 10
       },
       {
@@ -61853,9 +61839,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.15,
+        "probability": 0.075,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -61865,9 +61851,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.4233,
+        "probability": 0.2583,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -61879,7 +61865,7 @@
         ],
         "probability": 0.4,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -61889,9 +61875,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.2267,
+        "probability": 0.3467,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -61901,9 +61887,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.1067,
+        "probability": 0.18,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -61913,27 +61899,27 @@
           "Red",
           "Green"
         ],
-        "probability": 0.0267,
+        "probability": 0.0733,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0333,
+        "probability": 0.0167,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0622,
+        "probability": 0.0389,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -61942,50 +61928,50 @@
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
         "probability": 0.0667,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0378,
+        "probability": 0.0578,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0178,
+        "probability": 0.03,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0017,
+        "probability": 0.0046,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.0667,
+        "probability": 0.0333,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.1244,
+        "probability": 0.0778,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -61993,31 +61979,31 @@
         "colorType": "Colorless",
         "probability": 0.1333,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0756,
+        "probability": 0.1156,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0356,
+        "probability": 0.06,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0089,
+        "probability": 0.0244,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -62032,8 +62018,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "UG",
@@ -63490,18 +63475,6 @@
         "itemName": "Crown of the Vale"
       },
       {
-        "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
-      },
-      {
-        "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
-      },
-      {
         "type": "card",
         "probability": 1,
         "count": 1,
@@ -63520,6 +63493,18 @@
         "cardName": "Swords to Plowshares|ICE"
       },
       {
+        "type": "gold",
+        "probability": 0.75,
+        "count": 150,
+        "addMaxCount": 150
+      },
+      {
+        "type": "shards",
+        "probability": 0.5,
+        "count": 5,
+        "addMaxCount": 5
+      },
+      {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colors": [
@@ -63527,9 +63512,9 @@
           "Blue",
           "Red"
         ],
-        "probability": 0.2605,
+        "probability": 0.0868,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -63539,9 +63524,9 @@
           "Blue",
           "Red"
         ],
-        "probability": 0.4863,
+        "probability": 0.2084,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -63553,7 +63538,7 @@
         ],
         "probability": 0.5211,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -63563,9 +63548,9 @@
           "Blue",
           "Red"
         ],
-        "probability": 0.2953,
+        "probability": 0.5211,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -63575,9 +63560,9 @@
           "Blue",
           "Red"
         ],
-        "probability": 0.1389,
+        "probability": 0.2779,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -63587,79 +63572,79 @@
           "Blue",
           "Red"
         ],
-        "probability": 0.0347,
+        "probability": 0.1216,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0132,
+        "probability": 0.0044,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0215,
+        "probability": 0.0092,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0294,
+        "probability": 0.0276,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0149,
+        "probability": 0.0263,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.007,
+        "probability": 0.014,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0007,
+        "probability": 0.0023,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.0263,
+        "probability": 0.0088,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.0491,
+        "probability": 0.0211,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -63667,31 +63652,31 @@
         "colorType": "Colorless",
         "probability": 0.0526,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0298,
+        "probability": 0.0526,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.014,
+        "probability": 0.0281,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0035,
+        "probability": 0.0123,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -63706,8 +63691,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "WUR"
@@ -63733,18 +63717,6 @@
         "itemName": "Tasty Tome"
       },
       {
-        "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
-      },
-      {
-        "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
-      },
-      {
         "type": "card",
         "probability": 1,
         "count": 1,
@@ -63757,6 +63729,18 @@
         "cardName": "Mirror Universe|LEG"
       },
       {
+        "type": "gold",
+        "probability": 0.75,
+        "count": 150,
+        "addMaxCount": 150
+      },
+      {
+        "type": "shards",
+        "probability": 0.5,
+        "count": 5,
+        "addMaxCount": 5
+      },
+      {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colors": [
@@ -63764,9 +63748,9 @@
           "Black",
           "Red"
         ],
-        "probability": 0.225,
+        "probability": 0.075,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -63776,9 +63760,9 @@
           "Black",
           "Red"
         ],
-        "probability": 0.42,
+        "probability": 0.18,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -63790,7 +63774,7 @@
         ],
         "probability": 0.45,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -63800,9 +63784,9 @@
           "Black",
           "Red"
         ],
-        "probability": 0.255,
+        "probability": 0.45,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -63812,9 +63796,9 @@
           "Black",
           "Red"
         ],
-        "probability": 0.12,
+        "probability": 0.24,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -63824,27 +63808,27 @@
           "Black",
           "Red"
         ],
-        "probability": 0.03,
+        "probability": 0.105,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.025,
+        "probability": 0.0083,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0467,
+        "probability": 0.02,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -63853,50 +63837,50 @@
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
         "probability": 0.05,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0283,
+        "probability": 0.05,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0133,
+        "probability": 0.0267,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0017,
+        "probability": 0.0058,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.05,
+        "probability": 0.0167,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.0933,
+        "probability": 0.04,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -63904,31 +63888,31 @@
         "colorType": "Colorless",
         "probability": 0.1,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0567,
+        "probability": 0.1,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0267,
+        "probability": 0.0533,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0067,
+        "probability": 0.0233,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -63943,8 +63927,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "UBR"
@@ -63970,18 +63953,6 @@
         "itemName": "Shield of Air"
       },
       {
-        "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
-      },
-      {
-        "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
-      },
-      {
         "type": "card",
         "probability": 1,
         "count": 1,
@@ -63994,6 +63965,18 @@
         "cardName": "Hymn of Rebirth|ICE"
       },
       {
+        "type": "gold",
+        "probability": 0.75,
+        "count": 150,
+        "addMaxCount": 150
+      },
+      {
+        "type": "shards",
+        "probability": 0.5,
+        "count": 5,
+        "addMaxCount": 5
+      },
+      {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colors": [
@@ -64003,9 +63986,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.2074,
+        "probability": 0.0691,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -64017,9 +64000,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.3872,
+        "probability": 0.1659,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -64033,7 +64016,7 @@
         ],
         "probability": 0.4148,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -64045,9 +64028,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.2351,
+        "probability": 0.4148,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -64059,9 +64042,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.1106,
+        "probability": 0.2212,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -64073,27 +64056,27 @@
           "Red",
           "Green"
         ],
-        "probability": 0.0277,
+        "probability": 0.0968,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0309,
+        "probability": 0.0103,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0576,
+        "probability": 0.0247,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -64102,50 +64085,50 @@
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
         "probability": 0.0617,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.035,
+        "probability": 0.0617,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0165,
+        "probability": 0.0329,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0021,
+        "probability": 0.0072,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.0617,
+        "probability": 0.0206,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.1152,
+        "probability": 0.0494,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -64153,31 +64136,31 @@
         "colorType": "Colorless",
         "probability": 0.1235,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.07,
+        "probability": 0.1235,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0329,
+        "probability": 0.0658,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0082,
+        "probability": 0.0288,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -64192,8 +64175,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "WUBRG"
@@ -64216,18 +64198,6 @@
         "type": "item",
         "itemName": "Attendant's Prayerbook",
         "count": 1
-      },
-      {
-        "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
-      },
-      {
-        "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
       },
       {
         "type": "card",
@@ -64254,6 +64224,18 @@
         "cardName": "Kaysa|ALL"
       },
       {
+        "type": "gold",
+        "probability": 0.75,
+        "count": 150,
+        "addMaxCount": 150
+      },
+      {
+        "type": "shards",
+        "probability": 0.5,
+        "count": 5,
+        "addMaxCount": 5
+      },
+      {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colors": [
@@ -64261,9 +64243,9 @@
           "Blue",
           "Green"
         ],
-        "probability": 0.3,
+        "probability": 0.1,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -64273,9 +64255,9 @@
           "Blue",
           "Green"
         ],
-        "probability": 0.56,
+        "probability": 0.24,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -64287,7 +64269,7 @@
         ],
         "probability": 0.6,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -64297,9 +64279,9 @@
           "Blue",
           "Green"
         ],
-        "probability": 0.34,
+        "probability": 0.6,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -64309,9 +64291,9 @@
           "Blue",
           "Green"
         ],
-        "probability": 0.16,
+        "probability": 0.32,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -64321,9 +64303,9 @@
           "Blue",
           "Green"
         ],
-        "probability": 0.04,
+        "probability": 0.14,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -64338,8 +64320,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "WUG"
@@ -65139,18 +65120,6 @@
         "itemName": "Teferi's Trophy"
       },
       {
-        "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
-      },
-      {
-        "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
-      },
-      {
         "type": "card",
         "probability": 0.5,
         "count": 1,
@@ -65179,6 +65148,18 @@
         "probability": 1,
         "count": 1,
         "cardName": "Island|PGRU"
+      },
+      {
+        "type": "gold",
+        "probability": 1.0,
+        "count": 800,
+        "addMaxCount": 400
+      },
+      {
+        "type": "shards",
+        "probability": 1.0,
+        "count": 20,
+        "addMaxCount": 10
       },
       {
         "type": "card",
@@ -65475,14 +65456,14 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
+        "probability": 0.75,
+        "count": 10,
         "addMaxCount": 10
       },
       {
@@ -65493,9 +65474,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.1125,
+        "probability": 0.0562,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -65505,9 +65486,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.3175,
+        "probability": 0.1937,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -65519,7 +65500,7 @@
         ],
         "probability": 0.3,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -65529,9 +65510,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.17,
+        "probability": 0.26,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -65541,9 +65522,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.08,
+        "probability": 0.135,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -65553,27 +65534,27 @@
           "Red",
           "Green"
         ],
-        "probability": 0.02,
+        "probability": 0.055,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.05,
+        "probability": 0.025,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0933,
+        "probability": 0.0583,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -65582,50 +65563,50 @@
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
         "probability": 0.1,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0567,
+        "probability": 0.0867,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0267,
+        "probability": 0.045,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0025,
+        "probability": 0.0069,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.1,
+        "probability": 0.05,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.1867,
+        "probability": 0.1167,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -65633,31 +65614,31 @@
         "colorType": "Colorless",
         "probability": 0.2,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.1133,
+        "probability": 0.1733,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0533,
+        "probability": 0.09,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0133,
+        "probability": 0.0367,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -65672,8 +65653,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "GBR",
@@ -65726,18 +65706,6 @@
         "itemName": "Specter King's Trophy"
       },
       {
-        "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
-      },
-      {
-        "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
-      },
-      {
         "type": "card",
         "probability": 1,
         "count": 1,
@@ -65754,6 +65722,18 @@
         "probability": 1,
         "count": 1,
         "cardName": "Swamp|PELP"
+      },
+      {
+        "type": "gold",
+        "probability": 1.0,
+        "count": 800,
+        "addMaxCount": 400
+      },
+      {
+        "type": "shards",
+        "probability": 1.0,
+        "count": 20,
+        "addMaxCount": 10
       },
       {
         "type": "card",
@@ -66161,14 +66141,14 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
+        "probability": 0.75,
+        "count": 10,
         "addMaxCount": 10
       },
       {
@@ -66178,9 +66158,9 @@
           "Black",
           "Red"
         ],
-        "probability": 0.2,
+        "probability": 0.1,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -66189,9 +66169,9 @@
           "Black",
           "Red"
         ],
-        "probability": 0.3733,
+        "probability": 0.2333,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -66202,7 +66182,7 @@
         ],
         "probability": 0.4,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -66211,9 +66191,9 @@
           "Black",
           "Red"
         ],
-        "probability": 0.2267,
+        "probability": 0.3467,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -66222,9 +66202,9 @@
           "Black",
           "Red"
         ],
-        "probability": 0.1067,
+        "probability": 0.18,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -66233,27 +66213,27 @@
           "Black",
           "Red"
         ],
-        "probability": 0.0267,
+        "probability": 0.0733,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0333,
+        "probability": 0.0167,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0622,
+        "probability": 0.0389,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -66262,50 +66242,50 @@
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
         "probability": 0.0667,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0378,
+        "probability": 0.0578,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0178,
+        "probability": 0.03,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0017,
+        "probability": 0.0046,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.0667,
+        "probability": 0.0333,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.1244,
+        "probability": 0.0778,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -66313,31 +66293,31 @@
         "colorType": "Colorless",
         "probability": 0.1333,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0756,
+        "probability": 0.1156,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0356,
+        "probability": 0.06,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0089,
+        "probability": 0.0244,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -66352,8 +66332,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "B",
@@ -67176,18 +67155,6 @@
         "count": 1
       },
       {
-        "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
-      },
-      {
-        "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
-      },
-      {
         "type": "card",
         "probability": 0.5,
         "count": 1,
@@ -67216,6 +67183,18 @@
         "probability": 1,
         "count": 1,
         "cardName": "Plains|UGL"
+      },
+      {
+        "type": "gold",
+        "probability": 1.0,
+        "count": 800,
+        "addMaxCount": 400
+      },
+      {
+        "type": "shards",
+        "probability": 1.0,
+        "count": 20,
+        "addMaxCount": 10
       },
       {
         "type": "card",
@@ -69085,15 +69064,15 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.75,
+        "count": 150,
+        "addMaxCount": 150
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
+        "probability": 0.5,
+        "count": 5,
+        "addMaxCount": 5
       },
       {
         "type": "card",
@@ -69101,9 +69080,9 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.1125,
+        "probability": 0.0375,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -69111,9 +69090,9 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.7475,
+        "probability": 0.3025,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -69123,7 +69102,7 @@
         ],
         "probability": 0.6,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -69131,9 +69110,9 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.34,
+        "probability": 0.6,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -69141,9 +69120,9 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.16,
+        "probability": 0.32,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -69151,9 +69130,9 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.04,
+        "probability": 0.14,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -69168,8 +69147,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "G",
@@ -70877,14 +70855,14 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
+        "probability": 0.75,
+        "count": 10,
         "addMaxCount": 10
       },
       {
@@ -70896,9 +70874,9 @@
           "Black",
           "Green"
         ],
-        "probability": 0.1909,
+        "probability": 0.0955,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -70909,9 +70887,9 @@
           "Black",
           "Green"
         ],
-        "probability": 0.3564,
+        "probability": 0.2227,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -70924,7 +70902,7 @@
         ],
         "probability": 0.3818,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -70935,9 +70913,9 @@
           "Black",
           "Green"
         ],
-        "probability": 0.2164,
+        "probability": 0.3309,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -70948,9 +70926,9 @@
           "Black",
           "Green"
         ],
-        "probability": 0.1018,
+        "probability": 0.1718,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -70961,27 +70939,27 @@
           "Black",
           "Green"
         ],
-        "probability": 0.0255,
+        "probability": 0.07,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0364,
+        "probability": 0.0182,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0679,
+        "probability": 0.0424,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -70990,50 +70968,50 @@
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\EG\\Q}\\E",
         "probability": 0.0727,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0412,
+        "probability": 0.063,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0194,
+        "probability": 0.0327,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0024,
+        "probability": 0.0067,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.0727,
+        "probability": 0.0364,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.1358,
+        "probability": 0.0848,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -71041,31 +71019,31 @@
         "colorType": "Colorless",
         "probability": 0.1455,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0824,
+        "probability": 0.1261,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0388,
+        "probability": 0.0655,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0097,
+        "probability": 0.0267,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -71080,8 +71058,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "GRW",
@@ -71134,18 +71111,6 @@
         "itemName": "Xira's Trophy"
       },
       {
-        "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
-      },
-      {
-        "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
-      },
-      {
         "type": "card",
         "probability": 0.5,
         "count": 1,
@@ -71164,6 +71129,18 @@
         "cardName": "Gratuitous Violence|ONS"
       },
       {
+        "type": "gold",
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
+      },
+      {
+        "type": "shards",
+        "probability": 0.75,
+        "count": 10,
+        "addMaxCount": 10
+      },
+      {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colors": [
@@ -71171,9 +71148,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.228,
+        "probability": 0.114,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -71183,9 +71160,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.4256,
+        "probability": 0.266,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -71197,7 +71174,7 @@
         ],
         "probability": 0.456,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -71207,9 +71184,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.2584,
+        "probability": 0.3952,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -71219,9 +71196,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.1216,
+        "probability": 0.2052,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -71231,27 +71208,27 @@
           "Red",
           "Green"
         ],
-        "probability": 0.0304,
+        "probability": 0.0836,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.024,
+        "probability": 0.012,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0448,
+        "probability": 0.028,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -71260,50 +71237,50 @@
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
         "probability": 0.048,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0272,
+        "probability": 0.0416,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0128,
+        "probability": 0.0216,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0016,
+        "probability": 0.0044,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.048,
+        "probability": 0.024,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.0896,
+        "probability": 0.056,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -71311,31 +71288,31 @@
         "colorType": "Colorless",
         "probability": 0.096,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0544,
+        "probability": 0.0832,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0256,
+        "probability": 0.0432,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0064,
+        "probability": 0.0176,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -71350,8 +71327,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "BGR",
@@ -72618,14 +72594,14 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
+        "probability": 0.75,
+        "count": 10,
         "addMaxCount": 10
       },
       {
@@ -72634,9 +72610,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.2769,
+        "probability": 0.1385,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -72644,9 +72620,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.5169,
+        "probability": 0.3231,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -72656,7 +72632,7 @@
         ],
         "probability": 0.5538,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -72664,9 +72640,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.3138,
+        "probability": 0.48,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -72674,9 +72650,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.1477,
+        "probability": 0.2492,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -72684,79 +72660,79 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.0369,
+        "probability": 0.1015,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E",
-        "probability": 0.0038,
+        "probability": 0.0019,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E",
-        "probability": 0.0159,
+        "probability": 0.0095,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E",
-        "probability": 0.0177,
+        "probability": 0.0167,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E",
-        "probability": 0.0087,
+        "probability": 0.0133,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E",
-        "probability": 0.0041,
+        "probability": 0.0069,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E",
-        "probability": 0.0003,
+        "probability": 0.0007,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.0154,
+        "probability": 0.0077,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.0287,
+        "probability": 0.0179,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -72764,31 +72740,31 @@
         "colorType": "Colorless",
         "probability": 0.0308,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0174,
+        "probability": 0.0267,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0082,
+        "probability": 0.0138,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0021,
+        "probability": 0.0056,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -72803,8 +72779,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "B",
@@ -75598,18 +75573,6 @@
         "itemName": "Grovetender's Robes"
       },
       {
-        "type": "gold",
-        "probability": 0.75,
-        "count": 150,
-        "addMaxCount": 150
-      },
-      {
-        "type": "shards",
-        "probability": 0.5,
-        "count": 5,
-        "addMaxCount": 5
-      },
-      {
         "type": "card",
         "probability": 1,
         "count": 1,
@@ -75620,6 +75583,18 @@
         "probability": 1,
         "count": 1,
         "cardName": "Plow Under|UDS"
+      },
+      {
+        "type": "gold",
+        "probability": 0.75,
+        "count": 150,
+        "addMaxCount": 150
+      },
+      {
+        "type": "shards",
+        "probability": 0.5,
+        "count": 5,
+        "addMaxCount": 5
       },
       {
         "type": "card",
@@ -88395,14 +88370,14 @@
       {
         "type": "gold",
         "probability": 1.0,
-        "count": 3000,
-        "addMaxCount": 2000
+        "count": 10000,
+        "addMaxCount": 5000
       },
       {
         "type": "shards",
         "probability": 1.0,
-        "count": 80,
-        "addMaxCount": 40
+        "count": 300,
+        "addMaxCount": 100
       },
       {
         "type": "card",
@@ -88410,7 +88385,7 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.525,
+        "probability": 0.75,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88430,7 +88405,7 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.3,
+        "probability": 0.195,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88440,7 +88415,7 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.15,
+        "probability": 0.075,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88450,17 +88425,7 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.06,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-E.dck",
-        "colors": [
-          "Black"
-        ],
-        "probability": 0.015,
+        "probability": 0.03,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88469,7 +88434,7 @@
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E",
-        "probability": 0.0292,
+        "probability": 0.0417,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88478,7 +88443,7 @@
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E",
-        "probability": 0.0693,
+        "probability": 0.0802,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88487,7 +88452,7 @@
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E",
-        "probability": 0.0432,
+        "probability": 0.0331,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88496,7 +88461,7 @@
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E",
-        "probability": 0.0167,
+        "probability": 0.0083,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88505,16 +88470,7 @@
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E",
-        "probability": 0.0067,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-E.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\EB\\Q}\\E",
-        "probability": 0.0004,
+        "probability": 0.0033,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88522,7 +88478,7 @@
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.1167,
+        "probability": 0.1667,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88538,7 +88494,7 @@
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
-        "probability": 0.0667,
+        "probability": 0.0433,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88546,7 +88502,7 @@
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0333,
+        "probability": 0.0167,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88554,15 +88510,7 @@
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0133,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-E.dck",
-        "colorType": "Colorless",
-        "probability": 0.0033,
+        "probability": 0.0067,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88688,14 +88636,14 @@
       {
         "type": "gold",
         "probability": 1.0,
-        "count": 3000,
-        "addMaxCount": 2000
+        "count": 10000,
+        "addMaxCount": 5000
       },
       {
         "type": "shards",
         "probability": 1.0,
-        "count": 80,
-        "addMaxCount": 40
+        "count": 300,
+        "addMaxCount": 100
       },
       {
         "type": "card",
@@ -88703,7 +88651,7 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.0788,
+        "probability": 0.1125,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88723,7 +88671,7 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.4513,
+        "probability": 0.5615,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88733,7 +88681,7 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.18,
+        "probability": 0.09,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88743,17 +88691,7 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.072,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-E.dck",
-        "colors": [
-          "Red"
-        ],
-        "probability": 0.018,
+        "probability": 0.036,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88762,7 +88700,7 @@
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E",
-        "probability": 0.0146,
+        "probability": 0.0208,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88771,7 +88709,7 @@
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E",
-        "probability": 0.0108,
+        "probability": 0.0122,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88780,7 +88718,7 @@
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E",
-        "probability": 0.0313,
+        "probability": 0.029,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88789,7 +88727,7 @@
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E",
-        "probability": 0.0067,
+        "probability": 0.0033,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88798,16 +88736,7 @@
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E",
-        "probability": 0.0027,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-E.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\ER\\Q}\\E",
-        "probability": 0.0002,
+        "probability": 0.0013,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88815,7 +88744,7 @@
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.0467,
+        "probability": 0.0667,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88831,7 +88760,7 @@
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
-        "probability": 0.0267,
+        "probability": 0.0173,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88839,7 +88768,7 @@
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0133,
+        "probability": 0.0067,
         "count": 4,
         "addMaxCount": 3
       },
@@ -88847,15 +88776,7 @@
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0053,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-E.dck",
-        "colorType": "Colorless",
-        "probability": 0.0013,
+        "probability": 0.0027,
         "count": 4,
         "addMaxCount": 3
       },
@@ -91841,15 +91762,15 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 3000,
-        "addMaxCount": 2000
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 80,
-        "addMaxCount": 40
+        "probability": 0.75,
+        "count": 10,
+        "addMaxCount": 10
       },
       {
         "type": "card",
@@ -91857,9 +91778,9 @@
         "colors": [
           "White"
         ],
-        "probability": 0.1088,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0233,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -91867,9 +91788,9 @@
         "colors": [
           "White"
         ],
-        "probability": 0.6993,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.2875,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -91877,9 +91798,9 @@
         "colors": [
           "White"
         ],
-        "probability": 0.2486,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.373,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -91887,9 +91808,9 @@
         "colors": [
           "White"
         ],
-        "probability": 0.1243,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.3232,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -91897,9 +91818,9 @@
         "colors": [
           "White"
         ],
-        "probability": 0.0497,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.1678,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -91907,111 +91828,111 @@
         "colors": [
           "White"
         ],
-        "probability": 0.0124,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0684,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E",
-        "probability": 0.0552,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0118,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E",
-        "probability": 0.0544,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0256,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E",
-        "probability": 0.1048,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.1013,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E",
-        "probability": 0.0252,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0656,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E",
-        "probability": 0.0101,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0341,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E",
-        "probability": 0.0006,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0035,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.1766,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0378,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
+        "colorType": "Colorless",
+        "probability": 0.0883,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "probability": 0.1514,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-B.dck",
-        "colorType": "Colorless",
-        "probability": 0.1009,
-        "count": 4,
-        "addMaxCount": 3
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0505,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.1312,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0202,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0681,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.005,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0277,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -92026,7 +91947,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 2
+        "count": 1
       }
     ],
     "colors": "W",
@@ -92503,15 +92424,15 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 3000,
-        "addMaxCount": 2000
+        "probability": 0.75,
+        "count": 150,
+        "addMaxCount": 150
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 80,
-        "addMaxCount": 40
+        "probability": 0.5,
+        "count": 5,
+        "addMaxCount": 5
       },
       {
         "type": "card",
@@ -92519,9 +92440,9 @@
         "colors": [
           "Blue"
         ],
-        "probability": 0.316,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0451,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -92529,9 +92450,9 @@
         "colors": [
           "Blue"
         ],
-        "probability": 0.6229,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.2004,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -92539,9 +92460,9 @@
         "colors": [
           "Blue"
         ],
-        "probability": 0.2889,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.4333,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -92549,9 +92470,9 @@
         "colors": [
           "Blue"
         ],
-        "probability": 0.1444,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.4333,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -92559,9 +92480,9 @@
         "colors": [
           "Blue"
         ],
-        "probability": 0.0578,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.2311,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -92569,111 +92490,111 @@
         "colors": [
           "Blue"
         ],
-        "probability": 0.0144,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.1011,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E",
-        "probability": 0.0405,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0058,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E",
-        "probability": 0.0299,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0096,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E",
-        "probability": 0.087,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0716,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E",
+        "probability": 0.0556,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-D.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\EU\\Q}\\E",
+        "probability": 0.0296,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-E.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\EU\\Q}\\E",
+        "probability": 0.0016,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-S.dck",
+        "colorType": "Colorless",
         "probability": 0.0185,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-D.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\EU\\Q}\\E",
-        "probability": 0.0074,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-E.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\EU\\Q}\\E",
-        "probability": 0.0002,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-S.dck",
-        "colorType": "Colorless",
-        "probability": 0.1296,
-        "count": 4,
-        "addMaxCount": 3
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
+        "colorType": "Colorless",
+        "probability": 0.0444,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "probability": 0.1111,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-B.dck",
-        "colorType": "Colorless",
-        "probability": 0.0741,
-        "count": 4,
-        "addMaxCount": 3
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.037,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.1111,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0148,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0593,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0037,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0259,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -92688,7 +92609,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 2
+        "count": 1
       }
     ],
     "colors": "U",
@@ -93063,15 +92984,15 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 3000,
-        "addMaxCount": 2000
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 80,
-        "addMaxCount": 40
+        "probability": 0.75,
+        "count": 10,
+        "addMaxCount": 10
       },
       {
         "type": "card",
@@ -93079,29 +93000,29 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.5744,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.1231,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
+        "colors": [
+          "Black"
+        ],
+        "probability": 0.2872,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-B.dck",
         "colors": [
           "Black"
         ],
         "probability": 0.4923,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-B.dck",
-        "colors": [
-          "Black"
-        ],
-        "probability": 0.3282,
-        "count": 4,
-        "addMaxCount": 3
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -93109,9 +93030,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.1641,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.4267,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -93119,9 +93040,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.0656,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.2215,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -93129,111 +93050,111 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.0164,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0903,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E",
-        "probability": 0.0209,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0045,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E",
-        "probability": 0.0497,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0222,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E",
-        "probability": 0.031,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0391,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E",
-        "probability": 0.012,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0311,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E",
-        "probability": 0.0048,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0162,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E",
-        "probability": 0.0003,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0016,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.0838,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0179,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
+        "colorType": "Colorless",
+        "probability": 0.0419,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "probability": 0.0718,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-B.dck",
-        "colorType": "Colorless",
-        "probability": 0.0479,
-        "count": 4,
-        "addMaxCount": 3
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0239,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0622,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0096,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0323,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0024,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0132,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -93248,7 +93169,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 2
+        "count": 1
       }
     ],
     "colors": "B",
@@ -93724,32 +93645,32 @@
         "itemName": "Dragon Lord's Trophy"
       },
       {
-        "type": "gold",
-        "probability": 1.0,
-        "count": 3000,
-        "addMaxCount": 2000
-      },
-      {
-        "type": "shards",
-        "probability": 1.0,
-        "count": 80,
-        "addMaxCount": 40
-      },
-      {
         "type": "card",
         "probability": 1,
         "count": 1,
         "cardName": "Nalathni Dragon|DRC94"
       },
       {
+        "type": "gold",
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
+      },
+      {
+        "type": "shards",
+        "probability": 0.75,
+        "count": 10,
+        "addMaxCount": 10
+      },
+      {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colors": [
           "Red"
         ],
-        "probability": 0.0608,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.013,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -93757,9 +93678,9 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.842,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.3342,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -93767,9 +93688,9 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.2778,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.4167,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -93777,9 +93698,9 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.1389,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.3611,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -93787,9 +93708,9 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.0556,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.1875,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -93797,111 +93718,111 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.0139,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0764,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E",
-        "probability": 0.0446,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0095,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E",
-        "probability": 0.0329,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0155,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E",
-        "probability": 0.0956,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.087,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E",
-        "probability": 0.0204,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.053,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E",
-        "probability": 0.0081,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0275,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E",
-        "probability": 0.0005,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0028,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.1426,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0306,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
+        "colorType": "Colorless",
+        "probability": 0.0713,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "probability": 0.1222,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-B.dck",
-        "colorType": "Colorless",
-        "probability": 0.0815,
-        "count": 4,
-        "addMaxCount": 3
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0407,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.1059,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0163,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.055,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0041,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0224,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -93916,7 +93837,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 2
+        "count": 1
       }
     ],
     "colors": "R",
@@ -94393,15 +94314,15 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 3000,
-        "addMaxCount": 2000
+        "probability": 0.75,
+        "count": 150,
+        "addMaxCount": 150
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 80,
-        "addMaxCount": 40
+        "probability": 0.5,
+        "count": 5,
+        "addMaxCount": 5
       },
       {
         "type": "card",
@@ -94409,9 +94330,9 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.24,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0343,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -94419,9 +94340,9 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.9486,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.2766,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -94429,9 +94350,9 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.3657,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.5486,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -94439,9 +94360,9 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.1829,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.5486,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -94449,9 +94370,9 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.0731,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.2926,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -94459,111 +94380,111 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.0183,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.128,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EG\\Q}\\E",
-        "probability": 0.0125,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0018,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EG\\Q}\\E",
-        "probability": 0.0092,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.003,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EG\\Q}\\E",
-        "probability": 0.0268,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0221,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EG\\Q}\\E",
+        "probability": 0.0171,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-D.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\EG\\Q}\\E",
+        "probability": 0.0091,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-E.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\EG\\Q}\\E",
+        "probability": 0.0015,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-S.dck",
+        "colorType": "Colorless",
         "probability": 0.0057,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-D.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\EG\\Q}\\E",
-        "probability": 0.0023,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-E.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\EG\\Q}\\E",
-        "probability": 0.0002,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-S.dck",
-        "colorType": "Colorless",
-        "probability": 0.04,
-        "count": 4,
-        "addMaxCount": 3
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
+        "colorType": "Colorless",
+        "probability": 0.0137,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "probability": 0.0343,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-B.dck",
-        "colorType": "Colorless",
-        "probability": 0.0229,
-        "count": 4,
-        "addMaxCount": 3
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0114,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0343,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0046,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0183,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0011,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.008,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -94578,7 +94499,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 2
+        "count": 1
       }
     ],
     "colors": "G",
@@ -95785,18 +95706,6 @@
         "count": 1
       },
       {
-        "type": "gold",
-        "probability": 1.0,
-        "count": 10000,
-        "addMaxCount": 5000
-      },
-      {
-        "type": "shards",
-        "probability": 1.0,
-        "count": 300,
-        "addMaxCount": 100
-      },
-      {
         "type": "card",
         "probability": 0.1,
         "count": 1,
@@ -95827,6 +95736,18 @@
         "cardName": "Tropical Island|LEA"
       },
       {
+        "type": "gold",
+        "probability": 1.0,
+        "count": 3000,
+        "addMaxCount": 2000
+      },
+      {
+        "type": "shards",
+        "probability": 1.0,
+        "count": 80,
+        "addMaxCount": 40
+      },
+      {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colors": [
@@ -95835,7 +95756,7 @@
           "Red",
           "Green"
         ],
-        "probability": 0.3148,
+        "probability": 0.2204,
         "count": 4,
         "addMaxCount": 3
       },
@@ -95861,7 +95782,7 @@
           "Red",
           "Green"
         ],
-        "probability": 0.0819,
+        "probability": 0.1259,
         "count": 4,
         "addMaxCount": 3
       },
@@ -95874,7 +95795,7 @@
           "Red",
           "Green"
         ],
-        "probability": 0.0315,
+        "probability": 0.063,
         "count": 4,
         "addMaxCount": 3
       },
@@ -95887,7 +95808,20 @@
           "Red",
           "Green"
         ],
-        "probability": 0.0126,
+        "probability": 0.0252,
+        "count": 4,
+        "addMaxCount": 3
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-E.dck",
+        "colors": [
+          "White",
+          "Blue",
+          "Red",
+          "Green"
+        ],
+        "probability": 0.0063,
         "count": 4,
         "addMaxCount": 3
       },
@@ -95896,7 +95830,7 @@
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.2284,
+        "probability": 0.1599,
         "count": 4,
         "addMaxCount": 3
       },
@@ -95914,7 +95848,7 @@
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0594,
+        "probability": 0.0914,
         "count": 4,
         "addMaxCount": 3
       },
@@ -95923,7 +95857,7 @@
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0228,
+        "probability": 0.0457,
         "count": 4,
         "addMaxCount": 3
       },
@@ -95932,7 +95866,16 @@
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0091,
+        "probability": 0.0183,
+        "count": 4,
+        "addMaxCount": 3
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-E.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
+        "probability": 0.0017,
         "count": 4,
         "addMaxCount": 3
       },
@@ -95940,7 +95883,7 @@
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.4568,
+        "probability": 0.3198,
         "count": 4,
         "addMaxCount": 3
       },
@@ -95956,7 +95899,7 @@
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
-        "probability": 0.1188,
+        "probability": 0.1827,
         "count": 4,
         "addMaxCount": 3
       },
@@ -95964,7 +95907,7 @@
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0457,
+        "probability": 0.0914,
         "count": 4,
         "addMaxCount": 3
       },
@@ -95972,7 +95915,15 @@
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0183,
+        "probability": 0.0365,
+        "count": 4,
+        "addMaxCount": 3
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-E.dck",
+        "colorType": "Colorless",
+        "probability": 0.0091,
         "count": 4,
         "addMaxCount": 3
       },
@@ -96027,18 +95978,6 @@
         "count": 1
       },
       {
-        "type": "gold",
-        "probability": 1.0,
-        "count": 3000,
-        "addMaxCount": 2000
-      },
-      {
-        "type": "shards",
-        "probability": 1.0,
-        "count": 80,
-        "addMaxCount": 40
-      },
-      {
         "type": "card",
         "probability": 1,
         "count": 1,
@@ -96051,14 +95990,26 @@
         "cardName": "Shared Triumph|ONS"
       },
       {
+        "type": "gold",
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
+      },
+      {
+        "type": "shards",
+        "probability": 0.75,
+        "count": 10,
+        "addMaxCount": 10
+      },
+      {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colors": [
           "White"
         ],
-        "probability": 0.1458,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0312,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96066,9 +96017,9 @@
         "colors": [
           "White"
         ],
-        "probability": 0.9375,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.3854,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96076,9 +96027,9 @@
         "colors": [
           "White"
         ],
-        "probability": 0.3333,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.5,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96086,9 +96037,9 @@
         "colors": [
           "White"
         ],
-        "probability": 0.1667,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.4333,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96096,9 +96047,9 @@
         "colors": [
           "White"
         ],
-        "probability": 0.0667,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.225,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96106,111 +96057,111 @@
         "colors": [
           "White"
         ],
+        "probability": 0.0917,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-S.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\EW\\Q}\\E",
+        "probability": 0.0052,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-A.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\EW\\Q}\\E",
+        "probability": 0.0113,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-B.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\EW\\Q}\\E",
+        "probability": 0.0446,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-C.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\EW\\Q}\\E",
+        "probability": 0.0289,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-D.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\EW\\Q}\\E",
+        "probability": 0.015,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-E.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\EW\\Q}\\E",
+        "probability": 0.0015,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-S.dck",
+        "colorType": "Colorless",
         "probability": 0.0167,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-S.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\EW\\Q}\\E",
-        "probability": 0.0243,
-        "count": 4,
-        "addMaxCount": 3
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "cardText": "\\Q{\\EW\\Q}\\E",
-        "probability": 0.024,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0389,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\EW\\Q}\\E",
-        "probability": 0.0462,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-C.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\EW\\Q}\\E",
-        "probability": 0.0111,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-D.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\EW\\Q}\\E",
-        "probability": 0.0044,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-E.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\EW\\Q}\\E",
-        "probability": 0.0003,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-S.dck",
-        "colorType": "Colorless",
-        "probability": 0.0778,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "probability": 0.0667,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-B.dck",
-        "colorType": "Colorless",
-        "probability": 0.0444,
-        "count": 4,
-        "addMaxCount": 3
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0222,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0578,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0089,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.03,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0022,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0122,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -96225,7 +96176,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 2
+        "count": 1
       }
     ],
     "colors": "W",
@@ -96263,18 +96214,6 @@
         "count": 1
       },
       {
-        "type": "gold",
-        "probability": 1.0,
-        "count": 3000,
-        "addMaxCount": 2000
-      },
-      {
-        "type": "shards",
-        "probability": 1.0,
-        "count": 80,
-        "addMaxCount": 40
-      },
-      {
         "type": "card",
         "probability": 1,
         "count": 1,
@@ -96293,14 +96232,26 @@
         "cardName": "Righteous Charge|PO2"
       },
       {
+        "type": "gold",
+        "probability": 0.75,
+        "count": 150,
+        "addMaxCount": 150
+      },
+      {
+        "type": "shards",
+        "probability": 0.5,
+        "count": 5,
+        "addMaxCount": 5
+      },
+      {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colors": [
           "White"
         ],
-        "probability": 0.175,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.025,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96308,9 +96259,9 @@
         "colors": [
           "White"
         ],
-        "probability": 1.0,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.315,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96318,9 +96269,9 @@
         "colors": [
           "White"
         ],
-        "probability": 0.525,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.6,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96328,9 +96279,9 @@
         "colors": [
           "White"
         ],
-        "probability": 0.2,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.6,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96338,9 +96289,9 @@
         "colors": [
           "White"
         ],
-        "probability": 0.08,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.32,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96348,9 +96299,9 @@
         "colors": [
           "White"
         ],
-        "probability": 0.02,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.14,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -96365,7 +96316,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 2
+        "count": 1
       }
     ],
     "colors": "W",
@@ -96398,14 +96349,14 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
+        "probability": 0.75,
+        "count": 10,
         "addMaxCount": 10
       },
       {
@@ -96414,9 +96365,9 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.0804,
+        "probability": 0.0402,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96424,9 +96375,9 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.5339,
+        "probability": 0.317,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96436,7 +96387,7 @@
         ],
         "probability": 0.4286,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96444,9 +96395,9 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.2429,
+        "probability": 0.3714,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96454,9 +96405,9 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.1143,
+        "probability": 0.1929,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96464,79 +96415,79 @@
         "colors": [
           "Green"
         ],
+        "probability": 0.0786,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-S.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\EG\\Q}\\E",
+        "probability": 0.0089,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-A.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\EG\\Q}\\E",
+        "probability": 0.0145,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-B.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\EG\\Q}\\E",
+        "probability": 0.0813,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-C.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\EG\\Q}\\E",
+        "probability": 0.0495,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-D.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\EG\\Q}\\E",
+        "probability": 0.0257,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-E.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\EG\\Q}\\E",
+        "probability": 0.0039,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-S.dck",
+        "colorType": "Colorless",
         "probability": 0.0286,
         "count": 3,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-S.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\EG\\Q}\\E",
-        "probability": 0.0179,
-        "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "cardText": "\\Q{\\EG\\Q}\\E",
-        "probability": 0.024,
+        "probability": 0.0667,
         "count": 3,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-B.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\EG\\Q}\\E",
-        "probability": 0.0972,
-        "count": 3,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-C.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\EG\\Q}\\E",
-        "probability": 0.0324,
-        "count": 3,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-D.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\EG\\Q}\\E",
-        "probability": 0.0152,
-        "count": 3,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-E.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\EG\\Q}\\E",
-        "probability": 0.0014,
-        "count": 3,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-S.dck",
-        "colorType": "Colorless",
-        "probability": 0.0571,
-        "count": 3,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-A.dck",
-        "colorType": "Colorless",
-        "probability": 0.1067,
-        "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96544,31 +96495,31 @@
         "colorType": "Colorless",
         "probability": 0.1143,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0648,
+        "probability": 0.099,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0305,
+        "probability": 0.0514,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0076,
+        "probability": 0.021,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -96583,8 +96534,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "G",
@@ -96618,14 +96568,14 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
+        "probability": 0.75,
+        "count": 10,
         "addMaxCount": 10
       },
       {
@@ -96635,9 +96585,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.1125,
+        "probability": 0.0562,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96646,9 +96596,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.5325,
+        "probability": 0.3187,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96659,7 +96609,7 @@
         ],
         "probability": 0.45,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96668,9 +96618,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.255,
+        "probability": 0.39,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96679,9 +96629,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.12,
+        "probability": 0.2025,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96690,79 +96640,79 @@
           "Red",
           "Green"
         ],
-        "probability": 0.03,
+        "probability": 0.0825,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.025,
+        "probability": 0.0125,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.035,
+        "probability": 0.0219,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0617,
+        "probability": 0.0573,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0283,
+        "probability": 0.0433,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0133,
+        "probability": 0.0225,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0012,
+        "probability": 0.0034,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.05,
+        "probability": 0.025,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.0933,
+        "probability": 0.0583,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96770,31 +96720,31 @@
         "colorType": "Colorless",
         "probability": 0.1,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0567,
+        "probability": 0.0867,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0267,
+        "probability": 0.045,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0067,
+        "probability": 0.0183,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -96809,8 +96759,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "RG",
@@ -96843,18 +96792,6 @@
         "count": 1
       },
       {
-        "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
-      },
-      {
-        "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
-      },
-      {
         "type": "card",
         "probability": 1,
         "count": 1,
@@ -96867,15 +96804,27 @@
         "cardName": "Swamp|PELP"
       },
       {
+        "type": "gold",
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
+      },
+      {
+        "type": "shards",
+        "probability": 0.75,
+        "count": 10,
+        "addMaxCount": 10
+      },
+      {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colors": [
           "Black",
           "Red"
         ],
-        "probability": 0.2,
+        "probability": 0.1,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96884,9 +96833,9 @@
           "Black",
           "Red"
         ],
-        "probability": 0.3733,
+        "probability": 0.2333,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96897,7 +96846,7 @@
         ],
         "probability": 0.4,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96906,9 +96855,9 @@
           "Black",
           "Red"
         ],
-        "probability": 0.2267,
+        "probability": 0.3467,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96917,9 +96866,9 @@
           "Black",
           "Red"
         ],
-        "probability": 0.1067,
+        "probability": 0.18,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96928,27 +96877,27 @@
           "Black",
           "Red"
         ],
-        "probability": 0.0267,
+        "probability": 0.0733,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0333,
+        "probability": 0.0167,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0622,
+        "probability": 0.0389,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -96957,50 +96906,50 @@
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
         "probability": 0.0667,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0378,
+        "probability": 0.0578,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0178,
+        "probability": 0.03,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0017,
+        "probability": 0.0046,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.0667,
+        "probability": 0.0333,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.1244,
+        "probability": 0.0778,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97008,31 +96957,31 @@
         "colorType": "Colorless",
         "probability": 0.1333,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0756,
+        "probability": 0.1156,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0356,
+        "probability": 0.06,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0089,
+        "probability": 0.0244,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -97047,8 +96996,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "BR",
@@ -97213,15 +97161,15 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.75,
+        "count": 150,
+        "addMaxCount": 150
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
+        "probability": 0.5,
+        "count": 5,
+        "addMaxCount": 5
       },
       {
         "type": "card",
@@ -97229,9 +97177,9 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.0375,
+        "probability": 0.0125,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97239,9 +97187,9 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.8225,
+        "probability": 0.3275,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97251,7 +97199,7 @@
         ],
         "probability": 0.6,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97259,9 +97207,9 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.34,
+        "probability": 0.6,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97269,9 +97217,9 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.16,
+        "probability": 0.32,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97279,9 +97227,9 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.04,
+        "probability": 0.14,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -97296,8 +97244,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "R",
@@ -97333,15 +97280,15 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.75,
+        "count": 150,
+        "addMaxCount": 150
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
+        "probability": 0.5,
+        "count": 5,
+        "addMaxCount": 5
       },
       {
         "type": "card",
@@ -97349,9 +97296,9 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.0375,
+        "probability": 0.0125,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97359,9 +97306,9 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.8225,
+        "probability": 0.3275,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97371,7 +97318,7 @@
         ],
         "probability": 0.6,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97379,9 +97326,9 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.34,
+        "probability": 0.6,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97389,9 +97336,9 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.16,
+        "probability": 0.32,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97399,9 +97346,9 @@
         "colors": [
           "Red"
         ],
-        "probability": 0.04,
+        "probability": 0.14,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -97416,8 +97363,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "R",
@@ -97448,14 +97394,14 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
+        "probability": 0.75,
+        "count": 10,
         "addMaxCount": 10
       },
       {
@@ -97464,9 +97410,9 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.1013,
+        "probability": 0.0506,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97474,9 +97420,9 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.6728,
+        "probability": 0.3994,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97486,7 +97432,7 @@
         ],
         "probability": 0.54,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97494,9 +97440,9 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.306,
+        "probability": 0.468,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97504,9 +97450,9 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.144,
+        "probability": 0.243,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97514,79 +97460,79 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.036,
+        "probability": 0.099,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EG\\Q}\\E",
-        "probability": 0.0062,
+        "probability": 0.0031,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EG\\Q}\\E",
-        "probability": 0.0084,
+        "probability": 0.0051,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EG\\Q}\\E",
-        "probability": 0.034,
+        "probability": 0.0285,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EG\\Q}\\E",
-        "probability": 0.0113,
+        "probability": 0.0173,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EG\\Q}\\E",
-        "probability": 0.0053,
+        "probability": 0.009,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EG\\Q}\\E",
-        "probability": 0.0005,
+        "probability": 0.0014,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.02,
+        "probability": 0.01,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.0373,
+        "probability": 0.0233,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97594,31 +97540,31 @@
         "colorType": "Colorless",
         "probability": 0.04,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0227,
+        "probability": 0.0347,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0107,
+        "probability": 0.018,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0027,
+        "probability": 0.0073,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -97633,8 +97579,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "G",
@@ -97782,15 +97727,15 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.75,
+        "count": 150,
+        "addMaxCount": 150
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
+        "probability": 0.5,
+        "count": 5,
+        "addMaxCount": 5
       },
       {
         "type": "card",
@@ -97798,9 +97743,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.3,
+        "probability": 0.1,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97808,9 +97753,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.56,
+        "probability": 0.24,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97820,7 +97765,7 @@
         ],
         "probability": 0.6,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97828,9 +97773,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.34,
+        "probability": 0.6,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97838,9 +97783,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.16,
+        "probability": 0.32,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97848,9 +97793,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.04,
+        "probability": 0.14,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -97865,8 +97810,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "B",
@@ -97903,15 +97847,15 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.75,
+        "count": 150,
+        "addMaxCount": 150
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
+        "probability": 0.5,
+        "count": 5,
+        "addMaxCount": 5
       },
       {
         "type": "card",
@@ -97919,9 +97863,9 @@
         "colors": [
           "White"
         ],
-        "probability": 0.075,
+        "probability": 0.025,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97929,9 +97873,9 @@
         "colors": [
           "White"
         ],
-        "probability": 0.785,
+        "probability": 0.315,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97941,7 +97885,7 @@
         ],
         "probability": 0.6,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97949,9 +97893,9 @@
         "colors": [
           "White"
         ],
-        "probability": 0.34,
+        "probability": 0.6,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97959,9 +97903,9 @@
         "colors": [
           "White"
         ],
-        "probability": 0.16,
+        "probability": 0.32,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -97969,9 +97913,9 @@
         "colors": [
           "White"
         ],
-        "probability": 0.04,
+        "probability": 0.14,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -97986,8 +97930,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "W",
@@ -98025,14 +97968,14 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
+        "probability": 0.75,
+        "count": 10,
         "addMaxCount": 10
       },
       {
@@ -98041,9 +97984,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.3,
+        "probability": 0.15,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -98051,9 +97994,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.56,
+        "probability": 0.35,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -98063,7 +98006,7 @@
         ],
         "probability": 0.6,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -98071,9 +98014,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.34,
+        "probability": 0.52,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -98081,9 +98024,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.16,
+        "probability": 0.27,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -98091,9 +98034,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.04,
+        "probability": 0.11,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -98108,8 +98051,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "B",
@@ -98254,14 +98196,14 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
+        "probability": 0.75,
+        "count": 10,
         "addMaxCount": 10
       },
       {
@@ -98270,9 +98212,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.3,
+        "probability": 0.15,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -98280,9 +98222,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.56,
+        "probability": 0.35,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -98292,7 +98234,7 @@
         ],
         "probability": 0.6,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -98300,9 +98242,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.34,
+        "probability": 0.52,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -98310,9 +98252,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.16,
+        "probability": 0.27,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -98320,9 +98262,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.04,
+        "probability": 0.11,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -98337,8 +98279,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "B",
@@ -98486,14 +98427,14 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
+        "probability": 0.75,
+        "count": 10,
         "addMaxCount": 10
       },
       {
@@ -98502,9 +98443,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.3,
+        "probability": 0.15,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -98512,9 +98453,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.56,
+        "probability": 0.35,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -98524,7 +98465,7 @@
         ],
         "probability": 0.6,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -98532,9 +98473,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.34,
+        "probability": 0.52,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -98542,9 +98483,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.16,
+        "probability": 0.27,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -98552,9 +98493,9 @@
         "colors": [
           "Black"
         ],
-        "probability": 0.04,
+        "probability": 0.11,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -98569,8 +98510,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "B",
@@ -98742,14 +98682,14 @@
       {
         "type": "gold",
         "probability": 1.0,
-        "count": 3000,
-        "addMaxCount": 2000
+        "count": 10000,
+        "addMaxCount": 5000
       },
       {
         "type": "shards",
         "probability": 1.0,
-        "count": 80,
-        "addMaxCount": 40
+        "count": 300,
+        "addMaxCount": 100
       },
       {
         "type": "card",
@@ -98757,7 +98697,7 @@
         "colors": [
           "Blue"
         ],
-        "probability": 0.2698,
+        "probability": 0.3854,
         "count": 4,
         "addMaxCount": 3
       },
@@ -98767,7 +98707,7 @@
         "colors": [
           "Blue"
         ],
-        "probability": 0.5319,
+        "probability": 0.6013,
         "count": 4,
         "addMaxCount": 3
       },
@@ -98777,7 +98717,7 @@
         "colors": [
           "Blue"
         ],
-        "probability": 0.2467,
+        "probability": 0.1603,
         "count": 4,
         "addMaxCount": 3
       },
@@ -98787,7 +98727,7 @@
         "colors": [
           "Blue"
         ],
-        "probability": 0.1233,
+        "probability": 0.0617,
         "count": 4,
         "addMaxCount": 3
       },
@@ -98797,17 +98737,7 @@
         "colors": [
           "Blue"
         ],
-        "probability": 0.0493,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-E.dck",
-        "colors": [
-          "Blue"
-        ],
-        "probability": 0.0123,
+        "probability": 0.0247,
         "count": 4,
         "addMaxCount": 3
       },
@@ -98816,7 +98746,7 @@
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E",
-        "probability": 0.0559,
+        "probability": 0.0799,
         "count": 4,
         "addMaxCount": 3
       },
@@ -98825,7 +98755,7 @@
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E",
-        "probability": 0.0413,
+        "probability": 0.0467,
         "count": 4,
         "addMaxCount": 3
       },
@@ -98834,7 +98764,7 @@
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E",
-        "probability": 0.12,
+        "probability": 0.1111,
         "count": 4,
         "addMaxCount": 3
       },
@@ -98843,7 +98773,7 @@
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E",
-        "probability": 0.0256,
+        "probability": 0.0128,
         "count": 4,
         "addMaxCount": 3
       },
@@ -98852,16 +98782,7 @@
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E",
-        "probability": 0.0102,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-E.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\EU\\Q}\\E",
-        "probability": 0.0003,
+        "probability": 0.0051,
         "count": 4,
         "addMaxCount": 3
       },
@@ -98869,7 +98790,7 @@
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.1789,
+        "probability": 0.2556,
         "count": 4,
         "addMaxCount": 3
       },
@@ -98885,7 +98806,7 @@
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
-        "probability": 0.1022,
+        "probability": 0.0664,
         "count": 4,
         "addMaxCount": 3
       },
@@ -98893,7 +98814,7 @@
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0511,
+        "probability": 0.0256,
         "count": 4,
         "addMaxCount": 3
       },
@@ -98901,15 +98822,7 @@
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0204,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-E.dck",
-        "colorType": "Colorless",
-        "probability": 0.0051,
+        "probability": 0.0102,
         "count": 4,
         "addMaxCount": 3
       },
@@ -98982,14 +98895,14 @@
       {
         "type": "gold",
         "probability": 1.0,
-        "count": 3000,
-        "addMaxCount": 2000
+        "count": 10000,
+        "addMaxCount": 5000
       },
       {
         "type": "shards",
         "probability": 1.0,
-        "count": 80,
-        "addMaxCount": 40
+        "count": 300,
+        "addMaxCount": 100
       },
       {
         "type": "card",
@@ -98997,7 +98910,7 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.1909,
+        "probability": 0.2727,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99007,7 +98920,7 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.7545,
+        "probability": 0.8909,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99017,7 +98930,7 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.2909,
+        "probability": 0.1891,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99027,7 +98940,7 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.1455,
+        "probability": 0.0727,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99037,17 +98950,7 @@
         "colors": [
           "Green"
         ],
-        "probability": 0.0582,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-E.dck",
-        "colors": [
-          "Green"
-        ],
-        "probability": 0.0145,
+        "probability": 0.0291,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99056,7 +98959,7 @@
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EG\\Q}\\E",
-        "probability": 0.0398,
+        "probability": 0.0568,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99065,7 +98968,7 @@
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EG\\Q}\\E",
-        "probability": 0.0294,
+        "probability": 0.0332,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99074,7 +98977,7 @@
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EG\\Q}\\E",
-        "probability": 0.0854,
+        "probability": 0.079,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99083,7 +98986,7 @@
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EG\\Q}\\E",
-        "probability": 0.0182,
+        "probability": 0.0091,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99092,16 +98995,7 @@
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EG\\Q}\\E",
-        "probability": 0.0073,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-E.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\EG\\Q}\\E",
-        "probability": 0.0007,
+        "probability": 0.0036,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99109,7 +99003,7 @@
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.1273,
+        "probability": 0.1818,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99125,7 +99019,7 @@
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
-        "probability": 0.0727,
+        "probability": 0.0473,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99133,7 +99027,7 @@
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0364,
+        "probability": 0.0182,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99141,15 +99035,7 @@
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0145,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-E.dck",
-        "colorType": "Colorless",
-        "probability": 0.0036,
+        "probability": 0.0073,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99223,14 +99109,14 @@
       {
         "type": "gold",
         "probability": 1.0,
-        "count": 3000,
-        "addMaxCount": 2000
+        "count": 10000,
+        "addMaxCount": 5000
       },
       {
         "type": "shards",
         "probability": 1.0,
-        "count": 80,
-        "addMaxCount": 40
+        "count": 300,
+        "addMaxCount": 100
       },
       {
         "type": "card",
@@ -99238,7 +99124,7 @@
         "colors": [
           "White"
         ],
-        "probability": 0.1466,
+        "probability": 0.2095,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99248,7 +99134,7 @@
         "colors": [
           "White"
         ],
-        "probability": 0.9426,
+        "probability": 1.0,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99258,7 +99144,7 @@
         "colors": [
           "White"
         ],
-        "probability": 0.3351,
+        "probability": 0.3489,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99268,7 +99154,7 @@
         "colors": [
           "White"
         ],
-        "probability": 0.1676,
+        "probability": 0.0838,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99278,17 +99164,7 @@
         "colors": [
           "White"
         ],
-        "probability": 0.067,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-E.dck",
-        "colors": [
-          "White"
-        ],
-        "probability": 0.0168,
+        "probability": 0.0335,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99297,7 +99173,7 @@
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E",
-        "probability": 0.0236,
+        "probability": 0.0338,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99306,7 +99182,7 @@
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E",
-        "probability": 0.0233,
+        "probability": 0.0264,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99315,7 +99191,7 @@
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E",
-        "probability": 0.0449,
+        "probability": 0.0404,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99324,7 +99200,7 @@
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E",
-        "probability": 0.0108,
+        "probability": 0.0054,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99333,16 +99209,7 @@
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E",
-        "probability": 0.0043,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-E.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\EW\\Q}\\E",
-        "probability": 0.0003,
+        "probability": 0.0022,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99350,7 +99217,7 @@
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.0757,
+        "probability": 0.1081,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99366,7 +99233,7 @@
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
-        "probability": 0.0432,
+        "probability": 0.0281,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99374,7 +99241,7 @@
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0216,
+        "probability": 0.0108,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99382,15 +99249,7 @@
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0086,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-E.dck",
-        "colorType": "Colorless",
-        "probability": 0.0022,
+        "probability": 0.0043,
         "count": 4,
         "addMaxCount": 3
       },
@@ -99426,14 +99285,14 @@
       {
         "type": "gold",
         "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "count": 3000,
+        "addMaxCount": 2000
       },
       {
         "type": "shards",
         "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
+        "count": 80,
+        "addMaxCount": 40
       },
       {
         "type": "card",
@@ -99442,30 +99301,30 @@
           "Blue",
           "Green"
         ],
-        "probability": 0.2368,
-        "count": 3,
+        "probability": 0.5526,
+        "count": 4,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
-        "colors": [
-          "Blue",
-          "Green"
-        ],
-        "probability": 0.4421,
-        "count": 3,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-B.dck",
         "colors": [
           "Blue",
           "Green"
         ],
         "probability": 0.4737,
-        "count": 3,
+        "count": 4,
+        "addMaxCount": 3
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-B.dck",
+        "colors": [
+          "Blue",
+          "Green"
+        ],
+        "probability": 0.3158,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99475,8 +99334,8 @@
           "Blue",
           "Green"
         ],
-        "probability": 0.2684,
-        "count": 3,
+        "probability": 0.1579,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99486,8 +99345,8 @@
           "Blue",
           "Green"
         ],
-        "probability": 0.1263,
-        "count": 3,
+        "probability": 0.0632,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99497,8 +99356,8 @@
           "Blue",
           "Green"
         ],
-        "probability": 0.0316,
-        "count": 3,
+        "probability": 0.0158,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99506,8 +99365,8 @@
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0211,
-        "count": 3,
+        "probability": 0.0491,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99515,8 +99374,8 @@
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0246,
-        "count": 3,
+        "probability": 0.0263,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99524,8 +99383,8 @@
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0568,
-        "count": 3,
+        "probability": 0.0439,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99533,8 +99392,8 @@
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0239,
-        "count": 3,
+        "probability": 0.014,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99542,8 +99401,8 @@
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0112,
-        "count": 3,
+        "probability": 0.0056,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99551,56 +99410,56 @@
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0011,
-        "count": 3,
+        "probability": 0.0005,
+        "count": 4,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.0421,
-        "count": 3,
+        "probability": 0.0982,
+        "count": 4,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
-        "colorType": "Colorless",
-        "probability": 0.0786,
-        "count": 3,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "probability": 0.0842,
-        "count": 3,
+        "count": 4,
+        "addMaxCount": 3
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-B.dck",
+        "colorType": "Colorless",
+        "probability": 0.0561,
+        "count": 4,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0477,
-        "count": 3,
+        "probability": 0.0281,
+        "count": 4,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0225,
-        "count": 3,
+        "probability": 0.0112,
+        "count": 4,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0056,
-        "count": 3,
+        "probability": 0.0028,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99616,8 +99475,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 2
       }
     ],
     "colors": "UG",
@@ -99637,14 +99495,14 @@
       {
         "type": "gold",
         "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "count": 3000,
+        "addMaxCount": 2000
       },
       {
         "type": "shards",
         "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
+        "count": 80,
+        "addMaxCount": 40
       },
       {
         "type": "card",
@@ -99653,30 +99511,30 @@
           "Blue",
           "Black"
         ],
-        "probability": 0.18,
-        "count": 3,
+        "probability": 0.42,
+        "count": 4,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
-        "colors": [
-          "Blue",
-          "Black"
-        ],
-        "probability": 0.336,
-        "count": 3,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-B.dck",
         "colors": [
           "Blue",
           "Black"
         ],
         "probability": 0.36,
-        "count": 3,
+        "count": 4,
+        "addMaxCount": 3
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-B.dck",
+        "colors": [
+          "Blue",
+          "Black"
+        ],
+        "probability": 0.24,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99686,8 +99544,8 @@
           "Blue",
           "Black"
         ],
-        "probability": 0.204,
-        "count": 3,
+        "probability": 0.12,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99697,8 +99555,8 @@
           "Blue",
           "Black"
         ],
-        "probability": 0.096,
-        "count": 3,
+        "probability": 0.048,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99708,8 +99566,8 @@
           "Blue",
           "Black"
         ],
-        "probability": 0.024,
-        "count": 3,
+        "probability": 0.012,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99717,8 +99575,8 @@
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.04,
-        "count": 3,
+        "probability": 0.0933,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99726,8 +99584,8 @@
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.0747,
-        "count": 3,
+        "probability": 0.08,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99735,8 +99593,8 @@
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.08,
-        "count": 3,
+        "probability": 0.0533,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99744,8 +99602,8 @@
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.0453,
-        "count": 3,
+        "probability": 0.0267,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99753,8 +99611,8 @@
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.0213,
-        "count": 3,
+        "probability": 0.0107,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99762,56 +99620,56 @@
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.002,
-        "count": 3,
+        "probability": 0.001,
+        "count": 4,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.08,
-        "count": 3,
+        "probability": 0.1867,
+        "count": 4,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
-        "colorType": "Colorless",
-        "probability": 0.1493,
-        "count": 3,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "probability": 0.16,
-        "count": 3,
+        "count": 4,
+        "addMaxCount": 3
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-B.dck",
+        "colorType": "Colorless",
+        "probability": 0.1067,
+        "count": 4,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0907,
-        "count": 3,
+        "probability": 0.0533,
+        "count": 4,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0427,
-        "count": 3,
+        "probability": 0.0213,
+        "count": 4,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0107,
-        "count": 3,
+        "probability": 0.0053,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99827,8 +99685,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 2
       }
     ],
     "colors": "UB",
@@ -99854,14 +99711,14 @@
       {
         "type": "gold",
         "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "count": 3000,
+        "addMaxCount": 2000
       },
       {
         "type": "shards",
         "probability": 1.0,
-        "count": 20,
-        "addMaxCount": 10
+        "count": 80,
+        "addMaxCount": 40
       },
       {
         "type": "card",
@@ -99869,8 +99726,8 @@
         "colors": [
           "Blue"
         ],
-        "probability": 0.15,
-        "count": 3,
+        "probability": 0.35,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99879,8 +99736,8 @@
         "colors": [
           "Blue"
         ],
-        "probability": 0.538,
-        "count": 3,
+        "probability": 0.69,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99889,8 +99746,8 @@
         "colors": [
           "Blue"
         ],
-        "probability": 0.48,
-        "count": 3,
+        "probability": 0.32,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99899,8 +99756,8 @@
         "colors": [
           "Blue"
         ],
-        "probability": 0.272,
-        "count": 3,
+        "probability": 0.16,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99909,8 +99766,8 @@
         "colors": [
           "Blue"
         ],
-        "probability": 0.128,
-        "count": 3,
+        "probability": 0.064,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99919,8 +99776,8 @@
         "colors": [
           "Blue"
         ],
-        "probability": 0.032,
-        "count": 3,
+        "probability": 0.016,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99928,8 +99785,8 @@
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E",
-        "probability": 0.0125,
-        "count": 3,
+        "probability": 0.0292,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99937,8 +99794,8 @@
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E",
-        "probability": 0.0168,
-        "count": 3,
+        "probability": 0.0216,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99946,8 +99803,8 @@
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E",
-        "probability": 0.068,
-        "count": 3,
+        "probability": 0.0626,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99955,8 +99812,8 @@
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E",
-        "probability": 0.0227,
-        "count": 3,
+        "probability": 0.0133,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99964,8 +99821,8 @@
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E",
-        "probability": 0.0107,
-        "count": 3,
+        "probability": 0.0053,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -99973,56 +99830,56 @@
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E",
-        "probability": 0.0003,
-        "count": 3,
+        "probability": 0.0002,
+        "count": 4,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.04,
-        "count": 3,
+        "probability": 0.0933,
+        "count": 4,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
-        "colorType": "Colorless",
-        "probability": 0.0747,
-        "count": 3,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "probability": 0.08,
-        "count": 3,
+        "count": 4,
+        "addMaxCount": 3
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-B.dck",
+        "colorType": "Colorless",
+        "probability": 0.0533,
+        "count": 4,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0453,
-        "count": 3,
+        "probability": 0.0267,
+        "count": 4,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0213,
-        "count": 3,
+        "probability": 0.0107,
+        "count": 4,
         "addMaxCount": 3
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0053,
-        "count": 3,
+        "probability": 0.0027,
+        "count": 4,
         "addMaxCount": 3
       },
       {
@@ -100038,8 +99895,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 2
       }
     ],
     "colors": "U",
@@ -100284,18 +100140,6 @@
         "itemName": "Santa's Hat"
       },
       {
-        "type": "gold",
-        "probability": 0.75,
-        "count": 150,
-        "addMaxCount": 150
-      },
-      {
-        "type": "shards",
-        "probability": 0.5,
-        "count": 5,
-        "addMaxCount": 5
-      },
-      {
         "type": "card",
         "probability": 1,
         "count": 1,
@@ -100330,6 +100174,18 @@
         "probability": 1,
         "count": 1,
         "cardName": "Goblin War Drums|FEM"
+      },
+      {
+        "type": "gold",
+        "probability": 0.75,
+        "count": 150,
+        "addMaxCount": 150
+      },
+      {
+        "type": "shards",
+        "probability": 0.5,
+        "count": 5,
+        "addMaxCount": 5
       },
       {
         "type": "card",
@@ -100611,14 +100467,14 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 800,
-        "addMaxCount": 400
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 20,
+        "probability": 0.75,
+        "count": 10,
         "addMaxCount": 10
       },
       {
@@ -100631,9 +100487,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.225,
+        "probability": 0.1125,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -100645,9 +100501,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.42,
+        "probability": 0.2625,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -100661,7 +100517,7 @@
         ],
         "probability": 0.45,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -100673,9 +100529,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.255,
+        "probability": 0.39,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -100687,9 +100543,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.12,
+        "probability": 0.2025,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -100701,27 +100557,27 @@
           "Red",
           "Green"
         ],
-        "probability": 0.03,
+        "probability": 0.0825,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.025,
+        "probability": 0.0125,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0467,
+        "probability": 0.0292,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -100730,50 +100586,50 @@
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
         "probability": 0.05,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0283,
+        "probability": 0.0433,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0133,
+        "probability": 0.0225,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0017,
+        "probability": 0.0046,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.05,
+        "probability": 0.025,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.0933,
+        "probability": 0.0583,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -100781,31 +100637,31 @@
         "colorType": "Colorless",
         "probability": 0.1,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0567,
+        "probability": 0.0867,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0267,
+        "probability": 0.045,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0067,
+        "probability": 0.0183,
         "count": 3,
-        "addMaxCount": 3
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -100820,8 +100676,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 1,
-        "addMaxCount": 1
+        "count": 1
       }
     ],
     "colors": "WUBRG",
@@ -100853,15 +100708,15 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 3000,
-        "addMaxCount": 2000
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 80,
-        "addMaxCount": 40
+        "probability": 0.75,
+        "count": 10,
+        "addMaxCount": 10
       },
       {
         "type": "card",
@@ -100871,33 +100726,33 @@
           "Blue",
           "Green"
         ],
-        "probability": 0.6432,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.1378,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
+        "colors": [
+          "White",
+          "Blue",
+          "Green"
+        ],
+        "probability": 0.3216,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-B.dck",
         "colors": [
           "White",
           "Blue",
           "Green"
         ],
         "probability": 0.5514,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-B.dck",
-        "colors": [
-          "White",
-          "Blue",
-          "Green"
-        ],
-        "probability": 0.3676,
-        "count": 4,
-        "addMaxCount": 3
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -100907,9 +100762,9 @@
           "Blue",
           "Green"
         ],
-        "probability": 0.1838,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.4778,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -100919,9 +100774,9 @@
           "Blue",
           "Green"
         ],
-        "probability": 0.0735,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.2481,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -100931,111 +100786,111 @@
           "Blue",
           "Green"
         ],
-        "probability": 0.0184,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.1011,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0189,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0041,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EG\\Q}\\E",
+        "probability": 0.0095,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EG\\Q}\\E",
         "probability": 0.0162,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-B.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0108,
-        "count": 4,
-        "addMaxCount": 3
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0054,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0141,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0022,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0073,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0002,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0011,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.0378,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0081,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.0324,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0189,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
-        "probability": 0.0216,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0324,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0108,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0281,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0043,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0146,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0011,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0059,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -101050,7 +100905,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 2
+        "count": 1
       }
     ],
     "colors": "WUG",
@@ -101082,15 +100937,15 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 3000,
-        "addMaxCount": 2000
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 80,
-        "addMaxCount": 40
+        "probability": 0.75,
+        "count": 10,
+        "addMaxCount": 10
       },
       {
         "type": "card",
@@ -101100,33 +100955,33 @@
           "Blue",
           "Black"
         ],
-        "probability": 0.64,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.1371,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
+        "colors": [
+          "White",
+          "Blue",
+          "Black"
+        ],
+        "probability": 0.32,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-B.dck",
         "colors": [
           "White",
           "Blue",
           "Black"
         ],
         "probability": 0.5486,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-B.dck",
-        "colors": [
-          "White",
-          "Blue",
-          "Black"
-        ],
-        "probability": 0.3657,
-        "count": 4,
-        "addMaxCount": 3
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -101136,9 +100991,9 @@
           "Blue",
           "Black"
         ],
-        "probability": 0.1829,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.4754,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -101148,9 +101003,9 @@
           "Blue",
           "Black"
         ],
-        "probability": 0.0731,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.2469,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -101160,111 +101015,111 @@
           "Blue",
           "Black"
         ],
-        "probability": 0.0183,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.1006,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.02,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0043,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
+        "probability": 0.01,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
         "probability": 0.0171,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-B.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.0114,
-        "count": 4,
-        "addMaxCount": 3
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.0057,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0149,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.0023,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0077,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E",
-        "probability": 0.0003,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0016,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.04,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0086,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.0343,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.02,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
-        "probability": 0.0229,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0343,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0114,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0297,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0046,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0154,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0011,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0063,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -101279,7 +101134,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 2
+        "count": 1
       }
     ],
     "colors": "WUB",
@@ -101311,15 +101166,15 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 3000,
-        "addMaxCount": 2000
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 80,
-        "addMaxCount": 40
+        "probability": 0.75,
+        "count": 10,
+        "addMaxCount": 10
       },
       {
         "type": "card",
@@ -101329,33 +101184,33 @@
           "Black",
           "Red"
         ],
-        "probability": 0.6432,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.1378,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
+        "colors": [
+          "Blue",
+          "Black",
+          "Red"
+        ],
+        "probability": 0.3216,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-B.dck",
         "colors": [
           "Blue",
           "Black",
           "Red"
         ],
         "probability": 0.5514,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-B.dck",
-        "colors": [
-          "Blue",
-          "Black",
-          "Red"
-        ],
-        "probability": 0.3676,
-        "count": 4,
-        "addMaxCount": 3
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -101365,9 +101220,9 @@
           "Black",
           "Red"
         ],
-        "probability": 0.1838,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.4778,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -101377,9 +101232,9 @@
           "Black",
           "Red"
         ],
-        "probability": 0.0735,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.2481,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -101389,111 +101244,111 @@
           "Black",
           "Red"
         ],
-        "probability": 0.0184,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.1011,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0189,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0041,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
+        "probability": 0.0095,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
         "probability": 0.0162,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-B.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0108,
-        "count": 4,
-        "addMaxCount": 3
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0054,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0141,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0022,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0073,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EU\\Q}\\E|\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E",
-        "probability": 0.0003,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0015,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.0378,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0081,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.0324,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0189,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
-        "probability": 0.0216,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0324,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0108,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0281,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0043,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0146,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0011,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0059,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -101508,7 +101363,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 2
+        "count": 1
       }
     ],
     "colors": "UBR",
@@ -101540,15 +101395,15 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 3000,
-        "addMaxCount": 2000
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 80,
-        "addMaxCount": 40
+        "probability": 0.75,
+        "count": 10,
+        "addMaxCount": 10
       },
       {
         "type": "card",
@@ -101558,9 +101413,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.4824,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.1034,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -101570,9 +101425,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.7122,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.3561,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -101582,9 +101437,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.3676,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.5514,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -101594,9 +101449,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.1838,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.4778,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -101606,9 +101461,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.0735,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.2481,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -101618,111 +101473,111 @@
           "Red",
           "Green"
         ],
-        "probability": 0.0184,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.1011,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0189,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0041,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
+        "probability": 0.0095,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
         "probability": 0.0162,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-B.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0108,
-        "count": 4,
-        "addMaxCount": 3
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0054,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0141,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0022,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0073,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EW\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0002,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0011,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.0378,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0081,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.0324,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0189,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
-        "probability": 0.0216,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0324,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0108,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0281,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0043,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0146,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.0011,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0059,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -101737,7 +101592,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 2
+        "count": 1
       }
     ],
     "colors": "WRG",
@@ -101769,15 +101624,15 @@
       },
       {
         "type": "gold",
-        "probability": 1.0,
-        "count": 3000,
-        "addMaxCount": 2000
+        "probability": 0.85,
+        "count": 400,
+        "addMaxCount": 300
       },
       {
         "type": "shards",
-        "probability": 1.0,
-        "count": 80,
-        "addMaxCount": 40
+        "probability": 0.75,
+        "count": 10,
+        "addMaxCount": 10
       },
       {
         "type": "card",
@@ -101787,33 +101642,33 @@
           "Red",
           "Green"
         ],
-        "probability": 0.6462,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.1385,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
+        "colors": [
+          "Black",
+          "Red",
+          "Green"
+        ],
+        "probability": 0.3231,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-B.dck",
         "colors": [
           "Black",
           "Red",
           "Green"
         ],
         "probability": 0.5538,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-B.dck",
-        "colors": [
-          "Black",
-          "Red",
-          "Green"
-        ],
-        "probability": 0.3692,
-        "count": 4,
-        "addMaxCount": 3
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -101823,9 +101678,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.1846,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.48,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -101835,9 +101690,9 @@
           "Red",
           "Green"
         ],
-        "probability": 0.0738,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.2492,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
@@ -101847,111 +101702,111 @@
           "Red",
           "Green"
         ],
-        "probability": 0.0185,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.1015,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0179,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0038,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
+        "colorType": "Colorless",
+        "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
+        "probability": 0.009,
+        "count": 3,
+        "addMaxCount": 2
+      },
+      {
+        "type": "card",
+        "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
         "probability": 0.0154,
-        "count": 4,
-        "addMaxCount": 3
-      },
-      {
-        "type": "card",
-        "sourceDeck": "decks/rewards/tier-B.dck",
-        "colorType": "Colorless",
-        "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0103,
-        "count": 4,
-        "addMaxCount": 3
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0051,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0133,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0021,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0069,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
         "cardText": "\\Q{\\EB\\Q}\\E|\\Q{\\ER\\Q}\\E|\\Q{\\EG\\Q}\\E",
-        "probability": 0.0003,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0014,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-S.dck",
         "colorType": "Colorless",
-        "probability": 0.0359,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0077,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-A.dck",
         "colorType": "Colorless",
-        "probability": 0.0308,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0179,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-B.dck",
         "colorType": "Colorless",
-        "probability": 0.0205,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0308,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-C.dck",
         "colorType": "Colorless",
-        "probability": 0.0103,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0267,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-D.dck",
         "colorType": "Colorless",
-        "probability": 0.0041,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0138,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "card",
         "sourceDeck": "decks/rewards/tier-E.dck",
         "colorType": "Colorless",
-        "probability": 0.001,
-        "count": 4,
-        "addMaxCount": 3
+        "probability": 0.0056,
+        "count": 3,
+        "addMaxCount": 2
       },
       {
         "type": "deckCard",
@@ -101966,7 +101821,7 @@
         "rarity": [
           "Rare"
         ],
-        "count": 2
+        "count": 1
       }
     ],
     "colors": "BRG",


### PR DESCRIPTION
- Replace formula-based boss tier classification with guide-based difficulty overrides from the game guide
- Add new Medium Boss tier (S=15%, A=35%) between Boss and Mini-Boss for mid-game encounters
- Promote 5 palace final bosses (Serra, Urza, Yawgmoth, Jaya, Gaea) from Major Boss to Elite Boss
- Promote Halls of Time trio from Boss to Major Boss
- Demote 1997 Shandalar bosses and Elder Dragons from Major Boss to Medium Boss
- Demote low-difficulty flavor bosses (Werebear, Chicken farm, etc.) from Boss to Mini-Boss
- Net effect: early-game farming less lucrative, endgame encounters properly elite