### PR TITLE
Fix migrating Adventure data losing inventory after the recent main world update

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/data/EffectData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/EffectData.java
@@ -6,6 +6,7 @@ import forge.item.PaperCard;
 import forge.item.PaperToken;
 import forge.model.FModel;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Map;
@@ -13,13 +14,17 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class EffectData implements Serializable {
+    @Serial
+    private static final long serialVersionUID = -1350202758899129612L;
+
     public String name = null;           //Effect name. Can be checked for.
+
     //Duel effects.
     public int lifeModifier = 0;         //Amount to add to starting Life.
     public int changeStartCards = 0;     //Amount to add to starting hand size.
     public String[] startBattleWithCard; //Cards that start in the Battlefield.
     public String[] startBattleWithCardInCommandZone; //Cards that start in the Command Zone of the Battlefield.
-    public String[] startBattleWithCardInHand; //Cards that start in the first hand you draw (currently doesn't work on mulligan) 
+    public String[] startBattleWithCardInHand; //Cards that start in the first hand you draw (currently doesn't work on mulligan)
 
     //Map only effects.
     public boolean colorView = false;    //Allows to display enemy colors on the map.


### PR DESCRIPTION
This works as an (ugly hack type of?) a solution so that the inventory data is not lost on load. If a more comprehensive solution is needed, it's outside of my area of expertise, so help is welcome...

We do set serial IDs in many places in the code though, so maybe this is viable?