### PR TITLE
Old Border Shandalar: Fix incorrect edition labels in precon starter decks

### DIFF
--- a/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/4ED - Black Starter.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/4ED - Black Starter.dck
@@ -10,7 +10,7 @@ Name=Black Starter
 2 Paralyze|4ED|1
 2 Will-o'-the-Wisp|4ED|1
 2 Vampire Bats|4ED|1
-1 Unholy Strength|3ED|1
+1 Unholy Strength|4ED|1
 2 Drudge Skeletons|4ED|1
 2 Black Knight|4ED|1
 2 Animate Dead|4ED|1

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/4ED - White Starter.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/4ED - White Starter.dck
@@ -16,7 +16,7 @@ Name=White Starter
 2 Mesa Pegasus|4ED|1
 2 White Knight|4ED|1
 2 Disenchant|4ED|1
-1 Blessing|3ED|1
+1 Blessing|4ED|1
 1 Holy Strength|4ED|1
 2 Wrath of God|4ED|1
 1 Armageddon|4ED|1

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/APC - Pandemonium.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/APC - Pandemonium.dck
@@ -22,16 +22,16 @@ Name=Pandemonium
 3 Penumbra Bobcat|APC|1
 2 Penumbra Kavu|APC|1
 1 Penumbra Wurm|APC|1
-2 Quirion Elves|MIR|1
+2 Quirion Elves|INV|1
 1 Quirion Trailblazer|INV|1
 1 Stratadon|PLS|1
 2 Urborg Elf|APC|1
 1 Wayfaring Giant|INV|1
 2 Exotic Curse|INV|1
-2 Fertile Ground|USG|1
+2 Fertile Ground|INV|1
 1 Captain's Maneuver|APC|1
 2 Evasive Action|APC|1
-3 Harrow|TMP|1
+3 Harrow|INV|1
 1 Order // Chaos|APC|1
 2 Allied Strategies|PLS|1
 1 Gaea's Balance|APC|1

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/APC - Swoop.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/APC - Swoop.dck
@@ -23,7 +23,7 @@ Name=Swoop
 1 Tidal Visionary|INV|1
 2 Urborg Elf|APC|1
 2 Ceta Sanctuary|APC|1
-1 Fertile Ground|USG|1
+1 Fertile Ground|INV|1
 1 Yavimaya's Embrace|APC|1
 1 Confound|PLS|1
 1 Jaded Response|APC|1

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/APC - Whirlpool.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/APC - Whirlpool.dck
@@ -30,7 +30,7 @@ Name=Whirlpool
 2 Jilt|APC|1
 1 Opt|INV|1
 1 Scorching Lava|INV|1
-2 Stun|TMP|1
+2 Stun|INV|1
 1 Suffocating Blast|APC|1
 2 Chromatic Sphere|INV|1
 [Sideboard]

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/LGN - Elvish Rage.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/LGN - Elvish Rage.dck
@@ -9,7 +9,7 @@ Name=Elvish Rage
 1 Birchlore Rangers|ONS|1
 1 Bloodline Shaman|ONS|1
 3 Defiant Elf|LGN|1
-2 Elven Riders|LEG|1
+2 Elven Riders|ONS|1
 1 Elvish Pathcutter|ONS|1
 1 Elvish Pioneer|ONS|1
 1 Elvish Scrapper|ONS|1
@@ -21,7 +21,7 @@ Name=Elvish Rage
 3 Patron of the Wild|LGN|1
 3 Stonewood Invoker|LGN|1
 1 Snarling Undorak|ONS|1
-1 Taunting Elf|UDS|1
+1 Taunting Elf|ONS|1
 2 Timberwatch Elf|LGN|1
 1 Tribal Forcemage|LGN|1
 1 Wellwisher|ONS|1

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/LGN - Morph Mayhem.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/LGN - Morph Mayhem.dck
@@ -34,7 +34,7 @@ Name=Morph Mayhem
 1 Akroma's Blessing|ONS|1
 1 Discombobulate|ONS|1
 1 Improvised Armor|ONS|1
-2 Pacifism|MIR|1
+2 Pacifism|ONS|1
 [Sideboard]
 
 [Planes]

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/LGN - Sliver Shivers.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/LGN - Sliver Shivers.dck
@@ -27,7 +27,7 @@ Name=Sliver Shivers
 2 Tribal Unity|ONS|1
 2 Explosive Vegetation|ONS|1
 1 Crown of Vigor|ONS|1
-4 Pacifism|MIR|1
+4 Pacifism|ONS|1
 [Sideboard]
 
 [Planes]

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/NMS - Breakdown.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/NMS - Breakdown.dck
@@ -21,7 +21,7 @@ Name=Breakdown
 3 Waterfront Bouncer|MMQ|1
 2 Woodripper|NMS|1
 1 Dehydration|MMQ|1
