### PR TITLE
Card cleanup: 2026-07-13 [Reminder text: Sundry fixes]

### DIFF
--- a/forge-gui/res/cardsfolder/a/arc_trail.txt
+++ b/forge-gui/res/cardsfolder/a/arc_trail.txt
@@ -1,7 +1,7 @@
 Name:Arc Trail
 ManaCost:1 R
 Types:Sorcery
-A:SP$ DealDamage | ValidTgts$ Any | TgtPrompt$ Select any target (2 damage) | NumDmg$ 2 | DamageMap$ True | SubAbility$ DBDealDamage | SpellDescription$ CARDNAME deals 2 damage to any target and 1 damage to another target.
-SVar:DBDealDamage:DB$ DealDamage | ValidTgts$ Any | TgtPrompt$ Select any target (1 damage) | TargetUnique$ True | NumDmg$ 1 | SubAbility$ DBDamageResolve
+A:SP$ DealDamage | ValidTgts$ Any | TgtPrompt$ Select any target (2 damage) | NumDmg$ 2 | DamageMap$ True | SubAbility$ DBDealDamage | SpellDescription$ CARDNAME deals 2 damage to any target and 1 damage to any other target.
+SVar:DBDealDamage:DB$ DealDamage | ValidTgts$ Any | TgtPrompt$ Select any other target (1 damage) | TargetUnique$ True | NumDmg$ 1 | SubAbility$ DBDamageResolve
 SVar:DBDamageResolve:DB$ DamageResolve
-Oracle:Arc Trail deals 2 damage to any target and 1 damage to another target.
+Oracle:Arc Trail deals 2 damage to any target and 1 damage to any other target.

--- a/forge-gui/res/cardsfolder/b/boulder_dash.txt
+++ b/forge-gui/res/cardsfolder/b/boulder_dash.txt
@@ -2,6 +2,6 @@ Name:Boulder Dash
 ManaCost:1 R
 Types:Sorcery
 A:SP$ DealDamage | ValidTgts$ Any | TgtPrompt$ Select any target (2 damage) | NumDmg$ 2 | DamageMap$ True | SubAbility$ DBDealDamage | SpellDescription$ CARDNAME deals 2 damage to any target and 1 damage to any other target.
-SVar:DBDealDamage:DB$ DealDamage | ValidTgts$ Any | TgtPrompt$ Select any target (1 damage) | TargetUnique$ True | NumDmg$ 1 | SubAbility$ DBDamageResolve
+SVar:DBDealDamage:DB$ DealDamage | ValidTgts$ Any | TgtPrompt$ Select any other target (1 damage) | TargetUnique$ True | NumDmg$ 1 | SubAbility$ DBDamageResolve
 SVar:DBDamageResolve:DB$ DamageResolve
 Oracle:Boulder Dash deals 2 damage to any target and 1 damage to any other target.

--- a/forge-gui/res/cardsfolder/b/bounty_of_might.txt
+++ b/forge-gui/res/cardsfolder/b/bounty_of_might.txt
@@ -1,7 +1,7 @@
 Name:Bounty of Might
 ManaCost:4 G G
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature (1) | NumAtt$ +3 | NumDef$ +3 | SubAbility$ DBPump | SpellDescription$ Target creature gets +3/+3 until end of turn.
-SVar:DBPump:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature (2) | NumAtt$ +3 | NumDef$ +3 | SubAbility$ DBPump2 | SpellDescription$ Target creature gets +3/+3 until end of turn.
-SVar:DBPump2:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature (3) | NumAtt$ +3 | NumDef$ +3 | SpellDescription$ Target creature gets +3/+3 until end of turn.
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature (1) | NumAtt$ +3 | NumDef$ +3 | SubAbility$ DBPump | SpellDescription$ Target creature gets +3/+3 until end of turn.,,,,,,
+SVar:DBPump:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature (2) | NumAtt$ +3 | NumDef$ +3 | SubAbility$ DBPump1 | SpellDescription$ Target creature gets +3/+3 until end of turn.,,,,,,
+SVar:DBPump1:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature (3) | NumAtt$ +3 | NumDef$ +3 | SpellDescription$ Target creature gets +3/+3 until end of turn.
 Oracle:Target creature gets +3/+3 until end of turn.\nTarget creature gets +3/+3 until end of turn.\nTarget creature gets +3/+3 until end of turn.

--- a/forge-gui/res/cardsfolder/c/coretapper.txt
+++ b/forge-gui/res/cardsfolder/c/coretapper.txt
@@ -2,7 +2,7 @@ Name:Coretapper
 ManaCost:2
 Types:Artifact Creature Myr
 PT:1/1
