### PR TITLE
Route libgdx-port checks through the target GUI

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
@@ -220,6 +220,11 @@ public final class CMatchUI
     }
 
     @Override
+    public boolean isLibgdxPort() {
+        return false;
+    }
+
+    @Override
     public void setGameView(GameView gameView0) {
         super.setGameView(gameView0);
         gameView0 = getGameView(); //ensure updated game view used for below logic

--- a/forge-gui-desktop/src/test/java/forge/net/HeadlessNetworkGuiGame.java
+++ b/forge-gui-desktop/src/test/java/forge/net/HeadlessNetworkGuiGame.java
@@ -82,6 +82,7 @@ public class HeadlessNetworkGuiGame extends NetworkGuiGame {
     @Override public void updatePhase(boolean saveState) { }
     @Override public void updateTurn(PlayerView player) { }
     @Override public void updatePlayerControl() { }
+    @Override public boolean isLibgdxPort() { return false; }
     @Override public void enableOverlay() { }
     @Override public void disableOverlay() { }
     @Override public void showManaPool(PlayerView player) { }

--- a/forge-gui-mobile/src/forge/screens/match/MatchController.java
+++ b/forge-gui-mobile/src/forge/screens/match/MatchController.java
@@ -94,6 +94,11 @@ public class MatchController extends NetworkGuiGame {
     }
 
     @Override
+    public boolean isLibgdxPort() {
+        return true;
+    }
+
+    @Override
     protected void updateCurrentPlayer(final PlayerView player) {
         for (final PlayerView other : getLocalPlayers()) {
             if (!other.equals(player)) {

--- a/forge-gui/src/main/java/forge/gamemodes/match/input/InputConfirm.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/input/InputConfirm.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableList;
 import forge.game.card.Card;
 import forge.game.card.CardView;
 import forge.game.spellability.SpellAbility;
-import forge.gui.GuiBase;
 import forge.localinstance.properties.ForgePreferences;
 import forge.model.FModel;
 import forge.player.PlayerControllerHuman;
@@ -55,7 +54,7 @@ public class InputConfirm extends InputSyncronizedBase {
         return InputConfirm.confirm(controller, card, message, true, defaultOptions);
     }
     public static boolean confirm(final PlayerControllerHuman controller, final CardView card, final String message, final boolean defaultIsYes, final List<String> options) {
-         if (GuiBase.getInterface().isLibgdxPort()) {
+         if (controller.getGui().isLibgdxPort()) {
              return controller.getGui().confirm(card, message, defaultIsYes, options);
          }
         return confirm(controller, card, null, message, defaultIsYes, options);
@@ -64,7 +63,7 @@ public class InputConfirm extends InputSyncronizedBase {
         return InputConfirm.confirm(controller, sa, message, true, defaultOptions);
     }
     public static boolean confirm(final PlayerControllerHuman controller, final SpellAbility sa, final String message, final boolean defaultIsYes, final List<String> options) {
-         if (GuiBase.getInterface().isLibgdxPort()) {
+         if (controller.getGui().isLibgdxPort()) {
              if (sa == null)
                  return controller.getGui().confirm(null, message, defaultIsYes, options);
              if (sa.getTargets() != null && sa.getTargets().isTargetingAnyCard() && sa.getTargets().size() == 1)
@@ -77,7 +76,7 @@ public class InputConfirm extends InputSyncronizedBase {
          return InputConfirm.confirm(controller, card, sa, message, true, defaultOptions);
      }
      public static boolean confirm(final PlayerControllerHuman controller, final CardView card, final SpellAbility sa, final String message, final boolean defaultIsYes, final List<String> options) {
-         if (GuiBase.getInterface().isLibgdxPort()) {
+         if (controller.getGui().isLibgdxPort()) {
              return controller.getGui().confirm(card, message, defaultIsYes, options);
          }
          InputConfirm inp;

--- a/forge-gui/src/main/java/forge/gamemodes/match/input/InputPayMana.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/input/InputPayMana.java
@@ -19,7 +19,6 @@ import forge.game.spellability.AbilityManaPart;
 import forge.game.spellability.SpellAbility;
 import forge.game.spellability.SpellAbilityView;
 import forge.gui.FThreads;
-import forge.gui.GuiBase;
 import forge.player.PlayerControllerHuman;
 import forge.util.Evaluator;
 import forge.util.ITriggerEvent;
@@ -76,7 +75,7 @@ public abstract class InputPayMana extends InputSyncronizedBase {
 
     @Override
     protected boolean onCardSelected(final Card card, final List<Card> otherCardsToSelect, final ITriggerEvent triggerEvent) {
-        if (GuiBase.getInterface().isLibgdxPort()) {
+        if (getController().getGui().isLibgdxPort()) {
             // Mobile Forge allows to tap cards underneath the current card even if the current one is tapped
             if (otherCardsToSelect != null) {
                 for (Card c : otherCardsToSelect) {

--- a/forge-gui/src/main/java/forge/gamemodes/net/client/GameClientHandler.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/client/GameClientHandler.java
@@ -221,7 +221,8 @@ final class GameClientHandler extends GameProtocolHandler<IGuiGame> implements I
                 loginName,
                 Integer.parseInt(FModel.getPreferences().getPref(FPref.UI_AVATARS).split(",")[0]),
                 Integer.parseInt(FModel.getPreferences().getPref(FPref.UI_SLEEVES).split(",")[0]),
-                BuildInfo.getVersionString()
+                BuildInfo.getVersionString(),
+                GuiBase.getInterface().isLibgdxPort()
         ));
     }
 

--- a/forge-gui/src/main/java/forge/gamemodes/net/event/LoginEvent.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/event/LoginEvent.java
@@ -8,11 +8,13 @@ public class LoginEvent implements NetEvent {
     private final String username;
     private final int avatarIndex, sleeveIndex;
     private final String version;
-    public LoginEvent(final String username, final int avatarIndex, final int sleeveIndex, final String version) {
+    private final boolean libgdx;
+    public LoginEvent(final String username, final int avatarIndex, final int sleeveIndex, final String version, final boolean libgdx) {
         this.username = username;
         this.avatarIndex = avatarIndex;
         this.sleeveIndex = sleeveIndex;
         this.version = version;
+        this.libgdx = libgdx;
     }
 
     @Override
@@ -33,5 +35,9 @@ public class LoginEvent implements NetEvent {
 
     public String getVersion() {
         return version;
+    }
+
+    public boolean isLibgdx() {
+        return libgdx;
     }
 }

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
@@ -978,6 +978,7 @@ public final class FServerManager implements IHasForgeLog {
                         ctx.close();
                     } else {
                         client.setIndex(index);
+                        client.setLibgdx(event.isLibgdx());
                         if (index > 0) {
                             broadcast(new MessageEvent(String.format("%s joined the lobby.", event.getUsername())));
                             broadcastTo(new MessageEvent(formatAfkTimeoutMessage()),

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/RemoteClient.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/RemoteClient.java
@@ -20,6 +20,7 @@ public final class RemoteClient implements IToClient, IHasForgeLog {
     private volatile Channel channel;
     private String username;
     private int index = UNASSIGNED_SLOT;
+    private boolean libgdx;
     private volatile ReplyPool replies = new ReplyPool();
     private volatile Tracker codecTracker;
     private final AtomicInteger sendErrors = new AtomicInteger(0);
@@ -153,6 +154,13 @@ public final class RemoteClient implements IToClient, IHasForgeLog {
     }
     public void setIndex(final int index) {
         this.index = index;
+    }
+
+    public boolean isLibgdx() {
+        return libgdx;
+    }
+    public void setLibgdx(final boolean libgdx) {
+        this.libgdx = libgdx;
     }
 
     /**

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/RemoteClientGuiGame.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/RemoteClientGuiGame.java
@@ -64,6 +64,11 @@ public class RemoteClientGuiGame extends NetworkGuiGame implements IHasForgeLog 
         return client;
     }
 
+    @Override
+    public boolean isLibgdxPort() {
+        return client.isLibgdx();
+    }
+
     public void pause() {
         paused = true;
     }

--- a/forge-gui/src/main/java/forge/gui/control/FControlGameEventHandler.java
+++ b/forge-gui/src/main/java/forge/gui/control/FControlGameEventHandler.java
@@ -260,7 +260,7 @@ public class FControlGameEventHandler extends IGameEventVisitor.Base<Void> {
     @Override
     public Void visit(final GameEventSpellAbilityCast event) {
         needStackUpdate = true;
-        if (GuiBase.getInterface().isLibgdxPort() ||
+        if (matchController.isLibgdxPort() ||
                 ForgeConstants.STACK_EFFECT_NOTIFICATION_NEVER.equals(FModel.getPreferences().getPref(FPref.UI_STACK_EFFECT_NOTIFICATION_POLICY))) {
             // mobile port don't have notify stack addition like the desktop
             return processEvent();
@@ -282,7 +282,7 @@ public class FControlGameEventHandler extends IGameEventVisitor.Base<Void> {
     @Override
     public Void visit(final GameEventSpellRemovedFromStack event) {
         needStackUpdate = true;
-        if (GuiBase.getInterface().isLibgdxPort() ||
+        if (matchController.isLibgdxPort() ||
                 ForgeConstants.STACK_EFFECT_NOTIFICATION_NEVER.equals(FModel.getPreferences().getPref(FPref.UI_STACK_EFFECT_NOTIFICATION_POLICY))) {
         } else {
             processEvent();
@@ -388,7 +388,7 @@ public class FControlGameEventHandler extends IGameEventVisitor.Base<Void> {
 
     @Override
     public Void visit(final GameEventCardChangeZone event) {
-        if (GuiBase.getInterface().isLibgdxPort()) {
+        if (matchController.isLibgdxPort()) {
             if (event.from() != null) {
                 updateZone(event.from().player(), event.from().zoneType());
             }
@@ -446,7 +446,7 @@ public class FControlGameEventHandler extends IGameEventVisitor.Base<Void> {
 
     @Override
     public Void visit(final GameEventShuffle event) {
-        if (GuiBase.getInterface().isLibgdxPort()) {
+        if (matchController.isLibgdxPort()) {
             return updateZone(event.player(), ZoneType.Library);
         } else {
             return processEvent();

--- a/forge-gui/src/main/java/forge/gui/interfaces/IGuiGame.java
+++ b/forge-gui/src/main/java/forge/gui/interfaces/IGuiGame.java
@@ -34,6 +34,15 @@ import java.util.List;
 import java.util.Map;
 
 public interface IGuiGame {
+    /**
+     * Whether the renderer for this GUI is the libgdx (mobile) port.
+     * For local GUIs this matches GuiBase.getInterface().isLibgdxPort();
+     * for RemoteClientGuiGame it reflects the connected client's renderer
+     * (learned at lobby handshake), letting the host pick code paths that
+     * are actually implemented on the target.
+     */
+    boolean isLibgdxPort();
+
     void setGameView(GameView gameView);
 
     /**

--- a/forge-gui/src/main/java/forge/player/HumanCostDecision.java
+++ b/forge-gui/src/main/java/forge/player/HumanCostDecision.java
@@ -17,7 +17,6 @@ import forge.game.zone.ZoneType;
 import forge.gamemodes.match.input.InputConfirm;
 import forge.gamemodes.match.input.InputSelectCardsFromList;
 import forge.gamemodes.match.input.InputSelectManyBase;
-import forge.gui.GuiBase;
 import forge.gui.util.SGuiChoose;
 import forge.util.*;
 import forge.util.collect.FCollectionView;
@@ -1504,7 +1503,7 @@ public class HumanCostDecision extends CostDecisionMakerBase {
 
     private boolean confirmAction(CostPart costPart, String message) {
         CardView cardView = ability.getCardView();
-        if (GuiBase.getInterface().isLibgdxPort()) {
+        if (controller.getGui().isLibgdxPort()) {
             try {
                 //for cards like Sword-Point Diplomacy and others that uses imprinted as container for their ability
                 if (cardView != null && cardView.getImprintedCards() != null && cardView.getImprintedCards().size() == 1)

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -456,7 +456,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
             }
 
             final boolean useUiPointAtCard =
-                    FModel.getPreferences().getPrefBoolean(FPref.UI_SELECT_FROM_CARD_DISPLAYS) && !GuiBase.getInterface().isLibgdxPort() ?
+                    FModel.getPreferences().getPrefBoolean(FPref.UI_SELECT_FROM_CARD_DISPLAYS) && !getGui().isLibgdxPort() ?
                             (cz.is(ZoneType.Battlefield) || cz.is(ZoneType.Hand) || cz.is(ZoneType.Library) ||
                                     cz.is(ZoneType.Graveyard) || cz.is(ZoneType.Exile) || cz.is(ZoneType.Flashback) ||
                                     cz.is(ZoneType.Command) || cz.is(ZoneType.Sideboard)) :
@@ -811,7 +811,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
                 buildQuestion.append("\n").append(localizer.getMessage("lblTriggeredby")).append(": ").append(tos.get(AbilityKey.Card));
             }
         }
-        if (GuiBase.getInterface().isLibgdxPort()) {
+        if (getGui().isLibgdxPort()) {
             CardView cardView;
             SpellAbilityView spellAbilityView = wrapper.getView();
             if (spellAbilityView != null) //updated view
@@ -973,8 +973,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
         CardCollection toTop = null;
 
         tempShowCards(topN);
-        if (FModel.getPreferences().getPrefBoolean(FPref.UI_SELECT_FROM_CARD_DISPLAYS) &&
-                (!GuiBase.getInterface().isLibgdxPort()) && (!GuiBase.isNetPlay(getGui()))) { //prevent crash for desktop vs mobile port it will crash the netplay since mobile doesnt have manipulatecardlist, send the alternate below
+        if (FModel.getPreferences().getPrefBoolean(FPref.UI_SELECT_FROM_CARD_DISPLAYS) && !getGui().isLibgdxPort()) {
             CardCollectionView cardList = player.getCardsIn(ZoneType.Library);
             ImmutablePair<CardCollection, CardCollection> result =
                     arrangeForMove(localizer.getMessage("lblMoveCardstoToporBbottomofLibrary"), cardList, topN, true, true);
@@ -1441,7 +1440,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
     @Override
     public boolean confirmReplacementEffect(final ReplacementEffect replacementEffect, final SpellAbility effectSA,
                                             GameEntity affected, final String question) {
-        if (GuiBase.getInterface().isLibgdxPort()) {
+        if (getGui().isLibgdxPort()) {
             CardView cardView;
             SpellAbilityView spellAbilityView = effectSA == null ? null : effectSA.getView();
             if (spellAbilityView != null) //updated view
@@ -1561,7 +1560,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
     public CardCollection chooseCardsToDiscardToMaximumHandSize(final int nDiscard) {
         final int max = player.getMaxHandSize();
 
-        if (GuiBase.getInterface().isLibgdxPort()) {
+        if (getGui().isLibgdxPort()) {
             tempShowCards(player.getCardsIn(ZoneType.Hand));
             GameEntityViewMap<Card, CardView> gameCacheDiscard = GameEntityView.getMap(player.getCardsIn(ZoneType.Hand));
             List<CardView> views = getGui().many(String.format(localizer.getMessage("lblChooseMinCardToDiscard"), nDiscard),
@@ -1709,7 +1708,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
         if (sa != null && sa.isManaAbility()) {
             getGame().fireEvent(new GameEventAddLog(GameLogEntryType.LAND, message));
         } else {
-            if (sa != null && sa.getHostCard() != null && GuiBase.getInterface().isLibgdxPort()) {
+            if (sa != null && sa.getHostCard() != null && getGui().isLibgdxPort()) {
                 CardView cardView;
                 IPaperCard iPaperCard = sa.getHostCard().getPaperCard();
                 if (iPaperCard != null)
@@ -1868,7 +1867,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
 
     @Override
     public boolean confirmPayment(final CostPart costPart, final String question, SpellAbility sa) {
-        if (GuiBase.getInterface().isLibgdxPort()) {
+        if (getGui().isLibgdxPort()) {
             CardView cardView;
             try {
                 cardView = CardView.getCardForUi(ImageUtil.getPaperCardFromImageKey(sa.getView().getHostCard().getCurrentState().getTrackableImageKey()));
@@ -2218,7 +2217,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
 
     @Override
     public void revealAISkipCards(final String message, final Map<Player, Map<DeckSection, List<? extends PaperCard>>> unplayable) {
-        if (GuiBase.getInterface().isLibgdxPort()) {
+        if (getGui().isLibgdxPort()) {
             //restore old functionality for mobile version since list of card names can't be zoomed to display the cards
             for (Player p : unplayable.keySet()) {
                 final Map<DeckSection, List<? extends PaperCard>> removedUnplayableCards = unplayable.get(p);


### PR DESCRIPTION
## Bug report

Resolves #10613 — On the mobile client against a desktop host, search-your-library effects (Demonic Tutor, Solemn Simulacrum's basic-land trigger, fetch lands) present prompt but no cards are visible.

## The general issue

Several UI decision points read `GuiBase.getInterface().isLibgdxPort()` to determine whether to route to desktop or mobile rendering paths.

This is a process-global static answering **"is this JVM libgdx?"** — when the right question is **"is the player whose UI will render this libgdx?"**. The two answers agree in single-player and same-platform netplay, but diverge in cross-platform netplay: a desktop host serving a mobile client returns `false` and steers the choice down a desktop-renderer code path the mobile client cannot honor.

### How it manifests in the tutor case

```
PlayerControllerHuman.chooseSingleEntityForEffect (line 585)
                        │
                        ▼
        ┌──────────────────────────────────────┐
        │ useSelectCardsInput(optionList, sa)  │
        │                                      │
        │  Reads GuiBase.getInterface()        │
        │       .isLibgdxPort()                │
        │  ── PROCESS-LOCAL on the HOST ──     │
        │                                      │
        │  Library zone qualifies only when    │
        │  !isLibgdxPort()  (PCH.java:459)     │
        └──────────────┬───────────────────────┘
                       │
        ┌──────────────┴───────────────┐
        │                              │
   returns TRUE                  returns FALSE
        │                              │
        ▼                              ▼
   PATH A                          PATH B
   InputSelectEntitiesFromList     getGui().chooseSingleEntityForEffect
        │                              │
        │ setSelectables ──┐           │ → GameEntityPicker / SGuiChoose
        │ tempShowZones ───┤           │   (a self-contained dialog —
        │ updateZones      │           │    does NOT use tempShowZones)
        │ hideZones ───────┘           │
        ▼                              ▼
   Renders cards INSIDE the         Renders cards INSIDE the picker
   matching floating zone           dialog. Works regardless of
   on the player's screen.          whether floating zones exist.
   ── REQUIRES tempShowZones
      to be implemented ──
```

Desktop host → check returns false → PATH A → host serializes `tempShowZones` over the wire to the mobile client. Mobile's `MatchScreen.tempShowZones` is an unimplemented stub (`// pfps needs to actually do something`), so cards never render. The same anti-pattern wrong-routes confirm dialogs, scry reorder, end-step discard, AI-skip reveals, and stack notifications.

## The fix

Add `boolean isLibgdxPort()` to `IGuiGame`. Local GUIs return their process flavor; `RemoteClientGuiGame` returns the value the remote sent at lobby handshake (`LoginEvent` gains a `libgdx` field, populated by `GameClientHandler` and stored on `RemoteClient` at login). Every UI-flavor decision that calls `getGui()` afterwards is converted to the per-GUI check:

| File | Sites | What it gates |
|------|-------|---------------|
| `PlayerControllerHuman.java` | 459 | tutor / library-search picker (the reported bug) |
| `PlayerControllerHuman.java` | 977 | scry — also drops the `!isNetPlay(getGui())` workaround for the same defect class |
| `PlayerControllerHuman.java` | 814, 1444, 1871 | trigger / replacement / payment confirm dialogs |
| `PlayerControllerHuman.java` | 1564 | end-step hand-size discard picker |
| `PlayerControllerHuman.java` | 1712 | spell-played value notification |
| `PlayerControllerHuman.java` | 2221 | AI-skipped-cards reveal |
| `HumanCostDecision.java` | 1507 | cost-action confirm |
| `InputConfirm.java` | 58, 67, 80 | generic confirm dialogs |
| `InputPayMana.java` | 79 | mobile multi-tap behaviour |
| `FControlGameEventHandler.java` | 263, 285, 391, 449 | stack notifications + zone-update gating |

## Why it's safe

Semantically a no-op except where it fixes a bug:
- Single-player and same-platform netplay: returns the same value as before.
- `FControlGameEventHandler` is only ever bound to a local GUI (`HostedMatch.java:237` routes remotes to `GameEventForwarder`) — pure consistency cleanup.
- Cross-platform netplay: now routes per the receiving renderer.

`LoginEvent` gains one boolean field; the existing version-mismatch warning catches any wire-format incompatibility between divergent builds.

### Testing

Original bug can be easily recreated on master by casting Solemn Simulacrum as mobile client with desktop host.

Fix verified on `NetworkPlay/libgdx-handshake`: **Solemn Simulacrum tutor** (desktop host + mobile client, the original repro) now shows the library cards in the picker instead of an empty selection.

Note: although the bug report describes a recent change in behaviour, none of the relevant code paths (`PlayerControllerHuman.java:459`, the `MatchScreen.tempShowZones` stub, `useSelectCardsInput`, `InputSelectEntitiesFromList`) appear to have been modified by any recent commit in a way that would introduce this issue. This appears to be a long-standing latent bug.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)