### PR TITLE
Extend auto-pass P hotkey to mobile

### DIFF
--- a/forge-gui-mobile/src/forge/screens/match/MatchScreen.java
+++ b/forge-gui-mobile/src/forge/screens/match/MatchScreen.java
@@ -664,6 +664,12 @@ public class MatchScreen extends FScreen {
                     return true;
                 }
                 break;
+            case Keys.P: //auto-pass toggle on Ctrl+P on Android, P when running on desktop
+                if (KeyInputAdapter.isCtrlKeyDown() || GuiBase.getInterface().isRunningOnDesktop()) {
+                    YieldController.toggleAutoPassOrStopAll(getGameController());
+                    return true;
+                }
+                break;
             case Keys.Q: //concede game on Ctrl+Q
                 if (KeyInputAdapter.isCtrlKeyDown()) {
                     confirmUserConcedes();


### PR DESCRIPTION
#10606 added a P shortcut on desktop that toggles APINA or clears any active yield. 

Extend this to mobile, adding a `Keys.P` case mirroring `Keys.E` — calls the same shared `YieldController.toggleAutoPassOrStopAll(...)` the desktop action uses.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)