### PR TITLE
Try to get find cards in same set first

### DIFF
--- a/forge-core/src/main/java/forge/card/CardDb.java
+++ b/forge-core/src/main/java/forge/card/CardDb.java
@@ -672,12 +672,28 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
             CardEdition edition = editions.get(reqEditionCode.toUpperCase());
 
             PaperCard cardFromSet = this.getCardFromSet(request.cardName, edition, request.artIndex, request.collectorNumber, request.isFoil);
-            if(cardFromSet != null && request.flags != null)
+            if (cardFromSet != null && request.flags != null) {
                 cardFromSet = cardFromSet.copyWithFlags(request.flags);
+            }
 
-            if (cardFromSet != null)
+            if (cardFromSet != null) {
                 return cardFromSet;
+            }
+
+            if (request.artIndex > 0
+                    || (request.collectorNumber != null && !request.collectorNumber.isEmpty() && !request.collectorNumber.equals(IPaperCard.NO_COLLECTOR_NUMBER))) {
+                // If request failed, try again without artIndex and collectorNumber to attempt to find from same set first
+                cardFromSet = this.getCardFromSet(request.cardName, edition, -1, IPaperCard.NO_COLLECTOR_NUMBER, request.isFoil);
+                if(cardFromSet != null && request.flags != null)
+                    cardFromSet = cardFromSet.copyWithFlags(request.flags);
+
+                if (cardFromSet != null) {
+                    return cardFromSet;
+                }
+            }
+
         }
+
 
         // 2. Card lookup in edition with specified filter didn't work.
         // So now check whether the cards exist in the DB first,

--- a/forge-gui/res/adventure/Realm of Legends/decks/starter/commanderprecon/40K - The Ruinous Powers.dck
+++ b/forge-gui/res/adventure/Realm of Legends/decks/starter/commanderprecon/40K - The Ruinous Powers.dck
@@ -51,7 +51,7 @@ Set=40K
 1 Mandate of Abaddon|40K|1
 1 Molten Slagheap|40K|1
 1 Mortarion, Daemon Primarch|40K|1
-8 Mountain|40K|3
+8 Mountain|40K|2
 1 Mutalith Vortex Beast|40K|1
 1 Noise Marine|40K|1
 1 Nurgle's Conscription|40K|1

--- a/forge-gui/res/quest/commanderprecons/The Ruinous Powers [40K] [2022].dck
+++ b/forge-gui/res/quest/commanderprecons/The Ruinous Powers [40K] [2022].dck
@@ -51,7 +51,7 @@ Set=40K
 1 Mandate of Abaddon|40K|1
 1 Molten Slagheap|40K|1
 1 Mortarion, Daemon Primarch|40K|1
-8 Mountain|40K|3
+8 Mountain|40K|2
 1 Mutalith Vortex Beast|40K|1
 1 Noise Marine|40K|1
 1 Nurgle's Conscription|40K|1


### PR DESCRIPTION
If card is not found with artIndex and/or collectorNumber, try again to find it in the same set without them. Only then fallback to full database if still not found.

_Example: the 40K commander precon "Ruinous Powers" contains `Mountain|40K|3`. Although the 40K set has Mountains, it does not have one at artIndex 3. Currently this causes another Mountain to be loaded according to user art preferences, either from LEA or the latest set (eg TMT). A more logical behavior would be to load another Mountain from 40K instead, as these are available._