### PR TITLE
Decouple the replacement zone scan from PERFORMANCE_MODE

### DIFF
--- a/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
+++ b/forge-game/src/main/java/forge/game/replacement/ReplacementHandler.java
@@ -42,7 +42,6 @@ import forge.game.ability.ApiType;
 import forge.game.player.Player;
 import forge.game.player.PlayerCollection;
 import forge.game.spellability.AbilitySub;
-import forge.game.spellability.Spell;
 import forge.game.spellability.SpellAbility;
 import forge.game.zone.Zone;
 import forge.game.zone.ZoneType;
@@ -51,6 +50,9 @@ import forge.util.TextUtil;
 import forge.util.Visitor;
 
 public class ReplacementHandler {
+    private static final Set<ReplacementType> ZONE_RESTRICTED_EVENTS =
+            EnumSet.of(ReplacementType.Tap, ReplacementType.Untap, ReplacementType.ProduceMana);
+
     private final Game game;
 
     private Set<ReplacementEffect> hasRun = Sets.newHashSet();
@@ -103,17 +105,12 @@ public class ReplacementHandler {
             Card c = preList.get(crd);
             Zone cardZone = game.getZoneOf(c);
 
-            // all tap/untap/produce mana replacements are active from the battlefield or the
-            // command zone (e.g. Ood Sphere); skip other zones - this is a major hot path, as
-            // canTap/canUntap run a cantHappenCheck per mana source per AI cost check, and
-            // groupSourcesByManaColor runs a ProduceMana check per mana ability on top of that
-            // (performance mode only, in case a custom card wants one active from elsewhere)
-            if (Spell.isPerformanceMode()
-                    && (event == ReplacementType.Tap || event == ReplacementType.Untap
-                            || event == ReplacementType.ProduceMana)
-                    && cardZone != null
-                    && cardZone.getZoneType() != ZoneType.Battlefield
-                    && cardZone.getZoneType() != ZoneType.Command) {
+            // a tap/untap/produce mana replacement can only be active from a zone in
+            // STATIC_ABILITIES_SOURCE_ZONES (zonesCheck below rejects the rest), so don't scan
+            // libraries and hands - canTap/canUntap run a cantHappenCheck per mana source per AI
+            // cost check, and groupSourcesByManaColor a ProduceMana check per mana ability
+            if (ZONE_RESTRICTED_EVENTS.contains(event) && cardZone != null
+                    && !ZoneType.STATIC_ABILITIES_SOURCE_ZONES.contains(cardZone.getZoneType())) {
                 return true;
             }
 

--- a/forge-gui-desktop/src/test/java/forge/game/replacement/ReplacementScanZoneTest.java
+++ b/forge-gui-desktop/src/test/java/forge/game/replacement/ReplacementScanZoneTest.java
@@ -36,4 +36,30 @@ public class ReplacementScanZoneTest extends AITest {
 
         assertFalse("a graveyard declaration is honoured", looter.canUntap(me, true));
     }
+
+    /**
+     * A replacement that declares no ActiveZones$ is active in every zone, library included, so
+     * before this change an untap scan reached one buried in a library. Nothing in the pool relies
+     * on that - the 49 undeclared Untap effects are all "doesn't untap during your untap step" on a
+     * permanent - and this is the narrowing the skip actually makes.
+     */
+    @Test
+    public void anUndeclaredReplacementNoLongerReachesOutOfTheLibrary() {
+        Game game = initAndCreateGame();
+        Player me = game.getPlayers().get(0);
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN1, me);
+
+        Card looter = addCard("Merfolk Looter", me);
+        game.getAction().checkStateEffects(true);
+        assertTrue("nothing is stopping it untapping yet", looter.canUntap(me, true));
+
+        Card buried = addCardToZone("Ornithopter", me, ZoneType.Library);
+        buried.addReplacementEffect(ReplacementHandler.parseReplacement(
+                "Event$ Untap | ValidCard$ Creature"
+                        + " | ValidStepTurnToController$ You | Layer$ CantHappen", buried, true));
+        game.getAction().checkStateEffects(true);
+
+        assertTrue("a library card is not scanned for untap replacements",
+                looter.canUntap(me, true));
+    }
 }

--- a/forge-gui-desktop/src/test/java/forge/game/replacement/ReplacementScanZoneTest.java
+++ b/forge-gui-desktop/src/test/java/forge/game/replacement/ReplacementScanZoneTest.java
@@ -1,0 +1,39 @@
+package forge.game.replacement;
+
+import org.testng.annotations.Test;
+
+import forge.ai.AITest;
+import forge.game.Game;
+import forge.game.card.Card;
+import forge.game.phase.PhaseType;
+import forge.game.player.Player;
+import forge.game.zone.ZoneType;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
+/**
+ * The tap/untap/produce mana scan only visits the zones one of those replacements can be active
+ * from, so a card that declares ActiveZones$ outside the battlefield is still found there.
+ */
+public class ReplacementScanZoneTest extends AITest {
+
+    @Test
+    public void aReplacementCanAskForAnotherZone() {
+        Game game = initAndCreateGame();
+        Player me = game.getPlayers().get(0);
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN1, me);
+
+        Card looter = addCard("Merfolk Looter", me);
+        game.getAction().checkStateEffects(true);
+        assertTrue("nothing is stopping it untapping yet", looter.canUntap(me, true));
+
+        Card ghost = addCardToZone("Ornithopter", me, ZoneType.Graveyard);
+        ghost.addReplacementEffect(ReplacementHandler.parseReplacement(
+                "Event$ Untap | ActiveZones$ Graveyard | ValidCard$ Creature"
+                        + " | ValidStepTurnToController$ You | Layer$ CantHappen", ghost, true));
+        game.getAction().checkStateEffects(true);
+
+        assertFalse("a graveyard declaration is honoured", looter.canUntap(me, true));
+    }
+}


