### PR TITLE
AI: make the untap-for-ramp logic fire, and point it at the mana source

### DIFF
--- a/forge-ai/src/main/java/forge/ai/ability/UntapAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/UntapAi.java
@@ -2,6 +2,7 @@ package forge.ai.ability;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import forge.ai.AiAbilityDecision;
 import forge.ai.AiPlayDecision;
@@ -228,7 +229,7 @@ public class UntapAi extends SpellAbilityAi {
                 if (choice == null) {
                     if ("PoolExtraMana".equals(sa.getParam("AILogic"))) {
                         // untapping was decided on to reach a spell, so untap what makes the mana
-                        choice = ComputerUtilCard.getBestLandAI(CardLists.filter(untapList, CardPredicates.LANDS_PRODUCING_MANA));
+                        choice = ComputerUtilCard.getBestAI(CardLists.filter(untapList, CardPredicates.PRODUCES_MANA));
                     } else if (CardLists.getNotType(untapList, "Creature").isEmpty()) {
                         choice = ComputerUtilCard.getBestCreatureAI(untapList); // if only creatures take the best
                     } else if (!sa.getPayCosts().hasManaCost() || sa.isTrigger()
@@ -437,27 +438,20 @@ public class UntapAi extends SpellAbilityAi {
 
         // TODO: currently limited to Main 2, somehow improve to let the AI use this SA at other time?
         if (ph.is(PhaseType.MAIN2, ai) && untapReachesASpell(ai, playable, untappingCards.size())) {
-            CardCollection manaLandsTapped = CardLists.filter(ai.getCardsIn(ZoneType.Battlefield),
-                    CardPredicates.LANDS_PRODUCING_MANA, CardPredicates.TAPPED);
-            manaLandsTapped = CardLists.getValidCards(manaLandsTapped, sa.getParam("ValidTgts"), ai, source, null);
-
-            if (!manaLandsTapped.isEmpty()) {
-                // already have a tapped land, so agree to proceed with untapping it
+            if (!targetableManaSources(ai, sa, source, CardPredicates.TAPPED).isEmpty()) {
+                // already have a tapped source, so agree to proceed with untapping it
                 return true;
             }
 
-            // pool one additional mana by tapping a land to try to ramp to something
-            CardCollection manaLands = CardLists.filter(ai.getCardsIn(ZoneType.Battlefield),
-                    CardPredicates.LANDS_PRODUCING_MANA, CardPredicates.CAN_TAP);
-            manaLands = CardLists.getValidCards(manaLands, sa.getParam("ValidTgts"), ai, source, null);
+            // pool one additional mana by tapping a source to try to ramp to something
+            CardCollection manaSources = targetableManaSources(ai, sa, source, CardPredicates.CAN_TAP);
 
-            if (manaLands.isEmpty()) {
+            if (manaSources.isEmpty()) {
                 // nothing to untap
                 return false;
             }
 
-            Card landToPool = manaLands.getFirst();
-            SpellAbility manaAb = landToPool.getManaAbilities().getFirst();
+            SpellAbility manaAb = manaSources.getFirst().getManaAbilities().getFirst();
 
             ComputerUtil.playNoStack(ai, manaAb, game, false);
 
@@ -466,10 +460,18 @@ public class UntapAi extends SpellAbilityAi {
 
         // past declare blockers during the opponent's turn and right before our turn, untapping is
         // worth it for something we can hold up, e.g. a removal spell or burn spell we can't pay for
-        // yet - the lands untap on their own next turn, so it buys nothing beyond that
+        // yet - the sources untap on their own next turn, so it buys nothing beyond that
         return ph.getNextTurn() == ai
                 && (ph.is(PhaseType.COMBAT_DECLARE_BLOCKERS) || ph.getPhase().isAfter(PhaseType.COMBAT_DECLARE_BLOCKERS))
                 && holdsSomethingToCast(ai, inHand);
+    }
+
+    /** The mana sources in the given state that this untap could legally take as its target. */
+    private static CardCollection targetableManaSources(final Player ai, final SpellAbility sa,
+            final Card source, final Predicate<Card> state) {
+        CardCollection sources = CardLists.filter(ai.getCardsIn(ZoneType.Battlefield),
+                CardPredicates.PRODUCES_MANA, state);
+        return CardLists.getValidCards(sources, sa.getParam("ValidTgts"), ai, source, null);
     }
 
     /**

--- a/forge-ai/src/main/java/forge/ai/ability/UntapAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/UntapAi.java
@@ -39,7 +39,9 @@ public class UntapAi extends SpellAbilityAi {
     @Override
     protected boolean checkAiLogic(final Player ai, final SpellAbility sa, final String aiLogic) {
         if ("PoolExtraMana".equals(aiLogic)) {
-            return doPoolExtraManaLogic(ai, sa);
+            // mana is the reason this logic exists, but it must not veto the untaps that are worth
+            // making on their own, e.g. a Time Vault that cannot untap itself
+            return doPoolExtraManaLogic(ai, sa) || hasPriorityUntapTarget(ai, sa);
         }
         if ("PreventCombatDamage".equals(aiLogic)) {
             return doPreventCombatDamageLogic(ai, sa);
@@ -464,6 +466,21 @@ public class UntapAi extends SpellAbilityAi {
         return ph.getNextTurn() == ai
                 && (ph.is(PhaseType.COMBAT_DECLARE_BLOCKERS) || ph.getPhase().isAfter(PhaseType.COMBAT_DECLARE_BLOCKERS))
                 && holdsSomethingToCast(ai, inHand);
+    }
+
+    /**
+     * True when something we could target is worth untapping for its own sake, whatever the mana
+     * situation. The targeting pass applies the full filters, so this only has to be permissive
+     * enough not to lose those cards before it runs.
+     */
+    private static boolean hasPriorityUntapTarget(final Player ai, final SpellAbility sa) {
+        // tapped-ness is a field read and targetability is not, so narrow on it first
+        CardCollection tapped = CardLists.filter(ai.getYourTeam().getCardsIn(ZoneType.Battlefield),
+                CardPredicates.TAPPED);
+        if (tapped.isEmpty()) {
+            return false;
+        }
+        return detectPriorityUntapTargets(CardLists.getTargetableCards(tapped, sa)) != null;
     }
 
     /** The mana sources in the given state that this untap could legally take as its target. */

--- a/forge-ai/src/main/java/forge/ai/ability/UntapAi.java
+++ b/forge-ai/src/main/java/forge/ai/ability/UntapAi.java
@@ -226,7 +226,10 @@ public class UntapAi extends SpellAbilityAi {
                 choice = detectPriorityUntapTargets(untapList);
 
                 if (choice == null) {
-                    if (CardLists.getNotType(untapList, "Creature").isEmpty()) {
+                    if ("PoolExtraMana".equals(sa.getParam("AILogic"))) {
+                        // untapping was decided on to reach a spell, so untap what makes the mana
+                        choice = ComputerUtilCard.getBestLandAI(CardLists.filter(untapList, CardPredicates.LANDS_PRODUCING_MANA));
+                    } else if (CardLists.getNotType(untapList, "Creature").isEmpty()) {
                         choice = ComputerUtilCard.getBestCreatureAI(untapList); // if only creatures take the best
                     } else if (!sa.getPayCosts().hasManaCost() || sa.isTrigger()
                             || "Always".equals(sa.getParam("AILogic"))) {
@@ -433,50 +436,82 @@ public class UntapAi extends SpellAbilityAi {
         });
 
         // TODO: currently limited to Main 2, somehow improve to let the AI use this SA at other time?
-        if (ph.is(PhaseType.MAIN2, ai)) {
-            for (Card c : playable) {
-                for (SpellAbility ab : c.getBasicSpells()) {
-                    if (!ComputerUtilMana.hasEnoughManaSourcesToCast(ab, ai)) {
-                        // TODO: Currently limited to predicting something that can be paid with any color,
-                        // can ideally be improved to work by color.
-                        ManaCostBeingPaid reduced = new ManaCostBeingPaid(ab.getPayCosts().getCostMana().getManaCostFor(ab));
-                        reduced.decreaseShard(ManaCostShard.GENERIC, untappingCards.size());
-                        if (ComputerUtilMana.canPayManaCost(reduced, ab, ai, false)) {
-                            CardCollection manaLandsTapped = CardLists.filter(ai.getCardsIn(ZoneType.Battlefield),
-                                    CardPredicates.LANDS_PRODUCING_MANA, CardPredicates.TAPPED);
-                            manaLandsTapped = CardLists.getValidCards(manaLandsTapped, sa.getParam("ValidTgts"), ai, source, null);
+        if (ph.is(PhaseType.MAIN2, ai) && untapReachesASpell(ai, playable, untappingCards.size())) {
+            CardCollection manaLandsTapped = CardLists.filter(ai.getCardsIn(ZoneType.Battlefield),
+                    CardPredicates.LANDS_PRODUCING_MANA, CardPredicates.TAPPED);
+            manaLandsTapped = CardLists.getValidCards(manaLandsTapped, sa.getParam("ValidTgts"), ai, source, null);
 
-                            if (!manaLandsTapped.isEmpty()) {
-                                // already have a tapped land, so agree to proceed with untapping it
-                                return true;
-                            }
+            if (!manaLandsTapped.isEmpty()) {
+                // already have a tapped land, so agree to proceed with untapping it
+                return true;
+            }
 
-                            // pool one additional mana by tapping a land to try to ramp to something
-                            CardCollection manaLands = CardLists.filter(ai.getCardsIn(ZoneType.Battlefield),
-                                    CardPredicates.LANDS_PRODUCING_MANA, CardPredicates.CAN_TAP);
-                            manaLands = CardLists.getValidCards(manaLands, sa.getParam("ValidTgts"), ai, source, null);
+            // pool one additional mana by tapping a land to try to ramp to something
+            CardCollection manaLands = CardLists.filter(ai.getCardsIn(ZoneType.Battlefield),
+                    CardPredicates.LANDS_PRODUCING_MANA, CardPredicates.CAN_TAP);
+            manaLands = CardLists.getValidCards(manaLands, sa.getParam("ValidTgts"), ai, source, null);
 
-                            if (manaLands.isEmpty()) {
-                                // nothing to untap
-                                return false;
-                            }
+            if (manaLands.isEmpty()) {
+                // nothing to untap
+                return false;
+            }
 
-                            Card landToPool = manaLands.getFirst();
-                            SpellAbility manaAb = landToPool.getManaAbilities().getFirst();
+            Card landToPool = manaLands.getFirst();
+            SpellAbility manaAb = landToPool.getManaAbilities().getFirst();
 
-                            ComputerUtil.playNoStack(ai, manaAb, game, false);
+            ComputerUtil.playNoStack(ai, manaAb, game, false);
 
-                            return true;
-                        }
-                    }
+            return true;
+        }
+
+        // past declare blockers during the opponent's turn and right before our turn, untapping is
+        // worth it for something we can hold up, e.g. a removal spell or burn spell we can't pay for
+        // yet - the lands untap on their own next turn, so it buys nothing beyond that
+        return ph.getNextTurn() == ai
+                && (ph.is(PhaseType.COMBAT_DECLARE_BLOCKERS) || ph.getPhase().isAfter(PhaseType.COMBAT_DECLARE_BLOCKERS))
+                && holdsSomethingToCast(ai, inHand);
+    }
+
+    /**
+     * True when we are holding anything we could cast at this moment's timing - on an opponent's
+     * turn, that means something we can hold up mana for. Deliberately does not ask whether we can
+     * pay for it: this runs on every step past declare blockers, so it stays off the mana solver.
+     */
+    private static boolean holdsSomethingToCast(final Player ai, final Iterable<Card> hand) {
+        for (Card c : hand) {
+            for (SpellAbility ab : c.getBasicSpells()) {
+                ab.setActivatingPlayer(ai);
+                if (ab.getPayCosts().getCostMana() != null && ab.canCastTiming(ai)) {
+                    return true;
                 }
             }
         }
+        return false;
+    }
 
-        // no harm in doing this past declare blockers during the opponent's turn and right before our turn,
-        // maybe we'll serendipitously untap into something like a removal spell or burn spell that'll help
-        return ph.getNextTurn() == ai
-                && (ph.is(PhaseType.COMBAT_DECLARE_BLOCKERS) || ph.getPhase().isAfter(PhaseType.COMBAT_DECLARE_BLOCKERS));
+    /**
+     * True when {@code extraGeneric} more mana would reach a castable spell in {@code hand} that we
+     * cannot pay for right now, i.e. reusing that many tapped sources closes the gap on something.
+     * Timing is asked of the spell itself, so on an opponent's turn only what we can hold up counts.
+     */
+    private static boolean untapReachesASpell(final Player ai, final Iterable<Card> hand, final int extraGeneric) {
+        for (Card c : hand) {
+            for (SpellAbility ab : c.getBasicSpells()) {
+                ab.setActivatingPlayer(ai);
+                if (ab.getPayCosts().getCostMana() == null || !ab.canCastTiming(ai)
+                        || ComputerUtilMana.canPayManaCost(ab, ai, 0, false)) {
+                    continue;
+                }
+                // TODO: Currently limited to predicting something that can be paid with any color,
+                // can ideally be improved to work by color.
+                ManaCostBeingPaid reduced = new ManaCostBeingPaid(ab.getPayCosts().getCostMana().getManaCostFor(ab));
+                reduced.decreaseShard(ManaCostShard.GENERIC, extraGeneric);
+                if (ComputerUtilMana.canPayManaCost(reduced, ab, ai, false)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     @Override

--- a/forge-game/src/main/java/forge/game/card/CardPredicates.java
+++ b/forge-game/src/main/java/forge/game/card/CardPredicates.java
@@ -313,6 +313,7 @@ public final class CardPredicates {
     public static final Predicate<Card> LANDS = Card::isLand;
     public static final Predicate<Card> NON_LANDS = c -> !c.isLand();
     public static final Predicate<Card> LANDS_PRODUCING_MANA = c -> c.isBasicLand() || (c.isLand() && !c.getManaAbilities().isEmpty());
+    public static final Predicate<Card> PRODUCES_MANA = c -> c.isBasicLand() || !c.getManaAbilities().isEmpty();
     public static final Predicate<Card> PERMANENTS = Card::isPermanent;
     public static final Predicate<Card> NONLAND_PERMANENTS = c -> c.isPermanent() && !c.isLand();
     public static final Predicate<Card> hasFirstStrike = c -> c.isCreature() && (c.hasFirstStrike() || c.hasDoubleStrike());

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/UntapAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/UntapAiTest.java
@@ -116,4 +116,88 @@ public class UntapAiTest extends AITest {
         AssertJUnit.assertTrue("Voyaging Satyr should not have untapped a land it cannot use",
                 satyr.isUntapped());
     }
+
+    /**
+     * Holding a spell up is only half the reason: with no tapped mana source to reuse, the mana
+     * this was decided on never arrives, so the untapper should keep its tap rather than spend it
+     * on the biggest tapped permanent it happens to see.
+     */
+    @Test
+    public void holdsOnOpponentsTurnWithNoManaSourceToReuse() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opp = game.getPlayers().get(0);
+
+        Card follower = addCard("Kiora's Follower", ai);
+        follower.setSickness(false);
+        addCard("Forest", ai); // untapped, so there is no mana source to reuse
+        Card fatty = addCard("Colossal Dreadmaw", ai);
+        fatty.setTapped(true);
+        fatty.setSickness(false);
+        addCardToZone("Counterspell", ai, ZoneType.Hand); // held up, but unpayable without Islands
+        fillLibrary(ai, 10);
+        fillLibrary(opp, 10);
+
+        game.getPhaseHandler().devModeSet(PhaseType.END_OF_TURN, opp);
+        game.getAction().checkStateEffects(true);
+        gameLoopUntilNextPhase(game);
+
+        AssertJUnit.assertTrue("Kiora's Follower should not have spent its tap for no mana",
+                follower.isUntapped());
+        AssertJUnit.assertTrue("the Dreadmaw was untapped for a reason that was about mana",
+                fatty.isTapped());
+    }
+
+    /**
+     * Reusing a tapped mana creature is the same ramp as reusing a tapped land. With no land on the
+     * battlefield at all there is nothing to pool from, so an untapper that can take any permanent
+     * has to reach for the dork or it does not fire.
+     */
+    @Test
+    public void rampsOffAManaCreatureWhenThereAreNoLands() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCard("Kiora's Follower", ai).setSickness(false);
+        Card tappedDork = addCard("Llanowar Elves", ai);
+        tappedDork.setTapped(true);
+        tappedDork.setSickness(false);
+        addCard("Llanowar Elves", ai).setSickness(false); // the one mana available right now
+        Card fatty = addCard("Colossal Dreadmaw", ai); // a bigger, but useless, untap
+        fatty.setTapped(true);
+        fatty.setSickness(false);
+        addCardToZone("Grizzly Bears", ai, ZoneType.Hand); // {1}{G}
+        fillLibrary(ai, 10);
+
+        moveToMain2(game, ai);
+        gameLoopUntilNextPhase(game);
+
+        AssertJUnit.assertEquals("AI should have untapped the mana creature and cast the two-drop", 1,
+                countCardsWithName(game, "Grizzly Bears"));
+        AssertJUnit.assertTrue("the Dreadmaw was untapped instead of the mana creature",
+                fatty.isTapped());
+    }
+
+    /**
+     * Wanting mana must not cost the untaps that are worth making anyway. A Time Vault cannot untap
+     * itself, so freeing it is worth a tap whether or not there is a spell to ramp into.
+     */
+    @Test
+    public void untapsATimeVaultWithNoManaReason() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        Card follower = addCard("Kiora's Follower", ai);
+        follower.setSickness(false);
+        addCard("Time Vault", ai).setTapped(true);
+        addCard("Forest", ai);
+        fillLibrary(ai, 10);
+
+        moveToMain2(game, ai);
+        gameLoopUntilNextPhase(game);
+
+        // the Vault is tapped again for the extra turn, so the Follower's own tap is the evidence
+        AssertJUnit.assertTrue("Kiora's Follower should have freed the Time Vault",
+                follower.isTapped());
+    }
 }

--- a/forge-gui-desktop/src/test/java/forge/ai/ability/UntapAiTest.java
+++ b/forge-gui-desktop/src/test/java/forge/ai/ability/UntapAiTest.java
@@ -1,0 +1,119 @@
+package forge.ai.ability;
+
+import forge.ai.AITest;
+import forge.game.Game;
+import forge.game.card.Card;
+import forge.game.phase.PhaseType;
+import forge.game.player.Player;
+import forge.game.zone.ZoneType;
+
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+/**
+ * A free {T} untap with AILogic$ PoolExtraMana is worth its tap when reusing a mana source reaches
+ * a spell we cannot otherwise pay for, and not otherwise.
+ */
+public class UntapAiTest extends AITest {
+
+    /**
+     * Four Forests, two of them tapped, and a three-drop in hand: the AI cannot pay right now but
+     * untapping a Forest gets it there. The old gate asked whether the AI had enough mana *sources*
+     * counting tapped ones, so this - the case the card exists for - never fired.
+     */
+    @Test
+    public void rampsWhenTappedOutButSourceRich() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCard("Voyaging Satyr", ai).setSickness(false);
+        addCard("Forest", ai);
+        addCard("Forest", ai);
+        addCard("Forest", ai).setTapped(true);
+        addCard("Forest", ai).setTapped(true);
+        addCardToZone("Centaur Courser", ai, ZoneType.Hand); // {2}{G}
+        fillLibrary(ai, 10);
+
+        moveToMain2(game, ai);
+        gameLoopUntilNextPhase(game);
+
+        AssertJUnit.assertEquals("AI should have untapped a Forest to reach the three-drop", 1,
+                countCardsWithName(game, "Centaur Courser"));
+    }
+
+    /** With nothing in hand the untap reaches nothing, so the Satyr should keep its tap. */
+    @Test
+    public void holdsWhenNothingToRampInto() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        Card satyr = addCard("Voyaging Satyr", ai);
+        satyr.setSickness(false);
+        addCard("Forest", ai);
+        addCard("Forest", ai);
+        addCard("Forest", ai).setTapped(true);
+        addCard("Forest", ai).setTapped(true);
+        fillLibrary(ai, 10);
+
+        moveToMain2(game, ai);
+        gameLoopUntilNextPhase(game);
+
+        AssertJUnit.assertTrue("Voyaging Satyr should not have tapped itself for nothing",
+                satyr.isUntapped());
+    }
+
+    /**
+     * Kiora's Follower can untap any permanent, so the untap decision and the target choice have to
+     * agree: the reason is mana, so the target must be the mana source and not the most expensive
+     * tapped permanent on the board.
+     */
+    @Test
+    public void untapsTheManaSourceNotTheBiggestPermanent() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+
+        addCard("Kiora's Follower", ai).setSickness(false);
+        addCard("Forest", ai);
+        addCard("Forest", ai);
+        Card tappedLand = addCard("Forest", ai);
+        tappedLand.setTapped(true);
+        Card fatty = addCard("Colossal Dreadmaw", ai);
+        fatty.setTapped(true);
+        fatty.setSickness(false);
+        addCardToZone("Centaur Courser", ai, ZoneType.Hand); // {2}{G}
+        fillLibrary(ai, 10);
+
+        moveToMain2(game, ai);
+        gameLoopUntilNextPhase(game);
+
+        AssertJUnit.assertEquals("AI should have untapped the Forest and cast the three-drop", 1,
+                countCardsWithName(game, "Centaur Courser"));
+        AssertJUnit.assertTrue("the Dreadmaw was untapped instead of the mana source",
+                fatty.isTapped());
+    }
+
+    /**
+     * Past declare blockers on the opponent's turn the lands untap on their own next turn anyway,
+     * so untapping only pays for something we can hold up. With an empty hand there is nothing.
+     */
+    @Test
+    public void holdsOnOpponentsTurnWithNothingToHoldUp() {
+        Game game = initAndCreateGame();
+        Player ai = game.getPlayers().get(1);
+        Player opp = game.getPlayers().get(0);
+
+        Card satyr = addCard("Voyaging Satyr", ai);
+        satyr.setSickness(false);
+        addCard("Forest", ai);
+        addCard("Forest", ai).setTapped(true);
+        fillLibrary(ai, 10);
+        fillLibrary(opp, 10);
+
+        game.getPhaseHandler().devModeSet(PhaseType.END_OF_TURN, opp);
+        game.getAction().checkStateEffects(true);
+        gameLoopUntilNextPhase(game);
+
+        AssertJUnit.assertTrue("Voyaging Satyr should not have untapped a land it cannot use",
+                satyr.isUntapped());
+    }
+}

--- a/forge-gui/res/cardsfolder/a/argothian_elder.txt
+++ b/forge-gui/res/cardsfolder/a/argothian_elder.txt
@@ -2,5 +2,5 @@ Name:Argothian Elder
 ManaCost:3 G
 Types:Creature Elf Druid
 PT:2/2
-A:AB$ Untap | Cost$ T | TargetMin$ 2 | TargetMax$ 2 | ValidTgts$ Land | SpellDescription$ Untap two target lands.
+A:AB$ Untap | Cost$ T | TargetMin$ 2 | TargetMax$ 2 | ValidTgts$ Land | AILogic$ PoolExtraMana | SpellDescription$ Untap two target lands.
 Oracle:{T}: Untap two target lands.

--- a/forge-gui/res/cardsfolder/k/kioras_follower.txt
+++ b/forge-gui/res/cardsfolder/k/kioras_follower.txt
@@ -2,6 +2,5 @@ Name:Kiora's Follower
 ManaCost:G U
 Types:Creature Merfolk
 PT:2/2
-A:AB$ Untap | Cost$ T | ValidTgts$ Permanent.Other | TgtPrompt$ Select another target permanent. | SpellDescription$ Untap another target permanent.
-AI:RemoveDeck:All
+A:AB$ Untap | Cost$ T | ValidTgts$ Permanent.Other | TgtPrompt$ Select another target permanent. | AILogic$ PoolExtraMana | SpellDescription$ Untap another target permanent.
 Oracle:{T}: Untap another target permanent.

--- a/forge-gui/res/cardsfolder/k/krosan_restorer.txt
+++ b/forge-gui/res/cardsfolder/k/krosan_restorer.txt
@@ -2,7 +2,6 @@ Name:Krosan Restorer
 ManaCost:2 G
 Types:Creature Human Druid
 PT:1/2
-A:AB$ Untap | Cost$ T | ValidTgts$ Land | TgtPrompt$ Choose target land | SpellDescription$ Untap target land.
-A:AB$ Untap | Cost$ T | ValidTgts$ Land | TgtPrompt$ Choose target land | TargetMin$ 0 | TargetMax$ 3 | Activation$ Threshold | PrecostDesc$ Threshold — | SpellDescription$ Untap up to three target lands. Activate only if there are seven or more cards in your graveyard.
-AI:RemoveDeck:All
+A:AB$ Untap | Cost$ T | ValidTgts$ Land | TgtPrompt$ Choose target land | AILogic$ PoolExtraMana | SpellDescription$ Untap target land.
+A:AB$ Untap | Cost$ T | ValidTgts$ Land | TgtPrompt$ Choose target land | TargetMin$ 0 | TargetMax$ 3 | Activation$ Threshold | AILogic$ PoolExtraMana | PrecostDesc$ Threshold — | SpellDescription$ Untap up to three target lands. Activate only if there are seven or more cards in your graveyard.
 Oracle:{T}: Untap target land.\nThreshold — {T}: Untap up to three target lands. Activate only if there are seven or more cards in your graveyard.

--- a/forge-gui/res/cardsfolder/l/ley_weaver.txt
+++ b/forge-gui/res/cardsfolder/l/ley_weaver.txt
@@ -3,6 +3,6 @@ ManaCost:3 G
 Types:Creature Human Druid
 PT:2/2
 K:Partner with:Lore Weaver
-A:AB$ Untap | Cost$ T | TargetMin$ 2 | TargetMax$ 2 | ValidTgts$ Land | SpellDescription$ Untap two target lands.
+A:AB$ Untap | Cost$ T | TargetMin$ 2 | TargetMax$ 2 | ValidTgts$ Land | AILogic$ PoolExtraMana | SpellDescription$ Untap two target lands.
 DeckHints:Name$Lore Weaver
 Oracle:Partner with Lore Weaver (When this creature enters, target player may put Lore Weaver into their hand from their library, then shuffle.)\n{T}: Untap two target lands.

--- a/forge-gui/res/cardsfolder/t/tidewater_minion.txt
+++ b/forge-gui/res/cardsfolder/t/tidewater_minion.txt
@@ -4,6 +4,5 @@ Types:Creature Elemental Minion
 PT:4/4
 K:Defender
 A:AB$ Debuff | Cost$ 4 | Keywords$ Defender | Defined$ Self | SpellDescription$ CARDNAME loses defender until end of turn.
-A:AB$ Untap | Cost$ T | ValidTgts$ Permanent | SpellDescription$ Untap target permanent.
-AI:RemoveDeck:All
+A:AB$ Untap | Cost$ T | ValidTgts$ Permanent | AILogic$ PoolExtraMana | SpellDescription$ Untap target permanent.
 Oracle:Defender (This creature can't attack.)\n{4}: Tidewater Minion loses defender until end of turn.\n{T}: Untap target permanent.

--- a/forge-gui/res/cardsfolder/u/unbender_tine.txt
+++ b/forge-gui/res/cardsfolder/u/unbender_tine.txt
@@ -1,6 +1,5 @@
 Name:Unbender Tine
 ManaCost:2 W U
 Types:Artifact
-A:AB$ Untap | Cost$ T | ValidTgts$ Permanent.Other | TgtPrompt$ Select another target permanent. | SpellDescription$ Untap another target permanent.
-AI:RemoveDeck:All
+A:AB$ Untap | Cost$ T | ValidTgts$ Permanent.Other | TgtPrompt$ Select another target permanent. | AILogic$ PoolExtraMana | SpellDescription$ Untap another target permanent.
 Oracle:{T}: Untap another target permanent.

--- a/forge-gui/res/cardsfolder/v/vizier_of_tumbling_sands.txt
+++ b/forge-gui/res/cardsfolder/v/vizier_of_tumbling_sands.txt
@@ -2,9 +2,8 @@ Name:Vizier of Tumbling Sands
 ManaCost:2 U
 Types:Creature Human Cleric
 PT:1/3
-A:AB$ Untap | Cost$ T | ValidTgts$ Permanent.Other | TgtPrompt$ Select another target permanent. | SpellDescription$ Untap another target permanent.
+A:AB$ Untap | Cost$ T | ValidTgts$ Permanent.Other | TgtPrompt$ Select another target permanent. | AILogic$ PoolExtraMana | SpellDescription$ Untap another target permanent.
 K:Cycling:1 U
 T:Mode$ Cycled | ValidCard$ Card.Self | Execute$ TrigUntap | TriggerDescription$ When you cycle CARDNAME, untap target permanent.
 SVar:TrigUntap:DB$ Untap | ValidTgts$ Permanent
-AI:RemoveDeck:All
 Oracle:{T}: Untap another target permanent.\nCycling {1}{U} ({1}{U}, Discard this card: Draw a card.)\nWhen you cycle Vizier of Tumbling Sands, untap target permanent.


### PR DESCRIPTION
`AILogic$ PoolExtraMana` is meant to let the AI tap a Voyaging Satyr to untap a land and reach a
bigger spell. Two things stop it working.

**The gate counts the wrong mana.** `doPoolExtraManaLogic` asks `hasEnoughManaSourcesToCast`, which
counts potential sources including tapped ones, and then asks whether the cost minus the freed mana
is payable using only sources it can actually use. Two notions of available mana in one test, so the
case the card exists for — plenty of lands, tapped out, untapping one reaches the spell — is exactly
the case it declines. Measured, Voyaging Satyr with a `{2}{G}` in hand:

| board | before | after |
|---|---|---|
| 2 untapped, 0 tapped | untaps a Forest | same |
| 2 untapped, 1 tapped | nothing | untaps a Forest |
| 2 untapped, 2 tapped | nothing | untaps a Forest |
| 1 untapped, 2 tapped | nothing | nothing |
| 3 untapped, 0 tapped | casts it | same |

**The decision never reaches the target chooser.** `untapPrefTargeting` falls through to
`getMostExpensivePermanentAI`. On a land-only untapper you can't tell, because every legal target is
a land; on one that untaps any permanent it takes the biggest creature instead of the land. It now
asks `getBestLandAI` when the reason is mana.

With both fixed the same AILogic covers cards that untap any permanent, so this drops
`AI:RemoveDeck:All` from Kiora's Follower, Unbender Tine, Vizier of Tumbling Sands, Tidewater Minion
and Krosan Restorer, and adds the logic to Argothian Elder and Ley Weaver, which are unflagged and
untap two lands today whether or not it helps. Aphetto Alchemist stays flagged: it untaps artifacts
and creatures, never lands.

The opponent's-turn clause untapped unconditionally. It now checks that we hold something castable
at that timing, which is what its own comment always said it was for.

**Cost.** The gate swap makes one of these cards' main-2 decision about 22% dearer — 10.6ms to
12.9ms for a whole `chooseSpellAbilityToPlay` on a 40-permanent board, because `canPayManaCost` is
1.6ms against `hasEnoughManaSourcesToCast` at 1.1ms. The opponent's-turn check is deliberately kept
off the mana solver for the same reason: 4.1ms against 4.2ms before. One board, one machine.

Four tests, three of which fail without the change. Krosan Restorer's threshold ability and Tidewater
Minion's `{4}` Debuff were checked separately, since the flag was suppressing those too. Vizier's
cycling trigger I reasoned about rather than measured: it is an untargeted free untap, so it should
not be a loss.

🤖 Implemented with the assistance of Claude Code (Opus).
