### PR TITLE
AiPreference for SoulBond allowing Deadeye navigator to ignore tokens

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/BondAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/BondAi.java
@@ -24,8 +24,10 @@ import forge.ai.SpellAbilityAi;
 import forge.game.card.Card;
 import forge.game.player.Player;
 import forge.game.spellability.SpellAbility;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
+import java.util.stream.StreamSupport;
 
 /**
  * <p>
@@ -54,7 +56,21 @@ public final class BondAi extends SpellAbilityAi {
 
     @Override
     protected Card chooseSingleCard(Player ai, SpellAbility sa, Iterable<Card> options, boolean isOptional, Player targetedPlayer, Map<String, Object> params) {
-        return ComputerUtilCard.getBestCreatureAI(options);
+        final Card host = sa.getHostCard();
+        Iterable<Card> candidates = options;
+        if (host != null && host.hasSVar("AIPreference")) {
+            String[] prefs = StringUtils.split(host.getSVar("AIPreference"), "$");
+            if (prefs != null && prefs.length == 2 && "SoulBond".equals(prefs[0])) {
+                String restriction = prefs[1];
+                if (params.get("Partner") instanceof Card partner && !partner.isValid(restriction, ai, host, sa)) {
+                    return null;
+                }
+                candidates = StreamSupport.stream(options.spliterator(), false)
+                        .filter(c -> c.isValid(restriction, ai, host, sa))
+                        .toList();
+            }
+        }
+        return ComputerUtilCard.getBestCreatureAI(candidates);
     }
 
     @Override

--- a/forge-gui/res/cardsfolder/d/deadeye_navigator.txt
+++ b/forge-gui/res/cardsfolder/d/deadeye_navigator.txt
@@ -6,4 +6,5 @@ K:Soulbond
 S:Mode$ Continuous | Affected$ Creature.PairedWith,Card.Self+Paired | AddAbility$ DeadeyeFlicker | AddSVar$ DeadeyeReturn | Description$ As long as CARDNAME is paired with another creature, both creatures have "{1}{U}: Exile this creature, then return it to the battlefield under your control."
 SVar:DeadeyeFlicker:AB$ ChangeZone | Cost$ 1 U | Defined$ Self | Origin$ Battlefield | Destination$ Exile | SubAbility$ DeadeyeReturn | RememberChanged$ True | ForgetOtherRemembered$ True | SpellDescription$ Exile this creature, then return it to the battlefield under your control.
 SVar:DeadeyeReturn:DB$ ChangeZone | Defined$ Remembered | Origin$ All | Destination$ Battlefield | GainControl$ True
+SVar:AIPreference:SoulBond$Creature.!token
 Oracle:Soulbond (You may pair this creature with another unpaired creature when either enters. They remain paired for as long as you control both of them.)\nAs long as Deadeye Navigator is paired with another creature, each of those creatures has "{1}{U}: Exile this creature, then return it to the battlefield under your control."


### PR DESCRIPTION
An attempt to fix #10300 : `Deadeye navigator` will pair with other best non token creature.

Can be used for other soulbonding creatures, for example for `Wingcrafter`

```
SVar:AIPreference:SoulBond$Creature.!hasKeywordFlying
```
