### PR TITLE
Fix Arnyn, Deathbloom Botanist missing Deathtouch keyword

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/arnyn_deathbloom_botanist.txt
+++ b/forge-gui/res/cardsfolder/upcoming/arnyn_deathbloom_botanist.txt
@@ -2,7 +2,8 @@ Name:Arnyn, Deathbloom Botanist
 ManaCost:2 B
 Types:Legendary Creature Vampire Druid
 PT:2/2
+K:Deathtouch
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.YouCtrl+powerLE1,Creature.YouCtrl+toughnessLE1 | TriggerZones$ Battlefield | Execute$ TrigLoseLife | TriggerDescription$ Whenever a creature you control with power or toughness 1 or less dies, target opponent loses 2 life and you gain 2 life.
 SVar:TrigLoseLife:DB$ LoseLife | ValidTgts$ Opponent | LifeAmount$ 2 | SubAbility$ DBGainLife
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 2
-Oracle:Whenever a creature you control with power or toughness 1 or less dies, target opponent loses 2 life and you gain 2 life.
+Oracle:Deathtouch\nWhenever a creature you control with power or toughness 1 or less dies, target opponent loses 2 life and you gain 2 life.


### PR DESCRIPTION
## Summary

Arnyn, Deathbloom Botanist is missing her `Deathtouch` keyword in her card script. The card as printed has Deathtouch, but only the drain trigger was implemented.

**Change:** Added `K:Deathtouch` line and updated Oracle text to include Deathtouch.

## Card reference

> **Arnyn, Deathbloom Botanist** — 2B  
> Legendary Creature — Vampire Druid (2/2)  
> Deathtouch  
> Whenever a creature you control with power or toughness 1 or less dies, target opponent loses 2 life and you gain 2 life.

🤖 Generated with [Claude Code](https://claude.com/claude-code)