### PR TITLE
Forward setUsedToPay highlights to network clients

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/view/arcane/CardPanel.java
+++ b/forge-gui-desktop/src/main/java/forge/view/arcane/CardPanel.java
@@ -304,7 +304,7 @@ public class CardPanel extends SkinnedPanel implements CardContainer, IDisposabl
         final int offset = isTapped() && (!noBorderPref || cardImgHasAlpha) ? 1 : 0;
 
         // Magenta outline for when card is chosen
-        if (matchUI.isUsedToPay(getCard())) {
+        if (matchUI.isHighlighted(getCard())) {
             g2d.setColor(Color.magenta);
             final int n2 = Math.max(1, Math.round(2 * cardWidth * CardPanel.SELECTED_BORDER_SIZE));
             g2d.fillRoundRect(cardXOffset - n2, (cardYOffset - n2) + offset, cardWidth + (n2 * 2), cardHeight + (n2 * 2), cornerSize + n2, cornerSize + n2);
@@ -577,7 +577,7 @@ public class CardPanel extends SkinnedPanel implements CardContainer, IDisposabl
             CardFaceSymbols.drawSymbol("phasing", g, stateXSymbols, ySymbols);
         }
 
-        if (matchUI.isUsedToPay(card)) {
+        if (matchUI.isHighlighted(card)) {
             CardFaceSymbols.drawSymbol("sacrifice", g, (cardXOffset + (cardWidth / 2)) - 20,
                     (cardYOffset + (cardHeight / 2)) - 20);
         }

--- a/forge-gui-mobile/src/forge/card/CardRenderer.java
+++ b/forge-gui-mobile/src/forge/card/CardRenderer.java
@@ -801,7 +801,7 @@ public class CardRenderer {
             CardFaceSymbols.drawSymbol("defend", g, combatXSymbols, ySymbols, otherSymbolsSize, otherSymbolsSize);
         }
 
-        if (MatchController.instance.isUsedToPay(card)) {
+        if (MatchController.instance.isHighlighted(card)) {
             float sacSymbolSize = otherSymbolsSize * 1.2f;
             CardFaceSymbols.drawSymbol("sacrifice", g, (x + (w / 2)) - sacSymbolSize / 2, (y + (h / 2)) - sacSymbolSize / 2, otherSymbolsSize, otherSymbolsSize);
         }
@@ -815,7 +815,7 @@ public class CardRenderer {
             g.fillRect(FSkinColor.getStandardColor(Color.BLACK).alphaColor(0.6f), cx, cy, cw, ch);
         }
         //Magenta outline when card is chosen
-        if (MatchController.instance.isUsedToPay(card)) {
+        if (MatchController.instance.isHighlighted(card)) {
             g.drawRect(BORDER_THICKNESS, Color.MAGENTA, cx, cy, cw, ch);
         }
         //Ability Icons

--- a/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
@@ -1,6 +1,7 @@
 package forge.gamemodes.match;
 
 import com.google.common.collect.*;
+import forge.game.GameEntityView;
 import forge.game.GameLog;
 import forge.game.GameView;
 import forge.game.card.CardView;
@@ -278,33 +279,24 @@ public abstract class AbstractGuiGame implements IGuiGame, IMayViewCards {
         }
     }
 
-    private final Set<PlayerView> highlightedPlayers = Sets.newHashSet();
+    private final Set<GameEntityView> highlighted = Sets.newHashSet();
 
     @Override
-    public void setHighlighted(final PlayerView pv, final boolean b) {
-        final boolean hasChanged = b ? highlightedPlayers.add(pv) : highlightedPlayers.remove(pv);
+    public void setHighlighted(final GameEntityView gv, final boolean b) {
+        final boolean hasChanged = b ? highlighted.add(gv) : highlighted.remove(gv);
         if (hasChanged) {
-            updateLives(Collections.singleton(pv));
+            if (gv instanceof PlayerView pv) {
+                updateLives(Collections.singleton(pv));
+            }
+            if (gv instanceof CardView cv) {
+                // since we are in UI thread, may redraw the card right now
+                updateSingleCard(cv);
+            }
         }
     }
 
-    public boolean isHighlighted(final PlayerView player) {
-        return highlightedPlayers.contains(player);
-    }
-
-    private final Set<CardView> highlightedCards = Sets.newHashSet();
-
-    // used to highlight cards in UI
-    @Override
-    public void setUsedToPay(final CardView card, final boolean value) {
-        final boolean hasChanged = value ? highlightedCards.add(card) : highlightedCards.remove(card);
-        if (hasChanged) { // since we are in UI thread, may redraw the card right now
-            updateSingleCard(card);
-        }
-    }
-
-    public boolean isUsedToPay(final CardView card) {
-        return highlightedCards.contains(card);
+    public boolean isHighlighted(final GameEntityView ge) {
+        return highlighted.contains(ge);
     }
 
     private final Set<CardView> selectableCards = Sets.newHashSet();

--- a/forge-gui/src/main/java/forge/gamemodes/match/input/InputAttack.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/input/InputAttack.java
@@ -29,7 +29,6 @@ import forge.game.combat.CombatUtil;
 import forge.game.event.GameEventCombatUpdate;
 import forge.game.keyword.Keyword;
 import forge.game.player.Player;
-import forge.game.player.PlayerView;
 import forge.game.staticability.StaticAbilityMustAttack;
 import forge.game.zone.ZoneType;
 import forge.gui.events.UiEventAttackerDeclared;
@@ -288,7 +287,7 @@ public class InputAttack extends InputSyncronizedBase {
 
     private boolean undeclareAttacker(final Card card) {
         combat.removeFromCombat(card);
-        getController().getGui().setUsedToPay(CardView.get(card), false);
+        getController().getGui().setHighlighted(CardView.get(card), false);
         // When removing an attacker clear the attacking band
         activateBand(null);
 
@@ -300,12 +299,7 @@ public class InputAttack extends InputSyncronizedBase {
     private void setCurrentDefender(final GameEntity def) {
         currentDefender = def;
         for (final GameEntity ge : defenders) {
-            if (ge instanceof Card) {
-                getController().getGui().setUsedToPay(CardView.get((Card) ge), ge == def);
-            }
-            else if (ge instanceof Player) {
-                getController().getGui().setHighlighted(PlayerView.get((Player) ge), ge == def);
-            }
+            getController().getGui().setHighlighted(GameEntityView.get(ge), ge == def);
         }
         if (def != null) {
             potentialBanding = isBandingPossible();
@@ -317,14 +311,14 @@ public class InputAttack extends InputSyncronizedBase {
     private void activateBand(final AttackingBand band) {
         if (activeBand != null) {
             for (final Card card : activeBand.getAttackers()) {
-                getController().getGui().setUsedToPay(CardView.get(card), false);
+                getController().getGui().setHighlighted(CardView.get(card), false);
             }
         }
         activeBand = band;
 
         if (activeBand != null) {
             for (final Card card : activeBand.getAttackers()) {
-                getController().getGui().setUsedToPay(CardView.get(card), true);
+                getController().getGui().setHighlighted(CardView.get(card), true);
             }
         }
     }

--- a/forge-gui/src/main/java/forge/gamemodes/match/input/InputBlock.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/input/InputBlock.java
@@ -129,8 +129,7 @@ public class InputBlock extends InputSyncronizedBase {
                         if (isCorrectAction) {
                             combat.addBlocker(currentAttacker, card);
                             card.getGame().getMatch().fireEvent(new UiEventBlockerAssigned(
-                                    CardView.get(card),
-                                    CardView.get(currentAttacker)));
+                                    CardView.get(card), CardView.get(currentAttacker)));
                         }
                     }
                 }
@@ -163,11 +162,11 @@ public class InputBlock extends InputSyncronizedBase {
 
     private void setCurrentAttacker(final Card card) {
         if (currentAttacker != null) {
-            getController().getGui().setUsedToPay(CardView.get(currentAttacker), false);
+            getController().getGui().setHighlighted(CardView.get(currentAttacker), false);
         }
         currentAttacker = card;
         if (card != null) {
-            getController().getGui().setUsedToPay(CardView.get(card), true);
+            getController().getGui().setHighlighted(CardView.get(card), true);
         }
     }
 }

--- a/forge-gui/src/main/java/forge/gamemodes/match/input/InputLondonMulligan.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/input/InputLondonMulligan.java
@@ -133,12 +133,12 @@ public class InputLondonMulligan extends InputSyncronizedBase {
     }
 
     private void setCardHighlight(final Card card, final boolean state) {
-        getController().getGui().setUsedToPay(card.getView(), state);
+        getController().getGui().setHighlighted(card.getView(), state);
     }
 
     private void resetCardHighlights() {
         for (final Card c : selected) {
-            getController().getGui().setUsedToPay(c.getView(), false);
+            getController().getGui().setHighlighted(c.getView(), false);
         }
     }
 }

--- a/forge-gui/src/main/java/forge/gamemodes/match/input/InputSelectManyBase.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/input/InputSelectManyBase.java
@@ -2,10 +2,8 @@ package forge.gamemodes.match.input;
 
 import com.google.common.collect.Iterables;
 import forge.game.GameEntity;
-import forge.game.card.Card;
+import forge.game.GameEntityView;
 import forge.game.card.CardView;
-import forge.game.player.Player;
-import forge.game.player.PlayerView;
 import forge.game.spellability.SpellAbility;
 import forge.localinstance.properties.ForgePreferences;
 import forge.model.FModel;
@@ -125,23 +123,13 @@ public abstract class InputSelectManyBase<T extends GameEntity> extends InputSyn
         this.message = message0;
     }
 
-    protected void onSelectStateChanged(final GameEntity c, final boolean newState) {
-        if (c instanceof Card) {
-            getController().getGui().setUsedToPay(CardView.get((Card) c), newState); // UI supports card highlighting though this abstraction-breaking mechanism
-        }
-        else if (c instanceof Player) {
-            getController().getGui().setHighlighted(PlayerView.get((Player) c), newState);
-        }
+    protected void onSelectStateChanged(final GameEntity ge, final boolean newState) {
+        getController().getGui().setHighlighted(GameEntityView.get(ge), newState);
     }
 
     private void resetUsedToPay() {
-        for (final GameEntity c : getSelected()) {
-            if (c instanceof Card) {
-                getController().getGui().setUsedToPay(CardView.get((Card) c), false);
-            }
-            else if (c instanceof Player) {
-                getController().getGui().setHighlighted(PlayerView.get((Player) c), false);
-            }
+        for (final GameEntity ge : getSelected()) {
+            getController().getGui().setHighlighted(GameEntityView.get(ge), false);
         }
     }
 

--- a/forge-gui/src/main/java/forge/gamemodes/match/input/InputSelectTargets.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/input/InputSelectTargets.java
@@ -4,12 +4,12 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import forge.game.GameEntity;
+import forge.game.GameEntityView;
 import forge.game.GameObject;
 import forge.game.ability.ApiType;
 import forge.game.card.Card;
 import forge.game.card.CardView;
 import forge.game.player.Player;
-import forge.game.player.PlayerView;
 import forge.game.spellability.SpellAbility;
 import forge.game.spellability.TargetRestrictions;
 import forge.gui.FThreads;
@@ -71,7 +71,7 @@ public final class InputSelectTargets extends InputSyncronizedBase {
         FThreads.invokeInEdtNowOrLater(() -> {
             for (final GameEntity c : targets) {
                 if (c instanceof Card) {
-                    controller.getGui().setUsedToPay(CardView.get((Card) c), true);
+                    controller.getGui().setHighlighted(GameEntityView.get(c), true);
                 }
             }
             controller.getGui().updateZones(zonesToUpdate);
@@ -382,14 +382,11 @@ public final class InputSelectTargets extends InputSyncronizedBase {
 
     private void addTarget(final GameEntity ge) {
         sa.getTargets().add(ge);
-        if (ge instanceof Card) {
-            getController().getGui().setUsedToPay(CardView.get((Card) ge), true);
-            lastTarget = (Card) ge;
-        }
-        else if (ge instanceof Player) {
-            getController().getGui().setHighlighted(PlayerView.get((Player) ge), true);
-        }
         targets.add(ge);
+        if (ge instanceof Card c) {
+            lastTarget = c;
+        }
+        getController().getGui().setHighlighted(GameEntityView.get(ge), true);
 
         if (hasAllTargets()) {
             bOk = true;
@@ -410,27 +407,19 @@ public final class InputSelectTargets extends InputSyncronizedBase {
         }
         targets.remove(ge);
         sa.getTargets().remove(ge);
-        if (ge instanceof Card c) {
-            getController().getGui().setUsedToPay(CardView.get(c), false);
+        if (ge instanceof Card) {
             // try to get last selected card
             lastTarget = Iterables.getLast(IterableUtil.filter(targets, Card.class), null);
         }
-        else if (ge instanceof Player p) {
-            getController().getGui().setHighlighted(PlayerView.get(p), false);
-        }
+        getController().getGui().setHighlighted(GameEntityView.get(ge), false);
 
         this.showMessage();
     }
 
     private void done() {
-        for (final GameEntity c : targets) {
+        for (final GameEntity ge : targets) {
             //getController().macros().addRememberedAction(new TargetEntityAction(c.getView()));
-            if (c instanceof Card) {
-                getController().getGui().setUsedToPay(CardView.get((Card) c), false);
-            }
-            else if (c instanceof Player) {
-                getController().getGui().setHighlighted(PlayerView.get((Player) c), false);
-            }
+            getController().getGui().setHighlighted(GameEntityView.get(ge), false);
         }
 
         this.stop();

--- a/forge-gui/src/main/java/forge/gamemodes/net/ProtocolMethod.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/ProtocolMethod.java
@@ -73,7 +73,7 @@ public enum ProtocolMethod {
     setRememberedActions(Mode.SERVER, Void.TYPE),
     nextRememberedAction(Mode.SERVER, Void.TYPE),
     showWaitingTimer    (Mode.SERVER, Void.TYPE, PlayerView.class, String.class),
-    setUsedToPay        (Mode.SERVER, Void.TYPE, CardView.class, Boolean.TYPE),
+    setHighlighted      (Mode.SERVER, Void.TYPE, GameEntityView.class, Boolean.TYPE),
     handleGameEvents    (Mode.SERVER, Void.TYPE, List.class),
 
     // Client -> Server

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/NetGuiGame.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/NetGuiGame.java
@@ -279,9 +279,9 @@ public class NetGuiGame extends AbstractGuiGame {
     }
 
     @Override
-    public void setUsedToPay(final CardView card, final boolean value) {
-        super.setUsedToPay(card, value);
-        send(ProtocolMethod.setUsedToPay, card, value);
+    public void setHighlighted(final GameEntityView ge, final boolean value) {
+        super.setHighlighted(ge, value);
+        send(ProtocolMethod.setHighlighted, ge, value);
     }
 
     @Override

--- a/forge-gui/src/main/java/forge/gui/interfaces/IGuiGame.java
+++ b/forge-gui/src/main/java/forge/gui/interfaces/IGuiGame.java
@@ -234,9 +234,7 @@ public interface IGuiGame {
 
     void restoreOldZones(PlayerView playerView, PlayerZoneUpdates playerZoneUpdates);
 
-    void setHighlighted(PlayerView pv, boolean b);
-
-    void setUsedToPay(CardView card, boolean value);
+    void setHighlighted(GameEntityView pv, boolean b);
 
     void setSelectables(final Iterable<CardView> cards);
 


### PR DESCRIPTION
**Remote network clients currently don't get the blocker assignment highlight during declare blockers phase.**

`InputBlock.setCurrentAttacker()` calls `setUsedToPay()` to highlight the selected attacker, but this only reaches the host's local GUI. `InputBlock` runs on the host as part of the game engine, so the host's `PlayerControllerHuman.getGui()` returns its local `CMatchUI`. For the remote client player, `getGui()` returns `NetGuiGame` — but `setUsedToPay` was missing from the network protocol, so the call was silently absorbed without forwarding to the client.

<img width="50%" height="674" alt="Screenshot 2026-04-04 133227" src="https://github.com/user-attachments/assets/c0af02f4-0351-4d9c-b0e7-2b9277821bb1" />

## Solution

- Add `setUsedToPay` to `ProtocolMethod` and override in `NetGuiGame` to forward to clients.

- Simplify `InputBlock.setCurrentAttacker` to track previous/new selection instead of looping all attackers — The old setCurrentAttacker looped over all attackers, calling setUsedToPay once per attacker to clear all highlights then set the new one. Since setUsedToPay is now a protocol message, that loop would send N messages when only 2 matter (unhighlight old, highlight new). Replaced the loop with explicit previous/new tracking to avoid the redundant sends. This is safe because InputBlock only ever has one selected attacker at a time, stored in the currentAttacker field.

- Side benefit: also enables other highlights in network play that were previously host-only (attacker/defender selection, target highlighting, London mulligan selection)

## Alternatives considered

The core challenge is that `setUsedToPay` is driven by `InputBlock` on the host, which has access to the game engine - it knows which attackers exist, which can be legally blocked, and which is currently selected. The remote client has none of this context. 

So there are fundamentally two approaches: transmit across the network boundary, or attempt to recreate it client-side with a heuristic that can't access engine state. The latter approach requires significantly more code and can never be fully accurate (e.g. it can't check blocking legality). Transmitting is simpler and correct by construction.

The following alternative options were considered:

- **Client-side heuristic + selectCard sync** (~65 lines, 3 files) — CMatchUI auto-selects an attacker visually and sends `selectCard` to sync with host. No protocol change needed, but the heuristic can't check blocking legality (e.g. flying) and may highlight an unblockable attacker.
- **Client-side only, no sync** (~65 lines, 2 files) — CMatchUI auto-selects visually with no host communication. Visual hint can desync from host's actual blocker assignment so when client declares a blocker it is assigned against an attacker they did not intend.
- **New `highlightAttacker` protocol method** (~15 lines, 7 files) — Purpose-built method across `IGuiGame`, `ProtocolMethod`, `NetGuiGame`, and implementations. Adds a new interface method for a narrow use case.
- **Piggyback on `showCombat` parameter** (~20 lines, 7 files) — Pass the selected attacker as a parameter to `showCombat()`. Changes an existing interface signature across all implementations and callers.
- **Forward `setUsedToPay` via protocol** (chosen, 10 lines, 3 files) — Reuses existing `IGuiGame` method. Host remains authoritative with no engine changes. Smallest diff by far.

## Network cost

Network cost is trivial — each message is a CardView reference + boolean. `setCurrentAttacker` sends at most 2 messages (unhighlight previous, highlight new) rather than iterating all attackers. On the receiving end, `AbstractGuiGame.setUsedToPay` short-circuits redundant calls. `setUsedToPay` is transient UI state, not persistent game model state. The protocol message is fire-and-forget, same as `setPanelSelection` or `setSelectables`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)