### PR TITLE
Support deck-specified AI profiles

### DIFF
--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -54,6 +54,8 @@ import java.util.stream.Collectors;
  * Handles phase skips for now.
  */
 public class PlayerControllerAi extends PlayerController {
+    private static final String AI_PROFILE_HINT = "AiProfile";
+
     private final AiController brains;
 
     private boolean pilotsNonAggroDeck = false;
@@ -70,6 +72,11 @@ public class PlayerControllerAi extends PlayerController {
 
     public void setupAutoProfile(Deck deck) {
         pilotsNonAggroDeck = deck.getName().contains("Control") || deck.getAverageCMC() > 3;
+        final String deckAiProfile = deck.getAiHint(AI_PROFILE_HINT);
+        if (StringUtils.isNotBlank(deckAiProfile) && lobbyPlayer instanceof LobbyPlayerAi aiPlayer) {
+            aiPlayer.setRotateProfileEachGame(false);
+            aiPlayer.setAiProfile(deckAiProfile);
+        }
     }
 
     public void setUseSimulation(boolean value) {

--- a/forge-gui-desktop/src/test/java/forge/deck/DeckAiProfileTest.java
+++ b/forge-gui-desktop/src/test/java/forge/deck/DeckAiProfileTest.java
@@ -1,0 +1,29 @@
+package forge.deck;
+
+import forge.deck.io.DeckSerializer;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.testng.Assert.assertEquals;
+
+public class DeckAiProfileTest {
+    @Test
+    public void aiProfileIsReadFromAiHintsMetadata() throws IOException {
+        final File deckFile = File.createTempFile("forge-ai-profile", ".dck");
+        try {
+            final Deck deck = new Deck("Profile Test");
+            deck.setAiHint("DeckArchetype", "Combo");
+            deck.setAiHint("AiProfile", "Berserker");
+
+            DeckSerializer.writeDeck(deck, deckFile);
+
+            final Deck reloaded = DeckSerializer.fromFile(deckFile);
+            assertEquals(reloaded.getAiHint("AiProfile"), "Berserker");
+            assertEquals(reloaded.getAiHint("DeckArchetype"), "Combo");
+        } finally {
+            deckFile.delete();
+        }
+    }
+}


### PR DESCRIPTION
﻿## Problem

Deck authors currently cannot bind a deck to the AI profile that best fits that deck or scenario. This is a narrow slice of #8268.

## Minimal Fix

This adds a deck-file AI profile hint through the existing `AiHints` metadata field:

```text
AiHints=AiProfile$Reckless
```

`PlayerControllerAi.setupAutoProfile(Deck)` reads the existing `AiHints` entry with `getAiHint("AiProfile")` and applies a nonblank deck profile to AI lobby players. When a deck profile is applied, profile rotation is disabled for that AI player so the deck file remains deterministic.

The serializer test covers the deck-file metadata round trip and confirms an existing `AiHints` entry is preserved alongside `AiProfile`.

## Validation

Ran locally with temporary Maven/JDK tooling:

```text
mvn -pl forge-gui-desktop -am -Dtest=forge.deck.DeckAiProfileTest -Dsurefire.failIfNoSpecifiedTests=false test
mvn -pl forge-ai -am -DskipTests compile
```

Observed result:

- `DeckAiProfileTest`: `Tests run: 1, Failures: 0, Errors: 0, Skipped: 0`
- `forge-ai` compile: `BUILD SUCCESS`
- Maven checkstyle: `0 Checkstyle violations`

## AI Assistance Disclosure

Codex assisted with implementation and validation. I reviewed the diff and kept the scope limited to the deck-profile behavior requested in #8268.

## Known Limits

- No UI changes.
- No per-setting AI profile overrides.
- No AI heuristic changes.
- Profile names are passed through to the existing AI profile loading path.

Refs #8268.
