### PR TITLE
MagicColor: allow extra case for Colorless

### DIFF
--- a/forge-core/src/main/java/forge/card/MagicColor.java
+++ b/forge-core/src/main/java/forge/card/MagicColor.java
@@ -180,13 +180,17 @@ public final class MagicColor {
             };
         }
         public static Color fromName(final String color) {
+            if (color == null) {
+                return null;
+            }
             return switch (color.toLowerCase(Locale.ROOT)) {
                 case MagicColor.Constant.WHITE -> WHITE;
                 case MagicColor.Constant.BLUE -> BLUE;
                 case MagicColor.Constant.BLACK -> BLACK;
                 case MagicColor.Constant.RED -> RED;
                 case MagicColor.Constant.GREEN -> GREEN;
-                default -> COLORLESS;
+                case MagicColor.Constant.COLORLESS -> COLORLESS;
+                default -> null;
             };
         }
 

--- a/forge-core/src/main/java/forge/util/ImageUtil.java
+++ b/forge-core/src/main/java/forge/util/ImageUtil.java
@@ -293,7 +293,7 @@ public class ImageUtil {
 
     private static String specFaceToCollectorSuffix(String face) {
         MagicColor.Color color = MagicColor.Color.fromName(face);
-        if (color == MagicColor.Color.COLORLESS) return null;
+        if (color == null) return null;
         return color.getShortName().toLowerCase();
     }
 

--- a/forge-game/src/main/java/forge/game/keyword/KeywordWithType.java
+++ b/forge-game/src/main/java/forge/game/keyword/KeywordWithType.java
@@ -33,7 +33,7 @@ public class KeywordWithType extends KeywordInstance<KeywordWithType> implements
             descType = k[1];
         } else {
             MagicColor.Color color = MagicColor.Color.fromName(details);
-            if (color != MagicColor.Color.COLORLESS) {
+            if (color != null) {
                 type = "Card." + StringUtils.capitalize(color.getName());
                 descType = color.getName();
             } else {


### PR DESCRIPTION
This fixes `MagicColor.Color.fromName` to differ between "colorless" and "not-color"
also made the function null-safe