-A:AB$ PutCounter | Cost$ T | ValidTgts$ Artifact | TgtPrompt$ Select target artifact (1 counter) | CounterType$ CHARGE | CounterNum$ 1 | SpellDescription$ Put a charge counter on target artifact.
-A:AB$ PutCounter | Cost$ Sac<1/CARDNAME> | ValidTgts$ Artifact | TgtPrompt$ Select target artifact (2 counters) | CounterType$ CHARGE | CounterNum$ 2 | SpellDescription$ Put two charge counters on target artifact.
+A:AB$ PutCounter | Cost$ T | ValidTgts$ Artifact | TgtPrompt$ Select target artifact (1 charge counter) | CounterType$ CHARGE | CounterNum$ 1 | SpellDescription$ Put a charge counter on target artifact.
+A:AB$ PutCounter | Cost$ Sac<1/CARDNAME> | ValidTgts$ Artifact | TgtPrompt$ Select target artifact (2 charge counters) | CounterType$ CHARGE | CounterNum$ 2 | SpellDescription$ Put two charge counters on target artifact.
 AI:RemoveDeck:Random
 Oracle:{T}: Put a charge counter on target artifact.\nSacrifice Coretapper: Put two charge counters on target artifact.

--- a/forge-gui/res/cardsfolder/h/hidden_strings.txt
+++ b/forge-gui/res/cardsfolder/h/hidden_strings.txt
@@ -2,7 +2,7 @@ Name:Hidden Strings
 ManaCost:1 U
 Types:Sorcery
 K:Cipher
-A:SP$ TapOrUntap | ValidTgts$ Permanent | SubAbility$ DBTapOrUntap | SpellDescription$ You may tap or untap target permanent, then you may tap or untap another target permanent.
+A:SP$ TapOrUntap | ValidTgts$ Permanent | TgtPrompt$ Select target permanent (1) | SubAbility$ DBTapOrUntap | SpellDescription$ You may tap or untap target permanent, then you may tap or untap another target permanent.
 SVar:DBTapOrUntap:DB$ TapOrUntap | ValidTgts$ Permanent | TgtPrompt$ Select target permanent (2) | TargetUnique$ True
 AI:RemoveDeck:All
 DeckNeeds:Type$Creature

--- a/forge-gui/res/cardsfolder/p/phyrexian_adapter.txt
+++ b/forge-gui/res/cardsfolder/p/phyrexian_adapter.txt
@@ -3,7 +3,7 @@ ManaCost:1 U
 Types:Creature Phyrexian Wizard
 PT:1/3
 K:Flying
-S:Mode$ Continuous | Affected$ Incubator.token+YouCtrl | AddType$ Food,Blood,Clue,Treasure,Powerstone | AddAbility$ FoodSac & BloodSac & ClueSac & TreasureSac & PowerstoneTap | Description$ All Incubator tokens you control become Food, Blood, Clue, Treasure, and Powerstone in addition to their other types, and have the respective abilities of those tokens. (Once they transform, they're no longer Incubator tokens.)
+S:Mode$ Continuous | Affected$ Incubator.token+YouCtrl | AddType$ Food,Blood,Clue,Treasure,Powerstone | AddAbility$ FoodSac & BloodSac & ClueSac & TreasureSac & PowerstoneTap | Description$ All Incubator tokens you control are Food, Blood, Clue, Treasure, and Powerstone in addition to their other types, and have the respective abilities of those tokens. (Once they transform, they're no longer Incubator tokens.)
 SVar:FoodSac:AB$ GainLife | Cost$ 2 T Sac<1/CARDNAME/this artifact> | LifeAmount$ 3 | SpellDescription$ You gain 3 life.
 SVar:BloodSac:AB$ Draw | Cost$ 1 T Discard<1/Card> Sac<1/CARDNAME/this artifact> | NumCards$ 1 | SpellDescription$ Draw a card.
 SVar:ClueSac:AB$ Draw | Cost$ 2 Sac<1/CARDNAME/this artifact> | NumCards$ 1 | SpellDescription$ Draw a card.

--- a/forge-gui/res/cardsfolder/s/seeds_of_strength.txt
+++ b/forge-gui/res/cardsfolder/s/seeds_of_strength.txt
@@ -1,7 +1,7 @@
 Name:Seeds of Strength
 ManaCost:G W
 Types:Instant
-A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature (1) | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DBPump1 | SpellDescription$ Target creature gets +1/+1 until end of turn. Target creature gets +1/+1 until end of turn. Target creature gets +1/+1 until end of turn.
-SVar:DBPump1:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature (2) | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DBPump2
-SVar:DBPump2:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature (3) | NumAtt$ +1 | NumDef$ +1
+A:SP$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature (1) | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DBPump | SpellDescription$ Target creature gets +1/+1 until end of turn.,,,,,,
+SVar:DBPump:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature (2) | NumAtt$ +1 | NumDef$ +1 | SubAbility$ DBPump1 | SpellDescription$ Target creature gets +1/+1 until end of turn.,,,,,,
+SVar:DBPump1:DB$ Pump | ValidTgts$ Creature | TgtPrompt$ Select target creature (3) | NumAtt$ +1 | NumDef$ +1 | SpellDescription$ Target creature gets +1/+1 until end of turn.
 Oracle:Target creature gets +1/+1 until end of turn.\nTarget creature gets +1/+1 until end of turn.\nTarget creature gets +1/+1 until end of turn.


### PR DESCRIPTION
Following up on https://github.com/Card-Forge/forge/pull/11086 .
Various incidental fixes. Notably:
- Standardized internal reminder text usage on Prompt parameters
- Bounty of Might and Seeds of Strength should behave the same as concerns display in-game so I edited them accordingly.

And that's the last one of the batch.