### PR TITLE
Restore game log for reconnecting network clients

### DIFF
--- a/forge-game/src/main/java/forge/game/GameLog.java
+++ b/forge-game/src/main/java/forge/game/GameLog.java
@@ -58,6 +58,11 @@ public class GameLog extends Observable implements Serializable {
         this.notifyObservers();
     }
 
+    /** All entries in chronological (insertion) order — note {@link #getLogEntries} returns newest-first. */
+    public List<GameLogEntry> getAllEntries() {
+        return new ArrayList<>(log);
+    }
+
     /**
      * Gets the log entries below a certain level as a list.
      *

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/FServerManager.java
@@ -3,6 +3,10 @@ package forge.gamemodes.net.server;
 import forge.ai.LobbyPlayerAi;
 import forge.ai.PlayerControllerAi;
 import forge.game.Game;
+import forge.game.GameLogEntry;
+import forge.game.GameView;
+import forge.game.event.GameEvent;
+import forge.game.event.GameEventAddLog;
 import forge.game.player.Player;
 import forge.gamemodes.match.HostedMatch;
 import forge.gamemodes.match.LobbySlot;
@@ -841,6 +845,19 @@ public final class FServerManager implements IHasForgeLog {
         netGui.updateGameView();
         netGui.openView(new forge.trackable.TrackableCollection<>(netGui.getLocalPlayers()));
         netLog.info("[Reconnect] Sent game state and openView to slot {}", slotIndex);
+
+        // Replay the host's log entries to rebuild the client's log on re-connect
+        final GameView gameView = netGui.getGameView();
+        if (gameView != null && gameView.getGameLog() != null) {
+            final List<GameEvent> logEvents = new ArrayList<>();
+            for (final GameLogEntry entry : gameView.getGameLog().getAllEntries()) {
+                logEvents.add(new GameEventAddLog(entry.type(), entry.message(), entry.sourceCard()));
+            }
+            if (!logEvents.isEmpty()) {
+                netGui.replayEvents(logEvents);
+                netLog.info("[Reconnect] Replayed {} game log entries for slot {} ({})", logEvents.size(), slotIndex, client.getUsername());
+            }
+        }
 
         // Replay current prompt
         final PlayerControllerHuman pch = findRemoteController(slotIndex);

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/RemoteClientGuiGame.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/RemoteClientGuiGame.java
@@ -28,6 +28,7 @@ import forge.model.FModel;
 import forge.player.PlayerZoneUpdate;
 import forge.player.PlayerZoneUpdates;
 import forge.trackable.TrackableCollection;
+import forge.trackable.Tracker;
 import forge.util.FSerializableFunction;
 import forge.util.ITriggerEvent;
 
@@ -583,6 +584,17 @@ public class RemoteClientGuiGame extends NetworkGuiGame implements IHasForgeLog 
             forge.trackable.Tracker tracker = gameView != null ? gameView.getTracker() : null;
             sender.send(ProtocolMethod.applyDelta, DeltaPacket.eventsOnly(TrackableSerializer.wrapEvents(events, tracker)));
         }
+    }
+
+    /**
+     * Send events as a standalone applyDelta without running {@link DeltaSyncManager#collectDeltas},
+     * which is game-thread-only and would also redundantly re-send the full graph right after a reconnect's sendFullState.
+     */
+    public void replayEvents(final List<GameEvent> events) {
+        if (paused) { return; }
+        final GameView gameView = getGameView();
+        final Tracker tracker = gameView != null ? gameView.getTracker() : null;
+        sender.send(ProtocolMethod.applyDelta, DeltaPacket.eventsOnly(TrackableSerializer.wrapEvents(events, tracker)));
     }
 
     @Override


### PR DESCRIPTION
Addresses Card-Forge/forge#9861 item: _"Fix Make GameLog transient — clients build from forwarded events <!-- -->#9802 regression - reconnected players will not see the gamelog but did prior to this change"._

## Summary

`GameView.gameLog` is transient, so a reconnecting network client starts with an empty log and never sees the history that fired before it rejoined — a regression introduced by <!-- -->#9802, which made clients build their log from forwarded events rather than from synced state.

On reconnect, the host reconstructs its accumulated log entries as `GameEventAddLog` events and replays them to that client only, rebuilding its log through the existing formatter path. The whole batch ships as a single events-only `applyDelta` packet rather than one message per entry.

This replay runs right after the reconnect's `sendFullState`, which has already synced the entire object graph — and the log entries only reference cards and players already in that graph. So it deliberately bypasses `collectDeltas`: there's no new trackable state to diff, and running it would just redundantly re-serialize the whole graph (it's also game-thread-only, whereas this stays a plain serialize-and-send).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)