### PR TITLE
Hotfix: Mobile NPE when auto-pay can't cover a mana cost

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiController.java
+++ b/forge-ai/src/main/java/forge/ai/AiController.java
@@ -789,15 +789,18 @@ public class AiController {
         ManaCostBeingPaid cost = ComputerUtilMana.calculateManaCost(sa.getPayCosts(), sa, player, true, 0, false);
         CardCollection manaSources = ComputerUtilMana.getManaSourcesToPayCost(cost, sa, player, false);
 
-        if (manaSources.isEmpty()) {
+        if (manaSources == null || manaSources.isEmpty()) {
             return false;
         }
 
         // used for chained spells where two spells need to be cast in succession
         if (exceptForThisSa != null) {
-            manaSources.removeAll(ComputerUtilMana.getManaSourcesToPayCost(
+            CardCollection exceptSources = ComputerUtilMana.getManaSourcesToPayCost(
                     ComputerUtilMana.calculateManaCost(exceptForThisSa.getPayCosts(), exceptForThisSa, player, true, 0, false),
-                    exceptForThisSa, player, false));
+                    exceptForThisSa, player, false);
+            if (exceptSources != null) {
+                manaSources.removeAll(exceptSources);
+            }
         }
 
         // This is a simplification, since one mana source can produce more than one mana,

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
@@ -93,7 +93,11 @@ public class ComputerUtilMana {
     }
 
     public static CardCollection getManaSourcesToPayCost(final ManaCostBeingPaid cost, final SpellAbility sa, final Player ai, final boolean effect) {
-        return new CardCollection(payManaCost(cost, sa, ai, true, true, effect).stream().map(m -> m.getSourceCard()).filter(Objects::nonNull));
+        final List<Mana> payment = payManaCost(cost, sa, ai, true, true, effect);
+        if (payment == null) {
+            return null;
+        }
+        return new CardCollection(payment.stream().map(Mana::getSourceCard).filter(Objects::nonNull));
     }
 
     private static Integer scoreManaProducingCard(final Card card) {


### PR DESCRIPTION
## Summary

Fixes a crash on the mobile pay-mana screen (introduced in today's build by Card-Forge/forge#11176) that triggers whenever a spell's mana cost can't currently be fully auto-paid.

## Bug report

Multiple mobile users report random crashes as of today's build. The render thread dies with a `NullPointerException` while updating the pay-mana prompt:

    EDT > java.lang.NullPointerException: Attempt to invoke interface method 'java.util.stream.Stream java.util.List.stream()' on a null object reference
        at forge.ai.ComputerUtilMana.getManaSourcesToPayCost(ComputerUtilMana.java:96)
        at forge.gamemodes.match.input.InputPayMana$1.evaluate(InputPayMana.java:446)
        at forge.gamemodes.match.input.InputPayMana.ensureAutoPayManaSources(InputPayMana.java:449)
        at forge.gamemodes.match.input.InputPayMana.updateMessage(InputPayMana.java:403)
        ...
        at forge.gamemodes.match.input.InputProxy.lambda$update$0(InputProxy.java:71)
        at com.badlogic.gdx.backends.android.AndroidGraphics.onDrawFrame(AndroidGraphics.java:499)

## Root cause

Card-Forge/forge#11176 ("Autotap - Highlight affected cards") rewrote `ComputerUtilMana.getManaSourcesToPayCost` to delegate to `payManaCost(...)` and immediately call `.stream()` on the result. `payManaCost` returns `null` whenever the cost can't be fully paid — so the dereference NPEs.

That commit also newly wired the mobile `InputPayMana` auto-pay path to call this method on every message refresh, so any spell that can't currently be fully auto-tapped crashes the render thread the moment the prompt redraws.

## Fix

- `getManaSourcesToPayCost` now null-guards the `payManaCost` result and returns `null` on can't-pay. This matches the contract the new caller already expects — `InputPayMana` gates on `autoPayManaSources != null` to enable the Auto button and show the tap-highlight preview.
- `AiController.reserveManaSources`, the pre-existing caller, relied on the old always-non-null/empty contract (`isEmpty()`, `removeAll(...)`) and had the same latent NPE now that `payManaCost` can propagate `null` through this method — made both of its usages null-safe.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)