### PR TITLE
FRA: 5 prepare cards

### DIFF
--- a/forge-game/src/main/java/forge/game/card/CardProperty.java
+++ b/forge-game/src/main/java/forge/game/card/CardProperty.java
@@ -1848,6 +1848,10 @@ public class CardProperty {
             if (!card.isSuspected()) {
                 return false;
             }
+        } else if (property.equals("IsPrepared")) {
+            if (!card.isPrepared()) {
+                return false;
+            }
         } else if (property.equals("IsRemembered")) {
             if (!source.isRemembered(card)) {
                 return false;

--- a/forge-gui/res/cardsfolder/upcoming/paradox_shaper_omit_variables.txt
+++ b/forge-gui/res/cardsfolder/upcoming/paradox_shaper_omit_variables.txt
@@ -1,0 +1,18 @@
+Name:Paradox Shaper
+ManaCost:1 UB
+Types:Creature Octopus Wizard
+PT:1/3
+AlternateMode:Prepare
+T:Mode$ Phase | Phase$ Upkeep | CheckSVar$ Count$ValidSelf Card.!IsPrepared | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPrepare | TriggerDescription$ At the beginning of your upkeep, if this creature isn't prepared, it becomes prepared. (While it's prepared, you may cast a copy of its spell. Doing so unprepares it.)
+A:AB$ ChangeZone | Cost$ 2 | ValidTgts$ Card.YouOwn | ValidTgtsDesc$ card in your graveyard | Origin$ Graveyard | Destination$ Library | LibraryPosition$ -1 | SpellDescription$ Put target card from your graveyard on the bottom of your library.
+SVar:TrigPrepare:DB$ AlterAttribute | Attributes$ Prepared
+AlternateMode:Prepare
+Oracle:At the beginning of your upkeep, if this creature isn't prepared, it becomes prepared.\n{2}: Put target card from your graveyard on the bottom of your library.
+
+ALTERNATE
+
+Name:Omit Variables
+ManaCost:UB
+Types:Sorcery
+A:SP$ Mill | Defined$ You | NumCards$ 3 | SpellDescription$ Mill three cards. (Put the top three cards of your library into your graveyard.)
+Oracle:Mill three cards. (Put the top three cards of your library into your graveyard.)

--- a/forge-gui/res/cardsfolder/upcoming/prudent_fateseer_peer_review.txt
+++ b/forge-gui/res/cardsfolder/upcoming/prudent_fateseer_peer_review.txt
@@ -1,0 +1,20 @@
+Name:Prudent Fateseer
+ManaCost:1 WU WU
+Types:Creature Dwarf Wizard
+PT:1/4
+K:ETBReplacement:Other:DBPrepare
+SVar:DBPrepare:DB$ AlterAttribute | Attributes$ Prepared | SpellDescription$ This creature enters prepared.
+T:Mode$ Scry | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPumpAll | ActivationLimit$ 1 | TriggerDescription$ Whenever you scry or surveil, creatures you control get +1/+0 until end of turn. This ability triggers only once each turn.
+T:Mode$ Surveil | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPumpAll | ActivationLimit$ 1 | Secondary$ True | TriggerDescription$ Whenever you scry or surveil, creatures you control get +1/+0 until end of turn. This ability triggers only once each turn.
+SVar:TrigPumpAll:DB$ PumpAll | ValidCards$ Creature.YouCtrl | NumAtt$ +1
+AlternateMode:Prepare
+Oracle:This creature enters prepared.\nWhenever you scry or surveil, creatures you control get +1/+0 until end of turn. This ability triggers only once each turn.
+
+ALTERNATE
+
+Name:Peer Review
+ManaCost:2 WU
+Types:Sorcery
+A:SP$ Token | TokenScript$ cadet | SubAbility$ DBSurveil | SpellDescription$ Create a 2/2 colorless Wizard Soldier creature token named Cadet.
+SVar:DBSurveil:DB$ Surveil | Amount$ 1 | SpellDescription$ Surveil 1.
+Oracle:Create a 2/2 colorless Wizard Soldier creature token named Cadet. Surveil 1.

--- a/forge-gui/res/cardsfolder/upcoming/stingerquill_voxmancer_vicious_verse.txt
+++ b/forge-gui/res/cardsfolder/upcoming/stingerquill_voxmancer_vicious_verse.txt
@@ -1,0 +1,16 @@
+Name:Stingerquill Voxmancer
+ManaCost:BR
+Types:Creature Goblin Sorcerer
+PT:1/2
+T:Mode$ Phase | Phase$ Upkeep | CheckSVar$ Count$ValidSelf Card.!IsPrepared | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPrepare | TriggerDescription$ At the beginning of your upkeep, if this creature isn't prepared, it becomes prepared. (While it's prepared, you may cast a copy of its spell. Doing so unprepares it.)
+SVar:TrigPrepare:DB$ AlterAttribute | Attributes$ Prepared
+AlternateMode:Prepare
+Oracle:At the beginning of your upkeep, if this creature isn't prepared, it becomes prepared. (While it's prepared, you may cast a copy of its spell. Doing so unprepares it.)
+
+ALTERNATE
+
+Name:Vicious Verse
+ManaCost:BR
+Types:Sorcery
+A:SP$ DealDamage | ValidTgts$ Opponent | NumDmg$ 1 | SpellDescription$ CARDNAME deals 1 damage to target opponent
+Oracle:Vicious Verse deals 1 damage to target opponent.

