### PR TITLE
fix(Dracogenesis): restrict MayPlay to Dragons the controller owns

### DIFF
--- a/forge-gui/res/cardsfolder/d/dracogenesis.txt
+++ b/forge-gui/res/cardsfolder/d/dracogenesis.txt
@@ -1,7 +1,7 @@
 Name:Dracogenesis
 ManaCost:6 R R
 Types:Enchantment
-S:Mode$ Continuous | Affected$ Dragon | MayPlay$ True | MayPlayWithoutManaCost$ True | MayPlayDontGrantZonePermissions$ True | AffectedZone$ Hand,Graveyard,Library,Exile,Command | Description$ You may cast Dragon spells without paying their mana costs.
+S:Mode$ Continuous | Affected$ Dragon.YouOwn | MayPlay$ True | MayPlayWithoutManaCost$ True | MayPlayDontGrantZonePermissions$ True | AffectedZone$ Hand,Graveyard,Library,Exile,Command | Description$ You may cast Dragon spells without paying their mana costs.
 SVar:NonStackingEffect:True
 AI:RemoveDeck:Random
 Oracle:You may cast Dragon spells without paying their mana costs.


### PR DESCRIPTION
## Summary
Restricts Dracogenesis's `MayPlay` continuous effect to Dragon cards the controller owns (`Affected$ Dragon.YouOwn`).

## Why
Without the `.YouOwn` restriction, Dracogenesis matched Dragon cards in **all players' zones**, allowing the controller to cast opponents' Dragons for free. The card text says "You may cast Dragon spells" — the fix scopes the effect to cards the casting player owns.

## Test plan
- [ ] Cast Dracogenesis; confirm you can cast your own Dragons for free from hand, graveyard, library, exile, and command zone.
- [ ] Confirm Dracogenesis no longer grants MayPlay on opponents' Dragon cards.