### PR TITLE
Fix floating zone windows obscuring modals and lingering on macOS

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/view/FDialog.java
+++ b/forge-gui-desktop/src/main/java/forge/view/FDialog.java
@@ -5,6 +5,7 @@ import java.awt.Component;
 import java.awt.Container;
 import java.awt.Cursor;
 import java.awt.Dimension;
+import java.awt.Frame;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.GraphicsDevice;
@@ -79,7 +80,11 @@ public class FDialog extends SkinnedDialog implements ITitleBarOwner, KeyEventDi
     }
 
     public FDialog(final boolean modal0, final boolean allowResize0, final String insets) {
-        super(JOptionPane.getRootFrame(), modal0);
+        this(JOptionPane.getRootFrame(), modal0, allowResize0, insets);
+    }
+
+    public FDialog(final Frame owner, final boolean modal0, final boolean allowResize0, final String insets) {
+        super(owner, modal0);
         allowResize = allowResize0;
         setUndecorated(true);
         setIconImage(FSkin.getIcon(FSkinProp.ICO_FAVICON)); //use Forge icon by default
@@ -187,6 +192,8 @@ public class FDialog extends SkinnedDialog implements ITitleBarOwner, KeyEventDi
                     Singletons.getView().getNavigationBar().setMenuShortcutsEnabled(false);
                 }
                 openModals.push(this);
+                // macOS can float a non-modal sibling (floating zone, chat) above an app-modal dialog; invokeLater runs in the modal's own event pump, so this raises it above them once shown
+                SwingUtilities.invokeLater(this::toFront);
             }
         }
         else {

--- a/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingCardArea.java
+++ b/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingCardArea.java
@@ -94,8 +94,10 @@ public abstract class FloatingCardArea extends CardArea {
         }
     }
 
+    // Owned by the main Forge frame, not the invisible shared root frame: on macOS a focusable child of the
+    // invisible frame won't release focus when hidden, so it lingers and outlives the match behind the main window.
     @SuppressWarnings("serial")
-    protected final FDialog window = new FDialog(false, true, "0") {
+    protected final FDialog window = new FDialog(Singletons.getView().getFrame(), false, true, "0") {
         @Override
         public void setLocationRelativeTo(Component c) {
             if (hasBeenShown || locLoaded) { return; }

--- a/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingZone.java
+++ b/forge-gui-desktop/src/main/java/forge/view/arcane/FloatingZone.java
@@ -288,6 +288,7 @@ public class FloatingZone extends FloatingCardArea {
     public static void closeAll() {
         for (final FloatingZone cardArea : floatingAreas.values()) {
             cardArea.window.setVisible(false);
+            cardArea.window.dispose(); // release the native window; on macOS setVisible(false) alone can leave it lingering behind the main frame
         }
         floatingAreas.clear();
 


### PR DESCRIPTION
## Bug report

A macOS user reported several "subwindow" problems with the zone view, new this release:

- Casting a delve spell (e.g. Tasigur), the **Playable Zone window stayed on top of and blocked the card-selection prompt** — the real prompt sat behind it, and each per-card prompt re-opened behind the floating window.
- After selecting cards (e.g. Lotuslight Dancers), floating zone windows **didn't close** — they lingered atop the main window and only left when the main window was clicked (which sent them to the background, not away).
- Floating zone windows **survived the game behind the main window**, uncloseable except via the OS window manager.

## Root cause

The recent zone-view rework made these floating windows focusable while leaving them owned by the invisible shared root frame (`JOptionPane.getRootFrame()`).

This only misbehaves on macOS, because its Cocoa AWT peers handle windows differently from the Windows/Linux window managers. macOS enforces application modality by **blocking input** rather than by **reordering windows**, so a non-modal sibling can stay visually in front of a modal it no longer accepts clicks for. And a window owned by an invisible, never-shown frame has **no real parent window** to fall back to — so it is never re-stacked behind a modal, never hands focus back when hidden (it lingers until another window is clicked), and isn't tied to any visible window's lifecycle (so it outlives the match). Windows and Linux enforce owner/modal stacking and focus hand-off natively, so the same code behaves correctly there.

## Fix

- **Own the floating windows by the main Forge frame** instead of the invisible root frame — ties their focus and lifecycle to the main window so they stack, hide, and close with it.
- **Modal `FDialog`s raise themselves to front on show**, so a non-modal sibling can no longer obscure a modal prompt.
- **`closeAll()` now disposes** the windows post-game instead of only hiding them.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)