### PR TITLE
HOB: 4 cards

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/the_chief_warg.txt
+++ b/forge-gui/res/cardsfolder/upcoming/the_chief_warg.txt
@@ -3,7 +3,7 @@ ManaCost:2 B G
 Types:Legendary Creature Wolf
 PT:3/3
 K:Menace
-T:Mode$ AttackersDeclared | AttackingPlayer$ You | IsPresent$ Creature.YouCtrl+powerGE4 | Execute$ TrigDraw | TriggerZones$ Battlefield | TriggerDescription$ Ferocious — Whenever you attack while you control a creature with power 4 or greater, you draw a card and lose 1 life.
+T:Mode$ AttackersDeclared | AttackingPlayer$ You | IsPresent$ Creature.YouCtrl+powerGE4 | NoResolvingCheck$ True | Execute$ TrigDraw | TriggerZones$ Battlefield | TriggerDescription$ Ferocious — Whenever you attack while you control a creature with power 4 or greater, you draw a card and lose 1 life.
 SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1 | SubAbility$ DBLoseLife
 SVar:DBLoseLife:DB$ LoseLife | Defined$ You | LifeAmount$ 1
 Oracle:Menace (This creature can’t be blocked except by two or more creatures.)\nFerocious — Whenever you attack while you control a creature with power 4 or greater, you draw a card and lose 1 life.

--- a/forge-gui/res/cardsfolder/upcoming/the_chief_warg.txt
+++ b/forge-gui/res/cardsfolder/upcoming/the_chief_warg.txt
@@ -1,0 +1,9 @@
+Name:The Chief Warg
+ManaCost:2 B G
+Types:Legendary Creature Wolf
+PT:3/3
+K:Menace
+T:Mode$ AttackersDeclared | AttackingPlayer$ You | IsPresent$ Creature.YouCtrl+powerGE4 | Execute$ TrigDraw | TriggerZones$ Battlefield | TriggerDescription$ Ferocious — Whenever you attack while you control a creature with power 4 or greater, you draw a card and lose 1 life.
+SVar:TrigDraw:DB$ Draw | Defined$ You | NumCards$ 1 | SubAbility$ DBLoseLife
+SVar:DBLoseLife:DB$ LoseLife | Defined$ You | LifeAmount$ 1
+Oracle:Menace (This creature can’t be blocked except by two or more creatures.)\nFerocious — Whenever you attack while you control a creature with power 4 or greater, you draw a card and lose 1 life.

--- a/forge-gui/res/cardsfolder/upcoming/the_eagles_are_coming.txt
+++ b/forge-gui/res/cardsfolder/upcoming/the_eagles_are_coming.txt
@@ -1,0 +1,15 @@
+Name:The Eagles Are Coming!
+ManaCost:1 W
+Types:Instant
+K:Kicker:2 W W
+A:SP$ Pump | ValidTgtsDesc$ creature you own | ValidTgts$ Creature.YouOwn | TargetMin$ X | TargetMax$ X | SubAbility$ DBPump | StackDescription$ None | SpellDescription$ Choose target creature you own.
+SVar:DBPump:DB$ Pump | TgtPrompt$ Select any number of target creatures you own | ValidTgts$ Creature.YouOwn | TargetMin$ 0 | TargetMax$ Y | SubAbility$ DBChangeZone | StackDescription$ None | SpellDescription$ If this spell was kicked, instead choose any number of target creatures you own.
+SVar:DBChangeZone:DB$ ChangeZone | Origin$ Battlefield | Destination$ Hand | Defined$ Targeted | RememberChanged$ True | SubAbility$ DBDelayedTrigger | StackDescription$ Return {c:Targeted} to your hand. | SpellDescription$ Return each chosen creature to your hand.
+SVar:DBDelayedTrigger:DB$ DelayedTrigger | Mode$ Phase | Phase$ Upkeep | Execute$ TrigToken | RememberObjects$ Remembered | SubAbility$ DBCleanup | TriggerDescription$ At the beginning of the next upkeep, create a 4/4 white Bird Soldier creature token with flying for each creature returned to your hand this way.
+SVar:TrigToken:DB$ Token | TokenScript$ w_4_4_bird_soldier_flying | TokenOwner$ You | TokenAmount$ TokenX
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:X:Count$Kicked.0.1
+SVar:Y:Count$Valid Creature.YouOwn/Times.Z
+SVar:Z:Count$Kicked.1.0
+SVar:TokenX:DelayTriggerRemembered$Amount
+Oracle:Kicker {2}{W}{W} (You may pay an additional {2}{W}{W} as you cast this spell.)\nChoose target creature you own. If this spell was kicked, instead choose any number of target creatures you own. Return each chosen creature to your hand. At the beginning of the next upkeep, create a 4/4 white Bird Soldier creature token with flying for each creature returned to your hand this way.

