### PR TITLE
Fix Nethergoyf escape cost validation

### DIFF
--- a/forge-gui/src/main/java/forge/player/HumanCostDecision.java
+++ b/forge-gui/src/main/java/forge/player/HumanCostDecision.java
@@ -328,8 +328,8 @@ public class HumanCostDecision extends CostDecisionMakerBase {
                 Localizer.getInstance().getMessage("lblSelectToExile", Lang.getNumeral(nTypes)));
             inp.setCancelAllowed(true);
             inp.showAndWait();
-            if (inp.hasCancelled() || 
-                !Expressions.compare(AbilityUtils.countCardTypesFromList(list, false), "GE", nTypes)) {
+            if (inp.hasCancelled() ||
+                !Expressions.compare(AbilityUtils.countCardTypesFromList(inp.getSelected(), false), "GE", nTypes)) {
                     return null;
             }
             return PaymentDecision.card(inp.getSelected());


### PR DESCRIPTION
Nethergoyf's escape cost requires exiling cards with four or more card types among them.

Forge first builds a list of every eligible card in the graveyard, then asks the player which cards to exile. The validation was counting card types across that full candidate list instead of the cards the player actually selected. This meant a graveyard could contain four card types overall while the player selected only one or two types, and Forge would still accept the payment.

This changes the validation to count card types among the selected cards—the cards that will actually be exiled. A selection with fewer than four card types is now rejected.
