### PR TITLE
Fix multiplayer freeze on spells with non-mana optional costs

### DIFF
--- a/forge-game/src/main/java/forge/game/cost/CostPartWithList.java
+++ b/forge-game/src/main/java/forge/game/cost/CostPartWithList.java
@@ -35,7 +35,14 @@ public abstract class CostPartWithList extends CostPart {
 
     private boolean intrinsic = true;
 
-    protected final CardZoneTable table = new CardZoneTable();
+    // transient: only used server-side during cost payment, never needed by the client.
+    // CardZoneTable is not Serializable and must not enter the network serialization graph.
+    protected transient CardZoneTable table = new CardZoneTable();
+
+    private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        table = new CardZoneTable();
+    }
 
     public final CardCollectionView getLKIList() {
         return lkiList;


### PR DESCRIPTION
## Summary

Fixes https://github.com/Card-Forge/forge/issues/10276 — Multiplayer freeze when a remote client casts a spell with non-mana optional costs (Bargain, Retrace, Jump-start, or any optional cost involving sacrifice/discard/exile).

## Root Cause

`CostPartWithList.table` is a `CardZoneTable` field that does not implement `Serializable`. When the server sends optional cost choices to a remote client via `getChoices`, the `OptionalCostValue → Cost → CostPart` chain is serialized by Java's `ObjectOutputStream`. If any cost part extends `CostPartWithList` (e.g. `CostSacrifice`, `CostDiscard`, `CostExile`), the non-serializable `CardZoneTable` enters the serialization graph, causing `NotSerializableException`. The server thread then blocks permanently in `sendAndWait`, freezing the game.

## Testing

**Reproducing the original report:** The reported crash occurred casting Grow From the Ashes (kicker {2}) in a 4-player EDH game. Testing with that card alone did **not** trigger the crash — kicker {2} creates only `CostPartMana` which serializes fine. The original game log shows the same kicker path succeeded for Mold Shambler 11 minutes earlier in the same game. The exact trigger likely involves a card on the battlefield (possibly an AI player's) that modified the optional cost list, but the full board state cannot be determined from the logs.

**Confirming the serialization bug:** Casting a card with **Bargain** (e.g. Torch the Tower) from a remote client reliably reproduces the exact error: `NotSerializableException: forge.game.card.CardZoneTable` on the `getChoices (6 args)` call, followed by permanent game freeze.

**Verifying the fix:** After making `CostPartWithList.table` transient, the Bargain card cast succeeds over the network without error.

## The Fix

Mark `CostPartWithList.table` as `transient` so it is excluded from serialization. Add a `readObject` method to reinitialize the field after deserialization.

The `table` field tracks zone changes during cost payment execution — a purely server-side operation. The client receives `CostPartWithList` objects only for display purposes (showing cost text in choice dialogs) and never accesses the `table` field. There are no downsides to this change.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)