### PR TITLE
Card cleanup: 2026-06-27 [Reminder text: Incubator token]

### DIFF
--- a/forge-gui/res/cardsfolder/a/assimilate_essence.txt
+++ b/forge-gui/res/cardsfolder/a/assimilate_essence.txt
@@ -2,6 +2,6 @@ Name:Assimilate Essence
 ManaCost:1 U
 Types:Instant
 A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target creature or battle spell | ValidTgts$ Creature,Battle | UnlessCost$ 4 | UnlessResolveSubs$ WhenPaid | SubAbility$ DBIncubate | SpellDescription$ Counter target spell unless its controller pays {4}.
-SVar:DBIncubate:DB$ Incubate | Amount$ 2 | StackDescription$ SpellDescription | SpellDescription$ If they do, you incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+SVar:DBIncubate:DB$ Incubate | Amount$ 2 | StackDescription$ SpellDescription | SpellDescription$ If they do, you incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 DeckHas:Ability$Token|Counters & Type$Incubator|Artifact|Phyrexian
-Oracle:Counter target creature or battle spell unless its controller pays {4}. If they do, you incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+Oracle:Counter target creature or battle spell unless its controller pays {4}. If they do, you incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)

--- a/forge-gui/res/cardsfolder/b/blight_titan.txt
+++ b/forge-gui/res/cardsfolder/b/blight_titan.txt
@@ -3,11 +3,11 @@ ManaCost:4 B B
 Types:Creature Phyrexian Giant
 PT:6/6
 K:Deathtouch
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigMill | TriggerDescription$ Whenever CARDNAME enters or attacks, mill two cards, then incubate X, where X is the number of creature cards in your graveyard. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
-T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigMill | Secondary$ True | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME enters or attacks, mill two cards, then incubate X, where X is the number of creature cards in your graveyard. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigMill | TriggerDescription$ Whenever CARDNAME enters or attacks, mill two cards, then incubate X, where X is the number of creature cards in your graveyard. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigMill | Secondary$ True | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME enters or attacks, mill two cards, then incubate X, where X is the number of creature cards in your graveyard. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:TrigMill:DB$ Mill | Defined$ You | NumCards$ 2 | SubAbility$ DBIncubate
 SVar:DBIncubate:DB$ Incubate | Amount$ X
 SVar:X:Count$ValidGraveyard Creature.YouCtrl
 DeckHints:Ability$Graveyard
 DeckHas:Ability$Counters|Token & Type$Artifact
-Oracle:Deathtouch\nWhenever Blight Titan enters or attacks, mill two cards, then incubate X, where X is the number of creature cards in your graveyard. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+Oracle:Deathtouch\nWhenever Blight Titan enters or attacks, mill two cards, then incubate X, where X is the number of creature cards in your graveyard. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)

--- a/forge-gui/res/cardsfolder/b/blighted_burgeoning.txt
+++ b/forge-gui/res/cardsfolder/b/blighted_burgeoning.txt
@@ -3,10 +3,10 @@ ManaCost:2 G
 Types:Enchantment Aura
 K:Enchant:Land
 SVar:AttachAILogic:Pump
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigIncubate | TriggerDescription$ When CARDNAME enters, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigIncubate | TriggerDescription$ When CARDNAME enters, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:TrigIncubate:DB$ Incubate | Amount$ 2
 T:Mode$ TapsForMana | ValidCard$ Card.AttachedBy | Execute$ TrigMana | Static$ True | TriggerDescription$ Whenever enchanted land is tapped for mana, its controller adds an additional one mana of any color.
 SVar:TrigMana:DB$ Mana | Produced$ Any | Amount$ 1 | Defined$ TriggeredCardController
 AI:RemoveDeck:All
 DeckHas:Ability$Counters|Token
-Oracle:Enchant land\nWhen Blighted Burgeoning enters, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)\nWhenever enchanted land is tapped for mana, its controller adds an additional one mana of any color.
+Oracle:Enchant land\nWhen Blighted Burgeoning enters, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)\nWhenever enchanted land is tapped for mana, its controller adds an additional one mana of any color.

--- a/forge-gui/res/cardsfolder/b/bloated_processor.txt
+++ b/forge-gui/res/cardsfolder/b/bloated_processor.txt
@@ -3,9 +3,9 @@ ManaCost:2 B
 Types:Creature Phyrexian
 PT:3/2
 A:AB$ PutCounter | Cost$ Sac<1/Phyrexian.Other/another Phyrexian> | CounterType$ P1P1 | SpellDescription$ Put a +1/+1 counter on CARDNAME.
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigIncubate | TriggerDescription$ When CARDNAME dies, incubate X, where X is its power. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigIncubate | TriggerDescription$ When CARDNAME dies, incubate X, where X is its power. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:TrigIncubate:DB$ Incubate | Amount$ X
 SVar:X:TriggeredCard$CardPower
 DeckHas:Ability$Sacrifice|Counters|Token & Type$Incubator|Artifact
 DeckNeeds:Type$Phyrexian
