### PR TITLE
Fix auto-pass triggering improvise/convoke prompts

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AvailableActions.java
+++ b/forge-ai/src/main/java/forge/ai/AvailableActions.java
@@ -18,6 +18,15 @@ public final class AvailableActions {
     public static boolean compute(Player player, long timeoutMs) {
         long deadlineNanos = System.nanoTime() + timeoutMs * 1_000_000L;
 
+        // Run the predictive sweep under an AI controller so cost-adjustment chooseX dispatches don't prompt (mirrors InputPayMana auto-pay).
+        boolean[] result = {false};
+        player.runWithController(
+                () -> result[0] = scan(player, deadlineNanos, timeoutMs),
+                new PlayerControllerAi(player.getGame(), player, player.getOriginalLobbyPlayer()));
+        return result[0];
+    }
+
+    private static boolean scan(Player player, long deadlineNanos, long timeoutMs) {
         for (Card card : sortedCardsIn(player, ZoneType.Hand)) {
             for (SpellAbility sa : card.getAllPossibleAbilities(player, true)) {
                 if (checkTimeout(deadlineNanos, timeoutMs)) return true;


### PR DESCRIPTION
## Summary

With auto-pass on, holding a spell with Improvise (e.g. Kappa Cannoneer), Convoke, Delve, Assist, Offering, or Emerge in hand opens its choice dialog at every priority window. `AvailableActions.compute`'s predictive `canPayManaCost(test=true)` reaches `CostAdjustment.adjust`, which calls `controller.chooseX(...)` — and the human controller answers by opening a GUI prompt.

Wrap the predictive sweep in `Player.runWithController(..., new PlayerControllerAi(...))` — same pattern `InputPayMana` uses for the Auto-pay button. `chooseX` calls now resolve to the AI's no-prompt implementations (e.g. `ComputerUtilMana.getConvokeOrImproviseFromList`, which algorithmically assigns artifacts/creatures to the cost's generic shards). The AI methods read from `sa.getActivatingPlayer()` and the passed-in card lists, so the estimate is computed against the human's own board.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)