### PR TITLE
Fix AI not activating 'Power-Up' ability in combat #11120

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/CountersPutAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/CountersPutAi.java
@@ -632,7 +632,12 @@ public class CountersPutAi extends CountersAi {
             }
             // Instant +1/+1
             if (type.equals("P1P1") && !isSorcerySpeed(sa, ai)) {
-                if (!hasSacCost && !(ph.getNextTurn() == ai && ph.is(PhaseType.END_OF_TURN) && abCost.isReusuableResource())) {
+                final Combat combat = game.getCombat();
+                // e.g. Power-Up abilities: use it to survive or win combat even without a sac cost
+                final boolean savesOrWinsCombat = combat != null
+                        && doCombatAdaptLogic(cards.get(0), amount, combat).willingToPlay();
+                if (!hasSacCost && !savesOrWinsCombat
+                        && !(ph.getNextTurn() == ai && ph.is(PhaseType.END_OF_TURN) && abCost.isReusuableResource())) {
                     return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
                 }
             }

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/CountersPutAiPowerUpTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/CountersPutAiPowerUpTest.java
@@ -1,0 +1,51 @@
+package forge.ai.ability;
+
+import forge.ai.AiPlayDecision;
+import forge.ai.SpellAbilityAi;
+import forge.ai.SpellApiToAi;
+import forge.ai.simulation.SimulationTest;
+import forge.game.Game;
+import forge.game.ability.ApiType;
+import forge.game.card.Card;
+import forge.game.combat.Combat;
+import forge.game.phase.PhaseType;
+import forge.game.player.Player;
+import forge.game.spellability.SpellAbility;
+import org.testng.annotations.Test;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+
+public class CountersPutAiPowerUpTest extends SimulationTest {
+
+    @Test
+    public void testPowerUp_savesAttackerFromLethalCombat_aiActivates() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+
+        // Brave Brawler: 2/1, Power-Up {4}{W}: put two +1/+1 counters on this creature (becomes 4/3)
+        Card brawler = addCard("Brave Brawler", ai);
+        addCards("Plains", 5, ai);
+
+        // Giant Spider: 2/4 - unpumped Brawler dies without trading; pumped Brawler (4/3) survives and kills it
+        Card spider = addCard("Giant Spider", opponent);
+
+        game.getPhaseHandler().devModeSet(PhaseType.COMBAT_DECLARE_BLOCKERS, ai);
+        game.getAction().checkStateEffects(true);
+
+        Combat combat = new Combat(ai);
+        combat.addAttacker(brawler, opponent);
+        combat.addBlocker(brawler, spider);
+        game.getPhaseHandler().setCombat(combat);
+
+        SpellAbility powerUpSA = findSAWithPrefix(brawler, "Power-Up");
+        assertNotNull(powerUpSA);
+        powerUpSA.setActivatingPlayer(ai);
+
+        SpellAbilityAi aiLogic = SpellApiToAi.Converter.get(ApiType.PutCounter);
+        AiPlayDecision decision = aiLogic.canPlayWithSubs(ai, powerUpSA).decision();
+        assertEquals("AI should activate Power-Up to save its attacker and win combat",
+                AiPlayDecision.WillPlay, decision);
+    }
+}


### PR DESCRIPTION
## Problem

Issue #11120 reports that the CPU will attack as though it can use a Power-Up ability, but then will not activate that ability during combat, even when doing so would save its creature and win combat.

## Minimal Fix

For instant-speed PutCounter abilities that add +1/+1 counters, allow the AI to activate them during combat when existing combat pump logic determines the activation saves the creature or improves combat.
This keeps the existing restraint against spending reusable instant +1/+1 counter abilities too early, but adds a combat exception for cases like Power-Up.

## Validation

mvn -pl forge-gui-desktop -am "-Dtest=forge.ai.ability.CountersPutAiPowerUpTest" "-Dsurefire.failIfNoSpecifiedTests=false" test

## Known Limits

This is limited to +1/+1 counter abilities handled by CountersPutAi. It does not attempt to improve every Power-Up mode or every activated ability combat decision path.

## AI Assistance Disclosure

I used AI assistance to inspect the issue/code path, and also to help with making the test.

Refs #11120
