### PR TITLE
feat(draft): replace Cogwork Librarian opt-out dialog with opt-in button

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/scene/AdventureDeckEditor.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/AdventureDeckEditor.java
@@ -798,6 +798,13 @@ public class AdventureDeckEditor extends FDeckEditor {
             event.getDraft().setLogEntry(this.draftLog);
             deckHeader.initDraftLog(this.draftLog, this);
         }
+        if (event.getDraft() != null) {
+            deckHeader.initCogworkButton(() -> {
+                event.getDraft().getHumanPlayer().cogworkLibrarianActivatedByUI = true;
+                deckHeader.btnCogwork.setVisible(false);
+                deckHeader.revalidate();
+            });
+        }
     }
 
     public AdventureDeckEditor(Deck deckToPreview) {

--- a/forge-gui-mobile/src/forge/deck/FDeckEditor.java
+++ b/forge-gui-mobile/src/forge/deck/FDeckEditor.java
@@ -1124,6 +1124,7 @@ public class FDeckEditor extends TabPageScreen<FDeckEditor> {
         protected final FLabel btnSave;
         protected final FLabel btnMoreOptions;
         protected FDisplayObject btnDraftLog;
+        protected FLabel btnCogwork;
 
         protected DeckHeader() {
             setHeight(HEADER_HEIGHT);
@@ -1172,8 +1173,25 @@ public class FDeckEditor extends TabPageScreen<FDeckEditor> {
                 float width = Math.max(remainingWidth / 4, Math.min(height * 4, remainingWidth / 2));
                 btnDraftLog.setSize(width, height);
                 out.add(btnDraftLog);
+                remainingWidth -= width;
+            }
+            if(btnCogwork != null && btnCogwork.isVisible()) {
+                float width = Math.max(remainingWidth / 3, Math.min(height * 6, remainingWidth));
+                btnCogwork.setSize(width, height);
+                out.add(btnCogwork);
             }
             return out;
+        }
+
+        public void initCogworkButton(Runnable onActivate) {
+            this.btnCogwork = new FLabel.ButtonBuilder()
+                    .text(Localizer.getInstance().getMessage("lblUseCogworkLibrarian"))
+                    .pressedColor(Header.getBtnPressedColor())
+                    .command(e -> onActivate.run())
+                    .font(FSkinFont.get(14))
+                    .build();
+            this.btnCogwork.setVisible(false);
+            this.add(btnCogwork);
         }
 
         public void initDraftLog(GameLog draftLog, FContainer parentScreen) {
@@ -2247,6 +2265,17 @@ public class FDeckEditor extends TabPageScreen<FDeckEditor> {
                 return;
             }
 
+            // Show Cogwork Librarian button in the header if the ability is pending this pick
+            FLabel btnCogwork = parentScreen.deckHeader.btnCogwork;
+            if (btnCogwork != null) {
+                boolean librarianAvailable = getDraftPlayer().hasCogworkLibrarianAvailable()
+                        && !getDraftPlayer().cogworkLibrarianActivatedByUI;
+                if (btnCogwork.isVisible() != librarianAvailable) {
+                    btnCogwork.setVisible(librarianAvailable);
+                    parentScreen.deckHeader.revalidate();
+                }
+            }
+
             this.updateCaption();
             cardManager.setEnabled(true);
         }
@@ -2282,6 +2311,12 @@ public class FDeckEditor extends TabPageScreen<FDeckEditor> {
             assert(destination instanceof DeckSectionPage);
             BoosterDraft draft = parentScreen.getDraft();
             cardManager.setEnabled(false); //Prevent any weird inputs until choices are made and the next set of cards is ready.
+            // Hide the Librarian button now — refresh() will show it again next pack if still available
+            FLabel btnCogwork = parentScreen.deckHeader.btnCogwork;
+            if (btnCogwork != null && btnCogwork.isVisible()) {
+                btnCogwork.setVisible(false);
+                parentScreen.deckHeader.revalidate();
+            }
             DeckSection section = ((DeckSectionPage) destination).deckSection;
             FThreads.invokeInBackgroundThread(() -> {
                 draft.setChoice(card, section);

--- a/forge-gui-mobile/src/forge/screens/limited/DraftingProcessScreen.java
+++ b/forge-gui-mobile/src/forge/screens/limited/DraftingProcessScreen.java
@@ -38,6 +38,11 @@ public class DraftingProcessScreen extends FDeckEditor {
             draft.setLogEntry(this.draftLog);
             deckHeader.initDraftLog(this.draftLog, this);
         }
+        deckHeader.initCogworkButton(() -> {
+            draft.getHumanPlayer().cogworkLibrarianActivatedByUI = true;
+            deckHeader.btnCogwork.setVisible(false);
+            deckHeader.revalidate();
+        });
     }
 
     @Override

--- a/forge-gui/res/languages/en-US.properties
+++ b/forge-gui/res/languages/en-US.properties
@@ -959,6 +959,7 @@ lblAddBasicLands=Add Basic Lands
 ttAddBasicLands=Add basic lands to the deck
 lblCardCatalog=Card Catalog
 lblEditorLog=Editor Log
+lblUseCogworkLibrarian=Use Cogwork Librarian
 lblJumptoprevioustable=Jump to previous table
 lblJumptopnexttable=Jump to next table
 lblJumptotextfilter=Jump to text filter

--- a/forge-gui/src/main/java/forge/gamemodes/limited/LimitedPlayer.java
+++ b/forge-gui/src/main/java/forge/gamemodes/limited/LimitedPlayer.java
@@ -55,6 +55,9 @@ public class LimitedPlayer {
 
     private int playerFlags = 0;
 
+    /** Set by the draft UI when the player taps "Use Cogwork Librarian" before a pick. */
+    public boolean cogworkLibrarianActivatedByUI = false;
+
     private final List<PaperCard> faceUp = Lists.newArrayList();
     private final List<PaperCard> revealed = Lists.newArrayList();
     private final Map<String, List<String>> noted = new HashMap<>();
@@ -380,7 +383,7 @@ public class LimitedPlayer {
             }
         }
 
-        return true;
+        return passPack;
     }
 
     public void addLog(String message) {
@@ -688,10 +691,18 @@ public class LimitedPlayer {
         return true;
     }
 
+    /** Returns true if the Cogwork Librarian extra-draft opportunity is currently pending. */
+    public boolean hasCogworkLibrarianAvailable() {
+        return (playerFlags & CogworkLibrarianExtraDraft) == CogworkLibrarianExtraDraft;
+    }
+
     public boolean handleCogworkLibrarian(DraftPack pack, PaperCard drafted) {
-        if(pack.isEmpty())
-            return false;
-        return !Objects.equals(SGuiChoose.one("Draft an extra pick with Cogwork Librarian?", Lists.newArrayList("Yes", "No")), "No");
+        if (pack.isEmpty()) return false;
+        // Opt-in: the UI sets cogworkLibrarianActivatedByUI via a button tap before the pick.
+        // If the player did not tap the button this pick, default to not using it.
+        boolean activated = cogworkLibrarianActivatedByUI;
+        cogworkLibrarianActivatedByUI = false; // consume the flag
+        return activated;
     }
 
     public boolean handleAgentOfAcquisitions(DraftPack pack, PaperCard drafted) {


### PR DESCRIPTION
## Problem

When a player holds Cogwork Librarian during a cube draft, the current
implementation prompts "Draft an extra pick with Cogwork Librarian?" (Yes/No)
on every single pick until the player chooses to use it. The player must
actively click "No" on each pack they want to draft normally, which is
disruptive when they are waiting for the right pack to use the ability.

Additionally, there is a pre-existing bug: if a player activates Cogwork
and then drafts a card that has a draft action (e.g., Lore Seeker), the
extra pick is silently dropped. `draftCard()` ends with a hardcoded
`return true` when any draft action runs, overriding the `passPack = false`
set by Cogwork's handler.

## Changes

**`LimitedPlayer.java`**
- Add `cogworkLibrarianActivatedByUI` public flag, consumed by
  `handleCogworkLibrarian()` instead of showing a dialog. Defaults to
  `false`, so the ability is not used unless the player explicitly opts in.
- Add `hasCogworkLibrarianAvailable()` predicate so the UI can query
  pending state without touching internal flags.
- Replace `handleCogworkLibrarian()` dialog prompt with flag-read-and-clear.
- Fix `draftCard()` to `return passPack` instead of hardcoded `return true`,
  so Cogwork combined with draft-action cards (Lore Seeker, etc.) works
  correctly.

**`FDeckEditor.java` (mobile)**
- Add a persistent `btnUseLibrarian` button in `DraftPackPage`, hidden by
  default. Appears above the card list when Cogwork is pending.
- Override `doLayout()` to reserve space for the button when visible.
- Button tap sets `cogworkLibrarianActivatedByUI = true` and hides itself.
- Button is hidden at start of `moveCard()` and re-evaluated in `refresh()`
  after each pack loads.

## Behavior Change

| Before | After |
|--------|-------|
| Dialog on every pick while holding Cogwork; must click "No" to skip | Button visible while Cogwork is pending; tap once to use it |
| Extra pick dropped when combined with draft-action cards | Extra pick correctly retained |

## Testing

Draft with a cube containing Cogwork Librarian. Verify:
1. Button appears when Cogwork is in hand.
2. Tapping it grants the extra pick for that pick only.
3. Not tapping it skips the pick silently — no dialog.
4. Drafting Lore Seeker while Cogwork is pending correctly grants both effects.