### PR TITLE
Old Border Shandalar: Clarify starter pack limit

### DIFF
--- a/forge-gui/res/adventure/Shandalar Old Border/maps/map/main_story/spawn.tmx
+++ b/forge-gui/res/adventure/Shandalar Old Border/maps/map/main_story/spawn.tmx
@@ -115,7 +115,7 @@
                                                                 "options": [
                                                                     {
                                                                         "name": "(Continue)",
-                                                                        "text": "One more thing - It's dangerous to go alone! You may choose up to two packs.",
+                                                                        "text": "One more thing - It's dangerous to go alone! Take this. You may choose up to two packs.",
                                                                         "options": [
                                                                             {
                                                                                 "name": "(Accept Red Pack)",

--- a/forge-gui/res/adventure/Shandalar Old Border/maps/map/main_story/spawn.tmx
+++ b/forge-gui/res/adventure/Shandalar Old Border/maps/map/main_story/spawn.tmx
@@ -115,7 +115,7 @@
                                                                 "options": [
                                                                     {
                                                                         "name": "(Continue)",
-                                                                        "text": "One more thing - It's dangerous to go alone! Take this.",
+                                                                        "text": "One more thing - It's dangerous to go alone! You may choose up to two packs.",
                                                                         "options": [
                                                                             {
                                                                                 "name": "(Accept Red Pack)",


### PR DESCRIPTION
- Clarify that the first quest giver allows the player to choose up to two starter packs
- Make the limit clear when multiple color packs are offered
