### PR TITLE
YSOS, batch 5: 4 cards

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/scintillating_encore.txt
+++ b/forge-gui/res/cardsfolder/upcoming/scintillating_encore.txt
@@ -1,0 +1,7 @@
+Name:Scintillating Encore
+ManaCost:WB
+Types:Instant
+A:SP$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | NumAtt$ +2 | Duration$ Perpetual | SubAbility$ DBDelayedTrigger | SpellDescription$ Target creature you control perpetually gets +2/+0. When that creature dies this turn, return it to the battlefield tapped under its owner's control.
+SVar:DBDelayedTrigger:DB$ DelayedTrigger | Mode$ ChangesZone | RememberObjects$ Targeted | ValidCard$ Card.IsTriggerRemembered | Origin$ Battlefield | Destination$ Graveyard | ThisTurn$ True | Execute$ TrigReturn | StackDescription$ None | SpellDescription$ When that creature dies this turn, return it to the battlefield tapped under its owner's control.
+SVar:TrigReturn:DB$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | Defined$ TriggeredCard
+Oracle:Target creature you control perpetually gets +2/+0. When that creature dies this turn, return it to the battlefield tapped under its owner's control.

--- a/forge-gui/res/cardsfolder/upcoming/soovril_patient_antiquarian.txt
+++ b/forge-gui/res/cardsfolder/upcoming/soovril_patient_antiquarian.txt
@@ -1,0 +1,8 @@
+Name:Soovril, Patient Antiquarian
+ManaCost:R W
+Types:Legendary Creature Orc Cleric
+PT:2/3
+K:Vigilance
+A:AB$ PutCounter | Cost$ T | ValidTgts$ Card.nonLand+YouOwn+ThisTurnEnteredFrom_Graveyard | TgtZone$ Exile | TgtPrompt$ Select target nonland card in exile that was put there from your graveyard this turn | CounterType$ TIME | CounterNum$ 2 | SubAbility$ DBPump | SpellDescription$ Put two time counters on target nonland card in exile that was put there from your graveyard this turn. If it doesn't have suspend, it gains suspend.
+SVar:DBPump:DB$ Pump | Defined$ ParentTarget | ConditionDefined$ ParentTarget | ConditionPresent$ Card.withoutSuspend | PumpZone$ Exile | KW$ Suspend | Duration$ Permanent
+Oracle:Vigilance\n{T}: Put two time counters on target nonland card in exile that was put there from your graveyard this turn. If it doesn't have suspend, it gains suspend.

--- a/forge-gui/res/cardsfolder/upcoming/sundering_sentinel.txt
+++ b/forge-gui/res/cardsfolder/upcoming/sundering_sentinel.txt
@@ -9,10 +9,8 @@ SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ X | SubAbility$ DBInte
 SVar:DBIntensify:DB$ Intensify
 SVar:X:Count$Intensity
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigExile | TriggerDescription$ At the beginning of your end step, exile this creature. At the beginning of your next upkeep, return it to the battlefield under its owner's control. It gains haste.
-SVar:TrigExile:DB$ ChangeZone | ValidTgts$ Creature | Origin$ Battlefield | Destination$ Exile | RememberChanged$ True | SubAbility$ DelTrigEffect
-SVar:DelTrigEffect:DB$ DelayedTrigger | Mode$ Phase | Phase$ Upkeep | Execute$ TrigReturn | RememberObjects$ RememberedLKI | SubAbility$ DBCleanup1 | TriggerDescription$ At the beginning of your next upkeep, return it to the battlefield under its owner's control. It gains haste.
-SVar:TrigReturn:DB$ ChangeZone | Imprint$ True | Defined$ DelayTriggerRememberedLKI | Origin$ Exile | Destination$ Battlefield | SubAbility$ DBAnimate
-SVar:DBAnimate:DB$ Animate | Keywords$ Haste | Duration$ Permanent | Defined$ Imprinted | SubAbility$ DBCleanup2
-SVar:DBCleanup1:DB$ Cleanup | ClearRemembered$ True
-SVar:DBCleanup2:DB$ Cleanup | ClearImprinted$ True
+SVar:TrigExile:DB$ ChangeZone | Defined$ Self | Origin$ Battlefield | Destination$ Exile | RememberChanged$ True | SubAbility$ DelTrigEffect
+SVar:DelTrigEffect:DB$ DelayedTrigger | Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ TrigReturn | ConditionDefined$ Remembered | ConditionPresent$ Card | RememberObjects$ Remembered | TriggerDescription$ At the beginning of your next upkeep, return it to the battlefield under its owner's control. It gains haste.
+SVar:TrigReturn:DB$ ChangeZone | Defined$ DelayTriggerRememberedLKI | Origin$ Exile | Destination$ Battlefield | SubAbility$ DBPump
+SVar:DBPump:DB$ Pump | KW$ Haste | Duration$ Permanent | Defined$ Remembered
 Oracle:Starting intensity 2\nWhen this creature enters, it deals X damage to any target and you gain X life, where X is this creature's intensity. Then it intensifies.\nAt the beginning of your end step, exile this creature. At the beginning of your next upkeep, return it to the battlefield under its owner's control. It gains haste.

