### PR TITLE
Fix deck chooser freeze when sorting random generator decks

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/deckchooser/FDeckChooser.java
+++ b/forge-gui-desktop/src/main/java/forge/deckchooser/FDeckChooser.java
@@ -120,8 +120,8 @@ public class FDeckChooser extends JPanel implements IDecksComboBoxListener {
     private void updateDecks(final Iterable<DeckProxy> decks, final ItemManagerConfig config) {
         lstDecks.setAllowMultipleSelections(false);
 
-        lstDecks.setPool(decks);
         lstDecks.setup(config);
+        lstDecks.setPool(decks);
 
         btnRandom.setText(localizer.getMessage("lblRandomDeck"));
         btnRandom.setCommand((UiCommand) () -> DeckgenUtil.randomSelect(lstDecks));
@@ -153,8 +153,8 @@ public class FDeckChooser extends JPanel implements IDecksComboBoxListener {
     private void updateColors(Predicate<PaperCard> formatFilter) {
         lstDecks.setAllowMultipleSelections(true);
 
-        lstDecks.setPool(ColorDeckGenerator.getColorDecks(lstDecks, formatFilter, isAi));
         lstDecks.setup(ItemManagerConfig.STRING_ONLY);
+        lstDecks.setPool(ColorDeckGenerator.getColorDecks(lstDecks, formatFilter, isAi));
 
         btnRandom.setText(localizer.getMessage("lblRandomColors"));
         btnRandom.setCommand((UiCommand) () -> DeckgenUtil.randomSelectColors(lstDecks));
@@ -166,8 +166,8 @@ public class FDeckChooser extends JPanel implements IDecksComboBoxListener {
     private void updateMatrix(GameFormat format) {
         lstDecks.setAllowMultipleSelections(false);
 
-        lstDecks.setPool(ArchetypeDeckGenerator.getMatrixDecks(format, isAi));
         lstDecks.setup(ItemManagerConfig.STRING_ONLY);
+        lstDecks.setPool(ArchetypeDeckGenerator.getMatrixDecks(format, isAi));
 
         btnRandom.setText("Random");
         btnRandom.setCommand((UiCommand) () -> DeckgenUtil.randomSelect(lstDecks));
@@ -183,8 +183,8 @@ public class FDeckChooser extends JPanel implements IDecksComboBoxListener {
         }
 
         lstDecks.setAllowMultipleSelections(false);
-        lstDecks.setPool(CommanderDeckGenerator.getCommanderDecks(deckFormat, isAi, false));
         lstDecks.setup(ItemManagerConfig.STRING_ONLY);
+        lstDecks.setPool(CommanderDeckGenerator.getCommanderDecks(deckFormat, isAi, false));
 
         btnRandom.setText("Random");
         btnRandom.setCommand((UiCommand) () -> DeckgenUtil.randomSelect(lstDecks));
@@ -200,8 +200,8 @@ public class FDeckChooser extends JPanel implements IDecksComboBoxListener {
         }
 
         lstDecks.setAllowMultipleSelections(false);
-        lstDecks.setPool(CommanderDeckGenerator.getCommanderDecks(deckFormat, isAi, true));
         lstDecks.setup(ItemManagerConfig.STRING_ONLY);
+        lstDecks.setPool(CommanderDeckGenerator.getCommanderDecks(deckFormat, isAi, true));
 
         btnRandom.setText("Random");
         btnRandom.setCommand((UiCommand) () -> DeckgenUtil.randomSelect(lstDecks));

--- a/forge-gui-mobile/src/forge/deck/FDeckChooser.java
+++ b/forge-gui-mobile/src/forge/deck/FDeckChooser.java
@@ -1072,8 +1072,8 @@ public class FDeckChooser extends FScreen {
         }
 
         lstDecks.setSelectionSupport(1, maxSelections);
-        lstDecks.setPool(pool);
         lstDecks.setup(config);
+        lstDecks.setPool(pool);
 
         if (config == ItemManagerConfig.STRING_ONLY) {
             //hide edit/view buttons for string-only lists


### PR DESCRIPTION
## Bug report

Discord user report: With Format set to Commander, clicking "Random Commander Decks" or "Random Commander Card-Based Decks" from the deck-type dropdown froze the UI solid, with nothing written to the log. The freeze happened only when coming directly from the "Commander Decks" or "Precon Commander Decks" lists. Routing through "Random Decks" first and then into the random commander lists stayed snappy. The freeze eventually cleared on its own after 1–5 minutes.

A jstack taken during the freeze showed the AWT event thread RUNNABLE (not blocked) and stuck sorting the deck list: the sort comparator was calling `DeckProxy.getAI()` → `getDeck()` → `CommanderDeckGenerator` full random deck generation, once per comparison.

## Root cause

The random commander/color/archetype lists are generator pools: each entry builds a fresh random deck on demand, so any column whose sort key reads the deck (AI status, commander bracket) costs a full deck generation per access. These lists are configured as a single cheap name column (`STRING_ONLY`), but `FDeckChooser` called `setPool(...)` before `setup(STRING_ONLY)`. `setPool` sorts immediately, and the sort columns are not reset to the new config until `setup` runs — so the large generator pool was sorted using the *previous* screen's sort columns. If the user had sorted the Commander Decks list by the AI or Bracket column, that sort carried over and triggered O(N log N) full deck generations on the event thread.

This also explains the intermittency: it only triggers when the previous list's persisted sort is on a deck-generating column, and only bites noticeably when the new pool is large (the random commander lists have one entry per legal commander; the "Random Decks" detour sorts a tiny pool and also resets the columns, which is why that path stays fast).

The AI and Bracket columns are affected identically — both read the generated deck via `getDeck()` — so the fix is column-agnostic: resetting to the name-only sort before loading the pool neutralizes any deck-generating sort column.

## Fix

Reorder the two calls so `setup(config)` runs before `setPool(...)` in `FDeckChooser`, covering every method that loads a generator-backed pool (`updateColors`, `updateMatrix`, `updateRandomCommander`, `updateRandomCardGenCommander`, and the shared `updateDecks` helper used by `updateRandom`). The view's sort columns are reset to the configured column set before the pool is loaded and sorted, so the deck-generating sort columns are never applied to these lists. This matches the existing setup-then-setPool ordering used in the deck editor.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)