### PR TITLE
fix(draft): Lore Seeker adds cube booster from surplus in cube drafts

### DIFF
--- a/forge-core/src/main/java/forge/item/generation/UnOpenedProduct.java
+++ b/forge-core/src/main/java/forge/item/generation/UnOpenedProduct.java
@@ -65,6 +65,19 @@ public class UnOpenedProduct implements IUnOpenedProduct {
         return BoosterGenerator.getBoosterPack(tpl);
     }
 
+    /**
+     * Returns all cards still remaining in the print sheets (not yet drawn into boosters).
+     * Used by cube drafts to capture surplus cards after booster initialization.
+     */
+    public List<PaperCard> getRemainingCards() {
+        if (sheets == null) return new ArrayList<>();
+        List<PaperCard> remaining = new ArrayList<>();
+        for (PrintSheet ps : sheets.values()) {
+            remaining.addAll(ps.toFlatList());
+        }
+        return remaining;
+    }
+
     // If they request cards from an arbitrary pool, there's no use to cache printsheets.
     private List<PaperCard> getBoosterPack() {
         List<PaperCard> result = new ArrayList<>();

--- a/forge-gui/src/main/java/forge/gamemodes/limited/BoosterDraft.java
+++ b/forge-gui/src/main/java/forge/gamemodes/limited/BoosterDraft.java
@@ -74,6 +74,10 @@ public class BoosterDraft implements IBoosterDraft {
     static final List<CustomLimited> customs = new ArrayList<>();
     protected LimitedPoolType draftFormat;
 
+    // Surplus cube cards left over after boosters are distributed; used by Lore Seeker
+    private UnOpenedProduct cubeProduct = null;
+    private List<PaperCard> cubeSurplus = null;
+
     protected final List<IUnOpenedProduct> product = new ArrayList<>();
     public static void initializeCustomDrafts() {
         loadCustomDrafts();
@@ -407,6 +411,7 @@ public class BoosterDraft implements IBoosterDraft {
 
         final UnOpenedProduct toAdd = new UnOpenedProduct(tpl, dPool);
         toAdd.setLimitedPool(draft.isSingleton());
+        this.cubeProduct = toAdd; // retain reference to capture surplus after initialization
         for (int i = 0; i < draft.getNumPacks(); i++) {
             this.product.add(toAdd);
         }
@@ -501,7 +506,26 @@ public class BoosterDraft implements IBoosterDraft {
                 this.players.get(i).receiveUnopenedPack(pack);
             }
         }
+        // Capture surplus cube cards left over after all packs are distributed.
+        // These are used by Lore Seeker to add a cube booster mid-draft.
+        if (cubeProduct != null) {
+            cubeSurplus = new ArrayList<>(cubeProduct.getRemainingCards());
+            Collections.shuffle(cubeSurplus);
+        }
         startRound();
+    }
+
+    /** Returns a DraftPack drawn from cube surplus cards (for Lore Seeker in cube drafts).
+     *  Returns null if this is not a cube draft or surplus is exhausted. */
+    @Override
+    public DraftPack addBooster() {
+        if (cubeSurplus == null || cubeSurplus.isEmpty()) {
+            return null;
+        }
+        int packSize = Math.min(currentBoosterSize > 0 ? currentBoosterSize : 15, cubeSurplus.size());
+        List<PaperCard> cards = new ArrayList<>(cubeSurplus.subList(0, packSize));
+        cubeSurplus.subList(0, packSize).clear();
+        return new DraftPack(cards, nextId++);
     }
 
     public boolean startRound() {

--- a/forge-gui/src/main/java/forge/gamemodes/limited/IBoosterDraft.java
+++ b/forge-gui/src/main/java/forge/gamemodes/limited/IBoosterDraft.java
@@ -49,6 +49,9 @@ public interface IBoosterDraft {
     boolean hasNextChoice();
     boolean isRoundOver();
     DraftPack addBooster(CardEdition edition);
+
+    /** Returns a booster from cube surplus (Lore Seeker in cube drafts). Null if not a cube draft or surplus exhausted. */
+    default DraftPack addBooster() { return null; }
     Deck[] getComputerDecks(); // size 7, all the computers decks
     LimitedPlayer[] getOpposingPlayers(); // size 7, all the computers
     LimitedPlayer getHumanPlayer();

--- a/forge-gui/src/main/java/forge/gamemodes/limited/LimitedPlayer.java
+++ b/forge-gui/src/main/java/forge/gamemodes/limited/LimitedPlayer.java
@@ -738,6 +738,14 @@ public class LimitedPlayer {
     }
 
     public void addSingleBoosterPack() {
+        // In cube drafts, Lore Seeker adds a booster from the cube's surplus cards
+        DraftPack cubePack = draft.addBooster();
+        if (cubePack != null) {
+            packQueue.add(cubePack);
+            addLog(name() + " added a cube booster to the draft (Lore Seeker).");
+            return;
+        }
+
         // if this is just a normal draft, allow picking a pack from any set
         // If this is adventure or quest or whatever then we should limit it to something
         List<CardEdition> possibleEditions = FModel.getMagicDb().getEditions().stream()


### PR DESCRIPTION
## Problem

In cube drafts, Lore Seeker's effect ("after you draft this, you may add a
booster pack to the draft") calls `addBooster(CardEdition)`, which opens a
set-selection dialog and injects a booster from an arbitrary retail set.
This breaks the cube draft's card pool contract: players draft a card from
outside the cube.

## Background

In a cube draft, the number of cards used equals (players × packs × pack size).
The remainder of the cube's card pool sits unused after booster initialization.
For example, a 540-card cube with 8 players drafting 3 packs of 15 uses
8 × 3 × 15 = 360 cards, leaving 180 surplus. Lore Seeker should draw its
booster from this surplus rather than from a retail set.

## Changes

**`UnOpenedProduct.java`**
Add `getRemainingCards()`: returns all cards still in the print sheets after
booster draws. Enables callers to inspect surplus without modifying state.

**`BoosterDraft.java`**
- Retain a reference (`cubeProduct`) to the cube's `UnOpenedProduct` during
  `setupCustomDraft()`.
- After `initializeBoosters()` distributes all packs, snapshot remaining
  cards into a shuffled `cubeSurplus` list.
- Override `addBooster()` (no-arg) to draw a pack from `cubeSurplus`.
  Returns `null` when surplus is exhausted.

**`IBoosterDraft.java`**
Add `default DraftPack addBooster()` returning `null` as the base case for
non-cube draft implementations.

**`LimitedPlayer.java`**
In `addSingleBoosterPack()`, try `draft.addBooster()` first. If it returns
a pack (cube surplus available), use it. Fall back to the existing
set-selection dialog only for non-cube drafts or when surplus is exhausted.

## Non-cube drafts

Unaffected. `addBooster()` returns `null` for all non-`BoosterDraft`
implementations, and the fallback path runs as before.

## Testing

Draft with a cube containing Lore Seeker. Verify:
1. Drafting Lore Seeker adds a pack drawn from cube cards (not a retail set dialog).
2. After surplus is exhausted, falls back to the set-selection dialog.
3. Non-cube drafts with Lore Seeker continue to show the set dialog.
