### PR TITLE
AI: don't reveal own top card when a conditional draw can't pay off

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/PeekAndRevealAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PeekAndRevealAi.java
@@ -48,6 +48,21 @@ public class PeekAndRevealAi extends SpellAbilityAi {
             return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
         }
 
+        // if the AI may already look at its own top card (e.g. Iron Lad, Diverging Destiny),
+        // don't activate when a sub-ability conditioned on the revealed card can't pay off
+        if (libraryOwner == aiPlayer && !sa.isTrigger() && sa.hasParam("RememberRevealed")
+                && "1".equals(sa.getParamOrDefault("PeekAmount", "1"))) {
+            final Card topCard = aiPlayer.getCardsIn(ZoneType.Library).getFirst();
+            if (topCard.mayPlayerLook(aiPlayer)) {
+                for (AbilitySub sub = sa.getSubAbility(); sub != null; sub = sub.getSubAbility()) {
+                    if ("Remembered".equals(sub.getParam("ConditionDefined")) && sub.hasParam("ConditionPresent")
+                            && !topCard.isValid(sub.getParam("ConditionPresent").split(","), aiPlayer, sa.getHostCard(), sa)) {
+                        return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
+                    }
+                }
+            }
+        }
+
         if ("X".equals(sa.getParam("PeekAmount")) && sa.getSVar("X").equals("Count$xPaid")) {
             int xPay = ComputerUtilCost.setMaxXValue(sa, aiPlayer, sa.isTrigger());
             if (xPay == 0) {

--- a/forge-gui/res/cardsfolder/i/iron_lad_diverging_destiny.txt
+++ b/forge-gui/res/cardsfolder/i/iron_lad_diverging_destiny.txt
@@ -5,7 +5,7 @@ PT:2/2
 K:Flying
 K:Vigilance
 S:Mode$ Continuous | Affected$ Card.TopLibrary+YouCtrl | AffectedZone$ Library | MayLookAt$ You | Description$ You may look at the top card of your library any time.
-A:AB$ PeekAndReveal | Cost$ T | NoPeek$ True | RememberRevealed$ True | SubAbility$ DBDraw | SpellDescription$ Reveal the top card of your library. If it's an artifact card, draw a card.
+A:AB$ PeekAndReveal | Cost$ T | NoPeek$ True | RememberRevealed$ True | AILogic$ Main2 | SubAbility$ DBDraw | SpellDescription$ Reveal the top card of your library. If it's an artifact card, draw a card.
 SVar:DBDraw:DB$ Draw | ConditionDefined$ Remembered | ConditionPresent$ Artifact | SubAbility$ DBCleanup
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 Oracle:Flying, vigilance\nYou may look at the top card of your library any time.\n{T}: Reveal the top card of your library. If it's an artifact card, draw a card.


### PR DESCRIPTION
Fixes #11177

`PeekAndRevealAi.checkApiLogic` returned `WillPlay` unconditionally (as long as the library wasn't empty), so Iron Lad, Diverging Destiny tapped at the first opportunity every turn — during upkeep, and regardless of the top card.

Two changes:

- **PeekAndRevealAi**: when the AI is revealing its own top card, may already look at it (`mayPlayerLook`, granted here by Iron Lad's own static), and a sub-ability is conditioned on the revealed card (`ConditionDefined$ Remembered` + `ConditionPresent`), pre-check the condition against the top card and skip the activation when it can't pay off. Gated to activated abilities with `PeekAmount` 1 and `RememberRevealed` so triggers and multi-card peeks are untouched.
- **Card script**: added `AILogic$ Main2` (already supported by PeekAndRevealAi) so the activation waits for the second main phase, per the issue's second suggestion.

### Verification

Headless sims (4 games, Iron Lad deck with 8 artifact hits in 60 cards vs a defensive deck), same decks before/after:

| | master | this PR |
|---|---|---|
| activations | 30 — all during the upkeep step | 2 — both in main 2 |
| outcome | tapped blindly regardless of top card | both reveals hit an artifact (the AI cast the drawn Mind Stone immediately after) |

No exceptions in any sim game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
