### PR TITLE
Move GameState to game package; some cleanup

### DIFF
--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -877,7 +877,7 @@ public class PlayerControllerAi extends PlayerController {
     }
 
     @Override
-    public CardCollection chooseCardsToDiscardToMaximumHandSize(int numDiscard) {
+    public CardCollectionView chooseCardsToDiscardToMaximumHandSize(int numDiscard) {
         return brains.getCardsToDiscard(numDiscard, null, null);
     }
 

--- a/forge-game/src/main/java/forge/game/GameState.java
+++ b/forge-game/src/main/java/forge/game/GameState.java
@@ -26,7 +26,6 @@ import forge.game.spellability.AbilityManaPart;
 import forge.game.spellability.SpellAbility;
 import forge.game.zone.PlayerZone;
 import forge.game.zone.ZoneType;
-import forge.item.IPaperCard;
 import forge.item.PaperCard;
 import forge.item.PaperToken;
 import forge.util.TextUtil;
@@ -40,7 +39,7 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.stream.Stream;
 
-public abstract class GameState {
+public class GameState {
     private static final Map<ZoneType, String> ZONES = new HashMap<>();
     static {
         ZONES.put(ZoneType.Battlefield, "battlefield");
@@ -107,8 +106,6 @@ public abstract class GameState {
 
     public GameState() {
     }
-
-    public abstract IPaperCard getPaperCard(String cardName, String setCode, int artID);
 
     @Override
     public String toString() {

--- a/forge-game/src/main/java/forge/game/GameState.java
+++ b/forge-game/src/main/java/forge/game/GameState.java
@@ -1,4 +1,4 @@
-package forge.ai;
+package forge.game;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Lists;
@@ -10,8 +10,6 @@ import forge.card.CardStateName;
 import forge.card.GamePieceType;
 import forge.card.MagicColor;
 import forge.card.mana.ManaAtom;
-import forge.game.Game;
-import forge.game.GameEntity;
 import forge.game.ability.AbilityFactory;
 import forge.game.ability.ApiType;
 import forge.game.ability.effects.DetachedCardEffect;

--- a/forge-game/src/main/java/forge/game/player/PlayerController.java
+++ b/forge-game/src/main/java/forge/game/player/PlayerController.java
@@ -210,7 +210,7 @@ public abstract class PlayerController {
      *  when an effect has revealed extra cards, e.g. Reveal/Look modes). */
     public abstract CardCollectionView chooseCardsToDiscardFrom(Player playerDiscard, SpellAbility sa, CardCollection validCards, int min, int max, CardCollectionView visibleToChooser);
     public abstract CardCollectionView chooseCardsToDiscardUnlessType(int min, CardCollectionView hand, String[] unlessTypes, SpellAbility sa);
-    public abstract CardCollection chooseCardsToDiscardToMaximumHandSize(int numDiscard);
+    public abstract CardCollectionView chooseCardsToDiscardToMaximumHandSize(int numDiscard);
 
     public abstract CardCollectionView chooseCardsToDelve(int genericAmount, CardCollection grave);
     public abstract Map<Card, ManaCostShard> chooseCardsForConvokeOrImprovise(SpellAbility sa, ManaCost manaCost, CardCollectionView untappedCards, boolean artifacts, boolean creatures, Integer maxReduction);

--- a/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/match/CMatchUI.java
@@ -42,7 +42,7 @@ import forge.ImageCache;
 import forge.LobbyPlayer;
 import forge.Singletons;
 import forge.StaticData;
-import forge.ai.GameState;
+import forge.game.GameState;
 import forge.card.CardStateName;
 import forge.control.KeyboardShortcuts;
 import forge.deck.CardPool;

--- a/forge-gui-desktop/src/test/java/forge/gamesimulationtests/util/PlayerControllerForTests.java
+++ b/forge-gui-desktop/src/test/java/forge/gamesimulationtests/util/PlayerControllerForTests.java
@@ -433,7 +433,7 @@ public class PlayerControllerForTests extends PlayerController {
     }
 
     @Override
-    public CardCollection chooseCardsToDiscardToMaximumHandSize(int numDiscard) {
+    public CardCollectionView chooseCardsToDiscardToMaximumHandSize(int numDiscard) {
         return chooseItems(player.getZone(ZoneType.Hand).getCards(), numDiscard);
     }
 

--- a/forge-gui-desktop/src/test/java/forge/net/HeadlessNetworkGuiGame.java
+++ b/forge-gui-desktop/src/test/java/forge/net/HeadlessNetworkGuiGame.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Map;
 
 import forge.LobbyPlayer;
-import forge.ai.GameState;
+import forge.game.GameState;
 import forge.deck.CardPool;
 import forge.game.GameEntityView;
 import forge.game.card.CardView;

--- a/forge-gui-mobile/src/forge/screens/match/MatchController.java
+++ b/forge-gui-mobile/src/forge/screens/match/MatchController.java
@@ -15,7 +15,6 @@ import forge.game.GameState;
 import forge.deck.Deck;
 import forge.game.player.Player;
 import forge.game.player.PlayerController.FullControlFlag;
-import forge.item.IPaperCard;
 import forge.util.collect.FCollection;
 import forge.Forge;
 import forge.Graphics;
@@ -303,12 +302,7 @@ public class MatchController extends NetworkGuiGame {
             view.getStack().checkEmptyStack();
 
         if (ph != null && saveState && ph.isMain()) {
-            phaseGameState = new GameState() {
-                @Override
-                public IPaperCard getPaperCard(final String cardName, final String setCode, final int artID) {
-                    return FModel.getMagicDb().getCommonCards().getCard(cardName, setCode, artID);
-                }
-            };
+            phaseGameState = new GameState();
             try {
                 phaseGameState.initFromGame(getGameView().getGame());
             } catch (Exception e) {

--- a/forge-gui-mobile/src/forge/screens/match/MatchController.java
+++ b/forge-gui-mobile/src/forge/screens/match/MatchController.java
@@ -11,7 +11,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import forge.adventure.scene.DuelScene;
 import forge.adventure.util.Config;
-import forge.ai.GameState;
+import forge.game.GameState;
 import forge.deck.Deck;
 import forge.game.player.Player;
 import forge.game.player.PlayerController.FullControlFlag;

--- a/forge-gui/src/main/java/forge/gamemodes/net/server/RemoteClientGuiGame.java
+++ b/forge-gui/src/main/java/forge/gamemodes/net/server/RemoteClientGuiGame.java
@@ -1,7 +1,7 @@
 package forge.gamemodes.net.server;
 
 import forge.LobbyPlayer;
-import forge.ai.GameState;
+import forge.game.GameState;
 import forge.deck.CardPool;
 import forge.game.GameEntityView;
 import forge.game.event.GameEvent;

--- a/forge-gui/src/main/java/forge/gamemodes/puzzle/Puzzle.java
+++ b/forge-gui/src/main/java/forge/gamemodes/puzzle/Puzzle.java
@@ -19,10 +19,8 @@ import forge.game.spellability.SpellAbility;
 import forge.game.trigger.Trigger;
 import forge.game.trigger.TriggerHandler;
 import forge.game.zone.ZoneType;
-import forge.item.IPaperCard;
 import forge.item.InventoryItem;
 import forge.localinstance.properties.ForgeConstants;
-import forge.model.FModel;
 
 public class Puzzle extends GameState implements InventoryItem, Comparable<Puzzle> {
     String name;
@@ -106,10 +104,6 @@ public class Puzzle extends GameState implements InventoryItem, Comparable<Puzzl
     
     private void loadGameState(List<String> stateLines) {
         this.parse(stateLines);
-    }
-
-    public IPaperCard getPaperCard(final String cardName, final String setCode, final int artID) {
-        return FModel.getMagicDb().getCommonCards().getCard(cardName, setCode, artID);
     }
 
     public void setupMaxPlayerHandSize(Game game, int maxHandSize) {

--- a/forge-gui/src/main/java/forge/gamemodes/puzzle/Puzzle.java
+++ b/forge-gui/src/main/java/forge/gamemodes/puzzle/Puzzle.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 import com.google.common.collect.Sets;
 
-import forge.ai.GameState;
+import forge.game.GameState;
 import forge.card.GamePieceType;
 import forge.game.Game;
 import forge.game.GameType;

--- a/forge-gui/src/main/java/forge/gui/interfaces/IGuiGame.java
+++ b/forge-gui/src/main/java/forge/gui/interfaces/IGuiGame.java
@@ -1,7 +1,7 @@
 package forge.gui.interfaces;
 
 import forge.LobbyPlayer;
-import forge.ai.GameState;
+import forge.game.GameState;
 import forge.deck.CardPool;
 import forge.game.GameEntityView;
 import forge.game.GameView;

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -2821,12 +2821,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
         }
 
         private GameState createGameStateObject() {
-            return new GameState() {
-                @Override
-                public IPaperCard getPaperCard(final String cardName, final String setCode, final int artID) {
-                    return FModel.getMagicDb().getCommonCards().getCard(cardName, setCode, artID);
-                }
-            };
+            return new GameState();
         }
 
         /*

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -1736,7 +1736,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
     }
 
     @Override
-    public CardCollection chooseCardsToDiscardToMaximumHandSize(final int nDiscard) {
+    public CardCollectionView chooseCardsToDiscardToMaximumHandSize(final int nDiscard) {
         final int max = player.getMaxHandSize();
 
         if (getGui().isLibgdxPort()) {

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -4,7 +4,7 @@ import com.google.common.collect.*;
 import forge.LobbyPlayer;
 import forge.StaticData;
 import forge.ai.AvailableActions;
-import forge.ai.GameState;
+import forge.game.GameState;
 import forge.ai.PlayerControllerAi;
 import forge.gamemodes.net.server.RemoteClientGuiGame;
 import forge.card.*;


### PR DESCRIPTION
Was doing some experimentation with the GameState class and it seemed like something that'd make more sense to have in the game module than the AI one. It doesn't appear dependent on anything else in the AI module, so I've moved it.

It also had a vestigial abstract `getPaperCard` method, which was implemented the same way everywhere and - as far as I can tell - hasn't been used since a PR in 2017 replaced its only invocation with something else. Removed that method. It was also the only abstract method remaining in the class, so for now I made the class concrete and removed the anonymous implementations. We could go the other way and re-insert `getPaperCard` as the supplier for the card in `processCardsForZone`, but I'm not sure what we'd ever override it with and this way seems cleaner.

Changed the return type of `chooseCardsToDiscardToMaximumHandSize` to match the ones from `chooseCardsToDiscardFrom` and `chooseCardsToDiscardUnlessType`.