### PR TITLE
Let the AI play Citanul Flute

### DIFF
--- a/forge-gui/res/cardsfolder/c/citanul_flute.txt
+++ b/forge-gui/res/cardsfolder/c/citanul_flute.txt
@@ -3,5 +3,4 @@ ManaCost:5
 Types:Artifact
 A:AB$ ChangeZone | Cost$ X T | Origin$ Library | Destination$ Hand | ChangeType$ Creature.cmcLEX | ChangeNum$ 1 | SpellDescription$ Search your library for a creature card with mana value X or less, reveal it, put it into your hand, then shuffle.
 SVar:X:Count$xPaid
-AI:RemoveDeck:All
 Oracle:{X}, {T}: Search your library for a creature card with mana value X or less, reveal it, put it into your hand, then shuffle.


### PR DESCRIPTION
The `AI:RemoveDeck:All` flag on Citanul Flute looks stale. With it removed, the AI activates `{X}, {T}` and fetches sensibly — on a test library it took Serra Angel over Grizzly Bears and Llanowar Elves, since the fetch runs through `chooseCreature` (best by `evaluateCreature`, weighted toward what it can actually cast soon).

Activation ranks last in `ComputerUtilAbility`'s evaluator, so it behaves as a spare-mana sink rather than crowding out better plays.

One thing worth flagging for anyone else auditing these flags: **the flag hides its own evidence.** `AiController.getSpellAbilityToPlay` strips every ability of a `RemoveDeck:All` card out of the candidate list, so a flagged card can never be observed doing anything — whether or not its AI actually works. The only way to judge one is to remove the flag and watch a real turn, which is what I did here.

Caveats, neither of which blocks play: it inherits `evaluateCreature`'s blind spot for cheap bombs, and it can overpay X.

Full desktop suite green.

---
🤖 Implemented with the assistance of Claude Code (Opus).
