### PR TITLE
Make game ending idempotent

### DIFF
--- a/forge-game/src/main/java/forge/game/Game.java
+++ b/forge-game/src/main/java/forge/game/Game.java
@@ -555,6 +555,11 @@ public class Game {
     }
 
     public synchronized void setGameOver(GameEndReason reason) {
+        // early exit in case many events causing a game over have fired
+        if (age == GameStage.GameOver) {
+            return;
+        }
+
         for (Player p : allPlayers) {
             p.clearController();
         }


### PR DESCRIPTION
Game ending wasn't idempotent so something causing a lot of game end events would end it multiple times  (e.g. over 1000 triggers being put on the stack ends the game in a draw once for each trigger over 1000 put on the stack)  and break the UI. With this fix, we exit early if the game is already over.