### PR TITLE
Mobile freeze diagnostics: lifecycle, heap, uncaught exceptions, encoder stack traces

### DIFF
--- a/forge-game/src/main/java/forge/game/Game.java
+++ b/forge-game/src/main/java/forge/game/Game.java
@@ -51,6 +51,8 @@ import forge.trackable.Tracker;
 import forge.util.*;
 import forge.util.collect.FCollection;
 import org.apache.commons.lang3.tuple.Pair;
+import org.tinylog.Logger;
+import org.tinylog.TaggedLogger;
 
 import java.util.*;
 import java.util.function.Predicate;
@@ -59,6 +61,8 @@ import java.util.function.Predicate;
  * Represents the state of a <i>single game</i>, a new instance is created for each game.
  */
 public class Game {
+
+    private static final TaggedLogger netLog = Logger.tag("NETWORK");
 
     private static int maxId = 0;
     private static int nextId() { return ++maxId; }
@@ -707,7 +711,12 @@ public class Game {
         if (visit.getFound() == null) {
             forEachCardInGame(visit);
         }
-        return visit.getFound();
+        Card found = visit.getFound();
+        if (found == null) {
+            netLog.error("findByView: id={} (zone={}, controller={}) not found in any zone — returning null",
+                    view.getId(), view.getZone(), view.getController());
+        }
+        return found;
     }
 
     public Card findById(int id) {

--- a/forge-gui-android/src/forge/app/Main.java
+++ b/forge-gui-android/src/forge/app/Main.java
@@ -33,6 +33,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
+import android.os.Looper;
 import android.provider.Settings;
 import android.text.SpannableString;
 import android.text.TextUtils;
@@ -70,6 +71,8 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.json.JSONObject;
 import org.jupnp.DefaultUpnpServiceConfiguration;
 import org.jupnp.android.AndroidUpnpServiceConfiguration;
+import org.tinylog.Logger;
+import org.tinylog.TaggedLogger;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -78,6 +81,9 @@ import java.util.Date;
 import java.util.Set;
 
 public class Main extends AndroidApplication {
+    private static final TaggedLogger netLog = Logger.tag("NETWORK");
+    private static final long HEAP_HEARTBEAT_MS = 30_000L;
+
     private AndroidAdapter Gadapter;
     private ArrayList<String> gamepads;
     private AndroidClipboard androidClipboard;
@@ -89,6 +95,18 @@ public class Main extends AndroidApplication {
     private ProgressBar progressBar;
     private TextView progressText;
     private String versionString;
+    private Handler heapHeartbeatHandler;
+    private final Runnable heapHeartbeat = new Runnable() {
+        @Override public void run() {
+            Runtime r = Runtime.getRuntime();
+            long total = r.totalMemory(), free = r.freeMemory(), max = r.maxMemory();
+            netLog.info("[heap] used={}MB free={}MB total={}MB max={}MB",
+                    (total - free) >> 20, free >> 20, total >> 20, max >> 20);
+            if (heapHeartbeatHandler != null) {
+                heapHeartbeatHandler.postDelayed(this, HEAP_HEARTBEAT_MS);
+            }
+        }
+    };
 
     // The package name the resources are compiled under (stable across dev/prod).
     // If you ever change the base app package, update this constant once.
@@ -148,6 +166,7 @@ public class Main extends AndroidApplication {
 
     @Override
     protected void onResume() {
+        netLog.info("[lifecycle] onResume");
         try {
             super.onResume();
         } catch (Exception ignore) {}
@@ -161,6 +180,19 @@ public class Main extends AndroidApplication {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        // Capture uncaught exceptions before the JVM dies — without this, the stack trace would only reach Android logcat, not the network log users share
+        final Thread.UncaughtExceptionHandler prior = Thread.getDefaultUncaughtExceptionHandler();
+        Thread.setDefaultUncaughtExceptionHandler((t, e) -> {
+            try {
+                netLog.error(e, "[uncaught] thread={}", t.getName());
+            } catch (Throwable ignore) {}
+            if (prior != null) prior.uncaughtException(t, e);
+        });
+
+        netLog.info("[lifecycle] onCreate");
+        heapHeartbeatHandler = new Handler(Looper.getMainLooper());
+        heapHeartbeatHandler.postDelayed(heapHeartbeat, HEAP_HEARTBEAT_MS);
+
         super.onCreate(savedInstanceState);
         try {
             PackageInfo pInfo = getContext().getPackageManager().getPackageInfo(getContext().getPackageName(), 0);
@@ -542,6 +574,11 @@ public class Main extends AndroidApplication {
 
     @Override
     protected void onDestroy() {
+        netLog.info("[lifecycle] onDestroy");
+        if (heapHeartbeatHandler != null) {
+            heapHeartbeatHandler.removeCallbacks(heapHeartbeat);
+            heapHeartbeatHandler = null;
+        }
         super.onDestroy();
         //ensure app doesn't stick around
         //ActivityManager am = (ActivityManager)getSystemService(Activity.ACTIVITY_SERVICE);
@@ -549,7 +586,26 @@ public class Main extends AndroidApplication {
     }
 
     @Override
+    protected void onStop() {
+        netLog.info("[lifecycle] onStop");
+        super.onStop();
+    }
+
+    @Override
+    public void onLowMemory() {
+        netLog.warn("[lifecycle] onLowMemory");
+        super.onLowMemory();
+    }
+
+    @Override
+    public void onTrimMemory(int level) {
+        netLog.warn("[lifecycle] onTrimMemory level={}", level);
+        super.onTrimMemory(level);
+    }
+
+    @Override
     protected void onPause() {
+        netLog.info("[lifecycle] onPause");
         super.onPause();
 
         /*ForgePreferences prefs = FModel.getPreferences();

--- a/forge-gui/src/main/java/forge/gamemodes/net/GameProtocolHandler.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/GameProtocolHandler.java
@@ -5,6 +5,7 @@ import forge.gamemodes.net.event.ReplyEvent;
 import forge.gui.FThreads;
 import forge.gui.util.SOptionPane;
 import forge.localinstance.skin.FSkinProp;
+import forge.trackable.TrackableObject;
 import forge.util.IHasForgeLog;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -81,11 +82,11 @@ public abstract class GameProtocolHandler<T> extends ChannelInboundHandlerAdapte
                     try {
                         method.invoke(toInvoke, args);
                     } catch (final IllegalAccessException | IllegalArgumentException e) {
-                        netLog.error("Unknown protocol method {} with {} args", methodName, args == null ? 0 : args.length);
+                        netLog.error("Unknown protocol method {} args={}", methodName, describeArgs(args));
                     } catch (final InvocationTargetException e) {
                         //throw new RuntimeException(e.getTargetException());
                         catchedError[0] += (String.format("RuntimeException: %s (GameProtocolHandler.java Line 65)\n", e.getTargetException().toString()));
-                        netLog.error(e.getTargetException(), "InvocationTargetException in {}", methodName);
+                        netLog.error(e.getTargetException(), "InvocationTargetException in {} args={}", methodName, describeArgs(args));
                     }
                 } else {
                     Serializable reply = null;
@@ -98,12 +99,12 @@ public abstract class GameProtocolHandler<T> extends ChannelInboundHandlerAdapte
                             netLog.warn("Non-serializable return type {} for method {}, returning null", returnType.getName(), methodName);
                         }
                     } catch (final IllegalAccessException | IllegalArgumentException e) {
-                        netLog.error("Unknown protocol method {} with {} args, replying with null", methodName, args == null ? 0 : args.length);
+                        netLog.error("Unknown protocol method {} args={}, replying with null", methodName, describeArgs(args));
                     } catch (final NullPointerException | InvocationTargetException e) {
                         //throw new RuntimeException(e.getTargetException());
                         catchedError[0] += e.toString();
                         SOptionPane.showMessageDialog(catchedError[0], "Error", FSkinProp.ICO_WARNING);
-                        netLog.error("Exception in protocol method {}: {}", methodName, e.toString());
+                        netLog.error("Exception in protocol method {} args={}: {}", methodName, describeArgs(args), e.toString());
                     }
                     getRemote(ctx).send(new ReplyEvent(event.getId(), reply));
                 }
@@ -119,6 +120,24 @@ public abstract class GameProtocolHandler<T> extends ChannelInboundHandlerAdapte
                 FThreads.invokeInBackgroundThread(toRun);
             }
         }
+    }
+
+    private static String describeArgs(Object[] args) {
+        if (args == null) return "[]";
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < args.length; i++) {
+            if (i > 0) sb.append(", ");
+            Object a = args[i];
+            if (a == null) {
+                sb.append("null");
+            } else {
+                sb.append(a.getClass().getSimpleName());
+                if (a instanceof TrackableObject to) {
+                    sb.append('#').append(to.getId());
+                }
+            }
+        }
+        return sb.append(']').toString();
     }
 
     @Override

--- a/forge-gui/src/main/java/forge/gamemodes/net/TrackableSerializer.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/TrackableSerializer.java
@@ -10,6 +10,7 @@ import forge.trackable.TrackableTypes.TrackableType;
 import forge.trackable.Tracker;
 
 import org.tinylog.Logger;
+import org.tinylog.TaggedLogger;
 
 import net.jpountz.lz4.LZ4BlockOutputStream;
 
@@ -27,6 +28,8 @@ import java.util.List;
  * ({@link CObjectOutputStream}, {@link CObjectInputStream}).
  */
 public final class TrackableSerializer {
+    private static final TaggedLogger netLog = Logger.tag("NETWORK");
+
     static final byte TYPE_CARD_VIEW = 0;
     static final byte TYPE_PLAYER_VIEW = 1;
 
@@ -132,7 +135,7 @@ public final class TrackableSerializer {
             if (type != null) {
                 Object resolved = tracker.getObj(type, ref.id);
                 if (resolved == null) {
-                    Logger.warn("Could not resolve IdRef(tag={}, id={}) from Tracker", ref.typeTag, ref.id);
+                    netLog.warn("Could not resolve IdRef(tag={}, id={}) from Tracker", ref.typeTag, ref.id);
                 }
                 return resolved;
             }
@@ -185,7 +188,7 @@ public final class TrackableSerializer {
                 }
                 wrapped.add(new WrappedEvent(baos.toByteArray()));
             } catch (IOException e) {
-                Logger.warn("Failed to wrap event {}: {}", event.getClass().getSimpleName(), e.getMessage());
+                netLog.warn("Failed to wrap event {}: {}", event.getClass().getSimpleName(), e.getMessage());
             }
         }
         return wrapped;
@@ -207,7 +210,7 @@ public final class TrackableSerializer {
                         if (obj instanceof GameEvent e) events.add(e);
                     }
                 } catch (IOException | ClassNotFoundException e) {
-                    Logger.warn("Failed to unwrap event: {}", e.getMessage());
+                    netLog.warn("Failed to unwrap event: {}", e.getMessage());
                 }
             }
         }

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/RemoteClient.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/RemoteClient.java
@@ -61,8 +61,12 @@ public final class RemoteClient implements IToClient, IHasForgeLog {
             if (!f.isSuccess()) {
                 sendErrors.incrementAndGet();
                 Throwable c = f.cause();
-                String causeStr = c == null ? (f.isCancelled() ? "cancelled" : "no cause") : c.getClass().getSimpleName() + ": " + c.getMessage();
-                netLog.error("Network send error for {} (event: {}, cause: {})", username, event, causeStr);
+                if (c != null) {
+                    netLog.error(c, "Network send error for {} (event: {})", username, event);
+                } else {
+                    netLog.error("Network send error for {} (event: {}, cause: {})",
+                            username, event, f.isCancelled() ? "cancelled" : "no cause");
+                }
             }
         });
     }
@@ -83,8 +87,12 @@ public final class RemoteClient implements IToClient, IHasForgeLog {
             if (!f.isSuccess()) {
                 sendErrors.incrementAndGet();
                 Throwable c = f.cause();
-                String causeStr = c == null ? (f.isCancelled() ? "cancelled" : "no cause") : c.getClass().getSimpleName() + ": " + c.getMessage();
-                netLog.error("sendAndWait write failed for {} (event: {}, cause: {})", username, event, causeStr);
+                if (c != null) {
+                    netLog.error(c, "sendAndWait write failed for {} (event: {})", username, event);
+                } else {
+                    netLog.error("sendAndWait write failed for {} (event: {}, cause: {})",
+                            username, event, f.isCancelled() ? "cancelled" : "no cause");
+                }
                 replies.complete(event.getId(), null);
             }
         });

--- a/forge-gui/src/main/resources/tinylog.properties
+++ b/forge-gui/src/main/resources/tinylog.properties
@@ -11,4 +11,4 @@ level@org.eclipse.jetty  = warn
 writerNetFile        = network log
 writerNetFile.tag    = NETWORK
 writerNetFile.level  = trace
-writerNetFile.format = {date: HH:mm:ss.SSS} [{level|min-size=5}] {class-name}: {message}
+writerNetFile.format = {date: HH:mm:ss.SSS} [{level|min-size=5}] {class-name}: {message}{exception}


### PR DESCRIPTION
## Context

User reports mobile multiplayer freezes/disconnects, often when interacting with an opponent's action. No host crash. Client log just *stops* mid-stream — no shutdown event, no exception, no lifecycle hint. **Cause currently unknown** — could be Android backgrounding, OS memory-killing the app, an uncaught JVM exception, or a native crash. Logs alone can't distinguish them.

This PR adds lightweight instrumentation so the next freeze writes its cause to disk before the app dies.

## Changes

| Change | What it catches |
|---|---|
| `[lifecycle] onCreate/Resume/Pause/Stop/Destroy + onLowMemory + onTrimMemory` lines | User backgrounded the app, vs. Android memory-killed it, vs. JVM died on its own |
| Default `UncaughtExceptionHandler` writing the stack to the NETWORK log | Real Java bugs that kill the JVM before tinylog flushes |
| 30-second `[heap] used=… free=… total=… max=…` heartbeat | OOM vs. non-OOM (visible by `used` climbing toward `max` in the last entries) |
| `RemoteClient.send`/`sendAndWait` listeners pass throwable to `netLog.error(t, …)` | Real stack traces on encoder/IO failures (the prior `causeStr` flatten dropped the frames) |
| Tinylog NETWORK file format adds `{exception}` | Foundation for all the above — without it, throwables silently drop |
| Three `TrackableSerializer.Logger.warn(...)` calls re-tagged to NETWORK | IdRef resolution failures and event wrap/unwrap errors — previously console-only, so invisible in user-uploaded network logs |
| `Game.findByView` logs an error at the null-return path with id/zone/controller | Lookup misses at the source instead of as downstream NPEs in unrelated code |
| `GameProtocolHandler.describeArgs(...)` augments NPE/`InvocationTargetException` log lines with each arg's type and TrackableObject id | Correlates a null arg back to an earlier "Could not resolve IdRef" warning by id |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)