--- a/forge-gui/res/cardsfolder/upcoming/the_eagles_are_coming.txt
+++ b/forge-gui/res/cardsfolder/upcoming/the_eagles_are_coming.txt
@@ -4,9 +4,8 @@ Types:Instant
 K:Kicker:2 W W
 A:SP$ ChangeZone | Origin$ Battlefield | Destination$ Hand | ValidTgtsDesc$ creature you own | ValidTgts$ Creature.YouOwn | TargetMin$ X | TargetMax$ Y | RememberChanged$ True | SubAbility$ DBChangeZone | SubAbility$ DBDelayedTrigger | StackDescription$ Return {c:Targeted} to your hand. | SpellDescription$ Choose target creature you own. If this spell was kicked, instead choose any number of target creatures you own. Return each chosen creature to your hand.
 SVar:DBDelayedTrigger:DB$ Effect | Triggers$ UpkeepTrig | RememberObjects$ Remembered | Duration$ Permanent | SubAbility$ DBCleanup | SpellDescription$ At the beginning of the next upkeep, create a 4/4 white Bird Soldier creature token with flying for each creature returned to your hand this way.
-SVar:UpkeepTrig:Mode$ Phase | Phase$ Upkeep | Execute$ TrigToken | TriggerDescription$ At the beginning of the next upkeep, create a 4/4 white Bird Soldier creature token with flying for each creature returned to your hand this way.
-SVar:TrigToken:DB$ Token | TokenScript$ w_4_4_bird_soldier_flying | TokenOwner$ You | TokenAmount$ TokenX | SubAbility$ EagleCleanup
-SVar:EagleCleanup:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
+SVar:UpkeepTrig:Mode$ Phase | Phase$ Upkeep | Execute$ TrigToken | OneOff$ True | TriggerDescription$ At the beginning of the next upkeep, create a 4/4 white Bird Soldier creature token with flying for each creature returned to your hand this way.
+SVar:TrigToken:DB$ Token | TokenScript$ w_4_4_bird_soldier_flying | TokenOwner$ You | TokenAmount$ TokenX
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Count$Kicked.0.1
 SVar:Y:Count$Kicked.Z.1

--- a/forge-gui/res/cardsfolder/upcoming/the_eagles_are_coming.txt
+++ b/forge-gui/res/cardsfolder/upcoming/the_eagles_are_coming.txt
@@ -2,14 +2,14 @@ Name:The Eagles Are Coming!
 ManaCost:1 W
 Types:Instant
 K:Kicker:2 W W
-A:SP$ Pump | ValidTgtsDesc$ creature you own | ValidTgts$ Creature.YouOwn | TargetMin$ X | TargetMax$ X | SubAbility$ DBPump | StackDescription$ None | SpellDescription$ Choose target creature you own.
-SVar:DBPump:DB$ Pump | TgtPrompt$ Select any number of target creatures you own | ValidTgts$ Creature.YouOwn | TargetMin$ 0 | TargetMax$ Y | SubAbility$ DBChangeZone | StackDescription$ None | SpellDescription$ If this spell was kicked, instead choose any number of target creatures you own.
-SVar:DBChangeZone:DB$ ChangeZone | Origin$ Battlefield | Destination$ Hand | Defined$ Targeted | RememberChanged$ True | SubAbility$ DBDelayedTrigger | StackDescription$ Return {c:Targeted} to your hand. | SpellDescription$ Return each chosen creature to your hand.
-SVar:DBDelayedTrigger:DB$ DelayedTrigger | Mode$ Phase | Phase$ Upkeep | Execute$ TrigToken | RememberObjects$ Remembered | SubAbility$ DBCleanup | TriggerDescription$ At the beginning of the next upkeep, create a 4/4 white Bird Soldier creature token with flying for each creature returned to your hand this way.
-SVar:TrigToken:DB$ Token | TokenScript$ w_4_4_bird_soldier_flying | TokenOwner$ You | TokenAmount$ TokenX
+A:SP$ ChangeZone | Origin$ Battlefield | Destination$ Hand | ValidTgtsDesc$ creature you own | ValidTgts$ Creature.YouOwn | TargetMin$ X | TargetMax$ Y | RememberChanged$ True | SubAbility$ DBChangeZone | SubAbility$ DBDelayedTrigger | StackDescription$ Return {c:Targeted} to your hand. | SpellDescription$ Choose target creature you own. If this spell was kicked, instead choose any number of target creatures you own. Return each chosen creature to your hand.
+SVar:DBDelayedTrigger:DB$ Effect | Triggers$ UpkeepTrig | RememberObjects$ Remembered | Duration$ Permanent | SubAbility$ DBCleanup | SpellDescription$ At the beginning of the next upkeep, create a 4/4 white Bird Soldier creature token with flying for each creature returned to your hand this way.
+SVar:UpkeepTrig:Mode$ Phase | Phase$ Upkeep | Execute$ TrigToken | TriggerDescription$ At the beginning of the next upkeep, create a 4/4 white Bird Soldier creature token with flying for each creature returned to your hand this way.
+SVar:TrigToken:DB$ Token | TokenScript$ w_4_4_bird_soldier_flying | TokenOwner$ You | TokenAmount$ TokenX | SubAbility$ EagleCleanup
+SVar:EagleCleanup:DB$ ChangeZone | Defined$ Self | Origin$ Command | Destination$ Exile
 SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
 SVar:X:Count$Kicked.0.1
