### PR TITLE
Fix Adventure world saves failing to load after card-art sleeves Deck change

### DIFF
--- a/forge-core/src/main/java/forge/deck/Deck.java
+++ b/forge-core/src/main/java/forge/deck/Deck.java
@@ -46,6 +46,10 @@ import java.util.stream.Collectors;
  */
 @SuppressWarnings("serial")
 public class Deck extends DeckBase implements Iterable<Entry<DeckSection, CardPool>> {
+    // Pinned to the computed UID from before sleeveArtKey/sleeveArtOffset were added, so decks
+    // serialized into Adventure saves by older builds keep deserializing (new fields default).
+    private static final long serialVersionUID = -8539667316828440829L;
+
     // Crop offset (0..1000 along the slack axis) used when framing this deck's card-art sleeve
     public static final int DEFAULT_SLEEVE_OFFSET = 500;
 
@@ -582,7 +586,8 @@ public class Deck extends DeckBase implements Iterable<Entry<DeckSection, CardPo
 
     /** Card image key whose art_crop is this deck's sleeve, or "" to use the built-in sleeve. */
     public String getSleeveArtKey() {
-        return sleeveArtKey;
+        // null when deserialized from a stream written before this field existed
+        return sleeveArtKey == null ? "" : sleeveArtKey;
     }
     public void setSleeveArtKey(final String key) {
         sleeveArtKey = key == null ? "" : key;


### PR DESCRIPTION
## Issue

After #10994 (card-art deck sleeves), loading any existing Adventure world save that contains completed events fails and dumps the player back to the start menu:

```
[Invalid Class Exception]
Overriding serialized class version mismatch: local serialVersionUID = -1203811324742470844 stream serialVersionUID = -8539667316828440829
java.io.StreamCorruptedException: invalid type code: 6A
	at forge.adventure.util.SaveFileData.readObject(SaveFileData.java:185)
	at forge.adventure.player.PlayerStatistic.load(PlayerStatistic.java:131)
	at forge.adventure.player.AdventurePlayer.load(AdventurePlayer.java:398)
	at forge.adventure.world.WorldSave.load(WorldSave.java:164)
```

Every save made before #10994 whose `PlayerStatistic.completedEvents` is non-empty (i.e. the player ever finished a draft/event) will hit this on the next release.

## Root cause

`Deck` is Java-serialized inside Adventure saves (`AdventureEventData.registeredDeck` etc.) and does not declare a `serialVersionUID`, so it uses the JVM's computed one. #10994 added two non-transient fields (`sleeveArtKey`, `sleeveArtOffset`), which changed the computed UID from `-8539667316828440829` to `-1203811324742470844`.

On load, `SaveFileData.DecompressibleInputStream` "handles" the UID mismatch by substituting the local class descriptor and continuing to read. That trick is only safe when the field layout is unchanged: here the local descriptor expects two fields that old streams don't contain, so the reader consumes bytes belonging to the next objects in the stream, desynchronizes, and fails with `StreamCorruptedException: invalid type code`.

## Fix (smallest scope)

- Pin `Deck.serialVersionUID` to the pre-#10994 computed value (`-8539667316828440829L`). With matching UIDs the descriptor-substitution hack never fires and standard Java deserialization applies, which handles added fields natively (they default to `null`/`0`).
- Null-guard `getSleeveArtKey()`, since decks deserialized from pre-#10994 streams have `sleeveArtKey == null` (field initializers don't run during deserialization). Mirrors the existing guard in `LobbyPlayer.getSleeveArtKey()`.

## Verification

- `serialver` on the pre-#10994 tree confirms the pinned value is the old computed UID.
- Round-trip harness: decks serialized by a pre-#10994 build fail with the exact reported `invalid type code: 6A` on current master, and load correctly (with `sleeveArtKey` defaulting to empty, following stream data intact) with this patch.
- Reverse direction: decks serialized by the patched build deserialize fine on a pre-#10994 build, so new saves remain readable by older releases.
- Manually verified: an affected real-world Adventure save that reproduced the crash loads correctly with this patch.

