### PR TITLE
Show commander tax in perpetual mana cost overlay

### DIFF
--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -6929,6 +6929,9 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
         if (currentZone == zone) { return; }
         currentZone = zone;
         view.updateZone(this);
+        if (isCommander()) {
+            updateManaCostForView();
+        }
     }
 
     public boolean isInZone(final ZoneType zone) {

--- a/forge-game/src/main/java/forge/game/card/CardState.java
+++ b/forge-game/src/main/java/forge/game/card/CardState.java
@@ -44,6 +44,7 @@ import forge.game.spellability.SpellPermanent;
 import forge.game.staticability.StaticAbility;
 import forge.game.staticability.StaticAbilityMode;
 import forge.game.trigger.Trigger;
+import forge.game.zone.ZoneType;
 import forge.util.CardTranslation;
 import forge.util.ITranslatable;
 import forge.util.IterableUtil;
@@ -273,7 +274,24 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
     }
 
     public ManaCost getPerpetualAdjustedManaCost() {
-        return perpetualAdjustedManaCost == null ? getManaCost() : perpetualAdjustedManaCost;
+        ManaCost base = perpetualAdjustedManaCost == null ? getManaCost() : perpetualAdjustedManaCost;
+
+        // Layer commander tax on top of perpetual adjustments when in command zone
+        Card card = getCard();
+        if (card != null && card.isCommander() && card.getZone() != null
+                && card.getZone().is(ZoneType.Command)) {
+            Player owner = card.getOwner();
+            if (owner != null) {
+                int tax = owner.getCommanderCast(card) * 2;
+                if (tax > 0) {
+                    int newGeneric = base.getGenericCost() + tax;
+                    String shards = base.getShortString().replaceFirst("" + base.getGenericCost(), "").trim();
+                    String costStr = newGeneric + (shards.isEmpty() ? "" : " " + shards);
+                    return new ManaCost(costStr);
+                }
+            }
+        }
+        return base;
     }
 
     public final ColorSet getColor() {


### PR DESCRIPTION
## Summary
- Commander tax isn't technically a perpetual effect, but the perpetual overlay was added to answer "what does this card actually cost?" — commander tax is the most common reason a commander's cost differs from its printed cost, so it fits naturally here and a separate overlay setting isn't justified
- When the "perpetual mana cost" overlay is enabled, commanders in the command zone now display their mana cost including accumulated commander tax ({2} per previous cast from command zone)
- The tax is layered dynamically on top of any existing perpetual cost adjustments in the getter, keeping the perpetual calculation pipeline unchanged

## Design notes

**Scope:** The overlay shows permanent/intrinsic modifiers only (perpetual effects + commander tax), not external battlefield-state cost modifiers like Foundry Inspector. Similarly, cards that specifically offset commander tax — like Myth Unbound ({1} less per cast) or Liesa, Shroud of Dusk (pay life instead of tax) — are not reflected in the overlay. This is an existing limitation of the perpetual overlay — it has never accounted for external modifiers — and commander tax doesn't change that.

**View update trigger:** The mana cost overlay reads from a cached trackable property, so it needs an explicit `updateManaCostForView()` call to refresh. Three locations were considered:
- `Player.incCommanderCast()` — card is on the stack when this fires, so the zone-gated getter returns base cost (no effect)
- `GameAction.changeZone()` — multiple branches need the trigger, and `setPerpetual()` fires before the zone is set
- `Card.setZone()` — fires after zone assignment, single point for all transitions, gated behind `isCommander()`, consistent with the 50+ existing `view.update*()` calls in `Card.java`

`Card.setZone()` was chosen for simplicity and completeness.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)