### PR TITLE
Preserve hidden extrinsic keywords in Card.copyFrom (fixes P/T switch lost in LKI copies)

### DIFF
--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -8108,6 +8108,18 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
 
         setChangedCardKeywords(in.getChangedCardKeywords());
 
+        // Hidden extrinsic keywords (e.g. Inside Out's "power and toughness are
+        // switched", added via Pump's KW$ HIDDEN) are continuous-effect keyword
+        // changes just like changedCardKeywords above. Copying them keeps the
+        // last-known-information copy (CardCopyService.getLKICopy) faithful so
+        // that effects reading a creature's last-known P/T after it leaves the
+        // battlefield -- e.g. Fling's Sacrificed$CardPower -- see the switched
+        // value instead of the unswitched base.
+        for (Table.Cell<Long, Long, List<String>> cell : in.hiddenExtrinsicKeywords.cellSet()) {
+            this.hiddenExtrinsicKeywords.put(cell.getRowKey(), cell.getColumnKey(),
+                    Lists.newArrayList(cell.getValue()));
+        }
+
         this.changedCardTypes.putAll(in.changedCardTypes);
         this.changedCardTypesCharacterDefining.putAll(in.changedCardTypesCharacterDefining);
         updateTypeCache();

--- a/forge-gui-desktop/src/test/java/forge/ai/simulation/GameSimulationTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/simulation/GameSimulationTest.java
@@ -5,10 +5,12 @@ import forge.ai.ComputerUtilAbility;
 import forge.card.CardStateName;
 import forge.card.MagicColor;
 import forge.game.Game;
+import forge.game.ability.AbilityUtils;
 import forge.game.ability.ApiType;
 import forge.game.card.Card;
 import forge.game.card.CardCollection;
 import forge.game.card.CardCollectionView;
+import forge.game.card.CardCopyService;
 import forge.game.card.CounterEnumType;
 import forge.game.keyword.Keyword;
 import forge.game.phase.PhaseType;
@@ -26,6 +28,43 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class GameSimulationTest extends SimulationTest {
+
+    @Test
+    public void testSwitchedPowerToughnessSurvivesLKICopy() {
+        // Inside Out switches a creature's P/T via a HIDDEN extrinsic keyword
+        // ("CARDNAME's power and toughness are switched"). Effects that read a
+        // creature's last-known information after it leaves the battlefield --
+        // e.g. Fling's NumDmg$ X = Sacrificed$CardPower -- must see the switched
+        // value. Card.copyFrom (used by CardCopyService.getLKICopy) copied every
+        // sibling continuous-effect keyword store except hiddenExtrinsicKeywords,
+        // so the LKI copy dropped the switch and Fling dealt the unswitched base
+        // power instead of the switched value.
+        Game game = initAndCreateGame();
+        Player p = game.getPlayers().get(1);
+
+        Card spider = addCard("Giant Spider", p); // 2/4
+        addCardToZone("Island", p, ZoneType.Library); // for Inside Out's "Draw a card"
+        Card insideOut = addCardToZone("Inside Out", p, ZoneType.Hand);
+
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN1, p);
+        game.getAction().checkStateEffects(true);
+
+        SpellAbility io = insideOut.getFirstSpellAbility();
+        io.setActivatingPlayer(p);
+        io.getTargets().add(spider);
+        AbilityUtils.resolve(io);
+        game.getAction().checkStateEffects(true);
+
+        // 2/4 with power and toughness switched -> 4/2 (toughness 2, survives).
+        AssertJUnit.assertEquals(4, spider.getNetPower());
+        AssertJUnit.assertEquals(2, spider.getNetToughness());
+
+        // The last-known-information copy must preserve the switch keyword;
+        // this is exactly the value Fling's Sacrificed$CardPower reads.
+        Card lki = CardCopyService.getLKICopy(spider);
+        AssertJUnit.assertEquals("LKI copy must preserve switched power",
+                4, lki.getNetPower());
+    }
 
     @Test
     public void testActivateAbilityTriggers() {


### PR DESCRIPTION
## Problem

Casting **Inside Out** (*switch target creature's power and toughness*) on a creature and then **Fling**ing it deals the creature's *un-switched* power instead of the switched value.

Minimal repro:
- Tireless Tribe (1/1); pump its toughness with its own ability a few times, then cast Inside Out on it → it shows e.g. `33/1` on the battlefield.
- Fling it. Fling deals `NumDmg$ X` with `SVar:X:Sacrificed$CardPower`, read from the sacrificed creature's last-known information — it deals **1** (the un-switched base power), not 33.

Any effect that reads a creature's last-known power after it leaves the battlefield is affected (Fling, Soul's Fire, Hail Storm, etc.).

## Root cause

`CardCopyService.getLKICopy` builds the last-known-information copy through `Card.copyFrom(Card)`. `copyFrom` copies every sibling continuous-effect keyword store — `changedCardKeywords`, colors, types, names, traits — but **omits `hiddenExtrinsicKeywords`**, the table written by `Card.addHiddenExtrinsicKeywords`. Inside Out's switch is a `KW$ HIDDEN ...` pump keyword, so it lands in that omitted table and is dropped from the LKI copy; `getNetPower()` on the copy then returns the un-switched value.

## Fix

Copy `hiddenExtrinsicKeywords` in `copyFrom`, alongside the other keyword stores. `getLKICopy` already rebuilds the keyword cache after `copyFrom`, so the copied keyword takes effect.

## Test

Adds `GameSimulationTest#testSwitchedPowerToughnessSurvivesLKICopy`: switches a Giant Spider's P/T with Inside Out (→ 4/2) and asserts `CardCopyService.getLKICopy(spider).getNetPower() == 4`. It **fails on master** (`expected:<4> but was:<2>`) and **passes with this change**.

## Note

`GameCopier` (forge-ai simulation) already copies `hiddenExtrinsicKeywords` explicitly right after calling `copyFrom`; that local loop is now redundant and could be removed in a follow-up — arguably evidence this copy belonged in `copyFrom` all along.