### PR TITLE
feat: respect mana-loss prompt during phase skip and auto-pass

### DIFF
--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -1520,16 +1520,36 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
                     e.printStackTrace();
                 }
             }
-            netLog.trace("Returning null (mayAutoPass) for player {}", player.getName());
-            return null;
+            // Don't auto-pass over floating mana that would be lost — fall through
+            // to InputPassPriority so the mana-loss dialog can fire.
+            if (FModel.getPreferences().getPrefBoolean(FPref.UI_MANA_LOST_PROMPT) && stack.isEmpty()) {
+                Player priority = getGame().getPhaseHandler().getPriorityPlayer();
+                if (priority != null && priority.getManaPool().willManaBeLostAtEndOfPhase()
+                        && priority.getLobbyPlayer() == GamePlayerUtil.getGuiPlayer()) {
+                    // fall through to show InputPassPriority
+                } else {
+                    netLog.trace("Returning null (mayAutoPass) for player {}", player.getName());
+                    return null;
+                }
+            } else {
+                netLog.trace("Returning null (mayAutoPass) for player {}", player.getName());
+                return null;
+            }
         }
 
         if (stack.isEmpty()) {
             if (getGui().isUiSetToSkipPhase(getGame().getPhaseHandler().getPlayerTurn().getView(),
                     getGame().getPhaseHandler().getPhase())) {
-                netLog.trace("Returning null (skipPhase) for player {}", player.getName());
-                return null; // avoid prompt for input if stack is empty and
-                // player is set to skip the current phase
+                // Don't skip over a phase where floating mana would be lost.
+                boolean wouldLoseMana = FModel.getPreferences().getPrefBoolean(FPref.UI_MANA_LOST_PROMPT)
+                        && getGame().getPhaseHandler().getPriorityPlayer() != null
+                        && getGame().getPhaseHandler().getPriorityPlayer().getManaPool().willManaBeLostAtEndOfPhase()
+                        && getGame().getPhaseHandler().getPriorityPlayer().getLobbyPlayer() == GamePlayerUtil.getGuiPlayer();
+                if (!wouldLoseMana) {
+                    netLog.trace("Returning null (skipPhase) for player {}", player.getName());
+                    return null; // avoid prompt for input if stack is empty and
+                    // player is set to skip the current phase
+                }
             }
         } else {
             final SpellAbility ability = stack.peekAbility();


### PR DESCRIPTION
## Motivation

If you're the kind of person who casts Jeska's Will with Krark on the stack, generates twelve mana, flips Krark, gets the original spell returned to hand, clicks OK to pass priority, and then watches all that mana silently evaporate without so much as a warning — this PR is for you.

The `UI_MANA_LOST_PROMPT` preference (Preferences → Gameplay → *Prompt Mana Pool Emptying*) is supposed to warn you before passing priority causes mana loss. It does — but only if you manually click OK on the priority dialog. Two common code paths in `PlayerControllerHuman.chooseSpellAbilityToPlay` returned `null` before ever reaching `InputPassPriority.passPriority()`:

1. **Auto-pass / yield path** (`mayAutoPass()`) — returned `null` immediately after the delay, skipping the dialog entirely.
2. **Phase-skip path** (`isUiSetToSkipPhase`) — returned `null` to skip the phase, also bypassing the dialog.

## Changes

Both return paths now check `ManaPool.willManaBeLostAtEndOfPhase()` before returning null. If the pref is enabled, the stack is empty, and mana would be lost, they fall through to `InputPassPriority` so the existing dialog can fire normally.

Only applies to the local GUI player (`GamePlayerUtil.getGuiPlayer()`) — no change for AI or remote players.

Also removes a duplicate `FServerManager.AfkTimeout` import in `InputPassPriority.java`.

## Screenshots

**The setting (Preferences → Gameplay):**
![settings](https://raw.githubusercontent.com/RafaelHGOliveira/forge/screenshots/mana-loss-prompt/.github/screenshots/settings.png)

**The dialog that now actually appears:**
![prompt](https://raw.githubusercontent.com/RafaelHGOliveira/forge/screenshots/mana-loss-prompt/.github/screenshots/prompt.png)

## Test plan

- Enable *Prompt Mana Pool Emptying* in Preferences → Gameplay
- Tap mana sources, leave mana floating in pool
- Either set a phase to auto-skip **or** have auto-pass active
- Advance to the phase → dialog should appear warning about mana loss
- Clicking "Yes, lose the mana" passes through; "No" keeps priority