### PR TITLE
Add snow-covered basic lands option to Add Basic Lands dialog

### DIFF
--- a/forge-core/src/main/java/forge/card/CardEdition.java
+++ b/forge-core/src/main/java/forge/card/CardEdition.java
@@ -1072,27 +1072,4 @@ public final class CardEdition implements Comparable<CardEdition> {
         }
         return true;
     }
-
-    /**
-     * True when this edition contains all five snow-covered basic lands at
-     * BasicLand rarity. Sets like Coldsnap or Kaldheim print snow basics at
-     * common rarity (where they appear in boosters as part of the normal pack
-     * distribution) and are intentionally excluded - the limited deckbuilder
-     * only needs to surface snow basics for sets like Ice Age or Modern
-     * Horizons where they were treated as basics but never appeared in packs.
-     */
-    public boolean hasSnowBasicLands() {
-        for (String landName : MagicColor.Constant.SNOW_LANDS) {
-            boolean foundAtBasicRarity = false;
-            for (EditionEntry entry : this.getCardInSet(landName)) {
-                if (entry.rarity() == CardRarity.BasicLand) {
-                    foundAtBasicRarity = true;
-                    break;
-                }
-            }
-            if (!foundAtBasicRarity)
-                return false;
-        }
-        return true;
-    }
 }

--- a/forge-core/src/main/java/forge/card/CardEdition.java
+++ b/forge-core/src/main/java/forge/card/CardEdition.java
@@ -1072,4 +1072,27 @@ public final class CardEdition implements Comparable<CardEdition> {
         }
         return true;
     }
+
+    /**
+     * True when this edition contains all five snow-covered basic lands at
+     * BasicLand rarity. Sets like Coldsnap or Kaldheim print snow basics at
+     * common rarity (where they appear in boosters as part of the normal pack
+     * distribution) and are intentionally excluded - the limited deckbuilder
+     * only needs to surface snow basics for sets like Ice Age or Modern
+     * Horizons where they were treated as basics but never appeared in packs.
+     */
+    public boolean hasSnowBasicLands() {
+        for (String landName : MagicColor.Constant.SNOW_LANDS) {
+            boolean foundAtBasicRarity = false;
+            for (EditionEntry entry : this.getCardInSet(landName)) {
+                if (entry.rarity() == CardRarity.BasicLand) {
+                    foundAtBasicRarity = true;
+                    break;
+                }
+            }
+            if (!foundAtBasicRarity)
+                return false;
+        }
+        return true;
+    }
 }

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/AddBasicLandsDialog.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/AddBasicLandsDialog.java
@@ -26,6 +26,7 @@ import java.awt.image.BufferedImage;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import javax.swing.JCheckBox;
 import javax.swing.JOptionPane;
 import javax.swing.SwingConstants;
 
