### PR TITLE
Random Deck Generator (Theme): actually get land edition from deck

### DIFF
--- a/forge-gui/src/main/java/forge/deck/DeckGeneratorTheme.java
+++ b/forge-gui/src/main/java/forge/deck/DeckGeneratorTheme.java
@@ -19,13 +19,16 @@ package forge.deck;
 
 import forge.deck.generation.DeckGeneratorBase;
 import forge.deck.generation.IDeckGenPool;
+import forge.item.PaperCard;
 import forge.localinstance.properties.ForgeConstants;
 import forge.util.FileUtil;
 import forge.util.MyRandom;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * <p>
@@ -50,7 +53,6 @@ public class DeckGeneratorTheme extends DeckGeneratorBase {
     }
 
     private int basicLandPercentage = 0;
-    private String basicLandSet = null;
     private boolean testing = false;
 
     /**
@@ -157,7 +159,23 @@ public class DeckGeneratorTheme extends DeckGeneratorBase {
 
         errorBuilder.append("numBLands:").append(numBLands).append("\n");
 
-        addBasicLand(numBLands,basicLandSet);
+        // Make sure basicLandEdition is set
+        if (basicLandEdition == null) {
+            final List<String> setList = tDeck.toFlatList()
+                                              .stream()
+                                              .map(PaperCard::getEdition)
+                                              .distinct()
+                                              .collect(Collectors.toCollection(ArrayList::new));
+            Collections.shuffle(setList);
+            for (String set : setList) {
+                if (setBasicLandPool(set)) {
+                    basicLandEdition = set;
+                    break;
+                }
+            }
+        }
+
+        addBasicLand(numBLands,basicLandEdition);
 
         errorBuilder.append("DeckSize:").append(tDeck.countAll()).append("\n");
 
@@ -217,7 +235,7 @@ public class DeckGeneratorTheme extends DeckGeneratorBase {
             	final String[] ss = s.split("\\|");
                 basicLandPercentage = Integer.parseInt(ss[0].substring("BasicLandPercentage".length() + 1));
                 if(ss.length > 1)
-                	basicLandSet = ss[1];
+                	basicLandEdition = ss[1];
             }
             else if (s.equals("Testing")) {
                 testing = true;

--- a/forge-gui/src/main/java/forge/deck/DeckgenUtil.java
+++ b/forge-gui/src/main/java/forge/deck/DeckgenUtil.java
@@ -352,7 +352,7 @@ public class DeckgenUtil {
             final CardPool cards = gen.getDeck(60, forAi);
 
             if (null == deckName) {
-                deckName = Lang.joinHomogenous(Arrays.asList(selection));
+                deckName = Lang.joinHomogenous(List.of(selection));
             }
 
             // After generating card lists, build deck.

--- a/forge-gui/src/main/java/forge/deck/RandomDeckGenerator.java
+++ b/forge-gui/src/main/java/forge/deck/RandomDeckGenerator.java
@@ -147,30 +147,15 @@ public class RandomDeckGenerator extends DeckProxy implements Comparable<RandomD
     private Deck getUserDeck() {
         Iterable<DeckProxy> decks;
         final GameType gameType = lstDecks.getGameType();
-        switch (gameType) {
-            case CommanderGauntlet:
-            case Commander:
-                decks = DeckProxy.getAllCommanderDecks(DeckFormat.Commander.isLegalDeckPredicate());
-                break;
-            case Oathbreaker:
-                decks = DeckProxy.getAllOathbreakerDecks(DeckFormat.Oathbreaker.isLegalDeckPredicate());
-                break;
-            case TinyLeaders:
-                decks = DeckProxy.getAllTinyLeadersDecks(DeckFormat.TinyLeaders.isLegalDeckPredicate());
-                break;
-            case Brawl:
-                decks = DeckProxy.getAllBrawlDecks(DeckFormat.Brawl.isLegalDeckPredicate());
-                break;
-            case Archenemy:
-                decks = DeckProxy.getAllSchemeDecks(DeckFormat.Archenemy.isLegalDeckPredicate());
-                break;
-            case Planechase:
-                decks = DeckProxy.getAllPlanarDecks(DeckFormat.Planechase.isLegalDeckPredicate());
-                break;
-            default:
-                decks = DeckProxy.getAllConstructedDecks(gameType.getDeckFormat().isLegalDeckPredicate());
-                break;
-        }
+        decks = switch (gameType) {
+            case CommanderGauntlet, Commander -> DeckProxy.getAllCommanderDecks(DeckFormat.Commander.isLegalDeckPredicate());
+            case Oathbreaker -> DeckProxy.getAllOathbreakerDecks(DeckFormat.Oathbreaker.isLegalDeckPredicate());
+            case TinyLeaders -> DeckProxy.getAllTinyLeadersDecks(DeckFormat.TinyLeaders.isLegalDeckPredicate());
+            case Brawl -> DeckProxy.getAllBrawlDecks(DeckFormat.Brawl.isLegalDeckPredicate());
+            case Archenemy -> DeckProxy.getAllSchemeDecks(DeckFormat.Archenemy.isLegalDeckPredicate());
+            case Planechase -> DeckProxy.getAllPlanarDecks(DeckFormat.Planechase.isLegalDeckPredicate());
+            default -> DeckProxy.getAllConstructedDecks(gameType.getDeckFormat().isLegalDeckPredicate());
+        };
         if (Iterables.isEmpty(decks)) {
             return getGeneratedDeck(); //fall back to generated deck if no decks in filtered list
         }
@@ -183,28 +168,14 @@ public class RandomDeckGenerator extends DeckProxy implements Comparable<RandomD
     }
 
     private Deck getFavoriteDeck() {
-        Iterable<DeckProxy> decks;
-        switch (lstDecks.getGameType()) {
-            case CommanderGauntlet:
-            case Commander:
-                decks = DeckProxy.getAllCommanderDecks();
-                break;
-            case Oathbreaker:
-                decks = DeckProxy.getAllOathbreakerDecks();
-                break;
-            case TinyLeaders:
-                decks = DeckProxy.getAllTinyLeadersDecks();
-                break;
-            case Archenemy:
-                decks = DeckProxy.getAllSchemeDecks();
-                break;
-            case Planechase:
-                decks = DeckProxy.getAllPlanarDecks();
-                break;
-            default:
-                decks = DeckProxy.getAllConstructedDecks();
-                break;
-        }
+        Iterable<DeckProxy> decks = switch (lstDecks.getGameType()) {
+            case CommanderGauntlet, Commander -> DeckProxy.getAllCommanderDecks();
+            case Oathbreaker -> DeckProxy.getAllOathbreakerDecks();
+            case TinyLeaders -> DeckProxy.getAllTinyLeadersDecks();
+            case Archenemy -> DeckProxy.getAllSchemeDecks();
+            case Planechase -> DeckProxy.getAllPlanarDecks();
+            default -> DeckProxy.getAllConstructedDecks();
+        };
         decks = IterableUtil.filter(decks, DeckProxy::isFavoriteDeck);
         if (Iterables.isEmpty(decks)) {
             return getGeneratedDeck(); //fall back to generated deck if no favorite decks

--- a/forge-gui/src/main/java/forge/deck/io/Archetype.java
+++ b/forge-gui/src/main/java/forge/deck/io/Archetype.java
@@ -61,4 +61,9 @@ public class Archetype implements Serializable {
         }
         return output.toString();
     }
+
+    @Override
+    public String toString() {
+        return getName();
+    }
 }


### PR DESCRIPTION
The random deck generator is supposed to get basic lands from one of the editions in the deck (if possible), but at present it's almost always failing do to so and defaulting to LEA.  