### PR TITLE
Assign 15 cards that were falling back to the UNKNOWN set

### DIFF
--- a/forge-gui/res/editions/Alchemy Horizons Baldur's Gate.txt
+++ b/forge-gui/res/editions/Alchemy Horizons Baldur's Gate.txt
@@ -321,7 +321,9 @@ A-208 C A-Druidic Ritual @Vincent Christiaens
 A-209 R A-Earthquake Dragon @Johan Grenier
 A-210 U A-Emerald Dragon @Diego Gisbert
 A-215 U A-Jade Orb of Dragonkind @Olena Richards
+A-217 R A-Monster Manual @David Gaillet
 A-223 U A-Split the Spoils @Edgar Sánchez Hidalgo
+A-232 R A-Baba Lysaga, Night Witch @Slawomir Maniak
 A-239 U A-Krydle of Baldur's Gate @Bryan Sola
 A-243 M A-Minsc & Boo, Timeless Heroes @Andreas Zafiratos
 A-259 C A-Lantern of Revealing @Eytan Zana

--- a/forge-gui/res/editions/Innistrad Crimson Vow.txt
+++ b/forge-gui/res/editions/Innistrad Crimson Vow.txt
@@ -438,6 +438,7 @@ A-48 C A-Binding Geist @Campbell White
 A-52 U A-Cobbled Lancer @Igor Kieryluk
 A-58 R A-Dreamshackle Geist @Andreas Zafiratos
 A-62 U A-Gutter Skulker @Viko Menezes
+A-63 R A-Hullbreaker Horror @Svetlin Velinov
 A-66 C A-Lantern Bearer @Zoltan Boros
 A-69 U A-Mischievous Catgeist @Denman Rooke
 A-81 C A-Stitched Assistant @Andrey Kuzinskiy

--- a/forge-gui/res/editions/Innistrad Midnight Hunt.txt
+++ b/forge-gui/res/editions/Innistrad Midnight Hunt.txt
@@ -422,6 +422,7 @@ A-69 R A-Patrician Geist @Marta Nael
 A-70 U A-Phantom Carriage @Igor Kieryluk
 A-74 C A-Shipwreck Sifters @Svetlin Velinov
 A-106 C A-Hobbling Zombie @Josh Hass
+A-112 M A-The Meathook Massacre @Chris Seaman
 A-218 U A-Devoted Grafkeeper @Raoul Vitale
 
 [tokens]

--- a/forge-gui/res/editions/Kaldheim.txt
+++ b/forge-gui/res/editions/Kaldheim.txt
@@ -433,11 +433,14 @@ ScryfallCode=KHM
 
 [rebalanced]
 A-40 M A-Alrund, God of the Cosmos @Kieran Yanner
+A-41 M A-Alrund's Epiphany @Kieran Yanner
 A-51 R A-Cosmos Charger @Nils Hamm
 A-106 U A-Return Upon the Tide @Martina Fačková
 A-109 R A-Skemfar Avenger @Randy Vargas
+A-139 M A-Goldspan Dragon @Andrew Mar
 A-165 C A-Elderleaf Mentor @Zoltan Boros
 A-166 U A-Elven Bow @Dallas Williams
+A-169 R A-Esika's Chariot @Raoul Vitale
 A-198 M A-Tyvar Kell @Chris Rallis
 A-208 U A-Fall of the Impostor @Eric Deschamps
 A-212 U A-Harald, King of Skemfar @Grzegorz Rutkowski
@@ -446,6 +449,7 @@ A-224 U A-Narfi, Betrayer King @Daarken
 A-233 U A-Vega, the Watcher @Paul Scott Canavan
 A-237 R A-Cosmos Elixir @Volkan Baǵa
 A-253 U A-Bretagard Stronghold @Jung Park
+A-255 R A-Faceless Haven @Titus Lunter
 A-268 U A-Skemfar Elderhall @Johannes Voss
 A-378 R A-Canopy Tactician @Ekaterina Burmak
 A-385 U A-Elderfang Ritualist @Wisnu Tan

--- a/forge-gui/res/editions/Kamigawa Neon Dynasty.txt
+++ b/forge-gui/res/editions/Kamigawa Neon Dynasty.txt
@@ -549,6 +549,7 @@ A-95 U A-Dokuchi Silencer @David Rapoza
 A-114 M A-Nashi, Moon Sage's Scion @Valera Lutfullina
 A-116 U A-Nezumi Prowler @Joseph Weston
 A-131 C A-Akki Ronin @Olivier Bernard
+A-152 U A-Kumano Faces Kakkazan @Mike Bierek
 A-156 C A-Peerless Samurai @Micah Epstein
 A-215 U A-Asari Captain @Donato Giancola
 A-232 R A-Raiyuu, Storm's Edge @Heonhwa

--- a/forge-gui/res/editions/Modern Horizons 2.txt
+++ b/forge-gui/res/editions/Modern Horizons 2.txt
@@ -591,6 +591,7 @@ ScryfallCode=MH2
 
 [rebalanced]
 A-121 U A-Dragon's Rage Channeler @Martina Fačková
