### PR TITLE
Cleanup: Split draft event handling off ILobbyListener

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/screens/home/CLobby.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/CLobby.java
@@ -28,6 +28,7 @@ import forge.gamemodes.net.event.DraftPickEvent;
 import forge.gamemodes.net.server.ServerGameLobby;
 import forge.gui.FDraftOverlay;
 import forge.gui.GuiChoose;
+import forge.gui.interfaces.IDraftEventHandler;
 import forge.gui.framework.FScreen;
 import forge.gui.util.SOptionPane;
 import forge.item.PaperCard;
@@ -47,7 +48,7 @@ import forge.toolbox.FTextField;
 import forge.util.Localizer;
 import net.miginfocom.swing.MigLayout;
 
-public class CLobby {
+public class CLobby implements IDraftEventHandler {
 
     public enum LobbyMode { CONSTRUCTED, LIMITED }
 
@@ -404,7 +405,8 @@ public class CLobby {
         }
     }
 
-    void onDraftPackArrived(int seatIndex, List<PaperCard> pack,
+    @Override
+    public void draftPackArrived(int seatIndex, List<PaperCard> pack,
             int packNumber, int pickNumber, int timerDurationSeconds) {
         SwingUtilities.invokeLater(() -> {
             if (networkDraftEditor == null) {
@@ -474,7 +476,8 @@ public class CLobby {
         return EventParticipant.resolveName(seatIndex, viewParticipants, currentParticipants);
     }
 
-    void onDraftSeatPicked(int seatIndex, int[] seatQueueDepths) {
+    @Override
+    public void draftSeatPicked(int seatIndex, int[] seatQueueDepths) {
         SwingUtilities.invokeLater(() -> {
             FDraftOverlay.SINGLETON_INSTANCE.onSeatPicked(seatQueueDepths);
 
@@ -489,7 +492,8 @@ public class CLobby {
         });
     }
 
-    void onDraftAutoPicked(int seatIndex, PaperCard card, int packNumber, int pickInPack) {
+    @Override
+    public void draftAutoPicked(int seatIndex, PaperCard card, int packNumber, int pickInPack) {
         SwingUtilities.invokeLater(() -> {
             if (networkDraftEditor != null) {
                 networkDraftEditor.addAutoPickedCard(card, packNumber, pickInPack);
@@ -503,7 +507,8 @@ public class CLobby {
         FDraftOverlay.SINGLETON_INSTANCE.reset();
     }
 
-    void onReceiveEventPool(String eventId, Deck pool) {
+    @Override
+    public void receiveEventPool(String eventId, Deck pool) {
         SwingUtilities.invokeLater(() -> {
             if (networkDraftEditor != null) {
                 networkDraftEditor.completeDraft(pool);

--- a/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
@@ -26,6 +26,7 @@ import forge.gamemodes.net.*;
 import forge.gamemodes.net.event.UpdateLobbyPlayerEvent;
 import forge.gui.CardDetailPanel;
 import forge.gui.SwingPrefBinders;
+import forge.gui.interfaces.IDraftEventHandler;
 import forge.gui.interfaces.ILobbyView;
 import forge.gui.util.SOptionPane;
 import forge.interfaces.IPlayerChangeListener;
@@ -433,6 +434,11 @@ public class VLobby implements ILobbyView {
     }
 
     public CLobby getController() {
+        return controller;
+    }
+
+    @Override
+    public IDraftEventHandler getDraftHandler() {
         return controller;
     }
 
@@ -1193,24 +1199,4 @@ public class VLobby implements ILobbyView {
         }
     }
 
-    @Override
-    public void onDraftPackArrived(int seatIndex, List<PaperCard> pack,
-            int packNumber, int pickNumber, int timerDurationSeconds) {
-        controller.onDraftPackArrived(seatIndex, pack, packNumber, pickNumber, timerDurationSeconds);
-    }
-
-    @Override
-    public void onDraftSeatPicked(int seatIndex, int[] seatQueueDepths) {
-        controller.onDraftSeatPicked(seatIndex, seatQueueDepths);
-    }
-
-    @Override
-    public void onDraftAutoPicked(int seatIndex, PaperCard card, int packNumber, int pickInPack) {
-        controller.onDraftAutoPicked(seatIndex, card, packNumber, pickInPack);
-    }
-
-    @Override
-    public void onReceiveEventPool(String eventId, Deck pool) {
-        controller.onReceiveEventPool(eventId, pool);
-    }
 }

--- a/forge-gui/src/main/java/forge/gamemodes/net/NetConnectUtil.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/NetConnectUtil.java
@@ -30,37 +30,6 @@ public class NetConnectUtil {
     private NetConnectUtil() { }
 
     /**
-     * Base listener that forwards the four draft-specific callbacks to the given
-     * {@link ILobbyView}. Host-side and client-side listeners share the same draft
-     * forwarding logic; subclasses only need to override the non-draft methods.
-     */
-    private static abstract class DraftForwardingLobbyListener implements ILobbyListener {
-        private final ILobbyView view;
-
-        DraftForwardingLobbyListener(final ILobbyView view) {
-            this.view = view;
-        }
-
-        @Override
-        public void draftPackArrived(int seatIndex, List<forge.item.PaperCard> pack,
-                int packNumber, int pickNumber, int timerDurationSeconds) {
-            view.onDraftPackArrived(seatIndex, pack, packNumber, pickNumber, timerDurationSeconds);
-        }
-        @Override
-        public void draftSeatPicked(int seatIndex, int[] seatQueueDepths) {
-            view.onDraftSeatPicked(seatIndex, seatQueueDepths);
-        }
-        @Override
-        public void draftAutoPicked(int seatIndex, forge.item.PaperCard card, int packNumber, int pickInPack) {
-            view.onDraftAutoPicked(seatIndex, card, packNumber, pickInPack);
-        }
-        @Override
-        public void receiveEventPool(String eventId, forge.deck.Deck pool) {
-            view.onReceiveEventPool(eventId, pool);
-        }
-    }
-
-    /**
      * Prompt for the server address to join. Returns null if cancelled, or the address string.
      */
     public static String getJoinServerUrl() {
@@ -105,7 +74,7 @@ public class NetConnectUtil {
         // updateLobbyState; calling it again here would broadcast a duplicate LobbyUpdateEvent.
         view.setPlayerChangeListener(server::updateSlot);
 
-        server.setLobbyListener(new DraftForwardingLobbyListener(view) {
+        server.setLobbyListener(new ILobbyListener() {
             @Override
             public void update(final GameLobbyData state, final int slot) {
                 // NO-OP, lobby connected directly
@@ -123,6 +92,7 @@ public class NetConnectUtil {
                 return null;
             }
         });
+        server.setDraftHandler(view.getDraftHandler());
         chatInterface.setGameClient(new IRemote() {
             @Override
             public void send(final NetEvent event) {
@@ -211,7 +181,7 @@ public class NetConnectUtil {
         final ClientGameLobby lobby = new ClientGameLobby();
         final ILobbyView view =  onlineLobby.setLobby(lobby);
         lobby.setListener(view);
-        client.addLobbyListener(new DraftForwardingLobbyListener(view) {
+        client.addLobbyListener(new ILobbyListener() {
             @Override
             public void message(final String source, final String message, final ChatMessage.MessageType type) {
                 chatInterface.addMessage(new ChatMessage(source, message, type));
@@ -231,6 +201,7 @@ public class NetConnectUtil {
                 return lobby;
             }
         });
+        client.setDraftHandler(view.getDraftHandler());
         view.setPlayerChangeListener((index, event) -> client.send(event));
 
         NetworkLogConfig.activateNetworkLogging();

--- a/forge-gui/src/main/java/forge/gamemodes/net/client/FGameClient.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/client/FGameClient.java
@@ -8,6 +8,7 @@ import forge.gamemodes.net.NetworkLogConfig;
 import forge.util.IHasForgeLog;
 import forge.gamemodes.net.ReplyPool;
 import forge.gamemodes.net.event.*;
+import forge.gui.interfaces.IDraftEventHandler;
 import forge.gui.interfaces.IGuiGame;
 import forge.interfaces.ILobbyListener;
 import io.netty.bootstrap.Bootstrap;
@@ -34,6 +35,7 @@ public class FGameClient implements IToServer, IHasForgeLog {
     private final Integer port;
     private final String username;
     private final List<ILobbyListener> lobbyListeners = Lists.newArrayList();
+    private IDraftEventHandler draftHandler;
     private final ReplyPool replies = new ReplyPool();
     private volatile boolean disconnectSimulated;
     private Channel channel;
@@ -164,6 +166,10 @@ public class FGameClient implements IToServer, IHasForgeLog {
         lobbyListeners.add(listener);
     }
 
+    public void setDraftHandler(final IDraftEventHandler handler) {
+        this.draftHandler = handler;
+    }
+
     void setGameControllers(final Iterable<PlayerView> myPlayers) {
         for (final PlayerView p : myPlayers) {
             NetGameController controller = new NetGameController(this);
@@ -190,28 +196,8 @@ public class FGameClient implements IToServer, IHasForgeLog {
                 for (final ILobbyListener listener : lobbyListeners) {
                     listener.update(event.getState(), event.getSlot());
                 }
-            } else if (msg instanceof ReceiveEventPoolEvent event) {
-                for (final ILobbyListener listener : lobbyListeners) {
-                    listener.receiveEventPool(event.getEventId(), event.getPool());
-                }
-                return;
-            } else if (msg instanceof DraftAutoPickedEvent event) {
-                for (final ILobbyListener listener : lobbyListeners) {
-                    listener.draftAutoPicked(event.getSeatIndex(), event.getCard(),
-                            event.getPackNumber(), event.getPickInPack());
-                }
-                return;
-            } else if (msg instanceof DraftPackArrivedEvent event) {
-                for (final ILobbyListener listener : lobbyListeners) {
-                    listener.draftPackArrived(event.getSeatIndex(), event.getPack(),
-                            event.getPackNumber(), event.getPickNumber(),
-                            event.getTimerDurationSeconds());
-                }
-                return;
-            } else if (msg instanceof DraftSeatPickedEvent event) {
-                for (final ILobbyListener listener : lobbyListeners) {
-                    listener.draftSeatPicked(event.getSeatIndex(), event.getSeatQueueDepths());
-                }
+            } else if (msg instanceof NetEvent netEvent && draftHandler != null
+                    && draftHandler.dispatch(netEvent)) {
                 return;
             }
             super.channelRead(ctx, msg);

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
@@ -17,6 +17,7 @@ import forge.gamemodes.net.draft.BoosterDraftHost;
 import forge.util.IHasForgeLog;
 import forge.gamemodes.net.event.*;
 import forge.gui.GuiBase;
+import forge.gui.interfaces.IDraftEventHandler;
 import forge.gui.interfaces.IGuiGame;
 import forge.gui.util.SOptionPane;
 import forge.interfaces.IGameController;
@@ -78,6 +79,7 @@ public final class FServerManager implements IHasForgeLog {
     private UpnpService upnpService = null;
     private ServerGameLobby localLobby;
     private ILobbyListener lobbyListener;
+    private IDraftEventHandler draftHandler;
     private boolean UPnPMapped = false;
     private int port;
     private static final Localizer localizer = Localizer.getInstance();
@@ -288,22 +290,14 @@ public final class FServerManager implements IHasForgeLog {
     /**
      * Dispatch a broadcast event to the host's local listener — the host does
      * not receive its own broadcasts over the network, so we mirror them here.
-     * Kept in sync with {@code FGameClient.LobbyUpdateHandler}.
      */
     private void dispatchToLocalListener(final NetEvent event) {
-        if (lobbyListener == null) return;
         if (event instanceof MessageEvent e) {
-            lobbyListener.message(e.getSource(), e.getMessage(), e.getType());
-        } else if (event instanceof ReceiveEventPoolEvent e) {
-            lobbyListener.receiveEventPool(e.getEventId(), e.getPool());
-        } else if (event instanceof DraftAutoPickedEvent e) {
-            lobbyListener.draftAutoPicked(e.getSeatIndex(), e.getCard(),
-                    e.getPackNumber(), e.getPickInPack());
-        } else if (event instanceof DraftPackArrivedEvent e) {
-            lobbyListener.draftPackArrived(e.getSeatIndex(), e.getPack(),
-                    e.getPackNumber(), e.getPickNumber(), e.getTimerDurationSeconds());
-        } else if (event instanceof DraftSeatPickedEvent e) {
-            lobbyListener.draftSeatPicked(e.getSeatIndex(), e.getSeatQueueDepths());
+            if (lobbyListener != null) {
+                lobbyListener.message(e.getSource(), e.getMessage(), e.getType());
+            }
+        } else if (draftHandler != null) {
+            draftHandler.dispatch(event);
         }
     }
 
@@ -432,6 +426,10 @@ public final class FServerManager implements IHasForgeLog {
 
     public void setLobbyListener(final ILobbyListener listener) {
         this.lobbyListener = listener;
+    }
+
+    public void setDraftHandler(final IDraftEventHandler handler) {
+        this.draftHandler = handler;
     }
 
     public void updateLobbyState() {

--- a/forge-gui/src/main/java/forge/gui/interfaces/IDraftEventHandler.java
+++ b/forge-gui/src/main/java/forge/gui/interfaces/IDraftEventHandler.java
@@ -1,0 +1,39 @@
+package forge.gui.interfaces;
+
+import java.util.List;
+
+import forge.deck.Deck;
+import forge.gamemodes.net.event.DraftAutoPickedEvent;
+import forge.gamemodes.net.event.DraftPackArrivedEvent;
+import forge.gamemodes.net.event.DraftSeatPickedEvent;
+import forge.gamemodes.net.event.NetEvent;
+import forge.gamemodes.net.event.ReceiveEventPoolEvent;
+import forge.item.PaperCard;
+
+public interface IDraftEventHandler {
+    void draftPackArrived(int seatIndex, List<PaperCard> pack,
+            int packNumber, int pickNumber, int timerDurationSeconds);
+    void draftSeatPicked(int seatIndex, int[] seatQueueDepths);
+    void draftAutoPicked(int seatIndex, PaperCard card, int packNumber, int pickInPack);
+    void receiveEventPool(String eventId, Deck pool);
+
+    /** Returns true if {@code event} was a draft event and was dispatched. */
+    default boolean dispatch(NetEvent event) {
+        if (event instanceof DraftPackArrivedEvent e) {
+            draftPackArrived(e.getSeatIndex(), e.getPack(),
+                    e.getPackNumber(), e.getPickNumber(), e.getTimerDurationSeconds());
+            return true;
+        } else if (event instanceof DraftSeatPickedEvent e) {
+            draftSeatPicked(e.getSeatIndex(), e.getSeatQueueDepths());
+            return true;
+        } else if (event instanceof DraftAutoPickedEvent e) {
+            draftAutoPicked(e.getSeatIndex(), e.getCard(),
+                    e.getPackNumber(), e.getPickInPack());
+            return true;
+        } else if (event instanceof ReceiveEventPoolEvent e) {
+            receiveEventPool(e.getEventId(), e.getPool());
+            return true;
+        }
+        return false;
+    }
+}

--- a/forge-gui/src/main/java/forge/gui/interfaces/ILobbyView.java
+++ b/forge-gui/src/main/java/forge/gui/interfaces/ILobbyView.java
@@ -1,21 +1,11 @@
 package forge.gui.interfaces;
 
-import forge.deck.Deck;
 import forge.interfaces.IPlayerChangeListener;
 import forge.interfaces.IUpdateable;
-import forge.item.PaperCard;
-
-import java.util.List;
 
 public interface ILobbyView extends IUpdateable {
     void setPlayerChangeListener(IPlayerChangeListener iPlayerChangeListener);
 
-    default void onDraftPackArrived(int seatIndex, List<PaperCard> pack,
-            int packNumber, int pickNumber, int timerDurationSeconds) { }
-    /** Fires for every pod seat (including the viewing player) so views can refresh queue depths uniformly. */
-    default void onDraftSeatPicked(int seatIndex, int[] seatQueueDepths) { }
-    /** Fires when the pick timer expires and the server auto-selects a card. */
-    default void onDraftAutoPicked(int seatIndex, PaperCard card, int packNumber, int pickInPack) { }
-    /** Fires once at the end of the draft with the player's pool. */
-    default void onReceiveEventPool(String eventId, Deck pool) { }
+    /** Implementations that participate in network draft/sealed return their handler; others return null. */
+    default IDraftEventHandler getDraftHandler() { return null; }
 }

--- a/forge-gui/src/main/java/forge/interfaces/ILobbyListener.java
+++ b/forge-gui/src/main/java/forge/interfaces/ILobbyListener.java
@@ -1,22 +1,12 @@
 package forge.interfaces;
 
-import java.util.List;
-
-import forge.deck.Deck;
 import forge.gamemodes.match.GameLobby.GameLobbyData;
 import forge.gamemodes.net.ChatMessage;
 import forge.gamemodes.net.client.ClientGameLobby;
-import forge.item.PaperCard;
 
 public interface ILobbyListener {
     void message(String source, String message, ChatMessage.MessageType type);
     void update(GameLobbyData state, int slot);
     void close();
     ClientGameLobby getLobby();
-
-    default void draftPackArrived(int seatIndex, List<PaperCard> pack,
-            int packNumber, int pickNumber, int timerDurationSeconds) { }
-    default void draftSeatPicked(int seatIndex, int[] seatQueueDepths) { }
-    default void draftAutoPicked(int seatIndex, PaperCard card, int packNumber, int pickInPack) { }
-    default void receiveEventPool(String eventId, Deck pool) { }
 }


### PR DESCRIPTION
Addresses https://github.com/Card-Forge/forge/pull/10474#issuecomment-4522042958

Previously a draft pack-pick through the debugger went through three frames — `DraftForwardingLobbyListener.draftSeatPicked` → `VLobby.onDraftSeatPicked` → `CLobby.onDraftSeatPicked` — for what should be one network event reaching one handler. The four draft method signatures were also declared three times (on `ILobbyListener`, on `ILobbyView`, and in the forwarder adapter), with two near-twin `instanceof` dispatchers in `FServerManager` and `FGameClient` routing among them.

This PR:

- Introduces `IDraftEventHandler` as the single home for those four signatures, plus a `dispatch(NetEvent)` default that consolidates the `instanceof` routing.
- Has `CLobby` implement it directly.
- Adds a separate optional `draftHandler` slot on `FServerManager` and `FGameClient`, wired by `NetConnectUtil`.
- Deletes the forwarder adapter, the four pass-throughs on `VLobby`, and the four default methods on each of the two listener interfaces.
- Collapses the flagged stack from three frames to one. Adding a future draft event means touching one interface instead of six call sites.

Mobile compiles unchanged on this branch — `LobbyScreen` didn't override the removed defaults, and `ILobbyView.getDraftHandler()` defaults to `null` so it inherits that. The new shape is also the right seam for the eventual mobile online draft port: `OnlineLobbyScreen` will `implements IDraftEventHandler` directly with no forwarder, and mobile lobby screens that never draft no longer inherit four no-op callbacks they don't need.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)