### PR TITLE
Fix GameEventPlayerStatsChanged carrying ALL cards

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/DamagePreventEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DamagePreventEffect.java
@@ -168,7 +168,7 @@ public class DamagePreventEffect extends SpellAbilityEffect {
 
         o.getView().updatePreventNextDamage(o);
         if (o instanceof Player) {
-            game.fireEvent(new GameEventPlayerStatsChanged((Player) o, false));
+            game.fireEvent(new GameEventPlayerStatsChanged((Player) o));
         }
 
         game.getEndOfTurn().addUntil(new GameCommand() {
@@ -179,7 +179,7 @@ public class DamagePreventEffect extends SpellAbilityEffect {
                 game.getAction().exileEffect(eff);
                 o.getView().updatePreventNextDamage(o);
                 if (o instanceof Player) {
-                    game.fireEvent(new GameEventPlayerStatsChanged((Player) o, false));
+                    game.fireEvent(new GameEventPlayerStatsChanged((Player) o));
                 }
             }
         });

--- a/forge-game/src/main/java/forge/game/card/CardDamageTable.java
+++ b/forge-game/src/main/java/forge/game/card/CardDamageTable.java
@@ -49,8 +49,8 @@ public class CardDamageTable extends ForwardingTable<Card, GameEntity, Integer> 
                 ge.getGame().getTriggerHandler().runTrigger(TriggerType.DamagePreventedOnce, runParams, false);
 
                 ge.getView().updatePreventNextDamage(ge);
-                if (ge instanceof Player) {
-                    ge.getGame().fireEvent(new GameEventPlayerStatsChanged((Player) ge, false));
+                if (ge instanceof Player p) {
+                    ge.getGame().fireEvent(new GameEventPlayerStatsChanged(p));
                 }
             }
         }

--- a/forge-game/src/main/java/forge/game/event/GameEventPlayerStatsChanged.java
+++ b/forge-game/src/main/java/forge/game/event/GameEventPlayerStatsChanged.java
@@ -2,29 +2,21 @@ package forge.game.event;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
-import forge.game.card.CardView;
 import forge.game.player.Player;
 import forge.game.player.PlayerView;
 import forge.util.Lang;
 import forge.util.TextUtil;
+import forge.util.collect.FCollection;
 
