### PR TITLE
Fix AI eval thread races (timeout cancellation, parallel mustAttack Combat mutation)

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiAttackController.java
+++ b/forge-ai/src/main/java/forge/ai/AiAttackController.java
@@ -940,7 +940,12 @@ public class AiAttackController {
                         }
                     }
                     if (mustAttackDef != null) {
-                        combat.addAttacker(attacker, mustAttackDef);
+                        // combat is shared across these parallel futures and its attacker
+                        // multimap is not thread-safe; unsynchronized addAttacker calls
+                        // collide (ConcurrentModificationException, dropped attackers)
+                        synchronized (combat) {
+                            combat.addAttacker(attacker, mustAttackDef);
+                        }
                         attackersLeft.remove(attacker);
                         numForcedAttackers.incrementAndGet();
                     }

--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -1692,11 +1692,24 @@ public class AiController {
                 }
                 System.out.println(sb);
             }
-            // don't use Thread.stop() even where it still exists (Java <20): killing the
-            // eval thread mid-evaluation corrupts shared state; signal it to exit at the
-            // next SpellAbility via the volatile flag / interrupt instead
+            // ask the eval thread to exit at the next SpellAbility check first: a brutal
+            // Thread.stop() mid-evaluation can leave partially mutated shared state behind
             timeoutReached = true;
             future.cancel(true);
+            try {
+                t.join(500);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+            if (t.isAlive()) {
+                // last resort, see #8302: the eval thread may be stuck inside a single
+                // evaluation or an infinite loop and never reach the cooperative exit
+                try {
+                    t.stop();
+                } catch (UnsupportedOperationException | NoSuchMethodError ex) {
+                    // Stop support: dropped by Android and Java 20 / 26 removed it completely - so sadly thread will keep running
+                }
+            }
             // TODO mark some as skipped to increase chance to find something playable next priority
             return null;
         }

--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -98,7 +98,7 @@ public class AiController {
     private int lastAttackAggression;
     private boolean useLivingEnd;
     private List<SpellAbility> skipped;
-    private boolean timeoutReached;
+    private volatile boolean timeoutReached;
 
     public AiController(final Player computerPlayer, final Game game0) {
         player = computerPlayer;
@@ -1601,7 +1601,7 @@ public class AiController {
                     continue;
                 }
 
-                if (timeoutReached) {
+                if (timeoutReached || Thread.currentThread().isInterrupted()) {
                     timeoutReached = false;
                     break;
                 }
@@ -1681,16 +1681,23 @@ public class AiController {
         try {
             return future.get(game.getAITimeout(), TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            try {
-                e.printStackTrace();
-                t.stop();
-            } catch (UnsupportedOperationException | NoSuchMethodError ex) {
-                // Stop support: dropped by Android and Java 20 / 26 removed it completely - so sadly thread will keep running
-                timeoutReached = true;
-                future.cancel(true);
-                // TODO wait a few more seconds to try and exit at a safe point before letting the engine continue
-                // TODO mark some as skipped to increase chance to find something playable next priority
+            e.printStackTrace();
+            if (e instanceof TimeoutException) {
+                // log where the eval thread currently is - each timeout doubles as a
+                // profiler sample for diagnosing remaining AI slowdowns from user logs
+                StringBuilder sb = new StringBuilder("AI eval thread at timeout:");
+                StackTraceElement[] evalStack = t.getStackTrace();
+                for (int i = 0; i < Math.min(30, evalStack.length); i++) {
+                    sb.append("\n\tat ").append(evalStack[i]);
+                }
+                System.out.println(sb);
             }
+            // don't use Thread.stop() even where it still exists (Java <20): killing the
+            // eval thread mid-evaluation corrupts shared state; signal it to exit at the
+            // next SpellAbility via the volatile flag / interrupt instead
+            timeoutReached = true;
+            future.cancel(true);
+            // TODO mark some as skipped to increase chance to find something playable next priority
             return null;
         }
     }


### PR DESCRIPTION
Two thread-safety fixes for AI evaluation, both reproduced as `ConcurrentModificationException`s in real games / headless sims.

### 1. Cooperative timeout cancellation in `AiController.chooseSpellAbilityToPlayFromList`

The current timeout path tries `Thread.stop()` first. On Java 17 (the version most desktop users run) `stop()` still works — killing the eval thread at an arbitrary point while it holds partially-mutated shared state (`sa.setActivatingPlayer`, host card state, etc.). On Java 20+ it throws and falls back to a cooperative flag that has two defects: `timeoutReached` is **not volatile** (the eval thread may never observe it), and the abandoned thread keeps scanning game state while the game loop moves on — captured in a real game on 2.0.13:

```
java.util.concurrent.ExecutionException: java.util.ConcurrentModificationException
  at forge.ai.AiController.chooseSpellAbilityToPlayFromList(AiController.java:1680)
Caused by: java.util.ConcurrentModificationException
  at forge.util.Visitor.visitAll(Visitor.java:15)
  at forge.game.Game.forEachCardInGame(Game.java:751)
  at forge.game.replacement.ReplacementHandler.isPreventCombatDamageThisTurn(ReplacementHandler.java:913)
  ...
```

Changes: `timeoutReached` is now `volatile`; `Thread.stop()` is removed entirely (cooperative cancel on all Java versions); the eval loop also exits on `Thread.currentThread().isInterrupted()` (set by `future.cancel(true)`). Additionally, on timeout the eval thread's stack is logged (`AI eval thread at timeout:`) — every capped stall in a user log becomes a profiler sample, which is how the hot spots in the companion perf PR were found.

### 2. Synchronize shared `Combat` mutation in `AiAttackController.declareAttackers`

The mustAttack processing runs one `CompletableFuture` per attacker in parallel; `attackersLeft` was made a `ConcurrentLinkedQueue`, but `combat.addAttacker` mutates the combat's attacker multimap, which is not thread-safe. Reproduced in 4-player headless sims with goblin token decks (three occurrences in two games):

```
java.util.concurrent.CompletionException: java.util.ConcurrentModificationException
Caused by: java.util.ConcurrentModificationException
  at com.google.common.collect.AbstractMapBasedMultimap$Itr.next(AbstractMapBasedMultimap.java:1190)
  at forge.game.combat.Combat.getBandOfAttacker(Combat.java:313)
  at forge.game.combat.Combat.addAttacker(Combat.java:263)
  at forge.ai.AiAttackController.lambda$declareAttackers$11(AiAttackController.java:943)
```

Because the exception is swallowed by `.exceptionally(...)`, the colliding attacker is silently dropped from forced-attack processing — a gameplay bug, not just log noise. Fix: synchronize the `combat.addAttacker` call on the shared `combat`. After the fix, repeated 4-player sims show zero CMEs.
