### PR TITLE
Fix ability-menu crash and positioning for floating-zone cards

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
@@ -161,6 +161,7 @@ public final class CMatchUI
     private boolean allHands;
     private boolean showOverlay = true;
     private JPopupMenu openAbilityMenu;
+    private CardPanel lastClickedCardPanel;
 
     private IVDoc<? extends ICDoc> selectedDocBeforeCombat;
 
@@ -765,6 +766,10 @@ public final class CMatchUI
         return panels;
     }
 
+    public void setLastClickedCardPanel(final CardPanel panel) {
+        lastClickedCardPanel = panel;
+    }
+
     /**
      * Find the card panel belonging to a card, bringing up the corresponding
      * window or tab if necessary.
@@ -1012,7 +1017,10 @@ public final class CMatchUI
             // TODO: do we need a user setting for the scrollCount?
             MenuScroller.setScrollerFor(menu, 8, 125, 3, 1);
 
-            final CardPanel panel = findCardPanel(hostCard);
+            // Prefer the panel the user clicked so the menu opens there if the card shows in multiple windows
+            final CardPanel panel = lastClickedCardPanel != null && lastClickedCardPanel.isShowing()
+                    && hostCard.equals(lastClickedCardPanel.getCard())
+                    ? lastClickedCardPanel : findCardPanel(hostCard);
             final Component menuParent;
             final int x, y;
             if (panel == null || !panel.isShowing()) {

--- a/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
@@ -1015,8 +1015,8 @@ public final class CMatchUI
             final CardPanel panel = findCardPanel(hostCard);
             final Component menuParent;
             final int x, y;
-            if (panel == null) {
-                // Fall back to showing in VPrompt if no panel can be found
+            if (panel == null || !panel.isShowing()) {
+                // Fall back to VPrompt when there's no on-screen anchor — panel missing, or hidden (e.g. a closed Sideboard window)
                 menuParent = getCPrompt().getView().getTarMessage();
                 x = 0;
                 y = 0;

--- a/forge-gui-desktop/src/main/java/forge/view/arcane/CardPanelContainer.java
+++ b/forge-gui-desktop/src/main/java/forge/view/arcane/CardPanelContainer.java
@@ -159,6 +159,7 @@ public abstract class CardPanelContainer extends SkinnedPanel {
 
                 final CardPanel panel = getCardPanel(evt.getX(), evt.getY());
                 if (panel != null && mouseDownPanel == panel) {
+                    getMatchUI().setLastClickedCardPanel(panel);
                     if (SwingUtilities.isLeftMouseButton(evt)) {
                         mouseLeftClicked(panel, evt);
                     } else if (SwingUtilities.isRightMouseButton(evt)) {


### PR DESCRIPTION
## Bug report

Crash when casting a modal dual-faced card (e.g. Birgi) from the "Playable Zone Cards" window via a Wish, with the Sideboard window closed: `IllegalComponentStateException: component must be showing on the screen to determine its location`.

## Root cause

Cards in the "Playable Zone Cards" window report their real zone (Sideboard), so the face-selection popup was anchored to the card's home-zone panel. If that window was never opened the panel doesn't exist and the code already falls back safely; but once it had been opened then closed, the panel still existed yet was off-screen, so `JPopupMenu.show()` threw.

## Fix

- **Guard the anchor** — `getAbilityToPlay` now treats a non-showing panel like a missing one: the fallback condition becomes `panel == null || !panel.isShowing()`, so a hidden home-zone panel routes to the prompt area instead of into `JPopupMenu.show()`. This alone stops the crash for both the opened-then-closed floating window and docked-then-closed tab cases.
- **Anchor to the clicked panel** — `CardPanelContainer.mouseReleased` (the single dispatch point for every card area) records the clicked panel on `CMatchUI`, and `getAbilityToPlay` prefers it (when it's for the same card and on screen) over the zone-based `findCardPanel` lookup. The menu now opens in the window the card was actually clicked from, fixing the case where a card shown in multiple windows (e.g. both the Playable Zone Cards and Sideboard windows) opened its menu over the wrong one.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)