### PR TITLE
Fix SOS promo cards

### DIFF
--- a/forge-gui/res/editions/Secrets of Strixhaven.txt
+++ b/forge-gui/res/editions/Secrets of Strixhaven.txt
@@ -427,7 +427,7 @@ Replace=0.10F fromSheet("SOS common duals")+
 361 R Great Hall of the Biblioplex @Constantin Marin
 362 R Petrified Hamlet @Richard Wright
 
-[promos]
+[promo]
 306 M Emeritus of Ideation @Mark Poole
 363 U Lorehold Charm @Ksenia Kim
 364 U Prismari Charm @Inkognit


### PR DESCRIPTION
A section named "promo" is loaded as a normal edition card section. A section named "promos" gets treated like a print sheet. We've run into issues like this a couple times IIRC. Might be worth changing print sheets to require a distinct prefix or other distinction from regular edition sections.

Closes #10675. 