### PR TITLE
Card cleanup: 2026-07-11 [Reminder text: Explore]

### DIFF
--- a/forge-gui/res/cardsfolder/b/brazen_buccaneers.txt
+++ b/forge-gui/res/cardsfolder/b/brazen_buccaneers.txt
@@ -3,7 +3,7 @@ ManaCost:3 R
 Types:Creature Human Pirate
 PT:2/2
 K:Haste
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExplore | TriggerDescription$ When CARDNAME enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back on top or into your graveyard.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExplore | TriggerDescription$ When CARDNAME enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)
 SVar:TrigExplore:DB$ Explore
 DeckHas:Ability$Counters
 Oracle:Haste\nWhen Brazen Buccaneers enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)

--- a/forge-gui/res/cardsfolder/d/deadeye_tracker.txt
+++ b/forge-gui/res/cardsfolder/d/deadeye_tracker.txt
@@ -2,7 +2,7 @@ Name:Deadeye Tracker
 ManaCost:B
 Types:Creature Human Pirate
 PT:1/1
-A:AB$ ChangeZone | Cost$ 1 B T | TargetMin$ 2 | TargetMax$ 2 | Origin$ Graveyard | Destination$ Exile | ValidTgts$ Card.OppOwn | SubAbility$ TrigExplore | SpellDescription$ Exile two target cards from an opponent's graveyard. CARDNAME explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back on top or into your graveyard.)
+A:AB$ ChangeZone | Cost$ 1 B T | TargetMin$ 2 | TargetMax$ 2 | Origin$ Graveyard | Destination$ Exile | ValidTgts$ Card.OppOwn | SubAbility$ TrigExplore | SpellDescription$ Exile two target cards from an opponent's graveyard. CARDNAME explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)
 SVar:TrigExplore:DB$ Explore
 DeckHas:Ability$Counters
 Oracle:{1}{B}, {T}: Exile two target cards from an opponent's graveyard. Deadeye Tracker explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)

--- a/forge-gui/res/cardsfolder/d/dire_fleet_interloper.txt
+++ b/forge-gui/res/cardsfolder/d/dire_fleet_interloper.txt
@@ -3,7 +3,7 @@ ManaCost:3 B
 Types:Creature Human Pirate
 PT:2/2
 K:Menace
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExplore | TriggerDescription$ When CARDNAME enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back on top or into your graveyard.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExplore | TriggerDescription$ When CARDNAME enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)
 SVar:TrigExplore:DB$ Explore
 DeckHas:Ability$Counters
 Oracle:Menace\nWhen Dire Fleet Interloper enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)

--- a/forge-gui/res/cardsfolder/e/emissary_of_sunrise.txt
+++ b/forge-gui/res/cardsfolder/e/emissary_of_sunrise.txt
@@ -3,7 +3,7 @@ ManaCost:2 W
 Types:Creature Human Cleric
 PT:2/1
 K:First Strike
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExplore | TriggerDescription$ When CARDNAME enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back on top or into your graveyard.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExplore | TriggerDescription$ When CARDNAME enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)
 SVar:TrigExplore:DB$ Explore
 DeckHas:Ability$Counters
 Oracle:First strike\nWhen Emissary of Sunrise enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)

--- a/forge-gui/res/cardsfolder/i/ixallis_diviner.txt
+++ b/forge-gui/res/cardsfolder/i/ixallis_diviner.txt
@@ -2,7 +2,7 @@ Name:Ixalli's Diviner
 ManaCost:1 G
 Types:Creature Human Druid
 PT:0/3
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExplore | TriggerDescription$ When CARDNAME enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back on top or into your graveyard.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExplore | TriggerDescription$ When CARDNAME enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)
 SVar:TrigExplore:DB$ Explore
 DeckHas:Ability$Counters
 Oracle:When Ixalli's Diviner enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)

--- a/forge-gui/res/cardsfolder/p/pathfinding_exejaw.txt
+++ b/forge-gui/res/cardsfolder/p/pathfinding_exejaw.txt
@@ -2,7 +2,7 @@ Name:Pathfinding Axejaw
 ManaCost:3 G
 Types:Creature Dinosaur
 PT:4/3
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExplore | TriggerDescription$ When CARDNAME enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back on top or into your graveyard.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExplore | TriggerDescription$ When CARDNAME enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)
 SVar:TrigExplore:DB$ Explore
 DeckHas:Ability$Counters
 Oracle:When Pathfinding Axejaw enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)

