### PR TITLE
Let the AI play Bloom Tender

### DIFF
--- a/forge-gui/res/cardsfolder/b/bloom_tender.txt
+++ b/forge-gui/res/cardsfolder/b/bloom_tender.txt
@@ -3,5 +3,4 @@ ManaCost:1 G
 Types:Creature Elf Druid
 PT:1/1
 A:AB$ Mana | Cost$ T | Produced$ Special EachColorAmong_Valid Permanent.YouCtrl | SpellDescription$ For each color among permanents you control, add one mana of that color.
-AI:RemoveDeck:All
 Oracle:{T}: For each color among permanents you control, add one mana of that color.


### PR DESCRIPTION
Bloom Tender's mana ability is byte-identical to Faeburrow Elder's:

```
A:AB$ Mana | Cost$ T | Produced$ Special EachColorAmong_Valid Permanent.YouCtrl
```

Faeburrow Elder isn't flagged and ships to AI decks, so `AI:RemoveDeck:All` on Bloom Tender looks stale.

Confirmed by having the AI's real mana payer use it. On a board with Bloom Tender (green) plus a white permanent — colour set `{G, W}`, no lands — `ComputerUtilMana` pays `{G}{W}` for a Watchwolf by tapping Bloom Tender: `canPayManaCost` and `payManaCost` both succeed and the card ends up tapped, identical to Faeburrow Elder. Birds of Paradise on the same setup correctly *cannot* (it makes only one mana), so the check discriminates rather than always passing.

Full desktop suite green.

---
🤖 Implemented with the assistance of Claude Code (Opus).
