### PR TITLE
Let the AI play Tolaria West

### DIFF
--- a/forge-gui/res/cardsfolder/t/tolaria_west.txt
+++ b/forge-gui/res/cardsfolder/t/tolaria_west.txt
@@ -5,5 +5,4 @@ R:Event$ Moved | ValidCard$ Card.Self | Destination$ Battlefield | ReplacementRe
 SVar:ETBTapped:DB$ Tap | Defined$ Self | ETB$ True
 A:AB$ Mana | Cost$ T | Produced$ U | SpellDescription$ Add {U}.
 K:Transmute:1 U U
-AI:RemoveDeck:All
 Oracle:Tolaria West enters tapped.\n{T}: Add {U}.\nTransmute {1}{U}{U} ({1}{U}{U}, Discard this card: Search your library for a card with mana value 0, reveal it, put it into your hand, then shuffle. Transmute only as a sorcery.)


### PR DESCRIPTION
Tolaria West is excluded from AI decks by an `AI:RemoveDeck:All` flag applied in a 2018 blanket
pass (`92b0355a41` "AI:RemoveDeck (B-Z)"), not a card-specific decision. The flag also strips its
ordinary use as a land that taps for `{U}`.

Its Transmute ability is a generated `ChangeZone` tutor (search library for a same-mana-value card
→ hand), handled by the same `ChangeZoneAi` that already drives every other, unflagged, Transmute
card — so there is no card-specific reason for the flag.

Removing it restores both uses. Verified locally:

- Over a full AI turn the AI plays Tolaria West **as a land** (it does not waste it on the
  transmute); the transmute is available at sorcery speed in main 2 and fetches the best available
  mana-value-0 card via `getBestAI`.
- `forge-gui-desktop` suite stays green (286 passed).

🤖 Implemented with the assistance of Claude Code (Opus).
