### PR TITLE
Fix Stalwart Realmwarden ETB

### DIFF
--- a/forge-gui/res/cardsfolder/s/stalwart_realmwarden.txt
+++ b/forge-gui/res/cardsfolder/s/stalwart_realmwarden.txt
@@ -4,8 +4,8 @@ Types:Creature Human Soldier
 PT:2/2
 K:First Strike
 K:Lifelink
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | ForgetOnCast$ Card.nonCreature+YouCtrl | TriggerDescription$ When CARDNAME enters, the next noncreature spell target opponent casts costs {2} more to cast.
-SVar:TrigEffect:DB$ Effect | StaticAbilities$ RaiseCost | ValidTgts$ Opponent | EffectOwner$ Targeted | Triggers$ TrigCastSpell | Duration$ Permanent
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigEffect | TriggerDescription$ When CARDNAME enters, the next noncreature spell target opponent casts costs {2} more to cast.
+SVar:TrigEffect:DB$ Effect | StaticAbilities$ RaiseCost | ValidTgts$ Opponent | EffectOwner$ Targeted | ForgetOnCast$ Card.nonCreature+YouCtrl | Duration$ Permanent
 SVar:RaiseCost:Mode$ RaiseCost | Type$ Spell | ValidCard$ Card.nonCreature | Activator$ You | Amount$ 2 | Description$ The next noncreature spell target opponent casts costs {2} more to cast.
 DeckHas:Ability$LifeGain
 Oracle:First strike, Lifelink\nWhen Stalwart Realmwarden enters, the next noncreature spell target opponent casts costs {2} more to cast.


### PR DESCRIPTION
Looks like the wrong thing got swapped out during the `ForgetOnCast` cleanup? The missing `Execute$` param was causing crashes whenever the AI tried to evaluate its ETB. Seems like that should explode sooner.