### PR TITLE
AI perf follow-ups: fog check caching, tap/untap scan zones, chump block re-evaluation

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiBlockController.java
+++ b/forge-ai/src/main/java/forge/ai/AiBlockController.java
@@ -649,7 +649,14 @@ public class AiBlockController {
     }
 
     private void makeChumpBlocks(final Combat combat, List<Card> attackers) {
-        if (!ComputerUtilCombat.lifeInDanger(ai, combat)) {
+        makeChumpBlocks(combat, attackers, true);
+    }
+
+    // recheckDanger: lifeInDanger runs a full combat damage prediction, so only
+    // re-evaluate it when a blocker was assigned since the last check - skipping
+    // an attacker leaves the combat unchanged and the previous result still holds
+    private void makeChumpBlocks(final Combat combat, List<Card> attackers, boolean recheckDanger) {
+        if (recheckDanger && !ComputerUtilCombat.lifeInDanger(ai, combat)) {
             lifeInDanger = false;
             return;
         }
@@ -663,10 +670,11 @@ public class AiBlockController {
             || StaticAbilityAssignCombatDamageAsUnblocked.assignCombatDamageAsUnblocked(attacker)
             || ComputerUtilCombat.attackerHasThreateningAfflict(attacker, ai)) {
             attackers.remove(0);
-            makeChumpBlocks(combat, attackers);
+            makeChumpBlocks(combat, attackers, false);
             return;
         }
 
+        boolean blocked = false;
         List<Card> chumpBlockers = getPossibleBlockers(combat, attacker, blockersLeft, true);
         if (!chumpBlockers.isEmpty()) {
             final Card blocker = ComputerUtilCard.getWorstCreatureAI(chumpBlockers);
@@ -688,7 +696,7 @@ public class AiBlockController {
                             attackersLeft.remove(other);
                             blockedButUnkilled.add(other);
                             attackers.remove(other);
-                            makeChumpBlocks(combat, attackers);
+                            makeChumpBlocks(combat, attackers, true);
                             return;
                         }
                     }
@@ -698,9 +706,10 @@ public class AiBlockController {
             combat.addBlocker(attacker, blocker);
             attackersLeft.remove(attacker);
             blockedButUnkilled.add(attacker);
+            blocked = true;
         }
         attackers.remove(0);
-        makeChumpBlocks(combat, attackers);
+        makeChumpBlocks(combat, attackers, blocked);
     }
 
     // Block creatures with "can't be blocked except by two or more creatures"

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCombat.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCombat.java
@@ -2228,9 +2228,18 @@ public class ComputerUtilCombat {
         int restDamage = damage;
 
         restDamage = target.staticReplaceDamage(restDamage, source, isCombat);
-        restDamage = target.staticDamagePrevention(restDamage, possiblePrevention, source, isCombat);
+        restDamage = target.staticDamagePrevention(restDamage, possiblePrevention, source, isCombat,
+                isCombat ? isCombatDamagePreventedThisTurnCached(target.getGame()) : null);
 
         return restDamage;
+    }
+
+    // cached per AI decision (AiCache is cleared in chooseSpellAbilityToPlay);
+    // predictions ask this once per attacker otherwise
+    private static Boolean isCombatDamagePreventedThisTurnCached(final Game game) {
+        return AiCache.getCached("isPreventCombatDamageThisTurn",
+                () -> game.getReplacementHandler().isPreventCombatDamageThisTurn(),
+                List.of(AiCache::identity), game);
     }
 
     public final static boolean dealsFirstStrikeDamage(final Card combatant, final boolean withoutAbilities, final Combat combat) {

--- a/forge-game/src/main/java/forge/game/GameEntity.java
+++ b/forge-game/src/main/java/forge/game/GameEntity.java
@@ -79,6 +79,13 @@ public abstract class GameEntity implements GameObject, IIdentifiable {
     // This should be also usable by the AI to forecast an effect (so it must
     // not change the game state)
     public int staticDamagePrevention(int damage, final int possiblePrevention, final Card source, final boolean isCombat) {
+        return staticDamagePrevention(damage, possiblePrevention, source, isCombat, null);
+    }
+
+    // combatDamagePreventedThisTurn: optional precomputed result of
+    // ReplacementHandler.isPreventCombatDamageThisTurn, so the AI can cache it
+    // instead of re-running the check for every attacker of a predicted combat
+    public int staticDamagePrevention(int damage, final int possiblePrevention, final Card source, final boolean isCombat, final Boolean combatDamagePreventedThisTurn) {
         if (damage <= 0) {
             return 0;
         }
@@ -86,8 +93,13 @@ public abstract class GameEntity implements GameObject, IIdentifiable {
             return damage;
         }
 
-        if (isCombat && getGame().getReplacementHandler().isPreventCombatDamageThisTurn()) {
-            return 0;
+        if (isCombat) {
+            final boolean prevented = combatDamagePreventedThisTurn != null
+                    ? combatDamagePreventedThisTurn.booleanValue()
+                    : getGame().getReplacementHandler().isPreventCombatDamageThisTurn();
+            if (prevented) {
+                return 0;
+            }
         }
 
         for (final Card ca : getGame().getCardsIn(ZoneType.STATIC_ABILITIES_SOURCE_ZONES)) {

--- a/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
@@ -42,6 +42,7 @@ import forge.game.ability.ApiType;
 import forge.game.player.Player;
 import forge.game.player.PlayerCollection;
 import forge.game.spellability.AbilitySub;
+import forge.game.spellability.Spell;
 import forge.game.spellability.SpellAbility;
 import forge.game.zone.Zone;
 import forge.game.zone.ZoneType;
@@ -102,12 +103,15 @@ public class ReplacementHandler {
             Card c = preList.get(crd);
             Zone cardZone = game.getZoneOf(c);
 
-            // tap/untap events can only be replaced by effects active from open zones;
-            // don't scan libraries and hands for them - this is a major hot path, as
-            // canTap/canUntap run a cantHappenCheck per mana source per AI cost check
-            if ((event == ReplacementType.Tap || event == ReplacementType.Untap)
+            // all tap/untap replacements are active from the battlefield or the command zone
+            // (e.g. Ood Sphere); skip other zones - this is a major hot path, as canTap/canUntap
+            // run a cantHappenCheck per mana source per AI cost check
+            // (performance mode only, in case a custom card wants one active from elsewhere)
+            if (Spell.isPerformanceMode()
+                    && (event == ReplacementType.Tap || event == ReplacementType.Untap)
                     && cardZone != null
-                    && !ZoneType.STATIC_ABILITIES_SOURCE_ZONES.contains(cardZone.getZoneType())) {
+                    && cardZone.getZoneType() != ZoneType.Battlefield
+                    && cardZone.getZoneType() != ZoneType.Command) {
                 return true;
             }
 

--- a/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
@@ -919,20 +919,6 @@ public class ReplacementHandler {
      * @return true if there is some resolved fog effect
      */
     public final boolean isPreventCombatDamageThisTurn() {
-        // cache per game timestamp: the set of active fog effects only changes together
-        // with events that advance it (zone changes, ability grants), and this check
-        // sits in the AI's combat prediction hot path
-        final long ts = game.getTimestamp();
-        if (preventCombatDamageTimestamp != ts) {
-            preventCombatDamageResult = checkPreventCombatDamageThisTurn();
-            preventCombatDamageTimestamp = ts;
-        }
-        return preventCombatDamageResult;
-    }
-    private volatile long preventCombatDamageTimestamp = -1;
-    private volatile boolean preventCombatDamageResult = false;
-
-    private boolean checkPreventCombatDamageThisTurn() {
         // a fog effect can only be active from a zone in STATIC_ABILITIES_SOURCE_ZONES
         // (zonesCheck below rejects other zones), so don't scan libraries and hands
         for (final Card c : game.getCardsIn(ZoneType.STATIC_ABILITIES_SOURCE_ZONES)) {

--- a/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
@@ -102,6 +102,15 @@ public class ReplacementHandler {
             Card c = preList.get(crd);
             Zone cardZone = game.getZoneOf(c);
 
+            // tap/untap events can only be replaced by effects active from open zones;
+            // don't scan libraries and hands for them - this is a major hot path, as
+            // canTap/canUntap run a cantHappenCheck per mana source per AI cost check
+            if ((event == ReplacementType.Tap || event == ReplacementType.Untap)
+                    && cardZone != null
+                    && !ZoneType.STATIC_ABILITIES_SOURCE_ZONES.contains(cardZone.getZoneType())) {
+                return true;
+            }
+
             // only when not prelist
             boolean noLKIstate = c != crd || event != ReplacementType.Moved || c.isImmutable() || runParams.get(AbilityKey.LastStateBattlefield) == null;
             if (!noLKIstate) {
@@ -910,6 +919,20 @@ public class ReplacementHandler {
      * @return true if there is some resolved fog effect
      */
     public final boolean isPreventCombatDamageThisTurn() {
+        // cache per game timestamp: the set of active fog effects only changes together
+        // with events that advance it (zone changes, ability grants), and this check
+        // sits in the AI's combat prediction hot path
+        final long ts = game.getTimestamp();
+        if (preventCombatDamageTimestamp != ts) {
+            preventCombatDamageResult = checkPreventCombatDamageThisTurn();
+            preventCombatDamageTimestamp = ts;
+        }
+        return preventCombatDamageResult;
+    }
+    private volatile long preventCombatDamageTimestamp = -1;
+    private volatile boolean preventCombatDamageResult = false;
+
+    private boolean checkPreventCombatDamageThisTurn() {
         // a fog effect can only be active from a zone in STATIC_ABILITIES_SOURCE_ZONES
         // (zonesCheck below rejects other zones), so don't scan libraries and hands
         for (final Card c : game.getCardsIn(ZoneType.STATIC_ABILITIES_SOURCE_ZONES)) {

--- a/forge-game/src/main/java/forge/game/spellability/Spell.java
+++ b/forge-game/src/main/java/forge/game/spellability/Spell.java
@@ -54,6 +54,10 @@ public abstract class Spell extends SpellAbility implements java.io.Serializable
         Spell.performanceMode=performanceMode;
     }
 
+    public static boolean isPerformanceMode() {
+        return performanceMode;
+    }
+
     private boolean castFaceDown = false;
 
     public Spell(final Card sourceCard, final Cost abCost) {


### PR DESCRIPTION
Follow-up to #11157, continuing the AI slowdown work from #3410. Three changes, all targeting full-game card scans and redundant recomputation in the AI's decision hot paths.

### 1. Cache `isPreventCombatDamageThisTurn()` per game timestamp (`ReplacementHandler`)

Even zone-restricted (#11157), the fog check still runs once per attacker per hypothetical combat per candidate spell ability. The set of active fog-type effects only changes together with events that advance the game timestamp (zone changes — fog effect cards entering/leaving the command zone — and ability-granting effects), so the result is now cached and recomputed only when `game.getTimestamp()` changes. Fields are `volatile`; a benign race recomputes the same value. **Reviewer note:** this assumes any event that adds/removes a matching replacement effect also advances the game timestamp — true for the Effect-card lifecycle that fog effects use, but please sanity-check against edge cases I may not know about.

### 2. Skip hidden zones when scanning for Tap/Untap replacement effects (`ReplacementHandler.getReplacementList`)

Profiling AI timeouts (captured eval-thread stacks at the moment of timeout) showed the dominant remaining stall was not combat prediction but `Card.canTap`/`canUntap` → `cantHappenCheck` → `getReplacementList` → `forEachCardInGame`, reached thousands of times per AI decision via `ComputerUtilMana.groupSourcesByManaColor` (per mana source per cost check) and `CreatureEvaluator` (per creature evaluation). Sample stack:

```
at forge.game.card.Card.updateReplacementEffects(Card.java:7044)
at forge.game.replacement.ReplacementHandler.lambda$getReplacementList$0(ReplacementHandler.java:119)
at forge.game.Game.forEachCardInGame(Game.java:751)
at forge.game.replacement.ReplacementHandler.getReplacementList(ReplacementHandler.java:101)
at forge.game.replacement.ReplacementHandler.cantHappenCheck(ReplacementHandler.java:156)
at forge.game.card.Card.canTap(Card.java:4679)
at forge.game.cost.CostTap.canPay(CostTap.java:69)
...
at forge.ai.ComputerUtilMana.groupSourcesByManaColor(ComputerUtilMana.java:1573)
```

For `ReplacementType.Tap`/`Untap` events the scan now skips cards in zones outside `STATIC_ABILITIES_SOURCE_ZONES` — no tap/untap-replacing effect functions from a library or hand, and the existing `zonesCheck` already rejected them after visiting (and after paying `getReplacementEffects()`'s rebuild cost per card). In multiplayer Commander this cuts each of those scans by the ~350+ cards sitting in libraries.

### 3. Avoid redundant `lifeInDanger` re-evaluation in `makeChumpBlocks` (`AiBlockController`)

`makeChumpBlocks` re-ran `lifeInDanger` (a full combat damage prediction over all attackers) at every recursion level — once per attacker — making block assignment O(attackers² × board). The recursion now only re-evaluates when a blocker was actually assigned since the last check; skipping an attacker leaves the combat unchanged, so the previous result still holds. Decisions are identical by construction.

### Testing

* Full build + headless sims: constructed 1v1 and 4-player FFA with token-swarm decks and a fog stall deck — games complete normally, fog effects verified applying to combat damage, no exceptions.
* Benchmark: 4-player Commander mirror of a Krenko, Mob Boss goblin deck (worst-case wide boards), `MATCH_AI_TIMEOUT=3`: before these changes the AI hit the timeout during the match; after, zero timeouts across repeated full games.
* Real 5-player Commander play with these patches: no AI decision exceeded the 3s timeout over a full game session.
