### PR TITLE
Update brainstone.txt

### DIFF
--- a/forge-gui/res/cardsfolder/b/brainstone.txt
+++ b/forge-gui/res/cardsfolder/b/brainstone.txt
@@ -2,5 +2,5 @@ Name:Brainstone
 ManaCost:1
 Types:Artifact
 A:AB$ Draw | Cost$ 2 T Sac<1/CARDNAME> | NumCards$ 3 | SubAbility$ DBChangeZone | StackDescription$ {p:You} draws three cards, | SpellDescription$ Draw three cards, then put two cards from your hand on top of your library in any order.
-SVar:DBChangeZone:DB$ ChangeZone | Origin$ Hand | Destination$ Library | ChangeNum$ 2 | Mandatory$ True | StackDescription$ then puts two cards from their hand on top of their library in any order.
+SVar:DBChangeZone:DB$ ChangeZone | Origin$ Hand | Destination$ Library | ChangeNum$ 2 | Mandatory$ True | Reorder$ True | StackDescription$ then puts two cards from their hand on top of their library in any order.
 Oracle:{2}, {T}, Sacrifice Brainstone: Draw three cards, then put two cards from your hand on top of your library in any order.


### PR DESCRIPTION
I noticed when I was playing Realm of Legends that when I use this card on my miracle Aminatou deck, it doesn't give me an option to reorder the cards that I return. It seems like the card is missing something compared to Brainstorm, so I looked it up and found the reason why. Added the missing thing so that it will function closer to Brainstorm.