### PR TITLE
Add GuiBase.isMobile() helper for Android-or-iOS platform checks

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/util/Config.java
+++ b/forge-gui-mobile/src/forge/adventure/util/Config.java
@@ -123,7 +123,7 @@ public class Config {
     private String resPath() {
         // Android/iOS: resources live at ASSETS_DIR (extracted storage / app bundle);
         // the desktop-relative "./res" probes below never match there
-        if (GuiBase.isAndroid() || GuiBase.isIOS()) {
+        if (GuiBase.isMobile()) {
             return ForgeConstants.ASSETS_DIR;
         }
         return Files.exists(Paths.get("./res")) ? "./" : Files.exists(Paths.get("./forge-gui/")) ? "./forge-gui/" : "../forge-gui";

--- a/forge-gui-mobile/src/forge/assets/FSkin.java
+++ b/forge-gui-mobile/src/forge/assets/FSkin.java
@@ -110,7 +110,7 @@ public class FSkin {
     }
     private static void useFallbackDir() {
         // iOS and Android both need to use internal() for bundled resources
-        boolean isMobile = GuiBase.isAndroid() || GuiBase.isIOS();
+        boolean isMobile = GuiBase.isMobile();
         preferredDir = isMobile ? Gdx.files.internal("fallback_skin") : Gdx.files.classpath("fallback_skin");
     }
     public static void loadLight(String skinName, final SplashScreen splashScreen,FileHandle prefDir) {

--- a/forge-gui/src/main/java/forge/gui/GuiBase.java
+++ b/forge-gui/src/main/java/forge/gui/GuiBase.java
@@ -29,6 +29,9 @@ public class GuiBase {
     public static void setIsIOS(boolean value) { isIOSport = value; }
     public static boolean isIOS() { return isIOSport; }
 
+    /** @return true on mobile ports (Android or iOS), false on desktop. */
+    public static boolean isMobile() { return isAndroidport || isIOSport; }
+
     public static void setAdventureDirectory(String directory) { adventureDirectory = directory; }
     public static String getAdventureDirectory() { return adventureDirectory; }
 


### PR DESCRIPTION
With iOS support merged in #11190, `GuiBase.isAndroid()` no longer doubles as a "not desktop" check — code that actually means "any mobile port" now needs `isAndroid() || isIOS()` (noted by @Jetz72 in review on #11363).

This adds a small `GuiBase.isMobile()` helper for that case and converts the two call sites that already spell the check out (`Config.resPath()`, `FSkin.useFallbackDir()`). Other `isAndroid()` call sites that really mean "mobile" can migrate to it incrementally as they're touched.

Compiled `forge-gui-mobile -am` with no errors.