### PR TITLE
UNK: 15 cards, 4 tokens

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/17_year_cicadas.txt
+++ b/forge-gui/res/cardsfolder/upcoming/17_year_cicadas.txt
@@ -1,0 +1,9 @@
+Name:17-Year Cicadas
+ManaCost:7 W
+Types:Sorcery
+K:Suspend:17:0
+A:SP$ Token | TokenScript$ w_1_1_insect_flying | TokenAmount$ 10 | TokenOwner$ You | SubAbility$ DBChange | SpellDescription$ Create ten 1/1 white Insect creature tokens with flying. Exile CARDNAME with seventeen time counters on it.
+SVar:DBChange:DB$ ChangeZone | Origin$ Stack | Destination$ Exile | WithCountersType$ TIME | WithCountersAmount$ 17 | StackDescription$ None
+T:Mode$ SpellCast | ValidCard$ Card | ValidActivatingPlayer$ You | Execute$ TrigRemoveCounter | TriggerZones$ Exile | IsPresent$ Card.Self+suspended | PresentZone$ Exile | TriggerDescription$ Whenever you cast a spell, if this card is suspended, remove a time counter from it.
+SVar:TrigRemoveCounter:DB$ RemoveCounter | Defined$ Self | CounterType$ TIME | CounterNum$ 1
+Oracle:Create ten 1/1 white Insect creature tokens with flying. Exile 17-Year Cicadas with seventeen time counters on it.\nSuspend 17 — {0} (Rather than cast this card from your hand, you may pay {0} and exile it with seventeen time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost.)\nWhenever you cast a spell, if this card is suspended, remove a time counter from it.

--- a/forge-gui/res/cardsfolder/upcoming/another_night_in_vegas.txt
+++ b/forge-gui/res/cardsfolder/upcoming/another_night_in_vegas.txt
@@ -1,0 +1,13 @@
+Name:Another Night in Vegas
+ManaCost:2 B B
+Types:Enchantment
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ TrigCharm | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your upkeep, ABILITY
+SVar:TrigCharm:DB$ Charm | Choices$ WakeUp,VIPLineAccess,LifeOfParty,BreakfastAtDawn | ChoiceRestriction$ ThisGame
+SVar:WakeUp:DB$ ChangeZone | ValidTgts$ Creature | TgtPrompt$ Select target creature in a graveyard to return | Origin$ Graveyard | Destination$ Hand | SpellDescription$ Wake Up! — Return target creature card from a graveyard to its owner's hand.
+SVar:VIPLineAccess:DB$ ChangeZone | Origin$ Library | Destination$ Library | LibraryPosition$ 0 | ChangeType$ Card | ChangeNum$ 1 | Mandatory$ True | SpellDescription$ VIP Line Access — Search your library for a card, then shuffle and put that card on top.
+SVar:LifeOfParty:DB$ Effect | Triggers$ TrigCast | SpellDescription$ Life of the Party — Whenever a spell is cast this turn, you gain 2 life.
+SVar:TrigCast:Mode$ SpellCast | ValidCard$ Card | Execute$ TrigGainLife | TriggerDescription$ Whenever a spell is cast this turn, you gain 2 life.
+SVar:TrigGainLife:DB$ GainLife | LifeAmount$ 2
+SVar:BreakfastAtDawn:DB$ Token | TokenAmount$ 2 | TokenScript$ c_a_food_sac | TokenOwner$ You | SubAbility$ DBSac | SpellDescription$ Breakfast at Dawn — Create two Food tokens. Sacrifice this enchantment.
+SVar:DBSac:DB$ Sacrifice | SacValid$ Self
+Oracle:At the beginning of your upkeep, choose one that hasn't been chosen —\n• Wake Up! — Return target creature card from a graveyard to its owner's hand.\n• VIP Line Access — Search your library for a card, then shuffle and put that card on top.\n• Life of the Party — Whenever a spell is cast this turn, you gain 2 life.\n• Breakfast at Dawn — Create two Food tokens. Sacrifice this enchantment.

