### PR TITLE
Lobby update fixes and null-card guard in CMatchUI.updateCards

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
@@ -357,6 +357,9 @@ public class VLobby implements ILobbyView {
                 playerChangeListener.update(i, UpdateLobbyPlayerEvent.isReadyUpdate(false));
             }
         }
+        if (playerChangeListener != null) {
+            playerChangeListener.update(index, UpdateLobbyPlayerEvent.devModeUpdate(getPlayerPanel(index).isDevMode()));
+        }
         changePlayerFocus(index);
     }
     void firePlayerChangeListener(final int index) {

--- a/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
@@ -342,14 +342,20 @@ public class VLobby implements ILobbyView {
             return;
         }
 
-        firePlayerChangeListener(index);
+        if (playerChangeListener != null) {
+            playerChangeListener.update(index, UpdateLobbyPlayerEvent.isReadyUpdate(ready));
+        }
         changePlayerFocus(index);
     }
     void setDevMode(final int index) {
         // clear ready for everyone
         for (int i = 0; i < activePlayersNum; i++) {
-            getPlayerPanel(i).setIsReady(false);
-            firePlayerChangeListener(i);
+            final PlayerPanel panel = getPlayerPanel(i);
+            final boolean wasReady = panel.isReady();
+            panel.setIsReady(false);
+            if (wasReady && playerChangeListener != null) {
+                playerChangeListener.update(i, UpdateLobbyPlayerEvent.isReadyUpdate(false));
+            }
         }
         changePlayerFocus(index);
     }
@@ -387,7 +393,6 @@ public class VLobby implements ILobbyView {
                 panel.getPlayerName(),
                 panel.getAvatarIndex(), -1 /*TODO panel.getSleeveIndex()*/,
                 panel.getTeam(), panel.isArchenemy(),
-                panel.isReady(),
                 panel.isDevMode(),
                 panel.getAiOptions(),
                 panel.getAiProfile());

