### PR TITLE
YSOS, batch 3: 4 cards 

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/grave_studies.txt
+++ b/forge-gui/res/cardsfolder/upcoming/grave_studies.txt
@@ -1,0 +1,6 @@
+Name:Grave Studies
+ManaCost:B G
+Types:Instant
+A:SP$ MakeCard | Conjure$ True | Name$ Teacher's Pest | Zone$ Battlefield | SubAbility$ DBSac | SpellDescription$ Conjure a card named Teacher's Pest onto the battlefield, then each player sacrifices a creature.
+SVar:DBSac:DB$ Sacrifice | SacValid$ Creature | Defined$ Player
+Oracle:Conjure a card named Teacher's Pest onto the battlefield, then each player sacrifices a creature.

--- a/forge-gui/res/cardsfolder/upcoming/head_of_the_class.txt
+++ b/forge-gui/res/cardsfolder/upcoming/head_of_the_class.txt
@@ -1,0 +1,8 @@
+Name:Head of the Class
+ManaCost:W B
+Types:Creature Kithkin Cleric
+PT:2/2
+S:Mode$ ReduceCost | ValidCard$ Card | Type$ Spell | ValidSpell$ Spell.IsTargeting Valid Creature | Activator$ You | OnlyFirstSpell$ True | Condition$ PlayerTurn | Amount$ 1 | Color$ W B | IgnoreGeneric$ True | Description$ The first spell you cast during each of your turns that targets a creature costs {W}{B} less to cast. This effect reduces only the amount of colored mana you pay.
+T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | Execute$ TrigPump | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | TargetsValid$ Creature.inZoneBattlefield | TriggerDescription$ Repartee — Whenever you cast an instant or sorcery spell that targets a creature, this creature perpetually gets +1/+1.
+SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +1 | NumDef$ +1 | Duration$ Perpetual
+Oracle:The first spell you cast during each of your turns that targets a creature costs {W}{B} less to cast. This effect reduces only the amount of colored mana you pay.\nRepartee — Whenever you cast an instant or sorcery spell that targets a creature, this creature perpetually gets +1/+1.

--- a/forge-gui/res/cardsfolder/upcoming/honor_the_past.txt
+++ b/forge-gui/res/cardsfolder/upcoming/honor_the_past.txt
@@ -1,0 +1,6 @@
+Name:Honor the Past
+ManaCost:2 W
+Types:Sorcery
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | TgtPrompt$ Choose target creature card with mana value 6 or less in your graveyard | ValidTgts$ Creature.cmcLE6+YouCtrl | StaticEffect$ Animate | SpellDescription$ Return target creature card with mana value 6 or less from your graveyard to the battlefield. It's an artifact. (It's no longer a creature.)
+SVar:Animate:Mode$ Continuous | Affected$ Card.IsRemembered | AddType$ Artifact | RemoveCardTypes$ True
+Oracle:Return target creature card with mana value 6 or less from your graveyard to the battlefield. It's an artifact. (It's no longer a creature.)

--- a/forge-gui/res/cardsfolder/upcoming/impose_hierarchy.txt
+++ b/forge-gui/res/cardsfolder/upcoming/impose_hierarchy.txt
@@ -1,0 +1,7 @@
+Name:Impose Hierarchy
+ManaCost:1 B
+Types:Instant
+A:SP$ Destroy | ValidTgts$ Creature.cmcLE4 | TgtPrompt$ Select target creature with mana value 4 or less | SubAbility$ DBGainLife | SpellDescription$ Destroy target creature with mana value 4 or less. You gain 1 life for each creature card in its controller's hand.
+SVar:DBGainLife:DB$ GainLife | LifeAmount$ X
+SVar:X:Count$ValidHand Creature.OwnedBy TargetedController
+Oracle:Destroy target creature with mana value 4 or less. You gain 1 life for each creature card in its controller's hand.


### PR DESCRIPTION
- [Grave Studies](https://scryfall.com/card/ysos/20/grave-studies): Tested to satisfaction.
- [Head of the Class](https://scryfall.com/card/ysos/21/head-of-the-class): Seems to work for the most part (see first screenshot with Holy Strength as the targeting spell). However I am confounded by being able to chain free [Ephemerate](https://scryfall.com/card/mh1/7/ephemerate) spells by casting them on Head of the Class and letting them resolve one after the other (second screenshot). Apparently flickering Head of the Class is resetting the cast spell count for the turn to zero which shouldn't happen per rulings on, for instance, [Alisaie Leveilleur](https://scryfall.com/card/fic/9/alisaie-leveilleur). Gamestate file provided for testing convenience.
> "Spells that were cast before Alisaie Leveilleur entered count. If Alisaie Leveilleur was the first spell you cast this turn, the next spell you cast this turn is your second spell"

<img width="1099" height="1031" alt="headoftheclass_2" src="https://github.com/user-attachments/assets/af8604d8-a1cf-4d70-bab4-a625c4265fd0" />

<img width="1268" height="1023" alt="headoftheclass" src="https://github.com/user-attachments/assets/89111b4c-818d-489c-943d-2bcf6cfdacd3" />

[state_headoftheclass.txt](https://github.com/user-attachments/files/28180628/state_headoftheclass.txt)

- [Honor the Past](https://scryfall.com/card/ysos/1/honor-the-past): Tested to satisfaction.
- [Impose Hierarchy](https://scryfall.com/card/ysos/7/impose-hierarchy): Tested to satisfaction.