### PR TITLE
Add a seed option to simulation mode

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/view/SimulateMatch.java
+++ b/forge-gui-desktop/src/main/java/forge/view/SimulateMatch.java
@@ -29,6 +29,7 @@ import forge.localinstance.properties.ForgeConstants;
 import forge.model.FModel;
 import forge.player.GamePlayerUtil;
 import forge.util.Lang;
+import forge.util.MyRandom;
 import forge.util.TextUtil;
 import forge.util.WordUtil;
 import forge.util.storage.IStorage;
@@ -80,6 +81,12 @@ public class SimulateMatch {
         }
 
         boolean outputGamelog = !params.containsKey("q");
+
+        Long seed = null;
+        if (params.containsKey("s")) {
+            seed = Long.parseLong(params.get("s").get(0));
+            MyRandom.setRandom(new Random(seed));
+        }
 
         GameType type = GameType.Constructed;
         if (params.containsKey("f")) {
@@ -135,6 +142,9 @@ public class SimulateMatch {
         }
 
         sb.append(" - ").append(Lang.nounWithNumeral(nGames, "game")).append(" of ").append(type);
+        if (seed != null) {
+            sb.append(" seed ").append(seed);
+        }
 
         System.out.println(sb.toString());
 
@@ -157,7 +167,7 @@ public class SimulateMatch {
     }
 
     private static void argumentHelp() {
-        System.out.println("Syntax: forge.exe sim -d <deck1[.dck]> ... <deckX[.dck]> -D [D] -n [N] -m [M] -t [T] -p [P] -f [F] -q");
+        System.out.println("Syntax: forge.exe sim -d <deck1[.dck]> ... <deckX[.dck]> -D [D] -n [N] -m [M] -t [T] -p [P] -f [F] -s [S] -q");
         System.out.println("\tsim - stands for simulation mode");
         System.out.println("\tdeck1 (or deck2,...,X) - constructed deck name or filename (has to be quoted when contains multiple words)");
         System.out.println("\tdeck is treated as file if it ends with a dot followed by three numbers or letters");
@@ -167,6 +177,7 @@ public class SimulateMatch {
         System.out.println("\tT - Type of tournament to run with all provided decks (Bracket, RoundRobin, Swiss)");
         System.out.println("\tP - Amount of players per match (used only with Tournaments, defaults to 2)");
         System.out.println("\tF - format of games, defaults to constructed");
+        System.out.println("\tS - RNG seed for simulation");
         System.out.println("\tc - Clock flag. Set the maximum time in seconds before calling the match a draw, defaults to 120.");
         System.out.println("\tq - Quiet flag. Output just the game result, not the entire game log.");
     }


### PR DESCRIPTION
Simulation mode uses Forge's shared `MyRandom`, but does not expose a way to provide its seed from the command line. This makes it possible to rerun a simulation with the same random input when investigating AI behavior or regressions.

This adds `sim -s <seed>` and includes the chosen seed in the run header. When `-s` is omitted, behavior is unchanged.

I used Codex to help author this change.
