### PR TITLE
Card cleanup: 2026-05-13

### DIFF
--- a/forge-gui/res/cardsfolder/a/abraded_bluffs.txt
+++ b/forge-gui/res/cardsfolder/a/abraded_bluffs.txt
@@ -6,4 +6,4 @@ SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When CARDNAME enters, it deals 1 damage to target opponent.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Opponent | NumDmg$ 1
 A:AB$ Mana | Cost$ T | Produced$ Combo R W | SpellDescription$ Add {R} or {W}.
-Oracle:Abraded Bluffs enters tapped.\nWhen Abraded Bluffs enters, it deals 1 damage to target opponent.\n{T}:Add {R} or {W}.
+Oracle:Abraded Bluffs enters tapped.\nWhen Abraded Bluffs enters, it deals 1 damage to target opponent.\n{T}: Add {R} or {W}.

--- a/forge-gui/res/cardsfolder/a/anthropede.txt
+++ b/forge-gui/res/cardsfolder/a/anthropede.txt
@@ -5,7 +5,7 @@ PT:3/4
 K:Reach
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChoice | TriggerDescription$ When CARDNAME enters, you may discard a card or pay {2}. When you do, destroy target Room.
 SVar:TrigChoice:DB$ GenericChoice | Choices$ PayDiscard,Pay2
-SVar:Pay2:DB$ ImmediateTrigger | UnlessCost$ 2 | UnlessPayer$ You | UnlessSwitched$ True | Execute$ TrigDestroy | SpellDescription$ pay {2}: When you do, destroy target Room.
-SVar:PayDiscard:DB$ ImmediateTrigger | UnlessCost$ Discard<1/Card> | UnlessPayer$ You | UnlessSwitched$ True | Execute$ TrigDestroy | SpellDescription$ discard a card: When you do, destroy target Room.
-SVar:TrigDestroy:DB$ Destroy | ValidTgts$ Room | TgtPrompt$ Select target Room
+SVar:Pay2:DB$ ImmediateTrigger | UnlessCost$ 2 | UnlessPayer$ You | UnlessSwitched$ True | Execute$ TrigDestroy | SpellDescription$ You may pay {2}. When you do, destroy target Room. | TriggerDescription$ When you do, destroy target Room.
+SVar:PayDiscard:DB$ ImmediateTrigger | UnlessCost$ Discard<1/Card> | UnlessPayer$ You | UnlessSwitched$ True | Execute$ TrigDestroy | SpellDescription$ You may discard a card. When you do, destroy target Room. | TriggerDescription$ When you do, destroy target Room.
+SVar:TrigDestroy:DB$ Destroy | ValidTgts$ Room
 Oracle:Reach\nWhen Anthropede enters, you may discard a card or pay {2}. When you do, destroy target Room.

--- a/forge-gui/res/cardsfolder/b/bristling_backwoods.txt
+++ b/forge-gui/res/cardsfolder/b/bristling_backwoods.txt
@@ -6,4 +6,4 @@ SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When CARDNAME enters, it deals 1 damage to target opponent.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Opponent | NumDmg$ 1
 A:AB$ Mana | Cost$ T | Produced$ Combo R G | SpellDescription$ Add {R} or {G}.
-Oracle:Bristling Backwoods enters tapped.\nWhen Bristling Backwoods enters, it deals 1 damage to target opponent.\n{T}:Add {R} or {G}.
+Oracle:Bristling Backwoods enters tapped.\nWhen Bristling Backwoods enters, it deals 1 damage to target opponent.\n{T}: Add {R} or {G}.

--- a/forge-gui/res/cardsfolder/c/chandra_legacy_of_fire.txt
+++ b/forge-gui/res/cardsfolder/c/chandra_legacy_of_fire.txt
@@ -13,4 +13,4 @@ SVar:STPlay:Mode$ Continuous | Affected$ Card.IsRemembered | MayPlay$ True | Aff
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearImprinted$ True
 SVar:Z:Count$RememberedNumber
 DeckHints:Type$Planeswalker
