### PR TITLE
Update Commander deckgen matrix from EDHREC data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,5 @@ __pycache__
 
 # Ignore Claude configuration
 .claude
+# EDHREC commander matrix tool intermediates
+forge-gui/tools/build

--- a/forge-gui/tools/README-edhrec_to_forge.md
+++ b/forge-gui/tools/README-edhrec_to_forge.md
@@ -1,0 +1,59 @@
+# EDHREC Commander Matrix for Forge
+
+This project builds a Forge-compatible `Commander.dat` from EDHREC commander pages in two passes.
+
+The first pass scrapes EDHREC into a raw TSV. The second pass transforms that TSV into integer weights, then invokes `java/ForgeMatrixWriter.java`. The Java bridge uses Forge's own `PaperCard` objects and Java `ObjectOutputStream`, so the output has the same serialized shape that `CardThemedMatrixIO.loadMatrix("Commander")` expects:
+
+```java
+HashMap<String, List<Map.Entry<PaperCard, Integer>>>
+```
+
+The raw TSV preserves the fields needed to experiment with weight formulas without scraping EDHREC again: commander rank, commander deck count, card section, included deck count, eligible deck count, inclusion percentage, and synergy percentage.
+
+## Usage
+
+Pass 1, scrape raw EDHREC data:
+
+```bash
+python3 edhrec_to_forge.py \
+  --limit-commanders 1000 \
+  --cards-per-commander 500 \
+  --min-interval 2.0 \
+  --verbose
+```
+
+Pass 2, calculate weights and write `Commander.dat`:
+
+```bash
+python3 build_forge_matrix.py --weight-mode log
+```
+
+Useful options:
+
+```bash
+python3 edhrec_to_forge.py --refresh
+python3 edhrec_to_forge.py --no-resume
+python3 edhrec_to_forge.py --fill-incomplete
+python3 edhrec_to_forge.py --min-interval 5 --jitter 2
+python3 build_forge_matrix.py --weight-mode count
+python3 build_forge_matrix.py --weight-mode inclusion --skip-dat
+python3 build_forge_matrix.py --weight-mode sqrt --cards-per-commander 300
+python3 build_forge_matrix.py --no-expand-pairs
+```
+
+Weight modes:
+
+- `count`: raw included deck count. This is closest to Forge's current matrix semantics, but biases toward old cards.
+- `inclusion`: inclusion rate only. This is age-neutral, but can overvalue tiny samples.
+- `log`: inclusion rate multiplied by `log1p(included_decks)`. This is the default middle ground.
+- `sqrt`: inclusion rate multiplied by `sqrt(included_decks)`. This is stronger sample-size weighting than `log`.
+
+Notes:
+
+- These scripts are intended to run from `forge-gui/tools`. By default they write intermediate files under `forge-gui/tools/build` and write the final matrix to `forge-gui/res/deckgendecks/Commander.dat`.
+- Forge must already have `forge-gui-desktop/target/*jar-with-dependencies.jar`. If it does not, build Forge first.
+- EDHREC embeds commander ranks in Next.js JSON. The scraper reads that structured data and follows EDHREC's `more` JSON pointer for ranks beyond the first page.
+- Scraping resumes by default: if the output TSV already has rows for a commander, that commander is skipped on the next run. Use `--no-resume` to rebuild from scratch, or `--fill-incomplete` to re-scrape commanders with fewer than `--cards-per-commander` rows.
+- Pair commanders are expanded by default during the build step. An EDHREC page named `A // B` contributes its card weights to both `A` and `B`, and each commander gets the other partner as a weighted card entry. This matches Forge's individual-commander matrix keys. Use `--no-expand-pairs` only for diagnostics.
+- Live EDHREC requests default to at least 2 seconds apart plus random jitter, retry with exponential backoff, and honor numeric `Retry-After` responses. Cached pages do not make network requests.
+- Unknown cards and commanders are skipped by the Java writer so the `.dat` file only contains cards present in the local Forge database.

