### PR TITLE
Fix libgdx network client GL-thread deadlock on blocking dialogs

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/net/client/GameClientHandler.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/client/GameClientHandler.java
@@ -58,10 +58,12 @@ final class GameClientHandler extends GameProtocolHandler<IGuiGame> implements I
 
     @Override
     protected boolean shouldDispatchToGuiThread(final ProtocolMethod protocolMethod) {
-        // Libgdx blocking prompts deadlock if run on the GL thread — route return-value
-        // protocol methods to a background thread.
+        // Libgdx modal prompts block via WaitCallback and deadlock on the GL thread. Return-value
+        // methods always block; message/showErrorDialog return void but still open a blocking modal.
         if (GuiBase.getInterface().isLibgdxPort()
-                && !protocolMethod.getReturnType().equals(Void.TYPE)) {
+                && (!protocolMethod.getReturnType().equals(Void.TYPE)
+                    || protocolMethod == ProtocolMethod.message
+                    || protocolMethod == ProtocolMethod.showErrorDialog)) {
             return false;
         }
         return super.shouldDispatchToGuiThread(protocolMethod);


### PR DESCRIPTION
## Summary

A player on the Android (libgdx) build reported that a network game froze while the UI stayed responsive — they could still tap, but the game made no progress — and eventually they had to back out. No crash or error appeared in the logs for that build, unlike the previous build, which had logged exceptions.

The host-side network log shows the game thread blocking on a second declare-attackers input mid-combat: the engine re-prompted after rejecting the first declaration as illegal, and from that point the client sent nothing for ~37 seconds until it disconnected, with no exceptions logged. The logs are host-side only, so they show the stall but not what the client's UI was doing.

## Diagnosis (hypothesis)

Reading the code path that fits this evidence, the freeze is a deadlock of the client's GL/render thread. Server→client protocol methods that return `void` are dispatched to the GL thread, where `message` and `showErrorDialog` open a blocking modal via `WaitCallback.invokeAndWait()` — which posts the dialog to the GL thread and then waits *on* the GL thread, so the dialog can never render or be dismissed and the thread is stuck.

The libgdx guard in `GameClientHandler.shouldDispatchToGuiThread` (added in #10461) already routes the *return-value* dialog methods — `showOptionDialog`, `confirm`, `order`, `getChoices`, etc. — off the GL thread. Those are prompts the host invokes and waits on for the player's answer, so the guard uses a non-void return type as its signal for "this blocks the client." `message` and `showErrorDialog` break that assumption: the host fires them and forgets (they return void, no reply awaited), but the *client* still pops a modal that blocks until the user dismisses it. They block exactly like the return-value prompts, yet because they return void the existing heuristic leaves them on the GL thread — where the block becomes a deadlock. They are reached from routine gameplay — the "Attack declaration invalid" notice (`notifyOfValue`), `InputBlock`'s illegal-block errors, and `HumanCostDecision`'s invalid-cost message — which matches the reported declare-attackers stall.

## Fix

On libgdx, `GameClientHandler.shouldDispatchToGuiThread` now also routes `message` and `showErrorDialog` to a background thread. They block on the client just like the return-value prompts #10461 already backgrounds; the only reason the existing guard misses them is that they return void to the host. Because every caller funnels through these two protocol methods, this one change covers the attack, block, and cost-payment paths together.

## Why it's safe

- Backgrounding these void methods doesn't change reply handling: the host sends them fire-and-forget, and the void dispatch path sends no reply. The blocking wait simply moves to a background thread — the same model #10461 already uses for every return-value dialog — so the GL thread is free to render the dialog and process its dismissal.
- The two handlers only show a dialog; they touch no shared game-view state, so running concurrently with EDT view updates is safe (again matching the existing backgrounded dialogs).
- Desktop is unaffected: its dialogs use Swing's pumping modal (no `WaitCallback`), and the change is gated on `isLibgdxPort()`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)