### PR TITLE
Card cleanup: 2026-06-28 [Reminder text: Junk token]

### DIFF
--- a/forge-gui/res/cardsfolder/b/boomer_scrapper.txt
+++ b/forge-gui/res/cardsfolder/b/boomer_scrapper.txt
@@ -2,12 +2,12 @@ Name:Boomer Scrapper
 ManaCost:1 B R
 Types:Creature Human Soldier
 PT:1/1
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigLoseLife | TriggerDescription$ Whenever CARDNAME enters or attacks, you lose 1 life and create a Junk token. (It's an artifact with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
-T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigLoseLife | Secondary$ True | TriggerDescription$ Whenever CARDNAME enters or attacks, you lose 1 life and create a Junk token. (It's an artifact with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigLoseLife | TriggerDescription$ Whenever CARDNAME enters or attacks, you lose 1 life and create a Junk token. (It's an artifact with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigLoseLife | Secondary$ True | TriggerDescription$ Whenever CARDNAME enters or attacks, you lose 1 life and create a Junk token. (It's an artifact with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
 SVar:TrigLoseLife:DB$ LoseLife | LifeAmount$ 1 | SubAbility$ DBToken
 SVar:DBToken:DB$ Token | TokenScript$ c_a_junk_sac_exileplay | TokenOwner$ You
 T:Mode$ ChangesZone | ValidCard$ Card.token+YouCtrl | Origin$ Battlefield | Destination$ Any | Execute$ TrigCounter | TriggerZones$ Battlefield | TriggerDescription$ Whenever a token you control leaves the battlefield, put a +1/+1 counter on CARDNAME.
 SVar:TrigCounter:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ 1
 DeckHints:Ability$Token & Type$Treasure|Food|Junk|Map|Clue
 DeckHas:Ability$Token|Counters & Type$Artifact|Junk
-Oracle:Whenever Boomer Scrapper enters or attacks, you lose 1 life and create a Junk token. (It's an artifact with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")\nWhenever a token you control leaves the battlefield, put a +1/+1 counter on Boomer Scrapper.
+Oracle:Whenever Boomer Scrapper enters or attacks, you lose 1 life and create a Junk token. (It's an artifact with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")\nWhenever a token you control leaves the battlefield, put a +1/+1 counter on Boomer Scrapper.

--- a/forge-gui/res/cardsfolder/b/break_down.txt
+++ b/forge-gui/res/cardsfolder/b/break_down.txt
@@ -2,6 +2,6 @@ Name:Break Down
 ManaCost:2 G
 Types:Instant
 A:SP$ Destroy | ValidTgts$ Artifact,Enchantment | TgtPrompt$ Select target artifact or enchantment | SubAbility$ DBToken | SpellDescription$ Destroy target artifact or enchantment.
-SVar:DBToken:DB$ Token | TokenScript$ c_a_junk_sac_exileplay | TokenOwner$ You | SpellDescription$ Create a Junk token. (It's an artifact with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
+SVar:DBToken:DB$ Token | TokenScript$ c_a_junk_sac_exileplay | TokenOwner$ You | SpellDescription$ Create a Junk token. (It's an artifact with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
 DeckHas:Ability$Token|Sacrifice
-Oracle:Destroy target artifact or enchantment. Create a Junk token. (It's an artifact with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
+Oracle:Destroy target artifact or enchantment. Create a Junk token. (It's an artifact with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")

--- a/forge-gui/res/cardsfolder/c/c_a_m_p_.txt
+++ b/forge-gui/res/cardsfolder/c/c_a_m_p_.txt
@@ -1,9 +1,9 @@
 Name:C.A.M.P.
 ManaCost:3
 Types:Artifact Fortification
-T:Mode$ TapsForMana | ValidCard$ Card.FortifiedBy | Execute$ TrigPutCounter | TriggerDescription$ Whenever fortified land is tapped for mana, put a +1/+1 counter on target creature you control. If that creature shares a color with the mana that land produced, create a Junk token. (It's an artifact with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
+T:Mode$ TapsForMana | ValidCard$ Card.FortifiedBy | Execute$ TrigPutCounter | TriggerDescription$ Whenever fortified land is tapped for mana, put a +1/+1 counter on target creature you control. If that creature shares a color with the mana that land produced, create a Junk token. (It's an artifact with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
 SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | CounterType$ P1P1 | SubAbility$ DBJunk
 SVar:DBJunk:DB$ Token | ConditionDefined$ Targeted | ConditionPresent$ Card.SharesColorWith TriggeredProduced | TokenScript$ c_a_junk_sac_exileplay
 K:Fortify:3
 DeckHas:Ability$Counters|Token|Sacrifice & Type$Artifact|Junk
-Oracle:Whenever fortified land is tapped for mana, put a +1/+1 counter on target creature you control. If that creature shares a color with the mana that land produced, create a Junk token. (It's an artifact with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")\nFortify {3} ({3}: Attach to target land you control. Fortify only as a sorcery.)
+Oracle:Whenever fortified land is tapped for mana, put a +1/+1 counter on target creature you control. If that creature shares a color with the mana that land produced, create a Junk token. (It's an artifact with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")\nFortify {3} ({3}: Attach to target land you control. Fortify only as a sorcery.)

--- a/forge-gui/res/cardsfolder/c/commander_sofia_daguerre.txt
+++ b/forge-gui/res/cardsfolder/c/commander_sofia_daguerre.txt
@@ -3,8 +3,8 @@ ManaCost:3 W
 Types:Legendary Creature Human Pilot
 PT:1/3
 K:Flash
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDestroy | TriggerDescription$ Crash Landing — When CARDNAME enters, destroy up to one target legendary permanent. That permanent's controller creates a Junk token. (It's an artifact with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigDestroy | TriggerDescription$ Crash Landing — When CARDNAME enters, destroy up to one target legendary permanent. That permanent's controller creates a Junk token. (It's an artifact with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
 SVar:TrigDestroy:DB$ Destroy | ValidTgts$ Permanent.Legendary | TgtPrompt$ Select up to one target legendary permanent | TargetMin$ 0 | TargetMax$ 1 | SubAbility$ DBToken
 SVar:DBToken:DB$ Token | TokenScript$ c_a_junk_sac_exileplay | TokenOwner$ TargetedController
 DeckHas:Ability$Token & Type$Junk|Artifact
-Oracle:Flash\nCrash Landing — When Commander Sofia Daguerre enters, destroy up to one target legendary permanent. That permanent's controller creates a Junk token. (It's an artifact with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
+Oracle:Flash\nCrash Landing — When Commander Sofia Daguerre enters, destroy up to one target legendary permanent. That permanent's controller creates a Junk token. (It's an artifact with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")

--- a/forge-gui/res/cardsfolder/c/crimson_caravaneer.txt
+++ b/forge-gui/res/cardsfolder/c/crimson_caravaneer.txt
@@ -4,7 +4,7 @@ Types:Creature Human Scout
 PT:1/2
 K:Double Strike
 K:Trample
-T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigTreasure | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, create a Junk token. (It's an artifact with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigTreasure | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, create a Junk token. (It's an artifact with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
 SVar:TrigTreasure:DB$ Token | TokenScript$ c_a_junk_sac_exileplay | TokenOwner$ You
 DeckHas:Ability$Token & Type$Junk|Artifact
-Oracle:Double strike, trample\nWhenever Crimson Caravaneer deals combat damage to a player, create a Junk token. (It's an artifact with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
+Oracle:Double strike, trample\nWhenever Crimson Caravaneer deals combat damage to a player, create a Junk token. (It's an artifact with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")

--- a/forge-gui/res/cardsfolder/d/dogmeat_ever_loyal.txt
+++ b/forge-gui/res/cardsfolder/d/dogmeat_ever_loyal.txt
@@ -5,8 +5,8 @@ PT:3/3
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigMill | TriggerDescription$ When NICKNAME enters, mill five cards, then return an Aura or Equipment card from your graveyard to your hand.
 SVar:TrigMill:DB$ Mill | NumCards$ 5 | Defined$ You | SubAbility$ DBChangeZone
 SVar:DBChangeZone:DB$ ChangeZone | Origin$ Graveyard | Destination$ Hand | Mandatory$ True | ChangeType$ Aura.YouOwn,Equipment.YouOwn | Hidden$ True
-T:Mode$ Attacks | ValidCard$ Creature.enchanted+YouCtrl,Creature.YouCtrl+equipped | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever a creature you control that's enchanted or equipped attacks, create a Junk token. (It's an artifact with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
+T:Mode$ Attacks | ValidCard$ Creature.enchanted+YouCtrl,Creature.YouCtrl+equipped | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever a creature you control that's enchanted or equipped attacks, create a Junk token. (It's an artifact with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
 SVar:TrigToken:DB$ Token | TokenScript$ c_a_junk_sac_exileplay
 DeckHas:Ability$Graveyard|Token|Mill & Type$Artifact
 DeckNeeds:Type$Equipment|Aura
-Oracle:When Dogmeat enters, mill five cards, then return an Aura or Equipment card from your graveyard to your hand.\nWhenever a creature you control that's enchanted or equipped attacks, create a Junk token. (It's an artifact with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
+Oracle:When Dogmeat enters, mill five cards, then return an Aura or Equipment card from your graveyard to your hand.\nWhenever a creature you control that's enchanted or equipped attacks, create a Junk token. (It's an artifact with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")

--- a/forge-gui/res/cardsfolder/d/duchess_wayward_tavernkeep.txt
+++ b/forge-gui/res/cardsfolder/d/duchess_wayward_tavernkeep.txt
@@ -4,7 +4,7 @@ Types:Legendary Creature Human Citizen
 PT:4/3
 T:Mode$ DamageDone | ValidSource$ Creature.YouCtrl | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigPutCounter | TriggerZones$ Battlefield | TriggerDescription$ Hunters for Hire — Whenever a creature you control deals combat damage to a player, put a quest counter on it.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ TriggeredSourceLKICopy | CounterType$ QUEST | CounterNum$ 1
-A:AB$ Token | Cost$ 1 RemoveAnyCounter<1/QUEST/Permanent> | TokenScript$ c_a_junk_sac_exileplay | SpellDescription$ Create a Junk token. (It's an artifact with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
+A:AB$ Token | Cost$ 1 RemoveAnyCounter<1/QUEST/Permanent> | TokenScript$ c_a_junk_sac_exileplay | SpellDescription$ Create a Junk token. (It's an artifact with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
 DeckHas:Ability$Counters|Token & Type$Junk|Artifact
 SVar:AICounterOverrideQUEST:Positive
-Oracle:Hunters for Hire — Whenever a creature you control deals combat damage to a player, put a quest counter on it.\n{1}, Remove a quest counter from a permanent you control: Create a Junk token. (It's an artifact with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
+Oracle:Hunters for Hire — Whenever a creature you control deals combat damage to a player, put a quest counter on it.\n{1}, Remove a quest counter from a permanent you control: Create a Junk token. (It's an artifact with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")

--- a/forge-gui/res/cardsfolder/j/junk_jet.txt
+++ b/forge-gui/res/cardsfolder/j/junk_jet.txt
@@ -1,10 +1,10 @@
 Name:Junk Jet
 ManaCost:1 R
 Types:Artifact Equipment
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a Junk token. (It's an artifact with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a Junk token. (It's an artifact with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
 SVar:TrigToken:DB$ Token | TokenScript$ c_a_junk_sac_exileplay | TokenOwner$ You
 A:AB$ Pump | Cost$ 3 Sac<1/Artifact.Other/another artifact> | Defined$ Equipped | NumAtt$ Double | SpellDescription$ Double equipped creature's power until end of turn.
 K:Equip:1
 DeckHints:Ability$Token & Type$Treasure|Food|Junk|Map|Clue
 DeckHas:Ability$Token|Counters & Type$Artifact|Junk
-Oracle:When Junk Jet enters, create a Junk token. (It's an artifact with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")\n{3}, Sacrifice another artifact: Double equipped creature's power until end of turn.\nEquip {1}
+Oracle:When Junk Jet enters, create a Junk token. (It's an artifact with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")\n{3}, Sacrifice another artifact: Double equipped creature's power until end of turn.\nEquip {1}

--- a/forge-gui/res/cardsfolder/j/junktown.txt
+++ b/forge-gui/res/cardsfolder/j/junktown.txt
@@ -2,6 +2,6 @@ Name:Junktown
 ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
-A:AB$ Token | Cost$ 4 R T Sac<1/NICKNAME> | TokenAmount$ 3 | TokenScript$ c_a_junk_sac_exileplay | TokenOwner$ You | SpellDescription$ Create three Junk tokens. (They're artifacts with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
+A:AB$ Token | Cost$ 4 R T Sac<1/NICKNAME> | TokenAmount$ 3 | TokenScript$ c_a_junk_sac_exileplay | TokenOwner$ You | SpellDescription$ Create three Junk tokens. (They're artifacts with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
 DeckHas:Ability$Sacrifice|Token & Type$Junk|Artifact
-Oracle:{T}: Add {C}.\n{4}{R}, {T}, Sacrifice Junktown: Create three Junk tokens. (They're artifacts with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
+Oracle:{T}: Add {C}.\n{4}{R}, {T}, Sacrifice Junktown: Create three Junk tokens. (They're artifacts with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")

--- a/forge-gui/res/cardsfolder/m/mister_gutsy.txt
+++ b/forge-gui/res/cardsfolder/m/mister_gutsy.txt
@@ -4,9 +4,9 @@ Types:Artifact Creature Robot Soldier
 PT:1/1
 T:Mode$ SpellCast | ValidCard$ Aura,Equipment | ValidActivatingPlayer$ You | Execute$ TrigPutCounter | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast an Aura or Equipment spell, put a +1/+1 counter on CARDNAME.
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterNum$ 1 | CounterType$ P1P1
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME dies, create X Junk tokens, where X is the number of +1/+1 counters on it. (They're artifacts with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME dies, create X Junk tokens, where X is the number of +1/+1 counters on it. (They're artifacts with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
 SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ c_a_junk_sac_exileplay | TokenOwner$ TriggeredCardController
 SVar:X:TriggeredCard$CardCounters.P1P1
 DeckHas:Ability$Counters|Token & Type$Junk|Artifact
 DeckNeeds:Type$Aura|Equipment
-Oracle:Whenever you cast an Aura or Equipment spell, put a +1/+1 counter on Mister Gutsy.\nWhen Mister Gutsy dies, create X Junk tokens, where X is the number of +1/+1 counters on it. (They're artifacts with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
+Oracle:Whenever you cast an Aura or Equipment spell, put a +1/+1 counter on Mister Gutsy.\nWhen Mister Gutsy dies, create X Junk tokens, where X is the number of +1/+1 counters on it. (They're artifacts with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")

--- a/forge-gui/res/cardsfolder/r/rose_cutthroat_raider.txt
+++ b/forge-gui/res/cardsfolder/r/rose_cutthroat_raider.txt
@@ -3,11 +3,11 @@ ManaCost:2 R R
 Types:Legendary Artifact Creature Robot
 PT:3/2
 K:First Strike
-T:Mode$ Phase | Phase$ EndCombat | ValidPlayer$ You | CheckSVar$ RaidTest | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Raid — At end of combat on your turn, if you attacked this turn, create a Junk token for each opponent you attacked. (It's an artifact with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
+T:Mode$ Phase | Phase$ EndCombat | ValidPlayer$ You | CheckSVar$ RaidTest | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Raid — At end of combat on your turn, if you attacked this turn, create a Junk token for each opponent you attacked. (It's an artifact with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
 SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ c_a_junk_sac_exileplay | TokenOwner$ You
 SVar:RaidTest:Count$AttackersDeclared
 SVar:X:PlayerCountPropertyYou$OpponentsAttackedThisTurn
 T:Mode$ Sacrificed | ValidCard$ Junk.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigMana | TriggerDescription$ Whenever you sacrifice a Junk, add {R}.
 SVar:TrigMana:DB$ Mana | Produced$ R | Amount$ 1
 DeckHas:Ability$Sacrifice|Token & Type$Junk|Artifact
-Oracle:First strike\nRaid — At end of combat on your turn, if you attacked this turn, create a Junk token for each opponent you attacked. (It's an artifact with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")\nWhenever you sacrifice a Junk, add {R}.
+Oracle:First strike\nRaid — At end of combat on your turn, if you attacked this turn, create a Junk token for each opponent you attacked. (It's an artifact with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")\nWhenever you sacrifice a Junk, add {R}.

--- a/forge-gui/res/cardsfolder/v/veronica_dissident_scribe.txt
+++ b/forge-gui/res/cardsfolder/v/veronica_dissident_scribe.txt
@@ -5,8 +5,8 @@ PT:3/3
 K:Menace
 T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigDraw | TriggerDescription$ Whenever CARDNAME attacks, you may discard a card. If you do, draw a card.
 SVar:TrigDraw:AB$ Draw | Cost$ Discard<1/Card>
-T:Mode$ DiscardedAll | ValidPlayer$ You | FirstTime$ True | ValidCard$ Card.nonLand | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever you discard one or more nonland cards for the first time each turn, create a Junk token. (It's an artifact with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
+T:Mode$ DiscardedAll | ValidPlayer$ You | FirstTime$ True | ValidCard$ Card.nonLand | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ Whenever you discard one or more nonland cards for the first time each turn, create a Junk token. (It's an artifact with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
 SVar:TrigToken:DB$ Token | TokenScript$ c_a_junk_sac_exileplay
 SVar:HasAttackEffect:TRUE
 DeckHas:Ability$Token|Discard
-Oracle:Menace\nWhenever Veronica, Dissident Scribe attacks, you may discard a card. If you do, draw a card.\nWhenever you discard one or more nonland cards for the first time each turn, create a Junk token. (It's an artifact with "{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")
+Oracle:Menace\nWhenever Veronica, Dissident Scribe attacks, you may discard a card. If you do, draw a card.\nWhenever you discard one or more nonland cards for the first time each turn, create a Junk token. (It's an artifact with "{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.")


### PR DESCRIPTION
Following up on https://github.com/Card-Forge/forge/pull/11086 .
Dealing with the 'artifact' → 'token' update to the Junk activated ability (as in [Boomer Scrapper](https://gatherer.wizards.com/PIP/en-us/95/boomer-scrapper)). 