### PR TITLE
Update card fetching and unique card indexing

### DIFF
--- a/forge-core/src/main/java/forge/card/CardDb.java
+++ b/forge-core/src/main/java/forge/card/CardDb.java
@@ -755,11 +755,18 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
             filter = filter.and((c) -> collectorNumber.equals(c.getCollectorNumber()));
 
         List<PaperCard> candidates = getAllCards(cardName, filter);
-        // Weird quirk here. If a set contains both "Ancestral Recall" and "Emeritus of Ideation // Ancestral Recall", a
-        // card request for Ancestral Recall with no collector number could find either. Could use getAllCardsNoAlt, but
-        // then a request for "Fire" wouldn't find "Fire // Ice".
         if (candidates.isEmpty())
             return null;
+
+        if (candidates.stream().map(PaperCard::getRules).distinct().count() > 1)
+        {
+            //We've run into either an ambiguous alt-face or an Emeritus situation. Can't do anything for the former,
+            //but we can bias towards the main face if it's the latter.
+            String finalCardName = cardName;
+            if (candidates.stream().map(PaperCard::getName).anyMatch(n -> n.equalsIgnoreCase(finalCardName))) {
+                candidates.removeIf(c -> !c.getName().equalsIgnoreCase(finalCardName));
+            }
+        }
 
         Iterator<PaperCard> candidatesIterator = candidates.iterator();
         PaperCard candidate = candidatesIterator.next();

--- a/forge-core/src/main/java/forge/card/CardDb.java
+++ b/forge-core/src/main/java/forge/card/CardDb.java
@@ -62,7 +62,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
     private final CardEdition.Collection editions;
     private final Set<String> filtered;
 
-    private Map<String, Boolean> nonLegendaryCreatureNames = Maps.newHashMap();
+    private final Map<String, Boolean> nonLegendaryCreatureNames = Maps.newHashMap();
 
     public enum CardArtPreference {
         LATEST_ART_ALL_EDITIONS(false, true),
@@ -96,10 +96,6 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
         public boolean isFoil;
         public String collectorNumber;
         public Map<String, String> flags;
-
-        private CardRequest(String name, String edition, int artIndex, boolean isFoil, String collectorNumber) {
-            this(name, edition, artIndex, isFoil, collectorNumber, null);
-        }
 
         private CardRequest(String name, String edition, int artIndex, boolean isFoil, String collectorNumber, Map<String, String> flags) {
             cardName = name;
@@ -313,11 +309,10 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
             if (filteredCards.contains(rule.getPreInitName()))
                 continue;
             for (ICardFace face : rule.getAllFaces()) {
-                addFaceToDbNames(face);
-                rulesByAltName.put(face.getName(), rule);
+                addFaceToDbNames(face, rule);
             }
             if (rule.hasFunctionalVariants()) {
-                cacheFlavorNames(rule);
+                cacheRuleFlavorNames(rule);
             }
         }
 
@@ -327,12 +322,15 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
         }
     }
 
