### PR TITLE
CounterCustomType: extra fallback CounterType

### DIFF
--- a/forge-game/src/main/java/forge/game/card/CounterCustomType.java
+++ b/forge-game/src/main/java/forge/game/card/CounterCustomType.java
@@ -19,7 +19,11 @@ public record CounterCustomType(String keyword) implements CounterType {
     public static Set<CounterType> getValues() {
         return new LinkedHashSet<CounterType>(sMap.values());
     }
-
+    
+    @Override
+    public String toString() {
+        return keyword;
+    }
 
     public String getName() {
         return keyword;

--- a/forge-game/src/main/java/forge/game/card/CounterCustomType.java
+++ b/forge-game/src/main/java/forge/game/card/CounterCustomType.java
@@ -19,4 +19,9 @@ public record CounterCustomType(String keyword) implements CounterType {
     public static Set<CounterType> getValues() {
         return new LinkedHashSet<CounterType>(sMap.values());
     }
+
+
+    public String getName() {
+        return keyword;
+    }
 }

--- a/forge-game/src/main/java/forge/game/card/CounterCustomType.java
+++ b/forge-game/src/main/java/forge/game/card/CounterCustomType.java
@@ -1,0 +1,22 @@
+package forge.game.card;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.LinkedHashSet;
+
+import com.google.common.collect.Maps;
+
+public record CounterCustomType(String keyword) implements CounterType {
+    private static Map<String, CounterCustomType> sMap = Maps.newHashMap();
+
+    public static CounterCustomType get(String s) {
+        if (!sMap.containsKey(s)) {
+            sMap.put(s, new CounterCustomType(s));
+        }
+        return sMap.get(s);
+    }
+
+    public static Set<CounterType> getValues() {
+        return new LinkedHashSet<CounterType>(sMap.values());
+    }
+}

--- a/forge-game/src/main/java/forge/game/card/CounterEnumType.java
+++ b/forge-game/src/main/java/forge/game/card/CounterEnumType.java
@@ -511,14 +511,17 @@ public enum CounterEnumType implements CounterType {
         return this.name;
     }
 
+    @Override
     public int getRed() {
         return red;
     }
 
+    @Override
     public int getGreen() {
         return green;
     }
 
+    @Override
     public int getBlue() {
         return blue;
     }
@@ -535,10 +538,5 @@ public enum CounterEnumType implements CounterType {
     @Override
     public boolean is(CounterEnumType eType) {
         return this == eType;
-    }
-
-    @Override
-    public boolean isKeywordCounter() {
-        return false;
     }
 }

--- a/forge-game/src/main/java/forge/game/card/CounterEnumType.java
+++ b/forge-game/src/main/java/forge/game/card/CounterEnumType.java
@@ -526,6 +526,7 @@ public enum CounterEnumType implements CounterType {
         return blue;
     }
 
+    @Override
     public String getCounterOnCardDisplayName() {
         return counterOnCardDisplayName;
     }

--- a/forge-game/src/main/java/forge/game/card/CounterKeywordType.java
+++ b/forge-game/src/main/java/forge/game/card/CounterKeywordType.java
@@ -21,8 +21,8 @@ public record CounterKeywordType(String keyword, Keyword type, String desc) impl
 
     public static CounterKeywordType get(String s) {
         if (!sMap.containsKey(s)) {
-            KeywordInterface ki = isKeywordCounter(s) ? Keyword.getInstance(s) : null;
-            sMap.put(s, new CounterKeywordType(s, ki != null ? ki.getKeyword() : null, ki != null ? ki.getTitle() : null));
+            KeywordInterface ki = Keyword.getInstance(s);
+            sMap.put(s, new CounterKeywordType(s, ki.getKeyword(), ki.getTitle()));
         }
         return sMap.get(s);
     }
@@ -49,16 +49,14 @@ public record CounterKeywordType(String keyword, Keyword type, String desc) impl
     }
 
     private String getKeywordDescription() {
-        return desc != null ? desc : keyword;
+        return desc;
     }
 
-    public boolean is(CounterEnumType eType) {
-        return false;
-    }
-
+    @Override
     public boolean isKeywordCounter() {
-        return isKeywordCounter(keyword);
+        return true;
     }
+
     public static boolean isKeywordCounter(String keyword) {
         if (keyword.startsWith("Hexproof:")) {
             return true;
@@ -67,17 +65,5 @@ public record CounterKeywordType(String keyword, Keyword type, String desc) impl
             return true;
         }
         return keywordCounter.contains(keyword);
-    }
-
-    public int getRed() {
-        return 255;
-    }
-
-    public int getGreen() {
-        return 255;
-    }
-
-    public int getBlue() {
-        return 255;
     }
 }