-Oracle:Sacrifice another Phyrexian: Put a +1/+1 counter on Bloated Processor.\nWhen Bloated Processor dies, incubate X, where X is its power. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+Oracle:Sacrifice another Phyrexian: Put a +1/+1 counter on Bloated Processor.\nWhen Bloated Processor dies, incubate X, where X is its power. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)

--- a/forge-gui/res/cardsfolder/b/brimaz_blight_of_oreskos.txt
+++ b/forge-gui/res/cardsfolder/b/brimaz_blight_of_oreskos.txt
@@ -2,11 +2,11 @@ Name:Brimaz, Blight of Oreskos
 ManaCost:2 W B
 Types:Legendary Creature Phyrexian Cat
 PT:3/4
-T:Mode$ SpellCast | ValidCard$ Creature.Phyrexian,Creature.Artifact | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigIncubate | TriggerDescription$ Whenever you cast a Phyrexian creature or artifact creature spell, incubate X, where X is that spell's mana value. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+T:Mode$ SpellCast | ValidCard$ Creature.Phyrexian,Creature.Artifact | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigIncubate | TriggerDescription$ Whenever you cast a Phyrexian creature or artifact creature spell, incubate X, where X is that spell's mana value. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:TrigIncubate:DB$ Incubate | Amount$ TriggeredSpellAbility$CardManaCostLKI
 T:Mode$ Phase | Phase$ End of Turn | TriggerZones$ Battlefield | CheckSVar$ X | Execute$ TrigProliferate | TriggerDescription$ At the beginning of each end step, if a Phyrexian died under your control this turn, proliferate.
 SVar:TrigProliferate:DB$ Proliferate
 SVar:X:Count$ThisTurnEntered_Graveyard_from_Battlefield_Phyrexian.YouCtrl
 DeckHints:Type$Phyrexian & Ability$Sacrifice
 DeckHas:Ability$Token|Counters & Type$Artifact
-Oracle:Whenever you cast a Phyrexian creature or artifact creature spell, incubate X, where X is that spell's mana value. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)\nAt the beginning of each end step, if a Phyrexian died under your control this turn, proliferate.
+Oracle:Whenever you cast a Phyrexian creature or artifact creature spell, incubate X, where X is that spell's mana value. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)\nAt the beginning of each end step, if a Phyrexian died under your control this turn, proliferate.

--- a/forge-gui/res/cardsfolder/c/chrome_host_seedshark.txt
+++ b/forge-gui/res/cardsfolder/c/chrome_host_seedshark.txt
@@ -3,8 +3,8 @@ ManaCost:2 U
 Types:Creature Phyrexian Shark
 PT:2/4
 K:Flying
-T:Mode$ SpellCast | ValidCard$ Card.nonCreature | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigIncubate | TriggerDescription$ Whenever you cast a noncreature spell, incubate X, where X is that spell's mana value. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+T:Mode$ SpellCast | ValidCard$ Card.nonCreature | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigIncubate | TriggerDescription$ Whenever you cast a noncreature spell, incubate X, where X is that spell's mana value. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:TrigIncubate:DB$ Incubate | Amount$ TriggeredSpellAbility$CardManaCostLKI
 DeckHints:Type$Instant|Sorcery
 DeckHas:Ability$Token|Counters & Type$Artifact
-Oracle:Flying\nWhenever you cast a noncreature spell, incubate X, where X is that spell's mana value. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+Oracle:Flying\nWhenever you cast a noncreature spell, incubate X, where X is that spell's mana value. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)

--- a/forge-gui/res/cardsfolder/c/compleated_huntmaster.txt
+++ b/forge-gui/res/cardsfolder/c/compleated_huntmaster.txt
@@ -4,4 +4,4 @@ Types:Creature Phyrexian Elf Warrior
 PT:2/3
 A:AB$ Incubate | Cost$ 1 T Sac<1/Creature.Other;Artifact.Other/another creature or artifact> | Amount$ 3 | SpellDescription$ Incubate 3.
 DeckHas:Ability$Sacrifice|Counters|Token & Type$Incubator|Artifact
-Oracle:{1}, {T}, Sacrifice another creature or artifact: Incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+Oracle:{1}, {T}, Sacrifice another creature or artifact: Incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)

