### PR TITLE
Network cleanup: consolidate input/output streams

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/net/CObjectOutputStream.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/CObjectOutputStream.java
@@ -9,8 +9,10 @@ import java.io.OutputStream;
 
 /**
  * {@link ObjectOutputStream} subclass used by {@link CompatibleObjectEncoder}
- * for the payload of every network message. Two differences from the JDK
- * default:
+ * for the payload of every network message, and by
+ * {@link TrackableSerializer#wrapEvents}/{@link TrackableSerializer#measureSize}
+ * for inner-layer event serialization and size instrumentation. Two
+ * differences from the JDK default:
  *
  * <ul>
  *   <li>Writes a <b>thin class descriptor</b>: a one-byte type tag plus the
@@ -20,8 +22,9 @@ import java.io.OutputStream;
  *       the wire.</li>
  *   <li>When replacement is enabled (per-message, by the encoder), delegates
  *       {@code replaceObject} to {@link TrackableSerializer#replace} with the
- *       supplied Tracker, turning tracked CardView/PlayerView references into
- *       compact {@link TrackableSerializer.IdRef} markers.</li>
+ *       supplied Tracker / consumerId / eventMode, turning tracked
+ *       CardView/PlayerView references into compact {@link TrackableSerializer.IdRef}
+ *       (or {@link TrackableSerializer.EventCardRef} when {@code eventMode}) markers.</li>
  * </ul>
  */
 public class CObjectOutputStream extends ObjectOutputStream {
@@ -29,11 +32,13 @@ public class CObjectOutputStream extends ObjectOutputStream {
 
     private final Tracker tracker;
     private final int consumerId;
+    private final boolean eventMode;
 
-    CObjectOutputStream(OutputStream out, boolean replaceTrackables, Tracker tracker, int consumerId) throws IOException {
+    CObjectOutputStream(OutputStream out, boolean replaceTrackables, Tracker tracker, int consumerId, boolean eventMode) throws IOException {
         super(out);
         this.tracker = tracker;
         this.consumerId = consumerId;
+        this.eventMode = eventMode;
         if (replaceTrackables) {
             enableReplaceObject(true);
         }
@@ -47,6 +52,6 @@ public class CObjectOutputStream extends ObjectOutputStream {
 
     @Override
     protected Object replaceObject(Object obj) throws IOException {
-        return TrackableSerializer.replace(obj, tracker, consumerId, false);
+        return TrackableSerializer.replace(obj, tracker, consumerId, eventMode);
     }
 }

--- a/forge-gui/src/main/java/forge/gamemodes/net/CompatibleObjectEncoder.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/CompatibleObjectEncoder.java
@@ -74,7 +74,7 @@ public class CompatibleObjectEncoder extends MessageToByteEncoder<Serializable> 
 
         try {
             byteOut.write(LENGTH_PLACEHOLDER);
-            objectOut = new CObjectOutputStream(new LZ4BlockOutputStream(byteOut), replace, tracker, consumerId);
+            objectOut = new CObjectOutputStream(new LZ4BlockOutputStream(byteOut), replace, tracker, consumerId, false);
             objectOut.writeObject(msg);
             objectOut.flush();
         } finally {

--- a/forge-gui/src/main/java/forge/gamemodes/net/TrackableSerializer.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/TrackableSerializer.java
@@ -9,6 +9,9 @@ import forge.trackable.TrackableTypes;
 import forge.trackable.TrackableTypes.TrackableType;
 import forge.trackable.Tracker;
 
+import io.netty.handler.codec.serialization.ClassResolver;
+import io.netty.handler.codec.serialization.ClassResolvers;
+
 import org.tinylog.Logger;
 import org.tinylog.TaggedLogger;
 
@@ -29,6 +32,8 @@ import java.util.List;
  */
 public final class TrackableSerializer {
     private static final TaggedLogger netLog = Logger.tag("NETWORK");
+
+    private static final ClassResolver INNER_CLASS_RESOLVER = ClassResolvers.cacheDisabled(null);
 
     static final byte TYPE_CARD_VIEW = 0;
     static final byte TYPE_PLAYER_VIEW = 1;
@@ -150,9 +155,9 @@ public final class TrackableSerializer {
         try {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             LZ4BlockOutputStream lz4Out = new LZ4BlockOutputStream(baos);
-            ObjectOutputStream oos = tracker == null ? new ObjectOutputStream(lz4Out) : new ReplacingOutputStream(lz4Out, tracker, false);
-            oos.writeObject(obj);
-            oos.close();
+            try (CObjectOutputStream oos = new CObjectOutputStream(lz4Out, tracker != null, tracker, -1, false)) {
+                oos.writeObject(obj);
+            }
             return baos.size();
         } catch (Exception e) {
             return 0;
@@ -181,7 +186,7 @@ public final class TrackableSerializer {
         for (GameEvent event : events) {
             try {
                 ByteArrayOutputStream baos = new ByteArrayOutputStream(256);
-                try (ReplacingOutputStream out = new ReplacingOutputStream(baos, tracker, true)) {
+                try (CObjectOutputStream out = new CObjectOutputStream(baos, true, tracker, -1, true)) {
                     out.writeObject(event);
                 }
                 wrapped.add(new WrappedEvent(baos.toByteArray()));
@@ -203,7 +208,7 @@ public final class TrackableSerializer {
             if (item instanceof WrappedEvent we) {
                 try {
                     ByteArrayInputStream bais = new ByteArrayInputStream(we.data);
-                    try (ResolvingInputStream in = new ResolvingInputStream(bais, tracker)) {
+                    try (CObjectInputStream in = new CObjectInputStream(bais, INNER_CLASS_RESOLVER, tracker)) {
                         Object obj = in.readObject();
                         if (obj instanceof GameEvent e) events.add(e);
                     }
@@ -213,60 +218,6 @@ public final class TrackableSerializer {
             }
         }
         return events;
-    }
-
-    static class ReplacingOutputStream extends ObjectOutputStream {
-        private final Tracker tracker;
-        private final boolean eventMode;
-
-        ReplacingOutputStream(OutputStream out, Tracker tracker, boolean eventMode) throws IOException {
-            super(out);
-            this.tracker = tracker;
-            this.eventMode = eventMode;
-            enableReplaceObject(true);
-        }
-
-        @Override
-        protected Object replaceObject(Object obj) {
-            // Inner-layer stream (events / size measurement). No per-client
-            // consumer here — eventMode=true uses EventCardRef which carries
-            // its own snapshot, and DeltaPacket property maps already use
-            // Integer IDs via toNetworkValue, so the !eventMode path has
-            // nothing to replace.
-            return replace(obj, tracker, -1, eventMode);
-        }
-    }
-
-    static class ResolvingInputStream extends ObjectInputStream {
-        private final Tracker tracker;
-
-        ResolvingInputStream(InputStream in, Tracker tracker) throws IOException {
-            super(in);
-            this.tracker = tracker;
-            enableResolveObject(true);
-        }
-
-        // Android desugars records to classes with computed serialVersionUID; the JVM keeps records at 0L.
-        // Fall through to the local descriptor when UIDs mismatch.
-        @Override
-        protected ObjectStreamClass readClassDescriptor() throws IOException, ClassNotFoundException {
-            ObjectStreamClass streamDesc = super.readClassDescriptor();
-            try {
-                Class<?> localClass = Class.forName(streamDesc.getName());
-                ObjectStreamClass localDesc = ObjectStreamClass.lookup(localClass);
-                if (localDesc != null && streamDesc.getSerialVersionUID() != localDesc.getSerialVersionUID()) {
-                    return localDesc;
-                }
-            } catch (ClassNotFoundException ignored) {
-                // Class not found locally — fall through to stream descriptor.
-            }
-            return streamDesc;
-        }
-
-        @Override
-        protected Object resolveObject(Object obj) {
-            return resolve(obj, tracker);
-        }
     }
 
     private TrackableSerializer() {}


### PR DESCRIPTION
## Summary

[Comment on <!-- -->#10662](https://github.com/Card-Forge/forge/pull/10662#discussion_r3227126178) asked whether `TrackableSerializer.ReplacingOutputStream`/`ResolvingInputStream` were still needed once the outer-pipeline `CObjectOutputStream`/`CObjectInputStream` had grown the Tracker/consumerId plumbing. 

They weren't — the inner pair only served three call sites (`wrapEvents`, `unwrapEvents`, `measureSize`), all of which can be expressed in terms of the outer codec. The inner pair wrote full `ObjectStreamClass` blocks, carrying `serialVersionUID` on the wire — which is what the Android records workaround in `ResolvingInputStream.readClassDescriptor` had to compensate for (JVM keeps records at `0L`, d8 desugars records with a computed UID). `CObjectOutputStream` writes thin descriptors — a one-byte tag plus the UTF class name — so no UID travels on the wire and the disagreement never surfaces. 

Routing the three inner call sites through `CObjectOutputStream`/`CObjectInputStream` makes the workaround unreachable, and it's deleted with the classes.

## Implementation

- `CObjectOutputStream` gains an `eventMode` parameter so it can serve as both the outer-pipeline encoder (`IdRef` substitution) and the event-wrap encoder (`EventCardRef` substitution). The single outer caller in `CompatibleObjectEncoder` passes `false`.
- `wrapEvents` switches to `new CObjectOutputStream(baos, true, tracker, -1, true)`. `unwrapEvents` switches to `new CObjectInputStream(bais, INNER_CLASS_RESOLVER, tracker)`. `measureSize` switches and gains exception-safe try-with-resources.
- `INNER_CLASS_RESOLVER` is a static `ClassResolvers.cacheDisabled(null)` on `TrackableSerializer`, matching what the outer Netty pipeline uses in `FServerManager`/`FGameClient`.
- `ReplacingOutputStream` and `ResolvingInputStream` are deleted, taking the UID-mismatch fallback with them.

## Testing completed

- Smoke-tested cross-platform netplay with an Android emulator, events deserialize cleanly on both sides.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)