### PR TITLE
Remove unused GuiBase.isInterrupted flag

### DIFF
--- a/forge-gui-mobile/src/forge/screens/online/OnlineLobbyScreen.java
+++ b/forge-gui-mobile/src/forge/screens/online/OnlineLobbyScreen.java
@@ -15,7 +15,6 @@ import forge.gamemodes.net.OfflineLobby;
 import forge.gamemodes.net.client.FGameClient;
 import forge.gamemodes.net.server.FServerManager;
 import forge.gui.FThreads;
-import forge.gui.GuiBase;
 import forge.gui.interfaces.ILobbyView;
 import forge.gui.util.SOptionPane;
 import forge.localinstance.properties.ForgeConstants;
@@ -105,8 +104,6 @@ public class OnlineLobbyScreen extends LobbyScreen implements IOnlineLobby {
             FThreads.invokeInBackgroundThread(() -> {
                 final boolean callBackAlwaysTrue = SOptionPane.showOptionDialog(msg, Forge.getLocalizer().getMessage("lblError"), FSkinProp.ICO_WARNING, List.of(Forge.getLocalizer().getMessage("lblOK")), 1) == 0;
                 if (callBackAlwaysTrue) { //to activate online menu popup when player press play online
-                    GuiBase.setInterrupted(false);
-
                     if(FServerManager.getInstance() != null)
                         FServerManager.getInstance().stopServer();
                     if(getfGameClient() != null)
@@ -129,10 +126,6 @@ public class OnlineLobbyScreen extends LobbyScreen implements IOnlineLobby {
 
     @Override
     public void onActivate() {
-        if (GuiBase.isInterrupted()) {
-            GuiBase.setInterrupted(false);
-            return;
-        }
         if (getGameLobby() == null) {
             revalidate();
         } else {

--- a/forge-gui/src/main/java/forge/gamemodes/net/NetConnectUtil.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/NetConnectUtil.java
@@ -223,7 +223,6 @@ public class NetConnectUtil {
             }
             @Override
             public void close() {
-                GuiBase.setInterrupted(true);
                 onlineLobby.closeConn(Localizer.getInstance().getMessage("lblYourConnectionToHostWasInterrupted", url));
             }
             @Override

--- a/forge-gui/src/main/java/forge/gui/GuiBase.java
+++ b/forge-gui/src/main/java/forge/gui/GuiBase.java
@@ -10,7 +10,6 @@ public class GuiBase {
     private static IGuiBase guiInterface;
     private static boolean isAndroidport = false;
     private static String adventureDirectory = null;
-    private static boolean interrupted = false;
     private static int androidAPI = 0;
     private static String downloadsDir = "";
     private static boolean usingAppDirectory = false;
@@ -82,7 +81,4 @@ public class GuiBase {
         // to check all available IGuiGame
         return getInterface().hasNetGame();
     }
-
-    public static void setInterrupted(boolean value) { interrupted = value; }
-    public static boolean isInterrupted() { return interrupted; }
 }


### PR DESCRIPTION
`GuiBase.isInterrupted()` was added in [d87d825](https://github.com/Card-Forge/forge/commit/d87d825bcee14fc9fc65a0d83049a248c1cdb904) (2020) to suppress an auto-connect prompt. Back then, activating the online lobby with no active lobby immediately popped a "connect to a server?" input dialog (`onActivate` → `NetConnectUtil.getServerUrl()`). On a dropped connection, teardown calls `closeConn` → `Forge.back()`, which re-activates the lobby screen and re-fired that prompt — so the flag was set during teardown and read once in `onActivate` to skip it.

## Why removing it is safe

- **The thing it guarded against is gone.** #9899 replaced the auto-connect prompt with a passive Host/Join landing page. `onActivate` no longer prompts on activation; with no lobby it just calls `revalidate()` to lay out the Host/Join buttons.
- **The post-disconnect path lands correctly without it.** `closeConn` nulls the lobby before `Forge.back()`, so the re-activated `onActivate` takes the `revalidate()` branch — the Host/Join page, which is exactly where a disconnected client should end up.
- **No other callers.** The field, its accessors, and the `setInterrupted(true)` in `NetConnectUtil` were the only references to it anywhere in the tree.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)