### PR TITLE
Fix crash on game end from unfillable layout gap

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/gui/framework/SRearrangingUtil.java
+++ b/forge-gui-desktop/src/main/java/forge/gui/framework/SRearrangingUtil.java
@@ -317,7 +317,7 @@ public final class SRearrangingUtil {
         // Falls back to original priority order if none qualify.
         if (tryFillGap(true)) { return; }
         if (tryFillGap(false)) { return; }
-        throw new UnsupportedOperationException("Gap was not filled.");
+        // An unfillable gap is cosmetic and the caller removes the cell anyway, so fall through rather than throw
     }
 
     private static boolean containsField(final List<DragCell> cells) {


### PR DESCRIPTION
Discord user reported `UnsupportedOperationException: Gap was not filled.` thrown from `SRearrangingUtil.fillGap()` via `FloatingZone.closeAll()` -> `CMatchUI.finishGame()` at the end of a game (triggered by docking AI commanders'' command zones). Because `closeAll()` is the first thing `finishGame()` does, the throw aborted it before the win/lose screen was shown, leaving the match UI stuck.

`fillGap()` tears down docked zone cells one at a time, and the intermediate layout can leave a gap the grow-a-neighbor algorithm can''t cover. Gap-filling is purely cosmetic and the caller removes the cell regardless, so this drops the fatal `throw` and lets `fillGap()` fall through instead.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)