### PR TITLE
Better auto-sell

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/util/RewardActor.java
+++ b/forge-gui-mobile/src/forge/adventure/util/RewardActor.java
@@ -44,6 +44,7 @@ import forge.assets.ImageCache;
 import forge.card.CardImageRenderer;
 import forge.card.CardRenderer;
 import forge.card.CardSplitType;
+import forge.deck.DeckFormat;
 import forge.deck.DeckSection;
 import forge.game.card.CardView;
 import forge.gui.GuiBase;
@@ -1000,10 +1001,17 @@ public class RewardActor extends Actor implements Disposable, ImageFetcher.Callb
             if (autoSell != null && !autoSell.isVisible() && flipProcess == 1) {
                 autoSell.setVisible(true);
 
-                if (AdventurePlayer.current().isCommanderMode()) {
-                    PaperCard pc = reward.getCard();
-                    if (pc != null) {
+                PaperCard pc = reward.getCard();
+                if (pc != null &&
+                    !pc.getRules().getType().isBasic() &&
+                    !DeckFormat.canHaveAnyNumberOf(pc)
+                ) {
+                    if (AdventurePlayer.current().isCommanderMode()) {
                         setAutoSell(inCollectionLike(pc));
+                    } else {
+                        int ownedCount = AdventurePlayer.current().getCollectionCards(true).count(pc);
+                        
+                        setAutoSell(ownedCount >= 4);
                     }
                 }
             }

--- a/forge-gui-mobile/src/forge/adventure/util/RewardActor.java
+++ b/forge-gui-mobile/src/forge/adventure/util/RewardActor.java
@@ -1001,13 +1001,9 @@ public class RewardActor extends Actor implements Disposable, ImageFetcher.Callb
             if (autoSell != null && !autoSell.isVisible() && flipProcess == 1) {
                 autoSell.setVisible(true);
 
-                
-
                 PaperCard pc = reward.getCard();
 
-                if (pc != null &&
-                    !pc.getRules().getType().isBasic()
-                ) {
+                if (pc != null) {
                     DeckFormat deckFormat = AdventurePlayer.current().isCommanderMode() 
                         ? DeckFormat.Commander
                         : DeckFormat.Adventure;

--- a/forge-gui-mobile/src/forge/adventure/util/RewardActor.java
+++ b/forge-gui-mobile/src/forge/adventure/util/RewardActor.java
@@ -1001,17 +1001,24 @@ public class RewardActor extends Actor implements Disposable, ImageFetcher.Callb
             if (autoSell != null && !autoSell.isVisible() && flipProcess == 1) {
                 autoSell.setVisible(true);
 
+                
+
                 PaperCard pc = reward.getCard();
+
                 if (pc != null &&
-                    !pc.getRules().getType().isBasic() &&
-                    !DeckFormat.canHaveAnyNumberOf(pc)
+                    !pc.getRules().getType().isBasic()
                 ) {
+                    DeckFormat deckFormat = AdventurePlayer.current().isCommanderMode() 
+                        ? DeckFormat.Commander
+                        : DeckFormat.Adventure;
+                    int maxCopies = deckFormat.getMaxCardCopies(pc);
+
                     if (AdventurePlayer.current().isCommanderMode()) {
-                        setAutoSell(inCollectionLike(pc));
+                        setAutoSell(maxCopies == 1 && inCollectionLike(pc));
                     } else {
                         int ownedCount = AdventurePlayer.current().getCollectionCards(true).count(pc);
-                        
-                        setAutoSell(ownedCount >= 4);
+
+                        setAutoSell(ownedCount >= maxCopies);
                     }
                 }
             }


### PR DESCRIPTION
* No longer checks auto-sell for basic lands and cards that can have multiple copies of in a deck.
* (Non-commander) Checks auto-sell for cards you have four or more copies of.