### PR TITLE
Speed up combat legality checks on heavy boards

### DIFF
--- a/forge-game/src/main/java/forge/game/Game.java
+++ b/forge-game/src/main/java/forge/game/Game.java
@@ -630,6 +630,34 @@ public class Game {
         return cards;
     }
 
+    // Every static ability check asks for the cards that could be the source of one, and
+    // building that list copies most of the game. Combat evaluation does that thousands of
+    // times between two zone changes, so cache the list against a counter that every zone
+    // mutation bumps.
+    private int zoneVersion;
+    private CardCollectionView staticAbilitySourceCards;
+    private int staticAbilitySourceVersion = -1;
+
+    public synchronized void bumpZoneVersion() {
+        zoneVersion++;
+    }
+
+    /**
+     * The cards that may be the source of a static ability, i.e. those in
+     * {@link ZoneType#STATIC_ABILITIES_SOURCE_ZONES}.
+     * <p>
+     * Unlike {@link #getCardsIn(Iterable)} the returned view is shared rather than freshly
+     * built, so callers must only read it: modifying it corrupts the cache, and it is
+     * stale after the next zone change.
+     */
+    public synchronized CardCollectionView getStaticAbilitySourceCards() {
+        if (staticAbilitySourceCards == null || staticAbilitySourceVersion != zoneVersion) {
+            staticAbilitySourceCards = getCardsIn(ZoneType.STATIC_ABILITIES_SOURCE_ZONES);
+            staticAbilitySourceVersion = zoneVersion;
+        }
+        return staticAbilitySourceCards;
+    }
+
     public CardCollectionView getCardsInOwnedBy(final Iterable<ZoneType> zones, Player p) {
         CardCollection cards = new CardCollection();
         for (final ZoneType z : zones) {

--- a/forge-game/src/main/java/forge/game/combat/CombatUtil.java
+++ b/forge-game/src/main/java/forge/game/combat/CombatUtil.java
@@ -332,22 +332,22 @@ public class CombatUtil {
     }
 
     public static Cost getBlockCost(Game game, Card blocker, Card attacker) {
-        Cost blockCost = new Cost(ManaCost.ZERO, true);
+        // Allocated lazily: hardly any board has an effect that adds a cost to blocking,
+        // and this runs per blocker/attacker pair while blocks are being worked out.
+        Cost blockCost = null;
         // Sort abilities to apply them in proper order
-        boolean noCost = true;
-        for (Card card : game.getCardsIn(ZoneType.STATIC_ABILITIES_SOURCE_ZONES)) {
+        for (Card card : game.getStaticAbilitySourceCards()) {
             for (final StaticAbility stAb : card.getStaticAbilities()) {
                 Cost c1 = stAb.getBlockCost(blocker, attacker);
                 if (c1 != null) {
+                    if (blockCost == null) {
+                        blockCost = new Cost(ManaCost.ZERO, true);
+                    }
                     blockCost.add(c1);
-                    noCost = false;
                 }
             }
         }
 
-        if (noCost) {
-            return null;
-        }
         return blockCost;
     }
 
@@ -753,11 +753,17 @@ public class CombatUtil {
         final CardCollection requirementCards = new CardCollection();
         final Player defender = blocker.getController();
         for (final Card attacker : attackers) {
-            if (getBlockCost(blocker.getGame(), blocker, attacker) != null) {
+            // Check the block requirement before the block cost. Both skip this attacker,
+            // but getBlockCost walks every static ability in play while
+            // attackerLureSatisfied is a handful of keyword tests - and the common case,
+            // an attacker that places no requirement on this blocker, is skipped by the
+            // latter. Testing the cost first made every combat pay for a full scan of the
+            // board per attacker, per blocker.
+            if (attackerLureSatisfied(attacker, blocker, combat.getBlockers(attacker))) {
                 continue;
             }
 
-            if (attackerLureSatisfied(attacker, blocker, combat.getBlockers(attacker))) {
+            if (getBlockCost(blocker.getGame(), blocker, attacker) != null) {
                 continue;
             }
 

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityAssignCombatDamageAsUnblocked.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityAssignCombatDamageAsUnblocked.java
@@ -12,7 +12,7 @@ public class StaticAbilityAssignCombatDamageAsUnblocked {
 
     public static boolean assignCombatDamageAsUnblocked(final Card card, final boolean optional)  {
         final Game game = card.getGame();
-        for (final Card ca : game.getCardsIn(ZoneType.STATIC_ABILITIES_SOURCE_ZONES)) {
+        for (final Card ca : game.getStaticAbilitySourceCards()) {
             for (final StaticAbility stAb : ca.getStaticAbilities()) {
                 if (!stAb.checkConditions(StaticAbilityMode.AssignCombatDamageAsUnblocked)) {
                     continue;

--- a/forge-game/src/main/java/forge/game/staticability/StaticAbilityCantAttackBlock.java
+++ b/forge-game/src/main/java/forge/game/staticability/StaticAbilityCantAttackBlock.java
@@ -210,7 +210,7 @@ public class StaticAbilityCantAttackBlock {
         if (blocker != null) {
             list.add(blocker);
         }
-        list.addAll(attacker.getGame().getCardsIn(ZoneType.STATIC_ABILITIES_SOURCE_ZONES));
+        list.addAll(attacker.getGame().getStaticAbilitySourceCards());
         for (final Card ca : list) {
             for (final StaticAbility stAb : ca.getStaticAbilities()) {
                 if (!stAb.checkConditions(StaticAbilityMode.CantBlockBy)) {

--- a/forge-game/src/main/java/forge/game/zone/Zone.java
+++ b/forge-game/src/main/java/forge/game/zone/Zone.java
@@ -62,6 +62,7 @@ public class Zone implements java.io.Serializable, Iterable<Card> {
 
     protected void sort() {
         cardList.sort(COMPARATOR);
+        game.bumpZoneVersion();
     }
 
     public Zone(final ZoneType zone0, Game game0) {
@@ -80,9 +81,13 @@ public class Zone implements java.io.Serializable, Iterable<Card> {
         return new ZoneView(PlayerView.get(getPlayer()), zoneType);
     }
 
+    // Bumped at every point that mutates cardList, so Game can cache views derived from
+    // the zones. Deliberately not done in onChanged(), which PlayerZone overrides without
+    // calling super.
     public final void reorder(final Card c, final int index) {
         cardList.remove(c);
         cardList.add(index, c);
+        game.bumpZoneVersion();
     }
 
     public final void add(final Card c) {
@@ -146,6 +151,7 @@ public class Zone implements java.io.Serializable, Iterable<Card> {
                 cardList.add(index, c);
             }
         }
+        game.bumpZoneVersion();
         onChanged();
 
         game.fireEvent(new GameEventZone(zoneType, getPlayer(), EventValueChangeType.Added, c));
@@ -161,6 +167,7 @@ public class Zone implements java.io.Serializable, Iterable<Card> {
 
     public void remove(final Card c) {
         if (cardList.remove(c)) {
+            game.bumpZoneVersion();
             onChanged();
             game.fireEvent(new GameEventZone(zoneType, getPlayer(), EventValueChangeType.Removed, c));
         }
@@ -172,6 +179,7 @@ public class Zone implements java.io.Serializable, Iterable<Card> {
             c.setZone(this);
             cardList.add(c);
         }
+        game.bumpZoneVersion();
         onChanged();
         game.fireEvent(new GameEventZone(zoneType, getPlayer(), EventValueChangeType.ComplexUpdate, null));
     }
@@ -179,6 +187,7 @@ public class Zone implements java.io.Serializable, Iterable<Card> {
     public final void removeAllCards(boolean forcedWithoutEvents) {
         if (forcedWithoutEvents) {
             cardList.clear();
+            game.bumpZoneVersion();
         } else {
             for (Card c : cardList) {
                 remove(c);
@@ -260,6 +269,7 @@ public class Zone implements java.io.Serializable, Iterable<Card> {
 
     public void shuffle() {
         Collections.shuffle(cardList, MyRandom.getRandom());
+        game.bumpZoneVersion();
         onChanged();
     }
 

--- a/forge-gui-desktop/src/test/java/forge/ai/blocking/BlockRequirementTests.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/blocking/BlockRequirementTests.java
@@ -1,0 +1,84 @@
+package forge.ai.blocking;
+
+import org.testng.annotations.Test;
+
+import forge.ai.PlayerControllerAi;
+import forge.ai.simulation.SimulationTest;
+import forge.game.Game;
+import forge.game.card.Card;
+import forge.game.combat.Combat;
+import forge.game.phase.PhaseType;
+import forge.game.player.Player;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Covers block requirements - lure and "must be blocked if able" - which nothing else
+ * in the suite exercises.
+ *
+ * CombatUtil.mustBlockAnAttacker is only reached when an attacker places a requirement
+ * on a blocker, so a board without such attackers runs straight past it. That makes the
+ * method easy to change without any test noticing, which matters because it is a
+ * tempting target for further optimisation: its result depends only on the blocker, so
+ * caching it per blocker looks safe until you notice the result also depends on which
+ * blocks have already been assigned.
+ */
+public class BlockRequirementTests extends SimulationTest {
+
+    private static final String LURE_CREATURE = "Elvish Bard";        // all able to block do so
+    private static final String MUST_BLOCK = "Goblin Fire Fiend";     // must be blocked if able
+    private static final String VANILLA = "Grizzly Bears";
+
+    /** Declares blockers for the AI against every creature the attacker controls. */
+    private Combat attackWithAll(final Game game, final Player attacker, final Player ai) {
+        final Combat combat = new Combat(attacker);
+        for (final Card c : attacker.getCreaturesInPlay()) {
+            combat.addAttacker(c, ai);
+        }
+        ((PlayerControllerAi) ai.getController()).getAi().declareBlockersFor(ai, combat);
+        return combat;
+    }
+
+    @Test
+    public void lureTakesEveryAbleBlocker() {
+        final Game game = initAndCreateGame();
+        final Player human = game.getPlayers().get(0);
+        final Player ai = game.getPlayers().get(1);
+
+        final Card lure = addCard(LURE_CREATURE, human);
+        final Card other = addCard(VANILLA, human);
+        for (int i = 0; i < 3; i++) {
+            addCard(VANILLA, ai).setSickness(false);
+        }
+
+        game.getPhaseHandler().devModeSet(PhaseType.COMBAT_DECLARE_ATTACKERS, human);
+        game.getAction().checkStateEffects(true);
+
+        final Combat combat = attackWithAll(game, human, ai);
+
+        assertEquals(combat.getBlockers(lure).size(), 3, "every able blocker must block the lure creature");
+        assertEquals(combat.getBlockers(other).size(), 0,
+                "no blocker may block another attacker while the lure is unsatisfied");
+    }
+
+    @Test
+    public void mustBeBlockedIfAbleGetsABlocker() {
+        final Game game = initAndCreateGame();
+        final Player human = game.getPlayers().get(0);
+        final Player ai = game.getPlayers().get(1);
+
+        final Card mustBlock = addCard(MUST_BLOCK, human);
+        for (int i = 0; i < 3; i++) {
+            addCard(VANILLA, ai).setSickness(false);
+        }
+
+        game.getPhaseHandler().devModeSet(PhaseType.COMBAT_DECLARE_ATTACKERS, human);
+        game.getAction().checkStateEffects(true);
+
+        final Combat combat = attackWithAll(game, human, ai);
+
+        assertTrue(combat.getBlockers(mustBlock).size() >= 1,
+                "an attacker that must be blocked if able needs at least one blocker");
+    }
+}


### PR DESCRIPTION
## Problem

On a heavy board, working out attacks or blocks takes tens of seconds. Profiling
pointed at two redundancies in the shared combat legality code — both recompute
results that cannot differ, so removing them changes no decision.

Measured on a synthetic board of 40 creatures per side, this branch against master
on the same machine:

| | master | this branch |
|---|---|---|
| declare attackers | 17.7 s | **8.7 s** |
| declare blockers | 16.3 s | **6.8 s** |

Smaller boards improve proportionally (at 20 a side: 7.8 s → 5.2 s and 1.3 s → 0.8 s).

These are in `forge-game`, not the AI, so they also speed up the equivalent
legality checks during human play.

## Cause 1 — every static ability check copied the board

`Game.getCardsIn(Iterable<ZoneType>)` allocates a fresh `CardCollection` and copies
every card from every listed zone on each call. Every static-ability helper reaches
for `ZoneType.STATIC_ABILITIES_SOURCE_ZONES` through it — `getBlockCost`,
`StaticAbilityCantAttackBlock.cantBlockBy`,
`StaticAbilityAssignCombatDamageAsUnblocked`, and others. Combat evaluation calls
those thousands of times between two zone changes, so the same list is rebuilt over
and over.

`Game` now caches that list against a counter bumped by every zone mutation.

Two notes for reviewers:

- The counter is bumped at each point in `Zone` that mutates `cardList`, **not** in
  `Zone.onChanged()`, because `PlayerZone` overrides that without calling `super`.
  Missing a mutation would serve a stale list, so all of `add`, `remove`,
  `setCards`, `removeAllCards`, `reorder`, `shuffle` and `sort` bump it.
- The returned view is shared rather than freshly built, so unlike
  `getCardsIn(Iterable)` it must only be read. That is documented on the method; the
  three call sites converted here only iterate it.

## Cause 2 — block requirements were checked after block costs

`CombatUtil.mustBlockAnAttacker` tested `getBlockCost(...)` — which walks every
static ability in play — before `attackerLureSatisfied(...)`, which is a handful of
keyword tests. Both guard the same `continue`, so an attacker that places no
requirement on this blocker was skipped either way, but only after paying for a full
scan of the board. Since that is the overwhelmingly common case, swapping the two
guards lets it skip out first.

`getBlockCost` also allocates its `Cost` lazily now, as it returns `null` unless
something in play actually adds a cost to blocking.

## Decisions are unchanged

This is a performance change only, and was checked as such:

- The AI declares the same blockers at every board size before and after.
- `CombatUtil.canBlock(attacker, blocker, combat)` is called the same number of
  times, so control flow is unchanged — only its cost drops (892 µs → 128 µs per
  call at 40 a side).
## Tests are a separate commit — take or leave them

The fix is the first commit; the tests are the second and touch nothing else, so
they can be dropped without rebasing anything.

They exist because `mustBlockAnAttacker` — the method cause 2 reorders — is only
reached when an attacker places a requirement on a blocker, so no existing test
touches it: a board without lure or "must be blocked if able" attackers runs
straight past. Two cases, kept minimal per the contributing guidance on not
growing the suite unnecessarily.

The argument for them is about what comes next rather than this PR: the method is
an inviting optimisation target, since its result depends only on the blocker, so
caching it per blocker looks obviously safe until you notice it also depends on
which blocks have already been assigned. If you would rather not carry them, drop
the second commit — the reorder stands on its own, as both guards end in the same
`continue` and the same attackers pass either way.

Full `forge-gui-desktop` suite: 288 tests, the only failure being
`CardRankerTest.testRank`, which fails intermittently on master for unrelated
reasons (a 1 s timeout that is really measuring a one-time data load) and is
addressed separately in #11299.

## Relationship to #10507

No file overlap with #10507, which is in `Card` / `CardState` /
`KeywordCollection` / `AiAttackController`. This branch is in `Game`, `Zone`,
`CombatUtil` and two static-ability classes, so the two should be independent — and
the largest remaining hot spot I measured, `CardState.getStaticAbilities()`
allocating per call, is that PR's ground rather than this one's.

---

Assisted by an AI coding agent (Claude Opus 4.8); co-author credit is in the commit
per the contributing guidelines. Happy to share the profiling harness and benchmark
used for the numbers above if that is useful — they are left out here since the
benchmark takes ~100 s and asserts nothing, so it is a tool rather than a test.
