### PR TITLE
Apply another Sentry suggestion

### DIFF
--- a/forge-gui/src/main/java/forge/gamemodes/match/HostedMatch.java
+++ b/forge-gui/src/main/java/forge/gamemodes/match/HostedMatch.java
@@ -281,14 +281,20 @@ public class HostedMatch {
         // It's important to run match in a different thread to allow GUI inputs to be invoked from inside game. 
         // Game is set on pause while gui player takes decisions
         game.getAction().invoke(() -> {
+            // Capture the current game in a local so this lambda keeps operating on the
+            // game it started even if another thread (e.g. the EDT handling a player's
+            // "quit"/"continue" decision via addNextGameDecision -> endCurrentGame())
+            // concurrently clears the `game` field while match.startGame() is wrapping up.
+            final Game currentGame = game;
+
             if (humanCount == 0) {
                 // Create FControlGamePlayback in game thread to allow pausing
                 playbackControl = new FControlGamePlayback(humanControllers.get(0));
-                playbackControl.setGame(game);
-                game.subscribeToEvents(playbackControl);
+                playbackControl.setGame(currentGame);
+                currentGame.subscribeToEvents(playbackControl);
             }
             // Actually start the game!
-            match.startGame(game, startGameHook);
+            match.startGame(currentGame, startGameHook);
             // this function waits?
             if (endGameHook != null){
                 endGameHook.run();
@@ -309,7 +315,7 @@ public class HostedMatch {
             isMatchOver = match.isMatchOver();
             if (humanCount == 0) {
                 // ... if no human players, let AI decide next game
-                if (game.getRules().getGameType() == GameType.Constructed) {
+                if (currentGame.getRules().getGameType() == GameType.Constructed) {
                     // Dramatic interlude to signal end of game.
                     FThreads.delayInEDT(3000, () -> {
                         if (isMatchOver) {


### PR DESCRIPTION
<strong>Automated triage (Claude Code)</strong>

<code>startGame()</code> calls <code>game.getAction().invoke(() -&gt; { ... })</code>, which runs the lambda body on a separate "game thread" (the <code>ThreadPoolExecutor</code> seen in the trace) while <code>match.startGame(game, startGameHook)</code> blocks until the game finishes. After it returns, the lambda continues with post-game cleanup (flushing forwarders, checking <code>match.isMatchOver()</code>, and — for <code>humanCount == 0</code> — <code>game.getRules().getGameType()</code>).</p>
<p>Meanwhile, <code>endCurrentGame()</code> (called from <code>continueMatch()</code>, <code>restartMatch()</code>, or <code>addNextGameDecision(..., NextGameDecision.QUIT)</code>) sets the <strong>field</strong> <code>this.game = null</code>. <code>addNextGameDecision</code> can be triggered on the EDT (via <code>UiEventNextGameDecision</code>, e.g. a player choosing to quit/continue) asynchronously relative to the game thread, through <code>FThreads.invokeInEdtNowOrLater</code>.</p>
<p>If the EDT runs <code>endCurrentGame()</code> (nulling <code>this.game</code>) while the game thread is still inside <code>lambda$startGame$2</code>'s post-game cleanup (after <code>match.startGame()</code> returns but before/at line 322's <code>game.getRules()</code>), the lambda dereferences a now-null <code>this.game</code> field → NPE. Both reporting players ("Christine"/"Nymira") suggest a 2-human-player match, where one player's "leave/continue" decision races with the other thread's game-finish cleanup.</p>