### PR TITLE
Card cleanup: 2026-06-30 [Reminder text: Overload]

### DIFF
--- a/forge-gui/res/cardsfolder/b/blustersquall.txt
+++ b/forge-gui/res/cardsfolder/b/blustersquall.txt
@@ -3,4 +3,4 @@ ManaCost:U
 Types:Instant
 A:SP$ Tap | ValidTgts$ Creature.YouDontCtrl | TgtPrompt$ Select target creature you don't control | SpellDescription$ Tap target creature you don't control.
 K:Overload:3 U
-Oracle:Tap target creature you don't control.\nOverload {3}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
+Oracle:Tap target creature you don't control.\nOverload {3}{U} (You may cast this spell for its overload cost. If you do, change "target" in its text to "each.")

--- a/forge-gui/res/cardsfolder/b/break_the_ice.txt
+++ b/forge-gui/res/cardsfolder/b/break_the_ice.txt
@@ -4,4 +4,4 @@ Types:Sorcery
 A:SP$ Destroy | ValidTgts$ Land.Snow,Land.canProduceManaColor Colorless | TgtPrompt$ Select target land that is snow or could produce {C} | SpellDescription$ Destroy target land that is snow or could produce {C}.
 K:Overload:4 B B
 AI:RemoveDeck:Random
-Oracle:Destroy target land that is snow or could produce {C}.\nOverload {4}{B}{B} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
+Oracle:Destroy target land that is snow or could produce {C}.\nOverload {4}{B}{B} (You may cast this spell for its overload cost. If you do, change "target" in its text to "each.")

--- a/forge-gui/res/cardsfolder/c/chemisters_trick.txt
+++ b/forge-gui/res/cardsfolder/c/chemisters_trick.txt
@@ -6,4 +6,4 @@ SVar:DBAnimate:DB$ Effect | StaticAbilities$ MustAttack | StackDescription$ None
 SVar:MustAttack:Mode$ MustAttack | ValidCreature$ Card.IsRemembered | Description$ This creature attacks this turn if able.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 K:Overload:3 U R
-Oracle:Target creature you don't control gets -2/-0 until end of turn and attacks this turn if able.\nOverload {3}{U}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
+Oracle:Target creature you don't control gets -2/-0 until end of turn and attacks this turn if able.\nOverload {3}{U}{R} (You may cast this spell for its overload cost. If you do, change "target" in its text to "each.")

--- a/forge-gui/res/cardsfolder/c/counterflux.txt
+++ b/forge-gui/res/cardsfolder/c/counterflux.txt
@@ -4,4 +4,4 @@ Types:Instant
 R:Event$ Counter | ValidCard$ Card.Self | ValidSA$ Spell | Layer$ CantHappen | Description$ This spell can't be countered.
 A:SP$ Counter | TargetType$ Spell | TgtPrompt$ Select target spell you don't control. | ValidTgts$ Card.YouDontCtrl | SpellDescription$ Counter target spell you don't control.
 K:Overload:1 U U R
-Oracle:This spell can't be countered.\nCounter target spell you don't control.\nOverload {1}{U}{U}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
+Oracle:This spell can't be countered.\nCounter target spell you don't control.\nOverload {1}{U}{U}{R} (You may cast this spell for its overload cost. If you do, change "target" in its text to "each.")

--- a/forge-gui/res/cardsfolder/c/cyclonic_rift.txt
+++ b/forge-gui/res/cardsfolder/c/cyclonic_rift.txt
@@ -3,4 +3,4 @@ ManaCost:1 U
 Types:Instant
 A:SP$ ChangeZone | ValidTgts$ Permanent.nonLand+YouDontCtrl | TgtPrompt$ Select target nonland permanent you don't control | Origin$ Battlefield | Destination$ Hand | SpellDescription$ Return target nonland permanent you don't control to its owner's hand.
 K:Overload:6 U
-Oracle:Return target nonland permanent you don't control to its owner's hand.\nOverload {6}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
+Oracle:Return target nonland permanent you don't control to its owner's hand.\nOverload {6}{U} (You may cast this spell for its overload cost. If you do, change "target" in its text to "each.")

--- a/forge-gui/res/cardsfolder/d/damn.txt
+++ b/forge-gui/res/cardsfolder/d/damn.txt
@@ -3,4 +3,4 @@ ManaCost:B B
 Types:Sorcery
 K:Overload:2 W W
 A:SP$ Destroy | ValidTgts$ Creature | NoRegen$ True | SpellDescription$ Destroy target creature. A creature destroyed this way can't be regenerated.
-Oracle:Destroy target creature. A creature destroyed this way can't be regenerated.\nOverload {2}{W}{W} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
+Oracle:Destroy target creature. A creature destroyed this way can't be regenerated.\nOverload {2}{W}{W} (You may cast this spell for its overload cost. If you do, change "target" in its text to "each.")

