### PR TITLE
Funny card loading fix

### DIFF
--- a/forge-gui/res/editions/Unknown Event.txt
+++ b/forge-gui/res/editions/Unknown Event.txt
@@ -446,7 +446,7 @@ RB14 R Another Night in Vegas @
 RR14 R Brutal Command @
 UU14a U Tax Draw @
 UU14b U Tax Sweeper @
-CR15a C Fast // Furious @
+# CR15a C Fast // Furious @  -- disabled: collides with MH2 "Fast // Furious"; only rules script is the MH2 legal version, so loading this printing would attach wrong rules to joke art.
 RB15 R Monster Mash-Up @
 RR15 R Force of Rowan @
 RW15 R Crux of Mirrodin @


### PR DESCRIPTION
When funny cards are disabled, Forge is filtering card names rather than printings via a single funnyCards ban set. Any legal card sharing a name with a funny-set entry is banned too. Concretely: Fast // Furious (Modern Horizons 2, legal) is unavailable because Unknown Event contains a joke card with the same name. Forge's script implements the legal MH2 version, but the name match drops it before the script ever loads.

Fix: Since we don't even support the script for the funny version, fix is just replacing it with a comment to prevent interference with legal card loading.