### PR TITLE
Card cleanup: 2026-07-17 [\tokenscripts, pass #3]

### DIFF
--- a/forge-gui/res/tokenscripts/b_2_2_bird_flying.txt
+++ b/forge-gui/res/tokenscripts/b_2_2_bird_flying.txt
@@ -1,7 +1,7 @@
 Name:Bird Token
 ManaCost:no cost
-Types:Creature Bird
 Colors:black
+Types:Creature Bird
 PT:2/2
 K:Flying
 Oracle:Flying

--- a/forge-gui/res/tokenscripts/b_2_2_e_horror.txt
+++ b/forge-gui/res/tokenscripts/b_2_2_e_horror.txt
@@ -1,6 +1,6 @@
 Name:Horror Token
 ManaCost:no cost
-PT:2/2
 Colors:black
 Types:Enchantment Creature Horror
+PT:2/2
 Oracle:

--- a/forge-gui/res/tokenscripts/b_2_2_horror.txt
+++ b/forge-gui/res/tokenscripts/b_2_2_horror.txt
@@ -1,6 +1,6 @@
 Name:Horror Token
 ManaCost:no cost
-PT:2/2
 Colors:black
 Types:Creature Horror
+PT:2/2
 Oracle:

--- a/forge-gui/res/tokenscripts/b_6_6_demon_flying.txt
+++ b/forge-gui/res/tokenscripts/b_6_6_demon_flying.txt
@@ -1,7 +1,7 @@
 Name:Demon Token
 ManaCost:no cost
-Types:Creature Demon
 Colors:black
+Types:Creature Demon
 PT:6/6
 K:Flying
 Oracle:Flying

--- a/forge-gui/res/tokenscripts/bg_1_1_insect_flying.txt
+++ b/forge-gui/res/tokenscripts/bg_1_1_insect_flying.txt
@@ -1,7 +1,7 @@
 Name:Insect Token
 ManaCost:no cost
-Types:Creature Insect
 Colors:black,green
+Types:Creature Insect
 PT:1/1
 K:Flying
 Oracle:Flying

--- a/forge-gui/res/tokenscripts/mask.txt
+++ b/forge-gui/res/tokenscripts/mask.txt
@@ -3,6 +3,6 @@ ManaCost:no cost
 Colors:white
 Types:Enchantment Aura
 K:Enchant:Permanent:permanent
-K:Umbra armor
 SVar:AttachAILogic:Pump
+K:Umbra armor
 Oracle:Enchant permanent\nUmbra armor

--- a/forge-gui/res/tokenscripts/r_4_4_dinosaur_dragon_flying.txt
+++ b/forge-gui/res/tokenscripts/r_4_4_dinosaur_dragon_flying.txt
@@ -1,7 +1,7 @@
 Name:Dinosaur Dragon Token
 ManaCost:no cost
-Types:Creature Dinosaur Dragon
 Colors:red
+Types:Creature Dinosaur Dragon
 PT:4/4
 K:Flying
 Oracle:Flying

--- a/forge-gui/res/tokenscripts/stoneforged_blade.txt
+++ b/forge-gui/res/tokenscripts/stoneforged_blade.txt
@@ -1,7 +1,6 @@
 Name:Stoneforged Blade
 ManaCost:no cost
 Types:Artifact Equipment
-PT:5/5
 K:Indestructible
 K:Equip:0
 S:Mode$ Continuous | Affected$ Creature.EquippedBy | AddPower$ 5 | AddToughness$ 5 | AddKeyword$ Double Strike | Description$ Equipped creature gets +5/+5 and has double strike.

--- a/forge-gui/res/tokenscripts/w_1_1_a_toy.txt
+++ b/forge-gui/res/tokenscripts/w_1_1_a_toy.txt
@@ -1,6 +1,6 @@
 Name:Toy Token
 ManaCost:no cost
-Types:Artifact Creature Toy
 Colors:white
+Types:Artifact Creature Toy
 PT:1/1
 Oracle:

--- a/forge-gui/res/tokenscripts/w_1_1_e_glimmer.txt
+++ b/forge-gui/res/tokenscripts/w_1_1_e_glimmer.txt
@@ -1,6 +1,6 @@
 Name:Glimmer Token
 ManaCost:no cost
-PT:1/1
 Colors:white
 Types:Enchantment Creature Glimmer
+PT:1/1
 Oracle:

--- a/forge-gui/res/tokenscripts/w_2_1_insect_flying.txt
+++ b/forge-gui/res/tokenscripts/w_2_1_insect_flying.txt
@@ -1,7 +1,7 @@
 Name:Insect Token
 ManaCost:no cost
-PT:2/1
 Colors:white
 Types:Creature Insect
+PT:2/1
 K:Flying
 Oracle:Flying

--- a/forge-gui/res/tokenscripts/w_3_1_spirit_flying.txt
+++ b/forge-gui/res/tokenscripts/w_3_1_spirit_flying.txt
@@ -1,7 +1,7 @@
 Name:Spirit Token
 ManaCost:no cost
-Types:Creature Spirit
 Colors:white
+Types:Creature Spirit
 PT:3/1
 K:Flying
 Oracle:Flying


### PR DESCRIPTION
Standardizing line order to conform with existing patterns. Removed an extraneous `PT` line from [Nahiri, the Lithomancer's](https://scryfall.com/card/cmm/45/nahiri-the-lithomancer) Stoneforged Blade.