### PR TITLE
Desktop help menu tidy / log export

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/menus/HelpMenu.java
+++ b/forge-gui-desktop/src/main/java/forge/menus/HelpMenu.java
@@ -16,6 +16,7 @@ import forge.toolbox.FOptionPane;
 import forge.util.BuildInfo;
 import forge.util.FileUtil;
 import forge.util.Localizer;
+import forge.util.LogExporter;
 import forge.view.KeyboardShortcutsDialog;
 
 import static forge.localinstance.properties.ForgeConstants.GITHUB_FORGE_URL;
@@ -28,8 +29,11 @@ public final class HelpMenu {
         JMenu menu = new JMenu(localizer.getMessage("lblHelp"));
         menu.setMnemonic(KeyEvent.VK_H);
         menu.add(getMenu_GettingStarted());
-        menu.add(getMenu_Troubleshooting());
         menu.add(getMenuItem_KeyboardShortcuts());
+        menu.addSeparator();
+        menu.add(getMenuItem_OpenLogFile());
+        menu.add(getMenuItem_OpenLogFileDirectory());
+        menu.add(getMenuItem_ExportLogs());
         menu.addSeparator();
         menu.add(getMenuItem_ReleaseNotes());
         menu.add(getMenuItem_License());
@@ -52,13 +56,6 @@ public final class HelpMenu {
                     "Version : " + BuildInfo.getVersionString(),
                     localizer.getMessage("lblAboutForge"));
         };
