### PR TITLE
Avoid X=0 PumpAll AI choices

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/PumpAllAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PumpAllAi.java
@@ -63,8 +63,14 @@ public class PumpAllAi extends PumpAiBase {
             }
         }
 
-        final int power = AbilityUtils.calculateAmount(source, sa.getParam("NumAtt"), sa);
-        final int defense = AbilityUtils.calculateAmount(source, sa.getParam("NumDef"), sa);
+        final String numAttack = sa.getParamOrDefault("NumAtt", "0");
+        final String numDefense = sa.getParamOrDefault("NumDef", "0");
+        if (usesPaidX(sa, numAttack, numDefense) && !setPaidX(sa, ai)) {
+            return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
+        }
+
+        final int power = AbilityUtils.calculateAmount(source, numAttack, sa);
+        final int defense = AbilityUtils.calculateAmount(source, numDefense, sa);
         final List<String> keywords = sa.hasParam("KW") ? Arrays.asList(sa.getParam("KW").split(" & ")) : new ArrayList<>();
         final PhaseType phase = game.getPhaseHandler().getPhase();
 
@@ -161,5 +167,19 @@ public class PumpAllAi extends PumpAiBase {
             }
         }
         return false;
+    }
+
+    private boolean usesPaidX(final SpellAbility sa, final String numAttack, final String numDefense) {
+        return sa.getSVar("X").equals("Count$xPaid") && (numAttack.contains("X") || numDefense.contains("X"));
+    }
+
+    private boolean setPaidX(final SpellAbility sa, final Player ai) {
+        final SpellAbility root = sa.getRootAbility();
+        final Cost rootCost = root.getPayCosts();
+        if (rootCost == null || !rootCost.hasXInAnyCostPart()) {
+            return true;
+        }
+        root.setXManaCostPaid(null);
+        return ComputerUtilCost.setMaxXValue(root, ai, sa.isTrigger()) > 0;
     }
 }


### PR DESCRIPTION
## Problem

Issue #8957 reports the AI casting Exude Toxin with X = 0. That Omen is scripted as a `PumpAll` effect with `NumAtt$ -X`, `NumDef$ -X`, and `SVar:X:Count$xPaid`.

## Minimal Fix

For `PumpAll` abilities that use paid X in `NumAtt` or `NumDef`, set the root X value before calculating the pump amount. If the AI cannot pay a positive X, decline the play instead of evaluating the effect as X = 0.

## Validation

- `mvn -pl forge-ai -am -DskipTests compile`

## Known Limits

This is limited to `PumpAll` effects whose power or toughness change depends on paid X. It does not attempt to solve every X-spell decision path.

## AI Assistance Disclosure

I used AI assistance to inspect the issue/code path and draft this narrow change. I reviewed the diff and ran the validation above.

Refs #8957