### PR TITLE
Closing the UI tab in multiplayer after losing fixed

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
@@ -2,6 +2,7 @@ package forge.gamemodes.match;
 
 import com.google.common.collect.*;
 import forge.game.GameEntityView;
+import forge.game.GameEndReason;
 import forge.game.GameLog;
 import forge.game.GameView;
 import forge.game.card.CardView;
@@ -375,6 +376,9 @@ public abstract class AbstractGuiGame implements IGuiGame, IMayViewCards {
                     return false;
                 }
             } else {
+                if (!ignoreConcedeChain && !isNetGame() && forceEndGameForRemainingAIs()) {
+                    return false;
+                }
                 return !ignoreConcedeChain;
             }
             if (isNetGame()) {
@@ -407,6 +411,38 @@ public abstract class AbstractGuiGame implements IGuiGame, IMayViewCards {
             }
             return false; //let logic above handle closing current screen
         }
+    }
+
+    private boolean forceEndGameForRemainingAIs() {
+        final GameView gameView = getGameView();
+        if (gameView == null || gameView.isGameOver()) {
+            return false;
+        }
+
+        boolean hasRemainingLocalHuman = false;
+        boolean hasRemainingAi = false;
+        for (PlayerView player : gameView.getPlayers()) {
+            if (!player.getHasLost()) {
+                if (isLocalPlayer(player) && !player.isAI()) {
+                    hasRemainingLocalHuman = true;
+                    break;
+                }
+                if (player.isAI()) {
+                    hasRemainingAi = true;
+                }
+            }
+        }
+
+        if (hasRemainingLocalHuman || !hasRemainingAi) {
+            return false;
+        }
+
+        gameView.getGame().getAction().invoke(() -> {
+            if (!gameView.getGame().isGameOver()) {
+                gameView.getGame().setGameOver(GameEndReason.AllHumansLost);
+            }
+        });
+        return true;
     }
 
     public String getConcedeCaption() {

--- a/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
@@ -415,25 +415,19 @@ public abstract class AbstractGuiGame implements IGuiGame, IMayViewCards {
 
     private boolean forceEndGameForRemainingAIs() {
         final GameView gameView = getGameView();
-        if (gameView == null || gameView.isGameOver()) {
+        if (gameView == null) {
             return false;
         }
 
-        boolean hasRemainingLocalHuman = false;
         boolean hasRemainingAi = false;
         for (PlayerView player : gameView.getPlayers()) {
-            if (!player.getHasLost()) {
-                if (isLocalPlayer(player) && !player.isAI()) {
-                    hasRemainingLocalHuman = true;
-                    break;
-                }
-                if (player.isAI()) {
-                    hasRemainingAi = true;
-                }
+            if (!player.getHasLost() && player.isAI()) {
+                hasRemainingAi = true;
+                break;
             }
         }
 
-        if (hasRemainingLocalHuman || !hasRemainingAi) {
+        if (!hasRemainingAi) {
             return false;
         }
 


### PR DESCRIPTION
Fixed an issue in multiplayer matches where, after the human player had already lost, closing the match tab would only remove the UI while the remaining AI players kept playing in the background. This happened because the close/concede flow saw that no local human still needed to concede and treated the match as safe to close, even though the game itself was still running.

The fix updates AbstractGuiGame.concede() so that, in local non-network games, if all remaining active players are AI and no local human is still alive, Forge now explicitly ends the game with GameEndReason.AllHumansLost on the game thread. That allows the normal game-end cleanup path to run and prevents off-screen AI-vs-AI play from continuing after the tab is closed.