### PR TITLE
Mobile chat polish and match-screen unread indicator

### DIFF
--- a/docs/Development/ownership.md
+++ b/docs/Development/ownership.md
@@ -5,9 +5,9 @@ Please also try to check back a bit after your PR gets merged in case it causes 
 ## DevOps
 | Concept | Owners | Ancestors | Example tasks |
 | - | - | - | - |
-| PC Releases | friarsol | Agetian | - update Maven dependencies |
+| PC Releases | friarsol | Agetian | - update Maven dependencies<br>- maintain CI files |
 | Android Releases | | kevlahnota | |
-| Sentry | JaminCollins | | - watch for rare/unusual crashes |
+| Sentry | JaminCollins | | - watch trends for rare/unusual crashes |
 
 ## Ingame Engine
 | Concept | Owners | Ancestors | Example tasks |
@@ -26,7 +26,7 @@ Please also try to check back a bit after your PR gets merged in case it causes 
 ## User Interface
 | Concept | Owners | Ancestors | Example tasks |
 | - | - | - | - |
-| Desktop | | | |
+| Desktop | | | - performance profiling |
 | Android | | DrDev, kevlahnota | - test new libGDX versions |
 | Localization | | Alumi | - update card translation files<br>- update engine text (native speaker not required) |
 | Sound effects | | | |
@@ -41,7 +41,7 @@ Please also try to check back a bit after your PR gets merged in case it causes 
 | Concept | Owners | Ancestors | Example tasks |
 | - | - | - | - |
 | Quest | friarsol | | |
-| [Network Play](../network-play.md) | | JaminCollins | |
+| [Network Play](../network-play.md) | MostCromulent | JaminCollins | |
 | Gauntlet | | | |
 | Draft | | | |
 | Planar Conquest | | DrDev | |
@@ -61,4 +61,4 @@ Please also try to check back a bit after your PR gets merged in case it causes 
 ## Miscellaneous
 | Concept | Owners | Ancestors | Example tasks |
 | - | - | - | - |
-| Documentation | | | - update Wiki |
+| Documentation | TRT | | - update Wiki |

