### PR TITLE
Update deadly_cover_up.txt

### DIFF
--- a/forge-gui/res/cardsfolder/d/deadly_cover_up.txt
+++ b/forge-gui/res/cardsfolder/d/deadly_cover_up.txt
@@ -3,13 +3,15 @@ ManaCost:3 B B
 Types:Sorcery
 S:Mode$ OptionalCost | EffectZone$ All | ValidCard$ Card.Self | ValidSA$ Spell | Cost$ CollectEvidence<6> | Description$ As an additional cost to cast this spell, you may collect evidence 6. (Exile cards with total mana value 6 or greater from your graveyard.)
 A:SP$ DestroyAll | ValidCards$ Creature | SubAbility$ DBExile | SpellDescription$ Destroy all creatures.
-SVar:DBExile:DB$ ChangeZone | Mandatory$ True | ChangeType$ Card.OppCtrl | Hidden$ True | Origin$ Graveyard | Destination$ Exile | RememberChanged$ True | ConditionDefined$ Collected | ConditionPresent$ Card | SubAbility$ ExileYard | SpellDescription$ If evidence was collected, exile a card from an opponent's graveyard. Then search its owner's graveyard, hand, and library for any number of cards with that name and exile them.
+SVar:DBExile:DB$ ChangeZone | Mandatory$ True | ChangeType$ Card.OppCtrl | Hidden$ True | Origin$ Graveyard | Destination$ Exile | RememberChanged$ True | ConditionDefined$ Collected | ConditionPresent$ Card | SubAbility$ ExileYard | SpellDescription$ If evidence was collected, exile a card from an opponent's graveyard. Then search its owner's graveyard, hand, and library for any number of cards with that name and exile them. That player shuffles, then draws a card for each card exiled from their hand this way.
 SVar:ExileYard:DB$ ChangeZone | ChangeType$ Remembered.sameName | Origin$ Graveyard | DefinedPlayer$ RememberedController | Chooser$ You | ConditionDefined$ Collected | ConditionPresent$ Card | Destination$ Exile | ChangeNum$ NumInYard | Hidden$ True | SubAbility$ ExileHand
-SVar:ExileHand:DB$ ChangeZone | Origin$ Hand | Destination$ Exile | DefinedPlayer$ RememberedController | ChangeType$ Remembered.sameName | ConditionDefined$ Collected | ConditionPresent$ Card | ChangeNum$ NumInHand | Chooser$ You | SubAbility$ ExileLib | StackDescription$ None
-SVar:ExileLib:DB$ ChangeZone | Origin$ Library | Destination$ Exile | DefinedPlayer$ RememberedController | ChangeType$ Remembered.sameName | ConditionDefined$ Collected | ConditionPresent$ Card | ChangeNum$ NumInLib | Chooser$ You | Shuffle$ True | StackDescription$ None | SubAbility$ DBCleanup
-SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True
+SVar:ExileHand:DB$ ChangeZone | Origin$ Hand | Destination$ Exile | DefinedPlayer$ RememberedController | ChangeType$ Remembered.sameName | ConditionDefined$ Collected | ConditionPresent$ Card | ChangeNum$ NumInHand | Chooser$ You | Imprint$ True | SubAbility$ ExileLib | StackDescription$ None
+SVar:ExileLib:DB$ ChangeZone | Origin$ Library | Destination$ Exile | DefinedPlayer$ RememberedController | ChangeType$ Remembered.sameName | ConditionDefined$ Collected | ConditionPresent$ Card | ChangeNum$ NumInLib | Chooser$ You | Shuffle$ True | StackDescription$ None | SubAbility$ DBDraw
+SVar:DBDraw:DB$ Draw | Defined$ RememberedController | NumCards$ NumExiledHand | ConditionDefined$ Collected | ConditionPresent$ Card | SubAbility$ DBCleanup | StackDescription$ None
+SVar:DBCleanup:DB$ Cleanup | ClearRemembered$ True | ClearImprinted$ True
 SVar:NumInLib:PlayerCountDefinedRememberedOwner$CardsInLibrary
 SVar:NumInHand:PlayerCountDefinedRememberedOwner$CardsInHand
 SVar:NumInYard:PlayerCountDefinedRememberedOwner$CardsInGraveyard
+SVar:NumExiledHand:Imprinted$Amount
 DeckHints:Ability$Graveyard|Mill|Discard & Keyword$Dredge
-Oracle:As an additional cost to cast this spell, you may collect evidence 6.\nDestroy all creatures. If evidence was collected, exile a card from an opponent's graveyard. Then search its owner's graveyard, hand, and library for any number of cards with that name and exile them.
+Oracle:As an additional cost to cast this spell, you may collect evidence 6.\nDestroy all creatures. If evidence was collected, exile a card from an opponent's graveyard. Then search its owner's graveyard, hand, and library for any number of cards with that name and exile them. That player shuffles, then draws a card for each card exiled from their hand this way.


### PR DESCRIPTION
Oracle Text of Deadly Cover-Up
---
As an additional cost to cast this spell, you may collect evidence 6.

Destroy all creatures. If evidence was collected, exile a card from an opponent’s graveyard. Then search its owner’s graveyard, hand, and library for any number of cards with that name and exile them. **_That player shuffles, then draws a card for each card exiled from their hand this way._**

---

I noticed when I was manually checking for Oracle text and descriptions for cards that start with the letter D is that this card is missing an effect since its Oracle text was incomplete. With assistance from Claude, the missing effect from the card was added so that it functions how it should.