### PR TITLE
PP07.pzl - Added library

### DIFF
--- a/forge-gui/res/puzzle/PP07.pzl
+++ b/forge-gui/res/puzzle/PP07.pzl
@@ -13,4 +13,5 @@ humanhand=Swamp;Gurmag Angler;Disfigure;Compulsive Research
 humanlibrary=Dragon Fangs;Swamp;Lightning Bolt
 humangraveyard=Dragon Breath
 humanbattlefield=Mountain;Mountain;Swamp;Island;Island;Forest;Archaeomancer
+ailibrary=Plains;Plains;Swamp
 aibattlefield=Fume Spitter;Auramancer


### PR DESCRIPTION
Added three lands to the AI library so it couldn't draw from an empty library.
The image suggests the opponent has a library despite the cards not being specified.