-Oracle:At the beginning of your end step, Chandra, Legacy of Fire deals X damage to each opponent, where X is the number of planeswalkers you control.\n[+1]:Add {R} for each planeswalker you control.\n[0]: Remove a loyalty counter from each of any number of permanents you control. Exile that many cards from the top of your library. You may play them this turn.
+Oracle:At the beginning of your end step, Chandra, Legacy of Fire deals X damage to each opponent, where X is the number of planeswalkers you control.\n[+1]: Add {R} for each planeswalker you control.\n[0]: Remove a loyalty counter from each of any number of permanents you control. Exile that many cards from the top of your library. You may play them this turn.

--- a/forge-gui/res/cardsfolder/c/creosote_heath.txt
+++ b/forge-gui/res/cardsfolder/c/creosote_heath.txt
@@ -6,4 +6,4 @@ SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When CARDNAME enters, it deals 1 damage to target opponent.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Opponent | NumDmg$ 1
 A:AB$ Mana | Cost$ T | Produced$ Combo W G | SpellDescription$ Add {W} or {G}.
-Oracle:Creosote Heath enters tapped.\nWhen Creosote Heath enters, it deals 1 damage to target opponent.\n{T}:Add {W} or {G}.
+Oracle:Creosote Heath enters tapped.\nWhen Creosote Heath enters, it deals 1 damage to target opponent.\n{T}: Add {W} or {G}.

--- a/forge-gui/res/cardsfolder/e/eroded_canyon.txt
+++ b/forge-gui/res/cardsfolder/e/eroded_canyon.txt
@@ -6,4 +6,4 @@ SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When CARDNAME enters, it deals 1 damage to target opponent.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Opponent | NumDmg$ 1
 A:AB$ Mana | Cost$ T | Produced$ Combo U R | SpellDescription$ Add {U} or {R}.
-Oracle:Eroded Canyon enters tapped.\nWhen Eroded Canyon enters, it deals 1 damage to target opponent.\n{T}:Add {U} or {R}.
+Oracle:Eroded Canyon enters tapped.\nWhen Eroded Canyon enters, it deals 1 damage to target opponent.\n{T}: Add {U} or {R}.

--- a/forge-gui/res/cardsfolder/f/festering_gulch.txt
+++ b/forge-gui/res/cardsfolder/f/festering_gulch.txt
@@ -6,4 +6,4 @@ SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When CARDNAME enters, it deals 1 damage to target opponent.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Opponent | NumDmg$ 1
 A:AB$ Mana | Cost$ T | Produced$ Combo B G | SpellDescription$ Add {B} or {G}.
-Oracle:Festering Gulch enters tapped.\nWhen Festering Gulch enters, it deals 1 damage to target opponent.\n{T}:Add {B} or {G}.
+Oracle:Festering Gulch enters tapped.\nWhen Festering Gulch enters, it deals 1 damage to target opponent.\n{T}: Add {B} or {G}.

--- a/forge-gui/res/cardsfolder/f/forlorn_flats.txt
+++ b/forge-gui/res/cardsfolder/f/forlorn_flats.txt
@@ -6,4 +6,4 @@ SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When CARDNAME enters, it deals 1 damage to target opponent.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Opponent | NumDmg$ 1
 A:AB$ Mana | Cost$ T | Produced$ Combo W B | SpellDescription$ Add {W} or {B}.
-Oracle:Forlorn Flats enters tapped.\nWhen Forlorn Flats enters, it deals 1 damage to target opponent.\n{T}:Add {W} or {B}.
+Oracle:Forlorn Flats enters tapped.\nWhen Forlorn Flats enters, it deals 1 damage to target opponent.\n{T}: Add {W} or {B}.

--- a/forge-gui/res/cardsfolder/j/jagged_barrens.txt
+++ b/forge-gui/res/cardsfolder/j/jagged_barrens.txt
@@ -6,4 +6,4 @@ SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When CARDNAME enters, it deals 1 damage to target opponent.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Opponent | NumDmg$ 1
 A:AB$ Mana | Cost$ T | Produced$ Combo B R | SpellDescription$ Add {B} or {R}.
-Oracle:Jagged Barrens enters tapped.\nWhen Jagged Barrens enters, it deals 1 damage to target opponent.\n{T}:Add {B} or {R}.
+Oracle:Jagged Barrens enters tapped.\nWhen Jagged Barrens enters, it deals 1 damage to target opponent.\n{T}: Add {B} or {R}.

