### PR TITLE
Card cleanup: 2026-06-29 [Reminder text: Scry]

### DIFF
--- a/forge-gui/res/cardsfolder/a/aether_theorist.txt
+++ b/forge-gui/res/cardsfolder/a/aether_theorist.txt
@@ -4,5 +4,5 @@ Types:Creature Vedalken Rogue
 PT:1/3
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigEnergy | TriggerDescription$ When CARDNAME enters, you get {E}{E}{E} (three energy counters).
 SVar:TrigEnergy:DB$ PutCounter | Defined$ You | CounterType$ ENERGY | CounterNum$ 3
-A:AB$ Scry | Cost$ T PayEnergy<1> | ScryNum$ 1 | SpellDescription$ Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
-Oracle:When Aether Theorist enters, you get {E}{E}{E} (three energy counters).\n{T}, Pay {E}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+A:AB$ Scry | Cost$ T PayEnergy<1> | ScryNum$ 1 | SpellDescription$ Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+Oracle:When Aether Theorist enters, you get {E}{E}{E} (three energy counters).\n{T}, Pay {E}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/a/anchor_to_the_aether.txt
+++ b/forge-gui/res/cardsfolder/a/anchor_to_the_aether.txt
@@ -1,6 +1,6 @@
 Name:Anchor to the Aether
 ManaCost:2 U
 Types:Sorcery
-A:SP$ ChangeZone | ValidTgts$ Creature | Origin$ Battlefield | Destination$ Library | LibraryPosition$ 0 | SubAbility$ DBScry | SpellDescription$ Put target creature on top of its owner's library. Scry 1.
+A:SP$ ChangeZone | ValidTgts$ Creature | Origin$ Battlefield | Destination$ Library | LibraryPosition$ 0 | SubAbility$ DBScry | SpellDescription$ Put target creature on top of its owner's library. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
-Oracle:Put target creature on top of its owner's library. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Put target creature on top of its owner's library. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/a/aqueous_form.txt
+++ b/forge-gui/res/cardsfolder/a/aqueous_form.txt
@@ -4,8 +4,8 @@ Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Pump
 S:Mode$ CantBlockBy | ValidAttacker$ Creature.EnchantedBy | Description$ Enchanted creature can't be blocked.
-T:Mode$ Attacks | ValidCard$ Card.AttachedBy | Execute$ DBScry | TriggerZones$ Battlefield | TriggerDescription$ Whenever enchanted creature attacks, scry 1.
+T:Mode$ Attacks | ValidCard$ Card.AttachedBy | Execute$ DBScry | TriggerZones$ Battlefield | TriggerDescription$ Whenever enchanted creature attacks, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddSVar$ AE
 SVar:AE:SVar:HasAttackEffect:TRUE
-Oracle:Enchant creature\nEnchanted creature can't be blocked.\nWhenever enchanted creature attacks, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Enchant creature\nEnchanted creature can't be blocked.\nWhenever enchanted creature attacks, scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/a/artisans_sorrow.txt
+++ b/forge-gui/res/cardsfolder/a/artisans_sorrow.txt
@@ -1,6 +1,6 @@
 Name:Artisan's Sorrow
 ManaCost:3 G
 Types:Instant
