### PR TITLE
Card cleanup: 2026-06-28 [Reminder text: Blood token]

### DIFF
--- a/forge-gui/res/cardsfolder/a/anje_maid_of_dishonor.txt
+++ b/forge-gui/res/cardsfolder/a/anje_maid_of_dishonor.txt
@@ -2,10 +2,10 @@ Name:Anje, Maid of Dishonor
 ManaCost:2 B R
 Types:Legendary Creature Vampire
 PT:4/5
-T:Mode$ ChangesZoneAll | ValidCards$ Vampire.YouCtrl | Destination$ Battlefield | TriggerZones$ Battlefield | ActivationLimit$ 1 | Execute$ TrigToken | TriggerDescription$ Whenever CARDNAME and/or one or more other Vampires you control enter, create a Blood token. This ability triggers only once per turn. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZoneAll | ValidCards$ Vampire.YouCtrl | Destination$ Battlefield | TriggerZones$ Battlefield | ActivationLimit$ 1 | Execute$ TrigToken | TriggerDescription$ Whenever CARDNAME and/or one or more other Vampires you control enter, create a Blood token. This ability triggers only once per turn. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:TrigToken:DB$ Token | TokenScript$ c_a_blood_draw
 A:AB$ LoseLife | Cost$ 2 Sac<1/Creature.Other;Blood.token/another creature or a Blood token> | Defined$ Player.Opponent | LifeAmount$ 2 | SubAbility$ DBGainLife | SpellDescription$ Each opponent loses 2 life and you gain 2 life.
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 2
 DeckHas:Ability$Token|Sacrifice|LifeGain & Type$Blood
 DeckHints:Type$Vampire
-Oracle:Whenever Anje, Maid of Dishonor and/or one or more other Vampires you control enter, create a Blood token. This ability triggers only once per turn. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")\n{2}, Sacrifice another creature or a Blood token: Each opponent loses 2 life and you gain 2 life.
+Oracle:Whenever Anje, Maid of Dishonor and/or one or more other Vampires you control enter, create a Blood token. This ability triggers only once per turn. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")\n{2}, Sacrifice another creature or a Blood token: Each opponent loses 2 life and you gain 2 life.

--- a/forge-gui/res/cardsfolder/a/arterial_alchemy.txt
+++ b/forge-gui/res/cardsfolder/a/arterial_alchemy.txt
@@ -1,11 +1,11 @@
 Name:Arterial Alchemy
 ManaCost:2 R
 Types:Enchantment
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a Blood token for each opponent you have. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a Blood token for each opponent you have. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ c_a_blood_draw
 SVar:X:PlayerCountOpponents$Amount
 S:Mode$ Continuous | Affected$ Blood.token+YouCtrl | AddType$ Equipment | AddStaticAbility$ BloodEquip | AddKeyword$ Equip:2 | Description$ Blood tokens you control are Equipment in addition to their other types and have "Equipped creature gets +2/+0" and equip {2}.
 SVar:BloodEquip:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 2 | Description$ Equipped creature gets +2/+0.
 DeckHas:Ability$Token|Sacrifice & Type$Blood|Equipment
 DeckHints:Type$Blood
-Oracle:When Arterial Alchemy enters, create a Blood token for each opponent you have. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")\nBlood tokens you control are Equipment in addition to their other types and have "Equipped creature gets +2/+0" and equip {2}.
+Oracle:When Arterial Alchemy enters, create a Blood token for each opponent you have. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")\nBlood tokens you control are Equipment in addition to their other types and have "Equipped creature gets +2/+0" and equip {2}.

--- a/forge-gui/res/cardsfolder/b/belligerent_guest.txt
+++ b/forge-gui/res/cardsfolder/b/belligerent_guest.txt
@@ -3,7 +3,7 @@ ManaCost:2 R
 Types:Creature Vampire
 PT:3/2
 K:Trample
-T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigToken | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigToken | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:TrigToken:DB$ Token | TokenScript$ c_a_blood_draw
 DeckHas:Ability$Token|Sacrifice & Type$Blood
-Oracle:Trample\nWhenever Belligerent Guest deals combat damage to a player, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+Oracle:Trample\nWhenever Belligerent Guest deals combat damage to a player, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/b/blood_fountain.txt
+++ b/forge-gui/res/cardsfolder/b/blood_fountain.txt
@@ -1,8 +1,8 @@
 Name:Blood Fountain
 ManaCost:B
 Types:Artifact
-T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ DBToken | TriggerDescription$ When CARDNAME enters, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ DBToken | TriggerDescription$ When CARDNAME enters, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:DBToken:DB$ Token | TokenScript$ c_a_blood_draw
 A:AB$ ChangeZone | Cost$ 3 B T Sac<1/CARDNAME> | Origin$ Graveyard | Destination$ Hand | TargetMin$ 0 | TargetMax$ 2 | TgtPrompt$ Select up to two target creature cards in your graveyard | ValidTgts$ Creature.YouOwn | SpellDescription$ Return up to two target creature cards from your graveyard to your hand.
 DeckHas:Ability$Token|Sacrifice|Graveyard & Type$Blood
-Oracle:When Blood Fountain enters, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")\n{3}{B}, {T}, Sacrifice Blood Fountain: Return up to two target creature cards from your graveyard to your hand.
+Oracle:When Blood Fountain enters, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")\n{3}{B}, {T}, Sacrifice Blood Fountain: Return up to two target creature cards from your graveyard to your hand.

