### PR TITLE
AutoUpdater: test connectivity against the actual update host

### DIFF
--- a/forge-gui/src/main/java/forge/download/AutoUpdater.java
+++ b/forge-gui/src/main/java/forge/download/AutoUpdater.java
@@ -114,8 +114,16 @@ public class AutoUpdater {
     }
 
     private boolean testNetConnection() {
+        // test against the host updates are actually fetched from;
+        // releases.cardforge.org is no longer reachable and blocked all updates
+        String host;
+        try {
+            host = new URL(versionUrlString).getHost();
+        } catch (MalformedURLException e) {
+            host = "github.com";
+        }
         try (Socket socket = new Socket()) {
-            InetSocketAddress address = new InetSocketAddress("releases.cardforge.org", 443);
+            InetSocketAddress address = new InetSocketAddress(host, 443);
             socket.connect(address, 1000);
             return true;
         } catch (IOException e) {


### PR DESCRIPTION
Fixes the connectivity gate described in #11162.

`testNetConnection()` probed the hardcoded, no-longer-reachable `releases.cardforge.org:443` before every update check, so `verifyUpdateable()` silently aborted on all channels regardless of actual connectivity. The probe now targets the host of the URL the updater is actually about to fetch from (GitHub for the snapshot channel), falling back to `github.com` if the URL cannot be parsed.

This restores the snapshot update channel end-to-end. The release channel additionally needs its metadata/package URLs moved off the dead host (maintainer decision — see #11162), which this PR intentionally does not touch.