--- a/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
@@ -348,6 +348,12 @@ public class VLobby implements ILobbyView {
         changePlayerFocus(index);
     }
     void setDevMode(final int index) {
+        // Push dev mode first: subsequent ready-clear broadcasts trigger view.update,
+        // which re-syncs panel.isDevMode from slot.isDevMode. If the slot is stale
+        // at that point the dev mode checkbox flips back visually.
+        if (playerChangeListener != null) {
+            playerChangeListener.update(index, UpdateLobbyPlayerEvent.devModeUpdate(getPlayerPanel(index).isDevMode()));
+        }
         // clear ready for everyone
         for (int i = 0; i < activePlayersNum; i++) {
             final PlayerPanel panel = getPlayerPanel(i);
@@ -356,9 +362,6 @@ public class VLobby implements ILobbyView {
             if (wasReady && playerChangeListener != null) {
                 playerChangeListener.update(i, UpdateLobbyPlayerEvent.isReadyUpdate(false));
             }
-        }
-        if (playerChangeListener != null) {
-            playerChangeListener.update(index, UpdateLobbyPlayerEvent.devModeUpdate(getPlayerPanel(index).isDevMode()));
         }
         changePlayerFocus(index);
     }

--- a/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
@@ -617,8 +617,10 @@ public final class CMatchUI
     @Override
     public void updateCards(final Iterable<CardView> cards) {
         for (final CardView c : cards) {
+            // Null can flow in from a remote-side event whose IdRef failed to resolve in the tracker.
+            if (c == null) { continue; }
             final ZoneType zone = c.getZone();
-            if (zone == null) { return; }
+            if (zone == null) { continue; }
 
             switch (zone) {
             case Battlefield:

--- a/forge-gui-mobile/src/forge/screens/constructed/LobbyScreen.java
+++ b/forge-gui-mobile/src/forge/screens/constructed/LobbyScreen.java
@@ -844,6 +844,9 @@ public abstract class LobbyScreen extends LaunchScreen implements ILobbyView {
                 playerChangeListener.update(i, UpdateLobbyPlayerEvent.isReadyUpdate(false));
             }
         }
+        if (playerChangeListener != null) {
+            playerChangeListener.update(index, UpdateLobbyPlayerEvent.devModeUpdate(playerPanels.get(index).isDevMode()));
+        }
     }
     void firePlayerChangeListener(final int index) {
         if (playerChangeListener != null) {

--- a/forge-gui-mobile/src/forge/screens/constructed/LobbyScreen.java
+++ b/forge-gui-mobile/src/forge/screens/constructed/LobbyScreen.java
@@ -834,6 +834,12 @@ public abstract class LobbyScreen extends LaunchScreen implements ILobbyView {
         firePlayerChangeListener(index);
     }
     void setDevMode(final int index) {
+        // Push dev mode first: subsequent ready-clear broadcasts trigger view.update,
+        // which re-syncs panel.isDevMode from slot.isDevMode. If the slot is stale
+        // at that point the dev mode switch flips back visually.
+        if (playerChangeListener != null) {
+            playerChangeListener.update(index, UpdateLobbyPlayerEvent.devModeUpdate(playerPanels.get(index).isDevMode()));
+        }
         int playerCount = lobby.getNumberOfSlots();
         // clear ready for everyone
         for (int i = 0; i < playerCount; i++) {
@@ -843,9 +849,6 @@ public abstract class LobbyScreen extends LaunchScreen implements ILobbyView {
             if (wasReady && playerChangeListener != null) {
                 playerChangeListener.update(i, UpdateLobbyPlayerEvent.isReadyUpdate(false));
             }
-        }
-        if (playerChangeListener != null) {
-            playerChangeListener.update(index, UpdateLobbyPlayerEvent.devModeUpdate(playerPanels.get(index).isDevMode()));
         }
     }
     void firePlayerChangeListener(final int index) {

--- a/forge-gui-mobile/src/forge/screens/constructed/LobbyScreen.java
+++ b/forge-gui-mobile/src/forge/screens/constructed/LobbyScreen.java
@@ -838,8 +838,11 @@ public abstract class LobbyScreen extends LaunchScreen implements ILobbyView {
         // clear ready for everyone
         for (int i = 0; i < playerCount; i++) {
             final PlayerPanel panel = playerPanels.get(i);
+            final boolean wasReady = panel.isReady();
             panel.setIsReady(false);
-            firePlayerChangeListener(i);
+            if (wasReady && playerChangeListener != null) {
+                playerChangeListener.update(i, UpdateLobbyPlayerEvent.isReadyUpdate(false));
+            }
         }
     }
     void firePlayerChangeListener(final int index) {
@@ -884,7 +887,6 @@ public abstract class LobbyScreen extends LaunchScreen implements ILobbyView {
                 panel.getSleeveIndex(),
                 panel.getTeam(),
                 panel.isArchenemy(),
-                panel.isReady(),
                 panel.isDevMode(),
                 panel.getAiOptions(),
                 null); // TODO implement AI profile support for mobile

--- a/forge-gui-mobile/src/forge/screens/constructed/PlayerPanel.java
+++ b/forge-gui-mobile/src/forge/screens/constructed/PlayerPanel.java
@@ -1000,7 +1000,9 @@ public class PlayerPanel extends FContainer {
     public void setIsReady(boolean isReady0) {
         if (isReady == isReady0) { return; }
         isReady = isReady0;
-        if (allowNetworking) {
+        // humanAiSwitch doubles as the Open/AI selector for host-controlled opponent slots;
+        // only drive it from the ready field when the switch is actually showing Ready/NotReady.
+        if (allowNetworking && !isOpenAiSlotToggle()) {
             humanAiSwitch.setToggled(isReady);
         }
     }

--- a/forge-gui/src/main/java/forge/gamemodes/match/LobbySlot.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/LobbySlot.java
@@ -6,7 +6,10 @@ import forge.deck.Deck;
 import forge.gamemodes.net.event.UpdateLobbyPlayerEvent;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.IntConsumer;
 
 public final class LobbySlot implements Serializable {
     private static final long serialVersionUID = 9203252798721142264L;
@@ -41,68 +44,43 @@ public final class LobbySlot implements Serializable {
 
     boolean apply(final UpdateLobbyPlayerEvent data) {
         boolean changed = false;
-        if (data.getType() != null) {
-            setType(data.getType());
-            changed = true;
-        }
-        if (data.getName() != null) {
-            setName(data.getName());
-            changed = true;
-        }
-        if (data.getAvatarIndex() != -1) {
-            setAvatarIndex(data.getAvatarIndex());
-            changed = true;
-        }
-        if (data.getSleeveIndex() != -1) {
-            setSleeveIndex(data.getSleeveIndex());
-            changed = true;
-        }
-        if (data.getTeam() != -1) {
-            setTeam(data.getTeam());
-            changed = true;
-        }
-        if (data.getArchenemy() != null) {
-            setIsArchenemy(data.getArchenemy());
-            changed = true;
-        }
-        if (data.getReady() != null) {
-            setIsReady(data.getReady());
-            changed = true;
-        }
-        if (data.getDevMode() != null) {
-            setIsDevMode(data.getDevMode());
-            changed = true;
-        }
-        if (data.getAiOptions() != null) {
-            setAiOptions(data.getAiOptions());
-            changed = true;
-        }
+        changed |= setIfChanged(data.getType(),            this.type,           this::setType);
+        changed |= setIfChanged(data.getName(),            this.name,           this::setName);
+        changed |= setIntIfChanged(data.getAvatarIndex(),  this.avatarIndex,    this::setAvatarIndex);
+        changed |= setIntIfChanged(data.getSleeveIndex(),  this.sleeveIndex,    this::setSleeveIndex);
+        changed |= setIntIfChanged(data.getTeam(),         this.team,           this::setTeam);
+        changed |= setIfChanged(data.getArchenemy(),       this.isArchenemy,    this::setIsArchenemy);
+        changed |= setIfChanged(data.getReady(),           this.isReady,        this::setIsReady);
+        changed |= setIfChanged(data.getDevMode(),         this.isDevMode,      this::setIsDevMode);
+        changed |= setIfChanged(data.getAiOptions(),       this.aiOptions,      this::setAiOptions);
+        changed |= setIfChanged(data.getSchemeDeckName(),  this.SchemeDeckName, this::setSchemeDeckName);
+        changed |= setIfChanged(data.getAvatarVanguard(),  this.AvatarVanguard, this::setAvatarVanguard);
+        changed |= setIfChanged(data.getPlanarDeckName(),  this.PlanarDeckName, this::setPlanarDeckName);
+        changed |= setIfChanged(data.getDeckName(),        this.DeckName,       this::setDeckName);
+
         final Deck oldDeck = getDeck();
         if (data.getDeck() != null) {
             setDeck(data.getDeck());
         } else if (oldDeck != null && data.getSection() != null && data.getCards() != null) {
             oldDeck.putSection(data.getSection(), data.getCards());
         }
-        if (data.getSchemeDeckName() != null) {
-            setSchemeDeckName(data.getSchemeDeckName());
-            changed = true;
-        }
-        if (data.getAvatarVanguard() != null) {
-            setAvatarVanguard(data.getAvatarVanguard());
-            changed = true;
-        }
-        if (data.getPlanarDeckName() != null) {
-            setPlanarDeckName(data.getPlanarDeckName());
-            changed = true;
-        }
-        if (data.getDeckName() != null) {
-            setDeckName(data.getDeckName());
-            changed = true;
-        }
         if (data.getAiProfile() != null) {
             setAiProfile(data.getAiProfile());
         }
         return changed;
+    }
+
+    private static <T> boolean setIfChanged(T newValue, T oldValue, Consumer<T> setter) {
+        if (newValue == null || Objects.equals(newValue, oldValue)) return false;
+        setter.accept(newValue);
+        return true;
+    }
+
+    // -1 is the "field absent" sentinel for ints in UpdateLobbyPlayerEvent.
+    private static boolean setIntIfChanged(int newValue, int oldValue, IntConsumer setter) {
+        if (newValue == -1 || newValue == oldValue) return false;
+        setter.accept(newValue);
+        return true;
     }
 
     public LobbySlotType getType() {

--- a/forge-gui/src/main/java/forge/gamemodes/net/NetConnectUtil.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/NetConnectUtil.java
@@ -70,10 +70,9 @@ public class NetConnectUtil {
             @Override
             public void update(final int slot, final LobbySlotType type) {}
         });
-        view.setPlayerChangeListener((index, event) -> {
-            server.updateSlot(index, event);
-            server.updateLobbyState();
-        });
+        // updateSlot already routes through the IUpdateable listener above, which calls
+        // updateLobbyState; calling it again here would broadcast a duplicate LobbyUpdateEvent.
+        view.setPlayerChangeListener(server::updateSlot);
 
         server.setLobbyListener(new ILobbyListener() {
             @Override

--- a/forge-gui/src/main/java/forge/gamemodes/net/event/UpdateLobbyPlayerEvent.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/event/UpdateLobbyPlayerEvent.java
@@ -32,8 +32,8 @@ public final class UpdateLobbyPlayerEvent implements NetEvent {
     private String aiProfile = null;
 
 
-    public static UpdateLobbyPlayerEvent create(final LobbySlotType type, final String name, final int avatarIndex, final int sleeveIndex, final int team, final boolean isArchenemy, final boolean isReady, final boolean isDevMode, final Set<AIOption> aiOptions, final String aiProfile) {
-        return new UpdateLobbyPlayerEvent(type, name, avatarIndex, sleeveIndex, team, isArchenemy, isReady, isDevMode, aiOptions, aiProfile);
+    public static UpdateLobbyPlayerEvent create(final LobbySlotType type, final String name, final int avatarIndex, final int sleeveIndex, final int team, final boolean isArchenemy, final boolean isDevMode, final Set<AIOption> aiOptions, final String aiProfile) {
+        return new UpdateLobbyPlayerEvent(type, name, avatarIndex, sleeveIndex, team, isArchenemy, isDevMode, aiOptions, aiProfile);
     }
     public static UpdateLobbyPlayerEvent deckUpdate(final Deck deck) {
         return new UpdateLobbyPlayerEvent(deck);
@@ -109,7 +109,6 @@ public final class UpdateLobbyPlayerEvent implements NetEvent {
             final int sleeveIndex,
             final int team,
             final boolean isArchenemy,
-            final boolean isReady,
             final boolean isDevMode,
             final Set<AIOption> aiOptions,
             final String aiProfile) {
@@ -119,7 +118,6 @@ public final class UpdateLobbyPlayerEvent implements NetEvent {
         this.sleeveIndex = sleeveIndex;
         this.team = team;
         this.isArchenemy = isArchenemy;
-        this.isReady = isReady;
         this.isDevMode = isDevMode;
         this.aiOptions = aiOptions;
         this.aiProfile = aiProfile;

--- a/forge-gui/src/main/java/forge/gamemodes/net/event/UpdateLobbyPlayerEvent.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/event/UpdateLobbyPlayerEvent.java
@@ -67,6 +67,11 @@ public final class UpdateLobbyPlayerEvent implements NetEvent {
     public static UpdateLobbyPlayerEvent isReadyUpdate(final boolean isReady) {
         return new UpdateLobbyPlayerEvent(isReady);
     }
+    public static UpdateLobbyPlayerEvent devModeUpdate(final boolean isDevMode) {
+        final UpdateLobbyPlayerEvent event = new UpdateLobbyPlayerEvent();
+        event.isDevMode = isDevMode;
+        return event;
+    }
     public static UpdateLobbyPlayerEvent teamUpdate(int team) {
         return new UpdateLobbyPlayerEvent(team);
     }

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
@@ -86,7 +86,6 @@ public final class FServerManager implements IHasForgeLog {
     });
 
     private final Map<Integer, RemoteClientGuiGame> playerGuis = new ConcurrentHashMap<>(); // Store RemoteClientGuiGame instances for reuse
-    private final Map<Integer, Boolean> lastBroadcastReadyState = new ConcurrentHashMap<>(); // dedupe ready-state chat broadcasts
 
     // Network byte tracking for monitoring actual bandwidth usage
     private final forge.gamemodes.net.NetworkByteTracker byteTracker =
@@ -401,15 +400,11 @@ public final class FServerManager implements IHasForgeLog {
         localLobby.applyToSlot(index, event);
 
         if (event.getReady() != null) {
-            broadcastReadyState(index, localLobby.getSlot(index).getName(), event.getReady());
+            broadcastReadyState(localLobby.getSlot(index).getName(), event.getReady());
         }
     }
 
-    private void broadcastReadyState(int index, String playerName, boolean isReady) {
-        Boolean prev = lastBroadcastReadyState.put(index, isReady);
-        if (prev != null && prev == isReady) {
-            return; // no transition; skip duplicate broadcast
-        }
+    private void broadcastReadyState(String playerName, boolean isReady) {
         int readyCount = 0;
         int totalPlayers = 0;
         for (int i = 0; i < localLobby.getNumberOfSlots(); i++) {
@@ -936,7 +931,7 @@ public final class FServerManager implements IHasForgeLog {
                     }
                 }
                 if (event.getReady() != null) {
-                    broadcastReadyState(client.getIndex(), client.getUsername(), event.getReady());
+                    broadcastReadyState(client.getUsername(), event.getReady());
                 }
                 // Return to prevent duplicate processing by LobbyInputHandler
                 return;

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
@@ -86,6 +86,7 @@ public final class FServerManager implements IHasForgeLog {
     });
 
     private final Map<Integer, RemoteClientGuiGame> playerGuis = new ConcurrentHashMap<>(); // Store RemoteClientGuiGame instances for reuse
+    private final Map<Integer, Boolean> lastBroadcastReadyState = new ConcurrentHashMap<>(); // dedupe ready-state chat broadcasts
 
     // Network byte tracking for monitoring actual bandwidth usage
     private final forge.gamemodes.net.NetworkByteTracker byteTracker =
@@ -400,11 +401,15 @@ public final class FServerManager implements IHasForgeLog {
         localLobby.applyToSlot(index, event);
 
         if (event.getReady() != null) {
-            broadcastReadyState(localLobby.getSlot(index).getName(), event.getReady());
+            broadcastReadyState(index, localLobby.getSlot(index).getName(), event.getReady());
         }
     }
 
-    private void broadcastReadyState(String playerName, boolean isReady) {
+    private void broadcastReadyState(int index, String playerName, boolean isReady) {
+        Boolean prev = lastBroadcastReadyState.put(index, isReady);
+        if (prev != null && prev == isReady) {
+            return; // no transition; skip duplicate broadcast
+        }
         int readyCount = 0;
         int totalPlayers = 0;
         for (int i = 0; i < localLobby.getNumberOfSlots(); i++) {
@@ -931,7 +936,7 @@ public final class FServerManager implements IHasForgeLog {
                     }
                 }
                 if (event.getReady() != null) {
-                    broadcastReadyState(client.getUsername(), event.getReady());
+                    broadcastReadyState(client.getIndex(), client.getUsername(), event.getReady());
                 }
                 // Return to prevent duplicate processing by LobbyInputHandler
                 return;


### PR DESCRIPTION
- **`LobbySlot.apply`**: refactor the per-field `if (data.getX() != null) { setX(...); changed = true; }` cascade into `setIfChanged` / `setIntIfChanged` helpers that skip the write (and the `changed` flag) when the incoming value already matches the current one. Also routes `SchemeDeckName`, `AvatarVanguard`, `PlanarDeckName`, and `DeckName` through the same path; these were previously updated but never flipped `changed`, so listeners weren't notified.
- **`NetConnectUtil`**: drop the explicit `server.updateLobbyState()` call from the player-change listener. `server.updateSlot()` already routes through `updateLobbyState()` via the `IUpdateable` listener installed above, so the explicit call broadcast a duplicate `LobbyUpdateEvent` to every client on every slot change.
- **`FServerManager.broadcastReadyState`**: dedupe by slot index, tracking the last broadcast value per slot. Without this, `UpdateLobbyPlayerEvent`s with the same `getReady()` value (which fire routinely during normal lobby flow) repeated the chat line "Player X is ready" multiple times in a row.
- **`CMatchUI.updateCards`**: change `return` -> `continue` on null zone, and add a null check on the `CardView` itself. Null can flow in from a remote-side event whose IdRef failed to resolve in the tracker; without these guards the loop bailed out and dropped every later card in the same update batch from the visual update.