### PR TITLE
fix(Dracogenesis): restrict MayPlay to Dragons the controller owns

### DIFF
--- a/forge-gui/res/cardsfolder/d/dracogenesis.txt
+++ b/forge-gui/res/cardsfolder/d/dracogenesis.txt
@@ -1,7 +1,7 @@
 Name:Dracogenesis
 ManaCost:6 R R
 Types:Enchantment
-S:Mode$ Continuous | Affected$ Dragon | MayPlay$ True | MayPlayWithoutManaCost$ True | MayPlayDontGrantZonePermissions$ True | AffectedZone$ Hand,Graveyard,Library,Exile,Command | Description$ You may cast Dragon spells without paying their mana costs.
+S:Mode$ Continuous | Affected$ Dragon.YouOwn | MayPlay$ True | MayPlayWithoutManaCost$ True | MayPlayDontGrantZonePermissions$ True | AffectedZone$ Hand,Graveyard,Library,Exile,Command | Description$ You may cast Dragon spells without paying their mana costs.
 SVar:NonStackingEffect:True
 AI:RemoveDeck:Random
 Oracle:You may cast Dragon spells without paying their mana costs.


### PR DESCRIPTION
## Summary

- `Affected$ Dragon` was matching Dragon cards in **all players'** Hand/Graveyard/Library/Exile/Command zones, allowing the Dracogenesis controller to freely cast opponents' Dragons
- Added `.YouOwn` restriction so only Dragons owned by the controller are affected, matching the oracle text ("You may cast Dragon spells without paying their mana costs")

## Test plan

- [ ] Cast Dracogenesis; verify you can freely cast your own Dragon cards from hand/graveyard/exile/command
- [ ] Verify you cannot freely cast opponent's Dragon cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)