### PR TITLE
Cleanup: Types list 

### DIFF
--- a/forge-gui/res/editions/2016 Heroes of the Realm.txt
+++ b/forge-gui/res/editions/2016 Heroes of the Realm.txt
@@ -10,3 +10,8 @@ ScryfallCode=PHTR
 1 M Chandra, Gremlin Wrangler @Kari Christensen
 2 M Dungeon Master @Mike Burns
 3 M Nira, Hellkite Duelist @Yoichi Ito
+
+[CreatureTypes]
+Fighter:Fighters
+[WalkerTypes]
+Dungeon Master

--- a/forge-gui/res/editions/2017 Heroes of the Realm.txt
+++ b/forge-gui/res/editions/2017 Heroes of the Realm.txt
@@ -10,3 +10,6 @@ ScryfallCode=PH17
 1 M Diabolical Salvation @Zoltan Boros
 2 M Inzerva, Master of Insights @Filip Burburan
 3 M M'Odo, the Gnarled Oracle @Johann Bodin
+
+[WalkerTypes]
+Inzerva

--- a/forge-gui/res/editions/2023 Heroes of the Realm.txt
+++ b/forge-gui/res/editions/2023 Heroes of the Realm.txt
@@ -8,3 +8,6 @@ ScryfallCode=PH23
 [cards]
 1 M Mr. Monopoly, On the Go @Kevin Sidharta
 2 M Ormacar, Relic Wraith @Anna Podedworna
+
+[WalkerTypes]
+Monopoly

--- a/forge-gui/res/editions/Celebration Cards.txt
+++ b/forge-gui/res/editions/Celebration Cards.txt
@@ -17,3 +17,6 @@ ScryfallCode=PCEL
 
 [eternal]
 8 R Zur the Enchanter @Chase Stone ${"flavorName": "Post the Enchanter"}
+
+[WalkerTypes]
+Deb

--- a/forge-gui/res/editions/Drake Stone.txt
+++ b/forge-gui/res/editions/Drake Stone.txt
@@ -13,3 +13,6 @@ Type=Funny
 
 [eternal]
 2 U Concentrate @Kevin Smith
+
+[WalkerTypes]
+Stone

--- a/forge-gui/res/editions/Mystery Booster 2.txt
+++ b/forge-gui/res/editions/Mystery Booster 2.txt
@@ -393,3 +393,8 @@ F618 R Slumbering Waterways @Kevin Dubell
 F619 R Temur Elevator @Marika Lord
 F620 R Under-Construction Skyscraper @Kevin Dubell
 F621 R Value Town @Hélio Frazão
+
+[LandTypes]
+Omenpath:Omenpaths
+[WalkerTypes]
+You

--- a/forge-gui/res/editions/Mystery Booster Playtest Cards.txt
+++ b/forge-gui/res/editions/Mystery Booster Playtest Cards.txt
@@ -128,3 +128,10 @@ ScryfallCode=CMB1
 119 R Rift @Zach Francks
 120 R Taiga Stadium @Tara Rueping
 121 R Waste Land @Patrick Kuhlman
+
+[CreatureTypes]
+Mammoth:Mammoths
+[ArtifactTypes]
+Key:Keys
+[WalkerTypes]
+Duck

--- a/forge-gui/res/editions/Unglued.txt
+++ b/forge-gui/res/editions/Unglued.txt
@@ -106,3 +106,6 @@ ScryfallCode=UGL
 92 r_1_1_goblin @Pete Venters
 93 g_2_2_sheep @Kev Walker
 94 g_1_1_squirrel @Ron Spencer
+
+[CreatureTypes]
+Cow:Cows

--- a/forge-gui/res/editions/Unsanctioned.txt
+++ b/forge-gui/res/editions/Unsanctioned.txt
@@ -110,3 +110,8 @@ ScryfallCode=UND
 3 g_1_1_squirrel @Daniel Ljunggren
 4 c_4_4_dragon_flying @Autumn Rain Turkel
 5 c_5_5_giant_teddy_bear @Andrea Radeck
+
+[CreatureTypes]
+Clamfolk:Clamfolk
+[WalkerTypes]
+B.O.B.

--- a/forge-gui/res/editions/Unstable.txt
+++ b/forge-gui/res/editions/Unstable.txt
@@ -302,3 +302,10 @@ ScryfallCode=UST
 18 c_a_clue_draw @John Avon
 19 c_x_x_a_construct @Matt Gaser
 20 c_1_1_a_gnome @Dmitry Burmak
