### PR TITLE
update sos.rnk, misspelled and missing cards

### DIFF
--- a/forge-gui/res/draft/rankings/sos.rnk
+++ b/forge-gui/res/draft/rankings/sos.rnk
@@ -60,7 +60,7 @@
 #59|Wilt in the Heat|C|SOS
 #60|Grim Haruspex|M|SPG
 #61|Flow State|U|SOS
-#62|Stress Dream|U|SOA
+#62|Stress Dream|U|SOS
 #63|Artistic Process|U|SOA
 #64|Primary Research|U|SOA
 #65|Fix What's Broken|R|SOS

--- a/forge-gui/res/draft/rankings/sos.rnk
+++ b/forge-gui/res/draft/rankings/sos.rnk
@@ -62,7 +62,7 @@
 #61|Flow State|U|SOS
 #62|Stress Dream|U|SOS
 #63|Artistic Process|U|SOA
-#64|Primary Research|U|SOA
+#64|Primary Research|U|SOS
 #65|Fix What's Broken|R|SOS
 #66|Antiquities on the Loose|R|SOS
 #67|Applied Geometry|R|SOS

--- a/forge-gui/res/draft/rankings/sos.rnk
+++ b/forge-gui/res/draft/rankings/sos.rnk
@@ -200,7 +200,7 @@
 #199|Bulk Up|U|SOA
 #200|Dig Site Inventory|C|SOS
 #201|Soaring Stoneglider|U|SOS
-#202|chase inspiration|C|SOS
+#202|Chase Inspiration|C|SOS
 #203|Run Behind|C|SOS
 #204|Rabid Attack|U|SOS
 #205|Scathing Shadelock|U|SOS
@@ -331,10 +331,12 @@
 #330|Crop Rotation|R|SOA
 #331|Veil of Summer|R|SOA
 #332|Pox Plague|R|SOS
-#333|Forest|C|SOS
-#334|Island|C|SOS
-#335|Mountain|C|SOS
-#336|Plains|C|SOS
-#337|Swamp|C|SOS
+#333|Melancholic Poet|C|SOS
+#334|Masterful Flourish|C|SOS
+#335|Forest|C|SOS
+#336|Island|C|SOS
+#337|Mountain|C|SOS
+#338|Plains|C|SOS
+#339|Swamp|C|SOS
 
 


### PR DESCRIPTION
AI underdrafts misspelled or missing cards.

Primary Research|U|SOA -> Primary Research|U|SOS 
Stress Dream|U|SOA -> Stress Dream|U|SOS
chase inspiration -> Chase Inspiration

added: Melancholic Poet
added: Masterful Flourish
todo: Consider ranking newly added cards Poet and Flourish slightly higher, maybe 264 or so.