--- a/forge-gui/res/cardsfolder/d/downsize.txt
+++ b/forge-gui/res/cardsfolder/d/downsize.txt
@@ -3,4 +3,4 @@ ManaCost:U
 Types:Instant
 A:SP$ Pump | ValidTgts$ Creature.YouDontCtrl | TgtPrompt$ Select target creature you don't control | NumAtt$ -4 | SpellDescription$ Target creature you don't control gets -4/-0 until end of turn.
 K:Overload:2 U
-Oracle:Target creature you don't control gets -4/-0 until end of turn.\nOverload {2}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
+Oracle:Target creature you don't control gets -4/-0 until end of turn.\nOverload {2}{U} (You may cast this spell for its overload cost. If you do, change "target" in its text to "each.")

--- a/forge-gui/res/cardsfolder/d/dragonshift.txt
+++ b/forge-gui/res/cardsfolder/d/dragonshift.txt
@@ -4,4 +4,4 @@ Types:Instant
 A:SP$ Animate | ValidTgts$ Creature.YouCtrl | Power$ 4 | Toughness$ 4 | Keywords$ Flying | RemoveAllAbilities$ True | Colors$ Blue,Red | OverwriteColors$ True | Types$ Dragon | RemoveCreatureTypes$ True | SpellDescription$ Until end of turn, target creature you control becomes a blue and red Dragon with base power and toughness 4/4, loses all abilities, and gains flying.
 K:Overload:3 U U R R
 AI:RemoveDeck:All
-Oracle:Until end of turn, target creature you control becomes a blue and red Dragon with base power and toughness 4/4, loses all abilities, and gains flying.\nOverload {3}{U}{U}{R}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
+Oracle:Until end of turn, target creature you control becomes a blue and red Dragon with base power and toughness 4/4, loses all abilities, and gains flying.\nOverload {3}{U}{U}{R}{R} (You may cast this spell for its overload cost. If you do, change "target" in its text to "each.")

--- a/forge-gui/res/cardsfolder/d/dynacharge.txt
+++ b/forge-gui/res/cardsfolder/d/dynacharge.txt
@@ -3,4 +3,4 @@ ManaCost:R
 Types:Instant
 A:SP$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control. | NumAtt$ +2 | SpellDescription$ Target creature you control gets +2/+0 until end of turn.
 K:Overload:2 R
-Oracle:Target creature you control gets +2/+0 until end of turn.\nOverload {2}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
+Oracle:Target creature you control gets +2/+0 until end of turn.\nOverload {2}{R} (You may cast this spell for its overload cost. If you do, change "target" in its text to "each.")

--- a/forge-gui/res/cardsfolder/e/electrickery.txt
+++ b/forge-gui/res/cardsfolder/e/electrickery.txt
@@ -3,4 +3,4 @@ ManaCost:R
 Types:Instant
 A:SP$ DealDamage | ValidTgts$ Creature.YouDontCtrl | TgtPrompt$ Select target creature you don't control. | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to target creature you don't control.
 K:Overload:1 R
-Oracle:Electrickery deals 1 damage to target creature you don't control.\nOverload {1}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
+Oracle:Electrickery deals 1 damage to target creature you don't control.\nOverload {1}{R} (You may cast this spell for its overload cost. If you do, change "target" in its text to "each.")

--- a/forge-gui/res/cardsfolder/m/march_of_progress.txt
+++ b/forge-gui/res/cardsfolder/m/march_of_progress.txt
@@ -5,4 +5,4 @@ A:SP$ CopyPermanent | ValidTgts$ Artifact.Creature+YouCtrl | TgtPrompt$ Select t
 K:Overload:6 U
 DeckHas:Ability$Token
 DeckNeeds:Type$Artifact
-Oracle:Choose target artifact creature you control. For each creature chosen this way, create a token that's a copy of it.\nOverload {6}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
+Oracle:Choose target artifact creature you control. For each creature chosen this way, create a token that's a copy of it.\nOverload {6}{U} (You may cast this spell for its overload cost. If you do, change "target" in its text to "each.")

--- a/forge-gui/res/cardsfolder/m/mind_rake.txt
+++ b/forge-gui/res/cardsfolder/m/mind_rake.txt
@@ -3,4 +3,4 @@ ManaCost:2 B
 Types:Sorcery
 A:SP$ Discard | ValidTgts$ Player | NumCards$ 2 | Mode$ TgtChoose | SpellDescription$ Target player discards two cards.
 K:Overload:1 B
-Oracle:Target player discards two cards.\nOverload {1}{B} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
+Oracle:Target player discards two cards.\nOverload {1}{B} (You may cast this spell for its overload cost. If you do, change "target" in its text to "each.")

