### PR TITLE
Preserve caller-supplied texture load callbacks

### DIFF
--- a/forge-gui-mobile/src/forge/assets/Assets.java
+++ b/forge-gui-mobile/src/forge/assets/Assets.java
@@ -563,11 +563,15 @@ public class Assets implements Disposable {
                 if (parameter == null) {
                     parameter = (AssetLoaderParameters<T>) getTextureFilter();
                 }
-
-                // getTextureFilter() returns a shared instance; replace rather than wrap, or
-                // callbacks accumulate every load and eventually overflow the stack
-                parameter.loadedCallback = (assetManager, fileName1, type1) ->
-                        currentMemory = calculateTextureSize(assetManager, fileName1, type1);
+                // shared filter holds our own prior wrapper; chaining overflows the stack — replace it, but keep a fresh caller's callback (libgdx refcount restore on context loss)
+                boolean sharedFilter = parameter == (Object) textureParameter;
+                final AssetLoaderParameters.LoadedCallback prevCallback = sharedFilter ? null : parameter.loadedCallback;
+                parameter.loadedCallback = (assetManager, fileName1, type1) -> {
+                    if (prevCallback != null) {
+                        prevCallback.finishedLoading(assetManager, fileName1, type1);
+                    }
+                    currentMemory = calculateTextureSize(assetManager, fileName1, type1);
+                };
             }
             super.load(fileName, type, parameter);
         }


### PR DESCRIPTION
## Summary

Addresses a potential regression from #10887, identified by @Hanmac in https://github.com/Card-Forge/forge/pull/10887#issuecomment-4633207387.

That PR replaced `parameter.loadedCallback` unconditionally to stop callbacks chaining into a `StackOverflowError`. But libgdx's `Texture.invalidateAllTextures` (GL context loss / Android surface recreation) supplies its own callback that restores each texture's reference count, and Forge wires its `AssetManager` in via `Texture.setAssetManager` — so that callback was being dropped, leaving recovered textures at refcount 0.

The accumulation only ever happened on the single shared `TextureParameter` from `getTextureFilter()`. So this replaces the callback only on that shared instance, and preserves it on any fresh caller-supplied instance (keeping libgdx's refcount restore).

## Ensuring safety

The original analysis was scoped to Forge's own callers and missed the libgdx-internal one, so this time every texture `load` call path was enumerated explicitly. The shared instance is the only one carrying a self-accumulating wrapper, and a module-wide search confirmed no field-held or reused `TextureParameter` could defeat the check. The common card-art path behaves identically to #10887, and the libgdx refcount-restore callback was traced to confirm it now survives and runs once.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)