### PR TITLE
Make AI-vs-AI games deterministic at a fixed seed

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ComputerUtil.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtil.java
@@ -536,7 +536,9 @@ public class ComputerUtil {
 
         CardCollection typeList = CardLists.getValidCards(ai.getCardsIn(ZoneType.Battlefield), type.split(";"), source.getController(), source, ability);
         if (differentNames) {
-            final Set<Card> uniqueNameCards = Sets.newHashSet();
+            // LinkedHashSet: this list is copied back into typeList and drives which cards get
+            // sacrificed on a scoring tie, so its order must not depend on Card identity hashCode.
+            final Set<Card> uniqueNameCards = Sets.newLinkedHashSet();
             for (final Card card : typeList) {
                 // CR 201.2b Those objects have different names only if each of them has at least one name and no two objects in that group have a name in common
                 if (!card.hasNoName()) {

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilCost.java
@@ -385,7 +385,10 @@ public class ComputerUtilCost {
 
                 CardCollection typeList = CardLists.getValidCards(ai.getCardsIn(ZoneType.Battlefield), type.split(";"), source.getController(), source, sourceAbility);
                 if (differentNames) {
-                    final Set<Card> uniqueNameCards = Sets.newHashSet();
+                    // LinkedHashSet: this list is copied back into typeList and drives which cards
+                    // get sacrificed on a scoring tie, so its order must not depend on Card
+                    // identity hashCode (which varies per JVM run).
+                    final Set<Card> uniqueNameCards = Sets.newLinkedHashSet();
                     for (final Card card : typeList) {
                         // CR 201.2b Those objects have different names only if each of them has at least one name and no two objects in that group have a name in common
                         if (!card.hasNoName()) {

--- a/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
+++ b/forge-ai/src/main/java/forge/ai/ComputerUtilMana.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
 import forge.ai.AiCardMemory.MemorySet;
 import forge.ai.ability.AnimateAi;
 import forge.card.ColorSet;
@@ -1147,7 +1148,12 @@ public class ComputerUtilMana {
      */
     private static ListMultimap<ManaCostShard, SpellAbility> groupAndOrderToPayShards(final Player ai, final ListMultimap<Integer, SpellAbility> manaAbilityMap,
             final ManaCostBeingPaid cost) {
-        ListMultimap<ManaCostShard, SpellAbility> res = ArrayListMultimap.create();
+        // EnumMap-backed so keySet()/entries() iterate in ManaCostShard declaration order rather
+        // than the enum's identity-hash order (which varies per JVM run). sortManaAbilities and
+        // getNextShardToPay walk this keySet, so a nondeterministic order there made the AI's
+        // choice of which source to tap - and thus its whole line of play - nondeterministic.
+        ListMultimap<ManaCostShard, SpellAbility> res =
+                MultimapBuilder.enumKeys(ManaCostShard.class).arrayListValues().build();
 
         if ((cost.getGenericManaAmount() > 0 || cost.hasAnyKind(ManaAtom.OR_2_GENERIC)) && manaAbilityMap.containsKey(ManaAtom.GENERIC)) {
             res.putAll(ManaCostShard.GENERIC, manaAbilityMap.get(ManaAtom.GENERIC));

--- a/forge-game/src/main/java/forge/game/combat/AttackConstraints.java
+++ b/forge-game/src/main/java/forge/game/combat/AttackConstraints.java
@@ -139,9 +139,15 @@ public class AttackConstraints {
             }
         }
 
-        // Now try all others (plus empty attack) and count their violations
+        // Now try all others (plus empty attack) and count their violations. Iterate the ordered
+        // FCollection rather than asSet(): possible is a LinkedHashMap and the min() below keeps
+        // the first entry on a violation-count tie, so insertion order decides which attack is
+        // chosen. asSet() is a HashSet keyed by attack-config maps whose hashCodes come from Card
+        // identity hashes, i.e. per-JVM-random - which made the AI's attack nondeterministic.
         final FCollection<Map<Card, GameEntity>> legalAttackers = collectLegalAttackers(reqs, myMax);
-        possible.putAll(Maps.asMap(legalAttackers.asSet(), this::countViolations));
+        for (final Map<Card, GameEntity> attackMap : legalAttackers) {
+            possible.put(attackMap, countViolations(attackMap));
+        }
         int empty = countViolations(Collections.emptyMap());
         if (empty != -1) {
             possible.put(Collections.emptyMap(), empty);

--- a/forge-game/src/main/java/forge/game/mana/ManaCostBeingPaid.java
+++ b/forge-game/src/main/java/forge/game/mana/ManaCostBeingPaid.java
@@ -117,8 +117,11 @@ public class ManaCostBeingPaid {
     }
 
     // holds Mana_Part objects
-    // ManaPartColor is stored before ManaPartGeneric
-    private final Map<ManaCostShard, ShardCount> unpaidShards = Maps.newHashMap();
+    // An EnumMap iterates in ManaCostShard declaration order, which is deliberately "least ways to
+    // pay first" (colors before generic, per that enum's own comment). A HashMap iterated in
+    // identity-hash order instead - arbitrary and, because enum hashCode is identity-based, varying
+    // per JVM run, which made mana-source choice (and thus AI play) nondeterministic.
+    private final Map<ManaCostShard, ShardCount> unpaidShards = new EnumMap<>(ManaCostShard.class);
     private Map<String, Integer> xManaCostPaidByColor;
     private byte sunburstMap = 0;
     private int cntX = 0;

--- a/forge-game/src/main/java/forge/game/trigger/TriggerWaiting.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerWaiting.java
@@ -38,7 +38,11 @@ public class TriggerWaiting {
     }
 
     public void setTriggers(final List<Trigger> trigs) {
-        this.triggers = Maps.newHashMap();
+        // Preserve the order of trigs: getTriggers() feeds the order simultaneous triggers are put
+        // on the stack, and a plain HashMap would iterate in hashCode-bucket order, which varies
+        // per JVM run (Trigger.hashCode folds in the identity hash of the Trigger class object).
+        // LinkedHashMap keeps the deterministic zone-walk order from getActiveTrigger.
+        this.triggers = Maps.newLinkedHashMap();
         for (Trigger t : trigs) {
             triggers.put(t, t.getHostCard().getController());
         }


### PR DESCRIPTION
## Problem

AI-vs-AI games were **nondeterministic across runs even with a fixed `MyRandom` seed** — the same game replayed differently from one JVM launch to the next (on a reanimator test deck, ~40% of seeds diverged). This makes bugs hard to reproduce, blocks deterministic regression testing, and makes before/after performance comparison unreliable.

## Root cause

Order-significant iteration over collections whose key type uses **identity-based `hashCode`**, which the JVM randomizes per launch. This covers enums (`ManaCostShard`), and objects whose `hashCode` folds in a `Class` object's identity hash (e.g. `Trigger.hashCode() = Objects.hash(Trigger.class, id)`).

Diagnosed with `-XX:+UnlockExperimentalVMOptions -XX:hashCode=3` (deterministic identity hashes): under that flag replays were stable, under default hashing they diverged — confirming the cause is identity-hash-ordered iteration, not the RNG. Each site below was then localized by log-diffing the first point two runs diverge.

## Fixes (each independently revertable)

1. **Simultaneous trigger order** — `TriggerWaiting` collected fired triggers into a `HashMap<Trigger,Player>` and returned `keySet()`; `MagicStack` uses that as the order simultaneous triggers go on the stack. → `LinkedHashMap` (the setter already receives an ordered list). *First divergence seen: Solitude's evoke-sacrifice vs ETB-exile triggers swapping.*

2. **Mana shard order** — `ManaCostBeingPaid.unpaidShards` (`HashMap`) and `ComputerUtilMana`'s shard multimap (HashMap-backed) are keyed by the `ManaCostShard` enum and drive which source taps for a color. → `EnumMap` / `MultimapBuilder.enumKeys`. This also honors the ordering both the enum and the field's own comment already document ("least ways to pay first", "color before generic"). *First divergence: tapping Hallowed Fountain vs Godless Shrine for {W}.*

3. **Sacrifice candidate order** — the `+WithDifferentNames` sacrifice path filtered candidates through a `HashSet<Card>` and copied it back, scrambling the tie-break order. → `LinkedHashSet`.

4. **Attack tie-breaking** — `AttackConstraints.getLegalAttackers` picks the fewest-violation attack via `stream().min()` (first on tie) over a map filled from `legalAttackers.asSet()` (a `HashSet` keyed by attack-config maps). → iterate the ordered `FCollection`. Only affects boards with attack requirements (goad/lure/must-attack) that tie.

## Validation

- Full `forge-gui-desktop` suite: **286 tests, 0 failures**.
- **Determinism:** two full 5-seed passes (default hashing) are now byte-identical pass-to-pass on a reanimator deck, a Goblins deck, and a 510-card pile — where ~40% diverged before. Independently corroborated by pinning identity hashes with `-XX:hashCode=3`.

## Scope / honesty

I audited the highest-traffic decision paths — spell/ability selection, targeting, discard, mana, sacrifice, and combat — and the core selection logic (`Aggregates.itemWithMax` over zone-ordered lists, list-based discard, seeded `MyRandom` sampling) was already deterministic. This PR fixes the concrete sources that manifest across these decks plus the suite; I don't claim *every* path is covered (clone/copy, pile-splitting, and sim-mode copies weren't exhaustively swept). Each change is behavior-preserving apart from making a previously-arbitrary order deterministic.

---
🤖 Implemented with the assistance of Claude Code (Opus). Happy to split into per-fix PRs if that's easier to review.