### PR TITLE
Extend IdRef serialization from game events to protocol method args

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/net/CObjectInputStream.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/CObjectInputStream.java
@@ -1,15 +1,21 @@
 package forge.gamemodes.net;
 
+import forge.trackable.Tracker;
 import io.netty.handler.codec.serialization.ClassResolver;
 
 import java.io.*;
 
 public class CObjectInputStream extends ObjectInputStream {
     private final ClassResolver classResolver;
+    private final Tracker tracker;
 
-    CObjectInputStream(InputStream in, ClassResolver classResolver) throws IOException {
+    CObjectInputStream(InputStream in, ClassResolver classResolver, Tracker tracker) throws IOException {
         super(in);
         this.classResolver = classResolver;
+        this.tracker = tracker;
+        if (tracker != null) {
+            enableResolveObject(true);
+        }
     }
 
     @Override
@@ -34,5 +40,10 @@ public class CObjectInputStream extends ObjectInputStream {
             clazz = super.resolveClass(desc);
         }
         return clazz;
+    }
+
+    @Override
+    protected Object resolveObject(Object obj) throws IOException {
+        return TrackableRef.resolve(obj, tracker);
     }
 }

--- a/forge-gui/src/main/java/forge/gamemodes/net/CObjectOutputStream.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/CObjectOutputStream.java
@@ -8,8 +8,11 @@ import java.io.OutputStream;
 public class CObjectOutputStream extends ObjectOutputStream {
     static final int TYPE_THIN_DESCRIPTOR = 1;
 
-    CObjectOutputStream(OutputStream out) throws IOException {
+    CObjectOutputStream(OutputStream out, boolean replaceTrackables) throws IOException {
         super(out);
+        if (replaceTrackables) {
+            enableReplaceObject(true);
+        }
     }
 
     @Override
@@ -17,5 +20,10 @@ public class CObjectOutputStream extends ObjectOutputStream {
         //we only pass this and the decoder will lookup in the stream (faster method both mobile and desktop)
         write(TYPE_THIN_DESCRIPTOR);
         writeUTF(desc.getName());
+    }
+
+    @Override
+    protected Object replaceObject(Object obj) throws IOException {
+        return TrackableRef.replace(obj);
     }
 }

--- a/forge-gui/src/main/java/forge/gamemodes/net/CompatibleObjectDecoder.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/CompatibleObjectDecoder.java
@@ -1,6 +1,7 @@
 package forge.gamemodes.net;
 
 import forge.gui.GuiBase;
+import forge.trackable.Tracker;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.channel.ChannelHandlerContext;
@@ -9,11 +10,14 @@ import io.netty.handler.codec.serialization.ClassResolver;
 import net.jpountz.lz4.LZ4BlockInputStream;
 import org.tinylog.Logger;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.StreamCorruptedException;
 
 public class CompatibleObjectDecoder extends LengthFieldBasedFrameDecoder {
     private final ClassResolver classResolver;
+    private volatile Tracker tracker;
 
     public CompatibleObjectDecoder(ClassResolver classResolver) {
         this(1048576, classResolver);
@@ -22,6 +26,10 @@ public class CompatibleObjectDecoder extends LengthFieldBasedFrameDecoder {
     public CompatibleObjectDecoder(int maxObjectSize, ClassResolver classResolver) {
         super(maxObjectSize, 0, 4, 0, 4);
         this.classResolver = classResolver;
+    }
+
+    public void setTracker(Tracker tracker) {
+        this.tracker = tracker;
     }
 
     @Override
@@ -33,9 +41,16 @@ public class CompatibleObjectDecoder extends LengthFieldBasedFrameDecoder {
         }
         int frameSize = frame.readableBytes();
         long startMs = System.currentTimeMillis();
-        ObjectInputStream ois = GuiBase.hasPropertyConfig() ?
-                new ObjectInputStream(new LZ4BlockInputStream(new ByteBufInputStream(frame, true))):
-                    new CObjectInputStream(new LZ4BlockInputStream(new ByteBufInputStream(frame, true)),this.classResolver);
+
+        Tracker currentTracker = this.tracker;
+        ObjectInputStream ois;
+        if (GuiBase.hasPropertyConfig()) {
+            ois = currentTracker != null
+                    ? new ResolvingObjectInputStream(new LZ4BlockInputStream(new ByteBufInputStream(frame, true)), currentTracker)
+                    : new ObjectInputStream(new LZ4BlockInputStream(new ByteBufInputStream(frame, true)));
+        } else {
+            ois = new CObjectInputStream(new LZ4BlockInputStream(new ByteBufInputStream(frame, true)), this.classResolver, currentTracker);
+        }
 
         Object var5 = null;
         try {
@@ -53,5 +68,20 @@ public class CompatibleObjectDecoder extends LengthFieldBasedFrameDecoder {
         }
 
         return var5;
+    }
+
+    private static class ResolvingObjectInputStream extends ObjectInputStream {
+        private final Tracker tracker;
+
+        ResolvingObjectInputStream(InputStream in, Tracker tracker) throws IOException {
+            super(in);
+            this.tracker = tracker;
+            enableResolveObject(true);
+        }
+
+        @Override
+        protected Object resolveObject(Object obj) {
+            return TrackableRef.resolve(obj, tracker);
+        }
     }
 }

--- a/forge-gui/src/main/java/forge/gamemodes/net/CompatibleObjectEncoder.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/CompatibleObjectEncoder.java
@@ -1,5 +1,6 @@
 package forge.gamemodes.net;
 
+import forge.gamemodes.net.event.GuiGameEvent;
 import forge.gui.GuiBase;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufOutputStream;
@@ -8,11 +9,18 @@ import io.netty.handler.codec.MessageToByteEncoder;
 import net.jpountz.lz4.LZ4BlockOutputStream;
 import org.tinylog.Logger;
 
+import java.io.IOException;
 import java.io.ObjectOutputStream;
+import java.io.OutputStream;
 import java.io.Serializable;
 
 public class CompatibleObjectEncoder extends MessageToByteEncoder<Serializable> {
     private static final byte[] LENGTH_PLACEHOLDER = new byte[4];
+    private final boolean enableIdReplacement;
+
+    public CompatibleObjectEncoder(boolean enableIdReplacement) {
+        this.enableIdReplacement = enableIdReplacement;
+    }
 
     @Override
     protected void encode(ChannelHandlerContext ctx, Serializable msg, ByteBuf out) throws Exception {
@@ -20,9 +28,17 @@ public class CompatibleObjectEncoder extends MessageToByteEncoder<Serializable> 
         ByteBufOutputStream bout = new ByteBufOutputStream(out);
         ObjectOutputStream oout = null;
 
+        boolean replace = enableIdReplacement && shouldReplaceTrackables(msg);
+
         try {
             bout.write(LENGTH_PLACEHOLDER);
-            oout = GuiBase.hasPropertyConfig() ? new ObjectOutputStream(new LZ4BlockOutputStream(bout)) : new CObjectOutputStream(new LZ4BlockOutputStream(bout));
+            if (GuiBase.hasPropertyConfig()) {
+                oout = replace
+                        ? new ReplacingObjectOutputStream(new LZ4BlockOutputStream(bout))
+                        : new ObjectOutputStream(new LZ4BlockOutputStream(bout));
+            } else {
+                oout = new CObjectOutputStream(new LZ4BlockOutputStream(bout), replace);
+            }
             oout.writeObject(msg);
             oout.flush();
         } finally {
@@ -38,6 +54,26 @@ public class CompatibleObjectEncoder extends MessageToByteEncoder<Serializable> 
         out.setInt(startIdx, msgSize);
         if (msgSize > 20_000) {
             Logger.info("Encoded {} bytes (compressed) for {}", msgSize, msg.getClass().getSimpleName());
+        }
+    }
+
+    private static boolean shouldReplaceTrackables(Serializable msg) {
+        if (msg instanceof GuiGameEvent event) {
+            ProtocolMethod method = event.getMethod();
+            return method != ProtocolMethod.setGameView && method != ProtocolMethod.openView;
+        }
+        return false;
+    }
+
+    private static class ReplacingObjectOutputStream extends ObjectOutputStream {
+        ReplacingObjectOutputStream(OutputStream out) throws IOException {
+            super(out);
+            enableReplaceObject(true);
+        }
+
+        @Override
+        protected Object replaceObject(Object obj) {
+            return TrackableRef.replace(obj);
         }
     }
 }

--- a/forge-gui/src/main/java/forge/gamemodes/net/GameEventProxy.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/GameEventProxy.java
@@ -1,10 +1,7 @@
 package forge.gamemodes.net;
 
-import forge.game.card.CardView;
 import forge.game.event.GameEvent;
-import forge.game.player.PlayerView;
 import forge.trackable.TrackableObject;
-import forge.trackable.TrackableTypes;
 import forge.trackable.TrackableTypes.TrackableType;
 import forge.trackable.Tracker;
 
@@ -114,55 +111,6 @@ public class GameEventProxy implements Serializable, IHasNetLog {
         return result;
     }
 
-    // Only CardView and PlayerView are replaced with IdRef markers. These two
-    // types carry the largest object graphs and are always present in the GameView
-    // (registered via updateObjLookup on the IO thread before proxy unwrapping).
-    // Other TrackableObject types (StackItemView, SpellAbilityView, CombatView)
-    // are either ephemeral or not reachable from GameView's property graph, so
-    // they serialize normally.
-    private static final byte TYPE_CARD_VIEW = 0;
-    private static final byte TYPE_PLAYER_VIEW = 1;
-
-    /**
-     * Lightweight serializable marker that replaces a TrackableObject reference
-     * during proxy serialization.
-     */
-    static final class IdRef implements Serializable {
-        private static final long serialVersionUID = 1L;
-        final byte typeTag;
-        final int id;
-
-        IdRef(byte typeTag, int id) {
-            this.typeTag = typeTag;
-            this.id = id;
-        }
-    }
-
-    /**
-     * Returns the type tag for the given TrackableObject, or -1 if unsupported.
-     */
-    private static byte typeTagFor(TrackableObject obj) {
-        if (obj instanceof CardView) return TYPE_CARD_VIEW;
-        if (obj instanceof PlayerView) return TYPE_PLAYER_VIEW;
-        return -1;
-    }
-
-    /**
-     * Returns the TrackableType for the given type tag, for Tracker lookup.
-     */
-    private static TrackableType<?> trackableTypeFor(byte typeTag) {
-        switch (typeTag) {
-            case TYPE_CARD_VIEW: return TrackableTypes.CardViewType;
-            case TYPE_PLAYER_VIEW: return TrackableTypes.PlayerViewType;
-            default: return null;
-        }
-    }
-
-    /**
-     * ObjectOutputStream that replaces every TrackableObject with an IdRef.
-     * If a tracker is provided, verifies each ID is resolvable as a
-     * server-side sanity check.
-     */
     private static class IdReplacingOutputStream extends ObjectOutputStream {
         private final Tracker tracker;
         private boolean unresolvableRefs;
@@ -180,28 +128,23 @@ public class GameEventProxy implements Serializable, IHasNetLog {
         @Override
         protected Object replaceObject(Object obj) {
             if (obj instanceof TrackableObject trackable) {
-                byte tag = typeTagFor(trackable);
+                byte tag = TrackableRef.typeTagFor(trackable);
                 if (tag >= 0) {
                     if (tracker != null) {
-                        TrackableType<?> type = trackableTypeFor(tag);
+                        TrackableType<?> type = TrackableRef.trackableTypeFor(tag);
                         if (type != null && tracker.getObj(type, trackable.getId()) == null) {
                             netLog.debug("Server-side check: {} id={} not in tracker",
                                     trackable.getClass().getSimpleName(), trackable.getId());
                             unresolvableRefs = true;
                         }
                     }
-                    return new IdRef(tag, trackable.getId());
+                    return new TrackableRef.IdRef(tag, trackable.getId());
                 }
             }
             return obj;
         }
     }
 
-    /**
-     * ObjectInputStream that resolves IdRef markers back to TrackableObjects
-     * from the Tracker. Tracks whether any resolution failed so callers
-     * can drop damaged events.
-     */
     private static class IdResolvingInputStream extends ObjectInputStream {
         private final Tracker tracker;
         private boolean unresolvedRefs;
@@ -218,8 +161,8 @@ public class GameEventProxy implements Serializable, IHasNetLog {
 
         @Override
         protected Object resolveObject(Object obj) {
-            if (obj instanceof IdRef ref) {
-                TrackableType<?> type = trackableTypeFor(ref.typeTag);
+            if (obj instanceof TrackableRef.IdRef ref) {
+                TrackableType<?> type = TrackableRef.trackableTypeFor(ref.typeTag);
                 if (type != null) {
                     Object resolved = tracker.getObj(type, ref.id);
                     if (resolved == null) {

--- a/forge-gui/src/main/java/forge/gamemodes/net/TrackableRef.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/TrackableRef.java
@@ -1,0 +1,74 @@
+package forge.gamemodes.net;
+
+import forge.game.card.CardView;
+import forge.game.player.PlayerView;
+import forge.trackable.TrackableObject;
+import forge.trackable.TrackableTypes;
+import forge.trackable.TrackableTypes.TrackableType;
+import forge.trackable.Tracker;
+
+import org.tinylog.Logger;
+
+import java.io.Serializable;
+
+/**
+ * Shared primitives for replacing CardView/PlayerView references with
+ * lightweight {@link IdRef} markers during network serialization.
+ * Used by both {@link GameEventProxy} (game events) and the Netty
+ * encoder/decoder (protocol method args).
+ */
+final class TrackableRef {
+    static final byte TYPE_CARD_VIEW = 0;
+    static final byte TYPE_PLAYER_VIEW = 1;
+
+    static final class IdRef implements Serializable {
+        private static final long serialVersionUID = 1L;
+        final byte typeTag;
+        final int id;
+
+        IdRef(byte typeTag, int id) {
+            this.typeTag = typeTag;
+            this.id = id;
+        }
+    }
+
+    static byte typeTagFor(TrackableObject obj) {
+        if (obj instanceof CardView) return TYPE_CARD_VIEW;
+        if (obj instanceof PlayerView) return TYPE_PLAYER_VIEW;
+        return -1;
+    }
+
+    static TrackableType<?> trackableTypeFor(byte typeTag) {
+        switch (typeTag) {
+            case TYPE_CARD_VIEW: return TrackableTypes.CardViewType;
+            case TYPE_PLAYER_VIEW: return TrackableTypes.PlayerViewType;
+            default: return null;
+        }
+    }
+
+    static Object replace(Object obj) {
+        if (obj instanceof TrackableObject trackable) {
+            byte tag = typeTagFor(trackable);
+            if (tag >= 0) {
+                return new IdRef(tag, trackable.getId());
+            }
+        }
+        return obj;
+    }
+
+    static Object resolve(Object obj, Tracker tracker) {
+        if (obj instanceof IdRef ref) {
+            TrackableType<?> type = trackableTypeFor(ref.typeTag);
+            if (type != null) {
+                Object resolved = tracker.getObj(type, ref.id);
+                if (resolved == null) {
+                    Logger.warn("Could not resolve IdRef(tag={}, id={}) from Tracker", ref.typeTag, ref.id);
+                }
+                return resolved;
+            }
+        }
+        return obj;
+    }
+
+    private TrackableRef() {}
+}

--- a/forge-gui/src/main/java/forge/gamemodes/net/client/FGameClient.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/client/FGameClient.java
@@ -57,7 +57,7 @@ public class FGameClient implements IToServer, IHasNetLog {
                 public void initChannel(final SocketChannel ch) throws Exception {
                     final ChannelPipeline pipeline = ch.pipeline();
                     pipeline.addLast(
-                            new CompatibleObjectEncoder(),
+                            new CompatibleObjectEncoder(false),
                             new CompatibleObjectDecoder(9766*1024, ClassResolvers.cacheDisabled(null)),
                             new IdleStateHandler(0, HEARTBEAT_INTERVAL_SECONDS, 0, TimeUnit.SECONDS),
                             new MessageHandler(),

--- a/forge-gui/src/main/java/forge/gamemodes/net/client/GameClientHandler.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/client/GameClientHandler.java
@@ -7,6 +7,7 @@ import forge.game.card.CardView;
 import forge.game.player.PlayerView;
 import forge.game.player.RegisteredPlayer;
 import forge.gamemodes.match.LobbySlot;
+import forge.gamemodes.net.CompatibleObjectDecoder;
 import forge.gamemodes.net.GameEventProxy;
 import forge.gamemodes.net.GameProtocolHandler;
 import forge.gamemodes.net.IRemote;
@@ -40,6 +41,7 @@ final class GameClientHandler extends GameProtocolHandler<IGuiGame> {
     private Match match;
     private Game game;
     private GameView pendingGameView;
+    private volatile ChannelHandlerContext handlerCtx;
 
     /**
      * Creates a client-side game handler.
@@ -51,6 +53,12 @@ final class GameClientHandler extends GameProtocolHandler<IGuiGame> {
         this.tracker = null;
         this.match = null;
         this.game = null;
+    }
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+        super.handlerAdded(ctx);
+        this.handlerCtx = ctx;
     }
 
     @Override
@@ -93,6 +101,11 @@ final class GameClientHandler extends GameProtocolHandler<IGuiGame> {
 
                 // get a tracker
                 this.tracker = createTracker();
+
+                CompatibleObjectDecoder decoder = handlerCtx.pipeline().get(CompatibleObjectDecoder.class);
+                if (decoder != null) {
+                    decoder.setTracker(this.tracker);
+                }
 
                 for (PlayerView myPlayer : (TrackableCollection<PlayerView>) args[0]) {
                     if (myPlayer.getTracker() == null) {

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
@@ -119,7 +119,7 @@ public final class FServerManager {
                         public void initChannel(final SocketChannel ch) throws Exception {
                             final ChannelPipeline p = ch.pipeline();
                             p.addLast(
-                                    new CompatibleObjectEncoder(),
+                                    new CompatibleObjectEncoder(true),
                                     new CompatibleObjectDecoder(9766 * 1024, ClassResolvers.cacheDisabled(null)),
                                     new IdleStateHandler(HEARTBEAT_TIMEOUT_SECONDS, 0, 0, TimeUnit.SECONDS),
                                     new MessageHandler(),


### PR DESCRIPTION
### Issue

Every protocol method that passes a `CardView` or `PlayerView` argument triggers Java serialization of the entire object graph - a `CardView` pulls in its `PlayerView` owner, which pulls in all zones, which pull in all cards. This is redundant: the client already has these objects registered in its Tracker via `setGameView`. 

`GameEventProxy` already replaces CardView/PlayerView references with lightweight ID markers when serializing game events -avoiding Java serialization expanding each reference into the entire object graph. This PR extends the same IdRef pattern to protocol args at the Netty encoder/decoder level to avoid serializing the same data repeatedly.

### Solution

- Replace full TrackableObject serialization in protocol method arguments with lightweight ID references (IdRef markers) at the Netty encoder/decoder level
- Server encoder swaps CardView/PlayerView refs with `IdRef(typeTag, id)`; client decoder resolves them from the Tracker. `setGameView` and `openView` are excluded since they carry the full state
- Extract shared ID-mapping primitives from `GameEventProxy` into `TrackableRef` so both the encoder/decoder path (protocol args) and `GameEventProxy` (game events) reuse the same mechanism

### Why this is safe

The client's Tracker is kept in sync by `setGameView` messages that deliver the full game state. A CardView/PlayerView can only appear in a protocol method's args if it already exists in the game state. If the object was recently created, that state change generated GameEvents queued in the forwarder. `NetGuiGame.send()` calls `flushPendingEvents()` before every protocol message - this flushes accumulated events via `handleGameEvents`, which sends a `setGameView` (current full state) before the events. So any newly-created object should reache the client's Tracker before the protocol message that references it.

`setGameView` and `openView` themselves are excluded from replacement - they carry the full object state that populates the Tracker. The decoder only enables IdRef resolution after `openView`, when the client first has a valid Tracker.

If an IdRef fails to resolve, the field becomes `null` and a warning is logged. This is stricter than the old behavior, where the full (possibly stale) object was serialized inline. In practice, resolution failures should be rare: the flush-before-send pattern ensures the Tracker reflects the server's state at the time each message is composed.

If there is a resolution failure this should, at worst, result in a momentary visual glitch and a warning in the logs. No desync, no disconnect, no game state corruption.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)