### PR TITLE
Update craig_boone_novac_guard.txt

### DIFF
--- a/forge-gui/res/cardsfolder/c/craig_boone_novac_guard.txt
+++ b/forge-gui/res/cardsfolder/c/craig_boone_novac_guard.txt
@@ -6,8 +6,9 @@ K:Reach
 K:Lifelink
 T:Mode$ AttackersDeclared | Execute$ TrigPutCounter | ValidAttackers$ Creature | ValidAttackersAmount$ GE2 | TriggerZones$ Battlefield | AttackingPlayer$ You | TriggerDescription$ One for My Baby — Whenever you attack with two or more creatures, put two quest counters on CARDNAME. When you do, NICKNAME deals damage equal to the number of quest counters on it to up to one target creature unless that creature's controller has NICKNAME deal that much damage to them.
 SVar:TrigPutCounter:DB$ PutCounter | CounterType$ QUEST | CounterNum$ 2 | RememberPut$ True | SubAbility$ DBImmediateTrigger
-SVar:DBImmediateTrigger:DB$ ImmediateTrigger | ConditionDefined$ Remembered | ConditionPresent$ Card | Execute$ TrigDealDamage | SpellDescription$ When you do, NICKNAME deals damage equal to the number of quest counters on it to up to one target creature unless that creature's controller has NICKNAME deal that much damage to them.
+SVar:DBImmediateTrigger:DB$ ImmediateTrigger | ConditionDefined$ Remembered | ConditionPresent$ Card | Execute$ TrigDealDamage | SubAbility$ DBCleanup | SpellDescription$ When you do, NICKNAME deals damage equal to the number of quest counters on it to up to one target creature unless that creature's controller has NICKNAME deal that much damage to them.
 SVar:TrigDealDamage:DB$ DealDamage | ValidTgts$ Creature | TgtPrompt$ Select up to one target creature | TargetMin$ 0 | TargetMax$ 1 | NumDmg$ X | UnlessCost$ DamageYou<X> | UnlessPayer$ TargetedController
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Count$CardCounters.QUEST
 DeckHas:Ability$LifeGain|Counters
 SVar:AICounterOverrideQUEST:Positive


### PR DESCRIPTION
Noticed Craig Boone was remembering the immediate trigger for longer than it should. Fix herein was tested to satisfaction.

<img width="1506" height="742" alt="image" src="https://github.com/user-attachments/assets/9be48d5b-3f41-47eb-b60c-67f98fe6baf2" />
