### PR TITLE
YSOS: 8 cards (batch 2)

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/consumed_by_history.txt
+++ b/forge-gui/res/cardsfolder/upcoming/consumed_by_history.txt
@@ -1,0 +1,8 @@
+Name:Consumed by History
+ManaCost:1 R
+Types:Sorcery
+A:SP$ Effect | Triggers$ DiesTrig | SubAbility$ DBDamageAll | SpellDescription$ Until end of turn, whenever a nontoken creature dies, it perpetually gains unearth {5}.,,,,,,
+SVar:DiesTrig:Mode$ ChangesZone | ValidCard$ Creature.!token | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigPump | TriggerZones$ Command | TriggerDescription$ Whenever a nontoken creature dies, it perpetually gains unearth {5}.
+SVar:TrigPump:DB$ Pump | Defined$ TriggeredCard | PumpZone$ Graveyard | KW$ Unearth:5 | Duration$ Perpetual
+SVar:DBDamageAll:DB$ DamageAll | ValidCards$ Creature | NumDmg$ 3 | SpellDescription$ CARDNAME deals 3 damage to each creature.
+Oracle:Until end of turn, whenever a nontoken creature dies, it perpetually gains unearth {5}.\nConsumed by History deals 3 damage to each creature.

--- a/forge-gui/res/cardsfolder/upcoming/corpseweaver_prodigy.txt
+++ b/forge-gui/res/cardsfolder/upcoming/corpseweaver_prodigy.txt
@@ -1,0 +1,11 @@
+Name:Corpseweaver Prodigy
+ManaCost:2 B
+Types:Creature Treefolk Warlock
+PT:2/4
+K:Deathtouch
+R:Event$ Moved | ActiveZones$ Battlefield | Origin$ Battlefield | Destination$ Graveyard | ValidLKI$ Creature.OppCtrl | ReplaceWith$ Exile | Description$ If a creature an opponent controls would die, exile it instead.
+SVar:Exile:DB$ ChangeZone | Hidden$ True | Origin$ All | Destination$ Exile | Defined$ ReplacedCard
+T:Mode$ Phase | Phase$ Main | PhaseCount$ 2 | CheckSVar$ X | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigConjure | TriggerDescription$ Infusion — At the beginning of your second main phase, if you gained life this turn, conjure a card named Bridge from Below into your graveyard.
+SVar:TrigConjure:DB$ MakeCard | Conjure$ True | Name$ Bridge from Below | Zone$ Graveyard
+SVar:X:Count$LifeYouGainedThisTurn
+Oracle:Deathtouch\nIf a creature an opponent controls would die, exile it instead.\nInfusion — At the beginning of your second main phase, if you gained life this turn, conjure a card named Bridge from Below into your graveyard.

--- a/forge-gui/res/cardsfolder/upcoming/crescendo_conductor_boltwave.txt
+++ b/forge-gui/res/cardsfolder/upcoming/crescendo_conductor_boltwave.txt
@@ -1,0 +1,13 @@
+Name:Crescendo Conductor
+ManaCost:1 R
+Types:Creature Orc Sorcerer
+PT:2/2
+K:Reach
+T:Mode$ ConjureAll | ValidPlayer$ You | ValidCard$ Card | TriggerZones$ Battlefield | Execute$ TrigPrepare | TriggerDescription$ Whenever you conjure one or more cards, this creature becomes prepared.
+SVar:TrigPrepare:DB$ AlterAttribute | Attributes$ Prepared
+AlternateMode:Prepare
+Oracle:Reach\nWhenever you conjure one or more cards, this creature becomes prepared.
+
+ALTERNATE
+
+CopyFaceFrom:Boltwave

--- a/forge-gui/res/cardsfolder/upcoming/distracted_botanist.txt
+++ b/forge-gui/res/cardsfolder/upcoming/distracted_botanist.txt
@@ -1,0 +1,12 @@
+Name:Distracted Botanist
+ManaCost:1 B G
+Types:Creature Frog Druid
+PT:3/2
+K:Deathtouch
+K:Lifelink
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigAnimateAll | TriggerDescription$ When this creature dies, permanent cards in your graveyard perpetually gain "When this permanent enters, you draw a card and gain 1 life."
+SVar:TrigAnimateAll:DB$ AnimateAll | Zone$ Graveyard | Duration$ Perpetual | ValidCards$ Permanent.YouCtrl | Triggers$ EnterTrig
+SVar:EnterTrig:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ When this permanent enters, you draw a card and gain 1 life.
+SVar:TrigDraw:DB$ Draw | SubAbility$ DBGainLife
+SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1
+Oracle:Deathtouch, lifelink\nWhen this creature dies, permanent cards in your graveyard perpetually gain "When this permanent enters, you draw a card and gain 1 life."

