### PR TITLE
Feature/11167: Revamped input handling + better road detection

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/stage/Console.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/Console.java
@@ -18,11 +18,13 @@ public class Console extends Window {
 
     public void toggle() {
         if (isVisible()) {
+            Forge.advFreezePlayerControls = false;
             setVisible(false);
             getStage().unfocus(input);
             Gdx.input.setOnscreenKeyboardVisible(false);
         } else {
             if (!Forge.advFreezePlayerControls) {
+                Forge.advFreezePlayerControls = true;
                 setVisible(true);
                 getStage().setKeyboardFocus(input);
             }
@@ -58,7 +60,6 @@ public class Console extends Window {
                                     textField.setCursorPosition(Integer.MAX_VALUE);
                                 } else {
                                     index = 0;
-                                    textField.setText(commands.get(index));
                                     textField.setCursorPosition(Integer.MAX_VALUE);
                                 }
                             } else if (!commands.isEmpty()) {
@@ -78,7 +79,7 @@ public class Console extends Window {
                                     textField.setCursorPosition(Integer.MAX_VALUE);
                                 } else {
                                     index = commands.size - 1;
-                                    textField.setText(commands.get(index));
+                                    textField.setText("");
                                     textField.setCursorPosition(Integer.MAX_VALUE);
                                 }
                             } else if (!commands.isEmpty()) {

--- a/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
@@ -252,7 +252,6 @@ public abstract class GameStage extends Stage {
         showDialog();
     }
 
-
     public boolean axisMoved(Controller controller, int axisIndex, float value) {
         if (MapStage.getInstance().isDialogOnlyInput() || isPaused()) {
             return true;
@@ -267,7 +266,6 @@ public abstract class GameStage extends Stage {
         Fly
 
     }
-
 
     HashMap<PlayerModification, Float> currentModifications = new HashMap<>();
 
@@ -355,28 +353,24 @@ public abstract class GameStage extends Stage {
     @Override
     public final void act(float delta) {
         keyboardInput.setZero();
-
         for (int key : KeyBinding.Left.getBindings()) {
             if (Gdx.input.isKeyPressed(key)) {
                 keyboardInput.x = -1;
                 break;
             }
         }
-
         for (int key : KeyBinding.Right.getBindings()) {
             if (Gdx.input.isKeyPressed(key)) {
                 keyboardInput.x = 1;
                 break;
             }
         }
-
         for (int key : KeyBinding.Up.getBindings()) {
             if (Gdx.input.isKeyPressed(key)) {
                 keyboardInput.y = 1;
                 break;
             }
         }
-
         for (int key : KeyBinding.Down.getBindings()) {
             if (Gdx.input.isKeyPressed(key)) {
                 keyboardInput.y = -1;
@@ -384,9 +378,8 @@ public abstract class GameStage extends Stage {
             }
         }
 
-        Vector2 dir = new Vector2();
-
         // Input priority: touch > controller > keyboard
+        Vector2 dir = new Vector2();
         if (touchX >= 0 && touchInput.len() > 0.2f) {
             dir.set(touchInput);
 
@@ -462,7 +455,6 @@ public abstract class GameStage extends Stage {
     }
 
     abstract protected void onActing(float delta);
-
 
     @Override
     public boolean keyDown(int keycode) {

--- a/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
@@ -1,6 +1,5 @@
 package forge.adventure.stage;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.controllers.Controller;
 import com.badlogic.gdx.files.FileHandle;
@@ -383,29 +382,20 @@ public abstract class GameStage extends Stage {
             player.stop();
         } else {
             keyboardInput.setZero();
-            for (int key : KeyBinding.Left.getBindings()) {
-                if (Gdx.input.isKeyPressed(key)) {
-                    keyboardInput.x = -1;
-                    break;
-                }
+            if (KeyBinding.Left.isPressed()) {
+                keyboardInput.x -= 1;
             }
-            for (int key : KeyBinding.Right.getBindings()) {
-                if (Gdx.input.isKeyPressed(key)) {
-                    keyboardInput.x = 1;
-                    break;
-                }
+
+            if (KeyBinding.Right.isPressed()) {
+                keyboardInput.x += 1;
             }
-            for (int key : KeyBinding.Up.getBindings()) {
-                if (Gdx.input.isKeyPressed(key)) {
-                    keyboardInput.y = 1;
-                    break;
-                }
+
+            if (KeyBinding.Up.isPressed()) {
+                keyboardInput.y += 1;
             }
-            for (int key : KeyBinding.Down.getBindings()) {
-                if (Gdx.input.isKeyPressed(key)) {
-                    keyboardInput.y = -1;
-                    break;
-                }
+
+            if (KeyBinding.Down.isPressed()) {
+                keyboardInput.y -= 1;
             }
 
             // Input priority: touch > controller > keyboard

--- a/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
@@ -352,55 +352,13 @@ public abstract class GameStage extends Stage {
 
     @Override
     public final void act(float delta) {
-        keyboardInput.setZero();
-        for (int key : KeyBinding.Left.getBindings()) {
-            if (Gdx.input.isKeyPressed(key)) {
-                keyboardInput.x = -1;
-                break;
-            }
-        }
-        for (int key : KeyBinding.Right.getBindings()) {
-            if (Gdx.input.isKeyPressed(key)) {
-                keyboardInput.x = 1;
-                break;
-            }
-        }
-        for (int key : KeyBinding.Up.getBindings()) {
-            if (Gdx.input.isKeyPressed(key)) {
-                keyboardInput.y = 1;
-                break;
-            }
-        }
-        for (int key : KeyBinding.Down.getBindings()) {
-            if (Gdx.input.isKeyPressed(key)) {
-                keyboardInput.y = -1;
-                break;
-            }
-        }
-
-        // Input priority: touch > controller > keyboard
-        Vector2 dir = new Vector2();
-        if (touchX >= 0 && touchInput.len() > 0.2f) {
-            dir.set(touchInput);
-
-        } else if (controllerInput.len() > 0.2f) {
-            dir.set(controllerInput);
-
-        } else {
-            dir.set(keyboardInput);
-        }
-        if (dir.len() < 0.01f) {
-            player.stop();
-        } else {
-            player.getMovementDirection().set(dir);
-        }
-
         super.act(delta);
 
         if (animationTimeout >= 0) {
             animationTimeout -= delta;
             return;
         }
+
         Array<PlayerModification> modsToRemove = new Array<>();
         for (Map.Entry<PlayerModification, Float> mod : currentModifications.entrySet()) {
             mod.setValue(mod.getValue() - delta);
@@ -412,28 +370,75 @@ public abstract class GameStage extends Stage {
             onRemoveEffect(mod);
         }
 
-        if (isPaused()) {
-            return;
-        }
-
         if (onEndAction != null) {
-
             onEndAction.run();
             onEndAction = null;
         }
 
-        if (touchX >= 0) {
-            Vector2 target = this.screenToStageCoordinates(new Vector2(touchX, touchY));
+        if (isPaused() || isDialogOnlyInput() || Forge.advFreezePlayerControls) {
+            keyboardInput.setZero();
+            controllerInput.setZero();
+            touchInput.setZero();
+            player.getMovementDirection().setZero();
+            player.stop();
+        } else {
+            keyboardInput.setZero();
+            for (int key : KeyBinding.Left.getBindings()) {
+                if (Gdx.input.isKeyPressed(key)) {
+                    keyboardInput.x = -1;
+                    break;
+                }
+            }
+            for (int key : KeyBinding.Right.getBindings()) {
+                if (Gdx.input.isKeyPressed(key)) {
+                    keyboardInput.x = 1;
+                    break;
+                }
+            }
+            for (int key : KeyBinding.Up.getBindings()) {
+                if (Gdx.input.isKeyPressed(key)) {
+                    keyboardInput.y = 1;
+                    break;
+                }
+            }
+            for (int key : KeyBinding.Down.getBindings()) {
+                if (Gdx.input.isKeyPressed(key)) {
+                    keyboardInput.y = -1;
+                    break;
+                }
+            }
 
-            target.x -= player.getWidth() / 2f;
-            Vector2 diff = target.sub(player.pos());
+            // Input priority: touch > controller > keyboard
+            Vector2 dir = new Vector2();
+            if (touchX >= 0 && touchInput.len() > 0.2f) {
+                dir.set(touchInput);
 
-            if (diff.len() < 2) {
-                touchInput.setZero();
+            } else if (controllerInput.len() > 0.2f) {
+                dir.set(controllerInput);
+
             } else {
-                touchInput.set(diff);
+                dir.set(keyboardInput);
+            }
+            if (dir.len() < 0.01f) {
+                player.stop();
+            } else {
+                player.getMovementDirection().set(dir);
+            }
+
+            if (touchX >= 0) {
+                Vector2 target = this.screenToStageCoordinates(new Vector2(touchX, touchY));
+                target.x -= player.getWidth() / 2f;
+                Vector2 diff = target.sub(player.pos());
+
+                if (diff.len() < 2) {
+                    touchInput.setZero();
+                    player.stop();
+                } else {
+                    touchInput.set(diff);
+                }
             }
         }
+
         camera.position.x = Math.min(Math.max(Scene.getIntendedWidth() / 2f, player.pos().x), getViewport().getWorldWidth() - Scene.getIntendedWidth() / 2f);
         camera.position.y = Math.min(Math.max(Scene.getIntendedHeight() / 2f, player.pos().y), getViewport().getWorldHeight() - Scene.getIntendedHeight() / 2f);
 
@@ -582,6 +587,9 @@ public abstract class GameStage extends Stage {
     public void stop() {
         WorldStage.getInstance().getPlayerSprite().setMovementDirection(Vector2.Zero);
         MapStage.getInstance().getPlayerSprite().setMovementDirection(Vector2.Zero);
+        touchInput.setZero();
+        keyboardInput.setZero();
+        controllerInput.setZero();
         touchX = -1;
         touchY = -1;
         player.stop();
@@ -598,10 +606,12 @@ public abstract class GameStage extends Stage {
         if (isPaused())
             return true;
         if (KeyBinding.Left.isPressed(keycode) || KeyBinding.Right.isPressed(keycode)) {
+            player.getMovementDirection().x = 0;
             if (!player.isMoving())
                 stop();
         }
         if (KeyBinding.Down.isPressed(keycode) || KeyBinding.Up.isPressed(keycode)) {
+            player.getMovementDirection().y = 0;
             if (!player.isMoving())
                 stop();
         }

--- a/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
@@ -1,5 +1,6 @@
 package forge.adventure.stage;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.controllers.Controller;
 import com.badlogic.gdx.files.FileHandle;
@@ -75,6 +76,9 @@ public abstract class GameStage extends Stage {
     private float animationTimeout = 0;
     public static float maximumScrollDistance = 1.5f;
     public static float minimumScrollDistance = 0.3f;
+    private final Vector2 keyboardInput = new Vector2();
+    private final Vector2 controllerInput = new Vector2();
+    private final Vector2 touchInput = new Vector2();
 
     private String extraAnnouncement = "";
 
@@ -253,8 +257,7 @@ public abstract class GameStage extends Stage {
         if (MapStage.getInstance().isDialogOnlyInput() || isPaused()) {
             return true;
         }
-        player.getMovementDirection().x = controller.getAxis(0);
-        player.getMovementDirection().y = -controller.getAxis(1);
+        controllerInput.set(controller.getAxis(0), -controller.getAxis(1));
         if (player.getMovementDirection().len() < 0.2) {
             player.stop();
         }
@@ -354,6 +357,55 @@ public abstract class GameStage extends Stage {
 
     @Override
     public final void act(float delta) {
+        keyboardInput.setZero();
+
+        for (int key : KeyBinding.Left.getBindings()) {
+            if (Gdx.input.isKeyPressed(key)) {
+                keyboardInput.x = -1;
+                break;
+            }
+        }
+
+        for (int key : KeyBinding.Right.getBindings()) {
+            if (Gdx.input.isKeyPressed(key)) {
+                keyboardInput.x = 1;
+                break;
+            }
+        }
+
+        for (int key : KeyBinding.Up.getBindings()) {
+            if (Gdx.input.isKeyPressed(key)) {
+                keyboardInput.y = 1;
+                break;
+            }
+        }
+
+        for (int key : KeyBinding.Down.getBindings()) {
+            if (Gdx.input.isKeyPressed(key)) {
+                keyboardInput.y = -1;
+                break;
+            }
+        }
+
+
+        Vector2 dir = new Vector2();
+
+        // Input priority: touch > controller > keyboard
+        if (touchX >= 0 && touchInput.len() > 0.2f) {
+            dir.set(touchInput);
+
+        } else if (controllerInput.len() > 0.2f) {
+            dir.set(controllerInput);
+
+        } else {
+            dir.set(keyboardInput);
+        }
+        if (dir.len() < 0.01f) {
+            player.stop();
+        } else {
+            player.getMovementDirection().set(dir);
+        }
+
         super.act(delta);
 
         if (animationTimeout >= 0) {
@@ -375,7 +427,6 @@ public abstract class GameStage extends Stage {
             return;
         }
 
-
         if (onEndAction != null) {
 
             onEndAction.run();
@@ -384,14 +435,15 @@ public abstract class GameStage extends Stage {
 
         if (touchX >= 0) {
             Vector2 target = this.screenToStageCoordinates(new Vector2(touchX, touchY));
+
             target.x -= player.getWidth() / 2f;
             Vector2 diff = target.sub(player.pos());
 
             if (diff.len() < 2) {
-                diff.setZero();
-                player.stop();
+                touchInput.setZero();
+            } else {
+                touchInput.set(diff);
             }
-            player.setMovementDirection(diff);
         }
         camera.position.x = Math.min(Math.max(Scene.getIntendedWidth() / 2f, player.pos().x), getViewport().getWorldWidth() - Scene.getIntendedWidth() / 2f);
         camera.position.y = Math.min(Math.max(Scene.getIntendedHeight() / 2f, player.pos().y), getViewport().getWorldHeight() - Scene.getIntendedHeight() / 2f);
@@ -422,16 +474,16 @@ public abstract class GameStage extends Stage {
         if (isPaused())
             return true;
         if (KeyBinding.Left.isPressed(keycode)) {
-            player.getMovementDirection().x = -1;
+            keyboardInput.x = -1;
         }
         if (KeyBinding.Right.isPressed(keycode)) {
-            player.getMovementDirection().x = +1;
+            keyboardInput.x = +1;
         }
         if (KeyBinding.Up.isPressed(keycode)) {
-            player.getMovementDirection().y = +1;
+            keyboardInput.y = +1;
         }
         if (KeyBinding.Down.isPressed(keycode)) {
-            player.getMovementDirection().y = -1;
+            keyboardInput.y = -1;
         }
         if (keycode == Input.Keys.F5)//todo config
         {
@@ -558,12 +610,10 @@ public abstract class GameStage extends Stage {
         if (isPaused())
             return true;
         if (KeyBinding.Left.isPressed(keycode) || KeyBinding.Right.isPressed(keycode)) {
-            player.getMovementDirection().x = 0;
             if (!player.isMoving())
                 stop();
         }
         if (KeyBinding.Down.isPressed(keycode) || KeyBinding.Up.isPressed(keycode)) {
-            player.getMovementDirection().y = 0;
             if (!player.isMoving())
                 stop();
         }

--- a/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/GameStage.java
@@ -258,9 +258,6 @@ public abstract class GameStage extends Stage {
             return true;
         }
         controllerInput.set(controller.getAxis(0), -controller.getAxis(1));
-        if (player.getMovementDirection().len() < 0.2) {
-            player.stop();
-        }
         return true;
     }
 
@@ -386,7 +383,6 @@ public abstract class GameStage extends Stage {
                 break;
             }
         }
-
 
         Vector2 dir = new Vector2();
 

--- a/forge-gui-mobile/src/forge/adventure/stage/WorldStage.java
+++ b/forge-gui-mobile/src/forge/adventure/stage/WorldStage.java
@@ -230,8 +230,8 @@ public class WorldStage extends GameStage implements SaveFileContent {
 
     public void loadPOI(PointOfInterest poi) {
         try {
-            TileMapScene.instance().load(poi);
             stop();
+            TileMapScene.instance().load(poi);
             TileMapScene.instance().setFromWorldMap(true);
             Forge.switchScene(TileMapScene.instance());
         } catch (Exception e) {
@@ -266,7 +266,7 @@ public class WorldStage extends GameStage implements SaveFileContent {
         }
 
         World world = WorldSave.getCurrentSave().getWorld();
-        int currentBiome = World.highestBiome(world.getBiome((int) player.getX() / world.getTileSize(), (int) player.getY() / world.getTileSize()));
+        int currentBiome = World.highestBiome(world.getBiome((int) ((player.getX() + player.getWidth() / 2f) / world.getTileSize()), (int) (player.getY() / world.getTileSize())));
         List<BiomeData> biomeData = WorldSave.getCurrentSave().getWorld().getData().GetBiomes();
         float sprintingMod = currentModifications.containsKey(PlayerModification.Sprint) ? 2 : 1;
         if (biomeData.size() <= currentBiome) {// "if isOnRoad

--- a/forge-gui-mobile/src/forge/adventure/util/KeyBinding.java
+++ b/forge-gui-mobile/src/forge/adventure/util/KeyBinding.java
@@ -49,6 +49,10 @@ public enum KeyBinding {
         return false;
     }
 
+    public int[] getBindings() {
+        return bindings;
+    }
+
     // The controller binding always has index 1.
     final static String controllerPrefix = "XBox_";
 

--- a/forge-gui-mobile/src/forge/adventure/util/KeyBinding.java
+++ b/forge-gui-mobile/src/forge/adventure/util/KeyBinding.java
@@ -1,5 +1,6 @@
 package forge.adventure.util;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.controllers.Controller;
 import com.badlogic.gdx.controllers.ControllerMapping;
@@ -34,6 +35,15 @@ public enum KeyBinding {
         this.bindings = bindings;
     }
 
+    public boolean isPressed() {
+        for (int key : bindings) {
+            if (Gdx.input.isKeyPressed(key)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public boolean isPressed(int key) {
         return isPressed(key, null);
     }
@@ -47,10 +57,6 @@ public enum KeyBinding {
             }
         }
         return false;
-    }
-
-    public int[] getBindings() {
-        return bindings;
     }
 
     // The controller binding always has index 1.


### PR DESCRIPTION
Split off from: [Archipelago PR](https://github.com/Card-Forge/forge/pull/11167)

### Overhauled input system

- The base-game's input system currently suffers from multiple input methods fighting for control. One particular issue that prompted me to overhaul it was the angle the player walks in when inputting a diagonal direction on keyboard. It's not 45 degrees like you would expect, it's actually close to 22.5 degrees because one of the input methods correctly reads 45 degrees but the logic is executed a second time on one of the pressed keys (not both) resulting in a combined angle of 22.5 degrees. Further issues include one of the pressed keys being ignored until re-pressed if pressed too quickly in conjunction with other movement keys.
- The new input system defines a clear priority between keyboard/mouse (or touch)/controller inputs so they no longer fight for control.
- The new input system stores each of its directions/vectors in a separate value so no unintentional overlapping of directions occur
- Fixed a crash where the console would attempt to fetch a String for a list on an index which doesn't exist. Very easy to trigger after making a new game, just open the console and press arrow down and arrow up.

<img width="824" height="425" alt="image" src="https://github.com/user-attachments/assets/7f386689-4fe3-4d29-8428-edd904c49ccb" />

- Made the console clear the text field when pressing the down arrow without a more recent command in the console's history. This more closely mimics what Linux/Windows terminals do.

### Better road detection
- `forge-gui-mobile/src/forge/adventure/stage/WorldStage.java#L269` > This shifts the detection point for which biome the player is walking on to the centre of the sprite instead of the left-most pixel. The vertical axis remains unchanged at the bottom.