### PR TITLE
Fix Proteus Staff ordering the cards in reverse

### DIFF
--- a/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
+++ b/forge-ai/src/main/java/forge/ai/PlayerControllerAi.java
@@ -648,8 +648,7 @@ public class PlayerControllerAi extends PlayerController {
                 }
             }
 
-            if(source == null || !source.hasParam("LibraryPosition")
-                    || AbilityUtils.calculateAmount(source.getHostCard(), source.getParam("LibraryPosition"), source) >= 0) {
+            if (orderedMoveToTopOfLibrary(destinationZone, source)) {
                 //Cards going to the top of a deck are returned in reverse order.
                 Collections.reverse(reordered);
             }

--- a/forge-game/src/main/java/forge/game/player/PlayerController.java
+++ b/forge-game/src/main/java/forge/game/player/PlayerController.java
@@ -12,6 +12,7 @@ import forge.deck.Deck;
 import forge.deck.DeckSection;
 import forge.game.*;
 import forge.game.GameOutcome.AnteResult;
+import forge.game.ability.AbilityUtils;
 import forge.game.ability.effects.RollDiceEffect;
 import forge.game.card.*;
 import forge.game.combat.Combat;
@@ -200,6 +201,28 @@ public abstract class PlayerController {
      * deck, this will be the reverse of the order they will ultimately end up in.
      */
     public abstract CardCollectionView orderMoveToZoneList(CardCollectionView cards, ZoneType destinationZone, SpellAbility source);
+
+    protected boolean orderedMoveToTopOfLibrary(ZoneType destinationZone, SpellAbility source) {
+        if (!destinationZone.isDeck()) {
+            return false;
+        }
+
+        if (source == null) {
+            return true;
+        }
+
+        // Check all the possible LibraryPosition param names
+        String positionName;
+        if (source.hasParam("LibraryPosition")) {
+            positionName = "LibraryPosition";
+        } else if (source.hasParam("RevealedLibraryPosition")) {
+            positionName = "RevealedLibraryPosition";
+        } else {
+            return true;
+        }
+
+        return AbilityUtils.calculateAmount(source.getHostCard(), source.getParam(positionName), source) >= 0;
+    }
 
     /** p = target player, validCards - possible discards, min cards to discard. */
     public CardCollectionView chooseCardsToDiscardFrom(Player playerDiscard, SpellAbility sa, CardCollection validCards, int min, int max) {

--- a/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
+++ b/forge-gui/src/main/java/forge/player/PlayerControllerHuman.java
@@ -1146,10 +1146,7 @@ public class PlayerControllerHuman extends PlayerController implements IGameCont
         GameEntityViewMap<Card, CardView> gameCacheMove = GameEntityView.getMap(cards);
         List<CardView> choices = gameCacheMove.getTrackableKeys();
 
-        boolean topOfDeck = destinationZone.isDeck()
-                && (source == null
-                    || !source.hasParam("LibraryPosition")
-                    || AbilityUtils.calculateAmount(source.getHostCard(), source.getParam("LibraryPosition"), source) >= 0);
+        boolean topOfDeck = orderedMoveToTopOfLibrary(destinationZone, source);
 
         switch (destinationZone) {
             case Library:


### PR DESCRIPTION
Putting cards on bottom of the library was reversing order for RevealUntil + RevealedLibraryPosition