--- a/forge-gui/res/cardsfolder/upcoming/vigorbloom_vanguard_seed_suture.txt
+++ b/forge-gui/res/cardsfolder/upcoming/vigorbloom_vanguard_seed_suture.txt
@@ -1,0 +1,19 @@
+Name:Vigorbloom Vanguard
+ManaCost:1 GW
+Types:Creature Troll Druid
+PT:2/2
+K:ETBReplacement:Other:DBPrepare
+SVar:DBPrepare:DB$ AlterAttribute | Attributes$ Prepared | SpellDescription$ This creature enters prepared.
+S:Mode$ Continuous | Affected$ Creature.YouCtrl+counters_GE1_P1P1 | AddKeyword$ Vigilance | Description$ Each creature you control with a +1/+1 counter on it has vigilance.
+AlternateMode:Prepare
+Oracle:This creature enters prepared. (While it's prepared, you may cast a copy of its spell. Doing so unprepares it.)
+Each creature you control with a +1/+1 counter on it has vigilance.
+
+ALTERNATE
+
+Name:Seed Suture
+ManaCost:GW
+Types:Sorcery
+A:SP$ PutCounter | ValidTgts$ Creature | CounterType$ P1P1 | CounterNum$ 1 | SubAbility$ DBGainLife | SpellDescription$ Put a +1/+1 counter on target creature. You gain 1 life.
+SVar:DBGainLife:DB$ GainLife | LifeAmount$ 1
+Oracle:Put a +1/+1 counter on target creature. You gain 1 life.

--- a/forge-gui/res/cardsfolder/upcoming/woodwork_prodigy_soul_tether.txt
+++ b/forge-gui/res/cardsfolder/upcoming/woodwork_prodigy_soul_tether.txt
@@ -1,0 +1,16 @@
+Name:Woodwork Prodigy
+ManaCost:2 RG
+Types:Creature Cat Druid
+PT:3/3
+T:Mode$ Phase | Phase$ Upkeep | CheckSVar$ Count$ValidSelf Card.!IsPrepared | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigPrepare | TriggerDescription$ At the beginning of your upkeep, if this creature isn't prepared, it becomes prepared. (While it's prepared, you may cast a copy of its spell. Doing so unprepares it.)
+SVar:TrigPrepare:DB$ AlterAttribute | Attributes$ Prepared
+AlternateMode:Prepare
+Oracle:At the beginning of your upkeep, if this creature isn't prepared, it becomes prepared. (While it's prepared, you may cast a copy of its spell. Doing so unprepares it.)
+
+ALTERNATE
+
+Name:Soul Tether
+ManaCost:2 RG
+Types:Sorcery
+A:SP$ Token | TokenScript$ rg_a_heartwood | SpellDescription$ Create a Heartwood token. (It's a red and green artifact with "{T}: Add {R} or {G}.")
+Oracle:Create a Heartwood token. (It's a red and green artifact with "{T}: Add {R} or G.")

--- a/forge-gui/res/lists/TypeLists.txt
+++ b/forge-gui/res/lists/TypeLists.txt
@@ -377,6 +377,7 @@ Equipment
 Food:Foods
 Fortification
 Gold
+Heartwood
 Incubator:Incubators
 Infinity
 Junk

--- a/forge-gui/res/tokenscripts/rg_a_heartwood.txt
+++ b/forge-gui/res/tokenscripts/rg_a_heartwood.txt
@@ -1,0 +1,6 @@
+Name:Heartwood
+ManaCost:no cost
+Colors:red,green
+Types:Artifact Heartwood
+A:AB$ Mana | Cost$ T | Produced$ Combo R G | Amount$ 1 | SpellDescription$ Add {R} or {G}.
+Oracle:{T}: Add {R} or {G}.


### PR DESCRIPTION
As recently revealed; tested to satisfaction:
- [Paradox Shaper // Omit Variables](https://scryfall.com/card/fra/143/paradox-shaper-omit-variables) with intervening if support via the `IsPrepared` card property, calqued from `IsSuspected`.
- [Prudent Fateseer // Peer Review](https://scryfall.com/card/fra/146/prudent-fateseer-peer-review)
- [Stingerquill Voxmancer // Vicious Verse](https://scryfall.com/card/fra/151/stingerquill-voxmancer-vicious-verse)
- [Vigorbloom Vanguard // Seed Suture](https://scryfall.com/card/fra/161/vigorbloom-vanguard-seed-suture)
- [Woodwork Prodigy // Soul Tether](https://scryfall.com/card/fra/165/woodwork-prodigy-soul-tether) and associated token and artifact type