### PR TITLE
Card cleanup: 2026-06-28 [Reminder text: Gold token]

### DIFF
--- a/forge-gui/res/cardsfolder/c/curse_of_opulence.txt
+++ b/forge-gui/res/cardsfolder/c/curse_of_opulence.txt
@@ -3,7 +3,7 @@ ManaCost:R
 Types:Enchantment Aura Curse
 K:Enchant:Player
 SVar:AttachAILogic:Curse
-T:Mode$ AttackersDeclared | AttackedTarget$ Player.EnchantedBy | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever enchanted player is attacked, create a Gold token. Each opponent attacking that player does the same. (A Gold token is an artifact with "Sacrifice this artifact: Add one mana of any color.")
+T:Mode$ AttackersDeclared | AttackedTarget$ Player.EnchantedBy | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever enchanted player is attacked, create a Gold token. Each opponent attacking that player does the same. (A Gold token is an artifact with "Sacrifice this token: Add one mana of any color.")
 SVar:TrigToken:DB$ Token | TokenScript$ c_a_gold_sac | SubAbility$ DBToken
 SVar:DBToken:DB$ Token | TokenOwner$ TriggeredAttackingPlayer.Opponent+controlsCreature.attacking Player.EnchantedBy | TokenScript$ c_a_gold_sac
-Oracle:Enchant player\nWhenever enchanted player is attacked, create a Gold token. Each opponent attacking that player does the same. (A Gold token is an artifact with "Sacrifice this artifact: Add one mana of any color.")
+Oracle:Enchant player\nWhenever enchanted player is attacked, create a Gold token. Each opponent attacking that player does the same. (A Gold token is an artifact with "Sacrifice this token: Add one mana of any color.")

--- a/forge-gui/res/cardsfolder/g/gild.txt
+++ b/forge-gui/res/cardsfolder/g/gild.txt
@@ -1,6 +1,6 @@
 Name:Gild
 ManaCost:3 B
 Types:Sorcery
-A:SP$ ChangeZone | ValidTgts$ Creature | Origin$ Battlefield | Destination$ Exile | SubAbility$ DBToken | SpellDescription$ Exile target creature. Create a Gold token. (It's an artifact with "Sacrifice this artifact: Add one mana of any color.")
+A:SP$ ChangeZone | ValidTgts$ Creature | Origin$ Battlefield | Destination$ Exile | SubAbility$ DBToken | SpellDescription$ Exile target creature. Create a Gold token. (It's an artifact with "Sacrifice this token: Add one mana of any color.")
 SVar:DBToken:DB$ Token | TokenScript$ c_a_gold_sac | TokenOwner$ You
-Oracle:Exile target creature. Create a Gold token. (It's an artifact with "Sacrifice this artifact: Add one mana of any color.")
+Oracle:Exile target creature. Create a Gold token. (It's an artifact with "Sacrifice this token: Add one mana of any color.")

--- a/forge-gui/res/cardsfolder/k/king_macar_the_gold_cursed.txt
+++ b/forge-gui/res/cardsfolder/k/king_macar_the_gold_cursed.txt
@@ -2,9 +2,9 @@ Name:King Macar, the Gold-Cursed
 ManaCost:2 B B
 Types:Legendary Creature Human Noble
 PT:2/3
-T:Mode$ Untaps | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigExile | OptionalDecider$ You | TriggerDescription$ Inspired — Whenever CARDNAME becomes untapped, you may exile target creature. If you do, create a Gold token. (It's an artifact with "Sacrifice this artifact: Add one mana of any color.")
+T:Mode$ Untaps | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigExile | OptionalDecider$ You | TriggerDescription$ Inspired — Whenever CARDNAME becomes untapped, you may exile target creature. If you do, create a Gold token. (It's an artifact with "Sacrifice this token: Add one mana of any color.")
 SVar:TrigExile:DB$ ChangeZone | ValidTgts$ Creature | Origin$ Battlefield | Destination$ Exile | RememberChanged$ True | SubAbility$ DBToken
 SVar:DBToken:DB$ Token | TokenScript$ c_a_gold_sac | TokenOwner$ You | ConditionCheckSVar$ X | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Remembered$Amount
-Oracle:Inspired — Whenever King Macar, the Gold-Cursed becomes untapped, you may exile target creature. If you do, create a Gold token. (It's an artifact with "Sacrifice this artifact: Add one mana of any color.")
+Oracle:Inspired — Whenever King Macar, the Gold-Cursed becomes untapped, you may exile target creature. If you do, create a Gold token. (It's an artifact with "Sacrifice this token: Add one mana of any color.")

--- a/forge-gui/res/cardsfolder/t/the_first_iroan_games.txt
+++ b/forge-gui/res/cardsfolder/t/the_first_iroan_games.txt
@@ -5,6 +5,6 @@ K:Chapter:4:TrigToken,TrigPutCounter,TrigDraw,TrigGold
 SVar:TrigToken:DB$ Token | TokenScript$ w_1_1_human_soldier | TokenOwner$ You | SpellDescription$ Create a 1/1 white Human Soldier token.
 SVar:TrigPutCounter:DB$ PutCounter | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | CounterType$ P1P1 | CounterNum$ 3 | SpellDescription$ Put three +1/+1 counters on target creature you control.
 SVar:TrigDraw:DB$ Draw | NumCards$ 2 | ConditionPresent$ Creature.YouCtrl+powerGE4 | SpellDescription$ If you control a creature with power 4 or greater, draw two cards.
-SVar:TrigGold:DB$ Token | TokenScript$ c_a_gold_sac | TokenOwner$ You | SpellDescription$ Create a Gold token.
+SVar:TrigGold:DB$ Token | TokenScript$ c_a_gold_sac | TokenOwner$ You | SpellDescription$ Create a Gold token. (It's an artifact with "Sacrifice this token: Add one mana of any color.")
 DeckHas:Ability$Counters|Token
-Oracle:(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI — Create a 1/1 white Human Soldier creature token.\nII — Put three +1/+1 counters on target creature you control.\nIII — If you control a creature with power 4 or greater, draw two cards.\nIV — Create a Gold token. (It's an artifact with "Sacrifice this artifact: Add one mana of any color.")
+Oracle:(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI — Create a 1/1 white Human Soldier creature token.\nII — Put three +1/+1 counters on target creature you control.\nIII — If you control a creature with power 4 or greater, draw two cards.\nIV — Create a Gold token. (It's an artifact with "Sacrifice this token: Add one mana of any color.")


### PR DESCRIPTION
Following up on https://github.com/Card-Forge/forge/pull/11086 .
Generally dealing with the 'artifact' → 'token' update to the Gold activated ability (as in [Curse of Opulence](https://gatherer.wizards.com/CLB/en-us/786/curse-of-opulence)). A related change was addressed as well:
- Adding the reminder text in one scripts' Description parameter with reference to Gatherer ([The First Iroan Games](https://gatherer.wizards.com/THB/en-us/170/the-first-iroan-games)).