### PR TITLE
Ai doesn't activate ability of deadeye duelist

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/DamageDealAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DamageDealAi.java
@@ -740,7 +740,12 @@ public class DamageDealAi extends DamageAiBase {
                         || immediately) {
                     boolean pingAfterAttack = "PingAfterAttack".equals(logic) && phase.getPhase().isAfter(PhaseType.COMBAT_DECLARE_ATTACKERS) && phase.isPlayerTurn(ai);
                     boolean isPWAbility = sa.isPwAbility() && sa.getPayCosts().hasSpecificCostType(CostPutCounter.class);
-                    if (isPWAbility || (pingAfterAttack && !avoidTargetP(ai, sa)) || shouldTgtP(ai, sa, dmg, noPrevention)) {
+                    // Activated abilities that target only players (not creatures) should fire at end of opponent's turn
+                    boolean freePingPlayerOnly = !source.isSpell() && sa.isAbility()
+                            && tgt.canTgtPlayer() && !tgt.canTgtCreature()
+                            && phase.is(PhaseType.END_OF_TURN) && phase.getNextTurn().equals(ai)
+                            && !avoidTargetP(ai, sa);
+                    if (isPWAbility || (pingAfterAttack && !avoidTargetP(ai, sa)) || shouldTgtP(ai, sa, dmg, noPrevention) || freePingPlayerOnly) {
                         tcs.add(enemy);
                         if (divided) {
                             sa.addDividedAllocation(enemy, dmg);

--- a/forge-ai/src/main/java/forge/ai/ability/DamageDealAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DamageDealAi.java
@@ -675,29 +675,6 @@ public class DamageDealAi extends DamageAiBase {
 
                 // TODO: add check here if card is about to die from something
                 // on the stack or from taking combat damage
-
-                final Cost abCost = sa.getPayCosts();
-                boolean freePing = immediately || abCost == null || sa.getTargets().size() > 0;
-
-                if (!source.isSpell()) {
-                    if (phase.is(PhaseType.END_OF_TURN) && sa.isAbility() && abCost.isReusuableResource()) {
-                        if (phase.getNextTurn().equals(ai))
-                            freePing = true;
-                    }
-
-                    if (phase.is(PhaseType.MAIN2) && sa.isAbility()) {
-                        if (sa.isPwAbility() || source.hasSVar("EndOfTurnLeavePlay"))
-                            freePing = true;
-                    }
-                }
-
-                if (freePing && sa.canTarget(enemy) && !avoidTargetP(ai, sa)) {
-                    tcs.add(enemy);
-                    if (divided) {
-                        sa.addDividedAllocation(enemy, dmg);
-                        break;
-                    }
-                }
             } else if (tgt.canTgtCreature() || tgt.canTgtPlaneswalker()) {
                 final Card c = dealDamageChooseTgtC(ai, sa, dmg, noPrevention, enemy, mandatory);
                 if (c != null) {
@@ -734,18 +711,28 @@ public class DamageDealAi extends DamageAiBase {
                 return false;
             }
             if (sa.canTarget(enemy) && sa.canAddMoreTarget()) {
+                final Cost abCost = sa.getPayCosts();
+                boolean freePing = immediately || abCost == null || sa.getTargets().size() > 0;
+
+                if (!source.isSpell()) {
+                    if (phase.is(PhaseType.END_OF_TURN) && sa.isAbility() && abCost.isReusuableResource()) {
+                        if (phase.getNextTurn().equals(ai))
+                            freePing = true;
+                    }
+
+                    if (phase.is(PhaseType.MAIN2) && sa.isAbility()) {
+                        if (sa.isPwAbility() || source.hasSVar("EndOfTurnLeavePlay"))
+                            freePing = true;
+                    }
+                }
+
                 if ((phase.is(PhaseType.END_OF_TURN) && phase.getNextTurn().equals(ai))
                         || (isSorcerySpeed(sa, ai) && phase.is(PhaseType.MAIN2))
                         || ("BurnCreatures".equals(logic) && !enemy.getCreaturesInPlay().isEmpty())
                         || immediately) {
                     boolean pingAfterAttack = "PingAfterAttack".equals(logic) && phase.getPhase().isAfter(PhaseType.COMBAT_DECLARE_ATTACKERS) && phase.isPlayerTurn(ai);
                     boolean isPWAbility = sa.isPwAbility() && sa.getPayCosts().hasSpecificCostType(CostPutCounter.class);
-                    // Activated abilities that target only players (not creatures) should fire at end of opponent's turn
-                    boolean freePingPlayerOnly = !source.isSpell() && sa.isAbility()
-                            && tgt.canTgtPlayer() && !tgt.canTgtCreature()
-                            && phase.is(PhaseType.END_OF_TURN) && phase.getNextTurn().equals(ai)
-                            && !avoidTargetP(ai, sa);
-                    if (isPWAbility || (pingAfterAttack && !avoidTargetP(ai, sa)) || shouldTgtP(ai, sa, dmg, noPrevention) || freePingPlayerOnly) {
+                    if ((freePing && !avoidTargetP(ai, sa)) || isPWAbility || (pingAfterAttack && !avoidTargetP(ai, sa)) || shouldTgtP(ai, sa, dmg, noPrevention)) {
                         tcs.add(enemy);
                         if (divided) {
                             sa.addDividedAllocation(enemy, dmg);


### PR DESCRIPTION
Resolves #7476                                                                                                                                                                    

Deadeye Duelist has an activated ability ({1}, {T}: Deal 1 damage to target opponent) that the AI never used, except when the opponent was below 5 life.

Added a freePingPlayerOnly condition in DamageDealAi.java (damageChoosingTargets method) that allows the AI to fire activated abilities targeting only players at the end of the opponent's turn.
