### PR TITLE
Deck import: recognize Moxfield/Arena foil markers *F* and *E*

### DIFF
--- a/forge-core/src/main/java/forge/deck/DeckRecognizer.java
+++ b/forge-core/src/main/java/forge/deck/DeckRecognizer.java
@@ -438,9 +438,10 @@ public class DeckRecognizer {
     public static final String REX_COLL_NUMBER = String.format("(?<%s>\\*?[0-9A-Z]+(?:\\S[0-9A-Z]*)?)", REGRP_COLLNR);
     public static final String REX_CARD_COUNT = String.format("(?<%s>[\\d]{1,2})(?<mult>x)?", REGRP_CARDNO);
     // EXTRA
+    // Foil markers: (F) MTGGoldfish; *F* foil and *E* etched foil, Moxfield/MTGA style
     public static final String REGRP_FOIL_GFISH = "foil";
     private static final String REX_FOIL_MTGGOLDFISH = String.format(
-            "(?<%s>\\(F\\))?", REGRP_FOIL_GFISH);
+            "(?<%s>\\(F\\)|\\*[FE]\\*)?", REGRP_FOIL_GFISH);
     // XMage Sideboard indicator - pushed a bit further with deck section indication
     public static final String REGRP_DECK_SEC_XMAGE_STYLE = "decsec";
     private static final String REX_DECKSEC_XMAGE = String.format(

--- a/forge-gui-desktop/src/test/java/forge/deck/DeckRecognizerTest.java
+++ b/forge-gui-desktop/src/test/java/forge/deck/DeckRecognizerTest.java
@@ -1413,6 +1413,61 @@ public class DeckRecognizerTest extends CardMockTestCase {
         assertEquals(matcher.group(DeckRecognizer.REGRP_FOIL_GFISH), "(F)");
     }
 
+    @Test
+    public void testMatchFoilCardRequestMoxfieldFormat() {
+        // card-set-collnr, as exported via Moxfield's "Copy for Moxfield"
+        String foilRequest = "4 Aspect of Hydra (BNG) 117 *F*";
+        Pattern target = DeckRecognizer.CARD_SET_COLLNO_PATTERN;
+        Matcher matcher = target.matcher(foilRequest);
+        assertTrue(matcher.matches());
+        assertEquals(matcher.group(DeckRecognizer.REGRP_CARDNO), "4");
+        assertEquals(matcher.group(DeckRecognizer.REGRP_CARD), "Aspect of Hydra "); // TRIM
+        assertEquals(matcher.group(DeckRecognizer.REGRP_SET), "BNG");
+        assertEquals(matcher.group(DeckRecognizer.REGRP_COLLNR), "117");
+        assertEquals(matcher.group(DeckRecognizer.REGRP_FOIL_GFISH), "*F*");
+
+        // etched foil marker
+        foilRequest = "4 Aspect of Hydra (BNG) 117 *E*";
+        matcher = target.matcher(foilRequest);
+        assertTrue(matcher.matches());
+        assertEquals(matcher.group(DeckRecognizer.REGRP_FOIL_GFISH), "*E*");
+
+        // card-set
+        foilRequest = "4 Aspect of Hydra [BNG] *F*";
+        target = DeckRecognizer.CARD_SET_PATTERN;
+        matcher = target.matcher(foilRequest);
+        assertTrue(matcher.matches());
+        assertEquals(matcher.group(DeckRecognizer.REGRP_CARDNO), "4");
+        assertEquals(matcher.group(DeckRecognizer.REGRP_CARD), "Aspect of Hydra "); // TRIM
+        assertEquals(matcher.group(DeckRecognizer.REGRP_SET), "BNG");
+        assertEquals(matcher.group(DeckRecognizer.REGRP_FOIL_GFISH), "*F*");
+
+        // card-only
+        foilRequest = "4 Aspect of Hydra *F*";
+        target = DeckRecognizer.CARD_ONLY_PATTERN;
+        matcher = target.matcher(foilRequest);
+        assertTrue(matcher.matches());
+        assertEquals(matcher.group(DeckRecognizer.REGRP_CARDNO), "4");
+        assertEquals(matcher.group(DeckRecognizer.REGRP_CARD), "Aspect of Hydra "); // TRIM
+        assertEquals(matcher.group(DeckRecognizer.REGRP_FOIL_GFISH), "*F*");
+    }
+
+    @Test
+    public void testMoxfieldFoilCardLineIsImportedAsFoil() {
+        // full line as exported via Moxfield's "Copy for Moxfield" (issue #11005)
+        DeckRecognizer recognizer = new DeckRecognizer();
+        Token cardToken = recognizer.recogniseCardToken("4 Power Sink (TMP) 78 *F*", null);
+        assertNotNull(cardToken);
+        assertEquals(cardToken.getType(), TokenType.LEGAL_CARD);
+        assertNotNull(cardToken.getCard());
+        PaperCard tokenCard = cardToken.getCard();
+        assertEquals(cardToken.getQuantity(), 4);
+        assertEquals(tokenCard.getName(), "Power Sink");
+        assertEquals(tokenCard.getEdition(), "TMP");
+        assertEquals(tokenCard.getCollectorNumber(), "78");
+        assertTrue(tokenCard.isFoil());
+    }
+
     /*
      * =================================================== TOKEN/CARD PARSING:
      * Collector Number and Art Index


### PR DESCRIPTION
Fixes #11005

`DeckRecognizer`'s foil marker regex (`REX_FOIL_MTGGOLDFISH`) only matched MTGGoldfish's `(F)`. Moxfield's "Copy for Moxfield" export appends `*F*` (foil) / `*E*` (etched) instead, so those lines failed every card pattern (`matcher.matches()` is a full-line match) and the cards were silently skipped on import.

The marker regex now also accepts `*F*` and `*E*`, and since the existing `foil` capture group is already wired through `recogniseCardToken`, the imported card is correctly marked as foil — the issue's "preferably" case.

### Verification

Regex + full `recogniseCardToken` path against the real card DB:

| line | before | after |
|---|---|---|
| `1 Arcane Signet (C21) 251 *F*` | skipped | 1x Arcane Signet [C21], foil |
| `4 Power Sink (TMP) 78 *F*` | skipped | 4x Power Sink [TMP] #78, foil |
| `4 Power Sink (TMP) 78` | imported, nonfoil | unchanged |

Added `testMatchFoilCardRequestMoxfieldFormat` and `testMoxfieldFoilCardLineIsImportedAsFoil` to `DeckRecognizerTest`, mirroring the existing MTGGoldfish foil test.

Heads-up discovered while verifying: `DeckRecognizerTest` (and the other `CardMockTestCase`-based classes) currently execute 0 tests under `mvn test` — locally and in the `Test build` CI (master's suite reports 282 tests with no `forge.deck.DeckRecognizerTest` entries; the class's surefire report shows `tests="0"`). Likely PowerMock/TestNG instantiation silently failing (the `@ObjectFactory` in `CardMockTestCase` is commented out). The new tests follow the file's conventions so they'll run once that harness is repaired — happy to file a separate issue with the details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