--- a/forge-gui/res/cardsfolder/upcoming/auntie_ant_ant_auntie.txt
+++ b/forge-gui/res/cardsfolder/upcoming/auntie_ant_ant_auntie.txt
@@ -1,0 +1,12 @@
+Name:Auntie Ant, Ant Auntie
+ManaCost:3 R R
+Types:Legendary Creature Goblin Warlock
+PT:7/7
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigPutCounter | TriggerDescription$ When NICKNAME enters, multiblight 4. (Distribute four -1/-1 counters among creatures you control.)
+SVar:TrigPutCounter:DB$ PutCounter | Choices$ Creature.YouCtrl | ChoiceTitle$ Choose any number of creatures you control to distribute counters to | CounterType$ M1M1 | CounterNum$ 4 | ChoiceAmount$ 4 | DividedAsYouChoose$ 4
+T:Mode$ Attacks | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigRemoveCounter | TriggerDescription$ Whenever NICKNAME attacks, for each creature you control, you may remove a counter from it. Create a 1/1 green Insect creature token for each counter removed this way.
+SVar:TrigRemoveCounter:DB$ RemoveCounter | Choices$ Creature.YouCtrl | CounterType$ Any | CounterNum$ 1 | ChoiceOptional$ True | SubAbility$ DBToken | RememberAmount$ True
+SVar:DBToken:DB$ Token | TokenScript$ g_1_1_insect | TokenAmount$ X | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:X:Count$RememberedNumber
+Oracle:When Auntie Ant enters, multiblight 4. (Distribute four -1/-1 counters among creatures you control.)\nWhenever Auntie Ant attacks, for each creature you control, you may remove a counter from it. Create a 1/1 green Insect creature token for each counter removed this way.

--- a/forge-gui/res/cardsfolder/upcoming/bin_chicken.txt
+++ b/forge-gui/res/cardsfolder/upcoming/bin_chicken.txt
@@ -1,0 +1,18 @@
+Name:Bin Chicken
+ManaCost:3 B B
+Types:Creature Bird Pest
+PT:3/2
+S:Mode$ Continuous | Affected$ Food.YouCtrl+token | AffectedZone$ Battlefield | AddType$ Junk | AddAbility$ JunkSac | Description$ Food tokens you control are Junk in addition to their other types and have "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery."
+SVar:JunkSac:AB$ Dig | Cost$ T Sac<1/CARDNAME/this token> | SorcerySpeed$ True | Defined$ You | DigNum$ 1 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBEffect | SpellDescription$ Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.
+SVar:DBEffect:DB$ Effect | StaticAbilities$ STPlay | RememberObjects$ Remembered | ForgetOnMoved$ Exile | SubAbility$ DBCleanup
+SVar:STPlay:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsRemembered | AffectedZone$ Exile | Description$ You may play this card this turn.
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+S:Mode$ Continuous | Affected$ Junk.YouCtrl+token | AffectedZone$ Battlefield | AddType$ Food | AddAbility$ FoodSac | Description$ Junk tokens you control are Food in addition to their other types and have "{2}, {T}, Sacrifice this token: You gain 3 life."
+SVar:FoodSac:AB$ GainLife | Cost$ 2 T Sac<1/CARDNAME/this token> | Defined$ You | LifeAmount$ 3 | SpellDescription$ You gain 3 life.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigCharm | TriggerDescription$ When this creature enters, ABILITY
+SVar:TrigCharm:DB$ Charm | Choices$ DBFood,DBAmass
+SVar:DBFood:DB$ Token | TokenScript$ c_a_food_sac | TokenOwner$ You | SpellDescription$ Create a Food token.
+SVar:DBAmass:DB$ Amass | Type$ Bird | Num$ X | SpellDescription$ Amass Birds X, where X is the number of Foods you control.
+SVar:X:Count$Valid Food.YouCtrl
+A:AB$ ChangeZone | Cost$ 3 B B ExileFromGrave<1/Artifact> | Origin$ Graveyard | Destination$ Battlefield | ActivationZone$ Graveyard | SpellDescription$ Return this card from your graveyard to the battlefield tapped.
+Oracle:You may treat Food tokens as though they were Junk tokens and vice versa.\nWhen this creature enters, choose one —\n• Create a Food Token.\n• Amass Birds X, where X is the number of Foods you control.\n{3}{B}{B}, Exile an artifact card from your graveyard: Return this card from your graveyard to the battlefield.

