### PR TITLE
Alchemy Rebalancing for June 15, 2026

### DIFF
--- a/forge-gui/res/cardsfolder/o/oura_the_imitator.txt
+++ b/forge-gui/res/cardsfolder/o/oura_the_imitator.txt
@@ -1,7 +1,7 @@
 Name:Oura, the Imitator
 ManaCost:1 U B
 Types:Legendary Creature Faerie Noble
-PT:2/2
+PT:2/3
 K:Flash
 K:Flying
 K:Lifelink

--- a/forge-gui/res/cardsfolder/t/trackhand_trainer.txt
+++ b/forge-gui/res/cardsfolder/t/trackhand_trainer.txt
@@ -1,7 +1,7 @@
 Name:Trackhand Trainer
 ManaCost:U
 Types:Creature Merfolk
-PT:1/1
-A:AB$ Draw | Cost$ 4 U | SpellDescription$ Draw a card.
+PT:1/2
+A:AB$ Draw | Cost$ 3 U U | SpellDescription$ Draw a card.
 A:AB$ MakeCard | Cost$ U | Conjure$ True | Exhaust$ True | Name$ Training Grounds | Zone$ Battlefield | SpellDescription$ Conjure a card named Training Grounds onto the battlefield.
-Oracle:{4}{U}: Draw a card.\nExhaust — {U}: Conjure a card named Training Grounds onto the battlefield.
+Oracle:{3}{U}{U}: Draw a card.\nExhaust — {U}: Conjure a card named Training Grounds onto the battlefield.

--- a/forge-gui/res/cardsfolder/upcoming/infestation.txt
+++ b/forge-gui/res/cardsfolder/upcoming/infestation.txt
@@ -3,9 +3,9 @@ ManaCost:3 B B
 Types:Creature Elemental Incarnation
 PT:6/5
 K:Wither
-K:Evoke:2 B B PayLife<2>
+K:Evoke:1 B B PayLife<3>
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigConjure | TriggerDescription$ When this creature enters, conjure a card named Blowfly Infestation onto the battlefield. Then put a -1/-1 counter on each creature.
 SVar:TrigConjure:DB$ MakeCard | Conjure$ True | Name$ Blowfly Infestation | Zone$ Battlefield | SubAbility$ DBPutCounter
 SVar:DBPutCounter:DB$ PutCounterAll | ValidCards$ Creature | CounterType$ M1M1 | CounterNum$ 1
 DeckHas:Ability$Counters|Sacrifice
-Oracle:Wither\nWhen this creature enters, conjure a card named Blowfly Infestation onto the battlefield. Then put a -1/-1 counter on each creature.\nEvoke—{2}{B}{B}, Pay 2 life.
+Oracle:Wither\nWhen this creature enters, conjure a card named Blowfly Infestation onto the battlefield. Then put a -1/-1 counter on each creature.\nEvoke—{1}{B}{B}, Pay 3 life.


### PR DESCRIPTION
Source: https://magic.wizards.com/en/news/mtg-arena/announcements-june-15-2026#Rebalances

Aquatic Subtlety is still in an open PR #9638 

Alchemy only - no new script needed:
- [x] Infestation
- [x] Oura, the Imitator
- [x] Trackhand Trainer