### PR TITLE
MSC, batch 4: 5 cards

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/kimoyo_beads.txt
+++ b/forge-gui/res/cardsfolder/upcoming/kimoyo_beads.txt
@@ -1,0 +1,12 @@
+Name:Kimoyo Beads
+ManaCost:4
+Types:Artifact
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | Execute$ TrigCharm | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your end step, ABILITY
+SVar:TrigCharm:DB$ Charm | Choices$ DBDraw,DBToken,DBLife | ChoiceRestriction$ ThisGame
+SVar:DBDraw:DB$ Draw | SpellDescription$ AV Bead — Draw a card.
+SVar:DBToken:DB$ Token | TokenAmount$ 2 | TokenScript$ w_1_1_soldier | TokenOwner$ You | SpellDescription$ Communication Bead — Create two 1/1 white Soldier creature tokens.
+SVar:DBLife:DB$ GainLife | Defined$ You | LifeAmount$ 3 | SubAbility$ DBExile | SpellDescription$ Prime Bead — You gain 3 life. Exile this artifact, then return it to the battlefield under its owner’s control.
+SVar:DBExile:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | SubAbility$ DBReturn | RememberChanged$ True
+SVar:DBReturn:DB$ ChangeZone | Hidden$ True | Origin$ All | Destination$ Battlefield | Defined$ Remembered | SubAbility$ DBCleanup
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:At the beginning of your end step, choose one that hasn’t been chosen —\n• AV Bead — Draw a card.\n• Communication Bead — Create two 1/1 white Soldier creature tokens.\n• Prime Bead — You gain 3 life. Exile this artifact, then return it to the battlefield under its owner’s control.

--- a/forge-gui/res/cardsfolder/upcoming/mach_1_swooping_scoundrel.txt
+++ b/forge-gui/res/cardsfolder/upcoming/mach_1_swooping_scoundrel.txt
@@ -1,0 +1,9 @@
+Name:MACH-1, Swooping Scoundrel
+ManaCost:1 B
+Types:Legendary Artifact Creature Human Villain
+PT:1/3
+K:Flying
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSurveil | ActivationLimit$ 1 | TriggerDescription$ When NICKNAME enters and whenever you gain life, surveil 1. This ability triggers only once each turn.
+T:Mode$ LifeGained | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigSurveil | ActivationLimit$ 1 | Secondary$ True | TriggerDescription$ When NICKNAME enters and whenever you gain life, surveil 1. This ability triggers only once each turn.
+SVar:TrigSurveil:DB$ Surveil | Amount$ 1
+Oracle:Flying\nWhen MACH-1 enters and whenever you gain life, surveil 1. This ability triggers only once each turn. (To surveil 1, look at the top card of your library. You may put it into your graveyard.)

--- a/forge-gui/res/cardsfolder/upcoming/mbaku_jabari_chieftain.txt
+++ b/forge-gui/res/cardsfolder/upcoming/mbaku_jabari_chieftain.txt
@@ -1,0 +1,10 @@
+Name:M'Baku, Jabari Chieftain
+ManaCost:1 G G
+Types:Legendary Creature Human Noble Warrior
+PT:4/3
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | Execute$ TrigMonarch | TriggerZones$ Battlefield | CheckSVar$ NoMonarch | SVarCompare$ EQ0 | TriggerDescription$ At the beginning of your end step, if there is no monarch, target opponent becomes the monarch.
+SVar:TrigMonarch:DB$ BecomeMonarch | ValidTgts$ Opponent
+SVar:NoMonarch:PlayerCountPlayers$HasPropertyisMonarch
+T:Mode$ Attacks | ValidCard$ Creature | Attacked$ Player.Opponent+isMonarch | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever a creature attacks one of your opponents, if that player is the monarch, that creature gets +1/+1 and gains trample until end of turn.
+SVar:TrigPump:DB$ Pump | Defined$ TriggeredAttackerLKICopy | NumAtt$ +1 | NumDef$ +1 | KW$ Trample
+Oracle:At the beginning of your end step, if there is no monarch, target opponent becomes the monarch.\nWhenever a creature attacks one of your opponents, if that player is the monarch, that creature gets +1/+1 and gains trample until end of turn.

