### PR TITLE
Support |SET pinning in booster name() predicate

### DIFF
--- a/forge-core/src/main/java/forge/item/generation/BoosterGenerator.java
+++ b/forge-core/src/main/java/forge/item/generation/BoosterGenerator.java
@@ -724,7 +724,24 @@ public class BoosterGenerator {
             } else if (operator.startsWith("name(")) {
                 operator = StringUtils.strip(operator.substring(4), "() ");
                 String[] cardNames = TextUtil.splitWithParenthesis(operator, ',', '"', '"');
-                toAdd = PaperCardPredicates.names(Lists.newArrayList(cardNames));
+                // Support "Card Name|SET" pinning: resolve to a specific PaperCard.
+                List<String> plain = new ArrayList<>();
+                List<PaperCard> pinned = new ArrayList<>();
+                for (String n : cardNames) {
+                    if (n.contains("|")) {
+                        PaperCard c = StaticData.instance().getCommonCards().getCard(n);
+                        if (c != null) pinned.add(c);
+                    } else {
+                        plain.add(n);
+                    }
+                }
+                Predicate<PaperCard> plainPred = plain.isEmpty() ? null : PaperCardPredicates.names(plain);
+                Predicate<PaperCard> pinnedPred = pinned.isEmpty() ? null : pinned::contains;
+                if (plainPred != null && pinnedPred != null) {
+                    toAdd = plainPred.or(pinnedPred);
+                } else {
+                    toAdd = plainPred != null ? plainPred : pinnedPred;
+                }
             } else if (operator.startsWith("color(")) {
                 operator = StringUtils.strip(operator.substring("color(".length() + 1), "()\" ");
                 switch (operator.toLowerCase()) {


### PR DESCRIPTION
- Booster templates using `name("Card|SET")` in a non-main-code position silently produced zero cards for that slot. The slot parser routed `name(...)` through `buildExtraPredicate`, which used `PaperCardPredicates.names(...)` to compare operand strings against `card.getName()`. Names carrying a `|SET` suffix never matched, so the slot dropped.
- First surfaced on Shandalar Old Border's ICE booster, whose snow-covered basic land slot is pinned to the ICE printing: `1 name("Snow-Covered Plains|ICE", ...)`. Packs opened 14 cards instead of 15, with no snow basic.
- Fix resolves pinned names via `StaticData.getCommonCards().getCard(name)` (same call the mainCode branch uses) and filters with a set-contains predicate. Plain names without `|` keep the existing `PaperCardPredicates.names` path, so current callers (`Final Fantasy.txt`, `Oath of the Gatewatch.txt`) are unaffected.
- Benefits every booster-generation path since they all flow through `BoosterGenerator.getBoosterPack`: shop packs, draft packs, sealed packs, event rewards.