### PR TITLE
Fix life swap with no life change and side effects

### DIFF
--- a/forge-game/src/main/java/forge/game/Game.java
+++ b/forge-game/src/main/java/forge/game/Game.java
@@ -555,6 +555,11 @@ public class Game {
     }
 
     public synchronized void setGameOver(GameEndReason reason) {
+        // early exit in case many events causing a game over have fired
+        if (age == GameStage.GameOver) {
+            return;
+        }
+
         for (Player p : allPlayers) {
             p.clearController();
         }

--- a/forge-game/src/main/java/forge/game/Game.java
+++ b/forge-game/src/main/java/forge/game/Game.java
@@ -555,11 +555,6 @@ public class Game {
     }
 
     public synchronized void setGameOver(GameEndReason reason) {
-        // early exit in case many events causing a game over have fired
-        if (age == GameStage.GameOver) {
-            return;
-        }
-
         for (Player p : allPlayers) {
             p.clearController();
         }

--- a/forge-game/src/main/java/forge/game/ability/effects/LifeExchangeVariantEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/LifeExchangeVariantEffect.java
@@ -70,10 +70,12 @@ public class LifeExchangeVariantEffect extends SpellAbilityEffect {
             return;
         }
 
-
-        if (pLife > num && p.canLoseLife()) {
+        // Likewise, we still need to do this even if the life total doesn't change
+        if (pLife >= num && p.canLoseLife()) {
             final int diff = pLife - num;
             final int lost = p.loseLife(diff, false, false);
+            source.addNewPT(power, toughness, timestamp, 0);
+            game.fireEvent(new GameEventCardStatsChanged(source));
 
             if (lost > 0) { // Run triggers if player actually lost life
                 final Map<Player, Integer> lossMap = Maps.newHashMap();
@@ -84,13 +86,11 @@ public class LifeExchangeVariantEffect extends SpellAbilityEffect {
         } else if (num > pLife && p.canGainLife()) {
             final int diff = num - pLife;
             p.gainLife(diff, source, sa);
+            source.addNewPT(power, toughness, timestamp, 0);
+            game.fireEvent(new GameEventCardStatsChanged(source));
         } else {
             // do nothing if they cannot lose/gain this amount of life
         }
-
-        // 701.12g: We need to do this regardless of whether the life total actually changed
-        source.addNewPT(power, toughness, timestamp, 0);
-        game.fireEvent(new GameEventCardStatsChanged(source));
     }
 
 }

--- a/forge-game/src/main/java/forge/game/ability/effects/LifeExchangeVariantEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/LifeExchangeVariantEffect.java
@@ -70,8 +70,7 @@ public class LifeExchangeVariantEffect extends SpellAbilityEffect {
             return;
         }
 
-        // Likewise, we still need to do this even if the life total doesn't change
-        if (pLife >= num && p.canLoseLife()) {
+        if (pLife > num && p.canLoseLife()) {
             final int diff = pLife - num;
             final int lost = p.loseLife(diff, false, false);
             source.addNewPT(power, toughness, timestamp, 0);
@@ -88,7 +87,13 @@ public class LifeExchangeVariantEffect extends SpellAbilityEffect {
             p.gainLife(diff, source, sa);
             source.addNewPT(power, toughness, timestamp, 0);
             game.fireEvent(new GameEventCardStatsChanged(source));
-        } else {
+        }
+        // We still need to do this if the life total doesn't change because the creature's base power/toughness might
+        else if(pLife == num){
+            source.addNewPT(power, toughness, timestamp, 0);
+            game.fireEvent(new GameEventCardStatsChanged(source));
+        }
+        else {
             // do nothing if they cannot lose/gain this amount of life
         }
     }

--- a/forge-game/src/main/java/forge/game/ability/effects/LifeExchangeVariantEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/LifeExchangeVariantEffect.java
@@ -62,9 +62,9 @@ public class LifeExchangeVariantEffect extends SpellAbilityEffect {
         } else if ("Toughness".equals(mode)) {
             num = source.getNetToughness();
             toughness = pLife;
+        } else {
+            return;
         }
-        // We cannot safely return early here as no net change in life total might
-        // not mean no net change in power or toughness if they are modified.
 
         if (!source.isInPlay()) {
             return;

--- a/forge-game/src/main/java/forge/game/ability/effects/LifeExchangeVariantEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/LifeExchangeVariantEffect.java
@@ -70,12 +70,10 @@ public class LifeExchangeVariantEffect extends SpellAbilityEffect {
             return;
         }
 
-        // Likewise, we still need to do this even if the life total doesn't change
-        if (pLife >= num && p.canLoseLife()) {
+
+        if (pLife > num && p.canLoseLife()) {
             final int diff = pLife - num;
             final int lost = p.loseLife(diff, false, false);
-            source.addNewPT(power, toughness, timestamp, 0);
-            game.fireEvent(new GameEventCardStatsChanged(source));
 
             if (lost > 0) { // Run triggers if player actually lost life
                 final Map<Player, Integer> lossMap = Maps.newHashMap();
@@ -86,11 +84,13 @@ public class LifeExchangeVariantEffect extends SpellAbilityEffect {
         } else if (num > pLife && p.canGainLife()) {
             final int diff = num - pLife;
             p.gainLife(diff, source, sa);
-            source.addNewPT(power, toughness, timestamp, 0);
-            game.fireEvent(new GameEventCardStatsChanged(source));
         } else {
             // do nothing if they cannot lose/gain this amount of life
         }
+
+        // 701.12g: We need to do this regardless of whether the life total actually changed
+        source.addNewPT(power, toughness, timestamp, 0);
+        game.fireEvent(new GameEventCardStatsChanged(source));
     }
 
 }

--- a/forge-game/src/main/java/forge/game/ability/effects/LifeExchangeVariantEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/LifeExchangeVariantEffect.java
@@ -71,7 +71,7 @@ public class LifeExchangeVariantEffect extends SpellAbilityEffect {
         }
 
         // Likewise, we still need to do this even if the life total doesn't change
-        if (p.canLoseLife()) {
+        if (pLife >= num && p.canLoseLife()) {
             final int diff = pLife - num;
             final int lost = p.loseLife(diff, false, false);
             source.addNewPT(power, toughness, timestamp, 0);
@@ -83,13 +83,13 @@ public class LifeExchangeVariantEffect extends SpellAbilityEffect {
                 final Map<AbilityKey, Object> runParams = AbilityKey.mapFromPIMap(lossMap);
                 source.getGame().getTriggerHandler().runTrigger(TriggerType.LifeLostAll, runParams, false);
             }
-        } else if (p.canGainLife()) {
+        } else if (num > pLife && p.canGainLife()) {
             final int diff = num - pLife;
             p.gainLife(diff, source, sa);
             source.addNewPT(power, toughness, timestamp, 0);
             game.fireEvent(new GameEventCardStatsChanged(source));
         } else {
-            // do nothing if they are equal
+            // do nothing if they cannot lose/gain this amount of life
         }
     }
 

--- a/forge-game/src/main/java/forge/game/ability/effects/LifeExchangeVariantEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/LifeExchangeVariantEffect.java
@@ -89,7 +89,7 @@ public class LifeExchangeVariantEffect extends SpellAbilityEffect {
             game.fireEvent(new GameEventCardStatsChanged(source));
         }
         // We still need to do this if the life total doesn't change because the creature's base power/toughness might
-        else if(pLife == num){
+        else if (pLife == num){
             source.addNewPT(power, toughness, timestamp, 0);
             game.fireEvent(new GameEventCardStatsChanged(source));
         }

--- a/forge-game/src/main/java/forge/game/ability/effects/LifeExchangeVariantEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/LifeExchangeVariantEffect.java
@@ -62,15 +62,16 @@ public class LifeExchangeVariantEffect extends SpellAbilityEffect {
         } else if ("Toughness".equals(mode)) {
             num = source.getNetToughness();
             toughness = pLife;
-        } else {
-            return;
         }
+        // We cannot safely return early here as no net change in life total might
+        // not mean no net change in power or toughness if they are modified.
 
         if (!source.isInPlay()) {
             return;
         }
 
-        if (pLife > num && p.canLoseLife()) {
+        // Likewise, we still need to do this even if the life total doesn't change
+        if (p.canLoseLife()) {
             final int diff = pLife - num;
             final int lost = p.loseLife(diff, false, false);
             source.addNewPT(power, toughness, timestamp, 0);
@@ -82,7 +83,7 @@ public class LifeExchangeVariantEffect extends SpellAbilityEffect {
                 final Map<AbilityKey, Object> runParams = AbilityKey.mapFromPIMap(lossMap);
                 source.getGame().getTriggerHandler().runTrigger(TriggerType.LifeLostAll, runParams, false);
             }
-        } else if (num > pLife && p.canGainLife()) {
+        } else if (p.canGainLife()) {
             final int diff = num - pLife;
             p.gainLife(diff, source, sa);
             source.addNewPT(power, toughness, timestamp, 0);


### PR DESCRIPTION
Life swap effects didn't happen if life total didn't change, which results in the wrong game state for cards like [[tree of perdition]] swapping power/toughness with a player who had life equal to their modified toughness, but which still needed their base power/toughness to be updated.