### PR TITLE
Fix multiplayer crash when a remote client controls an opponent

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/net/server/RemoteClientGuiGame.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/RemoteClientGuiGame.java
@@ -5,6 +5,7 @@ import forge.ai.GameState;
 import forge.deck.CardPool;
 import forge.game.GameEntityView;
 import forge.game.event.GameEvent;
+import forge.game.event.GameEventPlayerControl;
 import forge.game.GameView;
 import forge.game.card.CardView;
 import forge.game.phase.PhaseType;
@@ -550,6 +551,11 @@ public class RemoteClientGuiGame extends NetworkGuiGame implements IHasForgeLog 
     @Override
     public void handleGameEvents(List<GameEvent> events) {
         if (paused) { return; }
+        for (GameEvent ev : events) {
+            if (ev instanceof GameEventPlayerControl pc) {
+                syncControlledPlayer(pc);
+            }
+        }
         netLog.info("Sending batch of {}: [{}]", events.size(),
                 events.stream().map(e -> e.getClass().getSimpleName()).collect(Collectors.joining(", ")));
         // When GameEventGameStarted arrives, prepareAllZones has completed —
@@ -601,6 +607,27 @@ public class RemoteClientGuiGame extends NetworkGuiGame implements IHasForgeLog 
             GameView gameView = getGameView();
             forge.trackable.Tracker tracker = gameView != null ? gameView.getTracker() : null;
             sender.send(ProtocolMethod.applyDelta, DeltaPacket.eventsOnly(TrackableSerializer.wrapEvents(events, tracker)));
+        }
+    }
+
+    /**
+     * Keep this proxy's local-player map in step with control changes. When a player on this
+     * client gains control of an opponent, the opponent's priority is handled through this
+     * client's shared input proxy, so {@link #setCurrentPlayer} must accept the controlled
+     * player as local. Mirrors {@code FControlGameEventHandler}, which does this for the
+     * host's own GUI; remote proxies only forward events and would otherwise never register
+     * the controlled player, throwing when their turn comes.
+     */
+    private void syncControlledPlayer(final GameEventPlayerControl ev) {
+        final PlayerView controlled = ev.player();
+        if (controlled == null) {
+            return;
+        }
+        final PlayerView master = ev.newLobbyPlayerName() == null ? null : controlled.getMindSlaveMaster();
+        if (master != null && ev.newControllerIsHuman() && isLocalPlayer(master)) {
+            setGameController(controlled, getGameController(master));
+        } else {
+            setGameController(controlled, null);
         }
     }
 


### PR DESCRIPTION
## Summary

Control-an-opponent effects (e.g. Secret of Bloodbending) crash the game in multiplayer when the controlling player is a remote client. Reproduction: in a network game, the remote client casts Secret of Bloodbending targeting the host; the game thread dies with `IllegalArgumentException` at `AbstractGuiGame.setCurrentPlayer` as soon as control takes effect on the host's turn.

Root cause: the controlled player's priority runs through the controller's shared `InputProxy`, so `InputProxy.update` calls `setCurrentPlayer` on the controller's GUI. On the host, that GUI's `FControlGameEventHandler` registers the controlled player as local when `GameEventPlayerControl` fires, so the call succeeds. The server-side `RemoteClientGuiGame` instead uses a `GameEventForwarder` that only relays events to the client and never updates its own `gameControllers` map — so the controlled player is never registered server-side and `setCurrentPlayer` throws.

The fix mirrors the host-side bookkeeping in `RemoteClientGuiGame`: on each `GameEventPlayerControl`, register or unregister the controlled player in the proxy's `gameControllers`, identifying the controller via the controlled player's mind-slave master and `isLocalPlayer` (not by name) so only the actual controller's proxy registers the player.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)