### PR TITLE
Asynchronous send: stop game thread blocking on slow clients

### DIFF
--- a/forge-gui-desktop/src/test/java/forge/net/analysis/AnalysisResult.java
+++ b/forge-gui-desktop/src/test/java/forge/net/analysis/AnalysisResult.java
@@ -66,10 +66,10 @@ public class AnalysisResult {
     private int totalEncodedMessages;
     private long minEncodedBytes;
     private long maxEncodedBytes;
-    private int totalSendBlocked;
-    private long totalBlockedMs;
-    private long minBlockedMs;
-    private long maxBlockedMs;
+    private int totalSaturationEpisodes;
+    private long totalSaturationMs;
+    private long maxSaturationMs;
+    private long totalSendsDuringSaturation;
 
     public AnalysisResult(List<GameLogMetrics> metrics) {
         this.allMetrics = metrics;
@@ -214,13 +214,10 @@ public class AnalysisResult {
                 .mapToLong(GameLogMetrics::getMinEncodedBytes)
                 .min().orElse(0);
         maxEncodedBytes = allMetrics.stream().mapToLong(GameLogMetrics::getMaxEncodedBytes).max().orElse(0);
-        totalSendBlocked = allMetrics.stream().mapToInt(GameLogMetrics::getSendBlockedCount).sum();
-        totalBlockedMs = allMetrics.stream().mapToLong(GameLogMetrics::getTotalBlockedMs).sum();
-        minBlockedMs = allMetrics.stream()
-                .filter(m -> m.getSendBlockedCount() > 0)
-                .mapToLong(GameLogMetrics::getMinBlockedMs)
-                .min().orElse(0);
-        maxBlockedMs = allMetrics.stream().mapToLong(GameLogMetrics::getMaxBlockedMs).max().orElse(0);
+        totalSaturationEpisodes = allMetrics.stream().mapToInt(GameLogMetrics::getSaturationEpisodeCount).sum();
+        totalSaturationMs = allMetrics.stream().mapToLong(GameLogMetrics::getTotalSaturationMs).sum();
+        maxSaturationMs = allMetrics.stream().mapToLong(GameLogMetrics::getMaxSaturationMs).max().orElse(0);
+        totalSendsDuringSaturation = allMetrics.stream().mapToLong(GameLogMetrics::getTotalSendsDuringSaturation).sum();
     }
 
     public int getTotalGames() { return totalGames; }
@@ -438,15 +435,17 @@ public class AnalysisResult {
                         TestUtils.formatBytes(minEncodedBytes), TestUtils.formatBytes(maxEncodedBytes)));
             }
 
