### PR TITLE
Only focus floating zone filter when no prompt button is actionable

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
@@ -296,6 +296,10 @@ public final class CMatchUI
     CPrompt getCPrompt() {
         return cPrompt;
     }
+    /** True if either prompt input button (OK/Cancel) is currently enabled. */
+    public boolean isInputButtonEnabled() {
+        return view.getBtnOK().isEnabled() || view.getBtnCancel().isEnabled();
+    }
     public CStack getCStack() {
         return cStack;
     }

--- a/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingZone.java
+++ b/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingZone.java
@@ -620,7 +620,11 @@ public class FloatingZone extends FloatingCardArea {
         onShow();
         // Override the base class's focusableWindowState=false so the search field can take keystrokes.
         getWindow().setFocusableWindowState(true);
-        if (getMatchUI().isSelecting()) {
+        // The window auto-grabs focus to the filter on show; suppress that while the prompt has an
+        // actionable button so OK/Cancel keep keyboard focus (the field stays clickable to filter).
+        final boolean takeFilterFocus = !getMatchUI().isInputButtonEnabled();
+        getWindow().setAutoRequestFocus(takeFilterFocus);
+        if (takeFilterFocus) {
             getWindow().setDefaultFocus(searchField);
         }
         getWindow().setVisible(true);


### PR DESCRIPTION
Opening a floating zone (graveyard, exile, etc.) could auto-grab keyboard focus to its search filter, stealing it from the prompt's OK/Cancel buttons.

This gates the focus grab on the prompt button state: the zone only takes filter focus when neither OK nor Cancel is enabled; otherwise focus stays on the prompt. The search field remains clickable to filter either way (`setAutoRequestFocus(false)` keeps the window focusable without auto-stealing focus).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)