### PR TITLE
Make phase label buttons more button-y

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/toolbox/special/PhaseLabel.java
+++ b/forge-gui-desktop/src/main/java/forge/toolbox/special/PhaseLabel.java
@@ -1,18 +1,23 @@
 package forge.toolbox.special;
 
 import java.awt.Color;
+import java.awt.Cursor;
 import java.awt.Dimension;
+import java.awt.GradientPaint;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.geom.RoundRectangle2D;
 
 import javax.swing.JLabel;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
+import javax.swing.Timer;
 
 import forge.game.phase.PhaseType;
+import forge.gui.MouseUtil;
 import forge.toolbox.FSkin;
 
 /**
@@ -30,6 +35,8 @@ public class PhaseLabel extends JLabel {
     private boolean active = false;
     private boolean hover = false;
     private boolean yieldMarked = false;
+    private boolean pressed = false;
+    private final Timer pressTimer;
     private Runnable onToggled;
     private Runnable onRightClick;
 
@@ -48,6 +55,12 @@ public class PhaseLabel extends JLabel {
         this.setHorizontalTextPosition(SwingConstants.CENTER);
         this.setHorizontalAlignment(SwingConstants.CENTER);
 
+        this.pressTimer = new Timer(90, e -> {
+            this.pressed = false;
+            this.repaintOnlyThisLabel();
+        });
+        this.pressTimer.setRepeats(false);
+
         this.addMouseListener(new MouseAdapter() {
             @Override
             public void mousePressed(final MouseEvent e) {
@@ -57,21 +70,26 @@ public class PhaseLabel extends JLabel {
                     }
                     return;
                 }
+                PhaseLabel.this.pressed = true;
+                PhaseLabel.this.pressTimer.restart();
                 PhaseLabel.this.enabled = !PhaseLabel.this.enabled;
                 if (PhaseLabel.this.onToggled != null) {
                     PhaseLabel.this.onToggled.run();
                 }
+                PhaseLabel.this.repaintOnlyThisLabel();
             }
 
             @Override
             public void mouseEntered(final MouseEvent e) {
                 PhaseLabel.this.hover = true;
+                MouseUtil.setCursor(Cursor.HAND_CURSOR);
                 PhaseLabel.this.repaintOnlyThisLabel();
             }
 
             @Override
             public void mouseExited(final MouseEvent e) {
                 PhaseLabel.this.hover = false;
+                MouseUtil.resetCursor();
                 PhaseLabel.this.repaintOnlyThisLabel();
             }
         });
@@ -177,10 +195,50 @@ public class PhaseLabel extends JLabel {
             g.fillRoundRect(1, 1, w - 2, h - 2, 5, 5);
         }
 
+        // raised = stop; hover previews the toggle, holding dips to pressed for click feedback
+        final boolean raised = !this.pressed && (this.hover ? !this.enabled : this.enabled);
+        drawBevel(g, w, h, raised);
+        if (this.pressed) {
+            drawPressOverlay(g, w, h);
+        }
+
         if (this.yieldMarked) {
             drawChevron(g, w, h);
         } else {
             super.paintComponent(g);
+        }
+    }
+
+    /** Darkens the chip briefly while it is pressed, so a click reads as a physical push before the new state settles. */
+    private void drawPressOverlay(final Graphics g, final int w, final int h) {
+        final Graphics2D g2 = (Graphics2D) g.create();
+        try {
+            g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            g2.setColor(new Color(0, 0, 0, 55));
+            g2.fill(new RoundRectangle2D.Float(1, 1, w - 2, h - 2, 5, 5));
+        } finally {
+            g2.dispose();
+        }
+    }
+
+    /** Shades the filled chip into a raised or pressed-in button without altering its skin colour. */
+    private void drawBevel(final Graphics g, final int w, final int h, final boolean raised) {
+        final Graphics2D g2 = (Graphics2D) g.create();
+        try {
+            g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            final RoundRectangle2D rr = new RoundRectangle2D.Float(1, 1, w - 2, h - 2, 5, 5);
+            g2.clip(rr);
+            final Color top = raised ? new Color(255, 255, 255, 42) : new Color(0, 0, 0, 50);
+            final Color bottom = raised ? new Color(0, 0, 0, 38) : new Color(255, 255, 255, 18);
+            g2.setPaint(new GradientPaint(0, 1, top, 0, h - 1, bottom));
+            g2.fill(rr);
+
+            // Soft top rim: a bright top-edge highlight — the light-based "raised" cue for a dark panel
+            final int rimAlpha = raised ? 85 : 20;
+            g2.setPaint(new GradientPaint(0, 1, new Color(255, 255, 255, rimAlpha), 0, 3, new Color(255, 255, 255, 0)));
+            g2.fill(rr);
+        } finally {
+            g2.dispose();
         }
     }
 


### PR DESCRIPTION
Many users don't realise phase labels are buttons rather than baked-in UI elements, hence constant bug reports about phases not being activated.

This PR makes a few subtle changes to make the design less flat and try and better signal their button-y nature. 

- The default cursor changes to a hand pointer when hovered over a phase label
- Adds a light bevel fill, gradient, and highlight edge to signal enabled/disabled button state
- Hovering over a button previews the changed state

Skin safe and makes no changes to color scheme.

This isn't the whole solution but hopefully it helps a bit. 

 | Before | After | 
  |:------:|:-----:|
  | <img width="125" alt="Before" src="https://github.com/user-attachments/assets/1e3ac528-0381-4e2b-b0cb-e3a6c8a0c438" /> | <img width="125" alt="After" src="https://github.com/user-attachments/assets/2e706d86-29b8-456a-a31e-45ff83369862" /> |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)