### PR TITLE
Remove The Kingpin of Crime from AI decks

### DIFF
--- a/forge-gui/res/cardsfolder/t/the_kingpin_of_crime.txt
+++ b/forge-gui/res/cardsfolder/t/the_kingpin_of_crime.txt
@@ -6,5 +6,5 @@ K:Extort
 T:Mode$ AttackersDeclared | AttackingPlayer$ You | Execute$ TrigEffect | TriggerZones$ Battlefield | TriggerDescription$ Whenever you attack, you may pay 2 life. If you do, until end of turn, creatures you control with toughness greater than their power assign combat damage equal to their toughness rather than their power.
 SVar:TrigEffect:AB$ Effect | Cost$ PayLife<2> | StaticAbilities$ CombatDamageToughness
 SVar:CombatDamageToughness:Mode$ CombatDamageToughness | ValidCard$ Creature.YouCtrl+powerLTtoughness | Description$ Until end of turn, creatures you control with toughness greater than their power assign combat damage equal to their toughness rather than their power.
-Oracle:Extort (Whenever you cast a spell, you may pay {W/B}. If you do, each opponent loses 1 life and you gain that much life.)\nWhenever you attack, you may pay 2 life. If you do, until end of turn, creatures you control with toughness greater than their power assign combat damage equal to their toughness rather than their power.
 AI:RemoveDeck:All
+Oracle:Extort (Whenever you cast a spell, you may pay {W/B}. If you do, each opponent loses 1 life and you gain that much life.)\nWhenever you attack, you may pay 2 life. If you do, until end of turn, creatures you control with toughness greater than their power assign combat damage equal to their toughness rather than their power.

--- a/forge-gui/res/cardsfolder/t/the_kingpin_of_crime.txt
+++ b/forge-gui/res/cardsfolder/t/the_kingpin_of_crime.txt
@@ -7,3 +7,4 @@ T:Mode$ AttackersDeclared | AttackingPlayer$ You | Execute$ TrigEffect | Trigger
 SVar:TrigEffect:AB$ Effect | Cost$ PayLife<2> | StaticAbilities$ CombatDamageToughness
 SVar:CombatDamageToughness:Mode$ CombatDamageToughness | ValidCard$ Creature.YouCtrl+powerLTtoughness | Description$ Until end of turn, creatures you control with toughness greater than their power assign combat damage equal to their toughness rather than their power.
 Oracle:Extort (Whenever you cast a spell, you may pay {W/B}. If you do, each opponent loses 1 life and you gain that much life.)\nWhenever you attack, you may pay 2 life. If you do, until end of turn, creatures you control with toughness greater than their power assign combat damage equal to their toughness rather than their power.
+AI:RemoveDeck:All


### PR DESCRIPTION
﻿## Problem
The Kingpin of Crime changes combat damage after attackers are already declared. The previous AI heuristic tried to pay for the trigger at that point, but that is not safe as a narrow fix because attack selection has already used the current power/toughness assumptions.

Related to #10922.

## Minimal Fix
Add `AI:RemoveDeck:All` so Forge does not include The Kingpin of Crime in AI decks until combat planning can account for this effect before attacks are chosen.

## Validation
- `git diff --check upstream/master --`
- Confirmed the PR diff is one card-script line: `AI:RemoveDeck:All`.

## Known Limits
This does not implement a general AI plan for toughness-as-combat-damage effects. It only prevents the unsupported card from being selected for AI decks.

## AI Assistance Disclosure
I used AI assistance to inspect the review feedback, revise the branch, and run validation. I reviewed the final one-line diff before updating the PR.
