### PR TITLE
Fix StackOverflowError from unbounded texture load callback chain

### DIFF
--- a/forge-gui-mobile/src/forge/assets/Assets.java
+++ b/forge-gui-mobile/src/forge/assets/Assets.java
@@ -564,14 +564,10 @@ public class Assets implements Disposable {
                     parameter = (AssetLoaderParameters<T>) getTextureFilter();
                 }
 
-                final AssetLoaderParameters.LoadedCallback prevCallback = parameter.loadedCallback;
-                parameter.loadedCallback = (assetManager, fileName1, type1) -> {
-                    if (prevCallback != null) {
-                        prevCallback.finishedLoading(assetManager, fileName1, type1);
-                    }
-
-                    currentMemory = calculateTextureSize(assetManager, fileName1, type1);
-                };
+                // getTextureFilter() returns a shared instance; replace rather than wrap, or
+                // callbacks accumulate every load and eventually overflow the stack
+                parameter.loadedCallback = (assetManager, fileName1, type1) ->
+                        currentMemory = calculateTextureSize(assetManager, fileName1, type1);
             }
             super.load(fileName, type, parameter);
         }


### PR DESCRIPTION
## Summary

In the libgdx UI (Adventure), after a long play session the game would show a white flash, stop loading card art, and eventually crash. A restart cleared it. The crash is a `StackOverflowError` thrown from deep inside texture loading:

```
com.badlogic.gdx.utils.GdxRuntimeException: java.lang.StackOverflowError
	at com.badlogic.gdx.assets.AssetManager.handleTaskError(AssetManager.java:629)
	at com.badlogic.gdx.assets.AssetManager.update(AssetManager.java:426)
	at com.badlogic.gdx.assets.AssetManager.finishLoadingAsset(AssetManager.java:483)
	at forge.assets.Assets$MemoryTrackingAssetManager.finishLoadingAsset(Assets.java:590)
	at forge.assets.Assets.getTexture(Assets.java:294)
	... (card render frames)
Caused by: java.lang.StackOverflowError
	at forge.assets.Assets$MemoryTrackingAssetManager.lambda$load$0(Assets.java:570)
	at forge.assets.Assets$MemoryTrackingAssetManager.lambda$load$0(Assets.java:570)
	... (repeated thousands of times)
```

**Root cause:** `MemoryTrackingAssetManager.load()` installed its memory-tracking callback by wrapping the existing `parameter.loadedCallback` in a new lambda that first invoked the previous one. Because `getTextureFilter()` returns a single shared `TextureParameter` instance that is reused on nearly every texture load, each load nested the callback one level deeper instead of replacing it. The chain grew by one per load over the whole session; once enough textures had loaded, invoking the chain recursed deep enough to overflow the stack — which is the long run of identical `lambda$load$0` frames in the trace. The white flash and missing art are the texture load failing partway, and a restart "fixes" it only because it resets the chain to zero.

**Fix:** Install a fresh callback on each load instead of wrapping the existing one, so the callbacks can never accumulate into a chain. This is a one-level replacement rather than an ever-growing nesting.

**Why it's safe:** The callback only feeds `currentMemory`, which is read solely by `getMemoryInMegabytes()` for the FPS/debug overlay — so dropping the chain changes no gameplay or rendering behavior, and `currentMemory` is still updated on every load. The old code chained in order to preserve any previously installed callback, but no caller in the codebase ever sets `loadedCallback`; the only thing that slot ever held was this manager's own wrapper, so nothing external is lost. The `parameter == null` → `getTextureFilter()` fallback that controls texture filtering is untouched.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)