### PR TITLE
Fix face-down exiled cards appearing blank

### DIFF
--- a/forge-game/src/main/java/forge/game/card/CardView.java
+++ b/forge-game/src/main/java/forge/game/card/CardView.java
@@ -1350,6 +1350,15 @@ public class CardView extends GameEntityView {
         }
         public String getImageKey(Iterable<PlayerView> viewers) {
             if (getState() == CardStateName.FaceDown) {
+                // For face-down exile cards (e.g. Gonti, Lord of Luxury), show the actual
+                // card face to players who have permission to look at it
+                if (getCard().isInZone(EnumSet.of(ZoneType.Exile))
+                        && viewers != null && canFaceDownBeShownToAny(viewers)) {
+                    CardStateView origState = getCard().getAlternateState();
+                    if (origState != null) {
+                        return origState.getTrackableImageKey();
+                    }
+                }
                 return getCard().getFacedownImageKey();
             }
             if (canBeShownToAny(viewers)) {


### PR DESCRIPTION
## Summary
Fix for face-down exiled cards (e.g. Gonti, Lord of Luxury) appearing blank to players who should be able to see them.

`CardStateView.getImageKey()` always returned the face-down image key for exiled cards without checking viewer permissions, which resolved to a blank placeholder image. Cards like Gonti grant look permission via `addMayLookFaceDownExile` when they exile face-down with `WithMayLook`, but `getImageKey()` never consulted this — it unconditionally returned the face-down key. The fix checks whether the viewer has permission to see face-down exile cards and returns the actual card image from the original card state when permitted.

**Before:** Gonti exiles a card face-down → controller sees a blank placeholder in the exile zone and in the playable zone cards area, despite having look permission granted by the ability
**After:** Gonti exiles a card face-down → controller sees the actual card face in the exile zone and playable zone cards area; opponent correctly still sees the face-down overlay

Also benefits Foretell (controller can now see their foretold card in exile rather than just the foretell overlay) and Heist (controller sees the heisted card).

Null-viewer calls (e.g. `CardPicturePanel`) are excluded to prevent information leaks to players without permission.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)