### PR TITLE
Consistency for nonbasic land pricing in Adventure and Planar Conquest modes

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/util/CardUtil.java
+++ b/forge-gui-mobile/src/forge/adventure/util/CardUtil.java
@@ -333,7 +333,16 @@ public class CardUtil {
         if (card == null)
             return 0;
 
-        return switch (card.getRarity()) {
+        CardRarity effectiveRarity = card.getRarity();
+
+        if (card.getRarity() == CardRarity.BasicLand
+                && !card.isVeryBasicLand()
+                && !MagicColor.Constant.SNOW_LANDS.contains(card.getName())
+                && !card.getName().equals("Wastes")) {
+            effectiveRarity = CardRarity.Common; // adjust for lands which are L rarity but are not basic lands
+        }
+
+        return switch (effectiveRarity) {
             case BasicLand -> 5;
             case Common -> 50;
             case Uncommon -> 150;

--- a/forge-gui-mobile/src/forge/screens/planarconquest/ConquestAEtherScreen.java
+++ b/forge-gui-mobile/src/forge/screens/planarconquest/ConquestAEtherScreen.java
@@ -122,6 +122,8 @@ public class ConquestAEtherScreen extends FScreen {
                 }
             } else if (card.getRarity() == CardRarity.BasicLand
                     && !card.isVeryBasicLand()
+                    && !card.getName().equals("Wastes")
+                    && !MagicColor.Constant.SNOW_LANDS.contains(card.getName())
                     && selectedRarity == CardRarity.Common
                     && btnCMCFilter.selectedOption == ConquestUtil.CMCFilter.CMC_LOW
                     && card.getRules().getColorIdentity().hasNoColorsExcept(commander.getCard().getRules().getColorIdentity())) {


### PR DESCRIPTION
Affects e.g. Final Fantasy dual color towns which are L rarity but are not basic lands.
They no longer cost $5 in Adventure mode.
Also a slight tweak to Planar Conquest to make it impossible to pull Wastes or Snow-Covered basic lands from the Aether, since they also count as basic lands.