### PR TITLE
Allow the grouping of identical cards

### DIFF
--- a/forge-gui-mobile/src/forge/deck/FDeckEditor.java
+++ b/forge-gui-mobile/src/forge/deck/FDeckEditor.java
@@ -5,7 +5,6 @@ import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.Align;
 import forge.Forge;
 import forge.Forge.KeyInputAdapter;
-import forge.adventure.scene.AdventureDeckEditor;
 import forge.Graphics;
 import forge.assets.*;
 import forge.card.CardEdition;
@@ -712,20 +711,10 @@ public class FDeckEditor extends TabPageScreen<FDeckEditor> {
     protected void toggleGroupIdenticalCards() {
         FModel.getPreferences().togglePrefBoolean(FPref.UI_GROUP_IDENTICAL_CARDS);
 
-        if(getCatalogPage() != null) {
-            getCatalogPage().scheduleRefresh();
-        }
-
-        if (getMainDeckPage() != null) {
-            getMainDeckPage().cardManager.updateView(false, null);
-        }
-
-        if (getSideboardPage() != null) {
-            getSideboardPage().cardManager.updateView(false, null);
-        }
-
-        if(this instanceof AdventureDeckEditor adventureEditor) {
-            adventureEditor.refresh();
+        for (TabPage<FDeckEditor> tabPage  : tabPages) {
+            if (tabPage instanceof CardManagerPage cmp) {
+                cmp.cardManager.updateView(false, null);
+            }
         }
     }
 
@@ -2220,7 +2209,7 @@ public class FDeckEditor extends TabPageScreen<FDeckEditor> {
         public DraftPackPage(CardManager cardManager) {
             super(cardManager, ItemManagerConfig.DRAFT_PACK, Localizer.getInstance().getMessage("lblPackN", String.valueOf(1)), FSkinImage.PACK);
             cardManager.setShowRanking(true);
-            cardManager.setAllowGroupIdenticalCards(false);
+            cardManager.setAllowGroupIdentical(false);
         }
 
         @Override

--- a/forge-gui-mobile/src/forge/deck/FDeckEditor.java
+++ b/forge-gui-mobile/src/forge/deck/FDeckEditor.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.Align;
 import forge.Forge;
 import forge.Forge.KeyInputAdapter;
+import forge.adventure.scene.AdventureDeckEditor;
 import forge.Graphics;
 import forge.assets.*;
 import forge.card.CardEdition;
@@ -639,6 +640,7 @@ public class FDeckEditor extends TabPageScreen<FDeckEditor> {
                     );
                 }
                 addItem(new FMenuItem(localizer.getMessage("btnCopyToClipboard"), Forge.hdbuttons ? FSkinImage.HDEXPORT : FSkinImage.BLANK, e -> FDeckViewer.copyDeckToClipboard(deck)));
+                addItem(new FCheckBoxMenuItem(localizer.getMessage("lblGroupIdenticalCards"), getGroupIdenticalCards(), e -> toggleGroupIdenticalCards()));
                 boolean devMode = FModel.getPreferences().getPrefBoolean(FPref.DEV_MODE_ENABLED);
                 if(!FModel.getPreferences().getPrefBoolean(FPref.ENFORCE_DECK_LEGALITY) || devMode)
                     addItem(new FCheckBoxMenuItem(localizer.getMessage("cbEnforceDeckLegality"), shouldEnforceConformity(), e -> toggleConformity()));
@@ -701,6 +703,30 @@ public class FDeckEditor extends TabPageScreen<FDeckEditor> {
             tags.add(DECK_TAG_SUPPRESS_CONFORMITY);
         if(getCatalogPage() != null)
             getCatalogPage().scheduleRefresh(); //Refresh to update commander options.
+    }
+
+    protected boolean getGroupIdenticalCards() {
+        return FModel.getPreferences().getPrefBoolean(FPref.UI_GROUP_IDENTICAL_CARDS);
+    }
+
+    protected void toggleGroupIdenticalCards() {
+        FModel.getPreferences().togglePrefBoolean(FPref.UI_GROUP_IDENTICAL_CARDS);
+
+        if(getCatalogPage() != null) {
+            getCatalogPage().scheduleRefresh();
+        }
+
+        if (getMainDeckPage() != null) {
+            getMainDeckPage().cardManager.updateView(false, null);
+        }
+
+        if (getSideboardPage() != null) {
+            getSideboardPage().cardManager.updateView(false, null);
+        }
+
+        if(this instanceof AdventureDeckEditor adventureEditor) {
+            adventureEditor.refresh();
+        }
     }
 
     protected void showDevAddCardDialog() {
@@ -2194,6 +2220,7 @@ public class FDeckEditor extends TabPageScreen<FDeckEditor> {
         public DraftPackPage(CardManager cardManager) {
             super(cardManager, ItemManagerConfig.DRAFT_PACK, Localizer.getInstance().getMessage("lblPackN", String.valueOf(1)), FSkinImage.PACK);
             cardManager.setShowRanking(true);
+            cardManager.setAllowGroupIdenticalCards(false);
         }
 
         @Override

--- a/forge-gui-mobile/src/forge/itemmanager/CardManager.java
+++ b/forge-gui-mobile/src/forge/itemmanager/CardManager.java
@@ -31,6 +31,7 @@ import forge.toolbox.FList.CompactModeHandler;
 public class CardManager extends ItemManager<PaperCard> {
     public CardManager(boolean wantUnique0) {
         super(PaperCard.class, wantUnique0);
+        setAllowGroupIdenticalCards(true);
     }
 
     @Override

--- a/forge-gui-mobile/src/forge/itemmanager/CardManager.java
+++ b/forge-gui-mobile/src/forge/itemmanager/CardManager.java
@@ -31,7 +31,7 @@ import forge.toolbox.FList.CompactModeHandler;
 public class CardManager extends ItemManager<PaperCard> {
     public CardManager(boolean wantUnique0) {
         super(PaperCard.class, wantUnique0);
-        setAllowGroupIdenticalCards(true);
+        setAllowGroupIdentical(true);
     }
 
     @Override

--- a/forge-gui-mobile/src/forge/itemmanager/ItemManager.java
+++ b/forge-gui-mobile/src/forge/itemmanager/ItemManager.java
@@ -66,7 +66,7 @@ public abstract class ItemManager<T extends InventoryItem> extends FContainer im
     private boolean showRanking = false;
     private boolean showPriceInfo = false;
     private boolean multiSelectMode = false;
-    private boolean allowGroupIdenticalCards = false;
+    private boolean allowGroupIdentical = false;
     private FEventHandler selectionChangedHandler, itemActivateHandler;
     private ContextMenuBuilder<T> contextMenuBuilder;
     private ContextMenu contextMenu;
@@ -965,16 +965,16 @@ public abstract class ItemManager<T extends InventoryItem> extends FContainer im
         return showPriceInfo;
     }
 
-    public boolean getAllowGroupIdenticalCards() {
-        return allowGroupIdenticalCards;
+    public boolean getAllowGroupIdentical() {
+        return allowGroupIdentical;
     }
 
-    public void setAllowGroupIdenticalCards(boolean allowGroupIdenticalCards0) {
-        if(allowGroupIdenticalCards == allowGroupIdenticalCards0) {
+    public void setAllowGroupIdentical(boolean allowGroupIdentical0) {
+        if(allowGroupIdentical == allowGroupIdentical0) {
             return;
         }
             
-        allowGroupIdenticalCards = allowGroupIdenticalCards0;
+        allowGroupIdentical = allowGroupIdentical0;
         if (pool != null) {
             updateView(false, null);
         }

--- a/forge-gui-mobile/src/forge/itemmanager/ItemManager.java
+++ b/forge-gui-mobile/src/forge/itemmanager/ItemManager.java
@@ -66,6 +66,7 @@ public abstract class ItemManager<T extends InventoryItem> extends FContainer im
     private boolean showRanking = false;
     private boolean showPriceInfo = false;
     private boolean multiSelectMode = false;
+    private boolean allowGroupIdenticalCards = false;
     private FEventHandler selectionChangedHandler, itemActivateHandler;
     private ContextMenuBuilder<T> contextMenuBuilder;
     private ContextMenu contextMenu;
@@ -962,6 +963,21 @@ public abstract class ItemManager<T extends InventoryItem> extends FContainer im
         if(currentSort != null && currentSort.getConfig().getDef() == ColumnDef.PRICE)
             return true;
         return showPriceInfo;
+    }
+
+    public boolean getAllowGroupIdenticalCards() {
+        return allowGroupIdenticalCards;
+    }
+
+    public void setAllowGroupIdenticalCards(boolean allowGroupIdenticalCards0) {
+        if(allowGroupIdenticalCards == allowGroupIdenticalCards0) {
+            return;
+        }
+            
+        allowGroupIdenticalCards = allowGroupIdenticalCards0;
+        if (pool != null) {
+            updateView(false, null);
+        }
     }
 
     public void setWantUnique(boolean unique) {

--- a/forge-gui-mobile/src/forge/itemmanager/views/ImageView.java
+++ b/forge-gui-mobile/src/forge/itemmanager/views/ImageView.java
@@ -26,6 +26,7 @@ import forge.item.PaperCard;
 import forge.itemmanager.*;
 import forge.itemmanager.filters.ItemFilter;
 import forge.localinstance.properties.ForgePreferences;
+import forge.localinstance.properties.ForgePreferences.FPref;
 import forge.model.FModel;
 import forge.toolbox.*;
 import forge.util.ImageFetcher;
@@ -450,8 +451,12 @@ public class ImageView<T extends InventoryItem> extends ItemView<T> {
                     group = otherItems;
                 }
 
-                for (int i = 0; i < qty; i++) {
-                    group.add(new ItemInfo(item, group));
+                if (showQtyOnCard(item)) {
+                    group.add(new ItemInfo(item, group, qty));
+                } else {
+                    for (int i = 0; i < qty; i++) {
+                        group.add(new ItemInfo(item, group));
+                    }
                 }
             }
         }
@@ -464,6 +469,10 @@ public class ImageView<T extends InventoryItem> extends ItemView<T> {
         }
 
         updateLayout(true);
+    }
+
+    private boolean showQtyOnCard(T item) {
+        return item instanceof PaperCard && itemManager.getAllowGroupIdenticalCards() && FModel.getPreferences().getPrefBoolean(FPref.UI_GROUP_IDENTICAL_CARDS);
     }
 
     @Override
@@ -1094,7 +1103,7 @@ public class ImageView<T extends InventoryItem> extends ItemView<T> {
         private final T item;
         private Integer cardPrice;
         private final Group group;
-        private int index, draftRank;
+        private int index, draftRank, qty;
         private FSkinImage draftRankImage = FSkinImage.DRAFTRANK_D;
         private CardStackPosition pos;
         private boolean selected, deckSelectMode, showRanking;
@@ -1106,8 +1115,14 @@ public class ImageView<T extends InventoryItem> extends ItemView<T> {
         //private TextureRegion tr;
 
         private ItemInfo(T item0, Group group0) {
+            this(item0, group0, 1);
+        }
+
+        private ItemInfo(T item0, Group group0, int qty0) {
             item = item0;
             group = group0;
+            qty = qty0;
+
             if (item instanceof DeckProxy) {
                 deckSelectMode = true;
                 deckProxy = (DeckProxy) item;
@@ -1167,6 +1182,19 @@ public class ImageView<T extends InventoryItem> extends ItemView<T> {
             textRenderer.drawText(g, message, skinFont, Color.BLACK, x, y + ymod, w, fontHeight, y + ymod, fontHeight, false, Align.center, true);
         }
 
+        private void drawSubLabel(Graphics g, String message, Color bgColor, float x, float y, float w, float h) {
+            FSkinFont skinFont = FSkinFont.forHeight(w / 8);
+            float fontHeight = skinFont.getLineHeight();
+            float ymod = h * 0.8f - fontHeight / 2;
+            float oldAlpha = g.getfloatAlphaComposite();
+            float width = w / 4;
+            float start  = x + w - (width);
+            g.setAlphaComposite(0.6f);
+            g.fillRect(bgColor, start, y + ymod, width, fontHeight);
+            g.setAlphaComposite(oldAlpha);
+            textRenderer.drawText(g, message, skinFont, Color.BLACK, start, y + ymod, width, fontHeight, y + ymod, fontHeight, false, Align.center, true);
+        }
+
         @Override
         public void draw(Graphics g) {
             final float x = getLeft() - group.getScrollLeft();
@@ -1197,6 +1225,10 @@ public class ImageView<T extends InventoryItem> extends ItemView<T> {
                     float x2 = x + rankSize / 2;
                     g.drawImage(draftRankImage, x2, y2 + 1, rankSize, rankSize);
                     g.drawText(String.valueOf(draftRank), FSkinFont.forHeight(rankSize / 4), Color.WHITE, x, y, w, h, true, Align.center, true);
+                }
+
+                if (qty > 1) {
+                    drawSubLabel(g, "x" + qty, Color.TAN, x, y, w, h);
                 }
 
                 if (itemManager.showPriceInfo()) {

--- a/forge-gui-mobile/src/forge/itemmanager/views/ImageView.java
+++ b/forge-gui-mobile/src/forge/itemmanager/views/ImageView.java
@@ -472,7 +472,7 @@ public class ImageView<T extends InventoryItem> extends ItemView<T> {
     }
 
     private boolean showQtyOnCard(T item) {
-        return item instanceof PaperCard && itemManager.getAllowGroupIdenticalCards() && FModel.getPreferences().getPrefBoolean(FPref.UI_GROUP_IDENTICAL_CARDS);
+        return item instanceof PaperCard && itemManager.getAllowGroupIdentical() && FModel.getPreferences().getPrefBoolean(FPref.UI_GROUP_IDENTICAL_CARDS);
     }
 
     @Override

--- a/forge-gui/res/languages/en-US.properties
+++ b/forge-gui/res/languages/en-US.properties
@@ -1319,6 +1319,7 @@ lblSave=Save
 lblDontSave=Don''t Save
 lblPackN=Pack {0}
 lblPromptCardRequest=Enter card request
+lblGroupIdenticalCards=Group identical cards
 #Forge.java
 lblLoadingFonts=Loading fonts...
 lblLoadingCardTranslations=Loading card translations...

--- a/forge-gui/src/main/java/forge/localinstance/properties/ForgePreferences.java
+++ b/forge-gui/src/main/java/forge/localinstance/properties/ForgePreferences.java
@@ -194,6 +194,7 @@ public class ForgePreferences extends PreferencesStore<ForgePreferences.FPref> {
         UI_HAND_NO_OVERLAP("false"),
         UI_ZONE_TAB_NEW_COUNT("true"),
         UI_ENABLE_AI_PICKER("false"),
+        UI_GROUP_IDENTICAL_CARDS("false"),
 
         UI_ENABLE_SOUNDS ("true"),
         UI_ENABLE_MUSIC ("true"),

--- a/forge-gui/src/main/java/forge/localinstance/properties/PreferencesStore.java
+++ b/forge-gui/src/main/java/forge/localinstance/properties/PreferencesStore.java
@@ -111,6 +111,10 @@ public abstract class PreferencesStore<T extends Enum<T> & PreferencesStore.IPre
 
         return val;
     }
+    
+    public final void togglePrefBoolean(final T q0) {
+        setPref(q0, !getPrefBoolean(q0));
+    }
 
     public final int getPrefInt(final T fp0) {
         try {


### PR DESCRIPTION
Added an option to group identical cards in the mobile deck editor.

<img width="664" height="786" alt="image" src="https://github.com/user-attachments/assets/646f1a70-697d-456c-a92b-511cb231bd6d" />

<img width="2543" height="1333" alt="image" src="https://github.com/user-attachments/assets/311e1d33-cb51-42c3-93e6-97ecde365b87" />
