### PR TITLE
YSOS: 4 cards, batch 1

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/advanced_floral_invocations.txt
+++ b/forge-gui/res/cardsfolder/upcoming/advanced_floral_invocations.txt
@@ -1,0 +1,16 @@
+Name:Advanced Floral Invocations
+ManaCost:BG
+Types:Enchantment Class
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | TriggerZones$ Battlefield | ValidCard$ Land.YouCtrl | Execute$ TrigMill | TriggerDescription$ Landfall — Whenever a land you control enters, mill two cards.
+SVar:TrigMill:DB$ Mill | NumCards$ 2 | Defined$ You
+K:Class:2:BG:AddTrigger$ LandfallTrigger
+SVar:LandfallTrigger:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | TriggerZones$ Battlefield | Execute$ DBPumpAll | TriggerDescription$ Whenever a land you control enters, creature cards in your graveyard perpetually get +1/+1.
+SVar:DBPumpAll:DB$ PumpAll | ValidCards$ Creature.YouCtrl | PumpZone$ Graveyard | NumAtt$ +1 | NumDef$ +1 | Duration$ Perpetual
+K:Class:3:4 BG BG:AddStaticAbility$ ProdigysWill | AddTrigger$ STrigCounter
+SVar:ProdigysWill:Mode$ Continuous | Affected$ Land.YouCtrl,Creature.YouCtrl | Condition$ PlayerTurn | MayPlay$ True | EffectZone$ Battlefield | AffectedZone$ Graveyard | Description$ You may play lands and cast creature spells from your graveyard. If you cast a spell this way, that creature enters with a finality counter on it.
+SVar:STrigCounter:Mode$ SpellCast | ValidCard$ Card.CastSa Spell.MayPlaySource | Execute$ TrigEffect | Static$ True | TriggerZones$ Battlefield
+SVar:TrigEffect:DB$ Effect | ReplacementEffects$ ReMoved | RememberObjects$ TriggeredCard
+SVar:ReMoved:Event$ Moved | Origin$ Stack | ValidCard$ Card.IsRemembered | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBCounter
+SVar:ETBCounter:DB$ PutCounter | ETB$ True | Defined$ ReplacedCard | CounterType$ FINALITY | CounterNum$ 1 | SubAbility$ RemoveSelf
+SVar:RemoveSelf:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
+Oracle:Landfall — Whenever a land you control enters, mill two cards.\n{B/G}: Level 2\nWhenever a land you control enters, creature cards in your graveyard perpetually get +1/+1.\n{4}{B/G}{B/G}: Level 3\nYou may play lands and cast creature spells from your graveyard. If you cast a spell this way, that creature enters with a finality counter on it.

--- a/forge-gui/res/cardsfolder/upcoming/algorithmic_ferocity.txt
+++ b/forge-gui/res/cardsfolder/upcoming/algorithmic_ferocity.txt
@@ -1,0 +1,7 @@
+Name:Algorithmic Ferocity
+ManaCost:G
+Types:Sorcery
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Choose target creature you control | KW$ Indestructible | NumAtt$ +X | SubAbility$ DBFight | SpellDescription$ Until end of turn, target creature you control gains indestructible and gets +1/+0 for each card in your hand with mana value 4 or greater. Then it fights target creature an opponent controls.
+SVar:DBFight:DB$ Fight | Defined$ ParentTarget | ValidTgts$ Creature.OppCtrl | AILogic$ Always | TgtPrompt$ Choose target creature an opponent controls
+SVar:X:Count$ValidHand Card.YouOwn+cmcGE4
+Oracle:Until end of turn, target creature you control gains indestructible and gets +1/+0 for each card in your hand with mana value 4 or greater. Then it fights target creature an opponent controls.

--- a/forge-gui/res/cardsfolder/upcoming/archaeomancers_spade.txt
+++ b/forge-gui/res/cardsfolder/upcoming/archaeomancers_spade.txt
@@ -1,0 +1,9 @@
+Name:Archaeomancer's Spade
+ManaCost:1 R W
+Types:Artifact
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSeekTwo | TriggerDescription$ When this artifact enters, seek two cards with flashback and put them into your graveyard.
+SVar:TrigSeekTwo:DB$ Seek | RememberFound$ True | Num$ 2 | Type$ Card.withFlashback | SubAbility$ DBEntomb
+SVar:DBEntomb:DB$ ChangeZone | Origin$ Hand | Destination$ Graveyard | Defined$ Remembered | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+A:AB$ Mana | Cost$ T | Produced$ R W | RestrictValid$ CantCastSpellFromHand | SpellDescription$ Add {R}{W}. This mana can't be spent to cast spells from your hand.
+Oracle:When this artifact enters, seek two cards with flashback and put them into your graveyard.\n{T}: Add {R}{W}. This mana can't be spent to cast spells from your hand.

--- a/forge-gui/res/cardsfolder/upcoming/blood_age_muster.txt
+++ b/forge-gui/res/cardsfolder/upcoming/blood_age_muster.txt
@@ -1,0 +1,8 @@
+Name:Blood Age Muster
+ManaCost:R W
+Types:Enchantment
+T:Mode$ ChangesZoneAll | ValidCards$ Card.YouOwn | Origin$ Graveyard | ActivationLimit$ 1 | Destination$ Any | TriggerZones$ Battlefield | Execute$ TrigConjure | TriggerDescription$ Whenever one or more cards leave your graveyard, conjure a random card from Blood Age Muster's spellbook onto the battlefield. Its base power and toughness perpetually become 2/2. This ability triggers only once each turn.
+SVar:TrigConjure:DB$ MakeCard | Conjure$ True | AtRandom$ True | Spellbook$ Blood Age General,Charging Strifeknight,Fuming Effigy,Pillardrop Warden,Spirit Mascot,Stonebinder's Familiar,Stonebound Mentor,Stone Docent,Stonerise Spirit,Summoned Dromedary | RememberMade$ True | SubAbility$ DBAnimate | Zone$ Battlefield
+SVar:DBAnimate:DB$ Animate | Duration$ Perpetual | Defined$ Remembered | Power$ 2 | Toughness$ 2 | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:Whenever one or more cards leave your graveyard, conjure a random card from Blood Age Muster's spellbook onto the battlefield. Its base power and toughness perpetually become 2/2. This ability triggers only once each turn.


### PR DESCRIPTION
As recently revealed:
- [Advanced Floral Invocations](https://scryfall.com/card/ysos/13/advanced-floral-invocations): Function tested to satisfaction. The only issue is with the Card Detail display showing a "null" line. I suppose that has something to do with this being the first time the activated ability of a Class has(?) to add a static ability and a triggered ability.
<img width="444" height="676" alt="floral_null" src="https://github.com/user-attachments/assets/f4f47836-275a-47d6-aa19-889e3c37ed6e" />

- [Algorithmic Ferocity](https://scryfall.com/card/ysos/10/algorithmic-ferocity): Tested to satisfaction.
- [Archaeomancer's Spade](https://scryfall.com/card/ysos/15/archaeomancers-spade): Tested to satisfaction.
- [Blood Age Muster](https://scryfall.com/card/ysos/16/blood-age-muster): Tested to satisfaction.