### PR TITLE
Adventure: consult AdventureOverrides for sealed event boosters

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/data/AdventureEventData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/AdventureEventData.java
@@ -3,7 +3,6 @@ package forge.adventure.data;
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.utils.Array;
 import forge.Forge;
-import forge.StaticData;
 import forge.adventure.character.EnemySprite;
 import forge.adventure.pointofintrest.PointOfInterestChanges;
 import forge.adventure.scene.RewardScene;
@@ -333,7 +332,7 @@ public class AdventureEventData implements Serializable {
                 if (isMetaSet) {
                     booster = cardBlock.getBooster(setCode);
                 } else {
-                    SealedTemplate template = StaticData.instance().getBoosters().get(setCode);
+                    SealedTemplate template = AdventureOverrides.instance().getBoosterTemplate(setCode);
                     if (template == null) continue;
                     booster = new UnOpenedProduct(template);
                 }
@@ -371,7 +370,7 @@ public class AdventureEventData implements Serializable {
                     if (isMetaSet) {
                         booster = cardBlock.getBooster(setCode);
                     } else {
-                        SealedTemplate template = StaticData.instance().getBoosters().get(setCode);
+                        SealedTemplate template = AdventureOverrides.instance().getBoosterTemplate(setCode);
                         if (template == null) continue;
                         booster = new UnOpenedProduct(template);
                     }

--- a/forge-gui-mobile/src/forge/adventure/util/AdventureEventController.java
+++ b/forge-gui-mobile/src/forge/adventure/util/AdventureEventController.java
@@ -161,9 +161,6 @@ public class AdventureEventController implements Serializable {
 
     public Deck generateBooster(String setCode) {
         SealedTemplate template = AdventureOverrides.instance().getBoosterTemplate(setCode);
-        if (template == null) {
-            template = StaticData.instance().getBoosters().get(setCode);
-        }
         List<PaperCard> cards = BoosterGenerator.getBoosterPack(template);
         Deck output = new Deck();
         output.getMain().add(cards);

--- a/forge-gui-mobile/src/forge/adventure/util/AdventureOverrides.java
+++ b/forge-gui-mobile/src/forge/adventure/util/AdventureOverrides.java
@@ -17,6 +17,7 @@
  */
 package forge.adventure.util;
 
+import forge.StaticData;
 import forge.adventure.data.ConfigData;
 import forge.card.CardEdition;
 import forge.item.SealedTemplate;
@@ -137,8 +138,13 @@ public final class AdventureOverrides {
         return Collections.unmodifiableList(merged);
     }
 
-    /** @return the overlay booster template for the given set code, or {@code null} if none. */
+    /**
+     * @return the overlay booster template for the given set code, or the
+     * upstream template if no overlay exists, or {@code null} if neither has one.
+     */
     public SealedTemplate getBoosterTemplate(String setCode) {
-        return boosters.get(setCode);
+        SealedTemplate overlay = boosters.get(setCode);
+        if (overlay != null) return overlay;
+        return StaticData.instance().getBoosters().get(setCode);
     }
 }


### PR DESCRIPTION
- `AdventureEventData.generateSealedPool` fetched booster templates directly from `StaticData.instance().getBoosters().get(setCode)`, bypassing the `AdventureOverrides` registry.
- Drafts and reward packs already use the override-first lookup via `AdventureEventController.generateBooster`. Sealed events did not, so plane-scoped overlays (e.g. Old Border Shandalar's 14+1 Ice Age booster) were silently ignored in sealed pools.
- Mirror the same override-first lookup pattern in both the human and AI pool branches of `generateSealedPool`.
- Verified locally that the override booster template for ICE produces 15-card packs with one snow-covered basic land per pack across 200 sample packs, drawing all five colors.