### PR TITLE
Card cleanup: 2026-06-27 [Reminder text: Map token]

### DIFF
--- a/forge-gui/res/cardsfolder/b/brackish_blunder.txt
+++ b/forge-gui/res/cardsfolder/b/brackish_blunder.txt
@@ -2,6 +2,6 @@ Name:Brackish Blunder
 ManaCost:1 U
 Types:Instant
 A:SP$ ChangeZone | ValidTgts$ Creature | Origin$ Battlefield | Destination$ Hand | SubAbility$ DBToken | SpellDescription$ Return target creature to its owner's hand.
-SVar:DBToken:DB$ Token | TokenScript$ c_a_map_sac_explore | ConditionDefined$ Targeted | ConditionPresent$ Card.tapped | SpellDescription$ If it was tapped, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.")
+SVar:DBToken:DB$ Token | TokenScript$ c_a_map_sac_explore | ConditionDefined$ Targeted | ConditionPresent$ Card.tapped | SpellDescription$ If it was tapped, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.")
 DeckHas:Ability$Token|Counters|Sacrifice & Type$Artifact|Map
-Oracle:Return target creature to its owner's hand. If it was tapped, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.")
+Oracle:Return target creature to its owner's hand. If it was tapped, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.")

--- a/forge-gui/res/cardsfolder/c/cartographers_companion.txt
+++ b/forge-gui/res/cardsfolder/c/cartographers_companion.txt
@@ -2,7 +2,7 @@ Name:Cartographer's Companion
 ManaCost:3
 Types:Artifact Creature Gnome
 PT:2/1
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.")
 SVar:TrigToken:DB$ Token | TokenScript$ c_a_map_sac_explore
 DeckHas:Ability$Token|Counters|Sacrifice & Type$Artifact|Map
-Oracle:When Cartographer's Companion enters, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.")
+Oracle:When Cartographer's Companion enters, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.")

--- a/forge-gui/res/cardsfolder/f/fanatical_offering.txt
+++ b/forge-gui/res/cardsfolder/f/fanatical_offering.txt
@@ -1,7 +1,7 @@
 Name:Fanatical Offering
 ManaCost:1 B
 Types:Instant
-A:SP$ Draw | Cost$ 1 B Sac<1/Artifact;Creature/artifact or creature> | NumCards$ 2 | SubAbility$ DBToken | SpellDescription$ Draw two cards and create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.")
+A:SP$ Draw | Cost$ 1 B Sac<1/Artifact;Creature/artifact or creature> | NumCards$ 2 | SubAbility$ DBToken | SpellDescription$ Draw two cards and create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.")
 SVar:DBToken:DB$ Token | TokenScript$ c_a_map_sac_explore | TokenOwner$ You
 DeckHas:Ability$Sacrifice|Token & Type$Artifact|Map
-Oracle:As an additional cost to cast this spell, sacrifice an artifact or creature.\nDraw two cards and create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.")
+Oracle:As an additional cost to cast this spell, sacrifice an artifact or creature.\nDraw two cards and create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.")

--- a/forge-gui/res/cardsfolder/g/get_lost.txt
+++ b/forge-gui/res/cardsfolder/g/get_lost.txt
@@ -1,7 +1,7 @@
 Name:Get Lost
 ManaCost:1 W
 Types:Instant
