### PR TITLE
Fix autopass not respecting event interrupts

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/match/YieldController.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/YieldController.java
@@ -501,7 +501,10 @@ public class YieldController {
         }
     }
 
-    private boolean shouldEvaluateInterrupts() {
+    /** True when an event-driven interrupt should be considered: either an interruptible
+     *  yield is active, or APINA + RESPECTS_INTERRUPTS are both on (so the next priority
+     *  window's auto-pass can be blocked by autoPassInterrupted). */
+    public boolean shouldEvaluateInterrupts() {
         if (isInterruptibleYieldActive()) return true;
         return getBoolPref(FPref.YIELD_AUTO_PASS_NO_ACTIONS) && getBoolPref(FPref.YIELD_AUTO_PASS_RESPECTS_INTERRUPTS);
     }

--- a/forge-gui/src/main/java/forge/gui/control/FControlGameEventHandler.java
+++ b/forge-gui/src/main/java/forge/gui/control/FControlGameEventHandler.java
@@ -282,7 +282,9 @@ public class FControlGameEventHandler extends IGameEventVisitor.Base<Void> {
     private void evaluateYieldInterruptForSpellCast(GameEventSpellAbilityCast event) {
         if (humanController == null) return;
         YieldController yc = humanController.getYieldController();
-        if (!yc.isYieldActive()) return;
+        // isYieldActive() only covers explicit yields; APINA-with-respects-interrupts
+        // also wants to be told about casts so it can set autoPassInterrupted.
+        if (!yc.shouldEvaluateInterrupts()) return;
         GameView gv = matchController.getGameView();
         if (gv == null || gv.getGame() == null) return;
         // Look up the actual SpellAbilityStackInstance by id (host-side; client gv.getGame() is null).
@@ -375,7 +377,8 @@ public class FControlGameEventHandler extends IGameEventVisitor.Base<Void> {
     public Void visit(final GameEventAttackersDeclared event) {
         if (humanController != null) {
             YieldController yc = humanController.getYieldController();
-            if (yc.isYieldActive()) {
+            // APINA-with-respects-interrupts wants the attackers signal too, not just explicit yields.
+            if (yc.shouldEvaluateInterrupts()) {
                 GameView gv = matchController.getGameView();
                 if (gv != null && gv.getCombat() != null) yc.onAttackersDeclared(gv.getCombat());
             }


### PR DESCRIPTION
When Auto-Pass-If-No-Actions (APINA) is on with "respects interrupts," it's supposed to stop auto-passing when an opponent casts a spell or declares attackers but. Fixed by broadening the gate to shouldEvaluateInterrupts() (true when an interruptible yield is active or when APINA + respects-interrupts are both on), so the auto-pass can be properly blocked by autoPassInterrupted for the next priority window.