### PR TITLE
Don't track exiled tokens in the until-leaves-battlefield list

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
@@ -814,7 +814,14 @@ public abstract class SpellAbilityEffect {
 
         final Card hostCard = sa.getHostCard();
         final Game game = hostCard.getGame();
-        hostCard.addUntilLeavesBattlefield(triggerList.allCards());
+        // tokens cease to exist once exiled and never return, and nothing ever cleans them from this list
+        final CardCollection toTrack = new CardCollection();
+        for (final Card c : triggerList.allCards()) {
+            if (!c.isToken()) {
+                toTrack.add(c);
+            }
+        }
+        hostCard.addUntilLeavesBattlefield(toTrack);
         final TriggerHandler trigHandler = game.getTriggerHandler();
 
         final Card lki;

--- a/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/SpellAbilityEffect.java
@@ -815,13 +815,7 @@ public abstract class SpellAbilityEffect {
         final Card hostCard = sa.getHostCard();
         final Game game = hostCard.getGame();
         // tokens cease to exist once exiled and never return, and nothing ever cleans them from this list
-        final CardCollection toTrack = new CardCollection();
-        for (final Card c : triggerList.allCards()) {
-            if (!c.isToken()) {
-                toTrack.add(c);
-            }
-        }
-        hostCard.addUntilLeavesBattlefield(toTrack);
+        hostCard.addUntilLeavesBattlefield(CardLists.filter(triggerList.allCards(), CardPredicates.NON_TOKEN));
         final TriggerHandler trigHandler = game.getTriggerHandler();
 
         final Card lki;


### PR DESCRIPTION
## Bug

A permanent that exiles a card "until ~ leaves the battlefield" (e.g. Seam Rip) draws a faded "ghost" of the exiled card on itself. When that card is a token (e.g. a Clue), the token ceases to exist the instant it's exiled — yet its ghost still shows, and the detail text still lists it under "Exiled until this leaves the battlefield."

## Root cause

Cards exiled this way are recorded in the host's `untilLeavesBattlefield` list, which is populated from `triggerList.allCards()` — including tokens. The cleanup that removes entries (`cleanupExiledWith`) only runs for cards with an `exiledWith` back-pointer, and `handleExiledWith` skips tokens — so a token is never linked and never removed, and `ceaseToExist` doesn't clean the list either. The ceased token lingers as an orphaned reference whose `CardView` still reports `zone=Exile`. The engine's return logic tolerates this (it re-validates with `getCardState` at return time), but the ghost UI and detail text read the list directly, without that check.

## Fix

Exclude tokens where the list is populated (`changeZoneUntilCommand`), mirroring the token exclusion already in `handleExiledWith`. A token exiled this way ceases and can never return, so there's no reason to track it.

## Why it's safe

- No game-outcome change: the return command already skipped tokens (`getCardState` is `null` for a ceased token).
- No legitimate token return is lost: these effects only exile cards that *left* a zone, and a token in exile always ceases.
- Non-token cards keep their `exiledWith` link and self-clean on their next zone change.
- Fixes both ghost UIs and the detail text at the source, with no UI special-casing.

## Alternatives considered

- **Filter ghosts by zone (`!= Exile`):** rejected — the orphaned token still reports `zone=Exile`, so it never fires.
- **Filter ghosts by `isToken()` in the UI:** rejected — display band-aid; leaves stale engine data and the detail text wrong.
- **Prune the list in `ceaseToExist`:** rejected here — the token has no `exiledWith` back-pointer to prune by, and it edits a hot shared path for a display bug. Would also cover a rarer non-token cease-to-exist orphan; noted as a possible follow-up.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)