### PR TITLE
[WIP] Fix NetworkPlayIntegrationTest port probe mismatch

### DIFF
--- a/forge-gui-desktop/src/test/java/forge/net/PortAllocator.java
+++ b/forge-gui-desktop/src/test/java/forge/net/PortAllocator.java
@@ -72,7 +72,9 @@ public class PortAllocator {
         try (ServerSocket socket = new ServerSocket()) {
             // Enable address reuse to speed up port availability after close
             socket.setReuseAddress(true);
-            socket.bind(new InetSocketAddress("localhost", port));
+            // Bind to wildcard (all interfaces) to match Netty's b.bind(port);
+            // a loopback-only probe misses ports occupied on other interfaces.
+            socket.bind(new InetSocketAddress(port));
             return true;
         } catch (IOException e) {
             // Port is in use or otherwise unavailable


### PR DESCRIPTION
Potential fix for <!-- -->#10488.

`PortAllocator.isPortAvailable` probed `localhost` (loopback only), but `FServerManager.startServer` binds via Netty's `b.bind(port)` (wildcard, all interfaces). On machines with a process bound to a non-loopback interface in the 50000+ range, the probe passes but the real bind fails with `Address already in use`. Probe now uses wildcard to match.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)