### PR TITLE
Card cleanup: 2026-07-16 [Reminder text: Shard token]

### DIFF
--- a/forge-gui/res/cardsfolder/n/niko_aris.txt
+++ b/forge-gui/res/cardsfolder/n/niko_aris.txt
@@ -2,7 +2,7 @@ Name:Niko Aris
 ManaCost:X W U U
 Types:Legendary Planeswalker Niko
 Loyalty:3
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create X Shard tokens. (They're enchantments with "{2}, Sacrifice this enchantment: Scry 1, then draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create X Shard tokens. (They're enchantments with "{2}, Sacrifice this token: Scry 1, then draw a card.")
 SVar:TrigToken:DB$ Token | TokenAmount$ X | TokenScript$ c_e_shard_draw | TokenOwner$ You
 SVar:X:Count$xPaid
 A:AB$ Effect | Cost$ AddCounter<1/LOYALTY> | Planeswalker$ True | StaticAbilities$ Unblockable | Triggers$ Trig | TargetMin$ 0 | TargetMax$ 1 | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | RememberObjects$ Targeted | ExileOnMoved$ Battlefield | AILogic$ MakeUnblockable | StackDescription$ SpellDescription | SpellDescription$ Up to one target creature you control can't be blocked this turn. Whenever that creature deals damage this turn, return it to its owner's hand.
@@ -13,4 +13,4 @@ A:AB$ DealDamage | Cost$ SubCounter<1/LOYALTY> | Planeswalker$ True | ValidTgts$
 SVar:Y:Count$YouDrewThisTurn/Twice
 A:AB$ Token | Cost$ SubCounter<1/LOYALTY> | Planeswalker$ True | TokenScript$ c_e_shard_draw | TokenOwner$ You | SpellDescription$ Create a Shard token.
 DeckHas:Ability$Token|Sacrifice
-Oracle:When Niko Aris enters, create X Shard tokens. (They're enchantments with "{2}, Sacrifice this enchantment: Scry 1, then draw a card.")\n[+1]: Up to one target creature you control can't be blocked this turn. Whenever that creature deals damage this turn, return it to its owner's hand.\n[-1]: Niko Aris deals 2 damage to target tapped creature for each card you've drawn this turn.\n[-1]: Create a Shard token.
+Oracle:When Niko Aris enters, create X Shard tokens. (They're enchantments with "{2}, Sacrifice this token: Scry 1, then draw a card.")\n[+1]: Up to one target creature you control can't be blocked this turn. Whenever that creature deals damage this turn, return it to its owner's hand.\n[-1]: Niko Aris deals 2 damage to target tapped creature for each card you've drawn this turn.\n[-1]: Create a Shard token.

--- a/forge-gui/res/cardsfolder/n/niko_light_of_hope.txt
+++ b/forge-gui/res/cardsfolder/n/niko_light_of_hope.txt
@@ -2,11 +2,11 @@ Name:Niko, Light of Hope
 ManaCost:2 W U
 Types:Legendary Creature Human Wizard
 PT:3/4
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create two Shard tokens. (They're enchantments with "{2}, Sacrifice this enchantment: Scry 1, then draw a card.")
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When CARDNAME enters, create two Shard tokens. (They're enchantments with "{2}, Sacrifice this token: Scry 1, then draw a card.")
 SVar:TrigToken:DB$ Token | TokenAmount$ 2 | TokenScript$ c_e_shard_draw | TokenOwner$ You
 A:AB$ ChangeZone | Cost$ 2 T | ValidTgts$ Creature.nonLegendary+YouCtrl | Origin$ Battlefield | Destination$ Exile | TgtPrompt$ Select target nonlegendary creature you control | SubAbility$ DBClone | RememberLKI$ True | Imprint$ True | SpellDescription$ Exile target nonlegendary creature you control. Shards you control become copies of it until the beginning of the next end step. Return it to the battlefield under its owner's control at the beginning of the next end step.
 SVar:DBClone:DB$ Clone | Defined$ RememberedLKI | CloneTarget$ Valid Shard.YouCtrl | Duration$ UntilNextEndStep | SubAbility$ DelTrig
 SVar:DelTrig:DB$ DelayedTrigger | Mode$ Phase | Phase$ End of Turn | Execute$ TrigReturn | RememberObjects$ ImprintedLKI | TriggerDescription$ Return exiled permanent to the battlefield. | SubAbility$ DBCleanup
 SVar:TrigReturn:DB$ ChangeZone | Origin$ Exile | Destination$ Battlefield | Defined$ DelayTriggerRememberedLKI
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearImprinted$ True
-Oracle:When Niko, Light of Hope enters, create two Shard tokens. (They're enchantments with "{2}, Sacrifice this enchantment: Scry 1, then draw a card.")\n{2}, {T}: Exile target nonlegendary creature you control. Shards you control become copies of it until the beginning of the next end step. Return it to the battlefield under its owner's control at the beginning of the next end step.
+Oracle:When Niko, Light of Hope enters, create two Shard tokens. (They're enchantments with "{2}, Sacrifice this token: Scry 1, then draw a card.")\n{2}, {T}: Exile target nonlegendary creature you control. Shards you control become copies of it until the beginning of the next end step. Return it to the battlefield under its owner's control at the beginning of the next end step.


### PR DESCRIPTION
A few stragglers among card scripts while I'm updating the relevant token script (as seen for [Niko Aris](https://gatherer.wizards.com/KHM/en-us/225/niko-aris) and [Niko, Light of Hope](https://scryfall.com/card/dsk/224/niko-light-of-hope) )