### PR TITLE
Fix intermittent CardRankerTest timeout failure

### DIFF
--- a/forge-gui-desktop/src/test/java/forge/CardRankerTest.java
+++ b/forge-gui-desktop/src/test/java/forge/CardRankerTest.java
@@ -3,10 +3,12 @@ package forge;
 import forge.card.CardRarity;
 import forge.card.CardRules;
 import forge.gamemodes.limited.CardRanker;
+import forge.gamemodes.limited.DraftRankCache;
 import forge.gui.GuiBase;
 import forge.item.PaperCard;
 import forge.localinstance.properties.ForgeConstants;
 import forge.util.FileUtil;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
@@ -22,6 +24,19 @@ public class CardRankerTest {
     @BeforeTest
     void setupTest() {
         GuiBase.setInterface(new GuiDesktop());
+    }
+
+    /**
+     * The first draft ranking lookup lazily reads and parses the entire rankings
+     * folder (~186 files, ~45k lines). Left to happen inside testRank, that one-time
+     * load dominates the method's 1 second timeout - the test measures disk I/O
+     * rather than ranking, and fails intermittently when the machine is busy running
+     * the rest of the suite. Warming it here keeps the timeout meaningful.
+     * Runs after @BeforeTest, so GuiBase is already set.
+     */
+    @BeforeClass
+    void warmDraftRankings() {
+        DraftRankCache.getRanking("Plains", "BFZ");
     }
 
     @Test(timeOut = 1000, enabled = true)


### PR DESCRIPTION
## Problem

`CardRankerTest.testRank` fails intermittently with:

```
org.testng.internal.thread.ThreadTimeoutException:
Method forge.CardRankerTest.testRank() didn't finish within the time-out 1000
```

It passes when run on its own and fails when the machine is busy running the rest of the suite, so it looks like noise — but it's reproducible under load and it costs everyone a re-run plus a manual check that the failure was "just the flaky one".

## Cause

The test asserts the ranking order of four cards, with a 1 second timeout. Its first ranking lookup goes through `DraftRankCache.getRanking`, which lazily constructs `ReadDraftRankings` and parses the **entire** rankings folder — around 186 files and 45,000 lines — inside the timed method.

So the timeout was effectively measuring one-time disk I/O and parsing rather than the ranking under test, and it had almost no headroom: about 0.66 s standalone against a 1.0 s limit, tipping over 1.0 s whenever the rest of the suite was competing for the machine.

## Fix

Warm the rankings in `@BeforeClass`, which runs after the existing `@BeforeTest` so `GuiBase` is already set. The timed method then measures only the ranking it actually asserts on.

The timeout is kept as-is, so it still guards against pathological ranking slowness — it just no longer fails on timing noise.

## Result

`testRank`, measured inside a full `forge-gui-desktop` suite run:

| | before | after |
|---|---|---|
| method time | 1.008 s (fails, limit 1.000 s) | **0.010 s** |

Four consecutive full-suite runs after the change: 286 tests, 0 failures, with `testRank` at 0.008 / 0.010 / 0.011 / 0.010 s — tightly clustered, no longer near the limit.

## Why it's worth fixing

Most CI workflows here run with `-DskipTests`, but `maven-publish.yml` runs `mvn ... install` without skipping tests, so this can intermittently fail a release build rather than only annoying contributors running the suite locally.

---

Assisted by an AI coding agent (Claude Opus 4.8); co-author credit is in the commit per the contributing guidelines.