-    }
-
-    private static JMenu getMenu_Troubleshooting() {
-        final Localizer localizer = Localizer.getInstance();
-        JMenu mnu = new JMenu(localizer.getMessage("lblTroubleshooting"));
-        mnu.add(getMenuItem_OpenLogFile());
-        return mnu;
     }
 
     private static JMenu getMenu_GettingStarted() {
@@ -89,6 +86,38 @@ public final class HelpMenu {
         JMenuItem menuItem = new JMenuItem(localizer.getMessage("lblOpenLogFile"));
         menuItem.addActionListener(getOpenFileAction(ExceptionHandler.getActiveLogFile()));
         return menuItem;
+    }
+
+    private static JMenuItem getMenuItem_OpenLogFileDirectory() {
+        final Localizer localizer = Localizer.getInstance();
+        JMenuItem menuItem = new JMenuItem(localizer.getMessage("lblOpenLogFileDirectory"));
+        menuItem.addActionListener(getOpenFileAction(new File(ForgeConstants.LOG_FILE).getParentFile()));
+        return menuItem;
+    }
+
+    private static JMenuItem getMenuItem_ExportLogs() {
+        final Localizer localizer = Localizer.getInstance();
+        JMenuItem menuItem = new JMenuItem(localizer.getMessage("lblExportLogs"));
+        menuItem.addActionListener(e -> exportLogs());
+        return menuItem;
+    }
+
+    private static void exportLogs() {
+        final Localizer localizer = Localizer.getInstance();
+        File downloads = new File(System.getProperty("user.home"), "Downloads");
+        if (!downloads.isDirectory()) {
+            downloads = new File(System.getProperty("user.home"));
+        }
+        try {
+            File zipFile = LogExporter.exportLogs(downloads);
+            if (zipFile == null) {
+                FOptionPane.showMessageDialog(localizer.getMessage("lblNoLogFilesFound"), localizer.getMessage("lblExportLogs"));
+                return;
+            }
+            FOptionPane.showMessageDialog(localizer.getMessage("lblSuccess") + "\n" + zipFile.getAbsolutePath(), localizer.getMessage("lblExportLogs"));
+        } catch (IOException ex) {
+            FOptionPane.showMessageDialog(ex.toString(), localizer.getMessage("lblError"));
+        }
     }
 
     private static JMenuItem getMenuItem_License() {

--- a/forge-gui-desktop/src/main/java/forge/screens/home/online/OnlineMenu.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/online/OnlineMenu.java
@@ -10,6 +10,7 @@ import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JSeparator;
 
+import forge.gamemodes.net.NetworkLogConfig;
 import forge.gui.FDraftOverlay;
 import forge.gui.FNetOverlay;
 import forge.localinstance.properties.ForgeConstants;
@@ -25,6 +26,8 @@ public final class OnlineMenu {
         menu.setMnemonic(KeyEvent.VK_O);
         menu.add(getMenuItem_HostGame());
         menu.add(getMenuItem_JoinGame());
+        menu.add(new JSeparator());
+        menu.add(getMenuItem_OpenNetworkLog());
         menu.add(getMenuItem_OpenNetworkLogs());
         menu.add(new JSeparator());
         menu.add(chatItem);
@@ -68,6 +71,12 @@ public final class OnlineMenu {
         return menuItem;
     }
 
+    private static JMenuItem getMenuItem_OpenNetworkLog() {
+        JMenuItem menuItem = new JMenuItem(Localizer.getInstance().getMessage("lblOpenNetworkLog"));
+        menuItem.addActionListener(e -> openInOS(NetworkLogConfig.getCurrentLogFile()));
+        return menuItem;
+    }
+
     private static JMenuItem getMenuItem_OpenNetworkLogs() {
         JMenuItem menuItem = new JMenuItem(Localizer.getInstance().getMessage("lblOpenNetworkLogs"));
         menuItem.addActionListener(e -> {
@@ -75,16 +84,23 @@ public final class OnlineMenu {
             if (!dir.exists()) {
                 dir.mkdirs();
             }
-            try {
-                if (System.getProperty("os.name").toLowerCase().contains("windows")) {
-                    Runtime.getRuntime().exec("rundll32 url.dll,FileProtocolHandler " + dir.getCanonicalPath());
-                } else {
-                    Desktop.getDesktop().open(dir);
-                }
-            } catch (IOException ex) {
-                ex.printStackTrace();
-            }
+            openInOS(dir);
         });
         return menuItem;
+    }
+
+    private static void openInOS(File file) {
+        if (file == null) {
+            return;
+        }
+        try {
+            if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+                Runtime.getRuntime().exec("rundll32 url.dll,FileProtocolHandler " + file.getCanonicalPath());
+            } else {
+                Desktop.getDesktop().open(file);
+            }
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        }
     }
 }

--- a/forge-gui-mobile/src/forge/screens/settings/FilesPage.java
+++ b/forge-gui-mobile/src/forge/screens/settings/FilesPage.java
@@ -2,10 +2,7 @@ package forge.screens.settings;
 
 import java.io.File;
 import java.io.IOException;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -37,6 +34,7 @@ import forge.toolbox.FList;
 import forge.toolbox.FOptionPane;
 import forge.toolbox.GuiChoose;
 import forge.util.FileUtil;
+import forge.util.LogExporter;
 import org.apache.commons.lang3.tuple.Pair;
 
 public class FilesPage extends TabPage<SettingsScreen> {
@@ -95,22 +93,7 @@ public class FilesPage extends TabPage<SettingsScreen> {
         lstItems.addItem(new Extra(Forge.getLocalizer().getMessage("lblExportLogs"), Forge.getLocalizer().getMessage("lblExportLogsDescription")) {
             @Override
             public void select() {
-                List<File> files = new ArrayList<>();
-                File userDir = new File(ForgeProfileProperties.getUserDir());
-                if (userDir.isDirectory()) {
-                    File[] forgeLogs = userDir.listFiles((d, n) -> n.startsWith("forge") && n.endsWith(".log"));
-                    if (forgeLogs != null) {
-                        Collections.addAll(files, forgeLogs);
-                    }
-                }
-                File netDir = new File(ForgeConstants.NETWORK_LOGS_DIR);
-                if (netDir.isDirectory()) {
-                    File[] netLogs = netDir.listFiles((d, n) -> n.startsWith("network-debug-") && n.endsWith(".log"));
-                    if (netLogs != null) {
-                        Collections.addAll(files, netLogs);
-                    }
-                }
-                exportLogs(files);
+                exportLogs();
             }
         }, 0);
         //Auditer
@@ -257,7 +240,7 @@ public class FilesPage extends TabPage<SettingsScreen> {
         lstItems.setBounds(0, 0, width, height);
     }
 
-    private void exportLogs(List<File> files) {
+    private void exportLogs() {
         if (Forge.getDeviceAdapter().needFileAccess()) {
             Forge.getDeviceAdapter().requestFileAcces();
             return;
@@ -265,14 +248,12 @@ public class FilesPage extends TabPage<SettingsScreen> {
         final String dialogTitle = Forge.getLocalizer().getMessage("lblExportLogs");
         FThreads.invokeInEdtLater(() -> LoadingOverlay.show(Forge.getLocalizer().getMessage("lblExporting"), true, () -> {
             try {
-                if (files.isEmpty()) {
+                File downloads = new FileHandle(Forge.getDeviceAdapter().getDownloadsDir()).file();
+                File zipFile = LogExporter.exportLogs(downloads);
+                if (zipFile == null) {
                     FOptionPane.showMessageDialog(Forge.getLocalizer().getMessage("lblNoLogFilesFound"), dialogTitle, FOptionPane.INFORMATION_ICON);
                     return;
                 }
-                String stamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"));
-                File downloads = new FileHandle(Forge.getDeviceAdapter().getDownloadsDir()).file();
-                File zipFile = new File(downloads, "forge-logs-" + stamp + ".zip");
-                ZipUtil.zipFiles(files, zipFile);
                 FOptionPane.showMessageDialog(Forge.getLocalizer().getMessage("lblSuccess") + "\n" + zipFile.getAbsolutePath(), dialogTitle, FOptionPane.INFORMATION_ICON);
             } catch (IOException e) {
                 FOptionPane.showMessageDialog(e.toString(), Forge.getLocalizer().getMessage("lblError"), FOptionPane.ERROR_ICON);

--- a/forge-gui/res/languages/de-DE.properties
+++ b/forge-gui/res/languages/de-DE.properties
@@ -383,7 +383,6 @@ lblExitFullScreen=Vollbild verlassen
 #HelpMenu.java
 lblHelp=Hilfe
 lblAboutForge=Über Forge
-lblTroubleshooting=Fehlerbehebung
 lblArticles=Artikel
 lblGettingStarted=Starthilfe
 lblHowtoPlay=Wie man spielt

--- a/forge-gui/res/languages/en-US.properties
+++ b/forge-gui/res/languages/en-US.properties
@@ -440,11 +440,11 @@ lblExitFullScreen=Exit Full Screen
 #HelpMenu.java
 lblHelp=Help
 lblAboutForge=About Forge
-lblTroubleshooting=Troubleshooting
 lblArticles=Articles
 lblGettingStarted=Getting Started
 lblHowtoPlay=How to Play
-lblOpenLogFile=Open Log File
+lblOpenLogFile=Open Game Log
+lblOpenLogFileDirectory=Open Game Log Directory
 lblForgeLicense=Forge License
 lblReleaseNotes=Release Notes
 #GameMenu.java
@@ -3014,7 +3014,8 @@ lblHotkeySelectHintMin=Ctrl+0 auto-fills by order to reach minimum
 #OnlineMenu.java
 lblOnline=Online
 lblShowChatPanel=Show Chat Panel
-lblOpenNetworkLogs=Open Network Logs
+lblOpenNetworkLog=Open Network Log
+lblOpenNetworkLogs=Open Network Log Directory
 lblDisconnect=Disconnect
 lblShowDraftPanel=Show Draft Panel
 #VLobby.java (network draft/sealed)

--- a/forge-gui/res/languages/es-ES.properties
+++ b/forge-gui/res/languages/es-ES.properties
@@ -360,7 +360,6 @@ lblExitFullScreen=Salir de pantalla completa
 #HelpMenu.java
 lblHelp=Ayuda
 lblAboutForge=Sobre Forge
-lblTroubleshooting=Solución de problemas
 lblArticles=Artículos (Inglés)
 lblGettingStarted=Empezando (Inglés)
 lblHowtoPlay=Cómo jugar (Inglés)

--- a/forge-gui/res/languages/fr-FR.properties
+++ b/forge-gui/res/languages/fr-FR.properties
@@ -358,7 +358,6 @@ lblExitFullScreen=Quitter le plein écran
 #HelpMenu.java
 lblHelp=Aide
 lblAboutForge=À propos de Forge
-lblTroubleshooting=Dépannage
 lblArticles=Articles
 lblGettingStarted=Mise en route
 lblHowtoPlay=Comment jouer

--- a/forge-gui/res/languages/it-IT.properties
+++ b/forge-gui/res/languages/it-IT.properties
@@ -357,7 +357,6 @@ lblExitFullScreen=Esci dalla modalità schermo intero
 #HelpMenu.java
 lblHelp=Aiuto
 lblAboutForge=Informazioni su Forge
-lblTroubleshooting=Risoluzione dei problemi
 lblArticles=Articoli
 lblGettingStarted=Per iniziare
 lblHowtoPlay=Come giocare

--- a/forge-gui/res/languages/ja-JP.properties
+++ b/forge-gui/res/languages/ja-JP.properties
@@ -358,7 +358,6 @@ lblExitFullScreen=全画面表示を終了
 #HelpMenu.java
 lblHelp=ヘルプ
 lblAboutForge=Forge について
-lblTroubleshooting=トラブルシューティング
 lblArticles=記事
 lblGettingStarted=はじめに
 lblHowtoPlay=ゲームのルール。

--- a/forge-gui/res/languages/ko-KR.properties
+++ b/forge-gui/res/languages/ko-KR.properties
@@ -391,7 +391,6 @@ lblExitFullScreen=전체 화면 종료
 #HelpMenu.java
 lblHelp=도움말
 lblAboutForge=Forge 정보
-lblTroubleshooting=문제 해결
 lblArticles=기사
 lblGettingStarted=시작하기
 lblHowtoPlay=게임 규칙

--- a/forge-gui/res/languages/pt-BR.properties
+++ b/forge-gui/res/languages/pt-BR.properties
@@ -370,7 +370,6 @@ lblExitFullScreen=Sair da Tela Cheia
 #HelpMenu.java
 lblHelp=Ajuda
 lblAboutForge=Sobre o Forge
-lblTroubleshooting=Solução de Problemas
 lblArticles=Artigos
 lblGettingStarted=Primeiros Passos
 lblHowtoPlay=Como Jogar

--- a/forge-gui/res/languages/zh-CN.properties
+++ b/forge-gui/res/languages/zh-CN.properties
@@ -360,7 +360,6 @@ lblExitFullScreen=退出全屏
 #HelpMenu.java
 lblHelp=帮助
 lblAboutForge=关于Forge
-lblTroubleshooting=故障排除
 lblArticles=文章
 lblGettingStarted=如何开始
 lblHowtoPlay=如何玩

--- a/forge-gui/src/main/java/forge/error/ExceptionHandler.java
+++ b/forge-gui/src/main/java/forge/error/ExceptionHandler.java
@@ -25,6 +25,7 @@ import forge.util.MultiplexOutputStream;
 
 import java.io.*;
 import java.lang.Thread.UncaughtExceptionHandler;
+import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
@@ -72,6 +73,34 @@ public class ExceptionHandler implements UncaughtExceptionHandler {
     }
 
     /**
+     * Copy the current contents of this JVM's active log file to dest. The active log is held under an
+     * exclusive lock for the process lifetime; on Windows that lock is mandatory, so the file can't be
+     * read through a separate handle. Reading it through the owning channel is the only way to snapshot
+     * it while Forge is running.
+     * @return true if a snapshot was written, false if no log is active
+     */
+    public static boolean snapshotActiveLog(File dest) throws IOException {
+        if (logChannel == null) {
+            return false;
+        }
+        long size = logChannel.size();
+        try (FileOutputStream out = new FileOutputStream(dest)) {
+            ByteBuffer buffer = ByteBuffer.allocate(8192);
+            long position = 0;
+            while (position < size) {
+                buffer.clear();
+                int read = logChannel.read(buffer, position);
+                if (read <= 0) {
+                    break;
+                }
+                out.write(buffer.array(), 0, read);
+                position += read;
+            }
+        }
+        return true;
+    }
+
+    /**
      * Call this at the beginning to make sure that the class is loaded and the
      * static initializer has run.
      */
@@ -107,7 +136,7 @@ public class ExceptionHandler implements UncaughtExceptionHandler {
             File slot = slotFile(parent, n);
             try {
                 FileChannel ch = FileChannel.open(slot.toPath(),
-                        StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+                        StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE, StandardOpenOption.READ);
                 FileLock lock = ch.tryLock();
                 if (lock != null) {
                     logChannel = ch;

--- a/forge-gui/src/main/java/forge/util/LogExporter.java
+++ b/forge-gui/src/main/java/forge/util/LogExporter.java
@@ -1,0 +1,76 @@
+package forge.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import forge.error.ExceptionHandler;
+import forge.localinstance.properties.ForgeConstants;
+import forge.localinstance.properties.ForgeProfileProperties;
+
+public final class LogExporter {
+    private LogExporter() { }
+
+    /**
+     * Bundle the forge and network debug logs into a timestamped zip in destDir.
+     * @return the created zip file, or null if no log files were found
+     */
+    public static File exportLogs(File destDir) throws IOException {
+        List<File> files = collectLogFiles();
+        if (files.isEmpty()) {
+            return null;
+        }
+        // The active log is locked for the process lifetime; on Windows it can't be read directly,
+        // so substitute an in-process snapshot read through the owning channel.
+        File snapshotDir = null;
+        File activeLog = ExceptionHandler.getActiveLogFile();
+        try {
+            if (activeLog != null) {
+                snapshotDir = Files.createTempDirectory("forge-logs").toFile();
+                File snapshot = new File(snapshotDir, activeLog.getName());
+                if (ExceptionHandler.snapshotActiveLog(snapshot)) {
+                    String activeName = activeLog.getName();
+                    files.replaceAll(f -> f.getName().equals(activeName) ? snapshot : f);
+                }
+            }
+            String stamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"));
+            File zipFile = new File(destDir, "forge-logs-" + stamp + ".zip");
+            ZipUtil.zipFiles(files, zipFile);
+            return zipFile;
+        } finally {
+            if (snapshotDir != null) {
+                File[] contents = snapshotDir.listFiles();
+                if (contents != null) {
+                    for (File f : contents) {
+                        f.delete();
+                    }
+                }
+                snapshotDir.delete();
+            }
+        }
+    }
+
+    private static List<File> collectLogFiles() {
+        List<File> files = new ArrayList<>();
+        File userDir = new File(ForgeProfileProperties.getUserDir());
+        if (userDir.isDirectory()) {
+            File[] forgeLogs = userDir.listFiles((d, n) -> n.startsWith("forge") && n.endsWith(".log"));
+            if (forgeLogs != null) {
+                Collections.addAll(files, forgeLogs);
+            }
+        }
+        File netDir = new File(ForgeConstants.NETWORK_LOGS_DIR);
+        if (netDir.isDirectory()) {
+            File[] netLogs = netDir.listFiles((d, n) -> n.startsWith("network-debug-") && n.endsWith(".log"));
+            if (netLogs != null) {
+                Collections.addAll(files, netLogs);
+            }
+        }
+        return files;
+    }
+}


### PR DESCRIPTION
Tweaks the desktop Help and Online menus for easier troubleshooting.

Ports the mobile "Export Logs" option over to the Help menu — it dumps all logs into a timestamped zip in the Downloads folder for easy sharing. The shared collection-and-zip logic moves into a platform-agnostic `LogExporter` in forge-gui, so desktop and mobile do not duplicate it.

Unifies the viewing options for game logs (Help menu) and network logs (Online menu) so each gets what the other already had:
- Game logs pick up an "Open Game Log Directory" shortcut (previously only network had a directory shortcut); this makes more sense now that we have log rotation.
- Network logs pick up an "Open Network Log" shortcut to open the current log file (previously only the game log had a file shortcut).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)