-1 False Demise|ALL|1
+1 False Demise|MMQ|1
 1 Seal of Strength|NMS|1
 1 War Tax|MMQ|1
 1 Seal of Removal|NMS|1

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/NMS - Eruption.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/NMS - Eruption.dck
@@ -26,7 +26,7 @@ Name=Eruption
 1 Inviolability|MMQ|1
 1 Seal of Cleansing|NMS|1
 3 Seal of Fire|NMS|1
-1 Disenchant|LEA|1
+1 Disenchant|MMQ|1
 1 Downhill Charge|NMS|1
 1 Ramosian Rally|MMQ|1
 1 Sivvi's Ruse|NMS|1

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/NMS - Mercenaries.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/NMS - Mercenaries.dck
@@ -26,7 +26,7 @@ Name=Mercenaries
 1 Intimidation|MMQ|1
 3 Parallax Dementia|NMS|1
 1 Seal of Doom|NMS|1
-2 Dark Ritual|LEA|1
+2 Dark Ritual|MMQ|1
 1 Dark Triumph|NMS|1
 1 Cateran Summons|MMQ|1
 1 Massacre|NMS|1

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/PCY - Distress.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/PCY - Distress.dck
@@ -27,15 +27,15 @@ Name=Distress
 1 Maggot Therapy|MMQ|1
 1 Seal of Cleansing|NMS|1
 1 Seal of Doom|NMS|1
-1 Afterlife|MIR|1
+1 Afterlife|MMQ|1
 1 Angelic Favor|NMS|1
-2 Dark Ritual|LEA|1
-1 Disenchant|LEA|1
+2 Dark Ritual|MMQ|1
+1 Disenchant|MMQ|1
 2 Excise|PCY|1
 1 Steal Strength|PCY|1
 1 Snuff Out|MMQ|1
 3 Despoil|PCY|1
-2 Rain of Tears|POR|1
+2 Rain of Tears|MMQ|1
 2 Rhystic Syphon|PCY|1
 1 Rhystic Tutor|PCY|1
 [Sideboard]

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/PCY - Pummel.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/PCY - Pummel.dck
@@ -31,7 +31,7 @@ Name=Pummel
 2 Wild Might|PCY|1
 1 Skyshroud Claim|NMS|1
 2 Snag|PCY|1
-1 Tranquility|LEA|1
+1 Tranquility|MMQ|1
 [Sideboard]
 
 [Planes]

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/PCY - Slither.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/PCY - Slither.dck
@@ -27,7 +27,7 @@ Name=Slither
 1 War Cadence|MMQ|1
 2 Invigorate|MMQ|1
 2 Rhystic Lightning|PCY|1
-1 Desert Twister|3ED|1
+1 Desert Twister|MMQ|1
 1 Flameshot|PCY|1
 1 Reverent Silence|NMS|1
 1 Chimeric Idol|PCY|1

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/PCY - Turnaround.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/PCY - Turnaround.dck
@@ -29,7 +29,7 @@ Name=Turnaround
 1 Rhystic Study|PCY|1
 1 Seal of Cleansing|NMS|1
 1 Daze|NMS|1
-1 Disenchant|LEA|1
+1 Disenchant|MMQ|1
 1 Foil|PCY|1
 1 Rethink|PCY|1
 1 Rhystic Shield|PCY|1

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/PLS - Barrage.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/PLS - Barrage.dck
@@ -28,13 +28,13 @@ Name=Barrage
 1 Thunderscape Apprentice|INV|1
 1 Thunderscape Battlemage|PLS|1
 1 Thunderscape Familiar|PLS|1
-2 Fertile Ground|USG|1
+2 Fertile Ground|INV|1
 1 Fires of Yavimaya|INV|1
 1 Assault // Battery|INV|1
 1 Explosive Growth|INV|1
 1 Magma Burst|PLS|1
 1 Scorching Lava|INV|1
-1 Simoon|VIS|1
+1 Simoon|INV|1
 1 Singe|PLS|1
 1 Implode|PLS|1
 [Sideboard]

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/PLS - Comeback.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/PLS - Comeback.dck
@@ -27,7 +27,7 @@ Name=Comeback
 2 Marsh Crocodile|PLS|1
 1 Nightscape Familiar|PLS|1
 2 Phyrexian Bloodstock|PLS|1
-2 Ravenous Rats|PO2|1
+2 Ravenous Rats|INV|1
 1 Sawtooth Loon|PLS|1
 2 Silver Drake|PLS|1
 1 Stormscape Apprentice|INV|1

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/PLS - Domain.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/PLS - Domain.dck
@@ -32,7 +32,7 @@ Name=Domain
 1 Strength of Unity|INV|1
 1 Confound|PLS|1
 1 Gaea's Might|PLS|1
