### PR TITLE
Funnel lobby view updates through the EDT (desktop)

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
+++ b/forge-gui-desktop/src/main/java/forge/screens/home/VLobby.java
@@ -25,6 +25,7 @@ import forge.gamemodes.match.LobbySlotType;
 import forge.gamemodes.net.*;
 import forge.gamemodes.net.event.UpdateLobbyPlayerEvent;
 import forge.gui.CardDetailPanel;
+import forge.gui.FThreads;
 import forge.gui.SwingPrefBinders;
 import forge.gui.interfaces.IDraftEventHandler;
 import forge.gui.interfaces.ILobbyView;
@@ -339,6 +340,10 @@ public class VLobby implements ILobbyView {
 
     @Override
     public void update(final int slot, final LobbySlotType type) {
+        FThreads.invokeInEdtNowOrLater(() -> updateImpl(slot, type));
+    }
+
+    private void updateImpl(final int slot, final LobbySlotType type) {
         final FDeckChooser deckChooser = getDeckChooser(slot);
         deckChooser.setIsAi(type==LobbySlotType.AI);
         DeckType selectedDeckType = deckChooser.getSelectedDeckType();
@@ -362,8 +367,14 @@ public class VLobby implements ILobbyView {
         }
     }
 
+    // Lobby updates arrive on the Netty IO thread (network) and the EDT (local actions);
+    // VLobby mutates non-thread-safe Swing state, so funnel every update through the EDT.
     @Override
     public void update(final boolean fullUpdate) {
+        FThreads.invokeInEdtNowOrLater(() -> updateImpl(fullUpdate));
+    }
+
+    private void updateImpl(final boolean fullUpdate) {
         activePlayersNum = lobby.getNumberOfSlots();
         addPlayerBtn.setEnabled(activePlayersNum < MAX_PLAYERS);
 


### PR DESCRIPTION
## The bug

A Discord user reported the multiplayer lobby freezing on the joiner's side — they can't pick decks or type a name — once the host switches to Commander or adds an AI; a plain Constructed lobby joins fine.

Logs from both players (identical Forge build) show the joiner decode exactly one large (~28–35 KB) `LobbyUpdateEvent`, then its single Netty IO thread goes silent — no further decodes, no heartbeats — until the host's 45 s idle timeout drops the connection. The pattern is identical across five frozen sessions; a working Constructed session instead shows a steady stream of updates decoded at ~5–7 ms each. Twice, clicking the lobby tab mid-freeze threw `NullPointerException … FDeckChooser.populate() because "fdc" is null` at `VSubmenuOnlineLobby.populate`.

## Root cause (hypothesis)

The root cause and fix proposed here are a hypothesis from code review by Claude, not a confirmed reproduction — the freeze couldn't be reproduced locally, where near-zero loopback latency runs the threads sequentially instead of overlapping.

Instrumenting a local build confirmed the underlying defect: `VLobby.update` runs on the Netty IO thread (`nioEventLoopGroup-*`) for network updates and on the EDT for local actions, with no synchronization, while mutating non-thread-safe Swing state — the deck-chooser cache (`HashMap`) and player-panel list (`ArrayList`). Commander/AI grows that shared state and loads heavier deck choosers; concurrent access from the two threads can wedge the Netty thread mid-update, stopping heartbeats and tripping the timeout. The `fdc == null` NPE is the same race from the EDT side, reading the panel list mid-mutation.

The cross-thread access is proven by the trace, but this PR isn't confirmed to resolve the reporter's freeze directly; it fixes a real defect that is a plausible cause.

## The fix

Marshal both `VLobby.update` overloads onto the EDT via `FThreads.invokeInEdtNowOrLater`, so the view is only ever touched by one thread.

Why it's safe:
- Runs inline when already on the EDT, preserving the synchronous contract existing EDT callers rely on (Start button, mode switch); only the off-EDT network path is deferred, and nothing reads lobby state after it.
- Confined to `forge-gui-desktop`'s `VLobby`; mobile has its own lobby screen and shared/network code is unchanged, so mobile is unaffected.
- On the host, only the view update defers; the lobby-state broadcast (serializing the already-mutated model) still runs synchronously, so ordering is unaffected.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)