### PR TITLE
Drop redundant global search in Game.findByView else branch

### DIFF
--- a/forge-game/src/main/java/forge/game/Game.java
+++ b/forge-game/src/main/java/forge/game/Game.java
@@ -702,8 +702,6 @@ public class Game {
             if (p != null) {
                 visit.visitAll(p.getZone(view.getZone()));
             }
-        } else {
-            forEachCardInGame(visit);
         }
         // Zone-specific search may miss if the view has stale zone info
         // (e.g. IdRef resolved from a tracker that wasn't updated after a


### PR DESCRIPTION
Requested by Hanmac in https://github.com/Card-Forge/forge/pull/10343#discussion_r3181902061.

When a `CardView` has no controller or zone, the else branch in `Game.findByView` invokes `forEachCardInGame`, and the existing stale-zone-info fallback then invokes it again on the same visitor. Removing the else branch lets the fallback handle that case in a single global walk. Behaviour is otherwise identical — `CardIdVisitor.getFound()` is idempotent, so the stack and controller+zone paths reach the same result.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)