-A:SP$ Destroy | ValidTgts$ Creature,Enchantment,Planeswalker | TgtPrompt$ Select target creature, enchantment, or planeswalker | SubAbility$ DBToken | SpellDescription$ Destroy target creature, enchantment, or planeswalker. Its controller creates two Map tokens. (They're artifacts with "{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.")
+A:SP$ Destroy | ValidTgts$ Creature,Enchantment,Planeswalker | TgtPrompt$ Select target creature, enchantment, or planeswalker | SubAbility$ DBToken | SpellDescription$ Destroy target creature, enchantment, or planeswalker. Its controller creates two Map tokens. (They're artifacts with "{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.")
 SVar:DBToken:DB$ Token | TokenScript$ c_a_map_sac_explore | TokenOwner$ TargetedController | TokenAmount$ 2
 DeckHas:Ability$Token|Sacrifice & Type$Artifact|Map
-Oracle:Destroy target creature, enchantment, or planeswalker. Its controller creates two Map tokens. (They're artifacts with "{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.")
+Oracle:Destroy target creature, enchantment, or planeswalker. Its controller creates two Map tokens. (They're artifacts with "{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.")

--- a/forge-gui/res/cardsfolder/s/sentinel_of_the_nameless_city.txt
+++ b/forge-gui/res/cardsfolder/s/sentinel_of_the_nameless_city.txt
@@ -3,9 +3,9 @@ ManaCost:2 G
 Types:Creature Merfolk Warrior Scout
 PT:3/4
 K:Vigilance
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ Whenever CARDNAME enters or attacks, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.")
-T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigToken | Secondary$ True | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME enters or attacks, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ Whenever CARDNAME enters or attacks, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.")
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigToken | Secondary$ True | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME enters or attacks, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.")
 SVar:TrigToken:DB$ Token | TokenScript$ c_a_map_sac_explore
 SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Token|Counters|Sacrifice & Type$Artifact|Map
-Oracle:Vigilance\nWhenever Sentinel of the Nameless City enters or attacks, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.")
+Oracle:Vigilance\nWhenever Sentinel of the Nameless City enters or attacks, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.")

--- a/forge-gui/res/cardsfolder/s/spyglass_siren.txt
+++ b/forge-gui/res/cardsfolder/s/spyglass_siren.txt
@@ -3,7 +3,7 @@ ManaCost:U
 Types:Creature Siren Pirate
 PT:1/1
 K:Flying
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.")
 SVar:TrigToken:DB$ Token | TokenScript$ c_a_map_sac_explore
 DeckHas:Ability$Token|Counters|Sacrifice & Type$Artifact|Map
-Oracle:Flying\nWhen Spyglass Siren enters, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.")
+Oracle:Flying\nWhen Spyglass Siren enters, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.")

--- a/forge-gui/res/cardsfolder/s/storm_fleet_negotiator.txt
+++ b/forge-gui/res/cardsfolder/s/storm_fleet_negotiator.txt
@@ -3,7 +3,7 @@ ManaCost:2 U
 Types:Creature Siren Pirate
 PT:2/2
 K:Flying
-T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPeek | TriggerZones$ Battlefield | TriggerDescription$ Parley — Whenever CARDNAME attacks, each player reveals the top card of their library. For each nonland card revealed this way, you create a Map token. Then each player draws a card. (A Map token is an artifact with "{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.")
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPeek | TriggerZones$ Battlefield | TriggerDescription$ Parley — Whenever CARDNAME attacks, each player reveals the top card of their library. For each nonland card revealed this way, you create a Map token. Then each player draws a card. (A Map token is an artifact with "{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.")
 SVar:TrigPeek:DB$ PeekAndReveal | Defined$ Player | RememberRevealed$ True | SubAbility$ DBToken
 SVar:DBToken:DB$ Token | TokenScript$ c_a_map_sac_explore | TokenAmount$ X | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw | Defined$ Player | SubAbility$ DBCleanup
@@ -11,4 +11,4 @@ SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Remembered$Valid Card.nonLand
 SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Token & Type$Map|Artifact
-Oracle:Flying\nParley — Whenever Storm Fleet Negotiator attacks, each player reveals the top card of their library. For each nonland card revealed this way, you create a Map token. Then each player draws a card. (A Map token is an artifact with "{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.")
+Oracle:Flying\nParley — Whenever Storm Fleet Negotiator attacks, each player reveals the top card of their library. For each nonland card revealed this way, you create a Map token. Then each player draws a card. (A Map token is an artifact with "{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.")

--- a/forge-gui/res/cardsfolder/t/topography_tracker.txt
+++ b/forge-gui/res/cardsfolder/t/topography_tracker.txt
@@ -2,9 +2,9 @@ Name:Topography Tracker
 ManaCost:2 G
 Types:Creature Merfolk Scout
 PT:2/2
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.")
 SVar:TrigToken:DB$ Token | TokenScript$ c_a_map_sac_explore
 R:Event$ Explore | ActiveZones$ Battlefield | ValidExplorer$ Creature.YouCtrl | ReplaceWith$ Explore1 | Description$ If a creature you control would explore, instead it explores, then it explores again.
 SVar:Explore1:DB$ Explore | Defined$ ReplacedCard | Num$ 2
 DeckHas:Ability$Token|Sacrifice & Type$Map|Artifact
-Oracle:When Topography Tracker enters, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.")\nIf a creature you control would explore, instead it explores, then it explores again.
+Oracle:When Topography Tracker enters, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.")\nIf a creature you control would explore, instead it explores, then it explores again.

--- a/forge-gui/res/cardsfolder/w/waterwind_scout.txt
+++ b/forge-gui/res/cardsfolder/w/waterwind_scout.txt
@@ -3,7 +3,7 @@ ManaCost:2 U
 Types:Creature Merfolk Scout
 PT:2/2
 K:Flying
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.")
 SVar:TrigToken:DB$ Token | TokenScript$ c_a_map_sac_explore
 DeckHas:Ability$Token|Counters|Sacrifice & Type$Artifact|Map
-Oracle:Flying\nWhen Waterwind Scout enters, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.")
+Oracle:Flying\nWhen Waterwind Scout enters, create a Map token. (It's an artifact with "{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.")

--- a/forge-gui/res/cardsfolder/w/worldwalker_helm.txt
+++ b/forge-gui/res/cardsfolder/w/worldwalker_helm.txt
@@ -1,9 +1,9 @@
 Name:Worldwalker Helm
 ManaCost:2 U
 Types:Artifact
-R:Event$ CreateToken | ActiveZones$ Battlefield | ValidPlayer$ You | ValidToken$ Artifact | ReplaceWith$ DBReplace | Description$ If you would create one or more artifact tokens, instead create those tokens plus an additional Map token. (It's an artifact with "{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.")
+R:Event$ CreateToken | ActiveZones$ Battlefield | ValidPlayer$ You | ValidToken$ Artifact | ReplaceWith$ DBReplace | Description$ If you would create one or more artifact tokens, instead create those tokens plus an additional Map token. (It's an artifact with "{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.")
 SVar:DBReplace:DB$ ReplaceToken | Type$ AddToken | Amount$ 1 | TokenScript$ c_a_map_sac_explore
 A:AB$ CopyPermanent | Cost$ 1 U T | ValidTgts$ Artifact.YouCtrl+token | TgtPrompt$ Select target artifact token you control to copy | SpellDescription$ Create a token that's a copy of target artifact token you control.
 DeckHas:Ability$Sacrifice|Token & Type$Artifact|Map
 DeckHints:Type$Artifact & Ability$Token
-Oracle:If you would create one or more artifact tokens, instead create those tokens plus an additional Map token. (It's an artifact with "{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.")\n{1}{U}, {T}: Create a token that's a copy of target artifact token you control.
+Oracle:If you would create one or more artifact tokens, instead create those tokens plus an additional Map token. (It's an artifact with "{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.")\n{1}{U}, {T}: Create a token that's a copy of target artifact token you control.


### PR DESCRIPTION
Following up on https://github.com/Card-Forge/forge/pull/11086
A good number of tokens have had their reminder text updated to replace "artifact" with "token" for relevant activated abilities. Such is the case for Map tokens as exemplified by  [Brackish Blunder](https://gatherer.wizards.com/LCI/en-us/46/brackish-blunder) and [Worldwalker Helm](https://gatherer.wizards.com/BIG/en-us/7/worldwalker-helm)