### PR TITLE
Desert: use PresentZone List

### DIFF
--- a/forge-game/src/main/java/forge/game/CardTraitBase.java
+++ b/forge-game/src/main/java/forge/game/CardTraitBase.java
@@ -323,20 +323,10 @@ public abstract class CardTraitBase implements GameObject, IHasCardView, IHasSVa
         if (params.containsKey("Revolt")) {
             if ("True".equalsIgnoreCase(params.get("Revolt")) != hostController.hasRevolt()) return false;
             else if ("None".equalsIgnoreCase(params.get("Revolt"))) {
-                boolean none = true;
-                for (Player p : game.getRegisteredPlayers()) {
-                    if (p.hasRevolt()) {
-                        none = false;
-                        break;
-                    }
-                }
-                if (!none) {
+                if (!game.getRegisteredPlayers().stream().noneMatch(Player::hasRevolt)) {
                     return false;
                 }
             }
-        }
-        if (params.containsKey("Desert")) {
-            if ("True".equalsIgnoreCase(params.get("Desert")) != hostController.hasDesert()) return false;
         }
         if (params.containsKey("Blessing")) {
             if ("True".equalsIgnoreCase(params.get("Blessing")) != hostController.hasBlessing()) return false;
@@ -410,23 +400,20 @@ public abstract class CardTraitBase implements GameObject, IHasCardView, IHasSVa
             final String sIsPresent = params.get("IsPresent");
             final String presentCompare = getParamOrDefault("PresentCompare", "GE1");
             final String presentPlayer = getParamOrDefault("PresentPlayer", "Any");
-            ZoneType presentZone = ZoneType.Battlefield;
-            if (params.containsKey("PresentZone")) {
-                presentZone = ZoneType.smartValueOf(params.get("PresentZone"));
-            }
             CardCollection list;
             if (params.containsKey("PresentDefined")) {
                 list = AbilityUtils.getDefinedCards(getHostCard(), params.get("PresentDefined"), this);
             } else {
+                List<ZoneType> presentZones = params.containsKey("PresentZone") ? ZoneType.listValueOf(params.get("PresentZone")) : List.of(ZoneType.Battlefield);
                 list = new CardCollection();
                 if (presentPlayer.equals("You") || presentPlayer.equals("Any")) {
-                    list.addAll(hostController.getCardsIn(presentZone));
+                    list.addAll(hostController.getCardsIn(presentZones));
                 }
                 if (presentPlayer.equals("Opponent") || presentPlayer.equals("Any")) {
-                    list.addAll(hostController.getOpponents().getCardsIn(presentZone));
+                    list.addAll(hostController.getOpponents().getCardsIn(presentZones));
                 }
                 if (presentPlayer.equals("Any")) {
-                    list.addAll(hostController.getAllies().getCardsIn(presentZone));
+                    list.addAll(hostController.getAllies().getCardsIn(presentZones));
                 }
             }
             list = CardLists.getValidCards(list, sIsPresent, hostController, this.getHostCard(), this);
@@ -444,16 +431,13 @@ public abstract class CardTraitBase implements GameObject, IHasCardView, IHasSVa
             final String sIsPresent = params.get("IsPresent2");
             final String presentCompare = getParamOrDefault("PresentCompare2", "GE1");
             final String presentPlayer = getParamOrDefault("PresentPlayer2", "Any");
-            ZoneType presentZone = ZoneType.Battlefield;
-            if (params.containsKey("PresentZone2")) {
-                presentZone = ZoneType.smartValueOf(params.get("PresentZone2"));
-            }
+            List<ZoneType> presentZones = params.containsKey("PresentZone2") ? ZoneType.listValueOf(params.get("PresentZone2")) : List.of(ZoneType.Battlefield);
             CardCollection list = new CardCollection();
             if (presentPlayer.equals("You") || presentPlayer.equals("Any")) {
-                list.addAll(hostController.getCardsIn(presentZone));
+                list.addAll(hostController.getCardsIn(presentZones));
             }
             if (presentPlayer.equals("Opponent") || presentPlayer.equals("Any")) {
-                list.addAll(hostController.getOpponents().getCardsIn(presentZone));
+                list.addAll(hostController.getOpponents().getCardsIn(presentZones));
             }
 
             list = CardLists.getValidCards(list, sIsPresent, hostController, this.getHostCard(), this);

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -2089,10 +2089,6 @@ public class Player extends GameEntity implements Comparable<Player> {
         return CardLists.count(getCardsIn(ZoneType.Battlefield), CardPredicates.ARTIFACTS) >= 3;
     }
 
-    public final boolean hasDesert() {
-        return getCardsIn(Arrays.asList(ZoneType.Battlefield, ZoneType.Graveyard)).anyMatch(CardPredicates.isType("Desert"));
-    }
-
     public final boolean hasThreshold() {
         return getZone(ZoneType.Graveyard).size() >= 7;
     }

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbilityCondition.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbilityCondition.java
@@ -88,9 +88,6 @@ public class SpellAbilityCondition extends SpellAbilityVariables {
             if (value.equals("Revolt")) {
                 this.setRevolt(true);
             }
-            if (value.equals("Desert")) {
-                this.setDesert(true);
-            }
             if (value.equals("Blessing")) {
                 this.setBlessing(true);
             }
@@ -182,7 +179,7 @@ public class SpellAbilityCondition extends SpellAbilityVariables {
         }
 
         if (params.containsKey("ConditionZone")) {
-            this.setPresentZone(ZoneType.smartValueOf(params.get("ConditionZone")));
+            this.setPresentZones(ZoneType.listValueOf(params.get("ConditionZone")));
         }
 
         if (params.containsKey("ConditionPlayerDefined")) {
@@ -268,7 +265,6 @@ public class SpellAbilityCondition extends SpellAbilityVariables {
         if (this.isMetalcraft() && !activator.hasMetalcraft()) return false;
         if (this.isDelirium() && !activator.hasDelirium()) return false;
         if (this.isRevolt() && !activator.hasRevolt()) return false;
-        if (this.isDesert() && !activator.hasDesert()) return false;
         if (this.isBlessing() && !activator.hasBlessing()) return false;
 
         if (this.kicked && !sa.isKicked()) return false;
@@ -350,18 +346,15 @@ public class SpellAbilityCondition extends SpellAbilityVariables {
             if (getPresentDefined() != null) {
                 list = AbilityUtils.getDefinedObjects(host, getPresentDefined(), sa);
             } else {
-                boolean usedLastState = false;
-                if (sa.isReplacementAbility()) {
-                    if (getPresentZone().equals(ZoneType.Battlefield)) {
-                        list = new FCollection<>(sa.getRootAbility().getLastStateBattlefield());
-                        usedLastState = true;
-                    } else if (getPresentZone().equals(ZoneType.Graveyard)) {
-                        list = new FCollection<>(sa.getRootAbility().getLastStateGraveyard());
-                        usedLastState = true;
+                list = new FCollection<>();
+                for (final ZoneType zone : getPresentZones()) {
+                    if (!sa.isReplacementAbility() || !zone.equals(ZoneType.Battlefield) || !zone.equals(ZoneType.Graveyard)) {
+                        list.addAll(game.getCardsIn(zone));
+                    } else if (zone.equals(ZoneType.Battlefield)) {
+                        list.addAll(sa.getRootAbility().getLastStateBattlefield());
+                    } else if (zone.equals(ZoneType.Graveyard)) {
+                        list.addAll(sa.getRootAbility().getLastStateGraveyard());
                     }
-                }
-                if (!usedLastState) {
-                    list = new FCollection<>(game.getCardsIn(getPresentZone()));
                 }
             }
 
@@ -381,19 +374,15 @@ public class SpellAbilityCondition extends SpellAbilityVariables {
             if (getPresentDefined2() != null) {
                 list = AbilityUtils.getDefinedObjects(host, getPresentDefined2(), sa);
             } else {
-                boolean usedLastState = false;
-                if (sa.isReplacementAbility()) {
-                    //for now, we will always look in the same zone as the other present
-                    if (getPresentZone().equals(ZoneType.Battlefield)) {
-                        list = new FCollection<>(sa.getRootAbility().getLastStateBattlefield());
-                        usedLastState = true;
-                    } else if (getPresentZone().equals(ZoneType.Graveyard)) {
-                        list = new FCollection<>(sa.getRootAbility().getLastStateGraveyard());
-                        usedLastState = true;
+                list = new FCollection<>();
+                for (final ZoneType zone : getPresentZones()) {
+                    if (!sa.isReplacementAbility() || !zone.equals(ZoneType.Battlefield) || !zone.equals(ZoneType.Graveyard)) {
+                        list.addAll(game.getCardsIn(zone));
+                    } else if (zone.equals(ZoneType.Battlefield)) {
+                        list.addAll(sa.getRootAbility().getLastStateBattlefield());
+                    } else if (zone.equals(ZoneType.Graveyard)) {
+                        list.addAll(sa.getRootAbility().getLastStateGraveyard());
                     }
-                }
-                if (!usedLastState) {
-                    list = new FCollection<>(game.getCardsIn(getPresentZone()));
                 }
             }
 

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbilityRestriction.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbilityRestriction.java
@@ -89,9 +89,6 @@ public class SpellAbilityRestriction extends SpellAbilityVariables {
             if (value.equals("Hellbent")) {
                 this.setHellbent(true);
             }
-            if (value.equals("Desert")) {
-                this.setDesert(true);
-            }
             if (value.equals("Blessing")) {
                 this.setBlessing(true);
             }
@@ -154,7 +151,7 @@ public class SpellAbilityRestriction extends SpellAbilityVariables {
                 this.setPresentCompare(params.get("PresentCompare"));
             }
             if (params.containsKey("PresentZone")) {
-                this.setPresentZone(ZoneType.smartValueOf(params.get("PresentZone")));
+                this.setPresentZones(ZoneType.listValueOf(params.get("PresentZone")));
             }
         }
 
@@ -412,11 +409,6 @@ public class SpellAbilityRestriction extends SpellAbilityVariables {
                 return false;
             }
         }
-        if (isDesert()) {
-            if (!activator.hasDesert()) {
-                return false;
-            }
-        }
         if (isBlessing()) {
             if (!activator.hasBlessing()) {
                 return false;
@@ -437,12 +429,12 @@ public class SpellAbilityRestriction extends SpellAbilityVariables {
                 return false;
             }
         }
-        if (this.getIsPresent() != null) {
+        if (getIsPresent() != null) {
             FCollection<GameObject> list;
             if (getPresentDefined() != null) {
                 list = AbilityUtils.getDefinedObjects(sa.getHostCard(), getPresentDefined(), sa);
             } else {
-                list = new FCollection<>(game.getCardsIn(getPresentZone()));
+                list = new FCollection<>(game.getCardsIn(getPresentZones()));
             }
 
             Predicate<GameObject> restriction = GameObjectPredicates.restriction(getIsPresent().split(","), activator, c, sa);

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbilityVariables.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbilityVariables.java
@@ -22,6 +22,7 @@ import forge.game.phase.PhaseType;
 import forge.game.zone.ZoneType;
 
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -89,7 +90,6 @@ public class SpellAbilityVariables implements Cloneable {
     private boolean delirium = false;
     private boolean hellbent = false;
     private boolean revolt = false;
-    private boolean desert = false;
     private boolean blessing = false;
     private boolean solved = false;
 
@@ -112,7 +112,7 @@ public class SpellAbilityVariables implements Cloneable {
     private String playerContains = null;
 
     /** The present zone. */
-    private ZoneType presentZone = ZoneType.Battlefield;
+    private List<ZoneType> presentZones = List.of(ZoneType.Battlefield);
 
     /** The svar to check. */
     private String sVarToCheck = null;
@@ -321,7 +321,6 @@ public class SpellAbilityVariables implements Cloneable {
     public void setDelirium(boolean delirium) {  this.delirium = delirium; }
 
     public void setRevolt(final boolean bRevolt) { revolt = bRevolt; }
-    public void setDesert(final boolean bDesert) { desert = bDesert; }
     public void setBlessing(final boolean bBlessing) { blessing = bBlessing; }
     public void setSolved(final boolean bSolved) { solved = bSolved; }
 
@@ -376,8 +375,8 @@ public class SpellAbilityVariables implements Cloneable {
      *
      * @return the present zone
      */
-    public final ZoneType getPresentZone() {
-        return this.presentZone;
+    public final List<ZoneType> getPresentZones() {
+        return this.presentZones;
     }
 
     /**
@@ -386,8 +385,8 @@ public class SpellAbilityVariables implements Cloneable {
      * @param presentZone
      *            the new present zone
      */
-    public final void setPresentZone(final ZoneType presentZone) {
-        this.presentZone = presentZone;
+    public final void setPresentZones(final List<ZoneType> presentZones) {
+        this.presentZones = presentZones;
     }
 
     /**
@@ -512,7 +511,6 @@ public class SpellAbilityVariables implements Cloneable {
 
     public final boolean isRevolt() {     return this.revolt;  }
 
-    public final boolean isDesert() {     return this.desert;  }
     public final boolean isBlessing() {     return this.blessing;  }
 
     public final boolean isSolved() {     return this.solved;  }

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbility.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbility.java
@@ -375,7 +375,6 @@ public class StaticAbility extends CardTraitBase implements IIdentifiable, Clone
             if (condition.equals("Metalcraft") && !controller.hasMetalcraft()) return false;
             if (condition.equals("Delirium") && !controller.hasDelirium()) return false;
             if (condition.equals("Ferocious") && !controller.hasFerocious()) return false;
-            if (condition.equals("Desert") && !controller.hasDesert()) return false;
             if (condition.equals("Blessing") && !controller.hasBlessing()) return false;
             if (condition.equals("Monarch") & !controller.isMonarch()) return false;
             if (condition.equals("Night") & !game.isNight()) return false;
@@ -424,7 +423,7 @@ public class StaticAbility extends CardTraitBase implements IIdentifiable, Clone
         }
 
         if (hasParam("IsPresent")) {
-            final ZoneType zone = hasParam("PresentZone") ? ZoneType.valueOf(getParam("PresentZone")) : ZoneType.Battlefield;
+            final List<ZoneType> zone = hasParam("PresentZone") ? ZoneType.listValueOf(getParam("PresentZone")) : List.of(ZoneType.Battlefield);
             final String compare = getParamOrDefault("PresentCompare", "GE1");
             CardCollectionView list = game.getCardsIn(zone);
             final String present = getParam("IsPresent");

--- a/forge-gui/res/cardsfolder/d/deserts_hold.txt
+++ b/forge-gui/res/cardsfolder/d/deserts_hold.txt
@@ -3,7 +3,7 @@ ManaCost:2 W
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curse
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Desert$ True | Execute$ TrigGainLife | TriggerDescription$ When CARDNAME enters, if you control a Desert or there is a Desert card in your graveyard, you gain 3 life.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | PresentZone$ Battlefield,Graveyard | IsPresent$ Desert | PresentPlayer$ You | Execute$ TrigGainLife | TriggerDescription$ When CARDNAME enters, if you control a Desert or there is a Desert card in your graveyard, you gain 3 life.
 SVar:TrigGainLife:DB$ GainLife | LifeAmount$ 3
 S:Mode$ CantAttack,CantBlock,CantBeActivated | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block and its activated abilities can't be activated.
 DeckHints:Type$Desert

--- a/forge-gui/res/cardsfolder/g/gilded_cerodon.txt
+++ b/forge-gui/res/cardsfolder/g/gilded_cerodon.txt
@@ -2,6 +2,6 @@ Name:Gilded Cerodon
 ManaCost:4 R
 Types:Creature Beast
 PT:4/4
-T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPump | TriggerZones$ Battlefield | Desert$ True | TriggerDescription$ Whenever CARDNAME attacks, if you control a Desert or there is a Desert card in your graveyard, target creature can't block this turn.
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPump | TriggerZones$ Battlefield | PresentZone$ Battlefield,Graveyard | IsPresent$ Desert | PresentPlayer$ You | TriggerDescription$ Whenever CARDNAME attacks, if you control a Desert or there is a Desert card in your graveyard, target creature can't block this turn.
 SVar:TrigPump:DB$ Pump | ValidTgts$ Creature | IsCurse$ True | KW$ HIDDEN CARDNAME can't block.
 Oracle:Whenever Gilded Cerodon attacks, if you control a Desert or there is a Desert card in your graveyard, target creature can't block this turn.

--- a/forge-gui/res/cardsfolder/s/sand_strangler.txt
+++ b/forge-gui/res/cardsfolder/s/sand_strangler.txt
@@ -2,7 +2,7 @@ Name:Sand Strangler
 ManaCost:3 R
 Types:Creature Beast
 PT:3/3
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDamage | OptionalDecider$ You | Desert$ True | TriggerDescription$ When CARDNAME enters, if you control a Desert or there is a Desert card in your graveyard, you may have CARDNAME deal 3 damage to target creature.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDamage | OptionalDecider$ You | PresentZone$ Battlefield,Graveyard | IsPresent$ Desert | PresentPlayer$ You | TriggerDescription$ When CARDNAME enters, if you control a Desert or there is a Desert card in your graveyard, you may have CARDNAME deal 3 damage to target creature.
 SVar:TrigDamage:DB$ DealDamage | ValidTgts$ Creature | NumDmg$ 3
 SVar:PlayMain1:TRUE
 DeckHints:Type$Desert

--- a/forge-gui/res/cardsfolder/s/sidewinder_naga.txt
+++ b/forge-gui/res/cardsfolder/s/sidewinder_naga.txt
@@ -2,6 +2,6 @@ Name:Sidewinder Naga
 ManaCost:2 G
 Types:Creature Snake Warrior
 PT:3/2
-S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 1 | AddKeyword$ Trample | Condition$ Desert | Description$ As long as you control a Desert or there is a Desert card in your graveyard, CARDNAME gets +1/+0 and has trample.
+S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 1 | AddKeyword$ Trample | IsPresent$ Desert.YouCtrl | PresentZone$ Battlefield,Graveyard | Description$ As long as you control a Desert or there is a Desert card in your graveyard, CARDNAME gets +1/+0 and has trample.
 DeckHints:Type$Desert
 Oracle:As long as you control a Desert or there is a Desert card in your graveyard, Sidewinder Naga gets +1/+0 and has trample.

--- a/forge-gui/res/cardsfolder/s/solitary_camel.txt
+++ b/forge-gui/res/cardsfolder/s/solitary_camel.txt
@@ -2,6 +2,6 @@ Name:Solitary Camel
 ManaCost:2 W
 Types:Creature Camel
 PT:3/2
-S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Lifelink | Condition$ Desert | Description$ CARDNAME has lifelink as long as you control a Desert or there is a Desert card in your graveyard. (Damage dealt by this creature also causes you to gain that much life.)
+S:Mode$ Continuous | Affected$ Card.Self | AddKeyword$ Lifelink | IsPresent$ Desert.YouCtrl | PresentZone$ Battlefield,Graveyard | Description$ CARDNAME has lifelink as long as you control a Desert or there is a Desert card in your graveyard. (Damage dealt by this creature also causes you to gain that much life.)
 DeckHints:Type$Desert
 Oracle:Solitary Camel has lifelink as long as you control a Desert or there is a Desert card in your graveyard. (Damage dealt by this creature also causes you to gain that much life.)

--- a/forge-gui/res/cardsfolder/u/unquenchable_thirst.txt
+++ b/forge-gui/res/cardsfolder/u/unquenchable_thirst.txt
@@ -2,7 +2,7 @@ Name:Unquenchable Thirst
 ManaCost:1 U
 Types:Enchantment Aura
 K:Enchant:Creature
-T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigTap | Desert$ True | TriggerDescription$ When CARDNAME enters, if you control a Desert or there is a Desert card in your graveyard, tap enchanted creature.
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigTap | PresentZone$ Battlefield,Graveyard | IsPresent$ Desert | PresentPlayer$ You | TriggerDescription$ When CARDNAME enters, if you control a Desert or there is a Desert card in your graveyard, tap enchanted creature.
 SVar:TrigTap:DB$ Tap | Defined$ Enchanted
 R:Event$ Untap | ActiveZones$ Battlefield | ValidCard$ Creature.AttachedBy | ValidStepTurnToController$ You | Layer$ CantHappen | Description$ Enchanted creature doesn't untap during its controller's untap step.
 DeckHints:Type$Desert

--- a/forge-gui/res/cardsfolder/w/wall_of_forgotten_pharaohs.txt
+++ b/forge-gui/res/cardsfolder/w/wall_of_forgotten_pharaohs.txt
@@ -3,6 +3,6 @@ ManaCost:2
 Types:Artifact Creature Wall
 PT:0/4
 K:Defender
-A:AB$ DealDamage | Cost$ T | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | NumDmg$ 1 | Activation$ Desert | SpellDescription$ CARDNAME deals 1 damage to target player or planeswalker. Activate only if you control a Desert or there is a Desert card in your graveyard.
+A:AB$ DealDamage | Cost$ T | ValidTgts$ Player,Planeswalker | TgtPrompt$ Select target player or planeswalker | NumDmg$ 1 | IsPresent$ Desert.YouCtrl | PresentZone$ Battlefield,Graveyard | SpellDescription$ CARDNAME deals 1 damage to target player or planeswalker. Activate only if you control a Desert or there is a Desert card in your graveyard.
 DeckHints:Type$Desert
 Oracle:Defender\n{T}: Wall of Forgotten Pharaohs deals 1 damage to target player or planeswalker. Activate only if you control a Desert or there is a Desert card in your graveyard.

--- a/forge-gui/res/cardsfolder/w/wretched_camel.txt
+++ b/forge-gui/res/cardsfolder/w/wretched_camel.txt
@@ -2,7 +2,7 @@ Name:Wretched Camel
 ManaCost:1 B
 Types:Creature Zombie Camel
 PT:2/1
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigDiscard | Desert$ True | TriggerDescription$ When CARDNAME dies, if you control a Desert or there is a Desert card in your graveyard, target player discards a card.
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigDiscard | PresentZone$ Battlefield,Graveyard | IsPresent$ Desert | PresentPlayer$ You | TriggerDescription$ When CARDNAME dies, if you control a Desert or there is a Desert card in your graveyard, target player discards a card.
 SVar:TrigDiscard:DB$ Discard | ValidTgts$ Player | NumCards$ 1 | Mode$ TgtChoose
 DeckHints:Type$Desert
 Oracle:When Wretched Camel dies, if you control a Desert or there is a Desert card in your graveyard, target player discards a card.


### PR DESCRIPTION
Closes #11013

* this makes PresentZone allow a List of ZoneTypes
* refactor Desert Check cards to use it that way

I noticed that there was no Card that used the SpellAbilityCondition anyway
