### PR TITLE
Reset reused mobile GUI state between matches

### DIFF
--- a/forge-gui-mobile/src/forge/GuiMobile.java
+++ b/forge-gui-mobile/src/forge/GuiMobile.java
@@ -346,6 +346,7 @@ public class GuiMobile implements IGuiBase {
 
     @Override
     public IGuiGame getNewGuiGame() {
+        MatchController.instance.resetForNewMatch();
         return MatchController.instance;
     }
 

--- a/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/AbstractGuiGame.java
@@ -90,16 +90,7 @@ public abstract class AbstractGuiGame implements IGuiGame, IMayViewCards {
     public final void setCurrentPlayer(PlayerView player) {
         player = TrackableTypes.PlayerViewType.lookup(player); //ensure we use the correct player
 
-        if (hasLocalPlayers() && !isLocalPlayer(player)) { //add check if gameControllers is not empty
-            if(GuiBase.getInterface().isLibgdxPort()){//spectator is registered as localplayer bug on ai vs ai (after .
-                if (spectator != null){               //human vs ai game), then it loses "control" when you watch ai vs ai,
-                    currentPlayer = null;             //again, and vice versa, This is to prevent throwing error, lose control,
-                    updateCurrentPlayer(null);        //workaround fix on mayviewcards below is needed or it will bug the UI..
-                    gameControllers.clear();
-                    return;
-                }
-            }
-
+        if (hasLocalPlayers() && !isLocalPlayer(player)) {
             throw new IllegalArgumentException();
         }
 
@@ -203,6 +194,20 @@ public abstract class AbstractGuiGame implements IGuiGame, IMayViewCards {
         this.spectator = spectator;
     }
 
+    /**
+     * Discard the previous match's controller bookkeeping. The mobile port hands out a single
+     * reused {@code MatchController} instance per match (see {@code GuiMobile.getNewGuiGame()}),
+     * whereas desktop constructs a fresh {@code CMatchUI}; without this reset the prior match's
+     * controllers and spectator leak into the next match and break {@link #setCurrentPlayer} and
+     * {@link #mayView}.
+     */
+    public void resetForNewMatch() {
+        gameControllers.clear();
+        originalGameControllers.clear();
+        spectator = null;
+        currentPlayer = null;
+    }
+
     @Override
     public final void updateSingleCard(final CardView card) {
         updateCards(Collections.singleton(card));
@@ -233,27 +238,10 @@ public abstract class AbstractGuiGame implements IGuiGame, IMayViewCards {
         if (!hasLocalPlayers()) {
             return true; //if not in game, card can be shown
         }
-        if (GuiBase.getInterface().isLibgdxPort()){
-            if (gameView != null && gameView.isGameOver()) {
-                return true;
-            }
-            if (spectator != null) { //workaround fix!! this is needed on above code or it will
-                for (Map.Entry<PlayerView, IGameController> e : gameControllers.entrySet()) {
-                    if (e.getValue().equals(spectator)) {
-                        gameControllers.remove(e.getKey());
-                        break;
-                    }
-                }
-                return true;
-            }
-            try {
-                if (getGameController().mayLookAtAllCards()) { // when it bugged here, the game thinks the spectator (null)
-                    return true;                               // is the humancontroller here (maybe because there is an existing game thread???)
-                }
-            } catch (NullPointerException e) {
-                return true; // return true so it will work as normal
-            }
-        } else if (getGameController().mayLookAtAllCards()) {
+        if (GuiBase.getInterface().isLibgdxPort() && gameView != null && gameView.isGameOver()) {
+            return true; //mobile: browse every zone from the minimized win/lose overlay after the match ends
+        }
+        if (getGameController().mayLookAtAllCards()) {
             return true;
         }
         return c.canBeShownToAny(getLocalPlayers());


### PR DESCRIPTION
Originally raised in review: https://github.com/Card-Forge/forge/pull/11006#pullrequestreview-4496729113

## Summary

The mobile port hands out a single reused `MatchController` instance for every match (`GuiMobile.getNewGuiGame()` returns the singleton), whereas desktop constructs a fresh `CMatchUI` each time. Because the mobile instance is never reset, the previous match's controllers and spectator leak into the next match. The visible symptom: after a human-vs-AI game, switching to watch an AI-vs-AI game registers the spectator as a local player, which loses "control" of the view and throws from `setCurrentPlayer`/`mayView`.

This PR resets that bookkeeping at the start of each match instead of papering over the leaked state mid-game.

## Root cause / history

The leak was previously masked by two libgdx-only workarounds inside `AbstractGuiGame`:

- `setCurrentPlayer` swallowed the `IllegalArgumentException` (clearing `gameControllers` and returning) whenever a stale `spectator` was present.
- `mayView` removed the spectator from `gameControllers` on the fly and wrapped `getGameController().mayLookAtAllCards()` in a `try/catch (NullPointerException)` that returned `true`.

Both were symptom-level patches for one root cause — match state carried over on the reused singleton — and the surrounding comments described them as fragile fixes that depended on each other.

## The fix

- Add `AbstractGuiGame.resetForNewMatch()` that clears `gameControllers`, `originalGameControllers`, `spectator`, and `currentPlayer`.
- Call it from `GuiMobile.getNewGuiGame()` so the reused instance starts each match clean.
- Remove both libgdx workarounds, restoring `setCurrentPlayer` and `mayView` to their straightforward form.

This makes the mobile lifecycle mirror desktop: desktop already starts every match with clean controller state because `GuiDesktop.getNewGuiGame()` constructs a fresh `CMatchUI`. Mobile reuses one `MatchController`, so `resetForNewMatch()` gives it the same clean-slate guarantee at the same point in the lifecycle — rather than letting stale state accumulate and patching the fallout mid-game.

## Why it's safe

- Mobile now behaves like desktop: both enter every match with empty controllers and no spectator, so the engine-facing `setCurrentPlayer`/`mayView` contracts are identical across platforms — the libgdx-only special cases are no longer needed.
- Every mobile match-start routes through `getNewGuiGame()` (local lobby, spectate, puzzle, draft, sealed), so the reset always runs before any controller is registered — the leaked state the workarounds handled can no longer exist.
- The spectate path (`HostedMatch`, `humanCount == 0`) sets a spectator but leaves `gameControllers` empty, so `mayView` returns early via `hasLocalPlayers()` and never reaches the now-unguarded `getGameController()` call.
- The invariant "non-empty `gameControllers` implies a non-null `currentPlayer` that is a key in the map" holds across every mutation site, so `getGameController()` is never null when `hasLocalPlayers()` is true — making the removed NPE catch dead code.
- Desktop is unaffected: it builds a fresh `CMatchUI` per match and never calls `resetForNewMatch()`. Adventure mode is also unaffected: it uses `MatchController.instance` directly rather than `getNewGuiGame()`, and never registers a spectator, so neither the reset nor the removed workarounds change its behavior.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