--- a/forge-gui/res/cardsfolder/l/lonely_arroyo.txt
+++ b/forge-gui/res/cardsfolder/l/lonely_arroyo.txt
@@ -6,4 +6,4 @@ SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When CARDNAME enters, it deals 1 damage to target opponent.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Opponent | NumDmg$ 1
 A:AB$ Mana | Cost$ T | Produced$ Combo W U | SpellDescription$ Add {W} or {U}.
-Oracle:Lonely Arroyo enters tapped.\nWhen Lonely Arroyo enters, it deals 1 damage to target opponent.\n{T}:Add {W} or {U}.
+Oracle:Lonely Arroyo enters tapped.\nWhen Lonely Arroyo enters, it deals 1 damage to target opponent.\n{T}: Add {W} or {U}.

--- a/forge-gui/res/cardsfolder/l/lush_oasis.txt
+++ b/forge-gui/res/cardsfolder/l/lush_oasis.txt
@@ -6,4 +6,4 @@ SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When CARDNAME enters, it deals 1 damage to target opponent.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Opponent | NumDmg$ 1
 A:AB$ Mana | Cost$ T | Produced$ Combo G U | SpellDescription$ Add {G} or {U}.
-Oracle:Lush Oasis enters tapped.\nWhen Lush Oasis enters, it deals 1 damage to target opponent.\n{T}:Add {G} or {U}.
+Oracle:Lush Oasis enters tapped.\nWhen Lush Oasis enters, it deals 1 damage to target opponent.\n{T}: Add {G} or {U}.

--- a/forge-gui/res/cardsfolder/n/nimble_hobbit.txt
+++ b/forge-gui/res/cardsfolder/n/nimble_hobbit.txt
@@ -4,8 +4,8 @@ Types:Creature Halfling Peasant
 PT:1/3
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigChoice | TriggerDescription$ Whenever CARDNAME attacks, you may sacrifice a Food or pay {2}{W}. When you do, tap target creature an opponent controls.
 SVar:TrigChoice:DB$ GenericChoice | Choices$ PayW,PaySacFood
-SVar:PayW:DB$ ImmediateTrigger | UnlessCost$ 2 W | UnlessPayer$ You | UnlessSwitched$ True | Execute$ TrigTap | SpellDescription$ pay {2}{W}: When you do, tap target creature an opponent controls.
-SVar:PaySacFood:DB$ ImmediateTrigger | UnlessCost$ Sac<1/Food> | UnlessPayer$ You | UnlessSwitched$ True | Execute$ TrigTap | SpellDescription$ sacrifice a Food: When you do, tap target creature an opponent controls.
+SVar:PayW:DB$ ImmediateTrigger | UnlessCost$ 2 W | UnlessPayer$ You | UnlessSwitched$ True | Execute$ TrigTap | SpellDescription$ You may pay {2}{W}. When you do, tap target creature an opponent controls. | TriggerDescription$ When you do, tap target creature an opponent controls.
+SVar:PaySacFood:DB$ ImmediateTrigger | UnlessCost$ Sac<1/Food> | UnlessPayer$ You | UnlessSwitched$ True | Execute$ TrigTap | SpellDescription$ You may sacrifice a Food. When you do, tap target creature an opponent controls. | TriggerDescription$ When you do, tap target creature an opponent controls.
 SVar:TrigTap:DB$ Tap | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls
 SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Sacrifice

--- a/forge-gui/res/cardsfolder/s/soured_springs.txt
+++ b/forge-gui/res/cardsfolder/s/soured_springs.txt
@@ -6,4 +6,4 @@ SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When CARDNAME enters, it deals 1 damage to target opponent.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Opponent | NumDmg$ 1
 A:AB$ Mana | Cost$ T | Produced$ Combo U B | SpellDescription$ Add {U} or {B}.
-Oracle:Soured Springs enters tapped.\nWhen Soured Springs enters, it deals 1 damage to target opponent.\n{T}:Add {U} or {B}.
+Oracle:Soured Springs enters tapped.\nWhen Soured Springs enters, it deals 1 damage to target opponent.\n{T}: Add {U} or {B}.

