### PR TITLE
Fix CardColors continuous abilities counting colorless

### DIFF
--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityContinuous.java
@@ -712,11 +712,13 @@ public final class StaticAbilityContinuous {
                     newKeywords.removeIf(input -> {
                         // replace one Keyword with list of keywords
                         if (input.contains("CardColors") || input.contains("cardColors")) {
-                            for (MagicColor.Color color : affectedCard.getColor()) {
-                                extraKeywords.add(
-                                    input.replaceAll("CardColors", StringUtils.capitalize(color.getName()))
-                                        .replaceAll("cardColors", color.getName())
+                            if (!(affectedCard.getColor().isColorless())) {
+                                for (MagicColor.Color color : affectedCard.getColor()) {
+                                    extraKeywords.add(
+                                            input.replaceAll("CardColors", StringUtils.capitalize(color.getName()))
+                                                    .replaceAll("cardColors", color.getName())
                                     );
+                                }
                             }
                             return true;
                         }


### PR DESCRIPTION
Fixes an issue where Earnest Fellowship and Tam, Mindful First-Year were giving colorless creatures protection/hexproof from colorless, as though colorless were itself a color.