--- a/forge-gui/res/cardsfolder/c/converter_beast.txt
+++ b/forge-gui/res/cardsfolder/c/converter_beast.txt
@@ -2,7 +2,7 @@ Name:Converter Beast
 ManaCost:3 G
 Types:Creature Phyrexian Beast
 PT:0/1
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigIncubate | TriggerDescription$ When CARDNAME enters, incubate 5. (Create an Incubator token with five +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigIncubate | TriggerDescription$ When CARDNAME enters, incubate 5. (Create an Incubator token with five +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:TrigIncubate:DB$ Incubate | Amount$ 5
 DeckHas:Ability$Counters|Token & Type$Incubator|Artifact
-Oracle:When Converter Beast enters, incubate 5. (Create an Incubator token with five +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+Oracle:When Converter Beast enters, incubate 5. (Create an Incubator token with five +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)

--- a/forge-gui/res/cardsfolder/c/corruption_of_towashi.txt
+++ b/forge-gui/res/cardsfolder/c/corruption_of_towashi.txt
@@ -1,10 +1,10 @@
 Name:Corruption of Towashi
 ManaCost:4 U
 Types:Enchantment
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigIncubate | TriggerDescription$ When CARDNAME enters, incubate 4. (Create an Incubator token with four +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigIncubate | TriggerDescription$ When CARDNAME enters, incubate 4. (Create an Incubator token with four +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:TrigIncubate:DB$ Incubate | Amount$ 4
 T:Mode$ Transformed | ValidCard$ Permanent.YouCtrl+inZoneBattlefield | Execute$ TrigDraw | TriggerZones$ Battlefield | OptionalDecider$ You | ResolvedLimit$ 1 | TriggerDescription$ Whenever a permanent you control transforms or a permanent you control enters transformed, you may draw a card. Do this only once each turn.
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Permanent.Transformed+YouCtrl | OptionalDecider$ You | TriggerZones$ Battlefield | Execute$ TrigDraw | Secondary$ True | ResolvedLimit$ 1 | TriggerDescription$ Whenever a permanent you control transforms or a permanent you control enters transformed, you may draw a card. Do this only once each turn.
 SVar:TrigDraw:DB$ Draw
 DeckHas:Ability$Counters|Token & Type$Incubator|Artifact|Phyrexian
-Oracle:When Corruption of Towashi enters, incubate 4. (Create an Incubator token with four +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)\nWhenever a permanent you control transforms or a permanent you control enters transformed, you may draw a card. Do this only once each turn.
+Oracle:When Corruption of Towashi enters, incubate 4. (Create an Incubator token with four +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)\nWhenever a permanent you control transforms or a permanent you control enters transformed, you may draw a card. Do this only once each turn.

--- a/forge-gui/res/cardsfolder/e/elvish_vatkeeper.txt
+++ b/forge-gui/res/cardsfolder/e/elvish_vatkeeper.txt
@@ -2,10 +2,10 @@ Name:Elvish Vatkeeper
 ManaCost:1 B G
 Types:Creature Phyrexian Elf
 PT:3/3
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigIncubate | TriggerDescription$ When CARDNAME enters, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigIncubate | TriggerDescription$ When CARDNAME enters, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:TrigIncubate:DB$ Incubate | Amount$ 2
 A:AB$ SetState | Cost$ 5 | TgtPrompt$ Select target Incubator token you control | ValidTgts$ Incubator.token+YouCtrl | Mode$ Transform | SubAbility$ DBDouble | SpellDescription$ Transform target Incubator token you control.
 SVar:DBDouble:DB$ MultiplyCounter | Defined$ Targeted | CounterType$ P1P1 | SpellDescription$ Double the number of +1/+1 counters on it.
 DeckHas:Ability$Counters|Token & Type$Incubator|Artifact
 DeckHints:Type$Incubator
-Oracle:When Elvish Vatkeeper enters, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)\n{5}: Transform target Incubator token you control. Double the number of +1/+1 counters on it.
+Oracle:When Elvish Vatkeeper enters, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)\n{5}: Transform target Incubator token you control. Double the number of +1/+1 counters on it.

--- a/forge-gui/res/cardsfolder/e/essence_of_orthodoxy.txt
+++ b/forge-gui/res/cardsfolder/e/essence_of_orthodoxy.txt
@@ -3,8 +3,8 @@ ManaCost:3 W W
 Types:Creature Phyrexian
 PT:3/3
 K:Flying
-T:Mode$ ChangesZone | ValidCard$ Card.Self,Phyrexian.Other+YouCtrl | Origin$ Any | Destination$ Battlefield | Execute$ TrigIncubate | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME or another Phyrexian you control enters, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+T:Mode$ ChangesZone | ValidCard$ Card.Self,Phyrexian.Other+YouCtrl | Origin$ Any | Destination$ Battlefield | Execute$ TrigIncubate | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME or another Phyrexian you control enters, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:TrigIncubate:DB$ Incubate | Amount$ 2
 DeckHints:Type$Phyrexian
 DeckHas:Ability$Token|Counters & Type$Artifact
-Oracle:Flying\nWhenever Essence of Orthodoxy or another Phyrexian you control enters, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+Oracle:Flying\nWhenever Essence of Orthodoxy or another Phyrexian you control enters, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)

--- a/forge-gui/res/cardsfolder/e/excise_the_imperfect.txt
+++ b/forge-gui/res/cardsfolder/e/excise_the_imperfect.txt
@@ -2,7 +2,7 @@ Name:Excise the Imperfect
 ManaCost:1 W W
 Types:Instant
 A:SP$ ChangeZone | Origin$ Battlefield | Destination$ Exile | ValidTgts$ Permanent.nonLand | TgtPrompt$ Select target nonland permanent | SubAbility$ DBIncubate | SpellDescription$ Exile target nonland permanent.
-SVar:DBIncubate:DB$ Incubate | Defined$ TargetedController | Amount$ X | SpellDescription$ Its controller incubates X, where X is its mana value. (They create an Incubator token with X +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+SVar:DBIncubate:DB$ Incubate | Defined$ TargetedController | Amount$ X | SpellDescription$ Its controller incubates X, where X is its mana value. (They create an Incubator token with X +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:X:Targeted$CardManaCost
 DeckHas:Ability$Counters|Token & Type$Incubator|Artifact|Phyrexian
-Oracle:Exile target nonland permanent. Its controller incubates X, where X is its mana value. (They create an Incubator token with X +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+Oracle:Exile target nonland permanent. Its controller incubates X, where X is its mana value. (They create an Incubator token with X +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)

--- a/forge-gui/res/cardsfolder/e/eyes_of_gitaxias.txt
+++ b/forge-gui/res/cardsfolder/e/eyes_of_gitaxias.txt
@@ -1,7 +1,7 @@
 Name:Eyes of Gitaxias
 ManaCost:2 U
 Types:Sorcery
-A:SP$ Incubate | Amount$ 3 | SubAbility$ DBDraw | SpellDescription$ Incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+A:SP$ Incubate | Amount$ 3 | SubAbility$ DBDraw | SpellDescription$ Incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:DBDraw:DB$ Draw | SpellDescription$ Draw a card.
 DeckHas:Ability$Counters|Token & Type$Incubator|Artifact|Phyrexian
-Oracle:Incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)\nDraw a card.
+Oracle:Incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)\nDraw a card.

--- a/forge-gui/res/cardsfolder/f/furnace_gremlin.txt
+++ b/forge-gui/res/cardsfolder/f/furnace_gremlin.txt
@@ -3,8 +3,8 @@ ManaCost:1 R
 Types:Creature Phyrexian Gremlin
 PT:1/2
 A:AB$ Pump | Cost$ 1 R | NumAtt$ +1 | SpellDescription$ CARDNAME gets +1/+0 until end of turn.
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigIncubate | TriggerDescription$ When CARDNAME dies, incubate X, where X is its power. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigIncubate | TriggerDescription$ When CARDNAME dies, incubate X, where X is its power. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:TrigIncubate:DB$ Incubate | Amount$ X
 SVar:X:TriggeredCard$CardPower
 DeckHas:Ability$Counters|Token & Type$Incubator|Artifact
-Oracle:{1}{R}: Furnace Gremlin gets +1/+0 until end of turn.\nWhen Furnace Gremlin dies, incubate X, where X is its power. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+Oracle:{1}{R}: Furnace Gremlin gets +1/+0 until end of turn.\nWhen Furnace Gremlin dies, incubate X, where X is its power. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)

--- a/forge-gui/res/cardsfolder/g/gift_of_compleation.txt
+++ b/forge-gui/res/cardsfolder/g/gift_of_compleation.txt
@@ -1,8 +1,8 @@
 Name:Gift of Compleation
 ManaCost:1 B
 Types:Enchantment
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigIncubate | TriggerDescription$ When CARDNAME enters, incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigIncubate | TriggerDescription$ When CARDNAME enters, incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:TrigIncubate:DB$ Incubate | Amount$ 3
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Phyrexian.YouCtrl | Execute$ TrigSurveil | TriggerZones$ Battlefield | TriggerDescription$ Whenever a Phyrexian you control dies, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)
 SVar:TrigSurveil:DB$ Surveil | Amount$ 1
-Oracle:When Gift of Compleation enters, incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)\nWhenever a Phyrexian you control dies, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)
+Oracle:When Gift of Compleation enters, incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)\nWhenever a Phyrexian you control dies, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)

