### PR TITLE
Fix Planar deck buttons hidden behind Constructed deck button

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/screens/home/PlayerPanel.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/PlayerPanel.java
@@ -179,8 +179,8 @@ public class PlayerPanel extends FPanel {
             this.add(chkReady, "cell 5 4, ax left, sx 2, wrap");
         }
 
-        this.add(deckLabel, variantBtnConstraints + ", cell 0 5, sx 2, ax right");
-        this.add(deckBtn, variantBtnConstraints + ", cell 2 5, pushx, growx, wmax 100%-153px, h 30px, spanx 4, wrap");
+        this.add(deckLabel, variantBtnConstraints + ", cell 0 3, sx 2, ax right");
+        this.add(deckBtn, variantBtnConstraints + ", cell 2 3, pushx, growx, wmax 100%-153px, h 30px, spanx 4, wrap");
 
         addHandlersDeckSelector();
 


### PR DESCRIPTION
<img width="1031" height="250" alt="Screenshot 2026-06-12 073119" src="https://github.com/user-attachments/assets/a6e49271-b15b-4b57-b17a-6ddbcd0ac638" />

**Bug:** When Planechase is selected, the "Select a planar deck" and "Planar Deck Editor" buttons sit hidden behind the Constructed deck button and can't be clicked. Selecting a second variant such as Commander makes them reappear, because Commander disables normal deck building and hides the Constructed button.

**Root cause:** #9590 (AI profile picker) moved the Constructed deck row from grid row 2 — where it shared a cell with the mutually-exclusive Commander row — onto grid row 5, which is already occupied by the Planechase row. Both rows are visible at once and the always-on-top Constructed button covers the planar buttons.

**Fix:** Move the Constructed deck row onto the unused grid row 3 so it no longer overlaps the Planechase widgets. Row 3 is free and sits below the team row in both AI-picker states, and `hidemode 3` collapses it when Constructed deck building is hidden.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)