-/**
- * This means card's characteristics have changed on server, clients must re-request them
- */
-public record GameEventPlayerStatsChanged(Collection<PlayerView> players, boolean updateCards, Collection<CardView> allCards) implements GameEvent {
+public record GameEventPlayerStatsChanged(FCollection<PlayerView> players) implements GameEvent {
 
-    public GameEventPlayerStatsChanged(Collection<Player> players, boolean updateCards) {
-        this(PlayerView.getCollection(players), updateCards,
-             updateCards ? players.stream().flatMap(p -> StreamSupport.stream(p.getAllCards().spliterator(), false))
-                     .map(CardView::get).collect(Collectors.toList()) : Collections.emptyList());
+    public GameEventPlayerStatsChanged(Collection<Player> players) {
+        this(PlayerView.getCollection(players));
     }
 
-    public GameEventPlayerStatsChanged(Player affected, boolean updateCards) {
-        this(Arrays.asList(affected), updateCards);
+    public GameEventPlayerStatsChanged(Player affected) {
+        this(Arrays.asList(affected));
     }
 
     /* (non-Javadoc)

--- a/forge-game/src/main/java/forge/game/phase/PhaseHandler.java
+++ b/forge-game/src/main/java/forge/game/phase/PhaseHandler.java
@@ -931,7 +931,7 @@ public class PhaseHandler implements java.io.Serializable, IHasForgeLog {
         }
 
         // fireEvent to update the Details
-        game.fireEvent(new GameEventPlayerStatsChanged(toUpdate, false));
+        game.fireEvent(new GameEventPlayerStatsChanged(toUpdate));
 
         return result;
     }

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -994,7 +994,7 @@ public class Player extends GameEntity implements Comparable<Player> {
         }
         changedKeywords.put(timestamp, staticId, cks);
         updateKeywords();
-        game.fireEvent(new GameEventPlayerStatsChanged(this, true));
+        game.fireEvent(new GameEventPlayerStatsChanged(this));
     }
 
     public final KeywordInterface getKeywordForStaticAbility(String kw, final long staticId) {
@@ -1015,7 +1015,7 @@ public class Player extends GameEntity implements Comparable<Player> {
                 getKeywordCard().removeChangedCardTraits(timestamp, staticId);
             }
             updateKeywords();
-            game.fireEvent(new GameEventPlayerStatsChanged(this, true));
+            game.fireEvent(new GameEventPlayerStatsChanged(this));
         }
         return change;
     }
@@ -1713,13 +1713,13 @@ public class Player extends GameEntity implements Comparable<Player> {
     public final void addMaxLandPlays(long timestamp, int value) {
         adjustLandPlays.put(timestamp, value);
         getView().updateMaxLandPlay(this);
-        getGame().fireEvent(new GameEventPlayerStatsChanged(this, false));
+        getGame().fireEvent(new GameEventPlayerStatsChanged(this));
     }
     public final boolean removeMaxLandPlays(long timestamp) {
         boolean changed = adjustLandPlays.remove(timestamp) != null;
         if (changed) {
             getView().updateMaxLandPlay(this);
-            getGame().fireEvent(new GameEventPlayerStatsChanged(this, false));
+            getGame().fireEvent(new GameEventPlayerStatsChanged(this));
         }
         return changed;
     }
@@ -1727,13 +1727,13 @@ public class Player extends GameEntity implements Comparable<Player> {
     public final void addMaxLandPlaysInfinite(long timestamp) {
         adjustLandPlaysInfinite.add(timestamp);
         getView().updateUnlimitedLandPlay(this);
-        getGame().fireEvent(new GameEventPlayerStatsChanged(this, false));
+        getGame().fireEvent(new GameEventPlayerStatsChanged(this));
     }
     public final boolean removeMaxLandPlaysInfinite(long timestamp) {
         boolean changed = adjustLandPlaysInfinite.remove(timestamp);
         if (changed) {
             getView().updateUnlimitedLandPlay(this);
-            getGame().fireEvent(new GameEventPlayerStatsChanged(this, false));
+            getGame().fireEvent(new GameEventPlayerStatsChanged(this));
         }
         return changed;
     }
@@ -2848,7 +2848,7 @@ public class Player extends GameEntity implements Comparable<Player> {
     public void incCommanderCast(Card commander) {
         commanderCast.merge(commander, 1, Integer::sum);
         getView().updateCommanderCast(this, commander);
-        getGame().fireEvent(new GameEventPlayerStatsChanged(this, false));
+        getGame().fireEvent(new GameEventPlayerStatsChanged(this));
     }
 
     public void resetCommanderStats() {
@@ -3704,12 +3704,12 @@ public class Player extends GameEntity implements Comparable<Player> {
     public void addAdditionalVote(long timestamp, int value) {
         additionalVotes.put(timestamp, value);
         getView().updateAdditionalVote(this);
-        getGame().fireEvent(new GameEventPlayerStatsChanged(this, false));
+        getGame().fireEvent(new GameEventPlayerStatsChanged(this));
     }
     public void removeAdditionalVote(long timestamp) {
         if (additionalVotes.remove(timestamp) != null) {
             getView().updateAdditionalVote(this);
-            getGame().fireEvent(new GameEventPlayerStatsChanged(this, false));
+            getGame().fireEvent(new GameEventPlayerStatsChanged(this));
         }
     }
 
@@ -3724,12 +3724,12 @@ public class Player extends GameEntity implements Comparable<Player> {
     public void addAdditionalOptionalVote(long timestamp, int value) {
         additionalOptionalVotes.put(timestamp, value);
         getView().updateOptionalAdditionalVote(this);
-        getGame().fireEvent(new GameEventPlayerStatsChanged(this, false));
+        getGame().fireEvent(new GameEventPlayerStatsChanged(this));
     }
     public void removeAdditionalOptionalVote(long timestamp) {
         if (additionalOptionalVotes.remove(timestamp) != null) {
             getView().updateOptionalAdditionalVote(this);
-            getGame().fireEvent(new GameEventPlayerStatsChanged(this, false));
+            getGame().fireEvent(new GameEventPlayerStatsChanged(this));
         }
     }
 
@@ -3761,7 +3761,7 @@ public class Player extends GameEntity implements Comparable<Player> {
         Player control = getGame().getControlVote();
         for (Player pl : getGame().getPlayers()) {
             pl.getView().updateControlVote(pl.equals(control));
-            getGame().fireEvent(new GameEventPlayerStatsChanged(pl, false));
+            getGame().fireEvent(new GameEventPlayerStatsChanged(pl));
         }
     }
 
@@ -3784,12 +3784,12 @@ public class Player extends GameEntity implements Comparable<Player> {
     public void addAdditionalVillainousChoices(long timestamp, int value) {
         additionalVillainousChoices.put(timestamp, value);
         getView().updateAdditionalVillainousChoices(this);
-        getGame().fireEvent(new GameEventPlayerStatsChanged(this, false));
+        getGame().fireEvent(new GameEventPlayerStatsChanged(this));
     }
     public void removeAdditionalVillainousChoices(long timestamp) {
         if (additionalVillainousChoices.remove(timestamp) != null) {
             getView().updateAdditionalVillainousChoices(this);
-            getGame().fireEvent(new GameEventPlayerStatsChanged(this, false));
+            getGame().fireEvent(new GameEventPlayerStatsChanged(this));
         }
     }
 

--- a/forge-gui/src/main/java/forge/gui/control/FControlGameEventHandler.java
+++ b/forge-gui/src/main/java/forge/gui/control/FControlGameEventHandler.java
@@ -458,8 +458,7 @@ public class FControlGameEventHandler extends IGameEventVisitor.Base<Void> {
         for (final PlayerView p : event.players()) {
             processPlayer(p, livesUpdate);
         }
-
-        return processCards(event.allCards(), cardsRefreshDetails);
+        return null;
     }
 
     public Void visit(final GameEventLandPlayed event) {

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -2772,7 +2772,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
         @Override
         public void setCanPlayUnlimitedLands(final boolean canPlayUnlimitedLands0) {
             canPlayUnlimitedLands = canPlayUnlimitedLands0;
-            getGame().fireEvent(new GameEventPlayerStatsChanged(player, false));
+            getGame().fireEvent(new GameEventPlayerStatsChanged(player));
         }
 
         /*


### PR DESCRIPTION
There should be no reason that player keywords still cause cards to update.
Besides `MatchController#refreshCardDetails` hasn't even used that param for a long time anyway.

@MostCromulent
maybe Claude can check I didn't miss something?