### PR DESCRIPTION
**Rewritten since you last looked** - +246/-11 across three files became **+48/-12 across two**, and the engine part is a net line deletion. What changed is at the bottom.

`PERFORMANCE_MODE` gates two unrelated things: the `Spell.canPlay` LKI re-control skip, which its settings text documents and warns about, and @Blackvipe99's Tap/Untap/ProduceMana zone skip from #11160, which it does not mention.

Only the first is a tradeoff. The second gives up nothing - `zonesCheck` already rejects those zones for every card that declares one, so the skip removes work whose result was thrown away. It ended up behind a flag whose description promises to disable correctness checks, and that is why it is off for almost everyone and never runs in CI.

So this isn't a new fast path. It takes the half of `PERFORMANCE_MODE` that was never lossy, makes it the default and unconditional behaviour, and leaves the flag holding only the branch its warning actually describes - one less thing hidden behind "this may break your game".

There is a second reason to want them apart, and it costs users today. The flag's *other* half is the live workaround for #8801 - casting cards owned by an opponent (Praetor's Grasp, Rev, Thief of Sanity, Decadent Dragon, and turn-control effects generally) breaks with Performance Mode **on**, and the standing advice is to turn it off. That advice currently also throws away this scan's speedup, because one flag gates both, which is what the thread was asking not to have to trade:

> it would be nice if there were a more robust solution for it than telling people to deal with the tradeoff of turning off Performance Mode

After this, turning Performance Mode off to fix the card interaction keeps the tap/untap speedup. #8801 was closed stale rather than fixed, so that tradeoff is still real.

This makes the zone restriction unconditional and takes its zones from `STATIC_ABILITIES_SOURCE_ZONES` - the same thing @Blackvipe99 did for the fog scan in #11157, a few hundred lines down in this file. `PERFORMANCE_MODE` keeps its default and now governs only the `Spell.canPlay` branch, which is exactly what its description says.

```java
if (ZONE_RESTRICTED_EVENTS.contains(event) && cardZone != null
        && !ZoneType.STATIC_ABILITIES_SOURCE_ZONES.contains(cardZone.getZoneType())) {
    return true;
}
```

It also delivers what #11160's comment promised - "in case a custom card wants one active from elsewhere". That skip returned *before* `zonesCheck`, so an `ActiveZones$` declaration was ignored outright; taking the zones from the shared constant means a graveyard or exile declaration now works.

## Why it isn't the general form

The obvious simplification is to drop the event set and restrict *every* replacement scan to `STATIC_ABILITIES_SOURCE_ZONES`, the way `isPreventCombatDamageThisTurn` already does further down this file. That breaks five cards. The constant deliberately excludes `Hand` (`/*, Hand*/`), and Loxodon Smiter, Obstinate Baloth, Nullhide Ferox, Wilt-Leaf Liege and Dodecapod all carry `R:Event$ Moved | ActiveZones$ Hand`. They are untouched here only because the restriction is scoped to `Tap`/`Untap`/`ProduceMana`. The fog scan can use the general form because `DamageDone` has no hand-active case; these three events are the set that does.

## Measured

