### PR TITLE
LandTraitChanges: small improvements

### DIFF
--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -3416,6 +3416,9 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     }
 
     public boolean hasRemoveIntrinsic() {
+        if (changedCardTypes.isEmpty()) {
+            return false;
+        }
         // only Layer 4 are affected, and it's never intrinsic
         return changedCardTypes.values().stream().anyMatch(ICardChangedType::isRemoveLandTypes);
     }
@@ -4126,10 +4129,13 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     }
 
     public Iterable<IKeywordsChange> getChangedCardKeywordsList(final CardState state) {
+        if (changedCardKeywordsByText.isEmpty() && changedCardKeywordsByWord.isEmpty() && changedCardKeywords.isEmpty()) {
+            return List.copyOf(state.getLandTraitChanges());
+        }
         return Iterables.concat(
             changedCardKeywordsByText.values(), // Layer 3
             ImmutableList.of(changedCardKeywordsByWord), // Layer 3
-            ImmutableList.of(state.getLandTraitChanges()), // Layer 4
+            state.getLandTraitChanges(), // Layer 4
             changedCardKeywords.values() // Layer 6
         );
     }
@@ -4959,9 +4965,12 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
     }
 
     public Iterable<ICardTraitChanges> getChangedCardTraitsList(CardState state) {
+        if (changedCardTraitsByText.isEmpty() && changedCardTraits.isEmpty()) {
+            return List.copyOf(state.getLandTraitChanges());
+        }
         return Iterables.<ICardTraitChanges>concat(
             changedCardTraitsByText.values(), // Layer 3
-            ImmutableList.of(state.getLandTraitChanges()), // Layer 4
+            state.getLandTraitChanges(), // Layer 4
             changedCardTraits.values() // Layer 6
         );
     }

--- a/forge-game/src/main/java/forge/game/card/Card.java
+++ b/forge-game/src/main/java/forge/game/card/Card.java
@@ -4128,9 +4128,9 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
         return changedCardKeywordsByText;
     }
 
-    public Iterable<IKeywordsChange> getChangedCardKeywordsList(final CardState state) {
+    public Iterable<? extends IKeywordsChange> getChangedCardKeywordsList(final CardState state) {
         if (changedCardKeywordsByText.isEmpty() && changedCardKeywordsByWord.isEmpty() && changedCardKeywords.isEmpty()) {
-            return List.copyOf(state.getLandTraitChanges());
+            return state.getLandTraitChanges();
         }
         return Iterables.concat(
             changedCardKeywordsByText.values(), // Layer 3
@@ -4964,9 +4964,9 @@ public class Card extends GameEntity implements Comparable<Card>, IHasSVars, ITr
         return changedCardTraitsByText.remove(timestamp, staticId) != null;
     }
 
-    public Iterable<ICardTraitChanges> getChangedCardTraitsList(CardState state) {
+    public Iterable<? extends ICardTraitChanges> getChangedCardTraitsList(CardState state) {
         if (changedCardTraitsByText.isEmpty() && changedCardTraits.isEmpty()) {
-            return List.copyOf(state.getLandTraitChanges());
+            return state.getLandTraitChanges();
         }
         return Iterables.<ICardTraitChanges>concat(
             changedCardTraitsByText.values(), // Layer 3

--- a/forge-game/src/main/java/forge/game/card/CardState.java
+++ b/forge-game/src/main/java/forge/game/card/CardState.java
@@ -109,7 +109,7 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
     private SpellAbility manifestUp;
     private SpellAbility cloakUp;
 
-    private LandTraitChanges landTraitChanges = new LandTraitChanges(this);
+    private List<LandTraitChanges> landTraitChanges = List.of(new LandTraitChanges(this));
 
     public CardState(Card card, CardStateName name) {
         this(card.getView().createAlternateState(name), card);
@@ -537,7 +537,7 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
         }
     }
 
-    public LandTraitChanges getLandTraitChanges() { return this.landTraitChanges; }
+    public List<LandTraitChanges> getLandTraitChanges() { return this.landTraitChanges; }
 
     record LandTraitChanges(CardState state, Map<MagicColor.Color, SpellAbility> map) implements ICardTraitChanges, IKeywordsChange
     {

--- a/forge-game/src/main/java/forge/game/card/CardState.java
+++ b/forge-game/src/main/java/forge/game/card/CardState.java
@@ -109,6 +109,7 @@ public class CardState implements GameObject, IHasSVars, ITranslatable {
     private SpellAbility manifestUp;
     private SpellAbility cloakUp;
 
+    // wrapped in a List so it can be reused directly
     private List<LandTraitChanges> landTraitChanges = List.of(new LandTraitChanges(this));
 
     public CardState(Card card, CardStateName name) {

--- a/forge-game/src/main/java/forge/game/keyword/KeywordCollection.java
+++ b/forge-game/src/main/java/forge/game/keyword/KeywordCollection.java
@@ -218,7 +218,7 @@ public class KeywordCollection implements ICardTraitChanges, Iterable<KeywordInt
         return result;
     }
 
-    public void applyChanges(Iterable<IKeywordsChange> changes) {
+    public void applyChanges(Iterable<? extends IKeywordsChange> changes) {
         for (final IKeywordsChange ck : changes) {
             ck.applyKeywords(this);
         }


### PR DESCRIPTION
Part of #11366

small improvement for LandTraitChanges

sadly Java doesn't let me cast `List<LandTraitChanges>` to both `Iterable<IKeywordsChange>` and `Iterable<ICardTraitChanges>`, so i need `List.copyOf`?


no other changes on the Iterable Lists yet.
Might need to test it first if i can change them into `Stream<>`?