### PR TITLE
Show name of waiting opponent in offline prompt

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
@@ -490,9 +490,9 @@ public abstract class AbstractGuiGame implements IGuiGame, IMayViewCards {
                     checkAwaitNextInputTimer();
                     synchronized (awaitNextInputTimer) {
                         if (awaitNextInputTask != null) {
-                            updatePromptForAwait(getCurrentPlayer());
+                            String waitingForName = updatePromptForAwait(getCurrentPlayer());
                             if (GuiBase.isNetPlay(AbstractGuiGame.this)) {
-                                showWaitingTimer(getCurrentPlayer(), findWaitingForPlayerName(getCurrentPlayer()));
+                                showWaitingTimer(getCurrentPlayer(), waitingForName);
                             }
                             awaitNextInputTask = null;
                         }
@@ -512,10 +512,13 @@ public abstract class AbstractGuiGame implements IGuiGame, IMayViewCards {
         }
     }
 
-    protected final void updatePromptForAwait(final PlayerView playerView) {
+    protected final String updatePromptForAwait(final PlayerView playerView) {
         // Append "Waiting for opponent..." below the yield prompt so the user keeps the
         // cancel-yield UI during opponent turns instead of losing it to the await prompt.
-        String waiting = Localizer.getInstance().getMessage("lblWaitingForOpponent");
+        String waitingForName = findWaitingForPlayerName(playerView);
+        String waiting = waitingForName != null
+                ? Localizer.getInstance().getMessage("lblWaitingForPlayer", waitingForName)
+                : Localizer.getInstance().getMessage("lblWaitingForOpponent");
         String yieldMsg = currentYieldMessage();
         if (yieldMsg != null) {
             cancelAwaitNextInput();
@@ -525,6 +528,7 @@ public abstract class AbstractGuiGame implements IGuiGame, IMayViewCards {
             showPromptMessage(playerView, waiting);
             updateButtons(playerView, false, false, false);
         }
+        return waitingForName;
     }
 
     private String currentYieldMessage() {


### PR DESCRIPTION
User request on Discord:

In offline games, the await prompt only ever showed a generic "Waiting for opponent...", giving no indication of which player the game was waiting on. The logic that resolves the specific waiting player (`findWaitingForPlayerName`) already existed but was only used by the network path, so offline games never benefited from it.

This makes `updatePromptForAwait` resolve the waiting player itself and show "Waiting for [name]..." when an opponent can be identified, falling back to the generic message otherwise. It now returns the resolved name, and the network call site reuses that return instead of computing it a second time.

The elapsed timer remains gated behind network play — so a network game still shows e.g. "Waiting for [name]... (12s)" — while offline play shows the name only, with no ticking timer.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)