### PR TITLE
Let the AI use Fiend Artisan's tutor

### DIFF
--- a/forge-gui/res/cardsfolder/f/fiend_artisan.txt
+++ b/forge-gui/res/cardsfolder/f/fiend_artisan.txt
@@ -6,6 +6,6 @@ S:Mode$ Continuous | Affected$ Card.Self | AddPower$ Y | AddToughness$ Y | Descr
 A:AB$ ChangeZone | Cost$ X BG T Sac<1/Creature.Other/another creature> | Origin$ Library | Destination$ Battlefield | ChangeType$ Creature.cmcLEX | ChangeNum$ 1 | SorcerySpeed$ True | StackDescription$ SpellDescription | SpellDescription$ Search your library for a creature card with mana value X or less, put it onto the battlefield, then shuffle. Activate only as a sorcery.
 SVar:Y:Count$ValidGraveyard Creature.YouOwn
 SVar:X:Count$xPaid
-AI:RemoveDeck:All
+SVar:NonCombatPriority:1
 DeckHints:Ability$Graveyard
 Oracle:Fiend Artisan gets +1/+1 for each creature card in your graveyard.\n{X}{B/G}, {T}, Sacrifice another creature: Search your library for a creature card with mana value X or less, put it onto the battlefield, then shuffle. Activate only as a sorcery.


### PR DESCRIPTION
Fiend Artisan is flagged `AI:RemoveDeck:All`, but the tutor AI handles it fine — given a clean main phase it sacrifices spare fodder and fetches the best creature it can afford (Colossal Dreadmaw in my test board). The reason it looks broken is combat.

With the flag off and no `NonCombatPriority`, the attack step swings the 1/1 body for one damage, tapping the very creature whose `{T}` tutor is worth far more — so by main 2 it can't pay the cost:

| main 1 board | before | with `NonCombatPriority:1` |
|---|---|---|
| no opposing blocker | attacks → tapped → **no fetch** | holds back → sacs fodder → **fetches** |
| opposing 3/3 blocker | held back anyway → fetched | fetches |

So this adds `SVar:NonCombatPriority:1` and drops the flag. `AiAttackController.shouldAttack` already honours that SVar, holding a creature back when `power × priority < oppLife` and it can afford a tap-cost ability; value 1 is the most conservative setting, which 53 other cards with tap abilities already use.

Full desktop suite green.

---
🤖 Implemented with the assistance of Claude Code (Opus).
