### PR TITLE
DestoryEffect: filter for canBeDestroyed first

### DIFF
--- a/forge-game/src/main/java/forge/game/GameAction.java
+++ b/forge-game/src/main/java/forge/game/GameAction.java
@@ -1442,7 +1442,7 @@ public class GameAction {
                 }
             }
             CardCollection noRegCreats = new CardCollection();
-            CardCollection desCreats = null;
+            CardCollection desCreats = new CardCollection();
             CardCollection unAttachList = new CardCollection();
             CardCollection sacrificeList = new CardCollection();
             PlayerCollection spaceSculptors = new PlayerCollection();
@@ -1462,9 +1462,6 @@ public class GameAction {
                         // ignore the state-based action that checks for lethal damage
                     } else if (c.hasKeyword("CARDNAME can't be destroyed by lethal damage unless lethal damage dealt by a single source is marked on it.")) {
                         if (c.getLethal() <= c.getMaxDamageFromSource() || c.hasBeenDealtDeathtouchDamage()) {
-                            if (desCreats == null) {
-                                desCreats = new CardCollection();
-                            }
                             desCreats.add(c);
                             c.setHasBeenDealtDeathtouchDamage(false);
                             checkAgainCard = true;
@@ -1473,9 +1470,6 @@ public class GameAction {
                     // Rule 704.5g - Destroy due to lethal damage
                     // Rule 704.5h - Destroy due to deathtouch
                     else if (c.hasBeenDealtDeathtouchDamage() || (c.getDamage() > 0 && c.getLethal() <= c.getDamage())) {
-                        if (desCreats == null) {
-                            desCreats = new CardCollection();
-                        }
                         desCreats.add(c);
                         c.setHasBeenDealtDeathtouchDamage(false);
                         checkAgainCard = true;
@@ -1573,17 +1567,12 @@ public class GameAction {
                 sacrificeDestroy(c, null, mapParams);
             }
 
-            if (desCreats != null) {
-                if (desCreats.size() > 1 && !orderedDesCreats) {
-                    desCreats = CardLists.filter(desCreats, Card::canBeDestroyed);
-                    if (!desCreats.isEmpty()) {
-                        desCreats = (CardCollection) GameActionUtil.orderCardsByTheirOwners(game, desCreats, ZoneType.Graveyard, null);
-                    }
-                    orderedDesCreats = true;
-                }
-                for (Card c : desCreats) {
-                    destroy(c, null, true, mapParams);
-                }
+            if (!desCreats.isEmpty() && !orderedDesCreats) {
+                desCreats = (CardCollection) GameActionUtil.orderCardsByTheirOwners(game, desCreats, ZoneType.Graveyard, null);
+                orderedDesCreats = true;
+            }
+            for (Card c : desCreats) {
+                destroy(c, null, true, mapParams);
             }
 
             if (sacrificeList.size() > 1 && !orderedSacrificeList) {

--- a/forge-game/src/main/java/forge/game/ability/effects/DestroyEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/DestroyEffect.java
@@ -2,13 +2,16 @@ package forge.game.ability.effects;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import forge.game.Game;
 import forge.game.GameActionUtil;
 import forge.game.ability.AbilityKey;
 import forge.game.ability.SpellAbilityEffect;
 import forge.game.card.Card;
+import forge.game.card.CardCollection;
 import forge.game.card.CardCollectionView;
+import forge.game.card.CardLists;
 import forge.game.card.CardUtil;
 import forge.game.card.CardZoneTable;
 import forge.game.spellability.SpellAbility;
@@ -54,7 +57,10 @@ public class DestroyEffect extends SpellAbilityEffect {
         CardCollectionView untargetedCards = CardUtil.getRadiance(sa);
         CardCollectionView tgtCards = getTargetCards(sa);
 
-        tgtCards = GameActionUtil.orderCardsByTheirOwners(game, tgtCards, ZoneType.Graveyard, sa);
+        Map<Boolean, CardCollection> tgtPartition = tgtCards.stream().collect(Collectors.partitioningBy(Card::canBeDestroyed, Collectors.toCollection(CardCollection::new)));
+        untargetedCards = CardLists.filter(untargetedCards, Card::canBeDestroyed);
+
+        tgtCards = GameActionUtil.orderCardsByTheirOwners(game, tgtPartition.get(true), ZoneType.Graveyard, sa);
         untargetedCards = GameActionUtil.orderCardsByTheirOwners(game, untargetedCards, ZoneType.Graveyard, sa);
 
         Map<AbilityKey, Object> params = AbilityKey.newMap();
@@ -72,6 +78,21 @@ public class DestroyEffect extends SpellAbilityEffect {
                 continue;
             }
             internalDestroy(gameCard, sa, params, zoneMovements);
+        }
+        if (sa.hasParam("AlwaysRemember") && sa.hasParam("RememberLKI")) {
+            for (final Card tgtC : tgtPartition.get(false)) {
+                if (!tgtC.isInPlay()) {
+                    continue;
+                }
+                Card gameCard = game.getCardState(tgtC, null);
+                // gameCard is LKI in that case, the card is not in game anymore
+                // or the timestamp did change
+                // this should check Self too
+                if (gameCard == null || !tgtC.equalsWithGameTimestamp(gameCard)) {
+                    continue;
+                }
+                host.addRemembered(zoneMovements.getLastStateBattlefield().get(gameCard));
+            }
         }
 
         for (final Card unTgtC : untargetedCards) {

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -6872,7 +6872,15 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     }
 
     public final boolean canBeDestroyed() {
-        return isInPlay() && !isPhasedOut() && (!hasKeyword(Keyword.INDESTRUCTIBLE) || (isCreature() && getNetToughness() <= 0));
+        return canBeDestroyed(null, true);
+    }
+
+    public final boolean canBeDestroyed(SpellAbility sa, boolean regenerate) {
+        final Map<AbilityKey, Object> repRunParams = AbilityKey.mapFromAffected(this);
+        repRunParams.put(AbilityKey.Cause, sa);
+        repRunParams.put(AbilityKey.Regeneration, regenerate);
+
+        return !getGame().getReplacementHandler().cantHappenCheck(ReplacementType.Destroy, repRunParams);
     }
 
     @Override

--- a/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
+++ b/forge-game/src/main/java/forge/game/card/CardFactoryUtil.java
@@ -2311,6 +2311,14 @@ public class CardFactoryUtil {
             final ReplacementEffect re = createETBReplacement(card, ReplacementLayer.Other, effect, false, true, intrinsic, "Card.Self+impended", "");
 
             inst.addReplacement(re);
+        } else if (keyword.equals("Indestructible")) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("Event$ Destroy | ValidCard$ Card.Self | Layer$ CantHappen");
+            sb.append("| ActiveZones$ Battlefield | Secondary$ True | Description$ Indestructible (");
+            sb.append(inst.getReminderText());
+            sb.append(")");
+
+            inst.addReplacement(ReplacementHandler.parseReplacement(sb.toString(), host, intrinsic, card));
         } else if (keyword.equals("Jump-start")) {
             StringBuilder sb = new StringBuilder();
             sb.append("Event$ Moved | ValidCard$ Card.Self | Origin$ Stack | ExcludeDestination$ Exile ");


### PR DESCRIPTION
Closes #11291

that should filter for `canBeDestroyed` while still respecting `AlwaysRemember`

the ones inside `internalDestroy` are still for the ReplacementEffects