### PR TITLE
Cancel End Turn auto-pass for playable post-blockers responses

### DIFF
--- a/forge-gui-desktop/src/test/java/forge/player/PlayerControllerHumanTest.java
+++ b/forge-gui-desktop/src/test/java/forge/player/PlayerControllerHumanTest.java
@@ -1,0 +1,96 @@
+package forge.player;
+
+import forge.ai.simulation.SimulationTest;
+import forge.game.Game;
+import forge.game.card.Card;
+import forge.game.combat.Combat;
+import forge.game.phase.PhaseType;
+import forge.game.player.Player;
+import forge.game.zone.ZoneType;
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+public class PlayerControllerHumanTest extends SimulationTest {
+    @Test
+    public void declareBlockersAutoPassInterruptIgnoresManaAbilitiesOnly() {
+        Game game = initAndCreateGame();
+        Player player = game.getPlayers().get(1);
+
+        addCardToZone("Mountain", player, ZoneType.Battlefield);
+
+        setDeclareBlockersPriority(game, player);
+
+        AssertJUnit.assertFalse(PlayerControllerHuman.hasPlayableNonManaAbility(player));
+    }
+
+    @Test
+    public void declareBlockersAutoPassInterruptIgnoresUnaffordableInstantCombatTrick() {
+        Game game = initAndCreateGame();
+        Player player = game.getPlayers().get(1);
+
+        addCardToZone("Grizzly Bears", player, ZoneType.Battlefield);
+        addCardToZone("Brute Force", player, ZoneType.Hand);
+
+        setDeclareBlockersPriority(game, player);
+
+        AssertJUnit.assertFalse(PlayerControllerHuman.hasPlayableNonManaAbility(player));
+    }
+
+    @Test
+    public void declareBlockersAutoPassInterruptFindsAffordableInstantCombatTrick() {
+        Game game = initAndCreateGame();
+        Player player = game.getPlayers().get(1);
+
+        addCardToZone("Grizzly Bears", player, ZoneType.Battlefield);
+        addCardToZone("Mountain", player, ZoneType.Battlefield);
+        addCardToZone("Brute Force", player, ZoneType.Hand);
+
+        setDeclareBlockersPriority(game, player);
+
+        AssertJUnit.assertTrue(PlayerControllerHuman.hasPlayableNonManaAbility(player));
+    }
+
+    @Test
+    public void declareBlockersAutoPassInterruptIgnoresSorceryTiming() {
+        Game game = initAndCreateGame();
+        Player player = game.getPlayers().get(1);
+
+        addCardToZone("Wrath of God", player, ZoneType.Hand);
+
+        setDeclareBlockersPriority(game, player);
+
+        AssertJUnit.assertFalse(PlayerControllerHuman.hasPlayableNonManaAbility(player));
+    }
+
+    @Test
+    public void declareBlockersAutoPassInterruptRequiresPlayerToBeAttacked() {
+        Game game = initAndCreateThreePlayerGame();
+        Player attackingPlayer = game.getPlayers().get(0);
+        Player attackedPlayer = game.getPlayers().get(1);
+        Player uninvolvedPlayer = game.getPlayers().get(2);
+
+        Card attacker = addCardToZone("Grizzly Bears", attackingPlayer, ZoneType.Battlefield);
+        addCardToZone("Grizzly Bears", attackedPlayer, ZoneType.Battlefield);
+        addCardToZone("Mountain", attackedPlayer, ZoneType.Battlefield);
+        addCardToZone("Brute Force", attackedPlayer, ZoneType.Hand);
+        addCardToZone("Grizzly Bears", uninvolvedPlayer, ZoneType.Battlefield);
+        addCardToZone("Mountain", uninvolvedPlayer, ZoneType.Battlefield);
+        addCardToZone("Brute Force", uninvolvedPlayer, ZoneType.Hand);
+
+        Combat combat = new Combat(attackingPlayer);
+        combat.addAttacker(attacker, attackedPlayer);
+        game.getPhaseHandler().devModeSet(PhaseType.COMBAT_DECLARE_BLOCKERS, attackingPlayer, false);
+        game.getPhaseHandler().setCombat(combat);
+
+        game.getPhaseHandler().setPriority(uninvolvedPlayer);
+        AssertJUnit.assertFalse(PlayerControllerHuman.shouldInterruptDeclareBlockersAutoPass(uninvolvedPlayer));
+
+        game.getPhaseHandler().setPriority(attackedPlayer);
+        AssertJUnit.assertTrue(PlayerControllerHuman.shouldInterruptDeclareBlockersAutoPass(attackedPlayer));
+    }
+
+    private void setDeclareBlockersPriority(Game game, Player player) {
+        game.getPhaseHandler().devModeSet(PhaseType.COMBAT_DECLARE_BLOCKERS, player);
+        game.getAction().checkStateEffects(true);
+    }
+}

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -1,6 +1,7 @@
 package forge.player;
 
 import com.google.common.collect.*;
+import forge.ai.ComputerUtilMana;
 import forge.LobbyPlayer;
 import forge.StaticData;
 import forge.ai.GameState;
@@ -29,6 +30,7 @@ import forge.game.keyword.KeywordInterface;
 import forge.game.mana.Mana;
 import forge.game.mana.ManaConversionMatrix;
 import forge.game.mana.ManaCostBeingPaid;
