### PR TITLE
Set spawning ability on Endure tokens

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/EndureEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/EndureEffect.java
@@ -81,6 +81,8 @@ public class EndureEffect extends TokenEffectBase {
                 result.setBaseToughnessString(num);
                 result.setBaseToughness(amount);
 
+                result.setTokenSpawningAbility(sa);
+
                 tokenTable.put(pl, result, 1);
             }
         }


### PR DESCRIPTION
Endure builds its Spirit token directly:

```java
Card result = TokenInfo.getProtoType(...);
result.setBasePower(amount);
result.setBaseToughness(amount);
```

Other direct token creation paths preserve the source spell ability on the created token:

```java
result.setTokenSpawningAbility(sa);
```

Examples:
- [`AmassEffect`](https://github.com/Card-Forge/forge/blob/master/forge-game/src/main/java/forge/game/ability/effects/AmassEffect.java#L68)
- [`CopyPermanentEffect`](https://github.com/Card-Forge/forge/blob/master/forge-game/src/main/java/forge/game/ability/effects/CopyPermanentEffect.java#L308)

This makes Endure-created tokens carry the same source ability metadata as those paths.