-            if (totalSendBlocked > 0) {
-                sb.append(String.format("| send() Blocked Count | %,d |\n",
-                        totalSendBlocked));
-                sb.append(String.format("| Avg Blocking Time | %d ms |\n",
-                        totalBlockedMs / totalSendBlocked));
-                sb.append(String.format("| Blocking Range | %d - %,d ms |\n",
-                        minBlockedMs, maxBlockedMs));
-                sb.append(String.format("| Total Thread Blocking | %s |\n",
-                        formatDurationMs(totalBlockedMs)));
+            if (totalSaturationEpisodes > 0) {
+                sb.append(String.format("| Saturation Episodes | %,d |\n",
+                        totalSaturationEpisodes));
+                sb.append(String.format("| Total Saturation Duration | %s |\n",
+                        formatDurationMs(totalSaturationMs)));
+                sb.append(String.format("| Avg Episode Duration | %d ms |\n",
+                        totalSaturationMs / totalSaturationEpisodes));
+                sb.append(String.format("| Longest Episode | %s |\n",
+                        formatDurationMs(maxSaturationMs)));
+                sb.append(String.format("| Server Sends During Saturation | %,d |\n",
+                        totalSendsDuringSaturation));
             }
 
             if (totalSendErrors > 0) {

--- a/forge-gui-desktop/src/test/java/forge/net/analysis/GameLogMetrics.java
+++ b/forge-gui-desktop/src/test/java/forge/net/analysis/GameLogMetrics.java
@@ -47,15 +47,15 @@ public class GameLogMetrics {
 
     private List<String> deckNames = new ArrayList<>();
 
-    // Network performance metrics (from Encoded/send() blocked lines)
+    // Network performance metrics (from Encoded / outbound saturation lines)
     private long totalEncodedBytes;
     private int encodedMessageCount;
     private long minEncodedBytes = Long.MAX_VALUE;
     private long maxEncodedBytes;
-    private int sendBlockedCount;
-    private long totalBlockedMs;
-    private long minBlockedMs = Long.MAX_VALUE;
-    private long maxBlockedMs;
+    private int saturationEpisodeCount;
+    private long totalSaturationMs;
+    private long maxSaturationMs;
+    private long totalSendsDuringSaturation;
 
     // Game timing
     private String firstTimestamp;
@@ -186,11 +186,11 @@ public class GameLogMetrics {
         if (bytes > maxEncodedBytes) maxEncodedBytes = bytes;
     }
 
-    public void recordSendBlocked(long ms) {
-        sendBlockedCount++;
-        totalBlockedMs += ms;
-        if (ms < minBlockedMs) minBlockedMs = ms;
-        if (ms > maxBlockedMs) maxBlockedMs = ms;
+    public void recordSaturationEpisode(long durationMs, int sendsDuringEpisode) {
+        saturationEpisodeCount++;
+        totalSaturationMs += durationMs;
+        if (durationMs > maxSaturationMs) maxSaturationMs = durationMs;
+        totalSendsDuringSaturation += sendsDuringEpisode;
     }
 
     public long getTotalEncodedBytes() { return totalEncodedBytes; }
@@ -199,11 +199,10 @@ public class GameLogMetrics {
     public long getMaxEncodedBytes() { return maxEncodedBytes; }
     public double getAvgEncodedBytes() { return encodedMessageCount > 0 ? (double) totalEncodedBytes / encodedMessageCount : 0; }
 
-    public int getSendBlockedCount() { return sendBlockedCount; }
-    public long getTotalBlockedMs() { return totalBlockedMs; }
-    public long getMinBlockedMs() { return sendBlockedCount > 0 ? minBlockedMs : 0; }
-    public long getMaxBlockedMs() { return maxBlockedMs; }
-    public double getAvgBlockedMs() { return sendBlockedCount > 0 ? (double) totalBlockedMs / sendBlockedCount : 0; }
+    public int getSaturationEpisodeCount() { return saturationEpisodeCount; }
+    public long getTotalSaturationMs() { return totalSaturationMs; }
+    public long getMaxSaturationMs() { return maxSaturationMs; }
+    public long getTotalSendsDuringSaturation() { return totalSendsDuringSaturation; }
 
     public String getFirstTimestamp() { return firstTimestamp; }
     public void setFirstTimestamp(String ts) { this.firstTimestamp = ts; }

--- a/forge-gui-desktop/src/test/java/forge/net/analysis/NetworkLogAnalyzer.java
+++ b/forge-gui-desktop/src/test/java/forge/net/analysis/NetworkLogAnalyzer.java
@@ -65,9 +65,9 @@ public class NetworkLogAnalyzer {
     private static final Pattern ENCODED_BYTES_PATTERN = Pattern.compile(
             "Encoded (\\d+) bytes \\(compressed\\)");
 
-    // "send() blocked 214 ms for <player>"
-    private static final Pattern SEND_BLOCKED_PATTERN = Pattern.compile(
-            "send\\(\\) blocked (\\d+) ms");
+    // "<player> recovered after 1.3s outbound buffer saturation (47 server sends)"
+    private static final Pattern SATURATION_RECOVERY_PATTERN = Pattern.compile(
+            "recovered after (\\d+)\\.(\\d+)s outbound buffer saturation \\((\\d+) server sends\\)");
 
     // Turn detection from event batch lists: "GameEventTurnBegan" in batch contents
     private static final Pattern BATCH_TURN_BEGAN_PATTERN = Pattern.compile(
@@ -449,11 +449,15 @@ public class NetworkLogAnalyzer {
                     continue;
                 }
 
-                // send() blocking times
-                Matcher blockedMatcher = SEND_BLOCKED_PATTERN.matcher(line);
-                if (blockedMatcher.find()) {
+                // Outbound buffer saturation episode (recovery line carries duration + send count)
+                Matcher saturationMatcher = SATURATION_RECOVERY_PATTERN.matcher(line);
+                if (saturationMatcher.find()) {
                     try {
-                        metrics.recordSendBlocked(Long.parseLong(blockedMatcher.group(1)));
+                        long seconds = Long.parseLong(saturationMatcher.group(1));
+                        long tenths = Long.parseLong(saturationMatcher.group(2));
+                        long durationMs = seconds * 1000 + tenths * 100;
+                        int sendsQueued = Integer.parseInt(saturationMatcher.group(3));
+                        metrics.recordSaturationEpisode(durationMs, sendsQueued);
                     } catch (NumberFormatException e) {
                         // skip
                     }

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
@@ -62,6 +62,9 @@ import java.util.function.Predicate;
 public final class FServerManager implements IHasForgeLog {
 
     static final int HEARTBEAT_TIMEOUT_SECONDS = Integer.getInteger("forge.net.heartbeatTimeout", 45);
+
+    private static final int OUTBOUND_BUFFER_LOW_WATER = 64 * 1024;
+    private static final int OUTBOUND_BUFFER_HIGH_WATER = 1024 * 1024;
     private static final int RECONNECT_TIMEOUT_SECONDS = 300;
 
     private static FServerManager instance = null;
@@ -141,12 +144,15 @@ public final class FServerManager implements IHasForgeLog {
                     .childHandler(new ChannelInitializer<SocketChannel>() {
                         @Override
                         public void initChannel(final SocketChannel ch) throws Exception {
+                            ch.config().setWriteBufferWaterMark(
+                                    new WriteBufferWaterMark(OUTBOUND_BUFFER_LOW_WATER, OUTBOUND_BUFFER_HIGH_WATER));
                             final ChannelPipeline p = ch.pipeline();
                             p.addLast(
                                     new CompatibleObjectEncoder(byteTracker),
                                     new CompatibleObjectDecoder(9766 * 1024, ClassResolvers.cacheDisabled(null)),
                                     new IdleStateHandler(HEARTBEAT_TIMEOUT_SECONDS, 0, 0, TimeUnit.SECONDS),
                                     new MessageHandler(),
+                                    new SaturationLoggingHandler(),
                                     new RegisterClientHandler(),
                                     new LobbyInputHandler(),
                                     new DeregisterClientHandler(),
@@ -874,6 +880,28 @@ public final class FServerManager implements IHasForgeLog {
                 broadcast(new MessageEvent(username, text));
             }
             super.channelRead(ctx, msg);
+        }
+    }
+
+    private class SaturationLoggingHandler extends ChannelInboundHandlerAdapter {
+        @Override
+        public void channelWritabilityChanged(final ChannelHandlerContext ctx) throws Exception {
+            final RemoteClient client = clients.get(ctx.channel());
+            if (client != null) {
+                if (!ctx.channel().isWritable()) {
+                    client.saturationStartMs = System.currentTimeMillis();
+                    client.sendsDuringSaturation.set(0);
+                    netLog.warn("Outbound buffer saturated for {} (pending {} bytes)",
+                            client.getUsername(), ctx.channel().bytesBeforeWritable());
+                } else if (client.saturationStartMs > 0L) {
+                    long durationMs = System.currentTimeMillis() - client.saturationStartMs;
+                    int sends = client.sendsDuringSaturation.get();
+                    client.saturationStartMs = 0L;
+                    netLog.info("{} recovered after {}.{}s outbound buffer saturation ({} server sends)",
+                            client.getUsername(), durationMs / 1000, (durationMs % 1000) / 100, sends);
+                }
+            }
+            super.channelWritabilityChanged(ctx);
         }
     }
 

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/RemoteClient.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/RemoteClient.java
@@ -22,6 +22,16 @@ public final class RemoteClient implements IToClient, IHasForgeLog {
     private volatile ReplyPool replies = new ReplyPool();
     private final AtomicInteger sendErrors = new AtomicInteger(0);
 
+    // Package-private: SaturationLoggingHandler reads/resets these on writability transitions
+    volatile long saturationStartMs = 0L;
+    final AtomicInteger sendsDuringSaturation = new AtomicInteger(0);
+
+    private void recordSendIfSaturated(final Channel ch) {
+        if (!ch.isWritable()) {
+            sendsDuringSaturation.incrementAndGet();
+        }
+    }
+
     public RemoteClient(final Channel channel) {
         this.channel = channel;
     }
@@ -45,28 +55,39 @@ public final class RemoteClient implements IToClient, IHasForgeLog {
 
     @Override
     public void send(final NetEvent event) {
-        try {
-            long startMs = System.currentTimeMillis();
-            channel.writeAndFlush(event).sync();
-            long elapsed = System.currentTimeMillis() - startMs;
-            if (elapsed > 50) {
-                netLog.info("send() blocked {} ms for {} (event: {})", elapsed, username, event);
+        final Channel ch = channel;
+        recordSendIfSaturated(ch);
+        ch.writeAndFlush(event).addListener(f -> {
+            if (!f.isSuccess()) {
+                sendErrors.incrementAndGet();
+                Throwable c = f.cause();
+                String causeStr = c == null ? (f.isCancelled() ? "cancelled" : "no cause") : c.getClass().getSimpleName() + ": " + c.getMessage();
+                netLog.error("Network send error for {} (event: {}, cause: {})", username, event, causeStr);
             }
-        } catch (Exception e) {
-            sendErrors.incrementAndGet();
-            netLog.error("Network send error for {} (event: {})", username, event, e);
-        }
+        });
     }
 
     @Override
     public void write(final NetEvent event) {
-        channel.write(event);
+        final Channel ch = channel;
+        recordSendIfSaturated(ch);
+        ch.write(event);
     }
 
     @Override
     public Object sendAndWait(final IdentifiableNetEvent event) {
         replies.initialize(event.getId());
-        send(event);
+        final Channel ch = channel;
+        recordSendIfSaturated(ch);
+        ch.writeAndFlush(event).addListener(f -> {
+            if (!f.isSuccess()) {
+                sendErrors.incrementAndGet();
+                Throwable c = f.cause();
+                String causeStr = c == null ? (f.isCancelled() ? "cancelled" : "no cause") : c.getClass().getSimpleName() + ": " + c.getMessage();
+                netLog.error("sendAndWait write failed for {} (event: {}, cause: {})", username, event, causeStr);
+                replies.complete(event.getId(), null);
+            }
+        });
         return replies.get(event.getId());
     }
 


### PR DESCRIPTION
## What's the issue

In network multiplayer **server writes move at the speed of the slowest client**. The cost of one bad connection (high latency, low effective throughput, slow client-side processing, anything that delays TCP acknowledgments) is paid by every player in the game, because the game thread is shared.

This is because the server's game thread cannot fire a new event to remote clients until every connected client has received the previous one. Each event goes through `channel.writeAndFlush(event).sync()` per client, in sequence — and `.sync()` blocks the calling thread until the write has been accepted by the OS socket buffer, which can only happen after the receiver's TCP stack has acknowledged enough prior bytes. Slow clients hold up the chain.

Bursts of game activity that produce many events in a short time multiply the effect — each event in the burst waits for the full slowest-client round-trip before the next can fire.

## What's the history

The synchronous behaviour does not appear to be an intentional design choice. Git history shows `.sync()` was added in February 2018 ([802036f693e](https://github.com/Card-Forge/forge/commit/802036f693e), *"print a message when unable to send event"*) so write exceptions would flow into a surrounding `try/catch` for logging. Without `.sync()`, `writeAndFlush` returns a `ChannelFuture` whose failure is reported asynchronously via listener — which the 2018 patch did not use. The original Forge networking before Feb 2018 was async. The proper fix in 2018 would have been to attach an error listener.

## What's the fix

Replace the synchronous `channel.writeAndFlush(event).sync()` calls in `RemoteClient` with asynchronous `channel.writeAndFlush(event)` plus a `ChannelFuture` listener for error reporting. The game thread fires the write and continues; success/failure is observed off-thread.

### User-facing effect

- **The host (running the server):** their local UI is driven by the same game thread that today parks on `.sync()`. With the change, the host's UI updates in real time regardless of any remote client's network. This is often the most visible benefit, since the host is usually actively playing while their game freezes whenever a remote opponent's link stalls.
- **Other remote players in a game with one slow participant:** their UI no longer freezes when a different opponent has a bad connection. Each remote client experiences only their own connection's quality, not the slowest player's.
- **The slow remote participant themselves:** unchanged in feel — their UI updates as fast as their own connection allows. They simply stop dragging everyone else along when it isn't their decision to make.
- **Whichever player the engine is currently waiting on for a response** (priority decisions, target selection, mulligan, blocker declarations, choosing modes, ordering triggers — anything routed through `sendAndWait`): the game still waits for their reply, by design. The engine cannot progress without the answer, before or after the change. If the player on the bad connection happens to be the one being prompted, they're the bottleneck — but that's current behaviour, not regression.

### How it works

Three changes in `RemoteClient`:

- `send()` writes async; errors logged via listener. The old `send() blocked X ms` telemetry is removed — once the call is async, the calling thread doesn't block, so blocked-ms is meaningless. The equivalent signal (a client falling behind) now comes from saturation logging — see below.
- `sendAndWait()` no longer delegates to `send()`; it does its own async `writeAndFlush()` with a listener that completes the reply future with `null` on write failure, so the game thread doesn't park for up to 45 s waiting for heartbeat to detect a dead connection.
- `write()` is unchanged in send semantics — it gains a saturation-counter increment, nothing more.

Client synchronisation is preserved:

The `sendAndWait()` path is the mechanism for "server fires a request and waits for the client's answer" — the engine genuinely cannot progress past a prompt (target selection, mulligan, ordering triggers, paying X) without the response. The reply-future wait inside `sendAndWait()` is what enforces that synchronisation, and it is **unchanged**. The async refactor only removes the *additional* block on the write itself flushing, which today happens *on top of* the reply wait, contributing nothing to correctness.

Per-request wait goes from `(write_flush + client_processing + reply)` to `(client_processing + reply)`. The "waiting for the client's answer" part is preserved exactly. If a write actually fails (channel closing, encoder error), the listener now completes the reply future with `null` immediately, and callers already handle `null` as "client did not answer" — strictly faster than today, where they parked until the 45s heartbeat noticed.

### Saturation error logging (replaces `send() blocked X ms`)

With async writes, per-call blocking time is no longer a meaningful signal — but we still want to know when a client can't keep up. The replacement observes Netty's outbound buffer directly:

- `WriteBufferWaterMark(64 KB low, 1 MB high)` configured on each client channel. Hard-coded constants — same standard everywhere.
- New `SaturationLoggingHandler` listens for `channelWritabilityChanged` events and logs entry/recovery as a paired set of lines:

  ```
  [WARN ] RemoteClient: Outbound buffer saturated for PlayerName (pending 1.2 MB)
  [INFO ] RemoteClient: PlayerName recovered after 1.3s outbound buffer saturation (47 server sends)
  ```

  The "47 server sends" counter is incremented inside `send()`/`write()`/`sendAndWait()` whenever `isWritable()` is false, so the recovery line shows how many writes piled up during the saturation window.
- `NetworkLogAnalyzer` swaps its old `send() blocked X ms` parser for one that reads the new recovery lines, reporting episode count and total / average / max duration in the network performance section.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)