--- a/forge-gui/res/cardsfolder/b/blood_petal_celebrant.txt
+++ b/forge-gui/res/cardsfolder/b/blood_petal_celebrant.txt
@@ -3,7 +3,7 @@ ManaCost:1 R
 Types:Creature Vampire
 PT:2/1
 S:Mode$ Continuous | Affected$ Card.Self+attacking | AddKeyword$ First Strike | Description$ CARDNAME has first strike as long as it's attacking.
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME dies, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME dies, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:TrigToken:DB$ Token | TokenScript$ c_a_blood_draw | TokenOwner$ You
 DeckHas:Ability$Token|Sacrifice & Type$Blood
-Oracle:Blood Petal Celebrant has first strike as long as it's attacking.\nWhen Blood Petal Celebrant dies, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+Oracle:Blood Petal Celebrant has first strike as long as it's attacking.\nWhen Blood Petal Celebrant dies, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/b/blood_servitor.txt
+++ b/forge-gui/res/cardsfolder/b/blood_servitor.txt
@@ -2,7 +2,7 @@ Name:Blood Servitor
 ManaCost:3
 Types:Artifact Creature Construct
 PT:2/2
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigBlood | TriggerDescription$ When CARDNAME enters, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigBlood | TriggerDescription$ When CARDNAME enters, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:TrigBlood:DB$ Token | TokenScript$ c_a_blood_draw | TokenOwner$ You
 DeckHas:Ability$Token|Sacrifice & Type$Blood
-Oracle:When Blood Servitor enters, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+Oracle:When Blood Servitor enters, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/b/bloodcrazed_socialite.txt
+++ b/forge-gui/res/cardsfolder/b/bloodcrazed_socialite.txt
@@ -3,11 +3,11 @@ ManaCost:3 B
 Types:Creature Vampire
 PT:3/3
 K:Menace
-T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ DBToken | TriggerDescription$ When CARDNAME enters, create a Blood token.
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ DBToken | TriggerDescription$ When CARDNAME enters, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:DBToken:DB$ Token | TokenScript$ c_a_blood_draw
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, you may sacrifice a Blood token. If you do, it gets +2/+2 until end of turn.
 SVar:TrigPump:AB$ Pump | Cost$ Sac<1/Blood.token/Blood token> | Defined$ Self | NumAtt$ +2 | NumDef$ +2 | SpellDescription$ CARDNAME gets +2/+2 until end of turn.
 SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Token|Sacrifice & Type$Blood
 DeckHints:Type$Blood
-Oracle:Menace\nWhen Bloodcrazed Socialite enters, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")\nWhenever Bloodcrazed Socialite attacks, you may sacrifice a Blood token. If you do, it gets +2/+2 until end of turn.
+Oracle:Menace\nWhen Bloodcrazed Socialite enters, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")\nWhenever Bloodcrazed Socialite attacks, you may sacrifice a Blood token. If you do, it gets +2/+2 until end of turn.

--- a/forge-gui/res/cardsfolder/b/bloodsplatter_vampire.txt
+++ b/forge-gui/res/cardsfolder/b/bloodsplatter_vampire.txt
@@ -3,6 +3,6 @@ ManaCost:1 B
 Types:Creature Vampire
 PT:2/1
 K:Flying
