### PR TITLE
Card cleanup: 2026-06-29 [Reminder text: Indestructible]

### DIFF
--- a/forge-gui/res/cardsfolder/a/accursed_horde.txt
+++ b/forge-gui/res/cardsfolder/a/accursed_horde.txt
@@ -2,6 +2,6 @@ Name:Accursed Horde
 ManaCost:3 B
 Types:Creature Zombie
 PT:3/3
-A:AB$ Pump | Cost$ 1 B | ValidTgts$ Zombie.attacking | TgtPrompt$ Select target attacking Zombie | KW$ Indestructible | SpellDescription$ Target attacking Zombie gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it. If its toughness is 0 or less, it's still put into its owner's graveyard.)
+A:AB$ Pump | Cost$ 1 B | ValidTgts$ Zombie.attacking | TgtPrompt$ Select target attacking Zombie | KW$ Indestructible | SpellDescription$ Target attacking Zombie gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it. If its toughness is 0 or less, it still dies.)
 DeckHints:Type$Zombie
-Oracle:{1}{B}: Target attacking Zombie gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it. If its toughness is 0 or less, it's still put into its owner's graveyard.)
+Oracle:{1}{B}: Target attacking Zombie gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it. If its toughness is 0 or less, it still dies.)

--- a/forge-gui/res/cardsfolder/d/darksteel_myr.txt
+++ b/forge-gui/res/cardsfolder/d/darksteel_myr.txt
@@ -3,4 +3,4 @@ ManaCost:3
 Types:Artifact Creature Myr
 PT:0/1
 K:Indestructible
-Oracle:Indestructible (Damage and effects that say "destroy" don't destroy this creature. If its toughness is 0 or less, it's still put into its owner's graveyard.)
+Oracle:Indestructible (Damage and effects that say "destroy" don't destroy this creature. If its toughness is 0 or less, it still dies.)

--- a/forge-gui/res/cardsfolder/d/darksteel_sentinel.txt
+++ b/forge-gui/res/cardsfolder/d/darksteel_sentinel.txt
@@ -5,4 +5,4 @@ PT:3/3
 K:Vigilance
 K:Indestructible
 K:Flash
-Oracle:Flash (You may cast this spell any time you could cast an instant.)\nVigilance\nIndestructible (Damage and effects that say "destroy" don't destroy this creature. If its toughness is 0 or less, it's still put into its owner's graveyard.)
+Oracle:Flash (You may cast this spell any time you could cast an instant.)\nVigilance\nIndestructible (Damage and effects that say "destroy" don't destroy this creature. If its toughness is 0 or less, it still dies.)

--- a/forge-gui/res/cardsfolder/p/pitiless_vizier.txt
+++ b/forge-gui/res/cardsfolder/p/pitiless_vizier.txt
@@ -2,6 +2,6 @@ Name:Pitiless Vizier
 ManaCost:3 B
 Types:Creature Minotaur Cleric
 PT:4/2
-T:Mode$ Discarded | ValidCard$ Card.YouOwn | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever you cycle or discard a card, CARDNAME gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it. If its toughness is 0 or less, it's still put into its owner's graveyard.)
+T:Mode$ Discarded | ValidCard$ Card.YouOwn | TriggerZones$ Battlefield | Execute$ TrigPump | TriggerDescription$ Whenever you cycle or discard a card, CARDNAME gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it. If its toughness is 0 or less, it still dies.)
 SVar:TrigPump:DB$ Pump | Defined$ Self | KW$ Indestructible
-Oracle:Whenever you cycle or discard a card, Pitiless Vizier gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it. If its toughness is 0 or less, it's still put into its owner's graveyard.)
+Oracle:Whenever you cycle or discard a card, Pitiless Vizier gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it. If its toughness is 0 or less, it still dies.)

--- a/forge-gui/res/cardsfolder/s/seraph_of_the_suns.txt
+++ b/forge-gui/res/cardsfolder/s/seraph_of_the_suns.txt
@@ -4,4 +4,4 @@ Types:Creature Angel
 PT:4/4
 K:Flying
 K:Indestructible
