### PR TITLE
Prompt for token owner when running the "Add Token to Battlefield" action in dev mode menu.

### DIFF
--- a/forge-gui/res/languages/de-DE.properties
+++ b/forge-gui/res/languages/de-DE.properties
@@ -1448,6 +1448,7 @@ lblFileNotFound=Datei nicht gefunden
 lblPutCardInWhichPlayerZone=Lege Karte bei welchem Spieler in {0}?
 lblPutCardInWhichPlayerBattlefield=Lege die Karte bei welchem Spieler auf das Spielfeld?
 lblPutCardInWhichPlayerPlayOrStack=Die Karte soll für welchen Spieler ins Spiel/auf den Stapel?
+lblPutTokenInWhichPlayerBattlefield=Lege Token bei welchem Spieler auf das Spielfeld?
 lblCardShouldBeSummoningSicknessConfirm=Soll {0} unter Einsatzverzögerung leiden?
 lblCardShouldBeAddedToLibraryTopOrBottom=Soll {0} auf oder unter die Bibliothek?
 lblExileCardsFromPlayerHandConfirm=Karte(n) aus welcher Spielerhand ins Exil schicken?

--- a/forge-gui/res/languages/en-US.properties
+++ b/forge-gui/res/languages/en-US.properties
@@ -1530,6 +1530,7 @@ lblFileNotFound=File not found
 lblPutCardInWhichPlayerZone=Put card in {0} for which player?
 lblPutCardInWhichPlayerBattlefield=Put card on the battlefield for which player?
 lblPutCardInWhichPlayerPlayOrStack=Put card on the stack / in play for which player?
+lblPutTokenInWhichPlayerBattlefield=Put token on the battlefield for which player?
 lblCardShouldBeSummoningSicknessConfirm=Should {0} be affected with Summoning Sickness?
 lblCardShouldBeAddedToLibraryTopOrBottom=Should {0} be added to the top or to the bottom of the library?
 lblExileCardsFromPlayerHandConfirm=Exile card(s) from which player''s hand?

--- a/forge-gui/res/languages/es-ES.properties
+++ b/forge-gui/res/languages/es-ES.properties
@@ -1430,6 +1430,7 @@ lblFileNotFound=Fichero no encontrado
 lblPutCardInWhichPlayerZone=¿Poner carta en {0} para qué jugador?
 lblPutCardInWhichPlayerBattlefield=¿Poner carta en el campo de batalla para qué jugador?
 lblPutCardInWhichPlayerPlayOrStack=¿Poner carta en la pila / en juego para qué jugador?
+lblPutTokenInWhichPlayerBattlefield=¿Poner ficha en el campo de batalla para qué jugador?
 lblCardShouldBeSummoningSicknessConfirm=¿Debería {0} verse afectado por la Enfermedad Invocadora?
 lblCardShouldBeAddedToLibraryTopOrBottom=¿Debería añadirse {0} a la parte superior o inferior de la biblioteca?
 lblExileCardsFromPlayerHandConfirm=¿Exiliar carta(s) de qué mano del jugador?

--- a/forge-gui/res/languages/fr-FR.properties
+++ b/forge-gui/res/languages/fr-FR.properties
@@ -1425,6 +1425,7 @@ lblFileNotFound=Fichier introuvable
 lblPutCardInWhichPlayerZone=Mettre la carte dans {0} pour quel joueur ?
 lblPutCardInWhichPlayerBattlefield=Mettre une carte sur le champ de bataille pour quel joueur ?
 lblPutCardInWhichPlayerPlayOrStack=Mettre une carte sur la pile / en jeu pour quel joueur ?
+lblPutTokenInWhichPlayerBattlefield=Mettre un jeton sur le champ de bataille pour quel joueur ?
 lblCardShouldBeSummoningSicknessConfirm=Est-ce que {0} devrait être affecté par le mal d'invocation ?
 lblCardShouldBeAddedToLibraryTopOrBottom=Faut-il ajouter {0} en haut ou en bas de la bibliothèque ?
 lblExileCardsFromPlayerHandConfirm=Exilez des cartes de la main de quel joueur ?

--- a/forge-gui/res/languages/it-IT.properties
+++ b/forge-gui/res/languages/it-IT.properties
@@ -1422,6 +1422,7 @@ lblFileNotFound=File non trovato
 lblPutCardInWhichPlayerZone=Per quale giocatore vuoi mettere la carta {0}?
 lblPutCardInWhichPlayerBattlefield=Per quale giocatore vuoi mettere la carta nel campo di battaglia?
 lblPutCardInWhichPlayerPlayOrStack=Per quale giocatore vuoi mettere la carta in pila / in gioco?
