### PR TITLE
Fix logging regression (Sentry suggestion)

### DIFF
--- a/forge-gui/src/main/java/forge/error/ExceptionHandler.java
+++ b/forge-gui/src/main/java/forge/error/ExceptionHandler.java
@@ -105,6 +105,15 @@ public class ExceptionHandler implements UncaughtExceptionHandler {
      * static initializer has run.
      */
     public static void registerErrorHandling() {
+        if (logChannel != null) {
+            // Already holding our slot lock in this JVM (e.g. Forge.create() re-entered
+            // after Android recreates the GL surface/context). Re-running the logic below
+            // would tryLock() our own activeLogFile via a second channel, which throws
+            // OverlappingFileLockException (not an IOException, so it wouldn't be caught
+            // by the archive-probe loop) and would also claim a second log slot.
+            return;
+        }
+
         File parent = new File(ForgeConstants.LOG_FILE).getParentFile();
         parent.mkdirs();
 


### PR DESCRIPTION
<strong>Automated triage (Claude Code)</strong></p>
<p><code>registerErrorHandling()</code> is re-entered within the same JVM when <code>Forge.create()</code> runs again after Android recreates the GL surface/context (no <code>unregisterErrorHandling()</code> call in between — that only happens in <code>dispose()</code>).</p>
<p>On re-entry, the "archive unowned slot files" loop (added in #10588 / commit <code>3395c61ae2</code>, 2026-05-03) lists files matching <code>forge\d*\.log</code>. This list includes <code>activeLogFile</code> (e.g. <code>forge.log</code>), which this JVM is <em>already</em> holding via <code>logChannel</code>/<code>logLock</code> from the first call. The loop opens a <strong>second</strong> <code>FileChannel</code> on that same file and calls <code>tryLock()</code>.</p>
<p>Per the <code>FileChannel.tryLock()</code> javadoc, this throws <code>OverlappingFileLockException</code> when the <strong>same JVM</strong> already holds an overlapping lock — and <code>OverlappingFileLockException</code> is an <code>IllegalStateException</code>, not an <code>IOException</code>, so it is <strong>not</strong> caught by the loop's <code>catch (IOException ignored)</code>. It propagates out of <code>registerErrorHandling()</code> → <code>Forge.create()</code> → <code>AndroidGraphics.onSurfaceChanged()</code> → <code>GLSurfaceView$GLThread.guardedRun()</code>, exactly matching this issue's stack trace (<code>tryLock</code> → <code>FileChannelImpl.tryLock</code> → <code>SharedFileLockTable.add</code>/<code>checkList</code>).</p>
<p>Even if that exception were caught, the subsequent <code>CREATE_NEW</code> loop would skip <code>forge.log</code> (<code>FileAlreadyExistsException</code>) and claim <code>forge1.log</code> as a <em>second</em> slot for the same running instance — leaking a channel/lock and violating the "one slot per instance" invariant the rotation rewrite was meant to establish.</p>