--- a/forge-gui/res/cardsfolder/m/mizzium_mortars.txt
+++ b/forge-gui/res/cardsfolder/m/mizzium_mortars.txt
@@ -3,4 +3,4 @@ ManaCost:1 R
 Types:Sorcery
 A:SP$ DealDamage | ValidTgts$ Creature.YouDontCtrl | TgtPrompt$ Select target creature you don't control | NumDmg$ 4 | SpellDescription$ CARDNAME deals 4 damage to target creature you don't control.
 K:Overload:3 R R R
-Oracle:Mizzium Mortars deals 4 damage to target creature you don't control.\nOverload {3}{R}{R}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
+Oracle:Mizzium Mortars deals 4 damage to target creature you don't control.\nOverload {3}{R}{R}{R} (You may cast this spell for its overload cost. If you do, change "target" in its text to "each.")

--- a/forge-gui/res/cardsfolder/m/mizzium_skin.txt
+++ b/forge-gui/res/cardsfolder/m/mizzium_skin.txt
@@ -3,4 +3,4 @@ ManaCost:U
 Types:Instant
 A:SP$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | NumDef$ +1 | KW$ Hexproof | SpellDescription$ Target creature you control gets +0/+1 and gains hexproof until end of turn.
 K:Overload:1 U
-Oracle:Target creature you control gets +0/+1 and gains hexproof until end of turn.\nOverload {1}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
+Oracle:Target creature you control gets +0/+1 and gains hexproof until end of turn.\nOverload {1}{U} (You may cast this spell for its overload cost. If you do, change "target" in its text to "each.")

--- a/forge-gui/res/cardsfolder/m/mizzixs_mastery.txt
+++ b/forge-gui/res/cardsfolder/m/mizzixs_mastery.txt
@@ -7,4 +7,4 @@ SVar:ExileMe:DB$ ChangeZone | Defined$ Self | Origin$ Stack | Destination$ Exile
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 K:Overload:5 R R R
 AI:RemoveDeck:All
-Oracle:Exile target card that's an instant or sorcery from your graveyard. For each card exiled this way, copy it, and you may cast the copy without paying its mana cost. Exile Mizzix's Mastery.\nOverload {5}{R}{R}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
+Oracle:Exile target card that's an instant or sorcery from your graveyard. For each card exiled this way, copy it, and you may cast the copy without paying its mana cost. Exile Mizzix's Mastery.\nOverload {5}{R}{R}{R} (You may cast this spell for its overload cost. If you do, change "target" in its text to "each.")

--- a/forge-gui/res/cardsfolder/r/rise_and_shine.txt
+++ b/forge-gui/res/cardsfolder/r/rise_and_shine.txt
@@ -7,4 +7,4 @@ SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 K:Overload:4 U U
 DeckHas:Ability$Counters
 DeckNeeds:Type$Artifact
-Oracle:Target noncreature artifact you control becomes a 0/0 artifact creature. Put four +1/+1 counters on each artifact that became a creature this way.\nOverload {4}{U}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
+Oracle:Target noncreature artifact you control becomes a 0/0 artifact creature. Put four +1/+1 counters on each artifact that became a creature this way.\nOverload {4}{U}{U} (You may cast this spell for its overload cost. If you do, change "target" in its text to "each.")

--- a/forge-gui/res/cardsfolder/s/scale_up.txt
+++ b/forge-gui/res/cardsfolder/s/scale_up.txt
@@ -3,4 +3,4 @@ ManaCost:G
 Types:Sorcery
 A:SP$ Animate | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | Power$ 6 | Toughness$ 4 | Colors$ Green | OverwriteColors$ True | Types$ Wurm | RemoveCreatureTypes$ True | SpellDescription$ Until end of turn, target creature you control becomes a green Wurm with base power and toughness 6/4.
 K:Overload:4 G G
-Oracle:Until end of turn, target creature you control becomes a green Wurm with base power and toughness 6/4.\nOverload {4}{G}{G} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
+Oracle:Until end of turn, target creature you control becomes a green Wurm with base power and toughness 6/4.\nOverload {4}{G}{G} (You may cast this spell for its overload cost. If you do, change "target" in its text to "each.")

--- a/forge-gui/res/cardsfolder/s/stirring_address.txt
+++ b/forge-gui/res/cardsfolder/s/stirring_address.txt
@@ -3,4 +3,4 @@ ManaCost:1 W
 Types:Instant
 A:SP$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | NumAtt$ +2 | NumDef$ +2 | SpellDescription$ Target creature you control gets +2/+2 until end of turn.
 K:Overload:5 W
