### PR TITLE
Card cleanup: 2026-07-17 [\tokenscripts, pass #2]

### DIFF
--- a/forge-gui/res/tokenscripts/c_a_map_sac_explore.txt
+++ b/forge-gui/res/tokenscripts/c_a_map_sac_explore.txt
@@ -1,5 +1,5 @@
 Name:Map Token
 ManaCost:no cost
 Types:Artifact Map
-A:AB$ Explore | Cost$ 1 T Sac<1/CARDNAME/this token> | TgtPrompt$ Select target creature you control | ValidTgts$ Creature.YouCtrl | SorcerySpeed$ True | SpellDescription$ Target creature you control explores. Activate only as a sorcery. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard.)
+A:AB$ Explore | Cost$ 1 T Sac<1/CARDNAME/this token> | ValidTgtsDesc$ creature you control | ValidTgts$ Creature.YouCtrl | SorcerySpeed$ True | SpellDescription$ Target creature you control explores. Activate only as a sorcery. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard.)
 Oracle:{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard.)

--- a/forge-gui/res/tokenscripts/c_e_shard_draw.txt
+++ b/forge-gui/res/tokenscripts/c_e_shard_draw.txt
@@ -1,6 +1,6 @@
 Name:Shard Token
 ManaCost:no cost
 Types:Enchantment Shard
-A:AB$ Scry | Cost$ 2 Sac<1/CARDNAME/this token> | CostDesc$ {2}, Sacrifice this enchantment: | ScryNum$ 1 | SubAbility$ DBDraw | StackDescription$ SpellDescription | SpellDescription$ Scry 1, then draw a card.
+A:AB$ Scry | Cost$ 2 Sac<1/CARDNAME/this token> | ScryNum$ 1 | SubAbility$ DBDraw | StackDescription$ SpellDescription | SpellDescription$ Scry 1, then draw a card.
 SVar:DBDraw:DB$ Draw | Defined$ You | NumCards$ 1 | StackDescription$ None
 Oracle:{2}, Sacrifice this token: Scry 1, then draw a card.

--- a/forge-gui/res/tokenscripts/festering_goblin.txt
+++ b/forge-gui/res/tokenscripts/festering_goblin.txt
@@ -3,6 +3,6 @@ ManaCost:no cost
 Colors:black
 Types:Creature Zombie Goblin
 PT:1/1
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ When CARDNAME dies, target creature gets -1/-1 until end of turn.
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigPump | TriggerDescription$ When this token dies, target creature gets -1/-1 until end of turn.
 SVar:TrigPump:DB$ Pump | ValidTgts$ Creature | NumAtt$ -1 | NumDef$ -1 | IsCurse$ True
-Oracle:When Festering Goblin dies, target creature gets -1/-1 until end of turn.
+Oracle:When this token dies, target creature gets -1/-1 until end of turn.

