### PR TITLE
devmode: planewalkers ETB with loyalty counters

### DIFF
--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -3079,6 +3079,12 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
                                 if (forgeCard.isCreature()) {
                                     forgeCard.setSickness(lastSummoningSickness);
                                 }
+                                if (forgeCard.isPlaneswalker()) {
+                                    String loyalty = forgeCard.getCurrentState().getBaseLoyalty();
+                                    if (StringUtils.isNumeric(loyalty)) {
+                                        forgeCard.addCounterInternal(CounterEnumType.LOYALTY, Integer.parseInt(loyalty), p, false, null, null);
+                                    }
+                                }
                             } else {
                                 getGui().message(localizer.getMessage("lblChosenCardNotPermanentorCantExistIndependentlyontheBattleground"), localizer.getMessage("lblError"));
                                 return;


### PR DESCRIPTION
I was a little bit puzzled, when a planewalker added from devmode disappeared after the first phase change (because of missing loyalty counters). There is already a dedicated dev mode button for adding counters, but I think that this small code change is worth saving users those extra clicks.

Still doesn't work for `Dakkon, Shadow Slayer` 😞.