--- a/forge-gui/res/cardsfolder/g/glissa_herald_of_predation.txt
+++ b/forge-gui/res/cardsfolder/g/glissa_herald_of_predation.txt
@@ -4,9 +4,9 @@ Types:Legendary Creature Phyrexian Zombie Elf
 PT:3/5
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | Execute$ TrigCharm | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of combat on your turn, ABILITY
 SVar:TrigCharm:DB$ Charm | Choices$ Incubate,Transform,PumpAll
-SVar:Incubate:DB$ Incubate | Amount$ 2 | Times$ 2 | SpellDescription$ Incubate 2 twice. (To incubate 2, create an Incubator token with two +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+SVar:Incubate:DB$ Incubate | Amount$ 2 | Times$ 2 | SpellDescription$ Incubate 2 twice. (To incubate 2, create an Incubator token with two +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:Transform:DB$ SetState | Defined$ Valid Incubator.token+YouCtrl | Mode$ Transform | SpellDescription$ Transform all Incubator tokens you control.
 SVar:PumpAll:DB$ PumpAll | ValidCards$ Phyrexian.YouCtrl | KW$ First Strike & Deathtouch | SpellDescription$ Phyrexians you control gain first strike and deathtouch until end of turn.
 DeckHas:Ability$Token|Counters & Type$Artifact
 DeckHints:Type$Phyrexian
-Oracle:At the beginning of combat on your turn, choose one —\n• Incubate 2 twice. (To incubate 2, create an Incubator token with two +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)\n• Transform all Incubator tokens you control.\n• Phyrexians you control gain first strike and deathtouch until end of turn.
+Oracle:At the beginning of combat on your turn, choose one —\n• Incubate 2 twice. (To incubate 2, create an Incubator token with two +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)\n• Transform all Incubator tokens you control.\n• Phyrexians you control gain first strike and deathtouch until end of turn.

--- a/forge-gui/res/cardsfolder/i/ichor_drinker.txt
+++ b/forge-gui/res/cardsfolder/i/ichor_drinker.txt
@@ -3,6 +3,6 @@ ManaCost:B
 Types:Creature Phyrexian Vampire
 PT:1/1
 K:Lifelink
-A:AB$ Incubate | Cost$ B ExileFromGrave<1/CARDNAME> | ActivationZone$ Graveyard | Amount$ 2 | SorcerySpeed$ True | StackDescription$ SpellDescription | SpellDescription$ Incubate 2. Activate only as a sorcery. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+A:AB$ Incubate | Cost$ B ExileFromGrave<1/CARDNAME> | ActivationZone$ Graveyard | Amount$ 2 | SorcerySpeed$ True | StackDescription$ SpellDescription | SpellDescription$ Incubate 2. Activate only as a sorcery. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 DeckHas:Ability$Token|Counters|Graveyard & Type$Incubator|Artifact
-Oracle:Lifelink\n{B}, Exile Ichor Drinker from your graveyard: Incubate 2. Activate only as a sorcery. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+Oracle:Lifelink\n{B}, Exile Ichor Drinker from your graveyard: Incubate 2. Activate only as a sorcery. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)

--- a/forge-gui/res/cardsfolder/i/infected_defector.txt
+++ b/forge-gui/res/cardsfolder/i/infected_defector.txt
@@ -2,7 +2,7 @@ Name:Infected Defector
 ManaCost:4 W
 Types:Creature Phyrexian Knight
 PT:4/3
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigIncubate | TriggerDescription$ When CARDNAME dies, incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigIncubate | TriggerDescription$ When CARDNAME dies, incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:TrigIncubate:DB$ Incubate | Amount$ 3
 DeckHas:Ability$Token|Counters|Graveyard & Type$Incubator|Artifact
-Oracle:When Infected Defector dies, incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+Oracle:When Infected Defector dies, incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)

