### PR TITLE
Fix UI bug causing opening hand to be invisible

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
@@ -380,9 +380,12 @@ public final class CMatchUI
         return view.getHands();
     }
     public VHand getHandFor(final PlayerView p) {
-        final int idx = getPlayerIndex(p);
-        final List<VHand> allHands = getHandViews();
-        return idx < 0 || idx >= allHands.size() ? null : allHands.get(idx);
+        for (final VHand hand : getHandViews()) {
+            if (p.equals(hand.getPlayer())) {
+                return hand;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/forge-gui-desktop/src/main/java/forge/screens/match/controllers/CHand.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/controllers/CHand.java
@@ -87,23 +87,6 @@ public class CHand implements ICDoc {
 
         final HandArea p = view.getHandArea();
 
-        final VField vf = matchUI.getFieldViewFor(player);
-        if (vf == null) {
-            return;
-        }
-        final Rectangle rctLibraryLabel = vf.getDetailsPanel().getLblLibrary().getBounds();
-
-        // Animation starts from the library label and runs to the hand panel.
-        // This check prevents animation running if label hasn't been realized yet.
-        if (rctLibraryLabel.isEmpty()) {
-            return;
-        }
-
-        // Don't perform animations if the user's in another tab.
-        if (!matchUI.isCurrentScreen()) {
-            return;
-        }
-
         //update card panels in hand area
         final List<CardView> cards;
         if (player.getHand() == null) {
@@ -147,6 +130,26 @@ public class CHand implements ICDoc {
         p.setCardPanels(cardPanels);
         view.updateTabLabel(ordering.size());
 
+        final VField vf = matchUI.getFieldViewFor(player);
+        if (vf == null) {
+            revealPlaceholders(placeholders);
+            return;
+        }
+        final Rectangle rctLibraryLabel = vf.getDetailsPanel().getLblLibrary().getBounds();
+
+        // Animation starts from the library label and runs to the hand panel.
+        // If that label has not been realized yet, the hand should still update.
+        if (rctLibraryLabel.isEmpty()) {
+            revealPlaceholders(placeholders);
+            return;
+        }
+
+        // Don't perform animations if the user's in another tab.
+        if (!matchUI.isCurrentScreen()) {
+            revealPlaceholders(placeholders);
+            return;
+        }
+
         //animate new cards into positions defined by placeholders
         final JLayeredPane layeredPane = Singletons.getView().getFrame().getLayeredPane();
         int fromZoneX = 0, fromZoneY = 0;
@@ -176,6 +179,12 @@ public class CHand implements ICDoc {
             else {
                 Animation.moveCard(placeholder);
             }
+        }
+    }
+
+    private void revealPlaceholders(final List<CardPanel> placeholders) {
+        for (final CardPanel placeholder : placeholders) {
+            Animation.moveCard(placeholder);
         }
     }
 

--- a/forge-gui-desktop/src/main/java/forge/screens/match/views/VHand.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/views/VHand.java
@@ -141,6 +141,10 @@ public class VHand implements IVDoc<CHand> {
         return VHand.this.hand;
     }
 
+    public PlayerView getPlayer() {
+        return player;
+    }
+
     private boolean isTabVisible() {
         return parentCell != null && parentCell.getSelected() == this;
     }


### PR DESCRIPTION
Fixes a desktop UI bug where a local player’s opening hand could be invisible during the mulligan prompt in multiplayer games.

The issue was easiest to reproduce in a 4-player game when the match entered the mulligan prompt while a different player’s field tab was selected. It could also be reproduced around conceding/restarting when the local player’s own tab was not selected. In that state, CHand.updateHand() tried to prepare the player’s hand display, but it returned early if the field/library-label layout anchor was not ready or the match screen was not currently active. Because that early return happened before the hand card panels were populated/revealed, the player’s hand tab could exist but show no visible cards.

There was a second wrinkle: newly created hand CardPanels start with displayEnabled=false, because normal card draw handling reveals them at the end of the draw animation. During mulligan/setup, if the animation cannot run because the layout anchor is unavailable, those placeholders stayed disabled. Later drawing a card triggered a normal hand update/animation path, which is why the UI partially or fully recovered after drawing.

This fix changes CHand.updateHand() so it always updates the hand contents first. Animation setup now happens afterward and is treated as optional. If the library label, field view, or screen state is not ready for animation, the new placeholders are revealed immediately using the existing non-animated Animation.moveCard(placeholder) path.

I also changed desktop hand lookup to find a VHand by its owning PlayerView instead of assuming the visible hand tab list has the same indexes as the full multiplayer player list. That avoids fragile behavior in multiplayer layouts where not every player necessarily has a visible hand document.