### PR TITLE
Rework current metagame net decks

### DIFF
--- a/forge-gui/res/lists/net-decks-commander.txt
+++ b/forge-gui/res/lists/net-decks-commander.txt
@@ -8,8 +8,8 @@ Commander On a Budget | https://github.com/Card-Forge/forge-extras/raw/refs/head
 Commander Quickie | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/commanderquickie.zip
 Commander VS | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/commandervs.zip
 Community Cup | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/communitycup-commander.zip
-Current Commander 1v1 Metagame | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/currentcommander1v1metagame.zip
 Current Commander Metagame | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/currentcommandermetagame.zip
+Current Duel Commander Metagame | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/currentduelcommandermetagame.zip
 Daily Deck List | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/dailydecks-commander.zip
 Daily Magic Update | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/dailymagicupdate-commander.zip
 Dear Azami | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/dearazami.zip

--- a/forge-gui/res/lists/net-decks.txt
+++ b/forge-gui/res/lists/net-decks.txt
@@ -10,18 +10,16 @@ Building on a Budget | https://github.com/Card-Forge/forge-extras/raw/refs/heads
 Card Preview | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/cardpreview.zip
 Community Cup | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/communitycup.zip
 Current Alchemy Metagame | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/currentalchemymetagame.zip
-Current Alchemy-BO1 Metagame | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/currentalchemybo1metagame.zip
 Current Historic Metagame | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/currenthistoricmetagame.zip
-Current Historic-BO1 Metagame | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/currenthistoricbo1metagame.zip
 Current Legacy Metagame | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/currentlegacymetagame.zip
 Current Modern Metagame | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/currentmodernmetagame.zip
 Current Pauper Metagame | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/currentpaupermetagame.zip
 Current Penny Dreadful Metagame | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/currentpennydreadfulmetagame.zip
 Current Pioneer Metagame | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/currentpioneermetagame.zip
+Current Premodern Metagame | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/currentpremodernmetagame.zip
 Current Standard Metagame | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/currentstandardmetagame.zip
 Current Standard-BO1 Metagame | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/currentstandardbo1metagame.zip
 Current Timeless Metagame | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/currenttimelessmetagame.zip
-Current Timeless-BO1 Metagame | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/currenttimelessbo1metagame.zip
 Current Vintage Metagame | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/currentvintagemetagame.zip
 Daily Deck List | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/dailydecks.zip
 Daily Magic Update | https://github.com/Card-Forge/forge-extras/raw/refs/heads/main/decks/dailymagicupdate.zip


### PR DESCRIPTION
This PR reworks the current metagame zips due to lack of data for some formats. All zips have been updated on forge-extras.

- Commander 1v1 renamed to Duel Commander.

- Alchemy/Alchemy-BO1 is now just Alchemy and contains BO1 decks.
- Historic/Historic-BO1 is now just Historic and contains BO1 decks.
- Timeless/Timeless-BO1 is now just Timeless and contains BO1 decks.

- Added Premodern current metagame.