--- a/forge-gui/res/cardsfolder/t/the_battle_of_dragon_brothers_fate_reforged.txt
+++ b/forge-gui/res/cardsfolder/t/the_battle_of_dragon_brothers_fate_reforged.txt
@@ -5,11 +5,11 @@ Defense:6
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigCharm | TriggerDescription$ When CARDNAME enters, ABILITY
 SVar:TrigCharm:DB$ Charm | Choices$ DBDestroyAll,DBManifestThree | AdditionalDescription$ and note the choice: Bolas or Ugin.
 SVar:DBDestroyAll:DB$ DestroyAll | ValidCards$ Creature | SubAbility$ DBClearUgin | SpellDescription$ Bolas — Destroy all creatures.
-SVar:DBClearUgin:DB$ Pump | Defined$ Player | ClearNotedCardsFor$ BattleUgin | SubAbility$ DBNoteBolas
-SVar:DBNoteBolas:DB$ Pump | NoteCards$ Self | NoteCardsFor$ BattleBolas
+SVar:DBClearUgin:DB$ Pump | Defined$ Player | ClearNotedCardsFor$ BattleUgin | SubAbility$ DBNoteBolas | StackDescription$ None
+SVar:DBNoteBolas:DB$ Pump | NoteCards$ Self | NoteCardsFor$ BattleBolas | StackDescription$ None
 SVar:DBManifestThree:DB$ Manifest | Amount$ 3 | SubAbility$ DBClearBolas | SpellDescription$ Ugin — Manifest the top three cards of your library.
-SVar:DBClearBolas:DB$ Pump | Defined$ Player | ClearNotedCardsFor$ BattleBolas | SubAbility$ DBNoteUgin
-SVar:DBNoteUgin:DB$ Pump | NoteCards$ Self | NoteCardsFor$ BattleUgin
+SVar:DBClearBolas:DB$ Pump | Defined$ Player | ClearNotedCardsFor$ BattleBolas | SubAbility$ DBNoteUgin | StackDescription$ None
+SVar:DBNoteUgin:DB$ Pump | NoteCards$ Self | NoteCardsFor$ BattleUgin | StackDescription$ None
 AlternateMode:DoubleFaced
 Oracle:(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen The Battle of Dragon Brothers enters, choose Bolas or Ugin.\n• Bolas — Destroy all creatures.\n• Ugin — Manifest the top three cards of your library.
 

--- a/forge-gui/res/cardsfolder/u/urzas_workshop.txt
+++ b/forge-gui/res/cardsfolder/u/urzas_workshop.txt
@@ -5,4 +5,4 @@ A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ T | Activation$ Metalcraft | PrecostDesc$ Metalcraft — | Produced$ C | Amount$ X | SpellDescription$ Add {C} for each Urza's land you control. Activate only if you control three or more artifacts.
 SVar:X:Count$Valid Urza's.Land+YouCtrl
 DeckNeeds:Type$Urza
-Oracle:{T}: Add {C}.\nMetalcraft — {T}:Add {C} for each Urza's land you control. Activate only if you control three or more artifacts.
+Oracle:{T}: Add {C}.\nMetalcraft — {T}: Add {C} for each Urza's land you control. Activate only if you control three or more artifacts.


### PR DESCRIPTION
Mostly resolving missing spaces trailing colons. Notably reworked [Anthropede](https://scryfall.com/card/dsk/167/anthropede), [Nimble Hobbit](https://scryfall.com/card/ltr/23/nimble-hobbit) and [The Battle of Dragon Brothers // Fate Reforged](https://scryfall.com/card/unk/RC07b/the-battle-of-dragon-brothers-fate-reforged) so they read a bit better on Prompt and Stack. Screenshots follow for the before and after of Anthropede's relevant behavior (applicable to Nimble Hobbit).

 <img width="1186" height="524" alt="choiceimmediatetrigger-1" src="https://github.com/user-attachments/assets/0b25e60e-5766-4708-bd4d-a96875dba1f4" />
 
<img width="1171" height="438" alt="choiceimmediatetrigger-2" src="https://github.com/user-attachments/assets/e624aa6f-5c13-495c-ad1d-47c4d82e3f01" />