### PR TITLE
HOB: 4 cards [Batch 4]

### DIFF
--- a/forge-gui/res/cardsfolder/upcoming/chief_wargs_company.txt
+++ b/forge-gui/res/cardsfolder/upcoming/chief_wargs_company.txt
@@ -1,0 +1,9 @@
+Name:Chief Warg's Company
+ManaCost:1 B G
+Types:Creature Wolf
+PT:5/3
+K:Trample
+S:Mode$ CantAttack | ValidCard$ Card.Self | IsPresent$ Wolf.YouCtrl+Other | PresentCompare$ LE1 | Description$ This creature can't attack unless you control two or more other Wolves.
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ At the beginning of your upkeep, create a 2/2 green Wolf creature token.
+SVar:TrigToken:DB$ Token | TokenScript$ g_2_2_wolf
+Oracle:Trample\nThis creature can't attack unless you control two or more other Wolves.\nAt the beginning of your upkeep, create a 2/2 green Wolf creature token.

--- a/forge-gui/res/cardsfolder/upcoming/desert_were_worm.txt
+++ b/forge-gui/res/cardsfolder/upcoming/desert_were_worm.txt
@@ -1,0 +1,11 @@
+Name:Desert Were-Worm
+ManaCost:4 R R
+Types:Creature Dragon Wurm
+PT:0/5
+S:Mode$ Continuous | Affected$ Card.Self | AddPower$ X | Description$ This creature gets +2/+0 for each Mountain you control.
+SVar:X:Count$Valid Mountain.YouCtrl/Times.2
+T:Mode$ AttackersDeclared | ValidAttackers$ Creature.YouCtrl | Execute$ TrigUntap | TriggerZones$ Battlefield | CheckSVar$ PackTactics | FirstTime$ True | SVarCompare$ GE12 | NoResolvingCheck$ True | TriggerDescription$ Whenever you attack with creatures with total power 12 or greater for the first time each turn, untap all attacking creatures. After this phase, there is an additional combat phase.
+SVar:TrigUntap:DB$ UntapAll | ValidCards$ Creature.YouCtrl+attacking | SubAbility$ DBAddCombat
+SVar:DBAddCombat:DB$ AddPhase | ExtraPhase$ Combat | AfterPhase$ EndCombat
+SVar:PackTactics:Count$Valid Creature.attacking$CardPower
+Oracle:This creature gets +2/+0 for each Mountain you control.\nWhenever you attack with creatures with total power 12 or greater for the first time each turn, untap all attacking creatures. After this phase, there is an additional combat phase.

--- a/forge-gui/res/cardsfolder/upcoming/desert_were_worm.txt
+++ b/forge-gui/res/cardsfolder/upcoming/desert_were_worm.txt
@@ -4,8 +4,12 @@ Types:Creature Dragon Wurm
 PT:0/5
 S:Mode$ Continuous | Affected$ Card.Self | AddPower$ X | Description$ This creature gets +2/+0 for each Mountain you control.
 SVar:X:Count$Valid Mountain.YouCtrl/Times.2
-T:Mode$ AttackersDeclared | ValidAttackers$ Creature.YouCtrl | Execute$ TrigUntap | TriggerZones$ Battlefield | CheckSVar$ PackTactics | FirstTime$ True | SVarCompare$ GE12 | NoResolvingCheck$ True | TriggerDescription$ Whenever you attack with creatures with total power 12 or greater for the first time each turn, untap all attacking creatures. After this phase, there is an additional combat phase.
+T:Mode$ AttackersDeclared | ValidAttackers$ Creature.YouCtrl | Execute$ TrigUntap | TriggerZones$ Battlefield | CheckSVar$ PackTactics | SVarCompare$ GE12 | NoResolvingCheck$ True | TriggerDescription$ Whenever you attack with creatures with total power 12 or greater for the first time each turn, untap all attacking creatures. After this phase, there is an additional combat phase.
 SVar:TrigUntap:DB$ UntapAll | ValidCards$ Creature.YouCtrl+attacking | SubAbility$ DBAddCombat
