### PR TITLE
Card cleanup: 2026-07-18, incidental

### DIFF
--- a/forge-gui/res/editions/Unknown Event.txt
+++ b/forge-gui/res/editions/Unknown Event.txt
@@ -518,3 +518,7 @@ RW90c R The Keeper of Favorite Cards @
 RW90d R The Keeper of Favorite Cards @
 RW90e R The Keeper of Favorite Cards @
 MZ99 M The Collector @
+
+[CreatureTypes]
+Glass:Glasses
+Stained:Stained


### PR DESCRIPTION
Noticed another card/token with orphaned subtypes, [Sagrada Familiar](https://scryfall.com/card/unk/UA03d/sagrada-familiar). On the assumption these are creature types, I added them to the appropriate edition file.