### PR TITLE
Old Border Shandalar: use fromSets() to pin ICE snow basics

### DIFF
--- a/forge-gui/res/adventure/Shandalar Old Border/editions/Ice Age.txt
+++ b/forge-gui/res/adventure/Shandalar Old Border/editions/Ice Age.txt
@@ -2,4 +2,4 @@
 [metadata]
 Code=ICE
 Date=1995-06-03
-Booster=10 Common, 3 Uncommon, 1 Rare, 1 name("Snow-Covered Plains|ICE", "Snow-Covered Island|ICE", "Snow-Covered Swamp|ICE", "Snow-Covered Mountain|ICE", "Snow-Covered Forest|ICE")
+Booster=10 Common, 3 Uncommon, 1 Rare, 1 name("Snow-Covered Plains", "Snow-Covered Island", "Snow-Covered Swamp", "Snow-Covered Mountain", "Snow-Covered Forest"):fromSets("ICE")


### PR DESCRIPTION
- The ICE booster overlay pinned the snow-covered basic slot via `|SET` suffix inside `name(...)`, which the booster generator does not parse: `buildExtraPredicate` routes `name(...)` through `PaperCardPredicates.names(...)`, comparing against `card.getName()` which never carries the `|SET` suffix, so the slot dropped and packs opened with 14 cards instead of 15.
- Switch to the existing `fromSets("ICE")` predicate chained after `name(...)` with the `:` operator separator. Both predicates AND together to select ICE-printed snow basics.
- Packs now open with the intended 10C + 3U + 1R + 1 snow basic. Verified on Shandalar Old Border.
- Closes #10439 (attempted the engine-level fix; `fromSets()` is the idiomatic route).