-3 Harrow|TMP|1
+3 Harrow|INV|1
 1 Rith's Charm|PLS|1
 1 Treva's Charm|PLS|1
 2 Worldly Counsel|INV|1

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/PLS - Scout.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/PLS - Scout.dck
@@ -22,7 +22,7 @@ Name=Scout
 1 Horned Kavu|PLS|1
 1 Mirrorwood Treefolk|PLS|1
 1 Nomadic Elf|INV|1
-1 Quirion Elves|MIR|1
+1 Quirion Elves|INV|1
 2 Quirion Explorer|PLS|1
 1 Radiant Kavu|PLS|1
 1 Rampant Elephant|INV|1
@@ -36,10 +36,10 @@ Name=Scout
 1 Thornscape Familiar|PLS|1
 1 Viashino Grappler|INV|1
 1 Armadillo Cloak|INV|1
-2 Fertile Ground|USG|1
+2 Fertile Ground|INV|1
 1 Eladamri's Call|PLS|1
 2 Gerrard's Command|PLS|1
-1 Harrow|TMP|1
+1 Harrow|INV|1
 1 Magma Burst|PLS|1
 1 Pollen Remedy|PLS|1
 1 Rith's Charm|PLS|1

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/SCG - Storm Surge.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/SCG - Storm Surge.dck
@@ -23,7 +23,7 @@ Name=Storm Surge
 1 Shoreline Ranger|SCG|1
 2 Silver Knight|SCG|1
 1 Whipcorder|ONS|1
-1 White Knight|LEA|1
+1 White Knight|LGN|1
 1 Willbender|LGN|1
 2 Zealous Inquisitor|SCG|1
 3 Astral Steel|SCG|1

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/STH - The Sparkler.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/STH - The Sparkler.dck
@@ -17,17 +17,17 @@ Name=The Sparkler
 1 Intruder Alarm|STH|1
 2 Propaganda|TMP|1
 2 Capsize|TMP|1
-1 Counterspell|LEA|1
+1 Counterspell|TMP|1
 1 Evacuation|STH|1
 3 Lightning Blast|TMP|1
 3 Mana Leak|STH|1
 1 Mind Games|STH|1
-2 Power Sink|LEA|1
+2 Power Sink|TMP|1
 1 Reins of Power|STH|1
 1 Searing Touch|TMP|1
-1 Shatter|LEA|1
+1 Shatter|TMP|1
 2 Shock|STH|1
-2 Spell Blast|LEA|1
+2 Spell Blast|TMP|1
 1 Whispers of the Muse|TMP|1
 1 Ransack|STH|1
 2 Fanning the Flames|STH|1

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/STH - The Spikes.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/STH - The Spikes.dck
@@ -29,7 +29,7 @@ Name=The Spikes
 1 Elven Rite|STH|1
 2 Rampant Growth|MIR|1
 1 Verdant Touch|STH|1
-1 Tranquility|LEA|1
+1 Tranquility|TMP|1
 [Sideboard]
 
 [Planes]

--- a/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/TOR - Sacrilege.dck
+++ b/forge-gui/res/adventure/Shandalar Old Border/decks/starter/precon/TOR - Sacrilege.dck
@@ -16,7 +16,7 @@ Name=Sacrilege
 2 Cabal Surgeon|TOR|1
 1 Carrion Wurm|TOR|1
 1 Crypt Creeper|ODY|1
-4 Gravedigger|POR|1
+4 Gravedigger|ODY|1
 1 Grotesque Hybrid|TOR|1
 1 Ichorid|TOR|1
 3 Mystic Familiar|TOR|1
@@ -25,7 +25,7 @@ Name=Sacrilege
 3 Teroh's Faithful|TOR|1
 1 Teroh's Vanguard|TOR|1
 1 Whispering Shade|ODY|1
-3 Buried Alive|WTH|1
+3 Buried Alive|ODY|1
 4 Crippling Fatigue|TOR|1
 1 Zombify|ODY|1
 1 Hypochondria|TOR|1


### PR DESCRIPTION
- Some precon starter deck cards were auto-assigned to their oldest printing (e.g., Counterspell|LEA in an STH precon)
- Fixed 36 cards across 23 decks to use the correct block-era edition
- Cards like Counterspell|LEA, Disenchant|LEA, Dark Ritual|LEA now use their correct block printings (TMP, MMQ, etc.)
- Also fixes cards from MIR, USG, TMP, POR, PO2, WTH, LEG, 3ED that had block-appropriate reprints available