### PR TITLE
Fix NPE and lobby spam on unregistered peer disconnects

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
@@ -945,11 +945,15 @@ public final class FServerManager implements IHasForgeLog {
                     String.format("%s disconnected. Waiting %s for reconnect...", username, formatTime(RECONNECT_TIMEOUT_SECONDS))));
                 lobbyListener.message(null, "(Host can use /skipreconnect to replace disconnected player with AI, or /skiptimeout to wait indefinitely.)");
                 netLog.info("[Disconnect] Player disconnected mid-game: {} (slot {}). Waiting for reconnect.", username, playerIndex);
-            } else {
-                // Normal disconnect (lobby or no valid slot)
+            } else if (client.hasValidSlot()) {
+                // Peer completed registration but match isn't active (or slot was freed earlier)
                 localLobby.disconnectPlayer(playerIndex);
                 broadcast(new MessageEvent(String.format("%s left the lobby.", username)));
                 broadcast(new LogoutEvent(username));
+            } else {
+                // Peer disconnected before completing registration — probe, crashed handshake, or rejection
+                netLog.info("[Disconnect] Unregistered peer disconnected from {}",
+                    ctx.channel().remoteAddress());
             }
             super.channelInactive(ctx);
         }

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/ServerGameLobby.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/ServerGameLobby.java
@@ -47,6 +47,9 @@ public final class ServerGameLobby extends GameLobby {
     }
     public void disconnectPlayer(final int index) {
         final LobbySlot slot = getSlot(index);
+        if (slot == null) {
+            return;
+        }
         slot.setType(LobbySlotType.OPEN);
         slot.setName(StringUtils.EMPTY);
         slot.setIsReady(false);


### PR DESCRIPTION
## Summary
Any TCP connection that drops on the game-server port before completing Forge's registration handshake triggers an NPE in `ServerGameLobby.disconnectPlayer` and broadcasts `"null left the lobby."` chat spam. Add a null-slot guard to `disconnectPlayer`, and split `FServerManager.channelInactive` so lobby-leave broadcasts only fire for peers that actually registered.

## What triggers this

Anything that opens a TCP connection but doesn't finish Forge's login handshake:

- Port scanners, HTTP / TLS probes (continuous on any public IP)
- Client crashes between connect and `LoginEvent`
- Server-full rejections (`connectPlayer` returns -1, channel is closed)
- Legitimate rejoin attempts that fail before completing registration (flaky network, user cancelling)

The fix handles all of them the same way.

## What's happening in the code

`RegisterClientHandler.channelActive` adds every new TCP peer to the `clients` map with `index = -1`. If the channel closes before a valid `LoginEvent`, `DeregisterClientHandler.channelInactive` falls into the else branch and calls `localLobby.disconnectPlayer(-1)`. `getSlot(-1)` returns null (intentional bounds check), the next line NPEs, and a `"null left the lobby."` / `LogoutEvent(null)` goes out to every real user.

**Not a crash.** Netty's `exceptionCaught` catches the NPE and closes just the probe's channel. Games continue. The impact is operational noise: 20-line stack traces in logs and confusing chat messages visible to real users.

## Evidence

From a user's debug log (`network-debug-20260415-172610.log`):

```
17:28:24.192 Client connected to server at /68.132.98.46:45068
17:28:24.216 TooLongFrameException ... Adjusted frame length exceeds 10000384: 369295626
17:28:24.221 [Disconnect] Client disconnected: index=-1, username=null
17:28:24.221 Connection exception: java.lang.NullPointerException
17:28:24.222   at forge.gamemodes.net.server.ServerGameLobby.disconnectPlayer(ServerGameLobby.java:50)
```

6 NPEs in ~0.5s from one probing IP; game completed normally 2+ minutes later. A separate log shows the same NPE triggered by an HTTP `GET` probe (frame-length `0x47455420` = ASCII `"GET "`).

## Fix

`ServerGameLobby.disconnectPlayer` — null-slot early-return:

```java
public void disconnectPlayer(final int index) {
    final LobbySlot slot = getSlot(index);
    if (slot == null) return;
    slot.setType(LobbySlotType.OPEN);
    ...
}
```

`FServerManager.channelInactive` — split the else:

```java
} else if (client.hasValidSlot()) {
    localLobby.disconnectPlayer(playerIndex);
    broadcast(new MessageEvent(String.format("%s left the lobby.", username)));
    broadcast(new LogoutEvent(username));
} else {
    netLog.info("[Disconnect] Unregistered peer disconnected from {}",
        ctx.channel().remoteAddress());
}
```

## Why this is safe

- `hasValidSlot()` is a stable invariant — `client.setIndex()` has one caller (successful registration) and nothing resets it
- Every valid-peer path (lobby leave, reconnect-wait, reconnect→disconnect, `convertToAI`) is unchanged
- Legitimate rejoin is unaffected — `disconnectedClients` state is keyed on username and untouched by failed retries
- Server-full rejections become silent instead of broadcasting `"<user> left"` for someone nobody saw join
- Defensive null-check in `disconnectPlayer` catches any unanticipated caller passing a bad index
- No change to connection acceptance, registration, heartbeats, or reconnect logic

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)