### PR TITLE
Fixes Varchild's War Riders Cumulative Upkeep from giving tokens to each opponent

### DIFF
--- a/forge-gui/release-files/CONTRIBUTORS.txt
+++ b/forge-gui/release-files/CONTRIBUTORS.txt
@@ -149,6 +149,7 @@ Monkey Gland Sauce
 Morgenmvffel
 mousep
 mtwilliams14
+mrcelophane
 Myrd
 myyk
 NCat39

--- a/forge-gui/res/cardsfolder/v/varchilds_war_riders.txt
+++ b/forge-gui/res/cardsfolder/v/varchilds_war_riders.txt
@@ -6,8 +6,10 @@ K:Trample
 K:Rampage:1
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigCumUpkeep | TriggerDescription$ Cumulative upkeep—Have an opponent create a 1/1 red Survivor creature token.
 SVar:TrigCumUpkeep:DB$ Charm | Choices$ TrigAgeSurvivor,TrigAgeSacrifice
-SVar:TrigAgeSurvivor:DB$ PutCounter | Defined$ Self | CounterType$ AGE | CounterNum$ 1 | SubAbility$ Survivor
-SVar:Survivor:DB$ Token | TokenAmount$ X | TokenScript$ r_1_1_survivor | TokenOwner$ Opponent | SpellDescription$ Have an opponent create a 1/1 red Survivor creature token.
+SVar:TrigAgeSurvivor:DB$ PutCounter | Defined$ Self | CounterType$ AGE | CounterNum$ 1 | SubAbility$ SurvivorDistribution
+SVar:SurvivorDistribution:DB$ Repeat | RepeatSubAbility$ SurvivorRecipient | MaxRepeat$ X | SpellDescription$ Have an opponent create a 1/1 red Survivor creature token for each Age Counter on CARDNAME.
+SVar:SurvivorRecipient:DB$ ChoosePlayer | Defined$ You | Choices$ Player.Opponent | ChoiceTitle$ Choose an opponent to create a 1/1 red Survivor creature token. | SubAbility$ Survivor
+SVar:Survivor:DB$ Token | TokenScript$ r_1_1_survivor | TokenOwner$ ChosenPlayer 
 SVar:X:Count$CardCounters.AGE
 SVar:TrigAgeSacrifice:DB$ PutCounter | Defined$ Self | CounterType$ AGE | CounterNum$ 1 | SubAbility$ Sacrifice
 SVar:Sacrifice:DB$ Sacrifice | Defined$ Self | SpellDescription$ Sacrifice CARDNAME.


### PR DESCRIPTION
Varchild's War Riders' Cumulative Upkeep was not working properly and was giving X Survivors to each opponent. It is supposed to let you give out a total of X to any number of Opponents. 