+A-145 C A-Unholy Heat @Kari Christensen
 
 [tokens]
 1 w_1_1_bird_flying @Howard Lyon

--- a/forge-gui/res/editions/Strixhaven School of Mages.txt
+++ b/forge-gui/res/editions/Strixhaven School of Mages.txt
@@ -408,6 +408,7 @@ ScryfallCode=STX
 
 [rebalanced]
 A-15 U A-Dueling Coach @Caio Monteiro
+A-41 U A-Divide by Zero @Liiga Smilshkalne
 A-46 U A-Mentor's Guidance @Brian Valeza
 A-56 U A-Symmetry Sage @Jehan Choo
 A-88 U A-Tenured Inkcaster @Jake Murray

--- a/forge-gui/res/editions/The Hobbit.txt
+++ b/forge-gui/res/editions/The Hobbit.txt
@@ -18,6 +18,7 @@ ScryfallCode=HOB
 90 U Burn, Burn, Tree and Fern @Rovina Cai
 93 R Desolation of Smaug @Irvin Rodriguez
 96 M Gandalf, Goblins' Bane @Francisco Miyara
+104 R The Misty Mountains Cold @Rovina Cai
 110 M Smaug the Magnificent @Francisco Miyara
 114 M Thorin, Mountain-king @Javier Charro
 142 C Wood Elves @Andreia Ugrai

--- a/forge-gui/res/editions/Throne of Eldraine.txt
+++ b/forge-gui/res/editions/Throne of Eldraine.txt
@@ -424,6 +424,7 @@ ScryfallCode=ELD
 
 [rebalanced]
 A-81 U A-Cauldron Familiar @Milivoj Ćeran
+A-125 R A-Fires of Invention @Stanton Feng
 
 [tokens]
 1 w_0_1_goat @Forrest Imel

--- a/forge-gui/res/editions/Zendikar Rising.txt
+++ b/forge-gui/res/editions/Zendikar Rising.txt
@@ -418,6 +418,7 @@ ScryfallCode=ZNR
 391 U Kargan Warleader @Colin Boyer
 
 [rebalanced]
+A-24 R A-Luminarch Aspirant @Mads Ahm
 A-68 R A-Master of Winds @Yigit Koroglu
 A-105 C A-Hagra Constrictor @Simon Dominic
 A-126 U A-Skyclave Shadowcat @Simon Dominic
@@ -430,6 +431,7 @@ A-198 R A-Oran-Rief Ooze @Daarken
 A-224 U A-Kargan Warleader @Colin Boyer
 A-228 U A-Moss-Pit Skeleton @Bryan Sola
 A-230 M A-Nahiri, Heir of the Ancients @Anna Steinbauer
+A-232 M A-Omnath, Locus of Creation @Chris Rahn
 A-234 R A-Phylath, World Sculptor @Victor Adame Minguez
 A-238 U A-Umara Mystic @Bryan Sola
 A-257 U A-Base Camp @Jokubas Uogintas


### PR DESCRIPTION
## What this does

Startup currently logs a warning for every card whose script exists but that no
edition file lists, and drops it into the UNKNOWN set:

```
The card A-Goldspan Dragon was not assigned to any set. Adding it to UNKNOWN set... to fix see res/editions/ folder.
```

Fifteen of those are simply missing entries. This adds them — 15 lines across 10
edition files, no code.

## The fourteen Alchemy rebalances

Each of these has a `[rebalanced]` section in the set it belongs to, and entries
for its siblings, but was itself never listed. Each new line mirrors the collector
number, rarity and artist of the original printing, exactly as the surrounding
entries do:

| set | added |
|---|---|
| Kaldheim | `A-41` Alrund's Epiphany, `A-139` Goldspan Dragon, `A-169` Esika's Chariot, `A-255` Faceless Haven |
| Zendikar Rising | `A-24` Luminarch Aspirant, `A-232` Omnath, Locus of Creation |
| Alchemy Horizons: Baldur's Gate | `A-217` Monster Manual, `A-232` Baba Lysaga, Night Witch |
| Strixhaven | `A-41` Divide by Zero |
| Throne of Eldraine | `A-125` Fires of Invention |
| Kamigawa: Neon Dynasty | `A-152` Kumano Faces Kakkazan |
| Innistrad: Crimson Vow | `A-63` Hullbreaker Horror |
| Innistrad: Midnight Hunt | `A-112` The Meathook Massacre |
| Modern Horizons 2 | `A-145` Unholy Heat |

## The Misty Mountains Cold

Added in #11297 — the card script landed but the entry in `The Hobbit.txt` did
not, so it was falling through to UNKNOWN. Added as `104 R ... @Rovina Cai` per
Scryfall.

## Result

Before: 20 "not assigned to any set" warnings at startup. After: 5.

The remaining five are a separate question and are deliberately **not** touched
here — see the comment below.
