### PR TITLE
Don't rebuild the string on every creature type check

### DIFF
--- a/forge-core/src/main/java/forge/card/CardType.java
+++ b/forge-core/src/main/java/forge/card/CardType.java
@@ -407,6 +407,13 @@ public final class CardType implements Comparable<CardType>, CardTypeView {
         if (s.isEmpty()) {
             return s;
         }
+        // With no hyphen to split on and a first character capitalize would leave alone, the
+        // loop below reassembles the argument unchanged - which is the case for every type name
+        // written the way a card script writes it. Skip the round trip through the StringBuilder.
+        final int first = s.codePointAt(0);
+        if (s.indexOf('-') < 0 && Character.toTitleCase(first) == first) {
+            return s;
+        }
         final StringBuilder sb = new StringBuilder();
         // to handle hyphenated Types
         // TODO checkout WordUtils for this


### PR DESCRIPTION
`CardType.hasCreatureType` normalises its argument through `toMixedCase`, which splits on `-`, capitalises each part and reassembles them through a `StringBuilder`. Callers overwhelmingly pass a name that is already in that form — a literal out of a card script, or a constant — so the whole thing allocates a `String[]`, a `StringBuilder` and a result `String` only to hand back a copy of its input.

It is a hot primitive. `hasCreatureType` sits under `hasSubtype`, which `CardStateProperty` consults for every `Valid$` clause the engine evaluates, and `CardState.getReplacementEffects` calls it three times per card per replacement scan.

Counted over a headless two-player game: **404453 calls in 1.27s of play, every one of which produced a string equal to its argument.**

### The change

Return the argument unchanged when the loop provably reassembles it: no hyphen to split on, and a leading code point `StringUtils.capitalize` would leave alone. Everything else still takes the existing path.

This is not a cache — there is no state and nothing to invalidate. It is the condition under which the existing code is the identity function.

The second half of that condition is `toTitleCase(cp) == cp`, which is the test `capitalize` itself makes. It is deliberately not `isUpperCase`: those disagree for the Latin digraphs U+01C4/01C7/01CA/01F1, whose titlecase form differs from their uppercase form, and using `isUpperCase` would genuinely change the output for them.

Verified by differential comparison against the old implementation over every defined code point in seven positions (leading, embedded, hyphenated, leading/trailing hyphen, double hyphen) plus the literals the engine actually passes — **2021386 inputs, no difference in output**. The `isUpperCase` variant fails 8 of those; this one fails none.

### Effect on a match

Eight seeded AI-vs-AI matches (`MyRandom.setRandom`, green creature mirror, 30-turn cap), each run twice before and twice after:

| seed | outcome | before (ms) | after (ms) | Δ |
|---|---|---|---|---|
| 101 | p2 wins T16 | 3243 / 3324 | 3326 / 2986 | −3.9% |
| 102 | p1 wins T15 | 2679 / 2726 | 2472 / 2340 | −11.0% |
| 103 | p1 wins T13 | 1425 / 1547 | 1311 / 1190 | −15.8% |
| 104 | cap T30 | 6488 / 6947 | 6343 / 5730 | −10.1% |
| 105 | cap T30, big boards | 28897 / 29313 | 27845 / 26780 | −6.2% |
| 106 | cap T30, big boards | 30683 / 31612 | 29084 / 29593 | −5.8% |
| 107 | cap T30, big boards | 16363 / 17734 | 15302 / 15683 | −9.1% |
| 108 | p1 wins T17 | 2555 / 2813 | 2269 / 2290 | −15.1% |
| **total** | | **92333 / 96016** | **87952 / 86592** | **−7.3%** |

All four runs produced identical per-seed fingerprints — same step count, turn, winner, life totals, graveyard sizes and board power — so the workload really is the same one before and after, and the change is visible only in the clock. The distributions do not overlap: the slowest run with the change beats the fastest without it. Run-to-run noise on the total is ~1.6%.

Short games gain most and big-board games least, which fits the mechanism: late-game time goes into combat and evaluation code where this primitive is a smaller share. The three turn-capped games are 77% of the total, so the aggregate is the pessimistic weighting.

Caveat: one deck archetype, two players, eight seeds, one machine. A real workload, but one workload.

### Notes

- No new tests. The differential check above was a throwaway — an exhaustive Unicode sweep of a five-line private method is CI weight for something the type system and the two conditions already pin down, and the contributing guide asks agents not to add that. Happy to add a small targeted one if you would rather have it.
- 286 existing tests green.

---

Written with Claude Code (Opus 4.8), per the AI coding agent guidance in CONTRIBUTING.md; also recorded as a commit co-author.