--- a/forge-gui/res/cardsfolder/upcoming/expansive_reapplication.txt
+++ b/forge-gui/res/cardsfolder/upcoming/expansive_reapplication.txt
@@ -1,0 +1,10 @@
+Name:Expansive Reapplication
+ManaCost:X G U
+Types:Instant
+Text:X can't be 0.\r\n
+A:SP$ Counter | Cost$ XMin1 X G U | TargetType$ Spell | ValidTgts$ Card | SubAbility$ DBNameCard | SpellDescription$ Counter target spell. Conjure a random creature card with mana value X onto the battlefield.
+SVar:DBNameCard:DB$ NameCard | AtRandom$ True | ValidCards$ Creature.cmcEQX | SubAbility$ DBConjure
+SVar:DBConjure:DB$ MakeCard | Name$ ChosenName | Conjure$ True | Zone$ Battlefield | SubAbility$ DBClearNamed
+SVar:DBClearNamed:DB$ Cleanup | ClearNamedCard$ True
+SVar:X:Count$xPaid
+Oracle:X can't be 0.\nCounter target spell. Conjure a random creature card with mana value X onto the battlefield.

--- a/forge-gui/res/cardsfolder/upcoming/feed_the_bog.txt
+++ b/forge-gui/res/cardsfolder/upcoming/feed_the_bog.txt
@@ -1,0 +1,7 @@
+Name:Feed the Bog
+ManaCost:1 B
+Types:Sorcery
+K:Replicate:1 B
+A:SP$ PumpAll | PumpZone$ Graveyard | ValidCards$ Creature.YouOwn | NumAtt$ +1 | NumDef$ +1 | Duration$ Perpetual | SubAbility$ DBReturn | SpellDescription$ Creature cards in your graveyard perpetually get +1/+1. Then return target creature card with mana value 3 or less from your graveyard to the battlefield.
+SVar:DBReturn:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | ValidTgts$ Creature.cmcLE3+YouCtrl | TgtPrompt$ Select target creature card with mana value 3 in your graveyard
+Oracle:Replicate {1}{B}\nCreature cards in your graveyard perpetually get +1/+1. Then return target creature card with mana value 3 or less from your graveyard to the battlefield.

--- a/forge-gui/res/cardsfolder/upcoming/galathul_galecaller_corvid_squall.txt
+++ b/forge-gui/res/cardsfolder/upcoming/galathul_galecaller_corvid_squall.txt
@@ -1,0 +1,19 @@
+Name:Galathul Galecaller
+ManaCost:1 U
+Types:Creature Bird Wizard
+PT:2/1
+K:Flash
+K:Flying
+T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPrepare | TriggerDescription$ Whenever this creature attacks, it becomes prepared.
+SVar:TrigPrepare:DB$ AlterAttribute | Attributes$ Prepared
+AlternateMode:Prepare
+Oracle:Flash\nFlying\nWhenever this creature attacks, it becomes prepared.
+
+ALTERNATE
+
+Name:Corvid Squall
+ManaCost:1 U
+Types:Sorcery
+K:Storm
+A:SP$ MakeCard | Conjure$ True | Name$ Storm Crow | Zone$ Battlefield | SpellDescription$ Conjure a card named Storm Crow onto the battlefield.
+Oracle:Conjure a card named Storm Crow onto the battlefield.\nStorm

--- a/forge-gui/res/cardsfolder/upcoming/glorifying_verse.txt
+++ b/forge-gui/res/cardsfolder/upcoming/glorifying_verse.txt
@@ -1,0 +1,7 @@
+Name:Glorifying Verse
+ManaCost:WB
+Types:Enchantment
+K:Exalted
+T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | Execute$ TrigConjure | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | TargetsValid$ Creature.inZoneBattlefield | TriggerDescription$ Repartee — Whenever you cast an instant or sorcery spell that targets a creature, conjure a card named Glorifying Verse into your hand.
+SVar:TrigConjure:DB$ MakeCard | Conjure$ True | Name$ Glorifying Verse | Zone$ Hand
+Oracle:Exalted\nRepartee — Whenever you cast an instant or sorcery spell that targets a creature, conjure a card named Glorifying Verse into your hand.


### PR DESCRIPTION
As revealed recently:
- [Consumed by History](https://scryfall.com/card/ysos/8/consumed-by-history): Tested to satisfaction.
- [Corpseweaver Prodigy](https://scryfall.com/card/ysos/5/corpseweaver-prodigy): Tested to satisfaction.
- [Crescendo Conductor // Boltwave](https://scryfall.com/card/ysos/9/crescendo-conductor-boltwave): Tested to satisfaction.
- [Distracted Botanist](https://scryfall.com/card/ysos/17/distracted-botanist): Tested to satisfaction.
- [Expansive Reapplication](https://scryfall.com/card/ysos/18/expansive-reapplication): Tested to satisfaction.
- [Feed the Bog](https://scryfall.com/card/ysos/6/feed-the-bog): Tested to satisfaction.
- [Galathul Galecaller // Corvid Squall](https://scryfall.com/card/ysos/3/galathul-galecaller-corvid-squall): Tested to satisfaction.
- [Glorifying Verse](https://scryfall.com/card/ysos/19/glorifying-verse): Tested to satisfaction.