### PR TITLE
Fix commander CardView desync on remote client

### DIFF
--- a/forge-game/src/main/java/forge/trackable/TrackableTypes.java
+++ b/forge-game/src/main/java/forge/trackable/TrackableTypes.java
@@ -104,7 +104,11 @@ public class TrackableTypes {
                     if (newObj != null) {
                         T existingObj = from.getTracker().getObj(itemType, newObj.getId());
                         if (existingObj != null) {
-                            existingObj.copyChangedProps(newObj);
+                            // Skip CardView collections — cross-zone refs like Commander hold stale copies
+                            if (prop.getType() != TrackableTypes.CardViewCollectionType &&
+                                    prop.getType() != TrackableTypes.StackItemViewListType) {
+                                existingObj.copyChangedProps(newObj);
+                            }
                             newCollection.add(existingObj);
                         } else {
                             from.getTracker().putObj(itemType, newObj.getId(), newObj);


### PR DESCRIPTION
@tool4ever - closes Card-Forge/forge#10406

**[Full root cause analysis, log analysis, and investigation results are in the attached document.](https://github.com/user-attachments/files/26765008/commander-desync-investigation.md)**

## Summary

Fixes a regression from #9642 where commanders on the remote client display incorrect state with delta-sync disabled:
- No summoning sickness icon when commander enters the battlefield
- Attacking commander appears untapped
- Cannot select commander as blocker (clicks ignored)

## Root Cause

`TrackableCollectionType.copyChangedProps` unconditionally copies properties from incoming CardViews onto the tracker's canonical instance. The `Commander` property (ordinal 210) is a cross-zone reference list that holds stale CardView copies (e.g. `zone=Stack`) sharing IDs with zone collections. Because it's processed before `Battlefield` (ordinal 216), it overwrites the canonical instance with stale state. The Battlefield pass becomes a self-copy no-op, so the corruption persists.

## Fix

Restore the pre-#9642 skip for `CardViewCollectionType` and `StackItemViewListType`: swap to the tracker instance for identity consistency (required by delta sync) but skip per-item property copying. This is safe for all card types — regular cards exist in exactly one zone, so the skip is a no-op (the tracker instance already has current properties from `refreshTrackerCardViews`). Commander damage and cast counts are `IntegerMapType` properties on PlayerView, not CardView collections, so they are unaffected.



## Testing



- **Manual (non-delta):** 2-player Commander, host commander displays correctly on client. Zero errors.
- **Manual (delta sync on):** 2-player Commander, same correct behavior. 6 checksums verified, zero mismatches.
- **Automated batch (delta sync on):** 10/10 games passed (3 Commander + 7 Constructed, 2p/3p/4p). 127 checksums verified across 2643 deltas, zero mismatches. Bandwidth savings: 91.0% overall, 94.6% state-only.

## Architectural note (true root cause)

`Commander` and `Flashback` are typed as `CardViewCollectionType` — the same type as actual zones — but have different semantics. They are cross-zone reference lists holding duplicate CardView copies of cards that also exist in their real zone collections. This type mismatch is the true root cause — `copyChangedProps` cannot distinguish zone collections (authoritative) from cross-zone references (stale copies). A cleaner model would store card IDs rather than full CardView copies, eliminating this class of bugs entirely. This fix is correct and minimal; the architectural debt remains.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)