### PR TITLE
Add pick two option to draft file

### DIFF
--- a/forge-gui/res/cube/Absolute Beginner Cube.dck
+++ b/forge-gui/res/cube/Absolute Beginner Cube.dck
@@ -1,0 +1,183 @@
+[metadata]
+name=Absolute Beginner Cube
+[Main]
+1 Healer's Hawk|FDN
+1 Healer's Hawk|FDN
+1 Rustwing Falcon|M19
+1 Savannah Lions|J25
+1 Savannah Lions|J25
+1 Savannah Lions|J25
+1 Alpine Watchdog|PLST
+1 Capashen Knight|M14
+1 Cathar Commando|INR
+1 Impassioned Orator|M20
+1 Knight of Glory|M13
+1 Mandible Justiciar|ONE
+1 Dazzling Angel|FDN
+1 Dazzling Angel|FDN
+1 Militant Inquisitor|J25
+1 Serra Angel|M12
+1 Serra's Guardian|M20
+1 Inspired Charge|MOM
+1 Inspired Charge|MOM
+1 Smite the Monstrous|ZNR
+1 Smite the Monstrous|ZNR
+1 Righteous Charge|GTC
+1 Holy Strength|M10
+1 Pacifism|J25
+1 Pacifism|J25
+1 Pacifism|J25
+1 Aegis Turtle|FDN
+1 Triton Shorestalker|OTC
+1 Triton Shorestalker|OTC
+1 Malcator's Watcher|J25
+1 Omenspeaker|CMR
+1 Chrome Prowler|J25
+1 Cloudkin Seer|J25
+1 Cloudkin Seer|J25
+1 Frost Lynx|IKO
+1 Man-o'-War|MH1
+1 Man-o'-War|MH1
+1 Stealer of Secrets|DDM
+1 Arcanis the Omnipotent|FDN
+1 Tolarian Terror|FDN
+1 Opt|TDC
+1 Opt|TDC
+1 Unsummon|M13
+1 Unsummon|M13
+1 Unsummon|M13
+1 Essence Scatter|DMU
+1 Essence Scatter|DMU
+1 Mordenkainen's Polymorph|AFR
+1 Cancel|M21
+1 Divination|PLST
+1 Divination|PLST
+1 Curiosity|JMP
+1 Typhoid Rats|J22
+1 Typhoid Rats|J22
+1 Vampire of the Dire Moon|J25
+1 Vampire of the Dire Moon|J25
+1 Child of Night|JMP
+1 Child of Night|JMP
+1 Knight of Infamy|M13
+1 Crow of Dark Tidings|J22
+1 Marauding Blight-Priest|J22
+1 Marauding Blight-Priest|J22
+1 Servant of Nefarox|M13
+1 Falkenrath Noble|J25
+1 Perilous Shadow|RTR
+1 Nefarox, Overlord of Grixis|M13
+1 Lash of Thorns|ELD
+1 Corpse Churn|CLU
+1 Doom Blade|GN3
+1 Doom Blade|GN3
+1 Last Gasp|JMP
+1 Last Gasp|JMP
+1 Murder|J25
+1 Disentomb|M13
+1 Zombify|A25
+1 No One Left Behind|BRO
+1 Unholy Strength|M10
+1 Mark of the Vampire|JMP
+1 Goblin Balloon Brigade|M11
+1 Raging Goblin|EVG
+1 Raging Goblin|EVG
+1 Raging Goblin|EVG
+1 Axgard Cavalry|FDN
+1 Axgard Cavalry|FDN
+1 Champion of the Flame|CMM
+1 Bladegraft Aspirant|ONE
+1 Boggart Brute|J25
+1 Boggart Brute|J25
+1 Breakneck Berserker|KHM
+1 Rummaging Goblin|J22
+1 Witty Roastmaster|SNC
+1 Keldon Raider|J25
+1 Rockslide Sorcerer|ZNR
+1 Shivan Dragon|M20
+1 Infuriate|J25
+1 Infuriate|J25
+1 Shock|SPM
+1 Shock|SPM
+1 Shock|SPM
+1 Lightning Strike|M19
+1 Lightning Strike|M19
+1 Soul's Fire|CMR
+1 Blaze|J22
+1 Act of Treason|RVR
+1 Llanowar Elves|M12
+1 Llanowar Elves|M12
+1 Llanowar Elves|M12
+1 Deadly Recluse|CMM
+1 Deadly Recluse|CMM
+1 Elvish Visionary|J25
+1 Flesh Burrower|DSK
+1 Daggerback Basilisk|PLST
+1 Grasping Longneck|DSK
+1 Bristling Boar|J22
+1 Bristling Boar|J22
+1 Colossadactyl|LCI
+1 Colossadactyl|LCI
+1 Aggressive Mammoth|FDN
+1 Colossal Dreadmaw|J25
+1 Colossal Dreadmaw|J25
+1 Giant Growth|J25
+1 Giant Growth|J25
+1 Return to Nature|PLST
+1 Broken Wings|ZNR
+1 Commune with Nature|MM2
+1 Rabid Bite|GN3
+1 Rabid Bite|GN3
+1 Rampant Growth|TDC
+1 Rampant Growth|TDC
+1 Overrun|SCD
+1 Crashing Drawbridge|TDC
+1 Hovermyr|NPH
+1 Hovermyr|NPH
+1 Hovermyr|NPH
+1 Manakin|J22
+1 Manakin|J22
+1 Perilous Myr|CMR
+1 Suspicious Bookcase|SNC
+1 Suspicious Bookcase|SNC
+1 Alloy Myr|JMP
+1 Alloy Myr|JMP
+1 Skyscanner|SCD
+1 Skyscanner|SCD
+1 Iron Golem|AFR
+1 Steel Hellkite|FDN
+1 Bonesplitter|CMR
+1 Short Sword|M21
+1 Short Sword|M21
+1 Short Sword|M21
+1 Cobbled Wings|XLN
+1 Cobbled Wings|XLN
+1 Gorgon Flail|J25
+1 Gorgon Flail|J25
+1 Prophetic Prism|J25
+1 Prophetic Prism|J25
+1 Vulshok Morningstar|DDI
+1 Vulshok Morningstar|DDI
+1 Fireshrieker|J25
+1 Haunted Cloak|CMM
+1 Haunted Cloak|CMM
+1 Ash Barrens|TDC
+1 Barren Moor|DSC
+1 Escape Tunnel|EOC
+1 Evolving Wilds|ECL
+1 Evolving Wilds|M20
+1 Forgotten Cave|J25
+1 Lonely Sandbar|SLD
+1 Secluded Steppe|EOC
+1 Shimmering Grotto|IMA
+1 Thriving Bluff|ECC
+1 Thriving Bluff|ECC
+1 Thriving Grove|ECC
+1 Thriving Grove|ECC
+1 Thriving Heath|ECC
+1 Thriving Heath|ECC
+1 Thriving Isle|ECC
+1 Thriving Isle|ECC
+1 Thriving Moor|ECC
+1 Thriving Moor|ECC
+1 Tranquil Thicket|DSC