+lblPutTokenInWhichPlayerBattlefield=Per quale giocatore vuoi mettere il segnalino nel campo di battaglia?
 lblCardShouldBeSummoningSicknessConfirm={0} deve essere affetto da debolezza da evocazione?
 lblCardShouldBeAddedToLibraryTopOrBottom={0} deve essere aggiunto alla cima o al fondo del grimorio?
 lblExileCardsFromPlayerHandConfirm=Dalla mano di quale giocatore vuoi esiliare la/le carta/e?

--- a/forge-gui/res/languages/ja-JP.properties
+++ b/forge-gui/res/languages/ja-JP.properties
@@ -1423,6 +1423,7 @@ lblFileNotFound=ファイルが見つかりません
 lblPutCardInWhichPlayerZone=どのプレイヤーの{0}にカードを置きますか？
 lblPutCardInWhichPlayerBattlefield=どのプレイヤーの戦場にカードを出しますか？
 lblPutCardInWhichPlayerPlayOrStack=どのプレイヤーにカードをスタックに追加しますか？
+lblPutTokenInWhichPlayerBattlefield=どのプレイヤーの戦場にトークンを出しますか？
 lblCardShouldBeSummoningSicknessConfirm={0}は召喚酔いの影響を受けますか？
 lblCardShouldBeAddedToLibraryTopOrBottom={0}をライブラリのトップ、またはボトムに追加しますか？
 lblExileCardsFromPlayerHandConfirm=どのプレイヤーの手札からカードを追放しますか？

--- a/forge-gui/res/languages/pt-BR.properties
+++ b/forge-gui/res/languages/pt-BR.properties
@@ -1452,6 +1452,7 @@ lblFileNotFound=Arquivo não encontrado
 lblPutCardInWhichPlayerZone=Colocar carta em {0} para qual jogador?
 lblPutCardInWhichPlayerBattlefield=Colocar carta no campo de batalha para qual jogador?
 lblPutCardInWhichPlayerPlayOrStack=Colocar carta na pilha / em jogo para qual jogador?
+lblPutTokenInWhichPlayerBattlefield=Colocar ficha no campo de batalha para qual jogador?
 lblCardShouldBeSummoningSicknessConfirm=Afetar {0} com Enjoo de Invocação?
 lblCardShouldBeAddedToLibraryTopOrBottom={0} deve ser adicionado ao topo ou fundo do grimório?
 lblExileCardsFromPlayerHandConfirm=Exilar carta(s) da mão de qual jogador?

--- a/forge-gui/res/languages/zh-CN.properties
+++ b/forge-gui/res/languages/zh-CN.properties
@@ -1429,6 +1429,7 @@ lblFileNotFound=文件未找到
 lblPutCardInWhichPlayerZone=将牌放于哪个牌手的{0}中？
 lblPutCardInWhichPlayerBattlefield=将牌放于哪个牌手的战场？
 lblPutCardInWhichPlayerPlayOrStack=将牌放于哪个牌手的堆叠/使哪个牌手使用牌？
+lblPutTokenInWhichPlayerBattlefield=将衍生物放于哪个牌手的战场？
 lblCardShouldBeSummoningSicknessConfirm={0}是否应该受到召唤失调的影响?
 lblCardShouldBeAddedToLibraryTopOrBottom=将{0}添加到牌库顶还是底？
 lblExileCardsFromPlayerHandConfirm=从哪位玩家手中放逐牌？

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -2860,7 +2860,13 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
 
         @Override
         public void addTokenToBattlefield() {
-            final Player p = getPlayer();
+            String message = localizer.getMessage("lblPutTokenInWhichPlayerBattlefield");
+            GameEntityViewMap<Player, PlayerView> gameCachePlayer = GameEntityView.getMap(getGame().getPlayers());
+            PlayerView pv = getGui().oneOrNone(message, gameCachePlayer.getTrackableKeys());
+            if (pv == null || !gameCachePlayer.containsKey(pv)) {
+                return;
+            }
+            final Player p = gameCachePlayer.get(pv);
 
             final TokenDb tokenDb = FModel.getMagicDb().getAllTokens();
             // Use rulesByName — the comprehensive, edition-agnostic token list
@@ -2897,6 +2903,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
                 }
                 return label + " — " + oracle.replace("\\n", ", ");
             };
+
             final List<CardRules> selection = getGui().getChoices(
                     localizer.getMessage("lblNameTheToken"), 0, 1, choices, null, displayFn);
             final CardRules chosen = selection.isEmpty() ? null : selection.get(0);


### PR DESCRIPTION
This PR updates the "Add Token to Battlefield" dev mode action to prompt for the token owner first.

Prompt logic taken from the handler of the "Add Card to Battlefield" action.

Non-english string translations are a "best guess" autocompletion from copilot.

Fixes #10154 