### PR TITLE
Selective Obliteration: AI chooses the most prominent color

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
@@ -1116,9 +1116,8 @@ public class ComputerUtilCard {
         return true;
     };
 
-    public static List<String> chooseColor(SpellAbility sa, int min, int max, List<String> colorChoices) {
+    public static List<String> chooseColor(Player ai, SpellAbility sa, int min, int max, List<String> colorChoices) {
         List<String> chosen = new ArrayList<>();
-        Player ai = sa.getActivatingPlayer();
         final Game game = ai.getGame();
         Player opp = ai.getStrongestOpponent();
         if (sa.hasParam("AILogic")) {
@@ -1145,9 +1144,6 @@ public class ComputerUtilCard {
                 chosen.add(getMostProminentColor(ai.getCardsIn(ZoneType.Battlefield), colorChoices));
             } else if (logic.equals("MostProminentHumanControls")) {
                 chosen.add(getMostProminentColor(opp.getCardsIn(ZoneType.Battlefield), colorChoices));
-            } else if (logic.equals("MostProminentRememberedControls") && rememberedPlayers.hasNext()) {
-                Player rememberedPlayer = rememberedPlayers.next();
-                chosen.add(getMostProminentColor(rememberedPlayer.getCardsIn(ZoneType.Battlefield), colorChoices));
             } else if (logic.equals("MostProminentPermanent")) {
                 chosen.add(getMostProminentColor(game.getCardsIn(ZoneType.Battlefield), colorChoices));
             } else if (logic.equals("MostProminentAttackers") && game.getPhaseHandler().inCombat()) {

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.IdentityHashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -1122,6 +1123,7 @@ public class ComputerUtilCard {
         Player opp = ai.getStrongestOpponent();
         if (sa.hasParam("AILogic")) {
             final String logic = sa.getParam("AILogic");
+            Iterator<Player> rememberedPlayers = IterableUtil.filter(sa.getHostCard().getRemembered(), Player.class).iterator();
 
             if (logic.equals("MostProminentInHumanDeck")) {
                 chosen.add(getMostProminentColor(CardLists.filterControlledBy(game.getCardsInGame(), opp), colorChoices));
@@ -1143,6 +1145,9 @@ public class ComputerUtilCard {
                 chosen.add(getMostProminentColor(ai.getCardsIn(ZoneType.Battlefield), colorChoices));
             } else if (logic.equals("MostProminentHumanControls")) {
                 chosen.add(getMostProminentColor(opp.getCardsIn(ZoneType.Battlefield), colorChoices));
+            } else if (logic.equals("MostProminentRememberedControls") && rememberedPlayers.hasNext()) {
+                Player rememberedPlayer = rememberedPlayers.next();
+                chosen.add(getMostProminentColor(rememberedPlayer.getCardsIn(ZoneType.Battlefield), colorChoices));
             } else if (logic.equals("MostProminentPermanent")) {
                 chosen.add(getMostProminentColor(game.getCardsIn(ZoneType.Battlefield), colorChoices));
             } else if (logic.equals("MostProminentAttackers") && game.getPhaseHandler().inCombat()) {

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
@@ -1115,7 +1115,7 @@ public class ComputerUtilCard {
         return true;
     };
 
-    public static List<String> chooseColor(Player ai, SpellAbility sa, int min, int max, List<String> colorChoices) {
+    public static List<String> chooseColor(Player ai, SpellAbility sa, List<String> colorChoices) {
         List<String> chosen = new ArrayList<>();
         final Game game = ai.getGame();
         Player opp = ai.getStrongestOpponent();

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCard.java
@@ -5,7 +5,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.IdentityHashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -1122,7 +1121,6 @@ public class ComputerUtilCard {
         Player opp = ai.getStrongestOpponent();
         if (sa.hasParam("AILogic")) {
             final String logic = sa.getParam("AILogic");
-            Iterator<Player> rememberedPlayers = IterableUtil.filter(sa.getHostCard().getRemembered(), Player.class).iterator();
 
             if (logic.equals("MostProminentInHumanDeck")) {
                 chosen.add(getMostProminentColor(CardLists.filterControlledBy(game.getCardsInGame(), opp), colorChoices));

--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -1065,7 +1065,7 @@ public class PlayerControllerAi extends PlayerController {
 
     @Override
     public ColorSet chooseColors(String message, SpellAbility sa, int min, int max, ColorSet options) {
-        return ColorSet.fromNames(ComputerUtilCard.chooseColor(player, sa, min, max, options.stream().map(MagicColor.Color::getName).collect(Collectors.toList())));
+        return ColorSet.fromNames(ComputerUtilCard.chooseColor(player, sa, options.stream().map(MagicColor.Color::getName).collect(Collectors.toList())));
     }
 
     /*

--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -1065,7 +1065,7 @@ public class PlayerControllerAi extends PlayerController {
 
     @Override
     public ColorSet chooseColors(String message, SpellAbility sa, int min, int max, ColorSet options) {
-        return ColorSet.fromNames(ComputerUtilCard.chooseColor(sa, min, max, options.stream().map(MagicColor.Color::getName).collect(Collectors.toList())));
+        return ColorSet.fromNames(ComputerUtilCard.chooseColor(player, sa, min, max, options.stream().map(MagicColor.Color::getName).collect(Collectors.toList())));
     }
 
     /*

--- a/forge-gui/res/cardsfolder/s/selective_obliteration.txt
+++ b/forge-gui/res/cardsfolder/s/selective_obliteration.txt
@@ -2,7 +2,7 @@ Name:Selective Obliteration
 ManaCost:3 C C
 Types:Sorcery
 A:SP$ RepeatEach | RepeatPlayers$ Player | RepeatSubAbility$ DBChooseColor | SubAbility$ ExileAll | SpellDescription$ Each player chooses a color.
-SVar:DBChooseColor:DB$ ChooseColor | Defined$ Remembered | AILogic$ MostProminentComputerControls | SubAbility$ FilterForExile
+SVar:DBChooseColor:DB$ ChooseColor | Defined$ Remembered | AILogic$ MostProminentRememberedControls | SubAbility$ FilterForExile
 SVar:FilterForExile:DB$ Pump | RememberObjects$ Valid Permanent.RememberedPlayerCtrl+MonoColor+ChosenColor
 SVar:ExileAll:DB$ ChangeZoneAll | Origin$ Battlefield | Destination$ Exile | ChangeType$ Card.nonColorless+!IsRemembered | SubAbility$ DBCleanup | SpellDescription$ Then exile each permanent unless it's colorless or it's only the color its controller chose.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True

--- a/forge-gui/res/cardsfolder/s/selective_obliteration.txt
+++ b/forge-gui/res/cardsfolder/s/selective_obliteration.txt
@@ -2,7 +2,7 @@ Name:Selective Obliteration
 ManaCost:3 C C
 Types:Sorcery
 A:SP$ RepeatEach | RepeatPlayers$ Player | RepeatSubAbility$ DBChooseColor | SubAbility$ ExileAll | SpellDescription$ Each player chooses a color.
-SVar:DBChooseColor:DB$ ChooseColor | Defined$ Remembered | AILogic$ MostProminentRememberedControls | SubAbility$ FilterForExile
+SVar:DBChooseColor:DB$ ChooseColor | Defined$ Remembered | AILogic$ MostProminentComputerControls | SubAbility$ FilterForExile
 SVar:FilterForExile:DB$ Pump | RememberObjects$ Valid Permanent.RememberedPlayerCtrl+MonoColor+ChosenColor
 SVar:ExileAll:DB$ ChangeZoneAll | Origin$ Battlefield | Destination$ Exile | ChangeType$ Card.nonColorless+!IsRemembered | SubAbility$ DBCleanup | SpellDescription$ Then exile each permanent unless it's colorless or it's only the color its controller chose.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True


### PR DESCRIPTION
Possible fix for #10552 

### problem

`Selective Obliteration` is a `RepeatEach` ability choosing a color with 

```
AILogic$ MostProminentInComputerDeck
```

The `ComputerUtilCard#chooseColor()` as-is incorrectly assumes, that the activatingPlayer is always AI (computer), so it searches the wrong player's permanents, finds nothing prominent and fallbacks to white. 

### fix

There is `Harsh Mercy` - similar card choosing creature type with `MostProminentInComputerDeck`. This one works, because `ComputerUtil#chooseSomeType` has the selecting player as its first parameter. 

### test

<img width="1240" height="587" alt="image" src="https://github.com/user-attachments/assets/0c988391-d616-46f7-9a39-a234b73b65e0" />
