### PR TITLE
Card cleanup: 2026-06-27 [Reminder text: Investigate]

### DIFF
--- a/forge-gui/res/cardsfolder/a/alquist_proft_master_sleuth.txt
+++ b/forge-gui/res/cardsfolder/a/alquist_proft_master_sleuth.txt
@@ -3,11 +3,11 @@ ManaCost:1 W U
 Types:Legendary Creature Human Detective
 PT:3/3
 K:Vigilance
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 A:AB$ Draw | Cost$ X W U U T Sac<1/Clue> | NumCards$ X | SubAbility$ DBGainLife | SpellDescription$ You draw X cards and gain X life.
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ X
 SVar:X:Count$xPaid
 DeckHas:Ability$Investigate|Token|Sacrifice|LifeGain & Type$Artifact|Clue
 DeckHints:Ability$Investigate
-Oracle:Vigilance\nWhen Alquist Proft, Master Sleuth enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")\n{X}{W}{U}{U}, {T}, Sacrifice a Clue: You draw X cards and gain X life.
+Oracle:Vigilance\nWhen Alquist Proft, Master Sleuth enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\n{X}{W}{U}{U}, {T}, Sacrifice a Clue: You draw X cards and gain X life.

--- a/forge-gui/res/cardsfolder/a/armed_with_proof.txt
+++ b/forge-gui/res/cardsfolder/a/armed_with_proof.txt
@@ -1,10 +1,10 @@
 Name:Armed with Proof
 ManaCost:2 W
 Types:Enchantment
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate twice. (To investigate, create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate twice. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate | Num$ 2
 S:Mode$ Continuous | Affected$ Clue.YouCtrl | AddType$ Equipment | AddStaticAbility$ TreasureEquip | AddKeyword$ Equip:2 | Description$ Clues you control are Equipment in addition to their other types and have "Equipped creature gets +2/+0" and equip {2}.
 SVar:TreasureEquip:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 2 | Description$ Equipped creature gets +2/+0.
 DeckHas:Ability$Token & Type$Clue|Artifact
 DeckHints:Type$Clue
-Oracle:When Armed with Proof enters, investigate twice. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")\nClues you control are Equipment in addition to their other types and have "Equipped creature gets +2/+0" and equip {2}.
+Oracle:When Armed with Proof enters, investigate twice. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nClues you control are Equipment in addition to their other types and have "Equipped creature gets +2/+0" and equip {2}.

--- a/forge-gui/res/cardsfolder/a/auspicious_arrival.txt
+++ b/forge-gui/res/cardsfolder/a/auspicious_arrival.txt
@@ -2,6 +2,6 @@ Name:Auspicious Arrival
 ManaCost:1 W
 Types:Instant
 A:SP$ Pump | ValidTgts$ Creature | NumAtt$ +2 | NumDef$ +2 | SubAbility$ DBInvestigate | SpellDescription$ Target creature gets +2/+2 until end of turn.
-SVar:DBInvestigate:DB$ Investigate | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+SVar:DBInvestigate:DB$ Investigate | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 DeckHas:Ability$Investigate|Token & Type$Artifact|Clue
-Oracle:Target creature gets +2/+2 until end of turn. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Target creature gets +2/+2 until end of turn. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/b/ballroom.txt
+++ b/forge-gui/res/cardsfolder/b/ballroom.txt
@@ -4,6 +4,6 @@ Types:Land
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 A:AB$ Mana | Cost$ T | Produced$ Combo W B | SpellDescription$ Add {W} or {B}.
-A:AB$ Investigate | Cost$ 4 T | SpellDescription$ Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:AB$ Investigate | Cost$ 4 T | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 DeckHints:Ability$Investigate|Token
-Oracle:Ballroom enters tapped.\n{T}: Add {W} or {B}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Ballroom enters tapped.\n{T}: Add {W} or {B}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/b/billiard_room.txt
+++ b/forge-gui/res/cardsfolder/b/billiard_room.txt
@@ -4,6 +4,6 @@ Types:Land
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 A:AB$ Mana | Cost$ T | Produced$ Combo B R | SpellDescription$ Add {B} or {R}.
-A:AB$ Investigate | Cost$ 4 T | SpellDescription$ Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:AB$ Investigate | Cost$ 4 T | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 DeckHints:Ability$Investigate|Token
-Oracle:Billiard Room enters tapped.\n{T}: Add {B} or {R}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Billiard Room enters tapped.\n{T}: Add {B} or {R}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/b/briarbridge_patrol.txt
+++ b/forge-gui/res/cardsfolder/b/briarbridge_patrol.txt
@@ -2,11 +2,11 @@ Name:Briarbridge Patrol
 ManaCost:3 G
 Types:Creature Human Warrior
 PT:3/3
-T:Mode$ DamageDealtOnce | ValidSource$ Card.Self | ValidTarget$ Creature | TriggerZones$ Battlefield | Execute$ TrigInvestigate | TriggerDescription$ Whenever CARDNAME deals damage to one or more creatures, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ DamageDealtOnce | ValidSource$ Card.Self | ValidTarget$ Creature | TriggerZones$ Battlefield | Execute$ TrigInvestigate | TriggerDescription$ Whenever CARDNAME deals damage to one or more creatures, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 T:Mode$ Phase | Phase$ End of Turn | TriggerZones$ Battlefield | CheckSVar$ ClueResearch | SVarCompare$ GE3 | Execute$ TrigCheatCreature | TriggerDescription$ At the beginning of each end step, if you sacrificed three or more Clues this turn, you may put a creature card from your hand onto the battlefield.
 SVar:TrigCheatCreature:DB$ ChangeZone | Origin$ Hand | Destination$ Battlefield | ChangeType$ Creature | ChangeNum$ 1 | SpellDescription$ You may put a creature card from your hand onto the battlefield.
 SVar:ClueResearch:PlayerCountPropertyYou$SacrificedThisTurn Clue
 DeckHints:Ability$Investigate
 DeckHas:Ability$Investigate|Token
-Oracle:Whenever Briarbridge Patrol deals damage to one or more creatures, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")\nAt the beginning of each end step, if you sacrificed three or more Clues this turn, you may put a creature card from your hand onto the battlefield.
+Oracle:Whenever Briarbridge Patrol deals damage to one or more creatures, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nAt the beginning of each end step, if you sacrificed three or more Clues this turn, you may put a creature card from your hand onto the battlefield.

--- a/forge-gui/res/cardsfolder/b/briarbridge_tracker.txt
+++ b/forge-gui/res/cardsfolder/b/briarbridge_tracker.txt
@@ -3,8 +3,8 @@ ManaCost:2 G
 Types:Creature Human Scout
 PT:2/3
 K:Vigilance
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 2 | IsPresent$ Card.token+YouCtrl | Description$ As long as you control a token, CARDNAME gets +2/+0.
 DeckHas:Ability$Token|Sacrifice
-Oracle:Vigilance\nWhen Briarbridge Tracker enters, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")\nAs long as you control a token, Briarbridge Tracker gets +2/+0.
+Oracle:Vigilance\nWhen Briarbridge Tracker enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nAs long as you control a token, Briarbridge Tracker gets +2/+0.

--- a/forge-gui/res/cardsfolder/b/bygone_bishop.txt
+++ b/forge-gui/res/cardsfolder/b/bygone_bishop.txt
@@ -3,7 +3,7 @@ ManaCost:2 W
 Types:Creature Spirit Cleric
 PT:2/3
 K:Flying
-T:Mode$ SpellCast | ValidCard$ Creature.cmcLE3 | ValidActivatingPlayer$ You | Execute$ DBInvestigate | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a creature spell with mana value 3 or less, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ SpellCast | ValidCard$ Creature.cmcLE3 | ValidActivatingPlayer$ You | Execute$ DBInvestigate | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a creature spell with mana value 3 or less, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:DBInvestigate:DB$ Investigate
 DeckHas:Ability$Investigate|Token
-Oracle:Flying\nWhenever you cast a creature spell with mana value 3 or less, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Flying\nWhenever you cast a creature spell with mana value 3 or less, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/b/byway_courier.txt
+++ b/forge-gui/res/cardsfolder/b/byway_courier.txt
@@ -2,7 +2,7 @@ Name:Byway Courier
 ManaCost:2 G
 Types:Creature Human Scout
 PT:3/2
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME dies, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME dies, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 DeckHas:Ability$Investigate|Token
-Oracle:When Byway Courier dies, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:When Byway Courier dies, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/c/carnage_interpreter.txt
+++ b/forge-gui/res/cardsfolder/c/carnage_interpreter.txt
@@ -2,11 +2,11 @@ Name:Carnage Interpreter
 ManaCost:1 BR BR
 Types:Creature Devil Detective
 PT:3/3
-T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigDiscard | TriggerDescription$ When CARDNAME enters, discard your hand, then investigate four times. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigDiscard | TriggerDescription$ When CARDNAME enters, discard your hand, then investigate four times. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigDiscard:DB$ Discard | Mode$ Hand | SubAbility$ DBInvestigate
 SVar:DBInvestigate:DB$ Investigate | Num$ 4
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ 2 | AddToughness$ 2 | AddKeyword$ Menace | CheckSVar$ X | SVarCompare$ LE1 | Description$ As long as you have one or fewer cards in hand, CARDNAME gets +2/+2 and has menace.
 SVar:X:Count$ValidHand Card.YouOwn
 DeckHas:Ability$Discard|Token & Type$Clue|Artifact
 DeckHints:Ability$Discard
-Oracle:When Carnage Interpreter enters, discard your hand, then investigate four times. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")\nAs long as you have one or fewer cards in hand, Carnage Interpreter gets +2/+2 and has menace.
+Oracle:When Carnage Interpreter enters, discard your hand, then investigate four times. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nAs long as you have one or fewer cards in hand, Carnage Interpreter gets +2/+2 and has menace.

--- a/forge-gui/res/cardsfolder/c/case_of_the_filched_falcon.txt
+++ b/forge-gui/res/cardsfolder/c/case_of_the_filched_falcon.txt
@@ -1,11 +1,11 @@
 Name:Case of the Filched Falcon
 ManaCost:U
 Types:Enchantment Case
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When this Case enters, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When this Case enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | TriggerZones$ Battlefield | IsPresent$ Artifact.YouCtrl | PresentCompare$ GE3 | IsPresent2$ Card.Self+!IsSolved | Execute$ SolveFalcon | TriggerDescription$ To solve — You control three or more artifacts. (If unsolved, solve at the beginning of your end step.)
 SVar:SolveFalcon:DB$ AlterAttribute | Defined$ Self | Attributes$ Solved
 A:AB$ PutCounter | Cost$ 2 U Sac<1/CARDNAME/this Case> | ValidTgts$ Artifact.nonCreature | TgtPrompt$ Select target noncreature artifact | Activation$ Solved | CounterType$ P1P1 | CounterNum$ 4 | SubAbility$ DBAnimate | PrecostDesc$ Solved — | SpellDescription$ Put four +1/+1 counters on target noncreature artifact. It becomes a 0/0 Bird creature with flying in addition to its other types.
 SVar:DBAnimate:DB$ Animate | Defined$ ParentTarget | Power$ 0 | Toughness$ 0 | Types$ Creature,Bird | Keywords$ Flying | Duration$ Permanent
 DeckNeeds:Type$Artifact
-Oracle:When this Case enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")\nTo solve — You control three or more artifacts. (If unsolved, solve at the beginning of your end step.)\nSolved — {2}{U}, Sacrifice this Case: Put four +1/+1 counters on target noncreature artifact. It becomes a 0/0 Bird creature with flying in addition to its other types.
+Oracle:When this Case enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nTo solve — You control three or more artifacts. (If unsolved, solve at the beginning of your end step.)\nSolved — {2}{U}, Sacrifice this Case: Put four +1/+1 counters on target noncreature artifact. It becomes a 0/0 Bird creature with flying in addition to its other types.

--- a/forge-gui/res/cardsfolder/c/chalk_outline.txt
+++ b/forge-gui/res/cardsfolder/c/chalk_outline.txt
@@ -1,8 +1,8 @@
 Name:Chalk Outline
 ManaCost:3 G
 Types:Enchantment
-T:Mode$ ChangesZoneAll | ValidCards$ Creature.YouOwn | Origin$ Graveyard | Destination$ Any | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever one or more creature cards leave your graveyard, create a 2/2 white and blue Detective creature token, then investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZoneAll | ValidCards$ Creature.YouOwn | Origin$ Graveyard | Destination$ Any | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever one or more creature cards leave your graveyard, create a 2/2 white and blue Detective creature token, then investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigToken:DB$ Token | TokenScript$ wu_2_2_detective | SubAbility$ DBInvestigate
 SVar:DBInvestigate:DB$ Investigate
 DeckHas:Ability$Token|Investigate & Type$Clue|Artifact|Detective & Color$White|Blue
-Oracle:Whenever one or more creature cards leave your graveyard, create a 2/2 white and blue Detective creature token, then investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Whenever one or more creature cards leave your graveyard, create a 2/2 white and blue Detective creature token, then investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/c/cold_case_cracker.txt
+++ b/forge-gui/res/cardsfolder/c/cold_case_cracker.txt
@@ -3,7 +3,7 @@ ManaCost:3 U
 Types:Creature Spirit Detective
 PT:3/3
 K:Flying
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME dies, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME dies, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 DeckHas:Ability$Token|Investigate & Type$Artifact|Clue
-Oracle:Flying\nWhen Cold Case Cracker dies, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Flying\nWhen Cold Case Cracker dies, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/c/confirm_suspicions.txt
+++ b/forge-gui/res/cardsfolder/c/confirm_suspicions.txt
@@ -1,7 +1,7 @@
 Name:Confirm Suspicions
 ManaCost:3 U U
 Types:Instant
-A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | SubAbility$ DBInvestigate | SpellDescription$ Counter target spell. Investigate three times. (To investigate, create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | SubAbility$ DBInvestigate | SpellDescription$ Counter target spell. Investigate three times. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:DBInvestigate:DB$ Investigate | Num$ 3
 DeckHas:Ability$Investigate|Token
-Oracle:Counter target spell.\nInvestigate three times. (To investigate, create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Counter target spell.\nInvestigate three times. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/c/confront_the_unknown.txt
+++ b/forge-gui/res/cardsfolder/c/confront_the_unknown.txt
@@ -1,9 +1,9 @@
 Name:Confront the Unknown
 ManaCost:G
 Types:Instant
-A:SP$ Investigate | SubAbility$ DBPump | SpellDescription$ Investigate, then target creature gets +1/+1 until end of turn for each Clue you control. (To investigate, create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.") | StackDescription$ Investigate.
+A:SP$ Investigate | SubAbility$ DBPump | SpellDescription$ Investigate, then target creature gets +1/+1 until end of turn for each Clue you control. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.") | StackDescription$ Investigate.
 SVar:DBPump:DB$ Pump | ValidTgts$ Creature | NumAtt$ +X | NumDef$ +X
 SVar:X:Count$Valid Clue.YouCtrl
 DeckHints:Ability$Investigate
 DeckHas:Ability$Investigate|Token
-Oracle:Investigate, then target creature gets +1/+1 until end of turn for each Clue you control. (To investigate, create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Investigate, then target creature gets +1/+1 until end of turn for each Clue you control. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/c/conservatory.txt
+++ b/forge-gui/res/cardsfolder/c/conservatory.txt
@@ -4,6 +4,6 @@ Types:Land
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 A:AB$ Mana | Cost$ T | Produced$ Combo G W | SpellDescription$ Add {G} or {W}.
-A:AB$ Investigate | Cost$ 4 T | SpellDescription$ Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:AB$ Investigate | Cost$ 4 T | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 DeckHints:Ability$Investigate|Token
-Oracle:Conservatory enters tapped.\n{T}: Add {G} or {W}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Conservatory enters tapped.\n{T}: Add {G} or {W}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/c/curious_inquiry.txt
+++ b/forge-gui/res/cardsfolder/c/curious_inquiry.txt
@@ -3,8 +3,8 @@ ManaCost:U
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Curiosity
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | AddToughness$ 1 | AddTrigger$ TrigDamageDone | Description$ Enchanted creature gets +1/+1 and has "Whenever this creature deals combat damage to a player, investigate." (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
-SVar:TrigDamageDone:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigInvestigate | TriggerDescription$ Whenever this creature deals combat damage to a player, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | AddToughness$ 1 | AddTrigger$ TrigDamageDone | Description$ Enchanted creature gets +1/+1 and has "Whenever this creature deals combat damage to a player, investigate." (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
+SVar:TrigDamageDone:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigInvestigate | TriggerDescription$ Whenever this creature deals combat damage to a player, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 DeckHas:Ability$Investigate|Token & Type$Artifact|Clue
-Oracle:Enchant creature\nEnchanted creature gets +1/+1 and has "Whenever this creature deals combat damage to a player, investigate." (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Enchant creature\nEnchanted creature gets +1/+1 and has "Whenever this creature deals combat damage to a player, investigate." (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/d/daring_sleuth_bearer_of_overwhelming_truths.txt
+++ b/forge-gui/res/cardsfolder/d/daring_sleuth_bearer_of_overwhelming_truths.txt
@@ -17,6 +17,6 @@ Colors:blue
 Types:Creature Human Wizard
 PT:3/2
 K:Prowess
-T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigInvestigate | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigInvestigate | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
-Oracle:Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever Bearer of Overwhelming Truths deals combat damage to a player, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever Bearer of Overwhelming Truths deals combat damage to a player, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/d/deduce.txt
+++ b/forge-gui/res/cardsfolder/d/deduce.txt
@@ -2,6 +2,6 @@ Name:Deduce
 ManaCost:1 U
 Types:Instant
 A:SP$ Draw | SubAbility$ DBInvestigate | SpellDescription$ Draw a card.
-SVar:DBInvestigate:DB$ Investigate | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+SVar:DBInvestigate:DB$ Investigate | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 DeckHas:Ability$Investigate|Token & Type$Clue|Artifact
-Oracle:Draw a card. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Draw a card. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/d/dennick_pious_apprentice_dennick_pious_apparition.txt
+++ b/forge-gui/res/cardsfolder/d/dennick_pious_apprentice_dennick_pious_apparition.txt
@@ -17,8 +17,8 @@ Colors:white,blue
 Types:Legendary Creature Spirit Soldier
 PT:3/2
 K:Flying
-T:Mode$ ChangesZoneAll | ValidCards$ Creature.!token | Origin$ Any | Destination$ Graveyard | TriggerZones$ Battlefield | ActivationLimit$ 1 | Execute$ TrigInvestigate | TriggerDescription$ Whenever one or more creature cards are put into graveyards from anywhere, investigate. This ability triggers only once each turn. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZoneAll | ValidCards$ Creature.!token | Origin$ Any | Destination$ Graveyard | TriggerZones$ Battlefield | ActivationLimit$ 1 | Execute$ TrigInvestigate | TriggerDescription$ Whenever one or more creature cards are put into graveyards from anywhere, investigate. This ability triggers only once each turn. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Graveyard | ReplaceWith$ Exile | Description$ If CARDNAME would be put into a graveyard from anywhere, exile it instead.
 SVar:Exile:DB$ ChangeZone | Hidden$ True | Origin$ All | Destination$ Exile | Defined$ ReplacedCard
-Oracle:Flying\nWhenever one or more creature cards are put into graveyards from anywhere, investigate. This ability triggers only once each turn. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")\nIf Dennick, Pious Apparition would be put into a graveyard from anywhere, exile it instead.
+Oracle:Flying\nWhenever one or more creature cards are put into graveyards from anywhere, investigate. This ability triggers only once each turn. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nIf Dennick, Pious Apparition would be put into a graveyard from anywhere, exile it instead.

--- a/forge-gui/res/cardsfolder/d/detectives_satchel.txt
+++ b/forge-gui/res/cardsfolder/d/detectives_satchel.txt
@@ -1,10 +1,10 @@
 Name:Detective's Satchel
 ManaCost:2 U R
 Types:Artifact
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate twice. (To investigate, create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate twice. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate | Num$ 2
 A:AB$ Token | Cost$ T | TokenScript$ c_1_1_a_thopter_flying | CheckSVar$ ArtifactSacrificed | SpellDescription$ Create a 1/1 colorless Thopter artifact creature token with flying. Activate only if you've sacrificed an artifact this turn.
 SVar:ArtifactSacrificed:PlayerCountPropertyYou$SacrificedThisTurn Artifact
 DeckHas:Ability$Token|Investigate & Type$Clue|Thopter
 DeckHints:Ability$Sacrifice & Type$Clue|Food|Treasure
-Oracle:When Detective's Satchel enters, investigate twice. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")\n{T}: Create a 1/1 colorless Thopter artifact creature token with flying. Activate only if you've sacrificed an artifact this turn.
+Oracle:When Detective's Satchel enters, investigate twice. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\n{T}: Create a 1/1 colorless Thopter artifact creature token with flying. Activate only if you've sacrificed an artifact this turn.

--- a/forge-gui/res/cardsfolder/d/dining_room.txt
+++ b/forge-gui/res/cardsfolder/d/dining_room.txt
@@ -4,6 +4,6 @@ Types:Land
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 A:AB$ Mana | Cost$ T | Produced$ Combo R G | SpellDescription$ Add {R} or {G}.
-A:AB$ Investigate | Cost$ 4 T | SpellDescription$ Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:AB$ Investigate | Cost$ 4 T | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 DeckHints:Ability$Investigate|Token
-Oracle:Dining Room enters tapped.\n{T}: Add {R} or {G}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Dining Room enters tapped.\n{T}: Add {R} or {G}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/d/disorder_in_the_court.txt
+++ b/forge-gui/res/cardsfolder/d/disorder_in_the_court.txt
@@ -1,11 +1,11 @@
 Name:Disorder in the Court
 ManaCost:X W U
 Types:Instant
-A:SP$ ChangeZone | ValidTgts$ Creature | TgtPrompt$ Select X target creatures | TargetMin$ X | TargetMax$ X | Origin$ Battlefield | Destination$ Exile | RememberChanged$ True | SubAbility$ DBInvestigate | SpellDescription$ Exile X target creatures, then investigate X times. Return the exiled cards to the battlefield tapped under their owners' control at the beginning of the next end step. (To investigate, create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:SP$ ChangeZone | ValidTgts$ Creature | TgtPrompt$ Select X target creatures | TargetMin$ X | TargetMax$ X | Origin$ Battlefield | Destination$ Exile | RememberChanged$ True | SubAbility$ DBInvestigate | SpellDescription$ Exile X target creatures, then investigate X times. Return the exiled cards to the battlefield tapped under their owners' control at the beginning of the next end step. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:DBInvestigate:DB$ Investigate | Num$ X | SubAbility$ DBDelTrig
 SVar:DBDelTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ TrigReturn | RememberObjects$ RememberedLKI | TriggerDescription$ Return the exiled cards to the battlefield tapped under their owners' control at the beginning of the next end step. | SubAbility$ DBCleanup
 SVar:TrigReturn:DB$ ChangeZone | Origin$ Exile | Destination$ Battlefield | Defined$ DelayTriggerRememberedLKI | Tapped$ True
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Count$xPaid
 DeckHas:Ability$Investigate|Token|Sacrifice
-Oracle:Exile X target creatures, then investigate X times. Return the exiled cards to the battlefield tapped under their owners' control at the beginning of the next end step. (To investigate, create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Exile X target creatures, then investigate X times. Return the exiled cards to the battlefield tapped under their owners' control at the beginning of the next end step. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/d/drag_the_canal.txt
+++ b/forge-gui/res/cardsfolder/d/drag_the_canal.txt
@@ -2,9 +2,9 @@ Name:Drag the Canal
 ManaCost:U B
 Types:Instant
 A:SP$ Token | TokenScript$ wu_2_2_detective | TokenOwner$ You | SubAbility$ DBGainLife | SpellDescription$ Create a 2/2 white and blue Detective creature token.
-SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 2 | ConditionCheckSVar$ X | SubAbility$ DBSurveil | SpellDescription$ If a creature died this turn, you gain 2 life, surveil 2, then investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 2 | ConditionCheckSVar$ X | SubAbility$ DBSurveil | SpellDescription$ If a creature died this turn, you gain 2 life, surveil 2, then investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:DBSurveil:DB$ Surveil | Amount$ 2 | ConditionCheckSVar$ X | SubAbility$ DBInvestigate
 SVar:DBInvestigate:DB$ Investigate | ConditionCheckSVar$ X
 SVar:X:Count$ThisTurnEntered_Graveyard_from_Battlefield_Creature
 DeckHas:Ability$Investigate|Token & Type$Artifact|Clue|Detective
-Oracle:Create a 2/2 white and blue Detective creature token. If a creature died this turn, you gain 2 life, surveil 2, then investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Create a 2/2 white and blue Detective creature token. If a creature died this turn, you gain 2 life, surveil 2, then investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/d/drownyard_explorers.txt
+++ b/forge-gui/res/cardsfolder/d/drownyard_explorers.txt
@@ -2,7 +2,7 @@ Name:Drownyard Explorers
 ManaCost:3 U
 Types:Creature Human Wizard
 PT:2/4
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 DeckHas:Ability$Investigate|Token
-Oracle:When Drownyard Explorers enters, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:When Drownyard Explorers enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/e/eliminate_the_impossible.txt
+++ b/forge-gui/res/cardsfolder/e/eliminate_the_impossible.txt
@@ -1,8 +1,8 @@
 Name:Eliminate the Impossible
 ManaCost:1 U
 Types:Instant
-A:SP$ Investigate | SubAbility$ DBDebuff | SpellDescription$ Investigate. Creatures your opponents control get -2/-0 until end of turn. If any of them are suspected, they're no longer suspected. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+A:SP$ Investigate | SubAbility$ DBDebuff | SpellDescription$ Investigate. Creatures your opponents control get -2/-0 until end of turn. If any of them are suspected, they're no longer suspected. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:DBDebuff:DB$ PumpAll | ValidCards$ Creature.OppCtrl | NumAtt$ -2 | SubAbility$ DBAlterAttribute
 SVar:DBAlterAttribute:DB$ AlterAttribute | Defined$ Valid Creature.OppCtrl+IsSuspected | Attributes$ Suspected | Activate$ False
 DeckHas:Ability$Token & Type$Artifact|Clue
-Oracle:Investigate. Creatures your opponents control get -2/-0 until end of turn. If any of them are suspected, they're no longer suspected. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Investigate. Creatures your opponents control get -2/-0 until end of turn. If any of them are suspected, they're no longer suspected. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/e/eloise_nephalia_sleuth.txt
+++ b/forge-gui/res/cardsfolder/e/eloise_nephalia_sleuth.txt
@@ -2,9 +2,9 @@ Name:Eloise, Nephalia Sleuth
 ManaCost:3 U B
 Types:Legendary Creature Human Rogue
 PT:4/4
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.YouCtrl+Other | TriggerZones$ Battlefield | Execute$ TrigInvestigate | TriggerDescription$ Whenever another creature you control dies, investigate (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.YouCtrl+Other | TriggerZones$ Battlefield | Execute$ TrigInvestigate | TriggerDescription$ Whenever another creature you control dies, investigate (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 T:Mode$ Sacrificed | ValidPlayer$ You | ValidCard$ Permanent.token+YouCtrl | Origin$ Any | Destination$ Battlefield | Execute$ DBSurveil | TriggerZones$ Battlefield | TriggerDescription$ Whenever you sacrifice a token, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)
 SVar:DBSurveil:DB$ Surveil | Amount$ 1
 DeckHas:Ability$Investigate|Token
-Oracle:Whenever another creature you control dies, investigate (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")\nWhenever you sacrifice a token, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)
+Oracle:Whenever another creature you control dies, investigate (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nWhenever you sacrifice a token, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)

--- a/forge-gui/res/cardsfolder/e/ethereal_investigator.txt
+++ b/forge-gui/res/cardsfolder/e/ethereal_investigator.txt
@@ -3,10 +3,10 @@ ManaCost:3 U
 Types:Creature Spirit
 PT:2/3
 K:Flying
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate X times, where X is the number of opponents you have. (To investigate, create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate X times, where X is the number of opponents you have. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate | Num$ X
 SVar:X:PlayerCountOpponents$Amount
 T:Mode$ Drawn | ValidCard$ Card.YouCtrl | Number$ 2 | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever you draw your second card each turn, create a 1/1 white Spirit creature token with flying.
 SVar:TrigToken:DB$ Token | TokenScript$ w_1_1_spirit_flying
 DeckHas:Ability$Token|Sacrifice
-Oracle:Flying\nWhen Ethereal Investigator enters, investigate X times, where X is the number of opponents you have. (To investigate, create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")\nWhenever you draw your second card each turn, create a 1/1 white Spirit creature token with flying.
+Oracle:Flying\nWhen Ethereal Investigator enters, investigate X times, where X is the number of opponents you have. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nWhenever you draw your second card each turn, create a 1/1 white Spirit creature token with flying.

--- a/forge-gui/res/cardsfolder/e/evidence_examiner.txt
+++ b/forge-gui/res/cardsfolder/e/evidence_examiner.txt
@@ -5,7 +5,7 @@ PT:2/2
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigEvidence | TriggerDescription$ At the beginning of combat on your turn, you may collect evidence 4. (Exile cards with total mana value 4 or greater from your graveyard.)
 # Empty Effect for Cost
 SVar:TrigEvidence:AB$ Pump | Cost$ CollectEvidence<4> | AILogic$ Always
-T:Mode$ CollectEvidence | ValidPlayer$ You | Execute$ TrigInvestigate | TriggerZones$ Battlefield | TriggerDescription$ Whenever you collect evidence, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ CollectEvidence | ValidPlayer$ You | Execute$ TrigInvestigate | TriggerZones$ Battlefield | TriggerDescription$ Whenever you collect evidence, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 DeckHas:Ability$Token|Counters & Type$Clue
-Oracle:At the beginning of combat on your turn, you may collect evidence 4. (Exile cards with total mana value 4 or greater from your graveyard.)\nWhenever you collect evidence, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:At the beginning of combat on your turn, you may collect evidence 4. (Exile cards with total mana value 4 or greater from your graveyard.)\nWhenever you collect evidence, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/e/expose_evil.txt
+++ b/forge-gui/res/cardsfolder/e/expose_evil.txt
@@ -1,7 +1,7 @@
 Name:Expose Evil
 ManaCost:1 W
 Types:Instant
-A:SP$ Tap | TargetMin$ 0 | TargetMax$ 2 | ValidTgts$ Creature | SubAbility$ DBInvestigate | SpellDescription$ Tap up to two target creatures. Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:SP$ Tap | TargetMin$ 0 | TargetMax$ 2 | ValidTgts$ Creature | SubAbility$ DBInvestigate | SpellDescription$ Tap up to two target creatures. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:DBInvestigate:DB$ Investigate
 DeckHas:Ability$Investigate|Token
-Oracle:Tap up to two target creatures.\nInvestigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Tap up to two target creatures.\nInvestigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/e/ezrim_agency_chief.txt
+++ b/forge-gui/res/cardsfolder/e/ezrim_agency_chief.txt
@@ -3,8 +3,8 @@ ManaCost:1 W W U U
 Types:Legendary Creature Archon Detective
 PT:5/5
 K:Flying
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate twice. (To investigate, create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate twice. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate | Num$ 2
 A:AB$ Pump | Cost$ 1 Sac<1/Artifact> | Defined$ Self | StackDescription$ SpellDescription | KWChoice$ Vigilance,Lifelink,Hexproof | SpellDescription$ NICKNAME gains your choice of vigilance, lifelink, or hexproof until end of turn.
 DeckHas:Ability$Token|Sacrifice|LifeGain|Investigate & Type$Clue|Artifact
-Oracle:Flying\nWhen Ezrim, Agency Chief enters, investigate twice. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")\n{1}, Sacrifice an artifact: Ezrim gains your choice of vigilance, lifelink, or hexproof until end of turn.
+Oracle:Flying\nWhen Ezrim, Agency Chief enters, investigate twice. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\n{1}, Sacrifice an artifact: Ezrim gains your choice of vigilance, lifelink, or hexproof until end of turn.

--- a/forge-gui/res/cardsfolder/f/fateful_absence.txt
+++ b/forge-gui/res/cardsfolder/f/fateful_absence.txt
@@ -1,7 +1,7 @@
 Name:Fateful Absence
 ManaCost:1 W
 Types:Instant
-A:SP$ Destroy | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | SubAbility$ DBInvestigate | SpellDescription$ Destroy target creature or planeswalker. Its controller investigates. (They create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:SP$ Destroy | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | SubAbility$ DBInvestigate | SpellDescription$ Destroy target creature or planeswalker. Its controller investigates. (They create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:DBInvestigate:DB$ Investigate | Num$ 1 | Defined$ TargetedController | StackDescription$ {p:TargetedController} investigates.
 DeckHas:Ability$Token|Sacrifice
-Oracle:Destroy target creature or planeswalker. Its controller investigates. (They create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Destroy target creature or planeswalker. Its controller investigates. (They create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/f/fleeting_memories.txt
+++ b/forge-gui/res/cardsfolder/f/fleeting_memories.txt
@@ -1,10 +1,10 @@
 Name:Fleeting Memories
 ManaCost:2 U
 Types:Enchantment
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 T:Mode$ Sacrificed | ValidCard$ Clue.YouCtrl | Execute$ TrigMill | TriggerZones$ Battlefield | TriggerDescription$ Whenever you sacrifice a Clue, target player mills three cards.
 SVar:TrigMill:DB$ Mill | NumCards$ 3 | ValidTgts$ Player | TgtPrompt$ Select target player
 DeckHints:Ability$Investigate
 DeckHas:Ability$Investigate|Token
-Oracle:When Fleeting Memories enters, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")\nWhenever you sacrifice a Clue, target player mills three cards.
+Oracle:When Fleeting Memories enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nWhenever you sacrifice a Clue, target player mills three cards.

--- a/forge-gui/res/cardsfolder/f/floodhound.txt
+++ b/forge-gui/res/cardsfolder/f/floodhound.txt
@@ -2,6 +2,6 @@ Name:Floodhound
 ManaCost:U
 Types:Creature Elemental Dog
 PT:1/2
-A:AB$ Investigate | Cost$ 3 T | SpellDescription$ Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:AB$ Investigate | Cost$ 3 T | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 DeckHints:Ability$Investigate|Token
-Oracle:{3}, {T}: Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:{3}, {T}: Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/f/flotsam_jetsam.txt
+++ b/forge-gui/res/cardsfolder/f/flotsam_jetsam.txt
@@ -1,12 +1,12 @@
 Name:Flotsam
 ManaCost:1 GU
 Types:Instant
-A:SP$ Mill | NumCards$ 3 | SubAbility$ DBInvestigate | SpellDescription$ Mill three cards. Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
-SVar:DBInvestigate:DB$ Investigate | SpellDescription$ Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:SP$ Mill | NumCards$ 3 | SubAbility$ DBInvestigate | SpellDescription$ Mill three cards.
+SVar:DBInvestigate:DB$ Investigate | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 DeckHints:Ability$Investigate
 DeckHas:Ability$Investigate|Token|Mill & Type$Artifact|Clue
 AlternateMode:Split
-Oracle:Mill three cards. Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Mill three cards. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 
 ALTERNATE
 

--- a/forge-gui/res/cardsfolder/f/follow_the_bodies.txt
+++ b/forge-gui/res/cardsfolder/f/follow_the_bodies.txt
@@ -2,6 +2,6 @@ Name:Follow the Bodies
 ManaCost:2 U
 Types:Sorcery
 K:Gravestorm
-A:SP$ Investigate | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+A:SP$ Investigate | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 DeckHas:Ability$Graveyard|Token & Type$Clue|Artifact
-Oracle:Gravestorm (When you cast this spell, copy it for each permanent put into a graveyard from the battlefield this turn.)\nInvestigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Gravestorm (When you cast this spell, copy it for each permanent put into a graveyard from the battlefield this turn.)\nInvestigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/f/forensic_gadgeteer.txt
+++ b/forge-gui/res/cardsfolder/f/forensic_gadgeteer.txt
@@ -5,4 +5,4 @@ PT:2/3
 T:Mode$ SpellCast | ValidCard$ Artifact | ValidActivatingPlayer$ You | Execute$ TrigInvestigate | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast an artifact spell, investigate.
 SVar:TrigInvestigate:DB$ Investigate
 S:Mode$ ReduceCost | ValidCard$ Artifact.YouCtrl | Type$ Ability | Amount$ 1 | MinMana$ 1 | AffectedZone$ Battlefield | Description$ Activated abilities of artifacts you control {1} less to activate. This effect can't reduce the mana in that cost to less than one mana.
-Oracle:Whenever you cast an artifact spell, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")\nActivated abilities of artifacts you control cost {1} less to activate. This effect can't reduce the mana in that cost to less than one mana.
+Oracle:Whenever you cast an artifact spell, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nActivated abilities of artifacts you control cost {1} less to activate. This effect can't reduce the mana in that cost to less than one mana.

--- a/forge-gui/res/cardsfolder/f/foul_play.txt
+++ b/forge-gui/res/cardsfolder/f/foul_play.txt
@@ -1,7 +1,7 @@
 Name:Foul Play
 ManaCost:1 B
 Types:Sorcery
-A:SP$ Destroy | ValidTgts$ Creature.powerLE2 | TgtPrompt$ Select target creature with power 2 or less | SubAbility$ DBInvestigate | SpellDescription$ Destroy target creature with power 2 or less. Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:SP$ Destroy | ValidTgts$ Creature.powerLE2 | TgtPrompt$ Select target creature with power 2 or less | SubAbility$ DBInvestigate | SpellDescription$ Destroy target creature with power 2 or less. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:DBInvestigate:DB$ Investigate
 DeckHas:Ability$Token|Sacrifice
-Oracle:Destroy target creature with power 2 or less. Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Destroy target creature with power 2 or less. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/f/funnel_web_recluse.txt
+++ b/forge-gui/res/cardsfolder/f/funnel_web_recluse.txt
@@ -3,8 +3,8 @@ ManaCost:4 G
 Types:Creature Spider
 PT:3/5
 K:Reach
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | CheckSVar$ Morbid | Execute$ TrigInvestigate | TriggerDescription$ Morbid — When CARDNAME enters, if a creature died this turn, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | CheckSVar$ Morbid | Execute$ TrigInvestigate | TriggerDescription$ Morbid — When CARDNAME enters, if a creature died this turn, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 SVar:Morbid:Count$Morbid.1.0
 DeckHas:Ability$Investigate|Token
-Oracle:Reach\nMorbid — When Funnel-Web Recluse enters, if a creature died this turn, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Reach\nMorbid — When Funnel-Web Recluse enters, if a creature died this turn, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/g/gleaming_geardrake.txt
+++ b/forge-gui/res/cardsfolder/g/gleaming_geardrake.txt
@@ -3,10 +3,10 @@ ManaCost:U R
 Types:Artifact Creature Drake
 PT:1/1
 K:Flying
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 T:Mode$ Sacrificed | ValidCard$ Artifact | ValidPlayer$ You | Execute$ TrigPutCounter | TriggerZones$ Battlefield | TriggerDescription$ Whenever you sacrifice an artifact, put a +1/+1 counter on CARDNAME.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
 DeckHas:Ability$Token|Counters & Type$Clue
 DeckHints:Ability$Sacrifice & Type$Artifact|Clue|Food|Treasure|Map
-Oracle:Flying\nWhen Gleaming Geardrake enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")\nWhenever you sacrifice an artifact, put a +1/+1 counter on Gleaming Geardrake.
+Oracle:Flying\nWhen Gleaming Geardrake enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nWhenever you sacrifice an artifact, put a +1/+1 counter on Gleaming Geardrake.

--- a/forge-gui/res/cardsfolder/g/gone_missing.txt
+++ b/forge-gui/res/cardsfolder/g/gone_missing.txt
@@ -1,7 +1,7 @@
 Name:Gone Missing
 ManaCost:4 U
 Types:Sorcery
-A:SP$ ChangeZone | ValidTgts$ Permanent | Origin$ Battlefield | Destination$ Library | LibraryPosition$ 0 | SubAbility$ DBInvestigate | SpellDescription$ Put target permanent on top of its owner's library. Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:SP$ ChangeZone | ValidTgts$ Permanent | Origin$ Battlefield | Destination$ Library | LibraryPosition$ 0 | SubAbility$ DBInvestigate | SpellDescription$ Put target permanent on top of its owner's library. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:DBInvestigate:DB$ Investigate
 DeckHas:Ability$Investigate|Token
-Oracle:Put target permanent on top of its owner's library.\nInvestigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Put target permanent on top of its owner's library.\nInvestigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/h/hall.txt
+++ b/forge-gui/res/cardsfolder/h/hall.txt
@@ -4,6 +4,6 @@ Types:Land
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 A:AB$ Mana | Cost$ T | Produced$ Combo R W | SpellDescription$ Add {R} or {W}.
-A:AB$ Investigate | Cost$ 4 T | SpellDescription$ Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:AB$ Investigate | Cost$ 4 T | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 DeckHints:Ability$Investigate|Token
-Oracle:Hall enters tapped.\n{T}: Add {R} or {W}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Hall enters tapped.\n{T}: Add {R} or {W}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/h/hard_evidence.txt
+++ b/forge-gui/res/cardsfolder/h/hard_evidence.txt
@@ -4,4 +4,4 @@ Types:Sorcery
 A:SP$ Token | TokenScript$ u_0_3_crab | TokenOwner$ You | SubAbility$ DBInvestigate | SpellDescription$ Create a 0/3 blue Crab creature token.
 SVar:DBInvestigate:DB$ Investigate | SpellDescription$ Investigate.
 DeckHas:Ability$Investigate|Token
-Oracle:Create a 0/3 blue Crab creature token.\nInvestigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Create a 0/3 blue Crab creature token.\nInvestigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/h/hold_for_questioning.txt
+++ b/forge-gui/res/cardsfolder/h/hold_for_questioning.txt
@@ -3,10 +3,10 @@ ManaCost:3 U
 Types:Enchantment Aura
 K:Enchant:Creature,Planeswalker:creature or planeswalker
 SVar:AttachAILogic:Curse
-T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigTap | TriggerDescription$ When this Aura enters, tap enchanted permanent and investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigTap | TriggerDescription$ When this Aura enters, tap enchanted permanent and investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigTap:DB$ Tap | Defined$ Enchanted | SubAbility$ DBInvestigate
 SVar:DBInvestigate:DB$ Investigate
 R:Event$ Untap | ActiveZones$ Battlefield | ValidCard$ Card.EnchantedBy | ValidStepTurnToController$ You | Layer$ CantHappen | Description$ Enchanted permanent doesn't untap during its controller's untap step and its activated abilities can't be activated.
 S:Mode$ CantBeActivated | ValidCard$ Card.EnchantedBy | Secondary$ True | Description$ Enchanted permanent doesn't untap during its controller's untap step and its activated abilities can't be activated.
 DeckHas:Ability$Investigate|Token|Sacrifice & Type$Artifact|Clue
-Oracle:Enchant creature or planeswalker\nWhen this Aura enters, tap enchanted permanent and investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")\nEnchanted permanent doesn't untap during its controller's untap step and its activated abilities can't be activated.
+Oracle:Enchant creature or planeswalker\nWhen this Aura enters, tap enchanted permanent and investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nEnchanted permanent doesn't untap during its controller's untap step and its activated abilities can't be activated.

--- a/forge-gui/res/cardsfolder/h/homicide_investigator.txt
+++ b/forge-gui/res/cardsfolder/h/homicide_investigator.txt
@@ -2,8 +2,8 @@ Name:Homicide Investigator
 ManaCost:1 B
 Types:Creature Human Detective
 PT:2/2
-T:Mode$ ChangesZoneAll | TriggerZones$ Battlefield | ValidCards$ Creature.!token+YouCtrl | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigInvestigate | ActivationLimit$ 1 | TriggerDescription$ Whenever one or more nontoken creatures you control die, investigate. This ability triggers only once each turn. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZoneAll | TriggerZones$ Battlefield | ValidCards$ Creature.!token+YouCtrl | Origin$ Battlefield | Destination$ Graveyard | Execute$ TrigInvestigate | ActivationLimit$ 1 | TriggerDescription$ Whenever one or more nontoken creatures you control die, investigate. This ability triggers only once each turn. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 DeckHints:Ability$Sacrifice
 DeckHas:Ability$Investigate|Token & Type$Artifact|Clue
-Oracle:Whenever one or more nontoken creatures you control die, investigate. This ability triggers only once each turn. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Whenever one or more nontoken creatures you control die, investigate. This ability triggers only once each turn. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/h/hostile_investigator.txt
+++ b/forge-gui/res/cardsfolder/h/hostile_investigator.txt
@@ -4,8 +4,8 @@ Types:Creature Ogre Rogue Detective
 PT:4/3
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDiscard | TriggerDescription$ When CARDNAME enters, target opponent discards a card.
 SVar:TrigDiscard:DB$ Discard | ValidTgts$ Opponent | NumCards$ 1 | Mode$ TgtChoose
-T:Mode$ DiscardedAll | ValidPlayer$ Player | ActivationLimit$ 1 | ValidCard$ Card | TriggerZones$ Battlefield | Execute$ TrigInvestigate | TriggerDescription$ Whenever one or more players discard one or more cards, investigate. This ability triggers only once each turn. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ DiscardedAll | ValidPlayer$ Player | ActivationLimit$ 1 | ValidCard$ Card | TriggerZones$ Battlefield | Execute$ TrigInvestigate | TriggerDescription$ Whenever one or more players discard one or more cards, investigate. This ability triggers only once each turn. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 DeckHas:Ability$Discard|Token|Sacrifice & Type$Artifact|Clue
 DeckHints:Ability$Discard
-Oracle:When Hostile Investigator enters, target opponent discards a card.\nWhenever one or more players discard one or more cards, investigate. This ability triggers only once each turn. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:When Hostile Investigator enters, target opponent discards a card.\nWhenever one or more players discard one or more cards, investigate. This ability triggers only once each turn. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/h/hotshot_investigators.txt
+++ b/forge-gui/res/cardsfolder/h/hotshot_investigators.txt
@@ -2,9 +2,9 @@ Name:Hotshot Investigators
 ManaCost:5 U
 Types:Creature Vedalken Detective
 PT:4/4
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChangeZone | TriggerDescription$ When CARDNAME enters, return up to one other target creature to its owner's hand. If you controlled it, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigChangeZone | TriggerDescription$ When CARDNAME enters, return up to one other target creature to its owner's hand. If you controlled it, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigChangeZone:DB$ ChangeZone | ValidTgts$ Creature.Other | TgtPrompt$ Select up to one other target creature | TargetMin$ 0 | TargetMax$ 1 | RememberLKI$ True | Origin$ Battlefield | Destination$ Hand | SubAbility$ DBInvestigate
 SVar:DBInvestigate:DB$ Investigate | ConditionDefined$ RememberedLKI | ConditionPresent$ Card.YouCtrl | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 DeckHas:Ability$Investigate|Token & Type$Clue
-Oracle:When Hotshot Investigators enters, return up to one other target creature to its owner's hand. If you controlled it, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:When Hotshot Investigators enters, return up to one other target creature to its owner's hand. If you controlled it, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/h/humble_the_brute.txt
+++ b/forge-gui/res/cardsfolder/h/humble_the_brute.txt
@@ -1,7 +1,7 @@
 Name:Humble the Brute
 ManaCost:4 W
 Types:Instant
-A:SP$ Destroy | ValidTgts$ Creature.powerGE4 | SubAbility$ DBInvestigate | TgtPrompt$ Select target creature with power 4 or greater | SpellDescription$ Destroy target creature with power 4 or greater. Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:SP$ Destroy | ValidTgts$ Creature.powerGE4 | SubAbility$ DBInvestigate | TgtPrompt$ Select target creature with power 4 or greater | SpellDescription$ Destroy target creature with power 4 or greater. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:DBInvestigate:DB$ Investigate
 DeckHas:Ability$Investigate|Token
-Oracle:Destroy target creature with power 4 or greater.\nInvestigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Destroy target creature with power 4 or greater.\nInvestigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/i/innocent_bystander.txt
+++ b/forge-gui/res/cardsfolder/i/innocent_bystander.txt
@@ -2,7 +2,7 @@ Name:Innocent Bystander
 ManaCost:1 R
 Types:Creature Goblin Citizen
 PT:2/1
-T:Mode$ DamageDoneOnce | ValidTarget$ Card.Self | DamageAmount$ GE3 | Execute$ TrigInvestigate | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME is dealt 3 or more damage, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ DamageDoneOnce | ValidTarget$ Card.Self | DamageAmount$ GE3 | Execute$ TrigInvestigate | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME is dealt 3 or more damage, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 DeckHas:Ability$Token|Investigate|Sacrifice & Type$Artifact|Clue
-Oracle:Whenever Innocent Bystander is dealt 3 or more damage, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Whenever Innocent Bystander is dealt 3 or more damage, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/i/inquisitor_eisenhorn.txt
+++ b/forge-gui/res/cardsfolder/i/inquisitor_eisenhorn.txt
@@ -7,8 +7,8 @@ SVar:DBReveal:DB$ Reveal | Defined$ You | RevealDefined$ TriggeredCard | Remembe
 SVar:DBTrigger:DB$ ImmediateTrigger | ConditionDefined$ Remembered | ConditionPresent$ Instant,Sorcery | SubAbility$ DBCleanup | Execute$ DBToken | TriggerDescription$ Whenever you reveal an instant or sorcery card this way, create Cherubael, a legendary 4/4 black Demon creature token with flying.
 SVar:DBToken:DB$ Token | TokenScript$ cherubael
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
-T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigInvestigate | CombatDamage$ True | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, investigate that many times. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigInvestigate | CombatDamage$ True | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, investigate that many times. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate | Num$ X | Defined$ You
 SVar:X:TriggerCount$DamageAmount
 DeckHas:Type$Clue|Demon|Artifact & Ability$Token|Sacrifice
-Oracle:You may reveal the first card you draw each turn as you draw it. Whenever you reveal an instant or sorcery card this way, create Cherubael, a legendary 4/4 black Demon creature token with flying.\nWhenever Inquisitor Eisenhorn deals combat damage to a player, investigate that many times. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:You may reveal the first card you draw each turn as you draw it. Whenever you reveal an instant or sorcery card this way, create Cherubael, a legendary 4/4 black Demon creature token with flying.\nWhenever Inquisitor Eisenhorn deals combat damage to a player, investigate that many times. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/i/inquisitor_greyfax.txt
+++ b/forge-gui/res/cardsfolder/i/inquisitor_greyfax.txt
@@ -4,8 +4,8 @@ Types:Legendary Creature Human Inquisitor
 PT:3/3
 K:Vigilance
 S:Mode$ Continuous | Affected$ Creature.Other+YouCtrl | AddPower$ 1 | AddKeyword$ Vigilance | Description$ Unquestionable Wisdom — Other creatures you control get +1/+0 and have vigilance.
-A:AB$ Tap | Cost$ 1 T | ValidTgts$ Creature.OppCtrl | SubAbility$ DBInvestigate | TgtPrompt$ Choose target creature an opponent controls | PrecostDesc$ Hunt for Heresy — | SpellDescription$ Tap target creature an opponent controls. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+A:AB$ Tap | Cost$ 1 T | ValidTgts$ Creature.OppCtrl | SubAbility$ DBInvestigate | TgtPrompt$ Choose target creature an opponent controls | PrecostDesc$ Hunt for Heresy — | SpellDescription$ Tap target creature an opponent controls. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:DBInvestigate:DB$ Investigate
 SVar:PlayMain1:TRUE
 DeckHas:Ability$Investigate|Token|Sacrifice & Type$Artifact|Clue
-Oracle:Vigilance\nUnquestionable Wisdom — Other creatures you control get +1/+0 and have vigilance.\nHunt for Heresy — {1}, {T}: Tap target creature an opponent controls. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Vigilance\nUnquestionable Wisdom — Other creatures you control get +1/+0 and have vigilance.\nHunt for Heresy — {1}, {T}: Tap target creature an opponent controls. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/j/jaces_scrutiny.txt
+++ b/forge-gui/res/cardsfolder/j/jaces_scrutiny.txt
@@ -1,7 +1,7 @@
 Name:Jace's Scrutiny
 ManaCost:1 U
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | NumAtt$ -4 | IsCurse$ True | SubAbility$ DBInvestigate | SpellDescription$ Target creature gets -4/-0 until end of turn. Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:SP$ Pump | ValidTgts$ Creature | NumAtt$ -4 | IsCurse$ True | SubAbility$ DBInvestigate | SpellDescription$ Target creature gets -4/-0 until end of turn. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:DBInvestigate:DB$ Investigate
 DeckHas:Ability$Investigate|Token
-Oracle:Target creature gets -4/-0 until end of turn.\nInvestigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Target creature gets -4/-0 until end of turn.\nInvestigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/k/kitchen.txt
+++ b/forge-gui/res/cardsfolder/k/kitchen.txt
@@ -4,6 +4,6 @@ Types:Land
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 A:AB$ Mana | Cost$ T | Produced$ Combo G U | SpellDescription$ Add {G} or {U}.
-A:AB$ Investigate | Cost$ 4 T | SpellDescription$ Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:AB$ Investigate | Cost$ 4 T | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 DeckHints:Ability$Investigate|Token
-Oracle:Kitchen enters tapped.\n{T}: Add {G} or {U}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Kitchen enters tapped.\n{T}: Add {G} or {U}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/l/lavinia_foil_to_conspiracy.txt
+++ b/forge-gui/res/cardsfolder/l/lavinia_foil_to_conspiracy.txt
@@ -3,7 +3,7 @@ ManaCost:1 WU WU
 Types:Legendary Creature Human Detective
 PT:2/3
 K:Vigilance
-T:Mode$ SpellCast | ValidCard$ Card.YouCtrl | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigInvestigate | ActivatorThisTurnCast$ EQ2 | TriggerDescription$ Whenever you cast your second spell each turn, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ SpellCast | ValidCard$ Card.YouCtrl | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigInvestigate | ActivatorThisTurnCast$ EQ2 | TriggerDescription$ Whenever you cast your second spell each turn, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 A:AB$ Mana | Cost$ T | Produced$ C | Amount$ 2 | OpponentTurn$ True | SpellDescription$ Add {C}{C}. Activate only during an opponent's turn.
-Oracle:Vigilance\nWhenever you cast your second spell each turn, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")\n{T}: Add {C}{C}. Activate only during an opponent's turn.
+Oracle:Vigilance\nWhenever you cast your second spell each turn, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\n{T}: Add {C}{C}. Activate only during an opponent's turn.

--- a/forge-gui/res/cardsfolder/l/lazav_wearer_of_faces.txt
+++ b/forge-gui/res/cardsfolder/l/lazav_wearer_of_faces.txt
@@ -2,7 +2,7 @@ Name:Lazav, Wearer of Faces
 ManaCost:U B
 Types:Legendary Creature Shapeshifter Detective
 PT:2/3
-T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ Whenever CARDNAME attacks, exile target card from a graveyard, then investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ Whenever CARDNAME attacks, exile target card from a graveyard, then investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigExile:DB$ ChangeZone | Origin$ Graveyard | Destination$ Exile | ValidTgts$ Card | SubAbility$ DBInvestigate
 SVar:DBInvestigate:DB$ Investigate
 T:Mode$ Sacrificed | ValidPlayer$ You | ValidCard$ Clue.YouCtrl | Execute$ TrigClone | TriggerZones$ Battlefield | TriggerDescription$ Whenever you sacrifice a Clue, you may have NICKNAME become a copy of a creature card exiled with it until end of turn.
@@ -10,4 +10,4 @@ SVar:TrigClone:DB$ Clone | Choices$ Creature.ExiledWithSource | ChoiceZone$ Exil
 SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Investigate|Token|Graveyard & Type$Artifact|Clue
 DeckHints:Ability$Graveyard
-Oracle:Whenever Lazav, Wearer of Faces attacks, exile target card from a graveyard, then investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")\nWhenever you sacrifice a Clue, you may have Lazav become a copy of a creature card exiled with it until end of turn.
+Oracle:Whenever Lazav, Wearer of Faces attacks, exile target card from a graveyard, then investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nWhenever you sacrifice a Clue, you may have Lazav become a copy of a creature card exiled with it until end of turn.

--- a/forge-gui/res/cardsfolder/l/library.txt
+++ b/forge-gui/res/cardsfolder/l/library.txt
@@ -4,6 +4,6 @@ Types:Land
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 A:AB$ Mana | Cost$ T | Produced$ Combo U R | SpellDescription$ Add {U} or {R}.
-A:AB$ Investigate | Cost$ 4 T | SpellDescription$ Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:AB$ Investigate | Cost$ 4 T | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 DeckHints:Ability$Investigate|Token
-Oracle:Library enters tapped.\n{T}: Add {U} or {R}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Library enters tapped.\n{T}: Add {U} or {R}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/l/lounge.txt
+++ b/forge-gui/res/cardsfolder/l/lounge.txt
@@ -4,6 +4,6 @@ Types:Land
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 A:AB$ Mana | Cost$ T | Produced$ Combo B G | SpellDescription$ Add {B} or {G}.
-A:AB$ Investigate | Cost$ 4 T | SpellDescription$ Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:AB$ Investigate | Cost$ 4 T | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 DeckHints:Ability$Investigate|Token
-Oracle:Lounge enters tapped.\n{T}: Add {B} or {G}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Lounge enters tapped.\n{T}: Add {B} or {G}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/l/loxodon_eavesdropper.txt
+++ b/forge-gui/res/cardsfolder/l/loxodon_eavesdropper.txt
@@ -2,9 +2,9 @@ Name:Loxodon Eavesdropper
 ManaCost:3 G
 Types:Creature Elephant Detective
 PT:3/3
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate | Num$ 1
 T:Mode$ Drawn | ValidCard$ Card.YouCtrl | Number$ 2 | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever you draw your second card each turn, CARDNAME gets +1/+1 and gains vigilance until end of turn.
 SVar:TrigPump:DB$ Pump | Defined$ Self | KW$ Vigilance | NumAtt$ +1 | NumDef$ +1
 DeckHas:Ability$Investigate|Token|Sacrifice & Type$Artifact|Clue
-Oracle:When Loxodon Eavesdropper enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")\nWhenever you draw your second card each turn, Loxodon Eavesdropper gets +1/+1 and gains vigilance until end of turn.
+Oracle:When Loxodon Eavesdropper enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nWhenever you draw your second card each turn, Loxodon Eavesdropper gets +1/+1 and gains vigilance until end of turn.

--- a/forge-gui/res/cardsfolder/m/magnifying_glass.txt
+++ b/forge-gui/res/cardsfolder/m/magnifying_glass.txt
@@ -2,7 +2,7 @@ Name:Magnifying Glass
 ManaCost:3
 Types:Artifact
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
-A:AB$ Investigate | Cost$ 4 T | SpellDescription$ Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:AB$ Investigate | Cost$ 4 T | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 DeckHas:Ability$Investigate|Token
 DeckHints:Name$Agency Outfitter
-Oracle:{T}: Add {C}.\n{4}, {T}: Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:{T}: Add {C}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/m/malcolm_the_eyes.txt
+++ b/forge-gui/res/cardsfolder/m/malcolm_the_eyes.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature Siren Pirate
 PT:2/2
 K:Flying
 K:Haste
-T:Mode$ SpellCast | ValidCard$ Card.YouCtrl | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigInvestigate | ActivatorThisTurnCast$ EQ2 | TriggerDescription$ Whenever you cast your second spell each turn, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ SpellCast | ValidCard$ Card.YouCtrl | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigInvestigate | ActivatorThisTurnCast$ EQ2 | TriggerDescription$ Whenever you cast your second spell each turn, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 DeckHints:Ability$Investigate|Token
-Oracle:Flying, haste\nWhenever you cast your second spell each turn, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Flying, haste\nWhenever you cast your second spell each turn, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/m/martha_jones.txt
+++ b/forge-gui/res/cardsfolder/m/martha_jones.txt
@@ -2,7 +2,7 @@ Name:Martha Jones
 ManaCost:2 U
 Types:Legendary Creature Human Cleric
 PT:3/2
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ Woman Who Walked the Earth — When CARDNAME enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ Woman Who Walked the Earth — When CARDNAME enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 T:Mode$ Sacrificed | ValidPlayer$ You | ValidCard$ Clue | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever you sacrifice a Clue, CARDNAME and up to one other target creature can't be blocked this turn.
 SVar:TrigPump:DB$ Effect | RememberObjects$ Self & Targeted | ValidTgts$ Creature | TargetMin$ 0 | TargetMax$ 1 | StaticAbilities$ Unblockable
@@ -10,4 +10,4 @@ SVar:Unblockable:Mode$ CantBlockBy | ValidAttacker$ Creature.IsRemembered | Desc
 K:Doctor's companion
 DeckHints:Ability$Investigate
 DeckHas:Ability$Investigate|Token|Sacrifice & Type$Artifact|Clue
-Oracle:Woman Who Walked the Earth — When Martha Jones enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")\nWhenever you sacrifice a Clue, Martha Jones and up to one other target creature can't be blocked this turn.\nDoctor's companion (You can have two commanders if the other is the Doctor.)
+Oracle:Woman Who Walked the Earth — When Martha Jones enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nWhenever you sacrifice a Clue, Martha Jones and up to one other target creature can't be blocked this turn.\nDoctor's companion (You can have two commanders if the other is the Doctor.)

--- a/forge-gui/res/cardsfolder/m/max_the_daredevil.txt
+++ b/forge-gui/res/cardsfolder/m/max_the_daredevil.txt
@@ -4,9 +4,9 @@ ManaCost:1 R G
 Types:Legendary Creature Human
 PT:3/2
 K:Haste
-T:Mode$ SpellCast | ValidCard$ Card.YouCtrl | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUntap | ActivatorThisTurnCast$ EQ2 | TriggerDescription$ Whenever you cast your second spell each turn, untap target creature, then investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ SpellCast | ValidCard$ Card.YouCtrl | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigUntap | ActivatorThisTurnCast$ EQ2 | TriggerDescription$ Whenever you cast your second spell each turn, untap target creature, then investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigUntap:DB$ Untap | ValidTgts$ Creature | SubAbility$ DBInvestigate
 SVar:DBInvestigate:DB$ Investigate
 K:Partner:Friends forever
 DeckHas:Ability$Investigate|Token|Sacrifice
-Oracle:Haste\nWhenever you cast your second spell each turn, untap target creature, then investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")\nPartner—Friends forever (You can have two commanders if both have this ability.)
+Oracle:Haste\nWhenever you cast your second spell each turn, untap target creature, then investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nPartner—Friends forever (You can have two commanders if both have this ability.)

--- a/forge-gui/res/cardsfolder/m/meddling_youths.txt
+++ b/forge-gui/res/cardsfolder/m/meddling_youths.txt
@@ -3,7 +3,7 @@ ManaCost:3 R W
 Types:Creature Human Detective
 PT:4/5
 K:Haste
-T:Mode$ AttackersDeclared | Execute$ TrigInvestigate | ValidAttackers$ Creature | ValidAttackersAmount$ GE3 | TriggerZones$ Battlefield | AttackingPlayer$ You | TriggerDescription$ Whenever you attack with three or more creatures, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ AttackersDeclared | Execute$ TrigInvestigate | ValidAttackers$ Creature | ValidAttackersAmount$ GE3 | TriggerZones$ Battlefield | AttackingPlayer$ You | TriggerDescription$ Whenever you attack with three or more creatures, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 DeckHas:Ability$Investigate|Token & Type$Clue|Artifact
-Oracle:Haste\nWhenever you attack with three or more creatures, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Haste\nWhenever you attack with three or more creatures, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/m/morska_undersea_sleuth.txt
+++ b/forge-gui/res/cardsfolder/m/morska_undersea_sleuth.txt
@@ -3,9 +3,9 @@ ManaCost:G W U
 Types:Legendary Creature Vedalken Fish Detective
 PT:2/3
 S:Mode$ Continuous | Affected$ You | SetMaxHandSize$ Unlimited | Description$ You have no maximum hand size.
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigInvestigate | TriggerDescription$ At the beginning of your upkeep, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigInvestigate | TriggerDescription$ At the beginning of your upkeep, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 T:Mode$ Drawn | ValidCard$ Card.YouCtrl | Number$ 2 | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Whenever you draw your second card each turn, put two +1/+1 counters on CARDNAME.
 SVar:TrigPutCounter:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ 2
 DeckHas:Ability$Counters|Investigate|Token|Sacrifice & Type$Artifact|Clue
-Oracle:You have no maximum hand size.\nAt the beginning of your upkeep, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")\nWhenever you draw your second card each turn, put two +1/+1 counters on Morska, Undersea Sleuth.
+Oracle:You have no maximum hand size.\nAt the beginning of your upkeep, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nWhenever you draw your second card each turn, put two +1/+1 counters on Morska, Undersea Sleuth.

--- a/forge-gui/res/cardsfolder/n/nick_valentine_private_eye.txt
+++ b/forge-gui/res/cardsfolder/n/nick_valentine_private_eye.txt
@@ -3,8 +3,8 @@ ManaCost:2 U
 Types:Legendary Artifact Creature Synth Detective
 PT:2/2
 S:Mode$ CantBlockBy | ValidAttacker$ Creature.Self | ValidBlocker$ Creature.nonArtifact | Description$ CARDNAME can't be blocked except by artifact creatures.
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self,Creature.Artifact+YouCtrl+Other | TriggerZones$ Battlefield | Execute$ TrigInvestigate | TriggerDescription$ Whenever CARDNAME or another artifact creature you control dies, you may investigate. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self,Creature.Artifact+YouCtrl+Other | TriggerZones$ Battlefield | Execute$ TrigInvestigate | TriggerDescription$ Whenever CARDNAME or another artifact creature you control dies, you may investigate. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate | Optional$ True
 DeckHints:Type$Artifact
 DeckHas:Ability$Investigate|Token & Type$Artifact|Clue
-Oracle:Nick Valentine, Private Eye can't be blocked except by artifact creatures.\nWhenever Nick Valentine or another artifact creature you control dies, you may investigate. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Nick Valentine, Private Eye can't be blocked except by artifact creatures.\nWhenever Nick Valentine or another artifact creature you control dies, you may investigate. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/n/no_witnesses.txt
+++ b/forge-gui/res/cardsfolder/n/no_witnesses.txt
@@ -1,7 +1,7 @@
 Name:No Witnesses
 ManaCost:2 W W
 Types:Sorcery
-A:SP$ Investigate | Num$ 1 | Defined$ Player.withMostTypeCreature | SubAbility$ DBDestroyAll | SpellDescription$ Each player who controls the most creatures investigates. Then destroy all creatures. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+A:SP$ Investigate | Num$ 1 | Defined$ Player.withMostTypeCreature | SubAbility$ DBDestroyAll | SpellDescription$ Each player who controls the most creatures investigates. Then destroy all creatures. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:DBDestroyAll:DB$ DestroyAll | ValidCards$ Creature
 AI:RemoveDeck:Random
-Oracle:Each player who controls the most creatures investigates. Then destroy all creatures. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Each player who controls the most creatures investigates. Then destroy all creatures. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/n/novice_inspector.txt
+++ b/forge-gui/res/cardsfolder/n/novice_inspector.txt
@@ -2,7 +2,7 @@ Name:Novice Inspector
 ManaCost:W
 Types:Creature Human Detective
 PT:1/2
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 DeckHas:Ability$Investigate|Token & Type$Clue|Artifact
-Oracle:When Novice Inspector enters, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:When Novice Inspector enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/o/on_the_job.txt
+++ b/forge-gui/res/cardsfolder/o/on_the_job.txt
@@ -2,6 +2,6 @@ Name:On the Job
 ManaCost:2 W W
 Types:Instant
 A:SP$ PumpAll | ValidCards$ Creature.YouCtrl | NumAtt$ +2 | NumDef$ +1 | SubAbility$ DBInvestigate | SpellDescription$ Creatures you control get +2/+1 until end of turn.
-SVar:DBInvestigate:DB$ Investigate | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+SVar:DBInvestigate:DB$ Investigate | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 DeckHas:Ability$Investigate|Token & Type$Artifact|Clue
-Oracle:Creatures you control get +2/+1 until end of turn. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Creatures you control get +2/+1 until end of turn. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/o/ongoing_investigation.txt
+++ b/forge-gui/res/cardsfolder/o/ongoing_investigation.txt
@@ -1,7 +1,7 @@
 Name:Ongoing Investigation
 ManaCost:1 U
 Types:Enchantment
-T:Mode$ DamageDoneOnce | CombatDamage$ True | ValidSource$ Creature.YouCtrl | TriggerZones$ Battlefield | ValidTarget$ Player | Execute$ DBInvestigate | TriggerDescription$ Whenever one or more creatures you control deal combat damage to a player, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ DamageDoneOnce | CombatDamage$ True | ValidSource$ Creature.YouCtrl | TriggerZones$ Battlefield | ValidTarget$ Player | Execute$ DBInvestigate | TriggerDescription$ Whenever one or more creatures you control deal combat damage to a player, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:DBInvestigate:DB$ Investigate
 A:AB$ Investigate | Cost$ 1 G ExileFromGrave<1/Creature> | SubAbility$ DBGainLife | SpellDescription$ Investigate. You gain 2 life.
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 2
@@ -9,4 +9,4 @@ SVar:PlayMain1:TRUE
 DeckNeeds:Color$Green
 DeckHints:Ability$Investigate
 DeckHas:Ability$Investigate|Token|LifeGain
-Oracle:Whenever one or more creatures you control deal combat damage to a player, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")\n{1}{G}, Exile a creature card from your graveyard: Investigate. You gain 2 life.
+Oracle:Whenever one or more creatures you control deal combat damage to a player, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\n{1}{G}, Exile a creature card from your graveyard: Investigate. You gain 2 life.

--- a/forge-gui/res/cardsfolder/o/osgood_operation_double.txt
+++ b/forge-gui/res/cardsfolder/o/osgood_operation_double.txt
@@ -5,8 +5,8 @@ PT:2/2
 T:Mode$ SpellCast | ValidCard$ Card.Self | Execute$ TrigCopy | TriggerDescription$ When you cast this spell, create a token that's a copy of it, except it isn't legendary.
 SVar:TrigCopy:DB$ CopySpellAbility | Defined$ TriggeredSpellAbility | NonLegendary$ True
 A:AB$ Mana | Cost$ T | Produced$ C | Amount$ 1 | RestrictValid$ Spell.Artifact,Activated.Artifact+inZoneBattlefield | SpellDescription$ Add {C}. Spend this mana only to cast an artifact spell or activate an ability of an artifact.
-T:Mode$ SpellCast | ValidCard$ Card.!wasCastFromYourHand | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigInvestigate | TriggerDescription$ Paradox — Whenever you cast a spell from anywhere other than your hand, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ SpellCast | ValidCard$ Card.!wasCastFromYourHand | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigInvestigate | TriggerDescription$ Paradox — Whenever you cast a spell from anywhere other than your hand, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 DeckHas:Ability$Token & Type$Clue|Artifact
 DeckHints:Type$Artifact
-Oracle:When you cast this spell, create a token that's a copy of it, except it isn't legendary.\n{T}: Add {C}. Spend this mana only to cast an artifact spell or activate an ability of an artifact.\nParadox — Whenever you cast a spell from anywhere other than your hand, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:When you cast this spell, create a token that's a copy of it, except it isn't legendary.\n{T}: Add {C}. Spend this mana only to cast an artifact spell or activate an ability of an artifact.\nParadox — Whenever you cast a spell from anywhere other than your hand, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/p/panther_pounce.txt
+++ b/forge-gui/res/cardsfolder/p/panther_pounce.txt
@@ -1,7 +1,7 @@
 Name:Panther Pounce
 ManaCost:W
 Types:Instant
-A:SP$ Investigate | ValidTgts$ Player | SubAbility$ DBPump | SpellDescription$ Target player investigates. Target creature gets +1/+0 and gains flying until end of turn. Untap it. (To investigate, create a Clue token. It's an artifact with ({2}, Sacrifice this token: Draw a card.")
+A:SP$ Investigate | ValidTgts$ Player | SubAbility$ DBPump | SpellDescription$ Target player investigates. Target creature gets +1/+0 and gains flying until end of turn. Untap it. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:DBPump:DB$ Pump | ValidTgts$ Creature | NumAtt$ +1 | KW$ Flying | SubAbility$ DBUntap
 SVar:DBUntap:DB$ Untap | Defined$ ParentTarget
-Oracle:Target player investigates. Target creature gets +1/+0 and gains flying until end of turn. Untap it. (To investigate, create a Clue token. It's an artifact with ({2}, Sacrifice this token: Draw a card.")
+Oracle:Target player investigates. Target creature gets +1/+0 and gains flying until end of turn. Untap it. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/p/persuasive_interrogators.txt
+++ b/forge-gui/res/cardsfolder/p/persuasive_interrogators.txt
@@ -2,10 +2,10 @@ Name:Persuasive Interrogators
 ManaCost:4 B B
 Types:Creature Gorgon Detective
 PT:5/6
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 T:Mode$ Sacrificed | ValidPlayer$ You | ValidCard$ Clue | TriggerZones$ Battlefield | Execute$ TrigPoison | TriggerDescription$ Whenever you sacrifice a Clue, target opponent gets two poison counters. (A player with ten or more poison counters loses the game.)
 SVar:TrigPoison:DB$ Poison | ValidTgts$ Opponent | Num$ 2
 DeckHas:Ability$Investigate|Token & Type$Artifact|Clue
 DeckHints:Ability$Sacrifice & Type$Clue
-Oracle:When Persuasive Interrogators enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")\nWhenever you sacrifice a Clue, target opponent gets two poison counters. (A player with ten or more poison counters loses the game.)
+Oracle:When Persuasive Interrogators enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nWhenever you sacrifice a Clue, target opponent gets two poison counters. (A player with ten or more poison counters loses the game.)

--- a/forge-gui/res/cardsfolder/p/piper_wright_publick_reporter.txt
+++ b/forge-gui/res/cardsfolder/p/piper_wright_publick_reporter.txt
@@ -2,11 +2,11 @@ Name:Piper Wright, Publick Reporter
 ManaCost:1 U
 Types:Legendary Creature Human Detective
 PT:1/2
-T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigInvestigate | CombatDamage$ True | TriggerDescription$ Whenever NICKNAME deals combat damage to a player, investigate that many times. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigInvestigate | CombatDamage$ True | TriggerDescription$ Whenever NICKNAME deals combat damage to a player, investigate that many times. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate | Num$ X | Defined$ You
 SVar:X:TriggerCount$DamageAmount
 T:Mode$ Sacrificed | ValidPlayer$ You | ValidCard$ Clue.YouCtrl | Execute$ TrigPutCounter | TriggerZones$ Battlefield | TriggerDescription$ Whenever you sacrifice a Clue, put a +1/+1 counter on target creature you control.
 SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | CounterType$ P1P1
 DeckHas:Type$Clue|Artifact & Ability$Token|Sacrifice|Counters
 DeckHints:Type$Clue
-Oracle:Whenever Piper Wright deals combat damage to a player, investigate that many times. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")\nWhenever you sacrifice a Clue, put a +1/+1 counter on target creature you control.
+Oracle:Whenever Piper Wright deals combat damage to a player, investigate that many times. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nWhenever you sacrifice a Clue, put a +1/+1 counter on target creature you control.

--- a/forge-gui/res/cardsfolder/p/press_for_answers.txt
+++ b/forge-gui/res/cardsfolder/p/press_for_answers.txt
@@ -1,8 +1,8 @@
 Name:Press for Answers
 ManaCost:1 U
 Types:Sorcery
-A:SP$ Tap | ValidTgts$ Creature | SubAbility$ DBPump | SpellDescription$ Tap target creature. It doesn't untap during its controller's next untap step. Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:SP$ Tap | ValidTgts$ Creature | SubAbility$ DBPump | SpellDescription$ Tap target creature. It doesn't untap during its controller's next untap step. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:DBPump:DB$ Pump | Defined$ Targeted | KW$ HIDDEN This card doesn't untap during your next untap step. | Duration$ Permanent | SubAbility$ DBInvestigate
 SVar:DBInvestigate:DB$ Investigate
 DeckHas:Ability$Investigate
-Oracle:Tap target creature. It doesn't untap during its controller's next untap step.\nInvestigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Tap target creature. It doesn't untap during its controller's next untap step.\nInvestigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/r/root_out.txt
+++ b/forge-gui/res/cardsfolder/r/root_out.txt
@@ -1,7 +1,7 @@
 Name:Root Out
 ManaCost:2 G
 Types:Sorcery
-A:SP$ Destroy | ValidTgts$ Artifact,Enchantment | TgtPrompt$ Select target artifact or enchantment | SubAbility$ DBInvestigate | SpellDescription$ Destroy target artifact or enchantment. Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:SP$ Destroy | ValidTgts$ Artifact,Enchantment | TgtPrompt$ Select target artifact or enchantment | SubAbility$ DBInvestigate | SpellDescription$ Destroy target artifact or enchantment. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:DBInvestigate:DB$ Investigate
 DeckHas:Ability$Investigate|Token
-Oracle:Destroy target artifact or enchantment.\nInvestigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Destroy target artifact or enchantment.\nInvestigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/r/rory_williams.txt
+++ b/forge-gui/res/cardsfolder/r/rory_williams.txt
@@ -5,10 +5,10 @@ PT:3/3
 K:Partner with:Amy Pond
 K:First Strike
 K:Lifelink
-T:Mode$ SpellCast | ValidCard$ Card.Self+!wasCastFromExile | Execute$ TrigExile | TriggerDescription$ The Last Centurion — When you cast this spell from anywhere other than exile, exile it with three time counters on it. It gains suspend. Then investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ SpellCast | ValidCard$ Card.Self+!wasCastFromExile | Execute$ TrigExile | TriggerDescription$ The Last Centurion — When you cast this spell from anywhere other than exile, exile it with three time counters on it. It gains suspend. Then investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigExile:DB$ ChangeZone | Defined$ TriggeredSpellAbility | Origin$ Stack | Destination$ Exile | WithCountersType$ TIME | WithCountersAmount$ 3 | RememberChanged$ True | SubAbility$ GiveSuspend
 SVar:GiveSuspend:DB$ Pump | Defined$ Remembered | KW$ Suspend | PumpZone$ Exile | Duration$ Permanent | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | SubAbility$ DBInvestigate
 SVar:DBInvestigate:DB$ Investigate
 DeckHas:Ability$LifeGain|Investigate|Token|Sacrifice & Type$Artifact|Clue
-Oracle:Partner with Amy Pond\nFirst strike, lifelink\nThe Last Centurion — When you cast this spell from anywhere other than exile, exile it with three time counters on it. It gains suspend. Then investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Partner with Amy Pond\nFirst strike, lifelink\nThe Last Centurion — When you cast this spell from anywhere other than exile, exile it with three time counters on it. It gains suspend. Then investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/s/sally_sparrow.txt
+++ b/forge-gui/res/cardsfolder/s/sally_sparrow.txt
@@ -3,7 +3,7 @@ ManaCost:2 W U
 Types:Legendary Creature Human Detective
 PT:2/3
 S:Mode$ CastWithFlash | ValidCard$ Creature | ValidSA$ Spell | Caster$ You | Description$ You may cast creature spells as though they had flash.
-T:Mode$ ChangesZoneAll | Origin$ Battlefield | ActivationLimit$ 1 | Destination$ Any | ValidCards$ Creature.YouCtrl+Other | Execute$ TrigInvestigate | TriggerZones$ Battlefield | TriggerDescription$ Whenever one or more other creatures you control leave the battlefield, investigate. This ability triggers only once each turn. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZoneAll | Origin$ Battlefield | ActivationLimit$ 1 | Destination$ Any | ValidCards$ Creature.YouCtrl+Other | Execute$ TrigInvestigate | TriggerZones$ Battlefield | TriggerDescription$ Whenever one or more other creatures you control leave the battlefield, investigate. This ability triggers only once each turn. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 DeckHas:Ability$Token & Type$Clue|Artifact
-Oracle:You may cast creature spells as though they had flash.\nWhenever one or more other creatures you control leave the battlefield, investigate. This ability triggers only once each turn. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:You may cast creature spells as though they had flash.\nWhenever one or more other creatures you control leave the battlefield, investigate. This ability triggers only once each turn. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/s/sarah_jane_smith.txt
+++ b/forge-gui/res/cardsfolder/s/sarah_jane_smith.txt
@@ -2,9 +2,9 @@ Name:Sarah Jane Smith
 ManaCost:1 W
 Types:Legendary Creature Human Detective
 PT:2/1
-T:Mode$ SpellCast | ValidCard$ Card.Historic | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | ActivationLimit$ 1 | Execute$ TrigInvestigate | TriggerDescription$ Whenever you cast a historic spell, investigate. This ability triggers only once each turn. (Artifacts, legendaries, and Sagas are historic. To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ SpellCast | ValidCard$ Card.Historic | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | ActivationLimit$ 1 | Execute$ TrigInvestigate | TriggerDescription$ Whenever you cast a historic spell, investigate. This ability triggers only once each turn. (Artifacts, legendaries, and Sagas are historic. To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 K:Doctor's companion
 DeckHas:Ability$Token|Sacrifice & Type$Artifact|Clue
 DeckNeeds:Type$Artifact|Enchantment|Legendary
-Oracle:Whenever you cast a historic spell, investigate. This ability triggers only once each turn. (Artifacts, legendaries, and Sagas are historic. To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")\nDoctor's companion (You can have two commanders if the other is the Doctor.)
+Oracle:Whenever you cast a historic spell, investigate. This ability triggers only once each turn. (Artifacts, legendaries, and Sagas are historic. To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nDoctor's companion (You can have two commanders if the other is the Doctor.)

--- a/forge-gui/res/cardsfolder/s/search_the_premises.txt
+++ b/forge-gui/res/cardsfolder/s/search_the_premises.txt
@@ -1,7 +1,7 @@
 Name:Search the Premises
 ManaCost:3 W
 Types:Enchantment
-T:Mode$ Attacks | ValidCard$ Creature | Attacked$ You,Planeswalker.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigInvestigate | TriggerDescription$ Whenever a creature attacks you or a planeswalker you control, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ Attacks | ValidCard$ Creature | Attacked$ You,Planeswalker.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigInvestigate | TriggerDescription$ Whenever a creature attacks you or a planeswalker you control, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 DeckHas:Ability$Investigate|Token
-Oracle:Whenever a creature attacks you or a planeswalker you control, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Whenever a creature attacks you or a planeswalker you control, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/s/secret_passage.txt
+++ b/forge-gui/res/cardsfolder/s/secret_passage.txt
@@ -4,6 +4,6 @@ Types:Land
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 A:AB$ Mana | Cost$ T | Produced$ Combo U B | SpellDescription$ Add {U} or {B}.
-A:AB$ Investigate | Cost$ 4 T | SpellDescription$ Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:AB$ Investigate | Cost$ 4 T | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 DeckHints:Ability$Investigate|Token
-Oracle:Secret Passage enters tapped.\n{T}: Add {U} or {B}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Secret Passage enters tapped.\n{T}: Add {U} or {B}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/s/secrets_of_the_key.txt
+++ b/forge-gui/res/cardsfolder/s/secrets_of_the_key.txt
@@ -2,7 +2,7 @@ Name:Secrets of the Key
 ManaCost:U
 Types:Instant
 K:Flashback:3 U
-A:SP$ Investigate | Num$ X | SpellDescription$ Investigate. If this spell was cast from a graveyard, investigate twice instead. (To investigate, create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:SP$ Investigate | Num$ X | SpellDescription$ Investigate. If this spell was cast from a graveyard, investigate twice instead. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:X:Count$wasCastFromGraveyard.2.1
 DeckHas:Ability$Investigate|Token
-Oracle:Investigate. If this spell was cast from a graveyard, investigate twice instead. (To investigate, create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")\nFlashback {3}{U}
+Oracle:Investigate. If this spell was cast from a graveyard, investigate twice instead. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nFlashback {3}{U}

--- a/forge-gui/res/cardsfolder/s/serene_sleuth.txt
+++ b/forge-gui/res/cardsfolder/s/serene_sleuth.txt
@@ -2,11 +2,11 @@ Name:Serene Sleuth
 ManaCost:1 W
 Types:Creature Human Detective
 PT:2/2
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 T:Mode$ Phase | Phase$ BeginCombat | ValidPlayer$ You | Execute$ TrigInvestigateEach | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of combat on your turn, investigate for each goaded creature you control. Then each creature you control is no longer goaded.
 SVar:TrigInvestigateEach:DB$ Investigate | Num$ Count$Valid Creature.IsGoaded+YouCtrl | SubAbility$ DBNoGoad
 SVar:DBNoGoad:DB$ Goad | NoLonger$ True | Defined$ Valid Creature.YouCtrl
 DeckHints:Ability$Investigate
 DeckHas:Ability$Investigate|Token|Sacrifice & Type$Artifact|Clue
-Oracle:When Serene Sleuth enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")\nAt the beginning of combat on your turn, investigate for each goaded creature you control. Then each creature you control is no longer goaded.
+Oracle:When Serene Sleuth enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nAt the beginning of combat on your turn, investigate for each goaded creature you control. Then each creature you control is no longer goaded.

--- a/forge-gui/res/cardsfolder/s/sharp_eyed_rookie.txt
+++ b/forge-gui/res/cardsfolder/s/sharp_eyed_rookie.txt
@@ -3,8 +3,8 @@ ManaCost:1 G
 Types:Creature Human Detective
 PT:2/2
 K:Vigilance
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.YouCtrl | Condition$ Evolve | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Whenever a creature you control enters, if its power is greater than CARDNAME's power or its toughness is greater than CARDNAME's toughness, put a +1/+1 counter on CARDNAME and investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.YouCtrl | Condition$ Evolve | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Whenever a creature you control enters, if its power is greater than CARDNAME's power or its toughness is greater than CARDNAME's toughness, put a +1/+1 counter on CARDNAME and investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigPutCounter:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBInvestigate
 SVar:DBInvestigate:DB$ Investigate
 DeckHas:Ability$Counters|Investigate|Token|Sacrifice & Type$Clue|Artifact
-Oracle:Vigilance\nWhenever a creature you control enters, if its power is greater than Sharp-Eyed Rookie's power or its toughness is greater than Sharp-Eyed Rookie's toughness, put a +1/+1 counter on Sharp-Eyed Rookie and investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Vigilance\nWhenever a creature you control enters, if its power is greater than Sharp-Eyed Rookie's power or its toughness is greater than Sharp-Eyed Rookie's toughness, put a +1/+1 counter on Sharp-Eyed Rookie and investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/s/study.txt
+++ b/forge-gui/res/cardsfolder/s/study.txt
@@ -4,6 +4,6 @@ Types:Land
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 A:AB$ Mana | Cost$ T | Produced$ Combo W U | SpellDescription$ Add {W} or {U}.
-A:AB$ Investigate | Cost$ 4 T | SpellDescription$ Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:AB$ Investigate | Cost$ 4 T | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 DeckHints:Ability$Investigate|Token
-Oracle:Study enters tapped.\n{T}: Add {W} or {U}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Study enters tapped.\n{T}: Add {W} or {U}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/s/survive_the_night.txt
+++ b/forge-gui/res/cardsfolder/s/survive_the_night.txt
@@ -1,7 +1,7 @@
 Name:Survive the Night
 ManaCost:2 W
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | NumAtt$ +1 | KW$ Indestructible | SubAbility$ DBInvestigate | SpellDescription$ Target creature gets +1/+0 and gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it.) Investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+A:SP$ Pump | ValidTgts$ Creature | NumAtt$ +1 | KW$ Indestructible | SubAbility$ DBInvestigate | SpellDescription$ Target creature gets +1/+0 and gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it.) Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:DBInvestigate:DB$ Investigate
 DeckHas:Ability$Investigate|Token
-Oracle:Target creature gets +1/+0 and gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it.)\nInvestigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Target creature gets +1/+0 and gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it.)\nInvestigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/s/syndicate_heavy.txt
+++ b/forge-gui/res/cardsfolder/s/syndicate_heavy.txt
@@ -3,8 +3,8 @@ ManaCost:2 WB WB
 Types:Creature Giant Rogue
 PT:4/4
 K:Extort
-T:Mode$ Phase | Phase$ End of Turn | TriggerZones$ Battlefield | CheckSVar$ YouLifeGained | SVarCompare$ GE4 | Execute$ TrigInvestigate | TriggerDescription$ At the beginning of each end step, if you gained 4 or more life this turn, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ Phase | Phase$ End of Turn | TriggerZones$ Battlefield | CheckSVar$ YouLifeGained | SVarCompare$ GE4 | Execute$ TrigInvestigate | TriggerDescription$ At the beginning of each end step, if you gained 4 or more life this turn, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 SVar:YouLifeGained:Count$LifeYouGainedThisTurn
 DeckHas:Ability$Token|Sacrifice
-Oracle:Extort (Whenever you cast a spell, you may pay {W/B}. If you do, each opponent loses 1 life and you gain that much life.)\nAt the beginning of each end step, if you gained 4 or more life this turn, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Extort (Whenever you cast a spell, you may pay {W/B}. If you do, each opponent loses 1 life and you gain that much life.)\nAt the beginning of each end step, if you gained 4 or more life this turn, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/t/tamiyo_inquisitive_student_tamiyo_seasoned_scholar.txt
+++ b/forge-gui/res/cardsfolder/t/tamiyo_inquisitive_student_tamiyo_seasoned_scholar.txt
@@ -3,7 +3,7 @@ ManaCost:U
 Types:Legendary Creature Moonfolk Wizard
 PT:0/3
 K:Flying
-T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME attacks, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME attacks, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 T:Mode$ Drawn | ValidCard$ Card.YouCtrl | Number$ 3 | TriggerZones$ Battlefield | Execute$ TrigTransform | TriggerDescription$ Whenever you draw your third card in a turn, exile NICKNAME, then return her to the battlefield transformed under her owner's control.
 SVar:TrigTransform:DB$ ChangeZone | Origin$ Battlefield | Destination$ Exile | RememberChanged$ True | SubAbility$ DBReturn
@@ -12,7 +12,7 @@ SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 DeckHints:Ability$Investigate
 DeckHas:Ability$Investigate|Token
 AlternateMode:DoubleFaced
-Oracle:Flying\nWhenever Tamiyo, Inquisitive Student attacks, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")\nWhenever you draw your third card in a turn, exile Tamiyo, then return her to the battlefield transformed under her owner's control.
+Oracle:Flying\nWhenever Tamiyo, Inquisitive Student attacks, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nWhenever you draw your third card in a turn, exile Tamiyo, then return her to the battlefield transformed under her owner's control.
 
 ALTERNATE
 

--- a/forge-gui/res/cardsfolder/t/tamiyos_journal.txt
+++ b/forge-gui/res/cardsfolder/t/tamiyos_journal.txt
@@ -1,9 +1,9 @@
 Name:Tamiyo's Journal
 ManaCost:5
 Types:Legendary Artifact Book
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigInvestigate | TriggerDescription$ At the beginning of your upkeep, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigInvestigate | TriggerDescription$ At the beginning of your upkeep, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 A:AB$ ChangeZone | Cost$ T Sac<3/Clue> | Origin$ Library | Destination$ Hand | ChangeType$ Card | ChangeNum$ 1 | Mandatory$ True | SpellDescription$ Search your library for a card, put that card into your hand, then shuffle.
 DeckHints:Ability$Investigate
 DeckHas:Ability$Investigate|Token
-Oracle:At the beginning of your upkeep, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")\n{T}, Sacrifice three Clues: Search your library for a card, put that card into your hand, then shuffle.
+Oracle:At the beginning of your upkeep, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\n{T}, Sacrifice three Clues: Search your library for a card, put that card into your hand, then shuffle.

--- a/forge-gui/res/cardsfolder/t/the_chase_is_on.txt
+++ b/forge-gui/res/cardsfolder/t/the_chase_is_on.txt
@@ -2,6 +2,6 @@ Name:The Chase Is On
 ManaCost:2 R
 Types:Instant
 A:SP$ Pump | ValidTgts$ Creature | KW$ First Strike | NumAtt$ +3 | SubAbility$ DBInvestigate | SpellDescription$ Target creature gets +3/+0 and gains first strike until end of turn.
-SVar:DBInvestigate:DB$ Investigate | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+SVar:DBInvestigate:DB$ Investigate | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 DeckHas:Ability$Token|Investigate & Type$Clue|Artifact
-Oracle:Target creature gets +3/+0 and gains first strike until end of turn. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Target creature gets +3/+0 and gains first strike until end of turn. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/t/the_seventh_doctor.txt
+++ b/forge-gui/res/cardsfolder/t/the_seventh_doctor.txt
@@ -2,7 +2,7 @@ Name:The Seventh Doctor
 ManaCost:3 W U
 Types:Legendary Creature Time Lord Doctor
 PT:3/6
-T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigGuess | TriggerZones$ Battlefield | TriggerDescription$ When CARDNAME attacks, choose a card in your hand. Defending player guesses whether that card's mana value is greater than the number of artifacts you control. If they guessed wrong, you may cast it without paying its mana cost. If you don't cast a spell this way, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigGuess | TriggerZones$ Battlefield | TriggerDescription$ When CARDNAME attacks, choose a card in your hand. Defending player guesses whether that card's mana value is greater than the number of artifacts you control. If they guessed wrong, you may cast it without paying its mana cost. If you don't cast a spell this way, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigGuess:DB$ ChooseCard | ChoiceZone$ Hand | Mandatory$ True | Defined$ You | Choices$ Card.YouOwn | AILogic$ RandomNonLand | Guess$ True | SubAbility$ DBGuess
 SVar:DBGuess:DB$ GenericChoice | Defined$ TriggeredDefendingPlayer | Choices$ GuessGreaterArtifacts,GuessNotGreaterArtifacts | AILogic$ Random | ShowChoice$ True
 SVar:GuessGreaterArtifacts:DB$ Play | Controller$ You | Defined$ ChosenCard | Optional$ True | WithoutManaCost$ True | ConditionDefined$ ChosenCard | ConditionPresent$ Card.cmcLEX+nonLand | RememberPlayed$ True | ConditionCompare$ GE1 | SubAbility$ DBInvestigate | SpellDescription$ The chosen card's mana value is greater the number of artifacts attacking player controls.
@@ -12,4 +12,4 @@ SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearChosenCard$ True
 SVar:X:Count$Valid Artifact.YouCtrl
 SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Token & Type$Clue|Artifact
-Oracle:When The Seventh Doctor attacks, choose a card in your hand. Defending player guesses whether that card's mana value is greater than the number of artifacts you control. If they guessed wrong, you may cast it without paying its mana cost. If you don't cast a spell this way, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:When The Seventh Doctor attacks, choose a card in your hand. Defending player guesses whether that card's mana value is greater than the number of artifacts you control. If they guessed wrong, you may cast it without paying its mana cost. If you don't cast a spell this way, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/t/they_went_this_way.txt
+++ b/forge-gui/res/cardsfolder/t/they_went_this_way.txt
@@ -2,6 +2,6 @@ Name:They Went This Way
 ManaCost:2 G
 Types:Sorcery
 A:SP$ ChangeZone | Origin$ Library | Destination$ Battlefield | ChangeType$ Land.Basic | ChangeTypeDesc$ basic land | Tapped$ True | SubAbility$ DBInvestigate | SpellDescription$ Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.
-SVar:DBInvestigate:DB$ Investigate | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+SVar:DBInvestigate:DB$ Investigate | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 DeckHas:Ability$Investigate|Token|Sacrifice & Type$Artifact|Clue
-Oracle:Search your library for a basic land card, put it onto the battlefield tapped, then shuffle. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Search your library for a basic land card, put it onto the battlefield tapped, then shuffle. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/t/thijarian_witness.txt
+++ b/forge-gui/res/cardsfolder/t/thijarian_witness.txt
@@ -3,8 +3,8 @@ ManaCost:1 G
 Types:Creature Alien Cleric
 PT:0/4
 K:Flash
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.Other+attackingAlone,Creature.Other+blockingAlone | TriggerZones$ Battlefield | Execute$ TrigExile | TriggerDescription$ Whenever another creature dies, if it was attacking or blocking alone, exile it and investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.Other+attackingAlone,Creature.Other+blockingAlone | TriggerZones$ Battlefield | Execute$ TrigExile | TriggerDescription$ Whenever another creature dies, if it was attacking or blocking alone, exile it and investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigExile:DB$ ChangeZone | Defined$ TriggeredNewCardLKICopy | Origin$ Graveyard | Destination$ Exile | SubAbility$ TrigInvestigate
 SVar:TrigInvestigate:DB$ Investigate
 DeckHas:Ability$Investigate|Token|Sacrifice & Type$Clue|Artifact
-Oracle:Flash\nBear Witness — Whenever another creature dies, if it was attacking or blocking alone, exile it and investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Flash\nBear Witness — Whenever another creature dies, if it was attacking or blocking alone, exile it and investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/t/thorough_investigation.txt
+++ b/forge-gui/res/cardsfolder/t/thorough_investigation.txt
@@ -6,4 +6,4 @@ SVar:TrigInvestigate:DB$ Investigate
 T:Mode$ Sacrificed | ValidCard$ Clue.YouCtrl | Execute$ TrigVenture | TriggerZones$ Battlefield | TriggerDescription$ Whenever you sacrifice a Clue, venture into the dungeon.
 SVar:TrigVenture:DB$ Venture
 DeckHas:Ability$Investigate|Token
-Oracle:Whenever you attack, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")\nWhenever you sacrifice a Clue, venture into the dungeon. (Enter the first room or advance to the next room.)
+Oracle:Whenever you attack, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nWhenever you sacrifice a Clue, venture into the dungeon. (Enter the first room or advance to the next room.)

--- a/forge-gui/res/cardsfolder/t/thraben_inspector.txt
+++ b/forge-gui/res/cardsfolder/t/thraben_inspector.txt
@@ -2,7 +2,7 @@ Name:Thraben Inspector
 ManaCost:W
 Types:Creature Human Soldier
 PT:1/2
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 DeckHas:Ability$Investigate|Token
-Oracle:When Thraben Inspector enters, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:When Thraben Inspector enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/t/tireless_tracker.txt
+++ b/forge-gui/res/cardsfolder/t/tireless_tracker.txt
@@ -2,10 +2,10 @@ Name:Tireless Tracker
 ManaCost:2 G
 Types:Creature Human Scout
 PT:3/2
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigInvestigate | TriggerDescription$ Landfall — Whenever a land you control enters, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Land.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigInvestigate | TriggerDescription$ Landfall — Whenever a land you control enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 T:Mode$ Sacrificed | ValidCard$ Clue.YouCtrl | Execute$ TrigPutCounter | TriggerZones$ Battlefield | TriggerDescription$ Whenever you sacrifice a Clue, put a +1/+1 counter on CARDNAME.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
 DeckHints:Ability$Investigate
 DeckHas:Ability$Investigate|Token|Counters
-Oracle:Landfall — Whenever a land you control enters, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")\nWhenever you sacrifice a Clue, put a +1/+1 counter on Tireless Tracker.
+Oracle:Landfall — Whenever a land you control enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nWhenever you sacrifice a Clue, put a +1/+1 counter on Tireless Tracker.

--- a/forge-gui/res/cardsfolder/t/torch_the_witness.txt
+++ b/forge-gui/res/cardsfolder/t/torch_the_witness.txt
@@ -2,8 +2,8 @@ Name:Torch the Witness
 ManaCost:X R
 Types:Sorcery
 A:SP$ DealDamage | ValidTgts$ Creature | NumDmg$ Y | ExcessSVar$ Excess | ExcessSVarCondition$ Card.targetedBy | SubAbility$ DBInvestigate | SpellDescription$ CARDNAME deals twice X damage to target creature.
-SVar:DBInvestigate:DB$ Investigate | Num$ 1 | ConditionCheckSVar$ Excess | SpellDescription$ If excess damage was dealt to that creature this way, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+SVar:DBInvestigate:DB$ Investigate | Num$ 1 | ConditionCheckSVar$ Excess | SpellDescription$ If excess damage was dealt to that creature this way, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:X:Count$xPaid
 SVar:Y:SVar$X/Twice
 DeckHas:Type$Clue|Artifact & Ability$Token
-Oracle:Torch the Witness deals twice X damage to target creature. If excess damage was dealt to that creature this way, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Torch the Witness deals twice X damage to target creature. If excess damage was dealt to that creature this way, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/t/toxin_analysis.txt
+++ b/forge-gui/res/cardsfolder/t/toxin_analysis.txt
@@ -2,6 +2,6 @@ Name:Toxin Analysis
 ManaCost:B
 Types:Instant
 A:SP$ Pump | ValidTgts$ Creature | KW$ Deathtouch & Lifelink | SubAbility$ DBInvestigate | SpellDescription$ Target creature gains deathtouch and lifelink until end of turn.
-SVar:DBInvestigate:DB$ Investigate | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+SVar:DBInvestigate:DB$ Investigate | SpellDescription$ Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 DeckHas:Ability$Token|Investigate|LifeGain & Type$Clue|Artifact
-Oracle:Target creature gains deathtouch and lifelink until end of turn. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Target creature gains deathtouch and lifelink until end of turn. Investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/t/trail_of_evidence.txt
+++ b/forge-gui/res/cardsfolder/t/trail_of_evidence.txt
@@ -1,8 +1,8 @@
 Name:Trail of Evidence
 ManaCost:2 U
 Types:Enchantment
-T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | Execute$ DBInvestigate | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast an instant or sorcery spell, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | Execute$ DBInvestigate | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast an instant or sorcery spell, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:DBInvestigate:DB$ Investigate
 DeckHas:Ability$Investigate|Token
 DeckNeeds:Type$Instant|Sorcery
-Oracle:Whenever you cast an instant or sorcery spell, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Whenever you cast an instant or sorcery spell, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/u/ulvenwald_mysteries.txt
+++ b/forge-gui/res/cardsfolder/u/ulvenwald_mysteries.txt
@@ -1,10 +1,10 @@
 Name:Ulvenwald Mysteries
 ManaCost:2 G
 Types:Enchantment
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.YouCtrl+!token | TriggerZones$ Battlefield | Execute$ TrigInvestigate | TriggerDescription$ Whenever a nontoken creature you control dies, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.YouCtrl+!token | TriggerZones$ Battlefield | Execute$ TrigInvestigate | TriggerDescription$ Whenever a nontoken creature you control dies, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 T:Mode$ Sacrificed | ValidCard$ Clue.YouCtrl | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever you sacrifice a Clue, create a 1/1 white Human Soldier creature token.
 SVar:TrigToken:DB$ Token | TokenScript$ w_1_1_human_soldier | TokenOwner$ You
 DeckHints:Ability$Investigate
 DeckHas:Ability$Investigate|Token
-Oracle:Whenever a nontoken creature you control dies, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")\nWhenever you sacrifice a Clue, create a 1/1 white Human Soldier creature token.
+Oracle:Whenever a nontoken creature you control dies, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nWhenever you sacrifice a Clue, create a 1/1 white Human Soldier creature token.

--- a/forge-gui/res/cardsfolder/u/undercover_crocodelf.txt
+++ b/forge-gui/res/cardsfolder/u/undercover_crocodelf.txt
@@ -2,8 +2,8 @@ Name:Undercover Crocodelf
 ManaCost:4 G U
 Types:Creature Elf Crocodile Detective
 PT:5/5
-T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigInvestigate | CombatDamage$ True | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigInvestigate | CombatDamage$ True | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate | Num$ 1
 K:Disguise:3 GU GU
 DeckHas:Type$Clue|Artifact & Ability$Token
-Oracle:Whenever Undercover Crocodelf deals combat damage to a player, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")\nDisguise {3}{G/U}{G/U} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)
+Oracle:Whenever Undercover Crocodelf deals combat damage to a player, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nDisguise {3}{G/U}{G/U} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)

--- a/forge-gui/res/cardsfolder/u/unshakable_tail.txt
+++ b/forge-gui/res/cardsfolder/u/unshakable_tail.txt
@@ -5,9 +5,9 @@ PT:3/2
 T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigSurveil | TriggerDescription$ When CARDNAME enters and at the beginning of your upkeep, surveil 1.
 T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigSurveil | Secondary$ True | TriggerDescription$ When CARDNAME enters and at the beginning of your upkeep, surveil 1.
 SVar:TrigSurveil:DB$ Surveil | Amount$ 1
-T:Mode$ ChangesZoneAll | ValidCards$ Creature.YouOwn | Origin$ Library | Destination$ Graveyard | TriggerZones$ Battlefield | Execute$ TrigInvestigate | TriggerDescription$ Whenever one or more creature cards are put into your graveyard from your library, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZoneAll | ValidCards$ Creature.YouOwn | Origin$ Library | Destination$ Graveyard | TriggerZones$ Battlefield | Execute$ TrigInvestigate | TriggerDescription$ Whenever one or more creature cards are put into your graveyard from your library, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 A:AB$ ChangeZone | Cost$ 2 Sac<1/Clue> | Origin$ Graveyard | Destination$ Hand | ActivationZone$ Graveyard | SpellDescription$ Return CARDNAME from your graveyard to your hand.
 DeckHas:Ability$Sacrifice|Graveyard|Token|Surveil & Type$Clue|Artifact
 DeckHints:Ability$Graveyard & Type$Clue
-Oracle:When Unshakable Tail enters and at the beginning of your upkeep, surveil 1.\nWhenever one or more creature cards are put into your graveyard from your library, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")\n{2}, Sacrifice a Clue: Return Unshakable Tail from your graveyard to your hand.
+Oracle:When Unshakable Tail enters and at the beginning of your upkeep, surveil 1.\nWhenever one or more creature cards are put into your graveyard from your library, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\n{2}, Sacrifice a Clue: Return Unshakable Tail from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/w/wavesifter.txt
+++ b/forge-gui/res/cardsfolder/w/wavesifter.txt
@@ -4,7 +4,7 @@ Types:Creature Elemental
 PT:3/2
 K:Flying
 K:Evoke:G U
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate twice. (To investigate, create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate twice. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate | Num$ 2
 DeckHas:Ability$Token
-Oracle:Flying\nWhen Wavesifter enters, investigate twice. (To investigate, create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")\nEvoke {G}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters.)
+Oracle:Flying\nWhen Wavesifter enters, investigate twice. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nEvoke {G}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters.)

--- a/forge-gui/res/cardsfolder/w/weirding_wood.txt
+++ b/forge-gui/res/cardsfolder/w/weirding_wood.txt
@@ -3,9 +3,9 @@ ManaCost:2 G
 Types:Enchantment Aura
 K:Enchant:Land
 SVar:AttachAILogic:Pump
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigInvestigate | TriggerDescription$ When CARDNAME enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate
 S:Mode$ Continuous | Affected$ Card.EnchantedBy | AddAbility$ WeirdingWoodTap | Description$ Enchanted land has "{T}: Add two mana of any one color."
 SVar:WeirdingWoodTap:AB$ Mana | Cost$ T | Produced$ Any | Amount$ 2 | SpellDescription$ Add two mana of any one color.
 DeckHas:Ability$Investigate|Token
-Oracle:Enchant land\nWhen Weirding Wood enters, investigate. (Create a colorless Clue artifact token with "{2}, Sacrifice this artifact: Draw a card.")\nEnchanted land has "{T}: Add two mana of any one color."
+Oracle:Enchant land\nWhen Weirding Wood enters, investigate. (Create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")\nEnchanted land has "{T}: Add two mana of any one color."

--- a/forge-gui/res/cardsfolder/w/wojek_investigator.txt
+++ b/forge-gui/res/cardsfolder/w/wojek_investigator.txt
@@ -4,9 +4,9 @@ Types:Creature Angel Detective
 PT:2/4
 K:Flying
 K:Vigilance
-T:Mode$ Phase | Phase$ Upkeep | TriggerZones$ Battlefield | Execute$ TrigInvestigate | ValidPlayer$ You | TriggerDescription$ At the beginning of your upkeep, investigate once for each opponent who has more cards in hand than you. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+T:Mode$ Phase | Phase$ Upkeep | TriggerZones$ Battlefield | Execute$ TrigInvestigate | ValidPlayer$ You | TriggerDescription$ At the beginning of your upkeep, investigate once for each opponent who has more cards in hand than you. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")
 SVar:TrigInvestigate:DB$ Investigate | Num$ X
 SVar:X:PlayerCountOpponents$HasPropertyHasCardsInHand_Card_GTY
 SVar:Y:Count$CardsInYourHand
 DeckHas:Ability$Token & Type$Clue|Artifact
-Oracle:Flying, vigilance\nAt the beginning of your upkeep, investigate once for each opponent who has more cards in hand than you. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this artifact: Draw a card.")
+Oracle:Flying, vigilance\nAt the beginning of your upkeep, investigate once for each opponent who has more cards in hand than you. (To investigate, create a Clue token. It's an artifact with "{2}, Sacrifice this token: Draw a card.")


### PR DESCRIPTION
Following up on https://github.com/Card-Forge/forge/pull/11086
Bringing disparate versions of the investigate reminder text in line, one just needing the 'artifact' → 'token' update to the Clue activated ability (like [Auspicious Arrival](https://gatherer.wizards.com/MKM/en-us/5/auspicious-arrival) ), others being older template versions for the ability (like [Armed with Proof](https://gatherer.wizards.com/MKC/en-us/9/armed-with-proof)). Notably the lack of 'They' on the reminder text for [Fateful Absence](https://gatherer.wizards.com/MID/en-us/18/fateful-absence) seems like an editorial oversight.