### PR TITLE
Old Border Shandalar: fix ICE snow basic distribution to all 5 colors

### DIFF
--- a/forge-gui/res/adventure/Shandalar Old Border/editions/Ice Age.txt
+++ b/forge-gui/res/adventure/Shandalar Old Border/editions/Ice Age.txt
@@ -2,4 +2,4 @@
 [metadata]
 Code=ICE
 Date=1995-06-03
-Booster=10 Common, 3 Uncommon, 1 Rare, 1 name("Snow-Covered Plains", "Snow-Covered Island", "Snow-Covered Swamp", "Snow-Covered Mountain", "Snow-Covered Forest"):fromSets("ICE")
+Booster=10 Common, 3 Uncommon, 1 Rare, 1 name("Snow-Covered Plains","Snow-Covered Island","Snow-Covered Swamp","Snow-Covered Mountain","Snow-Covered Forest"):fromSets("ICE")


### PR DESCRIPTION
- Follow-up to #10472. Testers report that all 48 ICE packs across 3 drafts contained only Snow-Covered Plains, never the other four colors.
- Root cause is in `BoosterGenerator.buildExtraPredicate`: the `name(...)` parser splits the name list by comma but never trims whitespace. Input `"A", "B", "C"` parses as names `["A", " B", " C"]`, so only the first name (no leading space) matches `card.getName()`.
- Pure data fix: drop the spaces after commas in the ICE booster slot list so all five snow basics are eligible.
- Verified locally that all five snow-covered basics now appear across ICE packs.