### PR TITLE
Post-match lobby cleanup and network concede fixes

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
@@ -352,12 +352,16 @@ public abstract class AbstractGuiGame implements IGuiGame, IMayViewCards {
         }
         if (hasLocalPlayers()) {
             boolean concedeNeeded = false;
-            // check if anyone still needs to confirm
+            // check if anyone still needs to concede
             for (final IGameController c : getOriginalGameControllers()) {
-                if (c instanceof PlayerControllerHuman) {
-                    if (((PlayerControllerHuman) c).getPlayer().getOutcome() == null) {
+                if (c instanceof PlayerControllerHuman pch) {
+                    if (pch.getPlayer().getOutcome() == null) {
                         concedeNeeded = true;
                     }
+                } else {
+                    // Network client — no access to Player outcome, but game
+                    // is still in progress (isGameOver checked above)
+                    concedeNeeded = true;
                 }
             }
             if (concedeNeeded) {
@@ -375,6 +379,11 @@ public abstract class AbstractGuiGame implements IGuiGame, IMayViewCards {
                 }
             } else {
                 return !ignoreConcedeChain;
+            }
+            if (isNetGame()) {
+                // Network: concede was sent to server asynchronously.
+                // Let the server drive game-end flow — don't send nextGameDecision here.
+                return false;
             }
             if (gameView.isGameOver()) {
                 // Don't immediately close, wait for win/lose screen

--- a/forge-gui/src/main/java/forge/gamemodes/match/GameLobby.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/GameLobby.java
@@ -527,6 +527,7 @@ public abstract class GameLobby implements IHasGameType {
         //if above checks succeed, return runnable that can be used to finish starting game
         return () -> {
             hostedMatch = GuiBase.getInterface().hostMatch();
+            hostedMatch.setOnMatchOver(this::onMatchOver);
             hostedMatch.startMatch(GameType.Constructed, variantTypes, players, guis);
 
             for (final Player p : hostedMatch.getGame().getPlayers()) {
@@ -540,6 +541,18 @@ public abstract class GameLobby implements IHasGameType {
 
             onGameStarted();
         };
+    }
+
+    protected void onMatchOver() {
+        hostedMatch = null;
+        gameControllers.clear();
+        for (int i = 0; i < getNumberOfSlots(); i++) {
+            final LobbySlot slot = getSlot(i);
+            if (slot != null) {
+                slot.setIsReady(false);
+            }
+        }
+        updateView(true);
     }
 
     public final static class GameLobbyData implements Serializable {

--- a/forge-gui/src/main/java/forge/gamemodes/match/HostedMatch.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/HostedMatch.java
@@ -56,6 +56,7 @@ public class HostedMatch {
     public HashMap<LobbySlot, IGameController> gameControllers = null;
     private Runnable startGameHook = null;
     private Runnable endGameHook = null;
+    private Runnable onMatchOver = null;
     private final List<PlayerControllerHuman> humanControllers = Lists.newArrayList();
     private Map<RegisteredPlayer, IGuiGame> guis;
     private int humanCount;
@@ -81,6 +82,7 @@ public class HostedMatch {
         startGameHook = hook;
     }
     public void setEndGameHook(Runnable hook) { endGameHook = hook; }
+    public void setOnMatchOver(Runnable callback) { onMatchOver = callback; }
 
     private static GameRules getDefaultRules(final GameType gameType) {
         final GameRules gameRules = new GameRules(gameType);
@@ -364,6 +366,18 @@ public class HostedMatch {
 
         game = null;
 
+        // Must precede shutdownForwarder — observer references become stale after null
+        for (PlayerControllerHuman hc : humanControllers) {
+            if (hc.getGui() instanceof forge.gamemodes.net.server.RemoteClientGuiGame ngg) {
+                forge.gui.control.GameEventForwarder fwd = ngg.getForwarder();
+                if (fwd != null) {
+                    for (PlayerControllerHuman allHc : humanControllers) {
+                        allHc.getInputQueue().deleteObserver(fwd);
+                    }
+                }
+            }
+        }
+
         for (final PlayerControllerHuman humanController : humanControllers) {
             if (humanController.getGui() instanceof forge.gamemodes.net.server.RemoteClientGuiGame ngg) {
                 ngg.shutdownForwarder();
@@ -520,6 +534,9 @@ public class HostedMatch {
             FThreads.invokeInEdtNowOrLater(() -> {
                 endCurrentGame();
                 isMatchOver = true;
+                if (onMatchOver != null) {
+                    onMatchOver.run();
+                }
             });
             return; // if any player chooses quit, quit the match
         }

--- a/forge-gui/src/main/java/forge/gamemodes/match/HostedMatch.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/HostedMatch.java
@@ -305,6 +305,17 @@ public class HostedMatch {
                 endGameHook.run();
             }
 
+            // Flush any buffered game events to remote clients so they receive
+            // GameEventGameOutcome and GameEventGameFinished before we proceed.
+            for (PlayerControllerHuman hc : humanControllers) {
+                if (hc.getGui() instanceof forge.gamemodes.net.server.RemoteClientGuiGame ngg) {
+                    forge.gui.control.GameEventForwarder fwd = ngg.getForwarder();
+                    if (fwd != null) {
+                        fwd.flush();
+                    }
+                }
+            }
+
             // After game is over...
             isMatchOver = match.isMatchOver();
             if (humanCount == 0) {

--- a/forge-gui/src/main/java/forge/gamemodes/net/GameProtocolHandler.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/GameProtocolHandler.java
@@ -47,6 +47,18 @@ public abstract class GameProtocolHandler<T> extends ChannelInboundHandlerAdapte
             protocolMethod.checkArgs(args);
 
             final Object toInvoke = getToInvoke(ctx);
+            if (toInvoke == null) {
+                netLog.info("Ignoring {} — controller no longer available (game ended)", methodName);
+                // For methods expecting a reply, send null so the client doesn't hang
+                final Class<?> earlyReturnType = protocolMethod.getReturnType();
+                if (!earlyReturnType.equals(Void.TYPE)) {
+                    final IRemote remote = getRemote(ctx);
+                    if (remote != null) {
+                        remote.send(new ReplyEvent(event.getId(), null));
+                    }
+                }
+                return;
+            }
 
             // Pre-call actions (runs on IO thread — blocks all subsequent messages)
             final long beforeCallStart = System.currentTimeMillis();

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/GameServerHandler.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/GameServerHandler.java
@@ -33,7 +33,8 @@ final class GameServerHandler extends GameProtocolHandler<IGameController> imple
 
     @Override
     protected IGameController getToInvoke(final ChannelHandlerContext ctx) {
-        return server.getController(getClient(ctx).getIndex());
+        final RemoteClient client = getClient(ctx);
+        return client != null ? server.getController(client.getIndex()) : null;
     }
 
     @Override

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/ServerGameLobby.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/ServerGameLobby.java
@@ -82,4 +82,11 @@ public final class ServerGameLobby extends GameLobby {
     @Override
     protected void onGameStarted() {
     }
+
+    @Override
+    protected void onMatchOver() {
+        super.onMatchOver();
+        FServerManager.getInstance().clearPlayerGuis();
+        FServerManager.getInstance().updateLobbyState();
+    }
 }

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -3344,6 +3344,15 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
         if (player != null) {
             player.concede();
             getGame().getAction().checkGameOverCondition();
+            if (getGame().isGameOver()) {
+                // Release all input latches — the game thread may be blocked
+                // on a different player's input queue than the one who conceded
+                for (Player p : getGame().getPlayers()) {
+                    if (p.getController() instanceof PlayerControllerHuman pch) {
+                        pch.getInputQueue().onGameOver(true);
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Addresses Phase 0.5 of the network draft/sealed implementation plan — hardening existing network match lifecycle before adding new game modes. Also fixes several pre-existing network concede bugs observed during testing. See discussion at [Card-Forge/forge<!-- -->#9861 (comment)](https://github.com/Card-Forge/forge/issues/9861#issuecomment-4234120552) and [follow-up](https://github.com/Card-Forge/forge/issues/9861#issuecomment-4245231008).

## Issues addressed

- **No lobby cleanup after network match** — the previous match's state lingered in the lobby after returning. Added `onMatchOver` callback to reset lobby state (null hostedMatch, un-ready slots, clear player GUIs, push lobby update to clients).

- **Client concede dialog never appeared** — `instanceof PlayerControllerHuman` excluded `NetGameController`, so the concede confirmation was silently skipped. Broadened the check to include network controllers.

- **Client concede force-quit both players** — client sent a premature `nextGameDecision(QUIT)` before the server processed the concede, ending the match for both. Network games now let the server drive the game-end flow.

- **Game thread blocked after concede** — only the conceding player's input latch was released, but the game thread could be waiting on the other player's input queue. Now releases all players' input latches.

- **Remote client never saw win/lose screen** — game-end events were buffered in `GameEventForwarder` and never flushed. Added explicit flush after the game loop exits.

- **NPEs from late-arriving messages** — protocol messages arriving after cleanup caused `NullPointerException` on the server. Added null guards in the protocol handler with null reply for non-void methods.

## Why these changes are safe

- **Lobby cleanup** only runs when a match ends via `NextGameDecision.QUIT` — the same path that already calls `endCurrentGame()`. It adds cleanup *after* existing teardown, doesn't change teardown order.
- **Concede dialog fix** only affects network clients. Local games still go through the `PlayerControllerHuman` path with the per-player outcome check. No behavior change for single-player or local multiplayer.
- **Skipping premature QUIT** only applies to network games (`isNetGame()` guard). Local games still send `nextGameDecision` synchronously as before.
- **Input latch release** is idempotent — `CountDownLatch.countDown()` on an already-released latch is a no-op.
- **Protocol null guards** only fire after cleanup when controllers are already gone. During normal gameplay, `getToInvoke()` and `getClient()` always return non-null.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)