### PR TITLE
Fix mobile network-client freeze on blocking dialog prompts

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/net/GameProtocolHandler.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/GameProtocolHandler.java
@@ -26,6 +26,10 @@ public abstract class GameProtocolHandler<T> extends ChannelInboundHandlerAdapte
     protected abstract T getToInvoke(ChannelHandlerContext ctx);
     protected abstract void beforeCall(ChannelHandlerContext ctx, ProtocolMethod protocolMethod, Object[] args);
 
+    protected boolean shouldDispatchToGuiThread(final ProtocolMethod protocolMethod) {
+        return runInEdt;
+    }
+
     @Override
     public final void channelRead(final ChannelHandlerContext ctx, final Object msg) {
         final String[] catchedError = {""};
@@ -109,7 +113,7 @@ public abstract class GameProtocolHandler<T> extends ChannelInboundHandlerAdapte
                 }
             };
 
-            if (runInEdt) {
+            if (shouldDispatchToGuiThread(protocolMethod)) {
                 FThreads.invokeInEdtNowOrLater(toRun);
             } else {
                 FThreads.invokeInBackgroundThread(toRun);

--- a/forge-gui/src/main/java/forge/gamemodes/net/client/GameClientHandler.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/client/GameClientHandler.java
@@ -5,6 +5,7 @@ import forge.game.card.CardView;
 import forge.game.player.PlayerView;
 import forge.gamemodes.net.GameEventProxy;
 import forge.gamemodes.net.GameProtocolHandler;
+import forge.gui.GuiBase;
 import forge.util.IHasForgeLog;
 import forge.gamemodes.net.IRemote;
 import forge.gamemodes.net.ProtocolMethod;
@@ -52,6 +53,17 @@ final class GameClientHandler extends GameProtocolHandler<IGuiGame> implements I
     @Override
     protected IGuiGame getToInvoke(final ChannelHandlerContext ctx) {
         return gui;
+    }
+
+    @Override
+    protected boolean shouldDispatchToGuiThread(final ProtocolMethod protocolMethod) {
+        // Libgdx blocking prompts deadlock if run on the GL thread — route return-value
+        // protocol methods to a background thread.
+        if (GuiBase.getInterface().isLibgdxPort()
+                && !protocolMethod.getReturnType().equals(Void.TYPE)) {
+            return false;
+        }
+        return super.shouldDispatchToGuiThread(protocolMethod);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary

Fixes a mobile network-client freeze triggered by `sendAndWait` dialog prompts — most visibly the cleanup-phase "discard down to max hand size" prompt. The remote mobile client hangs with no log output. Regressed by the delta sync merge ([#9642](https://github.com/Card-Forge/forge/pull/9642)) on master.

## Root cause

<!-- -->#9642 fixed `GuiMobile.isGuiThread()` from exclusion-based (`!isGameThread()`, which misidentified Netty and any third-party pool as the GL thread) to identity-based (compare against the GL thread captured in `Forge.create()`). Necessary — delta sync branches on `isGuiThread()` for freeze/unfreeze ordering, and `GameProtocolHandler` was mutating Scene2D state from Netty.

It exposed a latent precondition. Post-fix, `GameProtocolHandler` correctly routes `method.invoke` onto the GL thread via `Gdx.app.postRunnable()`. Return-value methods like `order` then enter `WaitCallback.invokeAndWait()` on the GL thread: it posts the dialog Runnable and calls `lock.wait()`. The GL thread is now blocked on the lock and the queued dialog Runnable never drains — silent freeze. `assertExecutedByEdt(false)` would have thrown but is bypassed in netplay (`if (GuiBase.isNetPlay(null)) return;`).

## Desktop vs mobile

Swing has nested modal event dispatch — `JDialog.setVisible(true)` from the EDT enters a secondary event loop that keeps pumping events until dispose. The EDT stays live. libgdx has no equivalent — the GL thread runs poll → update → render and `postRunnable` is drained only at the top of the next frame. Blocking the GL thread means the queue never drains. The rule "blocking prompts cannot run on the UI thread" is correct on every framework; Swing is the anomaly that tolerates the violation, which is why this regression is mobile-only.

## The fix

Add a `shouldDispatchToGuiThread(ProtocolMethod)` hook on `GameProtocolHandler` (defaults to the existing `runInEdt` flag). Override it in `GameClientHandler` to return `false` for return-value methods when `isLibgdxPort()`. Void methods stay on the GL thread so libgdx threading discipline is preserved.

17 net lines across two files. No core game code, no protocol-format change, no new network traffic — same one inbound message, same one outbound reply, just dispatched to a different thread inside the client.

## Why this is safe

- `GuiDesktop.isLibgdxPort()` returns `false`, so desktop short-circuits to `super.shouldDispatchToGuiThread(...)` which returns `runInEdt` — identical to the old `if (runInEdt)` branch.
- `GameServerHandler` does not override the hook, so server-side routing is unchanged.
- Mobile void methods still go through the GL thread — libgdx threading discipline from <!-- -->#9642 is preserved for UI updates.
- Return-value methods on libgdx now run on a thread that can safely block — matching pre-<!-- -->#9642 behaviour (they ran on the Netty IO thread).

### Cross-platform play

`shouldDispatchToGuiThread` is evaluated locally on whichever end receives the protocol message, and `GuiBase.getInterface().isLibgdxPort()` reflects *that* end's platform. The host's platform cannot affect the client's thread routing.

| Host | Client | Client dispatches return-value methods on... |
|---|---|---|
| Desktop | Desktop | EDT (Swing nested dispatch) — unchanged |
| Desktop | Mobile | `Game BT<N>` — fixed |
| Mobile | Desktop | EDT — unchanged |
| Mobile | Mobile | `Game BT<N>` — fixed |

Server-side routing (client → server methods like `getActivateDescription`) goes through `GameServerHandler`, which passes `super(false)` and does not override the hook, so it stays on a background thread regardless of platform.

## Architectural note — uniform solution not adopted here

The rule generalises: "return-value protocol methods never run on the GUI thread" is correct on every platform. An unconditional version in `GameProtocolHandler` would drop the subclass hook and the platform check entirely. Desktop return-value methods would shift from EDT to a background thread, but they already tolerate that transparently — every desktop path goes through `FThreads.invokeInEdtAndWait(...)`, which handles both callers.

**Not adopted in this PR** because desktop's network client has been running return-value methods on the EDT for years without reported issues and is considered stable. The mobile-only carve-out fixes the regression with minimum blast radius.

## Testing Done

- [x] Mobile-to-mobile match on master reproduces the freeze at the cleanup-phase discard prompt
- [x] Same repro on this branch renders the dialog and completes the prompt

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)