--- a/forge-gui/res/tokenscripts/g_x_x_treefolk_warrior_total_forests.txt
+++ b/forge-gui/res/tokenscripts/g_x_x_treefolk_warrior_total_forests.txt
@@ -3,7 +3,7 @@ ManaCost:no cost
 Colors:green
 Types:Creature Treefolk Warrior
 PT:*/*
-S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ This creature's power and toughness are each equal to the number of Forests you control.
+S:Mode$ Continuous | CharacteristicDefining$ True | SetPower$ X | SetToughness$ X | Description$ This token's power and toughness are each equal to the number of Forests you control.
 SVar:X:Count$Valid Forest.YouCtrl
 SVar:BuffedBy:Forest
-Oracle:This creature's power and toughness are each equal to the number of Forests you control.
+Oracle:This token's power and toughness are each equal to the number of Forests you control.

--- a/forge-gui/res/tokenscripts/r_0_2_dragon_egg_defender_hatches_dragon.txt
+++ b/forge-gui/res/tokenscripts/r_0_2_dragon_egg_defender_hatches_dragon.txt
@@ -4,7 +4,7 @@ Colors:red
 Types:Creature Dragon Egg
 PT:0/2
 K:Defender
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When this token dies, create a 2/2 red Dragon creature token with flying. It has "{R}: This creature gets +1/+0 until end of turn."
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When this token dies, create a 2/2 red Dragon creature token with flying. It has "{R}: This token gets +1/+0 until end of turn."
 SVar:TrigToken:DB$ Token | TokenOwner$ You | TokenScript$ r_2_2_dragon_flying_firebreathing
 SVar:SacMe:4
-Oracle:Defender\nWhen this token dies, create a 2/2 red Dragon creature token with flying. It has "{R}: This creature gets +1/+0 until end of turn."
+Oracle:Defender\nWhen this token dies, create a 2/2 red Dragon creature token with flying. It has "{R}: This token gets +1/+0 until end of turn."

--- a/forge-gui/res/tokenscripts/r_4_4_dragon_flying_firebending_4.txt
+++ b/forge-gui/res/tokenscripts/r_4_4_dragon_flying_firebending_4.txt
@@ -5,4 +5,4 @@ Types:Creature Dragon
 PT:4/4
 K:Flying
 K:Firebending:4
-Oracle:Flying\nFirebending 4 (Whenever this creature attacks, add {R}{R}{R}{R}. This mana lasts until end of combat.)
+Oracle:Flying\nFirebending 4 (Whenever this token attacks, add {R}{R}{R}{R}. This mana lasts until end of combat.)

--- a/forge-gui/res/tokenscripts/role_huntsman.txt
+++ b/forge-gui/res/tokenscripts/role_huntsman.txt
@@ -3,6 +3,6 @@ ManaCost:no cost
 Types:Enchantment Aura Role
 K:Enchant:Creature
 SVar:AttachAILogic:Pump
-S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | AddToughness$ 1 | AddAbility$ Mana | Description$ Enchanted creature gets +1/+1 and has "{T}: Add {G}."
-SVar:Mana:AB$ Mana | Cost$ T | Produced$ G | SpellDescription$ Add {G}.
+S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddPower$ 1 | AddToughness$ 1 | AddAbility$ ABMana | Description$ Enchanted creature gets +1/+1 and has "{T}: Add {G}."
+SVar:ABMana:AB$ Mana | Cost$ T | Produced$ G | SpellDescription$ Add {G}.
 Oracle:Enchant creature\nEnchanted creature gets +1/+1 and has "{T}: Add {G}."

--- a/forge-gui/res/tokenscripts/role_questing.txt
+++ b/forge-gui/res/tokenscripts/role_questing.txt
@@ -7,6 +7,6 @@ S:Mode$ Continuous | Affected$ Creature.EnchantedBy | AddKeyword$ Vigilance & De
 SVar:StaticNoBlock:Mode$ CantBlockBy | ValidAttacker$ Creature.Self | ValidBlocker$ Creature.powerLE2 | Description$ This creature can't be blocked by creatures with power 2 or less.
 SVar:StaticNoFog:Mode$ CantPreventDamage | IsCombat$ True | ValidSource$ Creature.YouCtrl | Description$ Combat damage that would be dealt by creatures you control can't be prevented.
 SVar:TrigChomp:Mode$ DamageDone | ValidSource$ Card.Self | ValidTarget$ Opponent | CombatDamage$ True | TriggerZones$ Battlefield | Execute$ MoreDamage | TriggerDescription$ Whenever this creature deals combat damage to an opponent, it deals that much damage to target planeswalker that player controls.
-SVar:MoreDamage:DB$ DealDamage | ValidTgts$ Planeswalker.ControlledBy TriggeredTarget | TgtPrompt$ Select target planeswalker that player controls | NumDmg$ X
+SVar:MoreDamage:DB$ DealDamage | ValidTgts$ Planeswalker.ControlledBy TriggeredTarget | ValidTgtsDesc$ planeswalker that player controls | NumDmg$ X
 SVar:X:TriggerCount$DamageAmount
 Oracle:Enchant creature\nEnchanted creature has vigilance, deathtouch, haste, "This creature can't be blocked by creatures with power 2 or less," "Combat damage that would be dealt by creatures you control can't be prevented," and "Whenever this creature deals combat damage to an opponent, it deals that much damage to target planeswalker that player controls."

--- a/forge-gui/res/tokenscripts/u_1_1_faerie_flying_blockflying.txt
+++ b/forge-gui/res/tokenscripts/u_1_1_faerie_flying_blockflying.txt
@@ -4,5 +4,5 @@ Colors:blue
 Types:Creature Faerie
 PT:1/1
 K:Flying
-S:Mode$ CantBlockBy | ValidAttacker$ Creature.withoutFlying | ValidBlocker$ Creature.Self | Description$ This creature can block only creatures with flying.
-Oracle:Flying\nThis creature can block only creatures with flying.
+S:Mode$ CantBlockBy | ValidAttacker$ Creature.withoutFlying | ValidBlocker$ Creature.Self | Description$ This token can block only creatures with flying.
+Oracle:Flying\nThis token can block only creatures with flying.

--- a/forge-gui/res/tokenscripts/u_3_3_fish_hatches_whale.txt
+++ b/forge-gui/res/tokenscripts/u_3_3_fish_hatches_whale.txt
@@ -3,7 +3,7 @@ ManaCost:no cost
 Colors:blue
 Types:Creature Fish
 PT:3/3
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When this creature dies, create a 6/6 blue Whale creature token with "When this creature dies, create a 9/9 blue Kraken creature token."
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When this token dies, create a 6/6 blue Whale creature token with "When this token dies, create a 9/9 blue Kraken creature token."
 SVar:TrigToken:DB$ Token | TokenScript$ u_6_6_whale_hatches_kraken | TokenOwner$ You
 SVar:SacMe:4
-Oracle:When this creature dies, create a 6/6 blue Whale creature token with "When this creature dies, create a 9/9 blue Kraken creature token."
+Oracle:When this token dies, create a 6/6 blue Whale creature token with "When this token dies, create a 9/9 blue Kraken creature token."

--- a/forge-gui/res/tokenscripts/u_6_6_whale_hatches_kraken.txt
+++ b/forge-gui/res/tokenscripts/u_6_6_whale_hatches_kraken.txt
@@ -3,7 +3,7 @@ ManaCost:no cost
 Colors:blue
 Types:Creature Whale
 PT:6/6
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When this creature dies, create a 9/9 blue Kraken creature token.
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription$ When this token dies, create a 9/9 blue Kraken creature token.
 SVar:TrigToken:DB$ Token | TokenScript$ u_9_9_kraken | TokenOwner$ You
 SVar:SacMe:1
-Oracle:When this creature dies, create a 9/9 blue Kraken creature token.
+Oracle:When this token dies, create a 9/9 blue Kraken creature token.

--- a/forge-gui/res/tokenscripts/volos_journal.txt
+++ b/forge-gui/res/tokenscripts/volos_journal.txt
@@ -2,6 +2,6 @@ Name:Volo's Journal
 ManaCost:no cost
 Types:Legendary Artifact Book
 K:Hexproof
-T:Mode$ SpellCast | ValidCard$ Creature | ValidActivatingPlayer$ You | Execute$ TrigNoteType | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a creature spell, note one of its creature types that hasn't been noted for this artifact.
+T:Mode$ SpellCast | ValidCard$ Creature | ValidActivatingPlayer$ You | Execute$ TrigNoteType | TriggerZones$ Battlefield | TriggerDescription$ Whenever you cast a creature spell, note one of its creature types that hasn't been noted for CARDNAME.
 SVar:TrigNoteType:DB$ ChooseType | Type$ Creature | TypesFromDefined$ TriggeredCard | Note$ True
-Oracle:Hexproof\nWhenever you cast a creature spell, note one of its creature types that hasn't been noted for this artifact.
+Oracle:Hexproof\nWhenever you cast a creature spell, note one of its creature types that hasn't been noted for Volo's Journal.

--- a/forge-gui/res/tokenscripts/w_2_2_human_knight_artifact_pump.txt
+++ b/forge-gui/res/tokenscripts/w_2_2_human_knight_artifact_pump.txt
@@ -3,6 +3,6 @@ ManaCost:no cost
 Colors:white
 Types:Creature Human Knight
 PT:2/2
-S:Mode$ Continuous | Affected$ Card.Self | CheckSVar$ X | AddPower$ 2 | AddToughness$ 2 | Description$ This creature gets +2/+2 as long as an artifact entered the battlefield under your control this turn.
+S:Mode$ Continuous | Affected$ Card.Self | CheckSVar$ X | AddPower$ 2 | AddToughness$ 2 | Description$ This token gets +2/+2 as long as an artifact entered the battlefield under your control this turn.
 SVar:X:Count$ThisTurnEntered_Battlefield_Artifact.YouCtrl
-Oracle:This creature gets +2/+2 as long as an artifact entered the battlefield under your control this turn.
+Oracle:This token gets +2/+2 as long as an artifact entered the battlefield under your control this turn.


### PR DESCRIPTION
Updating tokens per Gatherer associated with the card scripts updated in the following PRs:
- https://github.com/Card-Forge/forge/pull/11251
- https://github.com/Card-Forge/forge/pull/11252
- https://github.com/Card-Forge/forge/pull/11257

Updating the [firebending Dragon token](https://scryfall.com/card/ttla/9/dragon) per its printing.

Dealing with `TgtPrompt$` and minor standardization.