+import forge.game.phase.PhaseHandler;
 import forge.game.phase.PhaseType;
 import forge.game.player.*;
 import forge.game.player.actions.SelectCardAction;
@@ -93,6 +95,9 @@ import java.util.stream.Collectors;
  * Handles phase skips for now.
  */
 public class PlayerControllerHuman extends PlayerController implements IGameController, IHasForgeLog {
+    private static final ZoneType[] AUTOPASS_INTERRUPT_ZONES = {
+            ZoneType.Hand, ZoneType.Battlefield, ZoneType.Graveyard, ZoneType.Exile, ZoneType.Flashback, ZoneType.Command
+    };
 
     /**
      * Cards this player may look at right now, for example when searching a
@@ -1495,29 +1500,13 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
         final MagicStack stack = getGame().getStack();
 
         if (mayAutoPass()) {
-            // avoid prompting for input if current phase is set to be
-            // auto-passed instead posing a short delay if needed to
-            // prevent the game jumping ahead too quick
-            int delay = 0;
-            if (stack.isEmpty()) {
-                // make sure to briefly pause at phases you're not set up to skip
-                if (!isUiSetToSkipPhase(getGame().getPhaseHandler().getPlayerTurn().getView(),
-                        getGame().getPhaseHandler().getPhase())) {
-                    delay = FControlGamePlayback.phasesDelay;
-                }
+            if (shouldInterruptDeclareBlockersAutoPass(stack)) {
+                autoPassCancel();
             } else {
-                // pause slightly longer for spells and abilities on the stack resolving
-                delay = FControlGamePlayback.resolveDelay;
+                pauseForAutoPass(stack);
+                netLog.trace("Returning null (mayAutoPass) for player {}", player.getName());
+                return null;
             }
-            if (delay > 0) {
-                try {
-                    Thread.sleep(delay);
-                } catch (final InterruptedException e) {
-                    e.printStackTrace();
-                }
-            }
-            netLog.trace("Returning null (mayAutoPass) for player {}", player.getName());
-            return null;
         }
 
         if (stack.isEmpty()) {
@@ -1545,6 +1534,58 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
         defaultInput.showAndWait();
         netLog.trace("InputPassPriority returned for player {}, chosenSa={}", player.getName(), defaultInput.getChosenSa());
         return defaultInput.getChosenSa();
+    }
+
+    private void pauseForAutoPass(final MagicStack stack) {
+        final int delay;
+        if (stack.isEmpty()) {
+            delay = isUiSetToSkipPhase(getGame().getPhaseHandler().getPlayerTurn().getView(),
+                    getGame().getPhaseHandler().getPhase()) ? 0 : FControlGamePlayback.phasesDelay;
+        } else {
+            delay = FControlGamePlayback.resolveDelay;
+        }
+        if (delay <= 0) {
+            return;
+        }
+        try {
+            Thread.sleep(delay);
+        } catch (final InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private boolean shouldInterruptDeclareBlockersAutoPass(final MagicStack stack) {
+        return yieldController.autoPassUntilEndOfTurn() && stack.isEmpty()
+                && shouldInterruptDeclareBlockersAutoPass(player);
+    }
+
+    static boolean shouldInterruptDeclareBlockersAutoPass(final Player player) {
+        final Game game = player.getGame();
+        final PhaseHandler phaseHandler = game.getPhaseHandler();
+        if (!phaseHandler.is(PhaseType.COMBAT_DECLARE_BLOCKERS)) {
+            return false;
+        }
+        if (phaseHandler.getPriorityPlayer() != player) {
+            return false;
+        }
+        final Combat combat = phaseHandler.getCombat();
+        if (combat == null || !combat.isPlayerAttacked(player)) {
+            return false;
+        }
+        return hasPlayableNonManaAbility(player);
+    }
+
+    static boolean hasPlayableNonManaAbility(final Player player) {
+        for (final ZoneType zone : AUTOPASS_INTERRUPT_ZONES) {
+            for (final Card card : player.getCardsIn(zone)) {
+                for (final SpellAbility sa : card.getAllPossibleAbilities(player, true)) {
+                    if (!sa.isManaAbility() && ComputerUtilMana.canPayManaCost(sa.getPayCosts(), sa, player, 0, false)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
This branch fixes a UX issue where Forge could skip the legal priority window after blockers were declared. In Magic rules, players receive priority during the declare blockers step after blockers are assigned, so a defending player should be able to cast combat tricks or activate relevant abilities before combat damage.

The implementation updates human priority handling so End Turn auto-pass is interrupted during COMBAT_DECLARE_BLOCKERS only when it matters:

- the player has priority
- the player is actually being attacked
- the stack is empty
- the player has a payable non-mana spell or ability

This avoids waking unrelated players in multiplayer games and avoids stopping just because the player has mana abilities available. Spells that cost mana still count, but only if the mana cost can currently be paid.

Regression tests cover:

- mana abilities alone do not interrupt auto-pass
- unaffordable instant tricks do not interrupt auto-pass
- affordable instant tricks do interrupt auto-pass
- sorcery-speed cards do not interrupt during declare blockers
- uninvolved multiplayer opponents are not interrupted when another player is attacked

Verification:

mvn -pl forge-gui-desktop -am -Dtest=forge.player.PlayerControllerHumanTest -Dsurefire.failIfNoSpecifiedTests=false test