### PR TITLE
Mobile lobby: drive panel count from lobby state, not dropdown

### DIFF
--- a/forge-gui-mobile/src/forge/screens/constructed/LobbyScreen.java
+++ b/forge-gui-mobile/src/forge/screens/constructed/LobbyScreen.java
@@ -82,7 +82,10 @@ public abstract class LobbyScreen extends LaunchScreen implements ILobbyView {
         protected ScrollBounds layoutAndGetScrollBounds(float visibleWidth, float visibleHeight) {
             float y = 0;
             float height;
-            for (int i = 0; i < getNumPlayers(); i++) {
+            // Bound by panels.size() — panel.setMayEdit can call revalidate
+            // mid-loop in LobbyScreen.update() before all slots have panels.
+            int count = Math.min(getNumPlayers(), playerPanels.size());
+            for (int i = 0; i < count; i++) {
                 height = playerPanels.get(i).getPreferredHeight();
                 playerPanels.get(i).setBounds(0, y, visibleWidth, height);
                 y += height;
@@ -113,16 +116,19 @@ public abstract class LobbyScreen extends LaunchScreen implements ILobbyView {
         }
         cbPlayerCount.setSelectedItem(2);
         cbPlayerCount.setChangedHandler(event -> {
-            int numPlayers = getNumPlayers();
-            while(lobby.getNumberOfSlots() < getNumPlayers()){
+            // Use the dropdown's selected value as the target slot count.
+            // getNumPlayers() now derives from lobby.getNumberOfSlots(), so
+            // using it here would make the while loops degenerate.
+            int target = cbPlayerCount.getSelectedItem();
+            while(lobby.getNumberOfSlots() < target){
                 lobby.addSlot();
             }
-            while(lobby.getNumberOfSlots() > getNumPlayers()){
+            while(lobby.getNumberOfSlots() > target){
                 lobby.removeSlot(lobby.getNumberOfSlots()-1);
             }
             for (int i = 0; i < MAX_PLAYERS; i++) {
                 if(i<playerPanels.size()) {
-                    playerPanels.get(i).setVisible(i < numPlayers);
+                    playerPanels.get(i).setVisible(i < target);
                 }
             }
             playersScroll.revalidate();
@@ -264,7 +270,7 @@ public abstract class LobbyScreen extends LaunchScreen implements ILobbyView {
     }
 
     void updateLayoutForVariants() {
-        for (int i = 0; i < cbPlayerCount.getSelectedItem(); i++) {
+        for (int i = 0; i < getNumPlayers(); i++) {
             playerPanels.get(i).updateVariantControlsVisibility();
         }
         playersScroll.revalidate();
@@ -315,7 +321,10 @@ public abstract class LobbyScreen extends LaunchScreen implements ILobbyView {
     }
 
     public int getNumPlayers() {
-        return cbPlayerCount.getSelectedItem();
+        // Mirror desktop's VLobby.activePlayersNum: the lobby is the source of
+        // truth. The dropdown is only a host-side control for editing this
+        // count — for clients, the server dictates it via setData.
+        return lobby != null ? lobby.getNumberOfSlots() : cbPlayerCount.getSelectedItem();
     }
     public void setNumPlayers(int numPlayers) {
         cbPlayerCount.setSelectedItem(numPlayers);
@@ -604,7 +613,7 @@ public abstract class LobbyScreen extends LaunchScreen implements ILobbyView {
 
         setStartButtonAvailability();
 
-        for (int i = 0; i < cbPlayerCount.getSelectedItem(); i++) {
+        for (int i = 0; i < MAX_PLAYERS; i++) {
             final boolean hasPanel = i < playerPanels.size();
             if (i < playerCount) {
                 // visible panels
@@ -617,13 +626,17 @@ public abstract class LobbyScreen extends LaunchScreen implements ILobbyView {
                 }
                 else {
                     panel = new PlayerPanel(this, allowNetworking, i, slot, lobby.mayEdit(i), lobby.hasControl());
+                    // Register the panel before initialize: deck-chooser
+                    // population fires selection callbacks synchronously,
+                    // some of which call back into updateDeck(i) -> playerPanels.get(i).
+                    // (Mirrors desktop's VLobby.update at lines 272-277.)
+                    playerPanels.add(panel);
+                    playersScroll.add(panel);
                     if (i == 2) {
                         panel.initialize(FPref.CONSTRUCTED_P3_DECK_STATE, FPref.COMMANDER_P3_DECK_STATE, FPref.OATHBREAKER_P3_DECK_STATE, FPref.TINY_LEADER_P3_DECK_STATE, FPref.BRAWL_P3_DECK_STATE, DeckType.COLOR_DECK);
                     } else if (i == 3) {
                         panel.initialize(FPref.CONSTRUCTED_P4_DECK_STATE, FPref.COMMANDER_P4_DECK_STATE, FPref.OATHBREAKER_P4_DECK_STATE, FPref.TINY_LEADER_P4_DECK_STATE, FPref.BRAWL_P4_DECK_STATE, DeckType.COLOR_DECK);
                     }
-                    playerPanels.add(panel);
-                    playersScroll.add(panel);
                     isNewPanel = true;
                 }
 
@@ -684,6 +697,21 @@ public abstract class LobbyScreen extends LaunchScreen implements ILobbyView {
                 playerPanels.get(i).setVisible(false);
             }
         }
+
+        // Sync the displayed dropdown value to the lobby for clients (the
+        // server dictates the slot count, so the host-style dropdown should
+        // mirror it cosmetically). Skipped on hosts to avoid re-firing the
+        // changedHandler's addSlot/removeSlot path.
+        if (!lobby.hasControl() && playerCount >= 2 && playerCount <= MAX_PLAYERS) {
+            cbPlayerCount.setSelectedItem(playerCount);
+        }
+
+        // Force the scroll pane to lay out newly added panels. Mid-loop
+        // panel.setMayEdit() only revalidates when getHeight() > 0, which is
+        // false for freshly created panels — so without this, slots added by
+        // a server-driven update (client receiving a larger lobby) stay
+        // invisible until some other event triggers layout.
+        playersScroll.revalidate();
     }
 
     @Override
@@ -692,7 +720,10 @@ public abstract class LobbyScreen extends LaunchScreen implements ILobbyView {
     }
 
     private void updateDeck(final int playerIndex) {
-        if (playerIndex >= getNumPlayers()) { return; }
+        // Bound by panels.size() too — chooser-population callbacks during
+        // update() can fire updateDeck before the corresponding panel is
+        // registered, and the lobby's slot count may be ahead of the panel list.
+        if (playerIndex >= getNumPlayers() || playerIndex >= playerPanels.size()) { return; }
 
         PlayerPanel playerPanel = playerPanels.get(playerIndex);
         String deckName = "";

--- a/forge-gui-mobile/src/forge/screens/constructed/LobbyScreen.java
+++ b/forge-gui-mobile/src/forge/screens/constructed/LobbyScreen.java
@@ -82,8 +82,7 @@ public abstract class LobbyScreen extends LaunchScreen implements ILobbyView {
         protected ScrollBounds layoutAndGetScrollBounds(float visibleWidth, float visibleHeight) {
             float y = 0;
             float height;
-            // Bound by panels.size() — panel.setMayEdit can call revalidate
-            // mid-loop in LobbyScreen.update() before all slots have panels.
+            // setMayEdit can revalidate while update() is still adding panels.
             int count = Math.min(getNumPlayers(), playerPanels.size());
             for (int i = 0; i < count; i++) {
                 height = playerPanels.get(i).getPreferredHeight();
@@ -116,9 +115,7 @@ public abstract class LobbyScreen extends LaunchScreen implements ILobbyView {
         }
         cbPlayerCount.setSelectedItem(2);
         cbPlayerCount.setChangedHandler(event -> {
-            // Use the dropdown's selected value as the target slot count.
-            // getNumPlayers() now derives from lobby.getNumberOfSlots(), so
-            // using it here would make the while loops degenerate.
+            // The dropdown is the user's target; getNumPlayers() reads from the lobby and would loop forever.
             int target = cbPlayerCount.getSelectedItem();
             while(lobby.getNumberOfSlots() < target){
                 lobby.addSlot();
@@ -321,9 +318,6 @@ public abstract class LobbyScreen extends LaunchScreen implements ILobbyView {
     }
 
     public int getNumPlayers() {
-        // Mirror desktop's VLobby.activePlayersNum: the lobby is the source of
-        // truth. The dropdown is only a host-side control for editing this
-        // count — for clients, the server dictates it via setData.
         return lobby != null ? lobby.getNumberOfSlots() : cbPlayerCount.getSelectedItem();
     }
     public void setNumPlayers(int numPlayers) {
@@ -626,10 +620,7 @@ public abstract class LobbyScreen extends LaunchScreen implements ILobbyView {
                 }
                 else {
                     panel = new PlayerPanel(this, allowNetworking, i, slot, lobby.mayEdit(i), lobby.hasControl());
-                    // Register the panel before initialize: deck-chooser
-                    // population fires selection callbacks synchronously,
-                    // some of which call back into updateDeck(i) -> playerPanels.get(i).
-                    // (Mirrors desktop's VLobby.update at lines 272-277.)
+                    // Register before initialize: deck-chooser populate fires onSelectionChange synchronously, which can recurse into updateDeck(i).
                     playerPanels.add(panel);
                     playersScroll.add(panel);
                     if (i == 2) {
@@ -698,19 +689,12 @@ public abstract class LobbyScreen extends LaunchScreen implements ILobbyView {
             }
         }
 
-        // Sync the displayed dropdown value to the lobby for clients (the
-        // server dictates the slot count, so the host-style dropdown should
-        // mirror it cosmetically). Skipped on hosts to avoid re-firing the
-        // changedHandler's addSlot/removeSlot path.
+        // Cosmetic-only sync for clients; skipped on hosts to avoid re-firing the changedHandler's add/remove path.
         if (!lobby.hasControl() && playerCount >= 2 && playerCount <= MAX_PLAYERS) {
             cbPlayerCount.setSelectedItem(playerCount);
         }
 
-        // Force the scroll pane to lay out newly added panels. Mid-loop
-        // panel.setMayEdit() only revalidates when getHeight() > 0, which is
-        // false for freshly created panels — so without this, slots added by
-        // a server-driven update (client receiving a larger lobby) stay
-        // invisible until some other event triggers layout.
+        // setMayEdit's revalidate is gated on getHeight() > 0, which fresh panels don't satisfy.
         playersScroll.revalidate();
     }
 
@@ -720,9 +704,7 @@ public abstract class LobbyScreen extends LaunchScreen implements ILobbyView {
     }
 
     private void updateDeck(final int playerIndex) {
-        // Bound by panels.size() too — chooser-population callbacks during
-        // update() can fire updateDeck before the corresponding panel is
-        // registered, and the lobby's slot count may be ahead of the panel list.
+        // Chooser-populate callbacks can fire before the panel is registered.
         if (playerIndex >= getNumPlayers() || playerIndex >= playerPanels.size()) { return; }
 
         PlayerPanel playerPanel = playerPanels.get(playerIndex);


### PR DESCRIPTION
Fixes #10632.

## Bug report

On Android, joining an online lobby hosted by a desktop player worked correctly only when the mobile user took slot 1 ("second to join, after the host"). If the mobile user joined as slot 2 or higher (i.e. another client was already in slot 1), they couldn't ready up or change deck — and at higher slot counts they couldn't see their own slot at all.

## Root cause

`forge-gui-mobile`'s `LobbyScreen.getNumPlayers()` returned `cbPlayerCount.getSelectedItem()` — the local player-count dropdown, which defaults to 2 and only changes when the user manually picks a different value. For a host this matched the lobby (the dropdown's `changedHandler` calls `lobby.addSlot()`/`removeSlot()`), but for a client the lobby's slot count comes from the server via `LobbyUpdateEvent` and the dropdown was never updated. So a joining client's panel-creation loop, scroll layout, and `updateDeck` early-return all clamped to 2, regardless of how many slots the server actually had.

A handful of pre-existing ordering issues in `update()` were latent until clients started exercising slots 2/3: deck-chooser populate callbacks fired before `playerPanels.add(panel)`, mid-update `panel.setMayEdit()` revalidates iterated `playerPanels` while it was still being built, and `playersScroll` never got a final layout pass after the server-driven slot additions.

## Fix

Mirrors desktop's `VLobby` architecture (where `activePlayersNum` is recomputed from `lobby.getNumberOfSlots()` at the top of every `update()` and the dropdown-equivalent — `addPlayerBtn` — calls `lobby.addSlot()` directly):

- `getNumPlayers()` returns `lobby.getNumberOfSlots()`; the dropdown becomes a host-side input and a cosmetic readout for clients.
- `update()` loop iterates `MAX_PLAYERS` and hides panels beyond `playerCount` (matches `VLobby.update` lines 260–323).
- `cbPlayerCount.changedHandler` now reads `cbPlayerCount.getSelectedItem()` directly as its target slot count, since `getNumPlayers()` would otherwise be degenerate against the lobby.
- Panel registration in `update()` adds to `playerPanels` and `playersScroll` *before* calling `panel.initialize(...)` — matches `VLobby:272-277`. Deck-chooser populate fires `onSelectionChange` synchronously, which can recurse into `updateDeck(i)` expecting `playerPanels.get(i)` to find the panel.
- Defensive bounds in `playersScroll.layoutAndGetScrollBounds` and `updateDeck` (`Math.min(getNumPlayers(), playerPanels.size())`-style guards), to absorb any other mid-update callback that races the panel list against the lobby.
- Single `playersScroll.revalidate()` at the end of `update()`, since the mid-loop revalidates inside `setMayEdit` are gated on `getHeight() > 0`, which is false for freshly created panels.
- For clients (`!lobby.hasControl()`), the dropdown's displayed value is set to the lobby's slot count at the end of `update()` so the user sees the correct "Players: N".

## User-facing result

A mobile player joining an online lobby now sees every slot the host configured, regardless of join order, with their own slot fully interactive (ready toggle, deck/avatar/name/team controls) and the "Players: N" readout reflecting the actual lobby size.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)