--- a/forge-gui/res/cardsfolder/upcoming/sundering_sentinel.txt
+++ b/forge-gui/res/cardsfolder/upcoming/sundering_sentinel.txt
@@ -1,0 +1,18 @@
+Name:Sundering Sentinel
+ManaCost:2 R R W W
+Types:Artifact Creature Construct
+PT:6/7
+K:Starting intensity:2
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDealDamage | TriggerDescription$ When this creature enters, it deals X damage to any target and you gain X life, where X is this creature's intensity. Then it intensifies.
+SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Any | NumDmg$ X | SubAbility$ DBGainLife
+SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ X | SubAbility$ DBIntensify
+SVar:DBIntensify:DB$ Intensify
+SVar:X:Count$Intensity
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigExile | TriggerDescription$ At the beginning of your end step, exile this creature. At the beginning of your next upkeep, return it to the battlefield under its owner's control. It gains haste.
+SVar:TrigExile:DB$ ChangeZone | ValidTgts$ Creature | Origin$ Battlefield | Destination$ Exile | RememberChanged$ True | SubAbility$ DelTrigEffect
+SVar:DelTrigEffect:DB$ DelayedTrigger | Mode$ Phase | Phase$ Upkeep | Execute$ TrigReturn | RememberObjects$ RememberedLKI | SubAbility$ DBCleanup1 | TriggerDescription$ At the beginning of your next upkeep, return it to the battlefield under its owner's control. It gains haste.
+SVar:TrigReturn:DB$ ChangeZone | Imprint$ True | Defined$ DelayTriggerRememberedLKI | Origin$ Exile | Destination$ Battlefield | SubAbility$ DBAnimate
+SVar:DBAnimate:DB$ Animate | Keywords$ Haste | Duration$ Permanent | Defined$ Imprinted | SubAbility$ DBCleanup2
+SVar:DBCleanup1:DB$ Cleanup | ClearRemembered$ True
+SVar:DBCleanup2:DB$ Cleanup | ClearImprinted$ True
+Oracle:Starting intensity 2\nWhen this creature enters, it deals X damage to any target and you gain X life, where X is this creature's intensity. Then it intensifies.\nAt the beginning of your end step, exile this creature. At the beginning of your next upkeep, return it to the battlefield under its owner's control. It gains haste.

--- a/forge-gui/res/cardsfolder/upcoming/unbreakable_remnant.txt
+++ b/forge-gui/res/cardsfolder/upcoming/unbreakable_remnant.txt
@@ -1,0 +1,8 @@
+Name:Unbreakable Remnant
+ManaCost:W
+Types:Creature Spirit Soldier
+PT:2/1
+K:Escape:1 W ExileFromGrave<2/Card.Other/other>
+T:Mode$ SpellCast | ValidCard$ Card.Self+wasCastFromYourGraveyardByYou | Execute$ TrigPumpAll | TriggerDescription$ When you cast this spell from your graveyard, all cards you own named Unbreakable Remnant perpetually get +1/+1.
+SVar:TrigPumpAll:DB$ PumpAll | ValidCards$ Card.YouOwn+namedUnbreakable Remnant+!token | PumpZone$ All | NumAtt$ +1 | NumDef$ +1 | Duration$ Perpetual
+Oracle:Escape—{1}{W}, Exile two other cards from your graveyard.\nWhen you cast this spell from your graveyard, all cards you own named Unbreakable Remnant perpetually get +1/+1.


### PR DESCRIPTION
As revealed recently:
- [Scintillating Encore](https://scryfall.com/card/ysos/26/scintillating-encore): Tested to satisfaction.
- [Soovril, Patient Antiquarian](https://scryfall.com/card/ysos/27/soovril-patient-antiquarian): Tested to satisfaction.
- [Sundering Sentinel](https://scryfall.com/card/ysos/29/sundering-sentinel): Tested to satisfaction.
- [Unbreakable Remnant](https://scryfall.com/card/ysos/2/unbreakable-remnant): Tested to satisfaction.