-R:Event$ CreateToken | ActiveZones$ Battlefield | ValidPlayer$ Opponent | ValidToken$ Clue | ReplaceWith$ TokenReplace | Description$ If an opponent would create a Clue, they create a Blood instead.
+R:Event$ CreateToken | ActiveZones$ Battlefield | ValidPlayer$ Opponent | ValidToken$ Clue | ReplaceWith$ TokenReplace | Description$ If an opponent would create a Clue token, they create a Blood token instead. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:TokenReplace:DB$ ReplaceToken | Type$ ReplaceToken | TokenScript$ c_a_blood_draw
-Oracle:Flying\nIf an opponent would create a Clue, they create a Blood instead. (It's an artifact with {1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.)
+Oracle:Flying\nIf an opponent would create a Clue, they create a Blood instead. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/b/bloodtithe_harvester.txt
+++ b/forge-gui/res/cardsfolder/b/bloodtithe_harvester.txt
@@ -2,9 +2,9 @@ Name:Bloodtithe Harvester
 ManaCost:B R
 Types:Creature Vampire
 PT:3/2
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:TrigToken:DB$ Token | TokenScript$ c_a_blood_draw
 A:AB$ Pump | Cost$ T Sac<1/CARDNAME> | ValidTgts$ Creature | NumAtt$ -X | NumDef$ -X | SorcerySpeed$ True | AILogic$ Curse | SpellDescription$ Target creature gets -X/-X until end of turn, where X is twice the number of Blood tokens you control. Activate only as a sorcery.
 SVar:X:Count$Valid Blood.token+YouCtrl/Twice
 DeckHas:Ability$Token|Sacrifice & Type$Blood
-Oracle:When Bloodtithe Harvester enters, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")\n{T}, Sacrifice Bloodtithe Harvester: Target creature gets -X/-X until end of turn, where X is twice the number of Blood tokens you control. Activate only as a sorcery.
+Oracle:When Bloodtithe Harvester enters, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")\n{T}, Sacrifice Bloodtithe Harvester: Target creature gets -X/-X until end of turn, where X is twice the number of Blood tokens you control. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/b/bloodvial_purveyor.txt
+++ b/forge-gui/res/cardsfolder/b/bloodvial_purveyor.txt
@@ -4,10 +4,10 @@ Types:Creature Vampire
 PT:5/6
 K:Flying
 K:Trample
-T:Mode$ SpellCast | ValidActivatingPlayer$ Opponent | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever an opponent casts a spell, that player creates a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+T:Mode$ SpellCast | ValidActivatingPlayer$ Opponent | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever an opponent casts a spell, that player creates a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:TrigToken:DB$ Token | TokenScript$ c_a_blood_draw | TokenOwner$ TriggeredActivator
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ Whenever CARDNAME attacks, it gets +1/+0 until end of turn for each Blood token defending player controls.
 SVar:TrigPump:DB$ Pump | Defined$ Self | NumAtt$ +X
 SVar:X:Count$Valid Blood.token+DefenderCtrl
 SVar:HasAttackEffect:TRUE
-Oracle:Flying, trample\nWhenever an opponent casts a spell, that player creates a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")\nWhenever Bloodvial Purveyor attacks, it gets +1/+0 until end of turn for each Blood token defending player controls.
+Oracle:Flying, trample\nWhenever an opponent casts a spell, that player creates a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")\nWhenever Bloodvial Purveyor attacks, it gets +1/+0 until end of turn for each Blood token defending player controls.

--- a/forge-gui/res/cardsfolder/b/bloody_betrayal.txt
+++ b/forge-gui/res/cardsfolder/b/bloody_betrayal.txt
@@ -2,6 +2,6 @@ Name:Bloody Betrayal
 ManaCost:2 R
 Types:Sorcery
 A:SP$ GainControl | ValidTgts$ Creature | Untap$ True | AddKWs$ Haste | LoseControl$ EOT | SubAbility$ DBToken | SpellDescription$ Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.
-SVar:DBToken:DB$ Token | TokenScript$ c_a_blood_draw | SpellDescription$ Create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+SVar:DBToken:DB$ Token | TokenScript$ c_a_blood_draw | SpellDescription$ Create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 DeckHas:Ability$Token|Sacrifice & Type$Blood
-Oracle:Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+Oracle:Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/c/ceremonial_knife.txt
+++ b/forge-gui/res/cardsfolder/c/ceremonial_knife.txt
@@ -1,9 +1,9 @@
 Name:Ceremonial Knife
 ManaCost:1
 Types:Artifact Equipment
-S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 1 | AddTrigger$ TrigDamageDone | Description$ Equipped creature gets +1/+0 and has "Whenever this creature deals combat damage, create a Blood token." (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
-SVar:TrigDamageDone:Mode$ DamageDealtOnce | CombatDamage$ True | ValidSource$ Card.Self | Execute$ TrigBlood | TriggerDescription$ Whenever this creature deals combat damage, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 1 | AddTrigger$ TrigDamageDone | Description$ Equipped creature gets +1/+0 and has "Whenever this creature deals combat damage, create a Blood token." (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
+SVar:TrigDamageDone:Mode$ DamageDealtOnce | CombatDamage$ True | ValidSource$ Card.Self | Execute$ TrigBlood | TriggerDescription$ Whenever this creature deals combat damage, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:TrigBlood:DB$ Token | TokenScript$ c_a_blood_draw | TokenOwner$ You
 K:Equip:2
 DeckHas:Ability$Token|Sacrifice & Type$Blood
-Oracle:Equipped creature gets +1/+0 and has "Whenever this creature deals combat damage, create a Blood token." (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")\nEquip {2}
+Oracle:Equipped creature gets +1/+0 and has "Whenever this creature deals combat damage, create a Blood token." (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")\nEquip {2}

--- a/forge-gui/res/cardsfolder/e/exsanguinator_cavalry.txt
+++ b/forge-gui/res/cardsfolder/e/exsanguinator_cavalry.txt
@@ -4,9 +4,9 @@ Types:Creature Vampire Knight
 PT:2/3
 K:Menace
 K:Lifelink
-T:Mode$ DamageDone | ValidSource$ Knight.YouCtrl | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigPutCounter | TriggerZones$ Battlefield | TriggerDescription$ Whenever a Knight you control deals combat damage to a player, put a +1/+1 counter on that creature and create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+T:Mode$ DamageDone | ValidSource$ Knight.YouCtrl | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigPutCounter | TriggerZones$ Battlefield | TriggerDescription$ Whenever a Knight you control deals combat damage to a player, put a +1/+1 counter on that creature and create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ TriggeredSourceLKICopy | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBToken
 SVar:DBToken:DB$ Token | TokenScript$ c_a_blood_draw
 DeckHas:Ability$LifeGain|Token|Counters & Type$Blood|Artifact
 DeckHints:Type$Knight
-Oracle:Menace, lifelink\nWhenever a Knight you control deals combat damage to a player, put a +1/+1 counter on that creature and create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+Oracle:Menace, lifelink\nWhenever a Knight you control deals combat damage to a player, put a +1/+1 counter on that creature and create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/f/falkenrath_celebrants.txt
+++ b/forge-gui/res/cardsfolder/f/falkenrath_celebrants.txt
@@ -3,7 +3,7 @@ ManaCost:4 R
 Types:Creature Vampire
 PT:4/4
 K:Menace
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create two Blood tokens. (They're artifacts with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create two Blood tokens. (They're artifacts with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:TrigToken:DB$ Token | TokenAmount$ 2 | TokenScript$ c_a_blood_draw
 DeckHas:Ability$Token|Sacrifice & Type$Blood
-Oracle:Menace (This creature can't be blocked except by two or more creatures.)\nWhen Falkenrath Celebrants enters, create two Blood tokens. (They're artifacts with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+Oracle:Menace (This creature can't be blocked except by two or more creatures.)\nWhen Falkenrath Celebrants enters, create two Blood tokens. (They're artifacts with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/g/glass_cast_heart.txt
+++ b/forge-gui/res/cardsfolder/g/glass_cast_heart.txt
@@ -1,11 +1,11 @@
 Name:Glass-Cast Heart
 ManaCost:2 B
 Types:Artifact
-T:Mode$ AttackersDeclared | ValidAttackers$ Vampire.YouCtrl | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever one or more Vampires you control attack, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+T:Mode$ AttackersDeclared | ValidAttackers$ Vampire.YouCtrl | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever one or more Vampires you control attack, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:TrigToken:DB$ Token | TokenScript$ c_a_blood_draw
 A:AB$ Token | Cost$ B T PayLife<1> | TokenScript$ wb_1_1_vampire_lifelink | StackDescription$ SpellDescription | SpellDescription$ Create a 1/1 white and black Vampire creature token with lifelink.
-A:AB$ LoseLife | Cost$ B B T Sac<1/CARDNAME> Sac<13/Blood.token/Blood token> | CostDesc$ {B}{B}, {T}, Sacrifice CARDNAME and thirteen Blood tokens: | Defined$ Player.Opponent | LifeAmount$ 13 | SubAbility$ DBGainLife | SpellDescription$ Each opponent loses 13 life and you gain 13 life.
+A:AB$ LoseLife | Cost$ B B T Sac<1/CARDNAME> Sac<13/Blood.token> | CostDesc$ {B}{B}, {T}, Sacrifice CARDNAME and thirteen Blood tokens: | Defined$ Player.Opponent | LifeAmount$ 13 | SubAbility$ DBGainLife | SpellDescription$ Each opponent loses 13 life and you gain 13 life.
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 13
 DeckHints:Type$Vampire
 DeckHas:Ability$Token|Sacrifice|LifeGain & Type$Blood|Vampire
-Oracle:Whenever one or more Vampires you control attack, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")\n{B}, {T}, Pay 1 life: Create a 1/1 white and black Vampire creature token with lifelink.\n{B}{B}, {T}, Sacrifice Glass-Cast Heart and thirteen Blood tokens: Each opponent loses 13 life and you gain 13 life.
+Oracle:Whenever one or more Vampires you control attack, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")\n{B}, {T}, Pay 1 life: Create a 1/1 white and black Vampire creature token with lifelink.\n{B}{B}, {T}, Sacrifice Glass-Cast Heart and thirteen Blood tokens: Each opponent loses 13 life and you gain 13 life.

--- a/forge-gui/res/cardsfolder/g/gluttonous_guest.txt
+++ b/forge-gui/res/cardsfolder/g/gluttonous_guest.txt
@@ -2,9 +2,9 @@ Name:Gluttonous Guest
 ManaCost:2 B
 Types:Creature Vampire
 PT:1/4
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:TrigToken:DB$ Token | TokenScript$ c_a_blood_draw
 T:Mode$ Sacrificed | ValidCard$ Blood.token+YouCtrl | Execute$ TrigGainLife | TriggerZones$ Battlefield | TriggerDescription$ Whenever you sacrifice a Blood token, you gain 1 life.
 SVar:TrigGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1
 DeckHas:Ability$Token|Sacrifice|LifeGain & Type$Blood
-Oracle:When Gluttonous Guest enters, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")\nWhenever you sacrifice a Blood token, you gain 1 life.
+Oracle:When Gluttonous Guest enters, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")\nWhenever you sacrifice a Blood token, you gain 1 life.

--- a/forge-gui/res/cardsfolder/g/grisly_ritual.txt
+++ b/forge-gui/res/cardsfolder/g/grisly_ritual.txt
@@ -2,6 +2,6 @@ Name:Grisly Ritual
 ManaCost:5 B
 Types:Sorcery
 A:SP$ Destroy | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | SubAbility$ DBToken | SpellDescription$ Destroy target creature or planeswalker.
-SVar:DBToken:DB$ Token | TokenAmount$ 2 | TokenScript$ c_a_blood_draw | SpellDescription$ Create two Blood tokens. (They're artifacts with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+SVar:DBToken:DB$ Token | TokenAmount$ 2 | TokenScript$ c_a_blood_draw | SpellDescription$ Create two Blood tokens. (They're artifacts with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 DeckHas:Ability$Token|Sacrifice & Type$Blood
-Oracle:Destroy target creature or planeswalker. Create two Blood tokens. (They're artifacts with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+Oracle:Destroy target creature or planeswalker. Create two Blood tokens. (They're artifacts with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/i/ivora_insatiable_heir.txt
+++ b/forge-gui/res/cardsfolder/i/ivora_insatiable_heir.txt
@@ -3,10 +3,10 @@ ManaCost:1 R
 Types:Legendary Creature Vampire Warrior
 PT:1/1
 K:Trample
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters and whenever it deals combat damage to a player, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, sacrifice this artifact: Draw a card.")
-T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigToken | CombatDamage$ True | Secondary$ True | TriggerDescription$ When CARDNAME enters and whenever it deals combat damage to a player, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters and whenever it deals combat damage to a player, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigToken | CombatDamage$ True | Secondary$ True | TriggerDescription$ When CARDNAME enters and whenever it deals combat damage to a player, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:TrigToken:DB$ Token | TokenScript$ c_a_blood_draw
 T:Mode$ Discarded | ValidCard$ Card.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Whenever you discard a card, put a +1/+1 counter on NICKNAME.
 DeckHas:Ability$Counters
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1
-Oracle:Trample\nWhen Ivora, Insatiable Heir enters and whenever it deals combat damage to a player, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, sacrifice this artifact: Draw a card.")\nWhenever you discard a card, put a +1/+1 counter on Ivora.
+Oracle:Trample\nWhen Ivora, Insatiable Heir enters and whenever it deals combat damage to a player, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")\nWhenever you discard a card, put a +1/+1 counter on Ivora.

--- a/forge-gui/res/cardsfolder/k/kamber_the_plunderer.txt
+++ b/forge-gui/res/cardsfolder/k/kamber_the_plunderer.txt
@@ -4,10 +4,10 @@ Types:Legendary Creature Vampire Rogue
 PT:3/4
 K:Partner with:Laurine, the Diversion
 K:Lifelink
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.OppCtrl | TriggerZones$ Battlefield | Execute$ TrigGainLife | TriggerDescription$ Whenever a creature an opponent controls dies, you gain 1 life and create a Blood token.
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.OppCtrl | TriggerZones$ Battlefield | Execute$ TrigGainLife | TriggerDescription$ Whenever a creature an opponent controls dies, you gain 1 life and create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:TrigGainLife:DB$ GainLife | LifeAmount$ 1 | SubAbility$ DBToken
 SVar:DBToken:DB$ Token | TokenScript$ c_a_blood_draw | TokenOwner$ You
 SVar:PlayMain1:TRUE
 DeckHints:Name$Laurine, the Diversion
 DeckHas:Ability$Token|Sacrifice|LifeGain & Type$Blood
-Oracle:Partner with Laurine, the Diversion (When this creature enters, target player may put Laurine into their hand from their library, then shuffle.)\nLifelink\nWhenever a creature an opponent controls dies, you gain 1 life and create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+Oracle:Partner with Laurine, the Diversion (When this creature enters, target player may put Laurine into their hand from their library, then shuffle.)\nLifelink\nWhenever a creature an opponent controls dies, you gain 1 life and create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/l/lacerate_flesh.txt
+++ b/forge-gui/res/cardsfolder/l/lacerate_flesh.txt
@@ -2,6 +2,6 @@ Name:Lacerate Flesh
 ManaCost:4 R
 Types:Sorcery
 A:SP$ DealDamage | ValidTgts$ Creature | NumDmg$ 4 | ExcessSVar$ X | ExcessSVarCondition$ Card.targetedBy | SubAbility$ DBToken | SpellDescription$ CARDNAME deals 4 damage to target creature.
-SVar:DBToken:DB$ Token | TokenScript$ c_a_blood_draw | TokenAmount$ X | SpellDescription$ Create a number of Blood tokens equal to the amount of excess damage dealt to that creature this way. (They're artifacts with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+SVar:DBToken:DB$ Token | TokenScript$ c_a_blood_draw | TokenAmount$ X | SpellDescription$ Create a number of Blood tokens equal to the amount of excess damage dealt to that creature this way. (They're artifacts with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 DeckHas:Ability$Token|Sacrifice & Type$Blood
-Oracle:Lacerate Flesh deals 4 damage to target creature. Create a number of Blood tokens equal to the amount of excess damage dealt to that creature this way. (They're artifacts with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+Oracle:Lacerate Flesh deals 4 damage to target creature. Create a number of Blood tokens equal to the amount of excess damage dealt to that creature this way. (They're artifacts with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/m/markov_enforcer.txt
+++ b/forge-gui/res/cardsfolder/m/markov_enforcer.txt
@@ -4,9 +4,9 @@ Types:Creature Vampire Soldier
 PT:6/6
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self,Vampire.Other+YouCtrl | Execute$ TrigFight | TriggerDescription$ Whenever CARDNAME or another Vampire you control enters, CARDNAME fights up to one target creature an opponent controls.
 SVar:TrigFight:DB$ Fight | Defined$ Self | TargetMin$ 0 | TargetMax$ 1 | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select up to one target creature an opponent controls
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.DamagedBy | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever a creature dealt damage by CARDNAME this turn dies, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.DamagedBy | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever a creature dealt damage by CARDNAME this turn dies, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:TrigToken:DB$ Token | TokenScript$ c_a_blood_draw
 SVar:BuffedBy:Creature.Vampire
 DeckHints:Type$Vampire
 DeckHas:Ability$Token|Sacrifice & Type$Blood
-Oracle:Whenever Markov Enforcer or another Vampire you control enters, Markov Enforcer fights up to one target creature an opponent controls.\nWhenever a creature dealt damage by Markov Enforcer this turn dies, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+Oracle:Whenever Markov Enforcer or another Vampire you control enters, Markov Enforcer fights up to one target creature an opponent controls.\nWhenever a creature dealt damage by Markov Enforcer this turn dies, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/m/moonstone_eulogist.txt
+++ b/forge-gui/res/cardsfolder/m/moonstone_eulogist.txt
@@ -3,10 +3,10 @@ ManaCost:3 B B
 Types:Creature Bat Warlock
 PT:4/4
 K:Flying
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.OppCtrl | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever a creature an opponent controls dies, you create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.OppCtrl | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever a creature an opponent controls dies, you create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:TrigToken:DB$ Token | TokenScript$ c_a_blood_draw | TokenOwner$ You
 T:Mode$ Sacrificed | ValidCard$ Artifact | ValidPlayer$ You | Execute$ TrigPutCounter | TriggerZones$ Battlefield | TriggerDescription$ Whenever you sacrifice an artifact, put a +1/+1 counter on CARDNAME and you gain 1 life.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBGainLife
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1
 DeckHas:Ability$Token|Sacrifice|Counters & Type$Artifact|Blood
-Oracle:Flying\nWhenever a creature an opponent controls dies, you create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")\nWhenever you sacrifice an artifact, put a +1/+1 counter on Moonstone Eulogist and you gain 1 life.
+Oracle:Flying\nWhenever a creature an opponent controls dies, you create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")\nWhenever you sacrifice an artifact, put a +1/+1 counter on Moonstone Eulogist and you gain 1 life.

--- a/forge-gui/res/cardsfolder/o/olivias_attendants.txt
+++ b/forge-gui/res/cardsfolder/o/olivias_attendants.txt
@@ -3,9 +3,9 @@ ManaCost:4 R R
 Types:Creature Vampire
 PT:6/6
 K:Menace
-T:Mode$ DamageDealtOnce | ValidSource$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever CARDNAME deals damage, create that many Blood tokens. (They're artifacts with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+T:Mode$ DamageDealtOnce | ValidSource$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever CARDNAME deals damage, create that many Blood tokens. (They're artifacts with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ c_a_blood_draw
 SVar:X:TriggerCount$DamageAmount
 A:AB$ DealDamage | Cost$ 2 R | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to any target.
 DeckHas:Ability$Token|Sacrifice & Type$Blood
-Oracle:Menace\nWhenever Olivia's Attendants deals damage, create that many Blood tokens. (They're artifacts with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")\n{2}{R}: Olivia's Attendants deals 1 damage to any target.
+Oracle:Menace\nWhenever Olivia's Attendants deals damage, create that many Blood tokens. (They're artifacts with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")\n{2}{R}: Olivia's Attendants deals 1 damage to any target.

--- a/forge-gui/res/cardsfolder/p/pointed_discussion.txt
+++ b/forge-gui/res/cardsfolder/p/pointed_discussion.txt
@@ -1,8 +1,8 @@
 Name:Pointed Discussion
 ManaCost:2 B
 Types:Sorcery
-A:SP$ Draw | NumCards$ 2 | SubAbility$ DBLoseLife | StackDescription$ REP You draw_{p:You} draws & lose_loses & create_creates | SpellDescription$ You draw two cards, lose 2 life, then create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+A:SP$ Draw | NumCards$ 2 | SubAbility$ DBLoseLife | StackDescription$ REP You draw_{p:You} draws & lose_loses & create_creates | SpellDescription$ You draw two cards, lose 2 life, then create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:DBLoseLife:DB$ LoseLife | LifeAmount$ 2 | SubAbility$ DBToken | StackDescription$ None
 SVar:DBToken:DB$ Token | TokenScript$ c_a_blood_draw | TokenOwner$ You
 DeckHas:Ability$Token|Sacrifice & Type$Blood
-Oracle:You draw two cards, lose 2 life, then create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+Oracle:You draw two cards, lose 2 life, then create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/r/restless_bloodseeker_bloodsoaked_reveler.txt
+++ b/forge-gui/res/cardsfolder/r/restless_bloodseeker_bloodsoaked_reveler.txt
@@ -2,14 +2,14 @@ Name:Restless Bloodseeker
 ManaCost:1 B
 Types:Creature Vampire
 PT:1/3
-T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | CheckSVar$ X | Execute$ DBToken | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your end step, if you gained life this turn, create a Blood token.
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | CheckSVar$ X | Execute$ DBToken | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your end step, if you gained life this turn, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:X:Count$LifeYouGainedThisTurn
 SVar:DBToken:DB$ Token | TokenScript$ c_a_blood_draw
 A:AB$ SetState | Cost$ Sac<2/Blood.token/Blood token> | Defined$ Self | SorcerySpeed$ True | Mode$ Transform | SpellDescription$ Transform CARDNAME. Activate only as a sorcery.
 DeckHas:Ability$Token|Sacrifice|LifeGain & Type$Blood
 DeckNeeds:Ability$LifeGain
 AlternateMode:DoubleFaced
-Oracle:At the beginning of your end step, if you gained life this turn, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")\nSacrifice two Blood tokens: Transform Restless Bloodseeker. Activate only as a sorcery.
+Oracle:At the beginning of your end step, if you gained life this turn, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")\nSacrifice two Blood tokens: Transform Restless Bloodseeker. Activate only as a sorcery.
 
 ALTERNATE
 
@@ -18,9 +18,9 @@ ManaCost:no cost
 Colors:black
 Types:Creature Vampire
 PT:3/3
-T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | CheckSVar$ X | Execute$ DBToken | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your end step, if you gained life this turn, create a Blood token.
+T:Mode$ Phase | Phase$ End of Turn | ValidPlayer$ You | CheckSVar$ X | Execute$ DBToken | TriggerZones$ Battlefield | TriggerDescription$ At the beginning of your end step, if you gained life this turn, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:X:Count$LifeYouGainedThisTurn
 SVar:DBToken:DB$ Token | TokenScript$ c_a_blood_draw
 A:AB$ LoseLife | Cost$ 4 B | Defined$ Player.Opponent | LifeAmount$ 2 | SubAbility$ DBGainLife | SpellDescription$ Each opponent loses 2 life and you gain 2 life.
 SVar:DBGainLife:DB$ GainLife | LifeAmount$ 2
-Oracle:At the beginning of your end step, if you gained life this turn, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")\n{4}{B}: Each opponent loses 2 life and you gain 2 life.
+Oracle:At the beginning of your end step, if you gained life this turn, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")\n{4}{B}: Each opponent loses 2 life and you gain 2 life.

--- a/forge-gui/res/cardsfolder/s/sanguine_statuette.txt
+++ b/forge-gui/res/cardsfolder/s/sanguine_statuette.txt
@@ -1,9 +1,9 @@
 Name:Sanguine Statuette
 ManaCost:1 R
 Types:Artifact
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:TrigToken:DB$ Token | TokenScript$ c_a_blood_draw
 T:Mode$ Sacrificed | ValidCard$ Blood.token+YouCtrl | Execute$ TrigAnimate | TriggerZones$ Battlefield | OptionalDecider$ You | TriggerDescription$ Whenever you sacrifice a Blood token, you may have CARDNAME become a 3/3 Vampire artifact creature with haste until end of turn.
 SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 3 | Toughness$ 3 | Types$ Vampire,Artifact,Creature | RemoveCreatureTypes$ True | Keywords$ Haste
 DeckHas:Ability$Token|Sacrifice & Type$Blood|Vampire
-Oracle:When Sanguine Statuette enters, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")\nWhenever you sacrifice a Blood token, you may have Sanguine Statuette become a 3/3 Vampire artifact creature with haste until end of turn.
+Oracle:When Sanguine Statuette enters, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")\nWhenever you sacrifice a Blood token, you may have Sanguine Statuette become a 3/3 Vampire artifact creature with haste until end of turn.

--- a/forge-gui/res/cardsfolder/s/sigardas_imprisonment.txt
+++ b/forge-gui/res/cardsfolder/s/sigardas_imprisonment.txt
@@ -5,7 +5,7 @@ K:Enchant:Creature
 SVar:AttachAILogic:Curse
 S:Mode$ CantAttack,CantBlock | ValidCard$ Creature.EnchantedBy | Description$ Enchanted creature can't attack or block.
 A:AB$ ChangeZone | Cost$ 4 W | Defined$ Enchanted | Origin$ Battlefield | Destination$ Exile | SubAbility$ DBToken | SpellDescription$ Exile enchanted creature.
-SVar:DBToken:DB$ Token | TokenScript$ c_a_blood_draw | SpellDescription$ Create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+SVar:DBToken:DB$ Token | TokenScript$ c_a_blood_draw | SpellDescription$ Create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:NonStackingAttachEffect:True
 DeckHas:Ability$Token|Sacrifice & Type$Blood
-Oracle:Enchant creature\nEnchanted creature can't attack or block.\n{4}{W}: Exile enchanted creature. Create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+Oracle:Enchant creature\nEnchanted creature can't attack or block.\n{4}{W}: Exile enchanted creature. Create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/s/syphon_essence.txt
+++ b/forge-gui/res/cardsfolder/s/syphon_essence.txt
@@ -2,6 +2,6 @@ Name:Syphon Essence
 ManaCost:2 U
 Types:Instant
 A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target creature or planeswalker spell | ValidTgts$ Creature,Planeswalker | SubAbility$ DBToken | SpellDescription$ Counter target creature or planeswalker spell.
-SVar:DBToken:DB$ Token | TokenScript$ c_a_blood_draw | SpellDescription$ Create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+SVar:DBToken:DB$ Token | TokenScript$ c_a_blood_draw | SpellDescription$ Create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 DeckHas:Ability$Token|Sacrifice & Type$Blood
-Oracle:Counter target creature or planeswalker spell. Create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+Oracle:Counter target creature or planeswalker spell. Create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/v/vampires_kiss.txt
+++ b/forge-gui/res/cardsfolder/v/vampires_kiss.txt
@@ -3,6 +3,6 @@ ManaCost:1 B
 Types:Sorcery
 A:SP$ LoseLife | ValidTgts$ Player | LifeAmount$ 2 | SubAbility$ DBGainLife | StackDescription$ {p:Targeted} loses 2 life | SpellDescription$ Target player loses 2 life and you gain 2 life.
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 2 | StackDescription$ and {p:You} gains 2 life. | SubAbility$ DBBlood
-SVar:DBBlood:DB$ Token | TokenAmount$ 2 | TokenScript$ c_a_blood_draw | TokenOwner$ You | SpellDescription$ Create two Blood tokens. (They're artifacts with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+SVar:DBBlood:DB$ Token | TokenAmount$ 2 | TokenScript$ c_a_blood_draw | TokenOwner$ You | SpellDescription$ Create two Blood tokens. (They're artifacts with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 DeckHas:Ability$LifeGain|Token|Sacrifice & Type$Blood
-Oracle:Target player loses 2 life and you gain 2 life. Create two Blood tokens. (They're artifacts with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+Oracle:Target player loses 2 life and you gain 2 life. Create two Blood tokens. (They're artifacts with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/v/vampires_vengeance.txt
+++ b/forge-gui/res/cardsfolder/v/vampires_vengeance.txt
@@ -2,7 +2,7 @@ Name:Vampires' Vengeance
 ManaCost:2 R
 Types:Instant
 A:SP$ DamageAll | NumDmg$ 2 | ValidCards$ Creature.nonVampire | ValidDescription$ each non-Vampire creature. | SubAbility$ DBToken | SpellDescription$ CARDNAME deals 2 damage to each non-Vampire creature.
-SVar:DBToken:DB$ Token | TokenScript$ c_a_blood_draw | SpellDescription$ Create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+SVar:DBToken:DB$ Token | TokenScript$ c_a_blood_draw | SpellDescription$ Create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 DeckHas:Ability$Token|Sacrifice & Type$Blood
 DeckNeeds:Type$Vampire
-Oracle:Vampires' Vengeance deals 2 damage to each non-Vampire creature. Create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+Oracle:Vampires' Vengeance deals 2 damage to each non-Vampire creature. Create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/v/voldaren_bloodcaster_bloodbat_summoner.txt
+++ b/forge-gui/res/cardsfolder/v/voldaren_bloodcaster_bloodbat_summoner.txt
@@ -3,13 +3,13 @@ ManaCost:1 B
 Types:Creature Vampire Wizard
 PT:2/1
 K:Flying
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self,Creature.Other+!token+YouCtrl | Execute$ TrigToken | TriggerDescription$ Whenever CARDNAME or another nontoken creature you control dies, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self,Creature.Other+!token+YouCtrl | Execute$ TrigToken | TriggerDescription$ Whenever CARDNAME or another nontoken creature you control dies, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:TrigToken:DB$ Token | TokenScript$ c_a_blood_draw
 T:Mode$ TokenCreated | ValidPlayer$ You | ValidToken$ Blood | IsPresent$ Blood.token+YouCtrl | PresentCompare$ GE5 | Execute$ TrigTransform | TriggerZones$ Battlefield | TriggerDescription$ Whenever you create a Blood token, if you control five or more Blood tokens, transform CARDNAME.
 SVar:TrigTransform:DB$ SetState | Defined$ Self | Mode$ Transform
 DeckHas:Ability$Token|Sacrifice & Type$Blood
 AlternateMode:DoubleFaced
-Oracle:Flying\nWhenever Voldaren Bloodcaster or another nontoken creature you control dies, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")\nWhenever you create a Blood token, if you control five or more Blood tokens, transform Voldaren Bloodcaster.
+Oracle:Flying\nWhenever Voldaren Bloodcaster or another nontoken creature you control dies, create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")\nWhenever you create a Blood token, if you control five or more Blood tokens, transform Voldaren Bloodcaster.
 
 ALTERNATE
 

--- a/forge-gui/res/cardsfolder/v/voldaren_epicure.txt
+++ b/forge-gui/res/cardsfolder/v/voldaren_epicure.txt
@@ -2,8 +2,8 @@ Name:Voldaren Epicure
 ManaCost:R
 Types:Creature Vampire
 PT:1/1
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDmg1 | TriggerDescription$ When CARDNAME enters, it deals 1 damage to each opponent. Create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDmg1 | TriggerDescription$ When CARDNAME enters, it deals 1 damage to each opponent. Create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:TrigDmg1:DB$ DealDamage | NumDmg$ 1 | Defined$ Player.Opponent | SubAbility$ DBBlood
 SVar:DBBlood:DB$ Token | TokenScript$ c_a_blood_draw | TokenOwner$ You
 DeckHas:Ability$Token|Sacrifice & Type$Blood
-Oracle:When Voldaren Epicure enters, it deals 1 damage to each opponent. Create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+Oracle:When Voldaren Epicure enters, it deals 1 damage to each opponent. Create a Blood token. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")

--- a/forge-gui/res/cardsfolder/v/voldaren_estate.txt
+++ b/forge-gui/res/cardsfolder/v/voldaren_estate.txt
@@ -3,8 +3,8 @@ ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ T PayLife<1> | Produced$ Any | Amount$ 1 | RestrictValid$ Spell.Vampire | SpellDescription$ Add one mana of any color. Spend this mana only to cast a Vampire spell.
-A:AB$ Token | Cost$ 5 T | TokenScript$ c_a_blood_draw | ReduceCost$ X | SpellDescription$ Create a Blood token. This ability costs {1} less to activate for each Vampire you control. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+A:AB$ Token | Cost$ 5 T | TokenScript$ c_a_blood_draw | ReduceCost$ X | SpellDescription$ Create a Blood token. This ability costs {1} less to activate for each Vampire you control. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")
 SVar:X:Count$Valid Vampire.YouCtrl
 DeckHas:Ability$Token|Sacrifice & Type$Blood
 DeckNeeds:Type$Vampire
-Oracle:{T}: Add {C}.\n{T}, Pay 1 life: Add one mana of any color. Spend this mana only to cast a Vampire spell.\n{5}, {T}: Create a Blood token. This ability costs {1} less to activate for each Vampire you control. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.")
+Oracle:{T}: Add {C}.\n{T}, Pay 1 life: Add one mana of any color. Spend this mana only to cast a Vampire spell.\n{5}, {T}: Create a Blood token. This ability costs {1} less to activate for each Vampire you control. (It's an artifact with "{1}, {T}, Discard a card, Sacrifice this token: Draw a card.")


### PR DESCRIPTION
Following up on https://github.com/Card-Forge/forge/pull/11086 .
Generally dealing with the 'artifact' → 'token' update to the Blood activated ability (as in [Anje, Maid of Dishonor](https://gatherer.wizards.com/VOW/en-us/231/anje-maid-of-dishonor)). A few related changes were addressed as well, notably:
- Adding the reminder text in some scripts' Description parameters with reference to Gatherer.