### PR TITLE
AI: pick sensible targets for pure P/T-setting animate effects

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/AnimateAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/AnimateAi.java
@@ -258,6 +258,13 @@ public class AnimateAi extends SpellAbilityAi {
                 if (list.isEmpty()) {
                     return decision;
                 }
+                // don't gift a beneficial effect to an opponent's creature if self-targeting is possible
+                if (!sa.isCurse()) {
+                    List<Card> ownChoices = CardLists.filterControlledBy(list, aiPlayer);
+                    if (!ownChoices.isEmpty()) {
+                        list = ownChoices;
+                    }
+                }
                 Card toAnimate = ComputerUtilCard.getWorstAI(list);
                 rememberAnimatedThisTurn(aiPlayer, toAnimate);
                 sa.getTargets().add(toAnimate);
@@ -434,6 +441,35 @@ public class AnimateAi extends SpellAbilityAi {
             sa.getTargets().add(best);
             rememberAnimatedThisTurn(ai, best);
             return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+        }
+
+        // Pure P/T-setting effect without type or ability changes (e.g. Genemorph Imago):
+        // buff own creatures that actually gain from it, or shrink an opponent's
+        if (logic.isEmpty() && sa.hasParam("Power") && sa.hasParam("Toughness")
+                && !sa.hasParam("Types") && !sa.hasParam("Keywords") && !sa.hasParam("Abilities")) {
+            Card best = null;
+            int bestGain = 0;
+            for (final Card c : list) {
+                if (!c.isCreature()) {
+                    continue;
+                }
+                final Card animatedCopy = becomeAnimated(c, sa);
+                int gain = ComputerUtilCard.evaluateCreature(animatedCopy) - ComputerUtilCard.evaluateCreature(c);
+                if (c.getController().isOpponentOf(ai)) {
+                    // making an opponent's creature smaller is worth as much as it loses
+                    gain = -gain;
+                }
+                if (gain > bestGain) {
+                    bestGain = gain;
+                    best = c;
+                }
+            }
+            if (best != null) {
+                rememberAnimatedThisTurn(ai, best);
+                sa.getTargets().add(best);
+                return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+            }
+            return new AiAbilityDecision(0, AiPlayDecision.TargetingFailed);
         }
 
         // This is reasonable for now. Kamahl, Fist of Krosa and a sorcery or


### PR DESCRIPTION
Fixes #11171

Genemorph Imago's landfall trigger (`DB$ Animate | ValidTgts$ Creature | Power$ Y | Toughness$ Y`) sets base P/T without changing types, so `AnimateAi.animateTgtAI` had no branch for it and returned `CantPlayAi`. The mandatory-trigger fallback in `doTriggerNoCost` then targeted `getWorstAI` of **all** legal creatures — usually an opponent's smallest creature, gifting it the 3/3 buff, and repeatedly the same one.

Two changes:

- **animateTgtAI**: new branch for pure P/T-setting effects (Power + Toughness, no Types/Keywords/Abilities, no AILogic): evaluates each targetable creature via `becomeAnimated` + `evaluateCreature` and picks the own creature that gains the most — or an opponent's creature that would shrink the most, whichever is larger. Creatures whose stats wouldn't change are gain 0 and never picked, so repeated landfall triggers move on to fresh targets.
- **doTriggerNoCost fallback**: when a mandatory animate trigger still can't find a good target and the effect isn't a curse, prefer own creatures over handing the effect to an opponent.

### Verification

Headless sims (4 games, Imago deck with Evolving Wilds vs a goblin swarm deck), same decks before/after:

| | master | this PR |
|---|---|---|
| trigger targets | 11/11 on opponent's Goblin Tokens (5× the same token) | 14/14 on own creatures |
| re-targeting | hammered the same already-buffed token | switches to a new creature once one is buffed |

No exceptions in any sim game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
