### PR TITLE
Fix yield activation enabling cancel on forced input prompts

### DIFF
--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -3559,7 +3559,14 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
             // Switch the cancel button + prompt to "Yielding until X" so the user can disarm.
             // Otherwise the previous InputPassPriority "End Turn" label would persist and ESC
             // would skip the click on the client.
-            getGui().updateAutoPassPrompt();
+            // Skip when a forced input is active: it deliberately disables Cancel, and repainting
+            // would re-enable it as a "cancel yield" button that actually drops the input.
+            Input currentInput = inputProxy.getInput();
+            if (currentInput == null
+                    || currentInput instanceof InputPassPriority
+                    || currentInput instanceof InputLockUI) {
+                getGui().updateAutoPassPrompt();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Reported via Discord (Android, v2.0.13-SNAPSHOT-05.09): a Glacial Chasm ETB sacrifice trigger could silently no-op if the user clicked "Yield to entire stack" while the sacrifice prompt was showing, then pressed Cancel.

## Cause

`applyYieldUpdate` calls `updateAutoPassPrompt()` on every yield activation. That helper repaints the shared prompt panel — including re-enabling Cancel for "cancel yield". When the active input is a forced selection (e.g. `InputSelectCardsFromList` for "sacrifice a land", min=1) it had deliberately disabled Cancel; re-enabling it lets the user click what looks like "cancel yield" but is wired to the input's `onCancel`, which drops the mandatory selection with an empty result.

## Fix

Gate the repaint to passive inputs (`InputPassPriority`, `InputLockUI`, null). The yield flag still arms; the active prompt is left alone.

---

<img width="1011" height="597" alt="image" src="https://github.com/user-attachments/assets/937f118a-9c84-476f-8f25-c65e3fe61421" />

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)