`sim -d "Big 240531" "Big 240531" -n 3 -s 12345`, same seed throughout, so every build plays the *same* games - all 16 runs below produced identical turn counts and outcomes. Four rounds with the four builds interleaved round-robin rather than batched: this box drifts by tens of percent between batches, and batching quietly credits that drift to whichever build ran last. In-game time, mean of four rounds:

| | mean | vs master |
|---|---|---|
| master | 127 482 ms | - |
| **this PR** | **79 254 ms** | **1.61x** |
| #11366 (trait cache) alone | 53 513 ms | 2.38x |
| both | 50 134 ms | 2.54x |

Per-round ratios stay inside 1.59-1.63, 2.35-2.46 and 2.50-2.59.

I expected #11366 to subsume this, since the scan's cost is mostly the `getReplacementEffects()` rebuild that PR caches. It doesn't - caching makes each visit cheap, this stops ~1700 library and hand cards being visited at all - but the margin is smaller than this body used to claim. On top of #11366 it is worth **6.7%** (per-round 5.5-8.0%), not the ~15% I had here before. That older number came from batched runs and I no longer trust it.

## Safety

Every `Tap` and `ProduceMana` replacement in the pool declares `ActiveZones$` - 121 `Battlefield`, 3 `Command`. The 49 declaring nothing are all `Untap`, all "doesn't untap during your untap step" on a permanent. Nothing needs a zone this skips.

The earlier version of this section understated what that means, so to be precise: `zonesCheck` treats a missing `ActiveZones$` as active **everywhere**, not as battlefield-only -

```java
return !this.hostCard.isPhasedOut()
        && (validHostZones == null || validHostZones.isEmpty()
        || (hostCardZone != null && validHostZones.contains(hostCardZone.getZoneType())));
```

so those 49 are formally live in a library too. They are unreachable in practice, because an untap event never targets a card there, but the skip narrows a default-everywhere rather than trimming a declared zone. That is the honest statement of the change.

## Blast radius

Probed rather than argued: an undeclared `Untap` replacement hosted in each of the 19 `ZoneType`s, master against this branch. **Seven zones change**, not the two this body used to imply - `Hand` and `Library`, plus the five command-adjacent deck zones `SchemeDeck`, `PlanarDeck`, `AttractionDeck`, `ContraptionDeck` and `Junkyard`, which are in `PART_OF_COMMAND_ZONE` but not in `STATIC_ABILITIES_SOURCE_ZONES`. `Battlefield`, `Graveyard`, `Exile` and `Command` are unchanged; `Sideboard`, `Ante`, `Merged`, `Subgame` and `None` were already unscanned. `Flashback`, `Stack` and `ExtraHand` the probe could not construct.

The five deck zones are unreachable in the current pool. The 49 undeclared effects sit on ordinary permanents - creatures, artifacts, auras, one land - so none of them can be in a scheme, planar, attraction or contraption deck. The three cards of those types that do carry one of these events (Edge of Malacol, Imprison This Insolent Wretch, Mirri) all declare `ActiveZones$ Command`, which already excluded their own deck zone. `Hand` and `Library` are the only zones where the narrowing is observable.

The one thing given up: the constant excludes `Hand`, so a custom card declaring `ActiveZones$ Hand` on these three events would stop working. Nothing in the pool does, and the fog check already has this property. If it matters, widening the shared constant serves all ~30 call sites rather than just this one.

Two tests. The first is a no-regression guard for the zone set, and I should be straight that it is only that: at the default flag setting every zone is scanned today, so it passes on master too and discriminates only with the flag *on*. The second covers the narrowing itself and does fail against master at the default setting - an undeclared replacement is active in every zone, so an untap scan reached one sitting in a library. 356 tests, 0 failures, checkstyle clean.

## What changed since the first version

- **A 165-line `ReplacementScanZones` class is gone.** It parsed `Event$`/`ActiveZones$` out of card script text at startup to derive the zone set - re-implementing the parser next door to the real one, to compute what is a constant. It also missed its own use case: Effect-hosted replacements (False Dawn, Ood Sphere) get their command zone from `EffectEffect` in code, not script, so a text scan can't see them.
- **A middle version** registered widenings at `parseReplacement` instead. Better, but still inventing a zone set `STATIC_ABILITIES_SOURCE_ZONES` already meant, and it benchmarked no faster - complexity for nothing.
- **The offer to hide this behind a second, separately-named flag is withdrawn** - a new flag to work around the first being mis-scoped isn't a fix.
- The original body said this supersedes #11327. That's backwards now: #11327 is merged and this builds on it.

🤖 Implemented with the assistance of Claude Code (Opus 5).