--- a/forge-gui/res/cardsfolder/upcoming/colorless_ultimatum.txt
+++ b/forge-gui/res/cardsfolder/upcoming/colorless_ultimatum.txt
@@ -1,0 +1,8 @@
+Name:Colorless Ultimatum
+ManaCost:2 C C C 2
+Types:Sorcery
+A:SP$ RepeatEach | RepeatPlayers$ Opponent | RepeatSubAbility$ DBDigExile | SubAbility$ DBPump | SpellDescription$ Each opponent exiles half the cards in their library, rounded up. Until end of turn, creatures you control gain annihilator 1.
+SVar:DBDigExile:DB$ Dig | DigNum$ X | ChangeNum$ All | Defined$ Player.IsRemembered | DestinationZone$ Exile
+SVar:DBPump:DB$ PumpAll | ValidCards$ Creature.YouCtrl | KW$ Annihilator:1
+SVar:X:Count$ValidLibrary Card.RememberedPlayerCtrl/HalfUp
+Oracle:Each opponent exiles half the cards in their library, rounded up. Until end of turn, creatures you control gain annihilator 1.

--- a/forge-gui/res/cardsfolder/upcoming/crow_scarer.txt
+++ b/forge-gui/res/cardsfolder/upcoming/crow_scarer.txt
@@ -1,0 +1,10 @@
+Name:Crow Scarer
+ManaCost:4
+Types:Creature Scarecrow
+PT:2/4
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When this creature enters, each player creates two 1/1 black Bird creature tokens with flying.
+SVar:TrigToken:DB$ Token | TokenScript$ b_1_1_bird_flying | TokenAmount$ 2 | TokenOwner$ Player
+S:Mode$ Continuous | Affected$ Permanent.Bird | AddType$ Coward | Description$ Birds are Cowards in addition to their other types.
+S:Mode$ CantAttack | ValidCard$ Creature.Coward | Description$ Cowards can't attack or block creatures you control.
+S:Mode$ CantBlockBy | ValidAttacker$ Creature.YouCtrl | ValidBlocker$ Creature.Coward | Secondary$ True | Description$ Cowards can't attack or block creatures you control.
+Oracle:When this creature enters, each player creates two 1/1 black Bird creature tokens with flying.\nBirds are Cowards in addition to their other types.\nCowards can't attack or block creatures you control.

