### PR TITLE
Adventure: graceful map load failure and fix merfolkpool teleport case

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/scene/TileMapScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/TileMapScene.java
@@ -59,9 +59,17 @@ public class TileMapScene extends HudScene {
         if (map == null)
             return;
         if (nextMap != null) {
-            load(nextMap, nextSpawnPoint);
+            String target = nextMap;
+            int spawn = nextSpawnPoint;
             nextMap = null;
             nextSpawnPoint = 0;
+            try {
+                load(target, spawn);
+            } catch (Exception e) {
+                System.err.println("Error loading map " + target + "...");
+                e.printStackTrace();
+                MapStage.getInstance().exitDungeon(false, false);
+            }
         }
         stage.act(Gdx.graphics.getDeltaTime());
         hud.act(Gdx.graphics.getDeltaTime());

--- a/forge-gui/res/adventure/Shandalar Old Border/maps/map/merfolkpool/merfolkpool_6.tmx
+++ b/forge-gui/res/adventure/Shandalar Old Border/maps/map/merfolkpool/merfolkpool_6.tmx
@@ -50,7 +50,7 @@
   </object>
   <object id="61" template="../../../../common/maps/obj/door_down.tx" x="888.667" y="814.333">
    <properties>
-    <property name="teleport" value="../Shandalar Old Border/maps/map/merfolkpool/merfolkpool_6b.tmx" />
+    <property name="teleport" value="../Shandalar Old Border/maps/map/merfolkpool/merfolkpool_6B.tmx" />
     <property name="teleportObjectId" value="55" />
    </properties>
   </object>

--- a/forge-gui/res/adventure/common/maps/map/merfolkpool/merfolkpool_6.tmx
+++ b/forge-gui/res/adventure/common/maps/map/merfolkpool/merfolkpool_6.tmx
@@ -51,7 +51,7 @@
   <object id="60" template="../../obj/treasure.tx" x="376" y="796.5"/>
   <object id="61" template="../../obj/door_down.tx" x="888.667" y="814.333">
    <properties>
-    <property name="teleport" value="../common/maps/map/merfolkpool/merfolkpool_6b.tmx"/>
+    <property name="teleport" value="../common/maps/map/merfolkpool/merfolkpool_6B.tmx"/>
     <property name="teleportObjectId" value="55"/>
    </properties>
   </object>


### PR DESCRIPTION
- Teleport to a missing map file infinite-loops in `TileMapScene.act()`: `nextMap` was cleared after `load()`, so a thrown exception left `nextMap` populated and the same failed load retried every frame with no way for the player to escape.
- Clear `nextMap` before calling `load()`, wrap in try/catch, and call `MapStage.exitDungeon` on failure to return the player to the world map. Mirrors the existing pattern in `WorldStage.loadPOI`.
- Fix `merfolkpool_6.tmx` teleport referencing `merfolkpool_6b.tmx` when the actual file is `merfolkpool_6B.tmx`. Works on macOS/Windows but breaks on Linux case-sensitive filesystems, triggering the infinite-loop bug above. Applied to both the `common` copy and the `Shandalar Old Border` copy.