### PR TITLE
Fix AI implementation of Toxic Deluge and Flowstone Slide

### DIFF
--- a/forge-ai/src/main/java/forge/ai/AiAttackController.java
+++ b/forge-ai/src/main/java/forge/ai/AiAttackController.java
@@ -187,6 +187,15 @@ public class AiAttackController {
         this.blockers.remove(blocker);
     }
 
+    /**
+     * Counterpart to removeBlocker, for asking what an attack looks like without one of our own
+     * creatures - one that is about to die to something we are considering casting, say.
+     */
+    public void removeAttacker(Card attacker) {
+        this.myList.remove(attacker);
+        this.attackers.remove(attacker);
+    }
+
     private boolean canAttackWrapper(final Card attacker, final GameEntity defender) {
         if (nextTurn) {
             return CombatUtil.canAttackNextTurn(attacker, defender);

--- a/forge-ai/src/main/java/forge/ai/ComputerUtil.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtil.java
@@ -3179,6 +3179,13 @@ public class ComputerUtil {
         return predictNextCombatsRemainingLife(ai, serious, checkDiff, payment, excludedBlockers, ai.getOpponents());
     }
     public static int predictNextCombatsRemainingLife(Player ai, boolean serious, boolean checkDiff, int payment, final CardCollection excludedBlockers, final List<Player> opps) {
+        return predictNextCombatsRemainingLife(ai, serious, checkDiff, payment, excludedBlockers, opps, null);
+    }
+    /**
+     * @param excludedAttackers creatures to leave out of the opponents' attack - ones we are about
+     *            to kill, say, so that a board wipe is not weighed against the board it removes.
+     */
+    public static int predictNextCombatsRemainingLife(Player ai, boolean serious, boolean checkDiff, int payment, final CardCollection excludedBlockers, final List<Player> opps, final CardCollection excludedAttackers) {
         // life won't change
         int remainingLife = Integer.MAX_VALUE;
 
@@ -3197,6 +3204,9 @@ public class ComputerUtil {
 
             // TODO !thisCombat should include cards that will phase in
             for (Card att : opp.getCreaturesInPlay()) {
+                if (excludedAttackers != null && excludedAttackers.contains(att)) {
+                    continue;
+                }
                 // TODO should be limited based on how much getAttackCost the opp can pay
                 if ((thisCombat && CombatUtil.canAttack(att, ai)) || (!thisCombat && ComputerUtilCombat.canAttackNextTurn(att, ai))) {
                     // TODO need to copy the card

--- a/forge-ai/src/main/java/forge/ai/ability/PumpAiBase.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PumpAiBase.java
@@ -378,6 +378,17 @@ public abstract class PumpAiBase extends SpellAbilityAi {
     }
 
     /**
+     * Whether a -X/-X of the given size (passed as the negative NumDef) finishes this creature off.
+     * Shrinking it to zero toughness works even through indestructible.
+     */
+    protected static boolean diesToCurse(final Card c, final int defense) {
+        if (c.getNetToughness() <= -defense) {
+            return true;
+        }
+        return ComputerUtilCombat.getDamageToKill(c, false) <= -defense && !c.hasKeyword(Keyword.INDESTRUCTIBLE);
+    }
+
+    /**
      * <p>
      * getCurseCreatures.
      * </p>
@@ -401,12 +412,8 @@ public abstract class PumpAiBase extends SpellAbilityAi {
         }
 
         if (defense < 0) { // with spells that give -X/-X, compi will try to destroy a creature
-            list = CardLists.filter(list, c -> {
-                if (c.getSVar("Targeting").equals("Dies") || c.getNetToughness() <= -defense) {
-                    return true; // can kill indestructible creatures
-                }
-                return ComputerUtilCombat.getDamageToKill(c, false) <= -defense && !c.hasKeyword(Keyword.INDESTRUCTIBLE);
-            }); // leaves all creatures that will be destroyed
+            // leaves all creatures that will be destroyed
+            list = CardLists.filter(list, c -> c.getSVar("Targeting").equals("Dies") || diesToCurse(c, defense));
         } // -X/-X end
         else if (attack < 0 && !game.getReplacementHandler().isPreventCombatDamageThisTurn()) {
             // spells that give -X/0

--- a/forge-ai/src/main/java/forge/ai/ability/PumpAllAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PumpAllAi.java
@@ -9,7 +9,6 @@ import forge.game.card.CardCollection;
 import forge.game.card.CardLists;
 import forge.game.combat.Combat;
 import forge.game.cost.Cost;
-import forge.game.keyword.Keyword;
 import forge.game.phase.PhaseHandler;
 import forge.game.phase.PhaseType;
 import forge.game.player.Player;
@@ -75,18 +74,9 @@ public class PumpAllAi extends PumpAiBase {
 
         if (sa.isCurse()) {
             if (defense < 0) { // try to destroy creatures
-                comp = CardLists.filter(comp, c -> {
-                    if (c.getNetToughness() <= -defense) {
-                        return true; // can kill indestructible creatures
-                    }
-                    return ComputerUtilCombat.getDamageToKill(c, false) <= -defense && !c.hasKeyword(Keyword.INDESTRUCTIBLE);
-                }); // leaves all creatures that will be destroyed
-                human = CardLists.filter(human, c -> {
-                    if (c.getNetToughness() <= -defense) {
-                        return true; // can kill indestructible creatures
-                    }
-                    return ComputerUtilCombat.getDamageToKill(c, false) <= -defense && !c.hasKeyword(Keyword.INDESTRUCTIBLE);
-                }); // leaves all creatures that will be destroyed
+                // leaves all creatures that will be destroyed
+                comp = CardLists.filter(comp, c -> diesToCurse(c, defense));
+                human = CardLists.filter(human, c -> diesToCurse(c, defense));
             } // -X/-X end
             else if (power < 0) { // -X/-0
                 if (phase.isAfter(PhaseType.COMBAT_DECLARE_BLOCKERS)

--- a/forge-ai/src/main/java/forge/ai/ability/PumpAllAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PumpAllAi.java
@@ -1,5 +1,7 @@
 package forge.ai.ability;
 
+import com.google.common.collect.Iterables;
+
 import forge.ai.*;
 import forge.game.Game;
 import forge.game.GameObject;
@@ -9,6 +11,7 @@ import forge.game.card.CardCollection;
 import forge.game.card.CardLists;
 import forge.game.combat.Combat;
 import forge.game.cost.Cost;
+import forge.game.cost.CostPayLife;
 import forge.game.phase.PhaseHandler;
 import forge.game.phase.PhaseType;
 import forge.game.player.Player;
@@ -17,9 +20,20 @@ import forge.game.zone.ZoneType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 public class PumpAllAi extends PumpAiBase {
+
+    // What the AI charges itself for spending life, relative to how much of its total is going.
+    // Spending half of a healthy life total costs about as much as losing one creature.
+    private static final int LIFE_VALUE = 400;
+
+    // How many values of X we are willing to simulate a combat for before settling.
+    private static final int SURVIVAL_CHECKS = 3;
 
     /* (non-Javadoc)
      * @see forge.card.abilityfactory.SpellAiLogic#canPlayAI(forge.game.player.Player, java.util.Map, forge.card.spellability.SpellAbility)
@@ -62,15 +76,32 @@ public class PumpAllAi extends PumpAiBase {
             }
         }
 
+        final String valid = sa.getParamOrDefault("ValidCards", "");
+
+        CardCollection comp = CardLists.getValidCards(ai.getCardsIn(ZoneType.Battlefield), valid, source.getController(), source, sa);
+        // A mass pump lands on every opponent's board at once, so weigh all of them. In a two
+        // player game this is the same list getStrongestOpponent() was giving.
+        CardCollection human = CardLists.getValidCards(ai.getOpponents().getCardsIn(ZoneType.Battlefield), valid, source.getController(), source, sa);
+
+        // Nothing else announces X for a -X/-X sweep: PumpAll has an AI class, so the generic X
+        // handling in AiController is skipped, and on cards like Toxic Deluge the X lives in a
+        // non-mana cost (PayLife<X>) that path would not see either. Without this the amounts
+        // below both read 0 and the sweep evaluates as -0/-0.
+        if (sa.isCurse() && usesPaidX(sa)) {
+            final SweepChoice sweep = chooseXForSweep(ai, sa, comp, human);
+            if (sweep.x() <= 0) {
+                return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
+            }
+            // Clearing the way for a lethal swing is worth it whatever the card values below say.
+            if (sweep.lethal()) {
+                return new AiAbilityDecision(100, AiPlayDecision.WillPlay);
+            }
+        }
+
         final int power = AbilityUtils.calculateAmount(source, sa.getParam("NumAtt"), sa);
         final int defense = AbilityUtils.calculateAmount(source, sa.getParam("NumDef"), sa);
         final List<String> keywords = sa.hasParam("KW") ? Arrays.asList(sa.getParam("KW").split(" & ")) : new ArrayList<>();
         final PhaseType phase = game.getPhaseHandler().getPhase();
-
-        final String valid = sa.getParamOrDefault("ValidCards", "");
-
-        CardCollection comp = CardLists.getValidCards(ai.getCardsIn(ZoneType.Battlefield), valid, source.getController(), source, sa);
-        CardCollection human = CardLists.getValidCards(opp.getCardsIn(ZoneType.Battlefield), valid, source.getController(), source, sa);
 
         if (sa.isCurse()) {
             if (defense < 0) { // try to destroy creatures
@@ -141,6 +172,194 @@ public class PumpAllAi extends PumpAiBase {
             return new AiAbilityDecision(50, AiPlayDecision.MandatoryPlay);
         }
         return decision;
+    }
+
+    /** The X the AI settled on for a sweep, and whether taking it simply wins this turn. */
+    private record SweepChoice(int x, boolean lethal) {}
+
+    private static boolean usesPaidX(final SpellAbility sa) {
+        if (!sa.getParamOrDefault("NumDef", "").endsWith("X") || !"Count$xPaid".equals(sa.getSVar("X"))) {
+            return false;
+        }
+        // Only choose X where this ability is the thing announcing it. On triggers and sub-abilities
+        // (The Meathook Massacre, Orcus) X was already paid when the spell was cast, so there is no
+        // X left to find here and the AI would refuse an otherwise fine sweep.
+        final Cost cost = sa.getPayCosts();
+        return cost != null && cost.hasXInAnyCostPart();
+    }
+
+    private static boolean pumpsPower(final SpellAbility sa) {
+        return sa.getParamOrDefault("NumAtt", "").startsWith("+");
+    }
+
+    private static boolean paysLifeForX(final SpellAbility sa) {
+        final Cost cost = sa.getPayCosts();
+        final CostPayLife part = cost == null ? null : cost.getCostPartByType(CostPayLife.class);
+        return part != null && "X".equals(part.getAmount());
+    }
+
+    /**
+     * Picks how big a -X/-X sweep to pay for and records it on the ability, returning the chosen X.
+     * Returns 0 when no value of X is worth casting at, so the caller can bail out.
+     */
+    private SweepChoice chooseXForSweep(final Player ai, final SpellAbility sa, final CardCollection own, final CardCollection foes) {
+        // Also sets X to its maximum, which is what the amounts would otherwise be read at.
+        final int maxX = ComputerUtilCost.setMaxXValue(sa, ai, sa.isTrigger());
+        if (maxX <= 0) {
+            return new SweepChoice(0, false);
+        }
+
+        // Which creatures die only changes at the toughnesses actually on the battlefield, so try
+        // those values instead of every point up to maxX - otherwise the AI walks its whole life
+        // total one point at a time to reach the same answer. A superset is fine; diesToCurse stays
+        // the single authority on what any given X actually kills.
+        final SortedSet<Integer> candidates = new TreeSet<>();
+        for (Card c : Iterables.concat(own, foes)) {
+            addCandidate(candidates, c.getNetToughness(), maxX);
+            addCandidate(candidates, ComputerUtilCombat.getDamageToKill(c, false), maxX);
+        }
+
+        final boolean paysLife = paysLifeForX(sa);
+        // Power the pump hands out lasts only until end of turn, so it matters to whoever still has
+        // a combat coming: on an opponent's turn their survivors swing at us with it, on our own
+        // turn ours use it and theirs has expired long before they untap.
+        final boolean pumps = pumpsPower(sa);
+        final boolean ourTurn = ai.getGame().getPhaseHandler().isPlayerTurn(ai);
+
+        // Rank the candidates on card value alone. Both checks below simulate a combat, so they
+        // stay out of this loop and are asked only about the few values that could be chosen.
+        final Map<Integer, Integer> scores = new HashMap<>();
+        int cheapestLethal = 0;
+        for (final int x : candidates) {
+            int score = ComputerUtilCard.evaluateCreatureList(CardLists.filter(foes, c -> diesToCurse(c, -x)))
+                    - ComputerUtilCard.evaluateCreatureList(CardLists.filter(own, c -> diesToCurse(c, -x)));
+            if (paysLife) {
+                score -= LIFE_VALUE * x / Math.max(1, ai.getLife());
+            }
+            if (score > 0) {
+                scores.put(x, score);
+            }
+            // Candidates ascend, so this keeps the cheapest X that could reach.
+            if (cheapestLethal == 0 && couldReachLethal(ai, own, x, pumps && ourTurn ? x : 0)) {
+                cheapestLethal = x;
+            }
+        }
+
+        // Mirrors DamageAllAi: a sweep that just wins beats any card-value comparison. Only the
+        // cost has to be affordable here - if the swing is lethal there is no next combat to live
+        // through, so what the survivors could have hit back with does not matter.
+        if (cheapestLethal > 0 && canAfford(ai, sa, cheapestLethal, paysLife)
+                && winsThisTurn(ai, own, foes, cheapestLethal, pumps && ourTurn ? cheapestLethal : 0)) {
+            sa.setXManaCostPaid(cheapestLethal);
+            return new SweepChoice(cheapestLethal, true);
+        }
+
+        // Otherwise take the most valuable sweep we can actually live through. Sorted by value,
+        // then by size, so the cheapest X wins when a larger one kills nothing extra.
+        final List<Integer> ranked = new ArrayList<>(scores.keySet());
+        ranked.sort((a, b) -> {
+            final int byValue = Integer.compare(scores.get(b), scores.get(a));
+            return byValue != 0 ? byValue : Integer.compare(a, b);
+        });
+        int checked = 0;
+        for (final int x : ranked) {
+            if (checked++ >= SURVIVAL_CHECKS) {
+                break;
+            }
+            if (survivesSweep(ai, sa, own, foes, x, paysLife, pumps && !ourTurn ? x : 0)) {
+                sa.setXManaCostPaid(x);
+                return new SweepChoice(x, false);
+            }
+        }
+        return new SweepChoice(0, false);
+    }
+
+    /**
+     * Cheap necessary condition for winsThisTurn: no attack can deal more than every creature we
+     * keep connecting unblocked, so anything short of that is not worth planning an attack for.
+     */
+    private static boolean couldReachLethal(final Player ai, final CardCollection own, final int x, final int boost) {
+        final CardCollection survivors = CardLists.filter(own, c -> !diesToCurse(c, -x));
+        for (final Player opp : ai.getOpponents()) {
+            if (ComputerUtilCombat.sumDamageIfUnblocked(survivors, opp) + boost * survivors.size() >= opp.getLife()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void addCandidate(final SortedSet<Integer> candidates, final int x, final int maxX) {
+        if (x > 0 && x <= maxX) {
+            candidates.add(x);
+        }
+    }
+
+    /**
+     * Whether the AI still stands up to the coming combats once it has paid for this sweep and both
+     * boards have lost whatever it kills.
+     */
+    /** Whether the cost can be paid at all, and paying it does not kill the AI outright. */
+    private static boolean canAfford(final Player ai, final SpellAbility sa, final int x, final boolean paysLife) {
+        if (!paysLife) {
+            return true;
+        }
+        return ai.canPayLife(x, false, sa) && (ai.getLife() > x || ai.cantLoseForZeroOrLessLife());
+    }
+
+    private static boolean survivesSweep(final Player ai, final SpellAbility sa, final CardCollection own,
+            final CardCollection foes, final int x, final boolean paysLife, final int boost) {
+        if (!canAfford(ai, sa, x, paysLife)) {
+            return false;
+        }
+        final CardCollection ourDead = CardLists.filter(own, c -> diesToCurse(c, -x));
+        final CardCollection theirDead = CardLists.filter(foes, c -> diesToCurse(c, -x));
+
+        // Cheap and pessimistic first: assume nothing gets blocked. Real blocks only ever reduce
+        // that, so if we live through the worst case there is nothing to simulate.
+        final CardCollection survivors = CardLists.filter(foes, c -> !diesToCurse(c, -x));
+        final int worstCase = ComputerUtilCombat.sumDamageIfUnblocked(survivors, ai) + boost * survivors.size();
+        if (ai.getLife() - (paysLife ? x : 0) > worstCase) {
+            return true;
+        }
+        // The life goes before that combat, and a survivor's boost is charged per head, which the
+        // simulation below has no way to model.
+        final int lifeCost = (paysLife ? x : 0) + boost * survivors.size();
+        return ComputerUtil.predictNextCombatsRemainingLife(ai, true, false, lifeCost, ourDead,
+                ai.getOpponents(), theirDead) != Integer.MIN_VALUE;
+    }
+
+    /**
+     * Whether clearing the board at this X leaves the AI able to finish an opponent off this turn.
+     * Asks the attack planner rather than guessing, so fog, evasion and the rest are accounted for.
+     */
+    private static boolean winsThisTurn(final Player ai, final CardCollection own, final CardCollection foes,
+            final int x, final int boost) {
+        final PhaseHandler ph = ai.getGame().getPhaseHandler();
+        if (!ph.isPlayerTurn(ai) || !ph.getPhase().isBefore(PhaseType.COMBAT_DECLARE_ATTACKERS)) {
+            return false; // no attack step left to spend it on
+        }
+
+        final AiAttackController atk = new AiAttackController(ai);
+        for (final Card c : foes) {
+            if (diesToCurse(c, -x)) {
+                atk.removeBlocker(c);
+            }
+        }
+        for (final Card c : own) {
+            if (diesToCurse(c, -x)) {
+                atk.removeAttacker(c);
+            }
+        }
+
+        final Combat planned = new Combat(ai);
+        atk.declareAttackers(planned);
+        for (final Player opp : ai.getOpponents()) {
+            final int attacking = planned.getAttackersOf(opp).size();
+            if (attacking > 0 && ComputerUtilCombat.lifeThatWouldRemain(opp, planned) - boost * attacking <= 0) {
+                return true;
+            }
+        }
+        return false;
     }
 
     boolean pumpAgainstRemoval(Player ai, SpellAbility sa, List<Card> comp) {

--- a/forge-ai/src/main/java/forge/ai/ability/PumpAllAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/PumpAllAi.java
@@ -79,16 +79,18 @@ public class PumpAllAi extends PumpAiBase {
         final String valid = sa.getParamOrDefault("ValidCards", "");
 
         CardCollection comp = CardLists.getValidCards(ai.getCardsIn(ZoneType.Battlefield), valid, source.getController(), source, sa);
-        // A mass pump lands on every opponent's board at once, so weigh all of them. In a two
-        // player game this is the same list getStrongestOpponent() was giving.
-        CardCollection human = CardLists.getValidCards(ai.getOpponents().getCardsIn(ZoneType.Battlefield), valid, source.getController(), source, sa);
+        CardCollection human = CardLists.getValidCards(opp.getCardsIn(ZoneType.Battlefield), valid, source.getController(), source, sa);
+        // Choosing X needs every board the sweep actually lands on, not just the strongest
+        // opponent's. The card-value comparison further down keeps the narrower list on purpose:
+        // its +200 margin is calibrated against one opponent and does not rescale to a sum.
+        CardCollection allFoes = CardLists.getValidCards(ai.getOpponents().getCardsIn(ZoneType.Battlefield), valid, source.getController(), source, sa);
 
         // Nothing else announces X for a -X/-X sweep: PumpAll has an AI class, so the generic X
         // handling in AiController is skipped, and on cards like Toxic Deluge the X lives in a
         // non-mana cost (PayLife<X>) that path would not see either. Without this the amounts
         // below both read 0 and the sweep evaluates as -0/-0.
         if (sa.isCurse() && usesPaidX(sa)) {
-            final SweepChoice sweep = chooseXForSweep(ai, sa, comp, human);
+            final SweepChoice sweep = chooseXForSweep(ai, sa, comp, allFoes);
             if (sweep.x() <= 0) {
                 return new AiAbilityDecision(0, AiPlayDecision.CantPlayAi);
             }
@@ -203,20 +205,21 @@ public class PumpAllAi extends PumpAiBase {
      * Returns 0 when no value of X is worth casting at, so the caller can bail out.
      */
     private SweepChoice chooseXForSweep(final Player ai, final SpellAbility sa, final CardCollection own, final CardCollection foes) {
-        // Also sets X to its maximum, which is what the amounts would otherwise be read at.
-        final int maxX = ComputerUtilCost.setMaxXValue(sa, ai, sa.isTrigger());
-        if (maxX <= 0) {
-            return new SweepChoice(0, false);
+        // An X past the toughest thing we want dead kills no more of theirs and only more of ours,
+        // so it can never score better. That bounds the scan without asking what we can pay.
+        int worthwhile = 0;
+        for (Card c : foes) {
+            worthwhile = Math.max(worthwhile, Math.max(c.getNetToughness(), ComputerUtilCombat.getDamageToKill(c, false)));
         }
 
         // Which creatures die only changes at the toughnesses actually on the battlefield, so try
-        // those values instead of every point up to maxX - otherwise the AI walks its whole life
-        // total one point at a time to reach the same answer. A superset is fine; diesToCurse stays
-        // the single authority on what any given X actually kills.
+        // those values instead of every point up to the bound - otherwise the AI walks its whole
+        // life total one point at a time to reach the same answer. A superset is fine; diesToCurse
+        // stays the single authority on what any given X actually kills.
         final SortedSet<Integer> candidates = new TreeSet<>();
         for (Card c : Iterables.concat(own, foes)) {
-            addCandidate(candidates, c.getNetToughness(), maxX);
-            addCandidate(candidates, ComputerUtilCombat.getDamageToKill(c, false), maxX);
+            addCandidate(candidates, c.getNetToughness(), worthwhile);
+            addCandidate(candidates, ComputerUtilCombat.getDamageToKill(c, false), worthwhile);
         }
 
         final boolean paysLife = paysLifeForX(sa);
@@ -243,6 +246,23 @@ public class PumpAllAi extends PumpAiBase {
             if (cheapestLethal == 0 && couldReachLethal(ai, own, x, pumps && ourTurn ? x : 0)) {
                 cheapestLethal = x;
             }
+        }
+
+        // Asking what we can pay is the expensive part of this method - a mana solver call, about
+        // 4ms on a wide board - so it waits until the arithmetic above has found something worth
+        // paying for. The answer only ever narrows the candidates, so deferring it cannot change
+        // which X is chosen; on a board where the sweep can do nothing it is never made at all.
+        if (scores.isEmpty() && cheapestLethal == 0) {
+            return new SweepChoice(0, false);
+        }
+        final int maxX = ComputerUtilCost.setMaxXValue(sa, ai, sa.isTrigger());
+        if (maxX <= 0) {
+            return new SweepChoice(0, false);
+        }
+        scores.keySet().removeIf(x -> x > maxX);
+        // cheapestLethal is the smallest X that reached, so if it is unaffordable none below it is.
+        if (cheapestLethal > maxX) {
+            cheapestLethal = 0;
         }
 
         // Mirrors DamageAllAi: a sweep that just wins beats any card-value comparison. Only the

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/PumpAllAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/PumpAllAiTest.java
@@ -1,0 +1,107 @@
+package forge.ai.ability;
+
+import forge.ai.AITest;
+import forge.ai.SpellApiToAi;
+import forge.game.Game;
+import forge.game.ability.ApiType;
+import forge.game.card.Card;
+import forge.game.phase.PhaseType;
+import forge.game.player.Player;
+import forge.game.spellability.SpellAbility;
+import forge.game.trigger.Trigger;
+import forge.game.zone.ZoneType;
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+public class PumpAllAiTest extends AITest {
+
+    @Test
+    public void testToxicDelugeSweepsOpponentBoard() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+
+        addCards("Swamp", 3, ai);
+        Card deluge = addCardToZone("Toxic Deluge", ai, ZoneType.Hand);
+        addCards("Grizzly Bears", 3, opponent);
+
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN1, ai);
+        game.getAction().checkStateEffects(true);
+
+        SpellAbility sa = findPumpAllAbility(deluge);
+        AssertJUnit.assertNotNull("Toxic Deluge should have a PumpAll spell ability", sa);
+        sa.setActivatingPlayer(ai);
+
+        AssertJUnit.assertTrue("AI should cast Toxic Deluge to sweep an opposing board it does not share",
+                SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay());
+        AssertJUnit.assertEquals("AI should pay exactly enough life to kill 2/2s",
+                Integer.valueOf(2), sa.getXManaCostPaid());
+    }
+
+    @Test
+    public void testFlowstoneSlideSweepsForItsManaX() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+
+        addCards("Mountain", 6, ai);
+        Card slide = addCardToZone("Flowstone Slide", ai, ZoneType.Hand);
+        addCards("Grizzly Bears", 3, opponent);
+
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN1, ai);
+        game.getAction().checkStateEffects(true);
+
+        SpellAbility sa = findPumpAllAbility(slide);
+        AssertJUnit.assertNotNull("Flowstone Slide should have a PumpAll spell ability", sa);
+        sa.setActivatingPlayer(ai);
+
+        // +X/-X, so unlike Toxic Deluge the survivors get power out of it - which only counts
+        // against the AI on a turn the opponent still has a combat left.
+        AssertJUnit.assertTrue("AI should cast Flowstone Slide to sweep an opposing board",
+                SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay());
+        AssertJUnit.assertEquals("AI should pay the cheapest X that kills 2/2s",
+                Integer.valueOf(2), sa.getXManaCostPaid());
+    }
+
+    @Test
+    public void testAlreadyPaidXOnATriggerIsNotReannounced() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+
+        addCards("Grizzly Bears", 3, opponent);
+        Card meathook = addCard("The Meathook Massacre", ai);
+
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN1, ai);
+        game.getAction().checkStateEffects(true);
+
+        SpellAbility sa = null;
+        for (Trigger t : meathook.getTriggers()) {
+            SpellAbility overriding = t.getOverridingAbility();
+            if (overriding != null && overriding.getApi() == ApiType.PumpAll) {
+                sa = overriding;
+                break;
+            }
+        }
+        AssertJUnit.assertNotNull("The Meathook Massacre should have a PumpAll trigger", sa);
+
+        // X here was paid when the enchantment was cast. Trying to re-announce it finds no X in the
+        // trigger's own cost and yields nothing to pay, which would make the AI refuse the trigger.
+        sa.setActivatingPlayer(ai);
+        sa.setXManaCostPaid(3);
+
+        AssertJUnit.assertTrue("AI should take a trigger that wipes the opposing board",
+                SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay());
+        AssertJUnit.assertEquals("X paid on casting must survive the AI's evaluation of the trigger",
+                Integer.valueOf(3), sa.getXManaCostPaid());
+    }
+
+    private SpellAbility findPumpAllAbility(Card card) {
+        for (SpellAbility sa : card.getSpellAbilities()) {
+            if (sa.getApi() == ApiType.PumpAll) {
+                return sa;
+            }
+        }
+        return null;
+    }
+}

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/PumpAllAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/PumpAllAiTest.java
@@ -1,0 +1,170 @@
+package forge.ai.ability;
+
+import forge.ai.AITest;
+import forge.ai.SpellApiToAi;
+import forge.game.Game;
+import forge.game.ability.ApiType;
+import forge.game.card.Card;
+import forge.game.phase.PhaseType;
+import forge.game.player.Player;
+import forge.game.spellability.SpellAbility;
+import forge.game.trigger.Trigger;
+import forge.game.zone.ZoneType;
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+public class PumpAllAiTest extends AITest {
+
+    @Test
+    public void testToxicDelugeSweepsOpponentBoard() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+
+        addCards("Swamp", 3, ai);
+        Card deluge = addCardToZone("Toxic Deluge", ai, ZoneType.Hand);
+        addCards("Grizzly Bears", 3, opponent);
+
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN1, ai);
+        game.getAction().checkStateEffects(true);
+
+        SpellAbility sa = findPumpAllAbility(deluge);
+        AssertJUnit.assertNotNull("Toxic Deluge should have a PumpAll spell ability", sa);
+        sa.setActivatingPlayer(ai);
+
+        AssertJUnit.assertTrue("AI should cast Toxic Deluge to sweep an opposing board it does not share",
+                SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay());
+        AssertJUnit.assertEquals("AI should pay exactly enough life to kill 2/2s",
+                Integer.valueOf(2), sa.getXManaCostPaid());
+    }
+
+    @Test
+    public void testFlowstoneSlideSweepsForItsManaX() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+
+        addCards("Mountain", 6, ai);
+        Card slide = addCardToZone("Flowstone Slide", ai, ZoneType.Hand);
+        addCards("Grizzly Bears", 3, opponent);
+
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN1, ai);
+        game.getAction().checkStateEffects(true);
+
+        SpellAbility sa = findPumpAllAbility(slide);
+        AssertJUnit.assertNotNull("Flowstone Slide should have a PumpAll spell ability", sa);
+        sa.setActivatingPlayer(ai);
+
+        // +X/-X, so unlike Toxic Deluge the survivors get power out of it - which only counts
+        // against the AI on a turn the opponent still has a combat left.
+        AssertJUnit.assertTrue("AI should cast Flowstone Slide to sweep an opposing board",
+                SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay());
+        AssertJUnit.assertEquals("AI should pay the cheapest X that kills 2/2s",
+                Integer.valueOf(2), sa.getXManaCostPaid());
+    }
+
+    @Test
+    public void testAlreadyPaidXOnATriggerIsNotReannounced() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+
+        addCards("Grizzly Bears", 3, opponent);
+        Card meathook = addCard("The Meathook Massacre", ai);
+
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN1, ai);
+        game.getAction().checkStateEffects(true);
+
+        SpellAbility sa = null;
+        for (Trigger t : meathook.getTriggers()) {
+            SpellAbility overriding = t.getOverridingAbility();
+            if (overriding != null && overriding.getApi() == ApiType.PumpAll) {
+                sa = overriding;
+                break;
+            }
+        }
+        AssertJUnit.assertNotNull("The Meathook Massacre should have a PumpAll trigger", sa);
+
+        // X here was paid when the enchantment was cast. Trying to re-announce it finds no X in the
+        // trigger's own cost and yields nothing to pay, which would make the AI refuse the trigger.
+        sa.setActivatingPlayer(ai);
+        sa.setXManaCostPaid(3);
+
+        AssertJUnit.assertTrue("AI should take a trigger that wipes the opposing board",
+                SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay());
+        AssertJUnit.assertEquals("X paid on casting must survive the AI's evaluation of the trigger",
+                Integer.valueOf(3), sa.getXManaCostPaid());
+    }
+
+    @Test
+    public void aiSweepsAnOpposingBoardInARealTurn() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+
+        addCards("Swamp", 6, ai);
+        addCardToZone("Toxic Deluge", ai, ZoneType.Hand);
+        addCards("Grizzly Bears", 3, opponent);
+        fillLibrary(ai, 10);
+        fillLibrary(opponent, 10);
+
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN1, ai);
+        game.getAction().checkStateEffects(true);
+        playUntilNextTurn(game);
+
+        AssertJUnit.assertEquals("the sweep should have resolved and killed the 2/2s",
+                0, countCardsWithName(game, "Grizzly Bears", ZoneType.Battlefield));
+        AssertJUnit.assertEquals("paying only the life the kill needed", 18, ai.getLife());
+    }
+
+    @Test
+    public void aiSweepsForFlowstoneSlideInARealTurn() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+
+        addCards("Mountain", 8, ai);
+        addCardToZone("Flowstone Slide", ai, ZoneType.Hand);
+        addCards("Grizzly Bears", 3, opponent);
+        fillLibrary(ai, 10);
+        fillLibrary(opponent, 10);
+
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN1, ai);
+        game.getAction().checkStateEffects(true);
+        playUntilNextTurn(game);
+
+        AssertJUnit.assertEquals("the sweep should have resolved and killed the 2/2s",
+                0, countCardsWithName(game, "Grizzly Bears", ZoneType.Battlefield));
+    }
+
+    @Test
+    public void aiPicksAnXThatSparesItsOwnBoard() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+
+        addCards("Swamp", 6, ai);
+        addCardToZone("Toxic Deluge", ai, ZoneType.Hand);
+        addCards("Grizzly Bears", 3, opponent);
+        addCards("Hill Giant", 2, ai);
+        fillLibrary(ai, 10);
+        fillLibrary(opponent, 10);
+
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN1, ai);
+        game.getAction().checkStateEffects(true);
+        playUntilNextTurn(game);
+
+        AssertJUnit.assertEquals("the 2/2s it was aimed at should be gone",
+                0, countCardsWithName(game, "Grizzly Bears", ZoneType.Battlefield));
+        AssertJUnit.assertEquals("its own 3/3s should survive the X it chose",
+                2, countCardsWithName(game, "Hill Giant", ZoneType.Battlefield));
+    }
+    private SpellAbility findPumpAllAbility(Card card) {
+        for (SpellAbility sa : card.getSpellAbilities()) {
+            if (sa.getApi() == ApiType.PumpAll) {
+                return sa;
+            }
+        }
+        return null;
+    }
+}