-Oracle:Flying\nIndestructible (Damage and effects that say "destroy" don't destroy this creature. If its toughness is 0 or less, it's still put into its owner's graveyard.)
+Oracle:Flying\nIndestructible (Damage and effects that say "destroy" don't destroy this creature. If its toughness is 0 or less, it still dies.)

--- a/forge-gui/res/cardsfolder/s/shield_of_the_oversoul.txt
+++ b/forge-gui/res/cardsfolder/s/shield_of_the_oversoul.txt
@@ -4,6 +4,6 @@ Types:Enchantment Aura
 K:Enchant:Creature
 SVar:AttachAITgts:Card.Green,Card.White
 SVar:AttachAILogic:Pump
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy+Green | AddPower$ 1 | AddToughness$ 1 | AddKeyword$ Indestructible | Description$ As long as enchanted creature is green, it gets +1/+1 and has indestructible. (Lethal damage and effects that say "destroy" don't destroy it. If its toughness is 0 or less, it's still put into its owner's graveyard.)
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy+Green | AddPower$ 1 | AddToughness$ 1 | AddKeyword$ Indestructible | Description$ As long as enchanted creature is green, it gets +1/+1 and has indestructible. (Damage and effects that say "destroy" don't destroy it. If its toughness is 0 or less, it still dies.)
 S:Mode$ Continuous | Affected$ Creature.EnchantedBy+White | AddPower$ 1 | AddToughness$ 1 | AddKeyword$ Flying | Description$ As long as enchanted creature is white, it gets +1/+1 and has flying.
-Oracle:Enchant creature\nAs long as enchanted creature is green, it gets +1/+1 and has indestructible. (Damage and effects that say "destroy" don't destroy it. If its toughness is 0 or less, it's still put into its owner's graveyard.)\nAs long as enchanted creature is white, it gets +1/+1 and has flying.
+Oracle:Enchant creature\nAs long as enchanted creature is green, it gets +1/+1 and has indestructible. (Damage and effects that say "destroy" don't destroy it. If its toughness is 0 or less, it still dies.)\nAs long as enchanted creature is white, it gets +1/+1 and has flying.

--- a/forge-gui/res/cardsfolder/w/without_weakness.txt
+++ b/forge-gui/res/cardsfolder/w/without_weakness.txt
@@ -1,6 +1,6 @@
 Name:Without Weakness
 ManaCost:1 B
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | KW$ Indestructible | SpellDescription$ Target creature you control gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it. If its toughness is 0 or less, it's still put into its owner's graveyard.)
+A:SP$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | KW$ Indestructible | SpellDescription$ Target creature you control gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it. If its toughness is 0 or less, it still dies.)
 K:Cycling:2
-Oracle:Target creature you control gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it. If its toughness is 0 or less, it's still put into its owner's graveyard.)\nCycling {2} ({2}, Discard this card: Draw a card.)
+Oracle:Target creature you control gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it. If its toughness is 0 or less, it still dies.)\nCycling {2} ({2}, Discard this card: Draw a card.)

--- a/forge-gui/res/cardsfolder/w/withstand_death.txt
+++ b/forge-gui/res/cardsfolder/w/withstand_death.txt
@@ -2,4 +2,4 @@ Name:Withstand Death
 ManaCost:G
 Types:Instant
 A:SP$ Pump | ValidTgts$ Creature | KW$ Indestructible | SpellDescription$ Target creature gains indestructible until end of turn.
-Oracle:Target creature gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it. If its toughness is 0 or less, it's still put into its owner's graveyard.)
+Oracle:Target creature gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it. If its toughness is 0 or less, it still dies.)


### PR DESCRIPTION
Following up on https://github.com/Card-Forge/forge/pull/11086 .
Updating the Indestructible reminder text as seen for
[Accursed Horde](https://gatherer.wizards.com/HOU/en-us/56/accursed-horde) and [Shield of the Oversoul](https://gatherer.wizards.com/SHM/en-us/242/shield-of-the-oversoul).