### PR TITLE
Fix stale Play/Draw prompt after choosing Draw in network games

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
@@ -495,11 +495,18 @@ public abstract class AbstractGuiGame implements IGuiGame, IMayViewCards {
             return;
         }
         this.waitingStartTime = System.currentTimeMillis();
-        waitingTimer = new java.util.Timer("waitingTimer");
-        waitingTimer.schedule(new java.util.TimerTask() {
+        // Capture timer so stale EDT tick runnables detect cancel/restart and skip
+        final java.util.Timer myTimer = new java.util.Timer("waitingTimer");
+        waitingTimer = myTimer;
+        myTimer.schedule(new java.util.TimerTask() {
             @Override
             public void run() {
-                FThreads.invokeInEdtLater(() -> updateWaitingDisplay(forPlayer, waitingForPlayerName));
+                FThreads.invokeInEdtLater(() -> {
+                    if (waitingTimer != myTimer) {
+                        return; // canceled or replaced before the EDT got to us
+                    }
+                    updateWaitingDisplay(forPlayer, waitingForPlayerName);
+                });
             }
         }, 1000, 1000);
     }

--- a/forge-gui/src/main/java/forge/gamemodes/match/input/InputConfirm.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/input/InputConfirm.java
@@ -201,6 +201,11 @@ public class InputConfirm extends InputSyncronizedBase {
         }
     }
     
+    @Override
+    protected final boolean allowAwaitNextInput() {
+        return true;
+    }
+
     /** {@inheritDoc} */
     @Override
     protected final void onOk() {


### PR DESCRIPTION
Fixes a minor UI glitch in network play: after a player chose Draw in the "Play or Draw" dialog, the Play/Draw buttons stayed on their prompt until the opponent finished mulliganing — with no visual indication their selection had been accepted. Affects both host and remote players.

Two small fixes:

- **`InputConfirm.allowAwaitNextInput() → true`** — schedules the "Waiting for opponent" transition on click. Consistent with the existing override in `InputConfirmMulligan`, `InputLondonMulligan`, and `InputPassPriority`.
- **`AbstractGuiGame.waitingTimer` race guard** — `TimerTask.run()` posts updates to the EDT via `invokeInEdtLater`, which `Timer.cancel()` can't purge. A stale tick could overwrite the new prompt text after cancel. This is particularly visible on the remote client, where the tick can get scheduled onto the EDT while the client is still processing the flood of game-view/delta updates that arrive after the host completes their mulligan — by the time the client handles the new `showPromptMessage`, the stale tick is already queued ahead of the cancel. Fixed by capturing the `Timer` instance in the task and skipping the update if it no longer matches.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)