-SVar:Y:Count$Valid Creature.YouOwn/Times.Z
-SVar:Z:Count$Kicked.1.0
-SVar:TokenX:DelayTriggerRemembered$Amount
+SVar:Y:Count$Kicked.Z.1
+SVar:Z:Count$Valid Creature.YouOwn
+SVar:TokenX:Remembered$Amount
 Oracle:Kicker {2}{W}{W} (You may pay an additional {2}{W}{W} as you cast this spell.)\nChoose target creature you own. If this spell was kicked, instead choose any number of target creatures you own. Return each chosen creature to your hand. At the beginning of the next upkeep, create a 4/4 white Bird Soldier creature token with flying for each creature returned to your hand this way.

--- a/forge-gui/res/cardsfolder/upcoming/the_lonely_mountain.txt
+++ b/forge-gui/res/cardsfolder/upcoming/the_lonely_mountain.txt
@@ -1,0 +1,8 @@
+Name:The Lonely Mountain
+ManaCost:no cost
+Types:Land Mountain
+R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplaceWith$ LandTapped | ReplacementResult$ Updated | Description$ This land enters tapped unless you control an Equipment.
+SVar:LandTapped:DB$ Tap | Defined$ Self | ETB$ True | ConditionPresent$ Equipment.YouCtrl | ConditionCompare$ EQ0
+A:AB$ Token | Cost$ 4 R T | TokenScript$ r_2_2_dwarf | SorcerySpeed$ True | ReduceCost$ X | SpellDescription$ Create a 2/2 red Dwarf creature token. This ability costs {1} less to activate for each Equipment you control. Activate only as a sorcery.
+SVar:X:Count$Valid Equipment.YouCtrl
+Oracle:({T}: Add {R}.)\nThis land enters tapped unless you control an Equipment.\n{4}{R}, {T}: Create a 2/2 red Dwarf creature token. This ability costs {1} less to activate for each Equipment you control. Activate only as a sorcery.

--- a/forge-gui/res/cardsfolder/upcoming/thranduil_the_elvenking.txt
+++ b/forge-gui/res/cardsfolder/upcoming/thranduil_the_elvenking.txt
@@ -1,0 +1,9 @@
+Name:Thranduil, the Elvenking
+ManaCost:2 B G U
+Types:Legendary Creature Elf Noble
+PT:5/6
+S:Mode$ Continuous | Affected$ Card.Self | EffectZone$ Battlefield | GainsAbilitiesOf$ Elf.YouOwn | GainsAbilitiesOfZones$ Graveyard | Description$ NICKNAME has all activated abilities of all Elf cards in your graveyard.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Elf.Legendary+Other+YouCtrl | TriggerZones$ Battlefield | Execute$ TrigDraw | TriggerDescription$ Whenever another legendary Elf you control enters, draw two cards, then discard a card.
+SVar:TrigDraw:DB$ Draw | NumCards$ 2 | SubAbility$ DBDiscard
+SVar:DBDiscard:DB$ Discard | Mode$ TgtChoose
+Oracle:Thranduil has all activated abilities of all Elf cards in your graveyard.\nWhenever another legendary Elf you control enters, draw two cards, then discard a card.

--- a/forge-gui/res/tokenscripts/w_4_4_bird_soldier_flying.txt
+++ b/forge-gui/res/tokenscripts/w_4_4_bird_soldier_flying.txt
@@ -1,0 +1,7 @@
+Name:Bird Soldier Token
+ManaCost:no cost
+Colors:white
+Types:Creature Bird Soldier
+PT:4/4
+K:Flying
+Oracle:Flying


### PR DESCRIPTION
As revealed recently; tested to satisfaction:
- [The Chief Warg](https://scryfall.com/card/hob/150/the-chief-warg)
- [The Lonely Mountain](https://scryfall.com/card/hob/187/the-lonely-mountain)
- [Thranduil, the Elvenking](https://scryfall.com/card/hob/167/thranduil-the-elvenking)
- [The Eagles Are Coming!](https://scryfall.com/card/hob/12/the-eagles-are-coming!) and associated token

~As revealed recently; tested to some extent, perhaps needing support, either myself, in figuring it out, or the script, as concerns working as expected:~
- ~[The Eagles Are Coming!](https://scryfall.com/card/hob/12/the-eagles-are-coming!) and associated token~
→ ~Following [Expel the Unworthy](https://github.com/Card-Forge/forge/blob/master/forge-gui/res/cardsfolder/e/expel_the_unworthy.txt), As the script currently is I can target and get the creatures back to hand, kicked and not kicked, I can get the delayed trigger to remember the returned cards but, try as many permutations as I might, I get no tokens from the trigger. The `Pump` chain was set up on the off chance having `RememberChanged$` on each of a `ChangeZone` chain was an issue. That might very well not be the case. I do wonder, and will test, if the delayed trigger works better on an `Effect`.~
<img width="383" height="584" alt="eaglesarecoming" src="https://github.com/user-attachments/assets/e1b9f644-568c-49b7-b39d-d760dbf6ab0e" />
