### PR TITLE
Improve alternate desktop sound playback with shared PCM mixer

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/GuiDesktop.java
+++ b/forge-gui-desktop/src/main/java/forge/GuiDesktop.java
@@ -303,7 +303,7 @@ public class GuiDesktop implements IGuiBase {
 
     @Override
     public void startAltSoundSystem(final String filename, final boolean isSynchronized) {
-        new AltSoundSystem(filename, isSynchronized).start();
+        AltSoundSystem.play(filename, isSynchronized);
     }
 
     @Override

--- a/forge-gui-desktop/src/main/java/forge/sound/AltSoundSystem.java
+++ b/forge-gui-desktop/src/main/java/forge/sound/AltSoundSystem.java
@@ -3,14 +3,18 @@ package forge.sound;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioInputStream;
 import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.DataLine;
-import javax.sound.sampled.FloatControl;
+import javax.sound.sampled.LineUnavailableException;
 import javax.sound.sampled.Mixer;
 import javax.sound.sampled.SourceDataLine;
 import javax.sound.sampled.UnsupportedAudioFileException;
@@ -22,39 +26,248 @@ import forge.model.FModel;
  *
  * @author agetian
  */
-class AsyncSoundRegistry {
-    static Map<String, Integer> soundsPlayed = new HashMap<>();
+class AltSoundMixer implements Runnable {
+    private static final Object LOCK = new Object();
+    private static final float SAMPLE_RATE = 44100f;
+    private static final int CHANNELS = 2;
+    private static final int SAMPLE_SIZE_BITS = 16;
+    private static final int BYTES_PER_SAMPLE = SAMPLE_SIZE_BITS / 8;
+    private static final int FRAME_SIZE = CHANNELS * BYTES_PER_SAMPLE;
+    private static final int BUFFER_FRAMES = 512;
+    private static final int BUFFER_BYTES = BUFFER_FRAMES * FRAME_SIZE;
+    private static final int TAP_DELAY_MS = 70;
+    private static final long SOUND_DELAY_FRAMES = millisecondsToFrames(SoundSystem.DELAY);
+    private static final long TAP_DELAY_FRAMES = millisecondsToFrames(TAP_DELAY_MS);
+    private static final int MAX_SYNCED_SOUND_ITERATIONS = 1;
+    private static final int MAX_UNSYNCED_SOUND_ITERATIONS = 16;
+    private static final int MAX_TOTAL_SOUND_ITERATIONS = 32;
+    private static final AudioFormat MIX_FORMAT = new AudioFormat(
+            AudioFormat.Encoding.PCM_SIGNED, SAMPLE_RATE, SAMPLE_SIZE_BITS, CHANNELS, FRAME_SIZE, SAMPLE_RATE, false);
 
-    public synchronized static void registerSound(String soundName) {
-        soundsPlayed.merge(soundName, 1, Integer::sum);
-        //System.out.println("Register: Count for " + soundName + " = " + soundsPlayed.get(soundName));
-    }
+    private static final Map<String, CachedSound> soundCache = new HashMap<>();
+    private static final Map<String, Integer> soundsPlaying = new HashMap<>();
+    private static final Map<String, Long> nextStartFrame = new HashMap<>();
+    private static final List<ActiveSound> activeSounds = new ArrayList<>();
+    private static int totalSoundsPlaying;
+    private static long frameCursor;
+    private static boolean started;
 
-    public synchronized static void unregisterSound(String soundName) {
-        if (soundsPlayed.containsKey(soundName) && soundsPlayed.get(soundName) > 1) {
-            soundsPlayed.merge(soundName, -1, Integer::sum);
-        } else {
-            soundsPlayed.remove(soundName);
+    public static void play(String filename, boolean isSync) {
+        CachedSound sound;
+        try {
+            sound = loadSound(filename);
+        } catch (UnsupportedAudioFileException | IOException e) {
+            e.printStackTrace();
+            return;
         }
-        //System.out.println("Unregister: Count for " + soundName + " = " + soundsPlayed.get(soundName));
+
+        synchronized (LOCK) {
+            int maxIterations = isSync ? MAX_SYNCED_SOUND_ITERATIONS : MAX_UNSYNCED_SOUND_ITERATIONS;
+            if (totalSoundsPlaying >= MAX_TOTAL_SOUND_ITERATIONS
+                    || soundsPlaying.getOrDefault(filename, 0) >= maxIterations) {
+                return;
+            }
+
+            startMixer();
+
+            long startFrame = Math.max(frameCursor, nextStartFrame.getOrDefault(filename, 0L));
+            nextStartFrame.put(filename, startFrame + getDelayFrames(filename));
+            soundsPlaying.merge(filename, 1, Integer::sum);
+            totalSoundsPlaying++;
+            activeSounds.add(new ActiveSound(filename, sound, startFrame));
+            LOCK.notifyAll();
+        }
     }
 
-    public synchronized static boolean isRegistered(String soundName) {
-        return soundsPlayed.containsKey(soundName);
+    private static long getDelayFrames(String filename) {
+        String soundName = new File(filename).getName();
+        if ("draw.mp3".equals(soundName) || "tap.mp3".equals(soundName) || "untap.mp3".equals(soundName)) {
+            return TAP_DELAY_FRAMES;
+        }
+        return SOUND_DELAY_FRAMES;
     }
 
-    public synchronized static int getNumIterations(String soundName) {
-        return soundsPlayed.getOrDefault(soundName, 0);
+    private static long millisecondsToFrames(int milliseconds) {
+        return milliseconds * (long) SAMPLE_RATE / 1000L;
+    }
+
+    private static CachedSound loadSound(String filename) throws UnsupportedAudioFileException, IOException {
+        synchronized (LOCK) {
+            CachedSound sound = soundCache.get(filename);
+            if (sound != null) {
+                return sound;
+            }
+        }
+
+        File soundFile = new File(filename);
+        if (!soundFile.exists()) {
+            throw new IOException("Sound file does not exist: " + filename);
+        }
+
+        byte[] converted = AudioClip.getAudioClips(soundFile);
+        try (ByteArrayInputStream bis = new ByteArrayInputStream(converted);
+                AudioInputStream sourceStream = AudioSystem.getAudioInputStream(bis);
+                AudioInputStream pcmStream = AudioSystem.getAudioInputStream(MIX_FORMAT, sourceStream)) {
+            byte[] data = pcmStream.readAllBytes();
+            CachedSound sound = new CachedSound(data, data.length / FRAME_SIZE);
+            synchronized (LOCK) {
+                CachedSound existing = soundCache.get(filename);
+                if (existing != null) {
+                    return existing;
+                }
+                soundCache.put(filename, sound);
+                return sound;
+            }
+        }
+    }
+
+    private static void startMixer() {
+        if (started) {
+            return;
+        }
+
+        started = true;
+        Thread mixerThread = new Thread(new AltSoundMixer(), "Forge alternate sound mixer");
+        mixerThread.setDaemon(true);
+        mixerThread.start();
+    }
+
+    @Override
+    public void run() {
+        SourceDataLine audioLine;
+        try {
+            audioLine = openAudioLine();
+        } catch (LineUnavailableException e) {
+            e.printStackTrace();
+            synchronized (LOCK) {
+                started = false;
+            }
+            return;
+        }
+
+        audioLine.start();
+
+        int[] mixBuffer = new int[BUFFER_FRAMES * CHANNELS];
+        byte[] outputBuffer = new byte[BUFFER_BYTES];
+
+        while (true) {
+            float volume;
+            synchronized (LOCK) {
+                mixActiveSounds(mixBuffer);
+                volume = FModel.getPreferences().getPrefInt(FPref.UI_VOL_SOUNDS) / 100f;
+            }
+
+            writeMixedAudio(mixBuffer, outputBuffer, volume);
+            audioLine.write(outputBuffer, 0, outputBuffer.length);
+        }
+    }
+
+    private static SourceDataLine openAudioLine() throws LineUnavailableException {
+        DataLine.Info info = new DataLine.Info(SourceDataLine.class, MIX_FORMAT);
+
+        for (Mixer.Info mixerInfo : AudioSystem.getMixerInfo()) {
+            Mixer mixer = AudioSystem.getMixer(mixerInfo);
+            if (mixer.isLineSupported(info)) {
+                SourceDataLine line = AudioSystem.getSourceDataLine(MIX_FORMAT, mixerInfo);
+                line.open(MIX_FORMAT, BUFFER_BYTES * 4);
+                return line;
+            }
+        }
+
+        SourceDataLine line = AudioSystem.getSourceDataLine(MIX_FORMAT);
+        line.open(MIX_FORMAT, BUFFER_BYTES * 4);
+        return line;
+    }
+
+    private static void mixActiveSounds(int[] mixBuffer) {
+        Arrays.fill(mixBuffer, 0);
+
+        for (Iterator<ActiveSound> iterator = activeSounds.iterator(); iterator.hasNext();) {
+            ActiveSound active = iterator.next();
+            mixSound(active, mixBuffer);
+            if (active.positionFrame >= active.sound.frameCount) {
+                iterator.remove();
+                unregisterSound(active.filename);
+            }
+        }
+
+        frameCursor += BUFFER_FRAMES;
+    }
+
+    private static void mixSound(ActiveSound active, int[] mixBuffer) {
+        long relativeStart = active.startFrame - frameCursor;
+        if (relativeStart >= BUFFER_FRAMES) {
+            return;
+        }
+
+        int outputFrame = Math.max(0, (int) relativeStart);
+        int inputFrame = active.positionFrame;
+
+        int framesToMix = Math.min(BUFFER_FRAMES - outputFrame, active.sound.frameCount - inputFrame);
+        for (int frame = 0; frame < framesToMix; frame++) {
+            int inputOffset = (inputFrame + frame) * FRAME_SIZE;
+            int outputOffset = (outputFrame + frame) * CHANNELS;
+            for (int channel = 0; channel < CHANNELS; channel++) {
+                int sampleOffset = inputOffset + channel * BYTES_PER_SAMPLE;
+                int sample = (active.sound.data[sampleOffset] & 0xff) | (active.sound.data[sampleOffset + 1] << 8);
+                mixBuffer[outputOffset + channel] += sample;
+            }
+        }
+
+        if (relativeStart <= 0) {
+            active.positionFrame = inputFrame + framesToMix;
+        }
+    }
+
+    private static void writeMixedAudio(int[] mixBuffer, byte[] outputBuffer, float volume) {
+        for (int i = 0; i < mixBuffer.length; i++) {
+            int sample = Math.round(mixBuffer[i] * volume);
+            sample = Math.max(Short.MIN_VALUE, Math.min(Short.MAX_VALUE, sample));
+            int outputOffset = i * BYTES_PER_SAMPLE;
+            outputBuffer[outputOffset] = (byte) sample;
+            outputBuffer[outputOffset + 1] = (byte) (sample >> 8);
+        }
+    }
+
+    private static void unregisterSound(String soundName) {
+        if (soundsPlaying.containsKey(soundName) && soundsPlaying.get(soundName) > 1) {
+            soundsPlaying.merge(soundName, -1, Integer::sum);
+        } else {
+            soundsPlaying.remove(soundName);
+        }
+        if (totalSoundsPlaying > 0) {
+            totalSoundsPlaying--;
+        }
+    }
+
+    private static class CachedSound {
+        private final byte[] data;
+        private final int frameCount;
+
+        private CachedSound(byte[] data, int frameCount) {
+            this.data = data;
+            this.frameCount = frameCount;
+        }
+    }
+
+    private static class ActiveSound {
+        private final String filename;
+        private final CachedSound sound;
+        private final long startFrame;
+        private int positionFrame;
+
+        private ActiveSound(String filename, CachedSound sound, long startFrame) {
+            this.filename = filename;
+            this.sound = sound;
+            this.startFrame = startFrame;
+        }
     }
 }
 
 public class AltSoundSystem extends Thread {
 
-    private String filename;
-    private boolean isSync;
-
-    private final int EXTERNAL_BUFFER_SIZE = 524288;
-    private final int MAX_SOUND_ITERATIONS = 5;
+    private final String filename;
+    private final boolean isSync;
 
     public AltSoundSystem(String wavfile, boolean synced) {
         filename = wavfile;
@@ -63,89 +276,6 @@ public class AltSoundSystem extends Thread {
 
     @Override
     public void run() {
-        if (isSync && AsyncSoundRegistry.getNumIterations(filename) >= 1) {
-            return;
-        }
-        if (AsyncSoundRegistry.getNumIterations(filename) >= MAX_SOUND_ITERATIONS) {
-            return;
-        }
-
-        File soundFile = new File(filename);
-        if (!soundFile.exists()) {
-            return;
-        }
-
-        AudioInputStream audioInputStream = null;
-        try {
-            ByteArrayInputStream bis = new ByteArrayInputStream(AudioClip.getAudioClips(soundFile));
-            audioInputStream = AudioSystem.getAudioInputStream(bis);
-        } catch (UnsupportedAudioFileException | IOException e) {
-            e.printStackTrace();
-            return;
-        }
-
-        AudioFormat format = audioInputStream.getFormat();
-        SourceDataLine audioLine = null;
-        DataLine.Info info = new DataLine.Info(SourceDataLine.class, format);
-
-        Mixer.Info selectedMixer = null;
-
-        try {
-            for (Mixer.Info mixerInfo : AudioSystem.getMixerInfo()) {
-                Mixer mixer = AudioSystem.getMixer(mixerInfo);
-                if (mixer.isLineSupported(info)) {
-                    selectedMixer = mixerInfo;
-                    break;
-                }
-            }
-        } catch (Exception e) {
-            System.err.println(e.getMessage()); // print a warning but don't crash
-            return;
-        }
-
-        if (selectedMixer == null)
-            return;
-
-        try {
-            audioLine = AudioSystem.getSourceDataLine(format, selectedMixer);
-            audioLine.open(format);
-        } catch (Exception e) {
-            return;
-        }
-
-        if (audioLine.isControlSupported(FloatControl.Type.MASTER_GAIN)) {
-            float vol = FModel.getPreferences().getPrefInt(FPref.UI_VOL_SOUNDS) / 100f;
-            FloatControl gain = (FloatControl) audioLine.getControl(FloatControl.Type.MASTER_GAIN);
-            float dB = (float) (20.0 * Math.log10(Math.max(vol, 0.0001)));
-            dB = Math.max(dB, gain.getMinimum());
-            dB = Math.min(dB, gain.getMaximum());
-            gain.setValue(dB);
-        }
-
-        audioLine.start();
-        AsyncSoundRegistry.registerSound(filename);
-
-        int nBytesRead = 0;
-        byte[] audioBufData = new byte[EXTERNAL_BUFFER_SIZE];
-
-        try {
-            while (nBytesRead != -1) {
-                nBytesRead = audioInputStream.read(audioBufData, 0, audioBufData.length);
-                if (nBytesRead >= 0)
-                    audioLine.write(audioBufData, 0, nBytesRead);
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
-            return;
-        } finally {
-            audioLine.drain();
-            audioLine.close();
-            try {
-                audioInputStream.close();
-            } catch (IOException e) {
-                // Can't do much if closing it fails.
-            }
-            AsyncSoundRegistry.unregisterSound(filename);
-        }
+        AltSoundMixer.play(filename, isSync);
     }
 }

--- a/forge-gui-desktop/src/main/java/forge/sound/AltSoundSystem.java
+++ b/forge-gui-desktop/src/main/java/forge/sound/AltSoundSystem.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioInputStream;
@@ -31,18 +32,19 @@ class AltSoundMixer implements Runnable {
     private static final float SAMPLE_RATE = 44100f;
     private static final int CHANNELS = 2;
     private static final int SAMPLE_SIZE_BITS = 16;
-    private static final int BYTES_PER_SAMPLE = SAMPLE_SIZE_BITS / 8;
-    private static final int FRAME_SIZE = CHANNELS * BYTES_PER_SAMPLE;
+    private static final int BYTES_PER_FRAME = CHANNELS * (SAMPLE_SIZE_BITS / 8);
     private static final int BUFFER_FRAMES = 512;
-    private static final int BUFFER_BYTES = BUFFER_FRAMES * FRAME_SIZE;
+    private static final int BUFFER_SAMPLES = BUFFER_FRAMES * CHANNELS;
+    private static final int BUFFER_BYTES = BUFFER_FRAMES * BYTES_PER_FRAME;
     private static final int TAP_DELAY_MS = 70;
     private static final long SOUND_DELAY_FRAMES = millisecondsToFrames(SoundSystem.DELAY);
     private static final long TAP_DELAY_FRAMES = millisecondsToFrames(TAP_DELAY_MS);
+    private static final Set<String> SLOW_REPEAT_SOUNDS = Set.of("draw.mp3", "tap.mp3", "untap.mp3");
     private static final int MAX_SYNCED_SOUND_ITERATIONS = 1;
     private static final int MAX_UNSYNCED_SOUND_ITERATIONS = 16;
     private static final int MAX_TOTAL_SOUND_ITERATIONS = 32;
     private static final AudioFormat MIX_FORMAT = new AudioFormat(
-            AudioFormat.Encoding.PCM_SIGNED, SAMPLE_RATE, SAMPLE_SIZE_BITS, CHANNELS, FRAME_SIZE, SAMPLE_RATE, false);
+            AudioFormat.Encoding.PCM_SIGNED, SAMPLE_RATE, SAMPLE_SIZE_BITS, CHANNELS, BYTES_PER_FRAME, SAMPLE_RATE, false);
 
     private static final Map<String, CachedSound> soundCache = new HashMap<>();
     private static final Map<String, Integer> soundsPlaying = new HashMap<>();
@@ -75,16 +77,11 @@ class AltSoundMixer implements Runnable {
             soundsPlaying.merge(filename, 1, Integer::sum);
             totalSoundsPlaying++;
             activeSounds.add(new ActiveSound(filename, sound, startFrame));
-            LOCK.notifyAll();
         }
     }
 
     private static long getDelayFrames(String filename) {
-        String soundName = new File(filename).getName();
-        if ("draw.mp3".equals(soundName) || "tap.mp3".equals(soundName) || "untap.mp3".equals(soundName)) {
-            return TAP_DELAY_FRAMES;
-        }
-        return SOUND_DELAY_FRAMES;
+        return SLOW_REPEAT_SOUNDS.contains(new File(filename).getName()) ? TAP_DELAY_FRAMES : SOUND_DELAY_FRAMES;
     }
 
     private static long millisecondsToFrames(int milliseconds) {
@@ -108,8 +105,7 @@ class AltSoundMixer implements Runnable {
         try (ByteArrayInputStream bis = new ByteArrayInputStream(converted);
                 AudioInputStream sourceStream = AudioSystem.getAudioInputStream(bis);
                 AudioInputStream pcmStream = AudioSystem.getAudioInputStream(MIX_FORMAT, sourceStream)) {
-            byte[] data = pcmStream.readAllBytes();
-            CachedSound sound = new CachedSound(data, data.length / FRAME_SIZE);
+            CachedSound sound = new CachedSound(toSamples(pcmStream.readAllBytes()));
             synchronized (LOCK) {
                 CachedSound existing = soundCache.get(filename);
                 if (existing != null) {
@@ -119,6 +115,15 @@ class AltSoundMixer implements Runnable {
                 return sound;
             }
         }
+    }
+
+    private static short[] toSamples(byte[] data) {
+        short[] samples = new short[data.length / 2];
+        for (int i = 0; i < samples.length; i++) {
+            int offset = i * 2;
+            samples[i] = (short) ((data[offset] & 0xff) | (data[offset + 1] << 8));
+        }
+        return samples;
     }
 
     private static void startMixer() {
@@ -147,7 +152,7 @@ class AltSoundMixer implements Runnable {
 
         audioLine.start();
 
-        int[] mixBuffer = new int[BUFFER_FRAMES * CHANNELS];
+        int[] mixBuffer = new int[BUFFER_SAMPLES];
         byte[] outputBuffer = new byte[BUFFER_BYTES];
 
         while (true) {
@@ -185,7 +190,7 @@ class AltSoundMixer implements Runnable {
         for (Iterator<ActiveSound> iterator = activeSounds.iterator(); iterator.hasNext();) {
             ActiveSound active = iterator.next();
             mixSound(active, mixBuffer);
-            if (active.positionFrame >= active.sound.frameCount) {
+            if (active.positionFrame >= active.sound.frameCount()) {
                 iterator.remove();
                 unregisterSound(active.filename);
             }
@@ -203,14 +208,12 @@ class AltSoundMixer implements Runnable {
         int outputFrame = Math.max(0, (int) relativeStart);
         int inputFrame = active.positionFrame;
 
-        int framesToMix = Math.min(BUFFER_FRAMES - outputFrame, active.sound.frameCount - inputFrame);
+        int framesToMix = Math.min(BUFFER_FRAMES - outputFrame, active.sound.frameCount() - inputFrame);
         for (int frame = 0; frame < framesToMix; frame++) {
-            int inputOffset = (inputFrame + frame) * FRAME_SIZE;
+            int inputOffset = (inputFrame + frame) * CHANNELS;
             int outputOffset = (outputFrame + frame) * CHANNELS;
             for (int channel = 0; channel < CHANNELS; channel++) {
-                int sampleOffset = inputOffset + channel * BYTES_PER_SAMPLE;
-                int sample = (active.sound.data[sampleOffset] & 0xff) | (active.sound.data[sampleOffset + 1] << 8);
-                mixBuffer[outputOffset + channel] += sample;
+                mixBuffer[outputOffset + channel] += active.sound.samples[inputOffset + channel];
             }
         }
 
@@ -223,7 +226,7 @@ class AltSoundMixer implements Runnable {
         for (int i = 0; i < mixBuffer.length; i++) {
             int sample = Math.round(mixBuffer[i] * volume);
             sample = Math.max(Short.MIN_VALUE, Math.min(Short.MAX_VALUE, sample));
-            int outputOffset = i * BYTES_PER_SAMPLE;
+            int outputOffset = i * 2;
             outputBuffer[outputOffset] = (byte) sample;
             outputBuffer[outputOffset + 1] = (byte) (sample >> 8);
         }
@@ -241,12 +244,14 @@ class AltSoundMixer implements Runnable {
     }
 
     private static class CachedSound {
-        private final byte[] data;
-        private final int frameCount;
+        private final short[] samples;
 
-        private CachedSound(byte[] data, int frameCount) {
-            this.data = data;
-            this.frameCount = frameCount;
+        private CachedSound(short[] samples) {
+            this.samples = samples;
+        }
+
+        private int frameCount() {
+            return samples.length / CHANNELS;
         }
     }
 
@@ -264,18 +269,11 @@ class AltSoundMixer implements Runnable {
     }
 }
 
-public class AltSoundSystem extends Thread {
-
-    private final String filename;
-    private final boolean isSync;
-
-    public AltSoundSystem(String wavfile, boolean synced) {
-        filename = wavfile;
-        isSync = synced;
+public final class AltSoundSystem {
+    private AltSoundSystem() {
     }
 
-    @Override
-    public void run() {
-        AltSoundMixer.play(filename, isSync);
+    public static void play(String filename, boolean isSynchronized) {
+        AltSoundMixer.play(filename, isSynchronized);
     }
 }


### PR DESCRIPTION
## Summary

Reworks the desktop “Use Alternate Sound System” path to use a shared PCM mixer instead of opening a new `SourceDataLine` for every sound effect.

The previous alternate path avoided JavaSound `Clip`, but each effect still created and opened its own audio line. In bursty cases like dealing cards or auto-tapping lands, that caused irregular timing, overlapping artifacts, and poor rhythm. This change keeps the alternate path `Clip`-free while making playback much closer to the normal sound system.

## Changes

- Adds a shared alternate sound mixer thread for desktop sound effects.
- Decodes and caches sound effects as PCM samples.
- Mixes overlapping effects into one long-lived `SourceDataLine`.
- Removes per-sound thread creation from the desktop alternate sound path.
- Preserves synchronized-sound behavior and total playback caps.
- Adds slightly wider repeat spacing for short repeated effects:
  - `draw.mp3`
  - `tap.mp3`
  - `untap.mp3`
- Leaves mobile/libGDX sound paths untouched.
- Adds no new dependency.

## Why

This was motivated by intermittent desktop sound/lockup issues where the normal `Clip` path appeared to crash inside the Java/PipeWire audio stack. The alternate sound system avoided that path, but sounded noticeably wrong for repeated effects. A shared mixer avoids `Clip` and avoids per-effect audio-line setup jitter.

Thanks to Codex for help with code!