### PR TITLE
Cleanup / minor bug fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,21 @@
 
 [Official repo](https://github.com/Card-Forge/forge.git).
 
+## Contents
+
+- [Requirements / Tools](#requirements--tools)
+- [Project Quick Setup](#project-quick-setup)
+  - [IntelliJ](#intellij)
+  - [Eclipse](#eclipse)
+  - [Windows](#windows)
+  - [Linux / Mac OSX](#linux--mac-osx)
+  - [Android Platform](#android-platform)
+  - [Proguard update](#proguard-update)
+- [Card Scripting](#card-scripting)
+- [General Notes](#general-notes)
+- [Using AI coding agents](#using-ai-coding-agents)
+- [Project Hierarchy](#project-hierarchy)
+
 ## Requirements / Tools
 
 - your favourite Java IDE (IntelliJ, Eclipse, VSCodium, Emacs, Vi...)
@@ -21,20 +36,20 @@
 - Go to the project location on your machine. Run Maven to download all dependencies and build a snapshot.
   - Example for Windows & Linux: `mvn -U -B clean -P windows-linux install`
 
-## IntelliJ
+### IntelliJ
 
 IntelliJ is the recommended IDE for Forge development. Quick start guide for [setting up the Forge project within IntelliJ](https://github.com/Card-Forge/forge/wiki/IntelliJ-setup).
 
-## Eclipse
+### Eclipse
 
 Eclipse includes Maven integration so a separate install is not necessary.
 Google no longer supports Android SDK releases for Eclipse.
 
-## Windows
+### Windows
 
 TBD
 
-## Linux / Mac OSX
+### Linux / Mac OSX
 
 TBD
 
@@ -60,7 +75,8 @@ Card scripting resources are found in the forge-gui/res/ path.
 
 ## General Notes
 
-Art files need to be copyright-free and they should be in the public domain.
+- Art files need to be copyright-free and they should be in the public domain. Credits and attribution should be included in [Credit and Thanks](https://github.com/Card-Forge/forge/wiki/Credit-and-Thanks).
+- If your contribution adds new UI elements consider the [UI guidelines](https://github.com/Card-Forge/forge/wiki/UI-Guidelines).
 
 ## Using AI coding agents
 
@@ -68,7 +84,7 @@ If you use an AI agent (e.g. Claude Code, OpenAI Codex) to substantially code a 
 
 Agents have a tendency to add unnecessary new unit or wiring tests to the CI suite. This should be avoided unless necessary to catch potential future integration regressions.
 
-### Project Hierarchy
+## Project Hierarchy
 
 Forge is divided into 4 primary projects with additional projects that target specific platform releases. The primary projects are:
 

--- a/docs/Advanced-Yield-Options.md
+++ b/docs/Advanced-Yield-Options.md
@@ -23,13 +23,17 @@ These features are highly configurable through the **Yield Settings** dialog, an
 
 ## Auto-Pass
 
-**Auto-Pass** is a persistent toggle (**P** on desktop, or the Auto-Pass icon on the dock) that automatically passes priority whenever you have no playable actions available. It's the simplest way to speed up games where you often have nothing to do — enable it once and Forge stops asking for input you'd only use to pass. The same **P** key also doubles as a "stop everything" shortcut: if any yield is currently active (transient yield or Auto-Pass itself), pressing P clears them all in one shot without dismissing any prompt that's up.
+**Auto-Pass** is a persistent toggle that automatically passes priority whenever you have no playable actions available. It's the simplest way to speed up games where you often have nothing to do — enable it once and Forge stops asking for input you'd only use to pass.
+
+**How to enable/disable:**
+- **Desktop**: **P** hotkey, auto-pass button on the dock, or "Enable auto-pass" in the Game menu.
+- **Mobile**: **P** hotkey, or "Auto-Pass: ON/OFF" button in the Game menu.
+- The **P** hotkey doubles as a "stop everything" shortcut: if any yield is currently active (transient yield or Auto-Pass itself), pressing P clears them all in one shot without dismissing any prompt that's up.
 
 **How it works:**
 - When enabled, Forge scans your hand, battlefield, and external zones (graveyard, exile, command) for castable spells, playable lands, and activatable abilities.
 - If you have any available action, you keep priority as usual.
 - If you have no available action, Forge passes priority on your behalf without prompting.
-- On desktop, the Auto-Pass dock icon's background lights up gold while active. On mobile, the menu entry text reads `Auto-Pass: ON` / `Auto-Pass: OFF`.
 
 **Interaction with interrupts:** By default, Auto-Pass ignores your interrupt settings — it keeps passing as long as you have no actions, regardless of attackers, opponent spells, mass-removal, etc. Enable **Auto-pass respects interrupts** in the Yield Interrupt Settings section if you want interrupts to break Auto-Pass too.
 
@@ -38,7 +42,7 @@ These features are highly configurable through the **Yield Settings** dialog, an
 **Performance and timeout:** The action-availability scan can be expensive in complex board states. The scan is subject to the **Auto-pass calculation timeout** setting in the Yield Settings dialog. On timeout the system prompts you instead of auto-passing, so a false positive means an extra prompt rather than a long stall. The default is **Dynamic** — the budget scales with the number of playable cards (approximately 50ms per card, clamped between 50ms and 1500ms). Set your own value in the Yield Settings dialog to override.
 
 > [!NOTE]
-> **The Auto-pass AI is not perfect.** It is designed to avoid false negatives (passing priority when there is action you can take) as much as possible. There may be times it produces a false positive (giving you priority when there is nothing you can do). Use with appropriate caution.
+> **The Auto-pass AI is not perfect and should be used with caution.** It is designed to avoid false negatives (passing priority when there is action you can take) as much as possible. There may be times it produces a false positive (giving you priority when there is nothing you can do).
 
 ## Yield markers
 
@@ -54,7 +58,6 @@ A fast-forward symbol will appear on the targeted cell to show the marker is act
 
 **Cancelling:**
 - Right-click (or long-press) the marker again to cancel it.
-- Press **ESC** (desktop) to cancel any active marker.
 - An enabled interrupt firing (see [Yield Interrupt Settings](#yield-interrupt-settings)) cancels the marker and hands priority back to you.
 
 **Re-targeting:** Right-clicking (or long-pressing) a different phase indicator while a marker is active moves the marker to the new cell. Only one marker is active at a time.
@@ -62,7 +65,7 @@ A fast-forward symbol will appear on the targeted cell to show the marker is act
 ## Yield Settings Menu
 
 The **Yield Settings** dialog is the central configuration UI for yield behavior. It's accessible from:
-- **Desktop:** the cog button on the dock, the Game menu > **Yield Settings** entry, or Ctrl+Y.
+- **Desktop:** the Yield Settings button on the dock, the Game menu > **Yield Settings** entry, or Ctrl+Y.
 - **Mobile:** Game menu > **Yield Options**.
 
 The dialog has three sections:

--- a/docs/Network-Play.md
+++ b/docs/Network-Play.md
@@ -24,17 +24,17 @@
 
 # Requirements
 
-| Requirement | Details |
-|---|---|
-| **Platforms** | Desktop and Mobile. **Cross-platform play is supported** — any platform can host or join. |
-| **Players** | Up to **8 players** per game (1 host + up to 7 remote players) |
-| **Roles** | **Host** runs Forge as the server; **Client** connects to it |
-| **Game Types** | **Constructed** formats only (no Draft or Sealed). Supported variants: Commander, Oathbreaker, Tiny Leaders, Brawl, Archenemy, Planechase, Vanguard. |
-| **Network** | Local (same Wi-Fi, Wi-Fi Direct, Ethernet) or Remote (IPv4 internet) |
-| **Port** | Default: **36743** (TCP). Can be changed in Forge's network preferences. |
-| **Firewall** | Host must allow Forge or the server port through its firewall. Do **not** disable the firewall entirely. |
-| **Port Forward** | Required for remote play — forward the server port on the host's router, or use UPnP (see below) |
-| **IP Version** | IPv4 required. IPv6 with full Dual Stack works; Dual Stack Lite does **not**. |
+| Requirement | Details                                                                                                                                                                                                                  |
+|---|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Platforms** | Desktop and Mobile. **Cross-platform play is supported** — any platform can host or join.                                                                                                                                |
+| **Players** | Up to **8 players** per game (1 host + up to 7 remote players)                                                                                                                                                           |
+| **Roles** | **Host** runs Forge as the server; **Client** connects to it                                                                                                                                                             |
+| **Game Types** | **Constructed** formats. Supported variants: Commander, Oathbreaker, Tiny Leaders, Brawl, Archenemy, Planechase, Vanguard.<br>**Limited** formats: Draft and Sealed modes available on desktop (mobile support planned). |
+| **Network** | Local (same Wi-Fi, Wi-Fi Direct, Ethernet) or Remote (IPv4 internet)                                                                                                                                                     |
+| **Port** | Default: **36743** (TCP). Can be changed in Forge's network preferences.                                                                                                                                                 |
+| **Firewall** | Host must allow Forge or the server port through its firewall. Do **not** disable the firewall entirely.                                                                                                                 |
+| **Port Forward** | Required for remote play — forward the server port on the host's router, or use UPnP (see below)                                                                                                                         |
+| **IP Version** | IPv4 required. IPv6 with full Dual Stack works; Dual Stack Lite does **not**.                                                                                                                                            |
 
 ---
 
@@ -273,9 +273,6 @@ A common cause for this is that the client and server resource (res) folder cont
 
 ## Version Compatibility
 Forge automatically warns in the lobby chat when a client's version differs from the host's but **does not block the connection**. While network play between different versions of Forge can be possible, mismatched versions may cause desync or crashes mid-game. If possible always use the same version on all devices to avoid network compatibility issues.
-
-## Lag / High Bandwidth
-Network play currently lacks traffic optimization. A single game can transfer hundreds of megabytes. Slow connections will experience significant lag.
 
 ---
 

--- a/docs/Network-Play.md
+++ b/docs/Network-Play.md
@@ -24,17 +24,17 @@
 
 # Requirements
 
-| Requirement | Details                                                                                                                                                                                                                  |
-|---|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Platforms** | Desktop and Mobile. **Cross-platform play is supported** — any platform can host or join.                                                                                                                                |
-| **Players** | Up to **8 players** per game (1 host + up to 7 remote players)                                                                                                                                                           |
-| **Roles** | **Host** runs Forge as the server; **Client** connects to it                                                                                                                                                             |
+| Requirement | Details |
+|---|---|
+| **Platforms** | Desktop and Mobile. **Cross-platform play is supported** — any platform can host or join. |
+| **Players** | Up to **8 players** per game (1 host + up to 7 remote players) |
+| **Roles** | **Host** runs Forge as the server; **Client** connects to it |
 | **Game Types** | **Constructed** formats. Supported variants: Commander, Oathbreaker, Tiny Leaders, Brawl, Archenemy, Planechase, Vanguard.<br>**Limited** formats: Draft and Sealed modes available on desktop (mobile support planned). |
-| **Network** | Local (same Wi-Fi, Wi-Fi Direct, Ethernet) or Remote (IPv4 internet)                                                                                                                                                     |
-| **Port** | Default: **36743** (TCP). Can be changed in Forge's network preferences.                                                                                                                                                 |
-| **Firewall** | Host must allow Forge or the server port through its firewall. Do **not** disable the firewall entirely.                                                                                                                 |
-| **Port Forward** | Required for remote play — forward the server port on the host's router, or use UPnP (see below)                                                                                                                         |
-| **IP Version** | IPv4 required. IPv6 with full Dual Stack works; Dual Stack Lite does **not**.                                                                                                                                            |
+| **Network** | Local (same Wi-Fi, Wi-Fi Direct, Ethernet) or Remote (IPv4 internet) |
+| **Port** | Default: **36743** (TCP). Can be changed in Forge's network preferences. |
+| **Firewall** | Host must allow Forge or the server port through its firewall. Do **not** disable the firewall entirely. |
+| **Port Forward** | Required for remote play — forward the server port on the host's router, or use UPnP (see below) |
+| **IP Version** | IPv4 required. IPv6 with full Dual Stack works; Dual Stack Lite does **not**. |
 
 ---
 

--- a/docs/User-Guide.md
+++ b/docs/User-Guide.md
@@ -201,7 +201,7 @@ Forge offers several yield options depending on how long you want to skip prompt
 - **Yield to stack / Resolve entire stack** — auto-pass while the stack resolves. Right-click a stack item to choose: **Yield to stack** auto-passes until the stack empties or an interrupt fires (for example, an opponent casts another spell); **Resolve entire stack** keeps auto-passing until the whole stack is empty even if opponents cast more spells.
 
 > [!NOTE]
-> For more information and configuration options — including interrupt conditions, automatic yield suggestions, and speed settings — see [Advanced Yield Options](advanced-yield-options.md).
+> For more information and configuration options — including interrupt conditions, automatic yield suggestions, and speed settings — see [Advanced Yield Options](Advanced-Yield-Options.md).
 
 ## Individual Yields and Trigger Decisions
 When a spell or an ability appears on the stack you can right-click it to decide if you want to always accept (Always Yes) or always decline it (Always No). For abilities marked "(OPTIONAL)" the same right-click lets you set an auto-yield so you don't get prompted on subsequent activations.

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -6,7 +6,7 @@
   - [AI](ai.md)
   - [Network Play](network-play.md)
   - [Advanced search](Advanced-Search.md)
-  - [Advanced Yield Options](advanced-yield-options.md)
+  - [Advanced Yield Options](Advanced-Yield-Options.md)
 
 - Adventure Mode
 

--- a/forge-gui-desktop/src/main/java/forge/screens/match/views/VDock.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/views/VDock.java
@@ -303,9 +303,9 @@ public class VDock implements IVDoc<CDock> {
      */
     public enum DockButtonId {
         AUTO_PASS      (FSkinProp.ICO_AUTOPASS,         "lblYieldBtnAutoPassTooltip", true),
+        YIELD_SETTINGS (FSkinProp.ICO_DOCK_SETTINGS,    "lblYieldSettings",           true),
         MACRO_RECORD   (FSkinProp.ICO_DOCK_MACRO_RECORD, "lblMacroRecordStartTooltip", true),
         MACRO_PLAY     (FSkinProp.ICO_DOCK_MACRO_PLAY,  "lblMacroPlayUnavailableTooltip", true),
-        YIELD_SETTINGS (FSkinProp.ICO_DOCK_SETTINGS,    "lblYieldSettings",           true),
         END_TURN       (FSkinProp.ICO_DOCK_ENDTURN,     "lblEndTurn",                 true),
         ALPHA_STRIKE   (FSkinProp.ICO_DOCK_ALPHASTRIKE, "lblAlphaStrike",             true),
         TARGETING      (FSkinProp.ICO_ARCSOFF,          "lblTargetingArcs",           true),

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -3491,8 +3491,10 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
             getGame().getAction().checkGameOverCondition();
             if (getGame().isGameOver()) {
                 // Remote-client controllers on the server have no FControlGameEventHandler,
-                // so their input queues won't be released by the normal event path
-                for (Player p : getGame().getPlayers()) {
+                // so their input queues won't be released by the normal event path.
+                // Iterate registered players (not getPlayers(), which excludes the
+                // conceding player after onPlayerLost removes them from ingamePlayers).
+                for (Player p : getGame().getRegisteredPlayers()) {
                     if (p.getController() instanceof PlayerControllerHuman pch) {
                         pch.getInputQueue().onGameOver(true);
                     }


### PR DESCRIPTION
- **Network concede hang fix** — in a network 1v1, releasing the conceder's input queue iterated `ingamePlayers` after `onPlayerLost` had already removed them, so the blocked `InputPassPriority` never released and the server hung. Iterate `getRegisteredPlayers` instead.
- **Dock-button default order** — yield settings now sits next to auto-pass instead of three slots away. Existing users keep their saved layout.
- **Docs cleanup** — `Advanced-Yield-Options.md` accuracy fixes (removed non-existent ESC keybinding line, removed incorrect "gold dock icon" claim, restructured Auto-Pass section); `Network-Play.md` notes that Limited Draft/Sealed is available on desktop; filename casing on `Advanced-Yield-Options.md` brought in line with sibling docs.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)