--- a/forge-gui/tools/build_forge_matrix.py
+++ b/forge-gui/tools/build_forge_matrix.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Pass 2: transform raw EDHREC TSV data into a Forge-compatible Commander.dat."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import os
+import subprocess
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+@dataclass(frozen=True)
+class WeightedRow:
+    commander_rank: int
+    commander: str
+    card: str
+    weight: int
+
+
+PAIR_SEPARATOR = " // "
+NAME_REPLACEMENTS = {
+    "\ua789": ":",
+}
+
+
+def parse_int(value: str | None) -> int | None:
+    if value is None or value == "":
+        return None
+    return int(float(value))
+
+
+def parse_float(value: str | None) -> float | None:
+    if value is None or value == "":
+        return None
+    return float(value)
+
+
+def calculate_weight(row: dict[str, str], mode: str, scale: float, min_weight: int) -> int:
+    included = parse_int(row.get("included_decks")) or 0
+    eligible = parse_int(row.get("eligible_decks")) or parse_int(row.get("commander_decks")) or 0
+    inclusion_percent = parse_float(row.get("inclusion_percent"))
+
+    if eligible > 0:
+        inclusion_rate = included / eligible
+    elif inclusion_percent is not None:
+        inclusion_rate = inclusion_percent / 100.0
+    else:
+        inclusion_rate = 0.0
+
+    if mode == "count":
+        score = included
+    elif mode == "inclusion":
+        score = inclusion_rate * scale
+    elif mode == "log":
+        score = inclusion_rate * math.log1p(included) * scale
+    elif mode == "sqrt":
+        score = inclusion_rate * math.sqrt(included) * scale
+    else:
+        raise ValueError(f"unknown weight mode: {mode}")
+
+    return score_to_weight(score, min_weight)
+
+
+def score_to_weight(score: float, min_weight: int) -> int:
+    if score <= 0:
+        return 0
+    return max(min_weight, int(round(score)))
+
+
+def commander_names(raw_name: str, expand_pairs: bool) -> list[str]:
+    raw_name = normalize_name(raw_name)
+    if expand_pairs and PAIR_SEPARATOR in raw_name:
+        return [part.strip() for part in raw_name.split(PAIR_SEPARATOR) if part.strip()]
+    return [raw_name]
+
+
+def normalize_name(name: str) -> str:
+    for source, replacement in NAME_REPLACEMENTS.items():
+        name = name.replace(source, replacement)
+    return name
+
+
+def partner_weight(row: dict[str, str], args: argparse.Namespace) -> int:
+    commander_decks = parse_int(row.get("commander_decks")) or 0
+    if commander_decks <= 0:
+        return args.min_weight
+
+    if args.weight_mode == "count":
+        score = commander_decks
+    elif args.weight_mode == "log":
+        score = math.log1p(commander_decks) * args.scale
+    elif args.weight_mode == "sqrt":
+        score = math.sqrt(commander_decks) * args.scale
+    else:
+        score = args.scale
+    return score_to_weight(score, args.min_weight)
+
+
+def read_weighted_rows(args: argparse.Namespace) -> list[WeightedRow]:
+    by_commander_card: dict[str, dict[str, WeightedRow]] = defaultdict(dict)
+    pair_partner_rows: dict[tuple[str, str], WeightedRow] = {}
+
+    with args.input.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        for row in reader:
+            included = parse_int(row.get("included_decks")) or 0
+            if included < args.min_included_decks:
+                continue
+            weight = calculate_weight(row, args.weight_mode, args.scale, args.min_weight)
+            if weight <= 0:
+                continue
+            rank = parse_int(row.get("commander_rank")) or 999999
+            raw_commander = row["commander"]
+            commanders = commander_names(raw_commander, args.expand_pairs)
+            for commander in commanders:
+                weighted = WeightedRow(
+                    commander_rank=rank,
+                    commander=commander,
+                    card=normalize_name(row["card"]),
+                    weight=weight,
+                )
+                keep_best_row(by_commander_card[commander], weighted)
+
+            if args.expand_pairs and len(commanders) > 1:
+                p_weight = partner_weight(row, args)
+                for commander in commanders:
+                    for partner in commanders:
+                        if partner == commander:
+                            continue
+                        key = (commander, partner)
+                        existing = pair_partner_rows.get(key)
+                        candidate = WeightedRow(rank, commander, partner, p_weight)
+                        if existing is None or candidate.weight > existing.weight:
+                            pair_partner_rows[key] = candidate
+
+    for row in pair_partner_rows.values():
+        keep_best_row(by_commander_card[row.commander], row)
+
+    rows: list[WeightedRow] = []
+    for commander_cards in by_commander_card.values():
+        commander_rows = list(commander_cards.values())
+        commander_rows.sort(key=lambda item: (-item.weight, item.card))
+        if args.cards_per_commander > 0:
+            commander_rows = commander_rows[: args.cards_per_commander]
+        rows.extend(commander_rows)
+
+    rows.sort(key=lambda item: (item.commander_rank, item.commander, -item.weight, item.card))
+    return rows
+
+
+def keep_best_row(rows_by_card: dict[str, WeightedRow], candidate: WeightedRow) -> None:
+    existing = rows_by_card.get(candidate.card)
+    if existing is None or candidate.weight > existing.weight:
+        rows_by_card[candidate.card] = candidate
+
+
+def write_weighted_tsv(path: Path, rows: list[WeightedRow]) -> None:
+    if path.parent:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        handle.write("# commander\tcard\tweight\n")
+        for row in rows:
+            handle.write(f"{row.commander}\t{row.card}\t{row.weight}\n")
+
+
+def compile_writer(args: argparse.Namespace) -> Path:
+    jar_candidates = sorted((args.forge_dir / "forge-gui-desktop/target").glob("forge-gui-desktop-*-jar-with-dependencies.jar"))
+    if not jar_candidates:
+        raise SystemExit("Cannot find forge-gui-desktop jar-with-dependencies. Build Forge first with Maven.")
+    jar = jar_candidates[-1]
+    classes_dir = (args.build_dir / "classes").resolve()
+    classes_dir.mkdir(parents=True, exist_ok=True)
+    source = Path(__file__).resolve().parent / "java" / "ForgeMatrixWriter.java"
+    if not source.exists():
+        raise SystemExit(f"Cannot find Java writer source: {source}")
+    subprocess.run(["javac", "-cp", str(jar), "-d", str(classes_dir), str(source)], check=True)
+    return jar
+
+
+def write_dat(args: argparse.Namespace) -> None:
+    jar = compile_writer(args)
+    classes_dir = (args.build_dir / "classes").resolve()
+    forge_gui_dir = (args.forge_dir / "forge-gui").resolve()
+    cmd = [
+        "java",
+        "-cp",
+        os.pathsep.join([str(classes_dir), str(jar)]),
+        "ForgeMatrixWriter",
+        str(forge_gui_dir),
+        str(args.weighted_tsv.resolve()),
+        str(args.output.resolve()),
+    ]
+    subprocess.run(cmd, cwd=forge_gui_dir, check=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, default=SCRIPT_DIR / "build" / "edhrec_raw.tsv")
+    parser.add_argument("--weighted-tsv", type=Path, default=SCRIPT_DIR / "build" / "edhrec_weighted.tsv")
+    parser.add_argument("--output", type=Path, default=default_forge_gui_dir() / "res" / "deckgendecks" / "Commander.dat")
+    parser.add_argument("--forge-dir", type=Path, default=default_forge_root())
+    parser.add_argument("--build-dir", type=Path, default=SCRIPT_DIR / "build")
+    parser.add_argument(
+        "--weight-mode",
+        choices=("count", "inclusion", "log", "sqrt"),
+        default="log",
+        help="count preserves raw EDHREC counts; the other modes reduce age bias with denominator-aware scores.",
+    )
+    parser.add_argument("--scale", type=float, default=1000.0)
+    parser.add_argument("--min-weight", type=int, default=1)
+    parser.add_argument("--min-included-decks", type=int, default=1)
+    parser.add_argument("--cards-per-commander", type=int, default=500, help="Use 0 for no per-commander cap.")
+    parser.add_argument(
+        "--no-expand-pairs",
+        dest="expand_pairs",
+        action="store_false",
+        help="Keep EDHREC pair commanders as literal 'A // B' keys instead of expanding them to Forge's individual commander keys.",
+    )
+    parser.add_argument("--skip-dat", action="store_true", help="Only write the weighted TSV.")
+    parser.set_defaults(expand_pairs=True)
+    args = parser.parse_args()
+    args.input = args.input.resolve()
+    args.weighted_tsv = args.weighted_tsv.resolve()
+    args.output = args.output.resolve()
+    args.forge_dir = args.forge_dir.resolve()
+    args.build_dir = args.build_dir.resolve()
+    return args
+
+
+def default_forge_gui_dir() -> Path:
+    candidate = SCRIPT_DIR.parent
+    if candidate.name == "forge-gui":
+        return candidate
+    return Path.cwd()
+
+
+def default_forge_root() -> Path:
+    forge_gui_dir = default_forge_gui_dir()
+    if forge_gui_dir.name == "forge-gui":
+        return forge_gui_dir.parent
+    return Path.cwd()
+
+
+def main() -> None:
+    args = parse_args()
+    rows = read_weighted_rows(args)
+    write_weighted_tsv(args.weighted_tsv, rows)
+    print(f"Wrote weighted TSV: {args.weighted_tsv} ({len(rows)} rows)")
+    if not args.skip_dat:
+        write_dat(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/forge-gui/tools/edhrec_to_forge.py
+++ b/forge-gui/tools/edhrec_to_forge.py
@@ -1,0 +1,625 @@
+#!/usr/bin/env python3
+"""Pass 1: scrape raw EDHREC commander/card data into a TSV."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import html
+import json
+import re
+import random
+import sys
+import time
+import unicodedata
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Iterable
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+BASE_URL = "https://edhrec.com"
+SECTION_HEADINGS = {
+    "New Cards",
+    "High Synergy Cards",
+    "Top Cards",
+    "Game Changers",
+    "Creatures",
+    "Instants",
+    "Sorceries",
+    "Utility Artifacts",
+    "Artifacts",
+    "Enchantments",
+    "Battles",
+    "Planeswalkers",
+    "Utility Lands",
+    "Mana Artifacts",
+    "Lands",
+    "Back to Top",
+}
+LAST_REQUEST_AT = 0.0
+SCRIPT_DIR = Path(__file__).resolve().parent
+RETRY_STATUS_CODES = {429, 500, 502, 503, 504}
+TSV_FIELDS = (
+    "commander_rank",
+    "commander",
+    "commander_slug",
+    "commander_decks",
+    "card",
+    "section",
+    "included_decks",
+    "eligible_decks",
+    "inclusion_percent",
+    "synergy_percent",
+)
+
+
+@dataclass(frozen=True)
+class Commander:
+    rank: int
+    name: str
+    slug: str
+    decks: int | None = None
+
+
+@dataclass(frozen=True)
+class RawCardData:
+    commander_rank: int
+    commander: str
+    commander_slug: str
+    commander_decks: int | None
+    card: str
+    section: str | None
+    included_decks: int
+    eligible_decks: int | None
+    inclusion: float | None
+    synergy: int | None
+
+
+class TextExtractor(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.parts: list[str] = []
+
+    def handle_data(self, data: str) -> None:
+        text = " ".join(html.unescape(data).split())
+        if text:
+            self.parts.append(text)
+
+    def lines(self) -> list[str]:
+        return self.parts
+
+
+def wait_for_rate_limit(min_interval: float, jitter: float) -> None:
+    global LAST_REQUEST_AT
+    elapsed = time.monotonic() - LAST_REQUEST_AT
+    target = min_interval + random.uniform(0, jitter)
+    if elapsed < target:
+        time.sleep(target - elapsed)
+
+
+def fetch(url: str, cache_path: Path, refresh: bool, timeout: int, min_interval: float, jitter: float, retries: int) -> str:
+    global LAST_REQUEST_AT
+    if cache_path.exists() and not refresh:
+        return cache_path.read_text(encoding="utf-8")
+
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    request = Request(
+        url,
+        headers={
+            "User-Agent": "CommanderData/0.1 (+local Forge deckgen data build)",
+            "Accept": "text/html,application/xhtml+xml,application/json;q=0.9,*/*;q=0.8",
+        },
+    )
+    for attempt in range(retries + 1):
+        wait_for_rate_limit(min_interval, jitter)
+        try:
+            with urlopen(request, timeout=timeout) as response:
+                LAST_REQUEST_AT = time.monotonic()
+                body = response.read().decode(response.headers.get_content_charset() or "utf-8", errors="replace")
+            cache_path.write_text(body, encoding="utf-8")
+            return body
+        except HTTPError as exc:
+            LAST_REQUEST_AT = time.monotonic()
+            retry_after = exc.headers.get("Retry-After")
+            if exc.code in RETRY_STATUS_CODES and attempt < retries:
+                sleep_for = parse_retry_after(retry_after) or min(120.0, min_interval * (2 ** (attempt + 1)))
+                print(f"warning: {exc.code} for {url}; sleeping {sleep_for:.1f}s before retry", file=sys.stderr)
+                time.sleep(sleep_for)
+                continue
+            raise
+        except (URLError, TimeoutError):
+            LAST_REQUEST_AT = time.monotonic()
+            if attempt < retries:
+                sleep_for = min(120.0, min_interval * (2 ** (attempt + 1)))
+                print(f"warning: network error for {url}; sleeping {sleep_for:.1f}s before retry", file=sys.stderr)
+                time.sleep(sleep_for)
+                continue
+            raise
+    raise RuntimeError(f"unreachable fetch retry state for {url}")
+
+
+def parse_retry_after(value: str | None) -> float | None:
+    if not value:
+        return None
+    try:
+        return max(0.0, float(value))
+    except ValueError:
+        return None
+
+
+def parse_json_text(text: str) -> dict | None:
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
+def extract_next_data(page: str) -> dict | None:
+    match = re.search(r'<script id="__NEXT_DATA__" type="application/json">(.*?)</script>', page, re.DOTALL)
+    if not match:
+        return None
+    return parse_json_text(html.unescape(match.group(1)))
+
+
+def iter_cardlists(value: object) -> Iterable[dict]:
+    if isinstance(value, dict):
+        cardlists = value.get("cardlists")
+        if isinstance(cardlists, list):
+            for cardlist in cardlists:
+                if isinstance(cardlist, dict):
+                    yield cardlist
+        for child in value.values():
+            yield from iter_cardlists(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from iter_cardlists(child)
+
+
+def commanders_from_cardviews(cardviews: object) -> list[Commander]:
+    commanders: list[Commander] = []
+    if not isinstance(cardviews, list):
+        return commanders
+    for card in cardviews:
+        if not isinstance(card, dict):
+            continue
+        name = card.get("name")
+        rank = card.get("rank")
+        if not name or rank is None:
+            continue
+        slug = card.get("sanitized") or str(card.get("url", "")).removeprefix("/commanders/")
+        if not slug:
+            slug = slugify(name)
+        commanders.append(
+            Commander(
+                rank=int(rank),
+                name=name,
+                slug=slug,
+                decks=card.get("num_decks") or card.get("inclusion"),
+            )
+        )
+    return commanders
+
+
+def parse_commanders_from_json_payload(payload: dict, limit: int) -> tuple[list[Commander], str | None]:
+    commanders: list[Commander] = []
+    more = payload.get("more") if isinstance(payload.get("more"), str) else None
+
+    commanders.extend(commanders_from_cardviews(payload.get("cardviews")))
+
+    for cardlist in iter_cardlists(payload):
+        parsed = commanders_from_cardviews(cardlist.get("cardviews"))
+        if parsed:
+            commanders.extend(parsed)
+            if more is None and isinstance(cardlist.get("more"), str):
+                more = cardlist["more"]
+
+    deduped = {commander.rank: commander for commander in commanders}
+    result = [deduped[rank] for rank in sorted(deduped)[:limit]]
+    return result, more
+
+
+def visible_lines(page: str) -> list[str]:
+    parser = TextExtractor()
+    parser.feed(page)
+    return parser.lines()
+
+
+def slugify(name: str) -> str:
+    text = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode("ascii")
+    text = text.replace("//", " ")
+    text = text.replace("&", " and ")
+    text = re.sub(r"[^A-Za-z0-9]+", "-", text.lower())
+    return text.strip("-")
+
+
+def parse_deck_count(value: str) -> int:
+    value = value.replace(",", "").strip()
+    match = re.fullmatch(r"(\d+(?:\.\d+)?)([KkMm]?)", value)
+    if not match:
+        raise ValueError(value)
+    number = float(match.group(1))
+    suffix = match.group(2).lower()
+    if suffix == "k":
+        number *= 1_000
+    elif suffix == "m":
+        number *= 1_000_000
+    return int(round(number))
+
+
+def parse_commanders_from_html(page: str, limit: int) -> list[Commander]:
+    next_data = extract_next_data(page)
+    if next_data is not None:
+        commanders, _more = parse_commanders_from_json_payload(next_data, limit)
+        if commanders:
+            return commanders
+
+    lines = visible_lines(page)
+    commanders: list[Commander] = []
+    seen: set[int] = set()
+
+    for i, line in enumerate(lines):
+        match = re.fullmatch(r"Rank #(\d+)", line)
+        if not match:
+            continue
+        rank = int(match.group(1))
+        if rank in seen:
+            continue
+        name = previous_content_line(lines, i)
+        if not name or name in SECTION_HEADINGS:
+            continue
+        decks = None
+        if i + 1 < len(lines):
+            deck_match = re.fullmatch(r"([\d,.]+[KkMm]?) decks", lines[i + 1])
+            if deck_match:
+                decks = parse_deck_count(deck_match.group(1))
+        commanders.append(Commander(rank=rank, name=name, slug=slugify(name), decks=decks))
+        seen.add(rank)
+        if len(commanders) >= limit:
+            break
+
+    commanders.sort(key=lambda item: item.rank)
+    return commanders
+
+
+def previous_content_line(lines: list[str], index: int) -> str | None:
+    for j in range(index - 1, -1, -1):
+        candidate = lines[j].strip()
+        if candidate and not candidate.endswith("decks"):
+            return candidate
+    return None
+
+
+def commander_page_urls(page_number: int) -> Iterable[str]:
+    if page_number == 1:
+        yield f"{BASE_URL}/commanders"
+    else:
+        yield f"{BASE_URL}/commanders?page={page_number}"
+        yield f"{BASE_URL}/commanders/{page_number}"
+        yield f"{BASE_URL}/commanders?p={page_number}"
+
+
+def more_json_urls(path: str) -> Iterable[str]:
+    normalized = path.lstrip("/")
+    yield f"https://json-cloudflare.edhrec.com/pages/{normalized}"
+    yield f"https://json.edhrec.com/pages/{normalized}"
+    yield f"{BASE_URL}/{normalized}"
+
+
+def scrape_commanders(args: argparse.Namespace) -> list[Commander]:
+    by_rank: dict[int, Commander] = {}
+    more: str | None = None
+
+    cache_path = args.cache_dir / "commanders" / "commanders.html"
+    page = fetch(f"{BASE_URL}/commanders", cache_path, args.refresh, args.timeout, args.min_interval, args.jitter, args.retries)
+    next_data = extract_next_data(page)
+    if next_data is not None:
+        parsed, more = parse_commanders_from_json_payload(next_data, args.limit_commanders)
+    else:
+        parsed = parse_commanders_from_html(page, args.limit_commanders)
+    for commander in parsed:
+        by_rank.setdefault(commander.rank, commander)
+
+    if args.verbose:
+        print(f"commander page 1: +{len(parsed)}, total {len(by_rank)}", file=sys.stderr)
+
+    page_number = 2
+    while more and len(by_rank) < args.limit_commanders and page_number <= args.max_commander_pages:
+        page_added = 0
+        payload = None
+        for url in more_json_urls(more):
+            cache_name = re.sub(r"[^A-Za-z0-9]+", "_", more).strip("_")
+            cache_path = args.cache_dir / "commanders" / f"{cache_name}.json"
+            try:
+                text = fetch(url, cache_path, args.refresh, args.timeout, args.min_interval, args.jitter, args.retries)
+            except (HTTPError, URLError, TimeoutError) as exc:
+                if args.verbose:
+                    print(f"warning: cannot fetch {url}: {exc}", file=sys.stderr)
+                continue
+            payload = parse_json_text(text)
+            if payload is not None:
+                break
+
+        if payload is None:
+            break
+
+        parsed, more = parse_commanders_from_json_payload(payload, args.limit_commanders)
+        for commander in parsed:
+            if commander.rank not in by_rank:
+                by_rank[commander.rank] = commander
+                page_added += 1
+
+        if args.verbose:
+            print(f"commander page {page_number}: +{page_added}, total {len(by_rank)}", file=sys.stderr)
+        if page_added == 0:
+            break
+        page_number += 1
+
+    return [by_rank[rank] for rank in sorted(by_rank)[: args.limit_commanders]]
+
+
+def read_existing_rows(path: Path) -> list[RawCardData]:
+    if not path.exists():
+        return []
+
+    rows: list[RawCardData] = []
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        for row in reader:
+            if not row:
+                continue
+            rows.append(
+                RawCardData(
+                    commander_rank=int(row["commander_rank"]),
+                    commander=row["commander"],
+                    commander_slug=row["commander_slug"],
+                    commander_decks=parse_optional_int(row.get("commander_decks")),
+                    card=row["card"],
+                    section=row.get("section") or None,
+                    included_decks=int(row["included_decks"]),
+                    eligible_decks=parse_optional_int(row.get("eligible_decks")),
+                    inclusion=parse_optional_float(row.get("inclusion_percent")),
+                    synergy=parse_optional_int(row.get("synergy_percent")),
+                )
+            )
+    return rows
+
+
+def parse_optional_int(value: str | None) -> int | None:
+    if value is None or value == "":
+        return None
+    return int(float(value))
+
+
+def parse_optional_float(value: str | None) -> float | None:
+    if value is None or value == "":
+        return None
+    return float(value)
+
+
+def parse_card_data(commander: Commander, page: str, per_commander_limit: int) -> list[RawCardData]:
+    if per_commander_limit <= 0:
+        return []
+
+    next_data = extract_next_data(page)
+    if next_data is not None:
+        rows = parse_card_data_from_json_payload(commander, next_data, per_commander_limit)
+        if rows:
+            return rows
+
+    lines = visible_lines(page)
+    rows: list[RawCardData] = []
+    seen_cards: set[str] = set()
+    inclusion_re = re.compile(r"(\d+(?:\.\d+)?)%inclusion\s+([\d,.]+[KkMm]?) decks(?:\s+([\d,.]+[KkMm]?) decks)?")
+    synergy_re = re.compile(r"(-?\d+)%\s*synergy")
+    current_section: str | None = None
+
+    for i, line in enumerate(lines):
+        if line in SECTION_HEADINGS:
+            current_section = line
+            continue
+        match = inclusion_re.fullmatch(line)
+        if not match:
+            continue
+        card = previous_content_line(lines, i)
+        if not card or card in SECTION_HEADINGS or card == commander.name or card in seen_cards:
+            continue
+        try:
+            included_decks = parse_deck_count(match.group(2))
+            eligible_decks = parse_deck_count(match.group(3)) if match.group(3) else None
+        except ValueError:
+            continue
+        synergy = None
+        for lookahead in lines[i + 1 : i + 4]:
+            synergy_match = synergy_re.fullmatch(lookahead)
+            if synergy_match:
+                synergy = int(synergy_match.group(1))
+                break
+        rows.append(
+            RawCardData(
+                commander_rank=commander.rank,
+                commander=commander.name,
+                commander_slug=commander.slug,
+                commander_decks=commander.decks,
+                card=card,
+                section=current_section,
+                included_decks=included_decks,
+                eligible_decks=eligible_decks,
+                inclusion=float(match.group(1)),
+                synergy=synergy,
+            )
+        )
+        seen_cards.add(card)
+        if len(rows) >= per_commander_limit:
+            break
+
+    return rows
+
+
+def parse_card_data_from_json_payload(commander: Commander, payload: dict, per_commander_limit: int) -> list[RawCardData]:
+    rows: list[RawCardData] = []
+    seen_cards: set[str] = set()
+
+    for cardlist in iter_cardlists(payload):
+        section = cardlist.get("header") if isinstance(cardlist.get("header"), str) else None
+        for card in cardlist.get("cardviews", []):
+            if not isinstance(card, dict):
+                continue
+            name = card.get("name")
+            if not name or name == commander.name or name in seen_cards:
+                continue
+
+            included = card.get("num_decks") or card.get("inclusion")
+            eligible = card.get("potential_decks")
+            if included is None:
+                continue
+
+            included_decks = int(included)
+            eligible_decks = int(eligible) if eligible is not None else None
+            inclusion_percent = None
+            if eligible_decks:
+                inclusion_percent = round((included_decks / eligible_decks) * 100.0, 4)
+
+            synergy = card.get("synergy")
+            synergy_percent = round(float(synergy) * 100) if synergy is not None else None
+
+            rows.append(
+                RawCardData(
+                    commander_rank=commander.rank,
+                    commander=commander.name,
+                    commander_slug=commander.slug,
+                    commander_decks=commander.decks,
+                    card=name,
+                    section=section,
+                    included_decks=included_decks,
+                    eligible_decks=eligible_decks,
+                    inclusion=inclusion_percent,
+                    synergy=synergy_percent,
+                )
+            )
+            seen_cards.add(name)
+            if len(rows) >= per_commander_limit:
+                return rows
+
+    return rows
+
+
+def scrape_card_data(
+    args: argparse.Namespace,
+    commanders: list[Commander],
+    existing_rows: list[RawCardData] | None = None,
+) -> list[RawCardData]:
+    all_rows: list[RawCardData] = list(existing_rows or [])
+    seen_pairs = {(row.commander_slug, row.card) for row in all_rows}
+    existing_counts: dict[str, int] = {}
+    for row in all_rows:
+        existing_counts[row.commander_slug] = existing_counts.get(row.commander_slug, 0) + 1
+
+    to_scrape_slugs = {
+        commander.slug
+        for commander in commanders
+        if (
+            existing_counts.get(commander.slug, 0) < args.cards_per_commander
+            if args.fill_incomplete
+            else existing_counts.get(commander.slug, 0) == 0
+        )
+    }
+    if args.verbose and existing_rows:
+        skipped = len(commanders) - len(to_scrape_slugs)
+        print(f"resume: loaded {len(existing_rows)} existing rows; skipping {skipped} existing commanders", file=sys.stderr)
+
+    for index, commander in enumerate(commanders, start=1):
+        if commander.slug not in to_scrape_slugs:
+            if args.verbose:
+                print(f"{index}/{len(commanders)} {commander.name}: already have {existing_counts.get(commander.slug, 0)} cards", file=sys.stderr)
+            continue
+        url = f"{BASE_URL}/commanders/{commander.slug}"
+        cache_path = args.cache_dir / "cards" / f"{commander.slug}.html"
+        try:
+            page = fetch(url, cache_path, args.refresh, args.timeout, args.min_interval, args.jitter, args.retries)
+        except (HTTPError, URLError, TimeoutError) as exc:
+            print(f"warning: cannot fetch {commander.name} at {url}: {exc}", file=sys.stderr)
+            continue
+        rows = parse_card_data(commander, page, args.cards_per_commander)
+        added = 0
+        for row in rows:
+            key = (row.commander_slug, row.card)
+            if key in seen_pairs:
+                continue
+            all_rows.append(row)
+            seen_pairs.add(key)
+            added += 1
+        if args.verbose or index % 25 == 0:
+            print(f"{index}/{len(commanders)} {commander.name}: {len(rows)} cards, +{added} new", file=sys.stderr)
+    return all_rows
+
+
+def write_tsv(path: Path, rows: list[RawCardData]) -> None:
+    if path.parent:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    rows = sorted(rows, key=lambda row: (row.commander_rank, row.commander, row.card))
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=TSV_FIELDS, delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(
+                {
+                    "commander_rank": row.commander_rank,
+                    "commander": row.commander,
+                    "commander_slug": row.commander_slug,
+                    "commander_decks": "" if row.commander_decks is None else row.commander_decks,
+                    "card": row.card,
+                    "section": "" if row.section is None else row.section,
+                    "included_decks": row.included_decks,
+                    "eligible_decks": "" if row.eligible_decks is None else row.eligible_decks,
+                    "inclusion_percent": "" if row.inclusion is None else row.inclusion,
+                    "synergy_percent": "" if row.synergy is None else row.synergy,
+                }
+            )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=SCRIPT_DIR / "build" / "edhrec_raw.tsv")
+    parser.add_argument("--cache-dir", type=Path, default=SCRIPT_DIR / "build" / "cache")
+    parser.add_argument("--limit-commanders", type=int, default=1000)
+    parser.add_argument("--cards-per-commander", type=int, default=500)
+    parser.add_argument("--max-commander-pages", type=int, default=20)
+    parser.add_argument(
+        "--min-interval",
+        type=float,
+        default=2.0,
+        help="Minimum seconds between live EDHREC requests. Cached pages do not wait.",
+    )
+    parser.add_argument("--jitter", type=float, default=0.75, help="Random extra seconds added to live request spacing.")
+    parser.add_argument("--retries", type=int, default=3)
+    parser.add_argument("--timeout", type=int, default=30)
+    parser.add_argument("--refresh", action="store_true")
+    parser.add_argument("--no-resume", action="store_true", help="Ignore an existing output TSV and rebuild it from scratch.")
+    parser.add_argument(
+        "--fill-incomplete",
+        action="store_true",
+        help="When resuming, re-scrape commanders that have fewer than --cards-per-commander rows. By default any existing commander is skipped.",
+    )
+    parser.add_argument("--verbose", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    commanders = scrape_commanders(args)
+    if len(commanders) < args.limit_commanders:
+        print(
+            f"warning: found {len(commanders)} commanders; EDHREC may require a browser API path for ranks beyond the HTML pages",
+            file=sys.stderr,
+        )
+    existing_rows = [] if args.no_resume or args.refresh else read_existing_rows(args.output)
+    rows = scrape_card_data(args, commanders, existing_rows)
+    write_tsv(args.output, rows)
+    print(f"Wrote raw TSV: {args.output} ({len(rows)} rows)", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/forge-gui/tools/java/ForgeMatrixWriter.java
+++ b/forge-gui/tools/java/ForgeMatrixWriter.java
@@ -1,0 +1,202 @@
+import forge.CardStorageReader;
+import forge.StaticData;
+import forge.gui.GuiBase;
+import forge.gui.download.GuiDownloadService;
+import forge.gui.interfaces.IGuiBase;
+import forge.gui.interfaces.IGuiGame;
+import forge.item.PaperCard;
+import forge.localinstance.skin.FSkinProp;
+import forge.localinstance.skin.ISkinImage;
+import forge.model.FModel;
+import forge.sound.IAudioClip;
+import forge.sound.IAudioMusic;
+import forge.util.CardTranslation;
+import forge.util.FSerializableFunction;
+import forge.util.ImageFetcher;
+import forge.util.Lang;
+import forge.util.Localizer;
+
+import forge.gamemodes.match.HostedMatch;
+
+import org.jupnp.UpnpServiceConfiguration;
+
+import java.io.File;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public final class ForgeMatrixWriter {
+    private ForgeMatrixWriter() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 3) {
+            System.err.println("Usage: ForgeMatrixWriter <forge-gui-dir> <input.tsv> <output.dat>");
+            System.exit(2);
+        }
+
+        Path forgeGuiDir = Path.of(args[0]).toAbsolutePath().normalize();
+        Path input = Path.of(args[1]).toAbsolutePath().normalize();
+        Path output = Path.of(args[2]).toAbsolutePath().normalize();
+
+        GuiBase.setInterface(new HeadlessGui(forgeGuiDir));
+        FModel.loadDynamicGamedata();
+        Lang.createInstance("en-US");
+        Localizer.getInstance().initialize("en-US", forgeGuiDir.resolve("res/languages").toString());
+        CardTranslation.preloadTranslation("en-US", forgeGuiDir.resolve("res/languages").toString());
+        Path emptyCustomEditions = Files.createTempDirectory("forge-empty-custom-editions");
+
+        StaticData cards = new StaticData(
+                new CardStorageReader(forgeGuiDir.resolve("res/cardsfolder").toString(), CardStorageReader.ProgressObserver.emptyObserver, false),
+                new CardStorageReader(forgeGuiDir.resolve("res/tokenscripts").toString(), CardStorageReader.ProgressObserver.emptyObserver, false),
+                null,
+                null,
+                forgeGuiDir.resolve("res/editions").toString(),
+                emptyCustomEditions.toString(),
+                forgeGuiDir.resolve("res/blockdata").toString(),
+                forgeGuiDir.resolve("res/setlookup").toString(),
+                "",
+                true,
+                false,
+                false,
+                false);
+
+        HashMap<String, List<Map.Entry<PaperCard, Integer>>> matrix = new HashMap<>();
+        int rows = 0;
+        int skippedCards = 0;
+        int skippedCommanders = 0;
+        Map<String, Integer> unknownCommanders = new LinkedHashMap<>();
+        Map<String, Integer> unknownCards = new LinkedHashMap<>();
+
+        try (BufferedReader reader = Files.newBufferedReader(input, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                line = line.trim();
+                if (line.isEmpty() || line.startsWith("#")) {
+                    continue;
+                }
+
+                String[] parts = line.split("\t");
+                if (parts.length < 3) {
+                    System.err.println("Skipping malformed line: " + line);
+                    continue;
+                }
+
+                String commanderName = parts[0].trim();
+                String cardName = parts[1].trim();
+                int weight = Integer.parseInt(parts[2].trim());
+                if (weight <= 0) {
+                    continue;
+                }
+
+                PaperCard commander = cards.getCommonCards().getUniqueByName(commanderName);
+                if (commander == null) {
+                    skippedCommanders++;
+                    unknownCommanders.merge(commanderName, 1, Integer::sum);
+                    continue;
+                }
+
+                PaperCard card = cards.getCommonCards().getUniqueByName(cardName);
+                if (card == null) {
+                    skippedCards++;
+                    unknownCards.merge(cardName, 1, Integer::sum);
+                    continue;
+                }
+
+                matrix.computeIfAbsent(commander.getName(), key -> new ArrayList<>())
+                        .add(new AbstractMap.SimpleEntry<>(card, weight));
+                rows++;
+            }
+        }
+
+        if (output.getParent() != null) {
+            Files.createDirectories(output.getParent());
+        }
+        try (ObjectOutputStream objectOutput = new ObjectOutputStream(Files.newOutputStream(output))) {
+            objectOutput.writeObject(matrix);
+        }
+
+        System.out.printf(
+                "Wrote %d commanders, %d card weights, skipped %d unknown commanders and %d unknown cards%n",
+                matrix.size(), rows, skippedCommanders, skippedCards);
+        printUnknowns("Unknown commanders", unknownCommanders);
+        printUnknowns("Unknown cards", unknownCards);
+    }
+
+    private static void printUnknowns(String label, Map<String, Integer> unknowns) {
+        if (unknowns.isEmpty()) {
+            return;
+        }
+        System.out.printf("%s (%d unique):%n", label, unknowns.size());
+        unknowns.entrySet().stream()
+                .sorted(Map.Entry.<String, Integer>comparingByValue().reversed().thenComparing(Map.Entry.comparingByKey()))
+                .limit(100)
+                .forEach(entry -> System.out.printf("  %s\t%d%n", entry.getKey(), entry.getValue()));
+    }
+
+    private static final class HeadlessGui implements IGuiBase {
+        private final String assetsDir;
+
+        private HeadlessGui(Path forgeGuiDir) {
+            this.assetsDir = forgeGuiDir.toString() + File.separator;
+        }
+
+        @Override public boolean isRunningOnDesktop() { return true; }
+        @Override public boolean isLibgdxPort() { return false; }
+        @Override public String getCurrentVersion() { return "headless"; }
+        @Override public void invokeInEdtNow(Runnable runnable) { runnable.run(); }
+        @Override public void invokeInEdtLater(Runnable runnable) { runnable.run(); }
+        @Override public void invokeInEdtAndWait(Runnable proc) { proc.run(); }
+        @Override public void runBackgroundTask(String message, Runnable task) { task.run(); }
+        @Override public boolean isGuiThread() { return true; }
+        @Override public String getAssetsDir() { return assetsDir; }
+        @Override public ImageFetcher getImageFetcher() { return null; }
+        @Override public ISkinImage getSkinIcon(FSkinProp skinProp) { return null; }
+        @Override public ISkinImage getUnskinnedIcon(String path) { return null; }
+        @Override public ISkinImage getCardArt(PaperCard card, boolean backFace) { return null; }
+        @Override public ISkinImage createLayeredImage(PaperCard card, FSkinProp background, String overlayFilename, float opacity) { return null; }
+        @Override public void clearImageCache() { }
+        @Override public void refreshSkin() { }
+        @Override public String encodeSymbols(String str, boolean formatReminderText) { return str; }
+        @Override public int getAvatarCount() { return 0; }
+        @Override public int getSleevesCount() { return 0; }
+        @Override public float getScreenScale() { return 1.0f; }
+        @Override public void preventSystemSleep(boolean preventSleep) { }
+        @Override public void download(GuiDownloadService service, Consumer<Boolean> callback) { callback.accept(false); }
+        @Override public void copyToClipboard(String text) { }
+        @Override public void browseToUrl(String url) throws IOException, URISyntaxException { }
+        @Override public void showCardList(String title, String message, List<PaperCard> list) { }
+        @Override public boolean showBoxedProduct(String title, String message, List<PaperCard> list) { return false; }
+        @Override public void showBugReportDialog(String title, String text, boolean showExitAppBtn) { }
+        @Override public void showImageDialog(ISkinImage image, String message, String title) { }
+        @Override public int showOptionDialog(String message, String title, FSkinProp icon, List<String> options, int defaultOption) { return defaultOption; }
+        @Override public String showInputDialog(String message, String title, FSkinProp icon, String initialInput, List<String> inputOptions, boolean isNumeric) { return initialInput; }
+        @Override public String showFileDialog(String title, String defaultDir) { return defaultDir; }
+        @Override public File getSaveFile(File defaultFile) { return defaultFile; }
+        @Override public <T> List<T> order(String title, String top, int remainingObjectsMin, int remainingObjectsMax, List<T> sourceChoices, List<T> destChoices) { return destChoices; }
+        @Override public <T> List<T> getChoices(String message, int min, int max, Collection<T> choices, Collection<T> selected, FSerializableFunction<T, String> display) { return new ArrayList<>(selected); }
+        @Override public PaperCard chooseCard(String title, String message, List<PaperCard> list) { return list.isEmpty() ? null : list.get(0); }
+        @Override public boolean isSupportedAudioFormat(File file) { return false; }
+        @Override public IAudioClip createAudioClip(String filename) { return null; }
+        @Override public IAudioMusic createAudioMusic(String filename) { return null; }
+        @Override public void startAltSoundSystem(String filename, boolean isSynchronized) { }
+        @Override public void showSpellShop() { }
+        @Override public void showBazaar() { }
+        @Override public IGuiGame getNewGuiGame() { return null; }
+        @Override public HostedMatch hostMatch() { return null; }
+        @Override public UpnpServiceConfiguration getUpnpPlatformService() { return null; }
+        @Override public boolean hasNetGame() { return false; }
+    }
+}


### PR DESCRIPTION
## Summary

Replaces `forge-gui/res/deckgendecks/Commander.dat` with a newly generated Commander deckgen matrix based on EDHREC commander data. There are about 1000 commanders, compared to about 200 in the previous data set.

The source data was scraped from EDHREC’s Top Commanders, Past 2 Years dataset. The scrape collected raw commander/card association data first, then transformed it into Forge’s existing serialized matrix format.

For best results, combine with #10774.

Included are the Python+Java files I used to scrape EDHREC, and a README for using them.

Thanks to Codex for help with code and testing.