### PR TITLE
Online draft/sealed bug fixes and polish (desktop)

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/itemmanager/DeckManager.java
+++ b/forge-gui-desktop/src/main/java/forge/itemmanager/DeckManager.java
@@ -8,7 +8,6 @@ import java.awt.RenderingHints;
 import java.awt.event.MouseEvent;
 import java.util.*;
 import java.util.Map.Entry;
-import java.util.function.Consumer;
 
 import javax.swing.JMenu;
 import javax.swing.JTable;
@@ -65,7 +64,6 @@ public final class DeckManager extends ItemManager<DeckProxy> implements IHasGam
 
     private final GameType gameType;
     private UiCommand cmdDelete, cmdSelect;
-    private Consumer<DeckProxy> editDeckCommand;
 
     /**
      * Creates deck list for selected decks for quick deleting, editing, and
@@ -148,11 +146,6 @@ public final class DeckManager extends ItemManager<DeckProxy> implements IHasGam
     }
     public UiCommand getSelectCommand() {
         return this.cmdSelect;
-    }
-
-    /** Overrides {@link #editDeck} so a view can open the deck from its own storage. */
-    public void setEditDeckCommand(final Consumer<DeckProxy> c0) {
-        this.editDeckCommand = c0;
     }
 
     @Override
@@ -334,12 +327,15 @@ public final class DeckManager extends ItemManager<DeckProxy> implements IHasGam
     }
 
     public void editDeck(final DeckProxy deck) {
-        if (editDeckCommand != null) {
-            editDeckCommand.accept(deck);
-            return;
-        }
         ACEditorBase<? extends InventoryItem, ? extends DeckBase> editorCtrl = null;
         FScreen screen = null;
+
+        if (deck != null && DeckProxy.getEventTag(deck.getDeck(), "eventFormat") != null) {
+            screen = CEditorLimited.networkEventEditorScreen(deck.getDeck());
+            editorCtrl = new CEditorLimited<>(FModel.getDecks().getNetworkEventDecks(), Deck::new, screen, getCDetailPicture());
+            openEditor(deck, screen, editorCtrl);
+            return;
+        }
 
         switch (this.gameType) {
             case Quest:
@@ -388,6 +384,10 @@ public final class DeckManager extends ItemManager<DeckProxy> implements IHasGam
                 return;
         }
 
+        openEditor(deck, screen, editorCtrl);
+    }
+
+    private void openEditor(final DeckProxy deck, final FScreen screen, final ACEditorBase<? extends InventoryItem, ? extends DeckBase> editorCtrl) {
         if (!Singletons.getControl().ensureScreenActive(screen)) {
             return;
         }

--- a/forge-gui-desktop/src/main/java/forge/itemmanager/DeckManager.java
+++ b/forge-gui-desktop/src/main/java/forge/itemmanager/DeckManager.java
@@ -8,6 +8,7 @@ import java.awt.RenderingHints;
 import java.awt.event.MouseEvent;
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.function.Consumer;
 
 import javax.swing.JMenu;
 import javax.swing.JTable;
@@ -64,6 +65,7 @@ public final class DeckManager extends ItemManager<DeckProxy> implements IHasGam
 
     private final GameType gameType;
     private UiCommand cmdDelete, cmdSelect;
+    private Consumer<DeckProxy> editDeckCommand;
 
     /**
      * Creates deck list for selected decks for quick deleting, editing, and
@@ -146,6 +148,11 @@ public final class DeckManager extends ItemManager<DeckProxy> implements IHasGam
     }
     public UiCommand getSelectCommand() {
         return this.cmdSelect;
+    }
+
+    /** Overrides {@link #editDeck} so a view can open the deck from its own storage. */
+    public void setEditDeckCommand(final Consumer<DeckProxy> c0) {
+        this.editDeckCommand = c0;
     }
 
     @Override
@@ -327,6 +334,10 @@ public final class DeckManager extends ItemManager<DeckProxy> implements IHasGam
     }
 
     public void editDeck(final DeckProxy deck) {
+        if (editDeckCommand != null) {
+            editDeckCommand.accept(deck);
+            return;
+        }
         ACEditorBase<? extends InventoryItem, ? extends DeckBase> editorCtrl = null;
         FScreen screen = null;
 

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorLimited.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorLimited.java
@@ -28,8 +28,10 @@ import forge.card.CardEdition;
 import forge.deck.CardPool;
 import forge.deck.Deck;
 import forge.deck.DeckBase;
+import forge.deck.DeckProxy;
 import forge.deck.DeckSection;
 import forge.game.GameType;
+import forge.gamemodes.net.EventFormat;
 import forge.gui.UiCommand;
 import forge.gui.framework.DragCell;
 import forge.gui.framework.FScreen;
@@ -70,6 +72,12 @@ public final class CEditorLimited<T extends DeckBase> extends CDeckEditor<T> {
     private DragCell tinyLeadersDecksParent = null;
     private DragCell deckGenParent = null;
     private final List<DeckSection> allSections = new ArrayList<>();
+
+    /** Picks the editor screen for a network event deck from its eventFormat tag. */
+    public static FScreen networkEventEditorScreen(Deck deck) {
+        return deck != null && EventFormat.BOOSTER_DRAFT.name().equals(DeckProxy.getEventTag(deck, "eventFormat"))
+                ? FScreen.DECK_EDITOR_DRAFT : FScreen.DECK_EDITOR_SEALED;
+    }
 
     //========== Constructor
 

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorNetworkDraft.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorNetworkDraft.java
@@ -188,8 +188,7 @@ public class CEditorNetworkDraft extends ACEditorBase<PaperCard, Deck> {
         FDraftOverlay.SINGLETON_INSTANCE.reset();
         FScreen.DRAFTING_PROCESS.close();
 
-        // Reuse the sealed editor for post-draft pool editing — the UI is identical
-        FScreen editScreen = FScreen.DECK_EDITOR_SEALED;
+        FScreen editScreen = FScreen.DECK_EDITOR_DRAFT;
         CEditorLimited<Deck> editorCtrl = new CEditorLimited<>(
                 FModel.getDecks().getNetworkEventDecks(), Deck::new, editScreen, getCDetailPicture());
         Singletons.getControl().setCurrentScreen(editScreen);

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorNetworkDraft.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/controllers/CEditorNetworkDraft.java
@@ -216,6 +216,7 @@ public class CEditorNetworkDraft extends ACEditorBase<PaperCard, Deck> {
     public void update() {
         if (VEditorLog.SINGLETON_INSTANCE.getParentCell() == null) {
             VCardCatalog.SINGLETON_INSTANCE.getParentCell().addDoc(VEditorLog.SINGLETON_INSTANCE);
+            VEditorLog.SINGLETON_INSTANCE.showView();
         }
 
         ccAddLabel = this.getBtnAdd().getText();

--- a/forge-gui-desktop/src/main/java/forge/screens/deckeditor/views/VEditorLog.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/deckeditor/views/VEditorLog.java
@@ -60,7 +60,6 @@ public enum VEditorLog implements IVDoc<CEditorLog> {
 
     public void showView() {
         tab.setVisible(true);
-        tab.setOpaque(true);
         pnlContent.setOpaque(true);
         pnlContent.setVisible(true);
     }

--- a/forge-gui-desktop/src/main/java/forge/screens/home/CLobby.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/CLobby.java
@@ -367,6 +367,8 @@ public class CLobby implements IDraftEventHandler {
                 Localizer.getInstance().getMessage("lblNetworkLoadPastEventPrompt"), choices);
         if (chosen == null) return;
         activeEventId = chosen.id();
+        activeConformance = true;
+        view.setConformanceSelected(true);
         view.updateEventPanelState();
         view.updateActionButtons();
         view.updateDeckListFilter();

--- a/forge-gui-desktop/src/main/java/forge/screens/home/CLobby.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/CLobby.java
@@ -527,10 +527,11 @@ public class CLobby implements IDraftEventHandler {
                 networkDraftEditor = null;
             } else {
                 FModel.getDecks().getNetworkEventDecks().add(pool);
+                final FScreen screen = CEditorLimited.networkEventEditorScreen(pool);
                 CEditorLimited<Deck> editor = new CEditorLimited<>(
                         FModel.getDecks().getNetworkEventDecks(), Deck::new,
-                        FScreen.DECK_EDITOR_SEALED, CDeckEditorUI.SINGLETON_INSTANCE.getCDetailPicture());
-                Singletons.getControl().setCurrentScreen(FScreen.DECK_EDITOR_SEALED);
+                        screen, CDeckEditorUI.SINGLETON_INSTANCE.getCDetailPicture());
+                Singletons.getControl().setCurrentScreen(screen);
                 CDeckEditorUI.SINGLETON_INSTANCE.setEditorController(editor);
                 editor.getDeckController().load(null, pool.getName());
             }

--- a/forge-gui-desktop/src/main/java/forge/screens/home/CLobby.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/CLobby.java
@@ -2,8 +2,10 @@ package forge.screens.home;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedHashSet;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Vector;
 import java.util.function.Consumer;
 
@@ -256,12 +258,19 @@ public class CLobby implements IDraftEventHandler {
     }
 
     void scanAvailableEvents() {
-        LinkedHashSet<String> eventIds = new LinkedHashSet<>();
+        Map<String, String> datesByEventId = new LinkedHashMap<>();
         for (Deck d : FModel.getDecks().getNetworkEventDecks()) {
             String eventId = DeckProxy.getEventTag(d, "eventId");
-            if (eventId != null) eventIds.add(eventId);
+            if (eventId != null) {
+                datesByEventId.putIfAbsent(eventId, DeckProxy.getEventTag(d, "eventDate"));
+            }
         }
-        eventIdsByDropdownIndex = new ArrayList<>(eventIds);
+        List<String> ids = new ArrayList<>(datesByEventId.keySet());
+        // eventDate is "yyyy-MM-dd HH:mm", so reverse lexical order lists newest first
+        ids.sort(Comparator.comparing(
+                (String id) -> datesByEventId.get(id) != null ? datesByEventId.get(id) : "",
+                Comparator.reverseOrder()));
+        eventIdsByDropdownIndex = ids;
     }
 
     void openEventConfigDialog() {

--- a/forge-gui-desktop/src/main/java/forge/screens/home/online/CSubmenuOnlineDecks.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/online/CSubmenuOnlineDecks.java
@@ -1,15 +1,8 @@
 package forge.screens.home.online;
 
-import forge.Singletons;
-import forge.deck.Deck;
 import forge.deck.DeckProxy;
-import forge.gui.framework.FScreen;
 import forge.gui.framework.ICDoc;
 import forge.itemmanager.ItemManagerConfig;
-import forge.model.FModel;
-import forge.screens.deckeditor.CDeckEditorUI;
-import forge.screens.deckeditor.SEditorIO;
-import forge.screens.deckeditor.controllers.CEditorLimited;
 
 /**
  * Controls the online draft/sealed decks submenu in the home UI.
@@ -25,29 +18,6 @@ public enum CSubmenuOnlineDecks implements ICDoc {
 
     @Override
     public void initialize() {
-        final VSubmenuOnlineDecks view = VSubmenuOnlineDecks.SINGLETON_INSTANCE;
-        // Override editDeck so both double-click and the per-row edit button open
-        // from getNetworkEventDecks() instead of the getSealed() pool DeckManager would pick
-        view.getLstDecks().setEditDeckCommand(deck -> {
-            final FScreen screen = CEditorLimited.networkEventEditorScreen(deck != null ? deck.getDeck() : null);
-            final CEditorLimited<Deck> editorCtrl = new CEditorLimited<>(
-                    FModel.getDecks().getNetworkEventDecks(), Deck::new, screen,
-                    CDeckEditorUI.SINGLETON_INSTANCE.getCDetailPicture());
-
-            if (!Singletons.getControl().ensureScreenActive(screen)) {
-                return;
-            }
-            // Confirm before installing the new controller so a Cancel doesn't
-            // clobber the previous editor's unsaved state.
-            if (!SEditorIO.confirmSaveChanges(screen, true)) {
-                return;
-            }
-            CDeckEditorUI.SINGLETON_INSTANCE.setEditorController(editorCtrl);
-            if (deck != null) {
-                CDeckEditorUI.SINGLETON_INSTANCE.getCurrentEditorController()
-                        .getDeckController().load(deck.getPath(), deck.getName());
-            }
-        });
     }
 
     @Override

--- a/forge-gui-desktop/src/main/java/forge/screens/home/online/CSubmenuOnlineDecks.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/online/CSubmenuOnlineDecks.java
@@ -29,7 +29,7 @@ public enum CSubmenuOnlineDecks implements ICDoc {
         // Override editDeck so both double-click and the per-row edit button open
         // from getNetworkEventDecks() instead of the getSealed() pool DeckManager would pick
         view.getLstDecks().setEditDeckCommand(deck -> {
-            final FScreen screen = FScreen.DECK_EDITOR_SEALED;
+            final FScreen screen = CEditorLimited.networkEventEditorScreen(deck != null ? deck.getDeck() : null);
             final CEditorLimited<Deck> editorCtrl = new CEditorLimited<>(
                     FModel.getDecks().getNetworkEventDecks(), Deck::new, screen,
                     CDeckEditorUI.SINGLETON_INSTANCE.getCDetailPicture());

--- a/forge-gui-desktop/src/main/java/forge/screens/home/online/CSubmenuOnlineDecks.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/online/CSubmenuOnlineDecks.java
@@ -26,10 +26,9 @@ public enum CSubmenuOnlineDecks implements ICDoc {
     @Override
     public void initialize() {
         final VSubmenuOnlineDecks view = VSubmenuOnlineDecks.SINGLETON_INSTANCE;
-        // Override the default editDeck command so it uses getNetworkEventDecks()
-        // instead of the default getSealed() that DeckManager would pick
-        view.getLstDecks().setItemActivateCommand(() -> {
-            final DeckProxy deck = view.getLstDecks().getSelectedItem();
+        // Override editDeck so both double-click and the per-row edit button open
+        // from getNetworkEventDecks() instead of the getSealed() pool DeckManager would pick
+        view.getLstDecks().setEditDeckCommand(deck -> {
             final FScreen screen = FScreen.DECK_EDITOR_SEALED;
             final CEditorLimited<Deck> editorCtrl = new CEditorLimited<>(
                     FModel.getDecks().getNetworkEventDecks(), Deck::new, screen,

--- a/forge-gui/src/main/java/forge/gamemodes/match/GameLobby.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/GameLobby.java
@@ -548,10 +548,11 @@ public abstract class GameLobby implements IHasGameType {
         }
 
         //if above checks succeed, return runnable that can be used to finish starting game
+        final GameType baseGameType = data.isLimitedMode() ? GameType.Draft : GameType.Constructed;
         return () -> {
             hostedMatch = GuiBase.getInterface().hostMatch();
             hostedMatch.setOnMatchOver(this::onMatchOver);
-            hostedMatch.startMatch(GameType.Constructed, variantTypes, players, guis);
+            hostedMatch.startMatch(baseGameType, variantTypes, players, guis);
 
             for (final Player p : hostedMatch.getGame().getPlayers()) {
                 final LobbySlot slot = playerToSlot.get(p.getRegisteredPlayer());


### PR DESCRIPTION
## Summary

A set of bug fixes and polish for network draft/sealed on desktop:

- **Sideboard cap in limited matches:** networked limited games launched as Constructed, so the deck-building sideboard dialog wrongly demanded the pool be cut to the 15-card Constructed sideboard limit. They now launch as a limited game type (no sideboard cap).
- **Edit button now loads the deck:** the per-row Edit button in the Net Event Decks list opened an empty editor because it used the wrong deck pool; it now opens the selected deck, matching double-click behaviour.
- **Correct editor per format:** draft pools open in the Draft deck editor and sealed pools in the Sealed editor, instead of everything opening in the Sealed editor.
- **Immediate event filter:** choosing a past event now filters the deck list to that event right away, instead of requiring the "only allow decks from this event" checkbox to be toggled off and back on.
- **Past events sorted newest first:** the load-past-event picker now lists events by date, newest to oldest.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)