--- a/forge-gui/res/cardsfolder/i/injector_crocodile.txt
+++ b/forge-gui/res/cardsfolder/i/injector_crocodile.txt
@@ -2,8 +2,8 @@ Name:Injector Crocodile
 ManaCost:4 B B
 Types:Creature Phyrexian Crocodile
 PT:5/5
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigIncubate | TriggerDescription$ When CARDNAME dies, incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigIncubate | TriggerDescription$ When CARDNAME dies, incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:TrigIncubate:DB$ Incubate | Amount$ 3
 K:TypeCycling:Swamp:2
 DeckHas:Ability$Token|Counters & Type$Artifact
-Oracle:When Injector Crocodile dies, incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)\nSwampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it, put it into your hand, then shuffle.)
+Oracle:When Injector Crocodile dies, incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)\nSwampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it, put it into your hand, then shuffle.)

--- a/forge-gui/res/cardsfolder/m/marauding_dreadship.txt
+++ b/forge-gui/res/cardsfolder/m/marauding_dreadship.txt
@@ -3,7 +3,7 @@ ManaCost:2 R
 Types:Artifact Vehicle
 PT:4/1
 K:Haste
-T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigIncubate | TriggerZones$ Battlefield | TriggerDescription$ When CARDNAME enters, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigIncubate | TriggerZones$ Battlefield | TriggerDescription$ When CARDNAME enters, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:TrigIncubate:DB$ Incubate | Amount$ 2
 K:Crew:2
