### PR TITLE
Highlight server warnings in multiplayer chat

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/gui/FNetOverlay.java
+++ b/forge-gui-desktop/src/main/java/forge/gui/FNetOverlay.java
@@ -135,7 +135,7 @@ public enum FNetOverlay implements IOnlineChatInterface {
         Color playerColor = (skinTextColor != null) ? skinTextColor.getColor() : Color.WHITE;
         StyleConstants.setForeground(playerStyle, playerColor);
 
-        // Warning style: amber/caution color, distinct from blue system / white player.
+        // Warning style: amber/caution color, distinct from blue system / white player
         StyleConstants.setForeground(warningStyle, new Color(230, 160, 50));
 
         window.setTitle(Localizer.getInstance().getMessage("lblChat"));

--- a/forge-gui-desktop/src/main/java/forge/gui/FNetOverlay.java
+++ b/forge-gui-desktop/src/main/java/forge/gui/FNetOverlay.java
@@ -81,6 +81,7 @@ public enum FNetOverlay implements IOnlineChatInterface {
     private StyledDocument doc;
     private SimpleAttributeSet systemStyle;
     private SimpleAttributeSet playerStyle;
+    private SimpleAttributeSet warningStyle;
 
     private final FTextField txtInput = new FTextField.Builder().maxLength(255).build();
     private final FLabel cmdSend = new FLabel.ButtonBuilder().text(Localizer.getInstance().getMessage("lblSend")).build(); 
@@ -124,6 +125,7 @@ public enum FNetOverlay implements IOnlineChatInterface {
         doc = txtLog.getStyledDocument();
         systemStyle = new SimpleAttributeSet();
         playerStyle = new SimpleAttributeSet();
+        warningStyle = new SimpleAttributeSet();
 
         // Configure system message style: light blue RGB(100, 150, 255) - matches mobile implementation
         StyleConstants.setForeground(systemStyle, new Color(100, 150, 255));
@@ -132,6 +134,9 @@ public enum FNetOverlay implements IOnlineChatInterface {
         FSkin.SkinColor skinTextColor = FSkin.getColor(FSkin.Colors.CLR_TEXT);
         Color playerColor = (skinTextColor != null) ? skinTextColor.getColor() : Color.WHITE;
         StyleConstants.setForeground(playerStyle, playerColor);
+
+        // Warning style: amber/caution color, distinct from blue system / white player.
+        StyleConstants.setForeground(warningStyle, new Color(230, 160, 50));
 
         window.setTitle(Localizer.getInstance().getMessage("lblChat"));
         window.setVisible(false);
@@ -191,8 +196,7 @@ public enum FNetOverlay implements IOnlineChatInterface {
         if (message != null) {
             try {
                 doc.remove(0, doc.getLength());
-                SimpleAttributeSet style = message.isSystemMessage() ? systemStyle : playerStyle;
-                doc.insertString(0, message.getFormattedMessage(), style);
+                doc.insertString(0, message.getFormattedMessage(), styleFor(message));
             } catch (BadLocationException e) {
                 // Fallback to plain text if styled insert fails
                 txtLog.setText(message.getFormattedMessage());
@@ -257,13 +261,19 @@ public enum FNetOverlay implements IOnlineChatInterface {
     @Override
     public void addMessage(final ChatMessage message) {
         try {
-            // Choose style based on message type
-            SimpleAttributeSet style = message.isSystemMessage() ? systemStyle : playerStyle;
             String text = "\n" + message.getFormattedMessage();
-            doc.insertString(doc.getLength(), text, style);
+            doc.insertString(doc.getLength(), text, styleFor(message));
         } catch (BadLocationException e) {
             // Fallback - should not occur in normal operation
             e.printStackTrace();
         }
+    }
+
+    private SimpleAttributeSet styleFor(final ChatMessage message) {
+        return switch (message.getType()) {
+            case WARNING -> warningStyle;
+            case SYSTEM  -> systemStyle;
+            default      -> playerStyle;
+        };
     }
 }

--- a/forge-gui-desktop/src/test/java/forge/net/HeadlessNetworkClient.java
+++ b/forge-gui-desktop/src/test/java/forge/net/HeadlessNetworkClient.java
@@ -2,6 +2,7 @@ package forge.net;
 
 import forge.game.GameView;
 import forge.gamemodes.net.DeltaPacket;
+import forge.gamemodes.net.ChatMessage;
 import forge.util.IHasForgeLog;
 import forge.gamemodes.match.GameLobby.GameLobbyData;
 import forge.gamemodes.net.client.ClientGameLobby;
@@ -237,7 +238,7 @@ public class HeadlessNetworkClient implements AutoCloseable, IHasForgeLog {
         }
 
         @Override
-        public void message(String source, String message, forge.gamemodes.net.ChatMessage.MessageType type) {
+        public void message(String source, String message, ChatMessage.MessageType type) {
             netLog.info("Chat: {}: {}", source, message);
         }
 

--- a/forge-gui-desktop/src/test/java/forge/net/HeadlessNetworkClient.java
+++ b/forge-gui-desktop/src/test/java/forge/net/HeadlessNetworkClient.java
@@ -237,7 +237,7 @@ public class HeadlessNetworkClient implements AutoCloseable, IHasForgeLog {
         }
 
         @Override
-        public void message(String source, String message) {
+        public void message(String source, String message, forge.gamemodes.net.ChatMessage.MessageType type) {
             netLog.info("Chat: {}: {}", source, message);
         }
 

--- a/forge-gui-desktop/src/test/java/forge/net/UnifiedNetworkHarness.java
+++ b/forge-gui-desktop/src/test/java/forge/net/UnifiedNetworkHarness.java
@@ -496,7 +496,7 @@ public class UnifiedNetworkHarness implements IHasForgeLog {
             }
 
             @Override
-            public void message(String source, String message) {
+            public void message(String source, String message, forge.gamemodes.net.ChatMessage.MessageType type) {
                 netLog.info("Lobby message from {}: {}", source, message);
             }
 

--- a/forge-gui-desktop/src/test/java/forge/net/UnifiedNetworkHarness.java
+++ b/forge-gui-desktop/src/test/java/forge/net/UnifiedNetworkHarness.java
@@ -11,6 +11,7 @@ import forge.gamemodes.match.GameLobby.GameLobbyData;
 import forge.gamemodes.match.HostedMatch;
 import forge.gamemodes.match.LobbySlot;
 import forge.gamemodes.match.LobbySlotType;
+import forge.gamemodes.net.ChatMessage;
 import forge.util.IHasForgeLog;
 import forge.gamemodes.net.NetworkByteTracker;
 import forge.gamemodes.net.NetworkLogConfig;
@@ -496,7 +497,7 @@ public class UnifiedNetworkHarness implements IHasForgeLog {
             }
 
             @Override
-            public void message(String source, String message, forge.gamemodes.net.ChatMessage.MessageType type) {
+            public void message(String source, String message, ChatMessage.MessageType type) {
                 netLog.info("Lobby message from {}: {}", source, message);
             }
 

--- a/forge-gui-mobile/src/forge/screens/online/OnlineChatScreen.java
+++ b/forge-gui-mobile/src/forge/screens/online/OnlineChatScreen.java
@@ -103,6 +103,7 @@ public class OnlineChatScreen extends FScreen implements IOnlineChatInterface {
         private static final FSkinFont FONT = FSkinFont.get(12);
         private static final FSkinColor LOCAL_COLOR = FSkinColor.get(Colors.CLR_ZEBRA);
         private static final FSkinColor REMOTE_COLOR = LOCAL_COLOR.getContrastColor(-20);
+        private static final FSkinColor WARNING_COLOR = FSkinColor.getStandardColor(140, 95, 25);
         private static final FSkinColor MESSAGE_COLOR = FSkinColor.get(Colors.CLR_TEXT);
         private static final FSkinColor SOURCE_COLOR = MESSAGE_COLOR.alphaColor(0.75f);
         private static final FSkinColor TIMESTAMP_COLOR = MESSAGE_COLOR.alphaColor(0.5f);
@@ -142,7 +143,12 @@ public class OnlineChatScreen extends FScreen implements IOnlineChatInterface {
             float y = TEXT_INSET;
             float w = getWidth() - TRIANGLE_WIDTH;
             float h = getHeight() - TEXT_INSET;
-            FSkinColor color = isLocal ? LOCAL_COLOR : REMOTE_COLOR;
+            FSkinColor color;
+            if (message.getType() == ChatMessage.MessageType.WARNING) {
+                color = WARNING_COLOR;
+            } else {
+                color = isLocal ? LOCAL_COLOR : REMOTE_COLOR;
+            }
             int horzAlignment = isLocal ? Align.right : Align.left;
             float timestampHeight = FONT.getCapHeight();
             

--- a/forge-gui/src/main/java/forge/gamemodes/net/ChatMessage.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/ChatMessage.java
@@ -42,10 +42,6 @@ public class ChatMessage {
         return source == null || source.equals(prefs.getPref(FPref.PLAYER_NAME));
     }
 
-    public boolean isSystemMessage() {
-        return type == MessageType.SYSTEM;
-    }
-
     public MessageType getType() {
         return type;
     }

--- a/forge-gui/src/main/java/forge/gamemodes/net/ChatMessage.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/ChatMessage.java
@@ -13,7 +13,8 @@ public class ChatMessage {
 
     public enum MessageType {
         PLAYER,   // Regular player chat message
-        SYSTEM    // System notification (displayed in blue)
+        SYSTEM,   // System notification (displayed in blue)
+        WARNING   // Significant server warning (displayed in amber)
     }
 
     private final String source, message, timestamp;

--- a/forge-gui/src/main/java/forge/gamemodes/net/NetConnectUtil.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/NetConnectUtil.java
@@ -70,8 +70,8 @@ public class NetConnectUtil {
                 // NO-OP, lobby connected directly
             }
             @Override
-            public void message(final String source, final String message) {
-                chatInterface.addMessage(new ChatMessage(source, message));
+            public void message(final String source, final String message, final ChatMessage.MessageType type) {
+                chatInterface.addMessage(new ChatMessage(source, message, type));
             }
             @Override
             public void close() {
@@ -172,8 +172,8 @@ public class NetConnectUtil {
         lobby.setListener(view);
         client.addLobbyListener(new ILobbyListener() {
             @Override
-            public void message(final String source, final String message) {
-                chatInterface.addMessage(new ChatMessage(source, message));
+            public void message(final String source, final String message, final ChatMessage.MessageType type) {
+                chatInterface.addMessage(new ChatMessage(source, message, type));
             }
             @Override
             public void update(final GameLobbyData state, final int slot) {

--- a/forge-gui/src/main/java/forge/gamemodes/net/client/FGameClient.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/client/FGameClient.java
@@ -162,7 +162,7 @@ public class FGameClient implements IToServer, IHasForgeLog {
         public void channelRead(final ChannelHandlerContext ctx, final Object msg) throws Exception {
             if (msg instanceof MessageEvent event) {
                 for (final ILobbyListener listener : lobbyListeners) {
-                    listener.message(event.getSource(), event.getMessage());
+                    listener.message(event.getSource(), event.getMessage(), event.getType());
                 }
             }
             super.channelRead(ctx, msg);

--- a/forge-gui/src/main/java/forge/gamemodes/net/event/MessageEvent.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/event/MessageEvent.java
@@ -1,17 +1,29 @@
 package forge.gamemodes.net.event;
 
+import forge.gamemodes.net.ChatMessage;
 import forge.gamemodes.net.server.RemoteClient;
 
 public final class MessageEvent implements NetEvent {
     private static final long serialVersionUID = 1700060210647684186L;
 
     private final String source, message;
+    // Null for backwards compat with pre-WARNING-tag senders; getType() normalizes.
+    private final ChatMessage.MessageType type;
+
     public MessageEvent(final String message) {
-        this(null, message);
+        this(null, message, null);
     }
     public MessageEvent(final String source, final String message) {
+        this(source, message, null);
+    }
+    public MessageEvent(final String source, final String message, final ChatMessage.MessageType type) {
         this.source = source;
         this.message = message;
+        this.type = type;
+    }
+
+    public static MessageEvent warning(final String message) {
+        return new MessageEvent(null, message, ChatMessage.MessageType.WARNING);
     }
 
     @Override
@@ -24,6 +36,11 @@ public final class MessageEvent implements NetEvent {
 
     public String getMessage() {
         return message;
+    }
+
+    public ChatMessage.MessageType getType() {
+        if (type != null) return type;
+        return source == null ? ChatMessage.MessageType.SYSTEM : ChatMessage.MessageType.PLAYER;
     }
 
     @Override

--- a/forge-gui/src/main/java/forge/gamemodes/net/event/MessageEvent.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/event/MessageEvent.java
@@ -7,16 +7,19 @@ public final class MessageEvent implements NetEvent {
     private static final long serialVersionUID = 1700060210647684186L;
 
     private final String source, message;
-    // Null for backwards compat with pre-WARNING-tag senders; getType() normalizes.
-    private final ChatMessage.MessageType type;
+    // String not enum — unknown enum constants cause InvalidObjectException on older clients
+    private final String type;
 
     public MessageEvent(final String message) {
-        this(null, message, null);
+        this(null, message, (String) null);
     }
     public MessageEvent(final String source, final String message) {
-        this(source, message, null);
+        this(source, message, (String) null);
     }
     public MessageEvent(final String source, final String message, final ChatMessage.MessageType type) {
+        this(source, message, type != null ? type.name() : null);
+    }
+    private MessageEvent(final String source, final String message, final String type) {
         this.source = source;
         this.message = message;
         this.type = type;
@@ -39,8 +42,14 @@ public final class MessageEvent implements NetEvent {
     }
 
     public ChatMessage.MessageType getType() {
-        if (type != null) return type;
-        return source == null ? ChatMessage.MessageType.SYSTEM : ChatMessage.MessageType.PLAYER;
+        if (type == null) {
+            return source == null ? ChatMessage.MessageType.SYSTEM : ChatMessage.MessageType.PLAYER;
+        }
+        try {
+            return ChatMessage.MessageType.valueOf(type);
+        } catch (IllegalArgumentException e) {
+            return ChatMessage.MessageType.SYSTEM;
+        }
     }
 
     @Override

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
@@ -9,6 +9,7 @@ import forge.gamemodes.match.HostedMatch;
 import forge.gamemodes.match.LobbySlot;
 import forge.gamemodes.match.LobbySlotType;
 import forge.gamemodes.match.input.InputSynchronized;
+import forge.gamemodes.net.ChatMessage;
 import forge.gamemodes.net.CompatibleObjectDecoder;
 import forge.gamemodes.net.CompatibleObjectEncoder;
 import forge.gamemodes.net.NetworkLogConfig;
@@ -943,7 +944,7 @@ public final class FServerManager implements IHasForgeLog {
 
                 broadcast(MessageEvent.warning(
                     String.format("%s disconnected. Waiting %s for reconnect...", username, formatTime(RECONNECT_TIMEOUT_SECONDS))));
-                lobbyListener.message(null, "(Host can use /skipreconnect to replace disconnected player with AI, or /skiptimeout to wait indefinitely.)");
+                lobbyListener.message(null, "(Host can use /skipreconnect to replace disconnected player with AI, or /skiptimeout to wait indefinitely.)", ChatMessage.MessageType.SYSTEM);
                 netLog.info("[Disconnect] Player disconnected mid-game: {} (slot {}). Waiting for reconnect.", username, playerIndex);
             } else {
                 // Normal disconnect (lobby or no valid slot)

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
@@ -253,7 +253,7 @@ public final class FServerManager implements IHasForgeLog {
 
     public void broadcast(final NetEvent event) {
         if (event instanceof MessageEvent msgEvent) {
-            lobbyListener.message(msgEvent.getSource(), msgEvent.getMessage());
+            lobbyListener.message(msgEvent.getSource(), msgEvent.getMessage(), msgEvent.getType());
         }
         broadcastTo(event, clients.values());
     }
@@ -543,7 +543,7 @@ public final class FServerManager implements IHasForgeLog {
             ? localizer.getMessage("lblUPnPSuccess", String.valueOf(port))
             : localizer.getMessage("lblUPnPFailed", String.valueOf(port));
         if (lobbyListener != null) {
-            broadcast(new MessageEvent(msg));
+            broadcast(success ? new MessageEvent(msg) : MessageEvent.warning(msg));
         }
     }
 
@@ -724,7 +724,7 @@ public final class FServerManager implements IHasForgeLog {
         // Reset lobby slot
         localLobby.disconnectPlayer(client.getIndex());
 
-        broadcast(new MessageEvent(String.format("%s did not reconnect in time. AI has taken over.", username)));
+        broadcast(MessageEvent.warning(String.format("%s did not reconnect in time. AI has taken over.", username)));
     }
 
     public void convertToAI(final int slotIndex, final String username) {
@@ -858,12 +858,12 @@ public final class FServerManager implements IHasForgeLog {
                         final String clientVersion = event.getVersion();
                         final String hostVersion = BuildInfo.getVersionString();
                         if (clientVersion == null) {
-                            broadcast(new MessageEvent(String.format(
+                            broadcast(MessageEvent.warning(String.format(
                                 "Warning: Could not determine %s's Forge version. "
                                 + "Please use the same version as the host to avoid network compatibility issues.",
                                 event.getUsername())));
                         } else if (!clientVersion.equals(hostVersion)) {
-                            broadcast(new MessageEvent(String.format(
+                            broadcast(MessageEvent.warning(String.format(
                                 "Warning: %s is using Forge version %s (host: %s). "
                                 + "Please use the same version as the host to avoid network compatibility issues.",
                                 event.getUsername(), clientVersion, hostVersion)));
@@ -890,7 +890,7 @@ public final class FServerManager implements IHasForgeLog {
                 final String msg = name + " timed out after " + HEARTBEAT_TIMEOUT_SECONDS
                     + " seconds without a network response. Closing connection.";
                 netLog.warn(msg);
-                broadcast(new MessageEvent(msg));
+                broadcast(MessageEvent.warning(msg));
                 ctx.close();
                 return;
             }
@@ -941,7 +941,7 @@ public final class FServerManager implements IHasForgeLog {
                     }
                 }, 30_000L, 30_000L);
 
-                broadcast(new MessageEvent(
+                broadcast(MessageEvent.warning(
                     String.format("%s disconnected. Waiting %s for reconnect...", username, formatTime(RECONNECT_TIMEOUT_SECONDS))));
                 lobbyListener.message(null, "(Host can use /skipreconnect to replace disconnected player with AI, or /skiptimeout to wait indefinitely.)");
                 netLog.info("[Disconnect] Player disconnected mid-game: {} (slot {}). Waiting for reconnect.", username, playerIndex);

--- a/forge-gui/src/main/java/forge/interfaces/ILobbyListener.java
+++ b/forge-gui/src/main/java/forge/interfaces/ILobbyListener.java
@@ -1,10 +1,17 @@
 package forge.interfaces;
 
 import forge.gamemodes.match.GameLobby.GameLobbyData;
+import forge.gamemodes.net.ChatMessage;
 import forge.gamemodes.net.client.ClientGameLobby;
 
 public interface ILobbyListener {
-    void message(String source, String message);
+    // type may be null from older peers — implementations should fall back to source-based inference.
+    void message(String source, String message, ChatMessage.MessageType type);
+
+    default void message(String source, String message) {
+        message(source, message, null);
+    }
+
     void update(GameLobbyData state, int slot);
     void close();
     ClientGameLobby getLobby();

--- a/forge-gui/src/main/java/forge/interfaces/ILobbyListener.java
+++ b/forge-gui/src/main/java/forge/interfaces/ILobbyListener.java
@@ -5,13 +5,7 @@ import forge.gamemodes.net.ChatMessage;
 import forge.gamemodes.net.client.ClientGameLobby;
 
 public interface ILobbyListener {
-    // type may be null from older peers — implementations should fall back to source-based inference.
     void message(String source, String message, ChatMessage.MessageType type);
-
-    default void message(String source, String message) {
-        message(source, message, null);
-    }
-
     void update(GameLobbyData state, int slot);
     void close();
     ClientGameLobby getLobby();


### PR DESCRIPTION
<img width="450" alt="Screenshot 2026-04-18 112759" src="https://github.com/user-attachments/assets/91a17d6c-bcd5-4058-9a8c-8f10566e8251" />


## Summary
- Adds a `WARNING` `ChatMessage.MessageType` rendered amber on desktop (foreground) and mobile (bubble background), distinct from blue system / default player styles. Amber chosen over red for legibility on both light and dark themes.
- Tags session/connection-health broadcasts in `FServerManager`: UPnP failure, heartbeat timeout, disconnect notice, version mismatch, "did not reconnect in time".
- `MessageEvent.type` is stored as `String` (not enum) for serialization safety — unknown enum constants cause `InvalidObjectException` on older clients even when skipping fields the old class doesn't declare. `getType()` converts back to enum with fallback to `SYSTEM` for unrecognized values.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)