### PR TITLE
Improve death-drain creature evaluation

### DIFF
--- a/forge-ai/src/main/java/forge/ai/CreatureEvaluator.java
+++ b/forge-ai/src/main/java/forge/ai/CreatureEvaluator.java
@@ -333,11 +333,31 @@ public class CreatureEvaluator implements Function<Card, Integer> {
                 continue;
             }
             final SpellAbility ab = t.ensureAbility();
-            if (ab != null && ApiType.LoseLife.equals(ab.getApi())) {
+            if (isRepeatableOpponentDrain(ab)) {
                 value += 30;
             }
         }
         return value;
+    }
+
+    private boolean isRepeatableOpponentDrain(final SpellAbility ab) {
+        if (ab == null || !ApiType.LoseLife.equals(ab.getApi()) || !hasGainLifeSubAbility(ab)) {
+            return false;
+        }
+        final String defined = ab.getParamOrDefault("Defined", "");
+        final String validTgts = ab.getParamOrDefault("ValidTgts", "");
+        return defined.contains("Opponent") || "Player".equals(validTgts) || validTgts.contains("Opponent");
+    }
+
+    private boolean hasGainLifeSubAbility(final SpellAbility ab) {
+        SpellAbility sub = ab.getSubAbility();
+        while (sub != null) {
+            if (ApiType.GainLife.equals(sub.getApi())) {
+                return true;
+            }
+            sub = sub.getSubAbility();
+        }
+        return false;
     }
 
     protected int addValue(int value, String text) {

--- a/forge-ai/src/main/java/forge/ai/CreatureEvaluator.java
+++ b/forge-ai/src/main/java/forge/ai/CreatureEvaluator.java
@@ -175,6 +175,7 @@ public class CreatureEvaluator implements Function<Card, Integer> {
         if (ComputerUtilCard.hasActiveUndyingOrPersist(c)) {
             value += addValue(30, "revive");
         }
+        value += addValue(evaluateRepeatableDeathDrain(c), "death-drain");
 
         // Bad keywords
         if (c.hasKeyword(Keyword.DEFENDER) || c.hasKeyword("CARDNAME can't attack.")) {
@@ -316,6 +317,27 @@ public class CreatureEvaluator implements Function<Card, Integer> {
         }
         // default value
         return 10;
+    }
+
+    private int evaluateRepeatableDeathDrain(final Card c) {
+        int value = 0;
+        for (final Trigger t : c.getTriggers()) {
+            if (!TriggerType.ChangesZone.equals(t.getMode())) {
+                continue;
+            }
+            if (!"Battlefield".equals(t.getParamOrDefault("Origin", ""))
+                    || !"Graveyard".equals(t.getParamOrDefault("Destination", ""))) {
+                continue;
+            }
+            if (!t.getParamOrDefault("ValidCard", "").contains("Other")) {
+                continue;
+            }
+            final SpellAbility ab = t.ensureAbility();
+            if (ab != null && ApiType.LoseLife.equals(ab.getApi())) {
+                value += 30;
+            }
+        }
+        return value;
     }
 
     protected int addValue(int value, String text) {


### PR DESCRIPTION
﻿## Problem
When choosing creature removal targets, the AI can prefer a one-shot death trigger such as Serrated Scorpion over repeatable death-drain engines such as Zulaport Cutthroat, Blood Artist, and Cruel Celebrant.

Fixes #4171.

## Minimal Fix
Creature evaluation now adds a small value bump for dies triggers that:
- move from battlefield to graveyard,
- include `Other` in `ValidCard`, and
- execute a `LoseLife` ability.

This keeps self-only death triggers such as Serrated Scorpion from receiving the same repeatable-engine value.

## Validation
- `JAVA_HOME=/home/rauglothgor/.local/codex-tools/jdk17 /home/rauglothgor/.local/codex-tools/apache-maven-3.9.9/bin/mvn -pl forge-ai -am -DskipTests compile`
- Build succeeded with 0 checkstyle violations.

## Known Limits
This is not a general trigger evaluator. It only covers the narrow repeatable death-drain case described in the issue.

## AI Assistance Disclosure
I used AI assistance to inspect the issue, trace the target-evaluation path, make the narrow change, and run validation. I reviewed the final diff and validation before opening this PR.