--- a/forge-game/src/main/java/forge/game/card/CounterKeywordType.java
+++ b/forge-game/src/main/java/forge/game/card/CounterKeywordType.java
@@ -44,6 +44,7 @@ public record CounterKeywordType(String keyword, Keyword type, String desc) impl
         return getKeywordDescription();
     }
 
+    @Override
     public String getCounterOnCardDisplayName() {
         return getKeywordDescription();
     }

--- a/forge-game/src/main/java/forge/game/card/CounterType.java
+++ b/forge-game/src/main/java/forge/game/card/CounterType.java
@@ -13,16 +13,20 @@ public interface CounterType extends Serializable, ITranslatable {
         if ("Any".equalsIgnoreCase(name)) {
             return null;
         }
+        if (CounterKeywordType.isKeywordCounter(name)) {
+            return CounterKeywordType.get(name);
+        }
         try {
             return CounterEnumType.getType(name);
         } catch (final IllegalArgumentException ex) {
-            return CounterKeywordType.get(name);
+            return CounterCustomType.get(name);
         }
     }
     static List<CounterType> getValues() {
         List<CounterType> result = Lists.newArrayList();
         result.addAll(List.of(CounterEnumType.values()));
         result.addAll(CounterKeywordType.getValues());
+        result.addAll(CounterCustomType.getValues());
         return result;
     }
 
@@ -30,15 +34,25 @@ public interface CounterType extends Serializable, ITranslatable {
 
     String getCounterOnCardDisplayName();
 
-    boolean is(CounterEnumType eType);
+    default boolean is(CounterEnumType eType) {
+        return false;
+    }
 
-    boolean isKeywordCounter();
+    default boolean isKeywordCounter() {
+        return false;
+    }
 
-    int getRed();
+    default int getRed() {
+        return 255;
+    }
 
-    int getGreen();
+    default int getGreen() {
+        return 255;
+    }
 
-    int getBlue();
+    default int getBlue() {
+        return 255;
+    }
 
     @Override
     default String getTranslationKey() {

--- a/forge-game/src/main/java/forge/game/card/CounterType.java
+++ b/forge-game/src/main/java/forge/game/card/CounterType.java
@@ -32,7 +32,9 @@ public interface CounterType extends Serializable, ITranslatable {
 
     String getName();
 
-    String getCounterOnCardDisplayName();
+    default String getCounterOnCardDisplayName() {
+        return getName();
+    }
 
     default boolean is(CounterEnumType eType) {
         return false;

--- a/forge-gui-desktop/src/main/java/forge/gui/ListChooser.java
+++ b/forge-gui-desktop/src/main/java/forge/gui/ListChooser.java
@@ -413,7 +413,7 @@ public class ListChooser<T> {
             } else if (value instanceof CardType.CoreType c) {
                 defRenderer.setIcon(fromSkinProp(FSkinProp.iconFromCoreType(c)));
             } else if (value instanceof CounterType) {
-                if (value instanceof CounterKeywordType c && c.isKeywordCounter()) {
+                if (value instanceof CounterKeywordType c) {
                     defRenderer.setIcon(fromSkinProp(FSkinProp.iconFromKeyword(c.type(), c.keyword())));
                 } else {
                     defRenderer.setIcon(fromSkinProp(null));


### PR DESCRIPTION
Part of #10076

This splits the custom fallback from the `CounterKeywordType`
meaning that `CounterKeywordType` are always official Keywords.

While `CounterCustomType` are fallback if Counter isn't found.
(we might add logging later that it does a warning/error if CardRules isn't custom too)