### PR TITLE
Support Monstrosity spell ability property

### DIFF
--- a/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbility.java
@@ -593,6 +593,9 @@ public abstract class SpellAbility extends CardTraitBase implements ISpellAbilit
     public boolean isBoast() {
         return this.hasParam("Boast");
     }
+    public boolean isMonstrosity() {
+        return this.hasParam("Monstrosity");
+    }
     public boolean isExhaust() {
         return this.hasParam("Exhaust");
     }

--- a/forge-game/src/main/java/forge/game/spellability/SpellAbilityProperty.java
+++ b/forge-game/src/main/java/forge/game/spellability/SpellAbilityProperty.java
@@ -97,6 +97,8 @@ public class SpellAbilityProperty {
             return sa.isEquip();
         } else if (property.equals("Boast")) {
             return sa.isBoast();
+        } else if (property.equals("Monstrosity")) {
+            return sa.isMonstrosity();
         } else if (property.equals("Exhaust")) {
             return sa.isExhaust();
         } else if (property.equals("Mayhem")) {


### PR DESCRIPTION
Abilities with the Monstrosity script parameter can be identified directly, matching the existing pattern for Boast and other ability types. Enables valid strings such as Activated.Monstrosity to match.

Example:
S:Mode$ ReduceCost | ValidCard$ Card | ValidSpell$ Activated.Monstrosity | Activator$ You | Amount$ 1 | Description$ Monstrosity abilities you activate cost {1} less to activate.