### PR TITLE
Player: refactor extra playLand ability

### DIFF
--- a/forge-ai/src/main/java/forge/ai/simulation/GameSimulator.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameSimulator.java
@@ -170,7 +170,9 @@ public class GameSimulator {
         SpellAbility sa;
         if (origSa.isLandAbility()) {
             Card hostCard = (Card) copier.find(origSa.getHostCard());
-            if (!aiPlayer.playLand(hostCard, false, origSa)) {
+            if (origSa.canPlay()) {
+                aiPlayer.playLand(hostCard, origSa);
+            } else {
                 System.err.println("Simulation: Couldn't play land! " + origSa);
             }
             sa = origSa;

--- a/forge-game/src/main/java/forge/game/ability/effects/PlayLandVariantEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PlayLandVariantEffect.java
@@ -60,6 +60,6 @@ public class PlayLandVariantEffect extends SpellAbilityEffect {
         source.addCloneState(CardFactory.getCloneStates(random, source, sa), game.getNextTimestamp());
         source.updateStateForView();
 
-        activator.playLandNoCheck(source, sa);
+        activator.playLand(source, sa);
     }
 }

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -1628,18 +1628,7 @@ public class Player extends GameEntity implements Comparable<Player> {
         game.fireEvent(new GameEventShuffle(this));
     }
 
-    public final boolean playLand(final Card land, final boolean ignoreZoneAndTiming, SpellAbility cause) {
-        // Dakkon Blackblade Avatar will use a similar effect
-        if (canPlayLand(land, ignoreZoneAndTiming, cause)) {
-            playLandNoCheck(land, null);
-            return true;
-        }
-
-        game.getStack().unfreezeStack();
-        return false;
-    }
-
-    public final Card playLandNoCheck(final Card land, SpellAbility cause) {
+    public final Card playLand(final Card land, SpellAbility cause) {
         land.setController(this, 0);
         if (land.isFaceDown()) {
             land.turnFaceUp(null);

--- a/forge-game/src/main/java/forge/game/spellability/LandAbility.java
+++ b/forge-game/src/main/java/forge/game/spellability/LandAbility.java
@@ -63,7 +63,7 @@ public class LandAbility extends AbilityStatic {
     @Override
     public void resolve() {
         getHostCard().setSplitStateToPlayAbility(this);
-        final Card result = getActivatingPlayer().playLandNoCheck(getHostCard(), this);
+        final Card result = getActivatingPlayer().playLand(getHostCard(), this);
 
         // increase mayplay used
         if (getMayPlay() != null) {


### PR DESCRIPTION
part of #10465 

it does cleanup the extra playLand ability and renames the previous playLandNoCheck