+
+[CreatureTypes]
+Brainiac:Brainiacs
+Cyborg:Cyborgs
+Killbot:Killbots
+[ArtifactTypes]
+Contraption:Contraptions

--- a/forge-gui/res/lists/TypeLists.txt
+++ b/forge-gui/res/lists/TypeLists.txt
@@ -11,7 +11,6 @@ Gate:Gates
 Lair
 Locus
 Mine
-Omenpath
 Planet:Planets
 Power-Plant
 Sphere:Spheres
@@ -54,7 +53,6 @@ Bird:Birds
 Bison:Bisons
 Blinkmoth:Blinkmoths
 Boar:Boars
-Brainiac:Brainiacs
 Bringer:Bringers
 Brushwagg:Brushwaggs
 Camarid:Camarids
@@ -67,18 +65,15 @@ Cat:Cats
 Centaur:Centaurs
 Chimera:Chimeras
 Citizen:Citizens
-Clamfolk:Clamfolk
 Cleric:Clerics
 Clown:Clowns
 Cockatrice:Cockatrices
 Construct:Constructs
-Cow:Cows
 Coward:Cowards
 Coyote:Coyotes
 Crab:Crabs
 Crocodile:Crocodiles
 Cyberman:Cybermen
-Cyborg:Cyborgs
 Cyclops:Cyclopes
 Dalek:Daleks
 Detective:Detectives
@@ -113,7 +108,6 @@ Eternal:Eternals
 Eye:Eyes
 Faerie:Faeries
 Ferret:Ferrets
-Fighter:Fighters
 Fish:Fish
 Flagbearer:Flagbearers
 Fox:Foxes
@@ -166,7 +160,6 @@ Jellyfish:Jellyfishes
 Juggernaut:Juggernauts
 Kangaroo:Kangaroos
 Kavu:Kavu
-Killbot:Killbots
 Kirin:Kirins
 Kithkin:Kithkin
 Knight:Knights
@@ -183,7 +176,6 @@ Licid:Licids
 Lizard:Lizards
 Llama:Llamas
 Lobster:Lobsters
-Mammoth:Mammoths
 Manticore:Manticores
 Masticore:Masticores
 Mercenary:Mercenaries
@@ -372,7 +364,6 @@ Blood
 Bobblehead:Bobbleheads
 Book:Books
 Clue:Clues
-Contraption:Contraptions
 Equipment
 Food:Foods
 Fortification
@@ -380,7 +371,6 @@ Gold
 Incubator:Incubators
 Infinity
 Junk
-Key:Keys
 Lander:Landers
 Map
 Mutagen
@@ -396,7 +386,6 @@ Aminatou
 Angrath
 Arlinn
 Ashiok
-B.O.B.
 Bahamut
 Basri
 Bolas
@@ -407,13 +396,10 @@ Dack
 Dakkon
 Daretti
 Davriel
-Deb
 Dellian
 Dihada
 Domri
 Dovin
-Duck
-Dungeon Master
 Ellywick
 Elminster
 Elspeth
@@ -424,7 +410,6 @@ Gideon
 Grist
 Guff
 Huatli
-Inzerva
 Jace
 Jared
 Jaya
@@ -439,7 +424,6 @@ Liliana
 Lolth
 Lukka
 Minsc
-Monopoly
 Mordenkainen
 Nahiri
 Narset
@@ -455,7 +439,6 @@ Samut
 Sarkhan
 Serra
 Sorin
-Stone
 Szat
 Tamiyo
 Tasha
@@ -476,7 +459,6 @@ Wrenn
 Xenagos
 Yanggu
 Yanling
-You
 Zariel
 [DungeonTypes]
 Undercity


### PR DESCRIPTION
Per [previous discussion](https://github.com/Card-Forge/forge/pull/10808#discussion_r3328502391) and [previous relevant PR](https://github.com/Card-Forge/forge/pull/8113), non-legal subtypes are moved herein to relevant edition files.
I assumed no redundancy was necessary (Clamfolk are present in UND and UGL, for instance) and that Attractions got their shoe in the door by virtue of being legal in Commander (see [Balloon Stand](https://scryfall.com/card/unf/200a/balloon-stand) ). Wasn't entirely sure what to to about plane subtypes, seemingly all non-legal, so I left that list alone for the time being.