### PR TITLE
Only write network logs for network games and tests

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/net/NetConnectUtil.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/NetConnectUtil.java
@@ -46,6 +46,7 @@ public class NetConnectUtil {
         final ServerGameLobby lobby = new ServerGameLobby();
         final ILobbyView view = onlineLobby.setLobby(lobby);
 
+        NetworkLogConfig.activateNetworkLogging();
         server.startServer(port);
         server.setLobby(lobby);
 
@@ -191,6 +192,7 @@ public class NetConnectUtil {
         });
         view.setPlayerChangeListener((index, event) -> client.send(event));
 
+        NetworkLogConfig.activateNetworkLogging();
         try {
             client.connect();
         }

--- a/forge-gui/src/main/java/forge/gamemodes/net/NetworkLogConfig.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/NetworkLogConfig.java
@@ -244,11 +244,18 @@ public final class NetworkLogConfig implements IHasForgeLog {
         if (testMode && (batchId != null || globalInstanceSuffix != null)) {
             return computeLogfileKey();
         }
-        // In normal mode, use timestamp-based key
+        // In normal mode, only return a key if logging was explicitly activated
+        return normalModeKey;
+    }
+
+    /**
+     * Activate network logging for a real (non-test) network game.
+     * Sets the timestamp-based log file key so the writer starts routing to files.
+     */
+    public static void activateNetworkLogging() {
         if (normalModeKey == null) {
             normalModeKey = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"));
         }
-        return normalModeKey;
     }
 
     /**

--- a/forge-gui/src/main/java/forge/gamemodes/net/NetworkLogConfig.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/NetworkLogConfig.java
@@ -259,6 +259,15 @@ public final class NetworkLogConfig implements IHasForgeLog {
     }
 
     /**
+     * Deactivate network logging after a network game ends.
+     * Clears the normal-mode key so the writer stops routing to files.
+     * Does not affect test mode.
+     */
+    public static void deactivateNetworkLogging() {
+        normalModeKey = null;
+    }
+
+    /**
      * Compute the composite logfile key from instance suffix and test mode.
      * In test mode with a batchId, the batchId is used as the subdirectory name
      * rather than being part of the filename.

--- a/forge-gui/src/main/java/forge/gamemodes/net/NetworkLogWriter.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/NetworkLogWriter.java
@@ -54,6 +54,8 @@ public class NetworkLogWriter extends AbstractFormatPatternWriter {
             String globalKey = NetworkLogConfig.getGlobalLogfileKey();
             if (globalKey != null) {
                 key = globalKey;
+            } else {
+                return; // No logging context configured
             }
         }
 

--- a/forge-gui/src/main/java/forge/gamemodes/net/client/FGameClient.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/client/FGameClient.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import forge.game.player.PlayerView;
 import forge.gamemodes.net.CompatibleObjectDecoder;
 import forge.gamemodes.net.CompatibleObjectEncoder;
+import forge.gamemodes.net.NetworkLogConfig;
 import forge.util.IHasForgeLog;
 import forge.gamemodes.net.ReplyPool;
 import forge.gamemodes.net.event.*;
@@ -95,6 +96,7 @@ public class FGameClient implements IToServer, IHasForgeLog {
     public void close() {
         if (channel != null)
             channel.close();
+        NetworkLogConfig.deactivateNetworkLogging();
     }
 
     @Override

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
@@ -11,6 +11,7 @@ import forge.gamemodes.match.LobbySlotType;
 import forge.gamemodes.match.input.InputSynchronized;
 import forge.gamemodes.net.CompatibleObjectDecoder;
 import forge.gamemodes.net.CompatibleObjectEncoder;
+import forge.gamemodes.net.NetworkLogConfig;
 import forge.util.IHasForgeLog;
 import forge.gamemodes.net.event.*;
 import forge.gui.GuiBase;
@@ -225,6 +226,7 @@ public final class FServerManager implements IHasForgeLog {
         }
         isHosting = false;
         UPnPMapped = false;
+        NetworkLogConfig.deactivateNetworkLogging();
         // create new EventLoopGroups for potential restart
         bossGroup = new NioEventLoopGroup(1);
         workerGroup = new NioEventLoopGroup();


### PR DESCRIPTION
## Issue

`NetworkLogWriter` routes `NETWORK`-tagged log entries to per-session files, keyed by a timestamp or test instance identifier (e.g. `network-debug-20260414-053515.log`, `network-debug-game0-2p-test.log`). This keying exists so multi-process batch tests can route each game's logs to separate files. But the key also serves as an implicit "enabled" flag — the writer creates a file whenever a non-null key exists.

The problem: `getGlobalLogfileKey()` lazily initialized this key on first call, so any `netLog.trace()` in shared code paths (`InputSyncronizedBase`, `PlayerControllerHuman`) triggered file creation even in local AI games.

## Fix

Remove the lazy init so `getGlobalLogfileKey()` returns null by default. Add `activateNetworkLogging()` which `NetConnectUtil.host()` and `join()` call explicitly. The writer's `write()` method returns early when no key is configured. Deactivation happens when the server stops or the client disconnects, so a subsequent network session gets a fresh log file.

Three paths:
- **Network game:** `host()`/`join()` → `activateNetworkLogging()` sets `normalModeKey` → logs written → `stopServer()`/`close()` → `deactivateNetworkLogging()` clears it
- **Tests:** `setTestMode(true)` → `getGlobalLogfileKey()` uses batch/instance machinery → logs written (deactivation does not affect this path)
- **Local AI game:** nothing called → `normalModeKey` is null → `write()` returns early → no files

Returning to the lobby between games keeps the same key since neither teardown fires until the session ends.

**Testing:** 
- Local AI games do not trigger network log file creation. 
- Log files start being written as soon as joining the online lobby.
- Closing server and starting a new lobby results in fresh network log being written.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)