--- a/forge-gui/res/cardsfolder/f/flowstone_slide.txt
+++ b/forge-gui/res/cardsfolder/f/flowstone_slide.txt
@@ -3,5 +3,4 @@ ManaCost:X 2 R R
 Types:Sorcery
 A:SP$ PumpAll | ValidCards$ Creature | IsCurse$ True | NumAtt$ +X | NumDef$ -X | SpellDescription$ All creatures get +X/-X until end of turn.
 SVar:X:Count$xPaid
-AI:RemoveDeck:All
 Oracle:All creatures get +X/-X until end of turn.

--- a/forge-gui/res/cardsfolder/t/toxic_deluge.txt
+++ b/forge-gui/res/cardsfolder/t/toxic_deluge.txt
@@ -1,7 +1,6 @@
 Name:Toxic Deluge
 ManaCost:2 B
 Types:Sorcery
-A:SP$ PumpAll | Cost$ 2 B PayLife<X> | ValidCards$ Creature | NumAtt$ -X | NumDef$ -X | SpellDescription$ All creatures get -X/-X until end of turn.
+A:SP$ PumpAll | Cost$ 2 B PayLife<X> | ValidCards$ Creature | NumAtt$ -X | NumDef$ -X | IsCurse$ True | SpellDescription$ All creatures get -X/-X until end of turn.
 SVar:X:Count$xPaid
