### PR TITLE
Update CopySpellAbilityEffect.java

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/CopySpellAbilityEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CopySpellAbilityEffect.java
@@ -73,7 +73,7 @@ public class CopySpellAbilityEffect extends SpellAbilityEffect {
 
         List<SpellAbility> tgtSpells = getTargetSpells(sa);
 
-        if (tgtSpells.isEmpty() && "TriggeredSpellAbility".equals(sa.getParam("Defined"))) {
+        if (tgtSpells.isEmpty() && "TriggeredSourceSA".equals(sa.getParam("Defined"))) {
             final Object sourceSA = sa.getTriggeringObject(AbilityKey.SourceSA);
             if (sourceSA instanceof SpellAbility) {
                 tgtSpells = Lists.newArrayList((SpellAbility) sourceSA);

--- a/forge-game/src/main/java/forge/game/ability/effects/CopySpellAbilityEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/CopySpellAbilityEffect.java
@@ -73,6 +73,13 @@ public class CopySpellAbilityEffect extends SpellAbilityEffect {
 
         List<SpellAbility> tgtSpells = getTargetSpells(sa);
 
+        if (tgtSpells.isEmpty() && "TriggeredSpellAbility".equals(sa.getParam("Defined"))) {
+            final Object sourceSA = sa.getTriggeringObject(AbilityKey.SourceSA);
+            if (sourceSA instanceof SpellAbility) {
+                tgtSpells = Lists.newArrayList((SpellAbility) sourceSA);
+            }
+        }
+
         tgtSpells.removeIf(SpellAbility::cantBeCopied);
 
         if (tgtSpells.isEmpty() || amount == 0) {


### PR DESCRIPTION
Allows CopySpellAbility with Defined$ TriggeredSpellAbility to copy the source spell/ability from BecomesTarget trigger stored as AbilityKey.SourceSA, which had not been done before.