### PR TITLE
Add Adventure settings option to start directly in Adventure mode

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/scene/SettingsScene.java
+++ b/forge-gui-mobile/src/forge/adventure/scene/SettingsScene.java
@@ -35,6 +35,7 @@ public class SettingsScene extends UIScene {
     TextraButton backButton;
     TextraButton newPlane;
     ScrollPane scrollPane;
+    CheckBox startInAdventure;
 
     SelectBox<String> selectSourcePlane;
     TextField newPlaneName;
@@ -124,6 +125,19 @@ public class SettingsScene extends UIScene {
         settingGroup.add(plane).align(Align.right).pad(2);
         //addLabel(Forge.getLocalizer().getMessage("lblCreate") + Forge.getLocalizer().getMessage("lblWorld"));
         settingGroup.add(newPlane).align(Align.right).pad(2);
+
+        startInAdventure = addSettingField(
+                Forge.getLocalizer().getMessage("lblStartInAdventureMode"),
+                "Adventure".equalsIgnoreCase(FModel.getPreferences().getPref(ForgePreferences.FPref.UI_SELECTOR_MODE)),
+                new ChangeListener() {
+                    @Override
+                    public void changed(ChangeEvent event, Actor actor) {
+                        String startupMode = ((CheckBox) actor).isChecked() ? "Adventure" : "Default";
+                        FModel.getPreferences().setPref(ForgePreferences.FPref.UI_SELECTOR_MODE, startupMode);
+                        FModel.getPreferences().save();
+                        Forge.selector = startupMode;
+                    }
+                });
 
         if (!GuiBase.isAndroid()) {
             SelectBox<String> videomode = Controls.newComboBox(ForgeConstants.VIDEO_MODES, Config.instance().getSettingData().videomode, o -> {
@@ -381,6 +395,15 @@ public class SettingsScene extends UIScene {
         return true;
     }
 
+    @Override
+    public void enter() {
+        startInAdventure.setProgrammaticChangeEvents(false);
+        startInAdventure.setChecked("Adventure".equalsIgnoreCase(
+                FModel.getPreferences().getPref(ForgePreferences.FPref.UI_SELECTOR_MODE)));
+        startInAdventure.setProgrammaticChangeEvents(true);
+        super.enter();
+    }
+
     private void addInputField(String name, ForgePreferences.FPref pref) {
         TextField box = Controls.newTextField("");
         box.setText(FModel.getPreferences().getPref(pref));
@@ -434,12 +457,13 @@ public class SettingsScene extends UIScene {
         settingGroup.add(slide).align(Align.right);
     }
 
-    private void addSettingField(String name, boolean value, ChangeListener change) {
+    private CheckBox addSettingField(String name, boolean value, ChangeListener change) {
         CheckBox box = Controls.newCheckBox("");
         box.setChecked(value);
         box.addListener(change);
         addLabel(name);
         settingGroup.add(box).align(Align.right);
+        return box;
     }
 
     private void addSettingField(String name, int value, ChangeListener change) {

--- a/forge-gui/res/languages/en-US.properties
+++ b/forge-gui/res/languages/en-US.properties
@@ -1262,6 +1262,7 @@ lblVideoMode=Video Mode
 nlVideoMode=Applies the selected video mode option.
 lblSelectorMode=Selector Mode
 nlSelectorMode=Applies the selected mode at startup (Default enables the selector, Classic or Adventure option opens their main screen at startup).
+lblStartInAdventureMode=Start in Adventure mode (applies on next launch)
 lblShowFPSDisplay=Show FPS Display
 nlShowFPSDisplay=When enabled, show the FPS Display (Experimental).
 lblEnableUnknownCards=Enable Unknown Cards


### PR DESCRIPTION
Resolves #11344: adds an option inside Adventure Mode's settings to start Forge directly in Adventure Mode.

### Why

Adventure Mode fully supports controller navigation, but the mode-selector splash screen shown at startup does not. Players who primarily play Adventure with a controller must reach for the mouse on every launch just to get into the mode they always play. Forge already has a preference for this (`UI_SELECTOR_MODE`, exposed as "Selector Mode" in the classic mobile settings page), but it is not reachable from within Adventure Mode itself.

### What

Adds a **"Start in Adventure mode (applies on next launch)"** checkbox to Adventure's Settings scene, right below the World selector:

- Checked: sets `UI_SELECTOR_MODE` to `Adventure`, so the next launch boots straight into the Adventure main menu (fully controller-navigable).
- Unchecked: restores `Default`, bringing back the mode-selector splash screen — so switching back to other modes stays easy, per the issue discussion.
- The checkbox re-reads the preference on scene enter, so it stays in sync if the mode is changed from the classic Selector Mode setting.
- `Forge.selector` is updated immediately, matching how the classic `SettingsPage` applies the same preference.

No new preference is introduced — this only exposes the existing `UI_SELECTOR_MODE` preference where controller players need it.

### Changes

- `forge-gui-mobile/src/forge/adventure/scene/SettingsScene.java`: new checkbox wired to `UI_SELECTOR_MODE`; the boolean `addSettingField` overload now returns its `CheckBox` so the setting can be refreshed on enter.
- `forge-gui/res/languages/en-US.properties`: new `lblStartInAdventureMode` string.

Primary feature was written with Codex 5.6 Sol with guidance to scope it as small as possible, code reviewed in several rounds by Sol and Claude Fable, and manually tested (by me on MacOS) before opening the PR.

### Testing

- `mvn -pl forge-gui-mobile -am compile` passes on this branch.
- Feature validated in play on a macOS build carrying this change: direct boot into Adventure with the box checked, selector restored when unchecked, checkbox state stays in sync with the classic Selector Mode setting.

<img width="1920" height="1080" alt="Screenshot 2026-07-23 at 11 30 10 AM" src="https://github.com/user-attachments/assets/2047d1ee-6953-495f-9b8c-714277bca393" />
