### PR TITLE
Add search filter to mobile Settings menu

### DIFF
--- a/forge-gui-mobile/src/forge/screens/settings/SettingsPage.java
+++ b/forge-gui-mobile/src/forge/screens/settings/SettingsPage.java
@@ -31,12 +31,14 @@ import forge.toolbox.FGroupList;
 import forge.toolbox.FList;
 import forge.toolbox.FOptionPane;
 import forge.toolbox.FScrollPane;
+import forge.toolbox.FTextField;
 import forge.util.Lang;
 import forge.util.Utils;
 
 import java.util.*;
 
 public class SettingsPage extends TabPage<SettingsScreen> {
+    private final FTextField txtSearch = add(new FTextField());
     private final FGroupList<Setting> lstSettings = add(new FGroupList<>());
     private final CustomSelectSetting settingSkins;
     private final CustomSelectSetting settingCJKFonts;
@@ -45,6 +47,9 @@ public class SettingsPage extends TabPage<SettingsScreen> {
         super(Forge.getLocalizer().getMessage("lblSettings"), Forge.hdbuttons ? FSkinImage.HDPREFERENCE : FSkinImage.SETTINGS);
 
         lstSettings.setListItemRenderer(new SettingRenderer());
+        txtSearch.setFont(FSkinFont.get(12));
+        txtSearch.setGhostText(Forge.getLocalizer().getMessage("lblSearch"));
+        txtSearch.setChangedHandler(e -> applySearch());
 
         lstSettings.addGroup(Forge.getLocalizer().getMessage("lblGeneralSettings"));
         lstSettings.addGroup(Forge.getLocalizer().getMessage("lblGameplayOptions"));
@@ -731,9 +736,22 @@ public class SettingsPage extends TabPage<SettingsScreen> {
         settingCJKFonts.updateOptions(FSkinFont.getAllCJKFonts());
     }
 
+    private void applySearch() {
+        final String query = txtSearch.getText().toLowerCase().trim();
+        if (query.isEmpty()) {
+            lstSettings.setItemFilter(null);
+            return;
+        }
+        lstSettings.setItemFilter(setting ->
+            (setting.label != null && setting.label.toLowerCase().contains(query))
+            || (setting.description != null && setting.description.toLowerCase().contains(query)));
+    }
+
     @Override
     protected void doLayout(float width, float height) {
-        lstSettings.setBounds(0, 0, width, height);
+        float searchHeight = FTextField.getDefaultHeight(txtSearch.getFont());
+        txtSearch.setBounds(0, 0, width, searchHeight);
+        lstSettings.setBounds(0, searchHeight, width, height - searchHeight);
     }
 
     private abstract class Setting {

--- a/forge-gui-mobile/src/forge/toolbox/FGroupList.java
+++ b/forge-gui-mobile/src/forge/toolbox/FGroupList.java
@@ -2,6 +2,7 @@ package forge.toolbox;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
 
 import forge.Forge;
 import forge.Graphics;
@@ -134,6 +135,19 @@ public class FGroupList<E> extends FScrollPane {
         renderer = renderer0;
     }
 
+    public void setItemFilter(Predicate<E> filter) {
+        for (ListGroup group : groups) {
+            boolean anyVisible = false;
+            for (ListItem item : group.items) {
+                boolean visible = filter == null || filter.test(item.value);
+                item.setVisible(visible);
+                anyVisible |= visible;
+            }
+            group.setVisible(anyVisible);
+        }
+        revalidate();
+    }
+
     public FSkinFont getFont() {
         return font;
     }
@@ -204,7 +218,15 @@ public class FGroupList<E> extends FScrollPane {
                 height += GROUP_HEADER_HEIGHT;
             }
             if (!isCollapsed) {
-                height += renderer.getItemHeight() * items.size() + 1; //+1 so bottom border not cut off
+                int visibleCount = 0;
+                for (ListItem item : items) {
+                    if (item.isVisible()) {
+                        visibleCount++;
+                    }
+                }
+                if (visibleCount > 0) {
+                    height += renderer.getItemHeight() * visibleCount + 1; //+1 so bottom border not cut off
+                }
             }
             return height;
         }
@@ -220,6 +242,9 @@ public class FGroupList<E> extends FScrollPane {
             float itemHeight = renderer.getItemHeight();
 
             for (ListItem item : items) {
+                if (!item.isVisible()) {
+                    continue;
+                }
                 item.setBounds(0, y, width, itemHeight);
                 y += itemHeight;
             }


### PR DESCRIPTION
<img width="1915" height="1146" alt="Screenshot 2026-04-19 112926" src="https://github.com/user-attachments/assets/5dfc591b-1db0-495c-b0fc-6f8cf975ffcd" />

Adds a persistent search field at the top of the mobile Settings tab that filters items by label or description — replicating the search filter that already exists at the top of the desktop preferences menu.

`FGroupList` gains a `setItemFilter(Predicate)` method; its layout skips items and groups hidden by the filter. Other `FGroupList` consumers are unaffected (none call `setItemFilter` or toggle item visibility).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)