### PR TITLE
Fix network log cleanup

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/net/NetworkLogConfig.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/NetworkLogConfig.java
@@ -255,6 +255,7 @@ public final class NetworkLogConfig implements IHasForgeLog {
     public static void activateNetworkLogging() {
         if (normalModeKey == null) {
             normalModeKey = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"));
+            cleanupOldLogs();
         }
     }
 


### PR DESCRIPTION
Network log writer is intended to retain a history of the last 10 logs and delete any older entries to avoid file bloat.

However cleanupOldLogs() was only called by the test executor, not in normal network play. This allowed network logs to accumulate past the NET_MAX_LOG_FILES limit.

Fix by adding cleanupOldLogs() to the normal network play path.