### PR TITLE
Flashback support for no mana cost provided

### DIFF
--- a/forge-game/src/main/java/forge/game/GameActionUtil.java
+++ b/forge-game/src/main/java/forge/game/GameActionUtil.java
@@ -301,7 +301,15 @@ public final class GameActionUtil {
         // there is a flashback cost (and not the cards cost)
         if (keyword.contains(":")) { // K:Flashback:Cost:ExtraParams:ExtraDescription
             final String[] k = keyword.split(":");
-            newSA = sa.copyWithManaCostReplaced(activator, new Cost(k[1], false));
+            
+            // Default to mana cost if no cost provided
+            final String costString = k[1];
+            if (costString.equals("")) {
+                newSA = sa.copy(activator);
+            } else {
+                newSA = sa.copyWithManaCostReplaced(activator, new Cost(k[1], false));
+            }
+
             String extraParams =  k.length > 2 ? k[2] : "";
             if (!extraParams.isEmpty()) {
                 for (Map.Entry<String, String> param : AbilityFactory.getMapParams(extraParams).entrySet()) {

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -2223,7 +2223,15 @@ public class CardFactoryUtil {
 
             if (keyword.contains(":")) { // K:Flashback:Cost:ExtraParams:ExtraDescription
                 final String[] k = keyword.split(":");
-                final Cost cost = new Cost(k[1], false);
+
+                // Default to mana cost if no cost provided
+                final String costString = k[1];
+                Cost cost;
+                if (costString.equals("")) {
+                    cost = new Cost(card.getManaCost(), false);
+                } else {
+                    cost = new Cost(k[1], false);
+                }
                 sb.append(cost.isOnlyManaCost() ? " " : "—").append(cost.toSimpleString());
                 sb.append(cost.isOnlyManaCost() ? "" : ".");
 


### PR DESCRIPTION
Supports for empty cost in Flashback in `K:Flashback:Cost:ExtraParams:ExtraDescription`, which defaults to the card's mana cost. This allows for this `Flashback::ReduceCost$ 2:This spell costs {2} less to cast.`

<img width="375" height="523" alt="image" src="https://github.com/user-attachments/assets/c2735c1b-0355-4ca7-a778-4aff3b5db4f4" />
