### PR TITLE
Route opponent-hand reveal and discard through FloatingZone on desktop

### DIFF
--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -659,7 +659,7 @@ public class PlayerControllerAi extends PlayerController {
     }
 
     @Override
-    public CardCollection chooseCardsToDiscardFrom(Player p, SpellAbility sa, CardCollection validCards, int min, int max) {
+    public CardCollection chooseCardsToDiscardFrom(Player p, SpellAbility sa, CardCollection validCards, int min, int max, CardCollectionView visibleToChooser) {
         if (p == player) {
             return brains.getCardsToDiscard(min, max, validCards, sa);
         }

--- a/forge-game/src/main/java/forge/game/ability/effects/DiscardEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DiscardEffect.java
@@ -258,7 +258,10 @@ public class DiscardEffect extends SpellAbilityEffect {
                 int min = sa.hasParam("AnyNumber") || sa.hasParam("Optional") ? 0 : Math.min(validCards.size(), numCards);
                 int max = sa.hasParam("AnyNumber") ? validCards.size() : Math.min(validCards.size(), numCards);
 
-                toBeDiscarded = max == 0 ? CardCollection.EMPTY : chooser.getController().chooseCardsToDiscardFrom(p, sa, validCards, min, max);
+                // Reveal/Look modes disclose dPHand to the chooser; non-valid revealed cards should remain visible during the choice.
+                final boolean revealed = mode.startsWith("Reveal") || mode.startsWith("Look");
+                final CardCollectionView visibleToChooser = revealed ? dPHand : validCards;
+                toBeDiscarded = max == 0 ? CardCollection.EMPTY : chooser.getController().chooseCardsToDiscardFrom(p, sa, validCards, min, max, visibleToChooser);
 
                 if (toBeDiscarded.isEmpty()) {
                     continue;

--- a/forge-game/src/main/java/forge/game/player/PlayerController.java
+++ b/forge-game/src/main/java/forge/game/player/PlayerController.java
@@ -201,8 +201,14 @@ public abstract class PlayerController {
      */
     public abstract CardCollectionView orderMoveToZoneList(CardCollectionView cards, ZoneType destinationZone, SpellAbility source);
 
-    /** p = target player, validCards - possible discards, min cards to discard */
-    public abstract CardCollectionView chooseCardsToDiscardFrom(Player playerDiscard, SpellAbility sa, CardCollection validCards, int min, int max);
+    /** p = target player, validCards - possible discards, min cards to discard. */
+    public CardCollectionView chooseCardsToDiscardFrom(Player playerDiscard, SpellAbility sa, CardCollection validCards, int min, int max) {
+        return chooseCardsToDiscardFrom(playerDiscard, sa, validCards, min, max, validCards);
+    }
+
+    /** visibleToChooser - all cards the chooser is allowed to see during the choice (a superset of validCards
+     *  when an effect has revealed extra cards, e.g. Reveal/Look modes). */
+    public abstract CardCollectionView chooseCardsToDiscardFrom(Player playerDiscard, SpellAbility sa, CardCollection validCards, int min, int max, CardCollectionView visibleToChooser);
     public abstract CardCollectionView chooseCardsToDiscardUnlessType(int min, CardCollectionView hand, String[] unlessTypes, SpellAbility sa);
     public abstract CardCollection chooseCardsToDiscardToMaximumHandSize(int numDiscard);
 

--- a/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
@@ -1063,8 +1063,18 @@ public final class CMatchUI
         notePromptMessage(message);
     }
 
-    private void notePromptMessage(final String message) {
-        lastPromptMessage = message != null ? message : "";
+    private void notePromptMessage(String message) {
+        if (message != null) {
+            int lastBreak = message.lastIndexOf("\n");
+            if (lastBreak != -1) {
+                // try to only use the specific message of the input
+                // not fully accurate but ok for now
+                message = message.substring(lastBreak + 1);
+            }
+        } else {
+            message = "";
+        }
+        lastPromptMessage = message;
         if (isSelecting()) {
             FloatingZone.refreshSelectionPrompts();
         }

--- a/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
@@ -586,11 +586,7 @@ public final class CMatchUI
             for (final PlayerZoneUpdate update : zonesToUpdate) {
                 final PlayerView player = update.getPlayer();
                 for (final ZoneType zone : update.getZones()) {
-                    if (zone == ZoneType.Hand) {
-                        if (controller != player) {
-                            FloatingZone.hide(this, player, zone);
-                        }
-                    } else if (FLOATING_ZONE_TYPES.contains(zone)) {
+                    if (FLOATING_ZONE_TYPES.contains(zone) || (zone == ZoneType.Hand && controller != player)) {
                         FloatingZone.hide(this, player, zone);
                     }
                 }

--- a/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
@@ -586,8 +586,13 @@ public final class CMatchUI
             for (final PlayerZoneUpdate update : zonesToUpdate) {
                 final PlayerView player = update.getPlayer();
                 for (final ZoneType zone : update.getZones()) {
-                    if(FLOATING_ZONE_TYPES.contains(zone))
-                        FloatingZone.hide(this,player,zone);
+                    if (zone == ZoneType.Hand) {
+                        if (controller != player) {
+                            FloatingZone.hide(this, player, zone);
+                        }
+                    } else if (FLOATING_ZONE_TYPES.contains(zone)) {
+                        FloatingZone.hide(this, player, zone);
+                    }
                 }
             }
         }

--- a/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
@@ -176,6 +176,7 @@ public final class CMatchUI
     private final CPrompt cPrompt = new CPrompt(this);
     private final CStack cStack = new CStack(this);
     private int nextNotifiableStackIndex = 0;
+    private String lastPromptMessage = "";
 
     public CMatchUI() {
         this.view = new VMatchUI(this);
@@ -1048,15 +1049,29 @@ public final class CMatchUI
     public void showPromptMessage(final PlayerView playerView, final String message) {
         cancelWaitingTimer();
         cPrompt.setMessage(message);
+        notePromptMessage(message);
     }
     public void showPromptMessageNoCancel(final PlayerView playerView, final String message) {
         cPrompt.setMessage(message);
+        notePromptMessage(message);
     }
 
     @Override
     public void showCardPromptMessage(PlayerView playerView, String message, CardView card) {
         cancelWaitingTimer();
         cPrompt.setMessage(message, card);
+        notePromptMessage(message);
+    }
+
+    private void notePromptMessage(final String message) {
+        lastPromptMessage = message != null ? message : "";
+        if (isSelecting()) {
+            FloatingZone.refreshSelectionPrompts();
+        }
+    }
+
+    public String getPromptMessage() {
+        return lastPromptMessage;
     }
 
     @Override

--- a/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
@@ -641,6 +641,8 @@ public final class CMatchUI
                         cp.repaintOverlays();
                     }
                 }
+                // VHand only covers the local hand; opponent hands shown in a FloatingZone need an explicit refresh.
+                FloatingZone.refresh(c.getController(), zone);
                 break;
             default:
                 FloatingZone.refresh(c.getController(),zone); // in case the card is visible in the zone

--- a/forge-gui-desktop/src/main/java/forge/view/arcane/CardPanel.java
+++ b/forge-gui-desktop/src/main/java/forge/view/arcane/CardPanel.java
@@ -127,10 +127,15 @@ public class CardPanel extends SkinnedPanel implements CardContainer, IDisposabl
     private Color zoneBannerColor;
     private CachedCardImage cachedImage;
     private int groupCount;
+    private int hotkeyDigit; // 1..9 paints a numbered badge for Ctrl+digit selection; 0 hides
     private Font badgeFont;
     private int badgeFontCardWidth; // cardWidth when badgeFont was last computed
 
     private static final Color BADGE_BG_COLOR = new Color(0, 0, 0, 180);
+    private static final Color HOTKEY_BADGE_BG = new Color(20, 20, 20, 220);
+    private static final Color HOTKEY_BADGE_RING = new Color(220, 220, 220);
+    private static final int HOTKEY_BADGE_MIN_CARD_WIDTH = 80;
+    private static final int HOTKEY_BADGE_MAX_DIAMETER = 28;
     private static Font smallCounterFont;
     private static Font largeCounterFont;
 
@@ -414,6 +419,9 @@ public class CardPanel extends SkinnedPanel implements CardContainer, IDisposabl
         if (groupCount >= 2) {
             drawGroupCountBadge(g);
         }
+        if (hotkeyDigit > 0 && cardWidth >= HOTKEY_BADGE_MIN_CARD_WIDTH) {
+            drawHotkeyDigitBadge(g);
+        }
         if (zoneBannerText != null) {
             drawZoneBanner(g);
         }
@@ -556,6 +564,38 @@ public class CardPanel extends SkinnedPanel implements CardContainer, IDisposabl
         g2d.setColor(Color.WHITE);
         g2d.setFont(badgeFont);
         g2d.drawString(text, badgeX + padX, badgeY + padY + textHeight);
+    }
+
+    public int getHotkeyDigit() {
+        return hotkeyDigit;
+    }
+
+    public void setHotkeyDigit(final int digit) {
+        if (hotkeyDigit == digit) return;
+        hotkeyDigit = digit;
+        repaint();
+    }
+
+    private void drawHotkeyDigitBadge(final Graphics g) {
+        final Graphics2D g2d = (Graphics2D) g.create();
+        try {
+            g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            final int diameter = Math.min(HOTKEY_BADGE_MAX_DIAMETER, cardWidth / 5);
+            final int bx = cardXOffset + cardWidth - diameter - 2;
+            final int by = cardYOffset + 2;
+            g2d.setColor(HOTKEY_BADGE_BG);
+            g2d.fillOval(bx, by, diameter, diameter);
+            g2d.setColor(HOTKEY_BADGE_RING);
+            g2d.drawOval(bx, by, diameter, diameter);
+            g2d.setColor(Color.WHITE);
+            g2d.setFont(new Font("Dialog", Font.BOLD, Math.max(11, diameter * 2 / 3)));
+            final String text = String.valueOf(hotkeyDigit);
+            final FontMetrics fm = g2d.getFontMetrics();
+            g2d.drawString(text, bx + (diameter - fm.stringWidth(text)) / 2,
+                    by + (diameter + fm.getAscent()) / 2 - 2);
+        } finally {
+            g2d.dispose();
+        }
     }
 
     public boolean isBadgeHit(int mouseX, int mouseY) {

--- a/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingZone.java
+++ b/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingZone.java
@@ -673,6 +673,7 @@ public class FloatingZone extends FloatingCardArea {
             promptLabel.setText(FSkin.encodeSymbols(prompt, false));
             promptLabel.setVisible(true);
         } else {
+            promptLabel.setText("");
             promptLabel.setVisible(false);
         }
         window.revalidate();

--- a/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingZone.java
+++ b/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingZone.java
@@ -18,6 +18,8 @@
 package forge.view.arcane;
 
 import java.awt.Color;
+import java.awt.KeyboardFocusManager;
+import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionAdapter;
@@ -26,13 +28,17 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import javax.swing.BorderFactory;
 import javax.swing.ScrollPaneConstants;
+import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 import javax.swing.border.Border;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 
 import forge.game.card.CardView;
 import forge.game.player.PlayerView;
@@ -52,9 +58,12 @@ import forge.model.FModel;
 import forge.screens.match.CMatchUI;
 import forge.screens.match.views.VHand;
 import forge.screens.match.views.VZone;
+import forge.toolbox.FLabel;
 import forge.toolbox.FMouseAdapter;
 import forge.toolbox.FScrollPane;
 import forge.toolbox.FSkin;
+import forge.toolbox.FTextField;
+import forge.toolbox.MouseTriggerEvent;
 import forge.toolbox.special.PlayerDetailsPanel;
 import forge.util.Localizer;
 import forge.util.collect.FCollection;
@@ -518,6 +527,16 @@ public class FloatingZone extends FloatingCardArea {
     protected boolean sortedByName = false;
     protected FCollection<CardView> cardList;
 
+    private final FTextField searchField = new FTextField.Builder()
+            .ghostText(Localizer.getInstance().getMessage("lblFilterByName"))
+            .build();
+    private final FLabel hotkeyHint = new FLabel.Builder()
+            .text(Localizer.getInstance().getMessage("lblHotkeySelectHint"))
+            .fontSize(11)
+            .fontAlign(SwingConstants.CENTER)
+            .build();
+    private String filter = "";
+
     private final Comparator<CardView> comp = (lhs, rhs) -> {
         if (!getMatchUI().mayView(lhs)) {
             return (getMatchUI().mayView(rhs)) ? 1 : 0;
@@ -538,6 +557,11 @@ public class FloatingZone extends FloatingCardArea {
             } else if (zone == ZoneType.Flashback) {
                 cardList.sort(ZONE_ORDER_COMPARATOR);
             }
+            if (!filter.isEmpty()) {
+                final String needle = filter.toLowerCase(Locale.ROOT);
+                cardList.removeIf(card -> !getMatchUI().mayView(card)
+                        || !card.getName().toLowerCase(Locale.ROOT).contains(needle));
+            }
             return cardList;
         } else {
             return null;
@@ -546,7 +570,15 @@ public class FloatingZone extends FloatingCardArea {
 
     private FloatingZone(final CMatchUI matchUI, final PlayerView player0, final ZoneType zone0) {
         super(matchUI, new FScrollPane(false, ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED, ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER));
-        window.add(getScrollPane(), "grow, push");
+        searchField.getDocument().addDocumentListener(new DocumentListener() {
+            @Override public void insertUpdate(final DocumentEvent e) { onFilterChanged(); }
+            @Override public void removeUpdate(final DocumentEvent e) { onFilterChanged(); }
+            @Override public void changedUpdate(final DocumentEvent e) { onFilterChanged(); }
+        });
+        window.add(searchField, "growx, wrap");
+        window.add(getScrollPane(), "grow, push, wrap");
+        hotkeyHint.setVisible(false);
+        window.add(hotkeyHint, "growx");
         window.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE); //pfps so that old content does not reappear?
         getScrollPane().setViewportView(this);
         setOpaque(false);
@@ -554,6 +586,33 @@ public class FloatingZone extends FloatingCardArea {
         zone = zone0;
         setPlayer(player0);
         setVertical(true);
+    }
+
+    private void onFilterChanged() {
+        filter = searchField.getText();
+        refresh();
+    }
+
+    @Override
+    protected void showWindow() {
+        // Install before setVisible so our dispatcher precedes FDialog's per-show Esc handler.
+        ensureHotkeyDispatcherInstalled();
+        onShow();
+        // Override the base class's focusableWindowState=false so the search field can take keystrokes.
+        getWindow().setFocusableWindowState(true);
+        if (getMatchUI().isSelecting()) {
+            getWindow().setDefaultFocus(searchField);
+        }
+        getWindow().setVisible(true);
+    }
+
+    @Override
+    protected void hideWindow() {
+        super.hideWindow();
+        // Clear filter so it doesn't persist into the next time this zone is opened.
+        if (!searchField.getText().isEmpty()) {
+            searchField.setText("");
+        }
     }
 
     @Override
@@ -579,7 +638,19 @@ public class FloatingZone extends FloatingCardArea {
             }
         }
         setCardPanels(cardPanels);
-        getWindow().setTitle(String.format(title, cardPanels.size()));
+        final int shown = cardPanels.size();
+        final FCollectionView<CardView> zoneCards = player.getCards(zone);
+        final int total = zoneCards != null ? zoneCards.size() : shown;
+        if (!filter.isEmpty() && shown < total) {
+            final String sortDetail = sortedByName
+                    ? Localizer.getInstance().getMessage("lblRightClickToUnSort")
+                    : Localizer.getInstance().getMessage("lblRightClickToSort");
+            getWindow().setTitle(Localizer.getInstance().getMessage("lblPlayerZoneNOfMCardSortStatus",
+                    player.getName(), zone.getTranslatedName(), shown, total, sortDetail));
+        } else {
+            getWindow().setTitle(String.format(title, shown));
+        }
+        assignOwnHotkeyDigits();
     }
 
     private void toggleSorted() {
@@ -646,6 +717,62 @@ public class FloatingZone extends FloatingCardArea {
                 locPref = null;
                 break;
         }
+    }
+
+    private static boolean hotkeyDispatcherInstalled;
+
+    private static void ensureHotkeyDispatcherInstalled() {
+        if (hotkeyDispatcherInstalled) return;
+        hotkeyDispatcherInstalled = true;
+        KeyboardFocusManager.getCurrentKeyboardFocusManager()
+                .addKeyEventDispatcher(FloatingZone::dispatchHotkey);
+    }
+
+    private static boolean dispatchHotkey(final KeyEvent e) {
+        if (e.getID() != KeyEvent.KEY_PRESSED) return false;
+        // Esc with focused, non-empty search field clears the filter instead of closing the window.
+        if (e.getKeyCode() == KeyEvent.VK_ESCAPE && !e.isControlDown() && !e.isAltDown() && !e.isMetaDown()) {
+            for (final FloatingZone fz : floatingAreas.values()) {
+                if (!fz.isVisible()) continue;
+                if (fz.searchField.isFocusOwner() && !fz.searchField.getText().isEmpty()) {
+                    fz.searchField.setText("");
+                    return true;
+                }
+            }
+            return false;
+        }
+        if (!e.isControlDown() || e.isAltDown() || e.isMetaDown()) return false;
+        final int digit = e.getKeyCode() - KeyEvent.VK_0;
+        if (digit < 1 || digit > 9) return false;
+        for (final FloatingZone fz : floatingAreas.values()) {
+            if (!fz.isVisible()) continue;
+            final CardPanel target = fz.findPanelByHotkeyDigit(digit);
+            if (target == null) continue;
+            fz.getMatchUI().getGameController().selectCard(target.getCard(), null,
+                    new MouseTriggerEvent(MouseEvent.BUTTON1, 0, 0));
+            return true;
+        }
+        return false;
+    }
+
+    private CardPanel findPanelByHotkeyDigit(final int digit) {
+        for (final CardPanel panel : getCardPanels()) {
+            if (panel.getHotkeyDigit() == digit) return panel;
+        }
+        return null;
+    }
+
+    private void assignOwnHotkeyDigits() {
+        final boolean selecting = getMatchUI().isSelecting();
+        int next = 1;
+        for (final CardPanel panel : getCardPanels()) {
+            if (selecting && next <= 9 && getMatchUI().isSelectable(panel.getCard())) {
+                panel.setHotkeyDigit(next++);
+            } else {
+                panel.setHotkeyDigit(0);
+            }
+        }
+        hotkeyHint.setVisible(next > 1);
     }
 
 }

--- a/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingZone.java
+++ b/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingZone.java
@@ -587,7 +587,7 @@ public class FloatingZone extends FloatingCardArea {
         });
         promptLabel.setBorder(BorderFactory.createEmptyBorder(3, 6, 3, 6));
         promptLabel.setVisible(false);
-        window.add(promptLabel, "growx, wmin 10, gapbottom 4, wrap");
+        window.add(promptLabel, "growx, wmin 10, gapbottom 4, wrap, hidemode 3");
         window.add(searchField, "growx, wrap");
         window.add(getScrollPane(), "grow, push, wrap");
         hotkeyHint.setVisible(false);

--- a/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingZone.java
+++ b/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingZone.java
@@ -664,7 +664,6 @@ public class FloatingZone extends FloatingCardArea {
             getWindow().setTitle(String.format(title, shown));
         }
         updatePromptVisibility();
-        assignOwnHotkeyDigits();
     }
 
     private void updatePromptVisibility() {
@@ -755,6 +754,16 @@ public class FloatingZone extends FloatingCardArea {
     }
 
     private static boolean dispatchHotkey(final KeyEvent e) {
+        if (e.getKeyCode() == KeyEvent.VK_CONTROL) {
+            for (final FloatingZone fz : floatingAreas.values()) {
+                if (!fz.isVisible()) continue;
+                if (e.getID() == KeyEvent.KEY_RELEASED) {
+                    fz.assignOwnHotkeyDigits(true);
+                } else if (e.getID() == KeyEvent.KEY_PRESSED) {
+                    fz.assignOwnHotkeyDigits(false);
+                }
+            }
+        }
         if (e.getID() != KeyEvent.KEY_PRESSED) return false;
         // Esc with focused, non-empty search field clears the filter instead of closing the window.
         if (e.getKeyCode() == KeyEvent.VK_ESCAPE && !e.isControlDown() && !e.isAltDown() && !e.isMetaDown()) {
@@ -788,17 +797,19 @@ public class FloatingZone extends FloatingCardArea {
         return null;
     }
 
-    private void assignOwnHotkeyDigits() {
+    private void assignOwnHotkeyDigits(boolean clear) {
         final boolean selecting = getMatchUI().isSelecting();
         int next = 1;
         for (final CardPanel panel : getCardPanels()) {
-            if (selecting && next <= 9 && getMatchUI().isSelectable(panel.getCard())) {
+            if (!clear && selecting && next <= 9 && getMatchUI().isSelectable(panel.getCard())) {
                 panel.setHotkeyDigit(next++);
             } else {
                 panel.setHotkeyDigit(0);
             }
         }
-        hotkeyHint.setVisible(next > 1);
+        if (!clear) {
+            hotkeyHint.setVisible(next > 1);
+        }
     }
 
 }

--- a/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingZone.java
+++ b/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingZone.java
@@ -799,10 +799,9 @@ public class FloatingZone extends FloatingCardArea {
     }
 
     private void assignOwnHotkeyDigits(boolean clear) {
-        final boolean selecting = getMatchUI().isSelecting();
         int next = 1;
         for (final CardPanel panel : getCardPanels()) {
-            if (!clear && selecting && next <= 9 && getMatchUI().isSelectable(panel.getCard())) {
+            if (!clear && next <= 9 && getMatchUI().isSelectable(panel.getCard())) {
                 panel.setHotkeyDigit(next++);
             } else {
                 panel.setHotkeyDigit(0);

--- a/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingZone.java
+++ b/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingZone.java
@@ -58,6 +58,7 @@ import forge.model.FModel;
 import forge.screens.match.CMatchUI;
 import forge.screens.match.views.VHand;
 import forge.screens.match.views.VZone;
+import forge.toolbox.FHtmlViewer;
 import forge.toolbox.FLabel;
 import forge.toolbox.FMouseAdapter;
 import forge.toolbox.FScrollPane;
@@ -316,6 +317,13 @@ public class FloatingZone extends FloatingCardArea {
         }
     }
 
+    /** Lightweight refresh path for mid-selection prompt changes — avoids rebuilding card panels. */
+    public static void refreshSelectionPrompts() {
+        for (final FloatingZone fz : floatingAreas.values()) {
+            if (fz.isVisible()) fz.updatePromptVisibility();
+        }
+    }
+
     /** Returns the docked VZone for a player/zone, or null. */
     public static VZone getDockedZone(final PlayerView player, final ZoneType zone) {
         return dockedZones.get(getKey(player, zone));
@@ -530,6 +538,7 @@ public class FloatingZone extends FloatingCardArea {
     private final FTextField searchField = new FTextField.Builder()
             .ghostText(Localizer.getInstance().getMessage("lblFilterByName"))
             .build();
+    private final FHtmlViewer promptLabel = new FHtmlViewer();
     private final FLabel hotkeyHint = new FLabel.Builder()
             .text(Localizer.getInstance().getMessage("lblHotkeySelectHint"))
             .fontSize(11)
@@ -575,6 +584,9 @@ public class FloatingZone extends FloatingCardArea {
             @Override public void removeUpdate(final DocumentEvent e) { onFilterChanged(); }
             @Override public void changedUpdate(final DocumentEvent e) { onFilterChanged(); }
         });
+        promptLabel.setBorder(BorderFactory.createEmptyBorder(3, 6, 3, 6));
+        promptLabel.setVisible(false);
+        window.add(promptLabel, "growx, wmin 10, gapbottom 4, wrap");
         window.add(searchField, "growx, wrap");
         window.add(getScrollPane(), "grow, push, wrap");
         hotkeyHint.setVisible(false);
@@ -650,7 +662,20 @@ public class FloatingZone extends FloatingCardArea {
         } else {
             getWindow().setTitle(String.format(title, shown));
         }
+        updatePromptVisibility();
         assignOwnHotkeyDigits();
+    }
+
+    private void updatePromptVisibility() {
+        final boolean show = getMatchUI().isSelecting();
+        final String prompt = show ? getMatchUI().getPromptMessage() : null;
+        if (prompt != null && !prompt.isEmpty()) {
+            promptLabel.setText(FSkin.encodeSymbols(prompt, false));
+            promptLabel.setVisible(true);
+        } else {
+            promptLabel.setVisible(false);
+        }
+        window.revalidate();
     }
 
     private void toggleSorted() {

--- a/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingZone.java
+++ b/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingZone.java
@@ -67,6 +67,7 @@ import forge.toolbox.FTextField;
 import forge.toolbox.MouseTriggerEvent;
 import forge.toolbox.special.PlayerDetailsPanel;
 import forge.util.Localizer;
+import forge.util.StreamUtil;
 import forge.util.collect.FCollection;
 import forge.util.collect.FCollectionView;
 import forge.view.FView;
@@ -667,7 +668,7 @@ public class FloatingZone extends FloatingCardArea {
     }
 
     private void updatePromptVisibility() {
-        final boolean show = getMatchUI().isSelecting();
+        final boolean show = getCards() != null && StreamUtil.stream(getCards()).anyMatch(c -> getMatchUI().isSelectable(c));
         final String prompt = show ? getMatchUI().getPromptMessage() : null;
         if (prompt != null && !prompt.isEmpty()) {
             promptLabel.setText(FSkin.encodeSymbols(prompt, false));

--- a/forge-gui-desktop/src/test/java/forge/gamesimulationtests/util/PlayerControllerForTests.java
+++ b/forge-gui-desktop/src/test/java/forge/gamesimulationtests/util/PlayerControllerForTests.java
@@ -282,7 +282,7 @@ public class PlayerControllerForTests extends PlayerController {
     }
 
     @Override
-    public CardCollection chooseCardsToDiscardFrom(Player playerDiscard, SpellAbility sa, CardCollection validCards, int min, int max) {
+    public CardCollection chooseCardsToDiscardFrom(Player playerDiscard, SpellAbility sa, CardCollection validCards, int min, int max, CardCollectionView visibleToChooser) {
         return chooseItems(validCards, min);
     }
 

--- a/forge-gui/res/languages/en-US.properties
+++ b/forge-gui/res/languages/en-US.properties
@@ -1352,6 +1352,8 @@ lblSelectCard=select card
 lblClickToconfigureFilters=Click to configure filters
 lblShownOfTotalCards=Number of cards shown / Total available cards
 lblToggleShowOrHideOptionsForCurrentView=Toggle to show/hide options for current view
+lblFilterByName=Filter by name
+lblHotkeySelectHint=Press Ctrl+1-9 to quick-select
 lblFilterMenu=FilterMenu
 lblShowFilters=Show Filters
 lblAddOrEditFilter=Add/Edit Filter
@@ -2941,6 +2943,7 @@ lblCouldBotDeleteFile=Could not delete file.
 lblRightClickToUnSort=- sorted by name (right click in title to not sort)
 lblRightClickToSort=(right click in title to sort)
 lblPlayerZoneNCardSortStatus={0} {1} ({2}) {3}
+lblPlayerZoneNOfMCardSortStatus={0} {1} ({2} of {3}) {4}
 #OnlineMenu.java
 lblOnline=Online
 lblShowChatPanel=Show Chat Panel

--- a/forge-gui/src/main/java/forge/gamemodes/match/input/InputSelectManyBase.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/input/InputSelectManyBase.java
@@ -88,12 +88,10 @@ public abstract class InputSelectManyBase<T extends GameEntity> extends InputSyn
             }
             sb.append("\n").append(getMessage());
             showMessage(sb.toString(), card);
+        } else if (card != null) {
+            showMessage(getMessage(), card);
         } else {
-            if (card != null) { 
-                showMessage(getMessage(), card);
-            } else {
-                showMessage(getMessage());
-            }
+            showMessage(getMessage());
         }
         getController().getGui().updateButtons(getOwner(), hasEnoughTargets(), allowCancel, true);
     }

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -427,13 +427,9 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
     }
 
     private boolean useSelectCardsInput(final FCollectionView<? extends GameEntity> sourceList, final SpellAbility sa) {
-        //this can be used to stop zone select GUI when certain APIs would reveal illegal zone information
-        //initially created for HeistEffect which showed library placement
+        // would reveal illegal zone information
         if (sa != null && ApiType.Heist.equals(sa.getApi())) return false;
-        return useSelectCardsInput(sourceList);
-    }
 
-    private boolean useSelectCardsInput(final FCollectionView<? extends GameEntity> sourceList) {
         // can't use InputSelect from GUI thread (e.g., DevMode Tutor)
         if (FThreads.isGuiThread()) {
             return false;
@@ -486,7 +482,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
 
         getGui().setPanelSelection(CardView.get(sa.getHostCard()));
 
-        if (useSelectCardsInput(sourceList)) {
+        if (useSelectCardsInput(sourceList, sa)) {
             tempShowCards(sourceList);
             final InputSelectCardsFromList sc = new InputSelectCardsFromList(this, min, max, sourceList, sa);
             sc.setMessage(title);
@@ -645,7 +641,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
         }
 
         tempShow(optionList);
-        if (useSelectCardsInput(optionList)) {
+        if (useSelectCardsInput(optionList, sa)) {
             final InputSelectEntitiesFromList<T> input = new InputSelectEntitiesFromList<>(this, min, max, optionList, sa);
             input.setCancelAllowed(min == 0);
             input.setMessage(MessageUtil.formatMessage(title, player, targetedPlayer));
@@ -1168,7 +1164,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
                     && !sa.hasParam("RevealNumber")
                     && (discardMode.startsWith("Reveal") || discardMode.startsWith("Look"));
             tempShowCards(fullHandRevealedToChooser ? p.getCardsIn(ZoneType.Hand) : valid);
-            if (useSelectCardsInput(valid)) {
+            if (useSelectCardsInput(valid, sa)) {
                 final InputSelectCardsFromList inp = new InputSelectCardsFromList(this, min, max, valid, sa);
                 inp.setMessage(String.format(localizer.getMessage("lblChooseMinCardToDiscard"), optional ? max : min));
                 inp.setCancelAllowed(optional);

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -935,8 +935,26 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
         } else {
             tempShowCards(cards);
             TrackableCollection<CardView> collection = CardView.getCollection(cards);
-            getGui().reveal(fm, collection);
-            getGui().updateRevealedCards(collection);
+            // Show opponent's hand as a FloatingZone with a minimal OK dialog instead of a names list
+            final boolean useFloatingHandReveal = zone == ZoneType.Hand
+                    && owner != getLocalPlayerView()
+                    && FModel.getPreferences().getPrefBoolean(FPref.UI_SELECT_FROM_CARD_DISPLAYS)
+                    && !getGui().isLibgdxPort();
+            if (useFloatingHandReveal) {
+                final PlayerZoneUpdates zonesToUpdate = new PlayerZoneUpdates();
+                zonesToUpdate.add(new PlayerZoneUpdate(owner, zone));
+                final Iterable<PlayerZoneUpdate>[] zonesShown = new Iterable[1];
+                FThreads.invokeInEdtNowOrLater(() -> {
+                    getGui().updateZones(zonesToUpdate);
+                    zonesShown[0] = getGui().tempShowZones(getLocalPlayerView(), zonesToUpdate);
+                });
+                getGui().message(fm);
+                getGui().updateRevealedCards(collection);
+                FThreads.invokeInEdtNowOrLater(() -> getGui().hideZones(getLocalPlayerView(), zonesShown[0]));
+            } else {
+                getGui().reveal(fm, collection);
+                getGui().updateRevealedCards(collection);
+            }
             endTempShowCards();
         }
     }
@@ -1144,7 +1162,20 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
         boolean optional = min == 0;
 
         if (p != player) {
-            tempShowCards(valid);
+            // Reveal/Look modes (no RevealNumber) publicly disclose the full hand — keep non-selectable revealed cards visible
+            final String discardMode = sa.getParam("Mode");
+            final boolean fullHandRevealedToChooser = discardMode != null
+                    && !sa.hasParam("RevealNumber")
+                    && (discardMode.startsWith("Reveal") || discardMode.startsWith("Look"));
+            tempShowCards(fullHandRevealedToChooser ? p.getCardsIn(ZoneType.Hand) : valid);
+            if (useSelectCardsInput(valid)) {
+                final InputSelectCardsFromList inp = new InputSelectCardsFromList(this, min, max, valid, sa);
+                inp.setMessage(String.format(localizer.getMessage("lblChooseMinCardToDiscard"), optional ? max : min));
+                inp.setCancelAllowed(optional);
+                inp.showAndWait();
+                endTempShowCards();
+                return new CardCollection(inp.getSelected());
+            }
             GameEntityViewMap<Card, CardView> gameCacheDiscard = GameEntityView.getMap(valid);
             List<CardView> views = getGui().many(String.format(localizer.getMessage("lblChooseMinCardToDiscard"), optional ? max : min),
                     localizer.getMessage("lblDiscarded"), min, max, gameCacheDiscard.getTrackableKeys(), null);

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -1154,16 +1154,12 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
 
     @Override
     public CardCollectionView chooseCardsToDiscardFrom(final Player p, final SpellAbility sa,
-                                                       final CardCollection valid, final int min, final int max) {
+                                                       final CardCollection valid, final int min, final int max,
+                                                       final CardCollectionView visibleToChooser) {
         boolean optional = min == 0;
 
         if (p != player) {
-            // Reveal/Look modes (no RevealNumber) publicly disclose the full hand — keep non-selectable revealed cards visible
-            final String discardMode = sa.getParam("Mode");
-            final boolean fullHandRevealedToChooser = discardMode != null
-                    && !sa.hasParam("RevealNumber")
-                    && (discardMode.startsWith("Reveal") || discardMode.startsWith("Look"));
-            tempShowCards(fullHandRevealedToChooser ? p.getCardsIn(ZoneType.Hand) : valid);
+            tempShowCards(visibleToChooser);
             if (useSelectCardsInput(valid, sa)) {
                 final InputSelectCardsFromList inp = new InputSelectCardsFromList(this, min, max, valid, sa);
                 inp.setMessage(String.format(localizer.getMessage("lblChooseMinCardToDiscard"), optional ? max : min));


### PR DESCRIPTION
**USING MIND WARP, X=2**

**BEFORE:**
Reveal step
<img width="449" height="387" alt="Screenshot 2026-05-12 074617" src="https://github.com/user-attachments/assets/1d21404f-c906-46a9-8fdd-458ce368abdb" />
Select step
<img width="889" height="511" alt="Screenshot 2026-05-12 074624" src="https://github.com/user-attachments/assets/4f1623d9-a5a5-4c33-990e-5d39f84bc27b" />

**AFTER:**
Reveal step
<img width="773" height="625" alt="Screenshot 2026-05-12 074032" src="https://github.com/user-attachments/assets/99fcd7ae-a703-486d-8ccc-5b384b4d79a2" />
Select step
<img width="726" height="625" alt="Screenshot 2026-05-12 074044" src="https://github.com/user-attachments/assets/86ab18bc-968b-4dc2-8003-0e410347c0f0" />

---

## Summary

Per https://github.com/Card-Forge/forge/pull/10646#issuecomment-4416485496: `RevealYouChoose` / `LookYouChoose` discards (Inquisition, Mind Warp, etc.) currently surface as a names-list reveal dialog followed by a separate selection grid, when the opponent's hand could be the selection UI directly.

This routes both steps through the existing FloatingZone: reveal opens the hand face-up with a minimal OK acknowledgement; the pick uses `InputSelectCardsFromList` so legal targets are clicked in that same FloatingZone.

## Implementation

- `PlayerControllerHuman.reveal()` — desktop opponent-hand reveals swap `getGui().reveal()` (names list) for `tempShowZones` + `getGui().message()` (visual hand + minimal OK).
- `PlayerControllerHuman.chooseCardsToDiscardFrom()` — opponent-discard pick routes through `InputSelectCardsFromList`; tempShows the full hand for `Reveal*`/`Look*` modes without `RevealNumber` so revealed non-selectable cards stay visible. `RevealNumber` spells (Blackmail, Cabal Interrogator) keep the conservative tempShow-of-valid path so unrevealed cards stay face-down.
- `CMatchUI.hideZones()` — fix a pre-existing asymmetry: `tempShowZones` special-cases `ZoneType.Hand`, but `hideZones` only checked `FLOATING_ZONE_TYPES` (which omits Hand). The FloatingZone opens for an opponent's hand but never closed programmatically.

## Safety

Both PCH changes gate on `UI_SELECT_FROM_CARD_DISPLAYS && !getGui().isLibgdxPort()` — the same condition `useSelectCardsInput` already uses. Mobile and preference-off paths are unchanged. `isLibgdxPort()` is the per-GUI network-safe check from <!-- -->#10615. No engine, protocol, or `TrackableProperty` changes.

`RevealNumber` partial-reveal spells (e.g. Blackmail revealing 3 of 5) are rendered safely: `FloatingZone.getCards()` returns all hand cards, but each is drawn according to the existing `mayView` check — only `mayLookTemp`-flagged cards (the revealed subset) show their faces, the rest render as card backs. Non-revealed cards' identities stay hidden; only hand size is conveyed, which is already public info.

## Potential code cleanup (not in this PR)

`FPref.UI_SELECT_FROM_CARD_DISPLAYS` was added in 2019 (commit `09fc3ae60c2`) alongside the original `arrangeForScry` GUI introduction, which brought in-zone selection as a new UX. The preference has defaulted to `true` with no user-facing UI toggle ever since — effectively the active desktop UI path for 7+ years. 

The preference gates whether `InputSelect` extends beyond the local player's own hand and battlefield to other zones (opponent-hand FloatingZone, libraries, graveyards, etc.) — i.e. click a card in its zone display versus fall back to a names-list dialog. All three desktop call sites in `PlayerControllerHuman` pair it with `!getGui().isLibgdxPort()`. 

A separate cleanup PR could drop the `FPref` entry, simplify the three dual-gate sites to single `!isLibgdxPort()` checks, and collapse the now-dead fallback branches in `useSelectCardsInput` (the zone-set ternary) and `arrangeForScry` (the manual-order path).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)