### PR TITLE
Fix Gift on non-permanents

### DIFF
--- a/forge-game/src/main/java/forge/game/card/CardFactory.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactory.java
@@ -406,10 +406,10 @@ public class CardFactory {
             for (String t : face.getTriggers())
                 c.addTrigger(TriggerHandler.parseTrigger(t, c, true, c.getCurrentState()));
 
-            // keywords not before variables
-            c.addIntrinsicKeywords(face.getKeywords(), false);
-
             CardFactoryUtil.addAbilityFactoryAbilities(c, face.getAbilities());
+
+            // keywords not before variables and spells
+            c.addIntrinsicKeywords(face.getKeywords(), false);
         }
     }
 


### PR DESCRIPTION
Because the new face now has the correct card typing before we build its traits (which is certainly the better order) a latent bug got uncovered:
it entered the `abilityTextInstantSorcery` branch while preparing the keyword text but the face was still spell-less 💣
I can't think of a reason why we'd want to handle keywords in the middle instead of at the end so their first parsing run already generates more accurate results - so that's our future 🤞