--- a/forge-gui/res/draft/Absolute Beginners Cube.draft
+++ b/forge-gui/res/draft/Absolute Beginners Cube.draft
@@ -1,0 +1,8 @@
+Name:Absolute Beginners Cube
+DeckFile:Absolute Beginners Cube
+Singleton:True
+
+Booster: 15 Any
+NumPacks: 3
+NumPlayers: 4
+PickTwo: True

--- a/forge-gui/res/draft/Adam Styborkski's Pauper Cube.draft
+++ b/forge-gui/res/draft/Adam Styborkski's Pauper Cube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Amaz Peasant Cube.draft
+++ b/forge-gui/res/draft/Amaz Peasant Cube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Arena Powered Cube v3.0 2026-03.draft
+++ b/forge-gui/res/draft/Arena Powered Cube v3.0 2026-03.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Ben's Cube.draft
+++ b/forge-gui/res/draft/Ben's Cube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Bun Magic Cube.draft
+++ b/forge-gui/res/draft/Bun Magic Cube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Caleb Gannon's Powered Synergy Cube.draft
+++ b/forge-gui/res/draft/Caleb Gannon's Powered Synergy Cube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Card Kingdom Starter Cube v3.draft
+++ b/forge-gui/res/draft/Card Kingdom Starter Cube v3.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Cube Tutor 360 Pauper.draft
+++ b/forge-gui/res/draft/Cube Tutor 360 Pauper.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Cube Tutor 720.draft
+++ b/forge-gui/res/draft/Cube Tutor 720.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Cultic.draft
+++ b/forge-gui/res/draft/Cultic.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Dekkaru Cube.draft
+++ b/forge-gui/res/draft/Dekkaru Cube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Elliot Raff's Khans Expanded Cube (MTGO).draft
+++ b/forge-gui/res/draft/Elliot Raff's Khans Expanded Cube (MTGO).draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Eric Klug's Pro Tour Cube.draft
+++ b/forge-gui/res/draft/Eric Klug's Pro Tour Cube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Frontier.draft
+++ b/forge-gui/res/draft/Frontier.draft
@@ -6,3 +6,4 @@ LandSetCode:BFZ
 Booster: 15 Any  
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Guillaume Matignon's Jenny's-Johnny's Cube.draft
+++ b/forge-gui/res/draft/Guillaume Matignon's Jenny's-Johnny's Cube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Hypercube (383 cards).draft
+++ b/forge-gui/res/draft/Hypercube (383 cards).draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Jim Davis's Cube.draft
+++ b/forge-gui/res/draft/Jim Davis's Cube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Jospeh Vasoli's Peasant Cube.draft
+++ b/forge-gui/res/draft/Jospeh Vasoli's Peasant Cube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/LSVCube.draft
+++ b/forge-gui/res/draft/LSVCube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Legendary Cube April 2016.draft
+++ b/forge-gui/res/draft/Legendary Cube April 2016.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Legendary Cube.draft
+++ b/forge-gui/res/draft/Legendary Cube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTG Arena Chromatic Cube June 24.draft
+++ b/forge-gui/res/draft/MTG Arena Chromatic Cube June 24.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGA Cube 2020 April.draft
+++ b/forge-gui/res/draft/MTGA Cube 2020 April.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGACube.draft
+++ b/forge-gui/res/draft/MTGACube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Core Cube 2018 (540 cards).draft
+++ b/forge-gui/res/draft/MTGO Core Cube 2018 (540 cards).draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Cube 2014-03.draft
+++ b/forge-gui/res/draft/MTGO Cube 2014-03.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Grixis Cube (540 Cards).draft
+++ b/forge-gui/res/draft/MTGO Grixis Cube (540 Cards).draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Grixis Cube 2019-09 (540 Cards).draft
+++ b/forge-gui/res/draft/MTGO Grixis Cube 2019-09 (540 Cards).draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Khans Expanded Cube.draft
+++ b/forge-gui/res/draft/MTGO Khans Expanded Cube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Legacy Cube 2015-03.draft
+++ b/forge-gui/res/draft/MTGO Legacy Cube 2015-03.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Legacy Cube 2015-09.draft
+++ b/forge-gui/res/draft/MTGO Legacy Cube 2015-09.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Legacy Cube 2016-01.draft
+++ b/forge-gui/res/draft/MTGO Legacy Cube 2016-01.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Legacy Cube 2016-09.draft
+++ b/forge-gui/res/draft/MTGO Legacy Cube 2016-09.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Legacy Cube 2017-01.draft
+++ b/forge-gui/res/draft/MTGO Legacy Cube 2017-01.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Legacy Cube 2017-04.draft
+++ b/forge-gui/res/draft/MTGO Legacy Cube 2017-04.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Legacy Cube 2018-02.draft
+++ b/forge-gui/res/draft/MTGO Legacy Cube 2018-02.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Legacy Cube 2019-07.draft
+++ b/forge-gui/res/draft/MTGO Legacy Cube 2019-07.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Legacy Cube 2021-05.draft
+++ b/forge-gui/res/draft/MTGO Legacy Cube 2021-05.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Legacy Cube 2021-08.draft
+++ b/forge-gui/res/draft/MTGO Legacy Cube 2021-08.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Legacy Cube.draft
+++ b/forge-gui/res/draft/MTGO Legacy Cube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2013.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2013.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2014.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2014.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2015.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2015.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2016-06.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2016-06.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2016-11.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2016-11.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2016.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2016.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2017-06.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2017-06.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2017-12.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2017-12.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2017.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2017.draft
@@ -6,3 +6,4 @@ LandSetCode:RTR
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2018-06.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2018-06.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2018-12.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2018-12.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2019 Summer.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2019 Summer.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2019-06.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2019-06.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2019-12.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2019-12.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2020-04.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2020-04.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2020-07.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2020-07.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2020-12.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2020-12.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2021-07.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2021-07.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2022-02.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2022-02.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2023-05.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2023-05.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2023-08.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2023-08.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2023-10.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2023-10.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2024-02.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2024-02.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2024-06.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2024-06.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2025-04.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2025-04.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/MTGO Vintage Cube 2025-12.draft
+++ b/forge-gui/res/draft/MTGO Vintage Cube 2025-12.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Modern Cube 2017.draft
+++ b/forge-gui/res/draft/Modern Cube 2017.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Mono Blue Cube.draft
+++ b/forge-gui/res/draft/Mono Blue Cube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Old School 93-94 (540 Cards, Cube Cobra).draft
+++ b/forge-gui/res/draft/Old School 93-94 (540 Cards, Cube Cobra).draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Old School 93-94 Craig Wescoe's Cube (Cube Cobra).draft
+++ b/forge-gui/res/draft/Old School 93-94 Craig Wescoe's Cube (Cube Cobra).draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Old School 93-94 Magic Full Set 878 Card Cube.draft
+++ b/forge-gui/res/draft/Old School 93-94 Magic Full Set 878 Card Cube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Old School 93-94 Magic Powered 360 Card Cube.draft
+++ b/forge-gui/res/draft/Old School 93-94 Magic Powered 360 Card Cube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Old School 93-94 Magic Unpowered 400 Card Cube.draft
+++ b/forge-gui/res/draft/Old School 93-94 Magic Unpowered 400 Card Cube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Old School 93-95 (360 Cards, Cube Cobra).draft
+++ b/forge-gui/res/draft/Old School 93-95 (360 Cards, Cube Cobra).draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Old School 98 (350 Cards, Cube Cobra).draft
+++ b/forge-gui/res/draft/Old School 98 (350 Cards, Cube Cobra).draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Old School Alpha, Beta and 4 Horsemen (360 Cards, Cube Cobra).draft
+++ b/forge-gui/res/draft/Old School Alpha, Beta and 4 Horsemen (360 Cards, Cube Cobra).draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Old School Classically Trained - The First Five (Cube Cobra).draft
+++ b/forge-gui/res/draft/Old School Classically Trained - The First Five (Cube Cobra).draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Pioneer Cube.draft
+++ b/forge-gui/res/draft/Pioneer Cube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Regular Cube.draft
+++ b/forge-gui/res/draft/Regular Cube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Ryan Overturf's Grixis Cube (MTGO).draft
+++ b/forge-gui/res/draft/Ryan Overturf's Grixis Cube (MTGO).draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/SCG Con Cube 2018 December.draft
+++ b/forge-gui/res/draft/SCG Con Cube 2018 December.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Sam Black's No Search Cube.draft
+++ b/forge-gui/res/draft/Sam Black's No Search Cube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/The Arena Cube.draft
+++ b/forge-gui/res/draft/The Arena Cube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/The Modern Cube.draft
+++ b/forge-gui/res/draft/The Modern Cube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/The Original Recipe Twobert.draft
+++ b/forge-gui/res/draft/The Original Recipe Twobert.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 9 Any
 NumPacks: 5
 NumPlayers: 4
