### PR TITLE
Eliminate redundant protocol round-trip: cache UI skip-phase prefs

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/AttachEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/AttachEffect.java
@@ -122,8 +122,8 @@ public class AttachEffect extends SpellAbilityEffect {
             return;
         }
         String attachToName;
-        if (attachTo instanceof Card) {
-            attachToName = ((Card) attachTo).getTranslatedName();
+        if (attachTo instanceof Card c) {
+            attachToName = c.getTranslatedName();
         } else {
             attachToName = attachTo.toString();
         }
@@ -141,7 +141,7 @@ public class AttachEffect extends SpellAbilityEffect {
             }
 
             String message = Localizer.getInstance().getMessage("lblDoYouWantAttachSourceToTarget", attachment.getTranslatedName(), attachToName);
-            if (sa.hasParam("Optional") && !activator.getController().confirmAction(sa, null, message, null))
+            if (sa.hasParam("Optional") && !chooser.getController().confirmAction(sa, null, message, null))
             // TODO add params for message
                 continue;
 

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/DeckImport.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/DeckImport.java
@@ -539,7 +539,6 @@ public class DeckImport<TModel extends DeckBase> extends FDialog {
             });
         }
 
-
         // === ASSEMBLING ALL PANELS TOGETHER
         // ==================================
         this.add(this.scrollInput, "cell 0 0, w 40%, growy, pushy, spany 2");

--- a/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
@@ -68,8 +68,6 @@ import forge.game.spellability.StackItemView;
 import forge.game.zone.ZoneType;
 import forge.util.IHasForgeLog;
 import forge.gamemodes.net.NetworkGuiGame;
-import forge.gamemodes.net.client.NetGameController;
-import forge.interfaces.IGameController;
 import forge.gui.FNetOverlay;
 import forge.gui.FThreads;
 import forge.gui.GuiBase;
@@ -1313,26 +1311,7 @@ public final class CMatchUI
             }
         }
 
-        // Seed the host cache so isUiSetToSkipPhase reads locally instead of round-tripping
-        for (IGameController c : getOriginalGameControllers()) {
-            if (c instanceof NetGameController) {
-                ((NetGameController) c).replayUiSkipPhases(sortedPlayers, this::isUiSetToSkipPhase);
-            }
-        }
-    }
-
-    private void pushSkipPhaseToControllers(final PlayerView player, final PhaseType phase) {
-        // Mind-slave AND-combines the master's row with the controlled player's row, so a master
-        // toggle invalidates the cache for every player they control — re-push all dependents
-        for (PlayerView p : sortedPlayers) {
-            if (!p.equals(player) && !player.equals(p.getMindSlaveMaster())) continue;
-            final boolean shouldSkip = isUiSetToSkipPhase(p, phase);
-            for (IGameController c : getOriginalGameControllers()) {
-                if (c instanceof NetGameController) {
-                    ((NetGameController) c).setUiShouldSkipPhase(p, phase, shouldSkip);
-                }
-            }
-        }
+        seedSkipPhaseCache();
     }
 
     @Override

--- a/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
@@ -68,6 +68,8 @@ import forge.game.spellability.StackItemView;
 import forge.game.zone.ZoneType;
 import forge.util.IHasForgeLog;
 import forge.gamemodes.net.NetworkGuiGame;
+import forge.gamemodes.net.client.NetGameController;
+import forge.interfaces.IGameController;
 import forge.gui.FNetOverlay;
 import forge.gui.FThreads;
 import forge.gui.GuiBase;
@@ -1299,11 +1301,36 @@ public final class CMatchUI
         final PhaseType[] phases = PhaseType.values();
 
         for (int i = 0; i < fieldViews.size(); i++) {
-            final FPref[] keys = isLocalPlayer(sortedPlayers.get(i))
+            final PlayerView player = sortedPlayers.get(i);
+            final FPref[] keys = isLocalPlayer(player)
                     ? FPref.PHASES_HUMAN : FPref.PHASES_AI;
             final PhaseIndicator pi = fieldViews.get(i).getPhaseIndicator();
             for (int p = 1; p < phases.length; p++) {
-                pi.getLabelFor(phases[p]).setEnabled(prefs.getPrefBoolean(keys[p - 1]));
+                final PhaseType phase = phases[p];
+                final PhaseLabel label = pi.getLabelFor(phase);
+                label.setEnabled(prefs.getPrefBoolean(keys[p - 1]));
+                label.setOnToggled(() -> pushSkipPhaseToControllers(player, phase));
+            }
+        }
+
+        // Seed the host cache so isUiSetToSkipPhase reads locally instead of round-tripping
+        for (IGameController c : getOriginalGameControllers()) {
+            if (c instanceof NetGameController) {
+                ((NetGameController) c).replayUiSkipPhases(sortedPlayers, this::isUiSetToSkipPhase);
+            }
+        }
+    }
+
+    private void pushSkipPhaseToControllers(final PlayerView player, final PhaseType phase) {
+        // Mind-slave AND-combines the master's row with the controlled player's row, so a master
+        // toggle invalidates the cache for every player they control — re-push all dependents
+        for (PlayerView p : sortedPlayers) {
+            if (!p.equals(player) && !player.equals(p.getMindSlaveMaster())) continue;
+            final boolean shouldSkip = isUiSetToSkipPhase(p, phase);
+            for (IGameController c : getOriginalGameControllers()) {
+                if (c instanceof NetGameController) {
+                    ((NetGameController) c).setUiShouldSkipPhase(p, phase, shouldSkip);
+                }
             }
         }
     }

