### PR TITLE
Implement custom rebalanced draft formats for Old Border Shandalar

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/data/AdventureEventData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/AdventureEventData.java
@@ -265,7 +265,7 @@ public class AdventureEventData implements Serializable {
                 return false;
             if (!c.hasBoosterTemplate())
                 return false;
-            if(c.getBoosterTemplate().getNumberOfCardsExpected() <= 11)
+            if(c.getBoosterTemplate().getNumberOfCardsExpected() <= 7)
                 return false;
             for (PrintSheet ps : c.getPrintSheetsBySection()) {
                 //exclude block with sets containing P9 cards.

--- a/forge-gui/res/adventure/Shandalar Old Border/blockdata/blocks.txt
+++ b/forge-gui/res/adventure/Shandalar Old Border/blockdata/blocks.txt
@@ -1,2 +1,9 @@
+# Customized draft formats for better balance in Old Border Shandalar; upstream versions hidden via restrictedBlocks.
+Arabian Nights (Old Border), 4/8/2ED, ARN ARN ARN 3ED
+Antiquities (Old Border), 4/8/2ED, ATQ ATQ ATQ 3ED
+Legends (Old Border), 3/6/3ED, LEG 3ED
+The Dark (Old Border), 4/8/3ED, DRK DRK DRK 3ED
+Fallen Empires (Old Border), 4/8/3ED, FEM FEM FEM 3ED
+Homelands (Old Border), 4/8/4ED, HML HML HML 4ED
 # 1995-style ICE/ICE/ALL draft; upstream "Ice Age" hidden via restrictedBlocks.
 Ice Age (Old Border), 3/6/ICE, ICE ICE ALL

--- a/forge-gui/res/adventure/Shandalar Old Border/config.json
+++ b/forge-gui/res/adventure/Shandalar Old Border/config.json
@@ -114,7 +114,9 @@
     "Urza's Science Fair Project"
   ],
   "restrictedEditions": ["8ED", "P8ED", "MRD"],
-  "restrictedBlocks": ["Ice Age"],
+  "restrictedBlocks": ["Arabian Nights", "Antiquities", "Legends", "The Dark",
+    "Fallen Empires", "Homelands", "Ice Age"
+  ],
   "restrictedTokens": ["P03/r_4_4_bird_flying", "P03/b_x_x_demon_flying"],
   "allowedEditions": [
     "LEA", "LEB", "2ED", "3ED", "ARN", "ATQ", "LEG", "DRK", "FEM", "4ED",


### PR DESCRIPTION
@vanja-ivancevic Can you please test that this works as desired in the Old Border world context? Also, are the names of the rebalanced draft blocks too long, perhaps? Maybe we should shorten them somehow? If you have ideas for a shorter title, please let me know :)