### PR TITLE
CardDB cleanup; index cards by CardRules

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/ChooseCardNameAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ChooseCardNameAi.java
@@ -102,7 +102,7 @@ public class ChooseCardNameAi extends SpellAbilityAi {
         final CardDb cardDb = StaticData.instance().getCommonCards();
 
         for (ICardFace face : faces) {
-            final CardRules rules = cardDb.getRules(face.getName());
+            final CardRules rules = cardDb.getRulesOrElseUnsupported(face.getName());
             boolean isOther = rules.getOtherPart() == face;
             final PaperCard paper = cardDb.getCard(rules.getName());
             final Card card = Card.fromPaperCard(paper, ai);

--- a/forge-core/src/main/java/forge/card/CardDb.java
+++ b/forge-core/src/main/java/forge/card/CardDb.java
@@ -45,12 +45,12 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
 
     // need this to obtain cardReference by name+set+artindex
     private final ListMultimap<String, PaperCard> allCardsByName = Multimaps.newListMultimap(new TreeMap<>(String.CASE_INSENSITIVE_ORDER), Lists::newArrayList);
-    private final Map<String, PaperCard> uniqueCardsByName = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
-    private final Map<String, CardRules> rulesByName;
+    private final Map<String, CardRules> rulesByPrimaryName;
+    private final Map<String, CardRules> rulesByAltName = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
     private final ListMultimap<CardRules, PaperCard> allCardsByRules = Multimaps.newListMultimap(new TreeMap<>(CARD_RULES_NAME_COMPARATOR), Lists::newArrayList);
     private final Map<String, ICardFace> facesByName = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
     private final Map<String, String> normalizedNames = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
-    private static Map<String, String> artPrefs = Maps.newHashMap();
+    private static final Map<String, String> artPrefs = Maps.newHashMap();
     /**
      * Map of flavor names to the identifier of the functional variant on which they appear in their respective card rules.
      */
@@ -297,12 +297,9 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
 
     public CardDb(Map<String, CardRules> rules, CardEdition.Collection editions0, Set<String> filteredCards) {
         this.filtered = filteredCards;
-        this.rulesByName = rules;
+        this.rulesByPrimaryName = rules;
         this.editions = editions0;
 
-        //Collects additional mappings used for flavor names
-        //Need an extra map for these to avoid ConcurrentModificationException
-        Map<String, CardRules> extraRuleMappings = new HashMap<>();
         List<CardRules> needsPlaceholderFaces = new ArrayList<>();
 
         // create faces list from rules
@@ -318,7 +315,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
                 addFaceToDbNames(face);
             }
             if (rule.hasFunctionalVariants()) {
-                cacheFlavorNames(rule, extraRuleMappings);
+                cacheFlavorNames(rule);
             }
         }
 
@@ -326,8 +323,6 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
         for(CardRules rule : needsPlaceholderFaces) {
             rule.supplyPlaceholderFaces(this.facesByName);
         }
-
-        rulesByName.putAll(extraRuleMappings);
     }
 
     private void addFaceToDbNames(ICardFace face) {
@@ -360,7 +355,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
         }
     }
 
-    private void cacheFlavorNames(CardRules rules, Map<String, CardRules> map) {
+    private void cacheFlavorNames(CardRules rules) {
         if (rules.getSupportedFunctionalVariants() == null)
             return;
         boolean hasFlavorName = false;
@@ -370,7 +365,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
             if (baseName.equals(name))
                 continue;
             hasFlavorName = true;
-            map.put(name, rules);
+            rulesByAltName.put(name, rules);
             flavorNameMappings.put(name, variantName);
         }
         if (hasFlavorName)
@@ -403,7 +398,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
             if(!flavorNameMappings.containsKey(normalizedFlavorName)) {
                 flavorNameMappings.put(normalizedFlavorName, variantName);
                 flavorNameMappings.put(cr.getName(), IPaperCard.NO_FUNCTIONAL_VARIANT);
-                rulesByName.put(normalizedFlavorName, cr);
+                rulesByAltName.put(normalizedFlavorName, cr);
                 cacheFlavorName(cr.getMainPart().getFunctionalVariant(variantName));
                 if(cr.getOtherPart() != null)
                     cacheFlavorName(cr.getOtherPart().getFunctionalVariant(variantName));
@@ -440,7 +435,6 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
                 return;
             }
         }
-        rulesByName.putIfAbsent(cardName, cr);
         boolean reIndexNecessary = false;
         CardEdition ed = editions.get(setCode);
         if (ed == null || ed.equals(CardEdition.UNKNOWN)) {
@@ -452,8 +446,10 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
             reIndexNecessary |= addFromSetByName(cardName, ed, cr);
         }
 
