### PR TITLE
Some Deck Fixes in Realm of Legends

### DIFF
--- a/forge-gui/res/adventure/Realm of Legends/decks/legends/marrow-gnawer.dck
+++ b/forge-gui/res/adventure/Realm of Legends/decks/legends/marrow-gnawer.dck
@@ -1,5 +1,6 @@
 [metadata]
-Name=Marrow-Gnawer[Commander]
+Name=Marrow-Gnawer
+[Commander]
 1 Marrow-Gnawer|CHK|[124]
 [Main]
 1 Ashcoat of the Shadow Swarm|J22|[19]

--- a/forge-gui/res/adventure/Realm of Legends/decks/legends/the_mindskinner.dck
+++ b/forge-gui/res/adventure/Realm of Legends/decks/legends/the_mindskinner.dck
@@ -36,7 +36,7 @@ Name=The Mindskinner
 1 Hullbreaker Horror|INR
 1 Hurkyl, Master Wizard|BRO
 1 Inspiration from Beyond|FDN
-311 Island|DSK
+31 Island|DSK
 1 Jace Beleren|CMM
 1 Jace, Memory Adept|M14
 1 Jace, the Perfected Mind|ONE


### PR DESCRIPTION
When I encountered and fought Marrow-Gnawer, I didn't see the enemy commander. Looked up why that was the case and fixed it.

I also made an unrelated deck fix to The Mindskinner since I found out that it has 311 Islands. Made it 31 (which makes the card count 100).