### PR TITLE
Preserve simultaneous trigger order in TriggerWaiting

### DIFF
--- a/forge-game/src/main/java/forge/game/trigger/TriggerWaiting.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerWaiting.java
@@ -38,7 +38,8 @@ public class TriggerWaiting {
     }
 
     public void setTriggers(final List<Trigger> trigs) {
-        this.triggers = Maps.newHashMap();
+        // keySet() drives simultaneous-trigger stacking, so preserve collection order.
+        this.triggers = Maps.newLinkedHashMap();
         for (Trigger t : trigs) {
             triggers.put(t, t.getHostCard().getController());
         }


### PR DESCRIPTION
I hit a seeded Mono Black Aggro vs Esper Control simulation that produced different AI decision logs across runs. The first difference was simultaneous-trigger order after Cavalier of Night died.

`TriggerWaiting.setTriggers()` receives an ordered list, but copies it into a `HashMap`; `getTriggers()` later exposes its `keySet()` while those abilities are added to the stack. This changes the map to a `LinkedHashMap`, preserving the collected order. `MagicStack` still applies the normal player and controller ordering afterward.

Across eight runs, the `HashMap` version produced two distinct logs; the `LinkedHashMap` version produced one. Forcing constant JVM identity hashes also collapsed the baseline to one.

I used Codex to help diagnose and verify this change.

For less obvious fixes, is this amount of context useful in the PR, or would a small reproducer or permanent test be more helpful?