--- a/forge-gui-desktop/src/main/java/forge/toolbox/special/PhaseLabel.java
+++ b/forge-gui-desktop/src/main/java/forge/toolbox/special/PhaseLabel.java
@@ -20,13 +20,14 @@ public class PhaseLabel extends JLabel {
     private boolean enabled = true;
     private boolean active = false;
     private boolean hover = false;
+    private Runnable onToggled;
 
 
     /**
      * Shows phase labels, handles repainting and on/off states. A
      * PhaseLabel has "skip" and "active" states, meaning
      * "this phase is (not) skipped" and "this is the current phase".
-     * 
+     *
      * @param txt
      *            &emsp; Label text
      */
@@ -39,6 +40,9 @@ public class PhaseLabel extends JLabel {
             @Override
             public void mousePressed(final MouseEvent e) {
                 PhaseLabel.this.enabled = !PhaseLabel.this.enabled;
+                if (PhaseLabel.this.onToggled != null) {
+                    PhaseLabel.this.onToggled.run();
+                }
             }
 
             @Override
@@ -68,11 +72,16 @@ public class PhaseLabel extends JLabel {
 
     /**
      * Determines whether play pauses at this phase or not.
-     * 
+     *
      * @return boolean
      */
     public boolean getEnabled() {
         return this.enabled;
+    }
+
+    /** Fires after the user toggles this label by clicking. */
+    public void setOnToggled(final Runnable r) {
+        this.onToggled = r;
     }
 
     /**

--- a/forge-gui-mobile/src/forge/screens/match/MatchController.java
+++ b/forge-gui-mobile/src/forge/screens/match/MatchController.java
@@ -39,7 +39,9 @@ import forge.game.player.PlayerView;
 import forge.game.spellability.SpellAbilityView;
 import forge.game.zone.ZoneType;
 import forge.gamemodes.net.NetworkGuiGame;
+import forge.gamemodes.net.client.NetGameController;
 import forge.gamemodes.match.HostedMatch;
+import forge.interfaces.IGameController;
 import forge.gui.FThreads;
 import forge.gui.GuiBase;
 import forge.gui.util.SGuiChoose;
@@ -562,11 +564,33 @@ public class MatchController extends NetworkGuiGame {
         final PhaseType[] phases = PhaseType.values();
 
         for (final VPlayerPanel panel : panels) {
-            final FPref[] keys = instance.isLocalPlayer(panel.getPlayer())
+            final PlayerView player = panel.getPlayer();
+            final FPref[] keys = instance.isLocalPlayer(player)
                     ? FPref.PHASES_HUMAN : FPref.PHASES_AI;
             final VPhaseIndicator pi = panel.getPhaseIndicator();
             for (int p = 1; p < phases.length; p++) {
-                pi.getLabel(phases[p]).setStopAtPhase(prefs.getPrefBoolean(keys[p - 1]));
+                final PhaseType phase = phases[p];
+                final VPhaseIndicator.PhaseLabel label = pi.getLabel(phase);
+                label.setStopAtPhase(prefs.getPrefBoolean(keys[p - 1]));
+                label.setOnToggled(() -> pushSkipPhaseToControllers(player, phase));
+            }
+        }
+
+        // Seed the host cache so isUiSetToSkipPhase reads locally instead of round-tripping
+        final List<PlayerView> allPlayers = new ArrayList<>(panels.size());
+        for (VPlayerPanel panel : panels) allPlayers.add(panel.getPlayer());
+        for (IGameController c : instance.getOriginalGameControllers()) {
+            if (c instanceof NetGameController) {
+                ((NetGameController) c).replayUiSkipPhases(allPlayers, instance::isUiSetToSkipPhase);
+            }
+        }
+    }
+
+    private static void pushSkipPhaseToControllers(final PlayerView player, final PhaseType phase) {
+        final boolean shouldSkip = instance.isUiSetToSkipPhase(player, phase);
+        for (IGameController c : instance.getOriginalGameControllers()) {
+            if (c instanceof NetGameController) {
+                ((NetGameController) c).setUiShouldSkipPhase(player, phase, shouldSkip);
             }
         }
     }

--- a/forge-gui-mobile/src/forge/screens/match/MatchController.java
+++ b/forge-gui-mobile/src/forge/screens/match/MatchController.java
@@ -39,9 +39,7 @@ import forge.game.player.PlayerView;
 import forge.game.spellability.SpellAbilityView;
 import forge.game.zone.ZoneType;
 import forge.gamemodes.net.NetworkGuiGame;
-import forge.gamemodes.net.client.NetGameController;
 import forge.gamemodes.match.HostedMatch;
-import forge.interfaces.IGameController;
 import forge.gui.FThreads;
 import forge.gui.GuiBase;
 import forge.gui.util.SGuiChoose;
@@ -572,27 +570,11 @@ public class MatchController extends NetworkGuiGame {
                 final PhaseType phase = phases[p];
                 final VPhaseIndicator.PhaseLabel label = pi.getLabel(phase);
                 label.setStopAtPhase(prefs.getPrefBoolean(keys[p - 1]));
-                label.setOnToggled(() -> pushSkipPhaseToControllers(player, phase));
+                label.setOnToggled(() -> instance.pushSkipPhaseToControllers(player, phase));
             }
         }
 
-        // Seed the host cache so isUiSetToSkipPhase reads locally instead of round-tripping
-        final List<PlayerView> allPlayers = new ArrayList<>(panels.size());
-        for (VPlayerPanel panel : panels) allPlayers.add(panel.getPlayer());
-        for (IGameController c : instance.getOriginalGameControllers()) {
-            if (c instanceof NetGameController) {
-                ((NetGameController) c).replayUiSkipPhases(allPlayers, instance::isUiSetToSkipPhase);
-            }
-        }
-    }
-
-    private static void pushSkipPhaseToControllers(final PlayerView player, final PhaseType phase) {
-        final boolean shouldSkip = instance.isUiSetToSkipPhase(player, phase);
-        for (IGameController c : instance.getOriginalGameControllers()) {
-            if (c instanceof NetGameController) {
-                ((NetGameController) c).setUiShouldSkipPhase(player, phase, shouldSkip);
-            }
-        }
+        instance.seedSkipPhaseCache();
     }
 
     public static void writeMatchPreferences() {
@@ -706,6 +688,10 @@ public class MatchController extends NetworkGuiGame {
 
     @Override
     public boolean isUiSetToSkipPhase(final PlayerView playerTurn, final PhaseType phase) {
+        final PlayerView master = playerTurn.getMindSlaveMaster();
+        if (master != null && view.stopAtPhase(master, phase)) {
+            return false;
+        }
         return !view.stopAtPhase(playerTurn, phase);
     }
 

--- a/forge-gui-mobile/src/forge/screens/match/views/VPhaseIndicator.java
+++ b/forge-gui-mobile/src/forge/screens/match/views/VPhaseIndicator.java
@@ -110,6 +110,7 @@ public class VPhaseIndicator extends FContainer {
         private final PhaseType phaseType;
         private boolean stopAtPhase = false;
         private boolean active = false;
+        private Runnable onToggled;
 
         public PhaseLabel(String caption0, PhaseType phaseType0) {
             caption = caption0;
@@ -134,9 +135,15 @@ public class VPhaseIndicator extends FContainer {
             stopAtPhase = stopAtPhase0;
         }
 
+        /** Fires after the user toggles this label by tapping. */
+        public void setOnToggled(Runnable r) {
+            onToggled = r;
+        }
+
         @Override
         public boolean tap(float x, float y, int count) {
             stopAtPhase = !stopAtPhase;
+            if (onToggled != null) onToggled.run();
             return true;
         }
 

--- a/forge-gui/res/cardsfolder/c/curse_of_leeches_leeching_lurker.txt
+++ b/forge-gui/res/cardsfolder/c/curse_of_leeches_leeching_lurker.txt
@@ -4,7 +4,7 @@ Types:Enchantment Aura Curse
 K:Enchant:Player
 SVar:AttachAILogic:Curse
 R:Event$ Transform | ValidCard$ Card.Self | ReplaceWith$ Attach | Description$ As this permanent transforms into CARDNAME, attach it to a player.
-SVar:Attach:DB$ Attach | Object$ Self | Chooser$ You | PlayerChoices$ Player | ChoiceTitle$ Choose a player to attach this Curse to | AILogic$ Curse
+SVar:Attach:DB$ Attach | Object$ Self | PlayerChoices$ Player | ChoiceTitle$ Choose a player to attach this Curse to | AILogic$ Curse
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ Player.EnchantedBy | TriggerZones$ Battlefield | Execute$ TrigDrain | TriggerDescription$ At the beginning of enchanted player's upkeep, they lose 1 life and you gain 1 life.
 SVar:TrigDrain:DB$ LoseLife | Defined$ TriggeredPlayer | LifeAmount$ 1 | SubAbility$ DBGainLife
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1

--- a/forge-gui/res/cardsfolder/k/kudzu.txt
+++ b/forge-gui/res/cardsfolder/k/kudzu.txt
@@ -5,6 +5,6 @@ K:Enchant:Land
 SVar:AttachAILogic:Curse
 T:Mode$ Taps | ValidCard$ Card.AttachedBy | Execute$ TrigDestroy | TriggerDescription$ When enchanted land becomes tapped, destroy it. That land's controller may attach CARDNAME to a land of their choice.
 SVar:TrigDestroy:DB$ Destroy | Defined$ TriggeredCardLKICopy | SubAbility$ DBAttach
-SVar:DBAttach:DB$ Attach | Object$ Self | Chooser$ TriggeredCardController | Choices$ Land | AILogic$ Curse
+SVar:DBAttach:DB$ Attach | Object$ Self | Chooser$ TriggeredCardController | Choices$ Land | Optional$ True | AILogic$ Curse
 SVar:NonStackingAttachEffect:True
 Oracle:Enchant land\nWhen enchanted land becomes tapped, destroy it. That land's controller may attach Kudzu to a land of their choice.

--- a/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
@@ -9,10 +9,8 @@ import forge.game.card.CardView.CardStateView;
 import forge.game.event.GameEvent;
 import forge.game.event.GameEventSpellAbilityCast;
 import forge.game.event.GameEventSpellRemovedFromStack;
-import forge.game.phase.PhaseType;
 import forge.game.player.PlayerView;
 import forge.gamemodes.net.DeltaPacket;
-import forge.gamemodes.net.client.NetGameController;
 import forge.gui.FThreads;
 import forge.gui.GuiBase;
 import forge.gui.control.FControlGameEventHandler;
@@ -140,27 +138,6 @@ public abstract class AbstractGuiGame implements IGuiGame, IMayViewCards {
 
     public final Collection<IGameController> getOriginalGameControllers() {
         return originalGameControllers.values();
-    }
-
-    protected final void pushSkipPhaseToControllers(final PlayerView player, final PhaseType phase) {
-        // Mind-slave AND-combines master+controlled rows, so a master toggle invalidates dependents
-        for (final PlayerView p : getGameView().getPlayers()) {
-            if (!p.equals(player) && !player.equals(p.getMindSlaveMaster())) continue;
-            final boolean shouldSkip = isUiSetToSkipPhase(p, phase);
-            for (final IGameController c : getOriginalGameControllers()) {
-                if (c instanceof NetGameController nc) {
-                    nc.setUiShouldSkipPhase(p, phase, shouldSkip);
-                }
-            }
-        }
-    }
-
-    protected final void seedSkipPhaseCache() {
-        for (final IGameController c : getOriginalGameControllers()) {
-            if (c instanceof NetGameController nc) {
-                nc.replayUiSkipPhases(getGameView().getPlayers(), this::isUiSetToSkipPhase);
-            }
-        }
     }
 
     @Override

--- a/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
@@ -9,8 +9,10 @@ import forge.game.card.CardView.CardStateView;
 import forge.game.event.GameEvent;
 import forge.game.event.GameEventSpellAbilityCast;
 import forge.game.event.GameEventSpellRemovedFromStack;
+import forge.game.phase.PhaseType;
 import forge.game.player.PlayerView;
 import forge.gamemodes.net.DeltaPacket;
+import forge.gamemodes.net.client.NetGameController;
 import forge.gui.FThreads;
 import forge.gui.GuiBase;
 import forge.gui.control.FControlGameEventHandler;
@@ -138,6 +140,27 @@ public abstract class AbstractGuiGame implements IGuiGame, IMayViewCards {
 
     public final Collection<IGameController> getOriginalGameControllers() {
         return originalGameControllers.values();
+    }
+
+    protected final void pushSkipPhaseToControllers(final PlayerView player, final PhaseType phase) {
+        // Mind-slave AND-combines master+controlled rows, so a master toggle invalidates dependents
+        for (final PlayerView p : getGameView().getPlayers()) {
+            if (!p.equals(player) && !player.equals(p.getMindSlaveMaster())) continue;
+            final boolean shouldSkip = isUiSetToSkipPhase(p, phase);
+            for (final IGameController c : getOriginalGameControllers()) {
+                if (c instanceof NetGameController nc) {
+                    nc.setUiShouldSkipPhase(p, phase, shouldSkip);
+                }
+            }
+        }
+    }
+
+    protected final void seedSkipPhaseCache() {
+        for (final IGameController c : getOriginalGameControllers()) {
+            if (c instanceof NetGameController nc) {
+                nc.replayUiSkipPhases(getGameView().getPlayers(), this::isUiSetToSkipPhase);
+            }
+        }
     }
 
     @Override

--- a/forge-gui/src/main/java/forge/gamemodes/net/NetworkGuiGame.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/NetworkGuiGame.java
@@ -5,9 +5,11 @@ import forge.game.GameView;
 import forge.game.event.GameEvent;
 import forge.game.card.CardView;
 import forge.game.card.CardView.CardStateView;
+import forge.game.phase.PhaseType;
 import forge.game.player.PlayerView;
 import forge.game.zone.ZoneType;
 import forge.gamemodes.match.AbstractGuiGame;
+import forge.gamemodes.net.client.NetGameController;
 import forge.interfaces.IGameController;
 import forge.trackable.Tracker;
 import forge.trackable.TrackableCollection;
@@ -599,6 +601,33 @@ public abstract class NetworkGuiGame extends AbstractGuiGame implements IHasForg
         int phaseOrdinal = gameView.getPhase() != null ? gameView.getPhase().ordinal() : -1;
         netLog.error("[DeltaSync] Client breakdown: {}",
                 NetworkChecksumUtil.computeChecksumBreakdown(gameView.getTurn(), phaseOrdinal, gameView));
+    }
+
+    protected final void pushSkipPhaseToControllers(final PlayerView player, final PhaseType phase) {
+        // Mind-slave AND-combines master+controlled rows, so a master toggle invalidates dependents
+        for (final PlayerView p : getGameView().getPlayers()) {
+            if (!p.equals(player) && !player.equals(p.getMindSlaveMaster())) continue;
+            final boolean shouldSkip = isUiSetToSkipPhase(p, phase);
+            for (final IGameController c : getOriginalGameControllers()) {
+                if (c instanceof NetGameController nc) {
+                    nc.setUiShouldSkipPhase(p, phase, shouldSkip);
+                }
+            }
+        }
+    }
+
+    protected final void seedSkipPhaseCache() {
+        for (final IGameController c : getOriginalGameControllers()) {
+            if (c instanceof NetGameController nc) {
+                for (PlayerView p : getGameView().getPlayers()) {
+                    for (PhaseType ph : PhaseType.values()) {
+                        if (isUiSetToSkipPhase(p, ph)) {
+                            nc.setUiShouldSkipPhase(p, ph, Boolean.TRUE);
+                        }
+                    }
+                }
+            }
+        }
     }
 
 }

--- a/forge-gui/src/main/java/forge/gamemodes/net/ProtocolMethod.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/ProtocolMethod.java
@@ -69,7 +69,6 @@ public enum ProtocolMethod implements IHasForgeLog {
     // TODO case "setPlayerAvatar":
     openZones           (Mode.SERVER, PlayerZoneUpdates.class, PlayerView.class, Collection/*ZoneType*/.class, Map/*PlayerView,Object*/.class, Boolean.TYPE),
     restoreOldZones     (Mode.SERVER, Void.TYPE, PlayerView.class, PlayerZoneUpdates.class),
-    isUiSetToSkipPhase  (Mode.SERVER, Boolean.TYPE, PlayerView.class, PhaseType.class),
     setRememberedActions(Mode.SERVER, Void.TYPE),
     nextRememberedAction(Mode.SERVER, Void.TYPE),
     showWaitingTimer    (Mode.SERVER, Void.TYPE, PlayerView.class, String.class),
@@ -98,7 +97,8 @@ public enum ProtocolMethod implements IHasForgeLog {
     setShouldAutoYield        (Mode.CLIENT, Void.TYPE, String.class, Boolean.TYPE, Boolean.TYPE),
     setShouldAlwaysAcceptTrigger  (Mode.CLIENT, Void.TYPE, Integer.TYPE),
     setShouldAlwaysDeclineTrigger (Mode.CLIENT, Void.TYPE, Integer.TYPE),
-    setShouldAlwaysAskTrigger     (Mode.CLIENT, Void.TYPE, Integer.TYPE);
+    setShouldAlwaysAskTrigger     (Mode.CLIENT, Void.TYPE, Integer.TYPE),
+    setUiShouldSkipPhase          (Mode.CLIENT, Void.TYPE, PlayerView.class, PhaseType.class, Boolean.TYPE);
 
     private enum Mode {
         SERVER(IGuiGame.class),

--- a/forge-gui/src/main/java/forge/gamemodes/net/client/NetGameController.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/client/NetGameController.java
@@ -1,6 +1,7 @@
 package forge.gamemodes.net.client;
 
 import forge.game.card.CardView;
+import forge.game.phase.PhaseType;
 import forge.game.player.PlayerView;
 import forge.game.player.actions.PlayerAction;
 import forge.game.spellability.SpellAbilityView;
@@ -222,6 +223,29 @@ public class NetGameController implements IGameController {
         boolean abilityScope = activeModeIsAbilityScope();
         for (String key : getAutoYields()) {
             send(ProtocolMethod.setShouldAutoYield, key, Boolean.TRUE, abilityScope);
+        }
+    }
+
+    @Override
+    public boolean isUiSetToSkipPhase(final PlayerView turnPlayer, final PhaseType phase) {
+        // Never called on the client — host reads its own controller's cache
+        return false;
+    }
+
+    @Override
+    public void setUiShouldSkipPhase(final PlayerView turnPlayer, final PhaseType phase, final boolean shouldSkip) {
+        send(ProtocolMethod.setUiShouldSkipPhase, turnPlayer, phase, shouldSkip);
+    }
+
+    /** Sends only true entries; the host's empty-cache default already represents "don't skip". */
+    public void replayUiSkipPhases(final Iterable<PlayerView> allPlayers,
+                                   final java.util.function.BiPredicate<PlayerView, PhaseType> isSkipped) {
+        for (PlayerView p : allPlayers) {
+            for (PhaseType ph : PhaseType.values()) {
+                if (isSkipped.test(p, ph)) {
+                    send(ProtocolMethod.setUiShouldSkipPhase, p, ph, Boolean.TRUE);
+                }
+            }
         }
     }
 

--- a/forge-gui/src/main/java/forge/gamemodes/net/client/NetGameController.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/client/NetGameController.java
@@ -227,26 +227,8 @@ public class NetGameController implements IGameController {
     }
 
     @Override
-    public boolean isUiSetToSkipPhase(final PlayerView turnPlayer, final PhaseType phase) {
-        // Never called on the client — host reads its own controller's cache
-        return false;
-    }
-
-    @Override
     public void setUiShouldSkipPhase(final PlayerView turnPlayer, final PhaseType phase, final boolean shouldSkip) {
         send(ProtocolMethod.setUiShouldSkipPhase, turnPlayer, phase, shouldSkip);
-    }
-
-    /** Sends only true entries; the host's empty-cache default already represents "don't skip". */
-    public void replayUiSkipPhases(final Iterable<PlayerView> allPlayers,
-                                   final java.util.function.BiPredicate<PlayerView, PhaseType> isSkipped) {
-        for (PlayerView p : allPlayers) {
-            for (PhaseType ph : PhaseType.values()) {
-                if (isSkipped.test(p, ph)) {
-                    send(ProtocolMethod.setUiShouldSkipPhase, p, ph, Boolean.TRUE);
-                }
-            }
-        }
     }
 
     private IMacroSystem macros;

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/RemoteClientGuiGame.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/RemoteClientGuiGame.java
@@ -475,8 +475,8 @@ public class RemoteClientGuiGame extends NetworkGuiGame implements IHasForgeLog 
 
     @Override
     public boolean isUiSetToSkipPhase(final PlayerView playerTurn, final PhaseType phase) {
-        final Boolean result = sendAndWait(ProtocolMethod.isUiSetToSkipPhase, playerTurn, phase);
-        return Boolean.TRUE.equals(result);
+        // Host reads from PlayerControllerHuman's cache; this gui-side path is unreachable
+        return false;
     }
 
     @Override

--- a/forge-gui/src/main/java/forge/gui/interfaces/IGuiGame.java
+++ b/forge-gui/src/main/java/forge/gui/interfaces/IGuiGame.java
@@ -264,7 +264,6 @@ public interface IGuiGame {
     void autoPassUntilEndOfTurn(PlayerView player);
     boolean mayAutoPass(PlayerView player);
     void autoPassCancel(PlayerView player);
-
     void updateAutoPassPrompt();
 
     void setCurrentPlayer(PlayerView player);

--- a/forge-gui/src/main/java/forge/interfaces/IGameController.java
+++ b/forge-gui/src/main/java/forge/interfaces/IGameController.java
@@ -3,6 +3,7 @@ package forge.interfaces;
 import java.util.List;
 
 import forge.game.card.CardView;
+import forge.game.phase.PhaseType;
 import forge.game.player.PlayerView;
 import forge.game.spellability.SpellAbilityView;
 import forge.gamemodes.match.NextGameDecision;
@@ -71,4 +72,7 @@ public interface IGameController {
     void setShouldAlwaysAcceptTrigger(int trigger);
     void setShouldAlwaysDeclineTrigger(int trigger);
     void setShouldAlwaysAskTrigger(int trigger);
+
+    boolean isUiSetToSkipPhase(PlayerView turnPlayer, PhaseType phase);
+    void setUiShouldSkipPhase(PlayerView turnPlayer, PhaseType phase, boolean shouldSkip);
 }

--- a/forge-gui/src/main/java/forge/interfaces/IGameController.java
+++ b/forge-gui/src/main/java/forge/interfaces/IGameController.java
@@ -73,6 +73,5 @@ public interface IGameController {
     void setShouldAlwaysDeclineTrigger(int trigger);
     void setShouldAlwaysAskTrigger(int trigger);
 
-    boolean isUiSetToSkipPhase(PlayerView turnPlayer, PhaseType phase);
     void setUiShouldSkipPhase(PlayerView turnPlayer, PhaseType phase, boolean shouldSkip);
 }

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -29,6 +29,7 @@ import forge.game.keyword.KeywordInterface;
 import forge.game.mana.Mana;
 import forge.game.mana.ManaConversionMatrix;
 import forge.game.mana.ManaCostBeingPaid;
+import forge.game.phase.PhaseType;
 import forge.game.player.*;
 import forge.game.player.actions.SelectCardAction;
 import forge.game.player.actions.SelectPlayerAction;
@@ -106,6 +107,8 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
     private final Set<String> remoteAbilityYields = Sets.newHashSet();
     private final Map<Integer, Boolean> remoteTriggerDecisions = Maps.newTreeMap();
     private boolean remoteAutoYieldsDisabled;
+    // Empty/missing entry returns false (don't skip), matching a fresh UI's conservative default
+    private final Map<PlayerView, EnumSet<PhaseType>> remoteSkipPhases = Maps.newHashMap();
 
     protected final InputQueue inputQueue;
     protected final InputProxy inputProxy;
@@ -1505,7 +1508,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
             int delay = 0;
             if (stack.isEmpty()) {
                 // make sure to briefly pause at phases you're not set up to skip
-                if (!getGui().isUiSetToSkipPhase(getGame().getPhaseHandler().getPlayerTurn().getView(),
+                if (!isUiSetToSkipPhase(getGame().getPhaseHandler().getPlayerTurn().getView(),
                         getGame().getPhaseHandler().getPhase())) {
                     delay = FControlGamePlayback.phasesDelay;
                 }
@@ -1525,7 +1528,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
         }
 
         if (stack.isEmpty()) {
-            if (getGui().isUiSetToSkipPhase(getGame().getPhaseHandler().getPlayerTurn().getView(),
+            if (isUiSetToSkipPhase(getGame().getPhaseHandler().getPlayerTurn().getView(),
                     getGame().getPhaseHandler().getPhase())) {
                 netLog.trace("Returning null (skipPhase) for player {}", player.getName());
                 return null; // avoid prompt for input if stack is empty and
@@ -3593,5 +3596,23 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
     public void setShouldAlwaysAskTrigger(final int trigger) {
         if (isRemoteClient()) remoteTriggerDecisions.remove(trigger);
         else localStore().setTriggerDecision(trigger, AutoYieldStore.TriggerDecision.ASK);
+    }
+
+    @Override
+    public boolean isUiSetToSkipPhase(final PlayerView turnPlayer, final PhaseType phase) {
+        if (isRemoteClient()) {
+            EnumSet<PhaseType> set = remoteSkipPhases.get(turnPlayer);
+            return set != null && set.contains(phase);
+        }
+        return getGui().isUiSetToSkipPhase(turnPlayer, phase);
+    }
+
+    @Override
+    public void setUiShouldSkipPhase(final PlayerView turnPlayer, final PhaseType phase, final boolean shouldSkip) {
+        if (!isRemoteClient()) return;
+        EnumSet<PhaseType> set = remoteSkipPhases.computeIfAbsent(turnPlayer,
+                k -> EnumSet.noneOf(PhaseType.class));
+        if (shouldSkip) set.add(phase);
+        else set.remove(phase);
     }
 }

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -3487,8 +3487,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
     }
 
     private boolean activeModeIsInstall() {
-        return ForgeConstants.AUTO_YIELD_PER_ABILITY_INSTALL.equals(
-                FModel.getPreferences().getPref(FPref.UI_AUTO_YIELD_MODE));
+        return ForgeConstants.AUTO_YIELD_PER_ABILITY_INSTALL.equals(FModel.getPreferences().getPref(FPref.UI_AUTO_YIELD_MODE));
     }
 
     private AutoYieldStore.Tier activeTier() {
@@ -3518,7 +3517,8 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
     public void setShouldAutoYield(final String key, final boolean autoYield, final boolean isAbilityScope) {
         if (isRemoteClient()) {
             Set<String> bucket = isAbilityScope ? remoteAbilityYields : remoteCardYields;
-            if (autoYield) bucket.add(key); else bucket.remove(key);
+            if (autoYield) bucket.add(key);
+            else bucket.remove(key);
             return;
         }
         String storageKey = isAbilityScope ? AutoYieldStore.abilitySuffix(key) : key;
@@ -3532,7 +3532,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
     @Override
     public Iterable<String> getAutoYields() {
         if (isRemoteClient()) {
-            return com.google.common.collect.Iterables.concat(remoteCardYields, remoteAbilityYields);
+            return Iterables.concat(remoteCardYields, remoteAbilityYields);
         }
         if (activeModeIsInstall()) return PersistentYieldStore.get().getYields();
         return localStore().getYields(activeTier());
@@ -3598,7 +3598,6 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
         else localStore().setTriggerDecision(trigger, AutoYieldStore.TriggerDecision.ASK);
     }
 
-    @Override
     public boolean isUiSetToSkipPhase(final PlayerView turnPlayer, final PhaseType phase) {
         if (isRemoteClient()) {
             EnumSet<PhaseType> set = remoteSkipPhases.get(turnPlayer);


### PR DESCRIPTION
## What's the issue

In network multiplayer, **the host pings the remote client over the wire on every priority transition** to ask "is your UI configured to skip this phase?". Each call goes through `RemoteClientGuiGame.isUiSetToSkipPhase` → `sendAndWait(ProtocolMethod.isUiSetToSkipPhase, …)` — a full TCP round-trip. The host's game thread parks until the reply lands.

`PlayerControllerHuman.getActivePlayerInput` makes this call every time a remote human gets priority and the stack is empty — order-of-magnitude **~13 calls per turn for one remote human, ~26 for two**.

The data being asked for is **static across most of a match** — just the client's UI label state for "stop at this phase". There's no reason to round-trip it every time.

## What's the fix

The client tells the host its full skip-phase state once at match start, and pushes per-toggle deltas thereafter. The host caches it per `PlayerControllerHuman` and answers `isUiSetToSkipPhase` from local memory — zero round-trips on the hot path.

This is the same pattern recently established for auto-yield prefs (the controller-owns-prefs refactor): per-player preference state lives on `IGameController`, the host's `PlayerControllerHuman` keeps a remote-mirror map gated on `isRemoteClient()`, and `NetGameController` ships mutations via 1:1-named `Mode.CLIENT` protocol methods. Initial state is replayed at game start by the client (`replayActiveYields` for yields; `replayUiSkipPhases` for skip-phase here).

The only structural difference: yield prefs live in stores loaded before the game (so the seed fires from `FGameClient.setGameControllers`), whereas skip-phase prefs live in UI label state, which is populated by `actuateMatchPreferences` after game start. The seed therefore fires from the end of `actuateMatchPreferences` — the first point at which all label state and player views are settled.

### How it works

Three logical pieces:

1. **Host-side cache.** `PlayerControllerHuman` gains `Map<PlayerView, EnumSet<PhaseType>> remoteSkipPhases`. New `IGameController.isUiSetToSkipPhase` reads from it when serving a remote (`gui instanceof RemoteClientGuiGame`); the empty-cache default returns `false` (don't skip), matching a fresh UI's conservative default. The two `getActivePlayerInput` call sites swap from `getGui().isUiSetToSkipPhase(…)` to `this.isUiSetToSkipPhase(…)`.

2. **Client-side push.** New `Mode.CLIENT` `ProtocolMethod.setUiShouldSkipPhase(PlayerView, PhaseType, Boolean)` carries a single `(player, phase, shouldSkip)` mutation. `NetGameController.replayUiSkipPhases(allPlayers, isSkipped)` is a one-shot helper that pushes the full snapshot — only `shouldSkip == true` entries, since the host's empty cache already represents `false`.

3. **UI wiring.** `PhaseLabel` (desktop) and `VPhaseIndicator.PhaseLabel` (mobile) gain `setOnToggled(Runnable)`, fired post-flip. `CMatchUI.actuateMatchPreferences` (desktop) and `MatchController.actuateMatchPreferences` (mobile) wire per-`(player, phase)` callbacks at the end of label initialization, then fire the initial `replayUiSkipPhases` for any local `NetGameController`. Mid-game toggles ship one ~80-byte message each.

The old `Mode.SERVER ProtocolMethod.isUiSetToSkipPhase` is deleted. The `IGuiGame.isUiSetToSkipPhase` method stays — still used locally by `FControlGamePlayback`, and by the local-fallback branch inside `PlayerControllerHuman.isUiSetToSkipPhase`. All are local reads with no network cost.

## Why it's safe

- **Local play and hotseat are unchanged.** When `isRemoteClient()` is false, `isUiSetToSkipPhase` delegates to `getGui()` (label state, exactly as today) and `setUiShouldSkipPhase` is a no-op. The on-toggle push and the seed are gated on `instanceof NetGameController`, so local controllers (`PlayerControllerHuman`) skip them entirely. Existing hotseat semantics — both rows seeded from `PHASES_HUMAN`, independent toggles mid-match, last-write-wins on save — are preserved exactly.
- **Mind-slave correctness preserved.** Desktop's `CMatchUI.isUiSetToSkipPhase(turnPlayer, phase)` AND-combines the turn player's row with the master's row. When the master toggles their label, the cached answer for every player they control changes too. `pushSkipPhaseToControllers` iterates players and re-pushes any dependent — narrow edge case (Mindslaver, Sorin Markov ult) but the cache stays consistent with what the GUI would return locally.
- **Empty-cache default is the conservative choice.** Until the seed lands (a brief window at match start), the host returns "don't skip" → stop at every phase → user gets prompted as if they hadn't configured anything. No phase ever gets accidentally skipped before the snapshot arrives.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)