### PR TITLE
Fix malformed Forge card file lines

### DIFF
--- a/forge-gui/res/cardsfolder/m/moira_brown_guide_author.txt
+++ b/forge-gui/res/cardsfolder/m/moira_brown_guide_author.txt
@@ -2,11 +2,9 @@ Name:Moira Brown, Guide Author
 ManaCost:1 R W
 Types:Legendary Creature Human Citizen
 PT:2/3
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When NICKNAME enters, create a colorless Book Equipment artifact token named Wasteland Survival Guide with "Equipped creature gets +1/+1 for each quest counter among permanents you control" and equip 
-{1}.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When NICKNAME enters, create a colorless Book Equipment artifact token named Wasteland Survival Guide with "Equipped creature gets +1/+1 for each quest counter among permanents you control" and equip {1}.
 SVar:TrigToken:DB$ Token | TokenScript$ wasteland_survival_guide
 T:Mode$ AttackersDeclared | AttackingPlayer$ You | Execute$ TrigPutCounter | TriggerZones$ Battlefield | TriggerDescription$ Whenever you attack, put a quest counter on target nonland permanent you control.
 SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Permanent.nonLand+YouCtrl | TgtPrompt$ Select target nonland permanent you control | CounterType$ QUEST
 DeckHas:Ability$Token|Counters & Type$Artifact
-Oracle:When Moira Brown enters, create a colorless Book Equipment artifact token named Wasteland Survival Guide with "Equipped creature gets +1/+1 for each quest counter among permanents you control" and equip 
-{1}.\nWhenever you attack, put a quest counter on target nonland permanent you control.
+Oracle:When Moira Brown enters, create a colorless Book Equipment artifact token named Wasteland Survival Guide with "Equipped creature gets +1/+1 for each quest counter among permanents you control" and equip {1}.\nWhenever you attack, put a quest counter on target nonland permanent you control.

--- a/forge-gui/res/cardsfolder/p/press_into_service.txt
+++ b/forge-gui/res/cardsfolder/p/press_into_service.txt
@@ -3,5 +3,5 @@ ManaCost:4 R
 Types:Sorcery
 A:SP$ PutCounter | Support$ 2 | SubAbility$ DBGainControl
 SVar:DBGainControl:DB$ GainControl | ValidTgts$ Creature | LoseControl$ EOT | Untap$ True | AddKWs$ Haste | SpellDescription$ Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.
-SVar:PlayMain1
+SVar:PlayMain1:TRUE
 Oracle:Support 2. (Put a +1/+1 counter on each of up to two target creatures.)\nGain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.

--- a/forge-gui/res/cardsfolder/upcoming/lorehold_charm.txt
+++ b/forge-gui/res/cardsfolder/upcoming/lorehold_charm.txt
@@ -5,5 +5,4 @@ A:SP$ Charm | Choices$ DBSacrifice,DBChangeZone,DBPumpAll
 SVar:DBSacrifice:DB$ Sacrifice | Defined$ Player.Opponent | SacValid$ Artifact.!token | SpellDescription$ Each opponent sacrifices a nontoken artifact of their choice.
 SVar:DBChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | ValidTgts$ Artifact.cmcLE2+YouOwn,Creature.cmcLE2+YouOwn | ValidTgtDesc$ artifact or creature card with mana value 2 or less in your graveyard | SpellDescription$ Return target artifact or creature card with mana value 2 or less from your graveyard to the battlefield.
 SVar:DBPumpAll:DB$ PumpAll | ValidCards$ Creature.YouCtrl | NumAtt$ +1 | NumDef$ +1 | KW$ Trample | SpellDescription$ Creatures you control get +1/+1 and gain trample until end of turn.
-Oracle:Choose one —\n• Each opponent sacrifices a nontoken artifact of their choice.\n• Return target artifact or creature card with mana value 2 or less from your graveyard to the battlefield.\n
-• Creatures you control get +1/+1 and gain trample until end of turn.
+Oracle:Choose one —\n• Each opponent sacrifices a nontoken artifact of their choice.\n• Return target artifact or creature card with mana value 2 or less from your graveyard to the battlefield.\n• Creatures you control get +1/+1 and gain trample until end of turn.


### PR DESCRIPTION
We are currently writing a parser for Forge's DSL and these three cards are failing structural parsing:

- `forge-gui/res/cardsfolder/m/moira_brown_guide_author.txt`
- `forge-gui/res/cardsfolder/p/press_into_service.txt`
- `forge-gui/res/cardsfolder/upcoming/lorehold_charm.txt`

The failures were caused by malformed file lines:

- wrapped `equip {1}.` text split across raw lines in `moira_brown_guide_author.txt`
- bare `SVar:PlayMain1` in `press_into_service.txt`
- a stray third bullet outside the `Oracle:` line in `lorehold_charm.txt`

I'm not completely sure whether these should be fixed in the card files or tolerated by downstream parsers, but I'm assuming they should be fixed here because the other `32557/32560` card files in `cardsfolder` parse the syntax correctly under the same parser.

This PR only repairs those malformed lines; it does not change any parser behavior.