@@ -82,11 +83,24 @@ public class AddBasicLandsDialog {
     private final Deck deck;
 
     private FOptionPane optionPane;
+    private JCheckBox chkSnow; // null unless the caller opts in to snow-covered basics
     private int nonLandCount, oldLandCount;
     private CardEdition landSet;
 
     public AddBasicLandsDialog(Deck deck0) {
         this(deck0, null);
+    }
+    public AddBasicLandsDialog(Deck deck0, CardEdition defaultLandSet, boolean allowSnowLands) {
+        this(deck0, defaultLandSet);
+        if (!allowSnowLands) {
+            return;
+        }
+        chkSnow = new JCheckBox(Localizer.getInstance().getMessage("lblSnowCovered"));
+        chkSnow.setOpaque(false);
+        chkSnow.setEnabled(landSet != null && landSet.hasSnowBasicLands());
+        chkSnow.addActionListener(arg0 -> applySnowSelection());
+        panel.add(chkSnow);
+        panel.revalidate();
     }
     public AddBasicLandsDialog(Deck deck0, CardEdition defaultLandSet) {
         deck = deck0;
@@ -127,6 +141,14 @@ public class AddBasicLandsDialog {
 
         cbLandSet.addActionListener(arg0 -> {
             landSet = cbLandSet.getSelectedItem();
+            if (chkSnow != null) {
+                boolean snowAvailable = landSet != null && landSet.hasSnowBasicLands();
+                chkSnow.setEnabled(snowAvailable);
+                if (!snowAvailable && chkSnow.isSelected()) {
+                    chkSnow.setSelected(false);
+                    setSnowOnAllPanels(false);
+                }
+            }
             pnlPlains.refreshArtChoices();
             pnlIsland.refreshArtChoices();
             pnlSwamp.refreshArtChoices();
@@ -233,6 +255,18 @@ public class AddBasicLandsDialog {
         return null;
     }
 
+    private void applySnowSelection() {
+        setSnowOnAllPanels(chkSnow != null && chkSnow.isSelected());
+    }
+
+    private void setSnowOnAllPanels(boolean snow) {
+        pnlPlains.setSnow(snow);
+        pnlIsland.setSnow(snow);
+        pnlSwamp.setSnow(snow);
+        pnlMountain.setSnow(snow);
+        pnlForest.setSnow(snow);
+    }
+
     private void updateDeckInfoLabel() {
         int newLandCount = pnlPlains.count + pnlIsland.count + pnlSwamp.count + pnlMountain.count + pnlForest.count;
         int totalSymbolCount = pnlPlains.symbolCount + pnlIsland.symbolCount + pnlSwamp.symbolCount
@@ -274,9 +308,16 @@ public class AddBasicLandsDialog {
             int y = padding;
             int w = getWidth() - 2 * padding;
 
-            //layout land set combo box
+            //layout land set combo box (and snow-covered checkbox to its right when present)
             int comboBoxHeight = FTextField.HEIGHT;
-            cbLandSet.setBounds(x, y, w, comboBoxHeight);
+            if (chkSnow != null) {
+                int chkWidth = chkSnow.getPreferredSize().width;
+                cbLandSet.setBounds(x, y, w - chkWidth - padding, comboBoxHeight);
+                chkSnow.setBounds(x + w - chkWidth, y, chkWidth, comboBoxHeight);
+            }
+            else {
+                cbLandSet.setBounds(x, y, w, comboBoxHeight);
+            }
 
             //layout card panel scroller
             y += comboBoxHeight + padding;
@@ -305,7 +346,9 @@ public class AddBasicLandsDialog {
         private final LandCardPanel cardPanel;
         private final FLabel lblCount, btnSubtract, btnAdd;
         private final FComboBox<String> cbLandArt;
-        private final String cardName;
+        private final String baseCardName;
+        private String cardName;
+        private boolean useSnow;
         private PaperCard card;
         private int count, maxCount;
         private int symbolCount;
@@ -314,6 +357,7 @@ public class AddBasicLandsDialog {
             super(null);
             setOpaque(false);
 
+            baseCardName = cardName0;
             cardName = cardName0;
             cardPanel = new LandCardPanel();
             cbLandArt = new FComboBox<>();
@@ -383,6 +427,18 @@ public class AddBasicLandsDialog {
             cbLandArt.addItem(Localizer.getInstance().getMessage("lblAssortedArt"));
             for (int i = 1; i <= artChoiceCount; i++) {
                 cbLandArt.addItem(Localizer.getInstance().getMessage("lblCardArtN", String.valueOf(i)));
+            }
+        }
+
+        private void setSnow(boolean snow) {
+            if (useSnow == snow) { return; }
+            useSnow = snow;
+            cardName = snow ? "Snow-Covered " + baseCardName : baseCardName;
+            refreshArtChoices();
+            int artIndex = cbLandArt.getSelectedIndex();
+            if (artIndex >= 0) {
+                card = generateCard(artIndex);
+                cardPanel.repaint();
             }
         }
 

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/AddBasicLandsDialog.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/AddBasicLandsDialog.java
@@ -97,7 +97,7 @@ public class AddBasicLandsDialog {
         }
         chkSnow = new JCheckBox(Localizer.getInstance().getMessage("lblSnowCovered"));
         chkSnow.setOpaque(false);
-        chkSnow.setEnabled(landSet != null && landSet.hasSnowBasicLands());
+        chkSnow.setEnabled(landSet != null && "ICE".equals(landSet.getCode()));
         chkSnow.addActionListener(arg0 -> applySnowSelection());
         panel.add(chkSnow);
         panel.revalidate();
@@ -142,7 +142,7 @@ public class AddBasicLandsDialog {
         cbLandSet.addActionListener(arg0 -> {
             landSet = cbLandSet.getSelectedItem();
             if (chkSnow != null) {
-                boolean snowAvailable = landSet != null && landSet.hasSnowBasicLands();
+                boolean snowAvailable = landSet != null && "ICE".equals(landSet.getCode());
                 chkSnow.setEnabled(snowAvailable);
                 if (!snowAvailable && chkSnow.isSelected()) {
                     chkSnow.setSelected(false);

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorLimited.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorLimited.java
@@ -196,7 +196,7 @@ public final class CEditorLimited extends CDeckEditor<DeckGroup> {
 
         CardEdition defaultLandSet = CardEdition.Predicates.getRandomSetWithAllBasicLands(availableEditionCodes);
         boolean allowSnowLands = availableEditionCodes.stream()
-                .anyMatch(e -> e != null && e.hasSnowBasicLands());
+                .anyMatch(e -> e != null && "ICE".equals(e.getCode()));
 
         AddBasicLandsDialog dialog = new AddBasicLandsDialog(deck, defaultLandSet, allowSnowLands);
         CardPool landsToAdd = dialog.show();

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorLimited.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorLimited.java
@@ -195,8 +195,10 @@ public final class CEditorLimited extends CDeckEditor<DeckGroup> {
         }
 
         CardEdition defaultLandSet = CardEdition.Predicates.getRandomSetWithAllBasicLands(availableEditionCodes);
+        boolean allowSnowLands = availableEditionCodes.stream()
+                .anyMatch(e -> e != null && e.hasSnowBasicLands());
 
-        AddBasicLandsDialog dialog = new AddBasicLandsDialog(deck, defaultLandSet);
+        AddBasicLandsDialog dialog = new AddBasicLandsDialog(deck, defaultLandSet, allowSnowLands);
         CardPool landsToAdd = dialog.show();
         if (landsToAdd != null) {
             editor.onAddItems(landsToAdd, false);

--- a/forge-gui-mobile/src/forge/deck/AddBasicLandsDialog.java
+++ b/forge-gui-mobile/src/forge/deck/AddBasicLandsDialog.java
@@ -245,7 +245,7 @@ public class AddBasicLandsDialog extends FDialog {
     private void onEditionChange() {
         landSet = cbLandSet.getSelectedItem();
         if (chkSnow != null) {
-            boolean snowAvailable = landSet != null && landSet.hasSnowBasicLands();
+            boolean snowAvailable = landSet != null && "ICE".equals(landSet.getCode());
             chkSnow.setEnabled(snowAvailable);
             if (!snowAvailable && chkSnow.isSelected()) {
                 chkSnow.setSelected(false);

--- a/forge-gui-mobile/src/forge/deck/AddBasicLandsDialog.java
+++ b/forge-gui-mobile/src/forge/deck/AddBasicLandsDialog.java
@@ -39,6 +39,7 @@ import forge.card.mana.ManaCostShard;
 import forge.item.PaperCard;
 import forge.model.FModel;
 import forge.toolbox.FCardPanel;
+import forge.toolbox.FCheckBox;
 import forge.toolbox.FComboBox;
 import forge.toolbox.FContainer;
 import forge.toolbox.FDialog;
@@ -60,6 +61,7 @@ public class AddBasicLandsDialog extends FDialog {
 
     private final FLabel lblLandSet = add(new FLabel.Builder().text(Forge.getLocalizer().getMessage("lblLandSet") + ":").font(FSkinFont.get(12)).textColor(FLabel.getInlineLabelColor()).build());
     private final FComboBox<CardEdition> cbLandSet = add(new FComboBox<>(IterableUtil.filter(StaticData.instance().getSortedEditions(), CardEdition::hasBasicLands)));
+    private FCheckBox chkSnow; // null unless the caller opts in to snow-covered basics
 
     private final FScrollPane scroller = add(new FScrollPane() {
         @Override
@@ -115,6 +117,9 @@ public class AddBasicLandsDialog extends FDialog {
     private CardEdition landSet;
 
     public AddBasicLandsDialog(Deck deck, CardEdition defaultLandSet, final Consumer<CardPool> callback0, List<CardEdition> editionOptions) {
+        this(deck, defaultLandSet, callback0, editionOptions, false);
+    }
+    public AddBasicLandsDialog(Deck deck, CardEdition defaultLandSet, final Consumer<CardPool> callback0, List<CardEdition> editionOptions, boolean allowSnowLands) {
         super(Forge.getLocalizer().getMessage("lblAddBasicLandsAutoSuggest").replace("%s", deck.getName()), 2);
 
         callback = callback0;
@@ -131,6 +136,12 @@ public class AddBasicLandsDialog extends FDialog {
 
         if (editionOptions != null && !editionOptions.isEmpty()) {
             cbLandSet.setItems(editionOptions, editionOptions.get(0));
+        }
+
+        if (allowSnowLands) {
+            chkSnow = add(new FCheckBox(Forge.getLocalizer().getMessage("lblSnowCovered"), false));
+            chkSnow.setFont(lblLandSet.getFont());
+            chkSnow.setCommand(e -> applySnowSelection());
         }
 
         if (cbLandSet.getSelectedItem() == defaultLandSet) {
@@ -233,11 +244,31 @@ public class AddBasicLandsDialog extends FDialog {
 
     private void onEditionChange() {
         landSet = cbLandSet.getSelectedItem();
+        if (chkSnow != null) {
+            boolean snowAvailable = landSet != null && landSet.hasSnowBasicLands();
+            chkSnow.setEnabled(snowAvailable);
+            if (!snowAvailable && chkSnow.isSelected()) {
+                chkSnow.setSelected(false);
+                setSnowOnAllPanels(false);
+            }
+        }
         pnlPlains.refreshArtChoices();
         pnlIsland.refreshArtChoices();
         pnlSwamp.refreshArtChoices();
         pnlMountain.refreshArtChoices();
         pnlForest.refreshArtChoices();
+    }
+
+    private void applySnowSelection() {
+        setSnowOnAllPanels(chkSnow != null && chkSnow.isSelected());
+    }
+
+    private void setSnowOnAllPanels(boolean snow) {
+        pnlPlains.setSnow(snow);
+        pnlIsland.setSnow(snow);
+        pnlSwamp.setSnow(snow);
+        pnlMountain.setSnow(snow);
+        pnlForest.setSnow(snow);
     }
 
     @Override
@@ -247,9 +278,13 @@ public class AddBasicLandsDialog extends FDialog {
         float y = padding;
         float w = width - 2 * padding;
 
-        //layout land set combo box
+        //layout land set combo box (snow checkbox shares the label's row when present)
         float comboBoxHeight = cbLandSet.getHeight();
         lblLandSet.setBounds(x, y, lblLandSet.getAutoSizeBounds().width, comboBoxHeight);
+        if (chkSnow != null) {
+            float chkW = chkSnow.getAutoSizeBounds().width + comboBoxHeight; // room for the box icon
+            chkSnow.setBounds(x + w - chkW, y, chkW, comboBoxHeight);
+        }
         y+= comboBoxHeight;
         cbLandSet.setBounds(x, y, w, comboBoxHeight);
 
@@ -306,12 +341,15 @@ public class AddBasicLandsDialog extends FDialog {
         private final LandCardPanel cardPanel;
         private final FLabel lblCount, btnSubtract, btnAdd;
         private final FComboBox<String> cbLandArt;
-        private final String cardName;
+        private final String baseCardName;
+        private String cardName;
+        private boolean useSnow;
         private PaperCard card;
         private int count, maxCount;
         private double symbolCount;
 
         private LandPanel(String cardName0) {
+            baseCardName = cardName0;
             cardName = cardName0;
             cardPanel = add(new LandCardPanel());
             cbLandArt = add(new FComboBox<>());
@@ -370,6 +408,17 @@ public class AddBasicLandsDialog extends FDialog {
             cbLandArt.addItem(Forge.getLocalizer().getMessage("lblAssortedArt"));
             for (int i = 1; i <= artChoiceCount; i++) {
                 cbLandArt.addItem(Forge.getLocalizer().getMessage("lblCardArtN", String.valueOf(i)));
+            }
+        }
+
+        private void setSnow(boolean snow) {
+            if (useSnow == snow) { return; }
+            useSnow = snow;
+            cardName = snow ? "Snow-Covered " + baseCardName : baseCardName;
+            refreshArtChoices();
+            int artIndex = cbLandArt.getSelectedIndex();
+            if (artIndex >= 0) {
+                card = generateCard(artIndex);
             }
         }
 

--- a/forge-gui-mobile/src/forge/deck/FDeckEditor.java
+++ b/forge-gui-mobile/src/forge/deck/FDeckEditor.java
@@ -659,7 +659,7 @@ public class FDeckEditor extends TabPageScreen<FDeckEditor> {
         CardEdition defaultLandSet = allowedLandSets.get(0);
         List<CardEdition> finalAllowedLandSets = allowedLandSets;
         boolean allowSnowLands = allowedLandSets.stream()
-                .anyMatch(e -> e != null && e.hasSnowBasicLands());
+                .anyMatch(e -> e != null && "ICE".equals(e.getCode()));
         FThreads.invokeInEdtNowOrLater(() -> {
             AddBasicLandsDialog dialog = new AddBasicLandsDialog(deck, defaultLandSet, this::addChosenBasicLands, editorConfig.hasInfiniteCardPool() ? null : finalAllowedLandSets, allowSnowLands); //Null allows any lands to be selected
             dialog.show();

--- a/forge-gui-mobile/src/forge/deck/FDeckEditor.java
+++ b/forge-gui-mobile/src/forge/deck/FDeckEditor.java
@@ -658,8 +658,10 @@ public class FDeckEditor extends TabPageScreen<FDeckEditor> {
             allowedLandSets = List.of(FModel.getMagicDb().getEditions().get("JMP"));
         CardEdition defaultLandSet = allowedLandSets.get(0);
         List<CardEdition> finalAllowedLandSets = allowedLandSets;
+        boolean allowSnowLands = allowedLandSets.stream()
+                .anyMatch(e -> e != null && e.hasSnowBasicLands());
         FThreads.invokeInEdtNowOrLater(() -> {
-            AddBasicLandsDialog dialog = new AddBasicLandsDialog(deck, defaultLandSet, this::addChosenBasicLands, editorConfig.hasInfiniteCardPool() ? null : finalAllowedLandSets); //Null allows any lands to be selected
+            AddBasicLandsDialog dialog = new AddBasicLandsDialog(deck, defaultLandSet, this::addChosenBasicLands, editorConfig.hasInfiniteCardPool() ? null : finalAllowedLandSets, allowSnowLands); //Null allows any lands to be selected
             dialog.show();
 
         });

--- a/forge-gui/res/languages/en-US.properties
+++ b/forge-gui/res/languages/en-US.properties
@@ -1334,6 +1334,7 @@ lblRestartRequired=Restart Required
 lblSelect=Select %s
 #AddBasicLandsDialog.java
 lblLandSet=Land Set
+lblSnowCovered=Snow-Covered
 lblAddBasicLandsAutoSuggest=Add Basic Lands to %s\n(double-tap statistics to auto-suggest)
 lblDeckStatisticsAutoSuggest=Deck statistics. Double click to auto-suggest basic lands.
 lblAssortedArt=Assorted Art


### PR DESCRIPTION
- Adds a "Snow-Covered" checkbox next to the Land Set selector in the Add Basic Lands dialog (both desktop and mobile)
- Appears only when the limited pool contains Ice Age (including Ice Age block drafts with Alliances/Homelands sideboosters, as long as ICE itself is in the pool)
- Modern Horizons and Masters Edition II are intentionally excluded — they already distribute snow basics through their pack slots, so the UI workaround is unnecessary there
- The checkbox is auto-disabled when the currently selected dropdown edition is not Ice Age, and auto-unchecks if the user navigates away
- Constructed deckbuilders and any other caller of the existing constructors see no behavior change; the new behavior is opt-in via a new constructor parameter passed by \`CEditorLimited\` (desktop) and \`FDeckEditor.showAddBasicLandsDialog\` (mobile)
- Motivation: in Ice Age, snow basic lands historically only shipped in the 60-card starter decks and never in boosters, leaving "snow matters" cards practically useless in current Forge limited tournaments