### PR TITLE
Let the AI play three fight cards it was flagged out of

### DIFF
--- a/forge-gui/res/cardsfolder/c/contested_cliffs.txt
+++ b/forge-gui/res/cardsfolder/c/contested_cliffs.txt
@@ -2,7 +2,6 @@ Name:Contested Cliffs
 ManaCost:no cost
 Types:Land
 A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
-A:AB$ Pump | Cost$ R G T | ValidTgts$ Creature.Beast+YouCtrl | TgtPrompt$ Choose target Beast creature you control | SubAbility$ FightForTheCliffs | StackDescription$ None | SpellDescription$ Target Beast creature you control fights target creature an opponent controls. (Each deals damage equal to its power to the other.)
+A:AB$ Pump | Cost$ R G T | ValidTgts$ Creature.Beast+YouCtrl | TgtPrompt$ Choose target Beast creature you control | SubAbility$ FightForTheCliffs | AILogic$ Fight | StackDescription$ None | SpellDescription$ Target Beast creature you control fights target creature an opponent controls. (Each deals damage equal to its power to the other.)
 SVar:FightForTheCliffs:DB$ Fight | Defined$ ParentTarget | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Choose target creature an opponent controls
-AI:RemoveDeck:All
 Oracle:{T}: Add {C}.\n{R}{G}, {T}: Target Beast creature you control fights target creature an opponent controls. (Each deals damage equal to its power to the other.)

--- a/forge-gui/res/cardsfolder/t/triangle_of_war.txt
+++ b/forge-gui/res/cardsfolder/t/triangle_of_war.txt
@@ -1,7 +1,6 @@
 Name:Triangle of War
 ManaCost:1
 Types:Artifact
-A:AB$ Pump | Cost$ 2 Sac<1/CARDNAME> | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Choose target creature you control | SubAbility$ DBFight | SpellDescription$ Target creature you control fights target creature an opponent controls. (Each deals damage equal to its power to the other.)
+A:AB$ Pump | Cost$ 2 Sac<1/CARDNAME> | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Choose target creature you control | SubAbility$ DBFight | AILogic$ Fight | SpellDescription$ Target creature you control fights target creature an opponent controls. (Each deals damage equal to its power to the other.)
 SVar:DBFight:DB$ Fight | Defined$ ParentTarget | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Choose target creature an opponent controls
-AI:RemoveDeck:All
 Oracle:{2}, Sacrifice Triangle of War: Target creature you control fights target creature an opponent controls. (Each deals damage equal to its power to the other.)

--- a/forge-gui/res/cardsfolder/u/ulvenwald_tracker.txt
+++ b/forge-gui/res/cardsfolder/u/ulvenwald_tracker.txt
@@ -2,7 +2,6 @@ Name:Ulvenwald Tracker
 ManaCost:G
 Types:Creature Human Shaman
 PT:1/1
-A:AB$ Pump | Cost$ 1 G T | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | SubAbility$ TrackerFight | StackDescription$ None | SpellDescription$ Target creature you control fights another target creature.
+A:AB$ Pump | Cost$ 1 G T | ValidTgts$ Creature.YouCtrl | TgtPrompt$ Select target creature you control | SubAbility$ TrackerFight | AILogic$ Fight | StackDescription$ None | SpellDescription$ Target creature you control fights another target creature.
 SVar:TrackerFight:DB$ Fight | Defined$ ParentTarget | ValidTgts$ Creature | TargetUnique$ True | TgtPrompt$ Select another target creature
-AI:RemoveDeck:All
 Oracle:{1}{G}, {T}: Target creature you control fights another target creature.


### PR DESCRIPTION
Three fight cards were flagged `AI:RemoveDeck:All` because the AI would never activate them.

## Cause

Each scripts its fight as an `AB$ Pump` shell whose sub-ability is the actual `DB$ Fight`:

```
A:AB$ Pump | ... | ValidTgts$ Creature.YouCtrl | SubAbility$ ...Fight | ...
SVar:...Fight:DB$ Fight | Defined$ ParentTarget | ValidTgts$ Creature.OppCtrl | ...
```

None declares `AILogic$ Fight`. Without it:

- `PumpAi.checkApiLogic` never sets `isFight`, so it evaluates an empty pump (no `NumAtt`/`NumDef`) — nothing worth doing.
- `PumpAi.checkPhaseRestrictions` treats it as an instant-speed pump and refuses it in the main phases when the stack is empty, as if it were a combat trick being wasted. The AI returns `MissingPhaseRestrictions`.

So the ability is never used, and the `AI:RemoveDeck:All` follows.

`Vivien, Arkbow Ranger` and `Domri Rade` use the identical Pump+Fight shell **with** `AILogic$ Fight` and play fine, which is what pointed at the fix.

## Change

Add `AILogic$ Fight` to the three, and drop the now-stale `AI:RemoveDeck:All`:

| Card | Type |
|---|---|
| Ulvenwald Tracker | 1-drop, repeatable |
| Contested Cliffs | land, repeatable |
| Triangle of War | artifact, one-shot |

## Verified

Each probed on three boards (`canPlayWithSubs`, MAIN2):

| board | decision |
|---|---|
| own 6/6 vs opponent's 2/2 | casts — targets its own fighter and the opponent's creature |
| own 2/2 into opponent's 6/6 | declines |
| own 2/2 into opponent's 2/2 (even) | declines |

They share the `PumpAi` fight logic, so the good/bad judgement is common to all three. Full desktop suite green (286).

`Wayta, Trainer Prodigy` uses the same shell but is not flagged and has an extra "fight two of your own creatures" cost-reduction mode, so it is deliberately out of scope here.

---

Written with Claude Code (Opus 4.8), per the AI coding agent guidance in CONTRIBUTING.md; also recorded as a commit co-author.
