### PR TITLE
AI: include ProduceMana in the performance-mode replacement zone skip

### DIFF
--- a/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
@@ -103,12 +103,14 @@ public class ReplacementHandler {
             Card c = preList.get(crd);
             Zone cardZone = game.getZoneOf(c);
 
-            // all tap/untap replacements are active from the battlefield or the command zone
-            // (e.g. Ood Sphere); skip other zones - this is a major hot path, as canTap/canUntap
-            // run a cantHappenCheck per mana source per AI cost check
+            // all tap/untap/produce mana replacements are active from the battlefield or the
+            // command zone (e.g. Ood Sphere); skip other zones - this is a major hot path, as
+            // canTap/canUntap run a cantHappenCheck per mana source per AI cost check, and
+            // groupSourcesByManaColor runs a ProduceMana check per mana ability on top of that
             // (performance mode only, in case a custom card wants one active from elsewhere)
             if (Spell.isPerformanceMode()
-                    && (event == ReplacementType.Tap || event == ReplacementType.Untap)
+                    && (event == ReplacementType.Tap || event == ReplacementType.Untap
+                            || event == ReplacementType.ProduceMana)
                     && cardZone != null
                     && cardZone.getZoneType() != ZoneType.Battlefield
                     && cardZone.getZoneType() != ZoneType.Command) {


### PR DESCRIPTION
`getReplacementList` visits every card in the game. On the mana hot path that means rebuilding the replacement-effect list of ~1700 cards to find the handful that could ever apply — and it runs per mana source, per AI cost check.

The performance-mode zone skip added in #11160 already covers Tap/Untap, on the grounds that those replacements are only active from the battlefield or the command zone. This extends the same skip to `ProduceMana`, which `groupSourcesByManaColor` checks per mana ability on top of the Tap checks.

### Why ProduceMana qualifies

Survey of `forge-gui/res/cardsfolder`:

- 25 `Event$ ProduceMana` replacement-effect lines
- 23 declare `ActiveZones` — every one is `Battlefield` and/or `Command`
- the 2 that don't (False Dawn, Quarum Trench Gnomes) are both `SP$/AB$ Effect | ReplacementEffects$ ...`, i.e. hosted on Effect cards, which live in the command zone

So no ProduceMana replacement effect in the card database is active outside battlefield/command — the same justification that licensed Tap/Untap.

### Measurements

3 headless 4-player games, "Big 240531" mirror. Normalised per call, since sims aren't deterministic and game length varies between runs:

| | before | after |
|---|---|---|
| Tap scan | 2788.6 µs | 194.4 µs |
| ProduceMana scan | 2749.2 µs | 178.7 µs |
| RE-list rebuilds per scan | 1681 | 34 |

Tap was already covered by #11160; ProduceMana is what this change adds. The traversal itself is unchanged — this only avoids the per-card `getReplacementEffects()` rebuild, which measured as ~78% of the scan cost.

### Note

While measuring this I found that the skip never fires by default: `PERFORMANCE_MODE` defaults to `false`, so #11160's optimisation is inert for most users and is not exercised by CI. That's a separate discussion and I'll open it separately rather than bundle it here.

Edit/note from actual human: It seems claude (opus 4.8) is missing the note on identifying AI-generated code in this context window, so I'm adding it manually.  We're both trying to find the right balance of small PRs vs optimization wins, and we're both having fun (for likely quite different values of fun) getting our head around the engine, and the norms desired by the forge community - hope this help, and happy to shift if this is too much of a pain/distraction from the eternal grind of new sets, but also thrilled to maybe be able to help with something that's brought me much joy!
