### PR TITLE
Fix ConcurrentModificationException in client zone iteration

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/screens/match/views/VStack.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/views/VStack.java
@@ -128,8 +128,10 @@ public class VStack implements IVDoc<CStack> {
         hoveredItem = null;
         scroller.removeAll();
 
+        final Iterable<StackItemView> safeItems = controller.getMatchUI().isNetGame()
+                ? items.threadSafeIterable() : items;
         boolean isFirst = true;
-        for (final StackItemView item : items) {
+        for (final StackItemView item : safeItems) {
             final StackInstanceTextArea tar = new StackInstanceTextArea(item);
 
             scroller.add(tar, "pushx, growx" + (isFirst ? "" : ", gaptop 2px"));

--- a/forge-gui-desktop/src/main/java/forge/screens/match/views/VZone.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/views/VZone.java
@@ -24,6 +24,7 @@ import forge.screens.match.CMatchUI;
 import forge.screens.match.controllers.CZone;
 import forge.toolbox.FScrollPane;
 import forge.toolbox.MouseTriggerEvent;
+import forge.util.collect.FCollectionView;
 import forge.view.arcane.CardArea;
 import forge.util.Localizer;
 import forge.view.arcane.CardPanel;
@@ -93,10 +94,11 @@ public class VZone implements IVDoc<CZone> {
     /** Refresh card panels from zone data. */
     public void refresh() {
         final List<CardPanel> cardPanels = new ArrayList<>();
-        final Iterable<CardView> cards = player.getCards(zone);
+        final FCollectionView<CardView> cards = player.getCards(zone);
         if (cards != null) {
+            final Iterable<CardView> safeCards = matchUI.isNetGame() ? cards.threadSafeIterable() : cards;
             final List<CardView> cardList = new ArrayList<>();
-            for (final CardView card : cards) {
+            for (final CardView card : safeCards) {
                 cardList.add(card);
             }
             if (sortedByName) {

--- a/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingZone.java
+++ b/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingZone.java
@@ -58,6 +58,7 @@ import forge.toolbox.FSkin;
 import forge.toolbox.special.PlayerDetailsPanel;
 import forge.util.Localizer;
 import forge.util.collect.FCollection;
+import forge.util.collect.FCollectionView;
 import forge.view.FView;
 
 public class FloatingZone extends FloatingCardArea {
@@ -528,9 +529,10 @@ public class FloatingZone extends FloatingCardArea {
     };
 
     protected Iterable<CardView> getCards() {
-        Iterable<CardView> zoneCards = player.getCards(zone);
+        FCollectionView<CardView> zoneCards = player.getCards(zone);
         if (zoneCards != null) {
-            cardList = new FCollection<>(zoneCards);
+            Iterable<CardView> safe = getMatchUI().isNetGame() ? zoneCards.threadSafeIterable() : zoneCards;
+            cardList = new FCollection<>(safe);
             if (sortedByName) {
                 cardList.sort(comp);
             } else if (zone == ZoneType.Flashback) {

--- a/forge-gui-mobile/src/forge/screens/match/MatchScreen.java
+++ b/forge-gui-mobile/src/forge/screens/match/MatchScreen.java
@@ -492,8 +492,11 @@ public class MatchScreen extends FScreen {
                 VPlayerPanel playerPanel = getPlayerPanel(p);
                 if (playerPanel != null && playerPanelsList.contains(playerPanel)) {
                     playerViewSet.add(p);
-                    if (p.getBattlefield() != null) {
-                        for (CardView c : p.getBattlefield()) {
+                    FCollectionView<CardView> battlefield = p.getBattlefield();
+                    if (battlefield != null) {
+                        Iterable<CardView> bfIter = MatchController.instance.isNetGame()
+                                ? battlefield.threadSafeIterable() : battlefield;
+                        for (CardView c : bfIter) {
                             CardAreaPanel panel = CardAreaPanel.get(c);
                             Vector2 origin = panel.getTargetingArrowOrigin();
                             //outside left bounds

--- a/forge-gui-mobile/src/forge/screens/match/views/VField.java
+++ b/forge-gui-mobile/src/forge/screens/match/views/VField.java
@@ -9,11 +9,13 @@ import forge.game.player.PlayerView;
 import forge.gui.FThreads;
 import forge.localinstance.properties.ForgePreferences;
 import forge.model.FModel;
+import forge.screens.match.MatchController;
 import forge.screens.match.MatchScreen;
 import forge.screens.match.views.VCardDisplayArea.CardAreaPanel;
 import forge.toolbox.FCardPanel;
 import forge.toolbox.FContainer;
 import forge.toolbox.FDisplayObject;
+import forge.util.collect.FCollectionView;
 
 public class VField extends FContainer {
     private final PlayerView player;
@@ -62,10 +64,12 @@ public class VField extends FContainer {
         public void run() {
             clear();
 
-            Iterable<CardView> model = player.getBattlefield();
-            if (model == null) {
+            FCollectionView<CardView> battlefield = player.getBattlefield();
+            if (battlefield == null) {
                 return;
             }
+            Iterable<CardView> model = MatchController.instance.isNetGame()
+                    ? battlefield.threadSafeIterable() : battlefield;
 
             for (CardView card : model) {
                 CardAreaPanel cardPanel = CardAreaPanel.get(card);

--- a/forge-gui-mobile/src/forge/screens/match/views/VZoneDisplay.java
+++ b/forge-gui-mobile/src/forge/screens/match/views/VZoneDisplay.java
@@ -4,10 +4,13 @@ import java.util.List;
 
 import forge.Forge;
 import forge.Graphics;
+import forge.game.card.CardView;
 import forge.game.player.PlayerView;
 import forge.game.zone.ZoneType;
+import forge.screens.match.MatchController;
 import forge.toolbox.FCardPanel;
 import forge.toolbox.FDisplayObject;
+import forge.util.collect.FCollectionView;
 
 public class VZoneDisplay extends VCardDisplayArea {
     private final PlayerView player;
@@ -25,7 +28,9 @@ public class VZoneDisplay extends VCardDisplayArea {
 
     @Override
     public void update() {
-        refreshCardPanels(player.getCards(zoneType));
+        FCollectionView<CardView> cards = player.getCards(zoneType);
+        refreshCardPanels(cards != null && MatchController.instance.isNetGame()
+                ? cards.threadSafeIterable() : cards);
     }
 
     @Override


### PR DESCRIPTION
## Discovery

Investigating user reports of intermittent freezes on the mobile network client, two consecutive remote-client sessions on master reproduced a ConcurrentModificationException at two *different* reader sites:

- **Run 1 (client):** `VZoneDisplay.update` → `VCardDisplayArea.refreshCardPanels` (for-each over `player.getCards(zoneType)`), reached via `MatchController.updateZones`.
- **Run 2 (client):** `VField.updateRoutine.run` (for-each over `player.getBattlefield()`), reached via `MatchController.refreshCardDetails`.

Whether the user-reported "freezes" are this same race can't be confirmed without a stack trace from their environment, but the symptoms are consistent: a CME on the libgdx render thread aborts iteration mid-frame, leaving the client in a partial UI state — what users experience as a hang. Both crashes were on the client side of host/client mobile sessions, a few minutes into mid-game play. 

Same race, two different sites — the bug is systematic, not a freak accident.

## Why this is more noticeable now

The race has existed since the network architecture was first introduced — the Netty I/O thread mutates `TrackableCollection` state via `copyChangedProps` (and, since <!-- -->#9642, also via `applyDelta`) while the GUI thread reads. PR <!-- -->#9866 (Feb 2026) fixed three desktop CMatchUI surfaces, but missed several others.

The most plausible recent change to elevate the race from latent to visible is <!-- -->#10535 (async writes in RemoteClient). The host's game thread no longer blocks on `writeAndFlush(event).sync()`; events burst out asynchronously, so the client receives bursts of mutations in tight succession on the Netty thread, dramatically tightening the timing window in which the render thread can collide.

This also aligns with users report of issues starting after 27 April.

## The fix

All call sites in the match-screen UI directories (`forge-gui-mobile/screens/match/`, `forge-gui-desktop/screens/match/`, `forge-gui-desktop/view/arcane/`) that iterate a live `FCollectionView` from `PlayerView`/`GameView` getters were audited; six were identified as vulnerable to this race:

| File | Method | Iteration |
|---|---|---|
| `forge-gui-mobile/.../VZoneDisplay.java` | `update` | `player.getCards(zoneType)` (Run 1 crash site) |
| `forge-gui-mobile/.../VField.java` | `updateRoutine.run` | `player.getBattlefield()` ×2 (Run 2 crash site) |
| `forge-gui-mobile/.../MatchScreen.java` | `drawArcs` | `p.getBattlefield()` per player |
| `forge-gui-desktop/.../VZone.java` | `refresh` | `player.getCards(zone)` |
| `forge-gui-desktop/.../VStack.java` | `updateStack` | `model.getStack()` |
| `forge-gui-desktop/.../FloatingZone.java` | `getCards` | `new FCollection<>(zoneCards)` — the wrap itself iterates the live source during `addAll` |

Each site now snapshots the live collection before iterating: `isNetGame() ? coll.threadSafeIterable() : coll`.

## Consistency with precedent

This mirrors PR <!-- -->#9866 exactly — same mechanism, same `threadSafeIterable()` snapshot approach, same `isNetGame()` conditional. That PR fixed `CMatchUI.refreshField`, `setSelectables`, and `clearSelectables`. This PR patches the additional reader sites that <!-- -->#9866 didn't reach.

`FCollectionView.threadSafeIterable()` returns `Iterables.unmodifiableIterable(new ArrayList<>(list))` — a fresh ArrayList snapshot wrapped as unmodifiable. The `isNetGame()` gate avoids the (small) snapshot cost in single-player, where all updates run on the GUI thread anyway and there's no concurrent mutator.

## Alternative considered: architectural fix

The architectural alternative is to wrap `NetworkGuiGame.applyDelta` (and the mutation portion of `setGameView`) in `FThreads.invokeInEdtNowOrLater`, deferring all Netty-thread mutations to run on the GUI thread. This would address the *class* of race at its source — eliminating the same vulnerability for any current or future reader of `TrackableObject` state, not just the six audited sites.

Not adopted here for two reasons:

1. **Larger blast radius.** Moves load-bearing `applyDelta` work from the Netty thread onto the GUI thread. A delta with hundreds of `CardView` updates could spike a frame. Mitigation would need batch-coalescing of pending packets in one GUI pass, adding complexity.
2. **Changes ordering semantics.** Every current and future Netty-thread mutator path becomes deferred. Subtle ordering bugs could surface in code that currently relies on `applyDelta` completing synchronously before subsequent reads.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)