### PR TITLE
Fix Android crash: guard ProcessHandle in NetworkLogWriter

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/net/NetworkLogWriter.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/NetworkLogWriter.java
@@ -106,12 +106,14 @@ public class NetworkLogWriter extends AbstractFormatPatternWriter {
 
     private void writeSystemInfoHeader(BufferedWriter writer, String key) {
         try {
-            long pid = ProcessHandle.current().pid();
             StringBuilder sb = new StringBuilder();
             sb.append("=".repeat(80)).append("\n");
             sb.append("Network Debug Log Started\n");
             sb.append("Log file key: ").append(key).append("\n");
-            sb.append("PID: ").append(pid).append("\n");
+            try {
+                long pid = ProcessHandle.current().pid();
+                sb.append("PID: ").append(pid).append("\n");
+            } catch (NoClassDefFoundError e) { /* unavailable on Android */ }
             try {
                 String hwInfo = GuiBase.getHWInfo()
                         .replace("##########################################", "");

--- a/forge-gui/src/main/java/forge/gamemodes/net/NetworkLogWriter.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/NetworkLogWriter.java
@@ -110,10 +110,9 @@ public class NetworkLogWriter extends AbstractFormatPatternWriter {
             sb.append("=".repeat(80)).append("\n");
             sb.append("Network Debug Log Started\n");
             sb.append("Log file key: ").append(key).append("\n");
-            try {
-                long pid = ProcessHandle.current().pid();
-                sb.append("PID: ").append(pid).append("\n");
-            } catch (NoClassDefFoundError e) { /* unavailable on Android */ }
+            if (!GuiBase.isAndroid()) {
+                sb.append("PID: ").append(ProcessHandle.current().pid()).append("\n");
+            }
             try {
                 String hwInfo = GuiBase.getHWInfo()
                         .replace("##########################################", "");


### PR DESCRIPTION
`ProcessHandle.current().pid()` is unavailable on Android's ART runtime. After <!-- -->#10377 registered `NetworkLogWriter` in the Android service file, the writer is now discovered on Android — but `writeSystemInfoHeader()` crashes with `NoClassDefFoundError` on the first `netLog.trace()` call. Guard the PID line so it's skipped on Android; the rest of the log header writes normally.

Built and tested on Android emulator — confirmed matches start without crash and network logs are written.

**Note:** `NetworkLogWriter` is registered unconditionally via `tinylog.properties` and `netLog.trace()` calls fire in shared code paths (`InputSyncronizedBase`, `PlayerControllerHuman`), so the writer creates log files even for local AI games. This PR addresses the immediate crash; as follow-up should investigate whether tinylog writers can be registered conditionally so network logging only activates for network games.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)