-SVar:DBAddCombat:DB$ AddPhase | ExtraPhase$ Combat | AfterPhase$ EndCombat
-SVar:PackTactics:Count$Valid Creature.attacking$CardPower
+SVar:DBAddCombat:DB$ AddPhase | ExtraPhase$ Combat | AfterPhase$ EndCombat | SubAbility$ DBStore
+SVar:DBStore:DB$ StoreSVar | SVar$ TrigSwitch | Type$ Number | Expression$ 0
+SVar:PackTactics:Count$Valid Creature.attacking$CardPower/Times.TrigSwitch
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigReset | Static$ True
+T:Mode$ TurnBegin | Execute$ TrigReset | Static$ True
+SVar:TrigReset:DB$ StoreSVar | SVar$ TrigSwitch | Type$ Number | Expression$ 1
 Oracle:This creature gets +2/+0 for each Mountain you control.\nWhenever you attack with creatures with total power 12 or greater for the first time each turn, untap all attacking creatures. After this phase, there is an additional combat phase.

--- a/forge-gui/res/cardsfolder/upcoming/down_down_to_goblin_town.txt
+++ b/forge-gui/res/cardsfolder/upcoming/down_down_to_goblin_town.txt
@@ -1,0 +1,9 @@
+Name:Down, Down to Goblin-town
+ManaCost:2 B
+Types:Enchantment Saga
+K:Chapter:3:DBDiscard,DBAmass,DBDrain
+SVar:DBDiscard:DB$ Discard | ValidTgts$ Opponent | NumCards$ 1 | DiscardValid$ Card.nonLand | Mode$ RevealYouChoose | SpellDescription$ Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.
+SVar:DBAmass:DB$ Amass | Type$ Goblin | Num$ 1 | SpellDescription$ Amass Goblins 3. (Put a +1/+1 counter on an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army creature token first.)
+SVar:DBDrain:DB$ LoseLife | ValidTgts$ Opponent | LifeAmount$ 1 | SubAbility$ DBGainLife | SpellDescription$ Target player loses 1 life and you gain 1 life.
+SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1
+Oracle:(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI — Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.\nII — Amass Goblins 1. (Put a +1/+1 counter on an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army creature token first.)\n III, IV — Target opponent loses 1 life and you gain 1 life.

--- a/forge-gui/res/cardsfolder/upcoming/down_down_to_goblin_town.txt
+++ b/forge-gui/res/cardsfolder/upcoming/down_down_to_goblin_town.txt
@@ -1,7 +1,7 @@
 Name:Down, Down to Goblin-town
 ManaCost:2 B
 Types:Enchantment Saga
-K:Chapter:3:DBDiscard,DBAmass,DBDrain
+K:Chapter:3:DBDiscard,DBAmass,DBDrain,DBDrain
 SVar:DBDiscard:DB$ Discard | ValidTgts$ Opponent | NumCards$ 1 | DiscardValid$ Card.nonLand | Mode$ RevealYouChoose | SpellDescription$ Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.
 SVar:DBAmass:DB$ Amass | Type$ Goblin | Num$ 1 | SpellDescription$ Amass Goblins 1. (Put a +1/+1 counter on an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army creature token first.)
 SVar:DBDrain:DB$ LoseLife | ValidTgts$ Opponent | LifeAmount$ 1 | SubAbility$ DBGainLife | SpellDescription$ Target player loses 1 life and you gain 1 life.

--- a/forge-gui/res/cardsfolder/upcoming/down_down_to_goblin_town.txt
+++ b/forge-gui/res/cardsfolder/upcoming/down_down_to_goblin_town.txt
@@ -3,7 +3,7 @@ ManaCost:2 B
 Types:Enchantment Saga
 K:Chapter:3:DBDiscard,DBAmass,DBDrain
 SVar:DBDiscard:DB$ Discard | ValidTgts$ Opponent | NumCards$ 1 | DiscardValid$ Card.nonLand | Mode$ RevealYouChoose | SpellDescription$ Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.
-SVar:DBAmass:DB$ Amass | Type$ Goblin | Num$ 1 | SpellDescription$ Amass Goblins 3. (Put a +1/+1 counter on an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army creature token first.)
+SVar:DBAmass:DB$ Amass | Type$ Goblin | Num$ 1 | SpellDescription$ Amass Goblins 1. (Put a +1/+1 counter on an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army creature token first.)
 SVar:DBDrain:DB$ LoseLife | ValidTgts$ Opponent | LifeAmount$ 1 | SubAbility$ DBGainLife | SpellDescription$ Target player loses 1 life and you gain 1 life.
 SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1
 Oracle:(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI — Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.\nII — Amass Goblins 1. (Put a +1/+1 counter on an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army creature token first.)\n III, IV — Target opponent loses 1 life and you gain 1 life.

--- a/forge-gui/res/cardsfolder/upcoming/down_down_to_goblin_town.txt
+++ b/forge-gui/res/cardsfolder/upcoming/down_down_to_goblin_town.txt
@@ -1,7 +1,7 @@
 Name:Down, Down to Goblin-town
 ManaCost:2 B
 Types:Enchantment Saga
-K:Chapter:3:DBDiscard,DBAmass,DBDrain,DBDrain
+K:Chapter:4:DBDiscard,DBAmass,DBDrain,DBDrain
 SVar:DBDiscard:DB$ Discard | ValidTgts$ Opponent | NumCards$ 1 | DiscardValid$ Card.nonLand | Mode$ RevealYouChoose | SpellDescription$ Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.
 SVar:DBAmass:DB$ Amass | Type$ Goblin | Num$ 1 | SpellDescription$ Amass Goblins 1. (Put a +1/+1 counter on an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army creature token first.)
 SVar:DBDrain:DB$ LoseLife | ValidTgts$ Opponent | LifeAmount$ 1 | SubAbility$ DBGainLife | SpellDescription$ Target player loses 1 life and you gain 1 life.

--- a/forge-gui/res/cardsfolder/upcoming/gathering_of_darkness.txt
+++ b/forge-gui/res/cardsfolder/upcoming/gathering_of_darkness.txt
@@ -1,0 +1,7 @@
+Name:Gathering of Darkness
+ManaCost:3 B
+Types:Sorcery
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Creature.YouCtrl | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target creature card in your graveyard | SubAbility$ DBAmass | SpellDescription$ Return target creature card from your graveyard to your hand.,,,,,,
+SVar:DBAmass:DB$ Amass | Type$ Goblin | Num$ 3 | SpellDescription$ Amass Goblins 3. (Put three +1/+1 counters on an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army creature token first.)
+DeckHas:Ability$Graveyard
+Oracle:Return up to one target creature card from your graveyard to your hand.\nAmass Goblins 3. (Put three +1/+1 counters on an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army creature token first.)

--- a/forge-gui/res/cardsfolder/upcoming/gathering_of_darkness.txt
+++ b/forge-gui/res/cardsfolder/upcoming/gathering_of_darkness.txt
@@ -1,7 +1,7 @@
 Name:Gathering of Darkness
 ManaCost:3 B
 Types:Sorcery
-A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Creature.YouCtrl | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target creature card in your graveyard | SubAbility$ DBAmass | SpellDescription$ Return target creature card from your graveyard to your hand.,,,,,,
+A:SP$ ChangeZone | Origin$ Graveyard | Destination$ Hand | ValidTgts$ Creature.YouCtrl | TargetMin$ 0 | TargetMax$ 1 | TgtPrompt$ Select up to one target creature card in your graveyard | SubAbility$ DBAmass | SpellDescription$ Return up to one target creature card from your graveyard to your hand.,,,,,,
 SVar:DBAmass:DB$ Amass | Type$ Goblin | Num$ 3 | SpellDescription$ Amass Goblins 3. (Put three +1/+1 counters on an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army creature token first.)
 DeckHas:Ability$Graveyard
 Oracle:Return up to one target creature card from your graveyard to your hand.\nAmass Goblins 3. (Put three +1/+1 counters on an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army creature token first.)


### PR DESCRIPTION
As revealed recently; tested to satisfaction:
- [Chief Warg's Company](https://scryfall.com/card/hob/151/chief-wargs-company)
- [Down, Down to Goblin-town](https://scryfall.com/card/hob/65/down-down-to-goblin-town)
- [Gathering of Darkness](https://scryfall.com/card/hob/68/gathering-of-darkness)
- [Desert Were-Worm](https://scryfall.com/card/hob/92/desert-were-worm): As discussed below, attempted to implement the `StoreSVar` trick as succinctly as possible. Seems to work adequately.

~Needs support:~
- ~[Desert Were-Worm](https://scryfall.com/card/hob/92/desert-were-worm)~
→ ~`AttackersDeclared` needs either a FirstTime$  or a FirstAttack$ parameter. Not sure which is more appropriate. Currently this card's triggered ability triggers on each subsequent attack.~