### PR TITLE
Clean up Adventure card pool filters

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/data/RewardData.java
+++ b/forge-gui-mobile/src/forge/adventure/data/RewardData.java
@@ -1,9 +1,9 @@
 package forge.adventure.data;
 
 import com.badlogic.gdx.utils.Array;
-import com.google.common.collect.Iterables;
 import forge.ImageKeys;
 import forge.StaticData;
+import forge.adventure.player.AdventurePlayer;
 import forge.adventure.util.*;
 import forge.adventure.world.WorldSave;
 import forge.card.CardDb;
@@ -16,9 +16,11 @@ import forge.model.FModel;
 import forge.util.IterableUtil;
 import forge.util.StreamUtil;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.*;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * Data class that will be used to read Json configuration files
@@ -28,6 +30,7 @@ import java.util.function.Predicate;
  * Also used for deck generation and shops
  */
 public class RewardData implements Serializable {
+    @Serial
     private static final long serialVersionUID = 3158932532013393718L;
     public String type; // TODO convert to enum
     public float probability;
@@ -95,47 +98,41 @@ public class RewardData implements Serializable {
     private static Iterable<PaperCard> allCards;
     private static Iterable<PaperCard> allEnemyCards;
 
-    static private void initializeAllCards(){
+    static private void initializeAllCards() {
         ConfigData configData = Config.instance().getConfigData();
         RewardData legals = configData.legalCards;
 
-        allCards = CardUtil.getFullCardPool(false);
+        List<Predicate<PaperCard>> filters = new ArrayList<>();
 
-        if(legals != null)
-            allCards = IterableUtil.filter(allCards, new CardUtil.CardPredicate(legals, true));
-
-        if (Config.instance().getSettingData().excludeAlchemyVariants) {
-            allCards = IterableUtil.filter(allCards, PaperCardPredicates.IS_REBALANCED.negate());
-        }
+        if (legals != null)
+            filters.add(new CardUtil.CardPredicate(legals, true));
         
         // Filter out by editions and obtainability
-        if (configData.allowedEditions != null && configData.allowedEditions.length > 0) {
-            allCards = IterableUtil.filter(allCards, PaperCardPredicates.printedInAnyEditions(configData.allowedEditions));
-        } else if (configData.restrictedEditions != null && configData.restrictedEditions.length > 0) {
-            allCards = IterableUtil.filter(allCards, PaperCardPredicates.isObtainableNotRestricted(configData.restrictedEditions));
-        } else {
-            allCards = IterableUtil.filter(allCards, PaperCardPredicates.isObtainableAnyEdition());
-        }
+        if (configData.allowedEditions != null && configData.allowedEditions.length > 0)
+            filters.add(PaperCardPredicates.printedInAnyEditions(configData.allowedEditions));
+        else if (configData.restrictedEditions != null && configData.restrictedEditions.length > 0)
+            filters.add(PaperCardPredicates.isObtainableNotRestricted(configData.restrictedEditions));
+        else
+            filters.add(PaperCardPredicates.isObtainableAnyEdition());
+
+        if (Config.instance().getSettingData().excludeAlchemyVariants)
+            filters.add(PaperCardPredicates.IS_REBALANCED.negate());
+
+        if (!FModel.getPreferences().getPrefBoolean(FPref.UI_ANTE))
+            filters.add(pc -> !pc.getRules().hasKeyword("Remove CARDNAME from your deck before playing if you're not playing for ante."));
+
+        if (!AdventurePlayer.current().isCommanderMode())
+            filters.add(pc -> !pc.getRules().getAiHints().getRemNonCommanderDecks());
+
+        filters.add(pc -> !(pc.getRules().isCustom() && pc.getImageKey(false).startsWith(ImageKeys.ADVENTURECARD_PREFIX)));
 
         Set<String> restrictedCards = new HashSet<>(Arrays.asList(configData.restrictedCards));
+        filters.add(pc -> !restrictedCards.contains(pc.getName()));
 
         // Filter out specific cards.
-        allCards = IterableUtil.filter(allCards, input -> {
-            if (input == null)
-                return false;
-            if (!FModel.getPreferences().getPrefBoolean(FPref.UI_ANTE) &&
-                    Iterables.contains(input.getRules().getMainPart().getKeywords(), "Remove CARDNAME from your deck before playing if you're not playing for ante."))
-                return false;
-            // TODO check if commander player
-            if (input.getRules().getAiHints().getRemNonCommanderDecks())
-                return false;
-            if (input.getRules().isCustom() &&
-                    input.getImageKey(false).startsWith(ImageKeys.ADVENTURECARD_PREFIX)) {
-                return false;
-            }
-
-            return !restrictedCards.contains(input.getName());
-        });
+        allCards = CardUtil.getFullCardPool(false).stream()
+                .filter(IterableUtil.and(filters))
+                .collect(Collectors.toList());
 
         //Filter AI cards for enemies.
         allEnemyCards = IterableUtil.filter(allCards, input -> {
@@ -148,6 +145,10 @@ public class RewardData implements Serializable {
         if (allCards == null)
             initializeAllCards();
         return allCards;
+    }
+
+    public static void invalidateCardPool() {
+        allCards = null;
     }
 
     public Array<Reward> generate(boolean isForEnemy, boolean useSeedlessRandom) {

--- a/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
+++ b/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
@@ -787,6 +787,7 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
             getCurrentGameStage().setExtraAnnouncement(Forge.getLocalizer().getMessage("lblDataMigrationMsg"));
         }
 
+        RewardData.invalidateCardPool();
         onLifeTotalChangeList.emit();
         onShardsChangeList.emit();
         onGoldChangeList.emit();

--- a/forge-gui-mobile/src/forge/adventure/scene/SettingsScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/SettingsScene.java
@@ -8,6 +8,7 @@ import com.github.tommyettinger.textra.TextraButton;
 import com.github.tommyettinger.textra.TextraLabel;
 import forge.Forge;
 import forge.Graphics;
+import forge.adventure.data.RewardData;
 import forge.adventure.util.Config;
 import forge.adventure.util.Controls;
 import forge.assets.ImageCache;
@@ -237,6 +238,7 @@ public class SettingsScene extends UIScene {
             public void changed(ChangeEvent event, Actor actor) {
                 Config.instance().getSettingData().useAllCardVariants = ((CheckBox) actor).isChecked();
                 Config.instance().saveSettings();
+                RewardData.invalidateCardPool();
             }
         });
         addSettingField(Forge.getLocalizer().getMessage("lblPreferEraMatchedTokenArt"), Config.instance().getSettingData().preferEraMatchedTokenArt, new ChangeListener() {
@@ -253,6 +255,7 @@ public class SettingsScene extends UIScene {
             public void changed(ChangeEvent event, Actor actor) {
                 Config.instance().getSettingData().excludeAlchemyVariants = ((CheckBox) actor).isChecked();
                 Config.instance().saveSettings();
+                RewardData.invalidateCardPool();
             }
         });
         addSettingField(Forge.getLocalizer().getMessage("lblGenerateLDADecks"), Config.instance().getSettingData().generateLDADecks, new ChangeListener() {
@@ -295,6 +298,7 @@ public class SettingsScene extends UIScene {
                 boolean enabled = ((CheckBox) actor).isChecked();
                 cbAnteMatchRarity.setDisabled(!enabled);
                 cbAnteIncludeBasicLands.setDisabled(!enabled);
+                RewardData.invalidateCardPool();
             }
         });
         addCheckBox(Forge.getLocalizer().getMessage("lblPromptAutoSell"), ForgePreferences.FPref.PROMPT_FOR_AUTOSELL);


### PR DESCRIPTION
* Restructures code to generate the filter list first and then do one pass over the card pool to test them.
* The "remove from non-commander decks" filter is no longer applied when in a commander format. Closes #10401.
* Card pool is invalidated whenever a relevant setting is modified on the Adventure settings menu, or when a save file is loaded.