### PR TITLE
Fix AI X sizing that left Curse of the Swine and Distorting Wake uncastable

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/ChangeZoneAi.java
@@ -1116,6 +1116,16 @@ public class ChangeZoneAi extends SpellAbilityAi {
         // the Unless cost (for example, Erratic Portal)
         list.removeAll(getSafeTargetsIfUnlessCostPaid(ai, sa, list));
 
+        // X was sized against every legal target, but the list has since been narrowed to the ones
+        // the AI actually wants - usually just the opponents' permanents. Bring X down to match
+        // before the check below, otherwise controlling a single targetable permanent of its own is
+        // enough to make the AI refuse a spell it would happily cast for less.
+        if (!mandatory && "X".equals(sa.getTargetRestrictions().getMinTargets())
+                && "Count$xPaid".equals(sa.getSVar("X"))
+                && sa.getXManaCostPaid() != null && sa.getXManaCostPaid() > list.size()) {
+            sa.setXManaCostPaid(list.size());
+        }
+
         if (!mandatory && list.size() < sa.getMinTargets()) {
             return false;
         }

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/ChangeZoneAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/ChangeZoneAiTest.java
@@ -1,0 +1,57 @@
+package forge.ai.ability;
+
+import forge.ai.AITest;
+import forge.ai.SpellApiToAi;
+import forge.game.Game;
+import forge.game.ability.ApiType;
+import forge.game.card.Card;
+import forge.game.phase.PhaseType;
+import forge.game.player.Player;
+import forge.game.spellability.SpellAbility;
+import forge.game.zone.ZoneType;
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+public class ChangeZoneAiTest extends AITest {
+
+    @Test
+    public void testXTargetCountIgnoresTheAisOwnPermanents() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opponent = game.getPlayers().get(0);
+
+        addCards("Island", 12, ai);
+        // Distorting Wake targets any nonland permanent, so everything here is a legal target, but
+        // the AI only wants the opponent's. Its own used to inflate X past the number it would
+        // actually target, leaving it unable to cast the spell at all.
+        addCard("Ornithopter", ai);
+        addCard("Sol Ring", ai);
+        addCard("Runeclaw Bear", ai);
+
+        addCard("Colossal Dreadmaw", opponent);
+        addCard("Ancient Brontodon", opponent);
+
+        Card wake = addCardToZone("Distorting Wake", ai, ZoneType.Hand);
+        game.getPhaseHandler().devModeSet(PhaseType.MAIN2, ai);
+        game.getAction().checkStateEffects(true);
+
+        SpellAbility sa = null;
+        for (SpellAbility s : wake.getSpellAbilities()) {
+            if (s.getApi() == ApiType.ChangeZone) {
+                sa = s;
+                break;
+            }
+        }
+        AssertJUnit.assertNotNull("Distorting Wake should have a ChangeZone spell ability", sa);
+        sa.setActivatingPlayer(ai);
+
+        AssertJUnit.assertTrue("AI should still cast an X-targeting bounce while it controls permanents",
+                SpellApiToAi.Converter.get(sa).canPlayWithSubs(ai, sa).willingToPlay());
+        AssertJUnit.assertEquals("X should match the permanents the AI actually wants to target",
+                Integer.valueOf(2), sa.getXManaCostPaid());
+        for (Card t : sa.getTargets().getTargetCards()) {
+            AssertJUnit.assertFalse("AI should never target its own permanent with this",
+                    t.getController().equals(ai));
+        }
+    }
+}


### PR DESCRIPTION
On spells whose target count is X, the AI sizes X against every legal target and then narrows the targets — leaving X too big to satisfy, so it declines the spell entirely.

`ComputerUtilCost.setMaxXValue` caps X using `CardUtil.getValidCardsToTarget`, which counts everything legal. Later in `ChangeZoneAi.isPreferredTarget` the candidate list is narrowed to what the AI actually wants, which for exile and bounce effects is the opponents' permanents only. X is already fixed by then, so the `list.size() < sa.getMinTargets()` check below it fails.

The practical effect: controlling **one** targetable permanent of its own is enough to make these spells uncastable.

## Distorting Wake, before this change

It targets any nonland permanent, so any creature, artifact, enchantment or planeswalker triggers it. Opponent held two permanents throughout:

| AI's own nonland permanents | 0 | 1 | 2 | 3 | 5 |
|---|---|---|---|---|---|
| X chosen | 2 | 3 | 4 | 5 | 7 |
| casts? | yes | **no** | **no** | **no** | **no** |

X visibly tracks the whole battlefield rather than the opponent's side. It is not gated on having spare mana either — the same happens on four lands.

Distorting Wake carries no `AI:RemoveDeck` flag, so this is a card the AI is allowed to run today and cannot cast.

## The change

Re-cap X to the size of the narrowed list, immediately before that check. The AI then pays for exactly the permanents it wants and casts normally. It targets only the opponents' permanents, as it did before.

## Verified

Before and after, by reverting the change and re-running:

| Card | Flagged | Before (AI controls 3 permanents) | After |
|---|---|---|---|
| Distorting Wake | no | declines, X=5 | casts, X=2 |
| Curse of the Swine | `All` | declines, X=5 | casts, X=2 |
| Aether Tide | `All` | declines, X=5 | casts, X=2 |
| Alexi, Zephyr Mage | `All` | declines | still declines — unrelated |
| Vengeful Dreams | `All` | declines | still declines — unrelated |

The last two are untouched by this and remain broken for their own reasons.

245 tests green across `ChangeZoneAiTest`, the simulation suites, and the AI ability and combat tests.

## Scope

I have deliberately not removed any `AI:RemoveDeck:All` flags. Making these castable is a separate question from whether the AI plays them well, and Curse of the Swine still has a wart worth judging in real games first: when an opponent's only creatures are small, it will still exile them, and a 2/2 Boar is close to an even swap.

This is the non-simulation AI only. The simulation AI arrives at a similarly oversized X by a different route — `SpellAbilityChoicesIterator.announceX` always takes the maximum, with a standing TODO about iterating over values for performance reasons — and shares no decision code with these AI classes, so it is unaffected either way. Fixing that means widening a combinatorial search and belongs in its own change.

---

Written with Claude Code (Opus 4.8), per the AI coding agent guidance in CONTRIBUTING.md; also recorded as a commit co-author.