-AI:RemoveDeck:All
 Oracle:As an additional cost to cast this spell, pay X life.\nAll creatures get -X/-X until end of turn.


### PR DESCRIPTION
Both cards carry `AI:RemoveDeck:All` — the AI is not allowed to play them at all.

## What a reviewer can check

`PumpAllAiTest` has five assertions and all five fail without this change. Two go through
`canPlaySa` for the X the AI chooses. Three play a real turn with `playUntilNextTurn` and check
the board it left behind: that the sweep resolved, that Toxic Deluge paid only the 2 life the
kill needed, and that the X it picked spared its own 3/3s while killing the opponent's 2/2s.

## Why the flag removal cannot ship on its own

With only the script changes on current master, the AI casts both spells for X=0 and puts them
in the graveyard having killed nothing:

```
Flowstone Slide  endedIn=Graveyard  bearsSurviving=3  aiLife=20
Toxic Deluge     endedIn=Graveyard  bearsSurviving=3  aiLife=20
```

`AI:RemoveDeck:All` was load-bearing — it was protecting the AI from a card it would waste. The
flag comes off only because the X selection goes in.

## The cause

Their X is announced as a cost and nothing ever chose it: `PumpAll` has an AI class, so
`AiController`'s generic X handling is skipped, and Toxic Deluge's X lives in a `PayLife<X>`
cost that path would not have seen anyway. Toxic Deluge was also missing `IsCurse$ True`, so
`PumpAllAi` never reached its sweeper branch and instead asked whether to pump the AI's own
creatures.

