### PR TITLE
Determinism hooks: per-thread MyRandom seeding + order-stable zone preparation

### DIFF
--- a/forge-core/src/main/java/forge/util/MyRandom.java
+++ b/forge-core/src/main/java/forge/util/MyRandom.java
@@ -30,15 +30,27 @@ import java.util.Random;
  * @version $Id$
  */
 public class MyRandom {
-    /** Constant <code>random</code>. */
-    private static Random random = new SecureRandom();
+    /**
+     * Per-thread random source. Thread-local so concurrent games in one JVM
+     * (headless simulation workers, parallel AI harnesses) that seed their
+     * stream via {@link #setRandom(Random)} cannot contaminate each other's
+     * sequences. Inheritable so threads spawned from a seeded thread (AI
+     * evaluation helpers) continue the parent's stream instead of silently
+     * falling back to an unseeded one. Single-threaded behavior is unchanged.
+     */
+    private static final ThreadLocal<Random> random = new InheritableThreadLocal<Random>() {
+        @Override
+        protected Random initialValue() {
+            return new SecureRandom();
+        }
+    };
 
     /**
      * <p>
      * percentTrue.<br>
      * If percent is like 30, then 30% of the time it will be true.
      * </p>
-     * 
+     *
      * @param percent an int.
      * @return a boolean.
      */
@@ -48,26 +60,27 @@ public class MyRandom {
 
     /**
      * Gets the random.
-     * 
-     * @return the random
+     *
+     * @return the random for the current thread
      */
     public static Random getRandom() {
-        return MyRandom.random;
+        return random.get();
     }
 
     /**
-     * Sets the random provider. Used for deterministic simulation.
+     * Sets the random provider for the current thread (and threads it spawns
+     * afterwards). Used for deterministic simulation.
      * @param random the random
      */
     public static void setRandom(Random random) {
-        MyRandom.random = random;
+        MyRandom.random.set(random);
     }
 
     public static int[] splitIntoRandomGroups(final int value, final int numGroups) {
         int[] groups = new int[numGroups];
 
         for (int i = 0; i < value; i++) {
-            groups[random.nextInt(numGroups)]++;
+            groups[getRandom().nextInt(numGroups)]++;
         }
 
         return groups;

--- a/forge-game/src/main/java/forge/game/Match.java
+++ b/forge-game/src/main/java/forge/game/Match.java
@@ -200,7 +200,14 @@ public class Match {
     private static void preparePlayerZone(Player player, final ZoneType zoneType, CardPool section, boolean canRandomFoil) {
         PlayerZone library = player.getZone(zoneType);
         List<Card> newLibrary = new ArrayList<>();
-        for (final Entry<PaperCard, Integer> stackOfCards : section) {
+        // Iterate the deck section in sorted order: CardPool's backing map
+        // does not guarantee iteration order, so for a fixed seed the
+        // pre-shuffle library order, the random-foil roll sequence, and the
+        // card id assignment order could all vary across JVMs. Sorted
+        // iteration makes zone preparation a pure function of (deck, seed).
+        List<Entry<PaperCard, Integer>> ordered = Lists.newArrayList(section);
+        ordered.sort(Entry.comparingByKey());
+        for (final Entry<PaperCard, Integer> stackOfCards : ordered) {
             final PaperCard cp = stackOfCards.getKey();
             for (int i = 0; i < stackOfCards.getValue(); i++) {
                 final Card card = Card.fromPaperCard(cp, player);

--- a/forge-gui-desktop/src/test/java/forge/ai/simulation/PreShuffleDeterminismTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/simulation/PreShuffleDeterminismTest.java
@@ -1,0 +1,90 @@
+package forge.ai.simulation;
+
+import java.lang.reflect.Method;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import forge.deck.CardPool;
+import forge.game.Game;
+import forge.game.Match;
+import forge.game.card.Card;
+import forge.game.player.Player;
+import forge.game.zone.ZoneType;
+import forge.item.PaperCard;
+import forge.model.FModel;
+import forge.util.MyRandom;
+
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+/**
+ * Zone preparation must be a pure function of (deck, seed): CardPool's
+ * backing map does not guarantee iteration order, so without sorted
+ * iteration the pre-shuffle library order, random-foil roll sequence, and
+ * card id assignment could vary across JVMs for the same seed.
+ */
+public class PreShuffleDeterminismTest extends SimulationTest {
+
+    private static final String[][] DECK = {
+            {"Plains", "12"}, {"Island", "12"}, {"Runeclaw Bear", "4"},
+            {"Grizzly Bears", "4"}, {"Lightning Bolt", "4"}, {"Counterspell", "4"},
+            {"Sol Ring", "1"}, {"Fireball", "3"}, {"Shock", "4"},
+            {"Giant Growth", "4"}, {"Llanowar Elves", "4"}, {"Divination", "4"},
+    };
+
+    private CardPool pool(int[] order) {
+        CardPool p = new CardPool();
+        for (int i : order) {
+            PaperCard pc = FModel.getMagicDb().getCommonCards().getCard(DECK[i][0]);
+            AssertJUnit.assertNotNull(DECK[i][0], pc);
+            p.add(pc, Integer.parseInt(DECK[i][1]));
+        }
+        return p;
+    }
+
+    private List<String> prepare(Player player, CardPool section, long seed) throws Exception {
+        Method m = Match.class.getDeclaredMethod("preparePlayerZone",
+                Player.class, ZoneType.class, CardPool.class, boolean.class);
+        m.setAccessible(true);
+        MyRandom.setRandom(new Random(seed));
+        try {
+            m.invoke(null, player, ZoneType.Library, section, true);
+        } finally {
+            MyRandom.setRandom(new SecureRandom());
+        }
+        List<String> names = new ArrayList<>();
+        for (Card c : player.getZone(ZoneType.Library)) {
+            names.add(c.getName());
+        }
+        return names;
+    }
+
+    @Test
+    public void testLibraryPreparationIsInsertionOrderInvariant() throws Exception {
+        Game game = initAndCreateGame();
+        Player p = game.getPlayers().get(0);
+
+        int n = DECK.length;
+        int[] fwd = new int[n];
+        int[] rev = new int[n];
+        for (int i = 0; i < n; i++) {
+            fwd[i] = i;
+            rev[i] = n - 1 - i;
+        }
+
+        List<String> a = prepare(p, pool(fwd), 7L);
+        List<String> b = prepare(p, pool(rev), 7L);
+
+        AssertJUnit.assertEquals(60, a.size());
+        // same deck, same seed, different CardPool insertion order ->
+        // byte-identical library
+        AssertJUnit.assertEquals(a, b);
+        // and the pre-shuffle order is the sorted one (name-major), so it is
+        // stable across JVMs, not merely within this one
+        List<String> sorted = new ArrayList<>(a);
+        java.util.Collections.sort(sorted, String.CASE_INSENSITIVE_ORDER);
+        AssertJUnit.assertEquals(sorted, a);
+    }
+}

--- a/forge-gui-desktop/src/test/java/forge/util/MyRandomThreadLocalTest.java
+++ b/forge-gui-desktop/src/test/java/forge/util/MyRandomThreadLocalTest.java
@@ -1,0 +1,54 @@
+package forge.util;
+
+import java.security.SecureRandom;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.testng.AssertJUnit;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+/**
+ * MyRandom's per-thread seeding contract: seeded streams are isolated
+ * between sibling threads, and threads spawned from a seeded thread inherit
+ * its stream (so deterministic simulation survives helper threads).
+ */
+public class MyRandomThreadLocalTest {
+
+    @AfterMethod
+    public void restoreUnseeded() {
+        MyRandom.setRandom(new SecureRandom());
+    }
+
+    @Test
+    public void testSeededStreamsAreIsolatedBetweenThreads() throws Exception {
+        MyRandom.setRandom(new Random(1));
+        AtomicLong otherFirst = new AtomicLong();
+        Thread other = new Thread(() -> {
+            MyRandom.setRandom(new Random(2));
+            otherFirst.set(MyRandom.getRandom().nextLong());
+        });
+        other.start();
+        other.join();
+
+        // this thread's stream is untouched by the sibling's setRandom
+        AssertJUnit.assertEquals(new Random(1).nextLong(),
+                MyRandom.getRandom().nextLong());
+        AssertJUnit.assertEquals(new Random(2).nextLong(), otherFirst.get());
+    }
+
+    @Test
+    public void testSpawnedThreadInheritsSeededStream() throws Exception {
+        Random seeded = new Random(42);
+        MyRandom.setRandom(seeded);
+        AtomicReference<Random> childSees = new AtomicReference<>();
+        Thread child = new Thread(() -> childSees.set(MyRandom.getRandom()));
+        child.start();
+        child.join();
+
+        // inheritable: the child continues the parent's seeded stream rather
+        // than silently falling back to a fresh unseeded SecureRandom
+        AssertJUnit.assertSame(seeded, childSees.get());
+    }
+}


### PR DESCRIPTION
Draft for the determinism conversation with @Hanmac (#11260) and the manabrew project (Discord #ai-plotting) — two small, separately revertable changes that make seeded simulation deterministic across concurrent games and across JVMs. Re-authors the determinism patch carried in witchesofthehill/forge (`d658cbc757`, credited as co-author) with two refinements. Intentionally excludes per-Game ID counters (#11260 is the better design and is maintainer-led) and `ImageKeys.clearCaches()` (useful, but not determinism — can be its own PR).

**1. `MyRandom`: the random source becomes an `InheritableThreadLocal`.** `setRandom()` — already documented as the deterministic-simulation hook — now seeds the *calling thread's* stream, so concurrent headless games in one JVM can't contaminate each other's sequences. Refinement over the manabrew patch: inheritable, so threads spawned from a seeded thread (AI evaluation helpers) continue the parent's stream rather than silently falling back to an unseeded one. Single-threaded behavior is unchanged. Design question for review: `InheritableThreadLocal` vs plain `ThreadLocal` — we chose inheritable so seeding survives helper-thread spawns; happy to hear if there's a spawn pattern where inheritance is wrong.

**2. `Match.preparePlayerZone`: iterate the deck section in sorted order.** `CardPool`'s backing map doesn't guarantee iteration order, so for a fixed seed the pre-shuffle library order, the random-foil roll sequence, and the card-id assignment order can all vary across JVMs. Refinement over sorting the finished list: sorting the *iteration* also fixes the RNG-consumption and id-assignment order, making zone preparation a pure function of (deck, seed) — the id-assignment half complements #11260's same-construction-order ⇒ same-ids invariant. Note for anyone with seed-pinned game corpora: behavior-invariant but trajectory-changing for a given seed.

**Tests** (3 new, all green; full forge-gui-desktop suite green, 289 tests): seeded-stream isolation between sibling threads; child-thread stream inheritance; library preparation invariant under CardPool insertion order and stable cross-JVM (sorted pre-shuffle order asserted directly).

**Fork-fidelity verification**: we ran this branch through our forkcheck harness (mid-game fork → digest-identical state → deterministic seeded completion under a model-driven bridge, the gate built for #11203): twin determinism 40/40, 0 static mismatches, 0 transport failures — no fidelity regression.

Portions authored with an AI assistant (Claude), reviewed by a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)