### PR TITLE
Fix for Maze of Ith in multiplayer

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/EffectAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/EffectAi.java
@@ -134,8 +134,10 @@ public class EffectAi extends SpellAbilityAi {
                             return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
                         }
                     } else {
-                        List<Card> list = game.getCombat().getAttackers();
+                        Combat combat = game.getCombat();
+                        List<Card> list = combat.getAttackers();
                         list = CardLists.getTargetableCards(list, sa);
+                        list = CardLists.filter(list, c -> ai.equals(combat.getDefenderPlayerByAttacker(c)));
                         Card target = ComputerUtilCard.getBestCreatureAI(list);
                         if (target == null) {
                             return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);

--- a/forge-ai/src/main/java/forge/ai/ability/RemoveFromCombatAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/RemoveFromCombatAi.java
@@ -4,6 +4,8 @@ package forge.ai.ability;
 import forge.ai.AiAbilityDecision;
 import forge.ai.AiPlayDecision;
 import forge.ai.SpellAbilityAi;
+import forge.game.card.Card;
+import forge.game.combat.Combat;
 import forge.game.player.Player;
 import forge.game.spellability.SpellAbility;
 
@@ -20,7 +22,16 @@ public class RemoveFromCombatAi extends SpellAbilityAi {
         // AI should only activate this during Human's turn
 
         if ("RemoveBestAttacker".equals(sa.getParam("AILogic"))) {
-            boolean result = aiPlayer.getGame().getCombat() != null && aiPlayer.getGame().getCombat().getDefenders().contains(aiPlayer);
+            Combat combat = aiPlayer.getGame().getCombat();
+            boolean result = false;
+            if (combat != null) {
+                for (Card attacker : combat.getAttackers()) {
+                    if (aiPlayer.equals(combat.getDefenderPlayerByAttacker(attacker))) {
+                        result = true;
+                        break;
+                    }
+                }
+            }
             return result ? new AiAbilityDecision(100, AiPlayDecision.WillPlay) : new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
         }
 

--- a/forge-ai/src/main/java/forge/ai/ability/RemoveFromCombatAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/RemoveFromCombatAi.java
@@ -1,11 +1,8 @@
 package forge.ai.ability;
 
-
 import forge.ai.AiAbilityDecision;
 import forge.ai.AiPlayDecision;
 import forge.ai.SpellAbilityAi;
-import forge.game.card.Card;
-import forge.game.combat.Combat;
 import forge.game.player.Player;
 import forge.game.spellability.SpellAbility;
 
@@ -19,20 +16,8 @@ public class RemoveFromCombatAi extends SpellAbilityAi {
 
     @Override
     public AiAbilityDecision chkDrawback(Player aiPlayer, SpellAbility sa) {
-        // AI should only activate this during Human's turn
-
         if ("RemoveBestAttacker".equals(sa.getParam("AILogic"))) {
-            Combat combat = aiPlayer.getGame().getCombat();
-            boolean result = false;
-            if (combat != null) {
-                for (Card attacker : combat.getAttackers()) {
-                    if (aiPlayer.equals(combat.getDefenderPlayerByAttacker(attacker))) {
-                        result = true;
-                        break;
-                    }
-                }
-            }
-            return result ? new AiAbilityDecision(100, AiPlayDecision.WillPlay) : new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
+            return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
         }
 
         // TODO - implement AI

--- a/forge-ai/src/main/java/forge/ai/ability/UntapAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/UntapAi.java
@@ -1,6 +1,17 @@
 package forge.ai.ability;
 
-import forge.ai.*;
+import java.util.List;
+import java.util.Map;
+
+import forge.ai.AiAbilityDecision;
+import forge.ai.AiPlayDecision;
+import forge.ai.ComputerUtil;
+import forge.ai.ComputerUtilAbility;
+import forge.ai.ComputerUtilCard;
+import forge.ai.ComputerUtilCombat;
+import forge.ai.ComputerUtilCost;
+import forge.ai.ComputerUtilMana;
+import forge.ai.SpellAbilityAi;
 import forge.card.mana.ManaCostShard;
 import forge.game.Game;
 import forge.game.ability.AbilityUtils;
@@ -22,9 +33,6 @@ import forge.game.spellability.SpellAbility;
 import forge.game.spellability.TargetRestrictions;
 import forge.game.zone.ZoneType;
 import forge.util.collect.FCollectionView;
-
-import java.util.List;
-import java.util.Map;
 
 public class UntapAi extends SpellAbilityAi {
     @Override
@@ -155,6 +163,14 @@ public class UntapAi extends SpellAbilityAi {
             SpellAbility subSa = sa.getSubAbility();
             if (subSa.getApi() == ApiType.RemoveFromCombat && "RemoveBestAttacker".equals(subSa.getParam("AILogic"))) {
                 targetUntapped = true;
+                Combat combat = ai.getGame().getCombat();
+                if (combat == null) {
+                    return false;
+                }
+                list = CardLists.filter(list, c -> isAttackingAi(c, ai, combat));
+                if (list.isEmpty()) {
+                    return false;
+                }
             }
         }
 
@@ -357,30 +373,33 @@ public class UntapAi extends SpellAbilityAi {
             return false;
         }
 
-        // If damage can't be prevented. Just return false.
-
-         Combat activeCombat = game.getCombat();
+        Combat activeCombat = game.getCombat();
         if (activeCombat == null) {
             return false;
         }
 
         CardCollection list = CardLists.getTargetableCards(activeCombat.getAttackers(), sa);
+        list = CardLists.filter(list, c -> isAttackingAi(c, ai, activeCombat));
 
         if (list.isEmpty()) {
             return false;
         }
 
-         if (game.getPhaseHandler().is(PhaseType.COMBAT_DECLARE_BLOCKERS)) {
+        if (game.getPhaseHandler().is(PhaseType.COMBAT_DECLARE_BLOCKERS)) {
             // Blockers already set. Are there any dangerous unblocked creatures? Sort by creature that will deal the most damage?
             Card card = ComputerUtilCombat.mostDangerousAttacker(list, ai, activeCombat, true);
 
             if (card == null) { return false; }
 
-             sa.getTargets().add(card);
-             return true;
+            sa.getTargets().add(card);
+            return true;
         }
 
         return false;
+    }
+
+    private static boolean isAttackingAi(final Card card, final Player ai, final Combat combat) {
+        return ai.equals(combat.getDefenderPlayerByAttacker(card));
     }
 
     private static boolean alreadyAssignedTarget(final SpellAbility sa) {


### PR DESCRIPTION
In multiplayer games, the AI uses Maze of Ith and similar cards indiscriminately, even protecting other players at the cost of itself. Maze’s pre-existing script is broad: ValidTgts$ Creature.attacking, so all attacking creatures are targetable. The AI logic in UntapAi.java looks at all attackers during an opponent’s turn, instead of only attackers whose defending player is the AI. This is not unique to Maze: The same pattern could affect Maze of Shadows, Spires of Orazca, and targeted AILogic$ Fog effects like Shimian Night Stalker / Turn the Tables style cards. It is not a rules/card-script bug; it is AI target-selection being too multiplayer-naive.

Fix: I filtered defensive combat targets to only creatures attacking the AI or something defended by the AI, using combat.getDefenderPlayerByAttacker(card) == ai.

Changed:

UntapAi.java (line 162): filters RemoveBestAttacker untap targets.
UntapAi.java (line 374): filters Maze/Maze of Shadows targets.
EffectAi.java (line 140): filters targeted fog-style effects.
RemoveFromCombatAi.java (line 24): drawback check now looks for attackers actually aimed at the AI.

I tested in multiplayer and the fix works.