## The fix

`PumpAllAi` picks X for a -X/-X sweep when the ability announces its own X, scoring by what each
value destroys. Candidates are the toughnesses actually on the battlefield rather than every
point up to the maximum, so the AI does not walk a 40 point life total one step at a time.

Rather than reimplementing combat reasoning, the two questions it needs go to the code that
already answers them. Whether the swing simply wins goes to the attack planner, which knows
about fog, evasion and `cantWin`. Whether the AI lives through the counterattack goes to
`predictNextCombatsRemainingLife`, which models the blocks it will make — asked only when the
sweep is not lethal and a cheap pessimistic bound says the survivors could get there.

Each needed one small addition, in its own commit: a counterpart to `removeBlocker` for our own
creatures, and a way to tell combat prediction which attackers a wipe removes.

### Multiplayer: which boards a sweep is weighed against

`checkApiLogic` weighs a sweep against `getStrongestOpponent()`. For choosing X that undercounts:
a mass -X/-X lands on every opponent's board at once, so the X worth paying for is the one
measured against all of them. The X selection here takes the full list.

The pre-existing card-value comparison keeps the narrower list deliberately. Its margin

```java
(evaluateCreatureList(comp) + 200) < evaluateCreatureList(human)
```

is calibrated against a single opponent and does not rescale to a sum. With `human` summed over
the table the test becomes "am I behind the combined board", which the leader usually is.
Measured in a three-player game with the wider list feeding it: an AI holding the single best
board, four Hill Giants against three and three, sweeps and destroys its own four. With the
narrower list it declines and develops.

So the split is on purpose. The margin looks worth revisiting on its own terms, but that is not
this PR's to change.

Best read commit by commit — a shared predicate, the two enabling additions, the fix, then
tests. 363 tests, 0 checkstyle violations.

🤖 Implemented with the assistance of Claude Code (Opus 5).