--- a/forge-gui/res/cardsfolder/q/queens_agent.txt
+++ b/forge-gui/res/cardsfolder/q/queens_agent.txt
@@ -3,7 +3,7 @@ ManaCost:5 B
 Types:Creature Vampire Scout
 PT:3/3
 K:Lifelink
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExplore | TriggerDescription$ When CARDNAME enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back on top or into your graveyard.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExplore | TriggerDescription$ When CARDNAME enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)
 SVar:TrigExplore:DB$ Explore
 DeckHas:Ability$Counters
 Oracle:Lifelink\nWhen Queen's Agent enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)

--- a/forge-gui/res/cardsfolder/r/river_herald_guide.txt
+++ b/forge-gui/res/cardsfolder/r/river_herald_guide.txt
@@ -3,7 +3,7 @@ ManaCost:2 G
 Types:Creature Merfolk Scout
 PT:3/1
 K:Vigilance
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExplore | TriggerDescription$ When CARDNAME enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back on top or into your graveyard.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExplore | TriggerDescription$ When CARDNAME enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)
 SVar:TrigExplore:DB$ Explore
 DeckHas:Ability$Counters
 Oracle:Vigilance\nWhen River Herald Guide enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)

--- a/forge-gui/res/cardsfolder/r/river_herald_scout.txt
+++ b/forge-gui/res/cardsfolder/r/river_herald_scout.txt
@@ -2,7 +2,7 @@ Name:River Herald Scout
 ManaCost:1 U
 Types:Creature Merfolk Scout
 PT:1/2
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExplore | TriggerDescription$ When CARDNAME enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back on top or into your graveyard.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExplore | TriggerDescription$ When CARDNAME enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)
 SVar:TrigExplore:DB$ Explore
 DeckHas:Ability$Counters
 Oracle:When River Herald Scout enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)

--- a/forge-gui/res/cardsfolder/s/seekers_squire.txt
+++ b/forge-gui/res/cardsfolder/s/seekers_squire.txt
@@ -2,7 +2,7 @@ Name:Seekers' Squire
 ManaCost:1 B
 Types:Creature Human Scout
 PT:1/2
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExplore | TriggerDescription$ When CARDNAME enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back on top or into your graveyard.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExplore | TriggerDescription$ When CARDNAME enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)
 SVar:TrigExplore:DB$ Explore
 DeckHas:Ability$Counters
 Oracle:When Seekers' Squire enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)

--- a/forge-gui/res/cardsfolder/s/siren_lookout.txt
+++ b/forge-gui/res/cardsfolder/s/siren_lookout.txt
@@ -3,7 +3,7 @@ ManaCost:2 U
 Types:Creature Siren Pirate
 PT:1/2
 K:Flying
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExplore | TriggerDescription$ When CARDNAME enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back on top or into your graveyard.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExplore | TriggerDescription$ When CARDNAME enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)
 SVar:TrigExplore:DB$ Explore
 DeckHas:Ability$Counters
 Oracle:Flying\nWhen Siren Lookout enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)

--- a/forge-gui/res/cardsfolder/s/sunrise_seeker.txt
+++ b/forge-gui/res/cardsfolder/s/sunrise_seeker.txt
@@ -3,7 +3,7 @@ ManaCost:4 W
 Types:Creature Human Scout
 PT:3/3
 K:Vigilance
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExplore | TriggerDescription$ When CARDNAME enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back on top or into your graveyard.)
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigExplore | TriggerDescription$ When CARDNAME enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)
 SVar:TrigExplore:DB$ Explore
 DeckHas:Ability$Counters
 Oracle:Vigilance\nWhen Sunrise Seeker enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)


### PR DESCRIPTION
Following up on https://github.com/Card-Forge/forge/pull/11086 .
Updating the Explore reminder text on `Description` parameters as seen for [Sunrise Seeker](https://gatherer.wizards.com/XLN/en-us/40/sunrise-seeker) and as follows:
- `back on top or into` → `back or put it into` 