### PR TITLE
Fix mobile host adding AI to network game

### DIFF
--- a/forge-gui-mobile/src/forge/screens/constructed/PlayerPanel.java
+++ b/forge-gui-mobile/src/forge/screens/constructed/PlayerPanel.java
@@ -465,8 +465,31 @@ public class PlayerPanel extends FContainer {
         public void handleEvent(FEvent e) {
             boolean toggled = humanAiSwitch.isToggled();
             if (allowNetworking) {
-                setIsReady(toggled);
-                screen.setReady(index, toggled);
+                if (isOpenAiSlotToggle()) {
+                    LobbySlotType newType = toggled ? LobbySlotType.AI : LobbySlotType.OPEN;
+                    boolean wasAi = isAi();
+                    type = newType;
+
+                    LobbySlot slot = screen.getLobby().getSlot(index);
+                    slot.setType(newType);
+
+                    if (newType == LobbySlotType.AI && getPlayerName().isEmpty()) {
+                        setPlayerName(NameGenerator.getRandomName("Any", "Any", screen.getPlayerNames()));
+                    }
+
+                    screen.update(index, newType);
+
+                    if (isAi() != wasAi) {
+                        onIsAiChanged(isAi());
+                    }
+
+                    setMayEdit(screen.getLobby().mayEdit(index));
+                    refreshSlotToggle();
+                    screen.firePlayerChangeListener(index);
+                } else {
+                    setIsReady(toggled);
+                    screen.setReady(index, toggled);
+                }
             }
             else {
                 type = toggled ? LobbySlotType.AI : LobbySlotType.LOCAL;
@@ -484,6 +507,27 @@ public class PlayerPanel extends FContainer {
             }
         }
     };
+
+    private boolean isOpenAiSlotToggle() {
+        return allowNetworking && index > 0 && mayControl
+                && (type == LobbySlotType.OPEN || type == LobbySlotType.AI);
+    }
+
+    private void refreshSlotToggle() {
+        if (isOpenAiSlotToggle()) {
+            humanAiSwitch.setOffText(Forge.getLocalizer().getMessage("lblOpen"));
+            humanAiSwitch.setOnText(Forge.getLocalizer().getMessage("lblAI"));
+            humanAiSwitch.setEnabled(mayControl);
+        } else if (allowNetworking) {
+            humanAiSwitch.setOffText(Forge.getLocalizer().getMessage("lblNotReady"));
+            humanAiSwitch.setOnText(Forge.getLocalizer().getMessage("lblReady"));
+            humanAiSwitch.setEnabled(mayEdit);
+        } else {
+            humanAiSwitch.setOffText(Forge.getLocalizer().getMessage("lblHuman"));
+            humanAiSwitch.setOnText(Forge.getLocalizer().getMessage("lblAI"));
+            humanAiSwitch.setEnabled(mayEdit);
+        }
+    }
 
     private final FEventHandler devModeSwitched = new FEventHandler() {
         @Override
@@ -916,6 +960,8 @@ public class PlayerPanel extends FContainer {
             break;
         }
 
+        refreshSlotToggle();
+
         boolean isAi = isAi();
         if (isAi != wasAi && deckChooser != null) {
             onIsAiChanged(isAi);
@@ -966,7 +1012,7 @@ public class PlayerPanel extends FContainer {
         sleeveLabel.setEnabled(mayEdit);
         txtPlayerName.setEnabled(mayEdit);
         nameRandomiser.setEnabled(mayEdit);
-        humanAiSwitch.setEnabled(mayEdit);
+        refreshSlotToggle();
         cbTeam.setEnabled(mayEdit);
         if (devModeSwitch != null) {
             devModeSwitch.setEnabled(mayEdit);
@@ -992,6 +1038,7 @@ public class PlayerPanel extends FContainer {
     public void setMayControl(boolean mayControl0) {
         if (mayControl == mayControl0) { return; }
         mayControl = mayControl0;
+        refreshSlotToggle();
     }
 
     public void setMayRemove(boolean mayRemove0) {


### PR DESCRIPTION
## Summary
- On mobile, the host of an online lobby could not convert OPEN slots to AI — the Human/AI toggle was repurposed as a Ready toggle in network mode, leaving no UI path to add AI players. Desktop has had this capability all along via separate Human/AI/Open radios + a Ready checkbox.
- The underlying wiring to support host-added AI already existed — `ServerGameLobby.mayControl` permits the host to retype any non-`REMOTE` slot, and the lobby/protocol layers handle the type change end-to-end. The mobile side simply had no widget bound to that capability.
- This change reuses mobile's existing `humanAiSwitch` widget with three modes: `Human/AI` (offline), `Open/AI` (network host on slots 1+), `Not Ready/Ready` (network slot 0 and remote slots). Mode is selected from `(allowNetworking, index, mayControl, slot type)`.
- Confined to `forge-gui-mobile/PlayerPanel.java`. No protocol/server/model changes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)