### PR TITLE
Fix: route hand reveal to prompt instead of popup

### DIFF
--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -948,7 +948,12 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
                     getGui().updateZones(zonesToUpdate);
                     zonesShown[0] = getGui().tempShowZones(getLocalPlayerView(), zonesToUpdate);
                 });
-                getGui().message(fm);
+                final InputConfirm inp = new InputConfirm(this, fm,
+                        localizer.getMessage("lblOK"), localizer.getMessage("lblEndTurn"), true);
+                inp.showAndWait();
+                if (!inp.getResult()) {
+                    FThreads.invokeInEdtLater(this::autoPassUntilEndOfTurn);
+                }
                 getGui().updateRevealedCards(collection);
                 FThreads.invokeInEdtNowOrLater(() -> getGui().hideZones(getLocalPlayerView(), zonesShown[0]));
             } else {


### PR DESCRIPTION
**Before**
<img width="300" alt="image" src="https://github.com/user-attachments/assets/94bc8761-6c67-4d92-b2a8-affaddc4548d" />

**After**
<img width="300" alt="Screenshot 2026-05-18 132045" src="https://github.com/user-attachments/assets/76d971ac-550e-4f51-bc95-39e08bca389b" />

- Per dev feedback on <!-- -->#10660, the FloatingZone reveal acknowledgement fired a modal `getGui().message()` dialog that interrupted input focus (Duress was the reported case).
- Swap the modal for the existing "OK / End Turn" prompt used during priority passes — OK acknowledges; End Turn auto-passes through end of turn, same semantic as the rest of the input bar.
- Uses `InputConfirm` directly with "OK"/"End Turn" labels — no existing `Input` covers this shape, and a single-call-site subclass would be over-engineering. Same call-site pattern as `chooseStartingPlayer` (PCH:833). End Turn calls `autoPassUntilEndOfTurn()` via `FThreads.invokeInEdtLater`, mirroring `InputPassPriority.onCancel`.
- Mobile unchanged: `useFloatingHandReveal` is gated on `!getGui().isLibgdxPort()`, so the libgdx port takes the existing names-list `else` branch.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)