### PR TITLE
Remember repeated simultaneous ability ordering decisions

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/gui/DualListBox.java
+++ b/forge-gui-desktop/src/main/java/forge/gui/DualListBox.java
@@ -28,6 +28,7 @@ import forge.item.IPaperCard;
 import forge.item.PaperCard;
 import forge.screens.match.CMatchUI;
 import forge.toolbox.FButton;
+import forge.toolbox.FCheckBox;
 import forge.toolbox.FLabel;
 import forge.toolbox.FList;
 import forge.toolbox.FPanel;
@@ -59,6 +60,7 @@ public class DualListBox<T> extends FDialog {
     private final FButton removeAllButton;
     private final FButton okButton;
     private final FButton autoButton;
+    private final FCheckBox rememberDecisionCheckBox;
 
     private final FLabel orderedLabel;
     private final FLabel selectOrder;
@@ -151,6 +153,8 @@ public class DualListBox<T> extends FDialog {
         okButton.addActionListener(e -> _finish());
         autoButton = new FButton(Localizer.getInstance().getMessage("lblAuto"));
         autoButton.addActionListener(e -> { _addAll(); _finish(); });
+        rememberDecisionCheckBox = new FCheckBox(Localizer.getInstance().getMessage("lblRememberThisDecision"));
+        rememberDecisionCheckBox.setVisible(false);
 
         final FPanel leftPanel = new FPanel(new BorderLayout());
         selectOrder = new FLabel.Builder().text(Localizer.getInstance().getMessage("lblSelectOrder") + ":").build();
@@ -195,6 +199,7 @@ public class DualListBox<T> extends FDialog {
         add(leftPanel, listConstraints);
         add(centerPanel, "w 100, h 300");
         add(rightPanel, listConstraints);
+        add(rememberDecisionCheckBox, "newline, span 3, growx, gaptop 5");
 
         _setButtonState();
 
@@ -250,6 +255,14 @@ public class DualListBox<T> extends FDialog {
             selectOrder.setText(Localizer.getInstance().getMessage("lblSideboard") + String.format(" (%d):", sourceListModel.getSize()));
             orderedLabel.setText(Localizer.getInstance().getMessage("ttMain") + String.format(" (%d):", destListModel.getSize()));
         }
+    }
+
+    public void setRememberDecisionVisible(final boolean visible) {
+        rememberDecisionCheckBox.setVisible(visible);
+    }
+
+    public boolean isRememberDecisionSelected() {
+        return rememberDecisionCheckBox.isSelected();
     }
 
     private void _handleListKey(KeyEvent e, Runnable onSpace, FList<T> arrowFocusTarget) {

--- a/forge-gui-desktop/src/main/java/forge/gui/GuiChoose.java
+++ b/forge-gui-desktop/src/main/java/forge/gui/GuiChoose.java
@@ -22,6 +22,7 @@ import forge.game.card.CardView.CardStateView;
 import forge.item.InventoryItem;
 import forge.item.PaperCard;
 import forge.model.FModel;
+import forge.gui.interfaces.IGuiGame;
 import forge.screens.match.CMatchUI;
 import forge.toolbox.FOptionPane;
 import forge.util.FSerializableFunction;
@@ -232,11 +233,17 @@ public class GuiChoose {
     }
     public static <T> List<T> order(final String title, final String top, final int remainingObjectsMin, final int remainingObjectsMax,
             final List<T> sourceChoices, final List<T> destChoices, final CardView referenceCard, final boolean sideboardingMode, final CMatchUI matchUI) {
+        return orderWithRememberDecision(title, top, remainingObjectsMin, remainingObjectsMax, sourceChoices, destChoices, referenceCard, sideboardingMode, matchUI, false).ordered();
+    }
+
+    public static <T> IGuiGame.OrderResult<T> orderWithRememberDecision(final String title, final String top, final int remainingObjectsMin, final int remainingObjectsMax,
+            final List<T> sourceChoices, final List<T> destChoices, final CardView referenceCard, final boolean sideboardingMode, final CMatchUI matchUI, final boolean showRememberDecision) {
         // An input box for handling the order of choices.
 
-        final Callable<List<T>> callable = () -> {
+        final Callable<IGuiGame.OrderResult<T>> callable = () -> {
             final DualListBox<T> dual = new DualListBox<>(remainingObjectsMin, remainingObjectsMax, sourceChoices, destChoices, matchUI);
             dual.setSecondColumnLabelText(top);
+            dual.setRememberDecisionVisible(showRememberDecision);
 
             dual.setSideboardMode(sideboardingMode);
 
@@ -250,22 +257,23 @@ public class GuiChoose {
             dual.setVisible(true);
 
             final List<T> objects = dual.getOrderedList();
+            final boolean rememberDecision = dual.isRememberDecisionSelected();
 
             dual.dispose();
             if (matchUI != null) {
                 matchUI.clearPanelSelections();
             }
-            return objects;
+            return new IGuiGame.OrderResult<>(objects, rememberDecision);
         };
 
-        final FutureTask<List<T>> ft = new FutureTask<>(callable);
+        final FutureTask<IGuiGame.OrderResult<T>> ft = new FutureTask<>(callable);
         FThreads.invokeInEdtAndWait(ft);
         try {
             return ft.get();
         } catch (final Exception e) { // we have waited enough
             e.printStackTrace();
         }
-        return null;
+        return new IGuiGame.OrderResult<>(null, false);
     }
 
     public static List<CardView> manipulateCardList(final CMatchUI gui, final String title, final Iterable<CardView> cards, final Iterable<CardView> manipulable, 
@@ -295,4 +303,3 @@ public class GuiChoose {
     }
 
 }
-

--- a/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
@@ -65,6 +65,7 @@ import forge.game.player.PlayerView;
 import forge.game.spellability.SpellAbilityView;
 import forge.game.spellability.StackItemView;
 import forge.game.zone.ZoneType;
+import forge.gui.interfaces.IGuiGame;
 import forge.util.IHasForgeLog;
 import forge.gamemodes.match.YieldController;
 import forge.gamemodes.match.YieldMarker;
@@ -1237,6 +1238,12 @@ public final class CMatchUI
             Thread.dumpStack();
         }*/
         return GuiChoose.order(title, top, remainingObjectsMin, remainingObjectsMax, sourceChoices, destChoices, referenceCard, sideboardingMode, this);
+    }
+
+    @Override
+    public <T> IGuiGame.OrderResult<T> orderWithRememberDecision(final String title, final String top, final int remainingObjectsMin, final int remainingObjectsMax,
+            final List<T> sourceChoices, final List<T> destChoices, final CardView referenceCard, final boolean sideboardingMode) {
+        return GuiChoose.orderWithRememberDecision(title, top, remainingObjectsMin, remainingObjectsMax, sourceChoices, destChoices, referenceCard, sideboardingMode, this, true);
     }
 
     @Override

--- a/forge-gui/res/languages/de-DE.properties
+++ b/forge-gui/res/languages/de-DE.properties
@@ -1355,6 +1355,7 @@ lblChooseCardstoSpliceonto=Wähle Karte, an welche gekoppelt werden soll
 lblDoNextActioninSequence=Nächste Aktion ausführen
 lblPleaseDefineanActionSequenceFirst=Bitte lege erst die Aktionsreihenfolge fest.
 lblRememberActionSequence=Merke Aktionsreihenfolge
+lblRememberThisDecision=Diese Entscheidung merken
 lblYouMustHavePrioritytoUseThisFeature=Um diese Funktion zu nutzen brauchst du die Priorität.
 lblNameTheCard=Nenne die Karte
 lblWhichPlayerShouldRoll=Welcher Spieler soll würfeln?

--- a/forge-gui/res/languages/en-US.properties
+++ b/forge-gui/res/languages/en-US.properties
@@ -1497,6 +1497,7 @@ lblChooseaPile=Choose a pile
 lblSelectOrderForSimultaneousAbilities=Select order for simultaneous abilities
 lblReorderSimultaneousAbilities=Reorder simultaneous abilities
 lblResolveFirst=Resolve first
+lblRememberThisDecision=Remember this decision
 lblMoveCardstoToporBbottomofLibrary=Move cards to top or bottom of library
 lblSelectCardsToBeOutOnTheBottomOfYourLibrary=Select cards to be put on the bottom of your library
 lblCardsToPutOnTheBottom=Cards to put on the bottom
@@ -3458,4 +3459,3 @@ lblRemoveUnsupportedCard=Remove unsupported card
 lblRemoveAllUnsupportedCards=Unsupported cards have been removed from your inventory.
 lbldisableCrackedItems=Disable the possibility of your items breaking after losing a boss fight.
 lblusepricelist=Use the (currently experimental) price generation based on a set cardlist.
-

--- a/forge-gui/res/languages/es-ES.properties
+++ b/forge-gui/res/languages/es-ES.properties
@@ -1338,6 +1338,7 @@ lblChooseCardstoSpliceonto=Elige las cartas para unirlas
 lblDoNextActioninSequence=Realizar la siguiente acción en secuencia
 lblPleaseDefineanActionSequenceFirst=Por favor, define primero una secuencia de acción.
 lblRememberActionSequence=Recordar la Secuencia de Acción
+lblRememberThisDecision=Recordar esta decisión
 lblYouMustHavePrioritytoUseThisFeature=Debes tener prioridad para utilizar esta función.
 lblNameTheCard=Nombra la carta
 lblWhichPlayerShouldRoll=¿Qué jugador debe lanzar?

--- a/forge-gui/res/languages/fr-FR.properties
+++ b/forge-gui/res/languages/fr-FR.properties
@@ -1332,6 +1332,7 @@ lblChooseCardstoSpliceonto=Choisissez les cartes sur lesquelles coller
 lblDoNextActioninSequence=Faire l'action suivante dans l'ordre
 lblPleaseDefineanActionSequenceFirst=Veuillez d'abord définir une séquence d'action.
 lblRememberActionSequence=Mémoriser la séquence d'actions
+lblRememberThisDecision=Mémoriser cette décision
 lblYouMustHavePrioritytoUseThisFeature=Vous devez avoir la priorité pour utiliser cette fonctionnalité.
 lblNameTheCard=Nom de la carte
 lblWhichPlayerShouldRoll=Quel joueur doit lancer ?

--- a/forge-gui/res/languages/it-IT.properties
+++ b/forge-gui/res/languages/it-IT.properties
@@ -1329,6 +1329,7 @@ lblChooseCardstoSpliceonto=Scegli le carte da Unire
 lblDoNextActioninSequence=Esegui l'azione successiva in sequenza
 lblPleaseDefineanActionSequenceFirst=Definire prima una sequenza di azioni.
 lblRememberActionSequence=Ricorda la sequenza di azioni
+lblRememberThisDecision=Ricorda questa decisione
 lblYouMustHavePrioritytoUseThisFeature=Devi avere la priorità per usare questa funzione.
 lblNameTheCard=Nomina la carta
 lblWhichPlayerShouldRoll=Quale giocatore dovrebbe tirare?

--- a/forge-gui/res/languages/ja-JP.properties
+++ b/forge-gui/res/languages/ja-JP.properties
@@ -1331,6 +1331,7 @@ lblChooseCardstoSpliceonto=連繋するカードを選んでください
 lblDoNextActioninSequence=順番に次のアクションを実行
 lblPleaseDefineanActionSequenceFirst=最初にアクションシーケンスを定義してください。
 lblRememberActionSequence=アクションシーケンスを記憶
+lblRememberThisDecision=この決定を記憶
 lblYouMustHavePrioritytoUseThisFeature=この機能を使用するには優先権が必要です。
 lblNameTheCard=カード名を選ぶ
 lblWhichPlayerShouldRoll=誰がロールしますか？

--- a/forge-gui/res/languages/ko-KR.properties
+++ b/forge-gui/res/languages/ko-KR.properties
@@ -1386,6 +1386,7 @@ lblChooseCardstoSpliceonto=스플라이스할 카드를 선택
 lblDoNextActioninSequence=순서대로 다음 액션 실행
 lblPleaseDefineanActionSequenceFirst=먼저 액션 시퀀스를 정의하세요
 lblRememberActionSequence=액션 시퀀스 기억
+lblRememberThisDecision=이 결정 기억
 lblYouMustHavePrioritytoUseThisFeature=이 기능을 사용하려면 우선권이 필요합니다
 lblNameTheCard=카드명을 선택
 lblWhichPlayerShouldRoll=누가 굴릴까요

--- a/forge-gui/res/languages/pt-BR.properties
+++ b/forge-gui/res/languages/pt-BR.properties
@@ -1358,6 +1358,7 @@ lblChooseCardstoSpliceonto=Escolha as cartas para Unir com
 lblDoNextActioninSequence=Faça a Próxima Ação em Sequência
 lblPleaseDefineanActionSequenceFirst=Defina uma sequência de ações primeiro.
 lblRememberActionSequence=Lembrar Sequência de Ações
+lblRememberThisDecision=Lembrar esta decisão
 lblYouMustHavePrioritytoUseThisFeature=Você deve ter prioridade para usar este recurso.
 lblNameTheCard=Nomeie a carta
 lblWhichPlayerShouldRoll=Qual jogador deve jogar?

--- a/forge-gui/res/languages/zh-CN.properties
+++ b/forge-gui/res/languages/zh-CN.properties
@@ -1335,6 +1335,7 @@ lblChooseCardstoSpliceonto=选择要通联的牌。
 lblDoNextActioninSequence=按顺序执行下一步操作
 lblPleaseDefineanActionSequenceFirst=请先定义一个动作序列。
 lblRememberActionSequence=记住动作序列
+lblRememberThisDecision=记住此决定
 lblYouMustHavePrioritytoUseThisFeature=你必须有使用此功能的优先权。
 lblNameTheCard=选择牌名
 lblWhichPlayerShouldRoll=哪位玩家掷骰子？

--- a/forge-gui/src/main/java/forge/gui/interfaces/IGuiGame.java
+++ b/forge-gui/src/main/java/forge/gui/interfaces/IGuiGame.java
@@ -34,6 +34,8 @@ import java.util.List;
 import java.util.Map;
 
 public interface IGuiGame {
+    record OrderResult<T>(List<T> ordered, boolean rememberDecision) {}
+
     void setGameView(GameView gameView);
 
     /**
@@ -207,6 +209,11 @@ public interface IGuiGame {
 
     <T> List<T> order(String title, String top, List<T> sourceChoices, CardView c);
     <T> List<T> order(String title, String top, int remainingObjectsMin, int remainingObjectsMax, List<T> sourceChoices, List<T> destChoices, CardView referenceCard, boolean sideboardingMode);
+
+    default <T> OrderResult<T> orderWithRememberDecision(final String title, final String top, final int remainingObjectsMin, final int remainingObjectsMax,
+            final List<T> sourceChoices, final List<T> destChoices, final CardView referenceCard, final boolean sideboardingMode) {
+        return new OrderResult<>(order(title, top, remainingObjectsMin, remainingObjectsMax, sourceChoices, destChoices, referenceCard, sideboardingMode), false);
+    }
 
     /**
      * Ask the user to insert an object into a list of other objects. The

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -1946,24 +1946,53 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
         return PlaySpellAbility.payCostDuringAbilityResolve(this, player, cost, sa, null);
     }
 
-    // stores saved order for different sets of SpellAbilities
-    private final Map<String, List<Integer>> orderedSALookup = Maps.newHashMap();
+    // Stores previous ability orders for preselection or auto-apply in the current game.
+    private final Map<String, SavedAbilityOrder> orderedSALookup = Maps.newHashMap();
+
+    private record SavedAbilityOrder(List<Integer> order, boolean remember) {}
+
+    private static String getOrderLookupString(final SpellAbility sa) {
+        final String saStr = sa.toString();
+        final int idxAdditionalInfo = saStr.indexOf(" [");
+        return idxAdditionalInfo > 0 ? saStr.substring(0, idxAdditionalInfo) : saStr;
+    }
+
+    private static boolean isSavedOrderValid(final SavedAbilityOrder savedOrder, final int size) {
+        if (savedOrder == null || savedOrder.order().size() != size) {
+            return false;
+        }
+        final boolean[] seen = new boolean[size];
+        for (Integer index : savedOrder.order()) {
+            if (index == null || index < 0 || index >= size || seen[index]) {
+                return false;
+            }
+            seen[index] = true;
+        }
+        return true;
+    }
+
+    private static List<SpellAbility> applySavedOrder(final List<SpellAbility> spellAbilities, final SavedAbilityOrder savedOrder) {
+        final List<SpellAbility> orderedSAs = Lists.newArrayListWithCapacity(savedOrder.order().size());
+        for (Integer index : savedOrder.order()) {
+            orderedSAs.add(spellAbilities.get(index));
+        }
+        return orderedSAs;
+    }
 
     @Override
     public List<SpellAbility> orderSimultaneousSa(List<SpellAbility> activePlayerSAs) {
         if (activePlayerSAs.size() < 2)
             return activePlayerSAs;
-        final String firstStr = activePlayerSAs.get(0).toString();
         boolean needPrompt = !activePlayerSAs.get(0).isTrigger();
 
         // for the purpose of pre-ordering, no need for extra granularity
-        int idxAdditionalInfo = firstStr.indexOf(" [");
-        StringBuilder saLookupKey = new StringBuilder(idxAdditionalInfo > 0 ? firstStr.substring(0, idxAdditionalInfo - 1) : firstStr);
+        final String firstLookupStr = getOrderLookupString(activePlayerSAs.get(0));
+        StringBuilder saLookupKey = new StringBuilder(firstLookupStr);
 
         char delim = (char) 5;
         for (int i = 1; i < activePlayerSAs.size(); i++) {
             SpellAbility currentSa = activePlayerSAs.get(i);
-            String saStr = currentSa.toString();
+            String saStr = getOrderLookupString(currentSa);
 
             // if current SA isn't a trigger and it uses Targeting, try to show prompt
             if (currentSa.isTrigger()) {
@@ -1971,27 +2000,31 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
             } else if (currentSa.usesTargeting()) {
                 needPrompt = true;
             }
-            if (!needPrompt && !saStr.equals(firstStr)) {
+            if (!needPrompt && !saStr.equals(firstLookupStr)) {
                 // prompt by default unless all abilities are the same
                 needPrompt = true;
             }
 
             saLookupKey.append(delim).append(saStr);
-            idxAdditionalInfo = saLookupKey.indexOf(" [");
-            if (idxAdditionalInfo > 0) {
-                saLookupKey = new StringBuilder(saLookupKey.substring(0, idxAdditionalInfo - 1));
-            }
         }
         if (needPrompt) {
-            List<Integer> savedOrder = orderedSALookup.get(saLookupKey.toString());
+            final String saLookupKeyString = saLookupKey.toString();
+            SavedAbilityOrder savedOrder = orderedSALookup.get(saLookupKeyString);
+            if (!isSavedOrderValid(savedOrder, activePlayerSAs.size())) {
+                savedOrder = null;
+                orderedSALookup.remove(saLookupKeyString);
+            } else if (savedOrder.remember()) {
+                return applySavedOrder(activePlayerSAs, savedOrder);
+            }
             List<SpellAbilityView> orderedSAVs = Lists.newArrayList();
 
             // create a mapping between a spell's view and the spell itself
             Map<SpellAbilityView, SpellAbility> spellViewCache = SpellAbilityView.getMap(activePlayerSAs);
+            IGuiGame.OrderResult<SpellAbilityView> orderResult;
 
             if (savedOrder != null) {
                 orderedSAVs = Lists.newArrayList();
-                for (Integer index : savedOrder) {
+                for (Integer index : savedOrder.order()) {
                     orderedSAVs.add(activePlayerSAs.get(index).getView());
                 }
             } else {
@@ -2002,24 +2035,31 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
             if (savedOrder != null) {
                 boolean preselect = FModel.getPreferences()
                         .getPrefBoolean(FPref.UI_PRESELECT_PREVIOUS_ABILITY_ORDER);
-                orderedSAVs = getGui().order(localizer.getMessage("lblReorderSimultaneousAbilities"), localizer.getMessage("lblResolveFirst"), 0, 0,
+                orderResult = getGui().orderWithRememberDecision(localizer.getMessage("lblReorderSimultaneousAbilities"), localizer.getMessage("lblResolveFirst"), 0, 0,
                         preselect ? Lists.newArrayList() : orderedSAVs,
                         preselect ? orderedSAVs : Lists.newArrayList(), null, false);
             } else {
-                orderedSAVs = getGui().order(localizer.getMessage("lblSelectOrderForSimultaneousAbilities"), localizer.getMessage("lblResolveFirst"), orderedSAVs,
-                        null);
+                orderResult = getGui().orderWithRememberDecision(localizer.getMessage("lblSelectOrderForSimultaneousAbilities"), localizer.getMessage("lblResolveFirst"), 0, 0,
+                        orderedSAVs, null, null, false);
+            }
+            orderedSAVs = orderResult.ordered();
+            if (orderedSAVs == null) {
+                return activePlayerSAs;
             }
             List<SpellAbility> orderedSAs = Lists.newArrayList();
             for (SpellAbilityView spellAbilityView : orderedSAVs) {
                 orderedSAs.add(spellViewCache.get(spellAbilityView));
             }
-            // save order to avoid needing to prompt a second time to order
-            // the same abilities
-            savedOrder = Lists.newArrayListWithCapacity(activePlayerSAs.size());
-            for (SpellAbility sa : orderedSAs) {
-                savedOrder.add(activePlayerSAs.indexOf(sa));
+            // Save the last order so repeated prompts can start from the previous choice.
+            final Map<SpellAbility, Integer> originalIndexes = Maps.newIdentityHashMap();
+            for (int i = 0; i < activePlayerSAs.size(); i++) {
+                originalIndexes.put(activePlayerSAs.get(i), i);
             }
-            orderedSALookup.put(saLookupKey.toString(), savedOrder);
+            final List<Integer> newOrder = Lists.newArrayListWithCapacity(activePlayerSAs.size());
+            for (SpellAbility sa : orderedSAs) {
+                newOrder.add(originalIndexes.get(sa));
+            }
+            orderedSALookup.put(saLookupKeyString, new SavedAbilityOrder(newOrder, orderResult.rememberDecision()));
             return orderedSAs;
         }
         else


### PR DESCRIPTION
Adds an optional “Remember this decision” checkbox to the simultaneous ability ordering dialog. When checked, Forge stores the selected ordering for the current game and automatically reuses it when the exact same set of abilities occurs again.

Changes included:

- Adds a remembered-order result path to IGuiGame, CMatchUI, and GuiChoose.
- Adds the checkbox to DualListBox, positioned below the existing ordering controls.
- Stores remembered simultaneous ability orders in PlayerControllerHuman for the current game only.
- Keeps the existing previous-order preselection behavior for decisions that are not remembered.
- Skips the ordering prompt entirely when all simultaneous abilities are effectively identical and ordering would not matter.
- Adds localization for the new checkbox label across all UI language files.