### PR TITLE
#11064 Scarlet Witch, Chaotic Avenger ability

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/PlayEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/PlayEffect.java
@@ -184,7 +184,7 @@ public class PlayEffect extends SpellAbilityEffect {
 
         if (sa.hasParam("ValidSA")) {
             final String valid[] = sa.getParam("ValidSA").split(",");
-            final List<Card> invalid = tgtCards.stream().filter(c -> !IterableUtil.any(AbilityUtils.getBasicSpellsFromPlayEffect(c, controller), SpellAbilityPredicates.isValid(valid, controller, source, sa))).collect(Collectors.toList());
+            final List<Card> invalid = tgtCards.stream().filter(c -> lacksValidSpellAbility(c, controller, source, sa, valid)).collect(Collectors.toList());
             if (!invalid.isEmpty())
                 tgtCards.removeAll(invalid);
             if (tgtCards.isEmpty()) {
@@ -220,7 +220,7 @@ public class PlayEffect extends SpellAbilityEffect {
             if (hasTotalCMCLimit) {
                 // filter out cards with mana value greater than limit
                 final String [] valid = {"Spell.cmcLE" + totalCMCLimit};
-                final List<Card> invalid = tgtCards.stream().filter(c -> !IterableUtil.any(AbilityUtils.getBasicSpellsFromPlayEffect(c, controller), SpellAbilityPredicates.isValid(valid, controller, c, sa))).collect(Collectors.toList());
+                final List<Card> invalid = tgtCards.stream().filter(c -> lacksValidSpellAbility(c, controller, c, sa, valid)).collect(Collectors.toList());
                 if (!invalid.isEmpty())
                     tgtCards.removeAll(invalid);
                 if (tgtCards.isEmpty())
@@ -482,6 +482,24 @@ public class PlayEffect extends SpellAbilityEffect {
         if (controlledByPlayer != null) {
             controller.removeController(controlledByTimeStamp);
             controller.popPaidForSA();
+        }
+    }
+
+    private static boolean lacksValidSpellAbility(final Card card, final Player controller, final Card source,
+            final SpellAbility sa, final String[] valid) {
+        boolean wasFaceDown = false;
+        if (card.isFaceDown()) {
+            card.forceTurnFaceUp();
+            wasFaceDown = true;
+        }
+        try {
+            return !IterableUtil.any(AbilityUtils.getBasicSpellsFromPlayEffect(card, controller),
+                    SpellAbilityPredicates.isValid(valid, controller, source, sa));
+        } finally {
+            if (wasFaceDown) {
+                card.turnFaceDownNoUpdate();
+                card.updateStateForView();
+            }
         }
     }
 

--- a/forge-gui/res/cardsfolder/s/scarlet_witch_chaotic_avenger.txt
+++ b/forge-gui/res/cardsfolder/s/scarlet_witch_chaotic_avenger.txt
@@ -5,5 +5,5 @@ PT:3/3
 K:Flying
 T:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Player | Execute$ TrigDig | CombatDamage$ True | TriggerDescription$ Whenever NICKNAME deals combat damage to a player, look at the top two cards of your library, then exile them face down. Then you may cast a Hero or noncreature spell from among cards exiled with NICKNAME without paying its mana cost.
 SVar:TrigDig:DB$ Dig | DigNum$ 2 | ChangeNum$ All | DestinationZone$ Exile | ExileFaceDown$ True | WithMayLook$ True | RememberChanged$ True | SubAbility$ DBPlay
-SVar:DBPlay:DB$ Play | ValidZone$ Exile | Valid$ Hero.nonLand+ExiledWithSource,Card.nonCreature+nonLand+ExiledWithSource | ValidSA$ Spell | Controller$ You | WithoutManaCost$ True | Amount$ 1
+SVar:DBPlay:DB$ Play | ValidZone$ Exile | Valid$ Card.nonLand+ExiledWithSource | ValidSA$ Spell.Hero,Spell.nonCreature | Controller$ You | WithoutManaCost$ True | Optional$ True | Amount$ 1
 Oracle:Flying\nWhenever Scarlet Witch deals combat damage to a player, look at the top two cards of your library, then exile them face down. Then you may cast a Hero or noncreature spell from among cards exiled with Scarlet Witch without paying its mana cost.


### PR DESCRIPTION
## Problem

Issue #11064 describes a bug where Scarlet Witch, Chaotic Avenger's ability does not allow casting of exiled cards.

The card exiles the top 2 cards of your library face-down, then should allow casting a Hero or noncreature spell among those exiled cards without paying its mana cost. However, the Play effect's validation logic was unable to check the spell abilities of face-down cards, causing all cards to fail validation and be uncasting.

The relevant class is `PlayEffect` in `forge-game/src/main/java/forge/game/ability/effects/PlayEffect.java`, which handles the `Play` ability effect used by Scarlet Witch's triggered ability.

## Solution

The fix involved two changes:

1. **Card Definition Update** :
   - Refined the `ValidSA` parameter from generic `Spell` to `Spell.Hero,Spell.nonCreature` for more precise filtering
   - Simplified the `Valid` parameter to `Card.nonLand+ExiledWithSource`
   - Added `Optional$ True` to make casting truly optional

2. **PlayEffect.java Enhancement**:
   - Created a new private helper method `lacksValidSpellAbility()` that temporarily turns face-down cards face-up to check their abilities
   - Used a try-finally block to ensure face-down cards are properly restored to face-down state with updated view state
   - Refactored two filter conditions (lines 187 and 223) to use this new method, eliminating code duplication

**Why this approach:**
- Face-down cards have no visible characteristics, so validation requires temporarily revealing them
- The try-finally ensures proper cleanup regardless of exceptions
- Extracting into a helper method makes the code reusable and maintainable

## Validation

- `mvn -pl forge-gui -am -DskipTests compile` - Code compiles successfully
- Manual testing:
  - Played Scarlet Witch, dealt combat damage to opponent
  - Ability triggered and exiled 2 cards face-down
  - Both cards were selectable and castable in the Play dialog
  - Non-Hero and creature spells were correctly filtered out
  - Face-down cards remained hidden during gameplay after casting

## Known Limits

- Limited to Scarlet Witch and other abilities using the `Play` effect with face-down cards
- Does not address other potential face-down card handling edge cases in different ability effects
- Future improvements may be needed if other effects encounter similar validation issues with face-down cards

## AI Assistance Disclosure

I used AI assistance to help inspect the code, understand the issue, and draft this change. I reviewed all generated code, verified the implementation manually, and performed the validation listed above.

Refs #11064