-        if (reIndexNecessary)
+        if (reIndexNecessary) {
+            rulesByPrimaryName.putIfAbsent(cardName, cr); //TODO: Cache alt names here too.
             reIndex();
+        }
     }
 
     public void initialize(boolean logMissingPerEdition, boolean logMissingSummary, boolean enableUnknownCards) {
@@ -473,7 +469,9 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
             }
 
             for (CardEdition.EditionEntry cis : e.getAllCardsInSet()) {
-                CardRules cr = rulesByName.get(cis.name());
+                CardRules cr = rulesByPrimaryName.get(cis.name());
+                if (cr == null)
+                    cr = rulesByAltName.get(cis.name()); //Entry written using a flavor name
                 if (cr == null) {
                     missingCards.add(cis.name());
                     continue;
@@ -512,7 +510,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
             System.err.println("Upcoming set " + upcomingSet + " dated in the future. All `upcoming` cards will be added to this set with unknown rarity.");
         }
 
-        for (CardRules cr : rulesByName.values()) {
+        for (CardRules cr : rulesByPrimaryName.values()) {
             if (!contains(cr.getName())) {
                 if (!cr.isCustom()) {
                     if (upcomingSet != null && cr.getPath() != null && cr.getPath().contains("upcoming/")) {
@@ -592,11 +590,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
         return artPrefs.getOrDefault(cardName, null) != null;
     }
 
-    public CardRules getRules(String cardName) {
-        CardRules result = rulesByName.get(cardName);
-        return Objects.requireNonNullElseGet(result, () -> CardRules.getUnsupportedCardNamed(cardName));
-    }
-
+    @Override
     public CardArtPreference getCardArtPreference(){ return this.defaultCardArtPreference; }
     public void setCardArtPreference(boolean latestArt, boolean coreExpansionOnly){
         if (coreExpansionOnly){
@@ -605,6 +599,33 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
             this.defaultCardArtPreference = latestArt ? CardArtPreference.LATEST_ART_ALL_EDITIONS : CardArtPreference.ORIGINAL_ART_ALL_EDITIONS;
         }
     }
+
+    /**
+     * Retrieves a CardRules matching the provided name. 
+     * @param allowAltNames If false, the name must be the exact name of the card in its default state. If true, flavor 
+     *                      names and alternate face names can be used, though an exact match will be preferred.
+     * @see #getAllCards(String) 
+     * @see #getAllCardsNoAlt(String) 
+     */
+    public CardRules getRules(String cardName, boolean allowAltNames) {
+        cardName = getNormalizedName(cardName);
+        CardRules result = rulesByPrimaryName.get(cardName);
+        if (result != null)
+            return result;
+        if (allowAltNames) {
+            result = rulesByAltName.get(cardName);
+            return result;
+        }
+        return null;
+    }
+
+    public CardRules getRulesOrElseUnsupported(String cardName) {
+        CardRules rules = getRules(cardName, false);
+        if (rules == null)
+            return CardRules.getUnsupportedCardNamed(cardName);
+        return rules;
+    }
+
 
     public void setCardArtPreference(String artPreference){
         artPreference = artPreference.toLowerCase().trim();
@@ -1026,8 +1047,8 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
      *     <li>"Ironfang" (Transformed card back face) will return nothing.</li>
      *     <li>"Ancestral Recall" will only return printings of "Ancestral Recall", not "Emeritus of Ideation".</li>
      *     <li>"Fire" will return nothing. You must specify "Fire // Ice" or "Start // Fire".</li>
-     *     <li>"Spongebob Squarepants" will return nothing.</li>
-     *     <li>"Jodah, the Unifier" will return all Jodah printings, including "Spongebob Squarepants".</li>
+     *     <li>"SpongeBob SquarePants" will return nothing.</li>
+     *     <li>"Jodah, the Unifier" will return all Jodah printings, including "SpongeBob SquarePants".</li>
      * </ul>
      * @see #getAllCards(String)
      */
@@ -1176,13 +1197,13 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
             // works similarly to Map<K,V>, returning prev. value
             String cardName = rules.getName();
 
-            CardRules result = rulesByName.get(cardName);
+            CardRules result = rulesByPrimaryName.get(cardName);
             if (result != null && result.getName().equals(cardName)) { // change properties only
                 result.reinitializeFromRules(rules);
                 return result;
             }
 
-            result = rulesByName.put(cardName, rules);
+            result = rulesByPrimaryName.put(cardName, rules);
 
             // 1. generate all paper cards from edition data we have (either explicit, or found in res/editions, or add to unknown edition)
             List<PaperCard> paperCards = new ArrayList<>();

--- a/forge-core/src/main/java/forge/card/CardDb.java
+++ b/forge-core/src/main/java/forge/card/CardDb.java
@@ -48,6 +48,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
     private final Map<String, CardRules> rulesByPrimaryName;
     private final Map<String, CardRules> rulesByAltName = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
     private final ListMultimap<CardRules, PaperCard> allCardsByRules = Multimaps.newListMultimap(new TreeMap<>(CARD_RULES_NAME_COMPARATOR), Lists::newArrayList);
+    private final Map<CardRules, PaperCard> uniqueCardsByRules = Maps.newTreeMap(CARD_RULES_NAME_COMPARATOR);
     private final Map<String, ICardFace> facesByName = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
     private final Map<String, String> normalizedNames = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
     private static final Map<String, String> artPrefs = Maps.newHashMap();
@@ -555,14 +556,14 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
     }
 
     private void reIndex() {
-        uniqueCardsByName.clear();
-        for (Entry<String, Collection<PaperCard>> kv : allCardsByName.asMap().entrySet()) {
-            PaperCard pc = getFirstNonSpeicalWithImage(kv.getValue());
-            uniqueCardsByName.put(kv.getKey(), pc);
+        uniqueCardsByRules.clear();
+        for (Entry<CardRules, Collection<PaperCard>> kv : allCardsByRules.asMap().entrySet()) {
+            PaperCard pc = getFirstNonSpecialWithImage(kv.getValue());
+            uniqueCardsByRules.put(kv.getKey(), pc);
         }
     }
 
-    private static PaperCard getFirstNonSpeicalWithImage(final Collection<PaperCard> cards) {
+    private static PaperCard getFirstNonSpecialWithImage(final Collection<PaperCard> cards) {
         //NOTE: this is written this way to avoid checking final card in list
         final Iterator<PaperCard> iterator = cards.iterator();
         PaperCard pc = iterator.next();
@@ -580,7 +581,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
         PaperCard pc = this.getCard(cardRequestForPreferredArt);
         if (pc != null) {
             artPrefs.put(cardName, cardRequestForPreferredArt);
-            uniqueCardsByName.put(cardName, pc);
+            uniqueCardsByRules.put(pc.getRules(), pc);
             return true;
         }
         return false;
@@ -928,23 +929,21 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
     // returns a list of all cards from their respective latest (or preferred) editions
     @Override
     public Collection<PaperCard> getUniqueCards() {
-        return uniqueCardsByName.values();
-    }
-
-    public Collection<PaperCard> getUniqueCardsNoAlt() {
-        return Maps.filterEntries(this.uniqueCardsByName, e -> {
-            if (e == null)
-                return false;
-            return e.getKey().equals(e.getValue().getName());
-        }).values();
-    }
-
-    public List<PaperCard> getUniqueCardsNoAlt(String cardName) {
-        return Lists.newArrayList(Maps.filterEntries(uniqueCardsByName, entry -> entry.getKey().equals(entry.getValue().getName())).get(getNormalizedName(cardName)));
+        return uniqueCardsByRules.values();
     }
 
     public PaperCard getUniqueByName(final String name) {
-        return uniqueCardsByName.get(getNormalizedName(name));
+        CardRules rules = getRules(name, true);
+        if(rules == null)
+            return null;
+        return uniqueCardsByRules.get(rules);
+    }
+
+    public PaperCard getUniqueByNameNoAlt(String cardName) {
+        CardRules rules = getRules(cardName, false);
+        if(rules == null)
+            return null;
+        return uniqueCardsByRules.get(rules);
     }
 
     public Collection<ICardFace> getAllFaces() {
@@ -980,17 +979,13 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
         return Collections.unmodifiableCollection(allCardsByName.values());
     }
 
-    public Collection<PaperCard> getAllCardsNoAlt() {
-        return Multimaps.filterEntries(allCardsByName, entry -> entry.getKey().equals(entry.getValue().getName())).values();
-    }
-
     @Override
     public Stream<PaperCard> streamAllCards() {
         return allCardsByRules.values().stream();
     }
     @Override
     public Stream<PaperCard> streamUniqueCards() {
-        return uniqueCardsByName.values().stream();
+        return uniqueCardsByRules.values().stream();
     }
 
     public Stream<ICardFace> streamAllFaces() {

--- a/forge-core/src/main/java/forge/card/CardDb.java
+++ b/forge-core/src/main/java/forge/card/CardDb.java
@@ -41,11 +41,13 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
     public final static char NameSetSeparator = '|';
     public final static String FlagPrefix = "#";
     public static final String FlagSeparator = "\t";
+    public static final Comparator<CardRules> CARD_RULES_NAME_COMPARATOR = Comparator.comparing(CardRules::getPreInitName, String.CASE_INSENSITIVE_ORDER);
 
     // need this to obtain cardReference by name+set+artindex
     private final ListMultimap<String, PaperCard> allCardsByName = Multimaps.newListMultimap(new TreeMap<>(String.CASE_INSENSITIVE_ORDER), Lists::newArrayList);
     private final Map<String, PaperCard> uniqueCardsByName = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
     private final Map<String, CardRules> rulesByName;
+    private final ListMultimap<CardRules, PaperCard> allCardsByRules = Multimaps.newListMultimap(new TreeMap<>(CARD_RULES_NAME_COMPARATOR), Lists::newArrayList);
     private final Map<String, ICardFace> facesByName = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
     private final Map<String, String> normalizedNames = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
     private static Map<String, String> artPrefs = Maps.newHashMap();
@@ -538,6 +540,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
         allCardsByName.put(mainName, paperCard);
 
         CardRules rules = paperCard.getRules();
+        allCardsByRules.put(rules, paperCard);
         if (rules.getSplitType() == CardSplitType.None && !rules.hasFunctionalVariants()) {
             return;
         }
@@ -1056,17 +1059,11 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
 
     @Override
     public Stream<PaperCard> streamAllCards() {
-        return allCardsByName.values().stream();
+        return allCardsByRules.values().stream();
     }
     @Override
     public Stream<PaperCard> streamUniqueCards() {
         return uniqueCardsByName.values().stream();
-    }
-    public Stream<PaperCard> streamAllCardsNoAlt() {
-        return allCardsByName.entries().stream().filter(e -> e.getKey().equals(e.getValue().getName())).map(Entry::getValue);
-    }
-    public Stream<PaperCard> streamUniqueCardsNoAlt() {
-        return uniqueCardsByName.entrySet().stream().filter(e -> e.getKey().equals(e.getValue().getName())).map(Entry::getValue);
     }
 
     public Stream<ICardFace> streamAllFaces() {
@@ -1090,7 +1087,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
     };
 
     public Collection<PaperCard> getAllNonPromosNonReprintsNoAlt() {
-        return streamAllCardsNoAlt().filter(EDITION_NON_REPRINT).collect(Collectors.toList());
+        return streamAllCards().filter(EDITION_NON_REPRINT).collect(Collectors.toList());
     }
 
     public String getNormalizedName(final String cardName) {
@@ -1132,6 +1129,14 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
         return Lists.newArrayList(Multimaps.filterEntries(allCardsByName, entry -> entry.getKey().equals(entry.getValue().getName())).get(getNormalizedName(cardName)));
     }
 
+    public List<PaperCard> getAllCards(CardRules rules) {
+        return allCardsByRules.get(rules);
+    }
+
+    public List<PaperCard> getAllCards(PaperCard card) {
+        return getAllCards(card.getRules());
+    }
+
     /**
      * Returns a modifiable list of cards matching the given predicate
      */
@@ -1145,11 +1150,8 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
         return getAllCards(cardName).stream().filter(predicate).collect(Collectors.toCollection(ArrayList::new));
     }
 
-    /**
-     * Returns a modifiable list of cards matching the given predicate
-     */
-    public List<PaperCard> getAllCardsNoAlt(Predicate<PaperCard> predicate) {
-        return streamAllCardsNoAlt().filter(predicate).collect(Collectors.toCollection(ArrayList::new));
+    public List<PaperCard> getAllCards(PaperCard card, Predicate<PaperCard> predicate){
+        return getAllCards(card).stream().filter(predicate).collect(Collectors.toCollection(ArrayList::new));
     }
 
     public List<PaperCard> getAllCardsNoAlt(final String cardName, Predicate<PaperCard> predicate){
@@ -1186,7 +1188,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
     @Override
     public Predicate<? super PaperCard> wasPrintedInSets(Collection<String> setCodes) {
         Set<String> sets = new HashSet<>(setCodes);
-        return paperCard -> getAllCardsNoAlt(paperCard.getName()).stream()
+        return paperCard -> getAllCards(paperCard).stream()
                 .map(PaperCard::getEdition).anyMatch(editionCode ->
                     sets.contains(editionCode) &&
                         StaticData.instance().getCardEdition(editionCode).isCardObtainable(paperCard.getName())
@@ -1203,7 +1205,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
     // This Predicate validates if a card was printed at [rarity], on any of its printings
     @Override
     public Predicate<? super PaperCard> wasPrintedAtRarity(CardRarity rarity) {
-        return paperCard -> getAllCardsNoAlt(paperCard.getName()).stream()
+        return paperCard -> getAllCards(paperCard).stream()
                 .map(PaperCard::getRarity)
                 .anyMatch(rarity::equals);
     }

--- a/forge-core/src/main/java/forge/card/CardDb.java
+++ b/forge-core/src/main/java/forge/card/CardDb.java
@@ -704,21 +704,6 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
      * Therefore, the single Edition request can be overruled if no image is found
      * for the corresponding requested edition.
      */
-    @Override
-    public PaperCard getCardFromSet(String cardName, CardEdition edition, boolean isFoil) {
-        return getCardFromSet(cardName, edition, IPaperCard.NO_ART_INDEX,
-                IPaperCard.NO_COLLECTOR_NUMBER, isFoil);
-    }
-
-    @Override
-    public PaperCard getCardFromSet(String cardName, CardEdition edition, int artIndex, boolean isFoil) {
-        return getCardFromSet(cardName, edition, artIndex, IPaperCard.NO_COLLECTOR_NUMBER, isFoil);
-    }
-
-    @Override
-    public PaperCard getCardFromSet(String cardName, CardEdition edition, String collectorNumber, boolean isFoil) {
-        return getCardFromSet(cardName, edition, IPaperCard.NO_ART_INDEX, collectorNumber, isFoil);
-    }
 
     @Override
     public PaperCard getCardFromSet(String cardName, CardEdition edition, int artIndex, String collectorNumber, boolean isFoil) {
@@ -767,35 +752,6 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
      * ====================================================
      */
 
-    /* Get Card from Edition using the default `CardArtPreference`
-    NOTE: this method has NOT been included in the Interface API refactoring as it
-    relies on a specific (new) attribute included in the `CardDB` that sets the
-    default `ArtPreference`. This attribute does not necessarily belongs to any
-    class implementing ICardInterface, and so the not inclusion in the API
-     */
-    public PaperCard getCardFromEditions(final String cardName) {
-        return this.getCardFromEditions(cardName, this.defaultCardArtPreference);
-    }
-
-    public PaperCard getCardFromEditions(final String cardName, Predicate<PaperCard> filter) {
-        return this.getCardFromEditions(cardName, this.defaultCardArtPreference, filter);
-    }
-
-    @Override
-    public PaperCard getCardFromEditions(final String cardName, CardArtPreference artPreference) {
-        return getCardFromEditions(cardName, artPreference, IPaperCard.NO_ART_INDEX);
-    }
-
-    @Override
-    public PaperCard getCardFromEditions(final String cardName, CardArtPreference artPreference, Predicate<PaperCard> filter) {
-        return getCardFromEditions(cardName, artPreference, IPaperCard.NO_ART_INDEX, filter);
-    }
-
-    @Override
-    public PaperCard getCardFromEditions(final String cardInfo, final CardArtPreference artPreference, int artIndex) {
-        return this.tryToGetCardFromEditions(cardInfo, artPreference, artIndex, null);
-    }
-
     @Override
     public PaperCard getCardFromEditions(final String cardInfo, final CardArtPreference artPreference, int artIndex, Predicate<PaperCard> filter) {
         return this.tryToGetCardFromEditions(cardInfo, artPreference, artIndex, filter);
@@ -808,59 +764,9 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
      * ===============================================
      */
 
-    public PaperCard getCardFromEditionsReleasedBefore(String cardName, Date releaseDate){
-        return this.getCardFromEditionsReleasedBefore(cardName, this.defaultCardArtPreference, PaperCard.DEFAULT_ART_INDEX, releaseDate);
-    }
-
-    public PaperCard getCardFromEditionsReleasedBefore(String cardName, int artIndex, Date releaseDate){
-        return this.getCardFromEditionsReleasedBefore(cardName, this.defaultCardArtPreference, artIndex, releaseDate);
-    }
-
-    public PaperCard getCardFromEditionsReleasedBefore(String cardName, Date releaseDate, Predicate<PaperCard> filter){
-        return this.getCardFromEditionsReleasedBefore(cardName, this.defaultCardArtPreference, releaseDate, filter);
-    }
-
-    @Override
-    public PaperCard getCardFromEditionsReleasedBefore(String cardName, CardArtPreference artPreference, Date releaseDate){
-        return this.getCardFromEditionsReleasedBefore(cardName, artPreference, PaperCard.DEFAULT_ART_INDEX, releaseDate);
-    }
-
-    @Override
-    public PaperCard getCardFromEditionsReleasedBefore(String cardName, CardArtPreference artPreference, Date releaseDate, Predicate<PaperCard> filter){
-        return this.getCardFromEditionsReleasedBefore(cardName, artPreference, PaperCard.DEFAULT_ART_INDEX, releaseDate, filter);
-    }
-
-    @Override
-    public PaperCard getCardFromEditionsReleasedBefore(String cardName, CardArtPreference artPreference, int artIndex, Date releaseDate){
-        return this.tryToGetCardFromEditions(cardName, artPreference, artIndex, releaseDate, true, null);
-    }
-
     @Override
     public PaperCard getCardFromEditionsReleasedBefore(String cardName, CardArtPreference artPreference, int artIndex, Date releaseDate, Predicate<PaperCard> filter){
         return this.tryToGetCardFromEditions(cardName, artPreference, artIndex, releaseDate, true, filter);
-    }
-
-    public PaperCard getCardFromEditionsReleasedAfter(String cardName, Date releaseDate){
-        return this.getCardFromEditionsReleasedAfter(cardName, this.defaultCardArtPreference, PaperCard.DEFAULT_ART_INDEX, releaseDate);
-    }
-
-    public PaperCard getCardFromEditionsReleasedAfter(String cardName, int artIndex, Date releaseDate){
-        return this.getCardFromEditionsReleasedAfter(cardName, this.defaultCardArtPreference, artIndex, releaseDate);
-    }
-
-    @Override
-    public PaperCard getCardFromEditionsReleasedAfter(String cardName, CardArtPreference artPreference, Date releaseDate){
-        return this.getCardFromEditionsReleasedAfter(cardName, artPreference, PaperCard.DEFAULT_ART_INDEX, releaseDate);
-    }
-
-    @Override
-    public PaperCard getCardFromEditionsReleasedAfter(String cardName, CardArtPreference artPreference, Date releaseDate, Predicate<PaperCard> filter){
-        return this.getCardFromEditionsReleasedAfter(cardName, artPreference, PaperCard.DEFAULT_ART_INDEX, releaseDate, filter);
-    }
-
-    @Override
-    public PaperCard getCardFromEditionsReleasedAfter(String cardName, CardArtPreference artPreference, int artIndex, Date releaseDate){
-        return this.tryToGetCardFromEditions(cardName, artPreference, artIndex, releaseDate, false, null);
     }
 
     @Override

--- a/forge-core/src/main/java/forge/card/ICardDatabase.java
+++ b/forge-core/src/main/java/forge/card/ICardDatabase.java
@@ -1,6 +1,7 @@
 package forge.card;
 
 import forge.card.CardDb.CardArtPreference;
+import forge.item.IPaperCard;
 import forge.item.PaperCard;
 
 import java.util.Collection;
@@ -53,26 +54,70 @@ public interface ICardDatabase extends Iterable<PaperCard> {
     PaperCard getCard(String cardName, String edition, String collectorNumber, Map<String, String> flags);
 
     // 2. Card Lookup from a single Expansion Set
-    PaperCard getCardFromSet(String cardName, CardEdition edition, boolean isFoil);  // NOT yet used, included for API symmetry
-    PaperCard getCardFromSet(String cardName, CardEdition edition, String collectorNumber, boolean isFoil);
-    PaperCard getCardFromSet(String cardName, CardEdition edition, int artIndex, boolean isFoil);
+    default PaperCard getCardFromSet(String cardName, CardEdition edition, boolean isFoil) {
+        return getCardFromSet(cardName, edition, IPaperCard.NO_ART_INDEX, IPaperCard.NO_COLLECTOR_NUMBER, isFoil);
+    }  // NOT yet used, included for API symmetry
+
+    default PaperCard getCardFromSet(String cardName, CardEdition edition, String collectorNumber, boolean isFoil) {
+        return getCardFromSet(cardName, edition, IPaperCard.NO_ART_INDEX, collectorNumber, isFoil);
+    }
+
+    default PaperCard getCardFromSet(String cardName, CardEdition edition, int artIndex, boolean isFoil) {
+        return getCardFromSet(cardName, edition, artIndex, IPaperCard.NO_COLLECTOR_NUMBER, isFoil);
+    }
     PaperCard getCardFromSet(String cardName, CardEdition edition, int artIndex, String collectorNumber, boolean isFoil);
 
     // 3. Card lookup based on CardArtPreference Selection Policy
-    PaperCard getCardFromEditions(String cardName, CardArtPreference artPreference);
-    PaperCard getCardFromEditions(String cardName, CardArtPreference artPreference, Predicate<PaperCard> filter);
-    PaperCard getCardFromEditions(String cardName, CardArtPreference artPreference, int artIndex);
+    default PaperCard getCardFromEditions(String cardName)  {
+        return getCardFromEditions(cardName, getCardArtPreference(), IPaperCard.NO_ART_INDEX, null);
+    }
+    default PaperCard getCardFromEditions(String cardName, Predicate<PaperCard> filter) {
+        return getCardFromEditions(cardName, getCardArtPreference(), IPaperCard.NO_ART_INDEX, filter);
+    }
+    default PaperCard getCardFromEditions(String cardName, CardArtPreference artPreference)  {
+        return getCardFromEditions(cardName, artPreference, IPaperCard.NO_ART_INDEX, null);
+    }
+    default PaperCard getCardFromEditions(String cardName, CardArtPreference artPreference, Predicate<PaperCard> filter) {
+        return getCardFromEditions(cardName, artPreference, IPaperCard.NO_ART_INDEX, filter);
+    }
+    default PaperCard getCardFromEditions(String cardName, CardArtPreference artPreference, int artIndex)  {
+        return getCardFromEditions(cardName, artPreference, artIndex, null);
+    }
     PaperCard getCardFromEditions(String cardName, CardArtPreference artPreference, int artIndex, Predicate<PaperCard> filter);
 
     // 4. Specialised Card Lookup on CardArtPreference Selection and Release Date
-    PaperCard getCardFromEditionsReleasedBefore(String cardName, CardArtPreference artPreference, Date releaseDate);
-    PaperCard getCardFromEditionsReleasedBefore(String cardName, CardArtPreference artPreference, Date releaseDate, Predicate<PaperCard> filter);
-    PaperCard getCardFromEditionsReleasedBefore(String cardName, CardArtPreference artPreference, int artIndex, Date releaseDate);
+    default PaperCard getCardFromEditionsReleasedBefore(String cardName, Date releaseDate) {
+        return this.getCardFromEditionsReleasedBefore(cardName, getCardArtPreference(), PaperCard.DEFAULT_ART_INDEX, releaseDate, null);
+    }
+    default PaperCard getCardFromEditionsReleasedBefore(String cardName, int artIndex, Date releaseDate) {
+        return this.getCardFromEditionsReleasedBefore(cardName, getCardArtPreference(), artIndex, releaseDate, null);
+    }
+    default PaperCard getCardFromEditionsReleasedBefore(String cardName, CardArtPreference artPreference, Date releaseDate) {
+        return this.getCardFromEditionsReleasedBefore(cardName, artPreference, PaperCard.DEFAULT_ART_INDEX, releaseDate, null);
+    }
+    default PaperCard getCardFromEditionsReleasedBefore(String cardName, CardArtPreference artPreference, Date releaseDate, Predicate<PaperCard> filter) {
+        return this.getCardFromEditionsReleasedBefore(cardName, artPreference, PaperCard.DEFAULT_ART_INDEX, releaseDate, filter);
+    }
+    default PaperCard getCardFromEditionsReleasedBefore(String cardName, CardArtPreference artPreference, int artIndex, Date releaseDate) {
+        return this.getCardFromEditionsReleasedBefore(cardName, artPreference, artIndex, releaseDate, null);
+    }
     PaperCard getCardFromEditionsReleasedBefore(String cardName, CardArtPreference artPreference, int artIndex, Date releaseDate, Predicate<PaperCard> filter);
 
-    PaperCard getCardFromEditionsReleasedAfter(String cardName, CardArtPreference artPreference, Date releaseDate);
-    PaperCard getCardFromEditionsReleasedAfter(String cardName, CardArtPreference artPreference, Date releaseDate, Predicate<PaperCard> filter);
-    PaperCard getCardFromEditionsReleasedAfter(String cardName, CardArtPreference artPreference, int artIndex, Date releaseDate);
+    default PaperCard getCardFromEditionsReleasedAfter(String cardName, Date releaseDate) {
+        return this.getCardFromEditionsReleasedAfter(cardName, getCardArtPreference(), PaperCard.DEFAULT_ART_INDEX, releaseDate, null);
+    }
+    default PaperCard getCardFromEditionsReleasedAfter(String cardName, int artIndex, Date releaseDate) {
+        return this.getCardFromEditionsReleasedAfter(cardName, getCardArtPreference(), artIndex, releaseDate, null);
+    }
+    default PaperCard getCardFromEditionsReleasedAfter(String cardName, CardArtPreference artPreference, Date releaseDate)  {
+        return this.getCardFromEditionsReleasedAfter(cardName, artPreference, PaperCard.DEFAULT_ART_INDEX, releaseDate, null);
+    }
+    default PaperCard getCardFromEditionsReleasedAfter(String cardName, CardArtPreference artPreference, Date releaseDate, Predicate<PaperCard> filter) {
+        return this.getCardFromEditionsReleasedAfter(cardName, artPreference, PaperCard.DEFAULT_ART_INDEX, releaseDate, filter);
+    }
+    default PaperCard getCardFromEditionsReleasedAfter(String cardName, CardArtPreference artPreference, int artIndex, Date releaseDate) {
+        return this.getCardFromEditionsReleasedAfter(cardName, artPreference, artIndex, releaseDate, null);
+    }
     PaperCard getCardFromEditionsReleasedAfter(String cardName, CardArtPreference artPreference, int artIndex, Date releaseDate, Predicate<PaperCard> filter);
 
     /* CARDS COLLECTION RETRIEVAL METHODS
@@ -95,4 +140,6 @@ public interface ICardDatabase extends Iterable<PaperCard> {
     Predicate<? super PaperCard> wasPrintedInSets(Collection<String> allowedSetCodes);
     Predicate<? super PaperCard> isLegal(Collection<String> allowedSetCodes);
     Predicate<? super PaperCard> wasPrintedAtRarity(CardRarity rarity);
+
+    CardArtPreference getCardArtPreference();
 }

--- a/forge-core/src/main/java/forge/item/PaperCardPredicates.java
+++ b/forge-core/src/main/java/forge/item/PaperCardPredicates.java
@@ -67,7 +67,7 @@ public abstract class PaperCardPredicates {
     public static Predicate<PaperCard> printedInAnyEditions(final String[] editionCodes) {
         Set<String> editions = new HashSet<>(Arrays.asList(editionCodes));
 
-        return card -> StaticData.instance().getCommonCards().getAllCardsNoAlt(card.getName()).stream()
+        return card -> StaticData.instance().getCommonCards().getAllCards(card).stream()
             .map(PaperCard::getEdition).anyMatch(editionCode ->
                 editions.contains(editionCode) &&
                     StaticData.instance().getCardEdition(editionCode).isCardObtainable(card.getName())
@@ -80,7 +80,7 @@ public abstract class PaperCardPredicates {
     public static Predicate<PaperCard> onlyPrintedInEditions(final String[] editionCodes) {
         Set<String> editions = new HashSet<>(Arrays.asList(editionCodes));
 
-        return card -> StaticData.instance().getCommonCards().getAllCardsNoAlt(card.getName()).stream()
+        return card -> StaticData.instance().getCommonCards().getAllCards(card).stream()
             .map(PaperCard::getEdition).allMatch(editionCode ->
                 editions.contains(editionCode) &&
                     StaticData.instance().getCardEdition(editionCode).isCardObtainable(card.getName())
@@ -91,7 +91,7 @@ public abstract class PaperCardPredicates {
      * Filters cards that are obtainable in any edition.
      */
     public static Predicate<PaperCard> isObtainableAnyEdition() {
-        return card -> StaticData.instance().getCommonCards().getAllCardsNoAlt(card.getName()).stream()
+        return card -> StaticData.instance().getCommonCards().getAllCards(card).stream()
             .map(PaperCard::getEdition).anyMatch(editionCode ->
                 StaticData.instance().getCardEdition(editionCode).isCardObtainable(card.getName())
             );
@@ -107,7 +107,7 @@ public abstract class PaperCardPredicates {
         Set<String> restrictedEditions = new HashSet<>(Arrays.asList(restrictedEditionCodes));
 
         return card -> StaticData.instance().getCommonCards()
-            .getAllCardsNoAlt(card.getName()).stream()
+            .getAllCards(card).stream()
             .map(PaperCard::getEdition)
             .anyMatch(editionCode ->
                 !restrictedEditions.contains(editionCode) &&

--- a/forge-core/src/main/java/forge/util/ImageUtil.java
+++ b/forge-core/src/main/java/forge/util/ImageUtil.java
@@ -162,7 +162,7 @@ public class ImageUtil {
                     return card.getOtherPart().getName();
                 } else if (!card.getMeldWith().isEmpty()) {
                     final CardDb db = StaticData.instance().getCommonCards();
-                    return db.getRules(card.getMeldWith()).getOtherPart().getName();
+                    return db.getRulesOrElseUnsupported(card.getMeldWith()).getOtherPart().getName();
                 } else {
                     return null;
                 }

--- a/forge-game/src/main/java/forge/game/card/CardFactory.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactory.java
@@ -318,7 +318,7 @@ public class CardFactory {
             if (rules.getOtherPart() != null) {
                 readCardFace(card, rules.getOtherPart());
             } else if (!rules.getMeldWith().isEmpty()) {
-                readCardFace(card, StaticData.instance().getCommonCards().getRules(rules.getMeldWith()).getOtherPart());
+                readCardFace(card, StaticData.instance().getCommonCards().getRulesOrElseUnsupported(rules.getMeldWith()).getOtherPart());
             }
         }
 

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorCommander.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorCommander.java
@@ -83,15 +83,15 @@ public final class CEditorCommander extends CDeckEditor<Deck> {
         if (gameType == GameType.Brawl){
             GameFormat format = FModel.getFormats().get("Brawl");
             Predicate<CardRules> commanderFilter = CardRulesPredicates.CAN_BE_BRAWL_COMMANDER;
-            commanderPool = ItemPool.createFrom(commonCards.getAllCardsNoAlt(format.getFilterPrinted().and(PaperCardPredicates.fromRules(commanderFilter))), PaperCard.class);
+            commanderPool = ItemPool.createFrom(commonCards.getAllCards(format.getFilterPrinted().and(PaperCardPredicates.fromRules(commanderFilter))), PaperCard.class);
             normalPool = ItemPool.createFrom(format.getAllCards(), PaperCard.class);
         }
         else {
             Predicate<CardRules> commanderFilter = gameType == GameType.Oathbreaker
                     ? CardRulesPredicates.CAN_BE_OATHBREAKER.or(CardRulesPredicates.CAN_BE_SIGNATURE_SPELL)
                     : CardRulesPredicates.CAN_BE_COMMANDER;
-            commanderPool = ItemPool.createFrom(commonCards.getAllCardsNoAlt(PaperCardPredicates.fromRules(commanderFilter)),PaperCard.class);
-            normalPool = ItemPool.createFrom(commonCards.getAllCardsNoAlt(), PaperCard.class);
+            commanderPool = ItemPool.createFrom(commonCards.getAllCards(PaperCardPredicates.fromRules(commanderFilter)),PaperCard.class);
+            normalPool = ItemPool.createFrom(commonCards.getAllCards(), PaperCard.class);
         }
 
         CardManager catalogManager = new CardManager(getCDetailPicture(), true, false, false);

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorConstructed.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorConstructed.java
@@ -88,7 +88,7 @@ public final class CEditorConstructed extends CDeckEditor<Deck> {
                 allSections.add(DeckSection.Avatar);
                 allSections.add(DeckSection.Conspiracy);
 
-                normalPool = FModel.getAllCardsNoAlt();
+                normalPool = FModel.getAllCards();
                 avatarPool = FModel.getAvatarPool();
                 conspiracyPool = FModel.getConspiracyPool();
 
@@ -97,7 +97,7 @@ public final class CEditorConstructed extends CDeckEditor<Deck> {
                 allSections.add(DeckSection.Commander);
 
                 commanderPool = FModel.getCommanderPool();
-                normalPool = FModel.getAllCardsNoAlt();
+                normalPool = FModel.getAllCards();
 
                 wantUnique = true;
                 break;
@@ -105,7 +105,7 @@ public final class CEditorConstructed extends CDeckEditor<Deck> {
                 allSections.add(DeckSection.Commander);
 
                 commanderPool = FModel.getTinyLeadersCommander();
-                normalPool = FModel.getAllCardsNoAlt();
+                normalPool = FModel.getAllCards();
 
                 wantUnique = true;
                 break;
@@ -113,7 +113,7 @@ public final class CEditorConstructed extends CDeckEditor<Deck> {
                 allSections.add(DeckSection.Commander);
 
                 commanderPool = FModel.getOathbreakerCommander();
-                normalPool = FModel.getAllCardsNoAlt();
+                normalPool = FModel.getAllCards();
 
                 wantUnique = true;
                 break;

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorQuestCardShop.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorQuestCardShop.java
@@ -74,8 +74,8 @@ public final class CEditorQuestCardShop extends ACEditorBase<InventoryItem, Deck
     private final QuestController questData;
 
     private ItemPool<InventoryItem> cardsForSale;
-    private final ItemPool<InventoryItem> fullCatalogCards =
-            ItemPool.createFrom(FModel.getMagicDb().getCommonCards().getAllCardsNoAlt(), InventoryItem.class);
+    private final ItemPool<InventoryItem> fullCatalogCards
+            = ItemPool.createFrom(FModel.getMagicDb().getCommonCards().getAllCards(), InventoryItem.class);
     private boolean showingFullCatalog = false;
     private DragCell allDecksParent = null;
     private DragCell deckGenParent = null;

--- a/forge-gui-desktop/src/main/java/forge/screens/workshop/views/VWorkshopCatalog.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/workshop/views/VWorkshopCatalog.java
@@ -38,7 +38,7 @@ public enum VWorkshopCatalog implements IVDoc<CWorkshopCatalog> {
     VWorkshopCatalog() {
         this.cardManager = new CardManager(cDetailPicture, true, false, false);
         this.cardManager.setCaption(localizer.getMessage("lblCatalog"));
-        final Iterable<PaperCard> allCards = Iterables.concat(FModel.getMagicDb().getCommonCards().getAllCardsNoAlt(), FModel.getMagicDb().getVariantCards().getAllCards());
+        final Iterable<PaperCard> allCards = Iterables.concat(FModel.getMagicDb().getCommonCards().getAllCards(), FModel.getMagicDb().getVariantCards().getAllCards());
         this.cardManager.setPool(ItemPool.createFrom(allCards, PaperCard.class), true);
         this.cardManagerContainer.setItemManager(this.cardManager);
 

--- a/forge-gui-mobile/src/forge/adventure/util/CardUtil.java
+++ b/forge-gui-mobile/src/forge/adventure/util/CardUtil.java
@@ -83,7 +83,7 @@ public class CardUtil {
                 return !this.shouldBeEqual;
             if (!this.editions.isEmpty() && !this.editions.contains(card.getEdition())) {
                 boolean found = false;
-                List<PaperCard> allPrintings = FModel.getMagicDb().getCommonCards().getAllCardsNoAlt(card.getCardName());
+                List<PaperCard> allPrintings = FModel.getMagicDb().getCommonCards().getAllCards(card);
                 for (PaperCard c : allPrintings) {
                     if (this.editions.contains(c.getEdition())) {
                         found = true;
@@ -95,7 +95,7 @@ public class CardUtil {
             }
             if (!this.minDate.isEmpty()) {
                 boolean found = false;
-                List<PaperCard> allPrintings = FModel.getMagicDb().getCommonCards().getAllCardsNoAlt(card.getCardName());
+                List<PaperCard> allPrintings = FModel.getMagicDb().getCommonCards().getAllCards(card);
                 List<CardEdition> cardEditionList = new ArrayList<>();
 
                 Date d = parseDate(this.minDate);
@@ -850,7 +850,7 @@ public class CardUtil {
             }
             validCards = FModel.getMagicDb().getCommonCards().getAllCardsNoAlt(cardName, combined_predicate);
         } else {
-            validCards = FModel.getMagicDb().getCommonCards().getUniqueCardsNoAlt(cardName);
+            validCards = List.of(FModel.getMagicDb().getCommonCards().getUniqueByNameNoAlt(cardName));
             // Filter to allowed editions to prevent showing printings from wrong sets.
             if (configData.allowedEditions != null && configData.allowedEditions.length > 0) {
                 Set<String> allowed = new HashSet<>(Arrays.asList(configData.allowedEditions));
@@ -885,7 +885,7 @@ public class CardUtil {
         }
         List<PaperCard> cardPool = Config.instance().getSettingData().useAllCardVariants
                 ? FModel.getMagicDb().getCommonCards().getAllCardsNoAlt(cardName)
-                : FModel.getMagicDb().getCommonCards().getUniqueCardsNoAlt(cardName);
+                : List.of(FModel.getMagicDb().getCommonCards().getUniqueByNameNoAlt(cardName));
         List<PaperCard> validCards = cardPool.stream()
                 .filter(input -> input.getEdition().equals(edition)).collect(Collectors.toList());
 
@@ -910,12 +910,12 @@ public class CardUtil {
             }
             // For unique cards, replace non-allowed printings with allowed ones.
             List<PaperCard> filtered = new ArrayList<>();
-            for (PaperCard card : FModel.getMagicDb().getCommonCards().getUniqueCardsNoAlt()) {
+            for (PaperCard card : FModel.getMagicDb().getCommonCards().getUniqueCards()) {
                 if (card == null) continue;
                 if (allowed.contains(card.getEdition())) {
                     filtered.add(card);
                 } else {
-                    for (PaperCard p : FModel.getMagicDb().getCommonCards().getAllCardsNoAlt(card.getName())) {
+                    for (PaperCard p : FModel.getMagicDb().getCommonCards().getAllCards(card)) {
                         if (allowed.contains(p.getEdition())) {
                             filtered.add(p);
                             break;
@@ -927,7 +927,7 @@ public class CardUtil {
         }
         return allCardVariants
             ? FModel.getMagicDb().getCommonCards().getAllCards()
-            : FModel.getMagicDb().getCommonCards().getUniqueCardsNoAlt();
+            : FModel.getMagicDb().getCommonCards().getUniqueCards();
     }
 
     /**
@@ -971,7 +971,7 @@ public class CardUtil {
         Set<String> allowed = new HashSet<>(Arrays.asList(configData.allowedEditions));
         if (allowed.contains(card.getEdition()))
             return card;
-        for (PaperCard p : FModel.getMagicDb().getCommonCards().getAllCardsNoAlt(card.getName())) {
+        for (PaperCard p : FModel.getMagicDb().getCommonCards().getAllCards(card)) {
             if (allowed.contains(p.getEdition()))
                 return p;
         }

--- a/forge-gui-mobile/src/forge/deck/FDeckEditor.java
+++ b/forge-gui-mobile/src/forge/deck/FDeckEditor.java
@@ -66,7 +66,7 @@ public class FDeckEditor extends TabPageScreen<FDeckEditor> {
         }
 
         public ItemPool<PaperCard> getCardPool() {
-            return FModel.getAllCardsNoAlt();
+            return FModel.getAllCards();
         }
         protected Predicate<PaperCard> getCardFilter() { return null; }
 

--- a/forge-gui/src/main/java/forge/deck/DeckgenUtil.java
+++ b/forge-gui/src/main/java/forge/deck/DeckgenUtil.java
@@ -703,7 +703,7 @@ public class DeckgenUtil {
 
                 if (signatureSpells.size() > 0) { //pass signature spell as partner for simplicity
                     selectedPartner = signatureSpells.get(MyRandom.getRandom().nextInt(signatureSpells.size()));
-                    preSelectedCards.removeAll(StaticData.instance().getCommonCards().getAllCards(selectedPartner.getName()));
+                    preSelectedCards.removeAll(StaticData.instance().getCommonCards().getAllCards(selectedPartner));
                 }
             }
             else if (commander.getRules().canBePartnerCommander()) {
@@ -717,7 +717,7 @@ public class DeckgenUtil {
 
                 if (partners.size() > 0) {
                     selectedPartner = partners.get(MyRandom.getRandom().nextInt(partners.size()));
-                    preSelectedCards.removeAll(StaticData.instance().getCommonCards().getAllCards(selectedPartner.getName()));
+                    preSelectedCards.removeAll(StaticData.instance().getCommonCards().getAllCards(selectedPartner));
                 }
             }
             //randomly remove cards
@@ -740,7 +740,7 @@ public class DeckgenUtil {
                 ++i;
             }
             preSelectedCards.removeAll(toRemove);
-            preSelectedCards.removeAll(StaticData.instance().getCommonCards().getAllCards(commander.getName()));
+            preSelectedCards.removeAll(StaticData.instance().getCommonCards().getAllCards(commander));
             gen = new CardThemedCommanderDeckBuilder(commander, selectedPartner, preSelectedCards, forAi, format);
         }else{
             cardDb = FModel.getMagicDb().getCommonCards();
@@ -790,10 +790,10 @@ public class DeckgenUtil {
             }
             List<PaperCard> shortList = cardList.subList(0, shortlistlength);
             shortList.remove(commander);
-            shortList.removeAll(StaticData.instance().getCommonCards().getAllCards(commander.getName()));
+            shortList.removeAll(StaticData.instance().getCommonCards().getAllCards(commander));
             if (selectedPartner != null) {
                 shortList.remove(selectedPartner);
-                shortList.removeAll(StaticData.instance().getCommonCards().getAllCards(selectedPartner.getName()));
+                shortList.removeAll(StaticData.instance().getCommonCards().getAllCards(selectedPartner));
             }
             gen = new CardThemedCommanderDeckBuilder(commander, selectedPartner, shortList, forAi, format);
         }

--- a/forge-gui/src/main/java/forge/gamemodes/limited/CardThemedDeckBuilder.java
+++ b/forge-gui/src/main/java/forge/gamemodes/limited/CardThemedDeckBuilder.java
@@ -607,10 +607,10 @@ public class CardThemedDeckBuilder extends DeckGeneratorBase {
         List<PaperCard> possibleList = Lists.newArrayList(pool.getAllCards(possibleFromFullPool));
         //ensure we do not add more keycards in case they are commanders
         if (keyCard != null) {
-            possibleList.removeAll(StaticData.instance().getCommonCards().getAllCards(keyCard.getName()));
+            possibleList.removeAll(StaticData.instance().getCommonCards().getAllCards(keyCard));
         }
         if (secondKeyCard != null) {
-            possibleList.removeAll(StaticData.instance().getCommonCards().getAllCards(secondKeyCard.getName()));
+            possibleList.removeAll(StaticData.instance().getCommonCards().getAllCards(secondKeyCard));
         }
         //Iterator<PaperCard> iRandomPool = CardRanker.rankCardsInDeck(possibleList.subList(0, targetSize <= possibleList.size() ? targetSize : possibleList.size())).iterator();
         Collections.shuffle(possibleList);
@@ -833,10 +833,10 @@ public class CardThemedDeckBuilder extends DeckGeneratorBase {
         List<PaperCard> possibleList = Lists.newArrayList(pool.getAllCards(possibleFromFullPool));
         //ensure we do not add more keycards in case they are commanders
         if (keyCard != null) {
-            possibleList.removeAll(StaticData.instance().getCommonCards().getAllCards(keyCard.getName()));
+            possibleList.removeAll(StaticData.instance().getCommonCards().getAllCards(keyCard));
         }
         if (secondKeyCard != null) {
-            possibleList.removeAll(StaticData.instance().getCommonCards().getAllCards(secondKeyCard.getName()));
+            possibleList.removeAll(StaticData.instance().getCommonCards().getAllCards(secondKeyCard));
         }
         Collections.shuffle(possibleList);
         //addManaCurveCards(CardRanker.rankCardsInDeck(possibleList.subList(0, targetSize*3 <= possibleList.size() ? targetSize*3 : possibleList.size())),

--- a/forge-gui/src/main/java/forge/model/FModel.java
+++ b/forge-gui/src/main/java/forge/model/FModel.java
@@ -131,14 +131,13 @@ public final class FModel {
         return w;
     });
     private static final Supplier<GameFormat.Collection> formats = Suppliers.memoize(() -> new GameFormat.Collection(new GameFormat.Reader( new File(ForgeConstants.FORMATS_DATA_DIR), new File(ForgeConstants.USER_FORMATS_DIR), preferences.getPrefBoolean(FPref.LOAD_ARCHIVED_FORMATS))));
-    private static final Supplier<ItemPool<PaperCard>> uniqueCardsNoAlt = Suppliers.memoize(() -> ItemPool.createFrom(getMagicDb().getCommonCards().getUniqueCardsNoAlt(), PaperCard.class));
-    private static final Supplier<ItemPool<PaperCard>> allCardsNoAlt = Suppliers.memoize(() -> ItemPool.createFrom(getMagicDb().getCommonCards().getAllCardsNoAlt(), PaperCard.class));
+    private static final Supplier<ItemPool<PaperCard>> allCards = Suppliers.memoize(() -> ItemPool.createFrom(getMagicDb().getCommonCards().getAllCards(), PaperCard.class));
     private static final Supplier<ItemPool<PaperCard>> planechaseCards = Suppliers.memoize(() -> ItemPool.createFrom(getMagicDb().getVariantCards().getAllCards(PaperCardPredicates.fromRules(CardRulesPredicates.IS_PLANE_OR_PHENOMENON)), PaperCard.class));
     private static final Supplier<ItemPool<PaperCard>> archenemyCards = Suppliers.memoize(() -> ItemPool.createFrom(getMagicDb().getVariantCards().getAllCards(PaperCardPredicates.fromRules(CardRulesPredicates.IS_SCHEME)), PaperCard.class));
-    private static final Supplier<ItemPool<PaperCard>> brawlCommander = Suppliers.memoize(() -> ItemPool.createFrom(getMagicDb().getCommonCards().getAllCardsNoAlt(getFormats().get("Brawl").getFilterPrinted().and(PaperCardPredicates.fromRules(CardRulesPredicates.CAN_BE_BRAWL_COMMANDER))), PaperCard.class));
-    private static final Supplier<ItemPool<PaperCard>> oathbreakerCommander = Suppliers.memoize(() -> ItemPool.createFrom(getMagicDb().getCommonCards().getAllCardsNoAlt(PaperCardPredicates.fromRules(CardRulesPredicates.CAN_BE_OATHBREAKER.or(CardRulesPredicates.CAN_BE_SIGNATURE_SPELL))), PaperCard.class));
-    private static final Supplier<ItemPool<PaperCard>> tinyLeadersCommander = Suppliers.memoize(() -> ItemPool.createFrom(getMagicDb().getCommonCards().getAllCardsNoAlt(PaperCardPredicates.fromRules(CardRulesPredicates.CAN_BE_TINY_LEADERS_COMMANDER)), PaperCard.class));
-    private static final Supplier<ItemPool<PaperCard>> commanderPool = Suppliers.memoize(() -> ItemPool.createFrom(getMagicDb().getCommonCards().getAllCardsNoAlt(PaperCardPredicates.CAN_BE_COMMANDER), PaperCard.class));
+    private static final Supplier<ItemPool<PaperCard>> brawlCommander = Suppliers.memoize(() -> ItemPool.createFrom(getMagicDb().getCommonCards().getAllCards(getFormats().get("Brawl").getFilterPrinted().and(PaperCardPredicates.fromRules(CardRulesPredicates.CAN_BE_BRAWL_COMMANDER))), PaperCard.class));
+    private static final Supplier<ItemPool<PaperCard>> oathbreakerCommander = Suppliers.memoize(() -> ItemPool.createFrom(getMagicDb().getCommonCards().getAllCards(PaperCardPredicates.fromRules(CardRulesPredicates.CAN_BE_OATHBREAKER.or(CardRulesPredicates.CAN_BE_SIGNATURE_SPELL))), PaperCard.class));
+    private static final Supplier<ItemPool<PaperCard>> tinyLeadersCommander = Suppliers.memoize(() -> ItemPool.createFrom(getMagicDb().getCommonCards().getAllCards(PaperCardPredicates.fromRules(CardRulesPredicates.CAN_BE_TINY_LEADERS_COMMANDER)), PaperCard.class));
+    private static final Supplier<ItemPool<PaperCard>> commanderPool = Suppliers.memoize(() -> ItemPool.createFrom(getMagicDb().getCommonCards().getAllCards(PaperCardPredicates.CAN_BE_COMMANDER), PaperCard.class));
     private static final Supplier<ItemPool<PaperCard>> avatarPool = Suppliers.memoize(() -> ItemPool.createFrom(getMagicDb().getVariantCards().getAllCards(PaperCardPredicates.fromRules(CardRulesPredicates.IS_VANGUARD)), PaperCard.class));
     private static final Supplier<ItemPool<PaperCard>> conspiracyPool = Suppliers.memoize(() -> ItemPool.createFrom(getMagicDb().getVariantCards().getAllCards(PaperCardPredicates.fromRules(CardRulesPredicates.IS_CONSPIRACY)), PaperCard.class));
     private static final Supplier<ItemPool<PaperCard>> dungeonPool = Suppliers.memoize(() -> ItemPool.createFrom(getMagicDb().getVariantCards().getAllCards(PaperCardPredicates.fromRules(CardRulesPredicates.IS_DUNGEON)), PaperCard.class));
@@ -283,12 +282,8 @@ public final class FModel {
         return conquest.get();
     }
 
-    public static ItemPool<PaperCard> getUniqueCardsNoAlt() {
-        return uniqueCardsNoAlt.get();
-    }
-
-    public static ItemPool<PaperCard> getAllCardsNoAlt() {
-        return allCardsNoAlt.get();
+    public static ItemPool<PaperCard> getAllCards() {
+        return allCards.get();
     }
 
     public static ItemPool<PaperCard> getArchenemyCards() {

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -3010,7 +3010,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
                 f = lastAdded;
                 quantity = 1;
             } else {
-                List<CardFaceView> choices = carddb.getAllFaces().stream().map(CardFaceView::new).collect(Collectors.toList());
+                List<CardFaceView> choices = carddb.streamAllFaces().map(CardFaceView::new).collect(Collectors.toList());
                 Collections.sort(choices);
                 f = getGui().oneOrNone(localizer.getMessage("lblNameTheCard"), choices);
                 if (f != null) {

--- a/forge-gui/src/main/java/forge/util/ImageFetcher.java
+++ b/forge-gui/src/main/java/forge/util/ImageFetcher.java
@@ -50,7 +50,7 @@ public abstract class ImageFetcher {
             // the wrong frame.
             addScryfallUrl(c, face, useArtCrop, downloadUrls);
 
-            List<PaperCard> clones = StaticData.instance().getCommonCards().getAllCardsNoAlt(c.getName());
+            List<PaperCard> clones = StaticData.instance().getCommonCards().getAllCards(c);
             for (PaperCard pc : clones) {
                 if (c.getEdition().equalsIgnoreCase(pc.getEdition())) {
                     continue;
@@ -224,7 +224,7 @@ public abstract class ImageFetcher {
                     }
                     downloadUrls.add(setDownload.toString());
                 } else {
-                    List<PaperCard> clones = StaticData.instance().getCommonCards().getAllCardsNoAlt(paperCard.getName());
+                    List<PaperCard> clones = StaticData.instance().getCommonCards().getAllCards(paperCard);
                     for (PaperCard pc : clones) {
                         if (clones.size() > 1) {//clones only
                             if (!paperCard.getEdition().equalsIgnoreCase(pc.getEdition())) {


### PR DESCRIPTION
* Implements `allCardsByRules`, an alternative to `allCardsByName` that guarantees that cards don't appear in multiple entries due to things like prepared cards nesting one card within the faces of another. `allCardsByName` remains available for searching purposes.
* Migrates a bunch of CardDB's overloaded methods up to the interface as default methods.
* Removes the `noAlt` versions of the `getAllCards`/`getUniqueCards` methods when the name is not a parameter. The only real distinction between the two previously was that one version contained some unintended duplicate entries or was otherwise slightly wrong.
* Splits the `rulesByName` into `rulesByPrimaryName` and `rulesByAltName`. Allows a `noAlt` variant of `getRules`, though I chose to implement it as a parameter, which I might do for the others sometime too. 
* Switches `uniqueCardsByName` to `uniqueCardsByRules`, so that Emeritus of Ideation can no longer be chosen as the default printing of Ancestral Recall. 
* Swaps a few instances of name lookup to rules lookup. Going forward: if you want to search up other prints of a card, `getAllCards(CardRules)` or `getAllCards(PaperCard)` are preferable to `getAllCards(card.getName())`.