### PR TITLE
Restrict fog effect scan in isPreventCombatDamageThisTurn to zones where it can be active (AI perf)

### DIFF
--- a/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
@@ -910,24 +910,21 @@ public class ReplacementHandler {
      * @return true if there is some resolved fog effect
      */
     public final boolean isPreventCombatDamageThisTurn() {
-        final List<ReplacementEffect> list = Lists.newArrayList();
-        game.forEachCardInGame(new Visitor<Card>() {
-            @Override
-            public boolean visit(Card c) {
-                for (final ReplacementEffect re : c.getReplacementEffects()) {
-                    if (re.getMode() == ReplacementType.DamageDone
-                            && re.getLayer() == ReplacementLayer.Other
-                            && re.hasParam("Prevent") && re.getParam("Prevent").equals("True")
-                            && re.hasParam("IsCombat") && re.getParam("IsCombat").equals("True")
-                            && !re.hasParam("ValidSource") && !re.hasParam("ValidTarget")
-                            && re.zonesCheck(game.getZoneOf(c))) {
-                        list.add(re);
-                    }
+        // a fog effect can only be active from a zone in STATIC_ABILITIES_SOURCE_ZONES
+        // (zonesCheck below rejects other zones), so don't scan libraries and hands
+        for (final Card c : game.getCardsIn(ZoneType.STATIC_ABILITIES_SOURCE_ZONES)) {
+            for (final ReplacementEffect re : c.getReplacementEffects()) {
+                if (re.getMode() == ReplacementType.DamageDone
+                        && re.getLayer() == ReplacementLayer.Other
+                        && "True".equals(re.getParam("Prevent"))
+                        && "True".equals(re.getParam("IsCombat"))
+                        && !re.hasParam("ValidSource") && !re.hasParam("ValidTarget")
+                        && re.zonesCheck(game.getZoneOf(c))) {
+                    return true;
                 }
-                return true;
             }
-        });
-        return !list.isEmpty();
+        }
+        return false;
     }
 
     public boolean isReplacing() {


### PR DESCRIPTION
Performance fix for the AI slowdown investigated in #3410.

`ReplacementHandler.isPreventCombatDamageThisTurn()` currently visits **every card in every zone** (including all libraries and hands) via `forEachCardInGame`, and builds a full `List` of matching replacement effects just to call `isEmpty()` on it. This method sits at the bottom of the AI's combat-prediction hot path (`GameEntity.staticDamagePrevention` → `ComputerUtilCombat.predictDamageTo`), where it is called once per attacker per hypothetical block assignment per candidate spell ability — in multiplayer Commander that is easily thousands of full-game scans (~500 cards each) per AI decision. This is the same hotspot @Agetian profiled in #3410 (comment of 2023-07-06); it is also reproducible on 2.0.13 in 5-player Commander vs 4 AIs, where AI decisions routinely hit `MATCH_AI_TIMEOUT`.

### Change

* Scan only `game.getCardsIn(ZoneType.STATIC_ABILITIES_SOURCE_ZONES)` (Battlefield, Graveyard, Exile, Command, Stack) instead of every card in the game. This is behavior-preserving: the existing `re.zonesCheck(game.getZoneOf(c))` condition already rejects replacement effects on cards in other zones — they were being visited and then filtered out. Fog-type lasting effects live on battlefield permanents or command-zone effect cards, both covered. (Same zone set the neighboring code in `GameEntity.staticDamagePrevention` uses for its own replacement-effect scan.)
* Early-exit on the first match instead of collecting all matches into a list.

No functional change intended; this only reduces the cards visited (in a typical 5-player Commander game, from ~500 to the ~100 in the zones where such an effect can actually be active) and stops the scan at the first hit.

### Verification

* `forge-game` compiles cleanly with the change (`mvn -f forge-game/pom.xml compile`).
* The rewritten condition uses `"True".equals(re.getParam(...))`, which is null-safe, so the dropped `hasParam` checks are covered.

Further follow-ups discussed in #3410 (hoisting this check out of the per-attacker loop, and making `AiBlockController.makeChumpBlocks` avoid re-running `lifeInDanger` at every recursion level) would attack the remaining multipliers — happy to work on those separately if this approach is welcome.
