### PR TITLE
TrackableType: cleanup default value, reduce need of extra classes

### DIFF
--- a/forge-game/src/main/java/forge/game/GameView.java
+++ b/forge-game/src/main/java/forge/game/GameView.java
@@ -1,6 +1,7 @@
 package forge.game;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import com.google.common.collect.Iterables;
@@ -26,6 +27,7 @@ import forge.game.zone.MagicStack;
 import forge.trackable.TrackableCollection;
 import forge.trackable.TrackableObject;
 import forge.trackable.TrackableProperty;
+import forge.util.collect.FCollection;
 import forge.util.collect.FCollectionView;
 
 public class GameView extends TrackableObject {
@@ -119,7 +121,7 @@ public class GameView extends TrackableObject {
     }
 
     public FCollectionView<StackItemView> getStack() {
-        return get(TrackableProperty.Stack);
+        return Objects.requireNonNullElse(get(TrackableProperty.Stack), FCollection.getEmpty());
     }
 
     public StackItemView peekStack() {

--- a/forge-game/src/main/java/forge/trackable/TrackableTypes.java
+++ b/forge-game/src/main/java/forge/trackable/TrackableTypes.java
@@ -21,8 +21,10 @@ import forge.game.spellability.StackItemView;
 import forge.item.IPaperCard;
 
 public class TrackableTypes {
-    public static abstract class TrackableType<T> {
-        private TrackableType() {
+    public static class TrackableType<T> {
+        private T defaultValue;
+        private TrackableType(T defaultValue) {
+            this.defaultValue = defaultValue;
         }
 
         protected void updateObjLookup(Tracker tracker, T newObj) {
@@ -30,11 +32,15 @@ public class TrackableTypes {
         protected void copyChangedProps(TrackableObject from, TrackableObject to, TrackableProperty prop) {
             to.set(prop, from.get(prop));
         }
-        protected abstract T getDefaultValue();
+
+        protected T getDefaultValue() {
+            return defaultValue;
+        }
     }
 
-    public static abstract class TrackableObjectType<T extends TrackableObject> extends TrackableType<T> {
+    public static class TrackableObjectType<T extends TrackableObject> extends TrackableType<T> {
         private TrackableObjectType() {
+            super(null);
         }
 
         public T lookup(T from) {
@@ -73,10 +79,11 @@ public class TrackableTypes {
         }
     }
 
-    private static abstract class TrackableCollectionType<T extends TrackableObject> extends TrackableType<TrackableCollection<T>> {
+    private static class TrackableCollectionType<T extends TrackableObject> extends TrackableType<TrackableCollection<T>> {
         private final TrackableObjectType<T> itemType;
 
         private TrackableCollectionType(TrackableObjectType<T> itemType0) {
+            super(null);
             itemType = itemType0;
         }
 
@@ -121,74 +128,25 @@ public class TrackableTypes {
         }
     }
 
-    public static final TrackableType<Boolean> BooleanType = new TrackableType<Boolean>() {
-        @Override
-        public Boolean getDefaultValue() {
-            return false;
-        }
-    };
-    public static final TrackableType<Integer> IntegerType = new TrackableType<Integer>() {
-        @Override
-        public Integer getDefaultValue() {
-            return 0;
-        }
-    };
-    public static final TrackableType<Float> FloatType = new TrackableType<Float>() {
-        @Override
-        public Float getDefaultValue() {
-            return 0f;
-        }
-    };
-    public static final TrackableType<String> StringType = new TrackableType<String>() {
-        @Override
-        public String getDefaultValue() {
-            return "";
-        }
-    };
+    public static final TrackableType<Boolean> BooleanType = new TrackableType<Boolean>(false);
+    public static final TrackableType<Integer> IntegerType = new TrackableType<Integer>(0);
+    public static final TrackableType<Float> FloatType = new TrackableType<Float>(0f);
+    public static final TrackableType<String> StringType = new TrackableType<String>("");
 
     //make this quicker than having to define a new class for every single enum
     private static Map<Class<? extends Enum<?>>, TrackableType<?>> enumTypes = Maps.newHashMap();
 
     @SuppressWarnings("unchecked")
     public static <E extends Enum<E>> TrackableType<E> EnumType(final Class<E> enumType) {
-        TrackableType<E> type = (TrackableType<E>)enumTypes.get(enumType);
-        if (type == null) {
-            type = new TrackableType<E>() {
-                @Override
-                public E getDefaultValue() {
-                    return null;
-                }
-            };
-            enumTypes.put(enumType, type);
-        }
-        return type;
+        return (TrackableType<E>)enumTypes.computeIfAbsent(enumType, (t) -> new TrackableType<E>(null));
     }
 
-    public static final TrackableObjectType<CardView> CardViewType = new TrackableObjectType<CardView>() {
-        @Override
-        protected CardView getDefaultValue() {
-            return null;
-        }
-    };
+    public static final TrackableObjectType<CardView> CardViewType = new TrackableObjectType<CardView>();
 
-    public static final TrackableType<IPaperCard> IPaperCardType = new TrackableType<IPaperCard>() {
-        @Override
-        protected IPaperCard getDefaultValue() {
-            return null;
-        }
-    };
+    public static final TrackableType<IPaperCard> IPaperCardType = new TrackableType<IPaperCard>(null);
 
-    public static final TrackableCollectionType<CardView> CardViewCollectionType = new TrackableCollectionType<CardView>(CardViewType) {
-        @Override
-        protected TrackableCollection<CardView> getDefaultValue() {
-            return null;
-        }
-    };
+    public static final TrackableCollectionType<CardView> CardViewCollectionType = new TrackableCollectionType<CardView>(CardViewType);
     public static final TrackableObjectType<CardStateView> CardStateViewType = new TrackableObjectType<CardStateView>() {
-        @Override
-        protected CardStateView getDefaultValue() {
-            return null;
-        }
         @Override
         protected void copyChangedProps(TrackableObject from, TrackableObject to, TrackableProperty prop) {
             // CardStateViews share their parent CardView's ID, so multiple states
@@ -205,113 +163,23 @@ public class TrackableTypes {
             }
         }
     };
-    public static final TrackableType<CardTypeView> CardTypeViewType = new TrackableType<CardTypeView>() {
-        @Override
-        protected CardTypeView getDefaultValue() {
-            return CardType.EMPTY;
-        }
-    };
-    public static final TrackableObjectType<PlayerView> PlayerViewType = new TrackableObjectType<PlayerView>() {
-        @Override
-        protected PlayerView getDefaultValue() {
-            return null;
-        }
-    };
-    public static final TrackableCollectionType<PlayerView> PlayerViewCollectionType = new TrackableCollectionType<PlayerView>(PlayerViewType) {
-        @Override
-        protected TrackableCollection<PlayerView> getDefaultValue() {
-            return null;
-        }
-    };
-    public static final TrackableObjectType<GameEntityView> GameEntityViewType = new TrackableObjectType<GameEntityView>() {
-        @Override
-        protected GameEntityView getDefaultValue() {
-            return null;
-        }
-    };
-    public static final TrackableObjectType<StackItemView> StackItemViewType = new TrackableObjectType<StackItemView>() {
-        @Override
-        protected StackItemView getDefaultValue() {
-            return null;
-        }
-    };
-    public static final TrackableCollectionType<StackItemView> StackItemViewListType = new TrackableCollectionType<StackItemView>(StackItemViewType) {
-        @Override
-        protected TrackableCollection<StackItemView> getDefaultValue() {
-            return new TrackableCollection<>();
-        }
-    };
-    public static final TrackableObjectType<CombatView> CombatViewType = new TrackableObjectType<CombatView>() {
-        @Override
-        protected CombatView getDefaultValue() {
-            return null;
-        }
-    };
-    public static final TrackableType<ManaCost> ManaCostType = new TrackableType<ManaCost>() {
-        @Override
-        public ManaCost getDefaultValue() {
-            return ManaCost.NO_COST;
-        }
-    };
-    public static final TrackableType<ColorSet> ColorSetType = new TrackableType<ColorSet>() {
-        @Override
-        public ColorSet getDefaultValue() {
-            return ColorSet.C;
-        }
-    };
-    public static final TrackableType<List<String>> StringListType = new TrackableType<List<String>>() {
-        @Override
-        public List<String> getDefaultValue() {
-            return null;
-        }
-    };
-    public static final TrackableType<Set<String>> StringSetType = new TrackableType<Set<String>>() {
-        @Override
-        public Set<String> getDefaultValue() {
-            return null;
-        }
-    };
-    public static final TrackableType<Map<String, String>> StringMapType = new TrackableType<Map<String, String>>() {
-        @Override
-        public Map<String, String> getDefaultValue() {
-            return null;
-        }
-    };
+    public static final TrackableType<CardTypeView> CardTypeViewType = new TrackableType<CardTypeView>(CardType.EMPTY);
+    public static final TrackableObjectType<PlayerView> PlayerViewType = new TrackableObjectType<PlayerView>();
+    public static final TrackableCollectionType<PlayerView> PlayerViewCollectionType = new TrackableCollectionType<PlayerView>(PlayerViewType);
+    public static final TrackableObjectType<GameEntityView> GameEntityViewType = new TrackableObjectType<GameEntityView>();
+    public static final TrackableObjectType<StackItemView> StackItemViewType = new TrackableObjectType<StackItemView>();
+    public static final TrackableCollectionType<StackItemView> StackItemViewListType = new TrackableCollectionType<StackItemView>(StackItemViewType);
+    public static final TrackableObjectType<CombatView> CombatViewType = new TrackableObjectType<CombatView>();
+    public static final TrackableType<ManaCost> ManaCostType = new TrackableType<ManaCost>(ManaCost.NO_COST);
+    public static final TrackableType<ColorSet> ColorSetType = new TrackableType<ColorSet>(ColorSet.C);
+    public static final TrackableType<List<String>> StringListType = new TrackableType<List<String>>(null);
+    public static final TrackableType<Set<String>> StringSetType = new TrackableType<Set<String>>(null);
+    public static final TrackableType<Map<String, String>> StringMapType = new TrackableType<Map<String, String>>(null);
 
-    public static final TrackableType<Set<Integer>> IntegerSetType = new TrackableType<Set<Integer>>() {
-        @Override
-        public Set<Integer> getDefaultValue() {
-            return null;
-        }
-    };
-    public static final TrackableType<Map<Integer, Integer>> IntegerMapType = new TrackableType<Map<Integer, Integer>>() {
-        @Override
-        public Map<Integer, Integer> getDefaultValue() {
-            return null;
-        }
-    };
-    public static final TrackableType<Map<Byte, Integer>> ManaMapType = new TrackableType<Map<Byte, Integer>>() {
-        @Override
-        public Map<Byte, Integer> getDefaultValue() {
-            return null;
-        }
-    };
-    public static final TrackableType<Map<CounterType, Integer>> CounterMapType = new TrackableType<Map<CounterType, Integer>>() {
-        @Override
-        public Map<CounterType, Integer> getDefaultValue() {
-            return null;
-        }
-    };
-    public static final TrackableType<Map<Object, Object>> GenericMapType = new TrackableType<Map<Object, Object>>() {
-        @Override
-        public Map<Object, Object> getDefaultValue() {
-            return null;
-        }
-    };
-    public static final TrackableType<KeywordCollectionView> KeywordCollectionViewType = new TrackableType<KeywordCollectionView>() {
-        @Override
-        public KeywordCollectionView getDefaultValue() {
-            return KeywordCollectionView.EMPTY;
-        }
-    };
+    public static final TrackableType<Set<Integer>> IntegerSetType = new TrackableType<Set<Integer>>(null);
+    public static final TrackableType<Map<Integer, Integer>> IntegerMapType = new TrackableType<Map<Integer, Integer>>(null);
+    public static final TrackableType<Map<Byte, Integer>> ManaMapType = new TrackableType<Map<Byte, Integer>>(null);
+    public static final TrackableType<Map<CounterType, Integer>> CounterMapType = new TrackableType<Map<CounterType, Integer>>(null);
+    public static final TrackableType<Map<Object, Object>> GenericMapType = new TrackableType<Map<Object, Object>>(null);
+    public static final TrackableType<KeywordCollectionView> KeywordCollectionViewType = new TrackableType<KeywordCollectionView>(KeywordCollectionView.EMPTY);
 }


### PR DESCRIPTION
This cleanup reduce the need to define extra classes just for `getDefaultValue`
(java makes them anyway under the hood)

- ~~add new TrackableValueType where you can give its default value, mostly variant of `0` or Empty View~~ 
- TrackableType now supports set default value
- TrackableObjectType has `null` as default
- ~~TrackableCollectionType has an empty collection (that isn't created each time)~~
- TrackableCollectionType also has `null` as default
