### PR TITLE
fix(draft): prevent NPE when draft ends during pack-passing transition

### DIFF
--- a/forge-gui-mobile/src/forge/deck/FDeckEditor.java
+++ b/forge-gui-mobile/src/forge/deck/FDeckEditor.java
@@ -2226,6 +2226,7 @@ public class FDeckEditor extends TabPageScreen<FDeckEditor> {
                 draft.postDraftActions();
                 hideTab(); //hide this tab page when finished drafting
                 parentScreen.completeDraft();
+                return; // pool is null; do not fall through to cardManager.setPool(pool) below
             }
 
             this.draftingFaceDown = getDraftPlayer().hasArchdemonCurse();


### PR DESCRIPTION
## Problem

When the final round of a draft ends while packs are still being routed
between players, `BoosterDraft.nextChoice()` can return `null`. This is
expected and documented by a comment in `DraftPackPage.refresh()`. However,
the null-check block was missing a `return` statement, causing execution to
fall through to `cardManager.setPool(null)`, throwing a NullPointerException.

The result: a crash/error screen appears at the end of the draft. The deck
save dialog still works, but the experience is alarming to users.

## Root Cause

`hasNextChoice()` returns `true` when packs are still in transit between
players (round not yet over). `nextChoice()` processes those pass steps
internally via a recursive `passPacks()` call, which can drain all remaining
packs and return `null` if no new round can be started. The gap between the
two checks is where the null slips through.

## Fix

Add `return;` after `parentScreen.completeDraft()` in the null-pool branch
of `DraftPackPage.refresh()`.

## Testing

Reproduce by completing any cube or custom draft to the final pick. The
crash screen no longer appears.