-    private void addFaceToDbNames(ICardFace face) {
+    private void addFaceToDbNames(ICardFace face, CardRules rules) {
         if (face == null) {
             return;
         }
         final String name = face.getName();
         facesByName.put(name, face);
+        //Stash names of alternate faces for loose name-to-rules lookups. Technically ambiguous; first come, first served.
+        if (!rulesByPrimaryName.containsKey(name))
+            rulesByAltName.putIfAbsent(name, rules);
         final String normalName = StringUtils.stripAccents(name);
         if (!normalName.equals(name)) {
             normalizedNames.put(normalName, name);
@@ -340,13 +338,13 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
 
         if (face.hasFunctionalVariants()) {
             for (ICardFace varFace : face.getFunctionalVariants().values())
-                cacheFlavorName(varFace);
+                cacheFaceFlavorName(varFace);
         }
         if (face.getFlavorName() != null) //Probably shouldn't be putting a flavor name on the main print?
-            cacheFlavorName(face);
+            cacheFaceFlavorName(face);
     }
 
-    private void cacheFlavorName(ICardFace face) {
+    private void cacheFaceFlavorName(ICardFace face) {
         String altName = face.getFlavorName();
         if(altName == null)
             return;
@@ -357,7 +355,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
         }
     }
 
-    private void cacheFlavorNames(CardRules rules) {
+    private void cacheRuleFlavorNames(CardRules rules) {
         if (rules.getSupportedFunctionalVariants() == null)
             return;
         boolean hasFlavorName = false;
@@ -401,9 +399,9 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
                 flavorNameMappings.put(normalizedFlavorName, variantName);
                 flavorNameMappings.put(cr.getName(), IPaperCard.NO_FUNCTIONAL_VARIANT);
                 rulesByAltName.put(normalizedFlavorName, cr);
-                cacheFlavorName(cr.getMainPart().getFunctionalVariant(variantName));
+                cacheFaceFlavorName(cr.getMainPart().getFunctionalVariant(variantName));
                 if(cr.getOtherPart() != null)
-                    cacheFlavorName(cr.getOtherPart().getFunctionalVariant(variantName));
+                    cacheFaceFlavorName(cr.getOtherPart().getFunctionalVariant(variantName));
             }
         }
 
@@ -931,8 +929,8 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
         return uniqueCardsByRules.values();
     }
 
-    public PaperCard getUniqueByName(final String name) {
-        CardRules rules = getRules(name, true);
+    public PaperCard getUniqueByName(String cardName) {
+        CardRules rules = getRules(cardName, true);
         if(rules == null)
             return null;
         return uniqueCardsByRules.get(rules);

--- a/forge-core/src/main/java/forge/card/CardDb.java
+++ b/forge-core/src/main/java/forge/card/CardDb.java
@@ -65,7 +65,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
 
     private final Map<String, Boolean> nonLegendaryCreatureNames = Maps.newHashMap();
 
-    public enum CardArtPreference {
+    public enum CardArtPreference implements Comparator<CardEdition> {
         LATEST_ART_ALL_EDITIONS(false, true),
         LATEST_ART_CORE_EXPANSIONS_REPRINT_ONLY(true, true),
         ORIGINAL_ART_ALL_EDITIONS(false, false),
@@ -84,6 +84,15 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
         public boolean accept(CardEdition ed) {
             if (ed == null) return false;
             return !filterSets || ALLOWED_SET_TYPES.contains(ed.getType());
+        }
+
+        @Override
+        public int compare(CardEdition o1, CardEdition o2) {
+            if (o1 == o2)
+                return 0;
+            if(filterSets && (ALLOWED_SET_TYPES.contains(o1.getType()) != ALLOWED_SET_TYPES.contains(o2.getType())))
+                return ALLOWED_SET_TYPES.contains(o1.getType()) ? -1 : 1;
+            return (latestFirst ? -1 : 1) * o1.getDate().compareTo(o2.getDate());
         }
     }
 
@@ -559,29 +568,24 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
         uniqueCardsByRules.clear();
         uniqueCardsByFlavorName.clear();
         for (Entry<CardRules, Collection<PaperCard>> kv : allCardsByRules.asMap().entrySet()) {
-            PaperCard pc = getFirstNonSpecialWithImage(kv.getValue());
+            PaperCard pc = getBestUniquePrint(kv.getValue());
             uniqueCardsByRules.put(kv.getKey(), pc);
         }
         for (Entry<String, String> kv : flavorNameMappings.entrySet()) {
             if (kv.getValue().equals(IPaperCard.NO_FUNCTIONAL_VARIANT))
                 continue;
             String flavorName = kv.getKey();
-            PaperCard pc = getFirstNonSpecialWithImage(allCardsByName.get(flavorName));
+            PaperCard pc = getBestUniquePrint(allCardsByName.get(flavorName));
             uniqueCardsByFlavorName.put(flavorName, pc);
         }
     }
 
-    private static PaperCard getFirstNonSpecialWithImage(final Collection<PaperCard> cards) {
-        //NOTE: this is written this way to avoid checking final card in list
-        final Iterator<PaperCard> iterator = cards.iterator();
-        PaperCard pc = iterator.next();
-        while (iterator.hasNext()) {
-            if (pc.hasImage() && !pc.getRarity().equals(CardRarity.Special)) {
-                return pc;
-            }
-            pc = iterator.next();
-        }
-        return pc;
+    private PaperCard getBestUniquePrint(final Collection<PaperCard> cards) {
+        return cards.stream()
+                .filter(pc -> !pc.getRarity().equals(CardRarity.Special))
+                .min(Comparator.comparing((PaperCard pc) -> editions.get(pc.getEdition()), defaultCardArtPreference)
+                        .thenComparing(PaperCard::getCollectorNumber))
+                .orElseGet(() -> cards.iterator().next());
     }
 
     public boolean setPreferredArt(String cardName, String setCode, int artIndex) {

--- a/forge-core/src/main/java/forge/card/CardDb.java
+++ b/forge-core/src/main/java/forge/card/CardDb.java
@@ -939,36 +939,6 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
         return cardsInSet.size();
     }
 
-    // returns a list of all cards from their respective latest (or preferred) editions
-    @Override
-    public Collection<PaperCard> getUniqueCards() {
-        return uniqueCardsByRules.values();
-    }
-
-    public PaperCard getUniqueByName(String cardName) {
-        if (uniqueCardsByFlavorName.containsKey(cardName))
-            return uniqueCardsByFlavorName.get(cardName);
-        CardRules rules = getRules(cardName, true);
-        if(rules == null)
-            return null;
-        return uniqueCardsByRules.get(rules);
-    }
-
-    public PaperCard getUniqueByNameNoAlt(String cardName) {
-        CardRules rules = getRules(cardName, false);
-        if(rules == null)
-            return null;
-        return uniqueCardsByRules.get(rules);
-    }
-
-    public Collection<ICardFace> getAllFaces() {
-        return facesByName.values();
-    }
-
-    public ICardFace getFaceByName(final String name) {
-        return facesByName.get(getNormalizedName(name));
-    }
-
     public boolean isNonLegendaryCreatureName(final String name) {
         Boolean bool = nonLegendaryCreatureNames.get(name);
         if (bool != null) {
@@ -994,6 +964,16 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
         return Collections.unmodifiableCollection(allCardsByName.values());
     }
 
+    // returns a list of all cards from their respective latest (or preferred) editions
+    @Override
+    public Collection<PaperCard> getUniqueCards() {
+        return uniqueCardsByRules.values();
+    }
+    @Override
+    public Collection<ICardFace> getAllFaces() {
+        return facesByName.values();
+    }
+
     @Override
     public Stream<PaperCard> streamAllCards() {
         return allCardsByRules.values().stream();
@@ -1002,7 +982,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
     public Stream<PaperCard> streamUniqueCards() {
         return uniqueCardsByRules.values().stream();
     }
-
+    @Override
     public Stream<ICardFace> streamAllFaces() {
         return facesByName.values().stream();
     }
@@ -1062,8 +1042,11 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
      * </ul>
      * @see #getAllCards(String)
      */
-    public List<PaperCard> getAllCardsNoAlt(String cardName) {
-        return Lists.newArrayList(Multimaps.filterEntries(allCardsByName, entry -> entry.getKey().equals(entry.getValue().getName())).get(getNormalizedName(cardName)));
+    public List<PaperCard> getAllCardsNoAlt(String rulesName) {
+        CardRules rules = getRules(rulesName, false);
+        if(rules == null)
+            return null;
+        return allCardsByRules.get(rules);
     }
 
     public List<PaperCard> getAllCards(CardRules rules) {
@@ -1091,8 +1074,13 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
         return getAllCards(card).stream().filter(predicate).collect(Collectors.toCollection(ArrayList::new));
     }
 
-    public List<PaperCard> getAllCardsNoAlt(final String cardName, Predicate<PaperCard> predicate){
-        return getAllCardsNoAlt(cardName).stream().filter(predicate).collect(Collectors.toCollection(ArrayList::new));
+    public List<PaperCard> getAllCards(CardRules card, Predicate<PaperCard> predicate){
+        return getAllCards(card).stream().filter(predicate).collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    @Override
+    public List<PaperCard> getAllCardsNoAlt(final String rulesName, Predicate<PaperCard> predicate){
+        return getAllCardsNoAlt(rulesName).stream().filter(predicate).collect(Collectors.toCollection(ArrayList::new));
     }
 
     // Do I want a foiled version of these cards?
@@ -1110,6 +1098,29 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
             cards.add(card);
         }
         return cards;
+    }
+
+    @Override
+    public PaperCard getUniqueByName(String cardName) {
+        if (uniqueCardsByFlavorName.containsKey(cardName))
+            return uniqueCardsByFlavorName.get(cardName);
+        CardRules rules = getRules(cardName, true);
+        if(rules == null)
+            return null;
+        return uniqueCardsByRules.get(rules);
+    }
+
+    @Override
+    public PaperCard getUniqueByNameNoAlt(String rulesName) {
+        CardRules rules = getRules(rulesName, false);
+        if(rules == null)
+            return null;
+        return uniqueCardsByRules.get(rules);
+    }
+
+    @Override
+    public ICardFace getFaceByName(String faceName) {
+        return facesByName.get(getNormalizedName(faceName));
     }
 
     @Override

--- a/forge-core/src/main/java/forge/card/CardDb.java
+++ b/forge-core/src/main/java/forge/card/CardDb.java
@@ -56,6 +56,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
      * Map of flavor names to the identifier of the functional variant on which they appear in their respective card rules.
      */
     private final Map<String, String> flavorNameMappings = Maps.newHashMap();
+    private final Map<String, PaperCard> uniqueCardsByFlavorName = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
 
     private final Map<String, Integer> artIds = Maps.newHashMap();
 
@@ -556,9 +557,17 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
 
     private void reIndex() {
         uniqueCardsByRules.clear();
+        uniqueCardsByFlavorName.clear();
         for (Entry<CardRules, Collection<PaperCard>> kv : allCardsByRules.asMap().entrySet()) {
             PaperCard pc = getFirstNonSpecialWithImage(kv.getValue());
             uniqueCardsByRules.put(kv.getKey(), pc);
+        }
+        for (Entry<String, String> kv : flavorNameMappings.entrySet()) {
+            if (kv.getValue().equals(IPaperCard.NO_FUNCTIONAL_VARIANT))
+                continue;
+            String flavorName = kv.getKey();
+            PaperCard pc = getFirstNonSpecialWithImage(allCardsByName.get(flavorName));
+            uniqueCardsByFlavorName.put(flavorName, pc);
         }
     }
 
@@ -930,6 +939,8 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
     }
 
     public PaperCard getUniqueByName(String cardName) {
+        if (uniqueCardsByFlavorName.containsKey(cardName))
+            return uniqueCardsByFlavorName.get(cardName);
         CardRules rules = getRules(cardName, true);
         if(rules == null)
             return null;

--- a/forge-core/src/main/java/forge/card/CardDb.java
+++ b/forge-core/src/main/java/forge/card/CardDb.java
@@ -965,7 +965,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
 
     @Override
     public Collection<PaperCard> getAllCards() {
-        return Collections.unmodifiableCollection(allCardsByName.values());
+        return Collections.unmodifiableCollection(allCardsByRules.values());
     }
 
     // returns a list of all cards from their respective latest (or preferred) editions

--- a/forge-core/src/main/java/forge/card/CardDb.java
+++ b/forge-core/src/main/java/forge/card/CardDb.java
@@ -1049,7 +1049,7 @@ public final class CardDb implements ICardDatabase, IDeckGenPool {
     public List<PaperCard> getAllCardsNoAlt(String rulesName) {
         CardRules rules = getRules(rulesName, false);
         if(rules == null)
-            return null;
+            return List.of();
         return allCardsByRules.get(rules);
     }
 

--- a/forge-core/src/main/java/forge/card/ICardDatabase.java
+++ b/forge-core/src/main/java/forge/card/ICardDatabase.java
@@ -127,10 +127,16 @@ public interface ICardDatabase extends Iterable<PaperCard> {
     Collection<PaperCard> getAllCards(Predicate<PaperCard> predicate);
     Collection<PaperCard> getAllCards(String cardName,Predicate<PaperCard> predicate);
     Collection<PaperCard> getAllCards(CardEdition edition);
+    Collection<PaperCard> getAllCardsNoAlt(String rulesName, Predicate<PaperCard> predicate);
     Collection<PaperCard> getUniqueCards();
+    PaperCard getUniqueByName(String cardName);
+    PaperCard getUniqueByNameNoAlt(String rulesName);
+    Collection<ICardFace> getAllFaces();
+    ICardFace getFaceByName(String faceName);
 
     Stream<PaperCard> streamAllCards();
     Stream<PaperCard> streamUniqueCards();
+    Stream<ICardFace> streamAllFaces();
 
     /* UTILITY METHODS
      * =============== */

--- a/forge-gui-mobile/src/forge/itemmanager/CardManager.java
+++ b/forge-gui-mobile/src/forge/itemmanager/CardManager.java
@@ -70,7 +70,7 @@ public class CardManager extends ItemManager<PaperCard> {
 
     @Override
     protected Iterable<Entry<PaperCard, Integer>> getUnique(Iterable<Entry<PaperCard, Integer>> items) {
-        //TO-maybe-DO: Share logic between this and identical method in desktop.
+        //TO-maybe-DO: Share logic between this and identical method in desktop. Possibly also with the unique indexing in CardDB?
         ListMultimap<String, Entry<PaperCard, Integer>> entriesByName = Multimaps.newListMultimap(
                 new TreeMap<>(String.CASE_INSENSITIVE_ORDER), Lists::newArrayList);
         for (Entry<PaperCard, Integer> item : items) {

--- a/forge-gui/src/main/java/forge/deck/CardArchetypeLDAGenerator.java
+++ b/forge-gui/src/main/java/forge/deck/CardArchetypeLDAGenerator.java
@@ -84,7 +84,7 @@ public final class CardArchetypeLDAGenerator {
             int i = 0;
             while (topic.size()<=40&&i<highRankVocabs.size()) {
                 String cardName = highRankVocabs.get(i).getLeft();
-                if(!StaticData.instance().getCommonCards().getUniqueByName(cardName).getRules().getType().isBasicLand()){
+                if(!StaticData.instance().getCommonCards().getRules(cardName, true).getType().isBasicLand()){
                     if(highRankVocabs.get(i).getRight()>=0.005d) {
                         topicCards.add(cardName);
                     }

--- a/forge-gui/src/main/java/forge/deck/CardThemedDeckGenerator.java
+++ b/forge-gui/src/main/java/forge/deck/CardThemedDeckGenerator.java
@@ -16,7 +16,7 @@ public class CardThemedDeckGenerator extends DeckProxy implements Comparable<Car
         final List<DeckProxy> decks = new ArrayList<>();
             for (String card: CardArchetypeLDAGenerator.ldaPools.get(format.getName()).keySet()) {
                 //exclude non AI playables as keycards for AI decks
-                if (isForAi&&FModel.getMagicDb().getCommonCards().getUniqueByName(card).getRules().getAiHints().getRemAIDecks()) {
+                if (isForAi&&FModel.getMagicDb().getCommonCards().getRules(card, true).getAiHints().getRemAIDecks()) {
                     continue;
                 }
                 decks.add(new CardThemedDeckGenerator(card, format, isForAi));

--- a/forge-gui/src/main/java/forge/gamemodes/limited/CardThemedDeckBuilder.java
+++ b/forge-gui/src/main/java/forge/gamemodes/limited/CardThemedDeckBuilder.java
@@ -715,7 +715,7 @@ public class CardThemedDeckBuilder extends DeckGeneratorBase {
      * Only adds wastes if present in the card pool but if present adds them all
      */
     private void addWastesIfRequired(){
-        PaperCard waste = FModel.getMagicDb().getCommonCards().getUniqueByName("Wastes");
+        PaperCard waste = FModel.getMagicDb().getCommonCards().getUniqueByNameNoAlt("Wastes");
         if(colors.isColorless()&& keyCard.getRules().getColorIdentity().isColorless()
                 && format.isLegalCard(waste)) {
             while (landsNeeded > 0) {


### PR DESCRIPTION
* Updates the `getCardFromSet` logic to disambiguate cases where a set contains both a card, and then that same card as an alt (e.g. prepared spell) name of a separate card. It'll now prefer cards that match the name exactly. Should hopefully fix the wrong images being loaded in this case.
* Renamed some symbols, rearranged some methods, moved some signatures up to the `ICardDatabase` interface.
* `getAllCardsNoAlt` now uses a name-to-rules lookup rather than doing a name-to-card lookup and then filtering the list by rules-name. Behavior should be unchanged.
* Using a flavor name in `getUniqueByName` will now fetch the flavored print. Flavor names still aren't accepted by `getUniqueByNameNoAlt`.
* The unique cards index now chooses prints that best fit the user's card art preference.