### PR TITLE
Cache the per-card trigger and static ability lists

### DIFF
--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -628,6 +628,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
 
     // use by CopyPermanent
     public void setStates(Map<CardStateName, CardState> map) {
+        invalidateTraitCaches();
         states.clear();
         states.putAll(map);
     }
@@ -1932,7 +1933,15 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     }
 
     @Override
+    public void setCounters(final CounterType counterType, final Integer num) {
+        // Shield and Stun counters contribute replacement effects (see updateReplacementEffects).
+        invalidateTraitCaches();
+        super.setCounters(counterType, num);
+    }
+
+    @Override
     public final void setCounters(final Multiset<CounterType> allCounters) {
+        invalidateTraitCaches();
         boolean changed = counters.contains(CounterEnumType.MANABOND) || counters.elementSet().stream().allMatch(CounterType::isKeywordCounter);
         counters = allCounters;
         view.updateCounters(this);
@@ -4190,6 +4199,10 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     }
 
     public final void updateTypeCache() {
+        // updateTypes() only refreshes the current state, so drop every state's cached traits here:
+        // clone and rollback paths reach this via updateChangedText(), and relying on a non-current
+        // state's cache happening to match its equally stale type would be far too subtle.
+        invalidateTraitCaches();
         this.getCurrentState().updateTypes();
     }
 