--- a/docs/User-Guide.md
+++ b/docs/User-Guide.md
@@ -20,7 +20,7 @@
   - [Shift Key helper](#shift-key-helper)
   - [Full Control](#full-control)
   - [Repeatable Sequences (Macros)](#repeatable-sequences-macros)
-- [User Interface](#user-interface)
+- [Desktop User Interface](#desktop-user-interface)
   - [Layout](#layout)
   - [Viewing Cards in Different Zones](#viewing-cards-in-different-zones)
   - [Auto-Sort Multiplayer Fields](#auto-sort-multiplayer-fields)
@@ -34,8 +34,8 @@
 
 [***CLICK HERE FOR DOWNLOAD LINKS - Forge SNAPSHOT Version (DESKTOP/ANDROID)***](https://github.com/Card-Forge/forge/releases/tag/daily-snapshots)
 
-* For desktop, grab the installer file that ends in .jar
-* For android, grab the android file that ends in .apk
+* For Desktop, grab the installer file that ends in .jar
+* For Android, grab the app file that ends in .apk
   &dash; Watch the screen recording if one of following steps isn't clear for you
 
 <https://github.com/user-attachments/assets/7a0c7bb8-7cf9-4800-8091-bcc30ff2f4d8>

--- a/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
+++ b/forge-ai/src/main/java/forge/ai/simulation/GameStateEvaluator.java
@@ -50,14 +50,8 @@ public class GameStateEvaluator {
             return null;
         }
 
-        Game gameCopy;
         GameCopier copier = new GameCopier(evalGame);
-
-        if (evalGame.EXPERIMENTAL_RESTORE_SNAPSHOT) {
-            gameCopy = copier.makeCopy();
-        } else {
-            gameCopy = copier.makeCopy(null, aiPlayer);
-        }
+        Game gameCopy = copier.makeCopy(null, aiPlayer);
 
         gameCopy.getPhaseHandler().devAdvanceToPhase(PhaseType.COMBAT_DAMAGE, () -> GameSimulator.resolveStack(gameCopy, aiPlayer.getWeakestOpponent()));
         CombatSimResult result = new CombatSimResult();

--- a/forge-core/src/main/java/forge/util/Localizer.java
+++ b/forge-core/src/main/java/forge/util/Localizer.java
@@ -173,11 +173,6 @@ public class Localizer {
         }
     }
 
-    public List<Language> getLanguages() {
-        //TODO List all languages by getting their files
-        return null;
-    }
-
     public void registerObserver(LocalizationChangeObserver observer) {
         observers.add(observer);
     }
@@ -186,11 +181,6 @@ public class Localizer {
         for (LocalizationChangeObserver observer : observers) {
             observer.localizationChanged();
         }
-    }
-
-    public static class Language {
-        public String languageName;
-        public String languageID;
     }
 
 }

--- a/forge-gui-desktop/src/main/java/forge/screens/match/menus/GameMenu.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/menus/GameMenu.java
@@ -179,8 +179,7 @@ public final class GameMenu {
 
     private ActionListener getAutoYieldsAction() {
         return e -> {
-            final VAutoYields autoYields = new VAutoYields(matchUI);
-            autoYields.showAutoYields();
+            new VAutoYields(matchUI).showAutoYields();
         };
     }
 

--- a/forge-gui-mobile/src/forge/menu/FMenuBar.java
+++ b/forge-gui-mobile/src/forge/menu/FMenuBar.java
@@ -13,14 +13,15 @@ public class FMenuBar extends Header {
     private final List<FMenuTab> tabs = new ArrayList<>();
     private int selected = -1;
 
-    public void addTab(String text0, FDropDown dropDown0) {
-        addTab(text0, dropDown0, false);
+    public FMenuTab addTab(String text0, FDropDown dropDown0) {
+        return addTab(text0, dropDown0, false);
     }
 
-    public void addTab(String text0, FDropDown dropDown0, boolean iconOnly) {
+    public FMenuTab addTab(String text0, FDropDown dropDown0, boolean iconOnly) {
         FMenuTab tab = new FMenuTab(text0, this, dropDown0, tabs.size(), iconOnly);
         dropDown0.setMenuTab(tab);
         tabs.add(add(tab));
+        return tab;
     }
 
     public float getPreferredHeight() {

--- a/forge-gui-mobile/src/forge/menu/FMenuTab.java
+++ b/forge-gui-mobile/src/forge/menu/FMenuTab.java
@@ -1,5 +1,6 @@
 package forge.menu;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.utils.Align;
 
@@ -38,6 +39,10 @@ public class FMenuTab extends FDisplayObject {
     }
     public static final float PADDING = Utils.scale(2);
     private static final float SEPARATOR_WIDTH = Utils.scale(1);
+    private static final FSkinFont BADGE_FONT = FSkinFont.get(9);
+    private static final FSkinColor BADGE_COLOR = FSkinColor.getStandardColor(192, 50, 50);
+    private static final FSkinColor BADGE_TEXT_COLOR = FSkinColor.getStandardColor(255, 255, 255);
+    private static final long FLASH_DURATION_MS = 900;
 
     private final FMenuBar menuBar;
     private final FDropDown dropDown;
@@ -45,6 +50,8 @@ public class FMenuTab extends FDisplayObject {
     private String text;
     private float minWidth;
     private int index;
+    private int unreadCount;
+    private long flashStartMs;
 
     public FMenuTab(String text0, FMenuBar menuBar0, FDropDown dropDown0, int index0, boolean iconOnly0) {
         menuBar = menuBar0;
@@ -96,6 +103,19 @@ public class FMenuTab extends FDisplayObject {
 
     public void setActiveIcon(boolean value) {
         active = value;
+    }
+
+    public void incrementUnread() {
+        unreadCount++;
+        flashStartMs = System.currentTimeMillis();
+        Gdx.graphics.requestRendering();
+    }
+
+    public void clearUnread() {
+        if (unreadCount == 0 && flashStartMs == 0) { return; }
+        unreadCount = 0;
+        flashStartMs = 0;
+        Gdx.graphics.requestRendering();
     }
 
     @Override
@@ -153,6 +173,19 @@ public class FMenuTab extends FDisplayObject {
         h = getHeight() - 2 * PADDING;
         if (isHovered())
             g.fillRect(getSelBackColor().brighter(), x, y, w, h);
+
+        //flash overlay while a recent unread message highlights the tab
+        if (flashStartMs > 0) {
+            long elapsed = System.currentTimeMillis() - flashStartMs;
+            if (elapsed < FLASH_DURATION_MS) {
+                float alpha = 0.55f * (1f - (float) elapsed / FLASH_DURATION_MS);
+                g.fillRect(BADGE_COLOR.alphaColor(alpha), x, y, w, h);
+                Gdx.graphics.requestRendering();
+            } else {
+                flashStartMs = 0;
+            }
+        }
+
         if (iconOnly) {
             float mod = w * 0.75f;
             FImage icon = active ? FSkinImage.SEE : FSkinImage.UNSEE;
@@ -161,6 +194,17 @@ public class FMenuTab extends FDisplayObject {
             g.drawImage(icon, x + w/2 - scaleW/2, y + h/2 - scaleH/2, scaleW, scaleH);
         } else
             g.drawText(text, FONT, foreColor, x, y, w, h, false, Align.center, true);
+
+        //unread badge in the top-right corner
+        if (unreadCount > 0) {
+            String label = unreadCount > 99 ? "99+" : Integer.toString(unreadCount);
+            float textW = BADGE_FONT.getBounds(label).width;
+            float diameter = Math.max(BADGE_FONT.getLineHeight(), textW + 2 * Utils.scale(4));
+            float bx = getWidth() - diameter - PADDING;
+            float by = PADDING;
+            g.fillRect(BADGE_COLOR, bx, by, diameter, diameter);
+            g.drawText(label, BADGE_FONT, BADGE_TEXT_COLOR, bx, by, diameter, diameter, false, Align.center, true);
+        }
     }
     public boolean isShowingDropdownMenu(boolean any) {
         if (dropDown == null)

--- a/forge-gui-mobile/src/forge/screens/match/views/VChat.java
+++ b/forge-gui-mobile/src/forge/screens/match/views/VChat.java
@@ -9,6 +9,7 @@ import forge.gamemodes.net.IRemote;
 import forge.gamemodes.net.event.MessageEvent;
 import forge.localinstance.properties.ForgePreferences.FPref;
 import forge.menu.FDropDown;
+import forge.menu.FMenuTab;
 import forge.model.FModel;
 import forge.screens.online.ChatMessageBubble;
 import forge.screens.online.OnlineChatScreen;
@@ -55,8 +56,25 @@ public class VChat extends FDropDown implements IOnlineChatInterface {
         add(new ChatMessageBubble(message));
         if (isVisible()) {
             updateSizeAndPosition();
+        } else {
+            FMenuTab tab = getMenuTab();
+            if (tab != null) {
+                tab.incrementUnread();
+            }
         }
         Gdx.graphics.requestRendering();
+    }
+
+    @Override
+    public void setVisible(boolean visible0) {
+        boolean wasVisible = isVisible();
+        super.setVisible(visible0);
+        if (visible0 && !wasVisible) {
+            FMenuTab tab = getMenuTab();
+            if (tab != null) {
+                tab.clearUnread();
+            }
+        }
     }
 
     private void sendMessage() {

--- a/forge-gui-mobile/src/forge/screens/online/ChatMessageBubble.java
+++ b/forge-gui-mobile/src/forge/screens/online/ChatMessageBubble.java
@@ -13,12 +13,15 @@ import forge.util.Utils;
 
 public class ChatMessageBubble extends FDisplayObject {
     private static final FSkinFont FONT = FSkinFont.get(12);
+    private static final FSkinFont META_FONT = FSkinFont.get(9);
     private static final FSkinColor LOCAL_COLOR = FSkinColor.get(Colors.CLR_ZEBRA);
     private static final FSkinColor REMOTE_COLOR = LOCAL_COLOR.getContrastColor(-20);
     private static final FSkinColor WARNING_COLOR = FSkinColor.getStandardColor(140, 95, 25);
+    private static final FSkinColor SYSTEM_BUBBLE_COLOR = FSkinColor.getStandardColor(45, 95, 160);
+    private static final FSkinColor SYSTEM_TEXT_COLOR = FSkinColor.getStandardColor(255, 255, 255);
     private static final FSkinColor MESSAGE_COLOR = FSkinColor.get(Colors.CLR_TEXT);
-    private static final FSkinColor SOURCE_COLOR = MESSAGE_COLOR.alphaColor(0.75f);
-    private static final FSkinColor TIMESTAMP_COLOR = MESSAGE_COLOR.alphaColor(0.5f);
+    private static final FSkinColor META_COLOR = MESSAGE_COLOR.alphaColor(0.55f);
+    private static final FSkinColor SYSTEM_META_COLOR = SYSTEM_TEXT_COLOR.alphaColor(0.7f);
     private static final FSkinColor BORDER_COLOR = FSkinColor.get(Colors.CLR_BORDERS).alphaColor(0.5f);
     private static final float BORDER_THICKNESS = Utils.scale(1.5f);
     private static final float TEXT_INSET = Utils.scale(5);
@@ -26,7 +29,7 @@ public class ChatMessageBubble extends FDisplayObject {
 
     private final ChatMessage message;
     public final boolean isLocal;
-    private final String header;
+    private final boolean isSystem;
     private final TextRenderer textRenderer = new TextRenderer();
 
     public ChatMessage getMessage() {
@@ -36,21 +39,12 @@ public class ChatMessageBubble extends FDisplayObject {
     public ChatMessageBubble(ChatMessage message0) {
         message = message0;
         isLocal = message.isLocal();
-        if (isLocal || message.getSource() == null) {
-            header = null;
-        }
-        else {
-            header = message.getSource() + ":";
-        }
+        isSystem = message.getType() == ChatMessage.MessageType.SYSTEM;
     }
 
     public float getPreferredHeight(float width) {
-        float height = FONT.getCapHeight() + 4 * TEXT_INSET + 2 * BORDER_THICKNESS;
-        if (header != null) {
-            height += FONT.getLineHeight();
-        }
-        height += textRenderer.getWrappedBounds(message.getMessage(), FONT, width - 2 * TEXT_INSET).height;
-        return height;
+        return META_FONT.getLineHeight() + 4 * TEXT_INSET + 2 * BORDER_THICKNESS
+                + textRenderer.getWrappedBounds(message.getMessage(), FONT, width - 2 * TEXT_INSET).height;
     }
 
     @Override
@@ -59,20 +53,34 @@ public class ChatMessageBubble extends FDisplayObject {
         float y = TEXT_INSET;
         float w = getWidth() - TRIANGLE_WIDTH;
         float h = getHeight() - TEXT_INSET;
-        FSkinColor color;
-        if (message.getType() == ChatMessage.MessageType.WARNING) {
-            color = WARNING_COLOR;
-        } else {
-            color = isLocal ? LOCAL_COLOR : REMOTE_COLOR;
+        FSkinColor bubbleColor;
+        FSkinColor textColor;
+        FSkinColor metaColor;
+        switch (message.getType()) {
+            case WARNING:
+                bubbleColor = WARNING_COLOR;
+                textColor = MESSAGE_COLOR;
+                metaColor = META_COLOR;
+                break;
+            case SYSTEM:
+                bubbleColor = SYSTEM_BUBBLE_COLOR;
+                textColor = SYSTEM_TEXT_COLOR;
+                metaColor = SYSTEM_META_COLOR;
+                break;
+            default:
+                bubbleColor = isLocal ? LOCAL_COLOR : REMOTE_COLOR;
+                textColor = MESSAGE_COLOR;
+                metaColor = META_COLOR;
+                break;
         }
         int horzAlignment = isLocal ? Align.right : Align.left;
-        float timestampHeight = FONT.getCapHeight();
 
         //draw bubble fill
-        g.fillRect(color, x, y, w, h);
+        g.fillRect(bubbleColor, x, y, w, h);
         g.drawRect(BORDER_THICKNESS, BORDER_COLOR, x, y, w, h);
 
-        //draw triangle to make this look like chat bubble
+        //draw triangle to make this look like chat bubble — anchored near top of message area
+        float metaHeight = META_FONT.getLineHeight();
         float x1, x2;
         if (isLocal) {
             x1 = w - 1;
@@ -83,11 +91,11 @@ public class ChatMessageBubble extends FDisplayObject {
             x2 = 0;
         }
         float x3 = x1;
-        float y1 = y + timestampHeight + TEXT_INSET;
+        float y1 = y + TEXT_INSET;
         float y3 = y1 + TRIANGLE_WIDTH * 1.25f;
         float y2 = (y1 + y3) / 2;
 
-        g.fillTriangle(color, x1, y1, x2, y2, x3, y3);
+        g.fillTriangle(bubbleColor, x1, y1, x2, y2, x3, y3);
         g.drawLine(BORDER_THICKNESS, BORDER_COLOR, x1, y1, x2, y2);
         g.drawLine(BORDER_THICKNESS, BORDER_COLOR, x2, y2, x3, y3);
 
@@ -96,15 +104,25 @@ public class ChatMessageBubble extends FDisplayObject {
         y += TEXT_INSET;
         w -= 2 * TEXT_INSET;
 
-        if (!isLocal && message.getSource() != null) {
-            float sourceHeight = FONT.getLineHeight();
-            g.drawText(message.getSource() + ":", FONT, SOURCE_COLOR, x, y, w, sourceHeight, false, horzAlignment, true);
-            y += sourceHeight;
+        //message text first, meta line below
+        float messageHeight = getHeight() - y - metaHeight - 2 * TEXT_INSET;
+        textRenderer.drawText(g, message.getMessage(), FONT, textColor, x, y, w, messageHeight, y, messageHeight, true, horzAlignment, true);
+        y += messageHeight + TEXT_INSET;
+
+        //meta line: "Sender · HH:MM:SS" — Server identifies itself for system messages
+        String sourceLabel;
+        if (message.getType() == ChatMessage.MessageType.SYSTEM) {
+            sourceLabel = "Server";
+        } else {
+            sourceLabel = message.getSource();
         }
+        String meta = sourceLabel != null
+                ? sourceLabel + " · " + message.getTimestamp()
+                : message.getTimestamp();
+        g.drawText(meta, META_FONT, metaColor, x, y, w, metaHeight, false, horzAlignment, true);
+    }
 
-        g.drawText(message.getTimestamp(), FONT, TIMESTAMP_COLOR, x, h - timestampHeight, w, timestampHeight, false, horzAlignment, true);
-
-        h -= y + timestampHeight + TEXT_INSET;
-        textRenderer.drawText(g, message.getMessage(), FONT, MESSAGE_COLOR, x, y, w, h, y, h, true, horzAlignment, true);
+    public boolean isSystem() {
+        return isSystem;
     }
 }

--- a/forge-gui-mobile/src/forge/screens/online/ChatMessageBubble.java
+++ b/forge-gui-mobile/src/forge/screens/online/ChatMessageBubble.java
@@ -29,7 +29,6 @@ public class ChatMessageBubble extends FDisplayObject {
 
     private final ChatMessage message;
     public final boolean isLocal;
-    private final boolean isSystem;
     private final TextRenderer textRenderer = new TextRenderer();
 
     public ChatMessage getMessage() {
@@ -39,7 +38,6 @@ public class ChatMessageBubble extends FDisplayObject {
     public ChatMessageBubble(ChatMessage message0) {
         message = message0;
         isLocal = message.isLocal();
-        isSystem = message.getType() == ChatMessage.MessageType.SYSTEM;
     }
 
     public float getPreferredHeight(float width) {
@@ -122,7 +120,4 @@ public class ChatMessageBubble extends FDisplayObject {
         g.drawText(meta, META_FONT, metaColor, x, y, w, metaHeight, false, horzAlignment, true);
     }
 
-    public boolean isSystem() {
-        return isSystem;
-    }
 }

--- a/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
@@ -401,24 +401,17 @@ public abstract class AbstractGuiGame implements IGuiGame, IMayViewCards {
             return false;
         } else if (spectator == null) {
             return true; //if no local players or spectator, just quit
-        } else {
-            if (showConfirmDialog(Localizer.getInstance().getMessage("lblCloseGameSpectator"), Localizer.getInstance().getMessage("lblCloseGame"), Localizer.getInstance().getMessage("lblClose"), Localizer.getInstance().getMessage("lblCancel"))) {
-                IGameController controller = spectator;
-                spectator = null; //ensure we don't prompt again, including when calling nextGameDecision below
-                if (!isGamePaused())
-                    controller.selectButtonOk(); //pause
-                controller.nextGameDecision(NextGameDecision.QUIT);
-            }
-            return false; //let logic above handle closing current screen
+        } else if (showConfirmDialog(Localizer.getInstance().getMessage("lblCloseGameSpectator"), Localizer.getInstance().getMessage("lblCloseGame"), Localizer.getInstance().getMessage("lblClose"), Localizer.getInstance().getMessage("lblCancel"))) {
+            IGameController controller = spectator;
+            spectator = null; //ensure we don't prompt again, including when calling nextGameDecision below
+            if (!isGamePaused())
+                controller.selectButtonOk(); //pause
+            controller.nextGameDecision(NextGameDecision.QUIT);
         }
+        return false; //let logic above handle closing current screen
     }
 
     private boolean forceEndGameForRemainingAIs() {
-        final GameView gameView = getGameView();
-        if (gameView == null) {
-            return false;
-        }
-
         boolean hasRemainingAi = false;
         for (PlayerView player : gameView.getPlayers()) {
             if (!player.getHasLost() && player.isAI()) {

--- a/forge-gui/src/main/java/forge/localinstance/properties/ForgeNetPreferences.java
+++ b/forge-gui/src/main/java/forge/localinstance/properties/ForgeNetPreferences.java
@@ -43,8 +43,6 @@ public class ForgeNetPreferences extends PreferencesStore<ForgeNetPreferences.FN
         public String getDefault() {
             return strDefaultVal;
         }
-
-
     }
 
     /** Instantiates a ForgePreferences object. */

--- a/forge-gui/src/main/java/forge/player/HumanCostDecision.java
+++ b/forge-gui/src/main/java/forge/player/HumanCostDecision.java
@@ -869,7 +869,7 @@ public class HumanCostDecision extends CostDecisionMakerBase {
 
         if (cost.payCostFromSource()) {
             // UnlessCost so player might not want to pay (Fabricate)
-            if (ability.hasParam("UnlessCost") && !confirmAction(cost, Localizer.getInstance().getMessage("lblPutNTypeCounterOnTarget", c, cost.getCounter().getName(), ability.getHostCard().getDisplayName()))) {
+            if (isEffect() && ability.hasParam("UnlessCost") && !confirmAction(cost, Localizer.getInstance().getMessage("lblPutNTypeCounterOnTarget", c, cost.getCounter().getName(), ability.getHostCard().getDisplayName()))) {
                 return null;
             }
             return PaymentDecision.card(source);


### PR DESCRIPTION
Two improvements to the mobile chat experience.

## Match Chat tab unread indicator

<img width="75%" alt="Screenshot 2026-05-02 103010" src="https://github.com/user-attachments/assets/9cbc0232-a0d8-45bf-a7f8-c3962b1b67c3" />

- Red badge with unread count appears on the Chat tab while the dropdown is closed
- Brief red flash on each new message draws the eye even before you read the badge
- Includes system messages (disconnects, version mismatches, etc.) so the user doesn't miss server notices
- Both clear when the user opens the Chat tab

## Chat bubble styling

<img width="50%" alt="Screenshot 2026-05-02 103037" src="https://github.com/user-attachments/assets/b1f22057-1e16-456e-b03b-fdcd49e9a33c" />

- Sender is now identified on every bubble
- Message text on top, smaller meta line ("Sender · HH:MM:SS") below
- Server messages now render in a blue bubble with white text and identify "Server" as the sender, instead of looking identical to the host's own chat

Mobile-only — desktop chat is unchanged.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)