### PR TITLE
Fix turn transition after cleanup-step loss

### DIFF
--- a/forge-game/src/main/java/forge/game/phase/PhaseHandler.java
+++ b/forge-game/src/main/java/forge/game/phase/PhaseHandler.java
@@ -512,7 +512,11 @@ public class PhaseHandler implements java.io.Serializable, IHasForgeLog {
                     game.onCleanupPhase();
                     // set previous player
                     playerPreviousTurn = this.getPlayerTurn();
-                    setPlayerTurn(handleNextTurn());
+                    Player next = handleNextTurn();
+                    if (game.isGameOver()) {
+                        return;
+                    }
+                    setPlayerTurn(next);
 
                     // start effects for next turn (do this first for ControlPlayer)
                     game.getCleanup().executeUntil();
@@ -835,8 +839,19 @@ public class PhaseHandler implements java.io.Serializable, IHasForgeLog {
 
         game.getTriggerHandler().clearThisTurnDelayedTrigger();
 
+        // A player can receive an outcome after the last state-based check,
+        // so process the loss before selecting from the turn order.
+        game.getAction().checkGameOverCondition();
+        if (game.isGameOver()) {
+            return playerTurn;
+        }
+
         Player next = getNextActivePlayer();
         while (!next.isInGame()) {
+            game.getAction().checkGameOverCondition();
+            if (game.isGameOver()) {
+                return next;
+            }
             next = getNextActivePlayer();
         }
 
@@ -1144,6 +1159,9 @@ public class PhaseHandler implements java.io.Serializable, IHasForgeLog {
                 // end phase
                 givePriorityToPlayer = true;
                 onPhaseEnd();
+                if (game.isGameOver()) {
+                    return;
+                }
                 advanceToNextPhase();
                 onPhaseBegin();
             }
@@ -1202,6 +1220,9 @@ public class PhaseHandler implements java.io.Serializable, IHasForgeLog {
                 resolver.run();
             }
             onPhaseEnd();
+            if (game.isGameOver()) {
+                return false;
+            }
             advanceToNextPhase();
             onPhaseBegin();
         }


### PR DESCRIPTION
Forge's Puzzle mode can make a player lose during cleanup when the turn limit expires. The player receives a loss outcome immediately, but remains in the turn order until the game-over condition is processed. Next-turn selection could therefore keep returning the same lost player and hang.

| | Before | After |
|---|---|---|
| Pending loss | Select the next player first | Process the game outcome first |
| Duel | Assign the lost player and continue the phase transition | End without starting another phase |
| Multiplayer | Lost player remains in the rotation | Remove the lost player and select a live player |

Game outcomes are also checked again if next-player selection itself causes a loss.
