### PR TITLE
TriggerHandler: avoid extra synchronization

### DIFF
--- a/forge-game/src/main/java/forge/game/trigger/TriggerHandler.java
+++ b/forge-game/src/main/java/forge/game/trigger/TriggerHandler.java
@@ -41,14 +41,14 @@ import io.sentry.Breadcrumb;
 import io.sentry.Sentry;
 
 public class TriggerHandler {
-    private final Set<TriggerType> suppressedModes = Collections.synchronizedSet(EnumSet.noneOf(TriggerType.class));
+    private final Set<TriggerType> suppressedModes = EnumSet.noneOf(TriggerType.class);
     private boolean allSuppressed = false;
-    private final List<Trigger> activeTriggers = Collections.synchronizedList(new ArrayList<>());
+    private final List<Trigger> activeTriggers = new ArrayList<>();
 
-    private final List<Trigger> delayedTriggers = Collections.synchronizedList(new ArrayList<>());
-    private final List<Trigger> thisTurnDelayedTriggers = Collections.synchronizedList(new ArrayList<>());
-    private final ListMultimap<Player, Trigger> playerDefinedDelayedTriggers = Multimaps.synchronizedListMultimap(ArrayListMultimap.create());
-    private final List<TriggerWaiting> waitingTriggers = Collections.synchronizedList(new ArrayList<>());
+    private final List<Trigger> delayedTriggers = new ArrayList<>();
+    private final List<Trigger> thisTurnDelayedTriggers = new ArrayList<>();
+    private final ListMultimap<Player, Trigger> playerDefinedDelayedTriggers = ArrayListMultimap.create();
+    private final List<TriggerWaiting> waitingTriggers = new ArrayList<>();
     private final Game game;
 
     public TriggerHandler(final Game gameState) {


### PR DESCRIPTION
I'm not aware of a real use case that has multiple threads mess with the same TriggerHandler object?

The original commit ea23bb3 also seems rather random.
If this was really fixing some concurrent access then it's either hopefully long gone or will reappear and can be refactored at the source instead!

Besides the class wasn't even using any `synchronized` blocks like this mechanism requires anyway...