--- a/forge-gui/res/cardsfolder/upcoming/drop_bear.txt
+++ b/forge-gui/res/cardsfolder/upcoming/drop_bear.txt
@@ -1,0 +1,14 @@
+Name:Drop Bear
+ManaCost:3 R G
+Types:Creature Koala Bear Horror
+PT:*/*
+K:Flash
+K:Haste
+S:Mode$ Continuous | Affected$ Card.Self | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ CARDNAME's power and toughness are each equal to the number of Forests you control plus the number of Bears you control.
+SVar:X:Count$Valid Forest.YouCtrl/Plus.Y
+SVar:Y:Count$Valid Bear.YouCtrl
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigFight | TriggerDescription$ When this creature enters, it fights up to one target creature.
+SVar:TrigFight:DB$ Fight | Defined$ TriggeredCardLKICopy | ValidTgts$ Creature | TgtPrompt$ Select up to one target creature | TargetMin$ 0 | TargetMax$ 1
+SVar:BuffedBy:Forest,Bear
+SVar:NoZeroToughnessAI:True
+Oracle:Flash, haste\nDrop Bear has power and toughness each equal to the number of Forests you control plus the number of Bears you control.\nWhen this creature enters, it fights up to one target creature.

--- a/forge-gui/res/cardsfolder/upcoming/evy_fang_keeper.txt
+++ b/forge-gui/res/cardsfolder/upcoming/evy_fang_keeper.txt
@@ -1,0 +1,11 @@
+Name:Evy, Fang Keeper
+ManaCost:1 B G U
+Types:Legendary Creature Human Artist
+PT:3/4
+T:Mode$ SpellCast | ValidCard$ Creature | ValidActivatingPlayer$ You | Execute$ TrigGenericChoice | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a creature spell, you may draw on it. If you drew wings, it enters with a flying counter on it. If you drew boots, it enters with a haste counter on it. If you drew fangs, it enters with a deathtouch counter on it. If you drew something else, it enters with a +1/+1 counter on it.
+SVar:TrigGenericChoice:DB$ GenericChoice | Choices$ Wings,Boots,Fangs,Else | Defined$ You | ShowChoice$ ExceptSelf
+SVar:Wings:DB$ Pump | PumpZone$ Stack | Defined$ TriggeredCard | KW$ etbCounter:Flying:1 | Duration$ Permanent | SpellDescription$ Draw wings? (flying counter)
+SVar:Boots:DB$ Pump | PumpZone$ Stack | Defined$ TriggeredCard | KW$ etbCounter:Haste:1 | Duration$ Permanent | SpellDescription$ Draw boots? (haste counter)
+SVar:Fangs:DB$ Pump | PumpZone$ Stack | Defined$ TriggeredCard | KW$ etbCounter:Deathtouch:1 | Duration$ Permanent | SpellDescription$ Draw fangs? (deathtouch counter)
+SVar:Else:DB$ Pump | PumpZone$ Stack | Defined$ TriggeredCard | KW$ etbCounter:P1P1:1 | Duration$ Permanent | SpellDescription$ Draw something else? (+1/+1 counter)
+Oracle:Whenever you cast a creature spell, you may draw on it. If you drew wings, it enters with a flying counter on it. If you drew boots, it enters with a haste counter on it. If you drew fangs, it enters with a deathtouch counter on it. If you drew something else, it enters with a +1/+1 counter on it. (Previous drawings don't count. For example, if you gave it boots last game, give it more boots. Bigger boots. Boots in unexpected places.)

--- a/forge-gui/res/cardsfolder/upcoming/the_ancient_dingus.txt
+++ b/forge-gui/res/cardsfolder/upcoming/the_ancient_dingus.txt
@@ -1,0 +1,10 @@
+Name:The Ancient Dingus
+ManaCost:2 R G
+Types:Legendary Artifact Creature Elder Construct
+PT:4/4
+R:Event$ CreateToken | ActiveZones$ Battlefield | ValidPlayer$ Player | ValidToken$ Food | ReplaceWith$ DingusDmg | Description$ If a player would create a Food token, instead CARDNAME deals 2 damage to that player and they put a random card from a stack of visible unsleeved cards they own from outside the game into their hand.
+SVar:DingusDmg:DB$ DealDamage | Defined$ ReplacedPlayer | NumDmg$ 2 | SubAbility$ DBChangeZone
+SVar:DBChangeZone:DB$ ChangeZone | AtRandom$ True | Reveal$ True | Origin$ Sideboard | Destination$ Hand | ChangeType$ Card.OwnedBy ReplacedPlayer | ChangeNum$ 1 | Hidden$ True
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME attacks, target player creates a Food token.
+SVar:TrigToken:DB$ Token | ValidTgts$ Player | TokenScript$ c_a_food_sac | TokenOwner$ Targeted
+Oracle:If a player would create a Food token, instead The Ancient Dingus deals 2 damage to that player and they put a random card from a stack of visible unsleeved cards they own from outside the game into their hand.\nWhenever The Ancient Dingus attacks, target player creates a Food token.

--- a/forge-gui/res/cardsfolder/upcoming/the_bird_champion.txt
+++ b/forge-gui/res/cardsfolder/upcoming/the_bird_champion.txt
@@ -1,0 +1,12 @@
+Name:The Bird Champion
+ManaCost:2 G G U U
+Types:Legendary Creature Bird Wizard
+PT:9/9
+K:Defender
+K:Flying
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ At the beginning of your upkeep, create a 1/1 green and blue Bird creature token with flying for each Bird you control.
+SVar:TrigToken:DB$ Token | TokenScript$ gu_1_1_bird_flying | TokenAmount$ X
+SVar:X:Count$Valid Bird.YouCtrl
+R:Event$ GameLoss | ActiveZones$ Battlefield | ValidPlayer$ You | Layer$ CantHappen | CheckSVar$ X | SVarCompare$ GE12 | Description$ As long as you control twelve or more Birds, you can't lose the game and your opponents can't win the game.
+R:Event$ GameWin | ActiveZones$ Battlefield | ValidPlayer$ Opponent | Layer$ CantHappen | CheckSVar$ X | SVarCompare$ GE12 | Secondary$ True | Description$ As long as you control twelve or more Birds, you can't lose the game and your opponents can't win the game.
+Oracle:Defender, flying\nAt the beginning of your upkeep, create a 1/1 green and blue Bird creature token with flying for each Bird you control.\nAs long as you control twelve or more Birds, you can't lose the game and opponents can't win the game.

--- a/forge-gui/res/cardsfolder/upcoming/the_cookout_creator.txt
+++ b/forge-gui/res/cardsfolder/upcoming/the_cookout_creator.txt
@@ -1,0 +1,12 @@
+Name:The Cookout Creator
+ManaCost:W B G
+Types:Legendary Creature Human Gamer
+PT:3/3
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigFood | TriggerDescription$ When CARDNAME enters, create a Food token.
+SVar:TrigFood:DB$ Token | TokenScript$ c_a_food_sac
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ At the beginning of your upkeep, create a 1/1 colorless Human creature token for each Food you control.
+SVar:TrigToken:DB$ Token | TokenScript$ c_1_1_human | TokenAmount$ X
+SVar:X:Count$Valid Food.YouCtrl
+A:AB$ Draw | Cost$ tapXType<4/Human> | SubAbility$ DBToken | StackDescription$ SpellDescription | SpellDescription$ You draw a card and create a Treasure token.
+SVar:DBToken:DB$ Token | TokenScript$ c_a_treasure_sac
+Oracle:When The Cookout Creator enters, create a Food token.\nAt the beginning of your upkeep, create a 1/1 colorless Human creature token for each Food you control.\nTap four untapped Humans you control: You draw a card and create a Treasure token.

--- a/forge-gui/res/cardsfolder/upcoming/the_goblin_mastermind.txt
+++ b/forge-gui/res/cardsfolder/upcoming/the_goblin_mastermind.txt
@@ -1,0 +1,13 @@
+Name:The Goblin Mastermind
+ManaCost:2 B R
+Types:Legendary Creature Goblin Wizard
+PT:3/3
+S:Mode$ Continuous | Affected$ Card.YouCtrl | AffectedZone$ All | AddType$ Kindred & Goblin | Description$ As long as you control CARDNAME or it's your commander, permanents you control are Kindred Goblins in addition to their other types. The same is true for spells you control and cards that you own that aren't on the battlefield.
+S:Mode$ Continuous | Affected$ Card.YouCtrl | CheckSVar$ B | AffectedZone$ All | EffectZone$ All | AddType$ Kindred & Goblin | Secondary$ True | Description$ As long as you control CARDNAME or it's your commander, permanents you control are Kindred Goblins in addition to their other types. The same is true for spells you control and cards that you own that aren't on the battlefield.
+SVar:B:Count$ValidLibrary,Hand,Battlefield,Graveyard,Stack,Exile,Command Card.Self+YouOwn+IsCommander
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigCopyToken | CombatDamage$ True | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, you create a token that's a copy of one of Skirk Prospector, Goblin Lackey, Goblin Piledriver, Goblin Warchief, Boggart Harbinger, or Goblin Ringleader, chosen at random.
+SVar:TrigCopyToken:DB$ NameCard | Defined$ You | AtRandom$ True | ChooseFromList$ Skirk Prospector,Goblin Lackey,Goblin Piledriver,Goblin Warchief,Boggart Harbinger,Goblin Ringleader | SubAbility$ DBMake
+SVar:DBMake:DB$ MakeCard | Name$ ChosenName | Zone$ None | RememberMade$ True | SubAbility$ DBCopyPerm
+SVar:DBCopyPerm:DB$ CopyPermanent | Defined$ Remembered | SubAbility$ DBClearNamed
+SVar:DBClearNamed:DB$ Cleanup | ClearNamedCard$ True | ClearRemembered$ True
+Oracle:As long as you control The Goblin Mastermind or it's your commander, permanents you control are Kindred Goblins in addition to their other types. The same is true for spells you control and cards that you own that aren't on the battlefield.\nWhenever The Goblin Mastermind deals combat damage to a player, you create a token that's a copy of one of Skirk Prospector, Goblin Lackey, Goblin Piledriver, Goblin Warchief, Boggart Harbinger, or Goblin Ringleader, chosen at random.

--- a/forge-gui/res/cardsfolder/upcoming/the_ice_dancer.txt
+++ b/forge-gui/res/cardsfolder/upcoming/the_ice_dancer.txt
@@ -1,0 +1,12 @@
+Name:The Ice Dancer
+ManaCost:R W U
+Types:Legendary Creature Human Athlete
+PT:2/2
+A:AB$ Pump | Cost$ 2 Q | Defined$ Self | KW$ Flying | SpellDescription$ CARDNAME gains flying until end of turn.
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigToken | TriggerDescription$ Whenever The Ice Dancer deals combat damage to a player, create a Gold token. Then you draw X cards and gain X life, where X is the number of artifact tokens you control. The Ice Dancer deals X damage to each opponent.
+SVar:TrigToken:DB$ Token | TokenScript$ c_a_gold_sac | RememberTokens$ True | TokenOwner$ You | SubAbility$ DBDraw
+SVar:DBDraw:DB$ Draw | NumCards$ X | SubAbility$ DBGainLife
+SVar:DBGainLife:DB$ GainLife | LifeAmount$ X | SubAbility$ DBDamageAll
+SVar:DBDamageAll:DB$ DamageAll | ValidPlayers$ Opponent | NumDmg$ X
+SVar:X:Count$Valid Artifact.token+YouCtrl
+Oracle:{2}, {Q}: The Ice Dancer gains flying until end of turn. ({Q} is the untap symbol.)\nWhenever The Ice Dancer deals combat damage to a player, create a Gold token. Then you draw X cards and gain X life, where X is the number of artifact tokens you control. The Ice Dancer deals X damage to each opponent. (A Gold token is an artifact with "Sacrifice this token: Add one mana of any color.")

--- a/forge-gui/res/cardsfolder/upcoming/the_wizardly_barge.txt
+++ b/forge-gui/res/cardsfolder/upcoming/the_wizardly_barge.txt
@@ -1,0 +1,13 @@
+Name:The Wizardly Barge
+ManaCost:2 U R
+Types:Legendary Kindred Artifact Wizard Vehicle
+PT:3/5
+Text:[Developer's note: Due to game engine limitations, the "tournament-legal" restriction on the triggered ability isn't enforced (yet). Enjoy!]
+S:Mode$ Continuous | Affected$ Wizard.Other+YouCtrl | AddPower$ 1 | AddToughness$ 1 | Description$ Other Wizards you control get +1/+1.
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigCopyToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever The Wizardly Barge attacks, create a token that's a copy of a random tournament-legal Wizard creature.
+SVar:TrigCopyToken:DB$ NameCard | Defined$ You | AtRandom$ True | ValidCards$ Creature.Wizard | SubAbility$ DBMake
+SVar:DBMake:DB$ MakeCard | Name$ ChosenName | Zone$ None | RememberMade$ True | SubAbility$ DBCopyPerm
+SVar:DBCopyPerm:DB$ CopyPermanent | Defined$ Remembered | SubAbility$ DBClearNamed
+SVar:DBClearNamed:DB$ Cleanup | ClearNamedCard$ True | ClearRemembered$ True
+K:Crew:1
+Oracle:Other Wizards you control get +1/+1.\nWhenever The Wizardly Barge attacks, create a token that's a copy of a random tournament-legal Wizard creature. (I'd suggest looking them all up online and choosing one at random.)\nCrew 1

--- a/forge-gui/res/cardsfolder/upcoming/wurmcoil_broodmother.txt
+++ b/forge-gui/res/cardsfolder/upcoming/wurmcoil_broodmother.txt
@@ -1,0 +1,10 @@
+Name:Wurmcoil Broodmother
+ManaCost:9
+Types:Artifact Creature Wurm
+PT:9/9
+K:Deathtouch
+K:Lifelink
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME dies, create a Wurmcoil Engine token and a Wurmcoil Larva token.
+SVar:TrigToken:DB$ CopyPermanent | DefinedName$ Wurmcoil Engine | SubAbility$ DBToken
+SVar:DBToken:DB$ CopyPermanent | DefinedName$ Wurmcoil Larva
+Oracle:Deathtouch, lifelink\nWhen Wurmcoil Broodmother dies, create a Wurmcoil Engine token and a Wurmcoil Larva token.

--- a/forge-gui/res/editions/Unknown Event.txt
+++ b/forge-gui/res/editions/Unknown Event.txt
@@ -516,3 +516,8 @@ RW90a R The Keeper of Favorite Cards @
 RW90b R The Keeper of Favorite Cards @
 RW90c R The Keeper of Favorite Cards @
 MZ99 M The Collector @
+
+[CreatureTypes]
+Artist:Artists
+Athlete:Athletes
+Koala:Koalas

--- a/forge-gui/res/lists/TypeLists.txt
+++ b/forge-gui/res/lists/TypeLists.txt
@@ -30,10 +30,12 @@ Archer:Archers
 Archon:Archons
 Armadillo:Armadillos
 Artificer:Artificers
+Artist:Artists
 Army:Armies
 Assassin:Assassins
 Assembly-Worker:Assembly-Workers
 Astartes:Astartes
+Athlete:Athletes
 Atog:Atogs
 Aurochs:Aurochs
 Avatar:Avatars

--- a/forge-gui/res/lists/TypeLists.txt
+++ b/forge-gui/res/lists/TypeLists.txt
@@ -30,12 +30,10 @@ Archer:Archers
 Archon:Archons
 Armadillo:Armadillos
 Artificer:Artificers
-Artist:Artists
 Army:Armies
 Assassin:Assassins
 Assembly-Worker:Assembly-Workers
 Astartes:Astartes
-Athlete:Athletes
 Atog:Atogs
 Aurochs:Aurochs
 Avatar:Avatars
@@ -172,7 +170,6 @@ Killbot:Killbots
 Kirin:Kirins
 Kithkin:Kithkin
 Knight:Knights
-Koala:Koalas
 Kobold:Kobolds
 Kor:Kors
 Kraken:Krakens

--- a/forge-gui/res/lists/TypeLists.txt
+++ b/forge-gui/res/lists/TypeLists.txt
@@ -172,6 +172,7 @@ Killbot:Killbots
 Kirin:Kirins
 Kithkin:Kithkin
 Knight:Knights
+Koala:Koalas
 Kobold:Kobolds
 Kor:Kors
 Kraken:Krakens

--- a/forge-gui/res/tokenscripts/b_1_1_bird_flying.txt
+++ b/forge-gui/res/tokenscripts/b_1_1_bird_flying.txt
@@ -1,0 +1,7 @@
+Name:Bird Token
+ManaCost:no cost
+Colors:black
+Types:Creature Bird
+PT:1/1
+K:Flying
+Oracle:Flying

--- a/forge-gui/res/tokenscripts/c_1_1_human.txt
+++ b/forge-gui/res/tokenscripts/c_1_1_human.txt
@@ -1,0 +1,5 @@
+Name:Human Token
+ManaCost:no cost
+Types:Creature Human
+PT:1/1
+Oracle:

--- a/forge-gui/res/tokenscripts/gu_1_1_bird_flying.txt
+++ b/forge-gui/res/tokenscripts/gu_1_1_bird_flying.txt
@@ -1,0 +1,7 @@
+Name:Bird Token
+ManaCost:no cost
+Colors:green,blue
+Types:Creature Bird
+PT:1/1
+K:Flying
+Oracle:Flying

--- a/forge-gui/res/tokenscripts/w_1_1_insect_flying.txt
+++ b/forge-gui/res/tokenscripts/w_1_1_insect_flying.txt
@@ -1,0 +1,7 @@
+Name:Insect Token
+ManaCost:no cost
+Colors:white
+Types:Creature Insect
+PT:1/1
+K:Flying
+Oracle:Flying


### PR DESCRIPTION
Some seemingly easy enough cards going from the most recent release back in time. Waiting on the merger of the following PR, https://github.com/Card-Forge/forge/pull/10740 , since it deals with a crash involving Bin Chicken's amass effect and it also updates the [Un-card list](https://github.com/Card-Forge/forge/wiki/Un%E2%80%90cards,-Playtest-Cards,-and-Other-Funny-Cards). ~Also waiting on the merger of https://github.com/Card-Forge/forge/pull/10809 regarding the proper listing of non-legal subtypes per discussion below.~
- [17-Year Cicadas](https://scryfall.com/card/unk/UW05c/17-year-cicadas) and associated token: Tested to satisfaction
- [Another Night in Vegas](https://scryfall.com/card/unk/RB14/another-night-in-vegas):  Tested to satisfaction
- [Auntie Ant, Ant Auntie](https://scryfall.com/card/unk/RR05a/auntie-ant-ant-auntie): Since this is the only instance of the multiblight keyword, I opted to recreate it with a script line. Tested to satisfaction.
- [Bin Chicken](https://scryfall.com/card/unk/RB05c/bin-chicken): Treating Food tokens as Junk and vice-versa was interpreted as two separate continuous effects granting one codified token the type and standard ability of the other. Tested to satisfaction except for the amass line as explained above. I do understand from testing done for the PR mentioned above that it should work.
- [Colorless Ultimatum](https://scryfall.com/card/unk/RA07/colorless-ultimatum): The game engine converts the scripted `{2}{C}{C}{C}{2}` cost to `{4}{C}{C}{C}` with no issue. Maybe it's better to skip that calculation altogether? Tested to satisfaction.
- [Crow Scarer](https://scryfall.com/card/unk/UA02/crow-scarer) and associated token: Tested to satisfaction.
- [Drop Bear](https://scryfall.com/card/unk/RZ05n/drop-bear): Added Koala to ~`TypeLists.txt`~ the relevant edition file. Tested to satisfaction.
- [Evy, Fang Keeper](https://scryfall.com/card/unk/RZ03s/evy-fang-keeper): In the vein of "Ach! Hans, Run!", skipped the somatic requirement (if you will) and set up a flavorful enough `GenericChoice` between the granted ETBs. Added Artist to  ~`TypeLists.txt`~ the relevant edition file. Tested to satisfaction.
- [The Ancient Dingus](https://scryfall.com/card/unk/RZ04v/the-ancient-dingus): Regarding the replacement effect, skipped the unsleeved card requirement as presumably extraneous to implement and had it pull cards into hand from the players' sideboards. Tested to satisfaction.
- [The Bird Champion](https://scryfall.com/card/unk/RZ06i/the-bird-champion) and associated token: Tested to satisfaction.
- [The Cookout Creator](https://scryfall.com/card/unk/RZ03p/the-cookout-creator) and associated new token: Tested to satisfaction.
- [The Goblin Mastermind](https://scryfall.com/card/unk/RZ04w/the-goblin-mastermind): Tested to satisfaction.
- [The Ice Dancer](https://scryfall.com/card/unk/RZ03t/the-ice-dancer): Added Athlete to ~`TypeLists.txt`~ the relevant edition file. Tested to satisfaction.
- [The Wizardly Barge](https://scryfall.com/card/unk/RZ03r/the-wizardly-barge): Assumed and noted as such that the "tournament-legal" requirement is extraneous to implement as it can be context-dependent. Tested to satisfaction.
- [Wurmcoil Broodmother](https://scryfall.com/card/unk/RA09/wurmcoil-broodmother): Tested to satisfaction.