### PR TITLE
Update quicksilver_speedster.txt

### DIFF
--- a/forge-gui/res/cardsfolder/q/quicksilver_speedster.txt
+++ b/forge-gui/res/cardsfolder/q/quicksilver_speedster.txt
@@ -2,6 +2,7 @@ Name:Quicksilver, Speedster
 ManaCost:3 U R
 Types:Legendary Creature Mutant Hero
 PT:3/4
+K:Flash
 K:Double Strike
 K:Haste
 S:Mode$ CastWithFlash | ValidCard$ Card | ValidSA$ Spell | Caster$ You | IsPresent$ Card.Self+tapped | Description$ As long as NICKNAME is tapped, you may cast spells as though they had flash.


### PR DESCRIPTION
Per Oracle text, adds Flash to not-Flash because he lacked Flash and couldn't be there in a flash like the Flash.