-Oracle:Haste\nWhen Marauding Dreadship enters, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)
+Oracle:Haste\nWhen Marauding Dreadship enters, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)

--- a/forge-gui/res/cardsfolder/m/merciless_repurposing.txt
+++ b/forge-gui/res/cardsfolder/m/merciless_repurposing.txt
@@ -2,6 +2,6 @@ Name:Merciless Repurposing
 ManaCost:4 B B
 Types:Instant
 A:SP$ ChangeZone | ValidTgts$ Creature | Origin$ Battlefield | Destination$ Exile | SubAbility$ DBIncubate | SpellDescription$ Exile target creature.
-SVar:DBIncubate:DB$ Incubate | Amount$ 3 | SpellDescription$ Incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+SVar:DBIncubate:DB$ Incubate | Amount$ 3 | SpellDescription$ Incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 DeckHas:Ability$Token|Counters & Type$Artifact|Phyrexian
-Oracle:Exile target creature. Incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+Oracle:Exile target creature. Incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)

--- a/forge-gui/res/cardsfolder/p/phyrexian_awakening.txt
+++ b/forge-gui/res/cardsfolder/p/phyrexian_awakening.txt
@@ -1,10 +1,10 @@
 Name:Phyrexian Awakening
 ManaCost:2 W
 Types:Enchantment