+PickTwo: False

--- a/forge-gui/res/draft/The Pauper Cube 2023-06.draft
+++ b/forge-gui/res/draft/The Pauper Cube 2023-06.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/The Pauper Cube 2026-02.draft
+++ b/forge-gui/res/draft/The Pauper Cube 2026-02.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/The Peasant Cube 2023 (June).draft
+++ b/forge-gui/res/draft/The Peasant Cube 2023 (June).draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/The Peasant's Toolbox.draft
+++ b/forge-gui/res/draft/The Peasant's Toolbox.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Timothee Simonot's Twisted Color Pie Cube.draft
+++ b/forge-gui/res/draft/Timothee Simonot's Twisted Color Pie Cube.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/Wtwlf123 Powered Cube (540 cards).draft
+++ b/forge-gui/res/draft/Wtwlf123 Powered Cube (540 cards).draft
@@ -4,3 +4,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/cube_juzamjedi.draft
+++ b/forge-gui/res/draft/cube_juzamjedi.draft
@@ -5,3 +5,4 @@ LandSetCode:M11
 Booster: 5 Rare, 1 Mythic, 5 Common, 5 Uncommon
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/cube_skiera.draft
+++ b/forge-gui/res/draft/cube_skiera.draft
@@ -6,3 +6,4 @@ LandSetCode:M11
 Booster: 16 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/res/draft/www.mtgcube.com.draft
