### PR TITLE
Let the AI use Fauna Shaman's tutor

### DIFF
--- a/forge-gui/res/cardsfolder/f/fauna_shaman.txt
+++ b/forge-gui/res/cardsfolder/f/fauna_shaman.txt
@@ -2,5 +2,6 @@ Name:Fauna Shaman
 ManaCost:1 G
 Types:Creature Elf Shaman
 PT:2/2
-A:AB$ ChangeZone | Cost$ G T Discard<1/Creature> | Origin$ Library | Destination$ Hand | ChangeType$ Creature | ChangeNum$ 1 | SpellDescription$ Search your library for a Creature card and put it into your hand. Then shuffle.
+A:AB$ ChangeZone | Cost$ G T Discard<1/Creature> | Origin$ Library | Destination$ Hand | ChangeType$ Creature | ChangeNum$ 1 | AILogic$ SurvivalOfTheFittest | SpellDescription$ Search your library for a Creature card and put it into your hand. Then shuffle.
+SVar:AIPreference:DiscardCost$Special:SurvivalOfTheFittest
 Oracle:{G}, {T}, Discard a creature card: Search your library for a creature card, reveal it, put it into your hand, then shuffle.


### PR DESCRIPTION
Fauna Shaman (`{G}, {T}, Discard a creature: search your library for a creature and put it into your hand`) is unflagged, so the AI runs it — but it never uses the ability, playing as a vanilla 2/2.

## Cause

The block is the discard cost, not targeting or timing. `SpellAbilityAi.willPayCosts` → `ComputerUtilCost.checkDiscardCost` calls `ComputerUtil.getCardPreference(ai, source, "DiscardCost", …)`; with no preference declared it returns `null`, so the decision comes back `CostNotAcceptable` and the tutor never fires. The cost is judged in isolation, with no credit for the fact that the tutor hands back a *stronger* creature than the one discarded.

## Fix

`Survival of the Fittest` is the same ability (`{G}, discard a creature: tutor a creature to hand`) and already handles this with two hints:

```
AILogic$ SurvivalOfTheFittest
SVar:AIPreference:DiscardCost$Special:SurvivalOfTheFittest
```

The backing `SpecialCardAi.SurvivalOfTheFittest` handlers (`considerDiscardTarget` / `considerCardToGet`) are generic — they look only at the AI's own creatures in hand and library and its available mana, with no binding to the Survival card. So they apply unchanged to Fauna Shaman. This PR adds the same two hints; no Java change.

## Verified

| | before | after |
|---|---|---|
| `canPlaySa` (untapped, fodder in hand) | `CostNotAcceptable` | `WillPlay` at its firing window |
| full resolution (opponent's end of turn) | never activates | discards its worst spare creature, fetches the best affordable one |

Concretely: with two Grizzly Bears + a Runeclaw Bear in hand and a Colossal Dreadmaw in the library, it discards a Grizzly Bears and fetches the Dreadmaw — same behaviour as Survival of the Fittest, which fires this logic at the opponent's end of turn just before the AI's turn. 286 desktop tests pass.

---

Written with Claude Code (Opus 4.8), per the AI coding agent guidance in CONTRIBUTING.md; also recorded as a commit co-author.