@@ -4919,6 +4932,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
         return changedCardTraitsByText;
     }
     public final void setChangedCardTraitsByText(Table<Long, Long, CardTraitChanges> changes) {
+        invalidateTraitCaches();
         changedCardTraitsByText.clear();
         for (Table.Cell<Long, Long, CardTraitChanges> e : changes.cellSet()) {
             changedCardTraitsByText.put(e.getRowKey(), e.getColumnKey(), e.getValue().copy(this, true));
@@ -4926,6 +4940,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     }
     public final void addChangedCardTraitsByText(Collection<SpellAbility> spells,
             Collection<Trigger> trigger, Collection<ReplacementEffect> replacements, Collection<StaticAbility> statics, long timestamp, long staticId) {
+        invalidateTraitCaches();
         changedCardTraitsByText.put(timestamp, staticId, new CardTraitChanges(
             spells, trigger, replacements, statics, e -> true
         ));
@@ -4950,6 +4965,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
         return addChangedCardTraits(result, timestamp, staticId, updateView);
     }
     public final ICardTraitChanges addChangedCardTraits(ICardTraitChanges changes, long timestamp, long staticId, boolean updateView) {
+        invalidateTraitCaches();
         changedCardTraits.put(timestamp, staticId, changes);
         if (updateView) {
             updateAbilityTextForView();
@@ -4958,9 +4974,11 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     }
 
     public final boolean removeChangedCardTraits(long timestamp, long staticId) {
+        invalidateTraitCaches();
         return changedCardTraits.remove(timestamp, staticId) != null;
     }
     public final boolean removeChangedCardTraitsByText(long timestamp, long staticId) {
+        invalidateTraitCaches();
         return changedCardTraitsByText.remove(timestamp, staticId) != null;
     }
 
@@ -4980,6 +4998,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     }
 
     public final void setChangedCardTraits(Table<Long, Long, ICardTraitChanges> changes) {
+        invalidateTraitCaches();
         changedCardTraits.clear();
         for (Table.Cell<Long, Long, ICardTraitChanges> e : changes.cellSet()) {
             changedCardTraits.put(e.getRowKey(), e.getColumnKey(), e.getValue().copy(this, true));
@@ -4987,6 +5006,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     }
 
     public boolean clearChangedCardTraits() {
+        invalidateTraitCaches();
         boolean changed = false;
         if (!changedCardTraitsByText.isEmpty()) {
             changed = true;
@@ -5219,7 +5239,19 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     public final void updateKeywordsCache() {
         updateKeywordsCache(getCurrentState());
     }
+    /**
+     * Drop the cached trait lists (replacement effects / static abilities / triggers) on every
+     * state of this card. Called from each place an input to those lists can change.
+     */
+    public final void invalidateTraitCaches() {
+        for (CardState st : states.values()) {
+            st.invalidateTraitCache();
+        }
+    }
+
     public final void updateKeywordsCache(final CardState state) {
+        // Keywords contribute triggers/replacements/statics, so the trait lists must go too.
+        state.invalidateTraitCache();
         KeywordCollection keywords = new KeywordCollection();
 
         // Layer 1

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -628,6 +628,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
 
     // use by CopyPermanent
     public void setStates(Map<CardStateName, CardState> map) {
+        invalidateTraitCaches();
         states.clear();
         states.putAll(map);
     }
@@ -4192,6 +4193,10 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     }
 
     public final void updateTypeCache() {
+        // updateTypes() only refreshes the current state, so drop every state's cached traits here:
+        // clone and rollback paths reach this via updateChangedText(), and relying on a non-current
+        // state's cache happening to match its equally stale type would be far too subtle.
+        invalidateTraitCaches();
         this.getCurrentState().updateTypes();
     }
 
@@ -4921,6 +4926,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
         return changedCardTraitsByText;
     }
     public final void setChangedCardTraitsByText(Table<Long, Long, CardTraitChanges> changes) {
+        invalidateTraitCaches();
         changedCardTraitsByText.clear();
         for (Table.Cell<Long, Long, CardTraitChanges> e : changes.cellSet()) {
             changedCardTraitsByText.put(e.getRowKey(), e.getColumnKey(), e.getValue().copy(this, true));
@@ -4928,6 +4934,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     }
     public final void addChangedCardTraitsByText(Collection<SpellAbility> spells,
             Collection<Trigger> trigger, Collection<ReplacementEffect> replacements, Collection<StaticAbility> statics, long timestamp, long staticId) {
+        invalidateTraitCaches();
         changedCardTraitsByText.put(timestamp, staticId, new CardTraitChanges(
             spells, trigger, replacements, statics, e -> true
         ));
@@ -4952,6 +4959,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
         return addChangedCardTraits(result, timestamp, staticId, updateView);
     }
     public final ICardTraitChanges addChangedCardTraits(ICardTraitChanges changes, long timestamp, long staticId, boolean updateView) {
+        invalidateTraitCaches();
         changedCardTraits.put(timestamp, staticId, changes);
         if (updateView) {
             updateAbilityTextForView();
@@ -4960,9 +4968,11 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     }
 
     public final boolean removeChangedCardTraits(long timestamp, long staticId) {
+        invalidateTraitCaches();
         return changedCardTraits.remove(timestamp, staticId) != null;
     }
     public final boolean removeChangedCardTraitsByText(long timestamp, long staticId) {
+        invalidateTraitCaches();
         return changedCardTraitsByText.remove(timestamp, staticId) != null;
     }
 
@@ -4982,6 +4992,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     }
 
     public final void setChangedCardTraits(Table<Long, Long, ICardTraitChanges> changes) {
+        invalidateTraitCaches();
         changedCardTraits.clear();
         for (Table.Cell<Long, Long, ICardTraitChanges> e : changes.cellSet()) {
             changedCardTraits.put(e.getRowKey(), e.getColumnKey(), e.getValue().copy(this, true));
@@ -4989,6 +5000,7 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     }
 
     public boolean clearChangedCardTraits() {
+        invalidateTraitCaches();
         boolean changed = false;
         if (!changedCardTraitsByText.isEmpty()) {
             changed = true;
@@ -5221,7 +5233,19 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     public final void updateKeywordsCache() {
         updateKeywordsCache(getCurrentState());
     }
+    /**
+     * Drop the cached trait lists (triggers / static abilities) on every state of this card.
+     * Called from each place an input to those lists can change.
+     */
+    public final void invalidateTraitCaches() {
+        for (CardState st : states.values()) {
+            st.invalidateTraitCache();
+        }
+    }
+
     public final void updateKeywordsCache(final CardState state) {
+        // Keywords contribute triggers and statics, so the trait lists must go too.
+        state.invalidateTraitCache();
         KeywordCollection keywords = new KeywordCollection();
 
         // Layer 1

--- a/forge-game/src/main/java/forge/game/card/CardState.java
+++ b/forge-game/src/main/java/forge/game/card/CardState.java
@@ -114,6 +114,24 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
     // wrapped in a List so it can be reused directly
     private List<LandTraitChanges> landTraitChanges = List.of(new LandTraitChanges(this));
 
+    // Trait caches. getStaticAbilities/getTriggers rebuild their list from the layer system on
+    // every call - millions of times per game - and the result is identical to the previous one
+    // over 99.9% of the time. Cache it and drop the cache whenever any input changes; see
+    // Card.invalidateTraitCaches for the invalidation points.
+    private FCollectionView<StaticAbility> cachedStaticAbilities;
+    private FCollectionView<Trigger> cachedTraitTriggers;
+
+    /**
+     * Drop every cached trait list; they are rebuilt lazily on next access.
+     * Note: mutating a split state's raw trait lists must invalidate the whole card, because the
+     * Original state merges LeftSplit/RightSplit's lists into its own - hence those mutators call
+     * Card.invalidateTraitCaches() rather than this.
+     */
+    final void invalidateTraitCache() {
+        cachedStaticAbilities = null;
+        cachedTraitTriggers = null;
+    }
+
     public CardState(Card card, CardStateName name) {
         this(card.getView().createAlternateState(name), card);
     }
@@ -156,6 +174,9 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
 
     public void updateTypes() {
         this.changedType = getType().getTypeWithChanges(card.getChangedCardTypes());
+        // LandTraitChanges clears both lists when hasRemoveIntrinsic() is set, and that reads
+        // changedCardTypes - which every type mutation funnels through here to refresh.
+        invalidateTraitCache();
     }
     public void updateTypesForView() {
         view.updateType(this);
@@ -686,6 +707,9 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
     }
 
     public final FCollectionView<Trigger> getTriggers() {
+        if (cachedTraitTriggers != null) {
+            return cachedTraitTriggers;
+        }
         FCollection<Trigger> result = new FCollection<>(triggers);
         if (getStateName().equals(CardStateName.Original)) {
             if (getCard().hasState(CardStateName.LeftSplit))
@@ -694,6 +718,7 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
                 result.addAll(getCard().getState(CardStateName.RightSplit).triggers);
         }
         card.updateTriggers(result, this);
+        cachedTraitTriggers = result;
         return result;
     }
 
@@ -711,10 +736,14 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
     }
 
     public final boolean addTrigger(final Trigger t) {
+        card.invalidateTraitCaches();
         return triggers.add(t);
     }
 
     public final FCollectionView<StaticAbility> getStaticAbilities() {
+        if (cachedStaticAbilities != null) {
+            return cachedStaticAbilities;
+        }
         FCollection<StaticAbility> result = new FCollection<>(staticAbilities);
         if (getStateName().equals(CardStateName.Original)) {
             if (getCard().hasState(CardStateName.LeftSplit))
@@ -723,12 +752,15 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
                 result.addAll(getCard().getState(CardStateName.RightSplit).staticAbilities);
         }
         card.updateStaticAbilities(result, this);
+        cachedStaticAbilities = result;
         return result;
     }
     public final boolean addStaticAbility(StaticAbility stab) {
+        card.invalidateTraitCaches();
         return staticAbilities.add(stab);
     }
     public final boolean removeStaticAbility(StaticAbility stab) {
+        card.invalidateTraitCaches();
         return staticAbilities.remove(stab);
     }
 
@@ -963,6 +995,10 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
                 this.landManaAbilities.put(e.getKey(), e.getValue().copy(card, true));
             }
         }
+
+        // after the copy, not before: the trait copies above read back through this card, so an
+        // earlier drop could be refilled from a half-copied state
+        card.invalidateTraitCaches();
     }
 
     public final void addAbilitiesFrom(final CardState source, final boolean lki) {
@@ -993,6 +1029,8 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
                 staticAbilities.add(sa.copy(card, lki));
             }
         }
+
+        card.invalidateTraitCaches();
     }
 
     public CardState copy(final Card host, CardStateName name, final boolean lki) {

--- a/forge-game/src/main/java/forge/game/card/CardState.java
+++ b/forge-game/src/main/java/forge/game/card/CardState.java
@@ -112,6 +112,28 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
     // wrapped in a List so it can be reused directly
     private List<LandTraitChanges> landTraitChanges = List.of(new LandTraitChanges(this));
 
+    // Trait caches. getReplacementEffects/getStaticAbilities/getTriggers rebuild their list from the
+    // layer system on every call - tens of millions of times per game - and the result is identical
+    // to the previous one over 99.9% of the time. Cache it and drop the cache whenever any input
+    // changes; see Card.invalidateTraitCaches for the invalidation points.
+    private FCollectionView<ReplacementEffect> cachedReplacementsAsRulesHost;
+    private FCollectionView<ReplacementEffect> cachedReplacementsPlain;
+    private FCollectionView<StaticAbility> cachedStaticAbilities;
+    private FCollectionView<Trigger> cachedTraitTriggers;
+
+    /**
+     * Drop every cached trait list; they are rebuilt lazily on next access.
+     * Note: mutating a split state's raw trait lists must invalidate the whole card, because the
+     * Original state merges LeftSplit/RightSplit's lists into its own - hence those mutators call
+     * Card.invalidateTraitCaches() rather than this.
+     */
+    final void invalidateTraitCache() {
+        cachedReplacementsAsRulesHost = null;
+        cachedReplacementsPlain = null;
+        cachedStaticAbilities = null;
+        cachedTraitTriggers = null;
+    }
+
     public CardState(Card card, CardStateName name) {
         this(card.getView().createAlternateState(name), card);
     }
@@ -154,6 +176,9 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
 
     public void updateTypes() {
         this.changedType = getType().getTypeWithChanges(card.getChangedCardTypes());
+        // Type drives the Saga/planeswalker/battle ETB-counter replacements, the Adventure/Omen
+        // rules effects and the basic-land mana abilities, so any type change invalidates traits.
+        invalidateTraitCache();
     }
     public void updateTypesForView() {
         view.updateType(this);
@@ -673,6 +698,9 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
     }
 
     public final FCollectionView<Trigger> getTriggers() {
+        if (cachedTraitTriggers != null) {
+            return cachedTraitTriggers;
+        }
         FCollection<Trigger> result = new FCollection<>(triggers);
         if (getStateName().equals(CardStateName.Original)) {
             if (getCard().hasState(CardStateName.LeftSplit))
@@ -681,6 +709,7 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
                 result.addAll(getCard().getState(CardStateName.RightSplit).triggers);
         }
         card.updateTriggers(result, this);
+        cachedTraitTriggers = result;
         return result;
     }
 
@@ -698,10 +727,14 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
     }
 
     public final boolean addTrigger(final Trigger t) {
+        card.invalidateTraitCaches();
         return triggers.add(t);
     }
 
     public final FCollectionView<StaticAbility> getStaticAbilities() {
+        if (cachedStaticAbilities != null) {
+            return cachedStaticAbilities;
+        }
         FCollection<StaticAbility> result = new FCollection<>(staticAbilities);
         if (getStateName().equals(CardStateName.Original)) {
             if (getCard().hasState(CardStateName.LeftSplit))
@@ -710,12 +743,15 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
                 result.addAll(getCard().getState(CardStateName.RightSplit).staticAbilities);
         }
         card.updateStaticAbilities(result, this);
+        cachedStaticAbilities = result;
         return result;
     }
     public final boolean addStaticAbility(StaticAbility stab) {
+        card.invalidateTraitCaches();
         return staticAbilities.add(stab);
     }
     public final boolean removeStaticAbility(StaticAbility stab) {
+        card.invalidateTraitCaches();
         return staticAbilities.remove(stab);
     }
 
@@ -723,6 +759,13 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
         return getReplacementEffects(true);
     }
     public FCollectionView<ReplacementEffect> getReplacementEffects(boolean rulesHost) {
+        // rulesHost selects a different result (the global Adventure/Omen rules are appended only
+        // for the rules host), so the two variants are cached separately.
+        final FCollectionView<ReplacementEffect> cached =
+                rulesHost ? cachedReplacementsAsRulesHost : cachedReplacementsPlain;
+        if (cached != null) {
+            return cached;
+        }
         FCollection<ReplacementEffect> result = new FCollection<>(replacementEffects);
         // add Split to Original
         if (getStateName().equals(CardStateName.Original)) {
@@ -754,6 +797,7 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
         card.updateReplacementEffects(result, this, rulesHost);
 
         if (!rulesHost) {
+            cachedReplacementsPlain = result;
             return result;
         }
 
@@ -771,9 +815,11 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
             result.add(omenRep);
         }
 
+        cachedReplacementsAsRulesHost = result;
         return result;
     }
     public boolean addReplacementEffect(final ReplacementEffect replacementEffect) {
+        card.invalidateTraitCaches();
         return replacementEffects.add(replacementEffect);
     }
 
@@ -878,6 +924,8 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
         setRarity(source.rarity);
         setSetCode(source.setCode);
 
+        card.invalidateTraitCaches();
+
         Trigger dontCopyTr = null;
         if (ctb != null && ctb.hasParam("DoesntHaveThisAbility")) {
             SpellAbility root = ((SpellAbility) ctb).getRootAbility();
@@ -949,6 +997,7 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
     }
 
     public final void addAbilitiesFrom(final CardState source, final boolean lki) {
+        card.invalidateTraitCaches();
         for (SpellAbility sa : source.abilities) {
             if (sa.isIntrinsic() && sa.getApi() != ApiType.PermanentCreature && sa.getApi() != ApiType.PermanentNoncreature) {
                 abilities.add(sa.copy(card, lki));


### PR DESCRIPTION
`CardState.getTriggers()` and `getStaticAbilities()` rebuild their result from the layer system on every call — the changed-traits list, then the unhidden keywords — and the rebuilt list is identical to the previous one well over 99% of the time. This caches each list on the state and drops it whenever an input changes.

**Scope.** This previously cached replacement effects too. That is gone, along with the counter plumbing that existed only to serve it: the shield/stun/finality block in `updateReplacementEffects` is the only place counters reach a trait list, and per #11631 those extras are better moved out of `getReplacementEffects` than cached around. Triggers and statics have no such dependency — `getHiddenStaticAbilities()` already keeps the counter-derived statics out of the cached list.

**Invalidation points:** changed card traits (both tables), keyword cache updates, type changes (via `hasRemoveIntrinsic`), trigger/static mutation, state replacement, and card copies.

**Measured.**

- *Correctness:* every cache hit rebuilds the list and compares it against the cached one — 4M+ verified hits across the suite, zero mismatches. A deliberately injected disagreement was run first to confirm the check actually fires, and the LeftSplit/RightSplit merge path was checked separately since the suite covers it thinnest.
- *Speed:* A/B in one JVM behind a static flag, interleaved — 1.242x on an ordinary board, 1.094x on a dense one. The smaller figure is share-of-runtime; combat evaluation dominates a heavy board. Both are AITest setups over six turns rather than full games. (An earlier comment on this PR quoted 1.155x / 1.042x, measured before the flag also gated the new invalidation calls, so that baseline was not master.)
- Suite 357/0/6, checkstyle clean.

**Known limit.** The cache fields are unsynchronised and `CardView` reads `getTriggers()` from view code. That is the same exposure as the existing `cachedKeywords` field on `CardState`, so not a new risk class, but untested.

Written with Claude Code; the measurements and the differential check are mine to defend.