+++ b/forge-gui/res/draft/www.mtgcube.com.draft
@@ -5,3 +5,4 @@ Singleton:True
 Booster: 15 Any
 NumPacks: 3
 NumPlayers: 8
+PickTwo: False

--- a/forge-gui/src/main/java/forge/gamemodes/limited/BoosterDraft.java
+++ b/forge-gui/src/main/java/forge/gamemodes/limited/BoosterDraft.java
@@ -395,6 +395,8 @@ public class BoosterDraft implements IBoosterDraft {
         final int minPlayers = 2;
         final int maxPlayers = 8;
 
+        boolean pickTwo = draft.isPickTwo();
+
         // Check if numPlayers is set in draft file, if not default to 8.
         if (players == 0) {
             players = N_PLAYERS;
@@ -404,6 +406,12 @@ public class BoosterDraft implements IBoosterDraft {
         }
 
         setPodSize(players);
+
+        if (pickTwo) {
+            this.doublePickDuringDraft = DraftOptions.DoublePick.ALWAYS;
+        } else {
+            this.doublePickDuringDraft = DraftOptions.DoublePick.NEVER;
+        }
 
         final UnOpenedProduct toAdd = new UnOpenedProduct(tpl, dPool);
         toAdd.setLimitedPool(draft.isSingleton());

--- a/forge-gui/src/main/java/forge/gamemodes/limited/CustomLimited.java
+++ b/forge-gui/src/main/java/forge/gamemodes/limited/CustomLimited.java
@@ -74,6 +74,8 @@ public class CustomLimited extends DeckBase {
 
     private boolean singleton;
 
+    private boolean pickTwo;
+
     /** Name of the file containing custom card rankings. */
     private String customRankingsFile = "";
 
@@ -119,6 +121,7 @@ public class CustomLimited extends DeckBase {
         cd.numPacks = data.getInt("NumPacks");
         cd.singleton = data.getBoolean("Singleton");
         cd.numPlayers = data.getInt("NumPlayers");
+        cd.pickTwo = data.getBoolean("PickTwo");
         cd.customRankingsFile = data.get("CustomRankings", "rankings_cubecobra.txt");
         final Deck deckCube = cubes.get(data.get("DeckFile"));
         cd.cardPool = deckCube == null ? ItemPool.createFrom(FModel.getMagicDb().getCommonCards().getUniqueCards(), PaperCard.class) : deckCube.getMain();
@@ -213,6 +216,12 @@ public class CustomLimited extends DeckBase {
     }
 
     public void setSingleton(boolean bIn) { this.singleton = bIn; }
+
+    public boolean isPickTwo() {
+        return pickTwo;
+    }
+
+    public void setPickTwo(boolean bIn) { this.pickTwo = bIn; }
 
     public String getCustomRankingsFileName() {
         return customRankingsFile;


### PR DESCRIPTION
- Added code to support Pick Two draft in custom cube
- Added example cube (Absolute Beginners Cube)
- Updated all cube .draft files to include the new PickTwo field