--- a/forge-gui/res/cardsfolder/upcoming/mbaku_jabari_chieftain.txt
+++ b/forge-gui/res/cardsfolder/upcoming/mbaku_jabari_chieftain.txt
@@ -6,5 +6,5 @@ T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | Execute$ TrigMonarch | T
 SVar:TrigMonarch:DB$ BecomeMonarch | ValidTgts$ Opponent
 SVar:NoMonarch:PlayerCountPlayers$HasPropertyisMonarch
 T:Mode$ Attacks | ValidCard$ Creature | Attacked$ Player.Opponent+isMonarch | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever a creature attacks one of your opponents, if that player is the monarch, that creature gets +1/+1 and gains trample until end of turn.
-SVar:TrigPump:DB$ Pump | Defined$ TriggeredAttackerLKICopy | NumAtt$ +1 | NumDef$ +1 | KW$ Trample
+SVar:TrigPump:DB$ Pump | Defined$ TriggeredAttackerLKICopy | ConditionPlayerDefined$ TriggeredDefendingPlayer | ConditionPlayerContains$ Player.isMonarch | NumAtt$ +1 | NumDef$ +1 | KW$ Trample
 Oracle:At the beginning of your end step, if there is no monarch, target opponent becomes the monarch.\nWhenever a creature attacks one of your opponents, if that player is the monarch, that creature gets +1/+1 and gains trample until end of turn.

--- a/forge-gui/res/cardsfolder/upcoming/mjolnirs_might.txt
+++ b/forge-gui/res/cardsfolder/upcoming/mjolnirs_might.txt
@@ -1,0 +1,9 @@
+Name:Mjölnir's Might
+ManaCost:3 R
+Types:Sorcery
+A:SP$ DealDamage | ValidTgts$ Player | NumDmg$ 4 | SubAbility$ DBExile | SpellDescription$ CARDNAME deals 4 damage to target player.,,,,,,
+SVar:DBExile:DB$ Dig | DigNum$ 1 | ChangeNum$ All | DestinationZone$ Exile | RememberChanged$ True | SubAbility$ DBEffect | StackDescription$ REP Exile_{p:You} exiles & your library_their library & your next_their next & you may_{p:You} may | SpellDescription$ Exile the top card of your library. Until the end of your next turn, you may play that card.
+SVar:DBEffect:DB$ Effect | RememberObjects$ RememberedCard | Duration$ UntilTheEndOfYourNextTurn | StaticAbilities$ Play | SubAbility$ DBCleanup | ForgetOnMoved$ Exile
+SVar:Play:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsRemembered | AffectedZone$ Exile | Description$ Until the end of your next turn, you may play that card.
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+Oracle:Mjölnir’s Might deals 4 damage to target player.\nExile the top card of your library. Until the end of your next turn, you may play that card.

--- a/forge-gui/res/cardsfolder/upcoming/moon_boy_dino_rider.txt
+++ b/forge-gui/res/cardsfolder/upcoming/moon_boy_dino_rider.txt
@@ -1,0 +1,9 @@
+Name:Moon-Boy, Dino Rider
+ManaCost:1 G
+Types:Legendary Creature Ape Human
+PT:2/2
+S:Mode$ ReduceCost | ValidCard$ Dinosaur | Type$ Spell | Activator$ You | Amount$ 1 | Description$ Dinosaur spells you cast cost {1} less to cast.
+T:Mode$ Attacks | ValidCard$ Card.Self | IsPresent$ Dinosaur.YouCtrl | NoResolvingCheck$ True | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever NICKNAME attacks while you control a Dinosaur, NICKNAME gets +1/+1 until end of turn.
+SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +1 | NumDef$ +1
+SVar:HasAttackEffect:TRUE
+Oracle:Dinosaur spells you cast cost {1} less to cast.\nWhenever Moon-Boy attacks while you control a Dinosaur, Moon-Boy gets +1/+1 until end of turn.


### PR DESCRIPTION
As revealed recently; tested to satisfaction:
- [Kimoyo Beads](https://scryfall.com/card/msc/109/kimoyo-beads)
- [MACH-1, Swooping Scoundrel](https://scryfall.com/card/msc/662/mach-1-swooping-scoundrel)
- [M'Baku, Jabari Chieftain](https://scryfall.com/card/msc/67/mbaku-jabari-chieftain)
- [Mjölnir's Might](https://scryfall.com/card/msc/697/mj%C3%B6lnirs-might)
- [Moon-Boy, Dino Rider](https://scryfall.com/card/msc/563/moon-boy-dino-rider)