### PR TITLE
Hide incomplete planes in Adventure Mode unless Dev Mode is enabled

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/util/Config.java
+++ b/forge-gui-mobile/src/forge/adventure/util/Config.java
@@ -359,7 +359,6 @@ public class Config {
         for (int i = 0; i < adventures.size; i++) {
             adventures.set(i, "<user>" + adventures.get(i));
         }
-
         adventures.addAll(this.adventures);
 
         // A hard-coded list of planes that are currently not finished and are considered to be in development


### PR DESCRIPTION
Currently a hard-coded list, ideally should be its own .ini or .json file or something like that?..