### PR TITLE
MagicStack: store CastThisTurn as SpellAbility

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/SetStateAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/SetStateAi.java
@@ -129,7 +129,7 @@ public class SetStateAi extends SpellAbilityAi {
         return compareCards(card, transformed, ai, ph);
     }
 
-    private boolean shouldTurnFace(Card card, Player ai, PhaseHandler ph, String mode) {
+    private boolean shouldTurnFace(Card card, final Player ai, PhaseHandler ph, String mode) {
         if (card.isFaceDown()) {
             if ("TurnFaceDown".equals(mode)) {
                 return false;
@@ -137,13 +137,8 @@ public class SetStateAi extends SpellAbilityAi {
             // hidden agenda
             if (card.getState(CardStateName.Original).hasKeyword(Keyword.HIDDEN_AGENDA)
                     && card.isInZone(ZoneType.Command)) {
-                String chosenName = card.getNamedCard();
-                for (Card cast : ai.getGame().getStack().getSpellsCastThisTurn()) {
-                    if (cast.getController() == ai && cast.getName().equals(chosenName)) {
-                        return true;
-                    }
-                }
-                return false;
+                final String chosenName = card.getNamedCard();
+                return ai.getGame().getStack().getSpellsCastThisTurn().stream().anyMatch(sp -> ai.equals(sp.getActivatingPlayer()) && sp.getHostCard().getName().equals(chosenName));
             }
 
             // non-permanent facedown can't be turned face up

--- a/forge-game/src/main/java/forge/game/CardTraitBase.java
+++ b/forge-game/src/main/java/forge/game/CardTraitBase.java
@@ -509,15 +509,8 @@ public abstract class CardTraitBase implements GameObject, IHasCardView, IHasSVa
         }
 
         if (params.containsKey("WerewolfUntransformCondition")) {
-            List<Card> casted = game.getStack().getSpellsCastLastTurn();
-            boolean conditionMet = false;
-            for (Player p : game.getPlayers()) {
-                if (CardLists.count(casted, CardPredicates.isController(p)) > 1) {
-                    conditionMet = true;
-                    break;
-                }
-            }
-            if (!conditionMet) {
+            final List<Card> casted = game.getStack().getSpellsCastLastTurn();
+            if (game.getPlayers().stream().noneMatch(p -> CardLists.count(casted, CardPredicates.isController(p)) > 1)) {
                 return false;
             }
         }

--- a/forge-game/src/main/java/forge/game/Game.java
+++ b/forge-game/src/main/java/forge/game/Game.java
@@ -1416,7 +1416,7 @@ public class Game {
 
     public boolean isVoid() {
         return getLeftBattlefieldThisTurn().stream().anyMatch(c -> !c.isLand()) ||
-                getStack().getSpellsCastThisTurn().stream().anyMatch(s -> s.getCastSA().isWarp());
+                getStack().getSpellsCastThisTurn().stream().anyMatch(SpellAbility::isWarp);
     }
 
     public int getAITimeout() {

--- a/forge-game/src/main/java/forge/game/card/CardProperty.java
+++ b/forge-game/src/main/java/forge/game/card/CardProperty.java
@@ -657,7 +657,7 @@ public class CardProperty {
                             return false;
                         break;
                     case "LastCastThisTurn":
-                        final List<Card> c = game.getStack().getSpellsCastThisTurn();
+                        final List<Card> c = game.getStack().getSpellCardsCastThisTurn();
                         if (c.isEmpty() || !card.sharesColorWith(c.get(c.size() - 1))) {
                             return false;
                         }

--- a/forge-game/src/main/java/forge/game/card/CardUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardUtil.java
@@ -126,7 +126,7 @@ public final class CardUtil {
     }
 
     public static List<Card> getThisTurnCast(final String valid, final Card src, final CardTraitBase ctb, final Player controller) {
-        return CardLists.getValidCardsAsList(src.getGame().getStack().getSpellsCastThisTurn(), valid, controller, src, ctb);
+        return CardLists.getValidCardsAsList(src.getGame().getStack().getSpellCardsCastThisTurn(), valid, controller, src, ctb);
     }
 
     public static List<Card> getLastTurnCast(final String valid, final Card src, final CardTraitBase ctb, final Player controller) {

--- a/forge-game/src/main/java/forge/game/cost/CostAdjustment.java
+++ b/forge-game/src/main/java/forge/game/cost/CostAdjustment.java
@@ -542,7 +542,7 @@ public class CostAdjustment {
                         if (st.hasParam("ValidCard")) {
                             list = CardUtil.getThisTurnCast(st.getParam("ValidCard"), hostCard, st, controller);
                         } else {
-                            list = game.getStack().getSpellsCastThisTurn();
+                            list = game.getStack().getSpellCardsCastThisTurn();
                         }
 
                         if (st.hasParam("ValidSpell")) {

--- a/forge-game/src/main/java/forge/game/player/Player.java
+++ b/forge-game/src/main/java/forge/game/player/Player.java
@@ -101,7 +101,6 @@ public class Player extends GameEntity implements Comparable<Player> {
     private int landsPlayedThisTurn;
     private int landsPlayedLastTurn;
     private int numPowerSurgeLands;
-    private int spellsCastThisTurn;
     private int spellsCastThisGame;
     private int spellsCastLastTurn;
     private List<Card> spellsCastSinceBeginningOfLastTurn = Lists.newArrayList();
@@ -2125,7 +2124,8 @@ public class Player extends GameEntity implements Comparable<Player> {
     }
 
     public final boolean hasSurge() {
-        return !CardLists.filterControlledBy(game.getStack().getSpellsCastThisTurn(), getYourTeam()).isEmpty();
+        PlayerCollection team = getYourTeam();
+        return game.getStack().getSpellsCastThisTurn().stream().anyMatch(sp -> team.contains(sp.getActivatingPlayer()));
     }
 
     public final boolean hasBloodthirst() {
@@ -2299,7 +2299,7 @@ public class Player extends GameEntity implements Comparable<Player> {
     }
 
     public final List<Card> getSpellsCastSinceBegOfYourLastTurn() {
-        List<Card> all = new ArrayList<>(game.getStack().getSpellsCastThisTurn());
+        List<Card> all = new ArrayList<>(game.getStack().getSpellCardsCastThisTurn());
         all.addAll(spellsCastSinceBeginningOfLastTurn);
         return all;
     }
@@ -2311,21 +2311,15 @@ public class Player extends GameEntity implements Comparable<Player> {
     }
 
     public final int getSpellsCastThisTurn() {
-        return spellsCastThisTurn;
+        return (int) getGame().getStack().getSpellsCastThisTurn().stream().filter(sp -> this.equals(sp.getActivatingPlayer())).count();
     }
     public final int getSpellsCastLastTurn() {
         return spellsCastLastTurn;
     }
     public final void addSpellCastThisTurn() {
-        spellsCastThisTurn++;
         spellsCastThisGame++;
         achievementTracker.spellsCast++;
-        if (spellsCastThisTurn > achievementTracker.maxStormCount) {
-            achievementTracker.maxStormCount = spellsCastThisTurn;
-        }
-    }
-    public final void resetSpellsCastThisTurn() {
-        spellsCastThisTurn = 0;
+        achievementTracker.maxStormCount = Math.max(achievementTracker.maxStormCount, getSpellsCastThisTurn());
     }
     public final void setSpellsCastLastTurn(int num) {
         spellsCastLastTurn = num;
@@ -2498,7 +2492,6 @@ public class Player extends GameEntity implements Comparable<Player> {
         resetVenturedThisTurn();
         setDescended(0);
         setSpellsCastLastTurn(getSpellsCastThisTurn());
-        resetSpellsCastThisTurn();
         setLifeLostLastTurn(getLifeLostThisTurn());
         setLifeLostThisTurn(0);
         setLifeGainedThisTurn(0);

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbility.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbility.java
@@ -551,7 +551,7 @@ public class StaticAbility extends CardTraitBase implements IIdentifiable, Clone
     }
 
     public int getMayPlayTurn() {
-        return mayPlayTurn;
+        return mayPlayTurn + (int)this.hostCard.getGame().getStack().getSpellsCastThisTurn().stream().filter(sp -> this.equals(sp.getMayPlay())).count();
     }
 
     public void incMayPlayTurn() {

--- a/forge-game/src/main/java/forge/game/trigger/TriggerChangesZone.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerChangesZone.java
@@ -170,7 +170,7 @@ public class TriggerChangesZone extends Trigger {
         /* this trigger only activates for the nth spell you cast this turn */
         if (hasParam("ConditionYouCastThisTurn")) {
             final String compare = getParam("ConditionYouCastThisTurn");
-            List<Card> thisTurnCast = getHostCard().getGame().getStack().getSpellsCastThisTurn();
+            List<Card> thisTurnCast = getHostCard().getGame().getStack().getSpellCardsCastThisTurn();
             thisTurnCast = CardLists.filterControlledByAsList(thisTurnCast, getHostCard().getController());
 
             // checks which card this spell was the castSA

--- a/forge-game/src/main/java/forge/game/zone/MagicStack.java
+++ b/forge-game/src/main/java/forge/game/zone/MagicStack.java
@@ -71,7 +71,7 @@ public class MagicStack /* extends MyObservable */ implements Iterable<SpellAbil
     private boolean frozen = false;
     private boolean bResolving = false;
 
-    private final List<Card> thisTurnCast = Lists.newArrayList();
+    private final List<SpellAbility> thisTurnCast = Lists.newArrayList();
     private List<Card> lastTurnCast = Lists.newArrayList();
     private final List<SpellAbility> thisTurnActivated = Lists.newArrayList();
 
@@ -101,6 +101,7 @@ public class MagicStack /* extends MyObservable */ implements Iterable<SpellAbil
         primaryAbility = null;
         lastTurnCast.clear();
         thisTurnCast.clear();
+        thisTurnActivated.clear();
         curResolvingCard = null;
         frozenStack.clear();
         clearUndoStack();
@@ -135,7 +136,7 @@ public class MagicStack /* extends MyObservable */ implements Iterable<SpellAbil
                 ability.setHostCard(game.getAction().moveToStack(source, ability));
             }
             if (ability.equals(source.getCastSA())) {
-                SpellAbility cause = ability.copy(source, true);
+                SpellAbility cause = ability.copy(CardCopyService.getLKICopy(source), true);
 
                 cause.setLastStateBattlefield(game.getLastStateBattlefield());
                 cause.setLastStateGraveyard(game.getLastStateGraveyard());
@@ -360,9 +361,9 @@ public class MagicStack /* extends MyObservable */ implements Iterable<SpellAbil
         Map<AbilityKey, Object> runParams = AbilityKey.newMap();
 
         if (sp.isSpell() && !sp.isCopied()) {
-            final Card lki = CardCopyService.getLKICopy(source);
+            final Card lki = sp.equals(source.getCastSA()) ? source.getCastSA().getHostCard() : CardCopyService.getLKICopy(source);
             runParams.put(AbilityKey.CardLKI, lki);
-            thisTurnCast.add(lki);
+            thisTurnCast.add(sp.equals(source.getCastSA()) ? source.getCastSA() : sp.copy(lki, true));
             sp.getActivatingPlayer().addSpellCastThisTurn();
 
             // Add expend mana
@@ -376,7 +377,7 @@ public class MagicStack /* extends MyObservable */ implements Iterable<SpellAbil
         runParams.put(AbilityKey.Activator, activator);
         runParams.put(AbilityKey.SpellAbility, sp);
         runParams.put(AbilityKey.CurrentStormCount, thisTurnCast.size());
-        runParams.put(AbilityKey.CurrentCastSpells, Lists.newArrayList(thisTurnCast));
+        runParams.put(AbilityKey.CurrentCastSpells, getSpellCardsCastThisTurn());
 
         if (!sp.isCopied()) {
             // Run SpellAbilityCast triggers
@@ -523,11 +524,8 @@ public class MagicStack /* extends MyObservable */ implements Iterable<SpellAbil
             System.out.println(sp.getHostCard().getName() + " - activatingPlayer not set before adding to stack.");
         }
 
-        if (sp.isSpell() && sp.getMayPlay() != null) {
-            sp.getMayPlay().incMayPlayTurn();
-            if (sp.getMayPlay().hasParam("ReplaceGraveyard")) {
-                PlayEffect.addReplaceGraveyardEffect(sp.getHostCard(), sp.getMayPlay().getHostCard(), sp, sp, sp.getMayPlay().getParam("ReplaceGraveyard"));
-            }
+        if (sp.isSpell() && sp.getMayPlay() != null && sp.getMayPlay().hasParam("ReplaceGraveyard")) {
+            PlayEffect.addReplaceGraveyardEffect(sp.getHostCard(), sp.getMayPlay().getHostCard(), sp, sp, sp.getMayPlay().getParam("ReplaceGraveyard"));
         }
         si = si == null ? new SpellAbilityStackInstance(sp, id) : si;
 
@@ -920,8 +918,11 @@ public class MagicStack /* extends MyObservable */ implements Iterable<SpellAbil
         return false;
     }
 
-    public final List<Card> getSpellsCastThisTurn() {
+    public final List<SpellAbility> getSpellsCastThisTurn() {
         return thisTurnCast;
+    }
+    public final List<Card> getSpellCardsCastThisTurn() {
+        return thisTurnCast.stream().map(SpellAbility::getHostCard).collect(Collectors.toList());
     }
     public final List<Card> getSpellsCastLastTurn() {
         return lastTurnCast;
@@ -936,11 +937,12 @@ public class MagicStack /* extends MyObservable */ implements Iterable<SpellAbil
             lastTurnCast = Lists.newArrayList();
             return;
         }
+        List<Card> thisTurnCastCards = getSpellCardsCastThisTurn();
         for (Player player : game.getPlayers()) {
-            player.addSpellCastSinceBegOfYourLastTurn(thisTurnCast);
+            player.addSpellCastSinceBegOfYourLastTurn(thisTurnCastCards);
         }
-        lastTurnCast = Lists.newArrayList(thisTurnCast);
-        thisTurnCast.clear();
+        lastTurnCast = Lists.newArrayList(thisTurnCastCards);
+        this.thisTurnCast.clear();
         game.updateStackForView();
     }
 


### PR DESCRIPTION
Part of #4700 and related to #10465

This makes castThisTurn into a `List<SpellAbility>` instead of a `List<Card>`

while the Card -> castSA still can be done via `CardPredicates.castSA` and other stuff,
`getActivationPlayer` might be different from `getController`?

also it's an easier access to `getMayPlay()`