### PR TITLE
Avoid unsafe upkeep life-loss permanent plays

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/PermanentAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PermanentAi.java
@@ -176,12 +176,16 @@ public class PermanentAi extends SpellAbilityAi {
 
         // don't play cards without being able to pay the upkeep for
         boolean hasUpkeepCost = false;
+        int upkeepLifeLoss = 0;
         Cost upkeepCost = new Cost("0", true);
         for (Trigger t : source.getTriggers()) {
             if (!TriggerType.Phase.equals(t.getMode())) {
                 continue;
             }
             if (!"Upkeep".equals(t.getParam("Phase"))) {
+                continue;
+            }
+            if (!t.matchesValidParam("ValidPlayer", ai)) {
                 continue;
             }
             SpellAbility ab = t.ensureAbility();
@@ -195,6 +199,16 @@ public class PermanentAi extends SpellAbilityAi {
                 }
                 hasUpkeepCost = true;
                 upkeepCost.add(AbilityUtils.calculateUnlessCost(ab, ab.getParam("UnlessCost"), true));
+            } else if (ApiType.LoseLife.equals(ab.getApi()) && ab.hasParam("LifeAmount")) {
+                final Player oldActivator = ab.getActivatingPlayer();
+                ab.setActivatingPlayer(ai);
+                try {
+                    if (AbilityUtils.getDefinedPlayers(source, ab.getParamOrDefault("Defined", "You"), ab).contains(ai)) {
+                        upkeepLifeLoss += AbilityUtils.calculateAmount(source, ab.getParam("LifeAmount"), ab);
+                    }
+                } finally {
+                    ab.setActivatingPlayer(oldActivator);
+                }
             }
         }
 
@@ -208,6 +222,10 @@ public class PermanentAi extends SpellAbilityAi {
             if (!ComputerUtilCost.canPayCost(emptyAbility, ai, true)) {
                 return new AiAbilityDecision(0, AiPlayDecision.CantAfford);
             }
+        }
+        if (upkeepLifeLoss > 0 && (ai.getLife() <= upkeepLifeLoss
+                || ComputerUtil.aiLifeInDanger(ai, true, upkeepLifeLoss))) {
+            return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
         }
 
         // check for specific AI preferences


### PR DESCRIPTION
﻿## Problem

Some permanents have upkeep triggers that make their controller lose life. The AI already checks whether it can pay upkeep costs before casting a permanent, but it did not account for direct upkeep life loss in that same decision path.

This is relevant to #4305.

## Minimal Fix

- Extend the existing upkeep check in `PermanentAi` to count direct `LoseLife` upkeep triggers that fire for the AI and affect the AI.
- Decline the permanent when that upcoming life loss is lethal or when the existing serious life-danger helper says the life loss leaves the AI unsafe.
- Keep the logic generic; no card-specific Bitterblossom exception or threshold change.

## Validation

- `git diff --check`
- `JAVA_HOME=/home/rauglothgor/.local/codex-tools/jdk17 /home/rauglothgor/.local/codex-tools/apache-maven-3.9.9/bin/mvn -pl forge-ai -am -DskipTests compile`

## AI Assistance Disclosure

Substantial AI assistance was used to inspect the relevant AI path and prepare this small patch. I reviewed the resulting diff and validation output before opening the PR.

## Known Limits

This handles direct upkeep `LoseLife` abilities in the permanent AI playability check. It does not try to simulate every future upkeep sub-ability or build a broader long-term life-total planner.
