### PR TITLE
Enable mass-select for mandatory library searches

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChangeZoneEffect.java
@@ -1140,8 +1140,9 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
                     }
                 }
                 // ensure that selection is within maximum allowed changeNum
+                final int multiMin = sa.hasParam("Mandatory") ? Math.min(changeNum, fetchList.size()) : 0;
                 do {
-                    selectedCards = decider.getController().chooseCardsForZoneChange(destination, origin, sa, fetchList, 0, changeNum, delayedReveal, selectPrompt, decider);
+                    selectedCards = decider.getController().chooseCardsForZoneChange(destination, origin, sa, fetchList, multiMin, changeNum, delayedReveal, selectPrompt, decider);
                 } while (selectedCards != null && selectedCards.size() > changeNum);
                 if (selectedCards != null) {
                     chosenCards.addAll(selectedCards);
@@ -1561,7 +1562,6 @@ public class ChangeZoneEffect extends SpellAbilityEffect {
 
     private static boolean allowMultiSelect(Player decider, SpellAbility sa) {
         return decider.getController().isGuiPlayer()        // limit mass selection to human players for now
-                && !sa.hasParam("Mandatory")                // only handle optional decisions, for now
                 && !sa.hasParam("ShareLandType")
                 && !sa.hasParam("DifferentNames")
                 && !sa.hasParam("DifferentPower")


### PR DESCRIPTION
## Summary

Mandatory "search your library for X cards" effects (e.g. Insidious Dreams) currently route through a single-card picker called X times in sequence rather than one batch multi-select. Each iteration re-opens the FloatingZone (desktop) or chooser (mobile).

This PR drops the `!sa.hasParam("Mandatory")` guard in `ChangeZoneEffect.allowMultiSelect`, and threads the real min through `chooseCardsForZoneChange` — `multiMin = Math.min(changeNum, fetchList.size())`.

## History

Mass-select was introduced in 2018-03 (`a564f49381d`), with `!Mandatory` baked in as a phased-rollout limit: `// only handle optional decisions, for now`. A week later (`b959f61049e`) added a companion `!ChangeNum` guard because mass-select had no bound enforcement — the player could pick "an arbitrarily small or big amount of cards without any limitation". `!ChangeNum` was lifted in 2018-08 once an upper-bound re-prompt loop landed (`eaeb2838e01`, `5f6ea460dd7`). The lower bound stayed at `min=0`, which is fine for optional effects but kept `!Mandatory` in place. This PR completes that work.

## Why it's safe

PR <!-- -->#10676 widened `setSelectables` to carry `(min, max)` end-to-end, and `InputSelectManyBase.hasEnoughTargets` gates the OK button on `selected.size() >= min`. The engine now passing a real min hooks straight into that.

**Mobile:** `useSelectCardsInput` excludes the libgdx port from the InputSelect path for library zones, so mobile already routes through `getGui().chooseEntitiesForEffect` → `SGuiChoose.order` → `DualListBox`, which gates OK on `remainingMin ≤ source.count ≤ remainingMax`. Mandatory effects on mobile now route through one batched `DualListBox` instead of N sequential pickers.

## Testing

- before: Insidious Dreams routes to the single-card picker on a loop
- after: Insidious Dreams routes to mass-select with the user able to highlight multiple cards and process as a batch

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)