### PR TITLE
Improve AI restraint for costly land destruction abilities

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/DestroyAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DestroyAi.java
@@ -19,6 +19,9 @@ import forge.game.zone.ZoneType;
 import forge.util.collect.FCollectionView;
 
 public class DestroyAi extends SpellAbilityAi {
+    private static final String LOGIC_GHOST_QUARTER = "GhostQuarter";
+    private static final String LOGIC_LAND_FOR_LAND = "LandForLand";
+
     @Override
     public AiAbilityDecision chkDrawback(Player ai, SpellAbility sa) {
         return checkApiLogic(ai, sa);
@@ -229,9 +232,10 @@ public class DestroyAi extends SpellAbilityAi {
                 } else if (CardLists.getNotType(list, "Land").isEmpty()) {
                     choice = ComputerUtilCard.getBestLandToRemoveAI(ai, list, sa);
 
-                    if ("LandForLand".equals(logic) || "GhostQuarter".equals(logic)) {
-                        // Strip Mine, Wasteland - cut short if the relevant logic fails
-                        if (!doLandForLandRemovalLogic(sa, ai, choice, logic)) {
+                    String landRemovalLogic = getLandRemovalLogic(sa, logic);
+                    if (landRemovalLogic != null) {
+                        // Strip Mine, Wasteland, Dust Bowl, and similar lands.
+                        if (!doLandForLandRemovalLogic(sa, ai, choice, landRemovalLogic)) {
                             return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
                         }
                     }
@@ -298,6 +302,40 @@ public class DestroyAi extends SpellAbilityAi {
             }
         }
         return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+    }
+
+    private String getLandRemovalLogic(SpellAbility sa, String logic) {
+        if (LOGIC_GHOST_QUARTER.equals(logic)) {
+            return LOGIC_GHOST_QUARTER;
+        }
+        if (LOGIC_LAND_FOR_LAND.equals(logic) || isLandDestroyAbilityFromLand(sa)) {
+            return LOGIC_LAND_FOR_LAND;
+        }
+        return null;
+    }
+
+    private boolean isLandDestroyAbilityFromLand(SpellAbility sa) {
+        Cost cost = sa.getPayCosts();
+        return sa.isActivatedAbility()
+                && !sa.isSpell()
+                && sa.getHostCard().isLand()
+                && cost != null
+                && (cost.hasTapCost() || cost.hasManaCost()
+                        || cost.hasSpecificCostType(CostSacrifice.class));
+    }
+
+    private boolean hasNonSourceLandSacrificeCost(SpellAbility sa) {
+        Cost cost = sa.getPayCosts();
+        if (cost == null) {
+            return false;
+        }
+        for (CostPart part : cost.getCostParts()) {
+            if (part instanceof CostSacrifice && !part.payCostFromSource()
+                    && part.getType().contains("Land")) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
@@ -440,6 +478,15 @@ public class DestroyAi extends SpellAbilityAi {
         boolean tempoCheck = numLandsOTB >= amountNoTempoCheck
                 || ((numLandsInHand >= amountLandsInHand || isHighPriority) && ((numLandsInHand + numLandsOTB >= amountNoTimingCheck) || timingCheck));
 
+        // Dust Bowl-style costs are not a simple land-for-land exchange: the
+        // AI spends mana, taps a mana source, and sacrifices another land. Only
+        // accept that rate for a real lock or a high-priority land.
+        int manaCost = sa.getPayCosts() == null ? 0 : sa.getPayCosts().getTotalMana().getCMC();
+        if ((hasNonSourceLandSacrificeCost(sa) || manaCost >= 2)
+                && !highPriorityTgt && !canManaLock && !canColorLock) {
+            return false;
+        }
+
         // Tectonic Edge, Strip Mine, and Wasteland should not cash in a large
         // share of the AI's own mana base for a merely medium utility target.
         boolean sacrificesSourceLand = sa.getHostCard().isLand()
@@ -454,7 +501,7 @@ public class DestroyAi extends SpellAbilityAi {
 
         // For Ghost Quarter, only use it if you have either more lands in play than your opponent
         // or the same number of lands but an extra land in hand (otherwise the AI plays too suboptimally)
-        if ("GhostQuarter".equals(logic)) {
+        if (LOGIC_GHOST_QUARTER.equals(logic)) {
             return tempoCheck && (numLandsOTB > oppLands.size() || (numLandsOTB == oppLands.size() && numLandsInHand > 0));
         } else {
             return tempoCheck;

--- a/forge-ai/src/main/java/forge/ai/ability/DestroyAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DestroyAi.java
@@ -20,7 +20,6 @@ import forge.util.collect.FCollectionView;
 
 public class DestroyAi extends SpellAbilityAi {
     private static final String LOGIC_GHOST_QUARTER = "GhostQuarter";
-    private static final String LOGIC_LAND_FOR_LAND = "LandForLand";
 
     @Override
     public AiAbilityDecision chkDrawback(Player ai, SpellAbility sa) {
@@ -310,7 +309,6 @@ public class DestroyAi extends SpellAbilityAi {
     private boolean isLandDestroyAbilityFromLand(SpellAbility sa) {
         Cost cost = sa.getPayCosts();
         return sa.isActivatedAbility()
-                && !sa.isSpell()
                 && sa.getHostCard().getOriginalType().isLand()
                 && cost != null
                 && (cost.hasTapCost() || cost.hasManaCost()

--- a/forge-ai/src/main/java/forge/ai/ability/DestroyAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/DestroyAi.java
@@ -232,10 +232,9 @@ public class DestroyAi extends SpellAbilityAi {
                 } else if (CardLists.getNotType(list, "Land").isEmpty()) {
                     choice = ComputerUtilCard.getBestLandToRemoveAI(ai, list, sa);
 
-                    String landRemovalLogic = getLandRemovalLogic(sa, logic);
-                    if (landRemovalLogic != null) {
+                    if (shouldApplyLandRemovalLogic(sa, logic)) {
                         // Strip Mine, Wasteland, Dust Bowl, and similar lands.
-                        if (!doLandForLandRemovalLogic(sa, ai, choice, landRemovalLogic)) {
+                        if (!doLandForLandRemovalLogic(sa, ai, choice, logic)) {
                             return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
                         }
                     }
@@ -304,21 +303,15 @@ public class DestroyAi extends SpellAbilityAi {
         return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
     }
 
-    private String getLandRemovalLogic(SpellAbility sa, String logic) {
-        if (LOGIC_GHOST_QUARTER.equals(logic)) {
-            return LOGIC_GHOST_QUARTER;
-        }
-        if (LOGIC_LAND_FOR_LAND.equals(logic) || isLandDestroyAbilityFromLand(sa)) {
-            return LOGIC_LAND_FOR_LAND;
-        }
-        return null;
+    private boolean shouldApplyLandRemovalLogic(SpellAbility sa, String logic) {
+        return LOGIC_GHOST_QUARTER.equals(logic) || isLandDestroyAbilityFromLand(sa);
     }
 
     private boolean isLandDestroyAbilityFromLand(SpellAbility sa) {
         Cost cost = sa.getPayCosts();
         return sa.isActivatedAbility()
                 && !sa.isSpell()
-                && sa.getHostCard().isLand()
+                && sa.getHostCard().getOriginalType().isLand()
                 && cost != null
                 && (cost.hasTapCost() || cost.hasManaCost()
                         || cost.hasSpecificCostType(CostSacrifice.class));

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/DestroyAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/DestroyAiTest.java
@@ -1,0 +1,70 @@
+package forge.ai.ability;
+
+import forge.ai.AITest;
+import forge.ai.SpellApiToAi;
+import forge.game.Game;
+import forge.game.ability.ApiType;
+import forge.game.card.Card;
+import forge.game.phase.PhaseType;
+import forge.game.player.Player;
+import forge.game.spellability.SpellAbility;
+import forge.game.zone.ZoneType;
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+public class DestroyAiTest extends AITest {
+
+    @Test
+    public void testDustBowlDoesNotSpendExtraLandOnLowPriorityLand() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+
+        Card dustBowl = addCard("Dust Bowl", ai);
+        addCards("Forest", 5, ai);
+        addCardToZone("Forest", ai, ZoneType.Hand);
+        addCards("Forest", 5, opponent);
+        addCard("Tranquil Cove", opponent);
+
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN1, ai);
+        game.getAction().checkStateEffects(true);
+
+        AssertJUnit.assertFalse("AI should not spend Dust Bowl plus another land on a low-priority nonbasic",
+                canPlayDestroyAbility(ai, dustBowl));
+    }
+
+    @Test
+    public void testDustBowlCanAnswerHighPriorityLand() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+
+        Card dustBowl = addCard("Dust Bowl", ai);
+        addCards("Forest", 5, ai);
+        addCardToZone("Forest", ai, ZoneType.Hand);
+        addCards("Forest", 5, opponent);
+        addCards("Grizzly Bears", 3, opponent);
+        addCard("Gaea's Cradle", opponent);
+
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN1, ai);
+        game.getAction().checkStateEffects(true);
+
+        AssertJUnit.assertTrue("AI should still spend Dust Bowl on a high-priority land",
+                canPlayDestroyAbility(ai, dustBowl));
+    }
+
+    private boolean canPlayDestroyAbility(Player ai, Card source) {
+        SpellAbility sa = findDestroyAbility(source);
+        sa.setActivatingPlayer(ai);
+        return SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay();
+    }
+
+    private SpellAbility findDestroyAbility(Card card) {
+        for (SpellAbility sa : card.getSpellAbilities()) {
+            if (sa.getApi() == ApiType.Destroy) {
+                return sa;
+            }
+        }
+        return null;
+    }
+}

--- a/forge-gui/res/ai/Cautious.ai
+++ b/forge-gui/res/ai/Cautious.ai
@@ -163,8 +163,8 @@ ALWAYS_COPY_SPELL_IF_CMC_DIFF=4
 PRIORITY_REDUCTION_FOR_STORM_SPELLS=9
 MIN_COUNT_FOR_STORM_SPELLS=1
 
-# Logic for Strip Mine, Wasteland, Ghost Quarter and other similar sac-destroy lands marked with
-# AILogic$ LandForLand or GhostQuarter.
+# Logic for Strip Mine, Wasteland, and other similar sac-destroy land cards.
+# Ghost Quarter uses AILogic$ GhostQuarter for its replacement-land caution.
 STRIPMINE_MIN_LANDS_IN_HAND_TO_ACTIVATE=1
 STRIPMINE_MIN_LANDS_FOR_NO_TIMING_CHECK=9999
 STRIPMINE_MIN_LANDS_OTB_FOR_NO_TEMPO_CHECK=8

--- a/forge-gui/res/ai/Default.ai
+++ b/forge-gui/res/ai/Default.ai
@@ -163,8 +163,8 @@ ALWAYS_COPY_SPELL_IF_CMC_DIFF=2
 PRIORITY_REDUCTION_FOR_STORM_SPELLS=9
 MIN_COUNT_FOR_STORM_SPELLS=1
 
-# Logic for Strip Mine, Wasteland, Ghost Quarter and other similar sac-destroy lands marked with
-# AILogic$ LandForLand or GhostQuarter.
+# Logic for Strip Mine, Wasteland, and other similar sac-destroy land cards.
+# Ghost Quarter uses AILogic$ GhostQuarter for its replacement-land caution.
 STRIPMINE_MIN_LANDS_IN_HAND_TO_ACTIVATE=1
 STRIPMINE_MIN_LANDS_FOR_NO_TIMING_CHECK=9999
 STRIPMINE_MIN_LANDS_OTB_FOR_NO_TEMPO_CHECK=6

--- a/forge-gui/res/ai/Experimental.ai
+++ b/forge-gui/res/ai/Experimental.ai
@@ -163,8 +163,8 @@ ALWAYS_COPY_SPELL_IF_CMC_DIFF=2
 PRIORITY_REDUCTION_FOR_STORM_SPELLS=9
 MIN_COUNT_FOR_STORM_SPELLS=1
 
-# Logic for Strip Mine, Wasteland, Ghost Quarter and other similar sac-destroy lands marked with
-# AILogic$ LandForLand or GhostQuarter.
+# Logic for Strip Mine, Wasteland, and other similar sac-destroy land cards.
+# Ghost Quarter uses AILogic$ GhostQuarter for its replacement-land caution.
 STRIPMINE_MIN_LANDS_IN_HAND_TO_ACTIVATE=1
 STRIPMINE_MIN_LANDS_FOR_NO_TIMING_CHECK=9999
 STRIPMINE_MIN_LANDS_OTB_FOR_NO_TEMPO_CHECK=6

--- a/forge-gui/res/ai/Reckless.ai
+++ b/forge-gui/res/ai/Reckless.ai
@@ -163,8 +163,8 @@ ALWAYS_COPY_SPELL_IF_CMC_DIFF=1
 PRIORITY_REDUCTION_FOR_STORM_SPELLS=0
 MIN_COUNT_FOR_STORM_SPELLS=0
 
-# Logic for Strip Mine, Wasteland, Ghost Quarter and other similar sac-destroy lands marked with
-# AILogic$ LandForLand or GhostQuarter.
+# Logic for Strip Mine, Wasteland, and other similar sac-destroy land cards.
+# Ghost Quarter uses AILogic$ GhostQuarter for its replacement-land caution.
 STRIPMINE_MIN_LANDS_IN_HAND_TO_ACTIVATE=1
 STRIPMINE_MIN_LANDS_FOR_NO_TIMING_CHECK=3
 STRIPMINE_MIN_LANDS_OTB_FOR_NO_TEMPO_CHECK=4

--- a/forge-gui/res/cardsfolder/s/strip_mine.txt
+++ b/forge-gui/res/cardsfolder/s/strip_mine.txt
@@ -2,5 +2,5 @@ Name:Strip Mine
 ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
-A:AB$ Destroy | ValidTgts$ Land | Cost$ T Sac<1/CARDNAME> | AILogic$ LandForLand | SpellDescription$ Destroy target land.
+A:AB$ Destroy | ValidTgts$ Land | Cost$ T Sac<1/CARDNAME> | SpellDescription$ Destroy target land.
 Oracle:{T}: Add {C}.\n{T}, Sacrifice Strip Mine: Destroy target land.

--- a/forge-gui/res/cardsfolder/t/tectonic_edge.txt
+++ b/forge-gui/res/cardsfolder/t/tectonic_edge.txt
@@ -2,7 +2,7 @@ Name:Tectonic Edge
 ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
-A:AB$ Destroy | ValidTgts$ Land.nonBasic | TgtPrompt$ Select target nonbasic land. | Cost$ 1 T Sac<1/CARDNAME> | CheckSVar$ X | SVarCompare$ GE4 | AILogic$ LandForLand | SpellDescription$ Destroy target nonbasic land. Activate only if an opponent controls four or more lands.
+A:AB$ Destroy | ValidTgts$ Land.nonBasic | TgtPrompt$ Select target nonbasic land. | Cost$ 1 T Sac<1/CARDNAME> | CheckSVar$ X | SVarCompare$ GE4 | SpellDescription$ Destroy target nonbasic land. Activate only if an opponent controls four or more lands.
 SVar:X:PlayerCountOpponents$HighestValid Land.YouCtrl
 AI:RemoveDeck:Random
 Oracle:{T}: Add {C}.\n{1}, {T}, Sacrifice Tectonic Edge: Destroy target nonbasic land. Activate only if an opponent controls four or more lands.

--- a/forge-gui/res/cardsfolder/w/wasteland.txt
+++ b/forge-gui/res/cardsfolder/w/wasteland.txt
@@ -2,5 +2,5 @@ Name:Wasteland
 ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
-A:AB$ Destroy | ValidTgts$ Land.nonBasic | TgtPrompt$ Select target nonbasic land. | Cost$ T Sac<1/CARDNAME> | AILogic$ LandForLand | SpellDescription$ Destroy target nonbasic land.
+A:AB$ Destroy | ValidTgts$ Land.nonBasic | TgtPrompt$ Select target nonbasic land. | Cost$ T Sac<1/CARDNAME> | SpellDescription$ Destroy target nonbasic land.
 Oracle:{T}: Add {C}.\n{T}, Sacrifice Wasteland: Destroy target nonbasic land.


### PR DESCRIPTION
This updates DestroyAi so land-destruction abilities from lands are evaluated with the existing Strip Mine-style tempo logic even when the card script does not explicitly set AILogic.

The motivating case is Dust Bowl, whose script has no AILogic tag. Previously the AI could treat it like ordinary land removal and repeatedly spend {3}, tap Dust Bowl, and sacrifice another land to destroy low-impact nonbasic lands. With this change, Dust Bowl-like abilities are only accepted at that rate when the target is meaningfully valuable, contributes to a mana/color lock, or otherwise passes the existing land-destruction heuristics.

Changes:

- Added land-removal logic classification for GhostQuarter, LandForLand, and land-originated activated land-destroy abilities.
- Added a stricter cost gate for Dust Bowl-style effects that require extra mana or sacrificing another land.
- Preserved Ghost Quarter’s special caution, since the opponent may replace the destroyed land.
- Added regression tests covering Dust Bowl refusing low-priority nonbasics while still answering high-priority lands like Gaea’s Cradle.

Validation:

mvn -pl forge-gui-desktop -am -Dtest=forge.ai.ability.DestroyAiTest -Dsurefire.failIfNoSpecifiedTests=false test