### PR TITLE
MSC: Typhoid Mary, Fractured (support likely needed)

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/typhoid_mary_fractured.txt
+++ b/forge-gui/res/cardsfolder/upcoming/typhoid_mary_fractured.txt
@@ -1,0 +1,13 @@
+Name:Typhoid Mary, Fractured
+ManaCost:1 B R
+Types:Legendary Creature Mutant Villain
+PT:3/3
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigCharm | TriggerZones$ Battlefield | TriggerDescription$ Whenever NICKNAME attacks, ABILITY
+SVar:TrigCharm:DB$ Charm | CharmNum$ Count$Compare Y LT1.1.0 | Choices$ DBToken,DBDraw,DBDrain | Random$ True | SubAbility$ DBCharm | AdditionalDescription$ . If you discarded a card this turn, you choose one instead.
+SVar:DBCharm:DB$ Charm | CharmNum$ Count$Compare Y GE1.1.0 | Choices$ DBToken,DBDraw,DBDrain
+SVar:Y:PlayerCountPropertyYou$CardsDiscardedThisTurn
+SVar:DBToken:DB$ Token | TokenAmount$ 1 | TokenScript$ c_a_treasure_sac | TokenOwner$ You | SpellDescription$ Mary — Create a Treasure token.
+SVar:DBDraw:DB$ Draw | SpellDescription$ Typhoid Mary — Draw a card.
+SVar:DBDrain:DB$ LoseLife | Defined$ Opponent | LifeAmount$ 2 | SubAbility$ DBGainLife | SpellDescription$ Bloody Mary — Each opponent loses 2 life and you gain 2 life.
+SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 2
+Oracle:Whenever Typhoid Mary attacks, choose one at random. If you discarded a card this turn, you choose one instead.\n• Mary — Create a Treasure token.\n• Typhoid Mary — Draw a card.\n• Bloody Mary — Each opponent loses 2 life and you gain 2 life.


### PR DESCRIPTION
Taking the relevant Discord discussion into account, I took it that I should hew closely to existing practice for `Charm` effects for proper display instead of using `Branch`. As `CheckSVar`s aren't used for these lines (and I tried to no avail) the best tack I came across was use `Count$Compare` for `CharmNum$` to limit selection for each of two concatenated `Charm` lines. 

The current outcome is that the first line works fine if I haven't discarded a card, but if I do discard a card, the trigger goes on the stack with no effect. I take it that means the `Count$Compare` is working in limiting selection for the first line but somehow the second `Charm` line is being ignored.

FWIW, the only other card to have a functional `SubAbility$` associated with a `Charm` line is [Bind to Secrecy](https://github.com/Card-Forge/forge/blob/master/forge-gui/res/cardsfolder/b/bind_to_secrecy.txt).