-T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigIncubate | TriggerZones$ Battlefield | TriggerDescription$ When CARDNAME enters, incubate 4. (Create an Incubator token with four +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigIncubate | TriggerZones$ Battlefield | TriggerDescription$ When CARDNAME enters, incubate 4. (Create an Incubator token with four +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:TrigIncubate:DB$ Incubate | Amount$ 4
 S:Mode$ Continuous | Affected$ Phyrexian.YouCtrl | AddKeyword$ Vigilance | Description$ Phyrexians you control have vigilance.
 SVar:PlayMain1:TRUE
 DeckHints:Type$Phyrexian
 DeckHas:Ability$Token|Counters & Type$Artifact|Incubator|Phyrexian
-Oracle:When Phyrexian Awakening enters, incubate 4. (Create an Incubator token with four +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)\nPhyrexians you control have vigilance.
+Oracle:When Phyrexian Awakening enters, incubate 4. (Create an Incubator token with four +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)\nPhyrexians you control have vigilance.

--- a/forge-gui/res/cardsfolder/p/progenitor_exarch.txt
+++ b/forge-gui/res/cardsfolder/p/progenitor_exarch.txt
@@ -2,10 +2,10 @@ Name:Progenitor Exarch
 ManaCost:X X W
 Types:Creature Phyrexian Cat Cleric
 PT:1/2
-T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigIncubate | TriggerZones$ Battlefield | TriggerDescription$ When CARDNAME enters, incubate 3 X times. (To incubate 3, create an Incubator token with three +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigIncubate | TriggerZones$ Battlefield | TriggerDescription$ When CARDNAME enters, incubate 3 X times. (To incubate 3, create an Incubator token with three +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:TrigIncubate:DB$ Incubate | Amount$ 3 | Times$ X
 A:AB$ SetState | Cost$ T | TgtPrompt$ Select target Incubator token you control | ValidTgts$ Incubator.token+YouCtrl | Mode$ Transform | SpellDescription$ Transform target Incubator token you control.
 SVar:X:Count$xPaid
 DeckHints:Type$Incubator
 DeckHas:Ability$Token|Counters & Type$Artifact|Incubator
-Oracle:When Progenitor Exarch enters, incubate 3 X times. (To incubate 3, create an Incubator token with three +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)\n{T}: Transform target Incubator token you control.
+Oracle:When Progenitor Exarch enters, incubate 3 X times. (To incubate 3, create an Incubator token with three +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)\n{T}: Transform target Incubator token you control.

--- a/forge-gui/res/cardsfolder/s/sculpted_perfection.txt
+++ b/forge-gui/res/cardsfolder/s/sculpted_perfection.txt
@@ -1,9 +1,9 @@
 Name:Sculpted Perfection
 ManaCost:2 W B
 Types:Enchantment
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigIncubate | TriggerDescription$ When CARDNAME enters, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigIncubate | TriggerDescription$ When CARDNAME enters, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:TrigIncubate:DB$ Incubate | Amount$ 2
 S:Mode$ Continuous | Affected$ Phyrexian.YouCtrl | AddPower$ 1 | AddToughness$ 1 | Description$ Phyrexians you control get +1/+1.
 DeckHas:Ability$Token|Counters & Type$Artifact|Phyrexian
 DeckHints:Type$Phyrexian
-Oracle:When Sculpted Perfection enters, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)\nPhyrexians you control get +1/+1.
+Oracle:When Sculpted Perfection enters, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)\nPhyrexians you control get +1/+1.

--- a/forge-gui/res/cardsfolder/s/searing_barb.txt
+++ b/forge-gui/res/cardsfolder/s/searing_barb.txt
@@ -3,6 +3,6 @@ ManaCost:2 R
 Types:Sorcery
 A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ 2 | SubAbility$ DBCantBlock | SpellDescription$ CARDNAME deals 2 damage to any target.
 SVar:DBCantBlock:DB$ Pump | Defined$ Targeted.Creature | KW$ HIDDEN CARDNAME can't block. | IsCurse$ True | SubAbility$ DBIncubate | StackDescription$ SpellDescription | SpellDescription$ If it's a creature, it can't block this turn.
-SVar:DBIncubate:DB$ Incubate | Amount$ 1 | SpellDescription$ Incubate 1. (Create an Incubator token with a +1/+1 counter on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+SVar:DBIncubate:DB$ Incubate | Amount$ 1 | SpellDescription$ Incubate 1. (Create an Incubator token with a +1/+1 counter on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 DeckHas:Ability$Token|Counters & Type$Artifact|Incubator|Phyrexian
-Oracle:Searing Barb deals 2 damage to any target. If it's a creature, it can't block this turn. Incubate 1. (Create an Incubator token with a +1/+1 counter on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+Oracle:Searing Barb deals 2 damage to any target. If it's a creature, it can't block this turn. Incubate 1. (Create an Incubator token with a +1/+1 counter on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)

--- a/forge-gui/res/cardsfolder/s/sunder_the_gateway.txt
+++ b/forge-gui/res/cardsfolder/s/sunder_the_gateway.txt
@@ -2,9 +2,9 @@ Name:Sunder the Gateway
 ManaCost:1 W
 Types:Sorcery
 A:SP$ Charm | Choices$ Destroy,Incubate
-SVar:Destroy:DB$ Destroy | ValidTgts$ Artifact.OppCtrl+!token,Enchantment.OppCtrl+!token | SubAbility$ DBIncubate | TgtPrompt$ Select target nontoken artifact or enchantment an opponent controls | StackDescription$ Destroy {c:Targeted}. | SpellDescription$ Destroy target nontoken artifact or enchantment an opponent controls. Incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+SVar:Destroy:DB$ Destroy | ValidTgts$ Artifact.OppCtrl+!token,Enchantment.OppCtrl+!token | SubAbility$ DBIncubate | TgtPrompt$ Select target nontoken artifact or enchantment an opponent controls | StackDescription$ Destroy {c:Targeted}. | SpellDescription$ Destroy target nontoken artifact or enchantment an opponent controls. Incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:DBIncubate:DB$ Incubate | Amount$ 2
 SVar:Incubate:DB$ Incubate | Amount$ 2 | SubAbility$ DBTransform | StackDescription$ SpellDescription | SpellDescription$ Incubate 2, then transform an Incubator token you control.
 SVar:DBTransform:DB$ SetState | Choices$ Incubator.token+YouCtrl | ChoiceTitle$ Choose an Incubator token you control | Mandatory$ True | Mode$ Transform | StackDescription$ None
 DeckHas:Ability$Counters|Token & Type$Incubator|Artifact|Phyrexian
-Oracle:Choose one —\n• Destroy target nontoken artifact or enchantment an opponent controls. Incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)\n• Incubate 2, then transform an Incubator token you control.
+Oracle:Choose one —\n• Destroy target nontoken artifact or enchantment an opponent controls. Incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)\n• Incubate 2, then transform an Incubator token you control.

--- a/forge-gui/res/cardsfolder/s/sunfall.txt
+++ b/forge-gui/res/cardsfolder/s/sunfall.txt
@@ -2,7 +2,7 @@ Name:Sunfall
 ManaCost:3 W W
 Types:Sorcery
 A:SP$ ChangeZoneAll | ChangeType$ Creature | Origin$ Battlefield | Destination$ Exile | RememberChanged$ True | SubAbility$ DBIncubate | SpellDescription$ Exile all creatures.
-SVar:DBIncubate:DB$ Incubate | Amount$ X | SpellDescription$ Incubate X, where is the number of creatures exiled this way. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+SVar:DBIncubate:DB$ Incubate | Amount$ X | SpellDescription$ Incubate X, where is the number of creatures exiled this way. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:X:Remembered$Amount
 DeckHas:Ability$Token|Counters & Type$Artifact|Phyrexian
-Oracle:Exile all creatures. Incubate X, where X is the number of creatures exiled this way. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+Oracle:Exile all creatures. Incubate X, where X is the number of creatures exiled this way. (Create an Incubator token with X +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)

--- a/forge-gui/res/cardsfolder/t/tangled_skyline.txt
+++ b/forge-gui/res/cardsfolder/t/tangled_skyline.txt
@@ -1,9 +1,9 @@
 Name:Tangled Skyline
 ManaCost:4 G
 Types:Enchantment
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigGainLife | TriggerDescription$ When CARDNAME enters, you gain 5 life and incubate 5. (Create an Incubator token with five +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigGainLife | TriggerDescription$ When CARDNAME enters, you gain 5 life and incubate 5. (Create an Incubator token with five +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:TrigGainLife:DB$ GainLife | LifeAmount$ 5 | SubAbility$ DBIncubate
 SVar:DBIncubate:DB$ Incubate | Amount$ 5
 S:Mode$ Continuous | Affected$ Phyrexian.YouCtrl | AddKeyword$ Reach | Description$ Phyrexians you control have reach.
 DeckHas:Ability$Token|Counters|LifeGain & Type$Incubator|Artifact|Phyrexian
-Oracle:When Tangled Skyline enters, you gain 5 life and incubate 5. (Create an Incubator token with five +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)\nPhyrexians you control have reach.
+Oracle:When Tangled Skyline enters, you gain 5 life and incubate 5. (Create an Incubator token with five +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)\nPhyrexians you control have reach.

--- a/forge-gui/res/cardsfolder/t/tiller_of_flesh.txt
+++ b/forge-gui/res/cardsfolder/t/tiller_of_flesh.txt
@@ -2,8 +2,8 @@ Name:Tiller of Flesh
 ManaCost:3 W
 Types:Creature Phyrexian Knight
 PT:2/4
-T:Mode$ SpellCast | TriggerZones$ Battlefield | ValidActivatingPlayer$ You | TargetsValid$ Permanent.inZoneBattlefield | Execute$ TrigIncubate | TriggerDescription$ Whenever you cast a spell that targets one or more permanents, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+T:Mode$ SpellCast | TriggerZones$ Battlefield | ValidActivatingPlayer$ You | TargetsValid$ Permanent.inZoneBattlefield | Execute$ TrigIncubate | TriggerDescription$ Whenever you cast a spell that targets one or more permanents, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:TrigIncubate:DB$ Incubate | Amount$ 2
 DeckHas:Ability$Token|Counters & Type$Incubator|Artifact|Phyrexian
 DeckHints:Type$Instant|Sorcery
-Oracle:Whenever you cast a spell that targets one or more permanents, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+Oracle:Whenever you cast a spell that targets one or more permanents, incubate 2. (Create an Incubator token with two +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)

--- a/forge-gui/res/cardsfolder/t/traumatic_revelation.txt
+++ b/forge-gui/res/cardsfolder/t/traumatic_revelation.txt
@@ -2,7 +2,7 @@ Name:Traumatic Revelation
 ManaCost:1 B
 Types:Sorcery
 A:SP$ Discard | ValidTgts$ Opponent | Mode$ RevealYouChoose | Optional$ True | DiscardValid$ Creature,Battle | DiscardValidDesc$ creature or battle | RememberDiscarded$ True | SubAbility$ DBIncubate | StackDescription$ REP Target opponent_{p:Targeted} | SpellDescription$ Target opponent reveals their hand. You may choose a creature or battle card from it. If you do, that player discards that card.
-SVar:DBIncubate:DB$ Incubate | ConditionDefined$ Remembered | ConditionPresent$ Card | ConditionCompare$ EQ0 | Amount$ 3 | SubAbility$ DBCleanup | StackDescription$ SpellDescription | SpellDescription$ If you don't, incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+SVar:DBIncubate:DB$ Incubate | ConditionDefined$ Remembered | ConditionPresent$ Card | ConditionCompare$ EQ0 | Amount$ 3 | SubAbility$ DBCleanup | StackDescription$ SpellDescription | SpellDescription$ If you don't, incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 DeckHas:Ability$Token|Counters & Type$Artifact|Phyrexian
-Oracle:Target opponent reveals their hand. You may choose a creature or battle card from it. If you do, that player discards that card. If you don't, incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.)
+Oracle:Target opponent reveals their hand. You may choose a creature or battle card from it. If you do, that player discards that card. If you don't, incubate 3. (Create an Incubator token with three +1/+1 counters on it and "{2}: Transform this token." It transforms into a 0/0 Phyrexian artifact creature.)


### PR DESCRIPTION
Following up on https://github.com/Card-Forge/forge/pull/11086
A good number of tokens have had their reminder text updated to replace "artifact" with "token" for relevant activated abilities. Such is the case for Incubator tokens as exemplified by  [Assimilate Essence](https://gatherer.wizards.com/MOM/en-us/47/assimilate-essence) and [Traumatic Revelation](https://gatherer.wizards.com/MOM/en-us/127/traumatic-revelation).