-A:SP$ Destroy | ValidTgts$ Artifact,Enchantment | TgtPrompt$ Select target artifact or enchantment | SubAbility$ DBScry | SpellDescription$ Destroy target artifact or enchantment. Scry 2.
+A:SP$ Destroy | ValidTgts$ Artifact,Enchantment | TgtPrompt$ Select target artifact or enchantment | SubAbility$ DBScry | SpellDescription$ Destroy target artifact or enchantment. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:DBScry:DB$ Scry | ScryNum$ 2
-Oracle:Destroy target artifact or enchantment. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:Destroy target artifact or enchantment. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/a/augury_owl.txt
+++ b/forge-gui/res/cardsfolder/a/augury_owl.txt
@@ -3,6 +3,6 @@ ManaCost:1 U
 Types:Creature Bird
 PT:1/1
 K:Flying
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 3. (Look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 3. (Look at the top three cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 3
-Oracle:Flying\nWhen Augury Owl enters, scry 3. (Look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:Flying\nWhen Augury Owl enters, scry 3. (Look at the top three cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/a/automatic_librarian.txt
+++ b/forge-gui/res/cardsfolder/a/automatic_librarian.txt
@@ -2,6 +2,6 @@ Name:Automatic Librarian
 ManaCost:3
 Types:Artifact Creature Construct
 PT:3/2
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 2
-Oracle:When Automatic Librarian enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:When Automatic Librarian enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/b/battlewise_hoplite.txt
+++ b/forge-gui/res/cardsfolder/b/battlewise_hoplite.txt
@@ -2,7 +2,7 @@ Name:Battlewise Hoplite
 ManaCost:W U
 Types:Creature Human Soldier
 PT:2/2
-T:Mode$ SpellCast | ValidActivatingPlayer$ You | TargetsValid$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPut | TriggerDescription$ Heroic — Whenever you cast a spell that targets CARDNAME, put a +1/+1 counter on CARDNAME, then scry 1.
+T:Mode$ SpellCast | ValidActivatingPlayer$ You | TargetsValid$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigPut | TriggerDescription$ Heroic — Whenever you cast a spell that targets CARDNAME, put a +1/+1 counter on CARDNAME, then scry 1. (To scry 1, look at the top card of your library, then you may put that card on the bottom.)
 SVar:TrigPut:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBScry
 SVar:DBScry:DB$ Scry | ScryNum$ 1
-Oracle:Heroic — Whenever you cast a spell that targets Battlewise Hoplite, put a +1/+1 counter on Battlewise Hoplite, then scry 1. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)
+Oracle:Heroic — Whenever you cast a spell that targets Battlewise Hoplite, put a +1/+1 counter on Battlewise Hoplite, then scry 1. (To scry 1, look at the top card of your library, then you may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/b/battlewise_valor.txt
+++ b/forge-gui/res/cardsfolder/b/battlewise_valor.txt
@@ -1,6 +1,6 @@
 Name:Battlewise Valor
 ManaCost:1 W
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | NumAtt$ +2 | NumDef$ +2 | SubAbility$ DBScry | SpellDescription$ Target creature gets +2/+2 until end of turn. Scry 1.
+A:SP$ Pump | ValidTgts$ Creature | NumAtt$ +2 | NumDef$ +2 | SubAbility$ DBScry | SpellDescription$ Target creature gets +2/+2 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
-Oracle:Target creature gets +2/+2 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Target creature gets +2/+2 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/b/bolt_of_keranos.txt
+++ b/forge-gui/res/cardsfolder/b/bolt_of_keranos.txt
@@ -1,6 +1,6 @@
 Name:Bolt of Keranos
 ManaCost:1 R R
 Types:Sorcery
-A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ 3 | SubAbility$ DBScry | SpellDescription$ CARDNAME deals 3 damage to any target. Scry 1.
+A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ 3 | SubAbility$ DBScry | SpellDescription$ CARDNAME deals 3 damage to any target. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
-Oracle:Bolt of Keranos deals 3 damage to any target. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Bolt of Keranos deals 3 damage to any target. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/b/bronze_walrus.txt
+++ b/forge-gui/res/cardsfolder/b/bronze_walrus.txt
@@ -2,7 +2,7 @@ Name:Bronze Walrus
 ManaCost:3
 Types:Artifact Creature Walrus
 PT:2/2
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 2
 A:AB$ Mana | Cost$ T | Produced$ Any | SpellDescription$ Add one mana of any color.
-Oracle:When Bronze Walrus enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)\n{T}: Add one mana of any color.
+Oracle:When Bronze Walrus enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)\n{T}: Add one mana of any color.

--- a/forge-gui/res/cardsfolder/c/calculated_dismissal.txt
+++ b/forge-gui/res/cardsfolder/c/calculated_dismissal.txt
@@ -1,6 +1,6 @@
 Name:Calculated Dismissal
 ManaCost:2 U
 Types:Instant
-A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | UnlessCost$ 3 | SubAbility$ DBScry | SpellDescription$ Counter target spell unless its controller pays {3}. Spell mastery — If there are two or more instant and/or sorcery cards in your graveyard, scry 2.
+A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | UnlessCost$ 3 | SubAbility$ DBScry | SpellDescription$ Counter target spell unless its controller pays {3}. Spell mastery — If there are two or more instant and/or sorcery cards in your graveyard, scry 2. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:DBScry:DB$ Scry | ScryNum$ 2 | ConditionPresent$ Instant.YouOwn,Sorcery.YouOwn | ConditionZone$ Graveyard | ConditionCompare$ GE2
-Oracle:Counter target spell unless its controller pays {3}.\nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, scry 2. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:Counter target spell unless its controller pays {3}.\nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, scry 2. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/c/catacomb_sifter.txt
+++ b/forge-gui/res/cardsfolder/c/catacomb_sifter.txt
@@ -5,8 +5,8 @@ PT:2/3
 K:Devoid
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create a 1/1 colorless Eldrazi Scion creature token. It has "Sacrifice this creature: Add {C}."
 SVar:TrigToken:DB$ Token | TokenScript$ c_1_1_eldrazi_scion_sac | TokenOwner$ You
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.Other+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigScry | TriggerDescription$ Whenever another creature you control dies, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.Other+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigScry | TriggerDescription$ Whenever another creature you control dies, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 1
 DeckHints:Type$Eldrazi
 DeckHas:Ability$Mana.Colorless|Token
-Oracle:Devoid (This card has no color.)\nWhen Catacomb Sifter enters, create a 1/1 colorless Eldrazi Scion creature token. It has "Sacrifice this creature: Add {C}."\nWhenever another creature you control dies, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Devoid (This card has no color.)\nWhen Catacomb Sifter enters, create a 1/1 colorless Eldrazi Scion creature token. It has "Sacrifice this creature: Add {C}."\nWhenever another creature you control dies, scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/c/chorus_of_the_tides.txt
+++ b/forge-gui/res/cardsfolder/c/chorus_of_the_tides.txt
@@ -3,6 +3,6 @@ ManaCost:3 U
 Types:Creature Siren
 PT:3/2
 K:Flying
-T:Mode$ SpellCast | ValidActivatingPlayer$ You | TargetsValid$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigScry | TriggerDescription$ Heroic — Whenever you cast a spell that targets CARDNAME, scry 1.
+T:Mode$ SpellCast | ValidActivatingPlayer$ You | TargetsValid$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigScry | TriggerDescription$ Heroic — Whenever you cast a spell that targets CARDNAME, scry 1. (To scry 1, look at the top card of your library, then you may put that card on the bottom.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 1
-Oracle:Flying\nHeroic — Whenever you cast a spell that targets Chorus of the Tides, scry 1. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)
+Oracle:Flying\nHeroic — Whenever you cast a spell that targets Chorus of the Tides, scry 1. (To scry 1, look at the top card of your library, then you may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/c/cloudreader_sphinx.txt
+++ b/forge-gui/res/cardsfolder/c/cloudreader_sphinx.txt
@@ -3,6 +3,6 @@ ManaCost:4 U
 Types:Creature Sphinx
 PT:3/4
 K:Flying
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 2
-Oracle:Flying\nWhen Cloudreader Sphinx enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:Flying\nWhen Cloudreader Sphinx enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/c/condescend.txt
+++ b/forge-gui/res/cardsfolder/c/condescend.txt
@@ -1,7 +1,7 @@
 Name:Condescend
 ManaCost:X U
 Types:Instant
-A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | UnlessCost$ X | SubAbility$ DBScry | SpellDescription$ Counter target spell unless its controller pays {X}. Scry 2.
+A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | UnlessCost$ X | SubAbility$ DBScry | SpellDescription$ Counter target spell unless its controller pays {X}. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:DBScry:DB$ Scry | ScryNum$ 2
 SVar:X:Count$xPaid
-Oracle:Counter target spell unless its controller pays {X}. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:Counter target spell unless its controller pays {X}. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/c/cruel_finality.txt
+++ b/forge-gui/res/cardsfolder/c/cruel_finality.txt
@@ -1,6 +1,6 @@
 Name:Cruel Finality
 ManaCost:2 B
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | NumAtt$ -2 | NumDef$ -2 | IsCurse$ True | SubAbility$ DBScry | SpellDescription$ Target creature gets -2/-2 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+A:SP$ Pump | ValidTgts$ Creature | NumAtt$ -2 | NumDef$ -2 | IsCurse$ True | SubAbility$ DBScry | SpellDescription$ Target creature gets -2/-2 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
-Oracle:Target creature gets -2/-2 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Target creature gets -2/-2 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/c/crystal_ball.txt
+++ b/forge-gui/res/cardsfolder/c/crystal_ball.txt
@@ -1,5 +1,5 @@
 Name:Crystal Ball
 ManaCost:3
 Types:Artifact
-A:AB$ Scry | Cost$ 1 T | ScryNum$ 2 | SpellDescription$ Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
-Oracle:{1}, {T}: Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+A:AB$ Scry | Cost$ 1 T | ScryNum$ 2 | SpellDescription$ Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
+Oracle:{1}, {T}: Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/c/crystal_grotto.txt
+++ b/forge-gui/res/cardsfolder/c/crystal_grotto.txt
@@ -1,8 +1,8 @@
 Name:Crystal Grotto
 ManaCost:no cost
 Types:Land
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 1.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 1
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 A:AB$ Mana | Cost$ 1 T | Produced$ Any | SpellDescription$ Add one mana of any color.
-Oracle:When Crystal Grotto enters, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {C}.\n{1}, {T}: Add one mana of any color.
+Oracle:When Crystal Grotto enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {C}.\n{1}, {T}: Add one mana of any color.

--- a/forge-gui/res/cardsfolder/d/darksteel_pendant.txt
+++ b/forge-gui/res/cardsfolder/d/darksteel_pendant.txt
@@ -2,5 +2,5 @@ Name:Darksteel Pendant
 ManaCost:2
 Types:Artifact
 K:Indestructible
-A:AB$ Scry | Cost$ 1 T | ScryNum$ 1 | SpellDescription$ Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
-Oracle:Indestructible (Effects that say "destroy" don't destroy this artifact.)\n{1}, {T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+A:AB$ Scry | Cost$ 1 T | ScryNum$ 1 | SpellDescription$ Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+Oracle:Indestructible (Effects that say "destroy" don't destroy this artifact.)\n{1}, {T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/d/devout_decree.txt
+++ b/forge-gui/res/cardsfolder/d/devout_decree.txt
@@ -1,7 +1,7 @@
 Name:Devout Decree
 ManaCost:1 W
 Types:Sorcery
-A:SP$ ChangeZone | ValidTgts$ Creature.Black,Planeswalker.Red,Creature.Red,Planeswalker.Black | TgtPrompt$ Select target creature or planeswalker that's black or red | Origin$ Battlefield | Destination$ Exile | SubAbility$ DBScry | SpellDescription$ Exile target creature or planeswalker that's black or red. Scry 1.
+A:SP$ ChangeZone | ValidTgts$ Creature.Black,Planeswalker.Red,Creature.Red,Planeswalker.Black | TgtPrompt$ Select target creature or planeswalker that's black or red | Origin$ Battlefield | Destination$ Exile | SubAbility$ DBScry | SpellDescription$ Exile target creature or planeswalker that's black or red. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
 AI:RemoveDeck:All
-Oracle:Exile target creature or planeswalker that's black or red. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Exile target creature or planeswalker that's black or red. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/d/dissolve.txt
+++ b/forge-gui/res/cardsfolder/d/dissolve.txt
@@ -1,6 +1,6 @@
 Name:Dissolve
 ManaCost:1 U U
 Types:Instant
-A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | SubAbility$ DBScry | Destination$ Graveyard | SpellDescription$ Counter target spell. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | SubAbility$ DBScry | Destination$ Graveyard | SpellDescription$ Counter target spell. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
-Oracle:Counter target spell. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Counter target spell. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/d/drown_in_sorrow.txt
+++ b/forge-gui/res/cardsfolder/d/drown_in_sorrow.txt
@@ -1,6 +1,6 @@
 Name:Drown in Sorrow
 ManaCost:1 B B
 Types:Sorcery
-A:SP$ PumpAll | ValidCards$ Creature | NumAtt$ -2 | NumDef$ -2 | IsCurse$ True | SubAbility$ DBScry | SpellDescription$ All creatures get -2/-2 until end of turn. Scry 1.
+A:SP$ PumpAll | ValidCards$ Creature | NumAtt$ -2 | NumDef$ -2 | IsCurse$ True | SubAbility$ DBScry | SpellDescription$ All creatures get -2/-2 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
-Oracle:All creatures get -2/-2 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:All creatures get -2/-2 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/e/eager_construct.txt
+++ b/forge-gui/res/cardsfolder/e/eager_construct.txt
@@ -2,6 +2,6 @@ Name:Eager Construct
 ManaCost:2
 Types:Artifact Creature Construct
 PT:2/2
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ DBScry | TriggerDescription$ When CARDNAME enters, each player may scry 1. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ DBScry | TriggerDescription$ When CARDNAME enters, each player may scry 1. (To scry 1, look at the top card of your library, then you may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1 | Defined$ Player | Optional$ True
-Oracle:When Eager Construct enters, each player may scry 1. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)
+Oracle:When Eager Construct enters, each player may scry 1. (To scry 1, look at the top card of your library, then you may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/e/eyes_of_the_watcher.txt
+++ b/forge-gui/res/cardsfolder/e/eyes_of_the_watcher.txt
@@ -1,7 +1,7 @@
 Name:Eyes of the Watcher
 ManaCost:2 U
 Types:Enchantment
-T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | Execute$ TrigScry | OptionalDecider$ You | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast an instant or sorcery spell, you may pay {1}. If you do, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | Execute$ TrigScry | OptionalDecider$ You | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast an instant or sorcery spell, you may pay {1}. If you do, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:TrigScry:AB$ Scry | Cost$ 1 | ScryNum$ 2
 AI:RemoveDeck:All
-Oracle:Whenever you cast an instant or sorcery spell, you may pay {1}. If you do, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:Whenever you cast an instant or sorcery spell, you may pay {1}. If you do, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/f/fading_hope.txt
+++ b/forge-gui/res/cardsfolder/f/fading_hope.txt
@@ -1,6 +1,6 @@
 Name:Fading Hope
 ManaCost:U
 Types:Instant
-A:SP$ ChangeZone | ValidTgts$ Creature | Origin$ Battlefield | Destination$ Hand | SubAbility$ DBScry | SpellDescription$ Return target creature to its owner's hand. If its mana value was 3 or less, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+A:SP$ ChangeZone | ValidTgts$ Creature | Origin$ Battlefield | Destination$ Hand | SubAbility$ DBScry | SpellDescription$ Return target creature to its owner's hand. If its mana value was 3 or less, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ConditionDefined$ Targeted | ConditionPresent$ Card.cmcLE3 | ConditionCompare$ EQ1 | ScryNum$ 1
-Oracle:Return target creature to its owner's hand. If its mana value was 3 or less, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Return target creature to its owner's hand. If its mana value was 3 or less, scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/f/fated_conflagration.txt
+++ b/forge-gui/res/cardsfolder/f/fated_conflagration.txt
@@ -1,6 +1,6 @@
 Name:Fated Conflagration
 ManaCost:1 R R R
 Types:Instant
-A:SP$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ 5 | SubAbility$ DBScry | SpellDescription$ CARDNAME deals 5 damage to target creature or planeswalker. If it's your turn, scry 2.
+A:SP$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ 5 | SubAbility$ DBScry | SpellDescription$ CARDNAME deals 5 damage to target creature or planeswalker. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:DBScry:DB$ Scry | ScryNum$ 2 | ConditionPlayerTurn$ True
-Oracle:Fated Conflagration deals 5 damage to target creature or planeswalker. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:Fated Conflagration deals 5 damage to target creature or planeswalker. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/f/fated_infatuation.txt
+++ b/forge-gui/res/cardsfolder/f/fated_infatuation.txt
@@ -1,6 +1,6 @@
 Name:Fated Infatuation
 ManaCost:U U U
 Types:Instant
-A:SP$ CopyPermanent | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | SubAbility$ DBScry | SpellDescription$ Create a token that's a copy of target creature you control. If it's your turn, scry 2.
+A:SP$ CopyPermanent | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | SubAbility$ DBScry | SpellDescription$ Create a token that's a copy of target creature you control. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:DBScry:DB$ Scry | ScryNum$ 2 | ConditionPlayerTurn$ True
-Oracle:Create a token that's a copy of target creature you control. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:Create a token that's a copy of target creature you control. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/f/fated_intervention.txt
+++ b/forge-gui/res/cardsfolder/f/fated_intervention.txt
@@ -1,6 +1,6 @@
 Name:Fated Intervention
 ManaCost:2 G G G
 Types:Instant
-A:SP$ Token | TokenAmount$ 2 | TokenScript$ g_3_3_e_centaur | SubAbility$ DBScry | SpellDescription$ Create two 3/3 green Centaur enchantment creature tokens. If it's your turn, scry 2.
+A:SP$ Token | TokenAmount$ 2 | TokenScript$ g_3_3_e_centaur | SubAbility$ DBScry | SpellDescription$ Create two 3/3 green Centaur enchantment creature tokens. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:DBScry:DB$ Scry | ScryNum$ 2 | ConditionPlayerTurn$ True
-Oracle:Create two 3/3 green Centaur enchantment creature tokens. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:Create two 3/3 green Centaur enchantment creature tokens. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/f/fated_retribution.txt
+++ b/forge-gui/res/cardsfolder/f/fated_retribution.txt
@@ -1,6 +1,6 @@
 Name:Fated Retribution
 ManaCost:4 W W W
 Types:Instant
-A:SP$ DestroyAll | ValidCards$ Creature,Planeswalker | SubAbility$ DBScry | SpellDescription$ Destroy all creatures and planeswalkers. If it's your turn, scry 2.
+A:SP$ DestroyAll | ValidCards$ Creature,Planeswalker | SubAbility$ DBScry | SpellDescription$ Destroy all creatures and planeswalkers. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:DBScry:DB$ Scry | ScryNum$ 2 | ConditionPlayerTurn$ True
-Oracle:Destroy all creatures and planeswalkers. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:Destroy all creatures and planeswalkers. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/f/fated_return.txt
+++ b/forge-gui/res/cardsfolder/f/fated_return.txt
@@ -1,7 +1,7 @@
 Name:Fated Return
 ManaCost:4 B B B
 Types:Instant
-A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | GainControl$ True | TgtPrompt$ Choose target creature card in a graveyard | ValidTgts$ Creature | SubAbility$ DBPump | SpellDescription$ Put target creature card from a graveyard onto the battlefield under your control. It gains indestructible. If it's your turn, scry 2.
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Battlefield | GainControl$ True | TgtPrompt$ Choose target creature card in a graveyard | ValidTgts$ Creature | SubAbility$ DBPump | SpellDescription$ Put target creature card from a graveyard onto the battlefield under your control. It gains indestructible. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:DBPump:DB$ Pump | Defined$ ParentTarget | KW$ Indestructible | Duration$ Permanent | SubAbility$ DBScry
 SVar:DBScry:DB$ Scry | ScryNum$ 2 | ConditionPlayerTurn$ True
-Oracle:Put target creature card from a graveyard onto the battlefield under your control. It gains indestructible. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:Put target creature card from a graveyard onto the battlefield under your control. It gains indestructible. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/f/ferocious_charge.txt
+++ b/forge-gui/res/cardsfolder/f/ferocious_charge.txt
@@ -1,6 +1,6 @@
 Name:Ferocious Charge
 ManaCost:2 G
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | NumAtt$ +4 | NumDef$ +4 | SubAbility$ DBScry | SpellDescription$ Target creature gets +4/+4 until end of turn. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+A:SP$ Pump | ValidTgts$ Creature | NumAtt$ +4 | NumDef$ +4 | SubAbility$ DBScry | SpellDescription$ Target creature gets +4/+4 until end of turn. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:DBScry:DB$ Scry | ScryNum$ 2
-Oracle:Target creature gets +4/+4 until end of turn. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:Target creature gets +4/+4 until end of turn. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/f/fill_with_fright.txt
+++ b/forge-gui/res/cardsfolder/f/fill_with_fright.txt
@@ -2,5 +2,5 @@ Name:Fill with Fright
 ManaCost:3 B
 Types:Sorcery
 A:SP$ Discard | ValidTgts$ Player | TgtPrompt$ Select a player | Mode$ TgtChoose | NumCards$ 2 | SubAbility$ DBScry | SpellDescription$ Target player discards two cards.
-SVar:DBScry:DB$ Scry | ScryNum$ 2 | SpellDescription$ Scry 2.
-Oracle:Target player discards two cards. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+SVar:DBScry:DB$ Scry | ScryNum$ 2 | SpellDescription$ Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
+Oracle:Target player discards two cards. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/f/fleshtaker.txt
+++ b/forge-gui/res/cardsfolder/f/fleshtaker.txt
@@ -2,9 +2,9 @@ Name:Fleshtaker
 ManaCost:W B
 Types:Creature Human Assassin
 PT:2/2
-T:Mode$ Sacrificed | ValidCard$ Creature.Other | Execute$ TrigGainLife | TriggerZones$ Battlefield | ValidPlayer$ You | TriggerDescription$ Whenever you sacrifice another creature, you gain 1 life and scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+T:Mode$ Sacrificed | ValidCard$ Creature.Other | Execute$ TrigGainLife | TriggerZones$ Battlefield | ValidPlayer$ You | TriggerDescription$ Whenever you sacrifice another creature, you gain 1 life and scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:TrigGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1 | SubAbility$ DBScry
 SVar:DBScry:DB$ Scry | ScryNum$ 1
 A:AB$ Pump | Cost$ 1 Sac<1/Creature.Other/another creature> | Defined$ Self | NumAtt$ +2 | NumDef$ +2 | SpellDescription$ CARDNAME gets +2/+2 until end of turn.
 DeckHas:Ability$Sacrifice|LifeGain
-Oracle:Whenever you sacrifice another creature, you gain 1 life and scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{1}, Sacrifice another creature: Fleshtaker gets +2/+2 until end of turn.
+Oracle:Whenever you sacrifice another creature, you gain 1 life and scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{1}, Sacrifice another creature: Fleshtaker gets +2/+2 until end of turn.

--- a/forge-gui/res/cardsfolder/f/furious_bellow.txt
+++ b/forge-gui/res/cardsfolder/f/furious_bellow.txt
@@ -1,6 +1,6 @@
 Name:Furious Bellow
 ManaCost:1 R
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | NumAtt$ +3 | KW$ First Strike | SubAbility$ DBScry | SpellDescription$ Target creature gets +3/+0 and gains first strike until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+A:SP$ Pump | ValidTgts$ Creature | NumAtt$ +3 | KW$ First Strike | SubAbility$ DBScry | SpellDescription$ Target creature gets +3/+0 and gains first strike until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry
-Oracle:Target creature gets +3/+0 and gains first strike until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Target creature gets +3/+0 and gains first strike until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/g/geist_of_the_archives.txt
+++ b/forge-gui/res/cardsfolder/g/geist_of_the_archives.txt
@@ -3,6 +3,6 @@ ManaCost:2 U
 Types:Creature Spirit
 PT:0/4
 K:Defender
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigScry | TriggerDescription$ At the beginning of your upkeep, scry 1.
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigScry | TriggerDescription$ At the beginning of your upkeep, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 1
-Oracle:Defender\nAt the beginning of your upkeep, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Defender\nAt the beginning of your upkeep, scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/g/glimpse_the_sun_god.txt
+++ b/forge-gui/res/cardsfolder/g/glimpse_the_sun_god.txt
@@ -1,7 +1,7 @@
 Name:Glimpse the Sun God
 ManaCost:X W
 Types:Instant
-A:SP$ Tap | ValidTgts$ Creature | TgtPrompt$ Select X target creatures | TargetMin$ X | TargetMax$ X | SubAbility$ DBScry | SpellDescription$ Tap X target creatures. Scry 1.
+A:SP$ Tap | ValidTgts$ Creature | TgtPrompt$ Select X target creatures | TargetMin$ X | TargetMax$ X | SubAbility$ DBScry | SpellDescription$ Tap X target creatures. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
 SVar:X:Count$xPaid
-Oracle:Tap X target creatures. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Tap X target creatures. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/g/goggles_of_night.txt
+++ b/forge-gui/res/cardsfolder/g/goggles_of_night.txt
@@ -1,8 +1,8 @@
 Name:Goggles of Night
 ManaCost:1 U
 Types:Artifact Equipment
-T:Mode$ DamageDone | ValidSource$ Creature.EquippedBy | ValidTarget$ Player | CombatDamage$ True | Execute$ DBScry | TriggerZones$ Battlefield | TriggerDescription$ Whenever equipped creature deals combat damage to a player, scry 1, then draw a card. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)
+T:Mode$ DamageDone | ValidSource$ Creature.EquippedBy | ValidTarget$ Player | CombatDamage$ True | Execute$ DBScry | TriggerZones$ Battlefield | TriggerDescription$ Whenever equipped creature deals combat damage to a player, scry 1, then draw a card. (To scry 1, look at the top card of your library, then you may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1 | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1
 K:Equip:2
-Oracle:Whenever equipped creature deals combat damage to a player, scry 1, then draw a card. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)
+Oracle:Whenever equipped creature deals combat damage to a player, scry 1, then draw a card. (To scry 1, look at the top card of your library, then you may put that card on the bottom.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)

--- a/forge-gui/res/cardsfolder/g/guiding_bolt.txt
+++ b/forge-gui/res/cardsfolder/g/guiding_bolt.txt
@@ -2,5 +2,5 @@ Name:Guiding Bolt
 ManaCost:2 W
 Types:Instant
 A:SP$ Destroy | ValidTgts$ Creature.powerGE4 | SubAbility$ DBScry | TgtPrompt$ Select target creature with power 4 or greater | SpellDescription$ Destroy target creature with power 4 or greater.
-SVar:DBScry:DB$ Scry | ScryNum$ 2 | SpellDescription$ Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
-Oracle:Destroy target creature with power 4 or greater.\nScry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+SVar:DBScry:DB$ Scry | ScryNum$ 2 | SpellDescription$ Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
+Oracle:Destroy target creature with power 4 or greater.\nScry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/h/horizon_scholar.txt
+++ b/forge-gui/res/cardsfolder/h/horizon_scholar.txt
@@ -3,6 +3,6 @@ ManaCost:5 U
 Types:Creature Sphinx
 PT:4/4
 K:Flying
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 2
-Oracle:Flying\nWhen Horizon Scholar enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:Flying\nWhen Horizon Scholar enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/i/impede_momentum.txt
+++ b/forge-gui/res/cardsfolder/i/impede_momentum.txt
@@ -3,6 +3,6 @@ ManaCost:1 U
 Types:Sorcery
 A:SP$ Tap | ValidTgts$ Creature | SubAbility$ DBCounter | SpellDescription$ Tap target creature and put three stun counters on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)
 SVar:DBCounter:DB$ PutCounter | Defined$ Targeted | CounterType$ Stun | CounterNum$ 3 | SubAbility$ DBScry
-SVar:DBScry:DB$ Scry | ScryNum$ 1 | SpellDescription$ Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+SVar:DBScry:DB$ Scry | ScryNum$ 1 | SpellDescription$ Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 DeckHints:Ability$Counters
-Oracle:Tap target creature and put three stun counters on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nScry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Tap target creature and put three stun counters on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nScry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/j/jaces_sanctum.txt
+++ b/forge-gui/res/cardsfolder/j/jaces_sanctum.txt
@@ -2,7 +2,7 @@ Name:Jace's Sanctum
 ManaCost:3 U
 Types:Enchantment
 S:Mode$ ReduceCost | ValidCard$ Instant,Sorcery | Type$ Spell | Activator$ You | Amount$ 1 | Description$ Instant and sorcery spells you cast cost {1} less to cast.
-T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ DBScry | TriggerDescription$ Whenever you cast a instant or sorcery spell, scry 1.
+T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ DBScry | TriggerDescription$ Whenever you cast a instant or sorcery spell, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
 DeckHints:Type$Instant|Sorcery
-Oracle:Instant and sorcery spells you cast cost {1} less to cast.\nWhenever you cast an instant or sorcery spell, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Instant and sorcery spells you cast cost {1} less to cast.\nWhenever you cast an instant or sorcery spell, scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/j/jayas_firenado.txt
+++ b/forge-gui/res/cardsfolder/j/jayas_firenado.txt
@@ -1,6 +1,6 @@
 Name:Jaya's Firenado
 ManaCost:4 R
 Types:Sorcery
-A:SP$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ 5 | SubAbility$ DBScry | SpellDescription$ CARDNAME deals 5 damage to target creature or planeswalker. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+A:SP$ DealDamage | ValidTgts$ Creature,Planeswalker | TgtPrompt$ Select target creature or planeswalker | NumDmg$ 5 | SubAbility$ DBScry | SpellDescription$ CARDNAME deals 5 damage to target creature or planeswalker. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
-Oracle:Jaya's Firenado deals 5 damage to target creature or planeswalker. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Jaya's Firenado deals 5 damage to target creature or planeswalker. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/l/lapis_orb_of_dragonkind.txt
+++ b/forge-gui/res/cardsfolder/l/lapis_orb_of_dragonkind.txt
@@ -1,8 +1,8 @@
 Name:Lapis Orb of Dragonkind
 ManaCost:2 U
 Types:Artifact
-A:AB$ Mana | Cost$ T | Produced$ U | TriggersWhenSpent$ TrigSpent | SpellDescription$ Add {U}. When you spend this mana to cast a Dragon creature spell, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
-SVar:TrigSpent:Mode$ SpellCast | ValidCard$ Creature.Dragon | ValidActivatingPlayer$ You | Execute$ TrigScry | TriggerDescription$ When you spend this mana to cast a Dragon creature spell, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+A:AB$ Mana | Cost$ T | Produced$ U | TriggersWhenSpent$ TrigSpent | SpellDescription$ Add {U}. When you spend this mana to cast a Dragon creature spell, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
+SVar:TrigSpent:Mode$ SpellCast | ValidCard$ Creature.Dragon | ValidActivatingPlayer$ You | Execute$ TrigScry | TriggerDescription$ When you spend this mana to cast a Dragon creature spell, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 2
 DeckHints:Type$Dragon
-Oracle:{T}: Add {U}. When you spend this mana to cast a Dragon creature spell, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:{T}: Add {U}. When you spend this mana to cast a Dragon creature spell, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/l/lightning_javelin.txt
+++ b/forge-gui/res/cardsfolder/l/lightning_javelin.txt
@@ -1,6 +1,6 @@
 Name:Lightning Javelin
 ManaCost:3 R
 Types:Sorcery
-A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ 3 | SubAbility$ DBScry | SpellDescription$ CARDNAME deals 3 damage to any target. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ 3 | SubAbility$ DBScry | SpellDescription$ CARDNAME deals 3 damage to any target. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
-Oracle:Lightning Javelin deals 3 damage to any target. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Lightning Javelin deals 3 damage to any target. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/l/llanowar_empath.txt
+++ b/forge-gui/res/cardsfolder/l/llanowar_empath.txt
@@ -2,7 +2,7 @@ Name:Llanowar Empath
 ManaCost:3 G
 Types:Creature Elf Shaman
 PT:2/2
-T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2, then reveal the top card of your library. If it's a creature card, put it into your hand. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2, then reveal the top card of your library. If it's a creature card, put it into your hand. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 2 | SubAbility$ DBDig
 SVar:DBDig:DB$ Dig | DigNum$ 1 | Reveal$ True | ChangeNum$ All | ChangeValid$ Creature | LibraryPosition2$ 0
-Oracle:When Llanowar Empath enters, scry 2, then reveal the top card of your library. If it's a creature card, put it into your hand. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:When Llanowar Empath enters, scry 2, then reveal the top card of your library. If it's a creature card, put it into your hand. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/l/lose_hope.txt
+++ b/forge-gui/res/cardsfolder/l/lose_hope.txt
@@ -1,6 +1,6 @@
 Name:Lose Hope
 ManaCost:B
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | NumAtt$ -1 | NumDef$ -1 | IsCurse$ True | SubAbility$ DBScry | SpellDescription$ Target creature gets -1/-1 until end of turn. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+A:SP$ Pump | ValidTgts$ Creature | NumAtt$ -1 | NumDef$ -1 | IsCurse$ True | SubAbility$ DBScry | SpellDescription$ Target creature gets -1/-1 until end of turn. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:DBScry:DB$ Scry | ScryNum$ 2
-Oracle:Target creature gets -1/-1 until end of turn. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:Target creature gets -1/-1 until end of turn. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/l/lost_in_a_labyrinth.txt
+++ b/forge-gui/res/cardsfolder/l/lost_in_a_labyrinth.txt
@@ -1,6 +1,6 @@
 Name:Lost in a Labyrinth
 ManaCost:U
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | NumAtt$ -3 | IsCurse$ True | SubAbility$ DBScry | SpellDescription$ Target creature gets -3/-0 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+A:SP$ Pump | ValidTgts$ Creature | NumAtt$ -3 | IsCurse$ True | SubAbility$ DBScry | SpellDescription$ Target creature gets -3/-0 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
-Oracle:Target creature gets -3/-0 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Target creature gets -3/-0 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/l/lost_legion.txt
+++ b/forge-gui/res/cardsfolder/l/lost_legion.txt
@@ -2,6 +2,6 @@ Name:Lost Legion
 ManaCost:1 B B
 Types:Creature Spirit Knight
 PT:2/3
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 2
-Oracle:When Lost Legion enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:When Lost Legion enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/m/mystic_speculation.txt
+++ b/forge-gui/res/cardsfolder/m/mystic_speculation.txt
@@ -1,6 +1,6 @@
 Name:Mystic Speculation
 ManaCost:U
 Types:Sorcery
-A:SP$ Scry | ScryNum$ 3 | SpellDescription$ Scry 3. (Look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+A:SP$ Scry | ScryNum$ 3 | SpellDescription$ Scry 3. (Look at the top three cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 K:Buyback:2
-Oracle:Buyback {2} (You may pay an additional {2} as you cast this spell. If you do, put this card into your hand as it resolves.)\nScry 3. (Look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:Buyback {2} (You may pay an additional {2} as you cast this spell. If you do, put this card into your hand as it resolves.)\nScry 3. (Look at the top three cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/n/nefarious_imp.txt
+++ b/forge-gui/res/cardsfolder/n/nefarious_imp.txt
@@ -3,6 +3,6 @@ ManaCost:2 B
 Types:Creature Imp
 PT:2/1
 K:Flying
-T:Mode$ ChangesZoneAll | ValidCards$ Permanent.YouCtrl | Origin$ Battlefield | TriggerZones$ Battlefield | Execute$ TrigScry | TriggerDescription$ Whenever one or more permanents you control leave the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+T:Mode$ ChangesZoneAll | ValidCards$ Permanent.YouCtrl | Origin$ Battlefield | TriggerZones$ Battlefield | Execute$ TrigScry | TriggerDescription$ Whenever one or more permanents you control leave the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:TrigScry:DB$ Scry
-Oracle:Flying\nWhenever one or more permanents you control leave the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Flying\nWhenever one or more permanents you control leave the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/n/new_benalia.txt
+++ b/forge-gui/res/cardsfolder/n/new_benalia.txt
@@ -4,6 +4,6 @@ Types:Land
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 A:AB$ Mana | Cost$ T | Produced$ W | SpellDescription$ Add {W}.
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 1.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 1
-Oracle:New Benalia enters tapped.\nWhen New Benalia enters, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {W}.
+Oracle:New Benalia enters tapped.\nWhen New Benalia enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {W}.

--- a/forge-gui/res/cardsfolder/o/octoprophet.txt
+++ b/forge-gui/res/cardsfolder/o/octoprophet.txt
@@ -2,6 +2,6 @@ Name:Octoprophet
 ManaCost:3 U
 Types:Creature Octopus
 PT:3/3
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 2
-Oracle:When Octoprophet enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:When Octoprophet enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/o/omenspeaker.txt
+++ b/forge-gui/res/cardsfolder/o/omenspeaker.txt
@@ -2,6 +2,6 @@ Name:Omenspeaker
 ManaCost:1 U
 Types:Creature Human Wizard
 PT:1/3
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 2
-Oracle:When Omenspeaker enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:When Omenspeaker enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/o/oracles_insight.txt
+++ b/forge-gui/res/cardsfolder/o/oracles_insight.txt
@@ -3,8 +3,8 @@ ManaCost:3 U
 Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAILogic:Pump
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddAbility$ ABScry | AddSVar$ OraclesInsightDraw | Description$ Enchanted creature has "{T}: Scry 1, then draw a card."
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddAbility$ ABScry | AddSVar$ OraclesInsightDraw | Description$ Enchanted creature has "{T}: Scry 1, then draw a card." (To scry 1, look at the top card of your library, then you may put that card on the bottom.)
 SVar:ABScry:AB$ Scry | Cost$ T | ScryNum$ 1 | SubAbility$ OraclesInsightDraw | SpellDescription$ Scry 1, then draw a card.
 SVar:OraclesInsightDraw:DB$ Draw
 SVar:NonStackingAttachEffect:True
-Oracle:Enchant creature\nEnchanted creature has "{T}: Scry 1, then draw a card." (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)
+Oracle:Enchant creature\nEnchanted creature has "{T}: Scry 1, then draw a card." (To scry 1, look at the top card of your library, then you may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/o/overwhelmed_apprentice.txt
+++ b/forge-gui/res/cardsfolder/o/overwhelmed_apprentice.txt
@@ -2,7 +2,7 @@ Name:Overwhelmed Apprentice
 ManaCost:U
 Types:Creature Human Wizard
 PT:1/2
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigMill | TriggerDescription$ When CARDNAME enters, each opponent mills two cards. Then you scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigMill | TriggerDescription$ When CARDNAME enters, each opponent mills two cards. Then you scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:TrigMill:DB$ Mill | Defined$ Player.Opponent | NumCards$ 2 | SubAbility$ DBScry
 SVar:DBScry:DB$ Scry | ScryNum$ 2
-Oracle:When Overwhelmed Apprentice enters, each opponent mills two cards. Then you scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:When Overwhelmed Apprentice enters, each opponent mills two cards. Then you scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/p/packs_betrayal.txt
+++ b/forge-gui/res/cardsfolder/p/packs_betrayal.txt
@@ -1,8 +1,8 @@
 Name:Pack's Betrayal
 ManaCost:2 R
 Types:Sorcery
-A:SP$ GainControl | ValidTgts$ Creature | LoseControl$ EOT | Untap$ True | AddKWs$ Haste | SubAbility$ DBScry | SpellDescription$ Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. If you control a Wolf or Werewolf, scry 2.
-SVar:DBScry:DB$ Scry | ScryNum$ 2 | ConditionPresent$ Wolf.YouCtrl,Werewolf.YouCtrl | StackDescription$ If you control a Wolf or Werewolf, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+A:SP$ GainControl | ValidTgts$ Creature | LoseControl$ EOT | Untap$ True | AddKWs$ Haste | SubAbility$ DBScry | SpellDescription$ Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. If you control a Wolf or Werewolf, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
+SVar:DBScry:DB$ Scry | ScryNum$ 2 | ConditionPresent$ Wolf.YouCtrl,Werewolf.YouCtrl | StackDescription$ If you control a Wolf or Werewolf, scry 2.
 SVar:PlayMain1:ALWAYS
 DeckHints:Type$Wolf|Werewolf
-Oracle:Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. If you control a Wolf or Werewolf, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. If you control a Wolf or Werewolf, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/p/path_of_ancestry.txt
+++ b/forge-gui/res/cardsfolder/p/path_of_ancestry.txt
@@ -3,8 +3,8 @@ ManaCost:no cost
 Types:Land
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
-A:AB$ Mana | Cost$ T | Produced$ Combo ColorIdentity | TriggersWhenSpent$ TrigScry | SpellDescription$ Add one mana of any color in your commander's color identity. When that mana is spent to cast a creature spell that shares a creature type with your commander, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+A:AB$ Mana | Cost$ T | Produced$ Combo ColorIdentity | TriggersWhenSpent$ TrigScry | SpellDescription$ Add one mana of any color in your commander's color identity. When that mana is spent to cast a creature spell that shares a creature type with your commander, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:TrigScry:Mode$ SpellCast | ValidCard$ Creature.sharesCreatureTypeWith Commander | Execute$ DBScry | TriggerDescription$ When mana produced by CARDNAME is spent to cast a creature spell that shares a creature type with your commander, scry 1.
 SVar:DBScry:DB$ Scry | ScryNum$ 1
 AI:RemoveDeck:NonCommander
-Oracle:Path of Ancestry enters tapped.\n{T}: Add one mana of any color in your commander's color identity. When that mana is spent to cast a creature spell that shares a creature type with your commander, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Path of Ancestry enters tapped.\n{T}: Add one mana of any color in your commander's color identity. When that mana is spent to cast a creature spell that shares a creature type with your commander, scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/p/path_to_the_festival.txt
+++ b/forge-gui/res/cardsfolder/p/path_to_the_festival.txt
@@ -1,9 +1,9 @@
 Name:Path to the Festival
 ManaCost:2 G
 Types:Sorcery
-A:SP$ ChangeZone | Origin$ Library | Destination$ Battlefield | Tapped$ True | ChangeType$ Land.Basic | ChangeTypeDesc$ basic land | RememberChanged$ True | SubAbility$ DBScry | StackDescription$ SpellDescription | SpellDescription$ Search your library for a basic land card, put it onto the battlefield tapped, then shuffle. Then if there are three or more basic land types among lands you control, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+A:SP$ ChangeZone | Origin$ Library | Destination$ Battlefield | Tapped$ True | ChangeType$ Land.Basic | ChangeTypeDesc$ basic land | RememberChanged$ True | SubAbility$ DBScry | StackDescription$ SpellDescription | SpellDescription$ Search your library for a basic land card, put it onto the battlefield tapped, then shuffle. Then if there are three or more basic land types among lands you control, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ConditionCheckSVar$ X | ConditionSVarCompare$ GE3 | ScryNum$ 1
 SVar:X:PlayerCountPropertyYou$DomainPlayer
 K:Flashback:4 G
 DeckHas:Ability$Graveyard
-Oracle:Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle. Then if there are three or more basic land types among lands you control, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\nFlashback {4}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)
+Oracle:Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle. Then if there are three or more basic land types among lands you control, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\nFlashback {4}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)

--- a/forge-gui/res/cardsfolder/p/peregrination.txt
+++ b/forge-gui/res/cardsfolder/p/peregrination.txt
@@ -1,9 +1,9 @@
 Name:Peregrination
 ManaCost:3 G
 Types:Sorcery
-A:SP$ ChangeZone | Origin$ Library | Destination$ Library | ChangeType$ Land.Basic | ChangeTypeDesc$ basic land | ChangeNum$ 2 | RememberChanged$ True | Reveal$ True | Shuffle$ False | StackDescription$ SpellDescription | SubAbility$ DBChangeZone1 | SpellDescription$ Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Shuffle, then scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+A:SP$ ChangeZone | Origin$ Library | Destination$ Library | ChangeType$ Land.Basic | ChangeTypeDesc$ basic land | ChangeNum$ 2 | RememberChanged$ True | Reveal$ True | Shuffle$ False | StackDescription$ SpellDescription | SubAbility$ DBChangeZone1 | SpellDescription$ Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Shuffle, then scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBChangeZone1:DB$ ChangeZone | Origin$ Library | Destination$ Battlefield | ChangeType$ Land.IsRemembered | ChangeNum$ 1 | Mandatory$ True | NoLooking$ True | SelectPrompt$ Select a card to put onto the battlefield | Tapped$ True | Shuffle$ False | SubAbility$ DBChangeZone2 | StackDescription$ None
 SVar:DBChangeZone2:DB$ ChangeZone | Origin$ Library | Destination$ Hand | ChangeType$ Land.IsRemembered | Mandatory$ True | NoLooking$ True | SelectPrompt$ Select a card to put into your hand | StackDescription$ None | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | SubAbility$ DBScry
 SVar:DBScry:DB$ Scry | ScryNum$ 1 | StackDescription$ None
-Oracle:Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Shuffle, then scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Shuffle, then scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/p/phyrexian_vivisector.txt
+++ b/forge-gui/res/cardsfolder/p/phyrexian_vivisector.txt
@@ -2,7 +2,7 @@ Name:Phyrexian Vivisector
 ManaCost:1 B
 Types:Creature Phyrexian Human
 PT:2/2
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.YouCtrl | Execute$ TrigScry | TriggerDescription$ Whenever a creature you control dies, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.YouCtrl | Execute$ TrigScry | TriggerDescription$ Whenever a creature you control dies, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:TrigScry:DB$ Scry
 DeckHints:Ability$Sacrifice
-Oracle:Whenever a creature you control dies, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Whenever a creature you control dies, scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/p/portent_of_betrayal.txt
+++ b/forge-gui/res/cardsfolder/p/portent_of_betrayal.txt
@@ -1,6 +1,6 @@
 Name:Portent of Betrayal
 ManaCost:3 R
 Types:Sorcery
-A:SP$ GainControl | ValidTgts$ Creature | LoseControl$ EOT | Untap$ True | AddKWs$ Haste | SubAbility$ DBScry | SpellDescription$ Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Scry 1.
+A:SP$ GainControl | ValidTgts$ Creature | LoseControl$ EOT | Untap$ True | AddKWs$ Haste | SubAbility$ DBScry | SpellDescription$ Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
-Oracle:Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/p/preordain.txt
+++ b/forge-gui/res/cardsfolder/p/preordain.txt
@@ -1,6 +1,6 @@
 Name:Preordain
 ManaCost:U
 Types:Sorcery
-A:SP$ Scry | ScryNum$ 2 | SpellDescription$ Scry 2, then draw a card. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.) | SubAbility$ DBDraw
+A:SP$ Scry | ScryNum$ 2 | SubAbility$ DBDraw | SpellDescription$ Scry 2, then draw a card. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:DBDraw:DB$ Draw
-Oracle:Scry 2, then draw a card. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:Scry 2, then draw a card. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/p/prescient_chimera.txt
+++ b/forge-gui/res/cardsfolder/p/prescient_chimera.txt
@@ -3,6 +3,6 @@ ManaCost:3 U U
 Types:Creature Chimera
 PT:3/4
 K:Flying
-T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigScry | TriggerDescription$ Whenever you cast an instant or sorcery spell, scry 1.
+T:Mode$ SpellCast | ValidCard$ Instant,Sorcery | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigScry | TriggerDescription$ Whenever you cast an instant or sorcery spell, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 1
-Oracle:Flying\nWhenever you cast an instant or sorcery spell, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Flying\nWhenever you cast an instant or sorcery spell, scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/p/prism_array.txt
+++ b/forge-gui/res/cardsfolder/p/prism_array.txt
@@ -4,6 +4,6 @@ Types:Enchantment
 K:etbCounter:CRYSTAL:X:no Condition:Converge — CARDNAME enters with a crystal counter on it for each color spent to cast it.
 SVar:X:Count$Converge
 A:AB$ Tap | Cost$ SubCounter<1/CRYSTAL> | ValidTgts$ Creature | SpellDescription$ Tap target creature.
-A:AB$ Scry | Cost$ W U B R G | ScryNum$ 3 | SpellDescription$ Scry 3. (Look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+A:AB$ Scry | Cost$ W U B R G | ScryNum$ 3 | SpellDescription$ Scry 3. (Look at the top three cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 AI:RemoveDeck:All
-Oracle:Converge — Prism Array enters with a crystal counter on it for each color of mana spent to cast it.\nRemove a crystal counter from Prism Array: Tap target creature.\n{W}{U}{B}{R}{G}: Scry 3. (Look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:Converge — Prism Array enters with a crystal counter on it for each color of mana spent to cast it.\nRemove a crystal counter from Prism Array: Tap target creature.\n{W}{U}{B}{R}{G}: Scry 3. (Look at the top three cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/p/prophet_of_the_peak.txt
+++ b/forge-gui/res/cardsfolder/p/prophet_of_the_peak.txt
@@ -2,6 +2,6 @@ Name:Prophet of the Peak
 ManaCost:6
 Types:Artifact Creature Cat
 PT:5/5
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 2
-Oracle:When Prophet of the Peak enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:When Prophet of the Peak enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/p/putrid_cyclops.txt
+++ b/forge-gui/res/cardsfolder/p/putrid_cyclops.txt
@@ -2,10 +2,10 @@ Name:Putrid Cyclops
 ManaCost:2 B
 Types:Creature Zombie Cyclops
 PT:3/3
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSrcy | TriggerDescription$ When CARDNAME enters, scry 1, then reveal the top card of your library. CARDNAME gets -X/-X until end of turn, where X is that card's mana value. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSrcy | TriggerDescription$ When CARDNAME enters, scry 1, then reveal the top card of your library. CARDNAME gets -X/-X until end of turn, where X is that card's mana value. (To scry 1, look at the top card of your library, then you may put that card on the bottom.)
 SVar:TrigSrcy:DB$ Scry | ScryNum$ 1 | SubAbility$ DBReveal
 SVar:DBReveal:DB$ Dig | DigNum$ 1 | Reveal$ True | DestinationZone$ Library | LibraryPosition$ 0 | SubAbility$ DBPump
 SVar:DBPump:DB$ Pump | Defined$ TriggeredCard | NumAtt$ -X | NumDef$ -X
 SVar:X:Count$TopOfLibraryCMC
 AI:RemoveDeck:All
-Oracle:When Putrid Cyclops enters, scry 1, then reveal the top card of your library. Putrid Cyclops gets -X/-X until end of turn, where X is that card's mana value. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)
+Oracle:When Putrid Cyclops enters, scry 1, then reveal the top card of your library. Putrid Cyclops gets -X/-X until end of turn, where X is that card's mana value. (To scry 1, look at the top card of your library, then you may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/q/quicksilver_sea.txt
+++ b/forge-gui/res/cardsfolder/q/quicksilver_sea.txt
@@ -1,12 +1,12 @@
 Name:Quicksilver Sea
 ManaCost:no cost
 Types:Plane Mirrodin
-T:Mode$ PlaneswalkedTo | ValidCard$ Card.Self | Execute$ QuicksilverScry | TriggerDescription$ When you planeswalk to CARDNAME or at the beginning of your upkeep, scry 4. (Look at the top four cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ QuicksilverScry | TriggerZones$ Command | Secondary$ True | TriggerDescription$ When you planeswalk to CARDNAME or at the beginning of your upkeep, scry 4. (Look at the top four cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+T:Mode$ PlaneswalkedTo | ValidCard$ Card.Self | Execute$ QuicksilverScry | TriggerDescription$ When you planeswalk to CARDNAME or at the beginning of your upkeep, scry 4. (Look at the top four cards of your library, then put any number of them on the bottom and the rest on top in any order.)
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | Execute$ QuicksilverScry | TriggerZones$ Command | Secondary$ True | TriggerDescription$ When you planeswalk to CARDNAME or at the beginning of your upkeep, scry 4. (Look at the top four cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:QuicksilverScry:DB$ Scry | ScryNum$ 4
 T:Mode$ ChaosEnsues | TriggerZones$ Command | Execute$ RolledChaos | TriggerDescription$ Whenever chaos ensues, reveal the top card of your library. You may play it without paying its mana cost.
 SVar:RolledChaos:DB$ PeekAndReveal | RememberRevealed$ True | SubAbility$ DBPlay
 SVar:DBPlay:DB$ Play | Defined$ Remembered | Controller$ You | WithoutManaCost$ True | Optional$ True | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:AIRollPlanarDieParams:Mode$ Always
-Oracle:When you planeswalk to Quicksilver Sea or at the beginning of your upkeep, scry 4. (Look at the top four cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)\nWhenever chaos ensues, reveal the top card of your library. You may play it without paying its mana cost.
+Oracle:When you planeswalk to Quicksilver Sea or at the beginning of your upkeep, scry 4. (Look at the top four cards of your library, then put any number of them on the bottom and the rest on top in any order.)\nWhenever chaos ensues, reveal the top card of your library. You may play it without paying its mana cost.

--- a/forge-gui/res/cardsfolder/r/rage_of_purphoros.txt
+++ b/forge-gui/res/cardsfolder/r/rage_of_purphoros.txt
@@ -1,8 +1,8 @@
 Name:Rage of Purphoros
 ManaCost:4 R
 Types:Sorcery
-A:SP$ DealDamage | ValidTgts$ Creature | NumDmg$ 4 | SubAbility$ DBPump | SpellDescription$ CARDNAME deals 4 damage to target creature. It can't be regenerated this turn. Scry 1.
+A:SP$ DealDamage | ValidTgts$ Creature | NumDmg$ 4 | SubAbility$ DBPump | SpellDescription$ CARDNAME deals 4 damage to target creature. It can't be regenerated this turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBPump:DB$ Effect | RememberObjects$ ParentTarget | ForgetOnMoved$ Battlefield | StaticAbilities$ NoRegen | IsCurse$ True | SubAbility$ DBScry | AILogic$ CantRegenerate
 SVar:NoRegen:Mode$ CantRegenerate | ValidCard$ Card.IsRemembered | Description$ Creature can't be regenerated this turn.
 SVar:DBScry:DB$ Scry | ScryNum$ 1
-Oracle:Rage of Purphoros deals 4 damage to target creature. It can't be regenerated this turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Rage of Purphoros deals 4 damage to target creature. It can't be regenerated this turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/r/reaper_of_the_wilds.txt
+++ b/forge-gui/res/cardsfolder/r/reaper_of_the_wilds.txt
@@ -2,8 +2,8 @@ Name:Reaper of the Wilds
 ManaCost:2 B G
 Types:Creature Gorgon
 PT:4/5
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.Other | TriggerZones$ Battlefield | Execute$ TrigScry | TriggerDescription$ Whenever another creature dies, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature.Other | TriggerZones$ Battlefield | Execute$ TrigScry | TriggerDescription$ Whenever another creature dies, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 1
 A:AB$ Pump | Cost$ B | KW$ Deathtouch | Defined$ Self | SpellDescription$ CARDNAME gains deathtouch until end of turn.
 A:AB$ Pump | Cost$ 1 G | KW$ Hexproof | Defined$ Self | SpellDescription$ CARDNAME gains hexproof until end of turn.
-Oracle:Whenever another creature dies, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{B}: Reaper of the Wilds gains deathtouch until end of turn.\n{1}{G}: Reaper of the Wilds gains hexproof until end of turn.
+Oracle:Whenever another creature dies, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{B}: Reaper of the Wilds gains deathtouch until end of turn.\n{1}{G}: Reaper of the Wilds gains hexproof until end of turn.

--- a/forge-gui/res/cardsfolder/r/retreat_to_coralhelm.txt
+++ b/forge-gui/res/cardsfolder/r/retreat_to_coralhelm.txt
@@ -4,5 +4,5 @@ Types:Enchantment
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | TriggerZones$ Battlefield | ValidCard$ Land.YouCtrl | Execute$ TrigCharm | TriggerDescription$ Landfall — Whenever a land you control enters, ABILITY
 SVar:TrigCharm:DB$ Charm | Choices$ DBTapOrUntap,DBScry
 SVar:DBTapOrUntap:DB$ TapOrUntap | ValidTgts$ Creature | SpellDescription$ You may tap or untap target creature.
-SVar:DBScry:DB$ Scry | ScryNum$ 1 | SpellDescription$ Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
-Oracle:Landfall — Whenever a land you control enters, choose one —\n• You may tap or untap target creature.\n• Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+SVar:DBScry:DB$ Scry | ScryNum$ 1 | SpellDescription$ Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+Oracle:Landfall — Whenever a land you control enters, choose one —\n• You may tap or untap target creature.\n• Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/r/riddleform.txt
+++ b/forge-gui/res/cardsfolder/r/riddleform.txt
@@ -3,6 +3,6 @@ ManaCost:1 U
 Types:Enchantment
 T:Mode$ SpellCast | ValidCard$ Card.nonCreature | ValidActivatingPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigAnimate | OptionalDecider$ You | TriggerDescription$ Whenever you cast a noncreature spell, you may have CARDNAME become a 3/3 Sphinx creature with flying in addition to its other types until end of turn.
 SVar:TrigAnimate:DB$ Animate | Defined$ Self | Power$ 3 | Toughness$ 3 | Types$ Creature,Sphinx | Keywords$ Flying
-A:AB$ Scry | Cost$ 2 U | ScryNum$ 1 | SpellDescription$ Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+A:AB$ Scry | Cost$ 2 U | ScryNum$ 1 | SpellDescription$ Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:BuffedBy:Card.nonCreature+nonLand
-Oracle:Whenever you cast a noncreature spell, you may have Riddleform become a 3/3 Sphinx creature with flying in addition to its other types until end of turn.\n{2}{U}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Whenever you cast a noncreature spell, you may have Riddleform become a 3/3 Sphinx creature with flying in addition to its other types until end of turn.\n{2}{U}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/r/rise_of_eagles.txt
+++ b/forge-gui/res/cardsfolder/r/rise_of_eagles.txt
@@ -1,6 +1,6 @@
 Name:Rise of Eagles
 ManaCost:4 U U
 Types:Sorcery
-A:SP$ Token | TokenAmount$ 2 | TokenScript$ u_2_2_e_bird_flying | TokenOwner$ You | SubAbility$ DBScry | SpellDescription$ Create two 2/2 blue Bird enchantment creature tokens with flying. Scry 1.
+A:SP$ Token | TokenAmount$ 2 | TokenScript$ u_2_2_e_bird_flying | TokenOwner$ You | SubAbility$ DBScry | SpellDescription$ Create two 2/2 blue Bird enchantment creature tokens with flying. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
-Oracle:Create two 2/2 blue Bird enchantment creature tokens with flying. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Create two 2/2 blue Bird enchantment creature tokens with flying. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/s/samite_herbalist.txt
+++ b/forge-gui/res/cardsfolder/s/samite_herbalist.txt
@@ -2,8 +2,8 @@ Name:Samite Herbalist
 ManaCost:1 W
 Types:Creature Human Cleric
 PT:2/1
-T:Mode$ Taps | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigGainLife | TriggerDescription$ Whenever CARDNAME becomes tapped, you gain 1 life and scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+T:Mode$ Taps | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigGainLife | TriggerDescription$ Whenever CARDNAME becomes tapped, you gain 1 life and scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:TrigGainLife:DB$ GainLife | LifeAmount$ 1 | SubAbility$ DBScry
 SVar:DBScry:DB$ Scry | ScryNum$ 1
 DeckHas:Ability$LifeGain
-Oracle:Whenever Samite Herbalist becomes tapped, you gain 1 life and scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Whenever Samite Herbalist becomes tapped, you gain 1 life and scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/s/scouring_sands.txt
+++ b/forge-gui/res/cardsfolder/s/scouring_sands.txt
@@ -2,5 +2,5 @@ Name:Scouring Sands
 ManaCost:1 R
 Types:Sorcery
 A:SP$ DamageAll | ValidCards$ Creature.OppCtrl | ValidDescription$ each creature your opponents control | NumDmg$ 1 | SubAbility$ DBScry | SpellDescription$ CARDNAME deals 1 damage to each creature your opponents control.
-SVar:DBScry:DB$ Scry | ScryNum$ 1 | SpellDescription$ Scry 1.
-Oracle:Scouring Sands deals 1 damage to each creature your opponents control. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+SVar:DBScry:DB$ Scry | ScryNum$ 1 | SpellDescription$ Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+Oracle:Scouring Sands deals 1 damage to each creature your opponents control. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/s/sea_gods_revenge.txt
+++ b/forge-gui/res/cardsfolder/s/sea_gods_revenge.txt
@@ -1,6 +1,6 @@
 Name:Sea God's Revenge
 ManaCost:5 U
 Types:Sorcery
-A:SP$ ChangeZone | TargetMin$ 0 | TargetMax$ 3 | ValidTgts$ Creature.OppCtrl | Origin$ Battlefield | Destination$ Hand | SubAbility$ DBScry | SpellDescription$ Return up to three target creatures your opponents control to their owners' hands. Scry 1.
+A:SP$ ChangeZone | TargetMin$ 0 | TargetMax$ 3 | ValidTgts$ Creature.OppCtrl | Origin$ Battlefield | Destination$ Hand | SubAbility$ DBScry | SpellDescription$ Return up to three target creatures your opponents control to their owners' hands. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
-Oracle:Return up to three target creatures your opponents control to their owners' hands. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Return up to three target creatures your opponents control to their owners' hands. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/s/season_of_growth.txt
+++ b/forge-gui/res/cardsfolder/s/season_of_growth.txt
@@ -1,8 +1,8 @@
 Name:Season of Growth
 ManaCost:1 G
 Types:Enchantment
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigScry | TriggerDescription$ Whenever a creature you control enters, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigScry | TriggerDescription$ Whenever a creature you control enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 1
 T:Mode$ SpellCast | ValidCard$ Card.YouCtrl | ValidActivatingPlayer$ You | TargetsValid$ Creature.YouCtrl+inZoneBattlefield | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ Whenever you cast a spell that targets a creature you control, draw a card.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1
-Oracle:Whenever a creature you control enters, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\nWhenever you cast a spell that targets a creature you control, draw a card.
+Oracle:Whenever a creature you control enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\nWhenever you cast a spell that targets a creature you control, draw a card.

--- a/forge-gui/res/cardsfolder/s/seers_lantern.txt
+++ b/forge-gui/res/cardsfolder/s/seers_lantern.txt
@@ -2,6 +2,6 @@ Name:Seer's Lantern
 ManaCost:3
 Types:Artifact
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
-A:AB$ Scry | Cost$ 2 T | ScryNum$ 1 | SpellDescription$ Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+A:AB$ Scry | Cost$ 2 T | ScryNum$ 1 | SpellDescription$ Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 DeckHas:Ability$Mana.Colorless
-Oracle:{T}: Add {C}.\n{2}, {T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:{T}: Add {C}.\n{2}, {T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/s/select_for_inspection.txt
+++ b/forge-gui/res/cardsfolder/s/select_for_inspection.txt
@@ -1,6 +1,6 @@
 Name:Select for Inspection
 ManaCost:U
 Types:Instant
-A:SP$ ChangeZone | ValidTgts$ Creature.tapped | TgtPrompt$ Select target tapped creature | Origin$ Battlefield | Destination$ Hand | SubAbility$ DBScry | SpellDescription$ Return target tapped creature to its owner's hand. Scry 1.
+A:SP$ ChangeZone | ValidTgts$ Creature.tapped | TgtPrompt$ Select target tapped creature | Origin$ Battlefield | Destination$ Hand | SubAbility$ DBScry | SpellDescription$ Return target tapped creature to its owner's hand. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
-Oracle:Return target tapped creature to its owner's hand. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Return target tapped creature to its owner's hand. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/s/sentinel_totem.txt
+++ b/forge-gui/res/cardsfolder/s/sentinel_totem.txt
@@ -1,7 +1,7 @@
 Name:Sentinel Totem
 ManaCost:1
 Types:Artifact
-T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 1.
+T:Mode$ ChangesZone | ValidCard$ Card.Self | Origin$ Any | Destination$ Battlefield | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 1
 A:AB$ ChangeZoneAll | Cost$ T Exile<1/CARDNAME> | Origin$ Graveyard | Destination$ Exile | ChangeType$ Card | AILogic$ ExileGraveyards | SpellDescription$ Exile all graveyards.
-Oracle:When Sentinel Totem enters, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}, Exile Sentinel Totem: Exile all graveyards.
+Oracle:When Sentinel Totem enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}, Exile Sentinel Totem: Exile all graveyards.

--- a/forge-gui/res/cardsfolder/s/shadows_of_the_past.txt
+++ b/forge-gui/res/cardsfolder/s/shadows_of_the_past.txt
@@ -1,8 +1,8 @@
 Name:Shadows of the Past
 ManaCost:1 B
 Types:Enchantment
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature | TriggerZones$ Battlefield | Execute$ TrigScry | TriggerDescription$ Whenever a creature dies, scry 1.
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Creature | TriggerZones$ Battlefield | Execute$ TrigScry | TriggerDescription$ Whenever a creature dies, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 1
 A:AB$ LoseLife | Cost$ 4 B | Defined$ Player.Opponent | LifeAmount$ 2 | IsPresent$ Creature.YouOwn | PresentZone$ Graveyard | PresentCompare$ GE4 | SubAbility$ DBGainLife | SpellDescription$ Each opponent loses 2 life and you gain 2 life. Activate only if there are four or more creature cards in your graveyard.
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 2
-Oracle:Whenever a creature dies, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{4}{B}: Each opponent loses 2 life and you gain 2 life. Activate only if there are four or more creature cards in your graveyard.
+Oracle:Whenever a creature dies, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{4}{B}: Each opponent loses 2 life and you gain 2 life. Activate only if there are four or more creature cards in your graveyard.

--- a/forge-gui/res/cardsfolder/s/sigiled_skink.txt
+++ b/forge-gui/res/cardsfolder/s/sigiled_skink.txt
@@ -2,7 +2,7 @@ Name:Sigiled Skink
 ManaCost:1 R
 Types:Creature Lizard
 PT:2/1
-T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ DBScry | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME attacks, scry 1.
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ DBScry | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME attacks, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
 SVar:HasAttackEffect:TRUE
-Oracle:Whenever Sigiled Skink attacks, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Whenever Sigiled Skink attacks, scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/s/sigiled_starfish.txt
+++ b/forge-gui/res/cardsfolder/s/sigiled_starfish.txt
@@ -2,5 +2,5 @@ Name:Sigiled Starfish
 ManaCost:1 U
 Types:Creature Starfish
 PT:0/3
-A:AB$ Scry | Cost$ T | ScryNum$ 1 | SpellDescription$ Scry 1.
-Oracle:{T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+A:AB$ Scry | Cost$ T | ScryNum$ 1 | SpellDescription$ Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+Oracle:{T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/s/silver_raven.txt
+++ b/forge-gui/res/cardsfolder/s/silver_raven.txt
@@ -3,6 +3,6 @@ ManaCost:U
 Types:Artifact Creature Bird
 PT:1/1
 K:Flying
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 1
-Oracle:Flying\nWhen Silver Raven enters, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Flying\nWhen Silver Raven enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/s/simulacrum_synthesizer.txt
+++ b/forge-gui/res/cardsfolder/s/simulacrum_synthesizer.txt
@@ -1,7 +1,7 @@
 Name:Simulacrum Synthesizer
 ManaCost:2 U
 Types:Artifact
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2.
 SVar:TrigScry:DB$ Scry | ScryNum$ 2
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Artifact.YouCtrl+cmcGE3+Other | Execute$ TrigToken | TriggerZones$ Battlefield | TriggerDescription$ Whenever another artifact you control with mana value 3 or greater enters, create a 0/0 colorless Construct artifact creature token with "This creature gets +1/+1 for each artifact you control."
 SVar:TrigToken:DB$ Token | TokenScript$ c_0_0_a_construct_total_artifacts

--- a/forge-gui/res/cardsfolder/s/skywhalers_shot.txt
+++ b/forge-gui/res/cardsfolder/s/skywhalers_shot.txt
@@ -1,6 +1,6 @@
 Name:Skywhaler's Shot
 ManaCost:2 W
 Types:Instant
-A:SP$ Destroy | ValidTgts$ Creature.powerGE3 | TgtPrompt$ Select target creature with power 3 or greater | SubAbility$ DBScry | SpellDescription$ Destroy target creature with power 3 or greater. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+A:SP$ Destroy | ValidTgts$ Creature.powerGE3 | TgtPrompt$ Select target creature with power 3 or greater | SubAbility$ DBScry | SpellDescription$ Destroy target creature with power 3 or greater. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
-Oracle:Destroy target creature with power 3 or greater. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Destroy target creature with power 3 or greater. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/s/spark_jolt.txt
+++ b/forge-gui/res/cardsfolder/s/spark_jolt.txt
@@ -1,6 +1,6 @@
 Name:Spark Jolt
 ManaCost:R
 Types:Instant
-A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to any target. Scry 1. | SubAbility$ DBScry
+A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ 1 | SubAbility$ DBScry | SpellDescription$ CARDNAME deals 1 damage to any target. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
-Oracle:Spark Jolt deals 1 damage to any target. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Spark Jolt deals 1 damage to any target. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/s/spined_megalodon.txt
+++ b/forge-gui/res/cardsfolder/s/spined_megalodon.txt
@@ -3,6 +3,6 @@ ManaCost:5 U U
 Types:Creature Shark
 PT:5/7
 K:Hexproof
-T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ DBScry | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME attacks, scry 1.
+T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ DBScry | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME attacks, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
-Oracle:Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nWhenever Spined Megalodon attacks, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nWhenever Spined Megalodon attacks, scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/s/spite_of_mogis.txt
+++ b/forge-gui/res/cardsfolder/s/spite_of_mogis.txt
@@ -1,7 +1,7 @@
 Name:Spite of Mogis
 ManaCost:R
 Types:Sorcery
-A:SP$ DealDamage | ValidTgts$ Creature | NumDmg$ X | SubAbility$ DBScry | SpellDescription$ CARDNAME deals damage to target creature equal to the number of instant and sorcery cards in your graveyard. Scry 1.
+A:SP$ DealDamage | ValidTgts$ Creature | NumDmg$ X | SubAbility$ DBScry | SpellDescription$ CARDNAME deals damage to target creature equal to the number of instant and sorcery cards in your graveyard. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
 SVar:X:Count$ValidGraveyard Instant.YouOwn,Sorcery.YouOwn
-Oracle:Spite of Mogis deals damage to target creature equal to the number of instant and sorcery cards in your graveyard. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Spite of Mogis deals damage to target creature equal to the number of instant and sorcery cards in your graveyard. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/s/stand_firm.txt
+++ b/forge-gui/res/cardsfolder/s/stand_firm.txt
@@ -1,6 +1,6 @@
 Name:Stand Firm
 ManaCost:W
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DBScry | SpellDescription$ Target creature gets +1/+1 until end of turn. Scry 2 (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+A:SP$ Pump | ValidTgts$ Creature | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DBScry | SpellDescription$ Target creature gets +1/+1 until end of turn. Scry 2 (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:DBScry:DB$ Scry | ScryNum$ 2
-Oracle:Target creature gets +1/+1 until end of turn. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:Target creature gets +1/+1 until end of turn. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/s/stitched_assistant.txt
+++ b/forge-gui/res/cardsfolder/s/stitched_assistant.txt
@@ -3,8 +3,8 @@ ManaCost:2 U
 Types:Creature Zombie
 PT:3/2
 K:Exploit
-T:Mode$ Exploited | ValidCard$ Creature | ValidSource$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigScry | TriggerDescription$ When CARDNAME exploits a creature, scry 1, then draw a card. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)
+T:Mode$ Exploited | ValidCard$ Creature | ValidSource$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigScry | TriggerDescription$ When CARDNAME exploits a creature, scry 1, then draw a card. (To scry 1, look at the top card of your library, then you may put that card on the bottom.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 1 | SubAbility$ DBDraw
 SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1
 DeckHas:Ability$Sacrifice
-Oracle:Exploit (When this creature enters, you may sacrifice a creature.)\nWhen Stitched Assistant exploits a creature, scry 1, then draw a card. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)
+Oracle:Exploit (When this creature enters, you may sacrifice a creature.)\nWhen Stitched Assistant exploits a creature, scry 1, then draw a card. (To scry 1, look at the top card of your library, then you may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/s/stormcaller_of_keranos.txt
+++ b/forge-gui/res/cardsfolder/s/stormcaller_of_keranos.txt
@@ -3,5 +3,5 @@ ManaCost:2 R
 Types:Creature Human Shaman
 PT:2/2
 K:Haste
-A:AB$ Scry | Cost$ 1 U | ScryNum$ 1 | SpellDescription$ Scry 1. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)
-Oracle:Haste\n{1}{U}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+A:AB$ Scry | Cost$ 1 U | ScryNum$ 1 | SpellDescription$ Scry 1. (To scry 1, look at the top card of your library, then you may put that card on the bottom.)
+Oracle:Haste\n{1}{U}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/s/stormchaser_chimera.txt
+++ b/forge-gui/res/cardsfolder/s/stormchaser_chimera.txt
@@ -3,8 +3,8 @@ ManaCost:2 U R
 Types:Creature Chimera
 PT:2/3
 K:Flying
-A:AB$ Scry | Cost$ 2 U R | ScryNum$ 1 | SubAbility$ DBReveal | SpellDescription$ Scry 1, then reveal the top card of your library. CARDNAME gets +X/+0 until end of turn, where X is that card's mana value.
+A:AB$ Scry | Cost$ 2 U R | ScryNum$ 1 | SubAbility$ DBReveal | SpellDescription$ Scry 1, then reveal the top card of your library. CARDNAME gets +X/+0 until end of turn, where X is that card's mana value. (To scry 1, look at the top card of your library, then you may put that card on the bottom.)
 SVar:DBReveal:DB$ PeekAndReveal | PeekAmount$ 1 | NoPeek$ True | SubAbility$ DBPump
 SVar:DBPump:DB$ Pump | NumAtt$ +X
 SVar:X:Count$TopOfLibraryCMC
-Oracle:Flying\n{2}{U}{R}: Scry 1, then reveal the top card of your library. Stormchaser Chimera gets +X/+0 until end of turn, where X is that card's mana value. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)
+Oracle:Flying\n{2}{U}{R}: Scry 1, then reveal the top card of your library. Stormchaser Chimera gets +X/+0 until end of turn, where X is that card's mana value. (To scry 1, look at the top card of your library, then you may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/s/stymied_hopes.txt
+++ b/forge-gui/res/cardsfolder/s/stymied_hopes.txt
@@ -1,6 +1,6 @@
 Name:Stymied Hopes
 ManaCost:1 U
 Types:Instant
-A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | UnlessCost$ 1 | SubAbility$ DBScry | SpellDescription$ Counter target spell unless its controller pays {1}. Scry 1.
+A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell | ValidTgts$ Card | UnlessCost$ 1 | SubAbility$ DBScry | SpellDescription$ Counter target spell unless its controller pays {1}. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
-Oracle:Counter target spell unless its controller pays {1}. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Counter target spell unless its controller pays {1}. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/s/sudden_storm.txt
+++ b/forge-gui/res/cardsfolder/s/sudden_storm.txt
@@ -1,7 +1,7 @@
 Name:Sudden Storm
 ManaCost:3 U
 Types:Instant
-A:SP$ Tap | TargetMin$ 0 | TargetMax$ 2 | ValidTgts$ Creature | SubAbility$ TrigPump | SpellDescription$ Tap up to two target creatures. Those creatures don't untap during their controller's next untap steps. Scry 1.
+A:SP$ Tap | TargetMin$ 0 | TargetMax$ 2 | ValidTgts$ Creature | SubAbility$ TrigPump | SpellDescription$ Tap up to two target creatures. Those creatures don't untap during their controller's next untap steps. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:TrigPump:DB$ Pump | Defined$ Targeted | KW$ HIDDEN This card doesn't untap during your next untap step. | Duration$ Permanent | SubAbility$ DBScry
 SVar:DBScry:DB$ Scry | ScryNum$ 1
-Oracle:Tap up to two target creatures. Those creatures don't untap during their controllers' next untap steps. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Tap up to two target creatures. Those creatures don't untap during their controllers' next untap steps. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/s/sylvan_anthem.txt
+++ b/forge-gui/res/cardsfolder/s/sylvan_anthem.txt
@@ -2,6 +2,6 @@ Name:Sylvan Anthem
 ManaCost:G G
 Types:Enchantment
 S:Mode$ Continuous | Affected$ Creature.Green+YouCtrl | AddPower$ 1 | AddToughness$ 1 | Description$ Green creatures you control get +1/+1.
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.Green+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigScry | TriggerDescription$ Whenever a green creature you control enters, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Creature.Green+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigScry | TriggerDescription$ Whenever a green creature you control enters, scry 1.
 SVar:TrigScry:DB$ Scry | ScryNum$ 1
 Oracle:Green creatures you control get +1/+1.\nWhenever a green creature you control enters, scry 1.

--- a/forge-gui/res/cardsfolder/t/tel_jilad_justice.txt
+++ b/forge-gui/res/cardsfolder/t/tel_jilad_justice.txt
@@ -1,6 +1,6 @@
 Name:Tel-Jilad Justice
 ManaCost:1 G
 Types:Instant
-A:SP$ Destroy | ValidTgts$ Artifact | SubAbility$ DBScry | SpellDescription$ Destroy target artifact. Scry 2 (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+A:SP$ Destroy | ValidTgts$ Artifact | SubAbility$ DBScry | SpellDescription$ Destroy target artifact. Scry 2 (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:DBScry:DB$ Scry | ScryNum$ 2
-Oracle:Destroy target artifact. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:Destroy target artifact. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/t/temple_of_abandon.txt
+++ b/forge-gui/res/cardsfolder/t/temple_of_abandon.txt
@@ -3,7 +3,7 @@ ManaCost:no cost
 Types:Land
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 1.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 1
 A:AB$ Mana | Cost$ T | Produced$ Combo R G | SpellDescription$ Add {R} or {G}.
-Oracle:Temple of Abandon enters tapped.\nWhen Temple of Abandon enters, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {R} or {G}.
+Oracle:Temple of Abandon enters tapped.\nWhen Temple of Abandon enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {R} or {G}.

--- a/forge-gui/res/cardsfolder/t/temple_of_deceit.txt
+++ b/forge-gui/res/cardsfolder/t/temple_of_deceit.txt
@@ -3,7 +3,7 @@ ManaCost:no cost
 Types:Land
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 1.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 1
 A:AB$ Mana | Cost$ T | Produced$ Combo U B | SpellDescription$ Add {U} or {B}.
-Oracle:Temple of Deceit enters tapped.\nWhen Temple of Deceit enters, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {U} or {B}.
+Oracle:Temple of Deceit enters tapped.\nWhen Temple of Deceit enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {U} or {B}.

--- a/forge-gui/res/cardsfolder/t/temple_of_enlightenment.txt
+++ b/forge-gui/res/cardsfolder/t/temple_of_enlightenment.txt
@@ -3,7 +3,7 @@ ManaCost:no cost
 Types:Land
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 1.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 1
 A:AB$ Mana | Cost$ T | Produced$ Combo W U | SpellDescription$ Add {W} or {U}.
-Oracle:Temple of Enlightenment enters tapped.\nWhen Temple of Enlightenment enters, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {W} or {U}.
+Oracle:Temple of Enlightenment enters tapped.\nWhen Temple of Enlightenment enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {W} or {U}.

--- a/forge-gui/res/cardsfolder/t/temple_of_malice.txt
+++ b/forge-gui/res/cardsfolder/t/temple_of_malice.txt
@@ -3,7 +3,7 @@ ManaCost:no cost
 Types:Land
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 1.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 1
 A:AB$ Mana | Cost$ T | Produced$ Combo B R | SpellDescription$ Add {B} or {R}.
-Oracle:Temple of Malice enters tapped.\nWhen Temple of Malice enters, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {B} or {R}.
+Oracle:Temple of Malice enters tapped.\nWhen Temple of Malice enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {B} or {R}.

--- a/forge-gui/res/cardsfolder/t/temple_of_plenty.txt
+++ b/forge-gui/res/cardsfolder/t/temple_of_plenty.txt
@@ -3,7 +3,7 @@ ManaCost:no cost
 Types:Land
 R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ ETBTapped | Description$ CARDNAME enters tapped.
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 1.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 1
 A:AB$ Mana | Cost$ T | Produced$ Combo G W | SpellDescription$ Add {G} or {W}.
-Oracle:Temple of Plenty enters tapped.\nWhen Temple of Plenty enters, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {G} or {W}.
+Oracle:Temple of Plenty enters tapped.\nWhen Temple of Plenty enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {G} or {W}.

--- a/forge-gui/res/cardsfolder/t/tidepool_turtle.txt
+++ b/forge-gui/res/cardsfolder/t/tidepool_turtle.txt
@@ -2,5 +2,5 @@ Name:Tidepool Turtle
 ManaCost:3 U
 Types:Creature Turtle
 PT:2/5
-A:AB$ Scry | Cost$ 2 U | ScryNum$ 1 | SpellDescription$ Scry 1.(Look at the top card of your library. You may put that card on the bottom of your library.)
-Oracle:{2}{U}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+A:AB$ Scry | Cost$ 2 U | ScryNum$ 1 | SpellDescription$ Scry 1.(Look at the top card of your library. You may put that card on the bottom.)
+Oracle:{2}{U}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/t/titans_strength.txt
+++ b/forge-gui/res/cardsfolder/t/titans_strength.txt
@@ -1,6 +1,6 @@
 Name:Titan's Strength
 ManaCost:R
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | NumAtt$ +3 | NumDef$ +1 | SpellDescription$ Target creature gets +3/+1 until end of turn. Scry 1. | SubAbility$ DBScry
+A:SP$ Pump | ValidTgts$ Creature | NumAtt$ +3 | NumDef$ +1 | SubAbility$ DBScry | SpellDescription$ Target creature gets +3/+1 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
-Oracle:Target creature gets +3/+1 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Target creature gets +3/+1 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/t/trelasarra_moon_dancer.txt
+++ b/forge-gui/res/cardsfolder/t/trelasarra_moon_dancer.txt
@@ -2,9 +2,9 @@ Name:Trelasarra, Moon Dancer
 ManaCost:G W
 Types:Legendary Creature Elf Cleric
 PT:2/2
-T:Mode$ LifeGained | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Whenever you gain life, put a +1/+1 counter on CARDNAME and scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+T:Mode$ LifeGained | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPutCounter | TriggerDescription$ Whenever you gain life, put a +1/+1 counter on CARDNAME and scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:TrigPutCounter:DB$ PutCounter | Defined$ Self | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBScry
 SVar:DBScry:DB$ Scry | ScryNum$ 1
 DeckHints:Ability$LifeGain
 DeckHas:Ability$Counters
-Oracle:Whenever you gain life, put a +1/+1 counter on Trelasarra, Moon Dancer and scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Whenever you gain life, put a +1/+1 counter on Trelasarra, Moon Dancer and scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/u/unblinking_bleb.txt
+++ b/forge-gui/res/cardsfolder/u/unblinking_bleb.txt
@@ -3,6 +3,6 @@ ManaCost:3 U
 Types:Creature Illusion
 PT:1/3
 K:Morph:2 U
-T:Mode$ TurnFaceUp | ValidCard$ Card.Self,Permanent | Execute$ TrigScry | OptionalDecider$ You | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME or another permanent is turned face up, you may scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+T:Mode$ TurnFaceUp | ValidCard$ Card.Self,Permanent | Execute$ TrigScry | OptionalDecider$ You | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME or another permanent is turned face up, you may scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 2
-Oracle:Morph {2}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhenever Unblinking Bleb or another permanent is turned face up, you may scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:Morph {2}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhenever Unblinking Bleb or another permanent is turned face up, you may scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/v/vanquish_the_foul.txt
+++ b/forge-gui/res/cardsfolder/v/vanquish_the_foul.txt
@@ -1,6 +1,6 @@
 Name:Vanquish the Foul
 ManaCost:5 W
 Types:Sorcery
-A:SP$ Destroy | ValidTgts$ Creature.powerGE4 | TgtPrompt$ Select target creature with power 4 or greater | SubAbility$ DBScry | SpellDescription$ Destroy target creature with power 4 or greater. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+A:SP$ Destroy | ValidTgts$ Creature.powerGE4 | TgtPrompt$ Select target creature with power 4 or greater | SubAbility$ DBScry | SpellDescription$ Destroy target creature with power 4 or greater. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
-Oracle:Destroy target creature with power 4 or greater. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Destroy target creature with power 4 or greater. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/v/viscera_seer.txt
+++ b/forge-gui/res/cardsfolder/v/viscera_seer.txt
@@ -2,6 +2,6 @@ Name:Viscera Seer
 ManaCost:B
 Types:Creature Vampire Wizard
 PT:1/1
-A:AB$ Scry | Cost$ Sac<1/Creature> | ScryNum$ 1 | SpellDescription$ Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+A:AB$ Scry | Cost$ Sac<1/Creature> | ScryNum$ 1 | SpellDescription$ Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 AI:RemoveDeck:All
-Oracle:Sacrifice a creature: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Sacrifice a creature: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/v/voyages_end.txt
+++ b/forge-gui/res/cardsfolder/v/voyages_end.txt
@@ -1,6 +1,6 @@
 Name:Voyage's End
 ManaCost:1 U
 Types:Instant
-A:SP$ ChangeZone | ValidTgts$ Creature | Origin$ Battlefield | Destination$ Hand | SubAbility$ DBScry | SpellDescription$ Return target creature to its owner's hand. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+A:SP$ ChangeZone | ValidTgts$ Creature | Origin$ Battlefield | Destination$ Hand | SubAbility$ DBScry | SpellDescription$ Return target creature to its owner's hand. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:DBScry:DB$ Scry | ScryNum$ 1
-Oracle:Return target creature to its owner's hand. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Return target creature to its owner's hand. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/w/wall_of_runes.txt
+++ b/forge-gui/res/cardsfolder/w/wall_of_runes.txt
@@ -3,6 +3,6 @@ ManaCost:U
 Types:Creature Wall
 PT:0/4
 K:Defender
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 1
-Oracle:Defender (This creature can't attack.)\nWhen Wall of Runes enters, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+Oracle:Defender (This creature can't attack.)\nWhen Wall of Runes enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/w/watchful_automaton.txt
+++ b/forge-gui/res/cardsfolder/w/watchful_automaton.txt
@@ -2,5 +2,5 @@ Name:Watchful Automaton
 ManaCost:3
 Types:Artifact Creature Construct
 PT:2/2
-A:AB$ Scry | Cost$ 2 U | ScryNum$ 1 | SpellDescription$ Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
-Oracle:{2}{U}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+A:AB$ Scry | Cost$ 2 U | ScryNum$ 1 | SpellDescription$ Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+Oracle:{2}{U}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)

--- a/forge-gui/res/cardsfolder/w/willow_wind.txt
+++ b/forge-gui/res/cardsfolder/w/willow_wind.txt
@@ -3,6 +3,6 @@ ManaCost:4 U
 Types:Creature Elemental
 PT:3/4
 K:Flying
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2.
 SVar:TrigScry:DB$ Scry | ScryNum$ 2
 Oracle:Flying\nWhen Willow-Wind enters, scry 2.

--- a/forge-gui/res/cardsfolder/w/windrider_patrol.txt
+++ b/forge-gui/res/cardsfolder/w/windrider_patrol.txt
@@ -3,6 +3,6 @@ ManaCost:3 U U
 Types:Creature Merfolk Wizard
 PT:4/3
 K:Flying
-T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigScry | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | CombatDamage$ True | Execute$ TrigScry | TriggerZones$ Battlefield | TriggerDescription$ Whenever CARDNAME deals combat damage to a player, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 2
-Oracle:Flying\nWhenever Windrider Patrol deals combat damage to a player, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+Oracle:Flying\nWhenever Windrider Patrol deals combat damage to a player, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)

--- a/forge-gui/res/cardsfolder/w/witches_eye.txt
+++ b/forge-gui/res/cardsfolder/w/witches_eye.txt
@@ -2,6 +2,6 @@ Name:Witches' Eye
 ManaCost:1
 Types:Artifact Equipment
 K:Equip:1
-S:Mode$ Continuous | Affected$ Card.EquippedBy | AddAbility$ WitchScry | Description$ Equipped creature has "{1}, {T}: Scry 1."
+S:Mode$ Continuous | Affected$ Card.EquippedBy | AddAbility$ WitchScry | Description$ Equipped creature has "{1}, {T}: Scry 1." (To scry 1, look at the top card of your library, then you may put that card on the bottom.)
 SVar:WitchScry:AB$ Scry | Cost$ 1 T | ScryNum$ 1 | SpellDescription$ Scry 1.
-Oracle:Equipped creature has "{1}, {T}: Scry 1." (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)\nEquip {1}
+Oracle:Equipped creature has "{1}, {T}: Scry 1." (To scry 1, look at the top card of your library, then you may put that card on the bottom.)\nEquip {1}

--- a/forge-gui/res/cardsfolder/w/witching_well.txt
+++ b/forge-gui/res/cardsfolder/w/witching_well.txt
@@ -1,7 +1,7 @@
 Name:Witching Well
 ManaCost:U
 Types:Artifact
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 2
 A:AB$ Draw | Cost$ 3 U Sac<1/CARDNAME> | NumCards$ 2 | SpellDescription$ Draw two cards.
-Oracle:When Witching Well enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)\n{3}{U}, Sacrifice Witching Well: Draw two cards.
+Oracle:When Witching Well enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)\n{3}{U}, Sacrifice Witching Well: Draw two cards.

--- a/forge-gui/res/cardsfolder/z/zhalfirin_void.txt
+++ b/forge-gui/res/cardsfolder/z/zhalfirin_void.txt
@@ -1,8 +1,8 @@
 Name:Zhalfirin Void
 ManaCost:no cost
 Types:Land
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 1.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigScry | TriggerDescription$ When CARDNAME enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
 SVar:TrigScry:DB$ Scry | ScryNum$ 1
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 DeckHas:Ability$Mana.Colorless
-Oracle:When Zhalfirin Void enters, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {C}.
+Oracle:When Zhalfirin Void enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {C}.


### PR DESCRIPTION
Following up on https://github.com/Card-Forge/forge/pull/11086 .
Updating the Scry reminder text by dropping "of your library" as seen for [Aether Theorist](https://gatherer.wizards.com/KLD/en-us/37/aether-theorist). Also adding and removing the reminder text where relevant for Description parameters with reference to Gatherer.