### PR TITLE
Restore Android record deserialization fallback in TrackableSerializer

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/net/TrackableSerializer.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/TrackableSerializer.java
@@ -226,6 +226,23 @@ public final class TrackableSerializer {
             enableResolveObject(true);
         }
 
+        // Android desugars records to classes with computed serialVersionUID; the JVM keeps records at 0L.
+        // Fall through to the local descriptor when UIDs mismatch.
+        @Override
+        protected ObjectStreamClass readClassDescriptor() throws IOException, ClassNotFoundException {
+            ObjectStreamClass streamDesc = super.readClassDescriptor();
+            try {
+                Class<?> localClass = Class.forName(streamDesc.getName());
+                ObjectStreamClass localDesc = ObjectStreamClass.lookup(localClass);
+                if (localDesc != null && streamDesc.getSerialVersionUID() != localDesc.getSerialVersionUID()) {
+                    return localDesc;
+                }
+            } catch (ClassNotFoundException ignored) {
+                // Class not found locally — fall through to stream descriptor.
+            }
+            return streamDesc;
+        }
+
         @Override
         protected Object resolveObject(Object obj) {
             return resolve(obj, tracker);


### PR DESCRIPTION
Fixes #10590

Restores the `readClassDescriptor()` fallback that #10304 added for Android's record-vs-JVM serialVersionUID mismatch. The fallback was accidentally dropped when #10343 replaced `GameEventProxy` with `TrackableSerializer` — `resolveObject` got carried over, the descriptor override did not.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)