-Oracle:Target creature you control gets +2/+2 until end of turn.\nOverload {5}{W} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
+Oracle:Target creature you control gets +2/+2 until end of turn.\nOverload {5}{W} (You may cast this spell for its overload cost. If you do, change "target" in its text to "each.")

--- a/forge-gui/res/cardsfolder/s/street_spasm.txt
+++ b/forge-gui/res/cardsfolder/s/street_spasm.txt
@@ -4,4 +4,4 @@ Types:Instant
 A:SP$ DealDamage | ValidTgts$ Creature.withoutFlying+YouDontCtrl | TgtPrompt$ Select target creature without flying you don't control. | NumDmg$ X | SpellDescription$ CARDNAME deals X damage to target creature without flying you don't control.
 K:Overload:X X R R
 SVar:X:Count$xPaid
-Oracle:Street Spasm deals X damage to target creature without flying you don't control.\nOverload {X}{X}{R}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
+Oracle:Street Spasm deals X damage to target creature without flying you don't control.\nOverload {X}{X}{R}{R} (You may cast this spell for its overload cost. If you do, change "target" in its text to "each.")

--- a/forge-gui/res/cardsfolder/t/teleportal.txt
+++ b/forge-gui/res/cardsfolder/t/teleportal.txt
@@ -6,4 +6,4 @@ SVar:DBUnblockable:DB$ Effect | RememberObjects$ Remembered | ForgetOnMoved$ Bat
 SVar:Unblockable:Mode$ CantBlockBy | ValidAttacker$ Card.IsRemembered | Description$ This creature can't be blocked this turn.
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 K:Overload:3 U R
-Oracle:Target creature you control gets +1/+0 until end of turn and can't be blocked this turn.\nOverload {3}{U}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
+Oracle:Target creature you control gets +1/+0 until end of turn and can't be blocked this turn.\nOverload {3}{U}{R} (You may cast this spell for its overload cost. If you do, change "target" in its text to "each.")

--- a/forge-gui/res/cardsfolder/v/vandalblast.txt
+++ b/forge-gui/res/cardsfolder/v/vandalblast.txt
@@ -3,4 +3,4 @@ ManaCost:R
 Types:Sorcery
 A:SP$ Destroy | ValidTgts$ Artifact.YouDontCtrl | TgtPrompt$ Select target artifact you don't control | SpellDescription$ Destroy target artifact you don't control.
 K:Overload:4 R
-Oracle:Destroy target artifact you don't control.\nOverload {4}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
+Oracle:Destroy target artifact you don't control.\nOverload {4}{R} (You may cast this spell for its overload cost. If you do, change "target" in its text to "each.")

--- a/forge-gui/res/cardsfolder/w/weapon_surge.txt
+++ b/forge-gui/res/cardsfolder/w/weapon_surge.txt
@@ -3,4 +3,4 @@ ManaCost:R
 Types:Instant
 A:SP$ Pump | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | NumAtt$ +1 | KW$ First Strike | SpellDescription$ Target creature you control gets +1/+0 and gains first strike until end of turn.
 K:Overload:1 R
-Oracle:Target creature you control gets +1/+0 and gains first strike until end of turn.\nOverload {1}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
+Oracle:Target creature you control gets +1/+0 and gains first strike until end of turn.\nOverload {1}{R} (You may cast this spell for its overload cost. If you do, change "target" in its text to "each.")

--- a/forge-gui/res/cardsfolder/w/winds_of_abandon.txt
+++ b/forge-gui/res/cardsfolder/w/winds_of_abandon.txt
@@ -7,4 +7,4 @@ SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:DBGetLandsOne:DB$ ChangeZone | Optional$ True | Origin$ Library | Destination$ Battlefield | Tapped$ True | ChangeType$ Land.Basic | ChangeTypeDesc$ basic land | ChangeNum$ X | DefinedPlayer$ Player.IsRemembered | ConditionCheckSVar$ X | ConditionSVarCompare$ GE1
 SVar:X:RememberedLKI$Valid Card.RememberedPlayerCtrl
 K:Overload:4 W W
-Oracle:Exile target creature you don't control. For each creature exiled this way, its controller searches their library for a basic land card. Those players put those cards onto the battlefield tapped, then shuffle.\nOverload {4}{W}{W} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
+Oracle:Exile target creature you don't control. For each creature exiled this way, its controller searches their library for a basic land card. Those players put those cards onto the battlefield tapped, then shuffle.\nOverload {4}{W}{W} (You may cast this spell for its overload cost. If you do, change "target" in its text to "each.")


### PR DESCRIPTION
Following up on https://github.com/Card-Forge/forge/pull/11086 .
Updating the Overload reminder text as seen for [Blustersquall](https://gatherer.wizards.com/C15/en-us/89/blustersquall).