### PR TITLE
Fix tinylog network log writer not found in packaged builds

### DIFF
--- a/forge-gui-android/src/main/resources/META-INF/services/org.tinylog.writers.Writer
+++ b/forge-gui-android/src/main/resources/META-INF/services/org.tinylog.writers.Writer
@@ -6,3 +6,4 @@ org.tinylog.writers.RollingFileWriter
 org.tinylog.writers.SharedFileWriter
 org.tinylog.writers.JsonWriter
 org.tinylog.writers.SyslogWriter
+forge.gamemodes.net.NetworkLogWriter

--- a/forge-gui-desktop/pom.xml
+++ b/forge-gui-desktop/pom.xml
@@ -158,9 +158,9 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <attach>false</attach>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
+                    <descriptors>
+                        <descriptor>src/main/assembly/jar-with-dependencies.xml</descriptor>
+                    </descriptors>
                     <archive>
                         <manifestEntries>
                             <Implementation-Title>${project.name}</Implementation-Title>

--- a/forge-gui-desktop/src/main/assembly/jar-with-dependencies.xml
+++ b/forge-gui-desktop/src/main/assembly/jar-with-dependencies.xml
@@ -1,0 +1,23 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0
+                              https://maven.apache.org/xsd/assembly-2.2.0.xsd">
+    <id>jar-with-dependencies</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <containerDescriptorHandlers>
+        <containerDescriptorHandler>
+            <handlerName>metaInf-services</handlerName>
+        </containerDescriptorHandler>
+    </containerDescriptorHandlers>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/forge-gui-mobile-dev/pom.xml
+++ b/forge-gui-mobile-dev/pom.xml
@@ -145,9 +145,9 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <attach>false</attach>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
+                    <descriptors>
+                        <descriptor>src/main/assembly/jar-with-dependencies.xml</descriptor>
+                    </descriptors>
                     <archive>
                         <manifestEntries>
                             <Implementation-Title>${project.name}</Implementation-Title>

--- a/forge-gui-mobile-dev/src/main/assembly/jar-with-dependencies.xml
+++ b/forge-gui-mobile-dev/src/main/assembly/jar-with-dependencies.xml
@@ -1,0 +1,23 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0
+                              https://maven.apache.org/xsd/assembly-2.2.0.xsd">
+    <id>jar-with-dependencies</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <containerDescriptorHandlers>
+        <containerDescriptorHandler>
+            <handlerName>metaInf-services</handlerName>
+        </containerDescriptorHandler>
+    </containerDescriptorHandlers>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+</assembly>


### PR DESCRIPTION
## Summary

Fixes `LOGGER ERROR: Service implementation 'network log' not found` at startup in packaged builds (desktop and mobile-dev fat JARs).

## Root cause

The `maven-assembly-plugin`'s built-in `jar-with-dependencies` descriptor unpacks dependency JARs last, overwriting any `META-INF/services` files from the project modules. Both `tinylog-impl.jar` and `forge-gui.jar` ship `META-INF/services/org.tinylog.writers.Writer` — tinylog-impl's copy (listing only standard writers) overwrites forge-gui's copy (listing `NetworkLogWriter`), so tinylog can't find the custom writer at startup.

This was introduced by <!-- -->#9642 which added the `writerNetFile = network log` entry to `tinylog.properties`. Before that merge, no custom writer was referenced, so the overwrite was harmless.

## Why this wasn't visible in dev builds

IntelliJ runs use separate classpath entries (one per module/JAR), so `ClassLoader.getResources()` finds both service files and all writers are discovered. The error only appears when running from the assembled fat JAR, where both files compete for the same path and one is lost.

## Fix

Replace the built-in `descriptorRef` with a custom assembly descriptor that adds the `metaInf-services` container descriptor handler. This tells the assembly plugin to concatenate service files instead of overwriting them. Applied to both `forge-gui-desktop` and `forge-gui-mobile-dev`.

Also added `NetworkLogWriter` to `forge-gui-android`'s hardcoded service file, which uses a different workaround (<!-- -->#9977) because the Android build tool strips `META-INF/services` entirely.

## Why not use the Android approach for desktop/mobile-dev?

The Android fix ships a hardcoded service file listing all writers. For desktop and mobile-dev, the `jar-with-dependencies` assembly unpacks dependencies *after* the project's own classes, so a hardcoded file in the project gets overwritten — the opposite of what we need. The `metaInf-services` handler intercepts during assembly and merges instead.

## Risk

The custom descriptor is identical to Maven's built-in `jar-with-dependencies` descriptor with one addition (the handler). This built-in descriptor hasn't changed in years — it's just "unpack deps into one JAR." The `metaInf-services` handler is a standard Maven feature, not a third-party plugin.

## Testing

- Reproduced the error by running the unfixed fat JAR — confirmed `LOGGER ERROR` on line 2
- Applied fix, rebuilt, verified `NetworkLogWriter` appears in both fat JARs' merged service files
- Ran both fat JARs — error is gone, no new errors introduced
- Verified all other `META-INF/services` files are preserved in both fat JARs
- IntelliJ runs unaffected (no change to classpath behavior)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)